### PR TITLE
Add dotnet-format pre-commit hook, installer script, and docs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+if ! command -v dotnet >/dev/null 2>&1; then
+  echo "pre-commit: dotnet CLI is required to run formatting checks." >&2
+  exit 1
+fi
+
+dotnet format Meridian.sln --verify-no-changes

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -64,6 +64,7 @@ This directory contains guides for developers contributing to or extending the M
 |----------|-------------|
 | [GitHub Actions Summary](github-actions-summary.md) | CI/CD pipeline overview |
 | [Build Observability](build-observability.md) | Build metrics and diagnostics |
+| [Git Hooks](git-hooks.md) | Local pre-commit quality checks (`dotnet format`) |
 | [Tooling & Workflow Backlog](tooling-workflow-backlog.md) | Prioritized cleanup plan for repo automation |
 
 ### Desktop Development

--- a/docs/development/git-hooks.md
+++ b/docs/development/git-hooks.md
@@ -1,0 +1,35 @@
+# Git Hooks (Local Quality Gate)
+
+Use the repository-managed pre-commit hook to prevent style regressions before code is committed.
+
+## Install
+
+From the repository root:
+
+```bash
+./scripts/dev/install-git-hooks.sh
+```
+
+This configures `core.hooksPath` to `.githooks`, enabling the tracked hook scripts for this repository.
+
+## Current pre-commit checks
+
+The pre-commit hook runs:
+
+```bash
+dotnet format Meridian.sln --verify-no-changes
+```
+
+If formatting issues are detected, the commit is blocked until formatting is fixed.
+
+## Manually run the same check
+
+```bash
+dotnet format Meridian.sln --verify-no-changes
+```
+
+Or auto-fix formatting:
+
+```bash
+dotnet format Meridian.sln
+```

--- a/scripts/dev/install-git-hooks.sh
+++ b/scripts/dev/install-git-hooks.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+git -C "$repo_root" config core.hooksPath .githooks
+
+echo "Configured Git hooks path to '$repo_root/.githooks'."
+echo "Pre-commit will now run: dotnet format Meridian.sln --verify-no-changes"


### PR DESCRIPTION
### Motivation
- Ensure formatting regressions are caught locally by enforcing `dotnet format` before commits as suggested by the code quality report.
- Provide an easy, repository-tracked installation path so contributors opt into the local quality gate without manual setup.

### Description
- Add a tracked pre-commit hook at `.githooks/pre-commit` that checks for the `dotnet` CLI and runs `dotnet format Meridian.sln --verify-no-changes`.
- Add `scripts/dev/install-git-hooks.sh` which configures `git` to use the repository-managed `.githooks` directory via `core.hooksPath`.
- Add `docs/development/git-hooks.md` documenting installation and how to run or auto-fix the formatting check with `dotnet format`.
- Link the new `git-hooks.md` from `docs/development/README.md` under the CI/CD & Build section.

### Testing
- Ran a shell syntax check with `bash -n scripts/dev/install-git-hooks.sh`, which succeeded.
- Ran a shell syntax check with `sh -n .githooks/pre-commit`, which succeeded.
- Executed `./.githooks/pre-commit` in the environment, which correctly failed because the `dotnet` CLI is not available in this container (expected in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ea7dbfb8832085d37871d82be402)