### PR TITLE
Make OAuthRefreshService wrapper failures observable with structured logging and throttling

### DIFF
--- a/src/Meridian.Ui.Services/Services/CredentialService.cs
+++ b/src/Meridian.Ui.Services/Services/CredentialService.cs
@@ -22,16 +22,16 @@ public class CredentialService
 
     public event EventHandler<CredentialExpirationEventArgs>? CredentialExpiring;
 
-    public IReadOnlyList<CredentialWithMetadata> GetAllCredentialsWithMetadata()
+    public virtual IReadOnlyList<CredentialWithMetadata> GetAllCredentialsWithMetadata()
         => Array.Empty<CredentialWithMetadata>();
 
-    public Task<OAuthRefreshResult> RefreshOAuthTokenAsync(string providerId)
+    public virtual Task<OAuthRefreshResult> RefreshOAuthTokenAsync(string providerId)
         => Task.FromResult(new OAuthRefreshResult { Success = false, ErrorMessage = "Not implemented" });
 
-    public Task UpdateMetadataAsync(string resource, Action<CredentialMetadataUpdate> updateAction)
+    public virtual Task UpdateMetadataAsync(string resource, Action<CredentialMetadataUpdate> updateAction)
         => Task.CompletedTask;
 
-    public CredentialMetadataInfo? GetMetadata(string resource)
+    public virtual CredentialMetadataInfo? GetMetadata(string resource)
         => null;
 
     protected void OnCredentialExpiring(CredentialExpirationEventArgs e)

--- a/src/Meridian.Ui.Services/Services/OAuthRefreshService.cs
+++ b/src/Meridian.Ui.Services/Services/OAuthRefreshService.cs
@@ -1,5 +1,7 @@
 using System.Threading;
 using System.Timers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Meridian.Ui.Services;
 
@@ -10,14 +12,19 @@ namespace Meridian.Ui.Services;
 public sealed class OAuthRefreshService : IDisposable
 {
     private static readonly Lazy<OAuthRefreshService> _instance = new(() => new OAuthRefreshService());
+    private static readonly TimeSpan WrapperFailureLogThrottleWindow = TimeSpan.FromMinutes(1);
     /// <summary>
     /// Gets the singleton instance of the OAuth refresh service.
     /// </summary>
     public static OAuthRefreshService Instance => _instance.Value;
 
     private readonly CredentialService _credentialService;
+    private readonly ILogger<OAuthRefreshService> _logger;
     private readonly System.Timers.Timer _refreshTimer;
     private readonly System.Timers.Timer _expirationCheckTimer;
+    private readonly Dictionary<string, DateTime> _lastWrapperFailureLogByOperation = new(StringComparer.Ordinal);
+    private readonly object _wrapperFailureSync = new();
+    private int _wrapperFailureCount;
     private bool _isRunning;
     private bool _disposed;
 
@@ -45,10 +52,25 @@ public sealed class OAuthRefreshService : IDisposable
     /// Event raised when a token is about to expire and cannot be auto-refreshed.
     /// </summary>
     public event EventHandler<TokenExpirationWarningEventArgs>? TokenExpirationWarning;
+    /// <summary>
+    /// Event raised when a wrapper-level timer operation fails.
+    /// </summary>
+    public event EventHandler<OAuthWrapperFailureEventArgs>? WrapperOperationFailed;
+
+    /// <summary>
+    /// Count of wrapper-level failures observed by safe background wrappers.
+    /// </summary>
+    public int WrapperFailureCount => Volatile.Read(ref _wrapperFailureCount);
 
     private OAuthRefreshService()
+        : this(new CredentialService(), NullLogger<OAuthRefreshService>.Instance)
     {
-        _credentialService = new CredentialService();
+    }
+
+    internal OAuthRefreshService(CredentialService credentialService, ILogger<OAuthRefreshService>? logger = null)
+    {
+        _credentialService = credentialService;
+        _logger = logger ?? NullLogger<OAuthRefreshService>.Instance;
 
         _refreshTimer = new System.Timers.Timer(CheckIntervalMs);
         _refreshTimer.Elapsed += OnRefreshTimerElapsed;
@@ -179,8 +201,9 @@ public sealed class OAuthRefreshService : IDisposable
         {
             await CheckAndRefreshTokensAsync();
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            RecordWrapperFailure("CheckAndRefreshTokensAsync", ex);
         }
     }
 
@@ -190,9 +213,46 @@ public sealed class OAuthRefreshService : IDisposable
         {
             await CheckExpiringTokensAsync();
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            RecordWrapperFailure("CheckExpiringTokensAsync", ex);
         }
+    }
+
+    internal Task InvokeSafeCheckAndRefreshTokensForTestsAsync(CancellationToken ct = default)
+        => SafeCheckAndRefreshTokensAsync(ct);
+
+    internal Task InvokeSafeCheckExpiringTokensForTestsAsync(CancellationToken ct = default)
+        => SafeCheckExpiringTokensAsync(ct);
+
+    private void RecordWrapperFailure(string operationName, Exception ex)
+    {
+        Interlocked.Increment(ref _wrapperFailureCount);
+
+        var now = DateTime.UtcNow;
+        var shouldLog = true;
+        lock (_wrapperFailureSync)
+        {
+            if (_lastWrapperFailureLogByOperation.TryGetValue(operationName, out var lastLoggedAt) &&
+                now - lastLoggedAt < WrapperFailureLogThrottleWindow)
+            {
+                shouldLog = false;
+            }
+            else
+            {
+                _lastWrapperFailureLogByOperation[operationName] = now;
+            }
+        }
+
+        if (shouldLog)
+        {
+            _logger.LogError(
+                ex,
+                "OAuth refresh background wrapper failed for operation {OperationName}.",
+                operationName);
+        }
+
+        WrapperOperationFailed?.Invoke(this, new OAuthWrapperFailureEventArgs(operationName, ex, now, shouldLog));
     }
 
     private async Task CheckAndRefreshTokensAsync(CancellationToken ct = default)
@@ -373,5 +433,24 @@ public sealed class TokenExpirationWarningEventArgs : EventArgs
         ProviderId = providerId;
         ExpiresAt = expiresAt;
         CanAutoRefresh = canAutoRefresh;
+    }
+}
+
+/// <summary>
+/// Event args for wrapper-level failures in background safe wrappers.
+/// </summary>
+public sealed class OAuthWrapperFailureEventArgs : EventArgs
+{
+    public string OperationName { get; }
+    public Exception Exception { get; }
+    public DateTime OccurredAtUtc { get; }
+    public bool EmittedStructuredLog { get; }
+
+    public OAuthWrapperFailureEventArgs(string operationName, Exception exception, DateTime occurredAtUtc, bool emittedStructuredLog)
+    {
+        OperationName = operationName;
+        Exception = exception;
+        OccurredAtUtc = occurredAtUtc;
+        EmittedStructuredLog = emittedStructuredLog;
     }
 }

--- a/src/Meridian.Ui.Services/Services/OAuthRefreshService.cs
+++ b/src/Meridian.Ui.Services/Services/OAuthRefreshService.cs
@@ -11,6 +11,7 @@ namespace Meridian.Ui.Services;
 /// </summary>
 public sealed class OAuthRefreshService : IDisposable
 {
+    private static readonly Lazy<ILoggerFactory> _singletonLoggerFactory = new(() => LoggerFactory.Create(_ => { }));
     private static readonly Lazy<OAuthRefreshService> _instance = new(() => new OAuthRefreshService());
     private static readonly TimeSpan WrapperFailureLogThrottleWindow = TimeSpan.FromMinutes(1);
     /// <summary>
@@ -63,7 +64,7 @@ public sealed class OAuthRefreshService : IDisposable
     public int WrapperFailureCount => Volatile.Read(ref _wrapperFailureCount);
 
     private OAuthRefreshService()
-        : this(new CredentialService(), NullLogger<OAuthRefreshService>.Instance)
+        : this(new CredentialService(), _singletonLoggerFactory.Value.CreateLogger<OAuthRefreshService>())
     {
     }
 

--- a/tests/Meridian.Ui.Tests/Services/OAuthRefreshServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/OAuthRefreshServiceTests.cs
@@ -1,0 +1,112 @@
+using FluentAssertions;
+using Meridian.Ui.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Ui.Tests.Services;
+
+public sealed class OAuthRefreshServiceTests
+{
+    [Fact]
+    public async Task SafeCheckAndRefreshTokensAsync_WhenWrapperThrows_ShouldEmitFailureEventAndLog()
+    {
+        var credentialService = new TestCredentialService
+        {
+            Credentials =
+            [
+                new CredentialWithMetadata
+                {
+                    Resource = $"{CredentialService.OAuthTokenResource}.alpaca",
+                    IsOAuthToken = true,
+                    ExpiresAt = DateTime.UtcNow.AddMinutes(1),
+                    CanAutoRefresh = true
+                }
+            ],
+            RefreshException = new InvalidOperationException("refresh failure")
+        };
+
+        var logger = new TestLogger<OAuthRefreshService>();
+        var service = new OAuthRefreshService(credentialService, logger);
+        OAuthWrapperFailureEventArgs? evt = null;
+        service.WrapperOperationFailed += (_, e) => evt = e;
+
+        await service.InvokeSafeCheckAndRefreshTokensForTestsAsync();
+
+        service.WrapperFailureCount.Should().Be(1);
+        evt.Should().NotBeNull();
+        evt!.OperationName.Should().Be("CheckAndRefreshTokensAsync");
+        evt.Exception.Should().BeOfType<InvalidOperationException>();
+        evt.EmittedStructuredLog.Should().BeTrue();
+        logger.Entries.Should().ContainSingle(x => x.LogLevel == LogLevel.Error && x.Message.Contains("CheckAndRefreshTokensAsync"));
+    }
+
+    [Fact]
+    public async Task SafeCheckExpiringTokensAsync_WhenWarningSubscriberThrows_ShouldEmitThrottledWrapperEvents()
+    {
+        var credentialService = new TestCredentialService
+        {
+            Credentials =
+            [
+                new CredentialWithMetadata
+                {
+                    Resource = $"{CredentialService.OAuthTokenResource}.ibkr",
+                    IsOAuthToken = true,
+                    ExpiresAt = DateTime.UtcNow.AddMinutes(20),
+                    CanAutoRefresh = false
+                }
+            ]
+        };
+
+        var logger = new TestLogger<OAuthRefreshService>();
+        var service = new OAuthRefreshService(credentialService, logger);
+        var events = new List<OAuthWrapperFailureEventArgs>();
+        service.WrapperOperationFailed += (_, e) => events.Add(e);
+        service.TokenExpirationWarning += (_, _) => throw new InvalidOperationException("observer failed");
+
+        await service.InvokeSafeCheckExpiringTokensForTestsAsync();
+        await service.InvokeSafeCheckExpiringTokensForTestsAsync();
+
+        service.WrapperFailureCount.Should().Be(2);
+        events.Should().HaveCount(2);
+        events[0].EmittedStructuredLog.Should().BeTrue();
+        events[1].EmittedStructuredLog.Should().BeFalse();
+        logger.Entries.Count(x => x.LogLevel == LogLevel.Error && x.Message.Contains("CheckExpiringTokensAsync")).Should().Be(1);
+    }
+
+    private sealed class TestCredentialService : CredentialService
+    {
+        public IReadOnlyList<CredentialWithMetadata> Credentials { get; set; } = Array.Empty<CredentialWithMetadata>();
+        public Exception? RefreshException { get; set; }
+
+        public override IReadOnlyList<CredentialWithMetadata> GetAllCredentialsWithMetadata() => Credentials;
+
+        public override Task<OAuthRefreshResult> RefreshOAuthTokenAsync(string providerId)
+        {
+            if (RefreshException is not null)
+            {
+                throw RefreshException;
+            }
+
+            return Task.FromResult(new OAuthRefreshResult { Success = true, NewExpiration = DateTime.UtcNow.AddHours(1) });
+        }
+    }
+
+    private sealed class TestLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel LogLevel, string Message)> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve observability of background wrapper failures in `OAuthRefreshService` so timer threads remain non-crashing but every failure is observable for operator health and debugging. 
- Reduce repetitive log spam during persistent outages by coalescing structured error logs while still counting and emitting failure events for each occurrence.

### Description
- Replace empty `catch` blocks in safe wrappers with `RecordWrapperFailure` that increments a `WrapperFailureCount`, emits a `WrapperOperationFailed` event, and logs a structured `ILogger` error containing the operation name and exception. 
- Add per-operation throttling/coalescing using a one-minute `WrapperFailureLogThrottleWindow` so structured error logs are rate-limited while events and the failure counter continue to increment. 
- Make `CredentialService` members `virtual` and add an internal constructor and test hooks (`InvokeSafeCheckAndRefreshTokensForTestsAsync` / `InvokeSafeCheckExpiringTokensForTestsAsync`) to allow deterministic unit testing with test doubles. 
- Introduce `OAuthWrapperFailureEventArgs` payload and default to `NullLogger` in production paths to preserve existing singleton behavior without changing runtime crash-safety. 

### Testing
- Added unit tests at `tests/Meridian.Ui.Tests/Services/OAuthRefreshServiceTests.cs` that verify wrapper-level failure events, structured logging emission, and throttled log behavior under repeated wrapper failures. 
- Attempted to run the focused test filter with `dotnet test tests/Meridian.Ui.Tests/Meridian.Ui.Tests.csproj --filter "FullyQualifiedName~OAuthRefreshServiceTests" --logger "console;verbosity=normal"`, but the run could not execute in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8b0673c88320a03279abf5719df8)