### PR TITLE
Avoid exposing SPSC hot-path globally by using EventPipeline for global publisher

### DIFF
--- a/src/Meridian.Application/Composition/Features/CanonicalizationFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/CanonicalizationFeatureRegistration.cs
@@ -64,8 +64,7 @@ internal sealed class CanonicalizationFeatureRegistration : IServiceFeatureRegis
         services.AddSingleton<CanonicalizingPublisher>(sp =>
         {
             var metrics = sp.GetRequiredService<IEventMetrics>();
-            IMarketEventPublisher pipelinePublisher = sp.GetService<DualPathEventPipeline>()
-                ?? (IMarketEventPublisher)sp.GetRequiredService<EventPipeline>();
+            IMarketEventPublisher pipelinePublisher = sp.GetRequiredService<EventPipeline>();
             var innerPublisher = new PipelinePublisher(pipelinePublisher, metrics);
 
             var configStore = sp.GetRequiredService<ConfigStore>();

--- a/src/Meridian.Application/Composition/Features/PipelineFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/PipelineFeatureRegistration.cs
@@ -223,8 +223,7 @@ internal sealed class PipelineFeatureRegistration : IServiceFeatureRegistration
             }
 
             var metrics = sp.GetRequiredService<IEventMetrics>();
-            IMarketEventPublisher innerPublisher = sp.GetService<DualPathEventPipeline>()
-                ?? (IMarketEventPublisher)sp.GetRequiredService<EventPipeline>();
+            IMarketEventPublisher innerPublisher = sp.GetRequiredService<EventPipeline>();
             IMarketEventPublisher publisher = new PipelinePublisher(
                 innerPublisher,
                 metrics);


### PR DESCRIPTION
### Motivation

- `DualPathEventPipeline` routes trades and quotes through `SpscRingBuffer` instances which require exactly one producer, and exposing it as a singleton for the application-wide publisher allows concurrent producers to race and lose accepted events. 
- The change prevents multi-producer callers from entering a single-producer hot path so that slow-path durable publishing remains the default for shared publisher usage.

### Description

- Stop selecting `DualPathEventPipeline` as the inner `IMarketEventPublisher` for the global publisher and instead use `EventPipeline` as the resolved inner publisher in the shared registration path. 
- Apply the same safe selection to canonicalization wiring so `CanonicalizingPublisher` wraps the `EventPipeline` rather than attempting to use `DualPathEventPipeline`. 
- Changes are limited to DI/publisher wiring in `PipelineFeatureRegistration.cs` and `CanonicalizationFeatureRegistration.cs`; `DualPathEventPipeline` remains available but is no longer chosen as the global shared publisher.

### Testing

- Inspected and validated the DI registration changes and the resulting source diff to confirm the global publisher now resolves `EventPipeline` instead of `DualPathEventPipeline`. 
- No automated .NET unit or integration tests were executed in this environment because the `dotnet` SDK/runtime was not available, so no runtime test pass was performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e3e8e15e083208b1317f41ecb21f3)