### PR TITLE
docs: link orphaned documentation files from index pages

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -4,11 +4,15 @@ This repository includes project-local Codex skills under this folder.
 
 Current skills:
 
-- `meridian-blueprint`
-- `meridian-brainstorm`
-- `meridian-code-review`
-- `meridian-implementation-assurance`
-- `meridian-provider-builder`
-- `meridian-test-writer`
+| Skill | Entry Point | Key References |
+|-------|-------------|----------------|
+| `meridian-blueprint` | [`SKILL.md`](meridian-blueprint/SKILL.md) | [`blueprint-patterns.md`](meridian-blueprint/references/blueprint-patterns.md) |
+| `meridian-brainstorm` | [`SKILL.md`](meridian-brainstorm/SKILL.md) | [`competitive-landscape.md`](meridian-brainstorm/references/competitive-landscape.md) |
+| `meridian-code-review` | `SKILL.md` | — |
+| `meridian-implementation-assurance` | `SKILL.md` | — |
+| `meridian-provider-builder` | `SKILL.md` | — |
+| `meridian-test-writer` | `SKILL.md` | — |
+
+**Shared resources:** [`_shared/project-context.md`](_shared/project-context.md) — canonical project statistics, paths, and ADR anchors used by all skills.
 
 Use these skills as repo-owned guidance for Meridian-specific planning, ideation, review, provider work, implementation assurance, and test writing.

--- a/docs/ai/agents/README.md
+++ b/docs/ai/agents/README.md
@@ -220,6 +220,7 @@ performance safety, documentation sync, and traceable evaluation evidence.
 ### Claude Blueprint Agent
 
 **Location:** `.claude/agents/`
+**File:** [`.claude/agents/meridian-blueprint.md`](../../../.claude/agents/meridian-blueprint.md)
 **Used by:** Claude Code
 **Copilot equivalent:** [`.github/agents/blueprint-agent.md`](https://github.com/rodoHasArrived/Meridian/blob/main/.github/agents/blueprint-agent.md)
 **Skill equivalent:** the Blueprint skill documented under `.claude/skills/`
@@ -233,6 +234,7 @@ and implementation checklists — grounded in Meridian's actual stack.
 ### Claude Cleanup Agent
 
 **Location:** `.claude/agents/`
+**File:** [`.claude/agents/meridian-cleanup.md`](../../../.claude/agents/meridian-cleanup.md)
 **Used by:** Claude Code
 **Copilot equivalent:** [`.github/agents/cleanup-agent.md`](https://github.com/rodoHasArrived/Meridian/blob/main/.github/agents/cleanup-agent.md)
 
@@ -247,6 +249,7 @@ ADR attribute cleanup, deprecated/obsolete member cleanup, and log hygiene.
 ### Claude Documentation Agent
 
 **Location:** `.claude/agents/`
+**File:** [`.claude/agents/meridian-docs.md`](../../../.claude/agents/meridian-docs.md)
 **Used by:** Claude Code
 **Copilot equivalent:** [`.github/agents/documentation-agent.md`](https://github.com/rodoHasArrived/Meridian/blob/main/.github/agents/documentation-agent.md)
 

--- a/docs/ai/skills/README.md
+++ b/docs/ai/skills/README.md
@@ -76,8 +76,8 @@ static package content.
 **When it triggers:** design-doc requests, architecture spikes, interface planning, or roadmap-to-implementation handoffs.
 **On-demand resources:**
 
-- `references/blueprint-patterns.md` — reusable section patterns and implementation shapes
-- `references/pipeline-position.md` — pipeline-stage and handoff guidance
+- [`references/blueprint-patterns.md`](../../../.claude/skills/meridian-blueprint/references/blueprint-patterns.md) — reusable section patterns and implementation shapes
+- [`references/pipeline-position.md`](../../../.claude/skills/meridian-blueprint/references/pipeline-position.md) — pipeline-stage and handoff guidance
 - `../_shared/project-context.md` — canonical project statistics, paths, and ADR anchors
 
 ### `meridian-code-review`
@@ -87,26 +87,28 @@ static package content.
 **When it triggers:** code review, refactoring, architecture audit, MVVM cleanup, provider compliance, or performance review tasks.
 **On-demand resources and scripts:**
 
-- `references/architecture.md` — deep architecture context
-- `references/schemas.md` — eval/grading schemas
-- `agents/grader.md` — grading instructions for eval runs
+- [`references/architecture.md`](../../../.claude/skills/meridian-code-review/references/architecture.md) — deep architecture context
+- [`references/schemas.md`](../../../.claude/skills/meridian-code-review/references/schemas.md) — eval/grading schemas
+- [`agents/grader.md`](../../../.claude/skills/meridian-code-review/agents/grader.md) — grading instructions for eval runs
 - `scripts/run_eval.py`, `scripts/aggregate_benchmark.py`, `scripts/package_skill.py` — deterministic review helpers
 - Dynamic resources via the provider: `project-stats`, `git-context`
 
 ### `meridian-brainstorm`
 
 **Location:** [`.claude/skills/meridian-brainstorm/`](https://github.com/rodoHasArrived/Meridian/blob/main/.claude/skills/meridian-brainstorm)
+**SKILL.md:** [`.claude/skills/meridian-brainstorm/SKILL.md`](../../../.claude/skills/meridian-brainstorm/SKILL.md)
 **Purpose:** Generate high-value, implementable ideas that extend Meridian coherently.
 **When it triggers:** feature ideation, user-pain brainstorming, architecture brainstorms, or technical-debt ideation.
 **On-demand resources:**
 
-- `references/idea-dimensions.md` — evaluation rubric
-- `references/competitive-landscape.md` — external framing and differentiation context
+- [`references/idea-dimensions.md`](../../../.claude/skills/meridian-brainstorm/references/idea-dimensions.md) — evaluation rubric
+- [`references/competitive-landscape.md`](../../../.claude/skills/meridian-brainstorm/references/competitive-landscape.md) — external framing and differentiation context
 - `brainstorm-history.jsonl` — optional local continuity ledger when the host permits writes
 
 ### `meridian-provider-builder`
 
 **Location:** [`.claude/skills/meridian-provider-builder/`](https://github.com/rodoHasArrived/Meridian/blob/main/.claude/skills/meridian-provider-builder)
+**SKILL.md:** [`.claude/skills/meridian-provider-builder/SKILL.md`](../../../.claude/skills/meridian-provider-builder/SKILL.md)
 **Purpose:** Scaffold Meridian data providers with the right ADR, DI, and resilience patterns.
 **When it triggers:** new exchange/provider work, historical providers, streaming adapters, or symbol search implementations.
 **On-demand resources:**
@@ -122,8 +124,8 @@ static package content.
 **Passing threshold:** rubric score ≥ 8/10 and no category scored 0.
 **On-demand resources and scripts:**
 
-- `references/documentation-routing.md` — docs placement matrix and cross-linking rules
-- `references/evaluation-harness.md` — scenario set (A/B/C), rubric definitions, and pass/fail criteria
+- [`references/documentation-routing.md`](../../../.claude/skills/meridian-implementation-assurance/references/documentation-routing.md) — docs placement matrix and cross-linking rules
+- [`references/evaluation-harness.md`](../../../.claude/skills/meridian-implementation-assurance/references/evaluation-harness.md) — scenario set (A/B/C), rubric definitions, and pass/fail criteria
 - `scripts/doc_route.py` — routes catalog updates to the correct AI/agent index
 - `scripts/score_eval.py` — summarizes assurance scoring with JSON/text output
 - `python3 build/scripts/docs/validate-skill-packages.py` — validates skill packaging and references
@@ -131,6 +133,7 @@ static package content.
 ### `meridian-test-writer`
 
 **Location:** [`.claude/skills/meridian-test-writer/`](https://github.com/rodoHasArrived/Meridian/blob/main/.claude/skills/meridian-test-writer)
+**SKILL.md:** [`.claude/skills/meridian-test-writer/SKILL.md`](../../../.claude/skills/meridian-test-writer/SKILL.md)
 **Purpose:** Produce idiomatic Meridian xUnit tests with the right async, mocking, and cleanup patterns.
 **When it triggers:** new tests, test-gap remediation, or code-review follow-up for missing coverage.
 **On-demand resources:**


### PR DESCRIPTION
Added direct Markdown links to 20 previously orphaned files:

- .claude/agents/: added **File:** links for meridian-blueprint.md,
  meridian-cleanup.md, and meridian-docs.md in docs/ai/agents/README.md
- .claude/skills/: converted bare backtick references to Markdown links
  for all reference files (blueprint-patterns, pipeline-position,
  idea-dimensions, competitive-landscape, grader, architecture, schemas,
  documentation-routing, evaluation-harness) and added **SKILL.md:**
  entries for meridian-brainstorm, meridian-provider-builder, and
  meridian-test-writer in docs/ai/skills/README.md
- .codex/skills/: expanded README table with links to SKILL.md entry
  points and key reference files, plus a shared project-context.md entry

https://claude.ai/code/session_01K9ByhxQMT8Q1wtqTLZP63t