### PR TITLE
ci: scope Copilot brief to base-branch diff and fetch base ref

### DIFF
--- a/.github/workflows/copilot-swe-agent-copilot.yml
+++ b/.github/workflows/copilot-swe-agent-copilot.yml
@@ -39,6 +39,43 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve base ref and collect scoped diff
+        id: diff
+        shell: bash
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+
+          BASE_REF="${GITHUB_BASE_REF:-main}"
+          REMOTE_BASE="origin/${BASE_REF}"
+
+          git fetch --no-tags --prune --depth=200 origin "${BASE_REF}:${REMOTE_BASE}" || \
+            git fetch --no-tags --prune origin "${BASE_REF}:${REMOTE_BASE}"
+
+          DIFF_RANGE="${REMOTE_BASE}...HEAD"
+          mapfile -t CHANGED_FILES < <(git diff --name-only --diff-filter=ACMR "${DIFF_RANGE}" || true)
+
+          MAX_FILES=80
+          if (( ${#CHANGED_FILES[@]} > MAX_FILES )); then
+            CHANGED_FILES=("${CHANGED_FILES[@]:0:MAX_FILES}")
+            TRUNCATED=true
+          else
+            TRUNCATED=false
+          fi
+
+          {
+            echo "base_ref=${REMOTE_BASE}"
+            echo "diff_range=${DIFF_RANGE}"
+            echo "changed_count=${#CHANGED_FILES[@]}"
+            echo "truncated=${TRUNCATED}"
+            echo "changed_files<<EOF"
+            printf '%s\n' "${CHANGED_FILES[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build Copilot run brief
         id: brief
@@ -48,6 +85,14 @@ jobs:
             const eventName = context.eventName;
             const actor = context.actor;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const baseRef = `${{ steps.diff.outputs.base_ref }}`;
+            const diffRange = `${{ steps.diff.outputs.diff_range }}`;
+            const changedFilesCount = `${{ steps.diff.outputs.changed_count }}` || '0';
+            const changedFiles = `${{ steps.diff.outputs.changed_files }}`
+              .split('\n')
+              .map(x => x.trim())
+              .filter(Boolean);
+            const truncated = `${{ steps.diff.outputs.truncated }}` === 'true';
             const issueNumberInput = context.payload.inputs?.issue_number;
             const issueNumber = Number(issueNumberInput || context.payload.issue?.number || 0);
             const target = issueNumber > 0 ? `#${issueNumber}` : 'ad-hoc run';
@@ -91,6 +136,21 @@ jobs:
               '```text',
               requestText.trim(),
               '```',
+              '',
+              '## Scoped Repository Context',
+              `- Base ref: ${baseRef}`,
+              `- Diff range: ${diffRange}`,
+              `- Changed files captured: ${changedFilesCount}${truncated ? ' (truncated to first 80 files)' : ''}`,
+              '',
+              changedFiles.length
+                ? [
+                    '### Changed Files',
+                    '```text',
+                    ...changedFiles,
+                    '```',
+                    '',
+                  ].join('\n')
+                : '### Changed Files\n_No changed files detected for the selected diff range._\n',
               '',
               '## Linked Artifact and Visibility Plan',
               '- This run uploads a markdown artifact with the run brief and context.',


### PR DESCRIPTION
### Motivation
- Prevent oversized Copilot prompts by narrowing the repository context sent to Copilot to a bounded, auditable set of changed files.
- Make base-branch diffing robust in CI when the runner uses shallow clones by ensuring the base ref is fetched with sufficient history.
- Surface explicit metadata so reviewers can verify exactly what files were included in the generated Copilot brief.

### Description
- Switch `actions/checkout` in the Copilot workflow to `fetch-depth: 0` so full history is available for reliable diffs. 
- Add a `Resolve base ref and collect scoped diff` step that fetches `origin/${GITHUB_BASE_REF}` (fallback `main`) and computes a three-dot diff range `origin/<base>...HEAD` for the change set. 
- Build a trimmed changed-file list (first 80 files) and expose `base_ref`, `diff_range`, `changed_count`, `truncated`, and `changed_files` as workflow outputs. 
- Extend the Copilot run brief to include the base ref, diff range, truncated/file-count metadata, and the captured changed-file list for auditable prompt context.

### Testing
- Ran `git diff --check` on the modified workflow file and it returned no issues (passed). 
- Attempted to validate YAML with a small Python snippet but PyYAML is not installed in this environment so automated YAML parsing could not be completed (validation skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20e8bb1b88320b8ca7ec55b78be8b)