### PR TITLE
fix: emit GUIDs as uuid strings in config schema

### DIFF
--- a/config/appsettings.schema.json
+++ b/config/appsettings.schema.json
@@ -1063,16 +1063,8 @@
       }
     },
     "Guid": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "Variant": {
-          "type": "integer"
-        },
-        "Version": {
-          "type": "integer"
-        }
-      }
+      "type": "string",
+      "format": "uuid"
     },
     "IBClientPortalOptions": {
       "type": "object",

--- a/src/Meridian.Application/Config/ConfigJsonSchemaGenerator.cs
+++ b/src/Meridian.Application/Config/ConfigJsonSchemaGenerator.cs
@@ -143,6 +143,15 @@ public sealed class ConfigJsonSchemaGenerator
             return CreateTypedSchema("string");
         }
 
+        if (type == typeof(Guid))
+        {
+            return new JsonObject
+            {
+                ["type"] = "string",
+                ["format"] = "uuid"
+            };
+        }
+
         if (type.IsEnum)
         {
             return new JsonObject


### PR DESCRIPTION
### Motivation

- The generated `config/appsettings.schema.json` documented `Guid` as an object with `Variant`/`Version` fields which mismatches the runtime `Guid?` representation and can mislead IDE schema validation/autocomplete. 
- Ensure the schema and generator represent GUIDs as standard GUID strings so operator-authored configuration validates against both the schema and runtime binding.

### Description

- Add a `Guid` special-case to `ConfigJsonSchemaGenerator` so `Guid` types are emitted as JSON Schema `{"type":"string","format":"uuid"}` instead of an object definition. 
- Update the checked-in `config/appsettings.schema.json` `$defs.Guid` entry to `{"type":"string","format":"uuid"}` to match runtime `Guid?` expectations. 
- Changes are localized to `src/Meridian.Application/Config/ConfigJsonSchemaGenerator.cs` and `config/appsettings.schema.json`.

### Testing

- Confirmed the problematic `$defs.Guid` object shape was present before the fix by inspecting `config/appsettings.schema.json` with `nl`/`sed` and `rg`. 
- Verified the generator source now contains a `Guid` branch that emits `type: string` and `format: uuid` by inspecting `src/Meridian.Application/Config/ConfigJsonSchemaGenerator.cs`. 
- Confirmed the checked-in schema file now contains `"format": "uuid"` in `$defs.Guid` with `rg` and `nl` validations. 
- Attempted to regenerate the schema via `dotnet run --project src/Meridian/Meridian.csproj -- --generate-config-schema`, but the environment lacks `dotnet` so regeneration could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cd1c865c8320afa307a40743823e)