### PR TITLE
Enforce continuity contract packet gating for shared contract deltas

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -85,6 +85,10 @@ body:
           required: false
         - label: Contract migration notes added (required for breaking workstation/strategy/ledger contract changes)
           required: false
+        - label: Contract review packet artifact link added (required for shared-contract deltas in src/Meridian.Contracts/Workstation or src/Meridian.Contracts/Api)
+          required: false
+        - label: Migration note snippet added in PR body (required for non-additive shared-contract deltas)
+          required: false
 
   - type: textarea
     id: breaking-changes

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -74,13 +74,24 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Detect continuity contract changes
+      id: continuity-filter
+      uses: dorny/paths-filter@v3
+      with:
+        filters: |
+          continuity_contracts:
+            - 'src/Meridian.Contracts/Workstation/**'
+            - 'src/Meridian.Contracts/Api/**'
+
     - name: Capture PR body
+      if: steps.continuity-filter.outputs.continuity_contracts == 'true'
       env:
         PR_BODY: ${{ github.event.pull_request.body }}
       run: |
         printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr-body.md"
 
     - name: Run contract compatibility gate
+      if: steps.continuity-filter.outputs.continuity_contracts == 'true'
       run: |
         python3 scripts/check_contract_compatibility_gate.py \
           --base "${{ github.event.pull_request.base.sha }}" \
@@ -88,7 +99,7 @@ jobs:
           --pr-body-file "$RUNNER_TEMP/pr-body.md"
 
     - name: Generate contract review packet
-      if: always()
+      if: always() && steps.continuity-filter.outputs.continuity_contracts == 'true'
       run: |
         mkdir -p artifacts/contract-review/pr-${{ github.event.pull_request.number }}
         python3 scripts/generate_contract_review_packet.py \
@@ -100,12 +111,16 @@ jobs:
         cat artifacts/contract-review/pr-${{ github.event.pull_request.number }}/contract-review-packet.md >> "$GITHUB_STEP_SUMMARY"
 
     - name: Upload contract review packet
-      if: always()
+      if: always() && steps.continuity-filter.outputs.continuity_contracts == 'true'
       uses: actions/upload-artifact@v7
       with:
         name: contract-review-packet
         path: artifacts/contract-review/pr-${{ github.event.pull_request.number }}/
         retention-days: 14
+
+    - name: Skip note when no continuity contract files changed
+      if: steps.continuity-filter.outputs.continuity_contracts != 'true'
+      run: echo "Contract compatibility gate skipped because this PR does not touch src/Meridian.Contracts/Workstation or src/Meridian.Contracts/Api." >> $GITHUB_STEP_SUMMARY
 
   config-schema:
     name: Config Schema Check

--- a/docs/status/contract-compatibility-matrix.md
+++ b/docs/status/contract-compatibility-matrix.md
@@ -39,6 +39,27 @@ This matrix defines compatibility commitments for:
 2. New request fields must be optional for at least one full deprecation window.
 3. Endpoint handlers must continue accepting prior payload shapes during the deprecation window.
 
+
+## Continuity DTO/API Route Change Policy (Run/Portfolio/Ledger/Cash-Flow/Reconciliation)
+
+The following continuity contract families are shared between workstation clients and service boundaries:
+
+- Run continuity DTOs (execution session/replay and run status payloads).
+- Portfolio continuity DTOs (position, exposure, account summary, and snapshot payloads).
+- Ledger continuity DTOs (entries, balances, posting snapshots, and ledger health summaries).
+- Cash-flow continuity DTOs (cash ladder/event projections and run cash-flow projections).
+- Reconciliation continuity DTOs and API routes (break queues, operator inbox/review routes, and sign-off projections).
+
+Policy requirements:
+
+1. **Additive changes are preferred.** New optional/nullable members are allowed when old clients can ignore them safely.
+2. **Non-additive changes require migration notes.** Any DTO member removal, rename, type narrowing, enum member removal, route removal, or route parameter rename is treated as potential breaking continuity impact.
+3. **Migration notes must be explicit.** For each non-additive change, add a dated entry in **Migration Notes** documenting:
+   - impacted continuity DTOs/routes,
+   - compatibility shim/deprecation window (or waiver reference),
+   - downstream consumer action required (desktop, web, automation, or external integrations).
+4. **PR evidence is mandatory.** PRs with non-additive continuity changes must include a contract-review packet artifact link plus a PR-body migration-note snippet summarizing consumer impact and rollout guidance.
+
 ## Deprecation and Migration Policy
 
 | Change type | Minimum deprecation window | Required mitigation |

--- a/tests/scripts/test_check_contract_compatibility_gate.py
+++ b/tests/scripts/test_check_contract_compatibility_gate.py
@@ -88,6 +88,26 @@ diff --git a/src/Meridian.Strategies/Services/StrategyRunReadService.cs b/src/Me
 
         self.assertFalse(gate.patch_has_breaking_removal(patch))
 
+    def test_patch_has_breaking_removal_detects_continuity_dto_member_removal(self) -> None:
+        patch = """
+diff --git a/src/Meridian.Contracts/Workstation/ReconciliationContinuityDtos.cs b/src/Meridian.Contracts/Workstation/ReconciliationContinuityDtos.cs
+@@ -31 +31,0 @@ public sealed record ReconciliationContinuityDto(
+-    decimal PendingCashFlow,
+"""
+
+        self.assertTrue(gate.patch_has_breaking_removal(patch))
+
+
+    def test_patch_has_breaking_removal_detects_continuity_dto_member_rename(self) -> None:
+        patch = """
+diff --git a/src/Meridian.Contracts/Workstation/LedgerContinuityDtos.cs b/src/Meridian.Contracts/Workstation/LedgerContinuityDtos.cs
+@@ -18 +18 @@ public sealed record LedgerContinuityDto(
+-    decimal SettledCash,
++    decimal AvailableCash,
+"""
+
+        self.assertTrue(gate.patch_has_breaking_removal(patch))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/scripts/test_generate_contract_review_packet.py
+++ b/tests/scripts/test_generate_contract_review_packet.py
@@ -147,6 +147,29 @@ diff --git a/src/Meridian.Contracts/Api/UiApiRoutes.cs b/src/Meridian.Contracts/
         self.assertIn("src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs", markdown)
         self.assertIn("workstation-endpoints", markdown)
 
+    def test_build_review_packet_blocks_continuity_member_rename_without_migration_notes(self) -> None:
+        patch = """
+diff --git a/src/Meridian.Contracts/Workstation/PortfolioContinuityDtos.cs b/src/Meridian.Contracts/Workstation/PortfolioContinuityDtos.cs
+@@ -22 +22 @@ public sealed record PortfolioContinuityDto(
+-    decimal UnsettledCash,
++    decimal PendingCash,
+"""
+
+        packet = packet_module.build_review_packet(
+            base_ref="origin/main",
+            head_ref="HEAD",
+            changed_files=["src/Meridian.Contracts/Workstation/PortfolioContinuityDtos.cs"],
+            patch=patch,
+            matrix_doc_path="docs/status/contract-compatibility-matrix.md",
+            matrix_updated=False,
+            matrix_migration_note_added=False,
+            pr_migration_notes_present=False,
+            generated_at_utc="2026-04-27T00:00:00+00:00",
+        )
+
+        self.assertEqual(packet["summary"]["contractChangeCategory"], "potential-breaking")
+        self.assertFalse(packet["summary"]["readyForCadenceReview"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Ensure continuity DTO/API-route changes under `src/Meridian.Contracts/Workstation/` and `src/Meridian.Contracts/Api/` always run the contract scripts and produce a review packet so breaking continuity changes cannot merge without migration evidence.
- Make PR guidance and the compatibility matrix explicit for run/portfolio/ledger/cash-flow/reconciliation continuity surfaces so authors know required migration-note and packet requirements.

### Description
- Make the `contract-compatibility` job in `.github/workflows/pr-checks.yml` detect continuity contract changes using `dorny/paths-filter` for `src/Meridian.Contracts/Workstation/**` and `src/Meridian.Contracts/Api/**`, and conditionally run the compatibility gate, packet generation, and artifact upload when those paths are touched, while leaving the job required for PRs.
- Add a skip-summary step that emits a job-note when no continuity contract files changed to clarify when the gate is intentionally skipped.
- Add a new `## Continuity DTO/API Route Change Policy (Run/Portfolio/Ledger/Cash-Flow/Reconciliation)` section to `docs/status/contract-compatibility-matrix.md` with explicit policy about non-additive changes and required migration-note evidence and packet artifacts.
- Extend the PR entry form `.github/PULL_REQUEST_TEMPLATE.md` checklist with `Contract review packet artifact link added` and `Migration note snippet added in PR body` items for shared-contract deltas.
- Add unit tests to `tests/scripts/test_check_contract_compatibility_gate.py` and `tests/scripts/test_generate_contract_review_packet.py` covering continuity DTO member removal and rename scenarios and the expected packet/heuristic behavior.

### Testing
- Ran the updated script unit tests with `python3 -m unittest tests/scripts/test_check_contract_compatibility_gate.py tests/scripts/test_generate_contract_review_packet.py`, and all tests passed (`OK`).
- Verified the new workflow changes make the contract gate and packet generation conditional on continuity path changes while still uploading the packet artifact when those paths are touched by a PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26724c5408320987ee851d13ea81d)