### PR TITLE
Restrict secret-bearing skill eval job to workflow_dispatch

### DIFF
--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -165,6 +165,7 @@ jobs:
     # (e.g. when workflow_dispatch targets only a non-code-review skill).
     needs: [detect-changed-skills, validate-skill-structure]
     if: |
+      github.event_name == 'workflow_dispatch' &&
       needs.detect-changed-skills.outputs.mdc_code_review_changed == 'true' &&
       (needs.validate-skill-structure.result == 'success' || needs.validate-skill-structure.result == 'skipped')
     permissions:


### PR DESCRIPTION
### Motivation
- Prevent CI secret exfiltration by disallowing pull-request-controlled eval runs that execute repository Python with `ANTHROPIC_API_KEY` and upload its stdout as an artifact.

### Description
- Add `github.event_name == 'workflow_dispatch'` to the `if` guard on the `run-evals` job in `.github/workflows/skill-evals.yml` so the secret-bearing eval job only runs for manual `workflow_dispatch` invocations while preserving manual eval functionality.

### Testing
- Verified the workflow change and line-range with `git diff -- .github/workflows/skill-evals.yml && git status --short` and inspected the updated block with `nl -ba .github/workflows/skill-evals.yml | sed -n '158,176p'`, both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ea68d4148320964918c981441f24)