### PR TITLE
fix: cap run comparison request IDs to prevent unbounded compare workload

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -29,6 +29,7 @@ namespace Meridian.Ui.Shared.Endpoints;
 /// </summary>
 public static class WorkstationEndpoints
 {
+    private const int MaxRunComparisonRequestIds = 10;
     private const int SecurityCoveragePreviewLimit = 5;
 
     public static void MapWorkstationEndpoints(this WebApplication app, JsonSerializerOptions jsonOptions)
@@ -775,6 +776,11 @@ public static class WorkstationEndpoints
                 return Results.BadRequest(new { error = "At least two run IDs are required for comparison." });
             }
 
+            if (request.RunIds.Count > MaxRunComparisonRequestIds)
+            {
+                return Results.BadRequest(new { error = $"A maximum of {MaxRunComparisonRequestIds} run IDs can be compared per request." });
+            }
+
             var comparison = await readService.CompareRunsAsync(request.RunIds, context.RequestAborted).ConfigureAwait(false);
             if (request.Modes is { Count: > 0 })
             {
@@ -930,6 +936,11 @@ public static class WorkstationEndpoints
             if (runIds.Length < 2)
             {
                 return Results.BadRequest(new { error = "At least two run IDs are required for comparison." });
+            }
+
+            if (runIds.Length > MaxRunComparisonRequestIds)
+            {
+                return Results.BadRequest(new { error = $"A maximum of {MaxRunComparisonRequestIds} run IDs can be compared per request." });
             }
 
             var comparison = await readService.GetRunComparisonDtosAsync(runIds, context.RequestAborted).ConfigureAwait(false);

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -2559,6 +2559,38 @@ public sealed class WorkstationEndpointsTests
     }
 
     [Fact]
+    public async Task MapWorkstationEndpoints_CompareRuns_ShouldReturnBadRequestWhenTooManyRunIdsProvided()
+    {
+        await using var app = await CreateAppAsync(services =>
+        {
+            RegisterRunReadServices(services);
+        });
+
+        var runIds = Enumerable.Range(1, 11).Select(index => $"cmp-{index}").ToArray();
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync("/api/workstation/runs/compare", new { runIds });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task MapStrategyRunsCompare_ShouldReturnBadRequestWhenTooManyRunIdsProvided()
+    {
+        await using var app = await CreateAppAsync(services =>
+        {
+            RegisterRunReadServices(services);
+        });
+
+        var ids = string.Join(',', Enumerable.Range(1, 11).Select(index => $"cmp-{index}"));
+        var client = app.GetTestClient();
+
+        var response = await client.GetAsync($"/api/strategies/runs/compare?ids={ids}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
     public async Task MapWorkstationEndpoints_CompareRuns_ShouldFilterByModeWhenRequested()
     {
         await using var app = await CreateAppAsync(services =>


### PR DESCRIPTION
### Motivation
- The strategy run comparison endpoints accepted an unbounded list of run IDs and returned full equity-curve payloads for each, which can amplify repository scans and memory/CPU use and cause availability issues.
- Apply a minimal, low-risk guard at the API boundary that preserves existing DTOs and client behavior for normal UI use while preventing batch abuse.

### Description
- Added a shared `MaxRunComparisonRequestIds = 10` constant to `WorkstationEndpoints` and enforced it on both compare routes (`POST /api/workstation/runs/compare` and `GET /api/strategies/runs/compare`).
- The endpoints now return `400 BadRequest` with a clear error message when callers supply more than `MaxRunComparisonRequestIds` IDs.
- Added unit tests in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` to assert both endpoints reject requests with 11 IDs.
- Changes are limited to request validation at the endpoints and tests; the underlying comparison/data assembly behavior remains unchanged.

### Testing
- Added automated tests that exercise both compare endpoints and verify they return `400 BadRequest` for requests with 11 IDs (tests committed under `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs`).
- Attempted to run the focused tests with `dotnet test` but the execution failed in this environment because the .NET SDK is not available (`dotnet: command not found`).
- Local CI / developer runs with the .NET SDK are expected to run the new tests and should pass (no runtime behavior changes beyond request-size validation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cd0ff9e88320a7797ce257a6b508)