### PR TITLE
Thread QuantScript EnableUnsafeScripts into Roslyn script option safety policy

### DIFF
--- a/docs/plans/quant-script-environment-blueprint.md
+++ b/docs/plans/quant-script-environment-blueprint.md
@@ -83,6 +83,19 @@ The current repository already includes:
 - keep shared run-browser, run-detail, and comparison workflows inside the existing Research surface instead of building parallel QuantScript-only run management
 - route detailed UI, ViewModel, and interaction design to the page implementation guide instead of duplicating it here
 
+### Script Compilation Safety Contract (`QuantScriptOptions.EnableUnsafeScripts`)
+
+- `EnableUnsafeScripts = false` (default, **safe mode**) keeps QuantScript focused on Meridian-shipped APIs and references only.
+  - Script-level assembly loading is blocked (`#r` fails during compilation).
+  - Script-level source loading is blocked (`#load` and path-based source resolution fail during compilation).
+  - Path-based metadata/source reference resolution is disabled through explicit Roslyn resolver constraints.
+- `EnableUnsafeScripts = true` (**unsafe mode**) restores Roslyn's default script reference behavior for advanced research workflows.
+  - `#r` assembly references are allowed.
+  - `#load` source inclusion is allowed.
+  - Researchers can opt into external/reference-heavy scenarios, accepting the broader script trust surface.
+
+This flag is an intentional trust boundary: keep safe mode for standard operator/research environments and enable unsafe mode only for explicitly trusted local experimentation.
+
 ---
 
 ## Remaining Optional Work

--- a/src/Meridian.QuantScript/Compilation/RoslynScriptCompiler.cs
+++ b/src/Meridian.QuantScript/Compilation/RoslynScriptCompiler.cs
@@ -17,6 +17,9 @@ namespace Meridian.QuantScript.Compilation;
 /// </summary>
 public sealed class RoslynScriptCompiler : IQuantScriptCompiler
 {
+    private static readonly MetadataReferenceResolver SafeMetadataReferenceResolver = new RestrictedMetadataReferenceResolver();
+    private static readonly SourceReferenceResolver SafeSourceReferenceResolver = new RestrictedSourceReferenceResolver();
+
     // Parameter comment convention: // @param Name:Label:Default:Min:Max:Description
     private static readonly Regex ParamRegex = new(
         @"//\s*@param\s+(\w+):([^:]*):([^:]*):([^:]*):([^:]*):?(.*)",
@@ -123,8 +126,9 @@ public sealed class RoslynScriptCompiler : IQuantScriptCompiler
             BuildScriptOptions(),
             globalsType: typeof(QuantScriptGlobals));
 
-    private static ScriptOptions BuildScriptOptions() =>
-        ScriptOptions.Default
+    private ScriptOptions BuildScriptOptions()
+    {
+        var scriptOptions = ScriptOptions.Default
             .AddReferences(
                 typeof(QuantScriptGlobals).Assembly,
                 typeof(Backtesting.Engine.BacktestEngine).Assembly,
@@ -139,6 +143,51 @@ public sealed class RoslynScriptCompiler : IQuantScriptCompiler
                 "Meridian.QuantScript.Api",
                 "Meridian.Backtesting.Sdk",
                 "Meridian.Contracts.Domain.Models");
+
+        if (!_options.Value.EnableUnsafeScripts)
+        {
+            scriptOptions = scriptOptions
+                .WithMetadataResolver(SafeMetadataReferenceResolver)
+                .WithSourceResolver(SafeSourceReferenceResolver);
+        }
+
+        return scriptOptions;
+    }
+
+    private sealed class RestrictedMetadataReferenceResolver : MetadataReferenceResolver
+    {
+        public override bool Equals(object? other) => other is RestrictedMetadataReferenceResolver;
+
+        public override int GetHashCode() => typeof(RestrictedMetadataReferenceResolver).GetHashCode();
+
+        public override PortableExecutableReference? ResolveMissingAssembly(
+            MetadataReference definition,
+            AssemblyIdentity referenceIdentity) => null;
+
+        public override IEnumerable<PortableExecutableReference> ResolveReference(
+            string reference,
+            string? baseFilePath,
+            MetadataReferenceProperties properties)
+        {
+            throw new InvalidOperationException("Script-level assembly loading is disabled in safe mode.");
+        }
+    }
+
+    private sealed class RestrictedSourceReferenceResolver : SourceReferenceResolver
+    {
+        public override bool Equals(object? other) => other is RestrictedSourceReferenceResolver;
+
+        public override int GetHashCode() => typeof(RestrictedSourceReferenceResolver).GetHashCode();
+
+        public override string? NormalizePath(string path, string? baseFilePath) => null;
+
+        public override Stream OpenRead(string resolvedPath)
+        {
+            throw new InvalidOperationException("Script-level source loading is disabled in safe mode.");
+        }
+
+        public override string? ResolveReference(string path, string? baseFilePath) => null;
+    }
 
     /// <inheritdoc/>
     public IReadOnlyList<ParameterDescriptor> ExtractParameters(string source)

--- a/tests/Meridian.QuantScript.Tests/RoslynScriptCompilerTests.cs
+++ b/tests/Meridian.QuantScript.Tests/RoslynScriptCompilerTests.cs
@@ -124,6 +124,41 @@ public sealed class RoslynScriptCompilerTests
         r2.Success.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task CompileAsync_SafeMode_BlocksScriptLevelAssemblyReferences()
+    {
+        var compiler = BuildCompiler(new QuantScriptOptions { EnableUnsafeScripts = false });
+        var source = "#r \"System.Xml\"\nvar x = 1;";
+
+        var result = await compiler.CompileAsync(source);
+
+        result.Success.Should().BeFalse();
+        result.Diagnostics.Should().Contain(d => d.Message.Contains("disabled in safe mode", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task CompileAsync_SafeMode_BlocksPathBasedSourceLoading()
+    {
+        var compiler = BuildCompiler(new QuantScriptOptions { EnableUnsafeScripts = false });
+        var source = "#load \"helpers/common.csx\"\nvar x = 1;";
+
+        var result = await compiler.CompileAsync(source);
+
+        result.Success.Should().BeFalse();
+        result.Diagnostics.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task CompileAsync_UnsafeMode_AllowsScriptLevelAssemblyReferences()
+    {
+        var compiler = BuildCompiler(new QuantScriptOptions { EnableUnsafeScripts = true });
+        var source = "#r \"System.Xml\"\nusing System.Xml;\nvar doc = new XmlDocument();";
+
+        var result = await compiler.CompileAsync(source);
+
+        result.Success.Should().BeTrue();
+    }
+
     // ── Cancellation ─────────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Constrain script-level reference and source resolution when `QuantScriptOptions.EnableUnsafeScripts` is disabled to reduce the scripting trust surface for standard operator/research environments.
- Allow advanced, trusted local experimentation when `EnableUnsafeScripts` is explicitly enabled.

### Description
- Refactored `RoslynScriptCompiler.BuildScriptOptions()` from a static helper into an instance method that reads `_options.Value.EnableUnsafeScripts` and returns `ScriptOptions` accordingly. (file: `src/Meridian.QuantScript/Compilation/RoslynScriptCompiler.cs`)
- When `EnableUnsafeScripts == false`, applied explicit Roslyn resolver constraints via `RestrictedMetadataReferenceResolver` and `RestrictedSourceReferenceResolver` to block script-level `#r` assembly loading and path-based `#load` source inclusion. (file: `src/Meridian.QuantScript/Compilation/RoslynScriptCompiler.cs`)
- Added focused unit tests that assert the safe/unsafe contract: `CompileAsync_SafeMode_BlocksScriptLevelAssemblyReferences`, `CompileAsync_SafeMode_BlocksPathBasedSourceLoading`, and `CompileAsync_UnsafeMode_AllowsScriptLevelAssemblyReferences`. (file: `tests/Meridian.QuantScript.Tests/RoslynScriptCompilerTests.cs`)
- Documented the safe-vs-unsafe behavior and trust-boundary guidance in the QuantScript environment blueprint. (file: `docs/plans/quant-script-environment-blueprint.md`)

### Testing
- Added unit tests (`RoslynScriptCompilerTests`) covering safe-mode rejection of `#r` and `#load` and unsafe-mode allowance of `#r`; the tests are included under `tests/Meridian.QuantScript.Tests` and were compiled into the test project.
- Attempted to run the focused tests with `dotnet test tests/Meridian.QuantScript.Tests/Meridian.QuantScript.Tests.csproj --filter "FullyQualifiedName~RoslynScriptCompilerTests" --logger "console;verbosity=normal"`, but execution could not complete in this environment because `dotnet` is not available (`dotnet: command not found`).
- No automated test failures are reported in-repo; CI should run the new test cases and validate behavior in an environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d14c6b288320bfe2cec5ff70cd12)