### PR TITLE
Support date-indexed risk-free rates in backtest metrics

### DIFF
--- a/src/Meridian.Backtesting.Sdk/BacktestRequest.cs
+++ b/src/Meridian.Backtesting.Sdk/BacktestRequest.cs
@@ -58,8 +58,13 @@ public enum BacktestCommissionKind
 /// When true, adjusts historical bar prices for splits and dividends using Security Master data (default: true).
 /// </param>
 /// <param name="RiskFreeRate">
-/// Annualised risk-free rate used by <see cref="BacktestMetrics.SharpeRatio"/> and
-/// <see cref="BacktestMetrics.SortinoRatio"/> calculations (e.g. 0.04 for 4%). Defaults to 0.04.
+/// Annualised risk-free rate fallback used by <see cref="BacktestMetrics.SharpeRatio"/> and
+/// <see cref="BacktestMetrics.SortinoRatio"/> calculations when
+/// <see cref="RiskFreeRateSeries"/> is not provided (e.g. 0.04 for 4%). Defaults to 0.04.
+/// </param>
+/// <param name="RiskFreeRateSeries">
+/// Optional date-indexed annualised risk-free series used to compute period-matched excess returns
+/// for Sharpe/Sortino. Dates not present in the series fall back to <see cref="RiskFreeRate"/>.
 /// </param>
 /// <param name="MaxParticipationRate">
 /// Maximum fraction of a bar's traded volume that the <see cref="ExecutionModel.BarMidpoint"/> fill
@@ -95,6 +100,7 @@ public sealed record BacktestRequest(
     decimal MarketImpactCoefficient = 0.1m,
     bool AdjustForCorporateActions = true,
     double RiskFreeRate = 0.04,
+    IReadOnlyDictionary<DateOnly, double>? RiskFreeRateSeries = null,
     decimal MaxParticipationRate = 0m,
     bool FailOnUnknownSymbols = false)
 {

--- a/src/Meridian.Backtesting/Metrics/BacktestMetricsEngine.cs
+++ b/src/Meridian.Backtesting/Metrics/BacktestMetricsEngine.cs
@@ -25,13 +25,13 @@ internal static class BacktestMetricsEngine
         var totalShortRebates = allCashFlows.OfType<ShortRebateCashFlow>().Sum(c => c.Amount);
         var netPnl = grossPnl - totalCommissions - totalMarginInterest + totalShortRebates;
 
-        var dailyReturns = snapshots.Select(s => (double)s.DailyReturn).ToList();
+        var datedDailyReturns = snapshots.Select(s => (Date: s.Date, Return: (double)s.DailyReturn)).ToList();
         var years = Math.Max((snapshots[^1].Date.ToDateTime(TimeOnly.MinValue) - snapshots[0].Date.ToDateTime(TimeOnly.MinValue)).TotalDays / 365.0, 1.0 / 365.0);
 
         var totalReturn = initial == 0 ? 0m : (final - initial) / initial;
         var annualisedReturn = (decimal)(Math.Pow(1.0 + (double)totalReturn, 1.0 / years) - 1.0);
-        var sharpe = ComputeSharpe(dailyReturns, request.RiskFreeRate);
-        var sortino = ComputeSortino(dailyReturns, request.RiskFreeRate);
+        var sharpe = ComputeSharpe(datedDailyReturns, request.RiskFreeRate, request.RiskFreeRateSeries);
+        var sortino = ComputeSortino(datedDailyReturns, request.RiskFreeRate, request.RiskFreeRateSeries);
         var (maxDrawdown, maxDrawdownPct, recoveryDays) = ComputeMaxDrawdown(snapshots);
         var calmar = maxDrawdown == 0 ? 0.0 : (double)annualisedReturn / (double)maxDrawdownPct;
 
@@ -66,29 +66,48 @@ internal static class BacktestMetricsEngine
 
     // ── Statistical helpers ──────────────────────────────────────────────────
 
-    private static double ComputeSharpe(IReadOnlyList<double> dailyReturns, double annualRfr)
+    private static double ComputeSharpe(
+        IReadOnlyList<(DateOnly Date, double Return)> dailyReturns,
+        double annualRfr,
+        IReadOnlyDictionary<DateOnly, double>? annualRfrSeries)
     {
         if (dailyReturns.Count < 2)
             return 0.0;
-        var dailyRfr = annualRfr / 252.0;
-        var excess = dailyReturns.Select(r => r - dailyRfr).ToList();
+        var excess = dailyReturns
+            .Select(period => period.Return - ResolveDailyRiskFreeRate(period.Date, annualRfr, annualRfrSeries))
+            .ToList();
         var mean = excess.Average();
         var std = StdDev(excess);
         return std < 1e-10 ? 0.0 : mean / std * Math.Sqrt(252.0);
     }
 
-    private static double ComputeSortino(IReadOnlyList<double> dailyReturns, double annualRfr)
+    private static double ComputeSortino(
+        IReadOnlyList<(DateOnly Date, double Return)> dailyReturns,
+        double annualRfr,
+        IReadOnlyDictionary<DateOnly, double>? annualRfrSeries)
     {
         if (dailyReturns.Count < 2)
             return 0.0;
-        var dailyRfr = annualRfr / 252.0;
-        var excess = dailyReturns.Select(r => r - dailyRfr).ToList();
+        var excess = dailyReturns
+            .Select(period => period.Return - ResolveDailyRiskFreeRate(period.Date, annualRfr, annualRfrSeries))
+            .ToList();
         var mean = excess.Average();
         var downside = excess.Where(r => r < 0).ToList();
         if (downside.Count == 0)
             return double.PositiveInfinity;
         var downsideDev = Math.Sqrt(downside.Select(r => r * r).Average());
         return downsideDev < 1e-10 ? 0.0 : mean / downsideDev * Math.Sqrt(252.0);
+    }
+
+    private static double ResolveDailyRiskFreeRate(
+        DateOnly date,
+        double annualRfrFallback,
+        IReadOnlyDictionary<DateOnly, double>? annualRfrSeries)
+    {
+        var annualRate = annualRfrSeries is not null && annualRfrSeries.TryGetValue(date, out var value)
+            ? value
+            : annualRfrFallback;
+        return annualRate / 252.0;
     }
 
     private static (decimal maxDrawdown, decimal maxDrawdownPct, int recoveryDays) ComputeMaxDrawdown(

--- a/tests/Meridian.Backtesting.Tests/BacktestMetricsEngineTests.cs
+++ b/tests/Meridian.Backtesting.Tests/BacktestMetricsEngineTests.cs
@@ -10,6 +10,73 @@ namespace Meridian.Backtesting.Tests;
 /// </summary>
 public sealed class BacktestMetricsEngineTests
 {
+
+    [Fact]
+    public void Compute_ScalarRiskFreeRateFallback_UsesConstantDailyExcessReturns()
+    {
+        var startDate = new DateOnly(2024, 1, 2);
+        var snapshots = BuildSnapshots([100m, 102m, 101m, 103m], startDate);
+
+        var request = new BacktestRequest(
+            From: startDate,
+            To: startDate.AddDays(3),
+            InitialCash: 100m,
+            RiskFreeRate: 0.05);
+
+        var metrics = BacktestMetricsEngine.Compute(snapshots, [], [], request);
+
+        var returns = snapshots.Select(s => (double)s.DailyReturn).ToList();
+        var dailyRf = 0.05 / 252.0;
+        var excess = returns.Select(r => r - dailyRf).ToList();
+        var mean = excess.Average();
+        var std = SampleStdDev(excess);
+        var downside = excess.Where(r => r < 0).ToList();
+        var downsideDev = Math.Sqrt(downside.Select(r => r * r).Average());
+        var expectedSharpe = mean / std * Math.Sqrt(252.0);
+        var expectedSortino = mean / downsideDev * Math.Sqrt(252.0);
+
+        metrics.SharpeRatio.Should().BeApproximately(expectedSharpe, 1e-10);
+        metrics.SortinoRatio.Should().BeApproximately(expectedSortino, 1e-10);
+    }
+
+    [Fact]
+    public void Compute_RiskFreeRateSeries_UsesDateMatchedRatesWithFallback()
+    {
+        var startDate = new DateOnly(2024, 1, 2);
+        var snapshots = BuildSnapshots([100m, 102m, 101m, 103m], startDate);
+
+        var series = new Dictionary<DateOnly, double>
+        {
+            [startDate] = 0.00,
+            [startDate.AddDays(1)] = 0.252, // daily 0.1%
+            [startDate.AddDays(3)] = 0.126  // daily 0.05%
+        };
+
+        var request = new BacktestRequest(
+            From: startDate,
+            To: startDate.AddDays(3),
+            InitialCash: 100m,
+            RiskFreeRate: 0.05,
+            RiskFreeRateSeries: series);
+
+        var metrics = BacktestMetricsEngine.Compute(snapshots, [], [], request);
+
+        var expectedExcess = snapshots
+            .Select(s =>
+            {
+                var annual = series.TryGetValue(s.Date, out var rate) ? rate : 0.05;
+                return (double)s.DailyReturn - annual / 252.0;
+            })
+            .ToList();
+        var mean = expectedExcess.Average();
+        var std = SampleStdDev(expectedExcess);
+        var downside = expectedExcess.Where(r => r < 0).ToList();
+        var downsideDev = Math.Sqrt(downside.Select(r => r * r).Average());
+
+        metrics.SharpeRatio.Should().BeApproximately(mean / std * Math.Sqrt(252.0), 1e-10);
+        metrics.SortinoRatio.Should().BeApproximately(mean / downsideDev * Math.Sqrt(252.0), 1e-10);
+    }
+
     // ------------------------------------------------------------------ //
     //  ComputeMaxDrawdown — explicit peak tracking (regression: recovery  //
     //  days must use the recorded peak, not an algebraic reconstruction) //
@@ -131,6 +198,18 @@ public sealed class BacktestMetricsEngineTests
     // ------------------------------------------------------------------ //
     //  Helper                                                             //
     // ------------------------------------------------------------------ //
+
+    private static double SampleStdDev(IReadOnlyList<double> values)
+    {
+        if (values.Count < 2)
+        {
+            return 0.0;
+        }
+
+        var mean = values.Average();
+        var variance = values.Sum(v => (v - mean) * (v - mean)) / (values.Count - 1);
+        return Math.Sqrt(variance);
+    }
 
     private static IReadOnlyList<PortfolioSnapshot> BuildSnapshots(
         IEnumerable<decimal> equityValues,


### PR DESCRIPTION
### Motivation
- Enable Sharpe/Sortino calculations to use period-matched excess returns driven by a date-indexed risk-free series instead of only a scalar annual rate. 
- Preserve backward compatibility by keeping the scalar `RiskFreeRate` as a fallback when a series is not provided.

### Description
- Added optional `IReadOnlyDictionary<DateOnly,double>? RiskFreeRateSeries` to `BacktestRequest` and documented fallback semantics. (`src/Meridian.Backtesting.Sdk/BacktestRequest.cs`)
- Updated `BacktestMetricsEngine` to produce dated daily returns and compute excess returns using per-date lookups; `ComputeSharpe` and `ComputeSortino` now accept dated returns and an optional annual-rate series. (`src/Meridian.Backtesting/Metrics/BacktestMetricsEngine.cs`)
- Introduced `ResolveDailyRiskFreeRate` helper to map a date to a daily risk-free rate using the series with scalar fallback, and wired this into Sharpe/Sortino excess-return calculations. (`src/Meridian.Backtesting/Metrics/BacktestMetricsEngine.cs`)
- Added unit tests that validate scalar fallback behavior and date-indexed series behavior, plus a `SampleStdDev` helper for test computations. (`tests/Meridian.Backtesting.Tests/BacktestMetricsEngineTests.cs`)

### Testing
- Added tests: `Compute_ScalarRiskFreeRateFallback_UsesConstantDailyExcessReturns` and `Compute_RiskFreeRateSeries_UsesDateMatchedRatesWithFallback` in `BacktestMetricsEngineTests`.
- Attempted to run the focused unit tests via `dotnet test` for the Backtesting tests filter, but the test runner could not execute in this environment because `dotnet` was not available (run failed with `dotnet: command not found`).
- Tests are deterministic and exercise both fallback and per-date lookup code paths; they should pass when run in a standard .NET-capable CI or developer environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d122485c8320a844b5c4ebb78a8d)