### PR TITLE
Add execution manual-override route parity checks across backend, frontend, and docs

### DIFF
--- a/src/Meridian.Ui/dashboard/src/lib/api.trading.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api.trading.test.ts
@@ -151,6 +151,23 @@ describe("trading endpoint wiring", () => {
     );
   });
 
+
+
+  it("keeps API methods aligned to contract-manual override paths", async () => {
+    const CONTRACT_EXECUTION_CONTROLS = "/api/execution/controls" as const;
+    const CONTRACT_EXECUTION_MANUAL_OVERRIDES = "/api/execution/controls/manual-overrides" as const;
+    const CONTRACT_EXECUTION_MANUAL_OVERRIDE_CLEAR =
+      "/api/execution/controls/manual-overrides/ovr-contract/clear" as const;
+
+    await getExecutionControls();
+    await createExecutionManualOverride({ kind: "BypassOrderControls", reason: "contract-check" });
+    await clearExecutionManualOverride("ovr-contract");
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, CONTRACT_EXECUTION_CONTROLS, expect.anything());
+    expect(fetchMock).toHaveBeenNthCalledWith(2, CONTRACT_EXECUTION_MANUAL_OVERRIDES, expect.objectContaining({ method: "POST" }));
+    expect(fetchMock).toHaveBeenNthCalledWith(3, CONTRACT_EXECUTION_MANUAL_OVERRIDE_CLEAR, expect.objectContaining({ method: "POST" }));
+  });
+
   it("uses dev fixtures for workstation bootstrap GETs when the API host is missing", async () => {
     fetchMock.mockResolvedValue({ ok: false, status: 404, json: async () => ({}), text: async () => "" });
 

--- a/src/Meridian.Ui/dashboard/src/lib/workstation-endpoints.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/workstation-endpoints.test.ts
@@ -346,3 +346,21 @@ describe("workstation API endpoint catalog", () => {
     expect(() => reconciliationBreakEndpoint("\t")).toThrow("breakId is required");
   });
 });
+
+describe("execution control route contract parity", () => {
+  const CONTRACT_EXECUTION_MANUAL_OVERRIDES = "/api/execution/controls/manual-overrides" as const;
+  const CONTRACT_EXECUTION_MANUAL_OVERRIDE_CLEAR_TEMPLATE =
+    "/api/execution/controls/manual-overrides/{overrideId}/clear" as const;
+
+  it("keeps frontend helper constants aligned with backend contracts", () => {
+    expect(EXECUTION_API_ENDPOINTS.manualOverrides).toBe(
+      CONTRACT_EXECUTION_MANUAL_OVERRIDES,
+      "frontend helper diverged from backend contract: manual override create route"
+    );
+
+    expect(executionManualOverrideClearEndpoint("override-1")).toBe(
+      CONTRACT_EXECUTION_MANUAL_OVERRIDE_CLEAR_TEMPLATE.replace("{overrideId}", "override-1"),
+      "frontend helper diverged from backend contract: manual override clear route template"
+    );
+  });
+});

--- a/tests/Meridian.Tests/Ui/ExecutionRouteContractParityTests.cs
+++ b/tests/Meridian.Tests/Ui/ExecutionRouteContractParityTests.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using FluentAssertions;
+using Meridian.Contracts.Api;
+using Meridian.Ui.Shared.Endpoints;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Meridian.Tests.Ui;
+
+public sealed class ExecutionRouteContractParityTests
+{
+    [Fact]
+    public void ExecutionControlManualOverrideRoutes_ShouldMatchContractsAndEndpointMap()
+    {
+        var mappedRoutes = MapExecutionRoutes();
+
+        mappedRoutes.Should().Contain(UiApiRoutes.ExecutionControlsManualOverrides,
+            "endpoint map diverged from contracts for execution manual override create route");
+
+        mappedRoutes.Should().Contain(UiApiRoutes.ExecutionControlsManualOverrideClear,
+            "endpoint map diverged from contracts for execution manual override clear route");
+    }
+
+    private static HashSet<string> MapExecutionRoutes()
+    {
+        var builder = WebApplication.CreateBuilder();
+        var app = builder.Build();
+        app.MapExecutionEndpoints(new JsonSerializerOptions());
+
+        return app.Services
+            .GetRequiredService<EndpointDataSource>()
+            .Endpoints
+            .OfType<RouteEndpoint>()
+            .Select(endpoint => endpoint.RoutePattern.RawText)
+            .Where(route => !string.IsNullOrWhiteSpace(route))
+            .ToHashSet(StringComparer.Ordinal);
+    }
+}

--- a/tests/scripts/test_live_execution_controls_route_consistency.py
+++ b/tests/scripts/test_live_execution_controls_route_consistency.py
@@ -1,0 +1,33 @@
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROUTES_FILE = REPO_ROOT / "src/Meridian.Contracts/Api/UiApiRoutes.cs"
+DOC_FILE = REPO_ROOT / "docs/operations/live-execution-controls.md"
+
+
+def _extract_constant(name: str) -> str:
+    text = ROUTES_FILE.read_text(encoding="utf-8")
+    match = re.search(rf"public const string {name} = \"([^\"]+)\";", text)
+    if match is None:
+        raise AssertionError(f"contracts layer diverged: missing UiApiRoutes constant '{name}'")
+    return match.group(1)
+
+
+class LiveExecutionControlsRouteConsistencyTests(unittest.TestCase):
+    def test_doc_routes_match_contracts_for_manual_overrides(self) -> None:
+        doc_text = DOC_FILE.read_text(encoding="utf-8")
+
+        expected_routes = {
+            _extract_constant("ExecutionControlsManualOverrides"): "docs layer diverged from contracts for manual override create route",
+            _extract_constant("ExecutionControlsManualOverrideClear"): "docs layer diverged from contracts for manual override clear route",
+        }
+
+        for route, error_message in expected_routes.items():
+            if route not in doc_text:
+                self.fail(f"{error_message}: expected '{route}' in {DOC_FILE}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent silent route drift by asserting canonical execution control/manual-override routes are identical across contracts, mapped endpoints, frontend helpers/API calls, and docs.
- Make mismatches easy to diagnose by surfacing which layer (contracts, endpoint map, frontend helper/API layer, or docs) diverged.

### Description
- Add a C# integration parity test `tests/Meridian.Tests/Ui/ExecutionRouteContractParityTests.cs` that maps `ExecutionEndpoints` into an in-memory `WebApplication` and asserts `UiApiRoutes.ExecutionControlsManualOverrides` and `UiApiRoutes.ExecutionControlsManualOverrideClear` exist in the mapped endpoint set. 
- Add frontend helper and API-layer tests in the dashboard: `src/Meridian.Ui/dashboard/src/lib/workstation-endpoints.test.ts` verifies helper constants and the clear-route builder match the contract, and `src/Meridian.Ui/dashboard/src/lib/api.trading.test.ts` verifies `getExecutionControls`, `createExecutionManualOverride`, and `clearExecutionManualOverride` issue requests to the canonical contract routes.
- Add a docs-consistency script `tests/scripts/test_live_execution_controls_route_consistency.py` that extracts route constants from `UiApiRoutes.cs` and asserts the same strings appear in `docs/operations/live-execution-controls.md`.
- Include layer-specific assertion messages in each check so test failures indicate which layer diverged (contracts, endpoint map, frontend helper/API, or docs).

### Testing
- Ran the docs consistency test with `python3 -m unittest tests/scripts/test_live_execution_controls_route_consistency.py` which passed. 
- Ran dashboard unit tests with `npm run test:vitest -- src/lib/workstation-endpoints.test.ts src/lib/api.trading.test.ts` which passed (all added/affected vitest cases succeeded).
- Attempted to run the new C# parity test with `dotnet test ... --filter "FullyQualifiedName~ExecutionRouteContractParityTests"` but `dotnet` was not available in this execution environment; this test is included and should be executed in CI where `dotnet` is available so mismatches fail the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b7c05c74c8320852ad7a6bd68ace3)