### PR TITLE
Persist and propagate end-to-end trace context on MarketEvent

### DIFF
--- a/docs/evaluations/high-impact-improvement-brainstorm-2026-03.md
+++ b/docs/evaluations/high-impact-improvement-brainstorm-2026-03.md
@@ -324,11 +324,9 @@ meaningful error code.
 These changes improve the system's fundamental design, making it more
 maintainable, extensible, and correct by construction.
 
-### 3.1 End-to-End Trace Context Propagation — 📝 Open
+### 3.1 End-to-End Trace Context Propagation — ✅ Done (2026-03-24)
 
-**Current state**: OpenTelemetry is wired up (`TracedEventMetrics`,
-`OpenTelemetrySetup`), but there's no trace context flowing through the event
-pipeline. Each component logs independently with no correlation.
+**Current state**: Trace context is captured at pipeline ingress, restored in processing/storage spans, and stamped onto `MarketEvent` records (`TraceId`, `ParentSpanId`) so sinks and logs can correlate operations end-to-end.
 
 **What's missing**: When a trade arrives from Alpaca, gets processed through the
 pipeline, validated by data quality, and written to storage — there's no single
@@ -633,7 +631,7 @@ exhaustive and the compiler catches missing cases.
 | 2.4 | WebSocket buffer size limit | Stability | Low | High | ✅ Done (2026-03-12) |
 | 2.5 | Reconnection race fix | Stability | Medium | High | ✅ Done (2026-03-12) |
 | 2.6 | Provider connection timeout | Stability | Low | High | ✅ Done (2026-03-11) |
-| 3.1 | E2E trace propagation | Architecture | Low | High | 📝 Open |
+| 3.1 | E2E trace propagation | Architecture | Low | High | ✅ Done (2026-03-24) |
 | 3.2 | WebSocket provider base class | Architecture | Low | High | 📝 Open |
 | 3.3 | Decide F# strategy | Architecture | Low | Medium | 📝 Open |
 | 3.4 | Idempotent writes | Architecture | **Critical** | **Critical** | 📝 Open |

--- a/src/Meridian.Application/Pipeline/EventPipeline.cs
+++ b/src/Meridian.Application/Pipeline/EventPipeline.cs
@@ -997,7 +997,14 @@ public sealed class EventPipeline : IMarketEventPublisher, IBackpressureSignal, 
     public IEventMetrics EventMetrics => _metrics;
 
     private static TracedMarketEvent CaptureTraceContext(in MarketEvent evt)
-        => new(evt, EventTraceContext.CaptureCurrent());
+    {
+        var traceContext = EventTraceContext.CaptureCurrent();
+        var tracedEvent = traceContext.HasParent
+            ? evt.StampTraceContext(traceContext.ParentContext)
+            : evt;
+
+        return new TracedMarketEvent(tracedEvent, traceContext);
+    }
 
     private static Dictionary<string, object?> CreateLogScope(
         MarketEvent evt,

--- a/src/Meridian.Domain/Events/MarketEvent.cs
+++ b/src/Meridian.Domain/Events/MarketEvent.cs
@@ -21,7 +21,10 @@ public sealed record MarketEvent(
     // Canonicalization fields
     string? CanonicalSymbol = null,
     byte CanonicalizationVersion = 0,
-    string? CanonicalVenue = null
+    string? CanonicalVenue = null,
+    // End-to-end trace context captured at pipeline ingress.
+    string? TraceId = null,
+    string? ParentSpanId = null
 )
 {
     public static MarketEvent Trade(DateTimeOffset ts, string symbol, Trade trade, long seq = 0, string source = "IB")
@@ -135,6 +138,19 @@ public sealed record MarketEvent(
     /// to ensure consistent behavior regardless of canonicalization state.
     /// </summary>
     public string EffectiveSymbol => CanonicalSymbol ?? Symbol;
+
+    /// <summary>
+    /// Stamps the event with trace context captured at ingress so downstream sinks,
+    /// logs, and dead-letter flows can correlate records without relying on ambient Activity state.
+    /// </summary>
+    public MarketEvent StampTraceContext(ActivityContext parentContext)
+        => parentContext.TraceId == default
+            ? this
+            : this with
+            {
+                TraceId = parentContext.TraceId.ToString(),
+                ParentSpanId = parentContext.SpanId.ToString()
+            };
 
     /// <summary>
     /// Computes the estimated end-to-end latency in milliseconds using monotonic clock,

--- a/tests/Meridian.Tests/Application/Pipeline/EventPipelineTracePropagationTests.cs
+++ b/tests/Meridian.Tests/Application/Pipeline/EventPipelineTracePropagationTests.cs
@@ -31,6 +31,8 @@ public sealed class EventPipelineTracePropagationTests
         sink.ParentSpanIds[0].Should().NotBeNullOrWhiteSpace();
         sink.ParentSpanIds[0].Should().NotBe(parentActivity.SpanId.ToString());
         sink.OperationNames.Should().ContainSingle(name => name == "StoreMarketEvent.TraceCapturingSink");
+        sink.EventTraceIds.Should().ContainSingle(parentActivity.TraceId.ToString());
+        sink.EventParentSpanIds.Should().ContainSingle(parentActivity.SpanId.ToString());
     }
 
     [Fact]
@@ -45,6 +47,8 @@ public sealed class EventPipelineTracePropagationTests
 
         sink.TraceIds.Should().ContainSingle(id => !string.IsNullOrWhiteSpace(id));
         sink.OperationNames.Should().ContainSingle(name => name == "StoreMarketEvent.TraceCapturingSink");
+        sink.EventTraceIds.Should().ContainSingle(id => string.IsNullOrWhiteSpace(id));
+        sink.EventParentSpanIds.Should().ContainSingle(id => string.IsNullOrWhiteSpace(id));
     }
 
     private static ActivityListener CreateListener()
@@ -80,6 +84,8 @@ public sealed class EventPipelineTracePropagationTests
         private readonly List<string?> _traceIds = new();
         private readonly List<string?> _parentSpanIds = new();
         private readonly List<string?> _operationNames = new();
+        private readonly List<string?> _eventTraceIds = new();
+        private readonly List<string?> _eventParentSpanIds = new();
         private readonly TaskCompletionSource<bool> _received = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public IReadOnlyList<string?> TraceIds => _traceIds;
@@ -88,11 +94,17 @@ public sealed class EventPipelineTracePropagationTests
 
         public IReadOnlyList<string?> OperationNames => _operationNames;
 
+        public IReadOnlyList<string?> EventTraceIds => _eventTraceIds;
+
+        public IReadOnlyList<string?> EventParentSpanIds => _eventParentSpanIds;
+
         public ValueTask AppendAsync(MarketEvent evt, CancellationToken ct = default)
         {
             _traceIds.Add(Activity.Current?.TraceId.ToString());
             _parentSpanIds.Add(Activity.Current?.ParentSpanId.ToString());
             _operationNames.Add(Activity.Current?.OperationName);
+            _eventTraceIds.Add(evt.TraceId);
+            _eventParentSpanIds.Add(evt.ParentSpanId);
             _received.TrySetResult(true);
             return ValueTask.CompletedTask;
         }


### PR DESCRIPTION
### Motivation
- Provide end-to-end trace correlation through the event pipeline so sinks, logs, and dead-letter flows can be correlated by trace ID instead of relying only on ambient `Activity` state.
- Close the roadmap item for E2E trace propagation (3.1) by stamping ingress trace context onto events and restoring it during processing/storage spans.

### Description
- Add `TraceId` and `ParentSpanId` fields to `MarketEvent` and a helper `StampTraceContext(ActivityContext)` to persist ingress trace context on the event record.
- Update `EventPipeline.CaptureTraceContext` to capture the current `EventTraceContext` and, when a parent context exists, `StampTraceContext` onto the queued `MarketEvent` while still carrying the `TracedMarketEvent` wrapper for span propagation.
- Extend `EventPipelineTracePropagationTests` to assert both ambient-span propagation (`Activity.Current`) and persisted event-level metadata (`evt.TraceId`, `evt.ParentSpanId`) for parent-context and no-parent-context scenarios.
- Mark the evaluation/roadmap item `3.1 End-to-End Trace Context Propagation` as done (2026-03-24) in `docs/evaluations/high-impact-improvement-brainstorm-2026-03.md`.

### Testing
- Attempted to run the focused unit tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter EventPipelineTracePropagationTests`, but the environment lacks `dotnet` and the command failed (`/bin/bash: dotnet: command not found`).
- Tests were updated to cover the new behavior (`EventPipelineTracePropagationTests`) but could not be executed in this environment due to the missing .NET SDK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c31510a1fc8320851d5b3e180a9a60)