### PR TITLE
Add explicit lineage validation warnings in run continuity status

### DIFF
--- a/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
+++ b/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
@@ -525,6 +525,11 @@ public sealed record StrategyRunCashFlowDigest(
 
 /// <summary>
 /// Machine-readable continuity warning for shared run-centered workflows.
+/// Known warning codes include:
+/// missing-portfolio, missing-ledger, missing-cash-flow, missing-reconciliation, as-of-drift,
+/// open-reconciliation-breaks, security-coverage, lineage-parent-source-mismatch,
+/// lineage-missing-parent-with-source, promotion-target-run-missing, and
+/// promotion-lineage-shape-inconsistent.
 /// </summary>
 public sealed record StrategyRunContinuityWarning(
     string Code,

--- a/src/Meridian.Strategies/Services/StrategyRunContinuityService.cs
+++ b/src/Meridian.Strategies/Services/StrategyRunContinuityService.cs
@@ -115,6 +115,11 @@ public sealed class StrategyRunContinuityService
         RunCashFlowSummary? cashFlow,
         ReconciliationRunDetail? reconciliation)
     {
+        var promotion = run.Summary.Promotion;
+        var hasParent = !string.IsNullOrWhiteSpace(run.Summary.ParentRunId);
+        var promotionSource = promotion?.SourceRunId;
+        var promotionTarget = promotion?.TargetRunId;
+        var promotionState = promotion?.State ?? StrategyRunPromotionState.None;
         var hasPortfolio = run.Portfolio is not null;
         var hasLedger = run.Ledger is not null;
         var hasCashFlow = cashFlow is { TotalEntries: > 0 };
@@ -172,6 +177,45 @@ public sealed class StrategyRunContinuityService
             warnings.Add(new StrategyRunContinuityWarning(
                 Code: "security-coverage",
                 Message: $"Run has {securityCoverageIssues} security coverage issue(s) across continuity surfaces."));
+        }
+
+        if (hasParent
+            && !string.IsNullOrWhiteSpace(promotionSource)
+            && !string.Equals(run.Summary.ParentRunId, promotionSource, StringComparison.Ordinal))
+        {
+            warnings.Add(new StrategyRunContinuityWarning(
+                Code: "lineage-parent-source-mismatch",
+                Message: "Run has a parent link, but promotion source does not match the recorded parent run."));
+        }
+
+        if (!hasParent && !string.IsNullOrWhiteSpace(promotionSource))
+        {
+            warnings.Add(new StrategyRunContinuityWarning(
+                Code: "lineage-missing-parent-with-source",
+                Message: "Run has no parent link, but promotion source claims upstream ancestry."));
+        }
+
+        if ((promotionState is StrategyRunPromotionState.CandidateForPaper or StrategyRunPromotionState.CandidateForLive)
+            && string.IsNullOrWhiteSpace(promotionTarget))
+        {
+            warnings.Add(new StrategyRunContinuityWarning(
+                Code: "promotion-target-run-missing",
+                Message: "Promotion candidate is missing an expected target run identifier."));
+        }
+
+        var lineageInconsistent = promotionState switch
+        {
+            StrategyRunPromotionState.CandidateForPaper => hasParent,
+            StrategyRunPromotionState.CandidateForLive => !hasParent,
+            StrategyRunPromotionState.LiveManaged => !hasParent,
+            _ => false
+        };
+
+        if (lineageInconsistent)
+        {
+            warnings.Add(new StrategyRunContinuityWarning(
+                Code: "promotion-lineage-shape-inconsistent",
+                Message: $"Promotion state '{promotionState}' is inconsistent with the run lineage shape."));
         }
 
         return new StrategyRunContinuityStatus(

--- a/tests/Meridian.Tests/Strategies/StrategyRunContinuityServiceTests.cs
+++ b/tests/Meridian.Tests/Strategies/StrategyRunContinuityServiceTests.cs
@@ -2,7 +2,9 @@ using FluentAssertions;
 using Meridian.Backtesting.Sdk;
 using Meridian.Contracts.Workstation;
 using Meridian.Ledger;
+using Meridian.Strategies.Interfaces;
 using Meridian.Strategies.Models;
+using Meridian.Strategies.Promotions;
 using Meridian.Strategies.Services;
 using Meridian.Strategies.Storage;
 using Xunit;
@@ -11,6 +13,75 @@ namespace Meridian.Tests.Strategies;
 
 public sealed class StrategyRunContinuityServiceTests
 {
+    [Fact]
+    public async Task GetRunContinuityAsync_WithParentAndMismatchedPromotionSource_EmitsLineageMismatchWarning()
+    {
+        var store = new StrategyRunStore();
+        var run = BuildContinuityRun("lineage-source-mismatch") with { ParentRunId = "expected-parent" };
+        await store.RecordRunAsync(run);
+
+        var continuityService = BuildContinuityService(
+            store,
+            [BuildPromotionRecord("lineage-source-mismatch", "different-parent", "paper-target")]);
+        var continuity = await continuityService.GetRunContinuityAsync("lineage-source-mismatch");
+
+        continuity.Should().NotBeNull();
+        continuity!.ContinuityStatus.Warnings.Select(static warning => warning.Code)
+            .Should()
+            .Contain("lineage-parent-source-mismatch");
+    }
+
+    [Fact]
+    public async Task GetRunContinuityAsync_WithoutParentAndPromotionSource_EmitsMissingParentWarning()
+    {
+        var store = new StrategyRunStore();
+        await store.RecordRunAsync(BuildContinuityRun("lineage-parent-missing"));
+
+        var continuityService = BuildContinuityService(
+            store,
+            [BuildPromotionRecord("lineage-parent-missing", "claimed-parent", "paper-target")]);
+        var continuity = await continuityService.GetRunContinuityAsync("lineage-parent-missing");
+
+        continuity.Should().NotBeNull();
+        continuity!.ContinuityStatus.Warnings.Select(static warning => warning.Code)
+            .Should()
+            .Contain("lineage-missing-parent-with-source");
+    }
+
+    [Fact]
+    public async Task GetRunContinuityAsync_PromotionCandidateWithoutTarget_EmitsMissingTargetWarning()
+    {
+        var store = new StrategyRunStore();
+        await store.RecordRunAsync(BuildContinuityRun("lineage-target-missing"));
+
+        var continuityService = BuildContinuityService(
+            store,
+            [BuildPromotionRecord("lineage-target-missing", "lineage-target-missing", targetRunId: null)]);
+        var continuity = await continuityService.GetRunContinuityAsync("lineage-target-missing");
+
+        continuity.Should().NotBeNull();
+        continuity!.ContinuityStatus.Warnings.Select(static warning => warning.Code)
+            .Should()
+            .Contain("promotion-target-run-missing");
+    }
+
+    [Fact]
+    public async Task GetRunContinuityAsync_CandidateForLiveWithoutParent_EmitsLineageShapeWarning()
+    {
+        var store = new StrategyRunStore();
+        var paperRun = BuildContinuityRun("lineage-shape-paper") with { RunType = RunType.Paper };
+        await store.RecordRunAsync(paperRun);
+
+        var continuityService = BuildContinuityService(store);
+        var continuity = await continuityService.GetRunContinuityAsync("lineage-shape-paper");
+
+        continuity.Should().NotBeNull();
+        continuity!.Run.Summary.Promotion!.State.Should().Be(StrategyRunPromotionState.CandidateForLive);
+        continuity.ContinuityStatus.Warnings.Select(static warning => warning.Code)
+            .Should()
+            .Contain("promotion-lineage-shape-inconsistent");
+    }
+
     [Fact]
     public async Task GetRunContinuityAsync_BuildsRunCenteredSnapshotAcrossSharedSeams()
     {
@@ -207,6 +278,47 @@ public sealed class StrategyRunContinuityServiceTests
             },
             FundProfileId: "alpha-credit",
             FundDisplayName: "Alpha Credit");
+    }
+
+    private static StrategyRunContinuityService BuildContinuityService(
+        StrategyRunStore store,
+        IReadOnlyList<StrategyPromotionRecord>? promotionRecords = null)
+    {
+        var readService = new StrategyRunReadService(
+            store,
+            new PortfolioReadService(),
+            new LedgerReadService(),
+            new StubPromotionRecordStore(promotionRecords ?? []));
+        return new StrategyRunContinuityService(
+            readService,
+            new CashFlowProjectionService(store),
+            new ReconciliationRunService(
+                readService,
+                new ReconciliationProjectionService(),
+                new InMemoryReconciliationRunRepository()));
+    }
+
+    private static StrategyPromotionRecord BuildPromotionRecord(string runId, string sourceRunId, string? targetRunId)
+        => new(
+            PromotionId: $"promotion-{runId}",
+            TimestampUtc: new DateTimeOffset(2026, 4, 2, 16, 0, 0, TimeSpan.Zero),
+            StrategyId: "continuity-strategy",
+            StrategyName: "Continuity Strategy",
+            SourceRunId: sourceRunId,
+            TargetRunId: targetRunId,
+            SourceRunType: RunType.Backtest,
+            TargetRunType: RunType.Paper,
+            Decision: PromotionDecisionKinds.Approved,
+            ApprovedBy: "test-operator",
+            Reason: "test fixture");
+
+    private sealed class StubPromotionRecordStore(IReadOnlyList<StrategyPromotionRecord> records) : IPromotionRecordStore
+    {
+        public Task<IReadOnlyList<StrategyPromotionRecord>> LoadAllAsync(CancellationToken ct = default) =>
+            Task.FromResult(records);
+
+        public Task AppendAsync(StrategyPromotionRecord record, CancellationToken ct = default) =>
+            Task.CompletedTask;
     }
 
     private static global::Meridian.Ledger.Ledger CreateLedger(DateTimeOffset startedAt, DateTimeOffset completedAt)


### PR DESCRIPTION
### Motivation
- Detect and surface mismatches between recorded run lineage and promotion metadata so operator messaging is actionable and downstream UI consumers can map issues to specific remediation steps.

### Description
- Added promotion/lineage validation inside `StrategyRunContinuityService.BuildContinuityStatus` with checks for parent present but promotion source mismatch, parent absent while promotion source claims ancestry, promotion candidates missing `TargetRunId`, and promotion state inconsistent with the lineage shape.
- Emitted distinct warning codes and messages for each rule: `lineage-parent-source-mismatch`, `lineage-missing-parent-with-source`, `promotion-target-run-missing`, and `promotion-lineage-shape-inconsistent`.
- Documented the set of known continuity warning codes next to the `StrategyRunContinuityWarning` contract in `src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs` for downstream UI consumers.
- Added focused deterministic unit tests in `tests/Meridian.Tests/Strategies/StrategyRunContinuityServiceTests.cs`, including a `StubPromotionRecordStore` and helper `BuildPromotionRecord` to validate each new warning rule.

### Testing
- Attempted focused test run using `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~StrategyRunContinuityServiceTests" --logger "console;verbosity=minimal"`, but the environment lacks the `dotnet` runtime (`/bin/bash: dotnet: command not found`), so tests were not executed here.
- Unit tests added (examples): `GetRunContinuityAsync_WithParentAndMismatchedPromotionSource_EmitsLineageMismatchWarning`, `GetRunContinuityAsync_WithoutParentAndPromotionSource_EmitsMissingParentWarning`, `GetRunContinuityAsync_PromotionCandidateWithoutTarget_EmitsMissingTargetWarning`, and `GetRunContinuityAsync_CandidateForLiveWithoutParent_EmitsLineageShapeWarning`; these should be run in a developer or CI environment with `dotnet` installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f266aca8f88320b271ae579e29382a)