### PR TITLE
Add governance-focused tests for reconciliation, security lookup, and report generation

### DIFF
--- a/tests/Meridian.Tests/Application/ReconciliationRunServiceTests.cs
+++ b/tests/Meridian.Tests/Application/ReconciliationRunServiceTests.cs
@@ -68,6 +68,10 @@ public sealed class ReconciliationRunServiceTests
         detail.SecurityCoverageIssues.Should().NotBeNull();
         detail.SecurityCoverageIssues!.Should().Contain(issue => issue.Source == "portfolio" && issue.Symbol == "TSLA");
         detail.SecurityCoverageIssues.Should().Contain(issue => issue.Source == "ledger" && issue.Symbol == "TSLA");
+        detail.SecurityCoverageIssues.Should().OnlyContain(issue =>
+            issue.Reason.Contains("missing a Security Master match", StringComparison.OrdinalIgnoreCase));
+        detail.SecurityClassifications.Should().ContainKey("AAPL");
+        detail.SecurityClassifications.Should().NotContainKey("TSLA");
     }
 
     [Fact]
@@ -109,6 +113,41 @@ public sealed class ReconciliationRunServiceTests
         detail.SecurityClassifications["AAPL"].AssetClass.Should().Be("Equity");
         detail.SecurityClassifications["AAPL"].SubType.Should().Be("CommonShare");
         detail.SecurityClassifications["AAPL"].PrimaryIdentifierValue.Should().Be("AAPL");
+    }
+
+    [Fact]
+    public async Task RunAsync_WithClassificationEdgeCases_ShouldPreservePrimaryIdentifierAndSubtypeValues()
+    {
+        var store = new StrategyRunStore();
+        await store.RecordRunAsync(TestRunFactory.BuildReconciliationReadyRun("run-classification-edges"));
+
+        var lookup = new StubSecurityReferenceLookup();
+        lookup.Register("AAPL", new WorkstationSecurityReference(
+            SecurityId: Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            DisplayName: "Apple Inc.",
+            AssetClass: "Equity",
+            Currency: "USD",
+            Status: SecurityStatusDto.Active,
+            PrimaryIdentifier: "AAPL",
+            SubType: null));
+        lookup.Register("TSLA", new WorkstationSecurityReference(
+            SecurityId: Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+            DisplayName: "Tesla Inc.",
+            AssetClass: "LegacyEquity",
+            Currency: "USD",
+            Status: SecurityStatusDto.Active,
+            PrimaryIdentifier: "88160R101",
+            SubType: "LegacyEquitySubtype"));
+
+        var service = CreateService(store, new InMemoryReconciliationRunRepository(), lookup);
+
+        var detail = await service.RunAsync(new ReconciliationRunRequest("run-classification-edges"));
+
+        detail.Should().NotBeNull();
+        detail!.SecurityClassifications.Should().NotBeNull();
+        detail.SecurityClassifications!["AAPL"].SubType.Should().BeNull("ambiguous equity subtype should stay explicitly null");
+        detail.SecurityClassifications["TSLA"].SubType.Should().Be("LegacyEquitySubtype");
+        detail.SecurityClassifications["TSLA"].PrimaryIdentifierValue.Should().Be("88160R101");
     }
 
     [Fact]

--- a/tests/Meridian.Tests/Application/Services/ReportGenerationServiceTests.cs
+++ b/tests/Meridian.Tests/Application/Services/ReportGenerationServiceTests.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using FluentAssertions;
+using Meridian.Application.SecurityMaster;
+using Meridian.Application.Services;
+using Meridian.Contracts.SecurityMaster;
+using Meridian.Ledger;
+using NSubstitute;
+using Xunit;
+
+namespace Meridian.Tests.Application.Services;
+
+public sealed class ReportGenerationServiceTests
+{
+    [Fact]
+    public async Task GenerateAsync_WithMissingSecurityMetadata_UsesDeterministicUnclassifiedFallback()
+    {
+        var securityMaster = Substitute.For<ISecurityMasterQueryService>();
+        securityMaster
+            .GetByIdentifierAsync(SecurityIdentifierKind.Ticker, "UNKN", null, Arg.Any<CancellationToken>())
+            .Returns(new SecurityDetailDto(
+                SecurityId: Guid.NewGuid(),
+                AssetClass: null!,
+                Status: SecurityStatusDto.Active,
+                DisplayName: null!,
+                Currency: null!,
+                CommonTerms: JsonSerializer.SerializeToElement(new { }),
+                AssetSpecificTerms: JsonSerializer.SerializeToElement(new { }),
+                Identifiers: [],
+                Aliases: [],
+                Version: 1,
+                EffectiveFrom: DateTimeOffset.UtcNow.AddDays(-10),
+                EffectiveTo: null));
+
+        var service = new ReportGenerationService(securityMaster);
+        var book = BuildFundLedger("fund-report-1", ("UNKN", 125m));
+
+        var report = await service.GenerateAsync(new ReportRequest(
+            FundId: "fund-report-1",
+            AsOf: new DateTimeOffset(2026, 4, 20, 0, 0, 0, TimeSpan.Zero),
+            FundLedger: book));
+
+        report.TrialBalance.Should().ContainSingle();
+        var row = report.TrialBalance.Single();
+        row.Symbol.Should().Be("UNKN");
+        row.AssetClass.Should().BeNull();
+        row.DisplayName.Should().BeNull();
+        row.Currency.Should().BeNull();
+
+        report.AssetClassSections.Should().ContainSingle();
+        report.AssetClassSections[0].AssetClass.Should().Be("Unclassified");
+        report.AssetClassSections[0].Rows.Should().ContainSingle(r => r.Symbol == "UNKN");
+    }
+
+    [Fact]
+    public async Task GenerateAsync_PreservesIdentifierMappedRows_AndNullHandlingAcrossMultipleSymbols()
+    {
+        var securityMaster = Substitute.For<ISecurityMasterQueryService>();
+        securityMaster
+            .GetByIdentifierAsync(SecurityIdentifierKind.Ticker, "AAPL", null, Arg.Any<CancellationToken>())
+            .Returns(BuildDetail("Equity", "Apple Inc.", "USD"));
+        securityMaster
+            .GetByIdentifierAsync(SecurityIdentifierKind.Ticker, "CUSIP_037833100", null, Arg.Any<CancellationToken>())
+            .Returns(BuildDetail("Equity", "Apple Legacy Line", null));
+
+        var service = new ReportGenerationService(securityMaster);
+        var book = BuildFundLedger(
+            "fund-report-2",
+            ("AAPL", 300m),
+            ("CUSIP_037833100", 50m));
+
+        var report = await service.GenerateAsync(new ReportRequest(
+            FundId: "fund-report-2",
+            AsOf: new DateTimeOffset(2026, 4, 20, 0, 0, 0, TimeSpan.Zero),
+            FundLedger: book));
+
+        report.TrialBalance.Should().HaveCount(2);
+        report.TrialBalance.Should().Contain(row =>
+            row.Symbol == "AAPL" &&
+            row.AssetClass == "Equity" &&
+            row.DisplayName == "Apple Inc." &&
+            row.Currency == "USD");
+        report.TrialBalance.Should().Contain(row =>
+            row.Symbol == "CUSIP_037833100" &&
+            row.AssetClass == "Equity" &&
+            row.DisplayName == "Apple Legacy Line" &&
+            row.Currency is null);
+    }
+
+    private static FundLedgerBook BuildFundLedger(string fundId, params (string Symbol, decimal Balance)[] rows)
+    {
+        var book = new FundLedgerBook(fundId);
+        var asOf = new DateTimeOffset(2026, 4, 20, 12, 0, 0, TimeSpan.Zero);
+
+        foreach (var (symbol, balance) in rows)
+        {
+            var securityAccount = new LedgerAccount($"Security:{symbol}", LedgerAccountType.Asset, symbol);
+            var offsetAccount = new LedgerAccount($"Offset:{symbol}", LedgerAccountType.Equity);
+            book.FundLedger.PostLines(asOf, $"seed-{symbol}", [(securityAccount, balance, 0m), (offsetAccount, 0m, balance)]);
+        }
+
+        return book;
+    }
+
+    private static SecurityDetailDto BuildDetail(string assetClass, string displayName, string? currency)
+        => new(
+            SecurityId: Guid.NewGuid(),
+            AssetClass: assetClass,
+            Status: SecurityStatusDto.Active,
+            DisplayName: displayName,
+            Currency: currency,
+            CommonTerms: JsonSerializer.SerializeToElement(new { }),
+            AssetSpecificTerms: JsonSerializer.SerializeToElement(new { }),
+            Identifiers: [],
+            Aliases: [],
+            Version: 1,
+            EffectiveFrom: DateTimeOffset.UtcNow.AddDays(-5),
+            EffectiveTo: null);
+}

--- a/tests/Meridian.Tests/SecurityMaster/SecurityMasterReferenceLookupTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityMasterReferenceLookupTests.cs
@@ -96,6 +96,50 @@ public sealed class SecurityMasterReferenceLookupTests
         result.Should().NotBeNull();
         // Falls back to first identifier value
         result!.PrimaryIdentifier.Should().Be("AAPL");
+        result.CoverageStatus.Should().Be(WorkstationSecurityCoverageStatus.Resolved);
+        result.MatchedIdentifierKind.Should().Be(SecurityIdentifierKind.Ticker.ToString());
+        result.MatchedIdentifierValue.Should().Be("AAPL");
+    }
+
+    [Fact]
+    public async Task GetBySymbolAsync_WithDegradedMetadata_PreservesDeterministicResolvedLabeling()
+    {
+        var securityId = Guid.NewGuid();
+        var identifiers = new[]
+        {
+            new SecurityIdentifierDto(SecurityIdentifierKind.Cusip, "594918104", true, DateTimeOffset.UtcNow.AddDays(-1), null, null)
+        };
+        var detail = new SecurityDetailDto(
+            SecurityId: securityId,
+            AssetClass: "",
+            Status: SecurityStatusDto.Active,
+            DisplayName: "",
+            Currency: null,
+            CommonTerms: JsonSerializer.SerializeToElement(new { }),
+            AssetSpecificTerms: JsonSerializer.SerializeToElement(new { }),
+            Identifiers: identifiers,
+            Aliases: Array.Empty<SecurityAliasDto>(),
+            Version: 1,
+            EffectiveFrom: DateTimeOffset.UtcNow.AddDays(-30),
+            EffectiveTo: null);
+
+        var queryService = Substitute.For<ISecurityMasterQueryService>();
+        queryService
+            .GetByIdentifierAsync(SecurityIdentifierKind.Ticker, "MSFT", null, Arg.Any<CancellationToken>())
+            .Returns(detail);
+
+        var lookup = new SecurityMasterSecurityReferenceLookup(queryService);
+
+        var result = await lookup.GetBySymbolAsync("MSFT");
+
+        result.Should().NotBeNull();
+        result!.CoverageStatus.Should().Be(WorkstationSecurityCoverageStatus.Resolved);
+        result.MatchedIdentifierKind.Should().Be(SecurityIdentifierKind.Ticker.ToString());
+        result.MatchedIdentifierValue.Should().Be("MSFT");
+        result.PrimaryIdentifier.Should().Be("594918104");
+        result.AssetClass.Should().BeEmpty();
+        result.Currency.Should().BeNull();
+        result.SubType.Should().BeNull();
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Increase test coverage around governance and reconciliation edge-cases so unresolved instrument identity is explicitly surfaced and security-classification payloads remain deterministic. 
- Ensure degraded Security Master metadata still produces deterministic labeling and matched-identifier fields for downstream governance surfaces. 
- Validate classification edge-cases (ambiguous/legacy sub-types and non-ticker identifiers) are preserved end-to-end in reconciliation summaries. 
- Verify report-generation preserves null-handling semantics and produces an `Unclassified` asset-class section when enrichment is missing.

### Description
- Strengthened reconciliation tests in `tests/Meridian.Tests/Application/ReconciliationRunServiceTests.cs` to assert unresolved identities remain surfaced as security coverage issues with the expected missing-match reason and to assert resolved symbols appear only in the `SecurityClassifications` map. 
- Added a reconciliation classification-edge test in the same file to verify ambiguous equity `SubType` remains `null`, legacy subtype values are preserved, and non-ticker `PrimaryIdentifierValue` is carried through. 
- Extended `tests/Meridian.Tests/SecurityMaster/SecurityMasterReferenceLookupTests.cs` with assertions that degraded metadata still produces deterministic `CoverageStatus`, `MatchedIdentifierKind`, and `MatchedIdentifierValue`, and that primary identifier fallback behavior is correct. 
- Added `tests/Meridian.Tests/Application/Services/ReportGenerationServiceTests.cs` with tests that verify the `ReportGenerationService.GenerateAsync` handles missing enrichment deterministically (rows keep nulls) and groups unclassified rows into an `Unclassified` asset-class section, and that mixed symbol identifier handling preserves nulls and populated fields as expected.

### Testing
- Attempted a targeted test run with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ReconciliationRunServiceTests|FullyQualifiedName~SecurityMasterReferenceLookupTests|FullyQualifiedName~ReportGenerationServiceTests"`. 
- The test run could not be executed in this environment because the .NET SDK/runtime is not available (`dotnet: command not found`). 
- No production code was changed; these are test-only additions and are ready for CI where the full .NET toolchain is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ec6d27688320888a14b152186816)