### PR TITLE
fix: thread CancellationToken through ListDirectoryAsync in DiagnosticBundleService

### DIFF
--- a/src/Meridian.Application/Services/DiagnosticBundleService.cs
+++ b/src/Meridian.Application/Services/DiagnosticBundleService.cs
@@ -302,7 +302,7 @@ public sealed class DiagnosticBundleService
         {
             // Directory structure
             info.AppendLine("=== DIRECTORY STRUCTURE ===");
-            await ListDirectoryAsync(_dataRoot, info, "", 3);
+            await ListDirectoryAsync(_dataRoot, info, "", 3, ct);
             info.AppendLine();
 
             // Disk space
@@ -355,22 +355,25 @@ public sealed class DiagnosticBundleService
         {
             foreach (var dir in Directory.GetDirectories(path))
             {
+                ct.ThrowIfCancellationRequested();
                 var dirName = Path.GetFileName(dir);
                 if (dirName.StartsWith("."))
                     continue;
 
                 sb.AppendLine($"{indent}[DIR] {dirName}/");
 
-                await ListDirectoryAsync(dir, sb, indent + "  ", maxDepth - 1);
+                await ListDirectoryAsync(dir, sb, indent + "  ", maxDepth - 1, ct);
             }
 
             foreach (var file in Directory.GetFiles(path))
             {
+                ct.ThrowIfCancellationRequested();
                 var fileName = Path.GetFileName(file);
                 var fileInfo = new FileInfo(file);
                 sb.AppendLine($"{indent}{fileName} ({FormatSize(fileInfo.Length)})");
             }
         }
+        catch (OperationCanceledException) { throw; }
         catch (UnauthorizedAccessException) { /* Access denied */ }
         catch (IOException) { /* Directory access error */ }
     }


### PR DESCRIPTION
The ct parameter was declared but never passed to the recursive call or
used inside the loops, so cancellation had no effect during directory
traversal. This could cause the diagnostic bundle generation to ignore
cancellation requests on large storage trees.

Changes:
- Pass ct from CollectStorageInfoAsync into ListDirectoryAsync
- Call ct.ThrowIfCancellationRequested() at the start of each directory
  and file loop iteration
- Propagate ct through recursive ListDirectoryAsync calls
- Re-throw OperationCanceledException so it is not swallowed by the
  broad catch blocks below it

https://claude.ai/code/session_01K7j5Zjh2ahyyjtuEcFwn7V