### PR TITLE
Detect and report corrupt persisted ledger journal entries during reconstruction

### DIFF
--- a/src/Meridian.Execution/Services/PaperSessionPersistenceService.cs
+++ b/src/Meridian.Execution/Services/PaperSessionPersistenceService.cs
@@ -66,7 +66,8 @@ public sealed class PaperSessionPersistenceService
             // Reconstruct the ledger from its persisted journal entries so past runs
             // remain queryable by LedgerReadService without a live portfolio.
             var ledgerEntries = await _store.LoadLedgerJournalAsync(record.SessionId, ct).ConfigureAwait(false);
-            var reconstructedLedger = ReconstructLedger(ledgerEntries);
+            var reconstruction = ReconstructLedger(ledgerEntries);
+            var reconstructedLedger = reconstruction.Ledger;
 
             // Load persisted order history.
             var orders = await _store.LoadOrderHistoryAsync(record.SessionId, ct).ConfigureAwait(false);
@@ -83,6 +84,7 @@ public sealed class PaperSessionPersistenceService
                 Symbols = record.Symbols.ToList(),
                 Portfolio = portfolio,
                 ReconstructedLedger = reconstructedLedger,
+                Reconstruction = reconstruction,
             };
             foreach (var fill in fills)
                 session.FillHistory.Add(fill);
@@ -192,32 +194,7 @@ public sealed class PaperSessionPersistenceService
         {
             return null;
         }
-
-        ExecutionPortfolioSnapshotDto? portfolioSnapshot = null;
-        if (session.Portfolio is not null)
-        {
-            var positions = session.Portfolio.Positions.Values.Cast<ExecutionPosition>().ToArray();
-            portfolioSnapshot = new ExecutionPortfolioSnapshotDto(
-                Cash: session.Portfolio.Cash,
-                PortfolioValue: session.Portfolio.PortfolioValue,
-                UnrealisedPnl: session.Portfolio.UnrealisedPnl,
-                RealisedPnl: session.Portfolio.RealisedPnl,
-                Positions: positions,
-                AsOf: DateTimeOffset.UtcNow);
-        }
-
-        return new PaperSessionDetailDto(
-            Summary: ToSummary(session),
-            Symbols: session.Symbols.ToArray(),
-            Portfolio: portfolioSnapshot,
-            OrderHistory: session.OrderHistory.ToArray(),
-            FillCount: session.FillHistory.Count,
-            LedgerEntryCount: GetLedger(sessionId)?.JournalEntryCount ?? 0,
-            LastFillAt: session.FillHistory.Count > 0
-                ? session.FillHistory.Max(static fill => fill.Timestamp)
-                : null,
-            LastOrderUpdatedAt: ResolveLastOrderUpdatedAt(session.OrderHistory),
-            FillHistory: session.FillHistory.ToArray());
+        return BuildSessionDetailDto(sessionId, session);
     }
 
     /// <summary>Returns the portfolio state for a live session, or null.</summary>
@@ -444,11 +421,11 @@ public sealed class PaperSessionPersistenceService
         string sessionId,
         CancellationToken ct = default)
     {
-        var detail = GetSession(sessionId);
-        if (detail is null)
+        if (!_sessions.TryGetValue(sessionId, out var session))
         {
             return null;
         }
+        var detail = BuildSessionDetailDto(sessionId, session);
 
         var replayPortfolio = await ReplaySessionAsync(sessionId, ct).ConfigureAwait(false);
         if (replayPortfolio is null)
@@ -482,6 +459,7 @@ public sealed class PaperSessionPersistenceService
         var persistedLedgerLineCount = _store is null
             ? currentLedgerLineCount
             : persistedLedgerEntries.Sum(static entry => entry.Lines.Count);
+        var reconstruction = session.Reconstruction;
         var lastPersistedFillAt = persistedFills.Count > 0
             ? persistedFills.Max(fill => fill.Timestamp)
             : (DateTimeOffset?)null;
@@ -498,6 +476,12 @@ public sealed class PaperSessionPersistenceService
             CompareLedgerJournal(currentLedger, persistedLedgerEntries, mismatchReasons);
         }
 
+        if (reconstruction.CorruptEntryCount > 0)
+        {
+            mismatchReasons.Add(
+                $"Persisted ledger reconstruction skipped {reconstruction.CorruptEntryCount} corrupt entr{(reconstruction.CorruptEntryCount == 1 ? "y" : "ies")} (IDs: {string.Join(", ", reconstruction.CorruptEntryIds)}).");
+        }
+
         var verificationAudit = await RecordVerificationAuditAsync(
             detail,
             mismatchReasons,
@@ -509,6 +493,7 @@ public sealed class PaperSessionPersistenceService
             persistedLedgerLineCount,
             lastPersistedFillAt,
             lastPersistedOrderUpdateAt,
+            reconstruction,
             replayPortfolio,
             ct).ConfigureAwait(false);
 
@@ -524,6 +509,8 @@ public sealed class PaperSessionPersistenceService
             ComparedFillCount: comparedFillCount,
             ComparedOrderCount: comparedOrderCount,
             ComparedLedgerEntryCount: comparedLedgerEntryCount,
+            CorruptLedgerEntryCount: reconstruction.CorruptEntryCount,
+            CorruptLedgerEntryIds: reconstruction.CorruptEntryIds,
             LastPersistedFillAt: lastPersistedFillAt,
             LastPersistedOrderUpdateAt: lastPersistedOrderUpdateAt,
             VerificationAuditId: verificationAudit?.AuditId);
@@ -540,6 +527,7 @@ public sealed class PaperSessionPersistenceService
         int persistedLedgerLineCount,
         DateTimeOffset? lastPersistedFillAt,
         DateTimeOffset? lastPersistedOrderUpdateAt,
+        LedgerReconstructionResult reconstruction,
         ExecutionPortfolioSnapshotDto replayPortfolio,
         CancellationToken ct)
     {
@@ -563,6 +551,8 @@ public sealed class PaperSessionPersistenceService
             ["lastPersistedFillAt"] = lastPersistedFillAt?.ToString("O") ?? string.Empty,
             ["lastPersistedOrderUpdateAt"] = lastPersistedOrderUpdateAt?.ToString("O") ?? string.Empty,
             ["mismatchCount"] = mismatchReasons.Count.ToString(),
+            ["corruptLedgerEntryCount"] = reconstruction.CorruptEntryCount.ToString(),
+            ["corruptLedgerEntryIds"] = string.Join(",", reconstruction.CorruptEntryIds),
             ["primaryMismatchReason"] = mismatchReasons.FirstOrDefault() ?? string.Empty
         };
 
@@ -650,12 +640,13 @@ public sealed class PaperSessionPersistenceService
         }
     }
 
-    private static Meridian.Ledger.Ledger? ReconstructLedger(IReadOnlyList<PersistedJournalEntryDto> dtos)
+    private LedgerReconstructionResult ReconstructLedger(IReadOnlyList<PersistedJournalEntryDto> dtos)
     {
         if (dtos.Count == 0)
-            return null;
+            return LedgerReconstructionResult.Empty;
 
         var ledger = new Meridian.Ledger.Ledger();
+        var corruptEntryIds = new List<string>();
         foreach (var dto in dtos)
         {
             try
@@ -680,13 +671,20 @@ public sealed class PaperSessionPersistenceService
 
                 ledger.Post(entry);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // Skip corrupt entries — best-effort reconstruction.
+                var accountHint = dto.Lines?.FirstOrDefault()?.Account?.Name ?? "unknown";
+                corruptEntryIds.Add(dto.JournalEntryId.ToString("D"));
+                _logger.LogWarning(
+                    ex,
+                    "Skipping corrupt persisted ledger journal entry {JournalEntryId} (symbol={Symbol}, accountHint={AccountHint}) during paper session reconstruction.",
+                    dto.JournalEntryId,
+                    dto.Symbol ?? "unknown",
+                    accountHint);
             }
         }
 
-        return ledger;
+        return new LedgerReconstructionResult(ledger, corruptEntryIds);
     }
 
     // ------------------------------------------------------------------
@@ -944,6 +942,35 @@ public sealed class PaperSessionPersistenceService
             .Max();
     }
 
+    private PaperSessionDetailDto BuildSessionDetailDto(string sessionId, PaperSession session)
+    {
+        ExecutionPortfolioSnapshotDto? portfolioSnapshot = null;
+        if (session.Portfolio is not null)
+        {
+            var positions = session.Portfolio.Positions.Values.Cast<ExecutionPosition>().ToArray();
+            portfolioSnapshot = new ExecutionPortfolioSnapshotDto(
+                Cash: session.Portfolio.Cash,
+                PortfolioValue: session.Portfolio.PortfolioValue,
+                UnrealisedPnl: session.Portfolio.UnrealisedPnl,
+                RealisedPnl: session.Portfolio.RealisedPnl,
+                Positions: positions,
+                AsOf: DateTimeOffset.UtcNow);
+        }
+
+        return new PaperSessionDetailDto(
+            Summary: ToSummary(session),
+            Symbols: session.Symbols.ToArray(),
+            Portfolio: portfolioSnapshot,
+            OrderHistory: session.OrderHistory.ToArray(),
+            FillCount: session.FillHistory.Count,
+            LedgerEntryCount: GetLedger(sessionId)?.JournalEntryCount ?? 0,
+            LastFillAt: session.FillHistory.Count > 0
+                ? session.FillHistory.Max(static fill => fill.Timestamp)
+                : null,
+            LastOrderUpdatedAt: ResolveLastOrderUpdatedAt(session.OrderHistory),
+            FillHistory: session.FillHistory.ToArray());
+    }
+
     private sealed class PaperSession
     {
         public required string SessionId { get; init; }
@@ -963,6 +990,7 @@ public sealed class PaperSessionPersistenceService
         /// For active sessions use <c>Portfolio.Ledger</c> instead.
         /// </summary>
         public IReadOnlyLedger? ReconstructedLedger { get; init; }
+        public LedgerReconstructionResult Reconstruction { get; init; } = LedgerReconstructionResult.Empty;
     }
 }
 
@@ -1011,6 +1039,14 @@ public sealed record ExecutionPortfolioSnapshotDto(
     public decimal CashBalance => Cash;
 }
 
+internal sealed record LedgerReconstructionResult(
+    Meridian.Ledger.Ledger? Ledger,
+    IReadOnlyList<string> CorruptEntryIds)
+{
+    public static LedgerReconstructionResult Empty { get; } = new(null, []);
+    public int CorruptEntryCount => CorruptEntryIds.Count;
+}
+
 /// <summary>
 /// Result of replaying a paper session and comparing the replayed state to the
 /// currently tracked portfolio snapshot.
@@ -1027,6 +1063,8 @@ public sealed record PaperSessionReplayVerificationDto(
     int ComparedFillCount,
     int ComparedOrderCount,
     int ComparedLedgerEntryCount,
+    int CorruptLedgerEntryCount,
+    IReadOnlyList<string> CorruptLedgerEntryIds,
     DateTimeOffset? LastPersistedFillAt,
     DateTimeOffset? LastPersistedOrderUpdateAt,
     string? VerificationAuditId)

--- a/tests/Meridian.Tests/Execution/PaperSessionPersistenceServiceTests.cs
+++ b/tests/Meridian.Tests/Execution/PaperSessionPersistenceServiceTests.cs
@@ -976,7 +976,7 @@ public sealed class PaperSessionReplayTests : IDisposable
         verification.Should().NotBeNull();
         verification!.ReplayPortfolio.Positions.Should().ContainSingle(position => position.Symbol == "AAPL");
         verification.CorruptLedgerEntryCount.Should().Be(1);
-        verification.CorruptLedgerEntryIds.Should().Contain("journal-corrupt");
+        verification.CorruptLedgerEntryIds.Should().Contain("22222222-2222-2222-2222-222222222222");
         verification.IsConsistent.Should().BeFalse();
         verification.MismatchReasons.Should().Contain(reason =>
             reason.Contains("skipped 1 corrupt entry", StringComparison.OrdinalIgnoreCase));
@@ -985,7 +985,7 @@ public sealed class PaperSessionReplayTests : IDisposable
         var auditEntry = auditEntries.Single(entry => entry.AuditId == verification.VerificationAuditId);
         auditEntry.Outcome.Should().Be("AttentionRequired");
         auditEntry.Metadata!["corruptLedgerEntryCount"].Should().Be("1");
-        auditEntry.Metadata["corruptLedgerEntryIds"].Should().Contain("journal-corrupt");
+        auditEntry.Metadata["corruptLedgerEntryIds"].Should().Contain("22222222-2222-2222-2222-222222222222");
     }
 }
 

--- a/tests/Meridian.Tests/Execution/PaperSessionPersistenceServiceTests.cs
+++ b/tests/Meridian.Tests/Execution/PaperSessionPersistenceServiceTests.cs
@@ -1035,7 +1035,21 @@ internal sealed class CorruptLedgerReplayStore : IPaperSessionStore
             [new PersistedSessionRecord("PAPER-CORRUPT-001", "strat-corrupt", "Corrupt", 100_000m, DateTimeOffset.UtcNow.AddMinutes(-30), null, true, ["AAPL"])]);
 
     public Task<IReadOnlyList<ExecutionReport>> LoadFillsAsync(string sessionId, CancellationToken ct = default)
-        => Task.FromResult<IReadOnlyList<ExecutionReport>>([new ExecutionReport("fill-1", "AAPL", 10m, 100m, DateTimeOffset.UtcNow.AddMinutes(-20), ExecutionSide.Buy, OrderType.Market)]);
+        => Task.FromResult<IReadOnlyList<ExecutionReport>>(
+            [
+                new()
+                {
+                    OrderId = "fill-1",
+                    ReportType = ExecutionReportType.Fill,
+                    Symbol = "AAPL",
+                    Side = OrderSide.Buy,
+                    OrderStatus = OrderStatus.Filled,
+                    OrderQuantity = 10m,
+                    FilledQuantity = 10m,
+                    FillPrice = 100m,
+                    Timestamp = DateTimeOffset.UtcNow.AddMinutes(-20)
+                }
+            ]);
 
     public Task<IReadOnlyList<OrderState>> LoadOrderHistoryAsync(string sessionId, CancellationToken ct = default)
         => Task.FromResult<IReadOnlyList<OrderState>>([]);

--- a/tests/Meridian.Tests/Execution/PaperSessionPersistenceServiceTests.cs
+++ b/tests/Meridian.Tests/Execution/PaperSessionPersistenceServiceTests.cs
@@ -961,6 +961,32 @@ public sealed class PaperSessionReplayTests : IDisposable
 
         verification.Should().BeNull();
     }
+
+    [Fact]
+    public async Task VerifyReplayAsync_WhenLedgerJournalContainsCorruptEntries_ReportsDegradedButKeepsSuccessfulEntries()
+    {
+        await using var auditTrail = new ExecutionAuditTrailService(
+            new ExecutionAuditTrailOptions(Path.Combine(_tempDir, "corrupt-ledger-audit")),
+            NullLogger<ExecutionAuditTrailService>.Instance);
+        var service = Build(new CorruptLedgerReplayStore(), auditTrail);
+        await service.InitialiseAsync();
+
+        var verification = await service.VerifyReplayAsync("PAPER-CORRUPT-001");
+
+        verification.Should().NotBeNull();
+        verification!.ReplayPortfolio.Positions.Should().ContainSingle(position => position.Symbol == "AAPL");
+        verification.CorruptLedgerEntryCount.Should().Be(1);
+        verification.CorruptLedgerEntryIds.Should().Contain("journal-corrupt");
+        verification.IsConsistent.Should().BeFalse();
+        verification.MismatchReasons.Should().Contain(reason =>
+            reason.Contains("skipped 1 corrupt entry", StringComparison.OrdinalIgnoreCase));
+
+        var auditEntries = await auditTrail.GetAllAsync();
+        var auditEntry = auditEntries.Single(entry => entry.AuditId == verification.VerificationAuditId);
+        auditEntry.Outcome.Should().Be("AttentionRequired");
+        auditEntry.Metadata!["corruptLedgerEntryCount"].Should().Be("1");
+        auditEntry.Metadata["corruptLedgerEntryIds"].Should().Contain("journal-corrupt");
+    }
 }
 
 
@@ -994,6 +1020,93 @@ internal sealed class ThrowingLedgerSaveStore : IPaperSessionStore
         string sessionId,
         CancellationToken ct = default)
         => Task.FromResult<IReadOnlyList<PersistedJournalEntryDto>>([]);
+}
+
+internal sealed class CorruptLedgerReplayStore : IPaperSessionStore
+{
+    public Task SaveSessionMetadataAsync(PersistedSessionRecord record, CancellationToken ct = default) => Task.CompletedTask;
+    public Task AppendFillAsync(string sessionId, ExecutionReport fill, CancellationToken ct = default) => Task.CompletedTask;
+    public Task AppendOrderUpdateAsync(string sessionId, OrderState order, CancellationToken ct = default) => Task.CompletedTask;
+    public Task SaveLedgerJournalAsync(string sessionId, IReadOnlyList<PersistedJournalEntryDto> entries, CancellationToken ct = default) => Task.CompletedTask;
+    public Task SaveSessionClosedAtAsync(string sessionId, DateTimeOffset? closedAtUtc, CancellationToken ct = default) => Task.CompletedTask;
+
+    public Task<IReadOnlyList<PersistedSessionRecord>> LoadAllSessionsAsync(CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<PersistedSessionRecord>>(
+            [new PersistedSessionRecord("PAPER-CORRUPT-001", "strat-corrupt", "Corrupt", 100_000m, DateTimeOffset.UtcNow.AddMinutes(-30), null, true, ["AAPL"])]);
+
+    public Task<IReadOnlyList<ExecutionReport>> LoadFillsAsync(string sessionId, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<ExecutionReport>>([new ExecutionReport("fill-1", "AAPL", 10m, 100m, DateTimeOffset.UtcNow.AddMinutes(-20), ExecutionSide.Buy, OrderType.Market)]);
+
+    public Task<IReadOnlyList<OrderState>> LoadOrderHistoryAsync(string sessionId, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<OrderState>>([]);
+
+    public Task<IReadOnlyList<PersistedJournalEntryDto>> LoadLedgerJournalAsync(string sessionId, CancellationToken ct = default)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var journalOkId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var corruptJournalId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+        PersistedJournalEntryDto BuildEntry(
+            Guid journalId,
+            string description,
+            DateTimeOffset timestamp,
+            IReadOnlyList<PersistedLedgerLineDto> lines)
+            => new(
+                JournalEntryId: journalId,
+                Timestamp: timestamp,
+                Description: description,
+                Lines: lines,
+                ActivityType: "Trade",
+                Symbol: "AAPL",
+                SecurityId: null,
+                OrderId: null,
+                LedgerView: "Trading",
+                StrategyId: "strat-corrupt");
+
+        PersistedLedgerLineDto BuildLine(
+            Guid entryId,
+            Guid journalId,
+            DateTimeOffset timestamp,
+            string accountName,
+            decimal debit,
+            decimal credit,
+            string description)
+            => new(
+                EntryId: entryId,
+                JournalEntryId: journalId,
+                Timestamp: timestamp,
+                Account: new PersistedLedgerAccountDto(accountName, "Asset", "AAPL", null),
+                Debit: debit,
+                Credit: credit,
+                Description: description);
+
+        var validEntry = BuildEntry(
+            journalOkId,
+            "buy entry",
+            now.AddMinutes(-19),
+            [
+                BuildLine(Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1"), journalOkId, now.AddMinutes(-19), "Cash", 0m, 1000m, "credit cash"),
+                BuildLine(Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2"), journalOkId, now.AddMinutes(-19), "Position", 1000m, 0m, "debit pos")
+            ]);
+
+        // Intentionally corrupt: line references a different JournalEntryId than parent.
+        var corruptEntry = BuildEntry(
+            corruptJournalId,
+            "corrupt entry",
+            now.AddMinutes(-18),
+            [
+                BuildLine(
+                    Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1"),
+                    Guid.Parse("33333333-3333-3333-3333-333333333333"),
+                    now.AddMinutes(-18),
+                    "Cash",
+                    100m,
+                    0m,
+                    "bad")
+            ]);
+
+        return Task.FromResult<IReadOnlyList<PersistedJournalEntryDto>>([validEntry, corruptEntry]);
+    }
 }
 internal sealed class ThrowingOrderUpdateStore : IPaperSessionStore
 {


### PR DESCRIPTION
### Motivation
- Improve robustness and observability for paper-session ledger reconstruction when persisted journal entries are corrupt so replay verification can report degraded reconstructions. 

### Description
- Introduced `LedgerReconstructionResult` to return both a reconstructed `Ledger` and any corrupt persisted journal entry IDs from `ReconstructLedger` instead of returning a raw ledger. 
- `ReconstructLedger` now collects corrupt entry IDs, logs a warning for each skipped entry, and returns a `LedgerReconstructionResult` including the ledger and `CorruptEntryIds`. 
- Persisted reconstruction metadata is stored on `PaperSession` as `Reconstruction` during `InitialiseAsync` and propagated into replay verification logic. 
- `VerifyReplayInternalAsync` now includes corrupt-entry details in mismatch reasons, the verification DTO (`PaperSessionReplayVerificationDto`), and audit metadata (`corruptLedgerEntryCount` and `corruptLedgerEntryIds`). 
- Factored out duplicated session-detail construction into `BuildSessionDetailDto` and updated `GetSession` and verification flows to use it. 

### Testing
- Ran unit tests in `tests/Meridian.Tests/Execution/PaperSessionPersistenceServiceTests.cs` including the new test `VerifyReplayAsync_WhenLedgerJournalContainsCorruptEntries_ReportsDegradedButKeepsSuccessfulEntries`, which passed. 
- Existing replay verification tests were executed and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8b0131c0832090bb2236d7c75d61)