### PR TITLE
Fix WebSocket reconnect deadlock caused by receive-loop self-await

### DIFF
--- a/src/Meridian.Infrastructure/Resilience/WebSocketConnectionManager.cs
+++ b/src/Meridian.Infrastructure/Resilience/WebSocketConnectionManager.cs
@@ -662,12 +662,21 @@ public sealed class WebSocketConnectionManager : IAsyncDisposable
             catch (Exception ex) { _log.Debug(ex, "{Provider} CTS cancel failed during cleanup", _providerName); }
         }
 
-        // 3. Wait for the receive task to complete before disposing resources it uses
+        // 3. Wait for the receive task to complete before disposing resources it uses.
+        // Avoid self-await if cleanup is executing on the receive loop task itself.
         if (receiveTask != null)
         {
-            try
-            { await receiveTask.WaitAsync(ct).ConfigureAwait(false); }
-            catch (Exception ex) { _log.Debug(ex, "{Provider} receive task failed during cleanup", _providerName); }
+            var currentTaskId = Task.CurrentId;
+            if (currentTaskId.HasValue && receiveTask.Id == currentTaskId.Value)
+            {
+                _log.Debug("{Provider} skipping receive task self-await during cleanup", _providerName);
+            }
+            else
+            {
+                try
+                { await receiveTask.WaitAsync(ct).ConfigureAwait(false); }
+                catch (Exception ex) { _log.Debug(ex, "{Provider} receive task failed during cleanup", _providerName); }
+            }
         }
 
         // 4. Now safe to dispose CTS and WebSocket — receive loop has exited


### PR DESCRIPTION
### Motivation
- Fix a deadlock where the receive-loop could invoke the connection-lost handler inline and the reconnect path then awaited the same receive-loop task (self-await), blocking reconnection and causing a persistent streaming outage.

### Description
- In `WebSocketConnectionManager.CleanupConnectionAsync` skip awaiting the captured `_receiveTask` when `Task.CurrentId` equals `receiveTask.Id`, logging a debug message and preserving the existing `WaitAsync` behavior for all other cases.

### Testing
- Attempted a focused unit test run: `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~WebSocketConnectionManagerTests"`, but the environment lacks the .NET SDK (`dotnet: command not found`), so automated tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e3e8eac108320a1f02e3a1df7a49b)