### PR TITLE
fix: redact provider secrets from data source listings

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/ProviderEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ProviderEndpoints.cs
@@ -31,7 +31,7 @@ public static class ProviderEndpoints
             var cfg = store.Load();
             return Results.Json(new
             {
-                sources = cfg.DataSources?.Sources ?? Array.Empty<DataSourceConfig>(),
+                sources = (cfg.DataSources?.Sources ?? Array.Empty<DataSourceConfig>()).Select(RedactSensitiveProviderOptions).ToArray(),
                 defaultRealTimeSourceId = cfg.DataSources?.DefaultRealTimeSourceId,
                 defaultHistoricalSourceId = cfg.DataSources?.DefaultHistoricalSourceId,
                 enableFailover = cfg.DataSources?.EnableFailover ?? true,
@@ -493,7 +493,7 @@ public static class ProviderEndpoints
             var cfg = store.Load();
             return Results.Json(new
             {
-                sources = cfg.DataSources?.Sources ?? Array.Empty<DataSourceConfig>(),
+                sources = (cfg.DataSources?.Sources ?? Array.Empty<DataSourceConfig>()).Select(RedactSensitiveProviderOptions).ToArray(),
                 defaultRealTimeSourceId = cfg.DataSources?.DefaultRealTimeSourceId,
                 defaultHistoricalSourceId = cfg.DataSources?.DefaultHistoricalSourceId,
                 enableFailover = cfg.DataSources?.EnableFailover ?? true,
@@ -669,6 +669,19 @@ public static class ProviderEndpoints
         string? ApiSecret,
         string? Endpoint,
         string[]? Capabilities);
+
+    private static DataSourceConfig RedactSensitiveProviderOptions(DataSourceConfig source)
+    {
+        return source with
+        {
+            Alpaca = source.Alpaca is null
+                ? null
+                : source.Alpaca with { KeyId = null, SecretKey = null },
+            Polygon = source.Polygon is null
+                ? null
+                : source.Polygon with { ApiKey = null }
+        };
+    }
 
     private sealed record ProviderSetupResult(
         bool Success,

--- a/tests/Meridian.Tests/Integration/EndpointTests/ProviderEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/ProviderEndpointTests.cs
@@ -185,6 +185,39 @@ public sealed class ProviderEndpointTests
     #region Data Source CRUD
 
     [Fact]
+    public async Task GetDataSources_DoesNotReturnProviderSecrets()
+    {
+        var payload = new
+        {
+            Kind = "alpaca",
+            DisplayName = $"Alpaca Secret Test {Guid.NewGuid():N}",
+            ApiKey = "sensitive-key",
+            ApiSecret = "sensitive-secret",
+            Endpoint = (string?)null,
+            Capabilities = new[] { "streaming" }
+        };
+        var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+        var setupResponse = await _client.PostAsync("/api/providers/configure", content);
+        setupResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var response = await _client.GetAsync("/api/config/datasources");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await DeserializeAsync(response);
+        var sources = json["sources"];
+        sources.ValueKind.Should().Be(JsonValueKind.Array);
+
+        var configuredSource = sources.EnumerateArray()
+            .FirstOrDefault(source => source.GetProperty("name").GetString() == payload.DisplayName);
+
+        configuredSource.ValueKind.Should().NotBe(JsonValueKind.Undefined);
+        var alpaca = configuredSource.GetProperty("alpaca");
+        alpaca.GetProperty("keyId").ValueKind.Should().Be(JsonValueKind.Null);
+        alpaca.GetProperty("secretKey").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
     public async Task GetDataSources_ReturnsJsonWithSources()
     {
         var response = await _client.GetAsync("/api/config/datasources");


### PR DESCRIPTION
### Motivation
- Prevent accidental disclosure of provider credentials stored in DataSourceConfig objects when callers list configured data sources via the UI API.
- The existing listing endpoints returned the raw `DataSourceConfig` objects (including `Alpaca.KeyId`, `Alpaca.SecretKey`, and `Polygon.ApiKey`), contradicting the UI's expectation that secrets remain server-side.

### Description
- Added `RedactSensitiveProviderOptions(DataSourceConfig)` which returns a copy of a `DataSourceConfig` with `Alpaca.KeyId`, `Alpaca.SecretKey`, and `Polygon.ApiKey` set to `null` to prevent credential leakage.
- Applied the redaction to both `/api/config/datasources` and its alias `/api/config/data-sources` by projecting stored sources with `.Select(RedactSensitiveProviderOptions).ToArray()` before JSON serialization.
- Kept provider setup behavior (the POST `/api/providers/configure` endpoint still persists submitted credentials) but ensured the listing API does not return those sensitive fields.
- Added an integration test `GetDataSources_DoesNotReturnProviderSecrets` to `tests/Meridian.Tests/Integration/EndpointTests/ProviderEndpointTests.cs` that configures an Alpaca provider with secrets and asserts the listing response contains `null` for `keyId` and `secretKey`.

### Testing
- Added an integration test verifying redaction of Alpaca secrets in the data-source listing; the test is included in the commit but was not executed in this environment.
- Attempted to run the focused provider endpoint tests with `dotnet test --filter "FullyQualifiedName~ProviderEndpointTests"`, but the container lacks the `dotnet` SDK so tests could not be run (`dotnet: command not found`).
- Manual inspection and targeted edits were used to ensure the redaction is applied in both listing endpoints and the new test checks the intended behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79db1d3388320ac3684f7442e512e)