### PR TITLE
ci: optimize screenshot refresh workflow with shared WPF build and timing regression guard

### DIFF
--- a/.github/workflows/refresh-screenshots.yml
+++ b/.github/workflows/refresh-screenshots.yml
@@ -62,12 +62,62 @@ env:
   WPF_PROJECT: src/Meridian.Wpf/Meridian.Wpf.csproj
   WPF_CONFIGURATION: Release
   WPF_FRAMEWORK: net9.0-windows10.0.19041.0
+  SCREENSHOT_TIMING_BASELINE_MINUTES: 25
+  SCREENSHOT_TIMING_REGRESSION_PERCENT: 20
 
 jobs:
+  build-wpf:
+    name: Build WPF binaries
+    runs-on: windows-latest
+    timeout-minutes: 20
+
+    # Prevent recursive runs from the bot commit.
+    if: github.actor != 'github-actions[bot]'
+
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup .NET with Cache
+        uses: ./.github/actions/setup-dotnet-cache
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+          cache-suffix: desktop-screenshots
+
+      - name: Restore WPF project
+        run: |
+          dotnet restore "${{ env.WPF_PROJECT }}" --verbosity minimal /p:EnableWindowsTargeting=true
+
+      - name: Build WPF project once
+        run: |
+          dotnet build "${{ env.WPF_PROJECT }}" `
+            -c "${{ env.WPF_CONFIGURATION }}" `
+            -f "${{ env.WPF_FRAMEWORK }}" `
+            --no-restore `
+            --verbosity minimal `
+            /p:EnableWindowsTargeting=true `
+            /p:EnableFullWpfBuild=true `
+            -maxcpucount:1
+
+      - name: Upload WPF build binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: wpf-build-binaries
+          path: |
+            src/Meridian.Wpf/bin/${{ env.WPF_CONFIGURATION }}/${{ env.WPF_FRAMEWORK }}/**
+            src/Meridian/bin/${{ env.WPF_CONFIGURATION }}/**
+          if-no-files-found: error
+          retention-days: 2
+
   desktop-screenshots:
     name: Take WPF screenshots
     runs-on: windows-latest
-    timeout-minutes: 40
+    timeout-minutes: 35
+    needs: build-wpf
 
     # Prevent recursive runs from the bot commit.
     if: github.actor != 'github-actions[bot]'
@@ -119,6 +169,12 @@ jobs:
           dotnet-version: ${{ env.DOTNET_VERSION }}
           cache-suffix: desktop-screenshots
 
+      - name: Download WPF build binaries
+        uses: actions/download-artifact@v5
+        with:
+          name: wpf-build-binaries
+          path: .
+
       - name: Copy sample config
         run: Copy-Item config\appsettings.sample.json config\appsettings.json -Force
 
@@ -131,12 +187,37 @@ jobs:
         env:
           MDC_FIXTURE_MODE: '1'
         run: |
+          $startedUtc = (Get-Date).ToUniversalTime()
+
           pwsh -File scripts/dev/run-desktop-workflow.ps1 `
             -Workflow "${{ matrix.workflow.name }}" `
             -ProjectPath "${{ env.WPF_PROJECT }}" `
             -Configuration "${{ env.WPF_CONFIGURATION }}" `
             -Framework "${{ env.WPF_FRAMEWORK }}" `
-            -ScreenshotDirectory "${{ matrix.workflow.output }}"
+            -OutputRoot "artifacts/desktop-workflows/${{ matrix.workflow.name }}" `
+            -ScreenshotDirectory "${{ matrix.workflow.output }}" `
+            -SkipBuild
+
+          $finishedUtc = (Get-Date).ToUniversalTime()
+          $durationSeconds = [int][Math]::Round(($finishedUtc - $startedUtc).TotalSeconds)
+
+          New-Item -ItemType Directory -Force -Path artifacts/screenshot-runtime | Out-Null
+
+          [ordered]@{
+            workflow = "${{ matrix.workflow.name }}"
+            startedUtc = $startedUtc.ToString('o')
+            finishedUtc = $finishedUtc.ToString('o')
+            durationSeconds = $durationSeconds
+          } | ConvertTo-Json | Set-Content -Encoding utf8 "artifacts/screenshot-runtime/${{ matrix.workflow.name }}.json"
+
+      - name: Upload workflow runtime report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: screenshot-runtime-${{ matrix.workflow.name }}
+          path: artifacts/screenshot-runtime/${{ matrix.workflow.name }}.json
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Upload WPF screenshot diagnostics
         if: always()
@@ -145,8 +226,8 @@ jobs:
           name: wpf-desktop-screenshots-${{ matrix.workflow.name }}
           path: |
             ${{ inputs.output_root || 'docs/screenshots/desktop' }}/**/*.png
-            artifacts/desktop-workflows/**/manifest.json
-            artifacts/desktop-workflows/**/logs/*.log
+            artifacts/desktop-workflows/${{ matrix.workflow.name }}/**/manifest.json
+            artifacts/desktop-workflows/${{ matrix.workflow.name }}/**/logs/*.log
             wpf-startup-stdout.log
             wpf-startup-stderr.log
           if-no-files-found: warn
@@ -182,7 +263,7 @@ jobs:
       - name: Merge downloaded PNGs into workspace
         run: |
           $outputRoot = "${{ inputs.output_root || 'docs/screenshots/desktop' }}"
-          $normalizedOutputRoot = $outputRoot.Replace('\','/').Trim('/')
+          $normalizedOutputRoot = $outputRoot.Replace('\\','/').Trim('/')
           New-Item -ItemType Directory -Force -Path $outputRoot | Out-Null
 
           $pngs = Get-ChildItem -Path _artifacts -Recurse -Filter *.png -ErrorAction SilentlyContinue
@@ -191,7 +272,7 @@ jobs:
           foreach ($png in $pngs) {
             $artifactRoot = (Resolve-Path _artifacts).Path
             $rel = $png.FullName.Substring($artifactRoot.Length).TrimStart('\\','/')
-            $relNormalized = $rel.Replace('\','/')
+            $relNormalized = $rel.Replace('\\','/')
 
             # Each artifact is stored as: _artifacts/<artifact-name>/<original-path>/.../*.png
             # Find the first occurrence of the output root inside that path and copy from there.
@@ -257,3 +338,70 @@ jobs:
           )
 
           $lines | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+  timing-summary:
+    name: Workflow timing summary
+    runs-on: windows-latest
+    timeout-minutes: 10
+    needs: desktop-screenshots
+    if: always() && github.actor != 'github-actions[bot]'
+
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Download timing artifacts
+        uses: actions/download-artifact@v5
+        with:
+          pattern: screenshot-runtime-*
+          path: _runtime
+          merge-multiple: true
+
+      - name: Compare runtime to baseline
+        run: |
+          $baselineMinutes = [double]${{ env.SCREENSHOT_TIMING_BASELINE_MINUTES }}
+          $thresholdPercent = [double]${{ env.SCREENSHOT_TIMING_REGRESSION_PERCENT }}
+
+          $timingFiles = @(Get-ChildItem -Path _runtime -Filter *.json -File -ErrorAction SilentlyContinue)
+          if ($timingFiles.Count -eq 0) {
+            throw 'No timing artifacts were produced by the screenshot matrix jobs.'
+          }
+
+          $records = @()
+          foreach ($file in $timingFiles) {
+            $records += Get-Content -Raw -LiteralPath $file.FullName | ConvertFrom-Json
+          }
+
+          $totalSeconds = ($records | Measure-Object -Property durationSeconds -Sum).Sum
+          $totalMinutes = [Math]::Round(($totalSeconds / 60.0), 2)
+          $allowedMinutes = [Math]::Round(($baselineMinutes * (1 + ($thresholdPercent / 100.0))), 2)
+          $deltaPercent = if ($baselineMinutes -gt 0) {
+            [Math]::Round((($totalMinutes - $baselineMinutes) / $baselineMinutes) * 100.0, 2)
+          }
+          else {
+            0
+          }
+
+          $lines = @(
+            '## UI Screenshot Runtime Summary',
+            '',
+            "Baseline: **$baselineMinutes min**",
+            "Regression threshold: **$thresholdPercent%**",
+            "Allowed max runtime: **$allowedMinutes min**",
+            "Measured total runtime: **$totalMinutes min**",
+            "Delta vs baseline: **$deltaPercent%**",
+            '',
+            '| Workflow | Duration (sec) |',
+            '| --- | ---: |'
+          )
+
+          foreach ($record in ($records | Sort-Object workflow)) {
+            $lines += "| $($record.workflow) | $($record.durationSeconds) |"
+          }
+
+          $lines | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+          if ($totalMinutes -gt $allowedMinutes) {
+            throw "Screenshot runtime regression detected: $totalMinutes min exceeded allowed $allowedMinutes min ($thresholdPercent% over baseline)."
+          }


### PR DESCRIPTION
### Motivation

- Reduce repeated compile time by building the WPF project once and reusing binaries across matrix legs. 
- Keep per-workflow artifact isolation so screenshots/manifests remain organized and debuggable. 
- Make runtime visible per-matrix leg and detect regressions versus a baseline. 

### Description

- Add a `build-wpf` job that restores and builds `src/Meridian.Wpf/Meridian.Wpf.csproj` and uploads `wpf-build-binaries` as an artifact. 
- Change the `desktop-screenshots` matrix to `needs: build-wpf`, download `wpf-build-binaries` with `actions/download-artifact`, and invoke `scripts/dev/run-desktop-workflow.ps1` with `-SkipBuild` and per-workflow `-OutputRoot`. 
- Narrow diagnostics upload paths to each workflow's isolated output (`artifacts/desktop-workflows/${{ matrix.workflow.name }}`) and continue uploading per-workflow PNGs and logs. 
- Add timing knobs `SCREENSHOT_TIMING_BASELINE_MINUTES` and `SCREENSHOT_TIMING_REGRESSION_PERCENT`, emit per-leg runtime JSON files under `artifacts/screenshot-runtime/<workflow>.json`, and add a `timing-summary` job that aggregates runtimes, writes a workflow summary, and fails when total runtime exceeds the baseline plus the configured regression percent. 

### Testing

- Ran `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/refresh-screenshots.yml')"` to validate the workflow YAML and it succeeded. 
- Attempted to parse with Python/YAML but the environment lacked `PyYAML` so that run failed due to the missing module (environment issue, not workflow content).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f109e79434832090d9b2e93c9964cb)