### PR TITLE
ExportPresetServiceBase: log load/save failures and surface save failures to UI

### DIFF
--- a/src/Meridian.Ui.Services/Services/ExportPresetServiceBase.cs
+++ b/src/Meridian.Ui.Services/Services/ExportPresetServiceBase.cs
@@ -81,7 +81,7 @@ public class ExportPresetServiceBase
             if (_presets.Count == 0)
             {
                 _presets.AddRange(GetBuiltInPresets());
-                _ = await SavePresetsAsync(cancellationToken);
+                await SavePresetsAsync(cancellationToken);
             }
 
             EnsureBuiltInPresets();

--- a/src/Meridian.Ui.Services/Services/ExportPresetServiceBase.cs
+++ b/src/Meridian.Ui.Services/Services/ExportPresetServiceBase.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using Meridian.Contracts.Export;
 using Meridian.Storage.Archival;
-using Meridian.Ui.Services;
 
 namespace Meridian.Ui.Services.Services;
 
@@ -530,8 +529,8 @@ public class ExportPresetServiceBase
         => AtomicFileWriter.WriteAsync(_presetsFilePath, json, cancellationToken);
 
     protected virtual void LogLoadFailure(Exception exception)
-        => LoggingService.Instance.LogWarning($"Failed to load export presets from '{_presetsFilePath}'. Using built-in fallbacks.", exception);
+        => Meridian.Ui.Services.LoggingService.Instance.LogWarning($"Failed to load export presets from '{_presetsFilePath}'. Using built-in fallbacks.", exception);
 
     protected virtual void LogSaveFailure(Exception exception)
-        => LoggingService.Instance.LogWarning($"Failed to save export presets to '{_presetsFilePath}'.", exception);
+        => Meridian.Ui.Services.LoggingService.Instance.LogWarning($"Failed to save export presets to '{_presetsFilePath}'.", exception);
 }

--- a/src/Meridian.Ui.Services/Services/ExportPresetServiceBase.cs
+++ b/src/Meridian.Ui.Services/Services/ExportPresetServiceBase.cs
@@ -21,6 +21,12 @@ public class ExportPresetServiceBase
     /// </summary>
     public event EventHandler? PresetsChanged;
 
+
+    /// <summary>
+    /// Event raised when a save operation fails.
+    /// </summary>
+    public event EventHandler<Exception>? SaveFailed;
+
     /// <summary>
     /// Gets all available export presets.
     /// </summary>
@@ -75,7 +81,7 @@ public class ExportPresetServiceBase
             if (_presets.Count == 0)
             {
                 _presets.AddRange(GetBuiltInPresets());
-                await SavePresetsAsync(cancellationToken);
+                _ = await SavePresetsAsync(cancellationToken);
             }
 
             EnsureBuiltInPresets();
@@ -84,8 +90,9 @@ public class ExportPresetServiceBase
         {
             throw;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            LogLoadFailure(ex);
 
             if (_presets.Count == 0)
             {
@@ -97,7 +104,7 @@ public class ExportPresetServiceBase
     /// <summary>
     /// Saves presets to storage.
     /// </summary>
-    public async Task SavePresetsAsync(CancellationToken cancellationToken = default)
+    public async Task<bool> SavePresetsAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -105,14 +112,18 @@ public class ExportPresetServiceBase
         {
             var options = DesktopJsonOptions.PrettyPrint;
             var json = JsonSerializer.Serialize(_presets, options);
-            await AtomicFileWriter.WriteAsync(_presetsFilePath, json, cancellationToken).ConfigureAwait(false);
+            await WritePresetsFileAsync(json, cancellationToken).ConfigureAwait(false);
+            return true;
         }
         catch (OperationCanceledException)
         {
             throw;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            LogSaveFailure(ex);
+            SaveFailed?.Invoke(this, ex);
+            return false;
         }
     }
 
@@ -139,8 +150,10 @@ public class ExportPresetServiceBase
         };
 
         _presets.Add(preset);
-        await SavePresetsAsync(cancellationToken);
-        PresetsChanged?.Invoke(this, EventArgs.Empty);
+        if (await SavePresetsAsync(cancellationToken))
+        {
+            PresetsChanged?.Invoke(this, EventArgs.Empty);
+        }
 
         return preset;
     }
@@ -156,7 +169,11 @@ public class ExportPresetServiceBase
 
         preset.UpdatedAt = DateTime.UtcNow;
         _presets[index] = preset;
-        await SavePresetsAsync(cancellationToken);
+        if (!await SavePresetsAsync(cancellationToken))
+        {
+            return false;
+        }
+
         PresetsChanged?.Invoke(this, EventArgs.Empty);
 
         return true;
@@ -172,7 +189,11 @@ public class ExportPresetServiceBase
             return false;
 
         _presets.Remove(preset);
-        await SavePresetsAsync(cancellationToken);
+        if (!await SavePresetsAsync(cancellationToken))
+        {
+            return false;
+        }
+
         PresetsChanged?.Invoke(this, EventArgs.Empty);
 
         return true;
@@ -230,8 +251,10 @@ public class ExportPresetServiceBase
         };
 
         _presets.Add(duplicate);
-        await SavePresetsAsync(cancellationToken);
-        PresetsChanged?.Invoke(this, EventArgs.Empty);
+        if (await SavePresetsAsync(cancellationToken))
+        {
+            PresetsChanged?.Invoke(this, EventArgs.Empty);
+        }
 
         return duplicate;
     }
@@ -246,7 +269,7 @@ public class ExportPresetServiceBase
         {
             preset.LastUsedAt = DateTime.UtcNow;
             preset.UseCount++;
-            await SavePresetsAsync(cancellationToken);
+            _ = await SavePresetsAsync(cancellationToken);
         }
     }
 
@@ -299,8 +322,10 @@ public class ExportPresetServiceBase
             importedCount++;
         }
 
-        await SavePresetsAsync(cancellationToken);
-        PresetsChanged?.Invoke(this, EventArgs.Empty);
+        if (await SavePresetsAsync(cancellationToken))
+        {
+            PresetsChanged?.Invoke(this, EventArgs.Empty);
+        }
 
         return importedCount;
     }
@@ -500,4 +525,12 @@ public class ExportPresetServiceBase
         };
     }
 
+    protected virtual Task WritePresetsFileAsync(string json, CancellationToken cancellationToken)
+        => AtomicFileWriter.WriteAsync(_presetsFilePath, json, cancellationToken);
+
+    protected virtual void LogLoadFailure(Exception exception)
+        => LoggingService.Instance.LogWarning($"Failed to load export presets from '{_presetsFilePath}'. Using built-in fallbacks.", exception);
+
+    protected virtual void LogSaveFailure(Exception exception)
+        => LoggingService.Instance.LogWarning($"Failed to save export presets to '{_presetsFilePath}'.", exception);
 }

--- a/src/Meridian.Ui.Services/Services/ExportPresetServiceBase.cs
+++ b/src/Meridian.Ui.Services/Services/ExportPresetServiceBase.cs
@@ -188,9 +188,11 @@ public class ExportPresetServiceBase
         if (preset == null || preset.IsBuiltIn)
             return false;
 
-        _presets.Remove(preset);
+        var presetIndex = _presets.IndexOf(preset);
+        _presets.RemoveAt(presetIndex);
         if (!await SavePresetsAsync(cancellationToken))
         {
+            _presets.Insert(presetIndex, preset);
             return false;
         }
 

--- a/src/Meridian.Ui.Services/Services/ExportPresetServiceBase.cs
+++ b/src/Meridian.Ui.Services/Services/ExportPresetServiceBase.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Meridian.Contracts.Export;
 using Meridian.Storage.Archival;
+using Meridian.Ui.Services;
 
 namespace Meridian.Ui.Services.Services;
 

--- a/tests/Meridian.Ui.Tests/Services/AtomicPersistenceServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/AtomicPersistenceServiceTests.cs
@@ -93,11 +93,70 @@ public sealed class AtomicPersistenceServiceTests : IDisposable
         Directory.GetFiles(Path.GetDirectoryName(archivePath)!, "*.tmp").Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task LoadPresetsAsync_CorruptedFile_FallsBackAndLogsFailure()
+    {
+        var presetDirectory = Path.Combine(_tempDir, "corrupted-presets");
+        Directory.CreateDirectory(presetDirectory);
+        await File.WriteAllTextAsync(Path.Combine(presetDirectory, "export_presets.json"), "{not valid json");
+
+        var service = new TestExportPresetService(presetDirectory);
+
+        await service.LoadPresetsAsync();
+
+        service.Presets.Should().NotBeEmpty();
+        service.LoadFailures.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task SavePresetsAsync_WriteFailure_ReturnsFalseAndRaisesFailureEvent()
+    {
+        var presetDirectory = Path.Combine(_tempDir, "save-failure-presets");
+        var service = new TestExportPresetService(presetDirectory)
+        {
+            ForceWriteFailure = true
+        };
+
+        Exception? raisedException = null;
+        service.SaveFailed += (_, ex) => raisedException = ex;
+
+        _ = await service.CreatePresetAsync("Fails to save", format: ExportPresetFormat.Jsonl);
+
+        raisedException.Should().NotBeNull();
+        service.SaveFailures.Should().ContainSingle();
+    }
+
     private sealed class TestExportPresetService : ExportPresetServiceBase
     {
+        public bool ForceWriteFailure { get; set; }
+        public List<Exception> LoadFailures { get; } = new();
+        public List<Exception> SaveFailures { get; } = new();
+
         public TestExportPresetService(string presetsDirectoryPath)
             : base(presetsDirectoryPath)
         {
+        }
+
+        protected override Task WritePresetsFileAsync(string json, CancellationToken cancellationToken)
+        {
+            if (ForceWriteFailure)
+            {
+                throw new IOException("Forced write failure for test coverage.");
+            }
+
+            return base.WritePresetsFileAsync(json, cancellationToken);
+        }
+
+        protected override void LogLoadFailure(Exception exception)
+        {
+            LoadFailures.Add(exception);
+            base.LogLoadFailure(exception);
+        }
+
+        protected override void LogSaveFailure(Exception exception)
+        {
+            SaveFailures.Add(exception);
+            base.LogSaveFailure(exception);
         }
     }
 }

--- a/tests/Meridian.Ui.Tests/Services/AtomicPersistenceServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/AtomicPersistenceServiceTests.cs
@@ -126,6 +126,20 @@ public sealed class AtomicPersistenceServiceTests : IDisposable
         service.SaveFailures.Should().ContainSingle();
     }
 
+    [Fact]
+    public async Task DeletePresetAsync_SaveFailure_RestoresPresetInMemory()
+    {
+        var presetDirectory = Path.Combine(_tempDir, "delete-save-failure-presets");
+        var service = new TestExportPresetService(presetDirectory);
+        var preset = await service.CreatePresetAsync("Delete rollback", format: ExportPresetFormat.Jsonl);
+
+        service.ForceWriteFailure = true;
+        var deleted = await service.DeletePresetAsync(preset.Id);
+
+        deleted.Should().BeFalse();
+        service.GetPreset(preset.Id).Should().NotBeNull();
+    }
+
     private sealed class TestExportPresetService : ExportPresetServiceBase
     {
         public bool ForceWriteFailure { get; set; }


### PR DESCRIPTION
### Motivation
- Improve observability and resilience for export presets by logging exception context on load failures while retaining built-in fallbacks. 
- Surface persistent save failures to the UI so failed writes are not treated as silent successes. 
- Keep `OperationCanceledException` passthrough behavior unchanged for cancellation semantics.

### Description
- `LoadPresetsAsync` now logs load exceptions via an overridable `LogLoadFailure` and still falls back to built-in presets when necessary (`Presets` fallback preserved). 
- `SavePresetsAsync` now returns an explicit `Task<bool>` success flag, writes via an overridable `WritePresetsFileAsync`, and on exception logs via `LogSaveFailure` and emits a `SaveFailed` event instead of swallowing the error. 
- Mutating methods (`CreatePresetAsync`, `UpdatePresetAsync`, `DeletePresetAsync`, `DuplicatePresetAsync`, `ImportPresetsAsync`) only raise `PresetsChanged` when `SavePresetsAsync` reports success, preventing silent success signaling. 
- Added testability hooks (`WritePresetsFileAsync`, `LogLoadFailure`, `LogSaveFailure`) and updated tests: new tests in `tests/Meridian.Ui.Tests/Services/AtomicPersistenceServiceTests.cs` include a `TestExportPresetService` that overrides write/log hooks, plus tests for a corrupted preset file fallback and a forced write failure that raises the `SaveFailed` event.

### Testing
- Added unit tests: `LoadPresetsAsync_CorruptedFile_FallsBackAndLogsFailure` and `SavePresetsAsync_WriteFailure_ReturnsFalseAndRaisesFailureEvent` in `tests/Meridian.Ui.Tests/Services/AtomicPersistenceServiceTests.cs`. 
- Attempted to run a focused test slice (`AtomicPersistenceServiceTests`) but the automation environment lacked `dotnet`, so tests were not executed in-container. 
- Manual/CI run is recommended to validate the new tests and behavior in an environment with `dotnet` available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8b0b211c8320a9a070c794248704)