### PR TITLE
Add lineage timeline projection for strategy run timelines

### DIFF
--- a/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
+++ b/src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs
@@ -443,6 +443,27 @@ public sealed record StrategyRunComparison(
     bool HasLedger = false,
     bool HasAuditTrail = false);
 
+
+
+/// <summary>Projection mode for workstation run timeline queries.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<StrategyRunTimelineProjection>))]
+public enum StrategyRunTimelineProjection : byte
+{
+    Flat,
+    Lineage
+}
+
+/// <summary>Promotion/lineage event type emitted on strategy run timelines.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<StrategyRunLineageEventType>))]
+public enum StrategyRunLineageEventType : byte
+{
+    RunStarted,
+    RunCompleted,
+    PromotionDecision,
+    CrossModeTransition,
+    ReplayVerified
+}
+
 /// <summary>Filter options used for workstation run history retrieval.</summary>
 public sealed record StrategyRunHistoryQuery(
     IReadOnlyList<StrategyRunMode>? Modes = null,
@@ -463,6 +484,33 @@ public sealed record StrategyRunTimelineEntry(
     decimal? NetPnl,
     decimal? TotalReturn,
     int FillCount);
+
+
+/// <summary>Cross-mode transition metadata for lineage timeline events.</summary>
+public sealed record StrategyRunCrossModeTransitionMetadata(
+    StrategyRunMode? SourceMode,
+    StrategyRunMode? TargetMode,
+    string? SourceRunId,
+    string? TargetRunId,
+    string? PromotionReference,
+    string? ReplayAuditReference,
+    DateTimeOffset? ReplayVerifiedAt,
+    bool HasReplayAudit);
+
+/// <summary>Lineage timeline event grouped by canonical run identity.</summary>
+public sealed record StrategyRunLineageTimelineEntry(
+    string CanonicalRunKey,
+    string? ParentCanonicalRunKey,
+    string RunId,
+    string StrategyId,
+    string StrategyName,
+    StrategyRunMode Mode,
+    StrategyRunStatus Status,
+    DateTimeOffset EventTimestamp,
+    StrategyRunLineageEventType EventType,
+    string? PromotionDecision,
+    StrategyRunCrossModeTransitionMetadata? CrossModeTransition = null);
+
 /// <summary>
 /// Normalized cross-mode run comparison DTO that includes the full set of
 /// <c>BacktestMetrics</c> fields plus equity curve data and parentage chain info.

--- a/src/Meridian.Strategies/Services/StrategyRunReadService.cs
+++ b/src/Meridian.Strategies/Services/StrategyRunReadService.cs
@@ -93,6 +93,24 @@ public sealed class StrategyRunReadService
             .ToArray();
     }
 
+    public async Task<IReadOnlyList<StrategyRunLineageTimelineEntry>> GetLineageTimelineAsync(
+        StrategyRunHistoryQuery query,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var runs = await GetRunsAsync(query, ct).ConfigureAwait(false);
+
+        return runs
+            .GroupBy(static run => run.Identity?.CanonicalRunKey ?? run.RunId, StringComparer.Ordinal)
+            .SelectMany(BuildLineageTimelineEntries)
+            .OrderBy(static entry => entry.EventTimestamp)
+            .ThenBy(static entry => entry.CanonicalRunKey, StringComparer.Ordinal)
+            .ThenBy(static entry => entry.RunId, StringComparer.Ordinal)
+            .ThenBy(static entry => entry.EventType)
+            .ToArray();
+    }
+
     public async Task<StrategyRunDetail?> GetRunDetailAsync(string runId, CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(runId);
@@ -386,6 +404,106 @@ public sealed class StrategyRunReadService
             HasAuditTrail: !string.IsNullOrWhiteSpace(run.AuditReference),
             AuditReference: run.AuditReference);
     }
+
+    private static IEnumerable<StrategyRunLineageTimelineEntry> BuildLineageTimelineEntries(
+        IGrouping<string, StrategyRunSummary> lineageGroup)
+    {
+        foreach (var run in lineageGroup)
+        {
+            var canonicalRunKey = run.Identity?.CanonicalRunKey ?? run.RunId;
+            var parentCanonicalRunKey = run.Identity?.ParentCanonicalRunKey;
+            var promotionDecision = run.Identity?.PromotionDecision;
+            var replayAuditReference = run.Identity?.ReplayAuditReference;
+            var replayVerifiedAt = run.Identity?.ReplayVerifiedAt;
+            var sourceRunId = run.Identity?.PromotionSourceRunId;
+            var targetRunId = run.Identity?.PromotionTargetRunId;
+
+            yield return new StrategyRunLineageTimelineEntry(
+                CanonicalRunKey: canonicalRunKey,
+                ParentCanonicalRunKey: parentCanonicalRunKey,
+                RunId: run.RunId,
+                StrategyId: run.StrategyId,
+                StrategyName: run.StrategyName,
+                Mode: run.Mode,
+                Status: run.Status,
+                EventTimestamp: run.StartedAt,
+                EventType: StrategyRunLineageEventType.RunStarted,
+                PromotionDecision: promotionDecision,
+                CrossModeTransition: BuildTransitionMetadata(run.Mode, run.Mode, sourceRunId, targetRunId, run.Promotion?.AuditReference, replayAuditReference, replayVerifiedAt, run.Identity?.HasReplayAudit ?? false));
+
+            if (run.CompletedAt is { } completedAt)
+            {
+                yield return new StrategyRunLineageTimelineEntry(
+                    CanonicalRunKey: canonicalRunKey,
+                    ParentCanonicalRunKey: parentCanonicalRunKey,
+                    RunId: run.RunId,
+                    StrategyId: run.StrategyId,
+                    StrategyName: run.StrategyName,
+                    Mode: run.Mode,
+                    Status: run.Status,
+                    EventTimestamp: completedAt,
+                    EventType: StrategyRunLineageEventType.RunCompleted,
+                    PromotionDecision: promotionDecision,
+                    CrossModeTransition: null);
+            }
+
+            if (!string.IsNullOrWhiteSpace(promotionDecision))
+            {
+                var targetMode = run.Promotion?.SuggestedNextMode;
+                var eventType = targetMode.HasValue && targetMode.Value != run.Mode
+                    ? StrategyRunLineageEventType.CrossModeTransition
+                    : StrategyRunLineageEventType.PromotionDecision;
+
+                yield return new StrategyRunLineageTimelineEntry(
+                    CanonicalRunKey: canonicalRunKey,
+                    ParentCanonicalRunKey: parentCanonicalRunKey,
+                    RunId: run.RunId,
+                    StrategyId: run.StrategyId,
+                    StrategyName: run.StrategyName,
+                    Mode: run.Mode,
+                    Status: run.Status,
+                    EventTimestamp: run.LastUpdatedAt,
+                    EventType: eventType,
+                    PromotionDecision: promotionDecision,
+                    CrossModeTransition: BuildTransitionMetadata(run.Mode, targetMode, sourceRunId, targetRunId, run.Promotion?.AuditReference, replayAuditReference, replayVerifiedAt, run.Identity?.HasReplayAudit ?? false));
+            }
+
+            if ((run.Identity?.HasReplayAudit ?? false) && replayVerifiedAt is { } verifiedAt)
+            {
+                yield return new StrategyRunLineageTimelineEntry(
+                    CanonicalRunKey: canonicalRunKey,
+                    ParentCanonicalRunKey: parentCanonicalRunKey,
+                    RunId: run.RunId,
+                    StrategyId: run.StrategyId,
+                    StrategyName: run.StrategyName,
+                    Mode: run.Mode,
+                    Status: run.Status,
+                    EventTimestamp: verifiedAt,
+                    EventType: StrategyRunLineageEventType.ReplayVerified,
+                    PromotionDecision: promotionDecision,
+                    CrossModeTransition: BuildTransitionMetadata(run.Mode, run.Mode, sourceRunId, targetRunId, run.Promotion?.AuditReference, replayAuditReference, replayVerifiedAt, true));
+            }
+        }
+    }
+
+    private static StrategyRunCrossModeTransitionMetadata BuildTransitionMetadata(
+        StrategyRunMode? sourceMode,
+        StrategyRunMode? targetMode,
+        string? sourceRunId,
+        string? targetRunId,
+        string? promotionReference,
+        string? replayAuditReference,
+        DateTimeOffset? replayVerifiedAt,
+        bool hasReplayAudit) =>
+        new(
+            SourceMode: sourceMode,
+            TargetMode: targetMode,
+            SourceRunId: sourceRunId,
+            TargetRunId: targetRunId,
+            PromotionReference: promotionReference,
+            ReplayAuditReference: replayAuditReference,
+            ReplayVerifiedAt: replayVerifiedAt,
+            HasReplayAudit: hasReplayAudit);
 
     internal IReadOnlyList<StrategyRunContinuityWarning> GetPortfolioContinuityWarnings(StrategyRunDetail run) =>
         _portfolioReadService.BuildContinuityWarnings(run.Summary.RunId, run.Portfolio);

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -1584,6 +1584,7 @@ public static partial class WorkstationEndpoints
             string? mode,
             StrategyRunStatus? status,
             string? strategyId,
+            StrategyRunTimelineProjection? projection,
             int? limit,
             HttpContext context) =>
         {
@@ -1594,18 +1595,24 @@ public static partial class WorkstationEndpoints
             }
 
             var modes = ParseModes(mode);
-            var timeline = await readService.GetMergedTimelineAsync(
-                    new StrategyRunHistoryQuery(
-                        Modes: modes,
-                        Status: status,
-                        StrategyId: strategyId,
-                        Limit: Math.Clamp(limit ?? 100, 1, 500)),
-                    context.RequestAborted)
-                .ConfigureAwait(false);
+            var query = new StrategyRunHistoryQuery(
+                Modes: modes,
+                Status: status,
+                StrategyId: strategyId,
+                Limit: Math.Clamp(limit ?? 100, 1, 500));
+
+            if (projection == StrategyRunTimelineProjection.Lineage)
+            {
+                var lineageTimeline = await readService.GetLineageTimelineAsync(query, context.RequestAborted).ConfigureAwait(false);
+                return Results.Json(lineageTimeline, jsonOptions);
+            }
+
+            var timeline = await readService.GetMergedTimelineAsync(query, context.RequestAborted).ConfigureAwait(false);
             return Results.Json(timeline, jsonOptions);
         })
         .WithName("GetWorkstationMergedRunTimeline")
         .Produces<IReadOnlyList<StrategyRunTimelineEntry>>(200)
+        .Produces<IReadOnlyList<StrategyRunLineageTimelineEntry>>(200)
         .Produces(501);
 
         group.MapGet("/runs/sweeps", async (int? limit, HttpContext context) =>


### PR DESCRIPTION
### Motivation
- Provide a lineage-aware timeline view that groups events by canonical run identity so operators can inspect run ancestry, promotions, and cross-mode transitions in chronological order.
- Surface promotion decisions, replay verification, and cross-mode transition metadata alongside existing flat timeline entries so downstream callers can choose the projection they need.

### Description
- Added new DTOs to `src/Meridian.Contracts/Workstation/StrategyRunReadModels.cs`: `StrategyRunTimelineProjection`, `StrategyRunLineageEventType`, `StrategyRunCrossModeTransitionMetadata`, and `StrategyRunLineageTimelineEntry` to represent lineage timeline events and cross-mode metadata. 
- Implemented `GetLineageTimelineAsync(StrategyRunHistoryQuery)` in `src/Meridian.Strategies/Services/StrategyRunReadService.cs` which groups runs by `Identity.CanonicalRunKey` (falling back to `RunId`), emits events for run start, completion, promotion/cross-mode transition, and replay verification, and orders results by `EventTimestamp` with stable tie-breakers. 
- Added helper methods `BuildLineageTimelineEntries` and `BuildTransitionMetadata` to produce lineage events and cross-mode metadata while using existing identity/promotion/replay fields and handling missing data null-safely. 
- Extended the `/api/workstation/runs/timeline` endpoint in `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` to accept `projection=lineage` and return the lineage timeline while preserving the default flat timeline response for existing callers.

### Testing
- Attempted targeted unit tests via `dotnet test` filtered to `StrategyRunReadServiceTests` and `WorkstationEndpointsTests` using `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~StrategyRunReadServiceTests|FullyQualifiedName~WorkstationEndpointsTests"`, but the `dotnet` CLI was not available in the execution environment (error: `dotnet: command not found`).
- No other automated test runs were executed in this environment; code was compiled/validated locally by static editing only in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4af6fc2883208bfe76d8f8c99dba)