### PR TITLE
Redact sensitive provider query parameters in shared debug logging

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/Core/BaseHistoricalDataProvider.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/BaseHistoricalDataProvider.cs
@@ -276,7 +276,7 @@ public abstract class BaseHistoricalDataProvider : IHistoricalDataProvider, IRat
         ThrowIfDisposed();
         await WaitForRateLimitSlotAsync(ct).ConfigureAwait(false);
 
-        Log.Debug("Requesting {Provider} {DataType} for {Symbol}: {Url}", Name, dataType, symbol, url);
+        Log.Debug("Requesting {Provider} {DataType} for {Symbol}: {Url}", Name, dataType, symbol, RedactSensitiveQueryParameters(url));
 
         // Execute with resilience pipeline (retry, circuit breaker)
         var response = await ResiliencePipeline.ExecuteAsync(
@@ -285,6 +285,49 @@ public abstract class BaseHistoricalDataProvider : IHistoricalDataProvider, IRat
 
         return response;
     }
+
+    private static string RedactSensitiveQueryParameters(string url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return url;
+        }
+
+        var builder = new UriBuilder(uri);
+        if (string.IsNullOrEmpty(builder.Query))
+        {
+            return url;
+        }
+
+        var query = builder.Query.TrimStart('?');
+        var parts = query.Split('&', StringSplitOptions.RemoveEmptyEntries);
+
+        for (var i = 0; i < parts.Length; i++)
+        {
+            var equalsIndex = parts[i].IndexOf('=');
+            if (equalsIndex <= 0)
+            {
+                continue;
+            }
+
+            var key = parts[i][..equalsIndex];
+            if (!IsSensitiveQueryKey(key))
+            {
+                continue;
+            }
+
+            parts[i] = $"{key}=REDACTED";
+        }
+
+        builder.Query = string.Join('&', parts);
+        return builder.Uri.ToString();
+    }
+
+    private static bool IsSensitiveQueryKey(string key) =>
+        key.Equals("apikey", StringComparison.OrdinalIgnoreCase) ||
+        key.Equals("api_key", StringComparison.OrdinalIgnoreCase) ||
+        key.Equals("token", StringComparison.OrdinalIgnoreCase) ||
+        key.Equals("access_token", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Execute an HTTP GET request, handle the response, and return the content string.


### PR DESCRIPTION
### Motivation
- Prevent accidental leakage of provider credentials because the shared `ExecuteGetAsync` helper previously debug-logged full request URLs that can contain API keys in query parameters.
- Keep provider behavior unchanged while ensuring logs do not expose secrets when debug logging is enabled.

### Description
- Updated `BaseHistoricalDataProvider.ExecuteGetAsync` to log a sanitized URL instead of the raw URL by calling `RedactSensitiveQueryParameters(url)` before emitting the debug message.
- Added `RedactSensitiveQueryParameters` helper and `IsSensitiveQueryKey` predicate inside `BaseHistoricalDataProvider` to redact common secret-bearing query keys (`apikey`, `api_key`, `token`, `access_token`) while preserving the rest of the URL.
- The change only affects log output and does not modify outbound HTTP request URLs or the resilience/request execution pipeline.

### Testing
- Attempted to run local .NET validation (`dotnet --version` / `dotnet test`), but the environment lacks the .NET SDK/runtime so automated tests could not be executed (`dotnet: command not found`).
- The fix was verified by source inspection and by confirming the new logging call replaces the raw URL with a redacted variant in `BaseHistoricalDataProvider` (file: `src/Meridian.Infrastructure/Adapters/Core/BaseHistoricalDataProvider.cs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e3e8dbfa08320b50cee9ad8ebbcdc)