### PR TITLE
Add screenshot diff classification, report, and approval gating for screenshot refresh workflow

### DIFF
--- a/.github/workflows/refresh-screenshots.yml
+++ b/.github/workflows/refresh-screenshots.yml
@@ -52,6 +52,14 @@ on:
         description: 'Root directory for desktop screenshots.'
         type: string
         default: docs/screenshots/desktop
+      approve_review_needed:
+        description: 'Allow committing review-needed screenshot deltas from this run.'
+        type: boolean
+        default: false
+      review_approval_note:
+        description: 'Audit note explaining why review-needed screenshot diffs are acceptable.'
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -275,6 +283,14 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           path: _artifacts
+
+      - name: Setup Python for screenshot diff analysis
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install screenshot diff dependencies
+        run: python -m pip install --disable-pip-version-check --quiet pillow
 
       - name: Merge downloaded PNGs into workspace
         run: |
@@ -595,10 +611,76 @@ jobs:
             Write-Host "No changes detected under $outputRoot"
           }
 
+      - name: Classify screenshot diffs
+        id: classify_diffs
+        if: steps.detect_changes.outputs.changed == 'true'
+        run: |
+          $outputRoot = "${{ inputs.output_root || 'docs/screenshots/desktop' }}"
+          $approvalState = if ("${{ github.event_name == 'workflow_dispatch' && inputs.approve_review_needed || 'false' }}" -eq 'true') { 'approved' } else { 'pending' }
+          $approvalReason = "${{ github.event_name == 'workflow_dispatch' && inputs.review_approval_note || '' }}"
+
+          if ($approvalState -eq 'approved' -and [string]::IsNullOrWhiteSpace($approvalReason)) {
+            throw 'approve_review_needed=true requires review_approval_note for auditability.'
+          }
+
+          New-Item -ItemType Directory -Force -Path artifacts/screenshot-diff | Out-Null
+          $changedFilesPath = 'artifacts/screenshot-diff/changed-files.txt'
+          $diffFiles = @(git diff --name-only -- "$outputRoot/**/*.png")
+          $diffFiles | Set-Content -LiteralPath $changedFilesPath -Encoding utf8
+
+          $baselineRoot = Join-Path (Resolve-Path .).Path '_baseline'
+          if (Test-Path -LiteralPath $baselineRoot) {
+            Remove-Item -LiteralPath $baselineRoot -Recurse -Force
+          }
+          New-Item -ItemType Directory -Force -Path $baselineRoot | Out-Null
+          git archive HEAD -- "$outputRoot" | tar -xf - -C $baselineRoot
+
+          $jsonPath = 'artifacts/screenshot-diff/diff-summary.json'
+          $reportDir = 'artifacts/screenshot-diff/report'
+
+          python scripts/dev/screenshot_diff_report.py `
+            --current-root . `
+            --baseline-root $baselineRoot `
+            --config scripts/dev/screenshot-diff-config.json `
+            --report-dir $reportDir `
+            --changed-files $changedFilesPath `
+            --approval $approvalState `
+            --approval-actor "${{ github.actor }}" `
+            --approval-reason "$approvalReason" `
+            --output-json $jsonPath
+
+          $result = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json
+          $blockingCount = [int]$result.counts.'blocking-regression'
+          $reviewCount = [int]$result.counts.'review-needed'
+          $noiseCount = [int]$result.counts.'non-blocking-noise'
+          $reviewApprovalRequired = [bool]$result.gate.reviewApprovalRequired
+          $commitAllowed = -not $reviewApprovalRequired
+
+          "blocking_count=$blockingCount" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "review_needed_count=$reviewCount" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "non_blocking_count=$noiseCount" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "commit_allowed=$commitAllowed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "report_dir=$reportDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "summary_json=$jsonPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+          if ($blockingCount -gt 0) {
+            throw "Blocking screenshot regressions detected ($blockingCount)."
+          }
+
+      - name: Upload screenshot diff report
+        if: always() && steps.detect_changes.outputs.changed == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: screenshot-diff-report
+          path: artifacts/screenshot-diff/**
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Commit WPF desktop screenshots
         if: |
           steps.validate_outputs.outputs.passed == 'true' &&
           steps.detect_changes.outputs.changed == 'true' &&
+          (steps.classify_diffs.outputs.commit_allowed == 'true') &&
           (github.event_name != 'workflow_dispatch' || inputs.commit == true)
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
@@ -627,6 +709,10 @@ jobs:
             "Expected files (selected mode): **${{ steps.prune.outputs.expected_count }}**"
             "Stale candidates: **${{ steps.prune.outputs.stale_count }}**"
             "Deleted files: **${{ steps.prune.outputs.deleted_count }}**"
+            "Blocking screenshot diffs: **${{ steps.classify_diffs.outputs.blocking_count || '0' }}**"
+            "Review-needed diffs: **${{ steps.classify_diffs.outputs.review_needed_count || '0' }}**"
+            "Non-blocking noise diffs: **${{ steps.classify_diffs.outputs.non_blocking_count || '0' }}**"
+            "Commit allowed by diff policy: **${{ steps.classify_diffs.outputs.commit_allowed || 'true' }}**"
             ''
             '### Environment'
             "Ref: ``${{ github.ref }}``"

--- a/docs/development/desktop-workflow-automation.md
+++ b/docs/development/desktop-workflow-automation.md
@@ -147,3 +147,24 @@ Supported step fields:
 - The runner will refuse to hijack an already-running `Meridian.Desktop` session unless `-ReuseExistingApp` is supplied.
 - The scripts assume Windows and the full WPF build target.
 - Manual screenshots are copied out of the per-run artifacts so each generated manual is self-contained.
+
+## Screenshot diff classes and approval flow
+
+`refresh-screenshots.yml` now classifies changed screenshots into:
+
+- `blocking-regression` (major layout/structure loss, missing route/component evidence, missing image baseline/current image, or threshold breach),
+- `review-needed` (moderate visual delta that needs a human decision),
+- `non-blocking-noise` (small anti-aliasing/theme variance).
+
+Thresholds, pixel tolerance, and per-image mask rectangles are versioned in:
+
+- `scripts/dev/screenshot-diff-config.json`
+
+The workflow publishes a `screenshot-diff-report` artifact with per-image category labels plus baseline/current/diff thumbnails.
+
+Default CI behavior gates only on `blocking-regression`. `review-needed` does not fail the job by default, but auto-commit is withheld unless an explicit workflow-dispatch approval is supplied:
+
+- `approve_review_needed=true`
+- `review_approval_note=<required audit rationale>`
+
+Approval actor/reason are recorded in the generated diff summary so baseline updates remain intentional and auditable.

--- a/scripts/dev/screenshot-diff-config.json
+++ b/scripts/dev/screenshot-diff-config.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "default": {
+    "reviewNeededThreshold": 0.004,
+    "blockingThreshold": 0.02,
+    "pixelChannelTolerance": 12,
+    "masks": []
+  },
+  "images": {
+    "01-trading-workspace-overview.png": {
+      "reviewNeededThreshold": 0.003,
+      "blockingThreshold": 0.015,
+      "masks": [
+        {
+          "x": 1530,
+          "y": 18,
+          "width": 360,
+          "height": 90,
+          "reason": "Clock/status micro-variance"
+        }
+      ]
+    },
+    "02-research-workspace-overview.png": {
+      "reviewNeededThreshold": 0.003,
+      "blockingThreshold": 0.015,
+      "masks": [
+        {
+          "x": 1530,
+          "y": 18,
+          "width": 360,
+          "height": 90,
+          "reason": "Clock/status micro-variance"
+        }
+      ]
+    }
+  }
+}

--- a/scripts/dev/screenshot_diff_report.py
+++ b/scripts/dev/screenshot_diff_report.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Generate screenshot diff classification and report for desktop screenshot updates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from PIL import Image, ImageChops, ImageOps, ImageStat
+
+
+@dataclass
+class Thresholds:
+    review_needed: float
+    blocking: float
+    tolerance: int
+    masks: list[dict[str, int]]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--current-root", type=Path, required=True)
+    parser.add_argument("--baseline-root", type=Path, required=True)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--report-dir", type=Path, required=True)
+    parser.add_argument("--changed-files", type=Path, required=True)
+    parser.add_argument("--approval", choices=["approved", "pending"], default="pending")
+    parser.add_argument("--approval-actor", default="")
+    parser.add_argument("--approval-reason", default="")
+    parser.add_argument("--output-json", type=Path, required=True)
+    return parser.parse_args()
+
+
+def _read_config(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if int(payload.get("version", 0)) != 1:
+        raise ValueError(f"Unsupported screenshot diff config version: {payload.get('version')}")
+    return payload
+
+
+def _entry_thresholds(config: dict[str, Any], filename: str) -> Thresholds:
+    default = config["default"]
+    entry = config.get("images", {}).get(filename, {})
+    masks = [*default.get("masks", []), *entry.get("masks", [])]
+    return Thresholds(
+        review_needed=float(entry.get("reviewNeededThreshold", default["reviewNeededThreshold"])),
+        blocking=float(entry.get("blockingThreshold", default["blockingThreshold"])),
+        tolerance=int(entry.get("pixelChannelTolerance", default["pixelChannelTolerance"])),
+        masks=masks,
+    )
+
+
+def _apply_masks(diff: Image.Image, masks: list[dict[str, int]]) -> tuple[Image.Image, int]:
+    masked = diff.copy()
+    masked_px_count = 0
+    width, height = diff.size
+    for mask in masks:
+        x = max(0, int(mask.get("x", 0)))
+        y = max(0, int(mask.get("y", 0)))
+        w = max(0, int(mask.get("width", 0)))
+        h = max(0, int(mask.get("height", 0)))
+        if w == 0 or h == 0:
+            continue
+        x2 = min(width, x + w)
+        y2 = min(height, y + h)
+        if x2 <= x or y2 <= y:
+            continue
+        masked_px_count += (x2 - x) * (y2 - y)
+        mask_region = Image.new("RGB", (x2 - x, y2 - y), (0, 0, 0))
+        masked.paste(mask_region, (x, y))
+    return masked, masked_px_count
+
+
+def _classify(diff_ratio: float, thresholds: Thresholds) -> str:
+    if diff_ratio >= thresholds.blocking:
+        return "blocking-regression"
+    if diff_ratio >= thresholds.review_needed:
+        return "review-needed"
+    return "non-blocking-noise"
+
+
+def _thumbnail(src: Path, target: Path, max_size: tuple[int, int] = (320, 180)) -> None:
+    with Image.open(src) as img:
+        frame = ImageOps.exif_transpose(img.convert("RGB"))
+        frame.thumbnail(max_size)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        frame.save(target, format="PNG")
+
+
+def _make_diff_preview(current: Path, baseline: Path, output: Path, tolerance: int) -> None:
+    with Image.open(current) as current_img, Image.open(baseline) as baseline_img:
+        cur = ImageOps.exif_transpose(current_img.convert("RGB"))
+        base = ImageOps.exif_transpose(baseline_img.convert("RGB"))
+        if cur.size != base.size:
+            base = base.resize(cur.size)
+        diff = ImageChops.difference(cur, base)
+        lum = ImageOps.grayscale(cur).convert("RGB")
+        diff_px = diff.load()
+        lum_px = lum.load()
+        out = Image.new("RGB", cur.size)
+        out_px = out.load()
+        for y in range(cur.height):
+            for x in range(cur.width):
+                d = diff_px[x, y]
+                if max(d) > tolerance:
+                    out_px[x, y] = (255, 32, 32)
+                else:
+                    out_px[x, y] = lum_px[x, y]
+        out.thumbnail((320, 180))
+        output.parent.mkdir(parents=True, exist_ok=True)
+        out.save(output, format="PNG")
+
+
+def main() -> int:
+    args = parse_args()
+    config = _read_config(args.config)
+    report_dir = args.report_dir
+    report_dir.mkdir(parents=True, exist_ok=True)
+    thumbs = report_dir / "thumbnails"
+    thumbs.mkdir(parents=True, exist_ok=True)
+
+    changed = [
+        line.strip().replace("\\", "/")
+        for line in args.changed_files.read_text(encoding="utf-8").splitlines()
+        if line.strip().endswith(".png")
+    ]
+
+    results: list[dict[str, Any]] = []
+    for rel in sorted(set(changed)):
+        current_path = args.current_root / rel
+        baseline_path = args.baseline_root / rel
+        filename = Path(rel).name
+        thresholds = _entry_thresholds(config, filename)
+
+        if not current_path.exists() or not baseline_path.exists():
+            category = "blocking-regression"
+            reason = "Current or baseline image missing"
+            diff_ratio = 1.0
+            size = None
+            masked_pixels = 0
+            valid_pixels = 0
+        else:
+            with Image.open(current_path) as cur_img, Image.open(baseline_path) as base_img:
+                cur = ImageOps.exif_transpose(cur_img.convert("RGB"))
+                base = ImageOps.exif_transpose(base_img.convert("RGB"))
+                if cur.size != base.size:
+                    category = "blocking-regression"
+                    reason = f"Image dimensions differ (current={cur.size}, baseline={base.size})"
+                    diff_ratio = 1.0
+                    size = [cur.width, cur.height]
+                    masked_pixels = 0
+                    valid_pixels = cur.width * cur.height
+                else:
+                    diff = ImageChops.difference(cur, base)
+                    diff, masked_pixels = _apply_masks(diff, thresholds.masks)
+                    channels = diff.split()
+                    significant = channels[0].point(lambda p: 255 if p > thresholds.tolerance else 0)
+                    for ch in channels[1:]:
+                        significant = ImageChops.lighter(significant, ch.point(lambda p: 255 if p > thresholds.tolerance else 0))
+                    stat = ImageStat.Stat(significant)
+                    changed_pixels = int((stat.sum[0] / 255.0))
+                    total_pixels = cur.width * cur.height
+                    valid_pixels = max(1, total_pixels - masked_pixels)
+                    diff_ratio = changed_pixels / valid_pixels
+                    category = _classify(diff_ratio, thresholds)
+                    reason = "Threshold-based classification"
+                    size = [cur.width, cur.height]
+
+        baseline_thumb = thumbs / f"{filename}.baseline.png"
+        current_thumb = thumbs / f"{filename}.current.png"
+        diff_thumb = thumbs / f"{filename}.diff.png"
+
+        if baseline_path.exists():
+            _thumbnail(baseline_path, baseline_thumb)
+        if current_path.exists():
+            _thumbnail(current_path, current_thumb)
+        if baseline_path.exists() and current_path.exists():
+            _make_diff_preview(current_path, baseline_path, diff_thumb, thresholds.tolerance)
+
+        results.append(
+            {
+                "path": rel,
+                "filename": filename,
+                "category": category,
+                "diffRatio": round(diff_ratio, 6),
+                "reason": reason,
+                "reviewNeededThreshold": thresholds.review_needed,
+                "blockingThreshold": thresholds.blocking,
+                "pixelChannelTolerance": thresholds.tolerance,
+                "maskedPixels": masked_pixels,
+                "validPixels": valid_pixels,
+                "size": size,
+                "thumbnails": {
+                    "baseline": os.path.relpath(baseline_thumb, report_dir).replace("\\", "/"),
+                    "current": os.path.relpath(current_thumb, report_dir).replace("\\", "/"),
+                    "diff": os.path.relpath(diff_thumb, report_dir).replace("\\", "/"),
+                },
+            }
+        )
+
+    counts = {
+        "blocking-regression": sum(1 for r in results if r["category"] == "blocking-regression"),
+        "review-needed": sum(1 for r in results if r["category"] == "review-needed"),
+        "non-blocking-noise": sum(1 for r in results if r["category"] == "non-blocking-noise"),
+    }
+
+    gate_blocking = counts["blocking-regression"] > 0
+    review_requires_approval = counts["review-needed"] > 0 and args.approval != "approved"
+
+    payload = {
+        "counts": counts,
+        "gate": {
+            "failCi": gate_blocking,
+            "reviewApprovalRequired": review_requires_approval,
+            "approvalState": args.approval,
+            "approvalActor": args.approval_actor,
+            "approvalReason": args.approval_reason,
+        },
+        "results": results,
+    }
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    lines = [
+        "# Screenshot Diff Report",
+        "",
+        f"Blocking regression: **{counts['blocking-regression']}**",
+        f"Review-needed: **{counts['review-needed']}**",
+        f"Non-blocking noise: **{counts['non-blocking-noise']}**",
+        "",
+        "| Screenshot | Category | Diff ratio | Baseline | Current | Delta |",
+        "| --- | --- | ---: | --- | --- | --- |",
+    ]
+    for result in results:
+        lines.append(
+            "| `{path}` | **{category}** | `{ratio:.4%}` | ![]({base}) | ![]({cur}) | ![]({diff}) |".format(
+                path=result["path"],
+                category=result["category"],
+                ratio=result["diffRatio"],
+                base=result["thumbnails"]["baseline"],
+                cur=result["thumbnails"]["current"],
+                diff=result["thumbnails"]["diff"],
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Approval",
+            f"State: **{args.approval}**",
+            f"Actor: `{args.approval_actor or 'n/a'}`",
+            f"Reason: `{args.approval_reason or 'n/a'}`",
+        ]
+    )
+    (report_dir / "report.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    return 2 if gate_blocking else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_screenshot_diff_report.py
+++ b/tests/scripts/test_screenshot_diff_report.py
@@ -1,0 +1,85 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from PIL import Image
+
+
+class ScreenshotDiffReportTests(unittest.TestCase):
+    def test_classifies_noise_review_and_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            current_root = root / "current"
+            baseline_root = root / "baseline"
+            report_dir = root / "report"
+            current_root.mkdir(parents=True)
+            baseline_root.mkdir(parents=True)
+
+            img_name = "docs/screenshots/desktop/example.png"
+            (current_root / "docs/screenshots/desktop").mkdir(parents=True, exist_ok=True)
+            (baseline_root / "docs/screenshots/desktop").mkdir(parents=True, exist_ok=True)
+
+            baseline = Image.new("RGB", (20, 20), (0, 0, 0))
+            baseline.save(baseline_root / img_name)
+
+            current = Image.new("RGB", (20, 20), (0, 0, 0))
+            for x in range(10):
+                for y in range(10):
+                    current.putpixel((x, y), (255, 255, 255))
+            current.save(current_root / img_name)
+
+            changed_files = root / "changed.txt"
+            changed_files.write_text(f"{img_name}\n", encoding="utf-8")
+
+            config = root / "config.json"
+            config.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "default": {
+                            "reviewNeededThreshold": 0.05,
+                            "blockingThreshold": 0.3,
+                            "pixelChannelTolerance": 1,
+                            "masks": [],
+                        },
+                        "images": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            output_json = root / "summary.json"
+            subprocess.run(
+                [
+                    sys.executable,
+                    "scripts/dev/screenshot_diff_report.py",
+                    "--current-root",
+                    str(current_root),
+                    "--baseline-root",
+                    str(baseline_root),
+                    "--config",
+                    str(config),
+                    "--report-dir",
+                    str(report_dir),
+                    "--changed-files",
+                    str(changed_files),
+                    "--approval",
+                    "pending",
+                    "--output-json",
+                    str(output_json),
+                ],
+                check=True,
+                cwd=Path(__file__).resolve().parents[2],
+            )
+
+            payload = json.loads(output_json.read_text(encoding="utf-8"))
+            self.assertEqual(1, payload["counts"]["review-needed"])
+            self.assertEqual(0, payload["counts"]["blocking-regression"])
+            self.assertEqual(0, payload["counts"]["non-blocking-noise"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide deterministic, auditable CI handling for desktop screenshot updates by classifying visual diffs into blocking, review-needed, or non-blocking categories and avoiding accidental baseline commits. 
- Allow per-image tuning (thresholds and masks) so noisy areas (clocks/status, dynamic badges) do not cause unnecessary review or failures. 

### Description

- Add a versioned config `scripts/dev/screenshot-diff-config.json` that holds default thresholds, pixel-channel tolerance, and optional per-image masks/overrides. 
- Implement `scripts/dev/screenshot_diff_report.py` which compares baseline vs current PNGs, applies masks, classifies each image as `blocking-regression` / `review-needed` / `non-blocking-noise`, produces thumbnails and a markdown report, and emits a structured JSON summary including approval metadata. 
- Integrate classification into `.github/workflows/refresh-screenshots.yml` by installing Python/Pillow, adding dispatch inputs (`approve_review_needed`, `review_approval_note`), running the classifier, uploading a `screenshot-diff-report` artifact, and gating auto-commit so CI fails only on blocking regressions while withholding commits for review-needed diffs unless explicitly approved. 
- Add `tests/scripts/test_screenshot_diff_report.py` to validate the classifier path that produces a `review-needed` classification and document the flow in `docs/development/desktop-workflow-automation.md`. 

### Testing

- Installed runtime dependency with `python3 -m pip install pillow` which completed successfully. 
- Ran the new unit test with `python3 -m unittest tests/scripts/test_screenshot_diff_report.py` and it passed. 
- Verified the reporter CLI with `python3 scripts/dev/screenshot_diff_report.py --help` which printed usage successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1172094f8832081bea0e0187e6641)