### PR TITLE
Fix test compilation failures in workstation, monitoring, and risk tests

### DIFF
--- a/tests/Meridian.Tests/Application/Monitoring/AlertDispatcherTests.cs
+++ b/tests/Meridian.Tests/Application/Monitoring/AlertDispatcherTests.cs
@@ -262,7 +262,7 @@ public sealed class AlertDispatcherTests : IDisposable
 
             // The internal queue trims to maxRecentAlerts
             var alerts = sut.GetRecentAlerts(count: 100);
-            alerts.Should().HaveCountLessOrEqualTo(3);
+            alerts.Should().HaveCount(3);
         }
     }
 

--- a/tests/Meridian.Tests/Risk/PositionLimitRuleTests.cs
+++ b/tests/Meridian.Tests/Risk/PositionLimitRuleTests.cs
@@ -83,7 +83,7 @@ public sealed class PositionLimitRuleTests
     [Fact]
     public async Task EvaluateAsync_BuyFromFlatPosition_WithinLimit_ReturnsApproved()
     {
-        var tracker = TrackerWithPosition(DefaultSymbol, currentQuantity: 0m);
+        var tracker = TrackerWithPosition(DefaultSymbol, quantity: 0m);
         var sut = CreateSut(tracker, maxPositionSize: 100m);
 
         var result = await sut.EvaluateAsync(CreateBuyOrder(quantity: 50m));
@@ -94,7 +94,7 @@ public sealed class PositionLimitRuleTests
     [Fact]
     public async Task EvaluateAsync_BuyFromFlatPosition_ExceedsLimit_ReturnsRejected()
     {
-        var tracker = TrackerWithPosition(DefaultSymbol, currentQuantity: 0m);
+        var tracker = TrackerWithPosition(DefaultSymbol, quantity: 0m);
         var sut = CreateSut(tracker, maxPositionSize: 100m);
 
         var result = await sut.EvaluateAsync(CreateBuyOrder(quantity: 150m));
@@ -107,7 +107,7 @@ public sealed class PositionLimitRuleTests
     public async Task EvaluateAsync_BuyFromExistingPosition_ProjectedWithinLimit_ReturnsApproved()
     {
         // Current: 60 long, Buy 30 → projected 90, limit 100 → approve
-        var tracker = TrackerWithPosition(DefaultSymbol, currentQuantity: 60m);
+        var tracker = TrackerWithPosition(DefaultSymbol, quantity: 60m);
         var sut = CreateSut(tracker, maxPositionSize: 100m);
 
         var result = await sut.EvaluateAsync(CreateBuyOrder(quantity: 30m));
@@ -119,7 +119,7 @@ public sealed class PositionLimitRuleTests
     public async Task EvaluateAsync_BuyFromExistingPosition_ProjectedExceedsLimit_ReturnsRejected()
     {
         // Current: 80 long, Buy 30 → projected 110, limit 100 → reject
-        var tracker = TrackerWithPosition(DefaultSymbol, currentQuantity: 80m);
+        var tracker = TrackerWithPosition(DefaultSymbol, quantity: 80m);
         var sut = CreateSut(tracker, maxPositionSize: 100m);
 
         var result = await sut.EvaluateAsync(CreateBuyOrder(quantity: 30m));
@@ -131,7 +131,7 @@ public sealed class PositionLimitRuleTests
     public async Task EvaluateAsync_SellFromLongPosition_ProjectedWithinLimit_ReturnsApproved()
     {
         // Current: 80 long, Sell 60 → projected +20, abs(20) = 20 < 100 → approve
-        var tracker = TrackerWithPosition(DefaultSymbol, currentQuantity: 80m);
+        var tracker = TrackerWithPosition(DefaultSymbol, quantity: 80m);
         var sut = CreateSut(tracker, maxPositionSize: 100m);
 
         var result = await sut.EvaluateAsync(CreateSellOrder(quantity: 60m));
@@ -143,7 +143,7 @@ public sealed class PositionLimitRuleTests
     public async Task EvaluateAsync_SellFlipsToShortBeyondLimit_ReturnsRejected()
     {
         // Current: 50 long, Sell 200 → projected -150, abs(-150) = 150 > 100 → reject
-        var tracker = TrackerWithPosition(DefaultSymbol, currentQuantity: 50m);
+        var tracker = TrackerWithPosition(DefaultSymbol, quantity: 50m);
         var sut = CreateSut(tracker, maxPositionSize: 100m);
 
         var result = await sut.EvaluateAsync(CreateSellOrder(quantity: 200m));
@@ -155,7 +155,7 @@ public sealed class PositionLimitRuleTests
     public async Task EvaluateAsync_SellFlipsToShortWithinLimit_ReturnsApproved()
     {
         // Current: 50 long, Sell 120 → projected -70, abs(-70) = 70 < 100 → approve
-        var tracker = TrackerWithPosition(DefaultSymbol, currentQuantity: 50m);
+        var tracker = TrackerWithPosition(DefaultSymbol, quantity: 50m);
         var sut = CreateSut(tracker, maxPositionSize: 100m);
 
         var result = await sut.EvaluateAsync(CreateSellOrder(quantity: 120m));
@@ -167,7 +167,7 @@ public sealed class PositionLimitRuleTests
     public async Task EvaluateAsync_BuyExactlyAtLimit_ReturnsApproved()
     {
         // Exactly at limit: projected == maxPositionSize → abs(100) == 100, NOT > 100 → approve
-        var tracker = TrackerWithPosition(DefaultSymbol, currentQuantity: 0m);
+        var tracker = TrackerWithPosition(DefaultSymbol, quantity: 0m);
         var sut = CreateSut(tracker, maxPositionSize: 100m);
 
         var result = await sut.EvaluateAsync(CreateBuyOrder(quantity: 100m));
@@ -195,7 +195,7 @@ public sealed class PositionLimitRuleTests
     [Fact]
     public async Task EvaluateAsync_RejectedResult_ContainsSymbolInReason()
     {
-        var tracker = TrackerWithPosition(DefaultSymbol, currentQuantity: 0m);
+        var tracker = TrackerWithPosition(DefaultSymbol, quantity: 0m);
         var sut = CreateSut(tracker, maxPositionSize: 50m);
 
         var result = await sut.EvaluateAsync(CreateBuyOrder(quantity: 200m));

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -83,7 +83,7 @@ public sealed class WorkstationEndpointsTests
         comparisons.GetArrayLength().Should().BeGreaterThan(0);
         comparisons[0].GetProperty("modes").EnumerateArray()
             .Should()
-            .Contain(mode => mode.GetProperty("drillIn").GetProperty("attribution").GetString() is not null);
+            .Contain(mode => mode.GetProperty("drillIn").GetProperty("attribution").GetString() != null);
         research.RootElement.GetProperty("timeline").GetArrayLength().Should().Be(2);
 
         research.RootElement.GetProperty("metrics").EnumerateArray()


### PR DESCRIPTION
### Motivation
- Restore compilation for the test suite by addressing three separate compile-time errors reported by the test project.
- Remove C# patterns and API usages that are incompatible with expression trees or the available FluentAssertions surface used in tests.
- Align test callsites to the real helper method signature to avoid named-argument mismatch errors.

### Description
- Replaced the pattern-match `is not null` inside a `Contain(...)` predicate with a null comparison (`!= null`) to avoid the expression-tree error in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs`.
- Replaced the unsupported FluentAssertions call `HaveCountLessOrEqualTo` with the exact count assertion `HaveCount(3)` in `tests/Meridian.Tests/Application/Monitoring/AlertDispatcherTests.cs` to reflect the queue trimming expectation.
- Updated calls to `TrackerWithPosition` in `tests/Meridian.Tests/Risk/PositionLimitRuleTests.cs` to use the correct parameter name (`quantity`) to match the helper method signature.

### Testing
- Attempted to run the unit tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --no-restore`, which failed because the environment lacks the .NET SDK (`dotnet: command not found`).
- No automated test runs completed in this environment due to the missing `dotnet` toolchain; changes are limited to test code and intended to enable successful compilation when run in a .NET-equipped CI or developer machine.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd88ecebe48320a66b029b3d6b2a57)