### PR TITLE
Mitigate CSV formula injection in governance report-pack exports

### DIFF
--- a/src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs
+++ b/src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs
@@ -1033,9 +1033,24 @@ public sealed class FundOperationsWorkspaceReadService
             _ => value.ToString() ?? string.Empty
         };
 
+        if (IsPotentialSpreadsheetFormula(text))
+        {
+            text = $"'{text}";
+        }
+
         return text.IndexOfAny(['"', ',', '\r', '\n']) < 0
             ? text
             : $"\"{text.Replace("\"", "\"\"", StringComparison.Ordinal)}\"";
+    }
+
+    private static bool IsPotentialSpreadsheetFormula(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+
+        return text[0] is '=' or '+' or '-' or '@' or '\t' or '\r';
     }
 
     private static IReadOnlyList<string> BuildReportPackWarnings(


### PR DESCRIPTION
### Motivation
- Prevent attacker-controlled ledger and Security Master text fields from being interpreted as active spreadsheet formulas when opening generated governance CSV artifacts (e.g. `trial-balance.csv`, `asset-class-sections.csv`).

### Description
- Neutralize potential spreadsheet formulas by prefixing a single quote for values starting with `=`, `+`, `-`, `@`, tab, or carriage-return in `EscapeCsvValue` and added `IsPotentialSpreadsheetFormula` in `src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs`, preserving existing CSV quoting for commas/quotes/newlines.

### Testing
- No automated .NET tests were run because `dotnet` was unavailable in the execution environment (`/bin/bash: dotnet: command not found`), so there are no test results to report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cd19830c8320b93f063ebc2dfe20)