### PR TITLE
Scope fund workspace reconciliation break queue to requested fund/run set

### DIFF
--- a/src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs
+++ b/src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs
@@ -141,6 +141,7 @@ public sealed class FundOperationsWorkspaceReadService
             runs,
             ct);
         var reconciliationTask = BuildReconciliationSummaryAsync(
+            normalizedFundProfileId,
             accountSummaries,
             runs,
             ct);
@@ -262,7 +263,11 @@ public sealed class FundOperationsWorkspaceReadService
             asOf,
             ledgerBook,
             ct);
-        var reconciliationTask = BuildReconciliationSummaryAsync(accountSummaries, runs, ct);
+        var reconciliationTask = BuildReconciliationSummaryAsync(
+            normalizedFundProfileId,
+            accountSummaries,
+            runs,
+            ct);
         var navTask = BuildNavSummaryAsync(normalizedFundProfileId, currency, ledgerBook, asOf, ct);
 
         await Task.WhenAll(reportTask, ledgerTask, reconciliationTask, navTask).ConfigureAwait(false);
@@ -598,6 +603,7 @@ public sealed class FundOperationsWorkspaceReadService
     }
 
     private async Task<ReconciliationSummary> BuildReconciliationSummaryAsync(
+        string fundProfileId,
         IReadOnlyList<FundAccountSummary> accounts,
         IReadOnlyList<StrategyRunEntry> runs,
         CancellationToken ct)
@@ -706,19 +712,30 @@ public sealed class FundOperationsWorkspaceReadService
             BreakAmountTotal: breakAmountTotal,
             RecentRuns: ordered,
             SecurityCoverageIssueCount: securityCoverageIssues,
-            BreakQueue: await BuildBreakQueueProjectionAsync(ct).ConfigureAwait(false),
+            BreakQueue: await BuildBreakQueueProjectionAsync(fundProfileId, runs, ct).ConfigureAwait(false),
             LedgerImpactPreview: BuildLedgerImpactPreview(ordered),
-            HasCriticalBreakOpen: await HasCriticalBreakOpenAsync(ct).ConfigureAwait(false));
+            HasCriticalBreakOpen: await HasCriticalBreakOpenAsync(fundProfileId, runs, ct).ConfigureAwait(false));
     }
 
-    private async Task<ReconciliationBreakQueueProjectionDto?> BuildBreakQueueProjectionAsync(CancellationToken ct)
+    private async Task<ReconciliationBreakQueueProjectionDto?> BuildBreakQueueProjectionAsync(
+        string fundProfileId,
+        IReadOnlyList<StrategyRunEntry> runs,
+        CancellationToken ct)
     {
         if (_breakQueueRepository is null)
         {
             return null;
         }
 
-        var items = await _breakQueueRepository.GetAllAsync(null, ct).ConfigureAwait(false);
+        var scopedRunIds = runs
+            .Select(static run => run.RunId)
+            .Where(static runId => !string.IsNullOrWhiteSpace(runId))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var items = (await _breakQueueRepository.GetAllAsync(null, ct).ConfigureAwait(false))
+            .Where(item =>
+                string.Equals(item.FundAccountId, fundProfileId, StringComparison.OrdinalIgnoreCase) &&
+                scopedRunIds.Contains(item.RunId))
+            .ToArray();
         var projected = items
             .OrderByDescending(static item => item.LastUpdatedAt)
             .Select(static item => new ReconciliationBreakQueueProjectionItemDto(
@@ -770,15 +787,25 @@ public sealed class FundOperationsWorkspaceReadService
             ValidationFlags: flags);
     }
 
-    private async Task<bool> HasCriticalBreakOpenAsync(CancellationToken ct)
+    private async Task<bool> HasCriticalBreakOpenAsync(
+        string fundProfileId,
+        IReadOnlyList<StrategyRunEntry> runs,
+        CancellationToken ct)
     {
         if (_breakQueueRepository is null)
         {
             return false;
         }
 
+        var scopedRunIds = runs
+            .Select(static run => run.RunId)
+            .Where(static runId => !string.IsNullOrWhiteSpace(runId))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
         var items = await _breakQueueRepository.GetAllAsync(ReconciliationBreakQueueStatus.Open, ct).ConfigureAwait(false);
-        return items.Any(static item => item.Severity == ReconciliationBreakSeverity.Critical);
+        return items.Any(item =>
+            item.Severity == ReconciliationBreakSeverity.Critical &&
+            string.Equals(item.FundAccountId, fundProfileId, StringComparison.OrdinalIgnoreCase) &&
+            scopedRunIds.Contains(item.RunId));
     }
 
     private async Task<FundNavAttributionSummaryDto> BuildNavSummaryAsync(


### PR DESCRIPTION
### Motivation
- Prevent cross-fund information leakage from the reconciliation break queue exposed by the fund workspace endpoint by ensuring the projection is scoped to the requested `fundProfileId` and the workspace's selected run IDs.
- Ensure the global `HasCriticalBreakOpen` flag reflects only critical breaks for the requested fund/run set so unrelated funds cannot incorrectly block readiness or surface sensitive metadata.

### Description
- Threaded `fundProfileId` into the reconciliation summary machinery by changing calls to `BuildReconciliationSummaryAsync` to pass `normalizedFundProfileId` for both workspace and report-pack flows.
- Restrict `BuildBreakQueueProjectionAsync` to filter repository results by `item.FundAccountId == fundProfileId` and to only include queue items whose `RunId` is in the workspace `runs` set before projecting into `ReconciliationBreakQueueProjectionDto`.
- Restrict `HasCriticalBreakOpenAsync` to consider only open queue items that match `fundProfileId` and the scoped run IDs when determining whether a critical break is open.
- Changes made in `src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs` to implement the above scoping logic without altering DTO shapes or external endpoints.

### Testing
- Attempted to run unit tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~FundOperationsWorkspaceReadServiceTests" --logger "console;verbosity=minimal"`, but the container lacks the `dotnet` SDK and the command failed with `dotnet: command not found`.
- Local static verification performed by inspecting and running code edits; changes were committed on the branch (commit message: "Scope fund workspace reconciliation break queue to fund runs").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f3dcd7f9c83208d379ffd492fe755)