### PR TITLE
Reject non-mapping entries in source-modules.yml validation

### DIFF
--- a/tools/source_docs/validate_source_readmes.py
+++ b/tools/source_docs/validate_source_readmes.py
@@ -153,7 +153,14 @@ def validate(modules_path: Path, coverage_path: Path, repo_root: Path) -> list[s
     modules_doc = _load_yaml(modules_path)
     coverage_doc = _load_yaml(coverage_path)
 
-    modules = [m for m in _as_list(modules_doc.get("modules")) if isinstance(m, dict)]
+    modules: list[dict[str, Any]] = []
+    for index, module in enumerate(_as_list(modules_doc.get("modules"))):
+        if not isinstance(module, dict):
+            errors.append(
+                f"source-modules.yml entry at modules[{index}] must be a mapping/object."
+            )
+            continue
+        modules.append(module)
 
     module_ids: list[str] = []
     for module in modules:


### PR DESCRIPTION
### Motivation
- A prior change silently filtered non-dictionary `modules` entries which allowed malformed YAML to pass validation instead of reporting an error. 
- The validator should emit structured errors for invalid entries so CI and documentation checks surface malformed `source-modules.yml` data.

### Description
- Update `validate()` in `tools/source_docs/validate_source_readmes.py` to iterate `modules` with an index and explicitly detect non-dictionary entries. 
- When a `modules` entry is not a mapping, append an error like `source-modules.yml entry at modules[<index>] must be a mapping/object.` and skip it instead of dropping it silently. 
- Preserve the existing validation flow for dictionary module objects (checks for `id`, `path`, path existence, and duplicate `id` detection).

### Testing
- Ran `python3 -m py_compile tools/source_docs/validate_source_readmes.py` which succeeded. 
- Attempted to run the YAML validation path with `python3 tools/source_docs/validate_source_readmes.py --modules <tmp>/modules.yml --coverage <tmp>/coverage.yml --repo-root .` but the runtime check could not complete because `PyYAML` is not installed and the script raised `RuntimeError: PyYAML is required for source YAML validation mode.`. 
- Static inspection and a small local edit ensure the new error path appends errors for non-mapping `modules[*]` entries while leaving valid-module validation unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f3dcdd0d483209910c62c6cf32888)