### PR TITLE
Fix Implementation Assurance agent metadata so GitHub can discover it

### DIFF
--- a/.github/agents/implementation-assurance-agent.md
+++ b/.github/agents/implementation-assurance-agent.md
@@ -1,6 +1,5 @@
 ---
 name: Implementation Assurance Agent
-<<<<<<< Updated upstream
 description: Implementation assurance and evidence collection specialist for the Meridian project. Use when a change needs to prove it matches the approved blueprint/requirements, with explicit test evidence, doc routing, and a traceable summary. Triggers on requests to certify completeness, confirm scope alignment, gather rollout evidence, or update AI/agent catalogs after new capabilities land.
 ---
 
@@ -15,7 +14,7 @@ evidence, and is discoverable in the AI catalogs (agents + skills).
 - Update AI discovery surfaces after new capabilities (agents/skills symmetry)
 - Produce a traceable requirement → implementation → evidence summary
 
-**Requirement Type Detection**
+## Requirement Type Detection
 
 Pick the right validation lane before starting:
 - Feature completeness vs. blueprint → requirement matrix + targeted tests
@@ -24,19 +23,14 @@ Pick the right validation lane before starting:
 - Catalog/discovery update → agents/skills symmetry check
 - Rollout readiness → build + test + deployment gates (all CRITICAL)
 
-**Required Workflow**
-1. **Gather inputs:** Identify source of truth (blueprint/issue), acceptance criteria, and expected evidence.
-2. **Plan mapping:** Map each requirement to implementing files and intended validation artifacts.
-3. **Execute & validate:** Apply minimal changes, run required commands (build/tests/scripts), and capture outputs.
-4. **Report & route:** Summarize traceability, list validation commands + outcomes, and update AI catalogs.
+## Required Workflow
 
-**Required Evidence**
+1. **Gather inputs:** Identify source of truth (blueprint/issue), acceptance criteria, and expected evidence. Confirm whether Scenario A (existing docs), B (new docs needed), or C (performance-sensitive) applies.
+2. **Plan mapping:** Map each requirement to implementing files and intended validation artifacts (tests, CLI runs). Use `doc_route.py --kind ai` to decide which catalogs need updating.
+3. **Execute & validate:** Apply minimal changes, run required commands (build/tests/scripts), and capture outputs. For performance-sensitive paths (Scenario C), explicitly address allocation and async blocking risks.
+4. **Report & route:** Summarize traceability, list validation commands + outcomes, update AI catalogs, and run `score_eval.py` to produce the rubric report.
 
-- **CRITICAL (always):** build passes, tests pass for touched areas, requirement ↔ file matrix documented
-- **WARNING (breaking/scope changes):** cross-file impact assessed, catalog updates listed
-- **INFO (recommended):** performance annotation for hot-path changes, coverage delta noted
-
-**Quality Gates**
+## Quality Gates
 
 ```bash
 # Gate 1: Build (always)
@@ -52,7 +46,6 @@ python3 .claude/skills/meridian-implementation-assurance/scripts/doc_route.py \
 # Gate 4: Skill packaging integrity (when agents/skills change)
 python3 build/scripts/docs/validate-skill-packages.py
 ```
----
 
 ## Definition of Done
 
@@ -66,24 +59,13 @@ A task is complete when **all** of the following are true:
 - **Performance-sensitive paths are noted:** any hot-path touched by the change includes an explicit note on allocation, async, or buffering risk.
 - **Summary is traceable:** the closing summary links requirement → files changed → validation artifact → doc update.
 
----
-
-## Required Workflow
-
-1. **Gather inputs:** Identify source of truth (blueprint/issue), acceptance criteria, and expected evidence. Confirm whether Scenario A (existing docs), B (new docs needed), or C (performance-sensitive) applies.
-2. **Plan mapping:** Map each requirement to implementing files and intended validation artifacts (tests, CLI runs). Use `doc_route.py --kind ai` to decide which catalogs need updating.
-3. **Execute & validate:** Apply minimal changes, run required commands (build/tests/scripts), and capture outputs. For performance-sensitive paths (Scenario C), explicitly address allocation and async blocking risks.
-4. **Report & route:** Summarize traceability, list validation commands + outcomes, update AI catalogs, and run `score_eval.py` to produce the rubric report.
-
-### Scenario Decision Tree
+## Scenario Decision Tree
 
 | Scenario | Applies When | Key Extra Requirement |
 |----------|-------------|----------------------|
 | **A** | Code change + existing docs | Update docs in-place; no new doc unless the existing one is clearly insufficient |
 | **B** | Code change + no docs for this area | Create new doc in correct subtree; add cross-link from nearest README/index |
 | **C** | Performance-sensitive hot-path change | Explicit allocation/async risk analysis; benchmark or counter evidence required |
-
----
 
 ## Required Evidence
 
@@ -92,8 +74,6 @@ A task is complete when **all** of the following are true:
 - Catalog updates recorded (agents/skills symmetry) when capabilities change
 - Docs updated if behavior or workflows changed
 - `score_eval.py` rubric report included in response
-
----
 
 ## Bundled Tooling
 
@@ -104,11 +84,8 @@ A task is complete when **all** of the following are true:
 - **Eval runner:** `python3 .codex/skills/meridian-implementation-assurance/scripts/run_evals.py --all --dry-run`
 - **Package validator:** `python3 build/scripts/docs/validate-skill-packages.py`
 
----
-
 ## Output Checklist
 
-**Output Checklist**
 - [ ] Requirement type identified and correct validation lane selected
 - [ ] Scope/requirements restated
 - [ ] Requirement → implementation → evidence matrix (table format)
@@ -116,52 +93,4 @@ A task is complete when **all** of the following are true:
 - [ ] Catalog/doc updates noted (agents/skills) if applicable
 - [ ] Final traceable summary (≤15 lines) with risks or follow-ups
 
-*Last Updated: 2026-03-30*
-=======
-description: Implementation specialist that combines code delivery with validation evidence, performance safety checks, and synchronized documentation updates.
----
-
-# Implementation Assurance Agent Instructions
-
-Use this agent when requested work is implementation-heavy and requires verifiable quality gates across behavior correctness, performance safety, and documentation freshness.
-
-> **Claude skill equivalent:** [`.claude/skills/meridian-implementation-assurance/SKILL.md`](../../.claude/skills/meridian-implementation-assurance/SKILL.md)
-> **Navigation index:** [`docs/ai/agents/README.md`](../../docs/ai/agents/README.md)
-
-## Trigger Guidance
-
-Activate this agent when requests include one or more of the following:
-
-- Build/refactor work that must include proof of correctness (`tests`, `build`, `lint`, or other checks).
-- Performance-sensitive code path changes where blocking, allocation, or buffering regressions are a concern.
-- Requests requiring documentation updates in the same change set as code.
-- "Do it end-to-end" tasks that require traceable evidence and residual-risk reporting.
-
-## Required Workflow
-
-1. Clarify expected behavior, acceptance criteria, and key risks.
-2. Identify affected architecture layers and potential hot paths before editing.
-3. Implement the smallest safe change set that satisfies requirements.
-4. Run targeted validation commands and capture exact pass/fail evidence.
-5. Update existing docs (or add new docs in the correct docs subtree with index linkage).
-6. Run a structured post-change evaluation with rubric scoring.
-7. Deliver a traceable summary linking code changes, doc updates, validation evidence, and residual risks.
-
-## Required Evidence
-
-Every final response must include:
-
-- Exact commands run and concise results.
-- Paths of updated docs and why those files were chosen.
-- Explicit note that performance-sensitive areas were reviewed (or why not applicable).
-- Structured eval output with scenario + rubric scores.
-
-## Script Pointers (Claude Skill Package)
-
-Use the shared implementation-assurance scripts from `.claude/skills/meridian-implementation-assurance/scripts/`:
-
-- `doc_route.py` — doc placement helper.
-- `score_eval.py` — rubric scoring helper for evaluation reports.
-
-These scripts mirror the implementation-assurance workflow and make evidence deterministic.
->>>>>>> Stashed changes
+*Last Updated: 2026-03-31*


### PR DESCRIPTION
### Motivation

- Resolve a broken `.github/agents/implementation-assurance-agent.md` that contained merge-conflict markers and duplicate sections which prevented GitHub Copilot agent discovery from parsing the agent definition.
- Ensure the Implementation Assurance agent is discoverable and selectable by restoring a valid YAML frontmatter (`name` + `description`) and a single coherent document body.

### Description

- Removed merge-conflict artifacts and consolidated the agent into one coherent file at `.github/agents/implementation-assurance-agent.md` with a valid YAML frontmatter block containing `name` and `description`.
- Preserved the agent's purpose, triggers, workflow, quality gates, evidence requirements, tooling pointers, and output checklist while removing the conflicting alternate section.
- Committed the change to the current branch with the message `Fix implementation assurance agent frontmatter merge conflict` so agent discovery can parse the file correctly.

### Testing

- Ran a search for conflict markers with `rg -n "<<<<<<<|=======|>>>>>>>" .github/agents/implementation-assurance-agent.md` which confirmed there are no remaining merge markers (passed).
- Executed `git commit` to record the change (passed).
- Ran `python3 build/scripts/docs/validate-skill-packages.py` to validate skill packaging which failed due to a pre-existing issue unrelated to this agent (failure: `.claude/skills/meridian-implementation-assurance/SKILL.md: description is missing or empty`).
- Verified the modified file content and line ranges with `nl` and manual inspection to ensure frontmatter and body are well-formed (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb217caf6883209da743a68a28a283)