### PR TITLE
Harden audit chain verification against data tampering

### DIFF
--- a/src/Meridian.Storage/Services/AuditChainService.cs
+++ b/src/Meridian.Storage/Services/AuditChainService.cs
@@ -118,7 +118,8 @@ public sealed class AuditChainService : IAuditChainService
 
         var entry = new
         {
-            path = Path.GetFileName(filePath),
+            path = filePath,
+            fileHash,
             hash = entryHash,
             prev = previousHash,
             ts = DateTimeOffset.UtcNow.ToString("O")
@@ -156,7 +157,9 @@ public sealed class AuditChainService : IAuditChainService
 
         if (!File.Exists(chainLogPath))
         {
-            _log.Information("Chain log not found at {ChainLogPath}, marking as valid (empty chain)", chainLogPath);
+            _log.Warning("Chain log not found at {ChainLogPath}; unable to verify integrity", chainLogPath);
+            result.IsValid = false;
+            result.FirstTamperPath = chainLogPath;
             return result;
         }
 
@@ -186,6 +189,9 @@ public sealed class AuditChainService : IAuditChainService
                     var path = root.TryGetProperty("path"u8, out var pathElement)
                         ? pathElement.GetString() ?? ""
                         : "";
+                    var fileHash = root.TryGetProperty("fileHash"u8, out var fileHashElement)
+                        ? fileHashElement.GetString() ?? ""
+                        : "";
                     var currentHash = root.TryGetProperty("hash"u8, out var hashElement)
                         ? hashElement.GetString() ?? ""
                         : "";
@@ -195,6 +201,66 @@ public sealed class AuditChainService : IAuditChainService
                     var timestamp = root.TryGetProperty("ts"u8, out var tsElement)
                         ? tsElement.GetString() ?? ""
                         : "";
+
+                    if (string.IsNullOrWhiteSpace(path) || string.IsNullOrWhiteSpace(fileHash))
+                    {
+                        _log.Error("Audit chain entry at line {LineNumber} is missing required fields", lineNumber);
+                        result.IsValid = false;
+                        result.FirstTamperPath = path;
+                        if (DateTimeOffset.TryParse(timestamp, out var ts))
+                        {
+                            result.TamperedAt = ts;
+                        }
+
+                        break;
+                    }
+
+                    if (!File.Exists(path))
+                    {
+                        _log.Error("Audit chain file not found during verification: {Path}", path);
+                        result.IsValid = false;
+                        result.FirstTamperPath = path;
+                        if (DateTimeOffset.TryParse(timestamp, out var ts))
+                        {
+                            result.TamperedAt = ts;
+                        }
+
+                        break;
+                    }
+
+                    await using var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+                    var currentFileHashBytes = await SHA256.HashDataAsync(fileStream, ct).ConfigureAwait(false);
+                    var currentFileHash = Convert.ToHexString(currentFileHashBytes).ToLowerInvariant();
+
+                    if (!string.Equals(currentFileHash, fileHash, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _log.Error("Audit chain file hash mismatch at line {LineNumber} for {Path}", lineNumber, path);
+                        result.IsValid = false;
+                        result.FirstTamperPath = path;
+                        if (DateTimeOffset.TryParse(timestamp, out var ts))
+                        {
+                            result.TamperedAt = ts;
+                        }
+
+                        break;
+                    }
+
+                    var expectedEntryData = $"{path}{fileHash}{recordedPreviousHash}";
+                    var expectedEntryHashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(expectedEntryData));
+                    var expectedEntryHash = Convert.ToHexString(expectedEntryHashBytes).ToLowerInvariant();
+
+                    if (!string.Equals(expectedEntryHash, currentHash, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _log.Error("Audit chain entry hash mismatch at line {LineNumber} for {Path}", lineNumber, path);
+                        result.IsValid = false;
+                        result.FirstTamperPath = path;
+                        if (DateTimeOffset.TryParse(timestamp, out var ts))
+                        {
+                            result.TamperedAt = ts;
+                        }
+
+                        break;
+                    }
 
                     // Verify chain linkage: recorded previous hash should match actual previous hash
                     if (recordedPreviousHash != (previousHash ?? ""))

--- a/tests/Meridian.Tests/Storage/AuditChainServiceTests.cs
+++ b/tests/Meridian.Tests/Storage/AuditChainServiceTests.cs
@@ -1,0 +1,68 @@
+using Meridian.Storage.Services;
+using Xunit;
+
+namespace Meridian.Tests.Storage;
+
+public sealed class AuditChainServiceTests : IDisposable
+{
+    private readonly string _testRoot;
+    private readonly AuditChainService _service;
+
+    public AuditChainServiceTests()
+    {
+        _testRoot = Path.Combine(Path.GetTempPath(), $"mdc_audit_chain_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testRoot);
+        _service = new AuditChainService();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testRoot))
+        {
+            Directory.Delete(_testRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task VerifyChainAsync_DetectsDataFileTampering()
+    {
+        var dataPath = Path.Combine(_testRoot, "sample.jsonl");
+        await File.WriteAllTextAsync(dataPath, "before tamper");
+
+        await _service.AppendEntryAsync(dataPath);
+
+        await File.WriteAllTextAsync(dataPath, "after tamper");
+
+        var chainLogPath = Path.Combine(_testRoot, "chain.log");
+        var result = await _service.VerifyChainAsync(chainLogPath);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(dataPath, result.FirstTamperPath);
+    }
+
+    [Fact]
+    public async Task VerifyChainAsync_MissingChainLog_IsInvalid()
+    {
+        var chainLogPath = Path.Combine(_testRoot, "chain.log");
+
+        var result = await _service.VerifyChainAsync(chainLogPath);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(chainLogPath, result.FirstTamperPath);
+    }
+
+    [Fact]
+    public async Task VerifyChainAsync_ValidChain_IsValid()
+    {
+        var dataPath = Path.Combine(_testRoot, "valid.jsonl");
+        await File.WriteAllTextAsync(dataPath, "line-1");
+
+        await _service.AppendEntryAsync(dataPath);
+
+        var chainLogPath = Path.Combine(_testRoot, "chain.log");
+        var result = await _service.VerifyChainAsync(chainLogPath);
+
+        Assert.True(result.IsValid);
+        Assert.Equal(1, result.EntriesChecked);
+    }
+}


### PR DESCRIPTION
### Motivation
- The existing audit chain verifier only validated log-to-log linkage and treated a missing `chain.log` as a valid empty chain, allowing file-content tampering to go undetected.
- This change restores tamper-evidence by ensuring recorded file metadata is persisted and re-validated during verification so attackers cannot modify archived files while leaving the chain log unchanged.

### Description
- Updated `AuditChainService.AppendEntryAsync` to persist the full `path` and `fileHash` in each chain entry so verification has the data required to re-check file contents.
- Strengthened `AuditChainService.VerifyChainAsync` to treat a missing `chain.log` as invalid, require `path` and `fileHash` fields, verify the referenced file exists, recompute and compare the file SHA-256 against the recorded `fileHash`, and recompute/compare the entry hash before checking `prev` linkage.
- Kept chain-linkage verification (`prev`) while adding the additional file- and entry-hash checks to provide end-to-end tamper evidence.
- Added focused unit tests at `tests/Meridian.Tests/Storage/AuditChainServiceTests.cs` exercising a valid chain, missing `chain.log`, and detection of post-append data-file tampering.

### Testing
- Added unit tests: `tests/Meridian.Tests/Storage/AuditChainServiceTests.cs` covering valid-chain, missing-chain-log, and data-file-tamper detection scenarios.
- Attempted to run the targeted tests with `dotnet test --filter "FullyQualifiedName~AuditChainServiceTests"`, but the execution environment lacks the .NET SDK and `dotnet` is not available, so tests could not be executed here (failure: `dotnet: command not found`).
- All changes were committed on the feature branch with the message `Harden audit chain verification against data tampering` and are ready for CI to run the new tests in a proper .NET environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4027251083208eea6f9bdbd3f9b8)