### PR TITLE
Harden EDGAR ingest endpoint against abuse

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/EdgarReferenceDataEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/EdgarReferenceDataEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Meridian.Application.SecurityMaster;
 using Meridian.Contracts.Api;
+using Meridian.Contracts.Auth;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Storage.SecurityMaster;
 using Microsoft.AspNetCore.Builder;
@@ -14,21 +15,36 @@ namespace Meridian.Ui.Shared.Endpoints;
 /// </summary>
 public static class EdgarReferenceDataEndpoints
 {
+    private const int MaxEdgarIngestFilers = 250;
+
     public static void MapEdgarReferenceDataEndpoints(this WebApplication app, JsonSerializerOptions jsonOptions)
     {
         var group = app.MapGroup(string.Empty).WithTags("EDGAR");
 
         group.MapPost(UiApiRoutes.SecurityMasterEdgarIngest, async (
+            HttpContext httpContext,
             EdgarIngestRequest request,
             [FromServices] IEdgarIngestOrchestrator orchestrator,
             CancellationToken ct) =>
         {
-            var result = await orchestrator.IngestAsync(request, ct).ConfigureAwait(false);
+            if (!HasPermission(httpContext, UserPermission.ModifySecurityMaster))
+                return Results.Forbid();
+
+            var normalizedRequest = request with
+            {
+                MaxFilers = request.MaxFilers is > 0 and <= MaxEdgarIngestFilers
+                    ? request.MaxFilers
+                    : MaxEdgarIngestFilers
+            };
+
+            var result = await orchestrator.IngestAsync(normalizedRequest, ct).ConfigureAwait(false);
             return Results.Json(result, jsonOptions);
         })
         .WithName("IngestEdgarSecurityMaster")
         .Accepts<EdgarIngestRequest>("application/json")
-        .Produces<EdgarIngestResult>(StatusCodes.Status200OK);
+        .Produces<EdgarIngestResult>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status403Forbidden)
+        .RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy);
 
         group.MapGet(UiApiRoutes.ReferenceDataEdgarFiler, async (
             string cik,
@@ -71,5 +87,13 @@ public static class EdgarReferenceDataEndpoints
         .WithName("GetEdgarSecurityData")
         .Produces<EdgarSecurityDataRecord>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status404NotFound);
+    }
+
+    private static bool HasPermission(HttpContext context, UserPermission permission)
+    {
+        if (context.Items.TryGetValue(LoginSessionMiddleware.CurrentUserPermissionsKey, out var value) && value is UserPermission current)
+            return (current & permission) == permission;
+
+        return false;
     }
 }

--- a/tests/Meridian.Tests/Ui/EdgarReferenceDataEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/EdgarReferenceDataEndpointsTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using FluentAssertions;
 using Meridian.Application.SecurityMaster;
 using Meridian.Contracts.Api;
+using Meridian.Contracts.Auth;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Storage.SecurityMaster;
 using Meridian.Ui.Shared.Endpoints;
@@ -20,7 +21,7 @@ public sealed class EdgarReferenceDataEndpointsTests
     public async Task MapEdgarReferenceDataEndpoints_PostIngest_ReturnsResult()
     {
         var orchestrator = new FakeEdgarIngestOrchestrator();
-        await using var app = await CreateAppAsync(orchestrator, new FakeEdgarReferenceDataStore());
+        await using var app = await CreateAppAsync(orchestrator, new FakeEdgarReferenceDataStore(), UserPermission.ModifySecurityMaster);
         var client = app.GetTestClient();
 
         using var response = await client.PostAsJsonAsync(
@@ -31,12 +32,44 @@ public sealed class EdgarReferenceDataEndpointsTests
         orchestrator.LastRequest.Should().NotBeNull();
         orchestrator.LastRequest!.IncludeXbrl.Should().BeTrue();
         orchestrator.LastRequest.Cik.Should().Be("789019");
+        orchestrator.LastRequest.MaxFilers.Should().Be(1);
 
         var result = await response.Content.ReadFromJsonAsync<EdgarIngestResult>(
             new JsonSerializerOptions(JsonSerializerDefaults.Web));
         result!.DryRun.Should().BeTrue();
     }
 
+
+    [Fact]
+    public async Task MapEdgarReferenceDataEndpoints_PostIngest_RequiresModifySecurityMasterPermission()
+    {
+        var orchestrator = new FakeEdgarIngestOrchestrator();
+        await using var app = await CreateAppAsync(orchestrator, new FakeEdgarReferenceDataStore(), UserPermission.ViewSecurityMaster);
+        var client = app.GetTestClient();
+
+        using var response = await client.PostAsJsonAsync(
+            UiApiRoutes.SecurityMasterEdgarIngest,
+            new EdgarIngestRequest(MaxFilers: 1));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        orchestrator.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MapEdgarReferenceDataEndpoints_PostIngest_AppliesServerSideMaxFilersCap()
+    {
+        var orchestrator = new FakeEdgarIngestOrchestrator();
+        await using var app = await CreateAppAsync(orchestrator, new FakeEdgarReferenceDataStore(), UserPermission.ModifySecurityMaster);
+        var client = app.GetTestClient();
+
+        using var response = await client.PostAsJsonAsync(
+            UiApiRoutes.SecurityMasterEdgarIngest,
+            new EdgarIngestRequest(MaxFilers: null));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        orchestrator.LastRequest.Should().NotBeNull();
+        orchestrator.LastRequest!.MaxFilers.Should().Be(250);
+    }
     [Fact]
     public async Task MapEdgarReferenceDataEndpoints_GetFiler_ReturnsLocalPartition()
     {
@@ -137,7 +170,8 @@ public sealed class EdgarReferenceDataEndpointsTests
 
     private static async Task<WebApplication> CreateAppAsync(
         IEdgarIngestOrchestrator orchestrator,
-        IEdgarReferenceDataStore store)
+        IEdgarReferenceDataStore store,
+        UserPermission permissions = UserPermission.ModifySecurityMaster)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
@@ -148,6 +182,11 @@ public sealed class EdgarReferenceDataEndpointsTests
         builder.Services.AddSingleton(store);
 
         var app = builder.Build();
+        app.Use((context, next) =>
+        {
+            context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] = permissions;
+            return next();
+        });
         app.MapEdgarReferenceDataEndpoints(new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase


### PR DESCRIPTION
### Motivation
- The EDGAR ingest POST exposed a high-impact mutation and unbounded bulk-download surface that any authenticated (low-privilege) caller could trigger, enabling resource exhaustion and unauthorized Security Master writes. 
- The intent is to limit attack surface by enforcing caller permissions, applying rate limiting, and bounding server-side work to a safe default. 

### Description
- Require the `ModifySecurityMaster` permission before invoking the ingest orchestrator by checking `LoginSessionMiddleware.CurrentUserPermissionsKey` and returning `403` when missing. 
- Apply endpoint-level mutation rate limiting using the existing `UiEndpoints.MutationRateLimitPolicy` on the `POST /api/security-master/ingest/edgar` route. 
- Enforce a server-side `MaxEdgarIngestFilers` clamp (default/cap `250`) and normalize the incoming `MaxFilers` before calling `IEdgarIngestOrchestrator.IngestAsync` to prevent unbounded all-filer operations. 
- Add focused unit tests to verify successful ingest with permission, `403 Forbidden` when the caller lacks `ModifySecurityMaster`, and that the server-side filers cap is applied when `MaxFilers` is omitted. 

### Testing
- Added/updated unit tests in `tests/Meridian.Tests/Ui/EdgarReferenceDataEndpointsTests.cs` that exercise permission enforcement, cap application, and successful invocation. 
- Performed static verification and local endpoint test harness changes (injected `UserPermission` into `HttpContext.Items`) to exercise the new checks. 
- Attempted to run the focused test command `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~EdgarReferenceDataEndpointsTests"`, but the execution environment lacks the .NET SDK (`dotnet: command not found`), so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a8e74504832083d0372627ea1571)