### PR TITLE
Fix reconciliation primary identifier kind mapping

### DIFF
--- a/src/Meridian.Strategies/Services/ReconciliationRunService.cs
+++ b/src/Meridian.Strategies/Services/ReconciliationRunService.cs
@@ -267,7 +267,7 @@ public sealed class ReconciliationRunService : IReconciliationRunService
                     map[position.Symbol] = new SecurityClassificationSummaryDto(
                         AssetClass: position.Security.AssetClass,
                         SubType: position.Security.SubType,
-                        PrimaryIdentifierKind: position.Security.MatchedIdentifierKind ?? "Ticker",
+                        PrimaryIdentifierKind: "Ticker",
                         PrimaryIdentifierValue: position.Security.PrimaryIdentifier ?? position.Symbol,
                         MatchedIdentifierKind: position.Security.MatchedIdentifierKind,
                         MatchedIdentifierValue: position.Security.MatchedIdentifierValue,
@@ -287,7 +287,7 @@ public sealed class ReconciliationRunService : IReconciliationRunService
                     map[line.Symbol] = new SecurityClassificationSummaryDto(
                         AssetClass: line.Security.AssetClass,
                         SubType: line.Security.SubType,
-                        PrimaryIdentifierKind: line.Security.MatchedIdentifierKind ?? "Ticker",
+                        PrimaryIdentifierKind: "Ticker",
                         PrimaryIdentifierValue: line.Security.PrimaryIdentifier ?? line.Symbol,
                         MatchedIdentifierKind: line.Security.MatchedIdentifierKind,
                         MatchedIdentifierValue: line.Security.MatchedIdentifierValue,

--- a/tests/Meridian.Tests/Application/ReconciliationRunServiceTests.cs
+++ b/tests/Meridian.Tests/Application/ReconciliationRunServiceTests.cs
@@ -115,7 +115,7 @@ public sealed class ReconciliationRunServiceTests
         detail.SecurityClassifications!.Should().ContainKey("AAPL");
         detail.SecurityClassifications["AAPL"].AssetClass.Should().Be("Equity");
         detail.SecurityClassifications["AAPL"].SubType.Should().Be("CommonShare");
-        detail.SecurityClassifications["AAPL"].PrimaryIdentifierKind.Should().Be("ISIN");
+        detail.SecurityClassifications["AAPL"].PrimaryIdentifierKind.Should().Be("Ticker");
         detail.SecurityClassifications["AAPL"].PrimaryIdentifierValue.Should().Be("AAPL");
         detail.SecurityClassifications["AAPL"].MatchedIdentifierKind.Should().Be("ISIN");
         detail.SecurityClassifications["AAPL"].MatchedIdentifierValue.Should().Be("US0378331005");


### PR DESCRIPTION
### Motivation
- Fix a data-integrity regression where `PrimaryIdentifierKind` was being set from the matched identifier kind, producing inconsistent `PrimaryIdentifierKind: <matched-kind>` paired with `PrimaryIdentifierValue: <primary-value>` in reconciliation classifications.

### Description
- Change `BuildSecurityClassifications` to set `PrimaryIdentifierKind` to `"Ticker"` for both portfolio and ledger paths (keeping `MatchedIdentifierKind`/`MatchedIdentifierValue` intact) and update the unit test assertion in `ReconciliationRunServiceTests` to expect `"Ticker"` for the AAPL case.

### Testing
- Attempted a focused automated test run `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~RunAsync_WithSecurityLookup_ShouldPopulateAuthoritativeSecurityReferences"`, but the run could not be executed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cf4113848320be94db7ab1da611f)