### PR TITLE
Add resumable checkpointing for long-running dev workflows

### DIFF
--- a/scripts/dev/SharedCheckpoint.ps1
+++ b/scripts/dev/SharedCheckpoint.ps1
@@ -1,0 +1,151 @@
+Set-StrictMode -Version Latest
+
+function Get-MeridianCheckpointInputHash {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$InputObject
+    )
+
+    $json = $InputObject | ConvertTo-Json -Depth 20 -Compress
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($json)
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $hashBytes = $sha.ComputeHash($bytes)
+        return ([System.BitConverter]::ToString($hashBytes)).Replace('-', '').ToLowerInvariant()
+    }
+    finally {
+        $sha.Dispose()
+    }
+}
+
+function Save-MeridianCheckpointContext {
+    param([Parameter(Mandatory = $true)]$Context)
+
+    $payload = [ordered]@{
+        checkpointConventionVersion = 1
+        workflow = $Context.Workflow
+        runId = $Context.Data.runId
+        inputHash = $Context.Data.inputHash
+        inputSnapshot = $Context.Data.inputSnapshot
+        metadata = $Context.Data.metadata
+        steps = $Context.Data.steps
+        generatedAtUtc = (Get-Date).ToUniversalTime().ToString('O')
+    }
+
+    $directory = Split-Path -Parent $Context.Path
+    New-Item -ItemType Directory -Force -Path $directory | Out-Null
+    $payload | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $Context.Path -Encoding utf8
+}
+
+function Initialize-MeridianCheckpoint {
+    param(
+        [Parameter(Mandatory = $true)][string]$Workflow,
+        [Parameter(Mandatory = $true)][string]$CheckpointPath,
+        [Parameter(Mandatory = $true)][object]$InputObject,
+        [string[]]$ForceStep = @(),
+        [switch]$AllowInputMismatch
+    )
+
+    $resolvedPath = [System.IO.Path]::GetFullPath($CheckpointPath)
+    $inputHash = Get-MeridianCheckpointInputHash -InputObject $InputObject
+    $existing = $null
+
+    if (Test-Path -LiteralPath $resolvedPath) {
+        $existing = Get-Content -Raw -LiteralPath $resolvedPath | ConvertFrom-Json -AsHashtable
+    }
+
+    if ($null -ne $existing) {
+        $existingHash = if ($existing.ContainsKey('inputHash')) { [string]$existing.inputHash } else { '' }
+        if (-not [string]::Equals($existingHash, $inputHash, [System.StringComparison]::OrdinalIgnoreCase) -and -not $AllowInputMismatch) {
+            throw "Checkpoint input hash mismatch for '$Workflow'. Existing: $existingHash, current: $inputHash. Re-run with -AllowCheckpointInputMismatch to override."
+        }
+    }
+
+    $data = [ordered]@{
+        runId = if ($null -ne $existing -and $existing.ContainsKey('runId')) { [string]$existing.runId } else { [guid]::NewGuid().ToString('n') }
+        inputHash = $inputHash
+        inputSnapshot = $InputObject
+        metadata = if ($null -ne $existing -and $existing.ContainsKey('metadata')) { [hashtable]$existing.metadata } else { [ordered]@{} }
+        steps = if ($null -ne $existing -and $existing.ContainsKey('steps')) { [hashtable]$existing.steps } else { [ordered]@{} }
+    }
+
+    $context = [pscustomobject]@{
+        Workflow = $Workflow
+        Path = $resolvedPath
+        ForceStep = @($ForceStep | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        Data = $data
+    }
+
+    Save-MeridianCheckpointContext -Context $context
+    return $context
+}
+
+function Test-MeridianCheckpointStepShouldRun {
+    param(
+        [Parameter(Mandatory = $true)]$Context,
+        [Parameter(Mandatory = $true)][string]$StepId
+    )
+
+    if (@($Context.ForceStep) -contains $StepId) {
+        return $true
+    }
+
+    if (-not $Context.Data.steps.ContainsKey($StepId)) {
+        return $true
+    }
+
+    $status = [string]$Context.Data.steps[$StepId].state
+    return $status -ne 'succeeded'
+}
+
+function Start-MeridianCheckpointStep {
+    param(
+        [Parameter(Mandatory = $true)]$Context,
+        [Parameter(Mandatory = $true)][string]$StepId,
+        [Parameter(Mandatory = $true)][string]$Description
+    )
+
+    $Context.Data.steps[$StepId] = [ordered]@{
+        state = 'running'
+        description = $Description
+        timestampUtc = (Get-Date).ToUniversalTime().ToString('O')
+        inputHash = $Context.Data.inputHash
+        artifactPointers = @()
+    }
+    Save-MeridianCheckpointContext -Context $Context
+}
+
+function Complete-MeridianCheckpointStep {
+    param(
+        [Parameter(Mandatory = $true)]$Context,
+        [Parameter(Mandatory = $true)][string]$StepId,
+        [object[]]$ArtifactPointers = @()
+    )
+
+    if (-not $Context.Data.steps.ContainsKey($StepId)) {
+        throw "Cannot complete checkpoint step '$StepId' because it was not started."
+    }
+
+    $Context.Data.steps[$StepId].state = 'succeeded'
+    $Context.Data.steps[$StepId].timestampUtc = (Get-Date).ToUniversalTime().ToString('O')
+    $Context.Data.steps[$StepId].artifactPointers = @($ArtifactPointers)
+    Save-MeridianCheckpointContext -Context $Context
+}
+
+function Fail-MeridianCheckpointStep {
+    param(
+        [Parameter(Mandatory = $true)]$Context,
+        [Parameter(Mandatory = $true)][string]$StepId,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+
+    $Context.Data.steps[$StepId] = [ordered]@{
+        state = 'failed'
+        timestampUtc = (Get-Date).ToUniversalTime().ToString('O')
+        inputHash = $Context.Data.inputHash
+        error = $Message
+        artifactPointers = @()
+    }
+    Save-MeridianCheckpointContext -Context $Context
+}
+

--- a/scripts/dev/generate-desktop-user-manual.ps1
+++ b/scripts/dev/generate-desktop-user-manual.ps1
@@ -6,7 +6,10 @@ param(
     [string]$OutputPath = 'artifacts/desktop-manuals/desktop-user-manual.md',
     [string]$ScreenshotRoot = 'artifacts/desktop-manuals/screenshots',
     [string]$WorkflowRunRoot = 'artifacts/desktop-manual-runs',
-    [switch]$SkipBuild
+    [switch]$SkipBuild,
+    [string]$CheckpointPath = '',
+    [string[]]$ForceCheckpointStep = @(),
+    [switch]$AllowCheckpointInputMismatch
 )
 
 Set-StrictMode -Version Latest
@@ -14,6 +17,7 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
 Set-Location $repoRoot
+. (Join-Path $PSScriptRoot 'SharedCheckpoint.ps1')
 
 function Write-Info([string]$Message) { Write-Host "[INFO] $Message" -ForegroundColor Gray }
 function Write-Ok([string]$Message) { Write-Host "[ OK ] $Message" -ForegroundColor Green }
@@ -72,11 +76,34 @@ $resolvedWorkflowRunRoot = Resolve-RepoPath $WorkflowRunRoot
 $outputDirectory = Split-Path -Parent $resolvedOutputPath
 
 New-Item -ItemType Directory -Force -Path $outputDirectory, $resolvedScreenshotRoot, $resolvedWorkflowRunRoot | Out-Null
+if ([string]::IsNullOrWhiteSpace($CheckpointPath)) {
+    $CheckpointPath = Join-Path $resolvedWorkflowRunRoot 'desktop-user-manual.checkpoint.json'
+}
+$checkpoint = Initialize-MeridianCheckpoint `
+    -Workflow 'generate-desktop-user-manual' `
+    -CheckpointPath $CheckpointPath `
+    -InputObject ([ordered]@{
+        workflows = @($selectedWorkflows | ForEach-Object { [string]$_.name })
+        definitionPath = $catalogPath
+        outputPath = $resolvedOutputPath
+        screenshotRoot = $resolvedScreenshotRoot
+        workflowRunRoot = $resolvedWorkflowRunRoot
+        skipBuild = [bool]$SkipBuild
+    }) `
+    -ForceStep $ForceCheckpointStep `
+    -AllowInputMismatch:$AllowCheckpointInputMismatch
 
 $runSummaries = @()
 $buildSkipped = $SkipBuild
 
 foreach ($definition in $selectedWorkflows) {
+    $checkpointStepId = "capture-$($definition.name)"
+    if (-not (Test-MeridianCheckpointStepShouldRun -Context $checkpoint -StepId $checkpointStepId)) {
+        Write-Info "Skipping workflow '$($definition.name)' capture (checkpoint resume)."
+        continue
+    }
+
+    Start-MeridianCheckpointStep -Context $checkpoint -StepId $checkpointStepId -Description "Capture workflow $($definition.name) for manual."
     Write-Info "Capturing workflow '$($definition.name)' for the user manual..."
 
     $runnerArguments = @{
@@ -124,6 +151,7 @@ foreach ($definition in $selectedWorkflows) {
         screenshotDirectory = $workflowScreenshotDirectory
         steps = $publishedSteps
     }
+    Complete-MeridianCheckpointStep -Context $checkpoint -StepId $checkpointStepId -ArtifactPointers @($workflowScreenshotDirectory, $runResult.manifestPath)
 }
 
 $generatedAt = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss zzz')
@@ -168,7 +196,11 @@ foreach ($workflowSummary in $runSummaries) {
     }
 }
 
-$manualLines | Set-Content -LiteralPath $resolvedOutputPath -Encoding utf8
+if (Test-MeridianCheckpointStepShouldRun -Context $checkpoint -StepId 'write-manual') {
+    Start-MeridianCheckpointStep -Context $checkpoint -StepId 'write-manual' -Description 'Write desktop user manual markdown.'
+    $manualLines | Set-Content -LiteralPath $resolvedOutputPath -Encoding utf8
+    Complete-MeridianCheckpointStep -Context $checkpoint -StepId 'write-manual' -ArtifactPointers @($resolvedOutputPath)
+}
 
 Write-Ok "User manual written to $resolvedOutputPath"
 Write-Ok "Manual screenshots written to $resolvedScreenshotRoot"

--- a/scripts/dev/generate-dk1-pilot-parity-packet.ps1
+++ b/scripts/dev/generate-dk1-pilot-parity-packet.ps1
@@ -3,13 +3,17 @@ param(
     [string]$OutputRoot = "artifacts/provider-validation/_automation",
     [string]$SummaryJsonPath = "",
     [string]$OperatorSignoffPath = "",
-    [switch]$AllowFailedSummary
+    [switch]$AllowFailedSummary,
+    [string]$CheckpointPath = "",
+    [string[]]$ForceCheckpointStep = @(),
+    [switch]$AllowCheckpointInputMismatch
 )
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+. (Join-Path $PSScriptRoot "SharedCheckpoint.ps1")
 $summaryDir = Join-Path (Join-Path $repoRoot $OutputRoot) $DateStamp
 
 if ([string]::IsNullOrWhiteSpace($SummaryJsonPath)) {
@@ -23,8 +27,23 @@ else {
 if (-not (Test-Path -LiteralPath $SummaryJsonPath)) {
     throw "Wave 1 validation summary was not found: $SummaryJsonPath"
 }
+if ([string]::IsNullOrWhiteSpace($CheckpointPath)) {
+    $CheckpointPath = Join-Path $summaryDir "dk1-pilot-parity-packet.checkpoint.json"
+}
 
 $summary = Get-Content -Raw -LiteralPath $SummaryJsonPath | ConvertFrom-Json
+$checkpoint = Initialize-MeridianCheckpoint `
+    -Workflow "generate-dk1-pilot-parity-packet" `
+    -CheckpointPath $CheckpointPath `
+    -InputObject ([ordered]@{
+        dateStamp = $DateStamp
+        outputRoot = $OutputRoot
+        summaryJsonPath = $SummaryJsonPath
+        operatorSignoffPath = $OperatorSignoffPath
+        allowFailedSummary = [bool]$AllowFailedSummary
+    }) `
+    -ForceStep $ForceCheckpointStep `
+    -AllowInputMismatch:$AllowCheckpointInputMismatch
 
 $requiredSamples = @(
     [ordered]@{
@@ -694,7 +713,11 @@ $packet = [ordered]@{
     blockers = @($blockers)
 }
 
-$packet | ConvertTo-Json -Depth 7 | Set-Content -Path $jsonPath
+if (Test-MeridianCheckpointStepShouldRun -Context $checkpoint -StepId "write-dk1-packet-json") {
+    Start-MeridianCheckpointStep -Context $checkpoint -StepId "write-dk1-packet-json" -Description "Write DK1 pilot parity packet JSON."
+    $packet | ConvertTo-Json -Depth 7 | Set-Content -Path $jsonPath
+    Complete-MeridianCheckpointStep -Context $checkpoint -StepId "write-dk1-packet-json" -ArtifactPointers @($jsonPath)
+}
 
 $md = @(
     "# DK1 Pilot Parity Packet",
@@ -804,7 +827,11 @@ else {
     }
 }
 
-$md -join [Environment]::NewLine | Set-Content -Path $mdPath
+if (Test-MeridianCheckpointStepShouldRun -Context $checkpoint -StepId "write-dk1-packet-markdown") {
+    Start-MeridianCheckpointStep -Context $checkpoint -StepId "write-dk1-packet-markdown" -Description "Write DK1 pilot parity packet markdown."
+    $md -join [Environment]::NewLine | Set-Content -Path $mdPath
+    Complete-MeridianCheckpointStep -Context $checkpoint -StepId "write-dk1-packet-markdown" -ArtifactPointers @($mdPath)
+}
 
 Write-Host "DK1 pilot parity packet written to:"
 Write-Host "  $jsonPath"

--- a/scripts/dev/prepare-dk1-operator-signoff.ps1
+++ b/scripts/dev/prepare-dk1-operator-signoff.ps1
@@ -3,13 +3,17 @@ param(
     [string]$PacketPath = "",
     [switch]$Validate,
     [switch]$Force,
-    [switch]$Json
+    [switch]$Json,
+    [string]$CheckpointPath = "",
+    [string[]]$ForceCheckpointStep = @(),
+    [switch]$AllowCheckpointInputMismatch
 )
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+. (Join-Path $PSScriptRoot "SharedCheckpoint.ps1")
 $dateStamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd")
 $requiredOperatorOwners = @("Data Operations", "Provider Reliability", "Trading")
 
@@ -19,6 +23,21 @@ if ([string]::IsNullOrWhiteSpace($OutputPath)) {
 else {
     $OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
 }
+if ([string]::IsNullOrWhiteSpace($CheckpointPath)) {
+    $CheckpointPath = [System.IO.Path]::GetFullPath((Join-Path (Split-Path -Parent $OutputPath) "dk1-operator-signoff.checkpoint.json"))
+}
+$checkpoint = Initialize-MeridianCheckpoint `
+    -Workflow "prepare-dk1-operator-signoff" `
+    -CheckpointPath $CheckpointPath `
+    -InputObject ([ordered]@{
+        outputPath = $OutputPath
+        packetPath = $PacketPath
+        validate = [bool]$Validate
+        force = [bool]$Force
+        json = [bool]$Json
+    }) `
+    -ForceStep $ForceCheckpointStep `
+    -AllowInputMismatch:$AllowCheckpointInputMismatch
 
 function ConvertTo-RelativePath {
     param([Parameter(Mandatory)][string]$Path)
@@ -377,6 +396,11 @@ else {
 Assert-PacketReadyForOperatorReview -PacketReview $packetReview
 
 if ($Validate) {
+    $validateStepStarted = $false
+    if (Test-MeridianCheckpointStepShouldRun -Context $checkpoint -StepId "validate-signoff") {
+        Start-MeridianCheckpointStep -Context $checkpoint -StepId "validate-signoff" -Description "Validate existing DK1 operator sign-off."
+        $validateStepStarted = $true
+    }
     $review = Get-OperatorSignoffReview -Path $OutputPath -RequiredOwners $requiredOperatorOwners -PacketReview $packetReview
     if ($Json) {
         $review | ConvertTo-Json -Depth 8
@@ -398,6 +422,9 @@ if ($Validate) {
         }
         throw "DK1 operator sign-off is not complete. Missing owners: $(if ($review.missingOwners.Count -eq 0) { 'none' } else { $review.missingOwners -join ', ' }); packet binding requirements: $packetBindingDetail"
     }
+    if ($validateStepStarted) {
+        Complete-MeridianCheckpointStep -Context $checkpoint -StepId "validate-signoff" -ArtifactPointers @($OutputPath)
+    }
 
     return
 }
@@ -410,7 +437,11 @@ $outputDirectory = Split-Path -Parent $OutputPath
 New-Item -ItemType Directory -Force -Path $outputDirectory | Out-Null
 
 $template = New-OperatorSignoffTemplate -RequiredOwners $requiredOperatorOwners -PacketReview $packetReview
-$template | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $OutputPath -Encoding UTF8
+if (Test-MeridianCheckpointStepShouldRun -Context $checkpoint -StepId "write-signoff-template") {
+    Start-MeridianCheckpointStep -Context $checkpoint -StepId "write-signoff-template" -Description "Write DK1 operator sign-off template."
+    $template | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $OutputPath -Encoding UTF8
+    Complete-MeridianCheckpointStep -Context $checkpoint -StepId "write-signoff-template" -ArtifactPointers @($OutputPath)
+}
 
 if ($Json) {
     [ordered]@{

--- a/scripts/dev/run-desktop-workflow.ps1
+++ b/scripts/dev/run-desktop-workflow.ps1
@@ -15,7 +15,10 @@ param(
     [switch]$ReuseExistingApp,
     [switch]$NoFixture,
     [switch]$PassThru,
-    [int]$LaunchTimeoutSec = 90
+    [int]$LaunchTimeoutSec = 90,
+    [string]$CheckpointPath = '',
+    [string[]]$ForceCheckpointStep = @(),
+    [switch]$AllowCheckpointInputMismatch
 )
 
 Set-StrictMode -Version Latest
@@ -24,6 +27,7 @@ $ErrorActionPreference = 'Stop'
 $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
 Set-Location $repoRoot
 . (Join-Path $PSScriptRoot 'SharedBuild.ps1')
+. (Join-Path $PSScriptRoot 'SharedCheckpoint.ps1')
 
 function Write-Info([string]$Message) { Write-Host "[INFO] $Message" -ForegroundColor Gray }
 function Write-Ok([string]$Message) { Write-Host "[ OK ] $Message" -ForegroundColor Green }
@@ -703,11 +707,38 @@ else {
     Get-ConfigBool -Table $workflowDefinition -Key 'fixtureMode' -Fallback (Get-ConfigBool -Table $defaults -Key 'fixtureMode' -Fallback $true)
 }
 
+if ([string]::IsNullOrWhiteSpace($CheckpointPath)) {
+    $CheckpointPath = Join-Path $resolvedOutputRoot "checkpoints/$Workflow.checkpoint.json"
+}
+
+$checkpoint = Initialize-MeridianCheckpoint `
+    -Workflow "run-desktop-workflow:$Workflow" `
+    -CheckpointPath $CheckpointPath `
+    -InputObject ([ordered]@{
+        workflow = $Workflow
+        definitionPath = $catalogPath
+        projectPath = $resolvedProjectPath
+        configuration = $resolvedConfiguration
+        framework = $resolvedFramework
+        exeName = $resolvedExeName
+        outputRoot = $resolvedOutputRoot
+        screenshotDirectory = $resolvedScreenshotDirectory
+        skipBuild = [bool]$SkipBuild
+        fixtureMode = $useFixture
+    }) `
+    -ForceStep $ForceCheckpointStep `
+    -AllowInputMismatch:$AllowCheckpointInputMismatch
+
 $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
-$runDirectory = Join-Path $resolvedOutputRoot "$timestamp-$Workflow"
+$existingRunDirectory = if ($checkpoint.Data.metadata.ContainsKey('runDirectory')) { [string]$checkpoint.Data.metadata.runDirectory } else { '' }
+$runDirectory = if (-not [string]::IsNullOrWhiteSpace($existingRunDirectory)) { $existingRunDirectory } else { Join-Path $resolvedOutputRoot "$timestamp-$Workflow" }
 $logDirectory = Join-Path $runDirectory 'logs'
 $screenshotDirectory = if ($null -ne $resolvedScreenshotDirectory) { $resolvedScreenshotDirectory } else { Join-Path $runDirectory 'screenshots' }
 $manifestPath = Join-Path $runDirectory 'manifest.json'
+$checkpoint.Data.metadata.runDirectory = $runDirectory
+$checkpoint.Data.metadata.manifestPath = $manifestPath
+$checkpoint.Data.metadata.screenshotDirectory = $screenshotDirectory
+Save-MeridianCheckpointContext -Context $checkpoint
 
 New-Item -ItemType Directory -Force -Path $runDirectory, $logDirectory, $screenshotDirectory | Out-Null
 
@@ -747,7 +778,8 @@ try {
         Write-Info 'Created config/appsettings.json from sample.'
     }
 
-    if (-not $SkipBuild) {
+    if (-not $SkipBuild -and (Test-MeridianCheckpointStepShouldRun -Context $checkpoint -StepId 'build-desktop')) {
+        Start-MeridianCheckpointStep -Context $checkpoint -StepId 'build-desktop' -Description 'Restore and build Meridian desktop shell.'
         $desktopRestoreArgs = @(
             Get-MeridianBuildArguments `
                 -IsolationKey $buildIsolationKey `
@@ -774,6 +806,10 @@ try {
         if ($LASTEXITCODE -ne 0) {
             throw "dotnet build failed for '$resolvedProjectPath'."
         }
+        Complete-MeridianCheckpointStep -Context $checkpoint -StepId 'build-desktop' -ArtifactPointers @($exePath)
+    }
+    elseif (-not $SkipBuild) {
+        Write-Info 'Skipping desktop build (checkpoint resume).'
     }
 
     if (-not (Test-Path -LiteralPath $exePath)) {
@@ -803,19 +839,26 @@ try {
             $launchArguments += '--fixture'
         }
 
-        Write-Info "Launching Meridian desktop: $exePath"
-        $ownedProcess = Start-Process -FilePath $exePath `
-            -ArgumentList $launchArguments `
-            -WorkingDirectory $repoRoot `
-            -RedirectStandardOutput $stdoutPath `
-            -RedirectStandardError $stderrPath `
-            -PassThru `
-            -WindowStyle Normal
+        if (Test-MeridianCheckpointStepShouldRun -Context $checkpoint -StepId 'launch-desktop') {
+            Start-MeridianCheckpointStep -Context $checkpoint -StepId 'launch-desktop' -Description 'Launch Meridian desktop app.'
+            Write-Info "Launching Meridian desktop: $exePath"
+            $ownedProcess = Start-Process -FilePath $exePath `
+                -ArgumentList $launchArguments `
+                -WorkingDirectory $repoRoot `
+                -RedirectStandardOutput $stdoutPath `
+                -RedirectStandardError $stderrPath `
+                -PassThru `
+                -WindowStyle Normal
 
-        $manifest.run.launchArguments = $launchArguments
-        $manifest.run.processId = $ownedProcess.Id
-        $window = Wait-MeridianWindow -TimeoutSec $LaunchTimeoutSec -Process $ownedProcess
-        Write-Ok 'Meridian window detected.'
+            $manifest.run.launchArguments = $launchArguments
+            $manifest.run.processId = $ownedProcess.Id
+            $window = Wait-MeridianWindow -TimeoutSec $LaunchTimeoutSec -Process $ownedProcess
+            Complete-MeridianCheckpointStep -Context $checkpoint -StepId 'launch-desktop' -ArtifactPointers @($stdoutPath, $stderrPath)
+            Write-Ok 'Meridian window detected.'
+        }
+        else {
+            Write-Info 'Skipping desktop launch step marker (checkpoint resume).'
+        }
     }
 
     $operatingContextConfirmed = Ensure-EnteredOperatingContext -Process $ownedProcess
@@ -868,6 +911,15 @@ try {
 
         try {
             Write-Info ("Running step {0}: {1}" -f $stepIndex, $title)
+            $checkpointStepId = ('workflow-step-{0:D2}' -f $stepIndex)
+            if (-not (Test-MeridianCheckpointStepShouldRun -Context $checkpoint -StepId $checkpointStepId)) {
+                Write-Info ("Skipping step {0}: {1} (checkpoint resume)." -f $stepIndex, $title)
+                $stepResult.status = 'ok'
+                $stepResult.completedAt = (Get-Date).ToString('o')
+                $manifest.steps += [pscustomobject]$stepResult
+                continue
+            }
+            Start-MeridianCheckpointStep -Context $checkpoint -StepId $checkpointStepId -Description $title
 
             if ($null -ne $ownedProcess -and $ownedProcess.HasExited) {
                 throw "Meridian desktop exited unexpectedly with code $($ownedProcess.ExitCode)."
@@ -900,11 +952,13 @@ try {
 
             $stepResult.status = 'ok'
             $stepResult.completedAt = (Get-Date).ToString('o')
+            Complete-MeridianCheckpointStep -Context $checkpoint -StepId $checkpointStepId -ArtifactPointers @($capturePath)
         }
         catch {
             $stepResult.status = 'failed'
             $stepResult.error = $_.Exception.Message
             $stepResult.completedAt = (Get-Date).ToString('o')
+            Fail-MeridianCheckpointStep -Context $checkpoint -StepId $checkpointStepId -Message $_.Exception.Message
             $manifest.steps += [pscustomobject]$stepResult
             throw
         }

--- a/scripts/dev/run-wave1-provider-validation.ps1
+++ b/scripts/dev/run-wave1-provider-validation.ps1
@@ -2,7 +2,10 @@ param(
     [string]$Configuration = "Release",
     [string]$DateStamp = (Get-Date).ToString("yyyy-MM-dd"),
     [string]$OutputRoot = "artifacts/provider-validation/_automation",
-    [string]$OperatorSignoffPath = ""
+    [string]$OperatorSignoffPath = "",
+    [string]$CheckpointPath = "",
+    [string[]]$ForceCheckpointStep = @(),
+    [switch]$AllowCheckpointInputMismatch
 )
 
 $ErrorActionPreference = "Stop"
@@ -13,8 +16,12 @@ if ($PSVersionTable.PSVersion.Major -ge 7) {
 }
 
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+. (Join-Path $PSScriptRoot "SharedCheckpoint.ps1")
 $summaryDir = Join-Path $repoRoot $OutputRoot | Join-Path -ChildPath $DateStamp
 New-Item -ItemType Directory -Force -Path $summaryDir | Out-Null
+if ([string]::IsNullOrWhiteSpace($CheckpointPath)) {
+    $CheckpointPath = Join-Path $summaryDir "wave1-validation.checkpoint.json"
+}
 
 $testProject = "tests/Meridian.Tests/Meridian.Tests.csproj"
 $commonTestArgs = @(
@@ -278,8 +285,54 @@ function Invoke-Step {
     }
 }
 
-$results = foreach ($step in $steps) {
-    Invoke-Step -Step $step
+$checkpoint = Initialize-MeridianCheckpoint `
+    -Workflow "run-wave1-provider-validation" `
+    -CheckpointPath $CheckpointPath `
+    -InputObject ([ordered]@{
+        configuration = $Configuration
+        dateStamp = $DateStamp
+        outputRoot = $OutputRoot
+        operatorSignoffPath = $OperatorSignoffPath
+        steps = @($steps | ForEach-Object { [string]$_.Name })
+    }) `
+    -ForceStep $ForceCheckpointStep `
+    -AllowInputMismatch:$AllowCheckpointInputMismatch
+
+$results = New-Object System.Collections.Generic.List[object]
+foreach ($step in $steps) {
+    $stepSlug = ($step.Name.ToLowerInvariant() -replace '[^a-z0-9]+', '-').Trim('-')
+    if (-not (Test-MeridianCheckpointStepShouldRun -Context $checkpoint -StepId $stepSlug)) {
+        Write-Host "==> $($step.Name) (checkpoint resume: skipped)"
+        $logPath = Join-Path $summaryDir "$stepSlug.log"
+        $results.Add([ordered]@{
+            name = $step.Name
+            kind = $step.Kind
+            status = "passed"
+            exitCode = 0
+            durationSeconds = 0
+            command = "resumed-from-checkpoint"
+            logPath = $logPath.Substring($repoRoot.Length + 1).Replace('\', '/')
+            tail = "Step reused from checkpoint."
+        }) | Out-Null
+        continue
+    }
+
+    Start-MeridianCheckpointStep -Context $checkpoint -StepId $stepSlug -Description $step.Name
+    try {
+        $stepResult = Invoke-Step -Step $step
+        if ($stepResult.status -eq "failed") {
+            Fail-MeridianCheckpointStep -Context $checkpoint -StepId $stepSlug -Message "Step failed with exit code $($stepResult.exitCode)."
+        }
+        else {
+            Complete-MeridianCheckpointStep -Context $checkpoint -StepId $stepSlug -ArtifactPointers @($stepResult.logPath)
+        }
+
+        $results.Add($stepResult) | Out-Null
+    }
+    catch {
+        Fail-MeridianCheckpointStep -Context $checkpoint -StepId $stepSlug -Message $_.Exception.Message
+        throw
+    }
 }
 
 $failedResults = @($results | Where-Object status -eq "failed")
@@ -300,7 +353,11 @@ $summary = [ordered]@{
 
 $jsonPath = Join-Path $summaryDir "wave1-validation-summary.json"
 $mdPath = Join-Path $summaryDir "wave1-validation-summary.md"
-$summary | ConvertTo-Json -Depth 6 | Set-Content -Path $jsonPath
+if (Test-MeridianCheckpointStepShouldRun -Context $checkpoint -StepId "write-wave1-summary-json") {
+    Start-MeridianCheckpointStep -Context $checkpoint -StepId "write-wave1-summary-json" -Description "Write wave1-validation-summary.json"
+    $summary | ConvertTo-Json -Depth 6 | Set-Content -Path $jsonPath
+    Complete-MeridianCheckpointStep -Context $checkpoint -StepId "write-wave1-summary-json" -ArtifactPointers @($jsonPath)
+}
 
 $md = @(
     "# Wave 1 Validation Summary",
@@ -372,7 +429,11 @@ $md += @(
     "- $(($deferredProviders -join ", "))"
 )
 
-$md -join [Environment]::NewLine | Set-Content -Path $mdPath
+if (Test-MeridianCheckpointStepShouldRun -Context $checkpoint -StepId "write-wave1-summary-md") {
+    Start-MeridianCheckpointStep -Context $checkpoint -StepId "write-wave1-summary-md" -Description "Write wave1-validation-summary.md"
+    $md -join [Environment]::NewLine | Set-Content -Path $mdPath
+    Complete-MeridianCheckpointStep -Context $checkpoint -StepId "write-wave1-summary-md" -ArtifactPointers @($mdPath)
+}
 
 $packetScript = Join-Path $PSScriptRoot "generate-dk1-pilot-parity-packet.ps1"
 if (Test-Path -LiteralPath $packetScript) {
@@ -383,12 +444,25 @@ if (Test-Path -LiteralPath $packetScript) {
         $packetArgs.OperatorSignoffPath = $OperatorSignoffPath
     }
 
-    if ($summary.result -ne "passed") {
-        $packetArgs.AllowFailedSummary = $true
-        & $packetScript @packetArgs
+    if (Test-MeridianCheckpointStepShouldRun -Context $checkpoint -StepId "generate-dk1-packet") {
+        Start-MeridianCheckpointStep -Context $checkpoint -StepId "generate-dk1-packet" -Description "Generate DK1 parity packet."
+        try {
+            if ($summary.result -ne "passed") {
+                $packetArgs.AllowFailedSummary = $true
+                & $packetScript @packetArgs
+            }
+            else {
+                & $packetScript @packetArgs
+            }
+            Complete-MeridianCheckpointStep -Context $checkpoint -StepId "generate-dk1-packet" -ArtifactPointers @($summaryDir)
+        }
+        catch {
+            Fail-MeridianCheckpointStep -Context $checkpoint -StepId "generate-dk1-packet" -Message $_.Exception.Message
+            throw
+        }
     }
     else {
-        & $packetScript @packetArgs
+        Write-Host "==> DK1 parity packet generation (checkpoint resume: skipped)"
     }
 }
 


### PR DESCRIPTION
### Motivation
- Long-running developer workflows (provider validation, DK1 packet/signoff generation, desktop screenshot/manual runs) need resumable semantics to avoid redoing previously completed steps after interruptions.
- A small, shared checkpoint convention and helper reduces duplicated logic and makes artifact-producing scripts robust to partial failures and input changes.

### Description
- Add a shared checkpoint helper `scripts/dev/SharedCheckpoint.ps1` that implements a stable checkpoint payload and APIs: `Initialize-MeridianCheckpoint`, `Start-MeridianCheckpointStep`, `Complete-MeridianCheckpointStep`, `Fail-MeridianCheckpointStep`, `Test-MeridianCheckpointStepShouldRun`, and input-hash computation; the checkpoint convention records `runId`, per-step `state`, `timestampUtc`, `inputHash`, and `artifactPointers`.
- Apply checkpoint-aware resume semantics and new CLI options (`-CheckpointPath`, `-ForceCheckpointStep`, `-AllowCheckpointInputMismatch`) to provider validation workflows: `scripts/dev/run-wave1-provider-validation.ps1`, `scripts/dev/generate-dk1-pilot-parity-packet.ps1`, and `scripts/dev/prepare-dk1-operator-signoff.ps1` so steps, summary writes, and packet generation are checkpointed.
- Apply checkpoint-aware resume semantics to desktop artifact workflows: `scripts/dev/run-desktop-workflow.ps1` and `scripts/dev/generate-desktop-user-manual.ps1` so build/launch/workflow steps, per-workflow captures, manifests, screenshots, and manual writes can resume and emit artifact pointers.
- Checkpoint writes are colocated under each workflow output/run root and include artifact pointers for logs, manifests, screenshots, and generated documents; force-step and input-hash mismatch override are supported.

### Testing
- Attempted PowerShell parse/validation of the updated scripts inside the environment, but `pwsh` is not available in the container so runtime parse checks could not be executed.
- Static review of changes and local script wiring was performed to ensure checkpoint APIs are invoked consistently and default checkpoint locations are determined per-workflow.
- No automated unit/integration tests were changed or executed as part of this PR; runtime validation is recommended on a Windows workstation with `pwsh` available and a full desktop/workflow environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f105217fe883209cb2f02ff00c313e)