### PR TITLE
fix: recompute backtest order lifecycle from accepted fills

### DIFF
--- a/src/Meridian.Backtesting/Engine/BacktestEngine.cs
+++ b/src/Meridian.Backtesting/Engine/BacktestEngine.cs
@@ -465,6 +465,7 @@ public sealed class BacktestEngine(
 
             var model = SelectFillModel(order, evt, lobModel, barModel, marketImpactModel, requestDefault);
             var result = model.TryFill(order, evt);
+            var acceptedFilledQuantity = 0L;
 
             foreach (var fill in result.Fills)
             {
@@ -484,6 +485,7 @@ public sealed class BacktestEngine(
 
                 ContingentOrderManager.ReconcileOcoSiblings(pendingOrders, order, fill);
                 allFills.Add(fill);
+                acceptedFilledQuantity += fill.FilledQuantity;
                 rollingState.IncrementFills();
                 strategy.OnOrderFill(fill, ctx);
 
@@ -491,13 +493,31 @@ public sealed class BacktestEngine(
                     pendingOrders.Add(contingentOrder);
             }
 
-            if (result.RemoveOrder)
+            if (acceptedFilledQuantity == 0)
+            {
+                // Preserve trigger activation even when all generated fills were rejected.
+                pendingOrders[i] = result.WasTriggered
+                    ? order with { IsTriggered = true }
+                    : order;
+                continue;
+            }
+
+            var updatedOrder = order with
+            {
+                FilledQuantity = order.FilledQuantity + acceptedFilledQuantity,
+                Status = order.RemainingQuantity - Math.Abs(acceptedFilledQuantity) == 0
+                    ? OrderStatus.Filled
+                    : OrderStatus.PartiallyFilled,
+                IsTriggered = result.UpdatedOrder.IsTriggered
+            };
+
+            if (updatedOrder.IsComplete)
             {
                 filled.Add(order.OrderId);
                 continue;
             }
 
-            pendingOrders[i] = result.UpdatedOrder;
+            pendingOrders[i] = updatedOrder;
         }
 
         pendingOrders.RemoveAll(o =>

--- a/tests/Meridian.Backtesting.Tests/BacktestEngineIntegrationTests.cs
+++ b/tests/Meridian.Backtesting.Tests/BacktestEngineIntegrationTests.cs
@@ -325,6 +325,34 @@ public sealed class BacktestEngineIntegrationTests : IDisposable
             "the short-sell fill was rejected by the account rule; no fills should be recorded");
     }
 
+    [Fact]
+    public async Task RunAsync_RejectedMarketImpactSlices_DoNotRemoveRemainingOrderQuantity()
+    {
+        WriteCustomBarJsonl(
+            "AAPL",
+            (new DateOnly(2024, 1, 2), 100m, 100m, 100m, 100m, 40),
+            (new DateOnly(2024, 1, 3), 1m, 1m, 1m, 1m, 40));
+
+        var restrictedAccount = new FinancialAccount(
+            BacktestDefaults.DefaultBrokerageAccountId,
+            "No-Margin Brokerage",
+            FinancialAccountKind.Brokerage,
+            InitialCash: 500m,
+            Rules: new FinancialAccountRules(AllowMargin: false, AllowShortSelling: true));
+
+        var request = new BacktestRequest(
+            From: new DateOnly(2024, 1, 2),
+            To: new DateOnly(2024, 1, 3),
+            DataRoot: _dataRoot,
+            Accounts: [restrictedAccount]);
+
+        var strategy = new BuyFirstBarWithMarketImpactGtcStrategy("AAPL", quantity: 20);
+        var result = await _engine.RunAsync(request, strategy);
+
+        result.Fills.Sum(static fill => fill.FilledQuantity).Should().Be(20,
+            "the first accepted slice should keep the order pending so remaining quantity can fill later");
+    }
+
     // ------------------------------------------------------------------ //
     //  Progress reporting                                                 //
     // ------------------------------------------------------------------ //
@@ -507,6 +535,33 @@ public sealed class BacktestEngineIntegrationTests : IDisposable
             date = date.AddDays(1);
         }
     }
+
+    private void WriteCustomBarJsonl(string symbol, params (DateOnly Date, decimal Open, decimal High, decimal Low, decimal Close, long Volume)[] bars)
+    {
+        var symbolDir = Path.Combine(_dataRoot, symbol.ToUpperInvariant());
+        Directory.CreateDirectory(symbolDir);
+        var filePath = Path.Combine(symbolDir, $"{symbol}_bars_{bars[0].Date:yyyy-MM-dd}.jsonl");
+
+        using var writer = new StreamWriter(filePath);
+        var seq = 1L;
+        foreach (var bar in bars)
+        {
+            var payload = new HistoricalBar(
+                Symbol: symbol,
+                SessionDate: bar.Date,
+                Open: bar.Open,
+                High: bar.High,
+                Low: bar.Low,
+                Close: bar.Close,
+                Volume: bar.Volume,
+                Source: "test",
+                SequenceNumber: seq++);
+
+            var ts = payload.ToTimestampUtc();
+            var evt = MarketEvent.HistoricalBar(ts, symbol, payload, seq, "test");
+            writer.WriteLine(JsonSerializer.Serialize(evt, MarketDataJsonContext.HighPerformanceOptions));
+        }
+    }
 }
 
 // ------------------------------------------------------------------ //
@@ -656,6 +711,36 @@ file sealed class ShortFirstBarStrategy(string symbol, long quantity) : IBacktes
             ctx.PlaceMarketOrder(symbol, -quantity);   // negative quantity = short sell
             _shorted = true;
         }
+    }
+
+    public void OnOrderBook(LOBSnapshot snapshot, IBacktestContext ctx) { }
+    public void OnOrderFill(FillEvent fill, IBacktestContext ctx) { }
+    public void OnDayEnd(DateOnly date, IBacktestContext ctx) { }
+    public void OnFinished(IBacktestContext ctx) { }
+}
+
+file sealed class BuyFirstBarWithMarketImpactGtcStrategy(string symbol, long quantity) : IBacktestStrategy
+{
+    private bool _submitted;
+
+    public string Name => "BuyFirstBarWithMarketImpactGtc";
+
+    public void Initialize(IBacktestContext ctx) { }
+    public void OnTrade(Trade trade, IBacktestContext ctx) { }
+    public void OnQuote(BboQuotePayload quote, IBacktestContext ctx) { }
+
+    public void OnBar(HistoricalBar bar, IBacktestContext ctx)
+    {
+        if (_submitted || !bar.Symbol.Equals(symbol, StringComparison.OrdinalIgnoreCase))
+            return;
+
+        ctx.PlaceOrder(new OrderRequest(
+            Symbol: symbol,
+            Quantity: quantity,
+            Type: OrderType.Market,
+            TimeInForce: TimeInForce.Gtc,
+            ExecutionModel: ExecutionModel.MarketImpact));
+        _submitted = true;
     }
 
     public void OnOrderBook(LOBSnapshot snapshot, IBacktestContext ctx) { }


### PR DESCRIPTION
### Motivation
- Fix a correctness bug where `BacktestEngine` updated or removed orders based on the fill-model's aggregated `OrderFillResult` even when some generated fills were rejected by `SimulatedPortfolio.ProcessFill`, which could prematurely mark orders as complete or inflate `FilledQuantity`. 
- Maintain the existing behavior of discarding portfolio-rule-violating fills (e.g. no-margin / no-short) while ensuring order lifecycle and pending quantity reflect only accepted fills.

### Description
- Recompute pending-order state in `ProcessPendingOrders` by accumulating only accepted fills and building an `updatedOrder` from that accepted quantity, instead of blindly applying `result.UpdatedOrder` or `result.RemoveOrder` from the fill model; changes in `src/Meridian.Backtesting/Engine/BacktestEngine.cs` implement this logic. 
- Preserve trigger activation (`IsTriggered`) when generated fills all get rejected so trigger semantics remain intact without changing quantity/status incorrectly. 
- Add a regression integration test `RunAsync_RejectedMarketImpactSlices_DoNotRemoveRemainingOrderQuantity` plus helper `WriteCustomBarJsonl` and a deterministic strategy `BuyFirstBarWithMarketImpactGtcStrategy` to reproduce the MarketImpact multi-slice + no-margin rejection scenario; changes are in `tests/Meridian.Backtesting.Tests/BacktestEngineIntegrationTests.cs`.

### Testing
- Added the targeted integration test `RunAsync_RejectedMarketImpactSlices_DoNotRemoveRemainingOrderQuantity` to `tests/Meridian.Backtesting.Tests` but could not execute it here because `dotnet` is not installed in the execution environment. 
- Recommend running the backtesting test slice (for example: `dotnet test tests/Meridian.Backtesting.Tests/Meridian.Backtesting.Tests.csproj --filter "FullyQualifiedName~RunAsync_RejectedMarketImpactSlices_DoNotRemoveRemainingOrderQuantity"`) and the full `tests/Meridian.Backtesting.Tests` suite in CI to validate the fix and guard against regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8a4607648320ad75bb101c24aa53)