### PR TITLE
Handle multi-account strategy run scope inference safely

### DIFF
--- a/src/Meridian.Strategies/Services/StrategyRunScopeMetadataResolver.cs
+++ b/src/Meridian.Strategies/Services/StrategyRunScopeMetadataResolver.cs
@@ -23,11 +23,7 @@ internal static class StrategyRunScopeMetadataResolver
 
         if (string.IsNullOrWhiteSpace(accountId))
         {
-            accountId = entry.Metrics?.Fills
-                .Select(static fill => fill.AccountId)
-                .Where(static id => !string.IsNullOrWhiteSpace(id))
-                .Distinct(StringComparer.Ordinal)
-                .SingleOrDefault();
+            accountId = InferAccountIdFromFills(entry);
         }
 
         if (string.IsNullOrWhiteSpace(accountDisplayName) && !string.IsNullOrWhiteSpace(accountId))
@@ -62,5 +58,28 @@ internal static class StrategyRunScopeMetadataResolver
         }
 
         return null;
+    }
+
+    private static string? InferAccountIdFromFills(StrategyRunEntry entry)
+    {
+        if (entry.Metrics?.Fills is null)
+        {
+            return null;
+        }
+
+        using var distinctAccountIds = entry.Metrics.Fills
+            .Select(static fill => fill.AccountId)
+            .Where(static id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.Ordinal)
+            .Take(2)
+            .GetEnumerator();
+
+        if (!distinctAccountIds.MoveNext())
+        {
+            return null;
+        }
+
+        var firstAccountId = distinctAccountIds.Current;
+        return distinctAccountIds.MoveNext() ? null : firstAccountId;
     }
 }

--- a/tests/Meridian.Tests/Strategies/PortfolioReadServiceTests.cs
+++ b/tests/Meridian.Tests/Strategies/PortfolioReadServiceTests.cs
@@ -123,6 +123,35 @@ public sealed class PortfolioReadServiceTests
         summary.Should().BeNull();
     }
 
+    [Fact]
+    public void BuildSummary_MultiAccountFillsWithoutScope_DoesNotThrowAndLeavesScopeUnset()
+    {
+        var entry = BuildCompletedRun(
+            finalEquity: 120_000m,
+            realizedPnl: 15_000m,
+            unrealizedPnl: 5_000m);
+
+        entry = entry with
+        {
+            Metrics = entry.Metrics! with
+            {
+                Fills =
+                [
+                    new FillEvent(Guid.NewGuid(), Guid.NewGuid(), "AAPL", 10, 100m, 1m, DateTimeOffset.UtcNow, "acct-alpha"),
+                    new FillEvent(Guid.NewGuid(), Guid.NewGuid(), "AAPL", 12, 101m, 1m, DateTimeOffset.UtcNow.AddMinutes(1), "acct-beta")
+                ]
+            },
+            ParameterSet = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        };
+
+        var service = new PortfolioReadService();
+        var summary = service.BuildSummary(entry);
+
+        summary.Should().NotBeNull();
+        summary!.AccountScopeId.Should().BeNull();
+        summary.Positions.Should().OnlyContain(static position => position.AccountScopeId is null);
+    }
+
     // ── BuildSummaryAsync – without security lookup ──────────────────────────
 
     [Fact]


### PR DESCRIPTION
### Motivation
- The scope resolver previously used `SingleOrDefault()` over distinct fill `AccountId` values which throws `InvalidOperationException` when a run contains fills for more than one account, causing read endpoints to return 500s for valid multi-account runs. 
- The change intends to make account inference tolerant of mixed-account fills by only inferring a single-account scope when exactly one distinct non-empty account id exists and otherwise leaving the scope unset.

### Description
- Replaced the direct `SingleOrDefault()` inference with a new helper `InferAccountIdFromFills` that enumerates up to two distinct non-empty account ids and returns the id only when exactly one distinct value is present, otherwise it returns `null` (`src/Meridian.Strategies/Services/StrategyRunScopeMetadataResolver.cs`).
- Added a focused regression test `BuildSummary_MultiAccountFillsWithoutScope_DoesNotThrowAndLeavesScopeUnset` to `tests/Meridian.Tests/Strategies/PortfolioReadServiceTests.cs` which constructs a run with two different fill `AccountId`s and an empty `ParameterSet` and asserts the summary does not throw and leaves `AccountScopeId` unset.
- Changed files: `src/Meridian.Strategies/Services/StrategyRunScopeMetadataResolver.cs`, `tests/Meridian.Tests/Strategies/PortfolioReadServiceTests.cs`.

### Testing
- Attempted to run the new test with `dotnet test --filter "FullyQualifiedName~PortfolioReadServiceTests.BuildSummary_MultiAccountFillsWithoutScope_DoesNotThrowAndLeavesScopeUnset"` but the execution environment lacks the .NET SDK and `dotnet` is not available, so the test could not be executed here (`dotnet: command not found`).
- Static code inspection and reasoning confirm the new `InferAccountIdFromFills` enumerates at most two distinct ids and will return `null` when more than one distinct id exists, preventing the previous `InvalidOperationException`.
- The new unit test has been added to the test suite and should pass in CI or any environment with the .NET toolchain available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cd1993b08320a75add6ce98306ca)