### PR TITLE
Deterministic tie-breaking for equal-timestamp backtest events

### DIFF
--- a/src/Meridian.Backtesting/Engine/MultiSymbolMergeEnumerator.cs
+++ b/src/Meridian.Backtesting/Engine/MultiSymbolMergeEnumerator.cs
@@ -4,14 +4,20 @@ namespace Meridian.Backtesting.Engine;
 
 /// <summary>
 /// Merges multiple per-symbol <see cref="IAsyncEnumerable{MarketEvent}"/> streams into a single
-/// chronologically-ordered stream using a min-heap (priority queue) keyed on event timestamp.
+/// chronologically-ordered stream using a min-heap (priority queue) keyed on timestamp plus
+/// a deterministic secondary stream key.
 /// O(log n) per event where n is the number of symbol streams.
 /// </summary>
 /// <remarks>
-/// Tie-breaking: when two streams have events at the same millisecond timestamp, the stream with
-/// the lower index (i.e. earlier position in the <c>streams</c> list) is always
-/// dequeued first. This gives deterministic replay order provided the caller passes streams in a
-/// consistent order (e.g. sorted by symbol name).
+/// <para>
+/// Determinism contract: if two events have the same timestamp (at millisecond precision), the
+/// event from the lower stream index (earlier position in <paramref name="streams"/>) is always
+/// dequeued first.
+/// </para>
+/// <para>
+/// Callers that require repeatable equal-timestamp ordering must pass streams in a stable order
+/// (for example, symbol-sorted order) and keep that ordering consistent between runs.
+/// </para>
 /// </remarks>
 internal static class MultiSymbolMergeEnumerator
 {
@@ -21,16 +27,22 @@ internal static class MultiSymbolMergeEnumerator
         [EnumeratorCancellation] CancellationToken ct = default)
     {
         // Initialise enumerators and prime the heap.
-        // The heap key is a composite long: (timestampMs << 20) | streamIndex, so that events
-        // at the same millisecond are always dequeued in stream-index order (deterministic).
+        // Heap priority is (timestampMs, streamIndex), so equal timestamps are deterministically
+        // ordered by stream index.
         var enumerators = new IAsyncEnumerator<MarketEvent>[streams.Count];
-        var heap = new PriorityQueue<int, long>(streams.Count);
+        var heap = new PriorityQueue<int, (long TimestampMs, int StreamIndex)>(
+            streams.Count,
+            Comparer<(long TimestampMs, int StreamIndex)>.Default);
 
         for (var i = 0; i < streams.Count; i++)
         {
             enumerators[i] = streams[i].GetAsyncEnumerator(ct);
             if (await enumerators[i].MoveNextAsync().ConfigureAwait(false))
-                heap.Enqueue(i, MakeHeapKey(enumerators[i].Current.Timestamp.ToUnixTimeMilliseconds(), i));
+            {
+                heap.Enqueue(
+                    i,
+                    (enumerators[i].Current.Timestamp.ToUnixTimeMilliseconds(), i));
+            }
         }
 
         try
@@ -43,7 +55,11 @@ internal static class MultiSymbolMergeEnumerator
                 yield return enumerators[idx].Current;
 
                 if (await enumerators[idx].MoveNextAsync().ConfigureAwait(false))
-                    heap.Enqueue(idx, MakeHeapKey(enumerators[idx].Current.Timestamp.ToUnixTimeMilliseconds(), idx));
+                {
+                    heap.Enqueue(
+                        idx,
+                        (enumerators[idx].Current.Timestamp.ToUnixTimeMilliseconds(), idx));
+                }
             }
         }
         finally
@@ -52,12 +68,4 @@ internal static class MultiSymbolMergeEnumerator
                 await e.DisposeAsync().ConfigureAwait(false);
         }
     }
-
-    /// <summary>
-    /// Packs a millisecond timestamp and stream index into a single <see cref="long"/> heap key.
-    /// Lower stream index wins on equal timestamps, giving deterministic tie-breaking.
-    /// Supports up to 2^20 (≈1 million) concurrent streams.
-    /// </summary>
-    private static long MakeHeapKey(long timestampMs, int streamIndex)
-        => (timestampMs << 20) | (uint)(streamIndex & 0xFFFFF);
 }

--- a/tests/Meridian.Backtesting.Tests/BacktestEngineIntegrationTests.cs
+++ b/tests/Meridian.Backtesting.Tests/BacktestEngineIntegrationTests.cs
@@ -178,6 +178,49 @@ public sealed class BacktestEngineIntegrationTests : IDisposable
             "symbol filter must restrict universe to only requested symbols");
     }
 
+    [Fact]
+    public async Task RunAsync_EqualTimestampEvents_RespectStableSymbolOrder()
+    {
+        WriteEventJsonl("MSFT", new DateTimeOffset(2024, 1, 2, 14, 30, 0, TimeSpan.Zero));
+        WriteEventJsonl("AAPL", new DateTimeOffset(2024, 1, 2, 14, 30, 0, TimeSpan.Zero));
+
+        var strategy = new OrderedSymbolCaptureStrategy();
+        var request = new BacktestRequest(
+            From: new DateOnly(2024, 1, 2),
+            To: new DateOnly(2024, 1, 2),
+            Symbols: ["MSFT", "AAPL"],
+            DataRoot: _dataRoot);
+
+        await _engine.RunAsync(request, strategy);
+
+        strategy.BarSymbolsInArrivalOrder.Should().Equal(
+            ["MSFT", "AAPL"],
+            "equal-timestamp events should be ordered by stable stream/symbol order");
+    }
+
+    [Fact]
+    public async Task RunAsync_EqualTimestampEvents_AreRepeatableAcrossRuns()
+    {
+        WriteEventJsonl("MSFT", new DateTimeOffset(2024, 1, 2, 14, 30, 0, TimeSpan.Zero));
+        WriteEventJsonl("AAPL", new DateTimeOffset(2024, 1, 2, 14, 30, 0, TimeSpan.Zero));
+
+        var request = new BacktestRequest(
+            From: new DateOnly(2024, 1, 2),
+            To: new DateOnly(2024, 1, 2),
+            Symbols: ["MSFT", "AAPL"],
+            DataRoot: _dataRoot);
+
+        var firstRunStrategy = new OrderedSymbolCaptureStrategy();
+        var secondRunStrategy = new OrderedSymbolCaptureStrategy();
+
+        await _engine.RunAsync(request, firstRunStrategy);
+        await _engine.RunAsync(request, secondRunStrategy);
+
+        firstRunStrategy.BarSymbolsInArrivalOrder.Should().Equal(secondRunStrategy.BarSymbolsInArrivalOrder,
+            "equal-timestamp merge ordering should be deterministic across repeated runs");
+        firstRunStrategy.BarSymbolsInArrivalOrder.Should().Equal(["MSFT", "AAPL"]);
+    }
+
     // ------------------------------------------------------------------ //
     //  UTC date boundary filtering (regression: FilterBySymbolAndDate    //
     //  must use UtcDateTime.Date, not LocalDateTime.Date)                //
@@ -499,6 +542,21 @@ file sealed class BarTrackingStrategy : IBacktestStrategy
         Symbols.Add(bar.Symbol);
     }
 
+    public void OnOrderBook(LOBSnapshot snapshot, IBacktestContext ctx) { }
+    public void OnOrderFill(FillEvent fill, IBacktestContext ctx) { }
+    public void OnDayEnd(DateOnly date, IBacktestContext ctx) { }
+    public void OnFinished(IBacktestContext ctx) { }
+}
+
+file sealed class OrderedSymbolCaptureStrategy : IBacktestStrategy
+{
+    public string Name => "OrderedSymbolCapture";
+    public List<string> BarSymbolsInArrivalOrder { get; } = [];
+
+    public void Initialize(IBacktestContext ctx) { }
+    public void OnTrade(Trade trade, IBacktestContext ctx) { }
+    public void OnQuote(BboQuotePayload quote, IBacktestContext ctx) { }
+    public void OnBar(HistoricalBar bar, IBacktestContext ctx) => BarSymbolsInArrivalOrder.Add(bar.Symbol);
     public void OnOrderBook(LOBSnapshot snapshot, IBacktestContext ctx) { }
     public void OnOrderFill(FillEvent fill, IBacktestContext ctx) { }
     public void OnDayEnd(DateOnly date, IBacktestContext ctx) { }


### PR DESCRIPTION
### Motivation

- Ensure deterministic ordering when multiple per-symbol streams emit events with identical timestamps by enforcing a stable secondary sort key. 
- Avoid nondeterministic replay behavior that can lead to flaky backtests and hard-to-debug differences between runs. 

### Description

- Replaced the packed-bit `long` heap key with a tuple priority key `(timestampMs, streamIndex)` in `MultiSymbolMergeEnumerator.MergeAsync` so the priority queue orders by timestamp then by stream index. 
- Expanded XML documentation in `MultiSymbolMergeEnumerator` to state the determinism contract and require callers to provide streams in a stable order for repeatable ordering. 
- Added two integration regression tests to `tests/Meridian.Backtesting.Tests/BacktestEngineIntegrationTests.cs`: `RunAsync_EqualTimestampEvents_RespectStableSymbolOrder` and `RunAsync_EqualTimestampEvents_AreRepeatableAcrossRuns`. 
- Added `OrderedSymbolCaptureStrategy` test helper to capture bar arrival symbol order for assertions. 

### Testing

- Added automated tests `RunAsync_EqualTimestampEvents_RespectStableSymbolOrder` and `RunAsync_EqualTimestampEvents_AreRepeatableAcrossRuns` that assert equal-timestamp ordering follows the provided symbol/stream order and is repeatable across runs. 
- Attempted to run the focused test command `dotnet test tests/Meridian.Backtesting.Tests/Meridian.Backtesting.Tests.csproj --filter "FullyQualifiedName~RunAsync_EqualTimestampEvents" --logger "console;verbosity=normal"`, but the environment lacks the `dotnet` tool so the command could not be executed (failed with `bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d1263b4c83209e962f366271d464)