### PR TITLE
Add additive strategy run portfolio drill-in aggregate API

### DIFF
--- a/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
+++ b/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
@@ -617,6 +617,21 @@ public sealed record RunCashFlowSummary(
     RunCashLadder Ladder);
 
 /// <summary>
+/// Composite portfolio drill-in payload that keeps attribution, drawdown, cash-flow, and trade slices
+/// aligned under one additive, versioned contract.
+/// </summary>
+public sealed record RunPortfolioDrillInSummary(
+    string SchemaVersion,
+    string RunId,
+    DateTimeOffset AsOf,
+    string Currency,
+    StrategyRunMode Mode,
+    RunAttributionSummary? Attribution,
+    EquityCurveSummary? DrawdownProfile,
+    RunCashFlowSummary? CashFlow,
+    RunFillSummary? Trades);
+
+/// <summary>
 /// Lightweight run identity used to connect research, trading, and governance flows.
 /// </summary>
 public sealed record StrategyRunContinuityLink(

--- a/src/Meridian.Strategies/Services/StrategyRunReadService.cs
+++ b/src/Meridian.Strategies/Services/StrategyRunReadService.cs
@@ -18,6 +18,7 @@ public sealed class StrategyRunReadService
     private readonly PortfolioReadService _portfolioReadService;
     private readonly LedgerReadService _ledgerReadService;
     private readonly IPromotionRecordStore? _promotionRecordStore;
+    private readonly CashFlowProjectionService? _cashFlowProjectionService;
 
     internal PortfolioReadService PortfolioReadService => _portfolioReadService;
     internal LedgerReadService LedgerReadService => _ledgerReadService;
@@ -26,12 +27,14 @@ public sealed class StrategyRunReadService
         IStrategyRepository repository,
         PortfolioReadService portfolioReadService,
         LedgerReadService ledgerReadService,
-        IPromotionRecordStore? promotionRecordStore = null)
+        IPromotionRecordStore? promotionRecordStore = null,
+        CashFlowProjectionService? cashFlowProjectionService = null)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _portfolioReadService = portfolioReadService ?? throw new ArgumentNullException(nameof(portfolioReadService));
         _ledgerReadService = ledgerReadService ?? throw new ArgumentNullException(nameof(ledgerReadService));
         _promotionRecordStore = promotionRecordStore;
+        _cashFlowProjectionService = cashFlowProjectionService;
     }
 
     public async Task<IReadOnlyList<StrategyRunSummary>> GetRunsAsync(
@@ -779,5 +782,53 @@ public sealed class StrategyRunReadService
             TotalUnrealizedPnl: bySymbol.Sum(static item => item.UnrealizedPnl),
             TotalCommissions: bySymbol.Sum(static item => item.Commissions),
             BySymbol: bySymbol);
+    }
+
+    /// <summary>
+    /// Returns a normalized, versioned portfolio drill-in aggregate for one run.
+    /// </summary>
+    public async Task<RunPortfolioDrillInSummary?> GetPortfolioDrillInAsync(string runId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runId);
+
+        var run = await _repository.GetRunByIdAsync(runId, ct).ConfigureAwait(false);
+        if (run is null)
+        {
+            return null;
+        }
+
+        var attributionTask = GetAttributionAsync(runId, ct);
+        var drawdownTask = GetEquityCurveAsync(runId, ct);
+        var tradeTask = GetFillsAsync(runId, ct);
+        var cashFlowTask = _cashFlowProjectionService?.GetAsync(runId, ct) ?? Task.FromResult<RunCashFlowSummary?>(null);
+
+        await Task.WhenAll(attributionTask, drawdownTask, tradeTask, cashFlowTask).ConfigureAwait(false);
+
+        var asOf = GetLastUpdatedAt(run);
+        var currency = ResolveCurrencyContext(run, await cashFlowTask.ConfigureAwait(false));
+
+        return new RunPortfolioDrillInSummary(
+            SchemaVersion: "v1",
+            RunId: run.RunId,
+            AsOf: asOf,
+            Currency: currency,
+            Mode: MapMode(run.RunType),
+            Attribution: await attributionTask.ConfigureAwait(false),
+            DrawdownProfile: await drawdownTask.ConfigureAwait(false),
+            CashFlow: await cashFlowTask.ConfigureAwait(false),
+            Trades: await tradeTask.ConfigureAwait(false));
+    }
+
+    private static string ResolveCurrencyContext(StrategyRunEntry run, RunCashFlowSummary? cashFlow)
+    {
+        if (!string.IsNullOrWhiteSpace(cashFlow?.Currency))
+        {
+            return cashFlow.Currency;
+        }
+
+        var firstFillCurrency = run.Metrics?.Fills
+            .FirstOrDefault(static fill => !string.IsNullOrWhiteSpace(fill.Currency))
+            ?.Currency;
+        return string.IsNullOrWhiteSpace(firstFillCurrency) ? "USD" : firstFillCurrency;
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a single, versioned drill-in payload that bundles attribution, drawdown, cash-flow, and trade slices for aligned workstation drill-ins.
- Ensure shared field normalization (`AsOf`, `RunId`, currency context, `Mode`) so sub-panels present a consistent time basis and identity.
- Introduce the aggregate additively to avoid breaking existing endpoints and consumers.

### Description
- Added a new composite DTO `RunPortfolioDrillInSummary` in `src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs` that exposes `SchemaVersion`, `RunId`, `AsOf`, `Currency`, `Mode`, and nullable sub-panels for attribution, drawdown, cash-flow, and trades.
- Added an orchestrator method `GetPortfolioDrillInAsync` in `src/Meridian.Strategies/Services/StrategyRunReadService.cs` that composes existing internal methods `GetAttributionAsync`, `GetEquityCurveAsync`, `GetFillsAsync`, and the optional cash-flow projection to return the aggregate.
- Wire `StrategyRunReadService` constructor to accept an optional `CashFlowProjectionService` dependency so injection sites remain compatible and the cash-flow projection is additive.
- Normalize aggregate fields by using `GetLastUpdatedAt(run)` for the `AsOf` timestamp and a new `ResolveCurrencyContext` with fallback order: cash-flow currency → first fill currency → `USD`.

### Testing
- Attempted to run the targeted drill-in tests with `dotnet test --filter "FullyQualifiedName~StrategyRunDrillInTests"`, but the environment does not have `dotnet` installed so automated tests could not be executed here.
- No automated test results are available from this run; please run `dotnet test` locally or in CI (for example `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~StrategyRunDrillInTests"`) to validate compilation and behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4af7c0dc8320b27215acfea891dc)