### PR TITLE
ci(docs): fix action versions, path filters, and output size issues

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -361,9 +361,9 @@ jobs:
               - added|deleted: 'src/**'
               - added|deleted: 'docs/**'
             providers:
-              - 'src/Meridian/Infrastructure/Adapters/**'
+              - 'src/Meridian.Infrastructure/Adapters/**'
             interfaces:
-              - 'src/Meridian/Infrastructure/IMarketDataClient.cs'
+              - 'src/Meridian.ProviderSdk/IMarketDataClient.cs'
               - 'src/Meridian.Infrastructure/Adapters/Core/IHistoricalDataProvider*.cs'
             adrs:
               - 'docs/adr/**'
@@ -415,12 +415,12 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -529,7 +529,7 @@ jobs:
 
       - name: Upload docs validation reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: docs-validation-reports
           path: .artifacts/
@@ -555,7 +555,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -830,7 +830,7 @@ jobs:
 
       - name: Upload generated documentation snapshot
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: docs-generated-snapshot
           path: |
@@ -863,7 +863,7 @@ jobs:
           steps.changes.outputs.has_changes == 'true' &&
           github.event_name == 'workflow_dispatch' &&
           github.event.inputs.dry_run == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: docs-automation-diff
           path: docs-automation.patch
@@ -983,10 +983,11 @@ jobs:
 
       - name: Pull latest changes
         run: |
-          git pull origin ${{ github.ref_name }} --rebase || true
+          git pull origin ${{ github.ref_name }} --rebase \
+            || echo "::warning::git pull --rebase failed; proceeding with local checkout"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -999,32 +1000,61 @@ jobs:
             --include-notes ${{ github.event.inputs.include_notes || 'true' }} \
             --json-output todo-scan-results.json
 
-          # Extract metrics for workflow outputs
+          # Extract metrics for workflow outputs (no full JSON — avoids GITHUB_OUTPUT 1 MB limit)
           if [ -f todo-scan-results.json ]; then
             python3 << 'PYEOF'
           import json
           import os
-          
+
           with open('todo-scan-results.json', 'r') as f:
               data = json.load(f)
-          
+
           total_count = data.get('total_count', 0)
           untracked = [t for t in data.get('todos', []) if not t.get('has_issue', False)]
           new_todos = len(untracked)
-          scan_json = json.dumps(data, separators=(',', ':'))
-          
-          # Write to GITHUB_OUTPUT
+
+          # Write compact metrics only — full JSON stays in todo-scan-results.json artifact
           output_file = os.environ.get('GITHUB_OUTPUT', '/dev/null')
           with open(output_file, 'a') as f:
               f.write(f'total_count={total_count}\n')
               f.write(f'new_todos={new_todos}\n')
-              f.write(f'scan_json={scan_json}\n')
           PYEOF
           else
             echo "total_count=0" >> $GITHUB_OUTPUT
             echo "new_todos=0" >> $GITHUB_OUTPUT
-            echo 'scan_json={"total_count":0,"todos":[]}' >> $GITHUB_OUTPUT
           fi
+
+      - name: Build triage prompt summary
+        id: triage-summary
+        if: github.event.inputs.use_copilot != 'false'
+        run: |
+          python3 << 'PYEOF'
+          import json
+          import os
+          from pathlib import Path
+
+          scan_path = Path('todo-scan-results.json')
+          if not scan_path.exists():
+              summary = '{"total_count":0,"untracked_count":0,"sample":[]}'
+          else:
+              data = json.loads(scan_path.read_text(encoding='utf-8'))
+              todos = data.get('todos', [])
+              untracked = [t for t in todos if not t.get('has_issue', False)]
+              # Emit only the first 25 untracked items to keep the prompt bounded
+              sample = [
+                  {'type': t.get('tag', 'TODO'), 'file': t.get('file', ''), 'line': t.get('line', 0), 'text': t.get('text', '')[:120]}
+                  for t in untracked[:25]
+              ]
+              summary = json.dumps({
+                  'total_count': data.get('total_count', 0),
+                  'untracked_count': len(untracked),
+                  'sample': sample,
+              }, separators=(',', ':'))
+
+          output_file = os.environ.get('GITHUB_OUTPUT', '/dev/null')
+          with open(output_file, 'a') as f:
+              f.write(f'summary={summary}\n')
+          PYEOF
 
       - name: Generate Copilot triage recommendations
         id: copilot
@@ -1043,8 +1073,8 @@ jobs:
             4) Suggested batching plan
 
             Keep the output under 300 words.
-            Use this scan JSON:
-            ${{ steps.scan.outputs.scan_json }}
+            Use this scan summary (top 25 untracked items):
+            ${{ steps.triage-summary.outputs.summary }}
 
       - name: Build fallback triage report
         if: always()
@@ -1194,7 +1224,7 @@ jobs:
           fi
 
       - name: Upload scan results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: todo-scan-results
           path: |
@@ -1243,12 +1273,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download scan results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: todo-scan-results
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1294,10 +1324,12 @@ jobs:
           fetch-depth: 0
 
       - name: Pull latest changes
-        run: git pull origin ${{ github.ref_name }} --rebase || true
+        run: |
+          git pull origin ${{ github.ref_name }} --rebase \
+            || echo "::warning::git pull --rebase failed; proceeding with local checkout"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1331,7 +1363,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1366,7 +1398,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1402,7 +1434,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1440,7 +1472,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1476,7 +1508,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1515,7 +1547,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1551,7 +1583,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1663,7 +1695,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1712,7 +1744,7 @@ jobs:
           fi
 
       - name: Upload sync report artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: ai-docs-sync-report
           path: docs/generated/ai-docs-sync-report.md


### PR DESCRIPTION
- Bump actions/setup-node v6 → v4 (latest stable)
- Bump actions/setup-python v6 → v5 (latest stable)
- Bump actions/upload-artifact v7 → v4 (latest stable)
- Bump actions/download-artifact v8 → v4 (latest stable)
- Fix providers path filter: src/Meridian/Infrastructure → src/Meridian.Infrastructure
- Fix interfaces path filter: src/Meridian/Infrastructure/IMarketDataClient.cs →
  src/Meridian.ProviderSdk/IMarketDataClient.cs (actual location)
- Remove full scan_json from GITHUB_OUTPUT to prevent exceeding the 1 MB limit;
  metrics-only outputs (total_count, new_todos) are retained
- Add triage-summary step that builds a bounded 25-item sample from the scan
  artifact file and passes it to the AI inference prompt instead of the raw JSON
- Replace silent `|| true` git-pull swallowing with workflow warnings so
  rebase failures are visible in the run log

https://claude.ai/code/session_01FFyMk72FvG6bxnZofXQDqW