### PR TITLE
Fix reconciliation compile blockers in WPF build graph

### DIFF
--- a/src/Meridian.Domain/Reconciliation/StatementReconciliationAggregate.cs
+++ b/src/Meridian.Domain/Reconciliation/StatementReconciliationAggregate.cs
@@ -50,19 +50,3 @@ public sealed record ReconciliationCaseEvent(
     string OperatorId,
     ReconciliationCaseState NewState,
     string Note);
-
-public sealed class ReconciliationCase
-{
-    public required string CaseId { get; init; }
-    public required string RowId { get; init; }
-    public required string Severity { get; init; }
-    public required string Reason { get; init; }
-    public ReconciliationCaseState State { get; private set; } = ReconciliationCaseState.Open;
-    public List<ReconciliationCaseEvent> Events { get; } = [];
-
-    public void Transition(ReconciliationCaseState newState, string operatorId, string note)
-    {
-        State = newState;
-        Events.Add(new ReconciliationCaseEvent(DateTimeOffset.UtcNow, operatorId, newState, note));
-    }
-}

--- a/src/Meridian.Ui.Services/Meridian.Ui.Services.csproj
+++ b/src/Meridian.Ui.Services/Meridian.Ui.Services.csproj
@@ -30,6 +30,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Meridian.Contracts\Meridian.Contracts.csproj" />
+    <ProjectReference Include="..\Meridian.Infrastructure\Meridian.Infrastructure.csproj" />
+    <ProjectReference Include="..\Meridian.Ui.Shared\Meridian.Ui.Shared.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Motivation
- Unblock the `Build WPF binaries` job which failed due to unresolved reconciliation types and a duplicate `ReconciliationCase` definition in the domain layer.

### Description
- Removed the duplicate `ReconciliationCase` class from `src/Meridian.Domain/Reconciliation/StatementReconciliationAggregate.cs` so the domain has a single canonical `ReconciliationCase` type.
- Added `ProjectReference`s to `..\Meridian.Infrastructure\Meridian.Infrastructure.csproj` and `..\Meridian.Ui.Shared\Meridian.Ui.Shared.csproj` in `src/Meridian.Ui.Services/Meridian.Ui.Services.csproj` so `ReconciliationApiService` can resolve the store interfaces and DTO contracts it depends on.
- This change is limited to compile-graph cleanup and does not modify runtime reconciliation logic.

### Testing
- Attempted `dotnet build src/Meridian.Ui.Services/Meridian.Ui.Services.csproj` as a smoke compile check but the environment reported `dotnet: command not found`, so the build could not be executed.
- Attempted `dotnet build src/Meridian.Domain/Meridian.Domain.csproj` but it also could not be executed due to the same missing `dotnet` runtime in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f519d289448320bc0081c4338b12ea)