### PR TITLE
Only send GUID fundAccountId for trading readiness refresh

### DIFF
--- a/src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx
@@ -407,7 +407,8 @@ export function TradingScreen({ data }: TradingScreenProps) {
   const { pathname } = useLocation();
   const shellVm = useTradingScreenShellViewModel({ pathname, data });
   const blotterVm = useTradingBlotterViewModel(data);
-  const tradingReadiness = useTradingReadinessViewModel({ initialReadiness: data?.readiness ?? null, fundAccountId: data?.brokerage?.account ?? undefined });
+  const fundAccountId = asGuid(data?.brokerage?.account);
+  const tradingReadiness = useTradingReadinessViewModel({ initialReadiness: data?.readiness ?? null, fundAccountId });
   const executionEvidence = useExecutionEvidenceViewModel();
 
   const orderTicket = useOrderTicketViewModel({
@@ -1669,6 +1670,16 @@ export function TradingScreen({ data }: TradingScreenProps) {
       <ConfirmActionDialog vm={confirmVm} />
     </div>
   );
+}
+
+function asGuid(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+    ? value
+    : undefined;
 }
 
 function buildCockpitAcceptance({


### PR DESCRIPTION
### Motivation
- The trading UI forwarded `data.brokerage.account` into the `fundAccountId` query while the backend binds `fundAccountId` as `Guid?`, so non-GUID account labels (e.g. `DU1009034`) caused ASP.NET to reject readiness refresh requests with 400 errors.

### Description
- Compute a guarded `fundAccountId` in `src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx` using a new `asGuid` helper that returns the value only if it matches GUID syntax.
- Pass the guarded `fundAccountId` to `useTradingReadinessViewModel` instead of the raw `data?.brokerage?.account`, preserving behavior for real GUIDs and omitting display/account labels that are not GUIDs.
- Change is limited to the trading screen component and does not alter backend signing or API surface.

### Testing
- Attempted to run the dashboard test slice with `npm --prefix src/Meridian.Ui/dashboard run test -- trading-screen.test.tsx`, but the test run failed in this environment because `vitest` was not installed (`Cannot find module .../node_modules/vitest/vitest.mjs`), so no automated tests executed here.
- Recommend running `npm install` in `src/Meridian.Ui/dashboard` and then `npm run test` (or the project CI) to validate component and view-model tests after merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f253a36e08320bab4039326b575d8)