### PR TITLE
Resolve desktop executable path in run-desktop-workflow.ps1

### DIFF
--- a/scripts/dev/run-desktop-workflow.ps1
+++ b/scripts/dev/run-desktop-workflow.ps1
@@ -80,6 +80,49 @@ function Get-ConfigBool {
     return $Fallback
 }
 
+function Resolve-DesktopExecutablePath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PreferredPath,
+        [Parameter(Mandatory = $true)]
+        [string]$ProjectPath,
+        [Parameter(Mandatory = $true)]
+        [string]$Configuration,
+        [Parameter(Mandatory = $true)]
+        [string]$ExeName
+    )
+
+    if (Test-Path -LiteralPath $PreferredPath -PathType Leaf) {
+        return [System.IO.Path]::GetFullPath($PreferredPath)
+    }
+
+    $projectDirectory = Split-Path -Parent $ProjectPath
+    $projectRoot = if ([System.IO.Path]::IsPathRooted($projectDirectory)) {
+        [System.IO.Path]::GetFullPath($projectDirectory)
+    }
+    else {
+        [System.IO.Path]::GetFullPath((Join-Path $repoRoot $projectDirectory))
+    }
+
+    $configurationRoot = Join-Path $projectRoot "bin/$Configuration"
+    if (-not (Test-Path -LiteralPath $configurationRoot -PathType Container)) {
+        return [System.IO.Path]::GetFullPath($PreferredPath)
+    }
+
+    $candidates = @(
+        Get-ChildItem -LiteralPath $configurationRoot -Filter $ExeName -Recurse -File -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTimeUtc -Descending
+    )
+
+    if ($candidates.Count -gt 0) {
+        $resolvedCandidate = [System.IO.Path]::GetFullPath($candidates[0].FullName)
+        Write-Warn "Expected desktop executable path '$PreferredPath' was not found; using discovered binary '$resolvedCandidate'."
+        return $resolvedCandidate
+    }
+
+    return [System.IO.Path]::GetFullPath($PreferredPath)
+}
+
 function Get-MeridianWindowFromProcess {
     param(
         [System.Diagnostics.Process]$Process
@@ -844,6 +887,7 @@ New-Item -ItemType Directory -Force -Path $runDirectory, $logDirectory, $screens
 $stdoutPath = Join-Path $logDirectory 'stdout.log'
 $stderrPath = Join-Path $logDirectory 'stderr.log'
 $exePath = Get-MeridianProjectBinaryPath -RepoRoot $repoRoot -ProjectPath $resolvedProjectPath -Configuration $resolvedConfiguration -Framework $resolvedFramework -BinaryName $resolvedExeName -IsolationKey $buildIsolationKey
+$exePath = Resolve-DesktopExecutablePath -PreferredPath $exePath -ProjectPath $resolvedProjectPath -Configuration $resolvedConfiguration -ExeName $resolvedExeName
 $manifest = [ordered]@{
     workflow = [ordered]@{
         name = $workflowDefinition.name


### PR DESCRIPTION
### Motivation
- The desktop workflow launcher was hard-failing when the built binary did not live at the exact framework subfolder (for example `src/Meridian.Wpf/bin/Release/net9.0-windows10.0.19041.0/Meridian.Desktop.exe`), even though a valid `Meridian.Desktop.exe` existed elsewhere under `bin/`.
- The change aims to make the workflow resilient to differing framework output locations without changing project/assembly definitions.

### Description
- Added `Resolve-DesktopExecutablePath` to `scripts/dev/run-desktop-workflow.ps1` which preserves the preferred path when present but otherwise scans `bin/<Configuration>/` under the project for matching `ExeName` and returns the newest candidate.
- The resolver sorts candidates by `LastWriteTimeUtc`, logs a `Write-Warn` when falling back to a discovered binary, and returns a full path for use by the workflow.
- Wired the workflow to call `Resolve-DesktopExecutablePath` immediately after computing the default binary path so the manifest, artifact checks, and launch use the discovered executable.
- Behavior preserves existing preferred-path semantics and only falls back when the expected file is missing.

### Testing
- Attempted a PowerShell syntax parse using `pwsh -NoLogo -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('scripts/dev/run-desktop-workflow.ps1',...)"`, but the container lacks `pwsh` so the parse could not be executed (`pwsh: command not found`).
- The patch was committed locally and the modified file is `scripts/dev/run-desktop-workflow.ps1`; no other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21a324f948320a1b581952396b1d5)