### PR TITLE
fix: correct Reg T portfolio equity and ledger loan accounting

### DIFF
--- a/src/Meridian.Execution/Services/PaperTradingPortfolio.cs
+++ b/src/Meridian.Execution/Services/PaperTradingPortfolio.cs
@@ -130,7 +130,7 @@ public sealed class PaperTradingPortfolio : IMultiAccountPortfolioState
     /// <inheritdoc />
     public decimal PortfolioValue
     {
-        get { lock (_lock) { return _accounts.Values.Sum(static a => a.Cash + a.Positions.Values.Sum(static p => p.MarketValue)); } }
+        get { lock (_lock) { return _accounts.Values.Sum(static a => a.Cash + a.Positions.Values.Sum(static p => p.MarketValue) - a.MarginBalance); } }
     }
 
     /// <inheritdoc />
@@ -578,11 +578,28 @@ public sealed class PaperTradingPortfolio : IMultiAccountPortfolioState
             account.Cash -= notional + commission;
         }
 
-        _ledger?.PostLines(ts, $"Buy {qty} {symbol} @ {price:F4}",
-        [
-            (LedgerAccounts.Securities(symbol), notional, 0m),
-            (LedgerAccounts.Cash, 0m, notional),
-        ]);
+        if (_ledger is not null)
+        {
+            if (account.MarginModel is RegTMarginModel regtForLedger)
+            {
+                var cashRequired = notional * regtForLedger.LongInitialRate;
+                var borrowed = notional - cashRequired;
+                _ledger.PostLines(ts, $"Buy {qty} {symbol} @ {price:F4}",
+                [
+                    (LedgerAccounts.Securities(symbol), notional, 0m),
+                    (LedgerAccounts.Cash, 0m, cashRequired),
+                    (LedgerAccounts.MarginLoanPayable, 0m, borrowed),
+                ]);
+            }
+            else
+            {
+                _ledger.PostLines(ts, $"Buy {qty} {symbol} @ {price:F4}",
+                [
+                    (LedgerAccounts.Securities(symbol), notional, 0m),
+                    (LedgerAccounts.Cash, 0m, notional),
+                ]);
+            }
+        }
     }
 
     private void ApplyCoverShort(
@@ -653,7 +670,7 @@ public sealed class PaperTradingPortfolio : IMultiAccountPortfolioState
         account.RealisedPnl += realised;
 
         if (_ledger is not null)
-            PostSellLongEntry(symbol, closeQty, price, costBasisRemoved, realised, ts);
+            PostSellLongEntry(symbol, closeQty, price, costBasisRemoved, realised, loanRepaid, ts);
     }
 
     private void ApplyShortSell(
@@ -698,28 +715,32 @@ public sealed class PaperTradingPortfolio : IMultiAccountPortfolioState
     }
 
     private void PostSellLongEntry(string symbol, decimal closeQty, decimal price,
-        decimal costBasisRemoved, decimal realised, DateTimeOffset ts)
+        decimal costBasisRemoved, decimal realised, decimal loanRepaid, DateTimeOffset ts)
     {
         var proceeds = closeQty * price;
+        var cashProceeds = proceeds - loanRepaid;
         var description = $"Sell {closeQty} {symbol} @ {price:F4}";
         if (realised > 0)
             _ledger!.PostLines(ts, description,
             [
-                (LedgerAccounts.Cash, proceeds, 0m),
+                (LedgerAccounts.Cash, cashProceeds, 0m),
+                (LedgerAccounts.MarginLoanPayable, loanRepaid, 0m),
                 (LedgerAccounts.Securities(symbol), 0m, costBasisRemoved),
                 (LedgerAccounts.RealizedGain, 0m, realised),
             ]);
         else if (realised < 0)
             _ledger!.PostLines(ts, description,
             [
-                (LedgerAccounts.Cash, proceeds, 0m),
+                (LedgerAccounts.Cash, cashProceeds, 0m),
+                (LedgerAccounts.MarginLoanPayable, loanRepaid, 0m),
                 (LedgerAccounts.RealizedLoss, Math.Abs(realised), 0m),
                 (LedgerAccounts.Securities(symbol), 0m, costBasisRemoved),
             ]);
         else
             _ledger!.PostLines(ts, description,
             [
-                (LedgerAccounts.Cash, proceeds, 0m),
+                (LedgerAccounts.Cash, cashProceeds, 0m),
+                (LedgerAccounts.MarginLoanPayable, loanRepaid, 0m),
                 (LedgerAccounts.Securities(symbol), 0m, costBasisRemoved),
             ]);
     }

--- a/src/Meridian.Ledger/LedgerAccounts.cs
+++ b/src/Meridian.Ledger/LedgerAccounts.cs
@@ -37,6 +37,10 @@ public static class LedgerAccounts
     public static readonly LedgerAccount ShortRebateIncome =
         new("Short Rebate Income", LedgerAccountType.Revenue);
 
+    /// <summary>Outstanding broker loan used to finance margin long positions.</summary>
+    public static readonly LedgerAccount MarginLoanPayable =
+        new("Margin Loan Payable", LedgerAccountType.Liability);
+
     /// <summary>Dividend income received on long positions.</summary>
     public static readonly LedgerAccount DividendIncome =
         new("Dividend Income", LedgerAccountType.Revenue);

--- a/tests/Meridian.Tests/Execution/PaperTradingPortfolioTests.cs
+++ b/tests/Meridian.Tests/Execution/PaperTradingPortfolioTests.cs
@@ -369,6 +369,24 @@ public sealed class PaperTradingPortfolioRegTMarginTests
         // Assert
         portfolio.Cash.Should().Be(90_000m, because: "only $10 000 initial margin is debited");
         portfolio.MarginBalance.Should().Be(10_000m, because: "broker loaned the other $10 000");
+        portfolio.PortfolioValue.Should().Be(100_000m, because: "equity must subtract outstanding margin loan");
+    }
+
+    [Fact]
+    public void RegTAccount_BuyLong_PostsMarginLoanLiabilityInLedger()
+    {
+        var ledger = new Meridian.Ledger.Ledger();
+        var portfolio = new PaperTradingPortfolio(
+        [
+            new AccountDefinition("margin-1", "Reg T Account", AccountKind.Brokerage, 100_000m,
+                MarginType: MarginAccountType.RegT),
+        ], ledger);
+
+        portfolio.ApplyFill("margin-1", BuildFill("AAPL", OrderSide.Buy, qty: 100, price: 200m));
+
+        var buyEntry = ledger.Journal.Last(e => e.Description.Contains("Buy"));
+        buyEntry.Lines.Should().Contain(l => l.Account == LedgerAccounts.Cash && l.Credit == 10_000m);
+        buyEntry.Lines.Should().Contain(l => l.Account == LedgerAccounts.MarginLoanPayable && l.Credit == 10_000m);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation

- Portfolio equity was overstated for Reg T margin accounts because `PortfolioValue` summed cash plus market value without subtracting outstanding margin loans.  
- Ledger entries for Reg T buys credited cash for the full notional instead of splitting the trader-funded portion and the broker loan, causing ledger balances to diverge from in-memory cash.  
- Tests and reporting that consume `PortfolioValue` or the ledger could therefore show inconsistent or misleading balances for margin trades.

### Description

- Subtract outstanding account-level margin debt from the aggregate `PortfolioValue` by changing the calculation to include `- a.MarginBalance` (in `src/Meridian.Execution/Services/PaperTradingPortfolio.cs`).  
- Add a dedicated ledger liability account `MarginLoanPayable` to `src/Meridian.Ledger/LedgerAccounts.cs`.  
- Update the Reg T buy ledger posting to split funding between `Cash` (initial margin funded by the trader) and `LedgerAccounts.MarginLoanPayable` (broker loan) instead of crediting `Cash` for the full notional (in `src/Meridian.Execution/Services/PaperTradingPortfolio.cs`).  
- Update sell/close postings to record loan repayment against `MarginLoanPayable` and only credit net cash proceeds (aligning ledger entries with in-memory cash changes) and thread the loan repayment amount through `PostSellLongEntry` (in `src/Meridian.Execution/Services/PaperTradingPortfolio.cs`).  
- Add regression tests to validate that (1) `PortfolioValue` correctly reflects equity after a Reg T buy and (2) the buy ledger entry posts the margin-loan liability (in `tests/Meridian.Tests/Execution/PaperTradingPortfolioTests.cs`).

### Testing

- Attempted to run the focused unit test: `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~RegTAccount_BuyLong" --logger "console;verbosity=normal"`, but the command failed because `dotnet` is not available in the execution environment (error: `dotnet: command not found`).  
- New regression tests were added to `tests/Meridian.Tests/Execution/PaperTradingPortfolioTests.cs`; they are included in the PR but could not be executed in this container due to the missing .NET SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cd198c6c83208edc23b3f2d489cc)