### PR TITLE
feat(overview): add Today panel with day P&L, movers, orders, fills

### DIFF
--- a/src/Meridian.Ui/dashboard/src/screens/overview-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/overview-screen.tsx
@@ -12,6 +12,7 @@ import {
   RefreshCcw,
   Settings,
   Shield,
+  Sparkles,
   TrendingUp,
   XCircle
 } from "lucide-react";
@@ -33,6 +34,16 @@ import {
   type OverviewValueBlocker,
   type PortfolioPanelTone
 } from "@/screens/overview-screen.view-model";
+import {
+  buildTodayPanelViewModel,
+  type TodayFillRow,
+  type TodayMetric,
+  type TodayMoverRow,
+  type TodayOrderRow,
+  type TodayPanelViewModel,
+  type TodayQuickAction,
+  type TodayTone
+} from "@/screens/today-panel.view-model";
 import type {
   PortfolioWorkspaceResponse,
   SessionInfo,
@@ -105,6 +116,7 @@ export function OverviewScreen({ data, session, trading = null, portfolio = null
   const vm = useOverviewStatusViewModel(data, session);
   const StatusIcon = statusBannerIconConfig[vm.statusBanner.icon];
   const portfolioPanel = buildOverviewPortfolioPanel(trading, portfolio);
+  const todayPanel = buildTodayPanelViewModel(trading, portfolio);
 
   return (
     <div className="space-y-6">
@@ -158,6 +170,8 @@ export function OverviewScreen({ data, session, trading = null, portfolio = null
           {vm.refreshErrorText}
         </div>
       )}
+
+      <TodayPanel panel={todayPanel} />
 
       <PortfolioPanel panel={portfolioPanel} />
 
@@ -503,5 +517,291 @@ function EventRow({ event }: { event: OverviewActivityRow }) {
         </div>
       </div>
     </li>
+  );
+}
+
+const todayToneTextClass: Record<TodayTone, string> = {
+  default: "text-foreground",
+  success: "text-success",
+  warning: "text-warning",
+  danger: "text-danger"
+};
+
+const todayMoverPnlToneClass: Record<TodayTone, string> = {
+  default: "text-muted-foreground",
+  success: "text-success",
+  warning: "text-warning",
+  danger: "text-danger"
+};
+
+function TodayPanel({ panel }: { panel: TodayPanelViewModel }) {
+  return (
+    <Card className="border-border/70 bg-panel-strong">
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <div className="eyebrow-label">{panel.headline}</div>
+            <CardTitle className="mt-1 flex items-center gap-2 text-lg">
+              <Sparkles className="size-4 text-primary" aria-hidden="true" />
+              Your day at a glance
+            </CardTitle>
+            <CardDescription className="mt-1">{panel.subheadline}</CardDescription>
+          </div>
+          {panel.brokerageLabel ? (
+            <p className="font-mono text-[11px] text-muted-foreground">{panel.brokerageLabel}</p>
+          ) : null}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {panel.hasData ? (
+          <>
+            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              {panel.metrics.map((metric) => (
+                <TodayMetricTile key={metric.id} metric={metric} />
+              ))}
+            </div>
+
+            <div className="grid gap-4 xl:grid-cols-3">
+              <TodayMoversCard panel={panel} />
+              <TodayOrdersCard panel={panel} />
+              <TodayFillsCard panel={panel} />
+            </div>
+
+            <TodayQuickActions actions={panel.quickActions} />
+          </>
+        ) : (
+          <div className="rounded-md border border-border/60 bg-secondary/20 px-4 py-6 text-center text-sm text-muted-foreground">
+            <p>{panel.emptyMessage}</p>
+            <Button asChild variant="outline" size="sm" className="mt-3">
+              <Link to={panel.emptyActionHref} aria-label={panel.emptyActionAriaLabel}>
+                <Settings className="size-3.5" aria-hidden="true" />
+                <span className="ml-1.5">{panel.emptyActionLabel}</span>
+              </Link>
+            </Button>
+            <TodayQuickActions actions={panel.quickActions} />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TodayMetricTile({ metric }: { metric: TodayMetric }) {
+  return (
+    <div
+      role="group"
+      aria-label={metric.ariaLabel}
+      className="rounded-lg border border-border/70 bg-background/70 p-4"
+    >
+      <div className="eyebrow-label">{metric.label}</div>
+      <p className={cn("mt-2 text-xl font-semibold tabular-nums", todayToneTextClass[metric.tone])}>
+        {metric.value}
+      </p>
+      <p className="mt-1 text-xs leading-5 text-muted-foreground">{metric.detail}</p>
+    </div>
+  );
+}
+
+function TodayMoversCard({ panel }: { panel: TodayPanelViewModel }) {
+  return (
+    <Card className="border-border/60 bg-background/60">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-sm font-semibold">Top movers</CardTitle>
+          <Button asChild variant="ghost" size="sm" className="h-7 px-2 text-xs">
+            <Link to="/portfolio" aria-label="Open portfolio for all positions">
+              Portfolio
+              <ArrowRight className="size-3" aria-hidden="true" />
+            </Link>
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2 pt-0">
+        {panel.hasMovers ? (
+          <ul className="space-y-1.5" aria-label="Top movers today">
+            {panel.movers.map((mover) => (
+              <TodayMoverRowView key={mover.key} row={mover} />
+            ))}
+            {panel.moversMoreLabel ? (
+              <li className="pt-1 text-[11px] text-muted-foreground">{panel.moversMoreLabel}</li>
+            ) : null}
+          </ul>
+        ) : (
+          <p className="rounded-md border border-dashed border-border/60 px-3 py-3 text-xs text-muted-foreground">
+            {panel.moversEmptyMessage}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TodayMoverRowView({ row }: { row: TodayMoverRow }) {
+  return (
+    <li
+      role="group"
+      aria-label={row.ariaLabel}
+      className="flex items-center gap-x-3 rounded-md border border-border/55 bg-secondary/20 px-3 py-2 text-xs"
+    >
+      <span className="min-w-[3.5rem] font-mono font-semibold text-foreground">{row.symbol}</span>
+      <Badge variant={row.side === "Long" ? "outline" : "warning"} className="shrink-0 text-[10px]">
+        {row.side}
+      </Badge>
+      <span className="hidden font-mono text-muted-foreground sm:inline">{row.quantity}</span>
+      <span className="hidden font-mono text-muted-foreground md:inline">@{row.markPrice}</span>
+      <span className={cn("ml-auto font-mono font-medium tabular-nums", todayMoverPnlToneClass[row.dayPnlTone])}>
+        {row.dayPnl}
+      </span>
+    </li>
+  );
+}
+
+function TodayOrdersCard({ panel }: { panel: TodayPanelViewModel }) {
+  return (
+    <Card className="border-border/60 bg-background/60">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-sm font-semibold">
+            Open orders
+            {panel.ordersTotal > 0 ? (
+              <span className="ml-1.5 font-mono text-[11px] font-normal text-muted-foreground">
+                ({panel.ordersTotal})
+              </span>
+            ) : null}
+          </CardTitle>
+          <Button asChild variant="ghost" size="sm" className="h-7 px-2 text-xs">
+            <Link to="/trading" aria-label="Open trading cockpit for all orders">
+              Trading
+              <ArrowRight className="size-3" aria-hidden="true" />
+            </Link>
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2 pt-0">
+        {panel.hasOrders ? (
+          <ul className="space-y-1.5" aria-label="Open orders preview">
+            {panel.orders.map((order) => (
+              <TodayOrderRowView key={order.key} row={order} />
+            ))}
+            {panel.ordersMoreLabel ? (
+              <li className="pt-1 text-[11px] text-muted-foreground">{panel.ordersMoreLabel}</li>
+            ) : null}
+          </ul>
+        ) : (
+          <p className="rounded-md border border-dashed border-border/60 px-3 py-3 text-xs text-muted-foreground">
+            {panel.ordersEmptyMessage}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TodayOrderRowView({ row }: { row: TodayOrderRow }) {
+  return (
+    <li
+      role="group"
+      aria-label={row.ariaLabel}
+      className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md border border-border/55 bg-secondary/20 px-3 py-2 text-xs"
+    >
+      <span className="min-w-[3.5rem] font-mono font-semibold text-foreground">{row.symbol}</span>
+      <Badge variant={row.side === "Buy" ? "success" : "warning"} className="shrink-0 text-[10px]">
+        {row.side}
+      </Badge>
+      <span className="font-mono text-muted-foreground">{row.quantity}</span>
+      <span className="font-mono text-muted-foreground">{row.priceLabel}</span>
+      <span className="ml-auto font-mono text-[11px] text-muted-foreground">{row.status}</span>
+    </li>
+  );
+}
+
+function TodayFillsCard({ panel }: { panel: TodayPanelViewModel }) {
+  return (
+    <Card className="border-border/60 bg-background/60">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-sm font-semibold">
+            Recent fills
+            {panel.fillsTotal > 0 ? (
+              <span className="ml-1.5 font-mono text-[11px] font-normal text-muted-foreground">
+                ({panel.fillsTotal})
+              </span>
+            ) : null}
+          </CardTitle>
+          <Button asChild variant="ghost" size="sm" className="h-7 px-2 text-xs">
+            <Link to="/trading" aria-label="Open trading cockpit for all fills">
+              Trading
+              <ArrowRight className="size-3" aria-hidden="true" />
+            </Link>
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2 pt-0">
+        {panel.hasFills ? (
+          <ul className="space-y-1.5" aria-label="Recent fills preview">
+            {panel.fills.map((fill) => (
+              <TodayFillRowView key={fill.key} row={fill} />
+            ))}
+            {panel.fillsMoreLabel ? (
+              <li className="pt-1 text-[11px] text-muted-foreground">{panel.fillsMoreLabel}</li>
+            ) : null}
+          </ul>
+        ) : (
+          <p className="rounded-md border border-dashed border-border/60 px-3 py-3 text-xs text-muted-foreground">
+            {panel.fillsEmptyMessage}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TodayFillRowView({ row }: { row: TodayFillRow }) {
+  return (
+    <li
+      role="group"
+      aria-label={row.ariaLabel}
+      className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md border border-border/55 bg-secondary/20 px-3 py-2 text-xs"
+    >
+      <span className="min-w-[3.5rem] font-mono font-semibold text-foreground">{row.symbol}</span>
+      <Badge variant={row.side === "Buy" ? "success" : "warning"} className="shrink-0 text-[10px]">
+        {row.side}
+      </Badge>
+      <span className="font-mono text-muted-foreground">{row.quantity}</span>
+      <span className="font-mono text-muted-foreground">@{row.price}</span>
+      <span className="ml-auto font-mono text-[11px] text-muted-foreground">{row.timestampLabel}</span>
+    </li>
+  );
+}
+
+const todayQuickActionIcon: Record<TodayQuickAction["id"], ElementType> = {
+  "place-order": TrendingUp,
+  "add-symbol": Database,
+  "live-quote": LineChart,
+  reconcile: Shield
+};
+
+function TodayQuickActions({ actions }: { actions: TodayQuickAction[] }) {
+  return (
+    <div
+      aria-label="Quick actions"
+      className="flex flex-wrap items-center gap-2"
+      role="group"
+    >
+      <span className="text-xs font-semibold uppercase tracking-normal text-muted-foreground">
+        Quick actions
+      </span>
+      {actions.map((action) => {
+        const Icon = todayQuickActionIcon[action.id];
+        return (
+          <Button asChild variant="outline" size="sm" key={action.id}>
+            <Link to={action.href} aria-label={action.ariaLabel}>
+              <Icon className="size-3.5" aria-hidden="true" />
+              <span className="ml-1.5">{action.label}</span>
+            </Link>
+          </Button>
+        );
+      })}
+    </div>
   );
 }

--- a/src/Meridian.Ui/dashboard/src/screens/today-panel.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/today-panel.view-model.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTodayPanelViewModel,
+  parseSignedAmount
+} from "@/screens/today-panel.view-model";
+import type {
+  PortfolioWorkspaceResponse,
+  TradingWorkspaceResponse
+} from "@/types";
+
+const brokerage = {
+  provider: "Interactive Brokers",
+  account: "DU1009034",
+  environment: "paper",
+  connection: "Connected",
+  lastHeartbeat: "2s ago",
+  orderIngress: "healthy",
+  fillFeed: "healthy",
+  notes: ""
+} as const;
+
+const risk = {
+  state: "Healthy",
+  summary: "All clear.",
+  netExposure: "$10,000",
+  grossExposure: "$10,000",
+  var95: "$200",
+  maxDrawdown: "-0.5%",
+  buyingPowerUsed: "30%",
+  activeGuardrails: []
+} as const;
+
+function makeTrading(overrides: Partial<TradingWorkspaceResponse> = {}): TradingWorkspaceResponse {
+  return {
+    metrics: [],
+    positions: [],
+    openOrders: [],
+    fills: [],
+    risk: { ...risk, activeGuardrails: [...risk.activeGuardrails] },
+    brokerage: { ...brokerage },
+    readiness: null,
+    ...overrides
+  };
+}
+
+function makePortfolio(overrides: Partial<PortfolioWorkspaceResponse> = {}): PortfolioWorkspaceResponse {
+  return {
+    metrics: [],
+    positions: [],
+    risk: { ...risk, activeGuardrails: [...risk.activeGuardrails] },
+    brokerage: { ...brokerage },
+    runs: [],
+    cashFlow: null,
+    ...overrides
+  };
+}
+
+describe("today-panel view model", () => {
+  it("returns an empty placeholder when no trading or portfolio data is present", () => {
+    const vm = buildTodayPanelViewModel(null, null);
+
+    expect(vm.hasData).toBe(false);
+    expect(vm.subheadline).toContain("Connect a brokerage");
+    expect(vm.metrics.map((m) => m.value)).toEqual(["—", "—", "—", "—"]);
+    expect(vm.metrics.every((m) => m.tone === "default")).toBe(true);
+    expect(vm.hasMovers).toBe(false);
+    expect(vm.hasOrders).toBe(false);
+    expect(vm.hasFills).toBe(false);
+    expect(vm.quickActions.map((a) => a.id)).toEqual([
+      "place-order",
+      "add-symbol",
+      "live-quote",
+      "reconcile"
+    ]);
+    expect(vm.brokerageLabel).toBeNull();
+  });
+
+  it("aggregates day P&L across positions and tones the headline metric green when net positive", () => {
+    const trading = makeTrading({
+      positions: [
+        { symbol: "AAPL", side: "Long", quantity: "100", averagePrice: "188", markPrice: "189", dayPnl: "+$90", unrealizedPnl: "+$90", exposure: "$18,900" },
+        { symbol: "MSFT", side: "Long", quantity: "50", averagePrice: "410", markPrice: "414", dayPnl: "+$200", unrealizedPnl: "+$200", exposure: "$20,700" },
+        { symbol: "TSLA", side: "Short", quantity: "20", averagePrice: "180", markPrice: "175", dayPnl: "-$50", unrealizedPnl: "+$100", exposure: "-$3,500" }
+      ],
+      metrics: [
+        { id: "fills", label: "Fills", value: "13", delta: "+3", tone: "success" }
+      ]
+    });
+    const portfolio = makePortfolio({
+      metrics: [
+        { id: "portfolio-equity", label: "Portfolio Equity", value: "$120,000", delta: "+1.1%", tone: "success" },
+        { id: "portfolio-cash", label: "Cash", value: "$30,000", delta: "Available", tone: "default" }
+      ]
+    });
+
+    const vm = buildTodayPanelViewModel(trading, portfolio);
+
+    expect(vm.hasData).toBe(true);
+    const dayPnl = vm.metrics.find((m) => m.id === "today-day-pnl");
+    expect(dayPnl?.value).toBe("+$240");
+    expect(dayPnl?.tone).toBe("success");
+    expect(dayPnl?.detail).toBe("Across 3 open positions");
+
+    const equity = vm.metrics.find((m) => m.id === "today-equity");
+    expect(equity?.value).toBe("$120,000");
+    expect(equity?.tone).toBe("success");
+
+    const cash = vm.metrics.find((m) => m.id === "today-cash");
+    expect(cash?.value).toBe("$30,000");
+
+    expect(vm.brokerageLabel).toBe("Interactive Brokers · DU1009034 · paper");
+    expect(vm.subheadline).toContain("3 open positions");
+    expect(vm.subheadline).toContain("13 fills today");
+  });
+
+  it("ranks movers by absolute day P&L magnitude regardless of direction", () => {
+    const trading = makeTrading({
+      positions: [
+        { symbol: "FLAT", side: "Long", quantity: "10", averagePrice: "10", markPrice: "10", dayPnl: "+$0", unrealizedPnl: "$0", exposure: "$100" },
+        { symbol: "AAPL", side: "Long", quantity: "100", averagePrice: "188", markPrice: "189", dayPnl: "+$90", unrealizedPnl: "+$90", exposure: "$18,900" },
+        { symbol: "TSLA", side: "Short", quantity: "20", averagePrice: "180", markPrice: "175", dayPnl: "-$500", unrealizedPnl: "+$100", exposure: "-$3,500" },
+        { symbol: "MSFT", side: "Long", quantity: "50", averagePrice: "410", markPrice: "414", dayPnl: "+$200", unrealizedPnl: "+$200", exposure: "$20,700" }
+      ]
+    });
+
+    const vm = buildTodayPanelViewModel(trading, null);
+
+    expect(vm.movers.map((m) => m.symbol)).toEqual(["TSLA", "MSFT", "AAPL"]);
+    expect(vm.movers[0].dayPnlTone).toBe("danger");
+    expect(vm.movers[1].dayPnlTone).toBe("success");
+    expect(vm.movers.find((m) => m.symbol === "FLAT")).toBeUndefined();
+    expect(vm.moversTotal).toBe(4);
+  });
+
+  it("previews up to five open orders and emits a more-label when there are extras", () => {
+    const trading = makeTrading({
+      openOrders: Array.from({ length: 7 }).map((_, i) => ({
+        orderId: `OR-${i + 1}`,
+        symbol: i % 2 === 0 ? "AAPL" : "MSFT",
+        side: "Buy" as const,
+        type: i === 0 ? ("Market" as const) : ("Limit" as const),
+        quantity: "10",
+        limitPrice: i === 0 ? "—" : `100.0${i}`,
+        status: "Working" as const,
+        submittedAt: `09:4${i}:00 ET`
+      }))
+    });
+
+    const vm = buildTodayPanelViewModel(trading, null);
+
+    expect(vm.orders).toHaveLength(5);
+    expect(vm.orders[0].priceLabel).toBe("Market");
+    expect(vm.orders[1].priceLabel).toBe("100.01");
+    expect(vm.ordersTotal).toBe(7);
+    expect(vm.ordersMoreLabel).toBe("+2 more in trading cockpit");
+  });
+
+  it("previews up to five fills and emits a more-label when there are extras", () => {
+    const trading = makeTrading({
+      fills: Array.from({ length: 6 }).map((_, i) => ({
+        fillId: `FL-${i + 1}`,
+        orderId: `OR-${i + 1}`,
+        symbol: "AAPL",
+        side: "Buy" as const,
+        quantity: "10",
+        price: `189.0${i}`,
+        venue: "NASDAQ",
+        timestamp: `09:5${i}:00 ET`
+      }))
+    });
+
+    const vm = buildTodayPanelViewModel(trading, null);
+
+    expect(vm.fills).toHaveLength(5);
+    expect(vm.fillsTotal).toBe(6);
+    expect(vm.fillsMoreLabel).toBe("+1 more in trading cockpit");
+  });
+
+  it("falls back to portfolio data when only portfolio is available", () => {
+    const portfolio = makePortfolio({
+      positions: [
+        { symbol: "AAPL", side: "Long", quantity: "100", averagePrice: "188", markPrice: "189", dayPnl: "+$90", unrealizedPnl: "+$90", exposure: "$18,900" }
+      ],
+      metrics: [
+        { id: "portfolio-equity", label: "Portfolio Equity", value: "$50,000", delta: "+0.5%", tone: "success" }
+      ]
+    });
+
+    const vm = buildTodayPanelViewModel(null, portfolio);
+
+    expect(vm.hasData).toBe(true);
+    expect(vm.metrics.find((m) => m.id === "today-day-pnl")?.value).toBe("+$90");
+    expect(vm.metrics.find((m) => m.id === "today-equity")?.value).toBe("$50,000");
+    expect(vm.orders).toEqual([]);
+    expect(vm.fills).toEqual([]);
+    expect(vm.brokerageLabel).toBe("Interactive Brokers · DU1009034 · paper");
+  });
+});
+
+describe("parseSignedAmount", () => {
+  it("returns 0 for empty, null, undefined, dash, and lone sign inputs", () => {
+    expect(parseSignedAmount(null)).toBe(0);
+    expect(parseSignedAmount(undefined)).toBe(0);
+    expect(parseSignedAmount("")).toBe(0);
+    expect(parseSignedAmount("  ")).toBe(0);
+    expect(parseSignedAmount("—")).toBe(0);
+    expect(parseSignedAmount("-")).toBe(0);
+    expect(parseSignedAmount("+")).toBe(0);
+  });
+
+  it("strips currency symbols and thousand separators", () => {
+    expect(parseSignedAmount("+$1,250")).toBe(1250);
+    expect(parseSignedAmount("-$2,500.50")).toBe(-2500.5);
+    expect(parseSignedAmount("$300")).toBe(300);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/screens/today-panel.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/today-panel.view-model.ts
@@ -1,0 +1,414 @@
+import type {
+  PortfolioWorkspaceResponse,
+  TradingFill,
+  TradingOrder,
+  TradingPosition,
+  TradingWorkspaceResponse
+} from "@/types";
+
+export type TodayTone = "default" | "success" | "warning" | "danger";
+
+export interface TodayMetric {
+  id: string;
+  label: string;
+  value: string;
+  detail: string;
+  tone: TodayTone;
+  ariaLabel: string;
+}
+
+export interface TodayMoverRow {
+  key: string;
+  symbol: string;
+  side: "Long" | "Short";
+  quantity: string;
+  markPrice: string;
+  dayPnl: string;
+  dayPnlTone: TodayTone;
+  ariaLabel: string;
+}
+
+export interface TodayOrderRow {
+  key: string;
+  symbol: string;
+  side: TradingOrder["side"];
+  quantity: string;
+  type: TradingOrder["type"];
+  priceLabel: string;
+  status: TradingOrder["status"];
+  submittedLabel: string;
+  ariaLabel: string;
+}
+
+export interface TodayFillRow {
+  key: string;
+  symbol: string;
+  side: TradingFill["side"];
+  quantity: string;
+  price: string;
+  venue: string;
+  timestampLabel: string;
+  ariaLabel: string;
+}
+
+export type TodayQuickActionId = "place-order" | "add-symbol" | "live-quote" | "reconcile";
+
+export interface TodayQuickAction {
+  id: TodayQuickActionId;
+  label: string;
+  description: string;
+  href: string;
+  ariaLabel: string;
+}
+
+export interface TodayPanelViewModel {
+  hasData: boolean;
+  headline: string;
+  subheadline: string;
+  emptyMessage: string;
+  emptyActionHref: string;
+  emptyActionLabel: string;
+  emptyActionAriaLabel: string;
+  metrics: TodayMetric[];
+  movers: TodayMoverRow[];
+  moversTotal: number;
+  moversEmptyMessage: string;
+  hasMovers: boolean;
+  moversMoreLabel: string | null;
+  orders: TodayOrderRow[];
+  ordersTotal: number;
+  ordersEmptyMessage: string;
+  hasOrders: boolean;
+  ordersMoreLabel: string | null;
+  fills: TodayFillRow[];
+  fillsTotal: number;
+  fillsEmptyMessage: string;
+  hasFills: boolean;
+  fillsMoreLabel: string | null;
+  quickActions: TodayQuickAction[];
+  brokerageLabel: string | null;
+}
+
+const PREVIEW_LIMIT = 5;
+
+const QUICK_ACTIONS: TodayQuickAction[] = [
+  {
+    id: "place-order",
+    label: "Place order",
+    description: "Open the trading cockpit to stage a paper or live order.",
+    href: "/trading",
+    ariaLabel: "Open trading cockpit to place an order"
+  },
+  {
+    id: "add-symbol",
+    label: "Add symbol",
+    description: "Subscribe a symbol to the live data pipeline.",
+    href: "/data/watchlist",
+    ariaLabel: "Open the watchlist to add a symbol"
+  },
+  {
+    id: "live-quote",
+    label: "Look up quote",
+    description: "Inspect live bid/ask, recent trades, and L2 depth.",
+    href: "/data/quotes",
+    ariaLabel: "Open live quotes lookup"
+  },
+  {
+    id: "reconcile",
+    label: "Reconcile",
+    description: "Review accounting breaks and cash posture.",
+    href: "/accounting",
+    ariaLabel: "Open accounting reconciliation queue"
+  }
+];
+
+export function buildTodayPanelViewModel(
+  trading: TradingWorkspaceResponse | null,
+  portfolio: PortfolioWorkspaceResponse | null
+): TodayPanelViewModel {
+  const source = trading ?? portfolio;
+
+  if (!source) {
+    return {
+      hasData: false,
+      headline: "Today",
+      subheadline: "Connect a brokerage account or start a paper session to see your day's activity.",
+      emptyMessage: "No trading or portfolio data is available yet.",
+      emptyActionHref: "/settings",
+      emptyActionLabel: "Connect a brokerage",
+      emptyActionAriaLabel: "Open settings to connect a brokerage account",
+      metrics: emptyMetrics(),
+      movers: [],
+      moversTotal: 0,
+      moversEmptyMessage: "No open positions to track today.",
+      hasMovers: false,
+      moversMoreLabel: null,
+      orders: [],
+      ordersTotal: 0,
+      ordersEmptyMessage: "No working orders.",
+      hasOrders: false,
+      ordersMoreLabel: null,
+      fills: [],
+      fillsTotal: 0,
+      fillsEmptyMessage: "No fills recorded today.",
+      hasFills: false,
+      fillsMoreLabel: null,
+      quickActions: QUICK_ACTIONS,
+      brokerageLabel: null
+    };
+  }
+
+  const positions: TradingPosition[] = (source.positions ?? []).filter((p) => p.symbol && p.symbol !== "—");
+  const openOrders: TradingOrder[] = trading?.openOrders ?? [];
+  const fills: TradingFill[] = trading?.fills ?? [];
+
+  const totalDayPnl = positions.reduce((sum, pos) => sum + parseSignedAmount(pos.dayPnl), 0);
+  const totalUnrealized = positions.reduce((sum, pos) => sum + parseSignedAmount(pos.unrealizedPnl), 0);
+
+  const movers = buildMovers(positions);
+  const orders = buildOrders(openOrders);
+  const fillsRows = buildFills(fills);
+
+  const dayPnlTone = toneForAmount(totalDayPnl);
+
+  const portfolioMetrics = portfolio?.metrics ?? [];
+  const tradingMetrics = trading?.metrics ?? [];
+  const equityMetric = portfolioMetrics.find((m) => m.id === "portfolio-equity");
+  const cashMetric = portfolioMetrics.find((m) => m.id === "portfolio-cash");
+  const fillsMetric = tradingMetrics.find((m) => m.id === "fills");
+
+  const metrics: TodayMetric[] = [
+    {
+      id: "today-day-pnl",
+      label: "Day P&L",
+      value: positions.length > 0 ? formatSignedCurrency(totalDayPnl) : "—",
+      detail: positions.length > 0
+        ? `Across ${formatCountLabel(positions.length, "open position", "open positions")}`
+        : "No open positions",
+      tone: positions.length > 0 ? dayPnlTone : "default",
+      ariaLabel: positions.length > 0
+        ? `Day P&L ${formatSignedCurrency(totalDayPnl)} across ${formatCountLabel(positions.length, "open position", "open positions")}`
+        : "Day P&L unavailable, no open positions"
+    },
+    {
+      id: "today-equity",
+      label: "Account value",
+      value: equityMetric?.value ?? "—",
+      detail: equityMetric?.delta ?? "Awaiting brokerage equity feed",
+      tone: equityMetric?.tone ?? "default",
+      ariaLabel: equityMetric
+        ? `Account value ${equityMetric.value}, ${equityMetric.delta}`
+        : "Account value unavailable"
+    },
+    {
+      id: "today-cash",
+      label: "Cash",
+      value: cashMetric?.value ?? "—",
+      detail: cashMetric?.delta ?? "Awaiting portfolio cash feed",
+      tone: cashMetric?.tone ?? "default",
+      ariaLabel: cashMetric
+        ? `Cash ${cashMetric.value}, ${cashMetric.delta}`
+        : "Cash unavailable"
+    },
+    {
+      id: "today-unrealized",
+      label: "Unrealized P&L",
+      value: positions.length > 0 ? formatSignedCurrency(totalUnrealized) : "—",
+      detail: positions.length > 0
+        ? `Mark-to-market on ${formatCountLabel(positions.length, "position", "positions")}`
+        : "No open positions",
+      tone: positions.length > 0 ? toneForAmount(totalUnrealized) : "default",
+      ariaLabel: positions.length > 0
+        ? `Unrealized P&L ${formatSignedCurrency(totalUnrealized)} on ${formatCountLabel(positions.length, "position", "positions")}`
+        : "Unrealized P&L unavailable, no open positions"
+    }
+  ];
+
+  const brokerage = source.brokerage;
+  const brokerageLabel = brokerage
+    ? `${brokerage.provider} · ${brokerage.account} · ${brokerage.environment}`
+    : null;
+
+  const subheadline = buildSubheadline({
+    positions: positions.length,
+    orders: openOrders.length,
+    fills: fills.length,
+    fillsLabel: fillsMetric?.value ?? null
+  });
+
+  return {
+    hasData: true,
+    headline: "Today",
+    subheadline,
+    emptyMessage: "",
+    emptyActionHref: "/settings",
+    emptyActionLabel: "Connect a brokerage",
+    emptyActionAriaLabel: "Open settings to connect a brokerage account",
+    metrics,
+    movers,
+    moversTotal: positions.length,
+    moversEmptyMessage: "No open positions to track today.",
+    hasMovers: movers.length > 0,
+    moversMoreLabel: positions.length > movers.length
+      ? `+${positions.length - movers.length} more in portfolio`
+      : null,
+    orders,
+    ordersTotal: openOrders.length,
+    ordersEmptyMessage: "No working orders.",
+    hasOrders: orders.length > 0,
+    ordersMoreLabel: openOrders.length > orders.length
+      ? `+${openOrders.length - orders.length} more in trading cockpit`
+      : null,
+    fills: fillsRows,
+    fillsTotal: fills.length,
+    fillsEmptyMessage: "No fills recorded today.",
+    hasFills: fillsRows.length > 0,
+    fillsMoreLabel: fills.length > fillsRows.length
+      ? `+${fills.length - fillsRows.length} more in trading cockpit`
+      : null,
+    quickActions: QUICK_ACTIONS,
+    brokerageLabel
+  };
+}
+
+function emptyMetrics(): TodayMetric[] {
+  return [
+    {
+      id: "today-day-pnl",
+      label: "Day P&L",
+      value: "—",
+      detail: "Awaiting trading session",
+      tone: "default",
+      ariaLabel: "Day P&L unavailable"
+    },
+    {
+      id: "today-equity",
+      label: "Account value",
+      value: "—",
+      detail: "Awaiting brokerage equity feed",
+      tone: "default",
+      ariaLabel: "Account value unavailable"
+    },
+    {
+      id: "today-cash",
+      label: "Cash",
+      value: "—",
+      detail: "Awaiting portfolio cash feed",
+      tone: "default",
+      ariaLabel: "Cash unavailable"
+    },
+    {
+      id: "today-unrealized",
+      label: "Unrealized P&L",
+      value: "—",
+      detail: "No open positions",
+      tone: "default",
+      ariaLabel: "Unrealized P&L unavailable"
+    }
+  ];
+}
+
+function buildMovers(positions: TradingPosition[]): TodayMoverRow[] {
+  return positions
+    .map((pos) => ({ pos, magnitude: Math.abs(parseSignedAmount(pos.dayPnl)) }))
+    .filter((entry) => entry.magnitude > 0)
+    .sort((a, b) => b.magnitude - a.magnitude)
+    .slice(0, PREVIEW_LIMIT)
+    .map(({ pos }) => {
+      const dayPnlAmount = parseSignedAmount(pos.dayPnl);
+      const dayPnlTone = toneForAmount(dayPnlAmount);
+      return {
+        key: pos.positionKey ?? pos.symbol,
+        symbol: pos.symbol,
+        side: pos.side,
+        quantity: pos.quantity,
+        markPrice: pos.markPrice,
+        dayPnl: pos.dayPnl,
+        dayPnlTone,
+        ariaLabel: `${pos.symbol} ${pos.side} ${pos.quantity} shares, mark ${pos.markPrice}, day P&L ${pos.dayPnl}`
+      };
+    });
+}
+
+function buildOrders(orders: TradingOrder[]): TodayOrderRow[] {
+  return orders.slice(0, PREVIEW_LIMIT).map((order) => {
+    const priceLabel = order.type === "Market" ? "Market" : order.limitPrice;
+    return {
+      key: order.orderId,
+      symbol: order.symbol,
+      side: order.side,
+      quantity: order.quantity,
+      type: order.type,
+      priceLabel,
+      status: order.status,
+      submittedLabel: order.submittedAt,
+      ariaLabel: `${order.side} ${order.quantity} ${order.symbol} ${order.type.toLowerCase()} at ${priceLabel}, ${order.status}, submitted ${order.submittedAt}`
+    };
+  });
+}
+
+function buildFills(fills: TradingFill[]): TodayFillRow[] {
+  return fills.slice(0, PREVIEW_LIMIT).map((fill) => ({
+    key: fill.fillId,
+    symbol: fill.symbol,
+    side: fill.side,
+    quantity: fill.quantity,
+    price: fill.price,
+    venue: fill.venue,
+    timestampLabel: fill.timestamp,
+    ariaLabel: `${fill.side} ${fill.quantity} ${fill.symbol} at ${fill.price} on ${fill.venue}, ${fill.timestamp}`
+  }));
+}
+
+function buildSubheadline({
+  positions,
+  orders,
+  fills,
+  fillsLabel
+}: {
+  positions: number;
+  orders: number;
+  fills: number;
+  fillsLabel: string | null;
+}): string {
+  if (positions === 0 && orders === 0 && fills === 0) {
+    return "No portfolio activity yet. Add a symbol or place a paper order to get started.";
+  }
+  const parts: string[] = [];
+  parts.push(formatCountLabel(positions, "open position", "open positions"));
+  parts.push(formatCountLabel(orders, "working order", "working orders"));
+  parts.push(`${fillsLabel ?? String(fills)} fills today`);
+  return parts.join(" · ");
+}
+
+export function parseSignedAmount(value: string | null | undefined): number {
+  if (!value) {
+    return 0;
+  }
+  const trimmed = value.trim();
+  if (trimmed === "" || trimmed === "—" || trimmed === "-") {
+    return 0;
+  }
+  const cleaned = trimmed.replace(/[^0-9.\-+]/g, "");
+  if (cleaned === "" || cleaned === "+" || cleaned === "-") {
+    return 0;
+  }
+  const parsed = Number.parseFloat(cleaned);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function toneForAmount(amount: number): TodayTone {
+  if (amount > 0) return "success";
+  if (amount < 0) return "danger";
+  return "default";
+}
+
+function formatSignedCurrency(value: number): string {
+  const sign = value >= 0 ? "+" : "-";
+  const absLabel = Math.abs(value).toLocaleString(undefined, { maximumFractionDigits: 0 });
+  return `${sign}$${absLabel}`;
+}
+
+function formatCountLabel(count: number, singular: string, plural: string): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}

--- a/src/Meridian.Ui/wwwroot/workstation/index.html
+++ b/src/Meridian.Ui/wwwroot/workstation/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="data:," />
     <title>Meridian Web Workstation</title>
-    <script type="module" crossorigin src="/workstation/assets/index-DYItXtJH.js"></script>
-    <link rel="stylesheet" crossorigin href="/workstation/assets/index-BOd-7Psm.css">
+    <script type="module" crossorigin src="/workstation/assets/index-JRP6rto4.js"></script>
+    <link rel="stylesheet" crossorigin href="/workstation/assets/index-onOEaDby.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Land a high-value summary of the trader's day at the top of the Overview
screen so a user landing on Meridian sees their account state and recent
activity before scrolling through ops-style status surfaces. The panel
aggregates day P&L across positions, surfaces the top movers, previews
open orders and recent fills with link-outs into Trading and Portfolio,
and exposes quick actions for Place order / Add symbol / Look up quote /
Reconcile.

Includes a pure view-model module with 8 unit tests covering empty
state, P&L aggregation, mover ranking by absolute magnitude, order and
fill preview truncation, portfolio-only fallback, and signed-amount
parsing. Refreshes built workstation assets.