### PR TITLE
Add source-generated JSON context for fund-structure DTOs and polymorphic AccountDetails envelope

### DIFF
--- a/src/Meridian.Contracts/FundStructure/AccountManagementDtos.cs
+++ b/src/Meridian.Contracts/FundStructure/AccountManagementDtos.cs
@@ -1,5 +1,7 @@
 namespace Meridian.Contracts.FundStructure;
 
+using System.Text.Json.Serialization;
+
 /// <summary>Snapshot of an account's balance at a point in time.</summary>
 public sealed record AccountBalanceSnapshotDto(
     Guid SnapshotId,
@@ -131,6 +133,12 @@ public sealed record AccountReconciliationResultDto(
     decimal? Variance,
     string Reason);
 
+/// <summary>Polymorphic envelope for account-type specific details.</summary>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
+[JsonDerivedType(typeof(CustodianAccountDetailsEnvelopeDto), "custodian")]
+[JsonDerivedType(typeof(BankAccountDetailsEnvelopeDto), "bank")]
+public abstract record AccountDetailsDto;
+
 /// <summary>Custodian-specific account details.</summary>
 public sealed record CustodianAccountDetailsDto(
     string? SubAccountNumber,
@@ -141,6 +149,9 @@ public sealed record CustodianAccountDetailsDto(
     string? PrimebrokerGiveupCode,
     string? SafekeepingLocation,
     string? ServiceAgreementReference);
+
+/// <summary>Polymorphic envelope for custodian account details.</summary>
+public sealed record CustodianAccountDetailsEnvelopeDto(CustodianAccountDetailsDto Details) : AccountDetailsDto;
 
 /// <summary>Bank-specific account details.</summary>
 public sealed record BankAccountDetailsDto(
@@ -155,6 +166,9 @@ public sealed record BankAccountDetailsDto(
     string? IntermediaryBankName,
     string? BeneficiaryName,
     string? BeneficiaryAddress);
+
+/// <summary>Polymorphic envelope for bank account details.</summary>
+public sealed record BankAccountDetailsEnvelopeDto(BankAccountDetailsDto Details) : AccountDetailsDto;
 
 /// <summary>Request to create a new fund account.</summary>
 public sealed record CreateAccountRequest(

--- a/src/Meridian.Contracts/FundStructure/FundStructureContractsJsonContext.cs
+++ b/src/Meridian.Contracts/FundStructure/FundStructureContractsJsonContext.cs
@@ -1,0 +1,35 @@
+using System.Text.Json.Serialization;
+
+namespace Meridian.Contracts.FundStructure;
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    PropertyNameCaseInsensitive = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(AccountDetailsDto))]
+[JsonSerializable(typeof(CustodianAccountDetailsEnvelopeDto))]
+[JsonSerializable(typeof(BankAccountDetailsEnvelopeDto))]
+[JsonSerializable(typeof(CustodianAccountDetailsDto))]
+[JsonSerializable(typeof(BankAccountDetailsDto))]
+[JsonSerializable(typeof(AccountBalanceSnapshotDto))]
+[JsonSerializable(typeof(IReadOnlyList<AccountBalanceSnapshotDto>))]
+[JsonSerializable(typeof(CustodianPositionLineDto))]
+[JsonSerializable(typeof(IReadOnlyList<CustodianPositionLineDto>))]
+[JsonSerializable(typeof(BankStatementLineDto))]
+[JsonSerializable(typeof(IReadOnlyList<BankStatementLineDto>))]
+[JsonSerializable(typeof(AccountReconciliationRunDto))]
+[JsonSerializable(typeof(AccountReconciliationResultDto))]
+[JsonSerializable(typeof(IReadOnlyList<AccountReconciliationResultDto>))]
+[JsonSerializable(typeof(CustodianStatementBatchDto))]
+[JsonSerializable(typeof(BankStatementBatchDto))]
+[JsonSerializable(typeof(RecordAccountBalanceSnapshotRequest))]
+[JsonSerializable(typeof(IngestCustodianStatementRequest))]
+[JsonSerializable(typeof(IngestBankStatementRequest))]
+[JsonSerializable(typeof(CreateAccountRequest))]
+[JsonSerializable(typeof(UpdateCustodianAccountDetailsRequest))]
+[JsonSerializable(typeof(UpdateBankAccountDetailsRequest))]
+[JsonSerializable(typeof(ReconcileAccountRequest))]
+[JsonSerializable(typeof(FundAccountsDto))]
+[JsonSerializable(typeof(AccountSummaryDto))]
+[JsonSerializable(typeof(IReadOnlyList<AccountSummaryDto>))]
+public sealed partial class FundStructureContractsJsonContext : JsonSerializerContext;

--- a/src/Meridian.Ui.Shared/Endpoints/FundAccountEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/FundAccountEndpoints.cs
@@ -23,7 +23,7 @@ public static class FundAccountEndpoints
             if (service is null)
                 return ServiceUnavailable();
 
-            var request = JsonSerializer.Deserialize<CreateAccountRequest>(body.GetRawText(), jsonOptions);
+            var request = JsonSerializer.Deserialize(body.GetRawText(), FundStructureContractsJsonContext.Default.CreateAccountRequest);
             if (request is null)
                 return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
 
@@ -84,7 +84,7 @@ public static class FundAccountEndpoints
             if (service is null)
                 return ServiceUnavailable();
 
-            var request = JsonSerializer.Deserialize<UpdateCustodianAccountDetailsRequest>(body.GetRawText(), jsonOptions);
+            var request = JsonSerializer.Deserialize(body.GetRawText(), FundStructureContractsJsonContext.Default.UpdateCustodianAccountDetailsRequest);
             if (request is null)
                 return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
 
@@ -101,7 +101,7 @@ public static class FundAccountEndpoints
             if (service is null)
                 return ServiceUnavailable();
 
-            var request = JsonSerializer.Deserialize<UpdateBankAccountDetailsRequest>(body.GetRawText(), jsonOptions);
+            var request = JsonSerializer.Deserialize(body.GetRawText(), FundStructureContractsJsonContext.Default.UpdateBankAccountDetailsRequest);
             if (request is null)
                 return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
 
@@ -209,7 +209,7 @@ public static class FundAccountEndpoints
             if (service is null)
                 return ServiceUnavailable();
 
-            var request = JsonSerializer.Deserialize<RecordAccountBalanceSnapshotRequest>(body.GetRawText(), jsonOptions);
+            var request = JsonSerializer.Deserialize(body.GetRawText(), FundStructureContractsJsonContext.Default.RecordAccountBalanceSnapshotRequest);
             if (request is null)
                 return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
 
@@ -257,7 +257,7 @@ public static class FundAccountEndpoints
             if (service is null)
                 return ServiceUnavailable();
 
-            var request = JsonSerializer.Deserialize<IngestCustodianStatementRequest>(body.GetRawText(), jsonOptions);
+            var request = JsonSerializer.Deserialize(body.GetRawText(), FundStructureContractsJsonContext.Default.IngestCustodianStatementRequest);
             if (request is null)
                 return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
 
@@ -290,7 +290,7 @@ public static class FundAccountEndpoints
             if (service is null)
                 return ServiceUnavailable();
 
-            var request = JsonSerializer.Deserialize<IngestBankStatementRequest>(body.GetRawText(), jsonOptions);
+            var request = JsonSerializer.Deserialize(body.GetRawText(), FundStructureContractsJsonContext.Default.IngestBankStatementRequest);
             if (request is null)
                 return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
 
@@ -325,7 +325,7 @@ public static class FundAccountEndpoints
             if (service is null)
                 return ServiceUnavailable();
 
-            var request = JsonSerializer.Deserialize<ReconcileAccountRequest>(body.GetRawText(), jsonOptions);
+            var request = JsonSerializer.Deserialize(body.GetRawText(), FundStructureContractsJsonContext.Default.ReconcileAccountRequest);
             if (request is null)
                 return Results.Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
 

--- a/tests/Meridian.Tests/Contracts/FundStructureContractsJsonContextTests.cs
+++ b/tests/Meridian.Tests/Contracts/FundStructureContractsJsonContextTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using FluentAssertions;
+using Meridian.Contracts.FundStructure;
+
+namespace Meridian.Tests.Contracts;
+
+public sealed class FundStructureContractsJsonContextTests
+{
+    [Fact]
+    public void AccountDetailsEnvelope_ShouldRoundTripWithDiscriminator()
+    {
+        AccountDetailsDto payload = new CustodianAccountDetailsEnvelopeDto(
+            new CustodianAccountDetailsDto(
+                SubAccountNumber: "sub-1",
+                DtcParticipantCode: "DTC",
+                CrestMemberCode: null,
+                EuroclearAccountNumber: null,
+                ClearstreamAccountNumber: null,
+                PrimebrokerGiveupCode: "PB",
+                SafekeepingLocation: "NYC",
+                ServiceAgreementReference: "SA-9"));
+
+        var json = JsonSerializer.Serialize(payload, FundStructureContractsJsonContext.Default.AccountDetailsDto);
+        json.Should().Contain("\"kind\":\"custodian\"");
+
+        var roundTrip = JsonSerializer.Deserialize(json, FundStructureContractsJsonContext.Default.AccountDetailsDto);
+        roundTrip.Should().BeOfType<CustodianAccountDetailsEnvelopeDto>();
+    }
+
+    [Fact]
+    public void CreateAndBalanceDtos_ShouldRoundTripViaGeneratedContext()
+    {
+        var create = new CreateAccountRequest(
+            Guid.NewGuid(),
+            AccountTypeDto.Custodian,
+            "CUST-001",
+            "Custodian Primary",
+            "USD",
+            DateTimeOffset.UtcNow,
+            "tester",
+            CustodianDetails: new CustodianAccountDetailsDto("sub", null, null, null, null, null, null, null));
+
+        var createJson = JsonSerializer.Serialize(create, FundStructureContractsJsonContext.Default.CreateAccountRequest);
+        var createRoundTrip = JsonSerializer.Deserialize(createJson, FundStructureContractsJsonContext.Default.CreateAccountRequest);
+        createRoundTrip.Should().NotBeNull();
+        createRoundTrip!.AccountCode.Should().Be("CUST-001");
+
+        var snapshotRequest = new RecordAccountBalanceSnapshotRequest(
+            Guid.NewGuid(),
+            new DateOnly(2026, 4, 1),
+            "USD",
+            100m,
+            "manual",
+            PendingSettlement: 10m);
+
+        var snapshotJson = JsonSerializer.Serialize(snapshotRequest, FundStructureContractsJsonContext.Default.RecordAccountBalanceSnapshotRequest);
+        var snapshotRoundTrip = JsonSerializer.Deserialize(snapshotJson, FundStructureContractsJsonContext.Default.RecordAccountBalanceSnapshotRequest);
+        snapshotRoundTrip.Should().NotBeNull();
+        snapshotRoundTrip!.PendingSettlement.Should().Be(10m);
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure new fund-account DTOs and commands are covered by the repository's source-generated JSON metadata so endpoint bindings avoid reflection and remain ADR-014 compliant.
- Provide explicit polymorphic/discriminator handling for account-type details so `AccountDetailsDto` payloads round-trip safely with a stable `kind` discriminator.
- Replace reflection-based endpoint deserialization for fund-account write routes with generated `JsonSerializerContext` usage to align with established conventions.
- Add focused serialization tests to guard contract compatibility for create/balance/request DTOs and the new envelope shape.

### Description
- Added a new source-generated context `FundStructureContractsJsonContext` registering account/balance/statement/reconciliation DTOs and request/command types used by fund-account endpoints in `src/Meridian.Contracts/FundStructure/FundStructureContractsJsonContext.cs`.
- Introduced an abstract polymorphic envelope `AccountDetailsDto` with `[JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]` and discriminator-backed derived envelope types `CustodianAccountDetailsEnvelopeDto` and `BankAccountDetailsEnvelopeDto` in `src/Meridian.Contracts/FundStructure/AccountManagementDtos.cs` so details are sent as explicit envelopes.
- Updated fund-account endpoint request deserialization to use the generated context (`FundStructureContractsJsonContext.Default.*`) for write routes such as `CreateAccountRequest`, `RecordAccountBalanceSnapshotRequest`, `IngestCustodianStatementRequest`, `IngestBankStatementRequest`, `UpdateCustodianAccountDetailsRequest`, `UpdateBankAccountDetailsRequest`, and `ReconcileAccountRequest` in `src/Meridian.Ui.Shared/Endpoints/FundAccountEndpoints.cs`.
- Added tests `tests/Meridian.Tests/Contracts/FundStructureContractsJsonContextTests.cs` that validate the `kind` discriminator round-trip for the `AccountDetailsDto` envelope and source-gen round-trips for representative create and balance request DTOs.

### Testing
- Attempted to run the targeted contract serialization test: `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~FundStructureContractsJsonContextTests" --logger "console;verbosity=minimal"` but the environment lacks the `dotnet` runtime, so the test could not be executed (`/bin/bash: dotnet: command not found`).
- No other automated test runs were performed in this environment due to the missing `dotnet` toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d6b99f3c8320a383322a583e38b8)