### PR TITLE
Enforce authorization for workstation security-master bulk resolve

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -4,6 +4,7 @@ using Meridian.Application.Monitoring;
 using Meridian.Application.ProviderRouting;
 using Meridian.Application.SecurityMaster;
 using Meridian.Contracts.Api;
+using Meridian.Contracts.Auth;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Contracts.Workstation;
 using Meridian.Execution.Models;
@@ -743,6 +744,11 @@ public static class WorkstationEndpoints
             BulkResolveSecurityMasterConflictsRequest request,
             HttpContext context) =>
         {
+            if (!HasPermission(context, UserPermission.ModifySecurityMaster))
+            {
+                return Results.StatusCode(StatusCodes.Status403Forbidden);
+            }
+
             var workbenchService = context.RequestServices.GetService<ISecurityMasterWorkbenchQueryService>();
             if (workbenchService is null)
             {
@@ -758,6 +764,7 @@ public static class WorkstationEndpoints
         .WithName("BulkResolveSecurityMasterWorkstationConflicts")
         .Accepts<BulkResolveSecurityMasterConflictsRequest>("application/json")
         .Produces<BulkResolveSecurityMasterConflictsResult>(200)
+        .Produces(403)
         .Produces(501);
 
         // --- Multi-run comparison and diff ---
@@ -4066,6 +4073,16 @@ public static class WorkstationEndpoints
         }
 
         return await repository.ResolveAsync(request, ct).ConfigureAwait(false);
+    }
+
+    private static bool HasPermission(HttpContext context, UserPermission requiredPermission)
+    {
+        if (context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] is UserPermission permissions)
+        {
+            return (permissions & requiredPermission) == requiredPermission;
+        }
+
+        return false;
     }
 
     private static IResult ServeWorkstationIndex(IWebHostEnvironment environment)

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -10,6 +10,7 @@ using Meridian.Application.SecurityMaster;
 using Meridian.Application.Services;
 using Meridian.Backtesting.Sdk;
 using Meridian.Contracts.Api;
+using Meridian.Contracts.Auth;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Contracts.Workstation;
 using Meridian.Execution.Sdk;
@@ -2699,6 +2700,12 @@ public sealed class WorkstationEndpointsTests
                 NullLogger<FileReconciliationBreakQueueRepository>.Instance));
 
         var app = builder.Build();
+        app.Use(async (context, next) =>
+        {
+            context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] = UserPermission.ModifySecurityMaster;
+            await next();
+        });
+
         app.MapWorkstationEndpoints(new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,


### PR DESCRIPTION
### Motivation
- Close an authorization gap introduced by group-relative workstation routes that made `POST /api/workstation/security-master/conflicts/bulk-resolve` reachable without requiring `ModifySecurityMaster` permission.
- Prevent low-privilege authenticated sessions from performing bulk mutations to Security Master conflict state which could impact governance and downstream workflows.

### Description
- Gate the `POST /api/workstation/security-master/conflicts/bulk-resolve` endpoint with a permission check that returns HTTP `403` when the caller lacks `UserPermission.ModifySecurityMaster` by calling a new `HasPermission` helper.
- Add `HasPermission(HttpContext, UserPermission)` helper to `WorkstationEndpoints.cs` that reads permission flags from `HttpContext.Items` (populated by `LoginSessionMiddleware`).
- Document the new `403` response in the endpoint metadata and add the `Meridian.Contracts.Auth` import required for `UserPermission`.
- Update the in-memory endpoint test host in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` to inject `UserPermission.ModifySecurityMaster` into `HttpContext.Items` so existing endpoint tests remain valid under the new authorization gate.

### Testing
- Updated unit test harness in `CreateAppAsync` to set `LoginSessionMiddleware.CurrentUserPermissionsKey = UserPermission.ModifySecurityMaster` to allow existing bulk-resolve tests to exercise the endpoint under an authorized context.
- Attempted to run the focused test `MapWorkstationEndpoints_SecurityMasterBulkResolve_ShouldResolveOnlyEligibleConflicts` via `dotnet test`, but execution failed in this environment because `dotnet` is not installed (`dotnet: command not found`).
- No automated test failures were observed locally in this environment because the test run could not be executed; changes are limited and designed to be covered by the existing workstation endpoint tests when run in a proper .NET environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b4fbf4a08320b5e976505ab7f453)