### PR TITLE
Add golden-path installer and git hook scripts

### DIFF
--- a/build/scripts/docs/validate-golden-path.sh
+++ b/build/scripts/docs/validate-golden-path.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+
+required_files=(
+  "Makefile"
+  "README.md"
+  "docs/HELP.md"
+  "build/scripts/install/install.sh"
+  "build/scripts/hooks/install-hooks.sh"
+)
+
+for file in "${required_files[@]}"; do
+  if [[ ! -f "$file" ]]; then
+    echo "Missing required golden-path file: $file" >&2
+    exit 1
+  fi
+done
+
+# Ensure make wrappers point to concrete scripts.
+rg -n "^install:|^check-deps:|^install-hooks:" Makefile >/dev/null
+rg -n "build/scripts/install/install.sh" Makefile docs/HELP.md >/dev/null
+rg -n "build/scripts/hooks/install-hooks.sh" Makefile >/dev/null
+
+# Ensure scripts are executable.
+for script in build/scripts/install/install.sh build/scripts/hooks/install-hooks.sh; do
+  if [[ ! -x "$script" ]]; then
+    echo "Expected executable script: $script" >&2
+    exit 1
+  fi
+done
+
+echo "Golden path validation passed."

--- a/build/scripts/hooks/commit-msg
+++ b/build/scripts/hooks/commit-msg
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+msg_file="$1"
+if [[ ! -s "$msg_file" ]]; then
+  echo "Commit message must not be empty." >&2
+  exit 1
+fi

--- a/build/scripts/hooks/install-hooks.sh
+++ b/build/scripts/hooks/install-hooks.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HOOKS_SRC_DIR="$ROOT_DIR/build/scripts/hooks"
+GIT_HOOKS_DIR="$ROOT_DIR/.git/hooks"
+
+if [[ ! -d "$ROOT_DIR/.git" ]]; then
+  echo "ERROR: Not a git repository: $ROOT_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$GIT_HOOKS_DIR"
+for hook in pre-commit commit-msg; do
+  src="$HOOKS_SRC_DIR/$hook"
+  dst="$GIT_HOOKS_DIR/$hook"
+  if [[ ! -f "$src" ]]; then
+    echo "ERROR: Missing hook source: $src" >&2
+    exit 1
+  fi
+  cp "$src" "$dst"
+  chmod +x "$dst"
+  echo "Installed $hook"
+done
+
+echo "Git hooks installed successfully."

--- a/build/scripts/hooks/pre-commit
+++ b/build/scripts/hooks/pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lightweight pre-commit guard.
+if command -v dotnet >/dev/null 2>&1; then
+  dotnet format Meridian.sln --verify-no-changes --verbosity minimal || {
+    echo "Formatting check failed. Run: make format" >&2
+    exit 1
+  }
+fi

--- a/build/scripts/install/install.sh
+++ b/build/scripts/install/install.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="interactive"
+CHECK_ONLY=0
+
+usage() {
+  cat <<'USAGE'
+Usage: install.sh [--docker|--native|--check]
+
+Options:
+  --docker   Validate Docker prerequisites.
+  --native   Validate native (.NET) prerequisites.
+  --check    Validate common prerequisites only.
+  -h, --help Show this help text.
+USAGE
+}
+
+require_cmd() {
+  local cmd="$1"
+  local hint="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: '$cmd' is required. ${hint}" >&2
+    return 1
+  fi
+}
+
+check_common() {
+  require_cmd git "Install git from https://git-scm.com/downloads"
+}
+
+check_native() {
+  check_common
+  require_cmd dotnet "Install from https://dot.net/download"
+}
+
+check_docker() {
+  check_common
+  require_cmd docker "Install from https://docs.docker.com/get-docker/"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --docker) MODE="docker" ;;
+    --native) MODE="native" ;;
+    --check) MODE="check"; CHECK_ONLY=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+case "$MODE" in
+  docker)
+    check_docker
+    [[ "$CHECK_ONLY" -eq 1 ]] || echo "Docker prerequisites validated. Run 'make docker' to continue."
+    ;;
+  native)
+    check_native
+    [[ "$CHECK_ONLY" -eq 1 ]] || echo "Native prerequisites validated. Run 'make setup-dev' to continue."
+    ;;
+  check)
+    check_common
+    echo "Common prerequisites validated."
+    ;;
+  interactive)
+    check_common
+    echo "Select install mode: [docker|native]"
+    read -r selection || true
+    if [[ "${selection:-}" == "docker" ]]; then
+      check_docker
+      echo "Docker prerequisites validated."
+    else
+      check_native
+      echo "Native prerequisites validated."
+    fi
+    ;;
+  *)
+    echo "Invalid mode: $MODE" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
### Motivation
- The repository referenced installer and hook scripts from `Makefile` and CI but those files were missing, causing `make install-hooks` and `make check-deps` to fail with "No such file" errors.
- The golden-path CI workflow expects a concrete validation script to verify installer references and executable bits for the recommended developer path.
- Provide lightweight, cross-platform scripts so local development setup and CI validation are reliable and self-contained.

### Description
- Add `build/scripts/install/install.sh`, a small installer/validator that supports `--check`, `--docker`, `--native`, and interactive mode and performs prerequisite checks for `git`, `dotnet`, and `docker`.
- Add git hook assets and installer: `build/scripts/hooks/pre-commit`, `build/scripts/hooks/commit-msg`, and `build/scripts/hooks/install-hooks.sh`, where `pre-commit` runs a `dotnet format` verification and `commit-msg` enforces non-empty commit messages.
- Add `build/scripts/docs/validate-golden-path.sh` which the `golden-path-validation` workflow runs to ensure required files exist, Makefile references point to concrete scripts, and the scripts are executable.
- Update permissions (made scripts executable) and wire the new scripts to the existing `Makefile` wrappers so `make install-hooks` and `make check-deps` resolve correctly.

### Testing
- Ran `make install-hooks` and it installed `pre-commit` and `commit-msg` into `.git/hooks` successfully.
- Ran `make check-deps` which executed `build/scripts/install/install.sh --check` and returned success.
- Ran `./build/scripts/docs/validate-golden-path.sh` and it completed with "Golden path validation passed."

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3143ead10832090b58266a3db6713)