### PR TITLE
Strengthen ScriptRunner cancellation and timeout tests

### DIFF
--- a/tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs
+++ b/tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Meridian.QuantScript.Api;
 using Meridian.QuantScript.Compilation;
 using Meridian.QuantScript.Plotting;
@@ -14,7 +15,8 @@ public sealed class ScriptRunnerTests
     private static ScriptRunner BuildRunner(
         IQuantScriptCompiler? compiler = null,
         IQuantDataContext? dataContext = null,
-        PlotQueue? plotQueue = null)
+        PlotQueue? plotQueue = null,
+        int runTimeoutSeconds = 10)
     {
         compiler ??= new RoslynScriptCompiler(
             Options.Create(new QuantScriptOptions()),
@@ -27,7 +29,7 @@ public sealed class ScriptRunnerTests
             compiler,
             dataContext,
             plotQueue ?? new PlotQueue(),
-            Options.Create(new QuantScriptOptions { RunTimeoutSeconds = 10 }),
+            Options.Create(new QuantScriptOptions { RunTimeoutSeconds = runTimeoutSeconds }),
             NullLogger<ScriptRunner>.Instance,
             null);
     }
@@ -145,70 +147,74 @@ public sealed class ScriptRunnerTests
     // ── Cancellation ─────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task RunAsync_CancelledBeforeRun_ReturnsFailedOrCompletes()
+    public async Task RunAsync_PreCanceledToken_ThrowsOperationCanceledException()
     {
         var runner = BuildRunner();
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        try
-        {
-            var result = await runner.RunAsync("Print(\"hi\");", NoParams, cts.Token);
-            result.Should().NotBeNull();
-        }
-        catch (OperationCanceledException)
-        {
-            // Acceptable: some code paths throw on immediate cancellation
-        }
-    }
+        var act = () => runner.RunAsync("Print(\"hi\");", NoParams, cts.Token);
 
-    [Fact]
-    public async Task RunAsync_CancellationToken_CancelsRun()
-    {
-        var runner = BuildRunner();
-        using var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        // A pre-cancelled token throws OperationCanceledException from CompileAsync
-        try
-        {
-            var result = await runner.RunAsync("// should be cancelled", NoParams, cts.Token);
-            result.Should().NotBeNull();
-        }
-        catch (OperationCanceledException)
-        {
-            // Acceptable: compilation cancelled before run begins
-        }
+        await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
     // ── Timeout ───────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task RunAsync_Timeout_TerminatesAfterConfiguredDuration()
+    public async Task RunAsync_UserCancellationDuringRun_ReturnsCancelledRuntimeError_AndNoCheckpoint()
     {
-        var compiler = new RoslynScriptCompiler(
-            Options.Create(new QuantScriptOptions()),
-            NullLogger<RoslynScriptCompiler>.Instance);
-        var dataContext = new Mock<IQuantDataContext>().Object;
-        var shortTimeout = new QuantScriptOptions { RunTimeoutSeconds = 1 };
+        var runner = BuildRunner(runTimeoutSeconds: 10);
+        using var cts = new CancellationTokenSource();
 
-        var runner = new ScriptRunner(
-            compiler,
-            dataContext,
-            new PlotQueue(),
-            Options.Create(shortTimeout),
-            NullLogger<ScriptRunner>.Instance,
-            null);
+        cts.CancelAfter(TimeSpan.FromMilliseconds(200));
+        var elapsed = Stopwatch.StartNew();
 
-        // Use a tight spin-loop that respects the thread-pool cancellation token
-        // (Thread.Sleep cannot be interrupted, but a spin check can)
         var result = await runner.RunAsync(
-            "while(true) { if(System.Threading.Thread.Sleep(50) == false) {} }",
+            "while (true) { CancellationToken.ThrowIfCancellationRequested(); }",
+            NoParams,
+            cts.Token);
+
+        elapsed.Stop();
+
+        result.Success.Should().BeFalse();
+        result.RuntimeError.Should().Be("Script cancelled by user.");
+        result.Checkpoint.Should().BeNull();
+        result.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3));
+        elapsed.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
+    public async Task RunAsync_TimeoutDuringRun_ReturnsTimeoutRuntimeError_AndNoCheckpoint()
+    {
+        var runner = BuildRunner(runTimeoutSeconds: 1);
+        var elapsed = Stopwatch.StartNew();
+
+        var result = await runner.RunAsync(
+            "while (true) { CancellationToken.ThrowIfCancellationRequested(); }",
+            NoParams);
+        elapsed.Stop();
+
+        result.Success.Should().BeFalse();
+        result.RuntimeError.Should().Be("Script timed out.");
+        result.Checkpoint.Should().BeNull();
+        result.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3));
+        elapsed.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
+    public async Task ContinueWithAsync_TimeoutDuringRun_PreservesPreviousCheckpoint_AndReturnsTimeoutRuntimeError()
+    {
+        var runner = BuildRunner(runTimeoutSeconds: 1);
+        var first = await runner.RunAsync("var x = 41;", NoParams);
+
+        var result = await runner.ContinueWithAsync(
+            "while (true) { CancellationToken.ThrowIfCancellationRequested(); }",
+            first.Checkpoint!,
             NoParams);
 
-        // Should have been cancelled by the run timeout (success or cancelled are both acceptable
-        // depending on how the script terminates, but it should complete within the test)
-        result.Should().NotBeNull();
+        result.Success.Should().BeFalse();
+        result.RuntimeError.Should().Be("Script timed out.");
+        result.Checkpoint.Should().BeSameAs(first.Checkpoint);
     }
 
     // ── Data access ───────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Make cancellation and timeout tests deterministic and behavior-focused so the test suite verifies observable outcomes (runtime error text, `Success`, checkpoint behavior, and bounded elapsed time) rather than only non-null/exceptional results.
- Cover distinct runtime paths: pre-canceled token, user cancellation during run, timeout-driven cancellation, and the continuation timeout case to ensure checkpoint semantics are correct.

### Description
- Added an optional `runTimeoutSeconds` parameter to the `BuildRunner` helper to allow per-test timeout configuration via `BuildRunner(..., runTimeoutSeconds: n)`.
- Replaced the previous unreliable timeout spin-loop with a cancellation-aware long-running loop (`while (true) { CancellationToken.ThrowIfCancellationRequested(); }`) so runs reliably hit cancellation/timeout paths.
- Replaced the permissive pre-cancel test with a strict pre-canceled token test that asserts `OperationCanceledException` from `RunAsync` when the token is canceled before starting.
- Added separate tests asserting observable behavior: user-cancelled run returns `Success == false`, `RuntimeError == "Script cancelled by user."`, `Checkpoint == null` for fresh runs, and bounded elapsed time; timeout run returns `RuntimeError == "Script timed out."`; and a continuation-timeout test verifies the previous checkpoint is preserved.

### Testing
- Attempted to run the test project with `dotnet test tests/Meridian.QuantScript.Tests/Meridian.QuantScript.Tests.csproj -c Release --no-restore`, but the command could not be executed in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a25454ac832089101f3361378c81)