### PR TITLE
Import PromotionService namespace in JsonlPromotionRecordStore to fix compile error

### DIFF
--- a/src/Meridian.Strategies/Storage/JsonlPromotionRecordStore.cs
+++ b/src/Meridian.Strategies/Storage/JsonlPromotionRecordStore.cs
@@ -4,6 +4,7 @@ using Meridian.Storage.Archival;
 using Meridian.Strategies.Interfaces;
 using Meridian.Strategies.Promotions;
 using Meridian.Strategies.Serialization;
+using Meridian.Strategies.Services;
 using Microsoft.Extensions.Logging;
 
 namespace Meridian.Strategies.Storage;


### PR DESCRIPTION
### Motivation
- Fix a compile-time unresolved symbol caused by `JsonlPromotionRecordStore` calling `PromotionService.TryValidatePromotionRecord` without importing the `Meridian.Strategies.Services` namespace, which blocks builds that include `Meridian.Strategies`.

### Description
- Added `using Meridian.Strategies.Services;` to `src/Meridian.Strategies/Storage/JsonlPromotionRecordStore.cs` so `PromotionService.TryValidatePromotionRecord(...)` resolves correctly.

### Testing
- Attempted a targeted build with `dotnet build src/Meridian.Strategies/Meridian.Strategies.csproj -v minimal`, but `dotnet` is unavailable in this environment (`dotnet: command not found`), so compilation should be validated by CI or a local developer environment where .NET is installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b80dbd7a88320bfc2d693675add4b)