### PR TITLE
Standardize provider validation evidence artifacts and trust sign-off contract

### DIFF
--- a/docs/status/dk1-pilot-parity-runbook.md
+++ b/docs/status/dk1-pilot-parity-runbook.md
@@ -22,6 +22,7 @@ Provide a single reproducible runbook that proves DK1 pilot parity against the a
   - `artifacts/provider-validation/_automation/<yyyy-mm-dd>/wave1-validation-summary.md`
   - `artifacts/provider-validation/_automation/<yyyy-mm-dd>/dk1-pilot-parity-packet.json`
   - `artifacts/provider-validation/_automation/<yyyy-mm-dd>/dk1-pilot-parity-packet.md`
+- Evidence schema contract: [`provider-validation-evidence-schema.md`](./provider-validation-evidence-schema.md)
 
 ### Provider-specific evidence links
 
@@ -39,6 +40,10 @@ into `wave1-validation-summary.json` and `wave1-validation-summary.md`. The same
 [`scripts/dev/generate-dk1-pilot-parity-packet.ps1`](../../scripts/dev/generate-dk1-pilot-parity-packet.ps1)
 to assemble the DK1 operator-review packet from the generated summary, trust rationale mapping,
 baseline thresholds, and evidence documents.
+
+Readiness and operator-inbox trust decisions should be mapped from the summary fields
+`schemaVersion`, `calibration.kernelVersion`, `testRunIds`, and
+`readinessImpact.promotionRecommendation` before promotion claims are advanced.
 
 The generated `pilotReplaySampleSet` is the review contract for DK1 pilot parity:
 

--- a/docs/status/provider-validation-evidence-schema.md
+++ b/docs/status/provider-validation-evidence-schema.md
@@ -1,0 +1,52 @@
+# Provider Validation Evidence Artifact Schema (v1)
+
+This document defines the fixed automation artifact contract emitted under:
+
+`artifacts/provider-validation/_automation/<yyyy-mm-dd>/`
+
+## Required Artifacts
+
+1. `wave1-validation-summary.json` (machine-readable summary)
+2. `wave1-validation-summary.md` (human-readable summary)
+3. `dk1-pilot-parity-packet.json` + `dk1-pilot-parity-packet.md` (trust-gate packet)
+4. `dk1-operator-signoff.json` (promotion sign-off metadata)
+
+## Required Summary JSON Fields
+
+`wave1-validation-summary.json` must include:
+
+- `schemaVersion` (string; current: `provider-validation-evidence/v1`)
+- `generatedAtUtc` (ISO-8601 UTC timestamp)
+- `dateStamp` (`yyyy-mm-dd`)
+- `runId` (stable run identity for the date scope)
+- `configuration` (build/test configuration)
+- `result` (`passed` or `failed`)
+- `readinessImpact` object
+  - `trustDecisionTarget`
+  - `promotionRecommendation`
+  - `summary`
+- `calibration` object
+  - `kernelVersion`
+  - `sourceDocument`
+- `testRunIds` (array of executed lane IDs)
+- `activeProviderRows` (provider posture/lane/evidence rows)
+- `steps` (per-step command status, duration, and log path)
+
+## Readiness And Inbox Trust Mapping
+
+- `result=failed` or any failed step keeps readiness posture blocked/degraded for promotion decisions.
+- `readinessImpact.promotionRecommendation` feeds operator interpretation for:
+  - `GET /api/workstation/trading/readiness`
+  - `GET /api/workstation/operator/inbox`
+- `calibration.kernelVersion` ties evidence to DK trust-threshold interpretation and stale-calibration checks.
+- `dk1-pilot-parity-packet.json` resolves document/token and sample-review gates before operator review.
+
+## Promotion Sign-off Responsibilities
+
+Promotion beyond DK1 requires valid sign-off entries in `dk1-operator-signoff.json` for:
+
+- Data Operations
+- Provider Reliability
+- Trading
+
+Each approval must be bound to the exact reviewed packet metadata (path/status/generated timestamp/sample counts/contracts) before promotion can proceed.

--- a/scripts/dev/prepare-dk1-operator-signoff.ps1
+++ b/scripts/dev/prepare-dk1-operator-signoff.ps1
@@ -381,7 +381,9 @@ function New-OperatorSignoffTemplate {
     )
 
     $template = [ordered]@{
+        schemaVersion = "provider-validation-evidence-signoff/v1"
         generatedAtUtc = (Get-Date).ToUniversalTime().ToString("O")
+        runId = "dk1-operator-signoff-$dateStamp"
         purpose = "DK1 operator sign-off for the Alpaca/Robinhood/Yahoo pilot parity packet."
         requiredOwners = $RequiredOwners
         instructions = @(

--- a/scripts/dev/run-wave1-provider-validation.ps1
+++ b/scripts/dev/run-wave1-provider-validation.ps1
@@ -366,12 +366,24 @@ foreach ($step in $steps) {
 $failedResults = @($results | Where-Object status -eq "failed")
 
 $summary = [ordered]@{
+    schemaVersion = "provider-validation-evidence/v1"
     generatedAtUtc = (Get-Date).ToUniversalTime().ToString("O")
     dateStamp = $DateStamp
+    runId = "wave1-provider-validation-$DateStamp"
     configuration = $Configuration
     repoRoot = $repoRoot
     scope = "Active Wave 1 provider confidence, checkpoint resumability, and Parquet Level 2 flush proof"
     result = if ($failedResults.Count -eq 0) { "passed" } else { "failed" }
+    readinessImpact = [ordered]@{
+        trustDecisionTarget = "GET /api/workstation/trading/readiness and GET /api/workstation/operator/inbox"
+        promotionRecommendation = if ($failedResults.Count -eq 0) { "eligible-with-operator-signoff" } else { "blocked" }
+        summary = if ($failedResults.Count -eq 0) { "No blocking provider-validation failures detected." } else { "One or more provider-validation lanes failed; keep trust posture degraded until remediated." }
+    }
+    calibration = [ordered]@{
+        kernelVersion = "dk1-baseline-v1"
+        sourceDocument = "docs/status/dk1-baseline-trust-thresholds.md"
+    }
+    testRunIds = @($results | ForEach-Object { ($_.name.ToLowerInvariant() -replace '[^a-z0-9]+', '-').Trim('-') })
     activeProviderRows = $activeProviderRows
     pilotReplaySampleSet = $pilotReplaySampleSet
     crossCuttingClosures = $crossCuttingClosures
@@ -394,6 +406,10 @@ $md = @(
     "- Configuration: $Configuration",
     "- Scope: $($summary.scope)",
     "- Overall result: $($summary.result)",
+    "- Schema version: $($summary.schemaVersion)",
+    "- Run ID: $($summary.runId)",
+    "- Calibration kernel version: $($summary.calibration.kernelVersion)",
+    "- Promotion recommendation: $($summary.readinessImpact.promotionRecommendation)",
     "",
     "## Active Provider Set",
     "",


### PR DESCRIPTION
### Motivation

- Provide a fixed, auditable automation contract for provider-validation outputs so downstream readiness and promotion decisions consume consistent evidence artifacts.

### Description

- Add `docs/status/provider-validation-evidence-schema.md` that defines required timestamped artifact locations, required files, and required JSON fields (including provider posture, calibration, test run IDs, and readiness impact).
- Update `scripts/dev/run-wave1-provider-validation.ps1` to emit evidence metadata (`schemaVersion`, `runId`, `readinessImpact`, `calibration`, `testRunIds`) into `wave1-validation-summary.json` and surface those fields in the generated markdown summary; artifacts are written under `artifacts/provider-validation/_automation/<yyyy-mm-dd>/`.
- Update `scripts/dev/prepare-dk1-operator-signoff.ps1` to produce a structured sign-off template including `schemaVersion` and `runId` so approvals are auditable and bound to a packet.
- Update `docs/status/dk1-pilot-parity-runbook.md` to reference the new schema and to document how summary fields map into readiness/inbox trust interpretation and sign-off requirements.

### Testing

- Ran `git diff --check` with no issues reported (pass).
- Attempted a PowerShell parse/validation of the updated scripts, but `pwsh` is not available in the execution environment so the runtime check could not be completed (warning).
- No unit tests were changed; the change is focused on emitted artifact shape and runbook documentation and will be validated by executing the updated run scripts in an environment with PowerShell Core available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e2f8d664c8320af9e2bd6b6eef15a)