### PR TITLE
Fix desktop workflow bundle metadata for no-capture steps

### DIFF
--- a/scripts/dev/run-desktop-workflow.ps1
+++ b/scripts/dev/run-desktop-workflow.ps1
@@ -1287,6 +1287,7 @@ try {
             keys = $keys
             launchArgs = $launchArgs
             capturePath = $capturePath
+            bundleCapturePath = $null
             status = 'pending'
             startedAt = (Get-Date).ToString('o')
         }


### PR DESCRIPTION
### Motivation
- `run-desktop-workflow.ps1` runs under `Set-StrictMode -Version Latest` and unconditionally reads `lastSuccessfulStep.bundleCapturePath`, but that property was only set when a step performed a screenshot capture, causing successful steps with `"capture": false` to throw during bookkeeping.

### Description
- Initialize `bundleCapturePath` to `$null` in the per-step result object in `scripts/dev/run-desktop-workflow.ps1` so the property always exists and strict-mode property access cannot terminate the script.

### Testing
- Verified the change by inspecting the modified region and diffs with `nl | sed -n '1278,1295p'` and `git diff`, and committed the patch with `git commit` (all commands succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ab0eb8788320945a69ec0b3f505c)