### PR TITLE
fix(tests): align MarketEventBuilder.WithPayload with payload type

### DIFF
--- a/tests/Meridian.Tests/TestHelpers/Builders/MarketEventBuilder.cs
+++ b/tests/Meridian.Tests/TestHelpers/Builders/MarketEventBuilder.cs
@@ -88,6 +88,13 @@ public sealed class MarketEventBuilder
     /// <summary>Wraps an arbitrary pre-built <see cref="MarketEventPayload"/>.</summary>
     public MarketEventBuilder WithPayload(MarketEventPayload payload)
     {
+        _kind = payload switch
+        {
+            Trade => BuilderPayloadKind.Trade,
+            HistoricalBar => BuilderPayloadKind.Bar,
+            _ => throw new ArgumentException(
+                $"Unsupported payload type '{payload.GetType().Name}'. Use {nameof(WithTrade)} or {nameof(WithBar)} payloads.")
+        };
         _payload = payload;
         return this;
     }


### PR DESCRIPTION
### Motivation
- A test-helper bug allowed `WithPayload` to store arbitrary `MarketEventPayload` instances without updating the internal `_kind`, causing `Build()` to silently replace supplied payloads when `_kind` did not match the payload type.
- Make test fixtures deterministic and fail-fast so tests exercise the exact payloads supplied instead of masking mismatches with generated defaults.

### Description
- Updated `tests/Meridian.Tests/TestHelpers/Builders/MarketEventBuilder.cs` so `WithPayload` derives the internal `_kind` from the runtime payload type instead of leaving the previous/default kind.
- Implemented a switch expression that maps `Trade` to `BuilderPayloadKind.Trade` and `HistoricalBar` to `BuilderPayloadKind.Bar`, and throws an `ArgumentException` for unsupported `MarketEventPayload` subclasses with guidance to use `WithTrade` or `WithBar`.
- Preserved existing `WithTrade`, `WithBar`, and `Build()` behavior; the change prevents silent fallback to generated `Trade`/`HistoricalBar` values.

### Testing
- Attempted to run a focused test: `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~MarketEventBuilder" --logger "console;verbosity=minimal"`, but the execution environment lacks the .NET SDK and `dotnet` is not available, so tests could not be executed here (`dotnet: command not found`).
- The change is minimal and confined to the test project; a local or CI run with the .NET SDK should validate and pass existing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d026494c8320988e19e723cb227f)