### PR TITLE
docs: add Wave 4 objective pass/fail gate tables to roadmap, production-status, and kernel dashboard

### DIFF
--- a/docs/status/ROADMAP.md
+++ b/docs/status/ROADMAP.md
@@ -182,6 +182,17 @@ Across Waves 2-4, keep WPF workflow-first consolidation, validation coverage, an
 - connect external brokerage account state to fund-account review, cash movement, and reconciliation workflows through shared projections
 - deepen governance workflows without creating separate reporting or accounting stacks
 
+
+#### Wave 4 objective pass/fail gate (cockpit-style)
+
+"Wave 4 objective" is **Pass** only when every governance/fund-ops criterion below is green in CI and locally reproducible. It is **Fail** if any criterion is red.
+
+| Criterion | Required endpoint(s) + response fields | Required workstation surface behavior | Fail condition |
+| --- | --- | --- | --- |
+| Security Master conflict lifecycle is traceable end-to-end | `/api/security-master/conflicts`, `/api/security-master/conflicts/{conflictId}`, and `/api/security-master/conflicts/{conflictId}/resolve` must expose `ConflictReasonCode`, source-provenance identifiers, and resolution payload rationale (`ResolutionDecision`, `ResolutionRationale`, `Actor`, `TimestampUtc`, `CorrelationId`). | Operator can **search -> drill-in -> history -> resolution** for one conflicted instrument and see conflict reasons, source provenance, prior resolution history, and final resolution decision in one continuous flow. | Any missing linkage between conflict list/detail/resolution views, missing conflict reason code, missing source provenance, or missing explicit resolution rationale/audit chain in the same scenario run. |
+| Corporate action provenance and parameter versioning remain explainable | `/api/security-master/corporate-actions` and `/api/security-master/trading-parameters` must return event provenance (`CorporateActionSource`, `IngestedAtUtc`) plus effective version fields (`EffectiveVersion`, `EffectiveFromUtc`, `SupersedesVersion`). | Operator can **search -> drill-in -> history -> resolution** from instrument view into corporate-action timeline and trading-parameter history, then resolve a flagged discrepancy with the effective-version trail visible. | Corporate-action timeline lacks provenance, trading-parameter change lacks effective-version traceability, or discrepancy resolution is recorded without explainable source/version linkage. |
+| Governance audit trail is complete across fund-ops decisions | Governance workflow endpoints (`/api/fund-structure/workspace-view`, `/api/fund-structure/report-pack-preview`, and reconciliation decision endpoints) must emit audit metadata (`AuditActor`, `AuditTimestampUtc`, `CorrelationId`) and decision rationale fields for approvals/rejections. | Operator can **search -> drill-in -> history -> resolution** for an account/entity decision, inspect prior decision history, and complete or reject resolution with rationale that remains visible in history and governed output previews. | Any governance decision path that omits actor/timestamp/correlation, fails to retain decision rationale, or breaks history-to-resolution linkage between workspace and governed-output views. |
+
 **Exit signal:** Governance becomes a real operator workflow with concrete review, drill-in, and governed-output seams built on the same contracts already used elsewhere in the workstation.
 
 ### Wave 5: Backtest Studio unification

--- a/docs/status/kernel-readiness-dashboard.md
+++ b/docs/status/kernel-readiness-dashboard.md
@@ -80,6 +80,15 @@
 - [ ] **Calibration pass:** reconciliation exceptions are tuned with no unresolved critical mismatches.
 - [ ] **Operator sign-off:** Trading + Governance owners sign DK2 readiness.
 
+
+#### Governance/fund-ops scenario gate text (mirrors Wave 4 objective pass/fail)
+
+| Criterion | Required endpoint(s) + response fields | Required workstation surface behavior | Fail condition |
+| --- | --- | --- | --- |
+| Security Master conflict lifecycle is traceable end-to-end | `/api/security-master/conflicts`, `/api/security-master/conflicts/{conflictId}`, and `/api/security-master/conflicts/{conflictId}/resolve` must expose `ConflictReasonCode`, source-provenance identifiers, and resolution payload rationale (`ResolutionDecision`, `ResolutionRationale`, `Actor`, `TimestampUtc`, `CorrelationId`). | Operator can **search -> drill-in -> history -> resolution** for one conflicted instrument and see conflict reasons, source provenance, prior resolution history, and final resolution decision in one continuous flow. | Any missing linkage between conflict list/detail/resolution views, missing conflict reason code, missing source provenance, or missing explicit resolution rationale/audit chain in the same scenario run. |
+| Corporate action provenance and parameter versioning remain explainable | `/api/security-master/corporate-actions` and `/api/security-master/trading-parameters` must return event provenance (`CorporateActionSource`, `IngestedAtUtc`) plus effective version fields (`EffectiveVersion`, `EffectiveFromUtc`, `SupersedesVersion`). | Operator can **search -> drill-in -> history -> resolution** from instrument view into corporate-action timeline and trading-parameter history, then resolve a flagged discrepancy with the effective-version trail visible. | Corporate-action timeline lacks provenance, trading-parameter change lacks effective-version traceability, or discrepancy resolution is recorded without explainable source/version linkage. |
+| Governance audit trail is complete across fund-ops decisions | Governance workflow endpoints (`/api/fund-structure/workspace-view`, `/api/fund-structure/report-pack-preview`, and reconciliation decision endpoints) must emit audit metadata (`AuditActor`, `AuditTimestampUtc`, `CorrelationId`) and decision rationale fields for approvals/rejections. | Operator can **search -> drill-in -> history -> resolution** for an account/entity decision, inspect prior decision history, and complete or reject resolution with rationale that remains visible in history and governed output previews. | Any governance decision path that omits actor/timestamp/correlation, fails to retain decision rationale, or breaks history-to-resolution linkage between workspace and governed-output views. |
+
 ---
 
 ## Risk Register and Rollback Tracker

--- a/docs/status/production-status.md
+++ b/docs/status/production-status.md
@@ -104,6 +104,19 @@ Operator-readiness language for Wave 2 should stay “in progress” until the f
 - governance still needs deeper account/entity, multi-ledger, cash-flow, reconciliation, and governed reporting workflows
 - the next governance slices should extend shared DTOs, read models, and export seams instead of creating a second governance stack
 
+
+#### Wave 4 objective pass/fail gate (cockpit-style)
+
+"Wave 4 objective" is **Pass** only when every governance/fund-ops criterion below is green in CI and locally reproducible. It is **Fail** if any criterion is red.
+
+| Criterion | Required endpoint(s) + response fields | Required workstation surface behavior | Fail condition |
+| --- | --- | --- | --- |
+| Security Master conflict lifecycle is traceable end-to-end | `/api/security-master/conflicts`, `/api/security-master/conflicts/{conflictId}`, and `/api/security-master/conflicts/{conflictId}/resolve` must expose `ConflictReasonCode`, source-provenance identifiers, and resolution payload rationale (`ResolutionDecision`, `ResolutionRationale`, `Actor`, `TimestampUtc`, `CorrelationId`). | Operator can **search -> drill-in -> history -> resolution** for one conflicted instrument and see conflict reasons, source provenance, prior resolution history, and final resolution decision in one continuous flow. | Any missing linkage between conflict list/detail/resolution views, missing conflict reason code, missing source provenance, or missing explicit resolution rationale/audit chain in the same scenario run. |
+| Corporate action provenance and parameter versioning remain explainable | `/api/security-master/corporate-actions` and `/api/security-master/trading-parameters` must return event provenance (`CorporateActionSource`, `IngestedAtUtc`) plus effective version fields (`EffectiveVersion`, `EffectiveFromUtc`, `SupersedesVersion`). | Operator can **search -> drill-in -> history -> resolution** from instrument view into corporate-action timeline and trading-parameter history, then resolve a flagged discrepancy with the effective-version trail visible. | Corporate-action timeline lacks provenance, trading-parameter change lacks effective-version traceability, or discrepancy resolution is recorded without explainable source/version linkage. |
+| Governance audit trail is complete across fund-ops decisions | Governance workflow endpoints (`/api/fund-structure/workspace-view`, `/api/fund-structure/report-pack-preview`, and reconciliation decision endpoints) must emit audit metadata (`AuditActor`, `AuditTimestampUtc`, `CorrelationId`) and decision rationale fields for approvals/rejections. | Operator can **search -> drill-in -> history -> resolution** for an account/entity decision, inspect prior decision history, and complete or reject resolution with rationale that remains visible in history and governed output previews. | Any governance decision path that omits actor/timestamp/correlation, fails to retain decision rationale, or breaks history-to-resolution linkage between workspace and governed-output views. |
+
+Wave 4 readiness language should stay "in progress" until the full objective gate above is continuously passing.
+
 Use this file for readiness evidence and operator-facing risk notes; use [`ROADMAP.md`](ROADMAP.md) for full wave sequencing.
 
 ---


### PR DESCRIPTION
### Motivation

- Add a cockpit-style Wave 4 readiness gate so Governance/Fund-Ops has the same objective pass/fail language and acceptance criteria currently used for the Wave 2 cockpit. 
- Make criteria actionable by specifying required API endpoints/response fields, required workstation surface behavior (`search -> drill-in -> history -> resolution`), and explicit fail-condition wording. 
- Keep product and engineering aligned by mirroring the same gate text in the kernel readiness/dashboard scenario tracking.

### Description

- Inserted a "Wave 4 objective pass/fail gate (cockpit-style)" table under Wave 4 in `docs/status/ROADMAP.md` that lists three criteria with required endpoints, response fields, workstation behavior, and fail conditions. 
- Added the same Wave 4 gate table and an explicit "in progress" readiness sentence into `docs/status/production-status.md` near the Wave 4 readiness gates. 
- Mirrored the gate assertions as a "Governance/fund-ops scenario gate text" block under DK2 in `docs/status/kernel-readiness-dashboard.md` so DK reporting and governance scenario language match. 
- Committed updates to the three documentation files.

### Testing

- Ran `git diff --check` which reported no whitespace/format issues and allowed the changes to be staged and committed. 
- Attempted `dotnet build Meridian.sln -nologo` but the environment does not have `dotnet` installed, so compile verification could not be run here (failure: `dotnet: command not found`). 
- Verified the three files were modified and committed (commit performed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e5f6e46083209686fb1f87d8edb7)