### PR TITLE
Restrict reconciliation run detail endpoint access

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -961,6 +961,11 @@ public static partial class WorkstationEndpoints
 
         group.MapGet(WorkstationSubroute(UiApiRoutes.ReconciliationRunById), async (string reconciliationRunId, HttpContext context) =>
         {
+            if (!HasReconciliationMutationPermission(context))
+            {
+                return EndpointHelpers.Forbidden();
+            }
+
             var service = context.RequestServices.GetService<IReconciliationRunService>();
             if (service is null)
             {

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -3159,6 +3159,34 @@ public sealed class WorkstationEndpointsTests
     }
 
     [Fact]
+    public async Task MapWorkstationEndpoints_ReconciliationRunById_ShouldRequireReconciliationMutationPermission()
+    {
+        await using var app = await CreateAppAsync(services =>
+        {
+            RegisterRunReadServices(services);
+            services.AddSingleton<IReconciliationRunRepository, InMemoryReconciliationRunRepository>();
+            services.AddSingleton<ReconciliationProjectionService>();
+            services.AddSingleton<IReconciliationRunService, ReconciliationRunService>();
+        }, currentUserPermissions: UserPermission.ViewStrategies);
+
+        var store = app.Services.GetRequiredService<IStrategyRepository>();
+        await store.RecordRunAsync(BuildReconciliationReadyRun("run-recon-permission"));
+
+        var client = app.GetTestClient();
+        var createResponse = await client.PostAsJsonAsync(UiApiRoutes.ReconciliationRuns, new ReconciliationRunRequest("run-recon-permission"));
+        createResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var created = await createResponse.Content.ReadFromJsonAsync<ReconciliationRunDetail>(ServerJsonOptions);
+        created.Should().NotBeNull();
+
+        var byIdResponse = await client.GetAsync(
+            UiApiRoutes.ReconciliationRunById.Replace(
+                "{reconciliationRunId}",
+                created!.Summary.ReconciliationRunId));
+        byIdResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
     public async Task MapWorkstationEndpoints_ReconciliationRoutes_ShouldReturnNotFoundWhenNoRunExists()
     {
         await using var app = await CreateAppAsync(services =>


### PR DESCRIPTION
### Motivation
- Fix an information-disclosure regression where the reconciliation-to-workflow bridge could cause opaque `reconciliationRunId` values to become discoverable and then fetched by any authenticated reader via `GET /api/workstation/reconciliation/runs/{reconciliationRunId}`.

### Description
- Require the reconciliation mutation permission on the reconciliation-by-id endpoint by checking `HasReconciliationMutationPermission(context)` and returning `EndpointHelpers.Forbidden()` when unmet in `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs`.
- Add a focused regression test `MapWorkstationEndpoints_ReconciliationRunById_ShouldRequireReconciliationMutationPermission` that asserts a caller with only `UserPermission.ViewStrategies` receives `403 Forbidden` in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs`.

### Testing
- Attempted a targeted automated test run with `dotnet test` for the affected endpoint tests but it failed in this environment because `dotnet` is not installed, so no tests were executed here (`/bin/bash: dotnet: command not found`).
- The new unit test `MapWorkstationEndpoints_ReconciliationRunById_ShouldRequireReconciliationMutationPermission` was added to the test suite and should be run in CI or a local environment with the .NET SDK to verify the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f253a8f208320982ad8f7a652ee88)