### PR TITLE
Harden v1 contract compatibility checks for additive-only API evolution

### DIFF
--- a/docs/status/contract-compatibility-matrix.md
+++ b/docs/status/contract-compatibility-matrix.md
@@ -77,7 +77,7 @@ Any pull request touching scoped surfaces must pass:
 
 1. **Standard PR gates:** existing build/test/format gates in `.github/workflows/pr-checks.yml`.
 2. **Contract review packet:** `scripts/generate_contract_review_packet.py` for the same base/head range. The packet summarizes tracked surfaces, change category, migration-note status, and reviewer checklist items for the weekly interop cadence.
-3. **Contract compatibility gate:** `scripts/check_contract_compatibility_gate.py` from the `contract-compatibility` PR job and the release workflow. The gate flags public type/member/route removals, shared `UiApiRoutes` constant removals or value changes, plus scoped record constructor parameter and enum-member removals.
+3. **Contract compatibility gate:** `scripts/check_contract_compatibility_gate.py` from the `contract-compatibility` PR job and the release workflow. The gate flags public type/member/route removals, shared `UiApiRoutes` constant removals or value changes, scoped record constructor parameter and enum-member removals, and **new v1 required DTO fields** (non-nullable additions without null/default compatibility).
 4. **Contract regression tests (required when contract code changes):**
    - targeted workstation contract serialization/deserialization tests,
    - strategy service interface compatibility tests,
@@ -136,6 +136,9 @@ changes, that requires a matrix migration-note entry and PR-body migration notes
 `--pr-body-file <path>` when evaluating a pull request so the packet can verify those notes. A ready
 packet is still a review input, not owner approval; record the owner decision and any follow-up in
 the weekly interop notes and, when readiness status changes, in `kernel-readiness-dashboard.md`.
+For v1 contract deltas, include the compatibility-gate output in the packet attachment and explicitly
+confirm these assertions in the interop note: **(a)** no route removal/rename, **(b)** no required-field
+regression for existing DTOs, and **(c)** additive-only enum/field evolution.
 Pull request checks also upload a `contract-review-packet` artifact and append the Markdown packet
 to the contract-compatibility job summary so reviewers can inspect tracked surfaces and blocking
 findings even when the compatibility gate fails.
@@ -160,6 +163,8 @@ Use this section for every potential contract-breaking change. Entries must be a
 - 2026-04-27: Added `scripts/generate_contract_review_packet.py` as the repeatable weekly shared-interop review artifact for tracked contract changes. No runtime contract break introduced.
 - 2026-04-29: Updated `StrategyRunContinuityStatus` with additive `HasFills` coverage and tightened continuity warning-code expectations for run-centered readiness consumers. Older clients that do not read `HasFills` should continue defaulting to `false`/missing-field handling and can ignore unknown warning codes; consumers that branch on continuity warnings should treat new codes as additive and map unknown values to their existing generic warning UX.
 - 2026-04-29: Merge/release cadence now explicitly depends on passing both `scripts/check_contract_compatibility_gate.py --base <base> --head <head>` and the same-range `scripts/generate_contract_review_packet.py` review packet before owner sign-off.
+- 2026-05-19: Extended compatibility-gate coverage with regression tests so v1 compatibility workflows now fail when DTO deltas introduce new required fields; the shared interop packet must now explicitly attest no route removals/renames, no required-field regressions, and additive-only field/enum changes.
+- 2026-05-19: Documented v2 deprecation-window policy hook: any planned v2-only required-field or route-shape break must be pre-registered in this matrix with a dated migration note and at least a two-minor-release (or 60-day) coexistence window unless a release-manager emergency waiver is recorded.
 
 ## Pull Request Author Checklist
 

--- a/scripts/check_contract_compatibility_gate.py
+++ b/scripts/check_contract_compatibility_gate.py
@@ -65,6 +65,14 @@ REQUIRED_SECURITY_MASTER_HINTS = (
     "provenance",
     "source",
 )
+RECORD_PARAMETER_ADDITION_PATTERN = re.compile(
+    r"^\+\s*(?:\[property:\s*[^\]]+\]\s*)?"
+    rf"({CS_CONTRACT_TYPE_PATTERN})\s+@?([A-Za-z_]\w*)\s*(?:=\s*([^,)]+))?\s*[,)]\s*;?\s*$"
+)
+PROPERTY_ADDITION_PATTERN = re.compile(
+    r"^\+\s*public\s+(required\s+)?(?:static\s+|virtual\s+|override\s+|sealed\s+|readonly\s+)*"
+    rf"({CS_CONTRACT_TYPE_PATTERN})\s+([A-Za-z_]\w*)\s*\{{\s*(?:get|init|set)\b"
+)
 
 
 def run_git(args: list[str]) -> str:
@@ -112,6 +120,48 @@ def is_breaking_removal_line(line: str) -> bool:
 
 def patch_has_breaking_removal(patch: str) -> bool:
     return any(is_breaking_removal_line(line) for line in patch.splitlines())
+
+
+def _is_contract_source_file(path: str) -> bool:
+    normalized = path.lower()
+    return normalized.startswith("src/meridian.contracts/") and normalized.endswith(".cs")
+
+
+def find_required_field_regressions(changed_files: list[str], patch: str) -> list[str]:
+    current_file: str | None = None
+    violations: set[str] = set()
+    tracked_contract_files = {path for path in changed_files if _is_contract_source_file(path)}
+    if not tracked_contract_files:
+        return []
+
+    for raw_line in patch.splitlines():
+        if raw_line.startswith("+++ b/"):
+            current_file = raw_line[len("+++ b/"):].strip()
+            continue
+        if not current_file or current_file not in tracked_contract_files:
+            continue
+        if not raw_line.startswith("+") or raw_line.startswith("+++"):
+            continue
+
+        line = raw_line.rstrip()
+        property_match = PROPERTY_ADDITION_PATTERN.match(line)
+        if property_match:
+            required_prefix, property_type, _ = property_match.groups()
+            is_required = bool(required_prefix) or not property_type.endswith("?")
+            if is_required:
+                violations.add(current_file)
+            continue
+
+        parameter_match = RECORD_PARAMETER_ADDITION_PATTERN.match(line)
+        if not parameter_match:
+            continue
+        parameter_type, _, default_expression = parameter_match.groups()
+        is_nullable = parameter_type.endswith("?")
+        has_safe_default = bool(default_expression and default_expression.strip() in ("null", "default", "default!"))
+        if not is_nullable and not has_safe_default:
+            violations.add(current_file)
+
+    return sorted(violations)
 
 
 def _is_governance_contract_dto_path(path: str) -> bool:
@@ -181,6 +231,13 @@ def main() -> int:
         print("Contract compatibility gate failed: governance/accounting/reporting DTO instrument metadata must include Security Master identity/provenance fields.")
         for violation in security_master_reference_violations:
             print(f"- Add required Security Master identity/provenance fields to `{violation}` (for example: SecurityId + SecurityMasterSource/Provenance).")
+        return 1
+
+    required_field_violations = find_required_field_regressions(tracked_changed_files, patch)
+    if required_field_violations:
+        print("Contract compatibility gate failed: v1 contract changes must be additive-only and cannot introduce new required fields.")
+        for violation in required_field_violations:
+            print(f"- Make new DTO members optional in `{violation}` (nullable or null/default-backed) or defer to a versioned v2 contract.")
         return 1
 
     is_breaking = patch_has_breaking_removal(patch)

--- a/tests/scripts/test_check_contract_compatibility_gate.py
+++ b/tests/scripts/test_check_contract_compatibility_gate.py
@@ -114,11 +114,11 @@ diff --git a/src/Meridian.Contracts/Workstation/LedgerContinuityDtos.cs b/src/Me
         with tempfile.TemporaryDirectory(dir="src/Meridian.Contracts/Workstation") as tmp_dir:
             temp_path = Path(tmp_dir) / "GovernanceInstrumentContractDto.cs"
             temp_path.write_text("public sealed record GovernanceInstrumentContractDto(string InstrumentTicker);", encoding="utf-8")
-            changed_files = [str(temp_path)]
+            changed_files = [str(temp_path.relative_to(Path.cwd()))]
             patch = f"""
-diff --git a/{temp_path} b/{temp_path}
---- a/{temp_path}
-+++ b/{temp_path}
+diff --git a/{changed_files[0]} b/{changed_files[0]}
+--- a/{changed_files[0]}
++++ b/{changed_files[0]}
 @@ -1,0 +1 @@
 +    string InstrumentTicker,
 """
@@ -132,17 +132,53 @@ diff --git a/{temp_path} b/{temp_path}
             temp_path.write_text(
                 "public sealed record GovernanceInstrumentContractDto(string InstrumentTicker, Guid SecurityId, string SecurityMasterSource);",
                 encoding="utf-8")
-            changed_files = [str(temp_path)]
+            changed_files = [str(temp_path.relative_to(Path.cwd()))]
             patch = f"""
-diff --git a/{temp_path} b/{temp_path}
---- a/{temp_path}
-+++ b/{temp_path}
+diff --git a/{changed_files[0]} b/{changed_files[0]}
+--- a/{changed_files[0]}
++++ b/{changed_files[0]}
 @@ -1,0 +1,2 @@
 +    string InstrumentTicker,
 +    Guid SecurityId,
 """
             violations = gate.find_missing_security_master_instrument_references(changed_files, patch)
             self.assertEqual([], violations)
+
+    def test_find_required_field_regressions_flags_required_property_addition(self) -> None:
+        changed_files = ["src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs"]
+        patch = """
+diff --git a/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs b/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
++++ b/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
+@@ -200,0 +201 @@ public sealed class TradingOperatorReadinessDto
++    public required string ContractVersion { get; init; }
+"""
+
+        violations = gate.find_required_field_regressions(changed_files, patch)
+        self.assertEqual(changed_files, violations)
+
+    def test_find_required_field_regressions_flags_non_nullable_record_parameter_addition(self) -> None:
+        changed_files = ["src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs"]
+        patch = """
+diff --git a/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs b/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
++++ b/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
+@@ -102,0 +103 @@ public sealed record TradingOperatorReadinessDto(
++    string ContractVersion,
+"""
+
+        violations = gate.find_required_field_regressions(changed_files, patch)
+        self.assertEqual(changed_files, violations)
+
+    def test_find_required_field_regressions_allows_nullable_record_parameter_addition(self) -> None:
+        changed_files = ["src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs"]
+        patch = """
+diff --git a/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs b/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
++++ b/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
+@@ -102,0 +103 @@ public sealed record TradingOperatorReadinessDto(
++    string? ContractVersion = null,
+"""
+
+        violations = gate.find_required_field_regressions(changed_files, patch)
+        self.assertEqual([], violations)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Prevent accidental v1 contract regressions where new DTO fields are introduced as required (non-nullable) and break older clients.
- Strengthen the existing compatibility gate to catch required-field additions in `src/Meridian.Contracts/*.cs` diffs in addition to removals/renames.
- Make the compatibility workflow and weekly interop packet explicitly attest no route removal/rename, no required-field regressions, and additive-only enum/field changes for v1.

### Description

- Extended `scripts/check_contract_compatibility_gate.py` with new regex patterns and logic (`RECORD_PARAMETER_ADDITION_PATTERN`, `PROPERTY_ADDITION_PATTERN`) and a `find_required_field_regressions` pass that flags newly added non-nullable record parameters or required properties in tracked `src/Meridian.Contracts/*.cs` files.
- Integrated the required-field regression check into the main gate flow so v1 DTO deltas that introduce required fields fail the compatibility gate early.
- Added focused unit tests in `tests/scripts/test_check_contract_compatibility_gate.py` covering required-property additions, non-nullable record-parameter additions, and allowing nullable/default-backed additions.
- Updated `docs/status/contract-compatibility-matrix.md` to register the gate change, require explicit packet assertions for v1 deltas, and document a v2 deprecation-window policy hook (two minor releases / 60 days unless waived).

### Testing

- Ran `python3 -m unittest tests/scripts/test_check_contract_compatibility_gate.py` and all tests passed (15 tests, OK).
- Ensured the new gate logic runs on the same tracked surfaces previously enforced by `scripts/check_contract_compatibility_gate.py` and that the added tests exercise the new heuristics successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cd19feb1c832091abdb0559ab2326)