### PR TITLE
Add fund-ops persistence cutover scaffolding with shadow reconciliation

### DIFF
--- a/docs/operations/fund-ops-persistence-cutover-runbook.md
+++ b/docs/operations/fund-ops-persistence-cutover-runbook.md
@@ -1,0 +1,29 @@
+# Fund Operations Persistence Cutover Runbook
+
+## Scope
+Fund Structure, Fund Accounts, Direct Lending, Banking, and Money Market domains move from in-memory-first reads to persisted-projection reads in phased order.
+
+## Pre-checks
+1. Confirm shadow-write mode is enabled and reads remain `LegacyInMemory` for the target domain.
+2. Confirm reconciliation job has produced at least one full cycle with no critical discrepancies.
+3. Validate workstation API + UI parity for:
+   - `src/Meridian.Wpf/` workflows (Fund Accounts, Fund Ledger, Direct Lending)
+   - `src/Meridian.Ui/` workstation endpoints/read models.
+
+## Phase flow (per domain)
+1. Enable shadow writes.
+2. Observe reconciliation discrepancies and fix mapping gaps.
+3. Switch read mode to `PersistedProjection` behind feature toggle.
+4. Run focused regression tests for WPF and Ui.Shared endpoint maps.
+5. Keep rollback toggle available until two consecutive validation windows pass.
+
+## Rollback
+1. Flip domain read mode back to `LegacyInMemory`.
+2. Keep shadow writes enabled for evidence retention.
+3. Re-run reconciliation and capture discrepancy report.
+
+## Sign-off evidence
+- Config snapshot showing domain mode values.
+- Reconciliation logs with discrepancy count and timestamps.
+- WPF regression run output.
+- API/workstation endpoint regression output.

--- a/docs/status/fund-ops-persistence-cutover-status.md
+++ b/docs/status/fund-ops-persistence-cutover-status.md
@@ -1,4 +1,5 @@
 # Fund Operations Persistence Cutover Status
+**Last Updated:** 2026-05-22
 
 ## Domains
 - Fund Structure: Shadow-write scaffolded, reconciliation job registered, read cutover gated by config toggle.

--- a/docs/status/fund-ops-persistence-cutover-status.md
+++ b/docs/status/fund-ops-persistence-cutover-status.md
@@ -1,0 +1,13 @@
+# Fund Operations Persistence Cutover Status
+
+## Domains
+- Fund Structure: Shadow-write scaffolded, reconciliation job registered, read cutover gated by config toggle.
+- Fund Accounts: Shadow-write scaffolded, reconciliation job registered, read cutover gated by config toggle.
+- Direct Lending: Shadow-write scaffolded, reconciliation job registered, read cutover gated by config toggle.
+- Banking: Shadow-write scaffolded, reconciliation job registered, read cutover gated by config toggle.
+- Money Market: Shadow-write scaffolded, reconciliation job registered, read cutover gated by config toggle.
+
+## Current state
+- Default read mode remains `LegacyInMemory` for safety.
+- Reconciliation hosted service runs domain jobs and emits discrepancy warnings.
+- Canonical projection schema records are defined for all five domains.

--- a/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
@@ -11,6 +11,7 @@ using Meridian.Application.EnvironmentDesign;
 using Meridian.Application.Equity;
 using Meridian.Application.FixedIncome;
 using Meridian.Application.FundAccounts;
+using Meridian.Application.FundOperationsPersistence;
 using Meridian.Application.FundStructure;
 using Meridian.Application.Futures;
 using Meridian.Application.FxSpot;
@@ -41,6 +42,7 @@ using Meridian.Storage.SecurityMaster;
 using Meridian.Storage.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace Meridian.Application.Composition.Features;
@@ -280,6 +282,18 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
         services.TryAddSingleton<IEnvironmentValidationService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
         services.TryAddSingleton<IEnvironmentPublishService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
         services.TryAddSingleton<IEnvironmentRuntimeProjectionService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
+        services.TryAddSingleton(_ => new FundOperationsPersistenceOptions());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDomainProjectionReconciliationJob>(
+            _ => new NoOpDomainProjectionReconciliationJob(FundOperationsDomain.FundStructure)));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDomainProjectionReconciliationJob>(
+            _ => new NoOpDomainProjectionReconciliationJob(FundOperationsDomain.FundAccounts)));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDomainProjectionReconciliationJob>(
+            _ => new NoOpDomainProjectionReconciliationJob(FundOperationsDomain.DirectLending)));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDomainProjectionReconciliationJob>(
+            _ => new NoOpDomainProjectionReconciliationJob(FundOperationsDomain.Banking)));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDomainProjectionReconciliationJob>(
+            _ => new NoOpDomainProjectionReconciliationJob(FundOperationsDomain.MoneyMarket)));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, ProjectionReconciliationHostedService>());
         return services;
     }
 

--- a/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
@@ -282,7 +282,28 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
         services.TryAddSingleton<IEnvironmentValidationService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
         services.TryAddSingleton<IEnvironmentPublishService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
         services.TryAddSingleton<IEnvironmentRuntimeProjectionService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
-        services.TryAddSingleton(_ => new FundOperationsPersistenceOptions());
+        services.TryAddSingleton<FundOperationsPersistenceOptions>(sp =>
+        {
+            var configStore = sp.GetRequiredService<ConfigStore>();
+            var config = configStore.Load();
+            var persistenceConfig = config.FundOperationsPersistence;
+            if (persistenceConfig?.DomainModes is null or { Count: 0 })
+                return new FundOperationsPersistenceOptions();
+
+            var domainModes = new Dictionary<FundOperationsDomain, DomainCutoverMode>();
+            foreach (var (key, value) in persistenceConfig.DomainModes)
+            {
+                if (Enum.TryParse<FundOperationsDomain>(key, ignoreCase: true, out var domain))
+                {
+                    var readMode = Enum.TryParse<DomainReadMode>(value.ReadMode, ignoreCase: true, out var rm)
+                        ? rm
+                        : DomainReadMode.LegacyInMemory;
+                    domainModes[domain] = new DomainCutoverMode(value.ShadowWritesEnabled, readMode);
+                }
+            }
+
+            return new FundOperationsPersistenceOptions { DomainModes = domainModes };
+        });
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDomainProjectionReconciliationJob>(
             _ => new NoOpDomainProjectionReconciliationJob(FundOperationsDomain.FundStructure)));
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDomainProjectionReconciliationJob>(

--- a/src/Meridian.Application/FundOperationsPersistence/CanonicalProjectionSchemas.cs
+++ b/src/Meridian.Application/FundOperationsPersistence/CanonicalProjectionSchemas.cs
@@ -1,0 +1,15 @@
+namespace Meridian.Application.FundOperationsPersistence;
+
+public sealed record FundStructureProjectionSchema(Guid OrganizationId, string Code, string Name, string BaseCurrency, DateTimeOffset EffectiveFrom);
+public sealed record FundAccountProjectionSchema(Guid AccountId, Guid FundId, string AccountCode, string DisplayName, string AccountType, string BaseCurrency, bool IsActive);
+public sealed record DirectLendingProjectionSchema(Guid LoanId, string FacilityCode, string BorrowerName, decimal PrincipalOutstanding, string Currency, DateOnly AsOfDate);
+public sealed record BankingProjectionSchema(Guid EntityId, Guid BankTransactionId, string TransactionType, decimal Amount, string Currency, DateOnly EffectiveDate);
+public sealed record MoneyMarketProjectionSchema(Guid SecurityId, string DisplayName, string Currency, string? FundFamily, bool IsSweepEligible, int? WeightedAverageMaturityDays);
+
+public sealed class NoOpDomainProjectionReconciliationJob(FundOperationsDomain domain) : IDomainProjectionReconciliationJob
+{
+    public FundOperationsDomain Domain { get; } = domain;
+
+    public Task<IReadOnlyList<ProjectionDiscrepancy>> ReconcileAsync(CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<ProjectionDiscrepancy>>([]);
+}

--- a/src/Meridian.Application/FundOperationsPersistence/DomainReadSwitch.cs
+++ b/src/Meridian.Application/FundOperationsPersistence/DomainReadSwitch.cs
@@ -1,0 +1,16 @@
+namespace Meridian.Application.FundOperationsPersistence;
+
+public static class DomainReadSwitch
+{
+    public static T Select<T>(
+        FundOperationsPersistenceOptions options,
+        FundOperationsDomain domain,
+        Func<T> legacyReader,
+        Func<T> persistedReader)
+    {
+        var mode = options.GetMode(domain);
+        return mode.ReadMode == DomainReadMode.PersistedProjection
+            ? persistedReader()
+            : legacyReader();
+    }
+}

--- a/src/Meridian.Application/FundOperationsPersistence/FileShadowProjectionWriter.cs
+++ b/src/Meridian.Application/FundOperationsPersistence/FileShadowProjectionWriter.cs
@@ -19,10 +19,30 @@ public sealed class FileShadowProjectionWriter : IShadowProjectionWriter
 
     public FundOperationsDomain Domain { get; }
 
+    private static string SanitizePathSegment(string value)
+    {
+        var invalidChars = Path.GetInvalidFileNameChars()
+            .Concat(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar })
+            .ToHashSet();
+
+        var sanitizedChars = value
+            .Select(ch => invalidChars.Contains(ch) ? '_' : ch)
+            .ToArray();
+
+        var sanitized = new string(sanitizedChars);
+
+        while (sanitized.Contains("..", StringComparison.Ordinal))
+        {
+            sanitized = sanitized.Replace("..", "_", StringComparison.Ordinal);
+        }
+
+        return string.IsNullOrWhiteSpace(sanitized) ? "_" : sanitized;
+    }
+
     public async Task WriteAsync(string projectionName, string entityKey, object payload, CancellationToken ct = default)
     {
-        var safeProjection = projectionName.Replace('/', '_');
-        var safeEntity = entityKey.Replace('/', '_');
+        var safeProjection = SanitizePathSegment(projectionName);
+        var safeEntity = SanitizePathSegment(entityKey);
         var folder = Path.Combine(_rootPath, Domain.ToString(), safeProjection);
         Directory.CreateDirectory(folder);
         var path = Path.Combine(folder, $"{safeEntity}.json");

--- a/src/Meridian.Application/FundOperationsPersistence/FileShadowProjectionWriter.cs
+++ b/src/Meridian.Application/FundOperationsPersistence/FileShadowProjectionWriter.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+
+namespace Meridian.Application.FundOperationsPersistence;
+
+public sealed class FileShadowProjectionWriter : IShadowProjectionWriter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly string _rootPath;
+    public FileShadowProjectionWriter(FundOperationsDomain domain, string rootPath)
+    {
+        Domain = domain;
+        _rootPath = rootPath;
+    }
+
+    public FundOperationsDomain Domain { get; }
+
+    public async Task WriteAsync(string projectionName, string entityKey, object payload, CancellationToken ct = default)
+    {
+        var safeProjection = projectionName.Replace('/', '_');
+        var safeEntity = entityKey.Replace('/', '_');
+        var folder = Path.Combine(_rootPath, Domain.ToString(), safeProjection);
+        Directory.CreateDirectory(folder);
+        var path = Path.Combine(folder, $"{safeEntity}.json");
+        await using var stream = File.Create(path);
+        await JsonSerializer.SerializeAsync(stream, payload, JsonOptions, ct).ConfigureAwait(false);
+    }
+}

--- a/src/Meridian.Application/FundOperationsPersistence/FundOperationsPersistenceContracts.cs
+++ b/src/Meridian.Application/FundOperationsPersistence/FundOperationsPersistenceContracts.cs
@@ -1,0 +1,47 @@
+namespace Meridian.Application.FundOperationsPersistence;
+
+public enum FundOperationsDomain
+{
+    FundStructure,
+    FundAccounts,
+    DirectLending,
+    Banking,
+    MoneyMarket
+}
+
+public enum DomainReadMode
+{
+    LegacyInMemory = 0,
+    PersistedProjection = 1
+}
+
+public sealed record DomainCutoverMode(bool ShadowWritesEnabled, DomainReadMode ReadMode);
+
+public sealed record FundOperationsPersistenceOptions
+{
+    public Dictionary<FundOperationsDomain, DomainCutoverMode> DomainModes { get; init; } = new();
+
+    public DomainCutoverMode GetMode(FundOperationsDomain domain)
+        => DomainModes.TryGetValue(domain, out var mode)
+            ? mode
+            : new DomainCutoverMode(ShadowWritesEnabled: true, DomainReadMode.LegacyInMemory);
+}
+
+public sealed record ProjectionDiscrepancy(
+    FundOperationsDomain Domain,
+    string ProjectionName,
+    string EntityKey,
+    string Summary,
+    DateTimeOffset DetectedAt);
+
+public interface IDomainProjectionReconciliationJob
+{
+    FundOperationsDomain Domain { get; }
+    Task<IReadOnlyList<ProjectionDiscrepancy>> ReconcileAsync(CancellationToken ct = default);
+}
+
+public interface IShadowProjectionWriter
+{
+    FundOperationsDomain Domain { get; }
+    Task WriteAsync(string projectionName, string entityKey, object payload, CancellationToken ct = default);
+}

--- a/src/Meridian.Application/FundOperationsPersistence/FundOperationsPersistenceContracts.cs
+++ b/src/Meridian.Application/FundOperationsPersistence/FundOperationsPersistenceContracts.cs
@@ -24,7 +24,7 @@ public sealed record FundOperationsPersistenceOptions
     public DomainCutoverMode GetMode(FundOperationsDomain domain)
         => DomainModes.TryGetValue(domain, out var mode)
             ? mode
-            : new DomainCutoverMode(ShadowWritesEnabled: true, DomainReadMode.LegacyInMemory);
+            : new DomainCutoverMode(ShadowWritesEnabled: true, ReadMode: DomainReadMode.LegacyInMemory);
 }
 
 public sealed record ProjectionDiscrepancy(

--- a/src/Meridian.Application/FundOperationsPersistence/ProjectionReconciliationHostedService.cs
+++ b/src/Meridian.Application/FundOperationsPersistence/ProjectionReconciliationHostedService.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Application.FundOperationsPersistence;
+
+public sealed class ProjectionReconciliationHostedService(
+    IEnumerable<IDomainProjectionReconciliationJob> jobs,
+    ILogger<ProjectionReconciliationHostedService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            foreach (var job in jobs)
+            {
+                var discrepancies = await job.ReconcileAsync(stoppingToken).ConfigureAwait(false);
+                foreach (var discrepancy in discrepancies)
+                {
+                    logger.LogWarning(
+                        "Shadow projection discrepancy in {Domain} {Projection}/{EntityKey}: {Summary}",
+                        discrepancy.Domain,
+                        discrepancy.ProjectionName,
+                        discrepancy.EntityKey,
+                        discrepancy.Summary);
+                }
+            }
+
+            await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Meridian.Application/FundOperationsPersistence/ProjectionReconciliationHostedService.cs
+++ b/src/Meridian.Application/FundOperationsPersistence/ProjectionReconciliationHostedService.cs
@@ -9,23 +9,46 @@ public sealed class ProjectionReconciliationHostedService(
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        while (!stoppingToken.IsCancellationRequested)
+        using var timer = new PeriodicTimer(TimeSpan.FromMinutes(5));
+
+        try
         {
-            foreach (var job in jobs)
+            do
             {
-                var discrepancies = await job.ReconcileAsync(stoppingToken).ConfigureAwait(false);
-                foreach (var discrepancy in discrepancies)
+                foreach (var job in jobs)
                 {
-                    logger.LogWarning(
-                        "Shadow projection discrepancy in {Domain} {Projection}/{EntityKey}: {Summary}",
-                        discrepancy.Domain,
-                        discrepancy.ProjectionName,
-                        discrepancy.EntityKey,
-                        discrepancy.Summary);
+                    try
+                    {
+                        var discrepancies = await job.ReconcileAsync(stoppingToken).ConfigureAwait(false);
+                        foreach (var discrepancy in discrepancies)
+                        {
+                            logger.LogWarning(
+                                "Shadow projection discrepancy in {Domain} {Projection}/{EntityKey}: {Summary}",
+                                discrepancy.Domain,
+                                discrepancy.ProjectionName,
+                                discrepancy.EntityKey,
+                                discrepancy.Summary);
+                        }
+                    }
+                    catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, "Projection reconciliation job {JobType} failed.", job.GetType().FullName);
+                    }
                 }
             }
-
-            await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken).ConfigureAwait(false);
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false));
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Normal shutdown.
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Projection reconciliation hosted service encountered an unexpected error.");
         }
     }
 }

--- a/src/Meridian.Core/Config/AppConfig.cs
+++ b/src/Meridian.Core/Config/AppConfig.cs
@@ -58,7 +58,8 @@ public sealed record AppConfig(
     string? PluginsPath = null,
     bool CoLocationProfile = false,
     ProviderConnectionsConfig? ProviderConnections = null,
-    FeatureCapabilityOptions? FeatureCapabilities = null
+    FeatureCapabilityOptions? FeatureCapabilities = null,
+    FundOperationsPersistenceConfig? FundOperationsPersistence = null
 );
 
 /// <summary>
@@ -154,4 +155,26 @@ public sealed record SourceRegistryConfig(
 public sealed record ValidationPipelineConfig(
     bool Enabled = false,
     bool UseRealTimeMode = false
+);
+
+/// <summary>
+/// Configuration for per-domain fund operations persistence cutover.
+/// Controls shadow write and read mode toggles for each fund operations domain.
+/// </summary>
+/// <param name="DomainModes">
+/// Per-domain cutover modes keyed by domain name (e.g. "FundStructure", "FundAccounts").
+/// When null or empty, all domains default to shadow writes enabled with legacy in-memory reads.
+/// </param>
+public sealed record FundOperationsPersistenceConfig(
+    Dictionary<string, DomainCutoverModeConfig>? DomainModes = null
+);
+
+/// <summary>
+/// Serializable cutover mode for a single fund operations domain.
+/// </summary>
+/// <param name="ShadowWritesEnabled">Whether shadow projection writes are enabled for this domain.</param>
+/// <param name="ReadMode">Read mode: "LegacyInMemory" (default) or "PersistedProjection".</param>
+public sealed record DomainCutoverModeConfig(
+    bool ShadowWritesEnabled = true,
+    string ReadMode = "LegacyInMemory"
 );

--- a/tests/Meridian.Tests/Application/Composition/StorageFeatureRegistrationTests.cs
+++ b/tests/Meridian.Tests/Application/Composition/StorageFeatureRegistrationTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Meridian.Application.Composition;
 using Meridian.Application.Composition.Features;
 using Meridian.Application.DirectLending;
+using Meridian.Application.FundOperationsPersistence;
 using Meridian.Application.OperationsContinuity;
 using Meridian.Application.SecurityMaster;
 using Meridian.Contracts.DirectLending;
@@ -63,6 +64,9 @@ public sealed class StorageFeatureRegistrationTests : IDisposable
         services.Should().NotContain(sd => sd.ServiceType == typeof(IOperationsContinuityTransactionalCommitStore));
         services.Should().NotContain(sd => sd.ServiceType == typeof(IDirectLendingStateStore));
         services.Should().NotContain(sd => sd.ServiceType == typeof(IDirectLendingService));
+        services.Should().Contain(sd => sd.ServiceType == typeof(IDomainProjectionReconciliationJob));
+        services.Should().ContainSingle(sd => sd.ServiceType == typeof(IHostedService) &&
+            sd.ImplementationType == typeof(ProjectionReconciliationHostedService));
         services.Should().NotContain(sd => sd.ServiceType == typeof(IHostedService) &&
             sd.ImplementationType == typeof(SecurityMasterProjectionWarmupService));
         services.Should().NotContain(sd => sd.ServiceType == typeof(IHostedService) &&
@@ -94,6 +98,9 @@ public sealed class StorageFeatureRegistrationTests : IDisposable
         services.Should().ContainSingle(sd => sd.ServiceType == typeof(DirectLendingOptions));
         services.Should().ContainSingle(sd => sd.ServiceType == typeof(IDirectLendingStateStore));
         services.Should().ContainSingle(sd => sd.ServiceType == typeof(IDirectLendingService));
+        services.Should().Contain(sd => sd.ServiceType == typeof(IDomainProjectionReconciliationJob));
+        services.Should().ContainSingle(sd => sd.ServiceType == typeof(IHostedService) &&
+            sd.ImplementationType == typeof(ProjectionReconciliationHostedService));
         services.Should().ContainSingle(sd => sd.ServiceType == typeof(IHostedService) &&
             sd.ImplementationType == typeof(SecurityMasterProjectionWarmupService));
         services.Should().ContainSingle(sd => sd.ServiceType == typeof(IHostedService) &&


### PR DESCRIPTION
### Motivation
- Introduce canonical persistence schemas and a phased cutover path so Fund Structure, Fund Accounts, Direct Lending, Banking, and Money Market projections can be migrated from in-memory reads to durable persisted projections with minimal operator risk.
- Provide a safe shadow-write path that captures persisted projection payloads for comparison while leaving live reads unchanged until validation passes. 
- Add automated reconciliation/reporting so projection deltas are discovered and surfaced during the shadow phase, and provide an operator-runbook and status page for controlled cutover and rollback.

### Description
- Added a new persistence contract surface `src/Meridian.Application/FundOperationsPersistence/` with `FundOperationsPersistenceContracts.cs` (domain enums/options/discrepancy contracts) and projection schema types in `CanonicalProjectionSchemas.cs`.
- Implemented a file-backed shadow writer `FileShadowProjectionWriter` to persist projection payloads during shadow-write operation and a read-mode selector helper `DomainReadSwitch` to choose between legacy in-memory and persisted projection reads by domain.
- Added a hosted reconciliation loop `ProjectionReconciliationHostedService` plus a no-op reconciliation job scaffold `NoOpDomainProjectionReconciliationJob` and registered domain jobs and the hosted service in storage composition in `StorageFeatureRegistration.cs` so reconciliation runs out-of-the-box.
- Updated `StorageFeatureRegistrationTests` to assert that reconciliation jobs and the hosted reconciliation service are registered, and published operational documentation `docs/operations/fund-ops-persistence-cutover-runbook.md` and `docs/status/fund-ops-persistence-cutover-status.md` describing pre-checks, phased flow, rollback, and sign-off evidence.

### Testing
- Updated unit test assertions in `tests/Meridian.Tests/Application/Composition/StorageFeatureRegistrationTests.cs` to cover reconciliation job and hosted-service registrations and included them in the change set. 
- Attempted to run the focused test filter `dotnet test --filter "FullyQualifiedName~StorageFeatureRegistrationTests"`, but automated execution failed because the container environment lacks the `dotnet` CLI (`/bin/bash: dotnet: command not found`).
- No further automated test runs were executed in this environment; CI should run the full test matrix (including `StorageFeatureRegistrationTests`, focused WPF regression slices, and `src/Meridian.Ui` endpoint validations) as part of the merge validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10abf574e8832087f89c869a8fb1f6)