### PR TITLE
Normalize account-sync ingestion and emit continuity reconciliation deltas

### DIFF
--- a/src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs
+++ b/src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs
@@ -350,7 +350,7 @@ public sealed class InMemoryFundAccountService : IFundAccountService, IAccountMa
             {
                 EnsureAllowed(stored.Summary, "ingest-custodian-statement", request.IsBackfill, allowSuspended: true);
                 stored.CustodianBatches.Add(batch);
-                stored.CustodianPositions.AddRange(request.Lines);
+                UpsertCustodianPositions(stored.CustodianPositions, request.Lines);
                 snapshot = CaptureSnapshotLocked();
             }
         }
@@ -380,7 +380,7 @@ public sealed class InMemoryFundAccountService : IFundAccountService, IAccountMa
             {
                 EnsureAllowed(stored.Summary, "ingest-bank-statement", request.IsBackfill, allowSuspended: true);
                 stored.BankBatches.Add(batch);
-                stored.BankLines.AddRange(request.Lines);
+                UpsertBankStatementLines(stored.BankLines, request.Lines);
                 snapshot = CaptureSnapshotLocked();
             }
         }
@@ -485,6 +485,8 @@ public sealed class InMemoryFundAccountService : IFundAccountService, IAccountMa
                 Reason: "Cash balance matches internal ledger"));
         }
 
+        AddContinuityCheckResults(runId, request.AsOfDate, results, request.AccountId);
+
         if (positions.Count > 0)
         {
             results.Add(new AccountReconciliationResultDto(
@@ -529,6 +531,97 @@ public sealed class InMemoryFundAccountService : IFundAccountService, IAccountMa
 
         await PersistSnapshotAsync(snapshotToPersist, ct).ConfigureAwait(false);
         return run;
+    }
+
+    private static void UpsertCustodianPositions(
+        List<CustodianPositionLineDto> existing,
+        IReadOnlyList<CustodianPositionLineDto> incoming)
+    {
+        var index = existing.ToDictionary(
+            static line => BuildCustodianDedupKey(line),
+            static line => line,
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var line in incoming)
+        {
+            index[BuildCustodianDedupKey(line)] = line;
+        }
+
+        existing.Clear();
+        existing.AddRange(index.Values.OrderBy(static line => line.AsOfDate).ThenBy(static line => line.Identifier, StringComparer.OrdinalIgnoreCase));
+    }
+
+    private static void UpsertBankStatementLines(
+        List<BankStatementLineDto> existing,
+        IReadOnlyList<BankStatementLineDto> incoming)
+    {
+        var index = existing.ToDictionary(
+            static line => BuildBankDedupKey(line),
+            static line => line,
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var line in incoming)
+        {
+            index[BuildBankDedupKey(line)] = line;
+        }
+
+        existing.Clear();
+        existing.AddRange(index.Values.OrderBy(static line => line.TransactionDate).ThenBy(static line => line.Reference, StringComparer.OrdinalIgnoreCase));
+    }
+
+    private static string BuildCustodianDedupKey(CustodianPositionLineDto line)
+        => $"{line.AccountId:N}|{line.AsOfDate:yyyyMMdd}|{line.IdentifierType}|{line.Identifier}".ToUpperInvariant();
+
+    private static string BuildBankDedupKey(BankStatementLineDto line)
+        => $"{line.AccountId:N}|{line.TransactionDate:yyyyMMdd}|{line.ValueDate:yyyyMMdd}|{line.Currency}|{line.Amount:0.########}|{line.TransactionType}|{line.Reference ?? line.Description}".ToUpperInvariant();
+
+    private void AddContinuityCheckResults(
+        Guid runId,
+        DateOnly asOfDate,
+        List<AccountReconciliationResultDto> results,
+        Guid accountId)
+    {
+        AccountBalanceSnapshotDto? accountSync = null;
+        AccountBalanceSnapshotDto? runDerived = null;
+
+        lock (_gate)
+        {
+            if (!_accounts.TryGetValue(accountId, out var stored))
+            {
+                return;
+            }
+
+            accountSync = stored.Snapshots
+                .Where(static s => s.Source.StartsWith("brokerage-sync:", StringComparison.OrdinalIgnoreCase))
+                .Where(s => s.AsOfDate == asOfDate)
+                .OrderByDescending(static s => s.RecordedAt)
+                .FirstOrDefault();
+            runDerived = stored.Snapshots
+                .Where(static s => !s.Source.StartsWith("brokerage-sync:", StringComparison.OrdinalIgnoreCase))
+                .Where(s => s.AsOfDate == asOfDate)
+                .OrderByDescending(static s => s.RecordedAt)
+                .FirstOrDefault();
+        }
+
+        if (accountSync is null || runDerived is null)
+        {
+            return;
+        }
+
+        var variance = accountSync.CashBalance - runDerived.CashBalance;
+        results.Add(new AccountReconciliationResultDto(
+            Guid.NewGuid(),
+            runId,
+            CheckLabel: "RunVsAccountSyncCashContinuity",
+            IsMatch: variance == 0m,
+            Category: "Continuity",
+            Status: variance == 0m ? "Matched" : "Break",
+            ExpectedAmount: runDerived.CashBalance,
+            ActualAmount: accountSync.CashBalance,
+            Variance: variance,
+            Reason: variance == 0m
+                ? "Run-derived and account-sync-derived balances agree."
+                : "Run-derived and account-sync-derived balances diverge."));
     }
 
     public Task<IReadOnlyList<AccountReconciliationRunDto>> GetReconciliationRunsAsync(

--- a/tests/Meridian.Tests/Ui/BrokeragePortfolioSyncServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/BrokeragePortfolioSyncServiceTests.cs
@@ -86,6 +86,9 @@ public sealed class BrokeragePortfolioSyncServiceTests
             var reconciliationRuns = await fundAccountService.GetReconciliationRunsAsync(fundAccountId, cts.Token);
             reconciliationRuns.Should().ContainSingle();
             reconciliationRuns[0].Status.Should().NotBeNullOrWhiteSpace();
+
+            var reconciliationResults = await fundAccountService.GetReconciliationResultsAsync(reconciliationRuns[0].ReconciliationRunId, cts.Token);
+            reconciliationResults.Should().Contain(result => result.Category == "Cash");
         }
         finally
         {
@@ -252,6 +255,55 @@ public sealed class BrokeragePortfolioSyncServiceTests
             await act.Should().ThrowAsync<OperationCanceledException>();
             Directory.Exists(Path.Combine(root, "projections")).Should().BeFalse();
             Directory.Exists(Path.Combine(root, "raw")).Should().BeFalse();
+        }
+        finally
+        {
+            DeleteTempRoot(root);
+        }
+    }
+
+    [Fact]
+    public async Task Scenario_RunDerivedAndAccountSyncSnapshots_ContinuityDeltaIsEmitted()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var (service, serviceProvider) = CreateService(
+                root,
+                new FixedPortfolioAdapter("alpaca"),
+                new FixedActivityAdapter("alpaca"),
+                includeSecurityLookup: true);
+            var fundAccountId = Guid.NewGuid();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var fundAccountService = serviceProvider.GetRequiredService<IFundAccountService>();
+            await fundAccountService.CreateAccountAsync(
+                new CreateAccountRequest(
+                    fundAccountId,
+                    AccountTypeDto.Brokerage,
+                    "BRK-CONT",
+                    "Continuity Brokerage",
+                    "USD",
+                    DateTimeOffset.UtcNow.AddDays(-2),
+                    "tests"),
+                cts.Token);
+            await fundAccountService.RecordBalanceSnapshotAsync(
+                new RecordAccountBalanceSnapshotRequest(
+                    fundAccountId,
+                    DateOnly.FromDateTime(DateTime.UtcNow),
+                    "USD",
+                    CashBalance: 49900m,
+                    Source: "run-derived:paper",
+                    RecordedBy: "tests"),
+                cts.Token);
+
+            _ = await service.RunSyncAsync(
+                fundAccountId,
+                new WorkstationBrokerageSyncRunRequestDto("alpaca", "PA-CONT", "ops-review"),
+                cts.Token);
+
+            var runs = await fundAccountService.GetReconciliationRunsAsync(fundAccountId, cts.Token);
+            var results = await fundAccountService.GetReconciliationResultsAsync(runs[0].ReconciliationRunId, cts.Token);
+            results.Should().ContainSingle(r => r.CheckLabel == "RunVsAccountSyncCashContinuity" && r.Category == "Continuity" && r.IsMatch == false);
         }
         finally
         {


### PR DESCRIPTION
### Motivation
- Consolidate account-sync ingestion so custodian positions and bank statement lines are normalized and written through a single deterministic path instead of ad-hoc append-only writes.
- Provide deterministic deduplication and overwrite-on-conflict behavior for repeated external account events to prevent duplicate/ordering-induced projection drift.
- Surface explicit continuity checks that compare run-derived and account-sync-derived snapshots for the same fund account/as-of date so reconciliation deltas are observable to downstream workflows and operator UI.

### Description
- Replaced append-only ingestion with upsert-style normalization for custodian positions and bank statement lines via `UpsertCustodianPositions` and `UpsertBankStatementLines` in `InMemoryFundAccountService`. 
- Implemented deterministic deduplication keys: custodian dedup key is `(AccountId, AsOfDate, IdentifierType, Identifier)` and bank dedup key is `(AccountId, TransactionDate, ValueDate, Currency, Amount, TransactionType, Reference/Description)`. 
- Added `AddContinuityCheckResults` which computes a cash-variance between the latest `brokerage-sync:` account snapshot and the latest non-`brokerage-sync:` run-derived snapshot for the same `AsOfDate`, and emits an `AccountReconciliationResultDto` with `Category = "Continuity"` and `CheckLabel = "RunVsAccountSyncCashContinuity"` when present.
- Updated the account reconciliation flow to invoke the continuity check so continuity deltas are stored alongside other reconciliation results, and added test coverage to assert reconciliation-result emission.
- Tests updated: `tests/Meridian.Tests/Ui/BrokeragePortfolioSyncServiceTests.cs` now asserts `Cash` reconciliation results are present and adds a new test `Scenario_RunDerivedAndAccountSyncSnapshots_ContinuityDeltaIsEmitted` that seeds a run-derived snapshot and verifies the continuity break is produced by a subsequent brokerage sync.

### Testing
- A targeted test run was attempted with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~BrokeragePortfolioSyncServiceTests" --logger "console;verbosity=minimal"`, but the environment does not have the SDK installed and the command failed with `/bin/bash: dotnet: command not found` so automated tests could not be executed here.
- Local static review and repository compilation were not performed in this environment, so no automated tests completed successfully as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f519ea494c8320ac52462702a1a002)