### PR TITLE
ci: consolidate update-diagrams workflow to avoid push race

### DIFF
--- a/.github/workflows/update-diagrams.yml
+++ b/.github/workflows/update-diagrams.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   regenerate-diagrams:
-    name: Regenerate Graphviz diagrams
+    name: Regenerate diagram artifacts
     runs-on: ubuntu-latest
 
     steps:
@@ -70,22 +70,6 @@ jobs:
             echo "Generated ${base}.png"
           done
 
-      - name: Commit regenerated diagrams
-        uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          commit_message: 'docs(diagrams): regenerate Graphviz artifacts from DOT sources'
-          file_pattern: docs/diagrams/**/*.dot docs/diagrams/**/*.svg docs/diagrams/**/*.png
-
-  regenerate-uml-diagrams:
-    name: Regenerate PNG diagrams from PlantUML sources
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Install PlantUML
         run: |
           sudo apt-get update
@@ -115,8 +99,8 @@ jobs:
             plantuml -tpng "$file"
           done
 
-      - name: Commit regenerated UML diagrams
+      - name: Commit regenerated diagram artifacts
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_message: 'docs(uml): regenerate PNG diagrams from PlantUML sources'
-          file_pattern: docs/diagrams/uml/*.png
+          commit_message: 'docs(diagrams): regenerate diagram artifacts from sources'
+          file_pattern: docs/diagrams/**/*.dot docs/diagrams/**/*.puml docs/diagrams/**/*.svg docs/diagrams/**/*.png


### PR DESCRIPTION
### Motivation

- Prevent parallel workflow jobs from racing when pushing regenerated diagram artifacts, which can lead to non-fast-forward failures. 
- Ensure DOT and PlantUML artifacts are regenerated and committed deterministically in a single execution path.

### Description

- Merged the previous Graphviz and PlantUML jobs into a single `regenerate-diagrams` job that performs both DOT and PUML generation. 
- Renamed the job to `Regenerate diagram artifacts` and kept Graphviz and PlantUML install + render steps in the same job. 
- Replaced separate per-job commit steps with a single `stefanzweifel/git-auto-commit-action@v7` step that commits `docs/diagrams/**/*.dot`, `**/*.puml`, `**/*.svg`, and `**/*.png`. 
- Updated the auto-commit message to a unified `docs(diagrams): regenerate diagram artifacts from sources` and simplified the workflow structure to avoid duplicate checkouts.

### Testing

- Ran `git diff -- .github/workflows/update-diagrams.yml` to verify the workflow changes and observed the expected diff. 
- Attempted `actionlint .github/workflows/update-diagrams.yml`, but `actionlint` is not installed in the environment so linting was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c0cb22708320806a34cdfeb4423b)