### PR TITLE
Add provider promotion checklist to workstation readiness and provider-validation docs

### DIFF
--- a/docs/status/provider-validation-matrix.md
+++ b/docs/status/provider-validation-matrix.md
@@ -55,6 +55,23 @@ packet is signed and valid for DK1 exit. Future DK1 reviews must use a freshly g
 `artifacts/provider-validation/_automation/<yyyy-mm-dd>/dk1-pilot-parity-packet.json` packet plus
 its bound operator sign-off file before replacing that signed evidence.
 
+
+## Promotion Checklist Requirement (Paper + Live Enablement)
+
+Before enabling any broker for **paper** or **live** workflows, all four checks must be green in workstation/provider readiness:
+
+1. **Contract compatibility validation** (`artifacts/contract-review/<yyyy-mm-dd>/contract-review-packet.json` with `readyForCadenceReview=true`).
+2. **Focused adapter tests** (provider row evidence captured in the active Wave 1/DK packet).
+3. **Replay evidence generation** (consistent replay verification for the active paper session).
+4. **Degradation calibration output** (`provider-validation-evidence-bundle.json` posture `candidate-approved`).
+
+If any check fails, promotion enablement is blocked and operator surfaces must show explicit blockers.
+
+## Pass/Fail Criteria
+
+- **Pass:** all four checklist checks are true and no provider-promotion blockers are emitted.
+- **Fail:** one or more checks are false; paper/live enablement must remain disabled until evidence is regenerated under `artifacts/provider-validation/_automation/<yyyy-mm-dd>/` (and `artifacts/contract-review/<yyyy-mm-dd>/` for contract compatibility).
+
 ## Notes
 
 - Robinhood remains polling-oriented and unofficial. Do not describe it as websocket-validated.

--- a/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
+++ b/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
@@ -255,6 +255,18 @@ public sealed record TradingReportPackReadinessDto(
     int WarningCount,
     string? ManifestPath);
 
+
+public sealed record ProviderPromotionChecklistDto(
+    bool ContractCompatibilityValidated,
+    bool FocusedAdapterTestsValidated,
+    bool ReplayEvidenceGenerated,
+    bool DegradationCalibrationOutputValidated,
+    bool ReadyForPaperEnablement,
+    bool ReadyForLiveEnablement,
+    IReadOnlyList<string> Blockers,
+    string? EvidenceBundlePath,
+    DateTimeOffset EvaluatedAt);
+
 public sealed record TradingOperatorReadinessDto(
     DateTimeOffset AsOf,
     TradingPaperSessionReadinessDto? ActiveSession,
@@ -280,6 +292,8 @@ public sealed record TradingOperatorReadinessDto(
     public DateTimeOffset SnapshotMaterializedAt { get; init; }
 
     public string SnapshotVersion { get; init; } = string.Empty;
+
+    public ProviderPromotionChecklistDto? ProviderPromotionChecklist { get; init; }
 }
 
 public sealed record StrategyRunReviewPacketDto(

--- a/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
@@ -123,7 +123,8 @@ public sealed class TradingOperatorReadinessService
             ReadyForPaperOperation = overallStatus == TradingAcceptanceGateStatusDto.Ready,
             ReportPack = reportPack,
             SnapshotMaterializedAt = asOf,
-            SnapshotVersion = snapshotVersion
+            SnapshotVersion = snapshotVersion,
+            ProviderPromotionChecklist = BuildProviderPromotionChecklist(trustGate, replay, asOf)
         };
     }
 
@@ -1437,6 +1438,82 @@ public sealed class TradingOperatorReadinessService
             runId,
             workItemId: BuildWorkItemId("reconciliation-policy", runId));
     }
+
+    private ProviderPromotionChecklistDto BuildProviderPromotionChecklist(
+        TradingTrustGateReadinessDto trustGate,
+        TradingReplayReadinessDto? replay,
+        DateTimeOffset asOf)
+    {
+        var contractCompatibilityValidated = ResolveContractCompatibilityValidated();
+        var focusedAdapterTestsValidated = string.Equals(trustGate.Status, "ready-for-operator-review", StringComparison.OrdinalIgnoreCase) &&
+                                           trustGate.ReadySampleCount >= trustGate.RequiredSampleCount &&
+                                           trustGate.ValidatedEvidenceDocumentCount > 0;
+        var replayEvidenceGenerated = replay is { IsConsistent: true };
+        var degradationCalibrationOutputValidated = string.Equals(trustGate.PromotionPosture, "candidate-approved", StringComparison.OrdinalIgnoreCase);
+
+        var blockers = new List<string>();
+        if (!contractCompatibilityValidated)
+        {
+            blockers.Add("Contract compatibility validation packet is missing or not approved.");
+        }
+
+        if (!focusedAdapterTestsValidated)
+        {
+            blockers.Add("Focused adapter validation evidence is not ready in the provider promotion packet.");
+        }
+
+        if (!replayEvidenceGenerated)
+        {
+            blockers.Add("Replay evidence is missing or inconsistent for the active paper session.");
+        }
+
+        if (!degradationCalibrationOutputValidated)
+        {
+            blockers.Add("Provider degradation calibration output is missing or not candidate-approved.");
+        }
+
+        var ready = blockers.Count == 0;
+        return new ProviderPromotionChecklistDto(
+            ContractCompatibilityValidated: contractCompatibilityValidated,
+            FocusedAdapterTestsValidated: focusedAdapterTestsValidated,
+            ReplayEvidenceGenerated: replayEvidenceGenerated,
+            DegradationCalibrationOutputValidated: degradationCalibrationOutputValidated,
+            ReadyForPaperEnablement: ready,
+            ReadyForLiveEnablement: ready,
+            Blockers: blockers,
+            EvidenceBundlePath: trustGate.PacketPath,
+            EvaluatedAt: asOf);
+    }
+
+    private bool ResolveContractCompatibilityValidated()
+    {
+        try
+        {
+            var root = Directory.GetCurrentDirectory();
+            var contractRoot = Path.Combine(root, "artifacts", "contract-review");
+            if (!Directory.Exists(contractRoot))
+            {
+                return false;
+            }
+
+            var latest = Directory.EnumerateFiles(contractRoot, "contract-review-packet.json", SearchOption.AllDirectories)
+                .Select(path => new FileInfo(path))
+                .OrderByDescending(file => file.LastWriteTimeUtc)
+                .FirstOrDefault();
+            if (latest is null)
+            {
+                return false;
+            }
+
+            using var doc = System.Text.Json.JsonDocument.Parse(File.ReadAllText(latest.FullName));
+            return doc.RootElement.TryGetProperty("readyForCadenceReview", out var ready) && ready.ValueKind == System.Text.Json.JsonValueKind.True;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     /// <summary>
     /// Resolves the aggregate readiness status using deterministic precedence:
     /// <c>Blocked</c> overrides all other signals, <c>ReviewRequired</c> overrides <c>Ready</c>, and


### PR DESCRIPTION
### Motivation
- Enforce a promotion checklist requiring contract compatibility, focused adapter tests, replay evidence, and degradation calibration before enabling brokers for paper or live workflows.
- Surface provider readiness and blockers to operational users through existing workstation/operator readiness DTOs and APIs so operators can see why a promotion is blocked.
- Record and reference run-date validation artifacts under the provider-validation artifact structure and document pass/fail criteria in the provider validation matrix.

### Description
- Added a `ProviderPromotionChecklistDto` and exposed it as `ProviderPromotionChecklist` on `TradingOperatorReadinessDto` in `src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs`.
- Wired a `BuildProviderPromotionChecklist` projection into `TradingOperatorReadinessService` which evaluates: contract-compatibility packet approval, focused adapter test evidence from the DK1 trust packet, replay consistency, and degradation calibration posture (`candidate-approved`), and emits operator-visible blocker messages; implementation in `src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs`.
- Updated `docs/status/provider-validation-matrix.md` to add a formal "Promotion Checklist Requirement (Paper + Live Enablement)" section with explicit pass/fail criteria and references to run-date artifacts under `artifacts/provider-validation/_automation/<yyyy-mm-dd>/` and `artifacts/contract-review/<yyyy-mm-dd>/`.
- The contract compatibility check reads the latest `contract-review-packet.json` under `artifacts/contract-review/**` and expects `readyForCadenceReview=true`, and the readiness projection references the DK1 evidence bundle and packet paths emitted by existing validation scripts.

### Testing
- Attempted to run a focused readiness endpoint unit test via `dotnet test --filter "FullyQualifiedName~MapWorkstationEndpoints_TradingReadiness"`, but the command failed because `dotnet` is not available in the execution environment; no automated tests were executed here.
- Recommend CI run the full unit/integration test matrix (e.g. `make test` / `dotnet test` for relevant test projects) to validate wiring and DTO compatibility in a proper .NET environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cbc7dced48320814d33d30ed230be)