### PR TITLE
Harden banking payment approval endpoints

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/BankingEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/BankingEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Meridian.Application.Banking;
+using Meridian.Contracts.Auth;
 using Meridian.Contracts.Banking;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -59,7 +60,16 @@ public static class BankingEndpoints
                 return ServiceUnavailable();
             }
 
-            Guid? entityId = Guid.TryParse(context.Request.Query["entityId"], out var eid) ? eid : null;
+            if (!TryGetRequiredEntityId(context, out var entityId, out var entityError))
+            {
+                return entityError!;
+            }
+
+            if (!HasPermission(context, UserPermission.ViewDirectLending))
+            {
+                return Results.Problem("Forbidden.", statusCode: StatusCodes.Status403Forbidden);
+            }
+
             var results = await service.GetPendingPaymentsAsync(entityId, context.RequestAborted).ConfigureAwait(false);
             return Results.Json(results, jsonOptions);
         })
@@ -74,12 +84,34 @@ public static class BankingEndpoints
                 return ServiceUnavailable();
             }
 
+            if (!TryGetRequiredEntityId(context, out var entityId, out var entityError))
+            {
+                return entityError!;
+            }
+
+            if (!TryGetCurrentUsername(context, out var currentUser))
+            {
+                return Results.Problem("Unauthorized.", statusCode: StatusCodes.Status401Unauthorized);
+            }
+
+            if (!HasPermission(context, UserPermission.ManageDirectLending))
+            {
+                return Results.Problem("Forbidden.", statusCode: StatusCodes.Status403Forbidden);
+            }
+
+            var pending = await service.GetPendingPaymentsAsync(entityId, context.RequestAborted).ConfigureAwait(false);
+            if (!pending.Any(static p => p.PendingPaymentId == pendingPaymentId))
+            {
+                return Results.NotFound();
+            }
+
             var request = JsonSerializer.Deserialize<ApprovePaymentRequest>(body.GetRawText(), jsonOptions)
                           ?? new ApprovePaymentRequest(ReviewNotes: null, ReviewedBy: null);
+            var serverRequest = request with { ReviewedBy = currentUser };
 
             try
             {
-                var result = await service.ApprovePaymentAsync(pendingPaymentId, request, context.RequestAborted).ConfigureAwait(false);
+                var result = await service.ApprovePaymentAsync(pendingPaymentId, serverRequest, context.RequestAborted).ConfigureAwait(false);
                 return result is null ? Results.NotFound() : Results.Json(result, jsonOptions);
             }
             catch (BankingException ex)
@@ -100,15 +132,38 @@ public static class BankingEndpoints
                 return ServiceUnavailable();
             }
 
+            if (!TryGetRequiredEntityId(context, out var entityId, out var entityError))
+            {
+                return entityError!;
+            }
+
+            if (!TryGetCurrentUsername(context, out var currentUser))
+            {
+                return Results.Problem("Unauthorized.", statusCode: StatusCodes.Status401Unauthorized);
+            }
+
+            if (!HasPermission(context, UserPermission.ManageDirectLending))
+            {
+                return Results.Problem("Forbidden.", statusCode: StatusCodes.Status403Forbidden);
+            }
+
+            var pending = await service.GetPendingPaymentsAsync(entityId, context.RequestAborted).ConfigureAwait(false);
+            if (!pending.Any(static p => p.PendingPaymentId == pendingPaymentId))
+            {
+                return Results.NotFound();
+            }
+
             var request = JsonSerializer.Deserialize<RejectPaymentRequest>(body.GetRawText(), jsonOptions);
             if (request is null)
             {
                 return Results.Problem("Rejection request body is required.", statusCode: StatusCodes.Status400BadRequest);
             }
 
+            var serverRequest = request with { ReviewedBy = currentUser };
+
             try
             {
-                var result = await service.RejectPaymentAsync(pendingPaymentId, request, context.RequestAborted).ConfigureAwait(false);
+                var result = await service.RejectPaymentAsync(pendingPaymentId, serverRequest, context.RequestAborted).ConfigureAwait(false);
                 return result is null ? Results.NotFound() : Results.Json(result, jsonOptions);
             }
             catch (BankingException ex)
@@ -171,6 +226,35 @@ public static class BankingEndpoints
         .WithName("SeedBankTransactions")
         .Produces<BankTransactionSeedResultDto>(StatusCodes.Status201Created)
         .Produces(StatusCodes.Status400BadRequest);
+    }
+
+
+    private static bool TryGetRequiredEntityId(HttpContext context, out Guid entityId, out IResult? error)
+    {
+        if (!Guid.TryParse(context.Request.Query["entityId"], out entityId))
+        {
+            error = Results.Problem("'entityId' query parameter is required.", statusCode: StatusCodes.Status400BadRequest);
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static bool TryGetCurrentUsername(HttpContext context, out string username)
+    {
+        username = context.Items[LoginSessionMiddleware.CurrentUserKey] as string ?? string.Empty;
+        return !string.IsNullOrWhiteSpace(username);
+    }
+
+    private static bool HasPermission(HttpContext context, UserPermission requiredPermission)
+    {
+        if (context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] is not UserPermission permissions)
+        {
+            return false;
+        }
+
+        return (permissions & requiredPermission) == requiredPermission;
     }
 
     private static IBankingService? ResolveService(HttpContext context) =>


### PR DESCRIPTION
### Motivation
- Close a high-severity integrity vulnerability where pending payments could be enumerated and approved/rejected by any authenticated caller while trusting client-supplied reviewer identity and using only the global `pendingPaymentId` for authorization.
- Ensure approvals and rejections are scoped to an entity, bound to the authenticated reviewer, and gated by appropriate permissions to preserve servicing integrity.

### Description
- Restricted the pending-payments listing to require a scoped `entityId` query parameter and added a `ViewDirectLending` permission check to prevent global enumeration (`src/Meridian.Ui.Shared/Endpoints/BankingEndpoints.cs`).
- Hardened the approve and reject endpoints to require `entityId`, require the requestor to be authenticated, require `ManageDirectLending` permission, verify the pending payment belongs to the scoped entity, and force `ReviewedBy` to the server-derived username instead of using the client-supplied value (`src/Meridian.Ui.Shared/Endpoints/BankingEndpoints.cs`).
- Added small helpers to parse the required `entityId`, extract the current session username, and check permissions to keep the change minimal and localized (`TryGetRequiredEntityId`, `TryGetCurrentUsername`, `HasPermission`).
- Imported `Meridian.Contracts.Auth` to use `UserPermission` flags and integrated checks against the session middleware items set by `LoginSessionMiddleware`.

### Testing
- Attempted to run the focused DirectLending payment-approval tests with `dotnet test tests/Meridian.DirectLending.Tests/Meridian.DirectLending.Tests.csproj --filter "FullyQualifiedName~PaymentApprovalTests"`, but the environment lacks the .NET SDK and the command failed with `/bin/bash: dotnet: command not found` so automated tests could not be executed here.
- Changes are limited to HTTP endpoint guards and server-side binding of `ReviewedBy` and are implemented to be backward compatible with existing service interfaces; recommend running the repository unit and integration test suite (`make test`, `dotnet test` targets) in a CI environment with .NET tooling to validate behavior end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e7e46be483209c6025e3d7b35ad2)