### PR TITLE
Preserve security metadata when atomically rewriting config files

### DIFF
--- a/src/Meridian.Storage/Archival/AtomicFileWriter.cs
+++ b/src/Meridian.Storage/Archival/AtomicFileWriter.cs
@@ -74,11 +74,16 @@ public static partial class AtomicFileWriter
         }
 
         var tempPath = GetTempPath(destinationPath);
+        var destinationExists = File.Exists(destinationPath);
 
         try
         {
             // Write to temp file
             await File.WriteAllTextAsync(tempPath, content, Encoding.UTF8, ct);
+            if (destinationExists)
+            {
+                CopySecurityMetadata(destinationPath, tempPath);
+            }
 
             // Sync the temp file to disk
             await SyncFileAsync(tempPath, ct);
@@ -115,11 +120,16 @@ public static partial class AtomicFileWriter
         }
 
         var tempPath = GetTempPath(destinationPath);
+        var destinationExists = File.Exists(destinationPath);
 
         try
         {
             // Write to temp file
             await File.WriteAllBytesAsync(tempPath, content, ct);
+            if (destinationExists)
+            {
+                CopySecurityMetadata(destinationPath, tempPath);
+            }
 
             // Sync the temp file to disk
             await SyncFileAsync(tempPath, ct);
@@ -154,6 +164,7 @@ public static partial class AtomicFileWriter
         }
 
         var tempPath = GetTempPath(destinationPath);
+        var destinationExists = File.Exists(destinationPath);
 
         try
         {
@@ -168,6 +179,10 @@ public static partial class AtomicFileWriter
             {
                 await writeAction(writer);
                 await writer.FlushAsync();
+            }
+            if (destinationExists)
+            {
+                CopySecurityMetadata(destinationPath, tempPath);
             }
 
             // Sync the temp file
@@ -436,6 +451,28 @@ public static partial class AtomicFileWriter
         var directory = Path.GetDirectoryName(destinationPath) ?? ".";
         var fileName = Path.GetFileName(destinationPath);
         return Path.Combine(directory, $".{fileName}.{Guid.NewGuid():N}.tmp");
+    }
+
+    private static void CopySecurityMetadata(string sourcePath, string targetPath)
+    {
+        try
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                var sourceSecurity = File.GetAccessControl(sourcePath);
+                File.SetAccessControl(targetPath, sourceSecurity);
+                return;
+            }
+
+            var sourceMode = File.GetUnixFileMode(sourcePath);
+            File.SetUnixFileMode(targetPath, sourceMode);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex,
+                "Failed to preserve file security metadata while atomically writing {Path}",
+                sourcePath);
+        }
     }
 
     private static async Task SyncFileAsync(string path, CancellationToken ct)

--- a/tests/Meridian.Tests/Storage/AtomicFileWriterTests.cs
+++ b/tests/Meridian.Tests/Storage/AtomicFileWriterTests.cs
@@ -54,6 +54,24 @@ public sealed class AtomicFileWriterTests : IDisposable
     }
 
     [Fact]
+    public async Task WriteAsync_String_PreservesExistingUnixFileMode()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var path = Path.Combine(_testRoot, "permissions.txt");
+        await File.WriteAllTextAsync(path, "original");
+        File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        await AtomicFileWriter.WriteAsync(path, "updated");
+
+        var mode = File.GetUnixFileMode(path);
+        mode.Should().Be(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
+
+    [Fact]
     public async Task WriteAsync_String_CreatesDirectoryIfNeeded()
     {
         var path = Path.Combine(_testRoot, "sub", "dir", "test.txt");


### PR DESCRIPTION
### Motivation

- Atomic writes replaced existing files by creating a temp file then renaming it, which caused the replacement file to inherit default directory permissions and could broaden access to sensitive `AppConfig` contents such as provider/brokerage credentials.
- `ConfigStore.SaveAsync` and `SaveFeatureCapabilityOverridesAsync` now route through `AtomicFileWriter.WriteAsync`, so feature toggles or config saves could unintentionally expose secrets by changing file mode/ACLs.

### Description

- Added `CopySecurityMetadata(sourcePath, targetPath)` to `src/Meridian.Storage/Archival/AtomicFileWriter.cs` which copies ACL/security descriptors on Windows via `File.GetAccessControl`/`File.SetAccessControl` and copies Unix mode bits on non-Windows via `File.GetUnixFileMode`/`File.SetUnixFileMode`.
- Invoked metadata copying for existing destinations before the atomic replace in all `WriteAsync` overloads that create a temp file (`string`, `byte[]`, and `Func<StreamWriter, Task>` variants) so the temp file inherits the original file's security metadata prior to `File.Move`.
- Failure to copy metadata is handled non-fatally: the code logs a warning and continues to preserve the atomic write semantics and crash-safety.
- Added a regression unit test `WriteAsync_String_PreservesExistingUnixFileMode` in `tests/Meridian.Tests/Storage/AtomicFileWriterTests.cs` to assert Unix file mode is preserved after overwrite.

### Testing

- Added a unit test: `tests/Meridian.Tests/Storage/AtomicFileWriterTests.cs::WriteAsync_String_PreservesExistingUnixFileMode` which validates Unix mode preservation on overwrite.
- Attempted to run the focused test command `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~AtomicFileWriterTests"`, but the environment lacks the .NET SDK and `dotnet` is not available (`/bin/bash: dotnet: command not found`), so tests could not be executed here.
- The fix is minimal and limited to `AtomicFileWriter` behavior so CI or a local environment with the .NET SDK should be able to execute the new test and validate the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a8f85638832096a0cc61c5895a95)