### PR TITLE
Fix screenshot merge workflow TrimStart char handling

### DIFF
--- a/.github/workflows/refresh-screenshots.yml
+++ b/.github/workflows/refresh-screenshots.yml
@@ -435,7 +435,7 @@ jobs:
 
           foreach ($png in $pngs) {
             $artifactRoot = (Resolve-Path _artifacts).Path
-            $rel = $png.FullName.Substring($artifactRoot.Length).TrimStart('\\','/')
+            $rel = $png.FullName.Substring($artifactRoot.Length).TrimStart('\','/')
             $relNormalized = $rel.Replace('\\','/')
 
             # Each artifact is stored as: _artifacts/<artifact-name>/<original-path>/.../*.png


### PR DESCRIPTION
### Motivation
- Fix the failing "Commit screenshots → Merge downloaded PNGs into workspace" step by addressing an invalid `TrimStart()` call that passed a two-character string for backslash and caused a runtime error (`String must be exactly one character long`).

### Description
- Update `.github/workflows/refresh-screenshots.yml` to use single-character char literals in the merge step by changing `TrimStart('\\','/')` to `TrimStart('\','/')` so PowerShell receives valid `char` arguments.

### Testing
- Verified the change and file contents with `sed -n '420,455p' .github/workflows/refresh-screenshots.yml`, committed the update with `git commit`, and inspected the edited lines with `nl -ba .github/workflows/refresh-screenshots.yml | sed -n '432,444p'`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3971bb4908320940f29da68b6118b)