### PR TITLE
Fix screenshot workflow preflight argument typing and managed scope cleanup

### DIFF
--- a/.github/workflows/refresh-screenshots.yml
+++ b/.github/workflows/refresh-screenshots.yml
@@ -404,16 +404,13 @@ jobs:
           }
 
           $candidates = New-Object System.Collections.Generic.List[string]
-          $manualsRoot = [System.IO.Path]::GetFullPath((Join-Path $outputRoot 'manuals'))
-          $manualsRootPrefix = $manualsRoot.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
-          foreach ($managedDir in $managedDirectories) {
+          foreach ($managedScope in $managedScopes) {
+            $managedDir = [string]$managedScope.Path
             if (-not (Test-Path -LiteralPath $managedDir)) {
               continue
             }
 
-            $normalizedManagedDir = [System.IO.Path]::GetFullPath($managedDir)
-            $scanRecursively = $normalizedManagedDir.Equals($manualsRoot, [System.StringComparison]::OrdinalIgnoreCase) -or
-              $normalizedManagedDir.StartsWith($manualsRootPrefix, [System.StringComparison]::OrdinalIgnoreCase)
+            $scanRecursively = [bool]$managedScope.Recurse
 
             if ($scanRecursively) {
               $pngs = Get-ChildItem -LiteralPath $managedDir -Recurse -File -Filter '*.png' -ErrorAction SilentlyContinue
@@ -421,6 +418,7 @@ jobs:
             else {
               $pngs = Get-ChildItem -LiteralPath $managedDir -File -Filter '*.png' -ErrorAction SilentlyContinue
             }
+
             foreach ($png in $pngs) {
               $fullPath = [System.IO.Path]::GetFullPath($png.FullName)
               if (-not $expectedFiles.Contains($fullPath)) {

--- a/scripts/dev/run-desktop-workflow.ps1
+++ b/scripts/dev/run-desktop-workflow.ps1
@@ -737,16 +737,14 @@ function Test-StageOutputsValid {
 
 $catalogPath = Resolve-RepoPath $DefinitionPath
 $initialOutputRoot = if ($PSBoundParameters.ContainsKey('OutputRoot')) { Resolve-RepoPath $OutputRoot } else { Resolve-RepoPath 'artifacts/desktop-workflows' }
-$catalogPreflightArgs = @{
-    Scenario = 'desktop-workflow-catalog'
-    RequiredCommands = [string[]]@('dotnet')
-    RequiredPaths = [string[]]@($catalogPath)
-    WritableDirectories = [string[]]@($initialOutputRoot)
-    RequireWindows = $true
-    EmitJson = $true
-    AllowWarnings = $true
-}
-$catalogPreflight = Invoke-MeridianPreflight @catalogPreflightArgs
+$catalogPreflight = Invoke-MeridianPreflight `
+    -Scenario 'desktop-workflow-catalog' `
+    -RequiredCommands ([string[]]@('dotnet')) `
+    -RequiredPaths ([string[]]@([string]$catalogPath)) `
+    -WritableDirectories ([string[]]@([string]$initialOutputRoot)) `
+    -RequireWindows:$true `
+    -EmitJson:$true `
+    -AllowWarnings:$true
 
 if ($catalogPreflight.status -eq 'blocked') {
     throw "Preflight failed before workflow load. $(($catalogPreflight.blockingChecks | ConvertTo-Json -Depth 6 -Compress))"


### PR DESCRIPTION
### Motivation

- Preflight invocation used a hashtable splat that could contain values with incorrect types, causing `Invoke-MeridianPreflight @catalogPreflightArgs` to fail with an "Argument types do not match" error during screenshot workflow startup. 
- The cleanup stage iterated an undefined collection (`$managedDirectories`) instead of the actually-built `$managedScopes`, which would break stale-file scanning after the preflight issue is resolved.

### Description

- Replaced the hashtable splat for the catalog preflight in `scripts/dev/run-desktop-workflow.ps1` with an explicit, typed `Invoke-MeridianPreflight` call that casts arrays and booleans to the expected parameter types. 
- Updated `.github/workflows/refresh-screenshots.yml` to iterate `managedScopes` and derive each scope's `Path` and `Recurse` values directly, removing reliance on the non-existent `$managedDirectories`. 
- Removed the manual recursion inference logic that depended on the removed variable and simplified the PNG collection logic to use the scope `Recurse` flag explicitly.

### Testing

- Inspected the file diffs for `scripts/dev/run-desktop-workflow.ps1` and `.github/workflows/refresh-screenshots.yml` to verify the intended changes. 
- Attempted a PowerShell parse check using `pwsh` to validate the modified scripts, but the check could not be run because `pwsh` is not available in the current environment. 
- No further automated workflow or runtime tests were executed in this environment due to lack of PowerShell runtime support.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1287a94f483208f63da2eb9509e90)