### PR TITLE
Add reusable desktop workflow profiles and preflight validator

### DIFF
--- a/.github/workflows/refresh-screenshots.yml
+++ b/.github/workflows/refresh-screenshots.yml
@@ -22,6 +22,9 @@ on:
       - 'config/appsettings.sample.json'
       - 'scripts/dev/SharedBuild.ps1'
       - 'scripts/dev/desktop-workflows.json'
+      - 'scripts/dev/workflow-profiles/**'
+      - 'scripts/dev/SharedWorkflowProfiles.ps1'
+      - 'scripts/dev/validate-workflow-profile.ps1'
       - 'scripts/dev/run-desktop-workflow.ps1'
       - 'scripts/dev/capture-desktop-screenshots.ps1'
       - 'src/Meridian.Ui.Services/**'
@@ -198,6 +201,7 @@ jobs:
 
           pwsh -File scripts/dev/run-desktop-workflow.ps1 `
             -Workflow "${{ matrix.workflow.name }}" `
+            -Profile "${{ matrix.workflow.name }}" `
             -ProjectPath "${{ env.WPF_PROJECT }}" `
             -Configuration "${{ env.WPF_CONFIGURATION }}" `
             -Framework "${{ env.WPF_FRAMEWORK }}" `

--- a/scripts/dev/SharedWorkflowProfiles.ps1
+++ b/scripts/dev/SharedWorkflowProfiles.ps1
@@ -1,0 +1,130 @@
+Set-StrictMode -Version Latest
+
+function Resolve-MeridianWorkflowProfilePath {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepoRoot,
+        [Parameter(Mandatory = $true)][string]$ProfileName,
+        [string]$ProfileRoot = 'scripts/dev/workflow-profiles'
+    )
+
+    $root = if ([System.IO.Path]::IsPathRooted($ProfileRoot)) {
+        [System.IO.Path]::GetFullPath($ProfileRoot)
+    }
+    else {
+        [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $ProfileRoot))
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path $root ($ProfileName + '.json')))
+}
+
+function Get-MeridianWorkflowProfile {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepoRoot,
+        [Parameter(Mandatory = $true)][string]$ProfileName,
+        [string]$ProfileRoot = 'scripts/dev/workflow-profiles'
+    )
+
+    $profilePath = Resolve-MeridianWorkflowProfilePath -RepoRoot $RepoRoot -ProfileName $ProfileName -ProfileRoot $ProfileRoot
+    if (-not (Test-Path -LiteralPath $profilePath)) {
+        throw "Workflow profile '$ProfileName' was not found at '$profilePath'."
+    }
+
+    $profile = Get-Content -LiteralPath $profilePath -Raw | ConvertFrom-Json -AsHashtable
+    return [ordered]@{
+        name = $ProfileName
+        path = $profilePath
+        root = [System.IO.Path]::GetDirectoryName($profilePath)
+        data = $profile
+    }
+}
+
+function Get-MeridianWorkflowProfileValue {
+    param(
+        [hashtable]$Table,
+        [Parameter(Mandatory = $true)][string]$Key,
+        $Fallback = $null
+    )
+
+    if ($null -ne $Table -and $Table.Contains($Key) -and $null -ne $Table[$Key] -and "$($Table[$Key])" -ne '') {
+        return $Table[$Key]
+    }
+
+    return $Fallback
+}
+
+function Test-MeridianWorkflowProfile {
+    param(
+        [Parameter(Mandatory = $true)][hashtable]$ProfileData,
+        [switch]$NoFixture,
+        [switch]$ReuseExistingApp
+    )
+
+    $errors = New-Object System.Collections.Generic.List[string]
+    $warnings = New-Object System.Collections.Generic.List[string]
+
+    $build = Get-MeridianWorkflowProfileValue -Table $ProfileData -Key 'build' -Fallback @{}
+    $fixture = Get-MeridianWorkflowProfileValue -Table $ProfileData -Key 'fixture' -Fallback @{}
+    $host = Get-MeridianWorkflowProfileValue -Table $ProfileData -Key 'host' -Fallback @{}
+    $screenshots = Get-MeridianWorkflowProfileValue -Table $ProfileData -Key 'screenshots' -Fallback @{}
+
+    foreach ($key in @('projectPath', 'configuration', 'framework', 'exeName')) {
+        if ([string]::IsNullOrWhiteSpace([string](Get-MeridianWorkflowProfileValue -Table $build -Key $key -Fallback ''))) {
+            $errors.Add("build.$key is required.")
+        }
+    }
+
+    $fixtureRequired = [bool](Get-MeridianWorkflowProfileValue -Table $fixture -Key 'required' -Fallback $false)
+    if ($fixtureRequired -and $NoFixture) {
+        $errors.Add('Profile requires fixture mode, but -NoFixture was specified.')
+    }
+
+    $baseUrl = [string](Get-MeridianWorkflowProfileValue -Table $host -Key 'baseUrl' -Fallback '')
+    if ([string]::IsNullOrWhiteSpace($baseUrl)) {
+        $errors.Add('host.baseUrl is required.')
+    }
+    else {
+        $parsedBaseUri = $null
+        if (-not [System.Uri]::TryCreate($baseUrl, [System.UriKind]::Absolute, [ref]$parsedBaseUri)) {
+            $errors.Add("host.baseUrl '$baseUrl' must be an absolute URI.")
+        }
+    }
+
+    $healthPath = [string](Get-MeridianWorkflowProfileValue -Table $host -Key 'healthPath' -Fallback '')
+    if ([string]::IsNullOrWhiteSpace($healthPath)) {
+        $errors.Add('host.healthPath is required.')
+    }
+
+    $outputRoot = [string](Get-MeridianWorkflowProfileValue -Table $screenshots -Key 'outputRoot' -Fallback '')
+    if ([string]::IsNullOrWhiteSpace($outputRoot)) {
+        $warnings.Add('screenshots.outputRoot is not set; caller must provide output path.')
+    }
+
+    $retention = Get-MeridianWorkflowProfileValue -Table $screenshots -Key 'retention' -Fallback @{}
+    $maxAgeDays = [int](Get-MeridianWorkflowProfileValue -Table $retention -Key 'maxAgeDays' -Fallback 14)
+    $retainLatest = [int](Get-MeridianWorkflowProfileValue -Table $retention -Key 'retainLatest' -Fallback 10)
+    if ($maxAgeDays -lt 0) {
+        $errors.Add('screenshots.retention.maxAgeDays must be >= 0.')
+    }
+
+    if ($retainLatest -lt 0) {
+        $errors.Add('screenshots.retention.retainLatest must be >= 0.')
+    }
+
+    if ($ReuseExistingApp -and $fixtureRequired) {
+        $warnings.Add('Reusing an existing app can bypass fixture initialization from this profile.')
+    }
+
+    return [ordered]@{
+        isValid = $errors.Count -eq 0
+        errors = @($errors)
+        warnings = @($warnings)
+        resolved = [ordered]@{
+            fixtureRequired = $fixtureRequired
+            outputRoot = $outputRoot
+            retention = [ordered]@{
+                maxAgeDays = $maxAgeDays
+                retainLatest = $retainLatest
+            }
+        }
+    }
+}

--- a/scripts/dev/capture-desktop-screenshots.ps1
+++ b/scripts/dev/capture-desktop-screenshots.ps1
@@ -1,10 +1,12 @@
 [CmdletBinding()]
 param(
-  [string]$ProjectPath = 'src/Meridian.Wpf/Meridian.Wpf.csproj',
-  [string]$Configuration = 'Release',
-  [string]$Framework = 'net9.0-windows10.0.19041.0',
-  [string]$ExeName = 'Meridian.Desktop.exe',
-  [string]$OutputDir = 'docs/screenshots/desktop',
+  [string]$Profile = 'screenshot-catalog',
+  [string]$ProfileRoot = 'scripts/dev/workflow-profiles',
+  [string]$ProjectPath,
+  [string]$Configuration,
+  [string]$Framework,
+  [string]$ExeName,
+  [string]$OutputDir,
   [switch]$SkipBuild,
   [switch]$KeepAppOpen
 )
@@ -14,6 +16,22 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '../..')
 . (Join-Path $PSScriptRoot 'SharedBuild.ps1')
+$null = & (Join-Path $PSScriptRoot 'validate-workflow-profile.ps1') -Profile $Profile -ProfileRoot $ProfileRoot -EmitJson
+. (Join-Path $PSScriptRoot 'SharedWorkflowProfiles.ps1')
+$profileEnvelope = Get-MeridianWorkflowProfile -RepoRoot $repoRoot -ProfileName $Profile -ProfileRoot $ProfileRoot
+$buildProfile = Get-MeridianWorkflowProfileValue -Table $profileEnvelope.data -Key 'build' -Fallback @{}
+$fixtureProfile = Get-MeridianWorkflowProfileValue -Table $profileEnvelope.data -Key 'fixture' -Fallback @{}
+$screenshotsProfile = Get-MeridianWorkflowProfileValue -Table $profileEnvelope.data -Key 'screenshots' -Fallback @{}
+$retentionProfile = Get-MeridianWorkflowProfileValue -Table $screenshotsProfile -Key 'retention' -Fallback @{}
+
+$ProjectPath = if ($PSBoundParameters.ContainsKey('ProjectPath')) { $ProjectPath } else { [string](Get-MeridianWorkflowProfileValue -Table $buildProfile -Key 'projectPath' -Fallback 'src/Meridian.Wpf/Meridian.Wpf.csproj') }
+$Configuration = if ($PSBoundParameters.ContainsKey('Configuration')) { $Configuration } else { [string](Get-MeridianWorkflowProfileValue -Table $buildProfile -Key 'configuration' -Fallback 'Release') }
+$Framework = if ($PSBoundParameters.ContainsKey('Framework')) { $Framework } else { [string](Get-MeridianWorkflowProfileValue -Table $buildProfile -Key 'framework' -Fallback 'net9.0-windows10.0.19041.0') }
+$ExeName = if ($PSBoundParameters.ContainsKey('ExeName')) { $ExeName } else { [string](Get-MeridianWorkflowProfileValue -Table $buildProfile -Key 'exeName' -Fallback 'Meridian.Desktop.exe') }
+$OutputDir = if ($PSBoundParameters.ContainsKey('OutputDir')) { $OutputDir } else { [string](Get-MeridianWorkflowProfileValue -Table $screenshotsProfile -Key 'outputRoot' -Fallback 'docs/screenshots/desktop') }
+$fixtureRequired = [bool](Get-MeridianWorkflowProfileValue -Table $fixtureProfile -Key 'required' -Fallback $true)
+$retentionDays = [int](Get-MeridianWorkflowProfileValue -Table $retentionProfile -Key 'maxAgeDays' -Fallback 14)
+$retentionLatest = [int](Get-MeridianWorkflowProfileValue -Table $retentionProfile -Key 'retainLatest' -Fallback 10)
 $resolvedProjectPath = if ([System.IO.Path]::IsPathRooted($ProjectPath)) {
   [System.IO.Path]::GetFullPath($ProjectPath)
 }
@@ -21,6 +39,7 @@ else {
   [System.IO.Path]::GetFullPath((Join-Path $repoRoot $ProjectPath))
 }
 $buildIsolationKey = New-MeridianBuildIsolationKey -Prefix 'desktop-screenshots'
+Invoke-MeridianWorkflowArtifactRetention -OutputRoot ([System.IO.Path]::GetFullPath((Join-Path $repoRoot $OutputDir))) -MaxAgeDays $retentionDays -RetainLatest $retentionLatest
 
 function Assert-Command {
   param([string]$Name)
@@ -366,7 +385,9 @@ if (-not $SkipBuild) {
   )
 }
 
-$env:MDC_FIXTURE_MODE = '1'
+if ($fixtureRequired) {
+  $env:MDC_FIXTURE_MODE = '1'
+}
 $exePath = Get-MeridianProjectBinaryPath -RepoRoot $repoRoot -ProjectPath $resolvedProjectPath -Configuration $Configuration -Framework $Framework -BinaryName $ExeName -IsolationKey $buildIsolationKey
 $stdoutPath = 'wpf-startup-stdout.log'
 $stderrPath = 'wpf-startup-stderr.log'

--- a/scripts/dev/run-desktop-workflow.ps1
+++ b/scripts/dev/run-desktop-workflow.ps1
@@ -3,6 +3,8 @@
 param(
     [Parameter(Mandatory = $true)]
     [string]$Workflow,
+    [string]$Profile,
+    [string]$ProfileRoot = 'scripts/dev/workflow-profiles',
     [string]$DefinitionPath = 'scripts/dev/desktop-workflows.json',
     [string]$ProjectPath,
     [string]$Configuration,
@@ -28,6 +30,7 @@ $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
 Set-Location $repoRoot
 . (Join-Path $PSScriptRoot 'SharedBuild.ps1')
 . (Join-Path $PSScriptRoot 'SharedPreflight.ps1')
+. (Join-Path $PSScriptRoot 'SharedWorkflowProfiles.ps1')
 
 function Write-Info([string]$Message) { Write-Host "[INFO] $Message" -ForegroundColor Gray }
 function Write-Ok([string]$Message) { Write-Host "[ OK ] $Message" -ForegroundColor Green }
@@ -689,14 +692,24 @@ if ($null -eq $workflowDefinition) {
     throw "Workflow '$Workflow' was not found in '$catalogPath'."
 }
 
-$projectPathInput = if ($PSBoundParameters.ContainsKey('ProjectPath')) { $ProjectPath } else { Get-ConfigValue -Table $defaults -Key 'projectPath' -Fallback 'src/Meridian.Wpf/Meridian.Wpf.csproj' }
+$resolvedProfileName = if ($PSBoundParameters.ContainsKey('Profile') -and -not [string]::IsNullOrWhiteSpace($Profile)) { $Profile } else { $Workflow }
+$null = & (Join-Path $PSScriptRoot 'validate-workflow-profile.ps1') -Profile $resolvedProfileName -ProfileRoot $ProfileRoot -NoFixture:$NoFixture -ReuseExistingApp:$ReuseExistingApp -EmitJson
+$profileEnvelope = Get-MeridianWorkflowProfile -RepoRoot $repoRoot -ProfileName $resolvedProfileName -ProfileRoot $ProfileRoot
+$profileBuild = Get-MeridianWorkflowProfileValue -Table $profileEnvelope.data -Key 'build' -Fallback @{}
+$profileFixture = Get-MeridianWorkflowProfileValue -Table $profileEnvelope.data -Key 'fixture' -Fallback @{}
+$profileScreenshots = Get-MeridianWorkflowProfileValue -Table $profileEnvelope.data -Key 'screenshots' -Fallback @{}
+$profileRetention = Get-MeridianWorkflowProfileValue -Table $profileScreenshots -Key 'retention' -Fallback @{}
+
+$projectPathInput = if ($PSBoundParameters.ContainsKey('ProjectPath')) { $ProjectPath } else { Get-MeridianWorkflowProfileValue -Table $profileBuild -Key 'projectPath' -Fallback (Get-ConfigValue -Table $defaults -Key 'projectPath' -Fallback 'src/Meridian.Wpf/Meridian.Wpf.csproj') }
 $resolvedProjectPath = Resolve-RepoPath $projectPathInput
-$resolvedConfiguration = if ($PSBoundParameters.ContainsKey('Configuration')) { $Configuration } else { [string](Get-ConfigValue -Table $defaults -Key 'configuration' -Fallback 'Release') }
-$resolvedFramework = if ($PSBoundParameters.ContainsKey('Framework')) { $Framework } else { [string](Get-ConfigValue -Table $defaults -Key 'framework' -Fallback 'net9.0-windows10.0.19041.0') }
-$resolvedExeName = if ($PSBoundParameters.ContainsKey('ExeName')) { $ExeName } else { [string](Get-ConfigValue -Table $defaults -Key 'exeName' -Fallback 'Meridian.Desktop.exe') }
-$outputRootInput = if ($PSBoundParameters.ContainsKey('OutputRoot')) { $OutputRoot } else { [string](Get-ConfigValue -Table $defaults -Key 'outputRoot' -Fallback 'artifacts/desktop-workflows') }
+$resolvedConfiguration = if ($PSBoundParameters.ContainsKey('Configuration')) { $Configuration } else { [string](Get-MeridianWorkflowProfileValue -Table $profileBuild -Key 'configuration' -Fallback (Get-ConfigValue -Table $defaults -Key 'configuration' -Fallback 'Release')) }
+$resolvedFramework = if ($PSBoundParameters.ContainsKey('Framework')) { $Framework } else { [string](Get-MeridianWorkflowProfileValue -Table $profileBuild -Key 'framework' -Fallback (Get-ConfigValue -Table $defaults -Key 'framework' -Fallback 'net9.0-windows10.0.19041.0')) }
+$resolvedExeName = if ($PSBoundParameters.ContainsKey('ExeName')) { $ExeName } else { [string](Get-MeridianWorkflowProfileValue -Table $profileBuild -Key 'exeName' -Fallback (Get-ConfigValue -Table $defaults -Key 'exeName' -Fallback 'Meridian.Desktop.exe')) }
+$outputRootInput = if ($PSBoundParameters.ContainsKey('OutputRoot')) { $OutputRoot } else { [string](Get-MeridianWorkflowProfileValue -Table $profileScreenshots -Key 'outputRoot' -Fallback (Get-ConfigValue -Table $defaults -Key 'outputRoot' -Fallback 'artifacts/desktop-workflows')) }
 $resolvedOutputRoot = Resolve-RepoPath $outputRootInput
-Invoke-MeridianWorkflowArtifactRetention -OutputRoot $resolvedOutputRoot
+$retentionDays = [int](Get-MeridianWorkflowProfileValue -Table $profileRetention -Key 'maxAgeDays' -Fallback 14)
+$retentionLatest = [int](Get-MeridianWorkflowProfileValue -Table $profileRetention -Key 'retainLatest' -Fallback 10)
+Invoke-MeridianWorkflowArtifactRetention -OutputRoot $resolvedOutputRoot -MaxAgeDays $retentionDays -RetainLatest $retentionLatest
 $buildIsolationKey = New-MeridianBuildIsolationKey -Prefix ("desktop-workflow-" + $Workflow)
 $resolvedScreenshotDirectory = if ($PSBoundParameters.ContainsKey('ScreenshotDirectory')) {
     Resolve-RepoPath $ScreenshotDirectory
@@ -710,7 +723,13 @@ $useFixture = if ($NoFixture) {
     $false
 }
 else {
-    Get-ConfigBool -Table $workflowDefinition -Key 'fixtureMode' -Fallback (Get-ConfigBool -Table $defaults -Key 'fixtureMode' -Fallback $true)
+    $profileFixtureRequired = [bool](Get-MeridianWorkflowProfileValue -Table $profileFixture -Key 'required' -Fallback $true)
+    if ($profileFixtureRequired) {
+        $true
+    }
+    else {
+        Get-ConfigBool -Table $workflowDefinition -Key 'fixtureMode' -Fallback (Get-ConfigBool -Table $defaults -Key 'fixtureMode' -Fallback $true)
+    }
 }
 
 if ([string]::IsNullOrWhiteSpace($CheckpointPath)) {
@@ -722,6 +741,7 @@ $checkpoint = Initialize-MeridianCheckpoint `
     -CheckpointPath $CheckpointPath `
     -InputObject ([ordered]@{
         workflow = $Workflow
+        profile = $resolvedProfileName
         definitionPath = $catalogPath
         projectPath = $resolvedProjectPath
         configuration = $resolvedConfiguration
@@ -759,6 +779,8 @@ $manifest = [ordered]@{
         purpose = $workflowDefinition.purpose
     }
     run = [ordered]@{
+        profile = $resolvedProfileName
+        profilePath = $profileEnvelope.path
         catalogPath = $catalogPath
         projectPath = $resolvedProjectPath
         configuration = $resolvedConfiguration

--- a/scripts/dev/run-desktop.ps1
+++ b/scripts/dev/run-desktop.ps1
@@ -1,6 +1,8 @@
 #!/usr/bin/env pwsh
 [CmdletBinding()]
 param(
+    [string]$Profile = 'screenshot-catalog',
+    [string]$ProfileRoot = 'scripts/dev/workflow-profiles',
     [switch]$NoBuild,
     [switch]$Fixture,
     [Parameter(ValueFromRemainingArguments = $true)]
@@ -13,12 +15,32 @@ $ErrorActionPreference = 'Stop'
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '../..')
 Set-Location $repoRoot
 . (Join-Path $PSScriptRoot 'SharedBuild.ps1')
+. (Join-Path $PSScriptRoot 'SharedWorkflowProfiles.ps1')
+
+$profileEnvelope = Get-MeridianWorkflowProfile -RepoRoot $repoRoot -ProfileName $Profile -ProfileRoot $ProfileRoot
+$profileValidation = Test-MeridianWorkflowProfile -ProfileData $profileEnvelope.data
+if (-not $profileValidation.isValid) {
+    throw "Profile '$Profile' failed validation: $($profileValidation.errors -join '; ')"
+}
+
+$buildProfile = Get-MeridianWorkflowProfileValue -Table $profileEnvelope.data -Key 'build' -Fallback @{}
+$hostProfile = Get-MeridianWorkflowProfileValue -Table $profileEnvelope.data -Key 'host' -Fallback @{}
+$fixtureProfile = Get-MeridianWorkflowProfileValue -Table $profileEnvelope.data -Key 'fixture' -Fallback @{}
 
 $hostProject = 'src/Meridian/Meridian.csproj'
-$desktopProject = 'src/Meridian.Wpf/Meridian.Wpf.csproj'
+$desktopProject = [string](Get-MeridianWorkflowProfileValue -Table $buildProfile -Key 'projectPath' -Fallback 'src/Meridian.Wpf/Meridian.Wpf.csproj')
+$desktopConfiguration = [string](Get-MeridianWorkflowProfileValue -Table $buildProfile -Key 'configuration' -Fallback 'Debug')
+$desktopFramework = [string](Get-MeridianWorkflowProfileValue -Table $buildProfile -Key 'framework' -Fallback 'net9.0-windows10.0.19041.0')
+$desktopExeName = [string](Get-MeridianWorkflowProfileValue -Table $buildProfile -Key 'exeName' -Fallback 'Meridian.Desktop.exe')
+$hostBaseUrl = [string](Get-MeridianWorkflowProfileValue -Table $hostProfile -Key 'baseUrl' -Fallback 'http://localhost:8080')
+$hostHealthPath = [string](Get-MeridianWorkflowProfileValue -Table $hostProfile -Key 'healthPath' -Fallback '/healthz')
+$hostStartupTimeoutSec = [int](Get-MeridianWorkflowProfileValue -Table $hostProfile -Key 'startupTimeoutSec' -Fallback 30)
+$hostMode = [string](Get-MeridianWorkflowProfileValue -Table $hostProfile -Key 'mode' -Fallback 'desktop')
+$hostPort = [int](Get-MeridianWorkflowProfileValue -Table $hostProfile -Key 'port' -Fallback 8080)
+$fixtureRequired = [bool](Get-MeridianWorkflowProfileValue -Table $fixtureProfile -Key 'required' -Fallback $false)
 $buildIsolationKey = New-MeridianBuildIsolationKey -Prefix 'desktop-run'
 $hostExe = Get-MeridianProjectBinaryPath -RepoRoot $repoRoot -ProjectPath $hostProject -Configuration 'Debug' -Framework 'net9.0' -BinaryName 'Meridian.exe' -IsolationKey $buildIsolationKey
-$desktopExe = Get-MeridianProjectBinaryPath -RepoRoot $repoRoot -ProjectPath $desktopProject -Configuration 'Debug' -Framework 'net9.0-windows10.0.19041.0' -BinaryName 'Meridian.Desktop.exe' -IsolationKey $buildIsolationKey
+$desktopExe = Get-MeridianProjectBinaryPath -RepoRoot $repoRoot -ProjectPath $desktopProject -Configuration $desktopConfiguration -Framework $desktopFramework -BinaryName $desktopExeName -IsolationKey $buildIsolationKey
 $artifactsDir = Join-Path $repoRoot 'artifacts'
 $hostStdout = Join-Path $artifactsDir 'desktop-launcher-host.stdout.log'
 $hostStderr = Join-Path $artifactsDir 'desktop-launcher-host.stderr.log'
@@ -95,7 +117,8 @@ function Stop-WorkspaceDesktopProcesses {
 
 function Test-HealthyHost {
     try {
-        $response = Invoke-WebRequest -Uri 'http://localhost:8080/healthz' -UseBasicParsing -TimeoutSec 2
+        $healthUri = ($hostBaseUrl.TrimEnd('/')) + $hostHealthPath
+        $response = Invoke-WebRequest -Uri $healthUri -UseBasicParsing -TimeoutSec 2
         return $response.StatusCode -ge 200 -and $response.StatusCode -lt 300
     }
     catch {
@@ -142,6 +165,11 @@ try {
         throw 'The desktop launcher requires Windows because Meridian.Wpf is a Windows-only application.'
     }
 
+    if ($fixtureRequired -and -not $Fixture) {
+        $Fixture = $true
+        Write-Info "Profile '$Profile' requires fixture mode; enabling -Fixture."
+    }
+
     if ($Fixture) {
         Write-Info 'Fixture mode enabled; forcing synthetic backend overrides for deterministic local startup.'
         $env:MDC_DATASOURCE = 'Synthetic'
@@ -182,8 +210,8 @@ try {
             throw 'Meridian desktop restore failed.'
         }
 
-        & dotnet build $desktopProject -c Debug -v minimal -nologo --no-restore @(
-            Get-MeridianBuildArguments -IsolationKey $buildIsolationKey -EnableFullWpfBuild
+        & dotnet build $desktopProject -c $desktopConfiguration -v minimal -nologo --no-restore @(
+            Get-MeridianBuildArguments -IsolationKey $buildIsolationKey -TargetFramework $desktopFramework -EnableFullWpfBuild
         )
         if ($LASTEXITCODE -ne 0) {
             throw 'Meridian desktop build failed.'
@@ -199,12 +227,12 @@ try {
     }
 
     if (Test-HealthyHost) {
-        Write-Ok 'Reusing existing local Meridian host on http://localhost:8080'
+        Write-Ok "Reusing existing local Meridian host on $hostBaseUrl"
     }
     else {
-        Write-Info 'Starting local Meridian host on http://localhost:8080...'
+        Write-Info "Starting local Meridian host on $hostBaseUrl..."
         $hostProcess = Start-Process -FilePath $hostExe `
-            -ArgumentList @('--mode', 'desktop', '--http-port', '8080') `
+            -ArgumentList @('--mode', $hostMode, '--http-port', "$hostPort") `
             -WorkingDirectory $repoRoot `
             -RedirectStandardOutput $hostStdout `
             -RedirectStandardError $hostStderr `
@@ -212,7 +240,7 @@ try {
         $hostOwned = $true
 
         $healthy = $false
-        for ($attempt = 0; $attempt -lt 30; $attempt++) {
+        for ($attempt = 0; $attempt -lt $hostStartupTimeoutSec; $attempt++) {
             if ($hostProcess.HasExited) {
                 break
             }
@@ -227,7 +255,7 @@ try {
 
         if (-not $healthy) {
             Show-HostLogs
-            throw 'Local Meridian host failed to become healthy on http://localhost:8080.'
+            throw "Local Meridian host failed to become healthy on $hostBaseUrl."
         }
 
         Write-Ok 'Local Meridian host is healthy'

--- a/scripts/dev/validate-workflow-profile.ps1
+++ b/scripts/dev/validate-workflow-profile.ps1
@@ -1,0 +1,81 @@
+#!/usr/bin/env pwsh
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Profile,
+    [string]$ProfileRoot = 'scripts/dev/workflow-profiles',
+    [switch]$NoFixture,
+    [switch]$ReuseExistingApp,
+    [switch]$EmitJson
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
+. (Join-Path $PSScriptRoot 'SharedWorkflowProfiles.ps1')
+
+$profileEnvelope = Get-MeridianWorkflowProfile -RepoRoot $repoRoot -ProfileName $Profile -ProfileRoot $ProfileRoot
+$validation = Test-MeridianWorkflowProfile -ProfileData $profileEnvelope.data -NoFixture:$NoFixture -ReuseExistingApp:$ReuseExistingApp
+
+$build = Get-MeridianWorkflowProfileValue -Table $profileEnvelope.data -Key 'build' -Fallback @{}
+$projectPath = [string](Get-MeridianWorkflowProfileValue -Table $build -Key 'projectPath' -Fallback '')
+$resolvedProjectPath = if ([string]::IsNullOrWhiteSpace($projectPath)) {
+    ''
+}
+elseif ([System.IO.Path]::IsPathRooted($projectPath)) {
+    [System.IO.Path]::GetFullPath($projectPath)
+}
+else {
+    [System.IO.Path]::GetFullPath((Join-Path $repoRoot $projectPath))
+}
+
+if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+    $validation.errors += @("Required command 'dotnet' is not available in PATH.")
+}
+
+if (-not [string]::IsNullOrWhiteSpace($resolvedProjectPath) -and -not (Test-Path -LiteralPath $resolvedProjectPath)) {
+    $validation.errors += @("Configured build.projectPath does not exist: '$resolvedProjectPath'.")
+}
+
+$validation.isValid = $validation.errors.Count -eq 0
+$result = [ordered]@{
+    profile = $Profile
+    profilePath = $profileEnvelope.path
+    isValid = $validation.isValid
+    errors = $validation.errors
+    warnings = $validation.warnings
+    resolved = [ordered]@{
+        projectPath = $resolvedProjectPath
+        fixtureRequired = $validation.resolved.fixtureRequired
+        screenshotOutputRoot = $validation.resolved.outputRoot
+        retention = $validation.resolved.retention
+    }
+}
+
+if ($EmitJson) {
+    $result | ConvertTo-Json -Depth 10
+}
+else {
+    Write-Host "Profile: $($result.profile)"
+    Write-Host "Manifest: $($result.profilePath)"
+
+    if ($result.warnings.Count -gt 0) {
+        foreach ($warning in $result.warnings) {
+            Write-Warning $warning
+        }
+    }
+
+    if (-not $result.isValid) {
+        foreach ($error in $result.errors) {
+            Write-Error $error
+        }
+    }
+    else {
+        Write-Host 'Profile validation succeeded.' -ForegroundColor Green
+    }
+}
+
+if (-not $result.isValid) {
+    exit 1
+}

--- a/scripts/dev/workflow-profiles/debug-startup.json
+++ b/scripts/dev/workflow-profiles/debug-startup.json
@@ -1,0 +1,26 @@
+{
+  "build": {
+    "mode": "Release",
+    "projectPath": "src/Meridian.Wpf/Meridian.Wpf.csproj",
+    "configuration": "Release",
+    "framework": "net9.0-windows10.0.19041.0",
+    "exeName": "Meridian.Desktop.exe"
+  },
+  "fixture": {
+    "required": true
+  },
+  "host": {
+    "baseUrl": "http://localhost:8080",
+    "healthPath": "/healthz",
+    "startupTimeoutSec": 30,
+    "mode": "desktop",
+    "port": 8080
+  },
+  "screenshots": {
+    "outputRoot": "artifacts/desktop-workflows/debug-startup",
+    "retention": {
+      "maxAgeDays": 14,
+      "retainLatest": 10
+    }
+  }
+}

--- a/scripts/dev/workflow-profiles/manual-data-operations.json
+++ b/scripts/dev/workflow-profiles/manual-data-operations.json
@@ -1,0 +1,26 @@
+{
+  "build": {
+    "mode": "Release",
+    "projectPath": "src/Meridian.Wpf/Meridian.Wpf.csproj",
+    "configuration": "Release",
+    "framework": "net9.0-windows10.0.19041.0",
+    "exeName": "Meridian.Desktop.exe"
+  },
+  "fixture": {
+    "required": true
+  },
+  "host": {
+    "baseUrl": "http://localhost:8080",
+    "healthPath": "/healthz",
+    "startupTimeoutSec": 30,
+    "mode": "desktop",
+    "port": 8080
+  },
+  "screenshots": {
+    "outputRoot": "docs/screenshots/desktop/manuals/manual-data-operations",
+    "retention": {
+      "maxAgeDays": 14,
+      "retainLatest": 10
+    }
+  }
+}

--- a/scripts/dev/workflow-profiles/manual-governance.json
+++ b/scripts/dev/workflow-profiles/manual-governance.json
@@ -1,0 +1,26 @@
+{
+  "build": {
+    "mode": "Release",
+    "projectPath": "src/Meridian.Wpf/Meridian.Wpf.csproj",
+    "configuration": "Release",
+    "framework": "net9.0-windows10.0.19041.0",
+    "exeName": "Meridian.Desktop.exe"
+  },
+  "fixture": {
+    "required": true
+  },
+  "host": {
+    "baseUrl": "http://localhost:8080",
+    "healthPath": "/healthz",
+    "startupTimeoutSec": 30,
+    "mode": "desktop",
+    "port": 8080
+  },
+  "screenshots": {
+    "outputRoot": "docs/screenshots/desktop/manuals/manual-governance",
+    "retention": {
+      "maxAgeDays": 14,
+      "retainLatest": 10
+    }
+  }
+}

--- a/scripts/dev/workflow-profiles/manual-overview.json
+++ b/scripts/dev/workflow-profiles/manual-overview.json
@@ -1,0 +1,26 @@
+{
+  "build": {
+    "mode": "Release",
+    "projectPath": "src/Meridian.Wpf/Meridian.Wpf.csproj",
+    "configuration": "Release",
+    "framework": "net9.0-windows10.0.19041.0",
+    "exeName": "Meridian.Desktop.exe"
+  },
+  "fixture": {
+    "required": true
+  },
+  "host": {
+    "baseUrl": "http://localhost:8080",
+    "healthPath": "/healthz",
+    "startupTimeoutSec": 30,
+    "mode": "desktop",
+    "port": 8080
+  },
+  "screenshots": {
+    "outputRoot": "docs/screenshots/desktop/manuals/manual-overview",
+    "retention": {
+      "maxAgeDays": 14,
+      "retainLatest": 10
+    }
+  }
+}

--- a/scripts/dev/workflow-profiles/manual-research-and-trading.json
+++ b/scripts/dev/workflow-profiles/manual-research-and-trading.json
@@ -1,0 +1,26 @@
+{
+  "build": {
+    "mode": "Release",
+    "projectPath": "src/Meridian.Wpf/Meridian.Wpf.csproj",
+    "configuration": "Release",
+    "framework": "net9.0-windows10.0.19041.0",
+    "exeName": "Meridian.Desktop.exe"
+  },
+  "fixture": {
+    "required": true
+  },
+  "host": {
+    "baseUrl": "http://localhost:8080",
+    "healthPath": "/healthz",
+    "startupTimeoutSec": 30,
+    "mode": "desktop",
+    "port": 8080
+  },
+  "screenshots": {
+    "outputRoot": "docs/screenshots/desktop/manuals/manual-research-and-trading",
+    "retention": {
+      "maxAgeDays": 14,
+      "retainLatest": 10
+    }
+  }
+}

--- a/scripts/dev/workflow-profiles/screenshot-catalog.json
+++ b/scripts/dev/workflow-profiles/screenshot-catalog.json
@@ -1,0 +1,26 @@
+{
+  "build": {
+    "mode": "Release",
+    "projectPath": "src/Meridian.Wpf/Meridian.Wpf.csproj",
+    "configuration": "Release",
+    "framework": "net9.0-windows10.0.19041.0",
+    "exeName": "Meridian.Desktop.exe"
+  },
+  "fixture": {
+    "required": true
+  },
+  "host": {
+    "baseUrl": "http://localhost:8080",
+    "healthPath": "/healthz",
+    "startupTimeoutSec": 30,
+    "mode": "desktop",
+    "port": 8080
+  },
+  "screenshots": {
+    "outputRoot": "docs/screenshots/desktop",
+    "retention": {
+      "maxAgeDays": 14,
+      "retainLatest": 10
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

- Centralize desktop automation defaults (build, fixture, host health probe, screenshot paths/retention) into reusable manifests so local runs and CI use the same configuration.
- Make screenshot and desktop-launch workflows reproducible by name and reduce duplication across scripts and CI definitions.
- Surface configuration problems early with a manifest validator that checks required tools, paths, and conflicting options before execution.

### Description

- Add declarative workflow profile manifests under `scripts/dev/workflow-profiles/*.json` that declare build settings, fixture requirements, host URL/health probe settings, screenshot output roots, and retention policy.
- Add `scripts/dev/SharedWorkflowProfiles.ps1` with helpers to load, resolve, and validate profile manifests, and add `scripts/dev/validate-workflow-profile.ps1` as a standalone profile validator command.
- Update `scripts/dev/run-desktop.ps1`, `scripts/dev/capture-desktop-screenshots.ps1`, and `scripts/dev/run-desktop-workflow.ps1` to accept `-Profile` (and `-ProfileRoot`) and resolve defaults from the chosen manifest; apply fixture requirements and retention defaults from the profile and record profile metadata in run manifests/checkpoints.
- Update CI (`.github/workflows/refresh-screenshots.yml`) to pass matching profile names into the workflow runner and include the new profile and validator files in the workflow trigger paths so CI and local runs stay aligned.

### Testing

- Successfully parsed all profile JSON manifests with `python3` using a small JSON-load check (`python3 - <<'PY' import json,glob ...`), which completed without error.
- Attempted to run the PowerShell profile validator (`pwsh -NoProfile -File scripts/dev/validate-workflow-profile.ps1 -Profile screenshot-catalog`) but the runner environment lacked `pwsh` so the validator could not be executed here (the validator itself is included and will run on Windows/CI runners with PowerShell available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1171e11808320ade6699f8cd52155)