### PR TITLE
Add options lifecycle and provider validation evidence-bundle tests

### DIFF
--- a/tests/Meridian.Tests/Infrastructure/Providers/AlpacaBrokerageGatewayTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/AlpacaBrokerageGatewayTests.cs
@@ -823,6 +823,94 @@ public sealed class AlpacaBrokerageGatewayTests
             path.StartsWith("/v2/account/activities?direction=desc&page_size=100&after=", StringComparison.Ordinal));
     }
 
+
+    [Fact]
+    public async Task GetActivitySnapshotAsync_OptionsLifecycle_MapsPartialFillAndLegRejectStatuses()
+    {
+        var handler = new CapturingStubHandler(
+            _ => { },
+            request =>
+            {
+                var uri = request.RequestUri!;
+                if (uri.AbsolutePath == "/v2/account")
+                {
+                    return BuildAccountResponse();
+                }
+
+                if (uri.AbsolutePath == "/v2/orders")
+                {
+                    return BuildJson(new object[]
+                    {
+                        new
+                        {
+                            id = "ord-mleg-partial",
+                            client_order_id = "client-mleg-partial",
+                            symbol = "AAPL",
+                            side = "buy",
+                            type = "limit",
+                            qty = "2",
+                            filled_qty = "1",
+                            limit_price = "1.25",
+                            status = "partially_filled",
+                            created_at = "2026-04-25T14:30:00Z"
+                        },
+                        new
+                        {
+                            id = "ord-mleg-reject",
+                            client_order_id = "client-mleg-reject",
+                            symbol = "AAPL",
+                            side = "buy",
+                            type = "limit",
+                            qty = "1",
+                            filled_qty = "0",
+                            limit_price = "0.95",
+                            status = "rejected",
+                            created_at = "2026-04-25T14:31:00Z"
+                        }
+                    });
+                }
+
+                if (uri.AbsolutePath == "/v2/account/activities")
+                {
+                    return BuildJson(new object[]
+                    {
+                        new
+                        {
+                            id = "fill-partial-leg-1",
+                            activity_type = "FILL",
+                            transaction_time = "2026-04-25T14:35:00Z",
+                            symbol = "AAPL260116C00190000",
+                            qty = "1",
+                            price = "1.20",
+                            side = "buy",
+                            order_id = "ord-mleg-partial",
+                            commission = "0",
+                            exchange = "XNAS"
+                        }
+                    });
+                }
+
+                return BuildJson(new { });
+            });
+
+        var sut = CreateSut(handler);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var activity = await ((IBrokerageActivitySync)sut).GetActivitySnapshotAsync(
+            "TEST123",
+            new DateTimeOffset(2026, 4, 25, 0, 0, 0, TimeSpan.Zero),
+            cts.Token);
+
+        activity.Orders.Should().Contain(order => order.OrderId == "ord-mleg-partial" && order.Status == OrderStatus.PartiallyFilled);
+        activity.Orders.Should().Contain(order => order.OrderId == "ord-mleg-reject" && order.Status == OrderStatus.Rejected);
+        activity.Fills.Should().ContainSingle(fill =>
+            fill.FillId == "fill-partial-leg-1" &&
+            fill.OrderId == "ord-mleg-partial" &&
+            fill.Symbol == "AAPL260116C00190000" &&
+            fill.Quantity == 1m &&
+            fill.Price == 1.20m);
+    }
+
     // ── Stub infrastructure ───────────────────────────────────────────────
 
     private sealed class ConstantStubHandler : HttpMessageHandler

--- a/tests/scripts/test_run_provider_validation_evidence_bundle.py
+++ b/tests/scripts/test_run_provider_validation_evidence_bundle.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "dev" / "run-provider-validation-evidence-bundle.ps1"
+
+
+class RunProviderValidationEvidenceBundleTests(unittest.TestCase):
+    def test_skip_wave1_generates_traceable_bundle_with_expected_artifact_paths(self) -> None:
+        pwsh = shutil.which("pwsh")
+        if pwsh is None:
+            self.skipTest("pwsh is not available")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            output_root = root / "bundle-output"
+            date_stamp = "2026-05-01"
+            bundle_root = output_root / date_stamp
+            bundle_root.mkdir(parents=True, exist_ok=True)
+
+            summary_path = bundle_root / "wave1-validation-summary.json"
+            packet_path = bundle_root / "dk1-pilot-parity-packet.json"
+            signoff_path = bundle_root / "dk1-operator-signoff.json"
+
+            summary_path.write_text(json.dumps({"generatedAtUtc": "2026-05-01T10:00:00Z", "result": "passed"}), encoding="utf-8")
+            packet_path.write_text(json.dumps({"generatedAtUtc": "2026-05-01T10:01:00Z", "status": "ready-for-operator-review"}), encoding="utf-8")
+            signoff_path.write_text(json.dumps({
+                "requiredOwners": ["Data Operations", "Provider Reliability", "Trading"],
+                "approvals": [
+                    {"owner": "Data Operations", "signedBy": "data.ops", "signedAtUtc": "2026-05-01T10:02:00Z", "decision": "approved", "rationale": "ok"},
+                    {"owner": "Provider Reliability", "signedBy": "provider.reliability", "signedAtUtc": "2026-05-01T10:03:00Z", "decision": "approved", "rationale": "ok"},
+                    {"owner": "Trading", "signedBy": "trading.owner", "signedAtUtc": "2026-05-01T10:04:00Z", "decision": "approved", "rationale": "ok"},
+                ],
+                "packetReview": {
+                    "path": str(packet_path),
+                    "generatedAtUtc": "2026-05-01T10:01:00Z",
+                    "status": "ready-for-operator-review",
+                    "validForOperatorReview": True,
+                    "readySampleCount": 4,
+                    "validatedEvidenceDocumentCount": 4,
+                },
+            }), encoding="utf-8")
+
+            subprocess.run(
+                [
+                    pwsh,
+                    "-NoProfile",
+                    "-File",
+                    str(SCRIPT_PATH),
+                    "-DateStamp",
+                    date_stamp,
+                    "-OutputRoot",
+                    str(output_root),
+                    "-SkipWave1",
+                ],
+                cwd=REPO_ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            bundle = json.loads((bundle_root / "provider-validation-evidence-bundle.json").read_text(encoding="utf-8"))
+            self.assertEqual("provider-validation-bundle/v1", bundle["schemaVersion"])
+            self.assertEqual("passed", bundle["gateOutcome"]["wave1Result"])
+            self.assertEqual("ready-for-operator-review", bundle["gateOutcome"]["dk1Status"])
+            self.assertTrue(bundle["gateOutcome"]["operatorSignoffValidForDk1Exit"])
+            self.assertEqual("not-run", bundle["promotionPosture"]["status"])
+
+            for key in ["summaryPath", "parityPacketPath", "signoffPath"]:
+                artifact_path = Path(bundle[key])
+                self.assertTrue(artifact_path.exists(), f"Expected traceable artifact path for {key}: {artifact_path}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Strengthen coverage for options order lifecycles and multi-leg handling to surface partial-fill and leg-reject failure modes.
- Ensure provider-validation evidence bundles contain traceable artifact references so execution-to-ledger evidence can be audited in provider reporting.

### Description

- Added a focused activity-sync unit test `GetActivitySnapshotAsync_OptionsLifecycle_MapsPartialFillAndLegRejectStatuses` in `tests/Meridian.Tests/Infrastructure/Providers/AlpacaBrokerageGatewayTests.cs` that simulates multi-leg orders and validates mapping of `partially_filled` → `OrderStatus.PartiallyFilled`, `rejected` → `OrderStatus.Rejected`, and capture of leg-level fills.
- Added a scripted integration-style test `tests/scripts/test_run_provider_validation_evidence_bundle.py` that exercises `scripts/dev/run-provider-validation-evidence-bundle.ps1` with pre-seeded inputs and asserts the produced bundle schema fields and that `summaryPath`, `parityPacketPath`, and `signoffPath` are traceable and exist.
- Tests use existing stub/capturing HTTP handler scaffolding to simulate provider responses and assert activity/ledger ingestion semantics.

### Testing

- Ran `python3 -m unittest tests/scripts/test_run_provider_validation_evidence_bundle.py` in this environment which completed (the test is skipped when `pwsh` is unavailable). 
- Attempted the focused unit test with `dotnet test --filter "FullyQualifiedName~GetActivitySnapshotAsync_OptionsLifecycle_MapsPartialFillAndLegRejectStatuses"` but the `dotnet` CLI was not available in this environment so the C# unit test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cc2a737548320a8b9b6ba2ab04c93)