### PR TITLE
Block InMemory / non-production DI registrations on Production startup

### DIFF
--- a/docs/developer/build-test-run.md
+++ b/docs/developer/build-test-run.md
@@ -163,3 +163,31 @@ make ai-docs-archive-execute
 python3 build/scripts/docs/scan-todos.py --json-output docs/status/todo-scan-results.json
 python3 build/scripts/docs/validate-todo-registry.py --scan-json docs/status/todo-scan-results.json --registry docs/source/todo-registry.json --enforce-prefix docs/source/
 ```
+
+## Production DI policy: non-production service bindings
+
+Meridian now enforces a startup policy that blocks in-memory service implementations in production profiles.
+
+**Production detection sources (any one):**
+- `ASPNETCORE_ENVIRONMENT=Production`
+- `DOTNET_ENVIRONMENT=Production`
+- `MERIDIAN_ENVIRONMENT=Production`
+- `MERIDIAN_DEPLOYMENT_ENVIRONMENT=Production`
+- `MERIDIAN_MODE=Production` (or `Live`)
+
+### Allowed implementation matrix
+
+| Environment | In-memory implementations (for example `InMemory*Service`) | Implementations marked `[NonProductionOnlyImplementation]` or `INonProductionOnlyService` | Durable/persistent implementations |
+| --- | --- | --- | --- |
+| Test | Allowed | Allowed | Allowed |
+| Development | Allowed | Allowed | Allowed |
+| Staging | Allowed for controlled validation only | Allowed for controlled validation only | Preferred |
+| Production | **Prohibited (startup fails)** | **Prohibited (startup fails)** | **Required** |
+
+### CI/static validation lanes
+
+Use the targeted policy checks when changing DI composition:
+
+```bash
+dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ProductionServiceRegistrationPolicyTests|FullyQualifiedName~ProductionStartupPolicySmokeTests" --logger "console;verbosity=normal"
+```

--- a/src/Meridian.Application/Banking/InMemoryBankingService.cs
+++ b/src/Meridian.Application/Banking/InMemoryBankingService.cs
@@ -1,4 +1,5 @@
 using Meridian.Contracts.Banking;
+using Meridian.Application.Composition;
 
 namespace Meridian.Application.Banking;
 
@@ -7,7 +8,7 @@ namespace Meridian.Application.Banking;
 /// Holds pending payments and bank transactions in process memory; suitable for
 /// testing and non-persistent deployments.
 /// </summary>
-public sealed class InMemoryBankingService : IBankingService
+public sealed class InMemoryBankingService : INonProductionOnlyService, IBankingService
 {
     private readonly object _gate = new object();
     private readonly Dictionary<Guid, PendingPaymentDto> _pendingPayments = new();

--- a/src/Meridian.Application/Composition/ProductionServiceRegistrationPolicy.cs
+++ b/src/Meridian.Application/Composition/ProductionServiceRegistrationPolicy.cs
@@ -1,0 +1,74 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Application.Composition;
+
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class NonProductionOnlyImplementationAttribute : Attribute;
+
+public interface INonProductionOnlyService;
+
+public static class ProductionServiceRegistrationPolicy
+{
+    public static void Validate(IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        if (!IsProductionEnvironment())
+        {
+            return;
+        }
+
+        var violations = services
+            .Select(descriptor => descriptor.ImplementationType)
+            .Where(type => type is not null)
+            .Distinct()
+            .Where(IsNonProductionOnlyImplementation)
+            .Select(type => type!.FullName ?? type.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        if (violations.Length == 0)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Production startup policy rejected non-production DI registrations: {string.Join(", ", violations)}");
+    }
+
+    internal static bool IsNonProductionOnlyImplementation(Type implementationType)
+    {
+        if (implementationType is null)
+        {
+            return false;
+        }
+
+        if (implementationType.Name.StartsWith("InMemory", StringComparison.Ordinal) &&
+            implementationType.Name.EndsWith("Service", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (typeof(INonProductionOnlyService).IsAssignableFrom(implementationType))
+        {
+            return true;
+        }
+
+        return implementationType.GetCustomAttribute<NonProductionOnlyImplementationAttribute>() is not null;
+    }
+
+    internal static bool IsProductionEnvironment()
+    {
+        var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
+                          ?? Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT")
+                          ?? Environment.GetEnvironmentVariable("MERIDIAN_ENVIRONMENT")
+                          ?? Environment.GetEnvironmentVariable("MERIDIAN_DEPLOYMENT_ENVIRONMENT");
+
+        var mode = Environment.GetEnvironmentVariable("MERIDIAN_MODE");
+
+        return string.Equals(environment, "Production", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(mode, "Production", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(mode, "Live", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Meridian.Application/Composition/ServiceCompositionRoot.cs
+++ b/src/Meridian.Application/Composition/ServiceCompositionRoot.cs
@@ -124,6 +124,8 @@ public static class ServiceCompositionRoot
 
         TryRegisterCppTraderIntegration(services, options.ConfigPath);
 
+        ProductionServiceRegistrationPolicy.Validate(services);
+
         // Backtesting services are registered by the host project (Meridian.Backtesting references
         // Meridian.Application, so registration here would create a circular dependency).
 

--- a/src/Meridian.Application/DirectLending/InMemoryDirectLendingService.cs
+++ b/src/Meridian.Application/DirectLending/InMemoryDirectLendingService.cs
@@ -3,10 +3,11 @@ using System.Text;
 using System.Text.Json;
 using Meridian.Contracts.DirectLending;
 using Meridian.FSharp.DirectLendingInterop;
+using Meridian.Application.Composition;
 
 namespace Meridian.Application.DirectLending;
 
-public sealed partial class InMemoryDirectLendingService : IDirectLendingService
+public sealed partial class InMemoryDirectLendingService : INonProductionOnlyService, IDirectLendingService
 {
     private static readonly JsonSerializerOptions HashJsonOptions = new()
     {

--- a/src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs
+++ b/src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Meridian.Contracts.FundStructure;
 using Meridian.Storage.Archival;
+using Meridian.Application.Composition;
 
 namespace Meridian.Application.FundAccounts;
 
@@ -25,7 +26,7 @@ public sealed class AccountStatusPolicyException : InvalidOperationException
 /// Thread-safe fund-account service backed by an in-memory working set with optional
 /// durable JSON snapshot persistence for local-first workflows.
 /// </summary>
-public sealed class InMemoryFundAccountService : IFundAccountService, IAccountManagementService, IAccountQueryService
+public sealed class InMemoryFundAccountService : INonProductionOnlyService, IFundAccountService, IAccountManagementService, IAccountQueryService
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/src/Meridian.Application/FundStructure/InMemoryFundStructureService.cs
+++ b/src/Meridian.Application/FundStructure/InMemoryFundStructureService.cs
@@ -4,6 +4,7 @@ using Meridian.Contracts.FundStructure;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.FSharp.CashFlowInterop;
 using Meridian.Storage.Archival;
+using Meridian.Application.Composition;
 
 namespace Meridian.Application.FundStructure;
 
@@ -11,7 +12,7 @@ namespace Meridian.Application.FundStructure;
 /// Thread-safe governance structure service backed by an in-memory working set
 /// with optional durable JSON snapshot persistence for local-first workflows.
 /// </summary>
-public sealed class InMemoryFundStructureService : IFundStructureService
+public sealed class InMemoryFundStructureService : INonProductionOnlyService, IFundStructureService
 {
     private static readonly StringComparer AssignmentComparer = StringComparer.OrdinalIgnoreCase;
     private const string DefaultCashFlowCurrency = "USD";

--- a/src/Meridian.Application/Treasury/InMemoryMoneyMarketFundService.cs
+++ b/src/Meridian.Application/Treasury/InMemoryMoneyMarketFundService.cs
@@ -1,4 +1,5 @@
 using Meridian.Contracts.Treasury;
+using Meridian.Application.Composition;
 
 namespace Meridian.Application.Treasury;
 
@@ -8,7 +9,7 @@ namespace Meridian.Application.Treasury;
 /// Fund records are registered directly via <see cref="RegisterAsync"/>.
 /// Liquidity state is computed from WAM bands unless overridden per-fund.
 /// </summary>
-public sealed class InMemoryMoneyMarketFundService : IMoneyMarketFundService, IMmfLiquidityService
+public sealed class InMemoryMoneyMarketFundService : INonProductionOnlyService, IMoneyMarketFundService, IMmfLiquidityService
 {
     // WAM threshold (days) below which a fund is considered Liquid (standard MMF limit).
     private const int LiquidWamThresholdDays = 60;

--- a/src/Meridian.Ui.Shared/Services/InMemoryOperatorInboxService.cs
+++ b/src/Meridian.Ui.Shared/Services/InMemoryOperatorInboxService.cs
@@ -1,9 +1,10 @@
 using System.Collections.Concurrent;
 using Meridian.Contracts.Workstation;
+using Meridian.Application.Composition;
 
 namespace Meridian.Ui.Shared.Services;
 
-public sealed class InMemoryOperatorInboxService : IOperatorInboxService
+public sealed class InMemoryOperatorInboxService : INonProductionOnlyService, IOperatorInboxService
 {
     private readonly ConcurrentDictionary<string, OperatorWorkItemDto> _items =
         new(StringComparer.OrdinalIgnoreCase);

--- a/tests/Meridian.Tests/Application/Composition/ProductionServiceRegistrationPolicyTests.cs
+++ b/tests/Meridian.Tests/Application/Composition/ProductionServiceRegistrationPolicyTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using Meridian.Application.Composition;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Tests.Application.Composition;
+
+public sealed class ProductionServiceRegistrationPolicyTests
+{
+    [Fact]
+    public void AddMarketDataServices_WhenEnvironmentIsProduction_RejectsNonProductionOnlyImplementations()
+    {
+        using var environment = new EnvironmentVariableScope("ASPNETCORE_ENVIRONMENT", "Production");
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddMarketDataServices(CompositionOptions.Default);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*InMemory*Service*");
+    }
+
+    [Fact]
+    public void IsNonProductionOnlyImplementation_MatchesMarkerAndNamingPolicy()
+    {
+        ProductionServiceRegistrationPolicy
+            .IsNonProductionOnlyImplementation(typeof(MarkerOnlyService))
+            .Should().BeTrue();
+
+        ProductionServiceRegistrationPolicy
+            .IsNonProductionOnlyImplementation(typeof(InMemorySampleService))
+            .Should().BeTrue();
+
+        ProductionServiceRegistrationPolicy
+            .IsNonProductionOnlyImplementation(typeof(AllowedService))
+            .Should().BeFalse();
+    }
+
+    [NonProductionOnlyImplementation]
+    private sealed class MarkerOnlyService;
+
+    private sealed class InMemorySampleService;
+
+    private sealed class AllowedService;
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _originalValue;
+
+        public EnvironmentVariableScope(string name, string? value)
+        {
+            _name = name;
+            _originalValue = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose() => Environment.SetEnvironmentVariable(_name, _originalValue);
+    }
+}

--- a/tests/Meridian.Tests/Ui/ProductionStartupPolicySmokeTests.cs
+++ b/tests/Meridian.Tests/Ui/ProductionStartupPolicySmokeTests.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+
+namespace Meridian.Tests.Ui;
+
+public sealed class ProductionStartupPolicySmokeTests
+{
+    [Fact]
+    public void UiServer_WhenProductionEnvironmentAndInMemoryBindingsExist_FailsStartup()
+    {
+        using var environment = new EnvironmentVariableScope("ASPNETCORE_ENVIRONMENT", "Production");
+        var configPath = Path.Combine(Path.GetTempPath(), $"meridian-prod-policy-{Guid.NewGuid():N}.json");
+        File.WriteAllText(configPath, "{}");
+
+        try
+        {
+            Action act = () => _ = new Meridian.UiServer(configPath, port: 0);
+
+            act.Should().Throw<InvalidOperationException>()
+                .WithMessage("*non-production DI registrations*");
+        }
+        finally
+        {
+            File.Delete(configPath);
+        }
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _originalValue;
+
+        public EnvironmentVariableScope(string name, string? value)
+        {
+            _name = name;
+            _originalValue = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose() => Environment.SetEnvironmentVariable(_name, _originalValue);
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent accidental promotion of in-memory or test-only service implementations into production by failing fast during host startup when running in a production-equivalent environment. 
- Provide a single, auditable policy point into the DI composition path so CI/static checks can catch violations before deployment. 
- Allow explicit opt-ins/markers for test-only implementations instead of relying only on naming conventions. 

### Description

- Added `ProductionServiceRegistrationPolicy` in `src/Meridian.Application/Composition/ProductionServiceRegistrationPolicy.cs` which detects production-equivalent mode from `ASPNETCORE_ENVIRONMENT`, `DOTNET_ENVIRONMENT`, `MERIDIAN_ENVIRONMENT`, `MERIDIAN_DEPLOYMENT_ENVIRONMENT`, or `MERIDIAN_MODE` and rejects non-production registrations at composition time. 
- Introduced explicit non-production markers: the marker interface `INonProductionOnlyService` and the attribute `[NonProductionOnlyImplementation]` and detection logic that also recognizes `InMemory*Service` naming patterns. 
- Wired the validation into the centralized composition root by calling `ProductionServiceRegistrationPolicy.Validate(services)` from `ServiceCompositionRoot.AddMarketDataServices(...)` so hosts fail startup early if prohibited bindings exist. 
- Marked existing in-memory implementations as non-production-only (added `INonProductionOnlyService`) and added tests and a smoke test to cover the policy, plus developer docs describing the allowed implementation matrix and CI command. 

### Testing

- Added unit tests `ProductionServiceRegistrationPolicyTests` (CI/static validation for DI composition) and `ProductionStartupPolicySmokeTests` (smoke test asserting `UiServer` fails startup when prohibited bindings exist). 
- Recommended targeted validation command: `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ProductionServiceRegistrationPolicyTests|FullyQualifiedName~ProductionStartupPolicySmokeTests" --logger "console;verbosity=normal"`. 
- Local run attempt of the targeted tests in this environment failed because `dotnet` is not installed here (`/bin/bash: dotnet: command not found`), so the tests were not executed locally; CI should run them and is expected to fail startup for production-mode scenarios with prohibited bindings. 
- The change is designed so CI/static lanes will catch composition violations before promotion and the smoke test verifies `UiServer` rejects non-production DI in production mode.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10abf708048320bb462f8570d596af)