### PR TITLE
Add governance identity drill-in alias support

### DIFF
--- a/src/Meridian.Ui/dashboard/src/screens/governance-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/governance-screen.test.tsx
@@ -1,8 +1,24 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
+import * as api from "@/lib/api";
 import { GovernanceScreen } from "@/screens/governance-screen";
 import type { GovernanceWorkspaceResponse } from "@/types";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    searchSecurities: vi.fn().mockResolvedValue([]),
+    getSecurityIdentity: vi.fn().mockResolvedValue(null),
+    getSecurityConflicts: vi.fn().mockResolvedValue([]),
+    getReconciliationBreakQueue: vi.fn().mockResolvedValue([]),
+    resolveReconciliationBreak: vi.fn(),
+    reviewReconciliationBreak: vi.fn(),
+    getRunTrialBalance: vi.fn().mockResolvedValue([]),
+    resolveSecurityConflict: vi.fn()
+  };
+});
 
 const data: GovernanceWorkspaceResponse = {
   metrics: [
@@ -103,6 +119,82 @@ describe("GovernanceScreen", () => {
     );
 
     expect(screen.getByText("Security coverage")).toBeInTheDocument();
+  });
+
+  it("accepts and renders alias rows inside identity drill-in for governance workflows", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.searchSecurities).mockResolvedValueOnce([
+      {
+        securityId: "sec-1",
+        displayName: "Apple Inc.",
+        status: "Active",
+        classification: {
+          assetClass: "Equity",
+          subType: "CommonStock",
+          primaryIdentifierKind: "Ticker",
+          primaryIdentifierValue: "AAPL"
+        },
+        economicDefinition: {
+          currency: "USD",
+          version: 3,
+          effectiveFrom: "2024-01-01T00:00:00Z",
+          effectiveTo: null,
+          subType: "CommonStock",
+          assetFamily: "Equity",
+          issuerType: "Corporate"
+        }
+      }
+    ]);
+    vi.mocked(api.getSecurityIdentity).mockResolvedValueOnce({
+      securityId: "sec-1",
+      displayName: "Apple Inc.",
+      assetClass: "Equity",
+      status: "Active",
+      version: 3,
+      effectiveFrom: "2024-01-01T00:00:00Z",
+      effectiveTo: null,
+      identifiers: [
+        {
+          kind: "Ticker",
+          value: "AAPL",
+          isPrimary: true,
+          validFrom: "2024-01-01T00:00:00Z",
+          validTo: null,
+          provider: "Bloomberg"
+        }
+      ],
+      aliases: [
+        {
+          aliasId: "alias-1",
+          securityId: "sec-1",
+          aliasKind: "ProviderSymbol",
+          aliasValue: "AAPL.OQ",
+          provider: "Nasdaq",
+          scope: "Collector",
+          reason: "Market data source mapping",
+          createdBy: "ops.gov",
+          createdAt: "2025-01-01T00:00:00Z",
+          validFrom: "2025-01-01T00:00:00Z",
+          validTo: null,
+          isEnabled: true
+        }
+      ]
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/governance/security-master"]}>
+        <GovernanceScreen data={data} />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByPlaceholderText("Search securities…"), "AAPL");
+    const securityRow = await screen.findByText("Apple Inc.");
+    await user.click(securityRow);
+
+    expect(await screen.findByText(/Identity drill-in · Apple Inc\./i)).toBeInTheDocument();
+    expect(screen.getByText("Aliases")).toBeInTheDocument();
+    expect(screen.getByText("AAPL.OQ")).toBeInTheDocument();
+    expect(screen.getByText("Collector")).toBeInTheDocument();
   });
 
   it("renders reconciliation detail on deep-link routes and updates selection", async () => {

--- a/src/Meridian.Ui/dashboard/src/screens/governance-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/governance-screen.tsx
@@ -5,6 +5,7 @@ import { MetricCard } from "@/components/meridian/metric-card";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
+  getSecurityIdentity,
   getReconciliationBreakQueue,
   getRunTrialBalance,
   getSecurityConflicts,
@@ -18,6 +19,7 @@ import type {
   GovernanceWorkspaceResponse,
   ReconciliationBreakQueueItem,
   ResolveConflictRequest,
+  SecurityIdentityDrillIn,
   SecurityMasterConflict,
   SecurityMasterEntry
 } from "@/types";
@@ -77,6 +79,9 @@ export function GovernanceScreen({ data }: GovernanceScreenProps) {
   const [securityQuery, setSecurityQuery] = useState("");
   const [securityResults, setSecurityResults] = useState<SecurityMasterEntry[] | null>(null);
   const [securitySearching, setSecuritySearching] = useState(false);
+  const [selectedSecurityId, setSelectedSecurityId] = useState<string | null>(null);
+  const [securityIdentity, setSecurityIdentity] = useState<SecurityIdentityDrillIn | null>(null);
+  const [securityIdentityLoading, setSecurityIdentityLoading] = useState(false);
   const securitySearchRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // --- Security Master conflicts state ---
@@ -110,6 +115,8 @@ export function GovernanceScreen({ data }: GovernanceScreenProps) {
 
   function handleSecurityQueryChange(q: string) {
     setSecurityQuery(q);
+    setSelectedSecurityId(null);
+    setSecurityIdentity(null);
     if (securitySearchRef.current) clearTimeout(securitySearchRef.current);
     if (!q.trim()) { setSecurityResults(null); return; }
     securitySearchRef.current = setTimeout(() => {
@@ -119,6 +126,15 @@ export function GovernanceScreen({ data }: GovernanceScreenProps) {
         .catch(() => setSecurityResults([]))
         .finally(() => setSecuritySearching(false));
     }, 350);
+  }
+
+  function handleSelectSecurity(securityId: string) {
+    setSelectedSecurityId(securityId);
+    setSecurityIdentityLoading(true);
+    getSecurityIdentity(securityId)
+      .then(setSecurityIdentity)
+      .catch(() => setSecurityIdentity(null))
+      .finally(() => setSecurityIdentityLoading(false));
   }
 
   async function handleResolveConflict(conflictId: string, resolution: ResolveConflictRequest["resolution"]) {
@@ -430,7 +446,14 @@ export function GovernanceScreen({ data }: GovernanceScreenProps) {
                     </thead>
                     <tbody className="divide-y divide-border/50">
                       {securityResults.map((s) => (
-                        <tr key={s.securityId} className="bg-background/20">
+                        <tr
+                          key={s.securityId}
+                          className={cn(
+                            "cursor-pointer bg-background/20 transition-colors hover:bg-secondary/30",
+                            selectedSecurityId === s.securityId ? "bg-primary/10" : ""
+                          )}
+                          onClick={() => handleSelectSecurity(s.securityId)}
+                        >
                           <td className="px-3 py-2 font-semibold text-foreground">{s.displayName}</td>
                           <td className="px-3 py-2 text-muted-foreground">{s.classification.assetClass}</td>
                           <td className="px-3 py-2 font-mono text-muted-foreground">
@@ -442,6 +465,66 @@ export function GovernanceScreen({ data }: GovernanceScreenProps) {
                       ))}
                     </tbody>
                   </table>
+                </div>
+              )}
+              {securityIdentityLoading && <p className="text-sm text-muted-foreground">Loading identity drill-in…</p>}
+              {securityIdentity && (
+                <div className="space-y-4 rounded-xl border border-border/70 bg-secondary/20 p-4">
+                  <div>
+                    <h4 className="font-semibold text-foreground">Identity drill-in · {securityIdentity.displayName}</h4>
+                    <p className="text-xs text-muted-foreground">
+                      {securityIdentity.securityId} · v{securityIdentity.version} · {securityIdentity.assetClass}
+                    </p>
+                  </div>
+
+                  <div>
+                    <div className="mb-2 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Identifiers</div>
+                    <div className="overflow-x-auto rounded-lg border border-border/60">
+                      <table className="min-w-full divide-y divide-border/50 text-left text-xs sm:text-sm">
+                        <thead className="bg-secondary/30">
+                          <tr>{["Kind", "Value", "Provider", "Primary", "Valid"].map((col) => <th key={col} className="px-3 py-2">{col}</th>)}</tr>
+                        </thead>
+                        <tbody className="divide-y divide-border/40">
+                          {securityIdentity.identifiers.map((identifier) => (
+                            <tr key={`${identifier.kind}-${identifier.value}`}>
+                              <td className="px-3 py-2 font-mono">{identifier.kind}</td>
+                              <td className="px-3 py-2 font-mono">{identifier.value}</td>
+                              <td className="px-3 py-2">{identifier.provider ?? "—"}</td>
+                              <td className="px-3 py-2">{identifier.isPrimary ? "Yes" : "No"}</td>
+                              <td className="px-3 py-2 font-mono">{new Date(identifier.validFrom).toLocaleDateString()}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+
+                  <div>
+                    <div className="mb-2 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Aliases</div>
+                    {securityIdentity.aliases.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">No aliases found.</p>
+                    ) : (
+                      <div className="overflow-x-auto rounded-lg border border-border/60">
+                        <table className="min-w-full divide-y divide-border/50 text-left text-xs sm:text-sm">
+                          <thead className="bg-secondary/30">
+                            <tr>{["Kind", "Alias", "Provider", "Scope", "Enabled", "Valid From"].map((col) => <th key={col} className="px-3 py-2">{col}</th>)}</tr>
+                          </thead>
+                          <tbody className="divide-y divide-border/40">
+                            {securityIdentity.aliases.map((alias) => (
+                              <tr key={alias.aliasId}>
+                                <td className="px-3 py-2 font-mono">{alias.aliasKind}</td>
+                                <td className="px-3 py-2 font-mono">{alias.aliasValue}</td>
+                                <td className="px-3 py-2">{alias.provider ?? "—"}</td>
+                                <td className="px-3 py-2">{alias.scope}</td>
+                                <td className="px-3 py-2">{alias.isEnabled ? "Yes" : "No"}</td>
+                                <td className="px-3 py-2 font-mono">{new Date(alias.validFrom).toLocaleDateString()}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    )}
+                  </div>
                 </div>
               )}
             </CardContent>

--- a/src/Meridian.Ui/dashboard/src/types.ts
+++ b/src/Meridian.Ui/dashboard/src/types.ts
@@ -650,6 +650,21 @@ export interface SecurityIdentifierEntry {
   provider: string | null;
 }
 
+export interface SecurityAliasEntry {
+  aliasId: string;
+  securityId: string;
+  aliasKind: string;
+  aliasValue: string;
+  provider: string | null;
+  scope: "Operations" | "Collector" | "Execution" | "Migration";
+  reason: string | null;
+  createdBy: string;
+  createdAt: string;
+  validFrom: string;
+  validTo: string | null;
+  isEnabled: boolean;
+}
+
 export interface SecurityIdentityDrillIn {
   securityId: string;
   displayName: string;
@@ -659,6 +674,7 @@ export interface SecurityIdentityDrillIn {
   effectiveFrom: string;
   effectiveTo: string | null;
   identifiers: SecurityIdentifierEntry[];
+  aliases: SecurityAliasEntry[];
 }
 
 export interface SecurityMasterConflict {


### PR DESCRIPTION
### Motivation
- Align the dashboard client model with the API by representing security aliases in drill-in payloads so governance workflows can surface and act on alias metadata.
- Ensure the governance Security Master UI accepts and displays alias rows for operator review and downstream workflows.

### Description
- Added a `SecurityAliasEntry` interface and appended `aliases: SecurityAliasEntry[]` to `SecurityIdentityDrillIn` in `src/Meridian.Ui/dashboard/src/types.ts` to mirror the API `SecurityAliasDto` shape.
- Updated `src/Meridian.Ui/dashboard/src/screens/governance-screen.tsx` to fetch `getSecurityIdentity` when a search result is selected, preserve the returned identity in component state, and render identifier and alias tables (including loading and empty states) in the identity drill-in panel.
- Made search result rows selectable/clickable and visually highlighted the selected security for clarity in the Security Master workflow.
- Added/extended a front-end unit test in `src/Meridian.Ui/dashboard/src/screens/governance-screen.test.tsx` that mocks `@/lib/api` and validates alias payloads are accepted and rendered (asserts alias `AAPL.OQ` and scope `Collector` are displayed).

### Testing
- Added a new test scenario for the governance screen, but attempting to run the dashboard tests in this environment failed because the dashboard package manifest is missing, shown when running `pnpm --dir src/Meridian.Ui/dashboard test -- src/screens/governance-screen.test.tsx` and `npm run ui:dashboard:test -- src/screens/governance-screen.test.tsx` (both could not find `src/Meridian.Ui/dashboard/package.json`).
- No automated tests were executed here due to the missing dashboard `package.json`, so there are no local pass/fail results to report for the new test in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ec6bb3d08320941e4d321cf7a4f4)