### PR TITLE
Refactor promotion approval API to accept full approval payload

### DIFF
--- a/src/Meridian.Ui/dashboard/src/lib/api.trading.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api.trading.test.ts
@@ -12,9 +12,27 @@ describe("trading endpoint wiring", () => {
 
   it("wires promotion endpoints", async () => {
     await evaluatePromotion("run-123");
-    await approvePromotion("run-123", "ok");
+    await approvePromotion({
+      runId: "run-123",
+      approvedBy: "ops-1",
+      approvalReason: "Risk and quality checks passed",
+      reviewNotes: "Reviewed by trading desk",
+      manualOverrideId: "override-42"
+    });
     expect(fetchMock).toHaveBeenCalledWith("/api/promotion/evaluate/run-123", expect.anything());
-    expect(fetchMock).toHaveBeenCalledWith("/api/promotion/approve", expect.objectContaining({ method: "POST" }));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/promotion/approve",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          runId: "run-123",
+          approvedBy: "ops-1",
+          approvalReason: "Risk and quality checks passed",
+          reviewNotes: "Reviewed by trading desk",
+          manualOverrideId: "override-42"
+        })
+      })
+    );
   });
 
   it("wires execution/replay endpoints", async () => {

--- a/src/Meridian.Ui/dashboard/src/lib/api.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api.ts
@@ -102,8 +102,16 @@ export function evaluatePromotion(runId: string) {
   return getJson<PromotionEvaluationResult>(`/api/promotion/evaluate/${encodeURIComponent(runId)}`);
 }
 
-export function approvePromotion(runId: string, reviewNotes?: string) {
-  return postJson<PromotionDecisionResult>("/api/promotion/approve", { runId, reviewNotes });
+export interface ApprovePromotionRequest {
+  runId: string;
+  approvedBy: string;
+  approvalReason: string;
+  reviewNotes?: string;
+  manualOverrideId?: string;
+}
+
+export function approvePromotion(request: ApprovePromotionRequest) {
+  return postJson<PromotionDecisionResult>("/api/promotion/approve", request);
 }
 
 export function rejectPromotion(runId: string, reason: string) {

--- a/src/Meridian.Ui/dashboard/src/screens/trading-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/trading-screen.test.tsx
@@ -80,7 +80,22 @@ vi.mock("@/lib/api", async () => {
     setReplaySpeed: vi.fn().mockResolvedValue({}),
     evaluatePromotion: vi.fn().mockResolvedValue({ runId: "run-1", strategyId: "strat-1", strategyName: "S1", sourceMode: "backtest", targetMode: "paper", isEligible: true, sharpeRatio: 1.2, maxDrawdownPercent: 5, totalReturn: 10, reason: "Eligible", found: true, ready: true }),
     approvePromotion: vi.fn().mockResolvedValue({ success: true, promotionId: "promo-1", newRunId: "paper-1", reason: "approved" }),
-    getPromotionHistory: vi.fn().mockResolvedValue([{ promotionId: "promo-1", strategyId: "strat-1", strategyName: "S1", sourceRunType: "backtest", targetRunType: "paper", qualifyingSharpe: 1.2, qualifyingMaxDrawdownPercent: 5, qualifyingTotalReturn: 10, promotedAt: "2026-01-01" }]),
+    getPromotionHistory: vi.fn().mockResolvedValue([{
+      promotionId: "promo-1",
+      strategyId: "strat-1",
+      strategyName: "S1",
+      sourceRunType: "backtest",
+      targetRunType: "paper",
+      runId: "run-1",
+      approvedBy: "operator-7",
+      approvalReason: "Meets risk constraints",
+      reviewNotes: "Checked replay consistency",
+      manualOverrideId: "override-9",
+      qualifyingSharpe: 1.2,
+      qualifyingMaxDrawdownPercent: 5,
+      qualifyingTotalReturn: 10,
+      promotedAt: "2026-01-01"
+    }]),
     pauseStrategy: vi.fn().mockResolvedValue({ strategyId: "s", action: "pause", success: true, reason: null }),
     stopStrategy: vi.fn().mockResolvedValue({ strategyId: "s", action: "stop", success: true, reason: null })
   };
@@ -112,10 +127,25 @@ describe("TradingScreen", () => {
     const user = userEvent.setup();
     render(<MemoryRouter initialEntries={["/trading"]}><TradingScreen data={data} /></MemoryRouter>);
     await user.type(screen.getByLabelText("Run id"), "run-1");
+    await user.type(screen.getByLabelText("Approved by"), "operator-7");
+    await user.type(screen.getByLabelText("Approval reason"), "Meets risk constraints");
+    await user.type(screen.getByLabelText("Review notes"), "Checked replay consistency");
+    await user.type(screen.getByLabelText("Manual override id"), "override-9");
     await user.click(screen.getByRole("button", { name: /evaluate gate checks/i }));
     await screen.findByText(/Eligible: Yes/i);
     await user.click(screen.getByRole("button", { name: /confirm promote/i }));
     await screen.findByText(/Promoted\. Promotion ID: promo-1/i);
+    expect(api.approvePromotion).toHaveBeenCalledWith({
+      runId: "run-1",
+      approvedBy: "operator-7",
+      approvalReason: "Meets risk constraints",
+      reviewNotes: "Checked replay consistency",
+      manualOverrideId: "override-9"
+    });
+    await screen.findByText(/by operator-7/i);
+    await screen.findByText(/reason: Meets risk constraints/i);
+    await screen.findByText(/override: override-9/i);
+    await screen.findByText(/notes: Checked replay consistency/i);
   });
 
   it("shows error path when promotion evaluation fails", async () => {

--- a/src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx
@@ -168,6 +168,10 @@ export function TradingScreen({ data }: TradingScreenProps) {
   const [seekMs, setSeekMs] = useState("0");
 
   const [promotionRunId, setPromotionRunId] = useState("");
+  const [promotionApprovedBy, setPromotionApprovedBy] = useState("");
+  const [promotionApprovalReason, setPromotionApprovalReason] = useState("");
+  const [promotionReviewNotes, setPromotionReviewNotes] = useState("");
+  const [promotionManualOverrideId, setPromotionManualOverrideId] = useState("");
   const [promotionEval, setPromotionEval] = useState<PromotionEvaluationResult | null>(null);
   const [promotionHistory, setPromotionHistory] = useState<PromotionRecord[]>([]);
   const [promotionError, setPromotionError] = useState<string | null>(null);
@@ -346,11 +350,20 @@ export function TradingScreen({ data }: TradingScreenProps) {
   }
 
   async function handlePromoteToPaper() {
-    if (!promotionEval?.isEligible || !promotionRunId.trim()) return;
+    if (!promotionEval?.isEligible || !promotionRunId.trim() || !promotionApprovedBy.trim() || !promotionApprovalReason.trim()) {
+      setPromotionError("Approver and approval reason are required.");
+      return;
+    }
     setPromotionBusy(true);
     setPromotionError(null);
     try {
-      const result = await approvePromotion(promotionRunId.trim(), "Approved from trading workstation promotion gate.");
+      const result = await approvePromotion({
+        runId: promotionRunId.trim(),
+        approvedBy: promotionApprovedBy.trim(),
+        approvalReason: promotionApprovalReason.trim(),
+        reviewNotes: promotionReviewNotes.trim() || undefined,
+        manualOverrideId: promotionManualOverrideId.trim() || undefined
+      });
       setPromotionResult(result.success ? `Promoted. Promotion ID: ${result.promotionId ?? "n/a"}` : result.reason);
       const history = await getPromotionHistory();
       setPromotionHistory(history);
@@ -1034,9 +1047,39 @@ export function TradingScreen({ data }: TradingScreenProps) {
               onChange={(e) => setPromotionRunId(e.target.value)}
               className="w-full rounded-lg border border-border bg-background px-3 py-2 font-mono text-sm"
             />
+            <input
+              aria-label="Approved by"
+              placeholder="operator id"
+              value={promotionApprovedBy}
+              onChange={(e) => setPromotionApprovedBy(e.target.value)}
+              className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+              required
+            />
+            <input
+              aria-label="Approval reason"
+              placeholder="why this promotion is approved"
+              value={promotionApprovalReason}
+              onChange={(e) => setPromotionApprovalReason(e.target.value)}
+              className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+              required
+            />
+            <input
+              aria-label="Review notes"
+              placeholder="optional review notes"
+              value={promotionReviewNotes}
+              onChange={(e) => setPromotionReviewNotes(e.target.value)}
+              className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+            />
+            <input
+              aria-label="Manual override id"
+              placeholder="optional manual override id"
+              value={promotionManualOverrideId}
+              onChange={(e) => setPromotionManualOverrideId(e.target.value)}
+              className="w-full rounded-lg border border-border bg-background px-3 py-2 font-mono text-sm"
+            />
             <div className="flex gap-2">
               <Button size="sm" variant="outline" onClick={handleEvaluatePromotion} disabled={promotionBusy || !promotionRunId.trim()}>Evaluate gate checks</Button>
-              <Button size="sm" onClick={handlePromoteToPaper} disabled={promotionBusy || !promotionEval?.isEligible}>Confirm promote</Button>
+              <Button size="sm" onClick={handlePromoteToPaper} disabled={promotionBusy || !promotionEval?.isEligible || !promotionApprovedBy.trim() || !promotionApprovalReason.trim()}>Confirm promote</Button>
             </div>
             {promotionEval && (
               <div className="rounded-lg border border-border/60 p-3 text-xs">
@@ -1051,7 +1094,13 @@ export function TradingScreen({ data }: TradingScreenProps) {
               <p className="mb-2 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Audit trail</p>
               <ul className="space-y-1 text-xs">
                 {promotionHistory.slice(0, 4).map((record) => (
-                  <li key={record.promotionId} className="font-mono">{record.promotedAt} · {record.strategyId} · {record.sourceRunType}→{record.targetRunType}</li>
+                  <li key={record.promotionId} className="font-mono">
+                    {record.promotedAt} · {record.strategyId} · {record.sourceRunType}→{record.targetRunType}
+                    {record.approvedBy ? ` · by ${record.approvedBy}` : ""}
+                    {record.approvalReason ? ` · reason: ${record.approvalReason}` : ""}
+                    {record.manualOverrideId ? ` · override: ${record.manualOverrideId}` : ""}
+                    {record.reviewNotes ? ` · notes: ${record.reviewNotes}` : ""}
+                  </li>
                 ))}
               </ul>
             </div>

--- a/src/Meridian.Ui/dashboard/src/types.ts
+++ b/src/Meridian.Ui/dashboard/src/types.ts
@@ -71,6 +71,11 @@ export interface PromotionRecord {
   strategyName: string;
   sourceRunType: string;
   targetRunType: string;
+  runId?: string;
+  approvedBy?: string | null;
+  approvalReason?: string | null;
+  reviewNotes?: string | null;
+  manualOverrideId?: string | null;
   qualifyingSharpe: number;
   qualifyingMaxDrawdownPercent: number;
   qualifyingTotalReturn: number;


### PR DESCRIPTION
### Motivation
- Ensure promotion approvals include the full operator context and traceability fields (approver, reason, review notes, manual override) rather than loose positional args to improve auditability and extensibility.
- Simplify the frontend API surface by switching `approvePromotion` to accept a single typed payload object for clarity and future additions.

### Description
- Changed `approvePromotion` in `src/Meridian.Ui/dashboard/src/lib/api.ts` to accept an `ApprovePromotionRequest` object with `runId`, `approvedBy`, `approvalReason`, optional `reviewNotes`, and optional `manualOverrideId` and post that object to `/api/promotion/approve`.
- Updated the trading UI (`src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx`) to collect the new fields, require `approvedBy` and `approvalReason` before submission, and submit the full payload; added rendering of trace fields in the promotion history list.
- Extended the `PromotionRecord` type in `src/Meridian.Ui/dashboard/src/types.ts` to carry `runId`, `approvedBy`, `approvalReason`, `reviewNotes`, and `manualOverrideId` for UI/history display.
- Updated tests: `src/Meridian.Ui/dashboard/src/lib/api.trading.test.ts` now asserts the full JSON body is posted to `/api/promotion/approve`, and `src/Meridian.Ui/dashboard/src/screens/trading-screen.test.tsx` now drives the approval form with the full operator context, asserts `approvePromotion` was called with the payload, and verifies history rendering shows the trace fields.

### Testing
- Updated unit/UI tests in `src/Meridian.Ui/dashboard/src/lib/api.trading.test.ts` and `src/Meridian.Ui/dashboard/src/screens/trading-screen.test.tsx` to cover the new payload shape and history rendering; these tests are included in the change but were not executed in this environment.
- Attempted to run the dashboard UI test script with `npm run ui:dashboard:test`, but the command failed with `ENOENT` because `src/Meridian.Ui/dashboard/package.json` is not present in this checkout, so automated test execution could not be completed here.
- Local/static checks: repository files were updated to reflect the new API shape and UI wiring, and test assertions were adjusted accordingly to reflect the new request body and rendered trace fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ea8c30048320abfb26f46cbad1cc)