### PR TITLE
Add candlestick plotting and heatmap label validation to PlotRenderBehavior

### DIFF
--- a/src/Meridian.Wpf/Behaviors/PlotRenderBehavior.cs
+++ b/src/Meridian.Wpf/Behaviors/PlotRenderBehavior.cs
@@ -3,6 +3,7 @@ using Meridian.QuantScript.Plotting;
 using Meridian.Ui.Services.Services;
 using ScottPlot;
 using ScottPlot.WPF;
+using TickGenerators = ScottPlot.TickGenerators;
 using Palette = Meridian.Ui.Services.Services.ColorPalette;
 
 namespace Meridian.Wpf.Behaviors;
@@ -62,7 +63,8 @@ public static class PlotRenderBehavior
             or PlotType.Scatter
             or PlotType.Bar
             or PlotType.Histogram
-            or PlotType.MultiLine;
+            or PlotType.MultiLine
+            or PlotType.Candlestick;
 
         if (request.Series is not { Count: > 0 } &&
             request.MultiSeries is not { Count: > 0 } &&
@@ -115,17 +117,30 @@ public static class PlotRenderBehavior
             case PlotType.Heatmap:
                 if (request.HeatmapData is { Length: > 0 } heatmapData)
                 {
-                    var rowCount = heatmapData.Length;
-                    var columnCount = heatmapData[0].Length;
-                    var matrix = new double[rowCount, columnCount];
-
-                    for (var row = 0; row < rowCount; row++)
+                    if (!TryConvertHeatmapMatrix(heatmapData, out var matrix, out var heatmapDiagnostic))
                     {
-                        for (var column = 0; column < columnCount; column++)
-                            matrix[row, column] = heatmapData[row][column];
+                        WriteInvalidStructureDiagnostic(request, heatmapDiagnostic);
+                        break;
                     }
 
                     plot.Add.Heatmap(matrix);
+                    ApplyHeatmapLabels(plot, matrix.GetLength(0), matrix.GetLength(1), request.HeatmapLabels, request);
+                }
+                break;
+
+            case PlotType.Candlestick:
+                if (request.Candlestick is { Count: > 0 } candlestick)
+                {
+                    var ohlcs = candlestick
+                        .Select(bar => new OHLC(
+                            open: (double)bar.Open,
+                            high: (double)bar.High,
+                            low: (double)bar.Low,
+                            close: (double)bar.Close,
+                            dateTime: bar.Date.ToDateTime(TimeOnly.MinValue)))
+                        .ToArray();
+
+                    plot.Add.Candlestick(ohlcs);
                 }
                 break;
         }
@@ -138,4 +153,87 @@ public static class PlotRenderBehavior
 
     private static ScottPlot.Color ToScottPlot(ColorPalette.ArgbColor c)
         => new(c.R, c.G, c.B, c.A);
+
+    private static bool TryConvertHeatmapMatrix(
+        double[][] heatmapData,
+        out double[,] matrix,
+        out string diagnostic)
+    {
+        matrix = new double[0, 0];
+        diagnostic = string.Empty;
+
+        if (heatmapData.Length == 0)
+        {
+            diagnostic = "HeatmapData must contain at least one row.";
+            return false;
+        }
+
+        if (heatmapData[0] is not { Length: > 0 })
+        {
+            diagnostic = "HeatmapData first row must contain at least one value.";
+            return false;
+        }
+
+        var rowCount = heatmapData.Length;
+        var columnCount = heatmapData[0].Length;
+
+        for (var row = 0; row < rowCount; row++)
+        {
+            if (heatmapData[row] is not { Length: > 0 })
+            {
+                diagnostic = $"HeatmapData row {row} is null or empty.";
+                return false;
+            }
+
+            if (heatmapData[row].Length != columnCount)
+            {
+                diagnostic =
+                    $"HeatmapData row {row} has {heatmapData[row].Length} columns; expected {columnCount}.";
+                return false;
+            }
+        }
+
+        matrix = new double[rowCount, columnCount];
+        for (var row = 0; row < rowCount; row++)
+        {
+            for (var column = 0; column < columnCount; column++)
+                matrix[row, column] = heatmapData[row][column];
+        }
+
+        return true;
+    }
+
+    private static void ApplyHeatmapLabels(
+        Plot plot,
+        int rowCount,
+        int columnCount,
+        string[]? heatmapLabels,
+        PlotRequest request)
+    {
+        if (heatmapLabels is not { Length: > 0 })
+            return;
+
+        var xCount = Math.Min(columnCount, heatmapLabels.Length);
+        var yCount = Math.Min(rowCount, heatmapLabels.Length);
+
+        if (xCount != columnCount || yCount != rowCount)
+        {
+            WriteInvalidStructureDiagnostic(
+                request,
+                $"HeatmapLabels count ({heatmapLabels.Length}) does not match matrix dimensions ({rowCount}x{columnCount}). Labels were truncated.");
+        }
+
+        var xPositions = Enumerable.Range(0, xCount).Select(static i => (double)i).ToArray();
+        var yPositions = Enumerable.Range(0, yCount).Select(static i => (double)i).ToArray();
+        var xLabels = heatmapLabels.Take(xCount).ToArray();
+        var yLabels = heatmapLabels.Take(yCount).ToArray();
+
+        plot.Axes.Bottom.TickGenerator = new TickGenerators.NumericManual(xPositions, xLabels);
+        plot.Axes.Left.TickGenerator = new TickGenerators.NumericManual(yPositions, yLabels);
+    }
+
+    private static void WriteInvalidStructureDiagnostic(PlotRequest request, string reason)
+    {
+        Console.WriteLine($"[PlotRenderBehavior] Invalid plot request for '{request.Title}' ({request.Type}): {reason}");
+    }
 }

--- a/tests/Meridian.Wpf.Tests/Views/PlotRenderBehaviorTests.cs
+++ b/tests/Meridian.Wpf.Tests/Views/PlotRenderBehaviorTests.cs
@@ -1,0 +1,95 @@
+using System.IO;
+using ScottPlot.WPF;
+using Meridian.QuantScript.Api;
+using Meridian.QuantScript.Plotting;
+using Meridian.Wpf.Behaviors;
+using Meridian.Wpf.Tests.Support;
+
+namespace Meridian.Wpf.Tests.Views;
+
+public sealed class PlotRenderBehaviorTests
+{
+    [Fact]
+    public void CandlestickRequest_RendersCandlestickPlottable_AndDateAxisTicks()
+    {
+        WpfTestThread.Run(() =>
+        {
+            var request = new PlotRequest(
+                Title: "Candles",
+                Type: PlotType.Candlestick,
+                Candlestick:
+                [
+                    new PriceBar(new DateOnly(2025, 1, 2), 100m, 105m, 99m, 104m, 1000),
+                    new PriceBar(new DateOnly(2025, 1, 3), 104m, 106m, 102m, 103m, 1100)
+                ]);
+
+            var plot = new WpfPlot();
+            PlotRenderBehavior.SetRequest(plot, request);
+
+            plot.Plot.GetPlottables().Select(p => p.GetType().Name)
+                .Should().Contain(typeName => typeName.Contains("Candlestick", StringComparison.Ordinal));
+
+            plot.Plot.Axes.Bottom.TickGenerator.GetType().Name
+                .Should().Contain("DateTime", StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void HeatmapRequest_WithLabels_UsesManualAxisTicks()
+    {
+        WpfTestThread.Run(() =>
+        {
+            var request = new PlotRequest(
+                Title: "Correlation",
+                Type: PlotType.Heatmap,
+                HeatmapData:
+                [
+                    [1.0, 0.4],
+                    [0.4, 1.0]
+                ],
+                HeatmapLabels: ["AAPL", "MSFT"]);
+
+            var plot = new WpfPlot();
+            PlotRenderBehavior.SetRequest(plot, request);
+
+            plot.Plot.Axes.Bottom.TickGenerator.GetType().Name
+                .Should().Contain("NumericManual", StringComparison.Ordinal);
+
+            plot.Plot.Axes.Left.TickGenerator.GetType().Name
+                .Should().Contain("NumericManual", StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void HeatmapRequest_WithIrregularMatrix_WritesDiagnostic_AndSkipsHeatmap()
+    {
+        WpfTestThread.Run(() =>
+        {
+            var request = new PlotRequest(
+                Title: "BadMatrix",
+                Type: PlotType.Heatmap,
+                HeatmapData:
+                [
+                    [1.0, 0.5],
+                    [0.8]
+                ]);
+
+            var plot = new WpfPlot();
+            var originalOut = Console.Out;
+            using var writer = new StringWriter();
+
+            try
+            {
+                Console.SetOut(writer);
+                PlotRenderBehavior.SetRequest(plot, request);
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+
+            writer.ToString().Should().Contain("Invalid plot request", StringComparison.Ordinal);
+            plot.Plot.GetPlottables().Should().BeEmpty();
+        });
+    }
+}


### PR DESCRIPTION
### Motivation
- Enable rendering of OHLC candlestick charts from `PlotRequest.Candlestick` so scripts can display financial bars using the same date-axis behaviour as other time series.
- Make heatmap output self-describing by mapping `PlotRequest.HeatmapLabels` to axis ticks/annotations so correlation/factor matrices are interpretable without external lookups.
- Prevent silent failures when heatmap matrices are empty or irregular by validating matrix shape and emitting diagnostics instead of attempting to render invalid data.

### Description
- Added `PlotType.Candlestick` handling in `src/Meridian.Wpf/Behaviors/PlotRenderBehavior.cs` that converts `PriceBar` entries into ScottPlot `OHLC` values and calls `plot.Add.Candlestick(...)`, and included candlesticks in the existing `DateTimeTicksBottom()` path.
- Implemented heatmap shape validation via `TryConvertHeatmapMatrix(...)` to ensure non-empty, rectangular matrices before building the `double[,]` heatmap matrix.
- Implemented `ApplyHeatmapLabels(...)` that maps `PlotRequest.HeatmapLabels` to `NumericManual` tick generators on the bottom and left axes and emits a diagnostic when label count does not match matrix dimensions (labels are truncated safely).
- Added `WriteInvalidStructureDiagnostic(...)` to surface structural errors to the console when a plot request is invalid.
- Added behavior-level tests at `tests/Meridian.Wpf.Tests/Views/PlotRenderBehaviorTests.cs` covering candlestick plottable + date-axis behaviour, heatmap label tick mapping, and irregular-matrix diagnostic + skip-render behaviour.

### Testing
- No automated tests were executed locally because the runtime toolchain is not available in this environment; `dotnet --info` returned `dotnet: command not found` and `dotnet restore` could not be run here.
- New tests were added under `tests/Meridian.Wpf.Tests/Views/PlotRenderBehaviorTests.cs` and are intended to run on CI/Windows where the WPF test project is enabled.
- Changes were committed and are ready for CI to run `dotnet test` (Windows) to validate the behaviour-level tests; please run the CI pipeline to confirm passing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a32efbd08320b63b1dcd3a931f5e)