### PR TITLE
Expose volatilityMultiplier as constructor parameter in BarMidpointFi…

### DIFF
--- a/src/Meridian.Backtesting/Engine/BacktestEngine.cs
+++ b/src/Meridian.Backtesting/Engine/BacktestEngine.cs
@@ -66,7 +66,7 @@ public sealed class BacktestEngine(
         var portfolio = new SimulatedPortfolio(accounts, request.DefaultBrokerageAccountId, commissionModel, ledger, startTimestamp);
         var ctx = new BacktestContext(portfolio, universe, ledger, request.DefaultBrokerageAccountId);
         var orderBookFillModel = new OrderBookFillModel(commissionModel, tickSizes);
-        var barFillModel = new BarMidpointFillModel(commissionModel, request.SlippageBasisPoints, spreadAware: true, tickSizes, request.MaxParticipationRate);
+        var barFillModel = new BarMidpointFillModel(commissionModel, request.SlippageBasisPoints, spreadAware: true, tickSizes: tickSizes, maxParticipationRate: request.MaxParticipationRate);
         var marketImpactFillModel = new MarketImpactFillModel(commissionModel, request.MarketImpactCoefficient, request.SlippageBasisPoints);
 
         var pendingOrders = new List<Order>();

--- a/src/Meridian.Backtesting/FillModels/BarMidpointFillModel.cs
+++ b/src/Meridian.Backtesting/FillModels/BarMidpointFillModel.cs
@@ -10,7 +10,10 @@ namespace Meridian.Backtesting.FillModels;
 /// Supports market, limit, stop-market, and stop-limit semantics with a
 /// configurable midpoint slippage assumption. When <paramref name="spreadAware"/>
 /// is enabled, slippage is scaled by the bar's intrabar volatility (range / midpoint),
-/// simulating wider spreads in volatile conditions.
+/// simulating wider spreads in volatile conditions. The scaling formula is
+/// <c>slippageBasisPoints × (1 + volatilityFactor × <paramref name="volatilityMultiplier"/>)</c>;
+/// the default multiplier of 50 is an empirical calibration that maps a typical 1–2% intraday
+/// bar range to a 50–100% slippage increase — adjust when calibrating against real microstructure data.
 /// When <paramref name="tickSizes"/> is provided, fill prices are rounded to the
 /// instrument's tick grid before being returned.
 /// When <paramref name="maxParticipationRate"/> is greater than zero, the fill is
@@ -22,6 +25,7 @@ internal sealed class BarMidpointFillModel(
     ICommissionModel commissionModel,
     decimal slippageBasisPoints = 5m,
     bool spreadAware = false,
+    decimal volatilityMultiplier = 50m,
     IReadOnlyDictionary<string, decimal>? tickSizes = null,
     decimal maxParticipationRate = 0m) : IFillModel
 {
@@ -151,12 +155,8 @@ internal sealed class BarMidpointFillModel(
                 {
                     var range = bar.High - bar.Low;
                     var volatilityFactor = range / mid; // e.g., 0.02 for a 2% bar range
-                    // Scale: base slippage * (1 + volatility multiplier × 50).
-                    // The 50× factor is an empirical calibration: it maps a typical equity
-                    // intraday range of 1–2 % to a slippage increase of 50–100 %, approximating
-                    // the widening of quoted spreads in high-volatility conditions. Adjust this
-                    // constant when calibrating the model against actual market microstructure data.
-                    effectiveSlippage = slippageBasisPoints * (1m + volatilityFactor * 50m);
+                    // volatilityMultiplier is a calibration factor (default 50×); see constructor doc.
+                    effectiveSlippage = slippageBasisPoints * (1m + volatilityFactor * volatilityMultiplier);
                 }
 
                 var slip = mid * (effectiveSlippage / 10_000m);

--- a/tests/Meridian.Backtesting.Tests/FillModelTests.cs
+++ b/tests/Meridian.Backtesting.Tests/FillModelTests.cs
@@ -170,4 +170,62 @@ public sealed class FillModelTests
 
         result.Fills.Should().BeEmpty();
     }
+
+    // Bar: open=100, high=110, low=90, close=100 → mid=100, range=20, volatilityFactor=0.2
+
+    [Fact]
+    public void BarMidpointFillModel_SpreadAware_DefaultMultiplier_ProducesExpectedSlippage()
+    {
+        // effectiveSlippage = 10 * (1 + 0.2 * 50) = 110 bps; slip = 100 * 0.011 = 1.1; fillPrice = 101.1
+        var model = new BarMidpointFillModel(
+            new FixedCommissionModel(0m),
+            slippageBasisPoints: 10m,
+            spreadAware: true);
+
+        var order = new Order(Guid.NewGuid(), "SPY", OrderType.Market, 1L, null, null, DateTimeOffset.UtcNow);
+        var evt = MakeBarEvent("SPY", 100m, 110m, 90m, 100m);
+
+        var result = model.TryFill(order, evt);
+
+        result.Fills.Should().HaveCount(1);
+        result.Fills[0].FillPrice.Should().Be(101.1m);
+    }
+
+    [Fact]
+    public void BarMidpointFillModel_SpreadAware_CustomMultiplier100_IncreasesVolatilityScaling()
+    {
+        // effectiveSlippage = 10 * (1 + 0.2 * 100) = 210 bps; slip = 100 * 0.021 = 2.1; fillPrice = 102.1
+        var model = new BarMidpointFillModel(
+            new FixedCommissionModel(0m),
+            slippageBasisPoints: 10m,
+            spreadAware: true,
+            volatilityMultiplier: 100m);
+
+        var order = new Order(Guid.NewGuid(), "SPY", OrderType.Market, 1L, null, null, DateTimeOffset.UtcNow);
+        var evt = MakeBarEvent("SPY", 100m, 110m, 90m, 100m);
+
+        var result = model.TryFill(order, evt);
+
+        result.Fills.Should().HaveCount(1);
+        result.Fills[0].FillPrice.Should().Be(102.1m);
+    }
+
+    [Fact]
+    public void BarMidpointFillModel_SpreadAware_ZeroMultiplier_ProducesBaseSlippageOnly()
+    {
+        // effectiveSlippage = 10 * (1 + 0.2 * 0) = 10 bps (same as non-spread-aware); fillPrice = 100.1
+        var model = new BarMidpointFillModel(
+            new FixedCommissionModel(0m),
+            slippageBasisPoints: 10m,
+            spreadAware: true,
+            volatilityMultiplier: 0m);
+
+        var order = new Order(Guid.NewGuid(), "SPY", OrderType.Market, 1L, null, null, DateTimeOffset.UtcNow);
+        var evt = MakeBarEvent("SPY", 100m, 110m, 90m, 100m);
+
+        var result = model.TryFill(order, evt);
+
+        result.Fills.Should().HaveCount(1);
+        result.Fills[0].FillPrice.Should().Be(100.1m);
+    }
 }


### PR DESCRIPTION
…llModel

The spread-aware slippage formula used a hardcoded 50× volatility multiplier that the code comment explicitly noted should be tunable per strategy. This change promotes it to an optional constructor parameter with default 50m, preserving backward compatibility while enabling per-strategy calibration.

- Add `decimal volatilityMultiplier = 50m` parameter after `spreadAware`
- Replace hardcoded `50m` literal with the parameter in TryResolveFillPrice
- Update XML doc summary with the scaling formula and calibration guidance
- Fix BacktestEngine.cs call site to use named args (avoids slot shift)
- Add 3 spread-aware tests covering default, doubled, and zero multipliers

Closes audit item #13 from BACKTEST_ENGINE_CODE_REVIEW_2026_03_25.md

https://claude.ai/code/session_013ZfedH5Qa5EGK44GkxU3iu

name: Pull Request
description: Submit a pull request to contribute to the Meridian
title: "[PR]: "
labels: ["needs-review"]

body:
  - type: markdown
    attributes:
      value: |
        Thank you for contributing to Meridian! Please fill out this template to help us review your PR.

  - type: textarea
    id: description
    attributes:
      label: Description
      description: Please describe the changes in this PR
      placeholder: This PR adds/fixes/improves...
    validations:
      required: true

  - type: dropdown
    id: type
    attributes:
      label: Type of Change
      description: What type of change does this PR introduce?
      multiple: true
      options:
        - Bug fix
        - New feature
        - Performance improvement
        - Code refactoring
        - Documentation update
        - Build/CI changes
        - Test improvements
        - Dependency updates
    validations:
      required: true

  - type: textarea
    id: motivation
    attributes:
      label: Motivation and Context
      description: Why is this change required? What problem does it solve?
      placeholder: This change is needed because...
    validations:
      required: true

  - type: textarea
    id: testing
    attributes:
      label: How Has This Been Tested?
      description: Please describe the tests you ran to verify your changes
      placeholder: |
        - [ ] Unit tests
        - [ ] Integration tests
        - [ ] Manual testing on Windows
        - [ ] Manual testing on Linux
        - [ ] Benchmarks
    validations:
      required: true

  - type: checkboxes
    id: checklist
    attributes:
      label: Checklist
      description: Please confirm the following
      options:
        - label: My code follows the code style of this project
          required: true
        - label: I have updated the documentation accordingly
          required: false
        - label: I have added tests to cover my changes
          required: false
        - label: All new and existing tests passed
          required: true
        - label: I have checked my code and corrected any misspellings
          required: true
        - label: My changes generate no new warnings
          required: true
        - label: I have run benchmarks for performance-sensitive changes (make bench-quick)
          required: false
        - label: I have checked docs/ai/ai-known-errors.md for relevant patterns
          required: false
        - label: I have updated CHANGELOG.md (if applicable)
          required: false

  - type: textarea
    id: breaking-changes
    attributes:
      label: Breaking Changes
      description: Does this PR introduce any breaking changes? If yes, please describe.
      placeholder: This PR introduces breaking changes in...

  - type: textarea
    id: related-issues
    attributes:
      label: Related Issues
      description: Link any related issues here
      placeholder: |
        Fixes #123
        Related to #456

  - type: textarea
    id: additional-notes
    attributes:
      label: Additional Notes
      description: Any additional information that reviewers should know
