### PR TITLE
Add wrapper-level failure handling, logging and testability to OAuthRefreshService; make CredentialService extensible

### DIFF
--- a/src/Meridian.Execution/Services/PaperSessionPersistenceService.cs
+++ b/src/Meridian.Execution/Services/PaperSessionPersistenceService.cs
@@ -427,8 +427,6 @@ public sealed class PaperSessionPersistenceService
         }
         var detail = BuildSessionDetailDto(sessionId, session);
 
-        var detail = BuildSessionDetailDto(sessionId, session);
-
         var replayPortfolio = await ReplaySessionAsync(sessionId, ct).ConfigureAwait(false);
         if (replayPortfolio is null)
         {

--- a/src/Meridian.Ui.Services/Services/CredentialService.cs
+++ b/src/Meridian.Ui.Services/Services/CredentialService.cs
@@ -22,16 +22,16 @@ public class CredentialService
 
     public event EventHandler<CredentialExpirationEventArgs>? CredentialExpiring;
 
-    public IReadOnlyList<CredentialWithMetadata> GetAllCredentialsWithMetadata()
+    public virtual IReadOnlyList<CredentialWithMetadata> GetAllCredentialsWithMetadata()
         => Array.Empty<CredentialWithMetadata>();
 
-    public Task<OAuthRefreshResult> RefreshOAuthTokenAsync(string providerId)
+    public virtual Task<OAuthRefreshResult> RefreshOAuthTokenAsync(string providerId)
         => Task.FromResult(new OAuthRefreshResult { Success = false, ErrorMessage = "Not implemented" });
 
-    public Task UpdateMetadataAsync(string resource, Action<CredentialMetadataUpdate> updateAction)
+    public virtual Task UpdateMetadataAsync(string resource, Action<CredentialMetadataUpdate> updateAction)
         => Task.CompletedTask;
 
-    public CredentialMetadataInfo? GetMetadata(string resource)
+    public virtual CredentialMetadataInfo? GetMetadata(string resource)
         => null;
 
     protected void OnCredentialExpiring(CredentialExpirationEventArgs e)

--- a/src/Meridian.Ui.Services/Services/OAuthRefreshService.cs
+++ b/src/Meridian.Ui.Services/Services/OAuthRefreshService.cs
@@ -1,5 +1,7 @@
 using System.Threading;
 using System.Timers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Meridian.Ui.Services;
 
@@ -10,14 +12,20 @@ namespace Meridian.Ui.Services;
 public sealed class OAuthRefreshService : IDisposable
 {
     private static readonly Lazy<OAuthRefreshService> _instance = new(() => new OAuthRefreshService());
+    private static readonly TimeSpan WrapperFailureLogThrottleWindow = TimeSpan.FromMinutes(1);
+    private static readonly ILoggerFactory SingletonLoggerFactory = LoggerFactory.Create(static _ => { });
     /// <summary>
     /// Gets the singleton instance of the OAuth refresh service.
     /// </summary>
     public static OAuthRefreshService Instance => _instance.Value;
 
     private readonly CredentialService _credentialService;
+    private readonly ILogger<OAuthRefreshService> _logger;
     private readonly System.Timers.Timer _refreshTimer;
     private readonly System.Timers.Timer _expirationCheckTimer;
+    private readonly Dictionary<string, DateTime> _lastWrapperFailureLogByOperation = new(StringComparer.Ordinal);
+    private readonly object _wrapperFailureSync = new();
+    private int _wrapperFailureCount;
     private bool _isRunning;
     private bool _disposed;
 
@@ -45,10 +53,26 @@ public sealed class OAuthRefreshService : IDisposable
     /// Event raised when a token is about to expire and cannot be auto-refreshed.
     /// </summary>
     public event EventHandler<TokenExpirationWarningEventArgs>? TokenExpirationWarning;
+    /// <summary>
+    /// Event raised when a wrapper-level timer operation fails.
+    /// </summary>
+    public event EventHandler<OAuthWrapperFailureEventArgs>? WrapperOperationFailed;
+
+    /// <summary>
+    /// Count of wrapper-level failures observed by safe background wrappers.
+    /// </summary>
+    public int WrapperFailureCount => Volatile.Read(ref _wrapperFailureCount);
 
     private OAuthRefreshService()
+        : this(new CredentialService(), SingletonLoggerFactory.CreateLogger<OAuthRefreshService>())
     {
-        _credentialService = new CredentialService();
+    }
+
+    internal OAuthRefreshService(CredentialService credentialService, ILogger<OAuthRefreshService>? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(credentialService);
+        _credentialService = credentialService;
+        _logger = logger ?? NullLogger<OAuthRefreshService>.Instance;
 
         _refreshTimer = new System.Timers.Timer(CheckIntervalMs);
         _refreshTimer.Elapsed += OnRefreshTimerElapsed;
@@ -179,8 +203,9 @@ public sealed class OAuthRefreshService : IDisposable
         {
             await CheckAndRefreshTokensAsync();
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            RecordWrapperFailure(nameof(CheckAndRefreshTokensAsync), ex);
         }
     }
 
@@ -190,8 +215,64 @@ public sealed class OAuthRefreshService : IDisposable
         {
             await CheckExpiringTokensAsync();
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            RecordWrapperFailure(nameof(CheckExpiringTokensAsync), ex);
+        }
+    }
+
+    internal Task InvokeSafeCheckAndRefreshTokensForTestsAsync(CancellationToken ct = default)
+        => SafeCheckAndRefreshTokensAsync(ct);
+
+    internal Task InvokeSafeCheckExpiringTokensForTestsAsync(CancellationToken ct = default)
+        => SafeCheckExpiringTokensAsync(ct);
+
+    private void RecordWrapperFailure(string operationName, Exception ex)
+    {
+        Interlocked.Increment(ref _wrapperFailureCount);
+
+        var now = DateTime.UtcNow;
+        var shouldLog = true;
+        lock (_wrapperFailureSync)
+        {
+            if (_lastWrapperFailureLogByOperation.TryGetValue(operationName, out var lastLoggedAt) &&
+                now - lastLoggedAt < WrapperFailureLogThrottleWindow)
+            {
+                shouldLog = false;
+            }
+            else
+            {
+                _lastWrapperFailureLogByOperation[operationName] = now;
+            }
+        }
+
+        if (shouldLog)
+        {
+            _logger.LogError(
+                ex,
+                "OAuth refresh background wrapper failed for operation {OperationName}.",
+                operationName);
+        }
+
+        var handlers = WrapperOperationFailed;
+        if (handlers is null)
+        {
+            return;
+        }
+
+        foreach (EventHandler<OAuthWrapperFailureEventArgs> handler in handlers.GetInvocationList())
+        {
+            try
+            {
+                handler(this, new OAuthWrapperFailureEventArgs(operationName, ex, now, shouldLog));
+            }
+            catch (Exception eventEx)
+            {
+                _logger.LogError(
+                    eventEx,
+                    "OAuth refresh wrapper failure event handler threw for operation {OperationName}.",
+                    operationName);
+            }
         }
     }
 
@@ -373,5 +454,24 @@ public sealed class TokenExpirationWarningEventArgs : EventArgs
         ProviderId = providerId;
         ExpiresAt = expiresAt;
         CanAutoRefresh = canAutoRefresh;
+    }
+}
+
+/// <summary>
+/// Event args for wrapper-level failures in background safe wrappers.
+/// </summary>
+public sealed class OAuthWrapperFailureEventArgs : EventArgs
+{
+    public string OperationName { get; }
+    public Exception Exception { get; }
+    public DateTime OccurredAtUtc { get; }
+    public bool EmittedStructuredLog { get; }
+
+    public OAuthWrapperFailureEventArgs(string operationName, Exception exception, DateTime occurredAtUtc, bool emittedStructuredLog)
+    {
+        OperationName = operationName;
+        Exception = exception;
+        OccurredAtUtc = occurredAtUtc;
+        EmittedStructuredLog = emittedStructuredLog;
     }
 }

--- a/src/Meridian.Ui.Services/Services/OAuthRefreshService.cs
+++ b/src/Meridian.Ui.Services/Services/OAuthRefreshService.cs
@@ -64,9 +64,17 @@ public sealed class OAuthRefreshService : IDisposable
     public int WrapperFailureCount => Volatile.Read(ref _wrapperFailureCount);
 
     private OAuthRefreshService()
-        : this(new CredentialService(), SingletonLoggerFactory.CreateLogger<OAuthRefreshService>())
+        : this(CredentialService.Instance, SingletonLoggerFactory.CreateLogger<OAuthRefreshService>())
     {
     }
+
+    /// <summary>
+    /// Creates a new OAuth refresh service instance with explicit dependencies.
+    /// </summary>
+    public static OAuthRefreshService Create(
+        CredentialService credentialService,
+        ILogger<OAuthRefreshService>? logger = null)
+        => new(credentialService, logger);
 
     internal OAuthRefreshService(CredentialService credentialService, ILogger<OAuthRefreshService>? logger = null)
     {
@@ -99,7 +107,7 @@ public sealed class OAuthRefreshService : IDisposable
         _expirationCheckTimer.Start();
 
         // Perform initial check
-        _ = CheckAndRefreshTokensAsync();
+        _ = SafeCheckAndRefreshTokensAsync();
     }
 
     /// <summary>

--- a/src/Meridian.Ui.Services/Services/OAuthRefreshService.cs
+++ b/src/Meridian.Ui.Services/Services/OAuthRefreshService.cs
@@ -71,6 +71,10 @@ public sealed class OAuthRefreshService : IDisposable
     /// <summary>
     /// Creates a new OAuth refresh service instance with explicit dependencies.
     /// </summary>
+    /// <param name="credentialService">Credential service implementation used for token operations.</param>
+    /// <param name="logger">
+    /// Optional logger instance. When null, <see cref="NullLogger{T}.Instance"/> is used.
+    /// </param>
     public static OAuthRefreshService Create(
         CredentialService credentialService,
         ILogger<OAuthRefreshService>? logger = null)

--- a/tests/Meridian.Ui.Tests/Services/OAuthRefreshServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/OAuthRefreshServiceTests.cs
@@ -6,6 +6,8 @@ namespace Meridian.Ui.Tests.Services;
 
 public sealed class OAuthRefreshServiceTests
 {
+    private const string CheckAndRefreshOperationName = "CheckAndRefreshTokensAsync";
+
     [Fact]
     public async Task SafeCheckAndRefreshTokensAsync_WhenWrapperThrows_ShouldEmitFailureEventAndLog()
     {
@@ -23,7 +25,7 @@ public sealed class OAuthRefreshServiceTests
 
         service.WrapperFailureCount.Should().Be(1);
         evt.Should().NotBeNull();
-        evt!.OperationName.Should().Be("CheckAndRefreshTokensAsync");
+        evt!.OperationName.Should().Be(CheckAndRefreshOperationName);
         evt.Exception.Should().BeOfType<InvalidOperationException>();
         evt.EmittedStructuredLog.Should().BeTrue();
         logger.Entries.Should().ContainSingle(x => x.LogLevel == LogLevel.Error && x.Message.Contains("CheckAndRefreshTokensAsync"));

--- a/tests/Meridian.Ui.Tests/Services/OAuthRefreshServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/OAuthRefreshServiceTests.cs
@@ -15,7 +15,7 @@ public sealed class OAuthRefreshServiceTests
         };
 
         var logger = new TestLogger<OAuthRefreshService>();
-        var service = new OAuthRefreshService(credentialService, logger);
+        var service = OAuthRefreshService.Create(credentialService, logger);
         OAuthWrapperFailureEventArgs? evt = null;
         service.WrapperOperationFailed += (_, e) => evt = e;
 
@@ -23,7 +23,7 @@ public sealed class OAuthRefreshServiceTests
 
         service.WrapperFailureCount.Should().Be(1);
         evt.Should().NotBeNull();
-        evt!.OperationName.Should().Be(nameof(OAuthRefreshService.CheckAndRefreshTokensAsync));
+        evt!.OperationName.Should().Be("CheckAndRefreshTokensAsync");
         evt.Exception.Should().BeOfType<InvalidOperationException>();
         evt.EmittedStructuredLog.Should().BeTrue();
         logger.Entries.Should().ContainSingle(x => x.LogLevel == LogLevel.Error && x.Message.Contains("CheckAndRefreshTokensAsync"));
@@ -47,7 +47,7 @@ public sealed class OAuthRefreshServiceTests
         };
 
         var logger = new TestLogger<OAuthRefreshService>();
-        var service = new OAuthRefreshService(credentialService, logger);
+        var service = OAuthRefreshService.Create(credentialService, logger);
         var events = new List<OAuthWrapperFailureEventArgs>();
         service.WrapperOperationFailed += (_, e) => events.Add(e);
         service.TokenExpirationWarning += (_, _) => throw new InvalidOperationException("observer failed");
@@ -71,7 +71,7 @@ public sealed class OAuthRefreshServiceTests
         };
 
         var logger = new TestLogger<OAuthRefreshService>();
-        var service = new OAuthRefreshService(credentialService, logger);
+        var service = OAuthRefreshService.Create(credentialService, logger);
         service.WrapperOperationFailed += (_, _) => throw new InvalidOperationException("event subscriber failed");
 
         var act = () => service.InvokeSafeCheckAndRefreshTokensForTestsAsync();

--- a/tests/Meridian.Ui.Tests/Services/OAuthRefreshServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/OAuthRefreshServiceTests.cs
@@ -1,0 +1,129 @@
+using FluentAssertions;
+using Meridian.Ui.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Ui.Tests.Services;
+
+public sealed class OAuthRefreshServiceTests
+{
+    [Fact]
+    public async Task SafeCheckAndRefreshTokensAsync_WhenWrapperThrows_ShouldEmitFailureEventAndLog()
+    {
+        var credentialService = new TestCredentialService
+        {
+            CredentialsException = new InvalidOperationException("credential enumeration failed")
+        };
+
+        var logger = new TestLogger<OAuthRefreshService>();
+        var service = new OAuthRefreshService(credentialService, logger);
+        OAuthWrapperFailureEventArgs? evt = null;
+        service.WrapperOperationFailed += (_, e) => evt = e;
+
+        await service.InvokeSafeCheckAndRefreshTokensForTestsAsync();
+
+        service.WrapperFailureCount.Should().Be(1);
+        evt.Should().NotBeNull();
+        evt!.OperationName.Should().Be(nameof(OAuthRefreshService.CheckAndRefreshTokensAsync));
+        evt.Exception.Should().BeOfType<InvalidOperationException>();
+        evt.EmittedStructuredLog.Should().BeTrue();
+        logger.Entries.Should().ContainSingle(x => x.LogLevel == LogLevel.Error && x.Message.Contains("CheckAndRefreshTokensAsync"));
+    }
+
+    [Fact]
+    public async Task SafeCheckExpiringTokensAsync_WhenWarningSubscriberThrows_ShouldEmitThrottledWrapperEvents()
+    {
+        var credentialService = new TestCredentialService
+        {
+            Credentials =
+            [
+                new CredentialWithMetadata
+                {
+                    Resource = $"{CredentialService.OAuthTokenResource}.ibkr",
+                    IsOAuthToken = true,
+                    ExpiresAt = DateTime.UtcNow.AddMinutes(20),
+                    CanAutoRefresh = false
+                }
+            ]
+        };
+
+        var logger = new TestLogger<OAuthRefreshService>();
+        var service = new OAuthRefreshService(credentialService, logger);
+        var events = new List<OAuthWrapperFailureEventArgs>();
+        service.WrapperOperationFailed += (_, e) => events.Add(e);
+        service.TokenExpirationWarning += (_, _) => throw new InvalidOperationException("observer failed");
+
+        await service.InvokeSafeCheckExpiringTokensForTestsAsync();
+        await service.InvokeSafeCheckExpiringTokensForTestsAsync();
+
+        service.WrapperFailureCount.Should().Be(2);
+        events.Should().HaveCount(2);
+        events[0].EmittedStructuredLog.Should().BeTrue();
+        events[1].EmittedStructuredLog.Should().BeFalse();
+        logger.Entries.Count(x => x.LogLevel == LogLevel.Error && x.Message.Contains("CheckExpiringTokensAsync")).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SafeCheckAndRefreshTokensAsync_WhenWrapperFailureHandlerThrows_ShouldNotEscapeSafeWrapper()
+    {
+        var credentialService = new TestCredentialService
+        {
+            CredentialsException = new InvalidOperationException("credential enumeration failed")
+        };
+
+        var logger = new TestLogger<OAuthRefreshService>();
+        var service = new OAuthRefreshService(credentialService, logger);
+        service.WrapperOperationFailed += (_, _) => throw new InvalidOperationException("event subscriber failed");
+
+        var act = () => service.InvokeSafeCheckAndRefreshTokensForTestsAsync();
+
+        await act.Should().NotThrowAsync();
+        logger.Entries.Should().Contain(x => x.LogLevel == LogLevel.Error && x.Message.Contains("event handler threw"));
+    }
+
+    private sealed class TestCredentialService : CredentialService
+    {
+        public IReadOnlyList<CredentialWithMetadata> Credentials { get; set; } = Array.Empty<CredentialWithMetadata>();
+        public Exception? CredentialsException { get; set; }
+        public Exception? RefreshException { get; set; }
+
+        public override IReadOnlyList<CredentialWithMetadata> GetAllCredentialsWithMetadata()
+        {
+            if (CredentialsException is not null)
+            {
+                throw CredentialsException;
+            }
+
+            return Credentials;
+        }
+
+        public override Task<OAuthRefreshResult> RefreshOAuthTokenAsync(string providerId)
+        {
+            if (RefreshException is not null)
+            {
+                throw RefreshException;
+            }
+
+            return Task.FromResult(new OAuthRefreshResult { Success = true, NewExpiration = DateTime.UtcNow.AddHours(1) });
+        }
+    }
+
+    private sealed class TestLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel LogLevel, string Message)> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Improve robustness and observability of the OAuth refresh background work by capturing, logging and exposing wrapper-level failures. 
- Allow platform projects and tests to override credential behavior by making `CredentialService` methods virtual and enable injection of a testable `ILogger` into `OAuthRefreshService`.

### Description

- Marked `CredentialService` methods (`GetAllCredentialsWithMetadata`, `RefreshOAuthTokenAsync`, `UpdateMetadataAsync`, `GetMetadata`) as `virtual` so platform implementations can override them. 
- Enhanced `OAuthRefreshService` to accept a `CredentialService` and `ILogger<OAuthRefreshService>` via an internal constructor and to use a default singleton logger factory for the parameterless constructor. 
- Added wrapper-level failure tracking with `WrapperFailureCount`, a `WrapperOperationFailed` event, `OAuthWrapperFailureEventArgs`, and a throttled structured error log strategy to avoid log spam. 
- Introduced safe wrapper methods (`SafeCheckAndRefreshTokensAsync`, `SafeCheckExpiringTokensAsync`) that call `RecordWrapperFailure` on exceptions, and exposed test helpers `InvokeSafeCheckAndRefreshTokensForTestsAsync` and `InvokeSafeCheckExpiringTokensForTestsAsync`. 
- Implemented defensive error handling when invoking subscriber event handlers so event handler exceptions are logged but do not escape the safe wrapper. 

### Testing

- Added `tests/Meridian.Ui.Tests/Services/OAuthRefreshServiceTests.cs` containing three unit tests that exercise wrapper failure logging, event emission, throttling behavior, and resilience to subscriber exceptions. 
- Ran the test suite with `dotnet test` for the affected project and the new tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8b0673c88320a03279abf5719df8)