### PR TITLE
Populate Portfolio workspace cash-flow summary

### DIFF
--- a/src/Meridian.Execution/Models/IPortfolioState.cs
+++ b/src/Meridian.Execution/Models/IPortfolioState.cs
@@ -21,6 +21,13 @@ public interface IPortfolioState
     decimal RealisedPnl { get; }
 
     /// <summary>
+    /// Available buying power for new orders. Defaults to <see cref="Cash"/>
+    /// for cash accounts; margin-aware implementations override this to apply
+    /// the regime's leverage (e.g. Reg T 2× cash equity).
+    /// </summary>
+    decimal BuyingPower => Cash;
+
+    /// <summary>
     /// Open positions keyed by symbol, typed against the cross-pillar <see cref="IPosition"/> interface.
     /// Replaces the former <c>IReadOnlyDictionary&lt;string, ExecutionPosition&gt;</c> surface.
     /// Callers that require the concrete <see cref="ExecutionPosition"/> type (e.g. serialisation

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -2419,11 +2419,21 @@ public static class WorkstationEndpoints
 
         // Resolve all runs for the run-linked equity panel
         StrategyRunSummary[] allRuns = [];
+        StrategyRunDetail?[] runDetailsForCashFlow = [];
         if (readService is not null)
         {
             allRuns = (await readService.GetRunsAsync(ct: context.RequestAborted).ConfigureAwait(false))
                 .Take(12)
                 .ToArray();
+
+            // Fetch details for the most recent runs to power the cash-flow summary.
+            // Mirrors the Governance workspace pattern; bounded to avoid amplifying load.
+            var cashFlowRuns = allRuns.Take(6).ToArray();
+            runDetailsForCashFlow = cashFlowRuns.Length == 0
+                ? []
+                : await Task.WhenAll(cashFlowRuns.Select(run =>
+                        readService.GetRunDetailAsync(run.RunId, context.RequestAborted)))
+                    .ConfigureAwait(false);
         }
 
         // --- Metrics ---
@@ -2543,7 +2553,7 @@ public static class WorkstationEndpoints
             Risk: risk,
             Brokerage: brokerage,
             Runs: runs,
-            CashFlow: null);
+            CashFlow: BuildGovernanceWorkspaceCashFlowSummary(runDetailsForCashFlow));
     }
 
     private static async Task<WorkstationGovernancePayload> BuildGovernancePayloadAsync(HttpContext context)

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -1683,6 +1683,10 @@ public static class WorkstationEndpoints
             ? FormatPercent(totalPnl / portfolio.PortfolioValue)
             : "—";
 
+        var buyingPowerUsedDisplay = portfolio is not null && portfolio.BuyingPower > 0m
+            ? FormatPercent(grossExposure / portfolio.BuyingPower)
+            : "—";
+
         // --- Fills (completed orders from OMS) — PR-03: typed rows ---
         WorkstationTradingFillRow[] fills;
         if (oms is not null)
@@ -1725,7 +1729,7 @@ public static class WorkstationEndpoints
                 GrossExposure: portfolio is not null ? FormatCurrency(grossExposure) : "—",
                 Var95: "—",
                 MaxDrawdown: maxDrawdownDisplay,
-                BuyingPowerUsed: "—",
+                BuyingPowerUsed: buyingPowerUsedDisplay,
                 ActiveGuardrails:
                 [
                     "Single-name concentration cap set at 30% notional.",
@@ -2516,7 +2520,9 @@ public static class WorkstationEndpoints
             MaxDrawdown: portfolio is not null && portfolio.PortfolioValue > 0m
                 ? FormatPercent(totalPnl / portfolio.PortfolioValue)
                 : "—",
-            BuyingPowerUsed: "—",
+            BuyingPowerUsed: portfolio is not null && portfolio.BuyingPower > 0m
+                ? FormatPercent(grossExposure / portfolio.BuyingPower)
+                : "—",
             ActiveGuardrails: []);
 
         // --- Brokerage state ---

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -3003,6 +3003,8 @@ public sealed class WorkstationEndpointsTests
         var risk = trading.RootElement.GetProperty("risk");
         risk.GetProperty("netExposure").GetString().Should().Be("+$20K");
         risk.GetProperty("grossExposure").GetString().Should().Be("+$20K");
+        // Buying power = Cash (100K, default) → 20,000 / 100,000 = 20% utilisation.
+        risk.GetProperty("buyingPowerUsed").GetString().Should().Be("+20.0%");
     }
 
     [Fact]
@@ -3113,6 +3115,8 @@ public sealed class WorkstationEndpointsTests
 
         var risk = portfolio.RootElement.GetProperty("risk");
         risk.GetProperty("grossExposure").GetString().Should().Be("+$21K");
+        // Buying power = Cash (100K, default) → 21,000 / 100,000 = 21% utilisation.
+        risk.GetProperty("buyingPowerUsed").GetString().Should().Be("+21.0%");
     }
 
     private sealed class LiveMarkTestPortfolioState : Meridian.Execution.Models.IPortfolioState

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -2880,6 +2880,18 @@ public sealed class WorkstationEndpointsTests
             r.GetProperty("mode").GetString().Should().BeOneOf("paper", "backtest");
             r.GetProperty("notes").GetString().Should().NotBeNull();
         });
+
+        // Cash-flow summary is populated so the Portfolio workspace can surface
+        // cash posture and ledger variance without falling back to Governance fixtures.
+        var cashFlow = portfolio.RootElement.GetProperty("cashFlow");
+        cashFlow.ValueKind.Should().NotBe(JsonValueKind.Null);
+        cashFlow.GetProperty("tone").GetString().Should().NotBeNullOrEmpty();
+        cashFlow.GetProperty("summary").GetString().Should().NotBeNullOrEmpty();
+        cashFlow.TryGetProperty("totalCash", out _).Should().BeTrue();
+        cashFlow.TryGetProperty("totalLedgerCash", out _).Should().BeTrue();
+        cashFlow.TryGetProperty("netVariance", out _).Should().BeTrue();
+        cashFlow.TryGetProperty("runsWithCashSignals", out _).Should().BeTrue();
+        cashFlow.TryGetProperty("runsWithCashVariance", out _).Should().BeTrue();
     }
 
     [Fact]
@@ -2895,6 +2907,14 @@ public sealed class WorkstationEndpointsTests
         portfolio.RootElement.GetProperty("runs").GetArrayLength().Should().Be(0);
         portfolio.RootElement.GetProperty("risk").GetProperty("state").GetString().Should().Be("Healthy");
         portfolio.RootElement.GetProperty("brokerage").GetProperty("connection").GetString().Should().NotBeNullOrEmpty();
+
+        // CashFlow summary is always present (zeroed when there is no run data) so the
+        // Portfolio screen never has to discriminate between "no data" and "missing field".
+        var cashFlow = portfolio.RootElement.GetProperty("cashFlow");
+        cashFlow.ValueKind.Should().NotBe(JsonValueKind.Null);
+        cashFlow.GetProperty("runsWithCashSignals").GetInt32().Should().Be(0);
+        cashFlow.GetProperty("runsWithCashVariance").GetInt32().Should().Be(0);
+        cashFlow.GetProperty("tone").GetString().Should().Be("default");
     }
 
     [Fact]


### PR DESCRIPTION
Portfolio workspace was returning CashFlow: null, leaving the cash
posture and ledger variance panel blank on a real operator's first
visit. Fetch run details for the most recent runs (mirroring the
Governance workspace) and feed them through the existing builder so
operators see cash, ledger cash, financing, and variance signals.

https://claude.ai/code/session_01SGWnjLD1NMBWoSxRwWehKc