### PR TITLE
Unify reconciliation kernel across F# and C#: preserve partial-match and severity in DTOs

### DIFF
--- a/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
+++ b/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
@@ -24,7 +24,18 @@ public enum ReconciliationBreakStatus : byte
     Open = 0,
     Matched = 1,
     Investigating = 2,
-    Resolved = 3
+    Resolved = 3,
+    PartialMatch = 4
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter<ReconciliationBreakSeverity>))]
+public enum ReconciliationBreakSeverity : byte
+{
+    Info = 0,
+    Low = 1,
+    Medium = 2,
+    High = 3,
+    Critical = 4
 }
 
 /// <summary>
@@ -38,7 +49,8 @@ public enum ReconciliationBreakCategory : byte
     MissingPortfolioCoverage = 2,
     ClassificationGap = 3,
     TimingMismatch = 4,
-    MissingBankCoverage = 5
+    MissingBankCoverage = 5,
+    PartialMatch = 6
 }
 
 /// <summary>
@@ -101,6 +113,7 @@ public sealed record ReconciliationBreakDto(
     decimal? ExpectedAmount,
     decimal? ActualAmount,
     decimal Variance,
+    ReconciliationBreakSeverity Severity,
     string Reason,
     DateTimeOffset? ExpectedAsOf,
     DateTimeOffset? ActualAsOf);

--- a/src/Meridian.FSharp.Ledger/Interop.fs
+++ b/src/Meridian.FSharp.Ledger/Interop.fs
@@ -57,6 +57,7 @@ type PortfolioLedgerCheckResultDto = {
     HasActualAmount: bool
     Variance: decimal
     Reason: string
+    Severity: string
     ExpectedAsOf: DateTimeOffset
     ActualAsOf: DateTimeOffset
     HasExpectedAsOf: bool
@@ -216,6 +217,7 @@ type LedgerInterop private () =
                 HasActualAmount = result.HasActualAmount
                 Variance = result.Variance
                 Reason = result.Reason
+                Severity = result.Severity
                 ExpectedAsOf = result.ExpectedAsOf
                 ActualAsOf = result.ActualAsOf
                 HasExpectedAsOf = result.HasExpectedAsOf

--- a/src/Meridian.FSharp.Ledger/Reconciliation.fs
+++ b/src/Meridian.FSharp.Ledger/Reconciliation.fs
@@ -237,7 +237,7 @@ module Reconciliation =
                         if check.ExpectedAmount = 0m then 1m else check.ExpectedAmount
 
                     let timingToleranceDays =
-                        max 1 (int (System.Math.Ceiling(float maxAsOfDriftMinutes / 1440.0)))
+                        max 0 (int (System.Math.Ceiling(float maxAsOfDriftMinutes / 1440.0)))
 
                     let candidate: MatchCandidate = {
                         CandidateId = System.Guid.NewGuid()

--- a/src/Meridian.FSharp.Ledger/Reconciliation.fs
+++ b/src/Meridian.FSharp.Ledger/Reconciliation.fs
@@ -96,6 +96,7 @@ type PortfolioLedgerCheckResult = {
     HasActualAmount: bool
     Variance: decimal
     Reason: string
+    Severity: string
     ExpectedAsOf: System.DateTimeOffset
     ActualAsOf: System.DateTimeOffset
     HasExpectedAsOf: bool
@@ -223,25 +224,65 @@ module Reconciliation =
                 else
                     0m
 
-            let hasTimingDrift =
-                check.HasExpectedAsOf
-                && check.HasActualAsOf
-                && abs ((check.ActualAsOf - check.ExpectedAsOf).TotalMinutes) > float maxAsOfDriftMinutes
-
-            let category, status, missingSource, reason, isMatch =
-                if hasTimingDrift then
-                    "timing_mismatch", "open", "unknown", "Comparison timestamps drift beyond tolerance.", false
-                elif check.ExpectedPresent && not check.ActualPresent then
-                    "missing_ledger_coverage", "open", (if System.String.IsNullOrWhiteSpace check.MissingSourceHint then "ledger" else check.MissingSourceHint), "Expected portfolio coverage is missing a ledger counterpart.", false
+            let category, status, missingSource, reason, isMatch, severity =
+                if check.ExpectedPresent && not check.ActualPresent then
+                    "missing_ledger_coverage", "open", (if System.String.IsNullOrWhiteSpace check.MissingSourceHint then "ledger" else check.MissingSourceHint), "Expected portfolio coverage is missing a ledger counterpart.", false, BreakSeverity.asString BreakSeverity.Medium
                 elif not check.ExpectedPresent && check.ActualPresent then
-                    "missing_portfolio_coverage", "open", (if System.String.IsNullOrWhiteSpace check.MissingSourceHint then "portfolio" else check.MissingSourceHint), "Ledger coverage exists without a matching portfolio reference.", false
+                    "missing_portfolio_coverage", "open", (if System.String.IsNullOrWhiteSpace check.MissingSourceHint then "portfolio" else check.MissingSourceHint), "Ledger coverage exists without a matching portfolio reference.", false, BreakSeverity.asString BreakSeverity.Medium
                 elif not (System.String.IsNullOrWhiteSpace check.ActualKind)
                      && not (System.String.Equals(check.ActualKind, check.CategoryHint, System.StringComparison.OrdinalIgnoreCase)) then
-                    "classification_gap", "open", "unknown", "Coverage was found, but it is classified in the wrong ledger bucket.", false
-                elif check.HasExpectedAmount && check.HasActualAmount && abs variance > amountTolerance then
-                    "amount_mismatch", "open", "unknown", "Amounts differ beyond the configured tolerance.", false
+                    "classification_gap", "open", "unknown", "Coverage was found, but it is classified in the wrong ledger bucket.", false, BreakSeverity.asString BreakSeverity.High
+                elif check.HasExpectedAmount && check.HasActualAmount && check.HasExpectedAsOf && check.HasActualAsOf then
+                    let expectedAmountForSeverity =
+                        if check.ExpectedAmount = 0m then 1m else check.ExpectedAmount
+
+                    let timingToleranceDays =
+                        max 1 (int (System.Math.Ceiling(float maxAsOfDriftMinutes / 1440.0)))
+
+                    let candidate: MatchCandidate = {
+                        CandidateId = System.Guid.NewGuid()
+                        SecurityId = System.Guid.Empty
+                        ExpectedAmount = check.ExpectedAmount
+                        ActualAmount = check.ActualAmount
+                        ExpectedCurrency = "USD"
+                        ActualCurrency = "USD"
+                        ExpectedDate = check.ExpectedAsOf
+                        ActualDate = check.ActualAsOf
+                        Notes = check.Label
+                    }
+
+                    let matchingRule =
+                        { MatchingRule.``default`` with
+                            AmountTolerancePct = amountTolerance
+                            TimingToleranceDays = timingToleranceDays
+                            AllowPartialMatch = true
+                            MinMatchConfidence = 0.60m
+                        }
+
+                    match ReconciliationRules.applyBest [ matchingRule ] candidate with
+                    | FullMatch _ ->
+                        "matched", "matched", "unknown", "Comparison satisfied all configured checks.", true, BreakSeverity.asString BreakSeverity.Info
+                    | PartialMatch (_, partialReason) ->
+                        "partial_match", "partial_match", "unknown", partialReason, false, BreakSeverity.asString BreakSeverity.Low
+                    | NoMatch classification ->
+                        let inferredSeverity = LedgerBreakClassification.severity expectedAmountForSeverity classification |> BreakSeverity.asString
+                        match classification with
+                        | AmountBreak _ ->
+                            "amount_mismatch", "open", "unknown", "Amounts differ beyond the configured tolerance.", false, inferredSeverity
+                        | TimingBreak _ ->
+                            "timing_mismatch", "open", "unknown", "Comparison timestamps drift beyond tolerance.", false, inferredSeverity
+                        | CurrencyBreak _ ->
+                            "classification_gap", "open", "unknown", "Coverage was found, but currency classification diverged.", false, inferredSeverity
+                        | MissingEntry ->
+                            "missing_ledger_coverage", "open", "ledger", "Expected portfolio coverage is missing a ledger counterpart.", false, inferredSeverity
+                        | DuplicateEntry ->
+                            "classification_gap", "open", "unknown", "Coverage contains duplicate entries requiring investigation.", false, inferredSeverity
+                        | ClassificationBreak reason ->
+                            "classification_gap", "open", "unknown", reason, false, inferredSeverity
+                        | OtherBreak reason ->
+                            "classification_gap", "open", "unknown", reason, false, inferredSeverity
                 else
-                    "matched", "matched", "unknown", "Comparison satisfied all configured checks.", true
+                    "matched", "matched", "unknown", "Comparison satisfied all configured checks.", true, BreakSeverity.asString BreakSeverity.Info
 
             {
                 CheckId = check.CheckId
@@ -258,6 +299,7 @@ module Reconciliation =
                 HasActualAmount = check.HasActualAmount
                 Variance = variance
                 Reason = reason
+                Severity = severity
                 ExpectedAsOf = check.ExpectedAsOf
                 ActualAsOf = check.ActualAsOf
                 HasExpectedAsOf = check.HasExpectedAsOf

--- a/src/Meridian.FSharp.Ledger/Reconciliation.fs
+++ b/src/Meridian.FSharp.Ledger/Reconciliation.fs
@@ -281,6 +281,16 @@ module Reconciliation =
                             "classification_gap", "open", "unknown", reason, false, inferredSeverity
                         | OtherBreak reason ->
                             "classification_gap", "open", "unknown", reason, false, inferredSeverity
+                elif check.HasExpectedAmount && check.HasActualAmount then
+                    if check.ActualAmount <> check.ExpectedAmount then
+                        "amount_mismatch", "open", "unknown", "Amounts differ beyond the configured tolerance.", false, BreakSeverity.asString BreakSeverity.Medium
+                    else
+                        "matched", "matched", "unknown", "Comparison satisfied all configured checks.", true, BreakSeverity.asString BreakSeverity.Info
+                elif check.HasExpectedAsOf && check.HasActualAsOf then
+                    if check.ActualAsOf <> check.ExpectedAsOf then
+                        "timing_mismatch", "open", "unknown", "Comparison timestamps drift beyond tolerance.", false, BreakSeverity.asString BreakSeverity.Medium
+                    else
+                        "matched", "matched", "unknown", "Comparison satisfied all configured checks.", true, BreakSeverity.asString BreakSeverity.Info
                 else
                     "matched", "matched", "unknown", "Comparison satisfied all configured checks.", true, BreakSeverity.asString BreakSeverity.Info
 

--- a/src/Meridian.Strategies/Services/ReconciliationRunService.cs
+++ b/src/Meridian.Strategies/Services/ReconciliationRunService.cs
@@ -158,12 +158,12 @@ public sealed class ReconciliationRunService : IReconciliationRunService
         _ => ReconciliationBreakStatus.Open
     };
 
-    private static ReconciliationBreakSeverity MapSeverity(string severity) => severity switch
+    private static ReconciliationBreakSeverity MapSeverity(string severity) => severity.ToUpperInvariant() switch
     {
-        "Critical" => ReconciliationBreakSeverity.Critical,
-        "High" => ReconciliationBreakSeverity.High,
-        "Medium" => ReconciliationBreakSeverity.Medium,
-        "Low" => ReconciliationBreakSeverity.Low,
+        "CRITICAL" => ReconciliationBreakSeverity.Critical,
+        "HIGH" => ReconciliationBreakSeverity.High,
+        "MEDIUM" => ReconciliationBreakSeverity.Medium,
+        "LOW" => ReconciliationBreakSeverity.Low,
         _ => ReconciliationBreakSeverity.Info
     };
 

--- a/src/Meridian.Strategies/Services/ReconciliationRunService.cs
+++ b/src/Meridian.Strategies/Services/ReconciliationRunService.cs
@@ -89,6 +89,7 @@ public sealed class ReconciliationRunService : IReconciliationRunService
                 result.HasExpectedAmount ? result.ExpectedAmount : null,
                 result.HasActualAmount ? result.ActualAmount : null,
                 result.Variance,
+                MapSeverity(result.Severity),
                 result.Reason,
                 result.HasExpectedAsOf ? result.ExpectedAsOf : null,
                 result.HasActualAsOf ? result.ActualAsOf : null));
@@ -144,15 +145,26 @@ public sealed class ReconciliationRunService : IReconciliationRunService
         "missing_portfolio_coverage" => ReconciliationBreakCategory.MissingPortfolioCoverage,
         "classification_gap" => ReconciliationBreakCategory.ClassificationGap,
         "timing_mismatch" => ReconciliationBreakCategory.TimingMismatch,
+        "partial_match" => ReconciliationBreakCategory.PartialMatch,
         _ => ReconciliationBreakCategory.ClassificationGap
     };
 
     private static ReconciliationBreakStatus MapStatus(string status) => status switch
     {
         "matched" => ReconciliationBreakStatus.Matched,
+        "partial_match" => ReconciliationBreakStatus.PartialMatch,
         "investigating" => ReconciliationBreakStatus.Investigating,
         "resolved" => ReconciliationBreakStatus.Resolved,
         _ => ReconciliationBreakStatus.Open
+    };
+
+    private static ReconciliationBreakSeverity MapSeverity(string severity) => severity switch
+    {
+        "Critical" => ReconciliationBreakSeverity.Critical,
+        "High" => ReconciliationBreakSeverity.High,
+        "Medium" => ReconciliationBreakSeverity.Medium,
+        "Low" => ReconciliationBreakSeverity.Low,
+        _ => ReconciliationBreakSeverity.Info
     };
 
     private static IReadOnlyList<ReconciliationSecurityCoverageIssueDto> BuildSecurityCoverageIssues(StrategyRunDetail detail)

--- a/tests/Meridian.FSharp.Tests/LedgerKernelTests.fs
+++ b/tests/Meridian.FSharp.Tests/LedgerKernelTests.fs
@@ -295,6 +295,8 @@ let ``Portfolio ledger reconciliation marks exact match as matched`` () =
 
     result.IsMatch |> should equal true
     result.Category |> should equal "matched"
+    result.Status |> should equal "matched"
+    result.Severity |> should equal "Info"
 
 [<Fact>]
 let ``Portfolio ledger reconciliation flags amount mismatch`` () =
@@ -325,6 +327,40 @@ let ``Portfolio ledger reconciliation flags amount mismatch`` () =
 
     result.IsMatch |> should equal false
     result.Category |> should equal "amount_mismatch"
+    result.Status |> should equal "open"
+    result.Severity |> should equal "High"
+
+[<Fact>]
+let ``Portfolio ledger reconciliation surfaces partial match status explicitly`` () =
+    let checks : PortfolioLedgerCheckDto array =
+        [|
+            {
+                CheckId = "timing-partial"
+                Label = "Portfolio cash vs ledger cash timing drift"
+                ExpectedSource = "portfolio"
+                ActualSource = "ledger"
+                ExpectedAmount = 750m
+                ActualAmount = 750m
+                HasExpectedAmount = true
+                HasActualAmount = true
+                ExpectedPresent = true
+                ActualPresent = true
+                ExpectedAsOf = DateTimeOffset.Parse("2026-03-01T00:00:00Z")
+                ActualAsOf = DateTimeOffset.Parse("2026-03-05T00:00:00Z")
+                HasExpectedAsOf = true
+                HasActualAsOf = true
+                CategoryHint = "amount"
+                MissingSourceHint = ""
+                ActualKind = "amount"
+            }
+        |]
+
+    let result = LedgerInterop.ReconcilePortfolioLedgerChecks(0.01m, 4320, checks) |> Array.exactlyOne
+
+    result.IsMatch |> should equal false
+    result.Category |> should equal "partial_match"
+    result.Status |> should equal "partial_match"
+    result.Severity |> should equal "Low"
 
 [<Fact>]
 let ``Portfolio ledger reconciliation flags missing ledger coverage`` () =

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -1360,6 +1360,7 @@ public sealed class WorkstationEndpointsTests
                 ExpectedAmount: 100m + index,
                 ActualAmount: 95m + index,
                 Variance: 5m,
+                Severity: ReconciliationBreakSeverity.Medium,
                 Reason: "Seeded mismatch for history coverage",
                 ExpectedAsOf: createdAt,
                 ActualAsOf: createdAt))

--- a/tests/Meridian.Wpf.Tests/Services/FundReconciliationWorkbenchServiceTests.cs
+++ b/tests/Meridian.Wpf.Tests/Services/FundReconciliationWorkbenchServiceTests.cs
@@ -252,6 +252,7 @@ public sealed class FundReconciliationWorkbenchServiceTests
                     ExpectedAmount: 150m,
                     ActualAmount: 125m,
                     Variance: 25m,
+                    Severity: ReconciliationBreakSeverity.High,
                     Reason: "Broker statement has not been normalized yet.",
                     ExpectedAsOf: new DateTimeOffset(2026, 3, 21, 16, 30, 0, TimeSpan.Zero),
                     ActualAsOf: new DateTimeOffset(2026, 3, 21, 16, 29, 0, TimeSpan.Zero)),
@@ -264,6 +265,7 @@ public sealed class FundReconciliationWorkbenchServiceTests
                     ExpectedAmount: 50m,
                     ActualAmount: 10m,
                     Variance: 40m,
+                    Severity: ReconciliationBreakSeverity.Medium,
                     Reason: "Statement timestamp drift exceeds tolerance.",
                     ExpectedAsOf: new DateTimeOffset(2026, 3, 21, 16, 30, 0, TimeSpan.Zero),
                     ActualAsOf: new DateTimeOffset(2026, 3, 21, 16, 00, 0, TimeSpan.Zero)),
@@ -276,6 +278,7 @@ public sealed class FundReconciliationWorkbenchServiceTests
                     ExpectedAmount: 25m,
                     ActualAmount: 20m,
                     Variance: 5m,
+                    Severity: ReconciliationBreakSeverity.Low,
                     Reason: "Ledger posting is late.",
                     ExpectedAsOf: new DateTimeOffset(2026, 3, 21, 16, 30, 0, TimeSpan.Zero),
                     ActualAsOf: new DateTimeOffset(2026, 3, 21, 16, 28, 0, TimeSpan.Zero))

--- a/tests/Meridian.Wpf.Tests/ViewModels/FundLedgerViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/FundLedgerViewModelTests.cs
@@ -687,6 +687,7 @@ public sealed class FundLedgerViewModelTests
                     ExpectedAmount: 150m,
                     ActualAmount: 137.5m,
                     Variance: 12.5m,
+                    Severity: ReconciliationBreakSeverity.High,
                     Reason: "Broker statement has not been normalized yet.",
                     ExpectedAsOf: new DateTimeOffset(2026, 3, 21, 16, 30, 0, TimeSpan.Zero),
                     ActualAsOf: new DateTimeOffset(2026, 3, 21, 16, 29, 0, TimeSpan.Zero))


### PR DESCRIPTION
### Motivation
- Normalize reconciliation decision-making so the same matching logic is used for portfolio-vs-ledger checks and produces explicit partial-match outcomes and severity that governance consumers can rely on.
- Ensure F# kernel classifications (severity/category/status) are preserved through the F#→C# interop surface so UI/governance layers can distinguish matched vs partial vs unresolved.

### Description
- Route portfolio/ledger candidate evaluation through the rule engine by using `ReconciliationRules.applyBest` with a normalized `MatchCandidate` in `src/Meridian.FSharp.Ledger/Reconciliation.fs`. 
- Add `Severity` to the F# result DTO `PortfolioLedgerCheckResult` and return it from the F# interop in `src/Meridian.FSharp.Ledger/Interop.fs`.
- Extend workstation contracts in `src/Meridian.Contracts/Workstation/ReconciliationDtos.cs` with `ReconciliationBreakSeverity` and add `PartialMatch` enum members for category/status, and include `Severity` on `ReconciliationBreakDto`.
- Preserve partial-match and severity when converting F# results into governance DTOs in `src/Meridian.Strategies/Services/ReconciliationRunService.cs` by adding `MapSeverity`, mapping `partial_match` to `PartialMatch` category/status, and passing severity into `ReconciliationBreakDto`.
- Update unit test fixtures and assertions to expect the new `Severity` field and to assert `matched`, `partial_match`, and `open` semantics, with tests modified in `tests/Meridian.FSharp.Tests/LedgerKernelTests.fs`, `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs`, `tests/Meridian.Wpf.Tests/Services/FundReconciliationWorkbenchServiceTests.cs`, and `tests/Meridian.Wpf.Tests/ViewModels/FundLedgerViewModelTests.cs`.

### Testing
- Attempted to run the F# unit tests with `dotnet test tests/Meridian.FSharp.Tests/Meridian.FSharp.Tests.fsproj --nologo`, but the command failed in this environment because `dotnet` is not installed; result: command failed (`/bin/bash: line 1: dotnet: command not found`).
- Ran the implementation-assurance rubric script with `python3 .codex/skills/meridian-implementation-assurance/scripts/score_eval.py --scenario A --scores '{"behavior_correctness":2,"validation_evidence":1,"performance_safety":2,"documentation_sync":1,"traceable_summary":2}' --failed-check 'dotnet test unavailable in environment' --follow-up 'run full .NET test suite in CI with SDK installed' --json`, which completed successfully and reported a total score of 8 (Pass); follow-up: run full .NET test suite in CI with the SDK installed to validate integration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ee34faec83209f9c6d136101b89a)