### PR TITLE
Harden promotion approval gating checks

### DIFF
--- a/src/Meridian.Strategies/Services/PromotionService.cs
+++ b/src/Meridian.Strategies/Services/PromotionService.cs
@@ -234,6 +234,18 @@ public sealed class PromotionService
                 Reason: "Live runs cannot be promoted further.");
         }
 
+        var evaluation = await EvaluateAsync(run.RunId, ct: ct).ConfigureAwait(false);
+        if (!evaluation.IsEligible)
+        {
+            return new PromotionDecisionResult(
+                Success: false,
+                PromotionId: null,
+                NewRunId: null,
+                Reason: evaluation.BlockingReasons?.FirstOrDefault()
+                    ?? evaluation.Reason
+                    ?? "Promotion gate is blocked.");
+        }
+
         var targetRunType = run.RunType == RunType.Backtest ? RunType.Paper : RunType.Live;
         var approvalChecklist = PromotionApprovalChecklist.Normalize(request.ApprovalChecklist);
         var missingChecklistItems = PromotionApprovalChecklist.GetMissingRequiredItems(targetRunType, approvalChecklist);

--- a/src/Meridian.Ui/dashboard/src/screens/trading-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/trading-screen.view-model.ts
@@ -2586,6 +2586,10 @@ export function validatePromotionApproval(
     return evaluation.blockingReasons?.[0] ?? evaluation.reason ?? "Promotion gate is blocked.";
   }
 
+  if (evaluation.runId !== trimmedForm.runId) {
+    return "Run id changed. Re-evaluate gate checks before confirming promotion.";
+  }
+
   if (!trimmedForm.runId || !trimmedForm.approvedBy || !trimmedForm.approvalReason) {
     return "Run id, operator, and approval reason are required.";
   }


### PR DESCRIPTION
### Motivation

- Prevent a client-side gating bypass where a stale evaluation could be used to approve a different run id than the one evaluated, which could incorrectly promote ineligible runs.
- Ensure the backend remains authoritative by re-checking promotion eligibility during approval to close the integrity gap.

### Description

- Added a server-side re-evaluation in `PromotionService.ApproveAsync` to call `EvaluateAsync(...)` and reject approvals when the run is not eligible, returning a blocking reason when available (file: `src/Meridian.Strategies/Services/PromotionService.cs`).
- Strengthened client-side validation in the promotion view-model to require that the evaluated `runId` matches the currently entered `runId` before permitting approval and to force re-evaluation when the run id changes (file: `src/Meridian.Ui/dashboard/src/screens/trading-screen.view-model.ts`).
- These changes bind eligibility to the evaluated run and make the approval path defensive against stale or tampered client state.

### Testing

- Attempted to run dashboard view-model tests with `npm run test -- trading-screen.view-model --runInBand`, but the environment lacks `vitest` so the run failed (tool not found).
- Attempted to run .NET unit tests (`dotnet test ... PromotionServiceTests|PromotionServiceLiveGovernanceTests`), but the environment lacks `dotnet` so the run failed (tool not found).
- Local static inspection and existing tests in the repo referencing promotion validation were reviewed to ensure the new checks integrate with the existing view-model validation and approval flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d063370083208144d04e159f94fe)