### PR TITLE
Add test for workstation trading readiness contract and degraded behavior when evidence is missing

### DIFF
--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -1211,6 +1211,114 @@ public sealed class WorkstationEndpointsTests
     }
 
     [Fact]
+    public async Task MapWorkstationEndpoints_TradingReadiness_ShouldExposeRequiredContractFieldsAndDegradeWhenEvidenceIsMissing()
+    {
+        var rootPath = Path.Combine(Path.GetTempPath(), "meridian-tests", "workstation-readiness-contract", Guid.NewGuid().ToString("N"));
+        var automationRoot = Path.Combine(rootPath, "provider-validation", "_automation");
+        Directory.CreateDirectory(automationRoot);
+
+        try
+        {
+            await using var app = await CreateAppAsync(services =>
+            {
+                RegisterRunReadServices(services);
+                RegisterPromotionServices(services, Path.Combine(rootPath, "promotions"));
+                services.AddSingleton(new Dk1TrustGateReadinessOptions(automationRoot));
+                services.AddSingleton<Dk1TrustGateReadinessService>();
+                services.AddSingleton(_ => new ExecutionAuditTrailService(
+                    new ExecutionAuditTrailOptions(Path.Combine(rootPath, "audit")),
+                    NullLogger<ExecutionAuditTrailService>.Instance));
+                services.AddSingleton<IPaperSessionStore>(_ => new JsonlFilePaperSessionStore(
+                    Path.Combine(rootPath, "sessions"),
+                    NullLogger<JsonlFilePaperSessionStore>.Instance));
+                services.AddSingleton<PaperSessionPersistenceService>(sp => new PaperSessionPersistenceService(
+                    NullLogger<PaperSessionPersistenceService>.Instance,
+                    sp.GetRequiredService<IPaperSessionStore>(),
+                    sp.GetRequiredService<ExecutionAuditTrailService>()));
+            });
+
+            var store = app.Services.GetRequiredService<IStrategyRepository>();
+            await store.RecordRunAsync(BuildRun(
+                runId: "run-contract-backtest",
+                strategyId: "strat-contract",
+                strategyName: "Contract Coverage",
+                runType: RunType.Backtest,
+                startedAt: new DateTimeOffset(2026, 4, 28, 13, 0, 0, TimeSpan.Zero),
+                datasetReference: "dataset/us/equities",
+                feedReference: "synthetic:equities").Complete(BuildBacktestResultWithSymbol("AAPL")));
+
+            var session = await app.Services.GetRequiredService<PaperSessionPersistenceService>().CreateSessionAsync(new CreatePaperSessionDto(
+                StrategyId: "strat-contract",
+                StrategyName: "Contract Coverage",
+                InitialCash: 125_000m,
+                Symbols: ["AAPL"]));
+
+            var client = app.GetTestClient();
+            using var response = await client.GetAsync(UiApiRoutes.WorkstationTradingReadiness);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            using var payload = await ReadJsonAsync(client, UiApiRoutes.WorkstationTradingReadiness);
+            var root = payload.RootElement;
+            root.TryGetProperty("overallStatus", out var overallStatus).Should().BeTrue();
+            root.TryGetProperty("readyForPaperOperation", out var readyForPaperOperation).Should().BeTrue();
+            root.TryGetProperty("trustGate", out var trustGate).Should().BeTrue();
+            root.TryGetProperty("replay", out var replay).Should().BeTrue();
+            root.TryGetProperty("promotion", out var promotion).Should().BeTrue();
+            root.TryGetProperty("acceptanceGates", out var acceptanceGates).Should().BeTrue();
+            root.TryGetProperty("workItems", out var workItems).Should().BeTrue();
+            overallStatus.ValueKind.Should().Be(JsonValueKind.String);
+            readyForPaperOperation.ValueKind.Should().Be(JsonValueKind.False);
+            trustGate.ValueKind.Should().Be(JsonValueKind.Object);
+            replay.ValueKind.Should().Be(JsonValueKind.Null);
+            promotion.ValueKind.Should().Be(JsonValueKind.Null);
+            acceptanceGates.ValueKind.Should().Be(JsonValueKind.Array);
+            workItems.ValueKind.Should().Be(JsonValueKind.Array);
+
+            var readiness = await client.GetFromJsonAsync<TradingOperatorReadinessDto>(
+                UiApiRoutes.WorkstationTradingReadiness,
+                ServerJsonOptions);
+            readiness.Should().NotBeNull();
+
+            readiness!.ActiveSession.Should().NotBeNull();
+            readiness.ActiveSession!.SessionId.Should().Be(session.SessionId);
+            readiness.TrustGate.Should().NotBeNull();
+            readiness.TrustGate.Status.Should().Be("packet-unavailable");
+            readiness.TrustGate.Blockers.Should().ContainSingle();
+            readiness.Replay.Should().BeNull();
+            readiness.Promotion.Should().BeNull();
+            readiness.OverallStatus.Should().Be(TradingAcceptanceGateStatusDto.ReviewRequired);
+
+            readiness.AcceptanceGates.Should().ContainSingle(gate =>
+                gate.GateId == "dk1-trust" &&
+                gate.Status == TradingAcceptanceGateStatusDto.ReviewRequired);
+            readiness.AcceptanceGates.Should().ContainSingle(gate =>
+                gate.GateId == "replay" &&
+                gate.Status == TradingAcceptanceGateStatusDto.ReviewRequired &&
+                gate.SessionId == session.SessionId);
+            readiness.AcceptanceGates.Should().ContainSingle(gate =>
+                gate.GateId == "promotion" &&
+                gate.Status == TradingAcceptanceGateStatusDto.ReviewRequired &&
+                gate.RunId == "run-contract-backtest");
+            readiness.WorkItems.Should().Contain(item =>
+                item.Kind == OperatorWorkItemKindDto.ProviderTrustGate &&
+                item.Tone == OperatorWorkItemToneDto.Warning);
+            readiness.WorkItems.Should().Contain(item =>
+                item.Kind == OperatorWorkItemKindDto.PaperReplay &&
+                item.Tone == OperatorWorkItemToneDto.Warning);
+            readiness.WorkItems.Should().Contain(item =>
+                item.Kind == OperatorWorkItemKindDto.PromotionReview &&
+                item.Tone == OperatorWorkItemToneDto.Warning);
+        }
+        finally
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public async Task MapWorkstationEndpoints_TradingReadinessWithoutRegisteredReadinessService_ShouldUseSharedReadinessBuilder()
     {
         await using var app = await CreateAppAsync();


### PR DESCRIPTION
### Motivation

- Ensure the workstation trading readiness API exposes the required contract fields for operator UIs and returns stable JSON shapes.
- Verify the readiness endpoint degrades gracefully and surfaces appropriate acceptance gates and work items when evidence is missing.

### Description

- Add `MapWorkstationEndpoints_TradingReadiness_ShouldExposeRequiredContractFieldsAndDegradeWhenEvidenceIsMissing` to `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` which validates the JSON contract and DTO mapping for the `/api/workstation/trading/readiness` endpoint. 
- The test sets up a temporary test directory, registers `Dk1TrustGateReadinessService`, `ExecutionAuditTrailService`, `JsonlFilePaperSessionStore`, and `PaperSessionPersistenceService`, and creates a backtest run and a paper session. 
- It calls `UiApiRoutes.WorkstationTradingReadiness`, asserts the presence and kinds of top-level JSON properties, deserializes into `TradingOperatorReadinessDto`, and verifies readiness fields such as `TrustGate.Status == "packet-unavailable"`, `Replay` and `Promotion` are `null`, `OverallStatus` is `ReviewRequired`, and expected acceptance gates and work items are present. 
- The test cleans up the temporary directory after execution.

### Testing

- Ran the unit tests in the `Meridian.Tests` project with `dotnet test`, which executed the new readiness test and the existing test suite. 
- All tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c896c0580832095c4ba31430ad8cb)