### PR TITLE
fix: make security master conflict detection non-blocking

### DIFF
--- a/src/Meridian.Application/SecurityMaster/SecurityMasterService.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterService.cs
@@ -256,18 +256,24 @@ public sealed class SecurityMasterService : ISecurityMasterService, ISecurityMas
         });
     }
 
-    private async Task TryRecordConflictsAsync(SecurityProjectionRecord projection, Guid securityId, CancellationToken ct)
+    private Task TryRecordConflictsAsync(SecurityProjectionRecord projection, Guid securityId, CancellationToken ct)
     {
         if (_conflictService is null)
-            return;
-        try
+            return Task.CompletedTask;
+
+        _ = Task.Run(async () =>
         {
-            await _conflictService.RecordConflictsForProjectionAsync(projection, ct).ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Conflict detection failed for security {SecurityId}", securityId);
-        }
+            try
+            {
+                await _conflictService.RecordConflictsForProjectionAsync(projection, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Conflict detection failed for security {SecurityId}", securityId);
+            }
+        }, CancellationToken.None);
+
+        return Task.CompletedTask;
     }
 
     private static SecurityProjectionRecord CreateProjectionFromResult(


### PR DESCRIPTION
### Motivation
- Prevent create/amend write paths from blocking on an O(N) full-store conflict scan that can cause O(N^2) read amplification and availability degradation as the security master grows.

### Description
- Change `TryRecordConflictsAsync` in `src/Meridian.Application/SecurityMaster/SecurityMasterService.cs` to schedule `_conflictService.RecordConflictsForProjectionAsync(...)` via `Task.Run` and return immediately, preserving best-effort behavior and existing warning logging on failure.

### Testing
- No project unit or integration tests were executed in this environment because `dotnet` is not available (`dotnet --version` failed); only repository operations (`git status`, commit) were performed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f843cfd1788320b5e857321f4837e9)