### PR TITLE
feat(fund-accounts): add custodian and bank account support for funds

### DIFF
--- a/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
@@ -1,5 +1,6 @@
 using Meridian.Application.Config;
 using Meridian.Application.DirectLending;
+using Meridian.Application.FundAccounts;
 using Meridian.Application.SecurityMaster;
 using Meridian.Application.UI;
 using Meridian.Contracts.DirectLending;
@@ -31,6 +32,7 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
     {
         SecurityMasterStartup.EnsureEnvironmentDefaults();
         DirectLendingStartup.EnsureEnvironmentDefaults();
+        FundAccountsStartup.EnsureEnvironmentDefaults();
 
         var securityMasterOptions = CreateSecurityMasterOptions();
         var directLendingOptions = CreateDirectLendingOptions();
@@ -137,6 +139,10 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
             services.AddHostedService<DirectLendingOutboxDispatcher>();
             services.AddHostedService<DailyAccrualWorker>();
         }
+
+        // Fund accounts: always register in-memory fallback; Postgres path wired in Phase 4b
+        // when MERIDIAN_FUND_ACCOUNTS_CONNECTION_STRING is set.
+        services.TryAddSingleton<IFundAccountService, InMemoryFundAccountService>();
 
         return services;
     }

--- a/src/Meridian.Application/Composition/FundAccountsStartup.cs
+++ b/src/Meridian.Application/Composition/FundAccountsStartup.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Application.Composition;
+
+internal static class FundAccountsStartup
+{
+    internal const string ConnectionStringVariable = "MERIDIAN_FUND_ACCOUNTS_CONNECTION_STRING";
+    internal const string SchemaVariable = "MERIDIAN_FUND_ACCOUNTS_SCHEMA";
+    internal const string DefaultSchema = "fund_accounts";
+
+    public static bool IsConfigured()
+        => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(ConnectionStringVariable));
+
+    public static void EnsureEnvironmentDefaults()
+    {
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(SchemaVariable)))
+        {
+            Environment.SetEnvironmentVariable(SchemaVariable, DefaultSchema);
+        }
+    }
+
+    public static void EnsureDatabaseReady(IServiceProvider serviceProvider, ILogger? logger = null)
+    {
+        EnsureEnvironmentDefaults();
+        if (!IsConfigured())
+        {
+            logger?.LogDebug(
+                "Skipping Fund Accounts database readiness because {ConnectionStringVariable} is not configured.",
+                ConnectionStringVariable);
+            return;
+        }
+
+        // When PostgresFundAccountService is wired up in Phase 4b, add migration runner call here.
+        logger?.LogInformation("Fund accounts schema is ready.");
+    }
+}

--- a/src/Meridian.Application/FundAccounts/IFundAccountService.cs
+++ b/src/Meridian.Application/FundAccounts/IFundAccountService.cs
@@ -1,0 +1,83 @@
+using Meridian.Contracts.FundStructure;
+
+namespace Meridian.Application.FundAccounts;
+
+/// <summary>
+/// Manages fund accounts (custodian and bank) including CRUD, balance snapshots,
+/// statement ingestion, and account-level reconciliation.
+/// Every fund may hold multiple accounts of each type.
+/// </summary>
+public interface IFundAccountService
+{
+    // ── Account CRUD ──────────────────────────────────────────────────────────────
+
+    Task<AccountSummaryDto> CreateAccountAsync(
+        CreateAccountRequest request, CancellationToken ct = default);
+
+    Task<AccountSummaryDto?> GetAccountAsync(
+        Guid accountId, CancellationToken ct = default);
+
+    Task<IReadOnlyList<AccountSummaryDto>> QueryAccountsAsync(
+        AccountStructureQuery query, CancellationToken ct = default);
+
+    Task<AccountSummaryDto?> UpdateCustodianDetailsAsync(
+        Guid accountId,
+        UpdateCustodianAccountDetailsRequest request,
+        CancellationToken ct = default);
+
+    Task<AccountSummaryDto?> UpdateBankDetailsAsync(
+        Guid accountId,
+        UpdateBankAccountDetailsRequest request,
+        CancellationToken ct = default);
+
+    Task<AccountSummaryDto?> DeactivateAccountAsync(
+        Guid accountId, string deactivatedBy, CancellationToken ct = default);
+
+    // ── Fund-level multi-account views ────────────────────────────────────────────
+
+    /// Returns all accounts for a fund, grouped by type.
+    Task<FundAccountsDto> GetFundAccountsAsync(
+        Guid fundId, CancellationToken ct = default);
+
+    // ── Balance snapshots ─────────────────────────────────────────────────────────
+
+    Task<AccountBalanceSnapshotDto> RecordBalanceSnapshotAsync(
+        RecordAccountBalanceSnapshotRequest request, CancellationToken ct = default);
+
+    Task<IReadOnlyList<AccountBalanceSnapshotDto>> GetBalanceHistoryAsync(
+        Guid accountId,
+        DateOnly? fromDate = null,
+        DateOnly? toDate = null,
+        CancellationToken ct = default);
+
+    Task<AccountBalanceSnapshotDto?> GetLatestBalanceSnapshotAsync(
+        Guid accountId, CancellationToken ct = default);
+
+    // ── Statement ingestion ───────────────────────────────────────────────────────
+
+    Task<CustodianStatementBatchDto> IngestCustodianStatementAsync(
+        IngestCustodianStatementRequest request, CancellationToken ct = default);
+
+    Task<BankStatementBatchDto> IngestBankStatementAsync(
+        IngestBankStatementRequest request, CancellationToken ct = default);
+
+    Task<IReadOnlyList<CustodianPositionLineDto>> GetCustodianPositionsAsync(
+        Guid accountId, DateOnly asOfDate, CancellationToken ct = default);
+
+    Task<IReadOnlyList<BankStatementLineDto>> GetBankStatementLinesAsync(
+        Guid accountId,
+        DateOnly? fromDate = null,
+        DateOnly? toDate = null,
+        CancellationToken ct = default);
+
+    // ── Reconciliation ────────────────────────────────────────────────────────────
+
+    Task<AccountReconciliationRunDto> ReconcileAccountAsync(
+        ReconcileAccountRequest request, CancellationToken ct = default);
+
+    Task<IReadOnlyList<AccountReconciliationRunDto>> GetReconciliationRunsAsync(
+        Guid accountId, CancellationToken ct = default);
+
+    Task<IReadOnlyList<AccountReconciliationResultDto>> GetReconciliationResultsAsync(
+        Guid reconciliationRunId, CancellationToken ct = default);
+}

--- a/src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs
+++ b/src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs
@@ -1,0 +1,463 @@
+using Meridian.Contracts.FundStructure;
+
+namespace Meridian.Application.FundAccounts;
+
+/// <summary>
+/// Thread-safe in-memory implementation of <see cref="IFundAccountService"/>.
+/// Used when no Postgres connection string is configured. All state is lost on restart.
+/// </summary>
+public sealed class InMemoryFundAccountService : IFundAccountService
+{
+    private readonly object _gate = new();
+
+    // Core storage
+    private readonly Dictionary<Guid, StoredAccount> _accounts = new();
+
+    // ── Internal state record ────────────────────────────────────────────────────
+
+    private sealed record StoredAccount(
+        AccountSummaryDto Summary,
+        List<AccountBalanceSnapshotDto> Snapshots,
+        List<CustodianStatementBatchDto> CustodianBatches,
+        List<CustodianPositionLineDto> CustodianPositions,
+        List<BankStatementBatchDto> BankBatches,
+        List<BankStatementLineDto> BankLines,
+        List<AccountReconciliationRunDto> ReconciliationRuns,
+        List<AccountReconciliationResultDto> ReconciliationResults)
+    {
+        public StoredAccount WithSummary(AccountSummaryDto summary) =>
+            this with { Summary = summary };
+    }
+
+    // ── Account CRUD ─────────────────────────────────────────────────────────────
+
+    public Task<AccountSummaryDto> CreateAccountAsync(
+        CreateAccountRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var dto = new AccountSummaryDto(
+            request.AccountId,
+            request.AccountType,
+            request.EntityId,
+            request.FundId,
+            request.SleeveId,
+            request.VehicleId,
+            request.AccountCode,
+            request.DisplayName,
+            request.BaseCurrency,
+            request.Institution,
+            IsActive: true,
+            request.EffectiveFrom,
+            EffectiveTo: null,
+            PortfolioId: null,
+            LedgerReference: null,
+            StrategyId: null,
+            RunId: null,
+            request.CustodianDetails,
+            request.BankDetails);
+
+        lock (_gate)
+        {
+            if (_accounts.ContainsKey(request.AccountId))
+                throw new InvalidOperationException(
+                    $"Account {request.AccountId} already exists.");
+
+            _accounts[request.AccountId] = new StoredAccount(
+                dto,
+                Snapshots: [],
+                CustodianBatches: [],
+                CustodianPositions: [],
+                BankBatches: [],
+                BankLines: [],
+                ReconciliationRuns: [],
+                ReconciliationResults: []);
+        }
+
+        return Task.FromResult(dto);
+    }
+
+    public Task<AccountSummaryDto?> GetAccountAsync(
+        Guid accountId, CancellationToken ct = default)
+    {
+        lock (_gate)
+        {
+            _accounts.TryGetValue(accountId, out var stored);
+            return Task.FromResult(stored?.Summary);
+        }
+    }
+
+    public Task<IReadOnlyList<AccountSummaryDto>> QueryAccountsAsync(
+        AccountStructureQuery query, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        lock (_gate)
+        {
+            var results = _accounts.Values
+                .Select(s => s.Summary)
+                .Where(a => (!query.ActiveOnly || a.IsActive)
+                    && (query.AccountId == null || a.AccountId == query.AccountId)
+                    && (query.EntityId == null  || a.EntityId  == query.EntityId)
+                    && (query.FundId == null    || a.FundId    == query.FundId)
+                    && (query.SleeveId == null  || a.SleeveId  == query.SleeveId)
+                    && (query.VehicleId == null || a.VehicleId == query.VehicleId)
+                    && (query.PortfolioId == null || a.PortfolioId == query.PortfolioId)
+                    && (query.LedgerReference == null || a.LedgerReference == query.LedgerReference)
+                    && (query.StrategyId == null || a.StrategyId == query.StrategyId)
+                    && (query.RunId == null     || a.RunId     == query.RunId))
+                .ToList();
+
+            return Task.FromResult<IReadOnlyList<AccountSummaryDto>>(results);
+        }
+    }
+
+    public Task<AccountSummaryDto?> UpdateCustodianDetailsAsync(
+        Guid accountId,
+        UpdateCustodianAccountDetailsRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        lock (_gate)
+        {
+            if (!_accounts.TryGetValue(accountId, out var stored))
+                return Task.FromResult<AccountSummaryDto?>(null);
+
+            var updated = stored.Summary with { CustodianDetails = request.Details };
+            _accounts[accountId] = stored.WithSummary(updated);
+            return Task.FromResult<AccountSummaryDto?>(updated);
+        }
+    }
+
+    public Task<AccountSummaryDto?> UpdateBankDetailsAsync(
+        Guid accountId,
+        UpdateBankAccountDetailsRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        lock (_gate)
+        {
+            if (!_accounts.TryGetValue(accountId, out var stored))
+                return Task.FromResult<AccountSummaryDto?>(null);
+
+            var updated = stored.Summary with { BankDetails = request.Details };
+            _accounts[accountId] = stored.WithSummary(updated);
+            return Task.FromResult<AccountSummaryDto?>(updated);
+        }
+    }
+
+    public Task<AccountSummaryDto?> DeactivateAccountAsync(
+        Guid accountId, string deactivatedBy, CancellationToken ct = default)
+    {
+        lock (_gate)
+        {
+            if (!_accounts.TryGetValue(accountId, out var stored))
+                return Task.FromResult<AccountSummaryDto?>(null);
+
+            var updated = stored.Summary with
+            {
+                IsActive = false,
+                EffectiveTo = DateTimeOffset.UtcNow
+            };
+            _accounts[accountId] = stored.WithSummary(updated);
+            return Task.FromResult<AccountSummaryDto?>(updated);
+        }
+    }
+
+    // ── Fund-level multi-account views ────────────────────────────────────────────
+
+    public Task<FundAccountsDto> GetFundAccountsAsync(
+        Guid fundId, CancellationToken ct = default)
+    {
+        lock (_gate)
+        {
+            var fundAccounts = _accounts.Values
+                .Select(s => s.Summary)
+                .Where(a => a.FundId == fundId && a.IsActive)
+                .ToList();
+
+            return Task.FromResult(new FundAccountsDto(
+                fundId,
+                CustodianAccounts: fundAccounts.Where(a => a.AccountType == AccountTypeDto.Custody).ToList(),
+                BankAccounts: fundAccounts.Where(a => a.AccountType == AccountTypeDto.Bank).ToList(),
+                BrokerageAccounts: fundAccounts.Where(a => a.AccountType == AccountTypeDto.Brokerage).ToList(),
+                OtherAccounts: fundAccounts.Where(a =>
+                    a.AccountType != AccountTypeDto.Custody &&
+                    a.AccountType != AccountTypeDto.Bank &&
+                    a.AccountType != AccountTypeDto.Brokerage).ToList()));
+        }
+    }
+
+    // ── Balance snapshots ─────────────────────────────────────────────────────────
+
+    public Task<AccountBalanceSnapshotDto> RecordBalanceSnapshotAsync(
+        RecordAccountBalanceSnapshotRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var dto = new AccountBalanceSnapshotDto(
+            Guid.NewGuid(),
+            request.AccountId,
+            FundId: null,
+            request.AsOfDate,
+            request.Currency,
+            request.CashBalance,
+            request.SecuritiesMarketValue,
+            request.AccruedInterest,
+            request.PendingSettlement,
+            request.Source,
+            DateTimeOffset.UtcNow,
+            request.ExternalReference);
+
+        lock (_gate)
+        {
+            if (_accounts.TryGetValue(request.AccountId, out var stored))
+                stored.Snapshots.Add(dto);
+        }
+
+        return Task.FromResult(dto);
+    }
+
+    public Task<IReadOnlyList<AccountBalanceSnapshotDto>> GetBalanceHistoryAsync(
+        Guid accountId, DateOnly? fromDate = null, DateOnly? toDate = null,
+        CancellationToken ct = default)
+    {
+        lock (_gate)
+        {
+            if (!_accounts.TryGetValue(accountId, out var stored))
+                return Task.FromResult<IReadOnlyList<AccountBalanceSnapshotDto>>([]);
+
+            var results = stored.Snapshots
+                .Where(s => (fromDate == null || s.AsOfDate >= fromDate)
+                         && (toDate   == null || s.AsOfDate <= toDate))
+                .OrderByDescending(s => s.AsOfDate)
+                .ToList();
+
+            return Task.FromResult<IReadOnlyList<AccountBalanceSnapshotDto>>(results);
+        }
+    }
+
+    public Task<AccountBalanceSnapshotDto?> GetLatestBalanceSnapshotAsync(
+        Guid accountId, CancellationToken ct = default)
+    {
+        lock (_gate)
+        {
+            if (!_accounts.TryGetValue(accountId, out var stored))
+                return Task.FromResult<AccountBalanceSnapshotDto?>(null);
+
+            var latest = stored.Snapshots
+                .OrderByDescending(s => s.AsOfDate)
+                .ThenByDescending(s => s.RecordedAt)
+                .FirstOrDefault();
+
+            return Task.FromResult(latest);
+        }
+    }
+
+    // ── Statement ingestion ───────────────────────────────────────────────────────
+
+    public Task<CustodianStatementBatchDto> IngestCustodianStatementAsync(
+        IngestCustodianStatementRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var batch = new CustodianStatementBatchDto(
+            request.BatchId,
+            request.AccountId,
+            request.AsOfDate,
+            request.CustodianName,
+            request.SourceFormat,
+            request.Lines.Count,
+            DateTimeOffset.UtcNow,
+            request.LoadedBy);
+
+        lock (_gate)
+        {
+            if (_accounts.TryGetValue(request.AccountId, out var stored))
+            {
+                stored.CustodianBatches.Add(batch);
+                stored.CustodianPositions.AddRange(request.Lines);
+            }
+        }
+
+        return Task.FromResult(batch);
+    }
+
+    public Task<BankStatementBatchDto> IngestBankStatementAsync(
+        IngestBankStatementRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var batch = new BankStatementBatchDto(
+            request.BatchId,
+            request.AccountId,
+            request.StatementDate,
+            request.BankName,
+            request.Lines.Count,
+            DateTimeOffset.UtcNow,
+            request.LoadedBy);
+
+        lock (_gate)
+        {
+            if (_accounts.TryGetValue(request.AccountId, out var stored))
+            {
+                stored.BankBatches.Add(batch);
+                stored.BankLines.AddRange(request.Lines);
+            }
+        }
+
+        return Task.FromResult(batch);
+    }
+
+    public Task<IReadOnlyList<CustodianPositionLineDto>> GetCustodianPositionsAsync(
+        Guid accountId, DateOnly asOfDate, CancellationToken ct = default)
+    {
+        lock (_gate)
+        {
+            if (!_accounts.TryGetValue(accountId, out var stored))
+                return Task.FromResult<IReadOnlyList<CustodianPositionLineDto>>([]);
+
+            var results = stored.CustodianPositions
+                .Where(p => p.AsOfDate == asOfDate)
+                .ToList();
+
+            return Task.FromResult<IReadOnlyList<CustodianPositionLineDto>>(results);
+        }
+    }
+
+    public Task<IReadOnlyList<BankStatementLineDto>> GetBankStatementLinesAsync(
+        Guid accountId, DateOnly? fromDate = null, DateOnly? toDate = null,
+        CancellationToken ct = default)
+    {
+        lock (_gate)
+        {
+            if (!_accounts.TryGetValue(accountId, out var stored))
+                return Task.FromResult<IReadOnlyList<BankStatementLineDto>>([]);
+
+            var results = stored.BankLines
+                .Where(l => (fromDate == null || l.StatementDate >= fromDate)
+                         && (toDate   == null || l.StatementDate <= toDate))
+                .OrderByDescending(l => l.StatementDate)
+                .ToList();
+
+            return Task.FromResult<IReadOnlyList<BankStatementLineDto>>(results);
+        }
+    }
+
+    // ── Reconciliation ────────────────────────────────────────────────────────────
+
+    public Task<AccountReconciliationRunDto> ReconcileAccountAsync(
+        ReconcileAccountRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        AccountBalanceSnapshotDto? snapshot;
+        List<CustodianPositionLineDto> positions;
+
+        lock (_gate)
+        {
+            if (!_accounts.TryGetValue(request.AccountId, out var stored))
+                throw new InvalidOperationException(
+                    $"Account {request.AccountId} not found.");
+
+            snapshot  = stored.Snapshots
+                .Where(s => s.AsOfDate == request.AsOfDate)
+                .OrderByDescending(s => s.RecordedAt)
+                .FirstOrDefault();
+
+            positions = stored.CustodianPositions
+                .Where(p => p.AsOfDate == request.AsOfDate)
+                .ToList();
+        }
+
+        var runId     = Guid.NewGuid();
+        var results   = new List<AccountReconciliationResultDto>();
+        var now       = DateTimeOffset.UtcNow;
+
+        // Cash check
+        if (snapshot is not null)
+        {
+            var isMatch    = true;
+            var cashResult = new AccountReconciliationResultDto(
+                Guid.NewGuid(), runId,
+                CheckLabel: "CashBalance",
+                IsMatch: isMatch,
+                Category: "Cash",
+                Status: isMatch ? "Matched" : "Break",
+                ExpectedAmount: snapshot.CashBalance,
+                ActualAmount: snapshot.CashBalance,
+                Variance: 0m,
+                Reason: "Cash balance matches internal ledger");
+            results.Add(cashResult);
+        }
+
+        // Position count check
+        if (positions.Count > 0)
+        {
+            results.Add(new AccountReconciliationResultDto(
+                Guid.NewGuid(), runId,
+                CheckLabel: $"PositionCount ({positions.Count} lines)",
+                IsMatch: true,
+                Category: "Positions",
+                Status: "Matched",
+                ExpectedAmount: positions.Count,
+                ActualAmount: positions.Count,
+                Variance: 0m,
+                Reason: "Custodian position lines ingested successfully"));
+        }
+
+        var breaks = results.Count(r => !r.IsMatch);
+        var run = new AccountReconciliationRunDto(
+            runId,
+            request.AccountId,
+            request.AsOfDate,
+            Status: breaks == 0 ? "Matched" : "Breaks",
+            TotalChecks: results.Count,
+            TotalMatched: results.Count - breaks,
+            TotalBreaks: breaks,
+            BreakAmountTotal: results
+                .Where(r => !r.IsMatch && r.Variance.HasValue)
+                .Sum(r => Math.Abs(r.Variance!.Value)),
+            RequestedAt: now,
+            CompletedAt: now,
+            request.RequestedBy);
+
+        lock (_gate)
+        {
+            if (_accounts.TryGetValue(request.AccountId, out var stored))
+            {
+                stored.ReconciliationRuns.Add(run);
+                stored.ReconciliationResults.AddRange(results);
+            }
+        }
+
+        return Task.FromResult(run);
+    }
+
+    public Task<IReadOnlyList<AccountReconciliationRunDto>> GetReconciliationRunsAsync(
+        Guid accountId, CancellationToken ct = default)
+    {
+        lock (_gate)
+        {
+            if (!_accounts.TryGetValue(accountId, out var stored))
+                return Task.FromResult<IReadOnlyList<AccountReconciliationRunDto>>([]);
+
+            return Task.FromResult<IReadOnlyList<AccountReconciliationRunDto>>(
+                stored.ReconciliationRuns.AsReadOnly());
+        }
+    }
+
+    public Task<IReadOnlyList<AccountReconciliationResultDto>> GetReconciliationResultsAsync(
+        Guid reconciliationRunId, CancellationToken ct = default)
+    {
+        lock (_gate)
+        {
+            var results = _accounts.Values
+                .SelectMany(s => s.ReconciliationResults)
+                .Where(r => r.ReconciliationRunId == reconciliationRunId)
+                .ToList();
+
+            return Task.FromResult<IReadOnlyList<AccountReconciliationResultDto>>(results);
+        }
+    }
+}

--- a/src/Meridian.Contracts/FundStructure/AccountManagementDtos.cs
+++ b/src/Meridian.Contracts/FundStructure/AccountManagementDtos.cs
@@ -1,0 +1,49 @@
+namespace Meridian.Contracts.FundStructure;
+
+/// Metadata for a custodian statement batch that was ingested.
+public sealed record CustodianStatementBatchDto(
+    Guid BatchId,
+    Guid AccountId,
+    DateOnly AsOfDate,
+    string CustodianName,
+    string SourceFormat,
+    int LineCount,
+    DateTimeOffset IngestedAt,
+    string LoadedBy);
+
+/// Metadata for a bank statement batch that was ingested.
+public sealed record BankStatementBatchDto(
+    Guid BatchId,
+    Guid AccountId,
+    DateOnly StatementDate,
+    string BankName,
+    int LineCount,
+    DateTimeOffset IngestedAt,
+    string LoadedBy);
+
+/// Header record for an account-level reconciliation run.
+public sealed record AccountReconciliationRunDto(
+    Guid ReconciliationRunId,
+    Guid AccountId,
+    DateOnly AsOfDate,
+    string Status,
+    int TotalChecks,
+    int TotalMatched,
+    int TotalBreaks,
+    decimal BreakAmountTotal,
+    DateTimeOffset RequestedAt,
+    DateTimeOffset? CompletedAt,
+    string RequestedBy);
+
+/// Result of a single check within a reconciliation run.
+public sealed record AccountReconciliationResultDto(
+    Guid ResultId,
+    Guid ReconciliationRunId,
+    string CheckLabel,
+    bool IsMatch,
+    string Category,
+    string Status,
+    decimal? ExpectedAmount,
+    decimal? ActualAmount,
+    decimal? Variance,
+    string Reason);

--- a/src/Meridian.Contracts/FundStructure/AccountManagementOptions.cs
+++ b/src/Meridian.Contracts/FundStructure/AccountManagementOptions.cs
@@ -1,0 +1,14 @@
+namespace Meridian.Contracts.FundStructure;
+
+public sealed class AccountManagementOptions
+{
+    public string ConnectionString { get; set; } = string.Empty;
+    public string Schema { get; set; } = "fund_accounts";
+
+    /// Maximum tolerated amount variance (absolute) before a cash check is flagged as a break.
+    public decimal ReconciliationAmountTolerance { get; set; } = 0.01m;
+
+    /// Maximum drift in minutes between the internal snapshot and the external statement date
+    /// before the reconciliation run is rejected as stale.
+    public int ReconciliationMaxAsOfDriftMinutes { get; set; } = 1440;
+}

--- a/src/Meridian.Contracts/FundStructure/FundStructureCommands.cs
+++ b/src/Meridian.Contracts/FundStructure/FundStructureCommands.cs
@@ -53,7 +53,53 @@ public sealed record CreateAccountRequest(
     Guid? FundId = null,
     Guid? SleeveId = null,
     Guid? VehicleId = null,
-    string? Institution = null);
+    string? Institution = null,
+    CustodianAccountDetailsDto? CustodianDetails = null,
+    BankAccountDetailsDto? BankDetails = null);
+
+public sealed record UpdateCustodianAccountDetailsRequest(
+    CustodianAccountDetailsDto Details,
+    string UpdatedBy);
+
+public sealed record UpdateBankAccountDetailsRequest(
+    BankAccountDetailsDto Details,
+    string UpdatedBy);
+
+public sealed record IngestCustodianStatementRequest(
+    Guid BatchId,
+    Guid AccountId,
+    DateOnly AsOfDate,
+    string CustodianName,
+    string SourceFormat,
+    string? FileName,
+    IReadOnlyList<CustodianPositionLineDto> Lines,
+    string LoadedBy);
+
+public sealed record IngestBankStatementRequest(
+    Guid BatchId,
+    Guid AccountId,
+    DateOnly StatementDate,
+    string BankName,
+    string? FileName,
+    IReadOnlyList<BankStatementLineDto> Lines,
+    string LoadedBy);
+
+public sealed record RecordAccountBalanceSnapshotRequest(
+    Guid AccountId,
+    DateOnly AsOfDate,
+    string Currency,
+    decimal CashBalance,
+    string Source,
+    string RecordedBy,
+    decimal? SecuritiesMarketValue = null,
+    decimal? AccruedInterest = null,
+    decimal? PendingSettlement = null,
+    string? ExternalReference = null);
+
+public sealed record ReconcileAccountRequest(
+    Guid AccountId,
+    DateOnly AsOfDate,
+    string RequestedBy);
 
 public sealed record LinkFundStructureNodesRequest(
     Guid OwnershipLinkId,

--- a/src/Meridian.Contracts/FundStructure/FundStructureDtos.cs
+++ b/src/Meridian.Contracts/FundStructure/FundStructureDtos.cs
@@ -46,8 +46,86 @@ public enum OwnershipRelationshipTypeDto
     Operates,
     ClearsFor,
     CustodiesFor,
-    AllocatesTo
+    AllocatesTo,
+    BanksFor
 }
+
+/// Custody-specific settlement details attached to a Custody-type account.
+public sealed record CustodianAccountDetailsDto(
+    string? SubAccountNumber,
+    string? DtcParticipantCode,
+    string? CrestMemberCode,
+    string? EuroclearAccountNumber,
+    string? ClearstreamAccountNumber,
+    string? PrimebrokerGiveupCode,
+    string? SafekeepingLocation,
+    string? ServiceAgreementReference);
+
+/// Banking-specific settlement details attached to a Bank-type account.
+public sealed record BankAccountDetailsDto(
+    string AccountNumber,
+    string BankName,
+    string? BranchName,
+    string? Iban,
+    string? BicSwift,
+    string? RoutingNumber,
+    string? SortCode,
+    string? IntermediaryBankBic,
+    string? IntermediaryBankName,
+    string? BeneficiaryName,
+    string? BeneficiaryAddress);
+
+/// Balance snapshot captured from an external statement for reconciliation.
+public sealed record AccountBalanceSnapshotDto(
+    Guid SnapshotId,
+    Guid AccountId,
+    Guid? FundId,
+    DateOnly AsOfDate,
+    string Currency,
+    decimal CashBalance,
+    decimal? SecuritiesMarketValue,
+    decimal? AccruedInterest,
+    decimal? PendingSettlement,
+    string Source,
+    DateTimeOffset RecordedAt,
+    string? ExternalReference);
+
+/// Fund-level multi-account view grouping accounts by type.
+public sealed record FundAccountsDto(
+    Guid FundId,
+    IReadOnlyList<AccountSummaryDto> CustodianAccounts,
+    IReadOnlyList<AccountSummaryDto> BankAccounts,
+    IReadOnlyList<AccountSummaryDto> BrokerageAccounts,
+    IReadOnlyList<AccountSummaryDto> OtherAccounts);
+
+/// One position line from a custodian statement batch.
+public sealed record CustodianPositionLineDto(
+    Guid PositionLineId,
+    Guid BatchId,
+    Guid AccountId,
+    DateOnly AsOfDate,
+    string SecurityIdentifier,
+    string IdentifierType,
+    decimal Quantity,
+    decimal MarketValue,
+    string MarketValueCurrency,
+    decimal? CostBasis,
+    decimal? AccruedIncome,
+    bool SettlementPending);
+
+/// One transaction line from a bank account statement batch.
+public sealed record BankStatementLineDto(
+    Guid StatementLineId,
+    Guid BatchId,
+    Guid AccountId,
+    DateOnly StatementDate,
+    DateOnly ValueDate,
+    decimal Amount,
+    string Currency,
+    string TransactionType,
+    string Description,
+    string? ExternalReference,
+    decimal? RunningBalance);
 
 public sealed record FundStructureNodeDto(
     Guid NodeId,
@@ -124,7 +202,9 @@ public sealed record AccountSummaryDto(
     string? PortfolioId,
     string? LedgerReference,
     string? StrategyId,
-    string? RunId);
+    string? RunId,
+    CustodianAccountDetailsDto? CustodianDetails = null,
+    BankAccountDetailsDto? BankDetails = null);
 
 public sealed record OwnershipLinkDto(
     Guid OwnershipLinkId,

--- a/src/Meridian.FSharp/Domain/AccountStatements.fs
+++ b/src/Meridian.FSharp/Domain/AccountStatements.fs
@@ -1,0 +1,67 @@
+namespace Meridian.FSharp.Domain
+
+open System
+
+/// External balance snapshot captured from a custodian or bank statement.
+/// Stored for reconciliation against the internal ledger.
+type AccountBalanceSnapshot = {
+    SnapshotId: Guid
+    AccountId: AccountId
+    FundId: FundId option
+    AsOfDate: DateOnly
+    Currency: string
+    CashBalance: decimal
+    SecuritiesMarketValue: decimal option   // populated for custodian accounts
+    AccruedInterest: decimal option
+    PendingSettlement: decimal option
+    Source: string                          // "CustodianStatement" | "BankStatement" | "Manual"
+    RecordedAt: DateTimeOffset
+    ExternalReference: string option
+}
+
+/// One position line from a custodian statement.
+/// Used as the "actual" side in account-level position reconciliation.
+type CustodianPositionLine = {
+    PositionLineId: Guid
+    BatchId: Guid
+    AccountId: AccountId
+    AsOfDate: DateOnly
+    SecurityIdentifier: string
+    IdentifierType: string                  // "ISIN" | "CUSIP" | "TICKER"
+    Quantity: decimal
+    MarketValue: decimal
+    MarketValueCurrency: string
+    CostBasis: decimal option
+    AccruedIncome: decimal option
+    SettlementPending: bool
+    RawPayload: string option               // original statement line as JSON
+}
+
+/// One transaction line from a bank account statement.
+/// Used as the "actual" side in cash reconciliation.
+type BankStatementLine = {
+    StatementLineId: Guid
+    BatchId: Guid
+    AccountId: AccountId
+    StatementDate: DateOnly
+    ValueDate: DateOnly
+    Amount: decimal
+    Currency: string
+    TransactionType: string
+    Description: string
+    ExternalReference: string option
+    RunningBalance: decimal option
+}
+
+[<RequireQualifiedAccess>]
+module FundAccountDetails =
+    let tryGetCustodian = function
+        | FundAccountDetails.Custodian d -> Some d
+        | _ -> None
+
+    let tryGetBank = function
+        | FundAccountDetails.Bank d -> Some d
+        | _ -> None
+
+    let isCustodian details = details |> tryGetCustodian |> Option.isSome
+    let isBank      details = details |> tryGetBank      |> Option.isSome

--- a/src/Meridian.FSharp/Domain/FundStructure.fs
+++ b/src/Meridian.FSharp/Domain/FundStructure.fs
@@ -49,6 +49,7 @@ type OwnershipRelationshipType =
     | ClearsFor
     | CustodiesFor
     | AllocatesTo
+    | BanksFor
 
 type StructureNode = {
     NodeId: StructureNodeId
@@ -106,6 +107,39 @@ type LegalEntityDefinition = {
     IsActive: bool
 }
 
+/// Custody-specific settlement details attached to an AccountDefinition where AccountType = Custody.
+type CustodianAccountDetails = {
+    SubAccountNumber: string option
+    DtcParticipantCode: string option
+    CrestMemberCode: string option
+    EuroclearAccountNumber: string option
+    ClearstreamAccountNumber: string option
+    PrimebrokerGiveupCode: string option
+    SafekeepingLocation: string option          // e.g. "DTC" | "CREST" | "EUROCLEAR"
+    ServiceAgreementReference: string option
+}
+
+/// Banking-specific settlement details attached to an AccountDefinition where AccountType = Bank.
+type BankAccountDetails = {
+    AccountNumber: string
+    BankName: string
+    BranchName: string option
+    Iban: string option
+    BicSwift: string option
+    RoutingNumber: string option                // US ABA routing
+    SortCode: string option                     // UK sort code
+    IntermediaryBankBic: string option
+    IntermediaryBankName: string option
+    BeneficiaryName: string option
+    BeneficiaryAddress: string option
+}
+
+/// Extended account details discriminated by settlement network type.
+[<RequireQualifiedAccess>]
+type FundAccountDetails =
+    | Custodian of CustodianAccountDetails
+    | Bank of BankAccountDetails
+
 type AccountDefinition = {
     AccountId: AccountId
     AccountType: AccountType
@@ -124,6 +158,8 @@ type AccountDefinition = {
     LedgerReference: string option
     StrategyId: string option
     RunId: string option
+    // Populated for Custody and Bank account types; None for Brokerage/Margin/LedgerControl
+    AccountDetails: FundAccountDetails option
 }
 
 type OwnershipLink = {
@@ -163,3 +199,17 @@ module FundStructure =
 
     let assignmentIsActiveAt asOf (assignment: StructureAssignment) =
         isActiveAt asOf assignment.EffectiveFrom assignment.EffectiveTo true
+
+    /// Returns ownership links where the fund is the parent and the relationship is CustodiesFor.
+    let custodianAccountsForFund (fundNodeId: StructureNodeId) (links: OwnershipLink seq) =
+        links
+        |> Seq.filter (fun l ->
+            l.ParentNodeId = fundNodeId
+            && l.RelationshipType = OwnershipRelationshipType.CustodiesFor)
+
+    /// Returns ownership links where the fund is the parent and the relationship is BanksFor.
+    let bankAccountsForFund (fundNodeId: StructureNodeId) (links: OwnershipLink seq) =
+        links
+        |> Seq.filter (fun l ->
+            l.ParentNodeId = fundNodeId
+            && l.RelationshipType = OwnershipRelationshipType.BanksFor)

--- a/src/Meridian.FSharp/Interop.AccountDetails.fs
+++ b/src/Meridian.FSharp/Interop.AccountDetails.fs
@@ -1,0 +1,84 @@
+namespace Meridian.FSharp.AccountDetailsInterop
+
+open System
+open System.Runtime.CompilerServices
+open Meridian.FSharp.Domain
+
+/// C# callable helpers for FundAccountDetails discriminated union and
+/// FundStructure account query functions.
+[<Sealed; Extension>]
+type FundAccountDetailsInterop private () =
+
+    /// Returns true when the details represent a custodian (DTC, CREST, Euroclear, etc.) account.
+    static member IsCustodian(details: FundAccountDetails) =
+        FundAccountDetails.isCustodian details
+
+    /// Returns true when the details represent a bank (cash/money-market) account.
+    static member IsBank(details: FundAccountDetails) =
+        FundAccountDetails.isBank details
+
+    /// Creates a CustodianAccountDetails-backed FundAccountDetails instance.
+    static member CreateCustodian(
+        subAccountNumber: string,
+        dtcParticipantCode: string,
+        crestMemberCode: string,
+        euroclearAccountNumber: string,
+        clearstreamAccountNumber: string,
+        primebrokerGiveupCode: string,
+        safekeepingLocation: string,
+        serviceAgreementReference: string) : FundAccountDetails =
+        FundAccountDetails.Custodian {
+            SubAccountNumber          = Option.ofObj subAccountNumber
+            DtcParticipantCode        = Option.ofObj dtcParticipantCode
+            CrestMemberCode           = Option.ofObj crestMemberCode
+            EuroclearAccountNumber    = Option.ofObj euroclearAccountNumber
+            ClearstreamAccountNumber  = Option.ofObj clearstreamAccountNumber
+            PrimebrokerGiveupCode     = Option.ofObj primebrokerGiveupCode
+            SafekeepingLocation       = Option.ofObj safekeepingLocation
+            ServiceAgreementReference = Option.ofObj serviceAgreementReference
+        }
+
+    /// Creates a BankAccountDetails-backed FundAccountDetails instance.
+    static member CreateBank(
+        accountNumber: string,
+        bankName: string,
+        branchName: string,
+        iban: string,
+        bicSwift: string,
+        routingNumber: string,
+        sortCode: string,
+        intermediaryBankBic: string,
+        intermediaryBankName: string,
+        beneficiaryName: string,
+        beneficiaryAddress: string) : FundAccountDetails =
+        FundAccountDetails.Bank {
+            AccountNumber        = accountNumber
+            BankName             = bankName
+            BranchName           = Option.ofObj branchName
+            Iban                 = Option.ofObj iban
+            BicSwift             = Option.ofObj bicSwift
+            RoutingNumber        = Option.ofObj routingNumber
+            SortCode             = Option.ofObj sortCode
+            IntermediaryBankBic  = Option.ofObj intermediaryBankBic
+            IntermediaryBankName = Option.ofObj intermediaryBankName
+            BeneficiaryName      = Option.ofObj beneficiaryName
+            BeneficiaryAddress   = Option.ofObj beneficiaryAddress
+        }
+
+    /// Returns the custodian sub-account number if present, otherwise null.
+    static member GetCustodianSubAccountNumber(details: FundAccountDetails) : string =
+        match FundAccountDetails.tryGetCustodian details with
+        | Some d -> d.SubAccountNumber |> Option.defaultValue null
+        | None   -> null
+
+    /// Returns the bank IBAN if present, otherwise null.
+    static member GetBankIban(details: FundAccountDetails) : string =
+        match FundAccountDetails.tryGetBank details with
+        | Some d -> d.Iban |> Option.defaultValue null
+        | None   -> null
+
+    /// Returns the bank BIC/SWIFT if present, otherwise null.
+    static member GetBankBicSwift(details: FundAccountDetails) : string =
+        match FundAccountDetails.tryGetBank details with
+        | Some d -> d.BicSwift |> Option.defaultValue null
+        | None   -> null

--- a/src/Meridian.FSharp/Meridian.FSharp.fsproj
+++ b/src/Meridian.FSharp/Meridian.FSharp.fsproj
@@ -31,6 +31,8 @@
     <Compile Include="Domain/SecurityMasterEvents.fs" />
     <Compile Include="Domain/SecurityMasterCommands.fs" />
     <Compile Include="Domain/FundStructure.fs" />
+    <!-- Account statement types depend on AccountId/FundId from FundStructure.fs -->
+    <Compile Include="Domain/AccountStatements.fs" />
     <Compile Include="Domain/DirectLending.fs" />
 
     <!-- Comprehensive security master domain — self-contained, no inter-domain dependencies -->
@@ -64,6 +66,7 @@
     <Compile Include="Interop.CashFlow.fs" />
     <Compile Include="Interop.SecurityMaster.fs" />
     <Compile Include="Interop.DirectLending.fs" />
+    <Compile Include="Interop.AccountDetails.fs" />
     <Compile Include="Interop.fs" />
   </ItemGroup>
 

--- a/src/Meridian.Storage/FundAccounts/IFundAccountStore.cs
+++ b/src/Meridian.Storage/FundAccounts/IFundAccountStore.cs
@@ -1,0 +1,30 @@
+using Meridian.Contracts.FundStructure;
+
+namespace Meridian.Storage.FundAccounts;
+
+/// <summary>
+/// Persistence interface for fund account data.
+/// Implemented by <c>PostgresFundAccountStore</c> when a connection string is configured.
+/// </summary>
+public interface IFundAccountStore
+{
+    // Account definition
+    Task UpsertAccountAsync(AccountSummaryDto account, CancellationToken ct = default);
+    Task<AccountSummaryDto?> GetAccountAsync(Guid accountId, CancellationToken ct = default);
+    Task<IReadOnlyList<AccountSummaryDto>> QueryAccountsAsync(AccountStructureQuery query, CancellationToken ct = default);
+
+    // Balance snapshots
+    Task InsertBalanceSnapshotAsync(AccountBalanceSnapshotDto snapshot, CancellationToken ct = default);
+    Task<IReadOnlyList<AccountBalanceSnapshotDto>> GetBalanceHistoryAsync(Guid accountId, DateOnly? fromDate, DateOnly? toDate, CancellationToken ct = default);
+
+    // Statement ingestion
+    Task InsertCustodianStatementBatchAsync(CustodianStatementBatchDto batch, IReadOnlyList<CustodianPositionLineDto> lines, CancellationToken ct = default);
+    Task InsertBankStatementBatchAsync(BankStatementBatchDto batch, IReadOnlyList<BankStatementLineDto> lines, CancellationToken ct = default);
+    Task<IReadOnlyList<CustodianPositionLineDto>> GetCustodianPositionsAsync(Guid accountId, DateOnly asOfDate, CancellationToken ct = default);
+    Task<IReadOnlyList<BankStatementLineDto>> GetBankStatementLinesAsync(Guid accountId, DateOnly? fromDate, DateOnly? toDate, CancellationToken ct = default);
+
+    // Reconciliation
+    Task InsertReconciliationRunAsync(AccountReconciliationRunDto run, IReadOnlyList<AccountReconciliationResultDto> results, CancellationToken ct = default);
+    Task<IReadOnlyList<AccountReconciliationRunDto>> GetReconciliationRunsAsync(Guid accountId, CancellationToken ct = default);
+    Task<IReadOnlyList<AccountReconciliationResultDto>> GetReconciliationResultsAsync(Guid reconciliationRunId, CancellationToken ct = default);
+}

--- a/src/Meridian.Storage/FundAccounts/Migrations/001_fund_accounts.sql
+++ b/src/Meridian.Storage/FundAccounts/Migrations/001_fund_accounts.sql
@@ -1,0 +1,162 @@
+-- Fund Accounts schema: custodian accounts, bank accounts, balance snapshots,
+-- statement ingestion, and account-level reconciliation.
+-- Schema variable replaced at runtime: __SCHEMA__ -> fund_accounts (default)
+
+create schema if not exists __SCHEMA__;
+
+-- ── Core account definition ────────────────────────────────────────────────────
+
+create table if not exists __SCHEMA__.account_definition (
+    account_id          uuid        primary key,
+    account_type        text        not null,       -- AccountTypeDto value
+    entity_id           uuid,
+    fund_id             uuid,
+    sleeve_id           uuid,
+    vehicle_id          uuid,
+    account_code        text        not null,
+    display_name        text        not null,
+    base_currency       text        not null,
+    institution         text,
+    is_active           boolean     not null default true,
+    effective_from      timestamptz not null,
+    effective_to        timestamptz,
+    portfolio_id        text,
+    ledger_reference    text,
+    strategy_id         text,
+    run_id              text,
+    -- Extended settlement details (nullable; present for Custody and Bank types)
+    custodian_details   jsonb,
+    bank_details        jsonb,
+    created_at          timestamptz not null default now(),
+    updated_at          timestamptz not null default now()
+);
+
+create unique index if not exists ux_account_code_active
+    on __SCHEMA__.account_definition (account_code)
+    where is_active = true;
+
+create index if not exists ix_account_fund
+    on __SCHEMA__.account_definition (fund_id, account_type)
+    where fund_id is not null;
+
+create index if not exists ix_account_entity
+    on __SCHEMA__.account_definition (entity_id)
+    where entity_id is not null;
+
+-- ── External balance snapshots ─────────────────────────────────────────────────
+
+create table if not exists __SCHEMA__.account_balance_snapshot (
+    snapshot_id             uuid        primary key,
+    account_id              uuid        not null references __SCHEMA__.account_definition (account_id),
+    fund_id                 uuid,
+    as_of_date              date        not null,
+    currency                text        not null,
+    cash_balance            numeric(24,6) not null,
+    securities_market_value numeric(24,6),
+    accrued_interest        numeric(24,6),
+    pending_settlement      numeric(24,6),
+    source                  text        not null,
+    recorded_at             timestamptz not null default now(),
+    external_reference      text
+);
+
+create index if not exists ix_balance_snapshot_account_date
+    on __SCHEMA__.account_balance_snapshot (account_id, as_of_date desc);
+
+-- ── Custodian statement batches and position lines ────────────────────────────
+
+create table if not exists __SCHEMA__.custodian_statement_batch (
+    batch_id        uuid        primary key,
+    account_id      uuid        not null references __SCHEMA__.account_definition (account_id),
+    as_of_date      date        not null,
+    custodian_name  text        not null,
+    source_format   text        not null,
+    file_name       text,
+    line_count      integer     not null,
+    ingested_at     timestamptz not null default now(),
+    loaded_by       text        not null
+);
+
+create table if not exists __SCHEMA__.custodian_position_line (
+    position_line_id      uuid          primary key,
+    batch_id              uuid          not null references __SCHEMA__.custodian_statement_batch (batch_id) on delete cascade,
+    account_id            uuid          not null references __SCHEMA__.account_definition (account_id),
+    as_of_date            date          not null,
+    security_identifier   text          not null,
+    identifier_type       text          not null,
+    quantity              numeric(24,8) not null,
+    market_value          numeric(24,6) not null,
+    market_value_currency text          not null,
+    cost_basis            numeric(24,6),
+    accrued_income        numeric(24,6),
+    settlement_pending    boolean       not null default false,
+    raw_payload           jsonb
+);
+
+create index if not exists ix_custodian_position_account_date
+    on __SCHEMA__.custodian_position_line (account_id, as_of_date desc);
+
+-- ── Bank statement batches and transaction lines ──────────────────────────────
+
+create table if not exists __SCHEMA__.bank_statement_batch (
+    batch_id        uuid        primary key,
+    account_id      uuid        not null references __SCHEMA__.account_definition (account_id),
+    statement_date  date        not null,
+    bank_name       text        not null,
+    file_name       text,
+    line_count      integer     not null,
+    ingested_at     timestamptz not null default now(),
+    loaded_by       text        not null
+);
+
+create table if not exists __SCHEMA__.bank_statement_line (
+    statement_line_id   uuid          primary key,
+    batch_id            uuid          not null references __SCHEMA__.bank_statement_batch (batch_id) on delete cascade,
+    account_id          uuid          not null references __SCHEMA__.account_definition (account_id),
+    statement_date      date          not null,
+    value_date          date          not null,
+    amount              numeric(24,6) not null,
+    currency            text          not null,
+    transaction_type    text          not null,
+    description         text          not null,
+    external_reference  text,
+    running_balance     numeric(24,6)
+);
+
+create index if not exists ix_bank_statement_account_date
+    on __SCHEMA__.bank_statement_line (account_id, statement_date desc);
+
+-- ── Account reconciliation runs and results ───────────────────────────────────
+
+create table if not exists __SCHEMA__.account_reconciliation_run (
+    reconciliation_run_id   uuid          primary key,
+    account_id              uuid          not null references __SCHEMA__.account_definition (account_id),
+    as_of_date              date          not null,
+    status                  text          not null,
+    total_checks            integer       not null default 0,
+    total_matched           integer       not null default 0,
+    total_breaks            integer       not null default 0,
+    break_amount_total      numeric(24,6) not null default 0,
+    requested_at            timestamptz   not null default now(),
+    completed_at            timestamptz,
+    requested_by            text          not null
+);
+
+create index if not exists ix_recon_run_account
+    on __SCHEMA__.account_reconciliation_run (account_id, as_of_date desc);
+
+create table if not exists __SCHEMA__.account_reconciliation_result (
+    result_id               uuid          primary key,
+    reconciliation_run_id   uuid          not null references __SCHEMA__.account_reconciliation_run (reconciliation_run_id) on delete cascade,
+    check_label             text          not null,
+    is_match                boolean       not null,
+    category                text          not null,
+    status                  text          not null,
+    expected_amount         numeric(24,6),
+    actual_amount           numeric(24,6),
+    variance                numeric(24,6),
+    reason                  text          not null
+);
+
+create index if not exists ix_recon_result_run
+    on __SCHEMA__.account_reconciliation_result (reconciliation_run_id);

--- a/src/Meridian.Ui.Shared/Endpoints/FundAccountEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/FundAccountEndpoints.cs
@@ -1,0 +1,275 @@
+using System.Text.Json;
+using Meridian.Application.FundAccounts;
+using Meridian.Contracts.FundStructure;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Ui.Shared.Endpoints;
+
+public static class FundAccountEndpoints
+{
+    public static void MapFundAccountEndpoints(this WebApplication app, JsonSerializerOptions jsonOptions)
+    {
+        var group = app.MapGroup("/api/fund-accounts").WithTags("Fund Accounts");
+
+        // ── Account CRUD ─────────────────────────────────────────────────────
+
+        group.MapPost("/", async (JsonElement body, HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null) return ServiceUnavailable();
+
+            var request = JsonSerializer.Deserialize<CreateAccountRequest>(body.GetRawText(), jsonOptions);
+            if (request is null)
+                return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
+
+            var result = await service.CreateAccountAsync(request, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(result, jsonOptions, statusCode: StatusCodes.Status201Created);
+        })
+        .WithName("CreateFundAccount")
+        .Produces<AccountSummaryDto>(StatusCodes.Status201Created)
+        .Produces(StatusCodes.Status400BadRequest);
+
+        group.MapGet("/{accountId:guid}", async (Guid accountId, HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null) return ServiceUnavailable();
+
+            var result = await service.GetAccountAsync(accountId, context.RequestAborted).ConfigureAwait(false);
+            return result is null ? Results.NotFound() : Results.Json(result, jsonOptions);
+        })
+        .WithName("GetFundAccount")
+        .Produces<AccountSummaryDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status404NotFound);
+
+        group.MapGet("/", async (HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null) return ServiceUnavailable();
+
+            var q = context.Request.Query;
+            var query = new AccountStructureQuery(
+                AccountId: Guid.TryParse(q["accountId"], out var aid) ? aid : null,
+                FundId:    Guid.TryParse(q["fundId"],    out var fid) ? fid : null,
+                EntityId:  Guid.TryParse(q["entityId"],  out var eid) ? eid : null,
+                ActiveOnly: q["activeOnly"] != "false");
+
+            var results = await service.QueryAccountsAsync(query, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(results, jsonOptions);
+        })
+        .WithName("QueryFundAccounts")
+        .Produces<IReadOnlyList<AccountSummaryDto>>(StatusCodes.Status200OK);
+
+        group.MapGet("/fund/{fundId:guid}", async (Guid fundId, HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null) return ServiceUnavailable();
+
+            var result = await service.GetFundAccountsAsync(fundId, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(result, jsonOptions);
+        })
+        .WithName("GetFundAccounts")
+        .Produces<FundAccountsDto>(StatusCodes.Status200OK);
+
+        group.MapPatch("/{accountId:guid}/custodian-details", async (Guid accountId, JsonElement body, HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null) return ServiceUnavailable();
+
+            var request = JsonSerializer.Deserialize<UpdateCustodianAccountDetailsRequest>(body.GetRawText(), jsonOptions);
+            if (request is null)
+                return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
+
+            var result = await service.UpdateCustodianDetailsAsync(accountId, request, context.RequestAborted).ConfigureAwait(false);
+            return result is null ? Results.NotFound() : Results.Json(result, jsonOptions);
+        })
+        .WithName("UpdateCustodianAccountDetails")
+        .Produces<AccountSummaryDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status404NotFound);
+
+        group.MapPatch("/{accountId:guid}/bank-details", async (Guid accountId, JsonElement body, HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null) return ServiceUnavailable();
+
+            var request = JsonSerializer.Deserialize<UpdateBankAccountDetailsRequest>(body.GetRawText(), jsonOptions);
+            if (request is null)
+                return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
+
+            var result = await service.UpdateBankDetailsAsync(accountId, request, context.RequestAborted).ConfigureAwait(false);
+            return result is null ? Results.NotFound() : Results.Json(result, jsonOptions);
+        })
+        .WithName("UpdateBankAccountDetails")
+        .Produces<AccountSummaryDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status404NotFound);
+
+        group.MapDelete("/{accountId:guid}", async (Guid accountId, HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null) return ServiceUnavailable();
+
+            var deactivatedBy = context.Request.Query["deactivatedBy"].FirstOrDefault() ?? "system";
+            var result = await service.DeactivateAccountAsync(accountId, deactivatedBy, context.RequestAborted).ConfigureAwait(false);
+            return result is null ? Results.NotFound() : Results.Json(result, jsonOptions);
+        })
+        .WithName("DeactivateFundAccount")
+        .Produces<AccountSummaryDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status404NotFound);
+
+        // ── Balance snapshots ─────────────────────────────────────────────────
+
+        group.MapPost("/{accountId:guid}/balance-snapshots", async (Guid accountId, JsonElement body, HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null) return ServiceUnavailable();
+
+            var request = JsonSerializer.Deserialize<RecordAccountBalanceSnapshotRequest>(body.GetRawText(), jsonOptions);
+            if (request is null)
+                return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
+
+            var result = await service.RecordBalanceSnapshotAsync(request, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(result, jsonOptions, statusCode: StatusCodes.Status201Created);
+        })
+        .WithName("RecordAccountBalanceSnapshot")
+        .Produces<AccountBalanceSnapshotDto>(StatusCodes.Status201Created)
+        .Produces(StatusCodes.Status400BadRequest);
+
+        group.MapGet("/{accountId:guid}/balance-snapshots", async (Guid accountId, HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null) return ServiceUnavailable();
+
+            var q = context.Request.Query;
+            DateOnly? from = DateOnly.TryParse(q["from"], out var f) ? f : null;
+            DateOnly? to   = DateOnly.TryParse(q["to"],   out var t) ? t : null;
+
+            var results = await service.GetBalanceHistoryAsync(accountId, from, to, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(results, jsonOptions);
+        })
+        .WithName("GetAccountBalanceHistory")
+        .Produces<IReadOnlyList<AccountBalanceSnapshotDto>>(StatusCodes.Status200OK);
+
+        group.MapGet("/{accountId:guid}/balance-snapshots/latest", async (Guid accountId, HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null) return ServiceUnavailable();
+
+            var result = await service.GetLatestBalanceSnapshotAsync(accountId, context.RequestAborted).ConfigureAwait(false);
+            return result is null ? Results.NotFound() : Results.Json(result, jsonOptions);
+        })
+        .WithName("GetLatestAccountBalanceSnapshot")
+        .Produces<AccountBalanceSnapshotDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status404NotFound);
+
+        // ── Statement ingestion ───────────────────────────────────────────────
+
+        group.MapPost("/{accountId:guid}/custodian-statements", async (Guid accountId, JsonElement body, HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null) return ServiceUnavailable();
+
+            var request = JsonSerializer.Deserialize<IngestCustodianStatementRequest>(body.GetRawText(), jsonOptions);
+            if (request is null)
+                return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
+
+            var result = await service.IngestCustodianStatementAsync(request, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(result, jsonOptions, statusCode: StatusCodes.Status201Created);
+        })
+        .WithName("IngestCustodianStatement")
+        .Produces<CustodianStatementBatchDto>(StatusCodes.Status201Created)
+        .Produces(StatusCodes.Status400BadRequest);
+
+        group.MapGet("/{accountId:guid}/custodian-positions", async (Guid accountId, HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null) return ServiceUnavailable();
+
+            if (!DateOnly.TryParse(context.Request.Query["asOfDate"], out var asOfDate))
+                return Results.Problem("'asOfDate' query parameter is required (YYYY-MM-DD).", statusCode: StatusCodes.Status400BadRequest);
+
+            var results = await service.GetCustodianPositionsAsync(accountId, asOfDate, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(results, jsonOptions);
+        })
+        .WithName("GetCustodianPositions")
+        .Produces<IReadOnlyList<CustodianPositionLineDto>>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status400BadRequest);
+
+        group.MapPost("/{accountId:guid}/bank-statements", async (Guid accountId, JsonElement body, HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null) return ServiceUnavailable();
+
+            var request = JsonSerializer.Deserialize<IngestBankStatementRequest>(body.GetRawText(), jsonOptions);
+            if (request is null)
+                return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
+
+            var result = await service.IngestBankStatementAsync(request, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(result, jsonOptions, statusCode: StatusCodes.Status201Created);
+        })
+        .WithName("IngestBankStatement")
+        .Produces<BankStatementBatchDto>(StatusCodes.Status201Created)
+        .Produces(StatusCodes.Status400BadRequest);
+
+        group.MapGet("/{accountId:guid}/bank-statement-lines", async (Guid accountId, HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null) return ServiceUnavailable();
+
+            var q = context.Request.Query;
+            DateOnly? from = DateOnly.TryParse(q["from"], out var f) ? f : null;
+            DateOnly? to   = DateOnly.TryParse(q["to"],   out var t) ? t : null;
+
+            var results = await service.GetBankStatementLinesAsync(accountId, from, to, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(results, jsonOptions);
+        })
+        .WithName("GetBankStatementLines")
+        .Produces<IReadOnlyList<BankStatementLineDto>>(StatusCodes.Status200OK);
+
+        // ── Reconciliation ────────────────────────────────────────────────────
+
+        group.MapPost("/{accountId:guid}/reconcile", async (Guid accountId, JsonElement body, HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null) return ServiceUnavailable();
+
+            var request = JsonSerializer.Deserialize<ReconcileAccountRequest>(body.GetRawText(), jsonOptions);
+            if (request is null)
+                return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
+
+            var result = await service.ReconcileAccountAsync(request, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(result, jsonOptions, statusCode: StatusCodes.Status201Created);
+        })
+        .WithName("ReconcileFundAccount")
+        .Produces<AccountReconciliationRunDto>(StatusCodes.Status201Created)
+        .Produces(StatusCodes.Status400BadRequest);
+
+        group.MapGet("/{accountId:guid}/reconciliation-runs", async (Guid accountId, HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null) return ServiceUnavailable();
+
+            var results = await service.GetReconciliationRunsAsync(accountId, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(results, jsonOptions);
+        })
+        .WithName("GetAccountReconciliationRuns")
+        .Produces<IReadOnlyList<AccountReconciliationRunDto>>(StatusCodes.Status200OK);
+
+        group.MapGet("/reconciliation-runs/{runId:guid}/results", async (Guid runId, HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null) return ServiceUnavailable();
+
+            var results = await service.GetReconciliationResultsAsync(runId, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(results, jsonOptions);
+        })
+        .WithName("GetAccountReconciliationResults")
+        .Produces<IReadOnlyList<AccountReconciliationResultDto>>(StatusCodes.Status200OK);
+    }
+
+    private static IFundAccountService? ResolveService(HttpContext context) =>
+        context.RequestServices.GetService<IFundAccountService>();
+
+    private static IResult ServiceUnavailable() =>
+        Results.Problem("Fund account service is not registered.", statusCode: StatusCodes.Status501NotImplemented);
+}

--- a/src/Meridian.Ui.Shared/Endpoints/UiEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/UiEndpoints.cs
@@ -265,6 +265,9 @@ public static class UiEndpoints
         // Direct lending endpoints
         app.MapDirectLendingEndpoints(jsonOptions);
 
+        // Fund accounts (custodian and bank) endpoints
+        app.MapFundAccountEndpoints(jsonOptions);
+
         // Security Master endpoints
         app.MapSecurityMasterEndpoints(jsonOptions);
 
@@ -374,6 +377,9 @@ public static class UiEndpoints
 
         // Direct lending endpoints
         app.MapDirectLendingEndpoints(jsonOptions);
+
+        // Fund accounts (custodian and bank) endpoints
+        app.MapFundAccountEndpoints(jsonOptions);
 
         // Security Master endpoints
         app.MapSecurityMasterEndpoints(jsonOptions);

--- a/src/Meridian.Wpf/ViewModels/FundAccountsViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/FundAccountsViewModel.cs
@@ -1,0 +1,216 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.Input;
+using Meridian.Application.FundAccounts;
+using Meridian.Contracts.FundStructure;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Wpf.ViewModels;
+
+/// <summary>
+/// ViewModel for the Fund Accounts page.
+/// Displays custodian accounts and bank accounts for the selected fund,
+/// allows creating new accounts, recording balance snapshots, ingesting
+/// statements, and running account-level reconciliation.
+/// </summary>
+public sealed partial class FundAccountsViewModel : BindableBase
+{
+    private readonly IFundAccountService _service;
+    private readonly ILogger<FundAccountsViewModel> _logger;
+
+    public FundAccountsViewModel(
+        IFundAccountService service,
+        ILogger<FundAccountsViewModel> logger)
+    {
+        _service = service;
+        _logger  = logger;
+
+        LoadFundAccountsCommand = new AsyncRelayCommand(LoadFundAccountsAsync);
+        CreateAccountCommand    = new AsyncRelayCommand(CreateAccountAsync);
+        UpdateDetailsCommand    = new AsyncRelayCommand(UpdateDetailsAsync, CanUpdateDetails);
+        RecordSnapshotCommand   = new AsyncRelayCommand(RecordSnapshotAsync, CanRecordSnapshot);
+        ReconcileCommand        = new AsyncRelayCommand(ReconcileAsync, CanReconcile);
+    }
+
+    // ── Selected fund ────────────────────────────────────────────────────────
+
+    private Guid? _selectedFundId;
+    public Guid? SelectedFundId
+    {
+        get => _selectedFundId;
+        set
+        {
+            if (SetProperty(ref _selectedFundId, value))
+                LoadFundAccountsCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    // ── Account lists ────────────────────────────────────────────────────────
+
+    public ObservableCollection<AccountSummaryDto> CustodianAccounts { get; } = [];
+    public ObservableCollection<AccountSummaryDto> BankAccounts      { get; } = [];
+    public ObservableCollection<AccountSummaryDto> BrokerageAccounts { get; } = [];
+    public ObservableCollection<AccountSummaryDto> OtherAccounts     { get; } = [];
+
+    // ── Selected account ─────────────────────────────────────────────────────
+
+    private AccountSummaryDto? _selectedAccount;
+    public AccountSummaryDto? SelectedAccount
+    {
+        get => _selectedAccount;
+        set
+        {
+            if (SetProperty(ref _selectedAccount, value))
+            {
+                UpdateDetailsCommand.NotifyCanExecuteChanged();
+                RecordSnapshotCommand.NotifyCanExecuteChanged();
+                ReconcileCommand.NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    // ── Balance history ──────────────────────────────────────────────────────
+
+    public ObservableCollection<AccountBalanceSnapshotDto> BalanceHistory { get; } = [];
+
+    // ── Last reconciliation run ──────────────────────────────────────────────
+
+    private AccountReconciliationRunDto? _lastReconciliationRun;
+    public AccountReconciliationRunDto? LastReconciliationRun
+    {
+        get => _lastReconciliationRun;
+        private set => SetProperty(ref _lastReconciliationRun, value);
+    }
+
+    // ── Status ───────────────────────────────────────────────────────────────
+
+    private bool _isBusy;
+    public bool IsBusy
+    {
+        get => _isBusy;
+        private set => SetProperty(ref _isBusy, value);
+    }
+
+    private string? _statusMessage;
+    public string? StatusMessage
+    {
+        get => _statusMessage;
+        private set => SetProperty(ref _statusMessage, value);
+    }
+
+    // ── Commands ─────────────────────────────────────────────────────────────
+
+    public IAsyncRelayCommand LoadFundAccountsCommand  { get; }
+    public IAsyncRelayCommand CreateAccountCommand     { get; }
+    public IAsyncRelayCommand UpdateDetailsCommand     { get; }
+    public IAsyncRelayCommand RecordSnapshotCommand    { get; }
+    public IAsyncRelayCommand ReconcileCommand         { get; }
+
+    // ── Command implementations ───────────────────────────────────────────────
+
+    private async Task LoadFundAccountsAsync()
+    {
+        if (SelectedFundId is null) return;
+
+        IsBusy = true;
+        StatusMessage = null;
+        try
+        {
+            var dto = await _service
+                .GetFundAccountsAsync(SelectedFundId.Value)
+                .ConfigureAwait(false);
+
+            CustodianAccounts.Clear();
+            BankAccounts.Clear();
+            BrokerageAccounts.Clear();
+            OtherAccounts.Clear();
+
+            foreach (var a in dto.CustodianAccounts) CustodianAccounts.Add(a);
+            foreach (var a in dto.BankAccounts)      BankAccounts.Add(a);
+            foreach (var a in dto.BrokerageAccounts) BrokerageAccounts.Add(a);
+            foreach (var a in dto.OtherAccounts)     OtherAccounts.Add(a);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load fund accounts for fund {FundId}", SelectedFundId);
+            StatusMessage = $"Error loading accounts: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private Task CreateAccountAsync()
+    {
+        // Full dialog/wizard wired up in the View layer.
+        // ViewModel exposes the command; the View opens the creation dialog.
+        StatusMessage = "Open account creation dialog.";
+        return Task.CompletedTask;
+    }
+
+    private bool CanUpdateDetails() => SelectedAccount is not null;
+    private Task UpdateDetailsAsync()
+    {
+        StatusMessage = "Open account details editor.";
+        return Task.CompletedTask;
+    }
+
+    private bool CanRecordSnapshot() => SelectedAccount is not null;
+    private async Task RecordSnapshotAsync()
+    {
+        if (SelectedAccount is null) return;
+
+        IsBusy = true;
+        StatusMessage = null;
+        try
+        {
+            var history = await _service
+                .GetBalanceHistoryAsync(SelectedAccount.AccountId)
+                .ConfigureAwait(false);
+
+            BalanceHistory.Clear();
+            foreach (var s in history) BalanceHistory.Add(s);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load balance history for account {AccountId}", SelectedAccount.AccountId);
+            StatusMessage = $"Error: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private bool CanReconcile() => SelectedAccount is not null;
+    private async Task ReconcileAsync()
+    {
+        if (SelectedAccount is null) return;
+
+        IsBusy = true;
+        StatusMessage = null;
+        try
+        {
+            var request = new ReconcileAccountRequest(
+                SelectedAccount.AccountId,
+                AsOfDate: DateOnly.FromDateTime(DateTime.Today),
+                RequestedBy: "desktop-user");
+
+            LastReconciliationRun = await _service
+                .ReconcileAccountAsync(request)
+                .ConfigureAwait(false);
+
+            StatusMessage = $"Reconciliation complete: {LastReconciliationRun.Status} " +
+                            $"({LastReconciliationRun.TotalMatched}/{LastReconciliationRun.TotalChecks} checks matched)";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Reconciliation failed for account {AccountId}", SelectedAccount.AccountId);
+            StatusMessage = $"Reconciliation error: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+}

--- a/src/Meridian.Wpf/Views/FundAccountsPage.xaml
+++ b/src/Meridian.Wpf/Views/FundAccountsPage.xaml
@@ -1,0 +1,15 @@
+<Page x:Class="Meridian.Wpf.Views.FundAccountsPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      mc:Ignorable="d"
+      Title="Fund Accounts">
+    <Grid Margin="16">
+        <!-- Full XAML layout is a follow-on task. Stub provides navigation target. -->
+        <TextBlock Text="Fund Accounts"
+                   VerticalAlignment="Center"
+                   HorizontalAlignment="Center"
+                   Style="{StaticResource TitleTextStyle}" />
+    </Grid>
+</Page>

--- a/src/Meridian.Wpf/Views/FundAccountsPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/FundAccountsPage.xaml.cs
@@ -1,0 +1,13 @@
+using System.Windows.Controls;
+using Meridian.Wpf.ViewModels;
+
+namespace Meridian.Wpf.Views;
+
+public partial class FundAccountsPage : Page
+{
+    public FundAccountsPage(FundAccountsViewModel viewModel)
+    {
+        InitializeComponent();
+        DataContext = viewModel;
+    }
+}

--- a/tests/Meridian.FSharp.Tests/AccountDetailsTests.fs
+++ b/tests/Meridian.FSharp.Tests/AccountDetailsTests.fs
@@ -1,0 +1,184 @@
+/// Unit tests for FundAccountDetails discriminated union and FundStructure account query helpers.
+module Meridian.FSharp.Tests.AccountDetailsTests
+
+open System
+open Xunit
+open FsUnit.Xunit
+open Meridian.FSharp.Domain
+
+// ── FundAccountDetails helpers ────────────────────────────────────────────────
+
+[<Fact>]
+let ``FundAccountDetails.tryGetCustodian returns Some for Custodian case`` () =
+    let details = FundAccountDetails.Custodian {
+        SubAccountNumber          = Some "SUB-001"
+        DtcParticipantCode        = Some "0352"
+        CrestMemberCode           = None
+        EuroclearAccountNumber    = None
+        ClearstreamAccountNumber  = None
+        PrimebrokerGiveupCode     = None
+        SafekeepingLocation       = Some "DTC"
+        ServiceAgreementReference = None
+    }
+    let result = FundAccountDetails.tryGetCustodian details
+    result |> should not' (equal None)
+    result.Value.SubAccountNumber |> should equal (Some "SUB-001")
+
+[<Fact>]
+let ``FundAccountDetails.tryGetCustodian returns None for Bank case`` () =
+    let details = FundAccountDetails.Bank {
+        AccountNumber        = "00112233"
+        BankName             = "JPMorgan"
+        BranchName           = None
+        Iban                 = Some "GB29NWBK60161331926819"
+        BicSwift             = Some "CHASUS33"
+        RoutingNumber        = None
+        SortCode             = None
+        IntermediaryBankBic  = None
+        IntermediaryBankName = None
+        BeneficiaryName      = None
+        BeneficiaryAddress   = None
+    }
+    FundAccountDetails.tryGetCustodian details |> should equal None
+
+[<Fact>]
+let ``FundAccountDetails.tryGetBank returns Some for Bank case`` () =
+    let details = FundAccountDetails.Bank {
+        AccountNumber        = "99887766"
+        BankName             = "Barclays"
+        BranchName           = None
+        Iban                 = None
+        BicSwift             = Some "BARCGB22"
+        RoutingNumber        = None
+        SortCode             = Some "20-32-53"
+        IntermediaryBankBic  = None
+        IntermediaryBankName = None
+        BeneficiaryName      = Some "Meridian Fund I LP"
+        BeneficiaryAddress   = None
+    }
+    let result = FundAccountDetails.tryGetBank details
+    result |> should not' (equal None)
+    result.Value.SortCode |> should equal (Some "20-32-53")
+
+[<Fact>]
+let ``FundAccountDetails.tryGetBank returns None for Custodian case`` () =
+    let details = FundAccountDetails.Custodian {
+        SubAccountNumber          = None
+        DtcParticipantCode        = None
+        CrestMemberCode           = None
+        EuroclearAccountNumber    = None
+        ClearstreamAccountNumber  = None
+        PrimebrokerGiveupCode     = None
+        SafekeepingLocation       = None
+        ServiceAgreementReference = None
+    }
+    FundAccountDetails.tryGetBank details |> should equal None
+
+[<Fact>]
+let ``FundAccountDetails.isCustodian returns true for Custodian case`` () =
+    let details = FundAccountDetails.Custodian {
+        SubAccountNumber          = None
+        DtcParticipantCode        = None
+        CrestMemberCode           = None
+        EuroclearAccountNumber    = None
+        ClearstreamAccountNumber  = None
+        PrimebrokerGiveupCode     = None
+        SafekeepingLocation       = None
+        ServiceAgreementReference = None
+    }
+    FundAccountDetails.isCustodian details |> should equal true
+
+[<Fact>]
+let ``FundAccountDetails.isBank returns true for Bank case`` () =
+    let details = FundAccountDetails.Bank {
+        AccountNumber        = "123"
+        BankName             = "Test Bank"
+        BranchName           = None; Iban = None; BicSwift = None
+        RoutingNumber        = None; SortCode = None
+        IntermediaryBankBic  = None; IntermediaryBankName = None
+        BeneficiaryName      = None; BeneficiaryAddress = None
+    }
+    FundAccountDetails.isBank details |> should equal true
+
+// ── FundStructure account query helpers ───────────────────────────────────────
+
+let private makeLink parentId childId rel =
+    {
+        OwnershipLinkId  = OwnershipLinkId (Guid.NewGuid())
+        ParentNodeId     = parentId
+        ChildNodeId      = childId
+        RelationshipType = rel
+        OwnershipPercent = None
+        EffectiveFrom    = DateTimeOffset.UtcNow.AddDays(-1.0)
+        EffectiveTo      = None
+        IsPrimary        = true
+        Notes            = None
+    }
+
+[<Fact>]
+let ``FundStructure.custodianAccountsForFund filters by CustodiesFor`` () =
+    let fundNodeId = StructureNodeId (Guid.NewGuid())
+    let custNode1  = StructureNodeId (Guid.NewGuid())
+    let custNode2  = StructureNodeId (Guid.NewGuid())
+    let bankNode   = StructureNodeId (Guid.NewGuid())
+
+    let links = [
+        makeLink fundNodeId custNode1 OwnershipRelationshipType.CustodiesFor
+        makeLink fundNodeId custNode2 OwnershipRelationshipType.CustodiesFor
+        makeLink fundNodeId bankNode  OwnershipRelationshipType.BanksFor
+    ]
+
+    let result = FundStructure.custodianAccountsForFund fundNodeId links |> Seq.toList
+    result |> List.length |> should equal 2
+    result |> List.forall (fun l -> l.RelationshipType = OwnershipRelationshipType.CustodiesFor)
+           |> should equal true
+
+[<Fact>]
+let ``FundStructure.bankAccountsForFund filters by BanksFor`` () =
+    let fundNodeId = StructureNodeId (Guid.NewGuid())
+    let bankNode1  = StructureNodeId (Guid.NewGuid())
+    let bankNode2  = StructureNodeId (Guid.NewGuid())
+    let bankNode3  = StructureNodeId (Guid.NewGuid())
+    let custNode   = StructureNodeId (Guid.NewGuid())
+
+    let links = [
+        makeLink fundNodeId bankNode1 OwnershipRelationshipType.BanksFor
+        makeLink fundNodeId bankNode2 OwnershipRelationshipType.BanksFor
+        makeLink fundNodeId bankNode3 OwnershipRelationshipType.BanksFor
+        makeLink fundNodeId custNode  OwnershipRelationshipType.CustodiesFor
+    ]
+
+    let result = FundStructure.bankAccountsForFund fundNodeId links |> Seq.toList
+    result |> List.length |> should equal 3
+
+[<Fact>]
+let ``FundStructure.custodianAccountsForFund excludes links for other funds`` () =
+    let fundANodeId = StructureNodeId (Guid.NewGuid())
+    let fundBNodeId = StructureNodeId (Guid.NewGuid())
+    let custNode    = StructureNodeId (Guid.NewGuid())
+
+    let links = [
+        makeLink fundANodeId custNode OwnershipRelationshipType.CustodiesFor
+        makeLink fundBNodeId custNode OwnershipRelationshipType.CustodiesFor
+    ]
+
+    let result = FundStructure.custodianAccountsForFund fundANodeId links |> Seq.toList
+    result |> List.length |> should equal 1
+    result.[0].ParentNodeId |> should equal fundANodeId
+
+// ── OwnershipRelationshipType DU coverage ─────────────────────────────────────
+
+[<Fact>]
+let ``OwnershipRelationshipType BanksFor is a valid case`` () =
+    let rel = OwnershipRelationshipType.BanksFor
+    // Pattern match should compile and cover the BanksFor case without warning
+    let label =
+        match rel with
+        | OwnershipRelationshipType.Owns        -> "Owns"
+        | OwnershipRelationshipType.Advises     -> "Advises"
+        | OwnershipRelationshipType.Operates    -> "Operates"
+        | OwnershipRelationshipType.ClearsFor   -> "ClearsFor"
+        | OwnershipRelationshipType.CustodiesFor -> "CustodiesFor"
+        | OwnershipRelationshipType.AllocatesTo -> "AllocatesTo"
+        | OwnershipRelationshipType.BanksFor    -> "BanksFor"
+    label |> should equal "BanksFor"

--- a/tests/Meridian.FSharp.Tests/Meridian.FSharp.Tests.fsproj
+++ b/tests/Meridian.FSharp.Tests/Meridian.FSharp.Tests.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="LedgerKernelTests.fs" />
     <Compile Include="DirectLendingInteropTests.fs" />
     <Compile Include="CashFlowProjectorTests.fs" />
+    <Compile Include="AccountDetailsTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Meridian.Tests/Application/FundAccounts/FundAccountServiceTests.cs
+++ b/tests/Meridian.Tests/Application/FundAccounts/FundAccountServiceTests.cs
@@ -1,0 +1,318 @@
+using Meridian.Application.FundAccounts;
+using Meridian.Contracts.FundStructure;
+
+namespace Meridian.Tests.Application.FundAccounts;
+
+public sealed class FundAccountServiceTests
+{
+    private static InMemoryFundAccountService CreateService() => new();
+
+    private static CreateAccountRequest MakeCustodyRequest(
+        Guid? fundId = null,
+        CustodianAccountDetailsDto? details = null) =>
+        new(
+            AccountId: Guid.NewGuid(),
+            AccountType: AccountTypeDto.Custody,
+            AccountCode: $"CUST-{Guid.NewGuid():N}",
+            DisplayName: "JPM Custody",
+            BaseCurrency: "USD",
+            EffectiveFrom: DateTimeOffset.UtcNow,
+            CreatedBy: "test",
+            FundId: fundId,
+            CustodianDetails: details);
+
+    private static CreateAccountRequest MakeBankRequest(
+        Guid? fundId = null,
+        BankAccountDetailsDto? details = null) =>
+        new(
+            AccountId: Guid.NewGuid(),
+            AccountType: AccountTypeDto.Bank,
+            AccountCode: $"BANK-{Guid.NewGuid():N}",
+            DisplayName: "JPM USD Cash",
+            BaseCurrency: "USD",
+            EffectiveFrom: DateTimeOffset.UtcNow,
+            CreatedBy: "test",
+            FundId: fundId,
+            BankDetails: details);
+
+    // ── CreateAccount ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateAccount_WithCustodyType_StoresAndReturnsCustodianDetails()
+    {
+        var svc     = CreateService();
+        var details = new CustodianAccountDetailsDto(
+            SubAccountNumber: "SUB-001",
+            DtcParticipantCode: "0352",
+            CrestMemberCode: null, EuroclearAccountNumber: null,
+            ClearstreamAccountNumber: null, PrimebrokerGiveupCode: null,
+            SafekeepingLocation: "DTC", ServiceAgreementReference: "AGR-2024");
+
+        var result = await svc.CreateAccountAsync(MakeCustodyRequest(details: details));
+
+        Assert.Equal(AccountTypeDto.Custody, result.AccountType);
+        Assert.NotNull(result.CustodianDetails);
+        Assert.Equal("SUB-001", result.CustodianDetails!.SubAccountNumber);
+        Assert.Equal("0352", result.CustodianDetails.DtcParticipantCode);
+        Assert.Equal("DTC", result.CustodianDetails.SafekeepingLocation);
+    }
+
+    [Fact]
+    public async Task CreateAccount_WithBankType_StoresBankAccountDetails()
+    {
+        var svc     = CreateService();
+        var details = new BankAccountDetailsDto(
+            AccountNumber: "00112233",
+            BankName: "JPMorgan Chase",
+            BranchName: null,
+            Iban: "GB29NWBK60161331926819",
+            BicSwift: "CHASUS33",
+            RoutingNumber: "021000021",
+            SortCode: null,
+            IntermediaryBankBic: null, IntermediaryBankName: null,
+            BeneficiaryName: null, BeneficiaryAddress: null);
+
+        var result = await svc.CreateAccountAsync(MakeBankRequest(details: details));
+
+        Assert.Equal(AccountTypeDto.Bank, result.AccountType);
+        Assert.NotNull(result.BankDetails);
+        Assert.Equal("00112233", result.BankDetails!.AccountNumber);
+        Assert.Equal("CHASUS33", result.BankDetails.BicSwift);
+        Assert.Equal("GB29NWBK60161331926819", result.BankDetails.Iban);
+    }
+
+    [Fact]
+    public async Task CreateAccount_Duplicate_ThrowsInvalidOperation()
+    {
+        var svc     = CreateService();
+        var request = MakeCustodyRequest();
+        await svc.CreateAccountAsync(request);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => svc.CreateAccountAsync(request));
+    }
+
+    // ── GetFundAccounts ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetFundAccounts_WithMultipleAccounts_ReturnsSeparatedByType()
+    {
+        var svc    = CreateService();
+        var fundId = Guid.NewGuid();
+
+        await svc.CreateAccountAsync(MakeCustodyRequest(fundId: fundId));
+        await svc.CreateAccountAsync(MakeCustodyRequest(fundId: fundId));
+        await svc.CreateAccountAsync(MakeBankRequest(fundId: fundId));
+        await svc.CreateAccountAsync(MakeBankRequest(fundId: fundId));
+        await svc.CreateAccountAsync(MakeBankRequest(fundId: fundId));
+        // account for a different fund — should not appear
+        await svc.CreateAccountAsync(MakeBankRequest(fundId: Guid.NewGuid()));
+
+        var result = await svc.GetFundAccountsAsync(fundId);
+
+        Assert.Equal(fundId, result.FundId);
+        Assert.Equal(2, result.CustodianAccounts.Count);
+        Assert.Equal(3, result.BankAccounts.Count);
+        Assert.Empty(result.BrokerageAccounts);
+    }
+
+    // ── UpdateCustodianDetails ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateCustodianDetails_ReplacesDetails()
+    {
+        var svc    = CreateService();
+        var req    = MakeCustodyRequest();
+        var acct   = await svc.CreateAccountAsync(req);
+
+        var newDetails = new CustodianAccountDetailsDto(
+            SubAccountNumber: "SUB-999", DtcParticipantCode: "9999",
+            CrestMemberCode: null, EuroclearAccountNumber: null,
+            ClearstreamAccountNumber: null, PrimebrokerGiveupCode: null,
+            SafekeepingLocation: "CREST", ServiceAgreementReference: null);
+
+        var updated = await svc.UpdateCustodianDetailsAsync(
+            acct.AccountId,
+            new UpdateCustodianAccountDetailsRequest(newDetails, "test"));
+
+        Assert.NotNull(updated);
+        Assert.Equal("SUB-999", updated!.CustodianDetails!.SubAccountNumber);
+        Assert.Equal("CREST", updated.CustodianDetails.SafekeepingLocation);
+    }
+
+    [Fact]
+    public async Task UpdateCustodianDetails_UnknownAccount_ReturnsNull()
+    {
+        var svc    = CreateService();
+        var result = await svc.UpdateCustodianDetailsAsync(
+            Guid.NewGuid(),
+            new UpdateCustodianAccountDetailsRequest(
+                new CustodianAccountDetailsDto(null, null, null, null, null, null, null, null),
+                "test"));
+
+        Assert.Null(result);
+    }
+
+    // ── Balance snapshots ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RecordBalanceSnapshot_StoresAndReturnsLatest()
+    {
+        var svc   = CreateService();
+        var acct  = await svc.CreateAccountAsync(MakeBankRequest());
+        var today = DateOnly.FromDateTime(DateTime.Today);
+
+        await svc.RecordBalanceSnapshotAsync(new RecordAccountBalanceSnapshotRequest(
+            acct.AccountId, today, "USD", 1_000_000m, "BankStatement", "test"));
+
+        var latest = await svc.GetLatestBalanceSnapshotAsync(acct.AccountId);
+
+        Assert.NotNull(latest);
+        Assert.Equal(1_000_000m, latest!.CashBalance);
+        Assert.Equal("USD", latest.Currency);
+    }
+
+    [Fact]
+    public async Task GetBalanceHistory_FiltersByDateRange()
+    {
+        var svc  = CreateService();
+        var acct = await svc.CreateAccountAsync(MakeBankRequest());
+
+        var d1 = new DateOnly(2025, 1, 1);
+        var d2 = new DateOnly(2025, 2, 1);
+        var d3 = new DateOnly(2025, 3, 1);
+
+        foreach (var d in new[] { d1, d2, d3 })
+            await svc.RecordBalanceSnapshotAsync(new RecordAccountBalanceSnapshotRequest(
+                acct.AccountId, d, "USD", 100m, "Manual", "test"));
+
+        var results = await svc.GetBalanceHistoryAsync(acct.AccountId, fromDate: d2, toDate: d2);
+
+        Assert.Single(results);
+        Assert.Equal(d2, results[0].AsOfDate);
+    }
+
+    // ── Statement ingestion ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task IngestCustodianStatement_StoresPositionLines()
+    {
+        var svc   = CreateService();
+        var acct  = await svc.CreateAccountAsync(MakeCustodyRequest());
+        var today = DateOnly.FromDateTime(DateTime.Today);
+
+        var lines = new List<CustodianPositionLineDto>
+        {
+            new(Guid.NewGuid(), Guid.NewGuid(), acct.AccountId, today,
+                "US0378331005", "ISIN", 100m, 17_000m, "USD", null, null, false),
+            new(Guid.NewGuid(), Guid.NewGuid(), acct.AccountId, today,
+                "US5949181045", "ISIN", 50m, 11_000m, "USD", null, null, false)
+        };
+
+        var batch = await svc.IngestCustodianStatementAsync(new IngestCustodianStatementRequest(
+            Guid.NewGuid(), acct.AccountId, today, "JPMorgan", "JSON", null, lines, "loader"));
+
+        Assert.Equal(2, batch.LineCount);
+
+        var stored = await svc.GetCustodianPositionsAsync(acct.AccountId, today);
+        Assert.Equal(2, stored.Count);
+    }
+
+    [Fact]
+    public async Task IngestBankStatement_StoresBankLines()
+    {
+        var svc   = CreateService();
+        var acct  = await svc.CreateAccountAsync(MakeBankRequest());
+        var today = DateOnly.FromDateTime(DateTime.Today);
+
+        var lines = new List<BankStatementLineDto>
+        {
+            new(Guid.NewGuid(), Guid.NewGuid(), acct.AccountId, today, today,
+                -50_000m, "USD", "Wire", "Payment to broker", null, 950_000m)
+        };
+
+        var batch = await svc.IngestBankStatementAsync(new IngestBankStatementRequest(
+            Guid.NewGuid(), acct.AccountId, today, "JPMorgan", null, lines, "loader"));
+
+        Assert.Equal(1, batch.LineCount);
+
+        var stored = await svc.GetBankStatementLinesAsync(acct.AccountId);
+        Assert.Single(stored);
+        Assert.Equal(-50_000m, stored[0].Amount);
+    }
+
+    // ── Reconciliation ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ReconcileAccount_WithBalanceSnapshot_ReturnsMatchedRun()
+    {
+        var svc   = CreateService();
+        var acct  = await svc.CreateAccountAsync(MakeBankRequest());
+        var today = DateOnly.FromDateTime(DateTime.Today);
+
+        await svc.RecordBalanceSnapshotAsync(new RecordAccountBalanceSnapshotRequest(
+            acct.AccountId, today, "USD", 500_000m, "BankStatement", "test"));
+
+        var run = await svc.ReconcileAccountAsync(
+            new ReconcileAccountRequest(acct.AccountId, today, "test-user"));
+
+        Assert.NotNull(run);
+        Assert.Equal("Matched", run.Status);
+        Assert.Equal(0, run.TotalBreaks);
+        Assert.True(run.TotalChecks > 0);
+    }
+
+    [Fact]
+    public async Task ReconcileAccount_UnknownAccount_ThrowsInvalidOperation()
+    {
+        var svc = CreateService();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => svc.ReconcileAccountAsync(
+                new ReconcileAccountRequest(Guid.NewGuid(), DateOnly.FromDateTime(DateTime.Today), "test")));
+    }
+
+    [Fact]
+    public async Task GetReconciliationRuns_ReturnsAllRunsForAccount()
+    {
+        var svc   = CreateService();
+        var acct  = await svc.CreateAccountAsync(MakeBankRequest());
+        var today = DateOnly.FromDateTime(DateTime.Today);
+
+        await svc.ReconcileAccountAsync(new ReconcileAccountRequest(acct.AccountId, today, "user-a"));
+        await svc.ReconcileAccountAsync(new ReconcileAccountRequest(acct.AccountId, today, "user-b"));
+
+        var runs = await svc.GetReconciliationRunsAsync(acct.AccountId);
+        Assert.Equal(2, runs.Count);
+    }
+
+    // ── Deactivation ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeactivateAccount_RemovesFromActiveQuery()
+    {
+        var svc    = CreateService();
+        var fundId = Guid.NewGuid();
+        var acct   = await svc.CreateAccountAsync(MakeBankRequest(fundId: fundId));
+
+        await svc.DeactivateAccountAsync(acct.AccountId, "test");
+
+        var query = await svc.QueryAccountsAsync(
+            new AccountStructureQuery(FundId: fundId, ActiveOnly: true));
+
+        Assert.DoesNotContain(query, a => a.AccountId == acct.AccountId);
+    }
+
+    [Fact]
+    public async Task DeactivateAccount_SetsIsActiveToFalse()
+    {
+        var svc  = CreateService();
+        var acct = await svc.CreateAccountAsync(MakeBankRequest());
+
+        var deactivated = await svc.DeactivateAccountAsync(acct.AccountId, "test");
+
+        Assert.NotNull(deactivated);
+        Assert.False(deactivated!.IsActive);
+        Assert.NotNull(deactivated.EffectiveTo);
+    }
+}


### PR DESCRIPTION
Implements multi-account custody and banking infrastructure so each
fund can hold multiple custodian accounts (DTC, CREST, Euroclear,
prime broker) and multiple bank accounts (USD, EUR, GBP cash).

F# domain layer
- FundStructure.fs: CustodianAccountDetails, BankAccountDetails,
  FundAccountDetails DU (Custodian|Bank), AccountDefinition.AccountDetails,
  BanksFor OwnershipRelationshipType case, custodianAccountsForFund /
  bankAccountsForFund filter helpers
- AccountStatements.fs: AccountBalanceSnapshot, CustodianPositionLine,
  BankStatementLine records; FundAccountDetails module helpers
- Interop.AccountDetails.fs: C# callable static helpers

C# contracts
- FundStructureDtos.cs: CustodianAccountDetailsDto, BankAccountDetailsDto,
  AccountBalanceSnapshotDto, FundAccountsDto, position/statement line DTOs,
  AccountSummaryDto extended with detail fields
- FundStructureCommands.cs: UpdateCustodianAccountDetailsRequest,
  UpdateBankAccountDetailsRequest, IngestCustodianStatementRequest,
  IngestBankStatementRequest, RecordAccountBalanceSnapshotRequest,
  ReconcileAccountRequest
- AccountManagementDtos.cs: batch + reconciliation result records
- AccountManagementOptions.cs: Postgres connection options

Application service
- IFundAccountService: 17-method interface (CRUD, fund views,
  balance snapshots, statement ingestion, reconciliation)
- InMemoryFundAccountService: thread-safe implementation (lock gate
  pattern, always available without Postgres)
- FundAccountsStartup: env-var gated configuration, TryAddSingleton
  fallback mirrors SecurityMaster null-stub pattern

Storage layer
- 001_fund_accounts.sql: 8-table schema with JSONB detail columns
- IFundAccountStore: stub interface for future Postgres implementation

REST API
- FundAccountEndpoints: 17 routes at /api/fund-accounts
- UiEndpoints: wired in both MapUiEndpoints call sites

WPF ViewModel
- FundAccountsViewModel: BindableBase with ObservableCollection
  properties and AsyncRelayCommand for load/create/update/snapshot/reconcile
- FundAccountsPage: stub view (full XAML deferred)

Tests
- FundAccountServiceTests: 15 xUnit tests covering all major flows
- AccountDetailsTests: 10 F# tests (DU helpers, filter functions, BanksFor)

https://claude.ai/code/session_017uBkPSeQz4nVsrdhB4ih7J