### PR TITLE
fix(governance): require operator-provided reconciliation rationale

### DIFF
--- a/src/Meridian.Ui/dashboard/src/screens/governance-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/governance-screen.tsx
@@ -819,7 +819,14 @@ export function GovernanceScreen({ data }: GovernanceScreenProps) {
                       variant="outline"
                       disabled={!item.canResolve}
                       aria-label={item.resolveAriaLabel}
-                      onClick={() => void reconciliation.resolveBreak(item.breakId, "Resolved")}
+                      onClick={() => {
+                        const operatorRationale = window.prompt("Enter operator rationale for resolving this break:", "");
+                        if (operatorRationale === null) {
+                          return;
+                        }
+
+                        void reconciliation.resolveBreak(item.breakId, "Resolved", operatorRationale);
+                      }}
                     >
                       {item.resolveLabel}
                     </Button>
@@ -828,7 +835,14 @@ export function GovernanceScreen({ data }: GovernanceScreenProps) {
                       variant="ghost"
                       disabled={!item.canDismiss}
                       aria-label={item.dismissAriaLabel}
-                      onClick={() => void reconciliation.resolveBreak(item.breakId, "Dismissed")}
+                      onClick={() => {
+                        const operatorRationale = window.prompt("Enter operator rationale for dismissing this break:", "");
+                        if (operatorRationale === null) {
+                          return;
+                        }
+
+                        void reconciliation.resolveBreak(item.breakId, "Dismissed", operatorRationale);
+                      }}
                     >
                       {item.dismissLabel}
                     </Button>

--- a/src/Meridian.Ui/dashboard/src/screens/governance-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/governance-screen.view-model.ts
@@ -778,8 +778,15 @@ export function useGovernanceReconciliationViewModel(
 
   const resolveBreak = useCallback(async (
     breakId: string,
-    status: ResolveReconciliationBreakRequest["status"]
+    status: ResolveReconciliationBreakRequest["status"],
+    operatorRationale: string
   ) => {
+    const trimmedRationale = operatorRationale.trim();
+    if (!trimmedRationale) {
+      setBreakActionError("Operator rationale is required.");
+      return;
+    }
+
     const command: ReconciliationBreakCommand = status === "Resolved" ? "resolve" : "dismiss";
     setBreakAction({ breakId, command });
     setBreakActionError(null);
@@ -790,7 +797,7 @@ export function useGovernanceReconciliationViewModel(
         status,
         resolvedBy: "ops.gov",
         resolutionNote: "Reviewed in governance panel.",
-        operatorRationale: "Reviewed and actioned via governance panel."
+        operatorRationale: trimmedRationale
       });
       setBreakQueue((current) => replaceBreakQueueItem(current, updated));
     } catch (err) {


### PR DESCRIPTION
### Motivation
- A recent change sent a hard-coded `operatorRationale` for reconciliation transitions which bypasses meaningful operator justification and weakens audit/signoff integrity. 
- The UI must collect and persist an operator-specific rationale before allowing resolve/dismiss transitions so back-end audit fields record genuine operator input.

### Description
- Updated the reconciliation `Resolve` and `Dismiss` buttons to prompt the operator for a rationale and pass the entered text to the view-model instead of performing a one-click action. 
- Changed `resolveBreak` in the governance reconciliation view-model to accept an `operatorRationale` parameter, trim it, and reject empty input with an explicit error message. 
- Replaced the fixed `operatorRationale` payload with the trimmed operator-entered rationale when calling `services.resolveBreak` so the backend persists the real justification.

### Testing
- Verified the reported issue still existed in `HEAD` before the change by confirming the UI sent a constant `operatorRationale` string. 
- Ran the dashboard type-check/build with `cd src/Meridian.Ui/dashboard && npm run build`, which failed in this environment due to missing local type dependencies (`@testing-library/jest-dom`, `vitest/globals`) and not due to the change, so no successful automated build/test run completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ab0e08048320b4a67910058932a3)