### PR TITLE
fix: guard global.json SDK check when dotnet is unavailable

### DIFF
--- a/build/python/cli/buildctl.py
+++ b/build/python/cli/buildctl.py
@@ -516,6 +516,9 @@ def _check_global_json() -> tuple[bool, bool, str, str | None]:
     if not required:
         return True, False, "global.json: no SDK version constraint", None
 
+    if not _have("dotnet"):
+        return False, False, "dotnet SDK not found", "Install from https://dot.net/download"
+
     result = _run(["dotnet", "--version"])
     if result.returncode != 0:
         return False, False, "dotnet SDK not found", "Install from https://dot.net/download"


### PR DESCRIPTION
### Motivation
- The `doctor` diagnostics could crash with `FileNotFoundError` on systems without the `dotnet` executable because `_check_global_json()` invoked `dotnet --version` unconditionally instead of reporting a missing SDK as a diagnostic.

### Description
- Add a `if not _have("dotnet")` guard in `_check_global_json()` in `build/python/cli/buildctl.py` to return the existing diagnostic tuple (`False, False, "dotnet SDK not found", "Install from https://dot.net/download"`) before calling `_run(["dotnet", "--version"])`.

### Testing
- Ran `python3 build/python/cli/buildctl.py doctor --quick` and the command completed without traceback and now reports the missing `dotnet` SDK as a normal diagnostic failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d02636ac8320b18c076e364cc343)