### PR TITLE
Validate canonical security-id matches requested symbol/identifier

### DIFF
--- a/src/Meridian.Ui.Shared/Services/SecurityMasterSecurityReferenceLookup.cs
+++ b/src/Meridian.Ui.Shared/Services/SecurityMasterSecurityReferenceLookup.cs
@@ -40,7 +40,14 @@ public sealed class SecurityMasterSecurityReferenceLookup : ISecurityReferenceLo
         if (request.SecurityId is Guid securityId)
         {
             detail = await _queryService.GetByIdAsync(securityId, ct).ConfigureAwait(false);
-            lookupPath = "security-id";
+            if (detail is not null && MatchesRequest(detail, request))
+            {
+                lookupPath = "security-id";
+            }
+            else
+            {
+                detail = null;
+            }
         }
 
         if (detail is null)
@@ -104,6 +111,24 @@ public sealed class SecurityMasterSecurityReferenceLookup : ISecurityReferenceLo
             LookupSource: request.Source,
             IsInferredMatch: inferred,
             RiskCountry: riskCountry);
+    }
+
+    private static bool MatchesRequest(SecurityDetailDto detail, SecurityReferenceLookupRequest request)
+    {
+        var requestedSymbol = request.Symbol;
+        var requestedIdentifier = request.IdentifierValue;
+
+        if (string.IsNullOrWhiteSpace(requestedSymbol) && string.IsNullOrWhiteSpace(requestedIdentifier))
+        {
+            return true;
+        }
+
+        return detail.Identifiers.Any(
+            identifier =>
+                (!string.IsNullOrWhiteSpace(requestedSymbol)
+                 && string.Equals(identifier.Value, requestedSymbol, StringComparison.OrdinalIgnoreCase))
+                || (!string.IsNullOrWhiteSpace(requestedIdentifier)
+                    && string.Equals(identifier.Value, requestedIdentifier, StringComparison.OrdinalIgnoreCase)));
     }
 
     /// <summary>

--- a/tests/Meridian.Tests/SecurityMaster/SecurityMasterReferenceLookupTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityMasterReferenceLookupTests.cs
@@ -178,6 +178,77 @@ public sealed class SecurityMasterReferenceLookupTests
         result.SubType.Should().BeNull();
     }
 
+    [Fact]
+    public async Task GetByCanonicalAsync_WithMismatchedSecurityId_FallsBackToIdentifierLookup()
+    {
+        var requestedSecurityId = Guid.NewGuid();
+        var mismatchedDetail = BuildDetail(
+            requestedSecurityId,
+            "Equity",
+            [new SecurityIdentifierDto(SecurityIdentifierKind.Ticker, "MSFT", true, DateTimeOffset.UtcNow, null, null)]);
+        var expectedDetail = BuildDetail(
+            Guid.NewGuid(),
+            "Equity",
+            [new SecurityIdentifierDto(SecurityIdentifierKind.Ticker, "AAPL", true, DateTimeOffset.UtcNow, null, null)]);
+
+        var queryService = Substitute.For<ISecurityMasterQueryService>();
+        queryService.GetByIdAsync(requestedSecurityId, Arg.Any<CancellationToken>()).Returns(mismatchedDetail);
+        queryService.GetByIdentifierAsync(SecurityIdentifierKind.Ticker, "AAPL", "XNYS", Arg.Any<CancellationToken>())
+            .Returns(expectedDetail);
+
+        var lookup = new SecurityMasterSecurityReferenceLookup(queryService);
+
+        var result = await lookup.GetByCanonicalAsync(
+            new SecurityReferenceLookupRequest(
+                SecurityId: requestedSecurityId,
+                IdentifierKind: SecurityIdentifierKind.Ticker.ToString(),
+                IdentifierValue: "AAPL",
+                Symbol: "AAPL",
+                Venue: "XNYS",
+                Source: "test"));
+
+        result.Should().NotBeNull();
+        result!.SecurityId.Should().Be(expectedDetail.SecurityId);
+        result.LookupPath.Should().Be("identifier+venue");
+        await queryService.Received(1).GetByIdentifierAsync(
+            SecurityIdentifierKind.Ticker,
+            "AAPL",
+            "XNYS",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetByCanonicalAsync_WithMatchingSecurityId_ReturnsSecurityIdMatch()
+    {
+        var requestedSecurityId = Guid.NewGuid();
+        var matchingDetail = BuildDetail(
+            requestedSecurityId,
+            "Equity",
+            [new SecurityIdentifierDto(SecurityIdentifierKind.Ticker, "AAPL", true, DateTimeOffset.UtcNow, null, null)]);
+
+        var queryService = Substitute.For<ISecurityMasterQueryService>();
+        queryService.GetByIdAsync(requestedSecurityId, Arg.Any<CancellationToken>()).Returns(matchingDetail);
+
+        var lookup = new SecurityMasterSecurityReferenceLookup(queryService);
+
+        var result = await lookup.GetByCanonicalAsync(
+            new SecurityReferenceLookupRequest(
+                SecurityId: requestedSecurityId,
+                IdentifierKind: SecurityIdentifierKind.Ticker.ToString(),
+                IdentifierValue: "AAPL",
+                Symbol: "AAPL",
+                Venue: "XNYS",
+                Source: "test"));
+
+        result.Should().NotBeNull();
+        result!.LookupPath.Should().Be("security-id");
+        await queryService.DidNotReceive().GetByIdentifierAsync(
+            Arg.Any<SecurityIdentifierKind>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
     [Theory]
     [InlineData("Bond", "Bond")]
     [InlineData("TreasuryBill", "TreasuryBill")]


### PR DESCRIPTION
### Motivation
- The canonical lookup path accepted any `SecurityId` hit from ledger/run metadata as authoritative without verifying that the fetched security actually contains the requested ticker/identifier or venue, allowing crafted metadata to forge resolved Security Master matches and suppress reconciliation coverage issues.
- Change intent: ensure `SecurityId`-based resolution is only accepted when the resolved record contains the requested identifier/symbol, and otherwise fall back to identifier(+venue) resolution to preserve integrity of workstation/reconciliation surfaces.

### Description
- Hardened `SecurityMasterSecurityReferenceLookup.GetByCanonicalAsync` to validate `GetByIdAsync` results with a new `MatchesRequest` helper and only accept a `security-id` lookup when the fetched `SecurityDetailDto` contains the requested symbol or identifier value.
- When the fetched security does not match the request, the code now sets `detail = null` and continues with identifier (and venue) lookup instead of returning a misleading resolved reference.
- Added focused unit tests `GetByCanonicalAsync_WithMismatchedSecurityId_FallsBackToIdentifierLookup` and `GetByCanonicalAsync_WithMatchingSecurityId_ReturnsSecurityIdMatch` to cover the mismatch fallback and the matching `security-id` path.
- Files changed: `src/Meridian.Ui.Shared/Services/SecurityMasterSecurityReferenceLookup.cs` and `tests/Meridian.Tests/SecurityMaster/SecurityMasterReferenceLookupTests.cs`.

### Testing
- Added unit tests under `tests/Meridian.Tests/SecurityMaster/SecurityMasterReferenceLookupTests.cs` exercising both matching and mismatched `SecurityId` scenarios but these are new tests and were not executed in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`).
- No automated test run could be completed here due to the environment limitation; the new tests should be run in CI or a developer environment with the .NET SDK using `dotnet test` to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cd1a1ae88320b35daf2565e33f29)