### PR TITLE
Normalize screenshot artifact paths in workflow and rename ResearchShell to StrategyShell

### DIFF
--- a/.github/workflows/refresh-screenshots.yml
+++ b/.github/workflows/refresh-screenshots.yml
@@ -182,22 +182,25 @@ jobs:
       - name: Merge downloaded PNGs into workspace
         run: |
           $outputRoot = "${{ inputs.output_root || 'docs/screenshots/desktop' }}"
+          $normalizedOutputRoot = $outputRoot.Replace('\','/').Trim('/')
           New-Item -ItemType Directory -Force -Path $outputRoot | Out-Null
 
           $pngs = Get-ChildItem -Path _artifacts -Recurse -Filter *.png -ErrorAction SilentlyContinue
           Write-Host "Downloaded PNG count: $($pngs.Count)"
 
           foreach ($png in $pngs) {
-            $rel = $png.FullName.Substring((Resolve-Path _artifacts).Path.Length).TrimStart('\\')
+            $artifactRoot = (Resolve-Path _artifacts).Path
+            $rel = $png.FullName.Substring($artifactRoot.Length).TrimStart('\\','/')
+            $relNormalized = $rel.Replace('\','/')
 
             # Each artifact is stored as: _artifacts/<artifact-name>/<original-path>/.../*.png
             # Find the first occurrence of the output root inside that path and copy from there.
-            $idx = $rel.ToLower().IndexOf($outputRoot.ToLower())
+            $idx = $relNormalized.ToLower().IndexOf($normalizedOutputRoot.ToLower())
             if ($idx -lt 0) {
               continue
             }
 
-            $subPath = $rel.Substring($idx + $outputRoot.Length).TrimStart('\\','/')
+            $subPath = $relNormalized.Substring($idx + $normalizedOutputRoot.Length).TrimStart('/')
             $dest = Join-Path $outputRoot $subPath
 
             New-Item -ItemType Directory -Force -Path (Split-Path -Parent $dest) | Out-Null

--- a/scripts/dev/desktop-workflows.json
+++ b/scripts/dev/desktop-workflows.json
@@ -17,7 +17,7 @@
       "steps": [
         {
           "title": "Research Workspace",
-          "pageTag": "ResearchShell",
+          "pageTag": "StrategyShell",
           "captureName": "wpf-research-workspace",
           "notes": "Validate that the shell loads cleanly and the Research workspace remains screenshot ready."
         },
@@ -109,7 +109,7 @@
       "steps": [
         {
           "title": "Research Workspace",
-          "pageTag": "ResearchShell",
+          "pageTag": "StrategyShell",
           "captureName": "01-research-workspace",
           "notes": "Confirm that the shell rendered, the demo data banner is visible, and the status bar started updating."
         },
@@ -155,7 +155,7 @@
       "steps": [
         {
           "title": "Research Workspace",
-          "pageTag": "ResearchShell",
+          "pageTag": "StrategyShell",
           "captureName": "01-research-workspace",
           "notes": "Start on the Research workspace to review the shell status bar, demo data banner, and the first-launch landing experience."
         },
@@ -167,7 +167,7 @@
         },
         {
           "title": "Research Workspace",
-          "pageTag": "ResearchShell",
+          "pageTag": "StrategyShell",
           "captureName": "03-research-workspace",
           "notes": "The Research workspace now keeps the current workspace next action above the fold while secondary workspace actions stay behind expansion."
         },
@@ -257,7 +257,7 @@
       "steps": [
         {
           "title": "Research Workspace",
-          "pageTag": "ResearchShell",
+          "pageTag": "StrategyShell",
           "captureName": "01-research-shell",
           "notes": "The Research workspace is the umbrella view for strategy discovery, analysis, and run review."
         },


### PR DESCRIPTION
### Motivation
- Fix path-separator and trimming bugs when merging downloaded PNG artifacts into the workspace so CI copies screenshots reliably across platforms.
- Ensure the output root is matched case-insensitively and with normalized separators to avoid missed or mislocated files during the merge step.
- Update page tags used by the desktop screenshot tooling to reflect the renamed UI/page identifier from `ResearchShell` to `StrategyShell`.

### Description
- In `.github/workflows/refresh-screenshots.yml` introduce `$normalizedOutputRoot = $outputRoot.Replace('\','/').Trim('/')` and compute `$artifactRoot = (Resolve-Path _artifacts).Path` to normalize and anchor artifact paths prior to processing.
- Normalize each artifact-relative path into `relNormalized` (forward-slash form) and use it for the `IndexOf` and `Substring` operations, and trim leading slashes consistently so subpaths are computed correctly.
- Replace a number of `pageTag` entries in `scripts/dev/desktop-workflows.json` from `ResearchShell` to `StrategyShell` across the `screenshot-catalog`, `debug-startup`, `manual-overview`, and `manual-research-and-trading` workflows.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f2ccdd608320a0e8993c82d9b6e7)