### PR TITLE
Scope operator inbox refresh by active fund account context

### DIFF
--- a/src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, vi } from "vitest";
 import * as api from "@/lib/api";
 import { OperatorReadinessConsole } from "@/screens/operator-readiness-console";
 import { renderWithRouter } from "@/test/render";
-import type { OperatorInbox, OperatorWorkItem } from "@/types";
+import type { OperatorInbox, OperatorWorkItem, TradingWorkspaceResponse } from "@/types";
 
 const inbox: OperatorInbox = {
   asOf: "2026-04-29T12:01:00Z",
@@ -55,6 +55,88 @@ const criticalItem: OperatorWorkItem = {
   targetPageTag: "SecurityMaster"
 };
 
+const scopedTrading: TradingWorkspaceResponse = {
+  metrics: [],
+  positions: [],
+  openOrders: [],
+  fills: [],
+  risk: {
+    state: "Healthy",
+    summary: "Healthy",
+    netExposure: "$0",
+    grossExposure: "$0",
+    var95: "$0",
+    maxDrawdown: "0%",
+    buyingPowerUsed: "0%",
+    activeGuardrails: []
+  },
+  brokerage: {
+    provider: "Alpaca",
+    account: "PA-1",
+    environment: "paper",
+    connection: "Connected",
+    lastHeartbeat: "now",
+    orderIngress: "healthy",
+    fillFeed: "healthy",
+    notes: "ok"
+  },
+  readiness: {
+    asOf: "2026-04-29T12:00:00Z",
+    overallStatus: "Ready",
+    readyForPaperOperation: true,
+    acceptanceGates: [],
+    activeSession: null,
+    sessions: [],
+    replay: null,
+    controls: {
+      circuitBreakerOpen: false,
+      circuitBreakerReason: null,
+      circuitBreakerChangedBy: null,
+      circuitBreakerChangedAt: null,
+      manualOverrideCount: 0,
+      symbolLimitCount: 0,
+      defaultMaxPositionSize: 0
+    },
+    promotion: null,
+    trustGate: {
+      gateId: "dk1",
+      status: "signed",
+      readyForOperatorReview: true,
+      operatorSignoffRequired: false,
+      operatorSignoffStatus: "signed",
+      generatedAt: null,
+      packetPath: null,
+      sourceSummary: null,
+      requiredSampleCount: 0,
+      readySampleCount: 0,
+      validatedEvidenceDocumentCount: 0,
+      requiredOwners: [],
+      blockers: [],
+      detail: "",
+      operatorSignoff: null
+    },
+    brokerageSync: {
+      fundAccountId: "fund-1",
+      providerId: "alpaca",
+      externalAccountId: "PA-1",
+      health: "Healthy",
+      isLinked: true,
+      isStale: false,
+      lastAttemptedSyncAt: null,
+      lastSuccessfulSyncAt: null,
+      lastError: null,
+      positionCount: 0,
+      openOrderCount: 0,
+      fillCount: 0,
+      cashTransactionCount: 0,
+      securityMissingCount: 0,
+      warnings: []
+    },
+    workItems: [],
+    warnings: []
+  }
+};
+
 describe("OperatorReadinessConsole", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -83,7 +165,25 @@ describe("OperatorReadinessConsole", () => {
     expect(screen.getByRole("region", { name: "Latest runs readiness evidence" })).toBeInTheDocument();
     expect(screen.getByRole("list", { name: "Prioritized operator work items" })).toBeInTheDocument();
     expect(screen.getAllByRole("group", { name: /Promotion checklist incomplete: Warning/i }).length).toBeGreaterThan(0);
-    await waitFor(() => expect(api.getOperatorInbox).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(api.getOperatorInbox).toHaveBeenCalledWith());
+  });
+
+
+  it("scopes operator inbox refresh to the active fund account when trading context is available", async () => {
+    vi.spyOn(api, "getOperatorInbox").mockResolvedValueOnce(inbox);
+
+    renderWithRouter(
+      <OperatorReadinessConsole
+        research={null}
+        trading={scopedTrading}
+        dataOperations={null}
+        governance={null}
+      />,
+      { initialEntries: ["/trading/readiness"] }
+    );
+
+    await screen.findByRole("list", { name: "Prioritized operator work items" });
+    await waitFor(() => expect(api.getOperatorInbox).toHaveBeenCalledWith("fund-1"));
   });
 
   it("shows critical operator inbox items before lower-priority overflow", async () => {

--- a/src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.view-model.test.ts
@@ -1,4 +1,6 @@
-import { buildOperatorReadinessConsoleState } from "@/screens/operator-readiness-console.view-model";
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildOperatorReadinessConsoleState, useOperatorReadinessConsoleViewModel } from "@/screens/operator-readiness-console.view-model";
 import type {
   DataOperationsWorkspaceResponse,
   GovernanceWorkspaceResponse,
@@ -612,4 +614,41 @@ describe("operator readiness console view model", () => {
     expect(state.overallDetail).toContain("report-pack readiness item(s) still need review");
     expect(state.reportPackFacts[0]).toEqual(expect.objectContaining({ value: "No targets", level: "review" }));
   });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("requests a scoped operator inbox when trading readiness includes an active fund account", async () => {
+    const getOperatorInbox = vi.fn().mockResolvedValue(cleanInbox);
+
+    renderHook(() => useOperatorReadinessConsoleViewModel({
+      research,
+      trading,
+      dataOperations,
+      governance
+    }, { getOperatorInbox }));
+
+    await waitFor(() => expect(getOperatorInbox).toHaveBeenCalledWith("fund-1"));
+  });
+
+  it("requests an unscoped operator inbox when no active account context is available", async () => {
+    const getOperatorInbox = vi.fn().mockResolvedValue(cleanInbox);
+
+    renderHook(() => useOperatorReadinessConsoleViewModel({
+      research,
+      trading: {
+        ...trading,
+        readiness: {
+          ...readiness,
+          brokerageSync: null
+        }
+      },
+      dataOperations,
+      governance
+    }, { getOperatorInbox }));
+
+    await waitFor(() => expect(getOperatorInbox).toHaveBeenCalledWith(undefined));
+  });
+
 });

--- a/src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.view-model.ts
@@ -119,11 +119,11 @@ export interface BuildOperatorReadinessConsoleStateOptions {
 }
 
 export interface OperatorReadinessConsoleServices {
-  getOperatorInbox: () => Promise<OperatorInbox>;
+  getOperatorInbox: (fundAccountId?: string) => Promise<OperatorInbox>;
 }
 
 const defaultServices: OperatorReadinessConsoleServices = {
-  getOperatorInbox: () => getOperatorInbox()
+  getOperatorInbox: (fundAccountId?: string) => getOperatorInbox(fundAccountId)
 };
 
 const workstationWorkspaceKeys = new Set<string>(WORKSPACES.map((workspace) => workspace.key));
@@ -136,12 +136,14 @@ export function useOperatorReadinessConsoleViewModel(
   const [inboxLoading, setInboxLoading] = useState(true);
   const [inboxError, setInboxError] = useState<string | null>(null);
 
+  const activeFundAccountId = payload.trading?.readiness?.brokerageSync?.fundAccountId;
+
   useEffect(() => {
     let cancelled = false;
     setInboxLoading(true);
     setInboxError(null);
 
-    services.getOperatorInbox()
+    services.getOperatorInbox(activeFundAccountId)
       .then((inbox) => {
         if (!cancelled) {
           setOperatorInbox(inbox);
@@ -162,7 +164,7 @@ export function useOperatorReadinessConsoleViewModel(
     return () => {
       cancelled = true;
     };
-  }, [services]);
+  }, [activeFundAccountId, services]);
 
   return useMemo(
     () => buildOperatorReadinessConsoleState({


### PR DESCRIPTION
### Motivation
- Ensure operator-inbox fetches are scoped to the active trading account when available so inbox API calls include `fundAccountId` and return account-specific work items.
- Use the existing trading readiness/workspace account context rather than relying on global or implicit scoping to keep API requests deterministic.
- Add test coverage asserting both scoped and unscoped fetch behavior so future changes cannot regress inbox scoping.

### Description
- Updated `OperatorReadinessConsoleServices.getOperatorInbox` signature to accept an optional `fundAccountId` and changed the default implementation to forward it to `getOperatorInbox(fundAccountId)` from the API module.
- Derived `activeFundAccountId` from `payload.trading?.readiness?.brokerageSync?.fundAccountId` in the view-model and passed it into the inbox refresh in the `useEffect` hook, adding `activeFundAccountId` to the effect dependencies.
- Modified `src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.test.tsx` to add a `scopedTrading` fixture and a new integration test that asserts `getOperatorInbox("fund-1")` is called when trading readiness includes an active account, and adjusted the existing test to assert unscoped calls when no account context is provided.
- Extended `src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.view-model.test.ts` with hook-level tests using `renderHook` to assert the view-model calls the inbox service with the correct `fundAccountId` (or `undefined` when not present).

### Testing
- Updated and added tests: `src/screens/operator-readiness-console.test.tsx` and `src/screens/operator-readiness-console.view-model.test.ts` include assertions for scoped (`getOperatorInbox("fund-1")`) and unscoped (`getOperatorInbox()` / `getOperatorInbox(undefined)`) calls.
- Attempted to run the focused test command `npm --prefix src/Meridian.Ui/dashboard run test -- src/screens/operator-readiness-console.view-model.test.ts src/screens/operator-readiness-console.test.tsx`, but the test runner failed in this environment because `vitest` is not available on PATH (`sh: 1: vitest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50e5a01fc8320b793aa2144f6f892)