### PR TITLE
[Follow-up to #1418] Prevent synthetic streaming timeout injections from terminating subscriptions

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/Synthetic/SyntheticMarketDataClient.cs
+++ b/src/Meridian.Infrastructure/Adapters/Synthetic/SyntheticMarketDataClient.cs
@@ -146,7 +146,15 @@ public sealed class SyntheticMarketDataClient : IMarketDataClient, ISymbolSearch
         {
             var now = DateTimeOffset.UtcNow;
             var anchor = ComputeAnchor(profile, now, seq);
-            await ApplyStreamingScenarioAsync(ct).ConfigureAwait(false);
+            try
+            {
+                await ApplyStreamingScenarioAsync(ct).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                await DelayAsync(delay, ct).ConfigureAwait(false);
+                continue;
+            }
             var price = ApplyDegradation(Round4(anchor * (1m + Noise(profile.Symbol, now.Millisecond, (int)seq, 0.0008m))));
             var size = 25L * (1 + (long)(PositiveNoise(profile.Symbol, now.Second, (int)seq + 11, 40m)));
             var trade = new Trade(
@@ -177,7 +185,15 @@ public sealed class SyntheticMarketDataClient : IMarketDataClient, ISymbolSearch
             var anchor = ComputeAnchor(profile, now, seq);
             var tick = Math.Max(0.0001m, anchor * 0.00005m);
             var spread = Math.Max(0.01m, Round4(anchor * (0.00008m + PositiveNoise(profile.Symbol, now.Second, (int)seq, 0.00006m))));
-            await ApplyStreamingScenarioAsync(ct).ConfigureAwait(false);
+            try
+            {
+                await ApplyStreamingScenarioAsync(ct).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                await DelayAsync(delay, ct).ConfigureAwait(false);
+                continue;
+            }
             var bestBid = ApplyDegradation(Round4(anchor - spread / 2m));
             var bestAsk = ApplyDegradation(Round4(anchor + spread / 2m));
             var bids = new List<OrderBookLevel>(levels);


### PR DESCRIPTION
### Motivation
- Fix a high-priority fault path where injected streaming timeouts could escape publish loops and fault subscription tasks, causing streams to stop permanently and disrupting teardown.

### Description
- Caught injected `TimeoutException` from `ApplyStreamingScenarioAsync` inside both `PublishTradesAsync` and `PublishDepthAsync` loops in `src/Meridian.Infrastructure/Adapters/Synthetic/SyntheticMarketDataClient.cs` so the exception no longer faults the subscription task.
- On injected timeout the loops now wait one normal publish cadence via `await DelayAsync(delay, ct).ConfigureAwait(false)` and `continue` the loop to resume streaming.
- This change keeps deterministic timeout injection behavior for tests while preserving subscription task liveness and reliable `DisconnectAsync`/`CancelSubscriptionsAsync` teardown.

### Testing
- Attempted a targeted test run with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~SyntheticMarketDataProviderTests|FullyQualifiedName~SyntheticHistoricalProviderContractTests" --logger "console;verbosity=minimal"` but the environment lacks the .NET SDK (`/bin/bash: dotnet: command not found`).
- No automated tests executed here due to the runtime limitation; the fix is localized and intended to pass the existing test suite in normal CI/local `dotnet test` runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e383923c483209a49d91bb896b86c)