### PR TITLE
Add optional fund-ops scope metadata to strategy run portfolio & ledger read models

### DIFF
--- a/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
+++ b/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
@@ -185,7 +185,15 @@ public sealed record PortfolioSummary(
     decimal Financing,
     IReadOnlyList<PortfolioPositionSummary> Positions,
     int SecurityResolvedCount = 0,
-    int SecurityMissingCount = 0);
+    int SecurityMissingCount = 0,
+    string? AccountScopeId = null,
+    string? AccountScopeDisplayName = null,
+    string? EntityScopeId = null,
+    string? EntityScopeDisplayName = null,
+    string? SleeveScopeId = null,
+    string? SleeveScopeDisplayName = null,
+    string? VehicleScopeId = null,
+    string? VehicleScopeDisplayName = null);
 
 /// <summary>
 /// Shared position row for workstation portfolio views.
@@ -197,7 +205,15 @@ public sealed record PortfolioPositionSummary(
     decimal RealizedPnl,
     decimal UnrealizedPnl,
     bool IsShort,
-    WorkstationSecurityReference? Security = null);
+    WorkstationSecurityReference? Security = null,
+    string? AccountScopeId = null,
+    string? AccountScopeDisplayName = null,
+    string? EntityScopeId = null,
+    string? EntityScopeDisplayName = null,
+    string? SleeveScopeId = null,
+    string? SleeveScopeDisplayName = null,
+    string? VehicleScopeId = null,
+    string? VehicleScopeDisplayName = null);
 
 /// <summary>
 /// Shared ledger rollup for workstation governance and audit surfaces.
@@ -216,7 +232,15 @@ public sealed record LedgerSummary(
     IReadOnlyList<LedgerTrialBalanceLine> TrialBalance,
     IReadOnlyList<LedgerJournalLine> Journal,
     int SecurityResolvedCount = 0,
-    int SecurityMissingCount = 0);
+    int SecurityMissingCount = 0,
+    string? AccountScopeId = null,
+    string? AccountScopeDisplayName = null,
+    string? EntityScopeId = null,
+    string? EntityScopeDisplayName = null,
+    string? SleeveScopeId = null,
+    string? SleeveScopeDisplayName = null,
+    string? VehicleScopeId = null,
+    string? VehicleScopeDisplayName = null);
 
 /// <summary>
 /// Shared trial-balance row for workstation ledger views.
@@ -228,7 +252,15 @@ public sealed record LedgerTrialBalanceLine(
     string? FinancialAccountId,
     decimal Balance,
     int EntryCount,
-    WorkstationSecurityReference? Security = null);
+    WorkstationSecurityReference? Security = null,
+    string? AccountScopeId = null,
+    string? AccountScopeDisplayName = null,
+    string? EntityScopeId = null,
+    string? EntityScopeDisplayName = null,
+    string? SleeveScopeId = null,
+    string? SleeveScopeDisplayName = null,
+    string? VehicleScopeId = null,
+    string? VehicleScopeDisplayName = null);
 
 /// <summary>
 /// Shared journal row for workstation audit surfaces.
@@ -239,7 +271,15 @@ public sealed record LedgerJournalLine(
     string Description,
     decimal TotalDebits,
     decimal TotalCredits,
-    int LineCount);
+    int LineCount,
+    string? AccountScopeId = null,
+    string? AccountScopeDisplayName = null,
+    string? EntityScopeId = null,
+    string? EntityScopeDisplayName = null,
+    string? SleeveScopeId = null,
+    string? SleeveScopeDisplayName = null,
+    string? VehicleScopeId = null,
+    string? VehicleScopeDisplayName = null);
 
 /// <summary>
 /// Comparison row used when reviewing multiple runs side by side.

--- a/src/Meridian.Strategies/Services/LedgerReadService.cs
+++ b/src/Meridian.Strategies/Services/LedgerReadService.cs
@@ -67,15 +67,25 @@ public sealed class LedgerReadService
             return null;
         }
 
+        var scope = StrategyRunScopeMetadataResolver.Resolve(entry);
+
         var journal = ledger.Journal
             .OrderByDescending(static item => item.Timestamp)
-            .Select(static item => new LedgerJournalLine(
+            .Select(item => new LedgerJournalLine(
                 JournalEntryId: item.JournalEntryId,
                 Timestamp: item.Timestamp,
                 Description: item.Description,
                 TotalDebits: item.Lines.Sum(static line => line.Debit),
                 TotalCredits: item.Lines.Sum(static line => line.Credit),
-                LineCount: item.Lines.Count))
+                LineCount: item.Lines.Count,
+                AccountScopeId: scope.AccountId,
+                AccountScopeDisplayName: scope.AccountDisplayName,
+                EntityScopeId: scope.EntityId,
+                EntityScopeDisplayName: scope.EntityDisplayName,
+                SleeveScopeId: scope.SleeveId,
+                SleeveScopeDisplayName: scope.SleeveDisplayName,
+                VehicleScopeId: scope.VehicleId,
+                VehicleScopeDisplayName: scope.VehicleDisplayName))
             .ToArray();
 
         var accountSummaries = ledger.SummarizeAccounts()
@@ -84,13 +94,21 @@ public sealed class LedgerReadService
             .ToArray();
 
         var trialBalance = accountSummaries
-            .Select(static summary => new LedgerTrialBalanceLine(
+            .Select(summary => new LedgerTrialBalanceLine(
                 AccountName: summary.Account.Name,
                 AccountType: summary.Account.AccountType.ToString(),
                 Symbol: summary.Account.Symbol,
                 FinancialAccountId: summary.Account.FinancialAccountId,
                 Balance: summary.Balance,
-                EntryCount: summary.EntryCount))
+                EntryCount: summary.EntryCount,
+                AccountScopeId: string.IsNullOrWhiteSpace(scope.AccountId) ? summary.Account.FinancialAccountId : scope.AccountId,
+                AccountScopeDisplayName: scope.AccountDisplayName,
+                EntityScopeId: scope.EntityId,
+                EntityScopeDisplayName: scope.EntityDisplayName,
+                SleeveScopeId: scope.SleeveId,
+                SleeveScopeDisplayName: scope.SleeveDisplayName,
+                VehicleScopeId: scope.VehicleId,
+                VehicleScopeDisplayName: scope.VehicleDisplayName))
             .ToArray();
 
         return new LedgerSummary(
@@ -105,7 +123,15 @@ public sealed class LedgerReadService
             RevenueBalance: SumBalance(accountSummaries, LedgerAccountType.Revenue),
             ExpenseBalance: SumBalance(accountSummaries, LedgerAccountType.Expense),
             TrialBalance: trialBalance,
-            Journal: journal);
+            Journal: journal,
+            AccountScopeId: scope.AccountId,
+            AccountScopeDisplayName: scope.AccountDisplayName,
+            EntityScopeId: scope.EntityId,
+            EntityScopeDisplayName: scope.EntityDisplayName,
+            SleeveScopeId: scope.SleeveId,
+            SleeveScopeDisplayName: scope.SleeveDisplayName,
+            VehicleScopeId: scope.VehicleId,
+            VehicleScopeDisplayName: scope.VehicleDisplayName);
     }
 
     private static decimal SumBalance(

--- a/src/Meridian.Strategies/Services/PortfolioReadService.cs
+++ b/src/Meridian.Strategies/Services/PortfolioReadService.cs
@@ -66,15 +66,25 @@ public sealed class PortfolioReadService
             return null;
         }
 
+        var scope = StrategyRunScopeMetadataResolver.Resolve(entry);
+
         var positions = latestSnapshot.Positions.Values
             .OrderBy(static position => position.Symbol, StringComparer.OrdinalIgnoreCase)
-            .Select(static position => new PortfolioPositionSummary(
+            .Select(position => new PortfolioPositionSummary(
                 Symbol: position.Symbol,
                 Quantity: position.Quantity,
                 AverageCostBasis: position.AverageCostBasis,
                 RealizedPnl: position.RealizedPnl,
                 UnrealizedPnl: position.UnrealizedPnl,
-                IsShort: position.IsShort))
+                IsShort: position.IsShort,
+                AccountScopeId: scope.AccountId,
+                AccountScopeDisplayName: scope.AccountDisplayName,
+                EntityScopeId: scope.EntityId,
+                EntityScopeDisplayName: scope.EntityDisplayName,
+                SleeveScopeId: scope.SleeveId,
+                SleeveScopeDisplayName: scope.SleeveDisplayName,
+                VehicleScopeId: scope.VehicleId,
+                VehicleScopeDisplayName: scope.VehicleDisplayName))
             .ToArray();
 
         var longMarketValue = latestSnapshot.LongMarketValue;
@@ -99,7 +109,15 @@ public sealed class PortfolioReadService
             UnrealizedPnl: unrealizedPnl,
             Commissions: result.Metrics.TotalCommissions,
             Financing: financing,
-            Positions: positions);
+            Positions: positions,
+            AccountScopeId: scope.AccountId,
+            AccountScopeDisplayName: scope.AccountDisplayName,
+            EntityScopeId: scope.EntityId,
+            EntityScopeDisplayName: scope.EntityDisplayName,
+            SleeveScopeId: scope.SleeveId,
+            SleeveScopeDisplayName: scope.SleeveDisplayName,
+            VehicleScopeId: scope.VehicleId,
+            VehicleScopeDisplayName: scope.VehicleDisplayName);
     }
 
     private async Task<Dictionary<string, WorkstationSecurityReference?>> ResolveSecuritiesAsync(

--- a/src/Meridian.Strategies/Services/StrategyRunReadService.cs
+++ b/src/Meridian.Strategies/Services/StrategyRunReadService.cs
@@ -124,11 +124,15 @@ public sealed class StrategyRunReadService
 
             await Task.WhenAll(portfolioTask, ledgerTask).ConfigureAwait(false);
 
+            var scope = StrategyRunScopeMetadataResolver.Resolve(run);
+            var portfolio = ApplyScopeFallback(await portfolioTask.ConfigureAwait(false), scope);
+            var ledger = ApplyScopeFallback(await ledgerTask.ConfigureAwait(false), scope);
+
             return new StrategyRunDetail(
                 Summary: ToSummary(run),
                 Parameters: run.ParameterSet ?? EmptyParameters,
-                Portfolio: await portfolioTask.ConfigureAwait(false),
-                Ledger: await ledgerTask.ConfigureAwait(false),
+                Portfolio: portfolio,
+                Ledger: ledger,
                 Execution: BuildExecutionSummary(run),
                 Promotion: BuildPromotionSummary(run),
                 Governance: BuildGovernanceSummary(run));
@@ -296,6 +300,47 @@ public sealed class StrategyRunReadService
             FundProfileId: run.FundProfileId,
             FundDisplayName: run.FundDisplayName,
             ParentRunId: run.ParentRunId);
+    }
+
+
+    private static PortfolioSummary? ApplyScopeFallback(PortfolioSummary? summary, StrategyRunScopeMetadata scope)
+    {
+        if (summary is null)
+        {
+            return null;
+        }
+
+        return summary with
+        {
+            AccountScopeId = summary.AccountScopeId ?? scope.AccountId,
+            AccountScopeDisplayName = summary.AccountScopeDisplayName ?? scope.AccountDisplayName,
+            EntityScopeId = summary.EntityScopeId ?? scope.EntityId,
+            EntityScopeDisplayName = summary.EntityScopeDisplayName ?? scope.EntityDisplayName,
+            SleeveScopeId = summary.SleeveScopeId ?? scope.SleeveId,
+            SleeveScopeDisplayName = summary.SleeveScopeDisplayName ?? scope.SleeveDisplayName,
+            VehicleScopeId = summary.VehicleScopeId ?? scope.VehicleId,
+            VehicleScopeDisplayName = summary.VehicleScopeDisplayName ?? scope.VehicleDisplayName
+        };
+    }
+
+    private static LedgerSummary? ApplyScopeFallback(LedgerSummary? summary, StrategyRunScopeMetadata scope)
+    {
+        if (summary is null)
+        {
+            return null;
+        }
+
+        return summary with
+        {
+            AccountScopeId = summary.AccountScopeId ?? scope.AccountId,
+            AccountScopeDisplayName = summary.AccountScopeDisplayName ?? scope.AccountDisplayName,
+            EntityScopeId = summary.EntityScopeId ?? scope.EntityId,
+            EntityScopeDisplayName = summary.EntityScopeDisplayName ?? scope.EntityDisplayName,
+            SleeveScopeId = summary.SleeveScopeId ?? scope.SleeveId,
+            SleeveScopeDisplayName = summary.SleeveScopeDisplayName ?? scope.SleeveDisplayName,
+            VehicleScopeId = summary.VehicleScopeId ?? scope.VehicleId,
+            VehicleScopeDisplayName = summary.VehicleScopeDisplayName ?? scope.VehicleDisplayName
+        };
     }
 
     private static StrategyRunExecutionSummary BuildExecutionSummary(StrategyRunEntry run)

--- a/src/Meridian.Strategies/Services/StrategyRunScopeMetadataResolver.cs
+++ b/src/Meridian.Strategies/Services/StrategyRunScopeMetadataResolver.cs
@@ -1,0 +1,66 @@
+using Meridian.Strategies.Models;
+
+namespace Meridian.Strategies.Services;
+
+internal sealed record StrategyRunScopeMetadata(
+    string? AccountId,
+    string? AccountDisplayName,
+    string? EntityId,
+    string? EntityDisplayName,
+    string? SleeveId,
+    string? SleeveDisplayName,
+    string? VehicleId,
+    string? VehicleDisplayName);
+
+internal static class StrategyRunScopeMetadataResolver
+{
+    public static StrategyRunScopeMetadata Resolve(StrategyRunEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        var accountId = ReadScopeValue(entry, "accountScopeId", "accountId");
+        var accountDisplayName = ReadScopeValue(entry, "accountScopeDisplayName", "accountDisplayName", "accountName");
+
+        if (string.IsNullOrWhiteSpace(accountId))
+        {
+            accountId = entry.Metrics?.Fills
+                .Select(static fill => fill.AccountId)
+                .Where(static id => !string.IsNullOrWhiteSpace(id))
+                .Distinct(StringComparer.Ordinal)
+                .SingleOrDefault();
+        }
+
+        if (string.IsNullOrWhiteSpace(accountDisplayName) && !string.IsNullOrWhiteSpace(accountId))
+        {
+            accountDisplayName = accountId;
+        }
+
+        return new StrategyRunScopeMetadata(
+            AccountId: accountId,
+            AccountDisplayName: accountDisplayName,
+            EntityId: ReadScopeValue(entry, "entityScopeId", "entityId"),
+            EntityDisplayName: ReadScopeValue(entry, "entityScopeDisplayName", "entityDisplayName", "entityName"),
+            SleeveId: ReadScopeValue(entry, "sleeveScopeId", "sleeveId"),
+            SleeveDisplayName: ReadScopeValue(entry, "sleeveScopeDisplayName", "sleeveDisplayName", "sleeveName"),
+            VehicleId: ReadScopeValue(entry, "vehicleScopeId", "vehicleId"),
+            VehicleDisplayName: ReadScopeValue(entry, "vehicleScopeDisplayName", "vehicleDisplayName", "vehicleName"));
+    }
+
+    private static string? ReadScopeValue(StrategyRunEntry entry, params string[] keys)
+    {
+        if (entry.ParameterSet is null || entry.ParameterSet.Count == 0)
+        {
+            return null;
+        }
+
+        foreach (var key in keys)
+        {
+            if (entry.ParameterSet.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Meridian.Tests/Strategies/LedgerReadServiceTests.cs
+++ b/tests/Meridian.Tests/Strategies/LedgerReadServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentAssertions;
 using Meridian.Backtesting.Sdk;
 using Meridian.Contracts.SecurityMaster;
@@ -214,6 +215,46 @@ public sealed class LedgerReadServiceTests
     {
         var act = () => new LedgerReadService(null!);
         act.Should().Throw<ArgumentNullException>();
+    }
+
+
+    [Fact]
+    public void BuildSummary_MapsAndSerializesScopeMetadataFromRunParameters()
+    {
+        var entry = BuildCompletedRun() with
+        {
+            ParameterSet = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["accountScopeId"] = "acct-paper",
+                ["accountScopeDisplayName"] = "Paper Account",
+                ["entityScopeId"] = "entity-paper",
+                ["entityScopeDisplayName"] = "Paper Entity",
+                ["sleeveScopeId"] = "sleeve-paper",
+                ["sleeveScopeDisplayName"] = "Paper Sleeve",
+                ["vehicleScopeId"] = "vehicle-paper",
+                ["vehicleScopeDisplayName"] = "Paper Vehicle"
+            }
+        };
+
+        var service = new LedgerReadService();
+        var summary = service.BuildSummary(entry);
+
+        summary.Should().NotBeNull();
+        summary!.AccountScopeId.Should().Be("acct-paper");
+        summary.EntityScopeId.Should().Be("entity-paper");
+        summary.SleeveScopeId.Should().Be("sleeve-paper");
+        summary.VehicleScopeId.Should().Be("vehicle-paper");
+        summary.TrialBalance.Should().OnlyContain(line =>
+            line.AccountScopeId == "acct-paper" &&
+            line.EntityScopeId == "entity-paper" &&
+            line.SleeveScopeId == "sleeve-paper" &&
+            line.VehicleScopeId == "vehicle-paper");
+        summary.Journal.Should().OnlyContain(line => line.AccountScopeId == "acct-paper");
+
+        var json = JsonSerializer.Serialize(summary);
+        json.Should().Contain("entityScopeId");
+        json.Should().Contain("sleeveScopeDisplayName");
+        json.Should().Contain("vehicleScopeDisplayName");
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────

--- a/tests/Meridian.Tests/Strategies/PortfolioReadServiceTests.cs
+++ b/tests/Meridian.Tests/Strategies/PortfolioReadServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentAssertions;
 using Meridian.Backtesting.Sdk;
 using Meridian.Contracts.SecurityMaster;
@@ -244,6 +245,49 @@ public sealed class PortfolioReadServiceTests
     {
         var act = () => new PortfolioReadService(null!);
         act.Should().Throw<ArgumentNullException>();
+    }
+
+
+    [Fact]
+    public void BuildSummary_MapsAndSerializesScopeMetadataFromRunParameters()
+    {
+        var entry = BuildCompletedRun(
+            finalEquity: 120_000m,
+            realizedPnl: 15_000m,
+            unrealizedPnl: 5_000m) with
+        {
+            ParameterSet = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["accountScopeId"] = "acct-backtest",
+                ["accountScopeDisplayName"] = "Backtest Prime",
+                ["entityScopeId"] = "entity-alpha",
+                ["entityScopeDisplayName"] = "Alpha Management",
+                ["sleeveScopeId"] = "sleeve-growth",
+                ["sleeveScopeDisplayName"] = "Growth Sleeve",
+                ["vehicleScopeId"] = "vehicle-lp",
+                ["vehicleScopeDisplayName"] = "Alpha LP"
+            }
+        };
+
+        var service = new PortfolioReadService();
+        var summary = service.BuildSummary(entry);
+
+        summary.Should().NotBeNull();
+        summary!.AccountScopeId.Should().Be("acct-backtest");
+        summary.AccountScopeDisplayName.Should().Be("Backtest Prime");
+        summary.EntityScopeId.Should().Be("entity-alpha");
+        summary.SleeveScopeId.Should().Be("sleeve-growth");
+        summary.VehicleScopeId.Should().Be("vehicle-lp");
+        summary.Positions.Should().OnlyContain(position =>
+            position.AccountScopeId == "acct-backtest" &&
+            position.EntityScopeId == "entity-alpha" &&
+            position.SleeveScopeId == "sleeve-growth" &&
+            position.VehicleScopeId == "vehicle-lp");
+
+        var json = JsonSerializer.Serialize(summary);
+        json.Should().Contain("accountScopeId");
+        json.Should().Contain("entityScopeDisplayName");
+        json.Should().Contain("vehicleScopeDisplayName");
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────

--- a/tests/Meridian.Tests/Strategies/StrategyRunReadServiceTests.cs
+++ b/tests/Meridian.Tests/Strategies/StrategyRunReadServiceTests.cs
@@ -454,6 +454,83 @@ public sealed class StrategyRunReadServiceTests
         summary.Should().BeNull();
     }
 
+
+    [Theory]
+    [InlineData("scope-backtest", RunType.Backtest, "acct-backtest", "entity-backtest", "sleeve-backtest", "vehicle-backtest")]
+    [InlineData("scope-paper", RunType.Paper, "acct-paper", "entity-paper", "sleeve-paper", "vehicle-paper")]
+    [InlineData("scope-live", RunType.Live, "acct-live", "entity-live", "sleeve-live", "vehicle-live")]
+    public async Task GetRunDetailAsync_BacktestPaperLive_PopulatesScopedPortfolioAndLedgerFields(
+        string runId,
+        RunType runType,
+        string accountScopeId,
+        string entityScopeId,
+        string sleeveScopeId,
+        string vehicleScopeId)
+    {
+        var store = new StrategyRunStore();
+        var baseRun = BuildCompletedRun(
+            runId: runId,
+            strategyId: "scope-strategy",
+            strategyName: "Scoped Strategy",
+            finalEquity: 125_000m,
+            netPnl: 25_000m,
+            totalReturn: 0.25m,
+            realizedPnl: 9_000m,
+            unrealizedPnl: 16_000m,
+            fillCount: 2,
+            sharpeRatio: 1.42,
+            maxDrawdown: 5_500m);
+
+        var run = baseRun with
+        {
+            RunType = runType,
+            Engine = runType switch
+            {
+                RunType.Backtest => "MeridianNative",
+                RunType.Paper => "BrokerPaper",
+                _ => "BrokerLive"
+            },
+            ParameterSet = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["accountScopeId"] = accountScopeId,
+                ["accountScopeDisplayName"] = $"{accountScopeId}-display",
+                ["entityScopeId"] = entityScopeId,
+                ["entityScopeDisplayName"] = $"{entityScopeId}-display",
+                ["sleeveScopeId"] = sleeveScopeId,
+                ["sleeveScopeDisplayName"] = $"{sleeveScopeId}-display",
+                ["vehicleScopeId"] = vehicleScopeId,
+                ["vehicleScopeDisplayName"] = $"{vehicleScopeId}-display"
+            }
+        };
+
+        await store.RecordRunAsync(run);
+
+        var service = new StrategyRunReadService(store, new PortfolioReadService(), new LedgerReadService());
+
+        var detail = await service.GetRunDetailAsync(runId);
+
+        detail.Should().NotBeNull();
+        detail!.Summary.Mode.Should().Be(runType switch
+        {
+            RunType.Backtest => StrategyRunMode.Backtest,
+            RunType.Paper => StrategyRunMode.Paper,
+            _ => StrategyRunMode.Live
+        });
+        detail.Portfolio.Should().NotBeNull();
+        detail.Portfolio!.AccountScopeId.Should().Be(accountScopeId);
+        detail.Portfolio.EntityScopeId.Should().Be(entityScopeId);
+        detail.Portfolio.SleeveScopeId.Should().Be(sleeveScopeId);
+        detail.Portfolio.VehicleScopeId.Should().Be(vehicleScopeId);
+        detail.Portfolio.Positions.Should().OnlyContain(position => position.AccountScopeId == accountScopeId);
+
+        detail.Ledger.Should().NotBeNull();
+        detail.Ledger!.AccountScopeId.Should().Be(accountScopeId);
+        detail.Ledger.EntityScopeId.Should().Be(entityScopeId);
+        detail.Ledger.SleeveScopeId.Should().Be(sleeveScopeId);
+        detail.Ledger.VehicleScopeId.Should().Be(vehicleScopeId);
+        detail.Ledger.TrialBalance.Should().OnlyContain(line => line.EntityScopeId == entityScopeId);
+    }
+
     private static StrategyRunEntry BuildCompletedRun(
         string runId,
         string strategyId,


### PR DESCRIPTION
### Motivation

- Provide explicit, optional scoping fields so workstation portfolio/ledger read models can carry fund-operations identifiers (account/entity/sleeve/vehicle) and display names for downstream integration and UI labeling. 
- Keep existing consumers stable by introducing nullable/optional fields rather than changing existing types or semantics.
- Populate these scope fields from whatever repository data is available (run parameters, fills, ledger account ids) so backtests, paper, and live runs surface a consistent scope view.

### Description

- Added optional scope fields (`AccountScopeId`, `AccountScopeDisplayName`, `EntityScopeId`, `EntityScopeDisplayName`, `SleeveScopeId`, `SleeveScopeDisplayName`, `VehicleScopeId`, `VehicleScopeDisplayName`) to the workstation read-models: `PortfolioSummary`, `PortfolioPositionSummary`, `LedgerSummary`, `LedgerTrialBalanceLine`, and `LedgerJournalLine` in `src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs`.
- Introduced `StrategyRunScopeMetadataResolver` (`src/Meridian.Strategies/Services/StrategyRunScopeMetadataResolver.cs`) that normalizes scope extraction from `StrategyRunEntry.ParameterSet` using multiple key aliases and falls back to a single account id derived from fills when an explicit account scope is absent.
- Updated mapping services to populate scope fields: `PortfolioReadService` now resolves scope and sets top-level and position-level fields; `LedgerReadService` sets top-level, trial-balance, and journal-level scope fields and uses `FinancialAccountId` as a sensible trial-balance account fallback when no explicit `AccountScopeId` is present (`src/Meridian.Strategies/Services/PortfolioReadService.cs`, `src/Meridian.Strategies/Services/LedgerReadService.cs`).
- Updated orchestration in `StrategyRunReadService` to apply a scope fallback when composing `StrategyRunDetail` so run-level parameters and resolved summary fields are merged consistently (`src/Meridian.Strategies/Services/StrategyRunReadService.cs`).
- Added focused tests that validate mapping and JSON serialization of scope metadata: tests added/modified in `tests/Meridian.Tests/Strategies/PortfolioReadServiceTests.cs`, `tests/Meridian.Tests/Strategies/LedgerReadServiceTests.cs`, and `tests/Meridian.Tests/Strategies/StrategyRunReadServiceTests.cs` covering position/trial-balance/journal mapping and backtest/paper/live run fixtures.

### Testing

- Added unit tests that assert scope mapping and JSON serialization in:
  - `tests/Meridian.Tests/Strategies/PortfolioReadServiceTests.cs` (new test: `BuildSummary_MapsAndSerializesScopeMetadataFromRunParameters`).
  - `tests/Meridian.Tests/Strategies/LedgerReadServiceTests.cs` (new test: `BuildSummary_MapsAndSerializesScopeMetadataFromRunParameters`).
  - `tests/Meridian.Tests/Strategies/StrategyRunReadServiceTests.cs` (new theory: `GetRunDetailAsync_BacktestPaperLive_PopulatesScopedPortfolioAndLedgerFields`).
- Attempted to run the targeted test set with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PortfolioReadServiceTests|FullyQualifiedName~LedgerReadServiceTests|FullyQualifiedName~StrategyRunReadServiceTests"`, but test execution could not be performed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).
- All changes were implemented to be backward compatible (new fields are nullable) and unit tests were added to guard the mapping behavior; running the test command in a dev environment with `dotnet` installed should execute and validate the added tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91f21da988320ba0221980ec27f57)