### PR TITLE
fix(ci): harden export-standalone-exe release tag handling

### DIFF
--- a/.github/workflows/export-standalone-exe.yml
+++ b/.github/workflows/export-standalone-exe.yml
@@ -37,7 +37,7 @@ on:
           - Debug
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: export-standalone-exe-${{ github.ref }}
@@ -55,6 +55,8 @@ env:
 jobs:
   publish:
     name: Publish (${{ matrix.rid }})
+    permissions:
+      contents: write
     runs-on: windows-latest
     timeout-minutes: 45
 
@@ -84,21 +86,32 @@ jobs:
       - name: Resolve version
         id: version
         shell: pwsh
+        env:
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          GITHUB_REF_VALUE: ${{ github.ref }}
+          GITHUB_SHA_VALUE: ${{ github.sha }}
         run: |
-          $tag = "${{ inputs.release_tag }}"
-          if ("${{ github.ref }}" -match "^refs/tags/(v[^/]+)$") {
-            $v = $Matches[1]
+          $tag = $env:INPUT_RELEASE_TAG
+          $semverPattern = "^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$"
+
+          if ($env:GITHUB_REF_VALUE -match "^refs/tags/(v[^/]+)$") {
+            $candidate = $Matches[1]
           } elseif ($tag -ne "") {
-            # Validate that a manually supplied tag follows vX.Y.Z[-suffix] format.
-            if ($tag -notmatch "^v\d+\.\d+\.\d+") {
-              Write-Error "release_tag '$tag' must start with 'v' followed by a semantic version (e.g. v1.2.0)."
-              exit 1
-            }
-            $v = $tag
+            $candidate = $tag
           } else {
-            $sha = "${{ github.sha }}".Substring(0, 7)
+            $sha = $env:GITHUB_SHA_VALUE.Substring(0, 7)
             $v = "dev-$sha"
+            Write-Host "Resolved version: $v"
+            "version=$v" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            exit 0
           }
+
+          if ($candidate -notmatch $semverPattern) {
+            Write-Error "Resolved release tag '$candidate' must match semantic version tag format (e.g. v1.2.0 or v1.2.0-rc.1)."
+            exit 1
+          }
+
+          $v = $candidate
           Write-Host "Resolved version: $v"
           "version=$v" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
@@ -164,9 +177,14 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.release_tag }}
+          ARCHIVE: ${{ steps.archive.outputs.archive_name }}
         run: |
-          TAG="${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.release_tag }}"
-          ARCHIVE="${{ steps.archive.outputs.archive_name }}"
+          semver_pattern='^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          if [[ ! "$TAG" =~ $semver_pattern ]]; then
+            echo "Invalid release tag: $TAG" >&2
+            exit 1
+          fi
 
           echo "Uploading $ARCHIVE to release $TAG"
 


### PR DESCRIPTION
### Motivation
- The release workflow interpolated untrusted tag names and `workflow_dispatch` input directly into PowerShell and Bash script bodies, creating a command-injection risk. 
- The workflow granted `contents: write` at the top level, allowing any successful injection to modify release assets. 
- The change aims to validate and sanitize release/tag input and reduce token scope to prevent CI-side compromise of release artifacts.

### Description
- Changed top-level workflow permissions from `contents: write` to `contents: read` and granted `contents: write` only at the `publish` job level. 
- Moved `inputs.release_tag`, `github.ref`, and `github.sha` into step `env` variables and consume them from the environment instead of embedding `${{ }}` expressions inside script bodies. 
- Added strict semantic-version validation in the PowerShell `Resolve version` step to reject non-semver tag candidates and in the Bash `Upload to GitHub Release` step to reject invalid tags before any shell use. 
- Updated the Bash upload step to use `TAG` and `ARCHIVE` from the environment and to early-exit on invalid tags, avoiding runtime command/substitution parsing of untrusted values.

### Testing
- Ran `git diff --check` on the repository and it completed with no issues. 
- Verified the updated workflow file contents to confirm environment-based consumption of tag/input values and the added semver checks; no automated unit/integration tests were modified or required for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7bbc161288320a270d5d4ef1d55e4)