### PR TITLE
Fix cancellation-token fallback in native Backtest Studio engine

### DIFF
--- a/src/Meridian.Backtesting/MeridianNativeBacktestStudioEngine.cs
+++ b/src/Meridian.Backtesting/MeridianNativeBacktestStudioEngine.cs
@@ -123,7 +123,7 @@ public sealed class MeridianNativeBacktestStudioEngine : IBacktestStudioEngine
         }
         catch (OperationCanceledException ex)
         {
-            registration.Cancel(ex.CancellationToken.CanBeCanceled ? ex.CancellationToken : ct);
+            registration.Cancel(ex.CancellationToken.CanBeCanceled ? ex.CancellationToken : runToken);
             FinalizeTerminalRun(registration);
         }
         catch (Exception ex)


### PR DESCRIPTION
### Motivation
- Prevent a compile-time error and incorrect cancellation recording caused by referencing `ct` (out-of-scope) inside `ExecuteAsync`'s `OperationCanceledException` handler.

### Description
- Replaced the out-of-scope fallback token `ct` with the per-run token `runToken` in `src/Meridian.Backtesting/MeridianNativeBacktestStudioEngine.cs` inside the `catch (OperationCanceledException)` block.

### Testing
- Ran `python3 build/scripts/ai-repo-updater.py known-errors` which completed successfully.
- Ran `python3 build/scripts/ai-repo-updater.py audit-code --summary` which completed successfully and was used to validate the change.
- Attempted `dotnet restore` / `make test` but they failed in the container due to `dotnet` not being installed, so full build/tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a5582bf88320a66c333be8611388)