### PR TITLE
Handle injected synthetic streaming timeouts without faulting subscriptions

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/Synthetic/SyntheticMarketDataClient.cs
+++ b/src/Meridian.Infrastructure/Adapters/Synthetic/SyntheticMarketDataClient.cs
@@ -146,7 +146,15 @@ public sealed class SyntheticMarketDataClient : IMarketDataClient, ISymbolSearch
         {
             var now = DateTimeOffset.UtcNow;
             var anchor = ComputeAnchor(profile, now, seq);
-            await ApplyStreamingScenarioAsync(ct).ConfigureAwait(false);
+            try
+            {
+                await ApplyStreamingScenarioAsync(ct).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                await DelayAsync(delay, ct).ConfigureAwait(false);
+                continue;
+            }
             var price = ApplyDegradation(Round4(anchor * (1m + Noise(profile.Symbol, now.Millisecond, (int)seq, 0.0008m))));
             var size = 25L * (1 + (long)(PositiveNoise(profile.Symbol, now.Second, (int)seq + 11, 40m)));
             var trade = new Trade(
@@ -177,7 +185,15 @@ public sealed class SyntheticMarketDataClient : IMarketDataClient, ISymbolSearch
             var anchor = ComputeAnchor(profile, now, seq);
             var tick = Math.Max(0.0001m, anchor * 0.00005m);
             var spread = Math.Max(0.01m, Round4(anchor * (0.00008m + PositiveNoise(profile.Symbol, now.Second, (int)seq, 0.00006m))));
-            await ApplyStreamingScenarioAsync(ct).ConfigureAwait(false);
+            try
+            {
+                await ApplyStreamingScenarioAsync(ct).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                await DelayAsync(delay, ct).ConfigureAwait(false);
+                continue;
+            }
             var bestBid = ApplyDegradation(Round4(anchor - spread / 2m));
             var bestAsk = ApplyDegradation(Round4(anchor + spread / 2m));
             var bids = new List<OrderBookLevel>(levels);


### PR DESCRIPTION
### Motivation
- Prevent deterministic timeout injections in the synthetic provider from propagating out of the publish loops and permanently faulting subscription tasks, which caused streaming to stop and disrupted clean disconnect/teardown paths.

### Description
- Updated streaming publish loops in `src/Meridian.Infrastructure/Adapters/Synthetic/SyntheticMarketDataClient.cs` to catch injected `TimeoutException` thrown by `ApplyStreamingScenarioAsync` in both `PublishTradesAsync` and `PublishDepthAsync`.
- On injected timeout the loop now awaits the normal cadence delay (`DelayAsync(delay, ct)`) and `continue`s instead of letting the exception escape and fault the task.
- This preserves deterministic timeout behavior while keeping subscriptions alive and ensuring graceful shutdown during `DisconnectAsync`/`CancelSubscriptionsAsync`.

### Testing
- Attempted a focused test run with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~SyntheticMarketDataProviderTests" --logger "console;verbosity=minimal"`, but execution failed in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`), so automated test verification could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e384cb5a48320934c61cfe15e00cb)