### PR TITLE
Fix test isolation leak in ProviderCapabilityContractRegistrationTests

### DIFF
--- a/tests/Meridian.Tests/Application/Composition/ProviderCapabilityContractRegistrationTests.cs
+++ b/tests/Meridian.Tests/Application/Composition/ProviderCapabilityContractRegistrationTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Meridian.Application.Composition;
 using Meridian.Application.Composition.Features;
 using Meridian.Application.Config;
+using Meridian.Contracts.Api;
 using Meridian.Domain.Events;
 using Meridian.Infrastructure;
 using Meridian.Infrastructure.Adapters.Core;
@@ -13,8 +14,14 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Meridian.Tests.Application.Composition;
 
-public sealed class ProviderCapabilityContractRegistrationTests
+public sealed class ProviderCapabilityContractRegistrationTests : IDisposable
 {
+    public void Dispose()
+    {
+        ProviderCatalog.RuntimeCatalogProvider = null;
+        ProviderCatalog.RuntimeCatalogEntryProvider = null;
+    }
+
     [Fact]
     public async Task DataSourceDeclarations_ShouldMatchImplementedContracts_AndRegistrationPaths()
     {


### PR DESCRIPTION
### Motivation
- Prevent stale static `ProviderCatalog` runtime delegates from capturing and later trying to use a disposed test `ServiceProvider`, which causes order-dependent `ObjectDisposedException` failures across the test suite.

### Description
- Implemented `IDisposable` on `ProviderCapabilityContractRegistrationTests`, imported `Meridian.Contracts.Api`, and reset `ProviderCatalog.RuntimeCatalogProvider` and `ProviderCatalog.RuntimeCatalogEntryProvider` to `null` in `Dispose()` to ensure deterministic test isolation (file: `tests/Meridian.Tests/Application/Composition/ProviderCapabilityContractRegistrationTests.cs`).

### Testing
- Attempted to run the focused test with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ProviderCapabilityContractRegistrationTests"`, but the environment lacks the .NET SDK (`dotnet: command not found`), so no runtime test execution was possible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f3dce7a8c83208593a109e7f6b0b1)