### PR TITLE
Harden Copilot restore step with Linux fallback

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -54,7 +54,14 @@ jobs:
 
       - name: Restore .NET dependencies
         shell: bash
-        run: dotnet restore Meridian.sln -p:EnableWindowsTargeting=true --verbosity minimal
+        run: |
+          set -euo pipefail
+          if dotnet restore Meridian.sln -p:EnableWindowsTargeting=true --verbosity minimal; then
+            exit 0
+          fi
+
+          echo "Primary restore with EnableWindowsTargeting=true failed; retrying without Windows targeting to keep Copilot setup usable on Linux-only runners."
+          dotnet restore Meridian.sln --verbosity minimal
 
       - name: Build solution
         id: build


### PR DESCRIPTION
### Motivation
- Ensure the Copilot environment setup remains usable on Linux-only runners by providing a fallback when the Windows-targeted `dotnet restore` fails.

### Description
- Replace the single-line `dotnet restore Meridian.sln -p:EnableWindowsTargeting=true` step in `.github/workflows/copilot-setup-steps.yml` with a safe, `set -euo pipefail` wrapper that first attempts the Windows-targeting restore and, on failure, logs a message and retries `dotnet restore Meridian.sln` without `EnableWindowsTargeting`.

### Testing
- Attempted `dotnet restore Meridian.sln -p:EnableWindowsTargeting=true` locally in this container, which failed because `dotnet` is not installed (`/bin/bash: dotnet: command not found`), so CI restore/build/test steps could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27a1b87c08320ac571b2505cf32a0)