### PR TITLE
fix(security-master): validate search query and skip input

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
@@ -96,6 +96,18 @@ public static class SecurityMasterEndpoints
             [FromServices] ISecurityMasterQueryService queryService,
             CancellationToken ct) =>
         {
+            if (string.IsNullOrWhiteSpace(request.Query))
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["query"] = ["Query is required."]
+                });
+
+            if (request.Skip < 0)
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["skip"] = ["Skip must be non-negative."]
+                });
+
             var results = await queryService.SearchAsync(request, ct).ConfigureAwait(false);
             return Results.Json(results, jsonOptions);
         })

--- a/tests/Meridian.Tests/Ui/SecurityMasterIngestStatusEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/SecurityMasterIngestStatusEndpointsTests.cs
@@ -19,6 +19,56 @@ namespace Meridian.Tests.Ui;
 public sealed class SecurityMasterIngestStatusEndpointsTests
 {
     [Fact]
+    public async Task MapSecurityMasterEndpoints_SearchRoute_ReturnsBadRequest_WhenQueryMissing()
+    {
+        var queryService = Substitute.For<ContractsSecurityMasterQueryService>();
+        var conflictService = Substitute.For<ISecurityMasterConflictService>();
+        var ingestStatusService = Substitute.For<ISecurityMasterIngestStatusService>();
+        var commandService = Substitute.For<ISecurityMasterService>();
+        var importService = Substitute.For<ISecurityMasterImportService>();
+        var eventStore = Substitute.For<ISecurityMasterEventStore>();
+
+        await using var app = await CreateAppAsync(
+            queryService,
+            conflictService,
+            ingestStatusService,
+            commandService,
+            importService,
+            eventStore);
+        var client = app.GetTestClient();
+
+        using var response = await client.PostAsJsonAsync(UiApiRoutes.SecurityMasterSearch, new { query = (string?)null });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await queryService.DidNotReceive().SearchAsync(Arg.Any<SecuritySearchRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MapSecurityMasterEndpoints_SearchRoute_ReturnsBadRequest_WhenSkipNegative()
+    {
+        var queryService = Substitute.For<ContractsSecurityMasterQueryService>();
+        var conflictService = Substitute.For<ISecurityMasterConflictService>();
+        var ingestStatusService = Substitute.For<ISecurityMasterIngestStatusService>();
+        var commandService = Substitute.For<ISecurityMasterService>();
+        var importService = Substitute.For<ISecurityMasterImportService>();
+        var eventStore = Substitute.For<ISecurityMasterEventStore>();
+
+        await using var app = await CreateAppAsync(
+            queryService,
+            conflictService,
+            ingestStatusService,
+            commandService,
+            importService,
+            eventStore);
+        var client = app.GetTestClient();
+
+        using var response = await client.PostAsJsonAsync(UiApiRoutes.SecurityMasterSearch, new { query = "AAPL", skip = -1 });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await queryService.DidNotReceive().SearchAsync(Arg.Any<SecuritySearchRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task MapSecurityMasterEndpoints_IngestStatusRoute_ReturnsTypedPayload()
     {
         var queryService = Substitute.For<ContractsSecurityMasterQueryService>();


### PR DESCRIPTION
### Motivation
- Prevent runtime errors caused by unvalidated search inputs, specifically a `NullReferenceException` from `request.Query.Trim()` when `query` is null or missing and a PostgreSQL error when a negative `skip` is passed into `OFFSET`.

### Description
- Added runtime validation to the Security Master search endpoint (`src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs`) that returns HTTP 400 `ValidationProblem` when `query` is null/blank or when `skip` is negative.
- Added endpoint tests (`tests/Meridian.Tests/Ui/SecurityMasterIngestStatusEndpointsTests.cs`) that assert a `BadRequest` response for a missing `query` and for a negative `skip`, and verify the query service is not invoked when validation fails.

### Testing
- Added two automated endpoint tests covering missing `query` and negative `skip` inputs, both asserting `HttpStatusCode.BadRequest` and that `SearchAsync` is not called. These tests were added to the test suite but not executed here due to the environment missing the .NET SDK.
- Attempted to run the focused test command `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~SecurityMasterIngestStatusEndpointsTests"`, which failed in this environment with `/bin/bash: dotnet: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8a460674832087fee00db1676eee)