### PR TITLE
Refine shell navigation metadata labels and visual hierarchy

### DIFF
--- a/src/Meridian.Wpf/Models/ShellNavigationModels.cs
+++ b/src/Meridian.Wpf/Models/ShellNavigationModels.cs
@@ -71,9 +71,16 @@ public sealed record ShellNavigationItem(
     string Glyph,
     string VisibilityLabel)
 {
-    public string MetaLine => string.IsNullOrWhiteSpace(VisibilityLabel)
-        ? $"{WorkspaceTitle} · {SectionLabel}"
-        : $"{WorkspaceTitle} · {SectionLabel} · {VisibilityLabel}";
+    public string MetaLine
+    {
+        get
+        {
+            var parts = new[] { SectionLabel, VisibilityLabel }
+                .Where(static part => !string.IsNullOrWhiteSpace(part));
+
+            return string.Join(" · ", parts);
+        }
+    }
 }
 
 public sealed record WorkspaceShellState(
@@ -95,7 +102,14 @@ public sealed record ShellCommandPaletteEntry(
     string Glyph,
     string VisibilityLabel)
 {
-    public string MetaLine => string.IsNullOrWhiteSpace(VisibilityLabel)
-        ? $"{WorkspaceTitle} · {SectionLabel}"
-        : $"{WorkspaceTitle} · {SectionLabel} · {VisibilityLabel}";
+    public string MetaLine
+    {
+        get
+        {
+            var parts = new[] { SectionLabel, VisibilityLabel }
+                .Where(static part => !string.IsNullOrWhiteSpace(part));
+
+            return string.Join(" · ", parts);
+        }
+    }
 }

--- a/src/Meridian.Wpf/ViewModels/MainPageViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/MainPageViewModel.cs
@@ -1057,6 +1057,7 @@ public sealed class MainPageViewModel : BindableBase, IDisposable
         yield return descriptor.Subtitle;
         yield return descriptor.SectionLabel;
         yield return workspaceTitle;
+        yield return GetVisibilityLabel(descriptor.VisibilityTier);
 
         foreach (var keyword in descriptor.SearchKeywords)
         {
@@ -1134,9 +1135,9 @@ public sealed class MainPageViewModel : BindableBase, IDisposable
     private static string GetVisibilityLabel(ShellNavigationVisibilityTier visibilityTier)
         => visibilityTier switch
         {
-            ShellNavigationVisibilityTier.Primary => "Primary",
-            ShellNavigationVisibilityTier.Secondary => "Secondary",
-            ShellNavigationVisibilityTier.Overflow => "Overflow",
+            ShellNavigationVisibilityTier.Primary => string.Empty,
+            ShellNavigationVisibilityTier.Secondary => "Advanced",
+            ShellNavigationVisibilityTier.Overflow => "Admin",
             _ => string.Empty
         };
 

--- a/src/Meridian.Wpf/Views/MainPage.xaml
+++ b/src/Meridian.Wpf/Views/MainPage.xaml
@@ -87,6 +87,14 @@
             <Setter Property="TextWrapping" Value="Wrap" />
         </Style>
 
+        <Style x:Key="ShellNavMetaStyle" TargetType="TextBlock">
+            <Setter Property="FontFamily" Value="{StaticResource MeridianBodyFontFamily}" />
+            <Setter Property="FontSize" Value="10" />
+            <Setter Property="Foreground" Value="{StaticResource NavSectionLabelBrush}" />
+            <Setter Property="Opacity" Value="0.62" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+
         <!-- Marquee: uppercase muted section labels — light text on dark sidebar -->
         <Style x:Key="ShellSectionLabelStyle" TargetType="TextBlock">
             <Setter Property="FontFamily" Value="{StaticResource MeridianBodyFontFamily}" />
@@ -166,7 +174,7 @@
                                Style="{StaticResource ShellNavSubtitleStyle}"
                                Margin="0,2,0,0" />
                     <TextBlock Text="{Binding MetaLine}"
-                               Style="{StaticResource ShellSectionLabelStyle}"
+                               Style="{StaticResource ShellNavMetaStyle}"
                                Margin="0,4,0,0" />
                 </StackPanel>
             </Grid>
@@ -275,7 +283,7 @@
                                                    Style="{StaticResource ShellNavSubtitleStyle}"
                                                    Margin="0,2,0,0" />
                                         <TextBlock Text="{Binding MetaLine}"
-                                                   Style="{StaticResource ShellSectionLabelStyle}"
+                                                   Style="{StaticResource ShellNavMetaStyle}"
                                                    Margin="0,4,0,0" />
                                     </StackPanel>
                                 </Grid>

--- a/tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs
@@ -87,6 +87,20 @@ public sealed class MainShellViewModelTests
     }
 
     [Fact]
+    public void CommandPaletteQuery_UsesTierOrderingWithinMatchingResults()
+    {
+        WpfTestThread.Run(() =>
+        {
+            using var vm = CreateMainPageViewModel();
+
+            vm.CommandPaletteQuery = "workspace";
+
+            vm.CommandPalettePages.Should().NotBeEmpty();
+            vm.CommandPalettePages.First().PageTag.Should().Be("ResearchShell");
+        });
+    }
+
+    [Fact]
     public void CommandPaletteQuery_WhenNoResults_ShowsHelpfulEmptyStateAndCanClear()
     {
         WpfTestThread.Run(() =>
@@ -136,6 +150,20 @@ public sealed class MainShellViewModelTests
             vm.PrimaryNavigationItems.Select(item => item.PageTag).Should().Contain(["GovernanceShell", "FundLedger", "FundReconciliation"]);
             vm.OverflowNavigationItems.Select(item => item.PageTag).Should().Contain("Settings");
             vm.RelatedWorkflowItems.Select(item => item.PageTag).Should().Contain(["FundLedger", "FundReconciliation", "SecurityMaster"]);
+        });
+    }
+
+    [Fact]
+    public void WorkspaceNavigation_UsesFriendlyContextTagsInsteadOfRawTierNames()
+    {
+        WpfTestThread.Run(() =>
+        {
+            using var vm = CreateMainPageViewModel();
+
+            vm.SelectWorkspaceCommand.Execute("governance");
+
+            vm.SecondaryNavigationItems.Should().OnlyContain(item => item.VisibilityLabel != "Secondary");
+            vm.OverflowNavigationItems.Should().OnlyContain(item => item.VisibilityLabel == "Admin");
         });
     }
 


### PR DESCRIPTION
### Motivation
- Reduce user-facing noise by removing raw internal tier names (`Primary/Secondary/Overflow`) from metadata lines and surface task-relevant context instead. 
- Keep internal ordering/ranking based on `VisibilityTier` while preventing end users from seeing raw tier labels.
- Visually de-emphasize metadata in navigation and the command palette so `Title`/`Subtitle` remain primary.

### Description
- Changed `ShellNavigationItem.MetaLine` and `ShellCommandPaletteEntry.MetaLine` to compose only `SectionLabel` and `VisibilityLabel` (skipping repeated `WorkspaceTitle`) and join parts with ` · ` instead of always showing the workspace name. (`src/Meridian.Wpf/Models/ShellNavigationModels.cs`).
- Replaced the exposed tier text via `GetVisibilityLabel` so `Primary` maps to an empty label, `Secondary` -> `Advanced`, and `Overflow` -> `Admin`, preserving the underlying `VisibilityTier` enum for ordering and ranking logic. (`src/Meridian.Wpf/ViewModels/MainPageViewModel.cs`).
- Added visibility label into the command-palette searchable fields via `GetPaletteSearchFields` so queries still match on the new contextual tags. (`src/Meridian.Wpf/ViewModels/MainPageViewModel.cs`).
- Introduced a lighter `ShellNavMetaStyle` and applied it to navigation items and command-palette entries to visually de-emphasize metadata relative to title/subtitle. (`src/Meridian.Wpf/Views/MainPage.xaml`).
- Added unit tests to assert palette ordering and friendly visibility labels: `CommandPaletteQuery_UsesTierOrderingWithinMatchingResults` and `WorkspaceNavigation_UsesFriendlyContextTagsInsteadOfRawTierNames`. (`tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs`).

### Testing
- Added/updated tests in `tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs` to cover ranking behavior and friendly metadata labels, but full test execution was not possible in this environment. 
- Attempted to run a focused test command: `dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter "FullyQualifiedName~MainShellViewModelTests.CommandPaletteQuery_FiltersRegisteredPages|FullyQualifiedName~MainShellViewModelTests.CommandPaletteQuery_UsesTierOrderingWithinMatchingResults|FullyQualifiedName~MainShellViewModelTests.WorkspaceNavigation_UsesFriendlyContextTagsInsteadOfRawTierNames|FullyQualifiedName~MainShellViewModelTests.WorkspaceSelection_RefreshesPrimaryOverflowAndRelatedNavigation"`, which failed because the agent environment does not have the `dotnet` SDK installed (`dotnet: command not found`).
- Code changes were committed locally (`Refine shell metadata labels and styling`), but automated test run evidence is pending in CI where `dotnet` is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f02d83e48320a974313bbca2e204)