### PR TITLE
Refactor security reference resolution to canonical identity keys

### DIFF
--- a/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
+++ b/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
@@ -164,7 +164,10 @@ public sealed record WorkstationSecurityReference(
     string? MatchedIdentifierKind = null,
     string? MatchedIdentifierValue = null,
     string? MatchedProvider = null,
-    string? ResolutionReason = null);
+    string? ResolutionReason = null,
+    string? LookupPath = null,
+    string? LookupSource = null,
+    bool IsInferredMatch = false);
 
 /// <summary>
 /// Shared portfolio rollup for workstation research and trading surfaces.

--- a/src/Meridian.Strategies/Services/ISecurityReferenceLookup.cs
+++ b/src/Meridian.Strategies/Services/ISecurityReferenceLookup.cs
@@ -3,9 +3,40 @@ using Meridian.Contracts.Workstation;
 namespace Meridian.Strategies.Services;
 
 /// <summary>
+/// Canonical security identity context passed to workstation lookup services.
+/// </summary>
+public sealed record SecurityReferenceLookupRequest(
+    Guid? SecurityId = null,
+    string? IdentifierKind = null,
+    string? IdentifierValue = null,
+    string? Symbol = null,
+    string? Venue = null,
+    string? Currency = null,
+    string? AssetClass = null,
+    string? Source = null);
+
+/// <summary>
 /// Resolves workstation-friendly instrument metadata for portfolio and ledger drill-ins.
 /// </summary>
 public interface ISecurityReferenceLookup
 {
+    /// <summary>
+    /// Attempts to resolve security metadata using the richest canonical identity available.
+    /// </summary>
+    Task<WorkstationSecurityReference?> GetByCanonicalAsync(
+        SecurityReferenceLookupRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var symbol = string.IsNullOrWhiteSpace(request.Symbol)
+            ? request.IdentifierValue
+            : request.Symbol;
+
+        return string.IsNullOrWhiteSpace(symbol)
+            ? Task.FromResult<WorkstationSecurityReference?>(null)
+            : GetBySymbolAsync(symbol, ct);
+    }
+
     Task<WorkstationSecurityReference?> GetBySymbolAsync(string symbol, CancellationToken ct = default);
 }

--- a/src/Meridian.Strategies/Services/LedgerReadService.cs
+++ b/src/Meridian.Strategies/Services/LedgerReadService.cs
@@ -1,3 +1,4 @@
+using Meridian.Contracts.SecurityMaster;
 using Meridian.Contracts.Workstation;
 using Meridian.Ledger;
 using Meridian.Strategies.Models;
@@ -31,18 +32,15 @@ public sealed class LedgerReadService
             return summary;
         }
 
-        var lookup = await ResolveSecuritiesAsync(
-                summary.TrialBalance
-                    .Select(static line => line.Symbol)
-                    .Where(static symbol => !string.IsNullOrWhiteSpace(symbol))!
-                    .Select(static symbol => symbol!),
-                ct)
-            .ConfigureAwait(false);
+        var requests = BuildLookupRequests(entry, summary.TrialBalance);
+        var lookup = await ResolveSecuritiesAsync(requests, ct).ConfigureAwait(false);
 
         var trialBalance = summary.TrialBalance
             .Select(line => line with
             {
-                Security = line.Symbol is not null ? lookup.GetValueOrDefault(line.Symbol) : null
+                Security = line.Symbol is not null
+                    ? lookup.GetValueOrDefault(ComposeLineKey(line.Symbol, line.FinancialAccountId))
+                    : null
             })
             .ToArray();
 
@@ -115,8 +113,61 @@ public sealed class LedgerReadService
             .Where(summary => summary.Account.AccountType == accountType)
             .Sum(static summary => summary.Balance);
 
+    private static IReadOnlyDictionary<string, SecurityReferenceLookupRequest> BuildLookupRequests(
+        StrategyRunEntry entry,
+        IReadOnlyList<LedgerTrialBalanceLine> trialBalance)
+    {
+        var metadataByKey = entry.Metrics?.Ledger?.Journal
+            .Where(static item => !string.IsNullOrWhiteSpace(item.Metadata.Symbol))
+            .GroupBy(
+                static item => ComposeLineKey(item.Metadata.Symbol!, item.Metadata.FinancialAccountId),
+                StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                static group => group.Key,
+                static group =>
+                {
+                    var securityIds = group
+                        .Select(static item => item.Metadata.SecurityId)
+                        .Where(static id => id.HasValue)
+                        .Select(static id => id!.Value)
+                        .Distinct()
+                        .ToArray();
+                    var venues = group
+                        .Select(static item => item.Metadata.Institution)
+                        .Where(static venue => !string.IsNullOrWhiteSpace(venue))
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToArray();
+
+                    return (
+                        SecurityId: securityIds.Length == 1 ? securityIds[0] : (Guid?)null,
+                        Venue: venues.Length == 1 ? venues[0] : null);
+                },
+                StringComparer.OrdinalIgnoreCase)
+            ?? new Dictionary<string, (Guid? SecurityId, string? Venue)>(StringComparer.OrdinalIgnoreCase);
+
+        return trialBalance
+            .Where(static line => !string.IsNullOrWhiteSpace(line.Symbol))
+            .GroupBy(static line => ComposeLineKey(line.Symbol!, line.FinancialAccountId), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                static group => group.Key,
+                group =>
+                {
+                    var representative = group.First();
+                    var key = group.Key;
+                    var meta = metadataByKey.GetValueOrDefault(key);
+                    return new SecurityReferenceLookupRequest(
+                        SecurityId: meta.SecurityId,
+                        IdentifierKind: SecurityIdentifierKind.Ticker.ToString(),
+                        IdentifierValue: representative.Symbol,
+                        Symbol: representative.Symbol,
+                        Venue: meta.Venue ?? representative.FinancialAccountId,
+                        Source: meta.SecurityId is null ? "ledger-trial-balance" : "ledger-journal-metadata");
+                },
+                StringComparer.OrdinalIgnoreCase);
+    }
+
     private async Task<Dictionary<string, WorkstationSecurityReference?>> ResolveSecuritiesAsync(
-        IEnumerable<string> symbols,
+        IReadOnlyDictionary<string, SecurityReferenceLookupRequest> requests,
         CancellationToken ct)
     {
         var lookup = new Dictionary<string, WorkstationSecurityReference?>(StringComparer.OrdinalIgnoreCase);
@@ -125,13 +176,27 @@ public sealed class LedgerReadService
             return lookup;
         }
 
-        foreach (var symbol in symbols.Distinct(StringComparer.OrdinalIgnoreCase))
+        foreach (var (key, request) in requests)
         {
-            lookup[symbol] = await _securityReferenceLookup
-                .GetBySymbolAsync(symbol, ct)
-                .ConfigureAwait(false);
+            var resolved = await _securityReferenceLookup.GetByCanonicalAsync(request, ct).ConfigureAwait(false)
+                ?? (request.Symbol is null
+                    ? null
+                    : await _securityReferenceLookup.GetBySymbolAsync(request.Symbol, ct).ConfigureAwait(false));
+
+            lookup[key] = resolved is null
+                ? null
+                : resolved with
+                {
+                    LookupSource = request.Source,
+                    LookupPath = resolved.LookupPath ?? (request.SecurityId is null ? "symbol" : "security-id")
+                };
         }
 
         return lookup;
     }
+
+    private static string ComposeLineKey(string symbol, string? financialAccountId)
+        => string.IsNullOrWhiteSpace(financialAccountId)
+            ? symbol.Trim()
+            : $"{symbol.Trim()}::{financialAccountId.Trim()}";
 }

--- a/src/Meridian.Strategies/Services/PortfolioReadService.cs
+++ b/src/Meridian.Strategies/Services/PortfolioReadService.cs
@@ -1,3 +1,4 @@
+using Meridian.Contracts.SecurityMaster;
 using Meridian.Contracts.Workstation;
 using Meridian.Strategies.Models;
 
@@ -30,12 +31,8 @@ public sealed class PortfolioReadService
             return summary;
         }
 
-        var lookup = await ResolveSecuritiesAsync(
-                summary.Positions
-                    .Select(static position => position.Symbol)
-                    .Where(static symbol => !string.IsNullOrWhiteSpace(symbol)),
-                ct)
-            .ConfigureAwait(false);
+        var lookupRequests = BuildLookupRequests(entry, summary);
+        var lookup = await ResolveSecuritiesAsync(lookupRequests, ct).ConfigureAwait(false);
 
         var positions = summary.Positions
             .Select(position => position with
@@ -102,8 +99,52 @@ public sealed class PortfolioReadService
             Positions: positions);
     }
 
+    private static IReadOnlyDictionary<string, SecurityReferenceLookupRequest> BuildLookupRequests(
+        StrategyRunEntry entry,
+        PortfolioSummary summary)
+    {
+        var symbolsToSecurityId = entry.Metrics?.Ledger?.Journal
+            .Where(static item => !string.IsNullOrWhiteSpace(item.Metadata.Symbol))
+            .GroupBy(
+                static item => item.Metadata.Symbol!,
+                StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                static group => group.Key,
+                static group =>
+                {
+                    var candidates = group
+                        .Select(static entry => entry.Metadata.SecurityId)
+                        .Where(static id => id.HasValue)
+                        .Select(static id => id!.Value)
+                        .Distinct()
+                        .ToArray();
+                    return candidates.Length == 1 ? candidates[0] : (Guid?)null;
+                },
+                StringComparer.OrdinalIgnoreCase)
+            ?? new Dictionary<string, Guid?>(StringComparer.OrdinalIgnoreCase);
+
+        return summary.Positions
+            .Where(static position => !string.IsNullOrWhiteSpace(position.Symbol))
+            .GroupBy(static position => position.Symbol, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                static group => group.Key,
+                group =>
+                {
+                    var symbol = group.Key;
+                    var resolvedSecurityId = symbolsToSecurityId.GetValueOrDefault(symbol);
+                    var source = resolvedSecurityId is null ? "portfolio-position-symbol" : "ledger-metadata-security-id";
+                    return new SecurityReferenceLookupRequest(
+                        SecurityId: resolvedSecurityId,
+                        IdentifierKind: SecurityIdentifierKind.Ticker.ToString(),
+                        IdentifierValue: symbol,
+                        Symbol: symbol,
+                        Source: source);
+                },
+                StringComparer.OrdinalIgnoreCase);
+    }
+
     private async Task<Dictionary<string, WorkstationSecurityReference?>> ResolveSecuritiesAsync(
-        IEnumerable<string> symbols,
+        IReadOnlyDictionary<string, SecurityReferenceLookupRequest> requests,
         CancellationToken ct)
     {
         var lookup = new Dictionary<string, WorkstationSecurityReference?>(StringComparer.OrdinalIgnoreCase);
@@ -112,11 +153,19 @@ public sealed class PortfolioReadService
             return lookup;
         }
 
-        foreach (var symbol in symbols.Distinct(StringComparer.OrdinalIgnoreCase))
+        foreach (var (symbol, request) in requests)
         {
-            lookup[symbol] = await _securityReferenceLookup
-                .GetBySymbolAsync(symbol, ct)
-                .ConfigureAwait(false);
+            var resolved = await _securityReferenceLookup.GetByCanonicalAsync(request, ct).ConfigureAwait(false)
+                ?? await _securityReferenceLookup.GetBySymbolAsync(symbol, ct).ConfigureAwait(false);
+
+            lookup[symbol] = resolved is null
+                ? null
+                : resolved with
+                {
+                    LookupSource = request.Source,
+                    LookupPath = resolved.LookupPath ?? (request.SecurityId is null ? "symbol" : "security-id"),
+                    IsInferredMatch = request.SecurityId is null && string.IsNullOrWhiteSpace(request.IdentifierValue)
+                };
         }
 
         return lookup;

--- a/src/Meridian.Ui.Shared/Services/SecurityMasterSecurityReferenceLookup.cs
+++ b/src/Meridian.Ui.Shared/Services/SecurityMasterSecurityReferenceLookup.cs
@@ -16,16 +16,61 @@ public sealed class SecurityMasterSecurityReferenceLookup : ISecurityReferenceLo
         _queryService = queryService ?? throw new ArgumentNullException(nameof(queryService));
     }
 
-    public async Task<WorkstationSecurityReference?> GetBySymbolAsync(string symbol, CancellationToken ct = default)
+    public Task<WorkstationSecurityReference?> GetBySymbolAsync(string symbol, CancellationToken ct = default)
+        => GetByCanonicalAsync(
+            new SecurityReferenceLookupRequest(
+                IdentifierKind: SecurityIdentifierKind.Ticker.ToString(),
+                IdentifierValue: symbol,
+                Symbol: symbol,
+                Source: "symbol"),
+            ct);
+
+    public async Task<WorkstationSecurityReference?> GetByCanonicalAsync(
+        SecurityReferenceLookupRequest request,
+        CancellationToken ct = default)
     {
-        if (string.IsNullOrWhiteSpace(symbol))
+        ArgumentNullException.ThrowIfNull(request);
+
+        var normalizedIdentifierKind = request.IdentifierKind;
+        var normalizedIdentifierValue = request.IdentifierValue;
+        var lookupPath = "none";
+        SecurityDetailDto? detail = null;
+
+        if (request.SecurityId is Guid securityId)
         {
-            return null;
+            detail = await _queryService.GetByIdAsync(securityId, ct).ConfigureAwait(false);
+            lookupPath = "security-id";
         }
 
-        var detail = await _queryService
-            .GetByIdentifierAsync(SecurityIdentifierKind.Ticker, symbol, provider: null, ct)
-            .ConfigureAwait(false);
+        if (detail is null)
+        {
+            var identifierValue = normalizedIdentifierValue;
+            if (string.IsNullOrWhiteSpace(identifierValue))
+            {
+                identifierValue = string.IsNullOrWhiteSpace(request.Symbol) ? null : request.Symbol;
+                if (identifierValue is not null && string.IsNullOrWhiteSpace(normalizedIdentifierKind))
+                {
+                    normalizedIdentifierKind = SecurityIdentifierKind.Ticker.ToString();
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(identifierValue))
+            {
+                if (!Enum.TryParse<SecurityIdentifierKind>(normalizedIdentifierKind, ignoreCase: true, out var kind))
+                {
+                    kind = SecurityIdentifierKind.Ticker;
+                }
+
+                detail = await _queryService
+                    .GetByIdentifierAsync(kind, identifierValue, request.Venue, ct)
+                    .ConfigureAwait(false);
+
+                normalizedIdentifierKind = kind.ToString();
+                normalizedIdentifierValue = identifierValue;
+                lookupPath = request.Venue is null ? "identifier" : "identifier+venue";
+            }
+        }
+
         if (detail is null)
         {
             return null;
@@ -34,6 +79,10 @@ public sealed class SecurityMasterSecurityReferenceLookup : ISecurityReferenceLo
         var primaryIdentifier = detail.Identifiers
             .FirstOrDefault(static identifier => identifier.IsPrimary)?.Value
             ?? detail.Identifiers.FirstOrDefault()?.Value;
+
+        var inferred = request.SecurityId is null
+            && !string.IsNullOrWhiteSpace(request.Symbol)
+            && !string.Equals(normalizedIdentifierValue, request.Symbol, StringComparison.OrdinalIgnoreCase);
 
         return new WorkstationSecurityReference(
             SecurityId: detail.SecurityId,
@@ -44,10 +93,13 @@ public sealed class SecurityMasterSecurityReferenceLookup : ISecurityReferenceLo
             PrimaryIdentifier: primaryIdentifier,
             SubType: DeriveSubType(detail.AssetClass),
             CoverageStatus: WorkstationSecurityCoverageStatus.Resolved,
-            MatchedIdentifierKind: SecurityIdentifierKind.Ticker.ToString(),
-            MatchedIdentifierValue: symbol,
-            MatchedProvider: null,
-            ResolutionReason: null);
+            MatchedIdentifierKind: normalizedIdentifierKind,
+            MatchedIdentifierValue: normalizedIdentifierValue,
+            MatchedProvider: request.Venue,
+            ResolutionReason: request.Source,
+            LookupPath: lookupPath,
+            LookupSource: request.Source,
+            IsInferredMatch: inferred);
     }
 
     /// <summary>

--- a/tests/Meridian.Tests/Strategies/LedgerReadServiceTests.cs
+++ b/tests/Meridian.Tests/Strategies/LedgerReadServiceTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Meridian.Backtesting.Sdk;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Contracts.Workstation;
+using Meridian.Ledger;
 using Meridian.Strategies.Models;
 using Meridian.Strategies.Services;
 using Moq;
@@ -209,6 +210,74 @@ public sealed class LedgerReadServiceTests
             .BeLessThanOrEqualTo(summary.TrialBalance.Count);
     }
 
+
+    [Fact]
+    public async Task BuildSummaryAsync_WithAmbiguousSymbolAcrossVenues_UsesFinancialAccountVenueInCanonicalLookup()
+    {
+        var securityId = Guid.NewGuid();
+        var entry = BuildCompletedRun(symbol: "AAPL", financialAccountId: "ACC-NASDAQ", securityId: securityId, institution: "XNAS");
+        var resolved = new WorkstationSecurityReference(
+            SecurityId: securityId,
+            DisplayName: "Apple Inc. NASDAQ",
+            AssetClass: "Equity",
+            Currency: "USD",
+            Status: SecurityStatusDto.Active,
+            PrimaryIdentifier: "AAPL");
+
+        var lookup = new Mock<ISecurityReferenceLookup>();
+        lookup
+            .Setup(l => l.GetByCanonicalAsync(
+                It.Is<SecurityReferenceLookupRequest>(request =>
+                    request.Symbol == "AAPL"
+                    && request.SecurityId == securityId
+                    && request.Venue == "XNAS"
+                    && request.Source == "ledger-journal-metadata"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resolved);
+
+        var service = new LedgerReadService(lookup.Object);
+        var summary = await service.BuildSummaryAsync(entry);
+
+        summary.Should().NotBeNull();
+        summary!.TrialBalance
+            .Where(static line => line.Symbol == "AAPL")
+            .Should()
+            .OnlyContain(line => line.Security is not null && line.Security.SecurityId == securityId);
+    }
+
+    [Fact]
+    public async Task BuildSummaryAsync_WithMultiVenueIdentifier_PassesVenueFromTrialBalanceAccount()
+    {
+        var entry = BuildCompletedRun(symbol: "AAPL", financialAccountId: "ALPACA");
+        var resolved = new WorkstationSecurityReference(
+            SecurityId: Guid.NewGuid(),
+            DisplayName: "Apple Inc. via ALPACA",
+            AssetClass: "Equity",
+            Currency: "USD",
+            Status: SecurityStatusDto.Active,
+            PrimaryIdentifier: "AAPL");
+
+        var lookup = new Mock<ISecurityReferenceLookup>();
+        lookup
+            .Setup(l => l.GetByCanonicalAsync(
+                It.Is<SecurityReferenceLookupRequest>(request =>
+                    request.Symbol == "AAPL"
+                    && request.Venue == "ALPACA"
+                    && request.SecurityId is null
+                    && request.Source == "ledger-trial-balance"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resolved);
+
+        var service = new LedgerReadService(lookup.Object);
+        var summary = await service.BuildSummaryAsync(entry);
+
+        summary.Should().NotBeNull();
+        summary!.TrialBalance
+            .Where(static line => line.Symbol == "AAPL")
+            .Should()
+            .OnlyContain(line => line.Security is not null && line.Security.DisplayName.Contains("ALPACA"));
+    }
+
     [Fact]
     public void Constructor_NullLookup_Throws()
     {
@@ -218,7 +287,11 @@ public sealed class LedgerReadServiceTests
 
     // ── Helpers ──────────────────────────────────────────────────────────────
 
-    private static StrategyRunEntry BuildCompletedRun(string symbol = "AAPL")
+    private static StrategyRunEntry BuildCompletedRun(
+        string symbol = "AAPL",
+        string? financialAccountId = null,
+        Guid? securityId = null,
+        string? institution = null)
     {
         var startedAt = new DateTimeOffset(2026, 3, 1, 9, 30, 0, TimeSpan.Zero);
         var completedAt = startedAt.AddHours(8);
@@ -226,8 +299,8 @@ public sealed class LedgerReadServiceTests
         var ledger = new LedgerImpl();
         var cash = new LedgerAccount("Cash", LedgerAccountType.Asset);
         var ownerEquity = new LedgerAccount("Owner's Equity", LedgerAccountType.Equity);
-        var tradingGains = new LedgerAccount("Trading Gains", LedgerAccountType.Revenue, Symbol: symbol);
-        var commissions = new LedgerAccount("Commissions", LedgerAccountType.Expense, Symbol: symbol);
+        var tradingGains = new LedgerAccount("Trading Gains", LedgerAccountType.Revenue, Symbol: symbol, FinancialAccountId: financialAccountId);
+        var commissions = new LedgerAccount("Commissions", LedgerAccountType.Expense, Symbol: symbol, FinancialAccountId: financialAccountId);
 
         ledger.PostLines(startedAt, "initial-capital", new[]
         {
@@ -241,7 +314,7 @@ public sealed class LedgerReadServiceTests
             (tradingGains, 0m, 10_000m),
             (commissions, 50m, 0m),
             (cash, 0m, 50m),
-        });
+        }, new JournalEntryMetadata(Symbol: symbol, SecurityId: securityId, FinancialAccountId: financialAccountId, Institution: institution));
 
         return BuildEntryWithLedger(ledger, startedAt, completedAt, symbol);
     }

--- a/tests/Meridian.Tests/Strategies/PortfolioReadServiceTests.cs
+++ b/tests/Meridian.Tests/Strategies/PortfolioReadServiceTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Meridian.Backtesting.Sdk;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Contracts.Workstation;
+using Meridian.Ledger;
 using Meridian.Strategies.Models;
 using Meridian.Strategies.Services;
 using Moq;
@@ -237,6 +238,81 @@ public sealed class PortfolioReadServiceTests
         summary.Should().NotBeNull();
         summary!.SecurityResolvedCount.Should().Be(1);
         summary.SecurityMissingCount.Should().Be(1);
+    }
+
+
+    [Fact]
+    public async Task BuildSummaryAsync_WithAmbiguousSymbol_PrefersSecurityIdFromLedgerMetadata()
+    {
+        var entry = BuildCompletedRun(finalEquity: 120_000m, realizedPnl: 9_000m, unrealizedPnl: 4_000m);
+        var expectedSecurityId = Guid.NewGuid();
+
+        var ledger = new LedgerImpl();
+        var cash = new LedgerAccount("Cash", Meridian.Ledger.LedgerAccountType.Asset);
+        var gains = new LedgerAccount("Trading Gains", Meridian.Ledger.LedgerAccountType.Revenue, Symbol: "AAPL");
+        ledger.PostLines(
+            timestamp: new DateTimeOffset(2026, 3, 1, 16, 0, 0, TimeSpan.Zero),
+            description: "close-run",
+            lines:
+            [
+                (cash, 100m, 0m),
+                (gains, 0m, 100m)
+            ],
+            metadata: new JournalEntryMetadata(Symbol: "AAPL", SecurityId: expectedSecurityId, Institution: "XNAS"));
+
+        entry = entry with { Metrics = entry.Metrics! with { Ledger = ledger } };
+
+        var resolved = new WorkstationSecurityReference(
+            SecurityId: expectedSecurityId,
+            DisplayName: "Apple Inc. NASDAQ",
+            AssetClass: "Equity",
+            Currency: "USD",
+            Status: SecurityStatusDto.Active,
+            PrimaryIdentifier: "AAPL");
+
+        var lookup = new Mock<ISecurityReferenceLookup>();
+        lookup
+            .Setup(l => l.GetByCanonicalAsync(
+                It.Is<SecurityReferenceLookupRequest>(r =>
+                    r.Symbol == "AAPL"
+                    && r.SecurityId == expectedSecurityId
+                    && r.Source == "ledger-metadata-security-id"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resolved);
+
+        var service = new PortfolioReadService(lookup.Object);
+        var summary = await service.BuildSummaryAsync(entry);
+
+        summary.Should().NotBeNull();
+        summary!.Positions.Single(static p => p.Symbol == "AAPL").Security!.SecurityId.Should().Be(expectedSecurityId);
+    }
+
+    [Fact]
+    public async Task BuildSummaryAsync_WithCanonicalMiss_FallsBackToSymbolLookup()
+    {
+        var entry = BuildCompletedRun(finalEquity: 120_000m, realizedPnl: 9_000m, unrealizedPnl: 4_000m);
+
+        var fallback = new WorkstationSecurityReference(
+            SecurityId: Guid.NewGuid(),
+            DisplayName: "Apple Inc.",
+            AssetClass: "Equity",
+            Currency: "USD",
+            Status: SecurityStatusDto.Active,
+            PrimaryIdentifier: "AAPL");
+
+        var lookup = new Mock<ISecurityReferenceLookup>();
+        lookup
+            .Setup(l => l.GetByCanonicalAsync(It.IsAny<SecurityReferenceLookupRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WorkstationSecurityReference?)null);
+        lookup
+            .Setup(l => l.GetBySymbolAsync("AAPL", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fallback);
+
+        var service = new PortfolioReadService(lookup.Object);
+        var summary = await service.BuildSummaryAsync(entry);
+
+        summary.Should().NotBeNull();
+        summary!.Positions.Single(static p => p.Symbol == "AAPL").Security!.DisplayName.Should().Be("Apple Inc.");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Improve accuracy and traceability of security lookups by using richer canonical identity keys (security id, identifier kind/value, venue, etc.) instead of relying on raw symbol strings. 
- Surface where a match came from so governance and audit surfaces can distinguish exact vs inferred/looked-up matches.

### Description
- Introduced `SecurityReferenceLookupRequest` and added `GetByCanonicalAsync` to `ISecurityReferenceLookup`, with a symbol-fallback default implementation using `GetBySymbolAsync` when richer input is not available. (`src/Meridian.Strategies/Services/ISecurityReferenceLookup.cs`).
- Refactored `PortfolioReadService` to build canonical lookup requests from run artifacts (including single-candidate `SecurityId` from ledger metadata when present), resolve via canonical-first then symbol fallback, and annotate resolved `WorkstationSecurityReference` entries with `LookupPath`, `LookupSource`, and `IsInferredMatch`. (`src/Meridian.Strategies/Services/PortfolioReadService.cs`).
- Refactored `LedgerReadService` to key lookups by `(symbol, financialAccountId)`, derive per-key `SecurityId`/`Venue` from journal metadata when available, perform canonical-first resolution with symbol fallback, and stamp traceability on results. (`src/Meridian.Strategies/Services/LedgerReadService.cs`).
- Implemented canonical-resolution logic in the Security Master adapter `SecurityMasterSecurityReferenceLookup` to prefer `SecurityId` → identifier(+venue) → ticker, and to populate matched-kind/value/provider and lookup trace fields. (`src/Meridian.Ui.Shared/Services/SecurityMasterSecurityReferenceLookup.cs`).
- Extended `WorkstationSecurityReference` with governance traceability fields: `LookupPath`, `LookupSource`, and `IsInferredMatch`. (`src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs`).
- Added targeted unit tests to cover ambiguous-symbol and multi-venue scenarios and canonical-fallback behavior in:
  - `tests/Meridian.Tests/Strategies/PortfolioReadServiceTests.cs` (ambiguous symbol preference from ledger metadata and canonical-miss fallback)
  - `tests/Meridian.Tests/Strategies/LedgerReadServiceTests.cs` (venue-aware canonical lookup and trial-balance venue routing)

### Testing
- Added unit tests in `tests/Meridian.Tests/Strategies/PortfolioReadServiceTests.cs` and `tests/Meridian.Tests/Strategies/LedgerReadServiceTests.cs` exercising ambiguous-symbol, metadata-driven resolution, venue propagation, and canonical-vs-symbol fallback; these tests are included in the diff. 
- Attempted to run the targeted test filter via `dotnet test` in this environment but execution failed because `dotnet` is not present (`/bin/bash: dotnet: command not found`). No test run results are available from this environment.
- Manual code inspection and compilation assumptions were used to ensure consistent API changes and default symbol-fallback behavior; follow-up CI should run full test suite to validate behavior on a machine with the .NET SDK available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91f36d41c8320a04242a13a04f54e)