### PR TITLE
Cache corporate actions per ticker to avoid repeated Security Master lookups during windowed backtests

### DIFF
--- a/src/Meridian.Backtesting/CorporateActionAdjustmentService.cs
+++ b/src/Meridian.Backtesting/CorporateActionAdjustmentService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Meridian.Application.SecurityMaster;
 using Meridian.Contracts.SecurityMaster;
 using ISecurityMasterQueryService = Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService;
@@ -13,6 +14,7 @@ public sealed class CorporateActionAdjustmentService : ICorporateActionAdjustmen
     private readonly Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService _queryService;
     private readonly ISecurityResolver _resolver;
     private readonly ILogger<CorporateActionAdjustmentService> _logger;
+    private readonly ConcurrentDictionary<string, Task<List<CorporateActionDto>?>> _sortedActionsByTicker = new(StringComparer.OrdinalIgnoreCase);
 
     public CorporateActionAdjustmentService(
         Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService queryService,
@@ -68,7 +70,15 @@ public sealed class CorporateActionAdjustmentService : ICorporateActionAdjustmen
         }
     }
 
-    private async Task<List<CorporateActionDto>?> GetSortedCorporateActionsAsync(string ticker, CancellationToken ct)
+    private Task<List<CorporateActionDto>?> GetSortedCorporateActionsAsync(string ticker, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(ticker))
+            return Task.FromResult<List<CorporateActionDto>?>(null);
+
+        return _sortedActionsByTicker.GetOrAdd(ticker.Trim(), key => LoadSortedCorporateActionsAsync(key, ct));
+    }
+
+    private async Task<List<CorporateActionDto>?> LoadSortedCorporateActionsAsync(string ticker, CancellationToken ct)
     {
         var securityId = await _resolver.ResolveAsync(
             new ResolveSecurityRequest(

--- a/tests/Meridian.Backtesting.Tests/CorporateActionAdjustmentServiceTests.cs
+++ b/tests/Meridian.Backtesting.Tests/CorporateActionAdjustmentServiceTests.cs
@@ -185,6 +185,24 @@ public sealed class CorporateActionAdjustmentServiceTests
     }
 
 
+
+    [Fact]
+    public async Task AdjustAsync_MultipleWindows_ResolvesCorporateActionsOncePerTicker()
+    {
+        var securityId = Guid.NewGuid();
+        _mockResolver.SetResolveResult(securityId);
+        _mockQueryService.SetCorporateActions([]);
+
+        var bars = new[] { CreateBar("SPY", new DateOnly(2024, 1, 1), 100m, 110m, 90m, 105m) };
+
+        _ = await _service.AdjustAsync(bars, "SPY");
+        _ = await _service.AdjustAsync(bars, "SPY");
+        _ = await _service.AdjustAsync(bars, "SPY");
+
+        _mockResolver.ResolveCallCount.Should().Be(1);
+        _mockQueryService.GetCorporateActionsCallCount.Should().Be(1);
+    }
+
     [Fact]
     public async Task AdjustAsync_StreamedLargeHistory_IsEquivalentToBatch()
     {
@@ -273,20 +291,30 @@ public sealed class CorporateActionAdjustmentServiceTests
     {
         private Guid? _result;
 
+        public int ResolveCallCount { get; private set; }
+
         public void SetResolveResult(Guid? result) => _result = result;
 
         public Task<Guid?> ResolveAsync(ResolveSecurityRequest request, CancellationToken ct = default)
-            => Task.FromResult(_result);
+        {
+            ResolveCallCount++;
+            return Task.FromResult(_result);
+        }
     }
 
     private sealed class MockSecurityMasterQueryService : ISecurityMasterQueryService
     {
         private IReadOnlyList<CorporateActionDto> _actions = [];
 
+        public int GetCorporateActionsCallCount { get; private set; }
+
         public void SetCorporateActions(IReadOnlyList<CorporateActionDto> actions) => _actions = actions;
 
         public Task<IReadOnlyList<CorporateActionDto>> GetCorporateActionsAsync(Guid securityId, CancellationToken ct = default)
-            => Task.FromResult(_actions);
+        {
+            GetCorporateActionsCallCount++;
+            return Task.FromResult(_actions);
+        }
 
         public Task<PreferredEquityTermsDto?> GetPreferredEquityTermsAsync(Guid securityId, CancellationToken ct = default)
             => Task.FromResult<PreferredEquityTermsDto?>(null);


### PR DESCRIPTION
### Motivation
- The backtest windowing refactor caused `BacktestEngine` to call the batch corporate-action adjuster once per window, which re-resolves tickers and re-queries corporate actions on every flush and amplifies DB/CPU load for large/attacker-supplied datasets. 
- The change aims to eliminate repeated resolver/query work by caching resolved and sorted corporate actions per ticker for reuse across adjustment invocations.

### Description
- Added a per-ticker cache field `ConcurrentDictionary<string, Task<List<CorporateActionDto>?>> _sortedActionsByTicker` to `src/Meridian.Backtesting/CorporateActionAdjustmentService.cs` and wired lookups through it. 
- Reworked `GetSortedCorporateActionsAsync` to return cached tasks via `GetOrAdd` and introduced `LoadSortedCorporateActionsAsync` to perform the original resolve + query + sort logic, preserving behavior for empty/unknown/no-action cases. 
- Added a regression unit test `AdjustAsync_MultipleWindows_ResolvesCorporateActionsOncePerTicker` to `tests/Meridian.Backtesting.Tests/CorporateActionAdjustmentServiceTests.cs` that asserts the resolver and corporate-action query are invoked only once across repeated `AdjustAsync` calls for the same ticker.

### Testing
- Added the unit test `AdjustAsync_MultipleWindows_ResolvesCorporateActionsOncePerTicker` to verify caching semantics. 
- Attempted to run `dotnet test tests/Meridian.Backtesting.Tests/Meridian.Backtesting.Tests.csproj --filter "FullyQualifiedName~CorporateActionAdjustmentServiceTests" --logger "console;verbosity=minimal"`, but the command failed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`). 
- No automated test run completed here; please run the test suite in a developer or CI environment with the .NET SDK to validate the added test and caching behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4027d6cc832090c402e7c747b4b5)