### PR TITLE
Add reconciliation governance gate evaluation and readiness integration

### DIFF
--- a/docs/operations/reconciliation-policy-operations.md
+++ b/docs/operations/reconciliation-policy-operations.md
@@ -1,0 +1,29 @@
+# Reconciliation Policy Operations
+
+## Configuration
+
+`ReconciliationGovernanceService` evaluates reconciliation runs against policy thresholds:
+
+- `MaxOpenBreakCount`
+- `MaxCriticalOpenBreakCount`
+- `MaxAbsoluteVariance`
+- `RequireSecondaryApprovalForWaivers`
+
+The service writes durable audit entries to `artifacts/reconciliation/governance-audit.jsonl`.
+
+## Escalation and Sign-off
+
+If thresholds are breached:
+
+1. Gate becomes `Blocked` unless a waiver is requested.
+2. If waiver requires secondary sign-off, gate remains blocked until secondary approval is recorded.
+3. With required sign-off complete, gate transitions to `ReviewRequired` for operator approval workflow.
+
+## Evidence Export
+
+Use `ReconciliationGovernanceService.ExportEvidenceAsync(...)` to emit:
+
+- JSON payload (machine-readable)
+- Markdown summary (operator-readable)
+
+Store outputs under `artifacts/reconciliation/` following run-scoped naming.

--- a/src/Meridian.Strategies/Services/ReconciliationGovernanceService.cs
+++ b/src/Meridian.Strategies/Services/ReconciliationGovernanceService.cs
@@ -1,0 +1,113 @@
+using System.Text;
+using System.Text.Json;
+using Meridian.Contracts.Workstation;
+
+namespace Meridian.Strategies.Services;
+
+public sealed record ReconciliationPolicyThresholds(
+    int MaxOpenBreakCount = 0,
+    int MaxCriticalOpenBreakCount = 0,
+    decimal MaxAbsoluteVariance = 0.01m,
+    int MaxBreakAgeHours = 24,
+    bool RequireSecondaryApprovalForWaivers = true);
+
+public sealed record ReconciliationGateEvaluation(
+    TradingAcceptanceGateStatusDto Status,
+    string Detail,
+    int OpenBreakCount,
+    int CriticalOpenBreakCount,
+    decimal MaxObservedAbsoluteVariance,
+    bool SecondaryApprovalRequired);
+
+public interface IReconciliationGovernanceAuditStore
+{
+    Task AppendAsync(ReconciliationGateEvaluation evaluation, CancellationToken ct = default);
+}
+
+public sealed class JsonlReconciliationGovernanceAuditStore(string path) : IReconciliationGovernanceAuditStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web) { WriteIndented = false };
+    public async Task AppendAsync(ReconciliationGateEvaluation evaluation, CancellationToken ct = default)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path) ?? ".");
+        var payload = JsonSerializer.Serialize(new
+        {
+            asOf = DateTimeOffset.UtcNow,
+            status = evaluation.Status.ToString(),
+            evaluation.Detail,
+            evaluation.OpenBreakCount,
+            evaluation.CriticalOpenBreakCount,
+            evaluation.MaxObservedAbsoluteVariance,
+            evaluation.SecondaryApprovalRequired
+        }, JsonOptions);
+        await File.AppendAllTextAsync(path, payload + Environment.NewLine, Encoding.UTF8, ct).ConfigureAwait(false);
+    }
+}
+
+public sealed class ReconciliationGovernanceService(
+    IReconciliationRunRepository repository,
+    IReconciliationGovernanceAuditStore? auditStore = null)
+{
+    public async Task<ReconciliationGateEvaluation> EvaluateGateAsync(
+        string runId,
+        ReconciliationPolicyThresholds policy,
+        bool waiverRequested,
+        bool secondaryApprovalSigned,
+        CancellationToken ct = default)
+    {
+        var latest = await repository.GetLatestForRunAsync(runId, ct).ConfigureAwait(false);
+        if (latest is null)
+        {
+            var missing = new ReconciliationGateEvaluation(
+                TradingAcceptanceGateStatusDto.Blocked,
+                "No reconciliation run is available for this strategy run.",
+                0,
+                0,
+                0m,
+                false);
+            if (auditStore is not null) await auditStore.AppendAsync(missing, ct).ConfigureAwait(false);
+            return missing;
+        }
+
+        var openBreaks = latest.Breaks.Where(static b => b.Status is not ReconciliationBreakStatus.Resolved and not ReconciliationBreakStatus.Matched).ToArray();
+        var openCount = openBreaks.Length;
+        var criticalCount = openBreaks.Count(static b => b.Severity == ReconciliationBreakSeverity.Critical);
+        var maxAbsVariance = openBreaks.Select(static b => Math.Abs(b.Variance)).DefaultIfEmpty(0m).Max();
+
+        var secondaryRequired = waiverRequested && policy.RequireSecondaryApprovalForWaivers;
+        var breached = openCount > policy.MaxOpenBreakCount || criticalCount > policy.MaxCriticalOpenBreakCount || maxAbsVariance > policy.MaxAbsoluteVariance;
+        var reviewRequired = breached && waiverRequested && (!secondaryRequired || secondaryApprovalSigned);
+        var blocked = breached && (!waiverRequested || (secondaryRequired && !secondaryApprovalSigned));
+
+        var status = blocked
+            ? TradingAcceptanceGateStatusDto.Blocked
+            : reviewRequired
+                ? TradingAcceptanceGateStatusDto.ReviewRequired
+                : TradingAcceptanceGateStatusDto.Ready;
+
+        var detail = breached
+            ? $"Policy breached (open={openCount}, critical={criticalCount}, maxVariance={maxAbsVariance:0.####})."
+            : $"Policy within threshold (open={openCount}, critical={criticalCount}, maxVariance={maxAbsVariance:0.####}).";
+
+        var evaluation = new ReconciliationGateEvaluation(status, detail, openCount, criticalCount, maxAbsVariance, secondaryRequired);
+        if (auditStore is not null) await auditStore.AppendAsync(evaluation, ct).ConfigureAwait(false);
+        return evaluation;
+    }
+
+    public static async Task<string> ExportEvidenceAsync(
+        ReconciliationGateEvaluation evaluation,
+        string outputDirectory,
+        string runId,
+        CancellationToken ct = default)
+    {
+        Directory.CreateDirectory(outputDirectory);
+        var baseName = $"reconciliation-evidence-{runId}-{DateTimeOffset.UtcNow:yyyyMMddHHmmss}";
+        var jsonPath = Path.Combine(outputDirectory, baseName + ".json");
+        var mdPath = Path.Combine(outputDirectory, baseName + ".md");
+
+        await File.WriteAllTextAsync(jsonPath, JsonSerializer.Serialize(evaluation, new JsonSerializerOptions { WriteIndented = true }), ct).ConfigureAwait(false);
+        var summary = $"# Reconciliation Evidence\n\n- Run: `{runId}`\n- Status: `{evaluation.Status}`\n- Detail: {evaluation.Detail}\n- Open breaks: {evaluation.OpenBreakCount}\n- Critical open breaks: {evaluation.CriticalOpenBreakCount}\n- Max absolute variance: {evaluation.MaxObservedAbsoluteVariance}\n- Secondary approval required: {evaluation.SecondaryApprovalRequired}\n";
+        await File.WriteAllTextAsync(mdPath, summary, ct).ConfigureAwait(false);
+        return jsonPath;
+    }
+}

--- a/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
@@ -146,6 +146,7 @@ public sealed class TradingOperatorReadinessService
         var promotion = BuildPromotion(latestRun, promotionRecords);
         var trustGate = await ResolveTrustGateReadinessAsync(ct).ConfigureAwait(false);
         var reportPack = await ResolveReportPackReadinessAsync(latestRun, promotion, ct).ConfigureAwait(false);
+        var reconciliationGate = await ResolveReconciliationGateAsync(latestRun, ct).ConfigureAwait(false);
         if (promotion is null)
         {
             AddWorkItem(
@@ -172,6 +173,7 @@ public sealed class TradingOperatorReadinessService
 
         AddTrustGateWorkItem(workItems, trustGate);
         AddReportPackWorkItem(workItems, reportPack, latestRun?.Summary.RunId);
+        AddReconciliationGateWorkItem(workItems, reconciliationGate, latestRun?.Summary.RunId);
 
         var brokerageStatus = await ResolveBrokerageStatusAsync(fundAccountId, ct).ConfigureAwait(false);
         if (brokerageStatus is not null && brokerageStatus.Health is not WorkstationBrokerageSyncHealth.Healthy)
@@ -216,6 +218,7 @@ public sealed class TradingOperatorReadinessService
             promotion,
             trustGate,
             reportPack,
+            reconciliationGate,
             auditEntries);
         var overallStatus = ResolveOverallStatus(acceptanceGates);
         var evidenceCompleteness = BuildEvidenceCompleteness(acceptanceGates, workItems);
@@ -749,6 +752,7 @@ public sealed class TradingOperatorReadinessService
         TradingPromotionReadinessDto? promotion,
         TradingTrustGateReadinessDto trustGate,
         TradingReportPackReadinessDto reportPack,
+        ReconciliationGateEvaluation? reconciliationGate,
         IReadOnlyList<ExecutionAuditEntry> auditEntries)
         =>
         [
@@ -757,7 +761,8 @@ public sealed class TradingOperatorReadinessService
             BuildAuditControlGate(controls, auditEntries),
             BuildPromotionGate(promotion),
             BuildTrustGateAcceptance(trustGate),
-            BuildReportPackGate(reportPack)
+            BuildReportPackGate(reportPack),
+            BuildReconciliationGate(reconciliationGate)
         ];
 
     private static TradingAcceptanceGateDto BuildSessionGate(
@@ -1006,6 +1011,57 @@ public sealed class TradingOperatorReadinessService
         return TradingAcceptanceGateStatusDto.Ready;
     }
 
+
+    private async Task<ReconciliationGateEvaluation?> ResolveReconciliationGateAsync(StrategyRunDetail? latestRun, CancellationToken ct)
+    {
+        if (latestRun is null)
+        {
+            return null;
+        }
+
+        var governance = Resolve<ReconciliationGovernanceService>();
+        if (governance is null)
+        {
+            return null;
+        }
+
+        return await governance.EvaluateGateAsync(latestRun.Summary.RunId, new ReconciliationPolicyThresholds(), waiverRequested: false, secondaryApprovalSigned: false, ct).ConfigureAwait(false);
+    }
+
+    private static TradingAcceptanceGateDto BuildReconciliationGate(ReconciliationGateEvaluation? evaluation)
+    {
+        if (evaluation is null)
+        {
+            return new TradingAcceptanceGateDto(
+                GateId: "reconciliation",
+                Label: "Reconciliation policy",
+                Status: TradingAcceptanceGateStatusDto.ReviewRequired,
+                Detail: "Reconciliation policy evaluation is not available.");
+        }
+
+        return new TradingAcceptanceGateDto(
+            GateId: "reconciliation",
+            Label: "Reconciliation policy",
+            Status: evaluation.Status,
+            Detail: evaluation.Detail);
+    }
+
+    private static void AddReconciliationGateWorkItem(List<OperatorWorkItemDto> workItems, ReconciliationGateEvaluation? evaluation, string? runId)
+    {
+        if (evaluation is null || evaluation.Status == TradingAcceptanceGateStatusDto.Ready)
+        {
+            return;
+        }
+
+        AddWorkItem(
+            workItems,
+            OperatorWorkItemKindDto.PromotionReview,
+            "Reconciliation policy requires attention",
+            evaluation.Detail,
+            evaluation.Status == TradingAcceptanceGateStatusDto.Blocked ? OperatorWorkItemToneDto.Critical : OperatorWorkItemToneDto.Warning,
+            runId,
+            workItemId: BuildWorkItemId("reconciliation-policy", runId));
+    }
     private static TradingAcceptanceGateStatusDto ResolveOverallStatus(IReadOnlyList<TradingAcceptanceGateDto> gates)
     {
         if (gates.Any(static gate => gate.Status == TradingAcceptanceGateStatusDto.Blocked))

--- a/src/Meridian/UiServer.cs
+++ b/src/Meridian/UiServer.cs
@@ -112,6 +112,8 @@ public sealed class UiServer : IAsyncDisposable
         builder.Services.AddSingleton<IExternalStatementReconciliationSourceAdapter, ExternalStatementReconciliationSourceAdapter>();
         builder.Services.AddSingleton<ReconciliationProjectionService>();
         builder.Services.AddSingleton<IReconciliationRunService, ReconciliationRunService>();
+        builder.Services.AddSingleton<IReconciliationGovernanceAuditStore>(_ => new JsonlReconciliationGovernanceAuditStore(Path.Combine("artifacts", "reconciliation", "governance-audit.jsonl")));
+        builder.Services.AddSingleton<ReconciliationGovernanceService>();
         builder.Services.AddSingleton<CashFlowProjectionService>();
         builder.Services.AddSingleton<StrategyRunContinuityService>();
         builder.Services.AddSingleton(BrokeragePortfolioSyncOptions.Default);

--- a/tests/Meridian.Tests/Application/ReconciliationGovernanceServiceTests.cs
+++ b/tests/Meridian.Tests/Application/ReconciliationGovernanceServiceTests.cs
@@ -1,0 +1,40 @@
+using Meridian.Contracts.Workstation;
+using Meridian.Strategies.Services;
+
+namespace Meridian.Tests.Application;
+
+public sealed class ReconciliationGovernanceServiceTests
+{
+    [Fact]
+    public async Task EvaluateGateAsync_Blocks_WhenThresholdBreachedWithoutWaiver()
+    {
+        var repo = new InMemoryReconciliationRunRepository();
+        var detail = new ReconciliationRunDetail(
+            new ReconciliationRunSummary("rec-1", "run-1", DateTimeOffset.UtcNow, null, null, 0, 1, 1, false, 0.01m, 5),
+            [],
+            [new ReconciliationBreakDto("b1", "Mismatch", ReconciliationBreakCategory.AmountMismatch, ReconciliationBreakStatus.Open, "", 1m, 2m, 1m, ReconciliationBreakSeverity.Critical, "x", null, null)]);
+        await repo.SaveAsync(detail);
+
+        var sut = new ReconciliationGovernanceService(repo);
+        var result = await sut.EvaluateGateAsync("run-1", new ReconciliationPolicyThresholds(MaxOpenBreakCount: 0, MaxCriticalOpenBreakCount: 0, MaxAbsoluteVariance: 0.1m), false, false);
+
+        Assert.Equal(TradingAcceptanceGateStatusDto.Blocked, result.Status);
+    }
+
+    [Fact]
+    public async Task EvaluateGateAsync_ReviewRequired_WhenBreachedAndSecondaryApprovalSigned()
+    {
+        var repo = new InMemoryReconciliationRunRepository();
+        var detail = new ReconciliationRunDetail(
+            new ReconciliationRunSummary("rec-2", "run-2", DateTimeOffset.UtcNow, null, null, 0, 1, 1, false, 0.01m, 5),
+            [],
+            [new ReconciliationBreakDto("b1", "Mismatch", ReconciliationBreakCategory.AmountMismatch, ReconciliationBreakStatus.Open, "", 1m, 2m, 1m, ReconciliationBreakSeverity.High, "x", null, null)]);
+        await repo.SaveAsync(detail);
+
+        var sut = new ReconciliationGovernanceService(repo);
+        var result = await sut.EvaluateGateAsync("run-2", new ReconciliationPolicyThresholds(MaxOpenBreakCount: 0, MaxAbsoluteVariance: 0.1m), true, true);
+
+        Assert.Equal(TradingAcceptanceGateStatusDto.ReviewRequired, result.Status);
+        Assert.True(result.SecondaryApprovalRequired);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide configurable reconciliation policy thresholds and a gate evaluation seam to enforce readiness and promotion acceptance rules.
- Create durable audit/evidence records and operator-facing summaries for reconciliation outcomes to support escalation, sign-off, and run-scoped reporting.
- Surface reconciliation policy outcomes in the trading cockpit readiness projection and operator work-item queue so policy breaches block or flag acceptance.

### Description
- Added `ReconciliationGovernanceService` with `ReconciliationPolicyThresholds`, `ReconciliationGateEvaluation`, gate evaluation logic, and `ExportEvidenceAsync` for JSON + Markdown evidence exports in `src/Meridian.Strategies/Services/ReconciliationGovernanceService.cs`.
- Added a lightweight JSONL audit store `JsonlReconciliationGovernanceAuditStore` that appends audit lines under `artifacts/reconciliation/governance-audit.jsonl` and registered it in DI via `UiServer`.
- Integrated gate evaluation into `TradingOperatorReadinessService` so a `reconciliation` acceptance gate is built and non-ready outcomes generate operator work items and influence `OverallStatus` in readiness projections (`src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs`).
- Added unit tests `ReconciliationGovernanceServiceTests` covering blocked and review-required transitions and created operations documentation `docs/operations/reconciliation-policy-operations.md` describing configuration, escalation, and evidence export conventions.

### Testing
- Added unit tests in `tests/Meridian.Tests/Application/ReconciliationGovernanceServiceTests.cs` that assert blocked behavior when thresholds are breached and review-required when waiver + secondary approval conditions are used.
- Attempted to run the targeted tests with `dotnet test ... --filter "FullyQualifiedName~ReconciliationGovernanceServiceTests"`, but the environment lacks `dotnet` (`/bin/bash: dotnet: command not found`), so tests could not be executed in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50d5a0cd88320a025741fb45f65ac)