### PR TITLE
fix: redact DK1 trust gate filesystem paths in readiness API

### DIFF
--- a/src/Meridian.Ui.Shared/Services/Dk1TrustGateReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/Dk1TrustGateReadinessService.cs
@@ -101,24 +101,24 @@ public sealed class Dk1TrustGateReadinessService
         if (packetPath is null)
         {
             return CreateUnavailable(
-                $"No DK1 pilot parity packet was found under {NormalizePath(automationRoot)}.");
+                "No DK1 pilot parity packet was found under the configured automation root.");
         }
 
         try
         {
             await using var stream = File.OpenRead(packetPath);
             using var document = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
-            return BuildReadinessFromPacket(packetPath, document.RootElement);
+            return BuildReadinessFromPacket(packetPath, automationRoot, document.RootElement);
         }
         catch (Exception ex) when (ex is IOException or JsonException or UnauthorizedAccessException)
         {
             _logger.LogWarning(ex, "Unable to read DK1 pilot parity packet at {PacketPath}.", packetPath);
             return CreateUnavailable(
-                $"DK1 pilot parity packet could not be read from {NormalizePath(packetPath)}.");
+                "DK1 pilot parity packet could not be read from the automation archive.");
         }
     }
 
-    private TradingTrustGateReadinessDto BuildReadinessFromPacket(string packetPath, JsonElement root)
+    private TradingTrustGateReadinessDto BuildReadinessFromPacket(string packetPath, string automationRoot, JsonElement root)
     {
         var status = GetString(root, "status") ?? "unknown";
         var generatedAt = TryParseDateTimeOffset(GetString(root, "generatedAtUtc"));
@@ -178,7 +178,7 @@ public sealed class Dk1TrustGateReadinessService
             OperatorSignoffRequired: operatorSignoffRequired,
             OperatorSignoffStatus: operatorSignoffStatus,
             GeneratedAt: generatedAt,
-            PacketPath: NormalizePath(packetPath),
+            PacketPath: BuildDisplayPacketPath(packetPath, automationRoot),
             SourceSummary: sourceSummary,
             RequiredSampleCount: requiredSampleCount,
             ReadySampleCount: readySampleCount,
@@ -266,6 +266,34 @@ public sealed class Dk1TrustGateReadinessService
             .OrderByDescending(file => file.LastWriteTimeUtc)
             .Select(file => file.FullName)
             .FirstOrDefault();
+    }
+
+    private static string? BuildDisplayPacketPath(string? packetPath, string automationRoot)
+    {
+        if (string.IsNullOrWhiteSpace(packetPath))
+        {
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(automationRoot))
+        {
+            return Path.GetFileName(packetPath);
+        }
+
+        try
+        {
+            var relativePath = Path.GetRelativePath(automationRoot, packetPath);
+            if (relativePath.StartsWith("..", StringComparison.Ordinal))
+            {
+                return Path.GetFileName(packetPath);
+            }
+
+            return NormalizePath(relativePath);
+        }
+        catch (ArgumentException)
+        {
+            return Path.GetFileName(packetPath);
+        }
     }
 
     private static string BuildDetail(

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -1331,6 +1331,31 @@ public sealed class WorkstationEndpointsTests
         readiness.Blockers.Should().BeEmpty();
         readiness.TrustRationaleContract.Should().NotBeNull();
         readiness.TrustRationaleContract!.Status.Should().Be("validated");
+        readiness.PacketPath.Should().NotBeNull();
+        Path.IsPathRooted(readiness.PacketPath!).Should().BeFalse();
+        readiness.PacketPath.Should().Contain("dk1-pilot-parity-packet.json");
+    }
+
+    [Fact]
+    public async Task Dk1TrustGateReadinessService_WhenPacketMissing_ShouldNotDiscloseFilesystemPaths()
+    {
+        var automationRoot = Path.Combine(
+            Path.GetTempPath(),
+            "meridian-tests",
+            "dk1-missing-packet",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(automationRoot);
+
+        var service = new Dk1TrustGateReadinessService(
+            new Dk1TrustGateReadinessOptions(automationRoot),
+            NullLogger<Dk1TrustGateReadinessService>.Instance);
+
+        var readiness = await service.GetCurrentAsync();
+
+        readiness.Status.Should().Be("packet-unavailable");
+        readiness.PacketPath.Should().BeNull();
+        readiness.Detail.Should().Be("No DK1 pilot parity packet was found under the configured automation root.");
+        readiness.Detail.Should().NotContain(NormalizePathForAssertion(automationRoot));
     }
 
     [Fact]
@@ -2807,6 +2832,9 @@ public sealed class WorkstationEndpointsTests
             throw new InvalidOperationException(message);
         }
     }
+
+    private static string NormalizePathForAssertion(string path) =>
+        path.Replace(Path.DirectorySeparatorChar, '/');
 
     private sealed class ThrowingReconciliationBreakQueueRepository : IReconciliationBreakQueueRepository
     {


### PR DESCRIPTION
### Motivation

- Prevent disclosure of absolute server filesystem paths and deployment/user details through the workstation readiness API by removing absolute `PacketPath` and filesystem hints from user-facing fields.

### Description

- Change `Dk1TrustGateReadinessService` to emit a safe display path instead of an absolute path by adding `BuildDisplayPacketPath(packetPath, automationRoot)` and using it for `PacketPath` in the DTO (file: `src/Meridian.Ui.Shared/Services/Dk1TrustGateReadinessService.cs`).
- Make missing/unreadable-packet messages generic and remove embedded normalized filesystem roots/paths from readiness `Detail` strings (file: `src/Meridian.Ui.Shared/Services/Dk1TrustGateReadinessService.cs`).
- Update `BuildReadinessFromPacket` signature to accept the resolved automation root so the display path can be computed relative to it (file: `src/Meridian.Ui.Shared/Services/Dk1TrustGateReadinessService.cs`).
- Add and adjust unit tests that assert `PacketPath` is not rooted and that missing-packet details do not contain filesystem paths (file: `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs`).

### Testing

- Added targeted unit tests in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` that validate `PacketPath` redaction and missing-packet message behavior (not executed in this environment).
- Attempted to run the focused test filter `dotnet test --filter "FullyQualifiedName~Dk1TrustGateReadinessService_"`, but the execution environment does not have the .NET SDK installed so the test run failed with `dotnet: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d56af5e08320b52dde62e1ee6de4)