### PR TITLE
Harden desktop installer release signing workflow

### DIFF
--- a/.github/workflows/desktop-installer-packaging.yml
+++ b/.github/workflows/desktop-installer-packaging.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: desktop-installer-release-${{ github.ref }}
@@ -25,6 +25,8 @@ jobs:
     name: package-desktop-msix (${{ matrix.runtime }})
     runs-on: windows-latest
     timeout-minutes: 75
+    environment:
+      name: desktop-release-signing
     strategy:
       fail-fast: false
       matrix:
@@ -51,7 +53,8 @@ jobs:
             ${{ runner.os }}-nuget-desktop-installer-
             ${{ runner.os }}-nuget-
 
-      - name: Prepare optional signing certificate
+      - name: Prepare optional signing certificate (tag releases only)
+        if: startsWith(github.ref, 'refs/tags/v')
         id: signing
         shell: pwsh
         env:
@@ -66,14 +69,14 @@ jobs:
             "cert_path=$certPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
             Write-Host "Release signing certificate configured."
           } else {
-            Write-Host "No signing certificate secret found; installer will use a temporary development certificate."
+            throw "Tag release builds require MDC_SIGNING_CERT_PFX_BASE64 in the protected desktop-release-signing environment."
           }
 
       - name: Build desktop installer package
         shell: pwsh
         env:
           MDC_SIGNING_CERT_PFX: ${{ steps.signing.outputs.cert_path }}
-          MDC_SIGNING_CERT_PASSWORD: ${{ secrets.MDC_SIGNING_CERT_PASSWORD }}
+          MDC_SIGNING_CERT_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.MDC_SIGNING_CERT_PASSWORD || '' }}
         run: |
           $architecture = if ('${{ matrix.runtime }}' -eq 'win-arm64') { 'ARM64' } else { 'x64' }
           pwsh ./build/scripts/install/install.ps1 `
@@ -123,6 +126,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: write
 
     steps:
       - name: Download packaged installer artifacts


### PR DESCRIPTION
### Motivation
- Prevent accidental exposure of the repository signing PFX/password to untrusted refs or manual runs by reducing token scope and gating access to signing materials.
- Ensure signed artifacts can only be produced from protected tag-based releases and that missing signing secrets cause tag releases to fail instead of continuing insecurely.
- Reduce the blast radius of `GITHUB_TOKEN` write privileges by limiting `contents: write` to the job that publishes release assets.

### Description
- Changed top-level workflow permission from `contents: write` to `contents: read` to minimize default token scope. 
- Added `environment: desktop-release-signing` to the `build-msix` job so signing secrets can be governed by GitHub Environment protection rules. 
- Restricted the signing preparation step with `if: startsWith(github.ref, 'refs/tags/v')` and made tag runs fail if the `MDC_SIGNING_CERT_PFX_BASE64` secret is not present. 
- Ensured `MDC_SIGNING_CERT_PASSWORD` is provided only for tag refs and moved `contents: write` to the `release` job that publishes release assets. 

### Testing
- Ran repository scans and content checks using `rg` to locate workflow files and secret usages, and those queries returned expected matches (success). 
- Inspected the modified workflow with `sed`/`nl` and `git diff` to validate the intended changes are present (success). 
- Committed the workflow update with `git commit`, confirming the modified file was recorded (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1657b45a30832093ca0a324fec131b)