### PR TITLE
Direct lending: align in-memory workflow validation and not-found behavior

### DIFF
--- a/src/Meridian.Application/DirectLending/InMemoryDirectLendingService.Workflows.cs
+++ b/src/Meridian.Application/DirectLending/InMemoryDirectLendingService.Workflows.cs
@@ -21,6 +21,12 @@ public sealed partial class InMemoryDirectLendingService
 
     public Task<LoanServicingStateDto?> ApplyMixedPaymentAsync(Guid loanId, ApplyMixedPaymentRequest request, DirectLendingCommandMetadataDto? metadata = null, CancellationToken ct = default)
     {
+        ArgumentNullException.ThrowIfNull(request);
+        if (request.Amount <= 0m)
+        {
+            throw new DirectLendingCommandException(new DirectLendingCommandError(DirectLendingErrorCode.Validation, "Payment amount must be positive."));
+        }
+
         lock (_gate)
         {
             if (!_loans.TryGetValue(loanId, out var stored))
@@ -69,6 +75,12 @@ public sealed partial class InMemoryDirectLendingService
 
     public Task<LoanServicingStateDto?> AssessFeeAsync(Guid loanId, AssessFeeRequest request, DirectLendingCommandMetadataDto? metadata = null, CancellationToken ct = default)
     {
+        ArgumentNullException.ThrowIfNull(request);
+        if (request.Amount <= 0m)
+        {
+            throw new DirectLendingCommandException(new DirectLendingCommandError(DirectLendingErrorCode.Validation, "Fee amount must be positive."));
+        }
+
         lock (_gate)
         {
             if (!_loans.TryGetValue(loanId, out var stored))
@@ -92,6 +104,12 @@ public sealed partial class InMemoryDirectLendingService
 
     public Task<LoanServicingStateDto?> ApplyWriteOffAsync(Guid loanId, ApplyWriteOffRequest request, DirectLendingCommandMetadataDto? metadata = null, CancellationToken ct = default)
     {
+        ArgumentNullException.ThrowIfNull(request);
+        if (request.Amount <= 0m)
+        {
+            throw new DirectLendingCommandException(new DirectLendingCommandError(DirectLendingErrorCode.Validation, "Write-off amount must be positive."));
+        }
+
         lock (_gate)
         {
             if (!_loans.TryGetValue(loanId, out var stored))
@@ -124,7 +142,10 @@ public sealed partial class InMemoryDirectLendingService
     {
         lock (_gate)
         {
-            var stored = _loans[loanId];
+            if (!_loans.TryGetValue(loanId, out var stored))
+            {
+                throw new DirectLendingCommandException(new DirectLendingCommandError(DirectLendingErrorCode.NotFound, $"Loan '{loanId}' was not found."));
+            }
             var run = new ProjectionRunDto(Guid.NewGuid(), loanId, stored.TermsVersions[^1].VersionNumber, stored.Servicing.ServicingRevision, projectionAsOf ?? stored.TermsVersions[^1].Terms.MaturityDate, null, stored.History.LastOrDefault()?.EventId, "manual.request", ComputeTermsHash(stored.TermsVersions[^1].Terms), "in-memory", ProjectionRunStatus.Completed, GetList(_projectionRuns, loanId).LastOrDefault()?.ProjectionRunId, DateTimeOffset.UtcNow);
             var flows = BuildFlows(stored, run);
             GetList(_projectionRuns, loanId).Add(run);
@@ -160,6 +181,10 @@ public sealed partial class InMemoryDirectLendingService
     {
         lock (_gate)
         {
+            if (!_loans.ContainsKey(loanId))
+            {
+                throw new DirectLendingCommandException(new DirectLendingCommandError(DirectLendingErrorCode.NotFound, $"Loan '{loanId}' was not found."));
+            }
             var latestProjection = GetList(_projectionRuns, loanId).OrderByDescending(static x => x.GeneratedAt).FirstOrDefault();
             if (latestProjection is null)
             {

--- a/tests/Meridian.DirectLending.Tests/DirectLendingWorkflowTests.cs
+++ b/tests/Meridian.DirectLending.Tests/DirectLendingWorkflowTests.cs
@@ -109,6 +109,45 @@ public sealed class DirectLendingWorkflowTests
         checkpoints.Should().ContainSingle(x => x.ProjectionName == "direct-lending.full-rebuild");
     }
 
+
+    [Fact]
+    public async Task WorkflowCommands_ShouldThrowTypedValidationErrors_ForNonPositiveAmounts()
+    {
+        var service = new InMemoryDirectLendingService();
+        var loan = await service.CreateLoanAsync(BuildCreateRequest());
+
+        var mixedPayment = () => service.ApplyMixedPaymentAsync(
+            loan.LoanId,
+            new ApplyMixedPaymentRequest(0m, new DateOnly(2026, 3, 25), null, "pay-invalid"));
+        var fee = () => service.AssessFeeAsync(loan.LoanId, new AssessFeeRequest("Origination", 0m, new DateOnly(2026, 3, 25), "invalid"));
+        var writeOff = () => service.ApplyWriteOffAsync(loan.LoanId, new ApplyWriteOffRequest(0m, new DateOnly(2026, 3, 25), "invalid"));
+
+        var mixedPaymentException = await Assert.ThrowsAsync<DirectLendingCommandException>(mixedPayment);
+        var feeException = await Assert.ThrowsAsync<DirectLendingCommandException>(fee);
+        var writeOffException = await Assert.ThrowsAsync<DirectLendingCommandException>(writeOff);
+
+        mixedPaymentException.Error.Code.Should().Be(DirectLendingErrorCode.Validation);
+        feeException.Error.Code.Should().Be(DirectLendingErrorCode.Validation);
+        writeOffException.Error.Code.Should().Be(DirectLendingErrorCode.Validation);
+    }
+
+    [Fact]
+    public async Task ProjectionAndReconciliation_ShouldThrowNotFound_WhenLoanIsMissing()
+    {
+        var service = new InMemoryDirectLendingService();
+        var missingLoanId = Guid.NewGuid();
+
+        var projection = () => service.RequestProjectionAsync(missingLoanId, new DateOnly(2026, 4, 1));
+        var reconciliation = () => service.ReconcileAsync(missingLoanId);
+
+        var projectionException = await Assert.ThrowsAsync<DirectLendingCommandException>(projection);
+        var reconciliationException = await Assert.ThrowsAsync<DirectLendingCommandException>(reconciliation);
+
+        projectionException.Error.Code.Should().Be(DirectLendingErrorCode.NotFound);
+        reconciliationException.Error.Code.Should().Be(DirectLendingErrorCode.NotFound);
+    }
+
+
     private static CreateLoanRequest BuildCreateRequest() =>
         new(
             LoanId: Guid.NewGuid(),


### PR DESCRIPTION
### Motivation
- Make the in-memory direct-lending workflows behave consistently with the Postgres command path by returning typed domain errors instead of leaking null/key lookup behavior.
- Prevent silent runtime failures by validating inputs early and surfacing `Validation` and `NotFound` errors as `DirectLendingCommandException` so callers can rely on a consistent error model.

### Description
- Added argument/null and positive-amount validation to `ApplyMixedPaymentAsync`, `AssessFeeAsync`, and `ApplyWriteOffAsync` so they throw `DirectLendingCommandException` with `DirectLendingErrorCode.Validation` for non-positive amounts and null requests in `src/Meridian.Application/DirectLending/InMemoryDirectLendingService.Workflows.cs`.
- Hardened projection and reconciliation entry points to throw `DirectLendingCommandException` with `DirectLendingErrorCode.NotFound` when the loan id does not exist in the in-memory store (`RequestProjectionAsync` and `ReconcileAsync`).
- Added unit tests exercising these behaviors in `tests/Meridian.DirectLending.Tests/DirectLendingWorkflowTests.cs` (validation for non-positive amounts and not-found for missing loans).

### Testing
- Added/updated unit tests in `tests/Meridian.DirectLending.Tests/DirectLendingWorkflowTests.cs` to assert the new `Validation` and `NotFound` failure cases (tests were committed but not executed here).
- Attempted to run `dotnet test` but the environment does not have the `dotnet` CLI installed, causing `dotnet: command not found` so automated test execution could not be performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d5cfaebc8320bdd96047f021e0df)