### PR TITLE
Fix desktop workflow preflight argument binding

### DIFF
--- a/scripts/dev/run-desktop-workflow.ps1
+++ b/scripts/dev/run-desktop-workflow.ps1
@@ -737,14 +737,16 @@ function Test-StageOutputsValid {
 
 $catalogPath = Resolve-RepoPath $DefinitionPath
 $initialOutputRoot = if ($PSBoundParameters.ContainsKey('OutputRoot')) { Resolve-RepoPath $OutputRoot } else { Resolve-RepoPath 'artifacts/desktop-workflows' }
-$catalogPreflight = Invoke-MeridianPreflight `
-    -Scenario 'desktop-workflow-catalog' `
-    -RequiredCommands @('dotnet') `
-    -RequiredPaths @($catalogPath) `
-    -WritableDirectories @($initialOutputRoot) `
-    -RequireWindows `
-    -EmitJson `
-    -AllowWarnings
+$catalogPreflightArgs = @{
+    Scenario = 'desktop-workflow-catalog'
+    RequiredCommands = [string[]]@('dotnet')
+    RequiredPaths = [string[]]@($catalogPath)
+    WritableDirectories = [string[]]@($initialOutputRoot)
+    RequireWindows = $true
+    EmitJson = $true
+    AllowWarnings = $true
+}
+$catalogPreflight = Invoke-MeridianPreflight @catalogPreflightArgs
 
 if ($catalogPreflight.status -eq 'blocked') {
     throw "Preflight failed before workflow load. $(($catalogPreflight.blockingChecks | ConvertTo-Json -Depth 6 -Compress))"
@@ -914,15 +916,17 @@ try {
         }
 
         try {
-            $preflight = Invoke-MeridianPreflight `
-                -Scenario 'desktop-workflow' `
-                -RequiredCommands @('dotnet') `
-                -RequiredPaths @($catalogPath, $resolvedProjectPath) `
-                -WritableDirectories @($resolvedOutputRoot, $screenshotDirectory, $runDirectory, $logDirectory) `
-                -RequireWindows `
-                -FeatureFlagExpectations $(if (-not $useFixture) { @{ 'MDC_FIXTURE_MODE' = '0' } } else { @{} }) `
-                -EmitJson `
-                -AllowWarnings
+            $preflightArgs = @{
+                Scenario = 'desktop-workflow'
+                RequiredCommands = [string[]]@('dotnet')
+                RequiredPaths = [string[]]@($catalogPath, $resolvedProjectPath)
+                WritableDirectories = [string[]]@($resolvedOutputRoot, $screenshotDirectory, $runDirectory, $logDirectory)
+                RequireWindows = $true
+                FeatureFlagExpectations = $(if (-not $useFixture) { @{ 'MDC_FIXTURE_MODE' = '0' } } else { @{} })
+                EmitJson = $true
+                AllowWarnings = $true
+            }
+            $preflight = Invoke-MeridianPreflight @preflightArgs
             $preflightPath = Join-Path $runDirectory 'preflight.json'
             $preflight | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $preflightPath -Encoding utf8
             if ($preflight.status -eq 'blocked') {


### PR DESCRIPTION
### Motivation

- The desktop CI workflow failed early with `Argument types do not match` when calling `Invoke-MeridianPreflight`, indicating ambiguous PowerShell argument binding at the call sites.
- Make the preflight payload types explicit to avoid runtime binding errors and to keep the call semantics stable across environments.

### Description

- Rewrote the catalog preflight invocation in `scripts/dev/run-desktop-workflow.ps1` to use an explicit splatted hashtable (`@catalogPreflightArgs`) with typed arrays (`[string[]]`) and explicit booleans for switch-style flags. 
- Applied the same splatted-argument pattern to the runtime preflight invocation used in the `preflight` stage (`$preflightArgs`) with typed arrays for `RequiredCommands`, `RequiredPaths`, and `WritableDirectories` and explicit boolean values for `RequireWindows`, `EmitJson`, and `AllowWarnings`.
- Change is scoped to argument construction/invocation only and does not modify the core preflight logic or workflow behavior.

### Testing

- No unit or integration test suite was executed as part of this change in this environment. 
- Attempted to run the runtime workflow script (`pwsh -File scripts/dev/run-desktop-workflow.ps1 ...`) to validate behavior, but execution could not proceed because `pwsh` is not available in this container (`pwsh: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11f85a65083208d1e10592430cc6a)