### PR TITLE
Keep run-review fallback within Trading shell

### DIFF
--- a/src/Meridian.Wpf/Views/TradingWorkspaceShellPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/TradingWorkspaceShellPage.xaml.cs
@@ -19,6 +19,7 @@ namespace Meridian.Wpf.Views;
 public partial class TradingWorkspaceShellPage : TradingWorkspaceShellPageBase
 {
     internal readonly record struct TradingPortfolioNavigationTarget(string PageTag, PaneDropAction Action, string? RunId);
+    internal readonly record struct TradingRunReviewNavigationTarget(string PageTag, PaneDropAction Action, string? RunId, string StatusMessage);
 
     private readonly StrategyRunWorkspaceService _runService;
     private readonly FundContextService _fundContextService;
@@ -408,16 +409,9 @@ public partial class TradingWorkspaceShellPage : TradingWorkspaceShellPageBase
 
     private async void OpenRunReview_Click(object sender, RoutedEventArgs e)
     {
-        var activeRun = await _runService.GetActiveRunContextAsync().ConfigureAwait(true);
-        if (activeRun is null)
-        {
-            DeskActionStatusText.Text = "No active trading run is selected. Opened strategy runs so a review target can be chosen.";
-            NavigationService.NavigateTo("StrategyRuns");
-            return;
-        }
-
-        DeskActionStatusText.Text = $"Run review opened for {activeRun.StrategyName}.";
-        OpenWorkspacePage(TradingDockManager, "RunDetail", PaneDropAction.SplitRight, activeRun.RunId);
+        var target = ResolveRunReviewNavigationTarget(await _runService.GetActiveRunContextAsync().ConfigureAwait(true));
+        DeskActionStatusText.Text = target.StatusMessage;
+        OpenWorkspacePage(TradingDockManager, target.PageTag, target.Action, target.RunId);
     }
 
     private async void OpenPortfolio_Click(object sender, RoutedEventArgs e)
@@ -542,4 +536,17 @@ public partial class TradingWorkspaceShellPage : TradingWorkspaceShellPageBase
         => activeRun is null
             ? new TradingPortfolioNavigationTarget("AccountPortfolio", PaneDropAction.Replace, null)
             : new TradingPortfolioNavigationTarget("RunPortfolio", PaneDropAction.SplitLeft, activeRun.RunId);
+
+    internal static TradingRunReviewNavigationTarget ResolveRunReviewNavigationTarget(ActiveRunContext? activeRun)
+        => activeRun is null
+            ? new TradingRunReviewNavigationTarget(
+                "AccountPortfolio",
+                PaneDropAction.SplitRight,
+                null,
+                "No active trading run is selected. Opened account portfolio to keep run-review context inside Trading.")
+            : new TradingRunReviewNavigationTarget(
+                "RunDetail",
+                PaneDropAction.SplitRight,
+                activeRun.RunId,
+                $"Run review opened for {activeRun.StrategyName}.");
 }

--- a/tests/Meridian.Wpf.Tests/Views/TradingWorkspaceShellPageTests.cs
+++ b/tests/Meridian.Wpf.Tests/Views/TradingWorkspaceShellPageTests.cs
@@ -29,4 +29,30 @@ public sealed class TradingWorkspaceShellPageTests
         target.Action.Should().Be(PaneDropAction.Replace);
         target.RunId.Should().BeNull();
     }
+
+    [Fact]
+    public void ResolveRunReviewNavigationTarget_WithActiveRun_UsesRunDetailInsideTradingShell()
+    {
+        var target = TradingWorkspaceShellPage.ResolveRunReviewNavigationTarget(new ActiveRunContext
+        {
+            RunId = "paper-run-42",
+            StrategyName = "Alpha Mean Reversion"
+        });
+
+        target.PageTag.Should().Be("RunDetail");
+        target.Action.Should().Be(PaneDropAction.SplitRight);
+        target.RunId.Should().Be("paper-run-42");
+        target.StatusMessage.Should().Be("Run review opened for Alpha Mean Reversion.");
+    }
+
+    [Fact]
+    public void ResolveRunReviewNavigationTarget_WithoutActiveRun_FallsBackToAccountPortfolioInsideTradingShell()
+    {
+        var target = TradingWorkspaceShellPage.ResolveRunReviewNavigationTarget(null);
+
+        target.PageTag.Should().Be("AccountPortfolio");
+        target.Action.Should().Be(PaneDropAction.SplitRight);
+        target.RunId.Should().BeNull();
+        target.StatusMessage.Should().Contain("inside Trading");
+    }
 }


### PR DESCRIPTION
### Motivation
- Keep run-review actions within the Trading workspace when no active run is present instead of navigating to the Research `StrategyRuns` page.
- Preserve clear user feedback by surfacing an explanatory status message when a fallback Trading page is opened.

### Description
- Replaced the previous `OpenRunReview_Click` behaviour that navigated to `StrategyRuns` with a resolver-based flow that returns a `TradingRunReviewNavigationTarget` and opens it via `OpenWorkspacePage(TradingDockManager, ...)`.
- Added a new `TradingRunReviewNavigationTarget` record and `ResolveRunReviewNavigationTarget(ActiveRunContext?)` which returns `RunDetail` for an active run or falls back to `AccountPortfolio` inside Trading when no run is active, and includes a `StatusMessage` for `DeskActionStatusText`.
- Updated `OpenRunReview_Click` to set `DeskActionStatusText` from the resolved target and to open the resolved Trading-native page.
- Added unit tests in `tests/Meridian.Wpf.Tests/Views/TradingWorkspaceShellPageTests.cs` that assert the run-review resolver returns the expected page tag, pane action, run id, and status message for both active and no-active-run cases.

### Testing
- Added `TradingWorkspaceShellPageTests.ResolveRunReviewNavigationTarget_WithActiveRun_UsesRunDetailInsideTradingShell` and `ResolveRunReviewNavigationTarget_WithoutActiveRun_FallsBackToAccountPortfolioInsideTradingShell` to validate resolver behaviour; these tests are present in `tests/Meridian.Wpf.Tests/Views/TradingWorkspaceShellPageTests.cs`.
- Attempted to run the test subset with `dotnet test --filter "FullyQualifiedName~TradingWorkspaceShellPageTests"`, but the run failed in this environment because `dotnet` is not installed (no test execution results available here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91f1f88e48320a2ebea113ad66c42)