### PR TITLE
Add promotion rejection control to trading cockpit

### DIFF
--- a/docs/status/FULL_IMPLEMENTATION_TODO_2026_03_20.md
+++ b/docs/status/FULL_IMPLEMENTATION_TODO_2026_03_20.md
@@ -48,6 +48,7 @@ Closed platform work:
 - Paper-trading cockpit REST endpoints wired: `/api/execution/account`, `/api/execution/positions`, `/api/execution/portfolio`, `/api/execution/orders`, `/api/execution/health`, `/api/execution/capabilities`
 - Paper-trading session management endpoints: `/api/execution/sessions` (create, list, detail, close)
 - `Backtest → Paper → Live` promotion workflow endpoints: `/api/promotion/evaluate/{runId}`, `/api/promotion/approve`, `/api/promotion/reject`, `/api/promotion/history`
+- Trading dashboard promotion gate now supports both **approval** and **rejection** decisions with explicit operator rationale fields wired to the promotion API
 - Strategy lifecycle control endpoints: `/api/strategies/status`, `/api/strategies/{id}/status`, `/api/strategies/{id}/pause`, `/api/strategies/{id}/stop`
 - `PaperSessionPersistenceService`, `IPortfolioState`, `IOrderGateway`, `IOrderManager`, `StrategyLifecycleManager` fully wired in DI
 - Brokerage gateway framework complete: `IBrokerageGateway`, `BaseBrokerageGateway`, `BrokerageGatewayAdapter`, plus Alpaca/IB/StockSharp adapter implementations

--- a/src/Meridian.Ui/dashboard/src/screens/trading-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/trading-screen.test.tsx
@@ -105,6 +105,7 @@ vi.mock("@/lib/api", async () => {
     setReplaySpeed: vi.fn().mockResolvedValue({}),
     evaluatePromotion: vi.fn().mockResolvedValue({ runId: "run-1", strategyId: "strat-1", strategyName: "S1", sourceMode: "backtest", targetMode: "paper", isEligible: true, sharpeRatio: 1.2, maxDrawdownPercent: 5, totalReturn: 10, reason: "Eligible", found: true, ready: true }),
     approvePromotion: vi.fn().mockResolvedValue({ success: true, promotionId: "promo-1", newRunId: "paper-1", reason: "approved" }),
+    rejectPromotion: vi.fn().mockResolvedValue({ success: true, promotionId: null, newRunId: null, reason: "Run breached risk gate." }),
     getPromotionHistory: vi.fn().mockResolvedValue([{
       promotionId: "promo-1",
       strategyId: "strat-1",
@@ -204,6 +205,18 @@ describe("TradingScreen", () => {
     await user.type(screen.getByLabelText("Run id"), "run-bad");
     await user.click(screen.getByRole("button", { name: /evaluate gate checks/i }));
     await screen.findByText("eval failed");
+  });
+
+  it("supports rejecting a promotion with a required rationale", async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter initialEntries={["/trading"]}><TradingScreen data={data} /></MemoryRouter>);
+
+    await user.type(screen.getByLabelText("Run id"), "run-1");
+    await user.type(screen.getByLabelText("Rejection reason"), "Risk review failed on drawdown stability.");
+    await user.click(screen.getByRole("button", { name: /reject promotion/i }));
+
+    await screen.findByText(/Promotion rejected: Run breached risk gate\./i);
+    expect(api.rejectPromotion).toHaveBeenCalledWith("run-1", "Risk review failed on drawdown stability.");
   });
 
   it("supports replay start and restore session for reconnect/resume workflows", async () => {

--- a/src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx
@@ -11,7 +11,7 @@ import {
   DialogTitle
 } from "@/components/ui/dialog";
 import { MetricCard } from "@/components/meridian/metric-card";
-import { approvePromotion, cancelAllOrders, cancelOrder, closePosition, closePaperSession, createPaperSession, evaluatePromotion, getExecutionAudit, getExecutionControls, getExecutionSessions, getPaperSessionDetail, getPaperSessionReplayVerification, getPromotionHistory, getReplayFiles, getReplayStatus, pauseReplay, pauseStrategy, resumeReplay, seekReplay, setReplaySpeed as apiSetReplaySpeed, startReplay, stopReplay, stopStrategy, submitOrder } from "@/lib/api";
+import { approvePromotion, cancelAllOrders, cancelOrder, closePosition, closePaperSession, createPaperSession, evaluatePromotion, getExecutionAudit, getExecutionControls, getExecutionSessions, getPaperSessionDetail, getPaperSessionReplayVerification, getPromotionHistory, getReplayFiles, getReplayStatus, pauseReplay, pauseStrategy, rejectPromotion, resumeReplay, seekReplay, setReplaySpeed as apiSetReplaySpeed, startReplay, stopReplay, stopStrategy, submitOrder } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import type { ExecutionAuditEntry, ExecutionControlSnapshot, OrderSubmitRequest, PaperSessionDetail, PaperSessionReplayVerification, PaperSessionSummary, PromotionEvaluationResult, PromotionRecord, ReplayFileRecord, ReplayStatus, TradingActionResult, TradingWorkspaceResponse } from "@/types";
 
@@ -172,6 +172,7 @@ export function TradingScreen({ data }: TradingScreenProps) {
   const [promotionRunId, setPromotionRunId] = useState("");
   const [promotionApprovedBy, setPromotionApprovedBy] = useState("");
   const [promotionApprovalReason, setPromotionApprovalReason] = useState("");
+  const [promotionRejectionReason, setPromotionRejectionReason] = useState("");
   const [promotionReviewNotes, setPromotionReviewNotes] = useState("");
   const [promotionManualOverrideId, setPromotionManualOverrideId] = useState("");
   const [promotionEval, setPromotionEval] = useState<PromotionEvaluationResult | null>(null);
@@ -384,6 +385,27 @@ export function TradingScreen({ data }: TradingScreenProps) {
       setPromotionHistory(history);
     } catch (err) {
       setPromotionError(err instanceof Error ? err.message : "Promotion approval failed.");
+    } finally {
+      setPromotionBusy(false);
+    }
+  }
+
+  async function handleRejectPromotion() {
+    if (!promotionRunId.trim() || !promotionRejectionReason.trim()) {
+      setPromotionError("Run id and rejection reason are required.");
+      return;
+    }
+
+    setPromotionBusy(true);
+    setPromotionError(null);
+    setPromotionResult(null);
+    try {
+      const result = await rejectPromotion(promotionRunId.trim(), promotionRejectionReason.trim());
+      setPromotionResult(result.success ? `Promotion rejected: ${result.reason}` : result.reason);
+      const history = await getPromotionHistory();
+      setPromotionHistory(history);
+    } catch (err) {
+      setPromotionError(err instanceof Error ? err.message : "Promotion rejection failed.");
     } finally {
       setPromotionBusy(false);
     }
@@ -1121,6 +1143,13 @@ export function TradingScreen({ data }: TradingScreenProps) {
               required
             />
             <input
+              aria-label="Rejection reason"
+              placeholder="why this promotion is rejected"
+              value={promotionRejectionReason}
+              onChange={(e) => setPromotionRejectionReason(e.target.value)}
+              className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+            />
+            <input
               aria-label="Review notes"
               placeholder="optional review notes"
               value={promotionReviewNotes}
@@ -1137,6 +1166,7 @@ export function TradingScreen({ data }: TradingScreenProps) {
             <div className="flex gap-2">
               <Button size="sm" variant="outline" onClick={handleEvaluatePromotion} disabled={promotionBusy || !promotionRunId.trim()}>Evaluate gate checks</Button>
               <Button size="sm" onClick={handlePromoteToPaper} disabled={promotionBusy || !promotionEval?.isEligible || !promotionApprovedBy.trim() || !promotionApprovalReason.trim()}>Confirm promote</Button>
+              <Button size="sm" variant="destructive" onClick={handleRejectPromotion} disabled={promotionBusy || !promotionRunId.trim() || !promotionRejectionReason.trim()}>Reject promotion</Button>
             </div>
             {promotionEval && (
               <div className="rounded-lg border border-border/60 p-3 text-xs">


### PR DESCRIPTION
### Motivation
- Provide operators an explicit, auditable rejection path for the Backtest → Paper promotion gate so decisions can be recorded with rationale. 
- Keep the trading cockpit’s promotion UI aligned with the promotion API surface which already supports approve/reject outcomes. 
- Advance Wave 2 delivery by finishing the decision controls and ensuring promotion history refreshes after operator actions. 

### Description
- Add a rejection rationale input, local state (`promotionRejectionReason`), and a destructive `Reject promotion` button to the trading cockpit UI in `src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx`. 
- Implement `handleRejectPromotion` which calls the existing `rejectPromotion(runId, reason)` API and refreshes promotion history via `getPromotionHistory`. 
- Wire `rejectPromotion` into the dashboard API imports and enable client-side validation that both run id and rejection reason are provided before submission. 
- Add a UI test that mocks `rejectPromotion` and verifies the rejection happy-path, and update the normalized backlog doc to note that the promotion gate supports both approval and rejection with operator rationale (file edits listed). 

### Testing
- Added a Jest/React Testing Library test in `src/Meridian.Ui/dashboard/src/screens/trading-screen.test.tsx` that covers the rejection workflow but the repository-level UI tests were not runnable here. 
- Attempted to run `npm run ui:dashboard:test` which failed with `ENOENT` because `src/Meridian.Ui/dashboard/package.json` is not present in this environment. 
- Attempted to run `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~StrategyLifecycleManagerTests"` which failed because `dotnet` is not installed in the execution environment. 
- Note: the new UI test is present and will run in CI or a developer machine with the dashboard npm project and `dotnet` available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab5ded0b48320a31066388baf6095)