### PR TITLE
fix: add missing using directive for CollectionSessionViewModel

### DIFF
--- a/src/Meridian.Wpf/Views/CollectionSessionPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/CollectionSessionPage.xaml.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using Meridian.Wpf.Services;
+using Meridian.Wpf.ViewModels;
 
 namespace Meridian.Wpf.Views;
 


### PR DESCRIPTION
CollectionSessionPage.xaml.cs referenced CollectionSessionViewModel
without importing the Meridian.Wpf.ViewModels namespace, causing CS0246.

https://claude.ai/code/session_014KBWtkQzBet4LgqtkCxtD5