### PR TITLE
Fix missing market-data type import in BatchBacktestViewModel

### DIFF
--- a/src/Meridian.Wpf/ViewModels/BatchBacktestViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/BatchBacktestViewModel.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Meridian.Backtesting;
 using Meridian.Backtesting.Sdk;
+using Meridian.Contracts.Domain.Models;
 
 namespace Meridian.Wpf.ViewModels;
 


### PR DESCRIPTION
### Motivation
- The nested `NoOpBatchSweepStrategy` in `BatchBacktestViewModel.cs` implemented `IBacktestStrategy` but could not resolve the market-data event types (`Trade`, `BboQuotePayload`, `HistoricalBar`, `LOBSnapshot`), causing compile errors and incomplete interface implementation.

### Description
- Added `using Meridian.Contracts.Domain.Models;` to `src/Meridian.Wpf/ViewModels/BatchBacktestViewModel.cs` so the strategy method signatures match `IBacktestStrategy` and the market-data types resolve.

### Testing
- Attempted to run `dotnet build src/Meridian.Wpf/Meridian.Wpf.csproj -p:EnableWindowsTargeting=true`, but the command could not execute in this environment because `dotnet` is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d6f6432c8320b456c99bfcea498b)