### PR TITLE
fix: enforce .NET 10 SDK checks in bootstrap preflight scripts

### DIFF
--- a/build/scripts/install/install.sh
+++ b/build/scripts/install/install.sh
@@ -135,7 +135,7 @@ check_prerequisites() {
         local ver
         ver=$(dotnet --version)
         success "  .NET SDK ${ver}"
-        if [[ "${ver%%.*}" -lt 9 ]]; then
+        if [[ "${ver%%.*}" -lt 10 ]]; then
             warn "  .NET SDK ${ver} is too old — 10.0.100 or later is required (see global.json)"
             ok=false
         fi

--- a/scripts/dev/desktop-dev.ps1
+++ b/scripts/dev/desktop-dev.ps1
@@ -37,7 +37,7 @@ $dotnetVersion = (& dotnet --version).Trim()
 Info "Detected .NET SDK: $dotnetVersion"
 
 # Check if .NET 10 is installed
-if (-not $dotnetVersion.StartsWith("9.")) {
+if (-not $dotnetVersion.StartsWith("10.")) {
     Warn ".NET 10 SDK not detected (found: $dotnetVersion)"
     $validationWarnings += ".NET 10 SDK recommended but not installed"
     Write-Host ""


### PR DESCRIPTION
### Motivation
- The repo was migrated to .NET 10 but two setup/preflight checks still validated for .NET 9, which produced misleading readiness results and allowed incorrect SDK versions to pass validation; the predicates must match `global.json`'s SDK requirement (10.0.100).

### Description
- Update `scripts/dev/desktop-dev.ps1` to detect .NET 10 by checking `StartsWith("10.")` instead of `StartsWith("9.")`.
- Update `build/scripts/install/install.sh` prereq `--check` path to reject SDK major versions below `10` by changing the numeric test from `< 9` to `< 10`.

### Testing
- Run a shell syntax check with `bash -n build/scripts/install/install.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79ccd18b08320ab869ad17e5b9772)