### PR TITLE
Add extended cell kinds: state, concurrent, universe-builder, trade

### DIFF
--- a/src/Meridian.Strategies/Services/StrategyDesignService.cs
+++ b/src/Meridian.Strategies/Services/StrategyDesignService.cs
@@ -11,6 +11,11 @@ namespace Meridian.Strategies.Services;
 public sealed class StrategyDesignService
 {
     private const int MaxLoopIterations = 1_000;
+    private static readonly string[] ConcurrentCellSemantics = ["all-pass", "any-pass", "first-wins"];
+    private static readonly string[] TradeCellInstruments = ["Equity", "Option", "Future", "ETF"];
+    private static readonly string[] TradeCellDirections = ["Buy", "Sell", "SellShort", "BuyToCover"];
+    private static readonly string[] TradeCellSizingMethods = ["FixedShares", "FixedNotional", "PercentAUM", "EqualWeight"];
+    private static readonly string[] TradeCellSizingValueRequiredMethods = ["FixedShares", "FixedNotional", "PercentAUM"];
     private static readonly Regex FieldTokenRegex = new(
         @"\b[A-Z][A-Z0-9_]{2,}\b",
         RegexOptions.CultureInvariant | RegexOptions.Compiled,
@@ -81,6 +86,10 @@ public sealed class StrategyDesignService
         var messages = new List<StrategyDesignValidationMessage>();
         var cells = document.Cells ?? Array.Empty<StrategyDesignCell>();
         var transitions = document.Transitions ?? Array.Empty<StrategyDesignTransition>();
+        var cellIds = cells
+            .Where(static cell => !string.IsNullOrWhiteSpace(cell.CellId))
+            .Select(static cell => cell.CellId)
+            .ToHashSet(StringComparer.Ordinal);
 
         if (string.IsNullOrWhiteSpace(document.Name))
         {
@@ -137,7 +146,7 @@ public sealed class StrategyDesignService
                 }
             }
 
-            messages.AddRange(ValidateCellKindParameters(cell));
+            messages.AddRange(ValidateCellKindParameters(cell, cellIds));
         }
 
         var cellOrder = cells
@@ -345,6 +354,7 @@ public sealed class StrategyDesignService
 
     private static StrategyDesignCell NormalizeCell(StrategyDesignCell cell)
     {
+        var normalizedKind = string.IsNullOrWhiteSpace(cell.Kind) ? "formula" : cell.Kind.Trim().ToLowerInvariant();
         var normalizedRefs = NormalizeStringList(cell.FieldRefs)
             .Select(static field => field.ToUpperInvariant())
             .ToArray();
@@ -353,22 +363,26 @@ public sealed class StrategyDesignService
             normalizedRefs = ExtractSourceFieldRefs(cell.Source).ToArray();
         }
 
-        return cell with
-        {
-            CellId = string.IsNullOrWhiteSpace(cell.CellId) ? $"cell-{Guid.NewGuid():N}" : cell.CellId.Trim(),
-            Label = string.IsNullOrWhiteSpace(cell.Label) ? "Untitled cell" : cell.Label.Trim(),
-            Kind = string.IsNullOrWhiteSpace(cell.Kind) ? "formula" : cell.Kind.Trim().ToLowerInvariant(),
-            Purpose = string.IsNullOrWhiteSpace(cell.Purpose) ? "filter" : cell.Purpose.Trim().ToLowerInvariant(),
-            Source = cell.Source?.Trim() ?? string.Empty,
-            FieldRefs = normalizedRefs,
-            Parameters = cell.Parameters is null
-                ? null
-                : cell.Parameters
+        var normalizedParameters = cell.Parameters is null
+            ? null
+            : NormalizeCellParameters(
+                normalizedKind,
+                cell.Parameters
                     .Where(static item => !string.IsNullOrWhiteSpace(item.Key))
                     .ToDictionary(
                         static item => item.Key.Trim(),
                         static item => item.Value?.Trim() ?? string.Empty,
-                        StringComparer.OrdinalIgnoreCase),
+                        StringComparer.OrdinalIgnoreCase));
+
+        return cell with
+        {
+            CellId = string.IsNullOrWhiteSpace(cell.CellId) ? $"cell-{Guid.NewGuid():N}" : cell.CellId.Trim(),
+            Label = string.IsNullOrWhiteSpace(cell.Label) ? "Untitled cell" : cell.Label.Trim(),
+            Kind = normalizedKind,
+            Purpose = string.IsNullOrWhiteSpace(cell.Purpose) ? "filter" : cell.Purpose.Trim().ToLowerInvariant(),
+            Source = cell.Source?.Trim() ?? string.Empty,
+            FieldRefs = normalizedRefs,
+            Parameters = normalizedParameters,
             DisabledReason = string.IsNullOrWhiteSpace(cell.DisabledReason) ? null : cell.DisabledReason.Trim()
         };
     }
@@ -388,12 +402,23 @@ public sealed class StrategyDesignService
 
     private static IReadOnlyList<string> ResolveFieldRefs(StrategyDesignCell cell)
     {
-        if (cell.FieldRefs is { Count: > 0 })
+        var refs = cell.FieldRefs is { Count: > 0 }
+            ? NormalizeStringList(cell.FieldRefs).Select(static item => item.ToUpperInvariant()).ToArray()
+            : ExtractSourceFieldRefs(cell.Source).ToArray();
+
+        if (!string.Equals(cell.Kind, "universe-builder", StringComparison.OrdinalIgnoreCase) || cell.Parameters is null)
         {
-            return NormalizeStringList(cell.FieldRefs).Select(static item => item.ToUpperInvariant()).ToArray();
+            return refs;
         }
 
-        return ExtractSourceFieldRefs(cell.Source).ToArray();
+        var includeRules = cell.Parameters.TryGetValue("includeRules", out var include) ? include : null;
+        var excludeRules = cell.Parameters.TryGetValue("excludeRules", out var exclude) ? exclude : null;
+
+        return refs
+            .Concat(ExtractSourceFieldRefs(includeRules))
+            .Concat(ExtractSourceFieldRefs(excludeRules))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
     }
 
     private static IReadOnlyList<string> ExtractSourceFieldRefs(string? source)
@@ -418,6 +443,56 @@ public sealed class StrategyDesignService
             .ToArray()
         ?? [];
 
+    private static Dictionary<string, string> NormalizeCellParameters(string cellKind, Dictionary<string, string> parameters)
+    {
+        if (parameters.Count == 0)
+        {
+            return parameters;
+        }
+
+        if (string.Equals(cellKind, "concurrent", StringComparison.OrdinalIgnoreCase) &&
+            parameters.TryGetValue("semantics", out var semantics) &&
+            TryGetCanonicalValue(semantics, ConcurrentCellSemantics, out var canonicalSemantics))
+        {
+            parameters["semantics"] = canonicalSemantics;
+        }
+
+        if (string.Equals(cellKind, "trade", StringComparison.OrdinalIgnoreCase))
+        {
+            if (parameters.TryGetValue("instrument", out var instrument) &&
+                TryGetCanonicalValue(instrument, TradeCellInstruments, out var canonicalInstrument))
+            {
+                parameters["instrument"] = canonicalInstrument;
+            }
+
+            if (parameters.TryGetValue("direction", out var direction) &&
+                TryGetCanonicalValue(direction, TradeCellDirections, out var canonicalDirection))
+            {
+                parameters["direction"] = canonicalDirection;
+            }
+
+            if (parameters.TryGetValue("sizingMethod", out var sizingMethod) &&
+                TryGetCanonicalValue(sizingMethod, TradeCellSizingMethods, out var canonicalSizingMethod))
+            {
+                parameters["sizingMethod"] = canonicalSizingMethod;
+            }
+        }
+
+        return parameters;
+    }
+
+    private static bool TryGetCanonicalValue(string? value, IReadOnlyList<string> validValues, out string canonical)
+    {
+        canonical = string.Empty;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        canonical = validValues.FirstOrDefault(candidate => string.Equals(candidate, value.Trim(), StringComparison.OrdinalIgnoreCase)) ?? string.Empty;
+        return canonical.Length > 0;
+    }
+
     private static bool IsLoopTransition(StrategyDesignTransition transition, int fromIndex, int toIndex)
         => string.Equals(transition.Kind, "loop", StringComparison.OrdinalIgnoreCase)
            || fromIndex >= toIndex
@@ -432,7 +507,7 @@ public sealed class StrategyDesignService
     private static string SafeLabel(StrategyDesignCell cell)
         => string.IsNullOrWhiteSpace(cell.Label) ? cell.CellId : cell.Label;
 
-    private static IEnumerable<StrategyDesignValidationMessage> ValidateCellKindParameters(StrategyDesignCell cell)
+    private static IEnumerable<StrategyDesignValidationMessage> ValidateCellKindParameters(StrategyDesignCell cell, IReadOnlySet<string> cellIds)
     {
         var label = SafeLabel(cell);
         var p = cell.Parameters;
@@ -448,11 +523,31 @@ public sealed class StrategyDesignService
                 break;
 
             case "concurrent":
-                if (p is null || !p.TryGetValue("branchIds", out var branches) || string.IsNullOrWhiteSpace(branches))
-                    yield return Error("ConcurrentCellBranchesRequired", cell.CellId, $"{label} (concurrent) must define a branchIds parameter.");
+                var branchIds = p is null || !p.TryGetValue("branchIds", out var branches)
+                    ? []
+                    : branches
+                        .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                        .ToArray();
 
-                var validSemantics = new[] { "all-pass", "any-pass", "first-wins" };
-                if (p is null || !p.TryGetValue("semantics", out var sem) || !validSemantics.Contains(sem, StringComparer.OrdinalIgnoreCase))
+                if (branchIds.Length == 0)
+                {
+                    yield return Error("ConcurrentCellBranchesRequired", cell.CellId, $"{label} (concurrent) must define a branchIds parameter.");
+                }
+                else
+                {
+                    var missingBranches = branchIds
+                        .Where(branchId => !cellIds.Contains(branchId))
+                        .ToArray();
+                    if (missingBranches.Length > 0)
+                    {
+                        yield return Error(
+                            "ConcurrentCellBranchMissing",
+                            cell.CellId,
+                            $"{label} (concurrent) references missing branch cell IDs: {string.Join(", ", missingBranches)}.");
+                    }
+                }
+
+                if (p is null || !p.TryGetValue("semantics", out var sem) || !ConcurrentCellSemantics.Contains(sem, StringComparer.OrdinalIgnoreCase))
                     yield return Error("ConcurrentCellSemanticsRequired", cell.CellId, $"{label} (concurrent) semantics must be one of: all-pass, any-pass, first-wins.");
                 break;
 
@@ -462,20 +557,56 @@ public sealed class StrategyDesignService
 
                 if (p is null || !p.TryGetValue("includeRules", out var includeRules) || string.IsNullOrWhiteSpace(includeRules))
                     yield return Error("UniverseBuilderIncludeRulesRequired", cell.CellId, $"{label} (universe-builder) must define at least one includeRules parameter.");
+
+                if (p is not null)
+                {
+                    var hasMinSize = p.TryGetValue("minSize", out var minSizeRaw) && !string.IsNullOrWhiteSpace(minSizeRaw);
+                    var hasMaxSize = p.TryGetValue("maxSize", out var maxSizeRaw) && !string.IsNullOrWhiteSpace(maxSizeRaw);
+
+                    var minSizeIsValid = !hasMinSize || (decimal.TryParse(minSizeRaw, out var minSize) && minSize >= 0);
+                    var maxSizeIsValid = !hasMaxSize || (decimal.TryParse(maxSizeRaw, out var maxSize) && maxSize >= 0);
+
+                    if (!minSizeIsValid)
+                    {
+                        yield return Error("UniverseBuilderMinSizeInvalid", cell.CellId, $"{label} (universe-builder) minSize must be a non-negative number.");
+                    }
+
+                    if (!maxSizeIsValid)
+                    {
+                        yield return Error("UniverseBuilderMaxSizeInvalid", cell.CellId, $"{label} (universe-builder) maxSize must be a non-negative number.");
+                    }
+
+                    if (hasMinSize && hasMaxSize && minSizeIsValid && maxSizeIsValid)
+                    {
+                        decimal.TryParse(minSizeRaw, out var parsedMinSize);
+                        decimal.TryParse(maxSizeRaw, out var parsedMaxSize);
+                        if (parsedMinSize > parsedMaxSize)
+                        {
+                            yield return Error("UniverseBuilderSizeRangeInvalid", cell.CellId, $"{label} (universe-builder) minSize cannot be greater than maxSize.");
+                        }
+                    }
+                }
                 break;
 
             case "trade":
-                var validInstruments = new[] { "Equity", "Option", "Future", "ETF" };
-                if (p is null || !p.TryGetValue("instrument", out var instr) || !validInstruments.Contains(instr, StringComparer.OrdinalIgnoreCase))
+                if (p is null || !p.TryGetValue("instrument", out var instr) || !TradeCellInstruments.Contains(instr, StringComparer.OrdinalIgnoreCase))
                     yield return Error("TradeCellInstrumentRequired", cell.CellId, $"{label} (trade) instrument must be Equity, Option, Future, or ETF.");
 
-                var validDirections = new[] { "Buy", "Sell", "SellShort", "BuyToCover" };
-                if (p is null || !p.TryGetValue("direction", out var dir) || !validDirections.Contains(dir, StringComparer.OrdinalIgnoreCase))
+                if (p is null || !p.TryGetValue("direction", out var dir) || !TradeCellDirections.Contains(dir, StringComparer.OrdinalIgnoreCase))
                     yield return Error("TradeCellDirectionRequired", cell.CellId, $"{label} (trade) direction must be Buy, Sell, SellShort, or BuyToCover.");
 
-                var validSizing = new[] { "FixedShares", "FixedNotional", "PercentAUM", "EqualWeight" };
-                if (p is null || !p.TryGetValue("sizingMethod", out var sizing) || !validSizing.Contains(sizing, StringComparer.OrdinalIgnoreCase))
+                if (p is null || !p.TryGetValue("sizingMethod", out var sizing) || !TradeCellSizingMethods.Contains(sizing, StringComparer.OrdinalIgnoreCase))
+                {
                     yield return Error("TradeCellSizingRequired", cell.CellId, $"{label} (trade) sizingMethod must be FixedShares, FixedNotional, PercentAUM, or EqualWeight.");
+                }
+                else if (TradeCellSizingValueRequiredMethods.Contains(sizing, StringComparer.OrdinalIgnoreCase))
+                {
+                    var hasSizingValue = p.TryGetValue("sizingValue", out var sizingValueRaw) && !string.IsNullOrWhiteSpace(sizingValueRaw);
+                    if (!hasSizingValue || !decimal.TryParse(sizingValueRaw, out _))
+                    {
+                        yield return Error("TradeCellSizingValueRequired", cell.CellId, $"{label} (trade) sizingValue must be numeric when sizingMethod is {sizing}.");
+                    }
+                }
                 break;
         }
     }
@@ -677,7 +808,7 @@ public sealed class StrategyDesignService
                     "provider-bars/equities/daily",
                     ["SPY"],
                     [
-                        new("equity-universe", "Liquid equity universe", "universe-builder", "universe", "structured universe definition", ["PRICE", "MOMENTUM_63D"],
+                        new("equity-universe", "Liquid equity universe", "universe-builder", "universe", "structured universe definition", ["PRICE", "MOMENTUM_63D", "VOLATILITY_20D"],
                             new Dictionary<string, string> { ["assetClass"] = "Equity", ["includeRules"] = "PRICE > 10, MOMENTUM_63D > 0", ["excludeRules"] = "VOLATILITY_20D > 0.40", ["minSize"] = "20", ["maxSize"] = "100" }),
                         new("universe-rank", "Momentum rank", "formula", "rank", "MOMENTUM_63D - VOLATILITY_20D", ["MOMENTUM_63D", "VOLATILITY_20D"], null),
                         new("universe-risk", "Universe risk guard", "governance", "risk", "VOLATILITY_20D < 0.30", ["VOLATILITY_20D"], null)

--- a/src/Meridian.Strategies/Services/StrategyDesignService.cs
+++ b/src/Meridian.Strategies/Services/StrategyDesignService.cs
@@ -489,7 +489,8 @@ public sealed class StrategyDesignService
             return false;
         }
 
-        canonical = validValues.FirstOrDefault(candidate => string.Equals(candidate, value.Trim(), StringComparison.OrdinalIgnoreCase)) ?? string.Empty;
+        var trimmed = value.Trim();
+        canonical = validValues.FirstOrDefault(candidate => string.Equals(candidate, trimmed, StringComparison.OrdinalIgnoreCase)) ?? string.Empty;
         return canonical.Length > 0;
     }
 

--- a/src/Meridian.Strategies/Services/StrategyDesignService.cs
+++ b/src/Meridian.Strategies/Services/StrategyDesignService.cs
@@ -136,6 +136,8 @@ public sealed class StrategyDesignService
                         $"{fieldRef} is visible in the field catalog but disabled: {field.DisabledReason}"));
                 }
             }
+
+            messages.AddRange(ValidateCellKindParameters(cell));
         }
 
         var cellOrder = cells
@@ -430,12 +432,69 @@ public sealed class StrategyDesignService
     private static string SafeLabel(StrategyDesignCell cell)
         => string.IsNullOrWhiteSpace(cell.Label) ? cell.CellId : cell.Label;
 
+    private static IEnumerable<StrategyDesignValidationMessage> ValidateCellKindParameters(StrategyDesignCell cell)
+    {
+        var label = SafeLabel(cell);
+        var p = cell.Parameters;
+
+        switch (cell.Kind)
+        {
+            case "state":
+                if (p is null || !p.TryGetValue("exitCondition", out var exitCond) || string.IsNullOrWhiteSpace(exitCond))
+                    yield return Error("StateCellExitRequired", cell.CellId, $"{label} (state) must define an exitCondition parameter.");
+
+                if (p is null || !p.TryGetValue("stateLabel", out var stateLbl) || string.IsNullOrWhiteSpace(stateLbl))
+                    yield return Error("StateCellLabelRequired", cell.CellId, $"{label} (state) must define a stateLabel parameter.");
+                break;
+
+            case "concurrent":
+                if (p is null || !p.TryGetValue("branchIds", out var branches) || string.IsNullOrWhiteSpace(branches))
+                    yield return Error("ConcurrentCellBranchesRequired", cell.CellId, $"{label} (concurrent) must define a branchIds parameter.");
+
+                var validSemantics = new[] { "all-pass", "any-pass", "first-wins" };
+                if (p is null || !p.TryGetValue("semantics", out var sem) || !validSemantics.Contains(sem, StringComparer.OrdinalIgnoreCase))
+                    yield return Error("ConcurrentCellSemanticsRequired", cell.CellId, $"{label} (concurrent) semantics must be one of: all-pass, any-pass, first-wins.");
+                break;
+
+            case "universe-builder":
+                if (p is null || !p.TryGetValue("assetClass", out var assetClass) || string.IsNullOrWhiteSpace(assetClass))
+                    yield return Error("UniverseBuilderAssetClassRequired", cell.CellId, $"{label} (universe-builder) must define an assetClass parameter.");
+
+                if (p is null || !p.TryGetValue("includeRules", out var includeRules) || string.IsNullOrWhiteSpace(includeRules))
+                    yield return Error("UniverseBuilderIncludeRulesRequired", cell.CellId, $"{label} (universe-builder) must define at least one includeRules parameter.");
+                break;
+
+            case "trade":
+                var validInstruments = new[] { "Equity", "Option", "Future", "ETF" };
+                if (p is null || !p.TryGetValue("instrument", out var instr) || !validInstruments.Contains(instr, StringComparer.OrdinalIgnoreCase))
+                    yield return Error("TradeCellInstrumentRequired", cell.CellId, $"{label} (trade) instrument must be Equity, Option, Future, or ETF.");
+
+                var validDirections = new[] { "Buy", "Sell", "SellShort", "BuyToCover" };
+                if (p is null || !p.TryGetValue("direction", out var dir) || !validDirections.Contains(dir, StringComparer.OrdinalIgnoreCase))
+                    yield return Error("TradeCellDirectionRequired", cell.CellId, $"{label} (trade) direction must be Buy, Sell, SellShort, or BuyToCover.");
+
+                var validSizing = new[] { "FixedShares", "FixedNotional", "PercentAUM", "EqualWeight" };
+                if (p is null || !p.TryGetValue("sizingMethod", out var sizing) || !validSizing.Contains(sizing, StringComparer.OrdinalIgnoreCase))
+                    yield return Error("TradeCellSizingRequired", cell.CellId, $"{label} (trade) sizingMethod must be FixedShares, FixedNotional, PercentAUM, or EqualWeight.");
+                break;
+        }
+    }
+
     private static string BuildCellTraceDetail(StrategyDesignCell cell)
     {
         var refs = ResolveFieldRefs(cell);
-        return refs.Count == 0
-            ? $"{cell.Kind} cell runs without catalog fields."
-            : $"{cell.Kind} cell uses {string.Join(", ", refs)}.";
+        var refsLabel = refs.Count == 0 ? "no catalog fields" : string.Join(", ", refs);
+        var p = cell.Parameters;
+        return cell.Kind switch
+        {
+            "state" => $"State '{p?.GetValueOrDefault("stateLabel", cell.CellId)}' exits on: {p?.GetValueOrDefault("exitCondition", "(none)")}.",
+            "concurrent" => $"Concurrent evaluation ({p?.GetValueOrDefault("semantics", "?")}) across: {p?.GetValueOrDefault("branchIds", "(none)")}.",
+            "universe-builder" => $"Builds {p?.GetValueOrDefault("assetClass", "?")} universe using {refsLabel}.",
+            "trade" => $"Trade intent: {p?.GetValueOrDefault("direction", "?")} {p?.GetValueOrDefault("instrument", "?")} via {p?.GetValueOrDefault("sizingMethod", "?")}.",
+            _ => refs.Count == 0
+                ? $"{cell.Kind} cell runs without catalog fields."
+                : $"{cell.Kind} cell uses {refsLabel}."
+        };
     }
 
     private static string ComputeDatasetFingerprint(StrategyDesignDocument document, IReadOnlyList<string> fieldRefs)
@@ -541,6 +600,122 @@ public sealed class StrategyDesignService
                         new("t2", "payoff-panel", "review-proof", "next", "payoff reviewed")
                     ],
                     new Dictionary<string, string> { ["prototypeCommit"] = "2826afc0dc5ca4590bf0860871acd45933088bad" },
+                    now,
+                    now))),
+            new(
+                "state-machine-strategy",
+                "State machine strategy",
+                "Named execution states with entry/exit conditions — model a strategy as a lifecycle state machine.",
+                "Advanced",
+                "Meridian extended cell kinds",
+                ["state", "lifecycle", "conditional"],
+                Normalize(new StrategyDesignDocument(
+                    "state-machine-strategy",
+                    "State machine strategy",
+                    "Strategy execution modelled as a state machine with named checkpoints.",
+                    "1",
+                    "provider-bars/equities/daily",
+                    ["SPY", "QQQ"],
+                    [
+                        new("watching-state", "Watching", "state", "state", "initial monitoring phase", ["MOMENTUM_63D"],
+                            new Dictionary<string, string> { ["stateLabel"] = "Watching", ["exitCondition"] = "MOMENTUM_63D > 0.05", ["entryCondition"] = "PORTFOLIO_WEIGHT == 0", ["isTerminal"] = "false" }),
+                        new("holding-state", "Holding", "state", "state", "active position phase", ["MOMENTUM_63D", "VOLATILITY_20D"],
+                            new Dictionary<string, string> { ["stateLabel"] = "Holding", ["exitCondition"] = "MOMENTUM_63D < 0 || VOLATILITY_20D > 0.35", ["isTerminal"] = "false" }),
+                        new("exiting-state", "Exiting", "state", "state", "position wind-down phase", ["PORTFOLIO_WEIGHT"],
+                            new Dictionary<string, string> { ["stateLabel"] = "Exiting", ["exitCondition"] = "PORTFOLIO_WEIGHT == 0", ["isTerminal"] = "true" }),
+                        new("state-risk-guard", "State risk guard", "governance", "risk", "VOLATILITY_20D < 0.40", ["VOLATILITY_20D"], null)
+                    ],
+                    [
+                        new("t1", "watching-state", "holding-state", "next", "exit: MOMENTUM_63D > 0.05"),
+                        new("t2", "holding-state", "exiting-state", "next", "exit: MOMENTUM_63D < 0 || VOLATILITY_20D > 0.35"),
+                        new("t3", "exiting-state", "state-risk-guard", "next", "position closed")
+                    ],
+                    null,
+                    now,
+                    now))),
+            new(
+                "concurrent-branch-strategy",
+                "Concurrent branch strategy",
+                "Parallel evaluation point — multiple signal branches run simultaneously with configurable pass semantics.",
+                "Advanced",
+                "Meridian extended cell kinds",
+                ["concurrent", "parallel", "multi-signal"],
+                Normalize(new StrategyDesignDocument(
+                    "concurrent-branch-strategy",
+                    "Concurrent branch strategy",
+                    "Parallel signal evaluation: equity momentum and volatility screens run concurrently.",
+                    "1",
+                    "provider-bars/equities/daily",
+                    ["SPY", "QQQ", "AAPL"],
+                    [
+                        new("momentum-branch", "Momentum signal", "formula", "filter", "MOMENTUM_63D > 0.05", ["MOMENTUM_63D"], null),
+                        new("volatility-branch", "Volatility filter", "formula", "filter", "VOLATILITY_20D < 0.30", ["VOLATILITY_20D"], null),
+                        new("concurrent-gate", "Concurrent signal gate", "concurrent", "concurrent", "parallel branch evaluation", [],
+                            new Dictionary<string, string> { ["branchIds"] = "momentum-branch,volatility-branch", ["semantics"] = "all-pass" }),
+                        new("concurrent-risk", "Risk guard", "governance", "risk", "all concurrent branches satisfied", ["PORTFOLIO_WEIGHT"], null)
+                    ],
+                    [
+                        new("t1", "momentum-branch", "concurrent-gate", "next", "branch ready"),
+                        new("t2", "volatility-branch", "concurrent-gate", "next", "branch ready"),
+                        new("t3", "concurrent-gate", "concurrent-risk", "next", "gate resolved")
+                    ],
+                    null,
+                    now,
+                    now))),
+            new(
+                "structured-universe-strategy",
+                "Structured universe strategy",
+                "Explicit asset class, include/exclude rules, and size constraints for disciplined universe construction.",
+                "Universe",
+                "Meridian extended cell kinds",
+                ["universe-builder", "structured", "equity"],
+                Normalize(new StrategyDesignDocument(
+                    "structured-universe-strategy",
+                    "Structured universe strategy",
+                    "Universe-builder cell with explicit asset class rules and size bounds.",
+                    "1",
+                    "provider-bars/equities/daily",
+                    ["SPY"],
+                    [
+                        new("equity-universe", "Liquid equity universe", "universe-builder", "universe", "structured universe definition", ["PRICE", "MOMENTUM_63D"],
+                            new Dictionary<string, string> { ["assetClass"] = "Equity", ["includeRules"] = "PRICE > 10, MOMENTUM_63D > 0", ["excludeRules"] = "VOLATILITY_20D > 0.40", ["minSize"] = "20", ["maxSize"] = "100" }),
+                        new("universe-rank", "Momentum rank", "formula", "rank", "MOMENTUM_63D - VOLATILITY_20D", ["MOMENTUM_63D", "VOLATILITY_20D"], null),
+                        new("universe-risk", "Universe risk guard", "governance", "risk", "VOLATILITY_20D < 0.30", ["VOLATILITY_20D"], null)
+                    ],
+                    [
+                        new("t1", "equity-universe", "universe-rank", "next", "universe built"),
+                        new("t2", "universe-rank", "universe-risk", "next", "rank complete")
+                    ],
+                    null,
+                    now,
+                    now))),
+            new(
+                "trade-intent-strategy",
+                "Trade intent strategy",
+                "Explicit trade definition cell — instrument type, direction, sizing method, and price constraint.",
+                "Execution",
+                "Meridian extended cell kinds",
+                ["trade", "execution", "sizing"],
+                Normalize(new StrategyDesignDocument(
+                    "trade-intent-strategy",
+                    "Trade intent strategy",
+                    "Strategy with an explicit trade cell defining instrument, direction, and sizing.",
+                    "1",
+                    "provider-bars/equities/daily",
+                    ["SPY", "QQQ"],
+                    [
+                        new("trade-universe", "Liquid equity filter", "visual", "universe", "PRICE > 20", ["PRICE"], null),
+                        new("trade-rank", "Momentum score", "formula", "rank", "MOMENTUM_63D - VOLATILITY_20D", ["MOMENTUM_63D", "VOLATILITY_20D"], null),
+                        new("buy-equities", "Buy equities", "trade", "trade", "execute buy order on ranked universe", [],
+                            new Dictionary<string, string> { ["instrument"] = "Equity", ["direction"] = "Buy", ["sizingMethod"] = "EqualWeight", ["priceConstraint"] = "VWAP", ["sizingValue"] = "0.05" }),
+                        new("trade-risk", "Execution risk guard", "governance", "risk", "VOLATILITY_20D < 0.30 && PORTFOLIO_WEIGHT <= 0.10", ["VOLATILITY_20D", "PORTFOLIO_WEIGHT"], null)
+                    ],
+                    [
+                        new("t1", "trade-universe", "trade-rank", "next", "universe ready"),
+                        new("t2", "trade-rank", "buy-equities", "next", "rank complete"),
+                        new("t3", "buy-equities", "trade-risk", "next", "trade submitted")
+                    ],
+                    null,
                     now,
                     now)))
         ];

--- a/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.test.tsx
@@ -99,4 +99,48 @@ describe("StrategyDesignerScreen", () => {
       "/api/workstation/strategy/designer/run-backtest"
     );
   });
+
+  it("renders kind badge in cell canvas for state cells after loading the state machine template", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<StrategyDesignerScreen />);
+
+    await user.click(screen.getByRole("button", { name: "Load State machine strategy template" }));
+
+    const canvas = screen.getByTestId("strategy-builder-canvas");
+    expect(within(canvas).getAllByText("state").length).toBeGreaterThan(0);
+  });
+
+  it("inspector shows typed trade parameters when a trade cell is selected", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<StrategyDesignerScreen />);
+
+    await user.click(screen.getByRole("button", { name: "Load Trade intent strategy template" }));
+
+    const row = screen.getByRole("row", { name: /select buy equities/i });
+    row.focus();
+    await user.keyboard("{Enter}");
+
+    const inspector = screen.getByTestId("strategy-builder-inspector");
+    expect(within(inspector).getByText("Instrument type")).toBeInTheDocument();
+    expect(within(inspector).getByText("Direction")).toBeInTheDocument();
+    expect(within(inspector).getByText("Sizing method")).toBeInTheDocument();
+  });
+
+  it("inspector shows concurrent cell parameters when concurrent cell is selected", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<StrategyDesignerScreen />);
+
+    await user.click(screen.getByRole("button", { name: "Load Concurrent branch strategy template" }));
+
+    const canvas = screen.getByTestId("strategy-builder-canvas");
+    expect(within(canvas).getAllByText("concurrent").length).toBeGreaterThan(0);
+
+    const row = screen.getByRole("row", { name: /select concurrent signal gate/i });
+    row.focus();
+    await user.keyboard("{Enter}");
+
+    const inspector = screen.getByTestId("strategy-builder-inspector");
+    expect(within(inspector).getByText("Branch cell IDs")).toBeInTheDocument();
+    expect(within(inspector).getByText("Evaluation semantics")).toBeInTheDocument();
+  });
 });

--- a/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.tsx
@@ -1,4 +1,4 @@
-import { Database, Eye, FlaskConical, GitBranch, PlayCircle, Save, Search, ShieldCheck, Sparkles, Workflow } from "lucide-react";
+import { ArrowRightLeft, CircleDot, Database, Eye, FlaskConical, GitBranch, Layers, Network, PlayCircle, Save, Search, ShieldCheck, Sparkles, Workflow } from "lucide-react";
 import { DenseDataTable, type DenseDataTableColumn } from "@/components/meridian/ui-kit-primitives";
 import { MetricCard } from "@/components/meridian/metric-card";
 import { Badge } from "@/components/ui/badge";
@@ -12,6 +12,7 @@ import {
   type ParticipationViewModel,
   type PayoffChartViewModel,
   type StrategyBuilderCellDetailViewModel,
+  type StrategyBuilderCellKind,
   type StrategyBuilderCellViewModel,
   type StrategyBuilderFieldCatalogItem,
   type StrategyBuilderTemplate,
@@ -20,6 +21,29 @@ import {
   type StrategyDesignerViewModel,
   type StrategyLegDetailFieldViewModel
 } from "@/screens/strategy-designer-screen.view-model";
+
+function cellKindBadgeVariant(kind: StrategyBuilderCellKind): "default" | "outline" | "success" | "warning" | "danger" | "research" {
+  switch (kind) {
+    case "governance":       return "warning";
+    case "code":             return "research";
+    case "state":            return "default";
+    case "concurrent":       return "success";
+    case "universe-builder": return "success";
+    case "trade":            return "danger";
+    case "options-payoff":   return "warning";
+    default:                 return "outline";
+  }
+}
+
+function CellKindIcon({ kind }: { kind: StrategyBuilderCellKind }) {
+  switch (kind) {
+    case "state":            return <CircleDot className="h-3 w-3 text-muted-foreground" aria-hidden="true" />;
+    case "concurrent":       return <Network className="h-3 w-3 text-muted-foreground" aria-hidden="true" />;
+    case "universe-builder": return <Layers className="h-3 w-3 text-muted-foreground" aria-hidden="true" />;
+    case "trade":            return <ArrowRightLeft className="h-3 w-3 text-muted-foreground" aria-hidden="true" />;
+    default:                 return null;
+  }
+}
 
 export function StrategyDesignerScreen() {
   const vm = useStrategyDesignerViewModel();
@@ -197,7 +221,11 @@ function CellCanvasPanel({ vm }: { vm: StrategyBuilderWorkbenchViewModel }) {
       render: (row) => (
         <div className="min-w-0">
           <div className="font-medium text-foreground">{row.label}</div>
-          <div className="mt-1 font-mono text-xs text-muted-foreground">{row.cellId}</div>
+          <div className="mt-1 flex items-center gap-1.5">
+            <CellKindIcon kind={row.kind} />
+            <Badge variant={cellKindBadgeVariant(row.kind)}>{row.kind}</Badge>
+            <span className="font-mono text-xs text-muted-foreground">{row.cellId}</span>
+          </div>
         </div>
       )
     },

--- a/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.test.ts
@@ -18,12 +18,17 @@ import {
   findBreakEvenPrices,
   getStrategyBuilderFieldCatalog,
   getStrategyBuilderTemplates,
+  getStateCellParams,
+  getTradeCellParams,
+  getConcurrentCellParams,
+  getUniverseBuilderCellParams,
   getStrategyDesignerPalette,
   getStrategyDesignerSampleLegs,
   loadStrategyBuilderTemplate,
   reorderLegs,
   useStrategyDesignerViewModel,
   validateStrategyBuilderDocument,
+  type StrategyBuilderCell,
   type StrategyLeg
 } from "@/screens/strategy-designer-screen.view-model";
 
@@ -440,5 +445,165 @@ describe("strategy designer view-model", () => {
       label: "Clear canvas",
       confirmationPending: false
     });
+  });
+
+  it("validates state cell requires exitCondition and stateLabel parameters", () => {
+    const document = loadStrategyBuilderTemplate("equity-momentum-breakout");
+    const invalid = {
+      ...document,
+      cells: [
+        ...document.cells,
+        {
+          cellId: "monitoring-state",
+          label: "Monitoring state",
+          kind: "state" as const,
+          purpose: "state" as const,
+          source: "entry phase",
+          fieldRefs: [],
+          parameters: { stateLabel: "Monitoring" }
+        } satisfies StrategyBuilderCell
+      ]
+    };
+
+    const messages = validateStrategyBuilderDocument(invalid);
+    const codes = messages.map((m) => m.code);
+
+    expect(codes).toContain("StateCellExitRequired");
+    expect(codes).not.toContain("StateCellLabelRequired");
+  });
+
+  it("validates concurrent cell requires valid semantics", () => {
+    const document = loadStrategyBuilderTemplate("equity-momentum-breakout");
+    const invalid = {
+      ...document,
+      cells: [
+        ...document.cells,
+        {
+          cellId: "parallel-check",
+          label: "Parallel check",
+          kind: "concurrent" as const,
+          purpose: "concurrent" as const,
+          source: "parallel evaluation",
+          fieldRefs: [],
+          parameters: { branchIds: "cell-a,cell-b", semantics: "bad-value" }
+        } satisfies StrategyBuilderCell
+      ]
+    };
+
+    const messages = validateStrategyBuilderDocument(invalid);
+
+    expect(messages.map((m) => m.code)).toContain("ConcurrentCellSemanticsRequired");
+  });
+
+  it("passes validation for a fully populated universe-builder cell", () => {
+    const document = loadStrategyBuilderTemplate("structured-universe-strategy");
+    const messages = validateStrategyBuilderDocument(document);
+    const errors = messages.filter((m) => m.severity === "error");
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it("validates trade cell requires instrument, direction, and sizingMethod", () => {
+    const document = loadStrategyBuilderTemplate("equity-momentum-breakout");
+    const invalid = {
+      ...document,
+      cells: [
+        ...document.cells,
+        {
+          cellId: "trade-cell",
+          label: "Buy equities",
+          kind: "trade" as const,
+          purpose: "trade" as const,
+          source: "execute trade",
+          fieldRefs: [],
+          parameters: {}
+        } satisfies StrategyBuilderCell
+      ]
+    };
+
+    const messages = validateStrategyBuilderDocument(invalid);
+    const codes = messages.map((m) => m.code);
+
+    expect(codes).toContain("TradeCellInstrumentRequired");
+    expect(codes).toContain("TradeCellDirectionRequired");
+    expect(codes).toContain("TradeCellSizingRequired");
+  });
+
+  it("typed parameter extractors return null for wrong kind or missing parameters", () => {
+    const formulaCell: StrategyBuilderCell = {
+      cellId: "c",
+      label: "C",
+      kind: "formula",
+      purpose: "rank",
+      source: "PRICE",
+      fieldRefs: []
+    };
+
+    expect(getStateCellParams(formulaCell)).toBeNull();
+    expect(getTradeCellParams(formulaCell)).toBeNull();
+    expect(getConcurrentCellParams(formulaCell)).toBeNull();
+    expect(getUniverseBuilderCellParams(formulaCell)).toBeNull();
+  });
+
+  it("getStateCellParams returns null when required keys are absent", () => {
+    const stateCell: StrategyBuilderCell = {
+      cellId: "s",
+      label: "S",
+      kind: "state",
+      purpose: "state",
+      source: "phase",
+      fieldRefs: [],
+      parameters: { stateLabel: "Watching" }
+    };
+
+    expect(getStateCellParams(stateCell)).toBeNull();
+  });
+
+  it("four new cell-kind templates appear in the template gallery", () => {
+    const templates = getStrategyBuilderTemplates();
+    const ids = templates.map((t) => t.templateId);
+
+    expect(ids).toContain("state-machine-strategy");
+    expect(ids).toContain("concurrent-branch-strategy");
+    expect(ids).toContain("structured-universe-strategy");
+    expect(ids).toContain("trade-intent-strategy");
+  });
+
+  it("buildStrategyBuilderWorkbenchViewModel surfaces typed trade parameters in inspector fields", () => {
+    const document = loadStrategyBuilderTemplate("trade-intent-strategy");
+    const tradeCell = document.cells.find((c) => c.kind === "trade");
+    const vm = buildStrategyBuilderWorkbenchViewModel({
+      document,
+      selectedCellId: tradeCell?.cellId
+    });
+
+    const fields = vm.selectedCellDetail?.fields ?? [];
+
+    expect(fields.some((f) => f.id === "instrument")).toBe(true);
+    expect(fields.some((f) => f.id === "direction")).toBe(true);
+    expect(fields.some((f) => f.id === "sizing-method")).toBe(true);
+  });
+
+  it("buildStrategyBuilderWorkbenchViewModel surfaces state cell parameters in inspector", () => {
+    const document = loadStrategyBuilderTemplate("state-machine-strategy");
+    const stateCell = document.cells.find((c) => c.kind === "state");
+    const vm = buildStrategyBuilderWorkbenchViewModel({
+      document,
+      selectedCellId: stateCell?.cellId
+    });
+
+    const fields = vm.selectedCellDetail?.fields ?? [];
+
+    expect(fields.some((f) => f.id === "state-label")).toBe(true);
+    expect(fields.some((f) => f.id === "exit-condition")).toBe(true);
+  });
+
+  it("cloneStrategyBuilderDocument deep-copies parameters so mutations do not leak", () => {
+    const document = loadStrategyBuilderTemplate("trade-intent-strategy");
+    const tradeCell = document.cells.find((c) => c.kind === "trade")!;
+
+    expect(tradeCell.parameters?.["instrument"]).toBe("Equity");
+    const original = loadStrategyBuilderTemplate("trade-intent-strategy");
+    expect(original.cells.find((c) => c.kind === "trade")?.parameters?.["instrument"]).toBe("Equity");
   });
 });

--- a/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.test.ts
@@ -472,6 +472,30 @@ describe("strategy designer view-model", () => {
     expect(codes).not.toContain("StateCellLabelRequired");
   });
 
+  it("treats whitespace-only state parameters as missing", () => {
+    const document = loadStrategyBuilderTemplate("equity-momentum-breakout");
+    const invalid = {
+      ...document,
+      cells: [
+        ...document.cells,
+        {
+          cellId: "monitoring-state",
+          label: "Monitoring state",
+          kind: "state" as const,
+          purpose: "state" as const,
+          source: "entry phase",
+          fieldRefs: [],
+          parameters: { stateLabel: "   ", exitCondition: "   " }
+        } satisfies StrategyBuilderCell
+      ]
+    };
+
+    const codes = validateStrategyBuilderDocument(invalid).map((m) => m.code);
+
+    expect(codes).toContain("StateCellExitRequired");
+    expect(codes).toContain("StateCellLabelRequired");
+  });
+
   it("validates concurrent cell requires valid semantics", () => {
     const document = loadStrategyBuilderTemplate("equity-momentum-breakout");
     const invalid = {
@@ -495,12 +519,65 @@ describe("strategy designer view-model", () => {
     expect(messages.map((m) => m.code)).toContain("ConcurrentCellSemanticsRequired");
   });
 
+  it("validates concurrent cell branch IDs resolve to existing cells", () => {
+    const document = loadStrategyBuilderTemplate("equity-momentum-breakout");
+    const invalid = {
+      ...document,
+      cells: [
+        ...document.cells,
+        {
+          cellId: "parallel-check",
+          label: "Parallel check",
+          kind: "concurrent" as const,
+          purpose: "concurrent" as const,
+          source: "parallel evaluation",
+          fieldRefs: [],
+          parameters: { branchIds: "rank,missing-cell", semantics: "all-pass" }
+        } satisfies StrategyBuilderCell
+      ]
+    };
+
+    const codes = validateStrategyBuilderDocument(invalid).map((m) => m.code);
+
+    expect(codes).toContain("ConcurrentCellBranchMissing");
+  });
+
   it("passes validation for a fully populated universe-builder cell", () => {
     const document = loadStrategyBuilderTemplate("structured-universe-strategy");
     const messages = validateStrategyBuilderDocument(document);
     const errors = messages.filter((m) => m.severity === "error");
 
     expect(errors).toHaveLength(0);
+  });
+
+  it("validates universe-builder rule field references and size constraints", () => {
+    const document = loadStrategyBuilderTemplate("equity-momentum-breakout");
+    const invalid = {
+      ...document,
+      cells: [
+        ...document.cells,
+        {
+          cellId: "ub",
+          label: "Universe builder",
+          kind: "universe-builder" as const,
+          purpose: "universe" as const,
+          source: "build universe",
+          fieldRefs: ["PRICE"],
+          parameters: {
+            assetClass: "Equity",
+            includeRules: "UNKNOWN_FIELD > 10",
+            excludeRules: "VOLATILITY_20D > 0.2",
+            minSize: "101",
+            maxSize: "100"
+          }
+        } satisfies StrategyBuilderCell
+      ]
+    };
+
+    const codes = validateStrategyBuilderDocument(invalid).map((m) => m.code);
+
+    expect(codes).toContain("UnknownField");
+    expect(codes).toContain("UniverseBuilderSizeRangeInvalid");
   });
 
   it("validates trade cell requires instrument, direction, and sizingMethod", () => {
@@ -529,6 +606,37 @@ describe("strategy designer view-model", () => {
     expect(codes).toContain("TradeCellSizingRequired");
   });
 
+  it("requires numeric sizingValue for fixed trade sizing methods", () => {
+    const document = loadStrategyBuilderTemplate("equity-momentum-breakout");
+    const invalid = {
+      ...document,
+      cells: [
+        ...document.cells,
+        {
+          cellId: "trade-cell",
+          label: "Buy equities",
+          kind: "trade" as const,
+          purpose: "trade" as const,
+          source: "execute trade",
+          fieldRefs: [],
+          parameters: {
+            instrument: "equity",
+            direction: "buy",
+            sizingMethod: "FixedShares",
+            sizingValue: "not-a-number"
+          }
+        } satisfies StrategyBuilderCell
+      ]
+    };
+
+    const messages = validateStrategyBuilderDocument(invalid);
+    const codes = messages.map((m) => m.code);
+
+    expect(codes).toContain("TradeCellSizingValueRequired");
+    expect(codes).not.toContain("TradeCellInstrumentRequired");
+    expect(codes).not.toContain("TradeCellDirectionRequired");
+  });
+
   it("typed parameter extractors return null for wrong kind or missing parameters", () => {
     const formulaCell: StrategyBuilderCell = {
       cellId: "c",
@@ -543,6 +651,32 @@ describe("strategy designer view-model", () => {
     expect(getTradeCellParams(formulaCell)).toBeNull();
     expect(getConcurrentCellParams(formulaCell)).toBeNull();
     expect(getUniverseBuilderCellParams(formulaCell)).toBeNull();
+  });
+
+  it("typed extractors canonicalize concurrent and trade enums case-insensitively", () => {
+    const concurrentCell: StrategyBuilderCell = {
+      cellId: "concurrent",
+      label: "Concurrent",
+      kind: "concurrent",
+      purpose: "concurrent",
+      source: "parallel",
+      fieldRefs: [],
+      parameters: { branchIds: "a,b", semantics: "ALL-PASS" }
+    };
+    const tradeCell: StrategyBuilderCell = {
+      cellId: "trade",
+      label: "Trade",
+      kind: "trade",
+      purpose: "trade",
+      source: "trade",
+      fieldRefs: [],
+      parameters: { instrument: "equity", direction: "buy", sizingMethod: "equalweight" }
+    };
+
+    expect(getConcurrentCellParams(concurrentCell)?.semantics).toBe("all-pass");
+    expect(getTradeCellParams(tradeCell)?.instrument).toBe("Equity");
+    expect(getTradeCellParams(tradeCell)?.direction).toBe("Buy");
+    expect(getTradeCellParams(tradeCell)?.sizingMethod).toBe("EqualWeight");
   });
 
   it("getStateCellParams returns null when required keys are absent", () => {
@@ -601,9 +735,11 @@ describe("strategy designer view-model", () => {
   it("cloneStrategyBuilderDocument deep-copies parameters so mutations do not leak", () => {
     const document = loadStrategyBuilderTemplate("trade-intent-strategy");
     const tradeCell = document.cells.find((c) => c.kind === "trade")!;
+    tradeCell.parameters!["instrument"] = "Future";
+    tradeCell.parameters!["sizingValue"] = "999";
 
-    expect(tradeCell.parameters?.["instrument"]).toBe("Equity");
     const original = loadStrategyBuilderTemplate("trade-intent-strategy");
     expect(original.cells.find((c) => c.kind === "trade")?.parameters?.["instrument"]).toBe("Equity");
+    expect(original.cells.find((c) => c.kind === "trade")?.parameters?.["sizingValue"]).toBe("0.05");
   });
 });

--- a/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.test.ts
@@ -737,6 +737,8 @@ describe("strategy designer view-model", () => {
     const tradeCell = document.cells.find((c) => c.kind === "trade")!;
     tradeCell.parameters!["instrument"] = "Future";
     tradeCell.parameters!["sizingValue"] = "999";
+    expect(tradeCell.parameters?.["instrument"]).toBe("Future");
+    expect(tradeCell.parameters?.["sizingValue"]).toBe("999");
 
     const original = loadStrategyBuilderTemplate("trade-intent-strategy");
     expect(original.cells.find((c) => c.kind === "trade")?.parameters?.["instrument"]).toBe("Equity");

--- a/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.ts
@@ -229,6 +229,13 @@ export type TradeCellInstrumentType = "Equity" | "Option" | "Future" | "ETF";
 export type TradeCellDirection = "Buy" | "Sell" | "SellShort" | "BuyToCover";
 export type TradeCellSizingMethod = "FixedShares" | "FixedNotional" | "PercentAUM" | "EqualWeight";
 
+const FIELD_TOKEN_REGEX = /\b[A-Z][A-Z0-9_]{2,}\b/g;
+const CONCURRENT_CELL_SEMANTICS: ConcurrentCellSemantics[] = ["all-pass", "any-pass", "first-wins"];
+const TRADE_CELL_INSTRUMENTS: TradeCellInstrumentType[] = ["Equity", "Option", "Future", "ETF"];
+const TRADE_CELL_DIRECTIONS: TradeCellDirection[] = ["Buy", "Sell", "SellShort", "BuyToCover"];
+const TRADE_CELL_SIZING_METHODS: TradeCellSizingMethod[] = ["FixedShares", "FixedNotional", "PercentAUM", "EqualWeight"];
+const TRADE_CELL_SIZING_VALUE_REQUIRED_METHODS: TradeCellSizingMethod[] = ["FixedShares", "FixedNotional", "PercentAUM"];
+
 export interface TradeCellParameters {
   instrument: TradeCellInstrumentType;
   direction: TradeCellDirection;
@@ -237,61 +244,111 @@ export interface TradeCellParameters {
   sizingValue?: string;
 }
 
+function getTrimmedParameter(parameters: Record<string, string> | undefined, key: string): string | undefined {
+  const value = parameters?.[key];
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function toCanonicalEnumValue<T extends string>(value: string | undefined, validValues: readonly T[]): T | null {
+  if (!value) {
+    return null;
+  }
+
+  const canonical = validValues.find((candidate) => candidate.toLowerCase() === value.toLowerCase());
+  return canonical ?? null;
+}
+
+function parseBranchIds(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(",")
+    .map((branchId) => branchId.trim())
+    .filter((branchId) => branchId.length > 0);
+}
+
+function extractFieldTokens(source: string | undefined): string[] {
+  if (!source) {
+    return [];
+  }
+
+  const tokens = source.match(FIELD_TOKEN_REGEX) ?? [];
+  return [...new Set(tokens.map((token) => token.toUpperCase()))];
+}
+
+function resolveCellFieldRefs(cell: StrategyBuilderCell): string[] {
+  const refs = cell.fieldRefs.map((fieldRef) => fieldRef.trim().toUpperCase()).filter((fieldRef) => fieldRef.length > 0);
+  if (cell.kind !== "universe-builder") {
+    return [...new Set(refs)];
+  }
+
+  const includeRules = getTrimmedParameter(cell.parameters, "includeRules");
+  const excludeRules = getTrimmedParameter(cell.parameters, "excludeRules");
+  return [...new Set([...refs, ...extractFieldTokens(includeRules), ...extractFieldTokens(excludeRules)])];
+}
+
 export function getStateCellParams(cell: StrategyBuilderCell): StateCellParameters | null {
   if (cell.kind !== "state" || !cell.parameters) return null;
-  const exitCondition = cell.parameters["exitCondition"];
-  const stateLabel = cell.parameters["stateLabel"];
+  const exitCondition = getTrimmedParameter(cell.parameters, "exitCondition");
+  const stateLabel = getTrimmedParameter(cell.parameters, "stateLabel");
   if (!exitCondition || !stateLabel) return null;
   return {
-    entryCondition: cell.parameters["entryCondition"],
+    entryCondition: getTrimmedParameter(cell.parameters, "entryCondition"),
     exitCondition,
     stateLabel,
-    isTerminal: cell.parameters["isTerminal"]
+    isTerminal: getTrimmedParameter(cell.parameters, "isTerminal")
   };
 }
 
 export function getConcurrentCellParams(cell: StrategyBuilderCell): ConcurrentCellParameters | null {
   if (cell.kind !== "concurrent" || !cell.parameters) return null;
-  const branchIds = cell.parameters["branchIds"];
-  const semantics = cell.parameters["semantics"] as ConcurrentCellSemantics | undefined;
-  const validSemantics: ConcurrentCellSemantics[] = ["all-pass", "any-pass", "first-wins"];
-  if (!branchIds || !semantics || !validSemantics.includes(semantics)) return null;
-  return { branchIds, semantics };
+  const branchIds = getTrimmedParameter(cell.parameters, "branchIds");
+  const parsedBranchIds = parseBranchIds(branchIds);
+  const semantics = toCanonicalEnumValue(getTrimmedParameter(cell.parameters, "semantics"), CONCURRENT_CELL_SEMANTICS);
+  if (parsedBranchIds.length === 0 || !semantics) return null;
+  return { branchIds: parsedBranchIds.join(","), semantics };
 }
 
 export function getUniverseBuilderCellParams(cell: StrategyBuilderCell): UniverseBuilderCellParameters | null {
   if (cell.kind !== "universe-builder" || !cell.parameters) return null;
-  const assetClass = cell.parameters["assetClass"];
-  const includeRules = cell.parameters["includeRules"];
+  const assetClass = getTrimmedParameter(cell.parameters, "assetClass");
+  const includeRules = getTrimmedParameter(cell.parameters, "includeRules");
   if (!assetClass || !includeRules) return null;
   return {
     assetClass,
     includeRules,
-    excludeRules: cell.parameters["excludeRules"],
-    minSize: cell.parameters["minSize"],
-    maxSize: cell.parameters["maxSize"]
+    excludeRules: getTrimmedParameter(cell.parameters, "excludeRules"),
+    minSize: getTrimmedParameter(cell.parameters, "minSize"),
+    maxSize: getTrimmedParameter(cell.parameters, "maxSize")
   };
 }
 
 export function getTradeCellParams(cell: StrategyBuilderCell): TradeCellParameters | null {
   if (cell.kind !== "trade" || !cell.parameters) return null;
-  const instrument = cell.parameters["instrument"] as TradeCellInstrumentType | undefined;
-  const direction = cell.parameters["direction"] as TradeCellDirection | undefined;
-  const sizingMethod = cell.parameters["sizingMethod"] as TradeCellSizingMethod | undefined;
-  const validInstruments: TradeCellInstrumentType[] = ["Equity", "Option", "Future", "ETF"];
-  const validDirections: TradeCellDirection[] = ["Buy", "Sell", "SellShort", "BuyToCover"];
-  const validSizing: TradeCellSizingMethod[] = ["FixedShares", "FixedNotional", "PercentAUM", "EqualWeight"];
+  const instrument = toCanonicalEnumValue(getTrimmedParameter(cell.parameters, "instrument"), TRADE_CELL_INSTRUMENTS);
+  const direction = toCanonicalEnumValue(getTrimmedParameter(cell.parameters, "direction"), TRADE_CELL_DIRECTIONS);
+  const sizingMethod = toCanonicalEnumValue(getTrimmedParameter(cell.parameters, "sizingMethod"), TRADE_CELL_SIZING_METHODS);
+  const sizingValue = getTrimmedParameter(cell.parameters, "sizingValue");
   if (
-    !instrument || !validInstruments.includes(instrument) ||
-    !direction || !validDirections.includes(direction) ||
-    !sizingMethod || !validSizing.includes(sizingMethod)
+    !instrument ||
+    !direction ||
+    !sizingMethod ||
+    (TRADE_CELL_SIZING_VALUE_REQUIRED_METHODS.includes(sizingMethod) &&
+      (!sizingValue || !Number.isFinite(Number(sizingValue))))
   ) return null;
   return {
     instrument,
     direction,
     sizingMethod,
-    priceConstraint: cell.parameters["priceConstraint"],
-    sizingValue: cell.parameters["sizingValue"]
+    priceConstraint: getTrimmedParameter(cell.parameters, "priceConstraint"),
+    sizingValue
   };
 }
 
@@ -839,7 +896,7 @@ const STRATEGY_BUILDER_TEMPLATES: StrategyBuilderTemplate[] = [
           kind: "universe-builder",
           purpose: "universe",
           source: "structured universe definition",
-          fieldRefs: ["PRICE", "MOMENTUM_63D"],
+          fieldRefs: ["PRICE", "MOMENTUM_63D", "VOLATILITY_20D"],
           parameters: { assetClass: "Equity", includeRules: "PRICE > 10, MOMENTUM_63D > 0", excludeRules: "VOLATILITY_20D > 0.40", minSize: "20", maxSize: "100" }
         },
         { cellId: "universe-rank", label: "Momentum rank", kind: "formula", purpose: "rank", source: "MOMENTUM_63D - VOLATILITY_20D", fieldRefs: ["MOMENTUM_63D", "VOLATILITY_20D"] },
@@ -1101,6 +1158,7 @@ export function validateStrategyBuilderDocument(
 ): StrategyBuilderValidationMessage[] {
   const messages: StrategyBuilderValidationMessage[] = [];
   const fieldMap = new Map(fieldCatalog.map((field) => [field.fieldId, field]));
+  const cellIds = new Set(document.cells.map((cell) => cell.cellId));
 
   if (!document.datasetReference.trim()) {
     messages.push({
@@ -1139,9 +1197,9 @@ export function validateStrategyBuilderDocument(
       });
     }
 
-    messages.push(...validateCellKindParameters(cell));
+    messages.push(...validateCellKindParameters(cell, cellIds));
 
-    for (const ref of cell.fieldRefs) {
+    for (const ref of resolveCellFieldRefs(cell)) {
       const field = fieldMap.get(ref);
       if (!field) {
         messages.push({
@@ -1210,62 +1268,82 @@ export function validateStrategyBuilderDocument(
   return messages;
 }
 
-function hasNonBlankParameterValue(value: unknown): boolean {
-  if (typeof value === "string") {
-    return value.trim().length > 0;
-  }
-
-  return Boolean(value);
-}
-
-function validateCellKindParameters(cell: StrategyBuilderCell): StrategyBuilderValidationMessage[] {
+function validateCellKindParameters(cell: StrategyBuilderCell, cellIds: ReadonlySet<string>): StrategyBuilderValidationMessage[] {
   const messages: StrategyBuilderValidationMessage[] = [];
   const label = cell.label || cell.cellId;
 
   if (cell.kind === "state") {
-    if (!hasNonBlankParameterValue(cell.parameters?.["exitCondition"])) {
+    if (!getTrimmedParameter(cell.parameters, "exitCondition")) {
       messages.push({ code: "StateCellExitRequired", severity: "error", targetId: cell.cellId, message: `${label} (state) must define an exitCondition parameter.` });
     }
-    if (!hasNonBlankParameterValue(cell.parameters?.["stateLabel"])) {
+    if (!getTrimmedParameter(cell.parameters, "stateLabel")) {
       messages.push({ code: "StateCellLabelRequired", severity: "error", targetId: cell.cellId, message: `${label} (state) must define a stateLabel parameter.` });
     }
   }
 
   if (cell.kind === "concurrent") {
-    if (!cell.parameters?.["branchIds"]) {
+    const branchIds = parseBranchIds(getTrimmedParameter(cell.parameters, "branchIds"));
+    if (branchIds.length === 0) {
       messages.push({ code: "ConcurrentCellBranchesRequired", severity: "error", targetId: cell.cellId, message: `${label} (concurrent) must define a branchIds parameter listing the parallel cell IDs.` });
+    } else {
+      const missing = branchIds.filter((branchId) => !cellIds.has(branchId));
+      if (missing.length > 0) {
+        messages.push({ code: "ConcurrentCellBranchMissing", severity: "error", targetId: cell.cellId, message: `${label} (concurrent) references missing branch cell IDs: ${missing.join(", ")}.` });
+      }
     }
-    const validSemantics: ConcurrentCellSemantics[] = ["all-pass", "any-pass", "first-wins"];
-    const sem = cell.parameters?.["semantics"];
-    if (!sem || !validSemantics.includes(sem as ConcurrentCellSemantics)) {
+    const sem = toCanonicalEnumValue(getTrimmedParameter(cell.parameters, "semantics"), CONCURRENT_CELL_SEMANTICS);
+    if (!sem) {
       messages.push({ code: "ConcurrentCellSemanticsRequired", severity: "error", targetId: cell.cellId, message: `${label} (concurrent) semantics must be one of: all-pass, any-pass, first-wins.` });
     }
   }
 
   if (cell.kind === "universe-builder") {
-    if (!cell.parameters?.["assetClass"]) {
+    if (!getTrimmedParameter(cell.parameters, "assetClass")) {
       messages.push({ code: "UniverseBuilderAssetClassRequired", severity: "error", targetId: cell.cellId, message: `${label} (universe-builder) must define an assetClass parameter.` });
     }
-    if (!cell.parameters?.["includeRules"]) {
+    if (!getTrimmedParameter(cell.parameters, "includeRules")) {
       messages.push({ code: "UniverseBuilderIncludeRulesRequired", severity: "error", targetId: cell.cellId, message: `${label} (universe-builder) must define at least one includeRules parameter.` });
+    }
+
+    const minSize = getTrimmedParameter(cell.parameters, "minSize");
+    const maxSize = getTrimmedParameter(cell.parameters, "maxSize");
+    const parsedMinSize = minSize ? Number(minSize) : null;
+    const parsedMaxSize = maxSize ? Number(maxSize) : null;
+
+    if (minSize && (!Number.isFinite(parsedMinSize) || parsedMinSize < 0)) {
+      messages.push({ code: "UniverseBuilderMinSizeInvalid", severity: "error", targetId: cell.cellId, message: `${label} (universe-builder) minSize must be a non-negative number.` });
+    }
+    if (maxSize && (!Number.isFinite(parsedMaxSize) || parsedMaxSize < 0)) {
+      messages.push({ code: "UniverseBuilderMaxSizeInvalid", severity: "error", targetId: cell.cellId, message: `${label} (universe-builder) maxSize must be a non-negative number.` });
+    }
+    if (
+      parsedMinSize !== null &&
+      parsedMaxSize !== null &&
+      Number.isFinite(parsedMinSize) &&
+      Number.isFinite(parsedMaxSize) &&
+      parsedMinSize > parsedMaxSize
+    ) {
+      messages.push({ code: "UniverseBuilderSizeRangeInvalid", severity: "error", targetId: cell.cellId, message: `${label} (universe-builder) minSize cannot be greater than maxSize.` });
     }
   }
 
   if (cell.kind === "trade") {
-    const validInstruments: TradeCellInstrumentType[] = ["Equity", "Option", "Future", "ETF"];
-    const validDirections: TradeCellDirection[] = ["Buy", "Sell", "SellShort", "BuyToCover"];
-    const validSizing: TradeCellSizingMethod[] = ["FixedShares", "FixedNotional", "PercentAUM", "EqualWeight"];
-    const instr = cell.parameters?.["instrument"] as TradeCellInstrumentType | undefined;
-    const dir = cell.parameters?.["direction"] as TradeCellDirection | undefined;
-    const sizing = cell.parameters?.["sizingMethod"] as TradeCellSizingMethod | undefined;
-    if (!instr || !validInstruments.includes(instr)) {
+    const instr = toCanonicalEnumValue(getTrimmedParameter(cell.parameters, "instrument"), TRADE_CELL_INSTRUMENTS);
+    const dir = toCanonicalEnumValue(getTrimmedParameter(cell.parameters, "direction"), TRADE_CELL_DIRECTIONS);
+    const sizing = toCanonicalEnumValue(getTrimmedParameter(cell.parameters, "sizingMethod"), TRADE_CELL_SIZING_METHODS);
+    if (!instr) {
       messages.push({ code: "TradeCellInstrumentRequired", severity: "error", targetId: cell.cellId, message: `${label} (trade) instrument must be Equity, Option, Future, or ETF.` });
     }
-    if (!dir || !validDirections.includes(dir)) {
+    if (!dir) {
       messages.push({ code: "TradeCellDirectionRequired", severity: "error", targetId: cell.cellId, message: `${label} (trade) direction must be Buy, Sell, SellShort, or BuyToCover.` });
     }
-    if (!sizing || !validSizing.includes(sizing)) {
+    if (!sizing) {
       messages.push({ code: "TradeCellSizingRequired", severity: "error", targetId: cell.cellId, message: `${label} (trade) sizingMethod must be FixedShares, FixedNotional, PercentAUM, or EqualWeight.` });
+    } else if (TRADE_CELL_SIZING_VALUE_REQUIRED_METHODS.includes(sizing)) {
+      const sizingValue = getTrimmedParameter(cell.parameters, "sizingValue");
+      if (!sizingValue || !Number.isFinite(Number(sizingValue))) {
+        messages.push({ code: "TradeCellSizingValueRequired", severity: "error", targetId: cell.cellId, message: `${label} (trade) sizingValue must be numeric when sizingMethod is ${sizing}.` });
+      }
     }
   }
 
@@ -2203,7 +2281,7 @@ function buildStrategyBuilderDatasetFingerprint(document: StrategyBuilderDocumen
   const source = [
     document.datasetReference,
     document.universe.join(","),
-    document.cells.flatMap((cell) => cell.fieldRefs).sort().join(","),
+    document.cells.flatMap((cell) => resolveCellFieldRefs(cell)).sort().join(","),
     document.version
   ].join("|");
   let hash = 0;

--- a/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.ts
@@ -259,7 +259,8 @@ function toCanonicalEnumValue<T extends string>(value: string | undefined, valid
     return null;
   }
 
-  const canonical = validValues.find((candidate) => candidate.toLowerCase() === value.toLowerCase());
+  const normalizedValue = value.toLowerCase();
+  const canonical = validValues.find((candidate) => candidate.toLowerCase() === normalizedValue);
   return canonical ?? null;
 }
 

--- a/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.ts
@@ -1210,15 +1210,23 @@ export function validateStrategyBuilderDocument(
   return messages;
 }
 
+function hasNonBlankParameterValue(value: unknown): boolean {
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+
+  return Boolean(value);
+}
+
 function validateCellKindParameters(cell: StrategyBuilderCell): StrategyBuilderValidationMessage[] {
   const messages: StrategyBuilderValidationMessage[] = [];
   const label = cell.label || cell.cellId;
 
   if (cell.kind === "state") {
-    if (!cell.parameters?.["exitCondition"]) {
+    if (!hasNonBlankParameterValue(cell.parameters?.["exitCondition"])) {
       messages.push({ code: "StateCellExitRequired", severity: "error", targetId: cell.cellId, message: `${label} (state) must define an exitCondition parameter.` });
     }
-    if (!cell.parameters?.["stateLabel"]) {
+    if (!hasNonBlankParameterValue(cell.parameters?.["stateLabel"])) {
       messages.push({ code: "StateCellLabelRequired", severity: "error", targetId: cell.cellId, message: `${label} (state) must define a stateLabel parameter.` });
     }
   }

--- a/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.ts
@@ -140,7 +140,17 @@ export interface StrategyLegDetailViewModel {
   fields: StrategyLegDetailFieldViewModel[];
 }
 
-export type StrategyBuilderCellKind = "visual" | "formula" | "code" | "governance" | "options-payoff";
+export type StrategyBuilderCellKind =
+  | "visual"
+  | "formula"
+  | "code"
+  | "governance"
+  | "options-payoff"
+  | "state"
+  | "concurrent"
+  | "universe-builder"
+  | "trade";
+
 export type StrategyBuilderCellPurpose =
   | "universe"
   | "filter"
@@ -148,7 +158,10 @@ export type StrategyBuilderCellPurpose =
   | "risk"
   | "backtest"
   | "governance"
-  | "options-payoff";
+  | "options-payoff"
+  | "state"
+  | "concurrent"
+  | "trade";
 export type StrategyBuilderMessageSeverity = "error" | "warning" | "info";
 
 export interface StrategyBuilderFieldCatalogItem {
@@ -187,6 +200,99 @@ export interface StrategyBuilderCell {
   purpose: StrategyBuilderCellPurpose;
   source: string;
   fieldRefs: string[];
+  parameters?: Record<string, string>;
+}
+
+export interface StateCellParameters {
+  entryCondition?: string;
+  exitCondition: string;
+  stateLabel: string;
+  isTerminal?: string;
+}
+
+export type ConcurrentCellSemantics = "all-pass" | "any-pass" | "first-wins";
+
+export interface ConcurrentCellParameters {
+  branchIds: string;
+  semantics: ConcurrentCellSemantics;
+}
+
+export interface UniverseBuilderCellParameters {
+  assetClass: string;
+  includeRules: string;
+  excludeRules?: string;
+  minSize?: string;
+  maxSize?: string;
+}
+
+export type TradeCellInstrumentType = "Equity" | "Option" | "Future" | "ETF";
+export type TradeCellDirection = "Buy" | "Sell" | "SellShort" | "BuyToCover";
+export type TradeCellSizingMethod = "FixedShares" | "FixedNotional" | "PercentAUM" | "EqualWeight";
+
+export interface TradeCellParameters {
+  instrument: TradeCellInstrumentType;
+  direction: TradeCellDirection;
+  sizingMethod: TradeCellSizingMethod;
+  priceConstraint?: string;
+  sizingValue?: string;
+}
+
+export function getStateCellParams(cell: StrategyBuilderCell): StateCellParameters | null {
+  if (cell.kind !== "state" || !cell.parameters) return null;
+  const exitCondition = cell.parameters["exitCondition"];
+  const stateLabel = cell.parameters["stateLabel"];
+  if (!exitCondition || !stateLabel) return null;
+  return {
+    entryCondition: cell.parameters["entryCondition"],
+    exitCondition,
+    stateLabel,
+    isTerminal: cell.parameters["isTerminal"]
+  };
+}
+
+export function getConcurrentCellParams(cell: StrategyBuilderCell): ConcurrentCellParameters | null {
+  if (cell.kind !== "concurrent" || !cell.parameters) return null;
+  const branchIds = cell.parameters["branchIds"];
+  const semantics = cell.parameters["semantics"] as ConcurrentCellSemantics | undefined;
+  const validSemantics: ConcurrentCellSemantics[] = ["all-pass", "any-pass", "first-wins"];
+  if (!branchIds || !semantics || !validSemantics.includes(semantics)) return null;
+  return { branchIds, semantics };
+}
+
+export function getUniverseBuilderCellParams(cell: StrategyBuilderCell): UniverseBuilderCellParameters | null {
+  if (cell.kind !== "universe-builder" || !cell.parameters) return null;
+  const assetClass = cell.parameters["assetClass"];
+  const includeRules = cell.parameters["includeRules"];
+  if (!assetClass || !includeRules) return null;
+  return {
+    assetClass,
+    includeRules,
+    excludeRules: cell.parameters["excludeRules"],
+    minSize: cell.parameters["minSize"],
+    maxSize: cell.parameters["maxSize"]
+  };
+}
+
+export function getTradeCellParams(cell: StrategyBuilderCell): TradeCellParameters | null {
+  if (cell.kind !== "trade" || !cell.parameters) return null;
+  const instrument = cell.parameters["instrument"] as TradeCellInstrumentType | undefined;
+  const direction = cell.parameters["direction"] as TradeCellDirection | undefined;
+  const sizingMethod = cell.parameters["sizingMethod"] as TradeCellSizingMethod | undefined;
+  const validInstruments: TradeCellInstrumentType[] = ["Equity", "Option", "Future", "ETF"];
+  const validDirections: TradeCellDirection[] = ["Buy", "Sell", "SellShort", "BuyToCover"];
+  const validSizing: TradeCellSizingMethod[] = ["FixedShares", "FixedNotional", "PercentAUM", "EqualWeight"];
+  if (
+    !instrument || !validInstruments.includes(instrument) ||
+    !direction || !validDirections.includes(direction) ||
+    !sizingMethod || !validSizing.includes(sizingMethod)
+  ) return null;
+  return {
+    instrument,
+    direction,
+    sizingMethod,
+    priceConstraint: cell.parameters["priceConstraint"],
+    sizingValue: cell.parameters["sizingValue"]
+  };
 }
 
 export interface StrategyBuilderTransition {
@@ -614,6 +720,184 @@ const STRATEGY_BUILDER_TEMPLATES: StrategyBuilderTemplate[] = [
       disabled: false,
       disabledReason: null
     }
+  },
+  {
+    templateId: "state-machine-strategy",
+    name: "State machine strategy",
+    description: "Named execution states with entry/exit conditions — model a strategy as a lifecycle state machine.",
+    category: "Advanced",
+    tags: ["state", "lifecycle", "conditional"],
+    document: {
+      documentId: "state-machine-strategy",
+      name: "State machine strategy",
+      description: "Strategy execution modelled as a state machine with named checkpoints.",
+      version: "1",
+      datasetReference: "provider-bars/equities/daily",
+      universe: ["SPY", "QQQ"],
+      cells: [
+        {
+          cellId: "watching-state",
+          label: "Watching",
+          kind: "state",
+          purpose: "state",
+          source: "initial monitoring phase",
+          fieldRefs: ["MOMENTUM_63D"],
+          parameters: { stateLabel: "Watching", exitCondition: "MOMENTUM_63D > 0.05", entryCondition: "PORTFOLIO_WEIGHT == 0", isTerminal: "false" }
+        },
+        {
+          cellId: "holding-state",
+          label: "Holding",
+          kind: "state",
+          purpose: "state",
+          source: "active position phase",
+          fieldRefs: ["MOMENTUM_63D", "VOLATILITY_20D"],
+          parameters: { stateLabel: "Holding", exitCondition: "MOMENTUM_63D < 0 || VOLATILITY_20D > 0.35", isTerminal: "false" }
+        },
+        {
+          cellId: "exiting-state",
+          label: "Exiting",
+          kind: "state",
+          purpose: "state",
+          source: "position wind-down phase",
+          fieldRefs: ["PORTFOLIO_WEIGHT"],
+          parameters: { stateLabel: "Exiting", exitCondition: "PORTFOLIO_WEIGHT == 0", isTerminal: "true" }
+        },
+        { cellId: "state-risk-guard", label: "State risk guard", kind: "governance", purpose: "risk", source: "VOLATILITY_20D < 0.40", fieldRefs: ["VOLATILITY_20D"] }
+      ],
+      transitions: [
+        { transitionId: "t1", fromCellId: "watching-state", toCellId: "holding-state", kind: "next", condition: "exit: MOMENTUM_63D > 0.05" },
+        { transitionId: "t2", fromCellId: "holding-state", toCellId: "exiting-state", kind: "next", condition: "exit: MOMENTUM_63D < 0 || VOLATILITY_20D > 0.35" },
+        { transitionId: "t3", fromCellId: "exiting-state", toCellId: "state-risk-guard", kind: "next", condition: "position closed" }
+      ],
+      updatedAt: "2026-05-15T00:00:00Z"
+    },
+    loadCommand: {
+      label: "Load",
+      ariaLabel: "Load State machine strategy template",
+      disabled: false,
+      disabledReason: null
+    }
+  },
+  {
+    templateId: "concurrent-branch-strategy",
+    name: "Concurrent branch strategy",
+    description: "Parallel evaluation point — multiple signal branches run simultaneously with configurable pass semantics.",
+    category: "Advanced",
+    tags: ["concurrent", "parallel", "multi-signal"],
+    document: {
+      documentId: "concurrent-branch-strategy",
+      name: "Concurrent branch strategy",
+      description: "Parallel signal evaluation: equity momentum and volatility screens run concurrently.",
+      version: "1",
+      datasetReference: "provider-bars/equities/daily",
+      universe: ["SPY", "QQQ", "AAPL"],
+      cells: [
+        { cellId: "momentum-branch", label: "Momentum signal", kind: "formula", purpose: "filter", source: "MOMENTUM_63D > 0.05", fieldRefs: ["MOMENTUM_63D"] },
+        { cellId: "volatility-branch", label: "Volatility filter", kind: "formula", purpose: "filter", source: "VOLATILITY_20D < 0.30", fieldRefs: ["VOLATILITY_20D"] },
+        {
+          cellId: "concurrent-gate",
+          label: "Concurrent signal gate",
+          kind: "concurrent",
+          purpose: "concurrent",
+          source: "parallel branch evaluation",
+          fieldRefs: [],
+          parameters: { branchIds: "momentum-branch,volatility-branch", semantics: "all-pass" }
+        },
+        { cellId: "concurrent-risk", label: "Risk guard", kind: "governance", purpose: "risk", source: "all concurrent branches satisfied", fieldRefs: ["PORTFOLIO_WEIGHT"] }
+      ],
+      transitions: [
+        { transitionId: "t1", fromCellId: "momentum-branch", toCellId: "concurrent-gate", kind: "next", condition: "branch ready" },
+        { transitionId: "t2", fromCellId: "volatility-branch", toCellId: "concurrent-gate", kind: "next", condition: "branch ready" },
+        { transitionId: "t3", fromCellId: "concurrent-gate", toCellId: "concurrent-risk", kind: "next", condition: "gate resolved" }
+      ],
+      updatedAt: "2026-05-15T00:00:00Z"
+    },
+    loadCommand: {
+      label: "Load",
+      ariaLabel: "Load Concurrent branch strategy template",
+      disabled: false,
+      disabledReason: null
+    }
+  },
+  {
+    templateId: "structured-universe-strategy",
+    name: "Structured universe strategy",
+    description: "Explicit asset class, include/exclude rules, and size constraints for disciplined universe construction.",
+    category: "Universe",
+    tags: ["universe-builder", "structured", "equity"],
+    document: {
+      documentId: "structured-universe-strategy",
+      name: "Structured universe strategy",
+      description: "Universe-builder cell with explicit asset class rules and size bounds.",
+      version: "1",
+      datasetReference: "provider-bars/equities/daily",
+      universe: ["SPY"],
+      cells: [
+        {
+          cellId: "equity-universe",
+          label: "Liquid equity universe",
+          kind: "universe-builder",
+          purpose: "universe",
+          source: "structured universe definition",
+          fieldRefs: ["PRICE", "MOMENTUM_63D"],
+          parameters: { assetClass: "Equity", includeRules: "PRICE > 10, MOMENTUM_63D > 0", excludeRules: "VOLATILITY_20D > 0.40", minSize: "20", maxSize: "100" }
+        },
+        { cellId: "universe-rank", label: "Momentum rank", kind: "formula", purpose: "rank", source: "MOMENTUM_63D - VOLATILITY_20D", fieldRefs: ["MOMENTUM_63D", "VOLATILITY_20D"] },
+        { cellId: "universe-risk", label: "Universe risk guard", kind: "governance", purpose: "risk", source: "VOLATILITY_20D < 0.30", fieldRefs: ["VOLATILITY_20D"] }
+      ],
+      transitions: [
+        { transitionId: "t1", fromCellId: "equity-universe", toCellId: "universe-rank", kind: "next", condition: "universe built" },
+        { transitionId: "t2", fromCellId: "universe-rank", toCellId: "universe-risk", kind: "next", condition: "rank complete" }
+      ],
+      updatedAt: "2026-05-15T00:00:00Z"
+    },
+    loadCommand: {
+      label: "Load",
+      ariaLabel: "Load Structured universe strategy template",
+      disabled: false,
+      disabledReason: null
+    }
+  },
+  {
+    templateId: "trade-intent-strategy",
+    name: "Trade intent strategy",
+    description: "Explicit trade definition cell — instrument type, direction, sizing method, and price constraint.",
+    category: "Execution",
+    tags: ["trade", "execution", "sizing"],
+    document: {
+      documentId: "trade-intent-strategy",
+      name: "Trade intent strategy",
+      description: "Strategy with an explicit trade cell defining instrument, direction, and sizing.",
+      version: "1",
+      datasetReference: "provider-bars/equities/daily",
+      universe: ["SPY", "QQQ"],
+      cells: [
+        { cellId: "trade-universe", label: "Liquid equity filter", kind: "visual", purpose: "universe", source: "PRICE > 20", fieldRefs: ["PRICE"] },
+        { cellId: "trade-rank", label: "Momentum score", kind: "formula", purpose: "rank", source: "MOMENTUM_63D - VOLATILITY_20D", fieldRefs: ["MOMENTUM_63D", "VOLATILITY_20D"] },
+        {
+          cellId: "buy-equities",
+          label: "Buy equities",
+          kind: "trade",
+          purpose: "trade",
+          source: "execute buy order on ranked universe",
+          fieldRefs: [],
+          parameters: { instrument: "Equity", direction: "Buy", sizingMethod: "EqualWeight", priceConstraint: "VWAP", sizingValue: "0.05" }
+        },
+        { cellId: "trade-risk", label: "Execution risk guard", kind: "governance", purpose: "risk", source: "VOLATILITY_20D < 0.30 && PORTFOLIO_WEIGHT <= 0.10", fieldRefs: ["VOLATILITY_20D", "PORTFOLIO_WEIGHT"] }
+      ],
+      transitions: [
+        { transitionId: "t1", fromCellId: "trade-universe", toCellId: "trade-rank", kind: "next", condition: "universe ready" },
+        { transitionId: "t2", fromCellId: "trade-rank", toCellId: "buy-equities", kind: "next", condition: "rank complete" },
+        { transitionId: "t3", fromCellId: "buy-equities", toCellId: "trade-risk", kind: "next", condition: "trade submitted" }
+      ],
+      updatedAt: "2026-05-15T00:00:00Z"
+    },
+    loadCommand: {
+      label: "Load",
+      ariaLabel: "Load Trade intent strategy template",
+      disabled: false,
+      disabledReason: null
+    }
   }
 ];
 
@@ -855,6 +1139,8 @@ export function validateStrategyBuilderDocument(
       });
     }
 
+    messages.push(...validateCellKindParameters(cell));
+
     for (const ref of cell.fieldRefs) {
       const field = fieldMap.get(ref);
       if (!field) {
@@ -919,6 +1205,60 @@ export function validateStrategyBuilderDocument(
       targetId: document.documentId,
       message: "Add a risk or governance cell before promotion review."
     });
+  }
+
+  return messages;
+}
+
+function validateCellKindParameters(cell: StrategyBuilderCell): StrategyBuilderValidationMessage[] {
+  const messages: StrategyBuilderValidationMessage[] = [];
+  const label = cell.label || cell.cellId;
+
+  if (cell.kind === "state") {
+    if (!cell.parameters?.["exitCondition"]) {
+      messages.push({ code: "StateCellExitRequired", severity: "error", targetId: cell.cellId, message: `${label} (state) must define an exitCondition parameter.` });
+    }
+    if (!cell.parameters?.["stateLabel"]) {
+      messages.push({ code: "StateCellLabelRequired", severity: "error", targetId: cell.cellId, message: `${label} (state) must define a stateLabel parameter.` });
+    }
+  }
+
+  if (cell.kind === "concurrent") {
+    if (!cell.parameters?.["branchIds"]) {
+      messages.push({ code: "ConcurrentCellBranchesRequired", severity: "error", targetId: cell.cellId, message: `${label} (concurrent) must define a branchIds parameter listing the parallel cell IDs.` });
+    }
+    const validSemantics: ConcurrentCellSemantics[] = ["all-pass", "any-pass", "first-wins"];
+    const sem = cell.parameters?.["semantics"];
+    if (!sem || !validSemantics.includes(sem as ConcurrentCellSemantics)) {
+      messages.push({ code: "ConcurrentCellSemanticsRequired", severity: "error", targetId: cell.cellId, message: `${label} (concurrent) semantics must be one of: all-pass, any-pass, first-wins.` });
+    }
+  }
+
+  if (cell.kind === "universe-builder") {
+    if (!cell.parameters?.["assetClass"]) {
+      messages.push({ code: "UniverseBuilderAssetClassRequired", severity: "error", targetId: cell.cellId, message: `${label} (universe-builder) must define an assetClass parameter.` });
+    }
+    if (!cell.parameters?.["includeRules"]) {
+      messages.push({ code: "UniverseBuilderIncludeRulesRequired", severity: "error", targetId: cell.cellId, message: `${label} (universe-builder) must define at least one includeRules parameter.` });
+    }
+  }
+
+  if (cell.kind === "trade") {
+    const validInstruments: TradeCellInstrumentType[] = ["Equity", "Option", "Future", "ETF"];
+    const validDirections: TradeCellDirection[] = ["Buy", "Sell", "SellShort", "BuyToCover"];
+    const validSizing: TradeCellSizingMethod[] = ["FixedShares", "FixedNotional", "PercentAUM", "EqualWeight"];
+    const instr = cell.parameters?.["instrument"] as TradeCellInstrumentType | undefined;
+    const dir = cell.parameters?.["direction"] as TradeCellDirection | undefined;
+    const sizing = cell.parameters?.["sizingMethod"] as TradeCellSizingMethod | undefined;
+    if (!instr || !validInstruments.includes(instr)) {
+      messages.push({ code: "TradeCellInstrumentRequired", severity: "error", targetId: cell.cellId, message: `${label} (trade) instrument must be Equity, Option, Future, or ETF.` });
+    }
+    if (!dir || !validDirections.includes(dir)) {
+      messages.push({ code: "TradeCellDirectionRequired", severity: "error", targetId: cell.cellId, message: `${label} (trade) direction must be Buy, Sell, SellShort, or BuyToCover.` });
+    }
+    if (!sizing || !validSizing.includes(sizing)) {
+      messages.push({ code: "TradeCellSizingRequired", severity: "error", targetId: cell.cellId, message: `${label} (trade) sizingMethod must be FixedShares, FixedNotional, PercentAUM, or EqualWeight.` });
+    }
   }
 
   return messages;
@@ -1660,7 +2000,8 @@ function cloneStrategyBuilderDocument(document: StrategyBuilderDocument): Strate
     universe: [...document.universe],
     cells: document.cells.map((cell) => ({
       ...cell,
-      fieldRefs: [...cell.fieldRefs]
+      fieldRefs: [...cell.fieldRefs],
+      parameters: cell.parameters ? { ...cell.parameters } : undefined
     })),
     transitions: document.transitions.map((transition) => ({ ...transition }))
   };
@@ -1762,6 +2103,64 @@ function buildStrategyBuilderTrace(
   return trace;
 }
 
+function buildKindDescription(cell: StrategyBuilderCell, mappedCount: number): string {
+  switch (cell.kind) {
+    case "state":
+      return `State machine node. Exit: ${cell.parameters?.["exitCondition"] ?? "(not set)"}.`;
+    case "concurrent":
+      return `Parallel evaluation point (${cell.parameters?.["semantics"] ?? "semantics not set"}).`;
+    case "universe-builder":
+      return `Structured universe for ${cell.parameters?.["assetClass"] ?? "(asset class not set)"}.`;
+    case "trade":
+      return `Trade intent: ${cell.parameters?.["direction"] ?? "?"} ${cell.parameters?.["instrument"] ?? "?"} via ${cell.parameters?.["sizingMethod"] ?? "?"}.`;
+    default:
+      return `${cell.purpose} stage with ${mappedCount} mapped field${mappedCount === 1 ? "" : "s"}.`;
+  }
+}
+
+function buildKindParameterFields(cell: StrategyBuilderCell): StrategyLegDetailFieldViewModel[] {
+  if (cell.kind === "state") {
+    const p = getStateCellParams(cell);
+    if (!p) return [];
+    return [
+      { id: "state-label", label: "State label", value: p.stateLabel, tone: "default" },
+      { id: "exit-condition", label: "Exit condition", value: p.exitCondition, tone: "default" },
+      { id: "entry-condition", label: "Entry condition", value: p.entryCondition ?? "(none)", tone: p.entryCondition ? "default" : "muted" },
+      { id: "is-terminal", label: "Terminal state", value: p.isTerminal === "true" ? "Yes" : "No", tone: p.isTerminal === "true" ? "warning" : "muted" }
+    ];
+  }
+  if (cell.kind === "concurrent") {
+    const p = getConcurrentCellParams(cell);
+    if (!p) return [];
+    return [
+      { id: "branch-ids", label: "Branch cell IDs", value: p.branchIds, tone: "default" },
+      { id: "semantics", label: "Evaluation semantics", value: p.semantics, tone: "default" }
+    ];
+  }
+  if (cell.kind === "universe-builder") {
+    const p = getUniverseBuilderCellParams(cell);
+    if (!p) return [];
+    return [
+      { id: "asset-class", label: "Asset class", value: p.assetClass, tone: "default" },
+      { id: "include-rules", label: "Include rules", value: p.includeRules, tone: "default" },
+      { id: "exclude-rules", label: "Exclude rules", value: p.excludeRules ?? "(none)", tone: p.excludeRules ? "default" : "muted" },
+      { id: "size-constraints", label: "Size constraints", value: `min ${p.minSize ?? "—"} / max ${p.maxSize ?? "—"}`, tone: "default" }
+    ];
+  }
+  if (cell.kind === "trade") {
+    const p = getTradeCellParams(cell);
+    if (!p) return [];
+    return [
+      { id: "instrument", label: "Instrument type", value: p.instrument, tone: "default" },
+      { id: "direction", label: "Direction", value: p.direction, tone: p.direction === "Buy" || p.direction === "BuyToCover" ? "success" : "warning" },
+      { id: "sizing-method", label: "Sizing method", value: p.sizingMethod, tone: "default" },
+      { id: "price-constraint", label: "Price constraint", value: p.priceConstraint ?? "Market", tone: p.priceConstraint ? "default" : "muted" },
+      { id: "sizing-value", label: "Sizing value", value: p.sizingValue ?? "—", tone: "default" }
+    ];
+  }
+  return [];
+}
+
 function buildStrategyBuilderCellDetail(
   cell: StrategyBuilderCell,
   fieldMap: Map<string, StrategyBuilderFieldCatalogItem>
@@ -1774,7 +2173,7 @@ function buildStrategyBuilderCellDetail(
     id: STRATEGY_BUILDER_SELECTED_CELL_DETAIL_PANEL_ID,
     title: cell.label,
     eyebrow: `${cell.kind} cell`,
-    description: `${cell.purpose} stage with ${mapped.length} mapped field${mapped.length === 1 ? "" : "s"}.`,
+    description: buildKindDescription(cell, mapped.length),
     source: cell.source,
     ariaLabel: `Strategy builder cell detail for ${cell.label}`,
     fields: [
@@ -1786,7 +2185,8 @@ function buildStrategyBuilderCellDetail(
         label: "Fields",
         value: cell.fieldRefs.length > 0 ? cell.fieldRefs.join(", ") : "None",
         tone: cell.fieldRefs.some((fieldRef) => fieldMap.get(fieldRef)?.isEnabled === false) ? "danger" : "default"
-      }
+      },
+      ...buildKindParameterFields(cell)
     ]
   };
 }

--- a/tests/Meridian.Tests/Strategies/StrategyDesignServiceTests.cs
+++ b/tests/Meridian.Tests/Strategies/StrategyDesignServiceTests.cs
@@ -87,6 +87,102 @@ public sealed class StrategyDesignServiceTests
         validation.Messages.Should().Contain(message => message.Code == "LoopRationaleRequired");
     }
 
+    [Fact]
+    public void Validate_StateCellMissingExitCondition_ShouldBlock()
+    {
+        var service = new StrategyDesignService();
+        var document = service.Normalize(BuildDocument(cells:
+        [
+            new("state-node", "Monitoring", "state", "state", "monitoring phase", [],
+                new Dictionary<string, string> { ["stateLabel"] = "Monitoring" }),
+            new("risk", "Risk guard", "governance", "risk", "VOLATILITY_20D < 0.3", ["VOLATILITY_20D"])
+        ]));
+
+        var result = service.Validate(document);
+
+        result.IsValid.Should().BeFalse();
+        result.Messages.Should().Contain(m => m.Code == "StateCellExitRequired");
+        result.Messages.Should().NotContain(m => m.Code == "StateCellLabelRequired");
+    }
+
+    [Fact]
+    public void Validate_TradeCellWithAllRequiredParameters_ShouldPass()
+    {
+        var service = new StrategyDesignService();
+        var document = service.Normalize(BuildDocument(cells:
+        [
+            new("filter", "Filter universe", "visual", "filter", "PRICE > 20", ["PRICE"]),
+            new("trade-cell", "Buy equities", "trade", "trade", "execute buy order", [],
+                new Dictionary<string, string>
+                {
+                    ["instrument"] = "Equity",
+                    ["direction"] = "Buy",
+                    ["sizingMethod"] = "EqualWeight",
+                    ["priceConstraint"] = "VWAP"
+                }),
+            new("risk", "Risk guard", "governance", "risk", "VOLATILITY_20D < 0.3", ["VOLATILITY_20D"])
+        ]));
+
+        var result = service.Validate(document);
+
+        result.IsValid.Should().BeTrue(result.Summary);
+        result.Messages.Should().NotContain(m =>
+            m.Code == "TradeCellInstrumentRequired" ||
+            m.Code == "TradeCellDirectionRequired" ||
+            m.Code == "TradeCellSizingRequired");
+    }
+
+    [Fact]
+    public void Validate_ConcurrentCellWithBadSemantics_ShouldBlock()
+    {
+        var service = new StrategyDesignService();
+        var document = service.Normalize(BuildDocument(cells:
+        [
+            new("parallel", "Parallel check", "concurrent", "concurrent", "parallel eval", [],
+                new Dictionary<string, string>
+                {
+                    ["branchIds"] = "cell-a,cell-b",
+                    ["semantics"] = "bad-value"
+                }),
+            new("risk", "Risk guard", "governance", "risk", "true", [])
+        ]));
+
+        var result = service.Validate(document);
+
+        result.IsValid.Should().BeFalse();
+        result.Messages.Should().Contain(m => m.Code == "ConcurrentCellSemanticsRequired");
+    }
+
+    [Fact]
+    public void Validate_UniverseBuilderCellMissingAssetClass_ShouldBlock()
+    {
+        var service = new StrategyDesignService();
+        var document = service.Normalize(BuildDocument(cells:
+        [
+            new("ub", "Universe", "universe-builder", "universe", "build universe", ["PRICE"],
+                new Dictionary<string, string> { ["includeRules"] = "PRICE > 10" }),
+            new("risk", "Risk guard", "governance", "risk", "true", [])
+        ]));
+
+        var result = service.Validate(document);
+
+        result.IsValid.Should().BeFalse();
+        result.Messages.Should().Contain(m => m.Code == "UniverseBuilderAssetClassRequired");
+        result.Messages.Should().NotContain(m => m.Code == "UniverseBuilderIncludeRulesRequired");
+    }
+
+    [Fact]
+    public void Validate_FullyPopulatedStateCellTemplate_ShouldPass()
+    {
+        var service = new StrategyDesignService();
+        var template = service.GetTemplates().Single(t => t.TemplateId == "state-machine-strategy");
+        var document = service.Normalize(template.Document);
+
+        var result = service.Validate(document);
+
+        result.IsValid.Should().BeTrue(result.Summary);
+    }
+
     private static StrategyDesignDocument BuildDocument(
         IReadOnlyList<StrategyDesignCell>? cells = null,
         IReadOnlyList<StrategyDesignTransition>? transitions = null)

--- a/tests/Meridian.Tests/Strategies/StrategyDesignServiceTests.cs
+++ b/tests/Meridian.Tests/Strategies/StrategyDesignServiceTests.cs
@@ -154,6 +154,28 @@ public sealed class StrategyDesignServiceTests
     }
 
     [Fact]
+    public void Validate_ConcurrentCellWithMissingBranch_ShouldBlock()
+    {
+        var service = new StrategyDesignService();
+        var document = service.Normalize(BuildDocument(cells:
+        [
+            new("rank", "Rank", "formula", "rank", "MOMENTUM_63D > 0", ["MOMENTUM_63D"]),
+            new("parallel", "Parallel check", "concurrent", "concurrent", "parallel eval", [],
+                new Dictionary<string, string>
+                {
+                    ["branchIds"] = "rank,missing-cell",
+                    ["semantics"] = "all-pass"
+                }),
+            new("risk", "Risk guard", "governance", "risk", "true", [])
+        ]));
+
+        var result = service.Validate(document);
+
+        result.IsValid.Should().BeFalse();
+        result.Messages.Should().Contain(m => m.Code == "ConcurrentCellBranchMissing");
+    }
+
+    [Fact]
     public void Validate_UniverseBuilderCellMissingAssetClass_ShouldBlock()
     {
         var service = new StrategyDesignService();
@@ -169,6 +191,105 @@ public sealed class StrategyDesignServiceTests
         result.IsValid.Should().BeFalse();
         result.Messages.Should().Contain(m => m.Code == "UniverseBuilderAssetClassRequired");
         result.Messages.Should().NotContain(m => m.Code == "UniverseBuilderIncludeRulesRequired");
+    }
+
+    [Fact]
+    public void Validate_UniverseBuilderInvalidSizeConstraints_ShouldBlock()
+    {
+        var service = new StrategyDesignService();
+        var document = service.Normalize(BuildDocument(cells:
+        [
+            new("ub", "Universe", "universe-builder", "universe", "build universe", [],
+                new Dictionary<string, string>
+                {
+                    ["assetClass"] = "Equity",
+                    ["includeRules"] = "PRICE > 10",
+                    ["minSize"] = "101",
+                    ["maxSize"] = "100"
+                }),
+            new("risk", "Risk guard", "governance", "risk", "true", [])
+        ]));
+
+        var result = service.Validate(document);
+
+        result.IsValid.Should().BeFalse();
+        result.Messages.Should().Contain(m => m.Code == "UniverseBuilderSizeRangeInvalid");
+    }
+
+    [Fact]
+    public void Validate_UniverseBuilderRulesWithUnknownField_ShouldBlock()
+    {
+        var service = new StrategyDesignService();
+        var document = service.Normalize(BuildDocument(cells:
+        [
+            new("ub", "Universe", "universe-builder", "universe", "build universe", ["PRICE"],
+                new Dictionary<string, string>
+                {
+                    ["assetClass"] = "Equity",
+                    ["includeRules"] = "UNKNOWN_FIELD > 10"
+                }),
+            new("risk", "Risk guard", "governance", "risk", "true", [])
+        ]));
+
+        var result = service.Validate(document);
+
+        result.IsValid.Should().BeFalse();
+        result.Messages.Should().Contain(m => m.Code == "UnknownField" && m.TargetId == "ub");
+    }
+
+    [Fact]
+    public void Validate_TradeCellFixedSizingWithoutNumericValue_ShouldBlock()
+    {
+        var service = new StrategyDesignService();
+        var document = service.Normalize(BuildDocument(cells:
+        [
+            new("trade-cell", "Buy equities", "trade", "trade", "execute buy order", [],
+                new Dictionary<string, string>
+                {
+                    ["instrument"] = "Equity",
+                    ["direction"] = "Buy",
+                    ["sizingMethod"] = "FixedShares",
+                    ["sizingValue"] = "not-a-number"
+                }),
+            new("risk", "Risk guard", "governance", "risk", "true", [])
+        ]));
+
+        var result = service.Validate(document);
+
+        result.IsValid.Should().BeFalse();
+        result.Messages.Should().Contain(m => m.Code == "TradeCellSizingValueRequired");
+    }
+
+    [Fact]
+    public void Normalize_TradeAndConcurrentParameters_ShouldCanonicalizeEnums()
+    {
+        var service = new StrategyDesignService();
+        var document = BuildDocument(cells:
+        [
+            new("parallel", "Parallel check", "concurrent", "concurrent", "parallel eval", [],
+                new Dictionary<string, string>
+                {
+                    ["branchIds"] = "rank",
+                    ["semantics"] = "ALL-PASS"
+                }),
+            new("trade-cell", "Buy equities", "trade", "trade", "execute buy order", [],
+                new Dictionary<string, string>
+                {
+                    ["instrument"] = "equity",
+                    ["direction"] = "buy",
+                    ["sizingMethod"] = "equalweight"
+                }),
+            new("rank", "Rank", "formula", "rank", "MOMENTUM_63D > 0", ["MOMENTUM_63D"])
+        ]);
+
+        var normalized = service.Normalize(document);
+        var concurrent = normalized.Cells.Single(cell => cell.CellId == "parallel");
+        var trade = normalized.Cells.Single(cell => cell.CellId == "trade-cell");
+
+        concurrent.Parameters!["semantics"].Should().Be("all-pass");
+        trade.Parameters!["instrument"].Should().Be("Equity");
+        trade.Parameters!["direction"].Should().Be("Buy");
+        trade.Parameters!["sizingMethod"].Should().Be("EqualWeight");
     }
 
     [Fact]


### PR DESCRIPTION
## Description

This PR extends the strategy builder with four new cell kinds that enable more sophisticated strategy modeling:

- **State cells** (`state`): Named execution states with entry/exit conditions for lifecycle state machine modeling
- **Concurrent cells** (`concurrent`): Parallel evaluation points with configurable pass semantics (all-pass, any-pass, first-wins)
- **Universe-builder cells** (`universe-builder`): Structured asset class and rule-based universe construction with size constraints
- **Trade cells** (`trade`): Explicit trade intent definition with instrument type, direction, sizing method, and price constraints

Each new cell kind includes:
- Type-safe parameter interfaces (`StateCellParameters`, `ConcurrentCellParameters`, `UniverseBuilderCellParameters`, `TradeCellParameters`)
- Typed parameter extraction functions (`getStateCellParams`, `getConcurrentCellParams`, `getUniverseBuilderCellParams`, `getTradeCellParams`)
- Validation logic in both TypeScript and C# to enforce required parameters and valid enum values
- Four new template strategies demonstrating each cell kind in realistic workflows
- Inspector UI that surfaces typed parameters as structured fields with appropriate tone/styling
- Canvas rendering with kind-specific icons and badges

## Type of Change

- New feature
- Code refactoring
- Test improvements

## Motivation and Context

The strategy builder previously supported only basic cell kinds (visual, formula, code, governance, options-payoff). These new cell kinds enable:

1. **State machines**: Model strategies as lifecycle state machines with named checkpoints and conditional transitions
2. **Parallel signal evaluation**: Run multiple signal branches concurrently with explicit pass semantics
3. **Disciplined universe construction**: Define asset class, inclusion/exclusion rules, and size bounds explicitly
4. **Explicit trade execution**: Specify instrument, direction, sizing method, and price constraints as first-class strategy elements

The implementation maintains backward compatibility while adding structured parameter support to the `StrategyBuilderCell` interface.

## How Has This Been Tested?

- Added 10 new unit tests covering parameter validation, extraction, template loading, and UI rendering
- Added 3 new integration tests verifying template loading and inspector field population
- Added 5 new C# validation tests covering parameter requirements and edge cases
- All existing tests continue to pass
- Four new template strategies included with full validation coverage

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have checked my code and corrected any misspellings
- [x] My changes generate no new warnings

## Related Issues

None

## Additional Notes

The implementation is split across:
- `src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.ts` - TypeScript types, validators, extractors, templates, and UI view model builders
- `src/Meridian.Strategies/Services/StrategyDesignService.cs` - C# validation and template definitions
- Test files with comprehensive coverage of validation, extraction, and UI rendering

All parameter validation is performed consistently in both TypeScript and C# to ensure parity between client and server validation.

https://claude.ai/code/session_01ULHzoenDsS44aY275BbZph