### PR TITLE
Surface operator-inbox sign-off metadata in readiness console

### DIFF
--- a/src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.view-model.test.ts
@@ -704,8 +704,11 @@ describe("operator readiness console view model", () => {
       action: expect.objectContaining({ route: "/accounting/reconciliation" })
     }));
     expect(state.selectedWorkItemDetail?.fields).toEqual(expect.arrayContaining([
+      { label: "Required sign-off role", value: "Fund Controller" },
+      { label: "Sign-off status", value: "Pending" },
+      { label: "Tolerance profile", value: "month-end-25bp" },
       { label: "Route", value: "/accounting/reconciliation" },
-      { label: "Evidence", value: "Accounting - FundReconciliation - period-p02" }
+      { label: "Evidence", value: "Accounting - FundReconciliation - period-p02 - Fund Controller sign-off Pending" }
     ]));
     expect(state.nextAction).toEqual(expect.objectContaining({
       title: "SoftClosed sign-off required",

--- a/src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.view-model.ts
@@ -334,7 +334,7 @@ export function buildOperatorReadinessConsoleState({
     workItems: prioritizedWorkItems
   }), "cockpit-gates");
   const workItemRows = withRowPresentation(buildWorkItemRows(prioritizedWorkItems), "work-items");
-  const selectedWorkItemDetail = buildSelectedWorkItemDetail(workItemRows, selectedWorkItemId ?? null);
+  const selectedWorkItemDetail = buildSelectedWorkItemDetail(workItemRows, prioritizedWorkItems, selectedWorkItemId ?? null);
   const nextAction = buildNextAction({
     checkpointGates,
     workItemRows,
@@ -1079,17 +1079,32 @@ function prioritizeWorkItems(workItems: OperatorWorkItem[]): OperatorWorkItem[] 
 function buildWorkItemRow(item: OperatorWorkItem, includeAction: boolean): ReadinessConsoleRowBase {
   const action = includeAction ? buildWorkItemAction(item) : null;
   const createdAtLabel = formatReadinessUtcMinute(item.createdAt, "Timestamp unavailable");
+  const signoffSummary = buildSignoffSummary(item);
 
   return {
     id: item.workItemId,
     label: item.label,
     value: item.tone,
     detail: item.detail,
-    meta: [item.workspace, item.targetPageTag, item.runId, item.auditReference].filter(Boolean).join(" - ") || item.kind,
+    meta: [item.workspace, item.targetPageTag, item.runId, item.auditReference, signoffSummary].filter(Boolean).join(" - ") || item.kind,
     createdAtLabel,
     level: levelFromTone(item.tone),
     action
   };
+}
+
+function buildSignoffSummary(item: OperatorWorkItem): string | null {
+  const role = item.requiredSignoffRole?.trim();
+  const status = item.signoffStatus?.trim();
+  if (!role && !status) {
+    return null;
+  }
+
+  if (role && status) {
+    return `${role} sign-off ${status}`;
+  }
+
+  return role ? `${role} sign-off` : `Sign-off ${status}`;
 }
 
 function buildWorkItemAction(item: OperatorWorkItem): ReadinessConsoleRowAction | null {
@@ -1225,6 +1240,7 @@ function buildWorkItemsEmptyAction(nextAction: ReadinessConsoleNextAction): Read
 
 function buildSelectedWorkItemDetail(
   rows: ReadinessConsoleRow[],
+  workItems: OperatorWorkItem[],
   selectedWorkItemId: string | null
 ): ReadinessConsoleSelectedWorkItemDetail | null {
   if (rows.length === 0) {
@@ -1233,6 +1249,7 @@ function buildSelectedWorkItemDetail(
 
   const selectedRow = rows.find((row) => row.id === selectedWorkItemId) ?? rows[0];
   const actionRoute = selectedRow.action?.route ?? "No route action";
+  const selectedWorkItem = workItems.find((item) => item.workItemId === selectedRow.id) ?? null;
 
   return {
     id: selectedRow.id,
@@ -1247,6 +1264,9 @@ function buildSelectedWorkItemDetail(
       { label: "Work item ID", value: selectedRow.id },
       { label: "Attention", value: formatLevelText(selectedRow.level) },
       ...(selectedRow.createdAtLabel ? [{ label: "Created", value: selectedRow.createdAtLabel }] : []),
+      ...(selectedWorkItem?.requiredSignoffRole ? [{ label: "Required sign-off role", value: selectedWorkItem.requiredSignoffRole }] : []),
+      ...(selectedWorkItem?.signoffStatus ? [{ label: "Sign-off status", value: selectedWorkItem.signoffStatus }] : []),
+      ...(selectedWorkItem?.toleranceProfileId ? [{ label: "Tolerance profile", value: selectedWorkItem.toleranceProfileId }] : []),
       { label: "Route", value: actionRoute },
       { label: "Evidence", value: selectedRow.meta }
     ],


### PR DESCRIPTION
### Motivation
- Operators need to see sign-off metadata from the shared operator-inbox (required sign-off role, sign-off status, tolerance profile) when triaging readiness work items.  
- Enriching the UI evidence/meta text with sign-off summary improves triage without changing backend contracts.  
- Keep existing routing, IA, and primary readiness behavior unchanged while exposing the additional fields in the console detail panel.

### Description
- Added a `buildSignoffSummary` helper and include its output in work-item `meta` so evidence text now appends sign-off summary when present.  
- Render `requiredSignoffRole`, `signoffStatus`, and `toleranceProfileId` in the selected work-item detail fields by wiring the prioritized/merged work items into `buildSelectedWorkItemDetail`.  
- Adjusted the work-item row construction to carry the enriched `meta` and preserved existing `action`/route derivation logic.  
- Files changed: `src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.view-model.ts` and corresponding test updates in `src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.view-model.test.ts`.

### Testing
- Ran targeted unit tests with `npm run test -- operator-readiness-console.view-model.test.ts operator-readiness-console.test.tsx` and all tests passed (`27 tests` across the two files).  
- Built the dashboard with `npm run build` and the Vite production build completed successfully and produced `../wwwroot/workstation` assets.  
- Changes are limited to `src/Meridian.Ui/dashboard/` and validated via the updated unit tests and local build; no backend or WPF/mobile behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8c8e45188320bfaaf0d5121971cb)