### PR TITLE
Add QuantScript toolbar context globals and date-range validation

### DIFF
--- a/scripts/example-sharpe.csx
+++ b/scripts/example-sharpe.csx
@@ -8,28 +8,40 @@
 ///   1. Open the QuantScript page (sidebar → QuantScript).
 ///   2. Make sure you have local bar data for the chosen symbol (run a backfill
 ///      first if needed: `dotnet run -- --backfill --backfill-symbols SPY ...`).
-///   3. Adjust the parameters in the sidebar or edit the Param<T> calls below.
-///   4. Click Run (▶) to execute.
+///   3. Set Symbol / From / To / Interval in the toolbar if desired.
+///   4. Optionally override values in-script below.
+///   5. Click Run (▶) to execute.
 ///
-/// Parameters (overridable from the sidebar):
-///   Symbol          — ticker to analyse      (default: "SPY")
-///   LookbackMonths  — history window          (default: 12)
+/// Parameters (optional overrides):
+///   SymbolOverride   — explicit ticker override
+///   LookbackMonths   — optional trailing-month override when no date override is supplied
 ///   RiskFreeRate    — annual Rf for Sharpe    (default: 0.04)
+///
+/// Default behavior:
+///   Symbol/From/To/Interval come from the QuantScript toolbar via Context* helpers.
+///   If toolbar values are absent, this script falls back to SPY and a 12-month lookback.
 
 // ── Parameters ───────────────────────────────────────────────────────────────
 
-var symbol         = Param<string>("Symbol",         "SPY",  description: "Ticker symbol to analyse");
-var lookbackMonths = Param<int>   ("LookbackMonths", 12,     min: 1, max: 120,
-                                   description: "Number of months of history to load");
+var contextSymbol = ContextSymbol;
+var contextFrom = ContextFrom;
+var contextTo = ContextTo;
+var contextInterval = ContextInterval ?? "daily";
+
+var symbol         = Param<string>("SymbolOverride",
+                                   string.IsNullOrWhiteSpace(contextSymbol) ? "SPY" : contextSymbol!,
+                                   description: "Ticker symbol override (defaults to toolbar symbol)");
+var lookbackMonths = Param<int>   ("LookbackMonths", 12, min: 1, max: 120,
+                                   description: "Fallback months when toolbar dates are absent");
 var riskFreeRate   = Param<double>("RiskFreeRate",   0.04,   min: 0.0, max: 0.20,
                                    description: "Annual risk-free rate (e.g. 0.04 = 4%)");
 
 // ── Load price data ───────────────────────────────────────────────────────────
 
-var toDate   = DateTime.Today;
-var fromDate = toDate.AddMonths(-lookbackMonths);
+var toDate = (contextTo ?? DateOnly.FromDateTime(DateTime.Today)).ToDateTime(TimeOnly.MinValue);
+var fromDate = (contextFrom ?? DateOnly.FromDateTime(toDate.AddMonths(-lookbackMonths))).ToDateTime(TimeOnly.MinValue);
 
-Print($"Loading {symbol} from {fromDate:d} to {toDate:d} …");
+Print($"Loading {symbol} ({contextInterval}) from {fromDate:d} to {toDate:d} …");
 
 var prices = Data.Prices(symbol, fromDate, toDate);
 

--- a/src/Meridian.QuantScript/Compilation/QuantScriptGlobals.cs
+++ b/src/Meridian.QuantScript/Compilation/QuantScriptGlobals.cs
@@ -18,6 +18,10 @@ public sealed record ConsoleOutputEntry(
 /// </summary>
 public sealed class QuantScriptGlobals
 {
+    private const string ContextSymbolKey = "symbol";
+    private const string ContextFromKey = "from";
+    private const string ContextToKey = "to";
+    private const string ContextIntervalKey = "interval";
     private readonly List<ConsoleOutputEntry> _output = [];
     private readonly object _outputLock = new();
     private IReadOnlyDictionary<string, object?> _parameters;
@@ -106,6 +110,21 @@ public sealed class QuantScriptGlobals
         return defaultValue;
     }
 
+    /// <summary>Toolbar-selected symbol (normalized uppercase), if supplied by the host UI.</summary>
+    public string? ContextSymbol => GetStringContextValue(ContextSymbolKey);
+
+    /// <summary>Toolbar-selected start date, if supplied by the host UI.</summary>
+    public DateOnly? ContextFrom => GetDateOnlyContextValue(ContextFromKey);
+
+    /// <summary>Toolbar-selected end date, if supplied by the host UI.</summary>
+    public DateOnly? ContextTo => GetDateOnlyContextValue(ContextToKey);
+
+    /// <summary>Toolbar-selected interval (for example: daily, weekly, monthly), if supplied by the host UI.</summary>
+    public string? ContextInterval => GetStringContextValue(ContextIntervalKey);
+
+    /// <summary>Convenience helper for scripts that want both context dates in one call.</summary>
+    public (DateOnly? From, DateOnly? To) ContextDateRange() => (ContextFrom, ContextTo);
+
     // ── Cancellation ─────────────────────────────────────────────────────────
     public CancellationToken CancellationToken => _cancellationTokenProvider();
 
@@ -142,5 +161,39 @@ public sealed class QuantScriptGlobals
     {
         _parameters = parameters ?? new Dictionary<string, object?>();
         _cancellationTokenProvider = cancellationTokenProvider ?? throw new ArgumentNullException(nameof(cancellationTokenProvider));
+    }
+
+    private string? GetStringContextValue(string key)
+    {
+        var raw = GetContextValue(key);
+        return raw switch
+        {
+            null => null,
+            string text when string.IsNullOrWhiteSpace(text) => null,
+            string text => text,
+            _ => raw.ToString()
+        };
+    }
+
+    private DateOnly? GetDateOnlyContextValue(string key)
+    {
+        var raw = GetContextValue(key);
+        return raw switch
+        {
+            null => null,
+            DateOnly dateOnly => dateOnly,
+            DateTime dateTime => DateOnly.FromDateTime(dateTime),
+            DateTimeOffset dateTimeOffset => DateOnly.FromDateTime(dateTimeOffset.Date),
+            string text when DateOnly.TryParse(text, out var parsedDateOnly) => parsedDateOnly,
+            string text when DateTime.TryParse(text, out var parsedDateTime) => DateOnly.FromDateTime(parsedDateTime),
+            _ => null
+        };
+    }
+
+    private object? GetContextValue(string key)
+    {
+        if (_parameters.TryGetValue(key, out var value))
+            return value;
+        return _parameters.TryGetValue($"context.{key}", out value) ? value : null;
     }
 }

--- a/src/Meridian.Wpf/ViewModels/QuantScriptViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/QuantScriptViewModel.cs
@@ -283,6 +283,9 @@ public sealed class QuantScriptViewModel : BindableBase, IDisposable
         if (startIndex < 0 || endIndex < startIndex || endIndex >= NotebookCells.Count)
             return false;
 
+        if (!ValidateExecutionDateRange())
+            return false;
+
         ClearResults();
         IsRunning = true;
         StatusText = startIndex == endIndex ? $"Running {NotebookCells[endIndex].Title.ToLowerInvariant()}..." : $"Running cells {startIndex + 1}-{endIndex + 1}...";
@@ -629,7 +632,51 @@ public sealed class QuantScriptViewModel : BindableBase, IDisposable
         _fileWatcher.Renamed += (_, _) => System.Windows.Application.Current?.Dispatcher.InvokeAsync(RefreshScripts, DispatcherPriority.Background);
     }
 
-    private IReadOnlyDictionary<string, object?> BuildParameterDictionary() => Parameters.ToDictionary(parameter => parameter.Name, parameter => parameter.ParsedValue, StringComparer.OrdinalIgnoreCase);
+    private IReadOnlyDictionary<string, object?> BuildParameterDictionary()
+    {
+        var values = Parameters.ToDictionary(parameter => parameter.Name, parameter => parameter.ParsedValue, StringComparer.OrdinalIgnoreCase);
+
+        var normalizedSymbol = string.IsNullOrWhiteSpace(AssetSymbol) ? null : AssetSymbol.Trim().ToUpperInvariant();
+        var normalizedFrom = DateOnly.FromDateTime(FromDate.Date);
+        var normalizedTo = DateOnly.FromDateTime(ToDate.Date);
+        var normalizedInterval = NormalizeInterval(SelectedInterval);
+
+        values["symbol"] = normalizedSymbol;
+        values["from"] = normalizedFrom;
+        values["to"] = normalizedTo;
+        values["interval"] = normalizedInterval;
+
+        // Namespaced aliases keep script access resilient while still supporting helpers.
+        values["context.symbol"] = normalizedSymbol;
+        values["context.from"] = normalizedFrom;
+        values["context.to"] = normalizedTo;
+        values["context.interval"] = normalizedInterval;
+
+        return values;
+    }
+
+    private bool ValidateExecutionDateRange()
+    {
+        if (FromDate.Date <= ToDate.Date)
+            return true;
+
+        var message = $"Invalid date range: From ({FromDate:yyyy-MM-dd}) cannot be after To ({ToDate:yyyy-MM-dd}).";
+        StatusText = message;
+        Diagnostics.Add(new DiagnosticEntry("Validation", message));
+        AppendConsole(message, ConsoleEntryKind.Error);
+        return false;
+    }
+
+    private static string NormalizeInterval(string? interval) => (interval ?? string.Empty).Trim() switch
+    {
+        "Daily (Custom)" => "daily",
+        "Daily" => "daily",
+        "Weekly" => "weekly",
+        "Monthly" => "monthly",
+        var other when string.IsNullOrWhiteSpace(other) => "daily",
+        var other => other.ToLowerInvariant()
+    };
+
     private List<NotebookCellExecutionIdentity> GetCellIdentities() => NotebookCells.Select(cell => new NotebookCellExecutionIdentity(cell.Id, cell.Revision)).ToList();
 
     private void UpdateCellOrdinals()

--- a/tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs
+++ b/tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs
@@ -251,6 +251,29 @@ public sealed class ScriptRunnerTests
         result.ConsoleOutput.Should().Contain("Lookback=50");
     }
 
+    [Fact]
+    public async Task RunAsync_ContextHelpers_ReadToolbarContext()
+    {
+        var runner = BuildRunner();
+        const string source = """
+            var from = ContextFrom.HasValue ? ContextFrom.Value.ToString("yyyy-MM-dd") : "none";
+            var to = ContextTo.HasValue ? ContextTo.Value.ToString("yyyy-MM-dd") : "none";
+            Print($"ctx={ContextSymbol}|{from}|{to}|{ContextInterval}");
+            """;
+        var parameters = new Dictionary<string, object?>
+        {
+            ["symbol"] = "SPY",
+            ["from"] = new DateOnly(2024, 1, 2),
+            ["to"] = new DateOnly(2024, 2, 3),
+            ["interval"] = "daily"
+        };
+
+        var result = await runner.RunAsync(source, parameters);
+
+        result.Success.Should().BeTrue();
+        result.ConsoleOutput.Should().Contain("ctx=SPY|2024-01-02|2024-02-03|daily");
+    }
+
     // ── Null-parameters coercion ──────────────────────────────────────────────
 
     [Fact]

--- a/tests/Meridian.Wpf.Tests/ViewModels/QuantScriptViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/QuantScriptViewModelTests.cs
@@ -154,6 +154,41 @@ public sealed class QuantScriptViewModelTests
         };
         act.Should().NotThrow();
     }
+
+    [Fact]
+    public async Task RunScriptCommand_WhenDateRangeInvalid_BlocksRunAndReportsStatus()
+    {
+        var runner = new FakeScriptRunner();
+        var vm = CreateVm(runner: runner);
+        vm.FromDate = new DateTime(2025, 1, 2);
+        vm.ToDate = new DateTime(2025, 1, 1);
+
+        await vm.RunScriptCommand.ExecuteAsync(null);
+
+        runner.CallCount.Should().Be(0);
+        vm.StatusText.Should().Contain("Invalid date range");
+        vm.Diagnostics.Should().Contain(entry => entry.Key == "Validation");
+    }
+
+    [Fact]
+    public async Task RunScriptCommand_IncludesNormalizedToolbarContextInParameters()
+    {
+        var runner = new FakeScriptRunner();
+        var vm = CreateVm(runner: runner);
+        vm.AssetSymbol = " spy ";
+        vm.FromDate = new DateTime(2024, 1, 2);
+        vm.ToDate = new DateTime(2024, 2, 3);
+        vm.SelectedInterval = "Daily (Custom)";
+
+        await vm.RunScriptCommand.ExecuteAsync(null);
+
+        runner.CallCount.Should().Be(1);
+        runner.LastParameters.Should().NotBeNull();
+        runner.LastParameters!["symbol"].Should().Be("SPY");
+        runner.LastParameters["from"].Should().Be(new DateOnly(2024, 1, 2));
+        runner.LastParameters["to"].Should().Be(new DateOnly(2024, 2, 3));
+        runner.LastParameters["interval"].Should().Be("daily");
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
### Motivation
- Provide a stable, normalized UI context payload so QuantScript scripts can reliably consume toolbar selections (symbol, date range, interval) without brittle string literals.
- Surface invalid toolbar configuration (specifically `FromDate > ToDate`) early and prevent pointless runs while informing the user via `StatusText` and Diagnostics.

### Description
- Extend `QuantScriptViewModel.BuildParameterDictionary()` to always inject normalized toolbar context keys `symbol`, `from`, `to`, `interval` and namespaced aliases `context.*`, derived from `AssetSymbol`, `FromDate`, `ToDate`, and `SelectedInterval` (normalizing symbol casing and interval text). (changes: `src/Meridian.Wpf/ViewModels/QuantScriptViewModel.cs`)
- Add pre-run validation `ValidateExecutionDateRange()` that blocks execution when `FromDate` is after `ToDate`, sets `StatusText`, appends a `DiagnosticEntry`, and writes an error to the console. (changes: `src/Meridian.Wpf/ViewModels/QuantScriptViewModel.cs`)
- Add strongly-typed helpers on the scripting globals so scripts can read toolbar context without brittle lookups: `ContextSymbol`, `ContextFrom`, `ContextTo`, `ContextInterval`, and `ContextDateRange()` with robust coercion from multiple payload types. (changes: `src/Meridian.QuantScript/Compilation/QuantScriptGlobals.cs`)
- Update the sample script `scripts/example-sharpe.csx` to demonstrate using `Context*` helpers and fallback override behavior, and add unit tests to cover the view-model validation and context propagation. (changes: `scripts/example-sharpe.csx`, `tests/Meridian.Wpf.Tests/ViewModels/QuantScriptViewModelTests.cs`, `tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs`)

### Testing
- Attempted to run the project tests with `dotnet test tests/Meridian.QuantScript.Tests/Meridian.QuantScript.Tests.csproj -c Release --nologo`, but the command failed in this environment because the `dotnet` CLI is not available (`/bin/bash: dotnet: command not found`).
- Added unit tests (not executed here): `RunScriptCommand_WhenDateRangeInvalid_BlocksRunAndReportsStatus` and `RunScriptCommand_IncludesNormalizedToolbarContextInParameters` in `tests/Meridian.Wpf.Tests/ViewModels/QuantScriptViewModelTests.cs`, and `RunAsync_ContextHelpers_ReadToolbarContext` in `tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a32e0fa88320a118d595a66a9ba8)