### PR TITLE
Fix QuantScript toolbar context parameter collisions

### DIFF
--- a/src/Meridian.QuantScript/Compilation/QuantScriptGlobals.cs
+++ b/src/Meridian.QuantScript/Compilation/QuantScriptGlobals.cs
@@ -18,10 +18,10 @@ public sealed record ConsoleOutputEntry(
 /// </summary>
 public sealed class QuantScriptGlobals
 {
-    private const string ContextSymbolKey = "symbol";
-    private const string ContextFromKey = "from";
-    private const string ContextToKey = "to";
-    private const string ContextIntervalKey = "interval";
+    private const string ContextSymbolKey = "context.symbol";
+    private const string ContextFromKey = "context.from";
+    private const string ContextToKey = "context.to";
+    private const string ContextIntervalKey = "context.interval";
     private readonly List<ConsoleOutputEntry> _output = [];
     private readonly object _outputLock = new();
     private readonly object _parameterRegistrationLock = new();
@@ -257,8 +257,6 @@ public sealed class QuantScriptGlobals
 
     private object? GetContextValue(string key)
     {
-        if (_parameters.TryGetValue(key, out var value))
-            return value;
-        return _parameters.TryGetValue($"context.{key}", out value) ? value : null;
+        return _parameters.TryGetValue(key, out var value) ? value : null;
     }
 }

--- a/src/Meridian.Wpf/ViewModels/QuantScriptViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/QuantScriptViewModel.cs
@@ -1067,11 +1067,11 @@ public sealed class QuantScriptViewModel : BindableBase, IDisposable
             StringComparer.OrdinalIgnoreCase);
 
         if (!string.IsNullOrWhiteSpace(AssetSymbol))
-            parameters["symbol"] = AssetSymbol.Trim().ToUpperInvariant();
+            parameters["context.symbol"] = AssetSymbol.Trim().ToUpperInvariant();
 
-        parameters["from"] = DateOnly.FromDateTime(FromDate);
-        parameters["to"] = DateOnly.FromDateTime(ToDate);
-        parameters["interval"] = NormalizeInterval(SelectedInterval);
+        parameters["context.from"] = DateOnly.FromDateTime(FromDate);
+        parameters["context.to"] = DateOnly.FromDateTime(ToDate);
+        parameters["context.interval"] = NormalizeInterval(SelectedInterval);
         return parameters;
     }
 

--- a/tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs
+++ b/tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs
@@ -301,10 +301,10 @@ public sealed class ScriptRunnerTests
             """;
         var parameters = new Dictionary<string, object?>
         {
-            ["symbol"] = "SPY",
-            ["from"] = new DateOnly(2024, 1, 2),
-            ["to"] = new DateOnly(2024, 2, 3),
-            ["interval"] = "daily"
+            ["context.symbol"] = "SPY",
+            ["context.from"] = new DateOnly(2024, 1, 2),
+            ["context.to"] = new DateOnly(2024, 2, 3),
+            ["context.interval"] = "daily"
         };
 
         var result = await runner.RunAsync(source, parameters);

--- a/tests/Meridian.Wpf.Tests/ViewModels/QuantScriptViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/QuantScriptViewModelTests.cs
@@ -330,10 +330,10 @@ public sealed class QuantScriptViewModelTests
 
         runner.CallCount.Should().Be(1);
         runner.LastParameters.Should().NotBeNull();
-        runner.LastParameters!["symbol"].Should().Be("SPY");
-        runner.LastParameters["from"].Should().Be(new DateOnly(2024, 1, 2));
-        runner.LastParameters["to"].Should().Be(new DateOnly(2024, 2, 3));
-        runner.LastParameters["interval"].Should().Be("daily");
+        runner.LastParameters!["context.symbol"].Should().Be("SPY");
+        runner.LastParameters["context.from"].Should().Be(new DateOnly(2024, 1, 2));
+        runner.LastParameters["context.to"].Should().Be(new DateOnly(2024, 2, 3));
+        runner.LastParameters["context.interval"].Should().Be("daily");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- The toolbar was injecting context values using unqualified keys (`symbol`, `from`, `to`, `interval`) into a case-insensitive parameter dictionary and could overwrite user-defined script parameters.
- Context helpers also looked up the unqualified keys before `context.*` aliases, reinforcing the collision and causing unexpected script behavior.

### Description
- Write toolbar context only to namespaced keys (`context.symbol`, `context.from`, `context.to`, `context.interval`) in `QuantScriptViewModel.BuildParameterDictionary` to avoid clobbering user parameters.
- Rename `QuantScriptGlobals` context constants to the namespaced keys and remove the generic-key fallback lookup in `GetContextValue` so helpers read the explicit `context.*` entries.
- Update unit tests in `tests/Meridian.Wpf.Tests` and `tests/Meridian.QuantScript.Tests` to assert and supply the namespaced `context.*` keys.
- Changes touch `src/Meridian.Wpf/ViewModels/QuantScriptViewModel.cs`, `src/Meridian.QuantScript/Compilation/QuantScriptGlobals.cs`, and the two test files mentioned above.

### Testing
- Attempted a targeted test run with `dotnet test tests/Meridian.QuantScript.Tests/Meridian.QuantScript.Tests.csproj --filter "FullyQualifiedName~RunAsync_ContextHelpers_ReadToolbarContext" --logger "console;verbosity=minimal"`, but `dotnet` is not installed in this environment so the test could not be executed (`/bin/bash: dotnet: command not found`).
- No automated tests were run successfully here due to the missing `dotnet` toolchain, but existing tests were updated to reflect the new namespaced behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b11990c88320bf6d93ba7197104e)