### PR TITLE
[Follow-up to #1341] Fix corrupt ledger-entry ID assertions in replay verification test

### DIFF
--- a/tests/Meridian.Tests/Execution/PaperSessionPersistenceServiceTests.cs
+++ b/tests/Meridian.Tests/Execution/PaperSessionPersistenceServiceTests.cs
@@ -976,7 +976,7 @@ public sealed class PaperSessionReplayTests : IDisposable
         verification.Should().NotBeNull();
         verification!.ReplayPortfolio.Positions.Should().ContainSingle(position => position.Symbol == "AAPL");
         verification.CorruptLedgerEntryCount.Should().Be(1);
-        verification.CorruptLedgerEntryIds.Should().Contain("journal-corrupt");
+        verification.CorruptLedgerEntryIds.Should().Contain("22222222-2222-2222-2222-222222222222");
         verification.IsConsistent.Should().BeFalse();
         verification.MismatchReasons.Should().Contain(reason =>
             reason.Contains("skipped 1 corrupt entry", StringComparison.OrdinalIgnoreCase));
@@ -985,7 +985,7 @@ public sealed class PaperSessionReplayTests : IDisposable
         var auditEntry = auditEntries.Single(entry => entry.AuditId == verification.VerificationAuditId);
         auditEntry.Outcome.Should().Be("AttentionRequired");
         auditEntry.Metadata!["corruptLedgerEntryCount"].Should().Be("1");
-        auditEntry.Metadata["corruptLedgerEntryIds"].Should().Contain("journal-corrupt");
+        auditEntry.Metadata["corruptLedgerEntryIds"].Should().Contain("22222222-2222-2222-2222-222222222222");
     }
 }
 


### PR DESCRIPTION
### Motivation
- Align the replay-verification regression test with the updated reconstruction behavior that records corrupt ledger entry IDs using the persisted `JournalEntryId` GUID rather than a literal token.

### Description
- Updated `tests/Meridian.Tests/Execution/PaperSessionPersistenceServiceTests.cs` to replace the non-existent literal `"journal-corrupt"` with the persisted GUID `"22222222-2222-2222-2222-222222222222"` in both the `verification.CorruptLedgerEntryIds` assertion and the audit-metadata `corruptLedgerEntryIds` assertion.

### Testing
- Attempted a focused unit test via `dotnet test ... --filter "FullyQualifiedName~VerifyReplayAsync_WhenLedgerJournalContainsCorruptEntries_ReportsDegradedButKeepsSuccessfulEntries"`, but `dotnet` is unavailable in this environment so the test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9432810883208b1b659f35f38209)