### PR TITLE
Fix CS1003 syntax error in WorkstationEndpoints reconciliation payload

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -1404,7 +1404,7 @@ public static class WorkstationEndpoints
                     LastUpdatedAt: DateTimeOffset.UtcNow.AddMinutes(-8),
                     ReviewedBy: "ops.gov",
                     ReviewedAt: DateTimeOffset.UtcNow.AddMinutes(-8),
-                    ResolutionNote: "Investigating ticker reclassification."))
+                    ResolutionNote: "Investigating ticker reclassification.")
             },
             workspace = new
             {


### PR DESCRIPTION
### Motivation
- Resolve the compile-time `CS1003` error reported at `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs:1407` caused by an extra closing parenthesis in the reconciliation payload initializer.

### Description
- Remove the extraneous `)` from the second `ReconciliationBreakQueueItem` initializer in `BuildGovernancePayload` so the object initializer closes correctly in `WorkstationEndpoints.cs`.

### Testing
- Attempted to run `dotnet build src/Meridian.Ui.Shared/Meridian.Ui.Shared.csproj` but `dotnet` is not available in this environment, so automated build verification could not be executed; the fix was committed to the branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd872c206c832088618b0271315053)