### PR TITLE
Add ledger filtering and consolidation APIs to ProjectLedgerBook with integration tests

### DIFF
--- a/src/Meridian.Ledger/ProjectLedgerBook.cs
+++ b/src/Meridian.Ledger/ProjectLedgerBook.cs
@@ -166,8 +166,8 @@ public sealed class ProjectLedgerBook
                     : current.LastPostedAt;
 
                 summaries[summary.Account] = (
-                    current.Debits + summary.Debits,
-                    current.Credits + summary.Credits,
+                    current.Debits + summary.TotalDebits,
+                    current.Credits + summary.TotalCredits,
                     current.EntryCount + summary.EntryCount,
                     firstPostedAt,
                     lastPostedAt);

--- a/tests/Meridian.Tests/Ledger/LedgerIntegrationTests.cs
+++ b/tests/Meridian.Tests/Ledger/LedgerIntegrationTests.cs
@@ -244,13 +244,13 @@ public sealed class LedgerIntegrationTests
         var revenueSummary = summaries.Single(s => s.Account == revenue);
 
         cashSummary.Balance.Should().Be(130m);
-        cashSummary.Debits.Should().Be(130m);
-        cashSummary.Credits.Should().Be(0m);
+        cashSummary.TotalDebits.Should().Be(130m);
+        cashSummary.TotalCredits.Should().Be(0m);
         cashSummary.EntryCount.Should().Be(2);
 
         revenueSummary.Balance.Should().Be(130m);
-        revenueSummary.Debits.Should().Be(0m);
-        revenueSummary.Credits.Should().Be(130m);
+        revenueSummary.TotalDebits.Should().Be(0m);
+        revenueSummary.TotalCredits.Should().Be(130m);
         revenueSummary.EntryCount.Should().Be(2);
     }
 


### PR DESCRIPTION
### Motivation

- Provide APIs to filter ledgers by book, view and scenario and to produce consolidated views (trial balance, snapshot, journal entries, and account summaries) across those filtered ledgers.
- Centralize ledger filtering and aggregation logic to support querying and reporting use cases across multiple ledger instances in a project.

### Description

- Added `FilteredSnapshot`, `FilteredLedgerKeys`, `ConsolidatedTrialBalance`, `ConsolidatedSnapshotAsOf`, `ConsolidatedJournalEntries`, and `ConsolidatedAccountSummaries` to `ProjectLedgerBook` to support filtered views and aggregation across ledgers.
- Introduced helper methods `FilterLedgers`, `NormalizeOptionalValue`, and `CalculateNetBalance`, and updated `Snapshot` to use the shared `FilterLedgers` pipeline.
- Aggregation implementations sum balances, merge journal and ledger entry counts, order consolidated journal entries by `Timestamp` then `JournalEntryId`, and merge account summaries while preserving first/last posted timestamps.
- Added integration tests exercising filtered snapshots, filtered keys sorting, consolidated trial balances, point-in-time consolidated snapshots, consolidated journal queries, and consolidated account summaries.

### Testing

- Ran the test suite under `tests/Meridian.Tests` including the new integration tests for consolidation and filtering such as `ProjectLedgerBook_CanBuildConsolidatedTrialBalanceAcrossFilteredLedgers` and `ProjectLedgerBook_CanBuildConsolidatedAccountSummaries`.
- All tests completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2e23487088320a8f9bc594de96417)