### PR TITLE
Harden roadmap manual workflow input handling

### DIFF
--- a/.github/workflows/roadmap-tools-manual.yml
+++ b/.github/workflows/roadmap-tools-manual.yml
@@ -65,15 +65,20 @@ jobs:
 
       - name: Validate roadmap evidence file
         if: ${{ inputs.script == 'validate-roadmap-file' || inputs.script == 'all' }}
-        run: python3 tools/roadmap/validate_roadmap.py --roadmap "${{ inputs.roadmap_path }}"
+        env:
+          ROADMAP_PATH: ${{ inputs.roadmap_path }}
+        run: python3 tools/roadmap/validate_roadmap.py --roadmap "$ROADMAP_PATH"
 
       - name: Render roadmap docs (normalize)
         if: ${{ inputs.script == 'render' || inputs.script == 'all' }}
+        env:
+          ROADMAP_PATH: ${{ inputs.roadmap_path }}
+          RENDER_OUTPUT: ${{ inputs.render_output }}
         run: |
-          mkdir -p "$(dirname "${{ inputs.render_output }}")"
+          mkdir -p -- "$(dirname -- "$RENDER_OUTPUT")"
           python3 tools/roadmap/render_roadmap_docs.py \
-            "${{ inputs.roadmap_path }}" \
-            "${{ inputs.render_output }}"
+            "$ROADMAP_PATH" \
+            "$RENDER_OUTPUT"
 
       - name: Upload render output
         if: ${{ inputs.script == 'render' || inputs.script == 'all' }}
@@ -85,9 +90,12 @@ jobs:
 
       - name: Enforce phase scope
         if: ${{ inputs.script == 'enforce-phase-scope' || inputs.script == 'all' }}
+        env:
+          DISPATCH_PHASE: ${{ inputs.phase }}
+          BASE_REF: ${{ inputs.base_ref }}
         run: |
           python3 tools/roadmap/enforce_phase_scope.py \
-            --dispatch-phase "${{ inputs.phase }}" \
-            --base-ref "${{ inputs.base_ref }}" \
+            --dispatch-phase "$DISPATCH_PHASE" \
+            --base-ref "$BASE_REF" \
             --head-ref HEAD \
             --json


### PR DESCRIPTION
### Motivation
- The `roadmap-tools-manual` workflow interpolated `workflow_dispatch` string inputs directly into `run:` shell scripts, creating a command-injection risk when a manually-dispatched input contains shell metacharacters or command substitutions.
- The intent is to preserve the workflow functionality (`validate`, `validate-roadmap-file`, `render`, `enforce-phase-scope`) while eliminating the shell-injection vector.

### Description
- Stop direct interpolation of `${{ inputs.* }}` inside shell `run:` bodies and surface the inputs as step-level environment variables (`ROADMAP_PATH`, `RENDER_OUTPUT`, `DISPATCH_PHASE`, `BASE_REF`).
- Update the `validate-roadmap-file` step to use `env: ROADMAP_PATH` and call the script with `"$ROADMAP_PATH"`.
- Update the `render` step to export `ROADMAP_PATH` and `RENDER_OUTPUT` and call `mkdir` and the renderer using the quoted env vars to avoid pre-shell expansion.
- Update the `enforce-phase-scope` step to export `DISPATCH_PHASE` and `BASE_REF` and pass them to the script via `"$DISPATCH_PHASE"` and `"$BASE_REF"`.

### Testing
- No code-unit or integration tests were required for this YAML-only hardening; the change is behavior-preserving and confined to the GitHub Actions workflow definition.
- The change was locally verified by inspecting the updated workflow with `git diff` and line-numbered file output to confirm all vulnerable `run:` blocks now consume the safe environment variables (commit recorded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f253a5c24832082c29555d40ba1c1)