### PR TITLE
Handle missing screenshot contract files gracefully

### DIFF
--- a/scripts/dev/validate-screenshot-contract.py
+++ b/scripts/dev/validate-screenshot-contract.py
@@ -34,6 +34,20 @@ def fail(errors: list[str]) -> int:
 def validate() -> int:
     errors: list[str] = []
 
+    if not CONTRACT_PATH.exists():
+        print(
+            "Screenshot contract validation skipped: "
+            f"catalog not found at {CONTRACT_PATH.relative_to(REPO_ROOT)}."
+        )
+        return 0
+
+    if not README_PATH.exists():
+        print(
+            "Screenshot contract validation skipped: "
+            f"README not found at {README_PATH.relative_to(REPO_ROOT)}."
+        )
+        return 0
+
     contract = load_json(CONTRACT_PATH)
     screenshots = contract.get("screenshots", [])
     desktop_dir = REPO_ROOT / contract["desktopDirectory"]


### PR DESCRIPTION
### Motivation
- The screenshot catalog and README were removed, but `scripts/dev/validate-screenshot-contract.py` still attempted to read `docs/screenshots/desktop/catalog.json` and `docs/screenshots/README.md`, causing an unhandled `FileNotFoundError` that broke the screenshot refresh CI/developer workflow.

### Description
- Added early existence checks in `validate()` to detect missing `CONTRACT_PATH` and `README_PATH` and print a clear "validation skipped" message when either file is absent.
- The validator now returns success (exit code 0) when the catalog or README is missing, preserving normal validation behavior when the files are present.

### Testing
- Ran `python scripts/dev/validate-screenshot-contract.py` and observed it exit `0` with the message `Screenshot contract validation skipped: catalog not found at docs/screenshots/desktop/catalog.json.` which verifies the graceful skip behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ab0e985c832091adf5dbabb943c2)