### PR TITLE
Implement ledger postings for short-cover fills

### DIFF
--- a/src/Meridian.Execution/Services/PaperTradingPortfolio.cs
+++ b/src/Meridian.Execution/Services/PaperTradingPortfolio.cs
@@ -144,7 +144,11 @@ public sealed class PaperTradingPortfolio : IPortfolioState
             _positions[symbol] = pos;
         }
 
-        if (signedQty > 0)
+        if (signedQty > 0 && pos.Quantity < 0)
+        {
+            ApplyCoverShort(pos, symbol, signedQty, price, commission, ts);
+        }
+        else if (signedQty > 0)
         {
             ApplyBuy(pos, symbol, signedQty, price, commission, ts, orderId);
         }
@@ -193,6 +197,36 @@ public sealed class PaperTradingPortfolio : IPortfolioState
                     (LedgerAccounts.Cash, 0m, notional),
                 ]);
         }
+    }
+
+    private void ApplyCoverShort(
+        PaperPosition pos,
+        string symbol,
+        decimal qty,
+        decimal price,
+        decimal commission,
+        DateTimeOffset ts)
+    {
+        var coverQty = Math.Min(qty, Math.Abs(pos.Quantity));
+        var proceedsRemoved = coverQty * pos.CostBasis;
+        var coverCost = coverQty * price;
+        var realised = proceedsRemoved - coverCost;
+
+        pos.Quantity += coverQty;
+        if (pos.Quantity == 0m)
+        {
+            pos.CostBasis = 0m;
+        }
+
+        _cash -= coverCost + commission;
+        _realisedPnl += realised;
+
+        if (_ledger is null)
+        {
+            return;
+        }
+
+        PostCoverShortEntry(symbol, coverQty, price, proceedsRemoved, realised, ts);
     }
 
     private void ApplySellLong(
@@ -284,6 +318,44 @@ public sealed class PaperTradingPortfolio : IPortfolioState
             [
                 (LedgerAccounts.Cash, proceeds, 0m),
                 (LedgerAccounts.Securities(symbol), 0m, costBasisRemoved),
+            ]);
+        }
+    }
+
+    private void PostCoverShortEntry(
+        string symbol,
+        decimal coverQty,
+        decimal price,
+        decimal proceedsRemoved,
+        decimal realised,
+        DateTimeOffset ts)
+    {
+        var coverCost = coverQty * price;
+        var description = $"Cover {coverQty} {symbol} @ {price:F4}";
+        if (realised > 0m)
+        {
+            _ledger!.PostLines(ts, description,
+            [
+                (LedgerAccounts.ShortSecuritiesPayable(symbol), proceedsRemoved, 0m),
+                (LedgerAccounts.Cash, 0m, coverCost),
+                (LedgerAccounts.RealizedGain, 0m, realised),
+            ]);
+        }
+        else if (realised < 0m)
+        {
+            _ledger!.PostLines(ts, description,
+            [
+                (LedgerAccounts.ShortSecuritiesPayable(symbol), proceedsRemoved, 0m),
+                (LedgerAccounts.RealizedLoss, Math.Abs(realised), 0m),
+                (LedgerAccounts.Cash, 0m, coverCost),
+            ]);
+        }
+        else
+        {
+            _ledger!.PostLines(ts, description,
+            [
+                (LedgerAccounts.ShortSecuritiesPayable(symbol), proceedsRemoved, 0m),
+                (LedgerAccounts.Cash, 0m, coverCost),
             ]);
         }
     }

--- a/tests/Meridian.Tests/Execution/PaperTradingPortfolioTests.cs
+++ b/tests/Meridian.Tests/Execution/PaperTradingPortfolioTests.cs
@@ -142,6 +142,41 @@ public sealed class PaperTradingPortfolioTests
         sellEntry.Lines.Should().NotContain(l => l.Account == LedgerAccounts.RealizedLoss);
     }
 
+    [Fact]
+    public void ApplyFill_CoverShort_WithGain_RealisesGainAndPostsLedgerEntries()
+    {
+        var ledger = new Meridian.Ledger.Ledger();
+        var portfolio = new PaperTradingPortfolio(100_000m, ledger);
+        portfolio.ApplyFill(BuildFill("AAPL", OrderSide.Sell, qty: 10, price: 200m));
+        portfolio.ApplyFill(BuildFill("AAPL", OrderSide.Buy, qty: 10, price: 180m));
+
+        portfolio.Cash.Should().Be(100_000m + 2_000m - 1_800m);
+        portfolio.RealisedPnl.Should().Be(200m);
+        portfolio.Positions.Should().NotContainKey("AAPL");
+
+        var coverEntry = ledger.Journal.Single(e => e.Description.Contains("Cover"));
+        coverEntry.Lines.Should().Contain(l => l.Account == LedgerAccounts.ShortSecuritiesPayable("AAPL") && l.Debit == 2_000m);
+        coverEntry.Lines.Should().Contain(l => l.Account == LedgerAccounts.Cash && l.Credit == 1_800m);
+        coverEntry.Lines.Should().Contain(l => l.Account == LedgerAccounts.RealizedGain && l.Credit == 200m);
+    }
+
+    [Fact]
+    public void ApplyFill_CoverShort_WithLoss_RealisesLossAndPostsLedgerEntries()
+    {
+        var ledger = new Meridian.Ledger.Ledger();
+        var portfolio = new PaperTradingPortfolio(100_000m, ledger);
+        portfolio.ApplyFill(BuildFill("AAPL", OrderSide.Sell, qty: 10, price: 200m));
+        portfolio.ApplyFill(BuildFill("AAPL", OrderSide.Buy, qty: 10, price: 220m));
+
+        portfolio.Cash.Should().Be(100_000m + 2_000m - 2_200m);
+        portfolio.RealisedPnl.Should().Be(-200m);
+
+        var coverEntry = ledger.Journal.Single(e => e.Description.Contains("Cover"));
+        coverEntry.Lines.Should().Contain(l => l.Account == LedgerAccounts.ShortSecuritiesPayable("AAPL") && l.Debit == 2_000m);
+        coverEntry.Lines.Should().Contain(l => l.Account == LedgerAccounts.Cash && l.Credit == 2_200m);
+        coverEntry.Lines.Should().Contain(l => l.Account == LedgerAccounts.RealizedLoss && l.Debit == 200m);
+    }
+
     // -------------------------------------------------------------------------
     // UpdateMarketPrice / unrealised P&L
     // -------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Enable correct accounting when a buy fill reduces or closes an existing short position so realized P&L and ledger entries reflect cover activity.
- Ensure the `PaperTradingPortfolio` publishes balanced journal entries for short-cover flows so downstream read-models and reconciliation see consistent trial balances.

### Description
- Route buys that reduce an existing short position through a dedicated `ApplyCoverShort` path in `PaperTradingPortfolio` by inspecting `pos.Quantity` in `ApplyFillInternal` and calling `ApplyCoverShort` when buying into a short.
- Add `ApplyCoverShort` which computes `coverQty`, `proceedsRemoved`, `coverCost`, and `realised` P&L, updates `pos.Quantity`, `_cash`, and `_realisedPnl`, and clears `pos.CostBasis` when flat.
- Add `PostCoverShortEntry` which posts balanced ledger lines using `LedgerAccounts.ShortSecuritiesPayable`, `LedgerAccounts.Cash`, and conditional `LedgerAccounts.RealizedGain`/`LedgerAccounts.RealizedLoss` to represent cover outcomes.
- Add unit tests in `tests/Meridian.Tests/Execution/PaperTradingPortfolioTests.cs` covering profitable and loss-making short covers that assert cash movement, `RealisedPnl`, and expected ledger journal lines.
- Files changed: `src/Meridian.Execution/Services/PaperTradingPortfolio.cs` and `tests/Meridian.Tests/Execution/PaperTradingPortfolioTests.cs`.

### Testing
- Added two unit tests: `ApplyFill_CoverShort_WithGain_RealisesGainAndPostsLedgerEntries` and `ApplyFill_CoverShort_WithLoss_RealisesLossAndPostsLedgerEntries` which validate ledger postings and P&L behavior.
- Attempted to run targeted tests with `dotnet test --filter Ledger`, but the environment lacks the `dotnet` runtime (`/bin/bash: dotnet: command not found`), so no automated test run was executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d59fb1848320948a10a9d8331583)