### PR TITLE
Add continuity DTO contract assertions for web and retained WPF

### DIFF
--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -210,6 +210,66 @@ public sealed class WorkstationEndpointsTests
     }
 
     [Fact]
+    public async Task MapWorkstationEndpoints_OperationsContinuityDetail_ShouldExposeExplicitContinuityContractFields()
+    {
+        await using var app = await CreateAppAsync(RegisterOperationsContinuityServices);
+        var client = app.GetTestClient();
+        var fundAccountId = Guid.NewGuid();
+        var evidence = new OperationsEvidenceLinkDto(
+            EvidenceId: "ev-close-checklist",
+            Label: "Close Checklist",
+            Route: "/api/workstation/reporting/close-checklist/ev-close-checklist",
+            Source: "ops-runbook",
+            CapturedAtUtc: new DateTimeOffset(2026, 5, 20, 9, 30, 0, TimeSpan.Zero));
+
+        var start = await PostTransitionAsync(client, "/api/workstation/operations/continuity", new OperationsStartWorkflowRequestDto(
+            fundAccountId,
+            "2026-05",
+            Guid.NewGuid(),
+            "custodian",
+            "spoofed-user",
+            EvidenceLinks: [evidence]));
+        var workflowId = start.Workflow!.WorkflowId;
+
+        var import = await PostTransitionAsync(client, $"/api/workstation/operations/continuity/{workflowId}/broker/import",
+            new OperationsTransitionRequestDto(start.Workflow.Version, "spoofed-user", EvidenceLinks: [evidence]));
+        var normalized = await PostTransitionAsync(client, $"/api/workstation/operations/continuity/{workflowId}/broker/normalize",
+            new OperationsTransitionRequestDto(import.Workflow!.Version, "spoofed-user", EvidenceLinks: [evidence]));
+        var security = await PostTransitionAsync(client, $"/api/workstation/operations/continuity/{workflowId}/security-master/resolve",
+            new OperationsSecurityMasterResolveRequestDto(normalized.Workflow!.Version, "spoofed-user", EvidenceLinks: [evidence]));
+        var draft = await PostTransitionAsync(client, $"/api/workstation/operations/continuity/{workflowId}/ledger/draft",
+            new OperationsLedgerDraftRequestDto(security.Workflow!.Version, "spoofed-user", "ledger-preview-1", true, EvidenceLinks: [evidence]));
+        var validated = await PostTransitionAsync(client, $"/api/workstation/operations/continuity/{workflowId}/ledger/validate",
+            new OperationsLedgerValidationRequestDto(draft.Workflow!.Version, "spoofed-user", true, true, EvidenceLinks: [evidence]));
+        var posted = await PostTransitionAsync(client, $"/api/workstation/operations/continuity/{workflowId}/ledger/post",
+            new OperationsLedgerPostRequestDto(
+                validated.Workflow!.Version,
+                "spoofed-user",
+                "ledger-batch-1",
+                "period-close",
+                true,
+                EvidenceLinks: [evidence],
+                JournalCandidate: CreateOperationsLedgerJournalCandidate()));
+        var reconciled = await PostTransitionAsync(client, $"/api/workstation/operations/continuity/{workflowId}/reconciliation/run",
+            new OperationsReconciliationRunRequestDto(posted.Workflow!.Version, "spoofed-user", BreakCases: [], EvidenceLinks: [evidence]));
+        var posture = await PostTransitionAsync(client, $"/api/workstation/operations/continuity/{workflowId}/posture/refresh",
+            new OperationsGatePostureRequestDto(
+                reconciled.Workflow!.Version,
+                "spoofed-user",
+                ReportPackReady: false,
+                ReportPackId: "report-pack-2026-05",
+                EvidenceLinks: [evidence]));
+
+        posture.Workflow.Should().NotBeNull();
+        var workflow = posture.Workflow!;
+        workflow.EvidenceLinks.Should().NotBeEmpty();
+        workflow.ReportPackReadiness.ReportPackId.Should().Be("report-pack-2026-05");
+        workflow.ReportPackReadiness.IsReady.Should().BeFalse();
+        workflow.NextActions.Should().NotBeEmpty();
+        workflow.Blockers.Should().Contain(blocker => blocker.EvidenceLinks.Any());
+    }
+
+    [Fact]
     public async Task MapWorkstationEndpoints_OperationsContinuityRoutes_ShouldUseTrustedActorInsteadOfRequestActor()
     {
         await using var app = await CreateAppAsync(RegisterOperationsContinuityServices);

--- a/tests/Meridian.Wpf.Tests/Services/OperationsContinuityDtoContractTests.cs
+++ b/tests/Meridian.Wpf.Tests/Services/OperationsContinuityDtoContractTests.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Meridian.Contracts.Workstation;
+
+namespace Meridian.Wpf.Tests.Services;
+
+public sealed class OperationsContinuityDtoContractTests
+{
+    [Fact]
+    public void OperationsContinuityWorkflowDto_ShouldRoundTripSharedContractWithoutClientSideStatusDerivation()
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+        options.Converters.Add(new JsonStringEnumConverter());
+
+        var dto = new OperationsContinuityWorkflowDto(
+            WorkflowId: Guid.NewGuid(),
+            FundAccountId: Guid.NewGuid(),
+            PeriodId: "2026-05",
+            SecurityMasterSnapshotId: Guid.NewGuid(),
+            BrokerSource: "custodian",
+            CreatedAtUtc: new DateTimeOffset(2026, 5, 20, 9, 0, 0, TimeSpan.Zero),
+            UpdatedAtUtc: new DateTimeOffset(2026, 5, 20, 10, 0, 0, TimeSpan.Zero),
+            Version: 7,
+            Status: OperationsWorkflowStatusDto.ReconciliationActive,
+            BrokerIntakeState: OperationsBrokerIntakeStateDto.Complete,
+            SecurityMasterState: OperationsSecurityMasterStateDto.Complete,
+            LedgerPostingState: OperationsLedgerPostingStateDto.Complete,
+            ReconciliationState: OperationsReconciliationStateDto.InReview,
+            ApprovalState: OperationsApprovalStateDto.Pending,
+            Gates:
+            [
+                new OperationsGateDto(
+                    GateKey: OperationsGateKeyDto.Reconciliation,
+                    DisplayName: "Reconciliation",
+                    Status: OperationsGateStatusDto.ReviewRequired,
+                    IsRequired: true,
+                    Description: "Breaks require operator review.",
+                    Blockers:
+                    [
+                        new OperationsWorkflowBlockerDto(
+                            Code: "reconciliation-break",
+                            Message: "Open critical break must be resolved.",
+                            Gate: OperationsGateKeyDto.Reconciliation,
+                            Severity: "critical",
+                            EvidenceLinks:
+                            [
+                                new OperationsEvidenceLinkDto("ev-break-1", "Break packet", "/evidence/break-1", "reconciliation", DateTimeOffset.UtcNow)
+                            ])
+                    ],
+                    NextActions:
+                    [
+                        new OperationsNextActionDto("open-break", "Open Break Review", "/wpf/fund-reconciliation", OperationsGateKeyDto.Reconciliation)
+                    ],
+                    CompletedAtUtc: null,
+                    CompletedBy: null)
+            ],
+            Timeline: [],
+            BreakCases: [],
+            LedgerPreview: null,
+            Approvals: [],
+            ReportPackReadiness: new OperationsReportPackReadinessDto(
+                IsReady: false,
+                ReportPackId: "report-pack-2026-05",
+                BlockingReason: "Awaiting reconciliation sign-off.",
+                EvidenceLinks:
+                [
+                    new OperationsEvidenceLinkDto("ev-pack-1", "Draft report pack", "/evidence/report-pack", "reporting", DateTimeOffset.UtcNow)
+                ]),
+            EvidenceLinks:
+            [
+                new OperationsEvidenceLinkDto("ev-close-1", "Close checklist", "/evidence/close-checklist", "ops-runbook", DateTimeOffset.UtcNow)
+            ],
+            Blockers:
+            [
+                new OperationsWorkflowBlockerDto(
+                    Code: "report-pack-blocked",
+                    Message: "Report pack cannot be promoted.",
+                    Gate: OperationsGateKeyDto.Approval,
+                    Severity: "warning",
+                    EvidenceLinks:
+                    [
+                        new OperationsEvidenceLinkDto("ev-pack-1", "Draft report pack", "/evidence/report-pack", "reporting", DateTimeOffset.UtcNow)
+                    ])
+            ],
+            NextActions:
+            [
+                new OperationsNextActionDto(
+                    Code: "prepare-report-pack",
+                    Label: "Prepare Report Pack",
+                    Route: "/wpf/fund-report-pack",
+                    Gate: OperationsGateKeyDto.Approval)
+            ]);
+
+        var json = JsonSerializer.Serialize(dto, options);
+        var actual = JsonSerializer.Deserialize<OperationsContinuityWorkflowDto>(json, options);
+
+        actual.Should().NotBeNull();
+        actual!.Status.Should().Be(OperationsWorkflowStatusDto.ReconciliationActive);
+        actual.EvidenceLinks.Should().ContainSingle(link => link.EvidenceId == "ev-close-1");
+        actual.ReportPackReadiness.IsReady.Should().BeFalse();
+        actual.ReportPackReadiness.ReportPackId.Should().Be("report-pack-2026-05");
+        actual.Blockers.Should().ContainSingle(blocker => blocker.EvidenceLinks.Any(link => link.EvidenceId == "ev-pack-1"));
+        actual.NextActions.Should().ContainSingle(action => action.Code == "prepare-report-pack");
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure the operations continuity detail payload explicitly exposes evidence links, report-pack readiness posture, blocker→evidence linkage, and next actions so both web and retained WPF clients can consume identical semantics. 
- Provide guarded contract-level tests that assert the shared `Meridian.Contracts.Workstation` DTOs are stable and require no client-side status derivation.

### Description
- Added an endpoint contract test `MapWorkstationEndpoints_OperationsContinuityDetail_ShouldExposeExplicitContinuityContractFields` in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` that drives a workflow and asserts the returned continuity detail contains `EvidenceLinks`, `ReportPackReadiness` (id + readiness), `Blockers` with evidence links, and `NextActions`.
- Added a retained-WPF contract test `OperationsContinuityDtoContractTests` in `tests/Meridian.Wpf.Tests/Services/OperationsContinuityDtoContractTests.cs` that JSON round-trips an `OperationsContinuityWorkflowDto` (camelCase + enum-as-string) and asserts `Status`, `EvidenceLinks`, `ReportPackReadiness`, blocker evidence linkage, and `NextActions` are preserved.
- No service or DTO shape changes in production code were made; this change adds focused contract tests to validate current DTO semantics across runtimes.

### Testing
- Attempted to run the targeted endpoint test with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~MapWorkstationEndpoints_OperationsContinuityDetail_ShouldExposeExplicitContinuityContractFields"`, but the environment lacks the `dotnet` CLI so the test could not be executed (`/bin/bash: dotnet: command not found`).
- The new WPF-side JSON round-trip test is included but was not executed in this environment for the same `dotnet` limitation. 
- No automated test failures are reported because the CI/runtime test invocation was blocked by the missing `dotnet` tool in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e0dba2e288320bb9e0e5fce436b28)