### PR TITLE
Add continuity fill status and cross-surface warning coverage

### DIFF
--- a/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
+++ b/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
@@ -537,6 +537,7 @@ public sealed record StrategyRunContinuityStatus(
     bool HasPortfolio,
     bool HasLedger,
     bool HasCashFlow,
+    bool HasFills,
     bool HasReconciliation,
     int AsOfDriftMinutes,
     int OpenReconciliationBreaks,

--- a/src/Meridian.Strategies/Services/StrategyRunContinuityService.cs
+++ b/src/Meridian.Strategies/Services/StrategyRunContinuityService.cs
@@ -118,6 +118,7 @@ public sealed class StrategyRunContinuityService
         var hasPortfolio = run.Portfolio is not null;
         var hasLedger = run.Ledger is not null;
         var hasCashFlow = cashFlow is { TotalEntries: > 0 };
+        var hasFills = (run.Execution?.FillCount ?? run.Summary.FillCount) > 0;
         var hasReconciliation = reconciliation is not null;
         var asOfDriftMinutes = CalculateAsOfDriftMinutes(run.Portfolio?.AsOf, run.Ledger?.AsOf);
         var openBreaks = reconciliation?.Summary.OpenBreakCount ?? 0;
@@ -144,6 +145,13 @@ public sealed class StrategyRunContinuityService
             warnings.Add(new StrategyRunContinuityWarning(
                 Code: "missing-cash-flow",
                 Message: "Run has no recorded cash flows for cash-financing continuity."));
+        }
+
+        if (!hasFills)
+        {
+            warnings.Add(new StrategyRunContinuityWarning(
+                Code: "missing-fills",
+                Message: "Run has no execution fills recorded for continuity review."));
         }
 
         if (!hasReconciliation)
@@ -174,10 +182,18 @@ public sealed class StrategyRunContinuityService
                 Message: $"Run has {securityCoverageIssues} security coverage issue(s) across continuity surfaces."));
         }
 
+        if (run.Summary.Promotion?.State is StrategyRunPromotionState.CandidateForLive && run.Summary.Mode is StrategyRunMode.Backtest)
+        {
+            warnings.Add(new StrategyRunContinuityWarning(
+                Code: "lineage-promotion-gap",
+                Message: "Run is promoted toward live operations from a backtest lineage; validate paper lineage continuity."));
+        }
+
         return new StrategyRunContinuityStatus(
             HasPortfolio: hasPortfolio,
             HasLedger: hasLedger,
             HasCashFlow: hasCashFlow,
+            HasFills: hasFills,
             HasReconciliation: hasReconciliation,
             AsOfDriftMinutes: asOfDriftMinutes,
             OpenReconciliationBreaks: openBreaks,

--- a/tests/Meridian.Tests/Strategies/StrategyRunContinuityServiceTests.cs
+++ b/tests/Meridian.Tests/Strategies/StrategyRunContinuityServiceTests.cs
@@ -15,7 +15,7 @@ public sealed class StrategyRunContinuityServiceTests
     public async Task GetRunContinuityAsync_BuildsRunCenteredSnapshotAcrossSharedSeams()
     {
         var store = new StrategyRunStore();
-        var parentRun = BuildContinuityRun("continuity-root");
+        var parentRun = BuildContinuityRun("continuity-root", includeFills: true, promotionState: StrategyRunPromotionState.CandidateForLive);
         var childRun = StrategyRunEntry.Start("continuity-strategy", "Continuity Strategy", RunType.Paper) with
         {
             RunId = "continuity-paper",
@@ -67,11 +67,12 @@ public sealed class StrategyRunContinuityServiceTests
         continuity.ContinuityStatus.HasPortfolio.Should().BeTrue();
         continuity.ContinuityStatus.HasLedger.Should().BeTrue();
         continuity.ContinuityStatus.HasCashFlow.Should().BeTrue();
+        continuity.ContinuityStatus.HasFills.Should().BeFalse();
         continuity.ContinuityStatus.HasReconciliation.Should().BeTrue();
         continuity.ContinuityStatus.HasWarnings.Should().BeTrue();
         continuity.ContinuityStatus.Warnings.Select(static warning => warning.Code)
             .Should()
-            .Contain("security-coverage");
+            .Contain(["security-coverage", "lineage-promotion-gap"]);
         continuity.ContinuityStatus.Warnings.Select(static warning => warning.Code)
             .Should()
             .NotContain(["missing-reconciliation", "as-of-drift", "open-reconciliation-breaks"]);
@@ -100,10 +101,10 @@ public sealed class StrategyRunContinuityServiceTests
         continuity.ContinuityStatus.HasWarnings.Should().BeTrue();
         continuity.ContinuityStatus.Warnings.Select(static warning => warning.Code)
             .Should()
-            .Contain(["missing-cash-flow", "missing-reconciliation"]);
+            .Contain(["missing-cash-flow", "missing-fills", "missing-reconciliation"]);
     }
 
-    private static StrategyRunEntry BuildContinuityRun(string runId, bool includeCashFlows = true)
+    private static StrategyRunEntry BuildContinuityRun(string runId, bool includeCashFlows = true, bool includeFills = false, StrategyRunPromotionState promotionState = StrategyRunPromotionState.None)
     {
         var startedAt = new DateTimeOffset(2026, 4, 2, 9, 30, 0, TimeSpan.Zero);
         var completedAt = startedAt.AddHours(2);
@@ -181,7 +182,9 @@ public sealed class StrategyRunContinuityServiceTests
             Universe: new HashSet<string>(["AAPL"], StringComparer.OrdinalIgnoreCase),
             Snapshots: [snapshot],
             CashFlows: cashFlows,
-            Fills: [],
+            Fills: includeFills
+                ? [new FillEvent(Guid.NewGuid(), "AAPL", "buy", 10L, 40m, 0.5m, startedAt.AddMinutes(15), "ORD-1")]
+                : [],
             Metrics: metrics,
             Ledger: CreateLedger(startedAt, completedAt),
             ElapsedTime: TimeSpan.FromHours(2),
@@ -206,7 +209,8 @@ public sealed class StrategyRunContinuityServiceTests
                 ["rebalance"] = "weekly"
             },
             FundProfileId: "alpha-credit",
-            FundDisplayName: "Alpha Credit");
+            FundDisplayName: "Alpha Credit",
+            PromotionState: promotionState);
     }
 
     private static global::Meridian.Ledger.Ledger CreateLedger(DateTimeOffset startedAt, DateTimeOffset completedAt)

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -1780,6 +1780,46 @@ public sealed class WorkstationEndpointsTests
             .Contain("security-coverage");
     }
 
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_ContinuityWarnings_ShouldFlowAcrossResearchTradingGovernanceAndReviewPacket()
+    {
+        await using var app = await CreateAppAsync(services =>
+        {
+            RegisterRunReadServices(services);
+        });
+
+        var runId = $"run-cross-surface-continuity-{Guid.NewGuid():N}";
+        var store = app.Services.GetRequiredService<IStrategyRepository>();
+        await store.RecordRunAsync(BuildContinuityRun(runId, includeCashFlows: false, includeFills: false, promotionState: StrategyRunPromotionState.CandidateForLive));
+
+        var client = app.GetTestClient();
+
+        var reviewPacket = await client.GetFromJsonAsync<StrategyRunReviewPacketDto>($"/api/workstation/runs/{runId}/review-packet", ServerJsonOptions);
+        reviewPacket.Should().NotBeNull();
+        reviewPacket!.Continuity.Should().NotBeNull();
+        reviewPacket.Continuity!.ContinuityStatus.HasFills.Should().BeFalse();
+
+        var warningCodes = reviewPacket.Continuity.ContinuityStatus.Warnings.Select(static warning => warning.Code).ToArray();
+        warningCodes.Should().Contain(["missing-fills", "lineage-promotion-gap"]);
+
+        var inbox = await client.GetFromJsonAsync<OperatorInboxDto>("/api/workstation/operator/inbox", ServerJsonOptions);
+        inbox.Should().NotBeNull();
+        inbox!.Items.Should().Contain(item => item.WorkItemId.StartsWith("continuity-missing-fills", StringComparison.Ordinal));
+        inbox.Items.Should().Contain(item => item.WorkItemId.StartsWith("continuity-lineage-promotion-gap", StringComparison.Ordinal));
+
+        using var continuity = await ReadJsonAsync(client, $"/api/workstation/runs/{runId}/continuity");
+        var continuityWarnings = continuity.RootElement
+            .GetProperty("continuityStatus")
+            .GetProperty("warnings")
+            .EnumerateArray()
+            .Select(static warning => warning.GetProperty("code").GetString())
+            .ToArray();
+
+        continuity.RootElement.GetProperty("continuityStatus").GetProperty("hasFills").GetBoolean().Should().BeFalse();
+        continuityWarnings.Should().Contain(["missing-fills", "lineage-promotion-gap"]);
+        continuityWarnings.Should().Contain(warningCodes);
+    }
     [Fact]
     public async Task MapWorkstationEndpoints_RunContinuityRoute_ShouldReturnNotFoundForMissingRun()
     {
@@ -3281,22 +3321,40 @@ public sealed class WorkstationEndpointsTests
         };
     }
 
-    private static StrategyRunEntry BuildContinuityRun(string runId)
+    private static StrategyRunEntry BuildContinuityRun(string runId, bool includeCashFlows = true, bool includeFills = false, StrategyRunPromotionState promotionState = StrategyRunPromotionState.None)
     {
         var run = BuildReconciliationReadyRun(runId);
-        var cashFlows = new CashFlowEntry[]
-        {
-            new TradeCashFlow(run.StartedAt.AddMinutes(10), -400m, "AAPL", 10L, 40m),
-            new CommissionCashFlow(run.StartedAt.AddMinutes(10), -1m, "AAPL", Guid.NewGuid()),
-            new DividendCashFlow(run.StartedAt.AddDays(3), 25m, "AAPL", 10L, 2.5m)
-        };
+        var cashFlows = includeCashFlows
+            ? new CashFlowEntry[]
+            {
+                new TradeCashFlow(run.StartedAt.AddMinutes(10), -400m, "AAPL", 10L, 40m),
+                new CommissionCashFlow(run.StartedAt.AddMinutes(10), -1m, "AAPL", Guid.NewGuid()),
+                new DividendCashFlow(run.StartedAt.AddDays(3), 25m, "AAPL", 10L, 2.5m)
+            }
+            : [];
+        var fills = includeFills
+            ? new FillEvent[]
+            {
+                new(
+                    FillId: Guid.NewGuid(),
+                    OrderId: Guid.NewGuid(),
+                    Symbol: "AAPL",
+                    FilledQuantity: 10L,
+                    FillPrice: 40m,
+                    Commission: 1m,
+                    FilledAt: run.StartedAt.AddMinutes(10),
+                    AccountId: "default-brokerage")
+            }
+            : [];
 
         return run with
         {
             Metrics = run.Metrics! with
             {
-                CashFlows = cashFlows
+                CashFlows = cashFlows,
+                Fills = fills
             },
+            PromotionState = promotionState,
             FundProfileId = "alpha-credit",
             FundDisplayName = "Alpha Credit"
         };


### PR DESCRIPTION
### Motivation
- UI and service adapters need an explicit `continuityStatus.hasFills` flag so workspaces can reliably render fill-continuity state alongside existing cash/ledger/reconciliation signals. 
- Surfaces must surface machine-readable continuity warnings for `missing-fills` and `lineage-promotion-gap` so operator work items and inboxes show the same concerns regardless of entry point. 
- Tests must assert that new continuity fields/warnings are not silently omitted and that the same run yields the same continuity posture via `/continuity`, the review-packet, and operator-inbox work items. 

### Description
- Added `HasFills` to `StrategyRunContinuityStatus` in `src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs`. 
- Updated `StrategyRunContinuityService` (`src/Meridian.Strategies/Services/StrategyRunContinuityService.cs`) to compute `hasFills` from `run.Execution.FillCount` or `run.Summary.FillCount`, to emit a `missing-fills` warning when no fills exist, and to emit `lineage-promotion-gap` when a backtest lineage is promoted toward live. 
- Extended test fixtures and builders to control cash flows, fills, and promotion state in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` (added scenario knobs and a cross-surface regression test). 
- Expanded `StrategyRunContinuityService` unit tests in `tests/Meridian.Tests/Strategies/StrategyRunContinuityServiceTests.cs` to validate `HasFills` and the new warning codes, and added a cross-surface workstation endpoint test that verifies consistency between `/runs/{id}/continuity`, `/runs/{id}/review-packet`, and the operator inbox. 

### Testing
- Added unit/integration tests: `StrategyRunContinuityServiceTests` updates and a new `MapWorkstationEndpoints_ContinuityWarnings_ShouldFlowAcrossResearchTradingGovernanceAndReviewPacket` scenario in `WorkstationEndpointsTests`; these tests assert `hasFills` and the presence of `missing-fills` and `lineage-promotion-gap`. 
- Attempted to run a focused test pass (`dotnet test` filtered to continuity and workstation endpoint tests), but the execution environment lacks the `dotnet` SDK so the run failed with `/bin/bash: dotnet: command not found`. 
- All modified tests were committed and are ready to run in CI or a developer environment with .NET tooling available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f266aad5ec8320b0ceecea064b52d1)