### PR TITLE
Harden execution manual-override endpoints with RBAC checks

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Meridian.Contracts.Api;
+using Meridian.Contracts.Auth;
 using Meridian.Execution.Interfaces;
 using Meridian.Execution.Models;
 using Meridian.Execution.Sdk;
@@ -293,6 +294,11 @@ public static class ExecutionEndpoints
 
         group.MapPost("/controls/manual-overrides", async (CreateExecutionManualOverrideRequest request, HttpContext context) =>
         {
+            if (!HasExecutionControlMutationPermission(context))
+            {
+                return Results.Forbid();
+            }
+
             var controls = context.RequestServices.GetService<ExecutionOperatorControlService>();
             if (controls is null)
             {
@@ -321,11 +327,17 @@ public static class ExecutionEndpoints
         })
         .WithName("CreateExecutionManualOverride")
         .Produces<ExecutionManualOverride>(201)
+        .Produces(403)
         .Produces(400)
         .Produces(503);
 
         group.MapPost("/controls/manual-overrides/{overrideId}/clear", async (string overrideId, ClearExecutionManualOverrideRequest request, HttpContext context) =>
         {
+            if (!HasExecutionControlMutationPermission(context))
+            {
+                return Results.Forbid();
+            }
+
             var controls = context.RequestServices.GetService<ExecutionOperatorControlService>();
             if (controls is null)
             {
@@ -354,6 +366,7 @@ public static class ExecutionEndpoints
         })
         .WithName("ClearExecutionManualOverride")
         .Produces<TradingActionResult>(200)
+        .Produces(403)
         .Produces(404)
         .Produces(503);
 
@@ -994,6 +1007,23 @@ public static class ExecutionEndpoints
         }
 
         return "operator";
+    }
+
+    private static bool HasExecutionControlMutationPermission(HttpContext context)
+    {
+        const UserPermission requiredPermission = UserPermission.ManageOrders;
+
+        if (context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] is UserPermission permissionsFromContext)
+        {
+            return (permissionsFromContext & requiredPermission) == requiredPermission;
+        }
+
+        if (context.Items[LoginSessionMiddleware.CurrentUserRoleKey] is UserRole roleFromContext)
+        {
+            return RolePermissions.HasPermission(roleFromContext, requiredPermission);
+        }
+
+        return false;
     }
 
     private static Dictionary<string, string> MergeMetadata(


### PR DESCRIPTION
### Motivation
- Prevent low-privilege authenticated users from creating or clearing high-impact execution manual overrides (e.g. `BypassOrderControls`, `AllowLivePromotion`, `ForceBlockOrders`) via the UI API, which could otherwise bypass circuit-breakers, position limits, or allow live promotion.

### Description
- Add `Meridian.Contracts.Auth` import and a `HasExecutionControlMutationPermission(HttpContext)` helper that checks `LoginSessionMiddleware.CurrentUserPermissionsKey` or `CurrentUserRoleKey` and requires `UserPermission.ManageOrders`.
- Require the permission guard in the two mutation endpoints `POST /api/execution/controls/manual-overrides` and `POST /api/execution/controls/manual-overrides/{overrideId}/clear` and return HTTP 403 via `Results.Forbid()` when the caller lacks permission.
- Document the new 403 response in the endpoint metadata (`.Produces(403)`).

### Testing
- Attempted to run the focused unit test filter `ExecutionGovernanceEndpointsTests` with `dotnet test`, but the container environment lacks `dotnet`, so the automated test run could not be executed (`dotnet: command not found`).
- Performed static code inspection to verify the new permission checks are present and that endpoints now return 403 when the guard fails.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b24e85988320a420263f30b87482)