### PR TITLE
Add Meridian differentiation report for 2026-04-29

### DIFF
--- a/docs/plans/meridian-main-differentiation-report-2026-04-29.md
+++ b/docs/plans/meridian-main-differentiation-report-2026-04-29.md
@@ -1,0 +1,273 @@
+# Meridian-main differentiation report
+
+*Date: 2026-04-29 — America/Phoenix*
+
+## Executive summary
+
+I would not position Meridian-main as “another trading workstation” or “another front-to-back suite.” The market is already full of platforms that sell unified trade capture, accounting, reconciliation, and reporting: FundStudio emphasizes trade lifecycle, reconciliation, shadow NAV, reporting, managed services, and auditability; Enfusion emphasizes a single golden data set, integrated PMS/OEMS/accounting, APIs, and managed services; SimCorp emphasizes IBOR-to-ABOR continuity and real-time accounting/reporting; Arcesium emphasizes a synchronized golden source, reconciliation, and unified books; Addepar emphasizes integrations, reporting, and APIs; and ModelOp emphasizes inventory, evidence capture, controls, and policy workflows. That means Meridian wins only if it owns a sharper category.
+
+The best category is **evidence-backed investment operations**: trusted data, research runs, paper validation, ledger impact, reconciliation outcomes, and governed report artifacts all tied together in one explainable chain. That is where Meridian can be more defensible than generalist competitors, because the accessible project context already shows meaningful strengths in provider-agnostic data collection, historical backfill, paper trading, strategy lifecycle management, ledger-based P&L, web APIs, observability, and both WPF and web surfaces.
+
+If I were optimizing purely for differentiation and user value, I would prioritize eight things: a Run Evidence Graph and Evidence Vault, a Governed Report Pack Studio, a Reconciliation Desk, accounting-grade PaperOps, Shadow Books and Shadow NAV, a Strategy Passport, a Data Trust Passport, and an Operator Readiness Console. Together, those modules create a product story that competitors hint at from different angles but do not publicly frame the same way: **prove every investment decision from data to books to report**.
+
+## Assumptions and unknowns
+
+I could not directly inspect the live Meridian GitHub README, the current open-issues backlog, or current CI failures from a public repo endpoint, so those items remain **unspecified**. My working view of the project comes from an author-maintained public Meridian skill, plus the design-system archive and screenshots you supplied locally. The public skill describes Meridian as a provider-agnostic .NET 9 / C# 13 platform spanning real-time and historical market data collection, backtesting, live and simulated execution, strategy lifecycle management, a `PaperTradingGateway`, ledger-based P&L, a WPF desktop app, a web dashboard, MCP tooling, OpenTelemetry, and 33 CI/CD workflows.
+
+From the user-supplied design-system archive, I am also assuming that the active commercial UI direction is browser-first for new operator workflows, with WPF retained as a Windows shell and compatibility surface. I also infer that the intended web workspaces are Overview, Research, Trading, Data Operations, and Governance. Because those files are local artifacts rather than publicly searchable sources, I treat them as context rather than independently verifiable public evidence.
+
+A concise repo-state read, with unspecified items marked explicitly, looks like this:
+
+| Area | My working assumption | Confidence |
+|---|---|---|
+| Core product scope | Data collection, backtesting, execution, and strategy lifecycle are real pillars | High |
+| Paper trading | Present and material because `PaperTradingGateway` is called out publicly | High |
+| Ledger and accounting seam | Present at least at ledger-based P&L level; broader accounting depth is unspecified | Medium |
+| Reconciliation depth | Some capability is implied by prior context, but current casework maturity is unspecified | Medium-low |
+| Web-first direction | Likely active for new UX, based on the supplied design system | Medium-high |
+| WPF status | Still real and should be preserved for compatibility | High |
+| Open issues / failing checks | Unspecified |
+| Current report-pack implementation | Unspecified |
+| External integration coverage | Some APIs exist; breadth of ingest/export connectors is unspecified | Medium-low |
+
+In short, I am assuming Meridian already has enough raw capability to be commercially meaningful. The open question is not “what can it do at all,” but “what product category does it want to own, and what features make that claim credible?”
+
+## Where Meridian can stand apart
+
+The investment-operations market already proves that buyers will pay for unified workflows, reconciliation, shadow NAV, accounting, reporting, APIs, and managed services. FundStudio markets trade lifecycle to reconciliation, shadow NAV, and institutional reporting; Enfusion markets a single golden data set, automatically reconciled general ledger, shadow NAV, and APIs; SimCorp markets IBOR/ABOR continuity and real-time accounting; Arcesium markets a synchronized golden source, reconciliation, and unified books; and Addepar markets integrations, dynamic reporting, and API-based workflow extension.
+
+What none of those public descriptions emphasizes as strongly is a **research-to-books proof chain**. Meridian can differentiate by connecting upstream research and paper validation to downstream books, reconciliation, and reporting. That is a stronger wedge than trying to match full OMS breadth, full enterprise accounting depth, or broad generic analytics. It also fits the realities of a shorter settlement cycle: the U.S. Securities and Exchange Commission moved standard settlement to T+1 and explicitly tied the change to operational preparedness, institutional trade processing, and straight-through processing requirements, which raises the value of clean evidence, fast reconciliation, and fewer manual handoffs.
+
+I would summarize the market and Meridian’s wedge this way:
+
+| Crowded market theme | What competitors already prove | Meridian’s sharper wedge |
+|---|---|---|
+| Unified trade-to-report operations | FundStudio, Enfusion, SimCorp, Arcesium all market this | Research-to-report with continuous evidence lineage |
+| Reconciliation and shadow NAV | FundStudio, Enfusion, Arcesium all stress this | Reconciliation linked directly to runs, fills, ledger journals, and promotion history |
+| APIs and integrations | Enfusion and Addepar make this table stakes | Evidence APIs, not just positions/cash APIs |
+| Governance workflows | ModelOp proves inventory + evidence + approvals matter | Strategy Passport focused on promotion discipline, not generic enterprise governance |
+| Reporting | FundStudio, SimCorp, Addepar all treat reporting as a product | Governed report packs with line-level provenance back to evidence objects |
+
+That leads to one commercial claim I would keep repeating:
+
+> Meridian should become the system of record for investment decision evidence, not just the place where trades or reports happen.
+
+## The highest-value differentiation bets
+
+The table below is my longlist of twelve ideas, prioritized by user value and strategic fit rather than by novelty alone. I am using small, medium, and large effort estimates as directional planning shorthand.
+
+| Idea | Primary users | Commercial value | Effort | Current-repo dependency | Required data / models / APIs | Minimal viable scope | Package fit | Main risk |
+|---|---|---:|---:|---|---|---|---|---|
+| Run Evidence Graph & Evidence Vault | CIO, research lead, COO | Very high | M | Leverages runs, paper trading, ledger, web APIs already described publicly | `EvidenceNode`, `EvidenceEdge`, `EvidenceBundle`, lineage API | Seeded run-to-report evidence chain | Assurance | Over-designing a generic event lake |
+| Governed Report Pack Studio | COO, CFO/controller, IR | Very high | M | Depends on evidence objects and artifact generation | `ReportPackDefinition`, `Artifact`, `Approval`, render API | IC pack + promotion pack + close pack | Assurance, FundOps | Template sprawl |
+| Reconciliation Desk | Ops lead, controller, fund admin | Very high | M | Depends on internal book views and external-file ingest | `ReconciliationCase`, `BreakGroup`, `ToleranceProfile`, case API | Cash + position + trade break casework | FundOps | Messy external file variance |
+| Accounting-Grade PaperOps | Trader, controller, CIO | High | M | Leverages paper trading and ledger P&L | `PaperSessionClose`, posting rules, journal bridge API | Paper session → journals → P&L bridge | Assurance, FundOps | Accounting scope explosion |
+| Shadow Books & Shadow NAV | Controller, COO | Very high | M-L | Depends on ledger and reconciliation primitives | `Book`, `ExternalStatement`, NAV compare API | Internal vs external cash/position/NAV compare | FundOps | Multi-currency / multi-entity complexity |
+| Strategy Passport | CIO, PM, compliance | High | M | Depends on runs, promotions, evidence | `StrategyVersion`, `Passport`, review checklist API | Version, owner, approved use, blockers | Assurance | Drifting into generic governance |
+| Data Trust Passport | Data ops, quant lead, compliance | High | S-M | Depends on provider metadata and run capture | `DatasetSnapshot`, gaps, fallback chain, hash summary | Provider/gap/fallback/replay card | Assurance | Incomplete metadata capture |
+| Operator Readiness Console | COO, desk lead, CTO | High | S-M | Leverages web dashboard and read models | overview DTOs, blocker API, confidence rail | Overview page with blockers and deep links | All packages | Becoming a passive dashboard |
+| Integration Hub | CTO, ops engineering | High | M | Depends on stable IDs and APIs | import profiles, webhooks, evidence export APIs | CSV ingest + report/evidence webhooks | Connect | Support burden |
+| Close Control | Controller, COO | Medium-high | M | Depends on reconciliation and books | close period, lock state, checklist API | Open / soft-close / locked period MVP | FundOps | Premature enterprise complexity |
+| Cash Ladder & Liquidity Planner | Controller, treasury, PM | Medium | S-M | Depends on cash events and unsettled activity | projected cash model, cash-view API | 7/30/90-day cash ladder | FundOps | Weak data quality upstream |
+| Evidence-based Permissions | Compliance, COO | Medium | M | Depends on roles and evidence status | role matrix, policy gates | Block actions when evidence is stale | Enterprise add-on | Friction if introduced too early |
+
+A more buyer-centered comparison of the top ideas looks like this:
+
+| Feature | Research lead / CIO | Trader / desk lead | COO / ops | Controller / CFO | CTO / platform | Revenue potential |
+|---|---|---|---|---|---|---:|
+| Evidence Graph | High | Medium | High | Medium | Medium | $$$$ |
+| Report Packs | Medium | Low | High | High | Low | $$$$ |
+| Reconciliation Desk | Low | Low | High | High | Medium | $$$$ |
+| Accounting-Grade PaperOps | High | High | Medium | High | Medium | $$$ |
+| Shadow Books | Low | Low | High | High | Medium | $$$$ |
+| Strategy Passport | High | Medium | Medium | Low | Low | $$$ |
+| Data Trust Passport | High | Medium | Medium | Medium | Medium | $$$ |
+| Readiness Console | Medium | High | High | Medium | Medium | $$$ |
+
+### Run Evidence Graph and Evidence Vault
+
+**One-sentence pitch:** I would make every dataset snapshot, run, paper session, fill, position state, ledger journal, reconciliation case, approval, and report artifact part of one linked evidence chain.
+
+**Buyer persona:** This is strongest for the research lead or CIO who wants promotion discipline, and for the COO who wants explainability across the lifecycle.
+
+**Why it differentiates:** Competitors already sell unified data, books of record, or reconciliation, but Meridian’s best wedge is to preserve proof from research through books and report artifacts. The accessible Meridian context already includes run archive, paper promotion, ledger-based P&L, a paper trading gateway, and web APIs, which means Meridian appears unusually close to supporting this kind of lineage without inventing a totally new category.
+
+**MVP scope:** I would start read-only: one seeded strategy version, one dataset snapshot, one run, one paper session, one journal set, one reconciliation case, and one report pack all visible on one evidence timeline.
+
+**Key implementation steps:** define canonical IDs and provenance metadata; create evidence summary DTOs; link existing run, paper, and ledger objects; add an evidence timeline view in the web dashboard; and support WPF deep links into the same objects rather than parallel WPF-only models.
+
+**Required repo changes / services:** a shared evidence domain, evidence read-model APIs, artifact metadata storage, and adapters from existing run, paper, and ledger flow. Exact file boundaries are unspecified.
+
+**Risks / blockers:** a graph that is too generic becomes architecture theater. I would keep the first cut tightly bound to the golden path only.
+
+**Validation plan:** one deterministic seeded scenario should render the full chain; missing linkage should be measured as evidence completeness; and a user should be able to click from report artifact to journal to fill to run without leaving the shell.
+
+**Effort:** M.
+
+### Governed Report Pack Studio
+
+**One-sentence pitch:** I would turn Meridian outputs into deliverables that managers, controllers, and investors can actually consume: IC packs, promotion packs, reconciliation packs, and close packs.
+
+**Buyer persona:** COO, controller, investor relations, and smaller managers who need professional reporting without a massive reporting stack.
+
+**Why it differentiates:** FundStudio markets a drag-and-drop reporting engine, shadow-NAV packs, and scheduled distribution; SimCorp and Addepar also treat reporting as a core product surface. Meridian’s differentiator should be that every report section is traceable back to the evidence graph, not just to an abstract data warehouse.
+
+**MVP scope:** two packs first: a Strategy Promotion Pack and a Reconciliation / Close Pack, each with provenance sections and approval metadata.
+
+**Key implementation steps:** define pack definitions, artifact versioning, approval status, line-level provenance hooks, and a simple HTML/PDF render path from evidence objects.
+
+**Required repo changes / services:** `ReportPackDefinition`, artifact store metadata, render service, line-provenance adapters, and dashboard views.
+
+**Risks / blockers:** the risk is a generic report builder that ships late and solves nothing. I would begin with a fixed pack library, not a fully configurable studio.
+
+**Validation plan:** every seeded golden-path run should generate a promotion pack in under a minute; every section should deep-link to its source evidence; and versioned reruns should make deltas visible.
+
+**Effort:** M.
+
+### Reconciliation Desk
+
+**One-sentence pitch:** I would convert reconciliation from a queue or table into a casework product with ownership, tolerances, sign-offs, and evidence links.
+
+**Buyer persona:** Operations lead, controller, fund admin liaison, and any team that wakes up every morning to trade, cash, and position breaks.
+
+**Why it differentiates:** FundStudio, Enfusion, and Arcesium all market reconciliation and exception management; T+1 also increases the pressure to resolve operational discrepancies faster. Meridian’s opportunity is to make each break explainable in upstream context by linking it directly to runs, fills, journals, mappings, and report impact.
+
+**MVP scope:** three break classes: cash, position, and trade; plus owner, severity, status, tolerance profile, comments, and closure note.
+
+**Key implementation steps:** build import profiles for external statements; normalize external versus internal records; create `ReconciliationCase` and `BreakGroup`; and expose case lists, aging, and detail drill-ins in the dashboard.
+
+**Required repo changes / services:** ingest/mapping layer, reconciliation normalization service, casework models, and case APIs. Existing reconciliation depth is unspecified, so some foundational work may be needed.
+
+**Risks / blockers:** external-file variability can derail the first release. I would keep the MVP to a narrow set of CSV patterns and seeded cases.
+
+**Validation plan:** ship with three demo breaks; prove assignment, comment history, closure audit trail, and evidence drill-through; and measure median time-to-resolution in pilot use.
+
+**Effort:** M.
+
+### Accounting-grade PaperOps
+
+**One-sentence pitch:** I would make Meridian’s paper environment produce books, not just simulated fills.
+
+**Buyer persona:** Traders, systematic PMs, research leads, and controllers who want to know what a strategy would do to both positions and the books before real capital is committed.
+
+**Why it differentiates:** The accessible Meridian context already includes paper trading and ledger-based P&L, which is a rare combination. FundStudio and Enfusion both publicize order-to-accounting continuity; Meridian can go one step further by making *paper* order flow generate journals, cash movements, P&L bridges, and audit evidence before anything goes live.
+
+**MVP scope:** one paper session produces fills, allocations, position updates, cash movements, journal entries, and a trial-balance-style summary.
+
+**Key implementation steps:** define paper-session close logic; map security and cash events into postings; create a run-to-ledger bridge UI; and attach all outputs to the evidence graph.
+
+**Required repo changes / services:** paper-session close processor, posting projection rules, journal summary read models, and bridge endpoints.
+
+**Risks / blockers:** true accounting depth can sprawl. I would keep the first cut to one asset mix and one account model.
+
+**Validation plan:** one deterministic paper session should always produce the same journals and the same end-state balances; controllers should be able to explain end cash and P&L from the generated postings.
+
+**Effort:** M.
+
+### Shadow Books and Shadow NAV
+
+**One-sentence pitch:** I would let Meridian maintain internal books and compare them against brokers, custodians, or fund administrators.
+
+**Buyer persona:** Controller, COO, family office operator, and emerging manager that wants institutional-grade oversight without outsourcing all intelligence.
+
+**Why it differentiates:** FundStudio and Enfusion both make shadow NAV a visible selling point, and Addepar’s ecosystem even includes integrations that transform portfolio data into journal entries for a general ledger. That tells me the market values internal replication of external reporting. Meridian can differentiate by tying shadow books directly to research, paper validation, and reconciliation evidence instead of treating them as a separate accounting island.
+
+**MVP scope:** import one external statement format, compare against Meridian internal cash and positions, compute a shadow NAV summary, and generate exception cases when the two diverge.
+
+**Key implementation steps:** create `Book` and `ExternalStatement` abstractions; normalize cash and positions; compare and classify breaks; surface NAV variance; and feed those results into Reconciliation Desk and Report Pack Studio.
+
+**Required repo changes / services:** external statement model, book compare service, shadow NAV summary API, and close/report integrations.
+
+**Risks / blockers:** multi-entity and multi-currency complexity can balloon quickly. I would constrain the first deployment profile.
+
+**Validation plan:** controlled seed files should generate explainable NAV variance and reproducible breaks; variance should be traceable to specific journals or missing events.
+
+**Effort:** M-L.
+
+### Strategy Passport
+
+**One-sentence pitch:** I would give each strategy version a compact but formal operating record: owner, purpose, approved use, evidence status, and blockers.
+
+**Buyer persona:** CIO, PM, research lead, and compliance reviewer.
+
+**Why it differentiates:** ModelOp proves that inventory, evidence capture, and workflow controls are valuable, but Meridian should avoid building a generic enterprise AI-governance clone. A Strategy Passport is smaller, more sellable, and more relevant to Meridian’s research-to-paper-to-books path.
+
+**MVP scope:** strategy version, owner, approved use, linked runs, linked paper sessions, evidence completeness, open exceptions, and approval history.
+
+**Key implementation steps:** define the passport object; map run and promotion artifacts into it; add required-check states; surface visible blockers; and attach passport sections to report packs.
+
+**Required repo changes / services:** strategy version registry, promotion checklist/read models, review/approval metadata, and passport endpoints.
+
+**Risks / blockers:** this will lose focus if it becomes a general policy engine. I would keep it opinionated around Meridian’s golden path.
+
+**Validation plan:** every seeded strategy should have one passport; a strategy with stale evidence should visibly fail readiness; and the reason should trace to the exact missing artifact.
+
+**Effort:** M.
+
+### Data Trust Passport
+
+**One-sentence pitch:** I would attach a compact confidence record to every run and every pack so users can see whether the data was trustworthy before they trust the conclusions.
+
+**Buyer persona:** Quant lead, data-ops lead, PM, and compliance reviewer.
+
+**Why it differentiates:** SimCorp, Enfusion, and FundStudio all sell data integrity and centralized data as a core promise; Meridian can differentiate by making provider choice, fallback use, coverage gaps, and replay evidence visible at the decision point instead of hidden in infrastructure. The public Meridian context already describes provider failover, historical backfill, and data quality monitoring, so this is a natural extension.
+
+**MVP scope:** provider, symbols, date range, gap count, fallback chain invocation, validation age, and replay hash summary.
+
+**Key implementation steps:** define `DatasetSnapshot`; capture provider/fallback metadata during runs; expose trust summaries in run detail, passport detail, and pack metadata; and add an overview summary in the readiness console.
+
+**Required repo changes / services:** snapshot model, provider-health and validation adapters, replay summary metadata, and summary endpoints.
+
+**Risks / blockers:** if current runs do not persist enough source metadata, retrofitting may be harder than expected.
+
+**Validation plan:** seeded runs with different provider and gap scenarios should display different trust states; trust state should block downstream actions when policy says it must.
+
+**Effort:** S-M.
+
+### Operator Readiness Console
+
+**One-sentence pitch:** I would make the browser dashboard’s Overview workspace the place where an operator knows, in two seconds, what is blocked and why.
+
+**Buyer persona:** COO, desk lead, CTO, and any daily operator.
+
+**Why it differentiates:** This is not the deepest module, but it is the best demo and the highest day-to-day usability win. FundStudio’s homepage repeatedly sells “one view,” “operational command,” and clean morning workflows; Meridian’s best response is an evidence-aware command surface, not a prettier generic dashboard. Public Meridian context already includes a web dashboard, and your supplied design-system materials clearly point toward a cockpit-style browser shell.
+
+**MVP scope:** one page with provider trust, latest run, active paper session, open reconciliation cases, due report packs, and stale evidence blockers, plus a persistent confidence rail.
+
+**Key implementation steps:** create overview DTOs; design blocker cards with direct actions; support workspace deep links; and keep WPF as a client that launches or mirrors the same read models rather than duplicating them.
+
+**Required repo changes / services:** read-model composition service, overview APIs, blocker endpoints, shared state vocabulary, and screenshot-based acceptance checks.
+
+**Risks / blockers:** dashboards that do not drive action quickly become wallpaper. I would require every card to show state, ownership, and next action.
+
+**Validation plan:** time-to-answer tests for common scenarios, screenshot regression checks for healthy and blocked states, and click-depth metrics from overview to resolution path.
+
+**Effort:** S-M.
+
+## Packaging and sequencing
+
+I would package Meridian around workflows, not around technical subsystems. That is how competitors make complex stacks understandable to buyers, and it also aligns better with the accessible Meridian context than selling “modules” in a vacuum. FundStudio sells to roles and operational workflows, Enfusion sells front-to-back outcomes on one data set, SimCorp sells lifecycle continuity, and Addepar sells integrations plus reporting. Meridian should do the same, but with an evidence-first message.
+
+Three commercial packages make the most sense to me:
+
+| Package | Positioning | Included value | Target buyer | Pricing hypothesis |
+|---|---|---|---|---:|
+| **Meridian Assurance** | “Prove every strategy decision before capital is at risk.” | Evidence Graph, Data Trust Passport, Strategy Passport, Operator Readiness Console, Promotion and IC packs | CIO, quant lead, emerging manager | $40k–$90k ARR + onboarding |
+| **Meridian FundOps Control** | “Run shadow books, reconcile faster, and close with confidence.” | Reconciliation Desk, Shadow Books, accounting-grade PaperOps, close and reconciliation packs, readiness views | COO, controller, family office ops | $100k–$225k ARR + implementation |
+| **Meridian Connect Enterprise** | “Make your evidence, books, and workflows programmable.” | APIs, imports/exports, evidence delivery, webhooks, reporting artifacts, selected Assurance/FundOps modules | CTO, platform lead, larger manager | $180k–$400k ARR + custom implementation |
+
+I would sequence the work in a very opinionated way. First, make one golden-path demo undeniable: trusted data, research run, paper session, journal bridge, reconciliation case, report artifact. Second, productize the evidence and report surfaces because they make the story visible. Third, add the operational workflows — reconciliation and shadow books — that generate recurring pain relief. Only after that would I spend heavily on broader integration breadth, extra analytics, or more OMS-like surface area. That order matches both user value and commercial clarity.
+
+A compact first ninety days would look like this:
+
+| Window | Focus | Deliverables | Success criteria |
+|---|---|---|---|
+| First month | Lock the product claim | One seeded golden-path scenario; evidence schema; Overview read models | One live demo from trusted data to promotion pack |
+| Middle month | Ship the visible proof | Data Trust Passport, Strategy Passport, Report Pack MVP, Readiness Console MVP | Every seeded strategy has a visible passport and trust state |
+| Final month | Ship the daily ops value | Reconciliation Desk MVP, basic Shadow Books compare, close/report proof | Three seeded breaks resolved end-to-end; one shadow-NAV variance workflow demo |
+
+## Next steps
+
+If I were guiding Meridian-main from here, I would do four things immediately. I would first lock the category statement: **Meridian is an evidence-backed investment operations platform**, not a generic workstation. I would then pick one design-partner persona — probably an emerging hedge fund COO/controller pair or a family office operator — because those users feel the pain of paper validation, shadow books, reconciliation, and reporting most directly. Third, I would standardize one seeded golden-path scenario and refuse to ship features that do not strengthen it. Fourth, I would turn the next quarter into proof of two ideas only: the Evidence Graph and the Report / Reconciliation surface. Those two bets make every later feature easier to explain, sell, test, and trust.
+
+What I would *not* prioritize yet is broad live-broker sprawl, a giant analytics workbench, or a bank-style governance framework. Those categories are expensive, crowded, and easy to make incoherent. Meridian’s clearest path to more user value is not more breadth. It is tighter continuity: data trust, paper validation, books, reconciliation, and governed output, all in one explainable chain.


### PR DESCRIPTION
### Motivation
- Add a canonical planning document that captures the 2026-04-29 Meridian-main differentiation analysis, product positioning, prioritized bets, and a 90-day sequencing plan.

### Description
- Add the documentation file `docs/plans/meridian-main-differentiation-report-2026-04-29.md` containing the executive summary, assumptions/unknowns, differentiation thesis, prioritized feature bets (e.g., Evidence Graph, Report Pack Studio, Reconciliation Desk, PaperOps, Shadow Books, Strategy/Data Passports, Readiness Console), packaging proposals, sequencing, and next steps.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f28f74f7f483209c0653617bcd1e64)