### PR TITLE
fix: restore synchronous conflict detection in security master mutations

### DIFF
--- a/src/Meridian.Application/SecurityMaster/SecurityMasterService.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterService.cs
@@ -256,24 +256,19 @@ public sealed class SecurityMasterService : ISecurityMasterService, ISecurityMas
         });
     }
 
-    private Task TryRecordConflictsAsync(SecurityProjectionRecord projection, Guid securityId, CancellationToken ct)
+    private async Task TryRecordConflictsAsync(SecurityProjectionRecord projection, Guid securityId, CancellationToken ct)
     {
         if (_conflictService is null)
-            return Task.CompletedTask;
+            return;
 
-        _ = Task.Run(async () =>
+        try
         {
-            try
-            {
-                await _conflictService.RecordConflictsForProjectionAsync(projection, ct).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Conflict detection failed for security {SecurityId}", securityId);
-            }
-        }, CancellationToken.None);
-
-        return Task.CompletedTask;
+            await _conflictService.RecordConflictsForProjectionAsync(projection, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Conflict detection failed for security {SecurityId}", securityId);
+        }
     }
 
     private static SecurityProjectionRecord CreateProjectionFromResult(


### PR DESCRIPTION
### Motivation

- A recent change turned conflict detection into unbounded fire-and-forget `Task.Run` jobs, removing per-request back-pressure and allowing an authenticated caller to enqueue expensive full-security scans that can exhaust DB and app resources.  
- The intent of this change is to restore request-level back-pressure so create/amend operations wait for conflict detection completion (or fail fast with logged warnings) and prevent API-driven resource amplification.

### Description

- Replaced the fire-and-forget scheduling in `TryRecordConflictsAsync` with an awaited execution path in `src/Meridian.Application/SecurityMaster/SecurityMasterService.cs`, so the method completes only after `RecordConflictsForProjectionAsync` returns or logs an exception.  
- Converted the helper to an `async Task` that short-circuits when `_conflictService` is `null` and preserves existing try/catch logging on failure.  
- No behavioral changes to other background helpers (e.g., seed/corporate-action sync) were made; this change only affects conflict detection triggered after create/amend flows.

### Testing

- Attempted to run the targeted test slice `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~SecurityMaster" --logger "console;verbosity=minimal"`, but the test run could not execute in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).  
- No automated tests were executed successfully in this container; recommend running the same filtered test locally or in CI after restoring the .NET SDK to validate behavior and regression coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8dabf3bc83208127e9320fdc6260)