### PR TITLE
Add focused readiness tests for TradingOperatorReadinessService

### DIFF
--- a/tests/Meridian.Tests/Ui/TradingOperatorReadinessServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/TradingOperatorReadinessServiceTests.cs
@@ -238,6 +238,63 @@ public sealed class TradingOperatorReadinessServiceTests
             gate.Status == TradingAcceptanceGateStatusDto.Ready);
     }
 
+    [Fact]
+    public async Task GetAsync_WithFullyReadyPaperScenario_ShouldMarkCockpitReadyForPaperOperation()
+    {
+        await using var auditTrail = CreateAuditTrail(nameof(GetAsync_WithFullyReadyPaperScenario_ShouldMarkCockpitReadyForPaperOperation));
+        var persistence = new PaperSessionPersistenceService(
+            NullLogger<PaperSessionPersistenceService>.Instance,
+            auditTrail: auditTrail);
+        var session = await persistence.CreateSessionAsync(new CreatePaperSessionDto(
+            StrategyId: "strat-fully-ready",
+            StrategyName: "Fully Ready Strategy",
+            InitialCash: 100_000m,
+            Symbols: ["AAPL", "MSFT"]));
+        await persistence.VerifyReplayAsync(session.SessionId);
+
+        using var provider = new ServiceCollection()
+            .AddSingleton(auditTrail)
+            .AddSingleton(persistence)
+            .BuildServiceProvider();
+        var service = new TradingOperatorReadinessService(
+            provider,
+            NullLogger<TradingOperatorReadinessService>.Instance);
+
+        var readiness = await service.GetAsync();
+
+        readiness.AcceptanceGates.All(g => g.Status == TradingAcceptanceGateStatusDto.Ready).Should().BeTrue();
+        readiness.WorkItems.Should().NotContain(item => item.Tone == OperatorWorkItemToneDto.Critical);
+        readiness.OverallStatus.Should().Be(TradingAcceptanceGateStatusDto.Ready);
+        readiness.ReadyForPaperOperation.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetAsync_WithOneDowngradedGate_ShouldSetReadyForPaperOperationFalse()
+    {
+        await using var auditTrail = CreateAuditTrail(nameof(GetAsync_WithOneDowngradedGate_ShouldSetReadyForPaperOperationFalse));
+        var persistence = new PaperSessionPersistenceService(
+            NullLogger<PaperSessionPersistenceService>.Instance,
+            auditTrail: auditTrail);
+        await persistence.CreateSessionAsync(new CreatePaperSessionDto(
+            StrategyId: "strat-not-ready",
+            StrategyName: "Not Ready Strategy",
+            InitialCash: 100_000m,
+            Symbols: ["AAPL"]));
+
+        using var provider = new ServiceCollection()
+            .AddSingleton(auditTrail)
+            .AddSingleton(persistence)
+            .BuildServiceProvider();
+        var service = new TradingOperatorReadinessService(
+            provider,
+            NullLogger<TradingOperatorReadinessService>.Instance);
+
+        var readiness = await service.GetAsync();
+
+        readiness.AcceptanceGates.Should().Contain(g => g.Status != TradingAcceptanceGateStatusDto.Ready);
+        readiness.ReadyForPaperOperation.Should().BeFalse();
+    }
+
     private static ExecutionAuditTrailService CreateAuditTrail(string scenario)
     {
         var root = Path.Combine(


### PR DESCRIPTION
### Motivation

- Ensure the operator-readiness model exposes a clear, testable positive scenario where all gates are Ready and the cockpit is allowed for paper operation.
- Provide a targeted negative-path to verify that any single downgraded gate (or critical work item) prevents `ReadyForPaperOperation`.

### Description

- Added `GetAsync_WithFullyReadyPaperScenario_ShouldMarkCockpitReadyForPaperOperation` which creates an audit trail and paper session, verifies replay, and asserts: all acceptance gates are `Ready`, there are no `Critical` work items, `OverallStatus` is `Ready`, and `ReadyForPaperOperation` is `true`.
- Added `GetAsync_WithOneDowngradedGate_ShouldSetReadyForPaperOperationFalse` which leaves one readiness dependency downgraded and asserts that at least one gate is not `Ready` and `ReadyForPaperOperation` is `false`.
- Reused existing helpers such as `CreateAuditTrail` and `PaperSessionPersistenceService` to avoid duplicating fixture setup and to follow existing test patterns.

### Testing

- Attempted to run the two focused tests with `dotnet test ... --filter "FullyQualifiedName~GetAsync_WithFullyReadyPaperScenario_ShouldMarkCockpitReadyForPaperOperation|FullyQualifiedName~GetAsync_WithOneDowngradedGate_ShouldSetReadyForPaperOperationFalse"`, but the invocation could not be executed in this environment because the `dotnet` CLI is unavailable (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b78f9d7f083209b62eb3da3e0d2c9)