### PR TITLE
Add stage-aware telemetry to backtest engine progress reporting

### DIFF
--- a/src/Meridian.Backtesting.Sdk/BacktestProgressEvent.cs
+++ b/src/Meridian.Backtesting.Sdk/BacktestProgressEvent.cs
@@ -11,4 +11,21 @@ public sealed record BacktestProgressEvent(
     /// Rolling performance metrics available after at least 60 trading days have elapsed.
     /// <c>null</c> before that threshold or on the final completion event.
     /// </summary>
-    IntermediateMetrics? LiveMetrics = null);
+    IntermediateMetrics? LiveMetrics = null,
+    /// <summary>
+    /// Execution stage the engine was in when this event was emitted.
+    /// Defaults to <see cref="BacktestStage.Replaying"/> so legacy callers and
+    /// tests that construct events without a stage continue to observe the
+    /// dominant replay-loop behaviour.
+    /// </summary>
+    BacktestStage Stage = BacktestStage.Replaying,
+    /// <summary>
+    /// Wall-clock time spent in the current <see cref="Stage"/> up to the moment
+    /// this event was emitted. <see cref="TimeSpan.Zero"/> when the engine has
+    /// not begun timing (e.g. externally constructed events).
+    /// </summary>
+    TimeSpan StageElapsed = default,
+    /// <summary>
+    /// Wall-clock time since the engine run started, across all stages.
+    /// </summary>
+    TimeSpan TotalElapsed = default);

--- a/src/Meridian.Backtesting.Sdk/BacktestStage.cs
+++ b/src/Meridian.Backtesting.Sdk/BacktestStage.cs
@@ -1,0 +1,43 @@
+namespace Meridian.Backtesting.Sdk;
+
+/// <summary>
+/// Execution stages emitted by the native backtest engine alongside
+/// <see cref="BacktestProgressEvent"/>. Stages let operators see where time is
+/// spent and surface actionable bottlenecks beyond a coarse percentage.
+/// </summary>
+/// <remarks>
+/// Not every engine pass emits every stage. Corporate-action adjustment is lazy,
+/// fill simulation is interleaved with replay, and artifact persistence is the
+/// caller's responsibility in the current engine. Values are defined for the
+/// full trust-and-velocity plan so downstream consumers can reason about the
+/// complete surface today.
+/// </remarks>
+public enum BacktestStage
+{
+    /// <summary>Arguments and request shape are being validated.</summary>
+    ValidatingRequest = 0,
+
+    /// <summary>Symbol universe, security master, and tick sizes are being resolved.</summary>
+    ValidatingCoverage = 1,
+
+    /// <summary>Per-symbol replay streams are being opened.</summary>
+    LoadingData = 2,
+
+    /// <summary>Corporate-action adjustments are being applied to loaded bars.</summary>
+    ApplyingCorporateActions = 3,
+
+    /// <summary>Multi-symbol chronological merge and strategy dispatch are in progress.</summary>
+    Replaying = 4,
+
+    /// <summary>Pending orders are being matched against the active fill model.</summary>
+    SimulatingFills = 5,
+
+    /// <summary>End-of-run metrics are being computed from captured snapshots and fills.</summary>
+    ComputingMetrics = 6,
+
+    /// <summary>Run artifacts are being persisted (optional; caller-driven today).</summary>
+    PersistingArtifacts = 7,
+
+    /// <summary>Run finished successfully.</summary>
+    Completed = 8,
+}

--- a/src/Meridian.Backtesting/Engine/BacktestEngine.cs
+++ b/src/Meridian.Backtesting/Engine/BacktestEngine.cs
@@ -37,10 +37,12 @@ public sealed class BacktestEngine(
         ArgumentNullException.ThrowIfNull(strategy);
 
         var sw = Stopwatch.StartNew();
+        var stageTimer = new StageTimer(BacktestStage.ValidatingRequest);
         logger.LogInformation("Backtesting '{Strategy}' from {From} to {To} in {DataRoot}",
             strategy.Name, request.From, request.To, request.DataRoot);
 
         // 1. Discover universe
+        stageTimer.Transition(BacktestStage.ValidatingCoverage);
         var universe = await UniverseDiscovery.DiscoverAsync(
             catalogService, request.DataRoot, request.Symbols, request.From, request.To, ct)
             .ConfigureAwait(false);
@@ -48,6 +50,8 @@ public sealed class BacktestEngine(
         if (universe.Count == 0 && request.AssetEvents is not { Count: > 0 })
         {
             logger.LogWarning("No symbols found in data root '{DataRoot}' for the requested date range", request.DataRoot);
+            stageTimer.Transition(BacktestStage.Completed);
+            stageTimer.Stop();
             return CreateEmptyResult(request, universe, sw.Elapsed);
         }
 
@@ -86,9 +90,11 @@ public sealed class BacktestEngine(
         ApplyScheduledAssetEvents(request.From, assetEventsByDate, portfolio, ctx);
 
         // 4. Build per-symbol replay streams (with corporate action adjustments if enabled)
+        stageTimer.Transition(BacktestStage.LoadingData);
         var streams = await BuildSymbolStreamsAsync(universe, request, ct).ConfigureAwait(false);
 
         // 5. Replay loop — multi-symbol chronological merge
+        stageTimer.Transition(BacktestStage.Replaying);
         var currentDay = request.From;
         long eventsProcessed = 0;
         var totalDays = (request.To.ToDateTime(TimeOnly.MinValue) - request.From.ToDateTime(TimeOnly.MinValue)).Days + 1;
@@ -103,7 +109,7 @@ public sealed class BacktestEngine(
             // Day boundary — close out the previous day and apply any gap-day asset events.
             if (evtDate > currentDay)
             {
-                AdvanceDays(currentDay, evtDate, portfolio, ctx, strategy, pendingOrders, allSnapshots, allCashFlows, assetEventsByDate, progress, request.From, totalDays, eventsProcessed, rollingState, ct);
+                AdvanceDays(currentDay, evtDate, portfolio, ctx, strategy, pendingOrders, allSnapshots, allCashFlows, assetEventsByDate, progress, request.From, totalDays, eventsProcessed, rollingState, stageTimer, ct);
                 currentDay = evtDate;
             }
 
@@ -134,11 +140,24 @@ public sealed class BacktestEngine(
         }
 
         strategy.OnFinished(ctx);
-        progress?.Report(new BacktestProgressEvent(1.0, request.To, portfolio.ComputeCurrentEquity(), eventsProcessed, "Complete"));
 
         // 6. Compute metrics
+        stageTimer.Transition(BacktestStage.ComputingMetrics);
         var metrics = BacktestMetricsEngine.Compute(allSnapshots, allCashFlows, allFills, request);
         sw.Stop();
+
+        stageTimer.Transition(BacktestStage.Completed);
+        stageTimer.Stop();
+        progress?.Report(new BacktestProgressEvent(
+            ProgressFraction: 1.0,
+            CurrentDate: request.To,
+            PortfolioValue: portfolio.ComputeCurrentEquity(),
+            EventsProcessed: eventsProcessed,
+            Message: "Complete",
+            LiveMetrics: null,
+            Stage: stageTimer.CurrentStage,
+            StageElapsed: stageTimer.StageElapsed,
+            TotalElapsed: stageTimer.TotalElapsed));
 
         if (double.IsNaN(metrics.Xirr))
             logger.LogWarning("XIRR bisection did not converge for this backtest run; Xirr will be reported as NaN. Check cash-flow patterns for non-standard sign changes.");
@@ -303,6 +322,7 @@ public sealed class BacktestEngine(
         int totalDays,
         long eventsProcessed,
         RollingMetricsState rollingState,
+        StageTimer stageTimer,
         CancellationToken ct)
     {
         ProcessDayEnd(fromDay, portfolio, pendingOrders, ctx, strategy, snapshots, allCashFlows, ct);
@@ -326,11 +346,15 @@ public sealed class BacktestEngine(
                 liveMetrics = rollingState.Snapshot();
 
             progress?.Report(new BacktestProgressEvent(
-                (double)daysElapsed / totalDays,
-                date,
-                equity,
-                eventsProcessed,
-                LiveMetrics: liveMetrics));
+                ProgressFraction: (double)daysElapsed / totalDays,
+                CurrentDate: date,
+                PortfolioValue: equity,
+                EventsProcessed: eventsProcessed,
+                Message: null,
+                LiveMetrics: liveMetrics,
+                Stage: stageTimer.CurrentStage,
+                StageElapsed: stageTimer.StageElapsed,
+                TotalElapsed: stageTimer.TotalElapsed));
         }
     }
 

--- a/src/Meridian.Backtesting/Engine/StageTimer.cs
+++ b/src/Meridian.Backtesting/Engine/StageTimer.cs
@@ -1,0 +1,84 @@
+using System.Diagnostics;
+using Meridian.Backtesting.Sdk;
+
+namespace Meridian.Backtesting.Engine;
+
+/// <summary>
+/// Tracks the currently-active <see cref="BacktestStage"/> and the wall-clock
+/// time spent in each stage across a single backtest run. Not thread-safe;
+/// owned by the engine and only mutated on the replay thread.
+/// </summary>
+internal sealed class StageTimer
+{
+    private readonly Stopwatch _total;
+    private readonly Stopwatch _stage;
+    private readonly Dictionary<BacktestStage, TimeSpan> _cumulative = new();
+
+    public StageTimer(BacktestStage initialStage = BacktestStage.ValidatingRequest)
+    {
+        CurrentStage = initialStage;
+        _total = Stopwatch.StartNew();
+        _stage = Stopwatch.StartNew();
+    }
+
+    public BacktestStage CurrentStage { get; private set; }
+
+    public TimeSpan TotalElapsed => _total.Elapsed;
+
+    public TimeSpan StageElapsed => _stage.Elapsed;
+
+    /// <summary>
+    /// Ends the current stage and starts a new one. The prior stage's elapsed
+    /// time is accumulated into the cumulative totals. Transitioning to the
+    /// same stage is a no-op so callers may idempotently request the current
+    /// stage at phase boundaries.
+    /// </summary>
+    public void Transition(BacktestStage next)
+    {
+        if (next == CurrentStage)
+            return;
+
+        Accumulate(CurrentStage, _stage.Elapsed);
+        CurrentStage = next;
+        _stage.Restart();
+    }
+
+    /// <summary>
+    /// Stops all timers and folds the active stage's time into the cumulative
+    /// totals. Idempotent.
+    /// </summary>
+    public void Stop()
+    {
+        if (_stage.IsRunning)
+        {
+            Accumulate(CurrentStage, _stage.Elapsed);
+            _stage.Stop();
+        }
+
+        if (_total.IsRunning)
+            _total.Stop();
+    }
+
+    /// <summary>
+    /// Snapshot of cumulative time spent in each observed stage at the moment
+    /// this method is invoked. Includes the in-flight stage's current elapsed.
+    /// </summary>
+    public IReadOnlyDictionary<BacktestStage, TimeSpan> Cumulative()
+    {
+        var snapshot = new Dictionary<BacktestStage, TimeSpan>(_cumulative);
+        if (_stage.IsRunning)
+        {
+            snapshot[CurrentStage] = snapshot.TryGetValue(CurrentStage, out var prior)
+                ? prior + _stage.Elapsed
+                : _stage.Elapsed;
+        }
+        return snapshot;
+    }
+
+    private void Accumulate(BacktestStage stage, TimeSpan elapsed)
+    {
+        _cumulative[stage] = _cumulative.TryGetValue(stage, out var prior)
+            ? prior + elapsed
+            : elapsed;
+    }
+}

--- a/tests/Meridian.Backtesting.Tests/StageTelemetryTests.cs
+++ b/tests/Meridian.Backtesting.Tests/StageTelemetryTests.cs
@@ -1,0 +1,286 @@
+using System.Text.Json;
+using FluentAssertions;
+using Meridian.Application.Serialization;
+using Meridian.Backtesting.Engine;
+using Meridian.Domain.Events;
+using Meridian.Storage;
+using Meridian.Storage.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Meridian.Backtesting.Tests;
+
+/// <summary>
+/// Exercises stage-aware telemetry on <see cref="BacktestProgressEvent"/> and the
+/// internal <see cref="StageTimer"/> that backs it.  Coverage:
+///  • StageTimer transition semantics (durations, idempotency, cumulative).
+///  • Engine progress events carry the expected stage enum, elapsed durations,
+///    and monotonically non-decreasing <c>TotalElapsed</c> across the run.
+/// </summary>
+public sealed class StageTelemetryTests : IDisposable
+{
+    private readonly string _dataRoot;
+    private readonly BacktestEngine _engine;
+
+    public StageTelemetryTests()
+    {
+        _dataRoot = Path.Combine(Path.GetTempPath(), $"meridian-stage-telemetry-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dataRoot);
+
+        var catalog = new StorageCatalogService(_dataRoot, new StorageOptions());
+        _engine = new BacktestEngine(NullLogger<BacktestEngine>.Instance, catalog);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dataRoot))
+            Directory.Delete(_dataRoot, recursive: true);
+    }
+
+    // ------------------------------------------------------------------ //
+    //  StageTimer unit behaviour                                          //
+    // ------------------------------------------------------------------ //
+
+    [Fact]
+    public void StageTimer_StartsInRequestedStage_WithRunningStopwatches()
+    {
+        var timer = new StageTimer(BacktestStage.ValidatingRequest);
+
+        timer.CurrentStage.Should().Be(BacktestStage.ValidatingRequest);
+        timer.TotalElapsed.Should().BeGreaterThanOrEqualTo(TimeSpan.Zero);
+        timer.StageElapsed.Should().BeGreaterThanOrEqualTo(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void StageTimer_Transition_ResetsStageElapsed_AndPreservesTotalElapsed()
+    {
+        var timer = new StageTimer(BacktestStage.ValidatingRequest);
+        Thread.Sleep(15);
+        var totalBefore = timer.TotalElapsed;
+
+        timer.Transition(BacktestStage.Replaying);
+
+        timer.CurrentStage.Should().Be(BacktestStage.Replaying);
+        timer.StageElapsed.Should().BeLessThan(totalBefore,
+            "a fresh stage timer starts at (near) zero, while total elapsed keeps the pre-transition history");
+        timer.TotalElapsed.Should().BeGreaterThanOrEqualTo(totalBefore,
+            "TotalElapsed is monotonic across transitions");
+    }
+
+    [Fact]
+    public void StageTimer_TransitionToSameStage_IsIdempotent()
+    {
+        var timer = new StageTimer(BacktestStage.Replaying);
+        Thread.Sleep(15);
+        var stageBefore = timer.StageElapsed;
+
+        timer.Transition(BacktestStage.Replaying);
+
+        timer.CurrentStage.Should().Be(BacktestStage.Replaying);
+        timer.StageElapsed.Should().BeGreaterThanOrEqualTo(stageBefore,
+            "self-transition must not reset the active stage's elapsed time");
+    }
+
+    [Fact]
+    public void StageTimer_Cumulative_IncludesActiveStage_AndAccumulatesAcrossTransitions()
+    {
+        var timer = new StageTimer(BacktestStage.ValidatingRequest);
+        Thread.Sleep(10);
+        timer.Transition(BacktestStage.Replaying);
+        Thread.Sleep(10);
+        timer.Transition(BacktestStage.ComputingMetrics);
+        Thread.Sleep(10);
+
+        var snapshot = timer.Cumulative();
+
+        snapshot.Keys.Should().Contain(new[]
+        {
+            BacktestStage.ValidatingRequest,
+            BacktestStage.Replaying,
+            BacktestStage.ComputingMetrics,
+        });
+
+        foreach (var stage in snapshot.Keys)
+            snapshot[stage].Should().BeGreaterThan(TimeSpan.Zero, $"{stage} should have accumulated time");
+
+        snapshot.Values.Sum(t => t.Ticks).Should().BeLessThanOrEqualTo(timer.TotalElapsed.Ticks + TimeSpan.FromMilliseconds(5).Ticks,
+            "cumulative sum should not exceed total elapsed (allowing a small skew for in-flight stage sampling)");
+    }
+
+    [Fact]
+    public void StageTimer_Stop_IsIdempotent_AndFreezesElapsedValues()
+    {
+        var timer = new StageTimer(BacktestStage.Replaying);
+        Thread.Sleep(10);
+        timer.Stop();
+        var total1 = timer.TotalElapsed;
+        var stage1 = timer.StageElapsed;
+
+        Thread.Sleep(10);
+        timer.Stop();
+
+        timer.TotalElapsed.Should().Be(total1);
+        timer.StageElapsed.Should().Be(stage1);
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Engine-level stage emission                                        //
+    // ------------------------------------------------------------------ //
+
+    [Fact]
+    public async Task RunAsync_EmitsCompletionEvent_WithStageCompleted_AndPositiveTotalElapsed()
+    {
+        WriteBarJsonl("AAPL", new DateOnly(2024, 1, 2), new DateOnly(2024, 1, 3), basePrice: 180m);
+
+        var events = new List<BacktestProgressEvent>();
+        var progress = new Progress<BacktestProgressEvent>(e => { lock (events) events.Add(e); });
+
+        var request = new BacktestRequest(
+            From: new DateOnly(2024, 1, 2),
+            To: new DateOnly(2024, 1, 3),
+            DataRoot: _dataRoot);
+
+        await _engine.RunAsync(request, new TelemetryNoOpStrategy(), progress);
+        await WaitForProgressDeliveryAsync(events);
+
+        BacktestProgressEvent completion;
+        lock (events)
+        {
+            events.Should().NotBeEmpty("at least one progress event must be reported");
+            completion = events[^1];
+        }
+
+        completion.ProgressFraction.Should().Be(1.0);
+        completion.Stage.Should().Be(BacktestStage.Completed,
+            "the terminal event must report the Completed stage");
+        completion.TotalElapsed.Should().BeGreaterThan(TimeSpan.Zero,
+            "TotalElapsed on the completion event must reflect real wall-clock time");
+        completion.Message.Should().Be("Complete");
+    }
+
+    [Fact]
+    public async Task RunAsync_ProgressReports_TotalElapsedNonDecreasing_AndStagesInExpectedSet()
+    {
+        // Multi-day range forces AdvanceDays to emit per-day progress events,
+        // giving us multiple samples to assert monotonicity.
+        WriteBarJsonl("SPY", new DateOnly(2024, 1, 2), new DateOnly(2024, 1, 10), basePrice: 470m);
+
+        var events = new List<BacktestProgressEvent>();
+        var progress = new Progress<BacktestProgressEvent>(e => { lock (events) events.Add(e); });
+
+        var request = new BacktestRequest(
+            From: new DateOnly(2024, 1, 2),
+            To: new DateOnly(2024, 1, 10),
+            DataRoot: _dataRoot);
+
+        await _engine.RunAsync(request, new TelemetryNoOpStrategy(), progress);
+        await WaitForProgressDeliveryAsync(events, minCount: 2);
+
+        BacktestProgressEvent[] snapshot;
+        lock (events)
+        {
+            snapshot = events.ToArray();
+        }
+
+        snapshot.Should().HaveCountGreaterThan(1, "multi-day replay should emit more than a single terminal event");
+
+        var allowedStages = new[] { BacktestStage.Replaying, BacktestStage.Completed };
+        snapshot.Select(e => e.Stage).Distinct().Should().OnlyContain(s => allowedStages.Contains(s),
+            "the engine currently emits Replaying during the loop and Completed at the end");
+
+        for (var i = 1; i < snapshot.Length; i++)
+        {
+            snapshot[i].TotalElapsed.Should().BeGreaterThanOrEqualTo(snapshot[i - 1].TotalElapsed,
+                $"TotalElapsed must be non-decreasing across progress events (index {i})");
+        }
+
+        snapshot.Last().Stage.Should().Be(BacktestStage.Completed);
+    }
+
+    [Fact]
+    public async Task RunAsync_EmptyUniverse_StillReportsNothing_ButDoesNotThrow()
+    {
+        // The empty-universe fast path exits without reporting progress, which is
+        // the pre-existing contract. We assert the path continues to return a
+        // well-formed result after the telemetry refactor.
+        var events = new List<BacktestProgressEvent>();
+        var progress = new Progress<BacktestProgressEvent>(e => { lock (events) events.Add(e); });
+
+        var request = new BacktestRequest(
+            From: new DateOnly(2024, 1, 2),
+            To: new DateOnly(2024, 1, 3),
+            DataRoot: _dataRoot);
+
+        var result = await _engine.RunAsync(request, new TelemetryNoOpStrategy(), progress);
+
+        result.Should().NotBeNull();
+        result.TotalEventsProcessed.Should().Be(0);
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Helpers                                                            //
+    // ------------------------------------------------------------------ //
+
+    private static async Task WaitForProgressDeliveryAsync(List<BacktestProgressEvent> events, int minCount = 1, int timeoutMs = 1_000)
+    {
+        // Progress<T> posts to the SynchronizationContext or ThreadPool; give the
+        // posted callbacks a bounded window to drain before we assert on them.
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            lock (events)
+            {
+                if (events.Count >= minCount)
+                    return;
+            }
+            await Task.Delay(10);
+        }
+    }
+
+    private void WriteBarJsonl(string symbol, DateOnly from, DateOnly to, decimal basePrice, decimal dailyGain = 0m)
+    {
+        var symbolDir = Path.Combine(_dataRoot, symbol.ToUpperInvariant());
+        Directory.CreateDirectory(symbolDir);
+        var filePath = Path.Combine(symbolDir, $"{symbol}_bars_{from:yyyy-MM-dd}.jsonl");
+
+        using var writer = new StreamWriter(filePath);
+        var date = from;
+        var seq = 1L;
+        while (date <= to)
+        {
+            var open = basePrice + (date.DayNumber - from.DayNumber) * dailyGain;
+            var high = open + 5m;
+            var low = open - 5m;
+            var close = open + dailyGain;
+
+            var bar = new HistoricalBar(
+                Symbol: symbol,
+                SessionDate: date,
+                Open: open,
+                High: high,
+                Low: low,
+                Close: close,
+                Volume: 1_000_000L,
+                Source: "test",
+                SequenceNumber: seq++);
+
+            var ts = bar.ToTimestampUtc();
+            var evt = MarketEvent.HistoricalBar(ts, symbol, bar, seq, "test");
+
+            writer.WriteLine(JsonSerializer.Serialize(evt, MarketDataJsonContext.HighPerformanceOptions));
+            date = date.AddDays(1);
+        }
+    }
+}
+
+file sealed class TelemetryNoOpStrategy : IBacktestStrategy
+{
+    public string Name => "TelemetryNoOp";
+    public void Initialize(IBacktestContext ctx) { }
+    public void OnTrade(Trade trade, IBacktestContext ctx) { }
+    public void OnQuote(BboQuotePayload quote, IBacktestContext ctx) { }
+    public void OnBar(HistoricalBar bar, IBacktestContext ctx) { }
+    public void OnOrderBook(LOBSnapshot snapshot, IBacktestContext ctx) { }
+    public void OnOrderFill(FillEvent fill, IBacktestContext ctx) { }
+    public void OnDayEnd(DateOnly date, IBacktestContext ctx) { }
+    public void OnFinished(IBacktestContext ctx) { }
+}


### PR DESCRIPTION
## Description

This PR introduces stage-aware telemetry to the backtest engine, enabling operators to understand where time is spent during a backtest run. The changes add:

1. **BacktestStage enum** - Defines 9 execution stages from `ValidatingRequest` through `Completed`, representing the full lifecycle of a backtest run
2. **StageTimer class** - Internal timer that tracks wall-clock time spent in each stage, with support for:
   - Stage transitions with automatic elapsed time accumulation
   - Idempotent self-transitions (no-op if transitioning to the current stage)
   - Monotonic total elapsed time across all stages
   - Cumulative time snapshots per stage
3. **Enhanced BacktestProgressEvent** - Extended with three new fields:
   - `Stage` - Current execution stage (defaults to `Replaying` for backward compatibility)
   - `StageElapsed` - Time spent in the current stage
   - `TotalElapsed` - Total time since engine start
4. **Engine integration** - BacktestEngine now:
   - Creates and manages a StageTimer instance
   - Transitions through stages at appropriate boundaries (validation → coverage → loading → replaying → metrics → completed)
   - Reports stage information in progress events

## Type of Change

- New feature
- Test improvements

## Motivation and Context

The backtest engine previously reported only a coarse progress percentage without visibility into where time was actually spent. This made it difficult to identify bottlenecks—whether the slowdown was in data loading, replay, or metrics computation. Stage-aware telemetry provides actionable insights by:

- Allowing operators to see which stages are consuming the most time
- Enabling better capacity planning and optimization targeting
- Supporting future enhancements (e.g., stage-specific timeouts, parallel stage execution)
- Maintaining backward compatibility through sensible defaults

## How Has This Been Tested?

Added comprehensive test suite (`StageTelemetryTests`) covering:
- **StageTimer unit behavior**: Initialization, transitions, idempotency, cumulative tracking, and stop semantics
- **Engine-level emission**: Completion events report correct stage and positive elapsed times
- **Progress monotonicity**: Multi-day replays emit multiple events with non-decreasing `TotalElapsed` and valid stage values
- **Empty universe path**: Verifies the fast path for empty data still works correctly

All tests pass and exercise both the timer mechanics and end-to-end engine integration.

## Checklist

- [x] My code follows the code style of this project
- [x] All new and existing tests passed
- [x] I have checked my code and corrected any misspellings
- [x] My changes generate no new warnings
- [x] Added tests to cover the new functionality

## Additional Notes

The implementation is thread-safe at the engine level (StageTimer is owned by the replay thread only) and maintains backward compatibility—existing code that constructs `BacktestProgressEvent` without the new fields will continue to work with sensible defaults.

https://claude.ai/code/session_01ADQgyh6XZuN4rR8TDz1cft