### PR TITLE
Add mutation rate limiting to evidence export-manifest endpoint

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/EvidenceEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/EvidenceEndpoints.cs
@@ -159,7 +159,8 @@ public static class EvidenceEndpoints
         .WithName("ExportWorkstationEvidenceManifest")
         .Produces<EvidencePacketExportResponse>(200)
         .Produces<EvidenceEndpointErrorDto>(400)
-        .Produces<EvidenceEndpointErrorDto>(404);
+        .Produces<EvidenceEndpointErrorDto>(404)
+        .RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy);
 
         group.MapGet("/templates", (HttpContext context) =>
         {


### PR DESCRIPTION
### Motivation
- Close an abuse vector where `POST /api/workstation/evidence/subjects/{subjectKind}/{subjectId}/export-manifest` could be invoked repeatedly to create retained manifest files under `DataRoot` with no quota or throttling, by aligning this state-changing endpoint with existing mutation protections.

### Description
- Added `.RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy)` to the `export-manifest` endpoint in `src/Meridian.Ui.Shared/Endpoints/EvidenceEndpoints.cs` so the route is subject to the standard mutation rate limit while preserving the existing request/response behavior and payloads.

### Testing
- Verified repository and endpoint patterns with `rg --files -g 'AGENTS.md'` and `rg 'RequireRateLimiting\(' src/Meridian.Ui.Shared -n`, which succeeded and showed mutation endpoints use the same policy.
- Confirmed the `ExportWorkstationEvidenceManifest` route now includes `.RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy)` via `rg -n 'ExportWorkstationEvidenceManifest|RequireRateLimiting' src/Meridian.Ui.Shared/Endpoints/EvidenceEndpoints.cs` and by inspecting the modified file lines, which showed the new policy present.
- Performed a focused file edit and local verification of the changed lines in `src/Meridian.Ui.Shared/Endpoints/EvidenceEndpoints.cs`; no other functional changes or tests were altered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a174713c14c83209bb22570d8121b26)