### PR TITLE
Add settlement instruction overlap/default validation and tests

### DIFF
--- a/src/Meridian.FSharp/Domain/SettlementInstructionCommands.fs
+++ b/src/Meridian.FSharp/Domain/SettlementInstructionCommands.fs
@@ -1,0 +1,106 @@
+namespace Meridian.FSharp.Domain
+
+open System
+
+type SettlementDetailType =
+    | BankWire
+    | Custody
+    | Other of string
+
+type SettlementCounterpartyScope =
+    | Global
+    | Counterparty of string
+
+type SettlementInstruction = {
+    InstructionId: Guid
+    AccountId: AccountId
+    DetailType: SettlementDetailType
+    Currency: string
+    CounterpartyScope: SettlementCounterpartyScope
+    EffectiveFromUtc: DateTimeOffset
+    EffectiveToUtc: DateTimeOffset option
+    IsDefault: bool
+    IsClosed: bool
+    SupersedesInstructionId: Guid option
+}
+
+type SettlementCommandError = {
+    Code: string
+    Message: string
+}
+
+module SettlementInstructionCommands =
+    let private err code message = Error { Code = code; Message = message }
+
+    let private effectiveWindowValid (instruction: SettlementInstruction) =
+        instruction.EffectiveToUtc |> Option.forall (fun x -> x > instruction.EffectiveFromUtc)
+
+    let private overlaps (a: SettlementInstruction) (b: SettlementInstruction) =
+        let aEnd = a.EffectiveToUtc |> Option.defaultValue DateTimeOffset.MaxValue
+        let bEnd = b.EffectiveToUtc |> Option.defaultValue DateTimeOffset.MaxValue
+        a.EffectiveFromUtc < bEnd && b.EffectiveFromUtc < aEnd
+
+    let private allowsSupersede existing candidate =
+        candidate.SupersedesInstructionId = Some existing.InstructionId
+
+    let validateAddInstruction (existing: SettlementInstruction list) (candidate: SettlementInstruction) =
+        if not (effectiveWindowValid candidate) then
+            err "SETTLEMENT_EFFECTIVE_WINDOW_INVALID" "EffectiveToUtc must be greater than EffectiveFromUtc when present."
+        elif candidate.IsClosed then
+            err "SETTLEMENT_ACCOUNT_STATUS_CLOSED" "Cannot add settlement instruction for a closed account detail state."
+        else
+            let conflicting =
+                existing
+                |> List.filter (fun x ->
+                    x.AccountId = candidate.AccountId
+                    && x.DetailType = candidate.DetailType
+                    && not x.IsClosed
+                    && overlaps x candidate
+                    && not (allowsSupersede x candidate))
+
+            if not conflicting.IsEmpty then
+                err "SETTLEMENT_OVERLAP_CONFLICT" "Overlapping active windows for the same account/detail type require an explicit supersede reference."
+            else
+                Ok candidate
+
+    let enforceSingleDefault (existing: SettlementInstruction list) (candidate: SettlementInstruction) =
+        if not candidate.IsDefault then
+            Ok existing
+        else
+            let sameScope x =
+                x.AccountId = candidate.AccountId
+                && x.Currency.Equals(candidate.Currency, StringComparison.OrdinalIgnoreCase)
+                && x.CounterpartyScope = candidate.CounterpartyScope
+                && not x.IsClosed
+                && overlaps x candidate
+
+            if existing |> List.exists (fun x -> sameScope x && x.IsDefault && x.InstructionId <> candidate.InstructionId) then
+                err "SETTLEMENT_DEFAULT_COLLISION" "At most one default settlement instruction may exist per account/currency/counterparty scope/effective window."
+            else
+                Ok (existing |> List.map (fun x -> if sameScope x && x.InstructionId <> candidate.InstructionId then { x with IsDefault = false } else x))
+
+    let addSettlementInstructionCommand existing candidate =
+        match validateAddInstruction existing candidate with
+        | Error e -> Error e
+        | Ok validated ->
+            match enforceSingleDefault existing validated with
+            | Error e -> Error e
+            | Ok normalized -> Ok (validated :: normalized)
+
+    let setDefaultSettlementInstructionCommand existing instructionId =
+        match existing |> List.tryFind (fun x -> x.InstructionId = instructionId) with
+        | None -> err "SETTLEMENT_ACCOUNT_NOT_FOUND" "Settlement instruction was not found for the specified account."
+        | Some target when target.IsClosed -> err "SETTLEMENT_ACCOUNT_STATUS_CLOSED" "Cannot set default on a closed settlement instruction."
+        | Some target ->
+            let defaulted = { target with IsDefault = true }
+            match enforceSingleDefault existing defaulted with
+            | Error e -> Error e
+            | Ok normalized ->
+                Ok (normalized |> List.map (fun x -> if x.InstructionId = target.InstructionId then defaulted else x))
+
+    let upsertAccountDetailsCommand existing candidate =
+        if candidate.IsClosed then
+            err "SETTLEMENT_ACCOUNT_STATUS_CLOSED" "Cannot upsert details for a closed account status."
+        else
+            let withoutCurrent = existing |> List.filter (fun x -> x.InstructionId <> candidate.InstructionId)
+            addSettlementInstructionCommand withoutCurrent candidate

--- a/src/Meridian.FSharp/Meridian.FSharp.fsproj
+++ b/src/Meridian.FSharp/Meridian.FSharp.fsproj
@@ -31,6 +31,7 @@
     <Compile Include="Domain/SecurityMasterEvents.fs" />
     <Compile Include="Domain/SecurityMasterCommands.fs" />
     <Compile Include="Domain/FundStructure.fs" />
+    <Compile Include="Domain/SettlementInstructionCommands.fs" />
     <Compile Include="Domain/DirectLending.fs" />
 
     <!-- Comprehensive security master domain — self-contained, no inter-domain dependencies -->

--- a/tests/Meridian.FSharp.Tests/Meridian.FSharp.Tests.fsproj
+++ b/tests/Meridian.FSharp.Tests/Meridian.FSharp.Tests.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="LedgerKernelTests.fs" />
     <Compile Include="DirectLendingInteropTests.fs" />
     <Compile Include="CashFlowProjectorTests.fs" />
+    <Compile Include="SettlementInstructionCommandsTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Meridian.FSharp.Tests/SettlementInstructionCommandsTests.fs
+++ b/tests/Meridian.FSharp.Tests/SettlementInstructionCommandsTests.fs
@@ -1,0 +1,58 @@
+namespace Meridian.FSharp.Tests
+
+open System
+open FsUnit.Xunit
+open Xunit
+open Meridian.FSharp.Domain
+
+module SettlementInstructionFixtures =
+    let mk account detailType fromUtc toUtc isDefault supersedes =
+        { InstructionId = Guid.NewGuid()
+          AccountId = account
+          DetailType = detailType
+          Currency = "USD"
+          CounterpartyScope = SettlementCounterpartyScope.Global
+          EffectiveFromUtc = fromUtc
+          EffectiveToUtc = toUtc
+          IsDefault = isDefault
+          IsClosed = false
+          SupersedesInstructionId = supersedes }
+
+open SettlementInstructionFixtures
+open Meridian.FSharp.Domain.SettlementInstructionCommands
+
+[<Fact>]
+let ``rejects invalid effective window`` () =
+    let account = AccountId(Guid.NewGuid())
+    let fromUtc = DateTimeOffset.Parse("2026-01-10T00:00:00Z")
+    let candidate = mk account SettlementDetailType.BankWire fromUtc (Some fromUtc) false None
+    match addSettlementInstructionCommand [] candidate with
+    | Error e -> e.Code |> should equal "SETTLEMENT_EFFECTIVE_WINDOW_INVALID"
+    | Ok _ -> failwith "Expected validation error"
+
+[<Fact>]
+let ``rejects overlap without supersede`` () =
+    let account = AccountId(Guid.NewGuid())
+    let existing = mk account SettlementDetailType.Custody (DateTimeOffset.Parse("2026-01-01T00:00:00Z")) None false None
+    let candidate = mk account SettlementDetailType.Custody (DateTimeOffset.Parse("2026-02-01T00:00:00Z")) None false None
+    match addSettlementInstructionCommand [ existing ] candidate with
+    | Error e -> e.Code |> should equal "SETTLEMENT_OVERLAP_CONFLICT"
+    | Ok _ -> failwith "Expected overlap conflict"
+
+[<Fact>]
+let ``allows overlap when explicitly superseding`` () =
+    let account = AccountId(Guid.NewGuid())
+    let existing = mk account SettlementDetailType.Custody (DateTimeOffset.Parse("2026-01-01T00:00:00Z")) None false None
+    let candidate = mk account SettlementDetailType.Custody (DateTimeOffset.Parse("2026-02-01T00:00:00Z")) None false (Some existing.InstructionId)
+    match addSettlementInstructionCommand [ existing ] candidate with
+    | Ok xs -> xs.Length |> should equal 2
+    | Error e -> failwithf "Unexpected error: %s" e.Code
+
+[<Fact>]
+let ``rejects default collision for same scope and overlapping window`` () =
+    let account = AccountId(Guid.NewGuid())
+    let existing = mk account SettlementDetailType.BankWire (DateTimeOffset.Parse("2026-01-01T00:00:00Z")) None true None
+    let candidate = mk account SettlementDetailType.Custody (DateTimeOffset.Parse("2026-02-01T00:00:00Z")) None true None
+    match addSettlementInstructionCommand [ existing ] candidate with
+    | Error e -> e.Code |> should equal "SETTLEMENT_DEFAULT_COLLISION"
+    | Ok _ -> failwith "Expected default collision"


### PR DESCRIPTION
### Motivation
- Enforce domain-level correctness for settlement instructions: require `EffectiveToUtc > EffectiveFromUtc` when present and prevent ambiguous active-window overlaps for the same `(AccountId, detail-type)` unless an explicit supersede is provided.
- Ensure at-most-one default per `(AccountId, Currency, Counterparty scope, effective window)` and provide deterministic normalization/resolution behavior for add/upsert and set-default flows.
- Surface contract-level error codes so API callers can distinguish overlap, missing instruction, closed-status, and effective-window validation failures.

### Description
- Add a new F# module `Meridian.FSharp.Domain.SettlementInstructionCommands` with types and command entry points `addSettlementInstructionCommand`, `setDefaultSettlementInstructionCommand`, and `upsertAccountDetailsCommand` that implement overlap and default collision detection.
- Enforce `EffectiveToUtc > EffectiveFromUtc` when `EffectiveToUtc` is present and implement interval overlap detection plus `SupersedesInstructionId`-based allowance logic.
- Implement single-default enforcement with deterministic normalization (clears other defaults in the same scope/window) and return structured `SettlementCommandError` values with codes such as `SETTLEMENT_EFFECTIVE_WINDOW_INVALID`, `SETTLEMENT_OVERLAP_CONFLICT`, `SETTLEMENT_DEFAULT_COLLISION`, `SETTLEMENT_ACCOUNT_NOT_FOUND`, and `SETTLEMENT_ACCOUNT_STATUS_CLOSED`.
- Register the new module in `src/Meridian.FSharp/Meridian.FSharp.fsproj` and add focused unit tests in `tests/Meridian.FSharp.Tests/SettlementInstructionCommandsTests.fs`, plus include the test file in the test project file list.

### Testing
- Added unit tests covering invalid effective window, overlap rejection without supersede, overlap acceptance when explicitly superseding, and default-collision detection; these test files were added under `tests/Meridian.FSharp.Tests`.
- Attempted to run the focused test filter with `dotnet test tests/Meridian.FSharp.Tests/Meridian.FSharp.Tests.fsproj --filter "FullyQualifiedName~SettlementInstructionCommandsTests" --logger "console;verbosity=minimal"`, but the command could not be executed in the environment because `dotnet` was not available, so tests were not executed here (failure: `dotnet: command not found`).
- Recommend CI run the F# test project and full integration/test matrix to validate behavior in a proper .NET environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d6af72bc83208c34ec41d5fd2f4f)