### PR TITLE
Add provider capability matrix and include it in status review docs

### DIFF
--- a/docs/plans/current-direction-and-status.md
+++ b/docs/plans/current-direction-and-status.md
@@ -98,6 +98,7 @@ These documents define current direction and should be read in this order:
 | --- | --- |
 | [`../status/ROADMAP.md`](../status/ROADMAP.md) | Authoritative roadmap narrative, wave order, and conservative completion claims. |
 | [`../status/PROGRAM_STATE.md`](../status/PROGRAM_STATE.md) | Canonical wave status table and target dates. |
+| [`../status/provider-capability-matrix.md`](../status/provider-capability-matrix.md) | Provider capability/state ownership matrix used in recurring status review; non-`complete` rows require both an owner and a target sprint. |
 | [`README.md`](README.md) | Active plan index and role classification for every plan file in `docs/plans/`. |
 | [`evidence-backed-investment-operations-plan.md`](evidence-backed-investment-operations-plan.md) | Product-category filter and archive rule for the evidence-backed investment-operations direction. |
 | [`meridian-6-week-roadmap.md`](meridian-6-week-roadmap.md) | Short-horizon execution slice for W2-W4 plus trust-gate maintenance. |

--- a/docs/status/FEATURE_INVENTORY.md
+++ b/docs/status/FEATURE_INVENTORY.md
@@ -108,7 +108,7 @@ Evidence-backed narrative, client-facing commentary drafting, and evidence-aware
 | **IB Simulation Client** | ✅ | `IBSimulationClient` for testing without live connection |
 | **NoOp Client** | ✅ | `NoOpMarketDataClient` for dry-run / test harness scenarios |
 
-Provider validation matrix and evidence guidance now live in `docs/status/provider-validation-matrix.md` and `docs/providers/provider-confidence-baseline.md`, with `scripts/dev/run-wave1-provider-validation.ps1` as the offline gate runner and `artifacts/provider-validation/` treated as generated run output rather than retained source.
+Provider validation matrix and evidence guidance now live in `docs/status/provider-validation-matrix.md` and `docs/providers/provider-confidence-baseline.md`, with `scripts/dev/run-wave1-provider-validation.ps1` as the offline gate runner and `artifacts/provider-validation/` treated as generated run output rather than retained source. Track implementation-state and ownership gaps in [`provider-capability-matrix.md`](provider-capability-matrix.md) during routine status reviews.
 
 ### Remaining work to reach full provider coverage
 

--- a/docs/status/provider-capability-matrix.md
+++ b/docs/status/provider-capability-matrix.md
@@ -1,0 +1,9 @@
+# Provider Capability Matrix
+
+## Matrix Governance
+
+All rows with `State` values other than `complete` must include both `Owner` and `Target Sprint` before they can be considered valid for status review.
+
+| Provider | Folder | State | Capabilities | Contract Status | Reliability Status | Test Coverage | Readiness Impact | Owner | Target Sprint | Blocking Dependencies | Next Action |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| _TBD_ | `src/Meridian.Providers/<provider>` | `planned` | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |


### PR DESCRIPTION
### Motivation

- Provide a dedicated, reviewable matrix for tracking provider implementation state, ownership, and next actions. 
- Enforce governance that every non-`complete` provider row has an `Owner` and `Target Sprint` to improve accountability. 
- Surface provider capability gaps during routine status reviews by linking the matrix from the canonical status/plans documents. 

### Description

- Add `docs/status/provider-capability-matrix.md` containing the required columns and a top-level “Matrix Governance” rule that non-`complete` rows must include `Owner` and `Target Sprint`. 
- Insert an initial placeholder row in the new matrix to seed entries for providers. 
- Update `docs/status/FEATURE_INVENTORY.md` to reference the new matrix as part of routine status review context. 
- Add the new matrix to the Active Planning Set in `docs/plans/current-direction-and-status.md` so it appears in normal planning and review workflows. 

### Testing

- Verified the new file exists and reviewed its contents using `nl -ba docs/status/provider-capability-matrix.md` and confirmed the governance text and table header are present. 
- Confirmed references were added to `docs/status/FEATURE_INVENTORY.md` and `docs/plans/current-direction-and-status.md` using `rg -n` and by printing the affected ranges with `nl -ba ... | sed -n`. 
- Ran `git status --short` to confirm the changes are staged in the working tree and all verification commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e2f87660c8320af38f32b93ad13d8)