### PR TITLE
Liquidate holdings excluded by yield filters in CarryTradeBacktestStrategy

### DIFF
--- a/src/Meridian.Backtesting.Sdk/Strategies/AdvancedCarry/CarryTradeBacktestStrategy.cs
+++ b/src/Meridian.Backtesting.Sdk/Strategies/AdvancedCarry/CarryTradeBacktestStrategy.cs
@@ -153,9 +153,16 @@ public sealed class CarryTradeBacktestStrategy : IBacktestStrategy
         if (snapshots.Count == 0)
             return;
 
+        HashSet<string>? filteredSymbols = null;
+
         // Apply yield-based filtering / ranking for non-classic modes
         if (_yieldCarryMode != YieldCarryMode.ClassicCarry)
+        {
             snapshots = FilterByYield(snapshots);
+            filteredSymbols = snapshots
+                .Select(snapshot => snapshot.Symbol)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
 
         if (snapshots.Count < 1)
             return;
@@ -185,6 +192,15 @@ public sealed class CarryTradeBacktestStrategy : IBacktestStrategy
         {
             if (instruction.DeltaQuantity != 0)
                 ctx.PlaceMarketOrder(instruction.Symbol, instruction.DeltaQuantity);
+        }
+
+        if (filteredSymbols is not null)
+        {
+            foreach (var position in ctx.Positions)
+            {
+                if (position.Value.Quantity != 0 && !filteredSymbols.Contains(position.Key))
+                    ctx.PlaceMarketOrder(position.Key, -position.Value.Quantity);
+            }
         }
 
         _daysSinceRebalance = 0;


### PR DESCRIPTION
### Motivation
- Yield-based filtering (YieldSpread / YieldRotation) removed symbols from the optimizer universe, which caused previously held symbols that were filtered out to never receive a zero-target and therefore never be liquidated.
- This produced incorrect backtest and risk-management behaviour by leaving excluded positions open.

### Description
- Preserve the existing yield-filtered optimization flow and capture the post-filter symbol set into a `HashSet<string>` when non-classic modes are active.
- After executing `decision.RebalanceInstructions`, add a liquidation pass that iterates `ctx.Positions` and places market sell orders to flatten any held positions whose symbols are not present in the filtered symbol set.
- The change is localized to `CarryTradeBacktestStrategy.OnDayEnd` and does not alter optimizer internals or target-weight generation.

### Testing
- Attempted to run focused backtesting unit tests with `dotnet test tests/Meridian.Backtesting.Tests/Meridian.Backtesting.Tests.csproj --filter "FullyQualifiedName~CarryTrade" --logger "console;verbosity=normal"`, but the test run failed in this environment because `dotnet` is not installed (`/bin/bash: line 1: dotnet: command not found`).
- No automated tests were executed successfully in this container; the fix is minimal and isolated and should be validated with the existing backtesting test suite in a development environment that has the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cd1a66048320a6cdf195ee9b94c0)