### PR TITLE
Harden direct-lending ledger period validation

### DIFF
--- a/src/Meridian.Application/DirectLending/LoanAccountingProjector.cs
+++ b/src/Meridian.Application/DirectLending/LoanAccountingProjector.cs
@@ -37,14 +37,20 @@ public sealed class LoanAccountingProjector
     {
         if (_journalStore is null)
         {
-            return [];
+            throw new DirectLendingCommandException(
+                new DirectLendingCommandError(
+                    DirectLendingErrorCode.Validation,
+                    "Ledger journal store is required for direct-lending ledger-impacting events."));
         }
 
         var accountingDate = effectiveDate ?? contract.EffectiveDate;
         var period = await ResolvePostingPeriodAsync(accountingDate, ct).ConfigureAwait(false);
         if (period is null)
         {
-            return [];
+            throw new DirectLendingCommandException(
+                new DirectLendingCommandError(
+                    DirectLendingErrorCode.Validation,
+                    $"No open accounting period contains posting date '{accountingDate:yyyy-MM-dd}'."));
         }
 
         var policy = await _accountingPolicyService
@@ -194,12 +200,24 @@ public sealed class LoanAccountingProjector
 
     private async Task<LedgerAccountingPeriod?> ResolvePostingPeriodAsync(DateOnly accountingDate, CancellationToken ct)
     {
-        var periods = await _journalStore!.ListPeriodsAsync(ct: ct).ConfigureAwait(false);
-        return periods
-            .Where(period => period.StartDate <= accountingDate && period.EndDate >= accountingDate)
-            .OrderByDescending(period => string.Equals(period.Status, "Open", StringComparison.OrdinalIgnoreCase))
-            .ThenBy(period => period.StartDate)
-            .FirstOrDefault();
+        var periods = (await _journalStore!.ListPeriodsAsync(ct: ct).ConfigureAwait(false))
+            .Where(period =>
+                period.StartDate <= accountingDate &&
+                period.EndDate >= accountingDate &&
+                string.Equals(period.Status, "Open", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(period => period.StartDate)
+            .Take(2)
+            .ToArray();
+
+        if (periods.Length > 1)
+        {
+            throw new DirectLendingCommandException(
+                new DirectLendingCommandError(
+                    DirectLendingErrorCode.Validation,
+                    $"Multiple open accounting periods contain posting date '{accountingDate:yyyy-MM-dd}'."));
+        }
+
+        return periods.SingleOrDefault();
     }
 
     private static decimal GetDecimal(JsonElement root, params string[] propertyNames)


### PR DESCRIPTION
### Motivation

- Close a security/control gap where direct-lending events could proceed without ledger postings or be posted into non-open accounting periods, undermining period-close and audit integrity.
- Ensure ledger-impacting commands require a configured transactional ledger store and an explicit open posting period to prevent attacker-controlled dates from bypassing accounting controls.

### Description

- Updated `LoanAccountingProjector.ProjectAsync` to throw a `DirectLendingCommandException` when the `ILedgerJournalStore` is not provided instead of returning an empty entry list. (`src/Meridian.Application/DirectLending/LoanAccountingProjector.cs`)
- Require an `Open` accounting period for a posting date by filtering periods to `Status == "Open"` in `ResolvePostingPeriodAsync` and return a single matching period. (`ResolvePostingPeriodAsync` in `LoanAccountingProjector.cs`)
- Detect ambiguous configuration and reject when multiple open periods overlap the posting date by throwing a `DirectLendingCommandException` with a validation error. (`ResolvePostingPeriodAsync` in `LoanAccountingProjector.cs`)
- Make `ProjectAsync` fail when no open period is found, preventing direct-lending state/event commits without valid ledger postings. (`ProjectAsync` in `LoanAccountingProjector.cs`)

### Testing

- Attempted to run runtime test tooling (`dotnet --version` / `dotnet test`) but the execution environment lacks `dotnet`, so automated tests could not be executed here (failed: `dotnet` not found). No automated test run results are available from this environment.
- Changes were validated with targeted source inspection and repository search to confirm the vulnerable code paths were hardened (`LoanAccountingProjector.ProjectAsync` and `ResolvePostingPeriodAsync`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e3e8dfb788320b37229b5c3086f45)