### PR TITLE
Add Tradier canonical mappers for equity/options, order-status, and operational errors

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/Tradier/TradierCanonicalMappers.cs
+++ b/src/Meridian.Infrastructure/Adapters/Tradier/TradierCanonicalMappers.cs
@@ -1,0 +1,122 @@
+using System.Globalization;
+using Meridian.Execution.Sdk;
+
+namespace Meridian.Infrastructure.Adapters.Tradier;
+
+public static class TradierCanonicalMappers
+{
+    public static TradierCanonicalEquity NormalizeEquityPayload(TradierEquityPayload payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        var normalizedSymbol = NormalizeEquitySymbol(payload.Symbol);
+        return new TradierCanonicalEquity(
+            Symbol: normalizedSymbol,
+            Exchange: string.IsNullOrWhiteSpace(payload.Exchange) ? "UNKNOWN" : payload.Exchange.Trim().ToUpperInvariant(),
+            LastPrice: payload.LastPrice,
+            BidPrice: payload.BidPrice,
+            AskPrice: payload.AskPrice,
+            TradeTimestampUtc: payload.TradeTimestampUtc,
+            SourceSymbol: payload.Symbol);
+    }
+
+    public static TradierCanonicalOptionContract NormalizeOptionPayload(TradierOptionPayload payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        var underlying = NormalizeEquitySymbol(payload.UnderlyingSymbol);
+        var expiry = payload.ExpirationDate.ToString("yyMMdd", CultureInfo.InvariantCulture);
+        var right = payload.IsCall ? "C" : "P";
+        var strikeScaled = (int)Math.Round(payload.StrikePrice * 1000m, MidpointRounding.AwayFromZero);
+        var strikeToken = strikeScaled.ToString("D8", CultureInfo.InvariantCulture);
+        var canonicalContract = $"{underlying}{expiry}{right}{strikeToken}";
+
+        return new TradierCanonicalOptionContract(
+            UnderlyingSymbol: underlying,
+            ContractSymbol: canonicalContract,
+            ExpirationDate: payload.ExpirationDate,
+            StrikePrice: payload.StrikePrice,
+            IsCall: payload.IsCall,
+            BidPrice: payload.BidPrice,
+            AskPrice: payload.AskPrice,
+            LastPrice: payload.LastPrice,
+            OpenInterest: payload.OpenInterest,
+            Volume: payload.Volume,
+            SourceContractSymbol: payload.ContractSymbol);
+    }
+
+    public static TradierOrderTransition MapOrderTransition(TradierOrderStatusPayload payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        var status = (payload.Status ?? string.Empty).Trim().ToLowerInvariant();
+        var filled = Math.Max(payload.FilledQuantity, 0m);
+        var total = Math.Max(payload.OrderQuantity, 0m);
+
+        return status switch
+        {
+            "filled" => BuildTransition(OrderStatus.Filled, ExecutionReportType.Fill),
+            "partially_filled" => BuildTransition(OrderStatus.PartiallyFilled, ExecutionReportType.PartialFill),
+            "partial" => BuildTransition(OrderStatus.PartiallyFilled, ExecutionReportType.PartialFill),
+            "canceled" => BuildTransition(OrderStatus.Cancelled, ExecutionReportType.Cancelled),
+            "cancelled" => BuildTransition(OrderStatus.Cancelled, ExecutionReportType.Cancelled),
+            "rejected" => BuildTransition(OrderStatus.Rejected, ExecutionReportType.Rejected),
+            "expired" => BuildTransition(OrderStatus.Expired, ExecutionReportType.Expired),
+            "open" when filled > 0m && filled < total => BuildTransition(OrderStatus.PartiallyFilled, ExecutionReportType.PartialFill),
+            "open" => BuildTransition(OrderStatus.Accepted, ExecutionReportType.New),
+            "pending" => BuildTransition(OrderStatus.PendingNew, ExecutionReportType.New),
+            "pending_cancel" => BuildTransition(OrderStatus.PendingCancel, ExecutionReportType.New),
+            _ when filled > 0m && filled < total => BuildTransition(OrderStatus.PartiallyFilled, ExecutionReportType.PartialFill),
+            _ => BuildTransition(OrderStatus.Accepted, ExecutionReportType.New)
+        };
+
+        static TradierOrderTransition BuildTransition(OrderStatus status, ExecutionReportType reportType) =>
+            new(status, reportType);
+    }
+
+    public static TradierOperationalError MapBrokerError(TradierBrokerErrorPayload payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        var brokerCode = payload.Code?.Trim();
+        var message = string.IsNullOrWhiteSpace(payload.Message)
+            ? "Tradier returned an unspecified broker error."
+            : payload.Message.Trim();
+        var retriable = payload.HttpStatusCode is 408 or 429 || (payload.HttpStatusCode >= 500 && payload.HttpStatusCode <= 599);
+        var category = payload.HttpStatusCode switch
+        {
+            400 => "Validation",
+            401 or 403 => "Authentication",
+            404 => "NotFound",
+            408 => "Timeout",
+            409 => "Conflict",
+            429 => "RateLimit",
+            >= 500 and <= 599 => "ProviderUnavailable",
+            _ => "ProviderError"
+        };
+
+        return new TradierOperationalError(
+            Category: category,
+            Message: message,
+            BrokerCode: brokerCode,
+            HttpStatusCode: payload.HttpStatusCode,
+            IsRetriable: retriable,
+            RawPayload: payload.RawPayload ?? string.Empty);
+    }
+
+    private static string NormalizeEquitySymbol(string? symbol)
+    {
+        var trimmed = string.IsNullOrWhiteSpace(symbol) ? "UNKNOWN" : symbol.Trim().ToUpperInvariant();
+        return trimmed.Replace("/", ".", StringComparison.Ordinal).Replace(" ", string.Empty, StringComparison.Ordinal);
+    }
+}
+
+public sealed record TradierEquityPayload(string Symbol, string? Exchange, decimal LastPrice, decimal? BidPrice, decimal? AskPrice, DateTimeOffset TradeTimestampUtc);
+public sealed record TradierOptionPayload(string UnderlyingSymbol, string? ContractSymbol, DateOnly ExpirationDate, decimal StrikePrice, bool IsCall, decimal? BidPrice, decimal? AskPrice, decimal? LastPrice, long? OpenInterest, long? Volume);
+public sealed record TradierOrderStatusPayload(string? Status, decimal OrderQuantity, decimal FilledQuantity);
+public sealed record TradierBrokerErrorPayload(int HttpStatusCode, string? Code, string? Message, string? RawPayload = null);
+
+public sealed record TradierCanonicalEquity(string Symbol, string Exchange, decimal LastPrice, decimal? BidPrice, decimal? AskPrice, DateTimeOffset TradeTimestampUtc, string SourceSymbol);
+public sealed record TradierCanonicalOptionContract(string UnderlyingSymbol, string ContractSymbol, DateOnly ExpirationDate, decimal StrikePrice, bool IsCall, decimal? BidPrice, decimal? AskPrice, decimal? LastPrice, long? OpenInterest, long? Volume, string? SourceContractSymbol);
+public sealed record TradierOrderTransition(OrderStatus Status, ExecutionReportType ReportType);
+public sealed record TradierOperationalError(string Category, string Message, string? BrokerCode, int HttpStatusCode, bool IsRetriable, string RawPayload);

--- a/tests/Meridian.Tests/Infrastructure/Adapters/TradierCanonicalMappersTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Adapters/TradierCanonicalMappersTests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using Meridian.Execution.Sdk;
+using Meridian.Infrastructure.Adapters.Tradier;
+
+namespace Meridian.Tests.Infrastructure.Adapters;
+
+public sealed class TradierCanonicalMappersTests
+{
+    [Fact]
+    public void NormalizeEquityPayload_NormalizesSlashSymbolAndExchange()
+    {
+        var payload = new TradierEquityPayload("brk/b", "nyse", 501.23m, 501.20m, 501.25m, DateTimeOffset.Parse("2026-05-19T12:00:00Z"));
+
+        var result = TradierCanonicalMappers.NormalizeEquityPayload(payload);
+
+        result.Symbol.Should().Be("BRK.B");
+        result.Exchange.Should().Be("NYSE");
+        result.SourceSymbol.Should().Be("brk/b");
+    }
+
+    [Fact]
+    public void NormalizeOptionPayload_BuildsOccCanonicalContract()
+    {
+        var payload = new TradierOptionPayload("spy", "legacy", new DateOnly(2026, 12, 18), 650m, true, 2.1m, 2.2m, 2.15m, 1234, 4567);
+
+        var result = TradierCanonicalMappers.NormalizeOptionPayload(payload);
+
+        result.UnderlyingSymbol.Should().Be("SPY");
+        result.ContractSymbol.Should().Be("SPY261218C00650000");
+        result.SourceContractSymbol.Should().Be("legacy");
+    }
+
+    [Theory]
+    [InlineData("partially_filled", 100, 40, OrderStatus.PartiallyFilled, ExecutionReportType.PartialFill)]
+    [InlineData("canceled", 100, 40, OrderStatus.Cancelled, ExecutionReportType.Cancelled)]
+    [InlineData("rejected", 100, 0, OrderStatus.Rejected, ExecutionReportType.Rejected)]
+    [InlineData("open", 100, 40, OrderStatus.PartiallyFilled, ExecutionReportType.PartialFill)]
+    public void MapOrderTransition_MapsStatusTransitions(
+        string status,
+        decimal quantity,
+        decimal filled,
+        OrderStatus expectedStatus,
+        ExecutionReportType expectedType)
+    {
+        var transition = TradierCanonicalMappers.MapOrderTransition(new TradierOrderStatusPayload(status, quantity, filled));
+
+        transition.Status.Should().Be(expectedStatus);
+        transition.ReportType.Should().Be(expectedType);
+    }
+
+    [Fact]
+    public void MapBrokerError_MapsRateLimitAsRetriableOperationalError()
+    {
+        var payload = new TradierBrokerErrorPayload(429, "rate_limit", "Too many requests", "{...}");
+
+        var error = TradierCanonicalMappers.MapBrokerError(payload);
+
+        error.Category.Should().Be("RateLimit");
+        error.IsRetriable.Should().BeTrue();
+        error.BrokerCode.Should().Be("rate_limit");
+        error.Message.Should().Be("Too many requests");
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a Tradier → Meridian mapping layer so incoming equity and options payloads are normalized into the repository's canonical shapes used by UI/services and the execution pipeline.
- Ensure robust order lifecycle transitions are translated from Tradier status strings into Meridian `OrderStatus` and `ExecutionReportType`, with correct handling of partial fills, cancels, rejects, and expired states.
- Surface broker error details as a structured operational error model so UI and monitoring layers can classify, display, and decide retry semantics consistently.

### Description
- Added `src/Meridian.Infrastructure/Adapters/Tradier/TradierCanonicalMappers.cs` containing helpers to normalize equity payloads (symbol normalization `/`→`.`, uppercase, `UNKNOWN` defaults), option payloads (OCC-style contract assembly from underlying/expiry/right/strike), order-status → `(OrderStatus, ExecutionReportType)` transition logic that detects partial fills and common status variants, and error-to-operational-error classification including retriable detection and raw-payload preservation.
- Introduced lightweight payload and canonical record types used by the mappers (`TradierEquityPayload`, `TradierOptionPayload`, `TradierOrderStatusPayload`, `TradierBrokerErrorPayload`, `TradierCanonicalEquity`, `TradierCanonicalOptionContract`, `TradierOrderTransition`, `TradierOperationalError`).
- Order mapping covers synonyms (`canceled`/`cancelled`), explicit partial-fill detection when `filled > 0 && filled < total`, and sensible fallbacks to `Accepted`/`PendingNew` when appropriate to preserve downstream OMS semantics.
- Error mapping classifies HTTP-like codes into categories (`Validation`, `Authentication`, `RateLimit`, `Timeout`, `ProviderUnavailable`, etc.), sets `IsRetriable` for timeouts/rate-limits/5xx, and preserves `BrokerCode` and `RawPayload` for diagnostics and UI display.

### Testing
- Added unit tests in `tests/Meridian.Tests/Infrastructure/Adapters/TradierCanonicalMappersTests.cs` covering equity symbol normalization, option contract construction, order-transition mapping, and broker-error mapping.
- Attempted to run the focused test filter with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~TradierCanonicalMappersTests" --logger "console;verbosity=normal"` but the test run could not be executed in this environment because `dotnet` is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cc2a0cc9c83208989a0abef893765)