### PR TITLE
Add reconciliation severity plus cash/external-statement break typing

### DIFF
--- a/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
+++ b/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
@@ -12,7 +12,9 @@ public enum ReconciliationSourceKind : byte
     Unknown = 0,
     Portfolio = 1,
     Ledger = 2,
-    Bank = 3
+    Bank = 3,
+    ExternalStatement = Bank,
+    Cash = 4
 }
 
 /// <summary>
@@ -38,7 +40,22 @@ public enum ReconciliationBreakCategory : byte
     MissingPortfolioCoverage = 2,
     ClassificationGap = 3,
     TimingMismatch = 4,
-    MissingBankCoverage = 5
+    MissingBankCoverage = 5,
+    CashMismatch = 6,
+    MissingCashCoverage = 7,
+    MissingExternalStatementCoverage = 8,
+    ExternalStatementMismatch = 9
+}
+
+/// <summary>
+/// Relative urgency for a reconciliation break.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<ReconciliationBreakSeverity>))]
+public enum ReconciliationBreakSeverity : byte
+{
+    Info = 0,
+    Warning = 1,
+    Critical = 2
 }
 
 /// <summary>
@@ -103,7 +120,8 @@ public sealed record ReconciliationBreakDto(
     decimal Variance,
     string Reason,
     DateTimeOffset? ExpectedAsOf,
-    DateTimeOffset? ActualAsOf);
+    DateTimeOffset? ActualAsOf,
+    ReconciliationBreakSeverity Severity = ReconciliationBreakSeverity.Warning);
 
 /// <summary>
 /// Security Master coverage issue attached to a reconciliation run.
@@ -158,7 +176,8 @@ public sealed record ReconciliationBreakQueueItem(
     DateTimeOffset? ReviewedAt = null,
     string? ResolvedBy = null,
     DateTimeOffset? ResolvedAt = null,
-    string? ResolutionNote = null);
+    string? ResolutionNote = null,
+    ReconciliationBreakSeverity Severity = ReconciliationBreakSeverity.Warning);
 
 /// <summary>
 /// Request to move a break into active review and assign an operator.

--- a/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
+++ b/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
@@ -120,8 +120,10 @@ public sealed record ReconciliationBreakDto(
     decimal Variance,
     string Reason,
     DateTimeOffset? ExpectedAsOf,
-    DateTimeOffset? ActualAsOf,
-    ReconciliationBreakSeverity Severity = ReconciliationBreakSeverity.Warning);
+    DateTimeOffset? ActualAsOf)
+{
+    public ReconciliationBreakSeverity Severity { get; init; } = ReconciliationBreakSeverity.Warning;
+}
 
 /// <summary>
 /// Security Master coverage issue attached to a reconciliation run.

--- a/src/Meridian.Strategies/Services/ReconciliationRunService.cs
+++ b/src/Meridian.Strategies/Services/ReconciliationRunService.cs
@@ -91,8 +91,15 @@ public sealed class ReconciliationRunService : IReconciliationRunService
                 result.Variance,
                 result.Reason,
                 result.HasExpectedAsOf ? result.ExpectedAsOf : null,
-                result.HasActualAsOf ? result.ActualAsOf : null,
-                MapSeverity(result.Category, result.MissingSource, result.CheckId, result.ExpectedSource, result.ActualSource)));
+                result.HasActualAsOf ? result.ActualAsOf : null)
+            {
+                Severity = MapSeverity(
+                    result.Category,
+                    result.MissingSource,
+                    result.CheckId,
+                    result.ExpectedSource,
+                    result.ActualSource)
+            });
         }
 
         var securityCoverageIssues = BuildSecurityCoverageIssues(runDetail);

--- a/src/Meridian.Strategies/Services/ReconciliationRunService.cs
+++ b/src/Meridian.Strategies/Services/ReconciliationRunService.cs
@@ -189,7 +189,8 @@ public sealed class ReconciliationRunService : IReconciliationRunService
         if (string.Equals(category, "missing_ledger_coverage", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(category, "missing_portfolio_coverage", StringComparison.OrdinalIgnoreCase))
         {
-            return IsExternalStatementSource(missingSource)
+            return IsCashCheck(checkId) ||
+                   IsExternalStatementSource(missingSource)
                 ? ReconciliationBreakSeverity.Critical
                 : ReconciliationBreakSeverity.Warning;
         }

--- a/src/Meridian.Strategies/Services/ReconciliationRunService.cs
+++ b/src/Meridian.Strategies/Services/ReconciliationRunService.cs
@@ -136,11 +136,19 @@ public sealed class ReconciliationRunService : IReconciliationRunService
     public Task<IReadOnlyList<ReconciliationRunSummary>> GetHistoryForRunAsync(string runId, CancellationToken ct = default) =>
         _repository.GetHistoryForRunAsync(runId, ct);
 
-    private static ReconciliationBreakCategory MapCategory(string category, string missingSource = "", string checkId = "") => category switch
+    private static bool IsExternalStatementMismatchSource(string expectedSource = "", string actualSource = "") =>
+        IsExternalStatementSource(expectedSource) || IsExternalStatementSource(actualSource);
+
+    private static ReconciliationBreakCategory MapCategory(
+        string category,
+        string missingSource = "",
+        string checkId = "",
+        string expectedSource = "",
+        string actualSource = "") => category switch
     {
         "amount_mismatch" when IsCashCheck(checkId)
             => ReconciliationBreakCategory.CashMismatch,
-        "amount_mismatch" when IsExternalStatementSource(missingSource)
+        "amount_mismatch" when IsExternalStatementMismatchSource(expectedSource, actualSource)
             => ReconciliationBreakCategory.ExternalStatementMismatch,
         "amount_mismatch" => ReconciliationBreakCategory.AmountMismatch,
         "missing_ledger_coverage" when IsCashCheck(checkId)

--- a/src/Meridian.Strategies/Services/ReconciliationRunService.cs
+++ b/src/Meridian.Strategies/Services/ReconciliationRunService.cs
@@ -83,7 +83,7 @@ public sealed class ReconciliationRunService : IReconciliationRunService
             breaks.Add(new ReconciliationBreakDto(
                 result.CheckId,
                 result.Label,
-                MapCategory(result.Category, result.MissingSource),
+                MapCategory(result.Category, result.MissingSource, result.CheckId),
                 MapStatus(result.Status),
                 result.MissingSource,
                 result.HasExpectedAmount ? result.ExpectedAmount : null,
@@ -91,7 +91,8 @@ public sealed class ReconciliationRunService : IReconciliationRunService
                 result.Variance,
                 result.Reason,
                 result.HasExpectedAsOf ? result.ExpectedAsOf : null,
-                result.HasActualAsOf ? result.ActualAsOf : null));
+                result.HasActualAsOf ? result.ActualAsOf : null,
+                MapSeverity(result.Category, result.MissingSource, result.CheckId, result.ExpectedSource, result.ActualSource)));
         }
 
         var securityCoverageIssues = BuildSecurityCoverageIssues(runDetail);
@@ -135,17 +136,74 @@ public sealed class ReconciliationRunService : IReconciliationRunService
     public Task<IReadOnlyList<ReconciliationRunSummary>> GetHistoryForRunAsync(string runId, CancellationToken ct = default) =>
         _repository.GetHistoryForRunAsync(runId, ct);
 
-    private static ReconciliationBreakCategory MapCategory(string category, string missingSource = "") => category switch
+    private static ReconciliationBreakCategory MapCategory(string category, string missingSource = "", string checkId = "") => category switch
     {
+        "amount_mismatch" when IsCashCheck(checkId)
+            => ReconciliationBreakCategory.CashMismatch,
+        "amount_mismatch" when IsExternalStatementSource(missingSource)
+            => ReconciliationBreakCategory.ExternalStatementMismatch,
         "amount_mismatch" => ReconciliationBreakCategory.AmountMismatch,
+        "missing_ledger_coverage" when IsCashCheck(checkId)
+            => ReconciliationBreakCategory.MissingCashCoverage,
+        "missing_ledger_coverage" when IsExternalStatementSource(missingSource)
+            => ReconciliationBreakCategory.MissingExternalStatementCoverage,
         "missing_ledger_coverage" => ReconciliationBreakCategory.MissingLedgerCoverage,
         "missing_portfolio_coverage" when string.Equals(missingSource, "bank", StringComparison.OrdinalIgnoreCase)
             => ReconciliationBreakCategory.MissingBankCoverage,
+        "missing_portfolio_coverage" when IsExternalStatementSource(missingSource)
+            => ReconciliationBreakCategory.MissingExternalStatementCoverage,
+        "missing_portfolio_coverage" when IsCashCheck(checkId)
+            => ReconciliationBreakCategory.MissingCashCoverage,
         "missing_portfolio_coverage" => ReconciliationBreakCategory.MissingPortfolioCoverage,
         "classification_gap" => ReconciliationBreakCategory.ClassificationGap,
         "timing_mismatch" => ReconciliationBreakCategory.TimingMismatch,
         _ => ReconciliationBreakCategory.ClassificationGap
     };
+
+    private static ReconciliationBreakSeverity MapSeverity(
+        string category,
+        string missingSource,
+        string checkId,
+        string expectedSource,
+        string actualSource)
+    {
+        if (string.Equals(category, "timing_mismatch", StringComparison.OrdinalIgnoreCase))
+        {
+            return ReconciliationBreakSeverity.Info;
+        }
+
+        if (string.Equals(category, "classification_gap", StringComparison.OrdinalIgnoreCase))
+        {
+            return ReconciliationBreakSeverity.Warning;
+        }
+
+        if (string.Equals(category, "amount_mismatch", StringComparison.OrdinalIgnoreCase))
+        {
+            return IsCashCheck(checkId) ||
+                   IsExternalStatementSource(expectedSource) ||
+                   IsExternalStatementSource(actualSource)
+                ? ReconciliationBreakSeverity.Critical
+                : ReconciliationBreakSeverity.Warning;
+        }
+
+        if (string.Equals(category, "missing_ledger_coverage", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(category, "missing_portfolio_coverage", StringComparison.OrdinalIgnoreCase))
+        {
+            return IsExternalStatementSource(missingSource)
+                ? ReconciliationBreakSeverity.Critical
+                : ReconciliationBreakSeverity.Warning;
+        }
+
+        return ReconciliationBreakSeverity.Warning;
+    }
+
+    private static bool IsCashCheck(string checkId) =>
+        checkId.Contains("cash", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsExternalStatementSource(string source) =>
+        string.Equals(source, "bank", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(source, "external_statement", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(source, "statement", StringComparison.OrdinalIgnoreCase);
 
     private static ReconciliationBreakStatus MapStatus(string status) => status switch
     {

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -1738,7 +1738,8 @@ public static class WorkstationEndpoints
                     Reason: "Cash variance exceeds configured tolerance.",
                     AssignedTo: null,
                     DetectedAt: DateTimeOffset.UtcNow.AddMinutes(-18),
-                    LastUpdatedAt: DateTimeOffset.UtcNow.AddMinutes(-18)),
+                    LastUpdatedAt: DateTimeOffset.UtcNow.AddMinutes(-18),
+                    Severity: ReconciliationBreakSeverity.Critical),
                 new ReconciliationBreakQueueItem(
                     BreakId: "BRK-gov-run-001-2",
                     RunId: "gov-run-001",
@@ -1752,7 +1753,8 @@ public static class WorkstationEndpoints
                     LastUpdatedAt: DateTimeOffset.UtcNow.AddMinutes(-8),
                     ReviewedBy: "ops.gov",
                     ReviewedAt: DateTimeOffset.UtcNow.AddMinutes(-8),
-                    ResolutionNote: "Investigating ticker reclassification.")
+                    ResolutionNote: "Investigating ticker reclassification.",
+                    Severity: ReconciliationBreakSeverity.Warning)
             },
             workspace = new
             {
@@ -2901,7 +2903,8 @@ public static class WorkstationEndpoints
                         Reason: reconciliationBreak.Reason,
                         AssignedTo: null,
                         DetectedAt: DateTimeOffset.UtcNow,
-                        LastUpdatedAt: DateTimeOffset.UtcNow);
+                        LastUpdatedAt: DateTimeOffset.UtcNow,
+                        Severity: reconciliationBreak.Severity);
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- Represent cash and external-statement reconciliation cases explicitly and convey break severity to the workstation UI while keeping existing clients compatible.
- Provide explicit enums and categories so rule mapping and queue models can express statement/cash-specific mismatch types and urgency.

### Description
- Extended `ReconciliationSourceKind` to add `ExternalStatement` (aliased to `Bank` for backward compatibility) and `Cash` in `src/Meridian.Contracts/Workstation/ReconciliationDtos.cs`.
- Added `ReconciliationBreakSeverity` and added a `Severity` property (default `Warning`) to `ReconciliationBreakDto` and `ReconciliationBreakQueueItem` while preserving JSON string enum behavior via `JsonStringEnumConverter`.
- Expanded `ReconciliationBreakCategory` with cash/statement-specific values: `CashMismatch`, `MissingCashCoverage`, `MissingExternalStatementCoverage`, and `ExternalStatementMismatch`.
- Updated reconciliation materialization in `src/Meridian.Strategies/Services/ReconciliationRunService.cs` to map the new categories (using check id/source hints) and compute `Severity`, and updated workstation endpoints/seeding in `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` to carry severity into queue items.

### Testing
- Attempted to run `dotnet build src/Meridian.Contracts/Meridian.Contracts.csproj && dotnet build src/Meridian.Strategies/Meridian.Strategies.csproj && dotnet build src/Meridian.Ui.Shared/Meridian.Ui.Shared.csproj`, but the environment does not have the `dotnet` CLI installed (`/bin/bash: dotnet: command not found`).
- No automated unit or integration tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ee33616883208c6e19ac153ad7bd)