### PR TITLE
Harden governed operations-continuity endpoint authorization

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -544,7 +544,7 @@ public static partial class WorkstationEndpoints
             OperationsSecurityMasterOverrideApprovalRequestDto? request,
             HttpContext context) =>
         {
-            if (!HasReconciliationMutationPermission(context))
+            if (!HasSecurityMasterOverrideApprovalPermission(context))
             {
                 return EndpointHelpers.Forbidden();
             }
@@ -880,7 +880,7 @@ public static partial class WorkstationEndpoints
             OperationsReopenWorkflowRequestDto? request,
             HttpContext context) =>
         {
-            if (!HasReconciliationMutationPermission(context))
+            if (!HasGovernedWorkflowReopenPermission(context))
             {
                 return EndpointHelpers.Forbidden();
             }
@@ -901,7 +901,7 @@ public static partial class WorkstationEndpoints
                 return Results.Problem("Operations continuity workflow service is not registered.", statusCode: StatusCodes.Status501NotImplemented);
             }
 
-            var trustedRequest = request with { Actor = currentUser };
+            var trustedRequest = request with { Actor = currentUser, IsGovernedAdmin = HasGovernedWorkflowReopenPermission(context) };
             var result = await service.ReopenWorkflowAsync(workflowId, trustedRequest, context.RequestAborted).ConfigureAwait(false);
             return OperationsTransitionResult(result, jsonOptions);
         })
@@ -5556,6 +5556,15 @@ public static partial class WorkstationEndpoints
             UserPermission.AdminMaintenance,
             UserPermission.ManageDirectLending,
             UserPermission.ModifySecurityMaster);
+
+    private static bool HasSecurityMasterOverrideApprovalPermission(HttpContext context)
+        => EndpointAuthorization.HasAnyPermission(
+            context,
+            UserPermission.AdminMaintenance,
+            UserPermission.ModifySecurityMaster);
+
+    private static bool HasGovernedWorkflowReopenPermission(HttpContext context)
+        => EndpointAuthorization.HasPermission(context, UserPermission.AdminMaintenance);
 
     private static bool TryResolveCurrentUser(HttpContext context, out string currentUser)
         => EndpointAuthorization.TryResolveActor(context, out currentUser);

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -294,6 +294,49 @@ public sealed class WorkstationEndpointsTests
     }
 
     [Fact]
+    public async Task MapWorkstationEndpoints_OperationsContinuityReopenRoute_ShouldRequireGovernedAdminPermission()
+    {
+        await using var app = await CreateAppAsync(
+            RegisterOperationsContinuityServices,
+            currentUserPermissions: UserPermission.ManageDirectLending);
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/workstation/operations/continuity/{Guid.NewGuid()}/reopen",
+            new OperationsReopenWorkflowRequestDto(
+                1,
+                "spoofed-user",
+                "Reopen workflow",
+                "incident-123",
+                IsGovernedAdmin: true),
+            ServerJsonOptions);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_OperationsContinuitySecurityMasterOverrideApprovalRoute_ShouldRequireOverrideApprovalPermission()
+    {
+        await using var app = await CreateAppAsync(
+            RegisterOperationsContinuityServices,
+            currentUserPermissions: UserPermission.ManageDirectLending);
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/workstation/operations/continuity/{Guid.NewGuid()}/security-master/overrides/override-1/approve",
+            new OperationsSecurityMasterOverrideApprovalRequestDto(
+                1,
+                "spoofed-user",
+                "override-1",
+                "approve override",
+                "policy-1",
+                DateTimeOffset.UtcNow.AddDays(1)),
+            ServerJsonOptions);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
     public async Task MapWorkstationEndpoints_OperationsContinuityCommandRoutes_ShouldAdvanceToClosed()
     {
         await using var app = await CreateAppAsync(RegisterOperationsContinuityServices);


### PR DESCRIPTION
### Motivation
- Fix an authorization bypass where governed actions (workflow reopen and Security Master override approval) trusted client-supplied governance flags and accepted a broad reconciliation mutation permission that allowed non-admin users to perform governed operations. 
- Enforce server-side governance checks and tighter permission requirements to preserve separation-of-duties for financial close and override approval flows.

### Description
- Replaced broad guards for two governed endpoints in `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` so they require dedicated permissions: reopen now requires `AdminMaintenance`, and Security Master override approval requires `AdminMaintenance` or `ModifySecurityMaster` instead of accepting `ManageDirectLending`.
- Stopped trusting the client-controlled `IsGovernedAdmin` for reopen by forcing that value from the server-side permission evaluation (`IsGovernedAdmin = HasGovernedWorkflowReopenPermission(context)`) before dispatching to the workflow service.
- Added helper methods `HasSecurityMasterOverrideApprovalPermission` and `HasGovernedWorkflowReopenPermission` and left other reconciliation mutation guards unchanged for non-governed transitions.
- Added regression tests under `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` to assert that a session holding only `UserPermission.ManageDirectLending` receives `403 Forbidden` for both the reopen and override-approval routes (`MapWorkstationEndpoints_OperationsContinuityReopenRoute_ShouldRequireGovernedAdminPermission` and `MapWorkstationEndpoints_OperationsContinuitySecurityMasterOverrideApprovalRoute_ShouldRequireOverrideApprovalPermission`).

### Testing
- New unit tests were added: `MapWorkstationEndpoints_OperationsContinuityReopenRoute_ShouldRequireGovernedAdminPermission` and `MapWorkstationEndpoints_OperationsContinuitySecurityMasterOverrideApprovalRoute_ShouldRequireOverrideApprovalPermission` (not executed due to environment constraint).
- Attempted to run the targeted tests via `dotnet test ...` but the environment lacks the .NET SDK so the test run failed with `dotnet: command not found` and could not be executed here.
- The change is minimal and targeted to endpoint authorization plumbing and test coverage; CI or a local dev machine with the .NET SDK should be used to run the added tests and full test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d44c80f7c8320b3fc70a48c066aa1)