### PR TITLE
fix(execution): recompute paper cost basis after lot consumption

### DIFF
--- a/src/Meridian.Execution/Services/PaperTradingPortfolio.cs
+++ b/src/Meridian.Execution/Services/PaperTradingPortfolio.cs
@@ -984,7 +984,25 @@ internal sealed class PaperPosition(string symbol, decimal marketPrice = 0m)
             }
         }
 
+        CostBasis = CalculateRemainingLotCostBasis(isCoveringShort);
+
         return removedCostBasis;
+    }
+
+    private decimal CalculateRemainingLotCostBasis(bool isCoveringShort)
+    {
+        var remainingLots = isCoveringShort
+            ? _lots.Where(static lot => lot.OpenQuantity < 0m)
+            : _lots.Where(static lot => lot.OpenQuantity > 0m);
+
+        var remainingQuantity = remainingLots.Sum(static lot => Math.Abs(lot.OpenQuantity));
+        if (remainingQuantity == 0m)
+        {
+            return 0m;
+        }
+
+        var remainingNotional = remainingLots.Sum(static lot => Math.Abs(lot.OpenQuantity) * lot.EntryPrice);
+        return remainingNotional / remainingQuantity;
     }
 
     private PositionLot? SelectNextLot(PositionLotSelectionMethod method, bool isCoveringShort)

--- a/tests/Meridian.Tests/Execution/PaperTradingPortfolioLotSelectionTests.cs
+++ b/tests/Meridian.Tests/Execution/PaperTradingPortfolioLotSelectionTests.cs
@@ -31,6 +31,30 @@ public sealed class PaperTradingPortfolioLotSelectionTests
         portfolio.RealisedPnl.Should().Be(300m);
     }
 
+    [Fact]
+    public void ApplyFill_WhenPartiallySellingLong_RecomputesRemainingCostBasisFromLots()
+    {
+        var portfolio = new PaperTradingPortfolio(100_000m);
+
+        portfolio.ApplyFill(BuildFill("AAPL", OrderSide.Buy, 10, 100m));
+        portfolio.ApplyFill(BuildFill("AAPL", OrderSide.Buy, 10, 120m));
+        portfolio.ApplyFill(BuildFill("AAPL", OrderSide.Sell, 10, 130m));
+
+        portfolio.GetPositions().Single().CostBasis.Should().Be(120m);
+    }
+
+    [Fact]
+    public void ApplyFill_WhenPartiallyCoveringShort_RecomputesRemainingCostBasisFromLots()
+    {
+        var portfolio = new PaperTradingPortfolio(100_000m);
+
+        portfolio.ApplyFill(BuildFill("AAPL", OrderSide.Sell, 10, 100m));
+        portfolio.ApplyFill(BuildFill("AAPL", OrderSide.Sell, 10, 120m));
+        portfolio.ApplyFill(BuildFill("AAPL", OrderSide.Buy, 10, 90m));
+
+        portfolio.GetPositions().Single().CostBasis.Should().Be(120m);
+    }
+
     private static ExecutionReport BuildFill(string symbol, OrderSide side, decimal quantity, decimal price) =>
         new()
         {


### PR DESCRIPTION
### Motivation

- The lot-aware close logic consumed individual PositionLot entries for realised P&L but left the owning `PaperPosition.CostBasis` stale after partial closes, causing incorrect `AverageCostBasis` and `UnrealisedPnl` and compounding errors on future buys or covers.

### Description

- Recompute `PaperPosition.CostBasis` from the surviving lots after `ConsumeLots(...)` mutates or removes lots to ensure the position basis reflects remaining lot-weighted entry prices.
- Added a focused helper `CalculateRemainingLotCostBasis(bool isCoveringShort)` that computes the weighted-average entry price for remaining same-sided lots and returns `0m` when none remain.
- Preserved existing lot-selection behavior (FIFO/LIFO/HIFO) and the realised P&L calculation returned by `ConsumeLots(...)` while making the basis correction local to the `PaperPosition` implementation.
- Files changed: `src/Meridian.Execution/Services/PaperTradingPortfolio.cs` and tests added to `tests/Meridian.Tests/Execution/PaperTradingPortfolioLotSelectionTests.cs` covering partial long sell and partial short cover basis recomputation.

### Testing

- Added two unit tests: `ApplyFill_WhenPartiallySellingLong_RecomputesRemainingCostBasisFromLots` and `ApplyFill_WhenPartiallyCoveringShort_RecomputesRemainingCostBasisFromLots` under `PaperTradingPortfolioLotSelectionTests` to assert the remaining basis equals the surviving lot price.
- Attempted to run the focused test filter with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~PaperTradingPortfolioLotSelectionTests" --logger "console;verbosity=minimal"` but the environment lacks `dotnet` (`/bin/bash: dotnet: command not found`), so tests could not be executed here.
- Tests are included in the PR and expected to pass in CI where the .NET SDK is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ab0e04f48320b59ee3638cb1eac4)