### PR TITLE
Fix invalid Meridian.Domain.Enums import in ticker integration test

### DIFF
--- a/tests/Meridian.Tests/Integration/ConfigurableTickerDataCollectionTests.cs
+++ b/tests/Meridian.Tests/Integration/ConfigurableTickerDataCollectionTests.cs
@@ -4,7 +4,6 @@ using System.Text.Json.Serialization;
 using FluentAssertions;
 using Meridian.Infrastructure.Adapters.Core;
 using Meridian.Infrastructure.Adapters.YahooFinance;
-using Meridian.Domain.Enums;
 using Xunit;
 using Xunit.Abstractions;
 


### PR DESCRIPTION
### Motivation
- The integration test `ConfigurableTickerDataCollectionTests` failed to compile due to an incorrect `using Meridian.Domain.Enums;` directive that references a non-existent namespace, causing a build error for `DataGranularity` resolution.

### Description
- Removed the invalid `using Meridian.Domain.Enums;` line from `tests/Meridian.Tests/Integration/ConfigurableTickerDataCollectionTests.cs` so the test resolves `DataGranularity` from the existing `Meridian.Infrastructure.Adapters.Core` namespace where the enum is declared.

### Testing
- Attempted to run the focused test compilation with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ConfigurableTickerDataCollectionTests" --no-restore`, but the environment does not have `dotnet` installed so the automated test could not be executed here (failed: `dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c48e4c5c832095fb1fc756fe4e77)