### PR TITLE
Add canonical provider capability descriptors and metadata consistency tests

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/Core/ProviderCapabilityDescriptorCatalog.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/ProviderCapabilityDescriptorCatalog.cs
@@ -1,0 +1,63 @@
+using Meridian.Execution.Sdk;
+using Meridian.Infrastructure.Adapters.Alpaca;
+using Meridian.Infrastructure.Adapters.Polygon;
+using Meridian.Infrastructure.Adapters.Synthetic;
+using Meridian.Infrastructure.Adapters.YahooFinance;
+using Meridian.Infrastructure.Adapters.Finnhub;
+using Meridian.Infrastructure.Adapters.Tiingo;
+using Meridian.Infrastructure.Adapters.Stooq;
+using Meridian.Infrastructure.Adapters.AlphaVantage;
+using Meridian.Infrastructure.Adapters.Fred;
+using Meridian.Infrastructure.Adapters.NasdaqDataLink;
+using Meridian.Infrastructure.Adapters.InteractiveBrokers;
+
+namespace Meridian.Infrastructure.Adapters.Core;
+
+/// <summary>
+/// Canonical capability descriptors used to keep provider metadata, implemented interfaces,
+/// and registration paths aligned.
+/// </summary>
+public static class ProviderCapabilityDescriptorCatalog
+{
+    public static IReadOnlyList<ProviderCapabilityDescriptor> Descriptors { get; } =
+    [
+        new("alpaca", typeof(AlpacaMarketDataClient), typeof(AlpacaHistoricalDataProvider), typeof(AlpacaSymbolSearchProviderRefactored), typeof(AlpacaCorporateActionProvider), typeof(AlpacaOptionsChainProvider), typeof(AlpacaBrokerageGateway)),
+        new("synthetic", historical: typeof(SyntheticHistoricalDataProvider), search: typeof(SyntheticSymbolSearchProvider)),
+        new("ib", historical: typeof(IBHistoricalDataProvider)),
+        new("yahoo", historical: typeof(YahooFinanceHistoricalDataProvider)),
+        new("polygon", historical: typeof(PolygonHistoricalDataProvider), search: typeof(PolygonSymbolSearchProvider), corporateActions: typeof(PolygonCorporateActionProvider)),
+        new("tiingo", historical: typeof(TiingoHistoricalDataProvider)),
+        new("finnhub", historical: typeof(FinnhubHistoricalDataProvider), search: typeof(FinnhubSymbolSearchProvider)),
+        new("stooq", historical: typeof(StooqHistoricalDataProvider)),
+        new("alphavantage", historical: typeof(AlphaVantageHistoricalDataProvider)),
+        new("fred", historical: typeof(FredHistoricalDataProvider)),
+        new("nasdaq", historical: typeof(NasdaqDataLinkHistoricalDataProvider))
+    ];
+}
+
+public sealed record ProviderCapabilityDescriptor(
+    string ProviderId,
+    Type? Streaming = null,
+    Type? Historical = null,
+    Type? Search = null,
+    Type? CorporateActions = null,
+    Type? Options = null,
+    Type? Brokerage = null)
+{
+    public bool HasStreaming => Streaming is not null;
+    public bool HasHistorical => Historical is not null;
+    public bool HasSearch => Search is not null;
+    public bool HasCorporateActions => CorporateActions is not null;
+    public bool HasOptions => Options is not null;
+    public bool HasBrokerage => Brokerage is not null;
+
+    public IEnumerable<Type> Implementations()
+    {
+        if (Streaming is not null) yield return Streaming;
+        if (Historical is not null) yield return Historical;
+        if (Search is not null) yield return Search;
+        if (CorporateActions is not null) yield return CorporateActions;
+        if (Options is not null) yield return Options;
+        if (Brokerage is not null) yield return Brokerage;
+    }
+}

--- a/tests/Meridian.Tests/Providers/ProviderCapabilityDescriptorCatalogTests.cs
+++ b/tests/Meridian.Tests/Providers/ProviderCapabilityDescriptorCatalogTests.cs
@@ -1,0 +1,123 @@
+using Meridian.Execution.Sdk;
+using Meridian.Infrastructure;
+using Meridian.Infrastructure.Adapters.Core;
+using Meridian.ProviderSdk;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Tests.Providers;
+
+public sealed class ProviderCapabilityDescriptorCatalogTests
+{
+    [Fact]
+    public void Descriptors_match_implemented_interfaces()
+    {
+        foreach (var descriptor in ProviderCapabilityDescriptorCatalog.Descriptors)
+        {
+            if (descriptor.Streaming is not null)
+            {
+                descriptor.Streaming.Should().BeAssignableTo<IMarketDataClient>();
+            }
+
+            if (descriptor.Historical is not null)
+            {
+                descriptor.Historical.Should().BeAssignableTo<IHistoricalDataProvider>();
+            }
+
+            if (descriptor.Search is not null)
+            {
+                descriptor.Search.Should().BeAssignableTo<ISymbolSearchProvider>();
+            }
+
+            if (descriptor.CorporateActions is not null)
+            {
+                descriptor.CorporateActions.Should().BeAssignableTo<ICorporateActionProvider>();
+            }
+
+            if (descriptor.Options is not null)
+            {
+                descriptor.Options.Should().BeAssignableTo<IOptionsChainProvider>();
+            }
+
+            if (descriptor.Brokerage is not null)
+            {
+                descriptor.Brokerage.Should().BeAssignableTo<IBrokerageGateway>();
+            }
+        }
+    }
+
+    [Fact]
+    public void Descriptors_with_capabilities_are_resolvable_from_registration_paths()
+    {
+        var services = new ServiceCollection();
+        foreach (var descriptor in ProviderCapabilityDescriptorCatalog.Descriptors)
+        {
+            foreach (var implementation in descriptor.Implementations())
+            {
+                services.AddSingleton(implementation);
+            }
+        }
+
+        RegisterInterfacesFromDescriptors(services);
+        using var provider = services.BuildServiceProvider();
+
+        foreach (var descriptor in ProviderCapabilityDescriptorCatalog.Descriptors)
+        {
+            AssertResolvable(provider, descriptor.ProviderId, descriptor.Streaming, typeof(IMarketDataClient));
+            AssertResolvable(provider, descriptor.ProviderId, descriptor.Historical, typeof(IHistoricalDataProvider));
+            AssertResolvable(provider, descriptor.ProviderId, descriptor.Search, typeof(ISymbolSearchProvider));
+            AssertResolvable(provider, descriptor.ProviderId, descriptor.CorporateActions, typeof(ICorporateActionProvider));
+            AssertResolvable(provider, descriptor.ProviderId, descriptor.Options, typeof(IOptionsChainProvider));
+            AssertResolvable(provider, descriptor.ProviderId, descriptor.Brokerage, typeof(IBrokerageGateway));
+        }
+    }
+
+    private static void RegisterInterfacesFromDescriptors(IServiceCollection services)
+    {
+        foreach (var descriptor in ProviderCapabilityDescriptorCatalog.Descriptors)
+        {
+            if (descriptor.Streaming is not null)
+            {
+                services.AddSingleton(typeof(IMarketDataClient), sp => sp.GetRequiredService(descriptor.Streaming));
+            }
+
+            if (descriptor.Historical is not null)
+            {
+                services.AddSingleton(typeof(IHistoricalDataProvider), sp => sp.GetRequiredService(descriptor.Historical));
+            }
+
+            if (descriptor.Search is not null)
+            {
+                services.AddSingleton(typeof(ISymbolSearchProvider), sp => sp.GetRequiredService(descriptor.Search));
+            }
+
+            if (descriptor.CorporateActions is not null)
+            {
+                services.AddSingleton(typeof(ICorporateActionProvider), sp => sp.GetRequiredService(descriptor.CorporateActions));
+            }
+
+            if (descriptor.Options is not null)
+            {
+                services.AddSingleton(typeof(IOptionsChainProvider), sp => sp.GetRequiredService(descriptor.Options));
+            }
+
+            if (descriptor.Brokerage is not null)
+            {
+                services.AddSingleton(typeof(IBrokerageGateway), sp => sp.GetRequiredService(descriptor.Brokerage));
+            }
+        }
+    }
+
+    private static void AssertResolvable(IServiceProvider provider, string providerId, Type? implementation, Type contract)
+    {
+        if (implementation is null)
+        {
+            return;
+        }
+
+        var instances = provider.GetServices(contract).ToList();
+        instances.Should().NotBeEmpty($"provider '{providerId}' advertises {contract.Name}");
+        instances.Any(instance => implementation.IsInstanceOfType(instance))
+            .Should()
+            .BeTrue($"provider '{providerId}' should resolve {implementation.Name} via {contract.Name}");
+    }
+}


### PR DESCRIPTION
### Motivation
- Define a single, canonical capability descriptor per provider to keep advertised capabilities, implementation types, and DI registration paths aligned across streaming, historical, symbol-search, options, corporate-actions, and brokerage surfaces. 
- Catch metadata drift early by making capability claims (what a provider "supports") verifiable via automated tests. 

### Description
- Add `ProviderCapabilityDescriptorCatalog` in `src/Meridian.Infrastructure/Adapters/Core/ProviderCapabilityDescriptorCatalog.cs` containing a deterministic list of `ProviderCapabilityDescriptor` entries mapping provider IDs to concrete implementation `Type`s for each capability. 
- Introduce the `ProviderCapabilityDescriptor` record that exposes boolean capability helpers and an `Implementations()` enumerator. 
- Add tests in `tests/Meridian.Tests/Providers/ProviderCapabilityDescriptorCatalogTests.cs` that assert each declared implementation `Type` implements the expected contract interfaces (`IMarketDataClient`, `IHistoricalDataProvider`, `ISymbolSearchProvider`, `ICorporateActionProvider`, `IOptionsChainProvider`, `IBrokerageGateway`) and that advertised capability types are resolvable via DI registration paths. 

### Testing
- Added deterministic unit tests under `tests/Meridian.Tests/Providers/ProviderCapabilityDescriptorCatalogTests.cs` which perform interface-assignability and DI-resolution assertions and will fail when a descriptor advertises a capability that is not backed by a resolvable implementation. 
- Attempted to run `dotnet test` for the new test class (`--filter FullyQualifiedName~ProviderCapabilityDescriptorCatalogTests`) but the execution environment lacked the `dotnet` runtime (`/bin/bash: dotnet: command not found`), so tests were not executed here. 
- The test suite is deterministic and intended to run in CI or a developer environment with the .NET SDK installed via `dotnet test` against `tests/Meridian.Tests/Meridian.Tests.csproj`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e2f87a5a48320b4ea2498446a430d)