### PR TITLE
Harden CodeQL workflow and enable manual C# build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   analyze:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
@@ -46,7 +47,7 @@ jobs:
         - language: actions
           build-mode: none
         - language: csharp
-          build-mode: none
+          build-mode: manual
         - language: javascript-typescript
           build-mode: none
         - language: python
@@ -88,16 +89,21 @@ jobs:
     # to build your code.
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
+    - name: Setup .NET
+      if: matrix.language == 'csharp'
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '9.0.x'
+
+    - name: Restore C# solution
+      if: matrix.language == 'csharp'
       shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+      run: dotnet restore Meridian.sln --configfile NuGet.Config
+
+    - name: Build C# solution
+      if: matrix.language == 'csharp'
+      shell: bash
+      run: dotnet build Meridian.sln --no-restore -c Release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -144,6 +144,7 @@
     <PackageVersion Include="Bogus" Version="35.6.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.15" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.15" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/tests/Meridian.McpServer.Tests/Meridian.McpServer.Tests.csproj
+++ b/tests/Meridian.McpServer.Tests/Meridian.McpServer.Tests.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Moq" />
     <PackageReference Include="ModelContextProtocol" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation
- Prevent CodeQL upload failures caused by runs that lack `security-events: write` (commonly forked PR contexts) by restricting upload contexts. 
- Improve C# CodeQL extraction completeness because the previous `build-mode: none` produced many restore/missing-symbol failures during analysis. 
- Ensure deterministic package restores for CI by providing an explicit `NuGet.Config` and adding any missing test-package dependencies required for manual builds.

### Description
- Gate the analyze job in `.github/workflows/codeql.yml` with `if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false` to avoid uploads from forked PR runs. 
- Switch the C# matrix entry to `build-mode: manual` and replace the placeholder with concrete steps to `setup-dotnet@v4`, run `dotnet restore Meridian.sln --configfile NuGet.Config`, and `dotnet build Meridian.sln --no-restore -c Release` in `.github/workflows/codeql.yml`. 
- Add a repository-root `NuGet.Config` that configures `nuget.org` as the package source so CI restores are explicit and reproducible. 
- Add `Microsoft.AspNetCore.TestHost` to `Directory.Packages.props` and add an explicit `<PackageReference>` to `tests/Meridian.McpServer.Tests/Meridian.McpServer.Tests.csproj` to resolve direct `Microsoft.AspNetCore.TestHost` usage during analysis/build.

### Testing
- Attempted: `dotnet restore tests/Meridian.McpServer.Tests/Meridian.McpServer.Tests.csproj --configfile NuGet.Config`, which failed in this environment because the `dotnet` CLI is not installed (error: `dotnet: command not found`).
- Verified repository changes with `git diff` and committed the patch (`Harden CodeQL workflow and enable manual C# build`).
- No further automated test runs were executed in this environment; CI should validate the new workflow by running CodeQL in the intended GitHub runner with `dotnet` available and package feed access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2248971888320ad3f5f3a683eeab8)