### PR TITLE
Fix WPF target framework selection on Windows builds

### DIFF
--- a/src/Meridian.Wpf/Meridian.Wpf.csproj
+++ b/src/Meridian.Wpf/Meridian.Wpf.csproj
@@ -8,7 +8,6 @@
     <IsWindows Condition="'$(IsWindows)' != 'true' AND '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'True'">true</IsWindows>
     <!-- Default to false if all checks fail -->
     <IsWindows Condition="'$(IsWindows)' == ''">false</IsWindows>
-    <IsWindows Condition="'$(EnableFullWpfBuild)' != 'true'">false</IsWindows>
   </PropertyGroup>
 
   <!-- Non-Windows: Create a minimal stub that compiles but produces nothing -->


### PR DESCRIPTION
### Motivation
- Remove the forced non-Windows override that prevented the project from evaluating as `net9.0-windows` on Windows runners, which produced an assets file missing the `net9.0-windows` target and led to `NETSDK1005` during CI builds.

### Description
- Deleted the unconditional `<IsWindows Condition="'$(EnableFullWpfBuild)' != 'true'">false</IsWindows>` line from `src/Meridian.Wpf/Meridian.Wpf.csproj` so OS detection now relies on the existing platform checks and the Windows `PropertyGroup` will be selected on Windows agents.

### Testing
- Verified the change via `git diff` and `git status` showing the updated project file.
- Attempted `dotnet restore src/Meridian.Wpf/Meridian.Wpf.csproj -p:TargetFramework=net9.0-windows` but the command could not run because `dotnet` is not installed in this environment, so build/restore validation could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2e44a916c8320a72573d4258af5cc)