### PR TITLE
fix: require ModifySecurityMaster permission for convertible-terms PATCH

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Meridian.Contracts.Api;
+using Meridian.Contracts.Auth;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Storage.SecurityMaster;
 using Microsoft.AspNetCore.Builder;
@@ -311,10 +312,21 @@ public static class SecurityMasterEndpoints
         group.MapPatch(UiApiRoutes.SecurityMasterConvertibleEquityTerms, async (
             Guid securityId,
             AmendConvertibleEquityTermsRequest request,
+            HttpContext context,
             [FromServices] ISecurityMasterQueryService queryService,
             [FromServices] ISecurityMasterService service,
             CancellationToken ct) =>
         {
+            if (context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] is not UserPermission permissions)
+            {
+                return Results.Unauthorized();
+            }
+
+            if ((permissions & UserPermission.ModifySecurityMaster) != UserPermission.ModifySecurityMaster)
+            {
+                return Results.Forbid();
+            }
+
             var currentTerms = await queryService.GetConvertibleEquityTermsAsync(securityId, ct).ConfigureAwait(false);
             if (currentTerms is null)
             {

--- a/tests/Meridian.Tests/Ui/SecurityMasterConvertibleEquityEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/SecurityMasterConvertibleEquityEndpointsTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Meridian.Contracts.Auth;
+using Meridian.Contracts.SecurityMaster;
+using Meridian.Ui.Shared.Endpoints;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+
+namespace Meridian.Tests.Ui;
+
+public sealed class SecurityMasterConvertibleEquityEndpointsTests
+{
+    [Fact]
+    public async Task MapSecurityMasterEndpoints_PatchConvertibleTermsRoute_ReturnsForbid_WhenUserLacksModifyPermission()
+    {
+        var securityId = Guid.NewGuid();
+        var queryService = Substitute.For<ISecurityMasterQueryService>();
+        var service = Substitute.For<ISecurityMasterService>();
+
+        await using var app = await CreateAppAsync(queryService, service, UserPermission.ViewSecurityMaster);
+        var client = app.GetTestClient();
+
+        using var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Patch, $"/api/security-master/equities/{securityId}/conversion-terms")
+        {
+            Content = JsonContent.Create(BuildRequest(), options: new JsonSerializerOptions(JsonSerializerDefaults.Web))
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        await service.DidNotReceiveWithAnyArgs().AmendConvertibleEquityTermsAsync(default, default!, default);
+    }
+
+    private static async Task<WebApplication> CreateAppAsync(
+        ISecurityMasterQueryService queryService,
+        ISecurityMasterService service,
+        UserPermission permissions)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development
+        });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton(queryService);
+        builder.Services.AddSingleton(service);
+
+        var app = builder.Build();
+        app.Use(async (context, next) =>
+        {
+            context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] = permissions;
+            await next();
+        });
+
+        app.MapSecurityMasterEndpoints(new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        await app.StartAsync();
+        return app;
+    }
+
+    private static AmendConvertibleEquityTermsRequest BuildRequest()
+        => new(
+            ExpectedVersion: 3,
+            UnderlyingSecurityId: Guid.NewGuid(),
+            ConversionRatio: 1.25m,
+            ConversionPrice: 40.50m,
+            ConversionStartDate: new DateOnly(2026, 1, 1),
+            ConversionEndDate: new DateOnly(2026, 12, 31),
+            EffectiveFrom: DateTimeOffset.UtcNow,
+            SourceSystem: "test",
+            UpdatedBy: "codex",
+            SourceRecordId: null,
+            Reason: "security test");
+}


### PR DESCRIPTION
### Motivation
- A security report identified that `PATCH /api/security-master/equities/{securityId}/conversion-terms` allowed authenticated users with view-only roles to mutate convertible-equity terms despite an existing `ModifySecurityMaster` permission flag. 
- The change enforces the intended RBAC boundary so reference data and audit attribution cannot be modified by principals lacking mutation privileges.

### Description
- Added `using Meridian.Contracts.Auth;` and updated the convertible-terms PATCH handler in `src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs` to accept `HttpContext` and read `LoginSessionMiddleware.CurrentUserPermissionsKey`. 
- The endpoint now returns `401 Unauthorized` when no permission context is present and `403 Forbidden` when the caller lacks `UserPermission.ModifySecurityMaster`, while preserving the existing `404` behavior and normal success path that calls `ISecurityMasterService.AmendConvertibleEquityTermsAsync`. 
- Added a focused unit test `tests/Meridian.Tests/Ui/SecurityMasterConvertibleEquityEndpointsTests.cs` that asserts a caller with only `ViewSecurityMaster` receives `403 Forbidden` and that the amendment service is not invoked.

### Testing
- Added a unit test targeting the new authorization guard in `tests/Meridian.Tests/Ui/SecurityMasterConvertibleEquityEndpointsTests.cs`, but it was not executed in this environment because `dotnet` is not available. 
- Attempted a targeted test run with `dotnet test --filter "FullyQualifiedName~SecurityMasterConvertibleEquityEndpointsTests"` and the run failed here with `/bin/bash: dotnet: command not found`. 
- Recommend CI to run the full test suite (`make test` / `dotnet test`) to validate the new test and ensure no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b39e63cc8320b3d88ecf43b28ae7)