### PR TITLE
Add Debits/Credits compatibility aliases to LedgerAccountSummary

### DIFF
--- a/src/Meridian.Ledger/LedgerAccountSummary.cs
+++ b/src/Meridian.Ledger/LedgerAccountSummary.cs
@@ -13,6 +13,16 @@ public sealed record LedgerAccountSummary(
     DateTimeOffset? LastPostedAt)
 {
     /// <summary>
+    /// Backward-compatible alias for <see cref="TotalDebits"/>.
+    /// </summary>
+    public decimal Debits => TotalDebits;
+
+    /// <summary>
+    /// Backward-compatible alias for <see cref="TotalCredits"/>.
+    /// </summary>
+    public decimal Credits => TotalCredits;
+
+    /// <summary>
     /// Creates an empty summary for an account with no postings.
     /// </summary>
     public static LedgerAccountSummary Empty(LedgerAccount account)


### PR DESCRIPTION
### Motivation
- The solution build was failing with `CS1061` errors where code expected `Debits`/`Credits` properties on `LedgerAccountSummary`, so older call sites broke after renaming to `TotalDebits`/`TotalCredits`.
- Provide a backward-compatible surface so callers that still reference the old names compile without changing their call sites.

### Description
- Added read-only alias properties `Debits` and `Credits` to `LedgerAccountSummary` that return `TotalDebits` and `TotalCredits` respectively in `src/Meridian.Ledger/LedgerAccountSummary.cs`.
- This preserves the canonical `TotalDebits`/`TotalCredits` field names while restoring the previous API used by other code.

### Testing
- Attempted to run `dotnet build Meridian.sln -c Release --no-restore /p:EnableWindowsTargeting=true --verbosity minimal` in the environment, but the command could not be executed because `dotnet` is not available (`/bin/bash: dotnet: command not found`).
- Prior to the change, the automated build log showed two `CS1061` errors referencing missing `Debits`/`Credits`, and this change restores those members so the errors should be resolved when the project is built in a proper .NET-capable environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2e5d80bf883209c88e91278d7c0da)