### PR TITLE
Validate tooling metadata across modular Makefiles

### DIFF
--- a/build/scripts/validate-tooling-metadata.py
+++ b/build/scripts/validate-tooling-metadata.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PACKAGE_JSON = REPO_ROOT / "package.json"
-MAKEFILE = REPO_ROOT / "Makefile"
+MAKEFILES = [REPO_ROOT / "Makefile", *sorted((REPO_ROOT / "make").glob("*.mk"))]
 DEPENDABOT = REPO_ROOT / ".github" / "dependabot.yml"
 
 
@@ -31,10 +31,15 @@ def load_package_paths() -> list[str]:
     return paths
 
 
-def load_makefile_paths() -> list[str]:
-    text = MAKEFILE.read_text()
-    matches = re.findall(r"(?:^|[\s@])(node|python3)\s+([^\s\\]+)", text, flags=re.MULTILINE)
-    return [path for _tool, path in matches if "/" in path and not path.startswith("$(")]
+def load_makefile_paths() -> list[tuple[str, str]]:
+    paths: list[tuple[str, str]] = []
+    for makefile in MAKEFILES:
+        text = makefile.read_text()
+        matches = re.findall(r"(?:^|[\s@])(node|python3)\s+([^\s\\]+)", text, flags=re.MULTILINE)
+        for _tool, path in matches:
+            if "/" in path and not path.startswith("$("):
+                paths.append((makefile.relative_to(REPO_ROOT).as_posix(), path))
+    return paths
 
 
 def load_dependabot_directories() -> list[str]:
@@ -61,7 +66,8 @@ def validate_paths(paths: list[str], label: str, expect_dir: bool = False) -> li
 def main() -> int:
     errors: list[str] = []
     errors.extend(validate_paths(load_package_paths(), "package.json scripts"))
-    errors.extend(validate_paths(load_makefile_paths(), "Makefile command"))
+    for source, rel_path in load_makefile_paths():
+        errors.extend(validate_paths([rel_path], f"Makefile command ({source})"))
     errors.extend(validate_paths(load_dependabot_directories(), ".github/dependabot.yml", expect_dir=True))
 
     if errors:

--- a/tests/scripts/test_validate_tooling_metadata.py
+++ b/tests/scripts/test_validate_tooling_metadata.py
@@ -1,0 +1,28 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "build" / "scripts" / "validate-tooling-metadata.py"
+
+spec = importlib.util.spec_from_file_location("validate_tooling_metadata", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class ValidateToolingMetadataTests(unittest.TestCase):
+    def test_load_makefile_paths_scans_root_and_modular_makefiles(self) -> None:
+        paths = module.load_makefile_paths()
+
+        self.assertTrue(any(source == "Makefile" for source, _ in paths))
+        self.assertTrue(any(source.startswith("make/") for source, _ in paths))
+        self.assertIn(
+            ("make/docs.mk", "build/scripts/validate-tooling-metadata.py"),
+            paths,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Ensure hard-coded helper paths referenced in modular Makefiles do not drift by validating both the root `Makefile` and `make/*.mk` files.
- Improve diagnostics by reporting which Makefile a missing path came from so maintainers can fix the correct source quickly.

### Description
- Replace single `MAKEFILE` with `MAKEFILES = [REPO_ROOT / "Makefile", *sorted((REPO_ROOT / "make").glob("*.mk"))]` and scan them all. 
- Change `load_makefile_paths()` to return `(source_makefile, path)` tuples and reuse the existing node/python regex against each file. 
- Annotate validation errors as `Makefile command (<source-file>)` while leaving `package.json` and Dependabot checks unchanged. 
- Add `tests/scripts/test_validate_tooling_metadata.py` to assert that both the root `Makefile` and modular `make/*.mk` (including `make/docs.mk`) are scanned.

### Testing
- Ran `python3 -m unittest tests/scripts/test_validate_tooling_metadata.py`, which passed. 
- Ran the repository preflight `make verify-tooling-metadata`, which reported `Tooling metadata validation passed.` and succeeded. 
- The single CI/local preflight command remains `make verify-tooling-metadata`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e43b9c29c8320881a8e9f7a68b5d3)