### PR TITLE
Restore strict provider scoping in Security Master identifier resolution

### DIFF
--- a/src/Meridian.Storage/SecurityMaster/PostgresSecurityMasterStore.cs
+++ b/src/Meridian.Storage/SecurityMaster/PostgresSecurityMasterStore.cs
@@ -674,7 +674,7 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
             join {Qualified("securities")} s on s.security_id = i.security_id
             where i.identifier_kind = @identifier_kind
               and i.normalized_identifier_value = @normalized_identifier_value
-              and (@normalized_provider is null or i.normalized_provider = @normalized_provider)
+              and ((@normalized_provider is null and i.normalized_provider is null) or i.normalized_provider = @normalized_provider)
               and i.valid_from <= @as_of
               and (i.valid_to is null or i.valid_to > @as_of)
               and (@include_inactive = true or s.status = 'Active')
@@ -687,7 +687,7 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
             join {Qualified("securities")} s on s.security_id = a.security_id
             where a.alias_kind = @identifier_kind
               and a.normalized_alias_value = @normalized_identifier_value
-              and (@normalized_provider is null or a.normalized_provider = @normalized_provider)
+              and ((@normalized_provider is null and a.normalized_provider is null) or a.normalized_provider = @normalized_provider)
               and a.valid_from <= @as_of
               and (a.valid_to is null or a.valid_to > @as_of)
               and a.is_enabled = true

--- a/tests/Meridian.Tests/SecurityMaster/SecurityMasterPostgresRoundTripTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityMasterPostgresRoundTripTests.cs
@@ -204,7 +204,6 @@ public sealed class SecurityMasterPostgresRoundTripTests
         resolvedByAlias.Should().NotBeNull();
         resolvedByAlias!.SecurityId.Should().Be(securityId);
 
-        resolvedWithoutProvider.Should().NotBeNull();
-        resolvedWithoutProvider!.SecurityId.Should().Be(securityId);
+        resolvedWithoutProvider.Should().BeNull();
     }
 }


### PR DESCRIPTION
### Motivation
- A recent change made unscoped (`provider = null`) identifier and alias lookups act like a wildcard that matched any provider, allowing provider-scoped identifiers/aliases to satisfy unscoped lookups and enabling potential poisoning of symbol resolution used by validation and trading paths.
- The intent of this change is to restore the previous, strict provider-scoping behavior so unscoped requests only match truly unscoped rows and prevent provider-scoped entries from interfering with global lookups.

### Description
- Replaced the wildcard provider predicate in `PostgresSecurityMasterStore.ResolveSecurityIdAsync` for both identifier and alias queries with an explicit-null check so unscoped requests only match rows where `normalized_provider` is null: `((@normalized_provider is null and i.normalized_provider is null) or i.normalized_provider = @normalized_provider)` and the equivalent for aliases.
- Updated the round-trip test `GetByIdentifierAsync_ResolvesNormalizedIdentifierAndProviderValues` to assert that a provider-scoped identifier is not returned for an omitted provider by changing the expectation to `resolvedWithoutProvider.Should().BeNull();`.
- Changes are limited to `src/Meridian.Storage/SecurityMaster/PostgresSecurityMasterStore.cs` and `tests/Meridian.Tests/SecurityMaster/SecurityMasterPostgresRoundTripTests.cs` and preserve the lookup fallback to `securities` primary identifier.

### Testing
- The PostgreSQL round-trip test `GetByIdentifierAsync_ResolvesNormalizedIdentifierAndProviderValues` was updated to reflect the corrected behavior and now expects `null` for an unscoped lookup against a provider-scoped identifier.
- I attempted to run the focused test via `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~GetByIdentifierAsync_ResolvesNormalizedIdentifierAndProviderValues" --logger "console;verbosity=normal"` but the environment lacks the `dotnet` SDK (`/bin/bash: dotnet: command not found`), so automated test execution could not be performed here.
- No additional automated test runs were possible in this environment; the change is intentionally minimal to keep behavior-localized and test-friendly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f39e859b08320a8594eadc3b03326)