### PR TITLE
Add provider-aware route mapping for trading readiness work items

### DIFF
--- a/src/Meridian.Ui.Shared/Services/ProviderNavigationRouteMapper.cs
+++ b/src/Meridian.Ui.Shared/Services/ProviderNavigationRouteMapper.cs
@@ -1,0 +1,48 @@
+using System.Collections.ObjectModel;
+
+namespace Meridian.Ui.Shared.Services;
+
+internal static class ProviderNavigationRouteMapper
+{
+    private const string FallbackRoute = "/settings#provider-connection-center";
+
+    private static readonly IReadOnlyDictionary<string, string> CanonicalProviderByNormalizedId =
+        new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["alpaca"] = "alpaca",
+            ["ib"] = "ibkr",
+            ["ibkr"] = "ibkr",
+            ["interactivebrokers"] = "ibkr",
+            ["interactive-brokers"] = "ibkr",
+            ["stocksharp"] = "stocksharp",
+            ["ssharp"] = "stocksharp",
+            ["robinhood"] = "robinhood"
+        });
+
+    private static readonly IReadOnlyDictionary<string, string> RouteByCanonicalProvider =
+        new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["alpaca"] = "/settings#alpaca-provider-setup",
+            ["ibkr"] = "/settings#ibkr-provider-setup",
+            ["stocksharp"] = "/settings#stocksharp-provider-setup",
+            ["robinhood"] = "/settings#robinhood-provider-setup"
+        });
+
+    public static string ResolveProviderConnectionSettingsRoute(string? providerId)
+    {
+        if (string.IsNullOrWhiteSpace(providerId))
+        {
+            return FallbackRoute;
+        }
+
+        var normalizedProviderId = providerId.Trim().ToLowerInvariant();
+        if (!CanonicalProviderByNormalizedId.TryGetValue(normalizedProviderId, out var canonicalProvider))
+        {
+            return FallbackRoute;
+        }
+
+        return RouteByCanonicalProvider.TryGetValue(canonicalProvider, out var route)
+            ? route
+            : FallbackRoute;
+    }
+}

--- a/src/Meridian.Ui.Shared/Services/StrategyRunReviewPacketService.cs
+++ b/src/Meridian.Ui.Shared/Services/StrategyRunReviewPacketService.cs
@@ -253,7 +253,7 @@ public sealed class StrategyRunReviewPacketService
                 "FundReconciliation"),
             OperatorWorkItemKindDto.BrokerageSync => (
                 "Settings",
-                BuildProviderConnectionSettingsRoute(providerId),
+                ProviderNavigationRouteMapper.ResolveProviderConnectionSettingsRoute(providerId),
                 "ProviderConnectionCenter"),
             _ => (
                 "Trading",
@@ -262,19 +262,6 @@ public sealed class StrategyRunReviewPacketService
                     : UiApiRoutes.WithParam(UiApiRoutes.RunsReviewPacket, "runId", runId),
                 "TradingShell")
         };
-    }
-
-    private static string BuildProviderConnectionSettingsRoute(string? providerId)
-    {
-        if (string.IsNullOrWhiteSpace(providerId))
-        {
-            return "/settings#provider-connection-center";
-        }
-
-        var normalized = providerId.Trim().ToLowerInvariant();
-        return normalized == "alpaca"
-            ? "/settings#alpaca-provider-setup"
-            : $"/settings#provider-{normalized}-connection";
     }
 
     private static string BuildScopedId(string prefix, string scope)

--- a/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
@@ -389,7 +389,7 @@ public sealed class TradingOperatorReadinessService
             fundAccountId: brokerageStatus.FundAccountId,
             workItemId: BuildWorkItemId("brokerage-sync-attention", brokerageStatus.FundAccountId.ToString("N")),
             workspaceOverride: "Settings",
-            targetRouteOverride: BuildProviderConnectionSettingsRoute(brokerageStatus.ProviderId),
+            targetRouteOverride: ProviderNavigationRouteMapper.ResolveProviderConnectionSettingsRoute(brokerageStatus.ProviderId),
             targetPageTagOverride: "ProviderConnectionCenter");
     }
 
@@ -1799,7 +1799,7 @@ public sealed class TradingOperatorReadinessService
                 "TradingShell")
         };
 
-    private static string BuildProviderConnectionSettingsRoute(string? providerId)
+    private static string ProviderNavigationRouteMapper.ResolveProviderConnectionSettingsRoute(string? providerId)
     {
         if (string.IsNullOrWhiteSpace(providerId))
         {

--- a/tests/Meridian.Tests/Ui/TradingOperatorReadinessServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/TradingOperatorReadinessServiceTests.cs
@@ -567,4 +567,24 @@ public sealed class TradingOperatorReadinessServiceTests
                 $"{kind} route mapping is a compatibility contract for operator inbox deep-links");
         }
     }
+
+
+    [Theory]
+    [InlineData("alpaca", "/settings#alpaca-provider-setup")]
+    [InlineData("ALPACA", "/settings#alpaca-provider-setup")]
+    [InlineData("ib", "/settings#ibkr-provider-setup")]
+    [InlineData("ibkr", "/settings#ibkr-provider-setup")]
+    [InlineData("interactive-brokers", "/settings#ibkr-provider-setup")]
+    [InlineData("stocksharp", "/settings#stocksharp-provider-setup")]
+    [InlineData("robinhood", "/settings#robinhood-provider-setup")]
+    [InlineData("unknown-provider", "/settings#provider-connection-center")]
+    [InlineData("", "/settings#provider-connection-center")]
+    public void ProviderConnectionRouteMapper_ShouldResolveProviderAwareRoutesWithFallback(string providerId, string expectedRoute)
+    {
+        var route = ProviderNavigationRouteMapper.ResolveProviderConnectionSettingsRoute(providerId);
+
+        route.Should().Be(expectedRoute);
+    }
+
+
 }


### PR DESCRIPTION
### Motivation
- Remove Alpaca-only hard-coded route generation and make operator inbox deep-links provider-aware so work items point to the correct provider settings UI.
- Provide deterministic behavior for known provider aliases (alpaca, ib/ibkr/interactive-brokers, stocksharp, robinhood) and a safe fallback for unknown or empty provider IDs.
- Ensure acceptance-gate and brokerage-sync work items consistently include provider route metadata across readiness and review packet flows.

### Description
- Introduced `ProviderNavigationRouteMapper` with a canonical provider alias table and a `ResolveProviderConnectionSettingsRoute` helper that returns provider-specific routes or a fallback `"/settings#provider-connection-center"` when unknown. (`src/Meridian.Ui.Shared/Services/ProviderNavigationRouteMapper.cs`)
- Replaced in-place Alpaca-only route logic in `TradingOperatorReadinessService` with `ProviderNavigationRouteMapper.ResolveProviderConnectionSettingsRoute(...)` so brokerage-sync work items carry provider-aware `TargetRoute` metadata. (`src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs`)
- Replaced duplicate provider-route logic in `StrategyRunReviewPacketService` with the shared mapper to keep review-packet navigation aligned with readiness work items. (`src/Meridian.Ui.Shared/Services/StrategyRunReviewPacketService.cs`)
- Added focused tests to validate provider-resolve behavior and operator route mapping semantics by exercising `ProviderNavigationRouteMapper` resolution from the `TradingOperatorReadinessService` test suite. (`tests/Meridian.Tests/Ui/TradingOperatorReadinessServiceTests.cs`)

### Testing
- Added unit tests covering provider-route resolution and fallback semantics in `tests/Meridian.Tests/Ui/TradingOperatorReadinessServiceTests.cs`; these tests were committed with the change.
- Attempted to run the focused test slice with `dotnet test --filter "FullyQualifiedName~TradingOperatorReadinessServiceTests"`, but the test run failed in this environment because `dotnet` is not installed, so automated execution could not be completed here.
- No other automated tests were executed in this environment; the change is limited to routing logic and test files only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4a5391c8832083b175a587e45def)