### PR TITLE
Harden TODO scanner against symlink and oversized file reads

### DIFF
--- a/build/scripts/docs/scan-todos.py
+++ b/build/scripts/docs/scan-todos.py
@@ -10,6 +10,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Iterable
 
+MAX_SCAN_BYTES = 512 * 1024
+
 ROOT = Path(__file__).resolve().parents[3]
 DEFAULT_OUTPUT = ROOT / "docs/status/TODO.md"
 
@@ -106,9 +108,23 @@ def iter_files(root: Path) -> Iterable[Path]:
             path = current / filename
             if path.suffix.lower() not in TEXT_EXTENSIONS:
                 continue
+            if path.is_symlink():
+                continue
+
             rel_path = f"{rel_dir}/{filename}".strip("/")
             if is_excluded(rel_path):
                 continue
+
+            try:
+                resolved = path.resolve(strict=True)
+                resolved.relative_to(root)
+                stat_info = path.stat()
+            except (OSError, ValueError):
+                continue
+
+            if stat_info.st_size > MAX_SCAN_BYTES:
+                continue
+
             yield path
 
 


### PR DESCRIPTION
### Motivation
- The repository TODO scanner could follow symlinks and read arbitrary files on the CI runner, allowing a PR author to cause disclosure of sensitive runner files via symlinked paths.
- The scanner also read files without any size cap, which increases the risk of DoS or exfiltration by referencing large files.
- The change aims to minimally harden the scanner while preserving its intended TODO/FIXME/HACK/NOTE discovery behavior.

### Description
- In `build/scripts/docs/scan-todos.py` the `iter_files` enumeration was hardened to skip symlinked entries by checking `path.is_symlink()` before reading files.
- The scanner now resolves candidate paths using `path.resolve(strict=True)` and enforces the resolved path is under the repository root using `resolved.relative_to(root)` to avoid scanning targets outside the repo.
- A file-size guard `MAX_SCAN_BYTES = 512 * 1024` was added and large files are skipped based on `stat().st_size` to limit resource use and reduce leakage risk.

### Testing
- Ran the scanner CLI help to validate the script runs: `python3 build/scripts/docs/scan-todos.py --help` (succeeded).
- The changes are limited to the scanner enumeration and read-safety logic and do not alter the output format generation paths used by the documentation workflow (manual/integration validation recommended in CI).
- No repository unit tests were modified; recommend running the documentation workflow in an isolated environment to validate artifact outputs before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ef4b0abc83209f5bbbf324973193)