### PR TITLE
Integrate DK1 script unit tests into CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,11 @@ jobs:
           python3 scripts/check_status_delivery_claims.py
           python3 -m unittest tests/scripts/test_check_status_delivery_claims.py
 
+      - name: Validate provider-validation script tests
+        run: |
+          python3 -m unittest tests/scripts/test_generate_dk1_pilot_parity_packet.py
+          python3 -m unittest tests/scripts/test_prepare_dk1_operator_signoff.py
+
       - name: Validate TODO registry contract
         run: |
           python3 build/scripts/docs/scan-todos.py --json-output docs/status/todo-scan-results.json

--- a/.github/workflows/golden-path-validation.yml
+++ b/.github/workflows/golden-path-validation.yml
@@ -16,6 +16,8 @@ on:
       - "tests/Meridian.Tests/Application/Commands/LedgerCliCommandTests.cs"
       - "tests/Meridian.Tests/Integration/EndpointTests/PilotAcceptanceHarnessTests.cs"
       - "tests/scripts/test_golden_path_validation_workflow.py"
+      - "tests/scripts/test_generate_dk1_pilot_parity_packet.py"
+      - "tests/scripts/test_prepare_dk1_operator_signoff.py"
   push:
     branches:
       - main
@@ -33,6 +35,8 @@ on:
       - "tests/Meridian.Tests/Application/Commands/LedgerCliCommandTests.cs"
       - "tests/Meridian.Tests/Integration/EndpointTests/PilotAcceptanceHarnessTests.cs"
       - "tests/scripts/test_golden_path_validation_workflow.py"
+      - "tests/scripts/test_generate_dk1_pilot_parity_packet.py"
+      - "tests/scripts/test_prepare_dk1_operator_signoff.py"
   workflow_dispatch:
 
 permissions:
@@ -91,6 +95,11 @@ jobs:
 
       - name: Validate pilot readiness dashboard renderer
         run: python3 -m unittest build/scripts/docs/tests/test_pilot_readiness_dashboard.py
+
+      - name: Validate provider-validation script tests
+        run: |
+          python3 -m unittest tests/scripts/test_generate_dk1_pilot_parity_packet.py
+          python3 -m unittest tests/scripts/test_prepare_dk1_operator_signoff.py
 
       - name: Generate pilot readiness dashboard
         run: |


### PR DESCRIPTION
### Motivation
- Ensure the DK1 provider-validation script unit tests are executed by CI so changes to those scripts or tests are validated continuously.
- Surface regressions in `tests/scripts/test_generate_dk1_pilot_parity_packet.py` and `tests/scripts/test_prepare_dk1_operator_signoff.py` as part of existing verification lanes.

### Description
- Added a CI step to `.github/workflows/ci.yml` that runs `python3 -m unittest tests/scripts/test_generate_dk1_pilot_parity_packet.py` and `python3 -m unittest tests/scripts/test_prepare_dk1_operator_signoff.py`.
- Extended `.github/workflows/golden-path-validation.yml` path filters for both `pull_request` and `push` to include the two test files so changes to them trigger the golden-path workflow.
- Added a step to the `pilot-acceptance` job in `.github/workflows/golden-path-validation.yml` to execute the same two script tests as part of the pilot acceptance evidence lane.

### Testing
- Ran `python3 -m unittest tests/scripts/test_generate_dk1_pilot_parity_packet.py tests/scripts/test_prepare_dk1_operator_signoff.py` locally and the test run completed successfully (`OK`, with the existing tests skipped as expected).
- Modified workflows were committed and are ready to be exercised by CI; no CI failures were observed during the local validation step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4722cdbc832093055d3cd18d26b7)