### PR TITLE
Enrich shared fund-account seams from brokerage sync ingestion

### DIFF
--- a/src/Meridian.Ui.Shared/Services/BrokeragePortfolioSyncService.cs
+++ b/src/Meridian.Ui.Shared/Services/BrokeragePortfolioSyncService.cs
@@ -7,6 +7,7 @@ using Meridian.Execution.Sdk;
 using Meridian.Storage.Archival;
 using Meridian.Strategies.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Meridian.Ui.Shared.Services;
 
@@ -235,6 +236,7 @@ public sealed class BrokeragePortfolioSyncService
             ct).ConfigureAwait(false);
 
         await PersistProjectionAsync(projection, ct).ConfigureAwait(false);
+        await EnrichSharedReadServicesAsync(fundAccountId, attemptedAt, projection, ct).ConfigureAwait(false);
         return projection.Status;
     }
 
@@ -415,6 +417,40 @@ public sealed class BrokeragePortfolioSyncService
                 LastSuccessfulSyncAt: projection.Status.LastSuccessfulSyncAt,
                 LastRawSnapshotPath: projection.RawSnapshotPath,
                 LastProjectionPath: projection.ProjectionPath),
+            ct).ConfigureAwait(false);
+    }
+
+    private async Task EnrichSharedReadServicesAsync(
+        Guid fundAccountId,
+        DateTimeOffset attemptedAt,
+        WorkstationBrokerageSyncViewDto projection,
+        CancellationToken ct)
+    {
+        var fundAccountService = _services.GetService<IFundAccountService>();
+        if (fundAccountService is null || projection.Balance is null)
+        {
+            return;
+        }
+
+        await fundAccountService.RecordBalanceSnapshotAsync(
+            new RecordAccountBalanceSnapshotRequest(
+                AccountId: fundAccountId,
+                AsOfDate: DateOnly.FromDateTime(attemptedAt.UtcDateTime),
+                Currency: projection.Balance.Currency,
+                CashBalance: projection.Balance.Cash,
+                SecuritiesMarketValue: projection.Balance.Equity - projection.Balance.Cash,
+                AccruedInterest: 0m,
+                PendingSettlement: 0m,
+                Source: $"brokerage-sync:{projection.Link.ProviderId}",
+                CapturedBy: projection.Link.LinkedBy ?? "brokerage-sync",
+                ExternalReference: projection.Link.ExternalAccountId),
+            ct).ConfigureAwait(false);
+
+        await fundAccountService.ReconcileAccountAsync(
+            new ReconcileAccountRequest(
+                fundAccountId,
+                DateOnly.FromDateTime(attemptedAt.UtcDateTime),
+                projection.Link.LinkedBy ?? "brokerage-sync"),
             ct).ConfigureAwait(false);
     }
 

--- a/tests/Meridian.Tests/Ui/BrokeragePortfolioSyncServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/BrokeragePortfolioSyncServiceTests.cs
@@ -1,4 +1,6 @@
 using FluentAssertions;
+using Meridian.Application.FundAccounts;
+using Meridian.Contracts.FundStructure;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Contracts.Workstation;
 using Meridian.Execution.Sdk;
@@ -21,13 +23,25 @@ public sealed class BrokeragePortfolioSyncServiceTests
         var root = CreateTempRoot();
         try
         {
-            var service = CreateService(
+            var (service, serviceProvider) = CreateService(
                 root,
                 new FixedPortfolioAdapter("alpaca"),
                 new FixedActivityAdapter("alpaca"),
                 includeSecurityLookup: true);
             var fundAccountId = Guid.NewGuid();
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var fundAccountService = serviceProvider.GetRequiredService<IFundAccountService>();
+
+            await fundAccountService.CreateAccountAsync(
+                new CreateAccountRequest(
+                    fundAccountId,
+                    AccountTypeDto.Brokerage,
+                    "BRK-001",
+                    "Primary Brokerage",
+                    "USD",
+                    DateTimeOffset.UtcNow.AddDays(-10),
+                    "tests"),
+                cts.Token);
 
             var status = await service.RunSyncAsync(
                 fundAccountId,
@@ -63,6 +77,15 @@ public sealed class BrokeragePortfolioSyncServiceTests
             var restoredStatus = await service.GetStatusAsync(fundAccountId, cts.Token);
             restoredStatus.Health.Should().Be(WorkstationBrokerageSyncHealth.Healthy);
             restoredStatus.LastSuccessfulSyncAt.Should().Be(status.LastSuccessfulSyncAt);
+
+            var latestBalance = await fundAccountService.GetLatestBalanceSnapshotAsync(fundAccountId, cts.Token);
+            latestBalance.Should().NotBeNull();
+            latestBalance!.CashBalance.Should().Be(50000m);
+            latestBalance.SecuritiesMarketValue.Should().Be(75000m);
+
+            var reconciliationRuns = await fundAccountService.GetReconciliationRunsAsync(fundAccountId, cts.Token);
+            reconciliationRuns.Should().ContainSingle();
+            reconciliationRuns[0].Status.Should().NotBeNullOrWhiteSpace();
         }
         finally
         {
@@ -76,7 +99,7 @@ public sealed class BrokeragePortfolioSyncServiceTests
         var root = CreateTempRoot();
         try
         {
-            var service = CreateService(
+            var (service, _) = CreateService(
                 root,
                 new ThrowingPortfolioAdapter("alpaca", "Alpaca credentials are missing."),
                 new ThrowingActivityAdapter("alpaca", "Alpaca credentials are missing."),
@@ -110,7 +133,7 @@ public sealed class BrokeragePortfolioSyncServiceTests
         var root = CreateTempRoot();
         try
         {
-            var service = CreateService(
+            var (service, _) = CreateService(
                 root,
                 new FixedPortfolioAdapter("alpaca"),
                 new FixedActivityAdapter("alpaca"),
@@ -134,25 +157,28 @@ public sealed class BrokeragePortfolioSyncServiceTests
         }
     }
 
-    private static BrokeragePortfolioSyncService CreateService(
+    private static (BrokeragePortfolioSyncService Service, ServiceProvider Provider) CreateService(
         string root,
         IBrokeragePortfolioSync portfolioAdapter,
         IBrokerageActivitySync activityAdapter,
         bool includeSecurityLookup)
     {
         var services = new ServiceCollection();
+        services.AddSingleton<IFundAccountService, InMemoryFundAccountService>();
         if (includeSecurityLookup)
         {
             services.AddSingleton<ISecurityReferenceLookup>(new StaticSecurityReferenceLookup());
         }
+        var serviceProvider = services.BuildServiceProvider();
 
-        return new BrokeragePortfolioSyncService(
+        var syncService = new BrokeragePortfolioSyncService(
             new BrokeragePortfolioSyncOptions(root, TimeSpan.FromMinutes(30), "alpaca"),
             catalogs: [],
             portfolioAdapters: [portfolioAdapter],
             activityAdapters: [activityAdapter],
-            services: services.BuildServiceProvider(),
+            services: serviceProvider,
             logger: NullLogger<BrokeragePortfolioSyncService>.Instance);
+        return (syncService, serviceProvider);
     }
 
     private static string CreateTempRoot()


### PR DESCRIPTION
### Motivation

- Ensure brokerage sync outcomes feed authoritative shared read-models so fund-account summaries, portfolio summaries, ledger summaries, and reconciliation runs observe provider-derived state instead of relying only on a parallel brokerage projection.

### Description

- Added `EnrichSharedReadServicesAsync` to `BrokeragePortfolioSyncService` and call it from `RunSyncAsync` after `PersistProjectionAsync` to propagate sync outcomes into shared services via `IFundAccountService` (records a balance snapshot and triggers `ReconcileAccountAsync`).
- The sync service now resolves `IFundAccountService` from the injected `IServiceProvider` before writing snapshots and requesting reconciliation linkage for the synced `fundAccountId`/`AsOfDate`.
- Updated tests in `tests/Meridian.Tests/Ui/BrokeragePortfolioSyncServiceTests.cs` to register `InMemoryFundAccountService` in the test DI, create a fund-account prior to running the sync, and assert that `GetLatestBalanceSnapshotAsync` and `GetReconciliationRunsAsync` observe the brokerage-sync-driven changes.
- Minor API/test harness changes: `CreateService` in the test now returns the `ServiceProvider` alongside the `BrokeragePortfolioSyncService` so tests can access `IFundAccountService`.

### Testing

- Attempted to run the focused test filter with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~BrokeragePortfolioSyncServiceTests" --logger "console;verbosity=minimal"`, but the runner failed due to the environment missing `dotnet` (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f266adbdd083209bdb56844bbb00ef)