### PR TITLE
Align Polygon adapter capability and resilience coherence

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/Polygon/PolygonMarketDataClient.cs
+++ b/src/Meridian.Infrastructure/Adapters/Polygon/PolygonMarketDataClient.cs
@@ -92,7 +92,7 @@ public sealed class PolygonMarketDataClient : WebSocketProviderBase
     /// Minimum length for a valid Polygon API key.
     /// Polygon API keys are typically 32 characters, but we accept 20+ for flexibility.
     /// </summary>
-    private const int MinApiKeyLength = 20;
+    private const int MinApiKeyLength = PolygonApiKeyLimits.MinLength;
 
     /// <summary>
     /// Gets whether the client has a valid API key configured.
@@ -138,8 +138,8 @@ public sealed class PolygonMarketDataClient : WebSocketProviderBase
         depth: false) with
     {
         SupportedMarkets = new[] { "US" },
-        MaxRequestsPerWindow = 5,
-        RateLimitWindow = TimeSpan.FromMinutes(1),
+        MaxRequestsPerWindow = PolygonRateLimits.MaxRequestsPerWindowFree,
+        RateLimitWindow = PolygonRateLimits.Window,
         MinRequestDelay = TimeSpan.FromMilliseconds(12000)
     };
 
@@ -168,12 +168,10 @@ public sealed class PolygonMarketDataClient : WebSocketProviderBase
     /// <inheritdoc/>
     protected override Uri BuildWebSocketUri()
     {
-        var endpoint = _options.UseDelayed
-            ? $"wss://delayed.polygon.io/{_options.Feed}"
-            : $"wss://socket.polygon.io/{_options.Feed}";
+        var endpoint = PolygonEndpoints.WssUri(_options.Feed, _options.UseDelayed);
 
         Log.Information("Polygon WebSocket endpoint: {Endpoint} (Delayed: {UseDelayed})", endpoint, _options.UseDelayed);
-        return new Uri(endpoint);
+        return endpoint;
     }
 
     /// <inheritdoc/>

--- a/src/Meridian.Infrastructure/Adapters/Polygon/PolygonOptionsChainProvider.cs
+++ b/src/Meridian.Infrastructure/Adapters/Polygon/PolygonOptionsChainProvider.cs
@@ -36,7 +36,7 @@ namespace Meridian.Infrastructure.Adapters.Polygon;
 public sealed class PolygonOptionsChainProvider : IOptionsChainProvider
 {
     private const string BaseUrl = "https://api.polygon.io";
-    private const int MinApiKeyLength = 8;
+    private const int MinApiKeyLength = PolygonApiKeyLimits.MinLength;
     private const int DefaultPageLimit = 250;
 
     private readonly string? _apiKey;

--- a/tests/Meridian.Tests/Infrastructure/Providers/PolygonCoherenceTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/PolygonCoherenceTests.cs
@@ -1,0 +1,57 @@
+using System.Net;
+using FluentAssertions;
+using Meridian.Domain.Collectors;
+using Meridian.Domain.Events;
+using Meridian.Infrastructure.Adapters.Polygon;
+using Meridian.Tests.TestHelpers;
+using Xunit;
+
+namespace Meridian.Tests.Infrastructure.Providers;
+
+public sealed class PolygonCoherenceTests
+{
+    [Fact]
+    public async Task OptionsProvider_WithShortApiKey_DoesNotIssueHttpRequests()
+    {
+        var handler = new CountingHandler();
+        using var http = new HttpClient(handler);
+        var factory = new TestHttpClientFactory(http);
+        var provider = new PolygonOptionsChainProvider(factory, apiKey: "short-key");
+
+        var expirations = await provider.GetExpirationsAsync("AAPL");
+
+        expirations.Should().BeEmpty();
+        handler.RequestCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void StreamingProvider_UsesDocumentedFreeTierRateLimits()
+    {
+        var publisher = new TestMarketEventPublisher();
+        var trades = new TradeDataCollector(publisher, null);
+        var quotes = new QuoteCollector(publisher);
+        var client = new PolygonMarketDataClient(publisher, trades, quotes);
+
+        client.ProviderCapabilities.MaxRequestsPerWindow.Should().Be(5);
+        client.ProviderCapabilities.RateLimitWindow.Should().Be(TimeSpan.FromMinutes(1));
+    }
+
+    private sealed class CountingHandler : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"results\":[]}")
+            });
+        }
+    }
+
+    private sealed class TestHttpClientFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => client;
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure Polygon streaming, options, and HTTP/backfill surfaces use the same shared constants and resilience metadata to avoid capability mismatches.
- Centralize endpoint construction and API-key validation so delayed vs live feeds and credential gating behave consistently across providers.
- Add deterministic unit coverage for the coherence scenarios so changes are safe and non-networked.

### Description
- Replaced hard-coded API-key minimums with the shared constant by changing `MinApiKeyLength` to `PolygonApiKeyLimits.MinLength` in `PolygonMarketDataClient` and `PolygonOptionsChainProvider` to align credential validation.
- Switched streaming rate-limit metadata to use `PolygonRateLimits` constants (`MaxRequestsPerWindowFree` and `Window`) in `PolygonMarketDataClient` so capability/thresholds match documented free-tier values.
- Centralized WebSocket URI construction by using `PolygonEndpoints.WssUri(_options.Feed, _options.UseDelayed)` in `PolygonMarketDataClient` to avoid duplicated string construction for delayed/live endpoints.
- Added deterministic unit tests in `tests/Meridian.Tests/Infrastructure/Providers/PolygonCoherenceTests.cs` that assert short-key options calls do not issue HTTP requests and that streaming capability metadata reflects the free-tier rate window.

### Testing
- Added unit tests: `PolygonCoherenceTests.OptionsProvider_WithShortApiKey_DoesNotIssueHttpRequests` and `PolygonCoherenceTests.StreamingProvider_UsesDocumentedFreeTierRateLimits` (no network dependency, deterministic).
- Attempted to run focused Polygon tests via `dotnet test --filter "FullyQualifiedName~Polygon"`, but the runtime environment lacks `dotnet` so the test run failed with `/bin/bash: dotnet: command not found`.
- Local/CI validation: run `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~Polygon"` (or full test suite) in a .NET-enabled environment or CI pipeline; the new tests are expected to pass and provide the stated coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e303467988320a17f9403d288ef6b)