### PR TITLE
Fix Security Master gate bypass from caller-supplied zero issue counts

### DIFF
--- a/src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflow.cs
+++ b/src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflow.cs
@@ -1162,18 +1162,8 @@ public sealed class OperationsContinuityWorkflow
             return;
         }
 
-        if (SecurityMasterGate.Status == OperationsGateStatusDto.Blocked &&
-            SecurityMasterGate.Blockers.Any(static blocker =>
-                blocker.Code is "SM_RECON_SECURITY_UNRESOLVED" or "SM_ACCOUNTING_TERMS_INCOMPLETE"))
-        {
-            SecurityMasterState = OperationsSecurityMasterStateDto.Complete;
-            SecurityMasterGate = SecurityMasterGate.WithStatus(
-                OperationsGateStatusDto.Passed,
-                blockers: [],
-                nextActions: [],
-                completedAtUtc: now,
-                completedBy: actor);
-        }
+        // A zero-count signal from posture/reconciliation requests is caller-supplied metadata.
+        // Do not auto-pass/clear Security Master based only on those request values.
     }
 
     private static List<OperationsWorkflowBlockerDto> BuildSecurityMasterBlockers(

--- a/tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs
@@ -661,6 +661,12 @@ public sealed class OperationsContinuityWorkflowServiceTests
             BreakCases: [],
             SecurityAccountingIssueCount: 1));
         initiallyBlocked.Success.Should().BeTrue();
+        initiallyBlocked.Workflow!.Status.Should().Be(OperationsWorkflowStatusDto.Blocked);
+        initiallyBlocked.Workflow.Gates.Single(gate => gate.GateKey == OperationsGateKeyDto.SecurityMaster)
+            .Status.Should().Be(OperationsGateStatusDto.Blocked);
+        initiallyBlocked.Workflow.Blockers.Should().ContainSingle(blocker =>
+            blocker.Code == "SM_ACCOUNTING_TERMS_INCOMPLETE" &&
+            blocker.Gate == OperationsGateKeyDto.SecurityMaster);
 
         var stillBlocked = await service.RunReconciliationAsync(workflow.WorkflowId, new OperationsReconciliationRunRequestDto(
             initiallyBlocked.Workflow!.Version,

--- a/tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs
@@ -649,6 +649,36 @@ public sealed class OperationsContinuityWorkflowServiceTests
     }
 
     [Fact]
+    public async Task RunReconciliationAsync_ZeroSecurityIssueCounts_ShouldNotAutoPassSecurityMasterGate()
+    {
+        var service = CreateService(out _, out _);
+        var workflow = await CreateLedgerPostedWorkflowAsync(service);
+
+        var initiallyBlocked = await service.RunReconciliationAsync(workflow.WorkflowId, new OperationsReconciliationRunRequestDto(
+            workflow.Version,
+            "ops-user",
+            "Ran reconciliation with security-accounting issues",
+            BreakCases: [],
+            SecurityAccountingIssueCount: 1));
+        initiallyBlocked.Success.Should().BeTrue();
+
+        var stillBlocked = await service.RunReconciliationAsync(workflow.WorkflowId, new OperationsReconciliationRunRequestDto(
+            initiallyBlocked.Workflow!.Version,
+            "ops-user",
+            "Attempt to clear Security Master gate with caller-supplied zero counts",
+            BreakCases: [],
+            SecurityCoverageIssueCount: 0,
+            SecurityAccountingIssueCount: 0));
+
+        stillBlocked.Success.Should().BeTrue();
+        stillBlocked.Workflow!.Gates.Single(gate => gate.GateKey == OperationsGateKeyDto.SecurityMaster)
+            .Status.Should().Be(OperationsGateStatusDto.Blocked);
+        stillBlocked.Workflow.Blockers.Should().Contain(blocker =>
+            blocker.Code == "SM_ACCOUNTING_TERMS_INCOMPLETE" &&
+            blocker.Gate == OperationsGateKeyDto.SecurityMaster);
+    }
+
+    [Fact]
     public async Task ApproveWorkflowAsync_ShouldRequireApprovalMetadata()
     {
         var service = CreateService(out _, out _);


### PR DESCRIPTION
### Motivation
- A recent change allowed clients to pass `SecurityCoverageIssueCount=0` and `SecurityAccountingIssueCount=0` in posture/reconciliation requests and thereby clear the Security Master gate without server-side verification, which can bypass governance checks.
- The intent of this change is to stop treating caller-supplied zero counts as authoritative evidence that clears existing Security Master blockers.

### Description
- Removed the zero-count auto-pass/clear branch from `ApplySecurityMasterIssuePosture` in `src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflow.cs` so caller-supplied zero values no longer change `SecurityMasterGate` to `Passed`.
- Kept the existing behavior that adds blockers when positive issue counts are provided, preserving current blocking semantics for real issues.
- Added a regression test `RunReconciliationAsync_ZeroSecurityIssueCounts_ShouldNotAutoPassSecurityMasterGate` in `tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs` which reproduces the bypass attempt and asserts the Security Master gate remains blocked.

### Testing
- A targeted unit test was added: `RunReconciliationAsync_ZeroSecurityIssueCounts_ShouldNotAutoPassSecurityMasterGate` to validate the regression behavior and it is included with the test suite.
- I attempted to run the focused tests with `dotnet test --filter` but the environment lacks the .NET SDK so the tests could not be executed here (`dotnet: command not found`).
- Static review and a source-level reproduction confirmed the removed branch prevents an authenticated caller from clearing the Security Master gate by posting explicit zero counts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7179f0608320909d21fe649b1c89)