### PR TITLE
Clamp legacy timing date reconstruction to prevent overflow

### DIFF
--- a/src/Meridian.FSharp.Ledger/ReconciliationClassification.fs
+++ b/src/Meridian.FSharp.Ledger/ReconciliationClassification.fs
@@ -333,6 +333,17 @@ module ReconciliationClassification =
 
     /// Migration helper to safely map legacy break discriminators into the new canonical model.
     let classifyLegacy (nominalAmount: decimal) (legacy: LedgerBreakClassification) : CanonicalBreakClassification =
+        let minLegacyTimingDays = (DateTimeOffset.MinValue - DateTimeOffset.UnixEpoch).TotalDays
+        let maxLegacyTimingDays = (DateTimeOffset.MaxValue - DateTimeOffset.UnixEpoch).TotalDays
+
+        let safeLegacyTimingDate (daysLate: int) : DateTimeOffset =
+            let boundedDays =
+                daysLate
+                |> float
+                |> max minLegacyTimingDays
+                |> min maxLegacyTimingDays
+            DateTimeOffset.UnixEpoch.AddDays(boundedDays)
+
         let baseline: RawBreakFacts = {
             BreakType = None
             ExpectedQuantity = None
@@ -366,7 +377,7 @@ module ReconciliationClassification =
                 { baseline with
                     BreakType = Some "timing"
                     ExpectedSettlementDate = Some DateTimeOffset.UnixEpoch
-                    ActualSettlementDate = Some (DateTimeOffset.UnixEpoch.AddDays(float daysLate))
+                    ActualSettlementDate = Some (safeLegacyTimingDate daysLate)
                     TimingToleranceDays = 0 }
             | MissingEntry ->
                 { baseline with BreakType = Some "mapping-error"; MappingResolved = Some false }


### PR DESCRIPTION
### Motivation
- Prevent `ArgumentOutOfRangeException` when legacy `TimingBreak` day counts reconstructed as dates exceed the `DateTimeOffset` range and crash reconciliation classification. 
- Ensure canonical `classifyLegacy` remains stable when fed extreme but valid provider/imported date gaps.

### Description
- Added bounds calculation using `DateTimeOffset.MinValue`/`MaxValue` relative to `DateTimeOffset.UnixEpoch` and introduced `safeLegacyTimingDate` to clamp `daysLate` before calling `AddDays` in `classifyLegacy`.
- Replaced the direct `DateTimeOffset.UnixEpoch.AddDays(float daysLate)` call with `safeLegacyTimingDate` for the `TimingBreak` case in `src/Meridian.FSharp.Ledger/ReconciliationClassification.fs`.
- Kept the original canonical classification shape and severity computation intact; change only affects reconstruction of the synthetic `ActualSettlementDate` for legacy timing breaks.

### Testing
- Attempted to run targeted F# tests with `dotnet test tests/Meridian.FSharp.Tests/Meridian.FSharp.Tests.fsproj`, but the environment lacks the .NET SDK and the command failed with `/bin/bash: dotnet: command not found` so automated tests could not be executed here.
- The change is intentionally minimal and local to `classifyLegacy` to reduce regression risk; recommend running the repository test suite (`dotnet test`, `make test`) in a CI environment with .NET installed to validate behavior and coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b03f9cac8320a63c235243de394e)