### PR TITLE
Migrate DataQuality page actions into workspace command + inspector patterns

### DIFF
--- a/src/Meridian.Wpf/Views/DataQualityPage.xaml
+++ b/src/Meridian.Wpf/Views/DataQualityPage.xaml
@@ -4,6 +4,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:converters="clr-namespace:Meridian.Wpf.Converters"
+      xmlns:views="clr-namespace:Meridian.Wpf.Views"
       mc:Ignorable="d"
       d:DesignHeight="800" d:DesignWidth="1200"
       Background="{DynamicResource ShellWindowBackgroundBrush}"
@@ -54,6 +55,51 @@
                     </Button>
                 </StackPanel>
             </Grid>
+            </Border>
+
+            <views:WorkspaceCommandBarControl x:Name="CommandBar"
+                                              Margin="0,0,0,16"
+                                              CommandInvoked="OnCommandBarCommandInvoked" />
+
+            <Border x:Name="WorkspaceInteractionPanel"
+                    Style="{StaticResource WorkspaceInspectorCardStyle}"
+                    Margin="0,0,0,24"
+                    Visibility="Collapsed">
+                <StackPanel>
+                    <TextBlock x:Name="InteractionTitleText" Style="{StaticResource CardHeaderStyle}" />
+                    <TextBlock x:Name="InteractionBodyText"
+                               Margin="0,8,0,0"
+                               Foreground="{StaticResource ConsoleTextSecondaryBrush}"
+                               TextWrapping="Wrap" />
+                    <TextBox x:Name="InteractionInputBox"
+                             Margin="0,12,0,0"
+                             Background="{DynamicResource ConsoleBackgroundMediumBrush}"
+                             Foreground="{DynamicResource ConsoleTextBrush}"
+                             BorderThickness="1"
+                             Padding="8,6"
+                             Visibility="Collapsed" />
+                    <ItemsControl x:Name="InteractionItemsList"
+                                  Margin="0,12,0,0"
+                                  Visibility="Collapsed">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding}"
+                                           Margin="0,0,0,6"
+                                           Foreground="{StaticResource ConsoleTextSecondaryBrush}"
+                                           TextWrapping="Wrap" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    <WrapPanel Margin="0,14,0,0">
+                        <Button x:Name="InteractionPrimaryActionButton"
+                                Style="{StaticResource SecondaryButtonStyle}"
+                                Margin="0,0,8,0"
+                                Click="InteractionPrimaryAction_Click" />
+                        <Button x:Name="InteractionSecondaryActionButton"
+                                Style="{StaticResource GhostButtonStyle}"
+                                Click="InteractionSecondaryAction_Click" />
+                    </WrapPanel>
+                </StackPanel>
             </Border>
 
             <!-- Overall Quality Cards -->

--- a/src/Meridian.Wpf/Views/DataQualityPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/DataQualityPage.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Controls;
 using System.Windows.Media;
 using Meridian.Ui.Services.DataQuality;
 using Meridian.Wpf.Models;
+using Meridian.Wpf.Services;
 using Meridian.Wpf.ViewModels;
 
 namespace Meridian.Wpf.Views;
@@ -14,10 +15,14 @@ namespace Meridian.Wpf.Views;
 public partial class DataQualityPage : Page
 {
     private readonly DataQualityViewModel _viewModel;
+    private readonly NavigationService _navigationService;
+    private InteractionMode _interactionMode = InteractionMode.None;
+    private string? _pendingGapId;
 
-    public DataQualityPage(DataQualityViewModel viewModel)
+    public DataQualityPage(DataQualityViewModel viewModel, NavigationService navigationService)
     {
         _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+        _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
         DataContext = _viewModel;
         InitializeComponent();
 
@@ -31,6 +36,7 @@ public partial class DataQualityPage : Page
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
         await _viewModel.StartAsync();
+        CommandBar.CommandGroup = BuildCommandGroup();
         RenderTrendChart(_viewModel.TrendPoints);
         ApplyDrilldownHeatmap();
     }
@@ -47,29 +53,20 @@ public partial class DataQualityPage : Page
 
     private async void Refresh_Click(object sender, RoutedEventArgs e) => await _viewModel.RefreshAsync();
 
-    private async void RunQualityCheck_Click(object sender, RoutedEventArgs e)
-    {
-        var path = PromptForQualityCheckPath();
-        if (!string.IsNullOrWhiteSpace(path))
-        {
-            await _viewModel.RunQualityCheckAsync(path);
-        }
-    }
+    private void RunQualityCheck_Click(object sender, RoutedEventArgs e) => ShowQualityCheckPanel();
 
-    private async void RepairGap_Click(object sender, RoutedEventArgs e)
+    private void RepairGap_Click(object sender, RoutedEventArgs e)
     {
-        if (sender is Button button && button.Tag is string gapId && ShowConfirmation("Repair Gap", "Start repair for this gap?"))
+        if (sender is Button button && button.Tag is string gapId)
         {
-            await _viewModel.RepairGapAsync(gapId);
+            ShowConfirmationPanel("Repair Gap", "Start repair for this gap?", InteractionMode.ConfirmRepairGap, gapId);
         }
     }
 
     private async void RepairAllGaps_Click(object sender, RoutedEventArgs e)
     {
-        if (_viewModel.Gaps.Count > 0 && ShowConfirmation("Repair All Gaps", "Start repair for all listed gaps?"))
-        {
-            await _viewModel.RepairAllGapsAsync();
-        }
+        if (_viewModel.Gaps.Count > 0)
+            ShowConfirmationPanel("Repair All Gaps", "Start repair for all listed gaps?", InteractionMode.ConfirmRepairAll);
     }
 
     private async void CompareProviders_Click(object sender, RoutedEventArgs e)
@@ -77,7 +74,7 @@ public partial class DataQualityPage : Page
         if (sender is Button button && button.Tag is string symbol)
         {
             var comparison = await _viewModel.GetProviderComparisonAsync(symbol);
-            ShowProviderComparisonDialog(comparison.Symbol, comparison.Providers);
+            ShowProviderComparisonInspector(comparison.Symbol, comparison.Providers);
         }
     }
 
@@ -117,6 +114,62 @@ public partial class DataQualityPage : Page
     }
 
     private async void AcknowledgeAll_Click(object sender, RoutedEventArgs e) => await _viewModel.AcknowledgeAllAlertsAsync();
+
+    private void OnCommandBarCommandInvoked(object sender, WorkspaceCommandInvokedEventArgs e)
+    {
+        switch (e.Command.Id)
+        {
+            case "Refresh":
+                _ = _viewModel.RefreshAsync();
+                break;
+            case "RunQualityCheck":
+                ShowQualityCheckPanel();
+                break;
+            case "OpenDataBrowser":
+                OpenWorkflow("DataBrowser");
+                break;
+            case "OpenCollectionSessions":
+                OpenWorkflow("CollectionSessions");
+                break;
+            case "OpenSymbols":
+                OpenWorkflow("Symbols");
+                break;
+        }
+    }
+
+    private async void InteractionPrimaryAction_Click(object sender, RoutedEventArgs e)
+    {
+        switch (_interactionMode)
+        {
+            case InteractionMode.RunQualityCheck:
+                var path = InteractionInputBox.Text?.Trim();
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    InteractionBodyText.Text = "Enter a symbol or path before running the quality check.";
+                    return;
+                }
+
+                await _viewModel.RunQualityCheckAsync(path);
+                CloseInteractionPanel();
+                break;
+            case InteractionMode.ConfirmRepairGap:
+                if (!string.IsNullOrWhiteSpace(_pendingGapId))
+                {
+                    await _viewModel.RepairGapAsync(_pendingGapId);
+                }
+                CloseInteractionPanel();
+                break;
+            case InteractionMode.ConfirmRepairAll:
+                await _viewModel.RepairAllGapsAsync();
+                CloseInteractionPanel();
+                break;
+            default:
+                CloseInteractionPanel();
+                break;
+        }
+    }
+
+    private void InteractionSecondaryAction_Click(object sender, RoutedEventArgs e) => CloseInteractionPanel();
 
     private void AnomalyType_Changed(object sender, SelectionChangedEventArgs e)
     {
@@ -197,15 +250,88 @@ public partial class DataQualityPage : Page
         }
     }
 
-    private static string? PromptForQualityCheckPath()
-        => Microsoft.VisualBasic.Interaction.InputBox("Enter a symbol or path to check", "Run Quality Check", "SPY");
+    private static WorkspaceCommandGroup BuildCommandGroup()
+        => new()
+        {
+            PrimaryCommands =
+            [
+                new WorkspaceCommandItem { Id = "Refresh", Label = "Refresh", Description = "Refresh data quality metrics.", Glyph = "\uE72C", Tone = WorkspaceTone.Primary },
+                new WorkspaceCommandItem { Id = "RunQualityCheck", Label = "Run quality check", Description = "Run a quality check for a symbol or file path.", Glyph = "\uE9D5" }
+            ],
+            SecondaryCommands =
+            [
+                new WorkspaceCommandItem { Id = "OpenDataBrowser", Label = "Open data browser", Description = "Open data browser in the current shell workflow when possible.", Glyph = "\uE721" },
+                new WorkspaceCommandItem { Id = "OpenCollectionSessions", Label = "Open collection sessions", Description = "Open collection sessions in workspace routing.", Glyph = "\uE91C" },
+                new WorkspaceCommandItem { Id = "OpenSymbols", Label = "Open symbols", Description = "Open symbols page in workspace routing.", Glyph = "\uE8D2" }
+            ]
+        };
 
-    private static bool ShowConfirmation(string title, string message)
-        => MessageBox.Show(message, title, MessageBoxButton.OKCancel, MessageBoxImage.Question) == MessageBoxResult.OK;
-
-    private static void ShowProviderComparisonDialog(string symbol, IReadOnlyList<DataQualityProviderComparisonItem> providers)
+    private void ShowQualityCheckPanel()
     {
-        var lines = providers.Select(p => $"{p.Name}: {p.CompletenessText}, {p.LatencyText}, {p.FreshnessText}, {p.Status}");
-        MessageBox.Show(string.Join(Environment.NewLine, lines), $"Provider Comparison - {symbol}", MessageBoxButton.OK, MessageBoxImage.Information);
+        _interactionMode = InteractionMode.RunQualityCheck;
+        InteractionTitleText.Text = "Run quality check";
+        InteractionBodyText.Text = "Enter a symbol or path to run quality checks without leaving this workspace.";
+        InteractionInputBox.Text = "SPY";
+        InteractionInputBox.Visibility = Visibility.Visible;
+        InteractionItemsList.Visibility = Visibility.Collapsed;
+        InteractionPrimaryActionButton.Content = "Run";
+        InteractionSecondaryActionButton.Content = "Cancel";
+        WorkspaceInteractionPanel.Visibility = Visibility.Visible;
+    }
+
+    private void ShowConfirmationPanel(string title, string message, InteractionMode mode, string? gapId = null)
+    {
+        _interactionMode = mode;
+        _pendingGapId = gapId;
+        InteractionTitleText.Text = title;
+        InteractionBodyText.Text = message;
+        InteractionInputBox.Visibility = Visibility.Collapsed;
+        InteractionItemsList.Visibility = Visibility.Collapsed;
+        InteractionPrimaryActionButton.Content = "Confirm";
+        InteractionSecondaryActionButton.Content = "Cancel";
+        WorkspaceInteractionPanel.Visibility = Visibility.Visible;
+    }
+
+    private void ShowProviderComparisonInspector(string symbol, IReadOnlyList<DataQualityProviderComparisonItem> providers)
+    {
+        _interactionMode = InteractionMode.ShowComparison;
+        var lines = providers.Select(p => $"{p.Name}: {p.CompletenessText}, {p.LatencyText}, {p.FreshnessText}, {p.Status}").ToArray();
+        InteractionTitleText.Text = $"Provider comparison · {symbol}";
+        InteractionBodyText.Text = "Comparison details are shown inline so operators can keep context while reviewing symbols.";
+        InteractionItemsList.ItemsSource = lines;
+        InteractionInputBox.Visibility = Visibility.Collapsed;
+        InteractionItemsList.Visibility = Visibility.Visible;
+        InteractionPrimaryActionButton.Content = "Close";
+        InteractionSecondaryActionButton.Content = "Dismiss";
+        WorkspaceInteractionPanel.Visibility = Visibility.Visible;
+    }
+
+    private void CloseInteractionPanel()
+    {
+        _interactionMode = InteractionMode.None;
+        _pendingGapId = null;
+        InteractionInputBox.Text = string.Empty;
+        InteractionItemsList.ItemsSource = null;
+        WorkspaceInteractionPanel.Visibility = Visibility.Collapsed;
+    }
+
+    private void OpenWorkflow(string pageTag)
+    {
+        if (WorkspaceShellChromeState.GetIsHostedInWorkspaceShell(this))
+        {
+            _navigationService.NavigateTo("DataOperationsShell");
+            return;
+        }
+
+        _navigationService.NavigateTo(pageTag);
+    }
+
+    private enum InteractionMode
+    {
+        None,
+        RunQualityCheck,
+        ConfirmRepairGap,
+        ConfirmRepairAll,
+        ShowComparison
     }
 }

--- a/tests/Meridian.Wpf.Tests/Views/WorkspaceDeepPageChromeTests.cs
+++ b/tests/Meridian.Wpf.Tests/Views/WorkspaceDeepPageChromeTests.cs
@@ -66,6 +66,8 @@ public sealed class WorkspaceDeepPageChromeTests
     [InlineData(@"src\Meridian.Wpf\Views\NotificationCenterPage.xaml", "EmbeddedShellCompactHeaderCardStyle")]
     [InlineData(@"src\Meridian.Wpf\Views\SecurityMasterPage.xaml", "EmbeddedShellCompactHeaderCardStyle")]
     [InlineData(@"src\Meridian.Wpf\Views\ServiceManagerPage.xaml", "EmbeddedShellHeroCardStyle")]
+    [InlineData(@"src\Meridian.Wpf\Views\DataQualityPage.xaml", "WorkspaceCommandBarControl")]
+    [InlineData(@"src\Meridian.Wpf\Views\DataQualityPage.xaml", "WorkspaceInteractionPanel")]
     [InlineData(@"src\Meridian.Wpf\Views\PositionBlotterPage.xaml", "EmbeddedShellCompactHeaderCardStyle")]
     public void LegacyDeepPages_ShouldOptIntoSharedEmbeddedShellChrome(string relativePath, string expectedMarker)
     {
@@ -86,5 +88,16 @@ public sealed class WorkspaceDeepPageChromeTests
     {
         var absolutePath = RunMatUiAutomationFacade.GetRepoFilePath(relativePath);
         File.ReadAllText(absolutePath).Should().Contain(automationId);
+    }
+
+    [Fact]
+    public void DataQualityPage_ShouldAvoidBlockingPromptsInsideHostedWorkspaceExperience()
+    {
+        var pageCodePath = RunMatUiAutomationFacade.GetRepoFilePath(@"src\Meridian.Wpf\Views\DataQualityPage.xaml.cs");
+        var code = File.ReadAllText(pageCodePath);
+
+        code.Should().NotContain("MessageBox.Show");
+        code.Should().NotContain("Interaction.InputBox");
+        code.Should().Contain("OpenWorkflow(");
     }
 }


### PR DESCRIPTION
### Motivation
- Replace page-local blocking prompts and modal flows with shared non-blocking workspace command and inspector surfaces so operators keep context when Data Quality actions run inside hosted shell panes.
- Surface common operator affordances (refresh, run quality check, quick workflow navigation) as workspace command-bar actions and secondary inspector details to align with other workspace shells.
- Route cross-workflow opens through a shell-aware helper so pages prefer opening docked shell panes instead of performing orphan page navigations.

### Description
- Add a `WorkspaceCommandBarControl` and an inline `WorkspaceInteractionPanel` to `DataQualityPage.xaml` and wire up a `BuildCommandGroup()` to expose `Refresh`, `RunQualityCheck` and several quick workflow commands.
- Replace direct modal prompts (`Microsoft.VisualBasic.Interaction.InputBox` / `MessageBox.Show`) with non-blocking inspector flows implemented in `DataQualityPage.xaml.cs` via `ShowQualityCheckPanel`, `ShowConfirmationPanel`, and `ShowProviderComparisonInspector` and an `InteractionMode` state machine.
- Inject `NavigationService` into `DataQualityPage` and add `OpenWorkflow(string)` which is shell-aware (uses `WorkspaceShellChromeState.GetIsHostedInWorkspaceShell`) so hosted pages route back into the shell (`DataOperationsShell`) when appropriate.
- Update tests in `WorkspaceDeepPageChromeTests` to assert that `DataQualityPage` includes the workspace command bar and interaction panel and add a regression assertion ensuring no blocking APIs remain in the page code-behind.

### Testing
- Static/automated checks: ran a repository search with `rg` to confirm removal of `MessageBox.Show` / `Interaction.InputBox` usage from the Data Quality code paths and to verify presence of `WorkspaceCommandBarControl`, `WorkspaceInteractionPanel`, and `OpenWorkflow(` which succeeded.
- Tests added: `tests/Meridian.Wpf.Tests/Views/WorkspaceDeepPageChromeTests.cs` was updated to include XAML marker checks and a guard test against blocking prompts (test file changed and saved under VCS).
- Unit test run: attempted `dotnet test --filter "FullyQualifiedName~WorkspaceDeepPageChromeTests|FullyQualifiedName~DataQualityPageSmokeTests"` but automated test execution failed in this environment because `dotnet` is not installed, so full test execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91f1c90d48320974970112a682faa)