### PR TITLE
Harden README contract validator against path traversal and symlink escape

### DIFF
--- a/tests/scripts/test_validate_source_readmes.py
+++ b/tests/scripts/test_validate_source_readmes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -50,6 +51,84 @@ class ValidateSourceReadmesTests(unittest.TestCase):
         self.assertIn("module=missing-markers-module", output)
         self.assertIn("missing=missing generated block begin marker", output)
         self.assertIn("missing=missing generated block end marker", output)
+
+    def test_absolute_readme_path_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_root = Path(temp_dir)
+            modules = temp_root / "modules.yml"
+            coverage = temp_root / "coverage.yml"
+            outside_readme = temp_root / "outside.md"
+            outside_readme.write_text("# outside", encoding="utf-8")
+            modules.write_text("modules: []\n", encoding="utf-8")
+            coverage.write_text(
+                "readme_coverage:\n"
+                "  modules:\n"
+                "    - id: attack.module\n"
+                f"      readme_path: {outside_readme}\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(self.script),
+                    "--modules",
+                    str(modules),
+                    "--coverage",
+                    str(coverage),
+                    "--repo-root",
+                    str(self.repo_root),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("README path must be relative to repository root", result.stdout + result.stderr)
+
+    def test_symlink_readme_path_escaping_repo_root_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_root = Path(temp_dir)
+            modules = temp_root / "modules.yml"
+            coverage = temp_root / "coverage.yml"
+            outside_readme = temp_root / "outside.md"
+            outside_readme.write_text("# outside", encoding="utf-8")
+            symlink_path = self.repo_root / "tools/source_docs/fixtures/readme_contract/symlink-escape.md"
+            try:
+                if symlink_path.exists() or symlink_path.is_symlink():
+                    symlink_path.unlink()
+                symlink_path.symlink_to(outside_readme)
+                modules.write_text("modules: []\n", encoding="utf-8")
+                coverage.write_text(
+                    "readme_coverage:\n"
+                    "  modules:\n"
+                    "    - id: attack.module\n"
+                    f"      readme_path: {symlink_path.relative_to(self.repo_root)}\n",
+                    encoding="utf-8",
+                )
+
+                result = subprocess.run(
+                    [
+                        "python3",
+                        str(self.script),
+                        "--modules",
+                        str(modules),
+                        "--coverage",
+                        str(coverage),
+                        "--repo-root",
+                        str(self.repo_root),
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+
+                self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+                self.assertIn("README path escapes repository root", result.stdout + result.stderr)
+            finally:
+                if symlink_path.exists() or symlink_path.is_symlink():
+                    symlink_path.unlink()
 
 
 if __name__ == "__main__":

--- a/tools/source_docs/validate_source_readmes.py
+++ b/tools/source_docs/validate_source_readmes.py
@@ -148,6 +148,19 @@ def _as_list(value: Any) -> list[Any]:
     return value if isinstance(value, list) else []
 
 
+def _resolve_readme_path(repo_root: Path, readme_path: str) -> tuple[Path | None, str | None]:
+    candidate = Path(readme_path)
+    if candidate.is_absolute():
+        return None, f"README path must be relative to repository root: {readme_path}"
+
+    resolved_repo_root = repo_root.resolve()
+    resolved_readme = (resolved_repo_root / candidate).resolve()
+    if resolved_readme != resolved_repo_root and resolved_repo_root not in resolved_readme.parents:
+        return None, f"README path escapes repository root: {readme_path}"
+
+    return resolved_readme, None
+
+
 def validate(modules_path: Path, coverage_path: Path, repo_root: Path) -> list[str]:
     errors: list[str] = []
     modules_doc = _load_yaml(modules_path)
@@ -225,14 +238,24 @@ def validate(modules_path: Path, coverage_path: Path, repo_root: Path) -> list[s
     for module in coverage_modules:
         module_id = str(module.get("id", "<unknown>"))
         readme_path = module.get("readme_path")
-        if readme_path and not (repo_root / readme_path).exists():
+        if not readme_path:
+            continue
+
+        resolved_readme_path, path_error = _resolve_readme_path(repo_root, str(readme_path))
+        if path_error:
+            errors.append(path_error)
+            continue
+        if resolved_readme_path is None:
+            continue
+
+        if not resolved_readme_path.exists():
             errors.append(f"README path does not exist: {readme_path}")
         if readme_path and readme_path in moved_from_paths and readme_path not in moved_to_paths:
             errors.append(
                 f"Stale README path '{readme_path}' referenced after move/rename; update to current path."
             )
-        if readme_path and (repo_root / readme_path).exists():
-            readme_errors = validate_readme_contract(repo_root / readme_path, module_id)
+        if resolved_readme_path.exists():
+            readme_errors = validate_readme_contract(resolved_readme_path, module_id)
             for element_error in readme_errors:
                 errors.append(
                     f"README contract violation [module={module_id}] [path={readme_path}] [missing={element_error}]"


### PR DESCRIPTION
### Motivation
- The README contract validator previously opened coverage-supplied `readme_path` values directly which allowed absolute paths and symlink escapes to read files outside the repository or hang on special files.
- This change prevents untrusted coverage data from causing out-of-repo file access or denial-of-service during CI or developer automation.

### Description
- Added `_resolve_readme_path(repo_root, readme_path)` to enforce that `readme_path` is relative and that the resolved path remains under the canonical `repo_root`, and return clear error strings when checks fail.
- Updated `validate(...)` to skip empty `readme_path`, call `_resolve_readme_path(...)`, append explicit errors for invalid/escaping paths, and only call `validate_readme_contract(...)` with the resolved in-repo `Path`.
- Preserved existing contract checks (front matter, headings, generated block markers) while replacing unsafe `repo_root / readme_path` usage with resolved-path checks.
- Added regression tests in `tests/scripts/test_validate_source_readmes.py` to assert rejection of absolute `readme_path` values and symlink-based escapes.

### Testing
- Ran `python3 -m unittest tests/scripts/test_validate_source_readmes.py`, which could not complete in this environment because `PyYAML` is not installed and the test process fails early with a clear runtime error; this prevented exercising YAML-backed assertions here.
- Verified syntax only with `python3 -m py_compile tools/source_docs/validate_source_readmes.py tests/scripts/test_validate_source_readmes.py`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f3dcff7808320a2fa02f1b4628ee4)