### PR TITLE
Fix CS1737 in account ingest DTOs by reordering optional parameters

### DIFF
--- a/src/Meridian.Contracts/FundStructure/AccountManagementDtos.cs
+++ b/src/Meridian.Contracts/FundStructure/AccountManagementDtos.cs
@@ -72,10 +72,10 @@ public sealed record IngestCustodianStatementRequest(
     DateOnly AsOfDate,
     string CustodianName,
     string SourceFormat,
-    bool IsBackfill = false,
-    string? Notes,
     IReadOnlyList<CustodianPositionLineDto> Lines,
-    string LoadedBy);
+    string LoadedBy,
+    bool IsBackfill = false,
+    string? Notes = null);
 
 /// <summary>Request to ingest a bank statement.</summary>
 public sealed record IngestBankStatementRequest(
@@ -83,10 +83,10 @@ public sealed record IngestBankStatementRequest(
     Guid AccountId,
     DateOnly StatementDate,
     string BankName,
-    bool IsBackfill = false,
-    string? Notes,
     IReadOnlyList<BankStatementLineDto> Lines,
-    string LoadedBy);
+    string LoadedBy,
+    bool IsBackfill = false,
+    string? Notes = null);
 
 
 public sealed record CustodianStatementBatchDto(


### PR DESCRIPTION
### Motivation
- Fix a C# compile error (`CS1737`) caused by optional parameters placed before required parameters in positional record constructors in `src/Meridian.Contracts/FundStructure/AccountManagementDtos.cs`.

### Description
- Reordered primary-constructor parameters for `IngestCustodianStatementRequest` and `IngestBankStatementRequest` so required parameters (`Lines`, `LoadedBy`) appear before optional parameters, and made `Notes` explicitly optional with `= null`.

### Testing
- Attempted to run `dotnet build src/Meridian.Contracts/Meridian.Contracts.csproj -v minimal` but validation could not complete in this environment because `dotnet` is not installed (build not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d9f95ef88320b934df5410f8ed44)