### PR TITLE
Align workflow action versions with maintenance hygiene policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5.0.0
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/roadmap-source-docs.yml
+++ b/.github/workflows/roadmap-source-docs.yml
@@ -21,7 +21,7 @@ jobs:
   scope-gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
       - name: Enforce phase scope
@@ -43,9 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: scope-gate
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.12'
       - name: Install renderer dependencies


### PR DESCRIPTION
### Motivation
- The `Workflow Hygiene` check rejected workflows that used older action versions than the repository policy defined in `.github/workflows/maintenance.yml`.
- Bring failing workflows into compliance by matching the action versions already approved in `maintenance.yml` to prevent CI failures.

### Description
- Update `ci.yml` to use `actions/setup-python@v6.2.0` replacing `@v5.0.0` for the `source-doc-determinism` job.
- Update `roadmap-source-docs.yml` to use `actions/checkout@v6.0.2` in both jobs replacing `@v4` references.
- Update `roadmap-source-docs.yml` to use `actions/setup-python@v6.2.0` replacing `@v5`.

### Testing
- Verified pre- and post-change action references with `rg --line-number "actions/setup-python@|actions/checkout@"` and confirmed the updated pins succeeded.
- Printed the affected workflow sections with `nl -ba` to inspect the applied changes and confirmed the new versions appear in the files.
- Created a commit with message `Align workflow action versions with hygiene policy`, and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4620a5e08320a9bb21d1cad776bb)