### PR TITLE
Fix open reconciliation break metadata projection

### DIFF
--- a/src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs
+++ b/src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs
@@ -663,11 +663,14 @@ public sealed class InMemoryFundAccountService : IFundAccountService, IAccountMa
             }
 
             var breaks = stored.ReconciliationResults
-                .Where(r => !r.IsMatch && string.Equals(r.Category, "Position", StringComparison.OrdinalIgnoreCase))
+                .Where(r => !r.IsMatch
+                    && (string.Equals(r.Category, "Position", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(r.Category, "Positions", StringComparison.OrdinalIgnoreCase)))
                 .Select(r => new PositionReconciliationBreakDto(
                     r.ResultId,
                     accountId,
-                    DateOnly.FromDateTime(DateTime.UtcNow),
+                    stored.ReconciliationRuns.FirstOrDefault(run => run.ReconciliationRunId == r.ReconciliationRunId)?.AsOfDate
+                        ?? DateOnly.FromDateTime(DateTime.UtcNow),
                     r.CheckLabel,
                     r.ExpectedAmount ?? 0m,
                     r.ActualAmount ?? 0m,
@@ -694,8 +697,9 @@ public sealed class InMemoryFundAccountService : IFundAccountService, IAccountMa
                 .Select(r => new CashReconciliationBreakDto(
                     r.ResultId,
                     accountId,
-                    DateOnly.FromDateTime(DateTime.UtcNow),
-                    "USD",
+                    stored.ReconciliationRuns.FirstOrDefault(run => run.ReconciliationRunId == r.ReconciliationRunId)?.AsOfDate
+                        ?? DateOnly.FromDateTime(DateTime.UtcNow),
+                    stored.Summary.BaseCurrency,
                     r.ExpectedAmount ?? 0m,
                     r.ActualAmount ?? 0m,
                     r.Variance ?? 0m,


### PR DESCRIPTION
### Motivation
- The open-break accessors were producing incorrect metadata by stamping every break with `DateTime.UtcNow` instead of the originating reconciliation run `AsOfDate`, which corrupts historical reporting.
- Cash breaks were hardcoded to currency `"USD"` instead of using the account/snapshot base currency, producing misleading currency values for non-USD accounts.
- Position breaks could be omitted because the new accessor filtered for category `"Position"` while reconciliation results are generated with the plural category `"Positions"`.

### Description
- Relaxed the position-category filter to accept both `"Position"` and `"Positions"` so existing reconciliation results are not skipped in `GetOpenPositionBreaksAsync`.
- Map break `AsOfDate` from the owning `AccountReconciliationRunDto.AsOfDate` by looking up the run via `ReconciliationRunId`, with a fallback to `DateOnly.FromDateTime(DateTime.UtcNow)` if the run cannot be found.
- Replace the hardcoded cash currency with the account base currency (`stored.Summary.BaseCurrency`) when constructing `CashReconciliationBreakDto` in `GetOpenCashBreaksAsync`.
- Changes applied in `src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs` and limited to the open-break projection logic to preserve surrounding behavior.

### Testing
- Attempted to run the focused unit tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~FundAccountServiceTests" --logger "console;verbosity=minimal"`, but `dotnet` is not available in this environment so the tests could not be executed here (failure: `dotnet: command not found`).
- Static inspection and targeted source review validated that the change remediates the three identified issues (category mismatch, synthesized date, hardcoded currency).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ab0f09c483208bc1c1d4a292b013)