### PR TITLE
Fix Settings workspace hero tone UI thread marshaling

### DIFF
--- a/src/Meridian.Wpf/Features/Settings/Shell/SettingsWorkspaceShellPage.xaml.cs
+++ b/src/Meridian.Wpf/Features/Settings/Shell/SettingsWorkspaceShellPage.xaml.cs
@@ -61,10 +61,18 @@ public partial class SettingsWorkspaceShellPage : SettingsWorkspaceShellPageBase
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(SettingsWorkspaceShellViewModel.HeroBadgeTone))
+        if (e.PropertyName != nameof(SettingsWorkspaceShellViewModel.HeroBadgeTone))
         {
-            ApplyToneBindings();
+            return;
         }
+
+        if (!Dispatcher.CheckAccess())
+        {
+            _ = Dispatcher.InvokeAsync(ApplyToneBindings);
+            return;
+        }
+
+        ApplyToneBindings();
     }
 
     private void OnViewModelActionRequested(object? sender, SettingsWorkspaceShellActionRequestedEventArgs e)


### PR DESCRIPTION
### Motivation
- The Settings workspace refresh path can resume off the UI dispatcher because the view model uses `ConfigureAwait(false)`, and `ApplyPresentation` raises `PropertyChanged` that drives direct WPF control updates. 
- Without dispatcher marshaling the page may receive `PropertyChanged` on a thread-pool thread and mutate WPF controls, causing `InvalidOperationException` and a crashed page load.

### Description
- Added an early-return property filter to `SettingsWorkspaceShellPage.OnViewModelPropertyChanged` to only react to `HeroBadgeTone` changes. 
- Added a dispatcher check using `Dispatcher.CheckAccess()` and marshal `ApplyToneBindings` with `Dispatcher.InvokeAsync(...)` when not on the UI thread, otherwise call `ApplyToneBindings()` directly. 
- Change is localized to `src/Meridian.Wpf/Features/Settings/Shell/SettingsWorkspaceShellPage.xaml.cs` and preserves existing visual behavior while preventing cross-thread control mutation.

### Testing
- Attempted to run local WPF tests but `dotnet` is not available in this container, so no automated WPF tests were executed here. 
- Change is small and scoped to event handling (low risk); recommend running the WPF test slice `tests/Meridian.Wpf.Tests` or `make desktop-test` in a Windows dev environment to validate UI threading behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f253a55f48320831d4e707525fdda)