### PR TITLE
Add readiness contract matrix and WPF triage projection tests

### DIFF
--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -1687,6 +1687,23 @@ public sealed class WorkstationEndpointsTests
             readiness.WorkItems.Should().Contain(item =>
                 item.Kind == OperatorWorkItemKindDto.PromotionReview &&
                 item.Tone == OperatorWorkItemToneDto.Warning);
+
+            // Contract-level matrix for required readiness dimensions and deterministic critical-before-warning triage.
+            trustGate.TryGetProperty("status", out var trustGateStatus).Should().BeTrue();
+            trustGate.TryGetProperty("operatorSignoffStatus", out var trustGateSignoffStatus).Should().BeTrue();
+            trustGateStatus.ValueKind.Should().Be(JsonValueKind.String);
+            trustGateSignoffStatus.ValueKind.Should().Be(JsonValueKind.String);
+            promotion.TryGetProperty("approvalChecklist", out var promotionChecklist).Should().BeTrue();
+            promotionChecklist.ValueKind.Should().Be(JsonValueKind.Array);
+            root.TryGetProperty("activeSession", out var activeSession).Should().BeTrue();
+            activeSession.ValueKind.Should().Be(JsonValueKind.Object);
+            root.TryGetProperty("brokerageSync", out var brokerageSync).Should().BeTrue();
+            brokerageSync.ValueKind.Should().Be(JsonValueKind.Null);
+            var firstCritical = readiness.WorkItems.FindIndex(item => item.Tone == OperatorWorkItemToneDto.Critical);
+            var firstWarning = readiness.WorkItems.FindIndex(item => item.Tone == OperatorWorkItemToneDto.Warning);
+            firstCritical.Should().BeGreaterOrEqualTo(0);
+            firstWarning.Should().BeGreaterOrEqualTo(0);
+            firstCritical.Should().BeLessThan(firstWarning, "critical readiness blockers should be triaged before warning items");
         }
         finally
         {

--- a/tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs
@@ -831,6 +831,69 @@ public sealed class MainShellViewModelTests
     }
 
     [Fact]
+    public void OperatorInboxPresentation_AllClearScenario_RemainsActionableWithoutRunHistoryDuplication()
+    {
+        WpfTestThread.Run(async () =>
+        {
+            var inbox = new OperatorInboxDto(
+                DateTimeOffset.UtcNow,
+                [],
+                CriticalCount: 0,
+                WarningCount: 0,
+                ReviewCount: 0,
+                Summary: "No operator work items are open.");
+            var inboxClient = new FakeOperatorInboxApiClient(inbox);
+
+            using var vm = CreateMainPageViewModel(operatorInboxClient: inboxClient);
+
+            await WaitForConditionAsync(() => vm.OperatorInboxSummary.Contains("No operator work items", StringComparison.Ordinal));
+
+            vm.OperatorInboxButtonText.Should().Be("Queue");
+            vm.OperatorInboxSummary.Should().NotContain("run history", StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    [Fact]
+    public void OperatorInboxPresentation_MixedSeverityScenario_PrioritizesCriticalQueueItem()
+    {
+        WpfTestThread.Run(async () =>
+        {
+            var inbox = new OperatorInboxDto(
+                DateTimeOffset.UtcNow,
+                [
+                    new OperatorWorkItemDto(
+                        WorkItemId: "promotion-warning-1",
+                        Kind: OperatorWorkItemKindDto.PromotionReview,
+                        Label: "Promotion checklist review",
+                        Detail: "Review promotion checklist evidence.",
+                        Tone: OperatorWorkItemToneDto.Warning,
+                        CreatedAt: DateTimeOffset.UtcNow,
+                        TargetPageTag: "TradingShell"),
+                    new OperatorWorkItemDto(
+                        WorkItemId: "replay-critical-1",
+                        Kind: OperatorWorkItemKindDto.PaperReplay,
+                        Label: "Replay verification stale",
+                        Detail: "Session changed after replay audit.",
+                        Tone: OperatorWorkItemToneDto.Critical,
+                        CreatedAt: DateTimeOffset.UtcNow.AddSeconds(1),
+                        TargetPageTag: "TradingShell")
+                ],
+                CriticalCount: 1,
+                WarningCount: 1,
+                ReviewCount: 2,
+                Summary: "2 work items need review.");
+            var inboxClient = new FakeOperatorInboxApiClient(inbox);
+
+            using var vm = CreateMainPageViewModel(operatorInboxClient: inboxClient);
+
+            await WaitForConditionAsync(() => vm.OperatorInboxReviewCount == 2);
+
+            vm.OperatorInboxTone.Should().Be(WorkspaceTone.Danger);
+            vm.OperatorInboxPrimaryLabel.Should().Contain("Replay verification stale");
+        });
+    }
+
+    [Fact]
     public void OperatorInboxPresentation_WhenClientFails_DegradesToNotificationCenter()
     {
         WpfTestThread.Run(async () =>

--- a/tests/Meridian.Wpf.Tests/ViewModels/TradingWorkspaceShellViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/TradingWorkspaceShellViewModelTests.cs
@@ -280,6 +280,64 @@ public sealed class TradingWorkspaceShellViewModelTests
         actionId.Should().Be("NotificationCenter");
     }
 
+
+    [Fact]
+    public void BuildDeskHeroState_AllClearScenario_ProjectsReadyPostureWithoutQueueDuplication()
+    {
+        var readiness = CreateReadiness(
+            workItems: [],
+            overallStatus: TradingAcceptanceGateStatusDto.Ready,
+            readyForPaperOperation: true);
+
+        var hero = TradingWorkspaceShellPresentationService.BuildDeskHeroState(
+            activeRun: CreateActiveRun("paper-clear", "Clear Desk", "Paper"),
+            workflow: null,
+            readiness,
+            hasOperatingContext: true,
+            operatingContextDisplayName: "Clear Desk");
+
+        hero.BadgeText.Should().Be("Ready");
+        hero.FocusLabel.Should().Be("Paper oversight");
+        hero.Summary.Should().Contain("paper session");
+    }
+
+    [Fact]
+    public void BuildDeskHeroState_MixedSeverityScenario_PrioritizesCriticalQueuePosture()
+    {
+        var readiness = CreateReadiness(
+            workItems:
+            [
+                new OperatorWorkItemDto(
+                    WorkItemId: "promotion-warning-1",
+                    Kind: OperatorWorkItemKindDto.PromotionReview,
+                    Label: "Promotion checklist review",
+                    Detail: "Checklist evidence needs sign-off.",
+                    Tone: OperatorWorkItemToneDto.Warning,
+                    CreatedAt: new DateTimeOffset(2026, 4, 27, 17, 20, 0, TimeSpan.Zero),
+                    TargetPageTag: "TradingShell"),
+                new OperatorWorkItemDto(
+                    WorkItemId: "replay-critical-1",
+                    Kind: OperatorWorkItemKindDto.PaperReplay,
+                    Label: "Replay stale",
+                    Detail: "Replay verification is stale.",
+                    Tone: OperatorWorkItemToneDto.Critical,
+                    CreatedAt: new DateTimeOffset(2026, 4, 27, 17, 21, 0, TimeSpan.Zero),
+                    TargetPageTag: "TradingShell")
+            ],
+            overallStatus: TradingAcceptanceGateStatusDto.Blocked,
+            readyForPaperOperation: false);
+
+        var hero = TradingWorkspaceShellPresentationService.BuildDeskHeroState(
+            activeRun: CreateActiveRun("paper-mixed", "Mixed Desk", "Paper"),
+            workflow: null,
+            readiness,
+            hasOperatingContext: true,
+            operatingContextDisplayName: "Mixed Desk");
+
+        hero.FocusLabel.Should().Be("Readiness blocked");
+        hero.PrimaryActionId.Should().Be("FundAuditTrail");
+    }
+
     [Fact]
     public void ExecuteCommandAction_WithNoActiveRun_RaisesAccountPortfolioRequest()
     {


### PR DESCRIPTION
### Motivation
- Ensure the trading-readiness API contract explicitly exposes required readiness dimensions (promotion, checklist, session, replay, trust-gate signoff, brokerage sync, acceptance gates, execution controls, blockers) and that the serialized payload types are stable for UI clients. 
- Verify WPF consumer projection logic maps those readiness signals into hero/posture/queue text correctly and deterministically prioritizes critical work items over warnings. 
- Provide representative scenarios (all-clear and mixed-severity) to prevent inbox duplication with run-history and to validate triage behavior.

### Description
- Added contract-level assertions to `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` that verify JSON property presence and `JsonValueKind` for trust-gate signoff, promotion checklist, active session, and brokerage sync, and assert deterministic ordering that places `Critical` work items before `Warning` ones. 
- Added UI projection tests to `tests/Meridian.Wpf.Tests/ViewModels/TradingWorkspaceShellViewModelTests.cs` covering an `AllClear` scenario (projects ready hero posture) and a `MixedSeverity` scenario (ensures blocked/critical routing). 
- Added operator-inbox projection tests to `tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs` covering an `AllClear` inbox (actionable queue without run-history duplication) and a `MixedSeverity` inbox (critical-first queue posture and tone). 
- Kept changes scoped to tests only and exercised the same test builders/helpers already used by existing readiness and inbox tests.

### Testing
- Attempted to run the focused test command `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~MapWorkstationEndpoints_TradingReadiness_ShouldExposeRequiredContractFieldsAndDegradeWhenEvidenceIsMissing" --logger "console;verbosity=minimal"`, but the execution environment reported `dotnet: command not found`, so the automated test run could not complete. 
- No other CI/test runs were executed in this environment due to the missing `dotnet` runtime; tests should be validated in the normal CI or a developer machine with the .NET SDK installed using the same `dotnet test` filters described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4a56539c83209c3c6c299dbdaa85)