### PR TITLE
Isolate QuantScript plot queues per ScriptRunner invocation

### DIFF
--- a/src/Meridian.QuantScript/Compilation/ScriptRunner.cs
+++ b/src/Meridian.QuantScript/Compilation/ScriptRunner.cs
@@ -15,7 +15,6 @@ public sealed class ScriptRunner : IScriptRunner
 {
     private readonly IQuantScriptCompiler _compiler;
     private readonly IQuantDataContext _dataContext;
-    private readonly PlotQueue _plotQueue;
     private readonly Backtesting.Engine.BacktestEngine? _backtestEngine;
     private readonly QuantScriptOptions _options;
     private readonly ILogger<ScriptRunner> _logger;
@@ -30,7 +29,7 @@ public sealed class ScriptRunner : IScriptRunner
     {
         _compiler = compiler ?? throw new ArgumentNullException(nameof(compiler));
         _dataContext = dataContext ?? throw new ArgumentNullException(nameof(dataContext));
-        _plotQueue = plotQueue ?? throw new ArgumentNullException(nameof(plotQueue));
+        _ = plotQueue ?? throw new ArgumentNullException(nameof(plotQueue)); // retained for DI compatibility; per-run queues are now local
         _backtestEngine = backtestEngine; // null is valid — backtest is optional
         _options = options?.Value ?? new QuantScriptOptions();
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -110,7 +109,7 @@ public sealed class ScriptRunner : IScriptRunner
         string? runtimeError = null;
         IReadOnlyList<ScriptDiagnostic> continuationDiagnostics = Array.Empty<ScriptDiagnostic>();
         ScriptExecutionCheckpoint? nextCheckpoint = checkpoint;
-        var runPlotQueue = _plotQueue;
+        var runPlotQueue = new PlotQueue();
 
         await Task.Run(async () =>
         {

--- a/tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs
+++ b/tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs
@@ -288,4 +288,39 @@ public sealed class ScriptRunnerTests
         second.CompilationErrors.Should().NotBeEmpty();
         second.Checkpoint.Should().BeSameAs(first.Checkpoint);
     }
+
+    [Fact]
+    public async Task RunAsync_UsesFreshPerInvocationPlotQueue_NotInjectedQueueState()
+    {
+        var injectedQueue = new PlotQueue();
+        injectedQueue.Enqueue(new PlotRequest("leftover", PlotType.Line));
+        injectedQueue.Complete();
+
+        var runner = BuildRunner(plotQueue: injectedQueue);
+        var result = await runner.RunAsync("Print(\"no plots\")", NoParams);
+
+        result.Success.Should().BeTrue();
+        result.Plots.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RunAsync_PlotsDoNotLeakAcrossRuns()
+    {
+        var runner = BuildRunner();
+        const string emitPlotSource = """
+            var r = new ReturnSeries(
+                "T",
+                ReturnKind.Arithmetic,
+                new[] { new ReturnPoint(new DateOnly(2024, 1, 1), 0.01) });
+            r.Plot("run1");
+            """;
+
+        var first = await runner.RunAsync(emitPlotSource, NoParams);
+        var second = await runner.RunAsync("Print(\"second\")", NoParams);
+
+        first.Success.Should().BeTrue();
+        first.Plots.Should().ContainSingle(p => p.Title == "run1");
+        second.Success.Should().BeTrue();
+        second.Plots.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
### Motivation
- Prevent cross-run plot leakage by ensuring each script execution uses an independent `PlotQueue` instance bound only for the run scope.
- Keep DI compatibility for now by preserving the constructor `PlotQueue` parameter while moving to per-run queues.
- Make run results deterministic and safe for concurrent or sequential runs in UI and tests.

### Description
- `ScriptRunner.ExecuteAsync` now allocates a fresh `new PlotQueue()` per invocation and assigns it to `ScriptContext.PlotQueue` for the duration of the run scope.
- The per-run instance is `Complete()`d and drained with `DrainRemaining()` into `ScriptRunResult.Plots` so results contain only plots produced during that invocation.
- The constructor `PlotQueue` parameter is retained only for null-guarding (`_ = plotQueue ?? throw ...`) to preserve DI compatibility; it is no longer stored or used across runs.
- Added unit tests in `tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs` verifying that an injected queue with leftover items is ignored and that plots produced in one run do not appear in subsequent runs.

### Testing
- Added tests: `RunAsync_UsesFreshPerInvocationPlotQueue_NotInjectedQueueState` and `RunAsync_PlotsDoNotLeakAcrossRuns` in `tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs` (these tests exercise plot isolation logic).
- Attempted to run targeted tests with `dotnet test tests/Meridian.QuantScript.Tests/Meridian.QuantScript.Tests.csproj --filter "ScriptRunnerTests|PlotQueueTests"`, but the environment lacked the .NET SDK and the command failed with `dotnet: command not found`.
- Attempted `python3 scripts/score_eval.py --help` as part of the implementation-assurance workflow, but the helper script is not present and the command failed with file-not-found.
- Files changed: `src/Meridian.QuantScript/Compilation/ScriptRunner.cs` and `tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a250a7dc8320bfa809076648a7bb)