### PR TITLE
ci: skip setup-dotnet install when compatible SDK already exists

### DIFF
--- a/.github/actions/setup-dotnet-cache/action.yml
+++ b/.github/actions/setup-dotnet-cache/action.yml
@@ -20,7 +20,33 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Detect preinstalled .NET SDK
+      id: sdk-check
+      shell: bash
+      run: |
+        set -euo pipefail
+        requested_version="${{ inputs.dotnet-version }}"
+
+        # Convert patterns like 9.0.x to a prefix match (9.0.)
+        if [[ "$requested_version" == *".x" ]]; then
+          match_target="${requested_version%.x}."
+        else
+          match_target="$requested_version"
+        fi
+
+        escaped_target="$(printf '%s\n' "$match_target" | sed 's/[.[\*^$()+?{}|]/\\&/g')"
+
+        if command -v dotnet >/dev/null 2>&1 && dotnet --list-sdks | awk '{print $1}' | grep -Eq "^${escaped_target}"; then
+          echo "Preinstalled SDK matching '${requested_version}' found; skipping setup-dotnet download."
+          echo "needs-install=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "No preinstalled SDK matching '${requested_version}' found; setup-dotnet will install it."
+        echo "needs-install=true" >> "$GITHUB_OUTPUT"
+
     - name: Setup .NET SDK
+      if: ${{ steps.sdk-check.outputs.needs-install == 'true' }}
       uses: actions/setup-dotnet@v5.2.0
       with:
         dotnet-version: ${{ inputs.dotnet-version }}


### PR DESCRIPTION
### Motivation
- Prevent redundant `actions/setup-dotnet` downloads and installations on runners that already provide a compatible .NET SDK to reduce CI startup time.
- Logs showed time spent downloading/installing runtimes and SDKs even when the requested SDK family was present, so gate the installer when possible.

### Description
- Added a `Detect preinstalled .NET SDK` step to `.github/actions/setup-dotnet-cache/action.yml` that normalizes wildcard inputs like `9.0.x`, runs `dotnet --list-sdks`, and sets the composite action output `needs-install` to `true` or `false`.
- Gated the `actions/setup-dotnet@v5.2.0` step with `if: ${{ steps.sdk-check.outputs.needs-install == 'true' }}` so the installer runs only when no compatible SDK is found.
- Preserved existing behavior when no matching SDK is present and left NuGet caching and configuration unchanged.

### Testing
- Ran `ruby -e "require 'yaml'; YAML.load_file('.github/actions/setup-dotnet-cache/action.yml'); puts 'YAML parse ok'"` which succeeded and verified the action YAML parses.
- Attempted `python` YAML parse using `PyYAML`, but it failed because `PyYAML` is not installed in the environment (automated check failed due to missing module).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f5ebc73483209754b48647377667)