### PR TITLE
Add missing PyYAML dependency for source README validator

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,3 +7,4 @@ dependencies:
   - flake8
   - pytest
   - pillow
+  - pyyaml


### PR DESCRIPTION
### Motivation
- The source README validator `tools/source_docs/validate_source_readmes.py` imports `yaml` at module load time but the repository Python environment manifest did not declare PyYAML, causing `ModuleNotFoundError` in clean environments and preventing the validator from running.

### Description
- Add `pyyaml` to `environment.yml` dependencies so the validator can import `yaml` without changing the validator logic or behavior.

### Testing
- Ran `python3 tools/source_docs/validate_source_readmes.py --help` in the current container after the change and it still failed because the active interpreter environment was not rebuilt from `environment.yml`, demonstrating the original failure mode; the repository now declares the dependency so fresh environment bootstraps will install it.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e3fab5104832096e04827afec6720)