### PR TITLE
Add five docs dashboard generators and wire into automation profiles

### DIFF
--- a/build/scripts/docs/README.md
+++ b/build/scripts/docs/README.md
@@ -397,3 +397,41 @@ If you encounter issues with these scripts:
 ---
 
 *This directory is part of the Meridian documentation automation system.*
+
+### Readiness and Coverage Dashboards
+
+The following generators emit both Markdown and JSON artifacts and support `--summary` for one-line CLI diagnostics.
+
+```bash
+python3 generate-pilot-readiness-dashboard.py \
+  --output docs/status/pilot-readiness-dashboard.md \
+  --json-output docs/status/pilot-readiness-dashboard.json \
+  --summary
+
+python3 generate-paper-replay-reliability-dashboard.py \
+  --output docs/status/paper-replay-reliability-dashboard.md \
+  --json-output docs/status/paper-replay-reliability-dashboard.json \
+  --summary
+
+python3 generate-evidence-continuity-dashboard.py \
+  --output docs/status/evidence-continuity-dashboard.md \
+  --json-output docs/status/evidence-continuity-dashboard.json \
+  --summary
+
+python3 generate-governance-readiness-dashboard.py \
+  --output docs/status/governance-readiness-dashboard.md \
+  --json-output docs/status/governance-readiness-dashboard.json \
+  --summary
+
+python3 generate-api-contract-coverage-dashboard.py \
+  --output docs/status/api-contract-coverage-dashboard.md \
+  --json-output docs/status/api-contract-coverage-dashboard.json \
+  --summary
+```
+
+**Expected outputs:**
+- `docs/status/pilot-readiness-dashboard.md` + `.json`
+- `docs/status/paper-replay-reliability-dashboard.md` + `.json`
+- `docs/status/evidence-continuity-dashboard.md` + `.json`
+- `docs/status/governance-readiness-dashboard.md` + `.json`
+- `docs/status/api-contract-coverage-dashboard.md` + `.json`

--- a/build/scripts/docs/generate-api-contract-coverage-dashboard.py
+++ b/build/scripts/docs/generate-api-contract-coverage-dashboard.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Generate API contract coverage dashboard artifacts."""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Generate API contract coverage dashboard.")
+    p.add_argument("--output", required=True)
+    p.add_argument("--json-output", required=True)
+    p.add_argument("--summary", action="store_true")
+    p.add_argument("--root", default=".")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.root).resolve()
+    artifacts = [
+        "docs/status/api-docs-report.md",
+        "docs/status/contract-compatibility-matrix.md",
+    ]
+    checks = [{"artifact": a, "covered": (root / a).exists()} for a in artifacts]
+    coverage = round((sum(1 for c in checks if c['covered']) / len(checks)) * 100, 1)
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "dashboard": "api-contract-coverage",
+        "coverage_percent": coverage,
+        "checks": checks,
+    }
+    lines = ["# API Contract Coverage Dashboard", "", f"- Coverage: **{coverage}%**", "", "| Artifact | Covered |", "|---|---|"]
+    lines.extend(f"| `{c['artifact']}` | {'yes' if c['covered'] else 'no'} |" for c in checks)
+    lines.append("")
+    Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.output).write_text("\n".join(lines), encoding="utf-8")
+    Path(args.json_output).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.json_output).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    if args.summary:
+        print(f"api-contract-coverage: {coverage}%")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/scripts/docs/generate-evidence-continuity-dashboard.py
+++ b/build/scripts/docs/generate-evidence-continuity-dashboard.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Generate evidence continuity dashboard artifacts."""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Generate evidence continuity dashboard.")
+    p.add_argument("--output", required=True)
+    p.add_argument("--json-output", required=True)
+    p.add_argument("--summary", action="store_true")
+    p.add_argument("--root", default=".")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.root).resolve()
+    artifacts = [
+        "docs/status/contract-compatibility-matrix.md",
+        "docs/status/kernel-readiness-dashboard.md",
+        "docs/status/dk1-pilot-parity-runbook.md",
+    ]
+    checks = [{"artifact": a, "exists": (root / a).exists()} for a in artifacts]
+    continuity = round((sum(1 for c in checks if c['exists']) / len(checks)) * 100, 1)
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "dashboard": "evidence-continuity",
+        "continuity_percent": continuity,
+        "artifacts": checks,
+    }
+    lines = ["# Evidence Continuity Dashboard", "", f"- Continuity: **{continuity}%**", "", "## Artifacts", "", "| Artifact | Exists |", "|---|---|"]
+    lines.extend(f"| `{c['artifact']}` | {'yes' if c['exists'] else 'no'} |" for c in checks)
+    lines.append("")
+    Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.output).write_text("\n".join(lines), encoding="utf-8")
+    Path(args.json_output).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.json_output).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    if args.summary:
+        print(f"evidence-continuity: {continuity}%")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/scripts/docs/generate-governance-readiness-dashboard.py
+++ b/build/scripts/docs/generate-governance-readiness-dashboard.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Generate governance readiness dashboard artifacts."""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Generate governance readiness dashboard.")
+    p.add_argument("--output", required=True)
+    p.add_argument("--json-output", required=True)
+    p.add_argument("--summary", action="store_true")
+    p.add_argument("--root", default=".")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.root).resolve()
+    policies = [
+        "docs/status/contract-compatibility-matrix.md",
+        "docs/status/provider-validation-matrix.md",
+    ]
+    checks = [{"item": p, "status": "ready" if (root / p).exists() else "gap"} for p in policies]
+    ready = sum(1 for c in checks if c["status"] == "ready")
+    score = round((ready / len(checks)) * 100, 1)
+    payload = {"generated_at": datetime.now(timezone.utc).isoformat(), "dashboard": "governance-readiness", "score": score, "checks": checks}
+    md = ["# Governance Readiness Dashboard", "", f"- Governance score: **{score}%**", "", "| Control | Status |", "|---|---|", *[f"| `{c['item']}` | {c['status']} |" for c in checks], ""]
+    Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.output).write_text("\n".join(md), encoding="utf-8")
+    Path(args.json_output).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.json_output).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    if args.summary:
+        print(f"governance-readiness: {score}%")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/scripts/docs/generate-paper-replay-reliability-dashboard.py
+++ b/build/scripts/docs/generate-paper-replay-reliability-dashboard.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Generate paper replay reliability dashboard artifacts."""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate paper replay reliability dashboard.")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--json-output", required=True)
+    parser.add_argument("--summary", action="store_true")
+    parser.add_argument("--root", default=".")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.root).resolve()
+    signals = [
+        "docs/plans/paper-trading-cockpit-reliability-sprint.md",
+        "docs/status/FEATURE_INVENTORY.md",
+    ]
+    checks = [{"artifact": rel, "status": "present" if (root / rel).exists() else "missing"} for rel in signals]
+    present = sum(1 for c in checks if c["status"] == "present")
+    total = len(checks)
+    reliability = round((present / total) * 100, 1) if total else 0.0
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "dashboard": "paper-replay-reliability",
+        "reliability_percent": reliability,
+        "signals": checks,
+    }
+    md = [
+        "# Paper Replay Reliability Dashboard",
+        "",
+        f"- Generated: {payload['generated_at']}",
+        f"- Reliability posture: **{reliability}%** ({present}/{total} signals present)",
+        "",
+        "## Evidence Signals",
+        "",
+        "| Signal | Status |",
+        "|---|---|",
+        *[f"| `{c['artifact']}` | {c['status']} |" for c in checks],
+        "",
+    ]
+    Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.output).write_text("\n".join(md), encoding="utf-8")
+    Path(args.json_output).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.json_output).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    if args.summary:
+        print(f"paper-replay-reliability: {reliability}%")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/scripts/docs/generate-pilot-readiness-dashboard.py
+++ b/build/scripts/docs/generate-pilot-readiness-dashboard.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Generate a pilot-readiness dashboard in Markdown and JSON."""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate pilot readiness dashboard.")
+    parser.add_argument("--output", required=True, help="Markdown output path.")
+    parser.add_argument("--json-output", required=True, help="JSON output path.")
+    parser.add_argument("--summary", action="store_true", help="Print summary to stdout.")
+    parser.add_argument("--root", default=".", help="Repository root.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.root).resolve()
+
+    required_docs = [
+        "docs/status/provider-validation-matrix.md",
+        "docs/status/dk1-pilot-parity-runbook.md",
+        "docs/status/kernel-readiness-dashboard.md",
+    ]
+
+    checks: list[dict[str, str]] = []
+    for rel in required_docs:
+        path = root / rel
+        checks.append({"artifact": rel, "status": "present" if path.exists() else "missing"})
+
+    present = sum(1 for c in checks if c["status"] == "present")
+    total = len(checks)
+    score = round((present / total) * 100, 1) if total else 0.0
+
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "dashboard": "pilot-readiness",
+        "score": score,
+        "checks": checks,
+    }
+
+    md_lines = [
+        "# Pilot Readiness Dashboard",
+        "",
+        f"- Generated: {payload['generated_at']}",
+        f"- Readiness score: **{score}%** ({present}/{total} artifacts present)",
+        "",
+        "## Artifact Checks",
+        "",
+        "| Artifact | Status |",
+        "|---|---|",
+    ]
+    md_lines.extend(f"| `{c['artifact']}` | {c['status']} |" for c in checks)
+    md_lines.append("")
+
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text("\n".join(md_lines), encoding="utf-8")
+
+    jout = Path(args.json_output)
+    jout.parent.mkdir(parents=True, exist_ok=True)
+    jout.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    if args.summary:
+        print(f"pilot-readiness: score={score}% artifacts={present}/{total}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/scripts/docs/run-docs-automation.py
+++ b/build/scripts/docs/run-docs-automation.py
@@ -111,6 +111,31 @@ SCRIPT_CONFIG: Dict[str, Dict[str, Sequence[str] | str]] = {
         "args": ["--output", "docs/status/metrics-dashboard.md"],
         "output": "docs/status/metrics-dashboard.md",
     },
+    "generate-api-contract-coverage-dashboard": {
+        "script": "generate-api-contract-coverage-dashboard.py",
+        "args": ["--output", "docs/status/api-contract-coverage-dashboard.md", "--json-output", "docs/status/api-contract-coverage-dashboard.json"],
+        "output": "docs/status/api-contract-coverage-dashboard.md",
+    },
+    "generate-pilot-readiness-dashboard": {
+        "script": "generate-pilot-readiness-dashboard.py",
+        "args": ["--output", "docs/status/pilot-readiness-dashboard.md", "--json-output", "docs/status/pilot-readiness-dashboard.json"],
+        "output": "docs/status/pilot-readiness-dashboard.md",
+    },
+    "generate-paper-replay-reliability-dashboard": {
+        "script": "generate-paper-replay-reliability-dashboard.py",
+        "args": ["--output", "docs/status/paper-replay-reliability-dashboard.md", "--json-output", "docs/status/paper-replay-reliability-dashboard.json"],
+        "output": "docs/status/paper-replay-reliability-dashboard.md",
+    },
+    "generate-evidence-continuity-dashboard": {
+        "script": "generate-evidence-continuity-dashboard.py",
+        "args": ["--output", "docs/status/evidence-continuity-dashboard.md", "--json-output", "docs/status/evidence-continuity-dashboard.json"],
+        "output": "docs/status/evidence-continuity-dashboard.md",
+    },
+    "generate-governance-readiness-dashboard": {
+        "script": "generate-governance-readiness-dashboard.py",
+        "args": ["--output", "docs/status/governance-readiness-dashboard.md", "--json-output", "docs/status/governance-readiness-dashboard.json"],
+        "output": "docs/status/governance-readiness-dashboard.md",
+    },
     "generate-workflow-manifest": {
         "script": "generate-workflow-manifest.py",
         "args": [],
@@ -132,6 +157,11 @@ PROFILE_CONFIG: Dict[str, List[str]] = {
         "validate-examples",
         "check-ai-inventory",
         "generate-coverage",
+        "generate-pilot-readiness-dashboard",
+        "generate-paper-replay-reliability-dashboard",
+        "generate-evidence-continuity-dashboard",
+        "generate-governance-readiness-dashboard",
+        "generate-api-contract-coverage-dashboard",
         "generate-workflow-manifest",
     ],
     "full": [
@@ -148,6 +178,11 @@ PROFILE_CONFIG: Dict[str, List[str]] = {
         "generate-dependency-graph",
         "sync-readme-badges",
         "generate-metrics-dashboard",
+        "generate-pilot-readiness-dashboard",
+        "generate-paper-replay-reliability-dashboard",
+        "generate-evidence-continuity-dashboard",
+        "generate-governance-readiness-dashboard",
+        "generate-api-contract-coverage-dashboard",
         "generate-workflow-manifest",
     ],
 }


### PR DESCRIPTION
### Motivation

- Provide automated readiness, reliability, continuity, governance, and API-contract coverage signals for documentation pipelines. 
- Make these signals consumable by CI and operator workflows via both Markdown and machine-readable JSON outputs.

### Description

- Added five new generator scripts under `build/scripts/docs/`: `generate-pilot-readiness-dashboard.py`, `generate-paper-replay-reliability-dashboard.py`, `generate-evidence-continuity-dashboard.py`, `generate-governance-readiness-dashboard.py`, and `generate-api-contract-coverage-dashboard.py`, each accepting `--output`, `--json-output`, `--summary`, and `--root` arguments and emitting deterministic Markdown + JSON artifacts. 
- Each script performs lightweight repository-artifact presence/coverage checks and emits a timestamped payload suitable for automation pipelines. 
- Updated `SCRIPT_CONFIG` in `build/scripts/docs/run-docs-automation.py` to add one entry per new script with default `docs/status/` Markdown and JSON output paths. 
- Added the new script names to `PROFILE_CONFIG` so both the `core` and `full` automation profiles include these generators, and updated `build/scripts/docs/README.md` with usage examples and expected outputs.

### Testing

- Executed `python3 build/scripts/docs/generate-pilot-readiness-dashboard.py --output /tmp/pilot.md --json-output /tmp/pilot.json --summary` and observed a successful one-line summary output (success). 
- Ran `python3 build/scripts/docs/run-docs-automation.py --profile core --dry-run` to validate script selection and command wiring and observed the expected dry-run command list (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12a6ba5a08320a4dc1884251703b8)