### PR TITLE
fix: handle provider module discovery constructor failures

### DIFF
--- a/src/Meridian.ProviderSdk/ProviderModuleLoader.cs
+++ b/src/Meridian.ProviderSdk/ProviderModuleLoader.cs
@@ -60,8 +60,15 @@ public sealed class ProviderModuleLoader
         if (assemblies is null || assemblies.Length == 0)
             throw new ArgumentException("At least one assembly must be provided.", nameof(assemblies));
 
-        var modules = DiscoverModules(assemblies);
-        return await LoadModulesAsync(services, registry, modules, ct).ConfigureAwait(false);
+        var discovery = DiscoverModules(assemblies);
+        var report = await LoadModulesAsync(services, registry, discovery.Modules, ct).ConfigureAwait(false);
+        if (discovery.Failed.Count == 0)
+        {
+            return report;
+        }
+
+        var failed = report.Failed.Concat(discovery.Failed).ToArray();
+        return new ModuleLoadReport(report.Loaded, failed, report.TotalDiscovered + discovery.Failed.Count);
     }
 
     /// <summary>
@@ -141,9 +148,10 @@ public sealed class ProviderModuleLoader
     // Private helpers
     // ------------------------------------------------------------------
 
-    private IReadOnlyList<IProviderModule> DiscoverModules(Assembly[] assemblies)
+    private (IReadOnlyList<IProviderModule> Modules, IReadOnlyList<FailedModuleInfo> Failed) DiscoverModules(Assembly[] assemblies)
     {
         var modules = new List<IProviderModule>();
+        var failed = new List<FailedModuleInfo>();
 
         foreach (var assembly in assemblies)
         {
@@ -165,21 +173,33 @@ public sealed class ProviderModuleLoader
                 if (!typeof(IProviderModule).IsAssignableFrom(type))
                     continue;
 
-                if (Activator.CreateInstance(type) is IProviderModule module)
+                try
                 {
-                    modules.Add(module);
-                    _log.LogDebug("Discovered provider module {Type} ({ModuleId})", type.Name, module.ModuleId);
+                    if (Activator.CreateInstance(type) is IProviderModule module)
+                    {
+                        modules.Add(module);
+                        _log.LogDebug("Discovered provider module {Type} ({ModuleId})", type.Name, module.ModuleId);
+                    }
+                    else
+                    {
+                        _log.LogWarning(
+                            "Type {Type} implements IProviderModule but could not be instantiated via Activator.CreateInstance. " +
+                            "Use the LoadModulesAsync overload that accepts pre-built instances.", type.FullName);
+                        failed.Add(new FailedModuleInfo(type.Name, type.Name,
+                            "Could not instantiate provider module via Activator.CreateInstance.", null));
+                    }
                 }
-                else
+                catch (Exception ex)
                 {
-                    _log.LogWarning(
-                        "Type {Type} implements IProviderModule but could not be instantiated via Activator.CreateInstance. " +
-                        "Use the LoadModulesAsync overload that accepts pre-built instances.", type.FullName);
+                    _log.LogWarning(ex,
+                        "Skipping provider module type {Type} because Activator.CreateInstance threw during discovery.",
+                        type.FullName);
+                    failed.Add(new FailedModuleInfo(type.Name, type.Name, ex.Message, ex));
                 }
             }
         }
 
-        return modules;
+        return (modules, failed);
     }
 }
 

--- a/tests/Meridian.Tests/ProviderSdk/ProviderModuleLoaderTests.cs
+++ b/tests/Meridian.Tests/ProviderSdk/ProviderModuleLoaderTests.cs
@@ -92,6 +92,22 @@ public sealed class ProviderModuleLoaderTests
         report.AnyLoaded.Should().BeFalse();
     }
 
+    [Fact]
+    public async Task LoadFromAssembliesAsync_ModuleConstructorThrows_ReportsFailureWithoutBubbling()
+    {
+        var loader = new ProviderModuleLoader();
+        var services = new ServiceCollection();
+        var registry = new DataSourceRegistry();
+
+        var report = await loader.LoadFromAssembliesAsync(
+            services, registry, CancellationToken.None,
+            typeof(ThrowingConstructorProviderModule).Assembly);
+
+        report.LoadedCount.Should().BeGreaterThan(0);
+        report.FailedCount.Should().BeGreaterThan(0);
+        report.Failed.Should().Contain(f => f.ModuleId == nameof(ThrowingConstructorProviderModule));
+    }
+
     // -----------------------------------------------------------------------
     // Explicit module list
     // -----------------------------------------------------------------------
@@ -374,6 +390,16 @@ internal sealed class ThrowingRegisterProviderModule : IProviderModule
 
     public void Register(IServiceCollection services, DataSourceRegistry registry)
         => throw new InvalidOperationException("Simulated registration failure.");
+}
+
+internal sealed class ThrowingConstructorProviderModule : IProviderModule
+{
+    public ThrowingConstructorProviderModule()
+    {
+        throw new InvalidOperationException("Simulated constructor failure.");
+    }
+
+    public void Register(IServiceCollection services, DataSourceRegistry registry) { }
 }
 
 /// <summary>


### PR DESCRIPTION
### Motivation
- Assembly scanning could be aborted when `Activator.CreateInstance` throws for a malformed `IProviderModule` type, causing discovery to crash instead of reporting a failure. 
- The loader should skip and record per-module instantiation failures so a single broken module does not prevent others from loading. 
- Preserve the existing `ModuleLoadReport` failure-reporting behavior by including discovery-time failures in the final report. 

### Description
- Changed `LoadFromAssembliesAsync` to accept the discovery return value and merge discovery-time `FailedModuleInfo` entries into the returned `ModuleLoadReport`. 
- Reworked `DiscoverModules` to return `(Modules, Failed)` instead of just modules and added a per-type `try/catch` around `Activator.CreateInstance` to log and record instantiation exceptions as `FailedModuleInfo`. 
- When `Activator.CreateInstance` succeeds but does not produce an `IProviderModule`, the code now records a `FailedModuleInfo` entry instead of only logging a warning. 
- Files updated: `src/Meridian.ProviderSdk/ProviderModuleLoader.cs` and `tests/Meridian.Tests/ProviderSdk/ProviderModuleLoaderTests.cs` (added `ThrowingConstructorProviderModule` and a regression test `LoadFromAssembliesAsync_ModuleConstructorThrows_ReportsFailureWithoutBubbling`). 

### Testing
- Added an automated unit test `LoadFromAssembliesAsync_ModuleConstructorThrows_ReportsFailureWithoutBubbling` in `tests/Meridian.Tests/ProviderSdk/ProviderModuleLoaderTests.cs` that asserts discovery reports a failed module when a constructor throws. 
- Attempted to run `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ProviderModuleLoaderTests"`, but the execution environment lacks `dotnet` (`/bin/bash: dotnet: command not found`), so the test run could not be executed here; CI or a local environment with the .NET SDK should run the tests to verify the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8a465c44832088f65f4b8aac18bc)