### PR TITLE
Follow-up: restore in-memory preset on delete save failure

### DIFF
--- a/src/Meridian.Ui.Services/Services/ExportPresetServiceBase.cs
+++ b/src/Meridian.Ui.Services/Services/ExportPresetServiceBase.cs
@@ -188,9 +188,11 @@ public class ExportPresetServiceBase
         if (preset == null || preset.IsBuiltIn)
             return false;
 
-        _presets.Remove(preset);
+        var presetIndex = _presets.IndexOf(preset);
+        _presets.RemoveAt(presetIndex);
         if (!await SavePresetsAsync(cancellationToken))
         {
+            _presets.Insert(presetIndex, preset);
             return false;
         }
 

--- a/tests/Meridian.Ui.Tests/Services/AtomicPersistenceServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/AtomicPersistenceServiceTests.cs
@@ -126,6 +126,20 @@ public sealed class AtomicPersistenceServiceTests : IDisposable
         service.SaveFailures.Should().ContainSingle();
     }
 
+    [Fact]
+    public async Task DeletePresetAsync_SaveFailure_RestoresPresetInMemory()
+    {
+        var presetDirectory = Path.Combine(_tempDir, "delete-save-failure-presets");
+        var service = new TestExportPresetService(presetDirectory);
+        var preset = await service.CreatePresetAsync("Delete rollback", format: ExportPresetFormat.Jsonl);
+
+        service.ForceWriteFailure = true;
+        var deleted = await service.DeletePresetAsync(preset.Id);
+
+        deleted.Should().BeFalse();
+        service.GetPreset(preset.Id).Should().NotBeNull();
+    }
+
     private sealed class TestExportPresetService : ExportPresetServiceBase
     {
         public bool ForceWriteFailure { get; set; }


### PR DESCRIPTION
### Motivation
- Fix an inconsistent failure path where `DeletePresetAsync` removed a preset from the in-memory `_presets` list before persistence, causing callers to see `false` (failure) while the in-memory state no longer contained the preset and retries would fail.

### Description
- Update `DeletePresetAsync` to remove the preset by index, attempt `SavePresetsAsync`, and reinsert the preset at its original index when the save fails to keep the return value consistent with in-memory state (`src/Meridian.Ui.Services/Services/ExportPresetServiceBase.cs`).
- Add a regression unit test `DeletePresetAsync_SaveFailure_RestoresPresetInMemory` to `tests/Meridian.Ui.Tests/Services/AtomicPersistenceServiceTests.cs` that forces a write failure and asserts the preset remains in memory and the delete returns `false`.

### Testing
- Added test `DeletePresetAsync_SaveFailure_RestoresPresetInMemory` to the `AtomicPersistenceServiceTests` suite; it verifies the rollback behavior when `WritePresetsFileAsync` throws.
- Attempted to run the focused test slice (`AtomicPersistenceServiceTests`) but the container lacked `dotnet` so tests were not executed here (`/bin/bash: line 1: dotnet: command not found`); CI or a local environment with `dotnet` should be used to validate the new test and behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c927c5894832090e9028f97cff443)