### PR TITLE
fix: harden covered-call run queue against resource exhaustion

### DIFF
--- a/src/Meridian.Ui.Shared/Services/CoveredCall/CoveredCallBacktestService.cs
+++ b/src/Meridian.Ui.Shared/Services/CoveredCall/CoveredCallBacktestService.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Threading.Channels;
-using Meridian.Application.Pipeline;
 using Meridian.Backtesting.Engine;
 using Meridian.Backtesting.Sdk;
 using Meridian.Backtesting.Sdk.Strategies.OptionsOverwrite;
@@ -37,8 +36,18 @@ public sealed class CoveredCallBacktestService : ICoveredCallBacktestService, IH
     private readonly ILogger<CoveredCallBacktestService> _logger;
     private readonly TimeProvider _timeProvider;
 
+    private static readonly BoundedChannelOptions RunQueueOptions = new(capacity: 512)
+    {
+        FullMode = BoundedChannelFullMode.DropWrite,
+        SingleReader = true,
+        SingleWriter = false
+    };
+
     private readonly Channel<CoveredCallCommand> _channel =
-        EventPipelinePolicy.Default.CreateChannel<CoveredCallCommand>();
+        Channel.CreateBounded<CoveredCallCommand>(RunQueueOptions);
+
+    private const int MaxRetainedRuns = 2_000;
+    private static readonly TimeSpan TerminalRunRetention = TimeSpan.FromMinutes(30);
 
     private readonly ConcurrentDictionary<string, RunState> _runs = new(StringComparer.Ordinal);
 
@@ -145,6 +154,12 @@ public sealed class CoveredCallBacktestService : ICoveredCallBacktestService, IH
     {
         ArgumentNullException.ThrowIfNull(request);
         ValidateRequest(request);
+        PruneTerminalRuns();
+
+        if (_runs.Count >= MaxRetainedRuns)
+        {
+            throw new InvalidOperationException("Covered-call backtest queue is at capacity. Please retry shortly.");
+        }
 
         var runId = Guid.NewGuid().ToString("N");
         var queuedAt = _timeProvider.GetUtcNow();
@@ -588,6 +603,11 @@ public sealed class CoveredCallBacktestService : ICoveredCallBacktestService, IH
                 catch (SemaphoreFullException) { /* benign during resize */ }
                 catch (ObjectDisposedException) { /* benign during resize */ }
             }
+
+            if (state is { Phase: RunPhase.Completed or RunPhase.Failed or RunPhase.Cancelled })
+            {
+                state.Cts.Dispose();
+            }
         }
     }
 
@@ -615,6 +635,30 @@ public sealed class CoveredCallBacktestService : ICoveredCallBacktestService, IH
             throw new ArgumentException("InitialCash must be greater than zero.", nameof(request));
         if (request.InitialUnderlyingShares < 0)
             throw new ArgumentException("InitialUnderlyingShares cannot be negative.", nameof(request));
+    }
+
+
+    private void PruneTerminalRuns()
+    {
+        var now = _timeProvider.GetUtcNow();
+        foreach (var entry in _runs)
+        {
+            var state = entry.Value;
+            if (state.Phase is not (RunPhase.Completed or RunPhase.Failed or RunPhase.Cancelled))
+            {
+                continue;
+            }
+
+            if (!state.EndedAt.HasValue || now - state.EndedAt.Value < TerminalRunRetention)
+            {
+                continue;
+            }
+
+            if (_runs.TryRemove(entry.Key, out var removed))
+            {
+                removed.Cts.Dispose();
+            }
+        }
     }
 
     private void ResizeConcurrency(int desired)


### PR DESCRIPTION
### Motivation
- Mitigate a resource-exhaustion vulnerability in the covered-call backtest service where accepted runs created retained `RunState` entries and `CancellationTokenSource` objects that were never evicted or disposed, and the channel used `DropOldest` semantics so older commands could be silently discarded while their `RunState` remained in memory.
- Make the service fail fast under overload and reclaim per-run resources to reduce risk of memory/CPU/provider quota exhaustion from repeated API submissions.

### Description
- Replace the default event-pipeline channel with an explicit bounded channel via `Channel.CreateBounded<CoveredCallCommand>` configured with `BoundedChannelOptions` (`capacity: 512`, `FullMode = DropWrite`, `SingleReader = true`) so writes fail when saturated instead of silently dropping older commands.
- Add `MaxRetainedRuns = 2_000` and `TerminalRunRetention = TimeSpan.FromMinutes(30)`, call `PruneTerminalRuns()` at admission time, and reject new submissions when the in-memory `_runs` count reaches the hard cap to bound retained run-state growth.
- Implement `PruneTerminalRuns()` to evict terminal runs older than the retention window and dispose their per-run `CancellationTokenSource` objects, and also dispose each run's CTS in the execution `finally` when a run reaches a terminal phase.
- Remove an unused `using` and keep the change localized to `src/Meridian.Ui.Shared/Services/CoveredCall/CoveredCallBacktestService.cs` to preserve existing behavior while adding admission and cleanup guardrails.

### Testing
- Attempted to run `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter CoveredCall --no-restore`, but testing could not proceed because `dotnet` is not available in the execution environment (`dotnet: command not found`).
- Verified the patch via static inspection and repository search to confirm `RunQueueOptions`, the bounded `Channel` creation, `MaxRetainedRuns`, `PruneTerminalRuns()`, and CTS disposal were added to `src/Meridian.Ui.Shared/Services/CoveredCall/CoveredCallBacktestService.cs` as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e3e912038832083136a1d7e85b326)