### PR TITLE
Add DK1 packet single-run artifact continuity test

### DIFF
--- a/tests/scripts/test_generate_dk1_pilot_parity_packet.py
+++ b/tests/scripts/test_generate_dk1_pilot_parity_packet.py
@@ -58,6 +58,73 @@ class GenerateDk1PilotParityPacketTests(unittest.TestCase):
             )
             self.assertEqual(3, len(packet["operatorSignoff"]["approvals"]))
 
+
+    def test_single_run_writes_exactly_one_packet_with_restart_continuity_evidence(self) -> None:
+        pwsh = shutil.which("pwsh")
+        if pwsh is None:
+            self.skipTest("pwsh is not available")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            summary_path = temp_path / "wave1-validation-summary.json"
+            signoff_path = temp_path / "dk1-operator-signoff.json"
+
+            summary_path.write_text(json.dumps(_build_passing_summary()), encoding="utf-8")
+            packet_review = _write_reviewed_packet(temp_path, summary_path)
+            signoff_path.write_text(json.dumps(_build_signed_signoff(packet_review)), encoding="utf-8")
+
+            subprocess.run(
+                [
+                    pwsh,
+                    "-NoProfile",
+                    "-File",
+                    str(SCRIPT_PATH),
+                    "-SummaryJsonPath",
+                    str(summary_path),
+                    "-OperatorSignoffPath",
+                    str(signoff_path),
+                ],
+                cwd=REPO_ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            packets = sorted(temp_path.glob("dk1-pilot-parity-packet*.json"))
+            self.assertEqual(
+                1,
+                len(packets),
+                f"Expected exactly one packet artifact for a single run, found {len(packets)}: {packets}",
+            )
+
+            packet = json.loads(packets[0].read_text(encoding="utf-8"))
+            operator_signoff = packet.get("operatorSignoff", {})
+            packet_review_node = operator_signoff.get("packetReview", {})
+
+            self.assertTrue(str(packet.get("generatedAtUtc", "")).strip())
+            self.assertTrue(str(packet_review_node.get("generatedAtUtc", "")).strip())
+            self.assertTrue(str(packet_review_node.get("sourceSummary", "")).strip())
+            self.assertTrue(str(packet_review_node.get("path", "")).strip())
+            self.assertTrue(str(packet_review_node.get("status", "")).strip())
+
+            self.assertEqual(str(summary_path), packet_review_node.get("sourceSummary"))
+            self.assertEqual(str(packets[0]), packet_review_node.get("path"))
+
+            evidence_documents = packet.get("evidenceDocuments", [])
+            self.assertGreater(len(evidence_documents), 0)
+            self.assertTrue(
+                all(str(document.get("path", "")).strip() for document in evidence_documents),
+                "Expected evidence document references for restart continuity review.",
+            )
+
+            sample_review = packet.get("sampleReview", {})
+            samples = sample_review.get("samples", [])
+            self.assertGreater(len(samples), 0)
+            self.assertTrue(
+                all(str(sample.get("id", "")).strip() for sample in samples),
+                "Expected sample identifiers to remain linked for replay continuity verification.",
+            )
+
     def test_operator_signoff_path_rejects_stale_packet_binding(self) -> None:
         pwsh = shutil.which("pwsh")
         if pwsh is None:


### PR DESCRIPTION
### Motivation

- Ensure a fresh, deterministic run of the DK1 packet generator emits exactly one operator packet artifact and that the artifact contains restart/continuity evidence required for replay verification.  

### Description

- Add a new integration-style test `test_single_run_writes_exactly_one_packet_with_restart_continuity_evidence` to `tests/scripts/test_generate_dk1_pilot_parity_packet.py`.  
- The test runs `scripts/dev/generate-dk1-pilot-parity-packet.ps1` from an isolated temporary directory with deterministic `wave1-validation-summary.json` and `dk1-operator-signoff.json` inputs.  
- It asserts exactly one `dk1-pilot-parity-packet*.json` file is produced, and verifies restart-continuity linkage fields are present and non-empty (`generatedAtUtc`, `operatorSignoff.packetReview.generatedAtUtc`, `operatorSignoff.packetReview.sourceSummary`, `operatorSignoff.packetReview.path`, and `operatorSignoff.packetReview.status`).  
- The test also asserts presence of non-empty `evidenceDocuments[].path` entries and `sampleReview.samples[].id` values to ensure replay continuity references are emitted, and fails if multiple packet artifacts are produced by a single invocation.  

### Testing

- Ran the test suite with `python3 -m unittest tests/scripts/test_generate_dk1_pilot_parity_packet.py`; the test module executed successfully but individual tests were skipped in this environment because `pwsh` was not available (`Ran 3 tests ... OK (skipped=3)`).  
- The test includes a `pwsh` availability guard and is expected to run to completion in CI or local environments where `pwsh` is installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b79020e4c8320b53c4f7eaa484345)