### PR TITLE
fix: bound CppTrader snapshot depth iteration to prevent loop wraparound

### DIFF
--- a/src/Meridian.Infrastructure.CppTrader/Providers/CppTraderMarketDataClient.cs
+++ b/src/Meridian.Infrastructure.CppTrader/Providers/CppTraderMarketDataClient.cs
@@ -19,6 +19,7 @@ namespace Meridian.Infrastructure.CppTrader.Providers;
     Priority = 50, Description = "External CppTrader-native market data and execution host")]
 public sealed class CppTraderMarketDataClient : IMarketDataClient
 {
+    private const int MaxBookSnapshotDepthLevels = ushort.MaxValue;
     private readonly ICppTraderHostManager _hostManager;
     private readonly ICppTraderSymbolMapper _symbolMapper;
     private readonly TradeDataCollector _tradeCollector;
@@ -324,7 +325,17 @@ public sealed class CppTraderMarketDataClient : IMarketDataClient
     {
         _depthCollector.ResetSymbolStream(snapshot.Symbol);
 
-        for (ushort i = 0; i < snapshot.Bids.Count; i++)
+        var bidDepth = Math.Min(snapshot.Bids.Count, MaxBookSnapshotDepthLevels);
+        if (snapshot.Bids.Count > bidDepth)
+        {
+            _logger.LogWarning(
+                "Truncating CppTrader bid snapshot depth for {Symbol} from {OriginalCount} to {MaxCount}.",
+                snapshot.Symbol,
+                snapshot.Bids.Count,
+                bidDepth);
+        }
+
+        for (int i = 0; i < bidDepth; i++)
         {
             var level = snapshot.Bids[i];
             _depthCollector.OnDepth(new MarketDepthUpdate(
@@ -340,7 +351,17 @@ public sealed class CppTraderMarketDataClient : IMarketDataClient
                 Venue: snapshot.Venue));
         }
 
-        for (ushort i = 0; i < snapshot.Asks.Count; i++)
+        var askDepth = Math.Min(snapshot.Asks.Count, MaxBookSnapshotDepthLevels);
+        if (snapshot.Asks.Count > askDepth)
+        {
+            _logger.LogWarning(
+                "Truncating CppTrader ask snapshot depth for {Symbol} from {OriginalCount} to {MaxCount}.",
+                snapshot.Symbol,
+                snapshot.Asks.Count,
+                askDepth);
+        }
+
+        for (int i = 0; i < askDepth; i++)
         {
             var level = snapshot.Asks[i];
             _depthCollector.OnDepth(new MarketDepthUpdate(


### PR DESCRIPTION
### Motivation
- The CppTrader market-data client iterated snapshot levels with `ushort` counters which wrap at 65,536, allowing a malicious/compromised feed to create a non-terminating loop and stall the event pump.

### Description
- Added a per-side depth cap constant `MaxBookSnapshotDepthLevels = ushort.MaxValue` and compute `bidDepth`/`askDepth` using `Math.Min` before iterating.
- Replaced `for (ushort ...)` loops with safe `for (int i = 0; i < <depth>; i++)` loops to avoid unsigned wraparound and unbounded iteration.
- Emit warning logs when an incoming bid/ask snapshot is truncated to the cap so truncation is observable operationally.
- Modified file `src/Meridian.Infrastructure.CppTrader/Providers/CppTraderMarketDataClient.cs` to implement the fix.

### Testing
- Could not run .NET automated tests in this environment because `dotnet --version` fails with `dotnet: command not found` so no test suite was executed here.
- Verified the source changes with `git diff src/Meridian.Infrastructure.CppTrader/Providers/CppTraderMarketDataClient.cs` and committed the patch with `git commit -m "fix: bound cpptrader snapshot depth iteration"`.
- Recommend running the repository test matrix (`make test` / `dotnet test ...`) in a developer environment with the .NET SDK to validate behavior and regression coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4026ed2083209aad7d6a671a44f5)