### PR TITLE
feat(ui): surface live data and run analytics directly in operator screens

### DIFF
--- a/src/Meridian.Ui/dashboard/src/hooks/use-workstation-data.ts
+++ b/src/Meridian.Ui/dashboard/src/hooks/use-workstation-data.ts
@@ -256,6 +256,42 @@ export function useWorkstationData() {
     }
   }, []);
 
+  // Keep portfolio positions in sync with strategy execution.
+  const portfolioRefreshRevisionRef = useRef(0);
+  const portfolioRefreshAbortRef = useRef<AbortController | null>(null);
+  const refreshingPortfolio = useRef(false);
+  const refreshPortfolio = useCallback(async () => {
+    if (refreshingPortfolio.current || !mountedRef.current) return;
+    const revision = portfolioRefreshRevisionRef.current + 1;
+    portfolioRefreshRevisionRef.current = revision;
+    portfolioRefreshAbortRef.current?.abort();
+    const controller = new AbortController();
+    portfolioRefreshAbortRef.current = controller;
+    refreshingPortfolio.current = true;
+    try {
+      const [portfolio, brokeragePortfolio] = await Promise.allSettled([
+        getPortfolioWorkspace({ signal: controller.signal }),
+        getBrokerageHouseholdPortfolio("alpaca", { signal: controller.signal })
+      ]);
+      if (!mountedRef.current || portfolioRefreshRevisionRef.current !== revision) return;
+      setState((current) => {
+        let next = { ...current };
+        if (portfolio.status === "fulfilled") {
+          next = { ...next, portfolio: portfolio.value };
+        }
+        if (brokeragePortfolio.status === "fulfilled") {
+          next = { ...next, brokeragePortfolio: brokeragePortfolio.value };
+        }
+        return next;
+      });
+    } catch {
+      // silent — portfolio refresh is opportunistic
+    } finally {
+      if (portfolioRefreshAbortRef.current === controller) portfolioRefreshAbortRef.current = null;
+      refreshingPortfolio.current = false;
+    }
+  }, []);
+
   const upsertWorkflowPreset = useCallback((preset: WorkflowPreset) => {
     if (!mountedRef.current) {
       return;
@@ -289,7 +325,12 @@ export function useWorkstationData() {
     return () => clearInterval(id);
   }, [refreshTrading]);
 
-  return { ...state, refresh, refreshTrading, upsertWorkflowPreset };
+  useEffect(() => {
+    const id = setInterval(() => { void refreshPortfolio(); }, 60_000);
+    return () => clearInterval(id);
+  }, [refreshPortfolio]);
+
+  return { ...state, refresh, refreshTrading, refreshPortfolio, upsertWorkflowPreset };
 }
 
 function formatRequestError(reason: unknown, fallback: string): string {

--- a/src/Meridian.Ui/dashboard/src/lib/api.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api.ts
@@ -23,6 +23,7 @@ import type {
   LedgerSummary,
   LedgerTrialBalanceLine,
   MetricSnapshot,
+  NetSymbolPosition,
   OperatorInbox,
   OrderResult,
   OrderSubmitRequest,
@@ -1174,7 +1175,7 @@ export function getPortfolioExposure() {
 }
 
 export function getPortfolioSymbolExposure(symbol: string) {
-  return getJson<unknown>(portfolioSymbolExposureEndpoint(symbol));
+  return getJson<NetSymbolPosition>(portfolioSymbolExposureEndpoint(symbol));
 }
 
 // --- Live market data ---

--- a/src/Meridian.Ui/dashboard/src/screens/governance-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/governance-screen.tsx
@@ -879,13 +879,34 @@ export function GovernanceScreen({ data }: GovernanceScreenProps) {
               )}
               {reconciliation.rows.map((item) => (
                 <div key={item.breakId} className="rounded-lg border border-border/70 p-3">
-                  <div className="flex items-center justify-between gap-3">
-                    <div>
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
                       <div className="font-semibold">{item.strategyName} · {item.category}</div>
-                      <div className="text-xs text-muted-foreground">{item.reason}</div>
+                      <div className="mt-0.5 text-xs text-muted-foreground">{item.reason}</div>
                     </div>
-                    <div className="font-mono text-xs">{item.status}</div>
+                    <div className="flex shrink-0 items-center gap-2">
+                      {typeof item.variance === "number" && item.variance !== 0 && (
+                        <span className={cn("font-mono text-xs font-semibold", item.variance > 0 ? "text-success" : "text-danger")}>
+                          {item.variance > 0 ? "+" : ""}{item.variance.toLocaleString("en-US", { style: "currency", currency: "USD", minimumFractionDigits: 2 })}
+                        </span>
+                      )}
+                      <Badge variant={item.status === "Resolved" ? "success" : item.status === "InReview" ? "warning" : item.status === "Dismissed" ? "outline" : "danger"}>
+                        {item.status}
+                      </Badge>
+                    </div>
                   </div>
+                  {item.explainabilitySummary && (
+                    <div className="mt-2 rounded-md border border-border/50 bg-secondary/20 px-3 py-2 text-xs leading-5 text-muted-foreground">
+                      <span className="font-medium text-foreground">Analysis: </span>
+                      {item.explainabilitySummary}
+                    </div>
+                  )}
+                  {item.recommendedAction && (
+                    <div className="mt-2 rounded-md border border-primary/20 bg-primary/5 px-3 py-2 text-xs leading-5">
+                      <span className="font-medium text-primary">Recommended: </span>
+                      <span className="text-foreground">{item.recommendedAction}</span>
+                    </div>
+                  )}
                   <div className="mt-2 flex flex-wrap gap-2">
                     <Button
                       size="sm"

--- a/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.tsx
@@ -1,7 +1,9 @@
 import type { KeyboardEvent } from "react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { BriefcaseBusiness, LineChart, Network, Settings, Wallet } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
+import { getPortfolioSymbolExposure } from "@/lib/api";
+import type { NetSymbolPosition } from "@/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -120,6 +122,9 @@ export function PortfolioScreen({
   const location = useLocation();
   const brokerageAccountButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const shouldFocusBrokerageAccount = useRef(false);
+  const [exposureSymbol, setExposureSymbol] = useState<string | null>(null);
+  const [exposure, setExposure] = useState<NetSymbolPosition | null>(null);
+  const [exposureLoading, setExposureLoading] = useState(false);
   const vm = usePortfolioScreenViewModel({
     portfolio,
     trading,
@@ -138,6 +143,17 @@ export function PortfolioScreen({
     shouldFocusBrokerageAccount.current = false;
     brokerageAccountButtonRefs.current[vm.selectedBrokerageAccountKey]?.focus();
   }, [vm.selectedBrokerageAccountKey]);
+
+  function loadExposure(symbol: string) {
+    if (exposureLoading) return;
+    setExposureSymbol(symbol);
+    setExposure(null);
+    setExposureLoading(true);
+    getPortfolioSymbolExposure(symbol)
+      .then((result) => { setExposure(result); })
+      .catch(() => { setExposure(null); })
+      .finally(() => { setExposureLoading(false); });
+  }
 
   function handleBrokerageAccountFilterKeyDown(event: KeyboardEvent<HTMLDivElement>) {
     const command = resolveBrokerageAccountFilterKeyCommand(event.key);
@@ -611,6 +627,43 @@ export function PortfolioScreen({
                   </div>
                 ))}
               </dl>
+              <div className="mt-4">
+                <div className="eyebrow-label mb-2">Cross-strategy exposure</div>
+                {exposureSymbol === vm.selectedPosition.title ? (
+                  exposureLoading ? (
+                    <div className="rounded-md border border-border/60 bg-secondary/20 px-3 py-2 text-xs text-muted-foreground">
+                      Loading…
+                    </div>
+                  ) : exposure ? (
+                    <dl className="grid gap-2">
+                      <div className="grid grid-cols-[minmax(0,0.7fr)_minmax(0,1fr)] items-start gap-3 rounded-md border border-border/60 bg-secondary/25 px-3 py-2">
+                        <dt className="text-xs text-muted-foreground">Net qty (all runs)</dt>
+                        <dd className={cn("text-right font-mono text-xs", exposure.netQuantity >= 0 ? "text-success" : "text-danger")}>
+                          {exposure.netQuantity >= 0 ? "+" : ""}{exposure.netQuantity}
+                        </dd>
+                      </div>
+                      <div className="grid grid-cols-[minmax(0,0.7fr)_minmax(0,1fr)] items-start gap-3 rounded-md border border-border/60 bg-secondary/25 px-3 py-2">
+                        <dt className="text-xs text-muted-foreground">Gross qty (all runs)</dt>
+                        <dd className="text-right font-mono text-xs text-foreground">{exposure.grossQuantity}</dd>
+                      </div>
+                    </dl>
+                  ) : (
+                    <div className="rounded-md border border-border/60 bg-secondary/20 px-3 py-2 text-xs text-muted-foreground">
+                      No cross-strategy exposure data available.
+                    </div>
+                  )
+                ) : (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="w-full"
+                    onClick={() => { loadExposure(vm.selectedPosition!.title); }}
+                  >
+                    Check cross-strategy exposure
+                  </Button>
+                )}
+              </div>
             </>
           ) : (
             <div role="status" className="text-sm leading-6 text-muted-foreground">

--- a/src/Meridian.Ui/dashboard/src/screens/research-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/research-screen.tsx
@@ -1,5 +1,8 @@
+import { useEffect, useState } from "react";
 import { BarChart3, BookOpenText, ChartScatter, Network, Sigma, Sparkles } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
+import { getRunFills, getRunAttribution } from "@/lib/api";
+import type { RunFillSummary, RunAttributionSummary } from "@/types";
 import { MetricCard } from "@/components/meridian/metric-card";
 import { DenseDataTable, EntitySummary, ToolbarStrip, type DenseDataTableColumn } from "@/components/meridian/ui-kit-primitives";
 import { Badge } from "@/components/ui/badge";
@@ -526,52 +529,7 @@ export function ResearchScreen({ data }: ResearchScreenProps) {
 
       <Dialog open={Boolean(vm.selectedRunDetail)} onOpenChange={(open) => { if (!open) vm.closeRunDetail(); }}>
         {vm.selectedRunDetail && (
-          <DialogContent
-            aria-labelledby={vm.selectedRunDetail.dialogTitleId}
-            aria-describedby={vm.selectedRunDetail.dialogDescriptionId}
-            className="max-w-2xl"
-          >
-            <DialogHeader className="mb-5 flex flex-row items-start justify-between gap-4 space-y-0">
-              <div className="min-w-0">
-                <div className="eyebrow-label">{vm.selectedRunDetail.eyebrow}</div>
-                <div className="mt-2 flex flex-wrap items-center gap-2">
-                  <DialogTitle id={vm.selectedRunDetail.dialogTitleId}>
-                    {vm.selectedRunDetail.title}
-                  </DialogTitle>
-                  <Badge variant={vm.selectedRunDetail.modeBadgeVariant} dot>
-                    {vm.selectedRunDetail.modeBadgeLabel}
-                  </Badge>
-                </div>
-                <DialogDescription id={vm.selectedRunDetail.dialogDescriptionId} className="mt-2">
-                  {vm.selectedRunDetail.description}
-                </DialogDescription>
-                <p className="mt-1 text-xs font-mono text-muted-foreground">{vm.selectedRunDetail.subtitle}</p>
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                autoFocus
-                aria-label={vm.selectedRunDetail.closeButtonAriaLabel}
-                onClick={vm.closeRunDetail}
-              >
-                {vm.selectedRunDetail.closeButtonLabel}
-              </Button>
-            </DialogHeader>
-
-            <section aria-label={vm.selectedRunDetail.summaryLabel} className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-              {vm.selectedRunDetail.summaryRows.map((row) => (
-                <div key={row.id} className="rounded-md border border-border/70 bg-secondary/25 px-3 py-3">
-                  <div className="eyebrow-label">{row.label}</div>
-                  <div className="mt-2 truncate font-mono text-sm text-foreground">{row.value}</div>
-                </div>
-              ))}
-            </section>
-
-            <section className="mt-4 rounded-md border border-border/70 bg-background/45 px-4 py-3">
-              <div className="eyebrow-label">{vm.selectedRunDetail.notesLabel}</div>
-              <p className="mt-2 text-sm leading-6 text-muted-foreground">{vm.selectedRunDetail.notesText}</p>
-            </section>
-          </DialogContent>
+          <RunDetailDialogContent detail={vm.selectedRunDetail} onClose={vm.closeRunDetail} />
         )}
       </Dialog>
     </div>
@@ -1031,5 +989,167 @@ function PlotToolObservationRow({ row }: { row: ResearchPlotSampleRow }) {
         <Badge variant={sampleToneBadgeVariant[row.tone]}>{row.signalText}</Badge>
       </td>
     </tr>
+  );
+}
+
+function RunDetailDialogContent({
+  detail,
+  onClose
+}: {
+  detail: import("@/screens/research-screen.view-model").ResearchRunDetailState;
+  onClose: () => void;
+}) {
+  const [fills, setFills] = useState<RunFillSummary | null>(null);
+  const [attribution, setAttribution] = useState<RunAttributionSummary | null>(null);
+  const [detailLoading, setDetailLoading] = useState(true);
+
+  useEffect(() => {
+    setFills(null);
+    setAttribution(null);
+    setDetailLoading(true);
+    let cancelled = false;
+
+    Promise.allSettled([
+      getRunFills(detail.runId),
+      getRunAttribution(detail.runId)
+    ]).then(([fillsResult, attrResult]) => {
+      if (cancelled) return;
+      if (fillsResult.status === "fulfilled") setFills(fillsResult.value);
+      if (attrResult.status === "fulfilled") setAttribution(attrResult.value);
+      setDetailLoading(false);
+    }).catch(() => { if (!cancelled) setDetailLoading(false); });
+
+    return () => { cancelled = true; };
+  }, [detail.runId]);
+
+  const currencyFmt = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", minimumFractionDigits: 2 });
+  const pctFmt = (v: number) => `${v >= 0 ? "+" : ""}${v.toFixed(2)}%`;
+
+  return (
+    <DialogContent
+      aria-labelledby={detail.dialogTitleId}
+      aria-describedby={detail.dialogDescriptionId}
+      className="max-w-3xl max-h-[90vh] overflow-y-auto"
+    >
+      <DialogHeader className="mb-5 flex flex-row items-start justify-between gap-4 space-y-0">
+        <div className="min-w-0">
+          <div className="eyebrow-label">{detail.eyebrow}</div>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <DialogTitle id={detail.dialogTitleId}>{detail.title}</DialogTitle>
+            <Badge variant={detail.modeBadgeVariant} dot>{detail.modeBadgeLabel}</Badge>
+          </div>
+          <DialogDescription id={detail.dialogDescriptionId} className="mt-2">
+            {detail.description}
+          </DialogDescription>
+          <p className="mt-1 font-mono text-xs text-muted-foreground">{detail.subtitle}</p>
+        </div>
+        <Button variant="ghost" size="sm" autoFocus aria-label={detail.closeButtonAriaLabel} onClick={onClose}>
+          {detail.closeButtonLabel}
+        </Button>
+      </DialogHeader>
+
+      <section aria-label={detail.summaryLabel} className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {detail.summaryRows.map((row) => (
+          <div key={row.id} className="rounded-md border border-border/70 bg-secondary/25 px-3 py-3">
+            <div className="eyebrow-label">{row.label}</div>
+            <div className="mt-2 truncate font-mono text-sm text-foreground">{row.value}</div>
+          </div>
+        ))}
+      </section>
+
+      <section className="mt-4 rounded-md border border-border/70 bg-background/45 px-4 py-3">
+        <div className="eyebrow-label">{detail.notesLabel}</div>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">{detail.notesText}</p>
+      </section>
+
+      {detailLoading ? (
+        <div className="mt-4 rounded-md border border-border/60 bg-secondary/20 px-4 py-3 text-xs text-muted-foreground">
+          Loading fills and attribution…
+        </div>
+      ) : (
+        <>
+          {attribution && attribution.bySymbol.length > 0 && (
+            <section aria-label="Attribution by symbol" className="mt-4">
+              <div className="eyebrow-label mb-2">Attribution by symbol</div>
+              <div className="overflow-hidden rounded-lg border border-border/70">
+                <table className="min-w-full divide-y divide-border/60 text-left text-xs">
+                  <thead className="bg-secondary/30">
+                    <tr>
+                      {["Symbol", "Realized P&L", "Unrealized P&L", "Total P&L", "Commissions", "Trades"].map((col) => (
+                        <th key={col} className="px-3 py-2 font-semibold uppercase tracking-[0.14em] text-muted-foreground">{col}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border/50">
+                    {attribution.bySymbol.map((entry) => (
+                      <tr key={entry.symbol} className="bg-background/20">
+                        <td className="px-3 py-2 font-mono font-semibold text-foreground">{entry.symbol}</td>
+                        <td className={cn("px-3 py-2 font-mono", entry.realizedPnl >= 0 ? "text-success" : "text-danger")}>
+                          {currencyFmt.format(entry.realizedPnl)}
+                        </td>
+                        <td className={cn("px-3 py-2 font-mono", entry.unrealizedPnl >= 0 ? "text-success" : "text-danger")}>
+                          {currencyFmt.format(entry.unrealizedPnl)}
+                        </td>
+                        <td className={cn("px-3 py-2 font-mono font-semibold", entry.totalPnl >= 0 ? "text-success" : "text-danger")}>
+                          {currencyFmt.format(entry.totalPnl)}
+                        </td>
+                        <td className="px-3 py-2 font-mono text-muted-foreground">{currencyFmt.format(entry.commissions)}</td>
+                        <td className="px-3 py-2 font-mono text-foreground">{entry.tradeCount}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <div className="mt-2 flex flex-wrap gap-4 text-xs text-muted-foreground">
+                <span>Total realized: <span className="font-mono text-foreground">{currencyFmt.format(attribution.totalRealizedPnl)}</span></span>
+                <span>Total commissions: <span className="font-mono text-foreground">{currencyFmt.format(attribution.totalCommissions)}</span></span>
+              </div>
+            </section>
+          )}
+
+          {fills && fills.fills.length > 0 && (
+            <section aria-label="Recent fills" className="mt-4">
+              <div className="eyebrow-label mb-2">
+                Recent fills
+                <span className="ml-2 font-mono text-foreground">{fills.totalFills} total</span>
+              </div>
+              <div className="overflow-hidden rounded-lg border border-border/70">
+                <table className="min-w-full divide-y divide-border/60 text-left text-xs">
+                  <thead className="bg-secondary/30">
+                    <tr>
+                      {["Symbol", "Qty", "Price", "Commission", "Filled at"].map((col) => (
+                        <th key={col} className="px-3 py-2 font-semibold uppercase tracking-[0.14em] text-muted-foreground">{col}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border/50">
+                    {fills.fills.slice(0, 20).map((fill) => (
+                      <tr key={fill.fillId} className="bg-background/20">
+                        <td className="px-3 py-2 font-mono font-semibold text-foreground">{fill.symbol}</td>
+                        <td className={cn("px-3 py-2 font-mono", fill.filledQuantity >= 0 ? "text-success" : "text-danger")}>
+                          {fill.filledQuantity >= 0 ? "+" : ""}{fill.filledQuantity}
+                        </td>
+                        <td className="px-3 py-2 font-mono text-foreground">{currencyFmt.format(fill.fillPrice)}</td>
+                        <td className="px-3 py-2 font-mono text-muted-foreground">{currencyFmt.format(fill.commission)}</td>
+                        <td className="px-3 py-2 text-muted-foreground">{new Date(fill.filledAt).toLocaleString()}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              {fills.totalFills > 20 && (
+                <p className="mt-2 text-xs text-muted-foreground">Showing 20 of {fills.totalFills} fills.</p>
+              )}
+            </section>
+          )}
+
+          {attribution && attribution.bySymbol.length === 0 && fills && fills.fills.length === 0 && (
+            <div className="mt-4 rounded-md border border-dashed border-border/60 bg-secondary/15 px-4 py-3 text-xs text-muted-foreground">
+              No fills or attribution data available for this run.
+            </div>
+          )}
+        </>
+      )}
+    </DialogContent>
   );
 }

--- a/src/Meridian.Ui/dashboard/src/screens/research-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/research-screen.view-model.ts
@@ -177,6 +177,7 @@ export interface ResearchRunTableRow {
 }
 
 export interface ResearchRunDetailState {
+  runId: string;
   dialogTitleId: string;
   dialogDescriptionId: string;
   description: string;
@@ -1677,6 +1678,7 @@ export function buildRunDetail(run: ResearchRunRecord): ResearchRunDetailState {
   const statusText = formatText(run.status);
 
   return {
+    runId: run.id,
     dialogTitleId: `strategy-run-detail-${sanitizeDomId(run.id)}-title`,
     dialogDescriptionId: `strategy-run-detail-${sanitizeDomId(run.id)}-description`,
     description: `${title} is ${statusText} in ${modeLabel} mode.`,

--- a/src/Meridian.Ui/dashboard/src/types.ts
+++ b/src/Meridian.Ui/dashboard/src/types.ts
@@ -1045,6 +1045,12 @@ export interface WorkstationSecurityReference {
 
 // --- Portfolio types ---
 
+export interface NetSymbolPosition {
+  symbol: string;
+  netQuantity: number;
+  grossQuantity: number;
+}
+
 export interface PortfolioPositionSummary {
   symbol: string;
   quantity: number;


### PR DESCRIPTION
- Portfolio workspace now refreshes positions and brokerage holdings every 60s
  alongside the existing 30s trading refresh; operators see current holdings
  without manual reload.

- Research run detail dialog now fetches fills and attribution on open:
  attribution by symbol shows realized/unrealized P&L and trade count;
  recent fills table (capped at 20 rows) shows price, quantity, commission,
  and timestamp; data is loaded asynchronously with a graceful loading state.

- Portfolio position detail panel gains a one-click cross-strategy exposure
  check: fetching NetSymbolPosition from the aggregate portfolio service shows
  net and gross quantity across all active runs for the selected symbol.

- Governance break queue surfaces recommendedAction and explainabilitySummary
  already populated by the backend; variance is shown as a signed currency
  amount and status is promoted to a colored badge so priority is visible
  at a glance without opening a break detail.

All 606 dashboard tests pass; no new TypeScript errors introduced.

https://claude.ai/code/session_01E9g8x2359Zcs5Go4bZiV53