### PR TITLE
Fix stale coordinator lease cache after renewal exceptions

### DIFF
--- a/src/Meridian.Application/Coordination/LeaseManager.cs
+++ b/src/Meridian.Application/Coordination/LeaseManager.cs
@@ -202,6 +202,7 @@ public sealed class LeaseManager : ILeaseManager, IAsyncDisposable
                 }
                 catch (Exception ex)
                 {
+                    _heldLeases.TryRemove(resourceId, out _);
                     Interlocked.Increment(ref _renewalFailureCount);
                     _log.Warning(ex, "Unexpected renewal failure for {ResourceId}", resourceId);
                 }

--- a/tests/Meridian.Tests/Application/Coordination/LeaseManagerTests.cs
+++ b/tests/Meridian.Tests/Application/Coordination/LeaseManagerTests.cs
@@ -133,6 +133,31 @@ public sealed class LeaseManagerTests
         }
     }
 
+    [Fact]
+    public async Task LeaseManager_RemovesHeldLease_WhenRenewThrowsInBackgroundLoop()
+    {
+        var config = new CoordinationConfig(
+            Enabled: true,
+            Mode: CoordinationMode.SharedStorage,
+            InstanceId: "instance-a",
+            LeaseTtlSeconds: 30,
+            RenewIntervalSeconds: 1,
+            TakeoverDelaySeconds: 1,
+            RootPath: Path.Combine(Path.GetTempPath(), $"meridian_coord_{Guid.NewGuid():N}"));
+        var store = new ThrowingRenewStore();
+
+        await using var manager = new LeaseManager(config, store);
+        const string resourceId = "leader/cluster-coordinator";
+
+        var acquired = await manager.TryAcquireAsync(resourceId);
+        acquired.Acquired.Should().BeTrue();
+        manager.HoldsLease(resourceId).Should().BeTrue();
+
+        await Task.Delay(TimeSpan.FromSeconds(2));
+
+        manager.HoldsLease(resourceId).Should().BeFalse();
+    }
+
     private static CoordinationConfig CreateConfig(
         string dataRoot,
         int leaseTtlSeconds,
@@ -158,5 +183,48 @@ public sealed class LeaseManagerTests
     {
         if (Directory.Exists(path))
             Directory.Delete(path, true);
+    }
+
+    private sealed class ThrowingRenewStore : ICoordinationStore
+    {
+        private LeaseRecord? _lease;
+
+        public string RootPath => Path.GetTempPath();
+
+        public Task<LeaseAcquireResult> TryAcquireLeaseAsync(
+            string resourceId,
+            string instanceId,
+            TimeSpan leaseTtl,
+            TimeSpan takeoverDelay,
+            CancellationToken ct = default)
+        {
+            _lease = new LeaseRecord(
+                resourceId,
+                instanceId,
+                Version: 1,
+                AcquiredAtUtc: DateTimeOffset.UtcNow,
+                ExpiresAtUtc: DateTimeOffset.UtcNow.Add(leaseTtl),
+                LastRenewedAtUtc: DateTimeOffset.UtcNow);
+
+            return Task.FromResult(new LeaseAcquireResult(true, false, _lease, null, null, null));
+        }
+
+        public Task<bool> RenewLeaseAsync(string resourceId, string instanceId, TimeSpan leaseTtl, CancellationToken ct = default)
+            => throw new IOException("Simulated renew failure");
+
+        public Task<bool> ReleaseLeaseAsync(string resourceId, string instanceId, CancellationToken ct = default)
+        {
+            _lease = null;
+            return Task.FromResult(true);
+        }
+
+        public Task<LeaseRecord?> GetLeaseAsync(string resourceId, CancellationToken ct = default)
+            => Task.FromResult(_lease);
+
+        public Task<IReadOnlyList<LeaseRecord>> GetAllLeasesAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<LeaseRecord>>(_lease is null ? Array.Empty<LeaseRecord>() : [_lease]);
+
+        public Task<IReadOnlyList<string>> GetCorruptedLeaseFilesAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
     }
 }


### PR DESCRIPTION
### Motivation
- Cluster leadership relied on `ILeaseManager.HoldsLease` (a local cache) and could continue reporting leadership after a renewal error, enabling split-brain when another node later acquired the shared lease.  
- The change aims to close the window where a node with a stale local cache can continue leader-only work after storage/renewal failures without changing the overall lease semantics.

### Description
- On unexpected renewal exceptions the renewal loop now removes the resource from the local `_heldLeases` cache by calling `_heldLeases.TryRemove(resourceId, out _)` in `LeaseManager.RunRenewalLoopAsync` to avoid stale leadership evidence.  
- Added a focused regression test `LeaseManager_RemovesHeldLease_WhenRenewThrowsInBackgroundLoop` in `tests/Meridian.Tests/Application/Coordination/LeaseManagerTests.cs` that uses a `ThrowingRenewStore` to simulate `RenewLeaseAsync` throwing and verifies `HoldsLease` is cleared after the loop runs.  
- The change preserves existing acquire/release behavior and only removes the held-cache entry when renewal unexpectedly fails, keeping diagnostics counters and logging intact.  

### Testing
- A new unit test `LeaseManager_RemovesHeldLease_WhenRenewThrowsInBackgroundLoop` was added to validate the remediation by simulating renew failures and asserting `HoldsLease` becomes false.  
- An attempt was made to run the targeted test with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~LeaseManager_RemovesHeldLease_WhenRenewThrowsInBackgroundLoop"`, but the test could not be executed in this environment because `dotnet` is not installed.  
- Please run the new test and the normal test suite in CI with `dotnet test` (or the project test commands in `AGENTS.md`) to validate the fix in your environment/CI; the change is minimal and designed to be covered by the added unit test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8a481b3083208cee5405e42a9303)