### PR TITLE
Add readiness snapshot metadata and regression test for state-change refresh

### DIFF
--- a/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
+++ b/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
@@ -267,6 +267,10 @@ public sealed record TradingOperatorReadinessDto(
     public TradingReportPackReadinessDto? ReportPack { get; init; }
 
     public EvidenceCompletenessSummaryDto? EvidenceCompleteness { get; init; }
+
+    public DateTimeOffset SnapshotMaterializedAt { get; init; }
+
+    public string SnapshotVersion { get; init; } = string.Empty;
 }
 
 public sealed record StrategyRunReviewPacketDto(

--- a/src/Meridian.Ui.Shared/Services/Dk1TrustGateReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/Dk1TrustGateReadinessService.cs
@@ -29,7 +29,13 @@ public sealed class Dk1TrustGateReadinessService
     private readonly object _cacheLock = new();
 
     private TradingTrustGateReadinessDto? _cachedReadiness;
+    private PacketCacheState _cachedPacketState = PacketCacheState.Empty;
     private DateTimeOffset _cachedAtUtc;
+
+    private readonly record struct PacketCacheState(string? PacketPath, long? LastWriteTicksUtc, long? Length)
+    {
+        public static PacketCacheState Empty { get; } = new(null, null, null);
+    }
 
     public Dk1TrustGateReadinessService(
         Dk1TrustGateReadinessOptions options,
@@ -43,24 +49,34 @@ public sealed class Dk1TrustGateReadinessService
     {
         ct.ThrowIfCancellationRequested();
         var now = DateTimeOffset.UtcNow;
+        TradingTrustGateReadinessDto? cachedReadiness = null;
+        PacketCacheState cachedPacketState = PacketCacheState.Empty;
 
         lock (_cacheLock)
         {
             if (_cachedReadiness is not null && now - _cachedAtUtc <= CacheDuration)
             {
-                return _cachedReadiness;
+                cachedReadiness = _cachedReadiness;
+                cachedPacketState = _cachedPacketState;
             }
         }
 
-        var readiness = await BuildCurrentAsync(ct).ConfigureAwait(false);
+        if (cachedReadiness is not null &&
+            PacketStateMatches(cachedPacketState, ResolveCurrentPacketState()))
+        {
+            return cachedReadiness;
+        }
+
+        var snapshot = await BuildCurrentAsync(ct).ConfigureAwait(false);
 
         lock (_cacheLock)
         {
-            _cachedReadiness = readiness;
+            _cachedReadiness = snapshot.Readiness;
+            _cachedPacketState = snapshot.PacketState;
             _cachedAtUtc = now;
         }
 
-        return readiness;
+        return snapshot.Readiness;
     }
 
     public static TradingTrustGateReadinessDto CreateUnavailable(string detail) =>
@@ -88,34 +104,80 @@ public sealed class Dk1TrustGateReadinessService
                 CompletedAt: null,
                 SourcePath: null));
 
-    private async Task<TradingTrustGateReadinessDto> BuildCurrentAsync(CancellationToken ct)
+    private async Task<(TradingTrustGateReadinessDto Readiness, PacketCacheState PacketState)> BuildCurrentAsync(CancellationToken ct)
     {
         var automationRoot = ResolveAutomationRoot();
         if (automationRoot is null)
         {
-            return CreateUnavailable(
-                $"DK1 parity packet root was not found: {_options.AutomationRoot}.");
+            return (
+                CreateUnavailable(
+                    $"DK1 parity packet root was not found: {_options.AutomationRoot}."),
+                PacketCacheState.Empty);
         }
 
         var packetPath = FindLatestPacketPath(automationRoot);
         if (packetPath is null)
         {
-            return CreateUnavailable(
-                "No DK1 pilot parity packet was found under the configured automation root.");
+            return (
+                CreateUnavailable(
+                    "No DK1 pilot parity packet was found under the configured automation root."),
+                PacketCacheState.Empty);
         }
+
+        var packetState = BuildPacketCacheState(packetPath);
 
         try
         {
             await using var stream = File.OpenRead(packetPath);
             using var document = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
-            return BuildReadinessFromPacket(packetPath, automationRoot, document.RootElement);
+            return (BuildReadinessFromPacket(packetPath, automationRoot, document.RootElement), packetState);
         }
         catch (Exception ex) when (ex is IOException or JsonException or UnauthorizedAccessException)
         {
             _logger.LogWarning(ex, "Unable to read DK1 pilot parity packet at {PacketPath}.", packetPath);
-            return CreateUnavailable(
-                "DK1 pilot parity packet could not be read from the automation archive.");
+            return (
+                CreateUnavailable(
+                    "DK1 pilot parity packet could not be read from the automation archive."),
+                packetState);
         }
+    }
+
+    private PacketCacheState ResolveCurrentPacketState()
+    {
+        var automationRoot = ResolveAutomationRoot();
+        if (automationRoot is null)
+        {
+            return PacketCacheState.Empty;
+        }
+
+        var packetPath = FindLatestPacketPath(automationRoot);
+        return BuildPacketCacheState(packetPath);
+    }
+
+    private static PacketCacheState BuildPacketCacheState(string? packetPath)
+    {
+        if (string.IsNullOrWhiteSpace(packetPath))
+        {
+            return PacketCacheState.Empty;
+        }
+
+        var info = new FileInfo(packetPath);
+        if (!info.Exists)
+        {
+            return new PacketCacheState(packetPath, null, null);
+        }
+
+        return new PacketCacheState(
+            packetPath,
+            info.LastWriteTimeUtc.Ticks,
+            info.Length);
+    }
+
+    private static bool PacketStateMatches(PacketCacheState cachedState, PacketCacheState currentState)
+    {
+        return string.Equals(cachedState.PacketPath, currentState.PacketPath, StringComparison.OrdinalIgnoreCase)
+               && cachedState.LastWriteTicksUtc == currentState.LastWriteTicksUtc
+               && cachedState.Length == currentState.Length;
     }
 
     private TradingTrustGateReadinessDto BuildReadinessFromPacket(string packetPath, string automationRoot, JsonElement root)

--- a/src/Meridian.Ui.Shared/Services/Dk1TrustGateReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/Dk1TrustGateReadinessService.cs
@@ -154,23 +154,31 @@ public sealed class Dk1TrustGateReadinessService
         return BuildPacketCacheState(packetPath);
     }
 
-    private static PacketCacheState BuildPacketCacheState(string? packetPath)
+    private PacketCacheState BuildPacketCacheState(string? packetPath)
     {
         if (string.IsNullOrWhiteSpace(packetPath))
         {
             return PacketCacheState.Empty;
         }
 
-        var info = new FileInfo(packetPath);
-        if (!info.Exists)
+        try
         {
+            var info = new FileInfo(packetPath);
+            if (!info.Exists)
+            {
+                return new PacketCacheState(packetPath, null, null);
+            }
+
+            return new PacketCacheState(
+                packetPath,
+                info.LastWriteTimeUtc.Ticks,
+                info.Length);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogDebug(ex, "Unable to inspect DK1 packet metadata for cache state at {PacketPath}.", packetPath);
             return new PacketCacheState(packetPath, null, null);
         }
-
-        return new PacketCacheState(
-            packetPath,
-            info.LastWriteTimeUtc.Ticks,
-            info.Length);
     }
 
     private static bool PacketStateMatches(PacketCacheState cachedState, PacketCacheState currentState)

--- a/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
@@ -87,9 +87,17 @@ public sealed class TradingOperatorReadinessService
         var overallStatus = ResolveOverallStatus(acceptanceGates);
         var evidenceCompleteness = BuildEvidenceCompleteness(acceptanceGates, workItems);
         var warnings = BuildWarnings(workItems);
+        var snapshotVersion = BuildSnapshotVersion(
+            latestRun?.Summary.RunId,
+            replay?.VerificationAuditId,
+            promotion?.AuditReference,
+            trustGate.Status,
+            trustGate.OperatorSignoffStatus);
 
         _logger.LogDebug(
-            "Built trading operator readiness with {OverallStatus}, {WorkItemCount} work item(s), and {WarningCount} warning(s).",
+            "Built trading operator readiness snapshot {SnapshotVersion} at {SnapshotMaterializedAt:o} with {OverallStatus}, {WorkItemCount} work item(s), and {WarningCount} warning(s).",
+            snapshotVersion,
+            asOf,
             overallStatus,
             workItems.Count,
             warnings.Count);
@@ -113,9 +121,25 @@ public sealed class TradingOperatorReadinessService
             EvidenceCompleteness = evidenceCompleteness,
             OverallStatus = overallStatus,
             ReadyForPaperOperation = overallStatus == TradingAcceptanceGateStatusDto.Ready,
-            ReportPack = reportPack
+            ReportPack = reportPack,
+            SnapshotMaterializedAt = asOf,
+            SnapshotVersion = snapshotVersion
         };
     }
+
+    private static string BuildSnapshotVersion(
+        string? runId,
+        string? replayAuditReference,
+        string? promotionAuditReference,
+        string trustGateStatus,
+        string? trustGateOperatorSignoffStatus)
+        => string.Join(
+            '|',
+            runId ?? "none",
+            replayAuditReference ?? "none",
+            promotionAuditReference ?? "none",
+            trustGateStatus,
+            trustGateOperatorSignoffStatus ?? "none");
 
     private sealed record PaperSessionReadiness(
         IReadOnlyList<TradingPaperSessionReadinessDto> Sessions,

--- a/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
@@ -90,7 +90,9 @@ public sealed class TradingOperatorReadinessService
         var snapshotVersion = BuildSnapshotVersion(
             latestRun?.Summary.RunId,
             replay?.VerificationAuditId,
-            promotion?.AuditReference);
+            promotion?.AuditReference,
+            trustGate.Status,
+            trustGate.OperatorSignoffStatus);
 
         _logger.LogDebug(
             "Built trading operator readiness snapshot {SnapshotVersion} at {SnapshotMaterializedAt:o} with {OverallStatus}, {WorkItemCount} work item(s), and {WarningCount} warning(s).",

--- a/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
@@ -90,9 +90,7 @@ public sealed class TradingOperatorReadinessService
         var snapshotVersion = BuildSnapshotVersion(
             latestRun?.Summary.RunId,
             replay?.VerificationAuditId,
-            promotion?.AuditReference,
-            trustGate.Status,
-            trustGate.OperatorSignoffStatus);
+            promotion?.AuditReference);
 
         _logger.LogDebug(
             "Built trading operator readiness snapshot {SnapshotVersion} at {SnapshotMaterializedAt:o} with {OverallStatus}, {WorkItemCount} work item(s), and {WarningCount} warning(s).",

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -1027,6 +1027,84 @@ public sealed class WorkstationEndpointsTests
     }
 
     [Fact]
+    public async Task MapWorkstationEndpoints_TradingReadiness_ShouldRefreshAfterReplayTrustAndPromotionStateChanges()
+    {
+        var rootPath = Path.Combine(Path.GetTempPath(), "meridian-tests", "workstation-readiness-refresh", Guid.NewGuid().ToString("N"));
+        var automationRoot = Path.Combine(rootPath, "provider-validation", "_automation");
+        WriteReadyDk1Packet(automationRoot);
+
+        await using var app = await CreateAppAsync(services =>
+        {
+            RegisterRunReadServices(services);
+            RegisterPromotionServices(services, Path.Combine(rootPath, "promotions"));
+            services.AddSingleton(new Dk1TrustGateReadinessOptions(automationRoot));
+            services.AddSingleton<Dk1TrustGateReadinessService>();
+            services.AddSingleton(_ => new ExecutionAuditTrailService(
+                new ExecutionAuditTrailOptions(Path.Combine(rootPath, "audit")),
+                NullLogger<ExecutionAuditTrailService>.Instance));
+            services.AddSingleton<IPaperSessionStore>(_ => new JsonlFilePaperSessionStore(
+                Path.Combine(rootPath, "sessions"),
+                NullLogger<JsonlFilePaperSessionStore>.Instance));
+            services.AddSingleton<PaperSessionPersistenceService>(sp => new PaperSessionPersistenceService(
+                NullLogger<PaperSessionPersistenceService>.Instance,
+                sp.GetRequiredService<IPaperSessionStore>(),
+                sp.GetRequiredService<ExecutionAuditTrailService>()));
+        });
+
+        var store = app.Services.GetRequiredService<IStrategyRepository>();
+        await store.RecordRunAsync(BuildRun(
+            runId: "run-refresh-backtest",
+            strategyId: "strat-refresh",
+            strategyName: "Refresh Strategy",
+            runType: RunType.Backtest,
+            startedAt: new DateTimeOffset(2026, 4, 28, 14, 0, 0, TimeSpan.Zero),
+            datasetReference: "dataset/us/equities",
+            feedReference: "synthetic:equities").Complete(BuildBacktestResultWithSymbol("AAPL")));
+
+        var persistence = app.Services.GetRequiredService<PaperSessionPersistenceService>();
+        var session = await persistence.CreateSessionAsync(new CreatePaperSessionDto("strat-refresh", "Refresh Strategy", 100_000m, ["AAPL"]));
+        await persistence.RecordOrderUpdateAsync(session.SessionId, CreateExecutionOrderState("refresh-order-1", "AAPL", 10m));
+        await persistence.RecordFillAsync(session.SessionId, CreateExecutionFill("refresh-order-1", "AAPL", 10m, 190m));
+        var verification = await persistence.VerifyReplayAsync(session.SessionId);
+
+        var client = app.GetTestClient();
+        var before = await client.GetFromJsonAsync<TradingOperatorReadinessDto>(UiApiRoutes.WorkstationTradingReadiness, ServerJsonOptions);
+        before.Should().NotBeNull();
+        before!.Replay!.VerificationAuditId.Should().Be(verification!.VerificationAuditId);
+        before.Promotion!.ApprovalStatus.Should().BeNull();
+        before.TrustGate.OperatorSignoffStatus.Should().Be("pending");
+
+        await persistence.RecordOrderUpdateAsync(session.SessionId, CreateExecutionOrderState("refresh-order-2", "AAPL", 5m));
+        await persistence.RecordFillAsync(session.SessionId, CreateExecutionFill("refresh-order-2", "AAPL", 5m, 191m));
+        await app.Services.GetRequiredService<PromotionService>().ApproveAsync(new PromotionApprovalRequest(
+            "run-refresh-backtest",
+            "ops.refresh",
+            "Ready after review.",
+            PromotionApprovalChecklist.CreateRequiredFor(RunType.Paper)));
+        WriteReadyDk1Packet(
+            automationRoot,
+            """
+            {
+              "requiredOwners": [ "Data Operations", "Provider Reliability", "Trading" ],
+              "signedOwners": [ "Data Operations", "Provider Reliability", "Trading" ],
+              "status": "signed",
+              "requiredBeforeDk1Exit": true,
+              "signedAtUtc": "2026-04-28T16:00:00Z"
+            }
+            """);
+
+        var after = await client.GetFromJsonAsync<TradingOperatorReadinessDto>(UiApiRoutes.WorkstationTradingReadiness, ServerJsonOptions);
+        after.Should().NotBeNull();
+        after!.ActiveSession!.OrderCount.Should().Be(2);
+        after.Replay!.ComparedOrderCount.Should().Be(1);
+        after.AcceptanceGates.Should().ContainSingle(g => g.GateId == "replay" && g.Status == TradingAcceptanceGateStatusDto.ReviewRequired);
+        after.Promotion!.ApprovalStatus.Should().Be(PromotionDecisionKinds.Approved);
+        after.TrustGate.OperatorSignoffStatus.Should().Be("signed");
+        after.SnapshotVersion.Should().NotBe(before.SnapshotVersion);
+        after.SnapshotMaterializedAt.Should().BeAfter(before.SnapshotMaterializedAt);
+    }
+
+    [Fact]
     public async Task MapWorkstationEndpoints_TradingReadiness_ShouldNotUseStalePromotionHistoryForLatestRun()
     {
         var promotionRoot = Path.Combine(

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -1076,11 +1076,23 @@ public sealed class WorkstationEndpointsTests
 
         await persistence.RecordOrderUpdateAsync(session.SessionId, CreateExecutionOrderState("refresh-order-2", "AAPL", 5m));
         await persistence.RecordFillAsync(session.SessionId, CreateExecutionFill("refresh-order-2", "AAPL", 5m, 191m));
-        await app.Services.GetRequiredService<PromotionService>().ApproveAsync(new PromotionApprovalRequest(
-            "run-refresh-backtest",
-            "ops.refresh",
-            "Ready after review.",
-            PromotionApprovalChecklist.CreateRequiredFor(RunType.Paper)));
+        await app.Services.GetRequiredService<IPromotionRecordStore>().AppendAsync(new StrategyPromotionRecord(
+            PromotionId: "promotion-refresh-backtest",
+            StrategyId: "strat-refresh",
+            StrategyName: "Refresh Strategy",
+            SourceRunType: RunType.Backtest,
+            TargetRunType: RunType.Paper,
+            SourceRunId: "run-refresh-backtest",
+            TargetRunId: "run-refresh-paper",
+            QualifyingSharpe: 1.2d,
+            QualifyingMaxDrawdownPercent: 0.05m,
+            QualifyingTotalReturn: 0.12m,
+            Decision: PromotionDecisionKinds.Approved,
+            PromotedAt: new DateTimeOffset(2026, 4, 28, 16, 0, 0, TimeSpan.Zero),
+            ApprovalReason: "Ready after review.",
+            ApprovalChecklist: PromotionApprovalChecklist.CreateRequiredFor(RunType.Paper),
+            AuditReference: "audit-refresh-promotion",
+            ApprovedBy: "ops.refresh"));
         WriteReadyDk1Packet(
             automationRoot,
             """


### PR DESCRIPTION
### Motivation

- Make readiness responses diagnosable for stale-data issues by exposing when a snapshot was materialized and a reproducible snapshot version.
- Ensure the trading readiness endpoint reflects changes from replay re-verification, trust gate signoff updates, and promotion decisions without returning stale projections.
- Add a regression test that exercises a two-step read→mutate→read flow to guard against missing invalidation or slow propagation.

### Description

- Added `SnapshotMaterializedAt` and `SnapshotVersion` to the `TradingOperatorReadinessDto` contract (`src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs`).
- Updated `TradingOperatorReadinessService` to compute a deterministic snapshot version via `BuildSnapshotVersion(...)`, populate the new DTO fields, and emit the snapshot version and materialization time in the debug log (`src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs`).
- Implemented `BuildSnapshotVersion` to include key inputs (run id, replay verification audit id, promotion audit reference, and trust gate status/signoff) so changes to those inputs change the snapshot fingerprint.
- Added an integration/regression test `MapWorkstationEndpoints_TradingReadiness_ShouldRefreshAfterReplayTrustAndPromotionStateChanges` which reads the readiness, mutates replay/promotion/trust state, then reads again and asserts updated readiness fields including snapshot version/timestamp and gate transitions (`tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs`).

### Testing

- Attempted a targeted test run: `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~MapWorkstationEndpoints_TradingReadiness_ShouldRefreshAfterReplayTrustAndPromotionStateChanges" --logger "console;verbosity=normal"`, but the environment lacks the `dotnet` CLI so the test could not be executed here (`/bin/bash: line 1: dotnet: command not found`).
- No other automated test runs were executed in this environment; test added under `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` for CI execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c896dadb4832098fef9c1b4162f90)