### PR TITLE
Add Security Master REST endpoints for query and mutation workflows

### DIFF
--- a/src/Meridian.Contracts/Api/UiApiRoutes.cs
+++ b/src/Meridian.Contracts/Api/UiApiRoutes.cs
@@ -291,6 +291,17 @@ public static class UiApiRoutes
     public const string CalendarHolidays = "/api/calendar/holidays";
     public const string CalendarTradingDays = "/api/calendar/trading-days";
 
+
+    // Security Master endpoints
+    public const string SecurityMasterById = "/api/security-master/{securityId:guid}";
+    public const string SecurityMasterResolve = "/api/security-master/resolve";
+    public const string SecurityMasterSearch = "/api/security-master/search";
+    public const string SecurityMasterHistory = "/api/security-master/{securityId:guid}/history";
+    public const string SecurityMasterCreate = "/api/security-master";
+    public const string SecurityMasterAmend = "/api/security-master/amend";
+    public const string SecurityMasterDeactivate = "/api/security-master/deactivate";
+    public const string SecurityMasterAliasesUpsert = "/api/security-master/aliases/upsert";
+
     // Messaging endpoints
     public const string MessagingConfig = "/api/messaging/config";
     public const string MessagingStatus = "/api/messaging/status";

--- a/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using Meridian.Application.SecurityMaster;
+using Meridian.Contracts.Api;
+using Meridian.Contracts.SecurityMaster;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace Meridian.Ui.Shared.Endpoints;
+
+/// <summary>
+/// Endpoints for Security Master command/query workflows.
+/// </summary>
+public static class SecurityMasterEndpoints
+{
+    public static void MapSecurityMasterEndpoints(this WebApplication app, JsonSerializerOptions jsonOptions)
+    {
+        var group = app.MapGroup(string.Empty).WithTags("SecurityMaster");
+
+        group.MapGet(UiApiRoutes.SecurityMasterById, async (
+            Guid securityId,
+            ISecurityMasterQueryService queryService,
+            CancellationToken ct) =>
+        {
+            var detail = await queryService.GetByIdAsync(securityId, ct).ConfigureAwait(false);
+            return detail is null
+                ? Results.NotFound()
+                : Results.Json(detail, jsonOptions);
+        })
+        .WithName("GetSecurityMasterById")
+        .Produces<SecurityDetailDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status404NotFound);
+
+        group.MapPost(UiApiRoutes.SecurityMasterResolve, async (
+            ResolveSecurityRequest request,
+            ISecurityMasterQueryService queryService,
+            CancellationToken ct) =>
+        {
+            var detail = await queryService.GetByIdentifierAsync(
+                    request.IdentifierKind,
+                    request.IdentifierValue,
+                    request.Provider,
+                    ct)
+                .ConfigureAwait(false);
+
+            if (detail is null)
+            {
+                return Results.NotFound();
+            }
+
+            if (request.ActiveOnly && detail.Status != SecurityStatusDto.Active)
+            {
+                return Results.NotFound();
+            }
+
+            return Results.Json(detail, jsonOptions);
+        })
+        .WithName("ResolveSecurityMaster")
+        .Produces<SecurityDetailDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status404NotFound);
+
+        group.MapPost(UiApiRoutes.SecurityMasterSearch, async (
+            SecuritySearchRequest request,
+            ISecurityMasterQueryService queryService,
+            CancellationToken ct) =>
+        {
+            var results = await queryService.SearchAsync(request, ct).ConfigureAwait(false);
+            return Results.Json(results, jsonOptions);
+        })
+        .WithName("SearchSecurityMaster")
+        .Produces<IReadOnlyList<SecuritySummaryDto>>(StatusCodes.Status200OK);
+
+        group.MapGet(UiApiRoutes.SecurityMasterHistory, async (
+            Guid securityId,
+            int? take,
+            ISecurityMasterQueryService queryService,
+            CancellationToken ct) =>
+        {
+            var history = await queryService.GetHistoryAsync(
+                    new SecurityHistoryRequest(securityId, take.GetValueOrDefault(100)),
+                    ct)
+                .ConfigureAwait(false);
+
+            return history.Count == 0
+                ? Results.NotFound()
+                : Results.Json(history, jsonOptions);
+        })
+        .WithName("GetSecurityMasterHistory")
+        .Produces<IReadOnlyList<SecurityMasterEventEnvelope>>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status404NotFound);
+
+        group.MapPost(UiApiRoutes.SecurityMasterCreate, async (
+            CreateSecurityRequest request,
+            ISecurityMasterService service,
+            CancellationToken ct) =>
+        {
+            var detail = await service.CreateAsync(request, ct).ConfigureAwait(false);
+            return Results.Json(detail, jsonOptions, statusCode: StatusCodes.Status201Created);
+        })
+        .WithName("CreateSecurityMaster")
+        .Produces<SecurityDetailDto>(StatusCodes.Status201Created);
+
+        group.MapPost(UiApiRoutes.SecurityMasterAmend, async (
+            AmendSecurityTermsRequest request,
+            ISecurityMasterService service,
+            CancellationToken ct) =>
+        {
+            var detail = await service.AmendTermsAsync(request, ct).ConfigureAwait(false);
+            return Results.Json(detail, jsonOptions);
+        })
+        .WithName("AmendSecurityMaster")
+        .Produces<SecurityDetailDto>(StatusCodes.Status200OK);
+
+        group.MapPost(UiApiRoutes.SecurityMasterDeactivate, async (
+            DeactivateSecurityRequest request,
+            ISecurityMasterService service,
+            CancellationToken ct) =>
+        {
+            await service.DeactivateAsync(request, ct).ConfigureAwait(false);
+            return Results.NoContent();
+        })
+        .WithName("DeactivateSecurityMaster")
+        .Produces(StatusCodes.Status204NoContent);
+
+        group.MapPost(UiApiRoutes.SecurityMasterAliasesUpsert, async (
+            UpsertSecurityAliasRequest request,
+            ISecurityMasterService service,
+            CancellationToken ct) =>
+        {
+            var alias = await service.UpsertAliasAsync(request, ct).ConfigureAwait(false);
+            return Results.Json(alias, jsonOptions);
+        })
+        .WithName("UpsertSecurityMasterAlias")
+        .Produces<SecurityAliasDto>(StatusCodes.Status200OK);
+    }
+}

--- a/src/Meridian.Ui.Shared/Endpoints/UiEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/UiEndpoints.cs
@@ -260,6 +260,9 @@ public static class UiEndpoints
         // Direct lending endpoints
         app.MapDirectLendingEndpoints(jsonOptions);
 
+        // Security Master endpoints
+        app.MapSecurityMasterEndpoints(jsonOptions);
+
         // Map quality drops endpoints (C3/#16)
         var auditTrail = app.Services.GetService<DroppedEventAuditTrail>();
         app.MapQualityDropsEndpoints(auditTrail, jsonOptions);
@@ -354,6 +357,9 @@ public static class UiEndpoints
 
         // Direct lending endpoints
         app.MapDirectLendingEndpoints(jsonOptions);
+
+        // Security Master endpoints
+        app.MapSecurityMasterEndpoints(jsonOptions);
 
         // Map quality drops endpoints (C3/#16 - DroppedEventAuditTrail exposure)
         var auditTrail = app.Services.GetService<DroppedEventAuditTrail>();


### PR DESCRIPTION
### Motivation
- Surface the existing Security Master application services over the UI-hosted HTTP API so workstation and external clients can query and mutate canonical instrument definitions. 
- Make Security Master command/query flows (create, amend, deactivate, alias upsert, resolve, search, history, get-by-id) available as first-class REST routes under `/api/security-master/...` to continue productization.

### Description
- Add a new endpoint group `SecurityMasterEndpoints` in `src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs` that maps REST handlers to `ISecurityMasterQueryService` and `ISecurityMasterService`. 
- Introduce route constants for the Security Master API in `UiApiRoutes` (e.g. `SecurityMasterById`, `SecurityMasterResolve`, `SecurityMasterCreate`, etc.).
- Register the new endpoint group from both `MapUiEndpoints` and `MapUiEndpointsWithStatus` in `src/Meridian.Ui.Shared/Endpoints/UiEndpoints.cs` so routes are available in both hosting modes. 
- Endpoint behaviors include `GetById`, `Resolve` (supports `ActiveOnly` filtering), `Search`, `History`, `Create`, `AmendTerms`, `Deactivate`, and `UpsertAlias`, all using the app's shared `JsonSerializerOptions` and consistent HTTP result patterns.

### Testing
- Ran `git diff --check` which reported no whitespace/conflict issues and succeeded. 
- Attempted `dotnet test --filter "FullyQualifiedName~SecurityMaster"` but the run failed due to the environment missing the `dotnet` runtime, so integration/unit tests could not be executed in this container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d5b2ce1c8320a57b79f584447221)