### PR TITLE
Update documentation workflow: narrow triggers, bump `setup-python` to v6, and refine concurrency

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -36,9 +36,6 @@ on:
       - 'build/scripts/docs/**'
       - 'build/dotnet/DocGenerator/**'
       - 'build/**/*.py'
-      - 'src/**'
-      - 'tests/**'
-      - 'benchmarks/**'
       - 'config/appsettings.sample.json'
   pull_request:
     branches: ["main"]
@@ -52,7 +49,6 @@ on:
       - '.github/agents/**'
       - 'build/scripts/docs/**'
       - 'build/dotnet/DocGenerator/**'
-      - 'src/**'
   schedule:
     - cron: '0 3 * * 1'
   workflow_dispatch:
@@ -123,7 +119,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: documentation-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 defaults:
@@ -427,7 +423,7 @@ jobs:
           node-version: '20'
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -588,7 +584,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1156,7 +1152,7 @@ jobs:
             || echo "::warning::git pull --rebase failed; proceeding with local checkout"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1447,7 +1443,7 @@ jobs:
           name: todo-scan-results
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1498,7 +1494,7 @@ jobs:
             || echo "::warning::git pull --rebase failed; proceeding with local checkout"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1532,7 +1528,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1567,7 +1563,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1603,7 +1599,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1641,7 +1637,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1677,7 +1673,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1716,7 +1712,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1752,7 +1748,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -1864,7 +1860,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 


### PR DESCRIPTION
### Motivation
- Reduce unnecessary workflow runs by excluding broad repository paths from documentation triggers. 
- Keep GitHub Actions toolset current by upgrading `actions/setup-python` to the latest major supported version. 
- Prevent cross-workflow cancellation collisions by scoping the concurrency group to the workflow name and ref.

### Description
- Removed `src/**`, `tests/**`, and `benchmarks/**` from the `push` paths and removed `src/**` from the `pull_request` paths in `.github/workflows/documentation.yml` to limit when the docs workflow is triggered. 
- Changed the concurrency group from `documentation-${{ github.ref }}` to `${{ github.workflow }}-${{ github.ref }}` to isolate concurrency per workflow. 
- Upgraded all `uses: actions/setup-python@v5` occurrences to `uses: actions/setup-python@v6` across documentation-related jobs.

### Testing
- No automated tests were run as part of this change; this is a CI/workflow configuration update and will be validated when the workflow executes in GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4ebc4f29083208b60b2f7b4eeb699)