### PR TITLE
Restore missing README front-matter extraction helper

### DIFF
--- a/tools/source_docs/validate_source_readmes.py
+++ b/tools/source_docs/validate_source_readmes.py
@@ -82,6 +82,13 @@ def validate_file(path: Path) -> int:
     print(f"{path} passed enum validation")
     return 0
 
+
+def _extract_front_matter(text: str) -> tuple[dict[str, Any], str]:
+    if yaml is None:
+        raise ReadmeContractError("PyYAML is required for README front matter validation")
+    if not text.startswith("---\n"):
+        raise ReadmeContractError("front matter opening marker '---' is missing")
+
     closing = text.find("\n---\n", 4)
     if closing == -1:
         raise ReadmeContractError("front matter closing marker '---' is missing")


### PR DESCRIPTION
### Motivation
- The README validator crashed because `_extract_front_matter()` was undefined after front-matter parsing code was accidentally left unreachable inside `validate_file()`.

### Description
- Move the front-matter parsing logic into a standalone function `def _extract_front_matter(text: str) -> tuple[dict[str, Any], str]` in `tools/source_docs/validate_source_readmes.py`, add explicit checks for missing `PyYAML` and the opening `---` marker, and keep `validate_file()` terminating at `return 0`.

### Testing
- Compiled the script with `python3 -m py_compile tools/source_docs/validate_source_readmes.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e45f670888320ad8e713a537592aa)