### PR TITLE
Enhance Synthetic provider scenarios and add reusable test harness

### DIFF
--- a/docs/development/synthetic-provider-test-harness.md
+++ b/docs/development/synthetic-provider-test-harness.md
@@ -1,0 +1,36 @@
+# Synthetic Provider Test Harness (Short Guide)
+
+Use `SyntheticProviderTestHarness` for deterministic provider-family tests that need repeatable resilience behavior.
+
+## Location
+
+- Harness: `tests/Meridian.Tests/Infrastructure/Providers/SyntheticProviderTestHarness.cs`
+- Example migrated slices:
+  - `tests/Meridian.Tests/Infrastructure/Providers/SyntheticMarketDataProviderTests.cs`
+  - `tests/Meridian.Tests/Infrastructure/Providers/SyntheticHistoricalProviderContractTests.cs`
+
+## Scenario Controls
+
+`SyntheticScenarioConfig` is available on `SyntheticMarketDataConfig.Scenario` and supports:
+
+- `ThrottleEveryNCalls` + `ThrottleDelayMs`: deterministic soft-throttle cadence.
+- `TimeoutEveryNCalls`: deterministic timeout injection cadence.
+- `DegradeEveryNEvents`: periodic quote/trade/depth degradation for health-path assertions.
+- `ReplayBarsLimit`: cap replay-like history requests.
+- `BackfillBarsLimit`: cap backfill-oriented history requests.
+- `ApplyToHistorical` / `ApplyToStreaming`: select flow scope.
+
+## Minimal Usage
+
+```csharp
+var config = SyntheticProviderTestHarness.BuildScenarioConfig(
+    throttleEveryNCalls: 3,
+    timeoutEveryNCalls: 5,
+    degradeEveryNEvents: 4,
+    replayBarsLimit: 25,
+    backfillBarsLimit: 100);
+
+var provider = SyntheticProviderTestHarness.CreateHistorical(config);
+```
+
+Keep scenario cadence small in unit tests so failure/timeout paths are exercised within 1-3 calls.

--- a/src/Meridian.Core/Config/SyntheticMarketDataConfig.cs
+++ b/src/Meridian.Core/Config/SyntheticMarketDataConfig.cs
@@ -16,5 +16,18 @@ public sealed record SyntheticMarketDataConfig(
     bool IncludeReferenceData = true,
     string[]? UniverseSymbols = null,
     DateOnly? DefaultHistoryStart = null,
-    DateOnly? DefaultHistoryEnd = null
+    DateOnly? DefaultHistoryEnd = null,
+    SyntheticScenarioConfig? Scenario = null
+);
+
+public sealed record SyntheticScenarioConfig(
+    bool Enabled = false,
+    int ThrottleEveryNCalls = 0,
+    int TimeoutEveryNCalls = 0,
+    int DegradeEveryNEvents = 0,
+    int ReplayBarsLimit = 0,
+    int BackfillBarsLimit = 0,
+    int ThrottleDelayMs = 150,
+    bool ApplyToHistorical = true,
+    bool ApplyToStreaming = true
 );

--- a/src/Meridian.Infrastructure/Adapters/Synthetic/SyntheticHistoricalDataProvider.cs
+++ b/src/Meridian.Infrastructure/Adapters/Synthetic/SyntheticHistoricalDataProvider.cs
@@ -11,6 +11,7 @@ namespace Meridian.Infrastructure.Adapters.Synthetic;
 public sealed class SyntheticHistoricalDataProvider : IHistoricalDataProvider, ICorporateActionSource
 {
     private readonly SyntheticMarketDataConfig _config;
+    private int _requestCounter;
 
     public SyntheticHistoricalDataProvider(SyntheticMarketDataConfig? config = null)
     {
@@ -26,13 +27,51 @@ public sealed class SyntheticHistoricalDataProvider : IHistoricalDataProvider, I
 
     public Task<bool> IsAvailableAsync(CancellationToken ct = default) => Task.FromResult(_config.Enabled);
 
-    public Task<IReadOnlyList<HistoricalBar>> GetDailyBarsAsync(string symbol, DateOnly? from, DateOnly? to, CancellationToken ct = default)
-        => Task.FromResult<IReadOnlyList<HistoricalBar>>(BuildAdjustedBars(symbol, from, to)
-            .Select(bar => bar.ToHistoricalBar(preferAdjusted: true))
-            .ToArray());
+    private async Task ApplyScenarioAsync(bool replayOrBackfillRequest, CancellationToken ct)
+    {
+        var scenario = _config.Scenario;
+        if (scenario is null || !scenario.Enabled || !scenario.ApplyToHistorical)
+            return;
 
-    public Task<IReadOnlyList<AdjustedHistoricalBar>> GetAdjustedDailyBarsAsync(string symbol, DateOnly? from, DateOnly? to, CancellationToken ct = default)
-        => Task.FromResult<IReadOnlyList<AdjustedHistoricalBar>>(BuildAdjustedBars(symbol, from, to));
+        var call = Interlocked.Increment(ref _requestCounter);
+        if (scenario.ThrottleEveryNCalls > 0 && call % scenario.ThrottleEveryNCalls == 0)
+            await Task.Delay(TimeSpan.FromMilliseconds(Math.Max(1, scenario.ThrottleDelayMs)), ct).ConfigureAwait(false);
+
+        if (scenario.TimeoutEveryNCalls > 0 && call % scenario.TimeoutEveryNCalls == 0)
+            throw new TimeoutException("Synthetic scenario timeout injected for deterministic provider testing.");
+    }
+
+    private int ResolveHistoryLimit(bool replayOrBackfillRequest)
+    {
+        var scenario = _config.Scenario;
+        if (scenario is null || !scenario.Enabled || !scenario.ApplyToHistorical)
+            return 0;
+
+        if (replayOrBackfillRequest && scenario.BackfillBarsLimit > 0)
+            return scenario.BackfillBarsLimit;
+
+        return scenario.ReplayBarsLimit;
+    }
+
+    public async Task<IReadOnlyList<HistoricalBar>> GetDailyBarsAsync(string symbol, DateOnly? from, DateOnly? to, CancellationToken ct = default)
+    {
+        await ApplyScenarioAsync(replayOrBackfillRequest: true, ct).ConfigureAwait(false);
+        var bars = BuildAdjustedBars(symbol, from, to).Select(bar => bar.ToHistoricalBar(preferAdjusted: true));
+        var limit = ResolveHistoryLimit(replayOrBackfillRequest: true);
+        if (limit > 0)
+            bars = bars.Take(limit);
+        return bars.ToArray();
+    }
+
+    public async Task<IReadOnlyList<AdjustedHistoricalBar>> GetAdjustedDailyBarsAsync(string symbol, DateOnly? from, DateOnly? to, CancellationToken ct = default)
+    {
+        await ApplyScenarioAsync(replayOrBackfillRequest: true, ct).ConfigureAwait(false);
+        var bars = BuildAdjustedBars(symbol, from, to).AsEnumerable();
+        var limit = ResolveHistoryLimit(replayOrBackfillRequest: true);
+        if (limit > 0)
+            bars = bars.Take(limit);
+        return bars.ToArray();
+    }
 
     public Task<HistoricalQuotesResult> GetHistoricalQuotesAsync(string symbol, DateTimeOffset start, DateTimeOffset end, int? limit = null, CancellationToken ct = default)
         => Task.FromResult(BuildHistoricalQuotes(new[] { symbol }, start, end, limit));

--- a/src/Meridian.Infrastructure/Adapters/Synthetic/SyntheticMarketDataClient.cs
+++ b/src/Meridian.Infrastructure/Adapters/Synthetic/SyntheticMarketDataClient.cs
@@ -21,6 +21,7 @@ public sealed class SyntheticMarketDataClient : IMarketDataClient, ISymbolSearch
     private readonly ConcurrentDictionary<int, SyntheticSubscription> _tradeSubscriptions = new();
     private readonly ConcurrentDictionary<int, SyntheticSubscription> _depthSubscriptions = new();
     private int _nextSubscriptionId;
+    private int _streamEventCounter;
     private volatile bool _connected;
 
     public SyntheticMarketDataClient(IMarketEventPublisher publisher, SyntheticMarketDataConfig? config = null)
@@ -111,6 +112,30 @@ public sealed class SyntheticMarketDataClient : IMarketDataClient, ISymbolSearch
         GC.SuppressFinalize(this);
     }
 
+    private async Task ApplyStreamingScenarioAsync(CancellationToken ct)
+    {
+        var scenario = _config.Scenario;
+        if (scenario is null || !scenario.Enabled || !scenario.ApplyToStreaming)
+            return;
+
+        var index = Interlocked.Increment(ref _streamEventCounter);
+        if (scenario.ThrottleEveryNCalls > 0 && index % scenario.ThrottleEveryNCalls == 0)
+            await Task.Delay(TimeSpan.FromMilliseconds(Math.Max(1, scenario.ThrottleDelayMs)), ct).ConfigureAwait(false);
+
+        if (scenario.TimeoutEveryNCalls > 0 && index % scenario.TimeoutEveryNCalls == 0)
+            throw new TimeoutException("Synthetic streaming timeout injected for deterministic provider testing.");
+    }
+
+    private decimal ApplyDegradation(decimal value)
+    {
+        var scenario = _config.Scenario;
+        if (scenario is null || !scenario.Enabled || !scenario.ApplyToStreaming || scenario.DegradeEveryNEvents <= 0)
+            return value;
+
+        var index = Volatile.Read(ref _streamEventCounter);
+        return index > 0 && index % scenario.DegradeEveryNEvents == 0 ? Round4(value * 0.975m) : value;
+    }
+
     private async Task PublishTradesAsync(SymbolConfig cfg, CancellationToken ct)
     {
         var profile = SyntheticReferenceDataCatalog.GetProfileOrDefault(cfg.Symbol);
@@ -121,7 +146,8 @@ public sealed class SyntheticMarketDataClient : IMarketDataClient, ISymbolSearch
         {
             var now = DateTimeOffset.UtcNow;
             var anchor = ComputeAnchor(profile, now, seq);
-            var price = Round4(anchor * (1m + Noise(profile.Symbol, now.Millisecond, (int)seq, 0.0008m)));
+            await ApplyStreamingScenarioAsync(ct).ConfigureAwait(false);
+            var price = ApplyDegradation(Round4(anchor * (1m + Noise(profile.Symbol, now.Millisecond, (int)seq, 0.0008m))));
             var size = 25L * (1 + (long)(PositiveNoise(profile.Symbol, now.Second, (int)seq + 11, 40m)));
             var trade = new Trade(
                 Timestamp: now,
@@ -151,8 +177,9 @@ public sealed class SyntheticMarketDataClient : IMarketDataClient, ISymbolSearch
             var anchor = ComputeAnchor(profile, now, seq);
             var tick = Math.Max(0.0001m, anchor * 0.00005m);
             var spread = Math.Max(0.01m, Round4(anchor * (0.00008m + PositiveNoise(profile.Symbol, now.Second, (int)seq, 0.00006m))));
-            var bestBid = Round4(anchor - spread / 2m);
-            var bestAsk = Round4(anchor + spread / 2m);
+            await ApplyStreamingScenarioAsync(ct).ConfigureAwait(false);
+            var bestBid = ApplyDegradation(Round4(anchor - spread / 2m));
+            var bestAsk = ApplyDegradation(Round4(anchor + spread / 2m));
             var bids = new List<OrderBookLevel>(levels);
             var asks = new List<OrderBookLevel>(levels);
 

--- a/tests/Meridian.Tests/Infrastructure/Providers/SyntheticHistoricalProviderContractTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/SyntheticHistoricalProviderContractTests.cs
@@ -1,0 +1,9 @@
+using Meridian.Infrastructure.Adapters.Synthetic;
+
+namespace Meridian.Tests.Infrastructure.Providers;
+
+public sealed class SyntheticHistoricalProviderContractTests : HistoricalDataProviderContractTests<SyntheticHistoricalDataProvider>
+{
+    protected override SyntheticHistoricalDataProvider CreateProvider()
+        => SyntheticProviderTestHarness.CreateHistorical();
+}

--- a/tests/Meridian.Tests/Infrastructure/Providers/SyntheticMarketDataProviderTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/SyntheticMarketDataProviderTests.cs
@@ -15,7 +15,7 @@ public sealed class SyntheticMarketDataProviderTests
     [Fact]
     public async Task HistoricalProvider_ReturnsAdjustedBars_WithCorporateActions()
     {
-        var provider = new SyntheticHistoricalDataProvider(new SyntheticMarketDataConfig(Enabled: true));
+        var provider = SyntheticProviderTestHarness.CreateHistorical();
 
         var bars = await provider.GetAdjustedDailyBarsAsync("NVDA", new DateOnly(2024, 6, 3), new DateOnly(2024, 6, 14));
         var dividends = await provider.GetDividendsAsync("NVDA", new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31));
@@ -31,7 +31,7 @@ public sealed class SyntheticMarketDataProviderTests
     [Fact]
     public async Task HistoricalProvider_ReturnsQuotesTradesAndAuctions()
     {
-        var provider = new SyntheticHistoricalDataProvider(new SyntheticMarketDataConfig(Enabled: true, HistoricalTradeDensityPerDay: 12, HistoricalQuoteDensityPerDay: 16));
+        var provider = SyntheticProviderTestHarness.CreateHistorical(SyntheticProviderTestHarness.BuildScenarioConfig(replayBarsLimit: 20));
         var start = new DateTimeOffset(2024, 3, 18, 13, 30, 0, TimeSpan.Zero);
         var end = new DateTimeOffset(2024, 3, 18, 20, 0, 0, TimeSpan.Zero);
 
@@ -116,6 +116,22 @@ public sealed class SyntheticMarketDataProviderTests
 
         act.Should().Throw<ArgumentNullException>()
             .WithParameterName("cfg");
+    }
+
+
+    [Fact]
+    public async Task HistoricalProvider_ScenarioTimeout_IsRepeatable()
+    {
+        var provider = SyntheticProviderTestHarness.CreateHistorical(
+            SyntheticProviderTestHarness.BuildScenarioConfig(timeoutEveryNCalls: 2));
+
+        var start = new DateOnly(2024, 4, 1);
+        var end = new DateOnly(2024, 4, 5);
+
+        await provider.GetAdjustedDailyBarsAsync("AAPL", start, end);
+        var act = async () => await provider.GetAdjustedDailyBarsAsync("AAPL", start, end);
+
+        await act.Should().ThrowAsync<TimeoutException>();
     }
 
     private sealed class RecordingPublisher : IMarketEventPublisher

--- a/tests/Meridian.Tests/Infrastructure/Providers/SyntheticProviderTestHarness.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/SyntheticProviderTestHarness.cs
@@ -1,0 +1,33 @@
+using Meridian.Application.Config;
+using Meridian.Infrastructure.Adapters.Synthetic;
+
+namespace Meridian.Tests.Infrastructure.Providers;
+
+internal static class SyntheticProviderTestHarness
+{
+    public static SyntheticMarketDataConfig BuildScenarioConfig(
+        int throttleEveryNCalls = 0,
+        int timeoutEveryNCalls = 0,
+        int degradeEveryNEvents = 0,
+        int replayBarsLimit = 0,
+        int backfillBarsLimit = 0,
+        int throttleDelayMs = 20)
+        => new(
+            Enabled: true,
+            EventsPerSecond: 40,
+            HistoricalTradeDensityPerDay: 24,
+            HistoricalQuoteDensityPerDay: 24,
+            Scenario: new SyntheticScenarioConfig(
+                Enabled: true,
+                ThrottleEveryNCalls: throttleEveryNCalls,
+                TimeoutEveryNCalls: timeoutEveryNCalls,
+                DegradeEveryNEvents: degradeEveryNEvents,
+                ReplayBarsLimit: replayBarsLimit,
+                BackfillBarsLimit: backfillBarsLimit,
+                ThrottleDelayMs: throttleDelayMs,
+                ApplyToHistorical: true,
+                ApplyToStreaming: true));
+
+    public static SyntheticHistoricalDataProvider CreateHistorical(SyntheticMarketDataConfig? config = null)
+        => new(config ?? BuildScenarioConfig());
+}


### PR DESCRIPTION
### Motivation
- Provide deterministic, repeatable synthetic provider behaviors (throttling, timeouts, degradation, replay/backfill limits) to make provider resilience and backfill/replay tests reliable and reusable.
- Standardize scenario configuration and reuse across provider-family tests via a small harness and documentation so tests can express failure cadence without bespoke setup.

### Description
- Added `SyntheticScenarioConfig` and attached it to `SyntheticMarketDataConfig` to expose scenario controls like `ThrottleEveryNCalls`, `TimeoutEveryNCalls`, `DegradeEveryNEvents`, `ReplayBarsLimit`, and `BackfillBarsLimit` (see `SyntheticMarketDataConfig.Scenario`).
- Wired scenario handling into the historical provider by adding `ApplyScenarioAsync` and `ResolveHistoryLimit`, and updated `GetDailyBarsAsync` / `GetAdjustedDailyBarsAsync` to apply throttles, injected timeouts, and optional history limits.
- Enhanced streaming loops in `SyntheticMarketDataClient` with `ApplyStreamingScenarioAsync` and `ApplyDegradation` to deterministically inject delays/timeouts and periodic value degradation in trade/quote/depth publication paths.
- Added a reusable `SyntheticProviderTestHarness` to centralize construction of scenario-bearing `SyntheticMarketDataConfig` instances and a short guide at `docs/development/synthetic-provider-test-harness.md` describing usage and controls.
- Migrated tests to consume the harness by adding `SyntheticHistoricalProviderContractTests` and updating `SyntheticMarketDataProviderTests` to use the harness and include a repeatable timeout scenario assertion.

### Testing
- Added/modified automated tests in `tests/Meridian.Tests/Infrastructure/Providers`: `SyntheticMarketDataProviderTests` (updated) and `SyntheticHistoricalProviderContractTests` (new), and a small harness file `SyntheticProviderTestHarness.cs` to drive them.
- Attempted targeted run: `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~SyntheticMarketDataProviderTests|FullyQualifiedName~SyntheticHistoricalProviderContractTests" --logger "console;verbosity=minimal"`, but execution failed in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`).
- No automated test executions succeeded here due to the missing runtime; the added tests are in-tree and intended to pass under normal CI / local `dotnet` test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e303b27ec832082438b11985e8bd6)