### PR TITLE
Complete G2 backfill tracing, Track K equity tests and naming doc

### DIFF
--- a/docs/ai/claude/CLAUDE.domain-naming.md
+++ b/docs/ai/claude/CLAUDE.domain-naming.md
@@ -9,7 +9,7 @@
 > rename only when the inconsistency causes real confusion and the change is isolated to the domain
 > layer.
 >
-> **Last Updated:** 2026-03-26
+> **Last Updated:** 2026-05-15
 
 ---
 
@@ -94,6 +94,7 @@ excessively long (> ~20 characters):
 | `Conv` | Convertible/Conversion | `ConvTr`, `ConvRatio`, `ConvPrefDef` |
 | `Div` | Dividend | `DivRate`, `DivDt` |
 | `Red` | Redemption | `RedTr`, `RedPx`, `RedTerms` |
+| `Call` | Callable/Callability | `CallTr`, `FirstCallDt`, `CallPx` |
 | `Sen` | Seniority | `SenTr`, `SenCat` |
 | `Own` | Ownership | `OwnTr` |
 | `Inc` | Income | `IncTr` |
@@ -184,10 +185,32 @@ unless there is a distinct conceptual reason (e.g. `MaturityTerms` is a value-ob
 | `MaturityTerms` | Sub-record within `BondDef` (keep) |
 | `EconomicCallTerms` | Sub-record within `BondDef` (keep) |
 | `SecurityTermModules` | Container record (keep) |
+| `PreferredTerms` | `PrefShrDef` (preferred-share term sheet) |
+| `ConvertibleTerms` | Embedded in `ConvPrefDef` (convertible-preferred) |
 | New bond instrument type | `BondDef` |
-| New equity instrument type | `EquityDef` / `ComShrDef` / `PrefShrDef` |
+| New equity instrument type | `EquityDef` / `ComShrDef` / `PrefShrDef` / `ConvPrefDef` |
 | New option instrument type | `OptDef` |
 | New future instrument type | `FutDef` |
+
+**Preferred and convertible-preferred definitions** — use `PrefShrDef` for a standalone preferred
+share term sheet and `ConvPrefDef` when the instrument is also convertible. Both carry `CallTr`,
+`RedTr`, and `ConvTr` sub-records rather than duplicating callable/redemption/conversion fields:
+
+```fsharp
+type PrefShrDef = {
+    DivRate    : decimal option      // DivRate — see section 6 field rules
+    DivType    : DividendType        // Fixed | Floating | Cumulative
+    CallTr     : CallTr option       // callable-share terms
+    RedTr      : RedTr option        // redemption terms
+    LiqPref    : LiquidationPreference
+    ParticipTr : ParticipationTerms option
+}
+
+type ConvPrefDef = {
+    PrefShr : PrefShrDef             // preferred-share base
+    ConvTr  : ConvTr                 // conversion trait
+}
+```
 
 ### 5.5 Category / Taxonomy Unions — marker suffix
 
@@ -231,6 +254,7 @@ type OwnTr  = { HasVoting: bool; IsRestricted: bool; OwnershipCap: decimal optio
 type IncTr  = { IsIncomeProducing: bool; DivRate: decimal option; PayFreq: string option }
 type ConvTr = { IsConvertible: bool; ConvRatio: decimal option; ConvPx: decimal option }
 type RedTr  = { IsRedeemable: bool; FirstRedDt: DateOnly option; RedPx: decimal option }
+type CallTr = { IsCallable: bool; FirstCallDt: DateOnly option; CallPx: decimal option }
 type SenTr  = { SeniorityLevel: int; IsSeniorSecured: bool }
 type ListTr = { IsListed: bool; PrimaryExchId: ExchId option; ListedExp: DateOnly option }
 ```

--- a/src/Meridian.Infrastructure/Adapters/Core/Backfill/BackfillWorkerService.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/Backfill/BackfillWorkerService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
@@ -5,6 +6,7 @@ using Meridian.Application.Config;
 using Meridian.Application.Exceptions;
 using Meridian.Application.Logging;
 using Meridian.Application.Serialization;
+using Meridian.Application.Tracing;
 using Meridian.Contracts.Domain.Models;
 using Meridian.Contracts.Services;
 using Meridian.Domain.Events;
@@ -210,13 +212,22 @@ public sealed class BackfillWorkerService : IDisposable
     /// </summary>
     private async Task ProcessRequestAsync(BackfillRequest request, CancellationToken ct)
     {
+        using var activity = MarketDataTracing.StartBackfillActivity(
+            request.AssignedProvider ?? "unknown",
+            request.Symbol,
+            request.FromDate.ToString("yyyy-MM-dd"),
+            request.ToDate.ToString("yyyy-MM-dd"));
+
+        activity?.SetTag("backfill.job_id", request.JobId);
+        activity?.SetTag("backfill.request_id", request.RequestId);
+
         try
         {
             // Check offline-first mode
             if (_appConfig.OfflineFirstMode && _connectivityProbe != null && !_connectivityProbe.IsOnline)
             {
                 _log.Warning("Offline mode: queueing backfill for {Symbol} until connectivity restored", request.Symbol);
-                // Mark as offline queued and requeue
+                activity?.SetTag("backfill.outcome", "offline_queued");
                 await _requestQueue.EnqueueAsync(request, ct).ConfigureAwait(false);
                 return;
             }
@@ -247,10 +258,14 @@ public sealed class BackfillWorkerService : IDisposable
                     await _requestQueue.CompleteRequestAsync(request, true, ct: ct).ConfigureAwait(false);
                     await _jobManager.UpdateJobProgressAsync(request, ct).ConfigureAwait(false);
                     _progressTracker.MarkCompleted(request.Symbol);
+
+                    MarketDataTracing.RecordEventCount(activity, bars.Count);
+                    activity?.SetTag("backfill.outcome", "success");
                     return;
                 }
                 catch (OperationCanceledException) when (ct.IsCancellationRequested)
                 {
+                    activity?.SetTag("backfill.outcome", "cancelled");
                     throw;
                 }
                 catch (RateLimitException rle) when (request.AssignedProvider != null)
@@ -264,6 +279,7 @@ public sealed class BackfillWorkerService : IDisposable
                         var providerDelay = rle.RetryAfter;
                         var delay = providerDelay ?? CalculateBackoff(retryAttempt, RateLimitBaseDelay, RateLimitMaxDelay);
 
+                        activity?.SetTag("backfill.retry_count", retryAttempt);
                         _log.Information(
                             "Rate limited for {Symbol} via {Provider}, retrying in {Delay}ms via {DelaySource} (attempt {Attempt}/{Max})",
                             request.Symbol, request.AssignedProvider, delay.TotalMilliseconds,
@@ -277,6 +293,8 @@ public sealed class BackfillWorkerService : IDisposable
                         "Rate limit retry budget exhausted for {Symbol} via {Provider} after {Attempts} attempts",
                         request.Symbol, request.AssignedProvider, retryAttempt);
 
+                    MarketDataTracing.RecordError(activity, rle);
+                    activity?.SetTag("backfill.outcome", "rate_limit_exhausted");
                     await _requestQueue.CompleteRequestAsync(request, false, rle.Message, ct).ConfigureAwait(false);
                     await _jobManager.UpdateJobProgressAsync(request, ct).ConfigureAwait(false);
                     _progressTracker.MarkFailed(request.Symbol, rle.Message);
@@ -300,6 +318,7 @@ public sealed class BackfillWorkerService : IDisposable
                             retryAttempt++;
                             var delay = retryAfter ?? CalculateBackoff(retryAttempt, RateLimitBaseDelay, RateLimitMaxDelay);
 
+                            activity?.SetTag("backfill.retry_count", retryAttempt);
                             _log.Information(
                                 "Rate limited for {Symbol} via {Provider}, retrying in {Delay}ms via {DelaySource} (attempt {Attempt}/{Max})",
                                 request.Symbol, request.AssignedProvider, delay.TotalMilliseconds,
@@ -314,6 +333,8 @@ public sealed class BackfillWorkerService : IDisposable
                             request.Symbol, request.AssignedProvider, retryAttempt);
                     }
 
+                    MarketDataTracing.RecordError(activity, ex);
+                    activity?.SetTag("backfill.outcome", isRateLimited ? "rate_limit_exhausted" : "error");
                     await _requestQueue.CompleteRequestAsync(request, false, ex.Message, ct).ConfigureAwait(false);
                     await _jobManager.UpdateJobProgressAsync(request, ct).ConfigureAwait(false);
                     _progressTracker.MarkFailed(request.Symbol, ex.Message);

--- a/tests/Meridian.FSharp.Tests/DomainTests.fs
+++ b/tests/Meridian.FSharp.Tests/DomainTests.fs
@@ -875,3 +875,154 @@ let ``SecurityEconomicDefinition.normalize preserves unchanged optional fields``
     normalized.Common.CountryOfRisk    |> should equal (Some "US")
     normalized.Common.SettlementCycleDays |> should equal (Some 1)
     normalized.Classification          |> should equal (makeTestClassification ())
+
+// ---------------------------------------------------------------------------
+// EquityClassification module function tests
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``EquityClassification.asString returns "Common" for Common case`` () =
+    EquityClassification.asString EquityClassification.Common |> should equal "Common"
+
+[<Fact>]
+let ``EquityClassification.asString returns "Preferred" for Preferred case`` () =
+    let terms = {
+        DividendRate = Some 5.0m
+        DividendType = DividendType.Fixed
+        RedemptionPrice = Some 25.0m
+        RedemptionDate = None
+        CallableDate = None
+        ParticipationTerms = None
+        LiquidationPreference = LiquidationPreference.Pari
+    }
+    EquityClassification.asString (EquityClassification.Preferred terms) |> should equal "Preferred"
+
+[<Fact>]
+let ``EquityClassification.asString returns "Convertible" for Convertible case`` () =
+    let terms = {
+        UnderlyingSecurityId = SecurityId(Guid.NewGuid())
+        ConversionRatio = 2.0m
+        ConversionPrice = Some 50.0m
+        ConversionStartDate = None
+        ConversionEndDate = None
+    }
+    EquityClassification.asString (EquityClassification.Convertible terms) |> should equal "Convertible"
+
+[<Fact>]
+let ``EquityClassification.asString returns "ConvertiblePreferred" for ConvertiblePreferred case`` () =
+    let preferred = {
+        DividendRate = Some 6.0m
+        DividendType = DividendType.Cumulative
+        RedemptionPrice = None
+        RedemptionDate = None
+        CallableDate = None
+        ParticipationTerms = None
+        LiquidationPreference = LiquidationPreference.Senior 1.0m
+    }
+    let convertible = {
+        UnderlyingSecurityId = SecurityId(Guid.NewGuid())
+        ConversionRatio = 3.0m
+        ConversionPrice = None
+        ConversionStartDate = None
+        ConversionEndDate = None
+    }
+    EquityClassification.asString (EquityClassification.ConvertiblePreferred(preferred, convertible))
+    |> should equal "ConvertiblePreferred"
+
+[<Fact>]
+let ``EquityClassification.asString returns the label for Other case`` () =
+    EquityClassification.asString (EquityClassification.Other "SpecialPurpose")
+    |> should equal "SpecialPurpose"
+
+// ---------------------------------------------------------------------------
+// DividendType module function tests
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``DividendType.asString returns "Fixed" for Fixed`` () =
+    DividendType.asString DividendType.Fixed |> should equal "Fixed"
+
+[<Fact>]
+let ``DividendType.asString returns "Floating" for Floating`` () =
+    DividendType.asString DividendType.Floating |> should equal "Floating"
+
+[<Fact>]
+let ``DividendType.asString returns "Cumulative" for Cumulative`` () =
+    DividendType.asString DividendType.Cumulative |> should equal "Cumulative"
+
+// ---------------------------------------------------------------------------
+// LiquidationPreference module function tests
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``LiquidationPreference.asString returns "Pari" for Pari`` () =
+    LiquidationPreference.asString LiquidationPreference.Pari |> should equal "Pari"
+
+[<Fact>]
+let ``LiquidationPreference.asString returns "Senior" for Senior with any multiple`` () =
+    LiquidationPreference.asString (LiquidationPreference.Senior 1.5m) |> should equal "Senior"
+
+[<Fact>]
+let ``LiquidationPreference.asString returns "Subordinated" for Subordinated`` () =
+    LiquidationPreference.asString LiquidationPreference.Subordinated |> should equal "Subordinated"
+
+// ---------------------------------------------------------------------------
+// PreferredTerms — DividendType variant coverage
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``PreferredTerms accepts Floating dividend type`` () =
+    let terms = {
+        DividendRate = Some 3.5m
+        DividendType = DividendType.Floating
+        RedemptionPrice = Some 100.0m
+        RedemptionDate = Some (DateOnly(2035, 6, 1))
+        CallableDate = None
+        ParticipationTerms = None
+        LiquidationPreference = LiquidationPreference.Pari
+    }
+    DividendType.asString terms.DividendType |> should equal "Floating"
+    terms.DividendRate |> should equal (Some 3.5m)
+
+[<Fact>]
+let ``PreferredTerms accepts Cumulative dividend type with participation terms`` () =
+    let participation = {
+        ParticipatesInCommonDividends = true
+        AdditionalDividendThreshold = Some 1.00m
+    }
+    let terms = {
+        DividendRate = Some 4.0m
+        DividendType = DividendType.Cumulative
+        RedemptionPrice = None
+        RedemptionDate = None
+        CallableDate = Some (DateOnly(2030, 1, 1))
+        ParticipationTerms = Some participation
+        LiquidationPreference = LiquidationPreference.Senior 2.0m
+    }
+    DividendType.asString terms.DividendType |> should equal "Cumulative"
+    terms.ParticipationTerms |> should not' (equal None)
+    LiquidationPreference.asString terms.LiquidationPreference |> should equal "Senior"
+
+// ---------------------------------------------------------------------------
+// ConvertibleTerms — standalone Convertible classification
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``EquityClassification.Convertible round-trips through asString`` () =
+    let underlying = SecurityId(Guid.NewGuid())
+    let terms = {
+        UnderlyingSecurityId = underlying
+        ConversionRatio = 4.25m
+        ConversionPrice = Some 120.0m
+        ConversionStartDate = Some (DateOnly(2027, 1, 1))
+        ConversionEndDate = Some (DateOnly(2032, 12, 31))
+    }
+    let classification = EquityClassification.Convertible terms
+    EquityClassification.asString classification |> should equal "Convertible"
+
+    match classification with
+    | EquityClassification.Convertible ct ->
+        ct.UnderlyingSecurityId |> should equal underlying
+        ct.ConversionRatio |> should equal 4.25m
+        ct.ConversionPrice |> should equal (Some 120.0m)
+    | _ -> failwith "Expected Convertible case"


### PR DESCRIPTION
Three improvements:

1. BackfillWorkerService distributed tracing (G2 completion)
   - Wire MarketDataTracing.StartBackfillActivity() into ProcessRequestAsync
   - Tag each request with job_id, request_id, symbol, provider, and date range
   - Record outcome tags (success / rate_limit_exhausted / cancelled / error)
   - Record retry_count on each retry attempt
   - Record error and event count on each terminal path
   - Completes the remaining G2 open item: distributed tracing for backfill workers

2. F# equity module function tests (Track K)
   - EquityClassification.asString: all five cases (Common, Preferred, Convertible,
     ConvertiblePreferred, Other)
   - DividendType.asString: Fixed, Floating, Cumulative
   - LiquidationPreference.asString: Pari, Senior (with multiple), Subordinated
   - PreferredTerms variant coverage: Floating and Cumulative dividend types with
     participation terms and Senior liquidation preference
   - ConvertibleTerms standalone: Convertible classification round-trip test

3. Naming doc update (Track K exit criterion)
   - Add Call → CallTr to approved abbreviations table (section 4.2)
   - Add CallTr trait record example to Trait Records section (5.6)
   - Add PrefShrDef / ConvPrefDef definition record mapping and code pattern (5.4)
   - Update Last Updated date

https://claude.ai/code/session_01Ccr7E92nsX6SCFofXd8Ri9