### PR TITLE
Fix contract compatibility gate path coverage

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -82,6 +82,9 @@ jobs:
           continuity_contracts:
             - 'src/Meridian.Contracts/Workstation/**'
             - 'src/Meridian.Contracts/Api/**'
+            - 'src/Meridian.Strategies/Services/**'
+            - 'src/Meridian.Ledger/**'
+            - 'src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs'
 
     - name: Capture PR body
       if: steps.continuity-filter.outputs.continuity_contracts == 'true'
@@ -120,7 +123,7 @@ jobs:
 
     - name: Skip note when no continuity contract files changed
       if: steps.continuity-filter.outputs.continuity_contracts != 'true'
-      run: echo "Contract compatibility gate skipped because this PR does not touch src/Meridian.Contracts/Workstation or src/Meridian.Contracts/Api." >> $GITHUB_STEP_SUMMARY
+      run: echo "Contract compatibility gate skipped because this PR does not touch any tracked shared-contract surfaces (Contracts/Workstation, Contracts/Api, Strategies/Services, Ledger, or Ui.Shared WorkstationEndpoints)." >> $GITHUB_STEP_SUMMARY
 
   config-schema:
     name: Config Schema Check


### PR DESCRIPTION
### Motivation
- The PR workflow used `dorny/paths-filter` that only matched `Contracts/Workstation` and `Contracts/Api`, which let changes to other tracked shared-contract surfaces skip the compatibility gate and review-packet generation.
- The gate (`scripts/check_contract_compatibility_gate.py`) and the compatibility matrix document a broader set of tracked surfaces, so the workflow must include those paths to preserve CI governance.

### Description
- Expanded the continuity contract filter in `.github/workflows/pr-checks.yml` to include `src/Meridian.Strategies/Services/**`, `src/Meridian.Ledger/**`, and `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` so the job triggers for all tracked surfaces.
- Updated the skip-note echo in `.github/workflows/pr-checks.yml` to list the full tracked shared-contract surface set when no matched files are changed.
- No changes were made to the gate script or the compatibility matrix; this is a minimal workflow fix that preserves existing gate behavior.

### Testing
- Ran `python3 -m unittest tests/scripts/test_check_contract_compatibility_gate.py` and all tests passed (`Ran 12 tests — OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ab0ed764832098c31790b7ad1179)