### PR TITLE
security(ci): reduce untrusted PR credential exposure in documentation workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -409,6 +409,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: detect-changes
+    permissions:
+      contents: read
     if: |
       needs.detect-changes.outputs.any_changed == 'true'
     steps:
@@ -416,6 +418,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -571,8 +574,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: detect-changes
+    permissions:
+      contents: write
     if: |
-      needs.detect-changes.outputs.any_changed == 'true'
+      needs.detect-changes.outputs.any_changed == 'true' &&
+      github.event_name != 'pull_request'
     outputs:
       has_changes: ${{ steps.changes.outputs.has_changes }}
       changed_files: ${{ steps.changes.outputs.changed_files }}
@@ -581,7 +587,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -1135,6 +1141,8 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     outputs:
       total_count: ${{ steps.scan.outputs.total_count }}
       new_todos: ${{ steps.scan.outputs.new_todos }}
@@ -1145,6 +1153,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Pull latest changes
         run: |


### PR DESCRIPTION
### Motivation
- The documentation workflow previously ran PR-checked-out scripts with persisted git credentials and broad `GITHUB_TOKEN` write permissions, enabling a PR to execute untrusted code with repo write scope. 
- The change aims to minimize credential exposure for PR-triggered jobs while preserving regeneration behavior for trusted non-PR events.

### Description
- Add `permissions: contents: read` to the `validate-docs` and `scan-todos` jobs so PR-executed validation jobs have least-privilege access. 
- Set `persist-credentials: false` on `actions/checkout` in `validate-docs`, `regenerate-docs`, and `scan-todos` so checked-out PR code cannot inherit git auth. 
- Gate `regenerate-docs` with `github.event_name != 'pull_request'` and keep `permissions: contents: write` so write-capable regeneration only runs for trusted event types (push/schedule/dispatch). 
- Keep other job behaviors intact and apply minimal edits confined to `.github/workflows/documentation.yml`.

### Testing
- Ran `git diff -- .github/workflows/documentation.yml` to confirm the applied changes to the workflow and the expected diff output, which succeeded. 
- Inspected the updated sections with `nl -ba .github/workflows/documentation.yml | sed -n '404,430p;568,596p;1130,1160p'` to verify `permissions` and `persist-credentials` lines were added and the `regenerate-docs` condition was gated, which succeeded. 
- Committed the change with `git add .github/workflows/documentation.yml && git commit -m "security(ci): restrict docs workflow token exposure on PRs"`, which produced a successful commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e985ffac83209f29b1bfa52b837a)