### PR TITLE
Fix roadmap source docs validation metadata and module README coverage

### DIFF
--- a/docs/source/data/source-modules.yml
+++ b/docs/source/data/source-modules.yml
@@ -1,6 +1,6 @@
 schema_version: 1
 modules:
-  - module_id: meridian-host
+  - id: meridian-host
     name: Meridian Host
     layer: host
     priority_tier: priority
@@ -10,7 +10,7 @@ modules:
     architecture_boundary: composition-root-and-runtime-host
     roadmap_anchor: W2-paper-trading-cockpit
 
-  - module_id: meridian-application
+  - id: meridian-application
     name: Meridian Application
     layer: application
     priority_tier: priority
@@ -20,7 +20,7 @@ modules:
     architecture_boundary: orchestrators-commands-and-use-cases
     roadmap_anchor: W3-research-to-paper-continuity
 
-  - module_id: meridian-contracts
+  - id: meridian-contracts
     name: Meridian Contracts
     layer: contracts
     priority_tier: priority
@@ -30,7 +30,7 @@ modules:
     architecture_boundary: shared-dtos-and-transport-contracts
     roadmap_anchor: W3-research-to-paper-continuity
 
-  - module_id: meridian-ui-services
+  - id: meridian-ui-services
     name: Meridian UI Services
     layer: ui_services
     priority_tier: priority
@@ -40,7 +40,7 @@ modules:
     architecture_boundary: api-services-and-workstation-endpoints
     roadmap_anchor: W2-paper-trading-cockpit
 
-  - module_id: meridian-ui-shared
+  - id: meridian-ui-shared
     name: Meridian UI Shared
     layer: ui_shared
     priority_tier: priority
@@ -50,7 +50,7 @@ modules:
     architecture_boundary: shared-ui-read-models-and-contract-shims
     roadmap_anchor: W2-paper-trading-cockpit
 
-  - module_id: meridian-ui-dashboard
+  - id: meridian-ui-dashboard
     name: Meridian UI Dashboard
     layer: ui_dashboard
     priority_tier: priority
@@ -60,7 +60,7 @@ modules:
     architecture_boundary: browser-operator-workstation
     roadmap_anchor: W2-paper-trading-cockpit
 
-  - module_id: meridian-wpf-retained
+  - id: meridian-wpf-retained
     name: Meridian WPF (Retained Scope)
     layer: wpf_retained
     priority_tier: priority

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -1,0 +1,25 @@
+---
+id: meridian-application
+title: Meridian Application
+layer: application
+state: active
+canonical_path: src/Meridian.Application
+architecture_boundary: orchestrators-commands-and-use-cases
+roadmap_anchor: W3-research-to-paper-continuity
+---
+
+# Meridian Application
+
+## Purpose
+Application-layer use cases, orchestration services, and command handlers.
+
+## Responsibilities
+- Coordinate workflows across providers, storage, and execution subsystems.
+- Expose command and use-case entry points used by host and APIs.
+
+## Key dependencies
+- `src/Meridian.Contracts`
+- Infrastructure/provider abstractions consumed via interfaces.
+
+## Notes
+Keep orchestration here; avoid leaking transport/UI concerns into this layer.

--- a/src/Meridian.Contracts/README.md
+++ b/src/Meridian.Contracts/README.md
@@ -1,0 +1,25 @@
+---
+id: meridian-contracts
+title: Meridian Contracts
+layer: contracts
+state: active
+canonical_path: src/Meridian.Contracts
+architecture_boundary: shared-dtos-and-transport-contracts
+roadmap_anchor: W3-research-to-paper-continuity
+---
+
+# Meridian Contracts
+
+## Purpose
+Shared contracts and DTOs used across host, services, desktop, and dashboard surfaces.
+
+## Responsibilities
+- Define stable transport payloads and shared schema objects.
+- Provide compatibility-safe contracts for inter-module integration.
+
+## Key dependencies
+- Consumers in host, UI services, shared UI read models, and clients.
+- Serialization/runtime libraries required for DTO transport.
+
+## Notes
+Treat additive and breaking changes as cross-module compatibility work.

--- a/src/Meridian.Ui.Services/README.md
+++ b/src/Meridian.Ui.Services/README.md
@@ -1,0 +1,25 @@
+---
+id: meridian-ui-services
+title: Meridian UI Services
+layer: ui_services
+state: active
+canonical_path: src/Meridian.Ui.Services
+architecture_boundary: api-services-and-workstation-endpoints
+roadmap_anchor: W2-paper-trading-cockpit
+---
+
+# Meridian UI Services
+
+## Purpose
+Backend UI service endpoints and orchestrators for workstation-facing operator workflows.
+
+## Responsibilities
+- Serve workstation API endpoints and read-model projections.
+- Aggregate readiness, workflow, and operations data for UI consumption.
+
+## Key dependencies
+- `src/Meridian.Application`
+- `src/Meridian.Ui.Shared`
+
+## Notes
+Keep endpoint contracts aligned with shared UI models and compatibility gates.

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -1,0 +1,25 @@
+---
+id: meridian-ui-shared
+title: Meridian UI Shared
+layer: ui_shared
+state: active
+canonical_path: src/Meridian.Ui.Shared
+architecture_boundary: shared-ui-read-models-and-contract-shims
+roadmap_anchor: W2-paper-trading-cockpit
+---
+
+# Meridian UI Shared
+
+## Purpose
+Shared UI read models, compatibility shims, and cross-surface data structures.
+
+## Responsibilities
+- Define shared operator-facing projection types.
+- Support consistent dashboard and retained desktop data contracts.
+
+## Key dependencies
+- `src/Meridian.Contracts`
+- Consumers in `src/Meridian.Ui.Services`, `src/Meridian.Ui/dashboard`, and `src/Meridian.Wpf`
+
+## Notes
+Preserve cross-surface compatibility when evolving shared read models.

--- a/src/Meridian.Ui/dashboard/README.md
+++ b/src/Meridian.Ui/dashboard/README.md
@@ -1,0 +1,25 @@
+---
+id: meridian-ui-dashboard
+title: Meridian UI Dashboard
+layer: ui_dashboard
+state: active
+canonical_path: src/Meridian.Ui/dashboard
+architecture_boundary: browser-operator-workstation
+roadmap_anchor: W2-paper-trading-cockpit
+---
+
+# Meridian UI Dashboard
+
+## Purpose
+Browser-based operator workstation frontend for active web UI delivery.
+
+## Responsibilities
+- Render operator workflows and workstation experiences in the browser.
+- Consume UI services and shared read models for trading and operations surfaces.
+
+## Key dependencies
+- `src/Meridian.Ui.Services`
+- `src/Meridian.Ui.Shared`
+
+## Notes
+This is the active operator UI lane; keep shared contract parity with retained desktop.

--- a/src/Meridian.Wpf/README.md
+++ b/src/Meridian.Wpf/README.md
@@ -1,3 +1,13 @@
+---
+id: meridian-wpf-retained
+title: Meridian WPF (Retained Scope)
+layer: wpf_retained
+state: retained_support
+canonical_path: src/Meridian.Wpf
+architecture_boundary: retained-desktop-shell-and-compatibility
+roadmap_anchor: W4-governance-productization
+---
+
 # Meridian - WPF Desktop Application
 
 This is the WPF (.NET 10) desktop application for Meridian. It is the primary desktop operator shell and the main host for the workstation migration.

--- a/src/Meridian/README.md
+++ b/src/Meridian/README.md
@@ -1,0 +1,25 @@
+---
+id: meridian-host
+title: Meridian Host
+layer: host
+state: active
+canonical_path: src/Meridian
+architecture_boundary: composition-root-and-runtime-host
+roadmap_anchor: W2-paper-trading-cockpit
+---
+
+# Meridian Host
+
+## Purpose
+Composition root and runtime host for Meridian service startup and CLI entry points.
+
+## Responsibilities
+- Bootstrap dependency injection, configuration, and host lifetime.
+- Route CLI command execution and runtime hosting orchestration.
+
+## Key dependencies
+- `src/Meridian.Application`
+- `src/Meridian.Contracts`
+
+## Notes
+Keep startup orchestration and process-host concerns isolated from domain/application logic.


### PR DESCRIPTION
## Summary
- Renamed `module_id` to `id` for every module entry in `docs/source/data/source-modules.yml` to match validator expectations.
- Added missing module README files with validator-friendly YAML front matter and baseline module sections:
  - `src/Meridian/README.md`
  - `src/Meridian.Application/README.md`
  - `src/Meridian.Contracts/README.md`
  - `src/Meridian.Ui.Services/README.md`
  - `src/Meridian.Ui.Shared/README.md`
  - `src/Meridian.Ui/dashboard/README.md`
- Repaired `src/Meridian.Wpf/README.md` by prepending required front matter while preserving existing content.

## Why
The `roadmap-source-docs` workflow validation failed because:
1. `source-modules.yml` used `module_id` instead of required `id`.
2. Several `readme_path` targets did not exist.
3. `src/Meridian.Wpf/README.md` did not begin with a front matter opening marker (`---`).

## Notes
- This change is documentation/metadata only and does not alter runtime code paths.
- Per QA constraints, no build/test execution was performed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e481797d88320b2ba97c9c95a5045)