### PR TITLE
Include brokerage sync health in trading readiness acceptance gates

### DIFF
--- a/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
@@ -228,6 +228,7 @@ public sealed class TradingOperatorReadinessService
             trustGate,
             reportPack,
             reconciliationGate,
+            brokerageStatus,
             auditEntries);
         var overallStatus = ResolveOverallStatus(acceptanceGates);
         var evidenceCompleteness = BuildEvidenceCompleteness(acceptanceGates, workItems);
@@ -762,6 +763,7 @@ public sealed class TradingOperatorReadinessService
         TradingTrustGateReadinessDto trustGate,
         TradingReportPackReadinessDto reportPack,
         ReconciliationGateEvaluation? reconciliationGate,
+        WorkstationBrokerageSyncStatusDto? brokerageStatus,
         IReadOnlyList<ExecutionAuditEntry> auditEntries)
         =>
         [
@@ -771,8 +773,39 @@ public sealed class TradingOperatorReadinessService
             BuildPromotionGate(promotion),
             BuildTrustGateAcceptance(trustGate),
             BuildReportPackGate(reportPack),
-            BuildReconciliationGate(reconciliationGate)
+            BuildReconciliationGate(reconciliationGate),
+            BuildBrokerageSyncGate(brokerageStatus)
         ];
+
+
+    private static TradingAcceptanceGateDto BuildBrokerageSyncGate(WorkstationBrokerageSyncStatusDto? brokerageStatus)
+    {
+        if (brokerageStatus is null)
+        {
+            return new TradingAcceptanceGateDto(
+                GateId: "brokerage-sync",
+                Label: "Brokerage sync",
+                Status: TradingAcceptanceGateStatusDto.Ready,
+                Detail: "Brokerage sync gate is not account-scoped for this readiness query.");
+        }
+
+        var status = brokerageStatus.Health switch
+        {
+            WorkstationBrokerageSyncHealth.Healthy => TradingAcceptanceGateStatusDto.Ready,
+            WorkstationBrokerageSyncHealth.Degraded => TradingAcceptanceGateStatusDto.ReviewRequired,
+            WorkstationBrokerageSyncHealth.Failed => TradingAcceptanceGateStatusDto.Blocked,
+            _ => TradingAcceptanceGateStatusDto.ReviewRequired
+        };
+
+        return new TradingAcceptanceGateDto(
+            GateId: "brokerage-sync",
+            Label: "Brokerage sync",
+            Status: status,
+            Detail: brokerageStatus.Warnings.FirstOrDefault()
+                ?? brokerageStatus.LastError
+                ?? $"Brokerage sync health is {brokerageStatus.Health}.",
+            FundAccountId: brokerageStatus.FundAccountId);
+    }
 
     private static TradingAcceptanceGateDto BuildSessionGate(
         TradingPaperSessionReadinessDto? activeSession,


### PR DESCRIPTION
### Motivation
- Prevent `ReadyForPaperOperation` from being reported true when an account-scoped brokerage sync has failed by ensuring brokerage sync health affects overall readiness instead of only creating an operator work item.

### Description
- Pass the account-scoped `brokerageStatus` into `BuildAcceptanceGates` in `TradingOperatorReadinessService` so gates can be computed with brokerage context.
- Add `BuildBrokerageSyncGate(WorkstationBrokerageSyncStatusDto?)` which maps `Healthy` → `Ready`, `Degraded` → `ReviewRequired`, and `Failed` → `Blocked` and returns a `brokerage-sync` gate.
- Include the new `brokerage-sync` gate in the acceptance gate list so `ResolveOverallStatus` and `ReadyForPaperOperation` reflect brokerage sync health.
- Keep the existing operator work item creation for brokerage sync intact and continue to populate `TradingOperatorReadinessDto.BrokerageSync`.

### Testing
- Could not run automated `dotnet` tests because the `dotnet` CLI is not available in this environment (`/bin/bash: dotnet: command not found`).
- Validated the change via source inspection and diffs of `src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs` to confirm `brokerageStatus` is passed into gate construction and `BuildBrokerageSyncGate` was added and included in the gates list.
- Performed repository searches and file excerpts (`rg`, `sed`, `nl`) to verify the new gate is present and used by `ResolveOverallStatus`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cc0a148883208aac58512db4c4c5)