### PR TITLE
Organize command palette by item kind and enhance workspace navigation

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.tsx
@@ -5,11 +5,34 @@ import {
   buildCommandPaletteViewModel,
   resolveCommandPaletteKeyCommand,
   type CommandPaletteFocusBoundary,
+  type CommandPaletteItemKind,
+  type CommandPaletteItem,
   type CommandPaletteFocusTarget
 } from "@/components/meridian/command-palette.view-model";
 import { COMMAND_PALETTE_DIALOG_ID } from "@/app-shell.view-model";
 import { cn } from "@/lib/utils";
 import type { WorkflowLibrary, WorkflowPresetLibrary } from "@/types";
+
+const KIND_LABELS: Record<CommandPaletteItemKind, string> = {
+  workspace: "Workspaces",
+  route: "Quick routes",
+  preset: "Presets",
+  workflow: "Workflows"
+};
+
+const KIND_ORDER: CommandPaletteItemKind[] = ["workspace", "route", "preset", "workflow"];
+
+interface CommandGroup {
+  kind: CommandPaletteItemKind;
+  label: string;
+  items: CommandPaletteItem[];
+}
+
+function groupItems(items: CommandPaletteItem[]): CommandGroup[] {
+  return KIND_ORDER
+    .map((kind) => ({ kind, label: KIND_LABELS[kind], items: items.filter((item) => item.kind === kind) }))
+    .filter((group) => group.items.length > 0);
+}
 
 /**
  * Full-screen command palette overlay for quick workspace navigation.
@@ -186,10 +209,12 @@ export function CommandPalette({
           className="mt-3 h-10 w-full rounded-md border border-border/80 bg-background px-3 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-primary/70 focus-visible:ring-2 focus-visible:ring-primary/35"
           onChange={(event) => setQuery(event.target.value)}
         />
-        <nav className="mt-3 grid max-h-[62vh] gap-2 overflow-y-auto pr-1" aria-label={viewModel.commandListLabel}>
-          <div className="eyebrow-label">{viewModel.itemCountLabel}</div>
-          <div id="command-palette-filter-count" className="text-xs text-muted-foreground" aria-live="polite">
-            {viewModel.filteredItemCountLabel}
+        <nav className="mt-3 max-h-[62vh] overflow-y-auto pr-1" aria-label={viewModel.commandListLabel}>
+          <div className="flex items-center justify-between gap-3 pb-2">
+            <div className="eyebrow-label">{viewModel.itemCountLabel}</div>
+            <div id="command-palette-filter-count" className="text-xs text-muted-foreground" aria-live="polite">
+              {viewModel.filteredItemCountLabel}
+            </div>
           </div>
           {viewModel.emptyState ? (
             <div className="rounded-md border border-border/70 bg-secondary/25 px-3 py-3 text-sm">
@@ -197,44 +222,53 @@ export function CommandPalette({
               <div className="mt-1 text-muted-foreground">{viewModel.emptyState.detail}</div>
             </div>
           ) : null}
-          {viewModel.filteredItems.map((item) => (
-            <Link
-              key={item.id}
-              ref={item.id === viewModel.initialFocusItemId ? initialCommandRef : undefined}
-              to={item.route}
-              data-command-id={item.id}
-              aria-label={item.ariaLabel}
-              aria-current={item.active ? "page" : undefined}
-              className={cn(
-                "command-palette-command rounded-md border px-3 py-3 text-sm transition-colors",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-                item.active
-                  ? "border-primary/35 bg-primary/10 text-foreground"
-                  : "border-transparent hover:border-border/70 hover:bg-secondary/70"
-              )}
-              onClick={() => {
-                if (item.presetId && onPresetUsed) {
-                  void Promise.resolve(onPresetUsed(item.presetId)).catch(() => undefined);
-                }
+          {groupItems(viewModel.filteredItems).map((group) => (
+            <div key={group.kind} className="command-palette-group">
+              <div className="command-palette-group-label">{group.label}</div>
+              <div className="grid gap-1">
+                {group.items.map((item) => (
+                  <Link
+                    key={item.id}
+                    ref={item.id === viewModel.initialFocusItemId ? initialCommandRef : undefined}
+                    to={item.route}
+                    data-command-id={item.id}
+                    aria-label={item.ariaLabel}
+                    aria-current={item.active ? "page" : undefined}
+                    className={cn(
+                      "command-palette-command rounded-md border px-3 py-2.5 text-sm transition-colors",
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+                      item.active
+                        ? "border-primary/35 bg-primary/10 text-foreground"
+                        : "border-transparent hover:border-border/70 hover:bg-secondary/70"
+                    )}
+                    onClick={() => {
+                      if (item.presetId && onPresetUsed) {
+                        void Promise.resolve(onPresetUsed(item.presetId)).catch(() => undefined);
+                      }
 
-                closePalette();
-              }}
-            >
-              <span className="flex items-start justify-between gap-3">
-                <span className="min-w-0">
-                  <span className="block font-semibold">{item.commandLabel}</span>
-                  <span className="mt-1 block text-muted-foreground">{item.description}</span>
-                </span>
-                <span className="flex shrink-0 flex-col items-end gap-2">
-                  <span className="command-palette-route" aria-label={`Route ${item.routeLabel}`}>
-                    {item.routeLabel}
-                  </span>
-                  <span className="rounded-sm border border-border/70 bg-secondary/55 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-                    {item.statusLabel}
-                  </span>
-                </span>
-              </span>
-            </Link>
+                      closePalette();
+                    }}
+                  >
+                    <span className="flex items-start justify-between gap-3">
+                      <span className="min-w-0">
+                        <span className="block font-semibold leading-snug">{item.commandLabel}</span>
+                        <span className="mt-0.5 block text-xs text-muted-foreground">{item.description}</span>
+                      </span>
+                      <span className="flex shrink-0 flex-col items-end gap-1.5">
+                        <span className="command-palette-route" aria-label={`Route ${item.routeLabel}`}>
+                          {item.routeLabel}
+                        </span>
+                        {item.active && (
+                          <span className="rounded-sm border border-primary/35 bg-primary/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] text-primary">
+                            {item.statusLabel}
+                          </span>
+                        )}
+                      </span>
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </div>
           ))}
         </nav>
       </div>

--- a/src/Meridian.Ui/dashboard/src/components/meridian/mega-menu.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/mega-menu.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
-import { LayoutGrid, X } from "lucide-react";
+import { DatabaseZap, FileCheck2, FlaskConical, Landmark, LayoutGrid, RadioTower, Settings, WalletCards, X } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
 import {
   resolveMegaMenuKeyCommand,
@@ -7,6 +7,17 @@ import {
   type MegaMenuFocusBoundary
 } from "@/components/meridian/mega-menu.view-model";
 import { cn } from "@/lib/utils";
+import type { WorkspaceKey } from "@/types";
+
+const WORKSPACE_ICONS: Record<WorkspaceKey, typeof RadioTower> = {
+  trading: RadioTower,
+  portfolio: WalletCards,
+  accounting: Landmark,
+  reporting: FileCheck2,
+  strategy: FlaskConical,
+  data: DatabaseZap,
+  settings: Settings
+};
 
 /**
  * Masthead workspace mega menu. The view model owns open state, active route state,
@@ -110,8 +121,13 @@ export function MegaMenu() {
           className="mega-menu-panel"
         >
           <div className="mega-menu-grid">
-            {vm.sections.map((section) => (
+            {vm.sections.map((section) => {
+              const SectionIcon = WORKSPACE_ICONS[section.key];
+              return (
               <div key={section.key} className={cn("mega-menu-section", section.active && "active")}>
+                <div className="mega-menu-section-icon-row">
+                  <SectionIcon className="mega-menu-section-icon" aria-hidden="true" />
+                </div>
                 <div className="mega-menu-section-eyebrow">{section.eyebrow}</div>
                 <div className="mega-menu-section-heading">
                   <Link
@@ -144,13 +160,15 @@ export function MegaMenu() {
                   ))}
                 </ul>
               </div>
-            ))}
+              );
+            })}
           </div>
 
           <div className="mega-menu-footer">
             <span className="mega-menu-footer-label">{vm.footerLabel}</span>
-            <span className="mega-menu-footer-shortcut" aria-label="Open command palette with Control K">
-              {vm.footerShortcut}
+            <span className="mega-menu-footer-hint" aria-label="Open command palette with Control K">
+              <span className="mega-menu-footer-hint-label">Command palette</span>
+              <span className="mega-menu-footer-shortcut">{vm.footerShortcut}</span>
             </span>
           </div>
         </div>

--- a/src/Meridian.Ui/dashboard/src/components/meridian/workspace-nav.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/workspace-nav.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   DatabaseZap,
   FileCheck2,
@@ -56,24 +57,44 @@ export function WorkspaceNav({ className, onNavigate }: WorkspaceNavProps) {
         {viewModel.items.map((item) => {
           const Icon = icons[item.key];
           return (
-            <Link
-              key={item.key}
-              to={item.route}
-              aria-current={item.ariaCurrent}
-              aria-label={item.ariaLabel}
-              className={cn(
-                "operator-nav-item focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-                item.active ? "active" : ""
+            <React.Fragment key={item.key}>
+              <Link
+                to={item.route}
+                aria-current={item.ariaCurrent}
+                aria-label={item.ariaLabel}
+                className={cn(
+                  "operator-nav-item focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+                  item.active ? "active" : ""
+                )}
+                onClick={onNavigate}
+              >
+                <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+                <span className="truncate font-medium">{item.label}</span>
+                <span className={`operator-nav-status operator-nav-status-${item.statusTone}`}>
+                  <span className="operator-nav-status-dot" aria-hidden="true" />
+                  {item.statusLabel}
+                </span>
+              </Link>
+              {item.subItems.length > 0 && (
+                <div className="operator-nav-subitems" role="group" aria-label={`${item.label} sub-routes`}>
+                  {item.subItems.map((sub) => (
+                    <Link
+                      key={sub.route}
+                      to={sub.route}
+                      aria-current={sub.ariaCurrent}
+                      aria-label={sub.ariaLabel}
+                      className={cn(
+                        "operator-nav-subitem focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+                        sub.active && "active"
+                      )}
+                      onClick={onNavigate}
+                    >
+                      <span className="truncate">{sub.label}</span>
+                    </Link>
+                  ))}
+                </div>
               )}
-              onClick={onNavigate}
-            >
-              <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
-              <span className="truncate font-medium">{item.label}</span>
-              <span className={`operator-nav-status operator-nav-status-${item.statusTone}`}>
-                <span className="operator-nav-status-dot" aria-hidden="true" />
-                {item.statusLabel}
-              </span>
-            </Link>
+            </React.Fragment>
           );
         })}
       </nav>

--- a/src/Meridian.Ui/dashboard/src/components/meridian/workspace-nav.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/workspace-nav.view-model.ts
@@ -1,6 +1,14 @@
 import { isWorkspacePathActive, WORKSPACES, workspacePath } from "@/lib/workspace";
 import type { WorkspaceKey, WorkspaceSummary } from "@/types";
 
+export interface WorkspaceNavSubItemViewModel {
+  label: string;
+  route: string;
+  active: boolean;
+  ariaCurrent: "page" | undefined;
+  ariaLabel: string;
+}
+
 export interface WorkspaceNavItemViewModel {
   key: WorkspaceKey;
   label: string;
@@ -11,6 +19,7 @@ export interface WorkspaceNavItemViewModel {
   active: boolean;
   ariaCurrent: "page" | undefined;
   ariaLabel: string;
+  subItems: WorkspaceNavSubItemViewModel[];
 }
 
 export interface WorkspaceNavCurrentWorkspaceViewModel {
@@ -40,6 +49,43 @@ export interface WorkspaceNavViewModel {
 
 export type WorkspaceNavStatusTone = "live" | "review" | "paper" | "preview" | "setup";
 
+const WORKSPACE_SUBROUTES: Partial<Record<WorkspaceKey, { label: string; route: string }[]>> = {
+  trading: [
+    { label: "Orders", route: "/trading/orders" },
+    { label: "Positions", route: "/trading/positions" },
+    { label: "Risk", route: "/trading/risk" },
+    { label: "Readiness", route: "/trading/readiness" }
+  ],
+  portfolio: [
+    { label: "Attribution", route: "/portfolio/attribution" },
+    { label: "Brokerage sync", route: "/portfolio/brokerage-sync" }
+  ],
+  accounting: [
+    { label: "Reconciliation", route: "/accounting/reconciliation" },
+    { label: "Security Master", route: "/accounting/security-master" },
+    { label: "Approvals", route: "/accounting/approvals" }
+  ],
+  reporting: [
+    { label: "Report packs", route: "/reporting/report-packs" },
+    { label: "Evidence", route: "/reporting/evidence" },
+    { label: "Exports", route: "/reporting/exports" }
+  ],
+  strategy: [
+    { label: "Promotions", route: "/strategy/promotions" },
+    { label: "Research", route: "/strategy/research" },
+    { label: "Quant Lab", route: "/strategy/quant-lab" }
+  ],
+  data: [
+    { label: "Watchlist", route: "/data/watchlist" },
+    { label: "Live quotes", route: "/data/quotes" },
+    { label: "Backfill queues", route: "/data/backfills" }
+  ],
+  settings: [
+    { label: "Preferences", route: "/settings/preferences" },
+    { label: "Integrations", route: "/settings/integrations" }
+  ]
+};
+
 export function buildWorkspaceNavViewModel(
   pathname: string,
   workspaces: WorkspaceSummary[] = WORKSPACES
@@ -50,6 +96,19 @@ export function buildWorkspaceNavViewModel(
   const items = workspaces.map<WorkspaceNavItemViewModel>((workspace) => {
     const active = isWorkspacePathActive(pathname, workspace.key);
     const statusTone = workspaceStatusTone(workspace.status);
+    const rawSubRoutes = WORKSPACE_SUBROUTES[workspace.key] ?? [];
+    const subItems: WorkspaceNavSubItemViewModel[] = active
+      ? rawSubRoutes.map((sub) => {
+          const subActive = isSubRouteActive(pathname, sub.route);
+          return {
+            label: sub.label,
+            route: sub.route,
+            active: subActive,
+            ariaCurrent: subActive ? "page" : undefined,
+            ariaLabel: subActive ? `${sub.label}, current page` : `Open ${sub.label}`
+          };
+        })
+      : [];
 
     return {
       key: workspace.key,
@@ -62,7 +121,8 @@ export function buildWorkspaceNavViewModel(
       ariaCurrent: active ? "page" : undefined,
       ariaLabel: active
         ? `${workspace.label} workspace, current route, ${workspace.status}`
-        : `Open ${workspace.label} workspace, ${workspace.status}`
+        : `Open ${workspace.label} workspace, ${workspace.status}`,
+      subItems
     };
   });
 
@@ -90,6 +150,12 @@ export function buildWorkspaceNavViewModel(
     deliveryShortcutAriaLabel: "Open command palette with Control K",
     items
   };
+}
+
+function isSubRouteActive(pathname: string, route: string): boolean {
+  const clean = pathname.split(/[?#]/)[0]?.replace(/\/+$/, "") || "/";
+  const cleanRoute = route.replace(/\/+$/, "") || "/";
+  return clean === cleanRoute || clean.startsWith(`${cleanRoute}/`);
 }
 
 function workspaceStatusTone(status: string): WorkspaceNavStatusTone {

--- a/src/Meridian.Ui/dashboard/src/styles/index.css
+++ b/src/Meridian.Ui/dashboard/src/styles/index.css
@@ -340,7 +340,8 @@
     align-items: center;
     gap: 0.5rem;
     min-width: 0;
-    max-width: 600px;
+    width: 100%;
+    max-width: 640px;
     height: 34px;
     padding: 0 0.75rem;
     border: 1px solid var(--border-color);
@@ -350,6 +351,7 @@
     text-align: left;
     box-shadow: var(--shadow-panel);
     transition: border-color 150ms ease, box-shadow 150ms ease;
+    cursor: text;
   }
 
   .workstation-search:hover {
@@ -548,6 +550,42 @@
   .operator-nav-status-setup {
     border-color: rgba(169, 183, 199, 0.3);
     color: #a9b7c7;
+  }
+
+  /* ── Sidebar sub-items ─────────────────────────────────── */
+
+  .operator-nav-subitems {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    margin: 1px 0 4px;
+    padding-left: 1.5rem;
+    border-left: 1px solid rgba(42, 178, 212, 0.18);
+    margin-left: 1.375rem;
+  }
+
+  .operator-nav-subitem {
+    display: flex;
+    align-items: center;
+    min-height: 26px;
+    padding: 0 0.5rem;
+    border-radius: var(--radius-sm);
+    border-left: 2px solid transparent;
+    color: var(--fg-muted);
+    font-size: 0.75rem;
+    text-decoration: none;
+    transition: background-color 120ms ease, color 120ms ease, border-left-color 120ms ease;
+  }
+
+  .operator-nav-subitem:hover {
+    background: rgba(255, 255, 255, 0.04);
+    color: #d4e2f0;
+  }
+
+  .operator-nav-subitem.active {
+    background: rgba(42, 178, 212, 0.08);
+    border-left-color: var(--cyan-primary);
+    color: #e8f4ff;
   }
 
   .workbench {
@@ -994,6 +1032,21 @@
     background: rgba(var(--cyan-primary-rgb, 0 188 212) / 0.05);
   }
 
+  .mega-menu-section-icon-row {
+    margin-bottom: 0.375rem;
+  }
+
+  .mega-menu-section-icon {
+    width: 1rem;
+    height: 1rem;
+    color: var(--fg-muted);
+    transition: color 100ms ease;
+  }
+
+  .mega-menu-section.active .mega-menu-section-icon {
+    color: var(--cyan-primary);
+  }
+
   .mega-menu-section-eyebrow {
     font-family: "IBM Plex Mono", ui-monospace, monospace;
     font-size: 0.5625rem;
@@ -1104,6 +1157,19 @@
     color: var(--fg-muted);
   }
 
+  .mega-menu-footer-hint {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .mega-menu-footer-hint-label {
+    font-family: "IBM Plex Mono", ui-monospace, monospace;
+    font-size: 0.625rem;
+    letter-spacing: 0.08em;
+    color: var(--fg-muted);
+  }
+
   .mega-menu-footer-shortcut {
     display: inline-flex;
     align-items: center;
@@ -1118,6 +1184,22 @@
     letter-spacing: 0.12em;
     text-transform: uppercase;
     white-space: nowrap;
+  }
+
+  /* ── Command palette groups ────────────────────────────── */
+
+  .command-palette-group {
+    margin-bottom: 0.5rem;
+  }
+
+  .command-palette-group-label {
+    padding: 0.375rem 0.25rem 0.25rem;
+    font-family: "IBM Plex Mono", ui-monospace, monospace;
+    font-size: 0.5625rem;
+    font-weight: 500;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--fg-muted);
   }
 
   /* ── Entrance animations ───────────────────────────────── */


### PR DESCRIPTION
## Description

This PR enhances the command palette and workspace navigation with improved organization and visual hierarchy:

1. **Command Palette Grouping**: Items are now organized by kind (workspaces, routes, presets, workflows) with labeled section headers, improving discoverability and reducing cognitive load when searching.

2. **Workspace Navigation Sub-routes**: Added expandable sub-route navigation for workspace items (e.g., Orders, Positions, Risk under Trading). Sub-routes only appear when their parent workspace is active.

3. **Mega Menu Enhancements**: 
   - Added workspace icons to mega menu sections for better visual identification
   - Improved footer hint styling with separate label and shortcut display

4. **Visual Polish**: 
   - Refined spacing and typography in command palette items
   - Updated status badge styling to only show for active items
   - Improved search input styling with better cursor feedback
   - Added CSS classes for sidebar sub-items and command palette groups

## Type of Change

- New feature
- Code refactoring
- UI/UX improvement

## Motivation and Context

The command palette can contain many items across different categories. Grouping them by kind makes it easier for users to find what they're looking for. Similarly, adding sub-route navigation to workspaces provides quick access to common workspace sections without requiring additional navigation steps.

## How Has This Been Tested?

- Manual testing of command palette grouping and filtering
- Verification of workspace navigation sub-route display and active state tracking
- Visual inspection of mega menu icon rendering and footer hint layout
- Confirmed existing command palette and navigation functionality remains intact

## Checklist

- [x] My code follows the code style of this project
- [x] All new and existing tests passed
- [x] I have checked my code and corrected any misspellings
- [x] My changes generate no new warnings

## Related Issues

N/A

## Additional Notes

The grouping logic uses a predefined order (workspace, route, preset, workflow) to ensure consistent presentation. Sub-routes are only rendered when their parent workspace is active to keep the navigation clean and focused.

https://claude.ai/code/session_01MDJ8y1wG5FCRix4BwoxN18