### PR TITLE
fix(robinhood): validate instrument URLs to prevent ROBINHOOD_ACCESS_TOKEN exfiltration

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/Robinhood/RobinhoodBrokerageGateway.cs
+++ b/src/Meridian.Infrastructure/Adapters/Robinhood/RobinhoodBrokerageGateway.cs
@@ -705,9 +705,13 @@ public sealed class RobinhoodBrokerageGateway : IBrokerageGateway
     {
         if (string.IsNullOrWhiteSpace(instrumentUrl))
             return null;
+
+        if (!TryBuildTrustedRobinhoodUri(instrumentUrl, out var requestUri))
+            return null;
+
         try
         {
-            var resp = await client.GetAsync(instrumentUrl, ct).ConfigureAwait(false);
+            var resp = await client.GetAsync(requestUri, ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
                 return null;
             var instrument = await resp.Content.ReadFromJsonAsync(
@@ -728,9 +732,12 @@ public sealed class RobinhoodBrokerageGateway : IBrokerageGateway
         if (string.IsNullOrWhiteSpace(optionInstrumentUrl))
             return null;
 
+        if (!TryBuildTrustedRobinhoodUri(optionInstrumentUrl, out var requestUri))
+            return null;
+
         try
         {
-            var response = await client.GetAsync(optionInstrumentUrl, ct).ConfigureAwait(false);
+            var response = await client.GetAsync(requestUri, ct).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
                 return null;
 
@@ -742,6 +749,22 @@ public sealed class RobinhoodBrokerageGateway : IBrokerageGateway
         {
             return null;
         }
+    }
+
+    private static bool TryBuildTrustedRobinhoodUri(string url, out Uri uri)
+    {
+        uri = null!;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var parsed))
+            return false;
+
+        if (!string.Equals(parsed.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (!string.Equals(parsed.Host, "api.robinhood.com", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        uri = parsed;
+        return true;
     }
 
     private static Dictionary<string, string> BuildOptionPositionMetadata(

--- a/tests/Meridian.Tests/Infrastructure/Providers/RobinhoodBrokerageGatewayTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/RobinhoodBrokerageGatewayTests.cs
@@ -383,6 +383,48 @@ public sealed class RobinhoodBrokerageGatewayTests : IDisposable
         info.Cash.Should().Be(5000m);
     }
 
+    [Fact]
+    public async Task GetPositionsAsync_UntrustedInstrumentUrl_DoesNotFollowExternalHost()
+    {
+        var handler = new RecordingHttpHandler((request, _) =>
+        {
+            var response = request.RequestUri?.AbsolutePath switch
+            {
+                "/positions/" => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = BuildJson(new
+                    {
+                        results = new[]
+                        {
+                            new
+                            {
+                                instrument = "https://attacker.example/instruments/AAPL/",
+                                quantity = "10",
+                                average_buy_price = "150.00"
+                            }
+                        }
+                    })
+                },
+                "/options/positions/" => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = BuildJson(new { results = Array.Empty<object>() })
+                },
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("unexpected") }
+            };
+
+            return Task.FromResult(response);
+        });
+
+        var sut = CreateSut(handler);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var positions = await sut.GetPositionsAsync(cts.Token);
+
+        positions.Should().ContainSingle();
+        positions[0].Symbol.Should().Be("https://attacker.example/instruments/AAPL/");
+        handler.Requests.Should().NotContain(r => r.Url.Contains("attacker.example", StringComparison.OrdinalIgnoreCase));
+    }
+
     // ── CheckHealthAsync ──────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Prevent credential exfiltration where an attacker-controlled `instrument` URL in the Robinhood positions API could be fetched with a client that has `ROBINHOOD_ACCESS_TOKEN` as a default header.
- Close the vulnerable path `GetPositionsAsync -> ResolveSymbolFromInstrumentAsync` and the equivalent option-instrument path so the gateway will not follow untrusted absolute URLs.

### Description
- Added `TryBuildTrustedRobinhoodUri` to canonicalize and validate absolute instrument URLs and only allow `https` scheme with host `api.robinhood.com` in `src/Meridian.Infrastructure/Adapters/Robinhood/RobinhoodBrokerageGateway.cs`.
- Updated `ResolveSymbolFromInstrumentAsync` and `ResolveOptionInstrumentAsync` to use the validated `Uri` and to bail out when the instrument URL is not trusted.
- Left `CreateHttpClient` behavior unchanged (it still sets the Authorization header) and instead mitigated the leak by refusing to follow untrusted absolute URIs.
- Added regression test `GetPositionsAsync_UntrustedInstrumentUrl_DoesNotFollowExternalHost` in `tests/Meridian.Tests/Infrastructure/Providers/RobinhoodBrokerageGatewayTests.cs` that simulates a malicious instrument URL and asserts no external request is performed.

### Testing
- Added unit test `GetPositionsAsync_UntrustedInstrumentUrl_DoesNotFollowExternalHost` to ensure the gateway does not request attacker-controlled hosts (test added but not executed here).
- Attempted to run the focused xUnit test (`dotnet test --filter FullyQualifiedName~RobinhoodBrokerageGatewayTests.GetPositionsAsync_UntrustedInstrumentUrl_DoesNotFollowExternalHost`), but the environment lacks `dotnet`, so the test could not be executed (`/bin/bash: dotnet: command not found`).
- No other automated test runs were performed in this environment; CI should run the full test suite to validate the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d10f7bc08320970ff869e8e6e44e)