### PR TITLE
Add Portfolio workspace endpoint with typed DTOs and frontend integration

### DIFF
--- a/src/Meridian.Contracts/Workstation/WorkstationBootstrapDtos.cs
+++ b/src/Meridian.Contracts/Workstation/WorkstationBootstrapDtos.cs
@@ -210,9 +210,34 @@ public sealed record WorkstationGovernanceWorkspaceSummary(
     int SecurityIssues);
 
 /// <summary>
+/// A single export/reporting profile shown in the Reporting workspace.
+/// Matches <c>GovernanceReportingProfile</c> in the frontend types.
+/// </summary>
+public sealed record WorkstationGovernanceReportingProfilePayload(
+    string Id,
+    string Name,
+    string TargetTool,
+    string Format,
+    string Description,
+    bool LoaderScript,
+    bool DataDictionary);
+
+/// <summary>
+/// Typed reporting summary embedded inside <see cref="WorkstationGovernancePayload"/>.
+/// Replaces the anonymous-object placeholder introduced in the initial governance
+/// payload commit (PR-03 follow-on).
+/// </summary>
+public sealed record WorkstationGovernanceReportingPayload(
+    int ProfileCount,
+    IReadOnlyList<string> RecommendedProfiles,
+    IReadOnlyList<WorkstationGovernanceReportingProfilePayload> Profiles,
+    IReadOnlyList<string> ReportPackTargets,
+    string Summary);
+
+/// <summary>
 /// Typed payload returned by <c>GET /api/workstation/accounting</c> and
 /// <c>GET /api/workstation/reporting</c>.
-/// <c>ReconciliationQueue</c>, <c>BreakQueue</c>, <c>CashFlow</c>, <c>Reporting</c>, and
+/// <c>ReconciliationQueue</c>, <c>BreakQueue</c>, <c>CashFlow</c>, and
 /// <c>KernelObservability</c> are kept as <c>object</c> / <c>IReadOnlyList&lt;object&gt;</c>
 /// pending their own DTO evolution in a follow-on PR.
 /// </summary>
@@ -222,5 +247,40 @@ public sealed record WorkstationGovernancePayload(
     IReadOnlyList<object> BreakQueue,
     WorkstationGovernanceWorkspaceSummary Workspace,
     object CashFlow,
-    object Reporting,
+    WorkstationGovernanceReportingPayload Reporting,
     object KernelObservability);
+
+// ---------------------------------------------------------------------------
+// /api/workstation/portfolio
+// ---------------------------------------------------------------------------
+
+/// <summary>
+/// A single run linked to the portfolio view — lightweight digest for
+/// the portfolio run-linked equity panel.
+/// </summary>
+public sealed record WorkstationPortfolioRunRow(
+    string RunId,
+    string StrategyName,
+    string Engine,
+    string Mode,
+    string Status,
+    string Pnl,
+    string Sharpe,
+    string Dataset,
+    string Window,
+    string LastUpdated,
+    string Notes,
+    string? PromotionState);
+
+/// <summary>
+/// Unified payload returned by <c>GET /api/workstation/portfolio</c>.
+/// Aggregates paper positions, brokerage wiring state, run-linked equity,
+/// and cash-flow summary so the Portfolio workspace needs a single request.
+/// </summary>
+public sealed record WorkstationPortfolioPayload(
+    IReadOnlyList<WorkstationMetricCard> Metrics,
+    IReadOnlyList<WorkstationTradingPositionRow> Positions,
+    WorkstationTradingRiskState Risk,
+    WorkstationTradingBrokerageState Brokerage,
+    IReadOnlyList<WorkstationPortfolioRunRow> Runs,
+    object? CashFlow);

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -289,6 +289,14 @@ public static class WorkstationEndpoints
         })
         .WithName("GetWorkstationReporting");
 
+        group.MapGet("/portfolio", async (HttpContext context) =>
+        {
+            var payload = await BuildPortfolioPayloadAsync(context).ConfigureAwait(false);
+            return Results.Json(payload, jsonOptions);
+        })
+        .WithName("GetWorkstationPortfolio")
+        .Produces<WorkstationPortfolioPayload>(200);
+
         group.MapPost("/reconciliation/runs", async (ReconciliationRunRequest request, HttpContext context) =>
         {
             var service = context.RequestServices.GetService<IReconciliationRunService>();
@@ -2368,6 +2376,127 @@ public static class WorkstationEndpoints
                     : "Critical";
 
     // PR-03: returns typed DTO instead of anonymous object
+    private static async Task<WorkstationPortfolioPayload> BuildPortfolioPayloadAsync(HttpContext context)
+    {
+        var readService = context.RequestServices.GetService<StrategyRunReadService>();
+        var portfolio = context.RequestServices.GetService<IPortfolioState>();
+        var oms = context.RequestServices.GetService<IOrderManager>();
+        var brokerageConfiguration = context.RequestServices.GetService<BrokerageConfiguration>();
+
+        // Resolve all runs for the run-linked equity panel
+        StrategyRunSummary[] allRuns = [];
+        if (readService is not null)
+        {
+            allRuns = (await readService.GetRunsAsync(ct: context.RequestAborted).ConfigureAwait(false))
+                .Take(12)
+                .ToArray();
+        }
+
+        // --- Metrics ---
+        var realisedPnl = portfolio?.RealisedPnl ?? allRuns.FirstOrDefault()?.NetPnl ?? 0m;
+        var unrealisedPnl = portfolio?.UnrealisedPnl ?? 0m;
+        var totalPnl = realisedPnl + unrealisedPnl;
+        var pnlTone = totalPnl >= 0m ? "success" : "warning";
+
+        var metrics = new WorkstationMetricCard[]
+        {
+            new("portfolio-net-pnl", "Net P&L", FormatCurrency(totalPnl), totalPnl >= 0m ? "+session" : "-session", pnlTone),
+            new("portfolio-cash", "Cash", portfolio is not null ? FormatCurrency(portfolio.Cash) : "—", "0%", "default"),
+            new("portfolio-value", "Portfolio Value", portfolio is not null ? FormatCurrency(portfolio.PortfolioValue) : "—", "0%", "default"),
+            new("portfolio-runs", "Linked Runs", allRuns.Length.ToString(CultureInfo.InvariantCulture), "0%", "default")
+        };
+
+        // --- Positions ---
+        WorkstationTradingPositionRow[] positions;
+        if (portfolio is not null && portfolio.Positions.Count > 0)
+        {
+            positions = portfolio.Positions.Values.Select(pos => new WorkstationTradingPositionRow(
+                Symbol: pos.Symbol,
+                Side: pos.Quantity >= 0 ? "Long" : "Short",
+                Quantity: Math.Abs(pos.Quantity).ToString(CultureInfo.InvariantCulture),
+                AveragePrice: pos.AverageCostBasis.ToString("F2", CultureInfo.InvariantCulture),
+                MarkPrice: "—",
+                DayPnl: "—",
+                UnrealizedPnl: FormatCurrency(pos.UnrealizedPnl),
+                Exposure: "—")).ToArray();
+        }
+        else
+        {
+            positions = [];
+        }
+
+        // --- Risk state ---
+        var grossExposure = 0m;
+        var netExposureValue = 0m;
+        var riskState = "Healthy";
+        var riskSummary = "Portfolio exposure is within configured paper thresholds.";
+
+        if (portfolio is not null)
+        {
+            grossExposure = portfolio.Positions.Values.Sum(static pos => Math.Abs(pos.AverageCostBasis * pos.Quantity));
+            netExposureValue = portfolio.Positions.Values.Sum(pos => pos.AverageCostBasis * pos.Quantity);
+            var drawdownPct = portfolio.PortfolioValue > 0m ? totalPnl / portfolio.PortfolioValue : 0m;
+            if (drawdownPct < -0.05m)
+            {
+                riskState = "Constrained";
+                riskSummary = "Portfolio has breached the 5% drawdown threshold.";
+            }
+            else if (drawdownPct < -0.02m)
+            {
+                riskState = "Observe";
+                riskSummary = "Exposure nearing guardrail limits.";
+            }
+        }
+
+        var risk = new WorkstationTradingRiskState(
+            State: riskState,
+            Summary: riskSummary,
+            NetExposure: portfolio is not null ? FormatCurrency(netExposureValue) : "—",
+            GrossExposure: portfolio is not null ? FormatCurrency(grossExposure) : "—",
+            Var95: "—",
+            MaxDrawdown: portfolio is not null && portfolio.PortfolioValue > 0m
+                ? FormatPercent(totalPnl / portfolio.PortfolioValue)
+                : "—",
+            BuyingPowerUsed: "—",
+            ActiveGuardrails: []);
+
+        // --- Brokerage state ---
+        var brokerageValidation = BrokerageValidationEvaluator.Evaluate(brokerageConfiguration);
+        var latestRun = allRuns.FirstOrDefault(static r => r.Mode == StrategyRunMode.Paper) ?? allRuns.FirstOrDefault();
+        var brokerage = new WorkstationTradingBrokerageState(
+            Provider: brokerageValidation.GatewayDisplayName,
+            Account: latestRun is not null && !string.IsNullOrWhiteSpace(latestRun.PortfolioId) ? latestRun.PortfolioId : "—",
+            Environment: latestRun?.Mode == StrategyRunMode.Live ? "live" : "paper",
+            Connection: portfolio is not null ? "Connected" : "Disconnected",
+            LastHeartbeat: portfolio is not null ? "live" : "—",
+            OrderIngress: oms is not null ? "healthy" : "—",
+            FillFeed: portfolio is not null ? "healthy" : "—",
+            Notes: [BuildTradingBrokerageNotes(latestRun, portfolio is not null, brokerageConfiguration)]);
+
+        // --- Run-linked equity rows ---
+        var runs = allRuns.Select(static run => new WorkstationPortfolioRunRow(
+            RunId: run.RunId,
+            StrategyName: run.StrategyName,
+            Engine: run.Engine.ToString(),
+            Mode: run.Mode.ToString().ToLowerInvariant(),
+            Status: run.Status.ToString(),
+            Pnl: run.NetPnl.HasValue ? FormatCurrency(run.NetPnl.Value) : "—",
+            Sharpe: "—",
+            Dataset: run.DatasetReference ?? "—",
+            Window: run.StartedAt.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            LastUpdated: run.LastUpdatedAt.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture),
+            Notes: BuildRunNotes(run),
+            PromotionState: run.Promotion?.State.ToString())).ToArray();
+
+        return new WorkstationPortfolioPayload(
+            Metrics: metrics,
+            Positions: positions,
+            Risk: risk,
+            Brokerage: brokerage,
+            Runs: runs,
+            CashFlow: null);
+    }
+
     private static async Task<WorkstationGovernancePayload> BuildGovernancePayloadAsync(HttpContext context)
     {
         var readService = context.RequestServices.GetService<StrategyRunReadService>();
@@ -3477,10 +3606,10 @@ public static class WorkstationEndpoints
         return ledgerCash.Value - portfolioCash.Value;
     }
 
-    private static object BuildGovernanceReportingPayload()
+    private static WorkstationGovernanceReportingPayload BuildGovernanceReportingPayload()
     {
         var profiles = ExportProfile.GetBuiltInProfiles()
-            .Select(static profile => new GovernanceReportingProfilePayload(
+            .Select(static profile => new WorkstationGovernanceReportingProfilePayload(
                 Id: profile.Id,
                 Name: profile.Name,
                 TargetTool: profile.TargetTool,
@@ -3496,14 +3625,12 @@ public static class WorkstationEndpoints
             .Select(static profile => profile.Id)
             .ToArray();
 
-        return new
-        {
-            profileCount = profiles.Length,
-            recommendedProfiles = recommended,
-            profiles,
-            reportPackTargets = new[] { "board", "investor", "compliance", "fund-ops" },
-            summary = $"{profiles.Length} export/reporting profiles are available for governance workflows."
-        };
+        return new WorkstationGovernanceReportingPayload(
+            ProfileCount: profiles.Length,
+            RecommendedProfiles: recommended,
+            Profiles: profiles,
+            ReportPackTargets: ["board", "investor", "compliance", "fund-ops"],
+            Summary: $"{profiles.Length} export/reporting profiles are available for governance workflows.");
     }
 
     private static string BuildDisplayName(StrategyRunSummary? latest)
@@ -4167,14 +4294,6 @@ public static class WorkstationEndpoints
         string? AccountName,
         string Reason);
 
-    private sealed record GovernanceReportingProfilePayload(
-        string Id,
-        string Name,
-        string TargetTool,
-        string Format,
-        string Description,
-        bool LoaderScript,
-        bool DataDictionary);
 
     private sealed record ProviderTrustRationalePayload(
         string Status,

--- a/src/Meridian.Ui/dashboard/src/hooks/use-workstation-data.ts
+++ b/src/Meridian.Ui/dashboard/src/hooks/use-workstation-data.ts
@@ -4,6 +4,7 @@ import {
   getDataWorkspace,
   getGovernanceWorkspace,
   getAlpacaConnectionStatus,
+  getPortfolioWorkspace,
   getReportingWorkspace,
   getSession,
   getStrategyWorkspace,
@@ -17,6 +18,7 @@ import type {
   BrokerageHouseholdPortfolio,
   DataOperationsWorkspaceResponse,
   GovernanceWorkspaceResponse,
+  PortfolioWorkspaceResponse,
   ResearchWorkspaceResponse,
   SessionInfo,
   SystemOverviewResponse,
@@ -33,6 +35,7 @@ interface WorkstationDataState {
   overview: SystemOverviewResponse | null;
   research: ResearchWorkspaceResponse | null;
   trading: TradingWorkspaceResponse | null;
+  portfolio: PortfolioWorkspaceResponse | null;
   dataOperations: DataOperationsWorkspaceResponse | null;
   governance: GovernanceWorkspaceResponse | null;
   reporting: GovernanceWorkspaceResponse | null;
@@ -51,6 +54,7 @@ const initialState: WorkstationDataState = {
   overview: null,
   research: null,
   trading: null,
+  portfolio: null,
   dataOperations: null,
   governance: null,
   reporting: null,
@@ -75,6 +79,7 @@ export function useWorkstationData() {
       overview,
       research,
       trading,
+      portfolio,
       dataOperations,
       governance,
       reporting,
@@ -87,6 +92,7 @@ export function useWorkstationData() {
       getSystemStatus(),
       getStrategyWorkspace(),
       getTradingWorkspace(),
+      getPortfolioWorkspace(),
       getDataWorkspace(),
       getGovernanceWorkspace(),
       getReportingWorkspace(),
@@ -134,6 +140,7 @@ export function useWorkstationData() {
       overview: readBootstrap(overview),
       research: readWorkspace(["strategy"], research),
       trading: readWorkspace(["trading"], trading),
+      portfolio: readWorkspace(["portfolio"], portfolio),
       dataOperations: readWorkspace(["data"], dataOperations),
       governance: readWorkspace(["accounting"], governance),
       reporting: readWorkspace(["reporting"], reporting),

--- a/src/Meridian.Ui/dashboard/src/lib/api.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api.ts
@@ -686,6 +686,10 @@ export function revokeRobinhoodConnection() {
   return deleteJson<BrokerageConnectionStatus>("/api/brokerage-connections/robinhood");
 }
 
+export function getPortfolioWorkspace() {
+  return getJson<import("@/types").PortfolioWorkspaceResponse>("/api/workstation/portfolio");
+}
+
 export function getAlpacaConnectionStatus() {
   return getJson<BrokerageConnectionStatus>("/api/brokerage-connections/alpaca/status");
 }

--- a/src/Meridian.Ui/dashboard/src/types.ts
+++ b/src/Meridian.Ui/dashboard/src/types.ts
@@ -699,6 +699,30 @@ export interface TradingWorkspaceResponse {
   readiness?: TradingOperatorReadiness | null;
 }
 
+export interface PortfolioRunRow {
+  runId: string;
+  strategyName: string;
+  engine: string;
+  mode: string;
+  status: string;
+  pnl: string;
+  sharpe: string;
+  dataset: string;
+  window: string;
+  lastUpdated: string;
+  notes: string;
+  promotionState: string | null;
+}
+
+export interface PortfolioWorkspaceResponse {
+  metrics: MetricSnapshot[];
+  positions: TradingPosition[];
+  risk: TradingRiskState;
+  brokerage: BrokerageWiringStatus;
+  runs: PortfolioRunRow[];
+  cashFlow: GovernanceCashFlowSummary | null;
+}
+
 export interface GovernanceReconciliationRecord {
   runId: string;
   strategyName: string;

--- a/tests/Meridian.Tests/Ui/TradingOperatorReadinessServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/TradingOperatorReadinessServiceTests.cs
@@ -134,6 +134,110 @@ public sealed class TradingOperatorReadinessServiceTests
             gate.Status == TradingAcceptanceGateStatusDto.Ready);
     }
 
+    [Fact]
+    public async Task GetAsync_WithActivePaperSession_ShouldClearSessionBlockerAndMarkGateReady()
+    {
+        await using var auditTrail = CreateAuditTrail(nameof(GetAsync_WithActivePaperSession_ShouldClearSessionBlockerAndMarkGateReady));
+        var persistence = new PaperSessionPersistenceService(
+            NullLogger<PaperSessionPersistenceService>.Instance,
+            auditTrail: auditTrail);
+        await persistence.CreateSessionAsync(new CreatePaperSessionDto(
+            StrategyId: "strat-happy",
+            StrategyName: "Happy Path Strategy",
+            InitialCash: 100_000m));
+
+        using var provider = new ServiceCollection()
+            .AddSingleton(auditTrail)
+            .AddSingleton(persistence)
+            .BuildServiceProvider();
+        var service = new TradingOperatorReadinessService(
+            provider,
+            NullLogger<TradingOperatorReadinessService>.Instance);
+
+        var readiness = await service.GetAsync();
+
+        readiness.AcceptanceGates.Should().ContainSingle(gate =>
+            gate.GateId == "session" &&
+            gate.Status == TradingAcceptanceGateStatusDto.Ready);
+        readiness.WorkItems.Should().NotContain(item => item.WorkItemId == "paper-session-missing");
+        readiness.ActiveSession.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetAsync_WithActiveSessionAndVerifiedReplay_ShouldMarkBothSessionAndReplayGatesReady()
+    {
+        await using var auditTrail = CreateAuditTrail(nameof(GetAsync_WithActiveSessionAndVerifiedReplay_ShouldMarkBothSessionAndReplayGatesReady));
+        var persistence = new PaperSessionPersistenceService(
+            NullLogger<PaperSessionPersistenceService>.Instance,
+            auditTrail: auditTrail);
+        var session = await persistence.CreateSessionAsync(new CreatePaperSessionDto(
+            StrategyId: "strat-replay",
+            StrategyName: "Replay Strategy",
+            InitialCash: 50_000m,
+            Symbols: ["AAPL"]));
+        var replay = await persistence.VerifyReplayAsync(session.SessionId);
+
+        using var provider = new ServiceCollection()
+            .AddSingleton(auditTrail)
+            .AddSingleton(persistence)
+            .BuildServiceProvider();
+        var service = new TradingOperatorReadinessService(
+            provider,
+            NullLogger<TradingOperatorReadinessService>.Instance);
+
+        var readiness = await service.GetAsync();
+
+        readiness.AcceptanceGates.Should().ContainSingle(gate =>
+            gate.GateId == "session" &&
+            gate.Status == TradingAcceptanceGateStatusDto.Ready);
+        readiness.AcceptanceGates.Should().ContainSingle(gate =>
+            gate.GateId == "replay" &&
+            gate.Status == TradingAcceptanceGateStatusDto.Ready);
+        readiness.Replay.Should().NotBeNull();
+        readiness.Replay!.IsConsistent.Should().BeTrue();
+        readiness.Replay.VerificationAuditId.Should().Be(replay!.VerificationAuditId);
+        readiness.WorkItems.Should().NotContain(item =>
+            item.WorkItemId == "paper-session-missing" ||
+            item.WorkItemId == "replay-stale" ||
+            item.WorkItemId == "replay-inconsistent");
+    }
+
+    [Fact]
+    public async Task GetAsync_WithControlsRegistered_ShouldSurfaceControlsSnapshotAndClearAuditBlocker()
+    {
+        await using var auditTrail = CreateAuditTrail(nameof(GetAsync_WithControlsRegistered_ShouldSurfaceControlsSnapshotAndClearAuditBlocker));
+        var controlsRoot = Path.Combine(
+            Path.GetTempPath(),
+            "meridian-tests",
+            "trading-readiness",
+            nameof(GetAsync_WithControlsRegistered_ShouldSurfaceControlsSnapshotAndClearAuditBlocker),
+            Guid.NewGuid().ToString("N"),
+            "controls");
+        var controls = new ExecutionOperatorControlService(
+            new ExecutionOperatorControlOptions(controlsRoot),
+            NullLogger<ExecutionOperatorControlService>.Instance,
+            auditTrail);
+        await controls.SetDefaultPositionLimitAsync(100_000m, "risk.lead", "Paper desk limit accepted.");
+
+        using var provider = new ServiceCollection()
+            .AddSingleton(auditTrail)
+            .AddSingleton(controls)
+            .BuildServiceProvider();
+        var service = new TradingOperatorReadinessService(
+            provider,
+            NullLogger<TradingOperatorReadinessService>.Instance);
+
+        var readiness = await service.GetAsync();
+
+        readiness.Controls.Should().NotBeNull();
+        readiness.Controls.CircuitBreakerOpen.Should().BeFalse();
+        readiness.Controls.ExplainableEvidenceCount.Should().Be(1);
+        readiness.Controls.UnexplainedEvidenceCount.Should().Be(0);
+        readiness.AcceptanceGates.Should().ContainSingle(gate =>
+            gate.GateId == "audit-controls" &&
+            gate.Status == TradingAcceptanceGateStatusDto.Ready);
+    }
+
     private static ExecutionAuditTrailService CreateAuditTrail(string scenario)
     {
         var root = Path.Combine(

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -2753,6 +2753,115 @@ public sealed class WorkstationEndpointsTests
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
+    [Fact]
+    public async Task MapWorkstationEndpoints_PortfolioWorkspace_ShouldReturnTypedPayloadWithRunsAndPositions()
+    {
+        await using var app = await CreateAppAsync(services =>
+        {
+            RegisterRunReadServices(services);
+        });
+
+        var store = app.Services.GetRequiredService<IStrategyRepository>();
+        await store.RecordRunAsync(BuildRun(
+            runId: "portfolio-run-backtest",
+            strategyId: "strat-portfolio",
+            strategyName: "Portfolio Test Strategy",
+            runType: RunType.Backtest,
+            startedAt: new DateTimeOffset(2026, 4, 1, 9, 0, 0, TimeSpan.Zero),
+            datasetReference: "dataset/us/equities",
+            feedReference: "synthetic:equities"));
+        await store.RecordRunAsync(BuildRun(
+            runId: "portfolio-run-paper",
+            strategyId: "strat-portfolio",
+            strategyName: "Portfolio Test Strategy",
+            runType: RunType.Paper,
+            startedAt: new DateTimeOffset(2026, 4, 2, 9, 0, 0, TimeSpan.Zero),
+            datasetReference: "dataset/us/equities",
+            feedReference: "synthetic:equities"));
+
+        var client = app.GetTestClient();
+
+        using var portfolio = await ReadJsonAsync(client, "/api/workstation/portfolio");
+
+        // Metrics are present and non-empty
+        var metrics = portfolio.RootElement.GetProperty("metrics");
+        metrics.GetArrayLength().Should().Be(4);
+        metrics.EnumerateArray().Should().Contain(m =>
+            m.GetProperty("id").GetString() == "portfolio-runs" &&
+            m.GetProperty("value").GetString() == "2");
+
+        // Positions array exists (empty when no live portfolio)
+        portfolio.RootElement.GetProperty("positions").GetArrayLength().Should().BeGreaterThanOrEqualTo(0);
+
+        // Risk state is present
+        var risk = portfolio.RootElement.GetProperty("risk");
+        risk.GetProperty("state").GetString().Should().NotBeNullOrEmpty();
+        risk.GetProperty("summary").GetString().Should().NotBeNullOrEmpty();
+
+        // Brokerage state is present
+        var brokerage = portfolio.RootElement.GetProperty("brokerage");
+        brokerage.GetProperty("provider").GetString().Should().NotBeNullOrEmpty();
+        brokerage.GetProperty("connection").GetString().Should().NotBeNullOrEmpty();
+
+        // Run-linked equity panel has both runs
+        var runs = portfolio.RootElement.GetProperty("runs");
+        runs.GetArrayLength().Should().Be(2);
+        runs.EnumerateArray()
+            .Select(r => r.GetProperty("runId").GetString())
+            .Should().BeEquivalentTo("portfolio-run-paper", "portfolio-run-backtest");
+        runs.EnumerateArray().Should().AllSatisfy(r =>
+        {
+            r.GetProperty("strategyName").GetString().Should().Be("Portfolio Test Strategy");
+            r.GetProperty("mode").GetString().Should().BeOneOf("paper", "backtest");
+            r.GetProperty("notes").GetString().Should().NotBeNull();
+        });
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_PortfolioWorkspace_WithoutRunReadService_ShouldReturnEmptyRunsAndStableShape()
+    {
+        await using var app = await CreateAppAsync();
+        var client = app.GetTestClient();
+
+        using var portfolio = await ReadJsonAsync(client, "/api/workstation/portfolio");
+
+        portfolio.RootElement.GetProperty("metrics").GetArrayLength().Should().Be(4);
+        portfolio.RootElement.GetProperty("positions").GetArrayLength().Should().Be(0);
+        portfolio.RootElement.GetProperty("runs").GetArrayLength().Should().Be(0);
+        portfolio.RootElement.GetProperty("risk").GetProperty("state").GetString().Should().Be("Healthy");
+        portfolio.RootElement.GetProperty("brokerage").GetProperty("connection").GetString().Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_ReportingWorkspace_ShouldReturnTypedReportingPayloadWithProfiles()
+    {
+        await using var app = await CreateAppAsync();
+        var client = app.GetTestClient();
+
+        using var reporting = await ReadJsonAsync(client, "/api/workstation/reporting");
+
+        var reportingSection = reporting.RootElement.GetProperty("reporting");
+        reportingSection.GetProperty("profileCount").GetInt32().Should().BeGreaterThan(0);
+        reportingSection.GetProperty("summary").GetString().Should().Contain("profiles are available");
+        reportingSection.GetProperty("reportPackTargets").EnumerateArray()
+            .Select(t => t.GetString())
+            .Should().Contain("board").And.Contain("investor").And.Contain("compliance");
+
+        var profiles = reportingSection.GetProperty("profiles").EnumerateArray().ToArray();
+        profiles.Should().NotBeEmpty();
+        profiles.Should().AllSatisfy(profile =>
+        {
+            profile.GetProperty("id").GetString().Should().NotBeNullOrEmpty();
+            profile.GetProperty("name").GetString().Should().NotBeNullOrEmpty();
+            profile.GetProperty("format").GetString().Should().NotBeNullOrEmpty();
+        });
+
+        var recommended = reportingSection.GetProperty("recommendedProfiles").EnumerateArray()
+            .Select(r => r.GetString())
+            .ToArray();
+        recommended.Should().Contain("excel").Or.Contain("python-pandas");
+    }
+
     private static async Task<WebApplication> CreateAppAsync(Action<IServiceCollection>? configureServices = null)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions


### PR DESCRIPTION
## Description

This PR introduces a new `/api/workstation/portfolio` endpoint that provides a unified payload for the Portfolio workspace, aggregating paper positions, brokerage wiring state, run-linked equity, and risk metrics. Additionally, it refactors governance reporting payloads to use typed DTOs instead of anonymous objects.

### Changes

**Backend (C#)**
- Added `GET /api/workstation/portfolio` endpoint that returns `WorkstationPortfolioPayload`
- Implemented `BuildPortfolioPayloadAsync()` method that aggregates:
  - Metrics (Net P&L, Cash, Portfolio Value, Linked Runs)
  - Trading positions with P&L calculations
  - Risk state assessment (Healthy/Observe/Constrained based on drawdown thresholds)
  - Brokerage connection status and heartbeat
  - Run-linked equity panel (up to 12 most recent runs)
- Refactored `BuildGovernanceReportingPayload()` to return typed `WorkstationGovernanceReportingPayload` instead of anonymous object
- Added new DTOs in `WorkstationBootstrapDtos.cs`:
  - `WorkstationPortfolioPayload`
  - `WorkstationPortfolioRunRow`
  - `WorkstationGovernanceReportingPayload`
  - `WorkstationGovernanceReportingProfilePayload`

**Frontend (TypeScript)**
- Added `PortfolioWorkspaceResponse` and `PortfolioRunRow` interfaces
- Added `getPortfolioWorkspace()` API function
- Integrated portfolio data into workstation data hook

**Tests**
- Added comprehensive test coverage for portfolio endpoint:
  - `MapWorkstationEndpoints_PortfolioWorkspace_ShouldReturnTypedPayloadWithRunsAndPositions()` — validates metrics, positions, risk state, brokerage state, and run-linked equity
  - `MapWorkstationEndpoints_PortfolioWorkspace_WithoutRunReadService_ShouldReturnEmptyRunsAndStableShape()` — ensures graceful degradation
  - `MapWorkstationEndpoints_ReportingWorkspace_ShouldReturnTypedReportingPayloadWithProfiles()` — validates typed reporting payload
- Added three new tests to `TradingOperatorReadinessServiceTests` for session and replay verification scenarios

## Type of Change

- New feature
- Code refactoring

## Motivation and Context

The Portfolio workspace requires a single consolidated endpoint to display paper trading state, positions, risk metrics, and linked strategy runs. Previously, this data would have required multiple requests. The refactoring of governance reporting to use typed DTOs improves type safety and API contract clarity across the workstation endpoints.

## How Has This Been Tested?

- Added 3 new integration tests for the portfolio endpoint covering:
  - Full payload structure with runs and positions
  - Graceful degradation when services are unavailable
  - Typed reporting payload validation
- Added 3 new unit tests for trading operator readiness scenarios
- All existing tests pass

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly (DTOs include XML doc comments)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have checked my code and corrected any misspellings
- [x] My changes generate no new warnings
- [x] Contract review packet artifact link added (new workstation contract DTOs in `WorkstationBootstrapDtos.cs`)

## Related Issues

Implements Portfolio workspace data aggregation endpoint as part of workstation UI enhancement.

## Migration Notes

**Contract Addition (Non-Breaking)**

New DTOs added to `src/Meridian.Contracts/Workstation/WorkstationBootstrapDtos.cs`:
- `WorkstationPortfolioPayload` — new endpoint response type
- `WorkstationPortfolioRunRow` — new nested type
- `WorkstationGovernanceReportingPayload` — replaces anonymous object in `WorkstationGovernancePayload.Reporting`
- `WorkstationGovernanceReporting

https://claude.ai/code/session_019gkLYM5tZtHXK8XuJDwveC