### PR TITLE
Fix kernel observability metric wiring and ledger test type inference

### DIFF
--- a/src/Meridian.Application/Monitoring/PrometheusMetrics.cs
+++ b/src/Meridian.Application/Monitoring/PrometheusMetrics.cs
@@ -377,6 +377,16 @@ public static class PrometheusMetrics
         "Total kernel executions by domain",
         new CounterConfiguration { LabelNames = new[] { "domain" } });
 
+    private static readonly Gauge KernelThroughputPerMinute = Prometheus.Metrics.CreateGauge(
+        "mdc_kernel_throughput_per_minute",
+        "Observed kernel throughput per minute by domain",
+        new GaugeConfiguration { LabelNames = new[] { "domain" } });
+
+    private static readonly Gauge KernelLatencyPercentileMs = Prometheus.Metrics.CreateGauge(
+        "mdc_kernel_latency_percentile_milliseconds",
+        "Kernel latency percentile in milliseconds by domain and percentile",
+        new GaugeConfiguration { LabelNames = new[] { "domain", "percentile" } });
+
     private static readonly Counter KernelDeterminismChecksTotal = Prometheus.Metrics.CreateCounter(
         "mdc_kernel_determinism_checks_total",
         "Total kernel determinism checks by domain and outcome",
@@ -515,6 +525,25 @@ public static class PrometheusMetrics
         var safeDomain = string.IsNullOrWhiteSpace(domain) ? "unknown" : domain.Trim().ToLowerInvariant();
         KernelExecutionsTotal.WithLabels(safeDomain).Inc();
         KernelExecutionLatencyMs.WithLabels(safeDomain).Observe(Math.Max(0, latencyMilliseconds));
+    }
+
+    /// <summary>
+    /// Sets kernel throughput per minute for a domain.
+    /// </summary>
+    public static void SetKernelThroughputPerMinute(string domain, double throughputPerMinute)
+    {
+        var safeDomain = string.IsNullOrWhiteSpace(domain) ? "unknown" : domain.Trim().ToLowerInvariant();
+        KernelThroughputPerMinute.WithLabels(safeDomain).Set(Math.Max(0, throughputPerMinute));
+    }
+
+    /// <summary>
+    /// Sets kernel latency percentile in milliseconds for a domain.
+    /// </summary>
+    public static void SetKernelLatencyPercentile(string domain, string percentile, double latencyMilliseconds)
+    {
+        var safeDomain = string.IsNullOrWhiteSpace(domain) ? "unknown" : domain.Trim().ToLowerInvariant();
+        var safePercentile = string.IsNullOrWhiteSpace(percentile) ? "unknown" : percentile.Trim().ToLowerInvariant();
+        KernelLatencyPercentileMs.WithLabels(safeDomain, safePercentile).Set(Math.Max(0, latencyMilliseconds));
     }
 
     /// <summary>

--- a/src/Meridian.Application/ProviderRouting/KernelObservabilityService.cs
+++ b/src/Meridian.Application/ProviderRouting/KernelObservabilityService.cs
@@ -88,7 +88,6 @@ public sealed class KernelObservabilityService
         PrometheusMetrics.SetKernelCriticalSeverityRate(
             domain,
             snapshot.CriticalRateShortWindow,
-            snapshot.CriticalJumpActive,
             snapshot.CriticalJumpAlertTriggered);
     }
 

--- a/tests/Meridian.FSharp.Tests/LedgerKernelTests.fs
+++ b/tests/Meridian.FSharp.Tests/LedgerKernelTests.fs
@@ -688,7 +688,7 @@ let ``ReconciliationClassification unknown break type uses safe fallback migrati
 
 [<Fact>]
 let ``LedgerInterop ClassifyBreakFacts returns stable DTO values for governance consumers`` () =
-    let input = [|
+    let input : BreakFactsDto array = [|
         {
             BreakType = "price"
             ExpectedQuantity = None


### PR DESCRIPTION
## Summary
- add missing `PrometheusMetrics` APIs used by `KernelObservabilityService` for kernel throughput and latency percentile gauges
- align `SetKernelCriticalSeverityRate` call with current method signature by passing the alert trigger flag only
- disambiguate the record type in `LedgerKernelTests` by annotating test input as `BreakFactsDto array`, resolving F# record inference to `string option` fields

## Validation
- static inspection only (no test/build execution in this run)
- verified changed call sites and signatures are consistent across:
  - `src/Meridian.Application/ProviderRouting/KernelObservabilityService.cs`
  - `src/Meridian.Application/Monitoring/PrometheusMetrics.cs`
  - `tests/Meridian.FSharp.Tests/LedgerKernelTests.fs`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7eb1767b08320b1de0f2a8a5f20fe)