### PR TITLE
feat(security-master): productize full-text search, cache warm-up, pagination, and options validation

### DIFF
--- a/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
@@ -14,6 +14,7 @@ using Meridian.Storage.Policies;
 using Meridian.Storage.SecurityMaster;
 using Meridian.Storage.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Meridian.Application.Composition.Features;
 
@@ -91,6 +92,7 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
             ReplayBatchSize = ParseInt("MERIDIAN_DIRECT_LENDING_REPLAY_BATCH_SIZE", 250)
         });
 
+        services.AddSingleton<IValidateOptions<SecurityMasterOptions>, SecurityMasterOptionsValidator>();
         services.AddSingleton<ISecurityMasterEventStore, PostgresSecurityMasterEventStore>();
         services.AddSingleton<ISecurityMasterSnapshotStore, PostgresSecurityMasterSnapshotStore>();
         services.AddSingleton<ISecurityMasterStore, PostgresSecurityMasterStore>();
@@ -102,6 +104,7 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
         services.AddSingleton<ISecurityMasterService, SecurityMasterService>();
         services.AddSingleton<ISecurityMasterQueryService, SecurityMasterQueryService>();
         services.AddSingleton<ISecurityResolver, SecurityResolver>();
+        services.AddHostedService<SecurityMasterProjectionWarmupService>();
         services.AddSingleton<DirectLendingEventRebuilder>();
         services.AddSingleton<IDirectLendingStateStore, PostgresDirectLendingStateStore>();
         services.AddSingleton<IDirectLendingOperationsStore>(sp => (PostgresDirectLendingStateStore)sp.GetRequiredService<IDirectLendingStateStore>());

--- a/src/Meridian.Application/SecurityMaster/SecurityMasterOptionsValidator.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterOptionsValidator.cs
@@ -1,0 +1,42 @@
+using Meridian.Contracts.SecurityMaster;
+using Microsoft.Extensions.Options;
+
+namespace Meridian.Application.SecurityMaster;
+
+/// <summary>
+/// Validates <see cref="SecurityMasterOptions"/> at startup so misconfigured
+/// connection strings or out-of-range tuning parameters are caught early.
+/// </summary>
+public sealed class SecurityMasterOptionsValidator : IValidateOptions<SecurityMasterOptions>
+{
+    public ValidateOptionsResult Validate(string? name, SecurityMasterOptions options)
+    {
+        var failures = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(options.ConnectionString))
+        {
+            failures.Add(
+                $"{nameof(SecurityMasterOptions.ConnectionString)} is required. " +
+                "Set the MERIDIAN_SECURITY_MASTER_CONNECTION_STRING environment variable.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Schema))
+        {
+            failures.Add($"{nameof(SecurityMasterOptions.Schema)} must not be empty.");
+        }
+
+        if (options.SnapshotIntervalVersions < 1)
+        {
+            failures.Add($"{nameof(SecurityMasterOptions.SnapshotIntervalVersions)} must be >= 1 (got {options.SnapshotIntervalVersions}).");
+        }
+
+        if (options.ProjectionReplayBatchSize < 1)
+        {
+            failures.Add($"{nameof(SecurityMasterOptions.ProjectionReplayBatchSize)} must be >= 1 (got {options.ProjectionReplayBatchSize}).");
+        }
+
+        return failures.Count > 0
+            ? ValidateOptionsResult.Fail(failures)
+            : ValidateOptionsResult.Success;
+    }
+}

--- a/src/Meridian.Application/SecurityMaster/SecurityMasterProjectionWarmupService.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterProjectionWarmupService.cs
@@ -1,0 +1,54 @@
+using Meridian.Contracts.SecurityMaster;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Application.SecurityMaster;
+
+/// <summary>
+/// Hosted service that warms the in-memory projection cache on startup when
+/// <see cref="SecurityMasterOptions.PreloadProjectionCache"/> is enabled.
+/// This eliminates cold-start latency for the first queries after deployment.
+/// </summary>
+public sealed class SecurityMasterProjectionWarmupService : IHostedService
+{
+    private readonly SecurityMasterProjectionService _projectionService;
+    private readonly SecurityMasterOptions _options;
+    private readonly ILogger<SecurityMasterProjectionWarmupService> _logger;
+
+    public SecurityMasterProjectionWarmupService(
+        SecurityMasterProjectionService projectionService,
+        SecurityMasterOptions options,
+        ILogger<SecurityMasterProjectionWarmupService> logger)
+    {
+        _projectionService = projectionService;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!_options.PreloadProjectionCache)
+        {
+            _logger.LogDebug("Security Master projection cache pre-warm is disabled (PreloadProjectionCache=false).");
+            return;
+        }
+
+        _logger.LogInformation("Warming Security Master projection cache on startup...");
+
+        try
+        {
+            await _projectionService.WarmAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogWarning("Security Master projection cache warm-up was cancelled during startup.");
+        }
+        catch (Exception ex)
+        {
+            // Log and continue — a warm cache is a performance optimisation, not a hard requirement.
+            _logger.LogError(ex, "Security Master projection cache warm-up failed; queries will hit the database directly.");
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Meridian.Contracts/SecurityMaster/SecurityQueries.cs
+++ b/src/Meridian.Contracts/SecurityMaster/SecurityQueries.cs
@@ -10,6 +10,7 @@ public sealed record ResolveSecurityRequest(
 public sealed record SecuritySearchRequest(
     string Query,
     int Take = 50,
+    int Skip = 0,
     bool ActiveOnly = false);
 
 public sealed record SecurityHistoryRequest(

--- a/src/Meridian.Storage/SecurityMaster/Migrations/002_security_master_fts.sql
+++ b/src/Meridian.Storage/SecurityMaster/Migrations/002_security_master_fts.sql
@@ -1,0 +1,28 @@
+-- Migration 002: Full-text search support for security master
+-- Adds a trigger to keep search_vector populated and a GIN index for fast queries.
+
+create or replace function __SCHEMA__.update_security_search_vector()
+returns trigger as $$
+begin
+    new.search_vector :=
+        setweight(to_tsvector('simple', coalesce(new.display_name, '')), 'A') ||
+        setweight(to_tsvector('simple', coalesce(new.primary_identifier_value, '')), 'A') ||
+        setweight(to_tsvector('simple', coalesce(new.asset_class, '')), 'B') ||
+        setweight(to_tsvector('simple', coalesce(new.issuer_name, '')), 'B') ||
+        setweight(to_tsvector('simple', coalesce(new.exchange_code, '')), 'C') ||
+        setweight(to_tsvector('simple', coalesce(new.currency, '')), 'C');
+    return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists trg_security_search_vector on __SCHEMA__.securities;
+
+create trigger trg_security_search_vector
+    before insert or update on __SCHEMA__.securities
+    for each row execute function __SCHEMA__.update_security_search_vector();
+
+-- Backfill search_vector for any rows that predate this migration.
+update __SCHEMA__.securities set display_name = display_name where search_vector is null;
+
+create index if not exists ix_securities_search_vector
+    on __SCHEMA__.securities using gin(search_vector);

--- a/src/Meridian.Storage/SecurityMaster/PostgresSecurityMasterStore.cs
+++ b/src/Meridian.Storage/SecurityMaster/PostgresSecurityMasterStore.cs
@@ -123,20 +123,41 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
     {
         await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
         await using var command = connection.CreateCommand();
-        command.CommandText =
-            $"""
-            select security_id
-            from {Qualified("securities")}
-            where (
-                display_name ilike @pattern or
-                primary_identifier_value ilike @pattern)
-              and (@active_only = false or status = 'Active')
-            order by display_name
-            limit @take;
-            """;
-        command.Parameters.AddWithValue("pattern", $"%{request.Query}%");
+
+        var trimmedQuery = request.Query.Trim();
+        var useFts = trimmedQuery.Length >= 2;
+
+        // Use full-text search when the query is long enough for meaningful tokenisation.
+        // The ILIKE fallback catches short identifiers (e.g. "GE", "T") that tsvector skips.
+        command.CommandText = useFts
+            ? $"""
+               select security_id,
+                      ts_rank(search_vector, plainto_tsquery('simple', @query)) as rank
+               from {Qualified("securities")}
+               where (
+                   search_vector @@ plainto_tsquery('simple', @query)
+                   or display_name ilike @pattern
+                   or primary_identifier_value ilike @pattern)
+                 and (@active_only = false or status = 'Active')
+               order by rank desc, display_name
+               limit @take offset @skip;
+               """
+            : $"""
+               select security_id, 0::float4 as rank
+               from {Qualified("securities")}
+               where (
+                   display_name ilike @pattern
+                   or primary_identifier_value ilike @pattern)
+                 and (@active_only = false or status = 'Active')
+               order by display_name
+               limit @take offset @skip;
+               """;
+
+        command.Parameters.AddWithValue("query", trimmedQuery);
+        command.Parameters.AddWithValue("pattern", $"%{trimmedQuery}%");
         command.Parameters.AddWithValue("active_only", request.ActiveOnly);
         command.Parameters.AddWithValue("take", request.Take);
+        command.Parameters.AddWithValue("skip", request.Skip);
 
         var ids = new List<Guid>();
         await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);


### PR DESCRIPTION
## Summary

Closes the four highest-priority productization gaps in the Security Master module identified during audit:

- **Full-text search (migration 002)** – A `BEFORE INSERT/UPDATE` trigger populates `search_vector` from `display_name`, `primary_identifier_value`, `asset_class`, `issuer_name`, `exchange_code`, and `currency` (A/B/C weights). Existing rows are backfilled. A GIN index is created for fast `@@` queries. The `search_vector` column was defined in migration 001 but never populated.

- **Ranked search** – `SearchAsync` now uses `plainto_tsquery('simple', ...)` when the query is ≥2 characters, ordering results by `ts_rank` for relevance. A `display_name / primary_identifier_value ILIKE` fallback is included in the same query so short ticker symbols like "T" or "GE" are still matched.

- **Pagination** – `SecuritySearchRequest` gains a `Skip` parameter (default `0`). The SQL uses `LIMIT @take OFFSET @skip` so callers can page through results without re-fetching.

- **Cache warm-up** – `SecurityMasterProjectionWarmupService` is a new `IHostedService` that calls `SecurityMasterProjectionService.WarmAsync` on startup when `PreloadProjectionCache=true` (env `MERIDIAN_SECURITY_MASTER_PRELOAD_CACHE`, default `true`). Errors during warm-up are logged but not fatal; queries fall through to the database.

- **Options validation** – `SecurityMasterOptionsValidator` implements `IValidateOptions<SecurityMasterOptions>` and checks that `ConnectionString` and `Schema` are non-empty and that tuning parameters are in range. Registered in DI so tests and infrastructure tooling can validate configuration early.

## Files changed

| File | Change |
|------|--------|
| `Migrations/002_security_master_fts.sql` | New migration: trigger, backfill, GIN index |
| `PostgresSecurityMasterStore.cs` | FTS + ILIKE combined query, LIMIT/OFFSET pagination |
| `SecurityQueries.cs` | `Skip` added to `SecuritySearchRequest` |
| `SecurityMasterProjectionWarmupService.cs` | New `IHostedService` for cache pre-warm |
| `SecurityMasterOptionsValidator.cs` | New `IValidateOptions<SecurityMasterOptions>` |
| `StorageFeatureRegistration.cs` | Registers validator and warmup hosted service |

## Test plan

- [x] `dotnet build Meridian.sln -c Release /p:EnableWindowsTargeting=true` — 0 errors
- [x] `dotnet test tests/Meridian.Tests --filter SecurityMaster` — 20 passed, 3 skipped (Postgres integration tests require live DB)
- [ ] Integration: run migration against Postgres and verify `search_vector` is populated on insert and `SELECT ... @@ plainto_tsquery('simple', 'aapl')` returns results
- [ ] Integration: verify `SecurityMasterProjectionWarmupService` logs `Warmed security master projection cache` on startup

## Risks / tradeoffs

- `'simple'` dictionary used (not `'english'`) so ticker symbols and short codes are not stemmed — this is intentional for financial identifiers.
- The ILIKE clause in the FTS branch means a partial-match fallback is always evaluated; this is fine at current scale and can be removed once the FTS path is proven in production.
- `Skip` is offset-based (not cursor-based); suitable for low-volume admin UI use, not for high-throughput streaming pagination.

https://claude.ai/code/session_01RWnaw7QydxhFxKJubce9fF