### PR TITLE
Add execution controls API helpers and render controls snapshot in trading screen

### DIFF
--- a/src/Meridian.Ui/dashboard/src/lib/api.trading.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api.trading.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { approvePromotion, evaluatePromotion, getPaperSessionDetail, getReplayStatus, pauseReplay, resumeReplay, seekReplay, setReplaySpeed, startReplay, stopReplay } from "@/lib/api";
+import { approvePromotion, clearExecutionManualOverride, createExecutionManualOverride, evaluatePromotion, getExecutionControls, getPaperSessionDetail, getReplayStatus, pauseReplay, resumeReplay, seekReplay, setReplaySpeed, startReplay, stopReplay } from "@/lib/api";
 
 describe("trading endpoint wiring", () => {
   const fetchMock = vi.fn();
@@ -35,5 +35,25 @@ describe("trading endpoint wiring", () => {
     expect(fetchMock).toHaveBeenCalledWith("/api/replay/rep-1/seek", expect.objectContaining({ method: "POST" }));
     expect(fetchMock).toHaveBeenCalledWith("/api/replay/rep-1/speed", expect.objectContaining({ method: "POST" }));
     expect(fetchMock).toHaveBeenCalledWith("/api/replay/rep-1/status", expect.anything());
+  });
+
+  it("wires execution controls and manual override endpoints", async () => {
+    await getExecutionControls();
+    await createExecutionManualOverride({
+      kind: "BypassOrderControls",
+      reason: "maintenance",
+      symbol: "AAPL"
+    });
+    await clearExecutionManualOverride("ovr-1");
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/execution/controls", expect.anything());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/execution/controls/manual-override",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/execution/controls/manual-override/ovr-1/clear",
+      expect.objectContaining({ method: "POST" })
+    );
   });
 });

--- a/src/Meridian.Ui/dashboard/src/lib/api.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api.ts
@@ -4,6 +4,7 @@ import type {
   BackfillTriggerResult,
   DataOperationsWorkspaceResponse,
   EquityCurveSummary,
+  ExecutionControlSnapshot,
   ExecutionAuditEntry,
   GovernanceWorkspaceResponse,
   LedgerSummary,
@@ -33,7 +34,9 @@ import type {
   ReplayFileRecord,
   ReplayStatus,
   TradingActionResult,
-  TradingWorkspaceResponse
+  TradingWorkspaceResponse,
+  CreateExecutionManualOverrideRequest,
+  ExecutionManualOverride
 } from "@/types";
 
 async function getJson<T>(path: string): Promise<T> {
@@ -160,6 +163,18 @@ export function getPaperSessionReplayVerification(sessionId: string) {
 
 export function getExecutionAudit(take = 20) {
   return getJson<ExecutionAuditEntry[]>(`/api/execution/audit?take=${encodeURIComponent(String(take))}`);
+}
+
+export function getExecutionControls() {
+  return getJson<ExecutionControlSnapshot>("/api/execution/controls");
+}
+
+export function createExecutionManualOverride(request: CreateExecutionManualOverrideRequest) {
+  return postJson<ExecutionManualOverride>("/api/execution/controls/manual-override", request);
+}
+
+export function clearExecutionManualOverride(overrideId: string) {
+  return postJson<ExecutionControlSnapshot>(`/api/execution/controls/manual-override/${encodeURIComponent(overrideId)}/clear`);
 }
 
 // --- Strategy lifecycle ---

--- a/src/Meridian.Ui/dashboard/src/screens/trading-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/trading-screen.test.tsx
@@ -70,6 +70,25 @@ vi.mock("@/lib/api", async () => {
         metadata: { sessionId: "sess-1" }
       }
     ]),
+    getExecutionControls: vi.fn().mockResolvedValue({
+      circuitBreaker: { isOpen: false, reason: null, changedBy: "ops", changedAt: "2026-01-01T00:00:00Z" },
+      defaultMaxPositionSize: 5000,
+      symbolPositionLimits: { AAPL: 2500 },
+      manualOverrides: [
+        {
+          overrideId: "ovr-1",
+          kind: "BypassOrderControls",
+          reason: "incident drill",
+          createdBy: "ops",
+          createdAt: "2026-01-01T00:00:00Z",
+          expiresAt: null,
+          symbol: "AAPL",
+          strategyId: null,
+          runId: null
+        }
+      ],
+      asOf: "2026-01-01T00:20:00Z"
+    }),
     getReplayFiles: vi.fn().mockResolvedValue({ files: [{ path: "/tmp/replay.jsonl", name: "replay.jsonl", symbol: "AAPL", eventType: "trades", sizeBytes: 1, isCompressed: false, lastModified: "2026-01-01" }], total: 1, timestamp: "2026-01-01" }),
     startReplay: vi.fn().mockResolvedValue({ sessionId: "rep-1", filePath: "/tmp/replay.jsonl", status: "started", speedMultiplier: 1 }),
     getReplayStatus: vi.fn().mockResolvedValue({ sessionId: "rep-1", filePath: "/tmp/replay.jsonl", status: "running", speedMultiplier: 1, eventsProcessed: 3, totalEvents: 10, progressPercent: 30, startedAt: "2026-01-01" }),
@@ -108,6 +127,15 @@ describe("TradingScreen", () => {
     expect(screen.getByText("Backtest → Paper promotion gate")).toBeInTheDocument();
   });
 
+  it("fetches and renders execution controls snapshot", async () => {
+    render(<MemoryRouter initialEntries={["/trading"]}><TradingScreen data={data} /></MemoryRouter>);
+    await waitFor(() => expect(api.getExecutionControls).toHaveBeenCalled());
+    expect(screen.getByText(/Execution controls snapshot/i)).toBeInTheDocument();
+    expect(screen.getByText(/Breaker Closed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Default limit:/i)).toHaveTextContent("5000");
+    expect(screen.getByText(/Active overrides:/i)).toHaveTextContent("BypassOrderControls (AAPL)");
+  });
+
   it("handles promotion happy path", async () => {
     const user = userEvent.setup();
     render(<MemoryRouter initialEntries={["/trading"]}><TradingScreen data={data} /></MemoryRouter>);
@@ -116,6 +144,21 @@ describe("TradingScreen", () => {
     await screen.findByText(/Eligible: Yes/i);
     await user.click(screen.getByRole("button", { name: /confirm promote/i }));
     await screen.findByText(/Promoted\. Promotion ID: promo-1/i);
+  });
+
+  it("refreshes execution controls after control-affecting actions", async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter initialEntries={["/trading"]}><TradingScreen data={data} /></MemoryRouter>);
+    await waitFor(() => expect(api.getExecutionControls).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole("button", { name: /new order/i }));
+    await user.type(screen.getByPlaceholderText("AAPL"), "AAPL");
+    const quantityInput = screen.getAllByRole("spinbutton")[0];
+    await user.clear(quantityInput);
+    await user.type(quantityInput, "10");
+    await user.click(screen.getByRole("button", { name: /submit order/i }));
+
+    await waitFor(() => expect(api.getExecutionControls).toHaveBeenCalledTimes(2));
   });
 
   it("shows error path when promotion evaluation fails", async () => {

--- a/src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx
@@ -11,9 +11,9 @@ import {
   DialogTitle
 } from "@/components/ui/dialog";
 import { MetricCard } from "@/components/meridian/metric-card";
-import { approvePromotion, cancelAllOrders, cancelOrder, closePosition, closePaperSession, createPaperSession, evaluatePromotion, getExecutionAudit, getExecutionSessions, getPaperSessionDetail, getPaperSessionReplayVerification, getPromotionHistory, getReplayFiles, getReplayStatus, pauseReplay, pauseStrategy, resumeReplay, seekReplay, setReplaySpeed as apiSetReplaySpeed, startReplay, stopReplay, stopStrategy, submitOrder } from "@/lib/api";
+import { approvePromotion, cancelAllOrders, cancelOrder, closePosition, closePaperSession, createPaperSession, evaluatePromotion, getExecutionAudit, getExecutionControls, getExecutionSessions, getPaperSessionDetail, getPaperSessionReplayVerification, getPromotionHistory, getReplayFiles, getReplayStatus, pauseReplay, pauseStrategy, resumeReplay, seekReplay, setReplaySpeed as apiSetReplaySpeed, startReplay, stopReplay, stopStrategy, submitOrder } from "@/lib/api";
 import { cn } from "@/lib/utils";
-import type { ExecutionAuditEntry, OrderSubmitRequest, PaperSessionDetail, PaperSessionReplayVerification, PaperSessionSummary, PromotionEvaluationResult, PromotionRecord, ReplayFileRecord, ReplayStatus, TradingActionResult, TradingWorkspaceResponse } from "@/types";
+import type { ExecutionAuditEntry, ExecutionControlSnapshot, OrderSubmitRequest, PaperSessionDetail, PaperSessionReplayVerification, PaperSessionSummary, PromotionEvaluationResult, PromotionRecord, ReplayFileRecord, ReplayStatus, TradingActionResult, TradingWorkspaceResponse } from "@/types";
 
 interface TradingScreenProps {
   data: TradingWorkspaceResponse | null;
@@ -135,6 +135,7 @@ export function TradingScreen({ data }: TradingScreenProps) {
           occurredAt: new Date().toISOString()
         };
       }
+      await refreshExecutionControls();
       setConfirm((prev) => ({ ...prev, busy: false, result }));
     } catch (err) {
       setConfirm((prev) => ({
@@ -159,6 +160,7 @@ export function TradingScreen({ data }: TradingScreenProps) {
   const [selectedSessionDetail, setSelectedSessionDetail] = useState<PaperSessionDetail | null>(null);
   const [sessionReplayVerification, setSessionReplayVerification] = useState<PaperSessionReplayVerification | null>(null);
   const [executionAudit, setExecutionAudit] = useState<ExecutionAuditEntry[]>([]);
+  const [executionControls, setExecutionControls] = useState<ExecutionControlSnapshot | null>(null);
 
   const [replayFiles, setReplayFiles] = useState<ReplayFileRecord[]>([]);
   const [selectedReplayFile, setSelectedReplayFile] = useState("");
@@ -183,6 +185,15 @@ export function TradingScreen({ data }: TradingScreenProps) {
     }
   }
 
+  async function refreshExecutionControls() {
+    try {
+      const snapshot = await getExecutionControls();
+      setExecutionControls(snapshot);
+    } catch {
+      setExecutionControls(null);
+    }
+  }
+
   useEffect(() => {
     getExecutionSessions()
       .then(setSessions)
@@ -199,6 +210,7 @@ export function TradingScreen({ data }: TradingScreenProps) {
       .then(setPromotionHistory)
       .catch(() => { /* history unavailable */ });
     void refreshExecutionAudit();
+    void refreshExecutionControls();
   }, []);
 
   async function handleSubmitOrder(e: React.FormEvent) {
@@ -210,6 +222,7 @@ export function TradingScreen({ data }: TradingScreenProps) {
         setOrderState({ phase: "submitted", orderId: result.orderId, error: null });
         setShowOrderForm(false);
         setOrderForm({ symbol: "", side: "Buy", type: "Market", quantity: 0, limitPrice: null });
+        await refreshExecutionControls();
       } else {
         setOrderState({ phase: "error", orderId: null, error: result.reason ?? "Order failed." });
       }
@@ -265,6 +278,7 @@ export function TradingScreen({ data }: TradingScreenProps) {
         };
       });
       await refreshExecutionAudit();
+      await refreshExecutionControls();
     } catch (err) {
       setSessionError(err instanceof Error ? err.message : "Failed to close session.");
     }
@@ -293,6 +307,7 @@ export function TradingScreen({ data }: TradingScreenProps) {
       setSelectedSessionDetail(detail);
       setSessionReplayVerification(verification);
       await refreshExecutionAudit();
+      await refreshExecutionControls();
     } catch (err) {
       setSessionError(err instanceof Error ? err.message : "Failed to verify session replay.");
     }
@@ -457,6 +472,40 @@ export function TradingScreen({ data }: TradingScreenProps) {
                   <li key={guardrail}>{guardrail}</li>
                 ))}
               </ul>
+            </div>
+            <div className="mt-3 rounded-xl border border-border/70 bg-background/80 p-4">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Execution controls snapshot</p>
+                <span className={cn("text-xs font-semibold uppercase tracking-[0.14em]", executionControls?.circuitBreaker.isOpen ? "text-danger" : "text-success")}>
+                  Breaker {executionControls?.circuitBreaker.isOpen ? "Open" : "Closed"}
+                </span>
+              </div>
+              {executionControls ? (
+                <div className="space-y-1 text-xs text-muted-foreground">
+                  <p>
+                    Default limit: <span className="font-mono text-foreground">{executionControls.defaultMaxPositionSize ?? "Not set"}</span>
+                  </p>
+                  <p>
+                    Symbol limits:{" "}
+                    <span className="font-mono text-foreground">
+                      {Object.keys(executionControls.symbolPositionLimits).length === 0
+                        ? "None"
+                        : Object.entries(executionControls.symbolPositionLimits).map(([symbol, limit]) => `${symbol}=${limit}`).join(", ")}
+                    </span>
+                  </p>
+                  <p>
+                    Active overrides:{" "}
+                    <span className="font-mono text-foreground">
+                      {executionControls.manualOverrides.length === 0
+                        ? "None"
+                        : executionControls.manualOverrides.map((entry) => `${entry.kind}${entry.symbol ? ` (${entry.symbol})` : ""}`).join(", ")}
+                    </span>
+                  </p>
+                  <p className="font-mono">As of {executionControls.asOf}</p>
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground">Execution controls snapshot unavailable.</p>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/src/Meridian.Ui/dashboard/src/types.ts
+++ b/src/Meridian.Ui/dashboard/src/types.ts
@@ -155,6 +155,43 @@ export interface ExecutionAuditEntry {
   metadata: Record<string, string> | null;
 }
 
+export interface ExecutionCircuitBreakerState {
+  isOpen: boolean;
+  reason: string | null;
+  changedBy: string | null;
+  changedAt: string | null;
+}
+
+export interface ExecutionManualOverride {
+  overrideId: string;
+  kind: string;
+  reason: string;
+  createdBy: string;
+  createdAt: string;
+  expiresAt: string | null;
+  symbol: string | null;
+  strategyId: string | null;
+  runId: string | null;
+}
+
+export interface ExecutionControlSnapshot {
+  circuitBreaker: ExecutionCircuitBreakerState;
+  defaultMaxPositionSize: number | null;
+  symbolPositionLimits: Record<string, number>;
+  manualOverrides: ExecutionManualOverride[];
+  asOf: string;
+}
+
+export interface CreateExecutionManualOverrideRequest {
+  kind: string;
+  reason: string;
+  createdBy?: string | null;
+  symbol?: string | null;
+  strategyId?: string | null;
+  runId?: string | null;
+  expiresAt?: string | null;
+}
+
 export interface ReplayFileRecord {
   path: string;
   name: string;


### PR DESCRIPTION
### Motivation
- Surface operator-managed execution controls in the UI so operators can see circuit-breaker state, per-symbol/default limits, and active manual overrides adjacent to the risk summary. 
- Provide client helpers for the backend execution-controls endpoints and manual-override create/clear routes to allow the frontend to read and mutate control state. 
- Keep the trading cockpit in sync by re-fetching controls after actions that may affect control state (order submit, confirmation actions, session operations).

### Description
- Added API helpers in `src/Meridian.Ui/dashboard/src/lib/api.ts` for `GET /api/execution/controls`, `POST /api/execution/controls/manual-override`, and `POST /api/execution/controls/manual-override/{overrideId}/clear` and exported typed signatures. 
- Extended client types in `src/Meridian.Ui/dashboard/src/types.ts` with `ExecutionCircuitBreakerState`, `ExecutionManualOverride`, `ExecutionControlSnapshot`, and `CreateExecutionManualOverrideRequest` to match the backend payload fields (breaker, default/symbol limits, manual overrides, as-of). 
- Updated `src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx` to fetch the execution controls snapshot on mount, refresh the snapshot after control-affecting actions (confirmed actions, successful order submit, session close/verify), and render breaker status, default limit, symbol limits, active overrides, and `asOf` near the existing risk summary. 
- Added/updated tests: `src/Meridian.Ui/dashboard/src/screens/trading-screen.test.tsx` to assert controls are fetched and rendered and to assert controls are refreshed after submitting an order, and `src/Meridian.Ui/dashboard/src/lib/api.trading.test.ts` to verify the new API helper routes call the expected endpoints.

### Testing
- Added unit tests for the screen and API wiring (`trading-screen.test.tsx` and `api.trading.test.ts`) but could not run the dashboard test suite in this environment because the dashboard npm workspace manifest is missing; running `npm run ui:dashboard:test` produced an ENOENT error: `Could not read package.json: ENOENT: no such file or directory, open '/workspace/Meridian-main/src/Meridian.Ui/dashboard/package.json'`.
- Command run: `npm run ui:dashboard:test` and result: failed due to missing `src/Meridian.Ui/dashboard/package.json` (tests were not executed).
- Local static verification performed: repository file diffs and TypeScript changes were inspected and unit test files were added/updated; no frontend build or test runner completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ea8dc3cc83209f9c66b58033a6f8)