### PR TITLE
Block snake_case broker routing metadata aliases

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs
@@ -1290,8 +1290,10 @@ public static class ExecutionEndpoints
             return false;
         }
 
-        return metadata.Keys.Any(static key => key.Equals("assetClass", StringComparison.OrdinalIgnoreCase)
+        return metadata.Keys.Any(static key => key.Equals("asset_class", StringComparison.OrdinalIgnoreCase)
+            || key.Equals("assetClass", StringComparison.OrdinalIgnoreCase)
             || key.Equals("alpaca:asset_class", StringComparison.OrdinalIgnoreCase)
+            || key.Equals("broker_account_id", StringComparison.OrdinalIgnoreCase)
             || key.Equals("brokerAccountId", StringComparison.OrdinalIgnoreCase)
             || key.Equals("account_id", StringComparison.OrdinalIgnoreCase)
             || key.Equals("accountId", StringComparison.OrdinalIgnoreCase)

--- a/tests/Meridian.Tests/Ui/ExecutionGovernanceEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/ExecutionGovernanceEndpointsTests.cs
@@ -386,7 +386,7 @@ public sealed class ExecutionGovernanceEndpointsTests
     }
 
     [Fact]
-    public async Task SubmitOrder_WithFixedIncomeRoutingMetadata_PreservesSubmitPath()
+    public async Task SubmitOrder_WithFixedIncomeRoutingMetadata_IsRejected()
     {
         var tempRoot = CreateTempRoot();
         await using var app = await CreateAppAsync(services =>
@@ -417,12 +417,12 @@ public sealed class ExecutionGovernanceEndpointsTests
             }
         }));
 
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var result = JsonSerializer.Deserialize<OrderResult>(
             await response.Content.ReadAsStringAsync(),
             JsonOptions());
         result.Should().NotBeNull();
-        result!.Success.Should().BeTrue();
+        result!.Success.Should().BeFalse();
     }
 
     private static async Task<WebApplication> CreateAppAsync(


### PR DESCRIPTION
### Motivation
- The `/api/execution/orders/submit` endpoint lost coverage for snake_case broker-routing metadata keys, allowing client-supplied `asset_class` and `broker_account_id` to influence downstream Alpaca Broker API routing. 
- This change restores the intended guard to prevent authenticated callers from choosing downstream broker accounts via metadata.

### Description
- Restored snake_case aliases in `ContainsRestrictedBrokerRoutingMetadata` so the guard rejects `asset_class` and `broker_account_id` in addition to existing camelCase and namespaced keys in `src/Meridian.Ui.Shared/Endpoints/ExecutionEndpoints.cs`.
- Updated the governance test to assert rejection of fixed-income routing metadata by renaming the test to `SubmitOrder_WithFixedIncomeRoutingMetadata_IsRejected` and expecting `BadRequest` and `Success == false` in `tests/Meridian.Tests/Ui/ExecutionGovernanceEndpointsTests.cs`.
- Changes are minimal and focused on metadata validation to preserve existing order submission behavior while closing the routing bypass.

### Testing
- Updated unit test `SubmitOrder_WithFixedIncomeRoutingMetadata_IsRejected` was modified to reflect the secure behavior but could not be executed in this environment because `dotnet` is not installed (`dotnet: command not found`).
- No other automated test runs were performed in this environment due to missing runtime tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e407b2418832080e02f7788041e6e)