### PR TITLE
Fix malformed endpoint mappings in WorkstationEndpoints.cs

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -517,7 +517,6 @@ public static class WorkstationEndpoints
             string? strategyId,
             int? limit,
             HttpContext context) =>
-        app.MapGet("/api/strategies/runs/compare", async (string? ids, HttpContext context) =>
         {
             var readService = context.RequestServices.GetService<StrategyRunReadService>();
             if (readService is null)
@@ -568,7 +567,14 @@ public static class WorkstationEndpoints
         .Produces<IReadOnlyList<StrategyRunTimelineEntry>>(200)
         .Produces(501);
 
-        // --- Portfolio cash-flow projections ---
+        app.MapGet("/api/strategies/runs/compare", async (string? ids, HttpContext context) =>
+        {
+            var readService = context.RequestServices.GetService<StrategyRunReadService>();
+            if (readService is null)
+            {
+                return Results.Problem("Strategy run service is not registered.", statusCode: StatusCodes.Status501NotImplemented);
+            }
+
             if (string.IsNullOrWhiteSpace(ids))
             {
                 return Results.BadRequest(new { error = "At least two run IDs are required. Use ?ids=a,b" });
@@ -591,6 +597,8 @@ public static class WorkstationEndpoints
         .Produces<IReadOnlyList<RunComparisonDto>>(200)
         .Produces(400)
         .Produces(501);
+
+        // --- Portfolio cash-flow projections ---
 
 
         var portfolioGroup = app.MapGroup("/api/portfolio").WithTags("Portfolio");


### PR DESCRIPTION
### Motivation
- A missing lambda body brace caused the `group.MapGet("/runs/history", ...)` handler to flow into the next route declaration, producing many C# parse/CS errors and preventing the project from compiling.
- The strategy-run compare handler was inadvertently embedded in the history mapping, so it needed to be a standalone route to restore correct routing and validation behavior.
- The portfolio cash-flow mappings needed their comment/section repositioned so endpoint declarations remain well-formed and readable.

### Description
- Restored the missing lambda body block for `group.MapGet("/runs/history", ...)` so the history handler compiles and returns JSON as intended in `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs`.
- Recreated `app.MapGet("/api/strategies/runs/compare", ...)` as a separate endpoint block with its original validation and response flow, keeping it distinct from the workstation `history` route.
- Re-positioned the `// --- Portfolio cash-flow projections ---` comment after the compare mapping to keep endpoint groups separated and maintain code clarity.

### Testing
- Attempted to run `dotnet build src/Meridian.Ui.Shared/Meridian.Ui.Shared.csproj -v minimal`, but the `dotnet` tool is not available in this environment so the build could not be executed (failed: `/bin/bash: dotnet: command not found`).
- No automated test run completed due to the missing `dotnet` runtime in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd848293888320b6fc442e30eff8bd)