### PR TITLE
Fix web screenshot workflow shutdown hang

### DIFF
--- a/scripts/dev/capture-web-screenshots.mjs
+++ b/scripts/dev/capture-web-screenshots.mjs
@@ -123,7 +123,8 @@ function startViteServer(dashboardDir, host, port, logs) {
         BROWSER: "none",
         MERIDIAN_API_BASE_URL: process.env.MERIDIAN_API_BASE_URL ?? "http://127.0.0.1:8080"
       },
-      stdio: ["ignore", "pipe", "pipe"]
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: process.platform !== "win32"
     }
   );
 
@@ -134,25 +135,47 @@ function startViteServer(dashboardDir, host, port, logs) {
 }
 
 async function stopProcess(child) {
-  if (!child || child.killed || child.exitCode !== null) {
+  if (!child || child.exitCode !== null) {
     return;
   }
 
-  child.kill("SIGTERM");
-
-  await new Promise((resolve) => {
-    const timer = setTimeout(() => {
-      if (!child.killed) {
-        child.kill("SIGKILL");
-      }
-      resolve();
-    }, 5000);
-
-    child.once("exit", () => {
-      clearTimeout(timer);
-      resolve();
+  const waitForExit = (timeoutMs) =>
+    new Promise((resolve) => {
+      const timer = setTimeout(() => resolve(false), timeoutMs);
+      child.once("exit", () => {
+        clearTimeout(timer);
+        resolve(true);
+      });
     });
-  });
+
+  const killUnixGroup = (signal) => {
+    try {
+      process.kill(-child.pid, signal);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  if (process.platform === "win32") {
+    const taskkill = spawn("taskkill", ["/pid", String(child.pid), "/t", "/f"], { stdio: "ignore" });
+    await new Promise((resolve) => taskkill.once("exit", resolve));
+    return;
+  }
+
+  if (!killUnixGroup("SIGTERM")) {
+    child.kill("SIGTERM");
+  }
+
+  const exited = await waitForExit(5000);
+  if (exited) {
+    return;
+  }
+
+  if (!killUnixGroup("SIGKILL")) {
+    child.kill("SIGKILL");
+  }
+  await waitForExit(2000);
 }
 
 async function captureRoute(page, capture, outputDir, baseUrl, defaults, minBytes, minTextLength, timeoutMs) {


### PR DESCRIPTION
### Motivation
- The web screenshot workflow step could hang because the Vite dev server (spawned via `npm run dev`) and its child processes were not reliably torn down, leaving the capture step blocked waiting for process exit. 

### Description
- Launch the Vite server as a detached process group on Unix by setting `detached: process.platform !== "win32"` when spawning the `npm run dev` child process. 
- Replace the previous simple `child.kill` shutdown with a cross-platform `stopProcess` that waits for exit with timeouts and performs process-tree teardown. 
- On Unix, attempt to kill the server process group with `process.kill(-child.pid, signal)` and escalate from `SIGTERM` to `SIGKILL` if the process tree does not exit; on Windows use `taskkill /t /f` to ensure descendants are terminated. 
- Add bounded `waitForExit` logic so teardown does not block indefinitely and ensure the manifest/logs are still written after shutdown.

### Testing
- Ran `node scripts/dev/capture-web-screenshots.mjs --list` which returned the route list successfully, indicating the script parses config and starts without error (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f42a69a2808320a2b28b66927d4f94)