### PR TITLE
feat(overview): add portfolio at-a-glance cockpit panel to landing screen

### DIFF
--- a/src/Meridian.Ui/dashboard/src/app.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.tsx
@@ -252,7 +252,7 @@ export function App() {
             {shell.canRenderRoutes ? (
               <Suspense fallback={<WorkspaceRouteFallback title={`Loading ${shell.activeWorkspace.label}`} />}>
                 <Routes>
-                  <Route path="/" element={<OverviewScreen data={overview} session={session} />} />
+                  <Route path="/" element={<OverviewScreen data={overview} session={session} trading={trading} portfolio={portfolio} />} />
                   <Route path="/trading/readiness" element={(
                     <OperatorReadinessConsole
                       research={research}

--- a/src/Meridian.Ui/dashboard/src/screens/overview-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/overview-screen.tsx
@@ -23,17 +23,28 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import {
+  buildOverviewPortfolioPanel,
   useOverviewStatusViewModel,
   type OverviewActivityRow,
   type OverviewBriefingBadgeVariant,
   type OverviewBriefingTone,
-  type OverviewValueBlocker
+  type OverviewPortfolioPanel,
+  type OverviewValueBlocker,
+  type PortfolioPanelTone
 } from "@/screens/overview-screen.view-model";
-import type { SessionInfo, SystemOverviewResponse, WorkspaceKey } from "@/types";
+import type {
+  PortfolioWorkspaceResponse,
+  SessionInfo,
+  SystemOverviewResponse,
+  TradingWorkspaceResponse,
+  WorkspaceKey
+} from "@/types";
 
 interface OverviewScreenProps {
   data: SystemOverviewResponse | null;
   session: SessionInfo | null;
+  trading?: TradingWorkspaceResponse | null;
+  portfolio?: PortfolioWorkspaceResponse | null;
 }
 
 const systemStatusConfig = {
@@ -106,11 +117,12 @@ const workspaceIconConfig: Record<WorkspaceKey, { icon: ElementType; accent: str
   settings: { icon: Settings, accent: "text-muted-foreground" }
 };
 
-export function OverviewScreen({ data, session }: OverviewScreenProps) {
+export function OverviewScreen({ data, session, trading = null, portfolio = null }: OverviewScreenProps) {
   const vm = useOverviewStatusViewModel(data, session);
   const current = vm.current;
   const statusConfig = current ? systemStatusConfig[current.systemStatus] : null;
   const StatusIcon = statusConfig?.icon ?? Radio;
+  const portfolioPanel = buildOverviewPortfolioPanel(trading, portfolio);
 
   return (
     <div className="space-y-6">
@@ -165,6 +177,8 @@ export function OverviewScreen({ data, session }: OverviewScreenProps) {
           {vm.refreshErrorText}
         </div>
       )}
+
+      <PortfolioPanel panel={portfolioPanel} />
 
       <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
         <Card className="border-border/70 bg-panel-strong">
@@ -383,6 +397,105 @@ function ValueBlockerRow({ blocker }: { blocker: OverviewValueBlocker }) {
         </Link>
       </div>
     </li>
+  );
+}
+
+const portfolioPanelToneClass: Record<PortfolioPanelTone, string> = {
+  default: "text-foreground",
+  success: "text-success",
+  warning: "text-warning",
+  danger: "text-danger"
+} as const;
+
+const riskBadgeVariant: Record<PortfolioPanelTone, "outline" | "success" | "warning" | "danger"> = {
+  default: "outline",
+  success: "success",
+  warning: "warning",
+  danger: "danger"
+} as const;
+
+function PortfolioPanel({ panel }: { panel: OverviewPortfolioPanel }) {
+  return (
+    <Card className="border-border/70">
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <div className="eyebrow-label">Portfolio cockpit</div>
+            <CardTitle className="mt-1 flex items-center gap-2 text-base">
+              <TrendingUp className="size-4 text-success" aria-hidden="true" />
+              Portfolio at a glance
+            </CardTitle>
+          </div>
+          <div className="flex items-center gap-2">
+            {panel.hasData && (
+              <Badge variant={riskBadgeVariant[panel.riskTone]} dot={panel.riskTone === "success"}>
+                {panel.riskState}
+              </Badge>
+            )}
+            <Button asChild variant="outline" size="sm">
+              <Link to="/trading">
+                <ArrowRight className="size-3.5" aria-hidden="true" />
+                Trading cockpit
+              </Link>
+            </Button>
+          </div>
+        </div>
+        {panel.hasData && panel.brokerageLabel !== "—" && (
+          <p className="mt-1 font-mono text-[11px] text-muted-foreground">{panel.brokerageLabel}</p>
+        )}
+      </CardHeader>
+      <CardContent>
+        {panel.hasData ? (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              {panel.metrics.map((metric) => (
+                <MetricCard key={metric.id} {...metric} />
+              ))}
+            </div>
+            {panel.positions.length > 0 ? (
+              <div>
+                <p className="mb-2 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                  Open positions
+                </p>
+                <ul className="space-y-1.5" aria-label="Open positions overview">
+                  {panel.positions.map((pos) => (
+                    <li
+                      key={pos.key}
+                      role="group"
+                      aria-label={pos.ariaLabel}
+                      className="flex flex-wrap items-center gap-x-4 gap-y-1 rounded-md border border-border/60 bg-secondary/20 px-3 py-2 text-xs"
+                    >
+                      <span className="min-w-[3.5rem] font-mono font-semibold text-foreground">{pos.symbol}</span>
+                      <Badge variant={pos.side === "Long" ? "outline" : "warning"} className="shrink-0 text-[10px]">
+                        {pos.side}
+                      </Badge>
+                      <span className="font-mono text-muted-foreground">{pos.quantity} shares</span>
+                      <span className="font-mono text-muted-foreground">mark {pos.markPrice}</span>
+                      <span className={cn("ml-auto font-mono font-medium", portfolioPanelToneClass[pos.pnlTone])}>
+                        {pos.unrealizedPnl}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : (
+              <p className="rounded-md border border-border/60 bg-secondary/20 px-4 py-3 text-center text-xs text-muted-foreground">
+                {panel.emptyMessage}
+              </p>
+            )}
+            {panel.riskSummary ? (
+              <p className={cn("text-xs leading-5", portfolioPanelToneClass[panel.riskTone])}>
+                {panel.riskSummary}
+              </p>
+            ) : null}
+          </div>
+        ) : (
+          <p className="rounded-md border border-border/60 bg-secondary/20 px-4 py-6 text-center text-sm text-muted-foreground">
+            {panel.emptyMessage}
+          </p>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/Meridian.Ui/dashboard/src/screens/overview-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/overview-screen.view-model.ts
@@ -1,7 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getSystemStatus } from "@/lib/api";
 import { WORKSPACES, workspacePath } from "@/lib/workspace";
-import type { MetricSnapshot, SessionInfo, SystemEventRecord, SystemOverviewResponse, WorkspaceKey } from "@/types";
+import type {
+  MetricSnapshot,
+  PortfolioWorkspaceResponse,
+  SessionInfo,
+  SystemEventRecord,
+  SystemOverviewResponse,
+  TradingWorkspaceResponse,
+  WorkspaceKey
+} from "@/types";
 
 export type OverviewRefreshFetcher = () => Promise<SystemOverviewResponse>;
 
@@ -763,4 +771,121 @@ function formatTime(value: string | Date | null | undefined): string {
 
   const date = typeof value === "string" ? new Date(value) : value;
   return Number.isNaN(date.getTime()) ? "Unavailable" : date.toLocaleTimeString();
+}
+
+// --- Portfolio at-a-glance panel ---
+
+export type PortfolioPanelTone = "default" | "success" | "warning" | "danger";
+
+export interface OverviewPositionRow {
+  key: string;
+  symbol: string;
+  side: "Long" | "Short";
+  quantity: string;
+  markPrice: string;
+  unrealizedPnl: string;
+  pnlTone: PortfolioPanelTone;
+  exposure: string;
+  ariaLabel: string;
+}
+
+export interface OverviewPortfolioPanel {
+  hasData: boolean;
+  metrics: MetricSnapshot[];
+  positions: OverviewPositionRow[];
+  riskState: string;
+  riskTone: PortfolioPanelTone;
+  riskSummary: string;
+  brokerageLabel: string;
+  openOrderCount: number;
+  emptyMessage: string;
+}
+
+export function buildOverviewPortfolioPanel(
+  trading: TradingWorkspaceResponse | null,
+  portfolio: PortfolioWorkspaceResponse | null
+): OverviewPortfolioPanel {
+  const source = trading ?? portfolio;
+
+  if (!source) {
+    return {
+      hasData: false,
+      metrics: [],
+      positions: [],
+      riskState: "—",
+      riskTone: "default",
+      riskSummary: "",
+      brokerageLabel: "—",
+      openOrderCount: 0,
+      emptyMessage: "Connect a brokerage account or start a paper session to see your portfolio here."
+    };
+  }
+
+  const tradingMetrics = trading?.metrics ?? [];
+  const portfolioMetrics = portfolio?.metrics ?? tradingMetrics;
+
+  const pnlMetric = tradingMetrics.find((m) => m.id === "pnl") ?? portfolioMetrics.find((m) => m.id === "portfolio-equity");
+  const equityMetric = portfolioMetrics.find((m) => m.id === "portfolio-equity");
+  const cashMetric = portfolioMetrics.find((m) => m.id === "portfolio-cash");
+  const ordersMetric = tradingMetrics.find((m) => m.id === "orders");
+
+  const metrics: MetricSnapshot[] = [
+    pnlMetric
+      ? { ...pnlMetric, id: "overview-pnl", label: "Net P&L" }
+      : { id: "overview-pnl", label: "Net P&L", value: "—", tone: "default" },
+    equityMetric
+      ? { ...equityMetric, id: "overview-equity", label: "Portfolio Equity" }
+      : { id: "overview-equity", label: "Portfolio Equity", value: "—", tone: "default" },
+    cashMetric
+      ? { ...cashMetric, id: "overview-cash", label: "Cash" }
+      : { id: "overview-cash", label: "Cash", value: "—", tone: "default" },
+    ordersMetric
+      ? { ...ordersMetric, id: "overview-orders", label: "Open Orders" }
+      : {
+          id: "overview-orders",
+          label: "Open Orders",
+          value: String(trading?.openOrders.length ?? 0),
+          tone: "default"
+        }
+  ];
+
+  const riskState = source.risk?.state ?? "—";
+  const riskTone: PortfolioPanelTone =
+    riskState === "Constrained" ? "danger" : riskState === "Observe" ? "warning" : riskState === "Healthy" ? "success" : "default";
+
+  const positions: OverviewPositionRow[] = (source.positions ?? [])
+    .filter((pos) => pos.symbol !== "—")
+    .slice(0, 5)
+    .map((pos) => {
+      const pnlStr = pos.unrealizedPnl ?? "";
+      const pnlTone: PortfolioPanelTone = pnlStr.startsWith("+") ? "success" : pnlStr.startsWith("-") ? "danger" : "default";
+      return {
+        key: pos.positionKey ?? pos.symbol,
+        symbol: pos.symbol,
+        side: pos.side,
+        quantity: pos.quantity,
+        markPrice: pos.markPrice,
+        unrealizedPnl: pos.unrealizedPnl,
+        pnlTone,
+        exposure: pos.exposure,
+        ariaLabel: `${pos.symbol} ${pos.side} ${pos.quantity} shares, mark ${pos.markPrice}, unrealized P&L ${pos.unrealizedPnl}`
+      };
+    });
+
+  const brokerage = source.brokerage;
+  const brokerageLabel = brokerage
+    ? `${brokerage.provider} · ${brokerage.account} · ${brokerage.environment}`
+    : "—";
+
+  return {
+    hasData: true,
+    metrics,
+    positions,
+    riskState,
+    riskTone,
+    riskSummary: source.risk?.summary ?? "",
+    brokerageLabel,
+    openOrderCount: trading?.openOrders.length ?? 0,
+    emptyMessage: "No open positions. Use the trading cockpit to place your first order."
+  };
 }


### PR DESCRIPTION
The overview screen now shows the trader's actual portfolio state
immediately on landing instead of only system health metrics.

- Adds `buildOverviewPortfolioPanel` to the view model, sourcing live
  data from `TradingWorkspaceResponse` and `PortfolioWorkspaceResponse`
  (both already fetched by `useWorkstationData`).
- Renders a `PortfolioPanel` card with 4 metric chips (P&L, equity,
  cash, open orders), a compact positions list with mark prices and
  unrealized P&L tone, and a direct link to the trading cockpit.
- When no backend data is available the panel shows a clear connect CTA.
- No new API calls or backend changes required.

https://claude.ai/code/session_01RgCQka3zepxkP9PeuqdDF3