### PR TITLE
Harden Lean results ingest with ManageStrategies permission

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/LeanEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/LeanEndpoints.cs
@@ -5,6 +5,7 @@ using Meridian.Ledger;
 using Meridian.Strategies.Interfaces;
 using Meridian.Strategies.Models;
 using Meridian.Contracts.Api;
+using Meridian.Contracts.Auth;
 using Meridian.Storage;
 using Meridian.Ui.Shared;
 using Microsoft.AspNetCore.Builder;
@@ -454,8 +455,14 @@ public static class LeanEndpoints
         // Reads a Lean backtest result JSON file and stores it as a completed backtest record.
         group.MapPost(UiApiRoutes.LeanResultsIngest, async (
             [FromBody] LeanResultsIngestRequest? req,
+            HttpContext context,
             [FromServices] IStrategyRepository? repository) =>
         {
+            if (!EndpointAuthorization.HasPermission(context, UserPermission.ManageStrategies))
+            {
+                return Results.Forbid();
+            }
+
             if (req == null || string.IsNullOrEmpty(req.ResultsFilePath))
             {
                 return Results.BadRequest(new { error = "resultsFilePath is required." });


### PR DESCRIPTION
### Motivation
- Prevent unauthorised low-privilege authenticated users from creating or overwriting shared strategy run records via the Lean results ingest endpoint by enforcing a mutation-level permission check.

### Description
- Require `UserPermission.ManageStrategies` on `POST /api/lean/results/ingest` by accepting `HttpContext` in the handler and returning `Results.Forbid()` when `EndpointAuthorization.HasPermission(context, UserPermission.ManageStrategies)` is false, and add the `using Meridian.Contracts.Auth;` import.

### Testing
- Attempted a focused test run of `LeanEndpointTests` with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~LeanEndpointTests"`, but the runner was not available in this environment (`dotnet: command not found`), so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15ca70d47883208eb6bf1cad32eb8b)