### PR TITLE
Add shared enum schema and enforce enum consistency in roadmap/source validators

### DIFF
--- a/docs/roadmap/schemas/roadmap-item.v1.schema.json
+++ b/docs/roadmap/schemas/roadmap-item.v1.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "roadmap-item.v1.schema.json",
+  "type": "object",
+  "required": ["id", "status", "health", "priority", "evidence_posture", "completion_term"],
+  "properties": {
+    "id": {"type": "string"},
+    "status": {"$ref": "shared-enums.v1.schema.json#/$defs/status"},
+    "health": {"$ref": "shared-enums.v1.schema.json#/$defs/health"},
+    "priority": {"$ref": "shared-enums.v1.schema.json#/$defs/priority"},
+    "evidence_posture": {"$ref": "shared-enums.v1.schema.json#/$defs/evidence_posture"},
+    "completion_term": {"$ref": "shared-enums.v1.schema.json#/$defs/completion_term"}
+  },
+  "additionalProperties": true
+}

--- a/docs/roadmap/schemas/shared-enums.v1.schema.json
+++ b/docs/roadmap/schemas/shared-enums.v1.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "shared-enums.v1.schema.json",
+  "title": "Canonical Shared Enums",
+  "type": "object",
+  "$defs": {
+    "status": {
+      "type": "string",
+      "enum": ["not_started", "in_progress", "blocked", "completed", "cancelled"]
+    },
+    "health": {
+      "type": "string",
+      "enum": ["green", "yellow", "red", "unknown"]
+    },
+    "priority": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"]
+    },
+    "evidence_posture": {
+      "type": "string",
+      "enum": ["none", "draft", "partial", "verified", "audited"]
+    },
+    "completion_term": {
+      "type": "string",
+      "enum": ["done", "complete", "completed", "closed", "shipped"]
+    }
+  }
+}

--- a/docs/source/schemas/shared-enums.v1.schema.json
+++ b/docs/source/schemas/shared-enums.v1.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "shared-enums.v1.schema.json",
+  "title": "Canonical Shared Enums",
+  "type": "object",
+  "$defs": {
+    "status": {
+      "type": "string",
+      "enum": ["not_started", "in_progress", "blocked", "completed", "cancelled"]
+    },
+    "health": {
+      "type": "string",
+      "enum": ["green", "yellow", "red", "unknown"]
+    },
+    "priority": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"]
+    },
+    "evidence_posture": {
+      "type": "string",
+      "enum": ["none", "draft", "partial", "verified", "audited"]
+    },
+    "completion_term": {
+      "type": "string",
+      "enum": ["done", "complete", "completed", "closed", "shipped"]
+    }
+  }
+}

--- a/docs/source/schemas/source-doc.v1.schema.json
+++ b/docs/source/schemas/source-doc.v1.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "source-doc.v1.schema.json",
+  "type": "object",
+  "required": ["name", "status", "health", "priority", "evidence_posture", "completion_term"],
+  "properties": {
+    "name": {"type": "string"},
+    "status": {"$ref": "shared-enums.v1.schema.json#/$defs/status"},
+    "health": {"$ref": "shared-enums.v1.schema.json#/$defs/health"},
+    "priority": {"$ref": "shared-enums.v1.schema.json#/$defs/priority"},
+    "evidence_posture": {"$ref": "shared-enums.v1.schema.json#/$defs/evidence_posture"},
+    "completion_term": {"$ref": "shared-enums.v1.schema.json#/$defs/completion_term"}
+  },
+  "additionalProperties": true
+}

--- a/tools/roadmap/fixtures/invalid-enums.json
+++ b/tools/roadmap/fixtures/invalid-enums.json
@@ -1,0 +1,1 @@
+{"status":"moving","health":"ok","priority":"urgent","evidence_posture":"proven","completion_term":"finished"}

--- a/tools/roadmap/fixtures/valid-enums.json
+++ b/tools/roadmap/fixtures/valid-enums.json
@@ -1,0 +1,1 @@
+{"status":"in_progress","health":"green","priority":"high","evidence_posture":"verified","completion_term":"done"}

--- a/tools/roadmap/validate_roadmap.py
+++ b/tools/roadmap/validate_roadmap.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+CANONICAL = {
+    "status": {"not_started", "in_progress", "blocked", "completed", "cancelled"},
+    "health": {"green", "yellow", "red", "unknown"},
+    "priority": {"low", "medium", "high", "critical"},
+    "evidence_posture": {"none", "draft", "partial", "verified", "audited"},
+    "completion_term": {"done", "complete", "completed", "closed", "shipped"},
+}
+
+
+def _check(node: Any, path: str = "$") -> list[str]:
+    errors: list[str] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            child_path = f"{path}.{key}"
+            if key in CANONICAL and value not in CANONICAL[key]:
+                allowed = ", ".join(sorted(CANONICAL[key]))
+                errors.append(f"{child_path}: invalid '{value}' for {key}; allowed: [{allowed}]")
+            errors.extend(_check(value, child_path))
+    elif isinstance(node, list):
+        for i, item in enumerate(node):
+            errors.extend(_check(item, f"{path}[{i}]"))
+    return errors
+
+
+def validate_file(path: Path) -> int:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    errors = _check(data)
+    if errors:
+        print(f"{path} failed enum validation:")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+    print(f"{path} passed enum validation")
+    return 0
+
+
+if __name__ == "__main__":
+    fixtures = Path(__file__).parent / "fixtures"
+    exit_code = 0
+    for json_file in sorted(fixtures.glob("*.json")):
+        rc = validate_file(json_file)
+        is_invalid_fixture = json_file.name.startswith("invalid-")
+        if is_invalid_fixture and rc == 0:
+            print(f"{json_file} expected failure but passed")
+            exit_code = 1
+        elif not is_invalid_fixture and rc != 0:
+            print(f"{json_file} expected pass but failed")
+            exit_code = 1
+        elif is_invalid_fixture and rc != 0:
+            print(f"{json_file} correctly failed")
+        else:
+            print(f"{json_file} correctly passed")
+    raise SystemExit(exit_code)

--- a/tools/source_docs/fixtures/invalid-enums.json
+++ b/tools/source_docs/fixtures/invalid-enums.json
@@ -1,0 +1,1 @@
+{"name":"Doc B","status":"done","health":"fine","priority":"p1","evidence_posture":"approved","completion_term":"wrapped"}

--- a/tools/source_docs/fixtures/valid-enums.json
+++ b/tools/source_docs/fixtures/valid-enums.json
@@ -1,0 +1,1 @@
+{"name":"Doc A","status":"completed","health":"yellow","priority":"medium","evidence_posture":"partial","completion_term":"closed"}

--- a/tools/source_docs/validate_source_readmes.py
+++ b/tools/source_docs/validate_source_readmes.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+CANONICAL = {
+    "status": {"not_started", "in_progress", "blocked", "completed", "cancelled"},
+    "health": {"green", "yellow", "red", "unknown"},
+    "priority": {"low", "medium", "high", "critical"},
+    "evidence_posture": {"none", "draft", "partial", "verified", "audited"},
+    "completion_term": {"done", "complete", "completed", "closed", "shipped"},
+}
+
+
+def _check(node: Any, path: str = "$") -> list[str]:
+    errors: list[str] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            child_path = f"{path}.{key}"
+            if key in CANONICAL and value not in CANONICAL[key]:
+                allowed = ", ".join(sorted(CANONICAL[key]))
+                errors.append(f"{child_path}: invalid '{value}' for {key}; allowed: [{allowed}]")
+            errors.extend(_check(value, child_path))
+    elif isinstance(node, list):
+        for i, item in enumerate(node):
+            errors.extend(_check(item, f"{path}[{i}]"))
+    return errors
+
+
+def validate_file(path: Path) -> int:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    errors = _check(data)
+    if errors:
+        print(f"{path} failed enum validation:")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+    print(f"{path} passed enum validation")
+    return 0
+
+
+if __name__ == "__main__":
+    fixtures = Path(__file__).parent / "fixtures"
+    exit_code = 0
+    for json_file in sorted(fixtures.glob("*.json")):
+        rc = validate_file(json_file)
+        is_invalid_fixture = json_file.name.startswith("invalid-")
+        if is_invalid_fixture and rc == 0:
+            print(f"{json_file} expected failure but passed")
+            exit_code = 1
+        elif not is_invalid_fixture and rc != 0:
+            print(f"{json_file} expected pass but failed")
+            exit_code = 1
+        elif is_invalid_fixture and rc != 0:
+            print(f"{json_file} correctly failed")
+        else:
+            print(f"{json_file} correctly passed")
+    raise SystemExit(exit_code)


### PR DESCRIPTION
### Motivation
- Reduce duplicated enum lists across roadmap and source-doc schemas by centralizing canonical enums for `status`, `health`, `priority`, `evidence_posture`, and completion terms. 
- Ensure documentation/schema consumers and tooling enforce the same allowed values to avoid silent divergence. 

### Description
- Added canonical shared enum schema files `docs/roadmap/schemas/shared-enums.v1.schema.json` and `docs/source/schemas/shared-enums.v1.schema.json`. 
- Updated domain schemas to reference the canonical defs via `$ref` (`docs/roadmap/schemas/roadmap-item.v1.schema.json` and `docs/source/schemas/source-doc.v1.schema.json`). 
- Implemented validator scripts that check enum consistency and report exact JSON field paths on mismatch (`tools/roadmap/validate_roadmap.py` and `tools/source_docs/validate_source_readmes.py`). 
- Added fixture cases for valid and invalid enum inputs under `tools/roadmap/fixtures/` and `tools/source_docs/fixtures/` so validators assert correct pass/fail behavior. 

### Testing
- Ran `python3 tools/roadmap/validate_roadmap.py` which verified the valid fixture passed and the invalid fixture failed with field-level diagnostics. 
- Ran `python3 tools/source_docs/validate_source_readmes.py` which verified the valid fixture passed and the invalid fixture failed with field-level diagnostics. 
- Validator output includes the exact JSON path for each invalid value (for example `$.status`, `$.health`, etc.) to make failures actionable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e2b68dc708320a7f6ba105c134d3e)