### PR TITLE
Fix PaperTradingPortfolioTests expression-tree compile error and update maintenance checkout action

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -164,7 +164,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Prepare AI agent environment
         run: bash scripts/ai/setup-ai-agent.sh --install-dotnet
@@ -183,7 +183,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run docs drift checks
         run: |
@@ -207,7 +207,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Prepare AI agent environment
         run: bash scripts/ai/setup-ai-agent.sh --install-dotnet

--- a/tests/Meridian.Tests/Execution/PaperTradingPortfolioTests.cs
+++ b/tests/Meridian.Tests/Execution/PaperTradingPortfolioTests.cs
@@ -155,7 +155,8 @@ public sealed class PaperTradingPortfolioTests
         portfolio.Positions.Should().NotContainKey("AAPL");
 
         var coverEntry = ledger.Journal.Single(e => e.Description.Contains("Cover"));
-        coverEntry.Lines.Should().Contain(l => l.Account == LedgerAccounts.ShortSecuritiesPayable("AAPL") && l.Debit == 2_000m);
+        var shortPayable = LedgerAccounts.ShortSecuritiesPayable("AAPL", financialAccountId: null);
+        coverEntry.Lines.Should().Contain(l => l.Account == shortPayable && l.Debit == 2_000m);
         coverEntry.Lines.Should().Contain(l => l.Account == LedgerAccounts.Cash && l.Credit == 1_800m);
         coverEntry.Lines.Should().Contain(l => l.Account == LedgerAccounts.RealizedGain && l.Credit == 200m);
     }
@@ -172,7 +173,8 @@ public sealed class PaperTradingPortfolioTests
         portfolio.RealisedPnl.Should().Be(-200m);
 
         var coverEntry = ledger.Journal.Single(e => e.Description.Contains("Cover"));
-        coverEntry.Lines.Should().Contain(l => l.Account == LedgerAccounts.ShortSecuritiesPayable("AAPL") && l.Debit == 2_000m);
+        var shortPayable = LedgerAccounts.ShortSecuritiesPayable("AAPL", financialAccountId: null);
+        coverEntry.Lines.Should().Contain(l => l.Account == shortPayable && l.Debit == 2_000m);
         coverEntry.Lines.Should().Contain(l => l.Account == LedgerAccounts.Cash && l.Credit == 2_200m);
         coverEntry.Lines.Should().Contain(l => l.Account == LedgerAccounts.RealizedLoss && l.Debit == 200m);
     }


### PR DESCRIPTION
### Motivation
- Tests failed to compile because expression-tree-based FluentAssertions predicates contained method invocations that relied on omitted optional arguments, which C# expression trees disallow. 
- The maintenance workflow emitted a deprecation warning for Node.js 20 JavaScript actions and should use a newer `actions/checkout` version in the route used by maintenance runs.

### Description
- Replaced inline calls to `LedgerAccounts.ShortSecuritiesPayable("AAPL")` inside FluentAssertions predicates with a precomputed local `shortPayable` using an explicit `financialAccountId: null` in `tests/Meridian.Tests/Execution/PaperTradingPortfolioTests.cs` to avoid optional-argument invocation inside expression trees. 
- Updated all `uses: actions/checkout@v4` occurrences to `uses: actions/checkout@v5` in `.github/workflows/maintenance.yml` to address the Node.js 20 deprecation warning for actions.

### Testing
- Attempted to run the targeted tests with `dotnet test --filter PaperTradingPortfolioTests`, but the environment lacks the .NET SDK and the run failed with `dotnet: command not found`.
- Verified the source edits and resulting diffs by inspecting the modified files and confirming the changed assertions and workflow checkout version are present and syntactically correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2e5322d888320ad430295797da481)