### PR TITLE
Restore operator inbox review blockers across recent runs

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -1746,25 +1746,22 @@ public static class WorkstationEndpoints
                 .GetRunsAsync(new StrategyRunHistoryQuery(Limit: 6), context.RequestAborted)
                 .ConfigureAwait(false);
 
-            var latestRun = runs
-                .OrderByDescending(GetRunReviewTimestamp)
-                .FirstOrDefault();
-            if (latestRun is null || !ShouldSurfaceRunReviewWorkItems(latestRun))
+            foreach (var run in runs
+                         .Where(ShouldSurfaceRunReviewWorkItems)
+                         .OrderByDescending(GetRunReviewTimestamp))
             {
-                return;
-            }
+                var packet = await reviewPacketService
+                    .GetAsync(run.RunId, fundAccountId, context.RequestAborted)
+                    .ConfigureAwait(false);
+                if (packet is null)
+                {
+                    continue;
+                }
 
-            var packet = await reviewPacketService
-                .GetAsync(latestRun.RunId, fundAccountId, context.RequestAborted)
-                .ConfigureAwait(false);
-            if (packet is null)
-            {
-                return;
+                workItems.AddRange(packet.WorkItems
+                    .Where(static item => item.Tone is OperatorWorkItemToneDto.Warning or OperatorWorkItemToneDto.Critical)
+                    .Select(AttachOperatorNavigation));
             }
-
-            workItems.AddRange(packet.WorkItems
-                .Where(static item => item.Tone is OperatorWorkItemToneDto.Warning or OperatorWorkItemToneDto.Critical)
-                .Select(AttachOperatorNavigation));
         }
         catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
         {

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -1018,7 +1018,7 @@ public sealed class WorkstationEndpointsTests
     }
 
     [Fact]
-    public async Task MapWorkstationEndpoints_OperatorInbox_ShouldExcludeOlderRunReviewPacketBlockersWhenLatestRunIsClean()
+    public async Task MapWorkstationEndpoints_OperatorInbox_ShouldIncludeOlderRunReviewPacketBlockersWhenLatestRunIsClean()
     {
         await using var app = await CreateAppAsync(services =>
         {
@@ -1048,12 +1048,12 @@ public sealed class WorkstationEndpointsTests
                 ServerJsonOptions);
 
         inbox.Should().NotBeNull();
-        inbox!.Items.Should().NotContain(item =>
+        inbox!.Items.Should().Contain(item =>
             item.WorkItemId == $"promotion-review-{olderRunId.ToLowerInvariant()}");
     }
 
     [Fact]
-    public async Task MapWorkstationEndpoints_OperatorInbox_ShouldIncludeLatestRunReviewPacketBlockers()
+    public async Task MapWorkstationEndpoints_OperatorInbox_ShouldIncludeReviewPacketBlockersFromRecentRuns()
     {
         await using var app = await CreateAppAsync(services =>
         {
@@ -1085,15 +1085,23 @@ public sealed class WorkstationEndpointsTests
         inbox.Should().NotBeNull();
         inbox!.Items.Should().Contain(item => item.WorkItemId == "paper-session-missing");
 
-        var reviewItem = inbox.Items.Should().ContainSingle(item =>
+        var newestReviewItem = inbox.Items.Should().ContainSingle(item =>
             item.WorkItemId == $"promotion-review-{newestRunId.ToLowerInvariant()}" &&
             item.Kind == OperatorWorkItemKindDto.PromotionReview).Which;
+        var olderReviewItem = inbox.Items.Should().ContainSingle(item =>
+            item.WorkItemId == $"promotion-review-{olderRunId.ToLowerInvariant()}" &&
+            item.Kind == OperatorWorkItemKindDto.PromotionReview).Which;
 
-        reviewItem.Tone.Should().Be(OperatorWorkItemToneDto.Warning);
-        reviewItem.Workspace.Should().Be("Trading");
-        reviewItem.RunId.Should().Be(newestRunId);
-        reviewItem.TargetRoute.Should().Be(UiApiRoutes.RunsReviewPacket.Replace("{runId}", newestRunId, StringComparison.Ordinal));
-        reviewItem.TargetPageTag.Should().Be("TradingShell");
+        newestReviewItem.Tone.Should().Be(OperatorWorkItemToneDto.Warning);
+        newestReviewItem.Workspace.Should().Be("Trading");
+        newestReviewItem.RunId.Should().Be(newestRunId);
+        newestReviewItem.TargetRoute.Should().Be(UiApiRoutes.RunsReviewPacket.Replace("{runId}", newestRunId, StringComparison.Ordinal));
+        newestReviewItem.TargetPageTag.Should().Be("TradingShell");
+        olderReviewItem.Tone.Should().Be(OperatorWorkItemToneDto.Warning);
+        olderReviewItem.Workspace.Should().Be("Trading");
+        olderReviewItem.RunId.Should().Be(olderRunId);
+        olderReviewItem.TargetRoute.Should().Be(UiApiRoutes.RunsReviewPacket.Replace("{runId}", olderRunId, StringComparison.Ordinal));
+        olderReviewItem.TargetPageTag.Should().Be("TradingShell");
         inbox.Items.Should().OnlyContain(item =>
             !item.WorkItemId.StartsWith("promotion-review-", StringComparison.OrdinalIgnoreCase) ||
             item.Tone == OperatorWorkItemToneDto.Warning ||


### PR DESCRIPTION
### Motivation
- A recent change limited run-review packet work items to a single global latest run, which allowed unresolved warning/critical blockers on older recent runs to be omitted from the operator inbox. 
- The intent of this PR is to restore the previous behavior so operator inbox counts and readiness blockers reflect all relevant recent runs, not only the newest by timestamp.

### Description
- Updated `AddRunReviewPacketWorkItemsAsync` in `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` to iterate over all recent runs that satisfy `ShouldSurfaceRunReviewWorkItems` and load each run's review packet instead of selecting a single latest run. 
- For each run, the code now continues on `null` packets and still only adds packet items whose `Tone` is `Warning` or `Critical`, attaching navigation metadata via `AttachOperatorNavigation`. 
- Adjusted tests in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` to assert older unresolved run-review blockers are surfaced and to verify both older and newer recent runs contribute review-packet blockers, and renamed the tests to reflect the restored behavior.

### Testing
- Updated unit tests: modified `MapWorkstationEndpoints_OperatorInbox_*` tests in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` to validate older and recent run review items are included (tests were changed but not executed here). 
- Attempted to run the focused tests via `dotnet test ...` but execution failed due to missing .NET SDK in the environment (`dotnet: command not found`). 
- Change is minimal and limited to run-selection and testing logic; local code inspection validates the fix restores the previous multi-run aggregation behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a24188548320854a7ded63207a0e)