### PR TITLE
Harden provider failover with deterministic provider selection

### DIFF
--- a/docs/status/provider-failover-hardening.md
+++ b/docs/status/provider-failover-hardening.md
@@ -1,0 +1,31 @@
+# Provider Failover Hardening
+
+## Summary
+
+Failover orchestration under `src/Meridian.Infrastructure/Adapters/` now enforces deterministic provider selection when multiple candidates share the same priority, while preserving existing degraded-provider skip behavior.
+
+## Deterministic Selection Contract
+
+- Registry selection for backfill/search/streaming-capable provider metadata now applies:
+  1. ascending `ProviderPriority`
+  2. ascending ordinal `ProviderId` as a deterministic tie-break.
+- This removes non-deterministic tie behavior that could vary based on dictionary iteration order.
+- Degraded or unavailable providers are still skipped before tie-break selection is applied.
+
+## Health Transition + Failover Behavior
+
+- Streaming failover still triggers when a provider crosses `FailoverThreshold` and recovers once primary reaches `RecoveryThreshold`.
+- Backup selection remains deterministic and respects configured backup order while skipping degraded candidates.
+
+## Backfill/Failover Interplay
+
+- Backfill provider selection now deterministically resolves equal-priority healthy candidates.
+- If the top-priority provider is degraded/unavailable, selection advances to the next healthy candidate with the same deterministic tie-break.
+
+## Evidence
+
+Focused tests were added/expanded to validate:
+
+- deterministic registry tie-break behavior;
+- degraded-provider skip and health-transition behavior;
+- failover/backfill interplay under equal-priority backup candidates.

--- a/src/Meridian.Infrastructure/Adapters/Core/ProviderRegistry.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/ProviderRegistry.cs
@@ -184,7 +184,8 @@ public sealed class ProviderRegistry : IDisposable, IAsyncDisposable
     {
         return _allProviders.Values
             .Where(r => r.IsEnabled)
-            .OrderBy(r => r.Priority)
+             .OrderBy(r => r.Priority)
+            .ThenBy(r => r.Name, StringComparer.Ordinal)
             .Select(r => r.Provider)
             .ToList();
     }
@@ -207,7 +208,8 @@ public sealed class ProviderRegistry : IDisposable, IAsyncDisposable
     {
         return _allProviders.Values
             .Where(r => r.IsEnabled && predicate(r.Provider.ProviderCapabilities))
-            .OrderBy(r => r.Priority)
+             .OrderBy(r => r.Priority)
+            .ThenBy(r => r.Name, StringComparer.Ordinal)
             .Select(r => r.Provider)
             .ToList();
     }
@@ -224,7 +226,8 @@ public sealed class ProviderRegistry : IDisposable, IAsyncDisposable
     {
         return _allProviders.Values
             .Where(r => r.IsEnabled && r.Provider is T)
-            .OrderBy(r => r.Priority)
+             .OrderBy(r => r.Priority)
+            .ThenBy(r => r.Name, StringComparer.Ordinal)
             .Select(r => (T)r.Provider)
             .ToList();
     }
@@ -256,7 +259,8 @@ public sealed class ProviderRegistry : IDisposable, IAsyncDisposable
     {
         var candidates = _allProviders.Values
             .Where(r => r.IsEnabled && r.Provider is T)
-            .OrderBy(r => r.Priority);
+            .OrderBy(r => r.Priority)
+            .ThenBy(r => r.Name, StringComparer.Ordinal);
 
         foreach (var registered in candidates)
         {

--- a/tests/Meridian.Tests/Application/Pipeline/ProviderRegistryDeterministicSelectionTests.cs
+++ b/tests/Meridian.Tests/Application/Pipeline/ProviderRegistryDeterministicSelectionTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using Meridian.Infrastructure.Adapters.Core;
+using Moq;
+using Xunit;
+
+namespace Meridian.Tests.Application.Pipeline;
+
+public sealed class ProviderRegistryDeterministicSelectionTests
+{
+    [Fact]
+    public async Task GetBestBackfillProviderAsync_WhenEqualPriority_SelectsOrdinallyByProviderId()
+    {
+        var registry = new ProviderRegistry();
+        var zulu = CreateBackfillProvider("zulu", priority: 10, isAvailable: true);
+        var alpha = CreateBackfillProvider("alpha", priority: 10, isAvailable: true);
+
+        registry.Register(zulu.Object);
+        registry.Register(alpha.Object);
+
+        var best = await registry.GetBestBackfillProviderAsync();
+
+        best.Should().NotBeNull();
+        best!.ProviderId.Should().Be("alpha");
+    }
+
+    [Fact]
+    public async Task GetBestBackfillProviderAsync_SkipsDegradedProvider_ThenUsesDeterministicTieBreak()
+    {
+        var registry = new ProviderRegistry();
+        var degraded = CreateBackfillProvider("alpha", priority: 5, isAvailable: false);
+        var zulu = CreateBackfillProvider("zulu", priority: 10, isAvailable: true);
+        var beta = CreateBackfillProvider("beta", priority: 10, isAvailable: true);
+
+        registry.Register(zulu.Object);
+        registry.Register(beta.Object);
+        registry.Register(degraded.Object);
+
+        var best = await registry.GetBestBackfillProviderAsync();
+
+        best.Should().NotBeNull();
+        best!.ProviderId.Should().Be("beta");
+    }
+
+    private static Mock<IHistoricalDataProvider> CreateBackfillProvider(string id, int priority, bool isAvailable)
+    {
+        var mock = new Mock<IHistoricalDataProvider>();
+        mock.SetupGet(x => x.ProviderId).Returns(id);
+        mock.SetupGet(x => x.ProviderDisplayName).Returns($"{id} provider");
+        mock.SetupGet(x => x.ProviderDescription).Returns("test");
+        mock.SetupGet(x => x.ProviderPriority).Returns(priority);
+        mock.SetupGet(x => x.ProviderCapabilities).Returns(ProviderCapabilities.Backfill());
+        mock.SetupGet(x => x.Name).Returns(id);
+        mock.SetupGet(x => x.Description).Returns("test");
+        mock.SetupGet(x => x.Capabilities).Returns(new HistoricalDataCapabilities());
+        mock.Setup(x => x.IsAvailableAsync(It.IsAny<CancellationToken>())).ReturnsAsync(isAvailable);
+        return mock;
+    }
+}

--- a/tests/Meridian.Tests/Infrastructure/Providers/StreamingFailoverServiceTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/StreamingFailoverServiceTests.cs
@@ -235,4 +235,33 @@ public sealed class StreamingFailoverServiceTests : IDisposable
         snap = _service.GetProviderHealthSnapshots().First(s => s.ProviderId == "primary");
         snap.LastFailureTime.Should().NotBeNull();
     }
+
+    [Fact]
+    public void AutomaticFailover_SelectsFirstConfiguredHealthyBackup_WhenPrimaryDegraded()
+    {
+        var deterministicRule = new FailoverRuleConfig(
+            Id: "ordered-rule",
+            PrimaryProviderId: "primary",
+            BackupProviderIds: new[] { "backup1", "backup2" },
+            FailoverThreshold: 2,
+            RecoveryThreshold: 2);
+
+        var config = new DataSourcesConfig(
+            EnableFailover: true,
+            HealthCheckIntervalSeconds: 3600,
+            FailoverRules: new[] { deterministicRule });
+
+        _service.RegisterProvider("primary");
+        _service.RegisterProvider("backup1");
+        _service.RegisterProvider("backup2");
+        _service.Start(config);
+
+        _service.RecordFailure("backup1", "already degraded");
+        _service.RecordFailure("backup1", "already degraded");
+        _service.RecordFailure("primary", "timeout");
+        _service.RecordFailure("primary", "timeout");
+
+        _service.GetActiveProviderId("ordered-rule").Should().Be("backup2");
+    }
+
 }


### PR DESCRIPTION
### Motivation

- Eliminate non-deterministic tie-break behavior when multiple providers share the same priority so routing and failover are stable and reproducible.
- Preserve existing degraded/unavailable filtering while ensuring predictable backup selection during failover and backfill operations.

### Description

- Enforce an ordinal tie-break (`ThenBy(r => r.Name, StringComparer.Ordinal)`) after `Priority` in `ProviderRegistry` selection paths, specifically in `GetAllProviderMetadata`, `GetProvidersByCapability`, `GetProviders<T>`, and `GetBestAvailableProviderAsync` to guarantee deterministic ordering.
- Add `ProviderRegistryDeterministicSelectionTests` to validate equal-priority selection and degraded-provider skipping for backfill provider selection via `GetBestBackfillProviderAsync`.
- Extend `StreamingFailoverServiceTests` with `AutomaticFailover_SelectsFirstConfiguredHealthyBackup_WhenPrimaryDegraded` to assert deterministic backup selection when an earlier backup is already degraded.
- Document the hardening and the deterministic selection contract in `docs/status/provider-failover-hardening.md`.

### Testing

- Attempted to run the focused unit tests with `dotnet test ... --filter "FullyQualifiedName~ProviderRegistryDeterministicSelectionTests|FullyQualifiedName~StreamingFailoverServiceTests"`, but the test run could not be executed in this environment because `dotnet` is not installed (test execution failed).
- The change includes unit tests added to the test suite; CI or a local environment with the .NET SDK should be used to run `dotnet test` and verify the new tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e303309f08320a1cd6610fe00a0e3)