### PR TITLE
Fix stack overflow in analysis export file-stem helper

### DIFF
--- a/src/Meridian.Ui.Services/Services/AnalysisExportWizardService.cs
+++ b/src/Meridian.Ui.Services/Services/AnalysisExportWizardService.cs
@@ -898,7 +898,7 @@ public sealed class AnalysisExportWizardService
 
     internal static string CreateUniqueFileStem(string symbol)
     {
-        var safeStem = CreateUniqueFileStem(symbol);
+        var safeStem = CreateSafeFileStem(symbol);
         var normalizedSymbol = symbol.Trim();
         var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(normalizedSymbol));
         var suffix = Convert.ToHexString(hashBytes, 0, 4).ToLowerInvariant();


### PR DESCRIPTION
### Motivation
- Prevent a `StackOverflowException` during export filename generation caused by `CreateUniqueFileStem` recursively calling itself, which made CSV/SQL/Parquet export flows and a unit test fatal.

### Description
- Replace the recursive call with `CreateSafeFileStem(symbol)` in `AnalysisExportWizardService.CreateUniqueFileStem` so the helper returns a sanitized stem plus a stable 4-byte hex hash suffix, preserving filename-disambiguation behavior.

### Testing
- Attempted to run the focused unit tests with `dotnet test tests/Meridian.Ui.Tests/Meridian.Ui.Tests.csproj --filter "FullyQualifiedName~CreateUniqueFileStem_ShouldDisambiguateSymbolsWithSameSafeStem|FullyQualifiedName~ExportToSqlAsync_ShouldReturnGeneratedSidecarScript"`, but execution failed due to the environment missing the .NET SDK (`dotnet: command not found`), so automated tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb889d2c7083208bfc48df0c6587ac)