### PR TITLE
Fix OperationsWorkflowContractMatrix type closure in operations continuity DTOs

### DIFF
--- a/src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs
+++ b/src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs
@@ -250,6 +250,7 @@ public static class OperationsWorkflowContractMatrix
         "REPORT_PACK_NOT_READY",
         "APPROVAL_REQUIRED"
     };
+}
 
 [JsonConverter(typeof(JsonStringEnumConverter<OperationsIssueCodeDto>))]
 public enum OperationsIssueCodeDto : byte


### PR DESCRIPTION
### Motivation
- A missing closing brace left `OperationsIssueCodeDto` and subsequent declarations nested inside `OperationsWorkflowContractMatrix`, causing incorrect type scope and deviating from the file-scoped namespace style.

### Description
- Inserted a closing brace `}` immediately after the `IssueCodes` initializer in `src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs` so the `OperationsWorkflowContractMatrix` type is properly terminated and the following enum/record declarations are at namespace scope.

### Testing
- Ran a lightweight automated brace-balance check (`python3` lexer script) against `src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs`, which returned `brace balance OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e486b4828832090fdba67ee2f0905)