### PR TITLE
Fetch PR base and limit AI PR review diff context

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -321,13 +321,31 @@ jobs:
 
     - name: Get PR diff summary
       id: diff
+      shell: bash
       run: |
-        DIFF_STATS=$(git diff --stat origin/${{ github.base_ref }}...HEAD | tail -1)
-        CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | head -30)
-        echo "stats=$DIFF_STATS" >> $GITHUB_OUTPUT
-        echo "files<<FILESEOF" >> $GITHUB_OUTPUT
-        echo "$CHANGED_FILES" >> $GITHUB_OUTPUT
-        echo "FILESEOF" >> $GITHUB_OUTPUT
+        set -euo pipefail
+
+        BASE_REF="${{ github.base_ref }}"
+        REMOTE_BASE="origin/${BASE_REF}"
+
+        git fetch --no-tags --prune --depth=200 origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}" || \
+          git fetch --no-tags --prune origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
+        DIFF_RANGE="${REMOTE_BASE}...HEAD"
+        DIFF_STATS=$(git diff --stat "$DIFF_RANGE" | tail -1)
+
+        mapfile -t FILTERED_FILES < <(
+          git diff --name-only --diff-filter=ACMR "$DIFF_RANGE" | \
+            grep -Ev '(^README\.md$|^Meridian Design System \(3\)/README\.md$)' | \
+            head -30 || true
+        )
+
+        {
+          echo "stats=$DIFF_STATS"
+          echo "files<<FILESEOF"
+          printf '%s\n' "${FILTERED_FILES[@]}"
+          echo "FILESEOF"
+        } >> "$GITHUB_OUTPUT"
 
     - name: AI review summary
       id: ai-review


### PR DESCRIPTION
### Motivation

- Prevent AI PR review failures when the PR base branch (e.g. `main`) is not present in the checkout and avoid sending large, low-signal markdown into the AI prompt.
- Reduce AI input size by limiting changed-file context to actionable paths and excluding oversized README files to keep prompts bounded and focused.

### Description

- Update the `Get PR diff summary` step in `.github/workflows/pr-checks.yml` to run under `bash` with `set -euo pipefail` for robust scripting.
- Explicitly fetch the PR base branch using `git fetch ... "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"` and compute `DIFF_RANGE` from the fetched remote before running `git diff`.
- Restrict the file list to `git diff --name-only --diff-filter=ACMR`, cap the list to 30 entries, and filter out `README.md` and `Meridian Design System (3)/README.md` before writing the `GITHUB_OUTPUT` used by the AI step.

### Testing

- Validated the updated workflow snippet with `sed -n '300,370p' .github/workflows/pr-checks.yml` and `nl -ba .github/workflows/pr-checks.yml | sed -n '322,347p'`, and the outputs showed the intended changes without syntax issues.
- Confirmed workflow-related search results and locations using `rg` (search for AI/Copilot/diff-related patterns) and observed the expected matches; the command ran successfully.
- Applied and verified the automated patch via the `python3` patch script used during the rollout and confirmed the modified file content matched the intended edits; the script completed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2124091548320b37485c3d5dec3e5)