### PR TITLE
Add reconciliation break-queue and ledger-impact projections to FundOperations workspace

### DIFF
--- a/src/Meridian.Contracts/Workstation/FundOperationsDtos.cs
+++ b/src/Meridian.Contracts/Workstation/FundOperationsDtos.cs
@@ -177,7 +177,49 @@ public sealed record ReconciliationSummary(
     int OpenBreakCount,
     decimal BreakAmountTotal,
     IReadOnlyList<FundReconciliationItem> RecentRuns,
-    int SecurityCoverageIssueCount = 0);
+    int SecurityCoverageIssueCount = 0,
+    ReconciliationBreakQueueProjectionDto? BreakQueue = null,
+    LedgerImpactPreviewDto? LedgerImpactPreview = null,
+    bool HasCriticalBreakOpen = false);
+
+/// <summary>
+/// Reconciliation break-queue projection used by shared operator workflows.
+/// </summary>
+public sealed record ReconciliationBreakQueueProjectionDto(
+    int TotalCount,
+    int OpenCount,
+    int InReviewCount,
+    int ResolvedCount,
+    int DismissedCount,
+    int CriticalOpenCount,
+    IReadOnlyList<ReconciliationBreakQueueProjectionItemDto> Items);
+
+/// <summary>
+/// One projected reconciliation break row including routing and sign-off evidence fields.
+/// </summary>
+public sealed record ReconciliationBreakQueueProjectionItemDto(
+    string BreakId,
+    string? WorkflowId,
+    ReconciliationBreakSeverity Severity,
+    ReconciliationBreakQueueStatus Status,
+    string? Owner,
+    string? RequiredSignoffRole,
+    string? SignoffStatus,
+    string? RoutingTarget,
+    string? RoutingDetail,
+    string? EvidenceReference,
+    DateTimeOffset LastUpdatedAt);
+
+/// <summary>
+/// Preview of accounting impact if current breaks are submitted/closed with draft ledger entries.
+/// </summary>
+public sealed record LedgerImpactPreviewDto(
+    int DraftEntryCount,
+    decimal NetDebitEffect,
+    decimal NetCreditEffect,
+    decimal NetBalanceDelta,
+    bool HasValidationWarnings,
+    IReadOnlyList<string> ValidationFlags);
 
 /// <summary>
 /// Lightweight audit row combining journal and reconciliation activity.

--- a/src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs
+++ b/src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs
@@ -58,6 +58,7 @@ public sealed class FundOperationsWorkspaceReadService
     private readonly PortfolioReadService _portfolioReadService;
     private readonly ISecurityReferenceLookup? _securityReferenceLookup;
     private readonly IReconciliationRunService? _strategyReconciliationService;
+    private readonly IReconciliationBreakQueueRepository? _breakQueueRepository;
     private readonly NavAttributionService _navAttributionService;
     private readonly ReportGenerationService _reportGenerationService;
     private readonly IGovernanceReportPackRepository? _reportPackRepository;
@@ -72,6 +73,7 @@ public sealed class FundOperationsWorkspaceReadService
         ReportGenerationService reportGenerationService,
         ISecurityReferenceLookup? securityReferenceLookup = null,
         IReconciliationRunService? strategyReconciliationService = null,
+        IReconciliationBreakQueueRepository? breakQueueRepository = null,
         IGovernanceReportPackRepository? reportPackRepository = null,
         ReportPackValidationService? reportPackValidationService = null,
         ISecurityValidationGateService? securityValidationGate = null)
@@ -83,6 +85,7 @@ public sealed class FundOperationsWorkspaceReadService
         _reportGenerationService = reportGenerationService ?? throw new ArgumentNullException(nameof(reportGenerationService));
         _securityReferenceLookup = securityReferenceLookup;
         _strategyReconciliationService = strategyReconciliationService;
+        _breakQueueRepository = breakQueueRepository;
         _reportPackRepository = reportPackRepository;
         _reportPackValidationService = reportPackValidationService ?? new ReportPackValidationService();
         _securityValidationGate = securityValidationGate;
@@ -702,7 +705,80 @@ public sealed class FundOperationsWorkspaceReadService
             OpenBreakCount: openBreaks,
             BreakAmountTotal: breakAmountTotal,
             RecentRuns: ordered,
-            SecurityCoverageIssueCount: securityCoverageIssues);
+            SecurityCoverageIssueCount: securityCoverageIssues,
+            BreakQueue: await BuildBreakQueueProjectionAsync(ct).ConfigureAwait(false),
+            LedgerImpactPreview: BuildLedgerImpactPreview(ordered),
+            HasCriticalBreakOpen: await HasCriticalBreakOpenAsync(ct).ConfigureAwait(false));
+    }
+
+    private async Task<ReconciliationBreakQueueProjectionDto?> BuildBreakQueueProjectionAsync(CancellationToken ct)
+    {
+        if (_breakQueueRepository is null)
+        {
+            return null;
+        }
+
+        var items = await _breakQueueRepository.GetAllAsync(null, ct).ConfigureAwait(false);
+        var projected = items
+            .OrderByDescending(static item => item.LastUpdatedAt)
+            .Select(static item => new ReconciliationBreakQueueProjectionItemDto(
+                BreakId: item.BreakId,
+                WorkflowId: item.RunId,
+                Severity: item.Severity,
+                Status: item.Status,
+                Owner: item.AssignedTo,
+                RequiredSignoffRole: item.RequiredSignoffRole,
+                SignoffStatus: item.SignoffStatus,
+                RoutingTarget: item.RoutingTarget,
+                RoutingDetail: item.RoutingDetail,
+                EvidenceReference: item.UpstreamSyncCursor ?? item.ExternalAccountId,
+                LastUpdatedAt: item.LastUpdatedAt))
+            .ToArray();
+
+        return new ReconciliationBreakQueueProjectionDto(
+            TotalCount: projected.Length,
+            OpenCount: projected.Count(static item => item.Status == ReconciliationBreakQueueStatus.Open),
+            InReviewCount: projected.Count(static item => item.Status == ReconciliationBreakQueueStatus.InReview),
+            ResolvedCount: projected.Count(static item => item.Status == ReconciliationBreakQueueStatus.Resolved),
+            DismissedCount: projected.Count(static item => item.Status == ReconciliationBreakQueueStatus.Dismissed),
+            CriticalOpenCount: projected.Count(static item => item.Status == ReconciliationBreakQueueStatus.Open && item.Severity == ReconciliationBreakSeverity.Critical),
+            Items: projected);
+    }
+
+    private static LedgerImpactPreviewDto BuildLedgerImpactPreview(IReadOnlyList<FundReconciliationItem> items)
+    {
+        var draftEntryCount = items.Sum(static item => item.TotalBreaks);
+        var netDebit = items.Where(static item => item.BreakAmountTotal >= 0m).Sum(static item => item.BreakAmountTotal);
+        var netCredit = items.Where(static item => item.BreakAmountTotal < 0m).Sum(static item => Math.Abs(item.BreakAmountTotal));
+        var flags = new List<string>();
+        if (draftEntryCount > 0)
+        {
+            flags.Add("draft-entries-present");
+        }
+
+        if (items.Any(static item => item.TotalBreaks > 0 && !string.Equals(item.Status, "Resolved", StringComparison.OrdinalIgnoreCase)))
+        {
+            flags.Add("unresolved-breaks-blocking-close");
+        }
+
+        return new LedgerImpactPreviewDto(
+            DraftEntryCount: draftEntryCount,
+            NetDebitEffect: netDebit,
+            NetCreditEffect: netCredit,
+            NetBalanceDelta: netDebit - netCredit,
+            HasValidationWarnings: flags.Count > 0,
+            ValidationFlags: flags);
+    }
+
+    private async Task<bool> HasCriticalBreakOpenAsync(CancellationToken ct)
+    {
+        if (_breakQueueRepository is null)
+        {
+            return false;
+        }
+
+        var items = await _breakQueueRepository.GetAllAsync(ReconciliationBreakQueueStatus.Open, ct).ConfigureAwait(false);
+        return items.Any(static item => item.Severity == ReconciliationBreakSeverity.Critical);
     }
 
     private async Task<FundNavAttributionSummaryDto> BuildNavSummaryAsync(


### PR DESCRIPTION
### Motivation
- Provide shared read-model data that operator UIs (web and WPF) can use for break-queue routing, sign-off evidence linking, and close/submit-for-approval guards without breaking existing contracts. 
- Offer a fast, nullable-safe indicator for critical open breaks so guards can avoid scanning full queues on the hot path.

### Description
- Extended `ReconciliationSummary` with nullable projection fields `BreakQueue`, `LedgerImpactPreview`, and `HasCriticalBreakOpen` to keep the contract backward-compatible. 
- Added projection DTOs `ReconciliationBreakQueueProjectionDto`, `ReconciliationBreakQueueProjectionItemDto`, and `LedgerImpactPreviewDto` in `src/Meridian.Contracts/Workstation/FundOperationsDtos.cs` to expose routing, sign-off, evidence, draft entry counts, net debit/credit effects, and validation flags. 
- Wired an optional `IReconciliationBreakQueueRepository` into `FundOperationsWorkspaceReadService` and added `BuildBreakQueueProjectionAsync`, `BuildLedgerImpactPreview`, and `HasCriticalBreakOpenAsync` methods to populate the new fields when the repository is available while returning `null` when it is not. 
- Projection mapping includes `workflowId`, `severity`, `owner`, `status`, `requiredSignoffRole`, `signoffStatus`, `routingTarget`, `routingDetail`, and `evidenceReference` for operator routing and sign-off evidence linking.

### Testing
- Attempted a targeted test run using `dotnet test` for `ReportPackValidationServiceTests`, but the environment lacks the .NET SDK and the test run failed with `dotnet: command not found`.
- Service-level logic is exercised by the new projection methods; no automated tests were added in this change set due to environment limitations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cd19f31588320b6bd1acaf122901e)