### PR TITLE
Limit operator inbox review-packet aggregation to the latest run

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -1716,20 +1716,25 @@ public static class WorkstationEndpoints
                 .GetRunsAsync(new StrategyRunHistoryQuery(Limit: 6), context.RequestAborted)
                 .ConfigureAwait(false);
 
-            foreach (var run in runs.Where(ShouldSurfaceRunReviewWorkItems))
+            var latestRun = runs
+                .OrderByDescending(GetRunReviewTimestamp)
+                .FirstOrDefault();
+            if (latestRun is null || !ShouldSurfaceRunReviewWorkItems(latestRun))
             {
-                var packet = await reviewPacketService
-                    .GetAsync(run.RunId, fundAccountId, context.RequestAborted)
-                    .ConfigureAwait(false);
-                if (packet is null)
-                {
-                    continue;
-                }
-
-                workItems.AddRange(packet.WorkItems
-                    .Where(static item => item.Tone is OperatorWorkItemToneDto.Warning or OperatorWorkItemToneDto.Critical)
-                    .Select(AttachOperatorNavigation));
+                return;
             }
+
+            var packet = await reviewPacketService
+                .GetAsync(latestRun.RunId, fundAccountId, context.RequestAborted)
+                .ConfigureAwait(false);
+            if (packet is null)
+            {
+                return;
+            }
+
+            workItems.AddRange(packet.WorkItems
+                .Where(static item => item.Tone is OperatorWorkItemToneDto.Warning or OperatorWorkItemToneDto.Critical)
+                .Select(AttachOperatorNavigation));
         }
         catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
         {
@@ -1744,6 +1749,9 @@ public static class WorkstationEndpoints
     private static bool ShouldSurfaceRunReviewWorkItems(StrategyRunSummary run)
         => run.Promotion?.RequiresReview == true ||
            run.Status is StrategyRunStatus.Failed or StrategyRunStatus.Cancelled;
+
+    private static DateTimeOffset GetRunReviewTimestamp(StrategyRunSummary run)
+        => run.CompletedAt ?? run.LastUpdatedAt;
 
     private static OperatorWorkItemDto BuildRunReviewPacketUnavailableWorkItem(DateTimeOffset asOf)
         => new(

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -1017,16 +1017,63 @@ public sealed class WorkstationEndpointsTests
     }
 
     [Fact]
-    public async Task MapWorkstationEndpoints_OperatorInbox_ShouldIncludeRunReviewPacketWorkItems()
+    public async Task MapWorkstationEndpoints_OperatorInbox_ShouldExcludeOlderRunReviewPacketBlockersWhenLatestRunIsClean()
     {
         await using var app = await CreateAppAsync(services =>
         {
             RegisterRunReadServices(services);
         });
 
-        var runId = $"run-inbox-review-packet-{Guid.NewGuid():N}";
+        var olderRunId = $"run-inbox-review-packet-older-{Guid.NewGuid():N}";
+        var newestRunId = $"run-inbox-review-packet-newest-{Guid.NewGuid():N}";
         var store = app.Services.GetRequiredService<IStrategyRepository>();
-        await store.RecordRunAsync(BuildContinuityRun(runId));
+
+        await store.RecordRunAsync(BuildContinuityRun(olderRunId) with
+        {
+            StartedAt = new DateTimeOffset(2026, 3, 21, 16, 0, 0, TimeSpan.Zero),
+            EndedAt = new DateTimeOffset(2026, 3, 21, 16, 30, 0, TimeSpan.Zero)
+        });
+
+        await store.RecordRunAsync(BuildReconciliationReadyRun(newestRunId) with
+        {
+            StartedAt = new DateTimeOffset(2026, 3, 21, 18, 0, 0, TimeSpan.Zero),
+            EndedAt = new DateTimeOffset(2026, 3, 21, 18, 30, 0, TimeSpan.Zero)
+        });
+
+        var inbox = await app
+            .GetTestClient()
+            .GetFromJsonAsync<OperatorInboxDto>(
+                "/api/workstation/operator/inbox",
+                ServerJsonOptions);
+
+        inbox.Should().NotBeNull();
+        inbox!.Items.Should().NotContain(item =>
+            item.WorkItemId == $"promotion-review-{olderRunId.ToLowerInvariant()}");
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_OperatorInbox_ShouldIncludeLatestRunReviewPacketBlockers()
+    {
+        await using var app = await CreateAppAsync(services =>
+        {
+            RegisterRunReadServices(services);
+        });
+
+        var olderRunId = $"run-inbox-review-packet-older-{Guid.NewGuid():N}";
+        var newestRunId = $"run-inbox-review-packet-newest-{Guid.NewGuid():N}";
+        var store = app.Services.GetRequiredService<IStrategyRepository>();
+
+        await store.RecordRunAsync(BuildReconciliationReadyRun(olderRunId) with
+        {
+            StartedAt = new DateTimeOffset(2026, 3, 21, 16, 0, 0, TimeSpan.Zero),
+            EndedAt = new DateTimeOffset(2026, 3, 21, 16, 30, 0, TimeSpan.Zero)
+        });
+
+        await store.RecordRunAsync(BuildContinuityRun(newestRunId) with
+        {
+            StartedAt = new DateTimeOffset(2026, 3, 21, 18, 0, 0, TimeSpan.Zero),
+            EndedAt = new DateTimeOffset(2026, 3, 21, 18, 30, 0, TimeSpan.Zero)
+        });
 
         var inbox = await app
             .GetTestClient()
@@ -1036,15 +1083,19 @@ public sealed class WorkstationEndpointsTests
 
         inbox.Should().NotBeNull();
         inbox!.Items.Should().Contain(item => item.WorkItemId == "paper-session-missing");
+
         var reviewItem = inbox.Items.Should().ContainSingle(item =>
-            item.WorkItemId == $"promotion-review-{runId.ToLowerInvariant()}" &&
+            item.WorkItemId == $"promotion-review-{newestRunId.ToLowerInvariant()}" &&
             item.Kind == OperatorWorkItemKindDto.PromotionReview).Which;
 
         reviewItem.Tone.Should().Be(OperatorWorkItemToneDto.Warning);
         reviewItem.Workspace.Should().Be("Trading");
-        reviewItem.RunId.Should().Be(runId);
-        reviewItem.TargetRoute.Should().Be(UiApiRoutes.RunsReviewPacket.Replace("{runId}", runId, StringComparison.Ordinal));
+        reviewItem.RunId.Should().Be(newestRunId);
+        reviewItem.TargetRoute.Should().Be(UiApiRoutes.RunsReviewPacket.Replace("{runId}", newestRunId, StringComparison.Ordinal));
         reviewItem.TargetPageTag.Should().Be("TradingShell");
+        inbox.Items.Should().OnlyContain(item =>
+            !item.WorkItemId.StartsWith("promotion-review-", StringComparison.OrdinalIgnoreCase) ||
+            item.Tone is OperatorWorkItemToneDto.Warning or OperatorWorkItemToneDto.Critical);
         inbox.WarningCount.Should().BeGreaterThanOrEqualTo(1);
     }
 


### PR DESCRIPTION
### Motivation
- Reduce operator inbox churn and avoid surfacing stale review-packet blockers from older runs by ensuring only the most-recent run is considered for review-packet aggregation.
- Preserve existing review gating semantics so only runs requiring review (or failed/cancelled) can lead to review-packet requests, and keep emitted items limited to actionable tones.
- Keep work-item stability and dedup semantics unchanged so inbox grouping by `WorkItemId` does not introduce extra churn.

### Description
- Updated `AddRunReviewPacketWorkItemsAsync` in `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` to select a single latest run from `GetRunsAsync(...)` (ordered by a new `GetRunReviewTimestamp` helper) before calling `reviewPacketService.GetAsync` instead of iterating all runs.
- Added `GetRunReviewTimestamp(StrategyRunSummary)` helper that returns `CompletedAt ?? LastUpdatedAt` and left `ShouldSurfaceRunReviewWorkItems` unchanged as the promotion/status gate.
- Preserved the existing tone filter so only `Warning`/`Critical` review-packet work items are emitted, and preserved the `run-review-packets-unavailable` fallback item for service failures.
- Updated tests in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` to prove that older runs with actionable blockers are excluded when the newest run is clean and that newest-run blockers are still surfaced, and kept assertions that review-packet items remain warning/critical only.

### Testing
- Attempted to run the two targeted endpoint tests for the updated inbox scenarios (`MapWorkstationEndpoints_OperatorInbox_ShouldExcludeOlderRunReviewPacketBlockersWhenLatestRunIsClean` and `MapWorkstationEndpoints_OperatorInbox_ShouldIncludeLatestRunReviewPacketBlockers`) via `dotnet test`, but the environment lacks the `dotnet` CLI so tests could not be executed.
- No automated test failures were observed locally in this environment because the test run was not possible; tests were added/adjusted to cover the new behavior and are expected to pass in CI with a standard .NET test runner available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50e5a89048320aa54c5405ad91b47)