### PR TITLE
docs(diagrams): add 4 new diagrams and fix workflow/script issues

### DIFF
--- a/.github/workflows/update-diagrams.yml
+++ b/.github/workflows/update-diagrams.yml
@@ -4,8 +4,6 @@
 #   - update-uml-diagrams.yml (PlantUML → PNG)
 
 name: Update Diagram Artifacts
-# Replaces and combines:
-#   - update-uml-diagrams.yml (Regenerate PNG diagrams from PlantUML sources)
 
 on:
   push:

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -35,6 +35,10 @@ This folder contains architecture diagrams for the Meridian system, updated to r
 | **Domain Event Model** | MarketEvent hierarchy: all payload types, event type enum, and tier classification | `domain-event-model.dot` |
 | **F# Domain Library** | Railway-oriented validation, type-safe calculations, and C# interop layer | `fsharp-domain.dot` |
 | **Data Quality & Monitoring** | Quality scoring, SLA enforcement, outlier detection, and observability stack | `data-quality-monitoring.dot` |
+| **Backfill Workflow** | CLI/REST/scheduled backfill → CompositeProvider → rate limiting → gap detection → WAL + storage | `backfill-workflow.dot` |
+| **MCP Server** | Model Context Protocol server tools, resources, prompts, and Meridian backend integration | `mcp-server.dot` |
+| **Configuration Management** | appsettings.json hierarchy, environment variable overrides, IOptionsMonitor hot-reload | `configuration-management.dot` |
+| **Symbol Search & Resolution** | Search query → 5 providers → OpenFIGI canonical ID → SymbolMapper → provider-specific formats | `symbol-search-resolution.dot` |
 
 ---
 
@@ -262,6 +266,51 @@ Shows data quality scoring and the observability stack:
 - **Retention & Catalog** — RetentionComplianceReporter (policy audit), StorageCatalogService (symbol×date×type inventory)
 - **Observability** — Prometheus metrics (12 counters/gauges), Grafana dashboards, OpenTelemetry traces, `/health` + `/metrics` HTTP endpoints
 
+### Backfill Workflow
+
+Shows the end-to-end historical data backfill pipeline:
+
+1. **Entry Points** — CLI (`--backfill`), REST API, and automatic scheduled/gap-repair triggers
+2. **BackfillCoordinator** — Validates request, checks StorageCatalogService for existing coverage, partitions date range, enqueues work items
+3. **CompositeHistoricalDataProvider** — Priority-ordered failover across 13 providers, circuit breaker per provider, rate-limit rotation, health-based exclusion
+4. **Rate Limiting** — ProviderRateLimitTracker (token bucket), exponential backoff on 429 responses, per-provider limits documented
+5. **Provider Execution** — IAsyncEnumerable streaming, JSON source-generated parsing, OHLCV normalization, UTC canonicalization
+6. **Gap Detection & Validation** — Missing interval detection, F# railway-oriented validation (price/volume/timestamp checks)
+7. **Storage** — WAL → JSONL Sink → Parquet Sink → Tiered Storage Manager (hot/warm/cold)
+8. **Observability** — BackfillProgressTracker, Prometheus metrics, BackfillRunResult with coverage map
+
+### MCP Server
+
+Shows the Model Context Protocol server architecture:
+
+- **MCP Clients** — Claude Desktop, Claude.ai, and other MCP-compatible hosts connect via stdio JSON-RPC 2.0
+- **Tools** — `RunBackfill` (BackfillTools), `AddSymbol` / `RemoveSymbol` (SymbolTools), `ListBackfillProviders` / `GetLastBackfillResult` (ProviderTools), `QueryStoredData` (StorageTools)
+- **Resources** — `GetProviderCatalog` (provider health + capabilities), `GetStorageCatalog` (symbol×date inventory), `GetActiveConfiguration` (masked config snapshot)
+- **Prompts** — `BackfillSetup` (guided backfill workflow), `ProviderConfiguration` (API key setup instructions)
+- **Backend wiring** — DI injects BackfillCoordinator, StorageCatalogService, ProviderRegistry, IOptionsMonitor into all tool/resource classes
+
+### Configuration Management
+
+Shows the configuration hierarchy and hot-reload mechanism:
+
+- **Sources (lowest → highest priority)**: Built-in defaults → `appsettings.sample.json` → `appsettings.json` → Environment variables → CLI args
+- **Credentials**: Environment variables only — never in JSON files or source control (ADR-011)
+- **Options Pattern** — `IOptionsMonitor<T>` preferred for all runtime-mutable config; `IOptions<T>` only for static settings
+- **Hot-Reload** — `--watch-config` flag enables `FileSystemWatcher` on `appsettings.json`; `IOptionsMonitor.OnChange` callbacks propagate to streaming providers, storage, pipeline, and SLA monitor
+- **Typed Options** — `DataSourceOptions`, `SymbolsOptions`, `StorageOptions`, `BackfillOptions`, `DataQualityOptions`
+- **Diagnostics** — `--show-config` prints merged config with masked credentials; startup validation fails fast on bad config with friendly error codes
+
+### Symbol Search & Resolution
+
+Shows the full symbol search and canonical ID resolution flow:
+
+1. **Entry** — Free-text, ticker, ISIN, CUSIP, or SEDOL query via CLI or REST API
+2. **Fanout** — Query dispatched to all 5 search providers (Alpaca, Finnhub, Polygon, StockSharp) in parallel
+3. **Aggregation** — Results deduplicated by ticker+exchange, ranked by confidence (exact match, provider priority, active status, FIGI confirmation)
+4. **OpenFIGI Resolution** — Top candidate resolved to global FIGI ID via `OpenFigiClient`; result cached in `SecurityMasterEventStore` (event-sourced, snapshot + projection cache)
+5. **SymbolMapper** — Canonical FIGI → exchange-qualified ticker in each provider's format (e.g. `AAPL.US` for Stooq, `AAPL [SMART/USD]` for IB); `ContractFactory` for IB contract resolution
+6. **Output** — `CanonicalSymbol` with FIGI, ticker, asset class, currency, and pre-computed provider format cache; registered to `Symbol Registry`
+
 ### UI Navigation Map _(auto-generated)_
 
 Shows the current WPF sidebar implementation as it exists in source control:
@@ -429,4 +478,4 @@ See [uml/README.md](uml/README.md) for the full inventory and rendering instruct
 
 _Graphviz diagrams generated with DOT language. UML diagrams generated with PlantUML._
 
-_Last Updated: 2026-03-23_
+_Last Updated: 2026-03-24_

--- a/docs/diagrams/backfill-workflow.dot
+++ b/docs/diagrams/backfill-workflow.dot
@@ -1,0 +1,212 @@
+// Backfill Workflow Diagram
+// Meridian v1.7.x
+// Last Updated: 2026-03-24
+//
+// This diagram shows the end-to-end backfill workflow:
+// CLI command parsing → BackfillCoordinator → CompositeHistoricalDataProvider
+// → per-provider rate limiting → gap detection → WAL + storage.
+//
+// Generate: dot -Tpng backfill-workflow.dot -o backfill-workflow.png
+//           dot -Tsvg backfill-workflow.dot -o backfill-workflow.svg
+
+digraph BackfillWorkflow {
+  rankdir=TB;
+  graph [fontname="Helvetica", fontsize=12, bgcolor="white", compound=true, pad=0.5, splines=ortho];
+  node  [fontname="Helvetica", fontsize=10, shape=box, style="rounded,filled"];
+  edge  [fontname="Helvetica", fontsize=9, color="#4a5568"];
+
+  // Title
+  labelloc="t";
+  label="Meridian - Backfill Workflow\nCLI → CompositeProvider → Rate Limiting → Storage | v1.7.x";
+
+  // 1. Entry Points
+  subgraph cluster_entry {
+    label="1. Backfill Entry Points";
+    color="#805ad5";
+    style="rounded";
+    bgcolor="#faf5ff";
+
+    CLI [fillcolor="#ddd6fe",
+         label="CLI Command\n\n--backfill\n--backfill-provider <name>\n--backfill-symbols SPY,AAPL\n--backfill-from 2024-01-01\n--backfill-to   2024-01-31"];
+
+    REST [fillcolor="#ddd6fe",
+          label="REST API\n\nPOST /api/backfill/run\n{\n  provider, symbols,\n  from, to\n}"];
+
+    SCHEDULED [fillcolor="#e9d5ff",
+               label="Scheduled / Gap Repair\n\nBackfillScheduler\nAutomatic gap detection\nMissing date fills"];
+  }
+
+  // 2. Coordinator
+  subgraph cluster_coordinator {
+    label="2. Backfill Coordinator";
+    color="#2b6cb0";
+    style="rounded";
+    bgcolor="#dbeafe";
+
+    COORD [fillcolor="#93c5fd",
+           label="BackfillCoordinator\n\nValidate request params\nResolve provider by name\nPartition date range\nEnqueue work items\nTrack run status"];
+
+    CATALOG_CHECK [fillcolor="#bfdbfe",
+                   label="StorageCatalogService\n\nCheck existing coverage\nIdentify missing gaps\nSkip already-filled dates\nData lineage tracking"];
+
+    REQUEST [shape=note, fillcolor="#dbeafe",
+             label="BackfillRequest:\n• Symbols[]\n• DateRange (from/to)\n• ProviderName (optional)\n• MaxConcurrency\n• ForceRefresh flag"];
+  }
+
+  // 3. CompositeHistoricalDataProvider
+  subgraph cluster_composite {
+    label="3. CompositeHistoricalDataProvider (Failover Orchestrator)";
+    color="#2c7a7b";
+    style="rounded";
+    bgcolor="#d1fae5";
+
+    COMPOSITE [fillcolor="#6ee7b7",
+               label="CompositeHistoricalDataProvider\n\nPriority-based provider selection\nAutomatic failover on error\nCircuit breaker per provider\nRate-limit rotation\nHealth-based exclusion"];
+
+    PRIORITY [shape=note, fillcolor="#a7f3d0",
+              label="Provider Priority Order:\n1. Alpaca (5) / IB (5)\n2. Yahoo Finance (10)\n3. Polygon (15)\n4. Stooq (20)\n5. Tiingo (25)\n6. Nasdaq Data Link (30)\n7. StockSharp (35)\n8. Finnhub (35)\n9. Twelve Data (38)\n10. Alpha Vantage (40)\n11. FRED (45)"];
+
+    CIRCUIT [fillcolor="#a7f3d0",
+             label="CircuitBreaker\n[Per Provider]\n\nClosed → Open → Half-Open\nFailure counting\nAuto-recovery cooldown\nHealth metric export"];
+  }
+
+  // 4. Rate Limiting
+  subgraph cluster_ratelimit {
+    label="4. Rate Limiting & Throttling";
+    color="#ed8936";
+    style="rounded";
+    bgcolor="#fffaf0";
+
+    RATE_LIMITER [fillcolor="#fbd38d",
+                  label="ProviderRateLimitTracker\n\nToken bucket per provider\nRequest counting\nCooldown enforcement\nBurst allowance"];
+
+    BACKOFF [fillcolor="#feebc8",
+             label="Exponential Backoff\n\nOn 429 / rate-limit response\n1s → 2s → 4s → 8s → 16s\nJitter randomization\nMax 5 retries"];
+
+    subgraph cluster_provider_limits {
+      label="Per-Provider Rate Limits";
+      style="dashed";
+      color="#b7791f";
+
+      LIM_ALP  [shape=note, fillcolor="#fefcbf", label="Alpaca\n200 req/min"];
+      LIM_POL  [shape=note, fillcolor="#fefcbf", label="Polygon\n5 req/min (free)"];
+      LIM_AV   [shape=note, fillcolor="#fefcbf", label="Alpha Vantage\n5 req/min (free)"];
+      LIM_FINN [shape=note, fillcolor="#fefcbf", label="Finnhub\n60 req/min"];
+      LIM_TIING[shape=note, fillcolor="#fefcbf", label="Tiingo\n500 req/hr"];
+    }
+  }
+
+  // 5. Provider Execution
+  subgraph cluster_providers {
+    label="5. Historical Provider Execution";
+    color="#2c7a7b";
+    style="dashed";
+    bgcolor="#e6fffa";
+
+    HIST_CALL [fillcolor="#81e6d9",
+               label="IHistoricalDataProvider\n.GetHistoricalBarsAsync()\n.StreamHistoricalBarsAsync()\n\nIAsyncEnumerable<HistoricalBar>\nPaged fetch with backpressure\nAuto-decompress responses"];
+
+    PARSE [fillcolor="#b2f5ea",
+           label="Response Parsing\n\nJSON / CSV deserialization\nADR-014 source generators\nOHLCV normalization\nTimezone canonicalization (UTC)\nAdjusted price handling"];
+  }
+
+  // 6. Gap Detection & Validation
+  subgraph cluster_gaps {
+    label="6. Gap Detection & Sequence Validation";
+    color="#718096";
+    style="rounded";
+    bgcolor="#f7fafc";
+
+    GAP_DETECT [fillcolor="#e2e8f0",
+                label="Gap Detector\n\nCompare fetched vs expected dates\nMissing interval flagging\nOut-of-order detection\nIntegrityEvent emission on anomaly"];
+
+    FSHARP_VAL [fillcolor="#e2e8f0",
+                label="F# Validation Pipeline\n[Railway-Oriented]\n\nPrice > 0, Volume ≥ 0\nHigh ≥ Low, Close in range\nTimestamp monotonic\nError accumulation"];
+  }
+
+  // 7. Storage
+  subgraph cluster_storage {
+    label="7. Durable Storage";
+    color="#c53030";
+    style="rounded";
+    bgcolor="#fee2e2";
+
+    WAL [fillcolor="#fc8181", fontcolor="white",
+         label="Write-Ahead Log\n\nJournal before write\nCrash-safe guarantee\nSHA256 per entry\nNoSync / Batched modes"];
+
+    JSONL_SINK [fillcolor="#fecaca",
+                label="JSONL Sink\n\nAppend-only writes\nDaily partition files\n{root}/{symbol}/{type}/{date}.jsonl\nOptional LZ4 compression"];
+
+    PARQUET_SINK [fillcolor="#fecaca",
+                  label="Parquet Sink\n\nColumnar archival format\n10-20x compression\nSchema versioning\nBatch flush (1000 rows)"];
+
+    TIERED [fillcolor="#fecaca",
+            label="Tiered Storage Manager\n\nHot (SSD): 0-7 days\nWarm (HDD): 7-30 days\nCold (S3/Glacier): 30d+\nAutomatic tier promotion"];
+  }
+
+  // 8. Observability
+  subgraph cluster_obs {
+    label="8. Observability & Status";
+    color="#38a169";
+    style="rounded";
+    bgcolor="#f0fff4";
+
+    PROGRESS [fillcolor="#9ae6b4",
+              label="BackfillProgressTracker\n\nSymbol × date coverage\nRows fetched / stored\nProvider used per segment\nETA estimation"];
+
+    METRICS [fillcolor="#9ae6b4",
+             label="Prometheus Metrics\n\nmdc_backfill_requests_total\nmdc_backfill_rows_fetched\nmdc_backfill_errors_total\nmdc_provider_latency_seconds"];
+
+    RUN_RESULT [shape=note, fillcolor="#c6f6d5",
+                label="BackfillRunResult:\n• Symbol coverage map\n• Rows per provider\n• Gaps remaining\n• Duration + errors\n• StorageCatalog updated"];
+  }
+
+  // Data Flow
+  CLI -> COORD [color="#805ad5", penwidth=2, label="1. request"];
+  REST -> COORD [color="#805ad5", penwidth=2];
+  SCHEDULED -> COORD [color="#805ad5", style=dashed];
+
+  COORD -> CATALOG_CHECK [color="#2b6cb0", label="2. gap check"];
+  CATALOG_CHECK -> COORD [color="#2b6cb0", style=dashed, label="missing dates"];
+  COORD -> REQUEST [style=dashed];
+
+  COORD -> COMPOSITE [color="#2c7a7b", penwidth=2, label="3. fetch"];
+  COMPOSITE -> PRIORITY [style=dashed];
+  COMPOSITE -> CIRCUIT [color="#c53030", style=dashed];
+
+  COMPOSITE -> RATE_LIMITER [color="#ed8936", label="4. throttle"];
+  RATE_LIMITER -> BACKOFF [color="#ed8936", style=dashed, label="on 429"];
+  RATE_LIMITER -> LIM_ALP [style=dashed];
+  RATE_LIMITER -> LIM_POL [style=dashed];
+  RATE_LIMITER -> LIM_AV  [style=dashed];
+  RATE_LIMITER -> LIM_FINN[style=dashed];
+  RATE_LIMITER -> LIM_TIING[style=dashed];
+
+  RATE_LIMITER -> HIST_CALL [color="#2c7a7b", penwidth=2, label="5. execute"];
+  HIST_CALL -> PARSE [color="#2c7a7b"];
+
+  PARSE -> GAP_DETECT [color="#718096", label="6. validate"];
+  GAP_DETECT -> FSHARP_VAL [color="#718096"];
+
+  FSHARP_VAL -> WAL [color="#c53030", penwidth=2, label="7. store"];
+  WAL -> JSONL_SINK [color="#c53030", penwidth=2];
+  WAL -> PARQUET_SINK [color="#c53030"];
+  JSONL_SINK -> TIERED [color="#c53030", style=dashed];
+  PARQUET_SINK -> TIERED [color="#c53030", style=dashed];
+
+  COORD -> PROGRESS [color="#38a169", style=dashed, label="8. track"];
+  PROGRESS -> METRICS [color="#38a169", style=dashed];
+  COORD -> RUN_RESULT [color="#38a169", label="result"];
+  CATALOG_CHECK -> TIERED [style=dashed, color="#2b6cb0", label="update catalog"];
+
+  // Legend
+  subgraph cluster_legend {
+    label="Legend";
+    style="rounded";
+    color="#666666";
+    bgcolor="#fafafa";
+
+    LEG [shape=plaintext,
+         label="━━ Main backfill flow\n─ ─ Reference / Error handling\nNumbers = processing phase order"];
+  }
+}

--- a/docs/diagrams/configuration-management.dot
+++ b/docs/diagrams/configuration-management.dot
@@ -1,0 +1,190 @@
+// Configuration Management Diagram
+// Meridian v1.7.x
+// Last Updated: 2026-03-24
+//
+// This diagram shows the configuration management architecture:
+// appsettings.json hierarchy, environment variable overrides,
+// IOptionsMonitor hot-reload, and how components consume config.
+//
+// Generate: dot -Tpng configuration-management.dot -o configuration-management.png
+//           dot -Tsvg configuration-management.dot -o configuration-management.svg
+
+digraph ConfigurationManagement {
+  rankdir=TB;
+  graph [fontname="Helvetica", fontsize=12, bgcolor="white", compound=true, pad=0.5];
+  node  [fontname="Helvetica", fontsize=10, shape=box, style="rounded,filled"];
+  edge  [fontname="Helvetica", fontsize=9, color="#4a5568"];
+
+  // Title
+  labelloc="t";
+  label="Meridian - Configuration Management\nHierarchy, Hot-Reload, and IOptionsMonitor | v1.7.x";
+
+  // Configuration Sources (priority low → high)
+  subgraph cluster_sources {
+    label="Configuration Sources (lowest → highest priority)";
+    color="#4a5568";
+    style="rounded";
+    bgcolor="#f7fafc";
+
+    SRC_DEFAULT [fillcolor="#e2e8f0",
+                 label="Built-In Defaults\n[Priority 1 — lowest]\n\nHardcoded fallback values\nin ConfigurationDefaults.cs\nSafe minimal config"];
+
+    SRC_SAMPLE [fillcolor="#e2e8f0",
+                label="appsettings.sample.json\n[Priority 2]\n\nTemplate with all sections\nDocumented placeholders\nCommitted to source control"];
+
+    SRC_JSON [fillcolor="#fef3c7",
+              label="appsettings.json\n[Priority 3]\n\nUser-local runtime config\nGitignored (not committed)\nAll sections: DataSource,\nSymbols, Storage, Backfill,\nDataQuality, Sla, Maintenance"];
+
+    SRC_ENV [fillcolor="#fc8181", fontcolor="white",
+             label="Environment Variables\n[Priority 4 — highest]\n\nALPACA_KEY_ID\nALPACA_SECRET_KEY\nPOLYGON_API_KEY\nFINNHUB_API_KEY\nTIINGO_API_TOKEN\nIB_HOST / IB_PORT\n...and more"];
+
+    SRC_CLI [fillcolor="#fbd38d",
+             label="CLI / Command-Line Args\n[Priority 4 — highest]\n\n--http-port, --symbols\n--backfill-provider\nOverride at launch time"];
+  }
+
+  // Configuration Building
+  subgraph cluster_build {
+    label="Configuration Build (Program.cs)";
+    color="#2b6cb0";
+    style="rounded";
+    bgcolor="#dbeafe";
+
+    CONFIG_BUILDER [fillcolor="#93c5fd",
+                    label="IConfigurationBuilder\n(WebApplication.CreateBuilder)\n\nMerge all sources\nLast writer wins\nEnvironment-specific loading"];
+
+    ICONFIG [fillcolor="#bfdbfe",
+             label="IConfiguration\n(Merged Result)\n\nFlat key-value view\nSection hierarchy\nBind to typed objects"];
+  }
+
+  // Options Pattern
+  subgraph cluster_options {
+    label="Options Pattern (ADR-011)";
+    color="#805ad5";
+    style="rounded";
+    bgcolor="#ede9fe";
+
+    IOPTIONS_MON [fillcolor="#ddd6fe",
+                  label="IOptionsMonitor<T>\n[Preferred — ADR-011]\n\nRuntime-mutable config\nOnChange callbacks\nSupports hot-reload\nCurrentValue always fresh"];
+
+    IOPTIONS [fillcolor="#e9d5ff",
+              label="IOptions<T>\n[Snapshot — use sparingly]\n\nFixed at startup\nNo hot-reload\nOK for immutable settings"];
+
+    WATCH_CONFIG [fillcolor="#ddd6fe",
+                  label="--watch-config flag\n\nFileSystemWatcher on\nappsettings.json\nTriggers re-bind on change\nZero-downtime reload"];
+
+    subgraph cluster_typed_options {
+      label="Typed Options Classes";
+      style="dashed";
+      color="#6b21a8";
+
+      OPT_DATA [shape=note, fillcolor="#f3e8ff",
+                label="DataSourceOptions\n• ProviderName\n• ConnectionString\n• MaxReconnects"];
+
+      OPT_SYM [shape=note, fillcolor="#f3e8ff",
+               label="SymbolsOptions\n• Monitored[]\n• Archived[]\n• Tiers"];
+
+      OPT_STOR [shape=note, fillcolor="#f3e8ff",
+                label="StorageOptions\n• RootPath\n• Format\n• RetentionDays\n• CompressionLevel"];
+
+      OPT_BF [shape=note, fillcolor="#f3e8ff",
+              label="BackfillOptions\n• Providers[]\n• MaxConcurrency\n• DefaultDateRange"];
+
+      OPT_DQ [shape=note, fillcolor="#f3e8ff",
+              label="DataQualityOptions\n• MinGrade\n• OutlierSigma\n• SlaLatencyMs"];
+    }
+  }
+
+  // Credential Handling
+  subgraph cluster_creds {
+    label="Credential Handling (ADR-011)";
+    color="#c53030";
+    style="rounded";
+    bgcolor="#fee2e2";
+
+    CRED_ENV [fillcolor="#fecaca",
+              label="Environment Variables Only\n\nNEVER in appsettings.json\nNEVER in source control\nRead via IConfiguration\nMasked in logs/MCP reads"];
+
+    CRED_VALIDATE [fillcolor="#fecaca",
+                   label="CredentialValidator\n\n--validate-credentials\nTest each API key live\nReport missing / invalid\nSuggest env var names"];
+  }
+
+  // Consuming Components
+  subgraph cluster_consumers {
+    label="Components that Consume Configuration";
+    color="#2c7a7b";
+    style="rounded";
+    bgcolor="#d1fae5";
+
+    STREAM_PROV [fillcolor="#6ee7b7",
+                 label="Streaming Providers\n(IMarketDataClient)\n\nReads: connection strings,\nAPI keys, reconnect settings\nVia IOptionsMonitor"];
+
+    HIST_PROV [fillcolor="#6ee7b7",
+               label="Historical Providers\n(IHistoricalDataProvider)\n\nReads: API keys, base URLs,\nrate limits, priority order\nVia IOptionsMonitor"];
+
+    STORAGE_COMP [fillcolor="#6ee7b7",
+                  label="Storage Layer\n(Sinks, WAL, Tiering)\n\nReads: root path, format,\ncompression, retention\nVia IOptionsMonitor"];
+
+    PIPELINE [fillcolor="#6ee7b7",
+              label="EventPipeline\n\nReads: channel capacity,\ndrop policy, flush interval\nVia IOptionsMonitor"];
+
+    SLA_MON [fillcolor="#6ee7b7",
+             label="SLA Monitor\n\nReads: per-provider targets,\ngrade thresholds, alert rules\nVia IOptionsMonitor"];
+  }
+
+  // Validation & Diagnostics
+  subgraph cluster_diag {
+    label="Validation & Diagnostics";
+    color="#38a169";
+    style="rounded";
+    bgcolor="#f0fff4";
+
+    VAL_STARTUP [fillcolor="#9ae6b4",
+                 label="Startup Validation\n\nRequired field checks\nType coercion errors\nEarly-exit on bad config\nFriendly error codes"];
+
+    SHOW_CONFIG [fillcolor="#9ae6b4",
+                 label="--show-config\n\nPrint current merged config\nCredentials masked (***)\nEffective values shown\nSource annotated"];
+  }
+
+  // Flow edges
+  SRC_DEFAULT -> CONFIG_BUILDER [color="#4a5568", style=dashed];
+  SRC_SAMPLE -> CONFIG_BUILDER [color="#4a5568", style=dashed];
+  SRC_JSON -> CONFIG_BUILDER [color="#2b6cb0", penwidth=2];
+  SRC_ENV -> CONFIG_BUILDER [color="#c53030", penwidth=2, label="override"];
+  SRC_CLI -> CONFIG_BUILDER [color="#ed8936", penwidth=1.5, label="override"];
+
+  CONFIG_BUILDER -> ICONFIG [color="#2b6cb0", penwidth=2];
+
+  ICONFIG -> IOPTIONS_MON [color="#805ad5", penwidth=2, label="bind"];
+  ICONFIG -> IOPTIONS [color="#805ad5", style=dashed];
+  IOPTIONS_MON -> OPT_DATA [style=dashed];
+  IOPTIONS_MON -> OPT_SYM [style=dashed];
+  IOPTIONS_MON -> OPT_STOR [style=dashed];
+  IOPTIONS_MON -> OPT_BF [style=dashed];
+  IOPTIONS_MON -> OPT_DQ [style=dashed];
+
+  WATCH_CONFIG -> IOPTIONS_MON [color="#805ad5", label="reload trigger"];
+  SRC_JSON -> WATCH_CONFIG [color="#ed8936", style=dashed, label="watched"];
+
+  IOPTIONS_MON -> STREAM_PROV [color="#2c7a7b", penwidth=2];
+  IOPTIONS_MON -> HIST_PROV [color="#2c7a7b", penwidth=2];
+  IOPTIONS_MON -> STORAGE_COMP [color="#2c7a7b", penwidth=2];
+  IOPTIONS_MON -> PIPELINE [color="#2c7a7b"];
+  IOPTIONS_MON -> SLA_MON [color="#2c7a7b"];
+
+  SRC_ENV -> CRED_ENV [color="#c53030", label="credentials only"];
+  CRED_ENV -> CRED_VALIDATE [color="#c53030", style=dashed];
+
+  ICONFIG -> VAL_STARTUP [color="#38a169", label="validate at startup"];
+  ICONFIG -> SHOW_CONFIG [color="#38a169", style=dashed];
+
+  // Legend
+  subgraph cluster_legend {
+    label="Legend";
+    style="rounded";
+    color="#666666";
+    bgcolor="#fafafa";
+
+    LEG [shape=plaintext,
+         label="━━ Primary config flow\n─ ─ Reference / Optional\nPriority: env vars override JSON, JSON overrides defaults\nRed = credentials (env vars only, never in files)"];
+  }
+}

--- a/docs/diagrams/data-flow.dot
+++ b/docs/diagrams/data-flow.dot
@@ -1,6 +1,6 @@
 // Data Flow Diagram
-// Meridian v1.6.1
-// Last Updated: 2026-02-21
+// Meridian v1.7.x
+// Last Updated: 2026-03-24
 //
 // This diagram shows the end-to-end data flow through the system,
 // from ingestion to storage and export.
@@ -16,7 +16,7 @@ digraph DataFlow {
 
   // Title
   labelloc="t";
-  label="Meridian - Data Flow Diagram\nEnd-to-End Event Processing | v1.6.1";
+  label="Meridian - Data Flow Diagram\nEnd-to-End Event Processing | v1.7.x";
 
   // Onboarding Flow (First-Time Setup)
   subgraph cluster_onboarding {
@@ -28,13 +28,13 @@ digraph DataFlow {
     FIRST_RUN [fillcolor="#fbd38d", label="First-Run Detection\n\nDetect new install\nDisplay welcome"];
     WIZARD [fillcolor="#fbd38d", label="Configuration Wizard\n[8 Steps]\n\nInteractive setup\nProvider selection"];
     AUTO_CONFIG [fillcolor="#fbd38d", label="Auto-Configuration\n\nEnv var detection\nGenerate config"];
-    VALIDATE [fillcolor="#fbd38d", label="Validation\n\nTest connectivity\nValidate credentials"];
+    VALIDATE [fillcolor="#fbd38d", label="Validation\n\n--validate-credentials\n--test-connectivity"];
     CONFIG_FILE [shape=note, fillcolor="#feebc8", label="appsettings.json\n\nGenerated config\nReady to run"];
   }
 
   // Data Sources - Streaming
   subgraph cluster_streaming_sources {
-    label="Real-Time Streaming Sources";
+    label="Real-Time Streaming Sources (5 Providers)";
     color="#2b6cb0";
     style="rounded";
     bgcolor="#f0f8ff";
@@ -42,12 +42,13 @@ digraph DataFlow {
     IB [fillcolor="#4a90d9", fontcolor="white", label="IB TWS/Gateway\n[WebSocket]\n\nTrades, Quotes\nL2 Depth, Scanner"];
     ALP [fillcolor="#4a90d9", fontcolor="white", label="Alpaca\n[WebSocket]\n\nTrades, Quotes\nIEX/SIP Feeds"];
     NYSE [fillcolor="#4a90d9", fontcolor="white", label="NYSE Direct\n[Exchange Feed]\n\nUS Equities\nReal-time"];
-    SS [fillcolor="#4a90d9", fontcolor="white", label="StockSharp\n[Multi-Exchange]\n\nGlobal Markets"];
+    POL_STREAM [fillcolor="#4a90d9", fontcolor="white", label="Polygon.io\n[WebSocket]\n\nTrades, Quotes\nUS + Global"];
+    SS [fillcolor="#4a90d9", fontcolor="white", label="StockSharp\n[Multi-Exchange]\n\nGlobal Markets\n90+ Connectors"];
   }
 
   // Data Sources - Historical
   subgraph cluster_historical_sources {
-    label="Historical Data Sources (10 Providers)";
+    label="Historical Data Sources (13 Providers)";
     color="#2c7a7b";
     style="rounded";
     bgcolor="#e6fffa";
@@ -55,7 +56,7 @@ digraph DataFlow {
     YAHOO [fillcolor="#38a169", fontcolor="white", label="Yahoo Finance\n[REST]\n\n50K+ securities\nFree OHLCV"];
     TIINGO [fillcolor="#38a169", fontcolor="white", label="Tiingo\n[REST]\n\nDividend-adjusted\nFundamentals"];
     FINNHUB [fillcolor="#38a169", fontcolor="white", label="Finnhub\n[REST]\n\nHistorical\nNews, Fundamentals"];
-    OTHERS [fillcolor="#38a169", fontcolor="white", label="Polygon, Stooq\nNasdaq, Alpha V.\nIB, StockSharp\n\nEOD/Intraday"];
+    OTHERS [fillcolor="#38a169", fontcolor="white", label="Polygon, Stooq, Nasdaq\nAlpha V., IB, StockSharp\nTwelve Data, FRED\n\nEOD/Intraday/Economic"];
   }
 
   // Ingestion Layer
@@ -162,6 +163,7 @@ digraph DataFlow {
   IB -> STREAM_INGEST [color="#2b6cb0", penwidth=2, label="L1/L2\nstreaming"];
   ALP -> STREAM_INGEST [color="#2b6cb0", penwidth=2, label="trades\nquotes"];
   NYSE -> STREAM_INGEST [color="#2b6cb0", penwidth=2, label="exchange\nfeed"];
+  POL_STREAM -> STREAM_INGEST [color="#2b6cb0", penwidth=2, label="websocket\nfeed"];
   SS -> STREAM_INGEST [color="#2b6cb0", penwidth=2];
 
   // Data Flow Edges - Historical Sources
@@ -218,6 +220,7 @@ digraph DataFlow {
   FIRST_RUN -> AUTO_CONFIG [color="#ed8936", label="--auto-config"];
   WIZARD -> AUTO_CONFIG [color="#ed8936"];
   AUTO_CONFIG -> CONFIG_FILE [color="#ed8936", label="generates"];
+  AUTO_CONFIG -> VALIDATE [color="#ed8936", label="optional"];
   VALIDATE -> CONFIG_FILE [color="#ed8936", style=dashed, label="validates"];
   CONFIG_FILE -> STREAM_INGEST [color="#ed8936", style=dashed, label="enables"];
   CONFIG_FILE -> HIST_INGEST [color="#ed8936", style=dashed, label="enables"];

--- a/docs/diagrams/mcp-server.dot
+++ b/docs/diagrams/mcp-server.dot
@@ -1,0 +1,197 @@
+// MCP Server Architecture Diagram
+// Meridian v1.7.x
+// Last Updated: 2026-03-24
+//
+// This diagram shows the Model Context Protocol (MCP) server architecture:
+// tools, resources, prompts, and how they integrate with Meridian's core services.
+//
+// Generate: dot -Tpng mcp-server.dot -o mcp-server.png
+//           dot -Tsvg mcp-server.dot -o mcp-server.svg
+
+digraph McpServer {
+  rankdir=LR;
+  graph [fontname="Helvetica", fontsize=12, bgcolor="white", compound=true, pad=0.5];
+  node  [fontname="Helvetica", fontsize=10, shape=box, style="rounded,filled"];
+  edge  [fontname="Helvetica", fontsize=9, color="#4a5568"];
+
+  // Title
+  labelloc="t";
+  label="Meridian - MCP Server Architecture\nModel Context Protocol Integration | v1.7.x";
+
+  // MCP Clients
+  subgraph cluster_clients {
+    label="MCP Clients";
+    color="#4a5568";
+    style="rounded";
+    bgcolor="#f7fafc";
+
+    CLAUDE_CLIENT [fillcolor="#e2e8f0",
+                   label="Claude Desktop / Claude.ai\n\nAI assistant context\nTool invocation\nResource reads"];
+
+    OTHER_CLIENT [fillcolor="#e2e8f0",
+                  label="Other MCP Clients\n\nCopilot, Cursor, etc.\nMCP-compatible hosts\nCustom integrations"];
+  }
+
+  // MCP Server Host
+  subgraph cluster_server {
+    label="Meridian.McpServer (.NET 9 / ModelContextProtocol SDK)";
+    color="#805ad5";
+    style="rounded";
+    bgcolor="#faf5ff";
+
+    MCP_HOST [fillcolor="#ddd6fe",
+              label="McpServer Host\n\nASP.NET Core hosting\nStdio transport\nJSON-RPC 2.0 protocol\nCapabilities negotiation"];
+
+    DI [fillcolor="#e9d5ff",
+        label="Dependency Injection\n\nBackfillCoordinator\nStorageCatalogService\nProviderRegistry\nIOptionsMonitor<T>"];
+  }
+
+  // Tools
+  subgraph cluster_tools {
+    label="MCP Tools ([McpServerTool])";
+    color="#2b6cb0";
+    style="rounded";
+    bgcolor="#dbeafe";
+
+    subgraph cluster_backfill_tools {
+      label="BackfillTools";
+      style="dashed";
+      color="#1e40af";
+
+      T_BACKFILL [fillcolor="#bfdbfe",
+                  label="RunBackfill\n\nTrigger historical backfill\nParams: symbols, provider,\nfrom, to dates\nReturns: run summary JSON"];
+    }
+
+    subgraph cluster_symbol_tools {
+      label="SymbolTools";
+      style="dashed";
+      color="#1e40af";
+
+      T_ADD_SYM [fillcolor="#bfdbfe",
+                 label="AddSymbol\n\nAdd symbol to monitoring set\nParams: symbol, tier\nReturns: updated symbol list"];
+
+      T_RM_SYM [fillcolor="#bfdbfe",
+                label="RemoveSymbol\n\nRemove from monitoring\nParams: symbol\nReturns: confirmation"];
+    }
+
+    subgraph cluster_provider_tools {
+      label="ProviderTools";
+      style="dashed";
+      color="#1e40af";
+
+      T_LIST_PROV [fillcolor="#bfdbfe",
+                   label="ListBackfillProviders\n\nList all available providers\nWith health status\nPriority + capabilities"];
+
+      T_LAST_RESULT [fillcolor="#bfdbfe",
+                     label="GetLastBackfillResult\n\nFetch most recent run result\nCoverage map, row counts\nErrors + gaps remaining"];
+    }
+
+    subgraph cluster_storage_tools {
+      label="StorageTools";
+      style="dashed";
+      color="#1e40af";
+
+      T_QUERY [fillcolor="#bfdbfe",
+               label="QueryStoredData\n\nQuery stored data inventory\nParams: symbol, type, date range\nReturns: file list + row counts"];
+    }
+  }
+
+  // Resources
+  subgraph cluster_resources {
+    label="MCP Resources ([McpServerResource])";
+    color="#2c7a7b";
+    style="rounded";
+    bgcolor="#d1fae5";
+
+    R_CATALOG [fillcolor="#6ee7b7",
+               label="GetProviderCatalog\n\nmcp://meridian/providers\nAll providers: name, priority,\ncapabilities, health status\nJSON snapshot"];
+
+    R_STORAGE [fillcolor="#6ee7b7",
+               label="GetStorageCatalog\n\nmcp://meridian/storage\nSymbol × date × type inventory\nCoverage stats, file sizes\nGap summary per symbol"];
+
+    R_CONFIG [fillcolor="#6ee7b7",
+              label="GetActiveConfiguration\n\nmcp://meridian/config\nCurrent appsettings snapshot\nCredentials masked\nActive feature flags"];
+  }
+
+  // Prompts
+  subgraph cluster_prompts {
+    label="MCP Prompts ([McpServerPrompt])";
+    color="#ed8936";
+    style="rounded";
+    bgcolor="#fffaf0";
+
+    P_BACKFILL [fillcolor="#fbd38d",
+                label="BackfillSetup Prompt\n\nGuided backfill workflow\nParams: symbols, provider,\nfrom, to dates\nReturns structured message chain"];
+
+    P_PROVIDER [fillcolor="#fbd38d",
+                label="ProviderConfiguration Prompt\n\nProvider setup guidance\nParams: provider identifier\nAPI key instructions\nConfig snippet generation"];
+  }
+
+  // Core Services (Meridian backend)
+  subgraph cluster_backend {
+    label="Meridian Core Services";
+    color="#c53030";
+    style="rounded";
+    bgcolor="#fee2e2";
+
+    BACKFILL_SVC [fillcolor="#fecaca",
+                  label="BackfillCoordinator\n\nOrchestrates backfill runs\nManages provider failover\nRun status tracking"];
+
+    STORAGE_CATALOG [fillcolor="#fecaca",
+                     label="StorageCatalogService\n\nSymbol × date × type index\nGap identification\nData lineage"];
+
+    PROVIDER_REG [fillcolor="#fecaca",
+                  label="ProviderRegistry\n\nAll registered providers\nCapabilities + health\nPriority ordering"];
+
+    CONFIG_SVC [fillcolor="#fecaca",
+                label="IOptionsMonitor<T>\n\nLive configuration\nHot-reload support\nCredentials masked on read"];
+  }
+
+  // Client → Server
+  CLAUDE_CLIENT -> MCP_HOST [color="#805ad5", penwidth=2, label="stdio / JSON-RPC"];
+  OTHER_CLIENT -> MCP_HOST [color="#805ad5", penwidth=1, style=dashed];
+
+  // Server → components
+  MCP_HOST -> DI [style=dashed];
+  MCP_HOST -> T_BACKFILL [color="#2b6cb0", label="invoke"];
+  MCP_HOST -> T_ADD_SYM [color="#2b6cb0"];
+  MCP_HOST -> T_RM_SYM [color="#2b6cb0"];
+  MCP_HOST -> T_LIST_PROV [color="#2b6cb0"];
+  MCP_HOST -> T_LAST_RESULT [color="#2b6cb0"];
+  MCP_HOST -> T_QUERY [color="#2b6cb0"];
+  MCP_HOST -> R_CATALOG [color="#2c7a7b", label="read"];
+  MCP_HOST -> R_STORAGE [color="#2c7a7b"];
+  MCP_HOST -> R_CONFIG [color="#2c7a7b"];
+  MCP_HOST -> P_BACKFILL [color="#ed8936", label="expand"];
+  MCP_HOST -> P_PROVIDER [color="#ed8936"];
+
+  // Tools → backend services
+  T_BACKFILL -> BACKFILL_SVC [color="#c53030", penwidth=2];
+  T_ADD_SYM -> CONFIG_SVC [color="#c53030"];
+  T_RM_SYM -> CONFIG_SVC [color="#c53030"];
+  T_LIST_PROV -> PROVIDER_REG [color="#c53030"];
+  T_LAST_RESULT -> BACKFILL_SVC [color="#c53030"];
+  T_QUERY -> STORAGE_CATALOG [color="#c53030"];
+
+  // Resources → backend services
+  R_CATALOG -> PROVIDER_REG [color="#2c7a7b"];
+  R_STORAGE -> STORAGE_CATALOG [color="#2c7a7b"];
+  R_CONFIG -> CONFIG_SVC [color="#2c7a7b"];
+
+  // DI wires backend into server
+  DI -> BACKFILL_SVC [style=dashed, color="#805ad5"];
+  DI -> STORAGE_CATALOG [style=dashed, color="#805ad5"];
+  DI -> PROVIDER_REG [style=dashed, color="#805ad5"];
+  DI -> CONFIG_SVC [style=dashed, color="#805ad5"];
+
+  // Legend
+  subgraph cluster_legend {
+    label="Legend";
+    style="rounded";
+    color="#666666";
+    bgcolor="#fafafa";
+
+    LEG [shape=plaintext,
+         label="━━ Protocol / invocation boundary\n─ ─ Dependency injection / reference\nBlue  = Tools (write operations)\nGreen = Resources (read-only)\nOrange = Prompts (text templates)"];
+  }
+}

--- a/docs/diagrams/onboarding-flow.dot
+++ b/docs/diagrams/onboarding-flow.dot
@@ -1,6 +1,6 @@
 // Onboarding & Diagnostics Flow Diagram
-// Meridian v1.6.1
-// Last Updated: 2026-02-21
+// Meridian v1.7.x
+// Last Updated: 2026-03-24
 //
 // This diagram shows the user journey from first-run through setup to operational,
 // including all diagnostic and configuration options.
@@ -16,7 +16,7 @@ digraph OnboardingFlow {
 
   // Title
   labelloc="t";
-  label="Meridian - Onboarding & Diagnostics Flow\nUser Journey from Installation to Operation | v1.6.1";
+  label="Meridian - Onboarding & Diagnostics Flow\nUser Journey from Installation to Operation | v1.7.x";
 
   // Entry Point
   START [shape=oval, fillcolor="#38a169", fontcolor="white",
@@ -156,6 +156,7 @@ digraph OnboardingFlow {
 
   WELCOME -> WIZARD_OPT [style=dashed];
   WELCOME -> AUTO_OPT [style=dashed];
+  WELCOME -> GENERATE_OPT [style=dashed];
   WELCOME -> DETECT_OPT [style=dashed];
 
   // Setup options flow

--- a/docs/diagrams/symbol-search-resolution.dot
+++ b/docs/diagrams/symbol-search-resolution.dot
@@ -1,0 +1,187 @@
+// Symbol Search & Resolution Diagram
+// Meridian v1.7.x
+// Last Updated: 2026-03-24
+//
+// This diagram shows the symbol search and resolution flow:
+// search query → 5 search providers → result aggregation → OpenFIGI canonical
+// ID resolution → SymbolMapper → canonical symbol ready for data collection.
+//
+// Generate: dot -Tpng symbol-search-resolution.dot -o symbol-search-resolution.png
+//           dot -Tsvg symbol-search-resolution.dot -o symbol-search-resolution.svg
+
+digraph SymbolSearchResolution {
+  rankdir=TB;
+  graph [fontname="Helvetica", fontsize=12, bgcolor="white", compound=true, pad=0.5];
+  node  [fontname="Helvetica", fontsize=10, shape=box, style="rounded,filled"];
+  edge  [fontname="Helvetica", fontsize=9, color="#4a5568"];
+
+  // Title
+  labelloc="t";
+  label="Meridian - Symbol Search & Resolution\nSearch → OpenFIGI Canonical ID → Provider-Specific Formats | v1.7.x";
+
+  // 1. Search Entry
+  subgraph cluster_entry {
+    label="1. Search Entry";
+    color="#805ad5";
+    style="rounded";
+    bgcolor="#faf5ff";
+
+    USER_QUERY [fillcolor="#ddd6fe",
+                label="Search Query\n\nFree-text: \"Apple Inc\"\nTicker: \"AAPL\"\nISIN: \"US0378331005\"\nCUSIP: \"037833100\"\nSEDOL: \"2046251\""];
+
+    CLI_SEARCH [fillcolor="#e9d5ff",
+                label="CLI / REST API\n\n--symbols-add AAPL\n--symbol-status AAPL\nPOST /api/symbols/search\nGET  /api/symbols/{ticker}"];
+  }
+
+  // 2. Symbol Search Interface
+  subgraph cluster_interface {
+    label="2. ISymbolSearchProvider Interface";
+    color="#2b6cb0";
+    style="rounded";
+    bgcolor="#dbeafe";
+
+    I_SEARCH [shape=ellipse, fillcolor="#93c5fd",
+              label="ISymbolSearchProvider\n[Interface]\n\nSearchAsync(query, ct)\nReturns: SymbolSearchResult[]"];
+
+    SEARCH_RESULT [shape=note, fillcolor="#bfdbfe",
+                   label="SymbolSearchResult:\n• Ticker (exchange-local)\n• Name (company/fund)\n• Exchange (e.g. XNAS)\n• AssetClass (Equity, ETF…)\n• Currency\n• Description"];
+  }
+
+  // 3. Search Providers
+  subgraph cluster_providers {
+    label="3. Symbol Search Providers (5 Implemented)";
+    color="#2c7a7b";
+    style="rounded";
+    bgcolor="#d1fae5";
+
+    ALP_SEARCH [fillcolor="#6ee7b7",
+                label="AlpacaSymbolSearchProvider\n[Production]\n\nUS equities + ETFs\nReal-time status (active/inactive)\nAsset class filter\nFull text + ticker match"];
+
+    FINN_SEARCH [fillcolor="#6ee7b7",
+                 label="FinnhubSymbolSearchProvider\n[Production]\n\nGlobal stocks\nExchange filter\nInstrument type filter\nFull description included"];
+
+    POL_SEARCH [fillcolor="#6ee7b7",
+                label="PolygonSymbolSearchProvider\n[Production]\n\nUS + global tickers\nFull text search\nMarket type filter (stocks, fx…)\nActive/inactive flag"];
+
+    SS_SEARCH [fillcolor="#6ee7b7",
+               label="StockSharpSymbolSearchProvider\n[Production]\n\n90+ exchange coverage\nMulti-exchange search\nGlobal market identifiers"];
+
+    FIGI_SEARCH [fillcolor="#a7f3d0",
+                 label="OpenFigiClient\n[Production — FIGI Resolution]\n\nGlobal FIGI assignment lookup\nFIGI → ticker mapping\nCUSIP / SEDOL / ISIN → FIGI\nCross-market identification\nBulk batch API support"];
+  }
+
+  // 4. Result Aggregation
+  subgraph cluster_aggregate {
+    label="4. Result Aggregation & Deduplication";
+    color="#718096";
+    style="rounded";
+    bgcolor="#f7fafc";
+
+    AGGREGATOR [fillcolor="#e2e8f0",
+                label="SymbolSearchAggregator\n\nFanout to all providers\nDedup by ticker + exchange\nRank by confidence score\nMerge metadata fields\nSelect best canonical form"];
+
+    RANK [shape=note, fillcolor="#edf2f7",
+          label="Ranking Factors:\n• Exact ticker match\n• Provider priority\n• Market cap weight\n• Active status\n• FIGI confirmation"];
+  }
+
+  // 5. OpenFIGI Canonical ID
+  subgraph cluster_figi {
+    label="5. OpenFIGI Canonical Identification";
+    color="#ed8936";
+    style="rounded";
+    bgcolor="#fffaf0";
+
+    FIGI_API [fillcolor="#fbd38d",
+              label="OpenFIGI API\n(api.openfigi.com)\n\nMapping request:\n{idType, idValue, exchCode}\nReturns: FIGI + metadata\nFree tier: 250 req/hr"];
+
+    FIGI_RESULT [shape=note, fillcolor="#feebc8",
+                 label="FIGI Response:\n• FIGI (global unique ID)\n• CompositeFIGI\n• Ticker\n• Name\n• ExchangeCode\n• SecurityType\n• MarketSector"];
+
+    FIGI_CACHE [shape=cylinder, fillcolor="#fef3c7",
+                label="SecurityMasterEventStore\n[Event-sourced cache]\n\nFIGI → ticker map persisted\nISIN / CUSIP / SEDOL index\nSnapshot + projection cache\nZero-latency repeat lookups"];
+  }
+
+  // 6. Symbol Mapping
+  subgraph cluster_mapping {
+    label="6. Provider-Specific Symbol Mapping";
+    color="#38a169";
+    style="rounded";
+    bgcolor="#c6f6d5";
+
+    SYMBOL_MAPPER [fillcolor="#9ae6b4",
+                   label="SymbolMapper\n\nCanonical → provider format\nExchange suffix rules\nNormalize CUSIP/SEDOL/ISIN\nHandle ADR suffixes\nRegional market variants"];
+
+    CONTRACT_FACTORY [fillcolor="#9ae6b4",
+                      label="ContractFactory\n[IB-specific]\n\nSymbol → IB Contract\nMultiple exchange resolution\nConId lookup\nOption / futures specs"];
+
+    subgraph cluster_format_examples {
+      label="Format Examples";
+      style="dashed";
+      color="#276749";
+
+      FMT_IB   [shape=note, fillcolor="#c6f6d5", label="IB Format:\nAAPL [SMART/USD]"];
+      FMT_ALP  [shape=note, fillcolor="#c6f6d5", label="Alpaca Format:\nAAPL"];
+      FMT_POL  [shape=note, fillcolor="#c6f6d5", label="Polygon Format:\nAAPL"];
+      FMT_STOOQ[shape=note, fillcolor="#c6f6d5", label="Stooq Format:\nAAPL.US"];
+      FMT_YAHOO[shape=note, fillcolor="#c6f6d5", label="Yahoo Format:\nAAPL"];
+    }
+  }
+
+  // 7. Canonical Symbol
+  subgraph cluster_output {
+    label="7. Canonical Symbol — Ready for Data Collection";
+    color="#2b6cb0";
+    style="rounded";
+    bgcolor="#dbeafe";
+
+    CANONICAL [fillcolor="#93c5fd",
+               label="CanonicalSymbol\n\nGlobal identifier (FIGI)\nExchange-qualified ticker\nAsset class + currency\nProvider format cache\nReady to subscribe / backfill"];
+
+    SYMBOL_STORE [shape=cylinder, fillcolor="#bfdbfe",
+                  label="Symbol Registry\n(appsettings.json)\n\nMonitored symbols list\nArchival symbols list\nTier assignment\nAdded via --symbols-add"];
+  }
+
+  // Data Flow
+  USER_QUERY -> I_SEARCH [color="#805ad5", penwidth=2, label="1. query"];
+  CLI_SEARCH -> I_SEARCH [color="#805ad5", style=dashed];
+
+  I_SEARCH -> ALP_SEARCH [color="#2c7a7b", label="2. fanout"];
+  I_SEARCH -> FINN_SEARCH [color="#2c7a7b"];
+  I_SEARCH -> POL_SEARCH [color="#2c7a7b"];
+  I_SEARCH -> SS_SEARCH [color="#2c7a7b"];
+
+  ALP_SEARCH -> AGGREGATOR [color="#718096"];
+  FINN_SEARCH -> AGGREGATOR [color="#718096"];
+  POL_SEARCH -> AGGREGATOR [color="#718096"];
+  SS_SEARCH -> AGGREGATOR [color="#718096"];
+  AGGREGATOR -> RANK [style=dashed];
+  AGGREGATOR -> SEARCH_RESULT [style=dashed];
+
+  AGGREGATOR -> FIGI_SEARCH [color="#ed8936", label="3. FIGI lookup"];
+  FIGI_SEARCH -> FIGI_API [color="#ed8936", penwidth=2];
+  FIGI_API -> FIGI_RESULT [style=dashed];
+  FIGI_SEARCH -> FIGI_CACHE [color="#ed8936", label="cache hit?"];
+  FIGI_RESULT -> FIGI_CACHE [color="#ed8936", label="persist"];
+
+  FIGI_CACHE -> SYMBOL_MAPPER [color="#38a169", penwidth=2, label="4. map"];
+  SYMBOL_MAPPER -> CONTRACT_FACTORY [color="#38a169", style=dashed, label="IB only"];
+  SYMBOL_MAPPER -> FMT_IB [style=dashed];
+  SYMBOL_MAPPER -> FMT_ALP [style=dashed];
+  SYMBOL_MAPPER -> FMT_POL [style=dashed];
+  SYMBOL_MAPPER -> FMT_STOOQ [style=dashed];
+  SYMBOL_MAPPER -> FMT_YAHOO [style=dashed];
+
+  SYMBOL_MAPPER -> CANONICAL [color="#2b6cb0", penwidth=2, label="5. canonical"];
+  CANONICAL -> SYMBOL_STORE [color="#2b6cb0", label="register"];
+
+  // Legend
+  subgraph cluster_legend {
+    label="Legend";
+    style="rounded";
+    color="#666666";
+    bgcolor="#fafafa";
+
+    LEG [shape=plaintext,
+         label="━━ Search / resolution flow\n─ ─ Reference / Cache path\nGreen  = Search providers\nOrange = FIGI canonical ID\nBlue   = Final canonical symbol"];
+  }
+}


### PR DESCRIPTION
Fixes:
- data-flow.dot: bump to v1.7.x, add Polygon to streaming sources (was
  missing despite being a production provider), fix historical provider
  count label (10 → 13), fix orphan VALIDATE node (now connected via
  AUTO_CONFIG → VALIDATE edge)
- onboarding-flow.dot: bump to v1.7.x, connect GENERATE_OPT from WELCOME
  (was isolated — no incoming edge from the welcome node)
- update-diagrams.yml: remove duplicate "Replaces and combines" comment
  block that appeared twice at the top of the file

New diagrams:
- backfill-workflow.dot: end-to-end backfill CLI → BackfillCoordinator →
  CompositeHistoricalDataProvider → per-provider rate limiting → gap
  detection → WAL + tiered storage + observability
- mcp-server.dot: MCP server architecture showing all tools
  (BackfillTools, SymbolTools, ProviderTools, StorageTools), resources
  (provider/storage/config catalogs), prompts, and DI wiring into backend
- configuration-management.dot: appsettings.json hierarchy, env var
  override priority, IOptionsMonitor hot-reload flow, typed options
  classes, credential handling rules, and consuming components
- symbol-search-resolution.dot: search query → 5 provider fanout →
  result aggregation → OpenFIGI canonical ID → SecurityMasterEventStore
  cache → SymbolMapper provider-specific formats → CanonicalSymbol

README updated with new diagram entries and full descriptions.

https://claude.ai/code/session_017kcG95xdB5thpqbQdZ4y8C