### PR TITLE
Add DK1 pilot parity runbook, trust rationale, and baseline thresholds; link from dashboard

### DIFF
--- a/docs/status/dk1-baseline-trust-thresholds.md
+++ b/docs/status/dk1-baseline-trust-thresholds.md
@@ -1,0 +1,70 @@
+# DK1 Baseline Trust Thresholds and FP/FN Review Process
+
+**Last Updated:** 2026-04-21  
+**Owners:** Data Operations + Provider Reliability + Trading  
+**Scope:** Baseline trust thresholds for DK1 pilot and required false-positive/false-negative governance loop
+
+---
+
+## Baseline threshold profile (pilot default)
+
+| Metric | Baseline threshold | Breach interpretation | Immediate gate impact |
+|---|---|---|---|
+| Composite trust score | `< 0.80` | Aggregate trust below pilot safety floor | Block parity sign-off for affected window |
+| Connection stability score | `< 0.75` | Session/connectivity instability | Require operator review before trust restoration |
+| Error-rate score | `< 0.85` | Error rate too high for reliable trust claim | Mark window as degraded; no promotion dependency allowed |
+| Latency score | `< 0.80` | Latency outside calibrated normal band | Hold decisions dependent on low-latency parity |
+| Reconnect score | `< 0.70` | Reconnect behavior materially unstable | Keep run in caution/degraded state |
+
+> Thresholds are baseline defaults for DK1 pilot operations and must be recalibrated using current incident windows before broad rollout.
+
+## Severity bands for operator interpretation
+
+| Composite score range | Severity | Operator posture |
+|---|---|---|
+| `>= 0.90` | Healthy | Normal operation |
+| `0.80 - 0.89` | Watch | Continue operation with focused monitoring |
+| `0.70 - 0.79` | Degraded | Restrict parity-sensitive decisions |
+| `< 0.70` | Critical | Treat as trust failure; block gate progress |
+
+---
+
+## False-positive / false-negative review process
+
+### Definitions
+
+- **False positive (FP):** Alert raised, but later review confirms no meaningful trust degradation occurred.
+- **False negative (FN):** No alert raised, but later evidence confirms trust degradation should have been flagged.
+
+### Review cadence
+
+- Weekly DK1 review: classify all pilot-window alerts as TP/FP/FN/TN.
+- Mandatory post-incident review: any critical severity incident triggers same-day FP/FN classification.
+
+### Required evidence packet per review
+
+1. Run-date parity packet from [`dk1-pilot-parity-runbook.md`](./dk1-pilot-parity-runbook.md)
+2. Threshold and calibration context from [`../operations/provider-degradation-calibration.md`](../operations/provider-degradation-calibration.md)
+3. Alert rationale mapping from [`dk1-trust-rationale-mapping.md`](./dk1-trust-rationale-mapping.md)
+
+### Decision workflow
+
+1. **Classify outcomes** (TP/FP/FN/TN) per alert window.
+2. **Quantify impact**
+   - FP rate = `FP / (FP + TP)`
+   - FN rate = `FN / (FN + TP)`
+3. **Apply adjustment rule**
+   - If FP rate > 15%, tighten noisy reason-code thresholds only after confirming FN does not worsen.
+   - If FN rate > 5%, relax sensitivity guardrails to improve recall at degraded/critical severities.
+4. **Document decision**
+   - Record changed thresholds, rationale, approvers, and effective date in weekly review notes.
+5. **Re-run parity evidence**
+   - Execute Wave 1 validation command and attach updated summary artifacts before declaring calibration pass.
+
+### Exit criterion for DK1 calibration gate
+
+DK1 calibration gate can pass only when:
+
+- FP/FN review log is current for the active pilot window.
+- Any threshold changes are documented with approvers and dates.
+- Post-change parity evidence is linked and reproducible.

--- a/docs/status/dk1-pilot-parity-runbook.md
+++ b/docs/status/dk1-pilot-parity-runbook.md
@@ -1,0 +1,68 @@
+# DK1 Pilot Parity Runbook (Alpaca, Robinhood, Yahoo)
+
+**Last Updated:** 2026-04-21  
+**Owners:** Data Operations + Provider Reliability  
+**Scope:** Evidence-backed parity execution for DK1 pilot provider set (Alpaca, Robinhood, Yahoo)
+
+---
+
+## Purpose
+
+Provide a single reproducible runbook that proves DK1 pilot parity against the approved provider-validation evidence set.
+
+## Canonical evidence set (exact links)
+
+### Governing matrix and execution command
+
+- Provider validation matrix (authoritative provider evidence table): [`provider-validation-matrix.md`](./provider-validation-matrix.md)
+- Wave 1 validation command script (must be executed for every parity run): [`scripts/dev/run-wave1-provider-validation.ps1`](../../scripts/dev/run-wave1-provider-validation.ps1)
+- Generated automation outputs (must be attached for the run date):
+  - `artifacts/provider-validation/_automation/<yyyy-mm-dd>/wave1-validation-summary.json`
+  - `artifacts/provider-validation/_automation/<yyyy-mm-dd>/wave1-validation-summary.md`
+
+### Provider-specific evidence links
+
+- **Alpaca row evidence:** [`provider-validation-matrix.md#wave-1-matrix`](./provider-validation-matrix.md#wave-1-matrix) (Alpaca core provider confidence tests)
+- **Robinhood row evidence:** [`provider-validation-matrix.md#wave-1-matrix`](./provider-validation-matrix.md#wave-1-matrix) + runtime packet path `artifacts/provider-validation/robinhood/2026-04-09/`
+- **Yahoo row evidence:** [`provider-validation-matrix.md#wave-1-matrix`](./provider-validation-matrix.md#wave-1-matrix) (historical/fallback test suites)
+
+---
+
+## Run procedure
+
+1. **Sync evidence baseline**
+   - Verify `docs/status/provider-validation-matrix.md` is current for the pilot window.
+2. **Execute Wave 1 command matrix**
+   - Run `./scripts/dev/run-wave1-provider-validation.ps1` from repo root.
+3. **Capture output artifacts**
+   - Archive both generated files from `artifacts/provider-validation/_automation/<yyyy-mm-dd>/`.
+4. **Assemble provider packet**
+   - Confirm Alpaca, Robinhood, Yahoo evidence remains aligned with the matrix row expectations.
+5. **Publish parity packet**
+   - Add links to output artifacts in the weekly DK1 review note and in the dashboard row.
+
+---
+
+## Pass / fail criteria
+
+### Pass
+
+- Wave 1 script exits successfully.
+- Generated JSON/Markdown summaries exist for the run date.
+- No unresolved parity drift between dashboard claim and matrix evidence rows.
+
+### Fail
+
+- Script failure.
+- Missing run-date summary artifacts.
+- Matrix row evidence stale or contradictory to dashboard status.
+
+---
+
+## Operator handoff checklist
+
+- [ ] Run date recorded (UTC).
+- [ ] `wave1-validation-summary.json` linked.
+- [ ] `wave1-validation-summary.md` linked.
+- [ ] Robinhood manual runtime packet linked (if applicable).
+- [ ] Dashboard DK1 parity status updated with evidence references.

--- a/docs/status/dk1-trust-rationale-mapping.md
+++ b/docs/status/dk1-trust-rationale-mapping.md
@@ -1,0 +1,45 @@
+# DK1 Operator Trust Rationale Mapping
+
+**Last Updated:** 2026-04-21  
+**Owners:** Data Operations + Trading  
+**Scope:** Operator-facing trust rationale for DK1 alerts (signal source, reason code, recommended action)
+
+---
+
+## Purpose
+
+Define the required explainability contract for DK1 trust alerts so every alert has:
+
+1. **Signal source** (where the signal came from)
+2. **Reason code** (why the trust state changed)
+3. **Recommended action** (what operator should do next)
+
+## Trust rationale map
+
+| Signal source | Reason code | Operator-facing meaning | Recommended action |
+|---|---|---|---|
+| Provider quote/trade stream health telemetry | `PROVIDER_STREAM_DEGRADED` | Live stream reliability dropped below expected baseline. | Verify provider connectivity + entitlements, then monitor for recovery before promotion decisions. |
+| Provider reconnect monitor | `RECONNECT_INSTABILITY` | Frequent reconnects indicate unstable session quality. | Keep run in observation mode; require stable reconnect window before trusting parity-sensitive outputs. |
+| Error-rate monitor | `ERROR_RATE_SPIKE` | Provider/API errors exceeded acceptable rate for the active window. | Inspect recent provider errors and suppress downstream trust claims until error rate normalizes. |
+| Latency monitor | `LATENCY_REGRESSION` | Data latency moved outside calibrated operational range. | Delay operator promotion actions; review latency trend and compare against baseline window. |
+| Cross-provider parity comparator | `PARITY_DRIFT_DETECTED` | Provider outputs diverge materially from the pilot parity baseline. | Re-run parity packet and treat results as non-promotable until drift is explained or corrected. |
+| Missing data completeness checker | `DATA_COMPLETENESS_GAP` | Expected records/events were missing for the scenario window. | Trigger targeted backfill/replay and block trust sign-off for impacted symbols/windows. |
+| Calibration freshness validator | `CALIBRATION_STALE` | Trust thresholds are based on outdated calibration snapshot. | Run calibration refresh and do not approve threshold-sensitive decisions until freshness is restored. |
+
+---
+
+## Evidence and reference links
+
+- Kernel readiness dashboard DK1 explainability gate: [`kernel-readiness-dashboard.md#dk1---data-quality--provider-trust`](./kernel-readiness-dashboard.md#dk1---data-quality--provider-trust)
+- Provider validation evidence source: [`provider-validation-matrix.md`](./provider-validation-matrix.md)
+- Calibration workflow reference: [`../operations/provider-degradation-calibration.md`](../operations/provider-degradation-calibration.md)
+
+## Minimum operator UX requirement
+
+For every trust alert in pilot operations, the UI/API payload must expose:
+
+- `signalSource`
+- `reasonCode`
+- `recommendedAction`
+
+Alerts missing any field are treated as **explainability failures** for DK1 gate review.

--- a/docs/status/kernel-readiness-dashboard.md
+++ b/docs/status/kernel-readiness-dashboard.md
@@ -1,6 +1,6 @@
 # Kernel Readiness Dashboard (DK Program)
 
-**Last Updated:** 2026-04-20  
+**Last Updated:** 2026-04-21  
 **Program Scope:** Delivery Kernel waves DK1-DK2 mapped to Waves 2-4 in [`ROADMAP.md`](ROADMAP.md)  
 **Purpose:** single hand-authored status dashboard for subsystem kernel readiness, gate progression, implementation commitments, and rollback posture.
 
@@ -26,7 +26,7 @@
 
 | Subsystem | Wave | Owner | Parity | Explainability | Calibration | Operator Sign-off | Kernel Readiness | Next Milestone (Target Date) | Evidence / Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| Data quality + provider trust | DK1 | Data Operations & Provider Reliability owner | 🟡 | 🟡 | ⚪ | ⚪ | At Risk | Complete pilot parity runbook for Alpaca/Robinhood/Yahoo set (2026-05-01) | Must stay synchronized with provider validation matrix and Wave 1 scripts |
+| Data quality + provider trust | DK1 | Data Operations & Provider Reliability owner | 🟡 | 🟡 | 🟡 | ⚪ | At Risk | Complete pilot parity runbook for Alpaca/Robinhood/Yahoo set (2026-05-01) | Evidence pack: [DK1 pilot parity runbook](./dk1-pilot-parity-runbook.md), [trust rationale mapping](./dk1-trust-rationale-mapping.md), [baseline thresholds + FP/FN review](./dk1-baseline-trust-thresholds.md), [provider validation matrix](./provider-validation-matrix.md) |
 | Promotion + paper-trading cockpit | DK1 -> DK2 handoff | Trading Workstation owner | ⚪ | ⚪ | ⚪ | ⚪ | Not Started | Lock promotion-path audit fields + pilot review checklist (2026-05-08) | Depends on DK1 trust explainability and calibrated thresholds |
 | Export + packaging | DK2 | Data Operations Export owner | ⚪ | ⚪ | ⚪ | ⚪ | Not Started | Freeze export schema/version contract for governed pilot outputs (2026-05-15) | Must remain aligned with shared run/portfolio/ledger contract versions |
 | Reconciliation + governance | DK2 | Governance/Fund Ops owner | ⚪ | ⚪ | ⚪ | ⚪ | Not Started | Approve reconciliation tolerance profile + exception playbook (2026-05-22) | Requires promotion/export lineage continuity from DK2 |
@@ -52,16 +52,16 @@
 
 ### Entry checklist
 
-- [x] **Parity entry:** Wave 1 closure evidence remains current and reproducible.
-- [ ] **Explainability entry:** trust signals have operator-visible source and rationale.
-- [ ] **Calibration entry:** baseline trust thresholds are declared for pilot operations.
+- [x] **Parity entry:** Wave 1 closure evidence remains current and reproducible ([DK1 pilot parity runbook](./dk1-pilot-parity-runbook.md)).
+- [ ] **Explainability entry:** trust signals have operator-visible source and rationale ([trust rationale mapping](./dk1-trust-rationale-mapping.md)).
+- [ ] **Calibration entry:** baseline trust thresholds are declared for pilot operations ([baseline thresholds + FP/FN review](./dk1-baseline-trust-thresholds.md)).
 - [ ] **Operator entry:** Data Ops + Trading approve DK1 pilot scope.
 
 ### Exit checklist
 
-- [ ] **Parity pass:** cockpit views match validated provider/replay results for pilot scenarios.
-- [ ] **Explainability pass:** every trust alert maps to source, reason code, and operator action.
-- [ ] **Calibration pass:** thresholds tuned with documented false-positive/false-negative review.
+- [ ] **Parity pass:** cockpit views match validated provider/replay results for pilot scenarios ([DK1 pilot parity runbook](./dk1-pilot-parity-runbook.md)).
+- [ ] **Explainability pass:** every trust alert maps to source, reason code, and operator action ([trust rationale mapping](./dk1-trust-rationale-mapping.md)).
+- [ ] **Calibration pass:** thresholds tuned with documented false-positive/false-negative review ([baseline thresholds + FP/FN review](./dk1-baseline-trust-thresholds.md)).
 - [ ] **Operator sign-off:** Data Ops + Trading owners approve DK1 completion.
 
 ## DK2 - Promotion + export + reconciliation


### PR DESCRIPTION
### Motivation

- The DK1 dashboard referenced artifacts that were missing, leaving parity/explainability/calibration gates without explicit evidence links.  
- Provide operator-facing, evidence-backed artifacts so DK1 gate entry/exit decisions are reproducible and auditable.  
- Surface the artifacts directly from the Kernel Readiness Dashboard so gate closure is traceable to concrete run artifacts.

### Description

- Added `docs/status/dk1-pilot-parity-runbook.md` containing a reproducible parity run procedure for Alpaca/Robinhood/Yahoo with exact evidence links (provider validation matrix, `scripts/dev/run-wave1-provider-validation.ps1`, and expected artifact paths) plus pass/fail and handoff checklist.  
- Added `docs/status/dk1-trust-rationale-mapping.md` with an operator-facing mapping table that ties each trust signal source to a reason code and recommended operator action and defines the minimum alert explainability payload fields.  
- Added `docs/status/dk1-baseline-trust-thresholds.md` defining baseline DK1 trust thresholds, severity bands, and a documented false-positive/false-negative review workflow with cadence, evidence packet, adjustment rules, and exit criteria.  
- Updated `docs/status/kernel-readiness-dashboard.md` to include explicit links to the three new artifacts in the DK1 readiness board row and wired the same links into the DK1 entry/exit checklist items, and updated the dashboard "Last Updated" date.

### Testing

- Verified presence of the new files with a local file-existence check using a short Python script (`python3` file existence check); outcome: pass.  
- Verified relative markdown link resolution across the updated files with a link-check Python script (`python3` link validation); outcome: pass (`all-links-ok`).  
- Verified the Wave 1 validation command script exists (`test -f scripts/dev/run-wave1-provider-validation.ps1 && echo yes`); outcome: `yes`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a16f98388320b57646874314c9fc)