### PR TITLE
feat(screenshots): capture all workstation deep-link sub-pages

### DIFF
--- a/.github/workflows/refresh-screenshots.yml
+++ b/.github/workflows/refresh-screenshots.yml
@@ -288,6 +288,80 @@ jobs:
             })
           );
 
+          // Workstation deep-link sub-pages
+          // Screenshot 14: Trading – Orders blotter
+          await withRetry('workstation-trading-orders', () =>
+            shot('docs/screenshots/14-workstation-trading-orders.png', `${BASE}/workstation/trading/orders`, {
+              fullPage: true,
+              stableSelector: 'main, body',
+              waitMs: 500
+            })
+          );
+          // Screenshot 15: Trading – Positions
+          await withRetry('workstation-trading-positions', () =>
+            shot('docs/screenshots/15-workstation-trading-positions.png', `${BASE}/workstation/trading/positions`, {
+              fullPage: true,
+              stableSelector: 'main, body',
+              waitMs: 500
+            })
+          );
+          // Screenshot 16: Trading – Risk guardrails
+          await withRetry('workstation-trading-risk', () =>
+            shot('docs/screenshots/16-workstation-trading-risk.png', `${BASE}/workstation/trading/risk`, {
+              fullPage: true,
+              stableSelector: 'main, body',
+              waitMs: 500
+            })
+          );
+          // Screenshot 17: Data Operations – Provider health
+          await withRetry('workstation-data-operations-providers', () =>
+            shot('docs/screenshots/17-workstation-data-operations-providers.png', `${BASE}/workstation/data-operations/providers`, {
+              fullPage: true,
+              stableSelector: 'main, body',
+              waitMs: 500
+            })
+          );
+          // Screenshot 18: Data Operations – Backfill queue
+          await withRetry('workstation-data-operations-backfills', () =>
+            shot('docs/screenshots/18-workstation-data-operations-backfills.png', `${BASE}/workstation/data-operations/backfills`, {
+              fullPage: true,
+              stableSelector: 'main, body',
+              waitMs: 500
+            })
+          );
+          // Screenshot 19: Data Operations – Storage exports
+          await withRetry('workstation-data-operations-exports', () =>
+            shot('docs/screenshots/19-workstation-data-operations-exports.png', `${BASE}/workstation/data-operations/exports`, {
+              fullPage: true,
+              stableSelector: 'main, body',
+              waitMs: 500
+            })
+          );
+          // Screenshot 20: Governance – Ledger overview
+          await withRetry('workstation-governance-ledger', () =>
+            shot('docs/screenshots/20-workstation-governance-ledger.png', `${BASE}/workstation/governance/ledger`, {
+              fullPage: true,
+              stableSelector: 'main, body',
+              waitMs: 500
+            })
+          );
+          // Screenshot 21: Governance – Reconciliation history
+          await withRetry('workstation-governance-reconciliation', () =>
+            shot('docs/screenshots/21-workstation-governance-reconciliation.png', `${BASE}/workstation/governance/reconciliation`, {
+              fullPage: true,
+              stableSelector: 'main, body',
+              waitMs: 500
+            })
+          );
+          // Screenshot 22: Governance – Security master coverage
+          await withRetry('workstation-governance-security-master', () =>
+            shot('docs/screenshots/22-workstation-governance-security-master.png', `${BASE}/workstation/governance/security-master`, {
+              fullPage: true,
+              stableSelector: 'main, body',
+              waitMs: 500
+            })
+          );
+
           await browser.close();
           SCRIPT
 
@@ -338,4 +412,13 @@ jobs:
             echo "| Workstation – Trading | \`docs/screenshots/11-workstation-trading.png\` |"
             echo "| Workstation – Data Operations | \`docs/screenshots/12-workstation-data-operations.png\` |"
             echo "| Workstation – Governance | \`docs/screenshots/13-workstation-governance.png\` |"
+            echo "| Workstation – Trading: Orders | \`docs/screenshots/14-workstation-trading-orders.png\` |"
+            echo "| Workstation – Trading: Positions | \`docs/screenshots/15-workstation-trading-positions.png\` |"
+            echo "| Workstation – Trading: Risk | \`docs/screenshots/16-workstation-trading-risk.png\` |"
+            echo "| Workstation – Data Operations: Providers | \`docs/screenshots/17-workstation-data-operations-providers.png\` |"
+            echo "| Workstation – Data Operations: Backfills | \`docs/screenshots/18-workstation-data-operations-backfills.png\` |"
+            echo "| Workstation – Data Operations: Exports | \`docs/screenshots/19-workstation-data-operations-exports.png\` |"
+            echo "| Workstation – Governance: Ledger | \`docs/screenshots/20-workstation-governance-ledger.png\` |"
+            echo "| Workstation – Governance: Reconciliation | \`docs/screenshots/21-workstation-governance-reconciliation.png\` |"
+            echo "| Workstation – Governance: Security Master | \`docs/screenshots/22-workstation-governance-security-master.png\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -114,3 +114,75 @@ The **Data Operations** workspace of the React workstation shell, covering provi
 The **Governance** workspace of the React workstation shell, showing the fund ledger overview, risk audit history, reconciliation breaks, diagnostics, and operational settings.
 
 ![Workstation – Governance](13-workstation-governance.png)
+
+---
+
+## 14 – Workstation: Trading – Orders
+
+The **Orders blotter** deep-link within the Trading workspace, showing working and partially filled trading orders with status, fill quantity, and execution detail.
+
+![Workstation – Trading: Orders](14-workstation-trading-orders.png)
+
+---
+
+## 15 – Workstation: Trading – Positions
+
+The **Positions** deep-link within the Trading workspace, showing live positions, exposure, marks, and unrealized P&L.
+
+![Workstation – Trading: Positions](15-workstation-trading-positions.png)
+
+---
+
+## 16 – Workstation: Trading – Risk
+
+The **Risk guardrails** deep-link within the Trading workspace, showing the trading risk cockpit, position limits, drawdown stops, and order-rate throttle state.
+
+![Workstation – Trading: Risk](16-workstation-trading-risk.png)
+
+---
+
+## 17 – Workstation: Data Operations – Providers
+
+The **Provider health** deep-link within the Data Operations workspace, showing feed status, latency metrics, and operational notes for each registered provider.
+
+![Workstation – Data Operations: Providers](17-workstation-data-operations-providers.png)
+
+---
+
+## 18 – Workstation: Data Operations – Backfills
+
+The **Backfill queue** deep-link within the Data Operations workspace, showing active backfill jobs, progress, and review items.
+
+![Workstation – Data Operations: Backfills](18-workstation-data-operations-backfills.png)
+
+---
+
+## 19 – Workstation: Data Operations – Exports
+
+The **Storage exports** deep-link within the Data Operations workspace, showing export profiles and recent delivery targets.
+
+![Workstation – Data Operations: Exports](19-workstation-data-operations-exports.png)
+
+---
+
+## 20 – Workstation: Governance – Ledger
+
+The **Ledger overview** deep-link within the Governance workspace, showing cash flow summaries and audit-facing ledger details.
+
+![Workstation – Governance: Ledger](20-workstation-governance-ledger.png)
+
+---
+
+## 21 – Workstation: Governance – Reconciliation
+
+The **Reconciliation history** deep-link within the Governance workspace, showing open breaks, balanced runs, and reconciliation detail.
+
+![Workstation – Governance: Reconciliation](21-workstation-governance-reconciliation.png)
+
+---
+
+## 22 – Workstation: Governance – Security Master
+
+The **Security master coverage** deep-link within the Governance workspace, showing unresolved references and coverage risk across the instrument universe.
+
+![Workstation – Governance: Security Master](22-workstation-governance-security-master.png)


### PR DESCRIPTION
Adds 9 new screenshots (14–22) to the refresh-screenshots workflow,
covering every named route in the React workstation shell:

Trading workspace: orders blotter (14), positions (15), risk (16)
Data Operations workspace: providers (17), backfills (18), exports (19)
Governance workspace: ledger (20), reconciliation (21), security master (22)

Updates docs/screenshots/README.md with descriptions for all new pages.

https://claude.ai/code/session_01FnbYNFcVTrWnhRjPMcrH2C