### PR TITLE
Fix packaging endpoints to enforce fixed package root

### DIFF
--- a/src/Meridian.Application/Http/Endpoints/PackagingEndpoints.cs
+++ b/src/Meridian.Application/Http/Endpoints/PackagingEndpoints.cs
@@ -245,12 +245,13 @@ public static class PackagingEndpoints
         {
             try
             {
-                var packagesDir = directory ?? Path.Combine(dataRoot, "..", "packages");
+                var packagesDir = Path.GetFullPath(Path.Combine(dataRoot, "..", "packages"));
                 var packagePath = Path.Combine(packagesDir, fileName);
 
                 // Security: ensure the path is within the packages directory
                 var fullPath = Path.GetFullPath(packagePath);
-                var fullPackagesDir = Path.GetFullPath(packagesDir);
+                var fullPackagesDir = packagesDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                    + Path.DirectorySeparatorChar;
 
                 if (!fullPath.StartsWith(fullPackagesDir, StringComparison.OrdinalIgnoreCase))
                 {
@@ -281,12 +282,13 @@ public static class PackagingEndpoints
         {
             try
             {
-                var packagesDir = directory ?? Path.Combine(dataRoot, "..", "packages");
+                var packagesDir = Path.GetFullPath(Path.Combine(dataRoot, "..", "packages"));
                 var packagePath = Path.Combine(packagesDir, fileName);
 
                 // Security: ensure the path is within the packages directory
                 var fullPath = Path.GetFullPath(packagePath);
-                var fullPackagesDir = Path.GetFullPath(packagesDir);
+                var fullPackagesDir = packagesDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                    + Path.DirectorySeparatorChar;
 
                 if (!fullPath.StartsWith(fullPackagesDir, StringComparison.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
### Motivation
- The packaging `DELETE /api/packaging/{fileName}` and `GET /api/packaging/download/{fileName}` endpoints accepted a user-supplied `directory` query parameter and used it as the containment base, enabling arbitrary file read/delete of any file accessible to the process.
- Remediate the issue by anchoring file operations to the configured packages directory under the service `dataRoot` and tightening the containment check to prevent prefix edge cases.

### Description
- Updated the delete and download handlers in `src/Meridian.Application/Http/Endpoints/PackagingEndpoints.cs` to compute `packagesDir` as `Path.GetFullPath(Path.Combine(dataRoot, "..", "packages"))` and ignore the caller-provided `directory` for these routes.
- Hardened the containment check by normalizing the package root with a trailing directory separator via `packagesDir.TrimEnd(...) + Path.DirectorySeparatorChar` before calling `StartsWith` to avoid prefix-matching bypasses.
- Preserved existing response behavior (`Results.File`, `Results.NotFound`, `Results.BadRequest`) and left the package listing route unchanged in this patch.

### Testing
- Attempted to run the focused test command `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~Packaging" --logger "console;verbosity=minimal"`, but the environment lacks `dotnet` and the command failed with `dotnet: command not found`.
- No automated tests were executed successfully in this environment; please run the same `dotnet test` command in CI or a developer workstation to validate the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f302816883209e80e7a1a0ab0472)