### PR TITLE
Add unified provider integration status board

### DIFF
--- a/docs/status/kernel-readiness-dashboard.md
+++ b/docs/status/kernel-readiness-dashboard.md
@@ -16,6 +16,7 @@
 
 ## Program Cadence and Operating Window
 
+- **Provider integration status board:** [`provider-integration-status.md`](./provider-integration-status.md) is the single per-broker phase/blocker/evidence timestamp surface; keep it synchronized with this dashboard and the provider validation matrix.
 - **Roadmap/readiness escalation feed:** use generated [`program-state-summary.md`](./program-state-summary.md) / [`program-state-summary.json`](./program-state-summary.json) for wave-level primary owner, backup owner, escalation SLA, and dependency-owner routing.
 
 - **Cadence:** weekly subsystem review (Mon), cross-subsystem interop review (Wed), operator-readiness review (Fri)

--- a/docs/status/provider-integration-status.md
+++ b/docs/status/provider-integration-status.md
@@ -1,0 +1,47 @@
+# Provider Integration Status Board
+
+**Run Date:** 2026-05-19  
+**Source snapshots:** `docs/status/provider-validation-matrix.md` (Last Updated 2026-04-27), `docs/status/kernel-readiness-dashboard.md` (Last Updated 2026-04-27)  
+**Purpose:** single status document that shows each broker/provider phase, blockers, latest evidence timestamp, and refresh ownership/cadence for active integrations.
+
+## How to read this board
+
+- **Phase:**
+  - **Read-only** = data ingestion/research use only; no order routing.
+  - **Paper** = simulation/paper-trading workflows active; no production funds.
+  - **Production** = approved for production-path execution within Meridian governance gates.
+- **Latest evidence timestamp (UTC):** the most recent dated evidence run or snapshot currently referenced by source-of-truth status documents.
+- **Blockers:** explicit conditions that must be resolved before phase promotion.
+
+## Unified Provider Status
+
+| Provider/Broker | Current phase | Blockers to next phase | Latest evidence timestamp (UTC) | Evidence sources |
+| --- | --- | --- | --- | --- |
+| Alpaca | Paper | Production promotion checklist not yet represented in the active DK2 gate set and operator sign-off packet flow | 2026-04-27 | Wave 1 closure row in provider validation matrix; DK readiness board references the 2026-04-27 automation evidence pack |
+| Robinhood | Paper (bounded) | Unofficial API posture plus required manual broker-session/runtime evidence (`auth-session`, `quote-polling`, `order-submit-cancel`, `throttling-reconnect`) must be regenerated/attached for the review run | 2026-04-27 (latest signed Wave 1 packet set); bounded scenario packet noted as not retained in current repo | Robinhood bounded row in provider validation matrix; DK readiness board inherits Wave 1 packet date |
+| Yahoo Finance (historical/fallback) | Read-only | No execution lane; keep scoped to historical/fallback provider role unless roadmap explicitly expands scope | 2026-04-27 | Yahoo historical/fallback row in provider validation matrix; DK readiness board links same Wave 1 evidence window |
+| Interactive Brokers | Read-only (deferred from active Wave 1 gate) | Deferred-provider status in active gate; no current Wave 1 closure claim | 2026-04-27 snapshot date for current gate posture | Deferred-provider note in provider validation matrix |
+| Polygon | Read-only (deferred from active Wave 1 gate) | Deferred-provider status in active gate; no current Wave 1 closure claim | 2026-04-27 snapshot date for current gate posture | Deferred-provider note in provider validation matrix |
+| NYSE | Read-only (deferred from active Wave 1 gate) | Deferred-provider status in active gate; no current Wave 1 closure claim | 2026-04-27 snapshot date for current gate posture | Deferred-provider note in provider validation matrix |
+| StockSharp | Read-only (deferred from active Wave 1 gate) | Deferred-provider status in active gate; no current Wave 1 closure claim | 2026-04-27 snapshot date for current gate posture | Deferred-provider note in provider validation matrix |
+
+## Ownership and refresh cadence (active integrations)
+
+| Surface | Primary owner | Backup owner | Minimum refresh cadence | Refresh trigger |
+| --- | --- | --- | --- | --- |
+| `docs/status/provider-integration-status.md` (this board) | Data Operations & Provider Reliability owner | Trading Workstation owner | **Twice weekly during active integrations** (Monday + Thursday UTC) | Any provider phase move, blocker state change, new bounded-runtime evidence, or operator sign-off state change |
+| `docs/status/provider-validation-matrix.md` | Data Operations & Provider Reliability owner | Shared Platform Interop owner | Weekly minimum (or same-day when evidence changes) | New `run-wave1-provider-validation.ps1` output, DK1 packet/sign-off updates, or deferred-provider scope changes |
+| `docs/status/kernel-readiness-dashboard.md` | Trading Workstation owner | Governance/Fund Ops owner | Weekly minimum (Mon cadence rule already defined) | Any gate-status/readiness change, operator-sign-off movement, or milestone target-date update |
+
+## Refresh workflow
+
+1. Run provider evidence generation for the current run date (`yyyy-mm-dd`) and collect artifacts under `artifacts/provider-validation/_automation/<yyyy-mm-dd>/`.
+2. Update `provider-validation-matrix.md` with new evidence references and bounded/manual notes.
+3. Update `kernel-readiness-dashboard.md` if any gate/readiness/commitment state changes.
+4. Update this status board last so phase + blockers + timestamps reflect those two source snapshots.
+5. Validate consistency with `python3 scripts/check_program_state_consistency.py` before publishing status updates.
+
+## Run-date accuracy rule
+
+- Do not advance any `Latest evidence timestamp (UTC)` in this board unless the corresponding dated artifact or snapshot update exists.
+- If a source snapshot still points to an older signed packet (for example 2026-04-27), preserve that date here and list the current blocker rather than inferring freshness.

--- a/docs/status/provider-validation-matrix.md
+++ b/docs/status/provider-validation-matrix.md
@@ -5,6 +5,9 @@
 
 This matrix is Meridian's active Wave 1 evidence gate. Every row must point to executable repo evidence, with bounded runtime evidence regenerated and attached from the validation run when a provider scenario cannot be closed from checked-in tests. The current signed DK1 evidence is the 2026-04-27 packet set under `artifacts/provider-validation/_automation/2026-04-27/`; future date-stamped packets are current only for the run that produced them and need matching packet-bound sign-off before they can replace that evidence. Deferred providers stay out of the active gate even when they remain in the broader provider strategy.
 
+
+For the unified per-broker phase/blocker/evidence view, see [`provider-integration-status.md`](./provider-integration-status.md).
+
 ## Legend
 
 - ✅ Closed with executable repo evidence


### PR DESCRIPTION
### Motivation

- Provide a single, human-readable per-broker status surface that consolidates phase (Read-only/Paper/Production), blockers, and the latest evidence timestamps so operator owners can find current integration posture at a glance.
- Ensure the per-broker board is explicitly anchored to the authoritative source snapshots (`provider-validation-matrix.md` and `kernel-readiness-dashboard.md`) and that date stamps remain run-date accurate.
- Define ownership and a refresh cadence to keep status updates timely during active integrations.

### Description

- Add `docs/status/provider-integration-status.md` as the unified per-provider status board containing phase, blockers, latest evidence timestamp, evidence sources, a refresh workflow, and run-date accuracy rules.
- Link the new board from `docs/status/provider-validation-matrix.md` with `For the unified per-broker phase/blocker/evidence view, see [`provider-integration-status.md`](./provider-integration-status.md).`.
- Reference the new board from `docs/status/kernel-readiness-dashboard.md` and instruct readers to keep it synchronized with the matrix and dashboard.
- Define ownership and minimum refresh cadence for the new surface and the two source documents, plus the canonical refresh workflow that emits artifacts to `artifacts/provider-validation/_automation/<yyyy-mm-dd>/`.

### Testing

- Documentation-only change; no automated unit/integration tests were required or run for these edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cc2a9ab588320a0a4f2c662058735)