### PR TITLE
docs: source workflow inventory from generated manifest and add CI parity check

### DIFF
--- a/build/scripts/ci/check-workflow-hygiene.py
+++ b/build/scripts/ci/check-workflow-hygiene.py
@@ -31,6 +31,7 @@ ACTIVE_DOC_ROOTS = [
     REPO_ROOT / "docs" / "developer",
     REPO_ROOT / "docs" / "development",
 ]
+WORKFLOW_MANIFEST_PATH = REPO_ROOT / "docs" / "status" / "workflow-manifest.json"
 
 OLD_WORKFLOW_FILENAMES = {
     "benchmark.yml",
@@ -158,6 +159,49 @@ def check_no_committed_generated_artifacts(failures: list[str]) -> None:
             fail(f"Generated diagnostic artifact is tracked: {tracked}", failures)
 
 
+def check_no_manual_workflow_counts_in_docs(failures: list[str]) -> None:
+    scoped_roots = [
+        REPO_ROOT / "README.md",
+        REPO_ROOT / "docs" / "developer",
+        REPO_ROOT / "docs" / "development",
+    ]
+
+    banned_patterns = [
+        re.compile(r"\b(?:one|two|three|four|five|six|seven|eight|nine|ten|\d+)\s+workflows?\b", re.IGNORECASE),
+        re.compile(r"\bactive\s+lanes?\b", re.IGNORECASE),
+    ]
+    allowlist_substrings = {
+        "docs/status/workflow-manifest.json",
+        "docs/generated/workflow-command-reference.md",
+        "docs/status/workflow-validation-summary.json",
+    }
+
+    for path in iter_text_files(scoped_roots):
+        if path.suffix.lower() != ".md":
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for pattern in banned_patterns:
+            for match in pattern.finditer(text):
+                line_start = text.rfind("\n", 0, match.start()) + 1
+                line_end = text.find("\n", match.end())
+                if line_end == -1:
+                    line_end = len(text)
+                line = text[line_start:line_end]
+                if any(token in line for token in allowlist_substrings):
+                    continue
+                fail(
+                    f"{path.relative_to(REPO_ROOT)} contains manual workflow inventory wording ('{match.group(0)}'). "
+                    "Reference docs/status/workflow-manifest.json and generated workflow artifacts instead.",
+                    failures,
+                )
+                break
+
+
+def check_workflow_manifest_exists(failures: list[str]) -> None:
+    if not WORKFLOW_MANIFEST_PATH.exists():
+        fail("Missing canonical workflow manifest at docs/status/workflow-manifest.json.", failures)
+
+
 def main() -> int:
     failures: list[str] = []
 
@@ -167,6 +211,8 @@ def main() -> int:
     check_active_docs_do_not_reference_removed_workflows(failures)
     check_no_stale_absolute_paths(failures)
     check_no_committed_generated_artifacts(failures)
+    check_workflow_manifest_exists(failures)
+    check_no_manual_workflow_counts_in_docs(failures)
 
     if failures:
         print("Workflow hygiene checks failed:", file=sys.stderr)

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -93,7 +93,7 @@ For a broader docs map, return to the main [docs index](../README.md).
 
 Some topics in this folder have deeper source material outside `docs/development/`:
 
-- [`.github/workflows/README.md`](https://github.com/rodoHasArrived/Meridian-main/blob/main/.github/workflows/README.md) is the authoritative workflow inventory referenced by the GitHub Actions summary.
+- [`docs/status/workflow-manifest.json`](../status/workflow-manifest.json), [`docs/generated/workflow-command-reference.md`](../generated/workflow-command-reference.md), and [`docs/status/workflow-validation-summary.json`](../status/workflow-validation-summary.json) are the canonical workflow inventory source of truth surfaces referenced by the GitHub Actions summary.
 - [`build/scripts/docs/README.md`](https://github.com/rodoHasArrived/Meridian-main/blob/main/build/scripts/docs/README.md) is the script-level companion to the documentation automation guides.
 - [`scripts/dev/`](https://github.com/rodoHasArrived/Meridian-main/tree/main/scripts/dev) contains the PowerShell runners and workflow catalogs referenced by the desktop workflow guides.
 

--- a/docs/development/documentation-automation.md
+++ b/docs/development/documentation-automation.md
@@ -450,6 +450,23 @@ Documentation rules are defined in `build/rules/doc-rules.yaml`. See [Adding Cus
 
 All generated files include an "auto-generated" notice and should not be edited manually.
 
+## Canonical Workflow Inventory Source Of Truth
+
+Use the workflow-manifest artifacts below as the only authoritative workflow inventory.
+Do not hard-code explicit numeric workflow totals in docs under
+`README.md`, `docs/developer/`, or `docs/development/`.
+
+1. `docs/status/workflow-manifest.json` — canonical declared workflow inventory.
+2. `docs/generated/workflow-command-reference.md` — generated human-readable workflow command reference.
+3. `docs/status/workflow-validation-summary.json` — generated machine-readable validation summary, including `workflowCount`.
+4. `docs/status/workflow-drift-report.md` — generated drift surface for missing declared targets/scripts.
+
+When workflow inventory changes:
+
+- Update `docs/status/workflow-manifest.json`.
+- Run `python3 build/scripts/docs/generate-workflow-manifest.py`.
+- Reference generated artifacts in docs instead of restating workflow counts manually.
+
 ## Troubleshooting
 
 ### Workflow skipped all jobs

--- a/docs/development/github-actions-summary.md
+++ b/docs/development/github-actions-summary.md
@@ -3,9 +3,13 @@
 **Status:** Active
 **Reviewed:** 2026-05-18
 
-The Meridian Actions surface is now four workflows aligned to the current .NET 10
-solution, browser workstation, retained WPF desktop shell, and publish smoke needs.
-The detailed workflow reference lives in `.github/workflows/README.md`.
+The Meridian Actions surface is documented from the generated workflow inventory
+artifacts instead of hand-maintained counts. Use the generated command and
+validation outputs as the source of truth:
+
+- `docs/status/workflow-manifest.json` (canonical workflow manifest)
+- `docs/generated/workflow-command-reference.md` (generated workflow list + commands)
+- `docs/status/workflow-validation-summary.json` (machine-readable inventory summary)
 
 | Workflow | File | Trigger | Purpose |
 | --- | --- | --- | --- |
@@ -48,5 +52,6 @@ pwsh ./build/scripts/publish/publish.ps1 -Platform win-x64 -Project web-workstat
 
 The previous workflow set included overlapping PR, test-matrix, quality, nightly,
 release, documentation, Docker, benchmark, issue-management, AI, and generated-artifact
-workflows. Useful build/test/publish logic was merged into the four active lanes above.
+workflows. Useful build/test/publish logic was merged into the current generated
+workflow inventory described by the canonical manifest and generated outputs above.
 Externally deploying or mutating jobs were removed from the active workflow surface.


### PR DESCRIPTION
### Motivation

- Treat generated workflow artifacts as the single source of truth and stop embedding hard-coded workflow counts/names in docs.
- Prevent future drift by making CI fail when manual workflow counts or inventory wording are introduced.
- Make it easy for contributors to find and regenerate authoritative workflow documentation.

### Description

- Updated `docs/development/github-actions-summary.md` to remove hard-coded workflow-total language and point to generated artifacts (`docs/status/workflow-manifest.json`, `docs/generated/workflow-command-reference.md`, `docs/status/workflow-validation-summary.json`).
- Updated `docs/development/README.md` to reference the canonical manifest-generated workflow surfaces instead of manual inventory wording.
- Added a Canonical Workflow Inventory Source Of Truth section to `docs/development/documentation-automation.md` documenting the manifest->generate flow and recommended update steps.
- Extended `build/scripts/ci/check-workflow-hygiene.py` to require the presence of `docs/status/workflow-manifest.json` and to add `check_no_manual_workflow_counts_in_docs`, which scans `README.md`, `docs/developer/`, and `docs/development/` for banned manual-inventory phrasing (numeric workflow counts / “active lanes”) while allowing references to the generated artifacts.

### Testing

- Ran `python3 build/scripts/ci/check-workflow-hygiene.py`; the new parity guard exercised successfully and flagged a manual-count wording instance which was fixed in this change.
- The hygiene script also reported unrelated action-version mismatches in workflow YAML (pre-existing), which are outside the scope of this PR and remain to be addressed separately.
- No generated workflow manifest files were edited manually as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e43baedfc832091727ce500e6941f)