### PR TITLE
Add canonical Make lanes (bootstrap / verify-*) and lane-vocabulary guard

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,6 +9,17 @@ automation outside the current build/test/publish scope.
 
 ## Active Workflows
 
+## Canonical lane mapping
+
+| Lane | Workflow alignment |
+| --- | --- |
+| `bootstrap` | Local-only lane (`make bootstrap`); no dedicated hosted workflow. |
+| `verify-fast` | `CI` (`ci.yml`) and browser workstation job names reference this lane. |
+| `verify-full` | Local-only broad lane (`make verify-full`) used before PR when needed. |
+| `verify-docs` | `CI` source-doc determinism job plus local docs checks. |
+| `verify-desktop` | `Windows Desktop Build` (`windows-desktop-build.yml`). |
+| `verify-release` | `Publish Smoke` (`publish-smoke.yml`). |
+
 | Workflow | File | Trigger | Purpose | Artifacts |
 | --- | --- | --- | --- | --- |
 | CI | `ci.yml` | Pull requests, pushes to `main`, manual | Restores `Meridian.sln`, verifies formatting, builds the focused `Meridian.WebWorkstation.slnf` lane, runs non-integration .NET tests, then tests and builds `src/Meridian.Ui/dashboard`. | .NET TRX results on failure |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   dotnet:
-    name: Restore, Build, Test
+    name: verify-fast (restore/build/test)
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -81,6 +81,10 @@ jobs:
         run: |
           python3 build/scripts/docs/check-ai-contract-drift.py --canonical docs/ai/contract-policy.json --mirror docs/ai/copilot/contract-policy.mirror.json --mirror docs/ai/claude/contract-policy.mirror.json
 
+      - name: Validate lane vocabulary
+        run: |
+          python3 build/scripts/docs/check-known-lanes.py
+
       - name: Upload .NET test results
         if: failure()
         uses: actions/upload-artifact@v7.0.1
@@ -108,7 +112,7 @@ jobs:
           GITLEAKS_CONFIG: .gitleaks.toml
 
   browser-workstation:
-    name: Browser Workstation
+    name: verify-fast (browser workstation)
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
@@ -135,7 +139,7 @@ jobs:
         run: npm --prefix src/Meridian.Ui/dashboard run build
 
   source-doc-determinism:
-    name: Source Docs Determinism
+    name: verify-docs (source docs determinism)
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/publish-smoke.yml
+++ b/.github/workflows/publish-smoke.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   publish:
-    name: Publish ${{ inputs.project }} ${{ inputs.runtime }}
+    name: verify-release (publish ${{ inputs.project }} ${{ inputs.runtime }})
     runs-on: windows-latest
     timeout-minutes: 60
 

--- a/.github/workflows/windows-desktop-build.yml
+++ b/.github/workflows/windows-desktop-build.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   desktop:
-    name: Build and Test WPF
+    name: verify-desktop (build/test WPF)
     runs-on: windows-latest
     timeout-minutes: 55
 

--- a/README.md
+++ b/README.md
@@ -202,10 +202,28 @@ Manual fallback:
 dotnet run --project src/Meridian.Wpf/Meridian.Wpf.csproj /p:EnableFullWpfBuild=true
 ```
 
+
+### Canonical validation lanes
+
+| Lane | Use when | Maps to |
+| --- | --- | --- |
+| `bootstrap` | Setting up a fresh or repaired local dev environment. | `make setup-dev` |
+| `verify-fast` | Pre-commit or tight-loop validation for most code changes. | `make pre-pr` |
+| `verify-full` | Pre-PR broad validation and coverage collection. | `make pre-pr-full` |
+| `verify-docs` | Changing docs, workflow docs, AI/TODO governance references, or lane vocabulary. | `make docs-lint`, `make check-workflow-docs-parity`, `make check-status-delivery-claims`, `python3 build/scripts/docs/check-known-lanes.py` |
+| `verify-desktop` | Touching retained WPF desktop shell, routing, or shared contracts that need desktop confidence. | `make desktop-build`, `make desktop-test` |
+| `verify-release` | Validating publish outputs or release packaging paths. | `make publish` |
+
 ### Makefile shortcuts
 
 ```bash
 make help           # List all task targets
+make bootstrap      # Canonical lane: local bootstrap
+make verify-fast    # Canonical lane: fast validation
+make verify-full    # Canonical lane: full validation + coverage
+make verify-docs    # Canonical lane: docs/workflow/lane checks
+make verify-desktop # Canonical lane: retained desktop validation
+make verify-release # Canonical lane: publish validation
 make build-quick    # Shared restore-once, sequential Debug build
 npm run ui:dashboard:test   # Web workstation Vitest suite
 npm run ui:dashboard:build  # Web workstation production build

--- a/build/scripts/docs/check-known-lanes.py
+++ b/build/scripts/docs/check-known-lanes.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Fail when lane-matrix docs reference unknown lane names."""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+KNOWN = {
+    "bootstrap",
+    "verify-fast",
+    "verify-full",
+    "verify-docs",
+    "verify-desktop",
+    "verify-release",
+}
+
+FILES = [
+    pathlib.Path("README.md"),
+    pathlib.Path("docs/developer/build-test-run.md"),
+    pathlib.Path(".github/workflows/README.md"),
+]
+
+pattern = re.compile(r"\|\s*`([a-z][a-z-]+)`\s*\|")
+unknown: list[tuple[str, str]] = []
+for file_path in FILES:
+    text = file_path.read_text(encoding="utf-8")
+    for lane in pattern.findall(text):
+        if lane.startswith("verify-") or lane == "bootstrap":
+            if lane not in KNOWN:
+                unknown.append((str(file_path), lane))
+
+if unknown:
+    print("Unknown lane name(s) found in lane matrices:", file=sys.stderr)
+    for file_path, lane in unknown:
+        print(f"  - {lane} ({file_path})", file=sys.stderr)
+    print("Known lanes: " + ", ".join(sorted(KNOWN)), file=sys.stderr)
+    sys.exit(1)
+
+print("Known lane name check passed.")

--- a/docs/developer/build-test-run.md
+++ b/docs/developer/build-test-run.md
@@ -6,6 +6,17 @@
 
 Use the narrowest command that covers your change.
 
+## Canonical lane matrix
+
+| Lane | Use when | Maps to |
+| --- | --- | --- |
+| `bootstrap` | Initial setup, machine drift recovery, or local environment refresh. | `make setup-dev` |
+| `verify-fast` | Most day-to-day validation before pushing commits. | `make pre-pr` |
+| `verify-full` | Broad confidence checks before requesting review. | `make pre-pr-full` |
+| `verify-docs` | Docs/workflow-doc updates and lane-vocabulary drift checks. | `make docs-lint`, `make check-workflow-docs-parity`, `make check-status-delivery-claims`, `python3 build/scripts/docs/check-known-lanes.py` |
+| `verify-desktop` | Retained desktop shell changes or shared-contract checks needing WPF confidence. | `make desktop-build`, `make desktop-test` |
+| `verify-release` | Publish smoke and release packaging validation work. | `make publish` |
+
 ## Build
 
 ```powershell

--- a/make/build.mk
+++ b/make/build.mk
@@ -2,7 +2,8 @@
 # Build, Run, Format, Watch & Publish
 # =============================================================================
 
-.PHONY: build build-quick build-web-workstation run run-backfill run-selftest \
+.PHONY: bootstrap verify-fast verify-full verify-release \
+        build build-quick build-web-workstation run run-backfill run-selftest \
         lint format format-check \
         watch watch-build \
         install-hooks setup-dev \
@@ -19,6 +20,14 @@ build-quick: build-web-workstation ## Fast incremental build for the active brow
 
 build-web-workstation: ## Fast isolated browser workstation host build (Debug, no apphost)
 	@python3 build/python/cli/buildctl.py build --project Meridian.WebWorkstation.slnf --configuration Debug --verbosity quiet --isolation-key web-workstation-dev --property UseAppHost=false
+
+bootstrap: setup-dev ## Canonical lane: bootstrap local development prerequisites and quick validation
+
+verify-fast: pre-pr ## Canonical lane: format + fast unit checks
+
+verify-full: pre-pr-full ## Canonical lane: full pre-PR validation with coverage
+
+verify-release: publish ## Canonical lane: release publish validation across supported platforms
 
 run: setup-config ## Run the collector
 	@echo "$(BLUE)Running collector...$(NC)"

--- a/make/desktop.mk
+++ b/make/desktop.mk
@@ -5,7 +5,9 @@
 # The WPF project requires Windows or EnableWindowsTargeting=true.
 # See: src/Meridian.Wpf/README.md and docs/development/wpf-implementation-notes.md
 
-.PHONY: desktop-build desktop-test desktop-test-position-blotter-route desktop-test-operator-inbox-route
+.PHONY: verify-desktop desktop-build desktop-test desktop-test-position-blotter-route desktop-test-operator-inbox-route
+
+verify-desktop: desktop-build desktop-test ## Canonical lane: retained desktop build and test validation
 
 desktop-build: ## Build the WPF desktop project (requires Windows or EnableWindowsTargeting)
 	@echo "$(BLUE)Building Meridian.Wpf...$(NC)"

--- a/make/docs.mk
+++ b/make/docs.mk
@@ -2,12 +2,16 @@
 # Documentation
 # =============================================================================
 
-.PHONY: docs gen-context verify-adrs verify-contracts verify-tooling-metadata \
+.PHONY: verify-docs docs gen-context verify-adrs verify-contracts verify-tooling-metadata \
         gen-interfaces gen-structure gen-providers gen-workflows gen-workflow-manifest \
         update-claude-md docs-all check-workflow-docs-parity check-status-delivery-claims
 
 docs: gen-context verify-adrs gen-workflow-manifest ## Generate all documentation from code
 	@echo "$(GREEN)Documentation generated and verified$(NC)"
+
+verify-docs: docs-lint check-workflow-docs-parity check-status-delivery-claims ## Canonical lane: docs command, workflow, and status-claim validation
+	@python3 build/scripts/docs/check-known-lanes.py
+	@echo "$(GREEN)Documentation lane verification complete$(NC)"
 
 gen-context: ## Generate project-context.md from code annotations
 	@echo "$(BLUE)Generating project context from code...$(NC)"


### PR DESCRIPTION
### Motivation

- Standardize developer verification lanes so maintainers and CI use a shared vocabulary for common validation flows. 
- Avoid duplicating command logic by mapping new canonical lane names to existing Make targets. 
- Ensure docs and workflow matrices stay in sync by failing early when unknown lane names appear in documentation. 

### Description

- Added canonical lane aliases in Make: `bootstrap`, `verify-fast`, `verify-full`, and `verify-release` in `make/build.mk`, `verify-docs` in `make/docs.mk`, and `verify-desktop` in `make/desktop.mk`, each mapped to existing targets (e.g., `bootstrap` -> `make setup-dev`).
- Created a lightweight lane-vocabulary checker `build/scripts/docs/check-known-lanes.py` that scans key docs/workflow README files for unknown lane names and exits non-zero on mismatches. 
- Wired the lane check into the `verify-docs` Make lane and added a `Validate lane vocabulary` step in the CI job to run the check during hosted CI. 
- Updated workflow job names and documentation to reference the canonical lanes and added concise lane matrices in `README.md` and `docs/developer/build-test-run.md` describing when to use each lane. 

### Testing

- Ran `python3 build/scripts/docs/check-known-lanes.py` which printed `Known lane name check passed.` (success). 
- Executed a dry-run of the canonical lanes with `make -n bootstrap verify-fast verify-full verify-docs verify-desktop verify-release` to confirm mapped targets (dry-run succeeded). 
- Ran `make verify-docs` to exercise the docs pipeline; it surfaced pre-existing `check-workflow-docs-parity` hard-fail issues unrelated to the lane changes, causing `make verify-docs` to fail (see `artifacts/docs/workflow-docs-parity-report.md` for details).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e43bc02488320a8b7d6b203cabd4c)