### PR TITLE
Serialize structured product terms in economic definition JSON

### DIFF
--- a/src/Meridian.Application/SecurityMaster/SecurityEconomicDefinitionAdapter.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityEconomicDefinitionAdapter.cs
@@ -182,6 +182,24 @@ internal static class SecurityEconomicDefinitionAdapter
                 weightedAverageMaturityDays = definition.Terms.Fund.Value.WeightedAverageMaturityDays,
                 sweepEligible = definition.Terms.Fund.Value.SweepEligible,
                 liquidityFeeEligible = definition.Terms.Fund.Value.LiquidityFeeEligible
+            },
+            structuredProduct = definition.Terms.StructuredProduct is null ? null : new
+            {
+                factor = definition.Terms.StructuredProduct.Value.Factor,
+                factorDate = definition.Terms.StructuredProduct.Value.FactorDate,
+                weightedAvgCoupon = definition.Terms.StructuredProduct.Value.WeightedAvgCoupon,
+                weightedAvgMaturityMonths = definition.Terms.StructuredProduct.Value.WeightedAvgMaturityMonths,
+                weightedAvgLoanAgeMos = definition.Terms.StructuredProduct.Value.WeightedAvgLoanAgeMos,
+                collateralType = definition.Terms.StructuredProduct.Value.CollateralType is null ? null : definition.Terms.StructuredProduct.Value.CollateralType.Value,
+                poolIdentifier = definition.Terms.StructuredProduct.Value.PoolIdentifier is null ? null : definition.Terms.StructuredProduct.Value.PoolIdentifier.Value,
+                trancheClass = definition.Terms.StructuredProduct.Value.TrancheClass is null ? null : definition.Terms.StructuredProduct.Value.TrancheClass.Value,
+                prepaymentAssumption = definition.Terms.StructuredProduct.Value.PrepaymentAssumption is null ? null : SerializePrepaymentModel(definition.Terms.StructuredProduct.Value.PrepaymentAssumption.Value),
+                averageLifeYears = definition.Terms.StructuredProduct.Value.AverageLifeYears,
+                isInterestOnly = definition.Terms.StructuredProduct.Value.IsInterestOnly,
+                isPrincipalOnly = definition.Terms.StructuredProduct.Value.IsPrincipalOnly,
+                notionalBalance = definition.Terms.StructuredProduct.Value.NotionalBalance,
+                originator = definition.Terms.StructuredProduct.Value.Originator is null ? null : definition.Terms.StructuredProduct.Value.Originator.Value,
+                creditEnhancementPct = definition.Terms.StructuredProduct.Value.CreditEnhancementPct
             }
         });
 
@@ -202,5 +220,16 @@ internal static class SecurityEconomicDefinitionAdapter
         if (cat.IsSuperVoting)
             return "SuperVoting";
         throw new InvalidOperationException($"Unsupported {nameof(VotingRightsCat)} case encountered during serialization.");
+    }
+
+    private static object SerializePrepaymentModel(PrepaymentModel model)
+    {
+        if (model.IsPsa)
+            return new { model = "Psa", speed = ((PrepaymentModel.Psa)model).speed };
+        if (model.IsCpr)
+            return new { model = "Cpr", annualRate = ((PrepaymentModel.Cpr)model).annualRate };
+        if (model.IsSmm)
+            return new { model = "Smm", monthlyRate = ((PrepaymentModel.Smm)model).monthlyRate };
+        throw new InvalidOperationException($"Unsupported {nameof(PrepaymentModel)} case encountered during serialization.");
     }
 }


### PR DESCRIPTION
### Motivation
- The codebase added `StructuredProductTerms` to `SecurityTermModules` and populates it for structured bond subclasses, but the manual JSON projection in `SecurityEconomicDefinitionAdapter.BuildEconomicTermsJson` did not include `StructuredProduct`, causing structured bond metadata to be dropped from emitted `economicTerms` payloads.

### Description
- Extend `SecurityEconomicDefinitionAdapter.BuildEconomicTermsJson` to emit a top-level `structuredProduct` object populated from `definition.Terms.StructuredProduct` with all new fields such as `factor`, `factorDate`, `weightedAvgCoupon`, `prepaymentAssumption`, `isInterestOnly`, and others (`src/Meridian.Application/SecurityMaster/SecurityEconomicDefinitionAdapter.cs`).
- Add a focused helper `SerializePrepaymentModel(PrepaymentModel)` to preserve the DU shape for `PrepaymentModel` (`Psa`, `Cpr`, `Smm`) when serializing the `prepaymentAssumption` field.
- Keep the change minimal and backwards-compatible by emitting `null` when `StructuredProduct` is absent and reusing existing naming conventions used elsewhere in the adapter.

### Testing
- Performed source-level verification by inspecting `SecurityEconomicDefinitionAdapter.cs` and confirming the new `structuredProduct` projection appears in the anonymous object passed to `JsonSerializer.SerializeToElement`, and committed the change locally using `git` (commit recorded in this branch).
- Ran repository queries and diffs (`rg`, `sed`, `git diff`) to validate the inserted JSON properties are in the expected location and shape within the adapter.
- Attempted to run runtime unit tests (`dotnet test`) but the container lacks the .NET SDK, so no automated tests were executed; runtime tests are pending in an environment with `dotnet` available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cd19e55c8320a5cb3b43cd209c75)