### PR TITLE
fix: validate and clamp options strikeRange to prevent allocation abuse

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/Synthetic/SyntheticOptionsChainProvider.cs
+++ b/src/Meridian.Infrastructure/Adapters/Synthetic/SyntheticOptionsChainProvider.cs
@@ -27,6 +27,8 @@ public sealed class SyntheticOptionsChainProvider : IOptionsChainProvider
     private const int WeeklyCount = 4;
     private const int MonthlyCount = 3;
     private const int QuarterlyCount = 2;
+    internal const int DefaultStrikeRange = 10;
+    internal const int MaxStrikeRange = 100;
 
     private readonly SyntheticMarketDataConfig _config;
 
@@ -100,7 +102,7 @@ public sealed class SyntheticOptionsChainProvider : IOptionsChainProvider
         if (expiration <= asOf)
             return Task.FromResult<OptionChainSnapshot?>(null);
 
-        var strikes = GenerateStrikes(profile.BasePrice, strikeRange ?? 10);
+        var strikes = GenerateStrikes(profile.BasePrice, strikeRange ?? DefaultStrikeRange);
         var now = DateTimeOffset.UtcNow;
 
         var calls = strikes
@@ -228,6 +230,7 @@ public sealed class SyntheticOptionsChainProvider : IOptionsChainProvider
     /// </summary>
     internal static IReadOnlyList<decimal> GenerateStrikes(decimal underlyingPrice, int strikeRange)
     {
+        strikeRange = NormalizeStrikeRange(strikeRange);
         var increment = underlyingPrice switch
         {
             >= 200m => 5m,
@@ -239,7 +242,7 @@ public sealed class SyntheticOptionsChainProvider : IOptionsChainProvider
         // Round underlying to nearest increment to get ATM strike
         decimal atm = Math.Round(underlyingPrice / increment, MidpointRounding.AwayFromZero) * increment;
 
-        var strikes = new List<decimal>(strikeRange * 2 + 1);
+        var strikes = new List<decimal>(checked(strikeRange * 2 + 1));
         for (int i = -strikeRange; i <= strikeRange; i++)
         {
             var strike = atm + i * increment;
@@ -247,6 +250,15 @@ public sealed class SyntheticOptionsChainProvider : IOptionsChainProvider
                 strikes.Add(strike);
         }
         return strikes;
+    }
+
+
+    internal static int NormalizeStrikeRange(int strikeRange)
+    {
+        if (strikeRange < 0)
+            return 0;
+
+        return Math.Min(strikeRange, MaxStrikeRange);
     }
 
     /// <summary>

--- a/src/Meridian.Ui.Shared/Endpoints/OptionsEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/OptionsEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Meridian.Application.Services;
+using Meridian.Infrastructure.Adapters.Synthetic;
 using Meridian.Contracts.Api;
 using Meridian.Contracts.Domain.Enums;
 using Meridian.Contracts.Domain.Models;
@@ -82,6 +83,14 @@ public static class OptionsEndpoints
             var service = ctx.RequestServices.GetService<OptionsChainService>();
             if (service is null)
                 return ServiceUnavailableError("OptionsChainService", jsonOptions);
+
+            if (strikeRange.HasValue && !IsValidStrikeRange(strikeRange.Value))
+            {
+                return ValidationError(
+                    "strikeRange",
+                    $"Strike range must be between 0 and {SyntheticOptionsChainProvider.MaxStrikeRange}.",
+                    jsonOptions);
+            }
 
             // If expiration is specified, fetch that specific chain
             if (!string.IsNullOrWhiteSpace(expiration))
@@ -212,6 +221,14 @@ public static class OptionsEndpoints
                 if (!DateOnly.TryParse(request.Expiration, out var expDate))
                     return ValidationError("expiration", "Invalid expiration date format. Use yyyy-MM-dd.", jsonOptions);
 
+                if (request.StrikeRange.HasValue && !IsValidStrikeRange(request.StrikeRange.Value))
+                {
+                    return ValidationError(
+                        "strikeRange",
+                        $"Strike range must be between 0 and {SyntheticOptionsChainProvider.MaxStrikeRange}.",
+                        jsonOptions);
+                }
+
                 var chain = await service.FetchChainSnapshotAsync(
                     request.UnderlyingSymbol, expDate, request.StrikeRange, ct);
 
@@ -243,6 +260,11 @@ public static class OptionsEndpoints
             ErrorResponse.Validation(message, new[] { new FieldError(field, message) }),
             jsonOptions,
             statusCode: StatusCodes.Status400BadRequest);
+    }
+
+    private static bool IsValidStrikeRange(int strikeRange)
+    {
+        return strikeRange >= 0 && strikeRange <= SyntheticOptionsChainProvider.MaxStrikeRange;
     }
 
     private static OptionsChainResponse MapChainToResponse(OptionChainSnapshot chain)

--- a/tests/Meridian.Tests/Infrastructure/Providers/SyntheticOptionsChainProviderTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/SyntheticOptionsChainProviderTests.cs
@@ -255,6 +255,20 @@ public sealed class SyntheticOptionsChainProviderTests
         quote.Contract.Expiration.Should().Be(expiry);
     }
 
+
+    [Fact]
+    public void NormalizeStrikeRange_ClampsNegativeToZero()
+    {
+        SyntheticOptionsChainProvider.NormalizeStrikeRange(-5).Should().Be(0);
+    }
+
+    [Fact]
+    public void NormalizeStrikeRange_ClampsToMax()
+    {
+        SyntheticOptionsChainProvider.NormalizeStrikeRange(SyntheticOptionsChainProvider.MaxStrikeRange + 25)
+            .Should().Be(SyntheticOptionsChainProvider.MaxStrikeRange);
+    }
+
     // ------------------------------------------------------------------ //
     //  Metadata                                                            //
     // ------------------------------------------------------------------ //


### PR DESCRIPTION
### Motivation
- A caller-controlled `strikeRange` was forwarded unchecked into `SyntheticOptionsChainProvider.GenerateStrikes`, allowing negative or very large values to trigger exceptions or excessive allocations and CPU work.
- The synthetic provider is registered by default, exposing this amplification path via public endpoints, so validation is needed at both API and provider layers.

### Description
- Added API boundary validation in `OptionsEndpoints` to reject `strikeRange` values outside the allowed range and return a 400 validation error for both the `GET /api/options/chains/{underlyingSymbol}` and `POST /api/options/refresh` paths using `IsValidStrikeRange` and `SyntheticOptionsChainProvider.MaxStrikeRange`.
- Introduced `DefaultStrikeRange` and `MaxStrikeRange` constants in `SyntheticOptionsChainProvider`, and changed provider behavior to normalize/clamp caller input via a new `NormalizeStrikeRange` helper before generating strikes.
- Hardened internal arithmetic by using `checked` for the `List<T>` capacity computation to detect integer overflow and avoid constructing lists with invalid sizes.
- Added two unit tests to `SyntheticOptionsChainProviderTests` verifying that `NormalizeStrikeRange` clamps negative values to zero and clamps values above the maximum to `MaxStrikeRange`.

### Testing
- Added focused unit tests in `tests/Meridian.Tests/Infrastructure/Providers/SyntheticOptionsChainProviderTests.cs` covering strike-range normalization and clamping, but they were not executed here due to a missing .NET SDK in the execution environment.
- Attempted to run the provider test filter with `dotnet test` but the run failed with `/bin/bash: dotnet: command not found`, so local CI or maintainer machines should run `dotnet test` to validate all tests pass after merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d6c008908320a31078e632510b3d)