### PR TITLE
Add append-only operations_workflow_audit persistence with SHA-256 hash chaining

### DIFF
--- a/src/Meridian.Storage/DirectLending/IDirectLendingOperationsStore.cs
+++ b/src/Meridian.Storage/DirectLending/IDirectLendingOperationsStore.cs
@@ -43,6 +43,33 @@ public sealed record OperationsWorkflowAuditRecord(
     string Severity,
     IReadOnlyList<string> Tags);
 
+public sealed record OperationsWorkflowAuditAppendRequest(
+    Guid AuditId,
+    DateTimeOffset OccurredAtUtc,
+    string WorkflowId,
+    Guid FundAccountId,
+    string PeriodId,
+    string EventType,
+    string? FromState,
+    string? ToState,
+    string? Gate,
+    string? FromGateStatus,
+    string? ToGateStatus,
+    string Actor,
+    string Rationale,
+    string? TraceId,
+    string? RequestId,
+    string? SessionId,
+    string? RunId,
+    string? BrokerReferenceId,
+    string? SecurityReferenceId,
+    string? LedgerReferenceId,
+    string? ReconciliationReferenceId,
+    string? EvidenceReferenceId,
+    string? AuditReferenceId,
+    string Severity,
+    IReadOnlyList<string> Tags);
+
 public interface IDirectLendingOperationsStore
 {
     Task<IReadOnlyList<CashTransactionDto>> GetCashTransactionsAsync(Guid loanId, CancellationToken ct = default);
@@ -107,7 +134,7 @@ public interface IDirectLendingOperationsStore
 
     Task UpsertCheckpointAsync(RebuildCheckpointDto checkpoint, CancellationToken ct = default);
 
-    Task<OperationsWorkflowAuditRecord> AppendOperationsWorkflowAuditAsync(OperationsWorkflowAuditRecord record, CancellationToken ct = default);
+    Task<OperationsWorkflowAuditRecord> AppendOperationsWorkflowAuditAsync(OperationsWorkflowAuditAppendRequest request, CancellationToken ct = default);
 
     Task<IReadOnlyList<OperationsWorkflowAuditRecord>> GetOperationsWorkflowAuditAsync(string workflowId, CancellationToken ct = default);
 }

--- a/src/Meridian.Storage/DirectLending/IDirectLendingOperationsStore.cs
+++ b/src/Meridian.Storage/DirectLending/IDirectLendingOperationsStore.cs
@@ -14,6 +14,35 @@ public sealed record DirectLendingOutboxMessage(
     int ErrorCount,
     string? LastError);
 
+public sealed record OperationsWorkflowAuditRecord(
+    Guid AuditId,
+    DateTimeOffset OccurredAtUtc,
+    string WorkflowId,
+    Guid FundAccountId,
+    string PeriodId,
+    string EventType,
+    string? FromState,
+    string? ToState,
+    string? Gate,
+    string? FromGateStatus,
+    string? ToGateStatus,
+    string Actor,
+    string Rationale,
+    string? TraceId,
+    string? RequestId,
+    string? SessionId,
+    string? RunId,
+    string? BrokerReferenceId,
+    string? SecurityReferenceId,
+    string? LedgerReferenceId,
+    string? ReconciliationReferenceId,
+    string? EvidenceReferenceId,
+    string? AuditReferenceId,
+    string Hash,
+    string? PreviousHash,
+    string Severity,
+    IReadOnlyList<string> Tags);
+
 public interface IDirectLendingOperationsStore
 {
     Task<IReadOnlyList<CashTransactionDto>> GetCashTransactionsAsync(Guid loanId, CancellationToken ct = default);
@@ -77,4 +106,8 @@ public interface IDirectLendingOperationsStore
     Task<IReadOnlyList<RebuildCheckpointDto>> GetCheckpointsAsync(CancellationToken ct = default);
 
     Task UpsertCheckpointAsync(RebuildCheckpointDto checkpoint, CancellationToken ct = default);
+
+    Task<OperationsWorkflowAuditRecord> AppendOperationsWorkflowAuditAsync(OperationsWorkflowAuditRecord record, CancellationToken ct = default);
+
+    Task<IReadOnlyList<OperationsWorkflowAuditRecord>> GetOperationsWorkflowAuditAsync(string workflowId, CancellationToken ct = default);
 }

--- a/src/Meridian.Storage/DirectLending/Migrations/006_direct_lending_operations_workflow_audit.sql
+++ b/src/Meridian.Storage/DirectLending/Migrations/006_direct_lending_operations_workflow_audit.sql
@@ -1,0 +1,50 @@
+create table if not exists __SCHEMA__.operations_workflow_audit (
+    audit_id                      uuid primary key,
+    occurred_at_utc               timestamptz not null,
+    workflow_id                   text not null,
+    fund_account_id               uuid not null,
+    period_id                     text not null,
+    event_type                    text not null,
+    from_state                    text,
+    to_state                      text,
+    gate                          text,
+    from_gate_status              text,
+    to_gate_status                text,
+    actor                         text not null,
+    rationale                     text not null,
+    trace_id                      text,
+    request_id                    text,
+    session_id                    text,
+    run_id                        text,
+    broker_reference_id           text,
+    security_reference_id         text,
+    ledger_reference_id           text,
+    reconciliation_reference_id   text,
+    evidence_reference_id         text,
+    audit_reference_id            text,
+    hash                          text not null,
+    previous_hash                 text,
+    severity                      text not null,
+    tags                          text[] not null default '{}',
+    created_at                    timestamptz not null default now(),
+    constraint ck_operations_workflow_audit_event_type
+        check (event_type in (
+            'state_transition',
+            'gate_change',
+            'override_decision',
+            'ledger_validate_decision',
+            'ledger_post_decision',
+            'break_opened',
+            'break_assigned',
+            'break_resolved',
+            'break_closed',
+            'approval_action',
+            'close_action',
+            'reopen_action'))
+);
+
+create index if not exists ix_operations_workflow_audit_stream
+    on __SCHEMA__.operations_workflow_audit (workflow_id, occurred_at_utc, audit_id);
+
+create unique index if not exists ux_operations_workflow_audit_hash
+    on __SCHEMA__.operations_workflow_audit (workflow_id, hash);

--- a/src/Meridian.Storage/DirectLending/Migrations/006_direct_lending_operations_workflow_audit.sql
+++ b/src/Meridian.Storage/DirectLending/Migrations/006_direct_lending_operations_workflow_audit.sql
@@ -44,7 +44,15 @@ create table if not exists __SCHEMA__.operations_workflow_audit (
 );
 
 create index if not exists ix_operations_workflow_audit_stream
-    on __SCHEMA__.operations_workflow_audit (workflow_id, occurred_at_utc, audit_id);
+    on __SCHEMA__.operations_workflow_audit (workflow_id, created_at, audit_id);
 
 create unique index if not exists ux_operations_workflow_audit_hash
     on __SCHEMA__.operations_workflow_audit (workflow_id, hash);
+
+create unique index if not exists ux_operations_workflow_audit_previous_hash
+    on __SCHEMA__.operations_workflow_audit (workflow_id, previous_hash)
+    where previous_hash is not null;
+
+create unique index if not exists ux_operations_workflow_audit_genesis
+    on __SCHEMA__.operations_workflow_audit (workflow_id)
+    where previous_hash is null;

--- a/src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.WorkflowAudit.cs
+++ b/src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.WorkflowAudit.cs
@@ -1,0 +1,173 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Meridian.Contracts.DirectLending;
+
+namespace Meridian.Storage.DirectLending;
+
+public sealed partial class PostgresDirectLendingStateStore
+{
+    public async Task<OperationsWorkflowAuditRecord> AppendOperationsWorkflowAuditAsync(OperationsWorkflowAuditRecord record, CancellationToken ct = default)
+    {
+        await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(ct).ConfigureAwait(false);
+
+        string? previousHash = null;
+        await using (var previous = connection.CreateCommand())
+        {
+            previous.Transaction = transaction;
+            previous.CommandText =
+                $"""
+                select hash
+                from {Qualified("operations_workflow_audit")}
+                where workflow_id = @workflow_id
+                order by occurred_at_utc desc, audit_id desc
+                limit 1;
+                """;
+            previous.Parameters.AddWithValue("workflow_id", record.WorkflowId);
+            previousHash = (string?)await previous.ExecuteScalarAsync(ct).ConfigureAwait(false);
+        }
+
+        var computedHash = ComputeOperationsWorkflowAuditHash(record, previousHash);
+
+        await using (var insert = connection.CreateCommand())
+        {
+            insert.Transaction = transaction;
+            insert.CommandText =
+                $"""
+                insert into {Qualified("operations_workflow_audit")} (
+                    audit_id, occurred_at_utc, workflow_id, fund_account_id, period_id, event_type,
+                    from_state, to_state, gate, from_gate_status, to_gate_status, actor, rationale,
+                    trace_id, request_id, session_id, run_id,
+                    broker_reference_id, security_reference_id, ledger_reference_id, reconciliation_reference_id, evidence_reference_id, audit_reference_id,
+                    hash, previous_hash, severity, tags)
+                values (
+                    @audit_id, @occurred_at_utc, @workflow_id, @fund_account_id, @period_id, @event_type,
+                    @from_state, @to_state, @gate, @from_gate_status, @to_gate_status, @actor, @rationale,
+                    @trace_id, @request_id, @session_id, @run_id,
+                    @broker_reference_id, @security_reference_id, @ledger_reference_id, @reconciliation_reference_id, @evidence_reference_id, @audit_reference_id,
+                    @hash, @previous_hash, @severity, @tags);
+                """;
+            insert.Parameters.AddWithValue("audit_id", record.AuditId);
+            insert.Parameters.AddWithValue("occurred_at_utc", record.OccurredAtUtc.UtcDateTime);
+            insert.Parameters.AddWithValue("workflow_id", record.WorkflowId);
+            insert.Parameters.AddWithValue("fund_account_id", record.FundAccountId);
+            insert.Parameters.AddWithValue("period_id", record.PeriodId);
+            insert.Parameters.AddWithValue("event_type", record.EventType);
+            insert.Parameters.AddWithValue("from_state", (object?)record.FromState ?? DBNull.Value);
+            insert.Parameters.AddWithValue("to_state", (object?)record.ToState ?? DBNull.Value);
+            insert.Parameters.AddWithValue("gate", (object?)record.Gate ?? DBNull.Value);
+            insert.Parameters.AddWithValue("from_gate_status", (object?)record.FromGateStatus ?? DBNull.Value);
+            insert.Parameters.AddWithValue("to_gate_status", (object?)record.ToGateStatus ?? DBNull.Value);
+            insert.Parameters.AddWithValue("actor", record.Actor);
+            insert.Parameters.AddWithValue("rationale", record.Rationale);
+            insert.Parameters.AddWithValue("trace_id", (object?)record.TraceId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("request_id", (object?)record.RequestId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("session_id", (object?)record.SessionId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("run_id", (object?)record.RunId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("broker_reference_id", (object?)record.BrokerReferenceId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("security_reference_id", (object?)record.SecurityReferenceId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("ledger_reference_id", (object?)record.LedgerReferenceId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("reconciliation_reference_id", (object?)record.ReconciliationReferenceId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("evidence_reference_id", (object?)record.EvidenceReferenceId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("audit_reference_id", (object?)record.AuditReferenceId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("hash", computedHash);
+            insert.Parameters.AddWithValue("previous_hash", (object?)previousHash ?? DBNull.Value);
+            insert.Parameters.AddWithValue("severity", record.Severity);
+            insert.Parameters.AddWithValue("tags", record.Tags.ToArray());
+            await insert.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
+        return record with { Hash = computedHash, PreviousHash = previousHash };
+    }
+
+    public async Task<IReadOnlyList<OperationsWorkflowAuditRecord>> GetOperationsWorkflowAuditAsync(string workflowId, CancellationToken ct = default)
+    {
+        await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            $"""
+            select audit_id, occurred_at_utc, workflow_id, fund_account_id, period_id, event_type,
+                   from_state, to_state, gate, from_gate_status, to_gate_status, actor, rationale,
+                   trace_id, request_id, session_id, run_id,
+                   broker_reference_id, security_reference_id, ledger_reference_id, reconciliation_reference_id, evidence_reference_id, audit_reference_id,
+                   hash, previous_hash, severity, tags
+            from {Qualified("operations_workflow_audit")}
+            where workflow_id = @workflow_id
+            order by occurred_at_utc, audit_id;
+            """;
+        command.Parameters.AddWithValue("workflow_id", workflowId);
+
+        var results = new List<OperationsWorkflowAuditRecord>();
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            results.Add(new OperationsWorkflowAuditRecord(
+                reader.GetGuid(0),
+                new DateTimeOffset(reader.GetDateTime(1), TimeSpan.Zero),
+                reader.GetString(2),
+                reader.GetGuid(3),
+                reader.GetString(4),
+                reader.GetString(5),
+                reader.IsDBNull(6) ? null : reader.GetString(6),
+                reader.IsDBNull(7) ? null : reader.GetString(7),
+                reader.IsDBNull(8) ? null : reader.GetString(8),
+                reader.IsDBNull(9) ? null : reader.GetString(9),
+                reader.IsDBNull(10) ? null : reader.GetString(10),
+                reader.GetString(11),
+                reader.GetString(12),
+                reader.IsDBNull(13) ? null : reader.GetString(13),
+                reader.IsDBNull(14) ? null : reader.GetString(14),
+                reader.IsDBNull(15) ? null : reader.GetString(15),
+                reader.IsDBNull(16) ? null : reader.GetString(16),
+                reader.IsDBNull(17) ? null : reader.GetString(17),
+                reader.IsDBNull(18) ? null : reader.GetString(18),
+                reader.IsDBNull(19) ? null : reader.GetString(19),
+                reader.IsDBNull(20) ? null : reader.GetString(20),
+                reader.IsDBNull(21) ? null : reader.GetString(21),
+                reader.IsDBNull(22) ? null : reader.GetString(22),
+                reader.GetString(23),
+                reader.IsDBNull(24) ? null : reader.GetString(24),
+                reader.GetString(25),
+                reader.GetFieldValue<string[]>(26)));
+        }
+
+        return results;
+    }
+
+    private static string ComputeOperationsWorkflowAuditHash(OperationsWorkflowAuditRecord record, string? previousHash)
+    {
+        var canonicalPayload = JsonSerializer.Serialize(new
+        {
+            record.AuditId,
+            OccurredAtUtc = record.OccurredAtUtc.ToUniversalTime().ToString("O"),
+            record.WorkflowId,
+            record.FundAccountId,
+            record.PeriodId,
+            record.EventType,
+            record.FromState,
+            record.ToState,
+            record.Gate,
+            record.FromGateStatus,
+            record.ToGateStatus,
+            record.Actor,
+            record.Rationale,
+            record.TraceId,
+            record.RequestId,
+            record.SessionId,
+            record.RunId,
+            record.BrokerReferenceId,
+            record.SecurityReferenceId,
+            record.LedgerReferenceId,
+            record.ReconciliationReferenceId,
+            record.EvidenceReferenceId,
+            record.AuditReferenceId,
+            record.Severity,
+            Tags = record.Tags.OrderBy(static tag => tag, StringComparer.Ordinal).ToArray()
+        });
+
+        var bytes = Encoding.UTF8.GetBytes($"{canonicalPayload}|{previousHash ?? string.Empty}");
+        return Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+    }
+}

--- a/src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.WorkflowAudit.cs
+++ b/src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.WorkflowAudit.cs
@@ -1,13 +1,13 @@
 using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Meridian.Contracts.DirectLending;
 
 namespace Meridian.Storage.DirectLending;
 
 public sealed partial class PostgresDirectLendingStateStore
 {
-    public async Task<OperationsWorkflowAuditRecord> AppendOperationsWorkflowAuditAsync(OperationsWorkflowAuditRecord record, CancellationToken ct = default)
+    public async Task<OperationsWorkflowAuditRecord> AppendOperationsWorkflowAuditAsync(OperationsWorkflowAuditAppendRequest request, CancellationToken ct = default)
     {
         await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
         await using var transaction = await connection.BeginTransactionAsync(ct).ConfigureAwait(false);
@@ -21,14 +21,14 @@ public sealed partial class PostgresDirectLendingStateStore
                 select hash
                 from {Qualified("operations_workflow_audit")}
                 where workflow_id = @workflow_id
-                order by occurred_at_utc desc, audit_id desc
+                order by created_at desc, audit_id desc
                 limit 1;
                 """;
-            previous.Parameters.AddWithValue("workflow_id", record.WorkflowId);
+            previous.Parameters.AddWithValue("workflow_id", request.WorkflowId);
             previousHash = (string?)await previous.ExecuteScalarAsync(ct).ConfigureAwait(false);
         }
 
-        var computedHash = ComputeOperationsWorkflowAuditHash(record, previousHash);
+        var computedHash = ComputeOperationsWorkflowAuditHash(request, previousHash);
 
         await using (var insert = connection.CreateCommand())
         {
@@ -48,38 +48,65 @@ public sealed partial class PostgresDirectLendingStateStore
                     @broker_reference_id, @security_reference_id, @ledger_reference_id, @reconciliation_reference_id, @evidence_reference_id, @audit_reference_id,
                     @hash, @previous_hash, @severity, @tags);
                 """;
-            insert.Parameters.AddWithValue("audit_id", record.AuditId);
-            insert.Parameters.AddWithValue("occurred_at_utc", record.OccurredAtUtc.UtcDateTime);
-            insert.Parameters.AddWithValue("workflow_id", record.WorkflowId);
-            insert.Parameters.AddWithValue("fund_account_id", record.FundAccountId);
-            insert.Parameters.AddWithValue("period_id", record.PeriodId);
-            insert.Parameters.AddWithValue("event_type", record.EventType);
-            insert.Parameters.AddWithValue("from_state", (object?)record.FromState ?? DBNull.Value);
-            insert.Parameters.AddWithValue("to_state", (object?)record.ToState ?? DBNull.Value);
-            insert.Parameters.AddWithValue("gate", (object?)record.Gate ?? DBNull.Value);
-            insert.Parameters.AddWithValue("from_gate_status", (object?)record.FromGateStatus ?? DBNull.Value);
-            insert.Parameters.AddWithValue("to_gate_status", (object?)record.ToGateStatus ?? DBNull.Value);
-            insert.Parameters.AddWithValue("actor", record.Actor);
-            insert.Parameters.AddWithValue("rationale", record.Rationale);
-            insert.Parameters.AddWithValue("trace_id", (object?)record.TraceId ?? DBNull.Value);
-            insert.Parameters.AddWithValue("request_id", (object?)record.RequestId ?? DBNull.Value);
-            insert.Parameters.AddWithValue("session_id", (object?)record.SessionId ?? DBNull.Value);
-            insert.Parameters.AddWithValue("run_id", (object?)record.RunId ?? DBNull.Value);
-            insert.Parameters.AddWithValue("broker_reference_id", (object?)record.BrokerReferenceId ?? DBNull.Value);
-            insert.Parameters.AddWithValue("security_reference_id", (object?)record.SecurityReferenceId ?? DBNull.Value);
-            insert.Parameters.AddWithValue("ledger_reference_id", (object?)record.LedgerReferenceId ?? DBNull.Value);
-            insert.Parameters.AddWithValue("reconciliation_reference_id", (object?)record.ReconciliationReferenceId ?? DBNull.Value);
-            insert.Parameters.AddWithValue("evidence_reference_id", (object?)record.EvidenceReferenceId ?? DBNull.Value);
-            insert.Parameters.AddWithValue("audit_reference_id", (object?)record.AuditReferenceId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("audit_id", request.AuditId);
+            insert.Parameters.AddWithValue("occurred_at_utc", request.OccurredAtUtc.UtcDateTime);
+            insert.Parameters.AddWithValue("workflow_id", request.WorkflowId);
+            insert.Parameters.AddWithValue("fund_account_id", request.FundAccountId);
+            insert.Parameters.AddWithValue("period_id", request.PeriodId);
+            insert.Parameters.AddWithValue("event_type", request.EventType);
+            insert.Parameters.AddWithValue("from_state", (object?)request.FromState ?? DBNull.Value);
+            insert.Parameters.AddWithValue("to_state", (object?)request.ToState ?? DBNull.Value);
+            insert.Parameters.AddWithValue("gate", (object?)request.Gate ?? DBNull.Value);
+            insert.Parameters.AddWithValue("from_gate_status", (object?)request.FromGateStatus ?? DBNull.Value);
+            insert.Parameters.AddWithValue("to_gate_status", (object?)request.ToGateStatus ?? DBNull.Value);
+            insert.Parameters.AddWithValue("actor", request.Actor);
+            insert.Parameters.AddWithValue("rationale", request.Rationale);
+            insert.Parameters.AddWithValue("trace_id", (object?)request.TraceId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("request_id", (object?)request.RequestId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("session_id", (object?)request.SessionId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("run_id", (object?)request.RunId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("broker_reference_id", (object?)request.BrokerReferenceId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("security_reference_id", (object?)request.SecurityReferenceId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("ledger_reference_id", (object?)request.LedgerReferenceId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("reconciliation_reference_id", (object?)request.ReconciliationReferenceId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("evidence_reference_id", (object?)request.EvidenceReferenceId ?? DBNull.Value);
+            insert.Parameters.AddWithValue("audit_reference_id", (object?)request.AuditReferenceId ?? DBNull.Value);
             insert.Parameters.AddWithValue("hash", computedHash);
             insert.Parameters.AddWithValue("previous_hash", (object?)previousHash ?? DBNull.Value);
-            insert.Parameters.AddWithValue("severity", record.Severity);
-            insert.Parameters.AddWithValue("tags", record.Tags.ToArray());
+            insert.Parameters.AddWithValue("severity", request.Severity);
+            insert.Parameters.AddWithValue("tags", request.Tags.ToArray());
             await insert.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
 
         await transaction.CommitAsync(ct).ConfigureAwait(false);
-        return record with { Hash = computedHash, PreviousHash = previousHash };
+        return new OperationsWorkflowAuditRecord(
+            request.AuditId,
+            request.OccurredAtUtc,
+            request.WorkflowId,
+            request.FundAccountId,
+            request.PeriodId,
+            request.EventType,
+            request.FromState,
+            request.ToState,
+            request.Gate,
+            request.FromGateStatus,
+            request.ToGateStatus,
+            request.Actor,
+            request.Rationale,
+            request.TraceId,
+            request.RequestId,
+            request.SessionId,
+            request.RunId,
+            request.BrokerReferenceId,
+            request.SecurityReferenceId,
+            request.LedgerReferenceId,
+            request.ReconciliationReferenceId,
+            request.EvidenceReferenceId,
+            request.AuditReferenceId,
+            computedHash,
+            previousHash,
+            request.Severity,
+            request.Tags);
     }
 
     public async Task<IReadOnlyList<OperationsWorkflowAuditRecord>> GetOperationsWorkflowAuditAsync(string workflowId, CancellationToken ct = default)
@@ -95,7 +122,7 @@ public sealed partial class PostgresDirectLendingStateStore
                    hash, previous_hash, severity, tags
             from {Qualified("operations_workflow_audit")}
             where workflow_id = @workflow_id
-            order by occurred_at_utc, audit_id;
+            order by created_at, audit_id;
             """;
         command.Parameters.AddWithValue("workflow_id", workflowId);
 
@@ -136,38 +163,71 @@ public sealed partial class PostgresDirectLendingStateStore
         return results;
     }
 
-    private static string ComputeOperationsWorkflowAuditHash(OperationsWorkflowAuditRecord record, string? previousHash)
+    private static string ComputeOperationsWorkflowAuditHash(OperationsWorkflowAuditAppendRequest request, string? previousHash)
     {
-        var canonicalPayload = JsonSerializer.Serialize(new
-        {
-            record.AuditId,
-            OccurredAtUtc = record.OccurredAtUtc.ToUniversalTime().ToString("O"),
-            record.WorkflowId,
-            record.FundAccountId,
-            record.PeriodId,
-            record.EventType,
-            record.FromState,
-            record.ToState,
-            record.Gate,
-            record.FromGateStatus,
-            record.ToGateStatus,
-            record.Actor,
-            record.Rationale,
-            record.TraceId,
-            record.RequestId,
-            record.SessionId,
-            record.RunId,
-            record.BrokerReferenceId,
-            record.SecurityReferenceId,
-            record.LedgerReferenceId,
-            record.ReconciliationReferenceId,
-            record.EvidenceReferenceId,
-            record.AuditReferenceId,
-            record.Severity,
-            Tags = record.Tags.OrderBy(static tag => tag, StringComparer.Ordinal).ToArray()
-        });
+        var canonicalPayload = new OperationsWorkflowAuditHashPayload(
+            request.AuditId,
+            request.OccurredAtUtc.ToUniversalTime().ToString("O"),
+            request.WorkflowId,
+            request.FundAccountId,
+            request.PeriodId,
+            request.EventType,
+            request.FromState,
+            request.ToState,
+            request.Gate,
+            request.FromGateStatus,
+            request.ToGateStatus,
+            request.Actor,
+            request.Rationale,
+            request.TraceId,
+            request.RequestId,
+            request.SessionId,
+            request.RunId,
+            request.BrokerReferenceId,
+            request.SecurityReferenceId,
+            request.LedgerReferenceId,
+            request.ReconciliationReferenceId,
+            request.EvidenceReferenceId,
+            request.AuditReferenceId,
+            request.Severity,
+            request.Tags.OrderBy(static tag => tag, StringComparer.Ordinal).ToArray(),
+            previousHash ?? string.Empty);
 
-        var bytes = Encoding.UTF8.GetBytes($"{canonicalPayload}|{previousHash ?? string.Empty}");
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(
+            canonicalPayload,
+            OperationsWorkflowAuditJsonContext.Default.OperationsWorkflowAuditHashPayload);
         return Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
     }
+
+    private sealed record OperationsWorkflowAuditHashPayload(
+        Guid AuditId,
+        string OccurredAtUtc,
+        string WorkflowId,
+        Guid FundAccountId,
+        string PeriodId,
+        string EventType,
+        string? FromState,
+        string? ToState,
+        string? Gate,
+        string? FromGateStatus,
+        string? ToGateStatus,
+        string Actor,
+        string Rationale,
+        string? TraceId,
+        string? RequestId,
+        string? SessionId,
+        string? RunId,
+        string? BrokerReferenceId,
+        string? SecurityReferenceId,
+        string? LedgerReferenceId,
+        string? ReconciliationReferenceId,
+        string? EvidenceReferenceId,
+        string? AuditReferenceId,
+        string Severity,
+        string[] Tags,
+        string PreviousHash);
+
+    [JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Serialization)]
+    [JsonSerializable(typeof(OperationsWorkflowAuditHashPayload))]
+    private sealed partial class OperationsWorkflowAuditJsonContext : JsonSerializerContext;
 }

--- a/src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.WorkflowAudit.cs
+++ b/src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.WorkflowAudit.cs
@@ -79,34 +79,7 @@ public sealed partial class PostgresDirectLendingStateStore
         }
 
         await transaction.CommitAsync(ct).ConfigureAwait(false);
-        return new OperationsWorkflowAuditRecord(
-            request.AuditId,
-            request.OccurredAtUtc,
-            request.WorkflowId,
-            request.FundAccountId,
-            request.PeriodId,
-            request.EventType,
-            request.FromState,
-            request.ToState,
-            request.Gate,
-            request.FromGateStatus,
-            request.ToGateStatus,
-            request.Actor,
-            request.Rationale,
-            request.TraceId,
-            request.RequestId,
-            request.SessionId,
-            request.RunId,
-            request.BrokerReferenceId,
-            request.SecurityReferenceId,
-            request.LedgerReferenceId,
-            request.ReconciliationReferenceId,
-            request.EvidenceReferenceId,
-            request.AuditReferenceId,
-            computedHash,
-            previousHash,
-            request.Severity,
-            request.Tags);
+        return CreateOperationsWorkflowAuditRecord(request, computedHash, previousHash);
     }
 
     public async Task<IReadOnlyList<OperationsWorkflowAuditRecord>> GetOperationsWorkflowAuditAsync(string workflowId, CancellationToken ct = default)
@@ -199,6 +172,39 @@ public sealed partial class PostgresDirectLendingStateStore
         return Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
     }
 
+    private static OperationsWorkflowAuditRecord CreateOperationsWorkflowAuditRecord(
+        OperationsWorkflowAuditAppendRequest request,
+        string hash,
+        string? previousHash) =>
+        new(
+            request.AuditId,
+            request.OccurredAtUtc,
+            request.WorkflowId,
+            request.FundAccountId,
+            request.PeriodId,
+            request.EventType,
+            request.FromState,
+            request.ToState,
+            request.Gate,
+            request.FromGateStatus,
+            request.ToGateStatus,
+            request.Actor,
+            request.Rationale,
+            request.TraceId,
+            request.RequestId,
+            request.SessionId,
+            request.RunId,
+            request.BrokerReferenceId,
+            request.SecurityReferenceId,
+            request.LedgerReferenceId,
+            request.ReconciliationReferenceId,
+            request.EvidenceReferenceId,
+            request.AuditReferenceId,
+            hash,
+            previousHash,
+            request.Severity,
+            request.Tags);
+
     private sealed record OperationsWorkflowAuditHashPayload(
         Guid AuditId,
         string OccurredAtUtc,
@@ -225,7 +231,7 @@ public sealed partial class PostgresDirectLendingStateStore
         string? AuditReferenceId,
         string Severity,
         string[] Tags,
-        string PreviousHash);
+        string ChainPreviousHash);
 
     [JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(OperationsWorkflowAuditHashPayload))]

--- a/tests/Meridian.DirectLending.Tests/DirectLendingPostgresIntegrationTests.cs
+++ b/tests/Meridian.DirectLending.Tests/DirectLendingPostgresIntegrationTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
 using Meridian.Contracts.DirectLending;
+using Meridian.Storage.DirectLending;
+using Npgsql;
 
 namespace Meridian.DirectLending.Tests;
 
@@ -52,6 +54,78 @@ public sealed class DirectLendingPostgresIntegrationTests
         rebuilt.Servicing.DrawdownLots.Should().ContainSingle();
     }
 
+    [DirectLendingDatabaseFact]
+    public async Task AppendOperationsWorkflowAuditAsync_ShouldReturnLinearHashChainedStream()
+    {
+        await using var db = await DirectLendingPostgresTestDatabase.CreateOrSkipAsync();
+        if (db is null)
+        {
+            return;
+        }
+
+        var workflowId = $"wf-{Guid.NewGuid():N}";
+        var fundAccountId = Guid.NewGuid();
+        var periodId = "2026-Q2";
+
+        await db.Store.AppendOperationsWorkflowAuditAsync(
+            BuildAuditAppendRequest(
+                workflowId,
+                fundAccountId,
+                periodId,
+                eventType: "state_transition",
+                fromState: "draft",
+                toState: "ready"));
+
+        await db.Store.AppendOperationsWorkflowAuditAsync(
+            BuildAuditAppendRequest(
+                workflowId,
+                fundAccountId,
+                periodId,
+                eventType: "gate_change",
+                gate: "readiness",
+                fromGateStatus: "pending",
+                toGateStatus: "blocked"));
+
+        await db.Store.AppendOperationsWorkflowAuditAsync(
+            BuildAuditAppendRequest(
+                workflowId,
+                fundAccountId,
+                periodId,
+                eventType: "approval_action",
+                fromState: "ready",
+                toState: "approved"));
+
+        var stream = await db.Store.GetOperationsWorkflowAuditAsync(workflowId);
+
+        stream.Should().HaveCount(3);
+        stream[0].PreviousHash.Should().BeNull();
+        stream[0].Hash.Should().NotBeNullOrWhiteSpace();
+        stream[1].PreviousHash.Should().Be(stream[0].Hash);
+        stream[2].PreviousHash.Should().Be(stream[1].Hash);
+        stream.Select(static entry => entry.Hash).Should().OnlyHaveUniqueItems();
+    }
+
+    [DirectLendingDatabaseFact]
+    public async Task AppendOperationsWorkflowAuditAsync_ShouldRejectUnsupportedEventType()
+    {
+        await using var db = await DirectLendingPostgresTestDatabase.CreateOrSkipAsync();
+        if (db is null)
+        {
+            return;
+        }
+
+        var act = async () =>
+            await db.Store.AppendOperationsWorkflowAuditAsync(
+                BuildAuditAppendRequest(
+                    workflowId: $"wf-{Guid.NewGuid():N}",
+                    fundAccountId: Guid.NewGuid(),
+                    periodId: "2026-Q2",
+                    eventType: "unknown_event"));
+
+        var exception = await act.Should().ThrowAsync<PostgresException>();
+        exception.Which.SqlState.Should().Be(PostgresErrorCodes.CheckViolation);
+    }
+
     private static CreateLoanRequest BuildCreateRequest() =>
         new(
             LoanId: Guid.NewGuid(),
@@ -76,4 +150,41 @@ public sealed class DirectLendingPostgresIntegrationTests
                 DefaultRateSpreadBps: 200m,
                 PrepaymentAllowed: true,
                 CovenantsJson: "{\"leverage\": \"<= 4.5x\"}"));
+
+    private static OperationsWorkflowAuditAppendRequest BuildAuditAppendRequest(
+        string workflowId,
+        Guid fundAccountId,
+        string periodId,
+        string eventType,
+        string? fromState = null,
+        string? toState = null,
+        string? gate = null,
+        string? fromGateStatus = null,
+        string? toGateStatus = null) =>
+        new(
+            AuditId: Guid.NewGuid(),
+            OccurredAtUtc: DateTimeOffset.UtcNow,
+            WorkflowId: workflowId,
+            FundAccountId: fundAccountId,
+            PeriodId: periodId,
+            EventType: eventType,
+            FromState: fromState,
+            ToState: toState,
+            Gate: gate,
+            FromGateStatus: fromGateStatus,
+            ToGateStatus: toGateStatus,
+            Actor: "integration-test",
+            Rationale: "workflow audit verification",
+            TraceId: null,
+            RequestId: null,
+            SessionId: null,
+            RunId: null,
+            BrokerReferenceId: null,
+            SecurityReferenceId: null,
+            LedgerReferenceId: null,
+            ReconciliationReferenceId: null,
+            EvidenceReferenceId: null,
+            AuditReferenceId: null,
+            Severity: "info",
+            Tags: ["integration", "audit"]);
 }

--- a/tests/Meridian.DirectLending.Tests/DirectLendingPostgresIntegrationTests.cs
+++ b/tests/Meridian.DirectLending.Tests/DirectLendingPostgresIntegrationTests.cs
@@ -8,6 +8,8 @@ namespace Meridian.DirectLending.Tests;
 [Trait("Category", "Integration")]
 public sealed class DirectLendingPostgresIntegrationTests
 {
+    private const string WorkflowIdPrefix = "wf-";
+
     [DirectLendingDatabaseFact]
     public async Task PostgresService_ShouldPersistSchemaVersionedHistoryAndSnapshots()
     {
@@ -63,7 +65,7 @@ public sealed class DirectLendingPostgresIntegrationTests
             return;
         }
 
-        var workflowId = $"wf-{Guid.NewGuid():N}";
+        var workflowId = $"{WorkflowIdPrefix}{Guid.NewGuid():N}";
         var fundAccountId = Guid.NewGuid();
         var periodId = "2026-Q2";
 
@@ -103,6 +105,7 @@ public sealed class DirectLendingPostgresIntegrationTests
         stream[1].PreviousHash.Should().Be(stream[0].Hash);
         stream[2].PreviousHash.Should().Be(stream[1].Hash);
         stream.Select(static entry => entry.Hash).Should().OnlyHaveUniqueItems();
+        stream.Should().OnlyContain(static entry => IsValidSha256HexHash(entry.Hash));
     }
 
     [DirectLendingDatabaseFact]
@@ -117,7 +120,7 @@ public sealed class DirectLendingPostgresIntegrationTests
         var act = async () =>
             await db.Store.AppendOperationsWorkflowAuditAsync(
                 BuildAuditAppendRequest(
-                    workflowId: $"wf-{Guid.NewGuid():N}",
+                    workflowId: $"{WorkflowIdPrefix}{Guid.NewGuid():N}",
                     fundAccountId: Guid.NewGuid(),
                     periodId: "2026-Q2",
                     eventType: "unknown_event"));
@@ -187,4 +190,9 @@ public sealed class DirectLendingPostgresIntegrationTests
             AuditReferenceId: null,
             Severity: "info",
             Tags: ["integration", "audit"]);
+
+    private static bool IsValidSha256HexHash(string hash) =>
+        hash.Length == 64 &&
+        hash.All(static character =>
+            (character >= '0' && character <= '9') || (character >= 'a' && character <= 'f'));
 }

--- a/tests/Meridian.DirectLending.Tests/DirectLendingPostgresTestDatabase.cs
+++ b/tests/Meridian.DirectLending.Tests/DirectLendingPostgresTestDatabase.cs
@@ -1,7 +1,10 @@
 using Meridian.Application.DirectLending;
 using Meridian.Application.Ledger;
+using Meridian.Contracts.FundStructure;
 using Meridian.Contracts.DirectLending;
+using Meridian.Ledger;
 using Meridian.Storage.DirectLending;
+using Meridian.Storage.Ledger;
 using Npgsql;
 using Testcontainers.PostgreSql;
 
@@ -18,6 +21,7 @@ internal sealed class DirectLendingPostgresTestDatabase : IAsyncDisposable
 {
     private const string EnvVar = "MERIDIAN_DIRECT_LENDING_CONNECTION_STRING";
     private const string DisableDockerEnvVar = "MERIDIAN_DISABLE_DOCKER_TESTS";
+    private static readonly ILedgerJournalStore _noOpLedgerJournalStore = new InMemoryNoOpLedgerJournalStore();
 
     private readonly PostgreSqlContainer? _container;
 
@@ -41,7 +45,7 @@ internal sealed class DirectLendingPostgresTestDatabase : IAsyncDisposable
             Store,
             Store,
             QueryService,
-            new LoanAccountingProjector(journalStore: null, new AccountingPolicyService()),
+            new LoanAccountingProjector(_noOpLedgerJournalStore, new AccountingPolicyService()),
             Options);
         Service = new PostgresDirectLendingService(CommandService, QueryService);
     }
@@ -141,5 +145,47 @@ internal sealed class DirectLendingPostgresTestDatabase : IAsyncDisposable
             command.CommandText = $"drop schema if exists {Schema} cascade;";
             await command.ExecuteNonQueryAsync().ConfigureAwait(false);
         }
+    }
+
+    private sealed class InMemoryNoOpLedgerJournalStore : ILedgerJournalStore
+    {
+        public Task AppendAsync(LedgerJournalEntryWrite entry, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<IReadOnlyList<LedgerJournalEntryRecord>> GetByPeriodAsync(Guid periodId, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<LedgerJournalEntryRecord>>([]);
+
+        public Task<IReadOnlyList<LedgerJournalEntryRecord>> GetByAggregateAsync(Guid aggregateId, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<LedgerJournalEntryRecord>>([]);
+
+        public Task<LedgerAccountingPeriod?> GetPeriodAsync(Guid periodId, CancellationToken ct = default) =>
+            Task.FromResult<LedgerAccountingPeriod?>(null);
+
+        public Task<IReadOnlyList<LedgerAccountingPeriod>> ListPeriodsAsync(
+            Guid? ledgerBookId = null,
+            string? status = null,
+            string? fundProfileId = null,
+            Guid? fundStructureNodeId = null,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<LedgerAccountingPeriod>>([]);
+
+        public Task<LedgerAccountingPeriod> SavePeriodAsync(
+            LedgerAccountingPeriod period,
+            long expectedVersion,
+            PeriodCloseEventRecord? closeEvent = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(period);
+
+        public Task<LedgerBookRecord?> GetLedgerBookAsync(Guid ledgerBookId, CancellationToken ct = default) =>
+            Task.FromResult<LedgerBookRecord?>(null);
+
+        public Task<IReadOnlyList<LedgerBookRecord>> ListLedgerBooksAsync(
+            string? fundProfileId = null,
+            Guid? fundStructureNodeId = null,
+            FundStructureNodeKindDto? fundStructureNodeKind = null,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<LedgerBookRecord>>([]);
+
+        public Task<LedgerBookRecord> SaveLedgerBookAsync(LedgerBookRecord book, CancellationToken ct = default) =>
+            Task.FromResult(book);
     }
 }

--- a/tests/Meridian.DirectLending.Tests/DirectLendingPostgresTestDatabase.cs
+++ b/tests/Meridian.DirectLending.Tests/DirectLendingPostgresTestDatabase.cs
@@ -1,4 +1,5 @@
 using Meridian.Application.DirectLending;
+using Meridian.Application.Ledger;
 using Meridian.Contracts.DirectLending;
 using Meridian.Storage.DirectLending;
 using Npgsql;
@@ -36,7 +37,12 @@ internal sealed class DirectLendingPostgresTestDatabase : IAsyncDisposable
         Store = new PostgresDirectLendingStateStore(Options);
         Rebuilder = new DirectLendingEventRebuilder();
         QueryService = new PostgresDirectLendingQueryService(Store, Store, Rebuilder);
-        CommandService = new PostgresDirectLendingCommandService(Store, Store, QueryService, Options);
+        CommandService = new PostgresDirectLendingCommandService(
+            Store,
+            Store,
+            QueryService,
+            new LoanAccountingProjector(journalStore: null, new AccountingPolicyService()),
+            Options);
         Service = new PostgresDirectLendingService(CommandService, QueryService);
     }
 


### PR DESCRIPTION
### Motivation

- Provide an append-only, tamper-evident audit trail for operations/workflow events aligned with existing audit/event-store conventions and domain reference requirements. 
- Ensure each workflow stream is hash-chained so consumers can detect tampering and reconstruct provenance across state/gate/approval/ledger/break actions.

### Description

- Added a new persistence migration `src/Meridian.Storage/DirectLending/Migrations/006_direct_lending_operations_workflow_audit.sql` that creates the `operations_workflow_audit` table with the required fields, a check constraint for allowed `event_type` categories, a stream index and a unique `(workflow_id, hash)` index. 
- Introduced a strongly-typed append-only model `OperationsWorkflowAuditRecord` and new store methods `AppendOperationsWorkflowAuditAsync` and `GetOperationsWorkflowAuditAsync` on the storage contract in `src/Meridian.Storage/DirectLending/IDirectLendingOperationsStore.cs`. 
- Implemented the Postgres writer/reader in `src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.WorkflowAudit.cs` that: fetches the latest `hash` for the workflow stream, computes the current SHA-256 `hash` from a canonical JSON payload plus `previousHash` (tags are sorted for canonicalization), and inserts the new immutable row with both `hash` and `previous_hash`; the reader reconstructs ordered stream history. 
- Kept repository surface append-only (no update/delete methods added) so audit rows are immutable from the store/service API perspective.

### Testing

- Attempted a focused build with `dotnet build src/Meridian.Storage/Meridian.Storage.csproj -v minimal`, which could not run in this environment because `dotnet` is not installed and the build failed with `/bin/bash: line 1: dotnet: command not found`.
- No unit/integration test runs were executed in this container; validation is limited to static code additions and a committed migration + store implementation ready for CI run in an environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cd19b83f88320980b155fe966c8bf)