### PR TITLE
Restore workflow-period validation for operations-continuity ledger posting

### DIFF
--- a/src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflowService.cs
+++ b/src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflowService.cs
@@ -1258,6 +1258,10 @@ public sealed class OperationsContinuityWorkflowService : IOperationsContinuityW
         {
             blockers.Add(CreateJournalCandidateBlocker("LEDGER_JOURNAL_PERIOD_ID_REQUIRED", "Ledger journal candidate period id is required.", evidence));
         }
+        else if (TryResolveWorkflowPeriodGuid(workflow.PeriodId, out var workflowPeriodId) && candidate.PeriodId != workflowPeriodId)
+        {
+            blockers.Add(CreateJournalCandidateBlocker("LEDGER_JOURNAL_PERIOD_ID_MISMATCH", "Ledger journal candidate period id must match the workflow period.", evidence));
+        }
 
         if (candidate.AggregateId != Guid.Empty && candidate.AggregateId != workflow.FundAccountId)
         {
@@ -1307,6 +1311,9 @@ public sealed class OperationsContinuityWorkflowService : IOperationsContinuityW
 
         return blockers;
     }
+
+    private static bool TryResolveWorkflowPeriodGuid(string workflowPeriodId, out Guid resolvedPeriodId) =>
+        Guid.TryParse(workflowPeriodId, out resolvedPeriodId);
 
     private static OperationsWorkflowBlockerDto CreateJournalCandidateBlocker(
         string code,

--- a/tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs
@@ -943,6 +943,34 @@ public sealed class OperationsContinuityWorkflowServiceTests
     }
 
     [Fact]
+    public async Task PostLedgerEntriesAsync_ShouldRejectJournalCandidatePeriodThatDoesNotMatchWorkflowPeriod()
+    {
+        var service = CreateService(out _, out _);
+        var workflowPeriodId = Guid.NewGuid();
+        var start = await service.StartWorkflowAsync(new OperationsStartWorkflowRequestDto(
+            Guid.NewGuid(),
+            workflowPeriodId.ToString(),
+            null,
+            "custodian",
+            "ops-user"));
+        var workflow = await AdvanceToLedgerValidatedStateAsync(service, start.Workflow!);
+
+        var result = await service.PostLedgerEntriesAsync(workflow.WorkflowId, new OperationsLedgerPostRequestDto(
+            workflow.Version,
+            "ops-user",
+            LedgerBatchId: "ledger-batch-period-mismatch",
+            PostingKind: "period-close",
+            PeriodOpen: true,
+            JournalCandidate: CreateJournalCandidate(workflow.FundAccountId, Guid.NewGuid())));
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be("VALIDATION_FAILED");
+        result.Blockers.Should().ContainSingle(blocker =>
+            blocker.Code == "LEDGER_JOURNAL_PERIOD_ID_MISMATCH" &&
+            blocker.Gate == OperationsGateKeyDto.LedgerPosting);
+    }
+
+    [Fact]
     public async Task ResolveBreakCaseAsync_ShouldClearCriticalBreakAndAllowApprovalSubmission()
     {
         var service = CreateService(out _, out _);
@@ -1437,6 +1465,18 @@ public sealed class OperationsContinuityWorkflowServiceTests
         var security = await service.ResolveSecurityMasterMappingsAsync(start.Workflow.WorkflowId, new OperationsSecurityMasterResolveRequestDto(normalized.Workflow!.Version, "ops-user"));
         var draft = await service.BuildLedgerDraftAsync(start.Workflow.WorkflowId, new OperationsLedgerDraftRequestDto(security.Workflow!.Version, "ops-user", "ledger-preview-1", true));
         var validated = await service.ValidateLedgerDraftAsync(start.Workflow.WorkflowId, new OperationsLedgerValidationRequestDto(draft.Workflow!.Version, "ops-user", true, true));
+        return validated.Workflow!;
+    }
+
+    private static async Task<OperationsContinuityWorkflowDto> AdvanceToLedgerValidatedStateAsync(
+        OperationsContinuityWorkflowService service,
+        OperationsContinuityWorkflowDto workflow)
+    {
+        var import = await service.ImportBrokerDataAsync(workflow.WorkflowId, new OperationsTransitionRequestDto(workflow.Version, "ops-user"));
+        var normalized = await service.NormalizeBrokerTransactionsAsync(workflow.WorkflowId, new OperationsTransitionRequestDto(import.Workflow!.Version, "ops-user"));
+        var security = await service.ResolveSecurityMasterMappingsAsync(workflow.WorkflowId, new OperationsSecurityMasterResolveRequestDto(normalized.Workflow!.Version, "ops-user"));
+        var draft = await service.BuildLedgerDraftAsync(workflow.WorkflowId, new OperationsLedgerDraftRequestDto(security.Workflow!.Version, "ops-user", "ledger-preview-1", true));
+        var validated = await service.ValidateLedgerDraftAsync(workflow.WorkflowId, new OperationsLedgerValidationRequestDto(draft.Workflow!.Version, "ops-user", true, true));
         return validated.Workflow!;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent an authenticated mutation from appending a ledger journal into a different accounting period than the workflow being closed, which can corrupt accounting/audit integrity.
- Reintroduce the previously-removed invariant that the journal candidate period must map to the workflow period when the workflow period is a canonical GUID.

### Description
- Add a service-side validation in `ValidateJournalCandidate` to reject mismatched period GUIDs by returning `LEDGER_JOURNAL_PERIOD_ID_MISMATCH` when `candidate.PeriodId` does not equal the workflow period GUID resolved via `TryResolveWorkflowPeriodGuid` (`src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflowService.cs`).
- Add `TryResolveWorkflowPeriodGuid` helper to canonicalize string `workflow.PeriodId` into a `Guid` only when it parses as a GUID, preserving existing behavior for non-GUID period identifiers (`src/.../OperationsContinuityWorkflowService.cs`).
- Add a focused regression test `PostLedgerEntriesAsync_ShouldRejectJournalCandidatePeriodThatDoesNotMatchWorkflowPeriod` that starts a workflow with a GUID period and asserts the new `LEDGER_JOURNAL_PERIOD_ID_MISMATCH` blocker is returned for a mismatched candidate, plus a test helper `AdvanceToLedgerValidatedStateAsync` used to prepare the workflow state (`tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs`).

### Testing
- Added a unit test: `PostLedgerEntriesAsync_ShouldRejectJournalCandidatePeriodThatDoesNotMatchWorkflowPeriod` in `tests/Meridian.Tests/.../OperationsContinuityWorkflowServiceTests.cs` which asserts validation fails with `VALIDATION_FAILED` and blocker `LEDGER_JOURNAL_PERIOD_ID_MISMATCH`.
- Attempted to run the focused test with `dotnet test --filter "FullyQualifiedName~PostLedgerEntriesAsync_ShouldRejectJournalCandidatePeriodThatDoesNotMatchWorkflowPeriod"`, but the runtime environment lacks the `dotnet` SDK so the test run could not be executed (`/bin/bash: dotnet: command not found`).
- No other automated test runs were possible within this container; changes are limited and targeted to the operations-continuity validation path to minimize risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f2a6a057c8320920f73c79ce49595)