### PR TITLE
Startup-safe config self-healing: EnsureConfigurationExistsAsync + UI/logging updates

### DIFF
--- a/src/Meridian.Wpf/App.xaml.cs
+++ b/src/Meridian.Wpf/App.xaml.cs
@@ -973,6 +973,11 @@ public partial class App : System.Windows.Application
     {
         try
         {
+            var provisioningResult = await WpfServices.FirstRunService.Instance.EnsureConfigurationExistsAsync();
+            WpfServices.LoggingService.Instance.LogInfo(
+                "Configuration presence verification finished before validation",
+                ("Outcome", provisioningResult.ToString()));
+
             // Initialize the config service
             await WpfServices.ConfigService.Instance.InitializeAsync();
 

--- a/src/Meridian.Wpf/Services/FirstRunService.cs
+++ b/src/Meridian.Wpf/Services/FirstRunService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Meridian.Contracts.Configuration;
 
@@ -16,6 +17,8 @@ public sealed class FirstRunService
     private bool? _isFirstRun;
     private bool _isInitialized;
     private readonly object _lock = new();
+    private ConfigurationProvisioningResult _lastConfigurationProvisioningResult =
+        ConfigurationProvisioningResult.AlreadyValid;
 
     /// <summary>
     /// Gets the singleton instance of the FirstRunService.
@@ -184,6 +187,48 @@ public sealed class FirstRunService
     /// </summary>
     public bool IsInitialized => _isInitialized;
 
+    public ConfigurationProvisioningResult LastConfigurationProvisioningResult => _lastConfigurationProvisioningResult;
+
+    public Task<ConfigurationProvisioningResult> EnsureConfigurationExistsAsync()
+    {
+        lock (_lock)
+        {
+            Directory.CreateDirectory(AppDataPath);
+
+            if (!File.Exists(ConfigFilePath))
+            {
+                CreateDefaultConfiguration();
+                _lastConfigurationProvisioningResult = ConfigurationProvisioningResult.CreatedDefault;
+                LoggingService.Instance.LogInfo(
+                    "Configuration provisioning completed",
+                    ("Outcome", "CreatedDefault"),
+                    ("Path", ConfigFilePath));
+                return Task.FromResult(_lastConfigurationProvisioningResult);
+            }
+
+            if (!TryParseConfiguration(ConfigFilePath, out var parseError))
+            {
+                var backupPath = $"{ConfigFilePath}.invalid-{DateTime.UtcNow:yyyyMMddHHmmssfff}.bak";
+                File.Copy(ConfigFilePath, backupPath, overwrite: true);
+                CreateDefaultConfiguration();
+                _lastConfigurationProvisioningResult = ConfigurationProvisioningResult.RepairedInvalid;
+                LoggingService.Instance.LogWarning(
+                    "Configuration provisioning repaired invalid configuration",
+                    ("Path", ConfigFilePath),
+                    ("BackupPath", backupPath),
+                    ("Reason", parseError ?? "unknown"));
+                return Task.FromResult(_lastConfigurationProvisioningResult);
+            }
+
+            _lastConfigurationProvisioningResult = ConfigurationProvisioningResult.AlreadyValid;
+            LoggingService.Instance.LogInfo(
+                "Configuration provisioning skipped",
+                ("Outcome", "AlreadyValid"),
+                ("Path", ConfigFilePath));
+            return Task.FromResult(_lastConfigurationProvisioningResult);
+        }
+    }
+
     private void CreateDefaultConfiguration()
     {
         var defaultConfig = """
@@ -252,6 +297,29 @@ public sealed class FirstRunService
     {
         Initialized?.Invoke(this, e);
     }
+
+    private static bool TryParseConfiguration(string path, out string? parseError)
+    {
+        try
+        {
+            var json = File.ReadAllText(path);
+            using var _ = JsonDocument.Parse(json);
+            parseError = null;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            parseError = ex.Message;
+            return false;
+        }
+    }
+}
+
+public enum ConfigurationProvisioningResult
+{
+    CreatedDefault,
+    RepairedInvalid,
+    AlreadyValid
 }
 
 /// <summary>

--- a/src/Meridian.Wpf/Views/SetupWizardPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/SetupWizardPage.xaml.cs
@@ -103,6 +103,7 @@ public partial class SetupWizardPage : Page
 
     private void LoadExistingConfiguration()
     {
+        var provisioningResult = _firstRunService.LastConfigurationProvisioningResult;
         try
         {
             if (!File.Exists(_firstRunService.ConfigFilePath))
@@ -127,7 +128,12 @@ public partial class SetupWizardPage : Page
             var storageBase = MeridianPathDefaults.ResolveConfiguredDataRootFromJson(json);
             StorageLocationTextBox.Text = storageBase;
 
-            ConfigStatusText.Text = "Loaded existing configuration.";
+            ConfigStatusText.Text = provisioningResult switch
+            {
+                ConfigurationProvisioningResult.CreatedDefault => "Created a new default configuration at startup.",
+                ConfigurationProvisioningResult.RepairedInvalid => "Repaired an invalid configuration at startup and restored defaults.",
+                _ => "Loaded existing valid configuration."
+            };
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
### Motivation
- Ensure application startup is robust when the configuration file is missing or contains invalid JSON by provisioning a valid configuration before any validation runs. 
- Decouple self-healing of the config file from the first-run UX decision so onboarding flows remain driven by `IsFirstRunAsync()` while config repair happens deterministically at startup. 
- Surface user- and operator-visible indicators and structured logs for created, repaired, or already-valid configuration outcomes.

### Description
- Added `FirstRunService.EnsureConfigurationExistsAsync()` which always ensures `AppDataPath` exists, creates a default config when `ConfigFilePath` is missing, or backs up and replaces unreadable/invalid JSON with a default; it returns a `ConfigurationProvisioningResult` and records the last outcome via `LastConfigurationProvisioningResult`. (`src/Meridian.Wpf/Services/FirstRunService.cs`) 
- Added JSON parse check helper `TryParseConfiguration()` using `JsonDocument.Parse()` to detect invalid JSON, and write a timestamped backup when repairing a corrupt file. (`src/Meridian.Wpf/Services/FirstRunService.cs`) 
- Introduced `ConfigurationProvisioningResult` enum with members `CreatedDefault`, `RepairedInvalid`, and `AlreadyValid` and an accessor `LastConfigurationProvisioningResult`. (`src/Meridian.Wpf/Services/FirstRunService.cs`) 
- Invoke `EnsureConfigurationExistsAsync()` at startup in `App.InitializeConfigurationAsync()` before calling `ConfigService.InitializeAsync()` and `ValidateConfigAsync()`, and log the provisioning outcome. (`src/Meridian.Wpf/App.xaml.cs`) 
- Kept `IsFirstRunAsync()` semantics unchanged so onboarding decisions remain based on the config+marker presence logic. (`src/Meridian.Wpf/Services/FirstRunService.cs`) 
- Updated `SetupWizardPage.LoadExistingConfiguration()` to read `FirstRunService.LastConfigurationProvisioningResult` and show user-facing status text reflecting whether the configuration was created, repaired, or already valid. (`src/Meridian.Wpf/Views/SetupWizardPage.xaml.cs`) 
- Added structured log entries for the three branches: created default config, repaired invalid config (includes backup path and parse reason), and skipped because the config was already valid. (`src/Meridian.Wpf/Services/FirstRunService.cs`, `src/Meridian.Wpf/App.xaml.cs`)

### Testing
- Attempted to run a focused build: `dotnet build src/Meridian.Wpf/Meridian.Wpf.csproj -p:EnableWindowsTargeting=true -v minimal`, but the environment lacks `dotnet`, so the build could not be executed and no compile/test artifacts were produced. 
- No other automated tests were executed in this environment; code changes were validated by static inspection and local file edits only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17460647b88320b9b734d8300b016e)