### PR TITLE
Harden promotion trace validation and readiness gating

### DIFF
--- a/src/Meridian.Strategies/Services/PromotionService.cs
+++ b/src/Meridian.Strategies/Services/PromotionService.cs
@@ -289,6 +289,14 @@ public sealed class PromotionService
             approvalChecklist: approvalChecklist,
             manualOverrideId: request.ManualOverrideId,
             auditReference: auditReference);
+        if (!TryValidatePromotionRecord(promotionRecord, out var validationError))
+        {
+            return new PromotionDecisionResult(
+                Success: false,
+                PromotionId: null,
+                NewRunId: null,
+                Reason: validationError ?? "Promotion approval record is invalid.");
+        }
 
         var newRun = new StrategyRunEntry(
             RunId: newRunId,
@@ -402,6 +410,14 @@ public sealed class PromotionService
             reviewNotes: request.ReviewNotes,
             manualOverrideId: request.ManualOverrideId,
             auditReference: auditReference);
+        if (!TryValidatePromotionRecord(promotionRecord, out var validationError))
+        {
+            return new PromotionDecisionResult(
+                Success: false,
+                PromotionId: null,
+                NewRunId: null,
+                Reason: validationError ?? "Promotion rejection record is invalid.");
+        }
 
         await _promotionRecordStore.AppendAsync(promotionRecord, ct).ConfigureAwait(false);
 
@@ -461,6 +477,58 @@ public sealed class PromotionService
         }
 
         return null;
+    }
+
+    internal static bool TryValidatePromotionRecord(StrategyPromotionRecord record, out string? validationError)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        if (string.IsNullOrWhiteSpace(record.ApprovedBy))
+        {
+            validationError = "Promotion decision record requires operator identity.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(record.Decision))
+        {
+            validationError = "Promotion decision record requires a decision.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(record.ApprovalReason))
+        {
+            validationError = "Promotion decision record requires rationale.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(record.AuditReference))
+        {
+            validationError = "Promotion decision record requires durable audit reference.";
+            return false;
+        }
+
+        var isApproved = string.Equals(record.Decision, PromotionDecisionKinds.Approved, StringComparison.OrdinalIgnoreCase);
+        var isRejected = string.Equals(record.Decision, PromotionDecisionKinds.Rejected, StringComparison.OrdinalIgnoreCase);
+        if (!isApproved && !isRejected)
+        {
+            validationError = $"Promotion decision '{record.Decision}' is unsupported.";
+            return false;
+        }
+
+        if (isApproved && string.IsNullOrWhiteSpace(record.TargetRunId))
+        {
+            validationError = "Approved promotion records must include target run lineage.";
+            return false;
+        }
+
+        if (isRejected && !string.IsNullOrWhiteSpace(record.TargetRunId))
+        {
+            validationError = "Rejected promotion records must not include target run lineage.";
+            return false;
+        }
+
+        validationError = null;
+        return true;
     }
 }
 

--- a/src/Meridian.Strategies/Storage/JsonlPromotionRecordStore.cs
+++ b/src/Meridian.Strategies/Storage/JsonlPromotionRecordStore.cs
@@ -72,7 +72,17 @@ public sealed class JsonlPromotionRecordStore : IPromotionRecordStore
                     PromotionRecordJsonContext.Default.StrategyPromotionRecord);
                 if (record is not null)
                 {
-                    records.Add(record);
+                    if (PromotionService.TryValidatePromotionRecord(record, out var validationError))
+                    {
+                        records.Add(record);
+                    }
+                    else
+                    {
+                        _logger.LogWarning(
+                            "Skipping invalid promotion record in {Path}: {ValidationError}",
+                            _options.HistoryPath,
+                            validationError);
+                    }
                 }
             }
             catch (JsonException ex)
@@ -88,6 +98,10 @@ public sealed class JsonlPromotionRecordStore : IPromotionRecordStore
     public async Task AppendAsync(StrategyPromotionRecord record, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(record);
+        if (!PromotionService.TryValidatePromotionRecord(record, out var validationError))
+        {
+            throw new InvalidOperationException(validationError ?? "Promotion record is invalid.");
+        }
 
         Directory.CreateDirectory(_options.RootDirectory);
         var json = JsonSerializer.Serialize(record, PromotionRecordJsonContext.Default.StrategyPromotionRecord);

--- a/src/Meridian.Strategies/Storage/JsonlPromotionRecordStore.cs
+++ b/src/Meridian.Strategies/Storage/JsonlPromotionRecordStore.cs
@@ -4,6 +4,7 @@ using Meridian.Storage.Archival;
 using Meridian.Strategies.Interfaces;
 using Meridian.Strategies.Promotions;
 using Meridian.Strategies.Serialization;
+using Meridian.Strategies.Services;
 using Microsoft.Extensions.Logging;
 
 namespace Meridian.Strategies.Storage;

--- a/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
@@ -283,12 +283,13 @@ public sealed class TradingOperatorReadinessService
         else if (promotion.RequiresReview || !IsPromotionTraceComplete(promotion))
         {
             PrometheusMetrics.RecordRunContinuityMissingLineage("api", "promotion-trace-incomplete");
+            var missingFields = GetMissingPromotionTraceFields(promotion);
             AddWorkItem(
                 workItems,
                 OperatorWorkItemKindDto.PromotionReview,
                 "Promotion trace incomplete",
-                "Promotion evidence must include decision, operator, rationale, lineage, and audit reference.",
-                OperatorWorkItemToneDto.Warning,
+                $"Promotion evidence is incomplete. Missing: {string.Join(", ", missingFields)}.",
+                OperatorWorkItemToneDto.Critical,
                 promotion.SourceRunId ?? promotion.TargetRunId,
                 auditReference: promotion.AuditReference,
                 workItemId: BuildWorkItemId("promotion-trace-incomplete", promotion.SourceRunId ?? promotion.TargetRunId));
@@ -864,13 +865,60 @@ public sealed class TradingOperatorReadinessService
         !string.IsNullOrWhiteSpace(record.AuditReference);
 
     private static bool IsPromotionTraceComplete(TradingPromotionReadinessDto? promotion) =>
-        promotion is not null &&
-        !string.IsNullOrWhiteSpace(promotion.ApprovalStatus) &&
-        !string.IsNullOrWhiteSpace(promotion.ApprovedBy) &&
-        !string.IsNullOrWhiteSpace(promotion.Reason) &&
-        HasApprovalChecklist(promotion.ApprovalChecklist) &&
-        !string.IsNullOrWhiteSpace(promotion.SourceRunId) &&
-        !string.IsNullOrWhiteSpace(promotion.AuditReference);
+        GetMissingPromotionTraceFields(promotion).Count == 0;
+
+    private static IReadOnlyList<string> GetMissingPromotionTraceFields(TradingPromotionReadinessDto? promotion)
+    {
+        if (promotion is null)
+        {
+            return ["promotion"];
+        }
+
+        var missing = new List<string>();
+        if (string.IsNullOrWhiteSpace(promotion.ApprovalStatus))
+        {
+            missing.Add("decision");
+        }
+
+        if (string.IsNullOrWhiteSpace(promotion.ApprovedBy))
+        {
+            missing.Add("operator");
+        }
+
+        if (string.IsNullOrWhiteSpace(promotion.Reason))
+        {
+            missing.Add("rationale");
+        }
+
+        if (!HasApprovalChecklist(promotion.ApprovalChecklist))
+        {
+            missing.Add("checklist");
+        }
+
+        if (string.IsNullOrWhiteSpace(promotion.SourceRunId))
+        {
+            missing.Add("sourceRunId");
+        }
+
+        if (string.Equals(promotion.ApprovalStatus, PromotionDecisionKinds.Approved, StringComparison.OrdinalIgnoreCase) &&
+            string.IsNullOrWhiteSpace(promotion.TargetRunId))
+        {
+            missing.Add("targetRunId");
+        }
+
+        if (string.Equals(promotion.ApprovalStatus, PromotionDecisionKinds.Rejected, StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(promotion.TargetRunId))
+        {
+            missing.Add("targetRunId must be empty for rejected decisions");
+        }
+
+        if (string.IsNullOrWhiteSpace(promotion.AuditReference))
+        {
+            missing.Add("auditReference");
+        }
+
+        return missing;
+    }
 
     private static bool HasApprovalChecklist(IReadOnlyList<string>? approvalChecklist)
         => approvalChecklist is { Count: > 0 } &&
@@ -1226,8 +1274,8 @@ public sealed class TradingOperatorReadinessService
         return new TradingAcceptanceGateDto(
             GateId: "promotion",
             Label: "Promotion trace complete",
-            Status: TradingAcceptanceGateStatusDto.ReviewRequired,
-            Detail: "Promotion evidence must include decision, operator, rationale, checklist, lineage, and audit reference.",
+            Status: TradingAcceptanceGateStatusDto.Blocked,
+            Detail: $"Promotion evidence is incomplete. Missing: {string.Join(", ", GetMissingPromotionTraceFields(promotion))}.",
             RunId: promotion.SourceRunId ?? promotion.TargetRunId,
             AuditReference: promotion.AuditReference);
     }

--- a/tests/Meridian.Tests/Strategies/PromotionServiceTests.cs
+++ b/tests/Meridian.Tests/Strategies/PromotionServiceTests.cs
@@ -349,6 +349,41 @@ public sealed class PromotionServiceTests
         history[0].ApprovalChecklist.Should().BeEquivalentTo(PromotionApprovalChecklist.CreateRequiredFor(RunType.Paper));
     }
 
+    [Fact]
+    public async Task GetPromotionHistoryAsync_WithMalformedPersistedRecords_ShouldSkipInvalidEntries()
+    {
+        var tempRoot = CreateTempRoot();
+        var options = new PromotionRecordStoreOptions(Path.Combine(tempRoot, "promotion-history"));
+        Directory.CreateDirectory(options.RootDirectory);
+        var valid = new StrategyPromotionRecord(
+            PromotionId: "promotion-valid",
+            StrategyId: "s1",
+            StrategyName: "Strategy One",
+            SourceRunType: RunType.Backtest,
+            TargetRunType: RunType.Paper,
+            SourceRunId: "run-valid",
+            TargetRunId: "run-paper",
+            QualifyingSharpe: 1.1d,
+            QualifyingMaxDrawdownPercent: 0.05m,
+            QualifyingTotalReturn: 0.12m,
+            Decision: PromotionDecisionKinds.Approved,
+            PromotedAt: DateTimeOffset.UtcNow,
+            ApprovalReason: "approved",
+            ApprovalChecklist: PromotionApprovalChecklist.CreateRequiredFor(RunType.Paper),
+            AuditReference: "audit-valid",
+            ApprovedBy: "ops");
+        var malformed = valid with { PromotionId = "promotion-malformed", ApprovedBy = "" };
+        await File.WriteAllLinesAsync(
+            options.HistoryPath,
+            [System.Text.Json.JsonSerializer.Serialize(valid), System.Text.Json.JsonSerializer.Serialize(malformed)]);
+
+        var store = new JsonlPromotionRecordStore(options, NullLogger<JsonlPromotionRecordStore>.Instance);
+        var records = await store.LoadAllAsync();
+
+        records.Should().ContainSingle();
+        records[0].PromotionId.Should().Be("promotion-valid");
+    }
+
     // ---- Helpers ----
 
     private static PromotionService BuildService(out StrategyRunStore store, string? rootPath = null)


### PR DESCRIPTION
### Motivation
- Ensure every persisted promotion approval/rejection has explicit operator identity, decision, rationale, and durable audit reference so audit trails are trustworthy.
- Enforce lineage expectations so approved decisions include a `TargetRunId` and rejected decisions do not, preventing ambiguous promotion lineage.
- Surface missing or malformed promotion evidence as true readiness blockers (not mere warnings) so operator cockpits are not marked ready with incomplete governance traces.
- Avoid restart/regeneration surprises by skipping malformed persisted promotion records during rehydration and preventing invalid writes.

### Description
- Added a shared validator `TryValidatePromotionRecord(StrategyPromotionRecord, out string?)` in `PromotionService` and invoked it before persisting promotion records in both `ApproveAsync` and `RejectAsync` to enforce operator, decision, rationale, audit reference, and lineage rules.
- Updated `JsonlPromotionRecordStore` to skip invalid/deserialised records with a logged warning during `LoadAllAsync` and to throw on `AppendAsync` if a record fails validation, preventing invalid history from being written.
- Tightened `TradingOperatorReadinessService` to escalate incomplete promotion traces to critical `OperatorWorkItem` tone and to block the promotion acceptance gate with explicit missing-field details, by introducing `GetMissingPromotionTraceFields` and switching gate status to `Blocked` when incomplete.
- Added unit test `GetPromotionHistoryAsync_WithMalformedPersistedRecords_ShouldSkipInvalidEntries` in `tests/Meridian.Tests/Strategies/PromotionServiceTests.cs` to verify malformed persisted entries are ignored during store load.

### Testing
- Added a targeted unit test `GetPromotionHistoryAsync_WithMalformedPersistedRecords_ShouldSkipInvalidEntries` for the durable promotion store that verifies malformed entries are skipped (test added to `tests/Meridian.Tests/Strategies/PromotionServiceTests.cs`).
- Attempted to run the filtered test suite via `dotnet test` for `PromotionServiceTests`, `TradingOperatorReadinessServiceTests`, and readiness endpoint filters, but the environment lacked the `dotnet` runtime and the command failed with `dotnet: command not found` so automated tests could not be executed here.
- Behavior was validated by static inspection and local code updates (validator wired into approval/rejection and store load/append paths) and a unit that will run in CI where `dotnet` is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b7c043a188320b81a03137a558749)