### PR TITLE
Add acceptance test: readiness/inbox severity parity across Wave2 lanes

### DIFF
--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -1297,6 +1297,110 @@ public sealed class WorkstationEndpointsTests
     }
 
     [Fact]
+    public async Task MapWorkstationEndpoints_OperatorInbox_ShouldMatchReadinessSeverityAcrossWave2Lanes()
+    {
+        await using var app = await CreateAppAsync(services =>
+        {
+            RegisterRunReadServices(services);
+            services.AddSingleton<IReconciliationRunRepository, InMemoryReconciliationRunRepository>();
+            services.AddSingleton<ReconciliationProjectionService>();
+            services.AddSingleton<IReconciliationRunService, ReconciliationRunService>();
+        });
+
+        var runId = $"run-severity-parity-{Guid.NewGuid():N}";
+        var store = app.Services.GetRequiredService<IStrategyRepository>();
+        await store.RecordRunAsync(BuildReconciliationMismatchRun(runId));
+        var reconciliation = await app.Services
+            .GetRequiredService<IReconciliationRunService>()
+            .RunAsync(new ReconciliationRunRequest(runId));
+        reconciliation.Should().NotBeNull();
+
+        var client = app.GetTestClient();
+        var readiness = await client.GetFromJsonAsync<TradingOperatorReadinessDto>(
+            "/api/workstation/trading/readiness",
+            ServerJsonOptions);
+        var inbox = await client.GetFromJsonAsync<OperatorInboxDto>(
+            "/api/workstation/operator/inbox",
+            ServerJsonOptions);
+
+        readiness.Should().NotBeNull();
+        inbox.Should().NotBeNull();
+
+        var readinessSeverityByCategory = NormalizeReadinessSeverity(readiness!.WorkItems);
+        var inboxSeverityByCategory = NormalizeInboxSeverity(inbox!.Items);
+
+        AssertCategoryParity("replay", readinessSeverityByCategory, inboxSeverityByCategory, "paper-session-missing");
+        AssertCategoryParity("controls", readinessSeverityByCategory, inboxSeverityByCategory, "execution-evidence-incomplete");
+        AssertCategoryParity("promotion-traceability", readinessSeverityByCategory, inboxSeverityByCategory, "promotion-decision-missing");
+        AssertCategoryParity("reconciliation", readinessSeverityByCategory, inboxSeverityByCategory, "reconciliation-break-");
+        AssertCategoryParity("dk1-trust-gate", readinessSeverityByCategory, inboxSeverityByCategory, "dk1-trust-packet-unavailable");
+
+        static Dictionary<string, int> NormalizeReadinessSeverity(IEnumerable<OperatorWorkItemDto> items)
+            => items.GroupBy(static item => GetCategory(item.WorkItemId))
+                .ToDictionary(static group => group.Key, static group => group.Max(item => ToSeverityRank(item.Tone)), StringComparer.OrdinalIgnoreCase);
+
+        static Dictionary<string, int> NormalizeInboxSeverity(IEnumerable<OperatorWorkItemDto> items)
+            => items.GroupBy(static item => GetCategory(item.WorkItemId))
+                .ToDictionary(static group => group.Key, static group => group.Max(item => ToSeverityRank(item.Tone)), StringComparer.OrdinalIgnoreCase);
+
+        static string GetCategory(string workItemId)
+        {
+            if (workItemId.StartsWith("paper-session-", StringComparison.OrdinalIgnoreCase) ||
+                workItemId.StartsWith("paper-replay-", StringComparison.OrdinalIgnoreCase))
+            {
+                return "replay";
+            }
+
+            if (workItemId.StartsWith("execution-", StringComparison.OrdinalIgnoreCase))
+            {
+                return "controls";
+            }
+
+            if (workItemId.StartsWith("promotion-", StringComparison.OrdinalIgnoreCase))
+            {
+                return "promotion-traceability";
+            }
+
+            if (workItemId.StartsWith("reconciliation-break-", StringComparison.OrdinalIgnoreCase))
+            {
+                return "reconciliation";
+            }
+
+            if (workItemId.StartsWith("dk1-trust-", StringComparison.OrdinalIgnoreCase))
+            {
+                return "dk1-trust-gate";
+            }
+
+            return $"other:{workItemId}";
+        }
+
+        static int ToSeverityRank(OperatorWorkItemToneDto tone) =>
+            tone switch
+            {
+                OperatorWorkItemToneDto.Critical => 2,
+                OperatorWorkItemToneDto.Warning => 1,
+                _ => 0
+            };
+
+        static void AssertCategoryParity(
+            string category,
+            IReadOnlyDictionary<string, int> readiness,
+            IReadOnlyDictionary<string, int> inbox,
+            string expectedAnchorId)
+        {
+            readiness.ContainsKey(category).Should().BeTrue(
+                $"readiness lane should expose {category} via anchor '{expectedAnchorId}'");
+            inbox.ContainsKey(category).Should().BeTrue(
+                $"inbox lane should expose {category} via anchor '{expectedAnchorId}'");
+
+            var readinessSeverity = readiness[category];
+            var inboxSeverity = inbox[category];
+            inboxSeverity.Should().Be(readinessSeverity,
+                $"severity drift detected for {category} (anchor '{expectedAnchorId}')");
+        }
+    }
+
+    [Fact]
     public async Task MapWorkstationEndpoints_OperatorInbox_ShouldIncludeOlderRunReviewPacketBlockersWhenLatestRunIsClean()
     {
         await using var app = await CreateAppAsync(services =>


### PR DESCRIPTION
### Motivation
- Ensure the operator inbox projection and the trading readiness projection remain in sync for key Wave 2 lanes and to detect drift between the two surfaces.
- Provide an explicit, stable-test harness that exercises replay, controls, promotion traceability, reconciliation, and DK1 trust-gate paths so mismatches are discovered during CI.

### Description
- Add a new acceptance test `MapWorkstationEndpoints_OperatorInbox_ShouldMatchReadinessSeverityAcrossWave2Lanes` in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` that fetches both `/api/workstation/trading/readiness` and `/api/workstation/operator/inbox` in one scenario.
- Build a reconciliation-mismatch scenario by registering run-read services and running a reconciliation job to exercise the reconciliation lane.
- Normalize comparable categories by stable work-item id prefixes (via `GetCategory`) and map `OperatorWorkItemToneDto` to integer severity ranks with `ToSeverityRank`.
- Assert severity parity for five explicit categories using stable anchors: `replay` (anchor `paper-session-missing`), `controls` (anchor `execution-evidence-incomplete`), `promotion-traceability` (anchor `promotion-decision-missing`), `reconciliation` (anchor prefix `reconciliation-break-`), and `dk1-trust-gate` (anchor `dk1-trust-packet-unavailable`) so failures clearly identify which lane drifted.

### Testing
- Attempted to run the new test in this environment with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~MapWorkstationEndpoints_OperatorInbox_ShouldMatchReadinessSeverityAcrossWave2Lanes" --logger "console;verbosity=minimal"`, but the run failed because `dotnet` is not available in the container (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b79004f508320a66281b7ac9dc967)