### PR TITLE
ci: update python-package-conda workflow to use actions/checkout@v5 and skip pytest when no tests

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 5
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.10
       uses: actions/setup-python@v6
       with:
@@ -31,4 +31,8 @@ jobs:
     - name: Test with pytest
       run: |
         conda install pytest
-        pytest
+        if find . -type f \( -name "test_*.py" -o -name "*_test.py" \) | grep -q .; then
+          pytest
+        else
+          echo "No Python tests found; skipping pytest."
+        fi


### PR DESCRIPTION
### Motivation
- Remove the Node.js 20 deprecation warning caused by `actions/checkout@v4` and make the Conda workflow resilient when no Python tests are present.
- Prevent spurious CI failures where `pytest` returns a non-zero exit code in repositories without Python test files.

### Description
- Updated `.github/workflows/python-package-conda.yml` to use `actions/checkout@v5` in the `build-linux` job.
- Changed the `Test with pytest` step to detect test files with `find . -type f \( -name "test_*.py" -o -name "*_test.py" \) | grep -q .` and only run `pytest` when tests are found.
- When no tests are discovered the workflow now echoes `No Python tests found; skipping pytest.` instead of invoking `pytest`.

### Testing
- Inspected the diff with `git diff -- .github/workflows/python-package-conda.yml` to verify the intended changes (succeeded).
- Printed the updated workflow with `nl -ba .github/workflows/python-package-conda.yml` to confirm the inserted lines and shell snippet (succeeded).
- Attempted to parse the YAML using `python - <<'PY' ... yaml.safe_load(...)` but it failed due to the environment missing the `PyYAML` module, so manual inspection was used as a fallback (failed due to missing module).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d3264080832086207d3dd8c0aa4e)