### PR TITLE
fix(direct-lending): replay `loan.prepayment-penalty-charged` events in rebuilder and update endpoint test

### DIFF
--- a/src/Meridian.Application/DirectLending/DirectLendingEventRebuilder.cs
+++ b/src/Meridian.Application/DirectLending/DirectLendingEventRebuilder.cs
@@ -212,6 +212,30 @@ public sealed class DirectLendingEventRebuilder
                         break;
                     }
 
+
+                case "loan.prepayment-penalty-charged":
+                    {
+                        EnsureInitialized(contract, servicing, entry.EventType);
+                        var effectiveDate = entry.EffectiveDate ?? Deserialize<DateOnly>(root, "effectiveDate");
+                        var penaltyAmount = root.GetProperty("penaltyAmount").GetDecimal();
+
+                        servicing = servicing! with
+                        {
+                            Balances = servicing.Balances with
+                            {
+                                PenaltyAccruedUnpaid = servicing.Balances.PenaltyAccruedUnpaid + penaltyAmount
+                            },
+                            ServicingRevision = servicing.ServicingRevision + 1,
+                            RevisionHistory = PrependRevision(
+                                servicing.RevisionHistory,
+                                servicing.ServicingRevision + 1,
+                                "InternalEvent",
+                                effectiveDate,
+                                $"Prepayment penalty charged for {penaltyAmount:0.00}.",
+                                entry.RecordedAt)
+                        };
+                        break;
+                    }
                 case "loan.daily-accrual-posted":
                     {
                         EnsureInitialized(contract, servicing, entry.EventType);

--- a/tests/Meridian.Tests/Ui/DirectLendingEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/DirectLendingEndpointsTests.cs
@@ -49,6 +49,11 @@ public sealed class DirectLendingEndpointsTests
             new PostDailyAccrualRequest(new DateOnly(2026, 3, 24)));
         accrualResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
+        var penaltyResponse = await client.PostAsJsonAsync(
+            $"/api/loans/{created.LoanId}/prepayment-penalty",
+            new ChargePrepaymentPenaltyRequest(200_000m, new DateOnly(2026, 3, 24), "prepay-rebuild"));
+        penaltyResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
         var accrual = await accrualResponse.Content.ReadFromJsonAsync<DailyAccrualEntryDto>();
         accrual.Should().NotBeNull();
         accrual!.InterestAmount.Should().BeApproximately(44.444444444m, 0.000000001m);
@@ -85,12 +90,13 @@ public sealed class DirectLendingEndpointsTests
 
         var history = await client.GetFromJsonAsync<List<LoanEventLineageDto>>($"/api/loans/{created.LoanId}/history");
         history.Should().NotBeNull();
-        history!.Should().HaveCount(4);
+        history!.Should().HaveCount(5);
         history.Select(static item => item.EventType).Should().ContainInOrder(
             "loan.created",
             "loan.activated",
             "loan.drawdown-booked",
-            "loan.daily-accrual-posted");
+            "loan.daily-accrual-posted",
+            "loan.prepayment-penalty-charged");
         history.All(static item => item.CommandId.HasValue).Should().BeTrue();
         history.All(static item => item.CorrelationId.HasValue).Should().BeTrue();
         history.All(static item => item.ReplayFlag is false).Should().BeTrue();
@@ -99,7 +105,8 @@ public sealed class DirectLendingEndpointsTests
         rebuildResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var rebuilt = await rebuildResponse.Content.ReadFromJsonAsync<LoanAggregateSnapshotDto>();
         rebuilt.Should().NotBeNull();
-        rebuilt!.AggregateVersion.Should().Be(4);
+        rebuilt!.AggregateVersion.Should().Be(5);
+        rebuilt.Servicing.Balances.PenaltyAccruedUnpaid.Should().Be(4_000m);
         rebuilt.Servicing.AccrualEntries.Should().ContainSingle();
 
         var termsVersions = await client.GetFromJsonAsync<List<LoanTermsVersionDto>>($"/api/loans/{created.LoanId}/terms-versions");


### PR DESCRIPTION
### Motivation
- The `ChargePrepaymentPenalty` flows emit `loan.prepayment-penalty-charged` events but the event-sourced rebuild path did not recognize that event type, causing `RebuildStateFromHistoryAsync` and HTTP rebuild endpoints to throw and fail when histories contain the new event.

### Description
- Add a `case "loan.prepayment-penalty-charged"` to `DirectLendingEventRebuilder.Rebuild` that applies the penalty to `Servicing.Balances.PenaltyAccruedUnpaid`, increments `ServicingRevision`, and prepends an internal revision entry to `RevisionHistory` following existing handler patterns.
- Update the direct-lending endpoint lifecycle test (`DirectLendingEndpointsTests`) to invoke the prepayment-penalty command, assert the event appears in history, and assert the rebuilt aggregate version and penalty balance reflect the new event.
- Files changed: `src/Meridian.Application/DirectLending/DirectLendingEventRebuilder.cs`, `tests/Meridian.Tests/Ui/DirectLendingEndpointsTests.cs`.

### Testing
- Attempted focused unit test run with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~DirectLendingEndpoints_ShouldCreateAndFetchLoanLifecycle" --logger "console;verbosity=minimal"`, but the environment lacks the .NET SDK and the command failed with `dotnet: command not found` so tests could not be executed here.
- Applied local static inspection and repository grep to verify the new event handler matches the event payload shape and the updated test expects the updated history and rebuilt state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8a4675288320807c0b8acb47b37c)