### PR TITLE
Add QuantScript runtime resource limits with diagnostics

### DIFF
--- a/src/Meridian.QuantScript/Compilation/ScriptRunResult.cs
+++ b/src/Meridian.QuantScript/Compilation/ScriptRunResult.cs
@@ -12,6 +12,7 @@ public sealed record ScriptRunResult(
     TimeSpan CompileTime,
     long PeakMemoryBytes,
     IReadOnlyList<ScriptDiagnostic> CompilationErrors,
+    IReadOnlyList<ScriptDiagnostic> RuntimeDiagnostics,
     string? RuntimeError,
     string ConsoleOutput,
     IReadOnlyList<KeyValuePair<string, string>> Metrics,

--- a/src/Meridian.QuantScript/Compilation/ScriptRunner.cs
+++ b/src/Meridian.QuantScript/Compilation/ScriptRunner.cs
@@ -90,6 +90,7 @@ public sealed class ScriptRunner : IScriptRunner
                     CompileTime: compilationResult.CompilationTime,
                     PeakMemoryBytes: 0,
                     CompilationErrors: compilationResult.Diagnostics,
+                    RuntimeDiagnostics: Array.Empty<ScriptDiagnostic>(),
                     RuntimeError: null,
                     ConsoleOutput: string.Empty,
                     Metrics: Array.Empty<KeyValuePair<string, string>>(),
@@ -131,6 +132,7 @@ public sealed class ScriptRunner : IScriptRunner
 
         string? runtimeError = null;
         IReadOnlyList<ScriptDiagnostic> continuationDiagnostics = Array.Empty<ScriptDiagnostic>();
+        var runtimeDiagnostics = new List<ScriptDiagnostic>();
         ScriptExecutionCheckpoint? nextCheckpoint = checkpoint;
         var runPlotQueue = new PlotQueue();
         TimeSpan continuationCompileTime = TimeSpan.Zero;
@@ -198,7 +200,41 @@ public sealed class ScriptRunner : IScriptRunner
         wallClock.Stop();
         var peakMemory = Math.Max(0, GC.GetTotalMemory(false) - memBefore);
         var plots = runPlotQueue.DrainRemaining();
-        var resultSuccess = runtimeError is null && continuationDiagnostics.Count == 0;
+        var metrics = globals.DrainMetrics();
+        var capturedBacktests = globals.Backtest.DrainCapturedResults();
+
+        var outputItemsCount = metrics.Count + plots.Count + capturedBacktests.Count;
+        if (_options.MaxMemoryDeltaBytes > 0 && peakMemory > _options.MaxMemoryDeltaBytes)
+        {
+            runtimeDiagnostics.Add(new ScriptDiagnostic(
+                "RuntimeLimit",
+                $"Memory delta limit exceeded: {peakMemory} bytes > {_options.MaxMemoryDeltaBytes} bytes.",
+                0,
+                0));
+            runtimeError ??= "Script exceeded configured memory delta limit.";
+        }
+
+        if (_options.MaxRunElapsedMilliseconds > 0 && wallClock.ElapsedMilliseconds > _options.MaxRunElapsedMilliseconds)
+        {
+            runtimeDiagnostics.Add(new ScriptDiagnostic(
+                "RuntimeLimit",
+                $"Elapsed limit exceeded: {wallClock.ElapsedMilliseconds} ms > {_options.MaxRunElapsedMilliseconds} ms.",
+                0,
+                0));
+            runtimeError ??= "Script exceeded configured elapsed-time limit.";
+        }
+
+        if (_options.MaxOutputItemsPerRun > 0 && outputItemsCount > _options.MaxOutputItemsPerRun)
+        {
+            runtimeDiagnostics.Add(new ScriptDiagnostic(
+                "RuntimeLimit",
+                $"Output item limit exceeded: {outputItemsCount} items > {_options.MaxOutputItemsPerRun} items.",
+                0,
+                0));
+            runtimeError ??= "Script exceeded configured output-item limit.";
+        }
+
+        var resultSuccess = runtimeError is null && continuationDiagnostics.Count == 0 && runtimeDiagnostics.Count == 0;
         if (checkpoint is not null)
             compileTime = continuationCompileTime;
 
@@ -208,12 +244,13 @@ public sealed class ScriptRunner : IScriptRunner
             CompileTime: compileTime,
             PeakMemoryBytes: peakMemory,
             CompilationErrors: continuationDiagnostics,
+            RuntimeDiagnostics: runtimeDiagnostics,
             RuntimeError: runtimeError,
             ConsoleOutput: globals.DrainConsoleOutput(),
-            Metrics: globals.DrainMetrics(),
+            Metrics: metrics,
             Plots: plots,
             TradesSummary: Array.Empty<string>(),
-            CapturedBacktests: globals.Backtest.DrainCapturedResults(),
+            CapturedBacktests: capturedBacktests,
             RuntimeParameters: globals.SnapshotRuntimeParameters(),
             Checkpoint: resultSuccess ? nextCheckpoint : checkpoint);
     }
@@ -239,6 +276,7 @@ public sealed class ScriptRunner : IScriptRunner
             CompileTime: TimeSpan.Zero,
             PeakMemoryBytes: 0,
             CompilationErrors: Array.Empty<ScriptDiagnostic>(),
+            RuntimeDiagnostics: Array.Empty<ScriptDiagnostic>(),
             RuntimeError: "Script cancelled by user.",
             ConsoleOutput: string.Empty,
             Metrics: Array.Empty<KeyValuePair<string, string>>(),

--- a/src/Meridian.QuantScript/QuantScriptOptions.cs
+++ b/src/Meridian.QuantScript/QuantScriptOptions.cs
@@ -30,6 +30,24 @@ public sealed class QuantScriptOptions
     public string DefaultDataRoot { get; init; } = "./data";
 
     /// <summary>
+    /// Maximum allowed increase in managed memory (bytes) during a single script run.
+    /// Set to 0 or less to disable the guard.
+    /// </summary>
+    public long MaxMemoryDeltaBytes { get; init; } = 0;
+
+    /// <summary>
+    /// Optional guard for maximum elapsed run time in milliseconds, evaluated after each run.
+    /// Set to 0 or less to disable the guard.
+    /// </summary>
+    public int MaxRunElapsedMilliseconds { get; init; } = 0;
+
+    /// <summary>
+    /// Optional guard for maximum emitted artifacts (metrics + plots + captured backtests).
+    /// Set to 0 or less to disable the guard.
+    /// </summary>
+    public int MaxOutputItemsPerRun { get; init; } = 0;
+
+    /// <summary>
     /// File extension used to identify notebook documents in the scripts directory.
     /// Defaults to <c>.ipynb</c>.
     /// </summary>

--- a/src/Meridian.Wpf/ViewModels/QuantScriptViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/QuantScriptViewModel.cs
@@ -472,7 +472,11 @@ public sealed class QuantScriptViewModel : BindableBase, IDisposable
                     succeeded = false;
                     _session.RecordFailedRun(identities, index);
                     cell.State = NotebookCellExecutionState.Error;
-                    cell.StatusText = result.CompilationErrors.Count > 0 ? $"{result.CompilationErrors.Count} error(s)" : "Failed";
+                    cell.StatusText = result.CompilationErrors.Count > 0
+                        ? $"{result.CompilationErrors.Count} error(s)"
+                        : result.RuntimeDiagnostics.Count > 0
+                            ? "Resource limit"
+                            : "Failed";
                     MarkCellsStaleFrom(index + 1);
                     break;
                 }
@@ -537,6 +541,12 @@ public sealed class QuantScriptViewModel : BindableBase, IDisposable
 
         foreach (var diagnostic in result.CompilationErrors)
             AppendConsole($"[{diagnostic.Line}:{diagnostic.Column}] {diagnostic.Message}", ConsoleEntryKind.Error);
+
+        foreach (var runtimeDiagnostic in result.RuntimeDiagnostics)
+        {
+            AppendConsole($"[{runtimeDiagnostic.Severity}] {runtimeDiagnostic.Message}", ConsoleEntryKind.Error);
+            Diagnostics.Add(new DiagnosticEntry(runtimeDiagnostic.Severity, runtimeDiagnostic.Message));
+        }
 
         foreach (var metric in result.Metrics)
             AddOrUpdateMetric(metric.Key, metric.Value);

--- a/tests/Meridian.QuantScript.Tests/Helpers/FakeScriptRunner.cs
+++ b/tests/Meridian.QuantScript.Tests/Helpers/FakeScriptRunner.cs
@@ -52,6 +52,7 @@ public sealed class FakeScriptRunner : IScriptRunner
         CompileTime: TimeSpan.FromMilliseconds(10),
         PeakMemoryBytes: 0,
         CompilationErrors: Array.Empty<ScriptDiagnostic>(),
+        RuntimeDiagnostics: Array.Empty<ScriptDiagnostic>(),
         RuntimeError: null,
         ConsoleOutput: $"Script ran: {source.Length} chars",
         Metrics: Array.Empty<KeyValuePair<string, string>>(),

--- a/tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs
+++ b/tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs
@@ -16,7 +16,10 @@ public sealed class ScriptRunnerTests
         IQuantScriptCompiler? compiler = null,
         IQuantDataContext? dataContext = null,
         PlotQueue? plotQueue = null,
-        int runTimeoutSeconds = 10)
+        int runTimeoutSeconds = 10,
+        long maxMemoryDeltaBytes = 0,
+        int maxRunElapsedMilliseconds = 0,
+        int maxOutputItemsPerRun = 0)
     {
         compiler ??= new RoslynScriptCompiler(
             Options.Create(new QuantScriptOptions()),
@@ -29,7 +32,13 @@ public sealed class ScriptRunnerTests
             compiler,
             dataContext,
             plotQueue ?? new PlotQueue(),
-            Options.Create(new QuantScriptOptions { RunTimeoutSeconds = runTimeoutSeconds }),
+            Options.Create(new QuantScriptOptions
+            {
+                RunTimeoutSeconds = runTimeoutSeconds,
+                MaxMemoryDeltaBytes = maxMemoryDeltaBytes,
+                MaxRunElapsedMilliseconds = maxRunElapsedMilliseconds,
+                MaxOutputItemsPerRun = maxOutputItemsPerRun
+            }),
             NullLogger<ScriptRunner>.Instance,
             null);
     }
@@ -215,6 +224,30 @@ public sealed class ScriptRunnerTests
         result.Success.Should().BeFalse();
         result.RuntimeError.Should().Be("Script timed out.");
         result.Checkpoint.Should().BeSameAs(first.Checkpoint);
+    }
+
+    [Fact]
+    public async Task RunAsync_ElapsedLimitExceeded_ReturnsRuntimeLimitDiagnostic()
+    {
+        var runner = BuildRunner(maxRunElapsedMilliseconds: 1);
+
+        var result = await runner.RunAsync("System.Threading.Thread.Sleep(25);", NoParams);
+
+        result.Success.Should().BeFalse();
+        result.RuntimeError.Should().Be("Script exceeded configured elapsed-time limit.");
+        result.RuntimeDiagnostics.Should().ContainSingle(x => x.Severity == "RuntimeLimit");
+    }
+
+    [Fact]
+    public async Task RunAsync_OutputLimitExceeded_ReturnsRuntimeLimitDiagnostic()
+    {
+        var runner = BuildRunner(maxOutputItemsPerRun: 1);
+
+        var result = await runner.RunAsync("PrintMetric(\"One\", 1); PrintMetric(\"Two\", 2);", NoParams);
+
+        result.Success.Should().BeFalse();
+        result.RuntimeError.Should().Be("Script exceeded configured output-item limit.");
+        result.RuntimeDiagnostics.Should().Contain(x => x.Message.Contains("Output item limit exceeded"));
     }
 
     // ── Data access ───────────────────────────────────────────────────────────

--- a/tests/Meridian.Wpf.Tests/Support/FakeScriptRunner.cs
+++ b/tests/Meridian.Wpf.Tests/Support/FakeScriptRunner.cs
@@ -54,6 +54,7 @@ internal sealed class FakeScriptRunner : IScriptRunner
         CompileTime: TimeSpan.FromMilliseconds(10),
         PeakMemoryBytes: 0,
         CompilationErrors: Array.Empty<ScriptDiagnostic>(),
+        RuntimeDiagnostics: Array.Empty<ScriptDiagnostic>(),
         RuntimeError: null,
         ConsoleOutput: $"Script ran: {source.Length} chars",
         Metrics: Array.Empty<KeyValuePair<string, string>>(),


### PR DESCRIPTION
### Motivation
- Prevent runaway or noisy QuantScript runs by adding explicit, configurable guards for managed-memory delta, elapsed time, and emitted output items so script authors and operators get deterministic failures when limits are exceeded.
- Surface those failures as structured diagnostics so the UI and automation can present clear, actionable reasons for a run failure.

### Description
- Added new options on `QuantScriptOptions`: `MaxMemoryDeltaBytes`, `MaxRunElapsedMilliseconds`, and `MaxOutputItemsPerRun` to opt-in per-run guards.
- Extended `ScriptRunResult` with `RuntimeDiagnostics` and updated `ScriptRunner` to evaluate memory/elapsed/output limits after execution, emit `RuntimeLimit` diagnostics, set `RuntimeError` messages, and mark the run unsuccessful when limits are exceeded.
- Updated the WPF `QuantScriptViewModel` to append runtime diagnostics to the console and `Diagnostics` collection and to label failed cells as `"Resource limit"` when runtime diagnostics are present.
- Added deterministic unit tests in `tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs` for elapsed-time and output-item limit failures and updated fake script-runner helpers to populate `RuntimeDiagnostics` and allow passing new option values.

### Testing
- Added unit tests covering elapsed limit and output-item limit failure cases (`ScriptRunnerTests`); these tests were added to the test project but could not be executed in this environment because `dotnet` is not available and the attempted `dotnet test` returned `dotnet: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d14ec69083209fedb256ba4a21ec)