### PR TITLE
Unify workstation run continuity drill-in contract and links

### DIFF
--- a/src/Meridian.Contracts/Api/UiApiRoutes.cs
+++ b/src/Meridian.Contracts/Api/UiApiRoutes.cs
@@ -472,6 +472,9 @@ public static class UiApiRoutes
     public const string RunsReconciliation = "/api/workstation/runs/{runId}/reconciliation";
     public const string RunsReconciliationHistory = "/api/workstation/runs/{runId}/reconciliation/history";
     public const string RunsLedger = "/api/workstation/runs/{runId}/ledger";
+    /// <summary>
+    /// Canonical strategy run continuity drill-in route shared by workstation surfaces.
+    /// </summary>
     public const string RunsContinuity = "/api/workstation/runs/{runId}/continuity";
     public const string RunsReviewPacket = "/api/workstation/runs/{runId}/review-packet";
     public const string RunsLedgerTrialBalance = "/api/workstation/runs/{runId}/ledger/trial-balance";

--- a/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
+++ b/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
@@ -545,14 +545,25 @@ public sealed record StrategyRunContinuityStatus(
     IReadOnlyList<StrategyRunContinuityWarning> Warnings);
 
 /// <summary>
-/// Shared continuity drill-in that bundles the run-centered seams used across workspaces.
+/// Canonical shared continuity drill-in contract used by Research, Trading, and Governance run drill-ins.
+/// </summary>
+public sealed record StrategyRunContinuityDto(
+    StrategyRunDetail Run,
+    StrategyRunContinuityLineage Lineage,
+    StrategyRunCashFlowDigest? CashFlow,
+    ReconciliationRunSummary? Reconciliation,
+    StrategyRunContinuityStatus ContinuityStatus);
+
+/// <summary>
+/// Backward-compatible alias for <see cref="StrategyRunContinuityDto"/>.
 /// </summary>
 public sealed record StrategyRunContinuityDetail(
     StrategyRunDetail Run,
     StrategyRunContinuityLineage Lineage,
     StrategyRunCashFlowDigest? CashFlow,
     ReconciliationRunSummary? Reconciliation,
-    StrategyRunContinuityStatus ContinuityStatus);
+    StrategyRunContinuityStatus ContinuityStatus)
+    : StrategyRunContinuityDto(Run, Lineage, CashFlow, Reconciliation, ContinuityStatus);
 
 // ---------------------------------------------------------------------------
 // Lot-level tracking read models

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -426,7 +426,7 @@ public static class WorkstationEndpoints
         .Produces<LedgerSummary>(200)
         .Produces(404);
 
-        group.MapGet("/runs/{runId}/continuity", async (string runId, HttpContext context) =>
+        group.MapGet(UiApiRoutes.RunsContinuity, async (string runId, HttpContext context) =>
         {
             var continuityService = context.RequestServices.GetService<StrategyRunContinuityService>();
             if (continuityService is null)
@@ -437,10 +437,15 @@ public static class WorkstationEndpoints
             var detail = await continuityService.GetRunContinuityAsync(runId, context.RequestAborted).ConfigureAwait(false);
             return detail is null
                 ? Results.NotFound()
-                : Results.Json(detail, jsonOptions);
+                : Results.Json(new StrategyRunContinuityDto(
+                    detail.Run,
+                    detail.Lineage,
+                    detail.CashFlow,
+                    detail.Reconciliation,
+                    detail.ContinuityStatus), jsonOptions);
         })
         .WithName("GetRunContinuity")
-        .Produces<StrategyRunContinuityDetail>(200)
+        .Produces<StrategyRunContinuityDto>(200)
         .Produces(404)
         .Produces(501);
 
@@ -2819,7 +2824,7 @@ public static class WorkstationEndpoints
             Attribution: $"/api/workstation/runs/{run.RunId}/attribution",
             Ledger: string.IsNullOrWhiteSpace(run.LedgerReference) ? null : $"/api/workstation/runs/{run.RunId}/ledger",
             CashFlows: $"/api/portfolio/{run.RunId}/cash-flows",
-            Continuity: $"/api/workstation/runs/{run.RunId}/continuity");
+            Continuity: UiApiRoutes.RunsContinuity.Replace("{runId}", run.RunId, StringComparison.Ordinal));
 
     private static object BuildTimelineCard(StrategyRunSummary run) => new
     {
@@ -2864,6 +2869,7 @@ public static class WorkstationEndpoints
         attribution = $"/api/workstation/runs/{run.RunId}/attribution",
         ledger = string.IsNullOrWhiteSpace(run.LedgerReference) ? null : $"/api/workstation/runs/{run.RunId}/ledger",
         cashFlows = $"/api/portfolio/{run.RunId}/cash-flows",
+        continuity = UiApiRoutes.RunsContinuity.Replace("{runId}", run.RunId, StringComparison.Ordinal),
         comparison = "/api/workstation/runs/compare"
     };
 

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -1798,6 +1798,32 @@ public sealed class WorkstationEndpointsTests
     }
 
     [Fact]
+    public async Task MapWorkstationEndpoints_ContinuityDrillInsAcrossSurfaces_ShouldUseCanonicalRouteAndSharedSchema()
+    {
+        await using var app = await CreateAppAsync(RegisterRunReadServices);
+        var store = app.Services.GetRequiredService<IStrategyRepository>();
+        var reconciliationService = app.Services.GetRequiredService<IReconciliationRunService>();
+        await store.RecordRunAsync(BuildContinuityRun("run-continuity-shared"));
+        await reconciliationService.RunAsync(new ReconciliationRunRequest("run-continuity-shared"));
+
+        var client = app.GetTestClient();
+        var canonicalContinuityRoute = UiApiRoutes.RunsContinuity.Replace("{runId}", "run-continuity-shared", StringComparison.Ordinal);
+
+        using var research = await ReadJsonAsync(client, "/api/workstation/research");
+        using var trading = await ReadJsonAsync(client, "/api/workstation/trading");
+        using var briefing = await ReadJsonAsync(client, "/api/workstation/research/briefing");
+
+        ContainsStringValue(research.RootElement, canonicalContinuityRoute).Should().BeTrue();
+        ContainsStringValue(trading.RootElement, canonicalContinuityRoute).Should().BeTrue();
+        ContainsStringValue(briefing.RootElement, canonicalContinuityRoute).Should().BeTrue();
+
+        using var continuity = await ReadJsonAsync(client, canonicalContinuityRoute);
+        var propertyNames = continuity.RootElement.EnumerateObject().Select(static property => property.Name).ToArray();
+        propertyNames.Should().BeEquivalentTo(["run", "lineage", "cashFlow", "reconciliation", "continuityStatus"]);
+        continuity.RootElement.TryGetProperty("continuity", out _).Should().BeFalse("surfaces must not emit continuity-only envelope fields outside the shared DTO contract");
+    }
+
+    [Fact]
     public async Task MapWorkstationEndpoints_RunReviewPacket_ShouldReturnStableActionableWorkItems()
     {
         await using var app = await CreateAppAsync(services =>
@@ -2950,6 +2976,17 @@ public sealed class WorkstationEndpointsTests
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var stream = await response.Content.ReadAsStreamAsync();
         return await JsonDocument.ParseAsync(stream);
+    }
+
+    private static bool ContainsStringValue(JsonElement element, string expectedValue)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => string.Equals(element.GetString(), expectedValue, StringComparison.Ordinal),
+            JsonValueKind.Object => element.EnumerateObject().Any(property => ContainsStringValue(property.Value, expectedValue)),
+            JsonValueKind.Array => element.EnumerateArray().Any(item => ContainsStringValue(item, expectedValue)),
+            _ => false
+        };
     }
 
     private static async Task<OperatorWorkflowHomeSummary> ReadWorkflowSummaryAsync(HttpClient client, string path)


### PR DESCRIPTION
### Motivation

- Designate a single canonical continuity drill-in contract and route used across Research, Trading, and Governance surfaces to avoid per-surface divergence.  
- Replace ad-hoc per-surface continuity link assembly with a shared route/constant to ensure drill-in links always resolve to the same endpoint.  
- Add a regression to assert that all surfaces emit the canonical route and that the continuity response conforms to the shared schema.

### Description

- Introduced `StrategyRunContinuityDto` as the canonical continuity drill-in contract and kept `StrategyRunContinuityDetail` as a backward-compatible alias that derives from the DTO in `src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs`.  
- Documented the canonical continuity route and kept it as `UiApiRoutes.RunsContinuity` in `src/Meridian.Contracts/Api/UiApiRoutes.cs`.  
- Updated the workstation mapping in `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` to register the continuity endpoint using `UiApiRoutes.RunsContinuity`, return the canonical `StrategyRunContinuityDto`, and declare `.Produces<StrategyRunContinuityDto>(200)`.  
- Replaced hardcoded continuity link assembly with `UiApiRoutes.RunsContinuity.Replace("{runId}", run.RunId, StringComparison.Ordinal)` in the Research and run drill-in builders so all emitted drill-in links resolve to `/api/workstation/runs/{runId}/continuity`.  
- Added a test `MapWorkstationEndpoints_ContinuityDrillInsAcrossSurfaces_ShouldUseCanonicalRouteAndSharedSchema` and a helper `ContainsStringValue` to `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` that verifies Research, Trading, and Briefing payloads emit the canonical link and that the continuity response contains the expected shared DTO fields and no extra continuity-only envelope fields.

### Testing

- Attempted to run the targeted endpoint tests with `dotnet test ... --filter "FullyQualifiedName~MapWorkstationEndpoints_RunContinuityRoute_ShouldReturnSharedContinuityPayload|FullyQualifiedName~MapWorkstationEndpoints_ContinuityDrillInsAcrossSurfaces_ShouldUseCanonicalRouteAndSharedSchema"` but the test run could not be executed in this environment because `dotnet` is not available (`/bin/bash: line 1: dotnet: command not found`).  
- No automated test failures were observed in-repo because the tests were not executed in this container, and the changes were committed locally (branch changes included in the PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f267150468832080dd54c175e3e475)