### PR TITLE
feat(watchlist): sortable columns + hide-stale filter

### DIFF
--- a/src/Meridian.Ui/dashboard/src/app.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.test.tsx
@@ -88,6 +88,7 @@ describe("App", () => {
       workspaceErrors: {},
       refresh: vi.fn(),
       refreshTrading: vi.fn(),
+      refreshPortfolio: vi.fn(),
       upsertWorkflowPreset: vi.fn()
     });
   });
@@ -155,6 +156,7 @@ describe("App", () => {
       workspaceErrors: {},
       refresh: vi.fn(),
       refreshTrading: vi.fn(),
+      refreshPortfolio: vi.fn(),
       upsertWorkflowPreset: vi.fn()
     });
 
@@ -212,6 +214,7 @@ describe("App", () => {
       workspaceErrors: {},
       refresh: vi.fn(),
       refreshTrading: vi.fn(),
+      refreshPortfolio: vi.fn(),
       upsertWorkflowPreset: vi.fn()
     });
 
@@ -289,6 +292,7 @@ describe("App", () => {
       workspaceErrors: {},
       refresh,
       refreshTrading: vi.fn(),
+      refreshPortfolio: vi.fn(),
       upsertWorkflowPreset: vi.fn()
     });
 
@@ -341,6 +345,7 @@ describe("App", () => {
       },
       refresh,
       refreshTrading: vi.fn(),
+      refreshPortfolio: vi.fn(),
       upsertWorkflowPreset: vi.fn()
     });
 
@@ -386,6 +391,7 @@ describe("App", () => {
       workspaceErrors: {},
       refresh: vi.fn(),
       refreshTrading: vi.fn(),
+      refreshPortfolio: vi.fn(),
       upsertWorkflowPreset: vi.fn()
     });
 

--- a/src/Meridian.Ui/dashboard/src/components/meridian/ui-kit-primitives.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/ui-kit-primitives.tsx
@@ -36,11 +36,20 @@ export function ToolbarStrip({
   );
 }
 
+export type DenseDataTableSortDirection = "asc" | "desc";
+
+export interface DenseDataTableSortState {
+  columnId: string;
+  direction: DenseDataTableSortDirection;
+}
+
 export interface DenseDataTableColumn<T> {
   id: string;
   label: string;
   align?: "left" | "right";
   className?: string;
+  sortable?: boolean;
+  sortAriaLabel?: (next: DenseDataTableSortDirection | "remove") => string;
   render: (row: T) => ReactNode;
 }
 
@@ -56,7 +65,9 @@ export function DenseDataTable<T>({
   selectedRowId,
   emptyText,
   ariaLabel,
-  caption
+  caption,
+  sort,
+  onToggleSort
 }: {
   columns: DenseDataTableColumn<T>[];
   rows: T[];
@@ -70,6 +81,8 @@ export function DenseDataTable<T>({
   emptyText: string;
   ariaLabel: string;
   caption?: string | null;
+  sort?: DenseDataTableSortState | null;
+  onToggleSort?: (columnId: string) => void;
 }) {
   return (
     <div className="dense-data-table-wrap">
@@ -77,15 +90,57 @@ export function DenseDataTable<T>({
         {caption ? <caption className="sr-only">{caption}</caption> : null}
         <thead>
           <tr>
-            {columns.map((column) => (
-              <th
-                key={column.id}
-                scope="col"
-                className={cn(column.align === "right" ? "text-right" : "text-left", column.className)}
-              >
-                {column.label}
-              </th>
-            ))}
+            {columns.map((column) => {
+              const isSorted = sort?.columnId === column.id;
+              const ariaSort: "ascending" | "descending" | "none" | undefined = column.sortable
+                ? isSorted
+                  ? sort?.direction === "asc"
+                    ? "ascending"
+                    : "descending"
+                  : "none"
+                : undefined;
+              const headerClass = cn(
+                column.align === "right" ? "text-right" : "text-left",
+                column.className,
+                column.sortable ? "dense-data-table-sortable" : undefined,
+                isSorted ? "dense-data-table-sorted" : undefined
+              );
+
+              if (!column.sortable || !onToggleSort) {
+                return (
+                  <th key={column.id} scope="col" className={headerClass} aria-sort={ariaSort}>
+                    {column.label}
+                  </th>
+                );
+              }
+
+              const nextDirection: DenseDataTableSortDirection | "remove" = isSorted
+                ? sort?.direction === "asc"
+                  ? "desc"
+                  : "remove"
+                : "asc";
+              const buttonAriaLabel = column.sortAriaLabel
+                ? column.sortAriaLabel(nextDirection)
+                : nextDirection === "remove"
+                  ? `Clear sort by ${column.label}`
+                  : `Sort by ${column.label} ${nextDirection === "asc" ? "ascending" : "descending"}`;
+
+              return (
+                <th key={column.id} scope="col" className={headerClass} aria-sort={ariaSort}>
+                  <button
+                    type="button"
+                    className="dense-data-table-sort-button"
+                    onClick={() => onToggleSort(column.id)}
+                    aria-label={buttonAriaLabel}
+                  >
+                    <span>{column.label}</span>
+                    <span aria-hidden="true" className="dense-data-table-sort-indicator">
+                      {isSorted ? (sort?.direction === "asc" ? "▲" : "▼") : "↕"}
+                    </span>
+                  </button>
+                </th>
+              );
+            })}
           </tr>
         </thead>
         <tbody>

--- a/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { Activity, AlertCircle, CheckCircle2, Eye, LineChart, Plus, RefreshCw, Settings, Trash2 } from "lucide-react";
+import { Activity, AlertCircle, CheckCircle2, EyeOff, Eye, LineChart, Plus, RefreshCw, Settings, Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -18,7 +18,8 @@ import {
   useWatchlistScreenViewModel,
   type WatchlistDetailFieldTone,
   type WatchlistRowViewModel,
-  type WatchlistSelectedDetail
+  type WatchlistSelectedDetail,
+  type WatchlistSortColumn
 } from "@/screens/watchlist-screen.view-model";
 
 export function WatchlistScreen() {
@@ -155,20 +156,39 @@ export function WatchlistScreen() {
             items={vm.toolbarItems}
             ariaLabel="Symbol watchlist status"
             right={
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => void vm.refreshQuotes()}
-                disabled={vm.quoteRefreshCommand.disabled}
-                disabledReason={vm.quoteRefreshCommand.disabledReason}
-                busy={vm.quoteRefreshCommand.busy}
-                busyLabel={vm.quoteRefreshCommand.label}
-                aria-label={vm.quoteRefreshCommand.ariaLabel}
-              >
-                <RefreshCw className={`h-3.5 w-3.5 ${vm.quoteRefreshCommand.busy ? "animate-spin" : ""}`} aria-hidden="true" />
-                <span className="ml-1">{vm.quoteRefreshCommand.label}</span>
-              </Button>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  variant={vm.staleFilterCommand.pressed ? "secondary" : "outline"}
+                  size="sm"
+                  onClick={() => vm.setHideStale(!vm.hideStale)}
+                  disabled={vm.staleFilterCommand.disabled}
+                  disabledReason={vm.staleFilterCommand.disabledReason}
+                  aria-pressed={vm.staleFilterCommand.pressed}
+                  aria-label={vm.staleFilterCommand.ariaLabel}
+                >
+                  {vm.staleFilterCommand.pressed ? (
+                    <EyeOff className="h-3.5 w-3.5" aria-hidden="true" />
+                  ) : (
+                    <Eye className="h-3.5 w-3.5" aria-hidden="true" />
+                  )}
+                  <span className="ml-1">{vm.staleFilterCommand.label}</span>
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void vm.refreshQuotes()}
+                  disabled={vm.quoteRefreshCommand.disabled}
+                  disabledReason={vm.quoteRefreshCommand.disabledReason}
+                  busy={vm.quoteRefreshCommand.busy}
+                  busyLabel={vm.quoteRefreshCommand.label}
+                  aria-label={vm.quoteRefreshCommand.ariaLabel}
+                >
+                  <RefreshCw className={`h-3.5 w-3.5 ${vm.quoteRefreshCommand.busy ? "animate-spin" : ""}`} aria-hidden="true" />
+                  <span className="ml-1">{vm.quoteRefreshCommand.label}</span>
+                </Button>
+              </div>
             }
           />
           {vm.listState === "error" ? (
@@ -214,6 +234,8 @@ export function WatchlistScreen() {
                   emptyText={vm.listDescription}
                   ariaLabel={vm.tableLabel}
                   caption={vm.tableCaption}
+                  sort={vm.sort}
+                  onToggleSort={(columnId) => vm.toggleSort(columnId as WatchlistSortColumn)}
                 />
                 <WatchlistDetailPanel
                   title={vm.detailPanelTitle}
@@ -263,11 +285,13 @@ function buildColumns(
       id: "symbol",
       label: "Symbol",
       className: "font-mono font-semibold text-foreground",
+      sortable: true,
       render: (row) => row.symbol
     },
     {
       id: "status",
       label: "Status",
+      sortable: true,
       render: (row) => <Badge variant={row.statusVariant} dot>{row.status}</Badge>
     },
     {
@@ -289,6 +313,7 @@ function buildColumns(
       label: "Last",
       align: "right",
       className: `font-mono`,
+      sortable: true,
       render: (row) => <span className={lastToneClass[row.lastTone]}>{row.lastPriceLabel}</span>
     },
     {
@@ -303,6 +328,7 @@ function buildColumns(
       label: "Chg%",
       align: "right",
       className: "font-mono",
+      sortable: true,
       render: (row) => <span className={detailFieldToneClass[row.changeTone]}>{row.changePercentLabel}</span>
     },
     {
@@ -317,12 +343,14 @@ function buildColumns(
       label: "Spread",
       align: "right",
       className: "font-mono text-muted-foreground",
+      sortable: true,
       render: (row) => row.spreadLabel
     },
     {
       id: "quote-age",
       label: "Quote age",
       className: "text-muted-foreground",
+      sortable: true,
       render: (row) => <span className={row.quoteStale ? "text-warning" : undefined}>{row.quoteAgeLabel}</span>
     },
     {

--- a/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.view-model.test.ts
@@ -5,6 +5,7 @@ import {
   buildProviderSetupHandoff,
   buildQuoteRefreshCommand,
   buildQuoteStatus,
+  buildStaleFilterCommand,
   buildStarterPackCommands,
   buildStarterPackFeedback,
   buildWatchlistSelectedDetail,
@@ -12,11 +13,13 @@ import {
   buildWatchlistStats,
   formatRelative,
   parseWatchlistSymbols,
+  sortAndFilterWatchlistRows,
+  toggleWatchlistSort,
   useWatchlistScreenViewModel,
   validatePendingSymbol
 } from "@/screens/watchlist-screen.view-model";
 import type { QuotesSnapshotItem, SymbolRecord, SymbolStatistics } from "@/types";
-import type { WatchlistApi } from "@/screens/watchlist-screen.view-model";
+import type { WatchlistApi, WatchlistSortState } from "@/screens/watchlist-screen.view-model";
 
 const symbols: SymbolRecord[] = [
   {
@@ -393,6 +396,149 @@ describe("watchlist-screen view model", () => {
     await waitFor(() => expect(result.current.selectedSymbol).toBe("MSFT"));
     expect(result.current.selectedRowId).toBe("MSFT");
     expect(result.current.selectedDetail?.title).toBe("MSFT");
+  });
+});
+
+describe("watchlist sort and filter", () => {
+  const sortSamples: SymbolRecord[] = [
+    { symbol: "AAA", status: "Active", provider: "Polygon", lastEventAt: null, eventCount: 0, hasHistoricalData: false },
+    { symbol: "BBB", status: "Active", provider: "Polygon", lastEventAt: null, eventCount: 0, hasHistoricalData: false },
+    { symbol: "CCC", status: "Active", provider: "Polygon", lastEventAt: null, eventCount: 0, hasHistoricalData: false },
+    { symbol: "DDD", status: "Active", provider: "Polygon", lastEventAt: null, eventCount: 0, hasHistoricalData: false }
+  ];
+
+  const now = Date.parse("2026-05-09T01:00:00.000Z");
+
+  function makeQuote(overrides: {
+    symbol: string;
+    timestamp?: string;
+    lastPrice: number;
+    spread: number;
+    midPrice: number;
+    change: number;
+    changePercent: number | null;
+    high: number;
+    low: number;
+  }): QuotesSnapshotItem {
+    return {
+      symbol: overrides.symbol,
+      timestamp: overrides.timestamp ?? "2026-05-09T00:59:55.000Z",
+      bidPrice: overrides.midPrice - overrides.spread / 2,
+      bidSize: 10,
+      askPrice: overrides.midPrice + overrides.spread / 2,
+      askSize: 10,
+      midPrice: overrides.midPrice,
+      spread: overrides.spread,
+      lastPrice: overrides.lastPrice,
+      lastSize: 1,
+      lastTradeTimestamp: overrides.timestamp ?? "2026-05-09T00:59:55.000Z",
+      sequenceNumber: 1,
+      streamId: null,
+      venue: null,
+      session: {
+        sessionDate: "2026-05-09",
+        open: overrides.lastPrice - overrides.change,
+        high: overrides.high,
+        low: overrides.low,
+        last: overrides.lastPrice,
+        volume: 1000,
+        vwap: overrides.midPrice,
+        tradeCount: 50,
+        change: overrides.change,
+        changePercent: overrides.changePercent,
+        firstTradeAt: "2026-05-09T13:30:00.000Z",
+        lastTradeAt: overrides.timestamp ?? "2026-05-09T00:59:55.000Z"
+      }
+    };
+  }
+
+  const baseRows = buildWatchlistRows(
+    sortSamples,
+    {},
+    {
+      AAA: makeQuote({ symbol: "AAA", lastPrice: 50, spread: 0.05, midPrice: 50, change: 1, changePercent: 2, high: 51, low: 48 }),
+      BBB: makeQuote({ symbol: "BBB", lastPrice: 200, spread: 0.10, midPrice: 200, change: -3, changePercent: -1.5, high: 205, low: 199 }),
+      CCC: makeQuote({
+        symbol: "CCC",
+        timestamp: "2026-05-09T00:59:00.000Z",
+        lastPrice: 75,
+        spread: 0.02,
+        midPrice: 75,
+        change: 5,
+        changePercent: 7.1,
+        high: 76,
+        low: 70
+      })
+      // DDD intentionally has no quote
+    },
+    {},
+    now
+  );
+
+  it("sorts by change percent descending (largest movers first) and pushes missing data to the bottom", () => {
+    const sorted = sortAndFilterWatchlistRows(
+      baseRows,
+      { columnId: "change-percent", direction: "desc" } as WatchlistSortState,
+      false
+    );
+    expect(sorted.map((row) => row.symbol)).toEqual(["CCC", "AAA", "BBB", "DDD"]);
+  });
+
+  it("sorts by spread ascending (tightest markets first)", () => {
+    const sorted = sortAndFilterWatchlistRows(
+      baseRows,
+      { columnId: "spread", direction: "asc" } as WatchlistSortState,
+      false
+    );
+    expect(sorted.map((row) => row.symbol)).toEqual(["CCC", "AAA", "BBB", "DDD"]);
+  });
+
+  it("hides stale rows when requested but keeps no-quote rows visible", () => {
+    const sorted = sortAndFilterWatchlistRows(
+      baseRows,
+      { columnId: "symbol", direction: "asc" } as WatchlistSortState,
+      true
+    );
+    // CCC's quote timestamp is 60s old; stale threshold is 15s, so CCC is stale.
+    // DDD has no quote, so quoteStale is false — it remains visible.
+    expect(sorted.map((row) => row.symbol)).toEqual(["AAA", "BBB", "DDD"]);
+  });
+
+  it("toggles sort direction: first click sets desc, second click sets asc, third resets to symbol", () => {
+    const initial: WatchlistSortState = { columnId: "symbol", direction: "asc" };
+    const afterFirst = toggleWatchlistSort(initial, "change-percent");
+    expect(afterFirst).toEqual({ columnId: "change-percent", direction: "desc" });
+    const afterSecond = toggleWatchlistSort(afterFirst, "change-percent");
+    expect(afterSecond).toEqual({ columnId: "change-percent", direction: "asc" });
+    const afterThird = toggleWatchlistSort(afterSecond, "change-percent");
+    expect(afterThird).toEqual({ columnId: "symbol", direction: "asc" });
+  });
+
+  it("builds the stale filter command, disabling when no stale rows exist", () => {
+    expect(buildStaleFilterCommand(0, 0, false)).toMatchObject({
+      disabled: true,
+      disabledReason: "Add a symbol before filtering stale quotes."
+    });
+    expect(buildStaleFilterCommand(5, 0, false)).toMatchObject({
+      disabled: true,
+      disabledReason: "No stale quotes to hide."
+    });
+    expect(buildStaleFilterCommand(5, 2, false)).toEqual({
+      label: "Hide stale (2)",
+      ariaLabel: "Hide 2 stale quotes.",
+      pressed: false,
+      disabled: false,
+      disabledReason: null,
+      hiddenCount: 0
+    });
+    expect(buildStaleFilterCommand(5, 2, true)).toEqual({
+      label: "Showing fresh only (2 hidden)",
+      ariaLabel: "Showing fresh quotes only. 2 stale rows hidden. Click to show all rows.",
+      pressed: true,
+      disabled: false,
+      disabledReason: null,
+      hiddenCount: 2
+    });
   });
 });
 

--- a/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.view-model.ts
@@ -7,6 +7,27 @@ export type WatchlistListState = "loading" | "error" | "empty" | "ready";
 export type WatchlistPriceTone = "default" | "success" | "danger";
 export type WatchlistQuoteStatusTone = "default" | "warning" | "danger";
 export type WatchlistDetailFieldTone = "default" | "success" | "warning" | "danger" | "muted";
+export type WatchlistSortColumn =
+  | "symbol"
+  | "status"
+  | "last"
+  | "change-percent"
+  | "spread"
+  | "quote-age";
+export type WatchlistSortDirection = "asc" | "desc";
+
+export interface WatchlistSortState {
+  columnId: WatchlistSortColumn;
+  direction: WatchlistSortDirection;
+}
+
+const DEFAULT_SORT: WatchlistSortState = { columnId: "symbol", direction: "asc" };
+const STATUS_RANK: Record<SymbolRecord["status"], number> = {
+  Error: 0,
+  Active: 1,
+  Monitored: 2,
+  Archived: 3
+};
 
 const QUOTE_POLL_INTERVAL_MS = 2000;
 const QUOTE_STALE_THRESHOLD_MS = 15_000;
@@ -64,6 +85,16 @@ export interface WatchlistRowViewModel {
   removeDisabledReason: string | null;
   rowSelectAriaLabel: string;
   ariaLabel: string;
+  /** Numeric sort key for last price; null when the row has no live quote. */
+  lastPriceValue: number | null;
+  /** Numeric sort key for absolute day change; null when no session is available. */
+  changeValue: number | null;
+  /** Numeric sort key for day change percent; null when no session is available. */
+  changePercentValue: number | null;
+  /** Numeric sort key for bid/ask spread; null when no live quote. */
+  spreadValue: number | null;
+  /** Numeric sort key for quote age in milliseconds; null when no live quote. */
+  quoteAgeMs: number | null;
 }
 
 export interface WatchlistQuoteRefreshCommandState {
@@ -106,6 +137,15 @@ export interface WatchlistSelectedDetail {
   fields: WatchlistSelectedDetailField[];
 }
 
+export interface WatchlistFilterCommandState {
+  label: string;
+  ariaLabel: string;
+  pressed: boolean;
+  disabled: boolean;
+  disabledReason: string | null;
+  hiddenCount: number;
+}
+
 export interface WatchlistScreenViewModel {
   pendingSymbol: string;
   setPendingSymbol: (value: string) => void;
@@ -116,6 +156,11 @@ export interface WatchlistScreenViewModel {
   loadError: string | null;
   stats: MetricSnapshot[];
   rows: WatchlistRowViewModel[];
+  sort: WatchlistSortState;
+  toggleSort: (columnId: WatchlistSortColumn) => void;
+  hideStale: boolean;
+  setHideStale: (value: boolean) => void;
+  staleFilterCommand: WatchlistFilterCommandState;
   listState: WatchlistListState;
   listDescription: string;
   tableLabel: string;
@@ -177,6 +222,8 @@ export function useWatchlistScreenViewModel(api: WatchlistApi): WatchlistScreenV
   const [quoteRefreshing, setQuoteRefreshing] = useState(false);
   const [activeStarterPackId, setActiveStarterPackId] = useState<string | null>(null);
   const [selectedSymbol, setSelectedSymbol] = useState<string | null>(null);
+  const [sort, setSort] = useState<WatchlistSortState>(DEFAULT_SORT);
+  const [hideStale, setHideStale] = useState(false);
   const mountedRef = useRef(true);
   const refreshRevisionRef = useRef(0);
   const refreshAbortRef = useRef<AbortController | null>(null);
@@ -463,10 +510,18 @@ export function useWatchlistScreenViewModel(api: WatchlistApi): WatchlistScreenV
   const addValidation = validatePendingSymbol(pendingSymbol);
   const pendingSymbols = parseWatchlistSymbols(pendingSymbol);
   const submitError = submitFeedback?.tone === "danger" ? submitFeedback.message : null;
-  const rows = useMemo(
+  const allRows = useMemo(
     () => buildWatchlistRows(symbols ?? [], removing, quotes, previousMidRef.current),
     [symbols, removing, quotes]
   );
+  const rows = useMemo(
+    () => sortAndFilterWatchlistRows(allRows, sort, hideStale),
+    [allRows, sort, hideStale]
+  );
+  const toggleSort = useCallback((columnId: WatchlistSortColumn) => {
+    setSort((current) => toggleWatchlistSort(current, columnId));
+  }, []);
+
   useEffect(() => {
     if (rows.length === 0) {
       if (selectedSymbol !== null) {
@@ -482,14 +537,17 @@ export function useWatchlistScreenViewModel(api: WatchlistApi): WatchlistScreenV
 
   const selectedRow = rows.find((row) => row.symbol === selectedSymbol) ?? rows[0] ?? null;
   const listState = buildListState(symbols, loadError);
+  const totalQuoteCount = allRows.filter((row) => row.hasQuote).length;
+  const totalStaleCount = allRows.filter((row) => row.quoteStale).length;
   const quoteStatus = buildQuoteStatus({
     listState,
-    rowCount: rows.length,
-    quoteCount: rows.filter((row) => row.hasQuote).length,
-    staleCount: rows.filter((row) => row.quoteStale).length,
+    rowCount: allRows.length,
+    quoteCount: totalQuoteCount,
+    staleCount: totalStaleCount,
     quoteError,
     quoteFetchedAt
   });
+  const staleFilterCommand = buildStaleFilterCommand(allRows.length, totalStaleCount, hideStale);
 
   return {
     pendingSymbol,
@@ -501,10 +559,15 @@ export function useWatchlistScreenViewModel(api: WatchlistApi): WatchlistScreenV
     loadError,
     stats: buildWatchlistStats(stats),
     rows,
+    sort,
+    toggleSort,
+    hideStale,
+    setHideStale,
+    staleFilterCommand,
     listState,
-    listDescription: buildListDescription(listState, rows.length, loadError),
+    listDescription: buildListDescription(listState, rows.length, allRows.length, hideStale, loadError),
     tableLabel: "Subscribed symbol watchlist",
-    tableCaption: "Subscribed symbols sorted alphabetically with status, live bid and ask, last price, day change, day high/low, spread, quote age, provider, and actions.",
+    tableCaption: buildTableCaption(sort, hideStale),
     formLabel: "Add symbols to the watchlist",
     inputId: "add-symbol-input",
     inputPlaceholder: "Add symbols (e.g. MSFT, SPY)",
@@ -602,9 +665,85 @@ export function buildWatchlistRows(
         removeAriaLabel: isRemoving ? `Removing ${record.symbol} from watchlist` : `Remove ${record.symbol} from watchlist`,
         removeDisabledReason: isRemoving ? `${record.symbol} removal is already running.` : null,
         rowSelectAriaLabel: `Select ${record.symbol} watchlist row. ${record.symbol}. Status ${record.status}.`,
-        ariaLabel: `${record.symbol}. Status ${record.status}. Bid ${quote ? formatPriceSize(quote.bidPrice, quote.bidSize) : "not available"}. Ask ${quote ? formatPriceSize(quote.askPrice, quote.askSize) : "not available"}. Last ${quote ? formatPrice(quote.lastPrice) : "not available"}. Change ${changeLabel}. Change percent ${changePercentLabel}. Day high low ${dayRangeLabel}. Provider ${providerLabel}. Last event ${lastEventLabel}. ${eventCountLabel} events. History ${historyLabel}.`
+        ariaLabel: `${record.symbol}. Status ${record.status}. Bid ${quote ? formatPriceSize(quote.bidPrice, quote.bidSize) : "not available"}. Ask ${quote ? formatPriceSize(quote.askPrice, quote.askSize) : "not available"}. Last ${quote ? formatPrice(quote.lastPrice) : "not available"}. Change ${changeLabel}. Change percent ${changePercentLabel}. Day high low ${dayRangeLabel}. Provider ${providerLabel}. Last event ${lastEventLabel}. ${eventCountLabel} events. History ${historyLabel}.`,
+        lastPriceValue: toFiniteNumber(quote?.lastPrice),
+        changeValue: toFiniteNumber(session?.change),
+        changePercentValue: toFiniteNumber(session?.changePercent),
+        spreadValue: toFiniteNumber(quote?.spread),
+        quoteAgeMs: quoteAgeMs ?? null
       };
     });
+}
+
+export function sortAndFilterWatchlistRows(
+  rows: WatchlistRowViewModel[],
+  sort: WatchlistSortState,
+  hideStale: boolean
+): WatchlistRowViewModel[] {
+  const filtered = hideStale ? rows.filter((row) => !row.quoteStale) : rows;
+  const direction = sort.direction === "asc" ? 1 : -1;
+  return [...filtered].sort((left, right) => {
+    const leftKey = sortKeyFor(left, sort.columnId);
+    const rightKey = sortKeyFor(right, sort.columnId);
+    const leftMissing = leftKey === null;
+    const rightMissing = rightKey === null;
+    if (leftMissing && rightMissing) {
+      return left.symbol.localeCompare(right.symbol);
+    }
+    if (leftMissing) return 1;
+    if (rightMissing) return -1;
+
+    const primary = compareSortKeys(leftKey as number | string, rightKey as number | string);
+    if (primary !== 0) {
+      return primary * direction;
+    }
+    return left.symbol.localeCompare(right.symbol);
+  });
+}
+
+function sortKeyFor(row: WatchlistRowViewModel, columnId: WatchlistSortColumn): number | string | null {
+  switch (columnId) {
+    case "symbol":
+      return row.symbol;
+    case "status":
+      return STATUS_RANK[row.status];
+    case "last":
+      return row.lastPriceValue;
+    case "change-percent":
+      return row.changePercentValue;
+    case "spread":
+      return row.spreadValue;
+    case "quote-age":
+      return row.quoteAgeMs;
+  }
+}
+
+function compareSortKeys(left: number | string, right: number | string): number {
+  if (typeof left === "string" && typeof right === "string") {
+    return left.localeCompare(right);
+  }
+  if (typeof left === "number" && typeof right === "number") {
+    return left - right;
+  }
+  return String(left).localeCompare(String(right));
+}
+
+function toFiniteNumber(value: number | null | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function toggleWatchlistSort(
+  current: WatchlistSortState,
+  columnId: WatchlistSortColumn,
+  defaultSort: WatchlistSortState = DEFAULT_SORT
+): WatchlistSortState {
+  if (current.columnId !== columnId) {
+    return { columnId, direction: columnId === "symbol" ? "asc" : "desc" };
+  }
+  if (current.direction === "desc") {
+    return { columnId, direction: "asc" };
+  }
+  return defaultSort;
 }
 
 export function buildWatchlistSelectedDetail(
@@ -833,7 +972,13 @@ function buildListState(symbols: SymbolRecord[] | null, loadError: string | null
   return "ready";
 }
 
-function buildListDescription(state: WatchlistListState, rowCount: number, loadError: string | null): string {
+function buildListDescription(
+  state: WatchlistListState,
+  visibleCount: number,
+  totalCount: number,
+  hideStale: boolean,
+  loadError: string | null
+): string {
   switch (state) {
     case "loading":
       return "Loading symbols...";
@@ -841,9 +986,70 @@ function buildListDescription(state: WatchlistListState, rowCount: number, loadE
       return loadError ?? "Symbol watchlist failed to load.";
     case "empty":
       return "No symbols configured. Add one above to start collecting live data.";
-    case "ready":
-      return `${rowCount} symbol${rowCount === 1 ? "" : "s"} configured.`;
+    case "ready": {
+      const hidden = totalCount - visibleCount;
+      if (hideStale && hidden > 0) {
+        return `${visibleCount} of ${totalCount} symbol${totalCount === 1 ? "" : "s"} shown; ${hidden} stale hidden.`;
+      }
+      return `${totalCount} symbol${totalCount === 1 ? "" : "s"} configured.`;
+    }
   }
+}
+
+const SORT_COLUMN_LABELS: Record<WatchlistSortColumn, string> = {
+  "symbol": "symbol",
+  "status": "status",
+  "last": "last price",
+  "change-percent": "day change percent",
+  "spread": "spread",
+  "quote-age": "quote age"
+};
+
+function buildTableCaption(sort: WatchlistSortState, hideStale: boolean): string {
+  const directionLabel = sort.direction === "asc" ? "ascending" : "descending";
+  const sortLabel = SORT_COLUMN_LABELS[sort.columnId];
+  const filterLabel = hideStale ? " Stale rows are hidden." : "";
+  return `Subscribed symbols sorted by ${sortLabel} ${directionLabel}.${filterLabel} Columns show status, live bid and ask, last price, day change, day high/low, spread, quote age, provider, and actions.`;
+}
+
+export function buildStaleFilterCommand(
+  rowCount: number,
+  staleCount: number,
+  hideStale: boolean
+): WatchlistFilterCommandState {
+  const hiddenCount = hideStale ? staleCount : 0;
+  if (rowCount === 0) {
+    return {
+      label: "Hide stale",
+      ariaLabel: "Hide stale quotes. Disabled because there are no symbols yet.",
+      pressed: false,
+      disabled: true,
+      disabledReason: "Add a symbol before filtering stale quotes.",
+      hiddenCount: 0
+    };
+  }
+
+  if (staleCount === 0 && !hideStale) {
+    return {
+      label: "Hide stale",
+      ariaLabel: "Hide stale quotes. No stale quotes detected.",
+      pressed: false,
+      disabled: true,
+      disabledReason: "No stale quotes to hide.",
+      hiddenCount: 0
+    };
+  }
+
+  return {
+    label: hideStale ? `Showing fresh only (${staleCount} hidden)` : `Hide stale (${staleCount})`,
+    ariaLabel: hideStale
+      ? `Showing fresh quotes only. ${staleCount} stale row${staleCount === 1 ? "" : "s"} hidden. Click to show all rows.`
+      : `Hide ${staleCount} stale quote${staleCount === 1 ? "" : "s"}.`,
+    pressed: hideStale,
+    disabled: false,
+    disabledReason: null,
+    hiddenCount
+  };
 }
 
 function buildToolbarItems(

--- a/src/Meridian.Ui/dashboard/src/styles/index.css
+++ b/src/Meridian.Ui/dashboard/src/styles/index.css
@@ -801,6 +801,55 @@
     color: var(--fg-muted);
   }
 
+  .dense-data-table-sortable {
+    cursor: pointer;
+  }
+
+  .dense-data-table-sort-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    width: 100%;
+    padding: 0;
+    background: transparent;
+    border: 0;
+    font: inherit;
+    letter-spacing: inherit;
+    text-transform: inherit;
+    color: inherit;
+    cursor: pointer;
+  }
+
+  .dense-data-table th.text-right .dense-data-table-sort-button {
+    justify-content: flex-end;
+  }
+
+  .dense-data-table-sort-button:hover,
+  .dense-data-table-sort-button:focus-visible {
+    color: var(--fg);
+  }
+
+  .dense-data-table-sort-button:focus-visible {
+    outline: 2px solid rgba(42, 178, 212, 0.45);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+  }
+
+  .dense-data-table-sort-indicator {
+    opacity: 0.45;
+    font-size: 0.6875rem;
+    line-height: 1;
+  }
+
+  .dense-data-table-sorted .dense-data-table-sort-indicator {
+    opacity: 1;
+    color: var(--accent, #2ab2d4);
+  }
+
+  .dense-data-table-sorted .dense-data-table-sort-button {
+    color: var(--fg);
+  }
+
   .row-detail-panel {
     overflow: hidden;
     border: 1px solid rgba(31, 52, 76, 0.95);

--- a/src/Meridian.Ui/wwwroot/workstation/index.html
+++ b/src/Meridian.Ui/wwwroot/workstation/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="data:," />
     <title>Meridian Web Workstation</title>
-    <script type="module" crossorigin src="/workstation/assets/index-D9kVSsLv.js"></script>
-    <link rel="stylesheet" crossorigin href="/workstation/assets/index-Da9RkmXG.css">
+    <script type="module" crossorigin src="/workstation/assets/index-B8Ne1kva.js"></script>
+    <link rel="stylesheet" crossorigin href="/workstation/assets/index-7G4UVg37.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Power-user feature for traders: the operator watchlist now supports
clickable column-header sorting on symbol, status, last, change %,
spread, and quote age, plus a "Hide stale" toggle that filters out
stale rows while preserving accurate coverage stats.

Why this matters for end users: alphabetical-only sort hides the most
operationally relevant rows. Sorting by change% surfaces today's
biggest movers; sorting by spread reveals tight/wide markets; sorting
by quote age surfaces freshness issues. The stale filter lets traders
focus on actionable rows without losing the underlying status panel.

- Extend DenseDataTable with sortable column headers (aria-sort, keyboard
  accessible button, visual asc/desc indicator), defaulting off so other
  screens (trading, portfolio, governance, etc.) are untouched.
- Add WatchlistSortState, hideStale state, sortAndFilterWatchlistRows,
  toggleWatchlistSort, and buildStaleFilterCommand to the view model;
  numeric sort keys live on the row to keep sorting pure.
- Push missing-data rows to the bottom in both directions so "best" rows
  always appear first regardless of sort direction.
- Add 5 view-model tests covering sort directionality, null handling,
  filter behaviour, and the toggle cycle.

Also fix pre-existing TS errors in src/app.test.tsx mocks (missing
refreshPortfolio) so the production build completes again.

https://claude.ai/code/session_01NquF5eBKpTgNiq49kERLio