### PR TITLE
Bind reconciliation break resolve signoff actor to authenticated session

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -427,8 +427,16 @@ public static class WorkstationEndpoints
                 return Results.BadRequest(new { error = "Operator rationale is required for resolve or waive transitions." });
             }
 
+            var currentUser = context.Items[LoginSessionMiddleware.CurrentUserKey] as string;
+            if (string.IsNullOrWhiteSpace(currentUser))
+            {
+                return Results.Unauthorized();
+            }
+
+            var trustedRequest = request with { ResolvedBy = currentUser };
+
             await EnsureBreakQueueSeededAsync(context.RequestServices, context.RequestAborted).ConfigureAwait(false);
-            var transition = await ResolveBreakAsync(context.RequestServices, request, context.RequestAborted).ConfigureAwait(false);
+            var transition = await ResolveBreakAsync(context.RequestServices, trustedRequest, context.RequestAborted).ConfigureAwait(false);
             return transition.Status switch
             {
                 ReconciliationBreakQueueTransitionStatus.Success => Results.Json(transition.Item, jsonOptions),


### PR DESCRIPTION
### Motivation
- The resolve flow previously trusted the client-supplied `ResolvedBy` field, allowing an authenticated caller to forge the persisted signoff actor and corrupt reconciliation signoff/audit history. 
- The server-side authenticated identity is already attached by `LoginSessionMiddleware` to `HttpContext.Items`, so the endpoint should bind signoff actor to that trusted identity.

### Description
- Updated the `/reconciliation/break-queue/{breakId}/resolve` handler in `WorkstationEndpoints.cs` to read the authenticated user from `context.Items[LoginSessionMiddleware.CurrentUserKey]`. 
- The handler now returns `401 Unauthorized` if no authenticated user is present. 
- The code constructs a `trustedRequest = request with { ResolvedBy = currentUser }` and passes `trustedRequest` into `ResolveBreakAsync`, preventing client-supplied `ResolvedBy` from being persisted. 
- This is a minimal server-side fix that does not change DTOs or repository behavior and preserves existing transition logic while ensuring the persisted actor is server-trusted.

### Testing
- Attempted to run the targeted unit test `MapWorkstationEndpoints_BreakQueueResolveRoute_ShouldRequireReviewBeforeResolve` with `dotnet test`, but automated test execution could not run because `dotnet` is not available in the environment (`dotnet: command not found`).
- No automated tests were executed successfully as part of this change due to the environment limitation described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a2435e0483209c7925e6fb06c179)