### PR TITLE
Add provider-change readiness/inbox regression evidence index

### DIFF
--- a/docs/status/provider-validation-matrix.md
+++ b/docs/status/provider-validation-matrix.md
@@ -26,6 +26,21 @@ For the unified per-broker phase/blocker/evidence view, see [`provider-integrati
 | Execution/readiness parity slice (IBKR-focused contract stability) | `IBBrokerageGatewayTests.ConnectAsync_AfterReconnect_RehydratesSessionAndAllowsOrderLifecycleToContinue`, `IBBrokerageGatewayTests.GetPositionsAsync_MapsPositionCallbacks`, `TradingOperatorReadinessServiceTests.GetAsync_AfterRestart_ShouldPreserveReplayParityAndExecutionAuditEvidence` | Use run-date replay/session artifacts only when validating with a live broker gateway; CI closes the canonical projection stability contract for auth/session refresh, position snapshots, and replay-readiness reconstruction | ✅ | n/a |
 
 
+## Readiness/Inbox regression evidence index (provider-impacting changes)
+
+Use this compact index when a provider change can affect trading-readiness posture, operator-inbox projection, or endpoint dependency assumptions.
+Each run must link the provider packet set to readiness/inbox verification results and operator sign-off state before promotion review.
+
+| Evidence lane | Required artifact(s) | Verification outcome to record | Operator sign-off status |
+| --- | --- | --- | --- |
+| Provider validation baseline | `artifacts/provider-validation/_automation/<yyyy-mm-dd>/wave1-validation-summary.json` | Record `status` plus provider-row pass/bounded deltas for the changed adapter(s). | Mark `pending` until packet + endpoint checks are attached. |
+| DK1 parity packet | `artifacts/provider-validation/_automation/<yyyy-mm-dd>/dk1-pilot-parity-packet.json` | Record packet `status` (`ready-for-operator-review` or blocked) and any trust-gate blockers tied to provider changes. | Mark `review-ready` only when packet status is ready and blockers are explained. |
+| Trading readiness projection compatibility | `GET /api/workstation/trading/readiness` snapshot (or endpoint test evidence) + contract packet (`artifacts/contract-review/<yyyy-mm-dd>/contract-review-packet.json`) | Confirm projection compatibility for shared readiness fields (`OverallStatus`, `SnapshotVersion`, `AcceptanceGates`, `EvidenceCompleteness`) and note pass/fail. | Mark `pending` if compatibility is unresolved or endpoint assumptions drift. |
+| Operator inbox dependency assumptions | `GET /api/workstation/operator/inbox` snapshot (or endpoint test evidence) + linked readiness work-item mapping evidence | Confirm inbox blockers/severity/routing remain aligned with readiness acceptance gates for affected provider/account scopes. | Mark `pending` if inbox/readiness alignment is incomplete. |
+| DK1 operator approval | `artifacts/provider-validation/_automation/<yyyy-mm-dd>/dk1-operator-signoff.json` | Record `validForDk1Exit`, `signedOwners`, and missing owners tied to the same run-date packet set. | Mark `signed` only when `validForDk1Exit=true` and required owners are present. |
+
+Regression index rule: a provider-impacting change is promotion-eligible only when all five rows are linked to the same run date and no row remains in `pending` status.
+
 ## 2026-05-20 focused Robinhood polling hardening
 
 Focused validation on 2026-05-20 added offline coverage for the Robinhood quote-polling boundary:


### PR DESCRIPTION
### Motivation
- Provider-impacting adapter changes can silently break trading-readiness projections or operator-inbox routing, so a compact, repeatable index is needed to tie validation packets to endpoint verification outcomes and operator sign-off before promotion.

### Description
- Add a new "Readiness/Inbox regression evidence index (provider-impacting changes)" section to `docs/status/provider-validation-matrix.md` that provides a five-lane table mapping required artifacts to verification outcomes and operator sign-off states and a rule that all lanes must be linked to the same run date with no `pending` rows before promotion.

### Testing
- Automated insertion and content verification were performed using the insertion script and a file-inspection command (`nl -ba docs/status/provider-validation-matrix.md | sed -n '1,220p'`) and the updated file content was validated as expected; this is a documentation-only change and no code tests were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e303dc1508320acd95ca9e87ed6d0)