### PR TITLE
fix(nyse): reset reconnect cancellation token on manual connect

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/NYSE/NYSEDataSource.cs
+++ b/src/Meridian.Infrastructure/Adapters/NYSE/NYSEDataSource.cs
@@ -230,6 +230,12 @@ public sealed class NYSEDataSource : DataSourceBase, IRealtimeDataSource, IHisto
 
         await EnsureAuthenticatedAsync(ct).ConfigureAwait(false);
 
+        if (_reconnectCts.IsCancellationRequested)
+        {
+            _reconnectCts.Dispose();
+            _reconnectCts = new CancellationTokenSource();
+        }
+
         Log.Information("Connecting to NYSE WebSocket at {Url}", _options.EffectiveWebSocketUrl);
 
         try


### PR DESCRIPTION
### Motivation
- Prevent post-reconnect subscription sends from using a previously canceled `_reconnectCts.Token` after a manual `DisconnectAsync` followed by `ConnectAsync`, which could cause `SendAsync` calls to be canceled and leave local subscription state inconsistent with the NYSE server.

### Description
- Recreate `_reconnectCts` in `ConnectAsync` when `IsCancellationRequested` by disposing the old `CancellationTokenSource` and assigning a new `CancellationTokenSource` so subsequent subscription/unsubscription sends use a valid token (change in `src/Meridian.Infrastructure/Adapters/NYSE/NYSEDataSource.cs`).

### Testing
- Attempted to run the focused lifecycle tests `dotnet test ... --filter "FullyQualifiedName~NyseSharedLifecycleTests"`, but test execution could not be run here because `dotnet` is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8a45f8a48320ae33185e578bd11f)