### PR TITLE
fix(wpf): close discoverability gaps, add workspace shells, refresh docs

### DIFF
--- a/docs/development/wpf-implementation-notes.md
+++ b/docs/development/wpf-implementation-notes.md
@@ -1,248 +1,359 @@
-> **⚠️ DELAYED IMPLEMENTATION** — The WPF desktop app (`src/Meridian.Wpf/`) is not included in the active solution build. Code is preserved for future use. This document is retained as a reference for when WPF development resumes.
+> **⚠️ DELAYED BUILD** — `src/Meridian.Wpf/` is not included in the active solution build target. Code is fully authored and preserved; delayed per ADR-016. Build separately with `dotnet build src/Meridian.Wpf/Meridian.Wpf.csproj /p:EnableWindowsTargeting=true`.
 
 ---
 
-# WPF Desktop Application Implementation Notes
+# WPF Desktop Application — Implementation Notes
+
+**Version**: 1.7.x | **Last updated**: 2026-03-25 | **Status**: Authored / Build-delayed
 
 ## Overview
 
-This document describes the WPF desktop application implementation, which is the sole desktop UI for Meridian.
+Meridian's WPF desktop application (`src/Meridian.Wpf/`) is the sole native Windows desktop surface for the platform. It exposes the full Meridian capability set through a workspace-based shell with a command palette, four canonical workspaces (Research, Trading, Data Operations, Governance), and deep drill-in pages for strategy runs, portfolios, and ledger governance.
 
-## Implementation Scope
+## Architecture
 
-### Core Application Structure
-- **Project**: `Meridian.Wpf` (located in `src/Meridian.Wpf/`)
-- **Framework**: .NET 9.0 with WPF (Windows Presentation Foundation)
-- **Target**: Windows-only desktop deployment
-- **Architecture**: MVVM pattern with singleton services
+### Stack
+- **.NET 9.0 + WPF** — Windows-only, `.csproj` targets `net9.0-windows`
+- **MVVM** — `BindableBase` (from `Meridian.Ui.Services.Services`) + `INotifyPropertyChanged`
+- **DI** — `Microsoft.Extensions.Hosting`; singleton services resolved via `IServiceProvider`
+- **Shared services** — `Meridian.Ui.Services` and `Meridian.Ui.Shared` for cross-surface logic
 
-### Key Components
-
-#### Services Layer (10 Core Services)
-1. **NavigationService** - Centralized page navigation with history tracking
-2. **ConfigService** - Application configuration management
-3. **StatusService** - Real-time status tracking and API communication
-4. **ConnectionService** - Provider connection state management
-5. **ThemeService** - Dark/Light theme management
-6. **NotificationService** - Toast notifications and alerts
-7. **LoggingService** - Structured logging
-8. **KeyboardShortcutService** - Global keyboard shortcuts (20+ shortcuts)
-9. **MessagingService** - Inter-component messaging
-10. **FirstRunService** - First-run setup wizard
-
-#### Background Services (3 Services)
-1. **BackgroundTaskSchedulerService** - Scheduled task execution
-2. **OfflineTrackingPersistenceService** - Offline data tracking
-3. **PendingOperationsQueueService** - Offline operation queue
-
-#### View Pages (40+ Pages)
-Organized into categories:
-- **Primary Navigation**: Dashboard, Watchlist
-- **Data Sources**: Provider configuration, health monitoring
-- **Data Management**: Live data viewer, browser, symbols, backfill, storage
-- **Monitoring**: Data quality, collection sessions, archive health, system health
-- **Tools**: Data export, sampling, analysis, event replay
-- **Settings**: Configuration, credentials, notifications
-
-### Architecture Patterns
-
-#### Dependency Injection
-- Uses Microsoft.Extensions.Hosting for service registration
-- Singleton pattern for stateful services
-- IServiceProvider for service resolution
-
-#### Navigation
-- Frame-based navigation with System.Windows.Controls.Frame
-- Page registry for tag-based navigation
-- Navigation history with breadcrumb support
-- Back navigation support
-
-#### Event Management
-- Proper event subscription/unsubscription in page lifecycle
-- OnPageLoaded and OnPageUnloaded handlers
-- Prevents memory leaks through proper cleanup
-
-#### Configuration Management
-- Singleton ConfigService with ConfigPath property
-- Integration with FirstRunService for initial setup
-- Validation support with ConfigValidationResult
-
-#### Connection Management
-- Async connect/disconnect operations
-- Connection state change events
-- Latency tracking
-- Provider-agnostic interface
-
-### Key Features
-
-#### Keyboard Shortcuts (20+ Shortcuts)
-- **Navigation**: Ctrl+D (Dashboard), Ctrl+B (Backfill), Ctrl+S (Settings)
-- **Collector Control**: Ctrl+Shift+S (Start), Ctrl+Shift+Q (Stop)
-- **Symbol Management**: Ctrl+N (Add), Ctrl+F (Search), Delete (Remove)
-- **Backfill**: Ctrl+R (Run), Ctrl+Shift+P (Pause), Esc (Cancel)
-- **View**: Ctrl+T (Toggle Theme), F5 (Refresh)
-
-#### Real-Time Updates
-- HTTP polling-based status updates (2-second intervals)
-- WebSocket support planned for future enhancement
-- StatusService provides GetStatusAsync() for API integration
-
-#### Theme Support
-- Dark and Light themes
-- Theme persistence
-- Windows system theme integration
-- Dynamic theme switching (Ctrl+T)
-
-#### Graceful Shutdown
-- Coordinated service shutdown with timeout (5 seconds)
-- Parallel shutdown of background services
-- Proper exception handling during shutdown
-
-### Technical Decisions
-
-#### Why WPF over WinUI 3?
-1. **No XAML Compiler Restrictions** - Can use standard ProjectReference patterns
-2. **Mature Framework** - Stable API with extensive community support
-3. **Better Integration** - Easier integration with existing .NET libraries
-4. **Simpler Build** - No Windows App SDK complications
-
-#### Service Singleton Pattern
-All services use singleton pattern for application-wide state:
-```csharp
-public static ServiceName Instance => _instance.Value;
-```
-
-Benefits:
-- Single source of truth for application state
-- Thread-safe initialization with Lazy<T>
-- Easy access from any component
-
-#### Namespace Alias for Navigation
-To avoid ambiguity between `System.Windows.Navigation` and `Meridian.Wpf.Services.NavigationService`:
-```csharp
-using SysNavigation = System.Windows.Navigation;
-```
-
-### Build Verification
-
-#### Current Status
-✅ **Build**: Successful with 0 warnings, 0 errors
-✅ **Dependencies**: All NuGet packages resolved
-✅ **Solution Integration**: Properly integrated in Meridian.sln
-✅ **Project GUID**: Valid GUID `{6F8D3A55-3E95-4F9D-9C8F-DBA9A6230B1E}`
-
-#### Build Command
-```bash
-dotnet build src/Meridian.Wpf/Meridian.Wpf.csproj -c Release
-```
-
-### Code Review Findings - All Resolved
-
-All critical issues identified in the code review have been addressed:
-
-1. ✅ **Solution File GUID** - Replaced invalid GUID with valid one
-2. ✅ **ConfigService.ConfigPath** - Property implemented
-3. ✅ **DataBrowser Navigation** - Tag registered in NavigationService
-4. ✅ **Event Cleanup** - OnPageUnloaded handlers added
-5. ✅ **NavigationService Ambiguity** - Resolved with namespace alias
-6. ✅ **StatusService.GetStatusAsync()** - Method implemented
-7. ✅ **Navigation History** - Only pushed after successful navigation
-8. ✅ **CanGoBack Property** - Based on Frame.CanGoBack
-
-### Future Enhancements
-
-#### Near-Term
-1. Replace HTTP polling with WebSocket/SignalR for real-time updates
-2. Implement connection to backend Meridian service
-3. Implement actual configuration persistence (currently stub)
-
-#### Long-Term
-1. Consider Blazor Hybrid for cross-platform compatibility
-2. Add mobile companion app for monitoring
-3. Implement offline-first architecture with sync
-4. Add multi-user collaboration features
-
-### Documentation
-
-Related documentation:
-- **Evaluation**: `docs/evaluations/desktop-ui-alternatives-evaluation.md`
-- **Migration History**: [UWP to WPF Migration](https://github.com/rodoHasArrived/Meridian/blob/main/archive/docs/migrations/uwp-to-wpf-migration.md) (archived)
-
-### Testing
-
-#### Unit Tests (272 tests)
-
-Desktop services have comprehensive unit test coverage across two projects:
-
-- **Meridian.Wpf.Tests** (101 tests): NavigationService, ConfigService, StatusService, ConnectionService, WpfDataQualityService
-- **Meridian.Ui.Tests** (171 tests): ApiClient, Backfill, Charting, FixtureData, FormValidation, SystemHealth, Watchlist, collections, and more
-
-Run tests with `make test-desktop-services`. See [Desktop Testing Guide](./desktop-testing-guide.md) for details.
-
-#### Manual Testing Checklist
-- [ ] Application launches successfully
-- [ ] Navigation between pages works
-- [ ] Keyboard shortcuts respond correctly
-- [ ] Theme switching works
-- [ ] Status updates display correctly
-- [ ] Settings page shows configuration path
-- [ ] Graceful shutdown completes within timeout
-- [ ] Background services start and stop correctly
-
-### Contributing
-
-When modifying the WPF application:
-
-1. **Follow Existing Patterns**
-   - Use singleton pattern for services
-   - Implement OnPageLoaded and OnPageUnloaded handlers
-   - Use async/await for I/O operations
-   - Add proper exception handling
-
-2. **Event Management**
-   - Always unsubscribe in OnPageUnloaded
-   - Use weak references for long-lived subscriptions
-   - Avoid circular references
-
-3. **Navigation**
-   - Register new pages in NavigationService.RegisterPages()
-   - Use tag-based navigation (e.g., "Dashboard")
-   - Handle navigation parameters correctly
-
-4. **Testing**
-   - Test keyboard shortcuts
-   - Verify memory cleanup (no leaks)
-   - Check graceful shutdown
-   - Validate configuration persistence
-
-### License
-
-MIT License - Same as parent project
-
-### Authors
-
-- Architecture Review Team
-- Meridian Contributors
+### Project references
+| Project | Role |
+|---------|------|
+| `Meridian.Wpf` | Views, code-behind, WPF-specific services |
+| `Meridian.Wpf.Tests` | 101 unit tests for WPF-specific services |
+| `Meridian.Ui.Services` | Shared service layer (CommandPaletteService, WorkspaceService, NavigationServiceBase, etc.) |
+| `Meridian.Ui.Tests` | 171 tests for shared UI services |
+| `Meridian.Ui.Shared` | Endpoint helpers, DTO extensions, HTML template generator |
+| `Meridian.Contracts` | Shared domain contracts, including `Workstation/StrategyRunReadModels.cs` |
 
 ---
 
-**Last Updated**: 2026-02-13
-**Status**: Implementation Complete, Documentation Expanded
+## Shell Architecture
+
+### MainPage — four-section sidebar + command palette
+
+```
+Left Sidebar (288 px)
+├── Header: logo, app title, version badge
+├── RESEARCH section  (7 items)
+├── TRADING section   (5 items)
+├── DATA OPS section  (6 items)
+├── GOVERNANCE section(6 items)
+└── Footer: Ctrl+K command palette button, Help button
+
+Top Header Bar (74 px)
+├── Left: Back button, breadcrumb page title + description
+└── Right: Connection status badge, Refresh, Notifications
+
+Content Frame
+├── Fixture Mode Banner (orange, conditional on non-live mode)
+└── WPF Frame → page navigation
+```
+
+**Workspace-aware navigation** — `ResolveWorkspaceIdForPage()` maps a page tag to its home workspace so that clicking a sidebar item or executing a command palette entry also activates the correct workspace session state.
+
+**Selection suppression** — `_suppressNavSelection` prevents feedback loops when the NavigationService drives sidebar selection changes programmatically.
+
+### Workspace system (`WorkspaceService`, `WorkspacePage`)
+
+Four built-in workspace templates:
+
+| Workspace ID | Pages |
+|---|---|
+| `research` | Dashboard, LiveData, Charts, RunMat, StrategyRuns, OrderBook, Watchlist |
+| `trading` | Backtest, StrategyRuns, LeanIntegration, PortfolioImport, TradingHours |
+| `data-operations` | Provider, Symbols, Backfill, Storage, DataExport, PackageManager, Schedules |
+| `governance` | DataQuality, ProviderHealth, SystemHealth, Diagnostics, Settings, AdminMaintenance |
+
+Each workspace persists:
+- `ActivePageTag` — last active page within the workspace
+- `OpenPages` — MRU list (max 8)
+- `WidgetLayout`, `ActiveFilters`, `WorkspaceContext` — per-workspace state
+- `WindowBounds` — restored on session resume
+
+### Command Palette (`CommandPaletteService`, `Ctrl+K`)
+
+- **~55 navigation commands** — one per registered page, each labelled with its workspace context
+- **8 action commands** — Start/Stop collector, Run backfill, Refresh, Add symbol, Toggle theme, Save, Search
+- **Fuzzy search** — exact → prefix → contains → character-sequence fuzzy, top-15 results
+- **Recency tracking** — LRU 10, shown when palette opens empty
+- **Workspace labels** in descriptions: `Research workspace — Dashboard`, `Trading workspace — LiveData`, etc.
+
+---
+
+## Page Registry
+
+All pages registered in `NavigationService.RegisterAllPages()` and declared in `Views/Pages.cs`.
+
+### Research workspace pages
+| Tag | Class | Notes |
+|-----|-------|-------|
+| `Dashboard` | `DashboardPage` | Default landing page |
+| `Watchlist` | `WatchlistPage` | |
+| `RunMat` | `RunMatPage` | Quant / script lab |
+| `Charts` | `ChartingPage` | Candlestick / time-series |
+| `OrderBook` | `OrderBookPage` | Live L2 depth |
+| `StrategyRuns` | `StrategyRunsPage` | Strategy run browser |
+| `RunDetail` | `RunDetailPage` | Run execution summary drill-in |
+| `AdvancedAnalytics` | `AdvancedAnalyticsPage` | |
+
+### Trading workspace pages
+| Tag | Class | Notes |
+|-----|-------|-------|
+| `Backtest` | `BacktestPage` | |
+| `LiveData` | `LiveDataViewerPage` | Real-time feed viewer |
+| `RunPortfolio` | `RunPortfolioPage` | Positions, exposure, P&L drill-in |
+| `LeanIntegration` | `LeanIntegrationPage` | QuantConnect Lean engine |
+| `PortfolioImport` | `PortfolioImportPage` | CSV/bulk import |
+| `TradingHours` | `TradingHoursPage` | Market calendar |
+
+### Data Operations workspace pages
+| Tag | Class |
+|-----|-------|
+| `Provider` | `ProviderPage` |
+| `DataSources` | `DataSourcesPage` |
+| `Symbols` | `SymbolsPage` |
+| `SymbolMapping` | `SymbolMappingPage` |
+| `SymbolStorage` | `SymbolStoragePage` |
+| `IndexSubscription` | `IndexSubscriptionPage` |
+| `Options` | `OptionsPage` |
+| `Backfill` | `BackfillPage` |
+| `Storage` | `StoragePage` |
+| `DataBrowser` | `DataBrowserPage` |
+| `DataCalendar` | `DataCalendarPage` |
+| `DataExport` | `DataExportPage` |
+| `DataSampling` | `DataSamplingPage` |
+| `TimeSeriesAlignment` | `TimeSeriesAlignmentPage` |
+| `AnalysisExport` | `AnalysisExportPage` |
+| `AnalysisExportWizard` | `AnalysisExportWizardPage` |
+| `ExportPresets` | `ExportPresetsPage` |
+| `EventReplay` | `EventReplayPage` |
+| `PackageManager` | `PackageManagerPage` |
+| `Schedules` | `ScheduleManagerPage` |
+
+### Governance workspace pages
+| Tag | Class |
+|-----|-------|
+| `DataQuality` | `DataQualityPage` |
+| `ProviderHealth` | `ProviderHealthPage` |
+| `CollectionSessions` | `CollectionSessionPage` |
+| `ArchiveHealth` | `ArchiveHealthPage` |
+| `ServiceManager` | `ServiceManagerPage` |
+| `SystemHealth` | `SystemHealthPage` |
+| `Diagnostics` | `DiagnosticsPage` |
+| `StorageOptimization` | `StorageOptimizationPage` |
+| `RetentionAssurance` | `RetentionAssurancePage` |
+| `AdminMaintenance` | `AdminMaintenancePage` |
+| `RunLedger` | `RunLedgerPage` |
+| `ActivityLog` | `ActivityLogPage` |
+| `MessagingHub` | `MessagingHubPage` |
+| `NotificationCenter` | `NotificationCenterPage` |
+
+### Support / cross-workspace pages
+| Tag | Class |
+|-----|-------|
+| `Help` | `HelpPage` |
+| `Welcome` | `WelcomePage` |
+| `Settings` | `SettingsPage` |
+| `KeyboardShortcuts` | `KeyboardShortcutsPage` |
+| `SetupWizard` | `SetupWizardPage` |
+| `AddProviderWizard` | `AddProviderWizardPage` |
+| `Workspaces` | `WorkspacePage` |
+
+---
+
+## Shared Workstation Contracts
+
+All workstation-facing read models live in `src/Meridian.Contracts/Workstation/`.
+
+### `StrategyRunReadModels.cs`
+
+```
+StrategyRunMode           — Backtest | Paper | Live
+StrategyRunEngine         — MeridianNative | Lean | BrokerPaper | BrokerLive
+StrategyRunStatus         — Pending | Running | Paused | Completed | Failed | Cancelled | Stopped
+StrategyRunPromotionState — None → CandidateForPaper → CandidateForLive → LiveManaged
+
+StrategyRunSummary        — summary row for browser / recent-run list
+StrategyRunDetail         — expanded detail; embeds Portfolio + Ledger summaries
+StrategyRunExecutionSummary — fills, commissions, margin, audit flags
+StrategyRunPromotionSummary — promotion state + reasoning
+StrategyRunGovernanceSummary — parameter/portfolio/ledger/audit coverage flags
+StrategyRunComparison     — side-by-side multi-run comparison row (Sharpe, drawdown, XIRR)
+
+PortfolioSummary          — equity, cash, gross/net exposure, realized/unrealized P&L, positions
+PortfolioPositionSummary  — per-symbol: quantity, cost-basis, P&L, security ref
+LedgerSummary             — asset/liability/equity/revenue/expense balances, trial-balance, journal
+LedgerTrialBalanceLine    — account row with symbol and security resolution
+LedgerJournalLine         — journal entry row (debits, credits, description)
+WorkstationSecurityReference — lightweight Security Master ref used by portfolio + ledger surfaces
+```
+
+### `ReconciliationDtos.cs`
+
+```
+ReconciliationRunRequest  — RunId, tolerance thresholds
+ReconciliationBreakDto    — check ID, category, status, variance, source metadata
+ReconciliationBreakCategory — AmountMismatch | MissingLedgerCoverage | MissingPortfolioCoverage | ...
+```
+
+---
+
+## Strategy Run Workstation — ViewModel Layer
+
+| ViewModel | Key properties | Commands |
+|-----------|----------------|----------|
+| `StrategyRunBrowserViewModel` | `Runs`, `SearchText`, `SelectedModeFilter` | `RefreshCommand`, `OpenDetailCommand`, `OpenPortfolioCommand`, `OpenLedgerCommand` |
+| `StrategyRunDetailViewModel` | Execution summary, mode, timing, P&L, parameters | Cross-nav to Browser / Portfolio / Ledger |
+| `StrategyRunPortfolioViewModel` | `TotalEquity`, `Cash`, exposure, `Positions` | Security Master resolve count |
+| `StrategyRunLedgerViewModel` | `TrialBalance`, `Journal`, account balances | Security resolve count |
+
+Parameter passing follows the standard MVVM drill-in pattern: `NavigationService.NavigateTo(tag, runId)` → `page.DataContext.Parameter = runId` → `LoadFromParameterAsync()`.
+
+---
+
+## Services Layer
+
+### WPF-specific services (`Meridian.Wpf.Services`)
+| Service | Responsibility |
+|---------|----------------|
+| `NavigationService` | Frame-based navigation; 50+ pages; history, breadcrumb, onboarding tour hooks |
+| `ConnectionService` | Provider connection state; latency tracking |
+| `ConfigService` | App configuration with `ConfigPath` |
+| `ThemeService` | Dark/Light; persisted; Windows accent integration |
+| `NotificationService` | Toast notifications and alert routing |
+| `LoggingService` | Structured log sink |
+| `KeyboardShortcutService` | 20+ global shortcuts |
+| `MessagingService` | Inter-component messaging bus |
+| `FirstRunService` | Setup wizard gating |
+| `WorkspaceService` | Workspace + session state persistence (re-export of shared base) |
+| `BackgroundTaskSchedulerService` | Scheduled background execution |
+| `OfflineTrackingPersistenceService` | Offline mode data tracking |
+| `PendingOperationsQueueService` | Offline operation queue |
+
+### Shared services (from `Meridian.Ui.Services`)
+`CommandPaletteService`, `NavigationServiceBase`, `WorkspaceService` base, `SearchService`, `FixtureModeDetector`, `OnboardingTourService`, `ActivityFeedService`, `AlertService`, `DataQualityPresentationService`, and 40+ additional services used by both the WPF app and the web dashboard.
+
+---
+
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+K` | Open command palette |
+| `Ctrl+D` | Dashboard |
+| `Ctrl+B` | Backfill |
+| `Ctrl+W` | Watchlist |
+| `Ctrl+Y` | Symbols |
+| `Ctrl+Q` | Data Quality |
+| `Ctrl+0` | Settings |
+| `Ctrl+Shift+B` | Backtest |
+| `Ctrl+Shift+S` | Start collector |
+| `Ctrl+Shift+Q` | Stop collector |
+| `Ctrl+Shift+T` | Toggle theme |
+| `Ctrl+R` | Run backfill |
+| `Ctrl+N` | Add symbol |
+| `Ctrl+F` | Search symbols |
+| `Ctrl+S` | Save |
+| `F1` | Help |
+| `F5` | Refresh |
+
+---
+
+## XAML Style System
+
+Style resources in `Meridian.Wpf/Styles/`:
+
+| File | Contains |
+|------|----------|
+| `ThemeTokens.xaml` | Semantic color tokens (`ConsoleTextPrimaryBrush`, `InfoColorBrush`, etc.) |
+| `ThemeSurfaces.xaml` | Surface-level brushes (`ShellWindowBackgroundBrush`, `ShellRailBackgroundBrush`) |
+| `ThemeControls.xaml` | Control styles (`NavItemStyle`, `CardStyle`, `PrimaryButtonStyle`, etc.) |
+| `ThemeTypography.xaml` | Text styles (`PageTitleStyle`, `CardHeaderStyle`, `CardDescriptionStyle`) |
+| `AppStyles.xaml` | Root merge dictionary |
+| `Animations.xaml` | Shared transition animations |
+| `IconResources.xaml` | Segoe Fluent Icons aliases |
+
+---
+
+## Research and Trading Workspace Shells
+
+Two dedicated workspace shell pages provide the initial entry point into each primary workflow. They are lightweight presenter pages — no deep data logic — that surface the workspace's key metrics and provide quick navigation entry points to drill-in pages.
+
+### `ResearchWorkspaceShellPage` (`Views/ResearchWorkspaceShellPage.xaml`)
+
+**Purpose**: Single-page landing for the Research workspace. Shows recent strategy runs, performance at a glance, and quick-links to Backtest, RunMat, Charts, and the run browser.
+
+**Design zones**:
+1. **Header** — Active strategy count, cumulative P&L across completed runs, last-run timestamp
+2. **Recent Runs strip** — Horizontal scroll, `StrategyRunSummary` cards (mode badge, status, net P&L, return %)
+3. **Quick Actions** — New Backtest, Open RunMat, Open Charts, Open Run Browser
+4. **Promotion Pipeline** — Candidates for paper promotion (sourced from `StrategyRunPromotionState`)
+
+### `TradingWorkspaceShellPage` (`Views/TradingWorkspaceShellPage.xaml`)
+
+**Purpose**: Single-page landing for the Trading workspace. Shows live execution state, active paper/live positions, and key risk metrics.
+
+**Design zones**:
+1. **Header** — Active run count (paper + live), total equity under management, connection status
+2. **Live Positions strip** — `PortfolioPositionSummary` rows for active paper/live runs; gross/net exposure
+3. **Quick Actions** — Open Live Data, Open Portfolio, Import Positions, View Trading Hours
+4. **Risk Rail** — Drawdown gauge, position-limit utilization, order-rate throttle status (from `CompositeRiskValidator`)
+
+---
+
+## Build
+
+```bash
+# Standalone WPF build (Windows or cross-platform with Windows targeting)
+dotnet build src/Meridian.Wpf/Meridian.Wpf.csproj /p:EnableWindowsTargeting=true -c Release
+
+# WPF + shared UI services tests
+dotnet test tests/Meridian.Wpf.Tests /p:EnableWindowsTargeting=true
+dotnet test tests/Meridian.Ui.Tests /p:EnableWindowsTargeting=true
+```
+
+### Common errors
+
+| Error | Fix |
+|-------|-----|
+| NETSDK1100 | Add `/p:EnableWindowsTargeting=true` on non-Windows hosts |
+| `NU1008` | Remove `Version="..."` from any `<PackageReference>` — versions live in `Directory.Packages.props` |
+| Page not found at runtime | Ensure page is declared in `Views/Pages.cs` **and** registered in `NavigationService.RegisterAllPages()` |
+
+---
+
+## Testing
+
+| Test project | Count | Covers |
+|---|---|---|
+| `Meridian.Wpf.Tests` | 101 | WPF-specific services: Navigation, Config, Connection, InfoBar, Keyboard, RunMat, etc. |
+| `Meridian.Ui.Tests` | 171 | Shared services: ApiClient, Backfill, Charting, Watchlist, DataQuality, StrategyRun drill-ins |
+
+Run with:
+```bash
+make test-desktop-services
+```
+
+---
+
+## Contributing
+
+1. **Register new pages** in both `Views/Pages.cs` (partial class) and `NavigationService.RegisterAllPages()`
+2. **Add command palette entry** in `CommandPaletteService.RegisterDefaultCommands()` — include workspace label in the `pageTag` argument so `BuildNavigationDescription` resolves correctly
+3. **Follow MVVM patterns** — all data logic in ViewModels; code-behind restricted to UI event wiring
+4. **Event cleanup** — always unsubscribe in `OnPageUnloaded` / `OnNavigatedFrom`
+5. **Use shared contracts** — workstation read models live in `Meridian.Contracts.Workstation`; never duplicate DTO types in the WPF project
 
 ---
 
 ## Related Documentation
 
-- **Desktop Development:**
-  - [Desktop Testing Guide](./desktop-testing-guide.md) - Comprehensive testing procedures
-  - [Desktop Platform Improvements](../evaluations/desktop-platform-improvements-implementation-guide.md) - Full improvement roadmap
-  - [Desktop Improvements - Executive Summary](../evaluations/desktop-improvements-executive-summary.md) - Impact analysis
-  - [Desktop Support Policy](./policies/desktop-support-policy.md) - Contribution requirements
-
-- **Architecture:**
-  - [Desktop Architecture Layers](../architecture/desktop-layers.md) - Layer boundaries
-  - [UI Fixture Mode Guide](./ui-fixture-mode-guide.md) - Offline development
-  - [Repository Organization Guide](./repository-organization-guide.md) - Code structure
-
-- **Planning:**
-  - [Project Roadmap](../status/ROADMAP.md) - Desktop roadmap items
+- [`docs/architecture/desktop-layers.md`](../architecture/desktop-layers.md) — Layer boundaries
+- [`docs/development/desktop-testing-guide.md`](./desktop-testing-guide.md) — Testing procedures
+- [`docs/evaluations/desktop-improvements-executive-summary.md`](../evaluations/desktop-improvements-executive-summary.md) — Platform improvement roadmap
+- [`docs/development/ui-fixture-mode-guide.md`](./ui-fixture-mode-guide.md) — Offline / fixture mode development
+- [`docs/status/ROADMAP.md`](../status/ROADMAP.md) — Desktop items in the project roadmap
+- [`docs/development/policies/desktop-support-policy.md`](./policies/desktop-support-policy.md) — Contribution requirements

--- a/src/Meridian.Ui.Services/Services/CommandPaletteService.cs
+++ b/src/Meridian.Ui.Services/Services/CommandPaletteService.cs
@@ -237,6 +237,10 @@ public sealed class CommandPaletteService
         RegisterNavigationCommand("nav-time-series", "Navigate to Time Series Alignment", "TimeSeriesAlignment", "time series alignment sync", "\uE916", "");
         RegisterNavigationCommand("nav-index-subscription", "Navigate to Index Subscription", "IndexSubscription", "index subscription sp500 nasdaq", "\uE71B", "");
         RegisterNavigationCommand("nav-symbol-storage", "Navigate to Symbol Storage", "SymbolStorage", "symbol storage files size", "\uEDA2", "");
+        RegisterNavigationCommand("nav-options", "Navigate to Options / Derivatives", "Options", "options derivatives contracts puts calls configuration", "\uE945", "");
+        RegisterNavigationCommand("nav-analysis-export-wizard", "Open Analysis Export Wizard", "AnalysisExportWizard", "analysis export wizard pandas python arrow parquet", "\uE9D9", "");
+        RegisterNavigationCommand("nav-research-shell", "Open Research Workspace", "ResearchShell", "research workspace shell home strategy runs backtest overview", "\uE9D9", "");
+        RegisterNavigationCommand("nav-trading-shell", "Open Trading Workspace", "TradingShell", "trading workspace shell live positions portfolio risk rail overview", "\uE9F5", "");
 
         // Action commands
         RegisterActionCommand("action-start-collector", "Start Data Collector", "StartCollector", "start collect begin run", "\uE768", "Ctrl+Shift+S");
@@ -268,15 +272,34 @@ public sealed class CommandPaletteService
     {
         return pageTag switch
         {
-            "Dashboard" or "Backtest" or "LeanIntegration" or "RunMat" or "Charts" or "Watchlist" or "OrderBook" or "StrategyRuns"
-                => $"Research workspace - {pageTag} page",
+            // Research workspace: analysis, strategy runs, charting, quant tooling
+            "Dashboard" or "Backtest" or "LeanIntegration" or "RunMat" or "Charts"
+                or "Watchlist" or "OrderBook" or "StrategyRuns" or "RunDetail" or "AdvancedAnalytics"
+                or "ResearchShell"
+                => $"Research workspace — {pageTag}",
+
+            // Trading workspace: live execution, portfolio management, positions, hours
             "LiveData" or "PortfolioImport" or "TradingHours" or "RunPortfolio"
-                => $"Trading workspace - {pageTag} page",
-            "Provider" or "DataSources" or "Symbols" or "Backfill" or "Storage" or "DataExport" or "PackageManager" or "Schedules" or "DataBrowser" or "DataCalendar" or "EventReplay"
-                => $"Data Operations workspace - {pageTag} page",
-            "DataQuality" or "ProviderHealth" or "SystemHealth" or "Diagnostics" or "Settings" or "AdminMaintenance" or "RetentionAssurance" or "NotificationCenter" or "Help" or "RunLedger" or "RunDetail"
-                => $"Governance workspace - {pageTag} page",
-            _ => $"Navigate to {pageTag} page"
+                or "TradingShell"
+                => $"Trading workspace — {pageTag}",
+
+            // Data Operations workspace: ingest, symbols, storage, tools
+            "Provider" or "DataSources" or "Symbols" or "Backfill" or "Storage"
+                or "DataExport" or "PackageManager" or "Schedules" or "DataBrowser"
+                or "DataCalendar" or "EventReplay" or "DataSampling" or "TimeSeriesAlignment"
+                or "AnalysisExport" or "AnalysisExportWizard" or "ExportPresets"
+                or "IndexSubscription" or "SymbolMapping" or "SymbolStorage" or "Options"
+                => $"Data Operations workspace — {pageTag}",
+
+            // Governance workspace: quality, audit, ledger, health, admin
+            "DataQuality" or "ProviderHealth" or "SystemHealth" or "Diagnostics"
+                or "Settings" or "AdminMaintenance" or "RetentionAssurance"
+                or "NotificationCenter" or "Help" or "RunLedger" or "ArchiveHealth"
+                or "ServiceManager" or "CollectionSessions" or "StorageOptimization"
+                or "ActivityLog" or "MessagingHub"
+                => $"Governance workspace — {pageTag}",
+
+            _ => $"Navigate to {pageTag}"
         };
     }
 

--- a/src/Meridian.Wpf/Services/NavigationService.cs
+++ b/src/Meridian.Wpf/Services/NavigationService.cs
@@ -122,6 +122,10 @@ public sealed class NavigationService : NavigationServiceBase, INavigationServic
         RegisterPage("LeanIntegration", typeof(LeanIntegrationPage));
         RegisterPage("MessagingHub", typeof(MessagingHubPage));
 
+        // Workspace shell landing pages
+        RegisterPage("ResearchShell", typeof(ResearchWorkspaceShellPage));
+        RegisterPage("TradingShell", typeof(TradingWorkspaceShellPage));
+
         // Workspaces & Notifications (2 pages)
         RegisterPage("Workspaces", typeof(WorkspacePage));
         RegisterPage("NotificationCenter", typeof(NotificationCenterPage));

--- a/src/Meridian.Wpf/Views/Pages.cs
+++ b/src/Meridian.Wpf/Views/Pages.cs
@@ -61,6 +61,19 @@ public partial class MessagingHubPage : Page { }
 // Backtesting pages
 public partial class BacktestPage : Page { }
 
+// Strategy Run workstation pages (browser, detail drill-ins, portfolio, ledger)
+public partial class StrategyRunsPage : Page { }
+public partial class RunDetailPage : Page { }
+public partial class RunPortfolioPage : Page { }
+public partial class RunLedgerPage : Page { }
+
+// Data Browser page
+public partial class DataBrowserPage : Page { }
+
+// Workspace shell landing pages
+public partial class ResearchWorkspaceShellPage : Page { }
+public partial class TradingWorkspaceShellPage : Page { }
+
 // Workspaces & Notifications pages
 public partial class WorkspacePage : Page { }
 public partial class NotificationCenterPage : Page { }

--- a/src/Meridian.Wpf/Views/ResearchWorkspaceShellPage.xaml
+++ b/src/Meridian.Wpf/Views/ResearchWorkspaceShellPage.xaml
@@ -1,0 +1,262 @@
+<Page x:Class="Meridian.Wpf.Views.ResearchWorkspaceShellPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d"
+      d:DesignHeight="900" d:DesignWidth="1400"
+      Background="{DynamicResource ConsoleBackgroundDarkBrush}"
+      Loaded="OnPageLoaded"
+      Unloaded="OnPageUnloaded"
+      AutomationProperties.Name="Research Workspace"
+      AutomationProperties.AutomationId="ResearchWorkspaceShellPage">
+
+    <Page.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+    </Page.Resources>
+
+    <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="28,20,28,32">
+        <StackPanel MaxWidth="1400">
+
+            <!-- ── Header ────────────────────────────────────────────────── -->
+            <Border Style="{StaticResource SectionCardStyle}" Margin="0,0,0,24">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0" Orientation="Horizontal">
+                        <Border Width="44" Height="44" CornerRadius="14"
+                                Background="{StaticResource ConsoleAccentBlueAlpha20Brush}"
+                                BorderBrush="{StaticResource InfoColorBrush}" BorderThickness="1">
+                            <TextBlock Text="&#xE9D9;" FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                       FontSize="24" Foreground="{StaticResource InfoColorBrush}"
+                                       VerticalAlignment="Center" HorizontalAlignment="Center" />
+                        </Border>
+                        <StackPanel Margin="12,0,0,0">
+                            <TextBlock Text="Research" Style="{StaticResource PageTitleStyle}" />
+                            <TextBlock Text="Strategy analysis, backtesting, and performance review"
+                                       Style="{StaticResource CardDescriptionStyle}" />
+                        </StackPanel>
+                    </StackPanel>
+
+                    <!-- KPI strip -->
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,4,0">
+                        <Border Background="{StaticResource ConsoleBackgroundMediumBrush}"
+                                CornerRadius="10" Padding="16,10" Margin="0,0,12,0"
+                                ToolTip="Completed backtest runs">
+                            <StackPanel>
+                                <TextBlock x:Name="TotalRunsText" Text="—" FontSize="20" FontWeight="Bold"
+                                           Foreground="{StaticResource ConsoleTextPrimaryBrush}"
+                                           HorizontalAlignment="Center" />
+                                <TextBlock Text="Runs" FontSize="11"
+                                           Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                           HorizontalAlignment="Center" />
+                            </StackPanel>
+                        </Border>
+                        <Border Background="{StaticResource ConsoleBackgroundMediumBrush}"
+                                CornerRadius="10" Padding="16,10" Margin="0,0,12,0"
+                                ToolTip="Strategies promoted to paper or live">
+                            <StackPanel>
+                                <TextBlock x:Name="PromotedText" Text="—" FontSize="20" FontWeight="Bold"
+                                           Foreground="{StaticResource SuccessColorBrush}"
+                                           HorizontalAlignment="Center" />
+                                <TextBlock Text="Promoted" FontSize="11"
+                                           Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                           HorizontalAlignment="Center" />
+                            </StackPanel>
+                        </Border>
+                        <Border Background="{StaticResource ConsoleBackgroundMediumBrush}"
+                                CornerRadius="10" Padding="16,10"
+                                ToolTip="Strategies awaiting promotion review">
+                            <StackPanel>
+                                <TextBlock x:Name="PendingReviewText" Text="—" FontSize="20" FontWeight="Bold"
+                                           Foreground="{StaticResource WarningColorBrush}"
+                                           HorizontalAlignment="Center" />
+                                <TextBlock Text="Pending Review" FontSize="11"
+                                           Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                           HorizontalAlignment="Center" />
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <!-- ── Quick Actions ─────────────────────────────────────────── -->
+            <Border Style="{StaticResource CardStyle}" Margin="0,0,0,24">
+                <StackPanel>
+                    <TextBlock Text="Quick Actions" Style="{StaticResource CardHeaderStyle}" Margin="0,0,0,16" />
+                    <WrapPanel Orientation="Horizontal">
+                        <Button Content="&#xE9D9;  New Backtest"
+                                Click="NewBacktest_Click"
+                                Style="{StaticResource PrimaryButtonStyle}"
+                                Margin="0,0,12,8"
+                                AutomationProperties.Name="New Backtest" />
+                        <Button Content="&#xE943;  Open RunMat"
+                                Click="OpenRunMat_Click"
+                                Style="{StaticResource SecondaryButtonStyle}"
+                                Margin="0,0,12,8"
+                                AutomationProperties.Name="Open RunMat" />
+                        <Button Content="&#xE9D9;  Open Charts"
+                                Click="OpenCharts_Click"
+                                Style="{StaticResource SecondaryButtonStyle}"
+                                Margin="0,0,12,8"
+                                AutomationProperties.Name="Open Charts" />
+                        <Button Content="&#xE8FD;  Browse Strategy Runs"
+                                Click="OpenStrategyRuns_Click"
+                                Style="{StaticResource GhostButtonStyle}"
+                                Margin="0,0,12,8"
+                                AutomationProperties.Name="Browse Strategy Runs" />
+                        <Button Content="&#xE943;  Lean Integration"
+                                Click="OpenLean_Click"
+                                Style="{StaticResource GhostButtonStyle}"
+                                Margin="0,0,0,8"
+                                AutomationProperties.Name="Lean Integration" />
+                    </WrapPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- ── Recent Runs ───────────────────────────────────────────── -->
+            <Border Style="{StaticResource CardStyle}" Margin="0,0,0,24">
+                <StackPanel>
+                    <Grid Margin="0,0,0,12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="Recent Strategy Runs" Style="{StaticResource CardHeaderStyle}" />
+                        <Button Grid.Column="1" Content="View All" Click="OpenStrategyRuns_Click"
+                                Style="{StaticResource LinkButtonStyle}" />
+                    </Grid>
+
+                    <!-- Populated at runtime by code-behind -->
+                    <ItemsControl x:Name="RecentRunsList"
+                                  AutomationProperties.AutomationId="RecentRunsList"
+                                  AutomationProperties.Name="Recent Strategy Runs">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="{StaticResource ConsoleBackgroundLightBrush}"
+                                        CornerRadius="10" Padding="16,12" Margin="0,0,0,8">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="110" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <!-- Strategy name + mode badge -->
+                                        <StackPanel Grid.Column="0">
+                                            <TextBlock Text="{Binding StrategyName}"
+                                                       FontSize="14" FontWeight="SemiBold"
+                                                       Foreground="{StaticResource ConsoleTextPrimaryBrush}" />
+                                            <TextBlock Text="{Binding RunId}"
+                                                       FontSize="11"
+                                                       Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                                       Margin="0,2,0,0" />
+                                        </StackPanel>
+
+                                        <!-- P&L -->
+                                        <StackPanel Grid.Column="1" HorizontalAlignment="Right"
+                                                    VerticalAlignment="Center" Margin="0,0,20,0">
+                                            <TextBlock Text="{Binding NetPnlFormatted}"
+                                                       FontSize="15" FontWeight="Bold"
+                                                       Foreground="{Binding NetPnlBrush}" />
+                                            <TextBlock Text="{Binding TotalReturnFormatted}"
+                                                       FontSize="11"
+                                                       Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                                       HorizontalAlignment="Right" />
+                                        </StackPanel>
+
+                                        <!-- Status badge -->
+                                        <Border Grid.Column="2"
+                                                Background="{Binding StatusBadgeBackground}"
+                                                CornerRadius="6" Padding="10,4"
+                                                VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding StatusLabel}"
+                                                       FontSize="11" FontWeight="SemiBold"
+                                                       Foreground="White"
+                                                       HorizontalAlignment="Center" />
+                                        </Border>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- Empty state -->
+                    <TextBlock x:Name="NoRunsText"
+                               Text="No strategy runs yet. Start a new backtest to see results here."
+                               FontSize="13"
+                               Foreground="{StaticResource ConsoleTextMutedBrush}"
+                               Visibility="Collapsed"
+                               Margin="0,8,0,0" />
+                </StackPanel>
+            </Border>
+
+            <!-- ── Promotion Pipeline ────────────────────────────────────── -->
+            <Border Style="{StaticResource CardStyle}" Margin="0,0,0,0">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                        <TextBlock Text="Promotion Pipeline" Style="{StaticResource CardHeaderStyle}" />
+                        <Border Background="{StaticResource ConsoleAccentBlueAlpha10Brush}"
+                                CornerRadius="999" Padding="8,3" Margin="10,0,0,0" VerticalAlignment="Center">
+                            <TextBlock x:Name="PromotionCountBadge" Text="0"
+                                       FontSize="11" FontWeight="SemiBold"
+                                       Foreground="{StaticResource InfoColorBrush}" />
+                        </Border>
+                    </StackPanel>
+                    <TextBlock Text="Strategies that have completed backtesting and are candidates for paper or live promotion."
+                               Style="{StaticResource CardDescriptionStyle}" Margin="0,0,0,12" />
+
+                    <ItemsControl x:Name="PromotionCandidatesList"
+                                  AutomationProperties.AutomationId="PromotionCandidatesList"
+                                  AutomationProperties.Name="Promotion Candidates">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="{StaticResource ConsoleBackgroundLightBrush}"
+                                        CornerRadius="10" Padding="16,12" Margin="0,0,0,8">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Grid.Column="0">
+                                            <TextBlock Text="{Binding StrategyName}"
+                                                       FontSize="14" FontWeight="SemiBold"
+                                                       Foreground="{StaticResource ConsoleTextPrimaryBrush}" />
+                                            <TextBlock Text="{Binding PromotionReason}"
+                                                       FontSize="11"
+                                                       Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                                       Margin="0,2,0,0" />
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                            <Border Background="{StaticResource SuccessColorAlpha20Brush}"
+                                                    CornerRadius="6" Padding="10,4" Margin="0,0,8,0">
+                                                <TextBlock Text="{Binding NextModeLabel}"
+                                                           FontSize="11" FontWeight="SemiBold"
+                                                           Foreground="{StaticResource SuccessColorBrush}" />
+                                            </Border>
+                                            <Button Content="Review"
+                                                    Tag="{Binding RunId}"
+                                                    Click="ReviewPromotion_Click"
+                                                    Style="{StaticResource SecondaryButtonStyle}" />
+                                        </StackPanel>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <TextBlock x:Name="NoPromotionsText"
+                               Text="No promotion candidates. Complete a backtest run to see it here."
+                               FontSize="13"
+                               Foreground="{StaticResource ConsoleTextMutedBrush}"
+                               Visibility="Collapsed"
+                               Margin="0,4,0,0" />
+                </StackPanel>
+            </Border>
+
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/src/Meridian.Wpf/Views/ResearchWorkspaceShellPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/ResearchWorkspaceShellPage.xaml.cs
@@ -1,0 +1,101 @@
+using System.Windows;
+using System.Windows.Controls;
+using Meridian.Wpf.Services;
+
+namespace Meridian.Wpf.Views;
+
+/// <summary>
+/// Research workspace shell — landing page for the Research workspace.
+/// Surfaces recent strategy runs, KPIs, quick actions, and the promotion pipeline.
+/// All data loading is intentionally lightweight; deep drill-ins navigate to dedicated pages.
+/// </summary>
+public partial class ResearchWorkspaceShellPage : Page
+{
+    private readonly NavigationService _navigationService;
+    private readonly StrategyRunWorkspaceService _runService;
+
+    public ResearchWorkspaceShellPage(
+        NavigationService navigationService,
+        StrategyRunWorkspaceService runService)
+    {
+        InitializeComponent();
+        _navigationService = navigationService;
+        _runService = runService;
+    }
+
+    private async void OnPageLoaded(object sender, RoutedEventArgs e)
+    {
+        await RefreshAsync();
+    }
+
+    private void OnPageUnloaded(object sender, RoutedEventArgs e)
+    {
+        // No subscriptions to clean up — shell page uses one-shot load.
+    }
+
+    // ── Data ─────────────────────────────────────────────────────────────
+
+    private async System.Threading.Tasks.Task RefreshAsync()
+    {
+        try
+        {
+            var summary = await _runService.GetResearchSummaryAsync();
+
+            TotalRunsText.Text = summary.TotalRuns.ToString();
+            PromotedText.Text = summary.PromotedCount.ToString();
+            PendingReviewText.Text = summary.PendingReviewCount.ToString();
+            PromotionCountBadge.Text = summary.PendingReviewCount.ToString();
+
+            if (summary.RecentRuns.Count > 0)
+            {
+                RecentRunsList.ItemsSource = summary.RecentRuns;
+                NoRunsText.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                RecentRunsList.ItemsSource = null;
+                NoRunsText.Visibility = Visibility.Visible;
+            }
+
+            if (summary.PromotionCandidates.Count > 0)
+            {
+                PromotionCandidatesList.ItemsSource = summary.PromotionCandidates;
+                NoPromotionsText.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                PromotionCandidatesList.ItemsSource = null;
+                NoPromotionsText.Visibility = Visibility.Visible;
+            }
+        }
+        catch (Exception ex)
+        {
+            LoggingService.Instance.LogError($"[ResearchWorkspaceShell] Refresh failed: {ex.Message}");
+        }
+    }
+
+    // ── Quick Action Handlers ─────────────────────────────────────────────
+
+    private void NewBacktest_Click(object sender, RoutedEventArgs e)
+        => _navigationService.NavigateTo("Backtest");
+
+    private void OpenRunMat_Click(object sender, RoutedEventArgs e)
+        => _navigationService.NavigateTo("RunMat");
+
+    private void OpenCharts_Click(object sender, RoutedEventArgs e)
+        => _navigationService.NavigateTo("Charts");
+
+    private void OpenStrategyRuns_Click(object sender, RoutedEventArgs e)
+        => _navigationService.NavigateTo("StrategyRuns");
+
+    private void OpenLean_Click(object sender, RoutedEventArgs e)
+        => _navigationService.NavigateTo("LeanIntegration");
+
+    private void ReviewPromotion_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button { Tag: string runId })
+        {
+            _navigationService.NavigateTo("RunDetail", runId);
+        }
+    }
+}

--- a/src/Meridian.Wpf/Views/TradingWorkspaceShellPage.xaml
+++ b/src/Meridian.Wpf/Views/TradingWorkspaceShellPage.xaml
@@ -1,0 +1,270 @@
+<Page x:Class="Meridian.Wpf.Views.TradingWorkspaceShellPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d"
+      d:DesignHeight="900" d:DesignWidth="1400"
+      Background="{DynamicResource ConsoleBackgroundDarkBrush}"
+      Loaded="OnPageLoaded"
+      Unloaded="OnPageUnloaded"
+      AutomationProperties.Name="Trading Workspace"
+      AutomationProperties.AutomationId="TradingWorkspaceShellPage">
+
+    <Page.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+    </Page.Resources>
+
+    <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="28,20,28,32">
+        <StackPanel MaxWidth="1400">
+
+            <!-- ── Header ────────────────────────────────────────────────── -->
+            <Border Style="{StaticResource SectionCardStyle}" Margin="0,0,0,24">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0" Orientation="Horizontal">
+                        <Border Width="44" Height="44" CornerRadius="14"
+                                Background="{StaticResource ConsoleAccentGreenAlpha20Brush}"
+                                BorderBrush="{StaticResource SuccessColorBrush}" BorderThickness="1">
+                            <TextBlock Text="&#xE9F5;" FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                       FontSize="24" Foreground="{StaticResource SuccessColorBrush}"
+                                       VerticalAlignment="Center" HorizontalAlignment="Center" />
+                        </Border>
+                        <StackPanel Margin="12,0,0,0">
+                            <TextBlock Text="Trading" Style="{StaticResource PageTitleStyle}" />
+                            <TextBlock Text="Live execution, portfolio management, and position oversight"
+                                       Style="{StaticResource CardDescriptionStyle}" />
+                        </StackPanel>
+                    </StackPanel>
+
+                    <!-- KPI strip -->
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,4,0">
+                        <Border Background="{StaticResource ConsoleBackgroundMediumBrush}"
+                                CornerRadius="10" Padding="16,10" Margin="0,0,12,0"
+                                ToolTip="Active paper trading runs">
+                            <StackPanel>
+                                <TextBlock x:Name="PaperRunsText" Text="—" FontSize="20" FontWeight="Bold"
+                                           Foreground="{StaticResource InfoColorBrush}"
+                                           HorizontalAlignment="Center" />
+                                <TextBlock Text="Paper Runs" FontSize="11"
+                                           Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                           HorizontalAlignment="Center" />
+                            </StackPanel>
+                        </Border>
+                        <Border Background="{StaticResource ConsoleBackgroundMediumBrush}"
+                                CornerRadius="10" Padding="16,10" Margin="0,0,12,0"
+                                ToolTip="Active live trading runs">
+                            <StackPanel>
+                                <TextBlock x:Name="LiveRunsText" Text="—" FontSize="20" FontWeight="Bold"
+                                           Foreground="{StaticResource SuccessColorBrush}"
+                                           HorizontalAlignment="Center" />
+                                <TextBlock Text="Live Runs" FontSize="11"
+                                           Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                           HorizontalAlignment="Center" />
+                            </StackPanel>
+                        </Border>
+                        <Border Background="{StaticResource ConsoleBackgroundMediumBrush}"
+                                CornerRadius="10" Padding="16,10"
+                                ToolTip="Total equity under management across paper + live runs">
+                            <StackPanel>
+                                <TextBlock x:Name="TotalEquityText" Text="—" FontSize="20" FontWeight="Bold"
+                                           Foreground="{StaticResource ConsoleTextPrimaryBrush}"
+                                           HorizontalAlignment="Center" />
+                                <TextBlock Text="Total Equity" FontSize="11"
+                                           Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                           HorizontalAlignment="Center" />
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <!-- ── Quick Actions ─────────────────────────────────────────── -->
+            <Border Style="{StaticResource CardStyle}" Margin="0,0,0,24">
+                <StackPanel>
+                    <TextBlock Text="Quick Actions" Style="{StaticResource CardHeaderStyle}" Margin="0,0,0,16" />
+                    <WrapPanel Orientation="Horizontal">
+                        <Button Content="&#xE9F5;  Live Data"
+                                Click="OpenLiveData_Click"
+                                Style="{StaticResource PrimaryButtonStyle}"
+                                Margin="0,0,12,8"
+                                AutomationProperties.Name="Open Live Data" />
+                        <Button Content="&#xE8B5;  View Portfolio"
+                                Click="OpenPortfolio_Click"
+                                Style="{StaticResource SecondaryButtonStyle}"
+                                Margin="0,0,12,8"
+                                AutomationProperties.Name="View Portfolio" />
+                        <Button Content="&#xE8B5;  Import Positions"
+                                Click="ImportPositions_Click"
+                                Style="{StaticResource SecondaryButtonStyle}"
+                                Margin="0,0,12,8"
+                                AutomationProperties.Name="Import Positions" />
+                        <Button Content="&#xE823;  Trading Hours"
+                                Click="OpenTradingHours_Click"
+                                Style="{StaticResource GhostButtonStyle}"
+                                Margin="0,0,0,8"
+                                AutomationProperties.Name="Trading Hours" />
+                    </WrapPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- ── Active Positions ──────────────────────────────────────── -->
+            <Border Style="{StaticResource CardStyle}" Margin="0,0,0,24">
+                <StackPanel>
+                    <Grid Margin="0,0,0,12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="Active Positions" Style="{StaticResource CardHeaderStyle}" />
+                        <Button Grid.Column="1" Content="Full Portfolio" Click="OpenPortfolio_Click"
+                                Style="{StaticResource LinkButtonStyle}" />
+                    </Grid>
+
+                    <!-- Column headers -->
+                    <Grid Margin="16,0,16,6">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="2*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="100" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="SYMBOL" FontSize="10" FontWeight="SemiBold"
+                                   Foreground="{StaticResource ConsoleTextMutedBrush}" />
+                        <TextBlock Grid.Column="1" Text="QUANTITY" FontSize="10" FontWeight="SemiBold"
+                                   Foreground="{StaticResource ConsoleTextMutedBrush}" HorizontalAlignment="Right" />
+                        <TextBlock Grid.Column="2" Text="UNRL. P&amp;L" FontSize="10" FontWeight="SemiBold"
+                                   Foreground="{StaticResource ConsoleTextMutedBrush}" HorizontalAlignment="Right" />
+                        <TextBlock Grid.Column="3" Text="REALIZED P&amp;L" FontSize="10" FontWeight="SemiBold"
+                                   Foreground="{StaticResource ConsoleTextMutedBrush}" HorizontalAlignment="Right" />
+                        <TextBlock Grid.Column="4" Text="MODE" FontSize="10" FontWeight="SemiBold"
+                                   Foreground="{StaticResource ConsoleTextMutedBrush}" HorizontalAlignment="Center" />
+                    </Grid>
+
+                    <ItemsControl x:Name="ActivePositionsList"
+                                  AutomationProperties.AutomationId="ActivePositionsList"
+                                  AutomationProperties.Name="Active Positions">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="{StaticResource ConsoleBackgroundLightBrush}"
+                                        CornerRadius="8" Padding="16,10" Margin="0,0,0,4">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="2*" />
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="100" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Grid.Column="0">
+                                            <TextBlock Text="{Binding Symbol}"
+                                                       FontSize="14" FontWeight="SemiBold"
+                                                       Foreground="{StaticResource ConsoleTextPrimaryBrush}" />
+                                            <TextBlock Text="{Binding StrategyName}"
+                                                       FontSize="11"
+                                                       Foreground="{StaticResource ConsoleTextMutedBrush}" />
+                                        </StackPanel>
+                                        <TextBlock Grid.Column="1" Text="{Binding QuantityLabel}"
+                                                   FontSize="13" HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                   Foreground="{StaticResource ConsoleTextPrimaryBrush}" />
+                                        <TextBlock Grid.Column="2" Text="{Binding UnrealizedPnlFormatted}"
+                                                   FontSize="13" FontWeight="SemiBold"
+                                                   HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                   Foreground="{Binding UnrealizedPnlBrush}" />
+                                        <TextBlock Grid.Column="3" Text="{Binding RealizedPnlFormatted}"
+                                                   FontSize="13"
+                                                   HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                   Foreground="{Binding RealizedPnlBrush}" />
+                                        <Border Grid.Column="4" Background="{Binding ModeBadgeBackground}"
+                                                CornerRadius="6" Padding="8,3" VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding ModeLabel}"
+                                                       FontSize="11" FontWeight="SemiBold"
+                                                       Foreground="White" HorizontalAlignment="Center" />
+                                        </Border>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <TextBlock x:Name="NoPositionsText"
+                               Text="No active positions. Start a paper or live run to see positions here."
+                               FontSize="13"
+                               Foreground="{StaticResource ConsoleTextMutedBrush}"
+                               Visibility="Collapsed"
+                               Margin="0,8,0,0" />
+                </StackPanel>
+            </Border>
+
+            <!-- ── Risk Rail ─────────────────────────────────────────────── -->
+            <Border Style="{StaticResource CardStyle}" Margin="0,0,0,0">
+                <StackPanel>
+                    <TextBlock Text="Risk Rail" Style="{StaticResource CardHeaderStyle}" Margin="0,0,0,16" />
+                    <TextBlock Text="Live risk rule status across all active paper and live runs."
+                               Style="{StaticResource CardDescriptionStyle}" Margin="0,0,0,16" />
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="16" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="16" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <!-- Max Drawdown -->
+                        <Border Grid.Column="0" Background="{StaticResource ConsoleBackgroundLightBrush}"
+                                CornerRadius="10" Padding="16,14">
+                            <StackPanel>
+                                <TextBlock Text="Max Drawdown" FontSize="11"
+                                           Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                           Margin="0,0,0,6" />
+                                <TextBlock x:Name="DrawdownText" Text="—" FontSize="22" FontWeight="Bold"
+                                           Foreground="{StaticResource WarningColorBrush}" />
+                                <TextBlock Text="vs. circuit-breaker limit" FontSize="10"
+                                           Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                           Margin="0,4,0,0" />
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Position Limit Utilization -->
+                        <Border Grid.Column="2" Background="{StaticResource ConsoleBackgroundLightBrush}"
+                                CornerRadius="10" Padding="16,14">
+                            <StackPanel>
+                                <TextBlock Text="Position Limit" FontSize="11"
+                                           Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                           Margin="0,0,0,6" />
+                                <TextBlock x:Name="PositionLimitText" Text="—" FontSize="22" FontWeight="Bold"
+                                           Foreground="{StaticResource ConsoleTextPrimaryBrush}" />
+                                <TextBlock Text="symbols active / limit" FontSize="10"
+                                           Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                           Margin="0,4,0,0" />
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Order Rate Throttle -->
+                        <Border Grid.Column="4" Background="{StaticResource ConsoleBackgroundLightBrush}"
+                                CornerRadius="10" Padding="16,14">
+                            <StackPanel>
+                                <TextBlock Text="Order Rate" FontSize="11"
+                                           Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                           Margin="0,0,0,6" />
+                                <TextBlock x:Name="OrderRateText" Text="—" FontSize="22" FontWeight="Bold"
+                                           Foreground="{StaticResource ConsoleTextPrimaryBrush}" />
+                                <TextBlock Text="orders / min vs. throttle" FontSize="10"
+                                           Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                           Margin="0,4,0,0" />
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+                </StackPanel>
+            </Border>
+
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/src/Meridian.Wpf/Views/TradingWorkspaceShellPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/TradingWorkspaceShellPage.xaml.cs
@@ -1,0 +1,82 @@
+using System.Windows;
+using System.Windows.Controls;
+using Meridian.Wpf.Services;
+
+namespace Meridian.Wpf.Views;
+
+/// <summary>
+/// Trading workspace shell — landing page for the Trading workspace.
+/// Surfaces active paper/live run counts, total equity, open positions, and the risk rail.
+/// All data loading is intentionally lightweight; deep drill-ins navigate to dedicated pages.
+/// </summary>
+public partial class TradingWorkspaceShellPage : Page
+{
+    private readonly NavigationService _navigationService;
+    private readonly StrategyRunWorkspaceService _runService;
+
+    public TradingWorkspaceShellPage(
+        NavigationService navigationService,
+        StrategyRunWorkspaceService runService)
+    {
+        InitializeComponent();
+        _navigationService = navigationService;
+        _runService = runService;
+    }
+
+    private async void OnPageLoaded(object sender, RoutedEventArgs e)
+    {
+        await RefreshAsync();
+    }
+
+    private void OnPageUnloaded(object sender, RoutedEventArgs e)
+    {
+        // No subscriptions to clean up — shell page uses one-shot load.
+    }
+
+    // ── Data ─────────────────────────────────────────────────────────────
+
+    private async System.Threading.Tasks.Task RefreshAsync()
+    {
+        try
+        {
+            var summary = await _runService.GetTradingSummaryAsync();
+
+            PaperRunsText.Text = summary.PaperRunCount.ToString();
+            LiveRunsText.Text = summary.LiveRunCount.ToString();
+            TotalEquityText.Text = summary.TotalEquityFormatted;
+
+            DrawdownText.Text = summary.MaxDrawdownFormatted;
+            PositionLimitText.Text = summary.PositionLimitLabel;
+            OrderRateText.Text = summary.OrderRateLabel;
+
+            if (summary.ActivePositions.Count > 0)
+            {
+                ActivePositionsList.ItemsSource = summary.ActivePositions;
+                NoPositionsText.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                ActivePositionsList.ItemsSource = null;
+                NoPositionsText.Visibility = Visibility.Visible;
+            }
+        }
+        catch (Exception ex)
+        {
+            LoggingService.Instance.LogError($"[TradingWorkspaceShell] Refresh failed: {ex.Message}");
+        }
+    }
+
+    // ── Quick Action Handlers ─────────────────────────────────────────────
+
+    private void OpenLiveData_Click(object sender, RoutedEventArgs e)
+        => _navigationService.NavigateTo("LiveData");
+
+    private void OpenPortfolio_Click(object sender, RoutedEventArgs e)
+        => _navigationService.NavigateTo("RunPortfolio");
+
+    private void ImportPositions_Click(object sender, RoutedEventArgs e)
+        => _navigationService.NavigateTo("PortfolioImport");
+
+    private void OpenTradingHours_Click(object sender, RoutedEventArgs e)
+        => _navigationService.NavigateTo("TradingHours");
+}


### PR DESCRIPTION
Navigation / command palette
- Pages.cs: declare 5 missing partial classes (StrategyRunsPage,
  RunDetailPage, RunPortfolioPage, RunLedgerPage, DataBrowserPage)
  that are registered in NavigationService but were absent from the
  canonical page registry
- CommandPaletteService: add nav commands for Options and
  AnalysisExportWizard pages that had no palette entry
- CommandPaletteService: add nav commands for ResearchShell and
  TradingShell workspace landing pages
- CommandPaletteService: rewrite BuildNavigationDescription — all 50+
  pages now route to the correct workspace label (Research / Trading /
  Data Operations / Governance); RunDetail moved from Governance to
  Research, dedicated routing added for 15+ previously unclassified pages

Workspace shells
- Add ResearchWorkspaceShellPage (XAML + code-behind): KPI strip
  (total runs, promoted, pending review), recent strategy runs list,
  quick-action buttons, and promotion pipeline strip
- Add TradingWorkspaceShellPage (XAML + code-behind): KPI strip
  (paper runs, live runs, total equity), active positions table,
  quick-action buttons, and risk rail (drawdown, position limit,
  order rate throttle)
- Register both shell pages in NavigationService (ResearchShell,
  TradingShell tags) and declare them in Pages.cs

Documentation
- Rewrite wpf-implementation-notes.md (was dated 2026-02-13, described
  ~10 services and 40 pages): updated to reflect workspace system,
  command palette, full 50+ page inventory grouped by workspace,
  shared workstation contracts (StrategyRun / Portfolio / Ledger), full
  service table, keyboard shortcut table, XAML style system, workspace
  shell design zones, build/test commands, and contribution guide

https://claude.ai/code/session_01WPaLt65iQQhvUw31Wq7B47