### PR TITLE
Preserve floating bond coupon fields in SecurityMaster snapshot serialization

### DIFF
--- a/src/Meridian.FSharp/Interop.SecurityMaster.fs
+++ b/src/Meridian.FSharp/Interop.SecurityMaster.fs
@@ -125,17 +125,21 @@ type SecurityMasterSnapshotWrapper(record: SecurityMasterRecord) =
                    expiry = terms.Expiry
                    multiplier = terms.Multiplier |})
         | SecurityKind.Bond terms ->
-            let couponType =
+            let couponType, floatingIndex, spreadBps, capRate, floorRate =
                 match terms.Coupon with
-                | BondCouponStructure.Fixed _ -> "Fixed"
-                | BondCouponStructure.Floating _ -> "Floating"
-                | BondCouponStructure.ZeroCoupon -> "ZeroCoupon"
+                | BondCouponStructure.Fixed _ -> "Fixed", None, None, None, None
+                | BondCouponStructure.Floating(index, spread, cap, floor, _) -> "Floating", Some index, spread, cap, floor
+                | BondCouponStructure.ZeroCoupon -> "ZeroCoupon", None, None, None, None
             JsonSerializer.Serialize(
                 {| schemaVersion = schemaVersion
                    maturity = terms.Maturity
                    issueDate = terms.IssueDate
                    couponType = couponType
                    couponRate = BondTerms.couponRate terms
+                   floatingIndex = floatingIndex
+                   spreadBps = spreadBps
+                   capRate = capRate
+                   floorRate = floorRate
                    dayCount = BondTerms.dayCount terms
                    isCallable = terms.IsCallable
                    callDate = terms.CallDate

--- a/tests/Meridian.FSharp.Tests/DomainTests.fs
+++ b/tests/Meridian.FSharp.Tests/DomainTests.fs
@@ -534,6 +534,38 @@ let ``SecurityMasterSnapshotWrapper serializes current equity payload and identi
     wrapper.Currency |> should equal "USD"
 
 [<Fact>]
+let ``SecurityMasterSnapshotWrapper serializes floating bond coupon details`` () =
+    let maturity = DateOnly(2034, 9, 15)
+    let bondTerms = {
+        Maturity = maturity
+        IssueDate = Some (DateOnly(2024, 9, 15))
+        Coupon = BondCouponStructure.Floating("SOFR", Some 150m, Some 7.25m, Some 0.75m, Some "ACT/360")
+        IsCallable = true
+        CallDate = Some (DateOnly(2030, 9, 15))
+        IssuerName = Some "Meridian Capital"
+        Seniority = Some "Senior Unsecured"
+        Subclass = BondSubclass.FloatingRate
+    }
+    let command = createValidCommand () |> mapKind (fun _ -> SecurityKind.Bond bondTerms)
+
+    let record =
+        match SecurityMaster.create command with
+        | Ok [ SecurityMasterEvent.SecurityCreated snapshot ] -> snapshot
+        | Ok events -> failwithf "Expected SecurityCreated event, got: %A" events
+        | Error errors -> failwithf "Expected create to succeed, got: %A" errors
+
+    let wrapper = SecurityMasterSnapshotWrapper(record)
+    use assetDocument = JsonDocument.Parse(wrapper.AssetSpecificTermsJson)
+    let payload = assetDocument.RootElement
+
+    payload.GetProperty("couponType").GetString() |> should equal "Floating"
+    payload.GetProperty("floatingIndex").GetString() |> should equal "SOFR"
+    payload.GetProperty("spreadBps").GetDecimal() |> should equal 150m
+    payload.GetProperty("capRate").GetDecimal() |> should equal 7.25m
+    payload.GetProperty("floorRate").GetDecimal() |> should equal 0.75m
+    payload.GetProperty("dayCount").GetString() |> should equal "ACT/360"
+
+[<Fact>]
 let ``SecurityMasterLegacyUpgrade maps preferred classification into term modules`` () =
     let preferredTerms, _, classification = createConvertiblePreferredClassification ()
     let record = createSecurityRecord (Some classification)


### PR DESCRIPTION
### Motivation
- Floating-rate bond support added a required `floatingIndex` (and optional `spreadBps`, `capRate`, `floorRate`) when mapping serialized projections back to domain `BondTerms`, but the snapshot serializer omitted those fields causing a lossy round-trip and runtime failures. 
- The change aims to make projections non-lossy so the immediate reparse performed after create/amend does not throw for valid floating bonds.

### Description
- Update `SecurityMasterSnapshotWrapper` (`src/Meridian.FSharp/Interop.SecurityMaster.fs`) to emit `floatingIndex`, `spreadBps`, `capRate`, and `floorRate` when a bond's `Coupon` is `Floating`, while preserving existing behavior for `Fixed` and `ZeroCoupon` bonds. 
- Add a focused F# unit test (`tests/Meridian.FSharp.Tests/DomainTests.fs`) that creates a floating-rate bond and asserts the serialized asset payload contains `couponType = "Floating"` plus `floatingIndex`, `spreadBps`, `capRate`, `floorRate`, and `dayCount`.

### Testing
- Attempted to run the focused F# tests with `dotnet test --filter "FullyQualifiedName~SecurityMasterSnapshotWrapper"`, but the automation environment lacks `dotnet` so the tests could not be executed here (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8c0e52288320a0cb686f25d6811a)