### PR TITLE
Normalize near-zero negative option ask prices

### DIFF
--- a/src/Meridian.Contracts/Domain/Models/OptionQuote.cs
+++ b/src/Meridian.Contracts/Domain/Models/OptionQuote.cs
@@ -127,7 +127,9 @@ public sealed record OptionQuote : MarketEventPayload
         if (BidPrice < 0)
             throw new ArgumentOutOfRangeException(nameof(BidPrice), BidPrice, "Bid price cannot be negative");
 
-        if (AskPrice < 0)
+        var normalizedAskPrice = NormalizePrice(AskPrice);
+
+        if (normalizedAskPrice < 0)
             throw new ArgumentOutOfRangeException(nameof(AskPrice), AskPrice, "Ask price cannot be negative");
 
         if (UnderlyingPrice <= 0)
@@ -138,7 +140,7 @@ public sealed record OptionQuote : MarketEventPayload
         this.Contract = Contract ?? throw new ArgumentNullException(nameof(Contract));
         this.BidPrice = BidPrice;
         this.BidSize = BidSize;
-        this.AskPrice = AskPrice;
+        this.AskPrice = normalizedAskPrice;
         this.AskSize = AskSize;
         this.UnderlyingPrice = UnderlyingPrice;
         this.LastPrice = LastPrice;
@@ -188,4 +190,10 @@ public sealed record OptionQuote : MarketEventPayload
     /// Values &gt; 1 indicate in-the-money for calls; &lt; 1 for puts.
     /// </summary>
     public decimal Moneyness => Contract.Strike > 0 ? UnderlyingPrice / Contract.Strike : 0m;
+    private static decimal NormalizePrice(decimal price)
+    {
+        const decimal epsilon = 0.00000000000001m;
+        return price < 0m && price > -epsilon ? 0m : price;
+    }
+
 }

--- a/tests/Meridian.Tests/Domain/Models/OptionQuoteTests.cs
+++ b/tests/Meridian.Tests/Domain/Models/OptionQuoteTests.cs
@@ -81,6 +81,24 @@ public sealed class OptionQuoteTests
             .Which.ParamName.Should().Be("AskPrice");
     }
 
+
+    [Fact]
+    public void Constructor_WithNearZeroNegativeAskPrice_NormalizesToZero()
+    {
+        var quote = CreateQuote(askPrice: -0.0000000000000087380782937286m);
+
+        quote.AskPrice.Should().Be(0m);
+    }
+
+    [Fact]
+    public void Constructor_WithMateriallyNegativeAskPrice_ThrowsArgumentOutOfRangeException()
+    {
+        var act = () => CreateQuote(askPrice: -0.00000000000002m);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .Which.ParamName.Should().Be("AskPrice");
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]


### PR DESCRIPTION
### Motivation
- A tiny negative ask value (e.g. -8.7e-15) appeared due to floating/decimal precision drift and caused an `ArgumentOutOfRangeException` even though it is noise. 
- Harden domain validation so rounding noise is normalized to zero while preserving strict rejection for materially negative prices.

### Description
- Add a private `NormalizePrice(decimal)` helper to `src/Meridian.Contracts/Domain/Models/OptionQuote.cs` that clamps tiny negative values (epsilon = `0.00000000000001m`) to `0m`.
- Normalize `AskPrice` with `NormalizePrice` before performing the negative-value check and before storing into the record field in the constructor.
- Add two focused unit tests in `tests/Meridian.Tests/Domain/Models/OptionQuoteTests.cs` that assert near-zero negatives are normalized to `0m` and that materially negative values still throw `ArgumentOutOfRangeException`.

### Testing
- Added unit tests under `OptionQuoteTests`; attempted to run `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~OptionQuoteTests" --logger "console;verbosity=minimal"` but the environment lacked the `dotnet` runtime, so the test run failed in this container (no `dotnet` installed).
- The new tests are committed and ready to run in CI or a developer environment with `dotnet` present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f396db385c8320a438188f249fcda7)