### PR TITLE
Add reconciliation snapshot DTOs and project FundLedgerSnapshot into workspace payload

### DIFF
--- a/src/Meridian.Contracts/Workstation/FundLedgerDtos.cs
+++ b/src/Meridian.Contracts/Workstation/FundLedgerDtos.cs
@@ -64,3 +64,33 @@ public sealed record FundLedgerSummary(
     int EntityCount,
     int SleeveCount,
     int VehicleCount);
+
+/// <summary>
+/// Balance row captured in a reconciliation snapshot.
+/// </summary>
+public sealed record FundLedgerSnapshotBalanceLine(
+    string AccountName,
+    string AccountType,
+    string? Symbol,
+    string? FinancialAccountId,
+    decimal Balance);
+
+/// <summary>
+/// Point-in-time ledger snapshot used by reconciliation views.
+/// </summary>
+public sealed record FundLedgerDimensionSnapshot(
+    DateTimeOffset Timestamp,
+    int JournalEntryCount,
+    int LedgerEntryCount,
+    IReadOnlyList<FundLedgerSnapshotBalanceLine> Balances);
+
+/// <summary>
+/// Reconciliation snapshot of one fund ledger book, including consolidated totals and per-dimension breakdowns.
+/// </summary>
+public sealed record FundLedgerReconciliationSnapshot(
+    string FundProfileId,
+    DateTimeOffset AsOf,
+    FundLedgerDimensionSnapshot Consolidated,
+    IReadOnlyDictionary<string, FundLedgerDimensionSnapshot> Entities,
+    IReadOnlyDictionary<string, FundLedgerDimensionSnapshot> Sleeves,
+    IReadOnlyDictionary<string, FundLedgerDimensionSnapshot> Vehicles);

--- a/src/Meridian.Contracts/Workstation/FundOperationsWorkspaceDtos.cs
+++ b/src/Meridian.Contracts/Workstation/FundOperationsWorkspaceDtos.cs
@@ -75,6 +75,7 @@ public sealed record FundOperationsWorkspaceDto(
     IReadOnlyList<string> RelatedRunIds,
     FundWorkspaceSummary Workspace,
     FundLedgerSummary Ledger,
+    FundLedgerReconciliationSnapshot LedgerReconciliationSnapshot,
     IReadOnlyList<FundAccountSummary> Accounts,
     IReadOnlyList<BankAccountSnapshot> BankSnapshots,
     CashFinancingSummary CashFinancing,

--- a/src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs
+++ b/src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs
@@ -76,6 +76,7 @@ public sealed class FundOperationsWorkspaceReadService
             query.ScopeId,
             asOf,
             ledgerBook);
+        var ledgerReconciliationSnapshot = ProjectReconciliationSnapshot(ledgerBook.ReconciliationSnapshot(asOf));
 
         var cashTask = BuildCashFinancingSummaryAsync(
             baseCurrency,
@@ -118,6 +119,7 @@ public sealed class FundOperationsWorkspaceReadService
             RelatedRunIds: runs.Select(static run => run.RunId).ToArray(),
             Workspace: workspace,
             Ledger: ledger,
+            LedgerReconciliationSnapshot: ledgerReconciliationSnapshot,
             Accounts: accountSummaries,
             BankSnapshots: bankSnapshots,
             CashFinancing: cashFinancing,
@@ -540,6 +542,42 @@ public sealed class FundOperationsWorkspaceReadService
             SleeveCount: sleeveCount,
             VehicleCount: vehicleCount);
     }
+
+    public static FundLedgerReconciliationSnapshot ProjectReconciliationSnapshot(FundLedgerSnapshot snapshot)
+    {
+        return new FundLedgerReconciliationSnapshot(
+            FundProfileId: snapshot.FundId,
+            AsOf: snapshot.AsOf,
+            Consolidated: ProjectDimensionSnapshot(snapshot.Consolidated),
+            Entities: snapshot.Entities.ToDictionary(
+                static pair => pair.Key,
+                static pair => ProjectDimensionSnapshot(pair.Value),
+                StringComparer.OrdinalIgnoreCase),
+            Sleeves: snapshot.Sleeves.ToDictionary(
+                static pair => pair.Key,
+                static pair => ProjectDimensionSnapshot(pair.Value),
+                StringComparer.OrdinalIgnoreCase),
+            Vehicles: snapshot.Vehicles.ToDictionary(
+                static pair => pair.Key,
+                static pair => ProjectDimensionSnapshot(pair.Value),
+                StringComparer.OrdinalIgnoreCase));
+    }
+
+    private static FundLedgerDimensionSnapshot ProjectDimensionSnapshot(LedgerSnapshot snapshot) =>
+        new(
+            Timestamp: snapshot.Timestamp,
+            JournalEntryCount: snapshot.JournalEntryCount,
+            LedgerEntryCount: snapshot.LedgerEntryCount,
+            Balances: snapshot.Balances
+                .OrderBy(static pair => pair.Key.AccountType)
+                .ThenBy(static pair => pair.Key.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(static pair => new FundLedgerSnapshotBalanceLine(
+                    AccountName: pair.Key.Name,
+                    AccountType: pair.Key.AccountType.ToString(),
+                    Symbol: pair.Key.Symbol,
+                    FinancialAccountId: pair.Key.FinancialAccountId,
+                    Balance: pair.Value))
+                .ToArray());
 
     private static FundLedgerBook BuildLedgerBook(
         string fundProfileId,

--- a/src/Meridian.Wpf/Services/FundLedgerReadService.cs
+++ b/src/Meridian.Wpf/Services/FundLedgerReadService.cs
@@ -1,5 +1,6 @@
 using Meridian.Contracts.Workstation;
 using Meridian.Ledger;
+using Meridian.Wpf.Models;
 
 namespace Meridian.Wpf.Services;
 
@@ -22,28 +23,13 @@ public sealed class FundLedgerReadService
     public async Task<FundLedgerSummary?> GetAsync(FundLedgerQuery query, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(query);
-        await _fundContextService.LoadAsync(ct).ConfigureAwait(false);
-
-        var profile = _fundContextService.Profiles.FirstOrDefault(item =>
-            string.Equals(item.FundProfileId, query.FundProfileId, StringComparison.OrdinalIgnoreCase));
-        if (profile is null)
+        var context = await BuildContextAsync(query.FundProfileId, ct).ConfigureAwait(false);
+        if (context is null)
         {
             return null;
         }
 
-        var fundLedgerBook = new FundLedgerBook(profile.FundProfileId);
-        var runs = await _runWorkspaceService.GetRecordedRunEntriesAsync(ct).ConfigureAwait(false);
-
-        foreach (var run in runs.Where(run =>
-                     string.Equals(run.FundProfileId, profile.FundProfileId, StringComparison.OrdinalIgnoreCase) &&
-                     run.Metrics?.Ledger is not null))
-        {
-            foreach (var journalEntry in run.Metrics!.Ledger!.Journal)
-            {
-                fundLedgerBook.FundLedger.Post(journalEntry);
-            }
-        }
-
+        var (profile, fundLedgerBook) = context.Value;
         var asOf = query.AsOf ?? DateTimeOffset.UtcNow;
         var journal = BuildJournal(fundLedgerBook, query, asOf);
         var trialBalance = BuildTrialBalance(fundLedgerBook, query, asOf);
@@ -71,6 +57,87 @@ public sealed class FundLedgerReadService
             EntityCount: entityCount,
             SleeveCount: sleeveCount,
             VehicleCount: vehicleCount);
+    }
+
+    public async Task<FundLedgerReconciliationSnapshot?> GetReconciliationSnapshotAsync(
+        FundLedgerQuery query,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        var context = await BuildContextAsync(query.FundProfileId, ct).ConfigureAwait(false);
+        if (context is null)
+        {
+            return null;
+        }
+
+        var (_, fundLedgerBook) = context.Value;
+        var asOf = query.AsOf ?? DateTimeOffset.UtcNow;
+        return ProjectReconciliationSnapshot(fundLedgerBook.ReconciliationSnapshot(asOf));
+    }
+
+    public static FundLedgerReconciliationSnapshot ProjectReconciliationSnapshot(FundLedgerSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        return new FundLedgerReconciliationSnapshot(
+            FundProfileId: snapshot.FundId,
+            AsOf: snapshot.AsOf,
+            Consolidated: ProjectDimensionSnapshot(snapshot.Consolidated),
+            Entities: snapshot.Entities.ToDictionary(
+                static pair => pair.Key,
+                static pair => ProjectDimensionSnapshot(pair.Value),
+                StringComparer.OrdinalIgnoreCase),
+            Sleeves: snapshot.Sleeves.ToDictionary(
+                static pair => pair.Key,
+                static pair => ProjectDimensionSnapshot(pair.Value),
+                StringComparer.OrdinalIgnoreCase),
+            Vehicles: snapshot.Vehicles.ToDictionary(
+                static pair => pair.Key,
+                static pair => ProjectDimensionSnapshot(pair.Value),
+                StringComparer.OrdinalIgnoreCase));
+    }
+
+    private static FundLedgerDimensionSnapshot ProjectDimensionSnapshot(LedgerSnapshot snapshot) =>
+        new(
+            Timestamp: snapshot.Timestamp,
+            JournalEntryCount: snapshot.JournalEntryCount,
+            LedgerEntryCount: snapshot.LedgerEntryCount,
+            Balances: snapshot.Balances
+                .OrderBy(static pair => pair.Key.AccountType)
+                .ThenBy(static pair => pair.Key.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(static pair => new FundLedgerSnapshotBalanceLine(
+                    AccountName: pair.Key.Name,
+                    AccountType: pair.Key.AccountType.ToString(),
+                    Symbol: pair.Key.Symbol,
+                    FinancialAccountId: pair.Key.FinancialAccountId,
+                    Balance: pair.Value))
+                .ToArray());
+
+    private async Task<(FundProfileDetail Profile, FundLedgerBook Book)?> BuildContextAsync(
+        string fundProfileId,
+        CancellationToken ct)
+    {
+        await _fundContextService.LoadAsync(ct).ConfigureAwait(false);
+        var profile = _fundContextService.Profiles.FirstOrDefault(item =>
+            string.Equals(item.FundProfileId, fundProfileId, StringComparison.OrdinalIgnoreCase));
+        if (profile is null)
+        {
+            return null;
+        }
+
+        var book = new FundLedgerBook(profile.FundProfileId);
+        var runs = await _runWorkspaceService.GetRecordedRunEntriesAsync(ct).ConfigureAwait(false);
+        foreach (var run in runs.Where(run =>
+                     string.Equals(run.FundProfileId, profile.FundProfileId, StringComparison.OrdinalIgnoreCase) &&
+                     run.Metrics?.Ledger is not null))
+        {
+            foreach (var journalEntry in run.Metrics!.Ledger!.Journal)
+            {
+                book.FundLedger.Post(journalEntry);
+            }
+        }
+
+        return (profile, book);
     }
 
     private static IReadOnlyList<FundTrialBalanceLine> BuildTrialBalance(

--- a/tests/Meridian.Tests/Application/Services/FundOperationsWorkspaceReadServiceTests.cs
+++ b/tests/Meridian.Tests/Application/Services/FundOperationsWorkspaceReadServiceTests.cs
@@ -126,9 +126,41 @@ public sealed class FundOperationsWorkspaceReadServiceTests
         workspace.CashFinancing.PendingSettlement.Should().Be(150m);
         workspace.Ledger.JournalEntryCount.Should().BeGreaterThan(0);
         workspace.Ledger.TrialBalance.Should().NotBeEmpty();
+        workspace.LedgerReconciliationSnapshot.AsOf.Should().Be(new DateTimeOffset(2026, 4, 11, 16, 0, 0, TimeSpan.Zero));
+        workspace.LedgerReconciliationSnapshot.Consolidated.JournalEntryCount.Should().BeGreaterThan(0);
+        workspace.LedgerReconciliationSnapshot.Consolidated.LedgerEntryCount.Should().BeGreaterThan(0);
+        workspace.LedgerReconciliationSnapshot.Consolidated.Balances.Should().NotBeEmpty();
+        workspace.LedgerReconciliationSnapshot.Entities.Should().BeEmpty();
+        workspace.LedgerReconciliationSnapshot.Sleeves.Should().BeEmpty();
+        workspace.LedgerReconciliationSnapshot.Vehicles.Should().BeEmpty();
         workspace.Nav.ComponentCount.Should().BeGreaterThan(0);
         workspace.Reporting.ProfileCount.Should().BeGreaterThan(0);
         workspace.Workspace.TotalAccounts.Should().Be(2);
+    }
+
+    [Fact]
+    public void ProjectReconciliationSnapshot_MapsConsolidatedAndPerDimensionSnapshots()
+    {
+        var asOf = new DateTimeOffset(2026, 4, 11, 16, 0, 0, TimeSpan.Zero);
+        var cash = new LedgerAccount("Cash", LedgerAccountType.Asset);
+        var revenue = new LedgerAccount("Revenue", LedgerAccountType.Revenue);
+        var book = new FundLedgerBook("fund-projection");
+
+        book.EntityLedger("entity-a").PostLines(asOf, "entity-sale", [(cash, 70m, 0m), (revenue, 0m, 70m)]);
+        book.SleeveLedger("sleeve-core").PostLines(asOf, "sleeve-sale", [(cash, 20m, 0m), (revenue, 0m, 20m)]);
+        book.VehicleLedger("vehicle-master").PostLines(asOf, "vehicle-sale", [(cash, 10m, 0m), (revenue, 0m, 10m)]);
+
+        var projected = FundOperationsWorkspaceReadService.ProjectReconciliationSnapshot(
+            book.ReconciliationSnapshot(asOf));
+
+        projected.FundProfileId.Should().Be("fund-projection");
+        projected.Consolidated.JournalEntryCount.Should().Be(3);
+        projected.Consolidated.LedgerEntryCount.Should().Be(6);
+        projected.Consolidated.Balances.Should().ContainSingle(line => line.AccountName == "Cash" && line.Balance == 100m);
+        projected.Entities.Should().ContainKey("entity-a");
+        projected.Entities["entity-a"].Balances.Should().ContainSingle(line => line.AccountName == "Cash" && line.Balance == 70m);
+        projected.Sleeves.Should().ContainKey("sleeve-core");
+        projected.Vehicles.Should().ContainKey("vehicle-master");
     }
 
     [Fact]

--- a/tests/Meridian.Tests/Ledger/LedgerIntegrationTests.cs
+++ b/tests/Meridian.Tests/Ledger/LedgerIntegrationTests.cs
@@ -613,14 +613,21 @@ public sealed class LedgerIntegrationTests
 
         fund.EntityLedger("e1").PostLines(ts, "sale", new[] { (cash, 60m, 0m), (revenue, 0m, 60m) });
         fund.SleeveLedger("s1").PostLines(ts, "sale", new[] { (cash, 40m, 0m), (revenue, 0m, 40m) });
+        fund.VehicleLedger("v1").PostLines(ts, "sale", new[] { (cash, 25m, 0m), (revenue, 0m, 25m) });
 
         var snap = fund.ReconciliationSnapshot(ts);
 
         snap.FundId.Should().Be("fund-recon");
         snap.AsOf.Should().Be(ts);
-        snap.Consolidated.Balances[cash].Should().Be(100m);
+        snap.Consolidated.Balances[cash].Should().Be(125m);
+        snap.Consolidated.JournalEntryCount.Should().Be(3);
+        snap.Consolidated.LedgerEntryCount.Should().Be(6);
         snap.Entities.Should().ContainKey("e1");
+        snap.Entities["e1"].Balances[cash].Should().Be(60m);
+        snap.Entities["e1"].JournalEntryCount.Should().Be(1);
         snap.Sleeves.Should().ContainKey("s1");
-        snap.Vehicles.Should().BeEmpty();
+        snap.Sleeves["s1"].LedgerEntryCount.Should().Be(2);
+        snap.Vehicles.Should().ContainKey("v1");
+        snap.Vehicles["v1"].Balances[cash].Should().Be(25m);
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a canonical reconciliation snapshot DTO that mirrors the fields in `FundLedgerSnapshot` so reconciliation UI/screens can consume consolidated totals and per-dimension breakdowns.
- Surface the projected snapshot from ledger books into governance/workspace read APIs so a single workspace payload carries the reconciliation view for operator workflows.

### Description
- Add DTOs to `src/Meridian.Contracts/Workstation/FundLedgerDtos.cs` (`FundLedgerSnapshotBalanceLine`, `FundLedgerDimensionSnapshot`, and `FundLedgerReconciliationSnapshot`) to represent per-account rows, per-dimension snapshots (timestamp + counts + balances), and the full fund reconciliation snapshot.
- Add `LedgerReconciliationSnapshot` to `FundOperationsWorkspaceDto` in `src/Meridian.Contracts/Workstation/FundOperationsWorkspaceDtos.cs` so the workspace payload includes the reconciliation snapshot.
- Implement projection of `FundLedgerBook.ReconciliationSnapshot(asOf)` into the DTOs in both `src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs` and `src/Meridian.Wpf/Services/FundLedgerReadService.cs` via `ProjectReconciliationSnapshot(...)` and `ProjectDimensionSnapshot(...)`, and expose `GetReconciliationSnapshotAsync(...)` on the read service.
- Refactor ledger assembly into a shared `BuildContextAsync(...)` in `FundLedgerReadService` to avoid duplicating run-to-ledger bookkeeping logic and reuse it for reconciliation projection.
- Update tests to cover projection and mapping: `tests/Meridian.Tests/Ledger/LedgerIntegrationTests.cs` (expanded reconciliation snapshot assertions) and `tests/Meridian.Tests/Application/Services/FundOperationsWorkspaceReadServiceTests.cs` (workspace-level snapshot assertions and a dedicated `ProjectReconciliationSnapshot_MapsConsolidatedAndPerDimensionSnapshots` test).

### Testing
- Added and updated test assertions in `tests/Meridian.Tests/Ledger/LedgerIntegrationTests.cs` and `tests/Meridian.Tests/Application/Services/FundOperationsWorkspaceReadServiceTests.cs` to validate consolidated totals, per-dimension balances, and journal/ledger counts after projection.
- Attempted to run the focused test filter with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~LedgerIntegrationTests|FullyQualifiedName~FundOperationsWorkspaceReadServiceTests"` and the command failed in this environment with `/bin/bash: dotnet: command not found` so automated test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ee3f2c3c8320aa1adeb41b05c169)