### PR TITLE
Make SecurityIdentifierDto backwards-compatible with optional ValidTo/Provider

### DIFF
--- a/src/Meridian.Contracts/SecurityMaster/SecurityIdentifiers.cs
+++ b/src/Meridian.Contracts/SecurityMaster/SecurityIdentifiers.cs
@@ -28,8 +28,8 @@ public sealed record SecurityIdentifierDto(
     string Value,
     bool IsPrimary,
     DateTimeOffset ValidFrom,
-    DateTimeOffset? ValidTo,
-    string? Provider);
+    DateTimeOffset? ValidTo = null,
+    string? Provider = null);
 
 public sealed record SecurityAliasDto(
     Guid AliasId,


### PR DESCRIPTION
### Motivation
- CI build failed with `CS7036` because some call sites construct `SecurityIdentifierDto` without the trailing `ValidTo` and `Provider` arguments.

### Description
- Added default `null` values for the trailing parameters on `SecurityIdentifierDto` in `src/Meridian.Contracts/SecurityMaster/SecurityIdentifiers.cs` so `ValidTo` and `Provider` are optional and older call sites compile without changes.

### Testing
- The prior CI run using `dotnet build Meridian.sln -c Release --no-restore /p:EnableWindowsTargeting=true` failed with `CS7036` complaining about the missing `ValidTo` argument.
- A local `dotnet build` could not be executed in this environment because `dotnet` is not available (`dotnet: command not found`), so no post-change build verification was performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d0fdce048320ab52976d5f66b937)