### PR TITLE
Fix provider capability catalog: remove Polygon corporate-actions mapping

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/Core/ProviderCapabilityDescriptorCatalog.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/ProviderCapabilityDescriptorCatalog.cs
@@ -25,7 +25,7 @@ public static class ProviderCapabilityDescriptorCatalog
         new("synthetic", Historical: typeof(SyntheticHistoricalDataProvider)),
         new("ib", Historical: typeof(IBHistoricalDataProvider)),
         new("yahoo", Historical: typeof(YahooFinanceHistoricalDataProvider)),
-        new("polygon", Historical: typeof(PolygonHistoricalDataProvider), Search: typeof(PolygonSymbolSearchProvider), CorporateActions: typeof(PolygonCorporateActionFetcher)),
+        new("polygon", Historical: typeof(PolygonHistoricalDataProvider), Search: typeof(PolygonSymbolSearchProvider)),
         new("tiingo", Historical: typeof(TiingoHistoricalDataProvider)),
         new("finnhub", Historical: typeof(FinnhubHistoricalDataProvider), Search: typeof(FinnhubSymbolSearchProviderRefactored)),
         new("stooq", Historical: typeof(StooqHistoricalDataProvider)),


### PR DESCRIPTION
### Motivation
- The provider capability catalog advertised `PolygonCorporateActionFetcher` as a corporate-actions provider even though that type implements `IPolygonCorporateActionFetcher`/`IHostedService` and not `ICorporateActionProvider`, which breaks the descriptor/test contract and can cause build/test failures.

### Description
- Removed the `CorporateActions: typeof(PolygonCorporateActionFetcher)` mapping from `src/Meridian.Infrastructure/Adapters/Core/ProviderCapabilityDescriptorCatalog.cs`, leaving the Polygon descriptor with `Historical` and `Search` only; the Alpaca brokerage descriptor was intentionally left unchanged.

### Testing
- Attempted to run the focused unit test `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ProviderCapabilityDescriptorCatalogTests"`, but the environment lacks the .NET SDK so automated tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f253b97708320bd7a9761cdaec037)