### PR TITLE
fix(ib): harden option computation tick handling

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApi.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/EnhancedIBConnectionManager.IBApi.cs
@@ -801,7 +801,14 @@ public sealed partial class EnhancedIBConnectionManager : EWrapper, IDisposable
     public void tickOptionComputation(int tickerId, int field, int tickAttrib, double impliedVolatility, double delta, double optPrice, double pvDividend, double gamma, double vega, double theta, double undPrice)
     {
         RecordMessageReceived();
-        _router.OnTickOptionComputation(tickerId, field, impliedVolatility, delta, optPrice, pvDividend, gamma, vega, theta, undPrice);
+        try
+        {
+            _router.OnTickOptionComputation(tickerId, field, impliedVolatility, delta, optPrice, pvDividend, gamma, vega, theta, undPrice);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Dropping malformed option computation tick for tickerId {TickerId}.", tickerId);
+        }
     }
 
     public void marketDataType(int reqId, int marketDataType) { }

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBCallbackRouter.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBCallbackRouter.cs
@@ -322,20 +322,68 @@ public sealed class IBCallbackRouter
         if (impliedVol < 0 || undPrice <= 0)
             return;
 
+        if (!TryToDecimal(impliedVol, out var impliedVolDecimal) ||
+            !TryToDecimal(undPrice, out var underlyingPriceDecimal))
+        {
+            return;
+        }
+
+        var deltaDecimal = TryGreekToDecimal(delta);
+        var gammaDecimal = TryGreekToDecimal(gamma, clampNegativeToZero: true);
+        var thetaDecimal = TryGreekToDecimal(theta);
+        var vegaDecimal = TryGreekToDecimal(vega, clampNegativeToZero: true);
+        if (!deltaDecimal.HasValue || !gammaDecimal.HasValue || !thetaDecimal.HasValue || !vegaDecimal.HasValue)
+            return;
+
+        decimal? theoreticalPrice = null;
+        if (optPrice > 0)
+        {
+            if (!TryToDecimal(optPrice, out var theoreticalPriceDecimal))
+                return;
+
+            theoreticalPrice = theoreticalPriceDecimal;
+        }
+
         var greeks = new GreeksSnapshot(
             Timestamp: DateTimeOffset.UtcNow,
             Symbol: contract.UnderlyingSymbol,
             Contract: contract,
-            Delta: delta < -1.5 ? 0m : (decimal)delta,
-            Gamma: gamma < -1.5 ? 0m : (decimal)gamma,
-            Theta: theta < -1.5 ? 0m : (decimal)theta,
-            Vega: vega < -1.5 ? 0m : (decimal)vega,
+            Delta: deltaDecimal.Value,
+            Gamma: gammaDecimal.Value,
+            Theta: thetaDecimal.Value,
+            Vega: vegaDecimal.Value,
             Rho: 0m,
-            ImpliedVolatility: (decimal)impliedVol,
-            UnderlyingPrice: (decimal)undPrice,
-            TheoreticalPrice: optPrice > 0 ? (decimal?)optPrice : null);
+            ImpliedVolatility: impliedVolDecimal,
+            UnderlyingPrice: underlyingPriceDecimal,
+            TheoreticalPrice: theoreticalPrice);
 
         _optionCollector.OnGreeksUpdate(greeks);
+    }
+
+    private static bool TryToDecimal(double value, out decimal converted)
+    {
+        if (!double.IsFinite(value) || value < (double)decimal.MinValue || value > (double)decimal.MaxValue)
+        {
+            converted = 0m;
+            return false;
+        }
+
+        converted = (decimal)value;
+        return true;
+    }
+
+    private static decimal? TryGreekToDecimal(double value, bool clampNegativeToZero = false)
+    {
+        if (value < -1.5)
+            return 0m;
+
+        if (!TryToDecimal(value, out var converted))
+            return null;
+
+        if (clampNegativeToZero && converted < 0m)
+            return 0m;
+
+        return converted;
     }
 
     private void TryEmitQuote(int tickerId, string symbol, QuoteState state)


### PR DESCRIPTION
### Motivation
- Malformed or malicious IB `tickOptionComputation` payloads could contain `NaN`, `Infinity`, or out-of-range doubles which were cast directly to `decimal` or used as greeks and could throw `OverflowException` or `ArgumentOutOfRangeException`, allowing a single bad tick to fault the reader task and cause a market-data denial-of-service.

### Description
- Validate and guard numeric conversions in `IBCallbackRouter.OnTickOptionComputation` by adding `TryToDecimal` to check `double.IsFinite` and decimal-range-safety and early-return on invalid values instead of casting directly.
- Add `TryGreekToDecimal` to handle IB sentinel values (`< -1.5`) and to clamp non-sentinel negative `gamma`/`vega` to zero to satisfy `GreeksSnapshot` domain rules.
- Validate optional `optPrice` using the same decimal-safe conversion before setting `TheoreticalPrice` and stop processing when conversions fail.
- Add a defensive `try/catch` in `EnhancedIBConnectionManager.IBApi.tickOptionComputation` to log and drop malformed ticks so exceptions raised during routing do not escape and kill the reader loop.

### Testing
- Automated build and tests could not be executed in this environment because the .NET SDK is not installed (`dotnet: command not found`), so no `dotnet build`/`dotnet test` runs were performed here.
- The fix was validated by targeted source inspection and reasoning that the new guards prevent `NaN`/`Infinity`/out-of-range casts and domain-invalid greeks from reaching `GreeksSnapshot`, and that malformed ticks are now logged and dropped by the callback shim.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8a459b08832095e4b1fb726654de)