### PR TITLE
fix: avoid buffering desktop stderr diagnostics on failure

### DIFF
--- a/scripts/dev/run-desktop.ps1
+++ b/scripts/dev/run-desktop.ps1
@@ -361,9 +361,13 @@ try {
 
     if ($desktopProcess.ExitCode -ne 0) {
         if (Test-Path $desktopStderr) {
-            $stderrContent = Get-Content $desktopStderr | Out-String
-            if (-not [string]::IsNullOrWhiteSpace($stderrContent)) {
-                Write-Host $stderrContent.TrimEnd()
+            $hasStderr = $false
+            Get-Content -Path $desktopStderr | ForEach-Object {
+                $hasStderr = $true
+                Write-Host $_
+            }
+            if (-not $hasStderr) {
+                Write-Verbose "Desktop stderr log was empty: $desktopStderr"
             }
         }
 


### PR DESCRIPTION
### Motivation
- Prevent unbounded memory use when the desktop launcher prints redirected stderr on a non-zero exit by removing the `Get-Content ... | Out-String` buffering path in `scripts/dev/run-desktop.ps1`.

### Description
- Replace full-file materialization with a streaming loop using `Get-Content -Path $desktopStderr | ForEach-Object { Write-Host $_ }` plus a small `$hasStderr` guard while preserving existing failure messages and log-path diagnostics.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79db2a81083209a96245193746877)