### PR TITLE
Enforce Security Master references on governance DTOs and add CI contract-gate checks

### DIFF
--- a/docs/operations/governance-operator-workflow.md
+++ b/docs/operations/governance-operator-workflow.md
@@ -54,3 +54,21 @@ Before release, capture journey evidence that covers:
 2. Security Master → fund portfolio / ledger / reconciliation / cash / report-pack drill-ins.
 3. Governance report-pack preview continuity inside the fund workspace.
 4. Reconciliation queue actions and downstream reporting handoff.
+
+## 6) Architecture guard: instrument metadata in governance/accounting/reporting DTOs
+
+Allowed pattern:
+
+- Governance/accounting/reporting DTOs may include instrument-facing fields **only when** they carry Security Master identity + provenance references (for example `SecurityId` plus `SecurityMasterSource`/`SecurityMasterProvenance`).
+- Read services and export seams must resolve labels/classification through Security Master lookup flow rather than local descriptor synthesis.
+
+Forbidden pattern:
+
+- Adding or deriving local instrument descriptors (ticker/name/classification) in governance DTOs without required Security Master references.
+- Emitting endpoint/export payloads where instrument rows cannot be traced back to Security Master identity.
+
+Remediation:
+
+1. Add required Security Master identity and provenance fields to the DTO.
+2. Replace local descriptor derivation with Security Master lookup + reference projection.
+3. Re-run contract compatibility checks and governance regression slices before merge.

--- a/scripts/check_contract_compatibility_gate.py
+++ b/scripts/check_contract_compatibility_gate.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 TRACKED_PREFIXES = (
     "src/Meridian.Contracts/Workstation/",
+    "src/Meridian.Contracts/FundStructure/",
     "src/Meridian.Strategies/Services/",
     "src/Meridian.Ledger/",
 )
@@ -48,6 +49,22 @@ BREAKING_CONTRACT_SHAPE_PATTERNS = (
 )
 
 GIT_EXECUTABLE = shutil.which("git") or shutil.which("git.cmd") or "git"
+
+GOVERNANCE_DTO_PATH_HINTS = ("workstation", "fundstructure", "governance", "accounting", "reporting")
+INSTRUMENT_FIELD_HINTS = (
+    "instrument",
+    "symbol",
+    "ticker",
+    "cusip",
+    "isin",
+    "figi",
+)
+REQUIRED_SECURITY_MASTER_HINTS = (
+    "securityid",
+    "securitymaster",
+    "provenance",
+    "source",
+)
 
 
 def run_git(args: list[str]) -> str:
@@ -97,6 +114,42 @@ def patch_has_breaking_removal(patch: str) -> bool:
     return any(is_breaking_removal_line(line) for line in patch.splitlines())
 
 
+def _is_governance_contract_dto_path(path: str) -> bool:
+    normalized = path.lower()
+    return normalized.startswith("src/meridian.contracts/") and normalized.endswith(".cs") and any(
+        hint in normalized for hint in GOVERNANCE_DTO_PATH_HINTS
+    )
+
+
+def find_missing_security_master_instrument_references(changed_files: list[str], patch: str) -> list[str]:
+    instrument_touched_by_file: dict[str, bool] = {}
+    for raw_line in patch.splitlines():
+        if raw_line.startswith("+++ b/"):
+            path = raw_line[len("+++ b/"):].strip()
+            instrument_touched_by_file[path] = False
+            continue
+        if not raw_line.startswith("+") or raw_line.startswith("+++"):
+            continue
+        line = raw_line[1:].strip().lower()
+        if any(hint in line for hint in INSTRUMENT_FIELD_HINTS):
+            current = next(reversed(instrument_touched_by_file), None)
+            if current:
+                instrument_touched_by_file[current] = True
+
+    violations: list[str] = []
+    for file_path in changed_files:
+        if not _is_governance_contract_dto_path(file_path):
+            continue
+        if not instrument_touched_by_file.get(file_path):
+            continue
+        body = Path(file_path).read_text(encoding="utf-8").lower()
+        if any(hint in body for hint in REQUIRED_SECURITY_MASTER_HINTS):
+            continue
+        violations.append(file_path)
+
+    return violations
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Enforce contract compatibility migration-note requirements.")
     parser.add_argument("--base", required=True, help="Base git ref for comparison.")
@@ -123,6 +176,13 @@ def main() -> int:
         print(f"  - {path}")
 
     patch = run_git(["diff", "--unified=0", diff_range, "--", *tracked_changed_files])
+    security_master_reference_violations = find_missing_security_master_instrument_references(tracked_changed_files, patch)
+    if security_master_reference_violations:
+        print("Contract compatibility gate failed: governance/accounting/reporting DTO instrument metadata must include Security Master identity/provenance fields.")
+        for violation in security_master_reference_violations:
+            print(f"- Add required Security Master identity/provenance fields to `{violation}` (for example: SecurityId + SecurityMasterSource/Provenance).")
+        return 1
+
     is_breaking = patch_has_breaking_removal(patch)
 
     if not is_breaking:

--- a/tests/scripts/test_check_contract_compatibility_gate.py
+++ b/tests/scripts/test_check_contract_compatibility_gate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import tempfile
 import sys
 import unittest
 from pathlib import Path
@@ -107,6 +108,41 @@ diff --git a/src/Meridian.Contracts/Workstation/LedgerContinuityDtos.cs b/src/Me
 """
 
         self.assertTrue(gate.patch_has_breaking_removal(patch))
+
+
+    def test_find_missing_security_master_instrument_references_flags_governance_dto_without_identity_fields(self) -> None:
+        with tempfile.TemporaryDirectory(dir="src/Meridian.Contracts/Workstation") as tmp_dir:
+            temp_path = Path(tmp_dir) / "GovernanceInstrumentContractDto.cs"
+            temp_path.write_text("public sealed record GovernanceInstrumentContractDto(string InstrumentTicker);", encoding="utf-8")
+            changed_files = [str(temp_path)]
+            patch = f"""
+diff --git a/{temp_path} b/{temp_path}
+--- a/{temp_path}
++++ b/{temp_path}
+@@ -1,0 +1 @@
++    string InstrumentTicker,
+"""
+            violations = gate.find_missing_security_master_instrument_references(changed_files, patch)
+            self.assertEqual(changed_files, violations)
+
+
+    def test_find_missing_security_master_instrument_references_allows_security_master_linked_dto(self) -> None:
+        with tempfile.TemporaryDirectory(dir="src/Meridian.Contracts/Workstation") as tmp_dir:
+            temp_path = Path(tmp_dir) / "GovernanceInstrumentContractDto.cs"
+            temp_path.write_text(
+                "public sealed record GovernanceInstrumentContractDto(string InstrumentTicker, Guid SecurityId, string SecurityMasterSource);",
+                encoding="utf-8")
+            changed_files = [str(temp_path)]
+            patch = f"""
+diff --git a/{temp_path} b/{temp_path}
+--- a/{temp_path}
++++ b/{temp_path}
+@@ -1,0 +1,2 @@
++    string InstrumentTicker,
++    Guid SecurityId,
+"""
+            violations = gate.find_missing_security_master_instrument_references(changed_files, patch)
+            self.assertEqual([], violations)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Ensure governance/accounting/reporting DTOs cannot introduce instrument metadata without an authoritative Security Master identity and provenance reference to avoid downstream reconciliation and reporting drift. 
- Prevent accidental addition of local/derived instrument descriptors (ticker/name/classification) in governance surfaces that cannot be traced back to Security Master. 
- Provide an explicit operator/developer remediation path and an architecture guard note so violations are discoverable and fixable before merge.

### Description
- Extend the contract-compatibility gate by adding `src/Meridian.Contracts/FundStructure/` to the tracked surfaces and implementing a governance DTO heuristic in `scripts/check_contract_compatibility_gate.py` that fails when instrument fields are added without required Security Master identity/provenance hints. 
- Add unit regression coverage in `tests/scripts/test_check_contract_compatibility_gate.py` to flag DTO additions with instrument fields and to allow DTOs that include `SecurityId`/source linkage. 
- Publish a concise architecture guard in `docs/operations/governance-operator-workflow.md` documenting allowed vs forbidden instrument-data patterns and the expected remediation steps (add `SecurityId` + provenance and use Security Master lookup flows).

### Testing
- Ran the new unit tests with `python3 -m unittest tests/scripts/test_check_contract_compatibility_gate.py`, which completed successfully (all tests passed). 
- The new check integrates into the existing CI contract-compatibility step (the updated script is exercised by the repository's `Run contract compatibility gate` workflow).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f519eb4f248320b5cf87caaa96fca3)