### PR TITLE
fix(security): enforce role checks on fund account endpoints

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/FundAccountEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/FundAccountEndpoints.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Meridian.Application.Accounts;
 using Meridian.Application.FundAccounts;
 using Meridian.Application.FundStructure;
+using Meridian.Contracts.Auth;
 using Meridian.Contracts.FundStructure;
 using Meridian.Contracts.Workstation;
 using Meridian.Ui.Shared.Services;
@@ -16,6 +17,7 @@ public static class FundAccountEndpoints
     public static void MapFundAccountEndpoints(this WebApplication app, JsonSerializerOptions jsonOptions)
     {
         var group = app.MapGroup("/api/fund-accounts").WithTags("Fund Accounts");
+        group.AddEndpointFilter(RequireFundAccountAccess);
 
         // ── Account CRUD ─────────────────────────────────────────────────────
 
@@ -458,6 +460,33 @@ public static class FundAccountEndpoints
     private static Guid? TryParseGuidFilter(string? raw)
     {
         return Guid.TryParse(raw, out var parsed) ? parsed : null;
+    }
+
+    private static ValueTask<object?> RequireFundAccountAccess(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        if (!TryGetCurrentRole(context.HttpContext, out var role))
+        {
+            return ValueTask.FromResult<object?>(Results.Unauthorized());
+        }
+
+        if (role is UserRole.Admin or UserRole.Developer or UserRole.Accounting)
+        {
+            return next(context);
+        }
+
+        return ValueTask.FromResult<object?>(Results.Forbid());
+    }
+
+    private static bool TryGetCurrentRole(HttpContext context, out UserRole role)
+    {
+        if (context.Items.TryGetValue(LoginSessionMiddleware.CurrentUserRoleKey, out var item) && item is UserRole currentRole)
+        {
+            role = currentRole;
+            return true;
+        }
+
+        role = default;
+        return false;
     }
 
     private static IResult ServiceUnavailable() =>


### PR DESCRIPTION
### Motivation
- The `/api/fund-accounts` handlers return and mutate sensitive custody and banking identifiers but did not enforce role-based authorization, exposing high-value data to any authenticated session.
- A minimal, centralized guard is needed to prevent low-privilege roles from reading or modifying fund-account details while preserving existing endpoint surface and behavior for authorized operators.

### Description
- Added an import of the auth contract (`Meridian.Contracts.Auth`) and registered a group-level endpoint filter on the fund-account route group with `group.AddEndpointFilter(RequireFundAccountAccess)`.
- Implemented `RequireFundAccountAccess` as a lightweight `EndpointFilter` that returns `401` when no authenticated role is present and `403` when the caller's role is insufficient, and otherwise delegates to the endpoint handler.
- Restricted allowed roles to `Admin`, `Developer`, and `Accounting` (checked via `LoginSessionMiddleware.CurrentUserRoleKey`) by adding helper `TryGetCurrentRole` used by the filter.
- All changes are contained in `src/Meridian.Ui.Shared/Endpoints/FundAccountEndpoints.cs` and do not alter DTOs, storage, or service interfaces.

### Testing
- Attempted to run targeted unit tests: `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~FundAccount" --logger "console;verbosity=minimal"`, but the environment lacks the .NET SDK and the command failed with `dotnet: command not found` so no tests executed.
- Verified compile-local modifications via source edits and committed the change (no runtime test executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7c2c962388320b6d303fe591da9a8)