### PR TITLE
Polish workstation sidebar visual design

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/meridian/workspace-nav.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/workspace-nav.tsx
@@ -28,8 +28,13 @@ export function WorkspaceNav() {
 
   return (
     <aside className="operator-rail" aria-label={`${viewModel.brandTitle} ${viewModel.brandSubtitle}`}>
+      <header className="operator-rail-header">
+        <p className="operator-rail-title">{viewModel.brandTitle}</p>
+        <p className="operator-rail-subtitle">{viewModel.brandSubtitle}</p>
+      </header>
+
       <div className="operator-rail-section">{viewModel.modelEyebrow}</div>
-      <div className="mx-2 mb-3 rounded-lg border border-border/80 bg-card px-3 py-3 shadow-panel">
+      <div className="operator-rail-card">
         <p className="text-xs leading-5 text-muted-foreground">
           {viewModel.modelDescription}
         </p>
@@ -63,7 +68,7 @@ export function WorkspaceNav() {
         })}
       </nav>
 
-      <div className="mx-2 mt-5 rounded-lg border border-border bg-secondary/35 px-3 py-3 text-sm">
+      <div className="operator-rail-callout">
         <div className="eyebrow-label">{viewModel.deliveryEyebrow}</div>
         <div className="mt-2 font-semibold text-foreground">{viewModel.deliveryTitle}</div>
         <p className="mt-2 text-xs leading-5 text-muted-foreground">

--- a/src/Meridian.Ui/dashboard/src/styles/index.css
+++ b/src/Meridian.Ui/dashboard/src/styles/index.css
@@ -233,13 +233,40 @@
   .operator-rail {
     min-height: 0;
     overflow: auto;
-    padding: 0.75rem 0.625rem;
-    background: #08131f;
+    padding: 0.875rem 0.75rem;
+    background:
+      linear-gradient(180deg, rgba(19, 33, 49, 0.88) 0%, rgba(12, 22, 34, 0.96) 38%, rgba(8, 19, 31, 1) 100%);
     border-right: 1px solid var(--border-color);
   }
 
+  .operator-rail-header {
+    margin: 0 0.375rem 0.75rem;
+    padding: 0.75rem 0.75rem 0.6875rem;
+    border: 1px solid rgba(42, 178, 212, 0.18);
+    border-radius: var(--radius-lg);
+    background: linear-gradient(180deg, rgba(42, 178, 212, 0.12) 0%, rgba(42, 178, 212, 0.04) 100%);
+    box-shadow: var(--shadow-panel);
+  }
+
+  .operator-rail-title {
+    font-family: "Space Grotesk", "IBM Plex Sans", sans-serif;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #f6fbff;
+    line-height: 1.2;
+  }
+
+  .operator-rail-subtitle {
+    margin-top: 0.375rem;
+    font-family: "IBM Plex Mono", ui-monospace, monospace;
+    font-size: 0.625rem;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: rgba(96, 199, 231, 0.95);
+  }
+
   .operator-rail-section {
-    padding: 0.75rem 0.625rem 0.375rem;
+    padding: 0.625rem 0.625rem 0.375rem;
     font-family: "IBM Plex Mono", ui-monospace, monospace;
     font-size: 9.5px;
     text-transform: uppercase;
@@ -247,28 +274,39 @@
     color: var(--fg-muted);
   }
 
+  .operator-rail-card {
+    margin: 0 0.375rem 0.75rem;
+    border: 1px solid rgba(31, 52, 76, 0.95);
+    border-radius: var(--radius-lg);
+    background: linear-gradient(180deg, rgba(13, 24, 36, 0.95), rgba(10, 19, 29, 0.98));
+    padding: 0.75rem;
+    box-shadow: var(--shadow-panel);
+  }
+
   .operator-nav-item {
     display: grid;
     grid-template-columns: 16px minmax(0, 1fr) auto;
     gap: 0.5625rem;
     align-items: center;
-    min-height: 32px;
-    padding: 0.375rem 0.625rem;
-    border: 1px solid transparent;
-    border-radius: var(--radius-sm);
+    min-height: 34px;
+    padding: 0.4375rem 0.625rem;
+    border: 1px solid rgba(31, 52, 76, 0.2);
+    border-radius: var(--radius-md);
     color: var(--fg-muted);
     font-size: 0.75rem;
-    transition: background-color 200ms ease, border-color 200ms ease, color 200ms ease;
+    transition: background-color 180ms ease, border-color 180ms ease, color 180ms ease, transform 180ms ease;
   }
 
   .operator-nav-item:hover {
-    background: rgba(42, 178, 212, 0.06);
+    background: rgba(42, 178, 212, 0.08);
+    border-color: rgba(42, 178, 212, 0.2);
     color: #fff;
+    transform: translateY(-1px);
   }
 
   .operator-nav-item.active {
-    background: rgba(42, 178, 212, 0.10);
-    border-color: rgba(42, 178, 212, 0.28);
+    background: linear-gradient(90deg, rgba(42, 178, 212, 0.18) 0%, rgba(42, 178, 212, 0.1) 100%);
+    border-color: rgba(42, 178, 212, 0.35);
     box-shadow: inset 3px 0 0 var(--cyan-primary);
     color: #fff;
   }
@@ -281,6 +319,15 @@
 
   .operator-nav-item.active .operator-nav-status {
     color: var(--cyan-primary);
+  }
+
+  .operator-rail-callout {
+    margin: 1rem 0.375rem 0.5rem;
+    border: 1px solid rgba(31, 52, 76, 0.95);
+    border-radius: var(--radius-lg);
+    background: linear-gradient(180deg, rgba(20, 34, 49, 0.9) 0%, rgba(15, 28, 41, 0.95) 100%);
+    padding: 0.75rem;
+    box-shadow: var(--shadow-panel);
   }
 
   .workbench {


### PR DESCRIPTION
### Motivation
- Improve the workstation sidebar hierarchy and first-glance orientation by surfacing brand information and clarifying supporting copy. 
- Make the sidebar visually more professional and presentable with consistent card surfaces, refined typography, and higher-quality backgrounds. 
- Enhance navigation affordance and interaction polish so workspace rows feel precise and deliberate.

### Description
- Added a branded header block to the sidebar and replaced ad-hoc wrappers with semantic surface classes by updating `src/components/meridian/workspace-nav.tsx` to include `operator-rail-header`, `operator-rail-title`, and `operator-rail-subtitle` and to use `operator-rail-card` / `operator-rail-callout` wrappers. 
- Refined sidebar styling in `src/styles/index.css` by introducing a polished gradient rail background, card-style header and callout surfaces, adjusted spacing, improved typography, and subtle shadows. 
- Tuned navigation row presentation by updating `.operator-nav-item` spacing, borders, hover elevation (`transform`), transition timing, and a stronger active gradient/border treatment for clearer visual feedback.

### Testing
- Ran the component test suite for the sidebar with `cd src/Meridian.Ui/dashboard && npm run test -- workspace-nav`, which initially failed because `vitest` was not installed in `node_modules`. 
- Installed local dev dependencies with `cd src/Meridian.Ui/dashboard && npm install`. 
- Re-ran `cd src/Meridian.Ui/dashboard && npm run test -- workspace-nav` and observed all automated tests pass (`Test Files 2 passed, Tests 3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f42cf526c48320b0f7fd559a1a030f)