### PR TITLE
Fix golden-path CI: add missing installer scripts and validation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,12 +21,17 @@ x86/
 !build/scripts/
 !build/scripts/docs/
 !build/scripts/docs/*.py
+!build/scripts/docs/*.sh
+!build/scripts/install/
+!build/scripts/install/*.sh
+!build/scripts/hooks/
+!build/scripts/hooks/*.sh
 bld/
 
 # Publish output
 # Why: Published binaries are deployment artifacts, not source code.
 # They should be regenerated via `dotnet publish` for each deployment.
-publish/
+/publish/
 
 # Roslyn compiler cache
 # Why: IDE/compiler cache files that speed up compilation but are

--- a/build/scripts/docs/validate-golden-path.sh
+++ b/build/scripts/docs/validate-golden-path.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Golden Path Installer Reference Validator
+# =============================================================================
+#
+# Checks that every installer script referenced in docs and the Makefile
+# actually exists in the repository.  Fails with a non-zero exit code and
+# a clear error summary if any reference is broken.
+#
+# Usage:
+#   ./build/scripts/docs/validate-golden-path.sh
+#
+# =============================================================================
+
+set -euo pipefail
+
+# Move to repo root so relative paths work regardless of where the script is
+# invoked from.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    # Fall back to the directory two levels above this script.
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+}
+cd "$REPO_ROOT"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+pass() { echo -e "  ${GREEN}OK${NC}  $1"; }
+fail() { echo -e "  ${RED}MISSING${NC}  $1"; FAILURES+=("$1"); }
+
+FAILURES=()
+
+# ---------------------------------------------------------------------------
+# Golden-path files that MUST exist
+# ---------------------------------------------------------------------------
+#
+# These are the installer scripts and supporting files referenced from:
+#   - docs/HELP.md
+#   - docs/getting-started/README.md
+#   - Makefile (install, install-docker, install-native, check-deps,
+#               install-hooks, publish, publish-linux, publish-windows,
+#               publish-macos targets)
+#
+REQUIRED_FILES=(
+    # Installer
+    "build/scripts/install/install.sh"
+
+    # Git hook installer
+    "build/scripts/hooks/install-hooks.sh"
+
+    # Publisher
+    "build/scripts/publish/publish.sh"
+
+    # Config template (setup-config target copies this)
+    "config/appsettings.sample.json"
+
+    # Docker compose (docker-up target uses this)
+    "deploy/docker/docker-compose.yml"
+
+    # Dockerfile (docker-build target uses this)
+    "deploy/docker/Dockerfile"
+
+    # Key documentation files linked from getting-started
+    "docs/getting-started/README.md"
+    "docs/HELP.md"
+    "docs/providers/alpaca-setup.md"
+    "docs/providers/interactive-brokers-setup.md"
+    "docs/providers/provider-comparison.md"
+    "docs/providers/data-sources.md"
+    "docs/reference/environment-variables.md"
+    "docs/providers/backfill-guide.md"
+    "docs/architecture/storage-design.md"
+    "docs/status/ROADMAP.md"
+)
+
+echo ""
+echo -e "${BLUE}=== Golden Path Installer Reference Validation ===${NC}"
+echo ""
+echo "Checking that all installer-referenced files exist..."
+echo ""
+
+for f in "${REQUIRED_FILES[@]}"; do
+    if [ -e "$f" ]; then
+        pass "$f"
+    else
+        fail "$f"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Executable check — installer scripts must be executable
+# ---------------------------------------------------------------------------
+REQUIRED_EXECUTABLES=(
+    "build/scripts/install/install.sh"
+    "build/scripts/hooks/install-hooks.sh"
+    "build/scripts/publish/publish.sh"
+)
+
+echo ""
+echo "Checking that installer scripts are executable..."
+echo ""
+
+for f in "${REQUIRED_EXECUTABLES[@]}"; do
+    if [ ! -e "$f" ]; then
+        # Already flagged as missing above; skip the executable check.
+        continue
+    fi
+    if [ -x "$f" ]; then
+        pass "$f (executable)"
+    else
+        fail "$f (not executable — run: chmod +x $f)"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+if [ "${#FAILURES[@]}" -eq 0 ]; then
+    echo -e "${GREEN}All golden-path installer references are valid.${NC}"
+    echo ""
+    exit 0
+else
+    echo -e "${RED}Validation FAILED — ${#FAILURES[@]} missing reference(s):${NC}"
+    for f in "${FAILURES[@]}"; do
+        echo -e "  ${YELLOW}${f}${NC}"
+    done
+    echo ""
+    echo -e "${YELLOW}Create the missing files or update the documentation that references them.${NC}"
+    echo ""
+    exit 1
+fi

--- a/build/scripts/docs/validate-golden-path.sh
+++ b/build/scripts/docs/validate-golden-path.sh
@@ -29,8 +29,9 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-pass() { echo -e "  ${GREEN}OK${NC}  $1"; }
-fail() { echo -e "  ${RED}MISSING${NC}  $1"; FAILURES+=("$1"); }
+pass()         { echo -e "  ${GREEN}OK${NC}             $1"; }
+fail()         { echo -e "  ${RED}MISSING${NC}        $1"; FAILURES+=("$1"); }
+fail_notexec() { echo -e "  ${RED}NOT EXECUTABLE${NC} $1"; FAILURES+=("$1"); }
 
 FAILURES=()
 
@@ -112,7 +113,7 @@ for f in "${REQUIRED_EXECUTABLES[@]}"; do
     if [ -x "$f" ]; then
         pass "$f (executable)"
     else
-        fail "$f (not executable — run: chmod +x $f)"
+        fail_notexec "$f  (run: chmod +x $f)"
     fi
 done
 
@@ -125,7 +126,7 @@ if [ "${#FAILURES[@]}" -eq 0 ]; then
     echo ""
     exit 0
 else
-    echo -e "${RED}Validation FAILED — ${#FAILURES[@]} missing reference(s):${NC}"
+    echo -e "${RED}Validation FAILED — ${#FAILURES[@]} issue(s):${NC}"
     for f in "${FAILURES[@]}"; do
         echo -e "  ${YELLOW}${f}${NC}"
     done

--- a/build/scripts/docs/validate-golden-path.sh
+++ b/build/scripts/docs/validate-golden-path.sh
@@ -84,7 +84,7 @@ echo "Checking that all installer-referenced files exist..."
 echo ""
 
 for f in "${REQUIRED_FILES[@]}"; do
-    if [ -e "$f" ]; then
+    if [ -f "$f" ]; then
         pass "$f"
     else
         fail "$f"

--- a/build/scripts/hooks/install-hooks.sh
+++ b/build/scripts/hooks/install-hooks.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Meridian Git Hook Installer
+# =============================================================================
+#
+# Copies pre-commit and commit-msg hooks from .githooks/ into .git/hooks/.
+#
+# Usage:
+#   ./build/scripts/hooks/install-hooks.sh
+#
+# =============================================================================
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo -e "${RED}ERROR: Not inside a git repository.${NC}" >&2
+    exit 1
+}
+
+HOOKS_SRC="${REPO_ROOT}/.githooks"
+HOOKS_DST="${REPO_ROOT}/.git/hooks"
+
+if [ ! -d "$HOOKS_SRC" ]; then
+    echo -e "${RED}ERROR: .githooks/ directory not found at ${HOOKS_SRC}${NC}" >&2
+    exit 1
+fi
+
+mkdir -p "$HOOKS_DST"
+
+installed=0
+for hook in "$HOOKS_SRC"/*; do
+    name="$(basename "$hook")"
+    dst="${HOOKS_DST}/${name}"
+    cp "$hook" "$dst"
+    chmod +x "$dst"
+    echo -e "${GREEN}  Installed hook: ${name}${NC}"
+    installed=$((installed + 1))
+done
+
+if [ "$installed" -eq 0 ]; then
+    echo -e "${YELLOW}No hooks found in .githooks/ — nothing installed.${NC}"
+else
+    echo -e "${GREEN}${installed} hook(s) installed successfully.${NC}"
+fi

--- a/build/scripts/hooks/install-hooks.sh
+++ b/build/scripts/hooks/install-hooks.sh
@@ -3,7 +3,7 @@
 # Meridian Git Hook Installer
 # =============================================================================
 #
-# Copies pre-commit and commit-msg hooks from .githooks/ into .git/hooks/.
+# Copies all git hooks from .githooks/ into .git/hooks/.
 #
 # Usage:
 #   ./build/scripts/hooks/install-hooks.sh

--- a/build/scripts/hooks/install-hooks.sh
+++ b/build/scripts/hooks/install-hooks.sh
@@ -33,7 +33,11 @@ fi
 mkdir -p "$HOOKS_DST"
 
 installed=0
-for hook in "$HOOKS_SRC"/*; do
+shopt -s nullglob
+hooks_to_install=("$HOOKS_SRC"/*)
+shopt -u nullglob
+
+for hook in "${hooks_to_install[@]}"; do
     name="$(basename "$hook")"
     dst="${HOOKS_DST}/${name}"
     cp "$hook" "$dst"

--- a/build/scripts/install/install.sh
+++ b/build/scripts/install/install.sh
@@ -22,6 +22,14 @@ NC='\033[0m'
 
 MODE="${1:-}"
 
+# Move to repo root so all repo-relative paths (config/, data/, Meridian.sln,
+# deploy/) resolve correctly regardless of where the script is invoked from.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+}
+cd "$REPO_ROOT"
+
 # --- helpers -----------------------------------------------------------------
 info()    { echo -e "${BLUE}$*${NC}"; }
 success() { echo -e "${GREEN}$*${NC}"; }
@@ -128,7 +136,8 @@ check_prerequisites() {
         ver=$(dotnet --version)
         success "  .NET SDK ${ver}"
         if [[ "${ver%%.*}" -lt 9 ]]; then
-            warn "  .NET 9+ recommended"
+            warn "  .NET SDK ${ver} is too old — 9.0.100 or later is required (see global.json)"
+            ok=false
         fi
     else
         warn "  .NET SDK not found (required for native install)"

--- a/build/scripts/install/install.sh
+++ b/build/scripts/install/install.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Meridian Installer
+# =============================================================================
+#
+# Usage:
+#   ./build/scripts/install/install.sh            Interactive (Docker or Native)
+#   ./build/scripts/install/install.sh --docker   Docker-based installation
+#   ./build/scripts/install/install.sh --native   Native .NET installation
+#   ./build/scripts/install/install.sh --check    Check prerequisites only
+#
+# =============================================================================
+
+set -euo pipefail
+
+# --- colours -----------------------------------------------------------------
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+MODE="${1:-}"
+
+# --- helpers -----------------------------------------------------------------
+info()    { echo -e "${BLUE}$*${NC}"; }
+success() { echo -e "${GREEN}$*${NC}"; }
+warn()    { echo -e "${YELLOW}WARNING: $*${NC}"; }
+error()   { echo -e "${RED}ERROR: $*${NC}" >&2; exit 1; }
+
+check_dotnet() {
+    if ! command -v dotnet >/dev/null 2>&1; then
+        error ".NET SDK not found. Install from https://dot.net/download"
+    fi
+    local ver
+    ver=$(dotnet --version)
+    info "  .NET SDK ${ver} found"
+    if [[ "${ver%%.*}" -lt 9 ]]; then
+        warn ".NET 9 or later is recommended (found ${ver})"
+    fi
+}
+
+check_docker() {
+    if ! command -v docker >/dev/null 2>&1; then
+        error "Docker not found. Install from https://docs.docker.com/get-docker/"
+    fi
+    info "  Docker $(docker --version | cut -d' ' -f3 | tr -d ',') found"
+}
+
+setup_config() {
+    if [ ! -f config/appsettings.json ]; then
+        cp config/appsettings.sample.json config/appsettings.json
+        success "  Created config/appsettings.json from template"
+        warn "  Edit config/appsettings.json and set your API credentials"
+    else
+        info "  config/appsettings.json already exists"
+    fi
+    mkdir -p data logs
+}
+
+install_native() {
+    info ""
+    info "=== Native .NET Installation ==="
+    info ""
+
+    info "[1/4] Checking prerequisites..."
+    check_dotnet
+    info ""
+
+    info "[2/4] Setting up configuration..."
+    setup_config
+    info ""
+
+    info "[3/4] Restoring packages..."
+    dotnet restore Meridian.sln /p:EnableWindowsTargeting=true --verbosity quiet
+    success "  Packages restored"
+    info ""
+
+    info "[4/4] Building..."
+    dotnet build Meridian.sln -c Release --verbosity quiet --nologo /p:EnableWindowsTargeting=true
+    success "  Build succeeded"
+    info ""
+
+    success "Native installation complete!"
+    info ""
+    info "Next steps:"
+    info "  1. Set API credentials as environment variables:"
+    info "       export ALPACA__KEYID=your-key-id"
+    info "       export ALPACA__SECRETKEY=your-secret-key"
+    info "  2. Start the web dashboard:"
+    info "       make run-ui"
+}
+
+install_docker() {
+    info ""
+    info "=== Docker Installation ==="
+    info ""
+
+    info "[1/3] Checking prerequisites..."
+    check_docker
+    info ""
+
+    info "[2/3] Setting up configuration..."
+    setup_config
+    info ""
+
+    info "[3/3] Building Docker image..."
+    docker build -f deploy/docker/Dockerfile -t meridian:latest .
+    success "  Docker image built"
+    info ""
+
+    success "Docker installation complete!"
+    info ""
+    info "Next steps:"
+    info "  Start the container: docker compose -f deploy/docker/docker-compose.yml up -d"
+    info "  Open dashboard:      http://localhost:8080"
+}
+
+check_prerequisites() {
+    info ""
+    info "=== Prerequisite Check ==="
+    local ok=true
+
+    info ""
+    info "Checking .NET SDK..."
+    if command -v dotnet >/dev/null 2>&1; then
+        local ver
+        ver=$(dotnet --version)
+        success "  .NET SDK ${ver}"
+        if [[ "${ver%%.*}" -lt 9 ]]; then
+            warn "  .NET 9+ recommended"
+        fi
+    else
+        warn "  .NET SDK not found (required for native install)"
+        ok=false
+    fi
+
+    info ""
+    info "Checking Docker..."
+    if command -v docker >/dev/null 2>&1; then
+        success "  Docker $(docker --version | cut -d' ' -f3 | tr -d ',')"
+    else
+        warn "  Docker not found (required for Docker install)"
+    fi
+
+    info ""
+    info "Checking config..."
+    if [ -f config/appsettings.json ]; then
+        success "  config/appsettings.json exists"
+    else
+        warn "  config/appsettings.json missing — run 'make setup-config'"
+    fi
+
+    info ""
+    if [ "$ok" = "true" ]; then
+        success "Prerequisite check passed"
+    else
+        warn "Some prerequisites are missing — see above"
+        exit 1
+    fi
+}
+
+interactive() {
+    info ""
+    info "╔══════════════════════════════════════════════╗"
+    info "║         Meridian Installer                   ║"
+    info "╚══════════════════════════════════════════════╝"
+    info ""
+    info "How would you like to install Meridian?"
+    info ""
+    info "  1) Docker   — recommended, easiest setup"
+    info "  2) Native   — requires .NET 9 SDK"
+    info "  3) Check    — verify prerequisites only"
+    info "  q) Quit"
+    info ""
+    read -r -p "Choice [1/2/3/q]: " choice
+    case "$choice" in
+        1|docker)  install_docker  ;;
+        2|native)  install_native  ;;
+        3|check)   check_prerequisites ;;
+        q|Q)       info "Aborted."; exit 0 ;;
+        *)         error "Invalid choice: $choice" ;;
+    esac
+}
+
+# --- main --------------------------------------------------------------------
+case "$MODE" in
+    --docker)  install_docker ;;
+    --native)  install_native ;;
+    --check)   check_prerequisites ;;
+    "")        interactive ;;
+    *)         error "Unknown option: $MODE" ;;
+esac

--- a/build/scripts/install/install.sh
+++ b/build/scripts/install/install.sh
@@ -36,7 +36,7 @@ check_dotnet() {
     ver=$(dotnet --version)
     info "  .NET SDK ${ver} found"
     if [[ "${ver%%.*}" -lt 9 ]]; then
-        warn ".NET 9 or later is recommended (found ${ver})"
+        error ".NET SDK 9.0.100 or later is required by global.json (found ${ver}). Please install .NET 9 from https://dot.net/download"
     fi
 }
 

--- a/build/scripts/publish/publish.sh
+++ b/build/scripts/publish/publish.sh
@@ -50,11 +50,13 @@ case "$TARGET" in
     "")
         info "Publishing for all platforms..."
         publish_rid "linux-x64"
+        publish_rid "linux-arm64"
         publish_rid "win-x64"
         publish_rid "osx-x64"
+        publish_rid "osx-arm64"
         ;;
     *)
-        echo "ERROR: Unknown target '${TARGET}'. Valid: linux-x64, win-x64, osx-x64" >&2
+        echo "ERROR: Unknown target '${TARGET}'. Valid: linux-x64, win-x64, osx-x64, osx-arm64, linux-arm64" >&2
         exit 1
         ;;
 esac

--- a/build/scripts/publish/publish.sh
+++ b/build/scripts/publish/publish.sh
@@ -8,8 +8,10 @@
 # Usage:
 #   ./build/scripts/publish/publish.sh              All platforms
 #   ./build/scripts/publish/publish.sh linux-x64    Linux x64 only
+#   ./build/scripts/publish/publish.sh linux-arm64  Linux ARM64 only
 #   ./build/scripts/publish/publish.sh win-x64      Windows x64 only
 #   ./build/scripts/publish/publish.sh osx-x64      macOS x64 only
+#   ./build/scripts/publish/publish.sh osx-arm64    macOS ARM64 (Apple Silicon)
 #
 # =============================================================================
 
@@ -18,6 +20,14 @@ set -euo pipefail
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 NC='\033[0m'
+
+# Move to repo root so PROJECT and OUTPUT_DIR resolve correctly regardless of
+# where the script is invoked from.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+}
+cd "$REPO_ROOT"
 
 PROJECT="src/Meridian/Meridian.csproj"
 OUTPUT_DIR="publish"

--- a/build/scripts/publish/publish.sh
+++ b/build/scripts/publish/publish.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Meridian Publisher
+# =============================================================================
+#
+# Publishes self-contained executables for one or all target platforms.
+#
+# Usage:
+#   ./build/scripts/publish/publish.sh              All platforms
+#   ./build/scripts/publish/publish.sh linux-x64    Linux x64 only
+#   ./build/scripts/publish/publish.sh win-x64      Windows x64 only
+#   ./build/scripts/publish/publish.sh osx-x64      macOS x64 only
+#
+# =============================================================================
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+PROJECT="src/Meridian/Meridian.csproj"
+OUTPUT_DIR="publish"
+CONFIGURATION="Release"
+
+info()    { echo -e "${BLUE}$*${NC}"; }
+success() { echo -e "${GREEN}$*${NC}"; }
+
+publish_rid() {
+    local rid="$1"
+    info "Publishing for ${rid}..."
+    dotnet publish "$PROJECT" \
+        -c "$CONFIGURATION" \
+        -r "$rid" \
+        --self-contained true \
+        -p:PublishSingleFile=true \
+        -p:EnableWindowsTargeting=true \
+        --output "${OUTPUT_DIR}/${rid}" \
+        --verbosity quiet \
+        --nologo
+    success "  Published to ${OUTPUT_DIR}/${rid}"
+}
+
+TARGET="${1:-}"
+
+case "$TARGET" in
+    linux-x64|win-x64|osx-x64|osx-arm64|linux-arm64)
+        publish_rid "$TARGET"
+        ;;
+    "")
+        info "Publishing for all platforms..."
+        publish_rid "linux-x64"
+        publish_rid "win-x64"
+        publish_rid "osx-x64"
+        ;;
+    *)
+        echo "ERROR: Unknown target '${TARGET}'. Valid: linux-x64, win-x64, osx-x64" >&2
+        exit 1
+        ;;
+esac
+
+success "Done. Artifacts in ${OUTPUT_DIR}/"


### PR DESCRIPTION
## Summary

The `golden-path-validation` CI workflow was failing with exit code 127 because `build/scripts/docs/validate-golden-path.sh` did not exist.

- **Add `build/scripts/docs/validate-golden-path.sh`** — the validation script the workflow actually runs; checks all golden-path installer references (files + executable bits)
- **Add `build/scripts/install/install.sh`** — interactive installer (Docker / native) referenced by `make install`, `make install-docker`, `make install-native`, `make check-deps`, `make docker`, and `docs/HELP.md`
- **Add `build/scripts/hooks/install-hooks.sh`** — copies `.githooks/` into `.git/hooks/`; referenced by `make install-hooks` and `CLAUDE.md`
- **Add `build/scripts/publish/publish.sh`** — publishes self-contained executables; referenced by `make publish`, `make publish-linux`, `make publish-windows`, `make publish-macos`
- **Fix `.gitignore`** — anchor `publish/` to `/publish/` (root only) so `build/scripts/publish/` is not inadvertently ignored; add explicit `!build/scripts/{docs,install,hooks}/*.sh` negation entries

## Test plan

- [x] `./build/scripts/docs/validate-golden-path.sh` exits 0 locally (all references present and executable)
- [ ] `golden-path-validation` CI workflow passes on this PR
- [ ] `make install-hooks` runs without "No such file" error
- [ ] `make check-deps` runs without "No such file" error

https://claude.ai/code/session_01Wmk6EMdH8xh1GYpQWwJap6