### PR TITLE
Harden C# CodeQL workflow with manual build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
         - language: actions
           build-mode: none
         - language: csharp
-          build-mode: none
+          build-mode: manual
         - language: javascript-typescript
           build-mode: none
         - language: python
@@ -76,6 +76,20 @@ jobs:
 
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
+
+    - name: Setup .NET
+      if: matrix.language == 'csharp'
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '10.0.x'
+
+    - name: Restore C# solution
+      if: matrix.language == 'csharp'
+      run: dotnet restore Meridian.sln /p:EnableWindowsTargeting=true
+
+    - name: Build C# solution
+      if: matrix.language == 'csharp'
+      run: dotnet build Meridian.sln --configuration Release --no-restore /p:EnableWindowsTargeting=true
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/tests/scripts/test_project_target_framework_alignment.py
+++ b/tests/scripts/test_project_target_framework_alignment.py
@@ -86,13 +86,14 @@ class ProjectTargetFrameworkAlignmentTests(unittest.TestCase):
         self.assertIn("default: '10.0.x'", action)
         self.assertNotIn("default: '9.0.x'", action)
 
-    def test_codeql_csharp_analysis_does_not_restore_with_previous_sdk(self) -> None:
+    def test_codeql_csharp_analysis_builds_with_current_sdk(self) -> None:
         workflow = CODEQL_WORKFLOW.read_text(encoding="utf-8")
 
-        self.assertIn("- language: csharp\n          build-mode: none", workflow)
+        self.assertIn("- language: csharp\n          build-mode: manual", workflow)
+        self.assertIn("dotnet-version: '10.0.x'", workflow)
         self.assertNotIn("dotnet-version: '9.0.x'", workflow)
-        self.assertNotIn("Restore C# solution", workflow)
-        self.assertNotIn("Build C# solution", workflow)
+        self.assertIn("Restore C# solution", workflow)
+        self.assertIn("Build C# solution", workflow)
 
     def test_security_workflow_reports_current_platform(self) -> None:
         workflow = SECURITY_WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
### Motivation
- A recent change switched the C# CodeQL matrix to buildless analysis which reduces extraction fidelity for compiled C# projects and weakens the CI security gate.
- Restore the prior build-backed extraction so MSBuild-conditioned code, source-generator output, and Razor/build-time artifacts are available to CodeQL for more accurate analysis.

### Description
- Changed the CodeQL matrix entry for C# from `build-mode: none` to `build-mode: manual` in `.github/workflows/codeql.yml`.
- Added conditional `Setup .NET` (`actions/setup-dotnet@v4` with `dotnet-version: '10.0.x'`), `Restore C# solution` (`dotnet restore Meridian.sln`), and `Build C# solution` (`dotnet build Meridian.sln --no-restore`) steps that run when `matrix.language == 'csharp'` before analysis in `.github/workflows/codeql.yml`.
- Updated the workflow alignment test `tests/scripts/test_project_target_framework_alignment.py` to assert the C# entry uses `build-mode: manual`, validates `dotnet-version: '10.0.x'`, and requires the presence of `Restore C# solution` and `Build C# solution`.

### Testing
- Ran the targeted unit test with `python3 -m unittest tests.scripts.test_project_target_framework_alignment.ProjectTargetFrameworkAlignmentTests.test_codeql_csharp_analysis_builds_with_current_sdk` and it passed (`OK`).
- Confirmed the modified files are `.github/workflows/codeql.yml` and `tests/scripts/test_project_target_framework_alignment.py` and that the change is a minimal remediation preserving multi-language CodeQL behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a242d2fc8320a3fab9762d5dc989)