### PR TITLE
Decouple native backtest run lifetime from StartAsync token and add explicit run cancellation

### DIFF
--- a/src/Meridian.Application/Backtesting/BacktestStudioContracts.cs
+++ b/src/Meridian.Application/Backtesting/BacktestStudioContracts.cs
@@ -56,4 +56,9 @@ public interface IBacktestStudioEngine
     /// Implementations may await completion before returning.
     /// </summary>
     Task<BacktestResult> GetCanonicalResultAsync(string runHandle, CancellationToken ct);
+
+    /// <summary>
+    /// Requests cancellation for a previously started run.
+    /// </summary>
+    Task CancelAsync(string runHandle, CancellationToken ct);
 }

--- a/src/Meridian.Backtesting/BacktestStudioRunOrchestrator.cs
+++ b/src/Meridian.Backtesting/BacktestStudioRunOrchestrator.cs
@@ -55,7 +55,7 @@ public sealed class BacktestStudioRunOrchestrator : IAsyncDisposable
         await _repository.RecordRunAsync(entry, ct).ConfigureAwait(false);
         _runHandles[handle.RunId] = handle;
 
-        var monitorCts = CancellationTokenSource.CreateLinkedTokenSource(_shutdown.Token, ct);
+        var monitorCts = CancellationTokenSource.CreateLinkedTokenSource(_shutdown.Token);
         var monitorTask = MonitorRunCompletionAsync(entry, handle, engine, monitorCts);
         if (!_monitorTasks.TryAdd(handle.RunId, monitorTask))
         {
@@ -95,6 +95,18 @@ public sealed class BacktestStudioRunOrchestrator : IAsyncDisposable
         var handle = ResolveHandle(runId);
         var engine = ResolveEngine(handle.Engine);
         return engine.GetCanonicalResultAsync(handle.EngineRunHandle, ct);
+    }
+
+    /// <summary>
+    /// Requests cancellation for a previously started Backtest Studio run.
+    /// </summary>
+    public Task CancelAsync(string runId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runId);
+
+        var handle = ResolveHandle(runId);
+        var engine = ResolveEngine(handle.Engine);
+        return engine.CancelAsync(handle.EngineRunHandle, ct);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Meridian.Backtesting/MeridianNativeBacktestStudioEngine.cs
+++ b/src/Meridian.Backtesting/MeridianNativeBacktestStudioEngine.cs
@@ -41,7 +41,7 @@ public sealed class MeridianNativeBacktestStudioEngine : IBacktestStudioEngine
             throw new InvalidOperationException($"Unable to track native backtest run '{engineRunHandle}'.");
 
         registration.SetRunning();
-        _ = ExecuteAsync(request, registration, ct);
+        _ = ExecuteAsync(request, registration);
 
         return Task.FromResult(new BacktestStudioRunHandle(runId, engineRunHandle, Engine));
     }
@@ -62,9 +62,20 @@ public sealed class MeridianNativeBacktestStudioEngine : IBacktestStudioEngine
         return registration.Result.Task.WaitAsync(ct);
     }
 
-    private async Task ExecuteAsync(BacktestStudioRunRequest request, NativeRunRegistration registration, CancellationToken ct)
+    public Task CancelAsync(string runHandle, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runHandle);
+        ct.ThrowIfCancellationRequested();
+
+        var registration = Resolve(runHandle);
+        registration.RequestCancellation();
+        return Task.CompletedTask;
+    }
+
+    private async Task ExecuteAsync(BacktestStudioRunRequest request, NativeRunRegistration registration)
     {
         var progress = new Progress<BacktestProgressEvent>(evt => registration.UpdateProgress(evt));
+        var runToken = registration.Token;
 
         try
         {
@@ -72,14 +83,14 @@ public sealed class MeridianNativeBacktestStudioEngine : IBacktestStudioEngine
                     request.NativeRequest,
                     request.Strategy!,
                     progress,
-                    ct)
+                    runToken)
                 .ConfigureAwait(false);
 
             registration.Complete(result with { EngineMetadata = new BacktestEngineMetadata("MeridianNative") });
         }
         catch (OperationCanceledException ex)
         {
-            registration.Cancel(ex.CancellationToken.CanBeCanceled ? ex.CancellationToken : ct);
+            registration.Cancel(ex.CancellationToken.CanBeCanceled ? ex.CancellationToken : runToken);
         }
         catch (Exception ex)
         {
@@ -99,6 +110,7 @@ public sealed class MeridianNativeBacktestStudioEngine : IBacktestStudioEngine
     private sealed class NativeRunRegistration
     {
         private readonly object _gate = new();
+        private readonly CancellationTokenSource _runCancellation = new();
         private StrategyRunStatus _status = StrategyRunStatus.Pending;
         private double _progress;
         private string? _message;
@@ -118,6 +130,8 @@ public sealed class MeridianNativeBacktestStudioEngine : IBacktestStudioEngine
         public DateTimeOffset StartedAt { get; }
 
         public TaskCompletionSource<BacktestResult> Result { get; }
+
+        public CancellationToken Token => _runCancellation.Token;
 
         public void SetRunning()
         {
@@ -150,6 +164,8 @@ public sealed class MeridianNativeBacktestStudioEngine : IBacktestStudioEngine
 
             Result.TrySetResult(result);
         }
+
+        public void RequestCancellation() => _runCancellation.Cancel();
 
         public void Cancel(CancellationToken cancellationToken)
         {

--- a/tests/Meridian.Backtesting.Tests/MeridianNativeBacktestStudioEngineTests.cs
+++ b/tests/Meridian.Backtesting.Tests/MeridianNativeBacktestStudioEngineTests.cs
@@ -61,7 +61,34 @@ public sealed class MeridianNativeBacktestStudioEngineTests : IDisposable
     }
 
     [Fact]
-    public async Task StartAsync_WhenCallerCancels_CancelsNativeRun()
+    public async Task StartAsync_WhenStartTokenIsCanceledAfterScheduling_RunStillCompletes()
+    {
+        WriteBarJsonl("AAPL", new DateOnly(2024, 1, 2), 185m);
+
+        using var cts = new CancellationTokenSource();
+        var request = new BacktestStudioRunRequest(
+            StrategyId: "native-decoupled-cancel",
+            StrategyName: "NoOp",
+            Engine: StrategyRunEngine.MeridianNative,
+            NativeRequest: new BacktestRequest(
+                From: new DateOnly(2024, 1, 2),
+                To: new DateOnly(2024, 1, 2),
+                DataRoot: _dataRoot),
+            Strategy: new NoOpBacktestStrategy());
+
+        var handle = await _engine.StartAsync(request, cts.Token);
+        cts.Cancel();
+
+        var result = await _engine.GetCanonicalResultAsync(handle.EngineRunHandle, CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        var status = await _engine.GetStatusAsync(handle.EngineRunHandle, CancellationToken.None);
+
+        result.TotalEventsProcessed.Should().BeGreaterThan(0);
+        status.Status.Should().Be(StrategyRunStatus.Completed);
+    }
+
+    [Fact]
+    public async Task CancelAsync_WhenRunIsInFlight_TransitionsToCancelled()
     {
         WriteBarJsonl("AAPL", new DateOnly(2024, 1, 2), 185m);
 
@@ -75,9 +102,8 @@ public sealed class MeridianNativeBacktestStudioEngineTests : IDisposable
             backtestEngine,
             NullLogger<MeridianNativeBacktestStudioEngine>.Instance);
 
-        using var cts = new CancellationTokenSource();
         var request = new BacktestStudioRunRequest(
-            StrategyId: "native-cancel",
+            StrategyId: "native-explicit-cancel",
             StrategyName: "NoOp",
             Engine: StrategyRunEngine.MeridianNative,
             NativeRequest: new BacktestRequest(
@@ -87,10 +113,10 @@ public sealed class MeridianNativeBacktestStudioEngineTests : IDisposable
                 AdjustForCorporateActions: true),
             Strategy: new NoOpBacktestStrategy());
 
-        var handle = await engine.StartAsync(request, cts.Token);
+        var handle = await engine.StartAsync(request, CancellationToken.None);
         await blockingAdjuster.Started.WaitAsync(TimeSpan.FromSeconds(5));
 
-        cts.Cancel();
+        await engine.CancelAsync(handle.EngineRunHandle, CancellationToken.None);
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             async () => await engine.GetCanonicalResultAsync(handle.EngineRunHandle, CancellationToken.None)

--- a/tests/Meridian.Tests/Application/Backtesting/BacktestStudioRunOrchestratorTests.cs
+++ b/tests/Meridian.Tests/Application/Backtesting/BacktestStudioRunOrchestratorTests.cs
@@ -77,7 +77,7 @@ public sealed class BacktestStudioRunOrchestratorTests
     }
 
     [Fact]
-    public async Task StartAsync_WhenCallerCancels_RecordsCancelledRun()
+    public async Task StartAsync_WhenCallerCancelsAfterScheduling_RunCanStillComplete()
     {
         var store = new StrategyRunStore();
         var engine = new StubBacktestStudioEngine();
@@ -97,10 +97,41 @@ public sealed class BacktestStudioRunOrchestratorTests
         await engine.WaitForMonitorAsync(handle.EngineRunHandle);
 
         cts.Cancel();
+        engine.Complete(handle.EngineRunHandle, BuildResult(request.NativeRequest));
+
+        var completed = await WaitForRunAsync(
+            store,
+            "strategy-3",
+            run => run.EndedAt.HasValue);
+
+        completed.RunId.Should().Be(handle.RunId);
+        completed.TerminalStatus.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CancelAsync_WhenCalled_RecordsCancelledRun()
+    {
+        var store = new StrategyRunStore();
+        var engine = new StubBacktestStudioEngine();
+        await using var orchestrator = new BacktestStudioRunOrchestrator(
+            store,
+            [engine],
+            NullLogger<BacktestStudioRunOrchestrator>.Instance);
+
+        var request = new BacktestStudioRunRequest(
+            StrategyId: "strategy-cancel",
+            StrategyName: "Momentum",
+            Engine: StrategyRunEngine.MeridianNative,
+            NativeRequest: BuildRequest());
+
+        var handle = await orchestrator.StartAsync(request, CancellationToken.None);
+        await engine.WaitForMonitorAsync(handle.EngineRunHandle);
+
+        await orchestrator.CancelAsync(handle.RunId, CancellationToken.None);
 
         var cancelled = await WaitForRunAsync(
             store,
-            "strategy-3",
+            "strategy-cancel",
             run => run.TerminalStatus == StrategyRunStatus.Cancelled);
 
         cancelled.RunId.Should().Be(handle.RunId);
@@ -234,6 +265,14 @@ public sealed class BacktestStudioRunOrchestratorTests
                 _monitorCancelled[runHandle].TrySetResult(true);
                 throw;
             }
+        }
+
+        public Task CancelAsync(string runHandle, CancellationToken ct)
+        {
+            var status = _statuses[runHandle];
+            _statuses[runHandle] = status with { Status = StrategyRunStatus.Cancelled, Message = "Cancelled" };
+            _results[runHandle].TrySetCanceled(ct.IsCancellationRequested ? ct : new CancellationToken(canceled: true));
+            return Task.CompletedTask;
         }
 
         public void Complete(string runHandle, BacktestResult result)


### PR DESCRIPTION
### Motivation
- Prevent runs from being canceled when the caller cancels the `StartAsync` request after the run has been scheduled while still honoring immediate cancellation at `StartAsync` entry. 
- Provide an explicit control path to cancel an in-flight native run via run-control APIs instead of relying on the caller's start token.

### Description
- Kept the immediate cancellation check at `StartAsync` entry via `ct.ThrowIfCancellationRequested()` and schedule the run without passing the caller token to execution. (`src/Meridian.Backtesting/MeridianNativeBacktestStudioEngine.cs`)
- Introduced a per-run `CancellationTokenSource` inside `NativeRunRegistration` and exposed the run token via `NativeRunRegistration.Token`, which is passed to `_engine.RunAsync` in `ExecuteAsync`. (`src/Meridian.Backtesting/MeridianNativeBacktestStudioEngine.cs`)
- Added `CancelAsync(string runHandle, CancellationToken ct)` to the `IBacktestStudioEngine` contract and implemented it in the native engine to call the run-owned CTS (`RequestCancellation`). (`src/Meridian.Application/Backtesting/BacktestStudioContracts.cs`, `src/Meridian.Backtesting/MeridianNativeBacktestStudioEngine.cs`)
- Updated the `BacktestStudioRunOrchestrator` to stop linking the monitor cancellation to the caller `StartAsync` token (monitor only links to orchestrator shutdown) and added `CancelAsync(runId, ct)` that delegates to the engine. (`src/Meridian.Backtesting/BacktestStudioRunOrchestrator.cs`)
- Updated tests to validate the new semantics by verifying that a run continues after the caller cancels the `StartAsync` token, that explicit `CancelAsync` transitions a run to `Cancelled`, and that status/result behavior remains correct. (`tests/Meridian.Backtesting.Tests/MeridianNativeBacktestStudioEngineTests.cs`, `tests/Meridian.Tests/Application/Backtesting/BacktestStudioRunOrchestratorTests.cs`)

### Testing
- Updated and added unit tests under `tests/Meridian.Backtesting.Tests` and `tests/Meridian.Tests/Application/Backtesting` to cover: decoupled start-token behavior, explicit run cancellation, and status/result assertions; these test files were modified in this change. 
- Attempted to run the targeted tests with `dotnet test tests/Meridian.Backtesting.Tests/Meridian.Backtesting.Tests.csproj --filter MeridianNativeBacktestStudioEngineTests`, but `dotnet` is not available in the execution environment so automated test execution was not performed here. 
- Local CI or developer machines should run the test suite to confirm behavior; the changes are covered by the updated unit tests referenced above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ec26baec8320bfa8337d96071ed6)