### PR TITLE
Make dashboard Markdown render from canonical JSON payloads

### DIFF
--- a/build/scripts/docs/dashboard_rendering.py
+++ b/build/scripts/docs/dashboard_rendering.py
@@ -1,0 +1,51 @@
+"""Shared helpers for dashboard generators.
+
+JSON is the canonical source of truth. Dashboards should generate JSON first,
+then render Markdown from that JSON payload to avoid drift between formats.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def current_utc_timestamp() -> str:
+    """Return an ISO-8601 UTC timestamp string."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def write_canonical_json(payload: dict[str, Any], json_output: Path) -> dict[str, Any]:
+    """Write canonical JSON payload and return the same payload."""
+    json_output.parent.mkdir(parents=True, exist_ok=True)
+    json_output.write_text(json.dumps(payload, indent=2, default=str) + "\n", encoding="utf-8")
+    return payload
+
+
+def load_canonical_json(json_output: Path) -> dict[str, Any]:
+    """Load canonical JSON payload from disk."""
+    return json.loads(json_output.read_text(encoding="utf-8"))
+
+
+def render_markdown_from_json(
+    *,
+    json_payload: dict[str, Any],
+    render_body: callable,
+    data_sources: list[str],
+) -> str:
+    """Render deterministic markdown using canonical JSON payload.
+
+    ``render_body`` should accept the parsed JSON payload and return markdown body
+    content for the specific dashboard.
+    """
+    lines = [
+        "> Auto-generated from canonical JSON payload.",
+        f"> Generated: {json_payload.get('generated_at', current_utc_timestamp())}",
+        f"> Data sources: {', '.join(data_sources)}",
+        "",
+    ]
+    lines.append(render_body(json_payload).rstrip())
+    lines.append("")
+    return "\n".join(lines)

--- a/build/scripts/docs/generate-health-dashboard.py
+++ b/build/scripts/docs/generate-health-dashboard.py
@@ -36,6 +36,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional, Sequence
 
+from dashboard_rendering import (
+    current_utc_timestamp,
+    load_canonical_json,
+    render_markdown_from_json,
+    write_canonical_json,
+)
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -367,7 +374,7 @@ def analyse(root: Path) -> HealthMetrics:
         no_heading_files=no_heading_files,
         stale_files=stale_files,
         all_files=file_infos,
-        scan_time=now.isoformat(),
+        scan_time=current_utc_timestamp(),
         root_dir=str(root),
     )
     metrics.health_score = compute_health_score(metrics)
@@ -399,8 +406,11 @@ def _score_label(score: int) -> str:
     return "Critical"
 
 
-def generate_markdown(metrics: HealthMetrics) -> str:  # noqa: C901
-    """Generate a Markdown health dashboard report."""
+def _render_markdown_body_from_payload(payload: dict) -> str:  # noqa: C901
+    metrics = HealthMetrics(
+        **{k: v for k, v in payload.items() if k in {"total_files","total_lines","orphaned_count","no_heading_count","stale_count","todo_count","average_lines","health_score","orphaned_files","no_heading_files","stale_files","scan_time","root_dir"}},
+        all_files=[FileInfo(**item) for item in payload.get("all_files", [])],
+    )
     lines: list[str] = []
 
     lines.append("# Documentation Health Dashboard")
@@ -526,6 +536,14 @@ def generate_markdown(metrics: HealthMetrics) -> str:  # noqa: C901
     return "\n".join(lines)
 
 
+def generate_markdown_from_json_payload(payload: dict) -> str:
+    return render_markdown_from_json(
+        json_payload=payload,
+        render_body=_render_markdown_body_from_payload,
+        data_sources=["repo markdown (*.md)", "git commit metadata"],
+    )
+
+
 def generate_summary(metrics: HealthMetrics) -> str:
     """Return a compact single-paragraph summary for ``GITHUB_STEP_SUMMARY``."""
     return (
@@ -607,27 +625,32 @@ def main(argv: Optional[Sequence[str]] = None) -> int:  # noqa: C901
         print(f"Error during analysis: {exc}", file=sys.stderr)
         return 1
 
-    # Write Markdown report.
-    if args.output is not None:
-        try:
-            args.output.parent.mkdir(parents=True, exist_ok=True)
-            args.output.write_text(generate_markdown(metrics), encoding="utf-8")
-            print(f"Markdown report written to {args.output}")
-        except OSError as exc:
-            print(f"Error writing Markdown report: {exc}", file=sys.stderr)
-            return 1
+    if args.output is not None and args.json_output is None:
+        print("Error: --output requires --json-output so markdown is rendered from canonical JSON.", file=sys.stderr)
+        return 1
 
-    # Write JSON output.
+    if not any(root.rglob("*.md")):
+        print("Error: missing required markdown evidence input (*.md files).", file=sys.stderr)
+        return 1
+
+    payload = metrics.to_dict()
+
     if args.json_output is not None:
         try:
-            args.json_output.parent.mkdir(parents=True, exist_ok=True)
-            args.json_output.write_text(
-                json.dumps(metrics.to_dict(), indent=2, default=str),
-                encoding="utf-8",
-            )
+            write_canonical_json(payload, args.json_output)
             print(f"JSON metrics written to {args.json_output}")
         except OSError as exc:
             print(f"Error writing JSON output: {exc}", file=sys.stderr)
+            return 1
+
+    if args.output is not None:
+        try:
+            canonical = load_canonical_json(args.json_output)
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(generate_markdown_from_json_payload(canonical), encoding="utf-8")
+            print(f"Markdown report written to {args.output}")
+        except OSError as exc:
+            print(f"Error writing Markdown report: {exc}", file=sys.stderr)
             return 1
 
     # Print summary.

--- a/build/scripts/docs/generate-metrics-dashboard.py
+++ b/build/scripts/docs/generate-metrics-dashboard.py
@@ -29,6 +29,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from dashboard_rendering import (
+    current_utc_timestamp,
+    load_canonical_json,
+    render_markdown_from_json,
+    write_canonical_json,
+)
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -238,8 +245,14 @@ def _status_badge(rate: float) -> str:
         return "🔴 Poor"
 
 
-def generate_markdown(dashboard: MetricsDashboard) -> str:
-    """Generate Markdown metrics dashboard."""
+def _render_markdown_body_from_payload(payload: dict) -> str:
+    dashboard = MetricsDashboard(
+        workflows={name: WorkflowMetrics(**metrics) for name, metrics in payload.get("workflows", {}).items()},
+        tests=TestMetrics(**payload.get("tests", {})),
+        builds=BuildMetrics(**payload.get("builds", {})),
+        generated_at=payload.get("generated_at", ""),
+        lookback_days=payload.get("lookback_days", DEFAULT_LOOKBACK_DAYS),
+    )
     lines = []
 
     lines.append("# Build Metrics Dashboard")
@@ -356,6 +369,14 @@ def generate_markdown(dashboard: MetricsDashboard) -> str:
     return "\n".join(lines)
 
 
+def generate_markdown_from_json_payload(payload: dict) -> str:
+    return render_markdown_from_json(
+        json_payload=payload,
+        render_body=_render_markdown_body_from_payload,
+        data_sources=[".github/workflows/*.yml", "TestResults/*.trx", "build logs"],
+    )
+
+
 def generate_summary(dashboard: MetricsDashboard) -> str:
     """Generate concise summary for GITHUB_STEP_SUMMARY."""
     total_runs = sum(w.total_runs for w in dashboard.workflows.values())
@@ -380,7 +401,7 @@ def generate_summary(dashboard: MetricsDashboard) -> str:
 def build_dashboard(root: Path, lookback_days: int) -> MetricsDashboard:
     """Build metrics dashboard from repository data."""
     dashboard = MetricsDashboard(
-        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC"),
+        generated_at=current_utc_timestamp(),
         lookback_days=lookback_days,
     )
 
@@ -438,21 +459,29 @@ def main(argv: Optional[list[str]] = None) -> int:
         print(f"Error building dashboard: {exc}", file=sys.stderr)
         return 1
 
-    # Write Markdown
+    if args.output and not args.json_output:
+        print("Error: --output requires --json-output so markdown is rendered from canonical JSON.", file=sys.stderr)
+        return 1
+
+    if not (root / '.github' / 'workflows').exists():
+        print("Error: missing required workflow evidence directory .github/workflows", file=sys.stderr)
+        return 1
+    if not (root / 'TestResults').exists():
+        print("Error: missing required test evidence directory TestResults", file=sys.stderr)
+        return 1
+
+    payload = dashboard.to_dict()
+
+    if args.json_output:
+        write_canonical_json(payload, args.json_output)
+        print(f"JSON metrics written to {args.json_output}")
+
     if args.output:
-        md = generate_markdown(dashboard)
+        canonical = load_canonical_json(args.json_output)
+        md = generate_markdown_from_json_payload(canonical)
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(md, encoding='utf-8')
         print(f"Metrics dashboard written to {args.output}")
-
-    # Write JSON
-    if args.json_output:
-        args.json_output.parent.mkdir(parents=True, exist_ok=True)
-        args.json_output.write_text(
-            json.dumps(dashboard.to_dict(), indent=2, default=str),
-            encoding='utf-8'
-        )
-        print(f"JSON metrics written to {args.json_output}")
 
     # Print summary
     if args.summary:

--- a/build/scripts/docs/run-docs-automation.py
+++ b/build/scripts/docs/run-docs-automation.py
@@ -53,7 +53,7 @@ SCRIPT_CONFIG: Dict[str, Dict[str, Sequence[str] | str]] = {
     },
     "generate-health-dashboard": {
         "script": "generate-health-dashboard.py",
-        "args": ["--output", "docs/status/health-dashboard.md"],
+        "args": ["--output", "docs/status/health-dashboard.md", "--json-output", "docs/status/health-dashboard.json"],
         "output": "docs/status/health-dashboard.md",
     },
     "repair-links": {
@@ -108,7 +108,7 @@ SCRIPT_CONFIG: Dict[str, Dict[str, Sequence[str] | str]] = {
     },
     "generate-metrics-dashboard": {
         "script": "generate-metrics-dashboard.py",
-        "args": ["--output", "docs/status/metrics-dashboard.md"],
+        "args": ["--output", "docs/status/metrics-dashboard.md", "--json-output", "docs/status/metrics-dashboard.json"],
         "output": "docs/status/metrics-dashboard.md",
     },
     "generate-workflow-manifest": {

--- a/docs/development/documentation-automation.md
+++ b/docs/development/documentation-automation.md
@@ -337,6 +337,16 @@ When `--auto-create-todos` is enabled:
 3. If scan-todos fails, issue creation is skipped with a clear error message
 4. On success, it calls `create-todo-issues.py` with `--output-json docs/status/todo-issue-creation-summary.json`
 
+
+### Dashboard JSON Source-of-Truth
+
+The dashboard generators (`generate-health-dashboard.py` and `generate-metrics-dashboard.py`) use **JSON as the canonical stage**:
+
+1. The script computes metrics and writes canonical JSON (`--json-output`).
+2. Markdown rendering (`--output`) loads that JSON payload and renders deterministically from it.
+3. Automation should always pass both flags for dashboards, so Markdown cannot drift from the machine-readable payload.
+4. Required evidence inputs are validated; missing evidence causes a non-zero exit to surface automation drift early.
+
 ## Custom Rules
 
 Documentation rules are defined in `build/rules/doc-rules.yaml`. See [Adding Custom Rules](adding-custom-rules.md) for details.
@@ -354,9 +364,12 @@ Documentation rules are defined in `build/rules/doc-rules.yaml`. See [Adding Cus
 | `docs/status/TODO.md` | scan-todos.py | TODO tracking |
 | `docs/status/todo-scan-results.json` | scan-todos.py | Machine-readable TODO scan results used for auto issue creation |
 | `docs/status/todo-issue-creation-summary.json` | create-todo-issues.py | Machine-readable issue creation summary with status counts and issue numbers |
-| `docs/status/health-dashboard.md` | generate-health-dashboard.py | Health metrics |
+| `docs/status/health-dashboard.md` | generate-health-dashboard.py | Health metrics rendered from canonical JSON |
+| `docs/status/health-dashboard.json` | generate-health-dashboard.py | Canonical health dashboard payload |
 | `docs/status/link-repair-report.md` | repair-links.py | Broken link report |
 | `docs/status/example-validation.md` | validate-examples.py | Code example validation |
+| `docs/status/metrics-dashboard.md` | generate-metrics-dashboard.py | Build/test metrics rendered from canonical JSON |
+| `docs/status/metrics-dashboard.json` | generate-metrics-dashboard.py | Canonical metrics dashboard payload |
 | `docs/status/ai-inventory-report.md` | check-ai-inventory.py | AI assistant asset catalog drift report |
 | `docs/status/ai-inventory-report.json` | check-ai-inventory.py | Machine-readable AI inventory and drift findings |
 | `docs/status/coverage-report.md` | generate-coverage.py | Documentation coverage |


### PR DESCRIPTION
### Motivation

- Prevent drift between machine-readable dashboard data and human-readable Markdown by making JSON the canonical stage for dashboard generators.
- Centralize common rendering and timestamp/data-source metadata handling for consistency across multiple dashboard scripts.
- Surface missing-evidence or data problems early in automation by failing fast when required inputs are absent.

### Description

- Added a shared helper module `build/scripts/docs/dashboard_rendering.py` to write/load canonical JSON and render deterministic Markdown with generated timestamp and data-source metadata.
- Updated `build/scripts/docs/generate-health-dashboard.py` to produce canonical JSON first, require `--json-output` when `--output` is requested, validate required Markdown evidence, and render Markdown by loading the JSON payload.
- Updated `build/scripts/docs/generate-metrics-dashboard.py` to produce canonical JSON first, require `--json-output` when `--output` is requested, validate required evidence directories (`.github/workflows` and `TestResults`), and render Markdown from the saved JSON payload.
- Updated `build/scripts/docs/run-docs-automation.py` to pass both `--output` and `--json-output` by default for the health and metrics dashboard entries so automation invokes the canonical JSON stage.
- Documented the behavior in `docs/development/documentation-automation.md` and added the generated JSON artifacts (`docs/status/health-dashboard.json`, `docs/status/metrics-dashboard.json`) to the generated outputs table.

### Testing

- Verified Python syntax compilation with `python3 -m py_compile build/scripts/docs/dashboard_rendering.py build/scripts/docs/generate-health-dashboard.py build/scripts/docs/generate-metrics-dashboard.py build/scripts/docs/run-docs-automation.py`, which completed successfully.
- Confirmed that `run-docs-automation.py` configuration now includes `--json-output` for `generate-health-dashboard` and `generate-metrics-dashboard` when coordinating profile runs by inspecting the runner config entries.
- Performed local smoke checks of the modified dashboards to ensure they write JSON and render Markdown from the JSON payload when both `--json-output` and `--output` are provided (manual verification steps as part of the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12a6e23048320919c5f98a3fd741b)