### PR TITLE
Add live quotes and symbol watchlist screens to data operations

### DIFF
--- a/src/Meridian.Ui/dashboard/src/app.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.tsx
@@ -23,6 +23,7 @@ import { useWorkstationData } from "@/hooks/use-workstation-data";
 import { markWorkflowPresetUsed } from "@/lib/api";
 import { legacyWorkspaceRedirect } from "@/lib/workspace";
 import { DataOperationsScreen } from "@/screens/data-operations-screen";
+import { LiveQuotesScreen } from "@/screens/live-quotes-screen";
 import { GovernanceScreen } from "@/screens/governance-screen";
 import { OperatorReadinessConsole } from "@/screens/operator-readiness-console";
 import { PortfolioScreen } from "@/screens/portfolio-screen";
@@ -176,6 +177,7 @@ export function App() {
                 <Route path="/accounting/*" element={<GovernanceScreen data={governance} />} />
                 <Route path="/reporting/*" element={<ReportingScreen data={reporting} />} />
                 <Route path="/strategy/*" element={<ResearchScreen data={research} />} />
+                <Route path="/data/quotes" element={<LiveQuotesScreen />} />
                 <Route path="/data/*" element={<DataOperationsScreen data={dataOperations} />} />
                 <Route path="/settings/*" element={(
                   <SettingsScreen

--- a/src/Meridian.Ui/dashboard/src/app.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.tsx
@@ -24,6 +24,7 @@ import { markWorkflowPresetUsed } from "@/lib/api";
 import { legacyWorkspaceRedirect } from "@/lib/workspace";
 import { DataOperationsScreen } from "@/screens/data-operations-screen";
 import { LiveQuotesScreen } from "@/screens/live-quotes-screen";
+import { WatchlistScreen } from "@/screens/watchlist-screen";
 import { GovernanceScreen } from "@/screens/governance-screen";
 import { OperatorReadinessConsole } from "@/screens/operator-readiness-console";
 import { PortfolioScreen } from "@/screens/portfolio-screen";
@@ -178,6 +179,7 @@ export function App() {
                 <Route path="/reporting/*" element={<ReportingScreen data={reporting} />} />
                 <Route path="/strategy/*" element={<ResearchScreen data={research} />} />
                 <Route path="/data/quotes" element={<LiveQuotesScreen />} />
+                <Route path="/data/watchlist" element={<WatchlistScreen />} />
                 <Route path="/data/*" element={<DataOperationsScreen data={dataOperations} />} />
                 <Route path="/settings/*" element={(
                   <SettingsScreen

--- a/src/Meridian.Ui/dashboard/src/lib/api.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api.ts
@@ -717,3 +717,17 @@ export function getPortfolioExposure() {
 export function getPortfolioSymbolExposure(symbol: string) {
   return getJson<unknown>(`/api/portfolio/symbols/${encodeURIComponent(symbol)}/exposure`);
 }
+
+// --- Live market data ---
+
+export function getLiveQuote(symbol: string) {
+  return getJson<import("@/types").QuotesResponse>(`/api/data/quotes/${encodeURIComponent(symbol)}`);
+}
+
+export function getLiveTrades(symbol: string, limit = 25) {
+  return getJson<import("@/types").TradesResponse>(`/api/data/trades/${encodeURIComponent(symbol)}?limit=${limit}`);
+}
+
+export function getLiveOrderbook(symbol: string, levels = 10) {
+  return getJson<import("@/types").OrderBookResponse>(`/api/data/orderbook/${encodeURIComponent(symbol)}?levels=${levels}`);
+}

--- a/src/Meridian.Ui/dashboard/src/screens/data-operations-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/data-operations-screen.tsx
@@ -18,7 +18,7 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { KeyboardEvent, ReactNode } from "react";
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { MetricCard } from "@/components/meridian/metric-card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -79,6 +79,17 @@ export function DataOperationsScreen({ data }: DataOperationsScreenProps) {
 
   return (
     <div className="space-y-8">
+      <section className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap gap-2">
+          <Button asChild variant="outline" size="sm">
+            <Link to="/data/quotes" aria-label="Open live quotes and order book viewer">
+              <RadioTower className="h-4 w-4" aria-hidden="true" />
+              <span className="ml-1.5">Live quotes</span>
+            </Link>
+          </Button>
+        </div>
+      </section>
+
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         {data.metrics.map((metric) => <MetricCard key={metric.id} {...metric} />)}
       </section>

--- a/src/Meridian.Ui/dashboard/src/screens/data-operations-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/data-operations-screen.tsx
@@ -87,6 +87,12 @@ export function DataOperationsScreen({ data }: DataOperationsScreenProps) {
               <span className="ml-1.5">Live quotes</span>
             </Link>
           </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link to="/data/watchlist" aria-label="Open symbol watchlist">
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              <span className="ml-1.5">Watchlist</span>
+            </Link>
+          </Button>
         </div>
       </section>
 

--- a/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.tsx
@@ -1,0 +1,349 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ArrowDown, ArrowUp, LineChart, RefreshCw, Search } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { getLiveOrderbook, getLiveQuote, getLiveTrades } from "@/lib/api";
+import type {
+  OrderBookResponse,
+  QuotesResponse,
+  TradeDataResponse,
+  TradesResponse
+} from "@/types";
+
+const POLL_INTERVAL_MS = 2000;
+
+interface LoadState<T> {
+  data: T | null;
+  error: string | null;
+}
+
+function formatPrice(value: number | null | undefined, fractionDigits = 4): string {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return "—";
+  }
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: fractionDigits
+  });
+}
+
+function formatSize(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return "—";
+  }
+  return value.toLocaleString();
+}
+
+function formatTimestamp(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleTimeString(undefined, { hour12: false }) + "." + String(date.getMilliseconds()).padStart(3, "0");
+}
+
+export function LiveQuotesScreen() {
+  const [symbolInput, setSymbolInput] = useState("");
+  const [activeSymbol, setActiveSymbol] = useState<string | null>(null);
+  const [quote, setQuote] = useState<LoadState<QuotesResponse>>({ data: null, error: null });
+  const [trades, setTrades] = useState<LoadState<TradesResponse>>({ data: null, error: null });
+  const [orderbook, setOrderbook] = useState<LoadState<OrderBookResponse>>({ data: null, error: null });
+  const [refreshing, setRefreshing] = useState(false);
+  const inFlightRef = useRef(false);
+
+  const fetchAll = useCallback(async (symbol: string) => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    setRefreshing(true);
+    try {
+      const [q, t, ob] = await Promise.allSettled([
+        getLiveQuote(symbol),
+        getLiveTrades(symbol, 25),
+        getLiveOrderbook(symbol, 10)
+      ]);
+      setQuote(q.status === "fulfilled"
+        ? { data: q.value, error: null }
+        : { data: null, error: (q.reason as Error)?.message ?? "Failed to load quote" });
+      setTrades(t.status === "fulfilled"
+        ? { data: t.value, error: null }
+        : { data: null, error: (t.reason as Error)?.message ?? "Failed to load trades" });
+      setOrderbook(ob.status === "fulfilled"
+        ? { data: ob.value, error: null }
+        : { data: null, error: (ob.reason as Error)?.message ?? "Failed to load order book" });
+    } finally {
+      inFlightRef.current = false;
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!activeSymbol) return;
+    void fetchAll(activeSymbol);
+    const interval = window.setInterval(() => void fetchAll(activeSymbol), POLL_INTERVAL_MS);
+    return () => window.clearInterval(interval);
+  }, [activeSymbol, fetchAll]);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    const next = symbolInput.trim().toUpperCase();
+    if (!next) return;
+    setQuote({ data: null, error: null });
+    setTrades({ data: null, error: null });
+    setOrderbook({ data: null, error: null });
+    setActiveSymbol(next);
+  };
+
+  const quoteRow = quote.data?.quote;
+  const stale = orderbook.data?.isStale === true;
+  const venueLabel = quoteRow?.venue ?? orderbook.data?.venue ?? null;
+
+  const tradeRows = useMemo(() => trades.data?.trades?.slice(0, 25) ?? [], [trades.data]);
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <div className="eyebrow-label">Data Lane</div>
+          <CardTitle className="flex items-center gap-2">
+            <LineChart className="h-5 w-5 text-primary" />
+            Live quotes & order book
+          </CardTitle>
+          <CardDescription>
+            Look up live bid/ask, recent trades, and L2 depth for any subscribed symbol. Refreshes every {POLL_INTERVAL_MS / 1000}s.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <label htmlFor="live-quote-symbol" className="sr-only">Symbol</label>
+            <Input
+              id="live-quote-symbol"
+              placeholder="Enter a symbol (e.g. AAPL)"
+              value={symbolInput}
+              onChange={(event) => setSymbolInput(event.target.value)}
+              leadingIcon={<Search className="h-4 w-4" />}
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <div className="flex items-center gap-2">
+              <Button type="submit" variant="default">View quote</Button>
+              {activeSymbol ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void fetchAll(activeSymbol)}
+                  aria-label="Refresh live data now"
+                >
+                  <RefreshCw className={`h-4 w-4 ${refreshing ? "animate-spin" : ""}`} aria-hidden="true" />
+                  <span className="ml-1.5">Refresh</span>
+                </Button>
+              ) : null}
+            </div>
+          </form>
+          {activeSymbol ? (
+            <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <span className="font-semibold text-foreground">{activeSymbol}</span>
+              {venueLabel ? <Badge variant="outline">{venueLabel}</Badge> : null}
+              {stale ? <Badge variant="warning">Stale</Badge> : null}
+              <span>Last update {formatTimestamp(quoteRow?.timestamp ?? orderbook.data?.timestamp ?? null)}</span>
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      {!activeSymbol ? (
+        <Card>
+          <CardContent className="py-10 text-center text-sm text-muted-foreground">
+            Enter a symbol above to see live BBO, recent trades, and L2 depth.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 lg:grid-cols-[1fr_1fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Best bid / offer</CardTitle>
+              <CardDescription>Top-of-book quote and spread</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {quote.error && !quote.data ? (
+                <p className="text-sm text-danger">{quote.error}</p>
+              ) : !quoteRow ? (
+                <p className="text-sm text-muted-foreground">No quote data available for {activeSymbol}.</p>
+              ) : (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <BboPanel
+                    label="Bid"
+                    price={quoteRow.bidPrice}
+                    size={quoteRow.bidSize}
+                    tone="positive"
+                    icon={<ArrowDown className="h-4 w-4" aria-hidden="true" />}
+                  />
+                  <BboPanel
+                    label="Ask"
+                    price={quoteRow.askPrice}
+                    size={quoteRow.askSize}
+                    tone="negative"
+                    icon={<ArrowUp className="h-4 w-4" aria-hidden="true" />}
+                  />
+                  <MetricRow label="Mid" value={formatPrice(quoteRow.midPrice)} />
+                  <MetricRow label="Spread" value={formatPrice(quoteRow.spread)} />
+                  <MetricRow label="Sequence" value={quoteRow.sequenceNumber.toLocaleString()} />
+                  <MetricRow label="Stream" value={quoteRow.streamId ?? "—"} />
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Order book (L2)</CardTitle>
+              <CardDescription>Top {orderbook.data?.bids.length ?? 0} bids / {orderbook.data?.asks.length ?? 0} asks</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {orderbook.error && !orderbook.data ? (
+                <p className="text-sm text-danger">{orderbook.error}</p>
+              ) : !orderbook.data || (orderbook.data.bids.length === 0 && orderbook.data.asks.length === 0) ? (
+                <p className="text-sm text-muted-foreground">No depth data available for {activeSymbol}.</p>
+              ) : (
+                <DepthLadder data={orderbook.data} />
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="lg:col-span-2">
+            <CardHeader>
+              <CardTitle className="text-base">Recent trades</CardTitle>
+              <CardDescription>Last {tradeRows.length} prints</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {trades.error && !trades.data ? (
+                <p className="text-sm text-danger">{trades.error}</p>
+              ) : tradeRows.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No recent trades for {activeSymbol}.</p>
+              ) : (
+                <TradesTable trades={tradeRows} />
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MetricRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between border-b border-border/40 py-2 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-mono text-foreground">{value}</span>
+    </div>
+  );
+}
+
+interface BboPanelProps {
+  label: string;
+  price: number;
+  size: number;
+  tone: "positive" | "negative";
+  icon: React.ReactNode;
+}
+
+function BboPanel({ label, price, size, tone, icon }: BboPanelProps) {
+  const toneClass = tone === "positive"
+    ? "border-positive/30 bg-positive/5 text-positive"
+    : "border-danger/30 bg-danger/5 text-danger";
+  return (
+    <div className={`rounded-md border px-3 py-3 ${toneClass}`}>
+      <div className="flex items-center gap-1.5 text-xs uppercase tracking-wide">
+        {icon}
+        <span>{label}</span>
+      </div>
+      <div className="mt-2 font-mono text-2xl text-foreground">{formatPrice(price)}</div>
+      <div className="mt-1 text-xs text-muted-foreground">{formatSize(size)} shares</div>
+    </div>
+  );
+}
+
+function DepthLadder({ data }: { data: OrderBookResponse }) {
+  const maxSize = Math.max(
+    1,
+    ...data.bids.map((l) => l.size),
+    ...data.asks.map((l) => l.size)
+  );
+  return (
+    <div className="grid grid-cols-2 gap-2 font-mono text-xs">
+      <div>
+        <div className="mb-1 flex justify-between text-muted-foreground">
+          <span>Bid size</span>
+          <span>Price</span>
+        </div>
+        {data.bids.map((level) => (
+          <div key={`bid-${level.level}`} className="relative flex justify-between rounded-sm px-2 py-1">
+            <span
+              aria-hidden="true"
+              className="absolute inset-y-0 right-0 rounded-sm bg-positive/15"
+              style={{ width: `${(level.size / maxSize) * 100}%` }}
+            />
+            <span className="relative">{formatSize(level.size)}</span>
+            <span className="relative text-positive">{formatPrice(level.price)}</span>
+          </div>
+        ))}
+      </div>
+      <div>
+        <div className="mb-1 flex justify-between text-muted-foreground">
+          <span>Price</span>
+          <span>Ask size</span>
+        </div>
+        {data.asks.map((level) => (
+          <div key={`ask-${level.level}`} className="relative flex justify-between rounded-sm px-2 py-1">
+            <span
+              aria-hidden="true"
+              className="absolute inset-y-0 left-0 rounded-sm bg-danger/15"
+              style={{ width: `${(level.size / maxSize) * 100}%` }}
+            />
+            <span className="relative text-danger">{formatPrice(level.price)}</span>
+            <span className="relative">{formatSize(level.size)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TradesTable({ trades }: { trades: TradeDataResponse[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="border-b border-border/60 text-left text-xs uppercase tracking-wide text-muted-foreground">
+            <th className="px-2 py-2 font-medium">Time</th>
+            <th className="px-2 py-2 font-medium text-right">Price</th>
+            <th className="px-2 py-2 font-medium text-right">Size</th>
+            <th className="px-2 py-2 font-medium">Aggressor</th>
+            <th className="px-2 py-2 font-medium">Venue</th>
+          </tr>
+        </thead>
+        <tbody className="font-mono">
+          {trades.map((t) => {
+            const aggressor = t.aggressor?.toLowerCase();
+            const aggressorClass = aggressor === "buy"
+              ? "text-positive"
+              : aggressor === "sell"
+                ? "text-danger"
+                : "text-muted-foreground";
+            return (
+              <tr key={`${t.sequenceNumber}-${t.timestamp}`} className="border-b border-border/30">
+                <td className="px-2 py-1.5">{formatTimestamp(t.timestamp)}</td>
+                <td className="px-2 py-1.5 text-right">{formatPrice(t.price)}</td>
+                <td className="px-2 py-1.5 text-right">{formatSize(t.size)}</td>
+                <td className={`px-2 py-1.5 ${aggressorClass}`}>{t.aggressor}</td>
+                <td className="px-2 py-1.5 text-muted-foreground">{t.venue ?? "—"}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowDown, ArrowUp, LineChart, RefreshCw, Search } from "lucide-react";
+import { Link, useSearchParams } from "react-router-dom";
+import { ArrowDown, ArrowUp, ListPlus, LineChart, RefreshCw, Search } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -44,8 +45,10 @@ function formatTimestamp(iso: string | null | undefined): string {
 }
 
 export function LiveQuotesScreen() {
-  const [symbolInput, setSymbolInput] = useState("");
-  const [activeSymbol, setActiveSymbol] = useState<string | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialSymbol = (searchParams.get("symbol") ?? "").trim().toUpperCase();
+  const [symbolInput, setSymbolInput] = useState(initialSymbol);
+  const [activeSymbol, setActiveSymbol] = useState<string | null>(initialSymbol || null);
   const [quote, setQuote] = useState<LoadState<QuotesResponse>>({ data: null, error: null });
   const [trades, setTrades] = useState<LoadState<TradesResponse>>({ data: null, error: null });
   const [orderbook, setOrderbook] = useState<LoadState<OrderBookResponse>>({ data: null, error: null });
@@ -92,6 +95,7 @@ export function LiveQuotesScreen() {
     setTrades({ data: null, error: null });
     setOrderbook({ data: null, error: null });
     setActiveSymbol(next);
+    setSearchParams({ symbol: next }, { replace: true });
   };
 
   const quoteRow = quote.data?.quote;
@@ -127,6 +131,12 @@ export function LiveQuotesScreen() {
             />
             <div className="flex items-center gap-2">
               <Button type="submit" variant="default">View quote</Button>
+              <Button asChild variant="outline" size="sm">
+                <Link to="/data/watchlist" aria-label="Open symbol watchlist">
+                  <ListPlus className="h-4 w-4" aria-hidden="true" />
+                  <span className="ml-1.5">Watchlist</span>
+                </Link>
+              </Button>
               {activeSymbol ? (
                 <Button
                   type="button"

--- a/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.tsx
@@ -1,0 +1,261 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { Activity, AlertCircle, LineChart, Plus, RefreshCw, Trash2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  addSymbol as addSymbolApi,
+  getSymbols,
+  getSymbolsStatistics,
+  removeSymbol as removeSymbolApi
+} from "@/lib/api";
+import type { SymbolRecord, SymbolStatistics } from "@/types";
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return "Never";
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return "Never";
+  const diff = Date.now() - ts;
+  if (diff < 0) return new Date(iso).toLocaleString();
+  const seconds = Math.round(diff / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+function statusVariant(status: SymbolRecord["status"]) {
+  switch (status) {
+    case "Active":
+      return "success" as const;
+    case "Monitored":
+      return "default" as const;
+    case "Archived":
+      return "outline" as const;
+    case "Error":
+      return "danger" as const;
+    default:
+      return "outline" as const;
+  }
+}
+
+export function WatchlistScreen() {
+  const [symbols, setSymbols] = useState<SymbolRecord[] | null>(null);
+  const [stats, setStats] = useState<SymbolStatistics | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [pendingSymbol, setPendingSymbol] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [removing, setRemoving] = useState<Record<string, boolean>>({});
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      const [s, st] = await Promise.allSettled([getSymbols(), getSymbolsStatistics()]);
+      if (s.status === "fulfilled") {
+        setSymbols(s.value);
+        setLoadError(null);
+      } else {
+        setLoadError((s.reason as Error)?.message ?? "Failed to load symbols");
+      }
+      if (st.status === "fulfilled") {
+        setStats(st.value);
+      }
+    } finally {
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleAdd = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const next = pendingSymbol.trim().toUpperCase();
+    if (!next || submitting) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const result = await addSymbolApi(next);
+      if (!result.success) {
+        setSubmitError(`Could not add ${next}.`);
+        return;
+      }
+      setPendingSymbol("");
+      await refresh();
+    } catch (err) {
+      setSubmitError((err as Error)?.message ?? "Failed to add symbol");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleRemove = async (symbol: string) => {
+    setRemoving((current) => ({ ...current, [symbol]: true }));
+    try {
+      await removeSymbolApi(symbol);
+      await refresh();
+    } catch (err) {
+      setLoadError((err as Error)?.message ?? `Failed to remove ${symbol}`);
+    } finally {
+      setRemoving((current) => {
+        const { [symbol]: _ignored, ...rest } = current;
+        return rest;
+      });
+    }
+  };
+
+  const sortedSymbols = useMemo(() => {
+    if (!symbols) return null;
+    return [...symbols].sort((a, b) => a.symbol.localeCompare(b.symbol));
+  }, [symbols]);
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <div className="eyebrow-label">Data Lane</div>
+          <CardTitle className="flex items-center gap-2">
+            <Activity className="h-5 w-5 text-primary" />
+            Symbol watchlist
+          </CardTitle>
+          <CardDescription>
+            Add, remove, and monitor symbols subscribed to the live data pipeline. Click a symbol to view live quotes.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <StatCard label="Total" value={stats?.totalSymbols} />
+            <StatCard label="Monitored" value={stats?.monitoredSymbols} />
+            <StatCard label="Archived" value={stats?.archivedSymbols} />
+            <StatCard label="Errors" value={stats?.symbolsWithErrors} tone={stats && stats.symbolsWithErrors > 0 ? "danger" : "default"} />
+          </div>
+
+          <form onSubmit={handleAdd} className="mt-5 flex flex-col gap-2 sm:flex-row sm:items-center">
+            <label htmlFor="add-symbol-input" className="sr-only">Add symbol</label>
+            <Input
+              id="add-symbol-input"
+              placeholder="Add a symbol (e.g. MSFT)"
+              value={pendingSymbol}
+              onChange={(event) => setPendingSymbol(event.target.value)}
+              autoComplete="off"
+              spellCheck={false}
+              error={submitError !== null}
+              aria-describedby={submitError ? "add-symbol-error" : undefined}
+            />
+            <Button type="submit" variant="default" disabled={submitting || pendingSymbol.trim().length === 0}>
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              <span className="ml-1.5">{submitting ? "Adding…" : "Add"}</span>
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={() => void refresh()} aria-label="Refresh watchlist">
+              <RefreshCw className={`h-4 w-4 ${refreshing ? "animate-spin" : ""}`} aria-hidden="true" />
+              <span className="ml-1.5">Refresh</span>
+            </Button>
+          </form>
+          {submitError ? (
+            <p id="add-symbol-error" className="mt-2 flex items-center gap-1.5 text-xs text-danger">
+              <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />
+              {submitError}
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Subscribed symbols</CardTitle>
+          <CardDescription>
+            {sortedSymbols ? `${sortedSymbols.length} symbol${sortedSymbols.length === 1 ? "" : "s"} configured.` : "Loading…"}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {loadError && !sortedSymbols ? (
+            <p className="text-sm text-danger">{loadError}</p>
+          ) : !sortedSymbols ? (
+            <p className="text-sm text-muted-foreground">Loading symbols…</p>
+          ) : sortedSymbols.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No symbols configured. Add one above to start collecting live data.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border/60 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                    <th className="px-2 py-2 font-medium">Symbol</th>
+                    <th className="px-2 py-2 font-medium">Status</th>
+                    <th className="px-2 py-2 font-medium">Provider</th>
+                    <th className="px-2 py-2 font-medium">Last event</th>
+                    <th className="px-2 py-2 font-medium text-right">Events</th>
+                    <th className="px-2 py-2 font-medium">History</th>
+                    <th className="px-2 py-2" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {sortedSymbols.map((row) => {
+                    const isRemoving = removing[row.symbol] === true;
+                    return (
+                      <tr key={row.symbol} className="border-b border-border/30">
+                        <td className="px-2 py-1.5 font-mono font-semibold">{row.symbol}</td>
+                        <td className="px-2 py-1.5">
+                          <Badge variant={statusVariant(row.status)} dot>{row.status}</Badge>
+                        </td>
+                        <td className="px-2 py-1.5 text-muted-foreground">{row.provider ?? "—"}</td>
+                        <td className="px-2 py-1.5 text-muted-foreground">{formatRelative(row.lastEventAt)}</td>
+                        <td className="px-2 py-1.5 text-right font-mono">{row.eventCount.toLocaleString()}</td>
+                        <td className="px-2 py-1.5 text-muted-foreground">
+                          {row.hasHistoricalData ? <span className="text-positive">Yes</span> : "—"}
+                        </td>
+                        <td className="px-2 py-1.5 text-right">
+                          <div className="flex justify-end gap-1.5">
+                            <Button asChild variant="outline" size="sm">
+                              <Link
+                                to={`/data/quotes?symbol=${encodeURIComponent(row.symbol)}`}
+                                aria-label={`View live quotes for ${row.symbol}`}
+                              >
+                                <LineChart className="h-3.5 w-3.5" aria-hidden="true" />
+                                <span className="ml-1">Quote</span>
+                              </Link>
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              disabled={isRemoving}
+                              onClick={() => void handleRemove(row.symbol)}
+                              aria-label={`Remove ${row.symbol} from watchlist`}
+                            >
+                              <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                              <span className="ml-1">{isRemoving ? "Removing…" : "Remove"}</span>
+                            </Button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function StatCard({ label, value, tone = "default" }: { label: string; value: number | undefined; tone?: "default" | "danger" }) {
+  const toneClass = tone === "danger" ? "text-danger" : "text-foreground";
+  return (
+    <div className="rounded-md border border-border/60 bg-secondary/25 px-3 py-3">
+      <div className="text-xs uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className={`mt-1 font-mono text-2xl ${toneClass}`}>
+        {value === undefined ? "—" : value.toLocaleString()}
+      </div>
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/types.ts
+++ b/src/Meridian.Ui/dashboard/src/types.ts
@@ -1396,3 +1396,63 @@ export interface TradingParameters {
   circuitBreakerThresholdPct: number | null;
   asOf: string;
 }
+
+export interface QuoteDataResponse {
+  symbol: string;
+  timestamp: string;
+  bidPrice: number;
+  bidSize: number;
+  askPrice: number;
+  askSize: number;
+  midPrice: number | null;
+  spread: number | null;
+  sequenceNumber: number;
+  streamId: string | null;
+  venue: string | null;
+}
+
+export interface QuotesResponse {
+  symbol: string;
+  quote: QuoteDataResponse | null;
+  timestamp: string;
+}
+
+export interface TradeDataResponse {
+  symbol: string;
+  timestamp: string;
+  price: number;
+  size: number;
+  aggressor: string;
+  sequenceNumber: number;
+  streamId: string | null;
+  venue: string | null;
+}
+
+export interface TradesResponse {
+  symbol: string;
+  trades: TradeDataResponse[];
+  count: number;
+  timestamp: string;
+}
+
+export interface OrderBookLevelDto {
+  side: string;
+  level: number;
+  price: number;
+  size: number;
+  marketMaker: string | null;
+}
+
+export interface OrderBookResponse {
+  symbol: string;
+  timestamp: string;
+  bids: OrderBookLevelDto[];
+  asks: OrderBookLevelDto[];
+  midPrice: number | null;
+  imbalance: number | null;
+  marketState: string;
+  sequenceNumber: number;
+  isStale: boolean;
+  streamId: string | null;
+  venue: string | null;
+}


### PR DESCRIPTION
## Description

This PR adds two new screens to the data operations section of the dashboard:

1. **Live Quotes Screen** (`live-quotes-screen.tsx`): A real-time market data viewer that displays:
   - Best bid/offer (BBO) with top-of-book quotes and spread
   - Level 2 order book depth (configurable levels)
   - Recent trades with price, size, aggressor, and venue information
   - Auto-refreshing data every 2 seconds with manual refresh capability
   - Symbol search with URL parameter support for deep linking

2. **Watchlist Screen** (`watchlist-screen.tsx`): A symbol management interface that allows users to:
   - Add/remove symbols from the subscription watchlist
   - View symbol status (Active, Monitored, Archived, Error)
   - Track event counts and last activity timestamps
   - Quick navigation to live quotes for any symbol
   - Display aggregate statistics (total, monitored, archived, error counts)

Both screens integrate with new API endpoints for fetching live market data and managing symbol subscriptions. The implementation includes proper error handling, loading states, and responsive UI components.

## Type of Change

- New feature
- UI/UX enhancement

## Motivation and Context

These screens provide traders and analysts with real-time access to market data and a centralized location to manage their symbol subscriptions. The live quotes screen enables quick analysis of bid/ask spreads, order book depth, and recent trade activity, while the watchlist screen provides administrative control over which symbols are being monitored by the system.

## How Has This Been Tested?

- UI components render correctly with sample data
- API integration points are properly typed with new TypeScript interfaces
- Error states and loading states are handled appropriately
- Responsive design verified across different screen sizes
- URL parameter handling for symbol deep linking works as expected

## Checklist

- [x] My code follows the code style of this project
- [x] All new and existing tests passed
- [x] I have checked my code and corrected any misspellings
- [x] My changes generate no new warnings

## Related Issues

Adds new data operations screens for live market data viewing and symbol management.

https://claude.ai/code/session_01VZLwfx8RRz5PxMrYVbPSB4