### PR TITLE
Fix direct-lending projection persistence for extended terms

### DIFF
--- a/src/Meridian.Storage/DirectLending/Migrations/002_direct_lending_projections.sql
+++ b/src/Meridian.Storage/DirectLending/Migrations/002_direct_lending_projections.sql
@@ -44,6 +44,11 @@ create table if not exists __SCHEMA__.loan_terms_version (
     default_rate_spread_bps numeric(18,8),
     prepayment_allowed boolean not null,
     covenants_json jsonb,
+    interest_only_months integer not null default 0,
+    grace_period_days integer,
+    effective_rate_floor numeric(18,8),
+    effective_rate_cap numeric(18,8),
+    prepayment_penalty_rate numeric(18,8),
     primary key (loan_id, terms_version)
 );
 

--- a/src/Meridian.Storage/DirectLending/Migrations/006_direct_lending_terms_projection_extended_fields.sql
+++ b/src/Meridian.Storage/DirectLending/Migrations/006_direct_lending_terms_projection_extended_fields.sql
@@ -1,0 +1,6 @@
+alter table if exists __SCHEMA__.loan_terms_version
+    add column if not exists interest_only_months integer not null default 0,
+    add column if not exists grace_period_days integer,
+    add column if not exists effective_rate_floor numeric(18,8),
+    add column if not exists effective_rate_cap numeric(18,8),
+    add column if not exists prepayment_penalty_rate numeric(18,8);

--- a/src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.cs
+++ b/src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.cs
@@ -561,7 +561,12 @@ public sealed partial class PostgresDirectLendingStateStore : IDirectLendingStat
                     commitment_fee_rate,
                     default_rate_spread_bps,
                     prepayment_allowed,
-                    covenants_json)
+                    covenants_json,
+                    interest_only_months,
+                    grace_period_days,
+                    effective_rate_floor,
+                    effective_rate_cap,
+                    prepayment_penalty_rate)
                 values (
                     @loan_id,
                     @terms_version,
@@ -585,7 +590,12 @@ public sealed partial class PostgresDirectLendingStateStore : IDirectLendingStat
                     @commitment_fee_rate,
                     @default_rate_spread_bps,
                     @prepayment_allowed,
-                    cast(@covenants_json as jsonb));
+                    cast(@covenants_json as jsonb),
+                    @interest_only_months,
+                    @grace_period_days,
+                    @effective_rate_floor,
+                    @effective_rate_cap,
+                    @prepayment_penalty_rate);
                 """;
             insert.Parameters.AddWithValue("loan_id", loanId);
             insert.Parameters.AddWithValue("terms_version", termsVersion.VersionNumber);
@@ -610,6 +620,11 @@ public sealed partial class PostgresDirectLendingStateStore : IDirectLendingStat
             insert.Parameters.AddWithValue("default_rate_spread_bps", (object?)termsVersion.Terms.DefaultRateSpreadBps ?? DBNull.Value);
             insert.Parameters.AddWithValue("prepayment_allowed", termsVersion.Terms.PrepaymentAllowed);
             insert.Parameters.AddWithValue("covenants_json", (object?)termsVersion.Terms.CovenantsJson ?? "null");
+            insert.Parameters.AddWithValue("interest_only_months", termsVersion.Terms.InterestOnlyMonths);
+            insert.Parameters.AddWithValue("grace_period_days", (object?)termsVersion.Terms.GracePeriodDays ?? DBNull.Value);
+            insert.Parameters.AddWithValue("effective_rate_floor", (object?)termsVersion.Terms.EffectiveRateFloor ?? DBNull.Value);
+            insert.Parameters.AddWithValue("effective_rate_cap", (object?)termsVersion.Terms.EffectiveRateCap ?? DBNull.Value);
+            insert.Parameters.AddWithValue("prepayment_penalty_rate", (object?)termsVersion.Terms.PrepaymentPenaltyRate ?? DBNull.Value);
             await insert.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
     }
@@ -1065,7 +1080,12 @@ public sealed partial class PostgresDirectLendingStateStore : IDirectLendingStat
                    commitment_fee_rate,
                    default_rate_spread_bps,
                    prepayment_allowed,
-                   covenants_json::text
+                   covenants_json::text,
+                   interest_only_months,
+                   grace_period_days,
+                   effective_rate_floor,
+                   effective_rate_cap,
+                   prepayment_penalty_rate
             from {Qualified("loan_terms_version")}
             where loan_id = @loan_id
             order by terms_version desc;
@@ -1093,7 +1113,12 @@ public sealed partial class PostgresDirectLendingStateStore : IDirectLendingStat
                 reader.IsDBNull(18) ? null : reader.GetDecimal(18),
                 reader.IsDBNull(19) ? null : reader.GetDecimal(19),
                 reader.GetBoolean(20),
-                NormalizeJsonText(reader.IsDBNull(21) ? null : reader.GetString(21)));
+                NormalizeJsonText(reader.IsDBNull(21) ? null : reader.GetString(21)),
+                reader.GetInt32(22),
+                reader.IsDBNull(23) ? null : reader.GetInt32(23),
+                reader.IsDBNull(24) ? null : reader.GetDecimal(24),
+                reader.IsDBNull(25) ? null : reader.GetDecimal(25),
+                reader.IsDBNull(26) ? null : reader.GetDecimal(26));
 
             results.Add(new LoanTermsVersionDto(
                 reader.GetInt32(0),


### PR DESCRIPTION
### Motivation
- `DirectLendingTermsDto` was extended with five new economic fields (`InterestOnlyMonths`, `GracePeriodDays`, `EffectiveRateFloor`, `EffectiveRateCap`, `PrepaymentPenaltyRate`) but the normalized `loan_terms_version` projection schema and read/write paths were not updated, causing projection-backed reads to return default/null values for those fields.

### Description
- Updated the base projection DDL in `src/Meridian.Storage/DirectLending/Migrations/002_direct_lending_projections.sql` to include the five new columns so fresh installs create the extended schema.
- Added idempotent migration `src/Meridian.Storage/DirectLending/Migrations/006_direct_lending_terms_projection_extended_fields.sql` which uses `add column if not exists` to backfill the missing columns for existing databases.
- Extended the projection write path in `src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.cs` (`ReplaceTermsVersionsAsync`) to include the new columns in the `insert` column list and add parameter bindings for `@interest_only_months`, `@grace_period_days`, `@effective_rate_floor`, `@effective_rate_cap`, and `@prepayment_penalty_rate`.
- Extended the projection read path in `src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.cs` (`LoadTermsVersionProjectionsCoreAsync`) to select the new columns and to construct `DirectLendingTermsDto` with the full set of parameters so projection-backed reads populate the new fields.

### Testing
- Attempted to run the targeted direct-lending unit tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~DirectLending"`, but the run failed in this environment because `dotnet` is not installed (automated test run: failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8a4852888320b544a9adf28cb8f8)