### PR TITLE
Add Meridian Implementation Assurance skill with docs and evaluation scripts

### DIFF
--- a/.codex/skills/meridian-implementation-assurance/SKILL.md
+++ b/.codex/skills/meridian-implementation-assurance/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: meridian-implementation-assurance
+description: Implement Meridian changes with built-in correctness checks, performance guardrails, documentation synchronization, and structured self-evaluation. Use when Codex is asked to build or refactor code and must also verify behavior, prevent performance regressions, update existing docs, or add new docs in the correct repository section when none exists.
+---
+
+# Meridian Implementation Assurance
+
+Deliver production-ready code changes and leave documentation in a consistent, current state.
+
+Read `../_shared/project-context.md` before coding. Read `references/documentation-routing.md` before writing docs. Read `references/evaluation-harness.md` before finalizing output.
+
+## Workflow
+
+1. Define requested behavior, risks, and acceptance checks.
+2. Identify impacted layers and likely performance-sensitive paths before editing.
+3. Implement the smallest safe change set that satisfies the request.
+4. Run targeted validation (tests/build/lint) and capture concrete command results.
+5. Update related documentation; if missing, add docs in the correct doc area.
+6. Run the evaluation harness and report pass/fail with evidence.
+7. Summarize code + docs updates and call out residual risk.
+
+## Correctness Guardrails
+
+- Preserve existing contracts, nullability expectations, and cancellation flow.
+- Keep layer boundaries explicit (UI/service/storage/provider/execution).
+- Add or extend tests for happy path, failure path, and cancellation/disposal where relevant.
+- Prefer deterministic behavior over timing-sensitive heuristics.
+
+## Performance Guardrails
+
+- Inspect hot paths for avoidable allocations, synchronous blocking, and unbounded buffering.
+- Avoid `.Result`/`.Wait()` on async flows.
+- Keep logging and serialization costs proportional to execution frequency.
+- When introducing loops or streams, define cancellation and backpressure behavior.
+
+## Documentation Synchronization Rules
+
+- Update docs in the same PR as code changes when behavior, interfaces, architecture, or operations change.
+- Prefer editing an existing doc when one already covers the topic.
+- Create new docs only when no suitable home exists.
+- For new docs, choose placement using `references/documentation-routing.md` and add cross-links from the nearest index/README.
+- Keep documentation concrete: what changed, why, and how to use/operate it.
+
+
+## Automation Scripts
+
+Use bundled scripts to keep execution fast and consistent:
+
+- `scripts/doc_route.py`: recommend documentation location + filename and whether cross-linking is required.
+  - Example: `python3 scripts/doc_route.py --kind architecture --topic "provider orchestration retries"`
+- `scripts/score_eval.py`: compute rubric totals and generate a standardized eval report.
+  - Example: `python3 scripts/score_eval.py --scenario C --scores '{"behavior_correctness":2,"validation_evidence":2,"performance_safety":2,"documentation_sync":1,"traceable_summary":2}'`
+
+Run these scripts from the skill directory or with full paths.
+
+## Evaluation Requirement
+
+Treat `references/evaluation-harness.md` as mandatory for this skill. Always return:
+
+- Which scenario was evaluated.
+- Rubric scores by category.
+- Failing checks and corrective follow-ups.
+- Exact command evidence for tests/build checks.
+
+## Output Checklist
+
+Before finishing, confirm:
+
+- Code compiles or tests pass for the touched surface.
+- Performance-sensitive changes were reviewed with explicit notes.
+- Docs were updated (or newly added in the correct location).
+- Evaluation harness was completed with a rubric score summary.
+- Summary includes validation commands and any residual risk.

--- a/.codex/skills/meridian-implementation-assurance/agents/openai.yaml
+++ b/.codex/skills/meridian-implementation-assurance/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Meridian Implementation Assurance"
+  short_description: "Enforce correctness, performance, docs, and evals"
+  default_prompt: "Use $meridian-implementation-assurance to implement Meridian changes with validation, synchronized documentation updates, and rubric-based self-evaluation."

--- a/.codex/skills/meridian-implementation-assurance/references/documentation-routing.md
+++ b/.codex/skills/meridian-implementation-assurance/references/documentation-routing.md
@@ -1,0 +1,36 @@
+# Documentation Routing Guide
+
+Use this map to decide where updates belong when implementing code changes.
+
+## Core Rule
+
+Prefer updating an existing document in the most specific section first. Create a new document only if no existing document fits.
+
+## Routing Matrix
+
+- `docs/architecture/`
+  - Use for architecture boundaries, component responsibilities, and system design decisions that are not ADR-level.
+- `docs/adr/`
+  - Use for durable architecture decisions and trade-offs that should be tracked as ADRs.
+- `docs/reference/`
+  - Use for operator/developer reference material (APIs, data dictionaries, configuration behavior).
+- `docs/generated/`
+  - Use for generated outputs only. Do not hand-author unless the repo's workflow explicitly requires it.
+- `docs/evaluations/`
+  - Use for analysis documents, assessments, and option comparisons.
+- `docs/ai/`
+  - Use for AI-agent operating instructions, prompt conventions, and AI workflow documentation.
+
+## If No Documentation Exists
+
+1. Choose the nearest folder from the routing matrix.
+2. Add a focused markdown file with a clear title and scope.
+3. Link the new file from the nearest `README.md` or index document in that subtree.
+4. In the PR summary, mention the new doc path and why a new file was needed.
+
+## Quality Bar for Doc Updates
+
+- State **what changed** and **why**.
+- Include usage/operational impact when relevant.
+- Keep examples aligned with current code names and paths.
+- Remove or revise stale statements in nearby docs when discovered.

--- a/.codex/skills/meridian-implementation-assurance/references/evaluation-harness.md
+++ b/.codex/skills/meridian-implementation-assurance/references/evaluation-harness.md
@@ -1,0 +1,118 @@
+# Evaluation Harness
+
+Use this harness to evaluate whether outputs from `meridian-implementation-assurance` are complete, correct, and operationally safe.
+
+## How to Run the Eval
+
+1. Pick one or more scenarios from **Scenario Set**.
+2. Execute the skill workflow end-to-end.
+3. Score results with the **Rubric**.
+4. Record evidence in the **Evaluation Report Template**.
+5. If any critical check fails, revise output and re-score.
+
+## Script-Assisted Execution
+
+- Use `scripts/score_eval.py` to enforce rubric key coverage, compute totals, and emit a report block.
+- Use `scripts/doc_route.py` before documentation edits when placement is unclear.
+
+## Scenario Set
+
+### Scenario A — Code Change + Existing Docs
+
+Prompt pattern:
+
+- "Refactor `<component>` to support `<new behavior>`, keep performance stable, and update docs."
+
+Expected:
+
+- Code change implemented with targeted tests.
+- Existing docs updated in-place.
+- No contract regressions.
+
+### Scenario B — Code Change + Missing Docs
+
+Prompt pattern:
+
+- "Add `<feature>` and document it; there is no current doc for this area."
+
+Expected:
+
+- Code implemented and validated.
+- New doc created in correct docs subtree.
+- Nearest README/index receives cross-link.
+
+### Scenario C — Performance-Sensitive Path
+
+Prompt pattern:
+
+- "Optimize `<hot path>` without changing behavior and update related docs."
+
+Expected:
+
+- Hot-path analysis noted.
+- Blocking/buffering/allocation risks explicitly addressed.
+- Verification commands included.
+
+## Rubric (0-2 per category)
+
+Score each category:
+
+- **0 = Missing/incorrect**
+- **1 = Partial/unclear**
+- **2 = Complete and concrete**
+
+Categories:
+
+1. **Behavior Correctness**
+   - Change satisfies requested behavior.
+   - Contracts/cancellation/nullability preserved.
+2. **Validation Evidence**
+   - Includes exact commands and results.
+   - Tests/build checks map to touched areas.
+3. **Performance Safety**
+   - Hot-path risks are identified.
+   - Async blocking/unbounded buffering risks are handled.
+4. **Documentation Sync**
+   - Existing docs updated when applicable.
+   - New docs created only when needed and routed correctly.
+5. **Traceable Summary**
+   - Final summary links code, docs, validation, and residual risks.
+
+### Passing Threshold
+
+- **Pass:** total score >= 8/10 and no category scored 0.
+- **Fail:** total score < 8 or any category scored 0.
+
+## Evaluation Report Template
+
+Use this exact structure in the final response when running an eval:
+
+```markdown
+### Skill Eval Report
+
+- Scenario: <A|B|C>
+- Total Score: <n>/10
+- Outcome: <Pass|Fail>
+
+| Category | Score (0-2) | Evidence |
+|---|---:|---|
+| Behavior Correctness |  |  |
+| Validation Evidence |  |  |
+| Performance Safety |  |  |
+| Documentation Sync |  |  |
+| Traceable Summary |  |  |
+
+- Failed checks:
+  - <none or list>
+- Corrective follow-ups:
+  - <none or list>
+```
+
+## Quick Failure Heuristics
+
+Automatically fail if any of these occur:
+
+- No validation commands are shown.
+- Docs are claimed updated but no file/path is cited.
+- New docs are added with no README/index cross-link.
+- Performance-sensitive request has no performance discussion.

--- a/.codex/skills/meridian-implementation-assurance/scripts/doc_route.py
+++ b/.codex/skills/meridian-implementation-assurance/scripts/doc_route.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Suggest documentation location for Meridian changes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+ROUTES = {
+    "architecture": "docs/architecture/",
+    "adr": "docs/adr/",
+    "reference": "docs/reference/",
+    "generated": "docs/generated/",
+    "evaluation": "docs/evaluations/",
+    "ai": "docs/ai/",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Route documentation updates to the right docs subtree.")
+    p.add_argument(
+        "--kind",
+        required=True,
+        choices=sorted(ROUTES.keys()),
+        help="Documentation kind.",
+    )
+    p.add_argument("--topic", required=True, help="Short topic name used for filename suggestion.")
+    p.add_argument(
+        "--existing-doc",
+        action="store_true",
+        help="Mark when an existing doc already covers this topic; recommendation becomes update-in-place.",
+    )
+    p.add_argument("--json", action="store_true", help="Emit JSON instead of human-readable markdown.")
+    return p.parse_args()
+
+
+def slugify(value: str) -> str:
+    out = []
+    prev_dash = False
+    for ch in value.lower().strip():
+        if ch.isalnum():
+            out.append(ch)
+            prev_dash = False
+        else:
+            if not prev_dash:
+                out.append("-")
+                prev_dash = True
+    slug = "".join(out).strip("-")
+    return slug or "new-doc"
+
+
+def main() -> int:
+    args = parse_args()
+    base = ROUTES[args.kind]
+    suggested = f"{base}{slugify(args.topic)}.md"
+    action = "update-existing" if args.existing_doc else "create-new"
+
+    payload = {
+        "kind": args.kind,
+        "target_directory": base,
+        "suggested_file": suggested,
+        "action": action,
+        "cross_link_required": not args.existing_doc,
+    }
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print("### Documentation Route")
+        print(f"- Kind: {payload['kind']}")
+        print(f"- Directory: {payload['target_directory']}")
+        print(f"- Suggested file: {payload['suggested_file']}")
+        print(f"- Action: {payload['action']}")
+        print(f"- Cross-link required: {'yes' if payload['cross_link_required'] else 'no'}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/meridian-implementation-assurance/scripts/score_eval.py
+++ b/.codex/skills/meridian-implementation-assurance/scripts/score_eval.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Score meridian-implementation-assurance eval rubric and emit a report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+
+CATEGORIES = [
+    "behavior_correctness",
+    "validation_evidence",
+    "performance_safety",
+    "documentation_sync",
+    "traceable_summary",
+]
+
+
+@dataclass
+class EvalResult:
+    scenario: str
+    scores: dict[str, int]
+    failed_checks: list[str]
+    follow_ups: list[str]
+
+    @property
+    def total(self) -> int:
+        return sum(self.scores.values())
+
+    @property
+    def outcome(self) -> str:
+        has_zero = any(v == 0 for v in self.scores.values())
+        return "Pass" if self.total >= 8 and not has_zero else "Fail"
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Score rubric for Meridian Implementation Assurance skill.")
+    p.add_argument("--scenario", required=True, choices=["A", "B", "C"], help="Evaluated scenario ID.")
+    p.add_argument("--scores", required=True, help="JSON object of category->score (0-2).")
+    p.add_argument("--failed-check", action="append", default=[], help="Failed check description.")
+    p.add_argument("--follow-up", action="append", default=[], help="Corrective follow-up action.")
+    p.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return p.parse_args()
+
+
+def validate_scores(raw: dict[str, object]) -> dict[str, int]:
+    missing = [c for c in CATEGORIES if c not in raw]
+    extra = [k for k in raw if k not in CATEGORIES]
+    if missing or extra:
+        raise ValueError(
+            f"Invalid score keys. Missing={missing or 'none'} Extra={extra or 'none'} Expected={CATEGORIES}"
+        )
+
+    scores: dict[str, int] = {}
+    for k in CATEGORIES:
+        try:
+            val = int(raw[k])
+        except Exception as exc:  # noqa: BLE001
+            raise ValueError(f"Score for '{k}' is not an integer: {raw[k]!r}") from exc
+        if val < 0 or val > 2:
+            raise ValueError(f"Score for '{k}' must be between 0 and 2. Got {val}.")
+        scores[k] = val
+    return scores
+
+
+def to_markdown(result: EvalResult) -> str:
+    pretty = {
+        "behavior_correctness": "Behavior Correctness",
+        "validation_evidence": "Validation Evidence",
+        "performance_safety": "Performance Safety",
+        "documentation_sync": "Documentation Sync",
+        "traceable_summary": "Traceable Summary",
+    }
+    rows = "\n".join(
+        f"| {pretty[k]} | {v} |" for k, v in result.scores.items()
+    )
+
+    failed_lines = "\n".join(f"  - {x}" for x in (result.failed_checks or ["none"]))
+    follow_lines = "\n".join(f"  - {x}" for x in (result.follow_ups or ["none"]))
+
+    return (
+        "### Skill Eval Report\n\n"
+        f"- Scenario: {result.scenario}\n"
+        f"- Total Score: {result.total}/10\n"
+        f"- Outcome: {result.outcome}\n\n"
+        "| Category | Score (0-2) |\n"
+        "|---|---:|\n"
+        f"{rows}\n\n"
+        "- Failed checks:\n"
+        f"{failed_lines}\n"
+        "- Corrective follow-ups:\n"
+        f"{follow_lines}\n"
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        raw = json.loads(args.scores)
+        if not isinstance(raw, dict):
+            raise ValueError("--scores must decode to a JSON object.")
+        scores = validate_scores(raw)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    result = EvalResult(
+        scenario=args.scenario,
+        scores=scores,
+        failed_checks=args.failed_check,
+        follow_ups=args.follow_up,
+    )
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "scenario": result.scenario,
+                    "total": result.total,
+                    "outcome": result.outcome,
+                    "scores": result.scores,
+                    "failed_checks": result.failed_checks,
+                    "follow_ups": result.follow_ups,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(to_markdown(result))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Provide a reusable skill to implement and validate code changes with built-in correctness checks, performance guardrails, synchronized documentation updates, and a rubric-based evaluation flow.
- Centralize guidance for where to place or update docs when code changes require documentation edits and enforce a quality bar for doc updates.
- Supply small CLI utilities to help route documentation edits and to compute and emit standardized evaluation reports for the skill.

### Description

- Add `/.codex/skills/meridian-implementation-assurance/SKILL.md` which defines the skill, workflow, correctness and performance guardrails, documentation synchronization rules, automation script usage, and evaluation requirements.
- Add an agent interface file at `/.codex/skills/meridian-implementation-assurance/agents/openai.yaml` with display metadata and a default prompt for using the skill.
- Add documentation routing guidance in `references/documentation-routing.md` and an evaluation harness and rubric in `references/evaluation-harness.md` to prescribe scenarios, scoring, and the exact evaluation report template.
- Add two executable helper scripts: `scripts/doc_route.py` to suggest documentation placement and filename based on topic and kind, and `scripts/score_eval.py` to validate rubric inputs and emit a pass/fail evaluation report in markdown or JSON.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c84e286dc48320a5d03687a80bf404)