### PR TITLE
Prevent operating scope from overriding explicit route params

### DIFF
--- a/src/Meridian.Ui/dashboard/src/app-shell.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/app-shell.view-model.test.ts
@@ -3,6 +3,7 @@ import {
   buildAppShellViewState,
   buildCommandPaletteTriggerState,
   buildDevelopmentFixtureNoticeViewModel,
+  appendOperatingScopeToRoute,
   normalizeWorkspace,
   resolveAppShellCommandPaletteShortcut,
   type AppShellWorkspacePayload
@@ -352,6 +353,27 @@ describe("app shell view model", () => {
       ["reconciliation", "/accounting/reconciliation?symbol=MSFT&fundAccountId=fund-1&runId=run-9&provider=Alpaca&from=2026-05-01&to=2026-05-15"],
       ["report-packs", "/reporting/report-packs?symbol=MSFT&fundAccountId=fund-1&runId=run-9&provider=Alpaca&from=2026-05-01&to=2026-05-15"]
     ]);
+  });
+
+
+  it("does not overwrite authoritative query parameters when applying operating scope", () => {
+    const scopedRoute = appendOperatingScopeToRoute(
+      "/strategy?runId=run-victim",
+      {
+        label: "Operating scope",
+        summary: "Run: run-attacker",
+        subjectSymbol: null,
+        fundAccountId: null,
+        runId: "run-attacker",
+        provider: null,
+        hasScope: true,
+        clearAriaLabel: "Clear operating scope",
+        items: [],
+        queryParams: [{ key: "runId", value: "run-attacker", scopeKey: "runId" }]
+      }
+    );
+
+    expect(scopedRoute).toBe("/strategy?runId=run-victim");
   });
 
   it("keeps institutional operating scope in cross-workspace focus, evidence, and linked-context handoffs", () => {

--- a/src/Meridian.Ui/dashboard/src/app-shell.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/app-shell.view-model.ts
@@ -3102,7 +3102,7 @@ export function appendOperatingScopeToRoute(route: string, operatingScope: AppSh
   const allowedScopeKeys = operatingScopeKeysForRoute(route);
   return operatingScope.queryParams
     .filter((item) => allowedScopeKeys.has(item.scopeKey))
-    .reduce((current, item) => appendSearchValue(current, item.key, item.value), route);
+    .reduce((current, item) => appendSearchValue(current, item.key, item.value, true), route);
 }
 
 export function summarizeOperatingScopeForRoute(
@@ -3217,13 +3217,17 @@ function operatingScopeKeysForRoute(route: string): Set<AppShellOperatingScopeQu
   }
 }
 
-function appendSearchValue(route: string, key: string, value: string) {
+function appendSearchValue(route: string, key: string, value: string, preserveExisting = false) {
   const hashIndex = route.indexOf("#");
   const routeWithoutHash = hashIndex >= 0 ? route.slice(0, hashIndex) : route;
   const hash = hashIndex >= 0 ? route.slice(hashIndex) : "";
   const searchIndex = routeWithoutHash.indexOf("?");
   const pathname = searchIndex >= 0 ? routeWithoutHash.slice(0, searchIndex) : routeWithoutHash;
   const params = new URLSearchParams(searchIndex >= 0 ? routeWithoutHash.slice(searchIndex) : "");
+  if (preserveExisting && params.has(key)) {
+    return route;
+  }
+
   params.set(key, value);
   const nextSearch = params.toString();
   return `${pathname}${nextSearch ? `?${nextSearch}` : ""}${hash}`;


### PR DESCRIPTION
### Motivation
- A user-controllable operating scope could overwrite authoritative query parameters (e.g. `runId`, `fundAccountId`) in destination routes, causing UI navigation to misdirect operators to attacker-controlled contexts.
- The goal is to ensure operating-scope propagation preserves intent while not replacing backend-provided identifiers in links.

### Description
- Updated `appendOperatingScopeToRoute` to only add operating-scope query parameters when the destination route does not already include those keys by using a non-destructive append mode. 
- Added an optional `preserveExisting` flag to `appendSearchValue` (default `false`) and call it with `true` from the operating-scope path to avoid overwriting existing params. 
- Kept existing overwrite semantics for other callers by making the non-destructive behavior opt-in. 
- Added a regression test that asserts an attacker-controlled `runId` in operating scope cannot replace an explicit `runId` already present in the target route. 

### Testing
- Installed dashboard dependencies with `npm install` and ran focused tests with `npm run test -- src/app-shell.view-model.test.ts src/screens/evidence-workbench-screen.view-model.test.tsx`. 
- All targeted tests passed: `2 test files, 42 tests` (all green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f3dcd78948320be83e60629ed1eb6)