### PR TITLE
Align central Microsoft.Extensions and System.IO.Pipelines pins to 10.0.7 to fix WPF restore

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,23 +26,23 @@
   </PropertyGroup>
 
   <ItemGroup Label="Microsoft.Extensions">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup Label="ASP.NET Core">
@@ -96,7 +96,7 @@
   <ItemGroup Label="System Libraries">
     <PackageVersion Include="SSH.NET" Version="2025.1.0" />
     <PackageVersion Include="System.Threading.Channels" Version="10.0.5" />
-    <PackageVersion Include="System.IO.Pipelines" Version="10.0.5" />
+    <PackageVersion Include="System.IO.Pipelines" Version="10.0.7" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="System.Net.WebSockets.Client" Version="4.3.2" />
     <PackageVersion Include="System.Net.Http.Json" Version="10.0.5" />


### PR DESCRIPTION
### Motivation
- A WPF `dotnet restore` failed with NU1109 because central package pins in `Directory.Packages.props` were lower than transitive requirements introduced by `Microsoft.Extensions.Hosting 10.0.7` and `System.Text.Json 10.0.7`.
- Central transitive pinning (`CentralPackageTransitivePinningEnabled`) causes the centrally managed versions to win, so the central file must be aligned to the transitive graph to avoid downgrade conflicts.

### Description
- Updated `Directory.Packages.props` to raise the `Microsoft.Extensions.*` family entries to `10.0.7` to match hosting and text-json transitive requirements.
- Specifically bumped `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.Configuration.Json`, `Microsoft.Extensions.Configuration.Binder`, `Microsoft.Extensions.Configuration.EnvironmentVariables`, `Microsoft.Extensions.Configuration.CommandLine`, `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Http`, `Microsoft.Extensions.Http.Polly`, `Microsoft.Extensions.Logging`, `Microsoft.Extensions.Logging.Debug`, `Microsoft.Extensions.ObjectPool`, `Microsoft.Extensions.Options`, and `Microsoft.Extensions.Options.ConfigurationExtensions` to `10.0.7`.
- Updated `System.IO.Pipelines` from `10.0.5` to `10.0.7` under the `System Libraries` item group.
- Change is limited to central package pins in `Directory.Packages.props` and is intended to resolve transitive downgrade conflicts during restore.

### Testing
- Attempted `dotnet restore src/Meridian.Wpf/Meridian.Wpf.csproj --verbosity minimal /p:EnableWindowsTargeting=true` but the environment could not run it because `dotnet` was not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2249be9b88320832764607010a00e)