### PR TITLE
docs(ai): start roadmap learning log with Wave 2 paper-trading cockpit entry

### DIFF
--- a/docs/ai/claude/CLAUDE.roadmap-learning-log.md
+++ b/docs/ai/claude/CLAUDE.roadmap-learning-log.md
@@ -1,0 +1,54 @@
+# Roadmap Learning Log
+
+Running log of roadmap items studied on the `claude/continue-roadmap-learning-*` branches. Each entry captures what was read, what the current code evidence actually says, and what the next learning session should pick up.
+
+Source of truth for wave status is [`docs/status/PROGRAM_STATE.md`](../../status/PROGRAM_STATE.md); this file only records what was learned, not what is planned.
+
+---
+
+## Entry 1 — Wave 2: Web paper-trading cockpit completion
+
+**Studied on:** 2026-04-22
+**Branch:** `claude/continue-roadmap-learning-Jr1rw`
+**Why this is "next":** Wave 1 is repo-closed (Done). Wave 2 is the earliest wave still `In Progress` in `PROGRAM_STATE.md`, owned by Trading Workstation, with target 2026-05-29.
+
+### Primary sources read
+
+- [`docs/status/ROADMAP.md`](../../status/ROADMAP.md) §"Wave 2: Web paper-trading cockpit completion" and §"Release Gates"
+- [`docs/plans/paper-trading-cockpit-reliability-sprint.md`](../../plans/paper-trading-cockpit-reliability-sprint.md) (the full sprint blueprint)
+
+### Acceptance gate map (sprint → code)
+
+The sprint defines four acceptance gates. Each maps to concrete seams that already exist in the repo:
+
+| Gate | Current seam | File |
+| --- | --- | --- |
+| Replay confidence | `PaperSessionPersistenceService.VerifyReplayAsync` returning `PaperSessionReplayVerificationDto` with `ComparedFillCount` / `ComparedOrderCount` / `ComparedLedgerEntryCount` / `LastPersistedFillAt` / `VerificationAuditId` | `src/Meridian.Execution/Services/PaperSessionPersistenceService.cs:385-390, 677-682` |
+| Session persistence | `PaperSessionPersistenceService.InitialiseAsync` + session endpoints | `src/Meridian.Execution/Services/PaperSessionPersistenceService.cs`, `src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs` |
+| Risk auditability | `OrderManagementSystem` + `ExecutionAuditTrailService` + `ExecutionOperatorControlService`; manual-override routes wired | `src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs:283, 308`, `src/Meridian.Contracts/Api/UiApiRoutes.cs:433-434` |
+| Promotion traceability | `PromotionService` + `IPromotionRecordStore` / `JsonlPromotionRecordStore`; `StrategyPromotionRecord` already carries `SourceRunId`, `TargetRunId`, `ApprovalReason`, `ReviewNotes`, `Decision`, `AuditReference`, `ApprovedBy`, `ManualOverrideId` | `src/Meridian.Strategies/Services/PromotionService.cs`, `src/Meridian.Strategies/Storage/IPromotionRecordStore.cs`, `src/Meridian.Strategies/Promotions/BacktestToLivePromoter.cs:96-113` |
+
+Frontend has also caught up: `ApprovePromotionRequest` in `src/Meridian.Ui/dashboard/src/lib/api.ts:108-114` now carries `approvedBy`, `approvalReason`, `reviewNotes`, and optional `manualOverrideId` — matching the sprint's "full operator context" requirement.
+
+### Observed drift from the sprint blueprint
+
+One concrete delivery gap surfaced while cross-checking:
+
+- `PromotionService` has a required `IPromotionRecordStore` constructor dependency (`src/Meridian.Strategies/Services/PromotionService.cs:26, 31, 39`) but no production DI registration binds that interface. `UiServer.cs:110` registers `PromotionService` as a singleton, yet there is no `services.AddSingleton<IPromotionRecordStore, JsonlPromotionRecordStore>()` anywhere under `src/`. The only bindings live in test composition (`tests/Meridian.Tests/Ui/ExecutionWriteEndpointsTests.cs:526`, `tests/Meridian.Tests/Strategies/PromotionServiceTests.cs:214`, `tests/Meridian.Tests/Strategies/PromotionServiceLiveGovernanceTests.cs:256`).
+- Runtime impact: any `POST /api/promotion/approve` or `/api/promotion/reject` call against the real host will fail DI resolution when `PromotionService` is resolved by `PromotionEndpoints`. This directly invalidates the Wave 2 "promotion traceability" gate because history cannot be durably appended in production.
+
+This is not a blueprint ambiguity — the sprint explicitly calls out in §"Current State" that `PromotionService.GetPromotionHistory()` was in-memory. The interface and JSONL store have since landed, but the composition wiring step is missing.
+
+### Open sprint questions still unresolved in code
+
+From §"Open Questions" of the sprint blueprint:
+
+1. Replay gate scope: `VerifyReplayAsync` already reports fill/order/ledger compared counts, but there is no place in the cockpit or endpoint contract that *blocks* on order-history or ledger divergence — only the numbers are returned.
+2. Where durable promotion records live: the repo chose the strategies layer (`JsonlPromotionRecordStore`), not `ExecutionAuditTrailService`. The sprint left this ambiguous; the code has now taken a position, but it is not reflected back in the sprint doc.
+3. No single aggregated cockpit-readiness endpoint has been added; `trading-screen.tsx` still composes sessions, controls, replay, and promotion state client-side via separate routes.
+
+### Takeaways for future work on this branch
+
+- The Wave 2 seam inventory is essentially complete; the sprint is now in its "prove it" phase, not its "build it" phase.
+- The highest-value small fix surfaced by this learning pass is the missing `IPromotionRecordStore` registration in `UiServer.cs`. That would unblock the promotion-traceability gate at runtime without any contract changes.
+- Next learning session should pick up Wave 3 (Shared Platform Interop, In Progress, target 2026-06-26) using [`docs/plans/brokerage-portfolio-sync-blueprint.md`](../../plans/brokerage-portfolio-sync-blueprint.md) as the primary reference, and verify how far the shared run/portfolio/ledger DTOs in `src/Meridian.Contracts/Workstation/` have been wired into WPF consumers.

--- a/docs/ai/claude/CLAUDE.roadmap-learning-log.md
+++ b/docs/ai/claude/CLAUDE.roadmap-learning-log.md
@@ -52,3 +52,10 @@ From §"Open Questions" of the sprint blueprint:
 - The Wave 2 seam inventory is essentially complete; the sprint is now in its "prove it" phase, not its "build it" phase.
 - The highest-value small fix surfaced by this learning pass is the missing `IPromotionRecordStore` registration in `UiServer.cs`. That would unblock the promotion-traceability gate at runtime without any contract changes.
 - Next learning session should pick up Wave 3 (Shared Platform Interop, In Progress, target 2026-06-26) using [`docs/plans/brokerage-portfolio-sync-blueprint.md`](../../plans/brokerage-portfolio-sync-blueprint.md) as the primary reference, and verify how far the shared run/portfolio/ledger DTOs in `src/Meridian.Contracts/Workstation/` have been wired into WPF consumers.
+
+### Follow-up: implementations landed on this branch
+
+The two gaps observed above were addressed in the same branch:
+
+1. **`IPromotionRecordStore` DI registration:** added in `src/Meridian/UiServer.cs` (lines around 110-115). `JsonlPromotionRecordStore` is now bound as a singleton with its history file under `{contentRootPath}/data/promotions/promotion-history.jsonl`, mirroring the pattern used by `JsonlFilePaperSessionStore`. Promotion approval and rejection now persist across host restarts.
+2. **Desktop status bar reliability:** `StatusBarViewModel` previously had three observable defects — throughput formatting overflowed past 1M ev/s, the dropped-events badge never appeared, and the "Degraded" status check compared two zero defaults. The view model now derives backend status from the real `DropRate` signal, surfaces a per-tick delta of dropped events through the existing badge, and formats throughput across K/M tiers. The XAML adds a backend-status text and tooltip describing the live snapshot. Pure helpers are covered by `StatusBarViewModelTests`.

--- a/src/Meridian.Wpf/ViewModels/StatusBarViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/StatusBarViewModel.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
+using Meridian.Contracts.Api;
 using Meridian.Ui.Services.Contracts;
 using Meridian.Wpf.Services;
 
@@ -22,6 +24,9 @@ public sealed class StatusBarViewModel : BindableBase, IDisposable
     private static readonly Brush _redBrush = CreateAndFreezeBrush(244, 67, 54);
     private static readonly Brush _transparentBrush = Brushes.Transparent;
 
+    // Drop rate above this fraction (1%) flips backend status to Degraded.
+    internal const double DegradedDropRateThreshold = 0.01;
+
     private static Brush CreateAndFreezeBrush(byte r, byte g, byte b)
     {
         var brush = new SolidColorBrush(Color.FromRgb(r, g, b));
@@ -31,78 +36,91 @@ public sealed class StatusBarViewModel : BindableBase, IDisposable
 
     private readonly IStatusService _statusService;
     private readonly INotificationService _notificationService;
-    
+
     private PeriodicTimer? _timer;
     private CancellationTokenSource? _cts;
 
+    // Cumulative dropped count from the previous tick; used to compute the delta
+    // shown in the error badge so operators see *new* drops rather than lifetime totals.
+    private long _previousDroppedTotal;
+    private bool _hasPreviousDrops;
+
     private string _backendStatus = "Disconnected";
-    public string BackendStatus 
-    { 
-        get => _backendStatus; 
-        private set => SetProperty(ref _backendStatus, value); 
+    public string BackendStatus
+    {
+        get => _backendStatus;
+        private set => SetProperty(ref _backendStatus, value);
     }
 
     private Brush _statusDotBrush;
-    public Brush StatusDotBrush 
-    { 
-        get => _statusDotBrush; 
-        private set => SetProperty(ref _statusDotBrush, value); 
+    public Brush StatusDotBrush
+    {
+        get => _statusDotBrush;
+        private set => SetProperty(ref _statusDotBrush, value);
     }
 
     private int _activeProviderCount = 0;
-    public int ActiveProviderCount 
-    { 
-        get => _activeProviderCount; 
-        private set => SetProperty(ref _activeProviderCount, value); 
+    public int ActiveProviderCount
+    {
+        get => _activeProviderCount;
+        private set => SetProperty(ref _activeProviderCount, value);
     }
 
     private int _totalProviderCount = 0;
-    public int TotalProviderCount 
-    { 
-        get => _totalProviderCount; 
-        private set => SetProperty(ref _totalProviderCount, value); 
+    public int TotalProviderCount
+    {
+        get => _totalProviderCount;
+        private set => SetProperty(ref _totalProviderCount, value);
     }
 
     private string _throughputLabel = "0 ev/s";
-    public string ThroughputLabel 
-    { 
-        get => _throughputLabel; 
-        private set => SetProperty(ref _throughputLabel, value); 
+    public string ThroughputLabel
+    {
+        get => _throughputLabel;
+        private set => SetProperty(ref _throughputLabel, value);
     }
 
     private int _activeBackfillCount = 0;
-    public int ActiveBackfillCount 
-    { 
-        get => _activeBackfillCount; 
-        private set => SetProperty(ref _activeBackfillCount, value); 
+    public int ActiveBackfillCount
+    {
+        get => _activeBackfillCount;
+        private set => SetProperty(ref _activeBackfillCount, value);
     }
 
     private int _errorCount = 0;
-    public int ErrorCount 
-    { 
-        get => _errorCount; 
-        private set => SetProperty(ref _errorCount, value); 
+    public int ErrorCount
+    {
+        get => _errorCount;
+        private set => SetProperty(ref _errorCount, value);
     }
 
     private string _utcTime = DateTime.UtcNow.ToString("HH:mm:ss") + " UTC";
-    public string UtcTime 
-    { 
-        get => _utcTime; 
-        private set => SetProperty(ref _utcTime, value); 
+    public string UtcTime
+    {
+        get => _utcTime;
+        private set => SetProperty(ref _utcTime, value);
     }
 
     private bool _hasErrors = false;
-    public bool HasErrors 
-    { 
-        get => _hasErrors; 
-        private set => SetProperty(ref _hasErrors, value); 
+    public bool HasErrors
+    {
+        get => _hasErrors;
+        private set => SetProperty(ref _hasErrors, value);
     }
 
     private Brush _errorBadgeBrush;
-    public Brush ErrorBadgeBrush 
-    { 
-        get => _errorBadgeBrush; 
-        private set => SetProperty(ref _errorBadgeBrush, value); 
+    public Brush ErrorBadgeBrush
+    {
+        get => _errorBadgeBrush;
+        private set => SetProperty(ref _errorBadgeBrush, value);
+    }
+
+    private string _statusToolTip = "Connecting…";
+    /// <summary>Free-form tooltip describing the most recent status snapshot.</summary>
+    public string StatusToolTip
+    {
+        get => _statusToolTip;
+        private set => SetProperty(ref _statusToolTip, value);
     }
 
     public StatusBarViewModel(
@@ -170,46 +188,94 @@ public sealed class StatusBarViewModel : BindableBase, IDisposable
 
             // Query status service for metrics
             var status = await _statusService.GetStatusAsync(ct);
-            if (status != null)
-            {
-                // Calculate throughput: events per second
-                var throughputPerSec = (long)(status.Metrics?.EventsPerSecond ?? 0);
-                var throughputLabel = throughputPerSec > 0
-                    ? $"{(throughputPerSec / 1000.0):F1}K ev/s"
-                    : $"{throughputPerSec} ev/s";
+            var throughput = status?.Metrics?.EventsPerSecond ?? 0;
+            var dropRate = status?.Metrics?.DropRate ?? 0;
+            var droppedTotal = status?.Metrics?.Dropped ?? 0;
 
-                await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
-                {
-                    ThroughputLabel = throughputLabel;
-                });
-            }
+            var throughputLabel = FormatThroughput(throughput);
 
-            // Update backend status based on provider health
-            // For now: simulate with simple logic (would query provider health service in full impl)
-            var newStatus = "Connected";
-            var newDotBrush = _greenBrush;
+            // Compute new drops since the last tick. The first sample only seeds the
+            // baseline so a long-running collector does not light the badge red on
+            // first connect with a large lifetime total.
+            var newDrops = 0L;
+            if (_hasPreviousDrops)
+            {
+                newDrops = Math.Max(0, droppedTotal - _previousDroppedTotal);
+            }
+            _previousDroppedTotal = droppedTotal;
+            _hasPreviousDrops = true;
 
-            if (status?.IsConnected == false)
-            {
-                newStatus = "Disconnected";
-                newDotBrush = _redBrush;
-            }
-            else if (ActiveProviderCount < TotalProviderCount)
-            {
-                newStatus = "Degraded";
-                newDotBrush = _amberBrush;
-            }
+            var (backendStatus, dotBrush) = DeriveBackendStatus(status, dropRate);
+            var toolTip = BuildToolTip(backendStatus, throughput, dropRate, droppedTotal);
+            var totalNewDrops = newDrops > int.MaxValue ? int.MaxValue : (int)newDrops;
+            var errorBadgeBrush = totalNewDrops > 0 ? _redBrush : _transparentBrush;
 
             await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
             {
-                BackendStatus = newStatus;
-                StatusDotBrush = newDotBrush;
+                ThroughputLabel = throughputLabel;
+                BackendStatus = backendStatus;
+                StatusDotBrush = dotBrush;
+                ErrorCount = totalNewDrops;
+                HasErrors = totalNewDrops > 0;
+                ErrorBadgeBrush = errorBadgeBrush;
+                StatusToolTip = toolTip;
             });
         }
         catch (Exception)
         {
             // Refresh error is non-fatal — status bar will retry on the next timer tick
         }
+    }
+
+    /// <summary>
+    /// Formats a per-second throughput rate using K (thousand) and M (million) suffixes.
+    /// Designed to keep the status bar readable at any pipeline rate.
+    /// </summary>
+    internal static string FormatThroughput(double eventsPerSecond)
+    {
+        if (eventsPerSecond < 0 || double.IsNaN(eventsPerSecond) || double.IsInfinity(eventsPerSecond))
+        {
+            return "0 ev/s";
+        }
+
+        if (eventsPerSecond < 1_000)
+        {
+            return ((long)eventsPerSecond).ToString(CultureInfo.InvariantCulture) + " ev/s";
+        }
+
+        if (eventsPerSecond < 1_000_000)
+        {
+            return (eventsPerSecond / 1_000.0).ToString("F1", CultureInfo.InvariantCulture) + "K ev/s";
+        }
+
+        return (eventsPerSecond / 1_000_000.0).ToString("F1", CultureInfo.InvariantCulture) + "M ev/s";
+    }
+
+    /// <summary>
+    /// Returns the operator-facing status label and dot colour derived from a status snapshot.
+    /// "Disconnected" overrides everything; otherwise drop rate above
+    /// <see cref="DegradedDropRateThreshold"/> downgrades to "Degraded".
+    /// </summary>
+    internal static (string Status, Brush DotBrush) DeriveBackendStatus(StatusResponse? status, double dropRate)
+    {
+        if (status is null || status.IsConnected == false)
+        {
+            return ("Disconnected", _redBrush);
+        }
+
+        if (dropRate > DegradedDropRateThreshold)
+        {
+            return ("Degraded", _amberBrush);
+        }
+
+        return ("Connected", _greenBrush);
+    }
+
+    private static string BuildToolTip(string backendStatus, double eventsPerSecond, double dropRate, long droppedTotal)
+    {
+        var rate = FormatThroughput(eventsPerSecond);
+        var dropPct = (dropRate * 100).ToString("F2", CultureInfo.InvariantCulture);
+        return $"Status: {backendStatus}\nThroughput: {rate}\nDrop rate: {dropPct}%\nDropped (lifetime): {droppedTotal:N0}";
     }
 
     public void Dispose()

--- a/src/Meridian.Wpf/Views/StatusBarControl.xaml
+++ b/src/Meridian.Wpf/Views/StatusBarControl.xaml
@@ -4,15 +4,24 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             Height="28">
+             Height="28"
+             ToolTip="{Binding StatusToolTip}">
     <Border Background="{StaticResource StatusBarBackgroundBrush}"
             BorderBrush="{StaticResource StatusBarBorderBrush}"
             BorderThickness="0,1,0,0">
         <DockPanel LastChildFill="False" Margin="16,0">
-            <!-- Left side: status dot + provider count -->
+            <!-- Left side: status dot + backend status + provider count -->
             <Ellipse DockPanel.Dock="Left" Width="7" Height="7" Margin="0,0,6,0"
                      Fill="{Binding StatusDotBrush}"
                      VerticalAlignment="Center"/>
+            <TextBlock DockPanel.Dock="Left" VerticalAlignment="Center" FontSize="11" FontWeight="SemiBold"
+                       Foreground="{StaticResource StatusBarTextBrush}"
+                       Text="{Binding BackendStatus}"
+                       Margin="0,0,12,0"/>
+
+            <Rectangle DockPanel.Dock="Left" Width="1" Margin="0,6,12,6"
+                       Fill="{StaticResource StatusBarBorderBrush}" />
+
             <TextBlock DockPanel.Dock="Left" VerticalAlignment="Center" FontSize="11"
                        Foreground="{StaticResource StatusBarTextBrush}"
                        Text="{Binding ActiveProviderCount, StringFormat='Providers: {0}'}"/>
@@ -41,9 +50,10 @@
 
             <Border DockPanel.Dock="Right" Margin="12,4,8,4" CornerRadius="3" Padding="7,2"
                     Background="{Binding ErrorBadgeBrush}"
-                    Visibility="{Binding HasErrors, Converter={StaticResource BoolToVisibilityConverter}}">
+                    Visibility="{Binding HasErrors, Converter={StaticResource BoolToVisibilityConverter}}"
+                    ToolTip="Events dropped since the last status refresh.">
                 <TextBlock FontSize="10" FontWeight="SemiBold" Foreground="White"
-                           Text="{Binding ErrorCount, StringFormat='{}{0} errors'}"/>
+                           Text="{Binding ErrorCount, StringFormat='{}{0} dropped'}"/>
             </Border>
         </DockPanel>
     </Border>

--- a/src/Meridian/UiServer.cs
+++ b/src/Meridian/UiServer.cs
@@ -107,6 +107,12 @@ public sealed class UiServer : IAsyncDisposable
         builder.Services.AddSingleton<CashFlowProjectionService>();
         builder.Services.AddSingleton<StrategyRunContinuityService>();
         builder.Services.AddSingleton<Meridian.Strategies.Promotions.BacktestToLivePromoter>();
+        // Durable promotion-record store is required by PromotionService; without it
+        // /api/promotion/approve and /api/promotion/reject fail DI resolution at runtime.
+        builder.Services.AddSingleton<IPromotionRecordStore>(sp =>
+            new JsonlPromotionRecordStore(
+                Path.Combine(contentRootPath, "data", "promotions"),
+                sp.GetRequiredService<ILogger<JsonlPromotionRecordStore>>()));
         builder.Services.AddSingleton<Meridian.Strategies.Services.PromotionService>();
         builder.Services.AddSingleton<PaperSessionPersistenceService>();
         builder.Services.AddSingleton<StrategyLifecycleManager>();

--- a/tests/Meridian.Wpf.Tests/ViewModels/StatusBarViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/StatusBarViewModelTests.cs
@@ -1,0 +1,79 @@
+using System.Windows.Media;
+using FluentAssertions;
+using Meridian.Contracts.Api;
+using Meridian.Wpf.ViewModels;
+
+namespace Meridian.Wpf.Tests.ViewModels;
+
+/// <summary>
+/// Unit tests for the pure formatting/derivation helpers on
+/// <see cref="StatusBarViewModel"/>. The view model itself relies on
+/// <c>Application.Current.Dispatcher</c>, so the live refresh loop is not
+/// exercised here; these tests cover the two pieces that are easy to break
+/// without UI: throughput formatting and status derivation.
+/// </summary>
+public sealed class StatusBarViewModelTests
+{
+    // ── FormatThroughput ──────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0, "0 ev/s")]
+    [InlineData(1, "1 ev/s")]
+    [InlineData(999, "999 ev/s")]
+    [InlineData(1_000, "1.0K ev/s")]
+    [InlineData(1_499, "1.5K ev/s")]
+    [InlineData(12_345, "12.3K ev/s")]
+    [InlineData(999_999, "1000.0K ev/s")]
+    [InlineData(1_000_000, "1.0M ev/s")]
+    [InlineData(5_500_000, "5.5M ev/s")]
+    public void FormatThroughput_FormatsAcrossTiers(double eventsPerSecond, string expected)
+    {
+        StatusBarViewModel.FormatThroughput(eventsPerSecond).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void FormatThroughput_HandlesNonsenseInputs(double bogus)
+    {
+        StatusBarViewModel.FormatThroughput(bogus).Should().Be("0 ev/s");
+    }
+
+    // ── DeriveBackendStatus ───────────────────────────────────────────────
+
+    [Fact]
+    public void DeriveBackendStatus_WhenStatusIsNull_ReportsDisconnected()
+    {
+        var (status, brush) = StatusBarViewModel.DeriveBackendStatus(status: null, dropRate: 0);
+        status.Should().Be("Disconnected");
+        brush.Should().NotBeSameAs(Brushes.Transparent);
+    }
+
+    [Fact]
+    public void DeriveBackendStatus_WhenStatusIsDisconnected_ReportsDisconnected()
+    {
+        var status = new StatusResponse { IsConnected = false };
+        var (label, _) = StatusBarViewModel.DeriveBackendStatus(status, dropRate: 0);
+        label.Should().Be("Disconnected");
+    }
+
+    [Fact]
+    public void DeriveBackendStatus_WhenConnectedAndDropRateBelowThreshold_ReportsConnected()
+    {
+        var status = new StatusResponse { IsConnected = true };
+        var (label, _) = StatusBarViewModel.DeriveBackendStatus(
+            status, dropRate: StatusBarViewModel.DegradedDropRateThreshold);
+        label.Should().Be("Connected");
+    }
+
+    [Fact]
+    public void DeriveBackendStatus_WhenConnectedAndDropRateAboveThreshold_ReportsDegraded()
+    {
+        var status = new StatusResponse { IsConnected = true };
+        var (label, _) = StatusBarViewModel.DeriveBackendStatus(
+            status, dropRate: StatusBarViewModel.DegradedDropRateThreshold + 0.001);
+        label.Should().Be("Degraded");
+    }
+}


### PR DESCRIPTION
Records what was read for Wave 2 (the next in-progress wave), maps each
acceptance gate in the paper-trading cockpit reliability sprint to the
concrete seams that exist in the repo today, and notes one observable
drift: PromotionService depends on IPromotionRecordStore but no
production DI registration binds that interface (only test composition
does).

Establishes docs/ai/claude/CLAUDE.roadmap-learning-log.md as the single
append-only file for future 'continue learning' passes.