### PR TITLE
docs: reword instructional TODO references in agent guides

### DIFF
--- a/.claude/agents/meridian-cleanup.md
+++ b/.claude/agents/meridian-cleanup.md
@@ -420,14 +420,14 @@ catch (Exception ex) when (ex is not OperationCanceledException)
 ```
 
 **Leftover scaffold comments:**
-- `// TODO: implement` in methods that are already implemented.
+- placeholder implementation comments (for example, `// TODO: implement`) in methods that are already implemented.
 - `// Step 1:`, `// Step 2:` outline comments that match the code directly beneath
   them (the code is self-documenting; the outline adds nothing).
 - XML doc comments that are identical to the member name — identical-to-name summaries
   are noise; remove or expand them.
 
 **Do not remove:**
-- `// TODO:` or `// FIXME:` comments that describe genuine open work items — flag them
+- Open-work comments (for example, `// TODO:` or `// FIXME:`) that describe genuine pending tasks — flag them
   for the backlog instead
 - Disable pragmas on generated or interop code
 - Comments that explain non-obvious business logic, timing constraints, or why a

--- a/.github/agents/cleanup-agent.md
+++ b/.github/agents/cleanup-agent.md
@@ -382,7 +382,7 @@ catch (Exception ex) when (ex is not OperationCanceledException)
 - Flag empty `catch` blocks without a comment for removal or logging.
 
 **Leftover scaffold comments:**
-- `// TODO: implement` in methods that are already implemented.
+- placeholder implementation comments (for example, `// TODO: implement`) in methods that are already implemented.
 - `// Step 1:`, `// Step 2:` outline comments that match the code directly beneath
   them (the code is self-documenting; the outline adds nothing).
 - XML doc comments that read `/// <summary>Foo bar.</summary>` on a method named
@@ -390,7 +390,7 @@ catch (Exception ex) when (ex is not OperationCanceledException)
   remove or expand them.
 
 **Do not remove:**
-- `// TODO:` or `// FIXME:` comments that describe genuine open work items — flag
+- Open-work comments (for example, `// TODO:` or `// FIXME:`) that describe genuine pending tasks — flag
   them for the backlog instead.
 - Disable pragmas on generated or interop code.
 - Comments that explain non-obvious business logic, timing constraints, or why a

--- a/.github/agents/provider-builder-agent.md
+++ b/.github/agents/provider-builder-agent.md
@@ -78,7 +78,7 @@ What does this provider supply?
 | Brokerage gateway | `src/Meridian.Infrastructure/Adapters/Templates/TemplateBrokerageGateway.cs` |
 | Options chain | No template — model from `IOptionsChainProvider` interface and existing providers |
 
-Read the full template before writing any code. Templates contain inline `// TODO:` comments
+Read the full template before writing any code. Templates contain inline guidance comments
 explaining every required section.
 
 ### Step 2 — Create the Provider Directory


### PR DESCRIPTION
### Motivation
- Prevent instructional wording in agent guidance and provider templates from being interpreted as literal unresolved TODO work by clarifying the phrasing.

### Description
- Reworded leftover-scaffold comment guidance in `.claude/agents/meridian-cleanup.md` to use a neutral example form (e.g., "placeholder implementation comments (for example, `// TODO: implement`)" ).
- Applied the same wording change to the mirrored guidance in `.github/agents/cleanup-agent.md` for consistency.
- Updated `.github/agents/provider-builder-agent.md` to describe template inline guidance comments as guidance rather than presenting them as inline `// TODO:` work items.

### Testing
- Ran a targeted `rg` search against the three edited files to confirm the previously flagged instructional TODO phrases are no longer present, and the search returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e973b59883209763ca23164854cd)