### PR TITLE
feat(quantlab): parameter side panel, Heatmap/Candlestick renderers, sec-master wiring

### DIFF
--- a/src/Meridian.QuantScript/Api/QuantDataContext.cs
+++ b/src/Meridian.QuantScript/Api/QuantDataContext.cs
@@ -48,6 +48,7 @@ public sealed class QuantDataContext(
         if (bars.Count == 0)
         {
             logger.LogWarning("No price data found for {Symbol} from {From} to {To}", symbol, from, to);
+            await LogSecMasterHintAsync(symbol, ct).ConfigureAwait(false);
         }
 
         bars.Sort((a, b) => a.Date.CompareTo(b.Date));
@@ -111,6 +112,32 @@ public sealed class QuantDataContext(
             return new ScriptOrderBook(closest.Timestamp, bids, asks);
         }
         return null;
+    }
+
+    private async Task LogSecMasterHintAsync(string symbol, CancellationToken ct)
+    {
+        if (securityMasterQuery is null) return;
+        try
+        {
+            var detail = await securityMasterQuery.GetByIdentifierAsync(
+                SecurityIdentifierKind.Ticker, symbol, null, ct)
+                .ConfigureAwait(false);
+
+            if (detail is null)
+                logger.LogWarning(
+                    "Symbol {Symbol} is not registered in the Security Master. " +
+                    "Verify the ticker spelling. " +
+                    "Use Data.SecMaster(symbol) inside a script to query registered identifiers.",
+                    symbol);
+            else
+                logger.LogDebug(
+                    "Security Master: {Symbol} is known ({DisplayName}, {AssetClass}) but no price data was stored for the requested date range.",
+                    symbol, detail.DisplayName, detail.AssetClass);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogDebug(ex, "Security Master hint lookup failed for {Symbol}", symbol);
+        }
     }
 
     /// <inheritdoc />

--- a/src/Meridian.Ui/dashboard/src/components/meridian/quant-plot.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/quant-plot.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import type { QuantPlot, QuantPlotPoint, QuantPlotSeries } from "@/types";
+import type { QuantPlot, QuantPlotBar, QuantPlotPoint, QuantPlotSeries } from "@/types";
 
 const WIDTH = 480;
 const HEIGHT = 220;
@@ -118,6 +118,14 @@ export function QuantPlotChart({ plot }: QuantPlotChartProps) {
     return <ScatterChart plot={plot} points={renderable.points} bounds={renderable.bounds} />;
   }
 
+  if (renderable.kind === "candlestick") {
+    return <CandlestickChart plot={plot} bars={renderable.bars} bounds={renderable.bounds} />;
+  }
+
+  if (renderable.kind === "heatmap") {
+    return <HeatmapChart plot={plot} data={renderable.data} labels={renderable.labels} bounds={renderable.bounds} />;
+  }
+
   return <LineChart plot={plot} series={renderable.series} bounds={renderable.bounds} fillBaselineZero={renderable.fillBaseline} />;
 }
 
@@ -147,11 +155,26 @@ interface PreparedHistogram {
   bounds: Bounds;
 }
 
+interface PreparedCandlestick {
+  kind: "candlestick";
+  bars: QuantPlotBar[];
+  bounds: Bounds;
+}
+
+interface PreparedHeatmap {
+  kind: "heatmap";
+  data: number[][];
+  labels: string[];
+  bounds: Bounds;
+}
+
 type PreparedPlot =
   | PreparedLine
   | PreparedBar
   | PreparedScatter
   | PreparedHistogram
+  | PreparedCandlestick
+  | PreparedHeatmap
   | { kind: "unsupported" };
 
 export function prepareSeries(plot: QuantPlot): PreparedPlot {
@@ -207,6 +230,19 @@ export function prepareSeries(plot: QuantPlot): PreparedPlot {
         domain: safeBounds(values),
         bounds: safeBounds(bins.map((b) => b.count))
       };
+    }
+    case "Candlestick": {
+      const bars = plot.candlestick ?? [];
+      if (bars.length === 0) return { kind: "unsupported" };
+      const prices = bars.flatMap((b) => [b.open, b.high, b.low, b.close]).filter(Number.isFinite);
+      return { kind: "candlestick", bars, bounds: safeBounds(prices) };
+    }
+    case "Heatmap": {
+      const data = plot.heatmapData ?? [];
+      if (data.length === 0) return { kind: "unsupported" };
+      const labels = plot.heatmapLabels ?? [];
+      const allValues = data.flat().filter(Number.isFinite);
+      return { kind: "heatmap", data, labels, bounds: safeBounds(allValues) };
     }
     default:
       return { kind: "unsupported" };
@@ -398,6 +434,134 @@ function HistogramChart({
           </g>
         );
       })}
+    </ChartFrame>
+  );
+}
+
+function CandlestickChart({ plot, bars, bounds }: { plot: QuantPlot; bars: QuantPlotBar[]; bounds: Bounds }) {
+  const n = bars.length;
+  const slotW = n > 0 ? PLOT_WIDTH / n : PLOT_WIDTH;
+  const bodyW = Math.max(2, slotW * 0.6);
+
+  return (
+    <ChartFrame title={plot.title}>
+      <YAxis bounds={bounds} />
+      {bars.map((bar, i) => {
+        const cx = chartXFor(i, n);
+        const highY = chartYFor(bar.high, bounds);
+        const lowY = chartYFor(bar.low, bounds);
+        const openY = chartYFor(bar.open, bounds);
+        const closeY = chartYFor(bar.close, bounds);
+        const bullish = bar.close >= bar.open;
+        const color = bullish ? "#34d399" : "#f87171";
+        const bodyTop = Math.min(openY, closeY);
+        const bodyHeight = Math.max(1, Math.abs(closeY - openY));
+        return (
+          <g key={`${bar.date}-${i}`}>
+            <title>{`${bar.date}  O ${bar.open.toFixed(2)}  H ${bar.high.toFixed(2)}  L ${bar.low.toFixed(2)}  C ${bar.close.toFixed(2)}`}</title>
+            <line x1={cx} y1={highY} x2={cx} y2={lowY} stroke={color} strokeWidth={1} opacity={0.7} />
+            <rect
+              x={cx - bodyW / 2}
+              y={bodyTop}
+              width={bodyW}
+              height={bodyHeight}
+              fill={color}
+              fillOpacity={bullish ? 0.85 : 0.75}
+              stroke={color}
+              strokeWidth={0.5}
+            />
+          </g>
+        );
+      })}
+    </ChartFrame>
+  );
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return Math.round(a + (b - a) * t);
+}
+
+function heatmapColor(normalized: number): string {
+  const t = Math.max(0, Math.min(1, normalized));
+  // blue-500 → slate-50 → red-500 (diverging)
+  if (t <= 0.5) {
+    const s = t * 2;
+    return `rgb(${lerp(59, 248, s)},${lerp(130, 250, s)},${lerp(246, 252, s)})`;
+  }
+  const s = (t - 0.5) * 2;
+  return `rgb(${lerp(248, 239, s)},${lerp(250, 68, s)},${lerp(252, 68, s)})`;
+}
+
+function HeatmapChart({ plot, data, labels, bounds }: { plot: QuantPlot; data: number[][]; labels: string[]; bounds: Bounds }) {
+  const rows = data.length;
+  const cols = data[0]?.length ?? 0;
+  if (rows === 0 || cols === 0) return null;
+
+  const cellW = PLOT_WIDTH / cols;
+  const cellH = PLOT_HEIGHT / rows;
+  const range = bounds.max - bounds.min;
+
+  const xLabels = labels.length === cols ? labels : null;
+  const yLabels = labels.length === rows ? labels : null;
+
+  return (
+    <ChartFrame title={plot.title}>
+      {data.flatMap((row, ri) =>
+        row.map((val, ci) => {
+          const t = range === 0 ? 0.5 : (val - bounds.min) / range;
+          return (
+            <rect
+              key={`${ri}-${ci}`}
+              x={PADDING_LEFT + ci * cellW}
+              y={PADDING_TOP + ri * cellH}
+              width={Math.max(1, cellW - 0.5)}
+              height={Math.max(1, cellH - 0.5)}
+              fill={heatmapColor(t)}
+            >
+              <title>{val.toFixed(4)}</title>
+            </rect>
+          );
+        })
+      )}
+      {xLabels?.map((label, ci) => (
+        <text
+          key={`xl-${ci}`}
+          x={PADDING_LEFT + ci * cellW + cellW / 2}
+          y={HEIGHT - 6}
+          fontSize={9}
+          fill="rgba(148,163,184,0.85)"
+          textAnchor="middle"
+        >
+          {label.length > 6 ? `${label.slice(0, 5)}…` : label}
+        </text>
+      ))}
+      {yLabels?.map((label, ri) => (
+        <text
+          key={`yl-${ri}`}
+          x={PADDING_LEFT - 4}
+          y={PADDING_TOP + ri * cellH + cellH / 2 + 3}
+          fontSize={9}
+          fill="rgba(148,163,184,0.85)"
+          textAnchor="end"
+        >
+          {label.length > 6 ? `${label.slice(0, 5)}…` : label}
+        </text>
+      ))}
+      <defs>
+        <linearGradient id={`heatmap-scale-${plot.title.replace(/\s+/g, "-")}`} x1="0" x2="1" y1="0" y2="0">
+          <stop offset="0%" stopColor="rgb(59,130,246)" />
+          <stop offset="50%" stopColor="rgb(248,250,252)" />
+          <stop offset="100%" stopColor="rgb(239,68,68)" />
+        </linearGradient>
+      </defs>
+      <rect
+        x={PADDING_LEFT}
+        y={HEIGHT - 5}
+        width={PLOT_WIDTH}
+        height={3}
+        fill={`url(#heatmap-scale-${plot.title.replace(/\s+/g, "-")})`}
+        rx={1}
+      />
     </ChartFrame>
   );
 }

--- a/src/Meridian.Ui/dashboard/src/screens/quant-lab-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/quant-lab-screen.test.tsx
@@ -5,7 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { QuantLabScreen } from "@/screens/quant-lab-screen";
 import { renderWithRouter, waitForAsyncEffects } from "@/test/render";
 import * as api from "@/lib/api";
-import type { QuantRunResponse, QuantTemplatesResponse } from "@/types";
+import type { QuantParametersResponse, QuantRunResponse, QuantTemplatesResponse } from "@/types";
 
 const templates: QuantTemplatesResponse = {
   templates: [
@@ -63,9 +63,12 @@ const failedRun: QuantRunResponse = {
   runtimeParameters: []
 };
 
+const emptyParameters: QuantParametersResponse = { parameters: [] };
+
 describe("QuantLabScreen", () => {
   beforeEach(() => {
     vi.spyOn(api, "getQuantTemplates").mockResolvedValue(templates);
+    vi.spyOn(api, "extractQuantParameters").mockResolvedValue(emptyParameters);
   });
 
   afterEach(() => {

--- a/src/Meridian.Ui/dashboard/src/screens/quant-lab-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/quant-lab-screen.tsx
@@ -5,13 +5,14 @@ import {
   FlaskConical,
   Loader2,
   Play,
+  Settings2,
   Sparkles
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { QuantPlotChart } from "@/components/meridian/quant-plot";
-import { getQuantTemplates, runQuantScript } from "@/lib/api";
+import { extractQuantParameters, getQuantTemplates, runQuantScript } from "@/lib/api";
 import type {
   QuantDiagnostic,
   QuantParameter,
@@ -33,11 +34,65 @@ interface RunState {
 
 const initialRunState: RunState = { phase: "idle", result: null, error: null };
 
+function mergeParams(existing: QuantParameter[], incoming: QuantParameter[]): QuantParameter[] {
+  const map = new Map(existing.map((p) => [p.name, p]));
+  for (const p of incoming) map.set(p.name, p);
+  return [...map.values()];
+}
+
+function initNewParamValues(
+  existing: Record<string, string>,
+  params: QuantParameter[]
+): Record<string, string> {
+  const next = { ...existing };
+  let changed = false;
+  for (const p of params) {
+    if (!(p.name in next) && p.defaultValue !== null) {
+      next[p.name] = String(p.defaultValue);
+      changed = true;
+    }
+  }
+  return changed ? next : existing;
+}
+
+function buildParameters(
+  params: QuantParameter[],
+  values: Record<string, string>
+): Record<string, string | number | boolean | null> {
+  const result: Record<string, string | number | boolean | null> = {};
+  for (const p of params) {
+    const raw = values[p.name];
+    if (raw === undefined || raw === "") {
+      result[p.name] = null;
+      continue;
+    }
+    switch (p.typeName) {
+      case "bool":
+        result[p.name] = raw === "true";
+        break;
+      case "int":
+      case "long":
+      case "double":
+      case "float":
+      case "decimal": {
+        const n = Number(raw);
+        result[p.name] = Number.isFinite(n) ? n : null;
+        break;
+      }
+      default:
+        result[p.name] = raw;
+    }
+  }
+  return result;
+}
+
 export function QuantLabScreen() {
   const [source, setSource] = useState(DEFAULT_SOURCE);
   const [templates, setTemplates] = useState<QuantTemplate[]>([]);
   const [templatesError, setTemplatesError] = useState<string | null>(null);
   const [run, setRun] = useState<RunState>(initialRunState);
+  const [detectedParams, setDetectedParams] = useState<QuantParameter[]>([]);
+  const [paramValues, setParamValues] = useState<Record<string, string>>({});
 
   useEffect(() => {
     let cancelled = false;
@@ -55,6 +110,31 @@ export function QuantLabScreen() {
     };
   }, []);
 
+  // Debounced parameter extraction from source
+  useEffect(() => {
+    if (!source.trim()) {
+      setDetectedParams([]);
+      return;
+    }
+    const timer = setTimeout(() => {
+      extractQuantParameters(source)
+        .then((r) => {
+          setDetectedParams((prev) => mergeParams(prev, r.parameters));
+          setParamValues((prev) => initNewParamValues(prev, r.parameters));
+        })
+        .catch(() => {/* non-critical — QuantLab may be disabled */});
+    }, 600);
+    return () => clearTimeout(timer);
+  }, [source]);
+
+  // Merge runtime parameters discovered during a run
+  useEffect(() => {
+    const rp = run.result?.runtimeParameters;
+    if (!rp || rp.length === 0) return;
+    setDetectedParams((prev) => mergeParams(prev, rp));
+    setParamValues((prev) => initNewParamValues(prev, rp));
+  }, [run.result]);
+
   const handleRun = useCallback(async () => {
     if (!source.trim()) {
       setRun({ phase: "error", result: null, error: "Enter some script source first." });
@@ -62,7 +142,8 @@ export function QuantLabScreen() {
     }
     setRun({ phase: "running", result: null, error: null });
     try {
-      const result = await runQuantScript({ source, parameters: {} });
+      const parameters = buildParameters(detectedParams, paramValues);
+      const result = await runQuantScript({ source, parameters });
       setRun({ phase: "ready", result, error: null });
     } catch (err) {
       setRun({
@@ -71,11 +152,24 @@ export function QuantLabScreen() {
         error: (err as Error)?.message ?? "Failed to run script."
       });
     }
-  }, [source]);
+  }, [source, detectedParams, paramValues]);
 
   const loadTemplate = useCallback((template: QuantTemplate) => {
     setSource(template.source);
     setRun(initialRunState);
+    setDetectedParams([]);
+    setParamValues({});
+  }, []);
+
+  const handleParamChange = useCallback((name: string, value: string) => {
+    setParamValues((prev) => ({ ...prev, [name]: value }));
+  }, []);
+
+  const handleParamReset = useCallback((param: QuantParameter) => {
+    setParamValues((prev) => ({
+      ...prev,
+      [param.name]: param.defaultValue !== null ? String(param.defaultValue) : ""
+    }));
   }, []);
 
   const consoleLines = useMemo(() => {
@@ -134,7 +228,15 @@ export function QuantLabScreen() {
 
       <div className="grid gap-4 lg:grid-cols-[1fr_280px]">
         <RunResultPanel run={run} consoleLines={consoleLines} tone={summaryTone} />
-        <TemplatesPanel templates={templates} error={templatesError} onSelect={loadTemplate} />
+        <div className="space-y-4">
+          <ParametersSidePanel
+            params={detectedParams}
+            values={paramValues}
+            onChange={handleParamChange}
+            onReset={handleParamReset}
+          />
+          <TemplatesPanel templates={templates} error={templatesError} onSelect={loadTemplate} />
+        </div>
       </div>
     </div>
   );
@@ -230,7 +332,6 @@ function RunResultPanel({ run, consoleLines, tone }: RunResultPanelProps) {
           ) : null}
           <DiagnosticsBlock label="Compilation errors" entries={result.compilationErrors} tone="danger" />
           <DiagnosticsBlock label="Runtime diagnostics" entries={result.runtimeDiagnostics} tone="warning" />
-          <RuntimeParametersBlock parameters={result.runtimeParameters} />
         </CardContent>
       </Card>
 
@@ -280,21 +381,108 @@ function DiagnosticsBlock({
   );
 }
 
-function RuntimeParametersBlock({ parameters }: { parameters: QuantParameter[] }) {
-  if (parameters.length === 0) return null;
+function inputTypeFor(typeName: string): "number" | "checkbox" | "text" {
+  switch (typeName) {
+    case "int":
+    case "long":
+    case "double":
+    case "float":
+    case "decimal":
+      return "number";
+    case "bool":
+      return "checkbox";
+    default:
+      return "text";
+  }
+}
+
+function stepFor(typeName: string): string {
+  return typeName === "int" || typeName === "long" ? "1" : "any";
+}
+
+interface ParametersSidePanelProps {
+  params: QuantParameter[];
+  values: Record<string, string>;
+  onChange: (name: string, value: string) => void;
+  onReset: (param: QuantParameter) => void;
+}
+
+function ParametersSidePanel({ params, values, onChange, onReset }: ParametersSidePanelProps) {
+  if (params.length === 0) return null;
+
   return (
-    <div>
-      <div className="eyebrow-label mb-1">Parameters detected</div>
-      <ul className="space-y-1 text-xs text-muted-foreground">
-        {parameters.map((p) => (
-          <li key={p.name} className="font-mono">
-            {p.name} <span className="text-foreground/70">({p.typeName})</span>
-            {p.defaultValue !== null ? <span> = {p.defaultValue}</span> : null}
-            {p.description ? <span className="ml-2 italic opacity-70">{p.description}</span> : null}
-          </li>
-        ))}
-      </ul>
-    </div>
+    <Card className="self-start">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Settings2 className="h-4 w-4 text-primary" aria-hidden="true" />
+          Parameters
+        </CardTitle>
+        <CardDescription>Override script parameters before running.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-3" aria-label="Script parameters">
+          {params.map((p) => {
+            const inputType = inputTypeFor(p.typeName);
+            const currentValue = values[p.name] ?? (p.defaultValue !== null ? String(p.defaultValue) : "");
+            const isDefault = p.defaultValue !== null && currentValue === String(p.defaultValue);
+            return (
+              <li key={p.name} className="space-y-1">
+                <div className="flex items-center justify-between gap-1">
+                  <label
+                    htmlFor={`param-${p.name}`}
+                    className="text-xs font-medium text-foreground"
+                    title={p.description ?? undefined}
+                  >
+                    {p.label}
+                  </label>
+                  <span className="rounded bg-secondary/50 px-1 py-0.5 font-mono text-[10px] text-muted-foreground">
+                    {p.typeName}
+                  </span>
+                </div>
+                {inputType === "checkbox" ? (
+                  <div className="flex items-center gap-2">
+                    <input
+                      id={`param-${p.name}`}
+                      type="checkbox"
+                      checked={currentValue === "true"}
+                      onChange={(e) => onChange(p.name, e.target.checked ? "true" : "false")}
+                      className="h-4 w-4 rounded border border-border accent-primary"
+                      aria-label={`${p.label} parameter`}
+                    />
+                    <span className="text-xs text-muted-foreground">{currentValue === "true" ? "true" : "false"}</span>
+                  </div>
+                ) : (
+                  <input
+                    id={`param-${p.name}`}
+                    type={inputType}
+                    value={currentValue}
+                    min={p.min !== null && p.min > Number.MIN_SAFE_INTEGER ? p.min : undefined}
+                    max={p.max !== null && p.max < Number.MAX_SAFE_INTEGER ? p.max : undefined}
+                    step={inputType === "number" ? stepFor(p.typeName) : undefined}
+                    onChange={(e) => onChange(p.name, e.target.value)}
+                    className="w-full rounded-md border border-border/70 bg-background/60 px-2 py-1.5 font-mono text-xs text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                    aria-label={`${p.label} parameter`}
+                  />
+                )}
+                {p.description ? (
+                  <p className="text-[10px] leading-4 text-muted-foreground">{p.description}</p>
+                ) : null}
+                {!isDefault && p.defaultValue !== null ? (
+                  <button
+                    type="button"
+                    onClick={() => onReset(p)}
+                    className="text-[10px] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                    aria-label={`Reset ${p.label} to default`}
+                  >
+                    Reset to {p.defaultValue}
+                  </button>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
   );
 }
 


### PR DESCRIPTION
- Parameters side panel: debounced static extraction (POST /api/quant/parameters)
  seeds editable controls (number/checkbox/text) from Param<T>() declarations;
  runtime parameters from run results are merged in; values are forwarded to
  runQuantScript so overrides take effect immediately without source edits.

- Heatmap SVG renderer: diverging blue→white→red colour scale, row-major cells,
  axis labels from heatmapLabels when length matches cols or rows, gradient
  legend strip. Falls back to "unsupported" placeholder when heatmapData is null.

- Candlestick SVG renderer: bullish (#34d399) / bearish (#f87171) OHLC bodies
  with high/low wicks; proportional body width; tooltip per bar.

- QuantDataContext.LogSecMasterHintAsync: when Data.Prices() returns empty,
  queries Security Master by ticker and emits a structured warning
  ("not registered in Security Master — verify ticker spelling") or a debug log
  confirming the security is known but has no stored bars for the range.

https://claude.ai/code/session_016b8u3wLwcnpifdLgWAjvVc