### PR TITLE
Direct lending: add command idempotency guard, DB migration, invariants doc, and integration test

### DIFF
--- a/docs/architecture/write-path-invariants.md
+++ b/docs/architecture/write-path-invariants.md
@@ -1,0 +1,28 @@
+# Write-Path Invariants (Operator-Critical Domains)
+
+This document captures domain write invariants that must hold at persistence boundaries for operator/readiness workflows.
+
+## Fund Structure Updates
+- Every mutation is versioned and must advance aggregate version by exactly `+1`.
+- Stale writes are rejected as concurrency conflicts.
+- Transition evidence is append-only (`loan_event` lineage style) and never rewritten.
+
+## Account Lifecycle Changes
+- Account status transitions must be valid state-machine transitions (no implicit skips).
+- Activation/closure events require effective dates and audit metadata.
+- Duplicate externally triggered lifecycle commands must be idempotent by command key.
+
+## Lending Workflow Transitions
+- All servicing mutations are transactionally atomic with their event append and normalized projections.
+- Duplicate command retries (same `command_id`) must not append duplicate events.
+- Aggregate version mismatches are rejected with explicit `ConcurrencyConflict` domain errors.
+
+## Banking Movements
+- Cash movement rows must remain externally deduplicable by stable external references.
+- Posting + workflow evidence append must share one transaction boundary.
+- Reconciliation-facing state changes must produce append-only evidence records.
+
+## MMF Cash Operations
+- Cash subscription/redemption writes are append-only evented transitions.
+- Operator-readiness transitions must persist auditable state/gate changes.
+- External ingest/import commands must be idempotent under retry.

--- a/src/Meridian.Storage/DirectLending/Migrations/007_direct_lending_command_idempotency.sql
+++ b/src/Meridian.Storage/DirectLending/Migrations/007_direct_lending_command_idempotency.sql
@@ -1,0 +1,3 @@
+create unique index if not exists ux_loan_event_command_id
+    on __SCHEMA__.loan_event (loan_id, command_id)
+    where command_id is not null;

--- a/src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.cs
+++ b/src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.cs
@@ -278,6 +278,13 @@ public sealed partial class PostgresDirectLendingStateStore : IDirectLendingStat
         await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
         await using var transaction = await connection.BeginTransactionAsync(IsolationLevel.Serializable, ct).ConfigureAwait(false);
 
+        if (metadata.CommandId is Guid commandId &&
+            await CommandAlreadyAppliedAsync(connection, transaction, loanId, commandId, ct).ConfigureAwait(false))
+        {
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
+            return;
+        }
+
         var currentVersion = await LoadCurrentVersionAsync(connection, transaction, loanId, ct).ConfigureAwait(false);
         if (currentVersion != expectedVersion)
         {
@@ -295,6 +302,30 @@ public sealed partial class PostgresDirectLendingStateStore : IDirectLendingStat
         await MaybeInsertSnapshotAsync(connection, transaction, loanId, nextVersion, contract, servicing, forceSnapshot: false, ct).ConfigureAwait(false);
 
         await transaction.CommitAsync(ct).ConfigureAwait(false);
+    }
+
+    private async Task<bool> CommandAlreadyAppliedAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        Guid loanId,
+        Guid commandId,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText =
+            $"""
+            select 1
+            from {Qualified("loan_event")}
+            where loan_id = @loan_id
+              and command_id = @command_id
+            limit 1;
+            """;
+        command.Parameters.AddWithValue("loan_id", loanId);
+        command.Parameters.AddWithValue("command_id", commandId);
+
+        var existing = await command.ExecuteScalarAsync(ct).ConfigureAwait(false);
+        return existing is not null;
     }
 
     private async Task AppendLedgerJournalEntriesAsync(

--- a/tests/Meridian.DirectLending.Tests/DirectLendingPostgresIntegrationTests.cs
+++ b/tests/Meridian.DirectLending.Tests/DirectLendingPostgresIntegrationTests.cs
@@ -57,6 +57,37 @@ public sealed class DirectLendingPostgresIntegrationTests
     }
 
     [DirectLendingDatabaseFact]
+    public async Task CommandService_ShouldTreatDuplicateCommandIdAsIdempotent()
+    {
+        await using var db = await DirectLendingPostgresTestDatabase.CreateOrSkipAsync();
+        if (db is null)
+        {
+            return;
+        }
+
+        var created = await db.Service.CreateLoanAsync(BuildCreateRequest());
+        await db.Service.ActivateLoanAsync(created.LoanId, new ActivateLoanRequest(new DateOnly(2026, 3, 22)));
+
+        var commandId = Guid.NewGuid();
+        var metadata = new DirectLendingCommandMetadataDto(
+            CausationId: Guid.NewGuid(),
+            CorrelationId: Guid.NewGuid(),
+            CommandId: commandId,
+            SourceSystem: "integration-tests",
+            ReplayFlag: false);
+        var request = new ApplyPrincipalPaymentRequest(50_000m, new DateOnly(2026, 4, 1), "wire-dup-1");
+
+        var first = await db.CommandService.ApplyPrincipalPaymentAsync(created.LoanId, request, metadata);
+        var second = await db.CommandService.ApplyPrincipalPaymentAsync(created.LoanId, request, metadata);
+
+        first.Error.Should().BeNull();
+        second.Error.Should().BeNull();
+
+        var history = await db.Service.GetHistoryAsync(created.LoanId);
+        history.Count(item => item.EventType == "loan.principal-payment-applied").Should().Be(1);
+    }
+
+    [DirectLendingDatabaseFact]
     public async Task AppendOperationsWorkflowAuditAsync_ShouldReturnLinearHashChainedStream()
     {
         await using var db = await DirectLendingPostgresTestDatabase.CreateOrSkipAsync();


### PR DESCRIPTION
### Motivation
- Ensure externally triggered direct-lending commands are idempotent so retries do not produce duplicate events and compromise append-only evidence. 
- Capture write-path invariants for operator-critical domains (fund structure, account lifecycle, lending workflows, banking, MMF) to guide persistence and readiness expectations. 
- Align persistence transaction boundaries and optimistic-concurrency behavior with existing Ledger/Security Master patterns to reject stale writes explicitly.

### Description
- Added a write-path invariants document at `docs/architecture/write-path-invariants.md` describing versioning, idempotency, append-only evidence, and transactional boundaries for key domains. 
- Added a DB migration `src/Meridian.Storage/DirectLending/Migrations/007_direct_lending_command_idempotency.sql` that creates a nullable-safe unique index `ux_loan_event_command_id` on `(loan_id, command_id)` to enforce command-level deduplication. 
- Updated `PostgresDirectLendingStateStore.SaveAsync` to perform an in-transaction idempotency check using `command_id` and short-circuit duplicate command retries before applying state updates, event appends, ledger postings, and snapshots. 
- Added an integration test `CommandService_ShouldTreatDuplicateCommandIdAsIdempotent` to `tests/Meridian.DirectLending.Tests/DirectLendingPostgresIntegrationTests.cs` which replays the same `CommandId` for a principal-payment and asserts the event is appended only once.

### Testing
- Added an integration test `CommandService_ShouldTreatDuplicateCommandIdAsIdempotent` under `tests/Meridian.DirectLending.Tests`; no test execution succeeded in this environment. 
- Attempted to run the focused test with `dotnet test --filter "FullyQualifiedName~CommandService_ShouldTreatDuplicateCommandIdAsIdempotent"`, but the run failed because `dotnet` is not available in the current environment. 
- Migration scripts are registered via the existing `DirectLendingMigrationRunner` and will apply the new uniqueness index when migrations are executed in a properly provisioned environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10abf36cf48320a079b3d6bc1525e8)