### PR TITLE
Follow-up: preserve fixed-income submit metadata while blocking routing aliases

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
@@ -1066,10 +1066,8 @@ public static class ExecutionEndpoints
             return false;
         }
 
-        return metadata.Keys.Any(static key => key.Equals("asset_class", StringComparison.OrdinalIgnoreCase)
-            || key.Equals("assetClass", StringComparison.OrdinalIgnoreCase)
+        return metadata.Keys.Any(static key => key.Equals("assetClass", StringComparison.OrdinalIgnoreCase)
             || key.Equals("alpaca:asset_class", StringComparison.OrdinalIgnoreCase)
-            || key.Equals("broker_account_id", StringComparison.OrdinalIgnoreCase)
             || key.Equals("brokerAccountId", StringComparison.OrdinalIgnoreCase)
             || key.Equals("account_id", StringComparison.OrdinalIgnoreCase)
             || key.Equals("accountId", StringComparison.OrdinalIgnoreCase)

--- a/tests/Meridian.Tests/Ui/ExecutionGovernanceEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/ExecutionGovernanceEndpointsTests.cs
@@ -343,7 +343,7 @@ public sealed class ExecutionGovernanceEndpointsTests
     }
 
     [Fact]
-    public async Task SubmitOrder_WithRestrictedBrokerRoutingMetadata_ReturnsBadRequest()
+    public async Task SubmitOrder_WithRestrictedBrokerRoutingMetadataAlias_ReturnsBadRequest()
     {
         var tempRoot = CreateTempRoot();
         await using var app = await CreateAppAsync(services =>
@@ -369,7 +369,7 @@ public sealed class ExecutionGovernanceEndpointsTests
             quantity = 1,
             metadata = new Dictionary<string, string>
             {
-                ["broker_account_id"] = "acct-123"
+                ["brokerAccountId"] = "acct-123"
             }
         }));
 


### PR DESCRIPTION
### Motivation
- A recent hardening change blocked `asset_class` and `broker_account_id` in incoming order `metadata`, which unintentionally caused fixed-income submissions to be rejected at the endpoint before OMS validation. 
- The endpoint must continue to block client-controlled routing aliases while preserving canonical fixed-income fields relied on by the Alpaca gateway.

### Description
- Update `ContainsRestrictedBrokerRoutingMetadata` in `src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs` to stop treating canonical keys `asset_class` and `broker_account_id` as restricted while still detecting alias keys. 
- Continue blocking alias/alternate routing keys including `assetClass`, `alpaca:asset_class`, `brokerAccountId`, `account_id`, `accountId`, and `alpaca:broker_account_id`. 
- Adjust the focused endpoint test in `tests/Meridian.Tests/Ui/ExecutionGovernanceEndpointsTests.cs` to rename the test to `SubmitOrder_WithRestrictedBrokerRoutingMetadataAlias_ReturnsBadRequest` and assert rejection on the blocked alias key (`brokerAccountId`) instead of the canonical key. 
- Preserve the `ManageOrders` permission gate on `POST /api/execution/orders/submit` so submit authorization behavior remains unchanged.

### Testing
- Updated unit test `SubmitOrder_WithRestrictedBrokerRoutingMetadataAlias_ReturnsBadRequest` and the existing `SubmitOrder_WithoutManageOrdersPermission_ReturnsForbidden` are included in the patch and validate alias rejection and permission gating. 
- Attempted a focused test run with `dotnet test --filter "FullyQualifiedName~ExecutionGovernanceEndpointsTests"`, but the environment could not run `dotnet` (`dotnet: command not found`) so tests were not executed locally. 
- Recommend CI run the full `dotnet test` matrix to validate the changes end-to-end and ensure fixed-income submits reach OMS as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e25f49fbc8320b22273c947e96b71)