### PR TITLE
ci: fix PlantUML install permission and bump actions/checkout to v5

### DIFF
--- a/.github/workflows/update-diagrams.yml
+++ b/.github/workflows/update-diagrams.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -77,7 +77,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y default-jre-headless wget
           PLANTUML_VERSION="1.2024.8"
-          wget -q "https://github.com/plantuml/plantuml/releases/download/v${PLANTUML_VERSION}/plantuml-${PLANTUML_VERSION}.jar" \
+          sudo wget -q "https://github.com/plantuml/plantuml/releases/download/v${PLANTUML_VERSION}/plantuml-${PLANTUML_VERSION}.jar" \
             -O /usr/local/share/plantuml.jar
           printf '#!/bin/sh\nexec java -jar /usr/local/share/plantuml.jar "$@"\n' \
             | sudo tee /usr/local/bin/plantuml > /dev/null


### PR DESCRIPTION
### Motivation
- The Update Diagram Artifacts workflow was failing with `/usr/local/share/plantuml.jar: Permission denied` and should be aligned with the Node.js 24 migration guidance for JavaScript actions.

### Description
- Change the PlantUML download to use `sudo wget ... -O /usr/local/share/plantuml.jar` so the runner can write the jar into `/usr/local/share` without a permission error.
- Bump the workflow checkout action from `actions/checkout@v4` to `actions/checkout@v5` to align with Node.js 24 migration recommendations.

### Testing
- Ran `git diff --check` to validate there are no formatting issues and it succeeded.
- Verified the updated workflow contents with `nl -ba .github/workflows/update-diagrams.yml | sed -n '30,95p'` to confirm the `sudo wget` and `actions/checkout@v5` changes were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c5c561a48320a61d4d03c8a01ab2)