### PR TITLE
Fix workstation endpoint tests to use string enum JSON

### DIFF
--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using FluentAssertions;
 using Meridian.Application.SecurityMaster;
 using Meridian.Application.UI;
@@ -742,7 +743,8 @@ public sealed class WorkstationEndpointsTests
         var app = builder.Build();
         app.MapWorkstationEndpoints(new JsonSerializerOptions
         {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { new JsonStringEnumConverter() }
         });
 
         await app.StartAsync();


### PR DESCRIPTION
### Motivation
- Some workstation endpoint tests expect enum values to be serialized/deserialized as strings (e.g. `"Backtest"` and request modes like `"paper"`), but the test host used the default numeric enum representation which caused failures.

### Description
- Modified `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` to add `using System.Text.Json.Serialization;` and to register a `JsonStringEnumConverter` in the `JsonSerializerOptions` passed to `app.MapWorkstationEndpoints(...)` inside `CreateAppAsync`, ensuring enums are emitted and parsed as strings.

### Testing
- Attempted to run the workstation test subset with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --configuration Release --filter "FullyQualifiedName~WorkstationEndpointsTests"`, but the command could not run in this environment because `dotnet` is not available so no automated tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd8b75860c8320b08c8ccdab916326)