### PR TITLE
Fix primitive-array required field detection in contract compatibility gate

### DIFF
--- a/scripts/check_contract_compatibility_gate.py
+++ b/scripts/check_contract_compatibility_gate.py
@@ -37,7 +37,7 @@ CS_CONTRACT_TYPE_PATTERN = (
     r"(?:bool|byte|sbyte|short|ushort|int|uint|long|ulong|float|double|decimal|string|object|"
     r"Guid|DateOnly|DateTime|DateTimeOffset|TimeSpan|CancellationToken|"
     r"IReadOnlyList<[^>]+>|IReadOnlyDictionary<[^>]+>|IEnumerable<[^>]+>|"
-    r"Dictionary<[^>]+>|List<[^>]+>|[A-Z][\w.<>?,\[\]]+)\??"
+    r"Dictionary<[^>]+>|List<[^>]+>|[A-Z][\w.<>?,\[\]]+)(?:\[\])?\??"
 )
 
 BREAKING_CONTRACT_SHAPE_PATTERNS = (

--- a/tests/scripts/test_check_contract_compatibility_gate.py
+++ b/tests/scripts/test_check_contract_compatibility_gate.py
@@ -168,6 +168,30 @@ diff --git a/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs 
         violations = gate.find_required_field_regressions(changed_files, patch)
         self.assertEqual(changed_files, violations)
 
+    def test_find_required_field_regressions_flags_required_primitive_array_property_addition(self) -> None:
+        changed_files = ["src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs"]
+        patch = """
+diff --git a/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs b/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
++++ b/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
+@@ -200,0 +201 @@ public sealed class TradingOperatorReadinessDto
++    public required string[] Symbols { get; init; }
+"""
+
+        violations = gate.find_required_field_regressions(changed_files, patch)
+        self.assertEqual(changed_files, violations)
+
+    def test_find_required_field_regressions_flags_non_nullable_primitive_array_record_parameter_addition(self) -> None:
+        changed_files = ["src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs"]
+        patch = """
+diff --git a/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs b/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
++++ b/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
+@@ -102,0 +103 @@ public sealed record TradingOperatorReadinessDto(
++    string[] Symbols,
+"""
+
+        violations = gate.find_required_field_regressions(changed_files, patch)
+        self.assertEqual(changed_files, violations)
+
     def test_find_required_field_regressions_allows_nullable_record_parameter_addition(self) -> None:
         changed_files = ["src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs"]
         patch = """


### PR DESCRIPTION
### Motivation
- The compatibility gate missed required primitive-array DTO members (e.g. `string[]`, `int[]`) because the C# type regex only allowed `[]` in the custom/uppercase type branch, letting some breaking additions slip through.

### Description
- Update `CS_CONTRACT_TYPE_PATTERN` in `scripts/check_contract_compatibility_gate.py` to allow an optional `[]` suffix for any recognized contract type before nullability.
- This change makes both `PROPERTY_ADDITION_PATTERN` and `RECORD_PARAMETER_ADDITION_PATTERN` match primitive arrays such as `string[]` and `int[]`.
- Add focused unit tests in `tests/scripts/test_check_contract_compatibility_gate.py` to verify detection of a required `string[]` property and a non-nullable `string[]` record parameter.

### Testing
- Ran `python -m unittest tests/scripts/test_check_contract_compatibility_gate.py -v`, which ran 17 tests and all passed (OK).
- Existing contract-shape and governance tests remain unchanged and continue to validate other breaking-change heuristics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f3dcda6bc8320b36012640a1ad97e)