### PR TITLE
Add shared retry helper and telemetry for desktop screenshot workflows

### DIFF
--- a/scripts/dev/capture-desktop-screenshots.ps1
+++ b/scripts/dev/capture-desktop-screenshots.ps1
@@ -14,6 +14,7 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '../..')
 . (Join-Path $PSScriptRoot 'SharedBuild.ps1')
+. (Join-Path $PSScriptRoot 'shared/retry.ps1')
 $resolvedProjectPath = if ([System.IO.Path]::IsPathRooted($ProjectPath)) {
   [System.IO.Path]::GetFullPath($ProjectPath)
 }
@@ -370,6 +371,8 @@ $env:MDC_FIXTURE_MODE = '1'
 $exePath = Get-MeridianProjectBinaryPath -RepoRoot $repoRoot -ProjectPath $resolvedProjectPath -Configuration $Configuration -Framework $Framework -BinaryName $ExeName -IsolationKey $buildIsolationKey
 $stdoutPath = 'wpf-startup-stdout.log'
 $stderrPath = 'wpf-startup-stderr.log'
+$retryTelemetry = New-Object System.Collections.ArrayList
+$retryTelemetryPath = Join-Path $OutputDir 'retry-telemetry.json'
 
 if (-not (Test-Path $exePath)) {
   throw "WPF executable was not found at '$exePath'. Build the project or check your parameters."
@@ -381,30 +384,47 @@ $proc = Start-Process -FilePath $exePath -RedirectStandardOutput $stdoutPath -Re
 try {
   $window = $null
   Write-Host 'Waiting for Meridian window (up to 90 seconds)...'
-  for ($i = 0; $i -lt 45; $i++) {
-    Start-Sleep -Seconds 2
+  $windowRetry = Invoke-MeridianRetry `
+    -Name 'capture/launch/window-visible' `
+    -MaxAttempts 45 `
+    -BaseDelayMs 500 `
+    -MaxDelayMs 2000 `
+    -JitterMs 150 `
+    -TelemetrySink $retryTelemetry `
+    -Predicate {
+      if ($proc.HasExited) {
+        return [pscustomobject]@{
+          ready = $false
+          failure = (New-MeridianRetryFailure -Code 'desktop.process.exited' -Reason "WPF process exited before the main window appeared (exit code $($proc.ExitCode))." -Data @{ exitCode = $proc.ExitCode })
+        }
+      }
 
-    if ($proc.HasExited) {
-      Write-Host "Application exited with code $($proc.ExitCode)."
-      if (Test-Path $stdoutPath) { Write-Host '--- stdout ---'; Get-Content $stdoutPath | Write-Host }
-      if (Test-Path $stderrPath) { Write-Host '--- stderr ---'; Get-Content $stderrPath | Write-Host }
-      throw 'WPF process exited before the main window appeared.'
+      $candidateWindow = Find-MeridianWindow
+      if ($null -eq $candidateWindow) {
+        return [pscustomobject]@{
+          ready = $false
+          failure = (New-MeridianRetryFailure -Code 'desktop.window.not_visible' -Reason 'Meridian window was not visible yet.' -Data @{})
+        }
+      }
+
+      return [pscustomobject]@{
+        ready = $true
+        window = $candidateWindow
+      }
+    } `
+    -Action {
+      param($state)
+      return $state.window
     }
 
-    $window = Find-MeridianWindow
-    if ($window) {
-      Write-Host 'Meridian window detected.'
-      break
-    }
-  }
-
-  if (-not $window) {
+  if (-not $windowRetry.Success) {
     if (Test-Path $stdoutPath) { Write-Host '--- stdout ---'; Get-Content $stdoutPath | Write-Host }
     if (Test-Path $stderrPath) { Write-Host '--- stderr ---'; Get-Content $stderrPath | Write-Host }
-    throw 'Meridian window did not appear within 90 seconds.'
+    $launchFailure = $windowRetry.Failure
+    throw "[{0}] {1}" -f $launchFailure.code, $launchFailure.reason
   }
-
-  Start-Sleep -Seconds 4
+  $window = $windowRetry.Value
+  Write-Host 'Meridian window detected.'
 
   if (-not (Ensure-EnteredFundProfile -Window $window)) {
     Write-Warning 'Unable to enter the fund profile selector. Continuing without page navigation.'
@@ -447,7 +467,56 @@ try {
     $window = Find-MeridianWindow
 
     if ($window -and $ok) {
-      Save-WindowCapture -Window $window -Path (Join-Path $OutputDir "wpf-$slug.png")
+      $targetPath = Join-Path $OutputDir "wpf-$slug.png"
+      $captureRetry = Invoke-MeridianRetry `
+        -Name ("capture/page/$slug") `
+        -MaxAttempts 6 `
+        -BaseDelayMs 350 `
+        -MaxDelayMs 2500 `
+        -JitterMs 180 `
+        -TelemetrySink $retryTelemetry `
+        -Predicate {
+          $candidateWindow = Find-MeridianWindow
+          if ($null -eq $candidateWindow) {
+            return [pscustomobject]@{
+              ready = $false
+              failure = (New-MeridianRetryFailure -Code 'desktop.window.not_visible' -Reason "Window was not visible while capturing '$search'." -Data @{ page = $search; slug = $slug })
+            }
+          }
+
+          $shellMarker = $candidateWindow.FindFirst(
+            [System.Windows.Automation.TreeScope]::Descendants,
+            (New-Object System.Windows.Automation.PropertyCondition(
+              [System.Windows.Automation.AutomationElement]::AutomationIdProperty,
+              'ShellAutomationState'
+            ))
+          )
+
+          if ($null -eq $shellMarker) {
+            return [pscustomobject]@{
+              ready = $false
+              failure = (New-MeridianRetryFailure -Code 'desktop.automation.marker_missing' -Reason "Shell automation marker was not found while capturing '$search'." -Data @{ page = $search; slug = $slug })
+            }
+          }
+
+          return [pscustomobject]@{
+            ready = $true
+            window = $candidateWindow
+          }
+        } `
+        -Action {
+          param($state)
+          Save-WindowCapture -Window $state.window -Path $targetPath
+          return $targetPath
+        }
+
+      if ($captureRetry.Success) {
+        Write-Host "Saved: $($captureRetry.Value)"
+      }
+      else {
+        $failure = $captureRetry.Failure
+        Write-Warning ("Skipping '{0}' due to retry exhaustion [{1}] {2}" -f $search, $failure.code, $failure.reason)
+      }
     } else {
       Write-Warning "Skipping '$search' because navigation failed or window reference was lost."
     }
@@ -459,6 +528,25 @@ try {
     Format-Table -AutoSize
 }
 finally {
+  $retryReport = [ordered]@{
+    generatedAt = (Get-Date).ToString('o')
+    outputDirectory = $OutputDir
+    telemetry = @($retryTelemetry)
+    failureRanking = @(
+      $retryTelemetry |
+        Where-Object { $_.status -eq 'failed' -and $null -ne $_.failure } |
+        Group-Object { $_.failure.code } |
+        Sort-Object Count -Descending |
+        ForEach-Object {
+          [ordered]@{
+            code = $_.Name
+            count = $_.Count
+          }
+        }
+    )
+  }
+  $retryReport | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $retryTelemetryPath -Encoding utf8
+
   if (-not $KeepAppOpen) {
     Write-Host 'Stopping WPF process...'
     try { $proc | Stop-Process -Force -ErrorAction SilentlyContinue } catch {}

--- a/scripts/dev/run-desktop-workflow.ps1
+++ b/scripts/dev/run-desktop-workflow.ps1
@@ -28,6 +28,7 @@ $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
 Set-Location $repoRoot
 . (Join-Path $PSScriptRoot 'SharedBuild.ps1')
 . (Join-Path $PSScriptRoot 'SharedPreflight.ps1')
+. (Join-Path $PSScriptRoot 'shared/retry.ps1')
 
 function Write-Info([string]$Message) { Write-Host "[INFO] $Message" -ForegroundColor Gray }
 function Write-Ok([string]$Message) { Write-Host "[ OK ] $Message" -ForegroundColor Green }
@@ -772,10 +773,12 @@ $manifest = [ordered]@{
         startedAt = (Get-Date).ToString('o')
     }
     steps = @()
+    retryTelemetry = @()
 }
 
 $ownedProcess = $null
 $window = $null
+$retryTelemetry = New-Object System.Collections.ArrayList
 $originalFixtureEnv = [Environment]::GetEnvironmentVariable('MDC_FIXTURE_MODE', 'Process')
 $preflight = Invoke-MeridianPreflight `
     -Scenario 'desktop-workflow' `
@@ -968,20 +971,97 @@ try {
                 Send-WindowKeys -Window $window -Keys $keys
             }
 
-            Start-Sleep -Milliseconds $stepWaitMs
-            $pageReadiness = Wait-ForShellPage `
-                -Process $ownedProcess `
-                -ExpectedPageTag $pageTag `
-                -AcceptedPageTags $acceptedPageTags `
-                -TimeoutSec ([Math]::Max(8, [int][Math]::Ceiling(($stepWaitMs / 1000.0) + 4)))
-            $window = $pageReadiness.Window
-            $stepResult.observedPageTag = $pageReadiness.State.PageTag
-            $stepResult.observedPageTitle = $pageReadiness.State.PageTitle
+            $captureRetry = Invoke-MeridianRetry `
+                -Name ("{0}/step-{1:D2}/{2}" -f $Workflow, $stepIndex, $captureName) `
+                -MaxAttempts 6 `
+                -BaseDelayMs ([Math]::Max(250, [int]($stepWaitMs / 3))) `
+                -MaxDelayMs ([Math]::Max(1200, $stepWaitMs * 2)) `
+                -JitterMs 180 `
+                -TelemetrySink $retryTelemetry `
+                -Predicate {
+                    if ($null -ne $ownedProcess -and $ownedProcess.HasExited) {
+                        return [pscustomobject]@{
+                            ready = $false
+                            failure = (New-MeridianRetryFailure -Code 'desktop.process.exited' -Reason "Meridian desktop exited unexpectedly with code $($ownedProcess.ExitCode)." -Data @{ exitCode = $ownedProcess.ExitCode })
+                        }
+                    }
+
+                    $candidateWindow = Wait-MeridianWindow -TimeoutSec 5 -Process $ownedProcess
+                    if ($null -eq $candidateWindow) {
+                        return [pscustomobject]@{
+                            ready = $false
+                            failure = (New-MeridianRetryFailure -Code 'desktop.window.not_visible' -Reason 'Meridian window was not visible.' -Data @{})
+                        }
+                    }
+
+                    $rect = $candidateWindow.Current.BoundingRectangle
+                    if ($rect.Width -lt 200 -or $rect.Height -lt 200) {
+                        return [pscustomobject]@{
+                            ready = $false
+                            failure = (New-MeridianRetryFailure -Code 'desktop.window.too_small' -Reason "Window bounds are too small for capture ($($rect.Width)x$($rect.Height))." -Data @{ width = $rect.Width; height = $rect.Height })
+                        }
+                    }
+
+                    $shellState = Get-ShellAutomationState -Window $candidateWindow
+                    if (-not $shellState.Ready -or [string]::IsNullOrWhiteSpace($shellState.PageTag)) {
+                        return [pscustomobject]@{
+                            ready = $false
+                            failure = (New-MeridianRetryFailure -Code 'desktop.automation.marker_missing' -Reason 'Shell automation readiness marker was not present.' -Data @{ pageTag = $shellState.PageTag; pageTitle = $shellState.PageTitle })
+                        }
+                    }
+
+                    $expectedTags = @()
+                    if (-not [string]::IsNullOrWhiteSpace($pageTag)) { $expectedTags += $pageTag }
+                    if ($acceptedPageTags) { $expectedTags += @($acceptedPageTags | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) }
+                    $expectedTags = @($expectedTags | Select-Object -Unique)
+
+                    if ($expectedTags.Count -gt 0 -and -not ($expectedTags -contains $shellState.PageTag)) {
+                        return [pscustomobject]@{
+                            ready = $false
+                            failure = (New-MeridianRetryFailure -Code 'desktop.route.not_active' -Reason "Expected page tag '$pageTag' was not active." -Data @{ expectedTags = $expectedTags; observedPageTag = $shellState.PageTag; observedPageTitle = $shellState.PageTitle })
+                        }
+                    }
+
+                    return [pscustomobject]@{
+                        ready = $true
+                        window = $candidateWindow
+                        state = $shellState
+                    }
+                } `
+                -Action {
+                    param($readiness)
+
+                    Activate-MeridianWindow | Out-Null
+                    if ($shouldCapture -and $null -ne $capturePath) {
+                        return [pscustomobject]@{
+                            capturePath = (Save-WindowCapture -Window $readiness.window -Path $capturePath)
+                            state = $readiness.state
+                            window = $readiness.window
+                        }
+                    }
+
+                    return [pscustomobject]@{
+                        capturePath = $null
+                        state = $readiness.state
+                        window = $readiness.window
+                    }
+                }
+
+            if (-not $captureRetry.Success) {
+                $failure = $captureRetry.Failure
+                $failureCode = if ($failure -and $failure.PSObject.Properties.Name -contains 'code') { $failure.code } else { 'retry.unknown_failure' }
+                $failureReason = if ($failure -and $failure.PSObject.Properties.Name -contains 'reason') { $failure.reason } else { 'Capture readiness did not succeed before retries were exhausted.' }
+                throw "[${failureCode}] $failureReason"
+            }
+
+            $window = $captureRetry.Value.window
+            $stepResult.retryAttempts = $captureRetry.Attempts
+            $stepResult.retryName = $captureRetry.Telemetry.name
+            $stepResult.observedPageTag = $captureRetry.Value.state.PageTag
+            $stepResult.observedPageTitle = $captureRetry.Value.state.PageTitle
 
             if ($shouldCapture -and $null -ne $capturePath) {
-                Activate-MeridianWindow | Out-Null
-                $window = Wait-MeridianWindow -TimeoutSec 10 -Process $ownedProcess
-                $savedPath = Save-WindowCapture -Window $window -Path $capturePath
+                $savedPath = $captureRetry.Value.capturePath
                 $stepResult.capturePath = $savedPath
                 Write-Ok "Saved $savedPath"
             }
@@ -1011,6 +1091,22 @@ catch {
 }
 finally {
     $manifest.run.finishedAt = (Get-Date).ToString('o')
+    $manifest.retryTelemetry = @($retryTelemetry)
+    $manifest.retrySummary = [ordered]@{
+        total = $retryTelemetry.Count
+        failures = @(
+            $retryTelemetry |
+                Where-Object { $_.status -eq 'failed' -and $null -ne $_.failure } |
+                Group-Object { $_.failure.code } |
+                Sort-Object Count -Descending |
+                ForEach-Object {
+                    [ordered]@{
+                        code = $_.Name
+                        count = $_.Count
+                    }
+                }
+        )
+    }
     $manifest | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $manifestPath -Encoding utf8
 
     if (-not $KeepAppOpen -and $null -ne $ownedProcess) {

--- a/scripts/dev/shared/retry.ps1
+++ b/scripts/dev/shared/retry.ps1
@@ -1,0 +1,184 @@
+Set-StrictMode -Version Latest
+
+function New-MeridianRetryFailure {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Code,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Reason,
+
+        [hashtable]$Data = @{}
+    )
+
+    return [pscustomobject]@{
+        code = $Code
+        reason = $Reason
+        data = $Data
+    }
+}
+
+function Invoke-MeridianRetry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Predicate,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Action,
+
+        [int]$MaxAttempts = 5,
+        [int]$BaseDelayMs = 250,
+        [int]$MaxDelayMs = 4000,
+        [double]$BackoffMultiplier = 2.0,
+        [int]$JitterMs = 120,
+        [System.Collections.IList]$TelemetrySink
+    )
+
+    if ($MaxAttempts -lt 1) {
+        throw "Invoke-MeridianRetry requires MaxAttempts >= 1."
+    }
+
+    $startedAt = Get-Date
+    $attemptEvents = @()
+    $lastFailure = $null
+    $result = $null
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        $attemptStarted = Get-Date
+        $predicateState = $null
+        $predicateFailure = $null
+
+        try {
+            $predicateState = & $Predicate
+        }
+        catch {
+            $predicateFailure = New-MeridianRetryFailure `
+                -Code 'retry.predicate.exception' `
+                -Reason $_.Exception.Message `
+                -Data @{ exceptionType = $_.Exception.GetType().FullName }
+        }
+
+        $predicatePassed = $false
+        if ($null -eq $predicateFailure) {
+            if ($predicateState -is [bool]) {
+                $predicatePassed = $predicateState
+            }
+            elseif ($null -ne $predicateState -and $predicateState.PSObject.Properties.Name -contains 'ready') {
+                $predicatePassed = [bool]$predicateState.ready
+            }
+            else {
+                $predicatePassed = $null -ne $predicateState
+            }
+        }
+
+        if (-not $predicatePassed) {
+            if ($null -eq $predicateFailure) {
+                if ($null -ne $predicateState -and $predicateState.PSObject.Properties.Name -contains 'failure' -and $null -ne $predicateState.failure) {
+                    $predicateFailure = $predicateState.failure
+                }
+                else {
+                    $predicateFailure = New-MeridianRetryFailure `
+                        -Code 'retry.predicate.not_ready' `
+                        -Reason 'Readiness predicate did not pass.' `
+                        -Data @{
+                            state = $predicateState
+                        }
+                }
+            }
+
+            $lastFailure = $predicateFailure
+            $attemptEvents += [pscustomobject]@{
+                attempt = $attempt
+                phase = 'predicate'
+                status = 'retry'
+                code = $predicateFailure.code
+                reason = $predicateFailure.reason
+                timestamp = $attemptStarted.ToString('o')
+            }
+        }
+        else {
+            try {
+                $result = & $Action $predicateState
+                $attemptEvents += [pscustomobject]@{
+                    attempt = $attempt
+                    phase = 'action'
+                    status = 'ok'
+                    code = $null
+                    reason = $null
+                    timestamp = (Get-Date).ToString('o')
+                }
+
+                $event = [pscustomobject]@{
+                    name = $Name
+                    status = 'ok'
+                    attempts = $attempt
+                    startedAt = $startedAt.ToString('o')
+                    finishedAt = (Get-Date).ToString('o')
+                    durationMs = [int]((Get-Date) - $startedAt).TotalMilliseconds
+                    attemptsDetail = $attemptEvents
+                    failure = $null
+                }
+
+                if ($TelemetrySink) {
+                    [void]$TelemetrySink.Add($event)
+                }
+
+                return [pscustomobject]@{
+                    Success = $true
+                    Attempts = $attempt
+                    Value = $result
+                    Telemetry = $event
+                    Failure = $null
+                }
+            }
+            catch {
+                $lastFailure = New-MeridianRetryFailure `
+                    -Code 'retry.action.exception' `
+                    -Reason $_.Exception.Message `
+                    -Data @{ exceptionType = $_.Exception.GetType().FullName }
+
+                $attemptEvents += [pscustomobject]@{
+                    attempt = $attempt
+                    phase = 'action'
+                    status = 'retry'
+                    code = $lastFailure.code
+                    reason = $lastFailure.reason
+                    timestamp = (Get-Date).ToString('o')
+                }
+            }
+        }
+
+        if ($attempt -lt $MaxAttempts) {
+            $expDelay = [Math]::Min($MaxDelayMs, [int]($BaseDelayMs * [Math]::Pow($BackoffMultiplier, $attempt - 1)))
+            $jitter = if ($JitterMs -gt 0) { Get-Random -Minimum 0 -Maximum ($JitterMs + 1) } else { 0 }
+            Start-Sleep -Milliseconds ($expDelay + $jitter)
+        }
+    }
+
+    $failureEvent = [pscustomobject]@{
+        name = $Name
+        status = 'failed'
+        attempts = $MaxAttempts
+        startedAt = $startedAt.ToString('o')
+        finishedAt = (Get-Date).ToString('o')
+        durationMs = [int]((Get-Date) - $startedAt).TotalMilliseconds
+        attemptsDetail = $attemptEvents
+        failure = $lastFailure
+    }
+
+    if ($TelemetrySink) {
+        [void]$TelemetrySink.Add($failureEvent)
+    }
+
+    return [pscustomobject]@{
+        Success = $false
+        Attempts = $MaxAttempts
+        Value = $null
+        Telemetry = $failureEvent
+        Failure = $lastFailure
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace ad-hoc sleeps and fragile timing in desktop screenshot and workflow runners with a single retry primitive that encodes readiness, retries, exponential backoff, and jitter.
- Ensure each capture action validates a readiness predicate (window visible, route/page active, automation marker present) before taking screenshots.
- Provide machine-readable failure reasons and per-attempt telemetry so recurring flaky screens can be identified and ranked automatically.

### Description
- Add `scripts/dev/shared/retry.ps1` with `New-MeridianRetryFailure` and `Invoke-MeridianRetry` to run a readiness `Predicate` and execute an `Action` with configurable `MaxAttempts`, exponential backoff, jitter, structured failure payloads, and optional `TelemetrySink` aggregation.
- Update `scripts/dev/run-desktop-workflow.ps1` to import the retry helper and replace ad-hoc `Start-Sleep` / `Wait-ForShellPage` timing for each workflow step with `Invoke-MeridianRetry`, and to record `manifest.retryTelemetry` and a grouped `manifest.retrySummary` of failure-code frequencies.
- Update `scripts/dev/capture-desktop-screenshots.ps1` to import the retry helper, use `Invoke-MeridianRetry` for initial launch/window readiness and per-page capture readiness, and emit a `retry-telemetry.json` artifact containing telemetry and `failureRanking` for recurring failure codes.
- Emit structured failure codes such as `desktop.window.not_visible`, `desktop.window.too_small`, `desktop.automation.marker_missing`, `desktop.route.not_active`, and action/predicate exception codes to power automated ranking.

### Testing
- Attempted a PowerShell parse/validation run using `pwsh` to parse `scripts/dev/shared/retry.ps1`, `scripts/dev/run-desktop-workflow.ps1`, and `scripts/dev/capture-desktop-screenshots.ps1`, but the automation environment did not have `pwsh` installed so the parse step could not be executed (validation not completed).
- No other automated test suites were run in this environment; changes were committed successfully and a PR payload was prepared.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10ff1ec1c8320b33cdd7e5d36539f)