### PR TITLE
Centralize workspace copy strings and add copy catalog validation

### DIFF
--- a/src/Meridian.Wpf/Copy/WorkspaceCopyCatalog.cs
+++ b/src/Meridian.Wpf/Copy/WorkspaceCopyCatalog.cs
@@ -1,0 +1,118 @@
+namespace Meridian.Wpf.Copy;
+
+public sealed record WorkspaceDescriptorCopy(
+    string Id,
+    string Title,
+    string Description,
+    string Summary,
+    string TileSummary,
+    string ShellDisplayName);
+
+public sealed record WorkspaceCopyEntry(string Key, string Text);
+
+public static class WorkspaceCopyCatalog
+{
+    // Copy key convention: workspace.section.intent
+    public static class Research
+    {
+        public const string WorkspaceId = "research";
+        public static readonly WorkspaceDescriptorCopy Descriptor = new(
+            WorkspaceId,
+            "Research",
+            "Backtest studio, run comparison, charts, and investigation flows.",
+            "Operate model exploration with docked run, portfolio, and promotion context.",
+            "Runs · Compare · Promote",
+            "Backtest Studio");
+
+        public const string ShellTitle = "Research Workspace";
+        public const string ShellSubtitle = "Market briefing, run studio, and promotion-aware research workflow.";
+        public const string PrimaryScopeLabel = "Research";
+    }
+
+    public static class Trading
+    {
+        public const string WorkspaceId = "trading";
+        public static readonly WorkspaceDescriptorCopy Descriptor = new(
+            WorkspaceId,
+            "Trading",
+            "Live posture, order flow, execution, and risk-aware monitoring.",
+            "Operate the trading cockpit with explicit paper/live separation and audit reachability.",
+            "Live · Orders · Risk",
+            "Trading Cockpit");
+
+        public const string ShellTitle = "Trading Cockpit";
+        public const string ShellSubtitle = "Risk-aware trading shell for live posture, blotter review, safe staging, and docked execution detail.";
+        public const string PrimaryScopeLabel = "Desk";
+    }
+
+    public static class DataOperations
+    {
+        public const string WorkspaceId = "data-operations";
+        public static readonly WorkspaceDescriptorCopy Descriptor = new(
+            WorkspaceId,
+            "Data Operations",
+            "Providers, ingestion, storage, schedules, exports, and blocker visibility.",
+            "Operate the collection queue, freshness posture, and export pipeline from one workstation.",
+            "Providers · Storage · Jobs",
+            "Data Operations Workspace");
+
+        public const string ShellTitle = "Data Operations Workspace";
+        public const string ShellSubtitle = "Provider freshness, backfill pressure, storage posture, and export job visibility in one fixed operator shell.";
+        public const string PrimaryScopeLabel = "Queue";
+        public const string DefaultScopeLabel = "Provider and storage posture";
+        public const string DefaultScopeSummary = "Provider posture, backfill priority, storage follow-up, and export delivery stay in one fixed shell.";
+    }
+
+    public static class Governance
+    {
+        public const string WorkspaceId = "governance";
+        public static readonly WorkspaceDescriptorCopy Descriptor = new(
+            WorkspaceId,
+            "Governance",
+            "Controls, diagnostics, fund operations, reconciliation, and trust-critical review.",
+            "Operate accounts, ledger, reconciliation, and audit work from a single control surface.",
+            "Ledger · Audit · Controls",
+            "Governance Workspace");
+
+        public const string ShellTitle = "Governance Workspace";
+        public const string ShellSubtitleNoFund = "Organization-aware review shell for operations, accounting, reconciliation, reporting, and audit posture.";
+        public const string ShellSubtitleFund = "Review operations, accounting, reconciliations, reporting, and approval gates without leaving the workstation shell.";
+    }
+
+    public static IReadOnlyList<WorkspaceCopyEntry> Entries { get; } =
+    [
+        new("research.workspace.title", Research.Descriptor.Title),
+        new("research.workspace.description", Research.Descriptor.Description),
+        new("research.workspace.summary", Research.Descriptor.Summary),
+        new("research.workspace.tile-summary", Research.Descriptor.TileSummary),
+        new("research.shell.title", Research.ShellTitle),
+        new("research.shell.subtitle", Research.ShellSubtitle),
+        new("research.shell.primary-scope-label", Research.PrimaryScopeLabel),
+
+        new("trading.workspace.title", Trading.Descriptor.Title),
+        new("trading.workspace.description", Trading.Descriptor.Description),
+        new("trading.workspace.summary", Trading.Descriptor.Summary),
+        new("trading.workspace.tile-summary", Trading.Descriptor.TileSummary),
+        new("trading.shell.title", Trading.ShellTitle),
+        new("trading.shell.subtitle", Trading.ShellSubtitle),
+        new("trading.shell.primary-scope-label", Trading.PrimaryScopeLabel),
+
+        new("data-operations.workspace.title", DataOperations.Descriptor.Title),
+        new("data-operations.workspace.description", DataOperations.Descriptor.Description),
+        new("data-operations.workspace.summary", DataOperations.Descriptor.Summary),
+        new("data-operations.workspace.tile-summary", DataOperations.Descriptor.TileSummary),
+        new("data-operations.shell.title", DataOperations.ShellTitle),
+        new("data-operations.shell.subtitle", DataOperations.ShellSubtitle),
+        new("data-operations.shell.primary-scope-label", DataOperations.PrimaryScopeLabel),
+        new("data-operations.shell.scope-default", DataOperations.DefaultScopeLabel),
+        new("data-operations.shell.scope-summary-default", DataOperations.DefaultScopeSummary),
+
+        new("governance.workspace.title", Governance.Descriptor.Title),
+        new("governance.workspace.description", Governance.Descriptor.Description),
+        new("governance.workspace.summary", Governance.Descriptor.Summary),
+        new("governance.workspace.tile-summary", Governance.Descriptor.TileSummary),
+        new("governance.shell.title", Governance.ShellTitle),
+        new("governance.shell.subtitle.no-fund", Governance.ShellSubtitleNoFund),
+        new("governance.shell.subtitle.fund", Governance.ShellSubtitleFund)
+    ];
+}

--- a/src/Meridian.Wpf/Models/ShellNavigationCatalog.Workspaces.cs
+++ b/src/Meridian.Wpf/Models/ShellNavigationCatalog.Workspaces.cs
@@ -1,3 +1,4 @@
+using Meridian.Wpf.Copy;
 using Meridian.Wpf.Services;
 using Meridian.Wpf.ViewModels;
 
@@ -8,40 +9,40 @@ public static partial class ShellNavigationCatalog
     public static readonly IReadOnlyList<WorkspaceShellDescriptor> Workspaces =
     [
         new(
-            Id: "research",
-            Title: "Research",
-            Description: "Backtest studio, run comparison, charts, and investigation flows.",
-            Summary: "Operate model exploration with docked run, portfolio, and promotion context.",
+            Id: WorkspaceCopyCatalog.Research.Descriptor.Id,
+            Title: WorkspaceCopyCatalog.Research.Descriptor.Title,
+            Description: WorkspaceCopyCatalog.Research.Descriptor.Description,
+            Summary: WorkspaceCopyCatalog.Research.Descriptor.Summary,
             HomePageTag: "ResearchShell",
-            TileSummary: "Runs · Compare · Promote"),
+            TileSummary: WorkspaceCopyCatalog.Research.Descriptor.TileSummary),
         new(
-            Id: "trading",
-            Title: "Trading",
-            Description: "Live posture, order flow, execution, and risk-aware monitoring.",
-            Summary: "Operate the trading cockpit with explicit paper/live separation and audit reachability.",
+            Id: WorkspaceCopyCatalog.Trading.Descriptor.Id,
+            Title: WorkspaceCopyCatalog.Trading.Descriptor.Title,
+            Description: WorkspaceCopyCatalog.Trading.Descriptor.Description,
+            Summary: WorkspaceCopyCatalog.Trading.Descriptor.Summary,
             HomePageTag: "TradingShell",
-            TileSummary: "Live · Orders · Risk"),
+            TileSummary: WorkspaceCopyCatalog.Trading.Descriptor.TileSummary),
         new(
-            Id: "data-operations",
-            Title: "Data Operations",
-            Description: "Providers, ingestion, storage, schedules, exports, and blocker visibility.",
-            Summary: "Operate the collection queue, freshness posture, and export pipeline from one workstation.",
+            Id: WorkspaceCopyCatalog.DataOperations.Descriptor.Id,
+            Title: WorkspaceCopyCatalog.DataOperations.Descriptor.Title,
+            Description: WorkspaceCopyCatalog.DataOperations.Descriptor.Description,
+            Summary: WorkspaceCopyCatalog.DataOperations.Descriptor.Summary,
             HomePageTag: "DataOperationsShell",
-            TileSummary: "Providers · Storage · Jobs"),
+            TileSummary: WorkspaceCopyCatalog.DataOperations.Descriptor.TileSummary),
         new(
-            Id: "governance",
-            Title: "Governance",
-            Description: "Controls, diagnostics, fund operations, reconciliation, and trust-critical review.",
-            Summary: "Operate accounts, ledger, reconciliation, and audit work from a single control surface.",
+            Id: WorkspaceCopyCatalog.Governance.Descriptor.Id,
+            Title: WorkspaceCopyCatalog.Governance.Descriptor.Title,
+            Description: WorkspaceCopyCatalog.Governance.Descriptor.Description,
+            Summary: WorkspaceCopyCatalog.Governance.Descriptor.Summary,
             HomePageTag: "GovernanceShell",
-            TileSummary: "Ledger · Audit · Controls")
+            TileSummary: WorkspaceCopyCatalog.Governance.Descriptor.TileSummary)
     ];
 
     private static readonly WorkspaceShellDefinition ResearchWorkspaceShellDefinition =
         new(
-            WorkspaceId: "research",
+            WorkspaceId: WorkspaceCopyCatalog.Research.WorkspaceId,
             LayoutId: "research-backtest-studio",
-            DisplayName: "Backtest Studio",
+            DisplayName: WorkspaceCopyCatalog.Research.Descriptor.ShellDisplayName,
             DefaultPanes:
             [
                 Pane("Backtest", PaneDropAction.Replace),
@@ -66,9 +67,9 @@ public static partial class ShellNavigationCatalog
 
     private static readonly WorkspaceShellDefinition TradingWorkspaceShellDefinition =
         new(
-            WorkspaceId: "trading",
+            WorkspaceId: WorkspaceCopyCatalog.Trading.WorkspaceId,
             LayoutId: "trading-cockpit",
-            DisplayName: "Trading Cockpit",
+            DisplayName: WorkspaceCopyCatalog.Trading.Descriptor.ShellDisplayName,
             DefaultPanes:
             [
                 Pane("LiveData", PaneDropAction.Replace),
@@ -96,9 +97,9 @@ public static partial class ShellNavigationCatalog
 
     private static readonly WorkspaceShellDefinition DataOperationsWorkspaceShellDefinition =
         new(
-            WorkspaceId: "data-operations",
+            WorkspaceId: WorkspaceCopyCatalog.DataOperations.WorkspaceId,
             LayoutId: "data-operations-workspace",
-            DisplayName: "Data Operations Workspace",
+            DisplayName: WorkspaceCopyCatalog.DataOperations.Descriptor.ShellDisplayName,
             DefaultPanes:
             [
                 Pane("Provider", PaneDropAction.Replace),
@@ -113,9 +114,9 @@ public static partial class ShellNavigationCatalog
 
     private static readonly WorkspaceShellDefinition GovernanceWorkspaceShellDefinition =
         new(
-            WorkspaceId: "governance",
+            WorkspaceId: WorkspaceCopyCatalog.Governance.WorkspaceId,
             LayoutId: "governance-workspace",
-            DisplayName: "Governance Workspace",
+            DisplayName: WorkspaceCopyCatalog.Governance.Descriptor.ShellDisplayName,
             DefaultPanes:
             [
                 Pane("FundLedger", PaneDropAction.Replace),

--- a/src/Meridian.Wpf/Services/DataOperationsWorkspacePresentationBuilder.cs
+++ b/src/Meridian.Wpf/Services/DataOperationsWorkspacePresentationBuilder.cs
@@ -2,6 +2,7 @@ using Meridian.Contracts.Api;
 using Meridian.Contracts.Session;
 using Meridian.Ui.Services;
 using Meridian.Ui.Services.Services;
+using Meridian.Wpf.Copy;
 using Meridian.Wpf.Models;
 using ProviderInfoModel = Meridian.Ui.Services.Services.ProviderInfo;
 using StatusProviderInfoModel = Meridian.Ui.Services.Services.StatusProviderInfo;
@@ -124,9 +125,9 @@ public static class DataOperationsWorkspacePresentationBuilder
         {
             Context = new WorkspaceShellContextInput
             {
-                WorkspaceTitle = "Data Operations Workspace",
-                WorkspaceSubtitle = "Provider freshness, backfill pressure, storage posture, and export job visibility in one fixed operator shell.",
-                PrimaryScopeLabel = "Queue",
+                WorkspaceTitle = WorkspaceCopyCatalog.DataOperations.ShellTitle,
+                WorkspaceSubtitle = WorkspaceCopyCatalog.DataOperations.ShellSubtitle,
+                PrimaryScopeLabel = WorkspaceCopyCatalog.DataOperations.PrimaryScopeLabel,
                 PrimaryScopeValue = data.ScopeLabel,
                 AsOfValue = data.RetrievedAt.ToString("MMM dd yyyy HH:mm"),
                 FreshnessValue = freshnessValue,

--- a/src/Meridian.Wpf/Views/DataOperationsWorkspaceShellPage.xaml
+++ b/src/Meridian.Wpf/Views/DataOperationsWorkspaceShellPage.xaml
@@ -5,13 +5,14 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:models="clr-namespace:Meridian.Wpf.Models"
       xmlns:views="clr-namespace:Meridian.Wpf.Views"
+      xmlns:copy="clr-namespace:Meridian.Wpf.Copy"
       mc:Ignorable="d"
       d:DesignHeight="900"
       d:DesignWidth="1400"
       Background="{DynamicResource ConsoleBackgroundDarkBrush}"
       Loaded="OnPageLoaded"
       Unloaded="OnPageUnloaded"
-      AutomationProperties.Name="Data Operations Workspace"
+      AutomationProperties.Name="{x:Static copy:WorkspaceCopyCatalog.DataOperations.ShellTitle}"
       AutomationProperties.AutomationId="DataOperationsWorkspaceShellPage">
 
     <Page.Resources>

--- a/src/Meridian.Wpf/Views/DataOperationsWorkspaceShellPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/DataOperationsWorkspaceShellPage.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Media;
 using Meridian.Contracts.Api;
 using Meridian.Ui.Services;
 using Meridian.Ui.Services.Services;
+using Meridian.Wpf.Copy;
 using Meridian.Wpf.Models;
 using Meridian.Wpf.Services;
 using Meridian.Wpf.ViewModels;
@@ -91,10 +92,10 @@ public partial class DataOperationsWorkspaceShellPage : DataOperationsWorkspaceS
         var notifications = _notificationService.GetHistory().Take(4).ToArray();
         var operatingContext = _operatingContextService?.CurrentContext;
         var scopeLabel = operatingContext is null
-            ? "Provider and storage posture"
+            ? WorkspaceCopyCatalog.DataOperations.DefaultScopeLabel
             : $"{operatingContext.ScopeKind.ToDisplayName()} · {operatingContext.DisplayName}";
         var scopeSummary = operatingContext is null
-            ? "Provider posture, backfill priority, storage follow-up, and export delivery stay in one fixed shell."
+            ? WorkspaceCopyCatalog.DataOperations.DefaultScopeSummary
             : $"Route providers, backfills, storage, and export jobs for {operatingContext.DisplayName} without leaving the shell.";
 
         var providersTask = LoadSafeAsync("provider catalog", async () => (await _statusService.GetAvailableProvidersAsync()).ToArray(), Array.Empty<ProviderInfoModel>());

--- a/src/Meridian.Wpf/Views/GovernanceWorkspaceShellPage.xaml
+++ b/src/Meridian.Wpf/Views/GovernanceWorkspaceShellPage.xaml
@@ -5,13 +5,14 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:models="clr-namespace:Meridian.Wpf.Models"
       xmlns:views="clr-namespace:Meridian.Wpf.Views"
+      xmlns:copy="clr-namespace:Meridian.Wpf.Copy"
       mc:Ignorable="d"
       d:DesignHeight="900"
       d:DesignWidth="1400"
       Background="{DynamicResource ConsoleBackgroundDarkBrush}"
       Loaded="OnPageLoaded"
       Unloaded="OnPageUnloaded"
-      AutomationProperties.Name="Governance Workspace"
+      AutomationProperties.Name="{x:Static copy:WorkspaceCopyCatalog.Governance.ShellTitle}"
       AutomationProperties.AutomationId="GovernanceWorkspaceShellPage">
 
     <Page.Resources>

--- a/src/Meridian.Wpf/Views/GovernanceWorkspaceShellPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/GovernanceWorkspaceShellPage.xaml.cs
@@ -6,6 +6,7 @@ using Meridian.Contracts.Workstation;
 using Meridian.Ui.Shared.Services;
 using Meridian.Ui.Services;
 using Meridian.Ui.Services.Services;
+using Meridian.Wpf.Copy;
 using Meridian.Wpf.Models;
 using Meridian.Wpf.Services;
 using Meridian.Wpf.ViewModels;
@@ -82,8 +83,8 @@ public partial class GovernanceWorkspaceShellPage : GovernanceWorkspaceShellPage
             {
                 ContextStrip.ShellContext = await _shellContextService.CreateAsync(new WorkspaceShellContextInput
                 {
-                    WorkspaceTitle = "Governance Workspace",
-                    WorkspaceSubtitle = "Organization-aware review shell for operations, accounting, reconciliation, reporting, and audit posture.",
+                    WorkspaceTitle = WorkspaceCopyCatalog.Governance.ShellTitle,
+                    WorkspaceSubtitle = WorkspaceCopyCatalog.Governance.ShellSubtitleNoFund,
                     PrimaryScopeLabel = "Context",
                     PrimaryScopeValue = operatingContext?.DisplayName ?? "Awaiting fund-linked scope",
                     AsOfValue = "Awaiting fund-linked scope",
@@ -119,8 +120,8 @@ public partial class GovernanceWorkspaceShellPage : GovernanceWorkspaceShellPage
 
             ContextStrip.ShellContext = await _shellContextService.CreateAsync(new WorkspaceShellContextInput
             {
-                WorkspaceTitle = "Governance Workspace",
-                WorkspaceSubtitle = "Review operations, accounting, reconciliations, reporting, and approval gates without leaving the workstation shell.",
+                WorkspaceTitle = WorkspaceCopyCatalog.Governance.ShellTitle,
+                WorkspaceSubtitle = WorkspaceCopyCatalog.Governance.ShellSubtitleFund,
                 PrimaryScopeLabel = "Governance Scope",
                 PrimaryScopeValue = operatingContext?.DisplayName ?? $"{profile.DisplayName} · {profile.BaseCurrency}",
                 AsOfValue = ledger?.AsOf.ToLocalTime().ToString("MMM dd yyyy HH:mm") ?? "Awaiting ledger snapshot",

--- a/src/Meridian.Wpf/Views/ResearchWorkspaceShellPage.xaml
+++ b/src/Meridian.Wpf/Views/ResearchWorkspaceShellPage.xaml
@@ -4,13 +4,14 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:views="clr-namespace:Meridian.Wpf.Views"
+      xmlns:copy="clr-namespace:Meridian.Wpf.Copy"
       mc:Ignorable="d"
       d:DesignHeight="900"
       d:DesignWidth="1400"
       Background="{DynamicResource ConsoleBackgroundDarkBrush}"
       Loaded="OnPageLoaded"
       Unloaded="OnPageUnloaded"
-      AutomationProperties.Name="Research Workspace"
+      AutomationProperties.Name="{x:Static copy:WorkspaceCopyCatalog.Research.ShellTitle}"
       AutomationProperties.AutomationId="ResearchWorkspaceShellPage">
 
     <Page.Resources>

--- a/src/Meridian.Wpf/Views/ResearchWorkspaceShellPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/ResearchWorkspaceShellPage.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using Meridian.Contracts.Workstation;
+using Meridian.Wpf.Copy;
 using Meridian.Strategies.Services;
 using Meridian.Ui.Services;
 using Meridian.Wpf.Models;
@@ -188,9 +189,9 @@ public partial class ResearchWorkspaceShellPage : ResearchWorkspaceShellPageBase
 
         return new WorkspaceShellContextInput
         {
-            WorkspaceTitle = "Research Workspace",
-            WorkspaceSubtitle = "Market briefing, run studio, and promotion-aware research workflow.",
-            PrimaryScopeLabel = "Research",
+            WorkspaceTitle = WorkspaceCopyCatalog.Research.ShellTitle,
+            WorkspaceSubtitle = WorkspaceCopyCatalog.Research.ShellSubtitle,
+            PrimaryScopeLabel = WorkspaceCopyCatalog.Research.PrimaryScopeLabel,
             PrimaryScopeValue = activeRun?.StrategyName
                 ?? briefing.Workspace.LatestStrategyName
                 ?? "No active research run",

--- a/src/Meridian.Wpf/Views/TradingWorkspaceShellPage.xaml
+++ b/src/Meridian.Wpf/Views/TradingWorkspaceShellPage.xaml
@@ -4,13 +4,14 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:views="clr-namespace:Meridian.Wpf.Views"
+      xmlns:copy="clr-namespace:Meridian.Wpf.Copy"
       mc:Ignorable="d"
       d:DesignHeight="900"
       d:DesignWidth="1400"
       Background="{DynamicResource ConsoleBackgroundDarkBrush}"
       Loaded="OnPageLoaded"
       Unloaded="OnPageUnloaded"
-      AutomationProperties.Name="Trading Cockpit"
+      AutomationProperties.Name="{x:Static copy:WorkspaceCopyCatalog.Trading.ShellTitle}"
       AutomationProperties.AutomationId="TradingWorkspaceShellPage">
 
     <Grid Margin="20">
@@ -41,9 +42,9 @@
                         </Grid.ColumnDefinitions>
 
                         <StackPanel Grid.Column="0">
-                            <TextBlock Text="Trading Cockpit"
+                            <TextBlock Text="{x:Static copy:WorkspaceCopyCatalog.Trading.ShellTitle}"
                                        Style="{StaticResource PageTitleStyle}" />
-                            <TextBlock Text="Paper and live execution, active positions, and fund-aware risk posture from a single cockpit shell."
+                            <TextBlock Text="{x:Static copy:WorkspaceCopyCatalog.Trading.ShellSubtitle}"
                                        Margin="0,6,0,0"
                                        Style="{StaticResource CardDescriptionStyle}"
                                        TextWrapping="Wrap" />

--- a/src/Meridian.Wpf/Views/TradingWorkspaceShellPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/TradingWorkspaceShellPage.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using Meridian.Ui.Services;
+using Meridian.Wpf.Copy;
 using Meridian.Wpf.Models;
 using Meridian.Wpf.Services;
 using Meridian.Wpf.ViewModels;
@@ -123,9 +124,9 @@ public partial class TradingWorkspaceShellPage : TradingWorkspaceShellPageBase
 
             ContextStrip.ShellContext = await _shellContextService.CreateAsync(new WorkspaceShellContextInput
             {
-                WorkspaceTitle = "Trading Cockpit",
-                WorkspaceSubtitle = "Risk-aware trading shell for live posture, blotter review, safe staging, and docked execution detail.",
-                PrimaryScopeLabel = "Desk",
+                WorkspaceTitle = WorkspaceCopyCatalog.Trading.ShellTitle,
+                WorkspaceSubtitle = WorkspaceCopyCatalog.Trading.ShellSubtitle,
+                PrimaryScopeLabel = WorkspaceCopyCatalog.Trading.PrimaryScopeLabel,
                 PrimaryScopeValue = summary.ActiveRunContext?.StrategyName ?? (_fundContextService.CurrentFundProfile?.DisplayName ?? "No active trading run"),
                 AsOfValue = DateTimeOffset.Now.ToString("MMM dd yyyy HH:mm"),
                 FreshnessValue = summary.ActiveRunContext is null ? "Awaiting active run" : $"{summary.ActiveRunContext.ModeLabel} · {summary.ActiveRunContext.StatusLabel}",

--- a/tests/Meridian.Wpf.Tests/Copy/WorkspaceCopyCatalogTests.cs
+++ b/tests/Meridian.Wpf.Tests/Copy/WorkspaceCopyCatalogTests.cs
@@ -1,0 +1,48 @@
+using System.Text.RegularExpressions;
+using Meridian.Wpf.Copy;
+
+namespace Meridian.Wpf.Tests.Copy;
+
+public sealed class WorkspaceCopyCatalogTests
+{
+    private static readonly Regex CopyKeyPattern = new(
+        "^[a-z0-9-]+\\.[a-z0-9-]+\\.[a-z0-9-]+$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    [Fact]
+    public void CopyEntries_ShouldUseWorkspaceSectionIntentKeys()
+    {
+        foreach (var entry in WorkspaceCopyCatalog.Entries)
+        {
+            CopyKeyPattern.IsMatch(entry.Key)
+                .Should()
+                .BeTrue($"copy key '{entry.Key}' must follow workspace.section.intent");
+        }
+    }
+
+    [Fact]
+    public void CopyEntries_ShouldNotContainConflictingDuplicateKeys()
+    {
+        var conflicting = WorkspaceCopyCatalog.Entries
+            .GroupBy(entry => entry.Key, StringComparer.Ordinal)
+            .Where(group => group.Select(entry => entry.Text).Distinct(StringComparer.Ordinal).Count() > 1)
+            .Select(group => group.Key)
+            .ToArray();
+
+        conflicting.Should().BeEmpty("copy keys should not map to multiple conflicting values");
+    }
+
+    [Fact]
+    public void SubtitleEntries_ShouldStayWithinLengthBudget()
+    {
+        const int maxSubtitleLength = 120;
+
+        var overlong = WorkspaceCopyCatalog.Entries
+            .Where(entry => entry.Key.Contains("subtitle", StringComparison.Ordinal))
+            .Where(entry => entry.Text.Length > maxSubtitleLength)
+            .Select(entry => $"{entry.Key} ({entry.Text.Length})")
+            .ToArray();
+
+        overlong.Should().BeEmpty($"workspace subtitles must be <= {maxSubtitleLength} characters");
+    }
+}


### PR DESCRIPTION
### Motivation

- Reduce duplicated user-facing workspace strings by centralizing copy into a single catalog and enforce a naming convention for copy keys.
- Replace hardcoded literals in shell descriptors, presentation builders, and XAML with catalog references to make copy easier to maintain and localize.
- Add a small static validation suite to detect conflicting/duplicate keys and enforce subtitle length limits.

### Description

- Added a new copy catalog `src/Meridian.Wpf/Copy/WorkspaceCopyCatalog.cs` containing grouped `WorkspaceDescriptorCopy` records, per-workspace constants (titles, subtitles, scope labels), and an `Entries` list with canonical copy keys (`workspace.section.intent`).
- Refactored `src/Meridian.Wpf/Models/ShellNavigationCatalog.Workspaces.cs` to source workspace `Title`, `Description`, `Summary`, `TileSummary`, workspace IDs, and shell display names from the new catalog instead of inline literals.
- Updated workspace shell pages and presentation builder code to use catalog values: `Research`, `Trading`, `DataOperations`, and `Governance` shell context construction now references `WorkspaceCopyCatalog` constants (files updated under `src/Meridian.Wpf/Views/*WorkspaceShellPage.xaml.cs` and `src/Meridian.Wpf/Services/DataOperationsWorkspacePresentationBuilder.cs`).
- Replaced repeated XAML automation/title literals with `x:Static` references to `WorkspaceCopyCatalog` (updated `*.xaml` files for workspace shells) so presentation and automation names come from the single source-of-truth.
- Added static validation tests at `tests/Meridian.Wpf.Tests/Copy/WorkspaceCopyCatalogTests.cs` to validate copy key format (`workspace.section.intent`), detect conflicting duplicate keys mapping to different strings, and enforce a subtitle length budget.

### Testing

- Attempted to run the new tests with `dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter "WorkspaceCopyCatalogTests|ShellNavigationCatalogTests"`, but the command failed in this environment with `/bin/bash: line 1: dotnet: command not found` so tests could not be executed here.
- Attempted to run the evaluation helper `python scripts/score_eval.py --help`, but the script was not present in this environment and therefore could not be executed.
- The change set includes the new test files and references; CI or a local developer machine with the .NET SDK should be used to run `dotnet test` and verify the tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f03326a48320b842d51a881aef2b)