### PR TITLE
Harden Security Master mutation endpoint authorization

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
@@ -139,9 +139,14 @@ public static class SecurityMasterEndpoints
         /// </remarks>
         group.MapPost(UiApiRoutes.SecurityMasterCreate, async (
             CreateSecurityRequest request,
+            HttpContext context,
             [FromServices] ISecurityMasterService service,
             CancellationToken ct) =>
         {
+            var authorizationResult = RequireSecurityMasterMutationPermission(context);
+            if (authorizationResult is not null)
+                return authorizationResult;
+
             var detail = await service.CreateAsync(request, ct).ConfigureAwait(false);
             return Results.Json(detail, jsonOptions, statusCode: StatusCodes.Status201Created);
         })
@@ -158,9 +163,14 @@ public static class SecurityMasterEndpoints
         /// </remarks>
         group.MapPost(UiApiRoutes.SecurityMasterAmend, async (
             AmendSecurityTermsRequest request,
+            HttpContext context,
             [FromServices] ISecurityMasterService service,
             CancellationToken ct) =>
         {
+            var authorizationResult = RequireSecurityMasterMutationPermission(context);
+            if (authorizationResult is not null)
+                return authorizationResult;
+
             var detail = await service.AmendTermsAsync(request, ct).ConfigureAwait(false);
             return Results.Json(detail, jsonOptions);
         })
@@ -177,9 +187,14 @@ public static class SecurityMasterEndpoints
         /// </remarks>
         group.MapPost(UiApiRoutes.SecurityMasterDeactivate, async (
             DeactivateSecurityRequest request,
+            HttpContext context,
             [FromServices] ISecurityMasterService service,
             CancellationToken ct) =>
         {
+            var authorizationResult = RequireSecurityMasterMutationPermission(context);
+            if (authorizationResult is not null)
+                return authorizationResult;
+
             await service.DeactivateAsync(request, ct).ConfigureAwait(false);
             return Results.NoContent();
         })
@@ -196,9 +211,14 @@ public static class SecurityMasterEndpoints
         /// </remarks>
         group.MapPost(UiApiRoutes.SecurityMasterAliasesUpsert, async (
             UpsertSecurityAliasRequest request,
+            HttpContext context,
             [FromServices] ISecurityMasterService service,
             CancellationToken ct) =>
         {
+            var authorizationResult = RequireSecurityMasterMutationPermission(context);
+            if (authorizationResult is not null)
+                return authorizationResult;
+
             var alias = await service.UpsertAliasAsync(request, ct).ConfigureAwait(false);
             return Results.Json(alias, jsonOptions);
         })
@@ -472,6 +492,16 @@ public static class SecurityMasterEndpoints
         .WithName("PatchSecurityPreferredTerms")
         .Produces<SecurityDetailDto>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status404NotFound);
+    }
+
+    private static IResult? RequireSecurityMasterMutationPermission(HttpContext context)
+    {
+        if (context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] is not UserPermission permissions)
+            return Results.Unauthorized();
+
+        return (permissions & UserPermission.ModifySecurityMaster) != UserPermission.ModifySecurityMaster
+            ? Results.Forbid()
+            : null;
     }
 
     private static SecurityMasterIngestStatusResponse ToIngestStatusResponse(


### PR DESCRIPTION
### Motivation
- Several Security Master mutation endpoints (create, amend, deactivate, alias upsert) were mapped directly to `ISecurityMasterService` without endpoint-level authorization and therefore allowed any valid session to perform privileged reference-data changes and to supply audit actor fields. 
- The intent of this change is to restrict those mutation routes to principals that hold the `UserPermission.ModifySecurityMaster` permission while preserving existing behavior for authorized callers.

### Description
- Added an endpoint-level guard helper `RequireSecurityMasterMutationPermission(HttpContext)` that checks `context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey]` and enforces `UserPermission.ModifySecurityMaster`, returning `401` when no permission context is present and `403` when the permission is insufficient. 
- Applied the guard to the Security Master mutation routes for `CreateSecurityRequest`, `AmendSecurityTermsRequest`, `DeactivateSecurityRequest`, and `UpsertSecurityAliasRequest` by accepting `HttpContext` and invoking the helper before calling service methods. 
- Kept query and non-privileged endpoints unchanged; only tightened authorization on the four sensitive mutation endpoints. 
- File changed: `src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs`.

### Testing
- Attempted to run the focused UI tests with `dotnet test tests/Meridian.Ui.Tests/Meridian.Ui.Tests.csproj --filter "FullyQualifiedName~SecurityMaster"`, but the environment lacks the `dotnet` SDK and the command failed with `/bin/bash: dotnet: command not found`.
- Performed targeted static inspection (`rg`/file review) to verify the mutation endpoints now call the permission guard and that non-mutating routes were left intact, and this inspection validated the intended changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ece8b2288320af0eae8e91bbaeef)