### PR TITLE
Suppress CS0067 for contract-required IB brokerage stub events

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.cs
@@ -46,6 +46,8 @@ public sealed partial class EnhancedIBConnectionManager : IIBBrokerageClient
     public bool EnableHeartbeat { get; set; }
     public bool IsConnected => false;
 
+    // Required by IIBBrokerageClient contract so non-IBAPI builds remain interface-compatible with IBAPI builds.
+#pragma warning disable CS0067 // Event is never used
     public event EventHandler<int>? NextValidIdReceived;
     public event EventHandler<IBOrderStatusUpdate>? OrderStatusReceived;
     public event EventHandler<IBOpenOrderUpdate>? OpenOrderReceived;
@@ -56,6 +58,7 @@ public sealed partial class EnhancedIBConnectionManager : IIBBrokerageClient
     public event EventHandler<IBAccountSummaryUpdate>? AccountSummaryReceived;
     public event EventHandler<int>? AccountSummaryCompleted;
     public event EventHandler<IBApiError>? ErrorOccurred;
+#pragma warning restore CS0067
 
     /// <summary>
     /// Centralizes the platform guard used by the non-IBAPI build so each stub entry point stays concise.

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs
@@ -972,6 +972,8 @@ public sealed class IBBrokerageGateway : IBrokerageGateway
         public bool IsConnected => false;
         public string GuidanceMessage { get; }
 
+        // Required by IIBBrokerageClient contract so unsupported-runtime guidance mode remains substitutable.
+#pragma warning disable CS0067 // Event is never used
         public event EventHandler<int>? NextValidIdReceived;
         public event EventHandler<IBOrderStatusUpdate>? OrderStatusReceived;
         public event EventHandler<IBOpenOrderUpdate>? OpenOrderReceived;
@@ -982,6 +984,7 @@ public sealed class IBBrokerageGateway : IBrokerageGateway
         public event EventHandler<IBAccountSummaryUpdate>? AccountSummaryReceived;
         public event EventHandler<int>? AccountSummaryCompleted;
         public event EventHandler<IBApiError>? ErrorOccurred;
+#pragma warning restore CS0067
 
         public Task ConnectAsync(CancellationToken ct = default)
             => Task.FromException(CreateException());


### PR DESCRIPTION
### Motivation
- The non-IBAPI stub and the unsupported-runtime brokerage client declare a set of IB-related events solely to remain binary/contract-compatible with `IIBrokerageClient`, which currently triggers CS0067 warnings in builds that don't use the vendor API.

### Description
- Added a short explanatory comment and a narrow `#pragma warning disable CS0067` / `#pragma warning restore CS0067` block around the event declarations in `EnhancedIBConnectionManager` to silence the unused-event warning while preserving the interface contract (`src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.cs`).
- Applied the same targeted suppression and comment to the `UnsupportedIBBrokerageClient` event group in `IBBrokerageGateway` to keep the guidance-mode client substitutable (`src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBBrokerageGateway.cs`).
- Did not remove any events or other scaffolding so runtime/ABI compatibility with IBAPI builds is preserved.

### Testing
- Attempted `dotnet build src/Meridian.Infrastructure/Meridian.Infrastructure.csproj` to confirm warnings are resolved, but the environment is missing the .NET SDK and the build could not be run (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7eb52599c832085c3d1b260b8a314)