### PR TITLE
Inject real strategy factory into batch backtest sweeps

### DIFF
--- a/src/Meridian.Backtesting/BatchBacktestService.cs
+++ b/src/Meridian.Backtesting/BatchBacktestService.cs
@@ -75,6 +75,12 @@ public sealed class BatchBacktestRequest
 
     /// <summary>Maximum number of concurrent backtests. Defaults to ProcessorCount - 1.</summary>
     public int MaxConcurrency { get; init; } = Math.Max(1, Environment.ProcessorCount - 1);
+
+    /// <summary>Human-readable descriptor for the strategy used in each run.</summary>
+    public required string StrategyDescriptor { get; init; }
+
+    /// <summary>Builds a strategy instance for each parameter set in the sweep.</summary>
+    public required Func<IReadOnlyDictionary<string, object>, IBacktestStrategy> StrategyFactory { get; init; }
 }
 
 /// <summary>
@@ -83,6 +89,7 @@ public sealed class BatchBacktestRequest
 /// </summary>
 public sealed class BatchBacktestService : IBatchBacktestService
 {
+    private readonly Func<BacktestEngine, BacktestRequest, IBacktestStrategy, CancellationToken, Task<BacktestResult>> _runExecutor;
     private readonly ILogger<BatchBacktestService> _logger;
     private readonly Func<BacktestRequest, BacktestEngine> _engineFactory;
 
@@ -96,9 +103,21 @@ public sealed class BatchBacktestService : IBatchBacktestService
     public BatchBacktestService(
         ILogger<BatchBacktestService> logger,
         Func<BacktestRequest, BacktestEngine> engineFactory)
+        : this(
+            logger,
+            engineFactory,
+            static (engine, runRequest, strategy, ct) => engine.RunAsync(runRequest, strategy, null, ct))
+    {
+    }
+
+    internal BatchBacktestService(
+        ILogger<BatchBacktestService> logger,
+        Func<BacktestRequest, BacktestEngine> engineFactory,
+        Func<BacktestEngine, BacktestRequest, IBacktestStrategy, CancellationToken, Task<BacktestResult>> runExecutor)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _engineFactory = engineFactory ?? throw new ArgumentNullException(nameof(engineFactory));
+        _runExecutor = runExecutor ?? throw new ArgumentNullException(nameof(runExecutor));
     }
 
     /// <summary>
@@ -111,6 +130,8 @@ public sealed class BatchBacktestService : IBatchBacktestService
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(request.BaseRequest);
         ArgumentNullException.ThrowIfNull(request.ParameterGrid);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.StrategyDescriptor);
+        ArgumentNullException.ThrowIfNull(request.StrategyFactory);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(request.MaxConcurrency);
 
         var sw = Stopwatch.StartNew();
@@ -119,8 +140,8 @@ public sealed class BatchBacktestService : IBatchBacktestService
         var runs = new List<BatchBacktestRun>();
         var semaphore = new SemaphoreSlim(request.MaxConcurrency, request.MaxConcurrency);
 
-        _logger.LogInformation("Starting batch backtest with {Total} runs, max concurrency {MaxConcurrency}",
-            total, request.MaxConcurrency);
+        _logger.LogInformation("Starting batch backtest with {Total} runs, strategy {Strategy}, max concurrency {MaxConcurrency}",
+            total, request.StrategyDescriptor, request.MaxConcurrency);
 
         var tasks = request.ParameterGrid.Select((paramSet, index) =>
             RunSingleBacktestAsync(index, paramSet, request, semaphore, runs, completedCounter, total, progress, ct)
@@ -178,12 +199,10 @@ public sealed class BatchBacktestService : IBatchBacktestService
             {
                 var runRequest = ApplyParameters(request.BaseRequest, paramSet);
                 var engine = _engineFactory(runRequest);
-
-                // Create a simple strategy that does nothing (caller can extend with parameter-driven logic).
-                var strategy = new NoOpStrategy();
+                var strategy = request.StrategyFactory(paramSet);
 
                 result = await Task.Run(async () =>
-                    await engine.RunAsync(runRequest, strategy, null, ct).ConfigureAwait(false), ct)
+                    await _runExecutor(engine, runRequest, strategy, ct).ConfigureAwait(false), ct)
                     .ConfigureAwait(false);
 
                 _logger.LogInformation("Run {Index}/{Total} succeeded in {Duration}ms",
@@ -301,20 +320,4 @@ public sealed class BatchBacktestService : IBatchBacktestService
             _ => (TEnum)Enum.ToObject(typeof(TEnum), value)
         };
 
-    /// <summary>
-    /// Minimal no-op strategy for batch runs (caller can subclass to add parameter-driven logic).
-    /// </summary>
-    private sealed class NoOpStrategy : IBacktestStrategy
-    {
-        public string Name => "NoOp";
-
-        public void Initialize(IBacktestContext ctx) { }
-        public void OnTrade(Trade trade, IBacktestContext ctx) { }
-        public void OnQuote(BboQuotePayload quote, IBacktestContext ctx) { }
-        public void OnBar(HistoricalBar bar, IBacktestContext ctx) { }
-        public void OnOrderBook(LOBSnapshot snapshot, IBacktestContext ctx) { }
-        public void OnOrderFill(FillEvent fill, IBacktestContext ctx) { }
-        public void OnDayEnd(DateOnly date, IBacktestContext ctx) { }
-        public void OnFinished(IBacktestContext ctx) { }
-    }
 }

--- a/src/Meridian.Wpf/ViewModels/BatchBacktestViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/BatchBacktestViewModel.cs
@@ -579,8 +579,23 @@ public sealed class BatchBacktestViewModel : BindableBase, IDisposable, IDataErr
         {
             BaseRequest = baseRequest,
             ParameterGrid = BuildParameterGrid(),
-            MaxConcurrency = MaxConcurrency
+            MaxConcurrency = MaxConcurrency,
+            StrategyDescriptor = "NoOp",
+            StrategyFactory = static _ => new NoOpBatchSweepStrategy()
         };
+    }
+
+    private sealed class NoOpBatchSweepStrategy : IBacktestStrategy
+    {
+        public string Name => "NoOp";
+        public void Initialize(IBacktestContext ctx) { }
+        public void OnTrade(Trade trade, IBacktestContext ctx) { }
+        public void OnQuote(BboQuotePayload quote, IBacktestContext ctx) { }
+        public void OnBar(HistoricalBar bar, IBacktestContext ctx) { }
+        public void OnOrderBook(LOBSnapshot snapshot, IBacktestContext ctx) { }
+        public void OnOrderFill(FillEvent fill, IBacktestContext ctx) { }
+        public void OnDayEnd(DateOnly date, IBacktestContext ctx) { }
+        public void OnFinished(IBacktestContext ctx) { }
     }
 
     private IReadOnlyList<Dictionary<string, object>> BuildParameterGrid()

--- a/tests/Meridian.Backtesting.Tests/BatchBacktestServiceTests.cs
+++ b/tests/Meridian.Backtesting.Tests/BatchBacktestServiceTests.cs
@@ -1,0 +1,86 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Meridian.Backtesting;
+using Meridian.Backtesting.Engine;
+using Meridian.Backtesting.Portfolio;
+using Meridian.Backtesting.Sdk;
+
+namespace Meridian.Backtesting.Tests;
+
+public sealed class BatchBacktestServiceTests
+{
+    [Fact]
+    public async Task RunBatchAsync_UsesStrategyFactoryPerParameterSet_AndProducesDifferentiatedResults()
+    {
+        var service = new BatchBacktestService(
+            NullLogger<BatchBacktestService>.Instance,
+            _ => null!,
+            (_, runRequest, strategy, _) => Task.FromResult(CreateResult(runRequest, ((ParameterizedTestStrategy)strategy).Weight)));
+
+        var request = new BatchBacktestRequest
+        {
+            BaseRequest = CreateBaseRequest(),
+            ParameterGrid =
+            [
+                new Dictionary<string, object> { ["Weight"] = 1m, [nameof(BacktestRequest.InitialCash)] = 1_000m },
+                new Dictionary<string, object> { ["Weight"] = 3m, [nameof(BacktestRequest.InitialCash)] = 2_000m }
+            ],
+            MaxConcurrency = 1,
+            StrategyDescriptor = "ParameterizedTestStrategy",
+            StrategyFactory = static parameters => new ParameterizedTestStrategy(Convert.ToDecimal(parameters["Weight"]))
+        };
+
+        var summary = await service.RunBatchAsync(request, progress: null!, CancellationToken.None);
+
+        summary.Runs.Should().HaveCount(2);
+        summary.Runs.Select(run => run.Result!.Request.InitialCash).Should().BeEquivalentTo([1_000m, 2_000m]);
+        summary.Runs.Select(run => run.Result!.Metrics.NetPnl).Should().BeEquivalentTo([1_000m, 6_000m]);
+    }
+
+    private static BacktestRequest CreateBaseRequest()
+        => new(DateOnly.Parse("2025-01-01"), DateOnly.Parse("2025-01-10"), ["SPY"], 500m, 0.08, DataRoot: "/tmp");
+
+    private static BacktestResult CreateResult(BacktestRequest request, decimal weight)
+    {
+        var netPnl = request.InitialCash * weight;
+        var metrics = new BacktestMetrics(
+            request.InitialCash,
+            request.InitialCash + netPnl,
+            netPnl,
+            netPnl,
+            request.InitialCash == 0 ? 0 : netPnl / request.InitialCash,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            new Dictionary<string, SymbolAttribution>());
+
+        return new BacktestResult(request, new HashSet<string>(), [], [], [], metrics, new BacktestLedger(), TimeSpan.Zero, 0);
+    }
+
+    private sealed class ParameterizedTestStrategy(decimal weight) : IBacktestStrategy
+    {
+        public decimal Weight { get; } = weight;
+        public string Name => $"Weighted-{Weight}";
+        public void Initialize(IBacktestContext ctx) { }
+        public void OnTrade(Trade trade, IBacktestContext ctx) { }
+        public void OnQuote(BboQuotePayload quote, IBacktestContext ctx) { }
+        public void OnBar(HistoricalBar bar, IBacktestContext ctx) { }
+        public void OnOrderBook(LOBSnapshot snapshot, IBacktestContext ctx) { }
+        public void OnOrderFill(FillEvent fill, IBacktestContext ctx) { }
+        public void OnDayEnd(DateOnly date, IBacktestContext ctx) { }
+        public void OnFinished(IBacktestContext ctx) { }
+    }
+}


### PR DESCRIPTION
### Motivation
- Allow each sweep run to receive a real `IBacktestStrategy` (or factory) so parameter sweeps can drive strategy behavior instead of using a hardcoded no-op implementation.
- Make the batch service easier to test by providing a seam to control run execution and observe per-run strategy effects.
- Preserve desktop UI behavior by having the caller-side (WPF) supply an explicit no-op factory when a real strategy is not provided.

### Description
- Added required `StrategyDescriptor` and `StrategyFactory` properties to `BatchBacktestRequest` so callers supply a human-readable strategy label and a per-run factory that receives the parameter set and returns an `IBacktestStrategy` instance. (`src/Meridian.Backtesting/BatchBacktestService.cs`) 
- `BatchBacktestService` now validates `StrategyDescriptor`/`StrategyFactory`, logs the strategy in the batch start message, and invokes `request.StrategyFactory(paramSet)` for each run instead of creating an internal `NoOpStrategy`. (`src/Meridian.Backtesting/BatchBacktestService.cs`) 
- Introduced an internal `_runExecutor` seam (defaulting to `BacktestEngine.RunAsync`) so tests can inject a lightweight executor without changing production behavior. (`src/Meridian.Backtesting/BatchBacktestService.cs`) 
- Updated the WPF view model to populate `StrategyDescriptor` and `StrategyFactory` with a caller-side `NoOpBatchSweepStrategy` to remain compatible with existing UI flows. (`src/Meridian.Wpf/ViewModels/BatchBacktestViewModel.cs`) 
- Added `tests/Meridian.Backtesting.Tests/BatchBacktestServiceTests.cs` which exercises the new factory path by providing a `ParameterizedTestStrategy` and a custom run-executor, asserting that different parameter sets produce distinct `InitialCash` and `NetPnl` outcomes.

### Testing
- Added a focused unit test `tests/Meridian.Backtesting.Tests/BatchBacktestServiceTests.cs` that instantiates `BatchBacktestService` with an injected run-executor and a `ParameterizedTestStrategy` factory and asserts differentiated results for two parameter sets. (test file added to the test project.)
- Attempted `dotnet test tests/Meridian.Backtesting.Tests/Meridian.Backtesting.Tests.csproj --filter "FullyQualifiedName~BatchBacktestServiceTests"`, but execution failed because `dotnet` is not available in the current environment (`/bin/bash: dotnet: command not found`).
- No automated tests were executed successfully here; the added unit test is intended to run in CI or a developer environment with .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d118a6448320b4d8e69e6d62a220)