### PR TITLE
Harden direct-lending HTTP metadata to block replay outbox suppression

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/DirectLendingEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/DirectLendingEndpoints.cs
@@ -749,7 +749,7 @@ public static class DirectLendingEndpoints
             CorrelationId: metadata?.CorrelationId ?? TryParseGuidHeader(context, "X-Correlation-Id"),
             CausationId: metadata?.CausationId ?? TryParseGuidHeader(context, "X-Causation-Id"),
             SourceSystem: metadata?.SourceSystem ?? context.Request.Headers["X-Source-System"].ToString(),
-            ReplayFlag: metadata?.ReplayFlag ?? false);
+            ReplayFlag: false);
 
     private static Guid? TryParseGuidHeader(HttpContext context, string headerName)
         => Guid.TryParse(context.Request.Headers[headerName].ToString(), out var value) ? value : null;

--- a/tests/Meridian.Tests/Ui/DirectLendingEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/DirectLendingEndpointsTests.cs
@@ -130,7 +130,7 @@ public sealed class DirectLendingEndpointsTests
     }
 
     [Fact]
-    public async Task DirectLendingEndpoints_ShouldPreserveIngressEnvelopeMetadataInHistory()
+    public async Task DirectLendingEndpoints_ShouldIgnoreIngressReplayFlagMetadataInHistory()
     {
         await using var app = await CreateAppAsync(services =>
         {
@@ -149,7 +149,7 @@ public sealed class DirectLendingEndpointsTests
                 CorrelationId: correlationId,
                 CausationId: causationId,
                 SourceSystem: "ops-audit-test",
-                ReplayFlag: false));
+                ReplayFlag: true));
 
         var createResponse = await client.PostAsJsonAsync("/api/loans", createEnvelope);
         createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -164,6 +164,7 @@ public sealed class DirectLendingEndpointsTests
         history[0].CorrelationId.Should().Be(correlationId);
         history[0].CausationId.Should().Be(causationId);
         history[0].SourceSystem.Should().Be("ops-audit-test");
+        history[0].ReplayFlag.Should().BeFalse();
     }
 
     private static async Task<WebApplication> CreateAppAsync(Action<IServiceCollection> configureServices)


### PR DESCRIPTION
### Motivation
- Prevent external HTTP clients from setting `ReplayFlag=true` in direct-lending command envelopes and thereby suppressing the outbox messages that trigger projection, journal, and reconciliation workflows.

### Description
- Force `ReplayFlag: false` when merging inbound direct-lending command metadata in `DirectLendingEndpoints.MergeMetadata` to ensure replay mode cannot be enabled from public requests.
- Update endpoint test `DirectLendingEndpoints_ShouldIgnoreIngressReplayFlagMetadataInHistory` to POST an envelope with `ReplayFlag: true` and assert that history records `ReplayFlag` as `false` to prove the ingress boundary.
- Changed files: `src/Meridian.Ui.Shared/Endpoints/DirectLendingEndpoints.cs` and `tests/Meridian.Tests/Ui/DirectLendingEndpointsTests.cs`.

### Testing
- Added a focused unit test `DirectLendingEndpoints_ShouldIgnoreIngressReplayFlagMetadataInHistory` to validate the fix but it was not executed here.
- Attempted to run the focused test with `dotnet test --filter "FullyQualifiedName~DirectLendingEndpoints_ShouldIgnoreIngressReplayFlagMetadataInHistory"` but the environment lacks `dotnet` so the test run could not be completed (`dotnet: command not found`).
- The change and test were committed locally to the branch and are ready for CI verification where full `dotnet test` will validate the behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f397728083209713488b344df1fe)