### PR TITLE
Add unified provider validation evidence-bundle workflow and expose calibration posture to readiness DTO

### DIFF
--- a/docs/operations/provider-degradation-calibration.md
+++ b/docs/operations/provider-degradation-calibration.md
@@ -91,3 +91,32 @@ The workflow returns:
 - explicit `blockingReasons`
 
 A candidate kernel is promotable only when `approved == true`.
+
+
+## 7) Unified evidence-bundle automation
+
+Run the end-to-end flow with:
+
+```powershell
+./scripts/dev/run-provider-validation-evidence-bundle.ps1 -CalibrationInput ./incidents-2026-q1.json -BaselineKernelVersion kernel-v1 -CandidateKernelVersion kernel-v2
+```
+
+This command chains Wave 1 validation, DK1 parity packet generation, operator sign-off validation, and calibration governance output under `artifacts/provider-validation/_automation/<yyyy-mm-dd>/`.
+
+It fails fast when:
+- required summary/packet/sign-off fields are missing;
+- packet timestamps are stale compared with the Wave 1 summary;
+- gate outcomes are inconsistent (for example summary `passed` while packet is not `ready-for-operator-review`).
+
+Promotion checklist:
+1. `wave1-validation-summary.json` reports `result=passed`.
+2. `dk1-pilot-parity-packet.json` reports `status=ready-for-operator-review`.
+3. `dk1-operator-signoff.json` reports `validForDk1Exit=true`.
+4. Calibration governance output reports `approved=true` and `calibrationPass=true`.
+5. Evidence bundle reports `promotionPosture.status=candidate-approved`.
+
+Rollback triggers:
+- Any calibration governance `approved=false` decision.
+- Any stale or missing bundle artifact field in the required schema.
+- Any mismatch between summary and packet gate outcomes.
+- Any post-promotion packet/sign-off regression to non-ready or non-valid status.

--- a/docs/status/provider-validation-matrix.md
+++ b/docs/status/provider-validation-matrix.md
@@ -60,3 +60,17 @@ its bound operator sign-off file before replacing that signed evidence.
 - Robinhood remains polling-oriented and unofficial. Do not describe it as websocket-validated.
 - Yahoo is active only as a historical and fallback provider row for Wave 1.
 - `Polygon`, `Interactive Brokers`, `NYSE`, and `StockSharp` are deferred from the active Wave 1 gate.
+
+
+## Unified automation and promotion posture
+
+Use `./scripts/dev/run-provider-validation-evidence-bundle.ps1` to generate:
+- `wave1-validation-summary.json`
+- `dk1-pilot-parity-packet.json`
+- `dk1-operator-signoff.json`
+- `provider-degradation-governance.json` (when `-CalibrationInput` is provided)
+- `provider-validation-evidence-bundle.json`
+
+The evidence bundle standardizes schema and emits promotion posture (`candidate-approved`, `candidate-rejected`, or `not-run`) with baseline-versus-candidate kernel metadata.
+
+Promotion checklist and rollback triggers are authoritative in `docs/operations/provider-degradation-calibration.md`; this matrix requires those checks for any DK1 promotion decision.

--- a/scripts/dev/run-provider-validation-evidence-bundle.ps1
+++ b/scripts/dev/run-provider-validation-evidence-bundle.ps1
@@ -1,0 +1,88 @@
+param(
+    [string]$DateStamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd"),
+    [string]$OutputRoot = "artifacts/provider-validation/_automation",
+    [string]$CalibrationInput = "",
+    [string]$CandidateKernelVersion = "",
+    [string]$BaselineKernelVersion = "default",
+    [switch]$SkipWave1
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$bundleRoot = Join-Path (Join-Path $repoRoot $OutputRoot) $DateStamp
+New-Item -ItemType Directory -Force -Path $bundleRoot | Out-Null
+
+$wave1Script = Join-Path $PSScriptRoot "run-wave1-provider-validation.ps1"
+$packetScript = Join-Path $PSScriptRoot "generate-dk1-pilot-parity-packet.ps1"
+$signoffScript = Join-Path $PSScriptRoot "prepare-dk1-operator-signoff.ps1"
+
+$summaryPath = Join-Path $bundleRoot "wave1-validation-summary.json"
+$packetPath = Join-Path $bundleRoot "dk1-pilot-parity-packet.json"
+$signoffPath = Join-Path $bundleRoot "dk1-operator-signoff.json"
+$calibrationReportPath = Join-Path $bundleRoot "provider-degradation-calibration.md"
+$governancePath = Join-Path $bundleRoot "provider-degradation-governance.json"
+$bundlePath = Join-Path $bundleRoot "provider-validation-evidence-bundle.json"
+
+if (-not $SkipWave1) {
+    & $wave1Script -DateStamp $DateStamp -OutputRoot $OutputRoot
+}
+
+& $packetScript -DateStamp $DateStamp -OutputRoot $OutputRoot -SummaryJsonPath $summaryPath
+& $signoffScript -OutputPath $signoffPath -PacketPath $packetPath -Validate
+
+$calibration = $null
+if (-not [string]::IsNullOrWhiteSpace($CalibrationInput)) {
+    if ([string]::IsNullOrWhiteSpace($CandidateKernelVersion)) {
+        $CandidateKernelVersion = "kernel-$((Get-Date).ToUniversalTime().ToString('yyyyMMddHHmmss'))"
+    }
+
+    dotnet run --project src/Meridian/Meridian.csproj -- --calibrate-provider-degradation --calibration-input $CalibrationInput --candidate-kernel-version $CandidateKernelVersion --baseline-kernel-version $BaselineKernelVersion --calibration-report $calibrationReportPath --governance-output $governancePath | Out-Host
+    $calibration = Get-Content -Raw -LiteralPath $governancePath | ConvertFrom-Json
+}
+
+$summary = Get-Content -Raw -LiteralPath $summaryPath | ConvertFrom-Json
+$packet = Get-Content -Raw -LiteralPath $packetPath | ConvertFrom-Json
+$signoff = Get-Content -Raw -LiteralPath $signoffPath | ConvertFrom-Json
+
+if (-not $summary.generatedAtUtc -or -not $summary.result) { throw "Summary schema invalid: missing generatedAtUtc/result." }
+if (-not $packet.generatedAtUtc -or -not $packet.status) { throw "Parity packet schema invalid: missing generatedAtUtc/status." }
+if (-not $signoff.packetReview -or -not $signoff.packetReview.validForOperatorReview) { throw "Sign-off schema invalid or packet review not ready." }
+
+$summaryAt = [DateTimeOffset]::Parse($summary.generatedAtUtc)
+$packetAt = [DateTimeOffset]::Parse($packet.generatedAtUtc)
+if ($packetAt -lt $summaryAt) { throw "Stale packet: packet timestamp predates summary timestamp." }
+if ($summary.result -eq "passed" -and $packet.status -ne "ready-for-operator-review") { throw "Gate mismatch: summary passed but packet not ready-for-operator-review." }
+
+$promotion = if ($null -eq $calibration) {
+    [ordered]@{ status = "not-run"; recommendation = "Calibration input not provided." }
+} else {
+    [ordered]@{
+        status = if ($calibration.approved) { "candidate-approved" } else { "candidate-rejected" }
+        baselineKernelVersion = $BaselineKernelVersion
+        candidateKernelVersion = $CandidateKernelVersion
+        calibrationPass = [bool]$calibration.calibrationPass
+        approved = [bool]$calibration.approved
+        recommendation = if ($calibration.approved) { "Promote candidate kernel." } else { "Retain baseline kernel and rerun with updated calibration dataset." }
+    }
+}
+
+$bundle = [ordered]@{
+    generatedAtUtc = (Get-Date).ToUniversalTime().ToString("O")
+    dateStamp = $DateStamp
+    summaryPath = "artifacts/provider-validation/_automation/$DateStamp/wave1-validation-summary.json"
+    parityPacketPath = "artifacts/provider-validation/_automation/$DateStamp/dk1-pilot-parity-packet.json"
+    signoffPath = "artifacts/provider-validation/_automation/$DateStamp/dk1-operator-signoff.json"
+    calibrationGovernancePath = if (Test-Path $governancePath) { "artifacts/provider-validation/_automation/$DateStamp/provider-degradation-governance.json" } else { $null }
+    schemaVersion = "provider-validation-bundle/v1"
+    gateOutcome = [ordered]@{
+        wave1Result = [string]$summary.result
+        dk1Status = [string]$packet.status
+        operatorSignoffValidForDk1Exit = [bool]$signoff.validForDk1Exit
+    }
+    promotionPosture = $promotion
+}
+
+$bundle | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $bundlePath -Encoding utf8
+Write-Host "Evidence bundle created: $bundlePath"

--- a/scripts/dev/run-provider-validation-evidence-bundle.ps1
+++ b/scripts/dev/run-provider-validation-evidence-bundle.ps1
@@ -10,6 +10,17 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
+function ConvertTo-RepoRelativePath {
+    param([Parameter(Mandatory)][string]$Path)
+
+    $fullPath = [System.IO.Path]::GetFullPath($Path)
+    if ($fullPath.StartsWith($repoRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $fullPath.Substring($repoRoot.Length + 1).Replace('\', '/')
+    }
+
+    return $fullPath
+}
+
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 $bundleRoot = Join-Path (Join-Path $repoRoot $OutputRoot) $DateStamp
 New-Item -ItemType Directory -Force -Path $bundleRoot | Out-Null
@@ -30,7 +41,12 @@ if (-not $SkipWave1) {
 }
 
 & $packetScript -DateStamp $DateStamp -OutputRoot $OutputRoot -SummaryJsonPath $summaryPath
-& $signoffScript -OutputPath $signoffPath -PacketPath $packetPath -Validate
+if (-not (Test-Path -LiteralPath $signoffPath)) {
+    & $signoffScript -OutputPath $signoffPath -PacketPath $packetPath
+    throw "Operator sign-off template generated at '$signoffPath'. Complete and approve the template, then re-run this script."
+}
+
+$signoffReview = & $signoffScript -OutputPath $signoffPath -PacketPath $packetPath -Validate -Json | ConvertFrom-Json
 
 $calibration = $null
 if (-not [string]::IsNullOrWhiteSpace($CalibrationInput)) {
@@ -38,7 +54,24 @@ if (-not [string]::IsNullOrWhiteSpace($CalibrationInput)) {
         $CandidateKernelVersion = "kernel-$((Get-Date).ToUniversalTime().ToString('yyyyMMddHHmmss'))"
     }
 
-    dotnet run --project src/Meridian/Meridian.csproj -- --calibrate-provider-degradation --calibration-input $CalibrationInput --candidate-kernel-version $CandidateKernelVersion --baseline-kernel-version $BaselineKernelVersion --calibration-report $calibrationReportPath --governance-output $governancePath | Out-Host
+    $dotnetArgs = @(
+        "run",
+        "--project",
+        "src/Meridian/Meridian.csproj",
+        "--",
+        "--calibrate-provider-degradation",
+        "--calibration-input",
+        $CalibrationInput,
+        "--candidate-kernel-version",
+        $CandidateKernelVersion,
+        "--baseline-kernel-version",
+        $BaselineKernelVersion,
+        "--calibration-report",
+        $calibrationReportPath,
+        "--governance-output",
+        $governancePath
+    )
+    & dotnet @dotnetArgs | Out-Host
     $calibration = Get-Content -Raw -LiteralPath $governancePath | ConvertFrom-Json
 }
 
@@ -49,6 +82,7 @@ $signoff = Get-Content -Raw -LiteralPath $signoffPath | ConvertFrom-Json
 if (-not $summary.generatedAtUtc -or -not $summary.result) { throw "Summary schema invalid: missing generatedAtUtc/result." }
 if (-not $packet.generatedAtUtc -or -not $packet.status) { throw "Parity packet schema invalid: missing generatedAtUtc/status." }
 if (-not $signoff.packetReview -or -not $signoff.packetReview.validForOperatorReview) { throw "Sign-off schema invalid or packet review not ready." }
+if (-not $signoffReview.validForDk1Exit) { throw "Operator sign-off review did not satisfy DK1 exit requirements." }
 
 $summaryAt = [DateTimeOffset]::Parse($summary.generatedAtUtc)
 $packetAt = [DateTimeOffset]::Parse($packet.generatedAtUtc)
@@ -71,15 +105,15 @@ $promotion = if ($null -eq $calibration) {
 $bundle = [ordered]@{
     generatedAtUtc = (Get-Date).ToUniversalTime().ToString("O")
     dateStamp = $DateStamp
-    summaryPath = "artifacts/provider-validation/_automation/$DateStamp/wave1-validation-summary.json"
-    parityPacketPath = "artifacts/provider-validation/_automation/$DateStamp/dk1-pilot-parity-packet.json"
-    signoffPath = "artifacts/provider-validation/_automation/$DateStamp/dk1-operator-signoff.json"
-    calibrationGovernancePath = if (Test-Path $governancePath) { "artifacts/provider-validation/_automation/$DateStamp/provider-degradation-governance.json" } else { $null }
+    summaryPath = ConvertTo-RepoRelativePath -Path $summaryPath
+    parityPacketPath = ConvertTo-RepoRelativePath -Path $packetPath
+    signoffPath = ConvertTo-RepoRelativePath -Path $signoffPath
+    calibrationGovernancePath = if (Test-Path $governancePath) { ConvertTo-RepoRelativePath -Path $governancePath } else { $null }
     schemaVersion = "provider-validation-bundle/v1"
     gateOutcome = [ordered]@{
         wave1Result = [string]$summary.result
         dk1Status = [string]$packet.status
-        operatorSignoffValidForDk1Exit = [bool]$signoff.validForDk1Exit
+        operatorSignoffValidForDk1Exit = [bool]$signoffReview.validForDk1Exit
     }
     promotionPosture = $promotion
 }

--- a/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
+++ b/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
@@ -233,6 +233,12 @@ public sealed record TradingTrustGateReadinessDto(
     public TradingTrustGateContractReadinessDto? TrustRationaleContract { get; init; }
 
     public TradingTrustGateContractReadinessDto? BaselineThresholdContract { get; init; }
+
+    public string? CalibrationVersion { get; init; }
+
+    public DateTimeOffset? CalibrationValidatedAt { get; init; }
+
+    public string? PromotionPosture { get; init; }
 }
 
 public sealed record TradingReportPackReadinessDto(

--- a/src/Meridian.Ui.Shared/Services/Dk1TrustGateReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/Dk1TrustGateReadinessService.cs
@@ -171,6 +171,7 @@ public sealed class Dk1TrustGateReadinessService
             MissingOwners: missingOwners,
             CompletedAt: operatorSignoffCompletedAt,
             SourcePath: operatorSignoffSourcePath);
+        var latestEvidenceBundle = TryGetLatestEvidenceBundle(automationRoot);
 
         return new TradingTrustGateReadinessDto(
             GateId: "DK1",
@@ -203,9 +204,9 @@ public sealed class Dk1TrustGateReadinessService
             EvidenceDocuments = evidenceDocumentReviews,
             TrustRationaleContract = trustRationaleContract,
             BaselineThresholdContract = baselineThresholdContract,
-            CalibrationVersion = TryGetCalibrationVersion(automationRoot),
-            CalibrationValidatedAt = TryGetCalibrationValidatedAt(automationRoot),
-            PromotionPosture = TryGetPromotionPosture(automationRoot)
+            CalibrationVersion = TryGetCalibrationVersion(latestEvidenceBundle),
+            CalibrationValidatedAt = TryGetCalibrationValidatedAt(latestEvidenceBundle),
+            PromotionPosture = TryGetPromotionPosture(latestEvidenceBundle)
         };
     }
 
@@ -226,21 +227,18 @@ public sealed class Dk1TrustGateReadinessService
         return doc.RootElement.Clone();
     }
 
-    private static string? TryGetCalibrationVersion(string automationRoot)
+    private static string? TryGetCalibrationVersion(JsonElement? bundle)
     {
-        var bundle = TryGetLatestEvidenceBundle(automationRoot);
         return GetString(TryGetProperty(TryGetProperty(bundle, "promotionPosture"), "candidateKernelVersion"));
     }
 
-    private static DateTimeOffset? TryGetCalibrationValidatedAt(string automationRoot)
+    private static DateTimeOffset? TryGetCalibrationValidatedAt(JsonElement? bundle)
     {
-        var bundle = TryGetLatestEvidenceBundle(automationRoot);
         return TryParseDateTimeOffset(GetString(bundle, "generatedAtUtc"));
     }
 
-    private static string? TryGetPromotionPosture(string automationRoot)
+    private static string? TryGetPromotionPosture(JsonElement? bundle)
     {
-        var bundle = TryGetLatestEvidenceBundle(automationRoot);
         return GetString(TryGetProperty(TryGetProperty(bundle, "promotionPosture"), "status"));
     }
 
@@ -547,6 +545,9 @@ public sealed class Dk1TrustGateReadinessService
         var property = TryGetProperty(element, propertyName);
         return property is { ValueKind: JsonValueKind.String } value ? value.GetString() : null;
     }
+
+    private static string? GetString(JsonElement? element) =>
+        element is { ValueKind: JsonValueKind.String } value ? value.GetString() : null;
 
     private static int GetInt32(JsonElement? element, string propertyName)
     {

--- a/src/Meridian.Ui.Shared/Services/Dk1TrustGateReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/Dk1TrustGateReadinessService.cs
@@ -23,6 +23,7 @@ public sealed class Dk1TrustGateReadinessService
     ];
 
     private static readonly TimeSpan CacheDuration = TimeSpan.FromSeconds(30);
+    private const string EvidenceBundleFileName = "provider-validation-evidence-bundle.json";
 
     private readonly Dk1TrustGateReadinessOptions _options;
     private readonly ILogger<Dk1TrustGateReadinessService> _logger;
@@ -201,8 +202,46 @@ public sealed class Dk1TrustGateReadinessService
             SampleReviews = sampleReviews,
             EvidenceDocuments = evidenceDocumentReviews,
             TrustRationaleContract = trustRationaleContract,
-            BaselineThresholdContract = baselineThresholdContract
+            BaselineThresholdContract = baselineThresholdContract,
+            CalibrationVersion = TryGetCalibrationVersion(automationRoot),
+            CalibrationValidatedAt = TryGetCalibrationValidatedAt(automationRoot),
+            PromotionPosture = TryGetPromotionPosture(automationRoot)
         };
+    }
+
+    private static JsonElement? TryGetLatestEvidenceBundle(string automationRoot)
+    {
+        var bundlePath = Directory
+            .EnumerateFiles(automationRoot, EvidenceBundleFileName, SearchOption.AllDirectories)
+            .Select(path => new FileInfo(path))
+            .OrderByDescending(file => file.LastWriteTimeUtc)
+            .Select(file => file.FullName)
+            .FirstOrDefault();
+        if (bundlePath is null)
+        {
+            return null;
+        }
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(bundlePath));
+        return doc.RootElement.Clone();
+    }
+
+    private static string? TryGetCalibrationVersion(string automationRoot)
+    {
+        var bundle = TryGetLatestEvidenceBundle(automationRoot);
+        return GetString(TryGetProperty(TryGetProperty(bundle, "promotionPosture"), "candidateKernelVersion"));
+    }
+
+    private static DateTimeOffset? TryGetCalibrationValidatedAt(string automationRoot)
+    {
+        var bundle = TryGetLatestEvidenceBundle(automationRoot);
+        return TryParseDateTimeOffset(GetString(bundle, "generatedAtUtc"));
+    }
+
+    private static string? TryGetPromotionPosture(string automationRoot)
+    {
+        var bundle = TryGetLatestEvidenceBundle(automationRoot);
+        return GetString(TryGetProperty(TryGetProperty(bundle, "promotionPosture"), "status"));
     }
 
     private string? ResolveAutomationRoot()

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -2028,9 +2028,44 @@ public sealed class WorkstationEndpointsTests
         readiness.Blockers.Should().BeEmpty();
         readiness.TrustRationaleContract.Should().NotBeNull();
         readiness.TrustRationaleContract!.Status.Should().Be("validated");
+        readiness.CalibrationVersion.Should().BeNull();
+        readiness.CalibrationValidatedAt.Should().BeNull();
+        readiness.PromotionPosture.Should().BeNull();
         readiness.PacketPath.Should().NotBeNull();
         Path.IsPathRooted(readiness.PacketPath!).Should().BeFalse();
         readiness.PacketPath.Should().Contain("dk1-pilot-parity-packet.json");
+    }
+
+    [Fact]
+    public async Task Dk1TrustGateReadinessService_WithEvidenceBundle_ShouldExposeCalibrationPosture()
+    {
+        var automationRoot = Path.Combine(
+            Path.GetTempPath(),
+            "meridian-tests",
+            "dk1-calibration-bundle",
+            Guid.NewGuid().ToString("N"));
+        WriteReadyDk1Packet(automationRoot);
+        WriteProviderValidationEvidenceBundle(
+            automationRoot,
+            """
+            {
+              "generatedAtUtc": "2026-04-27T09:30:00Z",
+              "promotionPosture": {
+                "status": "candidate-approved",
+                "candidateKernelVersion": "kernel-v2"
+              }
+            }
+            """);
+
+        var service = new Dk1TrustGateReadinessService(
+            new Dk1TrustGateReadinessOptions(automationRoot),
+            NullLogger<Dk1TrustGateReadinessService>.Instance);
+
+        var readiness = await service.GetCurrentAsync();
+
+        readiness.CalibrationVersion.Should().Be("kernel-v2");
+        readiness.PromotionPosture.Should().Be("candidate-approved");
+        readiness.CalibrationValidatedAt.Should().Be(new DateTimeOffset(2026, 4, 27, 9, 30, 0, TimeSpan.Zero));
     }
 
     [Fact]
@@ -4044,6 +4079,15 @@ public sealed class WorkstationEndpointsTests
                 : string.Empty)
             .Replace("__OPERATOR_SIGNOFF__", operatorSignoffJson)
             .Replace("__BLOCKERS__", blockersJson));
+    }
+
+    private static void WriteProviderValidationEvidenceBundle(string automationRoot, string bundleJson)
+    {
+        var bundleDirectory = Path.Combine(automationRoot, "unit-ready");
+        Directory.CreateDirectory(bundleDirectory);
+        File.WriteAllText(
+            Path.Combine(bundleDirectory, "provider-validation-evidence-bundle.json"),
+            bundleJson);
     }
 
     private static void RegisterSecurityMasterWorkbenchServices(


### PR DESCRIPTION
### Motivation
- Provide a single scripted flow that chains Wave 1 validation outputs, DK1 parity packet generation, and operator sign-off validation into a dated evidence folder under `artifacts/provider-validation/_automation/<date>/` for reproducible review runs. 
- Standardize the required artifact schema and fail-fast validation so missing/stale/inconsistent evidence is caught early in the run. 
- Surface provider-degradation calibration results (baseline vs candidate, promotion recommendation) as operator-visible readiness metadata for the cockpit and API consumers. 

### Description
- Add `scripts/dev/run-provider-validation-evidence-bundle.ps1` which runs Wave 1 validation, generates the DK1 parity packet, validates operator sign-off, optionally runs provider-degradation calibration, and emits a standardized `provider-validation-evidence-bundle.json` with gate outcomes and promotion posture. 
- Implement fail-fast checks in the bundle flow for required summary/packet/sign-off fields, stale timestamps (packet < summary), and gate mismatches (e.g. summary `passed` but packet not `ready-for-operator-review`). 
- Extend the readiness contract with three new fields: `CalibrationVersion`, `CalibrationValidatedAt`, and `PromotionPosture` on `TradingTrustGateReadinessDto`. 
- Update `Dk1TrustGateReadinessService` to locate the latest evidence bundle and populate the new calibration/promotion fields so the dashboard/operator endpoints can report latest calibration version, validation date, and promotion posture. 
- Update docs: `docs/operations/provider-degradation-calibration.md` adds the unified automation usage, exact promotion checklist, and rollback triggers; `docs/status/provider-validation-matrix.md` documents the bundle outputs and requires the promotion checklist for DK1 decisions. 

### Testing
- Attempted to build the contracts project with `dotnet build src/Meridian.Contracts/Meridian.Contracts.csproj -c Release` but the environment lacks the `dotnet` tool, so the build could not be executed (`/bin/bash: dotnet: command not found`). 
- No automated unit or integration test runs were performed in this environment due to the missing `dotnet` runtime; runtime validation should be performed in a CI or developer environment with .NET available (recommended: run `./scripts/dev/run-provider-validation-evidence-bundle.ps1` and `dotnet test` as described in repo docs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca259fd8c832085c3dc10cbc74314)