### PR TITLE
Restrict workstation connection summaries to credential managers

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -2902,7 +2902,8 @@ public static partial class WorkstationEndpoints
         // --- Providers (real data from metrics store when available) ---
         var metricsStatus = configStore?.TryLoadProviderMetrics();
         var healthyProviderCount = metricsStatus?.HealthyProviders ?? 0;
-        var connectionRows = providerConnectionLifecycle is not null
+        var canManageCredentials = HasPermission(context, UserPermission.ManageCredentials);
+        var connectionRows = canManageCredentials && providerConnectionLifecycle is not null
             ? await providerConnectionLifecycle.GetConnectionsAsync(context.RequestAborted).ConfigureAwait(false)
             : [];
         var routingConnections = routingConnectionService is not null

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -612,7 +612,8 @@ public sealed class WorkstationEndpointsTests
         await using var app = await CreateAppAsync(services =>
         {
             RegisterConfigStores(services, configPath);
-        });
+        },
+            currentUserPermissions: UserPermission.ModifySecurityMaster | UserPermission.ManageCredentials);
         var client = app.GetTestClient();
 
         using var dataOperations = await ReadJsonAsync(client, "/api/workstation/data-operations");
@@ -668,7 +669,8 @@ public sealed class WorkstationEndpointsTests
             services.AddSingleton<ProviderConnectionLifecycleService>();
             services.AddSingleton<ProviderConnectionService>();
             services.AddSingleton<ProviderBindingService>();
-        });
+        },
+            currentUserPermissions: UserPermission.ModifySecurityMaster | UserPermission.ManageCredentials);
 
         var connectionService = app.Services.GetRequiredService<ProviderConnectionService>();
         var bindingService = app.Services.GetRequiredService<ProviderBindingService>();
@@ -719,6 +721,18 @@ public sealed class WorkstationEndpointsTests
             .Contain(item =>
                 item.GetProperty("id").GetString() == "routing-readiness" &&
                 item.GetProperty("detail").GetString()!.Contains("Bindings 2; fallback routes 1; production ready True.", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_DataOperationsPayload_WithoutManageCredentials_ShouldNotExposeConnectionSummary()
+    {
+        await using var app = await CreateAppAsync();
+        using var dataOperations = await ReadJsonAsync(app.GetTestClient(), "/api/workstation/data-operations");
+        var providers = dataOperations.RootElement.GetProperty("providers").EnumerateArray().ToArray();
+
+        providers.Should().NotBeEmpty();
+        providers.Should().OnlyContain(provider =>
+            provider.GetProperty("connectionSummary").ValueKind is JsonValueKind.Null or JsonValueKind.Undefined);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Fix an authorization bypass where `/api/workstation/data` and `/api/workstation/data-operations` embedded `ProviderConnectionRowDto` credential/account metadata without enforcing the `ManageCredentials` permission. 
- Preserve existing workstation routes while preventing sensitive credential-related metadata from being returned to lower-privilege authenticated users.

### Description
- Only load provider connection rows when the caller has `ManageCredentials` by checking `HasPermission(context, UserPermission.ManageCredentials)` before calling `ProviderConnectionLifecycleService.GetConnectionsAsync()` in `BuildDataOperationsPayloadAsync` (`WorkstationEndpoints.cs`).
- Keep the workstation payload routes (`/data` and `/data-operations`) available while preventing `connectionSummary` leakage for callers that lack `ManageCredentials` by supplying an empty connection list for those callers.
- Update tests in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` to run the privileged assertions under a principal that includes `ManageCredentials` and add a regression test `MapWorkstationEndpoints_DataOperationsPayload_WithoutManageCredentials_ShouldNotExposeConnectionSummary` that verifies non-privileged callers do not receive populated `connectionSummary` objects.

### Testing
- Updated unit tests in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` to cover both privileged visibility and non-privileged redaction of `connectionSummary`.
- Attempted a targeted test run (`dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~MapWorkstationEndpoints_DataOperations"`), but the environment lacks the `.NET` SDK so automated test execution could not be performed here (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f253b73408320a927f0d54330ee8f)