### PR TITLE
Fix npm script paths for diagram and icon generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "Build tools for Meridian",
   "scripts": {
-    "generate-icons": "node build/node/generate-icons.mjs",
-    "generate-diagrams": "node build/node/generate-diagrams.mjs",
+    "generate-icons": "node scripts/generate-icons.mjs",
+    "generate-diagrams": "node scripts/generate-diagrams.mjs",
     "ui:dashboard:install": "npm --prefix src/Meridian.Ui/dashboard install",
     "ui:dashboard:build": "npm --prefix src/Meridian.Ui/dashboard run build",
     "ui:dashboard:test": "npm --prefix src/Meridian.Ui/dashboard run test"


### PR DESCRIPTION
### Motivation
- CI `npm run generate-diagrams` failed with `MODULE_NOT_FOUND` because the scripts referenced `build/node/*` files that no longer exist, so the npm scripts must point to the actual `scripts/` location.

### Description
- Updated root `package.json` to run `node scripts/generate-diagrams.mjs` and `node scripts/generate-icons.mjs` instead of the removed `build/node/` paths.

### Testing
- Ran `npm run generate-diagrams` which completed successfully (exit code 0) and rendered `ui-implementation-flow.svg` and `ui-navigation-map.svg` as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c2ee82fc8320b88925f046a7dfe9)