### PR TITLE
Add intraday granularity configuration to Yahoo ticker artifact exports

### DIFF
--- a/tests/Meridian.Tests/Integration/ConfigurableTickerDataCollectionTests.cs
+++ b/tests/Meridian.Tests/Integration/ConfigurableTickerDataCollectionTests.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using FluentAssertions;
+using Meridian.Domain.Enums;
 using Meridian.Infrastructure.Adapters.Core;
 using Meridian.Infrastructure.Adapters.YahooFinance;
 using Xunit;
@@ -92,9 +93,14 @@ public sealed class ConfigurableTickerDataCollectionTests : IDisposable
             return DataGranularity.Minute15;
         }
 
-        return Enum.TryParse<DataGranularity>(envValue, ignoreCase: true, out var granularity)
-            ? granularity
-            : DataGranularity.Minute15;
+        if (Enum.TryParse<DataGranularity>(envValue, ignoreCase: true, out var granularity))
+        {
+            return granularity;
+        }
+
+        System.Console.Error.WriteLine(
+            $"Unsupported YAHOO_TICKER_INTRADAY_GRANULARITY value '{envValueRaw}'. Falling back to {DataGranularity.Minute15}.");
+        return DataGranularity.Minute15;
     }
 
     private static string ToCsvCell(string value)

--- a/tests/Meridian.Tests/Integration/ConfigurableTickerDataCollectionTests.cs
+++ b/tests/Meridian.Tests/Integration/ConfigurableTickerDataCollectionTests.cs
@@ -282,6 +282,9 @@ public sealed class ConfigurableTickerDataCollectionTests : IDisposable
                 _output.WriteLine($"  Adjusted bars: {adjustedBarCount}");
                 _output.WriteLine($"  Written to: {adjustedPath}");
 
+                var rawSucceeded = false;
+                var intradaySucceeded = false;
+
                 // Attempt raw bars (may fail due to OHLC validation on some symbols)
                 try
                 {
@@ -341,7 +344,19 @@ public sealed class ConfigurableTickerDataCollectionTests : IDisposable
 
                     _output.WriteLine($"  Raw bars: {rawBarCount}");
                     _output.WriteLine($"  Written to: {rawPath}");
+                    rawSucceeded = true;
+                }
+                catch (Exception ex)
+                {
+                    _output.WriteLine($"  Raw bars FAILED: {ex.Message}");
 
+                    // Write error details
+                    var errorPath = Path.Combine(_outputDir, $"{symbol}_raw_bars_error.txt");
+                    await File.WriteAllTextAsync(errorPath, $"Error fetching raw bars for {symbol}:\n{ex}");
+                }
+
+                try
+                {
                     var intradayTo = DateTimeOffset.UtcNow;
                     var intradayFrom = intradayTo.AddDays(-5);
                     var intradayBars = await _provider.GetAggregateBarsAsync(
@@ -398,17 +413,22 @@ public sealed class ConfigurableTickerDataCollectionTests : IDisposable
 
                     _output.WriteLine($"  Intraday bars ({intradayGranularity}): {intradayBarCount}");
                     _output.WriteLine($"  Written to: {intradayPath}");
-                    status = "OK";
+                    intradaySucceeded = true;
                 }
                 catch (Exception ex)
                 {
-                    _output.WriteLine($"  Raw bars FAILED: {ex.Message}");
-                    status = "Adjusted OK, Raw failed";
-
-                    // Write error details
-                    var errorPath = Path.Combine(_outputDir, $"{symbol}_raw_bars_error.txt");
-                    await File.WriteAllTextAsync(errorPath, $"Error fetching raw bars for {symbol}:\n{ex}");
+                    _output.WriteLine($"  Intraday bars FAILED ({intradayGranularity}): {ex.Message}");
+                    var intradayErrorPath = Path.Combine(_outputDir, $"{symbol}_intraday_error.txt");
+                    await File.WriteAllTextAsync(intradayErrorPath, $"Error fetching intraday bars for {symbol} ({intradayGranularity}):\n{ex}");
                 }
+
+                status = (rawSucceeded, intradaySucceeded) switch
+                {
+                    (true, true) => "OK",
+                    (false, true) => "Adjusted+Intra OK",
+                    (true, false) => "Adjusted+Raw OK",
+                    _ => "Adjusted only",
+                };
 
                 successCount++;
             }


### PR DESCRIPTION
### Motivation
- Enable the Yahoo ticker artifact test to accept a configurable intraday resolution via `YAHOO_TICKER_INTRADAY_GRANULARITY` (defaulting to `DataGranularity.Minute15`) so CI artifacts can include intraday coverage without changing test code.

### Description
- Added `using Meridian.Domain.Enums;` to `tests/Meridian.Tests/Integration/ConfigurableTickerDataCollectionTests.cs` and updated `GetConfiguredIntradayGranularity()` to parse `YAHOO_TICKER_INTRADAY_GRANULARITY`, return the parsed `DataGranularity` when valid, and emit a clear warning before falling back to `DataGranularity.Minute15`.

### Testing
- Attempted to run the focused test with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ConfigurableTickerDataCollectionTests"`, but the environment does not have `dotnet` installed so the automated run failed with `dotnet: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c60a3258832093171dfd4d263d3a)