### PR TITLE
Add docs Make targets for npm-based icon and diagram generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ help: ## Show this help message
 	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | grep -E 'run|build|test|clean|bench|lint|watch|setup-dev|format' | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(GREEN)%-18s$(NC) %s\n", $$1, $$2}'
 	@echo ""
 	@echo "$(BLUE)Documentation:$(NC)"
-	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | grep -E 'docs|verify-adr|verify-contract|verify-tooling-metadata|gen-context|gen-interface|gen-structure|gen-provider|gen-workflow|update-claude' | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(GREEN)%-18s$(NC) %s\n", $$1, $$2}'
+	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | grep -E 'docs|verify-adr|verify-contract|verify-tooling-metadata|gen-context|gen-interface|gen-structure|gen-provider|gen-workflow|update-claude|generate-icons|generate-diagrams' | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(GREEN)%-18s$(NC) %s\n", $$1, $$2}'
 	@echo ""
 	@echo "$(BLUE)Publishing:$(NC)"
 	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | grep -E 'publish' | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(GREEN)%-18s$(NC) %s\n", $$1, $$2}'

--- a/docs/diagrams/uml/README.md
+++ b/docs/diagrams/uml/README.md
@@ -76,7 +76,7 @@ The repository includes `.github/workflows/update-diagrams.yml` to keep committe
 - Push to `main` that modifies any of:
   - `docs/diagrams/uml/*.puml` — PlantUML source edits
   - `docs/diagrams/**/*.dot` — Graphviz DOT source edits
-  - `scripts/generate-diagrams.mjs` or `scripts/lib/ui-diagram-generator.mjs` — generator script edits
+  - `npm run generate-diagrams` (which invokes the canonical package script) — generator updates
   - `src/Meridian.Wpf/**/*.xaml` or `src/Meridian.Wpf/**/*.cs` — WPF source changes that affect UI diagrams
 - Manually via **Actions → Update Diagram Artifacts**
 

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -9,5 +9,5 @@ evidence.
 
 For scripted capture workflows, see
 [docs/development/desktop-workflow-automation.md](../development/desktop-workflow-automation.md)
-and `scripts/dev/capture-web-screenshots.mjs`.
+and `npm run screenshots` from `src/Meridian.Ui/dashboard`.
 

--- a/make/docs.mk
+++ b/make/docs.mk
@@ -4,7 +4,7 @@
 
 .PHONY: docs gen-context verify-adrs verify-contracts verify-tooling-metadata \
         gen-interfaces gen-structure gen-providers gen-workflows gen-workflow-manifest \
-        update-claude-md docs-all check-workflow-docs-parity check-status-delivery-claims
+        update-claude-md docs-all check-workflow-docs-parity check-status-delivery-claims generate-icons generate-diagrams
 
 docs: gen-context verify-adrs gen-workflow-manifest ## Generate all documentation from code
 	@echo "$(GREEN)Documentation generated and verified$(NC)"
@@ -76,6 +76,12 @@ update-claude-md: gen-structure ## Update CLAUDE.md repository structure
 		--claude-md CLAUDE.md \
 		--structure-source docs/generated/repository-structure.md
 	@echo "$(GREEN)Updated CLAUDE.md$(NC)"
+
+generate-icons: ## Generate documentation icon assets via npm script
+	@npm run generate-icons
+
+generate-diagrams: ## Generate documentation diagrams via npm script
+	@npm run generate-diagrams
 
 docs-lint: ## Validate documented make/pwsh command snippets resolve to real targets/scripts
 	@python3 build/scripts/docs/lint-command-snippets.py


### PR DESCRIPTION
### Motivation
- Standardize documentation build entrypoints on the canonical `package.json` scripts instead of calling `node path/to/script.mjs` from Makefiles.
- Provide explicit `make` targets so CI and local workflows can invoke icon/diagram generation consistently via `npm run` wrappers.
- Keep command examples in docs consistent with the canonical automation API expected by local and CI users.

### Description
- Added `generate-icons` and `generate-diagrams` targets to `make/docs.mk` that invoke `npm run generate-icons` and `npm run generate-diagrams` respectively, and added both targets to the file's `.PHONY` list.
- Updated the `Makefile` help grouping filter so `make help` lists `generate-icons` and `generate-diagrams` under the Documentation section.
- Replaced direct-script command references in docs so examples use `npm run screenshots` and `npm run generate-diagrams` instead of hard-coded `scripts/*.mjs` paths, updating `docs/screenshots/README.md` and `docs/diagrams/uml/README.md`. 
- Left `package.json` script names unchanged and treated them as the canonical API for local/CI automation.

### Testing
- Ran `make help` and verified both `generate-icons` and `generate-diagrams` appear in the Documentation group (success). 
- Performed repository search checks to confirm updated doc references and committed the intended file changes (verified via `git status` / commit output).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e43b8111483209fbfa02176ea1e7f)