### PR TITLE
Add tooling metadata integrity gate to Maintenance workflow

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -14,6 +14,10 @@ on:
       - "Directory.Packages.props"
       - "NuGet.config"
       - "global.json"
+      - ".github/dependabot.yml"
+      - "package.json"
+      - "Makefile"
+      - "make/*.mk"
   push:
     branches:
       - main
@@ -29,6 +33,10 @@ on:
       - "Directory.Packages.props"
       - "NuGet.config"
       - "global.json"
+      - ".github/dependabot.yml"
+      - "package.json"
+      - "Makefile"
+      - "make/*.mk"
   schedule:
     - cron: "20 10 * * 1"
   workflow_dispatch:
@@ -59,6 +67,9 @@ jobs:
 
       - name: Run Meridian workflow hygiene checks
         run: python3 build/scripts/ci/check-workflow-hygiene.py
+
+      - name: Verify tooling metadata integrity
+        run: python3 build/scripts/validate-tooling-metadata.py
 
       - name: Validate workflow syntax with actionlint
         uses: rhysd/actionlint@v1.7.12

--- a/docs/developer/build-test-run.md
+++ b/docs/developer/build-test-run.md
@@ -64,6 +64,16 @@ npm --prefix src/Meridian.Ui/dashboard run test
 npm --prefix src/Meridian.Ui/dashboard run build
 ```
 
+The `Maintenance` workflow also enforces a **metadata integrity gate** for tooling manifests via:
+
+```bash
+python3 build/scripts/validate-tooling-metadata.py
+```
+
+PR branch protection should require the `Maintenance / Workflow Hygiene` check so dependency and
+tooling metadata changes (including `.github/dependabot.yml`, `package.json`, `Makefile`, and
+`make/*.mk`) cannot merge without this validation.
+
 The `Windows Desktop Build` workflow mirrors a Windows-only WPF build and test pass:
 
 ```powershell
@@ -108,4 +118,3 @@ python3 build/scripts/docs/scan-todos.py --json-output docs/status/todo-scan-res
 python3 build/scripts/docs/validate-todo-registry.py --scan-json docs/status/todo-scan-results.json --registry docs/source/todo-registry.json --enforce-prefix docs/source/
 python3 build/scripts/docs/check-ai-contract-drift.py --canonical docs/ai/contract-policy.json --mirror docs/ai/copilot/contract-policy.mirror.json --mirror docs/ai/claude/contract-policy.mirror.json
 ```
-


### PR DESCRIPTION
### Motivation

- Ensure changes to dependency and tooling manifests are validated before they can merge by adding an explicit metadata integrity gate. 
- Trigger the gate on edits to tooling-related files so accidental or malicious metadata drift is caught early. 
- Encourage branch protection to require the `Maintenance / Workflow Hygiene` check as the metadata integrity gate for PRs.

### Description

- Added a `Verify tooling metadata integrity` step that runs `python3 build/scripts/validate-tooling-metadata.py` to the `workflow-hygiene` job in `.github/workflows/maintenance.yml`.
- Expanded the `pull_request` and `push` `paths` in `.github/workflows/maintenance.yml` to explicitly include `.github/dependabot.yml`, `package.json`, `Makefile`, and `make/*.mk`.
- Documented the new metadata integrity gate in `docs/developer/build-test-run.md` and recommended that branch protection require the `Maintenance / Workflow Hygiene` check.

### Testing

- Executed `python3 build/scripts/validate-tooling-metadata.py` locally and it passed with `Tooling metadata validation passed.`.
- No changes were made to the existing CI test matrix, so current CI behavior and test coverage are unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e43bd1bc4832084c39d812cd177bb)