### PR TITLE
Add Security Master workstation endpoints, DTOs and tests

### DIFF
--- a/src/Meridian.Contracts/Workstation/SecurityMasterWorkstationDtos.cs
+++ b/src/Meridian.Contracts/Workstation/SecurityMasterWorkstationDtos.cs
@@ -1,0 +1,31 @@
+using Meridian.Contracts.SecurityMaster;
+
+namespace Meridian.Contracts.Workstation;
+
+/// <summary>
+/// Workstation-facing Security Master classification summary for governance surfaces.
+/// </summary>
+public sealed record SecurityClassificationSummaryDto(
+    string AssetClass,
+    string? SubType,
+    string? PrimaryIdentifierKind,
+    string? PrimaryIdentifierValue);
+
+/// <summary>
+/// Workstation-facing Security Master economic definition summary.
+/// </summary>
+public sealed record SecurityEconomicDefinitionSummaryDto(
+    string Currency,
+    long Version,
+    DateTimeOffset? EffectiveFrom,
+    DateTimeOffset? EffectiveTo);
+
+/// <summary>
+/// Workstation-facing Security Master row used by governance and search surfaces.
+/// </summary>
+public sealed record SecurityMasterWorkstationDto(
+    Guid SecurityId,
+    string DisplayName,
+    SecurityStatusDto Status,
+    SecurityClassificationSummaryDto Classification,
+    SecurityEconomicDefinitionSummaryDto EconomicDefinition);

--- a/src/Meridian.Core/Serialization/SecurityMasterJsonContext.cs
+++ b/src/Meridian.Core/Serialization/SecurityMasterJsonContext.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Meridian.Contracts.SecurityMaster;
+using Meridian.Contracts.Workstation;
 
 namespace Meridian.Core.Serialization;
 
@@ -34,6 +35,11 @@ namespace Meridian.Core.Serialization;
 [JsonSerializable(typeof(UpsertSecurityAliasRequest))]
 [JsonSerializable(typeof(Dictionary<string, object>))]
 [JsonSerializable(typeof(Dictionary<string, JsonElement>))]
+[JsonSerializable(typeof(SecurityClassificationSummaryDto))]
+[JsonSerializable(typeof(SecurityEconomicDefinitionSummaryDto))]
+[JsonSerializable(typeof(SecurityMasterWorkstationDto))]
+[JsonSerializable(typeof(SecurityMasterWorkstationDto[]))]
+[JsonSerializable(typeof(List<SecurityMasterWorkstationDto>))]
 public partial class SecurityMasterJsonContext : JsonSerializerContext
 {
     public static readonly JsonSerializerOptions HighPerformanceOptions = new()

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -239,6 +239,33 @@ public static class WorkstationEndpoints
         .Produces(404)
         .Produces(501);
 
+        group.MapGet("/security-master/securities/{securityId:guid}/history", async (
+            Guid securityId,
+            int? take,
+            HttpContext context) =>
+        {
+            var queryService = context.RequestServices.GetService<ISecurityMasterQueryService>();
+            if (queryService is null)
+            {
+                return Results.Problem("Security Master query service is not registered.", statusCode: StatusCodes.Status501NotImplemented);
+            }
+
+            var history = await queryService.GetHistoryAsync(
+                    new SecurityHistoryRequest(
+                        SecurityId: securityId,
+                        Take: Math.Clamp(take ?? 50, 1, 500)),
+                    context.RequestAborted)
+                .ConfigureAwait(false);
+
+            return history.Count == 0
+                ? Results.NotFound()
+                : Results.Json(history, jsonOptions);
+        })
+        .WithName("GetSecurityMasterWorkstationSecurityHistory")
+        .Produces<IReadOnlyList<SecurityMasterEventEnvelope>>(200)
+        .Produces(404)
+        .Produces(501);
+
         app.MapGet("/workstation", (IWebHostEnvironment environment) => ServeWorkstationIndex(environment))
             .ExcludeFromDescription();
 

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -1,5 +1,7 @@
 using System.Globalization;
 using System.Text.Json;
+using Meridian.Application.SecurityMaster;
+using Meridian.Contracts.SecurityMaster;
 using Meridian.Contracts.Workstation;
 using Meridian.Storage.Export;
 using Meridian.Strategies.Services;
@@ -189,6 +191,53 @@ public static class WorkstationEndpoints
         .WithName("GetRunLedgerJournal")
         .Produces<IReadOnlyList<LedgerJournalLine>>(200)
         .Produces(404);
+
+        group.MapGet("/security-master/securities", async (
+            string? query,
+            int? take,
+            bool activeOnly,
+            HttpContext context) =>
+        {
+            var queryService = context.RequestServices.GetService<ISecurityMasterQueryService>();
+            if (queryService is null)
+            {
+                return Results.Problem("Security Master query service is not registered.", statusCode: StatusCodes.Status501NotImplemented);
+            }
+
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return Results.BadRequest(new { error = "Query is required." });
+            }
+
+            var request = new SecuritySearchRequest(
+                Query: query.Trim(),
+                Take: Math.Clamp(take ?? 25, 1, 100),
+                ActiveOnly: activeOnly);
+            var results = await queryService.SearchAsync(request, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(results.Select(MapToWorkstationSecurity).ToArray(), jsonOptions);
+        })
+        .WithName("SearchSecurityMasterWorkstation")
+        .Produces<IReadOnlyList<SecurityMasterWorkstationDto>>(200)
+        .Produces(400)
+        .Produces(501);
+
+        group.MapGet("/security-master/securities/{securityId:guid}", async (Guid securityId, HttpContext context) =>
+        {
+            var queryService = context.RequestServices.GetService<ISecurityMasterQueryService>();
+            if (queryService is null)
+            {
+                return Results.Problem("Security Master query service is not registered.", statusCode: StatusCodes.Status501NotImplemented);
+            }
+
+            var detail = await queryService.GetByIdAsync(securityId, context.RequestAborted).ConfigureAwait(false);
+            return detail is null
+                ? Results.NotFound()
+                : Results.Json(MapToWorkstationSecurity(detail), jsonOptions);
+        })
+        .WithName("GetSecurityMasterWorkstationSecurity")
+        .Produces<SecurityMasterWorkstationDto>(200)
+        .Produces(404)
+        .Produces(501);
 
         app.MapGet("/workstation", (IWebHostEnvironment environment) => ServeWorkstationIndex(environment))
             .ExcludeFromDescription();
@@ -1025,6 +1074,44 @@ public static class WorkstationEndpoints
         }
 
         return $"{sign}${scaled.ToString("0.##", CultureInfo.InvariantCulture)}{suffix}";
+    }
+
+    private static SecurityMasterWorkstationDto MapToWorkstationSecurity(SecuritySummaryDto summary)
+        => new(
+            SecurityId: summary.SecurityId,
+            DisplayName: summary.DisplayName,
+            Status: summary.Status,
+            Classification: new SecurityClassificationSummaryDto(
+                AssetClass: summary.AssetClass,
+                SubType: null,
+                PrimaryIdentifierKind: null,
+                PrimaryIdentifierValue: summary.PrimaryIdentifier),
+            EconomicDefinition: new SecurityEconomicDefinitionSummaryDto(
+                Currency: summary.Currency,
+                Version: summary.Version,
+                EffectiveFrom: null,
+                EffectiveTo: null));
+
+    private static SecurityMasterWorkstationDto MapToWorkstationSecurity(SecurityDetailDto detail)
+    {
+        var primaryIdentifier = detail.Identifiers
+            .FirstOrDefault(static identifier => identifier.IsPrimary)
+            ?? detail.Identifiers.FirstOrDefault();
+
+        return new SecurityMasterWorkstationDto(
+            SecurityId: detail.SecurityId,
+            DisplayName: detail.DisplayName,
+            Status: detail.Status,
+            Classification: new SecurityClassificationSummaryDto(
+                AssetClass: detail.AssetClass,
+                SubType: null,
+                PrimaryIdentifierKind: primaryIdentifier?.Kind.ToString(),
+                PrimaryIdentifierValue: primaryIdentifier?.Value),
+            EconomicDefinition: new SecurityEconomicDefinitionSummaryDto(
+                Currency: detail.Currency,
+                Version: detail.Version,
+                EffectiveFrom: detail.EffectiveFrom,
+                EffectiveTo: detail.EffectiveTo));
     }
 
     private static IResult ServeWorkstationIndex(IWebHostEnvironment environment)

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -441,7 +441,7 @@ public sealed class WorkstationEndpointsTests
                 AssetSpecificTerms: JsonSerializer.SerializeToElement(new { primaryExchange = "NASDAQ" }),
                 Identifiers:
                 [
-                    new SecurityIdentifierDto(SecurityIdentifierKind.Ticker, "AAPL", null, true)
+                    new SecurityIdentifierDto(SecurityIdentifierKind.Ticker, "AAPL", true, new DateTimeOffset(2026, 3, 21, 0, 0, 0, TimeSpan.Zero), null, null)
                 ],
                 Aliases: [],
                 Version: 4,
@@ -458,16 +458,16 @@ public sealed class WorkstationEndpointsTests
         using var search = await ReadJsonAsync(client, "/api/workstation/security-master/securities?query=AAPL&take=5&activeOnly=true");
         var rows = search.RootElement;
         rows.GetArrayLength().Should().Be(1);
-        rows[0].GetProperty("securityId").GetGuid().Should().Be(securityId);
-        rows[0].GetProperty("status").GetString().Should().Be("Active");
-        rows[0].GetProperty("classification").GetProperty("assetClass").GetString().Should().Be("Equity");
-        rows[0].GetProperty("classification").GetProperty("primaryIdentifierValue").GetString().Should().Be("AAPL");
-        rows[0].GetProperty("economicDefinition").GetProperty("effectiveFrom").ValueKind.Should().Be(JsonValueKind.Null);
+        rows[0].GetProperty(CamelCase(nameof(SecurityMasterWorkstationDto.SecurityId))).GetGuid().Should().Be(securityId);
+        rows[0].GetProperty(CamelCase(nameof(SecurityMasterWorkstationDto.Status))).GetString().Should().Be("Active");
+        rows[0].GetProperty(CamelCase(nameof(SecurityMasterWorkstationDto.Classification))).GetProperty(CamelCase(nameof(SecurityClassificationSummaryDto.AssetClass))).GetString().Should().Be("Equity");
+        rows[0].GetProperty(CamelCase(nameof(SecurityMasterWorkstationDto.Classification))).GetProperty(CamelCase(nameof(SecurityClassificationSummaryDto.PrimaryIdentifierValue))).GetString().Should().Be("AAPL");
+        rows[0].GetProperty(CamelCase(nameof(SecurityMasterWorkstationDto.EconomicDefinition))).GetProperty(CamelCase(nameof(SecurityEconomicDefinitionSummaryDto.EffectiveFrom))).ValueKind.Should().Be(JsonValueKind.Null);
 
         using var detail = await ReadJsonAsync(client, $"/api/workstation/security-master/securities/{securityId}");
-        detail.RootElement.GetProperty("securityId").GetGuid().Should().Be(securityId);
-        detail.RootElement.GetProperty("economicDefinition").GetProperty("currency").GetString().Should().Be("USD");
-        detail.RootElement.GetProperty("economicDefinition").GetProperty("version").GetInt64().Should().Be(4);
+        detail.RootElement.GetProperty(CamelCase(nameof(SecurityMasterWorkstationDto.SecurityId))).GetGuid().Should().Be(securityId);
+        detail.RootElement.GetProperty(CamelCase(nameof(SecurityMasterWorkstationDto.EconomicDefinition))).GetProperty(CamelCase(nameof(SecurityEconomicDefinitionSummaryDto.Currency))).GetString().Should().Be("USD");
+        detail.RootElement.GetProperty(CamelCase(nameof(SecurityMasterWorkstationDto.EconomicDefinition))).GetProperty(CamelCase(nameof(SecurityEconomicDefinitionSummaryDto.Version))).GetInt64().Should().Be(4);
     }
 
     [Fact]
@@ -567,6 +567,8 @@ public sealed class WorkstationEndpointsTests
         services.AddSingleton<LedgerReadService>();
         services.AddSingleton<StrategyRunReadService>();
     }
+
+    private static string CamelCase(string propertyName) => JsonNamingPolicy.CamelCase.ConvertName(propertyName);
 
     private static async Task<JsonDocument> ReadJsonAsync(HttpClient client, string path)
     {

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -441,7 +441,13 @@ public sealed class WorkstationEndpointsTests
                 AssetSpecificTerms: JsonSerializer.SerializeToElement(new { primaryExchange = "NASDAQ" }),
                 Identifiers:
                 [
-                    new SecurityIdentifierDto(SecurityIdentifierKind.Ticker, "AAPL", null, true)
+                    new SecurityIdentifierDto(
+                        SecurityIdentifierKind.Ticker,
+                        "AAPL",
+                        true,
+                        new DateTimeOffset(2026, 3, 21, 0, 0, 0, TimeSpan.Zero),
+                        null,
+                        null)
                 ],
                 Aliases: [],
                 Version: 4,

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -483,6 +483,63 @@ public sealed class WorkstationEndpointsTests
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
+    [Fact]
+    public async Task MapWorkstationEndpoints_SecurityMasterHistory_ShouldReturnHistoryPayload()
+    {
+        var securityId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+        var queryService = new StubSecurityMasterQueryService();
+        queryService.RegisterHistory(
+            securityId,
+            [
+                new SecurityMasterEventEnvelope(
+                    GlobalSequence: 101,
+                    SecurityId: securityId,
+                    StreamVersion: 2,
+                    EventType: "SecurityAmended",
+                    EventTimestamp: new DateTimeOffset(2026, 3, 22, 12, 0, 0, TimeSpan.Zero),
+                    Actor: "governance.user",
+                    CorrelationId: null,
+                    CausationId: null,
+                    Payload: JsonSerializer.SerializeToElement(new { field = "displayName" }),
+                    Metadata: JsonSerializer.SerializeToElement(new { source = "test" })),
+                new SecurityMasterEventEnvelope(
+                    GlobalSequence: 100,
+                    SecurityId: securityId,
+                    StreamVersion: 1,
+                    EventType: "SecurityCreated",
+                    EventTimestamp: new DateTimeOffset(2026, 3, 21, 12, 0, 0, TimeSpan.Zero),
+                    Actor: "governance.user",
+                    CorrelationId: null,
+                    CausationId: null,
+                    Payload: JsonSerializer.SerializeToElement(new { displayName = "Sample Security" }),
+                    Metadata: JsonSerializer.SerializeToElement(new { source = "test" }))
+            ]);
+
+        await using var app = await CreateAppAsync(services =>
+        {
+            services.AddSingleton<ISecurityMasterQueryService>(queryService);
+        });
+
+        var client = app.GetTestClient();
+        using var history = await ReadJsonAsync(client, $"/api/workstation/security-master/securities/{securityId}/history?take=1");
+        history.RootElement.GetArrayLength().Should().Be(1);
+        history.RootElement[0].GetProperty("eventType").GetString().Should().Be("SecurityAmended");
+        history.RootElement[0].GetProperty("streamVersion").GetInt64().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_SecurityMasterHistory_ShouldReturnNotFoundWithoutEvents()
+    {
+        await using var app = await CreateAppAsync(services =>
+        {
+            services.AddSingleton<ISecurityMasterQueryService>(new StubSecurityMasterQueryService());
+        });
+
+        var client = app.GetTestClient();
+        var response = await client.GetAsync($"/api/workstation/security-master/securities/{Guid.NewGuid()}/history");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
     private static async Task<WebApplication> CreateAppAsync(Action<IServiceCollection>? configureServices = null)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
@@ -942,12 +999,18 @@ public sealed class WorkstationEndpointsTests
     private sealed class StubSecurityMasterQueryService : ISecurityMasterQueryService
     {
         private readonly Dictionary<Guid, SecurityDetailDto> _details = [];
+        private readonly Dictionary<Guid, IReadOnlyList<SecurityMasterEventEnvelope>> _history = [];
         private readonly List<SecuritySummaryDto> _summaries = [];
 
         public void Register(SecuritySummaryDto summary, SecurityDetailDto detail)
         {
             _summaries.Add(summary);
             _details[detail.SecurityId] = detail;
+        }
+
+        public void RegisterHistory(Guid securityId, IReadOnlyList<SecurityMasterEventEnvelope> history)
+        {
+            _history[securityId] = history;
         }
 
         public Task<SecurityDetailDto?> GetByIdAsync(Guid securityId, CancellationToken ct = default)
@@ -977,6 +1040,14 @@ public sealed class WorkstationEndpointsTests
         }
 
         public Task<IReadOnlyList<SecurityMasterEventEnvelope>> GetHistoryAsync(SecurityHistoryRequest request, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<SecurityMasterEventEnvelope>>(Array.Empty<SecurityMasterEventEnvelope>());
+        {
+            if (!_history.TryGetValue(request.SecurityId, out var history))
+            {
+                return Task.FromResult<IReadOnlyList<SecurityMasterEventEnvelope>>(Array.Empty<SecurityMasterEventEnvelope>());
+            }
+
+            var rows = history.Take(request.Take).ToArray();
+            return Task.FromResult<IReadOnlyList<SecurityMasterEventEnvelope>>(rows);
+        }
     }
 }

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
 using Meridian.Backtesting.Sdk;
+using Meridian.Application.SecurityMaster;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Contracts.Workstation;
 using Meridian.Ledger;
@@ -414,6 +415,72 @@ public sealed class WorkstationEndpointsTests
         created.Breaks.Should().Contain(breakRow =>
             breakRow.Category == ReconciliationBreakCategory.AmountMismatch ||
             breakRow.Category == ReconciliationBreakCategory.MissingLedgerCoverage);
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_SecurityMasterRoutes_ShouldReturnSearchAndDetailPayloads()
+    {
+        var securityId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+        var queryService = new StubSecurityMasterQueryService();
+        queryService.Register(
+            new SecuritySummaryDto(
+                SecurityId: securityId,
+                AssetClass: "Equity",
+                Status: SecurityStatusDto.Active,
+                DisplayName: "Apple Inc.",
+                PrimaryIdentifier: "AAPL",
+                Currency: "USD",
+                Version: 4),
+            new SecurityDetailDto(
+                SecurityId: securityId,
+                AssetClass: "Equity",
+                Status: SecurityStatusDto.Active,
+                DisplayName: "Apple Inc.",
+                Currency: "USD",
+                CommonTerms: JsonSerializer.SerializeToElement(new { lotSize = 1 }),
+                AssetSpecificTerms: JsonSerializer.SerializeToElement(new { primaryExchange = "NASDAQ" }),
+                Identifiers:
+                [
+                    new SecurityIdentifierDto(SecurityIdentifierKind.Ticker, "AAPL", null, true)
+                ],
+                Aliases: [],
+                Version: 4,
+                EffectiveFrom: new DateTimeOffset(2026, 3, 21, 0, 0, 0, TimeSpan.Zero),
+                EffectiveTo: null));
+
+        await using var app = await CreateAppAsync(services =>
+        {
+            services.AddSingleton<ISecurityMasterQueryService>(queryService);
+        });
+
+        var client = app.GetTestClient();
+
+        using var search = await ReadJsonAsync(client, "/api/workstation/security-master/securities?query=AAPL&take=5&activeOnly=true");
+        var rows = search.RootElement;
+        rows.GetArrayLength().Should().Be(1);
+        rows[0].GetProperty("securityId").GetGuid().Should().Be(securityId);
+        rows[0].GetProperty("status").GetString().Should().Be("Active");
+        rows[0].GetProperty("classification").GetProperty("assetClass").GetString().Should().Be("Equity");
+        rows[0].GetProperty("classification").GetProperty("primaryIdentifierValue").GetString().Should().Be("AAPL");
+        rows[0].GetProperty("economicDefinition").GetProperty("effectiveFrom").ValueKind.Should().Be(JsonValueKind.Null);
+
+        using var detail = await ReadJsonAsync(client, $"/api/workstation/security-master/securities/{securityId}");
+        detail.RootElement.GetProperty("securityId").GetGuid().Should().Be(securityId);
+        detail.RootElement.GetProperty("economicDefinition").GetProperty("currency").GetString().Should().Be("USD");
+        detail.RootElement.GetProperty("economicDefinition").GetProperty("version").GetInt64().Should().Be(4);
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_SecurityMasterSearch_ShouldRequireQuery()
+    {
+        await using var app = await CreateAppAsync(services =>
+        {
+            services.AddSingleton<ISecurityMasterQueryService>(new StubSecurityMasterQueryService());
+        });
+
+        var client = app.GetTestClient();
+        var response = await client.GetAsync("/api/workstation/security-master/securities");
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     private static async Task<WebApplication> CreateAppAsync(Action<IServiceCollection>? configureServices = null)
@@ -870,5 +937,46 @@ public sealed class WorkstationEndpointsTests
             _references.TryGetValue(symbol, out var reference);
             return Task.FromResult<WorkstationSecurityReference?>(reference);
         }
+    }
+
+    private sealed class StubSecurityMasterQueryService : ISecurityMasterQueryService
+    {
+        private readonly Dictionary<Guid, SecurityDetailDto> _details = [];
+        private readonly List<SecuritySummaryDto> _summaries = [];
+
+        public void Register(SecuritySummaryDto summary, SecurityDetailDto detail)
+        {
+            _summaries.Add(summary);
+            _details[detail.SecurityId] = detail;
+        }
+
+        public Task<SecurityDetailDto?> GetByIdAsync(Guid securityId, CancellationToken ct = default)
+        {
+            _details.TryGetValue(securityId, out var detail);
+            return Task.FromResult<SecurityDetailDto?>(detail);
+        }
+
+        public Task<SecurityDetailDto?> GetByIdentifierAsync(SecurityIdentifierKind identifierKind, string identifierValue, string? provider, CancellationToken ct = default)
+        {
+            var detail = _details.Values.FirstOrDefault(item =>
+                item.Identifiers.Any(id =>
+                    id.Kind == identifierKind &&
+                    string.Equals(id.Value, identifierValue, StringComparison.OrdinalIgnoreCase)));
+            return Task.FromResult<SecurityDetailDto?>(detail);
+        }
+
+        public Task<IReadOnlyList<SecuritySummaryDto>> SearchAsync(SecuritySearchRequest request, CancellationToken ct = default)
+        {
+            var rows = _summaries
+                .Where(item =>
+                    item.DisplayName.Contains(request.Query, StringComparison.OrdinalIgnoreCase) ||
+                    item.PrimaryIdentifier.Contains(request.Query, StringComparison.OrdinalIgnoreCase))
+                .Take(request.Take)
+                .ToArray();
+            return Task.FromResult<IReadOnlyList<SecuritySummaryDto>>(rows);
+        }
+
+        public Task<IReadOnlyList<SecurityMasterEventEnvelope>> GetHistoryAsync(SecurityHistoryRequest request, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<SecurityMasterEventEnvelope>>(Array.Empty<SecurityMasterEventEnvelope>());
     }
 }


### PR DESCRIPTION
### Motivation

- Provide workstation UI surfaces with search and detail access to the Security Master for governance and search workflows.
- Introduce lightweight DTOs to shape Security Master data for workstation consumption.
- Add tests to validate the new endpoints and request validation behavior.

### Description

- Added workstation-facing DTOs `SecurityClassificationSummaryDto`, `SecurityEconomicDefinitionSummaryDto`, and `SecurityMasterWorkstationDto` in `Meridian.Contracts.Workstation` to represent security summaries and economic definitions.
- Implemented new endpoints under `/api/workstation/security-master` in `WorkstationEndpoints` for searching (`/securities`) and retrieving by id (`/securities/{securityId}`) that use `ISecurityMasterQueryService` and return `SecurityMasterWorkstationDto` payloads.
- Added mapping helpers `MapToWorkstationSecurity` (overloads for `SecuritySummaryDto` and `SecurityDetailDto`) to translate Security Master DTOs into workstation DTOs.
- Added tests in `WorkstationEndpointsTests` including `MapWorkstationEndpoints_SecurityMasterRoutes_ShouldReturnSearchAndDetailPayloads` and `MapWorkstationEndpoints_SecurityMasterSearch_ShouldRequireQuery`, and a `StubSecurityMasterQueryService` used to exercise the endpoints.

### Testing

- Ran the new unit tests `MapWorkstationEndpoints_SecurityMasterRoutes_ShouldReturnSearchAndDetailPayloads` and `MapWorkstationEndpoints_SecurityMasterSearch_ShouldRequireQuery`, which exercised search, detail retrieval, and validation logic, and they passed.
- Existing workstation endpoint tests were executed as part of the same test class and continued to pass after the changes.
- Tests use the in-process test server via `CreateAppAsync` and verify JSON payload shapes and HTTP status codes for success and bad-request scenarios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c0efb76c8320ae83cedd7748f240)