### PR TITLE
docs: add Security Master governance architecture guard and reviewer guidance

### DIFF
--- a/docs/plans/governance-fund-ops-blueprint.md
+++ b/docs/plans/governance-fund-ops-blueprint.md
@@ -115,6 +115,12 @@ Current expectation:
 - reuse the delivered workstation propagation and drill-in patterns already present across workstation and governance surfaces
 - limit new Security Master work to governance-specific gaps, not baseline productization that is already complete
 
+Governance architecture guard (required):
+
+- Security Master is the sole instrument-definition and instrument-metadata source for governance and fund-ops surfaces.
+- Any governance DTO that carries instrument metadata (symbol, issuer, coupon, maturity, classification, venue, lot/tick parameters, corporate-action context, or similar term fields) must reference Security Master identity/provenance fields (for example `WorkstationSecurityReference` and Security Master IDs/provenance summaries).
+- Governance-local instrument definitions are prohibited unless they are adapter-only ingestion/transformation intermediates that are explicitly mapped back to Security Master identities before workstation DTO publication or persistence.
+
 ### Layer 2: Fund accounting and multi-ledger kernel
 
 Extend the ledger model to support:
@@ -559,6 +565,8 @@ Current delivered slice: report-pack preview contracts and a shared preview endp
 - [ ] Keep F# kernels pure and deterministic wherever possible.
 - [ ] Keep WPF code-behind thin; prefer `BindableBase` view models and services.
 - [ ] Reuse existing export and workstation infrastructure before adding new stacks.
+- [ ] PR/review validation: no governance-local instrument definitions unless adapter-only and explicitly mapped to Security Master identity/provenance before exposure.
+- [ ] Reviewer search guidance: inspect governance DTO/service changes for instrument-term fields (for example `Symbol`, `Cusip`, `Isin`, `Coupon`, `Maturity`, `Issuer`, `Venue`, `AssetClass`) introduced without Security Master references/provenance wiring.
 - [ ] Update roadmap, feature inventory, and improvements docs in the same PRs as implementation changes.
 
 ## Suggested first PR slices

--- a/docs/status/FEATURE_INVENTORY.md
+++ b/docs/status/FEATURE_INVENTORY.md
@@ -520,7 +520,7 @@ This section inventories the workflow-centric product model that now sits above 
 | Trading workspace taxonomy | Partial | Command palette and shell terminology align on `Trading`, and the Trading shell now keeps run-scoped versus account-scoped portfolio drill-ins inside the cockpit instead of bouncing operators back to `Research`; cockpit-grade execution UX remains pending |
 | Data Operations workspace taxonomy | Partial | Operational pages are grouped consistently; further cross-links and workflow shells remain |
 | Governance workspace taxonomy | Partial | Portfolio/ledger/diagnostics/settings surfaces are grouped conceptually, and Security Master/reconciliation drill-ins are live; broader governance-first product flows remain incomplete |
-| Governance fund-ops workspace API baseline | Partial | `/api/fund-structure/workspace-view` and `/api/fund-structure/report-pack-preview` now aggregate fund-account state, banking, ledger, reconciliation, NAV attribution, and reporting profile previews for a `fundProfileId`; the Governance WPF shell now reuses the same shared projection, while workstation-shell polish and governed artifact generation remain open |
+| Governance fund-ops workspace API baseline | Partial | `/api/fund-structure/workspace-view` and `/api/fund-structure/report-pack-preview` now aggregate fund-account state, banking, ledger, reconciliation, NAV attribution, and reporting profile previews for a `fundProfileId`; the Governance WPF shell now reuses the same shared projection, while workstation-shell polish and governed artifact generation remain open. Guardrail: Security Master is the sole instrument source, and governance DTOs with instrument terms must carry Security Master identity/provenance references. |
 | Shared `StrategyRun` DTO/read-model baseline | Partial | Shared run summary/detail/comparison models exist; paper/live history expansion remains |
 | Shared portfolio read-model baseline | Partial | Portfolio summaries/positions derived from recorded runs exist; equity-history and broader source coverage remain |
 | Shared ledger read-model baseline | Partial | Ledger summaries, journal rows, and trial balance rows exist; account-summary and richer reconciliation UX remain |
@@ -544,6 +544,8 @@ This section inventories the workflow-centric product model that now sits above 
 - **Cash-flow modeling surfaces:** governance-oriented cash-movement and projection views are not yet productized.
 - **Multi-ledger tracking:** governance workflows do not yet expose multiple ledgers, ledger groups, or cross-ledger consolidation explicitly.
 - **Reconciliation engine expansion:** run-scoped reconciliation now exists for recorded strategy runs, but broader position, cash, NAV, external statement, and exception-queue workflows remain incomplete.
+- **Governance architecture review check:** flag governance-local instrument definitions unless they are adapter-only intermediates with explicit mapping to Security Master IDs/provenance before downstream DTO/service exposure.
+- **Reviewer search guidance:** for governance DTO/service diffs, search for instrument terms (`Symbol`, `Cusip`, `Isin`, `Coupon`, `Maturity`, `Issuer`, `Venue`, `AssetClass`) and confirm paired Security Master reference/provenance fields.
 - **Report generation tools:** export infrastructure exists and fund-scoped report-pack preview APIs now expose the first governed slice, but full investor, board, compliance, and fund-ops artifact generation is not yet productized.
 
 ### Remaining work

--- a/docs/status/IMPROVEMENTS.md
+++ b/docs/status/IMPROVEMENTS.md
@@ -1461,6 +1461,8 @@ See [`https://github.com/rodoHasArrived/Meridian/blob/main/archive/docs/INDEX.md
 **Remaining follow-on work:**
 - deepen governance and fund-operations workflows built on top of the delivered baseline through K2 and Wave 4 work
 - reuse Security Master metadata in account/entity, cash-flow, multi-ledger, reconciliation, and reporting workflows instead of creating a parallel governance seam
+- enforce PR/review validation that governance DTOs/services introducing instrument metadata carry Security Master identity/provenance fields, with no governance-local instrument definitions except adapter-only mapped intermediates
+- reviewer search guidance: scan governance DTO/service changes for instrument-term fields (`Symbol`, `Cusip`, `Isin`, `Coupon`, `Maturity`, `Issuer`, `Venue`, `AssetClass`) lacking Security Master references
 
 **ROADMAP:** Phase 12A baseline delivered; follow-ons continue in Phase 12 / Wave 4
 

--- a/docs/status/ROADMAP.md
+++ b/docs/status/ROADMAP.md
@@ -181,6 +181,7 @@ Across Waves 2-4, keep WPF workflow-first consolidation, validation coverage, an
 - add multi-ledger, cash-flow, reconciliation, and reporting slices on top of shared DTOs, read services, and export seams
 - connect external brokerage account state to fund-account review, cash movement, and reconciliation workflows through shared projections
 - deepen governance workflows without creating separate reporting or accounting stacks
+- enforce the governance architecture guard: Security Master remains the sole instrument source, and governance DTO/service additions with instrument metadata must carry Security Master identity/provenance references
 
 **Exit signal:** Governance becomes a real operator workflow with concrete review, drill-in, and governed-output seams built on the same contracts already used elsewhere in the workstation.
 
@@ -350,6 +351,8 @@ The implementation source of truth remains [`kernel-readiness-dashboard.md`](ker
 - **Cockpit hardening should precede live-readiness claims.** Meridian now has meaningful trading surfaces, but operator trust still matters more than feature count.
 - **The shared run model must remain the center of gravity.** If Research, Trading, Portfolio, Ledger, and Governance drift apart again, the workstation migration loses its product logic.
 - **Security Master must remain the authoritative seam.** It should enrich portfolio, ledger, reconciliation, and reporting flows rather than being reimplemented inside parallel governance workflows.
+
+- **Governance DTO/Service review search guidance:** in governance-related PRs, explicitly scan for new instrument-term fields (`Symbol`, `Cusip`, `Isin`, `Coupon`, `Maturity`, `Issuer`, `Venue`, `AssetClass`) that appear without Security Master identity/provenance references. Treat that as a review blocker unless the code is adapter-only with an explicit mapping step back to Security Master.
 - **Governance should extend shared DTOs, not invent a new stack.** Cash-flow, reconciliation, and reporting should reuse the same read-model and export seams already in place.
 - **WPF migration should avoid page-level re-fragmentation.** The right move is more orchestration and view-model or service extraction, not more page-local logic.
 - **Documentation drift is now a real delivery risk.** The planning set is large enough that roadmap, status, blueprint, and short-horizon docs need deliberate synchronization.


### PR DESCRIPTION
### Motivation
- Prevent governance subsystems from introducing parallel instrument definitions by making Security Master the single authoritative instrument-definition source and by adding reviewer guidance and PR checklist items to catch regressions early.

### Description
- Documentation-only changes that add a required "Governance architecture guard" to the governance blueprint, add a PR/review validation checklist item and explicit reviewer search guidance for instrument-term fields, and sync the same guardrail text into `docs/status/ROADMAP.md`, `docs/status/FEATURE_INVENTORY.md`, and `docs/status/IMPROVEMENTS.md` (files modified: `docs/plans/governance-fund-ops-blueprint.md`, `docs/status/ROADMAP.md`, `docs/status/FEATURE_INVENTORY.md`, `docs/status/IMPROVEMENTS.md`).

### Testing
- Ran `git diff --check` to validate there are no trailing whitespace or index issues and the check completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e5f943d08320aba9bb6370b144fe)