### PR TITLE
Add operations continuity contract enums and deterministic status derivation checks

### DIFF
--- a/src/Meridian.Application/OperationsContinuity/OperationsStatusDerivationService.cs
+++ b/src/Meridian.Application/OperationsContinuity/OperationsStatusDerivationService.cs
@@ -13,6 +13,9 @@ public sealed class OperationsStatusDerivationService : IOperationsStatusDerivat
     {
         ArgumentNullException.ThrowIfNull(workflow);
 
+        // Invariant precedence order (highest to lowest):
+        // Blocked > Closed > ReadyForClose > ReviewRouting > HighestActiveStage > NotStarted.
+        // Keep this explicit ordering deterministic to prevent status drift when new gates/states are added.
         if (workflow.Gates.Any(static gate => gate.Status == OperationsGateStatusDto.Blocked))
         {
             return OperationsWorkflowStatusDto.Blocked;
@@ -31,11 +34,14 @@ public sealed class OperationsStatusDerivationService : IOperationsStatusDerivat
 
         if (workflow.Gates.Any(static gate => gate.Status == OperationsGateStatusDto.ReviewRequired))
         {
+            // Review-required routes to reconciliation when reconciliation itself needs review,
+            // otherwise approval is the active review lane.
             return workflow.ReconciliationGate.Status == OperationsGateStatusDto.ReviewRequired
                 ? OperationsWorkflowStatusDto.ReconciliationActive
                 : OperationsWorkflowStatusDto.ApprovalPending;
         }
 
+        // Highest active stage ordering (later stage wins): Approval > Reconciliation > Ledger > Security > Broker.
         if (workflow.BrokerIngestGate.Status == OperationsGateStatusDto.Passed &&
             workflow.SecurityMasterGate.Status == OperationsGateStatusDto.Passed &&
             workflow.LedgerPostingGate.Status == OperationsGateStatusDto.Passed &&

--- a/src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs
+++ b/src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs
@@ -97,6 +97,29 @@ public enum OperationsApprovalStateDto : byte
     Rejected = 4
 }
 
+
+[JsonConverter(typeof(JsonStringEnumConverter<OperationsIssueCodeDto>))]
+public enum OperationsIssueCodeDto : byte
+{
+    Unknown = 0,
+    WorkflowAlreadyExists = 1,
+    VersionMismatch = 2,
+    BrokerSourceMissing = 3,
+    BrokerImportFailed = 4,
+    SecurityCoverageMissing = 5,
+    SecurityAccountingClassificationMissing = 6,
+    LedgerPreviewUnavailable = 7,
+    LedgerDraftUnbalanced = 8,
+    LedgerPostingValidationFailed = 9,
+    ReconciliationBreaksOpen = 10,
+    ReconciliationCriticalBreaksOpen = 11,
+    ApprovalReviewerMissing = 12,
+    ApprovalRejected = 13,
+    ReportPackMissing = 14,
+    ReportPackNotReady = 15,
+    GovernanceApprovalRequired = 16
+}
+
 public sealed record OperationsStartWorkflowRequestDto(
     Guid FundAccountId,
     string PeriodId,
@@ -112,7 +135,8 @@ public sealed record OperationsTransitionRequestDto(
     string Actor,
     string? Rationale = null,
     string? CorrelationId = null,
-    IReadOnlyList<OperationsEvidenceLinkDto>? EvidenceLinks = null);
+    IReadOnlyList<OperationsEvidenceLinkDto>? EvidenceLinks = null,
+    IReadOnlyList<string>? EvidenceReferenceIds = null);
 
 public sealed record OperationsSecurityMasterOverrideApprovalRequestDto(
     long ExpectedVersion,
@@ -302,7 +326,8 @@ public sealed record OperationsTransitionResultDto(
     string? ErrorMessage,
     OperationsContinuityWorkflowDto? Workflow,
     IReadOnlyList<OperationsWorkflowBlockerDto> Blockers,
-    IReadOnlyList<OperationsNextActionDto> NextActions);
+    IReadOnlyList<OperationsNextActionDto> NextActions,
+    long? NewVersion = null);
 
 public sealed record OperationsContinuityWorkflowSummaryDto(
     Guid WorkflowId,
@@ -437,7 +462,8 @@ public sealed record OperationsWorkflowBlockerDto(
     string Message,
     OperationsGateKeyDto? Gate,
     string Severity,
-    IReadOnlyList<OperationsEvidenceLinkDto> EvidenceLinks);
+    IReadOnlyList<OperationsEvidenceLinkDto> EvidenceLinks,
+    OperationsIssueCodeDto? IssueCode = null);
 
 public sealed record OperationsNextActionDto(
     string Code,

--- a/tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentAssertions;
 using Meridian.Application.OperationsContinuity;
 using Meridian.Contracts.FundStructure;
@@ -140,6 +141,26 @@ public sealed class OperationsContinuityWorkflowServiceTests
         workflow.SetApprovalState(OperationsApprovalStateDto.Approved, DateTimeOffset.UtcNow);
 
         derivation.Derive(workflow).Should().Be(OperationsWorkflowStatusDto.ReadyForClose);
+    }
+
+
+    [Fact]
+    public void Derive_ShouldUseDeterministicHighestActiveStageOrdering()
+    {
+        var derivation = new OperationsStatusDerivationService();
+        var workflow = OperationsContinuityWorkflow.Start(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "2026-05",
+            null,
+            "custodian",
+            DateTimeOffset.UtcNow);
+
+        workflow.ReplaceGate(workflow.BrokerIngestGate.WithStatus(OperationsGateStatusDto.InProgress));
+        workflow.ReplaceGate(workflow.SecurityMasterGate.WithStatus(OperationsGateStatusDto.InProgress));
+        workflow.ReplaceGate(workflow.LedgerPostingGate.WithStatus(OperationsGateStatusDto.InProgress));
+
+        derivation.Derive(workflow).Should().Be(OperationsWorkflowStatusDto.LedgerPostingDraft);
     }
 
     [Fact]
@@ -1296,5 +1317,15 @@ public sealed class OperationsContinuityWorkflowServiceTests
 
         public Task<IReadOnlyList<OperationsWorkflowAuditDto>> GetTimelineAsync(Guid workflowId, CancellationToken ct = default)
             => _inner.GetTimelineAsync(workflowId, ct);
+    }
+
+    [Fact]
+    public void OperationsContractEnums_ShouldSerializeAsStableStrings()
+    {
+        JsonSerializer.Serialize(OperationsWorkflowStatusDto.Blocked).Should().Be("\"Blocked\"");
+        JsonSerializer.Serialize(OperationsGateStatusDto.ReviewRequired).Should().Be("\"ReviewRequired\"");
+        JsonSerializer.Serialize(OperationsGateKeyDto.Reconciliation).Should().Be("\"Reconciliation\"");
+        JsonSerializer.Serialize(OperationsIssueCodeDto.ReconciliationCriticalBreaksOpen)
+            .Should().Be("\"ReconciliationCriticalBreaksOpen\"");
     }
 }


### PR DESCRIPTION
## Summary
- extended `OperationsContinuityDtos` with additive workflow contract fields:
  - new canonical `OperationsIssueCodeDto` enum for blocker/issue code stability
  - `OperationsTransitionRequestDto.EvidenceReferenceIds` to carry evidence references alongside existing links
  - `OperationsTransitionResultDto.NewVersion` for explicit post-transition version signaling
  - `OperationsWorkflowBlockerDto.IssueCode` for canonical blocker classification
- documented and preserved deterministic precedence ordering in `OperationsStatusDerivationService`:
  - blocked gate precedence
  - all-passed + approved => ready-for-close
  - explicit review-required routing (`ReconciliationActive` vs `ApprovalPending`)
  - highest active stage ordering comments to reduce future drift
- expanded workflow service tests with:
  - deterministic highest-active-stage derivation assertion
  - stable enum string-serialization coverage for new canonical codes/status keys

## Notes
- changes are additive-only and preserve existing DTO fields/signatures.
- no runtime/test execution was performed in this pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e0f3f14808320abafd7ba66a8aa8e)