### PR TITLE
Add latest-run actionable invariants for operator inbox projections

### DIFF
--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -1970,7 +1970,7 @@ public sealed class WorkstationEndpointsTests
     }
 
     [Fact]
-    public async Task MapWorkstationEndpoints_OperatorInbox_ShouldIncludeOlderRunReviewPacketBlockersWhenLatestRunIsClean()
+    public async Task MapWorkstationEndpoints_OperatorInbox_ShouldEmitOnlyLatestRunActionableReviewPacketBlockers()
     {
         await using var app = await CreateAppAsync(services =>
         {
@@ -2001,7 +2001,30 @@ public sealed class WorkstationEndpointsTests
 
         inbox.Should().NotBeNull();
         inbox!.Items.Should().Contain(item =>
+            item.WorkItemId == $"promotion-review-{newestRunId.ToLowerInvariant()}" &&
+            item.Tone == OperatorWorkItemToneDto.Warning);
+        inbox.Items.Should().NotContain(item =>
             item.WorkItemId == $"promotion-review-{olderRunId.ToLowerInvariant()}");
+
+        var newestReviewPacket = await app
+            .GetTestClient()
+            .GetFromJsonAsync<StrategyRunReviewPacketDto>(
+                $"/api/workstation/runs/{newestRunId}/review-packet",
+                ServerJsonOptions);
+        var olderReviewPacket = await app
+            .GetTestClient()
+            .GetFromJsonAsync<StrategyRunReviewPacketDto>(
+                $"/api/workstation/runs/{olderRunId}/review-packet",
+                ServerJsonOptions);
+
+        newestReviewPacket.Should().NotBeNull();
+        olderReviewPacket.Should().NotBeNull();
+        newestReviewPacket!.WorkItems.Should().ContainSingle(item =>
+            item.WorkItemId == $"promotion-review-{newestRunId.ToLowerInvariant()}" &&
+            item.Tone == OperatorWorkItemToneDto.Warning);
+        olderReviewPacket!.WorkItems.Should().ContainSingle(item =>
+            item.WorkItemId == $"promotion-review-{olderRunId.ToLowerInvariant()}" &&
+            item.Tone == OperatorWorkItemToneDto.Warning);
     }
 
     [Fact]

--- a/tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs
@@ -831,6 +831,62 @@ public sealed class MainShellViewModelTests
     }
 
     [Fact]
+    public void OperatorInboxPresentation_FiltersToLatestRunActionableItemsOnly()
+    {
+        WpfTestThread.Run(async () =>
+        {
+            var latestRunId = "run-latest-actionable";
+            var historicalRunId = "run-historical-only";
+            var inbox = new OperatorInboxDto(
+                DateTimeOffset.UtcNow,
+                [
+                    new OperatorWorkItemDto(
+                        WorkItemId: $"promotion-review-{latestRunId}",
+                        Kind: OperatorWorkItemKindDto.PromotionReview,
+                        Label: "Latest run requires promotion review",
+                        Detail: "The newest run is waiting for operator approval.",
+                        Tone: OperatorWorkItemToneDto.Warning,
+                        CreatedAt: DateTimeOffset.UtcNow,
+                        RunId: latestRunId,
+                        TargetRoute: UiApiRoutes.WithParam(UiApiRoutes.RunsReviewPacket, "runId", latestRunId),
+                        TargetPageTag: "TradingShell"),
+                    new OperatorWorkItemDto(
+                        WorkItemId: $"promotion-history-{historicalRunId}",
+                        Kind: OperatorWorkItemKindDto.PromotionReview,
+                        Label: "Historical run review (history only)",
+                        Detail: "A prior run remains visible in review history.",
+                        Tone: OperatorWorkItemToneDto.Info,
+                        CreatedAt: DateTimeOffset.UtcNow.AddMinutes(-15),
+                        RunId: historicalRunId,
+                        TargetRoute: UiApiRoutes.WithParam(UiApiRoutes.RunsReviewPacket, "runId", historicalRunId),
+                        TargetPageTag: "TradingShell"),
+                    new OperatorWorkItemDto(
+                        WorkItemId: "promotion-review-informational-latest",
+                        Kind: OperatorWorkItemKindDto.PromotionReview,
+                        Label: "Informational-only advisory",
+                        Detail: "No action needed for this item.",
+                        Tone: OperatorWorkItemToneDto.Info,
+                        CreatedAt: DateTimeOffset.UtcNow,
+                        TargetPageTag: "TradingShell")
+                ],
+                CriticalCount: 0,
+                WarningCount: 1,
+                ReviewCount: 1,
+                Summary: "1 warning work item needs review.");
+            var inboxClient = new FakeOperatorInboxApiClient(inbox);
+
+            using var vm = CreateMainPageViewModel(operatorInboxClient: inboxClient);
+
+            await WaitForConditionAsync(() => vm.OperatorInboxReviewCount == 1);
+
+            vm.OperatorInboxButtonText.Should().Be("Queue (1)");
+            vm.OperatorInboxTone.Should().Be(WorkspaceTone.Warning);
+            vm.OperatorInboxPrimaryLabel.Should().Be("Latest run requires promotion review");
+            vm.OperatorInboxSummary.Should().NotContain("informational", StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    [Fact]
     public void OperatorInboxPresentation_WhenClientFails_DegradesToNotificationCenter()
     {
         WpfTestThread.Run(async () =>


### PR DESCRIPTION
### Motivation
- Ensure operator inbox aggregation only surfaces actionable latest-run blockers (warning/critical) while excluding informational/history-only noise.
- Guarantee historical blockers remain discoverable on per-run review-packet surfaces so run-history remains complete.
- Keep the WPF shell queue projection aligned with server inbox semantics to avoid UI/endpoint drift.

### Description
- Updated the endpoint test in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` to assert the inbox only contains the newest run's actionable review blocker and explicitly excludes the older run's promotion item, while still verifying both runs expose their blockers via `runs/{runId}/review-packet` (new test name: `MapWorkstationEndpoints_OperatorInbox_ShouldEmitOnlyLatestRunActionableReviewPacketBlockers`).
- Added a WPF view-model test `OperatorInboxPresentation_FiltersToLatestRunActionableItemsOnly` to `tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs` that injects mixed fixtures (actionable latest-run, historical info-only, informational advisory) and asserts the shell shows a single actionable latest-run item and omits informational text.
- Changes touch `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` and `tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs` and add assertions that mirror the inbox invariant across server and desktop surfaces.

### Testing
- Attempted to run the focused test with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~MapWorkstationEndpoints_OperatorInbox_ShouldEmitOnlyLatestRunActionableReviewPacketBlockers"`, but the environment lacks the `dotnet` runtime and the command failed (`dotnet: command not found`).
- No automated tests were executed successfully in this environment due to the missing `dotnet` toolchain.
- Local CI or a developer machine with .NET SDK available should run `dotnet test` (or `make test`) to validate the new assertions pass across the full test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4a57adf08320823ebe5642289763)