### PR TITLE
Harden security-master corporate action mutation endpoint

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
@@ -376,9 +376,20 @@ public static class SecurityMasterEndpoints
         group.MapPost(UiApiRoutes.SecurityMasterCorporateActions, async (
             Guid securityId,
             CorporateActionDto dto,
+            HttpContext context,
             [FromServices] ISecurityMasterEventStore eventStore,
             CancellationToken ct) =>
         {
+            if (context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] is not UserPermission permissions)
+            {
+                return Results.Forbid();
+            }
+
+            if ((permissions & UserPermission.ModifySecurityMaster) != UserPermission.ModifySecurityMaster)
+            {
+                return Results.Forbid();
+            }
+
             if (dto.SecurityId != securityId)
             {
                 return Results.BadRequest("Corporate action SecurityId must match route parameter");
@@ -390,7 +401,9 @@ public static class SecurityMasterEndpoints
         .WithName("AppendSecurityMasterCorporateAction")
         .Accepts<CorporateActionDto>("application/json")
         .Produces(StatusCodes.Status200OK)
-        .Produces(StatusCodes.Status400BadRequest);
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status403Forbidden)
+        .RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy);
 
         // GET /api/security-master/conflicts
         group.MapGet(UiApiRoutes.SecurityMasterConflicts, async (


### PR DESCRIPTION
### Motivation
- Close an authorization and abuse gap where `POST /api/security-master/{securityId}/corporate-actions` accepted client-supplied corporate actions after only matching `SecurityId` and could be invoked by view-only users.
- Prevent low-privilege authenticated users from poisoning historical corporate-action data used by backtests and research.

### Description
- Added an explicit permission guard that reads `LoginSessionMiddleware.CurrentUserPermissionsKey` from `HttpContext.Items` and returns `403 Forbidden` when the caller lacks `UserPermission.ModifySecurityMaster` in the `POST /api/security-master/{securityId}/corporate-actions` handler in `SecurityMasterEndpoints.cs`.
- Included `HttpContext` as a handler parameter and returned `Results.Forbid()` when permissions are missing or insufficient.
- Added endpoint metadata for `403 Forbidden` and attached the existing `UiEndpoints.MutationRateLimitPolicy` via `.RequireRateLimiting(...)` to align this mutation route with other protected mutation endpoints.

### Testing
- Attempted to run a focused endpoint test with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~MapWorkstationEndpoints_TradingReadiness"`, but the run failed in this environment with `dotnet: command not found` so automated test execution could not be completed here.
- No other automated tests were executed in this environment; the change is minimal and intended to preserve existing behavior for authorized callers while preventing unauthorized mutation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e1c116dc83209582920a77dcafc5)