### PR TITLE
fix: enforce brokerage risk limits in live adapter

### DIFF
--- a/src/Meridian.Execution/Adapters/BrokerageGatewayAdapter.cs
+++ b/src/Meridian.Execution/Adapters/BrokerageGatewayAdapter.cs
@@ -21,12 +21,17 @@ public sealed class BrokerageGatewayAdapter : IOrderGateway
 {
     private readonly IBrokerageGateway _inner;
     private readonly ILogger<BrokerageGatewayAdapter> _logger;
+    private readonly BrokerageConfiguration _configuration;
     private bool _disposed;
 
-    public BrokerageGatewayAdapter(IBrokerageGateway inner, ILogger<BrokerageGatewayAdapter> logger)
+    public BrokerageGatewayAdapter(
+        IBrokerageGateway inner,
+        ILogger<BrokerageGatewayAdapter> logger,
+        BrokerageConfiguration? configuration = null)
     {
         _inner = inner ?? throw new ArgumentNullException(nameof(inner));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _configuration = configuration ?? new BrokerageConfiguration();
     }
 
     /// <inheritdoc />
@@ -57,34 +62,57 @@ public sealed class BrokerageGatewayAdapter : IOrderGateway
     }
 
     /// <inheritdoc />
-    public Task<OrderValidationResult> ValidateOrderAsync(OrderRequest request, CancellationToken ct = default)
+    public async Task<OrderValidationResult> ValidateOrderAsync(OrderRequest request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
         var caps = _inner.BrokerageCapabilities;
 
         if (!caps.SupportedOrderTypes.Contains(request.Type))
-            return Task.FromResult(new OrderValidationResult(false, $"Order type '{request.Type}' not supported by {BrokerName}."));
+            return new OrderValidationResult(false, $"Order type '{request.Type}' not supported by {BrokerName}.");
 
         if (!caps.SupportedTimeInForce.Contains(request.TimeInForce))
-            return Task.FromResult(new OrderValidationResult(false, $"Time in force '{request.TimeInForce}' not supported by {BrokerName}."));
+            return new OrderValidationResult(false, $"Time in force '{request.TimeInForce}' not supported by {BrokerName}.");
 
         if (request.Quantity <= 0)
-            return Task.FromResult(new OrderValidationResult(false, "Order quantity must be positive."));
+            return new OrderValidationResult(false, "Order quantity must be positive.");
 
         if (request.Type is SdkOrderType.Limit or SdkOrderType.StopLimit or SdkOrderType.LimitOnOpen or SdkOrderType.LimitOnClose &&
             (!request.LimitPrice.HasValue || request.LimitPrice <= 0))
-            return Task.FromResult(new OrderValidationResult(false, "Limit-style orders require a positive limit price."));
+            return new OrderValidationResult(false, "Limit-style orders require a positive limit price.");
 
         if (request.Type is SdkOrderType.StopMarket or SdkOrderType.StopLimit &&
             (!request.StopPrice.HasValue || request.StopPrice <= 0))
-            return Task.FromResult(new OrderValidationResult(false, "Stop/stop-limit orders require a positive stop price."));
+            return new OrderValidationResult(false, "Stop/stop-limit orders require a positive stop price.");
 
         if (request.Type is SdkOrderType.TrailingStop &&
             (!HasExactlyOnePositiveTrail(request.TrailPrice, request.TrailPercent)))
-            return Task.FromResult(new OrderValidationResult(false, "Trailing stop orders require exactly one positive trail price or trail percent."));
+            return new OrderValidationResult(false, "Trailing stop orders require exactly one positive trail price or trail percent.");
 
-        return Task.FromResult(new OrderValidationResult(true));
+        if (_configuration.MaxOrderNotional > 0m)
+        {
+            var effectivePrice = ResolveEffectivePrice(request);
+            if (effectivePrice.HasValue && (request.Quantity * effectivePrice.Value) > _configuration.MaxOrderNotional)
+                return new OrderValidationResult(false, $"Order notional exceeds configured maximum of {_configuration.MaxOrderNotional}.");
+        }
+
+        if (_configuration.MaxOpenOrders > 0)
+        {
+            var openOrders = await _inner.GetOpenOrdersAsync(ct).ConfigureAwait(false);
+            if (openOrders.Count >= _configuration.MaxOpenOrders)
+                return new OrderValidationResult(false, $"Open order count exceeds configured maximum of {_configuration.MaxOpenOrders}.");
+        }
+
+        if (_configuration.MaxPositionSize > 0m)
+        {
+            var positions = await _inner.GetPositionsAsync(ct).ConfigureAwait(false);
+            var aggregatePositionSize = positions.Sum(p => Math.Abs(p.Quantity));
+            var projectedPositionSize = aggregatePositionSize + Math.Abs(request.Quantity);
+            if (projectedPositionSize > _configuration.MaxPositionSize)
+                return new OrderValidationResult(false, $"Projected position size exceeds configured maximum of {_configuration.MaxPositionSize}.");
+        }
+
+        return new OrderValidationResult(true);
     }
 
     /// <inheritdoc />
@@ -175,4 +203,11 @@ public sealed class BrokerageGatewayAdapter : IOrderGateway
         var hasTrailPercent = trailPercent.HasValue && trailPercent.Value > 0m;
         return hasTrailPrice ^ hasTrailPercent;
     }
+
+    private static decimal? ResolveEffectivePrice(OrderRequest request) => request.Type switch
+    {
+        SdkOrderType.Limit or SdkOrderType.StopLimit or SdkOrderType.LimitOnOpen or SdkOrderType.LimitOnClose => request.LimitPrice,
+        SdkOrderType.StopMarket => request.StopPrice,
+        _ => request.LimitPrice ?? request.StopPrice
+    };
 }

--- a/src/Meridian.Execution/BrokerageServiceRegistration.cs
+++ b/src/Meridian.Execution/BrokerageServiceRegistration.cs
@@ -60,7 +60,7 @@ public static class BrokerageServiceRegistration
             // Resolve the named brokerage gateway via keyed registration
             var gateway = ResolveBrokerageGateway(sp, brokerageConfig.Gateway);
             var adapterLogger = sp.GetRequiredService<ILogger<BrokerageGatewayAdapter>>();
-            return new BrokerageGatewayAdapter(gateway, adapterLogger);
+            return new BrokerageGatewayAdapter(gateway, adapterLogger, brokerageConfig);
         });
 
         // Register the OMS with the resolved gateway

--- a/tests/Meridian.Tests/Execution/BrokerageGatewayAdapterTests.cs
+++ b/tests/Meridian.Tests/Execution/BrokerageGatewayAdapterTests.cs
@@ -179,6 +179,63 @@ public sealed class BrokerageGatewayAdapterTests
     }
 
     [Fact]
+    public async Task ValidateOrderAsync_RejectsOrderAboveConfiguredNotionalLimit()
+    {
+        var config = new BrokerageConfiguration { MaxOrderNotional = 100m };
+        await using var adapter = new BrokerageGatewayAdapter(
+            CreateMockGateway(),
+            NullLogger<BrokerageGatewayAdapter>.Instance,
+            config);
+        var request = new OrderRequest
+        {
+            Symbol = "AAPL",
+            Side = OrderSide.Buy,
+            Type = SdkOrderType.Limit,
+            Quantity = 2m,
+            LimitPrice = 75m
+        };
+
+        var result = await adapter.ValidateOrderAsync(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Reason.Should().Contain("notional");
+    }
+
+    [Fact]
+    public async Task ValidateOrderAsync_RejectsOrderWhenOpenOrderLimitReached()
+    {
+        var gateway = CreateMockGateway();
+        gateway.GetOpenOrdersAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            new BrokerOrder
+            {
+                OrderId = "1",
+                Symbol = "AAPL",
+                Side = OrderSide.Buy,
+                Type = SdkOrderType.Limit,
+                Status = SdkOrderStatus.Accepted
+            }
+        ]);
+        var config = new BrokerageConfiguration { MaxOpenOrders = 1 };
+        await using var adapter = new BrokerageGatewayAdapter(
+            gateway,
+            NullLogger<BrokerageGatewayAdapter>.Instance,
+            config);
+        var request = new OrderRequest
+        {
+            Symbol = "AAPL",
+            Side = OrderSide.Buy,
+            Type = SdkOrderType.Market,
+            Quantity = 1m
+        };
+
+        var result = await adapter.ValidateOrderAsync(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Reason.Should().Contain("Open order count");
+    }
+
+    [Fact]
     public async Task ValidateOrderAsync_RejectsLimitOnCloseWithoutLimitPrice()
     {
         var caps = BrokerageCapabilities.UsEquity() with


### PR DESCRIPTION
### Motivation
- The repository introduced `BrokerageConfiguration` with `MaxPositionSize`, `MaxOrderNotional`, and `MaxOpenOrders` but the live order path did not enforce those pre-trade limits, allowing oversized orders to reach brokers.
- This is a high-risk gap for live execution where configured guardrails must be applied before submitting orders to a brokerage.

### Description
- Wire the `BrokerageConfiguration` into the live adapter registration so the adapter can access configured risk limits (`BrokerageServiceRegistration` now passes `brokerageConfig` to `BrokerageGatewayAdapter`).
- Extend `BrokerageGatewayAdapter` to accept an optional `BrokerageConfiguration` and enforce pre-trade checks in `ValidateOrderAsync` for `MaxOrderNotional`, `MaxOpenOrders`, and `MaxPositionSize`, using an `ResolveEffectivePrice` helper and broker queries for open orders/positions.
- Preserve existing capability and shape validations and keep `SubmitAsync` routing behavior but fail submission when validation results are invalid.
- Add unit tests covering rejection when an order exceeds the configured notional limit and when the open-order limit is reached (tests updated in `tests/Meridian.Tests/Execution/BrokerageGatewayAdapterTests.cs`).

### Testing
- Added focused unit tests: `ValidateOrderAsync_RejectsOrderAboveConfiguredNotionalLimit` and `ValidateOrderAsync_RejectsOrderWhenOpenOrderLimitReached`, but they were not executed in this environment because `dotnet` is not installed here.
- An attempted targeted test run was `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~BrokerageGatewayAdapterTests"` and it failed with `/bin/bash: dotnet: command not found` in the container.
- Changes were committed locally under the message `fix: enforce brokerage risk limits in live adapter` and a PR summary was prepared; CI/test runs should be executed in a dotnet-capable environment to validate the new tests and overall build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4027c4708320ab8b3d699f1d36cb)