### PR TITLE
docs: refresh shared project context metadata

### DIFF
--- a/.codex/skills/_shared/project-context.md
+++ b/.codex/skills/_shared/project-context.md
@@ -1,5 +1,8 @@
 # Meridian Shared Project Context
 
+> Last verified: 2026-03-27 (UTC)
+> Canonical deep reference: `.claude/skills/_shared/project-context.md`
+
 Use this file as the common source of truth for Meridian-specific terminology, commands, and architecture when a skill needs repository grounding without repeating the same facts in every `SKILL.md`.
 
 ## Platform Snapshot
@@ -37,6 +40,7 @@ Prefer the narrowest validation command that matches the files being changed.
 - `src/Meridian.Backtesting/`, `src/Meridian.Backtesting.Sdk/`: replay engine and strategy SDK
 - `src/Meridian.Execution/`, `src/Meridian.Execution.Sdk/`: execution and broker gateway abstractions
 - `src/Meridian.Ledger/`: double-entry accounting ledger
+- `src/Meridian.Mcp/`, `src/Meridian.McpServer/`: MCP hosts, tools, and resources
 - `src/Meridian.Risk/`: pre-trade risk validation
 - `src/Meridian.Strategies/`: strategy lifecycle and run storage
 - `src/Meridian.Ui/`, `src/Meridian.Ui.Services/`, `src/Meridian.Ui.Shared/`: web UI and shared UI services


### PR DESCRIPTION
### Motivation
- Refresh the Codex shared project context to record a fresh verification timestamp, point to the canonical deep reference, and surface the MCP host projects in the solution layout.

### Description
- Updated `.codex/skills/_shared/project-context.md` to add `> Last verified: 2026-03-27 (UTC)`, a canonical pointer to `.claude/skills/_shared/project-context.md`, and include `src/Meridian.Mcp/` and `src/Meridian.McpServer/` in the Solution Layout section.

### Testing
- Ran `python3 build/scripts/ai-repo-updater.py audit-ai-docs --summary` (no findings) and validated the edit with `git diff -- .codex/skills/_shared/project-context.md` and `git show --stat --oneline HEAD`, all inspected successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5f1fbad808320830b88e632f657fd)