### PR TITLE
Add shared preflight runner and integrate into desktop/provider workflows

### DIFF
--- a/build/scripts/ai-repo-updater.py
+++ b/build/scripts/ai-repo-updater.py
@@ -1150,6 +1150,58 @@ def run_audit(root: Path, command: str) -> AuditReport:
     return report
 
 
+def run_shared_preflight(
+    root: Path,
+    scenario: str,
+    required_commands: list[str],
+    required_paths: list[Path],
+    writable_dirs: list[Path],
+) -> dict[str, Any]:
+    """Run the shared preflight wrapper so CI and local runs emit the same diagnostics."""
+    preflight_script = root / "scripts" / "dev" / "preflight_runner.py"
+    if not preflight_script.exists():
+        return {
+            "scenario": scenario,
+            "status": "blocked",
+            "blockingChecks": [
+                {
+                    "check": "path.preflight_runner",
+                    "message": f"Shared preflight runner is missing: {preflight_script}",
+                    "recommendation": "Restore scripts/dev/preflight_runner.py before running this command.",
+                }
+            ],
+            "warnings": [],
+            "nextAction": "Resolve blocking checks and rerun preflight.",
+        }
+
+    command = [sys.executable, str(preflight_script), "--scenario", scenario]
+    for item in required_commands:
+        command.extend(["--required-command", item])
+    for item in required_paths:
+        command.extend(["--required-path", str(item)])
+    for item in writable_dirs:
+        command.extend(["--writable-dir", str(item)])
+
+    proc = subprocess.run(command, cwd=root, capture_output=True, text=True)
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError:
+        payload = {
+            "scenario": scenario,
+            "status": "blocked",
+            "blockingChecks": [
+                {
+                    "check": "preflight.output",
+                    "message": "Shared preflight runner returned non-JSON output.",
+                    "recommendation": "Inspect preflight_runner.py output and fix JSON emission.",
+                }
+            ],
+            "warnings": [],
+            "nextAction": "Resolve blocking checks and rerun preflight.",
+        }
+    return payload
+
+
 def main(argv: list[str] | None = None) -> int:  # noqa: C901
     parser = argparse.ArgumentParser(
         description="AI Repository Updater — audit and improve the codebase.",
@@ -1206,6 +1258,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
         return 0
 
     elif args.command == "verify":
+        preflight = run_shared_preflight(
+            args.root,
+            scenario="ai-repo-updater.verify",
+            required_commands=["git", "dotnet"],
+            required_paths=[args.root / "Meridian.sln"],
+            writable_dirs=[args.root / "artifacts"],
+        )
+        if preflight.get("status") != "ok":
+            print(json.dumps(preflight, indent=2))
+            return 2
         result = run_verify(args.root)
         if args.json_output:
             args.json_output.parent.mkdir(parents=True, exist_ok=True)
@@ -1214,6 +1276,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
         return 0 if result.get("overall_ok") else 1
 
     elif args.command in ("maintenance-light", "maintenance-full"):
+        preflight = run_shared_preflight(
+            args.root,
+            scenario=f"ai-repo-updater.{args.command}",
+            required_commands=["git", "dotnet", "python3"],
+            required_paths=[args.root / "Meridian.sln", args.root / "build" / "python" / "cli" / "buildctl.py"],
+            writable_dirs=[args.root / ".ai", args.root / "artifacts"],
+        )
+        if preflight.get("status") != "ok":
+            print(json.dumps(preflight, indent=2))
+            return 2
         lane = "light" if args.command == "maintenance-light" else "full"
         result = run_maintenance(args.root, lane)
         status_file = args.status_file or args.json_output or (args.root / ".ai" / "maintenance-status.json")

--- a/scripts/dev/SharedPreflight.ps1
+++ b/scripts/dev/SharedPreflight.ps1
@@ -1,0 +1,124 @@
+Set-StrictMode -Version Latest
+
+function New-PreflightIssue {
+    param(
+        [Parameter(Mandatory = $true)][string]$Check,
+        [Parameter(Mandatory = $true)][string]$Message,
+        [Parameter(Mandatory = $true)][string]$Recommendation
+    )
+
+    return [ordered]@{
+        check = $Check
+        message = $Message
+        recommendation = $Recommendation
+    }
+}
+
+function Test-PreflightDirectoryWritable {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    try {
+        if (-not (Test-Path -LiteralPath $Path)) {
+            New-Item -ItemType Directory -Force -Path $Path | Out-Null
+        }
+
+        $probe = Join-Path $Path (".preflight-write-{0}.tmp" -f ([System.Guid]::NewGuid().ToString('N')))
+        Set-Content -LiteralPath $probe -Value 'ok' -Encoding utf8
+        Remove-Item -LiteralPath $probe -Force -ErrorAction SilentlyContinue
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
+function Invoke-MeridianPreflight {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Scenario,
+        [string[]]$RequiredCommands = @(),
+        [string[]]$RequiredPaths = @(),
+        [string[]]$WritableDirectories = @(),
+        [string[]]$RequiredEnvironmentVariables = @(),
+        [hashtable]$FeatureFlagExpectations = @{},
+        [switch]$RequireWindows,
+        [switch]$EmitJson,
+        [switch]$AllowWarnings,
+        [string]$SuccessNextAction = 'Proceed with workflow execution.'
+    )
+
+    $blockingChecks = New-Object System.Collections.Generic.List[object]
+    $warnings = New-Object System.Collections.Generic.List[object]
+
+    if ($RequireWindows -and -not ($IsWindows -or $env:OS -eq 'Windows_NT')) {
+        $blockingChecks.Add((New-PreflightIssue -Check 'platform.windows' -Message 'Workflow requires Windows.' -Recommendation 'Run this workflow on a Windows host with WPF/UI automation support.'))
+    }
+
+    foreach ($command in $RequiredCommands) {
+        if (-not (Get-Command $command -ErrorAction SilentlyContinue)) {
+            $blockingChecks.Add((New-PreflightIssue -Check ("command.{0}" -f $command) -Message "Required command '$command' was not found in PATH." -Recommendation "Install '$command' and ensure PATH is configured before rerunning."))
+        }
+    }
+
+    foreach ($path in $RequiredPaths) {
+        if (-not [string]::IsNullOrWhiteSpace($path) -and -not (Test-Path -LiteralPath $path)) {
+            $blockingChecks.Add((New-PreflightIssue -Check ("path.{0}" -f ($path -replace '[^A-Za-z0-9._/-]', '_')) -Message "Required path '$path' was not found." -Recommendation 'Verify the path exists or regenerate required inputs before rerunning.'))
+        }
+    }
+
+    foreach ($directory in $WritableDirectories) {
+        if ([string]::IsNullOrWhiteSpace($directory)) {
+            continue
+        }
+
+        if (-not (Test-PreflightDirectoryWritable -Path $directory)) {
+            $blockingChecks.Add((New-PreflightIssue -Check ("write.{0}" -f ($directory -replace '[^A-Za-z0-9._/-]', '_')) -Message "Directory '$directory' is not writable." -Recommendation 'Fix permissions or choose a writable output directory.'))
+        }
+    }
+
+    foreach ($variable in $RequiredEnvironmentVariables) {
+        $value = [Environment]::GetEnvironmentVariable($variable)
+        if ([string]::IsNullOrWhiteSpace($value)) {
+            $blockingChecks.Add((New-PreflightIssue -Check ("env.{0}" -f $variable) -Message "Required environment variable '$variable' is missing." -Recommendation "Set '$variable' before running this workflow."))
+        }
+    }
+
+    foreach ($feature in $FeatureFlagExpectations.Keys) {
+        $expectedValue = [string]$FeatureFlagExpectations[$feature]
+        $actual = [Environment]::GetEnvironmentVariable($feature)
+        if ([string]::IsNullOrWhiteSpace($actual)) {
+            $warnings.Add((New-PreflightIssue -Check ("feature.{0}" -f $feature) -Message "Feature flag '$feature' is not set." -Recommendation "Expected value '$expectedValue' when this workflow runs outside fixture mode."))
+            continue
+        }
+
+        if (-not [string]::Equals($actual, $expectedValue, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $warnings.Add((New-PreflightIssue -Check ("feature.{0}" -f $feature) -Message "Feature flag '$feature' is '$actual' (expected '$expectedValue')." -Recommendation 'Confirm the configured flag value matches the intended workflow mode.'))
+        }
+    }
+
+    $status = if ($blockingChecks.Count -gt 0) { 'blocked' } elseif ($warnings.Count -gt 0 -and -not $AllowWarnings) { 'warning' } else { 'ok' }
+    $nextAction = if ($blockingChecks.Count -gt 0) {
+        'Resolve blocking checks and rerun preflight.'
+    }
+    elseif ($warnings.Count -gt 0 -and -not $AllowWarnings) {
+        'Review warnings and decide whether to proceed.'
+    }
+    else {
+        $SuccessNextAction
+    }
+
+    $result = [ordered]@{
+        scenario = $Scenario
+        status = $status
+        blockingChecks = @($blockingChecks)
+        warnings = @($warnings)
+        nextAction = $nextAction
+        generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+    }
+
+    if ($EmitJson) {
+        $result | ConvertTo-Json -Depth 8 | Write-Host
+    }
+
+    return [pscustomobject]$result
+}

--- a/scripts/dev/generate-dk1-pilot-parity-packet.ps1
+++ b/scripts/dev/generate-dk1-pilot-parity-packet.ps1
@@ -8,6 +8,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
+. (Join-Path $PSScriptRoot 'SharedPreflight.ps1')
 
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 $summaryDir = Join-Path (Join-Path $repoRoot $OutputRoot) $DateStamp
@@ -20,8 +21,27 @@ else {
     $summaryDir = Split-Path -Parent $SummaryJsonPath
 }
 
-if (-not (Test-Path -LiteralPath $SummaryJsonPath)) {
-    throw "Wave 1 validation summary was not found: $SummaryJsonPath"
+$preflight = Invoke-MeridianPreflight `
+    -Scenario 'dk1-pilot-parity-packet' `
+    -RequiredPaths @($SummaryJsonPath) `
+    -WritableDirectories @($summaryDir) `
+    -EmitJson `
+    -AllowWarnings
+
+if (-not [string]::IsNullOrWhiteSpace($OperatorSignoffPath) -and -not (Test-Path -LiteralPath $OperatorSignoffPath)) {
+    $preflight.blockingChecks += [pscustomobject]@{
+        check = "path.operatorSignoff"
+        message = "Operator sign-off file was not found: $OperatorSignoffPath"
+        recommendation = "Provide a valid operator sign-off path or omit -OperatorSignoffPath."
+    }
+    $preflight.status = 'blocked'
+    $preflight.nextAction = 'Resolve blocking checks and rerun preflight.'
+}
+
+if ($preflight.status -eq 'blocked') {
+    $preflightPath = Join-Path $summaryDir 'preflight.json'
+    $preflight | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $preflightPath -Encoding utf8
+    throw "Preflight failed. See '$preflightPath' for diagnostics."
 }
 
 $summary = Get-Content -Raw -LiteralPath $SummaryJsonPath | ConvertFrom-Json

--- a/scripts/dev/preflight_runner.py
+++ b/scripts/dev/preflight_runner.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Shared preflight runner for CI + human workflow diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def issue(check: str, message: str, recommendation: str) -> dict[str, str]:
+    return {"check": check, "message": message, "recommendation": recommendation}
+
+
+def test_writable_dir(path: Path) -> bool:
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        probe = path / f".preflight-write-{os.getpid()}.tmp"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink(missing_ok=True)
+        return True
+    except OSError:
+        return False
+
+
+def run_preflight(args: argparse.Namespace) -> dict[str, object]:
+    blocking: list[dict[str, str]] = []
+    warnings: list[dict[str, str]] = []
+
+    if args.require_windows and platform.system().lower() != "windows":
+        blocking.append(issue("platform.windows", "Workflow requires Windows.", "Run on Windows with required desktop tooling."))
+
+    for command in args.required_command:
+        if shutil.which(command) is None:
+            blocking.append(issue(f"command.{command}", f"Required command '{command}' was not found in PATH.", f"Install '{command}' and retry."))
+
+    for raw_path in args.required_path:
+        path = Path(raw_path)
+        if not path.exists():
+            blocking.append(issue(f"path.{raw_path}", f"Required path '{raw_path}' was not found.", "Verify the path exists before rerunning."))
+
+    for raw_dir in args.writable_dir:
+        if not test_writable_dir(Path(raw_dir)):
+            blocking.append(issue(f"write.{raw_dir}", f"Directory '{raw_dir}' is not writable.", "Fix permissions or choose a writable location."))
+
+    for env_name in args.required_env:
+        if not os.getenv(env_name):
+            blocking.append(issue(f"env.{env_name}", f"Required environment variable '{env_name}' is missing.", f"Set '{env_name}' and rerun."))
+
+    for feature in args.feature_flag:
+        name, expected = feature.split("=", 1)
+        actual = os.getenv(name)
+        if not actual:
+            warnings.append(issue(f"feature.{name}", f"Feature flag '{name}' is not set.", f"Expected '{expected}' for non-fixture execution."))
+        elif actual.lower() != expected.lower():
+            warnings.append(issue(f"feature.{name}", f"Feature flag '{name}' is '{actual}' (expected '{expected}').", "Verify workflow mode and feature flags."))
+
+    status = "blocked" if blocking else "ok"
+    next_action = args.success_next_action if status == "ok" else "Resolve blocking checks and rerun preflight."
+
+    return {
+        "scenario": args.scenario,
+        "status": status,
+        "blockingChecks": blocking,
+        "warnings": warnings,
+        "nextAction": next_action,
+        "generatedAtUtc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run shared workflow preflight checks.")
+    parser.add_argument("--scenario", required=True)
+    parser.add_argument("--required-command", action="append", default=[])
+    parser.add_argument("--required-path", action="append", default=[])
+    parser.add_argument("--writable-dir", action="append", default=[])
+    parser.add_argument("--required-env", action="append", default=[])
+    parser.add_argument("--feature-flag", action="append", default=[], help="NAME=EXPECTED")
+    parser.add_argument("--require-windows", action="store_true")
+    parser.add_argument("--success-next-action", default="Proceed with workflow execution.")
+    args = parser.parse_args()
+
+    payload = run_preflight(args)
+    print(json.dumps(payload, indent=2))
+    return 0 if payload["status"] == "ok" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/prepare-dk1-operator-signoff.ps1
+++ b/scripts/dev/prepare-dk1-operator-signoff.ps1
@@ -8,6 +8,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
+. (Join-Path $PSScriptRoot 'SharedPreflight.ps1')
 
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 $dateStamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd")
@@ -18,6 +19,25 @@ if ([string]::IsNullOrWhiteSpace($OutputPath)) {
 }
 else {
     $OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+}
+
+$outputDirectory = Split-Path -Parent $OutputPath
+$requiredPaths = @()
+if (-not [string]::IsNullOrWhiteSpace($PacketPath)) {
+    $requiredPaths += [System.IO.Path]::GetFullPath($PacketPath)
+}
+
+$preflight = Invoke-MeridianPreflight `
+    -Scenario 'dk1-operator-signoff' `
+    -RequiredPaths $requiredPaths `
+    -WritableDirectories @($outputDirectory) `
+    -EmitJson `
+    -AllowWarnings
+
+if ($preflight.status -eq 'blocked') {
+    $preflightPath = Join-Path $outputDirectory 'preflight.json'
+    $preflight | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $preflightPath -Encoding utf8
+    throw "Preflight failed. See '$preflightPath' for diagnostics."
 }
 
 function ConvertTo-RelativePath {
@@ -406,7 +426,6 @@ if ((Test-Path -LiteralPath $OutputPath) -and -not $Force) {
     throw "Operator sign-off file already exists: $OutputPath. Re-run with -Force to replace it."
 }
 
-$outputDirectory = Split-Path -Parent $OutputPath
 New-Item -ItemType Directory -Force -Path $outputDirectory | Out-Null
 
 $template = New-OperatorSignoffTemplate -RequiredOwners $requiredOperatorOwners -PacketReview $packetReview

--- a/scripts/dev/run-desktop-workflow.ps1
+++ b/scripts/dev/run-desktop-workflow.ps1
@@ -24,18 +24,11 @@ $ErrorActionPreference = 'Stop'
 $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
 Set-Location $repoRoot
 . (Join-Path $PSScriptRoot 'SharedBuild.ps1')
+. (Join-Path $PSScriptRoot 'SharedPreflight.ps1')
 
 function Write-Info([string]$Message) { Write-Host "[INFO] $Message" -ForegroundColor Gray }
 function Write-Ok([string]$Message) { Write-Host "[ OK ] $Message" -ForegroundColor Green }
 function Write-Warn([string]$Message) { Write-Host "[WARN] $Message" -ForegroundColor Yellow }
-
-function Assert-Command {
-    param([string]$Name)
-
-    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
-        throw "Required command '$Name' was not found in PATH."
-    }
-}
 
 function Resolve-RepoPath {
     param([string]$Path)
@@ -655,20 +648,19 @@ function Send-WindowKeys {
     [System.Windows.Forms.SendKeys]::SendWait($Keys)
 }
 
-Assert-Command -Name 'dotnet'
-
-if (-not ($IsWindows -or $env:OS -eq 'Windows_NT')) {
-    throw 'Desktop workflow automation requires Windows because Meridian.Wpf is a Windows-only application.'
-}
-
-Add-Type -AssemblyName System.Drawing
-Add-Type -AssemblyName System.Windows.Forms
-[void][System.Reflection.Assembly]::LoadWithPartialName('UIAutomationClient')
-[void][System.Reflection.Assembly]::LoadWithPartialName('UIAutomationTypes')
-
 $catalogPath = Resolve-RepoPath $DefinitionPath
-if (-not (Test-Path -LiteralPath $catalogPath)) {
-    throw "Workflow catalog was not found at '$catalogPath'."
+$initialOutputRoot = if ($PSBoundParameters.ContainsKey('OutputRoot')) { Resolve-RepoPath $OutputRoot } else { Resolve-RepoPath 'artifacts/desktop-workflows' }
+$catalogPreflight = Invoke-MeridianPreflight `
+    -Scenario 'desktop-workflow-catalog' `
+    -RequiredCommands @('dotnet') `
+    -RequiredPaths @($catalogPath) `
+    -WritableDirectories @($initialOutputRoot) `
+    -RequireWindows `
+    -EmitJson `
+    -AllowWarnings
+
+if ($catalogPreflight.status -eq 'blocked') {
+    throw "Preflight failed before workflow load. $(($catalogPreflight.blockingChecks | ConvertTo-Json -Depth 6 -Compress))"
 }
 
 $catalog = Get-Content -LiteralPath $catalogPath -Raw | ConvertFrom-Json -AsHashtable
@@ -740,6 +732,26 @@ $manifest = [ordered]@{
 $ownedProcess = $null
 $window = $null
 $originalFixtureEnv = [Environment]::GetEnvironmentVariable('MDC_FIXTURE_MODE', 'Process')
+$preflight = Invoke-MeridianPreflight `
+    -Scenario 'desktop-workflow' `
+    -RequiredCommands @('dotnet') `
+    -RequiredPaths @($catalogPath, $resolvedProjectPath) `
+    -WritableDirectories @($resolvedOutputRoot, $screenshotDirectory, $runDirectory, $logDirectory) `
+    -RequireWindows `
+    -FeatureFlagExpectations $(if (-not $useFixture) { @{ 'MDC_FIXTURE_MODE' = '0' } } else { @{} }) `
+    -EmitJson `
+    -AllowWarnings
+
+if ($preflight.status -eq 'blocked') {
+    $preflightPath = Join-Path $runDirectory 'preflight.json'
+    $preflight | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $preflightPath -Encoding utf8
+    throw "Preflight failed. See '$preflightPath' for diagnostics."
+}
+
+Add-Type -AssemblyName System.Drawing
+Add-Type -AssemblyName System.Windows.Forms
+[void][System.Reflection.Assembly]::LoadWithPartialName('UIAutomationClient')
+[void][System.Reflection.Assembly]::LoadWithPartialName('UIAutomationTypes')
 
 try {
     if (-not (Test-Path -LiteralPath 'config/appsettings.json') -and (Test-Path -LiteralPath 'config/appsettings.sample.json')) {

--- a/scripts/dev/run-wave1-provider-validation.ps1
+++ b/scripts/dev/run-wave1-provider-validation.ps1
@@ -7,6 +7,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
+. (Join-Path $PSScriptRoot 'SharedPreflight.ps1')
 
 if ($PSVersionTable.PSVersion.Major -ge 7) {
     $PSNativeCommandUseErrorActionPreference = $false
@@ -15,6 +16,32 @@ if ($PSVersionTable.PSVersion.Major -ge 7) {
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 $summaryDir = Join-Path $repoRoot $OutputRoot | Join-Path -ChildPath $DateStamp
 New-Item -ItemType Directory -Force -Path $summaryDir | Out-Null
+$preflight = Invoke-MeridianPreflight `
+    -Scenario 'wave1-provider-validation' `
+    -RequiredCommands @('dotnet', 'pwsh') `
+    -RequiredPaths @(
+        (Join-Path $repoRoot "tests/Meridian.Tests/Meridian.Tests.csproj"),
+        (Join-Path $repoRoot "scripts/dev/generate-dk1-pilot-parity-packet.ps1")
+    ) `
+    -WritableDirectories @($summaryDir) `
+    -EmitJson `
+    -AllowWarnings
+
+if (-not [string]::IsNullOrWhiteSpace($OperatorSignoffPath) -and -not (Test-Path -LiteralPath $OperatorSignoffPath)) {
+    $preflight.blockingChecks += [pscustomobject]@{
+        check = "path.operatorSignoff"
+        message = "Operator sign-off file was not found: $OperatorSignoffPath"
+        recommendation = "Provide a valid operator sign-off path or omit -OperatorSignoffPath."
+    }
+    $preflight.status = 'blocked'
+    $preflight.nextAction = 'Resolve blocking checks and rerun preflight.'
+}
+
+if ($preflight.status -eq 'blocked') {
+    $preflightPath = Join-Path $summaryDir 'preflight.json'
+    $preflight | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $preflightPath -Encoding utf8
+    throw "Preflight failed. See '$preflightPath' for diagnostics."
+}
 
 $testProject = "tests/Meridian.Tests/Meridian.Tests.csproj"
 $commonTestArgs = @(


### PR DESCRIPTION
### Motivation

- Standardize and centralize prerequisite validation for workflows so CI and humans receive the same diagnostics before expensive or platform-specific operations run. 
- Provide a machine-readable, consistent preflight contract (`status`, `blockingChecks`, `warnings`, `nextAction`) that both PowerShell and Python consumers can emit and consume. 
- Fail fast on missing commands/paths, unwritable artifact directories, missing env/feature flags, or platform constraints (WPF/Windows) to avoid confusing downstream failures.

### Description

- Add `scripts/dev/SharedPreflight.ps1` as the canonical PowerShell preflight entry point that performs checks for required commands, paths, writable directories, required environment variables, feature-flag expectations, and optional Windows requirement, and emits the structured payload. 
- Add `scripts/dev/preflight_runner.py` as a Python wrapper that implements the same contract and CLI so Python/build automation can run the same checks and return consistent JSON/exit codes. 
- Integrate the preflight stage into `scripts/dev/run-desktop-workflow.ps1` with an early catalog/platform gate and a full workflow preflight prior to build/launch, blocking execution and writing `preflight.json` on failure. 
- Wire preflight into Wave‑1/provider scripts: `scripts/dev/run-wave1-provider-validation.ps1`, `scripts/dev/generate-dk1-pilot-parity-packet.ps1`, and `scripts/dev/prepare-dk1-operator-signoff.ps1`, and into build-side automation via `build/scripts/ai-repo-updater.py` for `verify` and maintenance lanes.

### Testing

- Ran Python static check: `python3 -m py_compile scripts/dev/preflight_runner.py build/scripts/ai-repo-updater.py`, which succeeded. 
- Executed a smoke preflight: `python3 scripts/dev/preflight_runner.py --scenario smoke --required-command python3 --required-path scripts/dev/preflight_runner.py --writable-dir artifacts`, which returned status `ok`. 
- Attempted PowerShell parse checks in the container but `pwsh` is not available here so PowerShell parsing/exec validation could not be run in this environment (CI/Windows hosts should validate `SharedPreflight.ps1` with `pwsh`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10517e400832082b735b8a4c89a8d)