### PR TITLE
Optimize maintenance workflow runtime with shallow fetches and concurrency

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: maintenance-checks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
@@ -34,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Classify maintenance route
         id: route
@@ -47,6 +51,7 @@ jobs:
           else
             BASE_REF="$(git rev-list --max-count=2 HEAD | tail -1)"
           fi
+          git cat-file -e "$BASE_REF^{commit}" 2>/dev/null || git fetch --no-tags --depth=1 origin "$BASE_REF"
           bash scripts/ai/route-maintenance.sh --classify-only --base "$BASE_REF" --head "${{ github.sha }}"
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import json
@@ -76,6 +81,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -93,6 +100,9 @@ jobs:
             BASE_REF="${{ github.event.pull_request.base.sha }}"
           else
             BASE_REF="${{ github.event.before }}"
+          fi
+          if [[ -n "$BASE_REF" && "$BASE_REF" != "0000000000000000000000000000000000000000" ]]; then
+            git cat-file -e "$BASE_REF^{commit}" 2>/dev/null || git fetch --no-tags --depth=1 origin "$BASE_REF"
           fi
           bash scripts/ai/route-maintenance.sh --base "$BASE_REF" --head "${{ github.sha }}"
 
@@ -119,7 +129,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -140,6 +150,9 @@ jobs:
               BASE_REF="${{ github.event.pull_request.base.sha }}"
             else
               BASE_REF="${{ github.event.before }}"
+            fi
+            if [[ -n "$BASE_REF" && "$BASE_REF" != "0000000000000000000000000000000000000000" ]]; then
+              git cat-file -e "$BASE_REF^{commit}" 2>/dev/null || git fetch --no-tags --depth=1 origin "$BASE_REF"
             fi
             bash scripts/ai/route-maintenance.sh --base "$BASE_REF" --head "${{ github.sha }}"
           fi


### PR DESCRIPTION
### Motivation

- Reduce runner time and checkout latency for the scheduled/CI maintenance workflow to improve feedback speed and lower costs.
- Avoid wasted work from overlapping runs by cancelling superseded maintenance checks automatically.
- Preserve correct route classification by ensuring the workflow can still resolve the base commit when using shallow fetches.

### Description

- Add workflow-level `concurrency` with `cancel-in-progress: true` so newer runs cancel older in-flight runs for the same ref.
- Reduce `actions/checkout` depth to `fetch-depth: 2` in the `detect-changes`, `maintenance-light`, and `maintenance-full` jobs to speed up clones.
- Add targeted base-commit guards that run `git cat-file -e "$BASE_REF^{commit}" || git fetch --no-tags --depth=1 origin "$BASE_REF"` before route/maintenance scripts so shallow clones still obtain the needed comparison commit only when necessary.
- Keep existing job logic and artifact uploads intact so behavior for scheduled/full runs remains unchanged.

### Testing

- Validated YAML syntax by loading the updated workflow with Ruby: `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/maintenance.yml')"` which returned `YAML parse ok`.
- Attempted a Python YAML load sanity check with `PyYAML`, but the check failed because the `yaml` module is not installed in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2e7e2a0248320922c7cb2cf307639)