### PR TITLE
Fix workstation static asset path traversal

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -1026,8 +1026,15 @@ public static class WorkstationEndpoints
             // UseStaticFiles() middleware runs after routing in WebApplication, so the
             // catch-all route must serve these files explicitly.
             var root = environment.WebRootPath ?? Path.Combine(environment.ContentRootPath, "wwwroot");
-            var filePath = Path.Combine(root, "workstation", path.Replace('/', Path.DirectorySeparatorChar));
-            if (!File.Exists(filePath))
+            var workstationRoot = Path.GetFullPath(Path.Combine(root, "workstation"));
+            var normalizedPath = path.Replace('/', Path.DirectorySeparatorChar)
+                .Replace('\\', Path.DirectorySeparatorChar);
+            if (Path.IsPathRooted(normalizedPath))
+                return Results.NotFound();
+
+            var filePath = Path.GetFullPath(Path.Combine(workstationRoot, normalizedPath));
+            var rootWithSeparator = workstationRoot.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            if (!filePath.StartsWith(rootWithSeparator, StringComparison.Ordinal) || !File.Exists(filePath))
                 return Results.NotFound();
 
             var ext = Path.GetExtension(filePath).ToLowerInvariant();


### PR DESCRIPTION
### Motivation
- The `/workstation/{*path}` catch-all route previously combined an attacker-controlled path with the webroot and served files without canonicalization or base-directory checks, allowing ../ traversal to arbitrary files with extensions under the content root.
- The change hardens the route to ensure only files under `wwwroot/workstation` can be served, preventing disclosure of configuration, logs, or other sensitive files.

### Description
- Canonicalize the workstation asset root using `Path.GetFullPath(Path.Combine(root, "workstation"))` and compute the requested file via `Path.GetFullPath` against that root to avoid relative-dot escape. 
- Normalize path separators and reject rooted input paths using `Path.IsPathRooted(normalizedPath)`. 
- Enforce that the resolved `filePath` starts with the canonical `workstationRoot` (with a trailing separator) and that the file exists before returning `Results.File`, preserving the original extension/content-type mapping. 
- Preserve existing fallback behavior that serves the SPA index when `path` is empty or lacks an extension.

### Testing
- No automated `.NET` build or test runs were executed because `dotnet` is not installed in the environment, so runtime/build/test validation was not possible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b32c379483208143151aa540cbc1)