### PR TITLE
fix(security): remove metadata-driven Alpaca notional sizing bypass

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/Alpaca/AlpacaBrokerageGateway.cs
@@ -29,9 +29,6 @@ namespace Meridian.Infrastructure.Adapters.Alpaca;
 /// - Supports fractional shares
 /// - Supports extended hours trading
 /// - Supports US equities and fixed income (US Treasuries, corporate bonds)
-/// - Fixed income orders may use notional sizing: set Metadata["notional"] = "true" on the OrderRequest
-///   and pass the dollar amount as Quantity. Optionally set Metadata["asset_class"] = "us_treasury"
-///   to route treasury orders explicitly.
 /// - Rate limit: 200 req/min
 /// </remarks>
 [DataSource("alpaca-brokerage", "Alpaca Brokerage", DataSourceType.Realtime, DataSourceCategory.Broker,
@@ -136,24 +133,16 @@ public sealed class AlpacaBrokerageGateway : IBrokerageGateway, IBrokerageAccoun
             "Alpaca submitting order: {Side} {Quantity} {Symbol} @ {Type}",
             request.Side, request.Quantity, request.Symbol, request.Type);
 
-        var isNotional = request.Metadata?.TryGetValue("notional", out var notionalFlag) == true
-            && string.Equals(notionalFlag, "true", StringComparison.OrdinalIgnoreCase);
-
-        string? assetClass = request.Metadata is not null
-            && request.Metadata.TryGetValue("asset_class", out var ac) ? ac : null;
-
         var payload = new AlpacaOrderPayload
         {
             Symbol = request.Symbol,
-            Qty = isNotional ? null : request.Quantity.ToString("G"),
-            Notional = isNotional ? request.Quantity.ToString("G") : null,
+            Qty = request.Quantity.ToString("G"),
             Side = request.Side == OrderSide.Buy ? "buy" : "sell",
             Type = MapOrderType(request.Type),
             TimeInForce = MapTimeInForce(request.TimeInForce),
             LimitPrice = request.LimitPrice?.ToString("G"),
             StopPrice = request.StopPrice?.ToString("G"),
             ClientOrderId = request.ClientOrderId,
-            AssetClass = assetClass,
         };
 
         using var client = CreateHttpClient();

--- a/tests/Meridian.Tests/Infrastructure/Providers/AlpacaBrokerageGatewayTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/AlpacaBrokerageGatewayTests.cs
@@ -230,7 +230,7 @@ public sealed class AlpacaBrokerageGatewayTests
     // ── SubmitOrderAsync: fixed income notional orders ────────────────────
 
     [Fact]
-    public async Task SubmitOrderAsync_NotionalTreasuryBuy_SendsNotionalField()
+    public async Task SubmitOrderAsync_NotionalMetadata_IsIgnoredAndQtyIsUsed()
     {
         string? capturedBody = null;
 
@@ -260,13 +260,14 @@ public sealed class AlpacaBrokerageGatewayTests
         }, cts.Token);
 
         report.ReportType.Should().Be(ExecutionReportType.New);
-        capturedBody.Should().Contain("\"notional\"");
-        capturedBody.Should().NotContain("\"qty\"");
+        capturedBody.Should().Contain("\"qty\"");
+        capturedBody.Should().NotContain("\"notional\"");
+        capturedBody.Should().NotContain("\"asset_class\"");
         await sut.DisposeAsync();
     }
 
     [Fact]
-    public async Task SubmitOrderAsync_NotionalOrder_UsesQuantityAsNotionalAmount()
+    public async Task SubmitOrderAsync_NotionalOrderMetadata_DoesNotSetNotionalField()
     {
         string? capturedBody = null;
 
@@ -293,10 +294,10 @@ public sealed class AlpacaBrokerageGatewayTests
 
         capturedBody.Should().NotBeNull();
         using var doc = JsonDocument.Parse(capturedBody!);
-        doc.RootElement.TryGetProperty("notional", out var notionalProp).Should().BeTrue();
-        notionalProp.GetString().Should().Be("2500");
+        doc.RootElement.TryGetProperty("qty", out var qtyProp).Should().BeTrue();
+        qtyProp.GetString().Should().Be("2500");
 
-        doc.RootElement.TryGetProperty("qty", out _).Should().BeFalse();
+        doc.RootElement.TryGetProperty("notional", out _).Should().BeFalse();
         await sut.DisposeAsync();
     }
 


### PR DESCRIPTION
### Motivation
- A metadata-driven path in the Alpaca gateway let callers flip `OrderRequest.Quantity` from units to dollar `notional` inside the gateway, which diverged from pre-trade position/risk checks that treat `Quantity` as units and thus allowed a governance bypass. 
- The change restores consistent semantics so OMS and risk checks evaluate the same sizing that is submitted to the broker.

### Description
- Remove metadata-driven `notional` handling from `AlpacaBrokerageGateway.SubmitOrderAsync` so the gateway no longer switches between `qty` and `notional` based on caller metadata. 
- Always serialize `request.Quantity` as `qty` when building the Alpaca order payload and stop forwarding metadata-provided `asset_class` for payload shaping. 
- Drop the inline doc comment that instructed callers to set `Metadata["notional"]` and `Metadata["asset_class"]` for notional/fixed-income routing. 
- Update focused unit tests in `tests/Meridian.Tests/Infrastructure/Providers/AlpacaBrokerageGatewayTests.cs` to assert that `notional` and `asset_class` metadata do not alter outbound order payload shape and that `qty` is used.

### Testing
- Updated unit tests cover the changed gateway behavior (tests in `tests/Meridian.Tests/Infrastructure/Providers/AlpacaBrokerageGatewayTests.cs` were modified to assert `qty` is present and `notional`/`asset_class` are not set). 
- Attempted to run a targeted test invocation `dotnet test ... --filter "FullyQualifiedName~AlpacaBrokerageGatewayTests"`, but execution failed in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`), so automated test execution could not be validated here; CI should run the full test suite to verify.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b89f06508320909a72ed78bcc7ac)