### PR TITLE
Define canonical StrategyRunIdentity and add compatibility checks

### DIFF
--- a/src/Meridian.Contracts/Workstation/StrategyRunContractCompatibility.cs
+++ b/src/Meridian.Contracts/Workstation/StrategyRunContractCompatibility.cs
@@ -1,0 +1,12 @@
+namespace Meridian.Contracts.Workstation;
+
+public static class StrategyRunContractCompatibility
+{
+    public static void EnsureCanonicalIdentity(StrategyRunSummary summary)
+    {
+        ArgumentNullException.ThrowIfNull(summary);
+        var identity = summary.Identity ?? throw new InvalidOperationException("Run projection missing canonical identity.");
+        if (string.IsNullOrWhiteSpace(identity.CanonicalRunKey)) throw new InvalidOperationException("CanonicalRunKey is required.");
+        if (identity.Mode != summary.Mode) throw new InvalidOperationException("Identity mode must match summary mode.");
+    }
+}

--- a/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
+++ b/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
@@ -82,6 +82,7 @@ public sealed record StrategyRunPromotionSummary(
     string? SourceRunId = null,
     string? TargetRunId = null,
     string? AuditReference = null,
+    StrategyRunIdentity? Identity = null,
     string? ApprovalStatus = null,
     string? ManualOverrideId = null,
     string? ApprovedBy = null,
@@ -99,6 +100,22 @@ public sealed record StrategyRunGovernanceSummary(
     string? AuditReference,
     string? DatasetReference,
     string? FeedReference);
+
+/// <summary>
+/// Canonical run identity and provenance contract shared by run projections.
+/// </summary>
+
+public sealed record StrategyRunIdentity(
+    string CanonicalRunKey,
+    string? ParentCanonicalRunKey,
+    IReadOnlyList<string> DerivedCanonicalRunKeys,
+    StrategyRunMode Mode,
+    string? PromotionSourceRunId,
+    string? PromotionTargetRunId,
+    string? PromotionDecision,
+    string? ReplayAuditReference,
+    DateTimeOffset? ReplayVerifiedAt,
+    bool HasReplayAudit);
 
 /// <summary>
 /// Summary row shown in a run browser or recent-run list.
@@ -122,6 +139,7 @@ public sealed record StrategyRunSummary(
     int FillCount,
     DateTimeOffset LastUpdatedAt,
     string? AuditReference = null,
+    StrategyRunIdentity? Identity = null,
     StrategyRunExecutionSummary? Execution = null,
     StrategyRunPromotionSummary? Promotion = null,
     StrategyRunGovernanceSummary? Governance = null,

--- a/src/Meridian.Strategies/Services/StrategyRunReadService.cs
+++ b/src/Meridian.Strategies/Services/StrategyRunReadService.cs
@@ -301,6 +301,7 @@ public sealed class StrategyRunReadService
             FillCount: run.Metrics?.Fills.Count ?? 0,
             LastUpdatedAt: GetLastUpdatedAt(run),
             AuditReference: run.AuditReference,
+            Identity: BuildIdentity(run, promotionLookup),
             Execution: BuildExecutionSummary(run),
             Promotion: BuildPromotionSummary(run, promotionLookup),
             Governance: BuildGovernanceSummary(run),
@@ -312,6 +313,25 @@ public sealed class StrategyRunReadService
             SweepObjective: run.SweepObjective);
     }
 
+
+    private static StrategyRunIdentity BuildIdentity(
+        StrategyRunEntry run,
+        IReadOnlyDictionary<string, StrategyPromotionRecord> promotionLookup)
+    {
+        promotionLookup.TryGetValue(run.RunId, out var matchedRecord);
+        var replayReference = run.AuditReference;
+        return new StrategyRunIdentity(
+            CanonicalRunKey: run.RunId,
+            ParentCanonicalRunKey: run.ParentRunId,
+            DerivedCanonicalRunKeys: Array.Empty<string>(),
+            Mode: MapMode(run.RunType),
+            PromotionSourceRunId: matchedRecord?.SourceRunId ?? run.ParentRunId,
+            PromotionTargetRunId: matchedRecord?.TargetRunId,
+            PromotionDecision: matchedRecord?.Decision,
+            ReplayAuditReference: replayReference,
+            ReplayVerifiedAt: run.EndedAt,
+            HasReplayAudit: !string.IsNullOrWhiteSpace(replayReference));
+    }
     private static StrategyRunExecutionSummary BuildExecutionSummary(StrategyRunEntry run)
     {
         var metrics = run.Metrics?.Metrics;

--- a/tests/Meridian.Tests/Strategies/StrategyRunReadServiceTests.cs
+++ b/tests/Meridian.Tests/Strategies/StrategyRunReadServiceTests.cs
@@ -12,6 +12,35 @@ namespace Meridian.Tests.Strategies;
 
 public sealed class StrategyRunReadServiceTests
 {
+
+    [Fact]
+    public async Task GetRunsAsync_ProvidesCanonicalIdentityAndCompatibilityPasses()
+    {
+        var store = new StrategyRunStore();
+        await store.RecordRunAsync(BuildCompletedRun(
+            runId: "run-identity",
+            strategyId: "momentum-1",
+            strategyName: "Momentum",
+            finalEquity: 120_000m,
+            netPnl: 20_000m,
+            totalReturn: 0.2m,
+            realizedPnl: 10_000m,
+            unrealizedPnl: 10_000m,
+            fillCount: 2,
+            sharpeRatio: 1.1,
+            maxDrawdown: 3_000m));
+
+        var service = new StrategyRunReadService(store, new PortfolioReadService(), new LedgerReadService());
+        var rows = await service.GetRunsAsync();
+
+        rows.Should().ContainSingle();
+        var row = rows[0];
+        row.Identity.Should().NotBeNull();
+        row.Identity!.CanonicalRunKey.Should().Be(row.RunId);
+        row.Identity.Mode.Should().Be(row.Mode);
+        StrategyRunContractCompatibility.EnsureCanonicalIdentity(row);
+    }
+
     [Fact]
     public async Task GetRunDetailAsync_BuildsSharedPortfolioAndLedgerModels()
     {


### PR DESCRIPTION
### Motivation
- Introduce a single canonical run identity seam so all run-facing projections and endpoints share an immutable run key, parent/derived relationships, mode, promotion lineage, and replay/audit markers instead of repeating ad-hoc fields. 
- Provide a clear compatibility guard so downstream consumers fail-fast when required provenance fields are missing or inconsistent. 

### Description
- Added a new contract type `StrategyRunIdentity` and attached it to `StrategyRunSummary` so the canonical identity is part of the shared workstation DTOs (`src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs`).
- Wired `StrategyRunReadService` to materialize the canonical identity via a new `BuildIdentity` helper and populate `Identity` in the `ToSummary` projection (`src/Meridian.Strategies/Services/StrategyRunReadService.cs`).
- Added `StrategyRunContractCompatibility.EnsureCanonicalIdentity` which validates presence and basic consistency of the canonical identity on a `StrategyRunSummary` (`src/Meridian.Contracts/Workstation/StrategyRunContractCompatibility.cs`).
- Added a unit test that exercises `GetRunsAsync` to confirm `Identity` is populated and passes the compatibility guard (`tests/Meridian.Tests/Strategies/StrategyRunReadServiceTests.cs`).

### Testing
- Added a focused unit test `GetRunsAsync_ProvidesCanonicalIdentityAndCompatibilityPasses` under `StrategyRunReadServiceTests` that asserts the `Identity` is present and consistent with the summary. 
- Attempted to run the focused test command `dotnet test --filter "FullyQualifiedName~StrategyRunReadServiceTests"` but the execution environment lacks `dotnet`, so automated tests were not executed in this container (no test failures observed at compile time here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f519e7dba88320a2606bfe6762bf6e)