### PR TITLE
ci(diagrams): support full project diagram regeneration in workflow

### DIFF
--- a/.github/workflows/update-diagrams.yml
+++ b/.github/workflows/update-diagrams.yml
@@ -1,6 +1,6 @@
 # Consolidated diagram artifact workflow
 # Replaces and combines:
-#   - update-diagrams.yml (Graphviz/DOT → SVG)
+#   - update-diagrams.yml (Graphviz/DOT → SVG + PNG)
 #   - update-uml-diagrams.yml (PlantUML → PNG)
 
 name: Update Diagram Artifacts
@@ -10,10 +10,12 @@ on:
     branches:
       - main
     paths:
-      - 'docs/diagrams/*.dot'
+      - 'docs/diagrams/**/*.dot'
       - 'docs/diagrams/uml/*.puml'
       - 'scripts/generate-diagrams.mjs'
       - 'scripts/lib/ui-diagram-generator.mjs'
+      - 'src/Meridian.Wpf/**/*.xaml'
+      - 'src/Meridian.Wpf/**/*.cs'
   workflow_dispatch:
 
 permissions:
@@ -25,7 +27,7 @@ concurrency:
 
 jobs:
   regenerate-diagrams:
-    name: Regenerate SVG diagrams
+    name: Regenerate Graphviz diagrams
     runs-on: ubuntu-latest
 
     steps:
@@ -49,12 +51,11 @@ jobs:
       - name: Install Graphviz
         run: sudo apt-get update && sudo apt-get install -y graphviz
 
-      - name: Regenerate all diagram artifacts
+      - name: Regenerate Graphviz artifacts from DOT
         run: |
           set -euo pipefail
 
-          shopt -s nullglob
-          dot_files=(docs/diagrams/*.dot)
+          mapfile -t dot_files < <(find docs/diagrams -type f -name '*.dot' | sort)
 
           if [ ${#dot_files[@]} -eq 0 ]; then
             echo "No DOT files found in docs/diagrams"
@@ -64,14 +65,16 @@ jobs:
           for file in "${dot_files[@]}"; do
             base="${file%.dot}"
             dot -Tsvg "$file" -o "${base}.svg"
+            dot -Tpng "$file" -o "${base}.png"
             echo "Generated ${base}.svg"
+            echo "Generated ${base}.png"
           done
 
       - name: Commit regenerated diagrams
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_message: 'docs(diagrams): regenerate SVG from DOT sources'
-          file_pattern: docs/diagrams/*.dot docs/diagrams/*.svg
+          commit_message: 'docs(diagrams): regenerate Graphviz artifacts from DOT sources'
+          file_pattern: docs/diagrams/**/*.dot docs/diagrams/**/*.svg docs/diagrams/**/*.png
 
   regenerate-uml-diagrams:
     name: Regenerate PNG diagrams from PlantUML sources


### PR DESCRIPTION
### Motivation

- The existing diagram regeneration workflow only covered a subset of DOT sources and produced SVGs only, leaving many DOT files and their PNG artifacts out of sync.
- WPF source changes that drive auto-generated UI DOT files were not included in the workflow triggers, causing generated diagrams to drift when UI code changed.

### Description

- Expanded workflow triggers to include recursive DOT sources with `docs/diagrams/**/*.dot` and WPF sources with `src/Meridian.Wpf/**/*.xaml` and `src/Meridian.Wpf/**/*.cs` so changes that affect generated DOT files will run the workflow.
- Replaced the DOT discovery with a `find`-based listing (`mapfile -t dot_files < <(find docs/diagrams -type f -name '*.dot' | sort)`) and updated the regeneration loop to render both SVG and PNG using `dot -Tsvg` and `dot -Tpng` for each DOT file.
- Updated the commit step and file patterns to include recursive DOT/SVG/PNG artifacts (`docs/diagrams/**/*.dot`, `docs/diagrams/**/*.svg`, `docs/diagrams/**/*.png`) and adjusted the job/name text to reflect Graphviz + PNG support; PlantUML `.puml -> .png` flow remains unchanged.

### Testing

- Validated the workflow YAML syntax by loading `.github/workflows/update-diagrams.yml` with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/update-diagrams.yml')"`, which succeeded.
- Attempted to validate with a Python YAML loader (`yaml.safe_load`) but that run failed in the environment due to `PyYAML` not being installed, which is an environment limitation rather than a YAML syntax error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2bdab80988320aade3db585150ca2)