### PR TITLE
fix(security): require strategy permission for Quant Lab run endpoint

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/QuantLabEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/QuantLabEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Meridian.Contracts.Api;
+using Meridian.Contracts.Auth;
 using Meridian.QuantScript.Compilation;
 using Meridian.QuantScript.Plotting;
 using Microsoft.AspNetCore.Builder;
@@ -43,6 +44,11 @@ public static class QuantLabEndpoints
                     new { error = "Source code is required" },
                     jsonOptions,
                     statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            if (!HasQuantLabExecutionPermission(ctx))
+            {
+                return Results.StatusCode(StatusCodes.Status403Forbidden);
             }
 
             var runner = services.GetService<IScriptRunner>();
@@ -120,6 +126,16 @@ public static class QuantLabEndpoints
         })
         .WithName("GetQuantTemplates")
         .Produces(200);
+    }
+
+    private static bool HasQuantLabExecutionPermission(HttpContext context)
+    {
+        if (context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] is not UserPermission permissions)
+        {
+            return false;
+        }
+
+        return (permissions & UserPermission.ManageStrategies) == UserPermission.ManageStrategies;
     }
 
     private static IResult QuantLabUnavailable(JsonSerializerOptions jsonOptions)


### PR DESCRIPTION
### Motivation
- The `POST /api/quant/run` endpoint accepted caller-controlled C# source and executed it in-process, allowing any authenticated user to run code with server privileges when `QuantLab:Enabled` was true.
- The change adds an explicit authorization gate to reduce the remote code execution risk to only explicitly authorized operator roles.

### Description
- Added `using Meridian.Contracts.Auth;` and an authorization check in the `POST /api/quant/run` handler to require a permission before execution.
- Introduced a `HasQuantLabExecutionPermission(HttpContext)` helper that reads `LoginSessionMiddleware.CurrentUserPermissionsKey` and requires `UserPermission.ManageStrategies`.
- When the caller lacks the permission the endpoint now returns `403 Forbidden`, and the parameter/template endpoints are left unchanged.

### Testing
- Performed static verification by inspecting `src/Meridian.Ui.Shared/Endpoints/QuantLabEndpoints.cs` to confirm the permission check and helper were added and that the endpoint returns `403` when missing; this inspection succeeded.
- Attempted to run .NET build/test tooling, but `dotnet` was not available in the environment so automated unit/integration tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe5e9ea5508320ae69bab68f60b0c5)