### PR TITLE
Generate trade tickets and scope asset-event ledger postings for backtests

### DIFF
--- a/src/Meridian.Backtesting.Sdk/BacktestResult.cs
+++ b/src/Meridian.Backtesting.Sdk/BacktestResult.cs
@@ -46,4 +46,5 @@ public sealed record BacktestResult(
     BacktestMetrics Metrics,
     IReadOnlyLedger Ledger,
     TimeSpan ElapsedTime,
-    long TotalEventsProcessed);
+    long TotalEventsProcessed,
+    IReadOnlyList<TradeTicket>? TradeTickets = null);

--- a/src/Meridian.Backtesting.Sdk/TradeTicket.cs
+++ b/src/Meridian.Backtesting.Sdk/TradeTicket.cs
@@ -1,0 +1,17 @@
+namespace Meridian.Backtesting.Sdk;
+
+/// <summary>
+/// Human-readable audit ticket that explains why a trading or asset-event cash movement occurred.
+/// </summary>
+public sealed record TradeTicket(
+    Guid TicketId,
+    DateTimeOffset Timestamp,
+    string ActivityType,
+    string? Symbol,
+    string Narrative,
+    decimal CashImpact,
+    long? Quantity = null,
+    decimal? UnitPrice = null,
+    string? AccountId = null,
+    Guid? OrderId = null,
+    Guid? FillId = null);

--- a/src/Meridian.Backtesting/Engine/BacktestEngine.cs
+++ b/src/Meridian.Backtesting/Engine/BacktestEngine.cs
@@ -129,7 +129,8 @@ public sealed class BacktestEngine(
             "Backtest complete: {Events} events, final equity {Equity:C}, net PnL {NetPnl:C} in {Elapsed}ms",
             eventsProcessed, metrics.FinalEquity, metrics.NetPnl, sw.ElapsedMilliseconds);
 
-        return new BacktestResult(request, universe, allSnapshots, allCashFlows, allFills, metrics, ledger, sw.Elapsed, eventsProcessed);
+        var tradeTickets = BuildTradeTickets(allCashFlows);
+        return new BacktestResult(request, universe, allSnapshots, allCashFlows, allFills, metrics, ledger, sw.Elapsed, eventsProcessed, tradeTickets);
     }
 
     // ── Private helpers ──────────────────────────────────────────────────────
@@ -351,7 +352,7 @@ public sealed class BacktestEngine(
     private static BacktestResult CreateEmptyResult(BacktestRequest request, IReadOnlySet<string> universe, TimeSpan elapsed)
     {
         var metrics = BacktestMetricsEngine.Compute([], [], [], request);
-        return new BacktestResult(request, universe, [], [], [], metrics, new BacktestLedger(), elapsed, 0);
+        return new BacktestResult(request, universe, [], [], [], metrics, new BacktestLedger(), elapsed, 0, []);
     }
 
     private static IFillModel SelectFillModel(
@@ -366,5 +367,108 @@ public sealed class BacktestEngine(
             ExecutionModel.BarMidpoint => barModel,
             _ => evt.Payload is LOBSnapshot ? lobModel : barModel
         };
+    }
+
+    private static IReadOnlyList<TradeTicket> BuildTradeTickets(IReadOnlyList<CashFlowEntry> cashFlows)
+    {
+        var tickets = new List<TradeTicket>(cashFlows.Count);
+
+        foreach (var flow in cashFlows.OrderBy(flow => flow.Timestamp))
+        {
+            switch (flow)
+            {
+                case TradeCashFlow trade:
+                    tickets.Add(new TradeTicket(
+                        Guid.NewGuid(),
+                        trade.Timestamp,
+                        "trade_cash_flow",
+                        trade.Symbol,
+                        $"Trade execution cash impact for {trade.Symbol} ({trade.Quantity} @ {trade.Price:F4}).",
+                        trade.Amount,
+                        trade.Quantity,
+                        trade.Price,
+                        trade.AccountId));
+                    break;
+                case CommissionCashFlow commission:
+                    tickets.Add(new TradeTicket(
+                        Guid.NewGuid(),
+                        commission.Timestamp,
+                        "commission",
+                        commission.Symbol,
+                        $"Commission charged for order {commission.OrderId} on {commission.Symbol}.",
+                        commission.Amount,
+                        AccountId: commission.AccountId,
+                        OrderId: commission.OrderId));
+                    break;
+                case AssetEventCashFlow assetEvent:
+                    tickets.Add(new TradeTicket(
+                        Guid.NewGuid(),
+                        assetEvent.Timestamp,
+                        $"asset_event:{assetEvent.EventType}".ToLowerInvariant(),
+                        assetEvent.Symbol,
+                        BuildAssetEventNarrative(assetEvent),
+                        assetEvent.Amount,
+                        assetEvent.UnitsImpacted,
+                        assetEvent.CashPerShare));
+                    break;
+                case DividendCashFlow dividend:
+                    tickets.Add(new TradeTicket(
+                        Guid.NewGuid(),
+                        dividend.Timestamp,
+                        "dividend",
+                        dividend.Symbol,
+                        $"Dividend receipt/charge for {dividend.Symbol} ({dividend.Shares} shares @ {dividend.DividendPerShare:F4}).",
+                        dividend.Amount,
+                        dividend.Shares,
+                        dividend.DividendPerShare,
+                        dividend.AccountId));
+                    break;
+                case MarginInterestCashFlow margin:
+                    tickets.Add(new TradeTicket(
+                        Guid.NewGuid(),
+                        margin.Timestamp,
+                        "margin_interest",
+                        Symbol: null,
+                        Narrative: $"Margin interest accrual at {margin.AnnualRate:P2} annualized rate.",
+                        CashImpact: margin.Amount,
+                        AccountId: margin.AccountId));
+                    break;
+                case CashInterestCashFlow cashInterest:
+                    tickets.Add(new TradeTicket(
+                        Guid.NewGuid(),
+                        cashInterest.Timestamp,
+                        "cash_interest",
+                        Symbol: null,
+                        Narrative: $"Cash interest accrual at {cashInterest.AnnualRate:P2} annualized rate.",
+                        CashImpact: cashInterest.Amount,
+                        AccountId: cashInterest.AccountId));
+                    break;
+                case ShortRebateCashFlow shortRebate:
+                    tickets.Add(new TradeTicket(
+                        Guid.NewGuid(),
+                        shortRebate.Timestamp,
+                        "short_rebate",
+                        shortRebate.Symbol,
+                        $"Short rebate on {shortRebate.Symbol} ({shortRebate.ShortShares} shares @ {shortRebate.AnnualRebateRate:P2}).",
+                        shortRebate.Amount,
+                        shortRebate.ShortShares,
+                        AccountId: shortRebate.AccountId));
+                    break;
+            }
+        }
+
+        return tickets;
+    }
+
+    private static string BuildAssetEventNarrative(AssetEventCashFlow assetEvent)
+    {
+        if (!string.IsNullOrWhiteSpace(assetEvent.Description))
+            return assetEvent.Description!;
+
+        var related = string.IsNullOrWhiteSpace(assetEvent.RelatedSymbol)
+            ? string.Empty
+            : $" related symbol {assetEvent.RelatedSymbol}.";
+
+        return $"{assetEvent.EventType} on {assetEvent.Symbol}: {assetEvent.UnitsImpacted} units impacted at {assetEvent.CashPerShare:F4} cash/share.{related}";
     }
 }

--- a/src/Meridian.Backtesting/Portfolio/SimulatedPortfolio.cs
+++ b/src/Meridian.Backtesting/Portfolio/SimulatedPortfolio.cs
@@ -314,7 +314,7 @@ internal sealed class SimulatedPortfolio
     {
         var amount = quantity * assetEvent.CashPerShare;
         account.Cash += amount;
-        PostAssetCashLedgerEntry(assetEvent, amount, quantity, assetEvent.Symbol, assetEvent.TargetSymbol);
+        PostAssetCashLedgerEntry(account, assetEvent, amount, quantity, assetEvent.Symbol, assetEvent.TargetSymbol);
         return amount;
     }
 
@@ -352,7 +352,7 @@ internal sealed class SimulatedPortfolio
         if (cashInLieu != 0m)
         {
             account.Cash += cashInLieu;
-            PostAssetCashLedgerEntry(assetEvent, cashInLieu, existingQty, assetEvent.Symbol, targetSymbol, suffix: "cash in lieu");
+            PostAssetCashLedgerEntry(account, assetEvent, cashInLieu, existingQty, assetEvent.Symbol, targetSymbol, suffix: "cash in lieu");
         }
 
         return cashInLieu;
@@ -377,6 +377,7 @@ internal sealed class SimulatedPortfolio
     }
 
     private void PostAssetCashLedgerEntry(
+        AccountState account,
         AssetEvent assetEvent,
         decimal amount,
         long quantity,
@@ -387,7 +388,10 @@ internal sealed class SimulatedPortfolio
         if (_ledger is null || amount == 0m)
             return;
 
-        var counterpartyAccount = SelectAssetEventAccount(assetEvent.EventType, amount);
+        var accountId = account.Account.AccountId;
+        var counterpartyAccount = SelectAssetEventAccount(assetEvent.EventType, amount, accountId);
+        var cashAccount = LedgerAccounts.CashAccount(accountId);
+        var metadata = BuildAssetEventMetadata(account, assetEvent, symbol, relatedSymbol, quantity, amount, suffix);
         var description = string.IsNullOrWhiteSpace(assetEvent.Description)
             ? $"{assetEvent.EventType} – {symbol}" + (string.IsNullOrWhiteSpace(relatedSymbol) || relatedSymbol.Equals(symbol, StringComparison.OrdinalIgnoreCase)
                 ? string.Empty
@@ -400,9 +404,10 @@ internal sealed class SimulatedPortfolio
                 assetEvent.EffectiveAt,
                 description,
                 [
-                    (LedgerAccounts.Cash, amount, 0m),
+                    (cashAccount, amount, 0m),
                     (counterpartyAccount, 0m, amount),
-                ]);
+                ],
+                metadata);
         }
         else
         {
@@ -412,18 +417,49 @@ internal sealed class SimulatedPortfolio
                 description,
                 [
                     (counterpartyAccount, outflow, 0m),
-                    (LedgerAccounts.Cash, 0m, outflow),
-                ]);
+                    (cashAccount, 0m, outflow),
+                ],
+                metadata);
         }
     }
 
-    private static LedgerAccount SelectAssetEventAccount(AssetEventType eventType, decimal amount) => eventType switch
+    private static LedgerAccount SelectAssetEventAccount(AssetEventType eventType, decimal amount, string accountId) => eventType switch
     {
-        AssetEventType.Dividend => amount >= 0m ? LedgerAccounts.DividendIncome : LedgerAccounts.DividendExpense,
-        AssetEventType.Coupon => amount >= 0m ? LedgerAccounts.CouponIncome : LedgerAccounts.CouponExpense,
-        AssetEventType.Fee => LedgerAccounts.CorporateActionExpense,
-        _ => amount >= 0m ? LedgerAccounts.CorporateActionIncome : LedgerAccounts.CorporateActionExpense,
+        AssetEventType.Dividend => amount >= 0m ? LedgerAccounts.DividendIncomeFor(accountId) : LedgerAccounts.DividendExpenseFor(accountId),
+        AssetEventType.Coupon => amount >= 0m ? LedgerAccounts.CouponIncomeFor(accountId) : LedgerAccounts.CouponExpenseFor(accountId),
+        AssetEventType.Fee => LedgerAccounts.CorporateActionExpenseFor(accountId),
+        _ => amount >= 0m ? LedgerAccounts.CorporateActionIncomeFor(accountId) : LedgerAccounts.CorporateActionExpenseFor(accountId),
     };
+
+    private JournalEntryMetadata BuildAssetEventMetadata(
+        AccountState account,
+        AssetEvent assetEvent,
+        string symbol,
+        string? relatedSymbol,
+        long quantity,
+        decimal amount,
+        string? suffix)
+    {
+        var tags = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["event_type"] = assetEvent.EventType.ToString(),
+            ["cash_per_share"] = assetEvent.CashPerShare.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ["position_factor"] = assetEvent.PositionFactor.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ["units_impacted"] = quantity.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ["cash_impact"] = amount.ToString(System.Globalization.CultureInfo.InvariantCulture),
+        };
+
+        if (!string.IsNullOrWhiteSpace(relatedSymbol))
+            tags["related_symbol"] = relatedSymbol!;
+
+        if (!string.IsNullOrWhiteSpace(suffix))
+            tags["ticket_variant"] = suffix!;
+
+        return BuildAccountMetadata(account, $"asset_event_{assetEvent.EventType.ToString().ToLowerInvariant()}", symbol) with
+        {
+            Tags = tags
+        };
+    }
 
     private static long ConvertToWholeUnits(decimal quantity) => quantity >= 0m
         ? (long)Math.Floor(quantity)

--- a/src/Meridian.Ledger/LedgerAccounts.cs
+++ b/src/Meridian.Ledger/LedgerAccounts.cs
@@ -67,6 +67,22 @@ public static class LedgerAccounts
 
     public static LedgerAccount DividendIncomeFor(string financialAccountId) =>
         CreateScoped("Dividend Income", LedgerAccountType.Revenue, financialAccountId);
+
+    public static LedgerAccount DividendExpenseFor(string financialAccountId) =>
+        CreateScoped("Dividend Expense", LedgerAccountType.Expense, financialAccountId);
+
+    public static LedgerAccount CouponIncomeFor(string financialAccountId) =>
+        CreateScoped("Coupon Income", LedgerAccountType.Revenue, financialAccountId);
+
+    public static LedgerAccount CouponExpenseFor(string financialAccountId) =>
+        CreateScoped("Coupon Expense", LedgerAccountType.Expense, financialAccountId);
+
+    public static LedgerAccount CorporateActionIncomeFor(string financialAccountId) =>
+        CreateScoped("Corporate Action Income", LedgerAccountType.Revenue, financialAccountId);
+
+    public static LedgerAccount CorporateActionExpenseFor(string financialAccountId) =>
+        CreateScoped("Corporate Action Expense", LedgerAccountType.Expense, financialAccountId);
+
     /// <summary>Dividend expense owed on short positions or other negative dividend adjustments.</summary>
     public static readonly LedgerAccount DividendExpense =
         new("Dividend Expense", LedgerAccountType.Expense);

--- a/tests/Meridian.Backtesting.Tests/SimulatedPortfolioTests.cs
+++ b/tests/Meridian.Backtesting.Tests/SimulatedPortfolioTests.cs
@@ -332,7 +332,10 @@ public sealed class SimulatedPortfolioTests
         portfolio.Cash.Should().Be(6_012.5m);
         var snapshot = portfolio.TakeSnapshot(exDate, DateOnly.FromDateTime(exDate.Date));
         snapshot.DayCashFlows.OfType<AssetEventCashFlow>().Should().ContainSingle(flow => flow.Amount == 12.5m && flow.EventType == AssetEventType.Dividend);
-        ledger.GetBalance(LedgerAccounts.DividendIncome).Should().Be(12.5m);
+        ledger.GetBalance(LedgerAccounts.DividendIncomeFor(BacktestDefaults.DefaultBrokerageAccountId)).Should().Be(12.5m);
+        ledger.GetJournalEntries(new LedgerQuery(ActivityType: "asset_event_dividend", Symbol: "SPY"))
+            .Should()
+            .ContainSingle();
     }
 
     [Fact]
@@ -346,7 +349,7 @@ public sealed class SimulatedPortfolioTests
         portfolio.ApplyAssetEvent(new AssetEvent(paymentDate, "TLT", AssetEventType.Coupon, CashPerShare: 2m));
 
         portfolio.Cash.Should().Be(10_490m);
-        ledger.GetBalance(LedgerAccounts.CouponExpense).Should().Be(10m);
+        ledger.GetBalance(LedgerAccounts.CouponExpenseFor(BacktestDefaults.DefaultBrokerageAccountId)).Should().Be(10m);
         var snapshot = portfolio.TakeSnapshot(paymentDate, DateOnly.FromDateTime(paymentDate.Date));
         snapshot.DayCashFlows.OfType<AssetEventCashFlow>().Should().ContainSingle(flow => flow.Amount == -10m && flow.EventType == AssetEventType.Coupon);
     }
@@ -392,7 +395,7 @@ public sealed class SimulatedPortfolioTests
         newPosition.Quantity.Should().Be(1);
         newPosition.AverageCostBasis.Should().Be(180m);
         portfolio.Cash.Should().Be(9_945m);
-        ledger.GetBalance(LedgerAccounts.CorporateActionIncome).Should().Be(215m);
+        ledger.GetBalance(LedgerAccounts.CorporateActionIncomeFor(BacktestDefaults.DefaultBrokerageAccountId)).Should().Be(215m);
     }
 
 }


### PR DESCRIPTION
### Motivation
- Improve auditability and explainability of historical backtests by recording why cash movements occurred (trades, commissions, dividends, coupons, interest, rebates, corporate actions). 
- Surface human-readable “trade tickets” alongside existing fills/cash-flows/ledger output so consumers can quickly understand why the backtest did what it did. 
- Ensure asset-event ledger postings are scoped to the financial account and include metadata/tags so ledger queries can filter and reconcile backtest outcomes accurately.

### Description
- Added a `TradeTicket` model and extended `BacktestResult` to optionally include `IReadOnlyList<TradeTicket>` so backtests may return explainable tickets (`src/Meridian.Backtesting.Sdk/TradeTicket.cs`, `src/Meridian.Backtesting.Sdk/BacktestResult.cs`).
- Implemented `BuildTradeTickets` in the backtest engine to convert all `CashFlowEntry` types into audit tickets and return them in the `BacktestResult` (`src/Meridian.Backtesting/Engine/BacktestEngine.cs`).
- Strengthened asset-event handling in the simulated portfolio so ledger postings are per-account, use scoped chart-of-accounts, and attach structured `JournalEntryMetadata.Tags` for filtering and provenance (`src/Meridian.Backtesting/Portfolio/SimulatedPortfolio.cs`).
- Added scoped ledger-account helpers for dividend/coupon/corporate-action income & expense to support per-financial-account postings, and updated tests to assert scoped ledger balances and metadata-queryability (`src/Meridian.Ledger/LedgerAccounts.cs`, `tests/Meridian.Backtesting.Tests/SimulatedPortfolioTests.cs`).

### Testing
- Updated unit test expectations in `tests/Meridian.Backtesting.Tests/SimulatedPortfolioTests.cs` to validate scoped account balances and that asset-event journal entries are discoverable via `LedgerQuery` (tests were modified but not executed here).
- Attempted to run the filtered backtesting tests with `dotnet test tests/Meridian.Backtesting.Tests/Meridian.Backtesting.Tests.csproj --filter "SimulatedPortfolioTests|LedgerQueryTests"`, but execution failed in this environment because the `dotnet` CLI is not installed. Automated test execution could not be completed here.
- No automated test failures reported by CI in this environment because tests were not executed; recommend running full test suite and a project build (`dotnet build` / `dotnet test`) in CI or a developer machine to validate compilation and behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c31471b8308320b8b20d2972d798e7)