### PR TITLE
Fix invalid clock participant syntax in timing-diagram-backfill.puml

### DIFF
--- a/docs/diagrams/uml/timing-diagram-backfill.puml
+++ b/docs/diagrams/uml/timing-diagram-backfill.puml
@@ -5,7 +5,6 @@ skinparam backgroundColor white
 title Meridian - Backfill Operation Timing Diagram
 
 ' ==================== PARTICIPANTS ====================
-clock "Wall Clock" as Clock
 concise "Backfill Service" as Backfill
 concise "Rate Limiter" as RateLimiter
 concise "Provider (Stooq)" as Stooq


### PR DESCRIPTION
Remove the undeclared `clock "Wall Clock" as Clock` line that lacked the
required `with period X` clause, causing PlantUML to fail with exit code 200.

https://claude.ai/code/session_01BZafNa3Q12qaHuxncSACEn