### PR TITLE
Add governance enrichment fields to report generation rows

### DIFF
--- a/src/Meridian.Application/Services/ReportGenerationService.cs
+++ b/src/Meridian.Application/Services/ReportGenerationService.cs
@@ -69,6 +69,7 @@ public sealed class ReportGenerationService
             ct.ThrowIfCancellationRequested();
 
             SecurityDetailDto? detail = null;
+            SecurityEconomicDefinitionRecord? economicDefinition = null;
             if (!string.IsNullOrWhiteSpace(account.Symbol))
             {
                 try
@@ -76,6 +77,13 @@ public sealed class ReportGenerationService
                     detail = await _securityMaster
                         .GetByIdentifierAsync(SecurityIdentifierKind.Ticker, account.Symbol, null, ct)
                         .ConfigureAwait(false);
+
+                    if (detail is not null)
+                    {
+                        economicDefinition = await _securityMaster
+                            .GetEconomicDefinitionByIdAsync(detail.SecurityId, ct)
+                            .ConfigureAwait(false);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -83,12 +91,23 @@ public sealed class ReportGenerationService
                 }
             }
 
+            var primaryIdentifier = economicDefinition?.Identifiers
+                .FirstOrDefault(static identifier => identifier.IsPrimary);
+            var lookupQuality = ResolveLookupQuality(detail, economicDefinition, primaryIdentifier);
+
             rows.Add(new EnrichedLedgerRow(
                 AccountName: account.Name,
                 AccountType: account.AccountType.ToString(),
                 Symbol: account.Symbol,
                 Currency: detail?.Currency,
                 AssetClass: detail?.AssetClass,
+                PrimaryIdentifierKind: primaryIdentifier?.Kind.ToString(),
+                PrimaryIdentifierValue: primaryIdentifier?.Value,
+                SubType: economicDefinition?.SubType,
+                AssetFamily: economicDefinition?.AssetFamily,
+                IssuerType: economicDefinition?.IssuerType,
+                RiskCountry: economicDefinition?.RiskCountry,
+                LookupQuality: lookupQuality,
                 DisplayName: detail?.DisplayName,
                 NetBalance: balance));
         }
@@ -102,13 +121,37 @@ public sealed class ReportGenerationService
     private static IReadOnlyList<AssetClassSection> BuildAssetClassSections(
         IReadOnlyList<EnrichedLedgerRow> rows)
         => rows
-            .GroupBy(r => r.AssetClass ?? "Unclassified", StringComparer.OrdinalIgnoreCase)
+            .GroupBy(r => r.AssetFamily ?? r.AssetClass ?? "Unclassified", StringComparer.OrdinalIgnoreCase)
             .Select(g => new AssetClassSection(
                 AssetClass: g.Key,
                 Rows: g.ToList(),
                 Total: g.Sum(r => r.NetBalance)))
             .OrderBy(s => s.AssetClass, StringComparer.Ordinal)
             .ToList();
+
+    private static string ResolveLookupQuality(
+        SecurityDetailDto? detail,
+        SecurityEconomicDefinitionRecord? economicDefinition,
+        SecurityIdentifierDto? primaryIdentifier)
+    {
+        if (detail is null)
+            return "missing";
+
+        if (economicDefinition is null)
+            return "partial";
+
+        var hasPrimaryIdentifier = primaryIdentifier is not null
+                                   && !string.IsNullOrWhiteSpace(primaryIdentifier.Value);
+        var hasGovernanceDimensions =
+            !string.IsNullOrWhiteSpace(economicDefinition.SubType)
+            && !string.IsNullOrWhiteSpace(economicDefinition.AssetFamily)
+            && !string.IsNullOrWhiteSpace(economicDefinition.IssuerType)
+            && !string.IsNullOrWhiteSpace(economicDefinition.RiskCountry);
+
+        return hasPrimaryIdentifier && hasGovernanceDimensions
+            ? "resolved"
+            : "partial";
+    }
 }
 
 // ── Request / result models ────────────────────────────────────────────────────
@@ -136,6 +179,13 @@ public sealed record EnrichedLedgerRow(
     string? Symbol,
     string? Currency,
     string? AssetClass,
+    string? PrimaryIdentifierKind,
+    string? PrimaryIdentifierValue,
+    string? SubType,
+    string? AssetFamily,
+    string? IssuerType,
+    string? RiskCountry,
+    string LookupQuality,
     string? DisplayName,
     decimal NetBalance);
 

--- a/tests/Meridian.Tests/Application/Services/ReportGenerationServiceTests.cs
+++ b/tests/Meridian.Tests/Application/Services/ReportGenerationServiceTests.cs
@@ -1,0 +1,240 @@
+using System.Text.Json;
+using FluentAssertions;
+using Meridian.Application.SecurityMaster;
+using Meridian.Application.Services;
+using Meridian.Contracts.SecurityMaster;
+using Meridian.Ledger;
+using Xunit;
+
+namespace Meridian.Tests.Application.Services;
+
+public sealed class ReportGenerationServiceTests
+{
+    [Fact]
+    public async Task GenerateAsync_WithEconomicDefinition_MapsGovernanceFieldsAndResolvedQuality()
+    {
+        var securityId = Guid.NewGuid();
+        var query = new StubSecurityMasterQueryService(
+            detailsBySymbol: new Dictionary<string, SecurityDetailDto>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["AAPL"] = BuildDetail(securityId, "AAPL", "Equity")
+            },
+            economicsBySecurityId: new Dictionary<Guid, SecurityEconomicDefinitionRecord>
+            {
+                [securityId] = BuildEconomicDefinition(
+                    securityId,
+                    assetClass: "Equity",
+                    assetFamily: "PublicEquity",
+                    subType: "CommonStock",
+                    issuerType: "Corporate",
+                    riskCountry: "US",
+                    primaryKind: SecurityIdentifierKind.Isin,
+                    primaryValue: "US0378331005")
+            });
+        var service = new ReportGenerationService(query);
+        var ledgerBook = BuildLedgerBookWithSymbols(["AAPL"]);
+
+        var report = await service.GenerateAsync(new ReportRequest(
+            FundId: "fund-1",
+            AsOf: new DateTimeOffset(2026, 4, 11, 0, 0, 0, TimeSpan.Zero),
+            FundLedger: ledgerBook));
+
+        var row = report.TrialBalance.Single(r => string.Equals(r.Symbol, "AAPL", StringComparison.OrdinalIgnoreCase));
+        row.PrimaryIdentifierKind.Should().Be(SecurityIdentifierKind.Isin.ToString());
+        row.PrimaryIdentifierValue.Should().Be("US0378331005");
+        row.SubType.Should().Be("CommonStock");
+        row.AssetFamily.Should().Be("PublicEquity");
+        row.IssuerType.Should().Be("Corporate");
+        row.RiskCountry.Should().Be("US");
+        row.LookupQuality.Should().Be("resolved");
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WithMissingEconomicDefinition_UsesPartialLookupQuality()
+    {
+        var securityId = Guid.NewGuid();
+        var query = new StubSecurityMasterQueryService(
+            detailsBySymbol: new Dictionary<string, SecurityDetailDto>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["AAPL"] = BuildDetail(securityId, "AAPL", "Equity")
+            },
+            economicsBySecurityId: new Dictionary<Guid, SecurityEconomicDefinitionRecord>());
+        var service = new ReportGenerationService(query);
+        var ledgerBook = BuildLedgerBookWithSymbols(["AAPL"]);
+
+        var report = await service.GenerateAsync(new ReportRequest(
+            FundId: "fund-1",
+            AsOf: new DateTimeOffset(2026, 4, 11, 0, 0, 0, TimeSpan.Zero),
+            FundLedger: ledgerBook));
+
+        var row = report.TrialBalance.Single(r => string.Equals(r.Symbol, "AAPL", StringComparison.OrdinalIgnoreCase));
+        row.LookupQuality.Should().Be("partial");
+        row.AssetFamily.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GenerateAsync_GroupsByAssetFamilyThenAssetClassFallback()
+    {
+        var equitySecurityId = Guid.NewGuid();
+        var creditSecurityId = Guid.NewGuid();
+        var query = new StubSecurityMasterQueryService(
+            detailsBySymbol: new Dictionary<string, SecurityDetailDto>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["AAPL"] = BuildDetail(equitySecurityId, "AAPL", "Equity"),
+                ["TLT"] = BuildDetail(creditSecurityId, "TLT", "FixedIncome")
+            },
+            economicsBySecurityId: new Dictionary<Guid, SecurityEconomicDefinitionRecord>
+            {
+                [equitySecurityId] = BuildEconomicDefinition(
+                    equitySecurityId,
+                    assetClass: "Equity",
+                    assetFamily: "PublicEquity",
+                    subType: "CommonStock",
+                    issuerType: "Corporate",
+                    riskCountry: "US",
+                    primaryKind: SecurityIdentifierKind.Isin,
+                    primaryValue: "US0378331005"),
+                [creditSecurityId] = BuildEconomicDefinition(
+                    creditSecurityId,
+                    assetClass: "FixedIncome",
+                    assetFamily: null,
+                    subType: "Treasury",
+                    issuerType: "Sovereign",
+                    riskCountry: "US",
+                    primaryKind: SecurityIdentifierKind.Isin,
+                    primaryValue: "US912810TM09")
+            });
+        var service = new ReportGenerationService(query);
+        var ledgerBook = BuildLedgerBookWithSymbols(["AAPL", "TLT"]);
+
+        var report = await service.GenerateAsync(new ReportRequest(
+            FundId: "fund-1",
+            AsOf: new DateTimeOffset(2026, 4, 11, 0, 0, 0, TimeSpan.Zero),
+            FundLedger: ledgerBook));
+
+        report.AssetClassSections.Select(section => section.AssetClass).Should().Contain("PublicEquity");
+        report.AssetClassSections.Select(section => section.AssetClass).Should().Contain("FixedIncome");
+    }
+
+    private static FundLedgerBook BuildLedgerBookWithSymbols(IReadOnlyList<string> symbols)
+    {
+        var ledgerBook = new FundLedgerBook("fund-1");
+        var timestamp = new DateTimeOffset(2026, 4, 11, 14, 0, 0, TimeSpan.Zero);
+
+        foreach (var symbol in symbols)
+        {
+            ledgerBook.FundLedger.PostLines(
+                timestamp,
+                $"Seed {symbol}",
+                [
+                    (new LedgerAccount($"Position {symbol}", LedgerAccountType.Asset, symbol), 100m, 0m),
+                    (new LedgerAccount("Capital", LedgerAccountType.Equity), 0m, 100m)
+                ]);
+        }
+
+        return ledgerBook;
+    }
+
+    private static SecurityDetailDto BuildDetail(Guid securityId, string symbol, string assetClass)
+        => new(
+            SecurityId: securityId,
+            AssetClass: assetClass,
+            Status: SecurityStatusDto.Active,
+            DisplayName: symbol,
+            Currency: "USD",
+            CommonTerms: EmptyJsonElement(),
+            AssetSpecificTerms: EmptyJsonElement(),
+            Identifiers:
+            [
+                new SecurityIdentifierDto(
+                    Kind: SecurityIdentifierKind.Ticker,
+                    Value: symbol,
+                    IsPrimary: true,
+                    ValidFrom: new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero))
+            ],
+            Aliases: [],
+            Version: 1,
+            EffectiveFrom: new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            EffectiveTo: null);
+
+    private static SecurityEconomicDefinitionRecord BuildEconomicDefinition(
+        Guid securityId,
+        string assetClass,
+        string? assetFamily,
+        string subType,
+        string issuerType,
+        string riskCountry,
+        SecurityIdentifierKind primaryKind,
+        string primaryValue)
+        => new(
+            SecurityId: securityId,
+            AssetClass: assetClass,
+            AssetFamily: assetFamily,
+            SubType: subType,
+            TypeName: subType,
+            IssuerType: issuerType,
+            RiskCountry: riskCountry,
+            Status: SecurityStatusDto.Active,
+            DisplayName: "Security",
+            Currency: "USD",
+            Classification: EmptyJsonElement(),
+            CommonTerms: EmptyJsonElement(),
+            EconomicTerms: EmptyJsonElement(),
+            Provenance: EmptyJsonElement(),
+            Version: 1,
+            EffectiveFrom: new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            EffectiveTo: null,
+            Identifiers:
+            [
+                new SecurityIdentifierDto(
+                    Kind: primaryKind,
+                    Value: primaryValue,
+                    IsPrimary: true,
+                    ValidFrom: new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero))
+            ],
+            LegacyAssetClass: null,
+            LegacyAssetSpecificTerms: null);
+
+    private static JsonElement EmptyJsonElement() => JsonDocument.Parse("{}").RootElement.Clone();
+
+    private sealed class StubSecurityMasterQueryService : ISecurityMasterQueryService
+    {
+        private readonly IReadOnlyDictionary<string, SecurityDetailDto> _detailsBySymbol;
+        private readonly IReadOnlyDictionary<Guid, SecurityEconomicDefinitionRecord> _economicsBySecurityId;
+
+        public StubSecurityMasterQueryService(
+            IReadOnlyDictionary<string, SecurityDetailDto> detailsBySymbol,
+            IReadOnlyDictionary<Guid, SecurityEconomicDefinitionRecord> economicsBySecurityId)
+        {
+            _detailsBySymbol = detailsBySymbol;
+            _economicsBySecurityId = economicsBySecurityId;
+        }
+
+        public Task<SecurityDetailDto?> GetByIdAsync(Guid securityId, CancellationToken ct = default)
+            => Task.FromResult<SecurityDetailDto?>(_detailsBySymbol.Values.FirstOrDefault(detail => detail.SecurityId == securityId));
+
+        public Task<SecurityDetailDto?> GetByIdentifierAsync(SecurityIdentifierKind identifierKind, string identifierValue, string? provider, CancellationToken ct = default)
+            => Task.FromResult(_detailsBySymbol.TryGetValue(identifierValue, out var detail) ? detail : null);
+
+        public Task<IReadOnlyList<SecuritySummaryDto>> SearchAsync(SecuritySearchRequest request, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<SecuritySummaryDto>>([]);
+
+        public Task<IReadOnlyList<SecurityMasterEventEnvelope>> GetHistoryAsync(SecurityHistoryRequest request, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<SecurityMasterEventEnvelope>>([]);
+
+        public Task<SecurityEconomicDefinitionRecord?> GetEconomicDefinitionByIdAsync(Guid securityId, CancellationToken ct = default)
+            => Task.FromResult(_economicsBySecurityId.TryGetValue(securityId, out var definition) ? definition : null);
+
+        public Task<TradingParametersDto?> GetTradingParametersAsync(Guid securityId, DateTimeOffset asOf, CancellationToken ct = default)
+            => Task.FromResult<TradingParametersDto?>(null);
+
+        public Task<IReadOnlyList<CorporateActionDto>> GetCorporateActionsAsync(Guid securityId, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<CorporateActionDto>>([]);
+
+        public Task<PreferredEquityTermsDto?> GetPreferredEquityTermsAsync(Guid securityId, CancellationToken ct = default)
+            => Task.FromResult<PreferredEquityTermsDto?>(null);
+
+        public Task<ConvertibleEquityTermsDto?> GetConvertibleEquityTermsAsync(Guid securityId, CancellationToken ct = default)
+            => Task.FromResult<ConvertibleEquityTermsDto?>(null);
+    }
+}


### PR DESCRIPTION
### Motivation
- Enrich governance report rows with security-definition fields required for oversight and grouping so governance views can surface primary identifiers, subtype, family, issuer, risk country, and an explicit coverage quality marker.
- Ensure enrichment uses the heavier economic-definition lookup when available (`GetEconomicDefinitionByIdAsync`) after the initial `GetByIdentifierAsync` match to populate governance-critical dimensions.
- Improve report grouping so governance slices prefer `AssetFamily` with fallback to `AssetClass` for more accurate board/compliance reporting.

### Description
- Expanded `EnrichedLedgerRow` to include `PrimaryIdentifierKind`, `PrimaryIdentifierValue`, `SubType`, `AssetFamily`, `IssuerType`, `RiskCountry`, and `LookupQuality` in `src/Meridian.Application/Services/ReportGenerationService.cs`.
- Updated `EnrichWithSecurityMasterAsync` to call `GetEconomicDefinitionByIdAsync(detail.SecurityId, ct)` when `GetByIdentifierAsync` succeeds and map those economic-definition fields into the enriched row.
- Added `ResolveLookupQuality` helper to classify coverage as `missing` / `partial` / `resolved` based on presence of `detail`, economic definition, primary identifier, and governance dimensions.
- Changed `BuildAssetClassSections` grouping to use `AssetFamily` first with fallback to `AssetClass` then `Unclassified`.
- Added unit tests `tests/Meridian.Tests/Application/Services/ReportGenerationServiceTests.cs` with a `StubSecurityMasterQueryService` covering: mapping of governance fields and `resolved` quality, `partial` quality when economic definition is missing, and grouping behavior (`AssetFamily` → `AssetClass` fallback).

### Testing
- Added focused tests but the test run could not be executed in this environment because `dotnet` is not available; attempted command: `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ReportGenerationServiceTests|FullyQualifiedName~FundStructureEndpointTests|FullyQualifiedName~FundOperationsWorkspaceReadServiceTests"` which failed with `/bin/bash: dotnet: command not found`.
- All new tests are included in the repository under `tests/Meridian.Tests/Application/Services/ReportGenerationServiceTests.cs` and are expected to run successfully in a normal build environment; test execution has not yet been validated here due to the missing runtime.
- No public endpoint DTOs were changed (report-pack preview DTOs remained unchanged) so integration contract surfaces were not altered by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ec68e48483209ac4413b81c3e600)