### PR TITLE
chore: refresh .claude skill catalog and agent stubs

### DIFF
--- a/.claude/agents/meridian-archive-organizer.md
+++ b/.claude/agents/meridian-archive-organizer.md
@@ -1,0 +1,23 @@
+---
+name: meridian-archive-organizer
+description: >
+  Archive and repository-structure specialist for Meridian. Decides whether files
+  should remain active, move to archive buckets, or be relocated to clearer
+  ownership paths while preserving traceability.
+tools: ["read", "search", "edit", "mcp"]
+---
+
+# Meridian — Archive Organizer
+
+Use this agent when users ask where content should live, whether a file is stale,
+or to archive deprecated/superseded docs and code with evidence-backed moves.
+
+> **Skill equivalent:** [`.claude/skills/meridian-archive-organizer/SKILL.md`](../skills/meridian-archive-organizer/SKILL.md)
+> **Shared project context:** [`.claude/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+
+## Workflow
+
+1. Read the target files and identify active owner subsystem.
+2. Classify each item as active, reference-only, historical, or superseded.
+3. Move/archive only with a reference trace and rationale.
+4. Verify links and paths after any move.

--- a/.claude/agents/meridian-repo-navigation.md
+++ b/.claude/agents/meridian-repo-navigation.md
@@ -1,0 +1,20 @@
+---
+name: meridian-repo-navigation
+description: >
+  Orientation specialist for Meridian. Quickly routes tasks to owning subsystem,
+  key entrypoints, and authoritative documentation before implementation.
+tools: ["read", "search", "mcp"]
+---
+
+# Meridian — Repo Navigation Specialist
+
+Use this agent to map user requests to the correct Meridian subsystem and first files.
+
+> **Skill equivalent:** [`.claude/skills/meridian-repo-navigation/SKILL.md`](../skills/meridian-repo-navigation/SKILL.md)
+> **Shared project context:** [`.claude/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+
+## Workflow
+
+1. Identify the requested capability and likely owning subsystem.
+2. Surface first-read files and high-signal entrypoints.
+3. Route to downstream specialist skills for deep work.

--- a/.claude/agents/meridian-roadmap-strategist.md
+++ b/.claude/agents/meridian-roadmap-strategist.md
@@ -1,0 +1,21 @@
+---
+name: meridian-roadmap-strategist
+description: >
+  Roadmap strategy specialist for Meridian. Builds and refreshes phased delivery
+  plans, opportunity maps, and target-state summaries tied to implementation flow.
+tools: ["read", "search", "edit", "mcp"]
+---
+
+# Meridian — Roadmap Strategist
+
+Use this agent when users request roadmap creation, roadmap updates, phased plans,
+or product-direction synthesis.
+
+> **Skill equivalent:** [`.claude/skills/meridian-roadmap-strategist/SKILL.md`](../skills/meridian-roadmap-strategist/SKILL.md)
+> **Shared project context:** [`.claude/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+
+## Workflow
+
+1. Gather current roadmap and active initiative context.
+2. Propose phased delivery with dependencies and risk notes.
+3. Map each phase to implementation-ready follow-up artifacts.

--- a/.claude/skills/meridian-archive-organizer/SKILL.md
+++ b/.claude/skills/meridian-archive-organizer/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: meridian-archive-organizer
+description: Archive deprecated, superseded, historical, or misplaced Meridian code and documentation while keeping the repository structure organized. Use when Codex needs to decide whether a file should stay active or move into `archive/`, relocate outdated code or docs into the correct archive bucket, clean up folder sprawl, answer "where should this live?" for Meridian repository-structure work, or perform an evidence-backed archive/reference-trace pass with repeatable validation.
+---
+
+# Meridian Archive Organizer
+
+Use this skill when the task is to retire stale material without losing useful history or making Meridian harder to navigate.
+
+Read these in order:
+1. `../_shared/project-context.md`
+2. `../../../archive/docs/README.md`
+3. `references/archive-placement-guide.md`
+4. `references/evaluation-harness.md` before finalizing a broad archive sweep or changing this skill
+
+## Definition of Done
+
+A task handled with this skill is complete only when all of the following are true:
+
+- Each target has an explicit classification: `active`, `archive-doc`, `archive-code`, `delete`, or `already-archived`.
+- Strong references and weak references are separated, either by direct reasoning or by `scripts/trace_archive_candidates.py`.
+- The destination matches the archive bucket or active folder rules in `references/archive-placement-guide.md`.
+- Any moved documentation has its README, index, or nearby cross-link updated.
+- A narrow validation command or trace artifact is cited in the final response.
+- For ambiguous, multi-file, or skill-evolution work, `references/evaluation-harness.md` is used and the eval result is reported.
+
+## Classification Lanes
+
+Choose a lane before moving anything:
+
+### `dated-doc-snapshot`
+
+Use for date-stamped status, audit, roadmap, or one-off narrative documents.
+
+- Archive when strong references are gone and only weak references remain.
+- Prefer `archive/docs/summaries/` unless the document is clearly an assessment, plan, or migration note.
+
+### `automation-owned-surface`
+
+Use for generated or machine-readable documentation artifacts that look stale but are still owned by repo tooling.
+
+- Keep active when docs/build/workflow tooling explicitly writes or consumes the file.
+- Typical examples: `docs/status/*.json`, `docs/generated/*`, and current docs automation outputs.
+
+### `local-scratch`
+
+Use for hidden folders, logs, ad hoc captures, and local tool output.
+
+- Prefer `delete` or `.gitignore`, not archive.
+- Treat `.playwright-cli/`, transient logs, and scratch captures as this lane unless the user explicitly wants historical retention.
+
+### `retired-code`
+
+Use for code or tests that may need historical retention.
+
+- Require stronger evidence than docs lanes: build/test safety, project inclusion awareness, and caller/link/doc checks.
+- Prefer mirroring the original relative path beneath `archive/code/`.
+
+## Workflow
+
+1. Pick the classification lane that matches the target.
+2. Gather evidence before moving anything: active references, project or solution inclusion, docs links, test usage, and whether the item still reflects current guidance.
+3. Use `scripts/trace_archive_candidates.py` for docs, dated snapshots, JSON sidecars, or root-structure ambiguity.
+3. Apply the smallest structure-preserving move:
+   - keep current material in canonical active folders
+   - move historical docs into the right `archive/docs/<bucket>/` folder
+   - move retired code into `archive/code/` and preserve the original relative path when practical
+4. Update indexes, links, or nearby docs when discoverability changes.
+5. Run the narrowest validation that proves the move did not break build, test, or documentation navigation.
+6. For broad or ambiguous sweeps, run the evaluation harness.
+7. Report what moved, why it moved, what stayed active, and any follow-up cleanup still worth doing.
+
+## Decision Rules
+
+- Keep files active when they are executable, referenced, or still define current guidance.
+- Keep generated documentation outputs active when the automation/docs tooling explicitly writes them there and surrounding docs treat them as current machine-readable surfaces.
+- Treat references from active README files, planning indexes, and human-maintained guidance as strong evidence that a document should stay active.
+- Downgrade README or sibling-doc references when they explicitly frame the target as a historical snapshot, prior review context, or archived background rather than current guidance.
+- Treat references from generated tree listings, stale validation reports, and inventory-style snapshots as weak evidence; they do not by themselves keep a dated document active.
+- Treat references coming only from already archived material as weak historical evidence, not proof that the active copy must stay where it is.
+- Ignore `.codex/`, `.claude/`, and similar AI/worktree mirror content as archive evidence unless the user explicitly asks to audit those surfaces too.
+- Archive documentation instead of deleting it when it has historical, audit, migration, or planning value.
+- Archive code instead of deleting it when it is no longer part of the active build or test graph but may still matter for migration context, rollback archaeology, or reference.
+- Delete only low-value artifacts with no reference value, such as transient outputs, duplicates, or generated clutter that should not live in git.
+- When evidence is incomplete, prefer archiving over deletion and say what remains uncertain.
+
+## Placement Rules
+
+- Use `archive/docs/assessments/` for audits, evaluations, and analysis reports.
+- Use `archive/docs/plans/` for completed, superseded, or abandoned plans and cleanup roadmaps.
+- Use `archive/docs/summaries/` for snapshots, one-off reports, and historical status notes.
+- Use `archive/docs/migrations/` for legacy migration or platform-transition material.
+- Use `archive/docs/assets/` for diagrams and supporting media tied to archived docs.
+- Use `archive/code/` for retired source or tests, and mirror the previous path beneath `archive/code/` when practical.
+- Keep active code under `src/`, active tests under `tests/`, current docs under `docs/`, automation and support scripts under `scripts/`, deployment material under `deploy/`, and generated outputs under `artifacts/` or ignored build folders.
+- Keep automation-owned status artifacts in `docs/status/` when build/docs tooling and documentation references expect them there.
+- Treat local hidden tool scratch folders such as `.playwright-cli/` as `delete` or `.gitignore` candidates, not archive candidates.
+
+## Guardrails
+
+- Do not archive code that is still included by a project, solution, source generator, XAML binding, reflection path, or current docs link without evidence.
+- Do not leave broken relative links after moving docs.
+- Do not mix structural archiving with feature implementation unless the user asks for both.
+- Keep each pass theme-based: stale docs, retired prototype, legacy tests, or folder cleanup.
+- Preserve filenames unless a rename materially improves placement clarity.
+- Update the archive indexes or placement guide when a move introduces a new recurring pattern.
+
+## Validation Guidance
+
+- For docs-only moves, update links and search for stale references in docs, config, and README-style entrypoints.
+- For code moves, confirm the files are no longer referenced by `*.csproj`, `Meridian.sln`, `Directory.Build.props`, tests, or active docs before moving them.
+- For generated docs or JSON outputs, check `build/scripts/docs/`, workflow files, and documentation-automation docs before reclassifying them as stale.
+- For root-structure cleanup, confirm the final top-level layout still matches `references/archive-placement-guide.md`.
+- Prefer targeted checks such as `Select-String`, narrow `dotnet build` or `dotnet test` commands, and archive index updates over full-repo validation unless the move is broad.
+
+## Automation Scripts
+
+Use bundled scripts to keep archive work deterministic:
+
+- `scripts/trace_archive_candidates.py`
+  - Trace references, separate strong vs weak evidence, and suggest a classification.
+  - Example: `python scripts/trace_archive_candidates.py --path docs/status/FULL_IMPLEMENTATION_TODO_2026_03_20.md --path docs/status/docs-automation-summary.json`
+- `scripts/run_evals.py`
+  - Run deterministic repo-grounded eval cases from `evals/evals.json`.
+  - Example: `python scripts/run_evals.py --all`
+- `scripts/score_eval.py`
+  - Produce a rubric-style score block for a manual archive pass or skill revision.
+  - Example: `python scripts/score_eval.py --scenario A --scores "{\"classification_accuracy\":2,\"reference_trace_quality\":2,\"placement_correctness\":2,\"safety_guardrails\":1,\"cleanup_follow_through\":2}"`
+
+## Evaluation Requirement
+
+Treat `references/evaluation-harness.md` as mandatory when:
+
+- changing this skill's heuristics
+- running a multi-file archive sweep
+- archiving dated documents that still have mixed evidence
+- claiming the skill is more robust after an iteration
+
+Return:
+
+- which lane or scenario was evaluated
+- the command evidence used
+- the recommendation or move outcome
+- the rubric score or deterministic eval results
+
+## Output Standards
+
+- State the classification for each moved item.
+- Name the old path and new path.
+- Summarize the evidence that made the move safe.
+- Mention any links, indexes, or structure docs updated.
+- Separate follow-up candidates from the work completed in the current pass.
+
+## Output Checklist
+
+Before finishing, confirm:
+
+- [ ] Every target has a classification and reason.
+- [ ] Strong vs weak references were separated.
+- [ ] Any archive destination matches the bucket rules.
+- [ ] README/index links were updated when paths changed.
+- [ ] Validation or trace commands are cited explicitly.
+- [ ] Evaluation results are included when the sweep or skill update was non-trivial.

--- a/.claude/skills/meridian-archive-organizer/agents/openai.yaml
+++ b/.claude/skills/meridian-archive-organizer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Meridian Archive Organizer"
+  short_description: "Archive stale files and tidy repo layout"
+  default_prompt: "Use $meridian-archive-organizer to classify stale Meridian files with evidence and move them into the right archive bucket."

--- a/.claude/skills/meridian-archive-organizer/evals/evals.json
+++ b/.claude/skills/meridian-archive-organizer/evals/evals.json
@@ -1,0 +1,59 @@
+{
+  "skill_name": "meridian-archive-organizer",
+  "last_updated": "2026-04-09",
+  "evals": [
+    {
+      "id": 1,
+      "description": "Dated backlog doc remains active because status guidance still treats it as source-of-truth",
+      "path": "docs/status/FULL_IMPLEMENTATION_TODO_2026_03_20.md",
+      "expected_recommendation": "active",
+      "min_strong_refs": 1,
+      "must_exist": true
+    },
+    {
+      "id": 2,
+      "description": "Automation-owned JSON sidecar remains active",
+      "path": "docs/status/docs-automation-summary.json",
+      "expected_recommendation": "active",
+      "min_strong_refs": 1,
+      "must_exist": true
+    },
+    {
+      "id": 3,
+      "description": "Archived roadmap snapshot remains archived",
+      "path": "archive/docs/summaries/ROADMAP_NOW_NEXT_LATER_2026_03_25.md",
+      "expected_recommendation": "already-archived",
+      "must_exist": true
+    },
+    {
+      "id": 4,
+      "description": "Active cleanup roadmap stays active despite archive-related wording",
+      "path": "docs/plans/codebase-audit-cleanup-roadmap.md",
+      "expected_recommendation": "active",
+      "min_strong_refs": 1,
+      "must_exist": true
+    },
+    {
+      "id": 5,
+      "description": "Local Playwright scratch path is treated as delete or ignore material",
+      "path": ".playwright-cli",
+      "expected_recommendation": "delete"
+    },
+    {
+      "id": 6,
+      "description": "Superseded ADR fixture remains an archive-doc candidate once only historical and inventory references remain",
+      "path": "docs/adr/ADR-015-platform-restructuring.md",
+      "repo_root": ".codex/skills/meridian-archive-organizer/fixtures/superseded-adr",
+      "expected_recommendation": "archive-doc",
+      "max_strong_refs": 0,
+      "must_exist": true
+    },
+    {
+      "id": 7,
+      "description": "Archived repo-wide audit snapshot stays classified as already archived after the move",
+      "path": "archive/docs/assessments/CODE_REVIEW_2026-03-16.md",
+      "expected_recommendation": "already-archived",
+      "must_exist": true
+    }
+  ]
+}

--- a/.claude/skills/meridian-archive-organizer/fixtures/superseded-adr/docs/adr/ADR-015-platform-restructuring.md
+++ b/.claude/skills/meridian-archive-organizer/fixtures/superseded-adr/docs/adr/ADR-015-platform-restructuring.md
@@ -1,0 +1,6 @@
+# ADR-015: Platform Restructuring
+
+Status: Superseded
+
+This historical ADR has been replaced by newer platform guidance and remains only
+for traceability during archive-skill evaluation.

--- a/.claude/skills/meridian-archive-organizer/fixtures/superseded-adr/docs/adr/README.md
+++ b/.claude/skills/meridian-archive-organizer/fixtures/superseded-adr/docs/adr/README.md
@@ -1,0 +1,3 @@
+# ADR Index
+
+- [ADR-015-platform-restructuring](ADR-015-platform-restructuring.md) - historical superseded note retained for migration traceability

--- a/.claude/skills/meridian-archive-organizer/fixtures/superseded-adr/docs/generated/repository-structure.md
+++ b/.claude/skills/meridian-archive-organizer/fixtures/superseded-adr/docs/generated/repository-structure.md
@@ -1,0 +1,3 @@
+# Repository Structure
+
+?   ?   ??? ADR-015-platform-restructuring.md

--- a/.claude/skills/meridian-archive-organizer/references/archive-placement-guide.md
+++ b/.claude/skills/meridian-archive-organizer/references/archive-placement-guide.md
@@ -1,0 +1,84 @@
+# Meridian Archive Placement Guide
+
+Use this guide when the task is about deciding whether Meridian content stays active, moves into `archive/`, or should be deleted.
+
+## Decision Matrix
+
+| Classification | Use when | Default destination |
+| --- | --- | --- |
+| `active` | The file is current, referenced, or part of active workflows | Keep in canonical active folder |
+| `archive-doc` | The document is historical, superseded, or reference-only | `archive/docs/<bucket>/` |
+| `archive-code` | The code or tests are retired but still worth preserving | `archive/code/<original-relative-path>` |
+| `delete` | The file is transient clutter or a no-value duplicate | Remove instead of archive |
+
+## Canonical Active Locations
+
+| Content type | Preferred location |
+| --- | --- |
+| Product and engineering docs | `docs/` |
+| Application and library source | `src/` |
+| Automated tests | `tests/` |
+| Support scripts and repo tooling | `scripts/` |
+| Deployment assets | `deploy/` |
+| Build and generated outputs | `artifacts/`, `bin/`, `obj/`, other ignored output folders |
+| Benchmarks and experiments still in active use | `benchmarks/` |
+| Project-specific planning or scoped work folders | `PROJECTS/`, `issues/`, or an existing active docs section |
+
+## Archive Buckets
+
+| Bucket | Use for |
+| --- | --- |
+| `archive/docs/assessments/` | Audits, investigations, evaluations, cleanup findings |
+| `archive/docs/plans/` | Completed or superseded plans, reorganization proposals, old roadmaps |
+| `archive/docs/summaries/` | Historical summaries, snapshots, one-off reports, retrospectives |
+| `archive/docs/migrations/` | Legacy migration notes, platform transition material |
+| `archive/docs/assets/` | Images, diagrams, or attachments used by archived docs |
+| `archive/code/` | Retired code and tests, preserving prior layout where practical |
+
+## Placement Heuristics
+
+- Mirror the old relative path under `archive/code/` when moving retired source or tests.
+- Prefer archiving over deletion when the item explains a past decision, migration, or removed subsystem.
+- Prefer deletion over archiving for generated outputs, caches, duplicate artifacts, and scratch files with no lasting reference value.
+- Before moving generated docs, confirm whether repo tooling intentionally publishes them into `docs/status/` or `docs/generated/`.
+- Keep active docs concise by moving historical material out of `docs/` once it stops guiding current work.
+- Update archive indexes or nearby README files when a move changes how someone will discover the material later.
+
+## Quick Checks Before Moving
+
+1. Search for references in project files, solution files, docs, and tests.
+2. Confirm the item is not part of the active build or runtime path.
+3. Distinguish strong references from weak ones:
+   - strong: active README files, current roadmap/plan docs, hand-maintained guidance
+   - weak: generated file trees, validation reports, automation snapshots, stale inventories
+4. Decide whether the value is historical reference or just clutter.
+5. Choose the most specific archive bucket available.
+6. Update any links or indexes that pointed at the old location.
+
+## Local Scratch Examples
+
+- Delete or ignore local tool output such as `.playwright-cli/`, temporary screenshot captures, and ad hoc session logs when they are not part of the documented repo workflow.
+- Archive only when the output itself has lasting historical value; otherwise keep the repo clean and rely on `.gitignore`.
+
+## Script-Assisted Trace
+
+Use the bundled trace script when a decision is not obvious from one README/index read:
+
+```bash
+python scripts/trace_archive_candidates.py --path docs/status/FULL_IMPLEMENTATION_TODO_2026_03_20.md
+python scripts/trace_archive_candidates.py --path docs/status/docs-automation-summary.json --path .playwright-cli --json
+```
+
+The trace output is most useful for:
+
+- separating strong references from weak inventory/report references
+- proving that a dated doc is still active
+- proving that a generated-looking file is automation-owned
+- identifying delete-or-ignore candidates at the repo root
+
+## Example Triggers
+
+- "Move this superseded migration plan into the archive."
+- "Archive the retired prototype code but keep it for reference."
+- "Where should this outdated audit report live?"
+- "Clean up the repo root and move stale folders into the right place."

--- a/.claude/skills/meridian-archive-organizer/references/evaluation-harness.md
+++ b/.claude/skills/meridian-archive-organizer/references/evaluation-harness.md
@@ -1,0 +1,107 @@
+# Evaluation Harness
+
+Use this harness when you are changing the archive skill, running a broad archive sweep, or claiming the skill is now more robust.
+
+## When To Use It
+
+Run the harness when any of the following are true:
+
+- you changed archive heuristics, placement rules, or evidence weighting
+- you are evaluating more than one archive candidate in a pass
+- a dated document still has mixed or ambiguous references
+- you need to prove the skill is safe before recommending deletes or moves
+
+## Script-Assisted Execution
+
+Prefer the bundled scripts over ad hoc reasoning when the task touches multiple files.
+
+1. Trace each candidate with `scripts/trace_archive_candidates.py`.
+2. Replay the deterministic scenarios in `evals/evals.json` with `scripts/run_evals.py`.
+3. If the pass was manual or exploratory, summarize it with `scripts/score_eval.py`.
+
+If a live-repo scenario has already been cleaned up or archived, prefer a small
+fixture repo under `fixtures/` plus a per-eval `repo_root` in `evals/evals.json`
+instead of pointing the deterministic suite at a path that no longer exists.
+
+The trace should ignore AI metadata and local mirror surfaces such as `.codex/` and `.claude/` so they do not inflate evidence counts.
+
+Recommended command sequence:
+
+```powershell
+python .codex/skills/meridian-archive-organizer/scripts/trace_archive_candidates.py --path docs/status/FULL_IMPLEMENTATION_TODO_2026_03_20.md
+python .codex/skills/meridian-archive-organizer/scripts/run_evals.py --all
+python .codex/skills/meridian-archive-organizer/scripts/score_eval.py --scenario B --scores "{\"classification_accuracy\":2,\"reference_trace_quality\":2,\"placement_correctness\":2,\"safety_guardrails\":2,\"cleanup_follow_through\":1}"
+```
+
+## Scenario Set
+
+### Scenario A
+
+A dated status or backlog document still has strong references from active planning or documentation entrypoints, so it must stay active.
+
+### Scenario B
+
+A dated snapshot has no strong references and only weak/generated references, so it should move into the correct archive docs bucket.
+
+References that say "snapshot", "historical", or "prior review context" count as weak evidence for this scenario.
+
+### Scenario C
+
+A generated or machine-readable documentation artifact is still written or consumed by automation, so it stays active even if it looks stale.
+
+### Scenario D
+
+A hidden local tool folder, scratch file, or log capture is local clutter and should be deleted or ignored rather than archived.
+
+## Rubric
+
+Score each category from `0` to `2`.
+
+- `classification_accuracy`
+  - `0`: wrong disposition
+  - `1`: partially right but hedged or inconsistent
+  - `2`: correct final classification
+- `reference_trace_quality`
+  - `0`: no evidence trail
+  - `1`: references gathered but not separated well
+  - `2`: strong and weak references clearly separated
+- `placement_correctness`
+  - `0`: wrong destination or no placement logic
+  - `1`: mostly right but bucket or path is unclear
+  - `2`: destination cleanly matches the placement guide
+- `safety_guardrails`
+  - `0`: risky move or delete with missing checks
+  - `1`: partial safety checks
+  - `2`: solution respects build, docs, and automation guardrails
+- `cleanup_follow_through`
+  - `0`: links or indexes left stale
+  - `1`: partial follow-through
+  - `2`: surrounding docs or structure were updated appropriately
+
+Passing threshold:
+
+- total score must be at least `8/10`
+- no category may be `0`
+
+## Evaluation Report Template
+
+Use this structure in the final response for a non-trivial archive pass:
+
+```text
+Scenario: B
+Targets: docs/status/EXAMPLE_2026_03_01.md
+Evidence:
+- trace command and result
+- strong references
+- weak references
+Outcome:
+- classification
+- old path -> new path
+Score:
+- classification_accuracy: 2
+- reference_trace_quality: 2
+- placement_correctness: 2
+- safety_guardrails: 1
+- cleanup_follow_through: 2
+Result: pass (9/10)
+```

--- a/.claude/skills/meridian-archive-organizer/scripts/run_evals.py
+++ b/.claude/skills/meridian-archive-organizer/scripts/run_evals.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Run deterministic eval cases for the Meridian archive organizer skill."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import OrderedDict
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[4]
+SKILL_DIR = Path(__file__).resolve().parents[1]
+TRACE_SCRIPT = Path(__file__).resolve().with_name("trace_archive_candidates.py")
+EVALS_PATH = SKILL_DIR / "evals" / "evals.json"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    selector = parser.add_mutually_exclusive_group(required=True)
+    selector.add_argument("--eval-id", type=int, help="Run a single eval by numeric id.")
+    selector.add_argument("--all", action="store_true", help="Run all configured evals.")
+    parser.add_argument("--dry-run", action="store_true", help="Print commands without executing them.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser.parse_args()
+
+
+def load_cases() -> dict[str, object]:
+    return json.loads(EVALS_PATH.read_text(encoding="utf-8"))
+
+
+def select_cases(payload: dict[str, object], eval_id: int | None) -> list[dict[str, object]]:
+    cases = payload["evals"]
+    if eval_id is None:
+        return cases
+    selected = [case for case in cases if case["id"] == eval_id]
+    if not selected:
+        raise ValueError(f"Eval id {eval_id} was not found in {EVALS_PATH}.")
+    return selected
+
+
+def resolve_repo_root(case: dict[str, object]) -> Path:
+    repo_root = case.get("repo_root")
+    if repo_root is None:
+        return ROOT_DIR
+
+    resolved = Path(repo_root)
+    if not resolved.is_absolute():
+        resolved = (ROOT_DIR / resolved).resolve()
+    return resolved
+
+
+def evaluate_case(case: dict[str, object], command: list[str], result: dict[str, object]) -> dict[str, object]:
+    checks: list[str] = []
+    failures: list[str] = []
+
+    expected_recommendation = case.get("expected_recommendation")
+    if expected_recommendation is not None:
+        if result["recommendation"] == expected_recommendation:
+            checks.append(f"recommendation matched `{expected_recommendation}`")
+        else:
+            failures.append(
+                f"recommendation expected `{expected_recommendation}` but got `{result['recommendation']}`"
+            )
+
+    if "must_exist" in case:
+        if result["exists"] == case["must_exist"]:
+            checks.append(f"exists matched `{case['must_exist']}`")
+        else:
+            failures.append(f"exists expected `{case['must_exist']}` but got `{result['exists']}`")
+
+    min_strong_refs = case.get("min_strong_refs")
+    if min_strong_refs is not None:
+        if result["strong_ref_count"] >= min_strong_refs:
+            checks.append(f"strong_ref_count >= {min_strong_refs}")
+        else:
+            failures.append(
+                f"strong_ref_count expected >= {min_strong_refs} but got {result['strong_ref_count']}"
+            )
+
+    max_strong_refs = case.get("max_strong_refs")
+    if max_strong_refs is not None:
+        if result["strong_ref_count"] <= max_strong_refs:
+            checks.append(f"strong_ref_count <= {max_strong_refs}")
+        else:
+            failures.append(
+                f"strong_ref_count expected <= {max_strong_refs} but got {result['strong_ref_count']}"
+            )
+
+    max_weak_refs = case.get("max_weak_refs")
+    if max_weak_refs is not None:
+        if result["weak_ref_count"] <= max_weak_refs:
+            checks.append(f"weak_ref_count <= {max_weak_refs}")
+        else:
+            failures.append(
+                f"weak_ref_count expected <= {max_weak_refs} but got {result['weak_ref_count']}"
+            )
+
+    return {
+        "id": case["id"],
+        "description": case["description"],
+        "path": case["path"],
+        "command": command,
+        "status": "pass" if not failures else "fail",
+        "checks": checks + failures,
+        "trace": result,
+    }
+
+
+def run_cases(cases: list[dict[str, object]]) -> list[dict[str, object]]:
+    cases_by_root: OrderedDict[str, list[dict[str, object]]] = OrderedDict()
+    for case in cases:
+        repo_root = str(resolve_repo_root(case))
+        cases_by_root.setdefault(repo_root, []).append(case)
+
+    evaluated: dict[tuple[str, str], dict[str, object]] = {}
+    for repo_root, grouped_cases in cases_by_root.items():
+        command = [
+            sys.executable,
+            str(TRACE_SCRIPT),
+            "--repo-root",
+            repo_root,
+        ]
+        for case in grouped_cases:
+            command.extend(["--path", case["path"]])
+        command.append("--json")
+
+        completed = subprocess.run(command, capture_output=True, text=True, check=False)
+        if completed.returncode != 0:
+            for case in grouped_cases:
+                evaluated[(repo_root, case["path"])] = {
+                    "id": case["id"],
+                    "description": case["description"],
+                    "path": case["path"],
+                    "command": command,
+                    "status": "fail",
+                    "checks": [f"trace script failed with exit code {completed.returncode}"],
+                    "stderr": completed.stderr.strip(),
+                }
+            continue
+
+        payload = json.loads(completed.stdout)
+        results_by_path = {result["path"]: result for result in payload["results"]}
+        for case in grouped_cases:
+            evaluated[(repo_root, case["path"])] = evaluate_case(case, command, results_by_path[case["path"]])
+
+    return [evaluated[(str(resolve_repo_root(case)), case["path"])] for case in cases]
+
+
+def print_markdown(results: list[dict[str, object]]) -> None:
+    passed = sum(1 for result in results if result["status"] == "pass")
+    print(f"## Eval Summary `{passed}/{len(results)}` passed")
+    print()
+    for result in results:
+        print(f"### Eval {result['id']} `{result['status']}`")
+        print(f"- description: {result['description']}")
+        print(f"- path: `{result['path']}`")
+        print(f"- command: `{' '.join(result['command'])}`")
+        for check in result["checks"]:
+            print(f"- check: {check}")
+        trace = result.get("trace")
+        if trace:
+            print(f"- recommendation: `{trace['recommendation']}`")
+            print(f"- strong_ref_count: `{trace['strong_ref_count']}`")
+            print(f"- weak_ref_count: `{trace['weak_ref_count']}`")
+        stderr = result.get("stderr")
+        if stderr:
+            print(f"- stderr: {stderr}")
+        print()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        payload = load_cases()
+        cases = select_cases(payload, args.eval_id)
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    if args.dry_run:
+        results = []
+        for case in cases:
+            command = [
+                sys.executable,
+                str(TRACE_SCRIPT),
+                "--repo-root",
+                str(ROOT_DIR),
+                "--path",
+                case["path"],
+                "--json",
+            ]
+            results.append(
+                {
+                    "id": case["id"],
+                    "description": case["description"],
+                    "path": case["path"],
+                    "command": command,
+                    "status": "dry-run",
+                    "checks": ["execution skipped because --dry-run was used"],
+                }
+            )
+        if args.json:
+            json.dump({"skill_name": payload["skill_name"], "results": results}, sys.stdout, indent=2)
+            sys.stdout.write("\n")
+        else:
+            print_markdown(results)
+        return 0
+
+    results = run_cases(cases)
+    output = {"skill_name": payload["skill_name"], "results": results}
+    if args.json:
+        json.dump(output, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        print_markdown(results)
+    return 0 if all(result["status"] == "pass" for result in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/meridian-archive-organizer/scripts/score_eval.py
+++ b/.claude/skills/meridian-archive-organizer/scripts/score_eval.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Score a manual archive-skill evaluation run."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+CATEGORIES = (
+    "classification_accuracy",
+    "reference_trace_quality",
+    "placement_correctness",
+    "safety_guardrails",
+    "cleanup_follow_through",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scenario", choices=["A", "B", "C", "D"], required=True)
+    parser.add_argument("--scores", required=True, help="JSON object with 0-2 scores for each rubric category.")
+    parser.add_argument("--failed-check", action="append", default=[], help="Optional failed checks to list.")
+    parser.add_argument("--follow-up", action="append", default=[], help="Optional follow-up actions to list.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser.parse_args()
+
+
+def load_scores(raw_scores: str) -> dict[str, int]:
+    parsed = json.loads(raw_scores)
+    scores: dict[str, int] = {}
+    for category in CATEGORIES:
+        value = parsed.get(category)
+        if value is None:
+            raise ValueError(f"Missing score for {category}.")
+        if not isinstance(value, int) or value < 0 or value > 2:
+            raise ValueError(f"Score for {category} must be an integer between 0 and 2.")
+        scores[category] = value
+    return scores
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, object]:
+    scores = load_scores(args.scores)
+    total = sum(scores.values())
+    passing = total >= 8 and all(value > 0 for value in scores.values())
+    return {
+        "scenario": args.scenario,
+        "scores": scores,
+        "total": total,
+        "max_total": len(CATEGORIES) * 2,
+        "failed_checks": args.failed_check,
+        "follow_up": args.follow_up,
+        "result": "pass" if passing else "fail",
+    }
+
+
+def print_markdown(payload: dict[str, object]) -> None:
+    print("### Archive Skill Eval")
+    print(f"- scenario: `{payload['scenario']}`")
+    print(f"- result: `{payload['result']}`")
+    print(f"- total: `{payload['total']}/{payload['max_total']}`")
+    for category, score in payload["scores"].items():
+        print(f"- {category}: `{score}`")
+    failed_checks = payload["failed_checks"]
+    if failed_checks:
+        for failed_check in failed_checks:
+            print(f"- failed_check: {failed_check}")
+    follow_up = payload["follow_up"]
+    if follow_up:
+        for item in follow_up:
+            print(f"- follow_up: {item}")
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        payload = build_payload(args)
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    if args.json:
+        json.dump(payload, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        print_markdown(payload)
+    return 0 if payload["result"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/meridian-archive-organizer/scripts/trace_archive_candidates.py
+++ b/.claude/skills/meridian-archive-organizer/scripts/trace_archive_candidates.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Trace archive candidates and separate strong vs weak references."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[4]
+SKIP_DIRS = {
+    ".claude",
+    ".codex",
+    ".git",
+    ".vs",
+    ".playwright-cli",
+    "bin",
+    "obj",
+    "node_modules",
+    "__pycache__",
+}
+TEXT_SUFFIXES = {
+    "",
+    ".cs",
+    ".csproj",
+    ".editorconfig",
+    ".fs",
+    ".fsproj",
+    ".fsx",
+    ".gitignore",
+    ".json",
+    ".md",
+    ".props",
+    ".ps1",
+    ".py",
+    ".sln",
+    ".targets",
+    ".toml",
+    ".txt",
+    ".xml",
+    ".xaml",
+    ".yaml",
+    ".yml",
+}
+DATED_NAME_RE = re.compile(r"(19|20)\d{2}[-_](0[1-9]|1[0-2])(?:[-_](0[1-9]|[12]\d|3[01]))?")
+TREE_LINE_RE = re.compile(r"^\s*[│├└]")
+SCRATCH_NAME_RE = re.compile(
+    r"(^\.playwright-cli$)|(\.log$)|(_stdout\.txt$)|(_stderr\.txt$)|(^scratch[-_.])|([-_.]scratch\.)",
+    re.IGNORECASE,
+)
+
+WEAK_EXACT_PATHS = {
+    ".github/agents/documentation-agent.md",
+    "docs/ai/copilot/instructions.md",
+    "docs/status/TODO.md",
+    "docs/status/api-docs-report.md",
+    "docs/status/badge-sync-report.md",
+    "docs/status/coverage-report.md",
+    "docs/status/docs-automation-summary.md",
+    "docs/status/example-validation.md",
+    "docs/status/health-dashboard.md",
+    "docs/status/link-repair-report.md",
+    "docs/status/metrics-dashboard.md",
+    "docs/status/rules-report.md",
+}
+WEAK_PREFIXES = (
+    "docs/generated/",
+)
+STRONG_STATUS_EXACT = {
+    "docs/status/FEATURE_INVENTORY.md",
+    "docs/status/IMPROVEMENTS.md",
+    "docs/status/OPPORTUNITY_SCAN.md",
+    "docs/status/README.md",
+    "docs/status/ROADMAP.md",
+    "docs/status/ROADMAP_COMBINED.md",
+    "docs/status/TARGET_END_PRODUCT.md",
+    "docs/status/production-status.md",
+}
+STRONG_PREFIXES = (
+    "docs/architecture/",
+    "docs/development/",
+    "docs/evaluations/",
+    "docs/operations/",
+    "docs/plans/",
+    "docs/providers/",
+    "docs/reference/",
+)
+AUTOMATION_OWNER_PATHS = (
+    ".github/workflows/documentation.yml",
+    "build/scripts/docs/run-docs-automation.py",
+    "docs/development/documentation-automation.md",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--path", action="append", required=True, help="Candidate path relative to repo root.")
+    parser.add_argument(
+        "--repo-root",
+        default=str(ROOT_DIR),
+        help="Repository root to scan. Defaults to the current Meridian workspace root.",
+    )
+    parser.add_argument("--limit", type=int, default=12, help="Maximum number of references to show per target.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser.parse_args()
+
+
+def to_repo_relative(path: Path, repo_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix().lstrip("./")
+
+
+def classify_zone(relative_path: str) -> str:
+    if relative_path.startswith("archive/docs/"):
+        return "archive-docs"
+    if relative_path.startswith("archive/code/"):
+        return "archive-code"
+    if relative_path.startswith("docs/"):
+        return "active-docs"
+    if relative_path.startswith("src/") or relative_path.startswith("tests/"):
+        return "active-code"
+    return "repo-root-or-other"
+
+
+def infer_lane(relative_path: str, target_path: Path, scratch: bool, automation_owned: bool) -> str:
+    if scratch:
+        return "local-scratch"
+    if automation_owned:
+        return "automation-owned-surface"
+    if target_path.suffix.lower() in {".cs", ".fs", ".xaml"} or relative_path.startswith(("src/", "tests/")):
+        return "retired-code"
+    return "dated-doc-snapshot"
+
+
+def is_scratch_target(relative_path: str, target_path: Path) -> bool:
+    parts = relative_path.split("/")
+    if any(part == ".playwright-cli" for part in parts):
+        return True
+    return bool(SCRATCH_NAME_RE.search(target_path.name))
+
+
+def iter_text_files(repo_root: Path):
+    for file_path in repo_root.rglob("*"):
+        if not file_path.is_file():
+            continue
+        if any(part in SKIP_DIRS for part in file_path.relative_to(repo_root).parts[:-1]):
+            continue
+        if file_path.stat().st_size > 2_000_000:
+            continue
+        if file_path.suffix.lower() not in TEXT_SUFFIXES:
+            continue
+        yield file_path
+
+
+def candidate_tokens(relative_path: str, target_path: Path) -> list[str]:
+    tokens = {relative_path, relative_path.replace("/", "\\"), target_path.name}
+    return sorted(token for token in tokens if token)
+
+
+def is_active_status_doc(relative_path: str) -> bool:
+    if relative_path in STRONG_STATUS_EXACT:
+        return True
+    return relative_path.startswith("docs/status/FULL_IMPLEMENTATION_TODO_")
+
+
+def is_weak_reference_path(relative_path: str) -> bool:
+    if relative_path in WEAK_EXACT_PATHS:
+        return True
+    return any(relative_path.startswith(prefix) for prefix in WEAK_PREFIXES)
+
+
+def is_automation_owned_status_json(relative_path: str) -> bool:
+    return relative_path.startswith("docs/status/") and relative_path.endswith(".json")
+
+
+def line_has_reference(line: str, tokens: list[str]) -> bool:
+    return any(token in line for token in tokens)
+
+
+def classify_reference_strength(reference_path: str, line: str, candidate_relative: str) -> str:
+    stripped = line.strip()
+    lowered = stripped.lower()
+    candidate_is_status_json = is_automation_owned_status_json(candidate_relative)
+    readme_inventory_path = reference_path.startswith("docs/") and reference_path.endswith("/README.md")
+
+    if TREE_LINE_RE.match(stripped):
+        return "weak"
+    if "auto-generated" in lowered or "generated tree" in lowered:
+        return "weak"
+    if "prior review context" in lowered:
+        return "weak"
+    if ("historical" in lowered or "snapshot" in lowered) and readme_inventory_path:
+        return "weak"
+    if reference_path.startswith("archive/"):
+        return "weak"
+    if is_weak_reference_path(reference_path):
+        return "weak"
+    if candidate_is_status_json and reference_path in AUTOMATION_OWNER_PATHS:
+        if "docs/status/" in line or candidate_relative.split("/")[-1] in line or "json-output" in lowered or "output-json" in lowered:
+            return "strong"
+    if reference_path in STRONG_STATUS_EXACT or is_active_status_doc(reference_path):
+        return "strong"
+    if any(reference_path.startswith(prefix) for prefix in STRONG_PREFIXES):
+        return "strong"
+    if reference_path.startswith("docs/status/") and reference_path.endswith(".json"):
+        return "weak"
+    if reference_path.startswith(".github/workflows/") or reference_path.startswith("build/scripts/"):
+        return "strong"
+    if reference_path.startswith("docs/") or reference_path.startswith(".github/"):
+        return "strong"
+    return "strong"
+
+
+def initialize_candidate_state(candidate_input: str, repo_root: Path) -> dict[str, object]:
+    target_path = (repo_root / candidate_input).resolve()
+    exists = target_path.exists()
+    is_dir = target_path.is_dir()
+    reference_path = target_path if exists else Path(candidate_input)
+    candidate_relative = to_repo_relative(reference_path, repo_root)
+    return {
+        "path": candidate_input,
+        "target_path": target_path,
+        "exists": exists,
+        "is_dir": is_dir,
+        "candidate_relative": candidate_relative,
+        "zone": classify_zone(candidate_relative),
+        "dated_name": bool(DATED_NAME_RE.search(reference_path.name)),
+        "scratch": is_scratch_target(candidate_relative, reference_path),
+        "tokens": candidate_tokens(candidate_relative, reference_path),
+        "references": [],
+        "strong_ref_count": 0,
+        "weak_ref_count": 0,
+        "owner_reference_found": False,
+    }
+
+
+def scan_references(states: list[dict[str, object]], repo_root: Path, limit: int) -> None:
+    searchable_states = [state for state in states if state["exists"] and not state["is_dir"]]
+    if not searchable_states:
+        return
+
+    for file_path in iter_text_files(repo_root):
+        reference_relative = to_repo_relative(file_path, repo_root)
+        try:
+            text = file_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            try:
+                text = file_path.read_text(encoding="utf-8-sig")
+            except UnicodeDecodeError:
+                continue
+
+        candidate_states = [
+            state
+            for state in searchable_states
+            if reference_relative != state["candidate_relative"] and any(token in text for token in state["tokens"])
+        ]
+        if not candidate_states:
+            continue
+
+        lines = text.splitlines()
+        for state in candidate_states:
+            for line_number, line in enumerate(lines, start=1):
+                if not line_has_reference(line, state["tokens"]):
+                    continue
+                strength = classify_reference_strength(reference_relative, line, state["candidate_relative"])
+                if strength == "strong":
+                    state["strong_ref_count"] += 1
+                    if reference_relative in AUTOMATION_OWNER_PATHS:
+                        state["owner_reference_found"] = True
+                else:
+                    state["weak_ref_count"] += 1
+                if len(state["references"]) < limit:
+                    state["references"].append(
+                        {
+                            "strength": strength,
+                            "file": reference_relative,
+                            "line": line_number,
+                            "excerpt": line.strip()[:220],
+                        }
+                    )
+
+
+def recommend(
+    relative_path: str,
+    zone: str,
+    target_path: Path,
+    dated_name: bool,
+    scratch: bool,
+    automation_owned: bool,
+    strong_count: int,
+    weak_count: int,
+) -> tuple[str, list[str]]:
+    reasons: list[str] = []
+    if zone.startswith("archive-"):
+        reasons.append("Path already lives under archive/.")
+        return "already-archived", reasons
+    if scratch:
+        reasons.append("Local scratch or hidden tool output should be deleted or ignored, not archived.")
+        return "delete", reasons
+    if automation_owned:
+        reasons.append("Machine-readable docs/status artifact is owned by repo automation.")
+        return "active", reasons
+    if strong_count > 0:
+        reasons.append("Active strong references still point at this target.")
+        return "active", reasons
+    if zone == "active-docs" and dated_name:
+        reasons.append("Dated active doc has no strong references and is a good archive-doc candidate.")
+        return "archive-doc", reasons
+    if zone == "active-docs" and weak_count > 0:
+        reasons.append("Only weak references were found; human-maintained entrypoints no longer keep it active.")
+        return "archive-doc", reasons
+    if zone == "active-code":
+        reasons.append("Code paths require explicit build and inclusion checks before archiving.")
+        return "needs-review", reasons
+    reasons.append("No deterministic safe move was proven.")
+    return "needs-review", reasons
+
+
+def finalize_candidate_state(state: dict[str, object]) -> dict[str, object]:
+    target_path = state["target_path"]
+    candidate_relative = state["candidate_relative"]
+    automation_owned = is_automation_owned_status_json(candidate_relative) and state["owner_reference_found"]
+
+    recommendation, reasons = recommend(
+        candidate_relative,
+        state["zone"],
+        target_path,
+        state["dated_name"],
+        state["scratch"],
+        automation_owned,
+        state["strong_ref_count"],
+        state["weak_ref_count"],
+    )
+    lane = infer_lane(candidate_relative, target_path, state["scratch"], automation_owned)
+
+    if not state["exists"]:
+        reasons.append("Target does not currently exist.")
+
+    return {
+        "path": state["path"],
+        "absolute_path": str(target_path),
+        "exists": state["exists"],
+        "is_dir": state["is_dir"],
+        "zone": state["zone"],
+        "lane": lane,
+        "dated_name": state["dated_name"],
+        "recommendation": recommendation,
+        "strong_ref_count": state["strong_ref_count"],
+        "weak_ref_count": state["weak_ref_count"],
+        "reasons": reasons,
+        "references": state["references"],
+    }
+
+
+def trace_candidates(candidate_inputs: list[str], repo_root: Path, limit: int) -> list[dict[str, object]]:
+    states = [initialize_candidate_state(candidate_input, repo_root) for candidate_input in candidate_inputs]
+    scan_references(states, repo_root, limit)
+    return [finalize_candidate_state(state) for state in states]
+
+
+def print_markdown(results: list[dict[str, object]]) -> None:
+    for result in results:
+        print(f"## {result['path']}")
+        print(f"- recommendation: `{result['recommendation']}`")
+        print(f"- lane: `{result['lane']}`")
+        print(f"- zone: `{result['zone']}`")
+        print(f"- dated_name: `{str(result['dated_name']).lower()}`")
+        print(f"- strong_ref_count: `{result['strong_ref_count']}`")
+        print(f"- weak_ref_count: `{result['weak_ref_count']}`")
+        for reason in result["reasons"]:
+            print(f"- reason: {reason}")
+        refs = result["references"]
+        if refs:
+            print("- references:")
+            for reference in refs:
+                safe_excerpt = reference["excerpt"].encode("ascii", "replace").decode("ascii")
+                print(
+                    f"  - [{reference['strength']}] {reference['file']}:{reference['line']} :: {safe_excerpt}"
+                )
+        else:
+            print("- references: none captured")
+        print()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).resolve()
+    results = trace_candidates(args.path, repo_root, args.limit)
+    payload = {"repo_root": str(repo_root), "results": results}
+    if args.json:
+        json.dump(payload, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        print_markdown(results)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/meridian-repo-navigation/SKILL.md
+++ b/.claude/skills/meridian-repo-navigation/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: meridian-repo-navigation
+description: Orient an AI quickly inside the Meridian repository before deeper implementation work. Use when the task starts with "where should I look", "what subsystem owns this", "route me to the right files", or when a large-repo task needs fast grounding before specialist skills take over.
+---
+
+# Meridian Repo Navigation
+
+Use this skill first when the main problem is orientation inside Meridian's size and structure rather than implementation details.
+
+Read these in order:
+1. `../_shared/project-context.md`
+2. `../../../docs/ai/generated/repo-navigation.md`
+3. `../../../docs/ai/navigation/README.md`
+
+If MCP access is available, prefer the generated navigation resources/tools before broad codebase searching:
+- `mdc://repo-navigation/quick-start`
+- `mdc://repo-navigation/catalog`
+- `find-subsystem`
+- `route-task`
+- `find-entrypoints`
+- `find-related-projects`
+- `find-authoritative-docs`
+
+## Roles
+
+### `repo-orienter`
+- Classify the task into the closest subsystem.
+- Name the first 2-3 projects, contracts, and docs to inspect.
+- Keep the answer orientation-first, not implementation-first.
+
+### `task-router`
+- Translate natural-language requests like provider bug, WPF issue, storage regression, or MCP tool work into the right route from the generated repo map.
+- Recommend the next specialist skill or agent once the subsystem is identified.
+
+### `execution-tracer`
+- For follow-up exploration, point at the likely entrypoints and dependency edges that explain execution flow.
+- Stay high-signal; do not dump exhaustive symbol lists.
+
+### `doc-router`
+- Point the AI to the authoritative docs and guardrails before changes start.
+- Prefer AI guides, migration blueprints, and developer guides over generic README scanning.
+
+## Workflow
+
+1. Match the task to a route in `docs/ai/generated/repo-navigation.md` or the MCP navigation tools.
+2. Confirm the owning subsystem, start projects, and key contracts.
+3. Read the authoritative docs for that route.
+4. Hand off to the specialist skill or agent only after orientation is complete.
+
+## Meridian Rules
+
+- Start with the generated repo map before broad recursive searching.
+- Prefer subsystem-level routing over file-by-file wandering.
+- Use the shared project context to keep terminology and commands consistent.
+- If multiple subsystems are involved, name the primary owner first and the cross-project edges second.

--- a/.claude/skills/meridian-repo-navigation/agents/openai.yaml
+++ b/.claude/skills/meridian-repo-navigation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Meridian Repo Navigation"
+  short_description: "Orient AI work inside Meridian"
+  default_prompt: "Use $meridian-repo-navigation to classify this task, route it to the owning subsystem, and name the first files and docs to inspect."

--- a/.claude/skills/meridian-roadmap-strategist/SKILL.md
+++ b/.claude/skills/meridian-roadmap-strategist/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: meridian-roadmap-strategist
+description: Create, refresh, and reconcile Meridian roadmap, delivery-plan, opportunity-map, and target-state documents. Use when the user asks for a roadmap, roadmap update, phased plan, delivery waves, opportunity analysis, product-direction summary, remaining-work summary, or a clear statement of Meridian's intended finished product.
+---
+
+# Meridian Roadmap Strategist
+
+Turn Meridian status, plan, and codebase signals into a roadmap another teammate can use to prioritize work.
+
+Read `../_shared/project-context.md` first. Read `references/roadmap-source-map.md` before deciding what is complete, what is still open, what new opportunities exist, or what the end-state product should be.
+
+## Workflow
+
+1. Identify the requested artifact:
+   - master roadmap refresh
+   - time-boxed roadmap
+   - opportunity scan
+   - end-state product summary
+   - combined roadmap plus opportunities plus target-state narrative
+2. Ground the work in current repository evidence before writing conclusions.
+3. Separate facts into four buckets: complete, partial, planned, and optional.
+4. Reconcile conflicts across roadmap, plan, audit, and status documents instead of repeating them blindly.
+5. Turn gaps into prioritized opportunities with a reason each item matters now.
+6. State the end product clearly: what Meridian becomes for the user when the roadmap is finished.
+7. Use exact dates when refreshing status documents or comparing planning snapshots.
+
+## Source Rules
+
+- Prefer repository-grounded documents over memory.
+- Treat `docs/status/ROADMAP.md` as the primary active roadmap unless the user asks for a new artifact.
+- Cross-check roadmap claims against nearby status, plan, audit, and architecture documents before marking work complete.
+- Distinguish shipping work from aspirational ideas.
+- Call out dependencies, blockers, and optional items explicitly.
+
+## Opportunity Rules
+
+When suggesting opportunities, prefer one of these categories:
+
+- workflow completion
+- operator UX
+- provider readiness
+- architecture simplification
+- reliability and observability
+- testing and validation
+- flagship product capabilities
+
+For each opportunity, explain:
+
+- the gap
+- the user or operator value
+- the dependency it unlocks
+- whether it belongs in the critical path, a later wave, or an optional track
+
+## End-State Rules
+
+When the user wants the final product outcome, describe Meridian in product terms, not only task lists.
+
+Cover these areas when relevant:
+
+- the operator workflow Meridian supports end to end
+- the major workspaces or product surfaces
+- how research, backtesting, paper trading, live trading, portfolio, and ledger experiences connect
+- what is first-class versus supporting infrastructure
+- what optional capabilities remain optional
+
+## Output Shapes
+
+Prefer one of these structures:
+
+```md
+## Summary
+## Current State
+## What Is Complete
+## What Remains
+## Opportunities
+## Target End Product
+## Recommended Next Waves
+## Risks and Dependencies
+```
+
+For a shorter artifact, use:
+
+```md
+## Snapshot
+## Top Opportunities
+## End State
+## Next Steps
+```
+
+## Quality Bar
+
+- Keep roadmap language concrete and repo-grounded.
+- Prefer delivery waves and dependency-aware sequencing over flat backlogs.
+- Mark assumptions when evidence is incomplete.
+- Avoid inflating completion status.
+- Keep the target-state narrative crisp enough that a stakeholder can repeat it in one paragraph.

--- a/.claude/skills/meridian-roadmap-strategist/agents/openai.yaml
+++ b/.claude/skills/meridian-roadmap-strategist/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Meridian Roadmap Strategist"
+  short_description: "Refresh Meridian roadmap and target-state docs"
+  default_prompt: "Use $meridian-roadmap-strategist to refresh Meridian roadmap or target-state docs using the current workstation, provider-confidence, and governance delivery waves."

--- a/.claude/skills/meridian-roadmap-strategist/references/roadmap-source-map.md
+++ b/.claude/skills/meridian-roadmap-strategist/references/roadmap-source-map.md
@@ -1,0 +1,49 @@
+# Roadmap Source Map
+
+Use this file to decide which Meridian sources to read first and how to shape roadmap outputs.
+
+## Source Priority
+
+1. `docs/status/ROADMAP.md`
+2. `docs/status/FEATURE_INVENTORY.md`
+3. `docs/status/FULL_IMPLEMENTATION_TODO_*.md`
+4. `docs/plans/trading-workstation-migration-blueprint.md`
+5. `docs/plans/meridian-6-week-roadmap.md`
+6. `docs/status/IMPROVEMENTS.md`
+7. `docs/status/EVALUATIONS_AND_AUDITS.md`
+8. directly relevant files in `src/` or `tests/` when a roadmap claim depends on current implementation
+
+## Typical Tasks
+
+### Refresh the active roadmap
+
+- Confirm the document date and repository snapshot.
+- Preserve completed work history, but move attention to remaining waves.
+- Re-check open items against newer plan or status docs.
+- Update the target-state wording if the product direction has shifted.
+
+### Create a new time-boxed roadmap
+
+- Start from the active roadmap, not a greenfield list.
+- Pull only the items that fit the requested horizon.
+- Keep non-goals explicit.
+- Put enabling work ahead of surface polish.
+
+### Suggest opportunities
+
+- Prefer opportunities that remove ambiguity, unblock a dependency, or improve operator trust.
+- Highlight whether the opportunity is product-facing, technical, or enabling.
+- Avoid listing ideas that have no clear place in Meridian's current direction.
+
+### State the end product
+
+- Describe the finished Meridian experience as a workflow-centric trading workstation.
+- Explain how research, strategy runs, portfolio, ledger, paper trading, and live operations fit together.
+- Distinguish mandatory end-state capabilities from optional expansions such as scale-out or specialized advanced tooling.
+
+## Useful Framing
+
+- "What is complete?" should be factual and conservative.
+- "What remains?" should focus on material delivery gaps, not every possible improvement.
+- "Opportunities" should be additive and prioritized, not a duplicate of the backlog.
+- "End product" should read like a product vision grounded in the roadmap, not marketing copy.


### PR DESCRIPTION
### Motivation

- Ensure the `.claude` agent catalog mirrors the broader Meridian skill inventory so agents and tools that read `.claude` can discover the same capabilities present elsewhere in the repo. 
- Add explicit agent stubs so the `meridian-archive-organizer`, `meridian-repo-navigation`, and `meridian-roadmap-strategist` capabilities are directly addressable by agent runners and UI surfaces. 
- Provide a deterministic eval and tracing toolchain for archive work so archive decisions can be validated with reproducible scripts and fixtures. 

### Description

- Added three `.claude/agents` entries: `meridian-archive-organizer.md`, `meridian-repo-navigation.md`, and `meridian-roadmap-strategist.md` to expose the agents in the Claude catalog. 
- Added corresponding `.claude/skills` packages for `meridian-archive-organizer`, `meridian-repo-navigation`, and `meridian-roadmap-strategist` including `SKILL.md`, `agents/openai.yaml`, and references; the archive skill also includes `evals/`, `fixtures/`, and scripts. 
- Implemented archive-organizer tooling: `scripts/trace_archive_candidates.py`, `scripts/run_evals.py`, and `scripts/score_eval.py`, plus guidance files `archive-placement-guide.md` and `evaluation-harness.md` and deterministic fixtures for eval scenarios. 
- Committed the additions as a single change (19 files added, commit created) to make the new skills discoverable and usable by local agent tooling. 

### Testing

- Verified repository state with `git status --short` and recorded the commit via `git commit`, and confirmed the last commit with `git log -1 --oneline`, all of which succeeded. 
- No build or runtime code changes were introduced, so no `dotnet build` or unit tests were run as part of this change. 
- Included eval and trace scripts are present for future automated validation, but they were not executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadbe4507c8320a51fd32c1d1f5587)