### PR TITLE
Surface live mark prices in workstation trading & portfolio views

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -7,6 +7,7 @@ using Meridian.Contracts.Api;
 using Meridian.Contracts.Auth;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Contracts.Workstation;
+using Meridian.Domain.Collectors;
 using Meridian.Execution.Models;
 using Meridian.Execution.Sdk;
 using Meridian.Execution.Services;
@@ -1550,6 +1551,8 @@ public static class WorkstationEndpoints
         var portfolio = context.RequestServices.GetService<IPortfolioState>();
         var oms = context.RequestServices.GetService<IOrderManager>();
         var brokerageConfiguration = context.RequestServices.GetService<BrokerageConfiguration>();
+        var quoteCollector = context.RequestServices.GetService<QuoteCollector>();
+        var tradeCollector = context.RequestServices.GetService<TradeDataCollector>();
 
         // When neither execution layer nor strategy run service is active, use fixture data
         if (portfolio is null && oms is null && readService is null)
@@ -1575,18 +1578,29 @@ public static class WorkstationEndpoints
         var pnlTone = totalPnl >= 0m ? "success" : "warning";
 
         // --- Positions (live execution layer when available) — PR-03: typed rows ---
+        // Live marks (BBO mid → last trade → cost basis) drive MarkPrice, UnrealizedPnl,
+        // and Exposure so operators see real-time PnL as quotes update.
         WorkstationTradingPositionRow[] positions;
         if (portfolio is not null && portfolio.Positions.Count > 0)
         {
-            positions = portfolio.Positions.Values.Select(pos => new WorkstationTradingPositionRow(
-                Symbol: pos.Symbol,
-                Side: pos.Quantity >= 0 ? "Long" : "Short",
-                Quantity: Math.Abs(pos.Quantity).ToString(CultureInfo.InvariantCulture),
-                AveragePrice: pos.AverageCostBasis.ToString("F2", CultureInfo.InvariantCulture),
-                MarkPrice: "—",
-                DayPnl: "—",
-                UnrealizedPnl: FormatCurrency(pos.UnrealizedPnl),
-                Exposure: "—")).ToArray();
+            positions = portfolio.Positions.Values.Select(pos =>
+            {
+                var mark = ResolveLiveMark(pos.Symbol, quoteCollector, tradeCollector);
+                var hasMark = mark.HasValue && mark.Value > 0m;
+                var effectiveMark = hasMark ? mark!.Value : pos.AverageCostBasis;
+                var liveUnrealized = (effectiveMark - pos.AverageCostBasis) * pos.Quantity;
+                var liveExposure = Math.Abs(pos.Quantity * effectiveMark);
+
+                return new WorkstationTradingPositionRow(
+                    Symbol: pos.Symbol,
+                    Side: pos.Quantity >= 0 ? "Long" : "Short",
+                    Quantity: Math.Abs(pos.Quantity).ToString(CultureInfo.InvariantCulture),
+                    AveragePrice: pos.AverageCostBasis.ToString("F2", CultureInfo.InvariantCulture),
+                    MarkPrice: hasMark ? effectiveMark.ToString("F2", CultureInfo.InvariantCulture) : "—",
+                    DayPnl: "—",
+                    UnrealizedPnl: FormatCurrency(hasMark ? liveUnrealized : pos.UnrealizedPnl),
+                    Exposure: hasMark ? FormatCurrency(liveExposure) : "—");
+            }).ToArray();
         }
         else
         {
@@ -1624,8 +1638,13 @@ public static class WorkstationEndpoints
 
         if (portfolio is not null)
         {
-            grossExposure = portfolio.Positions.Values.Sum(static pos => Math.Abs(pos.AverageCostBasis * pos.Quantity));
-            netExposureValue = portfolio.Positions.Values.Sum(pos => pos.AverageCostBasis * pos.Quantity);
+            foreach (var pos in portfolio.Positions.Values)
+            {
+                var mark = ResolveLiveMark(pos.Symbol, quoteCollector, tradeCollector);
+                var px = mark.HasValue && mark.Value > 0m ? mark.Value : pos.AverageCostBasis;
+                grossExposure += Math.Abs(pos.Quantity * px);
+                netExposureValue += pos.Quantity * px;
+            }
             var drawdownPct = portfolio.PortfolioValue > 0m
                 ? totalPnl / portfolio.PortfolioValue
                 : 0m;
@@ -2382,6 +2401,8 @@ public static class WorkstationEndpoints
         var portfolio = context.RequestServices.GetService<IPortfolioState>();
         var oms = context.RequestServices.GetService<IOrderManager>();
         var brokerageConfiguration = context.RequestServices.GetService<BrokerageConfiguration>();
+        var quoteCollector = context.RequestServices.GetService<QuoteCollector>();
+        var tradeCollector = context.RequestServices.GetService<TradeDataCollector>();
 
         // Resolve all runs for the run-linked equity panel
         StrategyRunSummary[] allRuns = [];
@@ -2406,19 +2427,28 @@ public static class WorkstationEndpoints
             new("portfolio-runs", "Linked Runs", allRuns.Length.ToString(CultureInfo.InvariantCulture), "0%", "default")
         };
 
-        // --- Positions ---
+        // --- Positions (live mark drives MarkPrice / UnrealizedPnl / Exposure) ---
         WorkstationTradingPositionRow[] positions;
         if (portfolio is not null && portfolio.Positions.Count > 0)
         {
-            positions = portfolio.Positions.Values.Select(pos => new WorkstationTradingPositionRow(
-                Symbol: pos.Symbol,
-                Side: pos.Quantity >= 0 ? "Long" : "Short",
-                Quantity: Math.Abs(pos.Quantity).ToString(CultureInfo.InvariantCulture),
-                AveragePrice: pos.AverageCostBasis.ToString("F2", CultureInfo.InvariantCulture),
-                MarkPrice: "—",
-                DayPnl: "—",
-                UnrealizedPnl: FormatCurrency(pos.UnrealizedPnl),
-                Exposure: "—")).ToArray();
+            positions = portfolio.Positions.Values.Select(pos =>
+            {
+                var mark = ResolveLiveMark(pos.Symbol, quoteCollector, tradeCollector);
+                var hasMark = mark.HasValue && mark.Value > 0m;
+                var effectiveMark = hasMark ? mark!.Value : pos.AverageCostBasis;
+                var liveUnrealized = (effectiveMark - pos.AverageCostBasis) * pos.Quantity;
+                var liveExposure = Math.Abs(pos.Quantity * effectiveMark);
+
+                return new WorkstationTradingPositionRow(
+                    Symbol: pos.Symbol,
+                    Side: pos.Quantity >= 0 ? "Long" : "Short",
+                    Quantity: Math.Abs(pos.Quantity).ToString(CultureInfo.InvariantCulture),
+                    AveragePrice: pos.AverageCostBasis.ToString("F2", CultureInfo.InvariantCulture),
+                    MarkPrice: hasMark ? effectiveMark.ToString("F2", CultureInfo.InvariantCulture) : "—",
+                    DayPnl: "—",
+                    UnrealizedPnl: FormatCurrency(hasMark ? liveUnrealized : pos.UnrealizedPnl),
+                    Exposure: hasMark ? FormatCurrency(liveExposure) : "—");
+            }).ToArray();
         }
         else
         {
@@ -2433,8 +2463,13 @@ public static class WorkstationEndpoints
 
         if (portfolio is not null)
         {
-            grossExposure = portfolio.Positions.Values.Sum(static pos => Math.Abs(pos.AverageCostBasis * pos.Quantity));
-            netExposureValue = portfolio.Positions.Values.Sum(pos => pos.AverageCostBasis * pos.Quantity);
+            foreach (var pos in portfolio.Positions.Values)
+            {
+                var mark = ResolveLiveMark(pos.Symbol, quoteCollector, tradeCollector);
+                var px = mark.HasValue && mark.Value > 0m ? mark.Value : pos.AverageCostBasis;
+                grossExposure += Math.Abs(pos.Quantity * px);
+                netExposureValue += pos.Quantity * px;
+            }
             var drawdownPct = portfolio.PortfolioValue > 0m ? totalPnl / portfolio.PortfolioValue : 0m;
             if (drawdownPct < -0.05m)
             {
@@ -3772,6 +3807,47 @@ public static class WorkstationEndpoints
         }
 
         return proxy.ToString("0.00", CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Resolves the freshest available mark price for a symbol so that workstation
+    /// position rows can display live unrealized P&amp;L and exposure instead of placeholders.
+    /// Priority: BBO mid (or far-touch when one side is missing) → most recent trade
+    /// price → null (caller falls back to cost basis).
+    /// </summary>
+    internal static decimal? ResolveLiveMark(string symbol, QuoteCollector? quotes, TradeDataCollector? trades)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            return null;
+        }
+
+        if (quotes is not null && quotes.TryGet(symbol, out var bbo) && bbo is not null)
+        {
+            if (bbo.MidPrice is { } mid && mid > 0m)
+            {
+                return mid;
+            }
+            if (bbo.AskPrice > 0m)
+            {
+                return bbo.AskPrice;
+            }
+            if (bbo.BidPrice > 0m)
+            {
+                return bbo.BidPrice;
+            }
+        }
+
+        if (trades is not null)
+        {
+            var recent = trades.GetRecentTrades(symbol, 1);
+            if (recent.Count > 0 && recent[0].Price > 0m)
+            {
+                return recent[0].Price;
+            }
+        }
+
+        return null;
     }
 
     private static string FormatPercent(decimal value)

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -2862,6 +2862,192 @@ public sealed class WorkstationEndpointsTests
         recommended.Should().Contain(value => value == "excel" || value == "python-pandas");
     }
 
+    [Fact]
+    public async Task MapWorkstationEndpoints_TradingPayload_WithLiveQuote_ReplacesPlaceholderMarkAndComputesUnrealizedPnl()
+    {
+        var publisher = new Meridian.Tests.TestHelpers.TestMarketEventPublisher();
+        var quotes = new Meridian.Domain.Collectors.QuoteCollector(publisher);
+        quotes.OnQuote(new Meridian.Contracts.Domain.Models.MarketQuoteUpdate(
+            Timestamp: DateTimeOffset.UtcNow,
+            Symbol: "AAPL",
+            BidPrice: 199.90m,
+            BidSize: 100,
+            AskPrice: 200.10m,
+            AskSize: 100,
+            StreamId: "TEST",
+            Venue: "TEST"));
+
+        var position = new Meridian.Execution.Models.ExecutionPosition(
+            Symbol: "AAPL",
+            Quantity: 100,
+            AverageCostBasis: 150m,
+            UnrealisedPnl: 0m,
+            RealisedPnl: 0m);
+
+        await using var app = await CreateAppAsync(services =>
+        {
+            RegisterRunReadServices(services);
+            services.AddSingleton<Meridian.Execution.Models.IPortfolioState>(new LiveMarkTestPortfolioState(position));
+            services.AddSingleton(quotes);
+        });
+
+        var client = app.GetTestClient();
+        using var trading = await ReadJsonAsync(client, "/api/workstation/trading");
+
+        var rows = trading.RootElement.GetProperty("positions").EnumerateArray().ToArray();
+        rows.Should().NotBeEmpty();
+        var row = rows[0];
+        row.GetProperty("symbol").GetString().Should().Be("AAPL");
+
+        // Mid of (199.90, 200.10) = 200.00
+        row.GetProperty("markPrice").GetString().Should().Be("200.00");
+
+        // (200 - 150) * 100 = +5,000 → FormatCurrency renders "+$5K"
+        var unrealized = row.GetProperty("unrealizedPnl").GetString();
+        unrealized.Should().NotBe("—");
+        unrealized.Should().Be("+$5K");
+
+        // |100 * 200| = 20,000 → "+$20K"
+        var exposure = row.GetProperty("exposure").GetString();
+        exposure.Should().NotBe("—");
+        exposure.Should().Be("+$20K");
+
+        // Risk panel net/gross exposure should also reflect live mark, not cost basis
+        // (cost-basis exposure would have been |100 * 150| = 15,000 → "+$15K")
+        var risk = trading.RootElement.GetProperty("risk");
+        risk.GetProperty("netExposure").GetString().Should().Be("+$20K");
+        risk.GetProperty("grossExposure").GetString().Should().Be("+$20K");
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_TradingPayload_WithoutQuote_FallsBackToLastTradePrice()
+    {
+        var publisher = new Meridian.Tests.TestHelpers.TestMarketEventPublisher();
+        var quotes = new Meridian.Domain.Collectors.QuoteCollector(publisher);
+        var trades = new Meridian.Domain.Collectors.TradeDataCollector(publisher, quotes);
+        trades.OnTrade(new Meridian.Domain.Models.MarketTradeUpdate(
+            Timestamp: DateTimeOffset.UtcNow,
+            Symbol: "AAPL",
+            Price: 175m,
+            Size: 50,
+            Aggressor: Meridian.Contracts.Domain.Enums.AggressorSide.Buy,
+            SequenceNumber: 1,
+            StreamId: "TEST",
+            Venue: "TEST"));
+
+        var position = new Meridian.Execution.Models.ExecutionPosition(
+            Symbol: "AAPL",
+            Quantity: 100,
+            AverageCostBasis: 150m,
+            UnrealisedPnl: 0m,
+            RealisedPnl: 0m);
+
+        await using var app = await CreateAppAsync(services =>
+        {
+            RegisterRunReadServices(services);
+            services.AddSingleton<Meridian.Execution.Models.IPortfolioState>(new LiveMarkTestPortfolioState(position));
+            services.AddSingleton(quotes);
+            services.AddSingleton(trades);
+        });
+
+        var client = app.GetTestClient();
+        using var trading = await ReadJsonAsync(client, "/api/workstation/trading");
+
+        var row = trading.RootElement.GetProperty("positions").EnumerateArray().First();
+        row.GetProperty("markPrice").GetString().Should().Be("175.00");
+        // (175 - 150) * 100 = +2,500 → "+$2.5K"
+        row.GetProperty("unrealizedPnl").GetString().Should().Be("+$2.5K");
+        // |100 * 175| = 17,500 → "+$17.5K"
+        row.GetProperty("exposure").GetString().Should().Be("+$17.5K");
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_TradingPayload_WithoutAnyMarketData_RetainsPlaceholderMark()
+    {
+        var position = new Meridian.Execution.Models.ExecutionPosition(
+            Symbol: "AAPL",
+            Quantity: 100,
+            AverageCostBasis: 150m,
+            UnrealisedPnl: 0m,
+            RealisedPnl: 0m);
+
+        await using var app = await CreateAppAsync(services =>
+        {
+            RegisterRunReadServices(services);
+            services.AddSingleton<Meridian.Execution.Models.IPortfolioState>(new LiveMarkTestPortfolioState(position));
+        });
+
+        var client = app.GetTestClient();
+        using var trading = await ReadJsonAsync(client, "/api/workstation/trading");
+
+        var row = trading.RootElement.GetProperty("positions").EnumerateArray().First();
+        row.GetProperty("markPrice").GetString().Should().Be("—");
+        row.GetProperty("exposure").GetString().Should().Be("—");
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_PortfolioPayload_WithLiveQuote_SurfacesLiveMarkAndExposure()
+    {
+        var publisher = new Meridian.Tests.TestHelpers.TestMarketEventPublisher();
+        var quotes = new Meridian.Domain.Collectors.QuoteCollector(publisher);
+        quotes.OnQuote(new Meridian.Contracts.Domain.Models.MarketQuoteUpdate(
+            Timestamp: DateTimeOffset.UtcNow,
+            Symbol: "MSFT",
+            BidPrice: 419.50m,
+            BidSize: 200,
+            AskPrice: 420.50m,
+            AskSize: 200,
+            StreamId: "TEST",
+            Venue: "TEST"));
+
+        var position = new Meridian.Execution.Models.ExecutionPosition(
+            Symbol: "MSFT",
+            Quantity: 50,
+            AverageCostBasis: 400m,
+            UnrealisedPnl: 0m,
+            RealisedPnl: 0m);
+
+        await using var app = await CreateAppAsync(services =>
+        {
+            RegisterRunReadServices(services);
+            services.AddSingleton<Meridian.Execution.Models.IPortfolioState>(new LiveMarkTestPortfolioState(position));
+            services.AddSingleton(quotes);
+        });
+
+        var client = app.GetTestClient();
+        using var portfolio = await ReadJsonAsync(client, "/api/workstation/portfolio");
+
+        var row = portfolio.RootElement.GetProperty("positions").EnumerateArray().First();
+        // Mid of (419.50, 420.50) = 420.00
+        row.GetProperty("markPrice").GetString().Should().Be("420.00");
+        // (420 - 400) * 50 = +1,000 → "+$1K"
+        row.GetProperty("unrealizedPnl").GetString().Should().Be("+$1K");
+        // |50 * 420| = 21,000 → "+$21K"
+        row.GetProperty("exposure").GetString().Should().Be("+$21K");
+
+        var risk = portfolio.RootElement.GetProperty("risk");
+        risk.GetProperty("grossExposure").GetString().Should().Be("+$21K");
+    }
+
+    private sealed class LiveMarkTestPortfolioState : Meridian.Execution.Models.IPortfolioState
+    {
+        public LiveMarkTestPortfolioState(params Meridian.Execution.Models.ExecutionPosition[] positions)
+        {
+            Positions = positions.ToDictionary(
+                position => position.Symbol,
+                position => (Meridian.Execution.Sdk.IPosition)position,
+                StringComparer.OrdinalIgnoreCase);
+            UnrealisedPnl = positions.Sum(static p => p.UnrealisedPnl);
+            RealisedPnl = positions.Sum(static p => p.RealisedPnl);
+        }
+
+        public decimal Cash => 100_000m;
+        public decimal PortfolioValue => 250_000m;
+        public decimal UnrealisedPnl { get; }
+        public decimal RealisedPnl { get; }
+        public IReadOnlyDictionary<string, Meridian.Execution.Sdk.IPosition> Positions { get; }
+    }
+
     private static async Task<WebApplication> CreateAppAsync(Action<IServiceCollection>? configureServices = null)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions


### PR DESCRIPTION
## Description

This PR enhances the workstation trading and portfolio endpoints to display real-time mark prices and compute live unrealized P&L and exposure based on current market data, rather than showing placeholders or stale cost-basis values.

### Changes

**WorkstationEndpoints.cs:**
- Added `ResolveLiveMark()` helper method that resolves the freshest available mark price for a symbol using a priority cascade: BBO mid price → far-touch bid/ask (when one side is missing) → most recent trade price → null (falls back to cost basis)
- Updated `BuildTradingPayloadAsync()` to:
  - Inject `QuoteCollector` and `TradeDataCollector` services
  - Compute live mark prices for each position
  - Calculate unrealized P&L and exposure using live marks instead of placeholders
  - Update risk panel (net/gross exposure) to reflect live marks
- Updated `BuildPortfolioPayloadAsync()` with identical live mark logic for consistency

**WorkstationEndpointsTests.cs:**
- Added `LiveMarkTestPortfolioState` test helper class to mock portfolio state
- Added 4 comprehensive test cases:
  - `MapWorkstationEndpoints_TradingPayload_WithLiveQuote_ReplacesPlaceholderMarkAndComputesUnrealizedPnl`: Verifies BBO mid price is used and P&L/exposure are computed correctly
  - `MapWorkstationEndpoints_TradingPayload_WithoutQuote_FallsBackToLastTradePrice`: Verifies fallback to last trade price when quotes unavailable
  - `MapWorkstationEndpoints_TradingPayload_WithoutAnyMarketData_RetainsPlaceholderMark`: Verifies graceful degradation to placeholders when no market data exists
  - `MapWorkstationEndpoints_PortfolioPayload_WithLiveQuote_SurfacesLiveMarkAndExposure`: Verifies portfolio endpoint also surfaces live marks

### Motivation and Context

Previously, position rows in the trading and portfolio views displayed "—" for mark price and exposure, and used stale unrealized P&L from the execution layer. This prevented operators from seeing real-time P&L as market conditions changed. By integrating live quote and trade data, operators now see accurate, up-to-the-moment position valuations and P&L.

### How Has This Been Tested?

- Added 4 new integration tests covering the happy path (live quotes), fallback path (trade data), and degraded path (no market data)
- Tests verify correct mark price resolution, P&L computation, and exposure calculation
- Tests validate both trading and portfolio endpoints
- All existing tests continue to pass

### Checklist

- [x] My code follows the code style of this project
- [x] All new and existing tests passed
- [x] I have checked my code and corrected any misspellings
- [x] My changes generate no new warnings

https://claude.ai/code/session_019mpG71nczeb4mCm9H5PB4K