### PR TITLE
fix: reduce TODO scan false positives by excluding generated and template files

### DIFF
--- a/build/scripts/docs/scan-todos.py
+++ b/build/scripts/docs/scan-todos.py
@@ -20,8 +20,13 @@ SKIP_DIRS = {".git", "node_modules", "bin", "obj", ".vs", ".idea", ".vscode", "p
 # Files/dirs whose content is meta (they process or report TODOs rather than contain them).
 # Scanning them produces thousands of self-referential false positives.
 SKIP_PATH_PREFIXES = (
-    "docs/status/TODO",        # the output file itself
-    "build/scripts/docs/",     # scripts that process TODO scan results
+    "docs/status/TODO",                              # the output file itself
+    "build/scripts/docs/",                           # scripts that process TODO scan results
+    "docs/_site/",                                   # generated docfx site
+    "docs/generated/",                               # auto-generated documentation
+    "docs/examples/provider-template/",              # template examples (not work items)
+    "archive/",                                      # archived/historical documentation
+    ".github/workflows/documentation.yml",           # workflow script with many metadata TODOs
 )
 TAG_PATTERN = re.compile(r"\b(TODO|FIXME|NOTE)\b", re.IGNORECASE)
 ISSUE_PATTERN = re.compile(r"(?:#\d+|issues?/\d+)")


### PR DESCRIPTION
Exclude the following from scan-todos.py to eliminate 194 false-positive items:
- docs/_site/ (generated docfx documentation with third-party TODOs)
- docs/generated/ (auto-generated resource files)
- docs/examples/provider-template/ (template examples meant for user reference)
- archive/ (archived and historical documentation)
- .github/workflows/documentation.yml (workflow metadata with inline script TODOs)

This reduces the TODO count from 425 to 231 items, focusing only on actionable
work items in the actual codebase and actively-maintained documentation.

Fixes the issue where the TODO.md scan was cluttered with noise from generated
files and template examples.

https://claude.ai/code/session_01FAHPTeYy9KnuZKRtdobXyV