### PR TITLE
Audit provider capability parity and harden backfill/symbol-search stability tests

### DIFF
--- a/docs/status/provider-validation-matrix.md
+++ b/docs/status/provider-validation-matrix.md
@@ -108,6 +108,34 @@ If any check fails, promotion enablement is blocked and operator surfaces must s
 - Yahoo is active only as a historical and fallback provider row for Wave 1.
 - `Polygon`, `Interactive Brokers`, `NYSE`, and `StockSharp` are deferred from the active Wave 1 gate.
 
+## 2026-05-20 capability-claim parity + deterministic data-shape audit
+
+The following audit reconciles current capability claims versus deterministic data-shape compatibility for the requested provider set:
+Finnhub, NYSE, Edgar, OpenFigi, YahooFinance, Tradier, TwelveData, AlphaVantage, Tiingo, Stooq, Fred, and NasdaqDataLink.
+
+| Provider | Capability-claim parity posture | Deterministic data-shape compatibility posture | Evidence anchor |
+| --- | --- | --- | --- |
+| Finnhub | Backfill + symbol-search supported through credential-gated adapters | JSON parse and contract fixtures enforce stable bar parsing and symbol-search projection | `FreeProviderContractTests`, `FreeHistoricalProviderParsingTests`, `ProviderFactoryCredentialContextTests` |
+| NYSE | Deferred from active Wave 1 closure; retained as provider inventory/runtime lane | Message/csv parser and pipeline tests lock schema, exchange-code mapping, and publication flow | `NYSEMessageParsingTests`, `NyseNationalTradesCsvParserTests`, `NyseMessagePipelineTests` |
+| Edgar | Security Master/symbol-search inventory support | Parser coverage validates ticker-entry extraction, malformed payload handling, and ingest projections | `EdgarSymbolSearchProviderTests` |
+| OpenFigi | Symbol mapping/search support | Recorded-response contract tests validate mapping/search parse determinism | `OpenFigiClientTests` |
+| YahooFinance | Active Wave 1 historical + fallback row | Historical/intraday contract suites lock fallback bar-shape expectations | `YahooFinanceHistoricalDataProviderTests`, `YahooFinanceIntradayContractTests` |
+| Tradier | Execution reconciliation support path (not active Wave 1 provider row) | Deterministic execution evidence + out-of-order/partial-fill handling covered in focused execution suites | `TradierExecutionReconciliationTests` |
+| TwelveData | Backfill inventory support via provider adapter | Stubbed-response parsing tests validate success/error/empty payload handling | `FreeHistoricalProviderParsingTests` |
+| AlphaVantage | Backfill inventory support (explicitly credential/enable gated) | Contract + parser tests validate rate-limit and error-shape behavior | `FreeProviderContractTests`, `FreeHistoricalProviderParsingTests` |
+| Tiingo | Backfill inventory support | Contract tests + factory credential-path tests keep adapter eligibility deterministic | `FreeProviderContractTests`, `ProviderFactoryCredentialContextTests` |
+| Stooq | Backfill inventory support | CSV parser tests validate stable row-to-bar conversion and empty dataset handling | `FreeProviderContractTests`, `FreeHistoricalProviderParsingTests` |
+| Fred | Backfill inventory support for economic-series lanes | Parser/credential tests validate deterministic failure surface when key/shape is invalid | `FreeHistoricalProviderParsingTests`, `ProviderFactoryCredentialContextTests` |
+| NasdaqDataLink | Backfill inventory support | Provider-factory credential/context tests verify deterministic inclusion and credential wiring | `ProviderFactoryCredentialContextTests` |
+
+### Unresolved items (owner + risk + defer rationale)
+
+| Item | Owner | Risk | Defer rationale |
+| --- | --- | --- | --- |
+| NYSE runtime entitlement/session evidence remains outside active Wave 1 closure | `@provider-infra` + `@ops-readiness` | False-positive readiness claims if parser-only confidence is mistaken for runtime-feed confidence | Wave 1 closure is intentionally limited to Alpaca/Robinhood/Yahoo; NYSE remains explicit deferred inventory while entitlement and runtime evidence lanes mature |
+| Tradier capability row is execution-focused and not yet normalized into an always-on provider matrix row | `@execution-reliability` | Claim drift between execution evidence and provider-row wording | Current closure requirement is execution reconciliation determinism; broader provider-row governance is deferred to next matrix expansion to avoid changing Wave 1 scope mid-gate |
+| OpenFigi + Edgar runtime dependency characteristics (rate/uptime/vendor policy) are not represented in DK1 runtime packet | `@security-master` + `@provider-infra` | Symbol-search quality can degrade without appearing in provider runtime packet gating | Current DK1 packet contract is broker/paper-session centered; expanding to search-governance metrics is deferred until packet schema revision window |
+
 
 ## Unified automation and promotion posture
 

--- a/tests/Meridian.Tests/Infrastructure/Providers/ProviderFactoryCredentialContextTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/ProviderFactoryCredentialContextTests.cs
@@ -9,7 +9,9 @@ using Meridian.Infrastructure.Adapters.Finnhub;
 using Meridian.Infrastructure.Adapters.Fred;
 using Meridian.Infrastructure.Adapters.NasdaqDataLink;
 using Meridian.Infrastructure.Adapters.Polygon;
+using Meridian.Infrastructure.Adapters.Stooq;
 using Meridian.Infrastructure.Adapters.Tiingo;
+using Meridian.Infrastructure.Adapters.YahooFinance;
 using Meridian.Infrastructure.Contracts;
 using Meridian.Tests.Ui;
 using Xunit;
@@ -111,6 +113,37 @@ public sealed class ProviderFactoryCredentialContextTests
             new ContextRequest(typeof(FredHistoricalDataProvider), ["FRED_API_KEY"]));
         resolver.ContextRequests.Should().ContainEquivalentOf(
             new ContextRequest(typeof(NasdaqDataLinkHistoricalDataProvider), ["NASDAQ_DATA_LINK_API_KEY"]));
+    }
+
+    [Fact]
+    public void CreateBackfillProviders_WithConfiguredFreeProviderSet_IsDeterministicAndCapabilityAligned()
+    {
+        var resolver = new TrackingCredentialResolver();
+        var factory = new ProviderFactory(
+            new AppConfig(
+                Backfill: new BackfillConfig(
+                    Providers: new BackfillProvidersConfig(
+                        Yahoo: new YahooFinanceConfig(Enabled: true),
+                        Nasdaq: new NasdaqDataLinkConfig(Enabled: true, ApiKey: "cfg-nasdaq-key"),
+                        Stooq: new StooqConfig(Enabled: true),
+                        Tiingo: new TiingoConfig(Enabled: true, ApiToken: "cfg-tiingo-token"),
+                        AlphaVantage: new AlphaVantageConfig(Enabled: true, ApiKey: "cfg-alpha-key"),
+                        Finnhub: new FinnhubConfig(Enabled: true, ApiKey: "cfg-finnhub-key"),
+                        Fred: new FredConfig(Enabled: true, ApiKey: "cfg-fred-key")))),
+            resolver);
+
+        var first = factory.CreateBackfillProviders();
+        var second = factory.CreateBackfillProviders();
+
+        first.Select(p => p.Name).Should().Equal(second.Select(p => p.Name),
+            "backfill provider ordering should remain deterministic for parity/backfill planning");
+        first.Should().ContainSingle(p => p is YahooFinanceHistoricalDataProvider);
+        first.Should().ContainSingle(p => p is NasdaqDataLinkHistoricalDataProvider);
+        first.Should().ContainSingle(p => p is StooqHistoricalDataProvider);
+        first.Should().ContainSingle(p => p is TiingoHistoricalDataProvider);
+        first.Should().ContainSingle(p => p is AlphaVantageHistoricalDataProvider);
+        first.Should().ContainSingle(p => p is FinnhubHistoricalDataProvider);
+        first.Should().ContainSingle(p => p is FredHistoricalDataProvider);
     }
 
     [Fact]

--- a/tests/Meridian.Tests/SymbolSearch/SymbolSearchServiceTests.cs
+++ b/tests/Meridian.Tests/SymbolSearch/SymbolSearchServiceTests.cs
@@ -117,6 +117,39 @@ public class SymbolSearchServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task SearchAsync_DeduplicatesCaseAndWhitespaceVariants_ForStableProviderParity()
+    {
+        var providerA = new Mock<ISymbolSearchProvider>();
+        providerA.Setup(p => p.Name).Returns("openfigi");
+        providerA.Setup(p => p.Priority).Returns(1);
+        providerA.Setup(p => p.IsAvailableAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        providerA.Setup(p => p.SearchAsync("MSFT", It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new SymbolSearchResult("MSFT", "Microsoft Corp", "NASDAQ", "Equity", "US", "USD", "openfigi", 95)
+            ]);
+
+        var providerB = new Mock<ISymbolSearchProvider>();
+        providerB.Setup(p => p.Name).Returns("finnhub");
+        providerB.Setup(p => p.Priority).Returns(2);
+        providerB.Setup(p => p.IsAvailableAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        providerB.Setup(p => p.SearchAsync("MSFT", It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new SymbolSearchResult(" msft ", "Microsoft Corporation", "NASDAQ", "Stock", "US", "USD", "finnhub", 90)
+            ]);
+
+        _service = new SymbolSearchService(
+            [providerA.Object, providerB.Object],
+            null,
+            new MetadataEnrichmentService());
+
+        var result = await _service.SearchAsync(new SymbolSearchRequest(Query: "MSFT", Limit: 10));
+
+        result.Results.Should().HaveCount(1, "symbol casing/spacing variants should collapse to one deterministic result");
+        result.Results[0].Symbol.Should().Be("MSFT");
+        result.Results[0].Source.Should().Be("openfigi", "highest-score canonical row should win deterministic merge");
+    }
+
+    [Fact]
     public async Task SearchAsync_WithSpecificProvider_QueriesOnlyThatProvider()
     {
         // Arrange


### PR DESCRIPTION
### Motivation

- Reconcile claimed provider capabilities with deterministic data-shape compatibility for a set of providers (Finnhub, NYSE, Edgar, OpenFigi, YahooFinance, Tradier, TwelveData, AlphaVantage, Tiingo, Stooq, Fred, NasdaqDataLink) to avoid silent parity drift. 
- Add focused, targeted tests that guard deterministic provider inclusion/ordering for backfill and stable deduplication/merge semantics for symbol search so parity and backfill planning remain reproducible. 
- Record unresolved items with owners, risks, and defer rationales so the DK1/Wave 1 packet and operator review have explicit open work and accountability.

### Description

- Added a new audit section to `docs/status/provider-validation-matrix.md` titled "2026-05-20 capability-claim parity + deterministic data-shape audit" with per-provider posture, evidence anchors, and a table of unresolved items including owner, risk, and defer rationale. 
- Added `CreateBackfillProviders_WithConfiguredFreeProviderSet_IsDeterministicAndCapabilityAligned` to `tests/Meridian.Tests/Infrastructure/Providers/ProviderFactoryCredentialContextTests.cs` to validate deterministic provider ordering across repeated factory calls and capability-aligned inclusion for Yahoo/Nasdaq/Stooq/Tiingo/AlphaVantage/Finnhub/Fred. 
- Added `SearchAsync_DeduplicatesCaseAndWhitespaceVariants_ForStableProviderParity` to `tests/Meridian.Tests/SymbolSearch/SymbolSearchServiceTests.cs` to verify case/whitespace symbol variants collapse into a single canonical result and that the highest-score source wins. 
- Minor test import/usings adjusted to include `Stooq` and `YahooFinance` provider adapters used by the new tests.

### Testing

- Targeted test suite: `ProviderFactoryCredentialContextTests` and `SymbolSearchServiceTests` were prepared to be executed but were not run because the `dotnet` CLI is unavailable in this environment (execution blocked). 
- No automated test run completed in this environment, so the new tests have not yet been validated by CI here. 
- The changes include only test and documentation updates and therefore should be fast to validate once run in normal CI with `dotnet test` for the affected projects.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e3039fb3083209d7a88b01a46bd18)