### PR TITLE
Add multi-backtest publication lineage for QuantScript strategy run mirroring

### DIFF
--- a/src/Meridian.Wpf/Services/QuantScriptExecutionHistoryService.cs
+++ b/src/Meridian.Wpf/Services/QuantScriptExecutionHistoryService.cs
@@ -83,9 +83,8 @@ public sealed class QuantScriptExecutionHistoryService
         var mirroredRunId = default(string);
         var warning = default(string);
 
-        if (request.CapturedBacktests.Count == 1)
+        if (request.CapturedBacktests.Count > 0)
         {
-            var backtest = request.CapturedBacktests[0];
             var publicationParameters = new Dictionary<string, string>(
                 request.ParameterSnapshot,
                 StringComparer.OrdinalIgnoreCase)
@@ -95,18 +94,15 @@ public sealed class QuantScriptExecutionHistoryService
                 ["executionId"] = executionId
             };
 
-            mirroredRunId = await _strategyRunWorkspaceService.RecordBacktestRunAsync(
-                backtest.Request,
-                backtest,
+            var mirroredRunIds = await _strategyRunWorkspaceService.RecordCapturedBacktestsAsync(
+                request.CapturedBacktests,
                 new BacktestRunPublicationOptions(
                     StrategyName: request.DocumentTitle,
                     StrategyId: BuildQuantScriptStrategyId(request.DocumentTitle),
+                    PublicationIdentity: executionId,
                     AdditionalParameters: publicationParameters),
                 ct).ConfigureAwait(false);
-        }
-        else if (request.CapturedBacktests.Count > 1)
-        {
-            warning = "Shared Research mirroring was skipped because this execution captured more than one backtest. Run the backtests separately to compare them in Strategy Runs.";
+            mirroredRunId = mirroredRunIds.FirstOrDefault();
         }
 
         var record = new QuantScriptExecutionRecord(

--- a/src/Meridian.Wpf/Services/StrategyRunWorkspaceService.cs
+++ b/src/Meridian.Wpf/Services/StrategyRunWorkspaceService.cs
@@ -15,6 +15,7 @@ public sealed record BacktestRunPublicationOptions(
     string StrategyName,
     string? StrategyId = null,
     string? ParentRunId = null,
+    string? PublicationIdentity = null,
     IReadOnlyDictionary<string, string>? AdditionalParameters = null,
     string? PortfolioId = null,
     string? LedgerReference = null,
@@ -353,6 +354,49 @@ public sealed class StrategyRunWorkspaceService
         await SetActiveRunContextAsync(entry.RunId, ct).ConfigureAwait(false);
 
         return entry.RunId;
+    }
+
+    public async Task<IReadOnlyList<string>> RecordCapturedBacktestsAsync(
+        IReadOnlyList<BacktestResult> backtests,
+        BacktestRunPublicationOptions publication,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(backtests);
+        ArgumentNullException.ThrowIfNull(publication);
+        ArgumentException.ThrowIfNullOrWhiteSpace(publication.StrategyName);
+
+        if (backtests.Count == 0)
+            return Array.Empty<string>();
+
+        var publicationIdentity = string.IsNullOrWhiteSpace(publication.PublicationIdentity)
+            ? Guid.NewGuid().ToString("N")
+            : publication.PublicationIdentity.Trim();
+        var parentRunId = $"quant-parent-{publicationIdentity}";
+        var recorded = new List<string>(backtests.Count);
+
+        for (var index = 0; index < backtests.Count; index++)
+        {
+            ct.ThrowIfCancellationRequested();
+            var childParameters = publication.AdditionalParameters is null
+                ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(publication.AdditionalParameters, StringComparer.OrdinalIgnoreCase);
+            childParameters["publicationIdentity"] = publicationIdentity;
+            childParameters["publicationIndex"] = (index + 1).ToString(CultureInfo.InvariantCulture);
+            childParameters["publicationCount"] = backtests.Count.ToString(CultureInfo.InvariantCulture);
+
+            var childOptions = publication with
+            {
+                StrategyName = backtests.Count == 1 ? publication.StrategyName : $"{publication.StrategyName} #{index + 1}",
+                ParentRunId = parentRunId,
+                PublicationIdentity = publicationIdentity,
+                AdditionalParameters = childParameters
+            };
+
+            var runId = await RecordBacktestRunAsync(backtests[index].Request, backtests[index], childOptions, ct).ConfigureAwait(false);
+            recorded.Add(runId);
+        }
+
+        return recorded;
     }
 
     private async Task<ActiveRunContext?> BuildActiveRunContextAsync(string runId, CancellationToken ct)

--- a/tests/Meridian.Wpf.Tests/Services/StrategyRunWorkspaceServiceTests.cs
+++ b/tests/Meridian.Wpf.Tests/Services/StrategyRunWorkspaceServiceTests.cs
@@ -278,6 +278,79 @@ public sealed class StrategyRunWorkspaceServiceTests
         detail.Parameters.Should().Contain(new KeyValuePair<string, string>("executionId", "exec-123"));
     }
 
+    [Fact]
+    public async Task RecordCapturedBacktestsAsync_WithZeroBacktests_ReturnsEmptyAndRecordsNothing()
+    {
+        var store = new StrategyRunStore();
+        var service = new StrategyRunWorkspaceService(
+            store,
+            new Meridian.Strategies.Services.PortfolioReadService(),
+            new Meridian.Strategies.Services.LedgerReadService());
+
+        var runIds = await service.RecordCapturedBacktestsAsync(
+            Array.Empty<BacktestResult>(),
+            new BacktestRunPublicationOptions("QuantScript Basket"));
+
+        runIds.Should().BeEmpty();
+        (await service.GetRunsAsync()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RecordCapturedBacktestsAsync_WithOneBacktest_PreservesDeterministicPublicationMetadata()
+    {
+        var store = new StrategyRunStore();
+        var service = new StrategyRunWorkspaceService(
+            store,
+            new Meridian.Strategies.Services.PortfolioReadService(),
+            new Meridian.Strategies.Services.LedgerReadService());
+
+        var runIds = await service.RecordCapturedBacktestsAsync(
+            [BuildResult()],
+            new BacktestRunPublicationOptions(
+                StrategyName: "Momentum Notebook",
+                StrategyId: "quantscript-momentum",
+                PublicationIdentity: "exec-one",
+                AdditionalParameters: new Dictionary<string, string> { ["symbol"] = "SPY" }));
+
+        runIds.Should().HaveCount(1);
+        var detail = await service.GetRunDetailAsync(runIds[0]);
+        detail.Should().NotBeNull();
+        detail!.Summary.ParentRunId.Should().Be("quant-parent-exec-one");
+        detail.Summary.StrategyName.Should().Be("Momentum Notebook");
+        detail.Parameters.Should().Contain(new KeyValuePair<string, string>("publicationIdentity", "exec-one"));
+        detail.Parameters.Should().Contain(new KeyValuePair<string, string>("publicationIndex", "1"));
+        detail.Parameters.Should().Contain(new KeyValuePair<string, string>("publicationCount", "1"));
+        detail.Parameters.Should().Contain(new KeyValuePair<string, string>("symbol", "SPY"));
+    }
+
+    [Fact]
+    public async Task RecordCapturedBacktestsAsync_WithMultipleBacktests_AssignsParentAndChildNaming()
+    {
+        var store = new StrategyRunStore();
+        var service = new StrategyRunWorkspaceService(
+            store,
+            new Meridian.Strategies.Services.PortfolioReadService(),
+            new Meridian.Strategies.Services.LedgerReadService());
+
+        var backtests = new[] { BuildResult(), BuildResult() };
+        var runIds = await service.RecordCapturedBacktestsAsync(
+            backtests,
+            new BacktestRunPublicationOptions(
+                StrategyName: "Basket Notebook",
+                StrategyId: "quantscript-basket",
+                PublicationIdentity: "exec-many"));
+
+        runIds.Should().HaveCount(2);
+        var first = await service.GetRunDetailAsync(runIds[0]);
+        var second = await service.GetRunDetailAsync(runIds[1]);
+        first!.Summary.ParentRunId.Should().Be("quant-parent-exec-many");
+        second!.Summary.ParentRunId.Should().Be("quant-parent-exec-many");
+        first.Summary.StrategyName.Should().Be("Basket Notebook #1");
+        second.Summary.StrategyName.Should().Be("Basket Notebook #2");
+        first.Parameters.Should().Contain(new KeyValuePair<string, string>("publicationIndex", "1"));
+        second.Parameters.Should().Contain(new KeyValuePair<string, string>("publicationIndex", "2"));
+    }
+
     private static BacktestResult BuildResult()
     {
         var startedAt = new DateTimeOffset(2026, 3, 20, 14, 0, 0, TimeSpan.Zero);

--- a/tests/Meridian.Wpf.Tests/ViewModels/QuantScriptViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/QuantScriptViewModelTests.cs
@@ -174,7 +174,7 @@ public sealed class QuantScriptViewModelTests
     public void SelectedExecutionRecord_WithoutMirroredRun_DisablesRunHistoryHandoffs()
     {
         var vm = CreateVm();
-        var record = MakeHistoryRecord(mirroredRunId: null);
+        var record = MakeHistoryRecord(mirroredRunId: null, capturedBacktestCount: 0);
 
         vm.RunHistory.Add(record);
         vm.SelectedExecutionRecord = record;
@@ -184,6 +184,20 @@ public sealed class QuantScriptViewModelTests
         vm.OpenRunBrowserCommand.CanExecute(null).Should().BeFalse();
         vm.OpenRunDetailCommand.CanExecute(null).Should().BeFalse();
         vm.CompareInResearchCommand.CanExecute(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SelectedExecutionRecord_WithMultipleCapturedBacktests_ReportsMirroredCountSummary()
+    {
+        var vm = CreateVm();
+        var record = MakeHistoryRecord(mirroredRunId: "run-quant-parent", capturedBacktestCount: 3);
+
+        vm.RunHistory.Add(record);
+        vm.SelectedExecutionRecord = record;
+
+        vm.SelectedHistoryEvidenceText.Should().Be("1 metric | 1 plot | 3 mirrored backtests");
+        vm.SelectedHistoryRunLinkText.Should().Contain("run-quant-parent");
+        vm.OpenRunBrowserCommand.CanExecute(null).Should().BeTrue();
     }
 
     // ── ScriptSource property ─────────────────────────────────────────────────
@@ -340,7 +354,7 @@ public sealed class QuantScriptViewModelTests
         xaml.Should().Contain("{Binding SelectedHistoryConsolePreview}");
     }
 
-    private static QuantScriptExecutionRecord MakeHistoryRecord(string? mirroredRunId)
+    private static QuantScriptExecutionRecord MakeHistoryRecord(string? mirroredRunId, int? capturedBacktestCount = null)
         => new(
             ExecutionId: Guid.NewGuid().ToString("N"),
             DocumentTitle: "Momentum Notebook",
@@ -356,7 +370,7 @@ public sealed class QuantScriptViewModelTests
             ConsoleExcerpt: "Loaded 42 bars",
             Metrics: [new QuantScriptExecutionMetricRecord("Sharpe", "1.23", "Risk")],
             PlotTitles: ["Equity Curve"],
-            CapturedBacktestCount: mirroredRunId is null ? 0 : 1,
+            CapturedBacktestCount: capturedBacktestCount ?? (mirroredRunId is null ? 0 : 1),
             MirroredRunId: mirroredRunId);
 
     private static string GetRepositoryFilePath(string relativePath)


### PR DESCRIPTION
### Motivation
- Enable publishing of executions that capture more than one `BacktestResult` by mirroring captured backtests into shared Strategy Runs with explicit parent/child lineage and stable metadata. 
- Preserve per-child parameter/context metadata and provide deterministic naming/indexing so repeated publishes are consistent and repeatable. 

### Description
- Extended `BacktestRunPublicationOptions` with a `PublicationIdentity` field and added `RecordCapturedBacktestsAsync(...)` to `src/Meridian.Wpf/Services/StrategyRunWorkspaceService.cs` to record 0/1/N backtests in a single deterministic flow. 
- `RecordCapturedBacktestsAsync` creates a stable parent id (`quant-parent-<publicationIdentity>`), emits one child run per captured backtest, injects `publicationIdentity`, `publicationIndex`, and `publicationCount` into child `AdditionalParameters`, and uses deterministic child naming (`<StrategyName> #<n>` for multi-run publishes). 
- Kept `RecordBacktestRunAsync` as the per-child recorder and reused it from the new multi-capture method. 
- Updated `src/Meridian.Wpf/Services/QuantScriptExecutionHistoryService.cs` so `RecordExecutionAsync` mirrors all captured backtests by invoking the new `RecordCapturedBacktestsAsync(...)` and uses the `executionId` as the `PublicationIdentity`. 
- Added unit tests in `tests/Meridian.Wpf.Tests/Services/StrategyRunWorkspaceServiceTests.cs` covering zero, one, and multiple captured backtest publishing behaviors and lineage metadata, and updated `tests/Meridian.Wpf.Tests/ViewModels/QuantScriptViewModelTests.cs` to cover multi-captured-backtest history presentation. 

### Testing
- Added automated unit tests: `StrategyRunWorkspaceServiceTests` (0/1/N capture cases) and `QuantScriptViewModelTests` (multi-backtest history presentation). 
- Attempted to run the workspace service tests with `dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter "FullyQualifiedName~StrategyRunWorkspaceServiceTests" /p:EnableWindowsTargeting=true --logger "console;verbosity=minimal"`, but the run failed in the automation environment with `dotnet: command not found`. 
- Tests are committed and should pass when executed in a developer environment with the .NET SDK installed using `dotnet test`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d151983483209fd9823622b62caa)