### PR TITLE
security: restore Codex approval gate default

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -3,4 +3,4 @@
 # broader filesystem access or unattended execution.
 sandbox_mode = "workspace-write"
 
-approval_policy = "never"
+approval_policy = "on-request"

--- a/.codex/environments/README.md
+++ b/.codex/environments/README.md
@@ -9,8 +9,9 @@ The matching Codex environment config lives in `.codex/environments/environment.
 
 ## Script Access
 
-Codex has workspace write access for this repository, including the full `scripts/` tree.
-You can execute repository scripts directly, for example:
+Codex runs with workspace write sandboxing for this repository, and script execution may require
+operator approval depending on the active approval policy.
+You can execute repository scripts (after approval when prompted), for example:
 
 ```bash
 bash scripts/ai/setup.sh


### PR DESCRIPTION
### Motivation
- Reinstate the repository-local Codex fail-closed approval behavior to remediate a hardening regression that allowed unattended `workspace-write` script execution when `approval_policy` was set to `never`.

### Description
- Set `approval_policy = "on-request"` in `.codex/config.toml` and updated `.codex/environments/README.md` to clarify that script execution may require operator approval while preserving the documented script examples.

### Testing
- Verified the changes and file contents with automated checks: `rg -n 'approval_policy|workspace write|approval' .codex/config.toml .codex/environments/README.md` and `nl -ba .codex/config.toml` which show `approval_policy = "on-request"` and the updated README lines; all checks exited successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f23c0743883209f4919ca0287b7ab)