### PR TITLE
Harden statement reconciliation CLI source validation

### DIFF
--- a/src/Meridian.Application/Commands/StatementCommands.cs
+++ b/src/Meridian.Application/Commands/StatementCommands.cs
@@ -18,22 +18,40 @@ internal sealed class StatementCommands : ICliCommand
             return CliResult.Fail(ErrorCode.RequiredFieldMissing);
 
         var svc = new StatementReconciliationService();
-        if (CliArguments.HasFlag(args, "--statement-validate"))
+        try
         {
-            var result = await svc.ValidateAsync(sourceKind, sourcePath, ct).ConfigureAwait(false);
-            Console.WriteLine(result);
+            if (CliArguments.HasFlag(args, "--statement-validate"))
+            {
+                var result = await svc.ValidateAsync(sourceKind, sourcePath, ct).ConfigureAwait(false);
+                Console.WriteLine(result);
+                return CliResult.Ok();
+            }
+
+            if (CliArguments.HasFlag(args, "--statement-import"))
+            {
+                var result = await svc.ImportAsync(sourceKind, sourcePath, ct).ConfigureAwait(false);
+                Console.WriteLine($"Imported statement batch {result.ImportId} with {result.RowCount} row(s).");
+                return CliResult.Ok();
+            }
+
+            var reconcileResult = await svc.ReconcileAsync(sourceKind, sourcePath, ct).ConfigureAwait(false);
+            Console.WriteLine($"Reconciled batch {reconcileResult.ImportId}: matches={reconcileResult.MatchCount}, unresolved={reconcileResult.UnresolvedCount}.");
             return CliResult.Ok();
         }
-
-        if (CliArguments.HasFlag(args, "--statement-import"))
+        catch (FileNotFoundException ex)
         {
-            var result = await svc.ImportAsync(sourceKind, sourcePath, ct).ConfigureAwait(false);
-            Console.WriteLine($"Imported statement batch {result.ImportId} with {result.RowCount} row(s).");
-            return CliResult.Ok();
+            Console.WriteLine(ex.Message);
+            return CliResult.Fail(ErrorCode.FileNotFound);
         }
-
-        var reconcileResult = await svc.ReconcileAsync(sourceKind, sourcePath, ct).ConfigureAwait(false);
-        Console.WriteLine($"Reconciled batch {reconcileResult.ImportId}: matches={reconcileResult.MatchCount}, unresolved={reconcileResult.UnresolvedCount}.");
-        return CliResult.Ok();
+        catch (NotSupportedException ex)
+        {
+            Console.WriteLine(ex.Message);
+            return CliResult.Fail(ErrorCode.NotSupported);
+        }
+        catch (ArgumentException ex)
+        {
+            Console.WriteLine(ex.Message);
+            return CliResult.Fail(ErrorCode.ValidationFailed);
+        }
     }
 }

--- a/src/Meridian.Application/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.Application/Reconciliation/StatementReconciliationService.cs
@@ -5,18 +5,42 @@ namespace Meridian.Application.Reconciliation;
 public sealed class StatementReconciliationService
 {
     public Task<string> ValidateAsync(string sourceKind, string sourcePath, CancellationToken ct)
-        => Task.FromResult($"Statement source '{sourceKind}:{sourcePath}' passed schema/balance validation.");
+    {
+        var normalizedSourceKind = ValidateSourceAccess(sourceKind, sourcePath);
+        return Task.FromResult($"Statement source '{normalizedSourceKind}:{sourcePath}' passed local file accessibility checks.");
+    }
 
     public Task<(string ImportId, int RowCount)> ImportAsync(string sourceKind, string sourcePath, CancellationToken ct)
     {
-        var id = DeterministicFingerprint.Compute($"{sourceKind}|{sourcePath}");
-        return Task.FromResult<(string, int)>((id, 0));
+        var normalizedSourceKind = ValidateSourceAccess(sourceKind, sourcePath);
+        var id = DeterministicFingerprint.Compute($"{normalizedSourceKind}|{sourcePath}");
+        var rowCount = File.ReadLines(sourcePath).Count();
+        return Task.FromResult<(string, int)>((id, rowCount));
     }
 
     public Task<(string ImportId, int MatchCount, int UnresolvedCount)> ReconcileAsync(string sourceKind, string sourcePath, CancellationToken ct)
     {
-        var id = DeterministicFingerprint.Compute($"{sourceKind}|{sourcePath}");
+        var normalizedSourceKind = ValidateSourceAccess(sourceKind, sourcePath);
+        var id = DeterministicFingerprint.Compute($"{normalizedSourceKind}|{sourcePath}");
         return Task.FromResult((id, 0, 0));
+    }
+
+    private static string ValidateSourceAccess(string sourceKind, string sourcePath)
+    {
+        if (string.IsNullOrWhiteSpace(sourceKind))
+            throw new ArgumentException("Statement source kind is required.", nameof(sourceKind));
+
+        if (string.IsNullOrWhiteSpace(sourcePath))
+            throw new ArgumentException("Statement source path is required.", nameof(sourcePath));
+
+        var normalizedSourceKind = sourceKind.Trim().ToLowerInvariant();
+        if (!string.Equals(normalizedSourceKind, "local", StringComparison.Ordinal))
+            throw new NotSupportedException($"Statement source kind '{sourceKind}' is not supported. Use 'local'.");
+
+        if (!File.Exists(sourcePath))
+            throw new FileNotFoundException($"Statement source file '{sourcePath}' was not found.", sourcePath);
+
+        return normalizedSourceKind;
     }
 
     public (IReadOnlyList<ReconciliationMatchLink> Matches, IReadOnlyList<ReconciliationCase> Cases) MatchRows(

--- a/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
@@ -28,4 +28,30 @@ public sealed class StatementReconciliationServiceTests
         Assert.Single(result.Cases);
         Assert.Equal("case:2", result.Cases[0].CaseId);
     }
+
+    [Fact]
+    public async Task ValidateAsync_ThrowsWhenLocalFileMissing()
+    {
+        var svc = new StatementReconciliationService();
+
+        await Assert.ThrowsAsync<FileNotFoundException>(() =>
+            svc.ValidateAsync("local", "/tmp/does-not-exist.csv", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ImportAsync_CountsRowsForLocalFile()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllLinesAsync(filePath, ["header", "row1", "row2"]);
+            var result = await svc.ImportAsync("local", filePath, CancellationToken.None);
+            Assert.Equal(3, result.RowCount);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
- Close a logic/integrity gap where `StatementReconciliationService` previously returned unconditional success for validate/import/reconcile operations without reading or validating the provided source. 
- Ensure automated reconciliation CLI paths surface missing, malformed, or unsupported statement inputs with non-success exit codes instead of silently succeeding.

### Description
- Added a `ValidateSourceAccess` helper to `StatementReconciliationService` that enforces non-empty `sourceKind`/`sourcePath`, only allows `local` for now, and checks `File.Exists` prior to operations. 
- Made `ValidateAsync`, `ImportAsync`, and `ReconcileAsync` call the validator and use a normalized `sourceKind` when computing the import fingerprint. 
- Updated `ImportAsync` to compute `RowCount` from the actual file contents using `File.ReadLines(sourcePath).Count()` instead of always returning `0`. 
- Updated `StatementCommands` to catch `FileNotFoundException`, `NotSupportedException`, and `ArgumentException` and return appropriate `CliResult.Fail(...)` error codes instead of always returning `CliResult.Ok()`. 
- Added unit tests in `tests/Meridian.Tests/StatementReconciliationServiceTests.cs` for missing-file validation (`ValidateAsync_ThrowsWhenLocalFileMissing`) and row counting (`ImportAsync_CountsRowsForLocalFile`).

### Testing
- Added targeted unit tests `ValidateAsync_ThrowsWhenLocalFileMissing` and `ImportAsync_CountsRowsForLocalFile` in `StatementReconciliationServiceTests`. 
- Attempted to run the focused tests with `dotnet test --filter "FullyQualifiedName~StatementReconciliationServiceTests"`, but the execution environment lacked the `dotnet` runtime so the command could not be executed here. 
- Recommend running the full test suite (for example `dotnet test` or CI) to validate behavior in a proper .NET environment and to exercise the new tests and CLI error mappings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ab0ddb1c83208a63f9b8fd02c8d0)