### PR TITLE
Gate position-action order placement with broker routing validation

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
@@ -701,6 +701,7 @@ public static class ExecutionEndpoints
         .WithName("ClosePositionByKey")
         .Produces<TradingActionResult>(200)
         .Produces<TradingActionResult>(400)
+        .Produces(403)
         .Produces(503);
 
         group.MapPost("/positions/actions/upsize", async (ExecutionPositionActionRequest request, HttpContext context) =>
@@ -744,6 +745,7 @@ public static class ExecutionEndpoints
         .WithName("UpsizePositionByKey")
         .Produces<TradingActionResult>(200)
         .Produces<TradingActionResult>(400)
+        .Produces(403)
         .Produces(503);
 
         group.MapPost("/positions/{symbol}/close", async (string symbol, HttpContext context) =>
@@ -894,11 +896,28 @@ public static class ExecutionEndpoints
 
         if (!TryValidateBrokerOrderPlacementGate(context, out var blockingMessage))
         {
+            var actionId = GenerateActionId();
+            var message = blockingMessage ?? "Broker order routing is disabled by validation gates.";
+            var auditEntry = await RecordOperatorAuditAsync(
+                context,
+                actionId,
+                action: actionName,
+                outcome: "Rejected",
+                message: message,
+                symbol: position.Symbol,
+                metadata: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["positionKey"] = position.PositionKey,
+                    ["reason"] = "GateBlocked",
+                    ["source"] = positionSource
+                }).ConfigureAwait(false);
+
             var blocked = new TradingActionResult(
-                ActionId: GenerateActionId(),
+                ActionId: actionId,
                 Status: "Rejected",
-                Message: blockingMessage ?? "Broker order routing is disabled by validation gates.",
-                OccurredAt: DateTimeOffset.UtcNow);
+                Message: message,
+                OccurredAt: DateTimeOffset.UtcNow,
+                AuditId: auditEntry?.AuditId);
             return Results.Json(blocked, jsonOptions, statusCode: StatusCodes.Status403Forbidden);
         }
 

--- a/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
@@ -892,6 +892,16 @@ public static class ExecutionEndpoints
             return Results.Problem("Order management system is not active.", statusCode: StatusCodes.Status503ServiceUnavailable);
         }
 
+        if (!TryValidateBrokerOrderPlacementGate(context, out var blockingMessage))
+        {
+            var blocked = new TradingActionResult(
+                ActionId: GenerateActionId(),
+                Status: "Rejected",
+                Message: blockingMessage ?? "Broker order routing is disabled by validation gates.",
+                OccurredAt: DateTimeOffset.UtcNow);
+            return Results.Json(blocked, jsonOptions, statusCode: StatusCodes.Status403Forbidden);
+        }
+
         var logger = GetLogger(context.RequestServices);
         var actionId = GenerateActionId();
         var actor = ResolveActor(context);

--- a/tests/Meridian.Tests/Ui/ExecutionWriteEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/ExecutionWriteEndpointsTests.cs
@@ -324,6 +324,36 @@ public sealed class ExecutionWriteEndpointsTests
     }
 
     [Fact]
+    public async Task ClosePositionAction_WhenProductionRoutingDisabled_Returns403AndDoesNotSubmit()
+    {
+        var gateway = new RecordingBrokerageGateway(CreateRobinhoodOptionPosition("opt-close"));
+        await using var app = await CreateAppAsync(services =>
+        {
+            RegisterBrokerageOms(services, gateway);
+            services.AddSingleton(new BrokerageConfiguration
+            {
+                Gateway = "robinhood",
+                BrokerFlows = new Dictionary<string, BrokerFlowFlags>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["robinhood"] = new() { ProductionOrderRoutingEnabled = false }
+                }
+            });
+        });
+
+        var client = app.GetTestClient();
+        var response = await client.PostAsync(
+            UiApiRoutes.ExecutionPositionActionClose,
+            JsonContent(new ExecutionPositionActionRequest("opt-close", Quantity: 1m)));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var result = await ReadActionResultAsync(response);
+        result.Status.Should().Be("Rejected");
+        result.Message.Should().Contain("Production order routing is disabled");
+        gateway.SubmittedRequests.Should().BeEmpty();
+    }
+
+
+    [Fact]
     public async Task PaperSessionLifecycleEndpoints_PreserveSymbolsAndExposeReplayContinuityAudit()
     {
         using var artifacts = TestArtifactDirectory.Create(nameof(PaperSessionLifecycleEndpoints_PreserveSymbolsAndExposeReplayContinuityAudit));


### PR DESCRIPTION
### Motivation
- A broker-routing/validation gate was added to the direct order submit endpoint but position-action endpoints could still construct and send market orders via the OMS without the gate, allowing a bypass of production-routing and signoff artifact controls.
- The change centralizes the gate check on the shared position-action path so all position-based order placements observe the same broker flow and artifact validation semantics as `POST /orders/submit`.

### Description
- Enforced `TryValidateBrokerOrderPlacementGate(context, out var blockingMessage)` in `SubmitPositionActionAsync(...)` before constructing and calling `oms.PlaceOrderAsync(...)`, returning a `403` `TradingActionResult` when the gate blocks the action.
- Preserved existing accepted-action behavior and metadata merging so valid position actions continue to submit orders unchanged when the gate passes.
- Added a regression test `ClosePositionAction_WhenProductionRoutingDisabled_Returns403AndDoesNotSubmit` to `tests/Meridian.Tests/Ui/ExecutionWriteEndpointsTests.cs` that verifies `POST /api/execution/positions/actions/close` is blocked when production routing is disabled and that the gateway receives no submitted requests.
- Modified files: `src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs` and `tests/Meridian.Tests/Ui/ExecutionWriteEndpointsTests.cs`.

### Testing
- Added a focused unit test `ClosePositionAction_WhenProductionRoutingDisabled_Returns403AndDoesNotSubmit` that exercises the gated position-close flow and asserts no gateway submissions occur.
- Attempted to run a targeted test filter via `dotnet test ...`, but automated execution was not possible in this environment because `dotnet` is not available (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cf3a2977c83209d7087e608618790)