### PR TITLE
Stream corporate-action adjustments with windowed processing

### DIFF
--- a/src/Meridian.Backtesting/CorporateActionAdjustmentService.cs
+++ b/src/Meridian.Backtesting/CorporateActionAdjustmentService.cs
@@ -32,7 +32,44 @@ public sealed class CorporateActionAdjustmentService : ICorporateActionAdjustmen
         if (bars.Count == 0)
             return bars;
 
-        // Resolve ticker to security ID
+        var sortedActions = await GetSortedCorporateActionsAsync(ticker, ct).ConfigureAwait(false);
+        if (sortedActions is null)
+            return bars;
+
+        var adjustedBars = new List<HistoricalBar>(bars.Count);
+        foreach (var bar in bars)
+        {
+            adjustedBars.Add(ApplyAdjustments(bar, sortedActions));
+        }
+
+        return adjustedBars;
+    }
+
+
+    public async IAsyncEnumerable<HistoricalBar> AdjustAsync(
+        IAsyncEnumerable<HistoricalBar> bars,
+        string ticker,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var sortedActions = await GetSortedCorporateActionsAsync(ticker, ct).ConfigureAwait(false);
+        if (sortedActions is null)
+        {
+            await foreach (var bar in bars.WithCancellation(ct).ConfigureAwait(false))
+            {
+                yield return bar;
+            }
+
+            yield break;
+        }
+
+        await foreach (var bar in bars.WithCancellation(ct).ConfigureAwait(false))
+        {
+            yield return ApplyAdjustments(bar, sortedActions);
+        }
+    }
+
+    private async Task<List<CorporateActionDto>?> GetSortedCorporateActionsAsync(string ticker, CancellationToken ct)
+    {
         var securityId = await _resolver.ResolveAsync(
             new ResolveSecurityRequest(
                 IdentifierKind: SecurityIdentifierKind.Ticker,
@@ -44,72 +81,45 @@ public sealed class CorporateActionAdjustmentService : ICorporateActionAdjustmen
         if (securityId is null)
         {
             _logger.LogWarning("Security not found in master for ticker {Ticker}", ticker);
-            return bars;
+            return null;
         }
 
-        // Get corporate actions
         var actions = await _queryService.GetCorporateActionsAsync(securityId.Value, ct)
             .ConfigureAwait(false);
 
         if (actions.Count == 0)
-            return bars;
+            return null;
 
-        _logger.LogInformation(
-            "Adjusted {Count} bars for {Ticker} using {ActionCount} corporate actions",
-            bars.Count, ticker, actions.Count);
+        return actions.OrderBy(a => a.ExDate).ToList();
+    }
 
-        // Sort actions by ExDate ascending
-        var sortedActions = actions.OrderBy(a => a.ExDate).ToList();
+    private static HistoricalBar ApplyAdjustments(HistoricalBar bar, IReadOnlyList<CorporateActionDto> sortedActions)
+    {
+        var barDate = bar.SessionDate;
+        decimal splitFactor = 1m;
+        decimal dividendAdjustment = 0m;
 
-        var adjustedBars = new List<HistoricalBar>(bars.Count);
-
-        // Process bars backward to forward through time
-        foreach (var bar in bars)
+        foreach (var action in sortedActions)
         {
-            var barDate = bar.SessionDate;
+            if (action.ExDate <= barDate)
+                continue;
 
-            // Accumulate split and dividend adjustments for all actions that occurred after this bar
-            decimal splitFactor = 1m;
-            decimal dividendAdjustment = 0m;
-
-            foreach (var action in sortedActions)
-            {
-                // Only apply actions with ExDate strictly after the bar date
-                if (action.ExDate <= barDate)
-                    continue;
-
-                if (action.EventType == "StockSplit" && action.SplitRatio.HasValue)
-                {
-                    splitFactor *= action.SplitRatio.Value;
-                }
-                else if (action.EventType == "Dividend" && action.DividendPerShare.HasValue)
-                {
-                    dividendAdjustment += action.DividendPerShare.Value;
-                }
-            }
-
-            // Apply adjustments
-            var adjustedOpen = (bar.Open - dividendAdjustment) / splitFactor;
-            var adjustedHigh = (bar.High - dividendAdjustment) / splitFactor;
-            var adjustedLow = (bar.Low - dividendAdjustment) / splitFactor;
-            var adjustedClose = (bar.Close - dividendAdjustment) / splitFactor;
-            var adjustedVolume = (long)(bar.Volume * splitFactor);
-
-            var adjustedBar = new HistoricalBar(
-                Symbol: bar.Symbol,
-                SessionDate: bar.SessionDate,
-                Open: adjustedOpen,
-                High: adjustedHigh,
-                Low: adjustedLow,
-                Close: adjustedClose,
-                Volume: adjustedVolume,
-                Source: bar.Source,
-                SequenceNumber: bar.SequenceNumber);
-
-            adjustedBars.Add(adjustedBar);
+            if (action.EventType == "StockSplit" && action.SplitRatio.HasValue)
+                splitFactor *= action.SplitRatio.Value;
+            else if (action.EventType == "Dividend" && action.DividendPerShare.HasValue)
+                dividendAdjustment += action.DividendPerShare.Value;
         }
 
-        return adjustedBars;
+        return new HistoricalBar(
+            Symbol: bar.Symbol,
+            SessionDate: bar.SessionDate,
+            Open: (bar.Open - dividendAdjustment) / splitFactor,
+            High: (bar.High - dividendAdjustment) / splitFactor,
+            Low: (bar.Low - dividendAdjustment) / splitFactor,
+            Close: (bar.Close - dividendAdjustment) / splitFactor,
+            Volume: (long)(bar.Volume * splitFactor),
+            Source: bar.Source,
+            SequenceNumber: bar.SequenceNumber);
     }
 
     /// <inheritdoc />

--- a/src/Meridian.Backtesting/Engine/BacktestEngine.cs
+++ b/src/Meridian.Backtesting/Engine/BacktestEngine.cs
@@ -233,74 +233,71 @@ public sealed class BacktestEngine(
     }
 
     /// <summary>
-    /// Wraps a symbol stream to apply corporate action adjustments to all HistoricalBar events.
+    /// Wraps a symbol stream to apply corporate action adjustments incrementally to HistoricalBar events.
     /// </summary>
     private async IAsyncEnumerable<MarketEvent> ApplyCorporateActionAdjustmentsAsync(
         IAsyncEnumerable<MarketEvent> source,
         string symbol,
         [EnumeratorCancellation] CancellationToken ct)
     {
-        // Buffer all bars for this symbol
-        var bars = new List<HistoricalBar>();
-        var nonBarEvents = new List<MarketEvent>();
+        const int barWindowSize = 4096;
+        var windowEvents = new List<MarketEvent>(barWindowSize * 2);
+        var windowBars = new List<HistoricalBar>(barWindowSize);
 
         await foreach (var evt in source.WithCancellation(ct))
         {
+            windowEvents.Add(evt);
             if (evt.Payload is HistoricalBar bar)
             {
-                bars.Add(bar);
+                windowBars.Add(bar);
+                if (windowBars.Count >= barWindowSize)
+                {
+                    foreach (var adjustedEvent in await FlushAdjustedWindowAsync(windowEvents, windowBars, symbol, ct).ConfigureAwait(false))
+                    {
+                        yield return adjustedEvent;
+                    }
+                }
+            }
+        }
+
+        foreach (var adjustedEvent in await FlushAdjustedWindowAsync(windowEvents, windowBars, symbol, ct).ConfigureAwait(false))
+        {
+            yield return adjustedEvent;
+        }
+    }
+
+    private async Task<IReadOnlyList<MarketEvent>> FlushAdjustedWindowAsync(
+        List<MarketEvent> windowEvents,
+        List<HistoricalBar> windowBars,
+        string symbol,
+        CancellationToken ct)
+    {
+        if (windowEvents.Count == 0)
+        {
+            return [];
+        }
+
+        var adjustedBars = windowBars.Count == 0
+            ? []
+            : await corporateActionAdjustment!.AdjustAsync(windowBars, symbol, ct).ConfigureAwait(false);
+
+        var output = new List<MarketEvent>(windowEvents.Count);
+        var adjustedIndex = 0;
+        foreach (var evt in windowEvents)
+        {
+            if (evt.Payload is HistoricalBar)
+            {
+                output.Add(MarketEvent.HistoricalBar(evt.Timestamp, symbol, adjustedBars[adjustedIndex++]));
             }
             else
             {
-                nonBarEvents.Add(evt);
+                output.Add(evt);
             }
         }
 
-        // Apply adjustments to all bars
-        var adjustedBars = await corporateActionAdjustment!.AdjustAsync(bars, symbol, ct)
-            .ConfigureAwait(false);
-
-        // Merge adjusted bars back with non-bar events
-        // Re-create events in chronological order
-        var barsByTimestamp = adjustedBars.OrderBy(b => b.SessionDate).ToList();
-        var nonBarsByTimestamp = nonBarEvents.OrderBy(e => e.Timestamp).ToList();
-
-        int bIdx = 0, nbIdx = 0;
-        while (bIdx < barsByTimestamp.Count && nbIdx < nonBarsByTimestamp.Count)
-        {
-            var bar = barsByTimestamp[bIdx];
-            var nonBar = nonBarsByTimestamp[nbIdx];
-            var barTimestamp = bar.SessionDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
-            if (barTimestamp <= nonBar.Timestamp.UtcDateTime)
-            {
-                yield return MarketEvent.HistoricalBar(
-                    new DateTimeOffset(barTimestamp, TimeSpan.Zero),
-                    symbol,
-                    bar);
-                bIdx++;
-            }
-            else
-            {
-                yield return nonBar;
-                nbIdx++;
-            }
-        }
-
-        while (bIdx < barsByTimestamp.Count)
-        {
-            var bar = barsByTimestamp[bIdx];
-            yield return MarketEvent.HistoricalBar(
-                new DateTimeOffset(bar.SessionDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc), TimeSpan.Zero),
-                symbol,
-                bar);
-            bIdx++;
-        }
-
-        while (nbIdx < nonBarsByTimestamp.Count)
-        {
-            yield return nonBarsByTimestamp[nbIdx];
-            nbIdx++;
-        }
+        windowEvents.Clear();
+        windowBars.Clear();
+        return output;
     }
 
     private static Dictionary<DateOnly, List<AssetEvent>> BuildAssetEventIndex(

--- a/src/Meridian.Backtesting/ICorporateActionAdjustmentService.cs
+++ b/src/Meridian.Backtesting/ICorporateActionAdjustmentService.cs
@@ -16,4 +16,29 @@ public interface ICorporateActionAdjustmentService
         IReadOnlyList<HistoricalBar> bars,
         string ticker,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Adjusts historical bars as a stream, yielding adjusted bars incrementally.
+    /// </summary>
+    /// <param name="bars">Source historical bars stream.</param>
+    /// <param name="ticker">Ticker symbol to resolve to security ID.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Adjusted bars stream.</returns>
+    async IAsyncEnumerable<HistoricalBar> AdjustAsync(
+        IAsyncEnumerable<HistoricalBar> bars,
+        string ticker,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var buffered = new List<HistoricalBar>();
+        await foreach (var bar in bars.WithCancellation(ct).ConfigureAwait(false))
+        {
+            buffered.Add(bar);
+        }
+
+        var adjusted = await AdjustAsync(buffered, ticker, ct).ConfigureAwait(false);
+        foreach (var bar in adjusted)
+        {
+            yield return bar;
+        }
+    }
 }

--- a/tests/Meridian.Backtesting.Tests/CorporateActionAdjustmentServiceTests.cs
+++ b/tests/Meridian.Backtesting.Tests/CorporateActionAdjustmentServiceTests.cs
@@ -184,6 +184,57 @@ public sealed class CorporateActionAdjustmentServiceTests
         result[0].Volume.Should().Be(6000);   // 1000 * 6
     }
 
+
+    [Fact]
+    public async Task AdjustAsync_StreamedLargeHistory_IsEquivalentToBatch()
+    {
+        var securityId = Guid.NewGuid();
+        _mockResolver.SetResolveResult(securityId);
+        _mockQueryService.SetCorporateActions([
+            new CorporateActionDto(Guid.NewGuid(), securityId, "StockSplit", new DateOnly(2024, 6, 1), null, null, null, 2m, null, null, null, null, null, null),
+            new CorporateActionDto(Guid.NewGuid(), securityId, "Dividend", new DateOnly(2024, 9, 1), null, 1m, "USD", null, null, null, null, null, null, null)
+        ]);
+
+        var bars = Enumerable.Range(0, 50_000)
+            .Select(i => CreateBar("SPY", new DateOnly(2020, 1, 1).AddDays(i), 100m + i, 101m + i, 99m + i, 100.5m + i, 1_000 + i))
+            .ToArray();
+
+        var batch = await _service.AdjustAsync(bars, "SPY");
+        var streamed = await CollectAsync(_service.AdjustAsync(ToAsync(bars), "SPY"));
+
+        streamed.Should().BeEquivalentTo(batch, options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public async Task AdjustAsync_StreamedLargeHistory_IsIncremental()
+    {
+        var securityId = Guid.NewGuid();
+        _mockResolver.SetResolveResult(securityId);
+        _mockQueryService.SetCorporateActions([]);
+
+        var produced = 0;
+        async IAsyncEnumerable<HistoricalBar> Source()
+        {
+            for (var i = 0; i < 100_000; i++)
+            {
+                produced++;
+                yield return CreateBar("SPY", new DateOnly(2020, 1, 1).AddDays(i), 100m, 101m, 99m, 100m);
+                await Task.Yield();
+            }
+        }
+
+        var consumed = 0;
+        await foreach (var _ in _service.AdjustAsync(Source(), "SPY"))
+        {
+            consumed++;
+            if (consumed == 250)
+            {
+                break;
+            }
+        }
+
+        produced.Should().BeLessThan(500);
+    }
     private static HistoricalBar CreateBar(
         string symbol,
         DateOnly date,
@@ -194,6 +245,27 @@ public sealed class CorporateActionAdjustmentServiceTests
         long volume = 1000000)
     {
         return new HistoricalBar(symbol, date, open, high, low, close, volume);
+    }
+
+
+    private static async IAsyncEnumerable<HistoricalBar> ToAsync(IEnumerable<HistoricalBar> bars)
+    {
+        foreach (var bar in bars)
+        {
+            yield return bar;
+            await Task.Yield();
+        }
+    }
+
+    private static async Task<List<HistoricalBar>> CollectAsync(IAsyncEnumerable<HistoricalBar> source)
+    {
+        var list = new List<HistoricalBar>();
+        await foreach (var item in source)
+        {
+            list.Add(item);
+        }
+
+        return list;
     }
 
     // Mock implementations


### PR DESCRIPTION
### Motivation
- The previous adjustment pipeline buffered all bars per symbol in `BacktestEngine.ApplyCorporateActionAdjustmentsAsync`, causing unbounded memory growth for large histories. 
- The change introduces a streaming/windowed adjustment path so bars can be processed incrementally and large-symbol histories remain bounded in memory during backtests.

### Description
- Reworked `BacktestEngine.ApplyCorporateActionAdjustmentsAsync` to use a bounded window (`barWindowSize = 4096`) and a `FlushAdjustedWindowAsync` helper that calls the adjustment service per-window and emits adjusted `MarketEvent` entries while preserving non-bar events and ordering (`src/Meridian.Backtesting/Engine/BacktestEngine.cs`).
- Added a streaming overload to `ICorporateActionAdjustmentService`: `AdjustAsync(IAsyncEnumerable<HistoricalBar>, string, CancellationToken)` with a default compatibility implementation so callers can opt into streaming without breaking existing implementations (`src/Meridian.Backtesting/ICorporateActionAdjustmentService.cs`).
- Implemented the streaming overload in `CorporateActionAdjustmentService` and refactored the adjustment logic into shared helpers `GetSortedCorporateActionsAsync` and `ApplyAdjustments` so both batch and streaming paths reuse the same algorithm (`src/Meridian.Backtesting/CorporateActionAdjustmentService.cs`).
- Added integration-style tests in `tests/Meridian.Backtesting.Tests/CorporateActionAdjustmentServiceTests.cs` that (a) verify streamed output is equivalent to batch-adjusted output for 50,000 bars and (b) assert incremental consumption behavior by breaking early from the streamed source to ensure the stream does not eagerly enumerate the entire input.

### Testing
- Added unit/integration tests `CorporateActionAdjustmentServiceTests.AdjustAsync_StreamedLargeHistory_IsEquivalentToBatch` and `AdjustAsync_StreamedLargeHistory_IsIncremental` in `tests/Meridian.Backtesting.Tests/CorporateActionAdjustmentServiceTests.cs` which assert output equivalence and bounded/incremental consumption respectively. 
- Attempted to run the focused test filter with `dotnet test --filter "FullyQualifiedName~CorporateActionAdjustmentServiceTests"`, but the execution environment lacks the .NET SDK so the test run failed with `/bin/bash: dotnet: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d11b52408320811c617d0bc12478)