### PR TITLE
Add ledger/reconciliation continuity contract parity guards

### DIFF
--- a/docs/architecture/workstation-continuity-payload-profile.md
+++ b/docs/architecture/workstation-continuity-payload-profile.md
@@ -1,0 +1,32 @@
+# Workstation Continuity Payload Profile (Source of Truth)
+
+This profile is the canonical payload contract for **Research**, **Trading**, and **Governance** consumers.
+
+## Canonical DTO surfaces
+
+- `FundLedgerSummary` (`FundLedgerDtos.cs`)
+- `ReconciliationRunSummary` (`ReconciliationDtos.cs`)
+- `StrategyRunContinuityDto` (`StrategyRunReadModels.cs`)
+
+These payloads are shared and must not fork per UI surface (web dashboard vs retained workstation shell).
+
+## Compatibility guard
+
+`LedgerReconciliationContractCompatibility` is the additive-only and required-field guard for readiness/governance paths:
+
+- Required identity/presence fields are enforced for fund ledger and reconciliation summaries.
+- Continuity payload must include `Run`, `Lineage`, and `ContinuityStatus`.
+- Contract evolution policy: additive-only member changes on canonical DTO records.
+
+## Serialization profile
+
+All parity tests use `JsonSerializerDefaults.Web` to validate shared JSON shape, including camelCase member names expected by both consumers.
+
+## Change policy
+
+When changing these contracts:
+
+1. Add new members only (non-breaking additive change).
+2. Update compatibility tests in `tests/Meridian.Tests/Contracts/LedgerReconciliationContractCompatibilityTests.cs`.
+3. Preserve required-field invariants used by readiness/governance flows.
+4. Avoid per-surface DTO variants unless a deliberate, reviewed versioning strategy is introduced.

--- a/src/Meridian.Contracts/Workstation/LedgerReconciliationContractCompatibility.cs
+++ b/src/Meridian.Contracts/Workstation/LedgerReconciliationContractCompatibility.cs
@@ -1,0 +1,44 @@
+namespace Meridian.Contracts.Workstation;
+
+public static class LedgerReconciliationContractCompatibility
+{
+    public static void EnsureFundLedgerSummaryRequiredFields(FundLedgerSummary summary)
+    {
+        ArgumentNullException.ThrowIfNull(summary);
+        if (string.IsNullOrWhiteSpace(summary.FundProfileId)) throw new InvalidOperationException("FundProfileId is required.");
+        if (string.IsNullOrWhiteSpace(summary.FundDisplayName)) throw new InvalidOperationException("FundDisplayName is required.");
+        if (summary.TrialBalance is null) throw new InvalidOperationException("TrialBalance is required.");
+        if (summary.Journal is null) throw new InvalidOperationException("Journal is required.");
+        if (summary.EntityCount < 0 || summary.SleeveCount < 0 || summary.VehicleCount < 0)
+        {
+            throw new InvalidOperationException("Entity/Sleeve/Vehicle counts cannot be negative.");
+        }
+    }
+
+    public static void EnsureReconciliationSummaryRequiredFields(ReconciliationRunSummary summary)
+    {
+        ArgumentNullException.ThrowIfNull(summary);
+        if (string.IsNullOrWhiteSpace(summary.ReconciliationRunId)) throw new InvalidOperationException("ReconciliationRunId is required.");
+        if (string.IsNullOrWhiteSpace(summary.RunId)) throw new InvalidOperationException("RunId is required.");
+        if (summary.BreakCount < 0 || summary.OpenBreakCount < 0) throw new InvalidOperationException("Break counters cannot be negative.");
+        if (summary.OpenBreakCount > summary.BreakCount) throw new InvalidOperationException("OpenBreakCount cannot exceed BreakCount.");
+    }
+
+    public static void EnsureContinuityRequiredFields(StrategyRunContinuityDto continuity)
+    {
+        ArgumentNullException.ThrowIfNull(continuity);
+        if (continuity.Run is null) throw new InvalidOperationException("Run payload is required.");
+        if (continuity.Lineage is null) throw new InvalidOperationException("Lineage payload is required.");
+        if (continuity.ContinuityStatus is null) throw new InvalidOperationException("ContinuityStatus payload is required.");
+
+        if (!continuity.ContinuityStatus.HasRun)
+        {
+            throw new InvalidOperationException("ContinuityStatus.HasRun must be true for readiness/governance flows.");
+        }
+
+        if (continuity.ContinuityStatus.Warnings is null)
+        {
+            throw new InvalidOperationException("ContinuityStatus.Warnings is required.");
+        }
+    }
+}

--- a/tests/Meridian.Tests/Contracts/LedgerReconciliationContractCompatibilityTests.cs
+++ b/tests/Meridian.Tests/Contracts/LedgerReconciliationContractCompatibilityTests.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+using Meridian.Contracts.Workstation;
+using Xunit;
+
+namespace Meridian.Tests.Contracts;
+
+public sealed class LedgerReconciliationContractCompatibilityTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void FundLedgerSummary_WebAndRetainedConsumers_SerializeSameMembers()
+    {
+        var dto = BuildFundLedgerSummary();
+
+        LedgerReconciliationContractCompatibility.EnsureFundLedgerSummaryRequiredFields(dto);
+
+        var json = JsonSerializer.Serialize(dto, JsonOptions);
+        Assert.Contains("\"fundProfileId\"", json);
+        Assert.Contains("\"fundDisplayName\"", json);
+        Assert.Contains("\"scopeKind\"", json);
+        Assert.Contains("\"trialBalance\"", json);
+        Assert.Contains("\"journal\"", json);
+
+        Assert.DoesNotContain("\"FundProfileId\"", json);
+    }
+
+    [Fact]
+    public void ReconciliationSummary_WebAndRetainedConsumers_SerializeSameMembers()
+    {
+        var dto = new ReconciliationRunSummary(
+            ReconciliationRunId: "recon-1",
+            RunId: "run-1",
+            CreatedAt: DateTimeOffset.Parse("2026-01-05T12:00:00Z"),
+            PortfolioAsOf: DateTimeOffset.Parse("2026-01-05T11:59:00Z"),
+            LedgerAsOf: DateTimeOffset.Parse("2026-01-05T11:59:00Z"),
+            MatchCount: 10,
+            BreakCount: 2,
+            OpenBreakCount: 1,
+            HasTimingDrift: false,
+            AmountTolerance: 0.01m,
+            MaxAsOfDriftMinutes: 5);
+
+        LedgerReconciliationContractCompatibility.EnsureReconciliationSummaryRequiredFields(dto);
+
+        var json = JsonSerializer.Serialize(dto, JsonOptions);
+        Assert.Contains("\"reconciliationRunId\"", json);
+        Assert.Contains("\"runId\"", json);
+        Assert.Contains("\"breakCount\"", json);
+        Assert.Contains("\"openBreakCount\"", json);
+    }
+
+    [Fact]
+    public void ContinuityDto_HasCanonicalPayloadProfile_ForResearchTradingGovernance()
+    {
+        var dto = BuildContinuityDto();
+
+        LedgerReconciliationContractCompatibility.EnsureContinuityRequiredFields(dto);
+
+        var json = JsonSerializer.Serialize(dto, JsonOptions);
+        Assert.Contains("\"run\"", json);
+        Assert.Contains("\"lineage\"", json);
+        Assert.Contains("\"continuityStatus\"", json);
+        Assert.Contains("\"reconciliation\"", json);
+        Assert.Contains("\"cashFlow\"", json);
+    }
+
+    [Fact]
+    public void AdditiveOnlyContractShape_GuardForLedgerReconciliationContinuityDtos()
+    {
+        AssertMembers(typeof(FundLedgerSummary),
+            "FundProfileId", "FundDisplayName", "ScopeKind", "ScopeId", "AsOf",
+            "JournalEntryCount", "LedgerEntryCount", "AssetBalance", "LiabilityBalance",
+            "EquityBalance", "RevenueBalance", "ExpenseBalance", "TrialBalance", "Journal",
+            "EntityCount", "SleeveCount", "VehicleCount", "ConsolidatedTotals", "LedgerSlices");
+
+        AssertMembers(typeof(ReconciliationRunSummary),
+            "ReconciliationRunId", "RunId", "CreatedAt", "PortfolioAsOf", "LedgerAsOf",
+            "MatchCount", "BreakCount", "OpenBreakCount", "HasTimingDrift", "AmountTolerance",
+            "MaxAsOfDriftMinutes", "SecurityIssueCount", "HasSecurityCoverageIssues",
+            "BankTransactionCount", "BankBreakCount", "ExpectedAccountingEventCount",
+            "ExpectedJournalPreviewCount", "SecurityMasterAccountingIssueCount", "HasSecurityMasterAccountingIssues");
+
+        AssertMembers(typeof(StrategyRunContinuityDto),
+            "Run", "Lineage", "CashFlow", "Reconciliation", "ContinuityStatus");
+    }
+
+    private static void AssertMembers(Type type, params string[] expectedMembers)
+    {
+        var actual = type.GetProperties().Select(p => p.Name).OrderBy(x => x).ToArray();
+        var expected = expectedMembers.OrderBy(x => x).ToArray();
+        Assert.Equal(expected, actual);
+    }
+
+    private static FundLedgerSummary BuildFundLedgerSummary() => new(
+        FundProfileId: "fund-1",
+        FundDisplayName: "Alpha Fund",
+        ScopeKind: FundLedgerScope.Consolidated,
+        ScopeId: null,
+        AsOf: DateTimeOffset.Parse("2026-01-05T12:00:00Z"),
+        JournalEntryCount: 2,
+        LedgerEntryCount: 2,
+        AssetBalance: 100m,
+        LiabilityBalance: 10m,
+        EquityBalance: 90m,
+        RevenueBalance: 5m,
+        ExpenseBalance: 1m,
+        TrialBalance: new[] { new FundTrialBalanceLine("Cash", "Asset", null, null, 100m, 1) },
+        Journal: new[] { new FundJournalLine(Guid.Parse("11111111-1111-1111-1111-111111111111"), DateTimeOffset.Parse("2026-01-05T12:00:00Z"), "seed", 100m, 100m, 2) },
+        EntityCount: 1,
+        SleeveCount: 1,
+        VehicleCount: 1);
+
+    private static StrategyRunContinuityDto BuildContinuityDto()
+    {
+        var summary = new StrategyRunSummary(
+            "run-1", "strat-1", "MeanRevert", StrategyRunMode.Paper, StrategyRunEngine.MeridianNative,
+            StrategyRunStatus.Completed, DateTimeOffset.Parse("2026-01-01T00:00:00Z"), DateTimeOffset.Parse("2026-01-02T00:00:00Z"),
+            null, null, null, null, 1m, 0.1m, 101m, 1, DateTimeOffset.Parse("2026-01-02T00:00:00Z"));
+        var detail = new StrategyRunDetail(summary, new Dictionary<string, string>(), null, null);
+        var lineage = new StrategyRunContinuityLineage(null, null, Array.Empty<StrategyRunContinuityLink>());
+        var status = new StrategyRunContinuityStatus(true, StrategyRunContinuitySeamHealthStatus.Healthy, true, StrategyRunContinuitySeamHealthStatus.Healthy, true, StrategyRunContinuitySeamHealthStatus.Healthy, true, StrategyRunContinuitySeamHealthStatus.Healthy, true, StrategyRunContinuitySeamHealthStatus.Healthy, true, StrategyRunContinuitySeamHealthStatus.Healthy, 0, 0, 0, false, Array.Empty<StrategyRunContinuityWarning>());
+        var reconciliation = new ReconciliationRunSummary("recon-1", "run-1", DateTimeOffset.Parse("2026-01-02T00:00:00Z"), null, null, 1, 0, 0, false, 0.01m, 5);
+        return new StrategyRunContinuityDto(detail, lineage, null, reconciliation, status);
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure the same DTO members and JSON shape are available to both the web dashboard and retained workstation to avoid per-surface schema forks. 
- Provide additive-only compatibility guards and required-field invariants for readiness/governance flows that depend on ledger/reconciliation/continuity payloads. 

### Description

- Added `LedgerReconciliationContractCompatibility` in `src/Meridian.Contracts/Workstation/LedgerReconciliationContractCompatibility.cs` with methods `EnsureFundLedgerSummaryRequiredFields`, `EnsureReconciliationSummaryRequiredFields`, and `EnsureContinuityRequiredFields` to validate required members and simple invariants. 
- Added parity-focused tests in `tests/Meridian.Tests/Contracts/LedgerReconciliationContractCompatibilityTests.cs` that assert `JsonSerializerDefaults.Web` serialization shape (camelCase), required-field invariants, and an additive-only member-shape guard for `FundLedgerSummary`, `ReconciliationRunSummary`, and `StrategyRunContinuityDto`. 
- Documented the canonical payload profile and change policy in `docs/architecture/workstation-continuity-payload-profile.md` describing the source-of-truth DTOs and the additive-only evolution policy. 

### Testing

- Added focused xUnit tests in `tests/Meridian.Tests/Contracts/LedgerReconciliationContractCompatibilityTests.cs` validating serialization shape and required-field guards, but they were not executed here because `dotnet` is not available in this environment when attempting `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter FullyQualifiedName~LedgerReconciliationContractCompatibilityTests` (command failed due to missing `dotnet`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4afa1e248320b909351eb35a14b3)