### PR TITLE
Clarify ambiguous workspace command labels and add automation IDs

### DIFF
--- a/src/Meridian.Wpf/Views/GovernanceWorkspaceShellPage.xaml
+++ b/src/Meridian.Wpf/Views/GovernanceWorkspaceShellPage.xaml
@@ -150,27 +150,37 @@
                 Margin="0,0,0,16">
             <WrapPanel>
                 <Button x:Name="OperationsLaneButton"
-                        Content="Operations"
+                        Content="Open Operations"
+                        AutomationProperties.Name="Open Operations Lane"
+                        AutomationProperties.AutomationId="OpenOperationsLaneButton"
                         Click="OpenOperationsLane_Click"
                         Style="{StaticResource SecondaryButtonStyle}"
                         Margin="0,0,8,0" />
                 <Button x:Name="AccountingLaneButton"
-                        Content="Accounting"
+                        Content="Open Accounting"
+                        AutomationProperties.Name="Open Accounting Lane"
+                        AutomationProperties.AutomationId="OpenAccountingLaneButton"
                         Click="OpenAccountingLane_Click"
                         Style="{StaticResource GhostButtonStyle}"
                         Margin="0,0,8,0" />
                 <Button x:Name="ReconciliationLaneButton"
-                        Content="Reconciliation"
+                        Content="Review Breaks"
+                        AutomationProperties.Name="Review Reconciliation Breaks Lane"
+                        AutomationProperties.AutomationId="ReviewReconciliationBreaksLaneButton"
                         Click="OpenReconciliationLane_Click"
                         Style="{StaticResource GhostButtonStyle}"
                         Margin="0,0,8,0" />
                 <Button x:Name="ReportingLaneButton"
-                        Content="Reporting"
+                        Content="Open Reporting"
+                        AutomationProperties.Name="Open Reporting Lane"
+                        AutomationProperties.AutomationId="OpenReportingLaneButton"
                         Click="OpenReportingLane_Click"
                         Style="{StaticResource GhostButtonStyle}"
                         Margin="0,0,8,0" />
                 <Button x:Name="AuditLaneButton"
-                        Content="Audit"
+                        Content="Open Audit Trail"
+                        AutomationProperties.Name="Open Audit Trail Lane"
+                        AutomationProperties.AutomationId="OpenAuditTrailLaneButton"
                         Click="OpenAuditLane_Click"
                         Style="{StaticResource GhostButtonStyle}" />
             </WrapPanel>
@@ -268,13 +278,13 @@
                                   VerticalScrollBarVisibility="Auto"
                                   HorizontalScrollBarVisibility="Disabled">
                         <StackPanel>
-                            <TextBlock Text="Operations"
+                            <TextBlock Text="Fund Ledger Operations"
                                        Style="{StaticResource ShellSectionLabelStyle}"
                                        Margin="0,0,0,8" />
                             <ItemsControl x:Name="OperationsQueueList"
                                           ItemTemplate="{StaticResource QueueItemTemplate}" />
 
-                            <TextBlock Text="Accounting"
+                            <TextBlock Text="Trial Balance Accounting"
                                        Style="{StaticResource ShellSectionLabelStyle}"
                                        Margin="0,12,0,8" />
                             <ItemsControl x:Name="AccountingQueueList"
@@ -292,7 +302,7 @@
                             <ItemsControl x:Name="ReportingQueueList"
                                           ItemTemplate="{StaticResource QueueItemTemplate}" />
 
-                            <TextBlock Text="Audit"
+                            <TextBlock Text="Audit Trail"
                                        Style="{StaticResource ShellSectionLabelStyle}"
                                        Margin="0,12,0,8" />
                             <ItemsControl x:Name="AuditQueueList"

--- a/src/Meridian.Wpf/Views/GovernanceWorkspaceShellPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/GovernanceWorkspaceShellPage.xaml.cs
@@ -244,16 +244,16 @@ public partial class GovernanceWorkspaceShellPage : GovernanceWorkspaceShellPage
         {
             PrimaryCommands =
             [
-                new WorkspaceCommandItem { Id = "FundLedger", Label = "Operations", Description = "Open operations lane", ShortcutHint = "Ctrl+1", Glyph = "\uEE94", Tone = WorkspaceTone.Primary },
-                new WorkspaceCommandItem { Id = "FundTrialBalance", Label = "Accounting", Description = "Open accounting lane", ShortcutHint = "Ctrl+2", Glyph = "\uE9D9" },
-                new WorkspaceCommandItem { Id = "FundReconciliation", Label = "Reconciliation", Description = "Open reconciliation lane", ShortcutHint = "Ctrl+3", Glyph = "\uE895" }
+                new WorkspaceCommandItem { Id = "FundLedger", Label = "Open Fund Ledger", Description = "Open the fund-ledger operations lane", ShortcutHint = "Ctrl+1", Glyph = "\uEE94", Tone = WorkspaceTone.Primary },
+                new WorkspaceCommandItem { Id = "FundTrialBalance", Label = "Open Trial Balance", Description = "Open the accounting trial-balance lane", ShortcutHint = "Ctrl+2", Glyph = "\uE9D9" },
+                new WorkspaceCommandItem { Id = "FundReconciliation", Label = "Review Recon Breaks", Description = "Review reconciliation breaks and approvals", ShortcutHint = "Ctrl+3", Glyph = "\uE895" }
             ],
             SecondaryCommands =
             [
-                new WorkspaceCommandItem { Id = "FundAccounts", Label = "Accounts", Description = "Open account surfaces", Glyph = "\uE8D4" },
-                new WorkspaceCommandItem { Id = "FundCashFinancing", Label = "Reporting", Description = "Open cash and reporting view", Glyph = "\uE8C7" },
+                new WorkspaceCommandItem { Id = "FundAccounts", Label = "Open Accounts", Description = "Open account and banking surfaces", Glyph = "\uE8D4" },
+                new WorkspaceCommandItem { Id = "FundCashFinancing", Label = "Open Reporting", Description = "Open cash, financing, and reporting", Glyph = "\uE8C7" },
                 new WorkspaceCommandItem { Id = "FundReportPack", Label = "Report Pack", Description = "Open governance report-pack preview", Glyph = "\uE8A5" },
-                new WorkspaceCommandItem { Id = "FundAuditTrail", Label = "Audit", Description = "Open audit trail", Glyph = "\uE7BA" },
+                new WorkspaceCommandItem { Id = "FundAuditTrail", Label = "Open Audit Trail", Description = "Open governance audit trail", Glyph = "\uE7BA" },
                 new WorkspaceCommandItem { Id = "Diagnostics", Label = "Diagnostics", Description = "Open diagnostics", Glyph = "\uE7BA" },
                 new WorkspaceCommandItem { Id = "NotificationCenter", Label = "Notifications", Description = "Open notifications", Glyph = "\uE7F4" },
                 new WorkspaceCommandItem { Id = "Settings", Label = "Settings", Description = "Open settings", Glyph = "\uE713" }

--- a/src/Meridian.Wpf/Views/ResearchWorkspaceShellPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/ResearchWorkspaceShellPage.xaml.cs
@@ -559,9 +559,9 @@ public partial class ResearchWorkspaceShellPage : ResearchWorkspaceShellPageBase
                 new WorkspaceCommandItem { Id = "RunDetail", Label = "Run Detail", Description = "Open run detail", Glyph = "\uE7C3" },
                 new WorkspaceCommandItem { Id = "RunPortfolio", Label = "Portfolio Inspector", Description = "Open portfolio inspector", Glyph = "\uE8B5" },
                 new WorkspaceCommandItem { Id = "RunLedger", Label = "Ledger Inspector", Description = "Open ledger inspector", Glyph = "\uEE94" },
-                new WorkspaceCommandItem { Id = "FundTrialBalance", Label = "Accounting Impact", Description = "Open trial-balance impact view", Glyph = "\uE9D9" },
-                new WorkspaceCommandItem { Id = "FundReconciliation", Label = "Reconciliation", Description = "Open reconciliation review", Glyph = "\uE895" },
-                new WorkspaceCommandItem { Id = "FundAuditTrail", Label = "Audit Trail", Description = "Open governance audit trail", Glyph = "\uE7BA" },
+                new WorkspaceCommandItem { Id = "FundTrialBalance", Label = "Open Accounting Impact", Description = "Open trial-balance impact view", Glyph = "\uE9D9" },
+                new WorkspaceCommandItem { Id = "FundReconciliation", Label = "Review Recon Breaks", Description = "Review reconciliation breaks", Glyph = "\uE895" },
+                new WorkspaceCommandItem { Id = "FundAuditTrail", Label = "Open Audit Trail", Description = "Open governance audit trail", Glyph = "\uE7BA" },
                 new WorkspaceCommandItem { Id = "LeanIntegration", Label = "Lean Integration", Description = "Open Lean integration", Glyph = "\uE943" }
             ]
         };

--- a/src/Meridian.Wpf/Views/TradingWorkspaceShellPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/TradingWorkspaceShellPage.xaml.cs
@@ -482,9 +482,9 @@ public partial class TradingWorkspaceShellPage : TradingWorkspaceShellPageBase
                 new WorkspaceCommandItem { Id = "RunRisk", Label = "Risk Rail", Description = "Open risk rail", Glyph = "\uE7BA" },
                 new WorkspaceCommandItem { Id = "EventReplay", Label = "Event Replay", Description = "Open event replay", Glyph = "\uE768" },
                 new WorkspaceCommandItem { Id = "CollectionSessions", Label = "Collection Sessions", Description = "Open collection sessions", Glyph = "\uE8EF" },
-                new WorkspaceCommandItem { Id = "FundTrialBalance", Label = "Accounting", Description = "Open accounting consequences", Glyph = "\uE9D9" },
-                new WorkspaceCommandItem { Id = "FundReconciliation", Label = "Reconciliation", Description = "Open reconciliation review", Glyph = "\uE895" },
-                new WorkspaceCommandItem { Id = "FundAuditTrail", Label = "Audit", Description = "Open audit trail", Glyph = "\uE7BA" },
+                new WorkspaceCommandItem { Id = "FundTrialBalance", Label = "Open Trial Balance", Description = "Open accounting consequences", Glyph = "\uE9D9" },
+                new WorkspaceCommandItem { Id = "FundReconciliation", Label = "Review Recon Breaks", Description = "Review reconciliation breaks", Glyph = "\uE895" },
+                new WorkspaceCommandItem { Id = "FundAuditTrail", Label = "Open Audit Trail", Description = "Open audit trail", Glyph = "\uE7BA" },
                 new WorkspaceCommandItem { Id = "NotificationCenter", Label = "Alerts", Description = "Open alerts", Glyph = "\uE7F4" },
                 new WorkspaceCommandItem { Id = "TradingHours", Label = "Trading Hours", Description = "Open trading hours", Glyph = "\uE823" }
             ]


### PR DESCRIPTION
### Motivation
- Short single-word command labels like `Operations`, `Accounting`, and `Audit` are ambiguous in the UI and can break test clarity and automation, so labels should be explicit about action + destination while remaining layout-safe. 
- Add automation metadata where buttons were relabeled so automated tests and accessibility tooling continue to target stable identifiers.

### Description
- Replaced ambiguous primary/secondary `WorkspaceCommandItem` labels with explicit action + destination labels (examples: `Open Fund Ledger`, `Open Trial Balance`, `Review Recon Breaks`, `Open Audit Trail`) and updated their descriptions in `BuildCommandGroup` for governance, trading, and research shells in `src/Meridian.Wpf/Views/GovernanceWorkspaceShellPage.xaml.cs`, `src/Meridian.Wpf/Views/TradingWorkspaceShellPage.xaml.cs`, and `src/Meridian.Wpf/Views/ResearchWorkspaceShellPage.xaml.cs`.
- Updated governance lane buttons in XAML to explicit action text and added automation metadata `AutomationProperties.Name` and `AutomationProperties.AutomationId` to each button in `src/Meridian.Wpf/Views/GovernanceWorkspaceShellPage.xaml` to preserve automation/test clarity.
- Tightened queue section headings to clearer phrases (`Fund Ledger Operations`, `Trial Balance Accounting`, `Audit Trail`) in `src/Meridian.Wpf/Views/GovernanceWorkspaceShellPage.xaml` to reduce ambiguity in the UI.
- Kept navigation/action IDs (e.g. `FundLedger`, `FundTrialBalance`, `FundReconciliation`, `FundAuditTrail`) unchanged so runtime routing and behavior are unaffected, and kept labels concise to reduce layout risk.

### Testing
- Ran a scoped search to locate ambiguous labels with `rg -n "\b(Open|Review|Operations|Accounting|Audit)\b" --glob "*.xaml" --glob "*.xaml.cs"` which completed successfully and guided the edits.
- Checked for remaining one-word `WorkspaceCommandItem` labels with `rg -n "WorkspaceCommandItem \{[^\n]*Label = \"(Open|Review|Operations|Accounting|Audit)\"" src/Meridian.Wpf/Views/*WorkspaceShellPage.xaml.cs` which returned expected results (no remaining ambiguous one-word labels in the targeted command builders).
- Attempted to build the WPF project with `dotnet build src/Meridian.Wpf/Meridian.Wpf.csproj -v minimal` and the command failed in this environment because `dotnet` is not installed (`/bin/bash: line 1: dotnet: command not found`).
- No automated unit/integration tests were executed in this environment beyond the searches above due to missing SDKs; runtime behavior was preserved by not changing action IDs and keeping description-only/label-only edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f02657e48320a39a54520f3113b0)