### PR TITLE
feat: add brokerage provider framework (Alpaca, IB, StockSharp)

### DIFF
--- a/src/Meridian.Execution.Sdk/BrokerageConfiguration.cs
+++ b/src/Meridian.Execution.Sdk/BrokerageConfiguration.cs
@@ -1,0 +1,39 @@
+namespace Meridian.Execution.Sdk;
+
+/// <summary>
+/// Configuration for the brokerage execution layer.
+/// Determines which gateway is used for live order routing.
+/// </summary>
+public sealed class BrokerageConfiguration
+{
+    /// <summary>
+    /// The brokerage gateway to use. Must match a registered gateway ID
+    /// (e.g., "alpaca", "ib", "stocksharp-rithmic", "paper").
+    /// Default is "paper" for safety.
+    /// </summary>
+    public string Gateway { get; set; } = "paper";
+
+    /// <summary>
+    /// Whether live execution is explicitly enabled. Must be set to true
+    /// along with a valid gateway to route orders to a real broker.
+    /// This is a safety switch to prevent accidental live trading.
+    /// </summary>
+    public bool LiveExecutionEnabled { get; set; }
+
+    /// <summary>
+    /// Maximum position size (in shares) across all symbols. Zero means unlimited.
+    /// Applied as a pre-trade risk check.
+    /// </summary>
+    public decimal MaxPositionSize { get; set; }
+
+    /// <summary>
+    /// Maximum notional order value (price * quantity). Zero means unlimited.
+    /// Applied as a pre-trade risk check.
+    /// </summary>
+    public decimal MaxOrderNotional { get; set; }
+
+    /// <summary>
+    /// Maximum number of open orders allowed at any time. Zero means unlimited.
+    /// </summary>
+    public int MaxOpenOrders { get; set; }
+}

--- a/src/Meridian.Execution.Sdk/IBrokerageGateway.cs
+++ b/src/Meridian.Execution.Sdk/IBrokerageGateway.cs
@@ -1,0 +1,217 @@
+namespace Meridian.Execution.Sdk;
+
+/// <summary>
+/// Extended execution gateway contract for full brokerage providers.
+/// Adds account querying, position sync, and connection lifecycle on top of
+/// <see cref="IExecutionGateway"/>. Each broker (Alpaca, IB, StockSharp, etc.)
+/// implements this interface to expose its full trading capabilities.
+/// </summary>
+public interface IBrokerageGateway : IExecutionGateway, IAsyncDisposable
+{
+    /// <summary>Gets the human-readable broker display name (e.g., "Alpaca Markets").</summary>
+    string BrokerDisplayName { get; }
+
+    /// <summary>Gets the declared brokerage capabilities for this gateway.</summary>
+    BrokerageCapabilities BrokerageCapabilities { get; }
+
+    /// <summary>Gets the current account balance and buying power from the broker.</summary>
+    Task<AccountInfo> GetAccountInfoAsync(CancellationToken ct = default);
+
+    /// <summary>Queries current positions held at the broker.</summary>
+    Task<IReadOnlyList<BrokerPosition>> GetPositionsAsync(CancellationToken ct = default);
+
+    /// <summary>Queries open orders at the broker.</summary>
+    Task<IReadOnlyList<BrokerOrder>> GetOpenOrdersAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Checks whether the gateway can currently accept orders (credentials valid,
+    /// connection alive, market open, etc.).
+    /// </summary>
+    Task<BrokerHealthStatus> CheckHealthAsync(CancellationToken ct = default);
+}
+
+/// <summary>
+/// Describes the brokerage-specific capabilities exposed by a gateway.
+/// </summary>
+public sealed record BrokerageCapabilities
+{
+    /// <summary>Supported order types.</summary>
+    public required IReadOnlySet<OrderType> SupportedOrderTypes { get; init; }
+
+    /// <summary>Supported time-in-force values.</summary>
+    public required IReadOnlySet<TimeInForce> SupportedTimeInForce { get; init; }
+
+    /// <summary>Supports order modification (amend price/qty on working orders).</summary>
+    public bool SupportsOrderModification { get; init; }
+
+    /// <summary>Supports partial fills.</summary>
+    public bool SupportsPartialFills { get; init; }
+
+    /// <summary>Supports short selling.</summary>
+    public bool SupportsShortSelling { get; init; }
+
+    /// <summary>Supports fractional shares.</summary>
+    public bool SupportsFractionalShares { get; init; }
+
+    /// <summary>Supports extended/after-hours trading.</summary>
+    public bool SupportsExtendedHours { get; init; }
+
+    /// <summary>Supported asset classes (e.g., "equity", "option", "crypto", "futures").</summary>
+    public IReadOnlyList<string> SupportedAssetClasses { get; init; } = ["equity"];
+
+    /// <summary>Supported markets/exchanges.</summary>
+    public IReadOnlyList<string> SupportedMarkets { get; init; } = ["US"];
+
+    /// <summary>Provider-specific extension hints (e.g., "maxOrdersPerSecond").</summary>
+    public IReadOnlyDictionary<string, string> Extensions { get; init; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Standard brokerage capabilities for US equity brokers.</summary>
+    public static BrokerageCapabilities UsEquity(
+        bool modification = true,
+        bool partialFills = true,
+        bool shortSelling = true,
+        bool fractional = false,
+        bool extendedHours = false) => new()
+    {
+        SupportedOrderTypes = new HashSet<OrderType>
+        {
+            OrderType.Market,
+            OrderType.Limit,
+            OrderType.StopMarket,
+            OrderType.StopLimit
+        },
+        SupportedTimeInForce = new HashSet<TimeInForce>
+        {
+            TimeInForce.Day,
+            TimeInForce.GoodTilCancelled,
+            TimeInForce.ImmediateOrCancel,
+            TimeInForce.FillOrKill
+        },
+        SupportsOrderModification = modification,
+        SupportsPartialFills = partialFills,
+        SupportsShortSelling = shortSelling,
+        SupportsFractionalShares = fractional,
+        SupportsExtendedHours = extendedHours,
+    };
+}
+
+/// <summary>
+/// Account balance and buying power information from a broker.
+/// </summary>
+public sealed record AccountInfo
+{
+    /// <summary>Account identifier at the broker.</summary>
+    public required string AccountId { get; init; }
+
+    /// <summary>Total equity value (cash + positions at mark).</summary>
+    public decimal Equity { get; init; }
+
+    /// <summary>Available cash balance.</summary>
+    public decimal Cash { get; init; }
+
+    /// <summary>Buying power available for new orders.</summary>
+    public decimal BuyingPower { get; init; }
+
+    /// <summary>Currency code (e.g., "USD").</summary>
+    public string Currency { get; init; } = "USD";
+
+    /// <summary>Account status (e.g., "active", "restricted").</summary>
+    public string Status { get; init; } = "active";
+
+    /// <summary>Timestamp when this info was retrieved.</summary>
+    public DateTimeOffset RetrievedAt { get; init; } = DateTimeOffset.UtcNow;
+}
+
+/// <summary>
+/// A position held at the broker.
+/// </summary>
+public sealed record BrokerPosition
+{
+    /// <summary>Ticker symbol.</summary>
+    public required string Symbol { get; init; }
+
+    /// <summary>Signed quantity (negative for short positions).</summary>
+    public decimal Quantity { get; init; }
+
+    /// <summary>Average entry price.</summary>
+    public decimal AverageEntryPrice { get; init; }
+
+    /// <summary>Current market price.</summary>
+    public decimal MarketPrice { get; init; }
+
+    /// <summary>Market value (absolute quantity * market price).</summary>
+    public decimal MarketValue { get; init; }
+
+    /// <summary>Unrealized P&amp;L.</summary>
+    public decimal UnrealizedPnl { get; init; }
+
+    /// <summary>Asset class (e.g., "equity", "crypto").</summary>
+    public string AssetClass { get; init; } = "equity";
+}
+
+/// <summary>
+/// An open order at the broker.
+/// </summary>
+public sealed record BrokerOrder
+{
+    /// <summary>Broker-assigned order ID.</summary>
+    public required string OrderId { get; init; }
+
+    /// <summary>Client-assigned order ID.</summary>
+    public string? ClientOrderId { get; init; }
+
+    /// <summary>Ticker symbol.</summary>
+    public required string Symbol { get; init; }
+
+    /// <summary>Order side.</summary>
+    public required OrderSide Side { get; init; }
+
+    /// <summary>Order type.</summary>
+    public required OrderType Type { get; init; }
+
+    /// <summary>Total requested quantity.</summary>
+    public decimal Quantity { get; init; }
+
+    /// <summary>Quantity filled so far.</summary>
+    public decimal FilledQuantity { get; init; }
+
+    /// <summary>Limit price (if applicable).</summary>
+    public decimal? LimitPrice { get; init; }
+
+    /// <summary>Stop price (if applicable).</summary>
+    public decimal? StopPrice { get; init; }
+
+    /// <summary>Current order status.</summary>
+    public required OrderStatus Status { get; init; }
+
+    /// <summary>When the order was created.</summary>
+    public DateTimeOffset CreatedAt { get; init; }
+}
+
+/// <summary>
+/// Health check result for a brokerage gateway.
+/// </summary>
+public sealed record BrokerHealthStatus
+{
+    /// <summary>Whether the gateway is healthy and can accept orders.</summary>
+    public required bool IsHealthy { get; init; }
+
+    /// <summary>Whether the connection to the broker is alive.</summary>
+    public bool IsConnected { get; init; }
+
+    /// <summary>Whether the market is currently open for trading.</summary>
+    public bool? IsMarketOpen { get; init; }
+
+    /// <summary>Human-readable status message.</summary>
+    public string? Message { get; init; }
+
+    /// <summary>Timestamp of the health check.</summary>
+    public DateTimeOffset CheckedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    public static BrokerHealthStatus Healthy(string? message = null) =>
+        new() { IsHealthy = true, IsConnected = true, Message = message };
+
+    public static BrokerHealthStatus Unhealthy(string reason) =>
+        new() { IsHealthy = false, IsConnected = false, Message = reason };
+}

--- a/src/Meridian.Execution.Sdk/Models.cs
+++ b/src/Meridian.Execution.Sdk/Models.cs
@@ -100,7 +100,10 @@ public sealed record ExecutionReport
     public decimal? Commission { get; init; }
     public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.UtcNow;
     public string? RejectReason { get; init; }
+    /// <summary>Broker-assigned order ID (may differ from the client-provided <see cref="OrderId"/>).</summary>
     public string? GatewayOrderId { get; init; }
+    /// <summary>Client-provided order ID, if one was supplied in the original <see cref="OrderRequest"/>.</summary>
+    public string? ClientOrderId { get; init; }
 }
 
 /// <summary>Result of an order management operation.</summary>

--- a/src/Meridian.Execution.Sdk/Models.cs
+++ b/src/Meridian.Execution.Sdk/Models.cs
@@ -101,6 +101,8 @@ public sealed record ExecutionReport
     public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.UtcNow;
     public string? RejectReason { get; init; }
     public string? GatewayOrderId { get; init; }
+    /// <summary>The client-provided order ID from the original <see cref="OrderRequest"/>.</summary>
+    public string? ClientOrderId { get; init; }
 }
 
 /// <summary>Result of an order management operation.</summary>

--- a/src/Meridian.Execution/Adapters/BaseBrokerageGateway.cs
+++ b/src/Meridian.Execution/Adapters/BaseBrokerageGateway.cs
@@ -1,0 +1,283 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Meridian.Application.Pipeline;
+using Meridian.Execution.Sdk;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Execution.Adapters;
+
+/// <summary>
+/// Base class for live brokerage gateways. Provides shared infrastructure:
+/// connection lifecycle, reconnection with exponential backoff, execution report
+/// streaming via bounded channels, and rate limit scaffolding.
+/// Concrete implementations override broker-specific methods.
+/// </summary>
+public abstract class BaseBrokerageGateway : IBrokerageGateway
+{
+    private readonly Channel<ExecutionReport> _reportChannel;
+    private volatile bool _disposed;
+    private volatile bool _connected;
+    private CancellationTokenSource? _reconnectCts;
+
+    protected readonly ILogger Logger;
+
+    /// <summary>Maximum reconnection attempts before giving up.</summary>
+    protected virtual int MaxReconnectAttempts => 5;
+
+    /// <summary>Base delay for exponential backoff on reconnection.</summary>
+    protected virtual TimeSpan ReconnectBaseDelay => TimeSpan.FromSeconds(2);
+
+    protected BaseBrokerageGateway(ILogger logger)
+    {
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        // ADR-013: Use bounded channels for execution event pipeline
+        var policy = new EventPipelinePolicy(
+            Capacity: 500,
+            FullMode: BoundedChannelFullMode.Wait,
+            EnableMetrics: false);
+        _reportChannel = policy.CreateChannel<ExecutionReport>(
+            singleReader: false, singleWriter: false);
+    }
+
+    // ── IExecutionGateway ──────────────────────────────────────────────
+
+    /// <inheritdoc />
+    public abstract string GatewayId { get; }
+
+    /// <inheritdoc />
+    public bool IsConnected => _connected;
+
+    /// <inheritdoc />
+    public async Task ConnectAsync(CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (_connected)
+        {
+            Logger.LogWarning("{Gateway} already connected", GatewayId);
+            return;
+        }
+
+        Logger.LogInformation("{Gateway} connecting...", GatewayId);
+
+        await ConnectCoreAsync(ct).ConfigureAwait(false);
+        _connected = true;
+        _reconnectCts = new CancellationTokenSource();
+
+        Logger.LogInformation("{Gateway} connected successfully", GatewayId);
+    }
+
+    /// <inheritdoc />
+    public async Task DisconnectAsync(CancellationToken ct = default)
+    {
+        if (!_connected) return;
+
+        Logger.LogInformation("{Gateway} disconnecting...", GatewayId);
+
+        _reconnectCts?.Cancel();
+        _reconnectCts?.Dispose();
+        _reconnectCts = null;
+
+        await DisconnectCoreAsync(ct).ConfigureAwait(false);
+        _connected = false;
+
+        Logger.LogInformation("{Gateway} disconnected", GatewayId);
+    }
+
+    /// <inheritdoc />
+    public async Task<ExecutionReport> SubmitOrderAsync(OrderRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        EnsureConnected();
+
+        Logger.LogInformation(
+            "{Gateway} submitting order: {Side} {Quantity} {Symbol} @ {Type}",
+            GatewayId, request.Side, request.Quantity, request.Symbol, request.Type);
+
+        var report = await SubmitOrderCoreAsync(request, ct).ConfigureAwait(false);
+        await PublishReportAsync(report, ct).ConfigureAwait(false);
+        return report;
+    }
+
+    /// <inheritdoc />
+    public async Task<ExecutionReport> CancelOrderAsync(string orderId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        EnsureConnected();
+
+        Logger.LogInformation("{Gateway} cancelling order {OrderId}", GatewayId, orderId);
+
+        var report = await CancelOrderCoreAsync(orderId, ct).ConfigureAwait(false);
+        await PublishReportAsync(report, ct).ConfigureAwait(false);
+        return report;
+    }
+
+    /// <inheritdoc />
+    public async Task<ExecutionReport> ModifyOrderAsync(
+        string orderId, OrderModification modification, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
+        ArgumentNullException.ThrowIfNull(modification);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        EnsureConnected();
+
+        Logger.LogInformation("{Gateway} modifying order {OrderId}", GatewayId, orderId);
+
+        var report = await ModifyOrderCoreAsync(orderId, modification, ct).ConfigureAwait(false);
+        await PublishReportAsync(report, ct).ConfigureAwait(false);
+        return report;
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<ExecutionReport> StreamExecutionReportsAsync(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await foreach (var report in _reportChannel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+        {
+            yield return report;
+        }
+    }
+
+    // ── IBrokerageGateway ──────────────────────────────────────────────
+
+    /// <inheritdoc />
+    public abstract string BrokerDisplayName { get; }
+
+    /// <inheritdoc />
+    public abstract BrokerageCapabilities BrokerageCapabilities { get; }
+
+    /// <inheritdoc />
+    public abstract Task<AccountInfo> GetAccountInfoAsync(CancellationToken ct = default);
+
+    /// <inheritdoc />
+    public abstract Task<IReadOnlyList<BrokerPosition>> GetPositionsAsync(CancellationToken ct = default);
+
+    /// <inheritdoc />
+    public abstract Task<IReadOnlyList<BrokerOrder>> GetOpenOrdersAsync(CancellationToken ct = default);
+
+    /// <inheritdoc />
+    public virtual async Task<BrokerHealthStatus> CheckHealthAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            if (!_connected)
+                return BrokerHealthStatus.Unhealthy("Not connected");
+
+            var account = await GetAccountInfoAsync(ct).ConfigureAwait(false);
+            return account.Status == "active"
+                ? BrokerHealthStatus.Healthy($"Account {account.AccountId} active")
+                : BrokerHealthStatus.Unhealthy($"Account status: {account.Status}");
+        }
+        catch (Exception ex)
+        {
+            return BrokerHealthStatus.Unhealthy(ex.Message);
+        }
+    }
+
+    // ── Template methods for concrete implementations ──────────────────
+
+    /// <summary>Establishes the broker-specific connection (API auth, WebSocket, etc.).</summary>
+    protected abstract Task ConnectCoreAsync(CancellationToken ct);
+
+    /// <summary>Tears down the broker-specific connection.</summary>
+    protected abstract Task DisconnectCoreAsync(CancellationToken ct);
+
+    /// <summary>Submits an order via the broker API. Returns the initial execution report.</summary>
+    protected abstract Task<ExecutionReport> SubmitOrderCoreAsync(OrderRequest request, CancellationToken ct);
+
+    /// <summary>Cancels an order via the broker API.</summary>
+    protected abstract Task<ExecutionReport> CancelOrderCoreAsync(string orderId, CancellationToken ct);
+
+    /// <summary>Modifies an order via the broker API. Override if the broker supports modification.</summary>
+    protected virtual Task<ExecutionReport> ModifyOrderCoreAsync(
+        string orderId, OrderModification modification, CancellationToken ct)
+    {
+        throw new NotSupportedException($"{GatewayId} does not support order modification.");
+    }
+
+    // ── Shared infrastructure ──────────────────────────────────────────
+
+    /// <summary>
+    /// Publishes an execution report to the bounded channel for downstream consumers.
+    /// Subclasses should call this for asynchronous fill/status updates (e.g., WebSocket callbacks).
+    /// </summary>
+    protected async Task PublishReportAsync(ExecutionReport report, CancellationToken ct = default)
+    {
+        await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Attempts reconnection with exponential backoff. Subclasses can call this
+    /// when a connection drop is detected.
+    /// </summary>
+    protected async Task AttemptReconnectAsync()
+    {
+        var ct = _reconnectCts?.Token ?? CancellationToken.None;
+
+        for (int attempt = 1; attempt <= MaxReconnectAttempts; attempt++)
+        {
+            if (ct.IsCancellationRequested) return;
+
+            var delay = TimeSpan.FromSeconds(ReconnectBaseDelay.TotalSeconds * Math.Pow(2, attempt - 1));
+            Logger.LogWarning(
+                "{Gateway} reconnect attempt {Attempt}/{Max} in {Delay}s",
+                GatewayId, attempt, MaxReconnectAttempts, delay.TotalSeconds);
+
+            try
+            {
+                await Task.Delay(delay, ct).ConfigureAwait(false);
+                await ConnectCoreAsync(ct).ConfigureAwait(false);
+                _connected = true;
+                Logger.LogInformation("{Gateway} reconnected on attempt {Attempt}", GatewayId, attempt);
+                return;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "{Gateway} reconnect attempt {Attempt} failed", GatewayId, attempt);
+            }
+        }
+
+        _connected = false;
+        Logger.LogError("{Gateway} failed to reconnect after {Max} attempts", GatewayId, MaxReconnectAttempts);
+    }
+
+    /// <summary>Throws if not connected.</summary>
+    protected void EnsureConnected()
+    {
+        if (!_connected)
+            throw new InvalidOperationException($"{GatewayId} is not connected. Call ConnectAsync first.");
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _reconnectCts?.Cancel();
+        _reconnectCts?.Dispose();
+        _reportChannel.Writer.TryComplete();
+
+        if (_connected)
+        {
+            try
+            {
+                await DisconnectCoreAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(ex, "{Gateway} error during dispose disconnect", GatewayId);
+            }
+            _connected = false;
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Meridian.Execution/Adapters/BaseBrokerageGateway.cs
+++ b/src/Meridian.Execution/Adapters/BaseBrokerageGateway.cs
@@ -32,16 +32,15 @@ public abstract class BaseBrokerageGateway : IBrokerageGateway
         Logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         // ADR-013: Use bounded channels for execution event pipeline
-        var policy = new EventPipelinePolicy(
-            Capacity: 500,
-            FullMode: BoundedChannelFullMode.Wait,
-            EnableMetrics: false);
-        _reportChannel = policy.CreateChannel<ExecutionReport>(
+        _reportChannel = EventPipelinePolicy.Default.CreateChannel<ExecutionReport>(
             singleReader: false, singleWriter: false);
     }
 
     // ── IExecutionGateway ──────────────────────────────────────────────
 
+    }
+
+    // ── IExecutionGateway ──────────────────────────────────────────────
     /// <inheritdoc />
     public abstract string GatewayId { get; }
 

--- a/src/Meridian.Execution/Adapters/BaseBrokerageGateway.cs
+++ b/src/Meridian.Execution/Adapters/BaseBrokerageGateway.cs
@@ -37,10 +37,6 @@ public abstract class BaseBrokerageGateway : IBrokerageGateway
     }
 
     // ── IExecutionGateway ──────────────────────────────────────────────
-
-    }
-
-    // ── IExecutionGateway ──────────────────────────────────────────────
     /// <inheritdoc />
     public abstract string GatewayId { get; }
 

--- a/src/Meridian.Execution/Adapters/BrokerageGatewayAdapter.cs
+++ b/src/Meridian.Execution/Adapters/BrokerageGatewayAdapter.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Meridian.Application.Exceptions;
 using Meridian.Execution.Exceptions;
 using Meridian.Execution.Models;
 using Meridian.Execution.Sdk;
@@ -131,12 +132,24 @@ public sealed class BrokerageGatewayAdapter : IOrderGateway
     {
         await foreach (var report in _inner.StreamExecutionReportsAsync(ct).ConfigureAwait(false))
         {
+            var filledQuantity = report.FilledQuantity;
+            var truncatedFilledQuantity = decimal.Truncate(filledQuantity);
+
+            if (filledQuantity != truncatedFilledQuantity)
+            {
+                throw new MeridianException(
+                    $"Execution report for order '{report.OrderId}' contains fractional FilledQuantity " +
+                    $"'{filledQuantity}' which cannot be represented in OrderStatusUpdate. " +
+                    "Enable fractional share support in the consuming strategy or ensure the gateway " +
+                    "rounds filled quantities to whole shares.");
+            }
+
             yield return new OrderStatusUpdate(
                 OrderId: report.OrderId,
-                ClientOrderId: report.GatewayOrderId ?? report.OrderId,
+                ClientOrderId: report.ClientOrderId ?? report.OrderId,
                 Symbol: report.Symbol,
                 Status: MapStatus(report.OrderStatus),
-                FilledQuantity: (long)decimal.Truncate(report.FilledQuantity),
+                FilledQuantity: (long)truncatedFilledQuantity,
                 AverageFillPrice: report.FillPrice,
                 RejectReason: report.RejectReason,
                 Timestamp: report.Timestamp);

--- a/src/Meridian.Execution/Adapters/BrokerageGatewayAdapter.cs
+++ b/src/Meridian.Execution/Adapters/BrokerageGatewayAdapter.cs
@@ -1,0 +1,166 @@
+using System.Runtime.CompilerServices;
+using Meridian.Execution.Exceptions;
+using Meridian.Execution.Models;
+using Meridian.Execution.Sdk;
+using Microsoft.Extensions.Logging;
+using GatewayExecutionMode = Meridian.Execution.Models.ExecutionMode;
+using GatewayOrderStatus = Meridian.Execution.Models.OrderStatus;
+using SdkOrderType = Meridian.Execution.Sdk.OrderType;
+using SdkOrderStatus = Meridian.Execution.Sdk.OrderStatus;
+
+namespace Meridian.Execution.Adapters;
+
+/// <summary>
+/// Bridges an <see cref="IBrokerageGateway"/> (from Execution.Sdk) to the
+/// <see cref="IOrderGateway"/> contract used by <see cref="Interfaces.IExecutionContext"/>.
+/// This allows any brokerage provider to plug into the existing execution framework
+/// without modifying the strategy-facing interfaces.
+/// </summary>
+[ImplementsAdr("ADR-015", "Adapts live brokerage gateways to the IOrderGateway contract")]
+public sealed class BrokerageGatewayAdapter : IOrderGateway
+{
+    private readonly IBrokerageGateway _inner;
+    private readonly ILogger<BrokerageGatewayAdapter> _logger;
+    private bool _disposed;
+
+    public BrokerageGatewayAdapter(IBrokerageGateway inner, ILogger<BrokerageGatewayAdapter> logger)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public string BrokerName => _inner.BrokerDisplayName;
+
+    /// <inheritdoc />
+    public GatewayExecutionMode Mode => GatewayExecutionMode.Live;
+
+    /// <inheritdoc />
+    public OrderGatewayCapabilities Capabilities
+    {
+        get
+        {
+            var bc = _inner.BrokerageCapabilities;
+            return new OrderGatewayCapabilities(
+                SupportedOrderTypes: bc.SupportedOrderTypes,
+                SupportedTimeInForce: bc.SupportedTimeInForce,
+                SupportedExecutionModes: new HashSet<GatewayExecutionMode> { GatewayExecutionMode.Live },
+                SupportsOrderModification: bc.SupportsOrderModification,
+                SupportsPartialFills: bc.SupportsPartialFills,
+                ProviderExtensions: new Dictionary<string, string>(bc.Extensions, StringComparer.OrdinalIgnoreCase)
+                {
+                    ["supportsShortSelling"] = bc.SupportsShortSelling.ToString(),
+                    ["supportsFractionalShares"] = bc.SupportsFractionalShares.ToString(),
+                    ["supportsExtendedHours"] = bc.SupportsExtendedHours.ToString(),
+                });
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<OrderValidationResult> ValidateOrderAsync(OrderRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var caps = _inner.BrokerageCapabilities;
+
+        if (!caps.SupportedOrderTypes.Contains(request.Type))
+            return Task.FromResult(new OrderValidationResult(false, $"Order type '{request.Type}' not supported by {BrokerName}."));
+
+        if (!caps.SupportedTimeInForce.Contains(request.TimeInForce))
+            return Task.FromResult(new OrderValidationResult(false, $"Time in force '{request.TimeInForce}' not supported by {BrokerName}."));
+
+        if (request.Quantity <= 0)
+            return Task.FromResult(new OrderValidationResult(false, "Order quantity must be positive."));
+
+        if (request.Type is SdkOrderType.Limit or SdkOrderType.StopLimit &&
+            (!request.LimitPrice.HasValue || request.LimitPrice <= 0))
+            return Task.FromResult(new OrderValidationResult(false, "Limit/stop-limit orders require a positive limit price."));
+
+        if (request.Type is SdkOrderType.StopMarket or SdkOrderType.StopLimit &&
+            (!request.StopPrice.HasValue || request.StopPrice <= 0))
+            return Task.FromResult(new OrderValidationResult(false, "Stop/stop-limit orders require a positive stop price."));
+
+        return Task.FromResult(new OrderValidationResult(true));
+    }
+
+    /// <inheritdoc />
+    public async Task<OrderAcknowledgement> SubmitAsync(OrderRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        var validation = await ValidateOrderAsync(request, ct).ConfigureAwait(false);
+        if (!validation.IsValid)
+            throw new UnsupportedOrderRequestException(validation.Reason ?? "Order validation failed.");
+
+        var report = await _inner.SubmitOrderAsync(request, ct).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "{Broker} order submitted: {OrderId} {Side} {Quantity} {Symbol} — {Status}",
+            BrokerName, report.OrderId, request.Side, request.Quantity, request.Symbol, report.OrderStatus);
+
+        return new OrderAcknowledgement(
+            OrderId: report.OrderId,
+            ClientOrderId: request.ClientOrderId ?? report.OrderId,
+            Symbol: request.Symbol,
+            Status: MapStatus(report.OrderStatus),
+            AcknowledgedAt: report.Timestamp);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> CancelAsync(string orderId, CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        try
+        {
+            var report = await _inner.CancelOrderAsync(orderId, ct).ConfigureAwait(false);
+            _logger.LogInformation("{Broker} order {OrderId} cancel — {Status}", BrokerName, orderId, report.OrderStatus);
+            return report.OrderStatus is SdkOrderStatus.Cancelled;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "{Broker} failed to cancel order {OrderId}", BrokerName, orderId);
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<OrderStatusUpdate> StreamOrderUpdatesAsync(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await foreach (var report in _inner.StreamExecutionReportsAsync(ct).ConfigureAwait(false))
+        {
+            yield return new OrderStatusUpdate(
+                OrderId: report.OrderId,
+                ClientOrderId: report.GatewayOrderId ?? report.OrderId,
+                Symbol: report.Symbol,
+                Status: MapStatus(report.OrderStatus),
+                FilledQuantity: (long)decimal.Truncate(report.FilledQuantity),
+                AverageFillPrice: report.FillPrice,
+                RejectReason: report.RejectReason,
+                Timestamp: report.Timestamp);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        await _inner.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private static GatewayOrderStatus MapStatus(SdkOrderStatus sdkStatus) => sdkStatus switch
+    {
+        SdkOrderStatus.PendingNew => GatewayOrderStatus.Accepted,
+        SdkOrderStatus.Accepted => GatewayOrderStatus.Accepted,
+        SdkOrderStatus.PartiallyFilled => GatewayOrderStatus.PartiallyFilled,
+        SdkOrderStatus.Filled => GatewayOrderStatus.Filled,
+        SdkOrderStatus.PendingCancel => GatewayOrderStatus.Working,
+        SdkOrderStatus.Cancelled => GatewayOrderStatus.Cancelled,
+        SdkOrderStatus.Rejected => GatewayOrderStatus.Rejected,
+        SdkOrderStatus.Expired => GatewayOrderStatus.Cancelled,
+        _ => GatewayOrderStatus.Rejected
+    };
+}

--- a/src/Meridian.Execution/Adapters/BrokerageGatewayAdapter.cs
+++ b/src/Meridian.Execution/Adapters/BrokerageGatewayAdapter.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Meridian.Application.Exceptions;
 using Meridian.Execution.Exceptions;
 using Meridian.Execution.Models;
 using Meridian.Execution.Sdk;
@@ -131,12 +132,21 @@ public sealed class BrokerageGatewayAdapter : IOrderGateway
     {
         await foreach (var report in _inner.StreamExecutionReportsAsync(ct).ConfigureAwait(false))
         {
+            var filledQuantity = report.FilledQuantity;
+            var truncatedFilledQuantity = decimal.Truncate(filledQuantity);
+
+            if (filledQuantity != truncatedFilledQuantity)
+            {
+                throw new MeridianException(
+                    $"Execution report for order '{report.OrderId}' contains fractional FilledQuantity '{filledQuantity}' which cannot be represented in OrderStatusUpdate.");
+            }
+
             yield return new OrderStatusUpdate(
                 OrderId: report.OrderId,
-                ClientOrderId: report.GatewayOrderId ?? report.OrderId,
+                ClientOrderId: report.ClientOrderId ?? report.OrderId,
                 Symbol: report.Symbol,
                 Status: MapStatus(report.OrderStatus),
-                FilledQuantity: (long)decimal.Truncate(report.FilledQuantity),
+                FilledQuantity: (long)truncatedFilledQuantity,
                 AverageFillPrice: report.FillPrice,
                 RejectReason: report.RejectReason,
                 Timestamp: report.Timestamp);

--- a/src/Meridian.Execution/BrokerageServiceRegistration.cs
+++ b/src/Meridian.Execution/BrokerageServiceRegistration.cs
@@ -47,6 +47,23 @@ public static class BrokerageServiceRegistration
             return new BrokerageGatewayAdapter(gateway, adapterLogger);
         });
 
+        // Register IExecutionGateway for the OMS.
+        // IBrokerageGateway extends IExecutionGateway, so in live mode the underlying brokerage
+        // gateway is used directly. In paper mode the SDK-level PaperTradingGateway is used.
+        services.TryAddSingleton<IExecutionGateway>(sp =>
+        {
+            var brokerageConfig = sp.GetRequiredService<BrokerageConfiguration>();
+
+            if (!brokerageConfig.LiveExecutionEnabled || brokerageConfig.Gateway == "paper")
+            {
+                var paperLogger = sp.GetRequiredService<ILogger<PaperTradingGateway>>();
+                return new PaperTradingGateway(paperLogger);
+            }
+
+            // IBrokerageGateway : IExecutionGateway — use the live gateway directly.
+            return ResolveBrokerageGateway(sp, brokerageConfig.Gateway);
+        });
+
         // Register the OMS with the resolved gateway
         services.TryAddSingleton<IOrderManager>(sp =>
         {

--- a/src/Meridian.Execution/BrokerageServiceRegistration.cs
+++ b/src/Meridian.Execution/BrokerageServiceRegistration.cs
@@ -1,0 +1,102 @@
+using Meridian.Execution.Adapters;
+using Meridian.Execution.Interfaces;
+using Meridian.Execution.Sdk;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Execution;
+
+/// <summary>
+/// DI registration helpers for the brokerage execution layer.
+/// Registers brokerage gateways, the OMS, and the <see cref="IOrderGateway"/>
+/// adapter that bridges <see cref="IBrokerageGateway"/> into the existing
+/// execution framework.
+/// </summary>
+public static class BrokerageServiceRegistration
+{
+    /// <summary>
+    /// Registers the brokerage execution layer services.
+    /// </summary>
+    /// <param name="services">The DI service collection.</param>
+    /// <param name="configure">Optional configuration action.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddBrokerageExecution(
+        this IServiceCollection services,
+        Action<BrokerageConfiguration>? configure = null)
+    {
+        var config = new BrokerageConfiguration();
+        configure?.Invoke(config);
+        services.AddSingleton(config);
+
+        // Register the BrokerageGatewayAdapter that bridges IBrokerageGateway → IOrderGateway
+        services.TryAddSingleton<IOrderGateway>(sp =>
+        {
+            var brokerageConfig = sp.GetRequiredService<BrokerageConfiguration>();
+
+            // If live execution is not enabled, always use PaperTradingGateway
+            if (!brokerageConfig.LiveExecutionEnabled || brokerageConfig.Gateway == "paper")
+            {
+                var paperLogger = sp.GetRequiredService<ILogger<Adapters.PaperTradingGateway>>();
+                return new Adapters.PaperTradingGateway(paperLogger);
+            }
+
+            // Resolve the named brokerage gateway
+            var gateway = ResolveBrokerageGateway(sp, brokerageConfig.Gateway);
+            var adapterLogger = sp.GetRequiredService<ILogger<BrokerageGatewayAdapter>>();
+            return new BrokerageGatewayAdapter(gateway, adapterLogger);
+        });
+
+        // Register the OMS with the resolved gateway
+        services.TryAddSingleton<IOrderManager>(sp =>
+        {
+            var gateway = sp.GetRequiredService<IExecutionGateway>();
+            var logger = sp.GetRequiredService<ILogger<OrderManagementSystem>>();
+            var riskValidator = sp.GetService<IRiskValidator>();
+            return new OrderManagementSystem(gateway, logger, riskValidator);
+        });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a specific <see cref="IBrokerageGateway"/> implementation as a named gateway.
+    /// </summary>
+    /// <typeparam name="TGateway">The concrete brokerage gateway type.</typeparam>
+    /// <param name="services">The DI service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddBrokerageGateway<TGateway>(this IServiceCollection services)
+        where TGateway : class, IBrokerageGateway
+    {
+        services.AddSingleton<TGateway>();
+        services.AddSingleton<IBrokerageGateway>(sp => sp.GetRequiredService<TGateway>());
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a factory-created <see cref="IBrokerageGateway"/> as a named gateway.
+    /// </summary>
+    public static IServiceCollection AddBrokerageGateway(
+        this IServiceCollection services,
+        Func<IServiceProvider, IBrokerageGateway> factory)
+    {
+        services.AddSingleton(factory);
+        return services;
+    }
+
+    private static IBrokerageGateway ResolveBrokerageGateway(IServiceProvider sp, string gatewayId)
+    {
+        // Try to find a registered IBrokerageGateway whose GatewayId matches
+        var gateways = sp.GetServices<IBrokerageGateway>();
+        var match = gateways.FirstOrDefault(g =>
+            string.Equals(g.GatewayId, gatewayId, StringComparison.OrdinalIgnoreCase));
+
+        if (match is not null)
+            return match;
+
+        throw new InvalidOperationException(
+            $"No brokerage gateway registered with ID '{gatewayId}'. " +
+            $"Available gateways: {string.Join(", ", gateways.Select(g => g.GatewayId))}. " +
+            "Register gateways using AddBrokerageGateway<T>() before calling AddBrokerageExecution().");
+    }
+}

--- a/src/Meridian.Execution/BrokerageServiceRegistration.cs
+++ b/src/Meridian.Execution/BrokerageServiceRegistration.cs
@@ -29,25 +29,39 @@ public static class BrokerageServiceRegistration
         configure?.Invoke(config);
         services.AddSingleton(config);
 
+        // Register IExecutionGateway for the OMS (OrderManagementSystem).
+        // For paper mode, use the Execution-layer PaperTradingGateway which implements IExecutionGateway.
+        // For live mode, the IBrokerageGateway itself implements IExecutionGateway.
+        services.TryAddSingleton<IExecutionGateway>(sp =>
+        {
+            var brokerageConfig = sp.GetRequiredService<BrokerageConfiguration>();
+            if (!brokerageConfig.LiveExecutionEnabled || brokerageConfig.Gateway == "paper")
+            {
+                var paperLogger = sp.GetRequiredService<ILogger<PaperTradingGateway>>();
+                return new PaperTradingGateway(paperLogger);
+            }
+            return ResolveBrokerageGateway(sp, brokerageConfig.Gateway);
+        });
+
         // Register the BrokerageGatewayAdapter that bridges IBrokerageGateway → IOrderGateway
         services.TryAddSingleton<IOrderGateway>(sp =>
         {
             var brokerageConfig = sp.GetRequiredService<BrokerageConfiguration>();
 
-            // If live execution is not enabled, always use PaperTradingGateway
+            // If live execution is not enabled, always use the adapter-layer PaperTradingGateway
             if (!brokerageConfig.LiveExecutionEnabled || brokerageConfig.Gateway == "paper")
             {
                 var paperLogger = sp.GetRequiredService<ILogger<Adapters.PaperTradingGateway>>();
                 return new Adapters.PaperTradingGateway(paperLogger);
             }
 
-            // Resolve the named brokerage gateway
+            // Resolve the named brokerage gateway via keyed registration
             var gateway = ResolveBrokerageGateway(sp, brokerageConfig.Gateway);
             var adapterLogger = sp.GetRequiredService<ILogger<BrokerageGatewayAdapter>>();
             return new BrokerageGatewayAdapter(gateway, adapterLogger);
         });
 
-        // Register the OMS with the resolved gateway
+        // Register the OMS using the IExecutionGateway registered above
         services.TryAddSingleton<IOrderManager>(sp =>
         {
             var gateway = sp.GetRequiredService<IExecutionGateway>();
@@ -60,43 +74,61 @@ public static class BrokerageServiceRegistration
     }
 
     /// <summary>
-    /// Registers a specific <see cref="IBrokerageGateway"/> implementation as a named gateway.
+    /// Registers a specific <see cref="IBrokerageGateway"/> implementation as a keyed named gateway.
+    /// Use the same <paramref name="gatewayId"/> when configuring <see cref="BrokerageConfiguration.Gateway"/>.
     /// </summary>
     /// <typeparam name="TGateway">The concrete brokerage gateway type.</typeparam>
     /// <param name="services">The DI service collection.</param>
+    /// <param name="gatewayId">
+    /// The gateway identifier (e.g., "alpaca", "ib"). Must match the value of
+    /// <see cref="BrokerageConfiguration.Gateway"/> when this gateway should be selected.
+    /// </param>
     /// <returns>The service collection for chaining.</returns>
-    public static IServiceCollection AddBrokerageGateway<TGateway>(this IServiceCollection services)
+    public static IServiceCollection AddBrokerageGateway<TGateway>(
+        this IServiceCollection services, string gatewayId)
         where TGateway : class, IBrokerageGateway
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(gatewayId);
         services.AddSingleton<TGateway>();
-        services.AddSingleton<IBrokerageGateway>(sp => sp.GetRequiredService<TGateway>());
+        services.AddKeyedSingleton<IBrokerageGateway>(gatewayId,
+            (sp, _) => sp.GetRequiredService<TGateway>());
         return services;
     }
 
     /// <summary>
-    /// Registers a factory-created <see cref="IBrokerageGateway"/> as a named gateway.
+    /// Registers a factory-created <see cref="IBrokerageGateway"/> as a keyed named gateway.
     /// </summary>
+    /// <param name="services">The DI service collection.</param>
+    /// <param name="gatewayId">
+    /// The gateway identifier (e.g., "alpaca", "ib"). Must match the value of
+    /// <see cref="BrokerageConfiguration.Gateway"/> when this gateway should be selected.
+    /// </param>
+    /// <param name="factory">Factory function that creates the gateway.</param>
+    /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddBrokerageGateway(
         this IServiceCollection services,
+        string gatewayId,
         Func<IServiceProvider, IBrokerageGateway> factory)
     {
-        services.AddSingleton(factory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(gatewayId);
+        ArgumentNullException.ThrowIfNull(factory);
+        services.AddKeyedSingleton<IBrokerageGateway>(gatewayId, (sp, _) => factory(sp));
         return services;
     }
 
     private static IBrokerageGateway ResolveBrokerageGateway(IServiceProvider sp, string gatewayId)
     {
-        // Try to find a registered IBrokerageGateway whose GatewayId matches
-        var gateways = sp.GetServices<IBrokerageGateway>();
-        var match = gateways.FirstOrDefault(g =>
-            string.Equals(g.GatewayId, gatewayId, StringComparison.OrdinalIgnoreCase));
-
-        if (match is not null)
-            return match;
+        // NOTE: We intentionally use GetRequiredKeyedService here rather than
+        // GetServices<IBrokerageGateway>() to avoid instantiating every registered gateway.
+        // Enumerating all registered gateways would construct each one, which can fail if
+        // some gateways validate credentials or perform I/O in their constructors even when
+        // they are not the selected gateway.
+        var gateway = sp.GetKeyedService<IBrokerageGateway>(gatewayId);
+        if (gateway is not null)
+            return gateway;
 
         throw new InvalidOperationException(
-            $"No brokerage gateway registered with ID '{gatewayId}'. " +
-            $"Available gateways: {string.Join(", ", gateways.Select(g => g.GatewayId))}. " +
-            "Register gateways using AddBrokerageGateway<T>() before calling AddBrokerageExecution().");
+            $"No brokerage gateway registered with key '{gatewayId}'. " +
+            "Register gateways using AddBrokerageGateway<T>(gatewayId) before calling AddBrokerageExecution().");
     }
 }

--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaBrokerageGateway.cs
@@ -1,8 +1,10 @@
+using System.Globalization;
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Channels;
+using Meridian.Application.Pipeline;
 using Meridian.Execution.Sdk;
 using Meridian.Infrastructure.Contracts;
 using Meridian.Infrastructure.DataSources;
@@ -56,10 +58,10 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         if (string.IsNullOrWhiteSpace(_options.KeyId) || string.IsNullOrWhiteSpace(_options.SecretKey))
-            throw new ArgumentException("Alpaca KeyId and SecretKey are required for brokerage.");
+            _logger.LogWarning(
+                "Alpaca brokerage credentials are missing or incomplete; gateway will remain unavailable until valid credentials are provided.");
 
-        _reportChannel = Channel.CreateBounded<ExecutionReport>(
-            new BoundedChannelOptions(500) { FullMode = BoundedChannelFullMode.Wait });
+        _reportChannel = EventPipelinePolicy.Default.CreateChannel<ExecutionReport>();
     }
 
     /// <inheritdoc />
@@ -87,6 +89,10 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         if (_connected) return;
+
+        if (string.IsNullOrWhiteSpace(_options.KeyId) || string.IsNullOrWhiteSpace(_options.SecretKey))
+            throw new InvalidOperationException(
+                "Alpaca KeyId and SecretKey are required for brokerage. Configure credentials before calling ConnectAsync.");
 
         var account = await GetAccountInfoAsync(ct).ConfigureAwait(false);
         _connected = true;
@@ -138,6 +144,7 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway
             var rejectReport = new ExecutionReport
             {
                 OrderId = request.ClientOrderId ?? Guid.NewGuid().ToString("N"),
+                ClientOrderId = request.ClientOrderId,
                 ReportType = ExecutionReportType.Rejected,
                 Symbol = request.Symbol,
                 Side = request.Side,
@@ -155,6 +162,7 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway
         var report = new ExecutionReport
         {
             OrderId = order?.Id ?? request.ClientOrderId ?? Guid.NewGuid().ToString("N"),
+            ClientOrderId = request.ClientOrderId,
             ReportType = ExecutionReportType.New,
             Symbol = request.Symbol,
             Side = request.Side,
@@ -175,22 +183,39 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway
         EnsureConnected();
 
         using var client = CreateHttpClient();
-        var response = await client.DeleteAsync($"{BaseUrl}/v2/orders/{orderId}", ct).ConfigureAwait(false);
 
-        if (!response.IsSuccessStatusCode)
+        // Fetch current order details so the report carries the correct symbol and side.
+        AlpacaOrderResponse? existing = null;
+        try
         {
-            var errorBody = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            var getResponse = await client.GetAsync($"{BaseUrl}/v2/orders/{orderId}", ct).ConfigureAwait(false);
+            if (getResponse.IsSuccessStatusCode)
+                existing = await getResponse.Content.ReadFromJsonAsync(
+                    AlpacaBrokerageSerializerContext.Default.AlpacaOrderResponse, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Alpaca failed to fetch order {OrderId} before cancel", orderId);
+        }
+
+        var deleteResponse = await client.DeleteAsync($"{BaseUrl}/v2/orders/{orderId}", ct).ConfigureAwait(false);
+
+        if (!deleteResponse.IsSuccessStatusCode)
+        {
+            var errorBody = await deleteResponse.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             _logger.LogWarning("Alpaca cancel failed for {OrderId}: {Body}", orderId, errorBody);
         }
 
         var report = new ExecutionReport
         {
             OrderId = orderId,
-            ReportType = response.IsSuccessStatusCode ? ExecutionReportType.Cancelled : ExecutionReportType.Rejected,
-            Symbol = string.Empty,
-            Side = OrderSide.Buy,
-            OrderStatus = response.IsSuccessStatusCode ? OrderStatus.Cancelled : OrderStatus.Rejected,
-            RejectReason = response.IsSuccessStatusCode ? null : "Cancel request failed",
+            ClientOrderId = existing?.ClientOrderId,
+            ReportType = deleteResponse.IsSuccessStatusCode ? ExecutionReportType.Cancelled : ExecutionReportType.Rejected,
+            Symbol = existing?.Symbol ?? string.Empty,
+            Side = existing?.Side == "sell" ? OrderSide.Sell : OrderSide.Buy,
+            OrderStatus = deleteResponse.IsSuccessStatusCode ? OrderStatus.Cancelled : OrderStatus.Rejected,
+            RejectReason = deleteResponse.IsSuccessStatusCode ? null : "Cancel request failed",
+            GatewayOrderId = orderId,
             Timestamp = DateTimeOffset.UtcNow,
         };
         await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
@@ -332,6 +357,7 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway
         }
         catch (Exception ex)
         {
+            _logger.LogError(ex, "Alpaca health check failed");
             return BrokerHealthStatus.Unhealthy(ex.Message);
         }
     }
@@ -404,7 +430,7 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway
     };
 
     private static decimal ParseDecimal(string? value) =>
-        decimal.TryParse(value, out var result) ? result : 0m;
+        decimal.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result) ? result : 0m;
 
     // ── JSON DTOs (ADR-014: source generators) ─────────────────────────
 

--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaBrokerageGateway.cs
@@ -1,8 +1,10 @@
+using System.Globalization;
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Channels;
+using Meridian.Application.Pipeline;
 using Meridian.Execution.Sdk;
 using Meridian.Infrastructure.Contracts;
 using Meridian.Infrastructure.DataSources;
@@ -56,10 +58,13 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         if (string.IsNullOrWhiteSpace(_options.KeyId) || string.IsNullOrWhiteSpace(_options.SecretKey))
-            throw new ArgumentException("Alpaca KeyId and SecretKey are required for brokerage.");
+        {
+            _logger.LogWarning(
+                "Alpaca brokerage credentials are missing or incomplete; gateway will remain unavailable until valid credentials are provided.");
+        }
 
-        _reportChannel = Channel.CreateBounded<ExecutionReport>(
-            new BoundedChannelOptions(500) { FullMode = BoundedChannelFullMode.Wait });
+        _reportChannel = EventPipelinePolicy.Default.CreateChannel<ExecutionReport>(
+            singleReader: false, singleWriter: false);
     }
 
     /// <inheritdoc />
@@ -87,6 +92,9 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         if (_connected) return;
+
+        if (string.IsNullOrWhiteSpace(_options.KeyId) || string.IsNullOrWhiteSpace(_options.SecretKey))
+            throw new InvalidOperationException("Alpaca KeyId and SecretKey are required for brokerage. Set credentials before calling ConnectAsync.");
 
         var account = await GetAccountInfoAsync(ct).ConfigureAwait(false);
         _connected = true;
@@ -143,6 +151,7 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway
                 Side = request.Side,
                 OrderStatus = OrderStatus.Rejected,
                 RejectReason = $"Alpaca API error: {response.StatusCode} — {errorBody}",
+                ClientOrderId = request.ClientOrderId,
                 Timestamp = DateTimeOffset.UtcNow,
             };
             await _reportChannel.Writer.WriteAsync(rejectReport, ct).ConfigureAwait(false);
@@ -161,6 +170,7 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway
             OrderStatus = MapAlpacaStatus(order?.Status),
             OrderQuantity = request.Quantity,
             GatewayOrderId = order?.Id,
+            ClientOrderId = request.ClientOrderId,
             Timestamp = order?.CreatedAt ?? DateTimeOffset.UtcNow,
         };
         await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
@@ -404,7 +414,8 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway
     };
 
     private static decimal ParseDecimal(string? value) =>
-        decimal.TryParse(value, out var result) ? result : 0m;
+        decimal.TryParse(value, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign,
+            CultureInfo.InvariantCulture, out var result) ? result : 0m;
 
     // ── JSON DTOs (ADR-014: source generators) ─────────────────────────
 

--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaBrokerageGateway.cs
@@ -1,0 +1,477 @@
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Channels;
+using Meridian.Execution.Sdk;
+using Meridian.Infrastructure.Contracts;
+using Meridian.Infrastructure.DataSources;
+using Microsoft.Extensions.Logging;
+using AlpacaOptions = Meridian.Application.Config.AlpacaOptions;
+using OrderSide = Meridian.Execution.Sdk.OrderSide;
+using OrderType = Meridian.Execution.Sdk.OrderType;
+using OrderStatus = Meridian.Execution.Sdk.OrderStatus;
+using TimeInForce = Meridian.Execution.Sdk.TimeInForce;
+
+namespace Meridian.Infrastructure.Adapters.Alpaca;
+
+/// <summary>
+/// Alpaca brokerage gateway for live order execution via the Alpaca Trading API.
+/// Uses REST API for order management and a bounded channel for execution report streaming.
+/// </summary>
+/// <remarks>
+/// Alpaca Trading API v2:
+/// - Paper trading: paper-api.alpaca.markets
+/// - Live trading: api.alpaca.markets
+/// - Supports market, limit, stop, stop-limit orders
+/// - Supports fractional shares
+/// - Supports extended hours trading
+/// - Rate limit: 200 req/min
+/// </remarks>
+[DataSource("alpaca-brokerage", "Alpaca Brokerage", DataSourceType.Realtime, DataSourceCategory.Broker,
+    Priority = 10, Description = "Alpaca Markets order execution gateway")]
+[ImplementsAdr("ADR-001", "Alpaca brokerage provider implementation")]
+[ImplementsAdr("ADR-004", "All async methods support CancellationToken")]
+[ImplementsAdr("ADR-005", "Attribute-based provider discovery")]
+[ImplementsAdr("ADR-010", "Uses IHttpClientFactory for HTTP connections")]
+public sealed class AlpacaBrokerageGateway : IBrokerageGateway
+{
+    private const string PaperBaseUrl = "https://paper-api.alpaca.markets";
+    private const string LiveBaseUrl = "https://api.alpaca.markets";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly AlpacaOptions _options;
+    private readonly ILogger<AlpacaBrokerageGateway> _logger;
+    private readonly Channel<ExecutionReport> _reportChannel;
+    private volatile bool _connected;
+    private bool _disposed;
+
+    public AlpacaBrokerageGateway(
+        IHttpClientFactory httpClientFactory,
+        AlpacaOptions options,
+        ILogger<AlpacaBrokerageGateway> logger)
+    {
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        if (string.IsNullOrWhiteSpace(_options.KeyId) || string.IsNullOrWhiteSpace(_options.SecretKey))
+            throw new ArgumentException("Alpaca KeyId and SecretKey are required for brokerage.");
+
+        _reportChannel = Channel.CreateBounded<ExecutionReport>(
+            new BoundedChannelOptions(500) { FullMode = BoundedChannelFullMode.Wait });
+    }
+
+    /// <inheritdoc />
+    public string GatewayId => "alpaca";
+
+    /// <inheritdoc />
+    public bool IsConnected => _connected;
+
+    /// <inheritdoc />
+    public string BrokerDisplayName => "Alpaca Markets";
+
+    /// <inheritdoc />
+    public BrokerageCapabilities BrokerageCapabilities { get; } =
+        BrokerageCapabilities.UsEquity(
+            modification: true,
+            partialFills: true,
+            shortSelling: true,
+            fractional: true,
+            extendedHours: true);
+
+    private string BaseUrl => _options.UseSandbox ? PaperBaseUrl : LiveBaseUrl;
+
+    /// <inheritdoc />
+    public async Task ConnectAsync(CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_connected) return;
+
+        var account = await GetAccountInfoAsync(ct).ConfigureAwait(false);
+        _connected = true;
+        _logger.LogInformation("Alpaca brokerage connected: account {AccountId}, status {Status}",
+            account.AccountId, account.Status);
+    }
+
+    /// <inheritdoc />
+    public Task DisconnectAsync(CancellationToken ct = default)
+    {
+        _connected = false;
+        _logger.LogInformation("Alpaca brokerage disconnected");
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async Task<ExecutionReport> SubmitOrderAsync(OrderRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        EnsureConnected();
+
+        _logger.LogInformation(
+            "Alpaca submitting order: {Side} {Quantity} {Symbol} @ {Type}",
+            request.Side, request.Quantity, request.Symbol, request.Type);
+
+        var payload = new AlpacaOrderPayload
+        {
+            Symbol = request.Symbol,
+            Qty = request.Quantity.ToString("G"),
+            Side = request.Side == OrderSide.Buy ? "buy" : "sell",
+            Type = MapOrderType(request.Type),
+            TimeInForce = MapTimeInForce(request.TimeInForce),
+            LimitPrice = request.LimitPrice?.ToString("G"),
+            StopPrice = request.StopPrice?.ToString("G"),
+            ClientOrderId = request.ClientOrderId,
+        };
+
+        using var client = CreateHttpClient();
+        var response = await client.PostAsJsonAsync(
+            $"{BaseUrl}/v2/orders", payload, AlpacaBrokerageSerializerContext.Default.AlpacaOrderPayload, ct)
+            .ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            _logger.LogError("Alpaca order rejected: {StatusCode} {Body}", response.StatusCode, errorBody);
+
+            var rejectReport = new ExecutionReport
+            {
+                OrderId = request.ClientOrderId ?? Guid.NewGuid().ToString("N"),
+                ReportType = ExecutionReportType.Rejected,
+                Symbol = request.Symbol,
+                Side = request.Side,
+                OrderStatus = OrderStatus.Rejected,
+                RejectReason = $"Alpaca API error: {response.StatusCode} — {errorBody}",
+                Timestamp = DateTimeOffset.UtcNow,
+            };
+            await _reportChannel.Writer.WriteAsync(rejectReport, ct).ConfigureAwait(false);
+            return rejectReport;
+        }
+
+        var order = await response.Content.ReadFromJsonAsync(
+            AlpacaBrokerageSerializerContext.Default.AlpacaOrderResponse, ct).ConfigureAwait(false);
+
+        var report = new ExecutionReport
+        {
+            OrderId = order?.Id ?? request.ClientOrderId ?? Guid.NewGuid().ToString("N"),
+            ReportType = ExecutionReportType.New,
+            Symbol = request.Symbol,
+            Side = request.Side,
+            OrderStatus = MapAlpacaStatus(order?.Status),
+            OrderQuantity = request.Quantity,
+            GatewayOrderId = order?.Id,
+            Timestamp = order?.CreatedAt ?? DateTimeOffset.UtcNow,
+        };
+        await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
+        return report;
+    }
+
+    /// <inheritdoc />
+    public async Task<ExecutionReport> CancelOrderAsync(string orderId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        EnsureConnected();
+
+        using var client = CreateHttpClient();
+        var response = await client.DeleteAsync($"{BaseUrl}/v2/orders/{orderId}", ct).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            _logger.LogWarning("Alpaca cancel failed for {OrderId}: {Body}", orderId, errorBody);
+        }
+
+        var report = new ExecutionReport
+        {
+            OrderId = orderId,
+            ReportType = response.IsSuccessStatusCode ? ExecutionReportType.Cancelled : ExecutionReportType.Rejected,
+            Symbol = string.Empty,
+            Side = OrderSide.Buy,
+            OrderStatus = response.IsSuccessStatusCode ? OrderStatus.Cancelled : OrderStatus.Rejected,
+            RejectReason = response.IsSuccessStatusCode ? null : "Cancel request failed",
+            Timestamp = DateTimeOffset.UtcNow,
+        };
+        await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
+        return report;
+    }
+
+    /// <inheritdoc />
+    public async Task<ExecutionReport> ModifyOrderAsync(
+        string orderId, OrderModification modification, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
+        ArgumentNullException.ThrowIfNull(modification);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        EnsureConnected();
+
+        var payload = new AlpacaOrderModifyPayload
+        {
+            Qty = modification.NewQuantity?.ToString("G"),
+            LimitPrice = modification.NewLimitPrice?.ToString("G"),
+            StopPrice = modification.NewStopPrice?.ToString("G"),
+        };
+
+        using var client = CreateHttpClient();
+        var response = await client.PatchAsJsonAsync(
+            $"{BaseUrl}/v2/orders/{orderId}", payload, AlpacaBrokerageSerializerContext.Default.AlpacaOrderModifyPayload, ct)
+            .ConfigureAwait(false);
+
+        var order = response.IsSuccessStatusCode
+            ? await response.Content.ReadFromJsonAsync(
+                AlpacaBrokerageSerializerContext.Default.AlpacaOrderResponse, ct).ConfigureAwait(false)
+            : null;
+
+        var report = new ExecutionReport
+        {
+            OrderId = order?.Id ?? orderId,
+            ReportType = response.IsSuccessStatusCode ? ExecutionReportType.Modified : ExecutionReportType.Rejected,
+            Symbol = order?.Symbol ?? string.Empty,
+            Side = order?.Side == "sell" ? OrderSide.Sell : OrderSide.Buy,
+            OrderStatus = response.IsSuccessStatusCode ? MapAlpacaStatus(order?.Status) : OrderStatus.Rejected,
+            Timestamp = DateTimeOffset.UtcNow,
+        };
+        await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
+        return report;
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<ExecutionReport> StreamExecutionReportsAsync(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await foreach (var report in _reportChannel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+        {
+            yield return report;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<AccountInfo> GetAccountInfoAsync(CancellationToken ct = default)
+    {
+        using var client = CreateHttpClient();
+        var response = await client.GetAsync($"{BaseUrl}/v2/account", ct).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var account = await response.Content.ReadFromJsonAsync(
+            AlpacaBrokerageSerializerContext.Default.AlpacaAccountResponse, ct).ConfigureAwait(false);
+
+        return new AccountInfo
+        {
+            AccountId = account?.AccountNumber ?? "unknown",
+            Equity = ParseDecimal(account?.Equity),
+            Cash = ParseDecimal(account?.Cash),
+            BuyingPower = ParseDecimal(account?.BuyingPower),
+            Currency = account?.Currency ?? "USD",
+            Status = account?.Status ?? "unknown",
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<BrokerPosition>> GetPositionsAsync(CancellationToken ct = default)
+    {
+        using var client = CreateHttpClient();
+        var response = await client.GetAsync($"{BaseUrl}/v2/positions", ct).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var positions = await response.Content.ReadFromJsonAsync(
+            AlpacaBrokerageSerializerContext.Default.AlpacaPositionResponseArray, ct).ConfigureAwait(false);
+
+        if (positions is null) return Array.Empty<BrokerPosition>();
+
+        return positions.Select(p => new BrokerPosition
+        {
+            Symbol = p.Symbol ?? string.Empty,
+            Quantity = ParseDecimal(p.Qty),
+            AverageEntryPrice = ParseDecimal(p.AvgEntryPrice),
+            MarketPrice = ParseDecimal(p.CurrentPrice),
+            MarketValue = ParseDecimal(p.MarketValue),
+            UnrealizedPnl = ParseDecimal(p.UnrealizedPl),
+            AssetClass = p.AssetClass ?? "equity",
+        }).ToList().AsReadOnly();
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<BrokerOrder>> GetOpenOrdersAsync(CancellationToken ct = default)
+    {
+        using var client = CreateHttpClient();
+        var response = await client.GetAsync($"{BaseUrl}/v2/orders?status=open", ct).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var orders = await response.Content.ReadFromJsonAsync(
+            AlpacaBrokerageSerializerContext.Default.AlpacaOrderResponseArray, ct).ConfigureAwait(false);
+
+        if (orders is null) return Array.Empty<BrokerOrder>();
+
+        return orders.Select(o => new BrokerOrder
+        {
+            OrderId = o.Id ?? string.Empty,
+            ClientOrderId = o.ClientOrderId,
+            Symbol = o.Symbol ?? string.Empty,
+            Side = o.Side == "sell" ? OrderSide.Sell : OrderSide.Buy,
+            Type = ParseOrderType(o.Type),
+            Quantity = ParseDecimal(o.Qty),
+            FilledQuantity = ParseDecimal(o.FilledQty),
+            LimitPrice = string.IsNullOrEmpty(o.LimitPrice) ? null : ParseDecimal(o.LimitPrice),
+            StopPrice = string.IsNullOrEmpty(o.StopPrice) ? null : ParseDecimal(o.StopPrice),
+            Status = MapAlpacaStatus(o.Status),
+            CreatedAt = o.CreatedAt ?? DateTimeOffset.UtcNow,
+        }).ToList().AsReadOnly();
+    }
+
+    /// <inheritdoc />
+    public async Task<BrokerHealthStatus> CheckHealthAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            if (!_connected) return BrokerHealthStatus.Unhealthy("Not connected");
+            var account = await GetAccountInfoAsync(ct).ConfigureAwait(false);
+            return account.Status == "active"
+                ? BrokerHealthStatus.Healthy($"Account {account.AccountId} active")
+                : BrokerHealthStatus.Unhealthy($"Account status: {account.Status}");
+        }
+        catch (Exception ex)
+        {
+            return BrokerHealthStatus.Unhealthy(ex.Message);
+        }
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync()
+    {
+        if (_disposed) return ValueTask.CompletedTask;
+        _disposed = true;
+        _connected = false;
+        _reportChannel.Writer.TryComplete();
+        return ValueTask.CompletedTask;
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private void EnsureConnected()
+    {
+        if (!_connected)
+            throw new InvalidOperationException("Alpaca brokerage gateway is not connected. Call ConnectAsync first.");
+    }
+
+    private HttpClient CreateHttpClient()
+    {
+        var client = _httpClientFactory.CreateClient("AlpacaBrokerage");
+        client.DefaultRequestHeaders.Add("APCA-API-KEY-ID", _options.KeyId);
+        client.DefaultRequestHeaders.Add("APCA-API-SECRET-KEY", _options.SecretKey);
+        return client;
+    }
+
+    private static string MapOrderType(OrderType type) => type switch
+    {
+        OrderType.Market => "market",
+        OrderType.Limit => "limit",
+        OrderType.StopMarket => "stop",
+        OrderType.StopLimit => "stop_limit",
+        _ => "market"
+    };
+
+    private static string MapTimeInForce(TimeInForce tif) => tif switch
+    {
+        TimeInForce.Day => "day",
+        TimeInForce.GoodTilCancelled => "gtc",
+        TimeInForce.ImmediateOrCancel => "ioc",
+        TimeInForce.FillOrKill => "fok",
+        _ => "day"
+    };
+
+    private static OrderStatus MapAlpacaStatus(string? status) => status switch
+    {
+        "new" => OrderStatus.Accepted,
+        "accepted" => OrderStatus.Accepted,
+        "pending_new" => OrderStatus.PendingNew,
+        "partially_filled" => OrderStatus.PartiallyFilled,
+        "filled" => OrderStatus.Filled,
+        "pending_cancel" => OrderStatus.PendingCancel,
+        "canceled" => OrderStatus.Cancelled,
+        "expired" => OrderStatus.Expired,
+        "rejected" => OrderStatus.Rejected,
+        _ => OrderStatus.PendingNew
+    };
+
+    private static OrderType ParseOrderType(string? type) => type switch
+    {
+        "market" => OrderType.Market,
+        "limit" => OrderType.Limit,
+        "stop" => OrderType.StopMarket,
+        "stop_limit" => OrderType.StopLimit,
+        _ => OrderType.Market
+    };
+
+    private static decimal ParseDecimal(string? value) =>
+        decimal.TryParse(value, out var result) ? result : 0m;
+
+    // ── JSON DTOs (ADR-014: source generators) ─────────────────────────
+
+    internal sealed class AlpacaOrderPayload
+    {
+        [JsonPropertyName("symbol")] public string? Symbol { get; set; }
+        [JsonPropertyName("qty")] public string? Qty { get; set; }
+        [JsonPropertyName("side")] public string? Side { get; set; }
+        [JsonPropertyName("type")] public string? Type { get; set; }
+        [JsonPropertyName("time_in_force")] public string? TimeInForce { get; set; }
+        [JsonPropertyName("limit_price")] public string? LimitPrice { get; set; }
+        [JsonPropertyName("stop_price")] public string? StopPrice { get; set; }
+        [JsonPropertyName("client_order_id")] public string? ClientOrderId { get; set; }
+    }
+
+    internal sealed class AlpacaOrderModifyPayload
+    {
+        [JsonPropertyName("qty")] public string? Qty { get; set; }
+        [JsonPropertyName("limit_price")] public string? LimitPrice { get; set; }
+        [JsonPropertyName("stop_price")] public string? StopPrice { get; set; }
+    }
+
+    internal sealed class AlpacaOrderResponse
+    {
+        [JsonPropertyName("id")] public string? Id { get; set; }
+        [JsonPropertyName("client_order_id")] public string? ClientOrderId { get; set; }
+        [JsonPropertyName("symbol")] public string? Symbol { get; set; }
+        [JsonPropertyName("side")] public string? Side { get; set; }
+        [JsonPropertyName("type")] public string? Type { get; set; }
+        [JsonPropertyName("qty")] public string? Qty { get; set; }
+        [JsonPropertyName("filled_qty")] public string? FilledQty { get; set; }
+        [JsonPropertyName("limit_price")] public string? LimitPrice { get; set; }
+        [JsonPropertyName("stop_price")] public string? StopPrice { get; set; }
+        [JsonPropertyName("status")] public string? Status { get; set; }
+        [JsonPropertyName("created_at")] public DateTimeOffset? CreatedAt { get; set; }
+    }
+
+    internal sealed class AlpacaAccountResponse
+    {
+        [JsonPropertyName("account_number")] public string? AccountNumber { get; set; }
+        [JsonPropertyName("equity")] public string? Equity { get; set; }
+        [JsonPropertyName("cash")] public string? Cash { get; set; }
+        [JsonPropertyName("buying_power")] public string? BuyingPower { get; set; }
+        [JsonPropertyName("currency")] public string? Currency { get; set; }
+        [JsonPropertyName("status")] public string? Status { get; set; }
+    }
+
+    internal sealed class AlpacaPositionResponse
+    {
+        [JsonPropertyName("symbol")] public string? Symbol { get; set; }
+        [JsonPropertyName("qty")] public string? Qty { get; set; }
+        [JsonPropertyName("avg_entry_price")] public string? AvgEntryPrice { get; set; }
+        [JsonPropertyName("current_price")] public string? CurrentPrice { get; set; }
+        [JsonPropertyName("market_value")] public string? MarketValue { get; set; }
+        [JsonPropertyName("unrealized_pl")] public string? UnrealizedPl { get; set; }
+        [JsonPropertyName("asset_class")] public string? AssetClass { get; set; }
+    }
+}
+
+/// <summary>
+/// Source-generated JSON serializer context for Alpaca brokerage DTOs (ADR-014).
+/// </summary>
+[JsonSerializable(typeof(AlpacaBrokerageGateway.AlpacaOrderPayload))]
+[JsonSerializable(typeof(AlpacaBrokerageGateway.AlpacaOrderModifyPayload))]
+[JsonSerializable(typeof(AlpacaBrokerageGateway.AlpacaOrderResponse))]
+[JsonSerializable(typeof(AlpacaBrokerageGateway.AlpacaOrderResponse[]))]
+[JsonSerializable(typeof(AlpacaBrokerageGateway.AlpacaAccountResponse))]
+[JsonSerializable(typeof(AlpacaBrokerageGateway.AlpacaPositionResponse[]))]
+[JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+internal sealed partial class AlpacaBrokerageSerializerContext : JsonSerializerContext;

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
+using Meridian.Application.Pipeline;
 using Meridian.Execution.Sdk;
 using Meridian.Infrastructure.Contracts;
 using Meridian.Infrastructure.DataSources;
@@ -42,6 +43,10 @@ public sealed class IBBrokerageGateway : IBrokerageGateway
     private volatile bool _connected;
     private bool _disposed;
     private int _nextOrderId;
+
+    // Tracks submitted orders so cancel/modify reports can carry the correct symbol and side.
+    // In a full TWS implementation the IB API provides this information via callbacks.
+    private readonly Dictionary<string, (string Symbol, OrderSide Side, string? ClientOrderId)> _submittedOrders = new();
 
     public IBBrokerageGateway(
         IBOptions options,
@@ -131,6 +136,10 @@ public sealed class IBBrokerageGateway : IBrokerageGateway
         // Build IB contract and order via the TWS API
         // This is where the IB API placeOrder() call would go
         var report = await SubmitToTwsAsync(orderId, request, ct).ConfigureAwait(false);
+
+        // Track submitted order so cancel/modify reports can carry the correct symbol and side.
+        _submittedOrders[orderId] = (request.Symbol, request.Side, request.ClientOrderId);
+
         await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
         return report;
     }
@@ -144,14 +153,18 @@ public sealed class IBBrokerageGateway : IBrokerageGateway
 
         _logger.LogInformation("IB cancelling order {OrderId}", orderId);
 
+        _submittedOrders.TryGetValue(orderId, out var tracked);
+
         // This is where the IB API cancelOrder() call would go
         var report = new ExecutionReport
         {
             OrderId = orderId,
+            ClientOrderId = tracked.ClientOrderId,
             ReportType = ExecutionReportType.Cancelled,
-            Symbol = string.Empty,
-            Side = OrderSide.Buy,
+            Symbol = tracked.Symbol ?? string.Empty,
+            Side = tracked.Symbol is not null ? tracked.Side : OrderSide.Buy,
             OrderStatus = OrderStatus.Cancelled,
+            GatewayOrderId = orderId,
             Timestamp = DateTimeOffset.UtcNow,
         };
         await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
@@ -169,14 +182,18 @@ public sealed class IBBrokerageGateway : IBrokerageGateway
 
         _logger.LogInformation("IB modifying order {OrderId}", orderId);
 
+        _submittedOrders.TryGetValue(orderId, out var tracked);
+
         // IB modification is done by re-placing the order with the same orderId
         var report = new ExecutionReport
         {
             OrderId = orderId,
+            ClientOrderId = tracked.ClientOrderId,
             ReportType = ExecutionReportType.Modified,
-            Symbol = string.Empty,
-            Side = OrderSide.Buy,
+            Symbol = tracked.Symbol ?? string.Empty,
+            Side = tracked.Symbol is not null ? tracked.Side : OrderSide.Buy,
             OrderStatus = OrderStatus.Accepted,
+            GatewayOrderId = orderId,
             Timestamp = DateTimeOffset.UtcNow,
         };
         await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
@@ -292,6 +309,7 @@ public sealed class IBBrokerageGateway : IBrokerageGateway
         return Task.FromResult(new ExecutionReport
         {
             OrderId = orderId,
+            ClientOrderId = request.ClientOrderId,
             ReportType = ExecutionReportType.New,
             Symbol = request.Symbol,
             Side = request.Side,

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
+using Meridian.Application.Pipeline;
 using Meridian.Execution.Sdk;
 using Meridian.Infrastructure.Contracts;
 using Meridian.Infrastructure.DataSources;

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs
@@ -49,8 +49,7 @@ public sealed class IBBrokerageGateway : IBrokerageGateway
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _reportChannel = Channel.CreateBounded<ExecutionReport>(
-            new BoundedChannelOptions(500) { FullMode = BoundedChannelFullMode.Wait });
+        _reportChannel = EventPipelinePolicy.CompletionQueue.CreateChannel<ExecutionReport>();
     }
 
     /// <inheritdoc />

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs
@@ -1,0 +1,305 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Meridian.Execution.Sdk;
+using Meridian.Infrastructure.Contracts;
+using Meridian.Infrastructure.DataSources;
+using Microsoft.Extensions.Logging;
+using IBOptions = Meridian.Application.Config.IBOptions;
+using OrderSide = Meridian.Execution.Sdk.OrderSide;
+using OrderType = Meridian.Execution.Sdk.OrderType;
+using OrderStatus = Meridian.Execution.Sdk.OrderStatus;
+using TimeInForce = Meridian.Execution.Sdk.TimeInForce;
+
+namespace Meridian.Infrastructure.Adapters.InteractiveBrokers;
+
+/// <summary>
+/// Interactive Brokers brokerage gateway for live order execution via the TWS/Gateway API.
+/// Communicates with IB TWS or IB Gateway running locally. Supports equities, options,
+/// futures, and forex.
+/// </summary>
+/// <remarks>
+/// IB TWS API:
+/// - Connects to TWS or IB Gateway on localhost (default port 7496 live, 7497 paper)
+/// - Full order lifecycle: submit, modify, cancel with real-time execution reports
+/// - Supports market, limit, stop, stop-limit, and many more order types
+/// - Supports partial fills and order modification
+/// - Rate limit: 50 messages/sec
+///
+/// This implementation provides the brokerage abstraction layer. The actual TWS API
+/// communication is delegated to the IB connection infrastructure. When IBAPI is not
+/// compiled in, this gateway operates in simulation mode using synthetic responses.
+/// </remarks>
+[DataSource("ib-brokerage", "Interactive Brokers Brokerage", DataSourceType.Realtime, DataSourceCategory.Broker,
+    Priority = 5, Description = "Interactive Brokers TWS/Gateway order execution")]
+[ImplementsAdr("ADR-001", "IB brokerage provider implementation")]
+[ImplementsAdr("ADR-004", "All async methods support CancellationToken")]
+[ImplementsAdr("ADR-005", "Attribute-based provider discovery")]
+public sealed class IBBrokerageGateway : IBrokerageGateway
+{
+    private readonly IBOptions _options;
+    private readonly ILogger<IBBrokerageGateway> _logger;
+    private readonly Channel<ExecutionReport> _reportChannel;
+    private volatile bool _connected;
+    private bool _disposed;
+    private int _nextOrderId;
+
+    public IBBrokerageGateway(
+        IBOptions options,
+        ILogger<IBBrokerageGateway> logger)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _reportChannel = Channel.CreateBounded<ExecutionReport>(
+            new BoundedChannelOptions(500) { FullMode = BoundedChannelFullMode.Wait });
+    }
+
+    /// <inheritdoc />
+    public string GatewayId => "ib";
+
+    /// <inheritdoc />
+    public bool IsConnected => _connected;
+
+    /// <inheritdoc />
+    public string BrokerDisplayName => "Interactive Brokers";
+
+    /// <inheritdoc />
+    public BrokerageCapabilities BrokerageCapabilities { get; } = new()
+    {
+        SupportedOrderTypes = new HashSet<OrderType>
+        {
+            OrderType.Market,
+            OrderType.Limit,
+            OrderType.StopMarket,
+            OrderType.StopLimit
+        },
+        SupportedTimeInForce = new HashSet<TimeInForce>
+        {
+            TimeInForce.Day,
+            TimeInForce.GoodTilCancelled,
+            TimeInForce.ImmediateOrCancel,
+            TimeInForce.FillOrKill
+        },
+        SupportsOrderModification = true,
+        SupportsPartialFills = true,
+        SupportsShortSelling = true,
+        SupportsFractionalShares = false,
+        SupportsExtendedHours = true,
+        SupportedAssetClasses = ["equity", "option", "futures", "forex"],
+        SupportedMarkets = ["US", "EU", "APAC"],
+    };
+
+    /// <inheritdoc />
+    public async Task ConnectAsync(CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_connected) return;
+
+        _logger.LogInformation(
+            "IB brokerage connecting to {Host}:{Port} (clientId={ClientId}, paper={Paper})",
+            _options.Host, _options.Port, _options.ClientId, _options.UsePaperTrading);
+
+        // Connection to TWS/Gateway via the IB API
+        // In non-IBAPI mode, we validate connectivity by checking host/port reachability
+        await ValidateConnectionAsync(ct).ConfigureAwait(false);
+
+        _connected = true;
+        _nextOrderId = 1;
+
+        _logger.LogInformation("IB brokerage connected to {Host}:{Port}", _options.Host, _options.Port);
+    }
+
+    /// <inheritdoc />
+    public Task DisconnectAsync(CancellationToken ct = default)
+    {
+        _connected = false;
+        _logger.LogInformation("IB brokerage disconnected");
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async Task<ExecutionReport> SubmitOrderAsync(OrderRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        EnsureConnected();
+
+        var orderId = request.ClientOrderId ?? GenerateOrderId();
+
+        _logger.LogInformation(
+            "IB submitting order {OrderId}: {Side} {Quantity} {Symbol} @ {Type}",
+            orderId, request.Side, request.Quantity, request.Symbol, request.Type);
+
+        // Build IB contract and order via the TWS API
+        // This is where the IB API placeOrder() call would go
+        var report = await SubmitToTwsAsync(orderId, request, ct).ConfigureAwait(false);
+        await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
+        return report;
+    }
+
+    /// <inheritdoc />
+    public async Task<ExecutionReport> CancelOrderAsync(string orderId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        EnsureConnected();
+
+        _logger.LogInformation("IB cancelling order {OrderId}", orderId);
+
+        // This is where the IB API cancelOrder() call would go
+        var report = new ExecutionReport
+        {
+            OrderId = orderId,
+            ReportType = ExecutionReportType.Cancelled,
+            Symbol = string.Empty,
+            Side = OrderSide.Buy,
+            OrderStatus = OrderStatus.Cancelled,
+            Timestamp = DateTimeOffset.UtcNow,
+        };
+        await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
+        return report;
+    }
+
+    /// <inheritdoc />
+    public async Task<ExecutionReport> ModifyOrderAsync(
+        string orderId, OrderModification modification, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
+        ArgumentNullException.ThrowIfNull(modification);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        EnsureConnected();
+
+        _logger.LogInformation("IB modifying order {OrderId}", orderId);
+
+        // IB modification is done by re-placing the order with the same orderId
+        var report = new ExecutionReport
+        {
+            OrderId = orderId,
+            ReportType = ExecutionReportType.Modified,
+            Symbol = string.Empty,
+            Side = OrderSide.Buy,
+            OrderStatus = OrderStatus.Accepted,
+            Timestamp = DateTimeOffset.UtcNow,
+        };
+        await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
+        return report;
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<ExecutionReport> StreamExecutionReportsAsync(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await foreach (var report in _reportChannel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+        {
+            yield return report;
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<AccountInfo> GetAccountInfoAsync(CancellationToken ct = default)
+    {
+        EnsureConnected();
+
+        // In a full implementation, this calls reqAccountSummary() on the IB API
+        // and awaits the accountSummary() callback
+        return Task.FromResult(new AccountInfo
+        {
+            AccountId = $"IB-{_options.ClientId}",
+            Equity = 0m,
+            Cash = 0m,
+            BuyingPower = 0m,
+            Currency = "USD",
+            Status = _options.UsePaperTrading ? "paper" : "active",
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<BrokerPosition>> GetPositionsAsync(CancellationToken ct = default)
+    {
+        EnsureConnected();
+
+        // In a full implementation, this calls reqPositions() on the IB API
+        // and collects position() callbacks
+        return Task.FromResult<IReadOnlyList<BrokerPosition>>(Array.Empty<BrokerPosition>());
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<BrokerOrder>> GetOpenOrdersAsync(CancellationToken ct = default)
+    {
+        EnsureConnected();
+
+        // In a full implementation, this calls reqOpenOrders() on the IB API
+        // and collects openOrder()/orderStatus() callbacks
+        return Task.FromResult<IReadOnlyList<BrokerOrder>>(Array.Empty<BrokerOrder>());
+    }
+
+    /// <inheritdoc />
+    public Task<BrokerHealthStatus> CheckHealthAsync(CancellationToken ct = default)
+    {
+        if (!_connected)
+            return Task.FromResult(BrokerHealthStatus.Unhealthy("Not connected to TWS/Gateway"));
+
+        return Task.FromResult(BrokerHealthStatus.Healthy(
+            $"Connected to {_options.Host}:{_options.Port} (client {_options.ClientId})"));
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync()
+    {
+        if (_disposed) return ValueTask.CompletedTask;
+        _disposed = true;
+        _connected = false;
+        _reportChannel.Writer.TryComplete();
+        return ValueTask.CompletedTask;
+    }
+
+    // ── Private helpers ─────────────────────────────────────────────────
+
+    private void EnsureConnected()
+    {
+        if (!_connected)
+            throw new InvalidOperationException("IB brokerage gateway is not connected. Call ConnectAsync first.");
+    }
+
+    private string GenerateOrderId()
+    {
+        var id = Interlocked.Increment(ref _nextOrderId);
+        return $"IB-{DateTimeOffset.UtcNow:yyyyMMdd}-{id:D6}";
+    }
+
+    private Task ValidateConnectionAsync(CancellationToken ct)
+    {
+        // In non-IBAPI builds, validate that a TWS/Gateway endpoint is configured.
+        // When IBAPI is available, this would call EClientSocket.eConnect().
+        if (string.IsNullOrWhiteSpace(_options.Host))
+            throw new InvalidOperationException("IB Host is not configured.");
+
+        if (_options.Port <= 0 || _options.Port > 65535)
+            throw new InvalidOperationException($"IB Port {_options.Port} is invalid.");
+
+        _logger.LogInformation("IB connection validated for {Host}:{Port}", _options.Host, _options.Port);
+        return Task.CompletedTask;
+    }
+
+    private Task<ExecutionReport> SubmitToTwsAsync(string orderId, OrderRequest request, CancellationToken ct)
+    {
+        // In a full IBAPI implementation, this would:
+        // 1. Build an IB Contract (symbol, secType, exchange, currency)
+        // 2. Build an IB Order (action, orderType, totalQuantity, lmtPrice, auxPrice, tif)
+        // 3. Call _client.placeOrder(nextValidOrderId, contract, order)
+        // 4. Await the orderStatus() callback
+
+        // For now, return an accepted report. The actual fill will come via the
+        // TWS callback pipeline when IBAPI is integrated.
+        return Task.FromResult(new ExecutionReport
+        {
+            OrderId = orderId,
+            ReportType = ExecutionReportType.New,
+            Symbol = request.Symbol,
+            Side = request.Side,
+            OrderStatus = OrderStatus.Accepted,
+            OrderQuantity = request.Quantity,
+            GatewayOrderId = orderId,
+            Timestamp = DateTimeOffset.UtcNow,
+        });
+    }
+}

--- a/src/Meridian.Infrastructure/Adapters/StockSharp/StockSharpBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/StockSharp/StockSharpBrokerageGateway.cs
@@ -1,0 +1,247 @@
+#if STOCKSHARP
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Meridian.Execution.Sdk;
+using Meridian.Infrastructure.Contracts;
+using Meridian.Infrastructure.DataSources;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Infrastructure.Adapters.StockSharp;
+
+/// <summary>
+/// StockSharp-based brokerage gateway that supports 90+ brokers and exchanges
+/// through StockSharp's unified connector framework. Supports Rithmic, CQG,
+/// IQFeed, Interactive Brokers via StockSharp, and many more.
+/// </summary>
+/// <remarks>
+/// StockSharp Connector features:
+/// - Unified adapter pattern: one gateway, many underlying brokers
+/// - Native order types per adapter (market, limit, stop, conditional)
+/// - Real-time execution reports via Connector.NewOrder / OrderChanged events
+/// - Portfolio and position sync via Connector.PortfolioChanged
+/// - Rate limits vary by underlying adapter
+/// </remarks>
+[DataSource("stocksharp-brokerage", "StockSharp Brokerage", DataSourceType.Realtime, DataSourceCategory.Broker,
+    Priority = 20, Description = "StockSharp unified brokerage gateway (Rithmic, CQG, IB, etc.)")]
+[ImplementsAdr("ADR-001", "StockSharp brokerage provider implementation")]
+[ImplementsAdr("ADR-004", "All async methods support CancellationToken")]
+[ImplementsAdr("ADR-005", "Attribute-based provider discovery")]
+public sealed class StockSharpBrokerageGateway : IBrokerageGateway
+{
+    private readonly ILogger<StockSharpBrokerageGateway> _logger;
+    private readonly Channel<ExecutionReport> _reportChannel;
+    private volatile bool _connected;
+    private bool _disposed;
+
+    /// <summary>The underlying StockSharp adapter type (e.g., "Rithmic", "CQG", "IB").</summary>
+    private readonly string _adapterType;
+
+    public StockSharpBrokerageGateway(
+        string adapterType,
+        ILogger<StockSharpBrokerageGateway> logger)
+    {
+        _adapterType = adapterType ?? throw new ArgumentNullException(nameof(adapterType));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _reportChannel = Channel.CreateBounded<ExecutionReport>(
+            new BoundedChannelOptions(500) { FullMode = BoundedChannelFullMode.Wait });
+    }
+
+    /// <inheritdoc />
+    public string GatewayId => $"stocksharp-{_adapterType.ToLowerInvariant()}";
+
+    /// <inheritdoc />
+    public bool IsConnected => _connected;
+
+    /// <inheritdoc />
+    public string BrokerDisplayName => $"StockSharp ({_adapterType})";
+
+    /// <inheritdoc />
+    public BrokerageCapabilities BrokerageCapabilities { get; } =
+        BrokerageCapabilities.UsEquity(
+            modification: true,
+            partialFills: true,
+            shortSelling: true,
+            fractional: false,
+            extendedHours: false);
+
+    /// <inheritdoc />
+    public async Task ConnectAsync(CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_connected) return;
+
+        _logger.LogInformation("StockSharp ({Adapter}) brokerage connecting...", _adapterType);
+
+        // In a full implementation, this would:
+        // 1. Create the StockSharp Connector with the appropriate adapter
+        // 2. Configure adapter-specific settings
+        // 3. Call Connector.Connect()
+        // 4. Wire up Connector.NewOrder, Connector.OrderChanged,
+        //    Connector.OrderRegisterFailed events to the report channel
+
+        await Task.CompletedTask.ConfigureAwait(false);
+        _connected = true;
+
+        _logger.LogInformation("StockSharp ({Adapter}) brokerage connected", _adapterType);
+    }
+
+    /// <inheritdoc />
+    public Task DisconnectAsync(CancellationToken ct = default)
+    {
+        _connected = false;
+        _logger.LogInformation("StockSharp ({Adapter}) brokerage disconnected", _adapterType);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async Task<ExecutionReport> SubmitOrderAsync(OrderRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        EnsureConnected();
+
+        var orderId = request.ClientOrderId ?? $"SS-{Guid.NewGuid():N}";
+
+        _logger.LogInformation(
+            "StockSharp ({Adapter}) submitting: {Side} {Quantity} {Symbol} @ {Type}",
+            _adapterType, request.Side, request.Quantity, request.Symbol, request.Type);
+
+        // In a full implementation, this would:
+        // 1. Create a StockSharp Security for the symbol
+        // 2. Create a StockSharp Order with the appropriate type/price/qty
+        // 3. Call Connector.RegisterOrder(order)
+        // 4. Return the initial report; fills arrive via events
+
+        var report = new ExecutionReport
+        {
+            OrderId = orderId,
+            ReportType = ExecutionReportType.New,
+            Symbol = request.Symbol,
+            Side = request.Side,
+            OrderStatus = OrderStatus.Accepted,
+            OrderQuantity = request.Quantity,
+            GatewayOrderId = orderId,
+            Timestamp = DateTimeOffset.UtcNow,
+        };
+        await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
+        return report;
+    }
+
+    /// <inheritdoc />
+    public async Task<ExecutionReport> CancelOrderAsync(string orderId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        EnsureConnected();
+
+        _logger.LogInformation("StockSharp ({Adapter}) cancelling {OrderId}", _adapterType, orderId);
+
+        // Connector.CancelOrder(order)
+        var report = new ExecutionReport
+        {
+            OrderId = orderId,
+            ReportType = ExecutionReportType.Cancelled,
+            Symbol = string.Empty,
+            Side = OrderSide.Buy,
+            OrderStatus = OrderStatus.Cancelled,
+            Timestamp = DateTimeOffset.UtcNow,
+        };
+        await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
+        return report;
+    }
+
+    /// <inheritdoc />
+    public async Task<ExecutionReport> ModifyOrderAsync(
+        string orderId, OrderModification modification, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
+        ArgumentNullException.ThrowIfNull(modification);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        EnsureConnected();
+
+        _logger.LogInformation("StockSharp ({Adapter}) modifying {OrderId}", _adapterType, orderId);
+
+        // Connector.ReRegisterOrder(oldOrder, newOrder)
+        var report = new ExecutionReport
+        {
+            OrderId = orderId,
+            ReportType = ExecutionReportType.Modified,
+            Symbol = string.Empty,
+            Side = OrderSide.Buy,
+            OrderStatus = OrderStatus.Accepted,
+            Timestamp = DateTimeOffset.UtcNow,
+        };
+        await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
+        return report;
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<ExecutionReport> StreamExecutionReportsAsync(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await foreach (var report in _reportChannel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+        {
+            yield return report;
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<AccountInfo> GetAccountInfoAsync(CancellationToken ct = default)
+    {
+        EnsureConnected();
+
+        // Connector.Portfolios / Connector.GetPortfolioValue()
+        return Task.FromResult(new AccountInfo
+        {
+            AccountId = $"SS-{_adapterType}",
+            Equity = 0m,
+            Cash = 0m,
+            BuyingPower = 0m,
+            Currency = "USD",
+            Status = "active",
+        });
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<BrokerPosition>> GetPositionsAsync(CancellationToken ct = default)
+    {
+        EnsureConnected();
+        // Connector.Positions
+        return Task.FromResult<IReadOnlyList<BrokerPosition>>(Array.Empty<BrokerPosition>());
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<BrokerOrder>> GetOpenOrdersAsync(CancellationToken ct = default)
+    {
+        EnsureConnected();
+        // Connector.Orders.Where(o => o.State == OrderStates.Active)
+        return Task.FromResult<IReadOnlyList<BrokerOrder>>(Array.Empty<BrokerOrder>());
+    }
+
+    /// <inheritdoc />
+    public Task<BrokerHealthStatus> CheckHealthAsync(CancellationToken ct = default)
+    {
+        if (!_connected)
+            return Task.FromResult(BrokerHealthStatus.Unhealthy("Not connected"));
+
+        return Task.FromResult(BrokerHealthStatus.Healthy($"StockSharp {_adapterType} connected"));
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync()
+    {
+        if (_disposed) return ValueTask.CompletedTask;
+        _disposed = true;
+        _connected = false;
+        _reportChannel.Writer.TryComplete();
+        return ValueTask.CompletedTask;
+    }
+
+    private void EnsureConnected()
+    {
+        if (!_connected)
+            throw new InvalidOperationException(
+                $"StockSharp ({_adapterType}) brokerage gateway is not connected. Call ConnectAsync first.");
+    }
+}
+#endif

--- a/src/Meridian.Infrastructure/Adapters/StockSharp/StockSharpBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/StockSharp/StockSharpBrokerageGateway.cs
@@ -1,6 +1,6 @@
 #if STOCKSHARP
 using System.Runtime.CompilerServices;
-using System.Threading.Channels;
+using Meridian.Application.Pipeline;
 using Meridian.Execution.Sdk;
 using Meridian.Infrastructure.Contracts;
 using Meridian.Infrastructure.DataSources;
@@ -36,14 +36,17 @@ public sealed class StockSharpBrokerageGateway : IBrokerageGateway
     /// <summary>The underlying StockSharp adapter type (e.g., "Rithmic", "CQG", "IB").</summary>
     private readonly string _adapterType;
 
+    // Tracks submitted orders so cancel/modify reports can carry the correct symbol and side.
+    // In a full StockSharp implementation the Connector raises events with order details.
+    private readonly Dictionary<string, (string Symbol, OrderSide Side, string? ClientOrderId)> _submittedOrders = new();
+
     public StockSharpBrokerageGateway(
         string adapterType,
         ILogger<StockSharpBrokerageGateway> logger)
     {
         _adapterType = adapterType ?? throw new ArgumentNullException(nameof(adapterType));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _reportChannel = Channel.CreateBounded<ExecutionReport>(
-            new BoundedChannelOptions(500) { FullMode = BoundedChannelFullMode.Wait });
+        _reportChannel = EventPipelinePolicy.Default.CreateChannel<ExecutionReport>();
     }
 
     /// <inheritdoc />
@@ -115,6 +118,7 @@ public sealed class StockSharpBrokerageGateway : IBrokerageGateway
         var report = new ExecutionReport
         {
             OrderId = orderId,
+            ClientOrderId = request.ClientOrderId,
             ReportType = ExecutionReportType.New,
             Symbol = request.Symbol,
             Side = request.Side,
@@ -123,6 +127,10 @@ public sealed class StockSharpBrokerageGateway : IBrokerageGateway
             GatewayOrderId = orderId,
             Timestamp = DateTimeOffset.UtcNow,
         };
+
+        // Track submitted order so cancel/modify reports carry the correct symbol and side.
+        _submittedOrders[orderId] = (request.Symbol, request.Side, request.ClientOrderId);
+
         await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
         return report;
     }
@@ -136,14 +144,18 @@ public sealed class StockSharpBrokerageGateway : IBrokerageGateway
 
         _logger.LogInformation("StockSharp ({Adapter}) cancelling {OrderId}", _adapterType, orderId);
 
+        _submittedOrders.TryGetValue(orderId, out var tracked);
+
         // Connector.CancelOrder(order)
         var report = new ExecutionReport
         {
             OrderId = orderId,
+            ClientOrderId = tracked.ClientOrderId,
             ReportType = ExecutionReportType.Cancelled,
-            Symbol = string.Empty,
-            Side = OrderSide.Buy,
+            Symbol = tracked.Symbol ?? string.Empty,
+            Side = tracked.Symbol is not null ? tracked.Side : OrderSide.Buy,
             OrderStatus = OrderStatus.Cancelled,
+            GatewayOrderId = orderId,
             Timestamp = DateTimeOffset.UtcNow,
         };
         await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
@@ -161,14 +173,18 @@ public sealed class StockSharpBrokerageGateway : IBrokerageGateway
 
         _logger.LogInformation("StockSharp ({Adapter}) modifying {OrderId}", _adapterType, orderId);
 
+        _submittedOrders.TryGetValue(orderId, out var tracked);
+
         // Connector.ReRegisterOrder(oldOrder, newOrder)
         var report = new ExecutionReport
         {
             OrderId = orderId,
+            ClientOrderId = tracked.ClientOrderId,
             ReportType = ExecutionReportType.Modified,
-            Symbol = string.Empty,
-            Side = OrderSide.Buy,
+            Symbol = tracked.Symbol ?? string.Empty,
+            Side = tracked.Symbol is not null ? tracked.Side : OrderSide.Buy,
             OrderStatus = OrderStatus.Accepted,
+            GatewayOrderId = orderId,
             Timestamp = DateTimeOffset.UtcNow,
         };
         await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);

--- a/src/Meridian.Infrastructure/Adapters/StockSharp/StockSharpBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/StockSharp/StockSharpBrokerageGateway.cs
@@ -1,6 +1,7 @@
 #if STOCKSHARP
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
+using Meridian.Application.Pipeline;
 using Meridian.Execution.Sdk;
 using Meridian.Infrastructure.Contracts;
 using Meridian.Infrastructure.DataSources;
@@ -42,8 +43,8 @@ public sealed class StockSharpBrokerageGateway : IBrokerageGateway
     {
         _adapterType = adapterType ?? throw new ArgumentNullException(nameof(adapterType));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _reportChannel = Channel.CreateBounded<ExecutionReport>(
-            new BoundedChannelOptions(500) { FullMode = BoundedChannelFullMode.Wait });
+        _reportChannel = EventPipelinePolicy.Default.CreateChannel<ExecutionReport>(
+            singleReader: false, singleWriter: false);
     }
 
     /// <inheritdoc />

--- a/src/Meridian.Infrastructure/Adapters/Templates/TemplateBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/Templates/TemplateBrokerageGateway.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
+using Meridian.Application.Pipeline;
 using Meridian.Execution.Sdk;
 using Microsoft.Extensions.Logging;
 using OrderSide = Meridian.Execution.Sdk.OrderSide;
@@ -38,13 +39,16 @@ public sealed class TemplateBrokerageGateway : IBrokerageGateway
     private volatile bool _connected;
     private bool _disposed;
 
+    // Tracks submitted orders so cancel/modify reports carry the correct symbol and side.
+    // TODO: In a full implementation, prefer querying the broker's API for live order state.
+    private readonly Dictionary<string, (string Symbol, OrderSide Side, string? ClientOrderId)> _submittedOrders = new();
+
     public TemplateBrokerageGateway(
         // TODO: Add IHttpClientFactory, options, etc.
         ILogger<TemplateBrokerageGateway> logger)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _reportChannel = Channel.CreateBounded<ExecutionReport>(
-            new BoundedChannelOptions(500) { FullMode = BoundedChannelFullMode.Wait });
+        _reportChannel = EventPipelinePolicy.Default.CreateChannel<ExecutionReport>();
     }
 
     // TODO: Change to your broker's ID (lowercase, no spaces)
@@ -103,6 +107,7 @@ public sealed class TemplateBrokerageGateway : IBrokerageGateway
         var report = new ExecutionReport
         {
             OrderId = orderId,
+            ClientOrderId = request.ClientOrderId,
             ReportType = ExecutionReportType.New,
             Symbol = request.Symbol,
             Side = request.Side,
@@ -111,6 +116,10 @@ public sealed class TemplateBrokerageGateway : IBrokerageGateway
             GatewayOrderId = orderId,
             Timestamp = DateTimeOffset.UtcNow,
         };
+
+        // Track submitted order so cancel/modify reports carry the correct symbol and side.
+        _submittedOrders[orderId] = (request.Symbol, request.Side, request.ClientOrderId);
+
         await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
         return report;
     }
@@ -121,14 +130,19 @@ public sealed class TemplateBrokerageGateway : IBrokerageGateway
         EnsureConnected();
 
         // TODO: Call your broker's cancel API
+        // TODO: For brokers that return order details on cancel, use the response to populate Symbol/Side.
+
+        _submittedOrders.TryGetValue(orderId, out var tracked);
 
         var report = new ExecutionReport
         {
             OrderId = orderId,
+            ClientOrderId = tracked.ClientOrderId,
             ReportType = ExecutionReportType.Cancelled,
-            Symbol = string.Empty,
-            Side = OrderSide.Buy,
+            Symbol = tracked.Symbol ?? string.Empty,
+            Side = tracked.Symbol is not null ? tracked.Side : OrderSide.Buy,
             OrderStatus = OrderStatus.Cancelled,
+            GatewayOrderId = orderId,
             Timestamp = DateTimeOffset.UtcNow,
         };
         await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
@@ -144,13 +158,17 @@ public sealed class TemplateBrokerageGateway : IBrokerageGateway
         // TODO: Call your broker's modify/amend API
         // Some brokers require cancel-replace instead of in-place modification
 
+        _submittedOrders.TryGetValue(orderId, out var tracked);
+
         var report = new ExecutionReport
         {
             OrderId = orderId,
+            ClientOrderId = tracked.ClientOrderId,
             ReportType = ExecutionReportType.Modified,
-            Symbol = string.Empty,
-            Side = OrderSide.Buy,
+            Symbol = tracked.Symbol ?? string.Empty,
+            Side = tracked.Symbol is not null ? tracked.Side : OrderSide.Buy,
             OrderStatus = OrderStatus.Accepted,
+            GatewayOrderId = orderId,
             Timestamp = DateTimeOffset.UtcNow,
         };
         await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);

--- a/src/Meridian.Infrastructure/Adapters/Templates/TemplateBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/Templates/TemplateBrokerageGateway.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
+using Meridian.Application.Pipeline;
 using Meridian.Execution.Sdk;
 using Microsoft.Extensions.Logging;
 using OrderSide = Meridian.Execution.Sdk.OrderSide;
@@ -43,8 +44,8 @@ public sealed class TemplateBrokerageGateway : IBrokerageGateway
         ILogger<TemplateBrokerageGateway> logger)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _reportChannel = Channel.CreateBounded<ExecutionReport>(
-            new BoundedChannelOptions(500) { FullMode = BoundedChannelFullMode.Wait });
+        _reportChannel = EventPipelinePolicy.Default.CreateChannel<ExecutionReport>(
+            singleReader: false, singleWriter: false);
     }
 
     // TODO: Change to your broker's ID (lowercase, no spaces)

--- a/src/Meridian.Infrastructure/Adapters/Templates/TemplateBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/Templates/TemplateBrokerageGateway.cs
@@ -1,0 +1,225 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Meridian.Execution.Sdk;
+using Microsoft.Extensions.Logging;
+using OrderSide = Meridian.Execution.Sdk.OrderSide;
+using OrderType = Meridian.Execution.Sdk.OrderType;
+using OrderStatus = Meridian.Execution.Sdk.OrderStatus;
+using TimeInForce = Meridian.Execution.Sdk.TimeInForce;
+
+namespace Meridian.Infrastructure.Adapters.Templates;
+
+/// <summary>
+/// Template brokerage gateway scaffold. Copy this file and fill in the TODOs
+/// to implement a new brokerage provider.
+///
+/// Steps to implement a new brokerage:
+/// 1. Copy this file to a new folder under Adapters/{BrokerName}/
+/// 2. Rename the class to {BrokerName}BrokerageGateway
+/// 3. Add [DataSource] and [ImplementsAdr] attributes
+/// 4. Implement all TODO methods with broker-specific API calls
+/// 5. Add JSON DTOs and a JsonSerializerContext for ADR-014 compliance
+/// 6. Register in DI: services.AddBrokerageGateway&lt;{BrokerName}BrokerageGateway&gt;()
+/// 7. Add configuration options record if needed
+/// 8. Add tests under tests/Meridian.Tests/Brokerage/
+/// </summary>
+// TODO: Add attributes:
+// [DataSource("your-broker", "Your Broker Name", DataSourceType.Realtime, DataSourceCategory.Broker,
+//     Priority = 15, Description = "Your broker order execution gateway")]
+// [ImplementsAdr("ADR-001", "Your broker brokerage provider implementation")]
+// [ImplementsAdr("ADR-004", "All async methods support CancellationToken")]
+// [ImplementsAdr("ADR-005", "Attribute-based provider discovery")]
+// [ImplementsAdr("ADR-010", "Uses IHttpClientFactory for HTTP connections")]
+public sealed class TemplateBrokerageGateway : IBrokerageGateway
+{
+    // TODO: Add your broker's HTTP client factory, config options, etc.
+    private readonly ILogger<TemplateBrokerageGateway> _logger;
+    private readonly Channel<ExecutionReport> _reportChannel;
+    private volatile bool _connected;
+    private bool _disposed;
+
+    public TemplateBrokerageGateway(
+        // TODO: Add IHttpClientFactory, options, etc.
+        ILogger<TemplateBrokerageGateway> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _reportChannel = Channel.CreateBounded<ExecutionReport>(
+            new BoundedChannelOptions(500) { FullMode = BoundedChannelFullMode.Wait });
+    }
+
+    // TODO: Change to your broker's ID (lowercase, no spaces)
+    public string GatewayId => "template";
+
+    public bool IsConnected => _connected;
+
+    // TODO: Change to your broker's display name
+    public string BrokerDisplayName => "Template Broker";
+
+    // TODO: Configure capabilities for your broker
+    public BrokerageCapabilities BrokerageCapabilities { get; } =
+        BrokerageCapabilities.UsEquity(
+            modification: true,
+            partialFills: true,
+            shortSelling: false,
+            fractional: false,
+            extendedHours: false);
+
+    public async Task ConnectAsync(CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_connected) return;
+
+        // TODO: Authenticate with your broker's API
+        // - Validate credentials
+        // - Establish WebSocket connection if needed
+        // - Fetch initial account state
+        await Task.CompletedTask.ConfigureAwait(false);
+
+        _connected = true;
+        _logger.LogInformation("Template broker connected");
+    }
+
+    public Task DisconnectAsync(CancellationToken ct = default)
+    {
+        // TODO: Close WebSocket/API connections
+        _connected = false;
+        return Task.CompletedTask;
+    }
+
+    public async Task<ExecutionReport> SubmitOrderAsync(OrderRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        EnsureConnected();
+
+        // TODO: Translate OrderRequest to your broker's order format and submit
+        // Example:
+        //   var brokerOrder = MapToBrokerOrder(request);
+        //   var response = await _httpClient.PostAsJsonAsync("/orders", brokerOrder, ct);
+        //   var brokerResponse = await response.Content.ReadFromJsonAsync<BrokerOrderResponse>(ct);
+
+        var orderId = request.ClientOrderId ?? Guid.NewGuid().ToString("N");
+
+        var report = new ExecutionReport
+        {
+            OrderId = orderId,
+            ReportType = ExecutionReportType.New,
+            Symbol = request.Symbol,
+            Side = request.Side,
+            OrderStatus = OrderStatus.Accepted,
+            OrderQuantity = request.Quantity,
+            GatewayOrderId = orderId,
+            Timestamp = DateTimeOffset.UtcNow,
+        };
+        await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
+        return report;
+    }
+
+    public async Task<ExecutionReport> CancelOrderAsync(string orderId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
+        EnsureConnected();
+
+        // TODO: Call your broker's cancel API
+
+        var report = new ExecutionReport
+        {
+            OrderId = orderId,
+            ReportType = ExecutionReportType.Cancelled,
+            Symbol = string.Empty,
+            Side = OrderSide.Buy,
+            OrderStatus = OrderStatus.Cancelled,
+            Timestamp = DateTimeOffset.UtcNow,
+        };
+        await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
+        return report;
+    }
+
+    public async Task<ExecutionReport> ModifyOrderAsync(
+        string orderId, OrderModification modification, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
+        EnsureConnected();
+
+        // TODO: Call your broker's modify/amend API
+        // Some brokers require cancel-replace instead of in-place modification
+
+        var report = new ExecutionReport
+        {
+            OrderId = orderId,
+            ReportType = ExecutionReportType.Modified,
+            Symbol = string.Empty,
+            Side = OrderSide.Buy,
+            OrderStatus = OrderStatus.Accepted,
+            Timestamp = DateTimeOffset.UtcNow,
+        };
+        await _reportChannel.Writer.WriteAsync(report, ct).ConfigureAwait(false);
+        return report;
+    }
+
+    public async IAsyncEnumerable<ExecutionReport> StreamExecutionReportsAsync(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await foreach (var report in _reportChannel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+        {
+            yield return report;
+        }
+    }
+
+    public Task<AccountInfo> GetAccountInfoAsync(CancellationToken ct = default)
+    {
+        EnsureConnected();
+
+        // TODO: Call your broker's account endpoint
+        return Task.FromResult(new AccountInfo
+        {
+            AccountId = "template-account",
+            Equity = 0m,
+            Cash = 0m,
+            BuyingPower = 0m,
+        });
+    }
+
+    public Task<IReadOnlyList<BrokerPosition>> GetPositionsAsync(CancellationToken ct = default)
+    {
+        EnsureConnected();
+        // TODO: Call your broker's positions endpoint
+        return Task.FromResult<IReadOnlyList<BrokerPosition>>(Array.Empty<BrokerPosition>());
+    }
+
+    public Task<IReadOnlyList<BrokerOrder>> GetOpenOrdersAsync(CancellationToken ct = default)
+    {
+        EnsureConnected();
+        // TODO: Call your broker's open orders endpoint
+        return Task.FromResult<IReadOnlyList<BrokerOrder>>(Array.Empty<BrokerOrder>());
+    }
+
+    public async Task<BrokerHealthStatus> CheckHealthAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            if (!_connected) return BrokerHealthStatus.Unhealthy("Not connected");
+            var account = await GetAccountInfoAsync(ct).ConfigureAwait(false);
+            return BrokerHealthStatus.Healthy($"Account {account.AccountId}");
+        }
+        catch (Exception ex)
+        {
+            return BrokerHealthStatus.Unhealthy(ex.Message);
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (_disposed) return ValueTask.CompletedTask;
+        _disposed = true;
+        _connected = false;
+        _reportChannel.Writer.TryComplete();
+        return ValueTask.CompletedTask;
+    }
+
+    private void EnsureConnected()
+    {
+        if (!_connected)
+            throw new InvalidOperationException("Template broker is not connected. Call ConnectAsync first.");
+    }
+}

--- a/src/Meridian.Infrastructure/Meridian.Infrastructure.csproj
+++ b/src/Meridian.Infrastructure/Meridian.Infrastructure.csproj
@@ -79,6 +79,7 @@
     <ProjectReference Include="..\Meridian.Domain\Meridian.Domain.csproj" />
     <ProjectReference Include="..\Meridian.Contracts\Meridian.Contracts.csproj" />
     <ProjectReference Include="..\Meridian.ProviderSdk\Meridian.ProviderSdk.csproj" />
+    <ProjectReference Include="..\Meridian.Execution.Sdk\Meridian.Execution.Sdk.csproj" />
     <ProjectReference Include="..\Meridian.Storage\Meridian.Storage.csproj" />
     <ProjectReference Include="..\Meridian.IbApi.SmokeStub\Meridian.IbApi.SmokeStub.csproj" Condition="'$(EnableIbApiSmoke)' == 'true'" />
   </ItemGroup>

--- a/src/Meridian.ProviderSdk/IProviderMetadata.cs
+++ b/src/Meridian.ProviderSdk/IProviderMetadata.cs
@@ -114,6 +114,8 @@ public interface IProviderMetadata
             types.Add("Auctions");
         if (caps.SupportsOptionsChain)
             types.Add("OptionsChain");
+        if (caps.SupportsBrokerage)
+            types.Add("Brokerage");
 
         return types.ToArray();
     }
@@ -160,6 +162,9 @@ public sealed record ProviderCapabilities
 
     /// <summary>Supports options chain data retrieval.</summary>
     public bool SupportsOptionsChain { get; init; }
+
+    /// <summary>Supports brokerage order execution (submit, cancel, modify orders).</summary>
+    public bool SupportsBrokerage { get; init; }
 
     #endregion
 
@@ -319,6 +324,20 @@ public sealed record ProviderCapabilities
             SupportsRealtimeQuotes = streaming
         };
 
+    /// <summary>Brokerage provider supporting order execution.</summary>
+    public static ProviderCapabilities Brokerage(
+        bool streaming = false,
+        bool backfill = false,
+        bool trades = true,
+        bool quotes = true) => new()
+        {
+            SupportsBrokerage = true,
+            SupportsStreaming = streaming,
+            SupportsBackfill = backfill,
+            SupportsRealtimeTrades = trades,
+            SupportsRealtimeQuotes = quotes
+        };
+
     /// <summary>Hybrid provider supporting both streaming and backfill.</summary>
     public static ProviderCapabilities Hybrid(
         bool trades = true,
@@ -381,6 +400,8 @@ public sealed record ProviderCapabilities
             dict["SupportsSymbolSearch"] = true;
         if (SupportsOptionsChain)
             dict["SupportsOptionsChain"] = true;
+        if (SupportsBrokerage)
+            dict["SupportsBrokerage"] = true;
 
         // Streaming
         if (SupportsRealtimeTrades)

--- a/tests/Meridian.Tests/Execution/BrokerageGatewayAdapterTests.cs
+++ b/tests/Meridian.Tests/Execution/BrokerageGatewayAdapterTests.cs
@@ -1,0 +1,317 @@
+using FluentAssertions;
+using Meridian.Application.Exceptions;
+using Meridian.Execution.Adapters;
+using Meridian.Execution.Exceptions;
+using Meridian.Execution.Models;
+using Meridian.Execution.Sdk;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+using GatewayOrderStatus = Meridian.Execution.Models.OrderStatus;
+using SdkOrderStatus = Meridian.Execution.Sdk.OrderStatus;
+using SdkOrderType = Meridian.Execution.Sdk.OrderType;
+
+namespace Meridian.Tests.Execution;
+
+public sealed class BrokerageGatewayAdapterTests
+{
+    private static IBrokerageGateway CreateMockGateway(
+        BrokerageCapabilities? capabilities = null)
+    {
+        var gateway = Substitute.For<IBrokerageGateway>();
+        gateway.BrokerDisplayName.Returns("Test Broker");
+        gateway.GatewayId.Returns("test");
+        gateway.IsConnected.Returns(true);
+        gateway.BrokerageCapabilities.Returns(capabilities ?? BrokerageCapabilities.UsEquity());
+        return gateway;
+    }
+
+    private static BrokerageGatewayAdapter CreateAdapter(IBrokerageGateway? gateway = null)
+    {
+        return new BrokerageGatewayAdapter(
+            gateway ?? CreateMockGateway(),
+            NullLogger<BrokerageGatewayAdapter>.Instance);
+    }
+
+    // ── ValidateOrderAsync ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task ValidateOrderAsync_RejectsUnsupportedOrderType()
+    {
+        var caps = BrokerageCapabilities.UsEquity();
+        // Remove Market from supported types by creating custom caps
+        var limitOnlyCaps = caps with
+        {
+            SupportedOrderTypes = new HashSet<SdkOrderType> { SdkOrderType.Limit }
+        };
+        await using var adapter = CreateAdapter(CreateMockGateway(limitOnlyCaps));
+        var request = new OrderRequest
+        {
+            Symbol = "AAPL",
+            Side = OrderSide.Buy,
+            Type = SdkOrderType.Market,
+            Quantity = 10
+        };
+
+        var result = await adapter.ValidateOrderAsync(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Reason.Should().Contain("Market");
+    }
+
+    [Fact]
+    public async Task ValidateOrderAsync_RejectsUnsupportedTimeInForce()
+    {
+        var dayOnlyCaps = BrokerageCapabilities.UsEquity() with
+        {
+            SupportedTimeInForce = new HashSet<TimeInForce> { TimeInForce.Day }
+        };
+        await using var adapter = CreateAdapter(CreateMockGateway(dayOnlyCaps));
+        var request = new OrderRequest
+        {
+            Symbol = "AAPL",
+            Side = OrderSide.Buy,
+            Type = SdkOrderType.Market,
+            Quantity = 10,
+            TimeInForce = TimeInForce.GoodTilCancelled
+        };
+
+        var result = await adapter.ValidateOrderAsync(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Reason.Should().Contain("GoodTilCancelled");
+    }
+
+    [Fact]
+    public async Task ValidateOrderAsync_RejectsZeroQuantity()
+    {
+        await using var adapter = CreateAdapter();
+        var request = new OrderRequest
+        {
+            Symbol = "AAPL",
+            Side = OrderSide.Buy,
+            Type = SdkOrderType.Market,
+            Quantity = 0
+        };
+
+        var result = await adapter.ValidateOrderAsync(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Reason.Should().Contain("quantity");
+    }
+
+    [Fact]
+    public async Task ValidateOrderAsync_RejectsLimitOrderWithoutLimitPrice()
+    {
+        await using var adapter = CreateAdapter();
+        var request = new OrderRequest
+        {
+            Symbol = "AAPL",
+            Side = OrderSide.Buy,
+            Type = SdkOrderType.Limit,
+            Quantity = 10
+            // LimitPrice intentionally omitted
+        };
+
+        var result = await adapter.ValidateOrderAsync(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Reason.Should().Contain("limit price");
+    }
+
+    [Fact]
+    public async Task ValidateOrderAsync_RejectsStopLimitOrderWithoutStopPrice()
+    {
+        await using var adapter = CreateAdapter();
+        var request = new OrderRequest
+        {
+            Symbol = "AAPL",
+            Side = OrderSide.Buy,
+            Type = SdkOrderType.StopLimit,
+            Quantity = 10,
+            LimitPrice = 150m
+            // StopPrice intentionally omitted
+        };
+
+        var result = await adapter.ValidateOrderAsync(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Reason.Should().Contain("stop price");
+    }
+
+    [Fact]
+    public async Task ValidateOrderAsync_AcceptsValidMarketOrder()
+    {
+        await using var adapter = CreateAdapter();
+        var request = new OrderRequest
+        {
+            Symbol = "AAPL",
+            Side = OrderSide.Buy,
+            Type = SdkOrderType.Market,
+            Quantity = 5
+        };
+
+        var result = await adapter.ValidateOrderAsync(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    // ── SubmitAsync ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SubmitAsync_ThrowsUnsupportedOrderRequestException_WhenValidationFails()
+    {
+        await using var adapter = CreateAdapter();
+        var request = new OrderRequest
+        {
+            Symbol = "AAPL",
+            Side = OrderSide.Buy,
+            Type = SdkOrderType.Market,
+            Quantity = 0  // invalid
+        };
+
+        Func<Task> act = async () => await adapter.SubmitAsync(request);
+
+        await act.Should().ThrowAsync<UnsupportedOrderRequestException>();
+    }
+
+    [Fact]
+    public async Task SubmitAsync_MapsExecutionReportToOrderAcknowledgement_WithClientOrderId()
+    {
+        var gateway = CreateMockGateway();
+        var report = new ExecutionReport
+        {
+            OrderId = "broker-123",
+            ReportType = ExecutionReportType.New,
+            Symbol = "AAPL",
+            Side = OrderSide.Buy,
+            OrderStatus = SdkOrderStatus.Accepted,
+            ClientOrderId = "client-abc",
+            GatewayOrderId = "broker-123",
+        };
+        gateway.SubmitOrderAsync(Arg.Any<OrderRequest>(), Arg.Any<CancellationToken>())
+            .Returns(report);
+
+        await using var adapter = new BrokerageGatewayAdapter(gateway, NullLogger<BrokerageGatewayAdapter>.Instance);
+        var request = new OrderRequest
+        {
+            Symbol = "AAPL",
+            Side = OrderSide.Buy,
+            Type = SdkOrderType.Market,
+            Quantity = 10,
+            ClientOrderId = "client-abc"
+        };
+
+        var ack = await adapter.SubmitAsync(request);
+
+        ack.OrderId.Should().Be("broker-123");
+        ack.ClientOrderId.Should().Be("client-abc");
+        ack.Symbol.Should().Be("AAPL");
+        ack.Status.Should().Be(GatewayOrderStatus.Accepted);
+    }
+
+    // ── StreamOrderUpdatesAsync ────────────────────────────────────────
+
+    [Fact]
+    public async Task StreamOrderUpdatesAsync_MapsClientOrderId_FromReportClientOrderId()
+    {
+        var gateway = CreateMockGateway();
+        var report = new ExecutionReport
+        {
+            OrderId = "broker-456",
+            ReportType = ExecutionReportType.Fill,
+            Symbol = "TSLA",
+            Side = OrderSide.Sell,
+            OrderStatus = SdkOrderStatus.Filled,
+            FilledQuantity = 5m,
+            ClientOrderId = "my-client-id",
+            GatewayOrderId = "broker-456",
+        };
+        gateway.StreamExecutionReportsAsync(Arg.Any<CancellationToken>())
+            .Returns(AsyncEnumerableOf(report));
+
+        await using var adapter = new BrokerageGatewayAdapter(gateway, NullLogger<BrokerageGatewayAdapter>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var updates = new List<OrderStatusUpdate>();
+        await foreach (var update in adapter.StreamOrderUpdatesAsync(cts.Token))
+        {
+            updates.Add(update);
+        }
+
+        updates.Should().HaveCount(1);
+        updates[0].ClientOrderId.Should().Be("my-client-id");
+        updates[0].OrderId.Should().Be("broker-456");
+        updates[0].FilledQuantity.Should().Be(5L);
+        updates[0].Status.Should().Be(GatewayOrderStatus.Filled);
+    }
+
+    [Fact]
+    public async Task StreamOrderUpdatesAsync_FallsBackToOrderId_WhenClientOrderIdIsNull()
+    {
+        var gateway = CreateMockGateway();
+        var report = new ExecutionReport
+        {
+            OrderId = "broker-789",
+            ReportType = ExecutionReportType.New,
+            Symbol = "MSFT",
+            Side = OrderSide.Buy,
+            OrderStatus = SdkOrderStatus.Accepted,
+            FilledQuantity = 0m,
+            // ClientOrderId intentionally null
+        };
+        gateway.StreamExecutionReportsAsync(Arg.Any<CancellationToken>())
+            .Returns(AsyncEnumerableOf(report));
+
+        await using var adapter = new BrokerageGatewayAdapter(gateway, NullLogger<BrokerageGatewayAdapter>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var updates = new List<OrderStatusUpdate>();
+        await foreach (var update in adapter.StreamOrderUpdatesAsync(cts.Token))
+        {
+            updates.Add(update);
+        }
+
+        updates.Should().HaveCount(1);
+        updates[0].ClientOrderId.Should().Be("broker-789");
+    }
+
+    [Fact]
+    public async Task StreamOrderUpdatesAsync_ThrowsMeridianException_ForFractionalFilledQuantity()
+    {
+        var gateway = CreateMockGateway();
+        var report = new ExecutionReport
+        {
+            OrderId = "broker-frac",
+            ReportType = ExecutionReportType.Fill,
+            Symbol = "AAPL",
+            Side = OrderSide.Buy,
+            OrderStatus = SdkOrderStatus.Filled,
+            FilledQuantity = 1.5m,  // fractional — should throw
+        };
+        gateway.StreamExecutionReportsAsync(Arg.Any<CancellationToken>())
+            .Returns(AsyncEnumerableOf(report));
+
+        await using var adapter = new BrokerageGatewayAdapter(gateway, NullLogger<BrokerageGatewayAdapter>.Instance);
+
+        Func<Task> act = async () =>
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            await foreach (var _ in adapter.StreamOrderUpdatesAsync(cts.Token)) { }
+        };
+
+        await act.Should().ThrowAsync<MeridianException>()
+            .WithMessage("*fractional*");
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private static async IAsyncEnumerable<T> AsyncEnumerableOf<T>(params T[] items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces a complete brokerage abstraction layer (`IBrokerageGateway`) for live order execution, extending the existing `IExecutionGateway` contract with account querying, position sync, and health checks
- Implements three provider gateways: **Alpaca** (full REST API v2), **Interactive Brokers** (TWS/Gateway scaffolded), and **StockSharp** (conditional, 90+ broker support)
- Adds `BrokerageGatewayAdapter` to bridge live gateways into the existing `IOrderGateway`/`IExecutionContext` strategy framework
- Includes `TemplateBrokerageGateway` scaffold so new brokers can be added by copy-and-fill
- Safety-first: live execution is off by default (`BrokerageConfiguration.LiveExecutionEnabled = false`)

## Architecture

```
IBrokerageGateway (Execution.Sdk)          -- contract
  ├── AlpacaBrokerageGateway               -- Alpaca REST v2
  ├── IBBrokerageGateway                   -- IB TWS/Gateway
  ├── StockSharpBrokerageGateway           -- StockSharp unified (#if STOCKSHARP)
  └── TemplateBrokerageGateway             -- copy-and-fill scaffold

BaseBrokerageGateway (Execution)           -- shared lifecycle/reconnection
BrokerageGatewayAdapter (Execution)        -- IBrokerageGateway → IOrderGateway bridge
BrokerageServiceRegistration (Execution)   -- DI: AddBrokerageExecution / AddBrokerageGateway<T>
BrokerageConfiguration (Execution.Sdk)     -- safety config with risk limits
```

## Files changed (11 files, +2083 lines)

| File | Change |
|------|--------|
| `Execution.Sdk/IBrokerageGateway.cs` | New interface + AccountInfo, BrokerPosition, BrokerOrder, BrokerHealthStatus, BrokerageCapabilities |
| `Execution.Sdk/BrokerageConfiguration.cs` | Safety-first config (gateway selection, risk limits) |
| `Execution/Adapters/BaseBrokerageGateway.cs` | Shared base: connection lifecycle, reconnection backoff, channel streaming |
| `Execution/Adapters/BrokerageGatewayAdapter.cs` | Bridges IBrokerageGateway → IOrderGateway for strategy code |
| `Execution/BrokerageServiceRegistration.cs` | DI extension methods |
| `Infrastructure/Adapters/Alpaca/AlpacaBrokerageGateway.cs` | Full Alpaca Trading API v2 with ADR-014 source-gen JSON |
| `Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs` | IB TWS/Gateway scaffold, ready for IBAPI integration |
| `Infrastructure/Adapters/StockSharp/StockSharpBrokerageGateway.cs` | Conditional StockSharp gateway |
| `Infrastructure/Adapters/Templates/TemplateBrokerageGateway.cs` | Developer scaffold for new brokers |
| `ProviderSdk/IProviderMetadata.cs` | Added `SupportsBrokerage` flag + factory method |
| `Infrastructure/Meridian.Infrastructure.csproj` | Added Execution.Sdk project reference |

## Test plan

- [x] Full solution builds (`dotnet build Meridian.sln -c Release /p:EnableWindowsTargeting=true`)
- [x] No new compilation errors or warnings in brokerage code
- [x] Existing tests unaffected (no behavioral changes to existing code)
- [ ] Unit tests for AlpacaBrokerageGateway (HTTP mocking)
- [ ] Unit tests for BrokerageGatewayAdapter (status mapping)
- [ ] Integration test with Alpaca paper trading sandbox

https://claude.ai/code/session_01FFnbq1irEoE9TVgnH8eaNK