### PR TITLE
Split Synthetic work into enablement baseline and template modernization; add harness parity gate

### DIFF
--- a/docs/plans/fund-management-product-vision-and-capability-matrix.md
+++ b/docs/plans/fund-management-product-vision-and-capability-matrix.md
@@ -269,12 +269,14 @@ These next steps keep the vision matrix aligned with the canonical Waves 2-4 pat
 
 ### Wave A: close Wave 2 cockpit acceptance evidence
 
+0. Complete **Synthetic enablement baseline** before provider Wave A completion claims: deterministic fixtures, replay utilities, and fault-injection hooks used by the acceptance harness.
 1. Keep DK1 provider-trust parity, explainability, calibration, and operator sign-off visible in the trading readiness lane.
 2. Prove paper-session create, restore, replay, audit/control, and promotion-review continuity through repo-backed operator scenarios.
 3. Keep WPF Trading, Trading Hours, OrderBook, Research, Data Operations, Provider Health, System Health triage, Notification Center filter recovery, Activity Log triage/export/clear support, Watchlist posture with pinned-first staging, and StrategyRuns recovery surfaces as consumers of shared readiness/calendar/depth/run/provider/diagnostics/history/log/symbol-state contracts, not separate acceptance models.
 
 **Exit criteria**
 
+- Deterministic harness readiness is complete and documented (fixtures + replay utilities + fault-injection hooks), and harness parity checks pass for the provider set targeted by Wave A.
 - `Backtest -> Paper` can be exercised as one auditable operator path.
 - Replay, signed DK1 trust posture, promotion checklist state, and operator work items are visible from the shared readiness contract and initial operator-inbox endpoint, with route-aware account-scoped WPF shell queue-button routing for the primary work item.
 - The WPF shell supports the workflow without introducing shell-local readiness semantics.
@@ -293,6 +295,7 @@ These next steps keep the vision matrix aligned with the canonical Waves 2-4 pat
 
 ### Wave C: productize governance and fund operations
 
+0. Finish **Synthetic template modernization** (post-baseline) so template evolution does not block Wave A provider completion.
 1. Extend the delivered file-backed reconciliation break queue and calibration-summary rollups into calibrated, durable casework.
 2. Turn governed report packs from generated artifacts into reviewed, approved, and publishable outputs with provenance.
 3. Connect account/entity, cash-flow, multi-ledger, reconciliation, and reporting views through the shared Fund Operations projection path, keeping Fund Accounts on shared account/provider-route/balance-history/shared-data evidence.
@@ -307,5 +310,6 @@ These next steps keep the vision matrix aligned with the canonical Waves 2-4 pat
 
 - Keep **contract-first sequencing**: merge shared DTO/read-model slices before dependent UI surfaces.
 - Treat **WPF + shared endpoint parity** as a release gate for each wave.
+- Treat **harness parity checks** as a hard gate before broad provider-wave rollout beyond Wave A pilot scope.
 - Maintain **evidence and auditability** by preserving replay/export/diagnostics support in every phase.
 - Run a **monthly roadmap reconciliation** between this matrix, the implementation backlog, the DK readiness dashboard, and the PR-sequenced roadmap to avoid phase drift.

--- a/docs/plans/wave-implementation-checklists.md
+++ b/docs/plans/wave-implementation-checklists.md
@@ -55,6 +55,11 @@ Use this together with:
 
 ### Completion Checklist
 
+- [ ] **Synthetic harness enablement baseline is complete before Wave A provider completion.**
+  - [ ] Deterministic fixtures are versioned and used by the acceptance harness.
+  - [ ] Replay utilities are available for repeatable restore/replay verification flows.
+  - [ ] Fault-injection hooks exist for provider-path resilience scenarios in the same harness lane.
+
 - [ ] **Trading readiness endpoint reports accurate state.**
   - [ ] Validate `GET /api/workstation/trading/readiness` for expected readiness fields.
   - [ ] Confirm the endpoint reflects current trust, replay, and promotion posture.
@@ -84,6 +89,11 @@ Use this together with:
   - [ ] Check `TrustedData`, `PaperPromotion`, and `PaperSession` gate states.
   - [ ] For any non-green gate, add explicit blocker text and owner.
   - [ ] Link blockers to concrete follow-up tasks and evidence expectations.
+
+- [ ] **Harness parity checks pass before broad provider wave rollout.**
+  - [ ] Run parity checks comparing deterministic harness outputs across the Wave A provider target set.
+  - [ ] Block broad rollout when parity mismatches are unresolved.
+  - [ ] Record parity evidence links and owners for any temporary exceptions.
 
 ---
 


### PR DESCRIPTION
### Motivation

- Split Synthetic work into two explicit phases so deterministic harness readiness is a prerequisite for Wave A provider completion and template modernization is deferred to Wave C.  
- Make deterministic fixtures, replay utilities, and fault-injection hooks first-class acceptance-harness requirements to improve repeatable provider validation.  
- Add a hard gate that requires harness parity checks before broad provider-wave rollout to prevent divergent provider behavior from propagating.

### Description

- Updated `docs/plans/fund-management-product-vision-and-capability-matrix.md` to require a **Synthetic enablement baseline** for Wave A, move **Synthetic template modernization** to Wave C, and add deterministic-harness exit criteria plus a cross-wave harness-parity guardrail.  
- Extended `docs/plans/wave-implementation-checklists.md` Wave 2 checklist with a dedicated Synthetic harness enablement baseline and a harness-parity rollout gate that blocks broad provider rollout until parity checks pass.  
- These are documentation-only changes (no production code modified) focused on planning, sequencing, and acceptance criteria.

### Testing

- No automated unit or integration tests were required because this is a docs-only change.  
- Repo-level validation was performed via `git status --short` and file inspection using `nl -ba`/`sed` to confirm the intended edits appear in `docs/plans/fund-management-product-vision-and-capability-matrix.md` and `docs/plans/wave-implementation-checklists.md`.  
- Changes were committed successfully as `2ef67028` and a PR draft was prepared via the `make_pr` helper.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e2f8f50b0832098c0500a06c76238)