### PR TITLE
Restore explicit gateway connection boundary for order operations

### DIFF
--- a/src/Meridian.Execution/OrderManagementSystem.cs
+++ b/src/Meridian.Execution/OrderManagementSystem.cs
@@ -25,7 +25,6 @@ public sealed class OrderManagementSystem : IOrderManager, IDisposable
     private readonly PaperSessionPersistenceService? _sessionPersistence;
     private readonly ILogger<OrderManagementSystem> _logger;
     private readonly Channel<ExecutionReport> _executionChannel;
-    private readonly SemaphoreSlim _gatewayConnectionLock = new(1, 1);
     private readonly ConcurrentDictionary<string, string> _orderSessionIds = new(StringComparer.OrdinalIgnoreCase);
     private int _orderSequence;
 
@@ -217,8 +216,6 @@ public sealed class OrderManagementSystem : IOrderManager, IDisposable
 
         try
         {
-            await EnsureGatewayConnectedAsync(correlationId, actor, runId, request.Symbol, ct).ConfigureAwait(false);
-
             var report = await _gateway.SubmitOrderAsync(request with { ClientOrderId = orderId }, ct)
                 .ConfigureAwait(false);
 
@@ -315,12 +312,6 @@ public sealed class OrderManagementSystem : IOrderManager, IDisposable
             return new OrderResult { Success = false, OrderId = orderId, ErrorMessage = "Order not found" };
         }
 
-        await EnsureGatewayConnectedAsync(
-            correlationId: null,
-            actor: null,
-            runId: null,
-            symbol: state.Symbol,
-            ct: ct).ConfigureAwait(false);
         var report = await _gateway.CancelOrderAsync(orderId, ct).ConfigureAwait(false);
         if (report.OrderStatus is not OrderStatus.Cancelled)
         {
@@ -353,12 +344,6 @@ public sealed class OrderManagementSystem : IOrderManager, IDisposable
             return new OrderResult { Success = false, OrderId = orderId, ErrorMessage = "Order not found" };
         }
 
-        await EnsureGatewayConnectedAsync(
-            correlationId: null,
-            actor: null,
-            runId: null,
-            symbol: state.Symbol,
-            ct: ct).ConfigureAwait(false);
         var report = await _gateway.ModifyOrderAsync(orderId, modification, ct).ConfigureAwait(false);
         var updated = ApplyReport(state, report);
         _orders[orderId] = updated;
@@ -413,7 +398,6 @@ public sealed class OrderManagementSystem : IOrderManager, IDisposable
     public void Dispose()
     {
         _executionChannel.Writer.TryComplete();
-        _gatewayConnectionLock.Dispose();
     }
 
     /// <summary>
@@ -428,77 +412,6 @@ public sealed class OrderManagementSystem : IOrderManager, IDisposable
     {
         var seq = Interlocked.Increment(ref _orderSequence);
         return $"MDN-{DateTimeOffset.UtcNow:yyyyMMdd}-{seq:D6}";
-    }
-
-    private async Task EnsureGatewayConnectedAsync(
-        string? correlationId,
-        string? actor,
-        string? runId,
-        string? symbol,
-        CancellationToken ct)
-    {
-        if (_gateway.IsConnected)
-        {
-            return;
-        }
-
-        await _gatewayConnectionLock.WaitAsync(ct).ConfigureAwait(false);
-        try
-        {
-            if (_gateway.IsConnected)
-            {
-                return;
-            }
-
-            _logger.LogInformation(
-                "Connecting execution gateway {GatewayId} on demand before order operation",
-                _gateway.GatewayId);
-
-            try
-            {
-                await _gateway.ConnectAsync(ct).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                if (_auditTrail is not null)
-                {
-                    await _auditTrail.RecordAsync(new ExecutionAuditEntry(
-                        AuditId: Guid.NewGuid().ToString("N"),
-                        Category: "Order",
-                        Action: "GatewayConnectFailed",
-                        Outcome: "Rejected",
-                        OccurredAt: DateTimeOffset.UtcNow,
-                        Actor: actor,
-                        BrokerName: _gateway.GatewayId,
-                        RunId: runId,
-                        Symbol: symbol,
-                        CorrelationId: correlationId,
-                        Message: ex.Message), ct).ConfigureAwait(false);
-                }
-
-                throw;
-            }
-
-            if (_auditTrail is not null)
-            {
-                await _auditTrail.RecordAsync(new ExecutionAuditEntry(
-                    AuditId: Guid.NewGuid().ToString("N"),
-                    Category: "Order",
-                    Action: "GatewayConnected",
-                    Outcome: "Connected",
-                    OccurredAt: DateTimeOffset.UtcNow,
-                    Actor: actor,
-                    BrokerName: _gateway.GatewayId,
-                    RunId: runId,
-                    Symbol: symbol,
-                    CorrelationId: correlationId,
-                    Message: $"Connected {_gateway.GatewayId} on demand before execution."), ct).ConfigureAwait(false);
-            }
-        }
-        finally
-        {
-            _gatewayConnectionLock.Release();
-        }
     }
 
     private static OrderState ApplyReport(OrderState current, ExecutionReport report)

--- a/tests/Meridian.Tests/Execution/OrderManagementSystemTests.cs
+++ b/tests/Meridian.Tests/Execution/OrderManagementSystemTests.cs
@@ -271,7 +271,7 @@ public sealed class OrderManagementSystemTests : IDisposable
     }
 
     [Fact]
-    public async Task PlaceOrderAsync_WhenGatewayStartsDisconnected_ConnectsAndAuditsSelectedGateway()
+    public async Task PlaceOrderAsync_WhenGatewayStartsDisconnected_DoesNotAutoConnect()
     {
         var connected = false;
         var gateway = Substitute.For<IExecutionGateway>();
@@ -284,21 +284,7 @@ public sealed class OrderManagementSystemTests : IDisposable
                 return Task.CompletedTask;
             });
         gateway.SubmitOrderAsync(Arg.Any<OrderRequest>(), Arg.Any<CancellationToken>())
-            .Returns(callInfo =>
-            {
-                var request = callInfo.Arg<OrderRequest>();
-                return new ExecutionReport
-                {
-                    OrderId = request.ClientOrderId ?? "ord-1",
-                    ClientOrderId = request.ClientOrderId,
-                    ReportType = ExecutionReportType.New,
-                    Symbol = request.Symbol,
-                    Side = request.Side,
-                    OrderStatus = OrderStatus.Accepted,
-                    OrderQuantity = request.Quantity,
-                    Timestamp = DateTimeOffset.UtcNow
-                };
-            });
+            .Returns(_ => throw new InvalidOperationException("robinhood is not connected. Call ConnectAsync first."));
 
         var tempRoot = Path.Combine(Path.GetTempPath(), "Meridian.Tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempRoot);
@@ -319,15 +305,13 @@ public sealed class OrderManagementSystemTests : IDisposable
             Quantity = 1m
         });
 
-        result.Success.Should().BeTrue();
-        await gateway.Received(1).ConnectAsync(Arg.Any<CancellationToken>());
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("not connected");
+        await gateway.DidNotReceive().ConnectAsync(Arg.Any<CancellationToken>());
 
         var auditEntries = await auditTrail.GetRecentAsync(10);
         auditEntries.Should().Contain(entry =>
-            entry.Action == "GatewayConnected" &&
-            entry.BrokerName == "robinhood");
-        auditEntries.Should().Contain(entry =>
-            entry.Action == "OrderSubmitted" &&
+            entry.Action == "OrderRejected" &&
             entry.BrokerName == "robinhood" &&
             entry.Symbol == "AAPL");
     }


### PR DESCRIPTION
### Motivation
- The changes revert an introduced on-demand gateway auto-connect path that allowed order/cancel/modify APIs to connect live brokerage gateways implicitly, which undermines the operational safety boundary for live trading.
- The intent is to prevent unauthorised or accidental live activation from ordinary API calls and preserve the explicit, separately governed connect/promotion workflow for live execution.

### Description
- Removed the `EnsureGatewayConnectedAsync` helper and its `_gatewayConnectionLock` usage from `OrderManagementSystem`, eliminating implicit `ConnectAsync` calls during order submit/cancel/modify flows (`src/Meridian.Execution/OrderManagementSystem.cs`).
- Removed pre-order auto-connect calls so `PlaceOrderAsync`, `CancelOrderAsync`, and `ModifyOrderAsync` now call gateway operations directly and will surface the gateway's not-connected error instead of connecting for the caller.
- Updated the focused OMS unit test to assert disconnected gateways are not auto-connected and that submission fails with a not-connected error, and to check that no `ConnectAsync` call was made (`tests/Meridian.Tests/Execution/OrderManagementSystemTests.cs`).

### Testing
- Attempted to run the targeted unit test filter `PlaceOrderAsync_WhenGatewayStartsDisconnected_DoesNotAutoConnect` via `dotnet test`, but the container environment lacks the .NET SDK so the test could not be executed (`/bin/bash: dotnet: command not found`).
- Local static inspection and updated unit assertions were applied and committed; existing CI or a developer machine with .NET should run the full test suite to verify behaviour and regression coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b47ed04c8320ab40cb737b0c584f)