### PR TITLE
Harden fund-account brokerage sync access checks

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/FundAccountEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/FundAccountEndpoints.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Meridian.Application.Accounts;
 using Meridian.Application.FundAccounts;
 using Meridian.Application.FundStructure;
+using Meridian.Contracts.Auth;
 using Meridian.Contracts.FundStructure;
 using Meridian.Contracts.Workstation;
 using Meridian.Ui.Shared.Services;
@@ -183,6 +184,9 @@ public static class FundAccountEndpoints
 
         group.MapGet("/brokerage-sync/accounts", async (HttpContext context) =>
         {
+            if (!HasBrokerageSyncAccess(context))
+                return Results.Forbid();
+
             var sync = ResolveBrokerageSyncService(context);
             if (sync is null)
                 return BrokerageSyncUnavailable();
@@ -196,6 +200,9 @@ public static class FundAccountEndpoints
 
         group.MapGet("/{accountId:guid}/brokerage-sync/status", async (Guid accountId, HttpContext context) =>
         {
+            if (!await CanAccessFundAccountBrokerageSyncAsync(accountId, context).ConfigureAwait(false))
+                return Results.Forbid();
+
             var sync = ResolveBrokerageSyncService(context);
             if (sync is null)
                 return BrokerageSyncUnavailable();
@@ -209,6 +216,9 @@ public static class FundAccountEndpoints
 
         group.MapPost("/{accountId:guid}/brokerage-sync/run", async (Guid accountId, HttpContext context) =>
         {
+            if (!await CanAccessFundAccountBrokerageSyncAsync(accountId, context, requireWriteAccess: true).ConfigureAwait(false))
+                return Results.Forbid();
+
             var sync = ResolveBrokerageSyncService(context);
             if (sync is null)
                 return BrokerageSyncUnavailable();
@@ -226,6 +236,9 @@ public static class FundAccountEndpoints
 #pragma warning disable CS0618 // Compatibility routes retain legacy brokerage projection payloads; readiness uses status DTOs.
         group.MapGet("/{accountId:guid}/brokerage-sync/positions", async (Guid accountId, HttpContext context) =>
         {
+            if (!await CanAccessFundAccountBrokerageSyncAsync(accountId, context).ConfigureAwait(false))
+                return Results.Forbid();
+
             var sync = ResolveBrokerageSyncService(context);
             if (sync is null)
                 return BrokerageSyncUnavailable();
@@ -239,6 +252,9 @@ public static class FundAccountEndpoints
 
         group.MapGet("/{accountId:guid}/brokerage-sync/activity", async (Guid accountId, HttpContext context) =>
         {
+            if (!await CanAccessFundAccountBrokerageSyncAsync(accountId, context).ConfigureAwait(false))
+                return Results.Forbid();
+
             var sync = ResolveBrokerageSyncService(context);
             if (sync is null)
                 return BrokerageSyncUnavailable();
@@ -465,6 +481,50 @@ public static class FundAccountEndpoints
 
     private static IResult BrokerageSyncUnavailable() =>
         Results.Problem("Brokerage sync service is not registered.", statusCode: StatusCodes.Status501NotImplemented);
+
+    private static bool HasBrokerageSyncAccess(HttpContext context)
+        => TryGetCurrentPermissions(context, out var permissions)
+           && permissions.HasFlag(UserPermission.ViewTrades);
+
+    private static async Task<bool> CanAccessFundAccountBrokerageSyncAsync(
+        Guid accountId,
+        HttpContext context,
+        bool requireWriteAccess = false)
+    {
+        if (!TryGetCurrentPermissions(context, out var permissions)
+            || !permissions.HasFlag(UserPermission.ViewTrades))
+        {
+            return false;
+        }
+
+        if (requireWriteAccess
+            && !permissions.HasFlag(UserPermission.ExecuteTrades)
+            && !permissions.HasFlag(UserPermission.ManageOrders))
+        {
+            return false;
+        }
+
+        var queryService = ResolveQueryService(context);
+        if (queryService is null)
+        {
+            return false;
+        }
+
+        var account = await queryService.GetAccountAsync(accountId, context.RequestAborted).ConfigureAwait(false);
+        return account is not null;
+    }
+
+    private static bool TryGetCurrentPermissions(HttpContext context, out UserPermission permissions)
+    {
+        permissions = UserPermission.None;
+        if (context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] is UserPermission currentPermissions)
+        {
+            permissions = currentPermissions;
+            return true;
+        }
+
+        return false;
+    }
 
     private static async Task<WorkstationBrokerageSyncRunRequestDto?> ReadBrokerageSyncRequestAsync(
         HttpContext context,

--- a/src/Meridian.Ui.Shared/Services/BrokeragePortfolioSyncService.cs
+++ b/src/Meridian.Ui.Shared/Services/BrokeragePortfolioSyncService.cs
@@ -518,13 +518,18 @@ public sealed class BrokeragePortfolioSyncService
         CancellationToken ct)
     {
         var account = await ResolveFundAccountAsync(fundAccountId, ct).ConfigureAwait(false);
-        var providerId = NormalizeProviderId(request?.ProviderId)
-            ?? NormalizeProviderId(account?.Institution)
+        if (account is null)
+        {
+            return null;
+        }
+
+        var providerId = NormalizeProviderId(account.Institution)
+            ?? NormalizeProviderId(request?.ProviderId)
             ?? _options.DefaultProviderId;
-        var externalAccountId = NormalizeExternalAccountId(request?.ExternalAccountId)
-            ?? NormalizeExternalAccountId(account?.CustodianDetails?.SubAccountNumber)
-            ?? NormalizeExternalAccountId(account?.PortfolioId)
-            ?? NormalizeExternalAccountId(account?.AccountCode);
+        var externalAccountId = NormalizeExternalAccountId(account.CustodianDetails?.SubAccountNumber)
+            ?? NormalizeExternalAccountId(account.PortfolioId)
+            ?? NormalizeExternalAccountId(account.AccountCode)
+            ?? NormalizeExternalAccountId(request?.ExternalAccountId);
 
         if (string.IsNullOrWhiteSpace(providerId) || string.IsNullOrWhiteSpace(externalAccountId))
         {
@@ -535,7 +540,7 @@ public sealed class BrokeragePortfolioSyncService
             FundAccountId: fundAccountId,
             ProviderId: providerId,
             ExternalAccountId: externalAccountId,
-            DisplayName: account?.DisplayName ?? $"{providerId}:{externalAccountId}",
+            DisplayName: account.DisplayName ?? $"{providerId}:{externalAccountId}",
             LinkedAt: DateTimeOffset.UtcNow,
             LinkedBy: request?.RequestedBy);
     }


### PR DESCRIPTION
### Motivation

- Remediate a high-severity vulnerability where brokerage sync endpoints could be invoked by low-privilege users to trigger provider reads (Alpaca) and expose sensitive brokerage balances, positions, orders, fills, and raw snapshot paths for arbitrary fund-account GUIDs.

### Description

- Added endpoint-level permission gates to the fund-account brokerage sync routes so account-scoped reads require `ViewTrades` and sync execution requires `ViewTrades` plus a write-capable trading permission (`ExecuteTrades` or `ManageOrders`).
- Implemented `TryGetCurrentPermissions`, `HasBrokerageSyncAccess`, and `CanAccessFundAccountBrokerageSyncAsync` helpers in `FundAccountEndpoints` to centralize session-permission checks and validate that the requested fund account exists before calling the sync service.
- Hardened `BrokeragePortfolioSyncService.ResolveLinkAsync` to return `null` when the fund account cannot be resolved and to prefer fund-account-derived `ProviderId`/`ExternalAccountId` values over caller-supplied fields to prevent arbitrary GUID linkage and request-driven tampering.
- Files changed: `src/Meridian.Ui.Shared/Endpoints/FundAccountEndpoints.cs` and `src/Meridian.Ui.Shared/Services/BrokeragePortfolioSyncService.cs`.

### Testing

- Attempted to run the targeted unit tests: `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~BrokeragePortfolioSyncServiceTests" --logger "console;verbosity=minimal"`, but the `dotnet` SDK/runtime is not available in this environment so the test run could not be executed (`dotnet: command not found`).
- All changes are minimal, scope-limited, and designed to fail-safe (deny access) when session/permission information or account lookups are missing. Please run the full test suite in CI or a local environment with the .NET SDK to validate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a9b247b8832085d1466c64b1c4c5)