### PR TITLE
Add offline provider-degradation calibration workflow and governance gates

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -14,6 +14,7 @@ Guides for deploying, monitoring, and maintaining the Meridian in production.
 | [Portable Data Packager](portable-data-packager.md) | Creating and importing data packages |
 | [MSIX Packaging](msix-packaging.md) | Desktop application packaging |
 | [Governance Operator Workflow](governance-operator-workflow.md) | Security Master, reconciliation queue, and governance export operations |
+| [Provider Degradation Calibration](provider-degradation-calibration.md) | Offline calibration and governance gates for provider degradation kernel promotions |
 
 ## Quick Links
 

--- a/docs/operations/provider-degradation-calibration.md
+++ b/docs/operations/provider-degradation-calibration.md
@@ -1,0 +1,93 @@
+# Provider degradation kernel calibration workflow
+
+This workflow adds an **offline calibration gate** before promoting new provider-degradation kernel weights.
+
+## 1) Calibration input dataset format
+
+Use a JSON file with this shape:
+
+```json
+{
+  "datasetId": "incidents-2026-q1",
+  "generatedAt": "2026-04-20T00:00:00Z",
+  "source": "historical-provider-incidents",
+  "windows": [
+    {
+      "provider": "Polygon",
+      "windowStart": "2026-01-04T14:30:00Z",
+      "windowEnd": "2026-01-04T14:35:00Z",
+      "observedSeverity": "Critical",
+      "connectionScore": 1.0,
+      "latencyScore": 0.8,
+      "errorRateScore": 0.9,
+      "reconnectScore": 0.7,
+      "eventsObserved": 40,
+      "alertVolumeObserved": 6
+    }
+  ]
+}
+```
+
+Each `windows[]` entry should represent one historical replay window captured from provider and data-quality incidents.
+
+## 2) Offline calibration runner
+
+Run:
+
+```bash
+Meridian --calibrate-provider-degradation \
+  --calibration-input ./incidents-2026-q1.json \
+  --candidate-kernel-version kernel-v2 \
+  --baseline-kernel-version kernel-v1
+```
+
+The runner replays historical windows, computes composite scores for baseline and candidate kernels, and produces precision/recall metrics for severity thresholds (Minor/Moderate/Major/Critical).
+
+## 3) Snapshot persistence
+
+Calibration snapshots are persisted to:
+
+- `dataRoot/calibration/provider-degradation/*.json`
+
+Each snapshot contains:
+
+- UTC timestamp (`createdAt`)
+- `baselineKernelVersion`
+- `candidateKernelVersion`
+- per-severity precision/recall
+- expected alert-volume delta
+- `calibrationPass`
+
+## 4) Freshness policy gates
+
+Governance checks enforce:
+
+- snapshot age <= policy `MaxSnapshotAge`
+- snapshot candidate version must match promotion candidate
+- minimum precision/recall thresholds at required severity (default: `Critical`)
+
+If any check fails, promotion is blocked with explicit blocking reasons.
+
+## 5) Dashboard/report output
+
+The calibration command generates a markdown report (`latest-report.md`) comparing:
+
+- baseline vs candidate precision/recall
+- threshold values used per severity
+- expected alert count baseline vs candidate
+- expected alert-volume percent change
+
+This report is suitable for governance review packets and dashboard ingestion.
+
+## 6) Governance workflow “calibration pass” check
+
+Promotion decisions for kernel weights are now tied to an explicit `calibrationPass` gate in `KernelWeightGovernanceWorkflowService`.
+
+The workflow returns:
+
+- `calibrationPass`
+- `freshnessPass`
+- `approved`
+- explicit `blockingReasons`
+
+A candidate kernel is promotable only when `approved == true`.

--- a/src/Meridian.Application/Commands/ProviderCalibrationCommand.cs
+++ b/src/Meridian.Application/Commands/ProviderCalibrationCommand.cs
@@ -32,16 +32,18 @@ internal sealed class ProviderCalibrationCommand : ICliCommand
 
         var baselineConfigPath = CliArguments.GetValue(args, "--baseline-config");
         var candidateConfigPath = CliArguments.GetValue(args, "--candidate-config");
+        var baselineConfig = await LoadConfigOrDefaultAsync(baselineConfigPath, ct).ConfigureAwait(false);
+        var candidateConfig = await LoadConfigOrDefaultAsync(candidateConfigPath, ct).ConfigureAwait(false);
 
         var baselineProfile = new ProviderDegradationKernelProfile(
             baselineKernelVersion,
-            await LoadConfigOrDefaultAsync(baselineConfigPath, ct).ConfigureAwait(false),
-            ProviderDegradationKernelProfile.Default().SeverityThresholds);
+            baselineConfig,
+            ProviderDegradationKernelProfile.BuildSeverityThresholds(baselineConfig));
 
         var candidateProfile = new ProviderDegradationKernelProfile(
             candidateKernelVersion,
-            await LoadConfigOrDefaultAsync(candidateConfigPath, ct).ConfigureAwait(false),
-            ProviderDegradationKernelProfile.Default().SeverityThresholds);
+            candidateConfig,
+            ProviderDegradationKernelProfile.BuildSeverityThresholds(candidateConfig));
 
         var dataset = await ProviderIncidentCalibrationDataset.LoadAsync(inputPath, ct).ConfigureAwait(false);
         var runner = new ProviderDegradationCalibrationRunner();

--- a/src/Meridian.Application/Commands/ProviderCalibrationCommand.cs
+++ b/src/Meridian.Application/Commands/ProviderCalibrationCommand.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using Meridian.Application.Monitoring;
+using Meridian.Application.ResultTypes;
+using Serilog;
+
+namespace Meridian.Application.Commands;
+
+internal sealed class ProviderCalibrationCommand : ICliCommand
+{
+    private readonly string _dataRoot;
+    private readonly ILogger _log;
+
+    public ProviderCalibrationCommand(string dataRoot, ILogger log)
+    {
+        _dataRoot = dataRoot;
+        _log = log;
+    }
+
+    public bool CanHandle(string[] args) => CliArguments.HasFlag(args, "--calibrate-provider-degradation");
+
+    public async Task<CliResult> ExecuteAsync(string[] args, CancellationToken ct = default)
+    {
+        var inputPath = CliArguments.RequireValue(args, "--calibration-input", "--calibration-input ./incidents.json");
+        if (inputPath is null)
+        {
+            return CliResult.Fail(ErrorCode.ConfigurationInvalid);
+        }
+
+        var candidateKernelVersion = CliArguments.GetValue(args, "--candidate-kernel-version") ?? $"kernel-{DateTimeOffset.UtcNow:yyyyMMddHHmmss}";
+        var baselineKernelVersion = CliArguments.GetValue(args, "--baseline-kernel-version") ?? "default";
+        var runBy = CliArguments.GetValue(args, "--run-by") ?? Environment.UserName;
+
+        var baselineConfigPath = CliArguments.GetValue(args, "--baseline-config");
+        var candidateConfigPath = CliArguments.GetValue(args, "--candidate-config");
+
+        var baselineProfile = new ProviderDegradationKernelProfile(
+            baselineKernelVersion,
+            await LoadConfigOrDefaultAsync(baselineConfigPath, ct).ConfigureAwait(false),
+            ProviderDegradationKernelProfile.Default().SeverityThresholds);
+
+        var candidateProfile = new ProviderDegradationKernelProfile(
+            candidateKernelVersion,
+            await LoadConfigOrDefaultAsync(candidateConfigPath, ct).ConfigureAwait(false),
+            ProviderDegradationKernelProfile.Default().SeverityThresholds);
+
+        var dataset = await ProviderIncidentCalibrationDataset.LoadAsync(inputPath, ct).ConfigureAwait(false);
+        var runner = new ProviderDegradationCalibrationRunner();
+        var snapshot = runner.Run(dataset, baselineProfile, candidateProfile, runBy);
+
+        var snapshotStore = new ProviderKernelCalibrationSnapshotStore(_dataRoot);
+        var snapshotPath = await snapshotStore.SaveAsync(snapshot, ct).ConfigureAwait(false);
+
+        var markdown = ProviderCalibrationReportWriter.BuildMarkdown(snapshot);
+        var reportOutputPath = CliArguments.GetValue(args, "--calibration-report")
+            ?? Path.Combine(_dataRoot, "calibration", "provider-degradation", "latest-report.md");
+
+        Directory.CreateDirectory(Path.GetDirectoryName(reportOutputPath) ?? ".");
+        await File.WriteAllTextAsync(reportOutputPath, markdown, ct).ConfigureAwait(false);
+
+        var freshnessHours = CliArguments.GetInt(args, "--freshness-hours", 24 * 14);
+        var minPrecision = LoadDouble(args, "--min-precision", 0.65);
+        var minRecall = LoadDouble(args, "--min-recall", 0.65);
+
+        var policy = new ProviderKernelCalibrationPolicy(
+            TimeSpan.FromHours(freshnessHours),
+            minPrecision,
+            minRecall,
+            IncidentSeverity.Critical);
+
+        var governanceWorkflow = new KernelWeightGovernanceWorkflowService(policy);
+        var promotionDecision = governanceWorkflow.EvaluatePromotion(candidateKernelVersion, snapshot, runBy);
+
+        var governanceOutputPath = CliArguments.GetValue(args, "--governance-output")
+            ?? Path.Combine(_dataRoot, "calibration", "provider-degradation", "latest-governance-decision.json");
+
+        await File.WriteAllTextAsync(
+            governanceOutputPath,
+            JsonSerializer.Serialize(promotionDecision, new JsonSerializerOptions { WriteIndented = true }),
+            ct).ConfigureAwait(false);
+
+        _log.Information(
+            "Provider calibration complete. Snapshot={SnapshotPath}; report={ReportPath}; governanceApproved={Approved}",
+            snapshotPath,
+            reportOutputPath,
+            promotionDecision.Approved);
+
+        Console.WriteLine(markdown);
+        Console.WriteLine($"Governance calibration gate pass: {promotionDecision.CalibrationPass}");
+
+        return promotionDecision.Approved
+            ? CliResult.Ok()
+            : CliResult.Fail(ErrorCode.ConfigurationInvalid);
+    }
+
+    private static async Task<ProviderDegradationConfig> LoadConfigOrDefaultAsync(string? path, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+        {
+            return ProviderDegradationConfig.Default;
+        }
+
+        await using var stream = File.OpenRead(path);
+        var config = await JsonSerializer.DeserializeAsync<ProviderDegradationConfig>(stream, cancellationToken: ct)
+            .ConfigureAwait(false);
+
+        return config ?? ProviderDegradationConfig.Default;
+    }
+
+    private static double LoadDouble(string[] args, string key, double defaultValue)
+    {
+        var raw = CliArguments.GetValue(args, key);
+        return double.TryParse(raw, out var value) ? value : defaultValue;
+    }
+}

--- a/src/Meridian.Application/Commands/ProviderCalibrationCommand.cs
+++ b/src/Meridian.Application/Commands/ProviderCalibrationCommand.cs
@@ -32,8 +32,17 @@ internal sealed class ProviderCalibrationCommand : ICliCommand
 
         var baselineConfigPath = CliArguments.GetValue(args, "--baseline-config");
         var candidateConfigPath = CliArguments.GetValue(args, "--candidate-config");
-        var baselineConfig = await LoadConfigOrDefaultAsync(baselineConfigPath, ct).ConfigureAwait(false);
-        var candidateConfig = await LoadConfigOrDefaultAsync(candidateConfigPath, ct).ConfigureAwait(false);
+        var baselineConfig = await LoadConfigOrDefaultAsync(baselineConfigPath, "--baseline-config", ct).ConfigureAwait(false);
+        if (baselineConfig is null)
+        {
+            return CliResult.Fail(ErrorCode.ConfigurationInvalid);
+        }
+
+        var candidateConfig = await LoadConfigOrDefaultAsync(candidateConfigPath, "--candidate-config", ct).ConfigureAwait(false);
+        if (candidateConfig is null)
+        {
+            return CliResult.Fail(ErrorCode.ConfigurationInvalid);
+        }
 
         var baselineProfile = new ProviderDegradationKernelProfile(
             baselineKernelVersion,
@@ -94,17 +103,26 @@ internal sealed class ProviderCalibrationCommand : ICliCommand
             : CliResult.Fail(ErrorCode.ConfigurationInvalid);
     }
 
-    private static async Task<ProviderDegradationConfig> LoadConfigOrDefaultAsync(string? path, CancellationToken ct)
+    private Task<ProviderDegradationConfig?> LoadConfigOrDefaultAsync(string? path, string optionName, CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+        if (string.IsNullOrWhiteSpace(path))
         {
-            return ProviderDegradationConfig.Default;
+            return Task.FromResult<ProviderDegradationConfig?>(ProviderDegradationConfig.Default);
         }
 
-        await using var stream = File.OpenRead(path);
-        var config = await JsonSerializer.DeserializeAsync<ProviderDegradationConfig>(stream, cancellationToken: ct)
-            .ConfigureAwait(false);
+        if (!File.Exists(path))
+        {
+            _log.Error("Provider calibration failed: supplied {OptionName} path does not exist: {ConfigPath}", optionName, path);
+            return Task.FromResult<ProviderDegradationConfig?>(null);
+        }
 
+        return LoadConfigAsync(path, ct);
+    }
+
+    private static async Task<ProviderDegradationConfig> LoadConfigAsync(string path, CancellationToken ct)
+    {
+        await using var stream = File.OpenRead(path);
+        var config = await JsonSerializer.DeserializeAsync<ProviderDegradationConfig>(stream, cancellationToken: ct).ConfigureAwait(false);
         return config ?? ProviderDegradationConfig.Default;
     }
 

--- a/src/Meridian.Application/Composition/Startup/SharedStartupBootstrapper.cs
+++ b/src/Meridian.Application/Composition/Startup/SharedStartupBootstrapper.cs
@@ -254,6 +254,7 @@ internal static class CommandDispatchPlanner
             new CatalogCommand(storageSearchService, log),
             new GenerateLoaderCommand(dataRoot, log),
             new WalRepairCommand(cfg, log),
+            new ProviderCalibrationCommand(dataRoot, log),
             // Security Master ingest: importService is null until the full host configures Postgres.
             new SecurityMasterCommands(importService: null, log)));
     }

--- a/src/Meridian.Application/Monitoring/ProviderDegradationCalibration.cs
+++ b/src/Meridian.Application/Monitoring/ProviderDegradationCalibration.cs
@@ -229,11 +229,30 @@ public sealed class ProviderKernelCalibrationSnapshotStore
         _rootPath = rootPath;
     }
 
+    private static string SanitizeFileNameComponent(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "unknown";
+        }
+
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(value.Length);
+        foreach (var c in value)
+        {
+            builder.Append(invalidChars.Contains(c) || c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar ? '_' : c);
+        }
+
+        var sanitized = builder.ToString();
+        return string.IsNullOrWhiteSpace(sanitized) ? "unknown" : sanitized;
+    }
+
     public async Task<string> SaveAsync(ProviderKernelCalibrationSnapshot snapshot, CancellationToken ct = default)
     {
         var dir = Path.Combine(_rootPath, "calibration", "provider-degradation");
         Directory.CreateDirectory(dir);
-        var path = Path.Combine(dir, $"{snapshot.CreatedAt:yyyyMMddHHmmss}_{snapshot.CandidateKernelVersion}_{snapshot.SnapshotId}.json");
+        var safeKernelVersion = SanitizeFileNameComponent(snapshot.CandidateKernelVersion);
+        var path = Path.Combine(dir, $"{snapshot.CreatedAt:yyyyMMddHHmmss}_{safeKernelVersion}_{snapshot.SnapshotId}.json");
 
         await using var stream = File.Create(path);
         await JsonSerializer.SerializeAsync(stream, snapshot, cancellationToken: ct).ConfigureAwait(false);

--- a/src/Meridian.Application/Monitoring/ProviderDegradationCalibration.cs
+++ b/src/Meridian.Application/Monitoring/ProviderDegradationCalibration.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Meridian.Application.Monitoring;
 
@@ -12,10 +13,15 @@ public sealed record ProviderIncidentCalibrationDataset(
     string Source,
     IReadOnlyList<ProviderIncidentWindow> Windows)
 {
+    private static readonly JsonSerializerOptions DatasetJsonOptions = new()
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+
     public static async Task<ProviderIncidentCalibrationDataset> LoadAsync(string path, CancellationToken ct = default)
     {
         await using var stream = File.OpenRead(path);
-        var dataset = await JsonSerializer.DeserializeAsync<ProviderIncidentCalibrationDataset>(stream, cancellationToken: ct)
+        var dataset = await JsonSerializer.DeserializeAsync<ProviderIncidentCalibrationDataset>(stream, DatasetJsonOptions, ct)
             .ConfigureAwait(false);
         return dataset ?? throw new InvalidOperationException($"Failed to parse calibration dataset from '{path}'.");
     }
@@ -24,7 +30,7 @@ public sealed record ProviderIncidentCalibrationDataset(
     {
         Directory.CreateDirectory(Path.GetDirectoryName(path) ?? ".");
         await using var stream = File.Create(path);
-        await JsonSerializer.SerializeAsync(stream, this, cancellationToken: ct).ConfigureAwait(false);
+        await JsonSerializer.SerializeAsync(stream, this, DatasetJsonOptions, ct).ConfigureAwait(false);
     }
 }
 
@@ -96,16 +102,16 @@ public sealed record ProviderDegradationKernelProfile(
     IReadOnlyDictionary<IncidentSeverity, double> SeverityThresholds)
 {
     public static ProviderDegradationKernelProfile Default(string kernelVersion = "default") =>
-        new(
-            kernelVersion,
-            ProviderDegradationConfig.Default,
-            new Dictionary<IncidentSeverity, double>
-            {
-                [IncidentSeverity.Minor] = 0.35,
-                [IncidentSeverity.Moderate] = 0.50,
-                [IncidentSeverity.Major] = 0.65,
-                [IncidentSeverity.Critical] = ProviderDegradationConfig.Default.DegradationThreshold
-            });
+        new(kernelVersion, ProviderDegradationConfig.Default, BuildSeverityThresholds(ProviderDegradationConfig.Default));
+
+    public static IReadOnlyDictionary<IncidentSeverity, double> BuildSeverityThresholds(ProviderDegradationConfig config) =>
+        new Dictionary<IncidentSeverity, double>
+        {
+            [IncidentSeverity.Minor] = 0.35,
+            [IncidentSeverity.Moderate] = 0.50,
+            [IncidentSeverity.Major] = 0.65,
+            [IncidentSeverity.Critical] = config.DegradationThreshold
+        };
 }
 
 public sealed class ProviderDegradationCalibrationRunner

--- a/src/Meridian.Application/Monitoring/ProviderDegradationCalibration.cs
+++ b/src/Meridian.Application/Monitoring/ProviderDegradationCalibration.cs
@@ -394,10 +394,23 @@ public static class ProviderCalibrationReportWriter
         builder.AppendLine("| Severity | Baseline precision | Candidate precision | Baseline recall | Candidate recall | Threshold (candidate) |");
         builder.AppendLine("|---|---:|---:|---:|---:|---:|");
 
-        foreach (var candidate in snapshot.CandidateMetrics.OrderBy(m => m.Severity))
+        static string FormatMetric(double? value) => value.HasValue ? value.Value.ToString("F3") : "N/A";
+
+        var baselineBySeverity = snapshot.BaselineMetrics.ToDictionary(m => m.Severity);
+        var candidateBySeverity = snapshot.CandidateMetrics.ToDictionary(m => m.Severity);
+        var severities = snapshot.BaselineMetrics
+            .Select(m => m.Severity)
+            .Concat(snapshot.CandidateMetrics.Select(m => m.Severity))
+            .Distinct()
+            .OrderBy(severity => severity);
+
+        foreach (var severity in severities)
         {
-            var baseline = snapshot.BaselineMetrics.Single(m => m.Severity == candidate.Severity);
-            builder.AppendLine($"| {candidate.Severity} | {baseline.Precision:F3} | {candidate.Precision:F3} | {baseline.Recall:F3} | {candidate.Recall:F3} | {candidate.Threshold:F3} |");
+            baselineBySeverity.TryGetValue(severity, out var baseline);
+            candidateBySeverity.TryGetValue(severity, out var candidate);
+
+            builder.AppendLine(
+                $"| {severity} | {FormatMetric(baseline?.Precision)} | {FormatMetric(candidate?.Precision)} | {FormatMetric(baseline?.Recall)} | {FormatMetric(candidate?.Recall)} | {FormatMetric(candidate?.Threshold)} |");
         }
 
         builder.AppendLine();

--- a/src/Meridian.Application/Monitoring/ProviderDegradationCalibration.cs
+++ b/src/Meridian.Application/Monitoring/ProviderDegradationCalibration.cs
@@ -183,7 +183,7 @@ public sealed class ProviderDegradationCalibrationRunner
 
                 if (predicted)
                 {
-                    alerts += window.AlertVolumeObserved > 0 ? window.AlertVolumeObserved : 1;
+                    alerts += window.AlertVolumeObserved;
                 }
 
                 if (predicted && actual) tp++;

--- a/src/Meridian.Application/Monitoring/ProviderDegradationCalibration.cs
+++ b/src/Meridian.Application/Monitoring/ProviderDegradationCalibration.cs
@@ -191,8 +191,8 @@ public sealed class ProviderDegradationCalibrationRunner
                 else if (!predicted && actual) fn++;
             }
 
-            var precision = tp + fp == 0 ? 1.0 : (double)tp / (tp + fp);
-            var recall = tp + fn == 0 ? 1.0 : (double)tp / (tp + fn);
+            var precision = tp + fp == 0 ? 0.0 : (double)tp / (tp + fp);
+            var recall = tp + fn == 0 ? 0.0 : (double)tp / (tp + fn);
 
             metrics.Add(new SeverityThresholdMetrics(
                 Severity: severity,

--- a/src/Meridian.Application/Monitoring/ProviderDegradationCalibration.cs
+++ b/src/Meridian.Application/Monitoring/ProviderDegradationCalibration.cs
@@ -1,0 +1,388 @@
+using System.Text;
+using System.Text.Json;
+
+namespace Meridian.Application.Monitoring;
+
+/// <summary>
+/// Historical labeled incident dataset used for offline provider-degradation kernel calibration.
+/// </summary>
+public sealed record ProviderIncidentCalibrationDataset(
+    string DatasetId,
+    DateTimeOffset GeneratedAt,
+    string Source,
+    IReadOnlyList<ProviderIncidentWindow> Windows)
+{
+    public static async Task<ProviderIncidentCalibrationDataset> LoadAsync(string path, CancellationToken ct = default)
+    {
+        await using var stream = File.OpenRead(path);
+        var dataset = await JsonSerializer.DeserializeAsync<ProviderIncidentCalibrationDataset>(stream, cancellationToken: ct)
+            .ConfigureAwait(false);
+        return dataset ?? throw new InvalidOperationException($"Failed to parse calibration dataset from '{path}'.");
+    }
+
+    public async Task SaveAsync(string path, CancellationToken ct = default)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path) ?? ".");
+        await using var stream = File.Create(path);
+        await JsonSerializer.SerializeAsync(stream, this, cancellationToken: ct).ConfigureAwait(false);
+    }
+}
+
+/// <summary>
+/// A historical replay window with precomputed signal components and labeled incident severity.
+/// </summary>
+public sealed record ProviderIncidentWindow(
+    string Provider,
+    DateTimeOffset WindowStart,
+    DateTimeOffset WindowEnd,
+    IncidentSeverity ObservedSeverity,
+    double ConnectionScore,
+    double LatencyScore,
+    double ErrorRateScore,
+    double ReconnectScore,
+    int EventsObserved,
+    int AlertVolumeObserved);
+
+public enum IncidentSeverity : byte
+{
+    None = 0,
+    Minor = 1,
+    Moderate = 2,
+    Major = 3,
+    Critical = 4
+}
+
+/// <summary>
+/// Snapshot of an offline calibration run, persisted for governance and promotion checks.
+/// </summary>
+public sealed record ProviderKernelCalibrationSnapshot(
+    string SnapshotId,
+    DateTimeOffset CreatedAt,
+    string DatasetId,
+    string BaselineKernelVersion,
+    string CandidateKernelVersion,
+    IReadOnlyList<SeverityThresholdMetrics> BaselineMetrics,
+    IReadOnlyList<SeverityThresholdMetrics> CandidateMetrics,
+    CalibrationComparisonSummary Comparison,
+    string RunBy,
+    bool CalibrationPass);
+
+public sealed record SeverityThresholdMetrics(
+    IncidentSeverity Severity,
+    double Threshold,
+    double Precision,
+    double Recall,
+    int TruePositives,
+    int FalsePositives,
+    int FalseNegatives,
+    int AlertCount);
+
+public sealed record CalibrationComparisonSummary(
+    double ExpectedAlertVolumeChangePercent,
+    int ExpectedAlertCountBaseline,
+    int ExpectedAlertCountCandidate,
+    IncidentSeverity DecisionSeverity,
+    double CandidatePrecision,
+    double CandidateRecall,
+    double BaselinePrecision,
+    double BaselineRecall);
+
+/// <summary>
+/// Candidate kernel profile used by calibration and governance promotion.
+/// </summary>
+public sealed record ProviderDegradationKernelProfile(
+    string KernelVersion,
+    ProviderDegradationConfig Config,
+    IReadOnlyDictionary<IncidentSeverity, double> SeverityThresholds)
+{
+    public static ProviderDegradationKernelProfile Default(string kernelVersion = "default") =>
+        new(
+            kernelVersion,
+            ProviderDegradationConfig.Default,
+            new Dictionary<IncidentSeverity, double>
+            {
+                [IncidentSeverity.Minor] = 0.35,
+                [IncidentSeverity.Moderate] = 0.50,
+                [IncidentSeverity.Major] = 0.65,
+                [IncidentSeverity.Critical] = ProviderDegradationConfig.Default.DegradationThreshold
+            });
+}
+
+public sealed class ProviderDegradationCalibrationRunner
+{
+    public ProviderKernelCalibrationSnapshot Run(
+        ProviderIncidentCalibrationDataset dataset,
+        ProviderDegradationKernelProfile baseline,
+        ProviderDegradationKernelProfile candidate,
+        string runBy,
+        DateTimeOffset? now = null)
+    {
+        ArgumentNullException.ThrowIfNull(dataset);
+        ArgumentNullException.ThrowIfNull(baseline);
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        var baselineMetrics = ComputeMetrics(dataset.Windows, baseline);
+        var candidateMetrics = ComputeMetrics(dataset.Windows, candidate);
+
+        var decisionSeverity = IncidentSeverity.Critical;
+        var baselineDecision = baselineMetrics.Single(m => m.Severity == decisionSeverity);
+        var candidateDecision = candidateMetrics.Single(m => m.Severity == decisionSeverity);
+
+        var comparison = new CalibrationComparisonSummary(
+            ExpectedAlertVolumeChangePercent: baselineDecision.AlertCount == 0
+                ? (candidateDecision.AlertCount > 0 ? 100 : 0)
+                : ((double)(candidateDecision.AlertCount - baselineDecision.AlertCount) / baselineDecision.AlertCount) * 100,
+            ExpectedAlertCountBaseline: baselineDecision.AlertCount,
+            ExpectedAlertCountCandidate: candidateDecision.AlertCount,
+            DecisionSeverity: decisionSeverity,
+            CandidatePrecision: candidateDecision.Precision,
+            CandidateRecall: candidateDecision.Recall,
+            BaselinePrecision: baselineDecision.Precision,
+            BaselineRecall: baselineDecision.Recall);
+
+        var calibrationPass = candidateDecision.Precision >= baselineDecision.Precision
+            && candidateDecision.Recall >= baselineDecision.Recall;
+
+        return new ProviderKernelCalibrationSnapshot(
+            SnapshotId: Guid.NewGuid().ToString("N"),
+            CreatedAt: now ?? DateTimeOffset.UtcNow,
+            DatasetId: dataset.DatasetId,
+            BaselineKernelVersion: baseline.KernelVersion,
+            CandidateKernelVersion: candidate.KernelVersion,
+            BaselineMetrics: baselineMetrics,
+            CandidateMetrics: candidateMetrics,
+            Comparison: comparison,
+            RunBy: runBy,
+            CalibrationPass: calibrationPass);
+    }
+
+    private static IReadOnlyList<SeverityThresholdMetrics> ComputeMetrics(
+        IReadOnlyList<ProviderIncidentWindow> windows,
+        ProviderDegradationKernelProfile profile)
+    {
+        var metrics = new List<SeverityThresholdMetrics>();
+
+        foreach (var (severity, threshold) in profile.SeverityThresholds.OrderBy(kvp => kvp.Key))
+        {
+            var tp = 0;
+            var fp = 0;
+            var fn = 0;
+            var alerts = 0;
+
+            foreach (var window in windows)
+            {
+                var score = ComputeComposite(window, profile.Config);
+                var predicted = score >= threshold;
+                var actual = window.ObservedSeverity >= severity;
+
+                if (predicted)
+                {
+                    alerts += window.AlertVolumeObserved > 0 ? window.AlertVolumeObserved : 1;
+                }
+
+                if (predicted && actual) tp++;
+                else if (predicted && !actual) fp++;
+                else if (!predicted && actual) fn++;
+            }
+
+            var precision = tp + fp == 0 ? 1.0 : (double)tp / (tp + fp);
+            var recall = tp + fn == 0 ? 1.0 : (double)tp / (tp + fn);
+
+            metrics.Add(new SeverityThresholdMetrics(
+                Severity: severity,
+                Threshold: threshold,
+                Precision: precision,
+                Recall: recall,
+                TruePositives: tp,
+                FalsePositives: fp,
+                FalseNegatives: fn,
+                AlertCount: alerts));
+        }
+
+        return metrics;
+    }
+
+    private static double ComputeComposite(ProviderIncidentWindow window, ProviderDegradationConfig config)
+    {
+        var composite =
+            window.ConnectionScore * config.ConnectionWeight +
+            window.LatencyScore * config.LatencyWeight +
+            window.ErrorRateScore * config.ErrorRateWeight +
+            window.ReconnectScore * config.ReconnectWeight;
+
+        return Math.Clamp(composite, 0.0, 1.0);
+    }
+}
+
+public sealed class ProviderKernelCalibrationSnapshotStore
+{
+    private readonly string _rootPath;
+
+    public ProviderKernelCalibrationSnapshotStore(string rootPath)
+    {
+        _rootPath = rootPath;
+    }
+
+    public async Task<string> SaveAsync(ProviderKernelCalibrationSnapshot snapshot, CancellationToken ct = default)
+    {
+        var dir = Path.Combine(_rootPath, "calibration", "provider-degradation");
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, $"{snapshot.CreatedAt:yyyyMMddHHmmss}_{snapshot.CandidateKernelVersion}_{snapshot.SnapshotId}.json");
+
+        await using var stream = File.Create(path);
+        await JsonSerializer.SerializeAsync(stream, snapshot, cancellationToken: ct).ConfigureAwait(false);
+        return path;
+    }
+
+    public async Task<ProviderKernelCalibrationSnapshot?> GetLatestAsync(CancellationToken ct = default)
+    {
+        var dir = Path.Combine(_rootPath, "calibration", "provider-degradation");
+        if (!Directory.Exists(dir))
+        {
+            return null;
+        }
+
+        var latestFile = new DirectoryInfo(dir)
+            .GetFiles("*.json")
+            .OrderByDescending(f => f.CreationTimeUtc)
+            .FirstOrDefault();
+
+        if (latestFile is null)
+        {
+            return null;
+        }
+
+        await using var stream = latestFile.OpenRead();
+        return await JsonSerializer.DeserializeAsync<ProviderKernelCalibrationSnapshot>(stream, cancellationToken: ct)
+            .ConfigureAwait(false);
+    }
+}
+
+public sealed record ProviderKernelCalibrationPolicy(
+    TimeSpan MaxSnapshotAge,
+    double MinPrecision,
+    double MinRecall,
+    IncidentSeverity RequiredSeverity)
+{
+    public static ProviderKernelCalibrationPolicy Default =>
+        new(TimeSpan.FromDays(14), MinPrecision: 0.65, MinRecall: 0.65, RequiredSeverity: IncidentSeverity.Critical);
+
+    public CalibrationGateDecision Evaluate(ProviderKernelCalibrationSnapshot? snapshot, string candidateKernelVersion, DateTimeOffset? now = null)
+    {
+        if (snapshot is null)
+        {
+            return new CalibrationGateDecision(false, false, ["No calibration snapshot found for candidate kernel."]);
+        }
+
+        var errors = new List<string>();
+        var evaluationTime = now ?? DateTimeOffset.UtcNow;
+        var freshnessPass = evaluationTime - snapshot.CreatedAt <= MaxSnapshotAge;
+        if (!freshnessPass)
+        {
+            errors.Add($"Calibration snapshot is stale (created {snapshot.CreatedAt:O}, max age {MaxSnapshotAge}).");
+        }
+
+        if (!string.Equals(snapshot.CandidateKernelVersion, candidateKernelVersion, StringComparison.Ordinal))
+        {
+            errors.Add($"Calibration snapshot candidate kernel '{snapshot.CandidateKernelVersion}' does not match requested '{candidateKernelVersion}'.");
+        }
+
+        var metric = snapshot.CandidateMetrics.FirstOrDefault(m => m.Severity == RequiredSeverity);
+        if (metric is null)
+        {
+            errors.Add($"Calibration snapshot is missing required severity '{RequiredSeverity}'.");
+        }
+        else
+        {
+            if (metric.Precision < MinPrecision)
+            {
+                errors.Add($"Candidate precision {metric.Precision:F3} is below required {MinPrecision:F3}.");
+            }
+
+            if (metric.Recall < MinRecall)
+            {
+                errors.Add($"Candidate recall {metric.Recall:F3} is below required {MinRecall:F3}.");
+            }
+        }
+
+        return new CalibrationGateDecision(errors.Count == 0, freshnessPass, errors);
+    }
+}
+
+public sealed record CalibrationGateDecision(
+    bool Passed,
+    bool FreshnessPassed,
+    IReadOnlyList<string> BlockingReasons);
+
+public sealed class KernelWeightGovernanceWorkflowService
+{
+    private readonly ProviderKernelCalibrationPolicy _policy;
+
+    public KernelWeightGovernanceWorkflowService(ProviderKernelCalibrationPolicy? policy = null)
+    {
+        _policy = policy ?? ProviderKernelCalibrationPolicy.Default;
+    }
+
+    public KernelPromotionDecision EvaluatePromotion(
+        string candidateKernelVersion,
+        ProviderKernelCalibrationSnapshot? snapshot,
+        string requestedBy,
+        DateTimeOffset? now = null)
+    {
+        var gate = _policy.Evaluate(snapshot, candidateKernelVersion, now);
+        return new KernelPromotionDecision(
+            CandidateKernelVersion: candidateKernelVersion,
+            RequestedBy: requestedBy,
+            EvaluatedAt: now ?? DateTimeOffset.UtcNow,
+            CalibrationPass: gate.Passed,
+            FreshnessPass: gate.FreshnessPassed,
+            Approved: gate.Passed,
+            BlockingReasons: gate.BlockingReasons);
+    }
+}
+
+public sealed record KernelPromotionDecision(
+    string CandidateKernelVersion,
+    string RequestedBy,
+    DateTimeOffset EvaluatedAt,
+    bool CalibrationPass,
+    bool FreshnessPass,
+    bool Approved,
+    IReadOnlyList<string> BlockingReasons);
+
+public static class ProviderCalibrationReportWriter
+{
+    public static string BuildMarkdown(ProviderKernelCalibrationSnapshot snapshot)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("# Provider Degradation Kernel Calibration Report");
+        builder.AppendLine();
+        builder.AppendLine($"- Snapshot: `{snapshot.SnapshotId}`");
+        builder.AppendLine($"- Created: `{snapshot.CreatedAt:O}`");
+        builder.AppendLine($"- Dataset: `{snapshot.DatasetId}`");
+        builder.AppendLine($"- Baseline kernel: `{snapshot.BaselineKernelVersion}`");
+        builder.AppendLine($"- Candidate kernel: `{snapshot.CandidateKernelVersion}`");
+        builder.AppendLine($"- Calibration pass: `{snapshot.CalibrationPass}`");
+        builder.AppendLine();
+        builder.AppendLine("## Candidate vs baseline metrics");
+        builder.AppendLine();
+        builder.AppendLine("| Severity | Baseline precision | Candidate precision | Baseline recall | Candidate recall | Threshold (candidate) |");
+        builder.AppendLine("|---|---:|---:|---:|---:|---:|");
+
+        foreach (var candidate in snapshot.CandidateMetrics.OrderBy(m => m.Severity))
+        {
+            var baseline = snapshot.BaselineMetrics.Single(m => m.Severity == candidate.Severity);
+            builder.AppendLine($"| {candidate.Severity} | {baseline.Precision:F3} | {candidate.Precision:F3} | {baseline.Recall:F3} | {candidate.Recall:F3} | {candidate.Threshold:F3} |");
+        }
+
+        builder.AppendLine();
+        builder.AppendLine("## Alert volume impact");
+        builder.AppendLine();
+        builder.AppendLine($"- Decision severity: `{snapshot.Comparison.DecisionSeverity}`");
+        builder.AppendLine($"- Baseline expected alerts: `{snapshot.Comparison.ExpectedAlertCountBaseline}`");
+        builder.AppendLine($"- Candidate expected alerts: `{snapshot.Comparison.ExpectedAlertCountCandidate}`");
+        builder.AppendLine($"- Expected change: `{snapshot.Comparison.ExpectedAlertVolumeChangePercent:F2}%`");
+
+        return builder.ToString();
+    }
+}

--- a/tests/Meridian.Tests/Application/Monitoring/ProviderDegradationCalibrationTests.cs
+++ b/tests/Meridian.Tests/Application/Monitoring/ProviderDegradationCalibrationTests.cs
@@ -6,6 +6,49 @@ namespace Meridian.Tests.Application.Monitoring;
 public sealed class ProviderDegradationCalibrationTests
 {
     [Fact]
+    public async Task LoadAsync_ParsesStringBasedSeverityEnums()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.json");
+        const string json = """
+                            {
+                              "datasetId": "dataset-2026-04",
+                              "generatedAt": "2026-04-20T00:00:00Z",
+                              "source": "test",
+                              "windows": [
+                                {
+                                  "provider": "A",
+                                  "windowStart": "2026-04-20T00:00:00Z",
+                                  "windowEnd": "2026-04-20T00:05:00Z",
+                                  "observedSeverity": "Critical",
+                                  "connectionScore": 0.9,
+                                  "latencyScore": 0.8,
+                                  "errorRateScore": 0.7,
+                                  "reconnectScore": 0.6,
+                                  "eventsObserved": 10,
+                                  "alertVolumeObserved": 1
+                                }
+                              ]
+                            }
+                            """;
+
+        try
+        {
+            await File.WriteAllTextAsync(path, json);
+            var dataset = await ProviderIncidentCalibrationDataset.LoadAsync(path);
+
+            dataset.Windows.Should().ContainSingle();
+            dataset.Windows[0].ObservedSeverity.Should().Be(IncidentSeverity.Critical);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
     public void Run_ComputesPrecisionRecallAndAlertVolumeComparison()
     {
         var dataset = BuildDataset();
@@ -29,6 +72,8 @@ public sealed class ProviderDegradationCalibrationTests
         snapshot.CandidateKernelVersion.Should().Be("candidate-v2");
         snapshot.BaselineMetrics.Should().HaveCount(4);
         snapshot.CandidateMetrics.Should().HaveCount(4);
+        snapshot.CandidateMetrics.Single(m => m.Severity == IncidentSeverity.Critical).Threshold
+            .Should().Be(candidate.Config.DegradationThreshold);
         snapshot.Comparison.ExpectedAlertCountCandidate.Should().BeGreaterThan(0);
         snapshot.Comparison.ExpectedAlertVolumeChangePercent.Should().NotBe(double.NaN);
     }

--- a/tests/Meridian.Tests/Application/Monitoring/ProviderDegradationCalibrationTests.cs
+++ b/tests/Meridian.Tests/Application/Monitoring/ProviderDegradationCalibrationTests.cs
@@ -1,0 +1,115 @@
+using FluentAssertions;
+using Meridian.Application.Monitoring;
+
+namespace Meridian.Tests.Application.Monitoring;
+
+public sealed class ProviderDegradationCalibrationTests
+{
+    [Fact]
+    public void Run_ComputesPrecisionRecallAndAlertVolumeComparison()
+    {
+        var dataset = BuildDataset();
+        var baseline = ProviderDegradationKernelProfile.Default("baseline");
+        var candidate = baseline with
+        {
+            KernelVersion = "candidate-v2",
+            Config = baseline.Config with
+            {
+                ConnectionWeight = 0.50,
+                LatencyWeight = 0.20,
+                ErrorRateWeight = 0.20,
+                ReconnectWeight = 0.10,
+                DegradationThreshold = 0.55
+            }
+        };
+
+        var runner = new ProviderDegradationCalibrationRunner();
+        var snapshot = runner.Run(dataset, baseline, candidate, "test");
+
+        snapshot.CandidateKernelVersion.Should().Be("candidate-v2");
+        snapshot.BaselineMetrics.Should().HaveCount(4);
+        snapshot.CandidateMetrics.Should().HaveCount(4);
+        snapshot.Comparison.ExpectedAlertCountCandidate.Should().BeGreaterThan(0);
+        snapshot.Comparison.ExpectedAlertVolumeChangePercent.Should().NotBe(double.NaN);
+    }
+
+    [Fact]
+    public void Policy_Evaluate_BlocksStaleSnapshot()
+    {
+        var snapshot = BuildSnapshot(createdAt: DateTimeOffset.UtcNow.AddDays(-30));
+        var policy = new ProviderKernelCalibrationPolicy(
+            TimeSpan.FromDays(14),
+            MinPrecision: 0.6,
+            MinRecall: 0.6,
+            RequiredSeverity: IncidentSeverity.Critical);
+
+        var decision = policy.Evaluate(snapshot, "candidate-v2");
+
+        decision.Passed.Should().BeFalse();
+        decision.FreshnessPassed.Should().BeFalse();
+        decision.BlockingReasons.Should().Contain(reason => reason.Contains("stale", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void GovernanceWorkflow_RequiresExplicitCalibrationPass()
+    {
+        var workflow = new KernelWeightGovernanceWorkflowService(
+            new ProviderKernelCalibrationPolicy(TimeSpan.FromDays(14), 0.8, 0.8, IncidentSeverity.Critical));
+
+        var weakSnapshot = BuildSnapshot(criticalPrecision: 0.62, criticalRecall: 0.59);
+        var decision = workflow.EvaluatePromotion("candidate-v2", weakSnapshot, "ops");
+
+        decision.Approved.Should().BeFalse();
+        decision.CalibrationPass.Should().BeFalse();
+        decision.BlockingReasons.Should().Contain(reason => reason.Contains("precision", StringComparison.OrdinalIgnoreCase)
+            || reason.Contains("recall", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static ProviderIncidentCalibrationDataset BuildDataset()
+    {
+        return new ProviderIncidentCalibrationDataset(
+            DatasetId: "dataset-2026-04",
+            GeneratedAt: DateTimeOffset.UtcNow,
+            Source: "historical-provider-incidents",
+            Windows:
+            [
+                new("A", DateTimeOffset.UtcNow.AddHours(-10), DateTimeOffset.UtcNow.AddHours(-9), IncidentSeverity.None, 0.1, 0.1, 0.0, 0.0, 120, 0),
+                new("A", DateTimeOffset.UtcNow.AddHours(-9), DateTimeOffset.UtcNow.AddHours(-8), IncidentSeverity.Moderate, 0.4, 0.3, 0.3, 0.1, 100, 2),
+                new("A", DateTimeOffset.UtcNow.AddHours(-8), DateTimeOffset.UtcNow.AddHours(-7), IncidentSeverity.Critical, 1.0, 0.8, 0.9, 0.7, 40, 6),
+                new("B", DateTimeOffset.UtcNow.AddHours(-7), DateTimeOffset.UtcNow.AddHours(-6), IncidentSeverity.Major, 0.7, 0.6, 0.5, 0.2, 70, 3),
+                new("B", DateTimeOffset.UtcNow.AddHours(-6), DateTimeOffset.UtcNow.AddHours(-5), IncidentSeverity.Minor, 0.3, 0.2, 0.1, 0.1, 90, 1)
+            ]);
+    }
+
+    private static ProviderKernelCalibrationSnapshot BuildSnapshot(
+        DateTimeOffset? createdAt = null,
+        double criticalPrecision = 0.9,
+        double criticalRecall = 0.9)
+    {
+        return new ProviderKernelCalibrationSnapshot(
+            SnapshotId: Guid.NewGuid().ToString("N"),
+            CreatedAt: createdAt ?? DateTimeOffset.UtcNow,
+            DatasetId: "dataset-2026-04",
+            BaselineKernelVersion: "baseline",
+            CandidateKernelVersion: "candidate-v2",
+            BaselineMetrics:
+            [
+                new(IncidentSeverity.Critical, 0.60, 0.70, 0.70, 10, 3, 2, 12)
+            ],
+            CandidateMetrics:
+            [
+                new(IncidentSeverity.Critical, 0.55, criticalPrecision, criticalRecall, 11, 2, 1, 13)
+            ],
+            Comparison: new CalibrationComparisonSummary(
+                ExpectedAlertVolumeChangePercent: 8.3,
+                ExpectedAlertCountBaseline: 12,
+                ExpectedAlertCountCandidate: 13,
+                DecisionSeverity: IncidentSeverity.Critical,
+                CandidatePrecision: criticalPrecision,
+                CandidateRecall: criticalRecall,
+                BaselinePrecision: 0.70,
+                BaselineRecall: 0.70),
+            RunBy: "ops",
+            CalibrationPass: criticalPrecision >= 0.70 && criticalRecall >= 0.70);
+    }
+}

--- a/tests/Meridian.Tests/Application/Monitoring/ProviderDegradationCalibrationTests.cs
+++ b/tests/Meridian.Tests/Application/Monitoring/ProviderDegradationCalibrationTests.cs
@@ -75,7 +75,7 @@ public sealed class ProviderDegradationCalibrationTests
         snapshot.CandidateMetrics.Single(m => m.Severity == IncidentSeverity.Critical).Threshold
             .Should().Be(candidate.Config.DegradationThreshold);
         snapshot.Comparison.ExpectedAlertCountCandidate.Should().BeGreaterThan(0);
-        snapshot.Comparison.ExpectedAlertVolumeChangePercent.Should().NotBe(double.NaN);
+        snapshot.Comparison.ExpectedAlertVolumeChangePercent.Should().BeFinite();
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Prevent stale kernel weights and brittle severity thresholds by adding an offline calibration workflow that evaluates historical provider/data-quality incidents before weight promotion.
- Provide evidence-backed precision/recall metrics and expected alert-volume impact so governance can make informed promotion decisions.
- Enforce freshness and minimum-quality gates so candidate kernel weights cannot be promoted without an explicit calibration pass.
- Surface results in a human- and machine-friendly report so operators and dashboards can compare baseline vs candidate behavior.

### Description
- Added historical dataset and replay models (`ProviderIncidentCalibrationDataset`, `ProviderIncidentWindow`, `IncidentSeverity`) and a calibration runner that computes per-severity `Precision`/`Recall` and alert-volume estimates (`ProviderDegradationCalibrationRunner`) in `src/Meridian.Application/Monitoring/ProviderDegradationCalibration.cs`.
- Persisted calibration snapshots with metadata and kernel versions via `ProviderKernelCalibrationSnapshot` and `ProviderKernelCalibrationSnapshotStore`, and added a markdown report writer `ProviderCalibrationReportWriter` to produce human-readable comparison reports.
- Introduced policy and governance gate types (`ProviderKernelCalibrationPolicy`, `CalibrationGateDecision`, `KernelWeightGovernanceWorkflowService`, `KernelPromotionDecision`) to require snapshot freshness and minimum precision/recall for a required severity before approving promotion.
- Added a new CLI command `--calibrate-provider-degradation` implemented in `src/Meridian.Application/Commands/ProviderCalibrationCommand.cs` that loads dataset input, runs calibration, writes snapshot/report, evaluates the governance gate, and emits a JSON governance decision and markdown report.
- Wired the CLI command into startup dispatch so the command is available from the main `Meridian` CLI via `SharedStartupBootstrapper` and added operations docs `docs/operations/provider-degradation-calibration.md` with usage and dataset format, plus a link from `docs/operations/README.md`.
- Added unit tests `tests/Meridian.Tests/Application/Monitoring/ProviderDegradationCalibrationTests.cs` covering metric computation, staleness blocking, and governance pass/fail semantics.

### Testing
- Added unit tests `ProviderDegradationCalibrationTests` that assert computed `Precision`/`Recall`, alert-volume comparison, policy staleness blocking, and governance `CalibrationPass` behavior (located at `tests/Meridian.Tests/Application/Monitoring/ProviderDegradationCalibrationTests.cs`).
- Attempted to run the new tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter ProviderDegradationCalibrationTests --nologo`, but the run failed in this environment because `dotnet` is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6a7868fdc83209bc527adb35a2b80)