### PR TITLE
QuantScript: Strongly-typed parameter bindings and inline validation UX

### DIFF
--- a/src/Meridian.Wpf/Models/QuantScriptModels.cs
+++ b/src/Meridian.Wpf/Models/QuantScriptModels.cs
@@ -1,6 +1,7 @@
 using Meridian.QuantScript.Documents;
 using Meridian.QuantScript.Plotting;
 using Meridian.Wpf.ViewModels;
+using System.Globalization;
 
 namespace Meridian.Wpf.Models;
 
@@ -181,7 +182,8 @@ public sealed class ParameterViewModel : BindableBase
         Name = name;
         ParameterType = parameterType ?? typeof(string);
         _parsedValue = defaultValue;
-        _rawValue = defaultValue?.ToString() ?? string.Empty;
+        _rawValue = FormatValue(defaultValue);
+        Validate();
     }
 
     public string Name { get; }
@@ -197,23 +199,251 @@ public sealed class ParameterViewModel : BindableBase
         }
     }
 
+    public bool BoolValue
+    {
+        get => ParsedValue is bool value && value;
+        set
+        {
+            if (!IsBoolean)
+                return;
+            SetTypedValue(value);
+        }
+    }
+
+    public decimal? NumericValue
+    {
+        get
+        {
+            if (!IsNumeric || ParsedValue is null)
+                return null;
+            return Convert.ToDecimal(ParsedValue, CultureInfo.InvariantCulture);
+        }
+        set
+        {
+            if (!IsNumeric)
+                return;
+            if (value is null)
+            {
+                RawValue = string.Empty;
+                return;
+            }
+
+            SetTypedValue(ConvertNumericFromDecimal(value.Value));
+        }
+    }
+
+    public string StringValue
+    {
+        get => RawValue;
+        set => RawValue = value ?? string.Empty;
+    }
+
+    public bool IsBoolean => GetUnderlyingType(ParameterType) == typeof(bool);
+    public bool IsNumeric => IsNumericType(GetUnderlyingType(ParameterType));
+
     public bool IsValid { get => _isValid; private set => SetProperty(ref _isValid, value); }
     public string? ValidationMessage { get => _validationMessage; private set => SetProperty(ref _validationMessage, value); }
     public object? ParsedValue { get => _parsedValue; private set => SetProperty(ref _parsedValue, value); }
 
     private void Validate()
     {
-        try
+        if (TryParseRawValue(_rawValue, out var parsed, out var validationMessage))
         {
-            ParsedValue = Convert.ChangeType(_rawValue, ParameterType);
+            ParsedValue = parsed;
             IsValid = true;
             ValidationMessage = null;
+            RaiseTypedPropertyChanged();
+            return;
+        }
+
+        IsValid = false;
+        ValidationMessage = validationMessage;
+        ParsedValue = null;
+        RaiseTypedPropertyChanged();
+    }
+
+    private void SetTypedValue(object? value)
+    {
+        var formatted = FormatValue(value);
+        if (string.Equals(_rawValue, formatted, StringComparison.Ordinal))
+        {
+            Validate();
+            return;
+        }
+
+        RawValue = formatted;
+    }
+
+    private bool TryParseRawValue(string rawValue, out object? parsedValue, out string? errorMessage)
+    {
+        var targetType = GetUnderlyingType(ParameterType);
+        var normalized = rawValue?.Trim() ?? string.Empty;
+
+        if (targetType == typeof(string))
+        {
+            parsedValue = rawValue ?? string.Empty;
+            errorMessage = null;
+            return true;
+        }
+
+        if (targetType != typeof(bool) && string.IsNullOrWhiteSpace(normalized))
+        {
+            parsedValue = null;
+            errorMessage = $"Invalid {targetType.Name} value";
+            return false;
+        }
+
+        if (targetType == typeof(bool))
+        {
+            if (TryParseBoolean(normalized, out var boolValue))
+            {
+                parsedValue = boolValue;
+                errorMessage = null;
+                return true;
+            }
+
+            parsedValue = null;
+            errorMessage = "Expected true or false";
+            return false;
+        }
+
+        if (targetType.IsEnum)
+        {
+            if (Enum.TryParse(targetType, normalized, true, out var enumValue))
+            {
+                parsedValue = enumValue;
+                errorMessage = null;
+                return true;
+            }
+
+            parsedValue = null;
+            errorMessage = $"Invalid {targetType.Name} value";
+            return false;
+        }
+
+        if (TryParseNumeric(targetType, normalized, out parsedValue))
+        {
+            errorMessage = null;
+            return true;
+        }
+
+        try
+        {
+            parsedValue = Convert.ChangeType(rawValue, targetType, CultureInfo.InvariantCulture);
+            errorMessage = null;
+            return true;
         }
         catch
         {
-            IsValid = false;
-            ValidationMessage = $"Invalid {ParameterType.Name} value";
-            ParsedValue = null;
+            parsedValue = null;
+            errorMessage = $"Invalid {targetType.Name} value";
+            return false;
         }
+    }
+
+    private static bool TryParseBoolean(string rawValue, out bool value)
+    {
+        if (bool.TryParse(rawValue, out value))
+            return true;
+
+        return rawValue.ToLowerInvariant() switch
+        {
+            "1" or "yes" or "y" or "on" => (value = true) == true,
+            "0" or "no" or "n" or "off" => (value = false) == false,
+            _ => false
+        };
+    }
+
+    private static bool TryParseNumeric(Type type, string rawValue, out object? value)
+    {
+        var styles = NumberStyles.Number;
+        var culture = CultureInfo.InvariantCulture;
+        if (type == typeof(int))
+        {
+            var parsed = int.TryParse(rawValue, styles, culture, out var intValue);
+            value = intValue;
+            return parsed;
+        }
+        if (type == typeof(long))
+        {
+            var parsed = long.TryParse(rawValue, styles, culture, out var longValue);
+            value = longValue;
+            return parsed;
+        }
+        if (type == typeof(float))
+        {
+            var parsed = float.TryParse(rawValue, styles, culture, out var floatValue);
+            value = floatValue;
+            return parsed;
+        }
+        if (type == typeof(double))
+        {
+            var parsed = double.TryParse(rawValue, styles, culture, out var doubleValue);
+            value = doubleValue;
+            return parsed;
+        }
+        if (type == typeof(decimal))
+        {
+            var parsed = decimal.TryParse(rawValue, styles, culture, out var decimalValue);
+            value = decimalValue;
+            return parsed;
+        }
+        if (type == typeof(short))
+        {
+            var parsed = short.TryParse(rawValue, styles, culture, out var shortValue);
+            value = shortValue;
+            return parsed;
+        }
+        if (type == typeof(byte))
+        {
+            var parsed = byte.TryParse(rawValue, styles, culture, out var byteValue);
+            value = byteValue;
+            return parsed;
+        }
+
+        value = null;
+        return false;
+    }
+
+    private object ConvertNumericFromDecimal(decimal value)
+    {
+        var targetType = GetUnderlyingType(ParameterType);
+        return targetType == typeof(int) ? decimal.ToInt32(value)
+            : targetType == typeof(long) ? decimal.ToInt64(value)
+            : targetType == typeof(float) ? (float)value
+            : targetType == typeof(double) ? (double)value
+            : targetType == typeof(decimal) ? value
+            : targetType == typeof(short) ? decimal.ToInt16(value)
+            : targetType == typeof(byte) ? decimal.ToByte(value)
+            : value;
+    }
+
+    private static string FormatValue(object? value)
+    {
+        if (value is null)
+            return string.Empty;
+
+        return value switch
+        {
+            bool boolValue => boolValue ? bool.TrueString : bool.FalseString,
+            IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+            _ => value.ToString() ?? string.Empty
+        };
+    }
+
+    private static Type GetUnderlyingType(Type type) => Nullable.GetUnderlyingType(type) ?? type;
+    private static bool IsNumericType(Type type) => type == typeof(int)
+        || type == typeof(long)
+        || type == typeof(float)
+        || type == typeof(double)
+        || type == typeof(decimal)
+        || type == typeof(short)
+        || type == typeof(byte);
+
+    private void RaiseTypedPropertyChanged()
+    {
+        RaisePropertyChanged(nameof(BoolValue));
+        RaisePropertyChanged(nameof(NumericValue));
+        RaisePropertyChanged(nameof(StringValue));
     }
 }

--- a/src/Meridian.Wpf/ViewModels/QuantScriptViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/QuantScriptViewModel.cs
@@ -188,7 +188,8 @@ public sealed class QuantScriptViewModel : BindableBase, IDisposable
     public string StatusText { get => _statusText; private set => SetProperty(ref _statusText, value); }
     public string ElapsedText { get => _elapsedText; private set => SetProperty(ref _elapsedText, value); }
     public string MemoryText { get => _memoryText; private set => SetProperty(ref _memoryText, value); }
-    public bool CanRun => !IsRunning && SelectedCell is not null;
+    public bool HasInvalidParameters => Parameters.Any(parameter => !parameter.IsValid);
+    public bool CanRun => !IsRunning && SelectedCell is not null && !HasInvalidParameters;
     public int ActiveResultsTab { get => _activeResultsTab; set => SetProperty(ref _activeResultsTab, value); }
 
     public IAsyncRelayCommand RunScriptCommand { get; }
@@ -590,6 +591,8 @@ public sealed class QuantScriptViewModel : BindableBase, IDisposable
 
     private void RefreshParameters()
     {
+        foreach (var parameter in Parameters)
+            parameter.PropertyChanged -= OnParameterPropertyChanged;
         Parameters.Clear();
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var cell in NotebookCells)
@@ -598,9 +601,15 @@ public sealed class QuantScriptViewModel : BindableBase, IDisposable
             {
                 if (!seen.Add(descriptor.Name))
                     continue;
-                Parameters.Add(new ParameterViewModel(descriptor.Name, descriptor.DefaultValue, ResolveParameterType(descriptor.TypeName)));
+                var parameter = new ParameterViewModel(descriptor.Name, descriptor.DefaultValue, ResolveParameterType(descriptor.TypeName));
+                parameter.PropertyChanged += OnParameterPropertyChanged;
+                Parameters.Add(parameter);
             }
         }
+
+        RaisePropertyChanged(nameof(HasInvalidParameters));
+        RaisePropertyChanged(nameof(CanRun));
+        NotifyCommandStateChanged();
     }
 
     private static Type ResolveParameterType(string? typeName) => (typeName ?? string.Empty).ToLowerInvariant() switch
@@ -693,5 +702,15 @@ public sealed class QuantScriptViewModel : BindableBase, IDisposable
         RefreshScriptsCommand.NotifyCanExecuteChanged();
         AddCellCommand.NotifyCanExecuteChanged();
         DeleteCellCommand.NotifyCanExecuteChanged();
+    }
+
+    private void OnParameterPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(ParameterViewModel.IsValid) && e.PropertyName != nameof(ParameterViewModel.ValidationMessage))
+            return;
+
+        RaisePropertyChanged(nameof(HasInvalidParameters));
+        RaisePropertyChanged(nameof(CanRun));
+        NotifyCommandStateChanged();
     }
 }

--- a/src/Meridian.Wpf/Views/QuantScriptPage.xaml
+++ b/src/Meridian.Wpf/Views/QuantScriptPage.xaml
@@ -14,52 +14,148 @@
     <behaviors:ParameterTemplateSelector x:Key="ParamSelector">
       <behaviors:ParameterTemplateSelector.NumericTemplate>
         <DataTemplate DataType="{x:Type models:ParameterViewModel}">
-          <DockPanel Margin="0,3">
-            <TextBlock DockPanel.Dock="Left"
-                       Width="100"
+          <Grid Margin="0,3">
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="100" />
+              <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0"
                        VerticalAlignment="Center"
                        FontSize="11"
                        Foreground="{StaticResource ConsoleTextSecondaryBrush}"
                        Text="{Binding Name}" />
-            <TextBox FontSize="11"
-                     Padding="6,4"
-                     Background="{StaticResource ConsoleBackgroundMediumBrush}"
-                     BorderBrush="{StaticResource ConsoleBorderBrush}"
-                     Foreground="{StaticResource ConsoleTextPrimaryBrush}"
-                     Text="{Binding RawValue, UpdateSourceTrigger=PropertyChanged}" />
-          </DockPanel>
+            <StackPanel Grid.Column="1">
+              <TextBox FontSize="11"
+                       Padding="6,4"
+                       Background="{StaticResource ConsoleBackgroundMediumBrush}"
+                       Foreground="{StaticResource ConsoleTextPrimaryBrush}"
+                       Text="{Binding RawValue, UpdateSourceTrigger=PropertyChanged}"
+                       ToolTip="{Binding ValidationMessage}">
+                <TextBox.Style>
+                  <Style TargetType="TextBox">
+                    <Setter Property="BorderBrush" Value="{StaticResource ConsoleBorderBrush}" />
+                    <Style.Triggers>
+                      <DataTrigger Binding="{Binding IsValid}" Value="False">
+                        <Setter Property="BorderBrush" Value="{StaticResource ErrorColorBrush}" />
+                      </DataTrigger>
+                    </Style.Triggers>
+                  </Style>
+                </TextBox.Style>
+              </TextBox>
+              <TextBlock Margin="2,2,0,0"
+                         FontSize="10"
+                         Foreground="{StaticResource ErrorColorBrush}"
+                         Text="{Binding ValidationMessage}">
+                <TextBlock.Style>
+                  <Style TargetType="TextBlock">
+                    <Setter Property="Visibility" Value="Collapsed" />
+                    <Style.Triggers>
+                      <DataTrigger Binding="{Binding IsValid}" Value="False">
+                        <Setter Property="Visibility" Value="Visible" />
+                      </DataTrigger>
+                    </Style.Triggers>
+                  </Style>
+                </TextBlock.Style>
+              </TextBlock>
+            </StackPanel>
+          </Grid>
         </DataTemplate>
       </behaviors:ParameterTemplateSelector.NumericTemplate>
       <behaviors:ParameterTemplateSelector.TextTemplate>
         <DataTemplate DataType="{x:Type models:ParameterViewModel}">
-          <DockPanel Margin="0,3">
-            <TextBlock DockPanel.Dock="Left"
-                       Width="100"
+          <Grid Margin="0,3">
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="100" />
+              <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0"
                        VerticalAlignment="Center"
                        FontSize="11"
                        Foreground="{StaticResource ConsoleTextSecondaryBrush}"
                        Text="{Binding Name}" />
-            <TextBox FontSize="11"
-                     Padding="6,4"
-                     Background="{StaticResource ConsoleBackgroundMediumBrush}"
-                     BorderBrush="{StaticResource ConsoleBorderBrush}"
-                     Foreground="{StaticResource ConsoleTextPrimaryBrush}"
-                     Text="{Binding RawValue, UpdateSourceTrigger=PropertyChanged}" />
-          </DockPanel>
+            <StackPanel Grid.Column="1">
+              <TextBox FontSize="11"
+                       Padding="6,4"
+                       Background="{StaticResource ConsoleBackgroundMediumBrush}"
+                       Foreground="{StaticResource ConsoleTextPrimaryBrush}"
+                       Text="{Binding StringValue, UpdateSourceTrigger=PropertyChanged}"
+                       ToolTip="{Binding ValidationMessage}">
+                <TextBox.Style>
+                  <Style TargetType="TextBox">
+                    <Setter Property="BorderBrush" Value="{StaticResource ConsoleBorderBrush}" />
+                    <Style.Triggers>
+                      <DataTrigger Binding="{Binding IsValid}" Value="False">
+                        <Setter Property="BorderBrush" Value="{StaticResource ErrorColorBrush}" />
+                      </DataTrigger>
+                    </Style.Triggers>
+                  </Style>
+                </TextBox.Style>
+              </TextBox>
+              <TextBlock Margin="2,2,0,0"
+                         FontSize="10"
+                         Foreground="{StaticResource ErrorColorBrush}"
+                         Text="{Binding ValidationMessage}">
+                <TextBlock.Style>
+                  <Style TargetType="TextBlock">
+                    <Setter Property="Visibility" Value="Collapsed" />
+                    <Style.Triggers>
+                      <DataTrigger Binding="{Binding IsValid}" Value="False">
+                        <Setter Property="Visibility" Value="Visible" />
+                      </DataTrigger>
+                    </Style.Triggers>
+                  </Style>
+                </TextBlock.Style>
+              </TextBlock>
+            </StackPanel>
+          </Grid>
         </DataTemplate>
       </behaviors:ParameterTemplateSelector.TextTemplate>
       <behaviors:ParameterTemplateSelector.BoolTemplate>
         <DataTemplate DataType="{x:Type models:ParameterViewModel}">
-          <DockPanel Margin="0,3">
-            <TextBlock DockPanel.Dock="Left"
-                       Width="100"
+          <Grid Margin="0,3">
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="100" />
+              <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0"
                        VerticalAlignment="Center"
                        FontSize="11"
                        Foreground="{StaticResource ConsoleTextSecondaryBrush}"
                        Text="{Binding Name}" />
-            <CheckBox VerticalAlignment="Center"
-                      IsChecked="{Binding RawValue}" />
-          </DockPanel>
+            <StackPanel Grid.Column="1">
+              <Border Padding="6,4"
+                      BorderThickness="1"
+                      ToolTip="{Binding ValidationMessage}">
+                <Border.Style>
+                  <Style TargetType="Border">
+                    <Setter Property="BorderBrush" Value="{StaticResource ConsoleBorderBrush}" />
+                    <Style.Triggers>
+                      <DataTrigger Binding="{Binding IsValid}" Value="False">
+                        <Setter Property="BorderBrush" Value="{StaticResource ErrorColorBrush}" />
+                      </DataTrigger>
+                    </Style.Triggers>
+                  </Style>
+                </Border.Style>
+                <CheckBox VerticalAlignment="Center"
+                          IsChecked="{Binding BoolValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+              </Border>
+              <TextBlock Margin="2,2,0,0"
+                         FontSize="10"
+                         Foreground="{StaticResource ErrorColorBrush}"
+                         Text="{Binding ValidationMessage}">
+                <TextBlock.Style>
+                  <Style TargetType="TextBlock">
+                    <Setter Property="Visibility" Value="Collapsed" />
+                    <Style.Triggers>
+                      <DataTrigger Binding="{Binding IsValid}" Value="False">
+                        <Setter Property="Visibility" Value="Visible" />
+                      </DataTrigger>
+                    </Style.Triggers>
+                  </Style>
+                </TextBlock.Style>
+              </TextBlock>
+            </StackPanel>
+          </Grid>
         </DataTemplate>
       </behaviors:ParameterTemplateSelector.BoolTemplate>
     </behaviors:ParameterTemplateSelector>


### PR DESCRIPTION
### Motivation
- Ensure parameter controls are type-correct (especially booleans) and provide immediate validation feedback so users can fix inputs before running scripts.
- Centralize parsing/formatting and expose typed accessors so UI templates and the execution layer use consistent, culture-invariant conversions.
- Prevent starting script runs when parameters are invalid to avoid runtime failures caused by bad inputs.

### Description
- `ParameterViewModel` (`src/Meridian.Wpf/Models/QuantScriptModels.cs`) now provides typed helpers `BoolValue`, `NumericValue`, and `StringValue`, plus centralized parse/format logic using `CultureInfo.InvariantCulture` and robust `TryParse` helpers for booleans, enums, and numeric types, and raises typed property notifications on validation changes.
- Parameter initialization now formats default values consistently and runs initial validation so `ParsedValue`/`IsValid` are correct on creation.
- `QuantScriptViewModel` (`src/Meridian.Wpf/ViewModels/QuantScriptViewModel.cs`) now exposes `HasInvalidParameters` and updates `CanRun` so `RunScriptCommand`/`RunAllCommand` are blocked when any parameter `IsValid == false`; it also subscribes to parameter `PropertyChanged` to re-evaluate command state when validation or messages change.
- Parameter templates in XAML (`src/Meridian.Wpf/Views/QuantScriptPage.xaml`) were updated so the bool template binds `CheckBox.IsChecked` to the typed `BoolValue` (two-way), and numeric/text/bool templates show inline validation (error border, tooltip, and visible validation message) to aid correction before execution.

### Testing
- Attempted to build the WPF project with `dotnet build src/Meridian.Wpf/Meridian.Wpf.csproj`, but the environment lacks the .NET SDK and the command failed with `dotnet: command not found` so no compile/run verification could be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a332628c8320b645131077861173)