### PR TITLE
Set explicit `timeout-minutes` for maintenance workflow jobs

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -22,6 +22,7 @@ jobs:
   detect-changes:
     name: maintenance / route
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       mode: ${{ steps.route.outputs.mode }}
       docs_only: ${{ steps.route.outputs.docs_only }}
@@ -46,13 +47,10 @@ jobs:
           else
             BASE_REF="$(git rev-list --max-count=2 HEAD | tail -1)"
           fi
-
           bash scripts/ai/route-maintenance.sh --classify-only --base "$BASE_REF" --head "${{ github.sha }}"
-
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import json
           from pathlib import Path
-
           route = json.loads(Path(".ai/maintenance-route.json").read_text(encoding="utf-8"))
           for key in ("mode", "docs_only", "workflow_changes", "ui_changes", "ledger_changes"):
               value = route[key]
@@ -71,6 +69,7 @@ jobs:
   maintenance-light:
     name: maintenance / light
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: detect-changes
     if: github.event_name != 'schedule' && needs.detect-changes.outputs.mode == 'light'
 
@@ -112,6 +111,7 @@ jobs:
   maintenance-full:
     name: maintenance / full
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     needs: detect-changes
     if: github.event_name == 'schedule' || github.event_name == 'push' || needs.detect-changes.outputs.mode == 'full'
 
@@ -158,6 +158,7 @@ jobs:
   doctor-environment:
     name: doctor / environment
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: [detect-changes, maintenance-full]
     if: always() && (github.event_name == 'schedule' || needs.detect-changes.outputs.mode == 'full')
 
@@ -176,6 +177,7 @@ jobs:
   docs-drift:
     name: docs / drift
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: detect-changes
     if: github.event_name == 'schedule' || needs.detect-changes.outputs.docs_only == 'true'
 
@@ -199,6 +201,7 @@ jobs:
   ledger-targeted:
     name: ledger / targeted
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: detect-changes
     if: needs.detect-changes.outputs.ledger_changes == 'true'
 


### PR DESCRIPTION
### Motivation
- Prevent maintenance CI jobs from running indefinitely and to bound resource usage by adding explicit timeouts to long-running workflow jobs.

### Description
- Add `timeout-minutes` to maintenance workflow jobs: `detect-changes` (`10`), `maintenance-light` (`45`), `maintenance-full` (`90`), `doctor-environment` (`45`), `docs-drift` (`15`), and `ledger-targeted` (`60`).
- Minor whitespace/format cleanup in the `Classify maintenance route` step around the `bash` and `python3` blocks.

### Testing
- No automated tests were run as part of this change because it only updates GitHub Actions workflow configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c690523883208d1ad4cfaec241f4)