### PR TITLE
docs: clarify operator-inbox routing/sign-off evidence requirements in Wave 2 runbook

### DIFF
--- a/docs/testing/wave2-cockpit-reliability-evidence-runbook.md
+++ b/docs/testing/wave2-cockpit-reliability-evidence-runbook.md
@@ -43,7 +43,7 @@ This command covers:
    - replay gate returns to `Ready`,
    - stale replay work item is cleared.
 7. Query operator inbox (`GET /api/workstation/operator/inbox`) and confirm severity/tone alignment
-   with readiness blockers.
+   with readiness blockers plus actionable routing/sign-off detail for each blocking item.
 
 ## Evidence Packet Contents
 
@@ -52,5 +52,5 @@ For each run date (`YYYY-MM-DD`), archive:
 - focused test output log,
 - replay audit IDs before and after stale recovery,
 - readiness payload snapshots for stale and recovered states,
-- operator-inbox snapshot for blocker alignment,
+- operator-inbox snapshot for blocker alignment and routing/sign-off detail evidence,
 - short narrative stating whether all four Wave 2 reliability gates are pass/review/blocked.


### PR DESCRIPTION
### Motivation
- Ensure the Wave 2 cockpit reliability runbook explicitly requires operator-inbox verification to include actionable routing and sign-off detail alongside severity/tone so evidence packets capture the routing/sign-off metadata needed for acceptance.

### Description
- Updated `docs/testing/wave2-cockpit-reliability-evidence-runbook.md` to require that `GET /api/workstation/operator/inbox` verification include actionable routing/sign-off detail for each blocking item and to include operator-inbox routing/sign-off detail in the evidence packet snapshot checklist.

### Testing
- Ran `make build-quick` and `make test-unit` (both failed due to `dotnet` not available), attempted focused `dotnet test` runs for `MapWorkstationEndpoints_TradingReadiness` and `MapWorkstationEndpoints_OperatorInbox` (failed due to missing `dotnet`), attempted `cd src/Meridian.Ui/dashboard && npm run test && npm run build` (failed due to missing `node_modules/vitest/vitest.mjs`), and verified presence of relevant references with `rg` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8c8cd83c83209a7221b9d238244e)