### PR TITLE
Retarget Meridian projects and build artifact workflow to .NET 10

### DIFF
--- a/.github/workflows/generate-build-artifact.yml
+++ b/.github/workflows/generate-build-artifact.yml
@@ -64,7 +64,7 @@ on:
         description: '.NET SDK version'
         required: false
         type: string
-        default: '9.0.x'
+        default: '10.0.x'
     outputs:
       artifact-name:
         description: 'Name of the uploaded build artifact (pass to actions/download-artifact)'
@@ -118,7 +118,7 @@ jobs:
       - name: Setup .NET with Cache
         uses: ./.github/actions/setup-dotnet-cache
         with:
-          dotnet-version: ${{ inputs.dotnet-version || '9.0.x' }}
+          dotnet-version: ${{ inputs.dotnet-version || '10.0.x' }}
           cache-suffix: 'build-artifact'
 
       - name: Restore dependencies

--- a/benchmarks/Meridian.Benchmarks/Meridian.Benchmarks.csproj
+++ b/benchmarks/Meridian.Benchmarks/Meridian.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/Meridian/Meridian.csproj
+++ b/src/Meridian/Meridian.csproj
@@ -3,7 +3,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
### Motivation
- Move the repository forward to .NET 10 by retargeting the application and benchmark projects and updating the reusable workflow SDK default so CI uses the .NET 10 SDK.

### Description
- Change `TargetFramework` from `net9.0` to `net10.0` in `src/Meridian/Meridian.csproj`.
- Change `TargetFramework` from `net9.0` to `net10.0` in `benchmarks/Meridian.Benchmarks/Meridian.Benchmarks.csproj`.
- Update the reusable workflow `.github/workflows/generate-build-artifact.yml` to use `10.0.x` instead of `9.0.x` for the `dotnet-version` input and fallback.

### Testing
- Ran `rg -n "TargetFramework|9\.0\.x|dotnet-version" src/Meridian/Meridian.csproj benchmarks/Meridian.Benchmarks/Meridian.Benchmarks.csproj .github/workflows/generate-build-artifact.yml` to verify replacements.
- Inspected the modified files with `nl`/`sed` to confirm the intended edits and did not run `dotnet build`/`dotnet test` because this is a configuration-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22083a2f88320be712404535080fb)