### PR TITLE
Harden sweep hash persistence against client forgery

### DIFF
--- a/src/Meridian.Backtesting/BacktestStudioRunOrchestrator.cs
+++ b/src/Meridian.Backtesting/BacktestStudioRunOrchestrator.cs
@@ -44,7 +44,15 @@ public sealed class BacktestStudioRunOrchestrator : IAsyncDisposable
         var engine = ResolveEngine(request.Engine);
         var handle = await engine.StartAsync(request, ct).ConfigureAwait(false);
 
-        var sweepHash = request.SweepDefinitionHash ?? ComputeSweepDefinitionHash(request.SweepObjective, request.Parameters);
+        var computedSweepHash = ComputeSweepDefinitionHash(request.SweepObjective, request.Parameters);
+        if (!string.IsNullOrWhiteSpace(request.SweepDefinitionHash) &&
+            !string.Equals(request.SweepDefinitionHash, computedSweepHash, StringComparison.Ordinal))
+        {
+            _logger.LogWarning(
+                "Backtest Studio run request {StrategyId} supplied a sweep definition hash that did not match the canonical value. Persisting canonical hash.",
+                request.StrategyId);
+        }
+
         var entry = StrategyRunEntry.Start(
             request.StrategyId,
             request.StrategyName,
@@ -56,7 +64,7 @@ public sealed class BacktestStudioRunOrchestrator : IAsyncDisposable
             parameterSet: request.Parameters) with
         {
             SweepId = request.SweepId,
-            SweepDefinitionHash = sweepHash,
+            SweepDefinitionHash = computedSweepHash,
             SweepObjective = request.SweepObjective
         };
 

--- a/tests/Meridian.Tests/Application/Backtesting/BacktestStudioRunOrchestratorTests.cs
+++ b/tests/Meridian.Tests/Application/Backtesting/BacktestStudioRunOrchestratorTests.cs
@@ -53,6 +53,34 @@ public sealed class BacktestStudioRunOrchestratorTests
         completed.TerminalStatus.Should().BeNull();
     }
 
+
+    [Fact]
+    public async Task StartAsync_IgnoresCallerSuppliedSweepDefinitionHash()
+    {
+        var store = new StrategyRunStore();
+        var engine = new StubBacktestStudioEngine();
+        await using var orchestrator = new BacktestStudioRunOrchestrator(
+            store,
+            [engine],
+            NullLogger<BacktestStudioRunOrchestrator>.Instance);
+
+        var request = new BacktestStudioRunRequest(
+            StrategyId: "strategy-sweep-hash",
+            StrategyName: "Momentum",
+            Engine: StrategyRunEngine.MeridianNative,
+            NativeRequest: BuildRequest(),
+            Parameters: new Dictionary<string, string> { ["lookback"] = "10" },
+            SweepId: "sweep-abc",
+            SweepDefinitionHash: "FORGED-HASH",
+            SweepObjective: "FinalEquity");
+
+        await orchestrator.StartAsync(request);
+
+        var started = await store.GetLatestRunAsync("strategy-sweep-hash");
+        started.Should().NotBeNull();
+        started!.SweepDefinitionHash.Should().NotBe("FORGED-HASH");
+    }
+
     [Fact]
     public async Task StartAsync_WhenEngineFails_RecordsFailedRun()
     {


### PR DESCRIPTION
### Motivation
- Prevent authenticated callers from poisoning sweep result groups by submitting arbitrary `SweepId`/`SweepDefinitionHash`; persisted sweep hashes must be canonical and verifiable (derived from `SweepObjective` + `Parameters`).

### Description
- Always compute the canonical sweep-definition hash with `ComputeSweepDefinitionHash(request.SweepObjective, request.Parameters)` and persist that value instead of trusting `request.SweepDefinitionHash` in `BacktestStudioRunOrchestrator` (`src/Meridian.Backtesting/BacktestStudioRunOrchestrator.cs`).
- Log a warning when a caller-supplied `SweepDefinitionHash` is present but does not match the computed canonical hash to aid operators in detecting forgery attempts.
- Add a focused regression test `StartAsync_IgnoresCallerSuppliedSweepDefinitionHash` to assert a forged `SweepDefinitionHash` is not persisted (`tests/Meridian.Tests/Application/Backtesting/BacktestStudioRunOrchestratorTests.cs`).

### Testing
- Added a unit test covering the forgery case; no automated tests could be executed in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`).
- Recommend running `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~BacktestStudioRunOrchestratorTests"` in CI or a local dev environment to validate the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ab0dd3f08320a8cf345e6d8d1f60)