### PR TITLE
Add sweep metadata to strategy runs and expose grouped sweep results

### DIFF
--- a/src/Meridian.Application/Backtesting/BacktestStudioContracts.cs
+++ b/src/Meridian.Application/Backtesting/BacktestStudioContracts.cs
@@ -16,7 +16,10 @@ public sealed record BacktestStudioRunRequest(
     string? FeedReference = null,
     string? BenchmarkSymbol = null,
     IReadOnlyDictionary<string, string>? Parameters = null,
-    IReadOnlyDictionary<string, string>? ExternalEngineOptions = null);
+    IReadOnlyDictionary<string, string>? ExternalEngineOptions = null,
+    string? SweepId = null,
+    string? SweepDefinitionHash = null,
+    string? SweepObjective = null);
 
 /// <summary>
 /// Stable handle returned when a Backtest Studio run is accepted by an engine.

--- a/src/Meridian.Backtesting/BacktestStudioRunOrchestrator.cs
+++ b/src/Meridian.Backtesting/BacktestStudioRunOrchestrator.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
 using Meridian.Application.Backtesting;
 using Meridian.Backtesting.Sdk;
 using Meridian.Contracts.Workstation;
@@ -42,6 +44,7 @@ public sealed class BacktestStudioRunOrchestrator : IAsyncDisposable
         var engine = ResolveEngine(request.Engine);
         var handle = await engine.StartAsync(request, ct).ConfigureAwait(false);
 
+        var sweepHash = request.SweepDefinitionHash ?? ComputeSweepDefinitionHash(request.SweepObjective, request.Parameters);
         var entry = StrategyRunEntry.Start(
             request.StrategyId,
             request.StrategyName,
@@ -50,7 +53,12 @@ public sealed class BacktestStudioRunOrchestrator : IAsyncDisposable
             datasetReference: request.DatasetReference,
             feedReference: request.FeedReference,
             engine: handle.Engine.ToString(),
-            parameterSet: request.Parameters);
+            parameterSet: request.Parameters) with
+        {
+            SweepId = request.SweepId,
+            SweepDefinitionHash = sweepHash,
+            SweepObjective = request.SweepObjective
+        };
 
         await _repository.RecordRunAsync(entry, ct).ConfigureAwait(false);
         _runHandles[handle.RunId] = handle;
@@ -207,5 +215,27 @@ public sealed class BacktestStudioRunOrchestrator : IAsyncDisposable
             return handle;
 
         throw new InvalidOperationException($"Backtest Studio run '{runId}' is not being tracked by the orchestrator.");
+    }
+
+    private static string? ComputeSweepDefinitionHash(string? objective, IReadOnlyDictionary<string, string>? parameters)
+    {
+        if (string.IsNullOrWhiteSpace(objective) && (parameters is null || parameters.Count == 0))
+        {
+            return null;
+        }
+
+        var builder = new StringBuilder();
+        builder.Append(objective?.Trim() ?? string.Empty);
+        builder.Append('|');
+        if (parameters is not null)
+        {
+            foreach (var pair in parameters.OrderBy(static p => p.Key, StringComparer.Ordinal))
+            {
+                builder.Append(pair.Key).Append('=').Append(pair.Value).Append(';');
+            }
+        }
+
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(builder.ToString()));
+        return Convert.ToHexString(bytes);
     }
 }

--- a/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
+++ b/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
@@ -127,7 +127,28 @@ public sealed record StrategyRunSummary(
     StrategyRunGovernanceSummary? Governance = null,
     string? FundProfileId = null,
     string? FundDisplayName = null,
-    string? ParentRunId = null);
+    string? ParentRunId = null,
+    string? SweepId = null,
+    string? SweepDefinitionHash = null,
+    string? SweepObjective = null);
+
+public sealed record StrategySweepObjectiveRanking(
+    string RunId,
+    string StrategyName,
+    decimal? ObjectiveValue,
+    decimal? NetPnl,
+    decimal? TotalReturn,
+    decimal? FinalEquity,
+    DateTimeOffset LastUpdatedAt);
+
+public sealed record StrategySweepResultGroup(
+    string SweepId,
+    string SweepDefinitionHash,
+    string? Objective,
+    DateTimeOffset StartedAt,
+    int RunCount,
+    IReadOnlyList<StrategyRunSummary> Runs,
+    IReadOnlyList<StrategySweepObjectiveRanking> ObjectiveRankings);
 
 /// <summary>
 /// Expanded detail for a single run, including derived portfolio and ledger views.

--- a/src/Meridian.Strategies/Models/StrategyRunEntry.cs
+++ b/src/Meridian.Strategies/Models/StrategyRunEntry.cs
@@ -25,7 +25,10 @@ public sealed record StrategyRunEntry(
     StrategyRunStatus? TerminalStatus = null,
     string? ParentRunId = null,
     string? FundProfileId = null,
-    string? FundDisplayName = null)
+    string? FundDisplayName = null,
+    string? SweepId = null,
+    string? SweepDefinitionHash = null,
+    string? SweepObjective = null)
 {
     /// <summary>Creates a new run entry with a generated run ID and current timestamp.</summary>
     public static StrategyRunEntry Start(string strategyId, string strategyName, RunType runType) =>

--- a/src/Meridian.Strategies/Services/StrategyRunReadService.cs
+++ b/src/Meridian.Strategies/Services/StrategyRunReadService.cs
@@ -238,6 +238,45 @@ public sealed class StrategyRunReadService
             .ToArray();
     }
 
+    public async Task<IReadOnlyList<StrategySweepResultGroup>> GetSweepResultGroupsAsync(int limit = 25, CancellationToken ct = default)
+    {
+        var runs = await GetRunsAsync(new StrategyRunHistoryQuery(Limit: Math.Clamp(limit * 20, 1, 500)), ct).ConfigureAwait(false);
+        return runs
+            .Where(static run => !string.IsNullOrWhiteSpace(run.SweepId) && !string.IsNullOrWhiteSpace(run.SweepDefinitionHash))
+            .GroupBy(static run => $"{run.SweepId}|{run.SweepDefinitionHash}", StringComparer.Ordinal)
+            .OrderByDescending(static group => group.Max(run => run.StartedAt))
+            .Take(Math.Clamp(limit, 1, 100))
+            .Select(group =>
+            {
+                var groupedRuns = group.OrderByDescending(static run => run.StartedAt).ToArray();
+                var topObjective = groupedRuns
+                    .Where(static run => run.Status == StrategyRunStatus.Completed)
+                    .OrderByDescending(static run => run.FinalEquity ?? decimal.MinValue)
+                    .ThenByDescending(static run => run.NetPnl ?? decimal.MinValue)
+                    .Take(10)
+                    .Select(static run => new StrategySweepObjectiveRanking(
+                        run.RunId,
+                        run.StrategyName,
+                        run.FinalEquity,
+                        run.NetPnl,
+                        run.TotalReturn,
+                        run.FinalEquity,
+                        run.LastUpdatedAt))
+                    .ToArray();
+
+                var head = groupedRuns[0];
+                return new StrategySweepResultGroup(
+                    SweepId: head.SweepId!,
+                    SweepDefinitionHash: head.SweepDefinitionHash!,
+                    Objective: head.SweepObjective,
+                    StartedAt: groupedRuns.Min(static run => run.StartedAt),
+                    RunCount: groupedRuns.Length,
+                    Runs: groupedRuns,
+                    ObjectiveRankings: topObjective);
+            })
+            .ToArray();
+    }
+
     private StrategyRunSummary ToSummary(
         StrategyRunEntry run,
         IReadOnlyDictionary<string, StrategyPromotionRecord> promotionLookup)
@@ -267,7 +306,10 @@ public sealed class StrategyRunReadService
             Governance: BuildGovernanceSummary(run),
             FundProfileId: run.FundProfileId,
             FundDisplayName: run.FundDisplayName,
-            ParentRunId: run.ParentRunId);
+            ParentRunId: run.ParentRunId,
+            SweepId: run.SweepId,
+            SweepDefinitionHash: run.SweepDefinitionHash,
+            SweepObjective: run.SweepObjective);
     }
 
     private static StrategyRunExecutionSummary BuildExecutionSummary(StrategyRunEntry run)

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -875,6 +875,21 @@ public static class WorkstationEndpoints
         .Produces<IReadOnlyList<StrategyRunTimelineEntry>>(200)
         .Produces(501);
 
+        group.MapGet("/runs/sweeps", async (int? limit, HttpContext context) =>
+        {
+            var readService = context.RequestServices.GetService<StrategyRunReadService>();
+            if (readService is null)
+            {
+                return Results.Problem("Strategy run service is not registered.", statusCode: StatusCodes.Status501NotImplemented);
+            }
+
+            var sweeps = await readService.GetSweepResultGroupsAsync(limit ?? 25, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(sweeps, jsonOptions);
+        })
+        .WithName("GetWorkstationSweepResults")
+        .Produces<IReadOnlyList<StrategySweepResultGroup>>(200)
+        .Produces(501);
+
         app.MapGet("/api/strategies/runs/compare", async (string? ids, HttpContext context) =>
         {
             var readService = context.RequestServices.GetService<StrategyRunReadService>();

--- a/tests/Meridian.Tests/Application/Backtesting/BacktestStudioRunOrchestratorTests.cs
+++ b/tests/Meridian.Tests/Application/Backtesting/BacktestStudioRunOrchestratorTests.cs
@@ -28,7 +28,9 @@ public sealed class BacktestStudioRunOrchestratorTests
             Engine: StrategyRunEngine.MeridianNative,
             NativeRequest: BuildRequest(),
             DatasetReference: "dataset:us-equities",
-            Parameters: new Dictionary<string, string> { ["lookback"] = "20" });
+            Parameters: new Dictionary<string, string> { ["lookback"] = "20" },
+            SweepId: "sweep-001",
+            SweepObjective: "FinalEquity");
 
         var handle = await orchestrator.StartAsync(request);
 
@@ -38,6 +40,9 @@ public sealed class BacktestStudioRunOrchestratorTests
         started.Engine.Should().Be("MeridianNative");
         started.DatasetReference.Should().Be("dataset:us-equities");
         started.ParameterSet.Should().ContainKey("lookback").WhoseValue.Should().Be("20");
+        started.SweepId.Should().Be("sweep-001");
+        started.SweepObjective.Should().Be("FinalEquity");
+        started.SweepDefinitionHash.Should().NotBeNullOrWhiteSpace();
         started.EndedAt.Should().BeNull();
 
         engine.Complete(handle.EngineRunHandle, BuildResult(request.NativeRequest));


### PR DESCRIPTION
### Motivation

- Link Backtest Studio batch/child runs to sweep metadata so batch results can be grouped and traced to an originating sweep. 
- Ensure deterministic identity for a sweep definition by computing a stable hash from the sweep objective and sorted parameters when one isn't supplied. 
- Surface grouped sweep results and objective rankings to UI/read-models so the dashboard can query sweep-level rollups and best-performing objectives.

### Description

- Added sweep metadata fields (`SweepId`, `SweepDefinitionHash`, `SweepObjective`) to the shared read-model contract `StrategyRunSummary` and introduced `StrategySweepResultGroup` and `StrategySweepObjectiveRanking` DTOs. 
- Extended the persisted run model `StrategyRunEntry` and the application contract `BacktestStudioRunRequest` to carry sweep metadata through the write/read lifecycle. 
- Updated `BacktestStudioRunOrchestrator` to persist sweep metadata on run creation and to compute a deterministic SHA-256 `SweepDefinitionHash` from the objective + sorted `Parameters` when no hash is provided. 
- Added grouping and objective-ranking logic in `StrategyRunReadService` and exposed a new workstation endpoint `GET /api/workstation/runs/sweeps` in `WorkstationEndpoints` to return sweep groups and rankings for UI consumption. 
- Updated `BacktestStudioRunOrchestrator` test to assert sweep metadata is persisted and that a hash is generated when none is supplied.

### Testing

- Updated unit test `BacktestStudioRunOrchestratorTests.StartAsync_RecordsInitialAndCompletedRunEntries` to validate sweep metadata persistence and hash generation, but no test suite was executed to completion in this environment. 
- Attempted to run the focused test via `dotnet test --filter "FullyQualifiedName~BacktestStudioRunOrchestratorTests"`, but the test run failed due to the container lacking the `dotnet` SDK (error: `dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d1200fdc8320b0c06c7107171110)