### PR TITLE
Enforce account operation policy by operational status (Active/Suspended/Closed)

### DIFF
--- a/src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs
+++ b/src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs
@@ -4,6 +4,21 @@ using Meridian.Storage.Archival;
 
 namespace Meridian.Application.FundAccounts;
 
+public sealed class AccountStatusPolicyException : InvalidOperationException
+{
+    public AccountStatusPolicyException(AccountOperationalStatusDto status, string operation, bool backfillAttempted)
+        : base($"Operation '{operation}' is not allowed while account status is '{status}'.")
+    {
+        Status = status;
+        Operation = operation;
+        BackfillAttempted = backfillAttempted;
+    }
+
+    public AccountOperationalStatusDto Status { get; }
+    public string Operation { get; }
+    public bool BackfillAttempted { get; }
+}
+
 /// <summary>
 /// Thread-safe fund-account service backed by an in-memory working set with optional
 /// durable JSON snapshot persistence for local-first workflows.
@@ -75,6 +90,7 @@ public sealed class InMemoryFundAccountService : IFundAccountService
             request.LedgerReference,
             request.StrategyId,
             request.RunId,
+            request.OperationalStatus,
             request.CustodianDetails,
             request.BankDetails);
 
@@ -152,6 +168,7 @@ public sealed class InMemoryFundAccountService : IFundAccountService
             {
                 return null;
             }
+            EnsureAllowed(stored.Summary, "update-custodian-details");
 
             updated = stored.Summary with { CustodianDetails = request.Details };
             _accounts[accountId] = stored.WithSummary(updated);
@@ -177,6 +194,7 @@ public sealed class InMemoryFundAccountService : IFundAccountService
             {
                 return null;
             }
+            EnsureAllowed(stored.Summary, "update-bank-details");
 
             updated = stored.Summary with { BankDetails = request.Details };
             _accounts[accountId] = stored.WithSummary(updated);
@@ -258,6 +276,7 @@ public sealed class InMemoryFundAccountService : IFundAccountService
         {
             if (_accounts.TryGetValue(request.AccountId, out var stored))
             {
+                EnsureAllowed(stored.Summary, "record-balance-snapshot", request.IsBackfill);
                 stored.Snapshots.Add(dto);
                 snapshot = CaptureSnapshotLocked();
             }
@@ -327,6 +346,7 @@ public sealed class InMemoryFundAccountService : IFundAccountService
         {
             if (_accounts.TryGetValue(request.AccountId, out var stored))
             {
+                EnsureAllowed(stored.Summary, "ingest-custodian-statement", request.IsBackfill, allowSuspended: true);
                 stored.CustodianBatches.Add(batch);
                 stored.CustodianPositions.AddRange(request.Lines);
                 snapshot = CaptureSnapshotLocked();
@@ -356,6 +376,7 @@ public sealed class InMemoryFundAccountService : IFundAccountService
         {
             if (_accounts.TryGetValue(request.AccountId, out var stored))
             {
+                EnsureAllowed(stored.Summary, "ingest-bank-statement", request.IsBackfill, allowSuspended: true);
                 stored.BankBatches.Add(batch);
                 stored.BankLines.AddRange(request.Lines);
                 snapshot = CaptureSnapshotLocked();
@@ -364,6 +385,19 @@ public sealed class InMemoryFundAccountService : IFundAccountService
 
         await PersistSnapshotAsync(snapshot, ct).ConfigureAwait(false);
         return batch;
+    }
+
+    private static void EnsureAllowed(AccountSummaryDto summary, string operation, bool isBackfill = false, bool allowSuspended = false)
+    {
+        if (summary.OperationalStatus == AccountOperationalStatusDto.Closed && !isBackfill)
+        {
+            throw new AccountStatusPolicyException(summary.OperationalStatus, operation, isBackfill);
+        }
+
+        if (summary.OperationalStatus == AccountOperationalStatusDto.Suspended && !allowSuspended)
+        {
+            throw new AccountStatusPolicyException(summary.OperationalStatus, operation, isBackfill);
+        }
     }
 
     public Task<IReadOnlyList<CustodianPositionLineDto>> GetCustodianPositionsAsync(

--- a/src/Meridian.Contracts/FundStructure/AccountManagementDtos.cs
+++ b/src/Meridian.Contracts/FundStructure/AccountManagementDtos.cs
@@ -56,6 +56,7 @@ public sealed record RecordAccountBalanceSnapshotRequest(
     string Currency,
     decimal CashBalance,
     string Source,
+    bool IsBackfill = false,
     string? RecordedBy = null,
     decimal? SecuritiesMarketValue = null,
     decimal? AccruedInterest = null,
@@ -69,6 +70,7 @@ public sealed record IngestCustodianStatementRequest(
     DateOnly AsOfDate,
     string CustodianName,
     string SourceFormat,
+    bool IsBackfill = false,
     string? Notes,
     IReadOnlyList<CustodianPositionLineDto> Lines,
     string LoadedBy);
@@ -79,6 +81,7 @@ public sealed record IngestBankStatementRequest(
     Guid AccountId,
     DateOnly StatementDate,
     string BankName,
+    bool IsBackfill = false,
     string? Notes,
     IReadOnlyList<BankStatementLineDto> Lines,
     string LoadedBy);
@@ -174,6 +177,7 @@ public sealed record CreateAccountRequest(
     string? LedgerReference = null,
     string? StrategyId = null,
     string? RunId = null,
+    AccountOperationalStatusDto OperationalStatus = AccountOperationalStatusDto.Active,
     CustodianAccountDetailsDto? CustodianDetails = null,
     BankAccountDetailsDto? BankDetails = null);
 

--- a/src/Meridian.Contracts/FundStructure/FundStructureDtos.cs
+++ b/src/Meridian.Contracts/FundStructure/FundStructureDtos.cs
@@ -58,6 +58,14 @@ public enum AccountTypeDto
     Other
 }
 
+[JsonConverter(typeof(JsonStringEnumConverter<AccountOperationalStatusDto>))]
+public enum AccountOperationalStatusDto
+{
+    Active,
+    Suspended,
+    Closed
+}
+
 [JsonConverter(typeof(JsonStringEnumConverter<OwnershipRelationshipTypeDto>))]
 public enum OwnershipRelationshipTypeDto
 {
@@ -209,6 +217,7 @@ public sealed record AccountSummaryDto(
     string? LedgerReference,
     string? StrategyId,
     string? RunId,
+    AccountOperationalStatusDto OperationalStatus = AccountOperationalStatusDto.Active,
     CustodianAccountDetailsDto? CustodianDetails = null,
     BankAccountDetailsDto? BankDetails = null,
     FundStructureSharedDataAccessDto? SharedDataAccess = null);

--- a/src/Meridian.Ui.Shared/Endpoints/FundAccountEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/FundAccountEndpoints.cs
@@ -88,8 +88,15 @@ public static class FundAccountEndpoints
             if (request is null)
                 return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
 
-            var result = await service.UpdateCustodianDetailsAsync(accountId, request, context.RequestAborted).ConfigureAwait(false);
-            return result is null ? Results.NotFound() : Results.Json(result, jsonOptions);
+                        try
+            {
+                var result = await service.UpdateCustodianDetailsAsync(accountId, request, context.RequestAborted).ConfigureAwait(false);
+                return result is null ? Results.NotFound() : Results.Json(result, jsonOptions);
+            }
+            catch (AccountStatusPolicyException ex)
+            {
+                return StatusPolicyConflict(ex);
+            }
         })
         .WithName("UpdateCustodianAccountDetails")
         .Produces<AccountSummaryDto>(StatusCodes.Status200OK)
@@ -105,8 +112,15 @@ public static class FundAccountEndpoints
             if (request is null)
                 return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
 
-            var result = await service.UpdateBankDetailsAsync(accountId, request, context.RequestAborted).ConfigureAwait(false);
-            return result is null ? Results.NotFound() : Results.Json(result, jsonOptions);
+                        try
+            {
+                var result = await service.UpdateBankDetailsAsync(accountId, request, context.RequestAborted).ConfigureAwait(false);
+                return result is null ? Results.NotFound() : Results.Json(result, jsonOptions);
+            }
+            catch (AccountStatusPolicyException ex)
+            {
+                return StatusPolicyConflict(ex);
+            }
         })
         .WithName("UpdateBankAccountDetails")
         .Produces<AccountSummaryDto>(StatusCodes.Status200OK)
@@ -213,8 +227,15 @@ public static class FundAccountEndpoints
             if (request is null)
                 return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
 
-            var result = await service.RecordBalanceSnapshotAsync(request, context.RequestAborted).ConfigureAwait(false);
-            return Results.Json(result, jsonOptions, statusCode: StatusCodes.Status201Created);
+                        try
+            {
+                var result = await service.RecordBalanceSnapshotAsync(request, context.RequestAborted).ConfigureAwait(false);
+                return Results.Json(result, jsonOptions, statusCode: StatusCodes.Status201Created);
+            }
+            catch (AccountStatusPolicyException ex)
+            {
+                return StatusPolicyConflict(ex);
+            }
         })
         .WithName("RecordAccountBalanceSnapshot")
         .Produces<AccountBalanceSnapshotDto>(StatusCodes.Status201Created)
@@ -261,8 +282,15 @@ public static class FundAccountEndpoints
             if (request is null)
                 return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
 
-            var result = await service.IngestCustodianStatementAsync(request, context.RequestAborted).ConfigureAwait(false);
-            return Results.Json(result, jsonOptions, statusCode: StatusCodes.Status201Created);
+                        try
+            {
+                var result = await service.IngestCustodianStatementAsync(request, context.RequestAborted).ConfigureAwait(false);
+                return Results.Json(result, jsonOptions, statusCode: StatusCodes.Status201Created);
+            }
+            catch (AccountStatusPolicyException ex)
+            {
+                return StatusPolicyConflict(ex);
+            }
         })
         .WithName("IngestCustodianStatement")
         .Produces<CustodianStatementBatchDto>(StatusCodes.Status201Created)
@@ -294,8 +322,15 @@ public static class FundAccountEndpoints
             if (request is null)
                 return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
 
-            var result = await service.IngestBankStatementAsync(request, context.RequestAborted).ConfigureAwait(false);
-            return Results.Json(result, jsonOptions, statusCode: StatusCodes.Status201Created);
+                        try
+            {
+                var result = await service.IngestBankStatementAsync(request, context.RequestAborted).ConfigureAwait(false);
+                return Results.Json(result, jsonOptions, statusCode: StatusCodes.Status201Created);
+            }
+            catch (AccountStatusPolicyException ex)
+            {
+                return StatusPolicyConflict(ex);
+            }
         })
         .WithName("IngestBankStatement")
         .Produces<BankStatementBatchDto>(StatusCodes.Status201Created)
@@ -360,6 +395,16 @@ public static class FundAccountEndpoints
         .WithName("GetAccountReconciliationResults")
         .Produces<IReadOnlyList<AccountReconciliationResultDto>>(StatusCodes.Status200OK);
     }
+
+
+    private static IResult StatusPolicyConflict(AccountStatusPolicyException ex) => Results.Json(new
+    {
+        error = "account_status_policy_violation",
+        status = ex.Status.ToString(),
+        operation = ex.Operation,
+        backfillAttempted = ex.BackfillAttempted,
+        detail = ex.Message
+    }, statusCode: StatusCodes.Status409Conflict);
 
     private static IFundAccountService? ResolveService(HttpContext context) =>
         context.RequestServices.GetService<IFundAccountService>();

--- a/tests/Meridian.Tests/Application/FundAccounts/FundAccountServiceTests.cs
+++ b/tests/Meridian.Tests/Application/FundAccounts/FundAccountServiceTests.cs
@@ -315,4 +315,35 @@ public sealed class FundAccountServiceTests
         Assert.False(deactivated!.IsActive);
         Assert.NotNull(deactivated.EffectiveTo);
     }
+
+    [Theory]
+    [InlineData(AccountOperationalStatusDto.Active, false)]
+    [InlineData(AccountOperationalStatusDto.Suspended, true)]
+    [InlineData(AccountOperationalStatusDto.Closed, true)]
+    public async Task UpdateCustodianDetails_EnforcesOperationalStatus(AccountOperationalStatusDto status, bool shouldFail)
+    {
+        var svc = CreateService();
+        var account = await svc.CreateAccountAsync(MakeCustodyRequest() with { OperationalStatus = status });
+        var action = () => svc.UpdateCustodianDetailsAsync(account.AccountId, new UpdateCustodianAccountDetailsRequest(
+            new CustodianAccountDetailsDto("x", null, null, null, null, null, null, null), "tester"));
+
+        if (shouldFail) await Assert.ThrowsAsync<AccountStatusPolicyException>(action);
+        else Assert.NotNull(await action());
+    }
+
+    [Theory]
+    [InlineData(AccountOperationalStatusDto.Active, false, false)]
+    [InlineData(AccountOperationalStatusDto.Suspended, false, true)]
+    [InlineData(AccountOperationalStatusDto.Closed, false, true)]
+    [InlineData(AccountOperationalStatusDto.Closed, true, false)]
+    public async Task RecordBalanceSnapshot_EnforcesOperationalStatus(AccountOperationalStatusDto status, bool isBackfill, bool shouldFail)
+    {
+        var svc = CreateService();
+        var account = await svc.CreateAccountAsync(MakeBankRequest() with { OperationalStatus = status });
+        var action = () => svc.RecordBalanceSnapshotAsync(new RecordAccountBalanceSnapshotRequest(
+            account.AccountId, DateOnly.FromDateTime(DateTime.Today), "USD", 100m, "Manual", IsBackfill: isBackfill));
+
+        if (shouldFail) await Assert.ThrowsAsync<AccountStatusPolicyException>(action);
+        else Assert.NotNull(await action());
+    }
 }


### PR DESCRIPTION
### Motivation
- Provide an explicit operational-status policy (Active / Suspended / Closed) so application-layer rules can block or allow mutations and ingestion consistently.
- Apply the matrix to account commands and reconciliation ingestion entrypoints so closed accounts are only modified in backfill mode and suspended accounts are read/recon-only where required.
- Surface policy violations as explicit domain/application errors so API clients receive actionable failure payloads instead of ambiguous errors.
- Add tests to guard command behavior across statuses and prevent policy drift.

### Description
- Added `AccountOperationalStatusDto` and threaded it into `AccountSummaryDto` and `CreateAccountRequest` to carry operational status in DTOs (`src/Meridian.Contracts/FundStructure/FundStructureDtos.cs`, `src/Meridian.Contracts/FundStructure/AccountManagementDtos.cs`).
- Added `IsBackfill` flags to `RecordAccountBalanceSnapshotRequest`, `IngestCustodianStatementRequest`, and `IngestBankStatementRequest` to allow controlled backfill exceptions (`src/Meridian.Contracts/FundStructure/AccountManagementDtos.cs`).
- Implemented `AccountStatusPolicyException` and `EnsureAllowed(...)` enforcement in `InMemoryFundAccountService` to block or allow operations per status (Closed blocks mutations unless `IsBackfill`, Suspended blocks mutations but allows ingestion as configured) (`src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs`).
- Updated fund-account endpoints to catch `AccountStatusPolicyException` and return a structured 409 conflict payload (`account_status_policy_violation`) containing `status`, `operation`, `backfillAttempted`, and `detail` (`src/Meridian.Ui.Shared/Endpoints/FundAccountEndpoints.cs`).
- Added targeted tests exercising status-policy permutations for `UpdateCustodianDetails` and `RecordBalanceSnapshot` to prevent regressions (`tests/Meridian.Tests/Application/FundAccounts/FundAccountServiceTests.cs`).

### Testing
- Added unit tests in `tests/Meridian.Tests/Application/FundAccounts/FundAccountServiceTests.cs` covering `Active`, `Suspended`, and `Closed` permutations with and without backfill; these tests were committed but not yet run in CI as part of this change.
- Attempted to run the focused test filter `FullyQualifiedName~FundAccountServiceTests` locally via `dotnet test`, but execution failed because the environment does not have the `dotnet` CLI installed (test run not executed).
- No other automated test runs were completed in this environment; tests are in place and expected to pass in the normal CI that has .NET tooling available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d6b3a3188320a5b0aa1d776d404f)