### PR TITLE
Use matched identifier metadata in reconciliation security classifications

### DIFF
--- a/src/Meridian.Contracts/Workstation/SecurityMasterWorkstationDtos.cs
+++ b/src/Meridian.Contracts/Workstation/SecurityMasterWorkstationDtos.cs
@@ -9,7 +9,10 @@ public sealed record SecurityClassificationSummaryDto(
     string AssetClass,
     string? SubType,
     string? PrimaryIdentifierKind,
-    string? PrimaryIdentifierValue);
+    string? PrimaryIdentifierValue,
+    string? MatchedIdentifierKind = null,
+    string? MatchedIdentifierValue = null,
+    string? MatchedProvider = null);
 
 /// <summary>
 /// Workstation-facing Security Master economic definition summary.

--- a/src/Meridian.Strategies/Services/ReconciliationRunService.cs
+++ b/src/Meridian.Strategies/Services/ReconciliationRunService.cs
@@ -213,8 +213,11 @@ public sealed class ReconciliationRunService : IReconciliationRunService
                     map[position.Symbol] = new SecurityClassificationSummaryDto(
                         AssetClass: position.Security.AssetClass,
                         SubType: position.Security.SubType,
-                        PrimaryIdentifierKind: "Ticker",
-                        PrimaryIdentifierValue: position.Security.PrimaryIdentifier ?? position.Symbol);
+                        PrimaryIdentifierKind: position.Security.MatchedIdentifierKind ?? "Ticker",
+                        PrimaryIdentifierValue: position.Security.PrimaryIdentifier ?? position.Symbol,
+                        MatchedIdentifierKind: position.Security.MatchedIdentifierKind,
+                        MatchedIdentifierValue: position.Security.MatchedIdentifierValue,
+                        MatchedProvider: position.Security.MatchedProvider);
                 }
             }
         }
@@ -230,8 +233,11 @@ public sealed class ReconciliationRunService : IReconciliationRunService
                     map[line.Symbol] = new SecurityClassificationSummaryDto(
                         AssetClass: line.Security.AssetClass,
                         SubType: line.Security.SubType,
-                        PrimaryIdentifierKind: "Ticker",
-                        PrimaryIdentifierValue: line.Security.PrimaryIdentifier ?? line.Symbol);
+                        PrimaryIdentifierKind: line.Security.MatchedIdentifierKind ?? "Ticker",
+                        PrimaryIdentifierValue: line.Security.PrimaryIdentifier ?? line.Symbol,
+                        MatchedIdentifierKind: line.Security.MatchedIdentifierKind,
+                        MatchedIdentifierValue: line.Security.MatchedIdentifierValue,
+                        MatchedProvider: line.Security.MatchedProvider);
                 }
             }
         }

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -2797,7 +2797,10 @@ public static class WorkstationEndpoints
                 AssetClass: summary.AssetClass,
                 SubType: DeriveSubType(summary.AssetClass),
                 PrimaryIdentifierKind: null,
-                PrimaryIdentifierValue: summary.PrimaryIdentifier),
+                PrimaryIdentifierValue: summary.PrimaryIdentifier,
+                MatchedIdentifierKind: null,
+                MatchedIdentifierValue: null,
+                MatchedProvider: null),
             EconomicDefinition: new SecurityEconomicDefinitionSummaryDto(
                 Currency: summary.Currency,
                 Version: summary.Version,
@@ -2818,7 +2821,10 @@ public static class WorkstationEndpoints
                 AssetClass: detail.AssetClass,
                 SubType: DeriveSubType(detail.AssetClass),
                 PrimaryIdentifierKind: primaryIdentifier?.Kind.ToString(),
-                PrimaryIdentifierValue: primaryIdentifier?.Value),
+                PrimaryIdentifierValue: primaryIdentifier?.Value,
+                MatchedIdentifierKind: null,
+                MatchedIdentifierValue: null,
+                MatchedProvider: null),
             EconomicDefinition: new SecurityEconomicDefinitionSummaryDto(
                 Currency: detail.Currency,
                 Version: detail.Version,

--- a/src/Meridian.Ui/dashboard/src/types.ts
+++ b/src/Meridian.Ui/dashboard/src/types.ts
@@ -621,6 +621,9 @@ export interface SecurityClassificationSummary {
   subType: string | null;
   primaryIdentifierKind: string | null;
   primaryIdentifierValue: string | null;
+  matchedIdentifierKind?: string | null;
+  matchedIdentifierValue?: string | null;
+  matchedProvider?: string | null;
 }
 
 export interface SecurityEconomicDefinitionSummary {

--- a/tests/Meridian.Tests/Application/ReconciliationRunServiceTests.cs
+++ b/tests/Meridian.Tests/Application/ReconciliationRunServiceTests.cs
@@ -85,7 +85,10 @@ public sealed class ReconciliationRunServiceTests
             Currency: "USD",
             Status: SecurityStatusDto.Active,
             PrimaryIdentifier: "AAPL",
-            SubType: "CommonShare"));
+            SubType: "CommonShare",
+            MatchedIdentifierKind: "ISIN",
+            MatchedIdentifierValue: "US0378331005",
+            MatchedProvider: "OpenFIGI"));
         lookup.Register("TSLA", new WorkstationSecurityReference(
             SecurityId: Guid.Parse("22222222-2222-2222-2222-222222222222"),
             DisplayName: "Tesla Inc.",
@@ -108,7 +111,12 @@ public sealed class ReconciliationRunServiceTests
         detail.SecurityClassifications!.Should().ContainKey("AAPL");
         detail.SecurityClassifications["AAPL"].AssetClass.Should().Be("Equity");
         detail.SecurityClassifications["AAPL"].SubType.Should().Be("CommonShare");
+        detail.SecurityClassifications["AAPL"].PrimaryIdentifierKind.Should().Be("ISIN");
         detail.SecurityClassifications["AAPL"].PrimaryIdentifierValue.Should().Be("AAPL");
+        detail.SecurityClassifications["AAPL"].MatchedIdentifierKind.Should().Be("ISIN");
+        detail.SecurityClassifications["AAPL"].MatchedIdentifierValue.Should().Be("US0378331005");
+        detail.SecurityClassifications["AAPL"].MatchedProvider.Should().Be("OpenFIGI");
+        detail.SecurityClassifications["TSLA"].PrimaryIdentifierKind.Should().Be("Ticker");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Reconciliation classifications should surface the identifier kind that was actually matched (e.g. ISIN) instead of always hardcoding `"Ticker"` so governance can make informed decisions.
- Preserve backward compatibility by falling back to `"Ticker"` when no matched kind is available.
- Propagate provider and matched-identifier context into governance-facing payloads so dashboards and audit surfaces can show provenance for automatic identifier matches.

### Description
- Updated `ReconciliationRunService.BuildSecurityClassifications` to prefer `position.Security.MatchedIdentifierKind` / `line.Security.MatchedIdentifierKind` for the classification `PrimaryIdentifierKind`, with a fallback to `"Ticker"`, and to include `MatchedIdentifierKind`, `MatchedIdentifierValue`, and `MatchedProvider` in the emitted DTO; changes in `src/Meridian.Strategies/Services/ReconciliationRunService.cs`.
- Extended the governance DTO `SecurityClassificationSummaryDto` to include optional `MatchedIdentifierKind`, `MatchedIdentifierValue`, and `MatchedProvider` fields in `src/Meridian.Contracts/Workstation/SecurityMasterWorkstationDtos.cs`.
- Updated workstation endpoint mappings to emit the new DTO shape (populating `null` where appropriate) in `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs`.
- Updated dashboard TypeScript types to accept the enriched classification payload by adding optional `matchedIdentifierKind`, `matchedIdentifierValue`, and `matchedProvider` in `src/Meridian.Ui/dashboard/src/types.ts`.
- Added/adjusted unit assertions to `tests/Meridian.Tests/Application/ReconciliationRunServiceTests.cs` to verify matched-identifier propagation and fallback behavior.

### Testing
- Attempted to run the reconciliation tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter ReconciliationRunServiceTests`, but the command failed in this environment with `/bin/bash: dotnet: command not found` so automated tests could not be executed here.
- Unit tests in `tests/Meridian.Tests` were updated to assert the new fields and fallback semantics, but their execution is pending in a CI or developer environment with the .NET SDK available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ec688890832098adf8dd3e8d3850)