### PR TITLE
Use atomic notebook persistence and collision-resistant suggested paths

### DIFF
--- a/src/Meridian.QuantScript/Documents/QuantScriptNotebookStore.cs
+++ b/src/Meridian.QuantScript/Documents/QuantScriptNotebookStore.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using System.Threading;
+using Meridian.Storage.Archival;
 
 namespace Meridian.QuantScript.Documents;
 
@@ -7,6 +9,8 @@ namespace Meridian.QuantScript.Documents;
 /// </summary>
 public sealed class QuantScriptNotebookStore : IQuantScriptNotebookStore
 {
+    private static long _pathSuffixCounter;
+
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -85,8 +89,8 @@ public sealed class QuantScriptNotebookStore : IQuantScriptNotebookStore
         var normalized = EnsureCells(document);
         Directory.CreateDirectory(Path.GetDirectoryName(path) ?? ScriptsDirectory);
 
-        await using var stream = File.Create(path);
-        await JsonSerializer.SerializeAsync(stream, normalized, SerializerOptions, ct).ConfigureAwait(false);
+        var serialized = JsonSerializer.Serialize(normalized, SerializerOptions);
+        await AtomicFileWriter.WriteAsync(path, serialized, ct).ConfigureAwait(false);
     }
 
     public string GetSuggestedNotebookPath(string title)
@@ -101,13 +105,8 @@ public sealed class QuantScriptNotebookStore : IQuantScriptNotebookStore
         if (string.IsNullOrWhiteSpace(sanitized))
             sanitized = "quantscript-notebook";
 
-        var candidate = Path.Combine(ScriptsDirectory, $"{sanitized}{NotebookExtension}");
-        if (!File.Exists(candidate))
-            return candidate;
-
-        return Path.Combine(
-            ScriptsDirectory,
-            $"{sanitized}-{DateTime.Now:yyyyMMddHHmmss}{NotebookExtension}");
+        var suffix = $"{DateTime.UtcNow.Ticks:x}-{Interlocked.Increment(ref _pathSuffixCounter):x}";
+        return Path.Combine(ScriptsDirectory, $"{sanitized}-{suffix}{NotebookExtension}");
     }
 
     private static QuantScriptNotebookDocument EnsureCells(QuantScriptNotebookDocument document)

--- a/tests/Meridian.QuantScript.Tests/QuantScriptNotebookStoreTests.cs
+++ b/tests/Meridian.QuantScript.Tests/QuantScriptNotebookStoreTests.cs
@@ -80,6 +80,51 @@ public sealed class QuantScriptNotebookStoreTests : IDisposable
         await act.Should().ThrowAsync<InvalidDataException>();
     }
 
+    [Fact]
+    public void GetSuggestedNotebookPath_CalledSuccessivelyWithinOneSecond_ReturnsUniquePaths()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        var store = BuildStore();
+
+        var first = store.GetSuggestedNotebookPath("Strategy Notebook");
+        var second = store.GetSuggestedNotebookPath("Strategy Notebook");
+
+        first.Should().NotBe(second);
+        Path.GetFileName(first).Should().StartWith("Strategy Notebook-");
+        Path.GetFileName(second).Should().StartWith("Strategy Notebook-");
+    }
+
+    [Fact]
+    public async Task SaveNotebook_WhenWriteIsInterrupted_PreservesLastGoodNotebook()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        var store = BuildStore();
+        var path = Path.Combine(_tempDirectory, "interrupted-save.mqnb");
+        var original = new QuantScriptNotebookDocument
+        {
+            Title = "Original",
+            Cells = [new QuantScriptNotebookCellDocument("cell-1", "Print(\"original\");")]
+        };
+
+        await store.SaveNotebookAsync(path, original);
+
+        var interrupted = new QuantScriptNotebookDocument
+        {
+            Title = "Interrupted",
+            Cells = [new QuantScriptNotebookCellDocument("cell-2", "Print(\"interrupted\");")]
+        };
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var interruptedSave = () => store.SaveNotebookAsync(path, interrupted, cts.Token);
+        await interruptedSave.Should().ThrowAsync<OperationCanceledException>();
+
+        var loaded = await store.LoadNotebookAsync(path);
+        loaded.Title.Should().Be("Original");
+        loaded.Cells.Should().ContainSingle();
+        loaded.Cells[0].Source.Should().Contain("original");
+    }
+
     private QuantScriptNotebookStore BuildStore()
         => new(new QuantScriptOptions
         {


### PR DESCRIPTION
### Motivation
- Prevent partial/corrupt notebook files by switching notebook saves to the project-standard atomic temp-write-then-rename pattern.  
- Avoid suggested-path collisions when multiple notebooks are created in quick succession by increasing the suffix entropy.

### Description
- Replaced direct stream write in `QuantScriptNotebookStore.SaveNotebookAsync` with JSON serialization followed by `AtomicFileWriter.WriteAsync` to perform atomic writes (`src/Meridian.QuantScript/Documents/QuantScriptNotebookStore.cs`).
- Added a monotonic counter plus UTC ticks suffix to `GetSuggestedNotebookPath` (`_pathSuffixCounter` + `DateTime.UtcNow.Ticks`) to avoid same-second collisions.
- Added `using Meridian.Storage.Archival;` and `using System.Threading;` and an `Interlocked`-backed counter to the store implementation.
- Added two tests in `tests/Meridian.QuantScript.Tests/QuantScriptNotebookStoreTests.cs`: one that verifies successive `GetSuggestedNotebookPath` calls produce unique names, and one that simulates an interrupted write (cancelling a save) and asserts the prior on-disk notebook remains intact.

### Testing
- Added unit tests: `GetSuggestedNotebookPath_CalledSuccessivelyWithinOneSecond_ReturnsUniquePaths` and `SaveNotebook_WhenWriteIsInterrupted_PreservesLastGoodNotebook` in `QuantScriptNotebookStoreTests` (not yet executed in this environment).
- Attempted to run `dotnet test tests/Meridian.QuantScript.Tests/Meridian.QuantScript.Tests.csproj --filter QuantScriptNotebookStoreTests` but the environment lacked the .NET SDK and the run failed with `dotnet: command not found` so test execution could not be verified here; tests should be validated by CI or a local developer machine.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a252cfc8832091b49a2f5464a7cc)