### PR TITLE
Add partial-match and break-severity tests; expose severity in reconciliation DTOs

### DIFF
--- a/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
+++ b/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
@@ -42,6 +42,19 @@ public enum ReconciliationBreakCategory : byte
 }
 
 /// <summary>
+/// Materiality level for a reconciliation break.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<ReconciliationBreakSeverity>))]
+public enum ReconciliationBreakSeverity : byte
+{
+    Info = 0,
+    Low = 1,
+    Medium = 2,
+    High = 3,
+    Critical = 4
+}
+
+/// <summary>
 /// Request to create a reconciliation run for a recorded strategy run.
 /// </summary>
 public sealed record ReconciliationRunRequest(
@@ -103,7 +116,8 @@ public sealed record ReconciliationBreakDto(
     decimal Variance,
     string Reason,
     DateTimeOffset? ExpectedAsOf,
-    DateTimeOffset? ActualAsOf);
+    DateTimeOffset? ActualAsOf,
+    ReconciliationBreakSeverity Severity = ReconciliationBreakSeverity.Info);
 
 /// <summary>
 /// Security Master coverage issue attached to a reconciliation run.

--- a/src/Meridian.Strategies/Services/ReconciliationRunService.cs
+++ b/src/Meridian.Strategies/Services/ReconciliationRunService.cs
@@ -91,7 +91,8 @@ public sealed class ReconciliationRunService : IReconciliationRunService
                 result.Variance,
                 result.Reason,
                 result.HasExpectedAsOf ? result.ExpectedAsOf : null,
-                result.HasActualAsOf ? result.ActualAsOf : null));
+                result.HasActualAsOf ? result.ActualAsOf : null,
+                MapSeverity(result.Category, result.Variance)));
         }
 
         var securityCoverageIssues = BuildSecurityCoverageIssues(runDetail);
@@ -153,6 +154,18 @@ public sealed class ReconciliationRunService : IReconciliationRunService
         "investigating" => ReconciliationBreakStatus.Investigating,
         "resolved" => ReconciliationBreakStatus.Resolved,
         _ => ReconciliationBreakStatus.Open
+    };
+
+    private static ReconciliationBreakSeverity MapSeverity(string category, decimal variance) => category switch
+    {
+        "timing_mismatch" => ReconciliationBreakSeverity.High,
+        "missing_ledger_coverage" or "missing_portfolio_coverage" => ReconciliationBreakSeverity.High,
+        "classification_gap" => ReconciliationBreakSeverity.Medium,
+        "amount_mismatch" when Math.Abs(variance) >= 1_000m => ReconciliationBreakSeverity.Critical,
+        "amount_mismatch" when Math.Abs(variance) >= 100m => ReconciliationBreakSeverity.High,
+        "amount_mismatch" when Math.Abs(variance) >= 10m => ReconciliationBreakSeverity.Medium,
+        "amount_mismatch" => ReconciliationBreakSeverity.Low,
+        _ => ReconciliationBreakSeverity.Info
     };
 
     private static IReadOnlyList<ReconciliationSecurityCoverageIssueDto> BuildSecurityCoverageIssues(StrategyRunDetail detail)

--- a/tests/Meridian.FSharp.Tests/LedgerKernelTests.fs
+++ b/tests/Meridian.FSharp.Tests/LedgerKernelTests.fs
@@ -483,6 +483,27 @@ let ``ReconciliationRules apply returns NoMatch AmountBreak when amount exceeds 
     | other -> failwithf "Expected NoMatch AmountBreak but got %A" other
 
 [<Fact>]
+let ``ReconciliationRules apply returns PartialMatch when partial matching enabled and confidence clears threshold`` () =
+    let permissiveRule = {
+        MatchingRule.``default`` with
+            AllowPartialMatch = true
+            MinMatchConfidence = 0.65m
+    }
+
+    let c = candidate
+                (Guid.NewGuid())
+                1000m 989.5m // 1.05% variance: outside 1% tolerance but close enough for partial
+                "USD" "USD"
+                (DateTimeOffset.Parse("2026-06-01T00:00:00Z"))
+                (DateTimeOffset.Parse("2026-06-01T00:00:00Z"))
+
+    match ReconciliationRules.apply permissiveRule c with
+    | PartialMatch (conf, reason) ->
+        conf |> should (be greaterThanOrEqualTo) 0.65m
+        reason.Contains("Amount variance") |> should equal true
+    | other -> failwithf "Expected PartialMatch but got %A" other
+
+[<Fact>]
 let ``ReconciliationRules applyBest selects first matching rule from priority list`` () =
     let secId = Guid.NewGuid()
     let c = candidate
@@ -565,6 +586,23 @@ let ``LedgerBreakClassification severity marks large amount break as Critical`` 
 let ``LedgerBreakClassification severity marks small amount break as Medium`` () =
     // Within 1% variance
     LedgerBreakClassification.severity 1000m (AmountBreak(1000m, 1005m))
+    |> should equal Medium
+
+[<Fact>]
+let ``LedgerBreakClassification severity honors timing and missing-entry materiality thresholds`` () =
+    LedgerBreakClassification.severity 1000m (TimingBreak 2)
+    |> should equal Low
+
+    LedgerBreakClassification.severity 1000m (TimingBreak 10)
+    |> should equal Medium
+
+    LedgerBreakClassification.severity 1000m (TimingBreak 45)
+    |> should equal High
+
+    LedgerBreakClassification.severity 25_000m MissingEntry
+    |> should equal High
+
+    LedgerBreakClassification.severity 500m MissingEntry
     |> should equal Medium
 
 [<Fact>]
@@ -750,6 +788,122 @@ let ``LedgerInterop ToBreakRecordClassificationDtos preserves canonical classifi
 
     dtos.Length |> should equal 1
     dtos[0].BreakId |> should equal record.BreakId
+    dtos[0].TaxonomyVersion |> should equal "reconciliation-break-taxonomy/v1"
     dtos[0].CanonicalClass |> should equal "CashFlow"
     dtos[0].PrimaryReasonCode |> should equal "CashAmountMismatch"
+    dtos[0].ReasonCodes |> should equal [| "CashAmountMismatch" |]
+    dtos[0].Severity |> should equal "High"
     dtos[0].IsFallbackClassification |> should equal false
+
+[<Fact>]
+let ``LedgerInterop ToReconciliationResultDtos preserves status and outcome metadata for C# consumers`` () =
+    let results : ReconciliationResult array = [|
+        {
+            SecurityId = "bond-1"
+            FlowId = "coupon-1"
+            EventId = "evt-1"
+            ExpectedAmount = 100m
+            ActualAmount = 100m
+            Variance = 0m
+            ExpectedCurrency = "USD"
+            ActualCurrency = "USD"
+            DueDate = DateTimeOffset.Parse("2026-09-01T00:00:00Z")
+            PostedAt = DateTimeOffset.Parse("2026-09-01T00:00:00Z")
+            Outcome = ReconciliationOutcome.Matched
+            OutcomeLabel = "Matched"
+            Status = ReconciliationStatus.Matched
+        }
+        {
+            SecurityId = "bond-2"
+            FlowId = "coupon-2"
+            EventId = "evt-2"
+            ExpectedAmount = 250m
+            ActualAmount = 200m
+            Variance = -50m
+            ExpectedCurrency = "USD"
+            ActualCurrency = "USD"
+            DueDate = DateTimeOffset.Parse("2026-10-01T00:00:00Z")
+            PostedAt = DateTimeOffset.Parse("2026-10-01T00:00:00Z")
+            Outcome = ReconciliationOutcome.UnderPaid -50m
+            OutcomeLabel = "UnderPaid"
+            Status = ReconciliationStatus.UnderPaid
+        }
+        {
+            SecurityId = "bond-3"
+            FlowId = "coupon-3"
+            EventId = "evt-3"
+            ExpectedAmount = 300m
+            ActualAmount = 300m
+            Variance = 0m
+            ExpectedCurrency = "USD"
+            ActualCurrency = "USD"
+            DueDate = DateTimeOffset.Parse("2026-11-01T00:00:00Z")
+            PostedAt = DateTimeOffset.Parse("2026-11-05T00:00:00Z")
+            Outcome = ReconciliationOutcome.TimingMismatch 4
+            OutcomeLabel = "TimingMismatch"
+            Status = ReconciliationStatus.TimingMismatch
+        }
+    |]
+
+    let dtos = LedgerInterop.ToReconciliationResultDtos results
+
+    dtos.Length |> should equal 3
+    dtos[0].Status |> should equal "Matched"
+    dtos[0].Outcome.Outcome |> should equal "Matched"
+    dtos[1].Status |> should equal "UnderPaid"
+    dtos[1].Outcome.Variance |> should equal (Some -50m)
+    dtos[2].Status |> should equal "TimingMismatch"
+    dtos[2].Outcome.DaysLate |> should equal (Some 4)
+
+[<Fact>]
+let ``LedgerInterop ReconcilePortfolioLedgerChecks preserves category and status labels at C# boundary`` () =
+    let checks : PortfolioLedgerCheckDto array = [|
+        {
+            CheckId = "amount-break"
+            Label = "Amount break"
+            ExpectedSource = "portfolio"
+            ActualSource = "ledger"
+            ExpectedAmount = 100m
+            ActualAmount = 70m
+            HasExpectedAmount = true
+            HasActualAmount = true
+            ExpectedPresent = true
+            ActualPresent = true
+            ExpectedAsOf = DateTimeOffset.Parse("2026-03-01T00:00:00Z")
+            ActualAsOf = DateTimeOffset.Parse("2026-03-01T00:00:00Z")
+            HasExpectedAsOf = true
+            HasActualAsOf = true
+            CategoryHint = "amount"
+            MissingSourceHint = ""
+            ActualKind = "amount"
+        }
+        {
+            CheckId = "timing-break"
+            Label = "Timing break"
+            ExpectedSource = "portfolio"
+            ActualSource = "ledger"
+            ExpectedAmount = 100m
+            ActualAmount = 100m
+            HasExpectedAmount = true
+            HasActualAmount = true
+            ExpectedPresent = true
+            ActualPresent = true
+            ExpectedAsOf = DateTimeOffset.Parse("2026-03-01T00:00:00Z")
+            ActualAsOf = DateTimeOffset.Parse("2026-03-01T00:20:00Z")
+            HasExpectedAsOf = true
+            HasActualAsOf = true
+            CategoryHint = "amount"
+            MissingSourceHint = ""
+            ActualKind = "amount"
+        }
+    |]
+
+    let results = LedgerInterop.ReconcilePortfolioLedgerChecks(0.01m, 5, checks)
+
+    results.Length |> should equal 2
+    results |> Array.find (fun r -> r.CheckId = "amount-break") |> fun r ->
+        r.Category |> should equal "amount_mismatch"
+        r.Status |> should equal "open"
+    results |> Array.find (fun r -> r.CheckId = "timing-break") |> fun r ->
+        r.Category |> should equal "timing_mismatch"
+        r.Status |> should equal "open"

--- a/tests/Meridian.Tests/Application/ReconciliationRunServiceTests.cs
+++ b/tests/Meridian.Tests/Application/ReconciliationRunServiceTests.cs
@@ -128,6 +128,47 @@ public sealed class ReconciliationRunServiceTests
     }
 
     [Fact]
+    public async Task RunAsync_WithNearToleranceVariance_ShouldKeepPartialLikeResultInMatches()
+    {
+        var store = new StrategyRunStore();
+        await store.RecordRunAsync(TestRunFactory.BuildReconciliationReadyRun(
+            "run-partial-like",
+            portfolioCashOverride: 750.005m));
+
+        var service = CreateService(store, new InMemoryReconciliationRunRepository());
+
+        var detail = await service.RunAsync(new ReconciliationRunRequest("run-partial-like", AmountTolerance: 0.01m));
+
+        detail.Should().NotBeNull();
+        detail!.Matches.Should().Contain(match =>
+            match.CheckId == "cash-balance" &&
+            match.Variance != 0m &&
+            Math.Abs(match.Variance) < 0.01m);
+    }
+
+    [Fact]
+    public async Task RunAsync_WithMaterialBreaks_ShouldSurfaceSeverityAndCanonicalReasonInDetail()
+    {
+        var store = new StrategyRunStore();
+        await store.RecordRunAsync(TestRunFactory.BuildReconciliationReadyRun(
+            "run-break-severity",
+            portfolioAsOfOffsetMinutes: 30,
+            portfolioCashOverride: 950m));
+
+        var service = CreateService(store, new InMemoryReconciliationRunRepository());
+
+        var detail = await service.RunAsync(new ReconciliationRunRequest("run-break-severity", AmountTolerance: 0.01m, MaxAsOfDriftMinutes: 5));
+
+        detail.Should().NotBeNull();
+        detail!.Breaks.Should().Contain(b => b.CheckId == "cash-balance"
+            && b.Category == ReconciliationBreakCategory.TimingMismatch
+            && b.Severity == ReconciliationBreakSeverity.High);
+        detail.Breaks.Should().Contain(b => b.CheckId == "net-equity"
+            && b.Category == ReconciliationBreakCategory.TimingMismatch
+            && b.Reason.Contains("drift beyond tolerance", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task GetHistoryForRunAsync_ShouldReturnNewestFirst()
     {
         var store = new StrategyRunStore();
@@ -299,10 +340,17 @@ public sealed class ReconciliationRunServiceTests
 
     private static class TestRunFactory
     {
-        public static StrategyRunEntry BuildReconciliationReadyRun(string runId)
+        public static StrategyRunEntry BuildReconciliationReadyRun(
+            string runId,
+            decimal? portfolioCashOverride = null,
+            int portfolioAsOfOffsetMinutes = 0,
+            int ledgerAsOfOffsetMinutes = 0)
         {
             var startedAt = new DateTimeOffset(2026, 3, 21, 16, 0, 0, TimeSpan.Zero);
             var completedAt = startedAt.AddMinutes(30);
+            var portfolioAsOf = completedAt.AddMinutes(portfolioAsOfOffsetMinutes);
+            var ledgerAsOf = completedAt.AddMinutes(ledgerAsOfOffsetMinutes);
+            var portfolioCash = portfolioCashOverride ?? 750m;
             var positions = new Dictionary<string, Position>(StringComparer.OrdinalIgnoreCase)
             {
                 ["AAPL"] = new("AAPL", 10, 40m, 0m, 0m),
@@ -313,21 +361,21 @@ public sealed class ReconciliationRunServiceTests
                 DisplayName: "Primary Brokerage",
                 Kind: FinancialAccountKind.Brokerage,
                 Institution: "Simulated Broker",
-                Cash: 750m,
+                Cash: portfolioCash,
                 MarginBalance: 0m,
                 LongMarketValue: 400m,
                 ShortMarketValue: -150m,
-                Equity: 1000m,
+                Equity: portfolioCash + 400m - 150m,
                 Positions: positions,
                 Rules: new FinancialAccountRules());
             var snapshot = new PortfolioSnapshot(
-                Timestamp: completedAt,
-                Date: DateOnly.FromDateTime(completedAt.UtcDateTime),
-                Cash: 750m,
+                Timestamp: portfolioAsOf,
+                Date: DateOnly.FromDateTime(portfolioAsOf.UtcDateTime),
+                Cash: portfolioCash,
                 MarginBalance: 0m,
                 LongMarketValue: 400m,
                 ShortMarketValue: -150m,
-                TotalEquity: 1000m,
+                TotalEquity: portfolioCash + 400m - 150m,
                 DailyReturn: 0m,
                 Positions: positions,
                 Accounts: new Dictionary<string, FinancialAccountSnapshot>(StringComparer.OrdinalIgnoreCase)
@@ -372,7 +420,7 @@ public sealed class ReconciliationRunServiceTests
                 CashFlows: [],
                 Fills: [],
                 Metrics: metrics,
-                Ledger: CreateLedger(),
+                Ledger: CreateLedger(ledgerAsOf),
                 ElapsedTime: TimeSpan.FromMinutes(30),
                 TotalEventsProcessed: 100);
 
@@ -483,20 +531,20 @@ public sealed class ReconciliationRunServiceTests
             };
         }
 
-        private static IReadOnlyLedger CreateLedger()
+        private static IReadOnlyLedger CreateLedger(DateTimeOffset asOf)
         {
             var ledger = new global::Meridian.Ledger.Ledger();
-            PostBalancedEntry(ledger, new DateTimeOffset(2026, 3, 21, 16, 0, 0, TimeSpan.Zero), "Initial capital",
+            PostBalancedEntry(ledger, asOf.AddMinutes(-30), "Initial capital",
             [
                 (LedgerAccounts.Cash, 1_000m, 0m),
                 (LedgerAccounts.CapitalAccount, 0m, 1_000m)
             ]);
-            PostBalancedEntry(ledger, new DateTimeOffset(2026, 3, 21, 16, 10, 0, TimeSpan.Zero), "Buy AAPL",
+            PostBalancedEntry(ledger, asOf.AddMinutes(-20), "Buy AAPL",
             [
                 (LedgerAccounts.Securities("AAPL"), 400m, 0m),
                 (LedgerAccounts.Cash, 0m, 400m)
             ]);
-            PostBalancedEntry(ledger, new DateTimeOffset(2026, 3, 21, 16, 20, 0, TimeSpan.Zero), "Open TSLA short",
+            PostBalancedEntry(ledger, asOf.AddMinutes(-10), "Open TSLA short",
             [
                 (LedgerAccounts.Cash, 150m, 0m),
                 (LedgerAccounts.ShortSecuritiesPayable("TSLA"), 0m, 150m)


### PR DESCRIPTION
### Motivation

- Increase reconciliation test coverage for real-world matching scenarios including exact/full match, amount mismatch, timing mismatch, and partial matches where `AllowPartialMatch = true` and confidence thresholds apply.  
- Ensure F# reconciliation outcomes, canonical taxonomy, reason codes and severity round-trip through `LedgerInterop` into C# DTOs consumed by the orchestration and workstation layers.  
- Surface break materiality (severity) at the orchestration boundary so `ReconciliationRunDetail` payloads include actionable severity for operator UX and downstream consumers.

### Description

- Added a `ReconciliationBreakSeverity` enum and extended `ReconciliationBreakDto` with a `Severity` field so severity can be carried in run detail payloads (`src/Meridian.Contracts/Workstation/ReconciliationDtos.cs`).  
- Mapped break category + variance → severity in `ReconciliationRunService` (added `MapSeverity`) and attach severity to each emitted break row (`src/Meridian.Strategies/Services/ReconciliationRunService.cs`).  
- Extended F# kernel tests in `tests/Meridian.FSharp.Tests/LedgerKernelTests.fs` to cover exact match, amount mismatch, timing mismatch, partial-match (when `AllowPartialMatch = true` and confidence threshold is met), severity thresholds for timing/missing-entry, and interop boundary assertions for `ToReconciliationResultDtos`, `ToBreakRecordClassificationDtos`, and `ReconcilePortfolioLedgerChecks`.  
- Added orchestration-level tests in `tests/Meridian.Tests/Application/ReconciliationRunServiceTests.cs` to verify near-tolerance (partial-like) matches remain in `ReconciliationRunDetail.Matches`, that break severity and canonical reason text appear in `ReconciliationRunDetail.Breaks`, and updated the test run factory to support deterministic cash/as-of overrides used by these scenarios.

### Testing

- Attempted to run the F# test project with `dotnet test tests/Meridian.FSharp.Tests/Meridian.FSharp.Tests.fsproj -c Release /p:EnableWindowsTargeting=true`, but the run failed in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`).  
- No automated test runs succeeded in this execution environment; the new and modified tests are committed and ready to run in CI or a developer environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ee36f6b083208863db7403020621)