### PR TITLE
fix: correct closed lot PnL semantics for short covers

### DIFF
--- a/src/Meridian.Backtesting.Sdk/ClosedLot.cs
+++ b/src/Meridian.Backtesting.Sdk/ClosedLot.cs
@@ -14,10 +14,11 @@ public sealed record ClosedLot(
     decimal ClosePrice,
     DateTimeOffset ClosedAt,
     Guid CloseFillId,
-    string? AccountId = null)
+    string? AccountId = null,
+    bool IsShort = false)
 {
     /// <summary>Total realised profit or loss for this lot.</summary>
-    public decimal RealizedPnl => (ClosePrice - EntryPrice) * Quantity;
+    public decimal RealizedPnl => (IsShort ? EntryPrice - ClosePrice : ClosePrice - EntryPrice) * Quantity;
 
     /// <summary>Total holding duration from open to close.</summary>
     public TimeSpan HoldingPeriod => ClosedAt - OpenedAt;
@@ -29,5 +30,5 @@ public sealed record ClosedLot(
     public bool IsLongTerm => HoldingPeriod >= TimeSpan.FromDays(365);
 
     /// <summary>Per-share realised P&amp;L (close price minus entry price).</summary>
-    public decimal RealizedPnlPerShare => ClosePrice - EntryPrice;
+    public decimal RealizedPnlPerShare => IsShort ? EntryPrice - ClosePrice : ClosePrice - EntryPrice;
 }

--- a/src/Meridian.Backtesting/Portfolio/SimulatedPortfolio.cs
+++ b/src/Meridian.Backtesting/Portfolio/SimulatedPortfolio.cs
@@ -924,7 +924,7 @@ internal sealed class SimulatedPortfolio
 
             account.ClosedLots.Add(new ClosedLot(
                 lot.LotId, symbol, lotClose, lot.EntryPrice, lot.OpenedAt,
-                lot.OpenFillId, coverPrice, closedAt, closeFillId, account.Account.AccountId));
+                lot.OpenFillId, coverPrice, closedAt, closeFillId, account.Account.AccountId, IsShort: true));
 
             if (lot.Quantity <= remaining)
             {

--- a/tests/Meridian.Backtesting.Tests/LotLevelTrackingTests.cs
+++ b/tests/Meridian.Backtesting.Tests/LotLevelTrackingTests.cs
@@ -255,6 +255,21 @@ public sealed class LotLevelTrackingTests
         snapshot.ClosedLots.Should().HaveCount(1);
     }
 
+    [Fact]
+    public void ShortCover_ClosedLot_RealizedPnl_MatchesShortSemantics()
+    {
+        var portfolio = MakePortfolio();
+
+        portfolio.ProcessFill(Sell("AAPL", 10, 400m));
+        portfolio.ProcessFill(Buy("AAPL", 10, 350m));
+
+        var closed = portfolio.GetClosedLots("AAPL");
+        closed.Should().HaveCount(1);
+        closed[0].IsShort.Should().BeTrue();
+        closed[0].RealizedPnl.Should().Be(500m); // (400-350)*10
+        closed[0].RealizedPnlPerShare.Should().Be(50m);
+    }
+
     // ── Multiple symbols, isolated lots ──────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
### Motivation

- ClosedLot previously computed realized PnL as `ClosePrice - EntryPrice` with no direction flag, which produces the wrong sign for short-cover closed lots and corrupts lot-level reporting and tax attribution.

### Description

- Add a boolean `IsShort` field to `ClosedLot` and make `RealizedPnl` and `RealizedPnlPerShare` direction-aware so shorts use `EntryPrice - ClosePrice` while longs keep `ClosePrice - EntryPrice` (`src/Meridian.Backtesting.Sdk/ClosedLot.cs`).
- Mark closed lots emitted by short-cover processing as `IsShort: true` in `SimulatedPortfolio.RealiseShortLots` to preserve correct lot-level semantics (`src/Meridian.Backtesting/Portfolio/SimulatedPortfolio.cs`).
- Add a regression test `ShortCover_ClosedLot_RealizedPnl_MatchesShortSemantics` that shorts and covers a position and asserts `IsShort`, `RealizedPnl`, and `RealizedPnlPerShare` values (`tests/Meridian.Backtesting.Tests/LotLevelTrackingTests.cs`).

### Testing

- Added a unit test `ShortCover_ClosedLot_RealizedPnl_MatchesShortSemantics` to the `LotLevelTrackingTests` suite; the test was authored to validate direction-aware closed-lot PnL behavior.
- Attempted to run the focused test set with `dotnet test ... --filter LotLevelTrackingTests`, but execution failed in this environment because `dotnet` is not installed (`dotnet: command not found`).
- Behavior and fix were validated by source inspection and by adding the unit test for CI execution where `dotnet` is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cd1a63cc8320b45080da874ef3f3)