### PR TITLE
Mask Alpaca credentials in /api/config response

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/ConfigEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ConfigEndpoints.cs
@@ -34,7 +34,16 @@ public static class ConfigEndpoints
                 dataRoot = cfg.DataRoot,
                 compress = cfg.Compress,
                 dataSource = cfg.DataSource.ToString(),
-                alpaca = cfg.Alpaca,
+                alpaca = cfg.Alpaca is null
+                    ? null
+                    : new
+                    {
+                        keyId = SensitiveValueMasker.Mask(cfg.Alpaca.KeyId),
+                        secretKey = SensitiveValueMasker.MaskCompletely(cfg.Alpaca.SecretKey),
+                        feed = cfg.Alpaca.Feed,
+                        useSandbox = cfg.Alpaca.UseSandbox,
+                        baseUrl = cfg.Alpaca.BaseUrl
+                    },
                 storage = cfg.Storage,
                 symbols = cfg.Symbols ?? Array.Empty<SymbolConfig>(),
                 backfill = cfg.Backfill,


### PR DESCRIPTION
### Motivation
- Prevent accidental disclosure of broker/API secrets by `GET /api/config` after the UiServer DI registration made the endpoint reachable, so authenticated but non-admin users cannot retrieve raw Alpaca credentials.

### Description
- Change `MapConfigEndpoints` in `src/Meridian.Ui.Shared/Endpoints/ConfigEndpoints.cs` to return a sanitized `alpaca` object that masks `keyId` with `SensitiveValueMasker.Mask(...)` and fully masks `secretKey` with `SensitiveValueMasker.MaskCompletely(...)`, while preserving non-sensitive fields (`feed`, `useSandbox`, `baseUrl`) and handling `null` safely.

### Testing
- Attempted to run targeted unit tests with `dotnet test ... --filter "FullyQualifiedName~Config"` but the environment lacks `dotnet` (`dotnet: command not found`), so no automated tests were executed here; change is small and localized to `ConfigEndpoints.cs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cc222ae483209c9b828d037647a1)