### PR TITLE
Guard workstation trust snapshot behind ViewSecurityMaster permission

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -1428,6 +1428,11 @@ public static partial class WorkstationEndpoints
             string? fundProfileId,
             HttpContext context) =>
         {
+            if (!HasPermission(context, UserPermission.ViewSecurityMaster))
+            {
+                return Results.StatusCode(StatusCodes.Status403Forbidden);
+            }
+
             var workbenchService = context.RequestServices.GetService<ISecurityMasterWorkbenchQueryService>();
             if (workbenchService is null)
             {
@@ -1444,6 +1449,7 @@ public static partial class WorkstationEndpoints
         })
         .WithName("GetSecurityMasterWorkstationTrustSnapshot")
         .Produces<SecurityMasterTrustSnapshotDto>(200)
+        .Produces(403)
         .Produces(404)
         .Produces(501);
 

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -3892,6 +3892,25 @@ public sealed class WorkstationEndpointsTests
     }
 
     [Fact]
+    public async Task MapWorkstationEndpoints_SecurityMasterTrustSnapshot_ShouldReturnForbiddenWithoutViewSecurityMasterPermission()
+    {
+        var securityId = Guid.Parse("60606060-6060-6060-6060-606060606060");
+        var queryService = new StubSecurityMasterQueryService();
+        queryService.RegisterSecurity(
+            CreateSecuritySummary(securityId, "Locked Security", "LOCK"),
+            CreateSecurityDetail(securityId, "Locked Security", "LOCK"));
+
+        await using var app = await CreateAppAsync(
+            services => RegisterSecurityMasterWorkbenchServices(services, queryService, new StubSecurityMasterConflictService([])),
+            currentUserPermissions: UserPermission.ViewStrategies);
+
+        var client = app.GetTestClient();
+        var response = await client.GetAsync($"/api/workstation/security-master/securities/{securityId}/trust-snapshot");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
     public async Task MapWorkstationEndpoints_SecurityMasterTrustSnapshot_ShouldReturnTypedWinningSourceProvenance()
     {
         var securityId = Guid.Parse("66666666-6666-6666-6666-666666666666");


### PR DESCRIPTION
### Motivation
- The workstation trust snapshot endpoint accepted `securityId` and `fundProfileId` and returned fund-scoped open-lot portfolio data without verifying that the caller had Security Master viewing rights, enabling potential exfiltration of sensitive portfolio/account information.

### Description
- Require `UserPermission.ViewSecurityMaster` at the start of the trust-snapshot endpoint in `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` so callers without the permission receive `403 Forbidden` instead of snapshot data.
- Document the new response by adding `.Produces(403)` to the endpoint metadata in `WorkstationEndpoints.cs`.
- Add a focused regression test `MapWorkstationEndpoints_SecurityMasterTrustSnapshot_ShouldReturnForbiddenWithoutViewSecurityMasterPermission` in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` that asserts requests from a caller with only `UserPermission.ViewStrategies` are rejected.

### Testing
- A focused unit test was added: `MapWorkstationEndpoints_SecurityMasterTrustSnapshot_ShouldReturnForbiddenWithoutViewSecurityMasterPermission` (located in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs`).
- An attempt was made to run the focused test via `dotnet test ...`, but the container environment does not have `dotnet` installed so automated test execution failed with `dotnet: command not found` and no tests were run in this environment.
- The changes are minimal and behavior-preserving for authorized callers, and the new test provides regression coverage for the authorization guard.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a8f7eaec8320b38282090a30eb06)