### PR TITLE
Add ConfigService-backed save/apply/reload flows to WPF Settings

### DIFF
--- a/src/Meridian.Wpf/Services/ConfigService.cs
+++ b/src/Meridian.Wpf/Services/ConfigService.cs
@@ -194,6 +194,21 @@ public sealed class ConfigService : ConfigServiceBase
     }
 
     /// <summary>
+    /// Loads the full configuration DTO from disk.
+    /// </summary>
+    public async Task<AppConfigDto> LoadConfigFromDiskAsync(CancellationToken ct = default)
+        => await LoadConfigCoreAsync(ct) ?? new AppConfigDto();
+
+    /// <summary>
+    /// Writes the full configuration DTO to disk.
+    /// </summary>
+    public Task WriteConfigAsync(AppConfigDto config, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        return SaveConfigCoreAsync(config, ct);
+    }
+
+    /// <summary>
     /// Validates a single provider's options inline (for real-time field validation).
     /// Returns a list of validation messages (empty if valid).
     /// </summary>

--- a/src/Meridian.Wpf/ViewModels/SettingsViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/SettingsViewModel.cs
@@ -11,6 +11,7 @@ using System.Windows;
 using System.Windows.Media;
 using CommunityToolkit.Mvvm.Input;
 using Meridian.Application.Config;
+using Meridian.Contracts.Configuration;
 using Meridian.Ui.Services.Services;
 using Meridian.Wpf.Features;
 using Meridian.Wpf.Models;
@@ -46,6 +47,10 @@ public sealed class SettingsViewModel : BindableBase
     private Visibility _noCredentialsVisibility = Visibility.Collapsed;
     private Visibility _credentialListVisibility = Visibility.Visible;
     private bool _loadingDesktopPreferences;
+    private bool _isConfigValid = true;
+    private bool _hasUnsavedChanges;
+    private string _configValidationErrors = string.Empty;
+    private bool _isPopulatingConfig;
 
     // ── Appearance / notification / performance settings (bindable defaults) ──
     private int _themeIndex;
@@ -100,8 +105,10 @@ public sealed class SettingsViewModel : BindableBase
 
         // Configuration commands
         OpenConfigFolderCommand = new RelayCommand(OpenConfigFolder);
-        ReloadConfigCommand = new RelayCommand(ReloadConfig);
-        ResetToDefaultsCommand = new RelayCommand(ResetToDefaults);
+        ReloadConfigCommand = new AsyncRelayCommand(ReloadConfigAsync);
+        ResetToDefaultsCommand = new AsyncRelayCommand(ResetToDefaultsAsync);
+        SaveConfigCommand = new AsyncRelayCommand(SaveConfigAsync, CanSaveConfig);
+        ApplyConfigCommand = new AsyncRelayCommand(ApplyConfigAsync, CanSaveConfig);
 
         // Test / support commands
         SendTestNotificationCommand = new RelayCommand(SendTestNotification);
@@ -219,14 +226,14 @@ public sealed class SettingsViewModel : BindableBase
     public int ThemeIndex
     {
         get => _themeIndex;
-        set => SetProperty(ref _themeIndex, value);
+        set => SetSettingProperty(ref _themeIndex, value);
     }
 
     /// <summary>Selected index of the accent-color ComboBox.</summary>
     public int AccentColorIndex
     {
         get => _accentColorIndex;
-        set => SetProperty(ref _accentColorIndex, value);
+        set => SetSettingProperty(ref _accentColorIndex, value);
     }
 
     public ShellDensityMode SelectedShellDensityMode
@@ -247,6 +254,7 @@ public sealed class SettingsViewModel : BindableBase
             }
 
             _settingsConfigService.SetShellDensityMode(value);
+            MarkDirty();
         }
     }
 
@@ -265,7 +273,10 @@ public sealed class SettingsViewModel : BindableBase
         set
         {
             if (SetProperty(ref _isNotificationsEnabled, value))
+            {
                 RaisePropertyChanged(nameof(NotificationsPanelOpacity));
+                MarkDirty();
+            }
         }
     }
 
@@ -275,37 +286,37 @@ public sealed class SettingsViewModel : BindableBase
     public string MaxConcurrentDownloads
     {
         get => _maxConcurrentDownloads;
-        set => SetProperty(ref _maxConcurrentDownloads, value);
+        set => SetSettingProperty(ref _maxConcurrentDownloads, value);
     }
 
     public string WriteBufferSize
     {
         get => _writeBufferSize;
-        set => SetProperty(ref _writeBufferSize, value);
+        set => SetSettingProperty(ref _writeBufferSize, value);
     }
 
     public bool IsMetricsEnabled
     {
         get => _isMetricsEnabled;
-        set => SetProperty(ref _isMetricsEnabled, value);
+        set => SetSettingProperty(ref _isMetricsEnabled, value);
     }
 
     public bool IsDebugLoggingEnabled
     {
         get => _isDebugLoggingEnabled;
-        set => SetProperty(ref _isDebugLoggingEnabled, value);
+        set => SetSettingProperty(ref _isDebugLoggingEnabled, value);
     }
 
     public string ApiBaseUrl
     {
         get => _apiBaseUrl;
-        set => SetProperty(ref _apiBaseUrl, value);
+        set => SetSettingProperty(ref _apiBaseUrl, value);
     }
 
     public string StatusRefreshInterval
     {
         get => _statusRefreshInterval;
-        set => SetProperty(ref _statusRefreshInterval, value);
+        set => SetSettingProperty(ref _statusRefreshInterval, value);
     }
 
     // ── Commands ──────────────────────────────────────────────────────────────
@@ -320,8 +331,10 @@ public sealed class SettingsViewModel : BindableBase
     public IRelayCommand TestAllCredentialsCommand { get; }
     public IRelayCommand ClearAllCredentialsCommand { get; }
     public IRelayCommand OpenConfigFolderCommand { get; }
-    public IRelayCommand ReloadConfigCommand { get; }
-    public IRelayCommand ResetToDefaultsCommand { get; }
+    public IAsyncRelayCommand ReloadConfigCommand { get; }
+    public IAsyncRelayCommand ResetToDefaultsCommand { get; }
+    public IAsyncRelayCommand SaveConfigCommand { get; }
+    public IAsyncRelayCommand ApplyConfigCommand { get; }
     public IRelayCommand SendTestNotificationCommand { get; }
     public IAsyncRelayCommand TestConnectionCommand { get; }
     public IRelayCommand CheckForUpdatesCommand { get; }
@@ -334,6 +347,7 @@ public sealed class SettingsViewModel : BindableBase
     public void Initialize()
     {
         LoadDesktopPreferences();
+        _ = LoadConfigAsync();
         RefreshCapabilityToggles();
         ConfigPath = _configService.ConfigPath;
         RefreshStoredCredentials();
@@ -561,13 +575,63 @@ public sealed class SettingsViewModel : BindableBase
         }
     }
 
-    private void ReloadConfig()
+    private async Task ReloadConfigAsync()
+    {
+        await LoadConfigAsync(true);
+    }
+
+    private async Task ResetToDefaultsAsync()
+    {
+        var result = MessageBox.Show(
+            "This will reset all settings to their default values. Your symbols and credentials will be preserved. Continue?",
+            "Reset to Defaults",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Question);
+
+        if (result != MessageBoxResult.Yes)
+            return;
+
+        try
+        {
+            await _configService.WriteConfigAsync(new AppConfigDto());
+            await LoadConfigAsync(false);
+            _notificationService.ShowNotification("Reset Complete", "Settings have been reset to defaults.", NotificationType.Success);
+        }
+        catch (Exception ex)
+        {
+            _notificationService.ShowNotification("Reset Failed", ex.Message, NotificationType.Error);
+        }
+    }
+
+    public bool IsConfigValid
+    {
+        get => _isConfigValid;
+        private set => SetProperty(ref _isConfigValid, value);
+    }
+
+    public bool HasUnsavedChanges
+    {
+        get => _hasUnsavedChanges;
+        private set => SetProperty(ref _hasUnsavedChanges, value);
+    }
+
+    public string ConfigValidationErrors
+    {
+        get => _configValidationErrors;
+        private set => SetProperty(ref _configValidationErrors, value);
+    }
+
+    private async Task LoadConfigAsync(bool showNotification = false)
     {
         try
         {
-            ConfigStatusText = "Valid";
-            ConfigStatusDot = new SolidColorBrush(Color.FromRgb(63, 185, 80));
-            _notificationService.ShowNotification("Configuration Reloaded", "Configuration has been reloaded successfully.", NotificationType.Success);
+            var config = await _configService.LoadConfigFromDiskAsync();
+            PopulateFromConfig(config);
+            await RefreshValidationAsync();
+            if (showNotification)
+            {
+                _notificationService.ShowNotification("Configuration Reloaded", "Configuration has been reloaded successfully.", NotificationType.Success);
+            }
         }
         catch (Exception ex)
         {
@@ -577,29 +641,92 @@ public sealed class SettingsViewModel : BindableBase
         }
     }
 
-    private void ResetToDefaults()
+    private void PopulateFromConfig(AppConfigDto config)
     {
-        var result = MessageBox.Show(
-            "This will reset all settings to their default values. Your symbols and credentials will be preserved. Continue?",
-            "Reset to Defaults",
-            MessageBoxButton.YesNo,
-            MessageBoxImage.Question);
-
-        if (result == MessageBoxResult.Yes)
+        _isPopulatingConfig = true;
+        try
         {
-            ThemeIndex = 0;
+            var settings = config.Settings ?? new AppSettingsDto();
+            ApiBaseUrl = config.IB?.BaseUrl ?? "http://localhost:8080";
+            StatusRefreshInterval = settings.StatusRefreshIntervalSeconds.ToString();
+            IsNotificationsEnabled = settings.NotificationsEnabled;
+            SelectedShellDensityMode = settings.CompactMode ? ShellDensityMode.Compact : ShellDensityMode.Standard;
+            ThemeIndex = string.Equals(settings.Theme, "Dark", StringComparison.OrdinalIgnoreCase) ? 2 : string.Equals(settings.Theme, "Light", StringComparison.OrdinalIgnoreCase) ? 1 : 0;
             AccentColorIndex = 0;
-            SelectedShellDensityMode = ShellDensityMode.Standard;
-            IsNotificationsEnabled = true;
-            MaxConcurrentDownloads = "4";
-            WriteBufferSize = "64";
-            IsMetricsEnabled = true;
+            MaxConcurrentDownloads = settings.MaxReconnectAttempts.ToString();
+            WriteBufferSize = config.Compress ? "64" : "0";
+            IsMetricsEnabled = settings.AutoReconnectEnabled;
             IsDebugLoggingEnabled = false;
-            ApiBaseUrl = "http://localhost:8080";
-            StatusRefreshInterval = "2";
-
-            _notificationService.ShowNotification("Reset Complete", "Settings have been reset to defaults.", NotificationType.Success);
+            HasUnsavedChanges = false;
         }
+        finally
+        {
+            _isPopulatingConfig = false;
+        }
+    }
+
+    private AppConfigDto BuildConfigDtoFromSettings()
+    {
+        var interval = int.TryParse(StatusRefreshInterval, out var parsedInterval) ? parsedInterval : 2;
+        var maxReconnect = int.TryParse(MaxConcurrentDownloads, out var parsedMaxReconnect) ? parsedMaxReconnect : 10;
+        return new AppConfigDto
+        {
+            IB = new IBOptionsDto { BaseUrl = ApiBaseUrl },
+            Compress = WriteBufferSize != "0",
+            Settings = new AppSettingsDto
+            {
+                Theme = ThemeIndex switch { 1 => "Light", 2 => "Dark", _ => "System" },
+                NotificationsEnabled = IsNotificationsEnabled,
+                CompactMode = SelectedShellDensityMode == ShellDensityMode.Compact,
+                AutoReconnectEnabled = IsMetricsEnabled,
+                MaxReconnectAttempts = maxReconnect,
+                StatusRefreshIntervalSeconds = interval
+            }
+        };
+    }
+
+    private async Task SaveConfigAsync() => await SaveOrApplyConfigAsync("Configuration Saved");
+    private async Task ApplyConfigAsync() => await SaveOrApplyConfigAsync("Configuration Applied");
+    private async Task SaveOrApplyConfigAsync(string messageTitle)
+    {
+        var validation = await RefreshValidationAsync();
+        if (!validation.IsValid)
+        {
+            _notificationService.ShowNotification("Validation Failed", string.Join(Environment.NewLine, validation.Errors), NotificationType.Error);
+            return;
+        }
+
+        await _configService.WriteConfigAsync(BuildConfigDtoFromSettings());
+        HasUnsavedChanges = false;
+        _notificationService.ShowNotification(messageTitle, "Settings have been written to disk.", NotificationType.Success);
+    }
+
+    private async Task<ConfigServiceValidationResult> RefreshValidationAsync()
+    {
+        var result = await _configService.ValidateConfigAsync();
+        IsConfigValid = result.IsValid;
+        ConfigValidationErrors = string.Join(Environment.NewLine, result.Errors);
+        ConfigStatusText = result.IsValid ? "Valid" : "Invalid";
+        ConfigStatusDot = result.IsValid ? new SolidColorBrush(Color.FromRgb(63, 185, 80)) : new SolidColorBrush(Color.FromRgb(248, 81, 73));
+        SaveConfigCommand.NotifyCanExecuteChanged();
+        ApplyConfigCommand.NotifyCanExecuteChanged();
+        return result;
+    }
+
+    private bool CanSaveConfig() => HasUnsavedChanges && IsConfigValid;
+    private void MarkDirty()
+    {
+        if (_isPopulatingConfig)
+            return;
+        HasUnsavedChanges = true;
+        _ = RefreshValidationAsync();
+    }
+    private bool SetSettingProperty<T>(ref T field, T value, string? propertyName = null)
+    {
+        if (!SetProperty(ref field, value, propertyName))
+            return false;
+        MarkDirty();
+        return true;
     }
 
     // ── Test / support ────────────────────────────────────────────────────────

--- a/src/Meridian.Wpf/Views/SettingsPage.xaml
+++ b/src/Meridian.Wpf/Views/SettingsPage.xaml
@@ -613,6 +613,14 @@
                         </StackPanel>
 
                         <StackPanel Orientation="Horizontal">
+                            <Button Content="Apply"
+                                    Style="{StaticResource SecondaryButtonStyle}"
+                                    Command="{Binding ApplyConfigCommand}"
+                                    Margin="0,0,8,0" />
+                            <Button Content="Save"
+                                    Style="{StaticResource SecondaryButtonStyle}"
+                                    Command="{Binding SaveConfigCommand}"
+                                    Margin="0,0,8,0" />
                             <Button Content="Open in Explorer"
                                     Style="{StaticResource SecondaryButtonStyle}"
                                     Command="{Binding OpenConfigFolderCommand}"
@@ -625,6 +633,10 @@
                                     Style="{StaticResource GhostButtonStyle}"
                                     Command="{Binding ResetToDefaultsCommand}" />
                         </StackPanel>
+                        <TextBlock Text="{Binding ConfigValidationErrors}"
+                                   Foreground="{StaticResource DangerColorBrush}"
+                                   TextWrapping="Wrap"
+                                   Margin="0,8,0,0" />
                     </StackPanel>
                 </Border>
 


### PR DESCRIPTION
### Motivation
- Provide a disk-backed settings workflow so the Settings page reads and writes the real `AppConfigDto` via the platform `ConfigService` rather than only mutating view-model properties. 
- Ensure saves are validated before persisting and surface validation errors to users while enabling explicit Apply/Save semantics and proper reload/reset behaviors.

### Description
- Added `LoadConfigFromDiskAsync` and `WriteConfigAsync` to `Wpf.Services.ConfigService` to expose full DTO read/write operations. 
- Extended `SettingsViewModel` with `SaveConfigCommand` and `ApplyConfigCommand`, a `LoadConfigAsync` initialization path and `PopulateFromConfig` to hydrate view properties from `AppConfigDto`, and `BuildConfigDtoFromSettings` to construct the DTO for persisting. 
- Replaced the old `ReloadConfig()` and `ResetToDefaults()` behaviors with real disk-backed flows that call `ConfigService` (`ReloadConfigAsync` and `ResetToDefaultsAsync`) and show success/failure notifications. 
- Added dirty-state and validation gating (`HasUnsavedChanges`, `IsConfigValid`, `ConfigValidationErrors`), consolidated inline validation via `ValidateConfigAsync` before writes, and blocked saves when invalid. 
- Updated `SettingsPage.xaml` to add `Apply` and `Save` buttons and to display validation errors inline; command availability is driven by the view-model `CanExecute` logic so Save/Apply are disabled when there are no changes or validation fails. 

### Testing
- Attempted a focused build of the WPF project with `dotnet build src/Meridian.Wpf/Meridian.Wpf.csproj -p:EnableFullWpfBuild=true -p:EnableWindowsTargeting=true`, but the environment lacked the `dotnet` runtime/tooling and the build failed with `dotnet: command not found` (no successful automated builds were run in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a174604c6a8832085ae59d8399a08de)