### PR TITLE
Fix 14 WPF build errors in Meridian.Wpf

### DIFF
--- a/src/Meridian.Wpf/ViewModels/ChartingPageViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/ChartingPageViewModel.cs
@@ -202,7 +202,8 @@ public sealed class ChartingPageViewModel : BindableBase
         if (_chartData == null || _chartData.Candles.Count == 0) return;
 
         var financialPoints = _chartData.Candles
-            .Select(c => new FinancialPoint(c.Timestamp, (double)c.High, (double)c.Open, (double)c.Close, (double)c.Low));
+            .Select(c => new FinancialPoint(c.Timestamp, (double)c.High, (double)c.Open, (double)c.Close, (double)c.Low))
+            .ToList();
 
         CandleSeries =
         [

--- a/src/Meridian.Wpf/ViewModels/QuantScriptViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/QuantScriptViewModel.cs
@@ -336,7 +336,7 @@ public sealed class QuantScriptViewModel : BindableBase, IDisposable
 
         if (result.Metrics.Count > 0 && result.Plots.Count == 0)
             ActiveResultsTab = 1; // Data Sheet
-        else if (result.Trades.Count > 0 && result.Plots.Count == 0)
+        else if (result.TradesSummary.Count > 0 && result.Plots.Count == 0)
             ActiveResultsTab = 4; // Backtest Output
 
         Diagnostics.Add(new DiagnosticEntry("Wall clock", $"{result.Elapsed.TotalSeconds:F2}s"));

--- a/src/Meridian.Wpf/ViewModels/RunRiskViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/RunRiskViewModel.cs
@@ -4,6 +4,7 @@ using Meridian.Contracts.Workstation;
 using Meridian.Strategies.Services;
 using Meridian.QuantScript.Plotting;
 using Meridian.Wpf.Services;
+using CurvePt = Meridian.Contracts.Workstation.EquityCurvePoint;
 
 namespace Meridian.Wpf.ViewModels;
 
@@ -272,7 +273,7 @@ public sealed class RunRiskViewModel : BindableBase
     /// Builds a <see cref="PlotRequest"/> showing the 21-day rolling annualised volatility
     /// derived from the equity curve's daily returns.
     /// </summary>
-    private static PlotRequest BuildVolatilityPlot(IReadOnlyList<EquityCurvePoint> points, int window = 21)
+    private static PlotRequest BuildVolatilityPlot(IReadOnlyList<CurvePt> points, int window = 21)
     {
         var series = new List<(DateOnly Date, double Value)>(points.Count);
 
@@ -289,7 +290,7 @@ public sealed class RunRiskViewModel : BindableBase
             Series: series);
     }
 
-    private static double ComputeRollingWindow(IReadOnlyList<EquityCurvePoint> points, int endIndex, int window)
+    private static double ComputeRollingWindow(IReadOnlyList<CurvePt> points, int endIndex, int window)
     {
         var start = endIndex - window + 1;
         var sum = 0.0;
@@ -316,7 +317,7 @@ public sealed class RunRiskViewModel : BindableBase
     /// Computes the full-period annualised volatility from all daily return observations
     /// using a single-pass algorithm to avoid double-iteration and intermediate allocations.
     /// </summary>
-    private static double ComputeAnnualisedVolatility(IReadOnlyList<EquityCurvePoint> points)
+    private static double ComputeAnnualisedVolatility(IReadOnlyList<CurvePt> points)
     {
         if (points.Count < 2)
             return double.NaN;

--- a/src/Meridian.Wpf/Views/AggregatePortfolioPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/AggregatePortfolioPage.xaml.cs
@@ -1,6 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
-using Meridian.Ui.Services.Services;
+using Meridian.Ui.Services;
 using Meridian.Wpf.ViewModels;
 
 namespace Meridian.Wpf.Views;

--- a/src/Meridian.Wpf/Views/DataExportPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/DataExportPage.xaml.cs
@@ -82,6 +82,14 @@ public partial class DataExportPage : Page
         _viewModel.SelectedLeanResolution = GetComboTag(LeanResolutionCombo) ?? "minute";
     }
 
+    // ── Scheduled exports toggle ──────────────────────────────────────────
+
+    private void EnableScheduledExportsToggle_Changed(object sender, RoutedEventArgs e)
+    {
+        if (sender is CheckBox cb)
+            _viewModel.IsScheduleEnabled = cb.IsChecked == true;
+    }
+
     // ── Database PasswordBox (non-bindable) ───────────────────────────────
 
     private void SetDatabaseCredentials_Click(object sender, RoutedEventArgs e)

--- a/src/Meridian.Wpf/Views/DataSourcesPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/DataSourcesPage.xaml.cs
@@ -98,6 +98,21 @@ public partial class DataSourcesPage : Page
             PolygonApiKeyBox.Password = _viewModel.PolygonApiKey;
     }
 
+    // ── Row-level Edit / Delete buttons ──────────────────────────────────
+    // Buttons in DataTemplates carry the source ID in their Tag property.
+
+    private void EditDataSource_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is System.Windows.Controls.Button { Tag: string id })
+            _viewModel.EditSourceCommand.Execute(id);
+    }
+
+    private async void DeleteDataSource_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is System.Windows.Controls.Button { Tag: string id })
+            await _viewModel.DeleteSourceCommand.ExecuteAsync(id);
+    }
+
     // ── Source enabled toggle (row-level; DataTemplate cannot bind commands
     //    from a parent context reliably without x:Name trickery) ──────────
 

--- a/src/Meridian.Wpf/Views/PositionBlotterPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/PositionBlotterPage.xaml.cs
@@ -15,7 +15,7 @@ public partial class PositionBlotterPage : Page
         InitializeComponent();
         _viewModel = new PositionBlotterViewModel(
             ApiClientService.Instance,
-            NavigationService.Instance);
+            Services.NavigationService.Instance);
         DataContext = _viewModel;
     }
 


### PR DESCRIPTION
- RunRiskViewModel: add CurvePt alias to resolve EquityCurvePoint ambiguity
  between Meridian.Contracts.Workstation and local Meridian.Wpf.ViewModels type
- QuantScriptViewModel: rename result.Trades -> result.TradesSummary to match
  ScriptRunResult record definition
- ChartingPageViewModel: add .ToList() so IEnumerable<FinancialPoint> satisfies
  IReadOnlyCollection<FinancialPoint> expected by CandlesticksSeries.Values
- AggregatePortfolioPage: fix using directive (Meridian.Ui.Services.Services ->
  Meridian.Ui.Services) so ApiClientService resolves
- PositionBlotterPage: qualify NavigationService as Services.NavigationService
  to avoid shadowing by the inherited WPF Page.NavigationService property
- DataSourcesPage: add EditDataSource_Click and DeleteDataSource_Click handlers
  referenced from DataSourcesPage.xaml button elements
- DataExportPage: add EnableScheduledExportsToggle_Changed handler referenced
  from DataExportPage.xaml CheckBox Checked/Unchecked events

https://claude.ai/code/session_01N46gQtC1WLTTrbTztr2NKB