### PR TITLE
Wire paper-trading cockpit, promotion workflow, and strategy lifecycle endpoints

### DIFF
--- a/docs/status/ROADMAP.md
+++ b/docs/status/ROADMAP.md
@@ -1,6 +1,6 @@
 # Meridian - Project Roadmap
 
-**Last Updated:** 2026-03-24
+**Last Updated:** 2026-03-25
 **Status:** Refocused on core platform functionality
 **Repository Snapshot (2026-03-24):** solution projects: 35 | `src/` projects: 27 | test projects: 7 | workflow files: 35 | source files: 1,118 (1,073 C# + 45 F#) | test files: 335 (326 C# + 9 F#) | tests: ~4,424
 
@@ -70,12 +70,19 @@ Paper trading is the primary execution surface. It validates strategies under re
   - `TemplateBrokerageGateway` — scaffold for new brokerage adapters
 - Brokerage DI registration via `BrokerageServiceRegistration` and `BrokerageConfiguration`
 
+**Completed (2026-03-25):**
+- Paper-trading cockpit REST endpoints wired: `/api/execution/account`, `/api/execution/positions`, `/api/execution/portfolio`, `/api/execution/orders`, `/api/execution/health`, `/api/execution/capabilities`
+- Paper-trading session management endpoints: `/api/execution/sessions` (create, list, detail, close)
+- `Backtest → Paper → Live` promotion workflow: `/api/promotion/evaluate/{runId}`, `/api/promotion/approve`, `/api/promotion/reject`, `/api/promotion/history`
+- Strategy lifecycle control endpoints: `/api/strategies/status`, `/api/strategies/{id}/status`, `/api/strategies/{id}/pause`, `/api/strategies/{id}/stop`
+- `PaperSessionPersistenceService`, `IPortfolioState`, `IOrderGateway`, `IOrderManager`, `StrategyLifecycleManager` fully wired in DI
+- Test coverage added for `PromotionService` and `PaperSessionPersistenceService`
+
 **Remaining work:**
-- Build a full paper-trading cockpit: live positions, open orders, fills, P&L, and controls exposed via the web dashboard
-- Complete the `Backtest → Paper` promotion workflow with safety gating and audit trail
-- Add paper-trading session persistence and replay support
-- Wire brokerage gateways into the paper-trading cockpit for order routing validation
-- Define the `Paper → Live` promotion gate leveraging the brokerage gateway framework
+- Wire brokerage gateways into live order routing (currently paper-only)
+- Define the `Paper → Live` promotion gate with additional human-approval controls
+- Add paper-trading session replay from persisted order history
+- Improve paper-trading cockpit UI in the React dashboard
 
 ---
 

--- a/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using Meridian.Execution;
 using Meridian.Execution.Interfaces;
 using Meridian.Execution.Models;
 using Meridian.Execution.Services;
@@ -79,7 +78,7 @@ public static class ExecutionEndpoints
 
         group.MapGet("/orders", (HttpContext context) =>
         {
-            var oms = context.RequestServices.GetService<OrderManagementSystem>();
+            var oms = context.RequestServices.GetService<IOrderManager>();
             if (oms is null)
                 return Results.Problem("Order management system is not active.", statusCode: StatusCodes.Status503ServiceUnavailable);
 
@@ -92,7 +91,7 @@ public static class ExecutionEndpoints
 
         group.MapGet("/orders/{orderId}", (string orderId, HttpContext context) =>
         {
-            var oms = context.RequestServices.GetService<OrderManagementSystem>();
+            var oms = context.RequestServices.GetService<IOrderManager>();
             if (oms is null)
                 return Results.Problem("Order management system is not active.", statusCode: StatusCodes.Status503ServiceUnavailable);
 
@@ -108,7 +107,7 @@ public static class ExecutionEndpoints
 
         group.MapPost("/orders/submit", async (OrderRequest request, HttpContext context) =>
         {
-            var oms = context.RequestServices.GetService<OrderManagementSystem>();
+            var oms = context.RequestServices.GetService<IOrderManager>();
             if (oms is null)
                 return Results.Problem("Order management system is not active.", statusCode: StatusCodes.Status503ServiceUnavailable);
 
@@ -125,7 +124,7 @@ public static class ExecutionEndpoints
 
         group.MapPost("/orders/{orderId}/cancel", async (string orderId, HttpContext context) =>
         {
-            var oms = context.RequestServices.GetService<OrderManagementSystem>();
+            var oms = context.RequestServices.GetService<IOrderManager>();
             if (oms is null)
                 return Results.Problem("Order management system is not active.", statusCode: StatusCodes.Status503ServiceUnavailable);
 
@@ -177,13 +176,13 @@ public static class ExecutionEndpoints
         {
             var persistence = context.RequestServices.GetService<PaperSessionPersistenceService>();
             if (persistence is null)
-                return Results.Json(Array.Empty<PaperSessionSummary>(), jsonOptions);
+                return Results.Json(Array.Empty<PaperSessionSummaryDto>(), jsonOptions);
 
             var sessions = persistence.GetSessions();
             return Results.Json(sessions, jsonOptions);
         })
         .WithName("GetExecutionSessions")
-        .Produces<IReadOnlyList<PaperSessionSummary>>(200);
+        .Produces<IReadOnlyList<PaperSessionSummaryDto>>(200);
 
         group.MapGet("/sessions/{sessionId}", (string sessionId, HttpContext context) =>
         {
@@ -195,7 +194,7 @@ public static class ExecutionEndpoints
             return session is null ? Results.NotFound() : Results.Json(session, jsonOptions);
         })
         .WithName("GetExecutionSessionById")
-        .Produces<PaperSessionDetail>(200)
+        .Produces<PaperSessionDetailDto>(200)
         .Produces(404);
 
         group.MapPost("/sessions/create", async (CreatePaperSessionRequest request, HttpContext context) =>
@@ -209,7 +208,7 @@ public static class ExecutionEndpoints
             return Results.Json(session, jsonOptions, statusCode: StatusCodes.Status201Created);
         })
         .WithName("CreateExecutionSession")
-        .Produces<PaperSessionSummary>(201)
+        .Produces<PaperSessionSummaryDto>(201)
         .Produces(503);
 
         group.MapPost("/sessions/{sessionId}/close", async (string sessionId, HttpContext context) =>
@@ -261,19 +260,3 @@ public sealed record CreatePaperSessionRequest(
     string? StrategyName,
     decimal InitialCash = 100_000m,
     IReadOnlyList<string>? Symbols = null);
-
-/// <summary>Summary of a paper trading session.</summary>
-public sealed record PaperSessionSummary(
-    string SessionId,
-    string StrategyId,
-    string? StrategyName,
-    decimal InitialCash,
-    DateTimeOffset CreatedAt,
-    DateTimeOffset? ClosedAt,
-    bool IsActive);
-
-/// <summary>Detailed view of a paper session including final portfolio state.</summary>
-public sealed record PaperSessionDetail(
-    PaperSessionSummary Summary,
-    ExecutionPortfolioSnapshot? Portfolio,
-    IReadOnlyList<OrderState>? OrderHistory);

--- a/src/Meridian.Ui.Shared/Endpoints/StrategyLifecycleEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/StrategyLifecycleEndpoints.cs
@@ -100,7 +100,6 @@ public static class StrategyLifecycleEndpoints
         .WithName("StopStrategy")
         .Produces<StrategyActionResult>(200)
         .Produces<StrategyActionResult>(409)
-        .Produces(404)
         .Produces(503);
     }
 }

--- a/src/Meridian.Ui.Shared/Endpoints/StrategyLifecycleEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/StrategyLifecycleEndpoints.cs
@@ -59,6 +59,9 @@ public static class StrategyLifecycleEndpoints
             if (manager is null)
                 return Results.Problem("Strategy lifecycle manager is not active.", statusCode: StatusCodes.Status503ServiceUnavailable);
 
+            if (!manager.GetStatuses().ContainsKey(strategyId))
+                return Results.NotFound(new { strategyId, error = "Strategy not registered." });
+
             try
             {
                 await manager.PauseAsync(strategyId, context.RequestAborted).ConfigureAwait(false);
@@ -76,13 +79,17 @@ public static class StrategyLifecycleEndpoints
         .Produces<StrategyActionResult>(200)
         .Produces<StrategyActionResult>(409)
         .Produces(404)
-        .Produces(503);
+        .Produces(503)
+        .RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy);
 
         group.MapPost("/{strategyId}/stop", async (string strategyId, HttpContext context) =>
         {
             var manager = context.RequestServices.GetService<StrategyLifecycleManager>();
             if (manager is null)
                 return Results.Problem("Strategy lifecycle manager is not active.", statusCode: StatusCodes.Status503ServiceUnavailable);
+
+            if (!manager.GetStatuses().ContainsKey(strategyId))
+                return Results.NotFound(new { strategyId, error = "Strategy not registered." });
 
             try
             {
@@ -100,7 +107,9 @@ public static class StrategyLifecycleEndpoints
         .WithName("StopStrategy")
         .Produces<StrategyActionResult>(200)
         .Produces<StrategyActionResult>(409)
-        .Produces(503);
+        .Produces(404)
+        .Produces(503)
+        .RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy);
     }
 }
 

--- a/src/Meridian.Ui.Shared/Endpoints/StrategyLifecycleEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/StrategyLifecycleEndpoints.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using Meridian.Strategies.Models;
+using Meridian.Strategies.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Ui.Shared.Endpoints;
+
+/// <summary>
+/// REST endpoints for querying and controlling the lifecycle of registered live strategies.
+/// Exposes pause, stop, and status operations. Strategy start is handled separately via
+/// the execution cockpit once an execution context is established.
+/// </summary>
+public static class StrategyLifecycleEndpoints
+{
+    public static void MapStrategyLifecycleEndpoints(this WebApplication app, JsonSerializerOptions jsonOptions)
+    {
+        var group = app.MapGroup("/api/strategies").WithTags("Strategies");
+
+        // --- Status queries ---
+
+        group.MapGet("/status", (HttpContext context) =>
+        {
+            var manager = context.RequestServices.GetService<StrategyLifecycleManager>();
+            if (manager is null)
+                return Results.Problem("Strategy lifecycle manager is not active.", statusCode: StatusCodes.Status503ServiceUnavailable);
+
+            var statuses = manager.GetStatuses();
+            var result = statuses.Select(kvp => new StrategyStatusDto(kvp.Key, kvp.Value.ToString())).ToArray();
+            return Results.Json(result, jsonOptions);
+        })
+        .WithName("GetAllStrategyStatuses")
+        .Produces<StrategyStatusDto[]>(200)
+        .Produces(503);
+
+        group.MapGet("/{strategyId}/status", (string strategyId, HttpContext context) =>
+        {
+            var manager = context.RequestServices.GetService<StrategyLifecycleManager>();
+            if (manager is null)
+                return Results.Problem("Strategy lifecycle manager is not active.", statusCode: StatusCodes.Status503ServiceUnavailable);
+
+            var statuses = manager.GetStatuses();
+            if (!statuses.TryGetValue(strategyId, out var status))
+                return Results.NotFound(new { strategyId, error = "Strategy not registered." });
+
+            return Results.Json(new StrategyStatusDto(strategyId, status.ToString()), jsonOptions);
+        })
+        .WithName("GetStrategyStatus")
+        .Produces<StrategyStatusDto>(200)
+        .Produces(404)
+        .Produces(503);
+
+        // --- Lifecycle control ---
+
+        group.MapPost("/{strategyId}/pause", async (string strategyId, HttpContext context) =>
+        {
+            var manager = context.RequestServices.GetService<StrategyLifecycleManager>();
+            if (manager is null)
+                return Results.Problem("Strategy lifecycle manager is not active.", statusCode: StatusCodes.Status503ServiceUnavailable);
+
+            try
+            {
+                await manager.PauseAsync(strategyId, context.RequestAborted).ConfigureAwait(false);
+                return Results.Json(new StrategyActionResult(strategyId, "paused", Success: true, Reason: null), jsonOptions);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.Json(
+                    new StrategyActionResult(strategyId, "pause", Success: false, Reason: ex.Message),
+                    jsonOptions,
+                    statusCode: StatusCodes.Status409Conflict);
+            }
+        })
+        .WithName("PauseStrategy")
+        .Produces<StrategyActionResult>(200)
+        .Produces<StrategyActionResult>(409)
+        .Produces(404)
+        .Produces(503);
+
+        group.MapPost("/{strategyId}/stop", async (string strategyId, HttpContext context) =>
+        {
+            var manager = context.RequestServices.GetService<StrategyLifecycleManager>();
+            if (manager is null)
+                return Results.Problem("Strategy lifecycle manager is not active.", statusCode: StatusCodes.Status503ServiceUnavailable);
+
+            try
+            {
+                await manager.StopAsync(strategyId, context.RequestAborted).ConfigureAwait(false);
+                return Results.Json(new StrategyActionResult(strategyId, "stopped", Success: true, Reason: null), jsonOptions);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.Json(
+                    new StrategyActionResult(strategyId, "stop", Success: false, Reason: ex.Message),
+                    jsonOptions,
+                    statusCode: StatusCodes.Status409Conflict);
+            }
+        })
+        .WithName("StopStrategy")
+        .Produces<StrategyActionResult>(200)
+        .Produces<StrategyActionResult>(409)
+        .Produces(404)
+        .Produces(503);
+    }
+}
+
+// --- DTOs ---
+
+/// <summary>Snapshot of a strategy's current lifecycle state.</summary>
+public sealed record StrategyStatusDto(string StrategyId, string Status);
+
+/// <summary>Result of a lifecycle control action (pause/stop).</summary>
+public sealed record StrategyActionResult(
+    string StrategyId,
+    string Action,
+    bool Success,
+    string? Reason);

--- a/src/Meridian.Ui.Shared/Endpoints/UiEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/UiEndpoints.cs
@@ -296,6 +296,9 @@ public static class UiEndpoints
         // Promotion workflow endpoints (Backtest → Paper → Live)
         app.MapPromotionEndpoints(jsonOptions);
 
+        // Strategy lifecycle control endpoints (pause/stop/status)
+        app.MapStrategyLifecycleEndpoints(jsonOptions);
+
         return app;
     }
 
@@ -399,6 +402,9 @@ public static class UiEndpoints
 
         // Promotion workflow endpoints (Backtest → Paper → Live)
         app.MapPromotionEndpoints(jsonOptions);
+
+        // Strategy lifecycle control endpoints (pause/stop/status)
+        app.MapStrategyLifecycleEndpoints(jsonOptions);
 
         return app;
     }

--- a/src/Meridian/UiServer.cs
+++ b/src/Meridian/UiServer.cs
@@ -6,6 +6,12 @@ using Meridian.Application.Monitoring.DataQuality;
 using Meridian.Application.Pipeline;
 using Meridian.Application.UI;
 using Meridian.Domain.Collectors;
+using Meridian.Execution;
+using Meridian.Execution.Adapters;
+using Meridian.Execution.Interfaces;
+using Meridian.Execution.Models;
+using Meridian.Execution.Sdk;
+using Meridian.Execution.Services;
 using Meridian.Infrastructure.Contracts;
 using Meridian.Strategies.Interfaces;
 using Meridian.Strategies.Services;
@@ -87,7 +93,24 @@ public sealed class UiServer : IAsyncDisposable
         builder.Services.AddSingleton<IReconciliationRunService, ReconciliationRunService>();
         builder.Services.AddSingleton<Meridian.Strategies.Promotions.BacktestToLivePromoter>();
         builder.Services.AddSingleton<Meridian.Strategies.Services.PromotionService>();
-        builder.Services.AddSingleton<Meridian.Execution.Services.PaperSessionPersistenceService>();
+        builder.Services.AddSingleton<PaperSessionPersistenceService>();
+        builder.Services.AddSingleton<StrategyLifecycleManager>();
+
+        // Execution layer — paper trading gateway wired for cockpit endpoints
+        builder.Services.AddSingleton<IOrderGateway>(sp =>
+            new Meridian.Execution.Adapters.PaperTradingGateway(
+                sp.GetRequiredService<ILogger<Meridian.Execution.Adapters.PaperTradingGateway>>()));
+        builder.Services.AddSingleton<IPortfolioState>(_ => new PaperTradingPortfolio(100_000m));
+        builder.Services.AddSingleton<IOrderManager>(sp =>
+        {
+            var gateway = sp.GetRequiredService<IExecutionGateway>();
+            var logger = sp.GetRequiredService<ILogger<OrderManagementSystem>>();
+            var risk = sp.GetService<IRiskValidator>();
+            return new OrderManagementSystem(gateway, logger, risk);
+        });
+        builder.Services.AddSingleton<IExecutionGateway>(sp =>
+            new Meridian.Execution.PaperTradingGateway(
+                sp.GetRequiredService<ILogger<Meridian.Execution.PaperTradingGateway>>()));
 
         // Register OpenAPI/Swagger services
         builder.Services.AddEndpointsApiExplorer();
@@ -154,6 +177,12 @@ public sealed class UiServer : IAsyncDisposable
                     return ["Historical"];
                 if (path.StartsWith("api/options"))
                     return ["Options"];
+                if (path.StartsWith("api/strategies"))
+                    return ["Strategies"];
+                if (path.StartsWith("api/execution"))
+                    return ["Execution"];
+                if (path.StartsWith("api/promotion"))
+                    return ["Promotion"];
                 return ["General"];
             });
         });

--- a/tests/Meridian.Tests/Execution/PaperSessionPersistenceServiceTests.cs
+++ b/tests/Meridian.Tests/Execution/PaperSessionPersistenceServiceTests.cs
@@ -1,0 +1,157 @@
+using FluentAssertions;
+using Meridian.Execution.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Meridian.Tests.Execution;
+
+public sealed class PaperSessionPersistenceServiceTests
+{
+    private static PaperSessionPersistenceService Build() =>
+        new(NullLogger<PaperSessionPersistenceService>.Instance);
+
+    // ---- CreateSessionAsync ----
+
+    [Fact]
+    public async Task CreateSessionAsync_ReturnsNewSession_WithMatchingStrategyId()
+    {
+        var service = Build();
+        var dto = new CreatePaperSessionDto("strat-1", "My Strategy", 50_000m);
+
+        var summary = await service.CreateSessionAsync(dto);
+
+        summary.StrategyId.Should().Be("strat-1");
+        summary.StrategyName.Should().Be("My Strategy");
+        summary.InitialCash.Should().Be(50_000m);
+        summary.IsActive.Should().BeTrue();
+        summary.ClosedAt.Should().BeNull();
+        summary.SessionId.Should().StartWith("PAPER-");
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_TwoCalls_ProduceDistinctSessionIds()
+    {
+        var service = Build();
+        var dto = new CreatePaperSessionDto("strat-1", null, 100_000m);
+
+        var s1 = await service.CreateSessionAsync(dto);
+        var s2 = await service.CreateSessionAsync(dto);
+
+        s1.SessionId.Should().NotBe(s2.SessionId);
+    }
+
+    // ---- GetSessions ----
+
+    [Fact]
+    public async Task GetSessions_AfterCreation_ContainsNewSession()
+    {
+        var service = Build();
+        var dto = new CreatePaperSessionDto("strat-2", null, 100_000m);
+        var summary = await service.CreateSessionAsync(dto);
+
+        var sessions = service.GetSessions();
+
+        sessions.Should().ContainSingle(s => s.SessionId == summary.SessionId);
+    }
+
+    [Fact]
+    public async Task GetSessions_WhenEmpty_ReturnsEmptyList()
+    {
+        var service = Build();
+
+        var sessions = service.GetSessions();
+
+        sessions.Should().BeEmpty();
+    }
+
+    // ---- GetSession ----
+
+    [Fact]
+    public async Task GetSession_WhenSessionExists_ReturnsDetail()
+    {
+        var service = Build();
+        var dto = new CreatePaperSessionDto("strat-3", "Detail Test", 100_000m);
+        var summary = await service.CreateSessionAsync(dto);
+
+        var detail = service.GetSession(summary.SessionId);
+
+        detail.Should().NotBeNull();
+        detail!.Summary.SessionId.Should().Be(summary.SessionId);
+        detail.Portfolio.Should().NotBeNull();
+        detail.OrderHistory.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetSession_WhenSessionNotFound_ReturnsNull()
+    {
+        var service = Build();
+
+        var detail = service.GetSession("nonexistent-session");
+
+        detail.Should().BeNull();
+    }
+
+    // ---- CloseSessionAsync ----
+
+    [Fact]
+    public async Task CloseSessionAsync_WhenSessionExists_ReturnsTrue()
+    {
+        var service = Build();
+        var dto = new CreatePaperSessionDto("strat-4", null, 100_000m);
+        var summary = await service.CreateSessionAsync(dto);
+
+        var closed = await service.CloseSessionAsync(summary.SessionId);
+
+        closed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CloseSessionAsync_WhenSessionExists_MarksInactive()
+    {
+        var service = Build();
+        var dto = new CreatePaperSessionDto("strat-5", null, 100_000m);
+        var summary = await service.CreateSessionAsync(dto);
+
+        await service.CloseSessionAsync(summary.SessionId);
+
+        var sessions = service.GetSessions();
+        sessions.Should().ContainSingle(s => s.SessionId == summary.SessionId && !s.IsActive);
+    }
+
+    [Fact]
+    public async Task CloseSessionAsync_WhenSessionNotFound_ReturnsFalse()
+    {
+        var service = Build();
+
+        var closed = await service.CloseSessionAsync("does-not-exist");
+
+        closed.Should().BeFalse();
+    }
+
+    // ---- GetActivePortfolio ----
+
+    [Fact]
+    public async Task GetActivePortfolio_AfterCreation_ReturnsPortfolio()
+    {
+        var service = Build();
+        var dto = new CreatePaperSessionDto("strat-6", null, 75_000m);
+        var summary = await service.CreateSessionAsync(dto);
+
+        var portfolio = service.GetActivePortfolio(summary.SessionId);
+
+        portfolio.Should().NotBeNull();
+        portfolio!.Cash.Should().Be(75_000m);
+    }
+
+    [Fact]
+    public async Task GetActivePortfolio_AfterClose_ReturnsNull()
+    {
+        var service = Build();
+        var dto = new CreatePaperSessionDto("strat-7", null, 100_000m);
+        var summary = await service.CreateSessionAsync(dto);
+        await service.CloseSessionAsync(summary.SessionId);
+
+        var portfolio = service.GetActivePortfolio(summary.SessionId);
+
+        portfolio.Should().BeNull();
+    }
+}

--- a/tests/Meridian.Tests/Strategies/PromotionServiceTests.cs
+++ b/tests/Meridian.Tests/Strategies/PromotionServiceTests.cs
@@ -1,0 +1,225 @@
+using FluentAssertions;
+using Meridian.Backtesting.Sdk;
+using Meridian.Ledger;
+using Meridian.Strategies.Models;
+using Meridian.Strategies.Promotions;
+using Meridian.Strategies.Services;
+using Meridian.Strategies.Storage;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Meridian.Tests.Strategies;
+
+public sealed class PromotionServiceTests
+{
+    // ---- EvaluateAsync ----
+
+    [Fact]
+    public async Task EvaluateAsync_WhenRunNotFound_ReturnsFalseAndFoundFalse()
+    {
+        var service = BuildService(out _);
+
+        var result = await service.EvaluateAsync("missing-run");
+
+        result.Found.Should().BeFalse();
+        result.IsEligible.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WhenRunNotCompleted_ReturnsNotReady()
+    {
+        var service = BuildService(out var store);
+        var run = StrategyRunEntry.Start("s1", "Strategy One", RunType.Backtest);
+        await store.RecordRunAsync(run);
+
+        var result = await service.EvaluateAsync(run.RunId);
+
+        result.Found.Should().BeTrue();
+        result.Ready.Should().BeFalse();
+        result.IsEligible.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WhenRunIsLive_ReturnsNotReady()
+    {
+        var service = BuildService(out var store);
+        var run = StrategyRunEntry.Start("s1", "Strategy One", RunType.Live) with
+        {
+            EndedAt = DateTimeOffset.UtcNow,
+            Metrics = BuildPassingResult()
+        };
+        await store.RecordRunAsync(run);
+
+        var result = await service.EvaluateAsync(run.RunId);
+
+        result.Ready.Should().BeFalse();
+        result.Reason.Should().Contain("Live runs cannot be promoted");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WhenRunHasNoMetrics_ReturnsNotReady()
+    {
+        var service = BuildService(out var store);
+        var run = StrategyRunEntry.Start("s1", "Strategy One", RunType.Backtest) with
+        {
+            EndedAt = DateTimeOffset.UtcNow,
+            Metrics = null
+        };
+        await store.RecordRunAsync(run);
+
+        var result = await service.EvaluateAsync(run.RunId);
+
+        result.Ready.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WhenPassingMetrics_ReturnsEligible()
+    {
+        var service = BuildService(out var store);
+        var run = StrategyRunEntry.Start("s1", "Strategy One", RunType.Backtest) with
+        {
+            EndedAt = DateTimeOffset.UtcNow,
+            Metrics = BuildPassingResult()
+        };
+        await store.RecordRunAsync(run);
+
+        var result = await service.EvaluateAsync(run.RunId);
+
+        result.Found.Should().BeTrue();
+        result.Ready.Should().BeTrue();
+        result.IsEligible.Should().BeTrue();
+        result.TargetMode.Should().Be(RunType.Paper);
+    }
+
+    // ---- ApproveAsync ----
+
+    [Fact]
+    public async Task ApproveAsync_WhenRunExists_CreatesNewRunAndRecordsHistory()
+    {
+        var service = BuildService(out var store);
+        var run = StrategyRunEntry.Start("s1", "Strategy One", RunType.Backtest) with
+        {
+            EndedAt = DateTimeOffset.UtcNow,
+            Metrics = BuildPassingResult()
+        };
+        await store.RecordRunAsync(run);
+
+        var result = await service.ApproveAsync(new PromotionApprovalRequest(run.RunId));
+
+        result.Success.Should().BeTrue();
+        result.NewRunId.Should().NotBeNullOrWhiteSpace();
+        result.PromotionId.Should().NotBeNullOrWhiteSpace();
+        service.GetPromotionHistory().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ApproveAsync_WhenRunNotFound_ReturnsFailure()
+    {
+        var service = BuildService(out _);
+
+        var result = await service.ApproveAsync(new PromotionApprovalRequest("missing-run"));
+
+        result.Success.Should().BeFalse();
+        result.NewRunId.Should().BeNull();
+    }
+
+    // ---- RejectAsync ----
+
+    [Fact]
+    public async Task RejectAsync_AlwaysReturnsSuccess()
+    {
+        var service = BuildService(out _);
+
+        var result = await service.RejectAsync(new PromotionRejectionRequest("any-run", "Not ready"));
+
+        result.Success.Should().BeTrue();
+        result.Reason.Should().Contain("Not ready");
+    }
+
+    // ---- GetPromotionHistory ----
+
+    [Fact]
+    public async Task GetPromotionHistory_AfterApproval_ContainsRecord()
+    {
+        var service = BuildService(out var store);
+        var run = StrategyRunEntry.Start("s1", "Strategy One", RunType.Backtest) with
+        {
+            EndedAt = DateTimeOffset.UtcNow,
+            Metrics = BuildPassingResult()
+        };
+        await store.RecordRunAsync(run);
+        await service.ApproveAsync(new PromotionApprovalRequest(run.RunId));
+
+        var history = service.GetPromotionHistory();
+
+        history.Should().HaveCount(1);
+        history[0].StrategyId.Should().Be("s1");
+        history[0].TargetRunType.Should().Be(RunType.Paper);
+    }
+
+    // ---- Helpers ----
+
+    private static PromotionService BuildService(out StrategyRunStore store)
+    {
+        store = new StrategyRunStore();
+        var promoter = new BacktestToLivePromoter();
+        return new PromotionService(store, promoter, NullLogger<PromotionService>.Instance);
+    }
+
+    private static BacktestResult BuildPassingResult()
+    {
+        var request = new BacktestRequest(
+            From: new DateOnly(2026, 1, 1),
+            To: new DateOnly(2026, 3, 1),
+            Symbols: ["SPY"],
+            InitialCash: 100_000m,
+            DataRoot: "./data");
+
+        var snapshot = new PortfolioSnapshot(
+            Timestamp: DateTimeOffset.UtcNow,
+            Date: new DateOnly(2026, 3, 1),
+            Cash: 110_000m,
+            MarginBalance: 0m,
+            LongMarketValue: 0m,
+            ShortMarketValue: 0m,
+            TotalEquity: 110_000m,
+            DailyReturn: 0m,
+            Positions: new Dictionary<string, Position>(),
+            Accounts: new Dictionary<string, FinancialAccountSnapshot>(),
+            DayCashFlows: []);
+
+        var metrics = new BacktestMetrics(
+            InitialCapital: 100_000m,
+            FinalEquity: 110_000m,
+            GrossPnl: 10_000m,
+            NetPnl: 9_500m,
+            TotalReturn: 0.10m,
+            AnnualizedReturn: 0.25m,
+            SharpeRatio: 1.5d,
+            SortinoRatio: 2.0d,
+            CalmarRatio: 3.0d,
+            MaxDrawdown: 2_000m,
+            MaxDrawdownPercent: 0.02m,
+            MaxDrawdownRecoveryDays: 5,
+            ProfitFactor: 2.0d,
+            WinRate: 0.65d,
+            TotalTrades: 20,
+            WinningTrades: 13,
+            LosingTrades: 7,
+            TotalCommissions: 500m,
+            TotalMarginInterest: 0m,
+            TotalShortRebates: 0m,
+            Xirr: 0.22d,
+            SymbolAttribution: new Dictionary<string, SymbolAttribution>());
+
+        return new BacktestResult(
+            Request: request,
+            Universe: new HashSet<string>(["SPY"], StringComparer.OrdinalIgnoreCase),
+            Snapshots: [snapshot],
+            CashFlows: [],
+            Fills: [],
+            Metrics: metrics,
+            Ledger: new Ledger(),
+            ElapsedTime: TimeSpan.FromMinutes(5),
+            TotalEventsProcessed: 500);
+    }
+}


### PR DESCRIPTION
- Fix ExecutionEndpoints: resolve OMS via IOrderManager interface (not concrete
  type) so all four order management endpoints return data instead of 503
- Fix session DTO mismatch: Produces<> annotations now reference
  PaperSessionSummaryDto/PaperSessionDetailDto from PaperSessionPersistenceService;
  remove redundant local record duplicates (PaperSessionSummary, PaperSessionDetail)
- Register execution layer in UiServer DI: IPortfolioState (PaperTradingPortfolio),
  IOrderGateway (Adapters.PaperTradingGateway), IExecutionGateway
  (Execution.PaperTradingGateway), IOrderManager (OrderManagementSystem)
- Register StrategyLifecycleManager in UiServer DI
- Add StrategyLifecycleEndpoints: GET /api/strategies/status,
  GET /api/strategies/{id}/status, POST /api/strategies/{id}/pause,
  POST /api/strategies/{id}/stop; wired in both MapUiEndpoints overloads
- Add Swagger tags for /api/strategies, /api/execution, /api/promotion
- Add PromotionServiceTests covering EvaluateAsync, ApproveAsync, RejectAsync,
  and GetPromotionHistory with full BacktestResult fixture
- Add PaperSessionPersistenceServiceTests covering create, close, list, detail,
  active portfolio, and edge cases
- Update ROADMAP.md: mark Wave 2 paper cockpit and promotion items complete

https://claude.ai/code/session_01VReB3VPv5WTXyquekYD2mU