### PR TITLE
Align CI and SDK pin to .NET 10 (global.json + scheduled-maintenance workflow)

### DIFF
--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -76,7 +76,7 @@ permissions:
   models: read
 
 env:
-  DOTNET_VERSION: '9.0.x'
+  DOTNET_VERSION: '10.0.x'
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.100",
     "rollForward": "latestMinor",
-    "allowPrerelease": false
+    "allowPrerelease": true
   }
 }


### PR DESCRIPTION
### Motivation
- CI runs were failing with `NETSDK1045` because the repository was targeting `net10.0` while CI and `global.json` were pinned to .NET 9, causing the restore step to use an SDK that cannot target .NET 10.

### Description
- Update `global.json` to pin the SDK to `10.0.100` and set `allowPrerelease: true` to allow resolution of preview .NET 10 SDKs where necessary.
- Update `.github/workflows/scheduled-maintenance.yml` to set `DOTNET_VERSION: '10.0.x'` so the workflow installs a .NET 10 SDK compatible with the project targets.

### Testing
- Validated `global.json` syntax with `python3 -m json.tool global.json`, which succeeded.
- Reviewed the repository diff with `git diff -- global.json .github/workflows/scheduled-maintenance.yml` to confirm the intended changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2252db5088320b34efb33fd166922)