### PR TITLE
Guard fund-account continuity reconciliation from null snapshot sources

### DIFF
--- a/src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs
+++ b/src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs
@@ -592,12 +592,12 @@ public sealed class InMemoryFundAccountService : IFundAccountService, IAccountMa
             }
 
             accountSync = stored.Snapshots
-                .Where(static s => s.Source.StartsWith("brokerage-sync:", StringComparison.OrdinalIgnoreCase))
+                .Where(static s => s.Source is not null && s.Source.StartsWith("brokerage-sync:", StringComparison.OrdinalIgnoreCase))
                 .Where(s => s.AsOfDate == asOfDate)
                 .OrderByDescending(static s => s.RecordedAt)
                 .FirstOrDefault();
             runDerived = stored.Snapshots
-                .Where(static s => !s.Source.StartsWith("brokerage-sync:", StringComparison.OrdinalIgnoreCase))
+                .Where(static s => s.Source is null || !s.Source.StartsWith("brokerage-sync:", StringComparison.OrdinalIgnoreCase))
                 .Where(s => s.AsOfDate == asOfDate)
                 .OrderByDescending(static s => s.RecordedAt)
                 .FirstOrDefault();

--- a/tests/Meridian.Tests/Ui/BrokeragePortfolioSyncServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/BrokeragePortfolioSyncServiceTests.cs
@@ -356,6 +356,60 @@ public sealed class BrokeragePortfolioSyncServiceTests
         }
     }
 
+    [Fact]
+    public async Task Scenario_NullSourceSnapshotPresent_ReconciliationStillCompletes()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var (service, serviceProvider) = CreateService(
+                root,
+                new FixedPortfolioAdapter("alpaca"),
+                new FixedActivityAdapter("alpaca"),
+                includeSecurityLookup: true);
+            var fundAccountId = Guid.NewGuid();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var fundAccountService = serviceProvider.GetRequiredService<IFundAccountService>();
+            await fundAccountService.CreateAccountAsync(
+                new CreateAccountRequest(
+                    fundAccountId,
+                    AccountTypeDto.Brokerage,
+                    "BRK-NULLSRC",
+                    "Null Source Brokerage",
+                    "USD",
+                    DateTimeOffset.UtcNow.AddDays(-2),
+                    "tests"),
+                cts.Token);
+
+            var snapshotBody = $$"""
+                                 {
+                                   "accountId": "{{fundAccountId}}",
+                                   "asOfDate": "{{DateOnly.FromDateTime(DateTime.UtcNow):yyyy-MM-dd}}",
+                                   "currency": "USD",
+                                   "cashBalance": 49900,
+                                   "source": null,
+                                   "recordedBy": "tests"
+                                 }
+                                 """;
+            var request = JsonSerializer.Deserialize(
+                snapshotBody,
+                FundStructureContractsJsonContext.Default.RecordAccountBalanceSnapshotRequest);
+            request.Should().NotBeNull();
+
+            await fundAccountService.RecordBalanceSnapshotAsync(request!, cts.Token);
+            var run = await service.RunSyncAsync(
+                fundAccountId,
+                new WorkstationBrokerageSyncRunRequestDto("alpaca", "PA-NULLSRC", "ops-review"),
+                cts.Token);
+
+            run.ReconciliationRunId.Should().NotBe(Guid.Empty);
+        }
+        finally
+        {
+            DeleteTempRoot(root);
+        }
+    }
+
     private static (BrokeragePortfolioSyncService Service, ServiceProvider Provider) CreateService(
         string root,
         IBrokeragePortfolioSync portfolioAdapter,


### PR DESCRIPTION
### Motivation

- A null `Source` on stored `AccountBalanceSnapshotDto` could cause a `NullReferenceException` in continuity reconciliation because `StartsWith(...)` was called without a null guard. 
- That crash can surface as an unhandled 500 from the reconcile endpoint and block reconciliation for the affected account.

### Description

- Made the continuity classification null-safe in `AddContinuityCheckResults` by checking `s.Source is not null` before calling `StartsWith` for `brokerage-sync:` and treating `null` as non-`brokerage-sync` for the complementary filter in `src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs`.
- Added a regression test `Scenario_NullSourceSnapshotPresent_ReconciliationStillCompletes` to `tests/Meridian.Tests/Ui/BrokeragePortfolioSyncServiceTests.cs` that deserializes a JSON snapshot with `"source": null`, records it, and verifies the brokerage sync reconciliation still completes.
- Changes are minimal and preserve existing behavior for non-null `Source` values while avoiding crashes when `Source` is missing or null.

### Testing

- Added a targeted unit test: `Scenario_NullSourceSnapshotPresent_ReconciliationStillCompletes` which verifies reconciliation completes when a null snapshot source is present.
- Attempted to run the new test locally with `dotnet test ... --filter "FullyQualifiedName~Scenario_NullSourceSnapshotPresent_ReconciliationStillCompletes"`, but the environment lacks the `dotnet` SDK (`/bin/bash: dotnet: command not found`) so automated execution could not be performed here.
- Static inspection and local test creation validate the fix addresses the reported `NullReferenceException` path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a383080083209539696ec534ca28)