### PR TITLE
fix: correct strategy runs API client response type

### DIFF
--- a/src/Meridian.Ui/dashboard/src/lib/api.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api.ts
@@ -26,6 +26,7 @@ import type {
   ResolveConflictRequest,
   ReviewReconciliationBreakRequest,
   ResearchRunRecord,
+  StrategyRunSummaryApiRecord,
   ResearchWorkspaceResponse,
   RunAttributionSummary,
   RunComparisonRow,
@@ -288,7 +289,7 @@ export function getReplayStatus(sessionId: string) {
 
 export function getStrategyRuns(strategyId: string, type?: "backtest" | "paper" | "live") {
   const params = type ? `?type=${encodeURIComponent(type)}` : "";
-  return getJson<ResearchRunRecord[]>(`/api/strategies/${encodeURIComponent(strategyId)}/runs${params}`);
+  return getJson<StrategyRunSummaryApiRecord[]>(`/api/strategies/${encodeURIComponent(strategyId)}/runs${params}`);
 }
 
 // --- Multi-run comparison and diff ---

--- a/src/Meridian.Ui/dashboard/src/types.ts
+++ b/src/Meridian.Ui/dashboard/src/types.ts
@@ -32,6 +32,28 @@ export interface MetricSnapshot {
   tone: "default" | "success" | "warning" | "danger";
 }
 
+
+
+export interface StrategyRunSummaryApiRecord {
+  runId: string;
+  strategyId: string;
+  strategyName: string;
+  mode: number;
+  engine: number;
+  status: number;
+  startedAt: string;
+  completedAt: string | null;
+  datasetReference: string | null;
+  feedReference: string | null;
+  portfolioId: string | null;
+  ledgerReference: string | null;
+  netPnl: number | null;
+  totalReturn: number | null;
+  finalEquity: number | null;
+  fillCount: number;
+  lastUpdatedAt: string;
+  auditReference?: string | null;
+}
 export interface ResearchRunRecord {
   id: string;
   strategyName: string;


### PR DESCRIPTION
### Motivation
- Fix a client/server contract mismatch where the dashboard helper `getStrategyRuns` was typed as `ResearchRunRecord[]` but the backend endpoint `/api/strategies/{strategyId}/runs` returns raw `StrategyRunSummary`-shaped JSON, which caused undefined fields and runtime type errors in frontend consumers.

### Description
- Add a new `StrategyRunSummaryApiRecord` type to `src/Meridian.Ui/dashboard/src/types.ts` that matches the endpoint JSON shape (fields such as `runId`, `strategyId`, numeric enum fields, timestamps, and references).
- Update `getStrategyRuns` in `src/Meridian.Ui/dashboard/src/lib/api.ts` to return `StrategyRunSummaryApiRecord[]` instead of `ResearchRunRecord[]` so consumers no longer assume preformatted display fields that the API does not provide.

### Testing
- Attempted an automated build with `npm run build` in `src/Meridian.Ui/dashboard`, which failed due to pre-existing toolchain/type-definition issues (`@testing-library/jest-dom` and `vitest/globals` type defs missing and TypeScript deprecation warnings) unrelated to this change.
- Verified via static inspection that the new type matches the server record shape and that `getStrategyRuns` now requests `StrategyRunSummaryApiRecord[]`, preventing the previously observed property mismatches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8a46567483208930005740db5902)