### PR TITLE
Redact sensitive environment variables in buildctl env-capture and env-diff

### DIFF
--- a/build/python/cli/buildctl.py
+++ b/build/python/cli/buildctl.py
@@ -1077,6 +1077,39 @@ def cmd_fingerprint(args: argparse.Namespace) -> int:
     return 0
 
 
+
+
+def _is_sensitive_env_var(name: str) -> bool:
+    lowered = name.lower()
+    sensitive_markers = (
+        "key",
+        "secret",
+        "token",
+        "password",
+        "connection_string",
+        "connectionstring",
+        "connstr",
+        "sas",
+        "private",
+        "credential",
+    )
+    return any(marker in lowered for marker in sensitive_markers)
+
+
+def _mask_env_value(value: str) -> str:
+    if not value:
+        return ""
+    if len(value) <= 4:
+        return "****"
+    return f"{value[:2]}***{value[-1]}"
+
+
+def _safe_env_snapshot() -> dict[str, str]:
+    return {
+        key: ("<redacted>" if _is_sensitive_env_var(key) else value)
+        for key, value in os.environ.items()
+    }
+
 # ---------------------------------------------------------------------------
 # env-capture command
 # ---------------------------------------------------------------------------
@@ -1092,7 +1125,7 @@ def cmd_env_capture(args: argparse.Namespace) -> int:
         "timestamp": _utc_now(),
         "platform": platform.platform(),
         "python": platform.python_version(),
-        "env": {k: v for k, v in os.environ.items() if not k.lower().endswith(("key", "secret", "token", "password"))},
+        "env": _safe_env_snapshot(),
     }
 
     result = _run(["dotnet", "--version"])
@@ -1147,8 +1180,10 @@ def cmd_env_diff(args: argparse.Namespace) -> int:
         v2 = flat2.get(key, "<missing>")
         if v1 != v2:
             print(f"  {key}:")
-            print(f"    {env1}: {v1}")
-            print(f"    {env2}: {v2}")
+            display_v1 = "<redacted>" if _is_sensitive_env_var(key) else _mask_env_value(v1)
+            display_v2 = "<redacted>" if _is_sensitive_env_var(key) else _mask_env_value(v2)
+            print(f"    {env1}: {display_v1}")
+            print(f"    {env2}: {display_v2}")
             diffs += 1
 
     if diffs == 0:


### PR DESCRIPTION
### Motivation
- The `build/python/cli/buildctl.py` env snapshot tooling wrote environment variables to `.ai/env-snapshots` and printed diffs, but only filtered names ending with `key`, `secret`, `token`, or `password`, which allowed `*_CONNECTION_STRING` and similar names to be captured in cleartext.
- Avoid accidental disclosure of database/service credentials or CI/dev secrets when snapshots are saved or printed to logs/artifacts.

### Description
- Added `_is_sensitive_env_var(name: str)` to detect sensitive environment names by matching a broader set of markers (including `connection_string`, `connectionstring`, `connstr`, `sas`, `credential`, etc.).
- Added `_mask_env_value(value: str)` and `_safe_env_snapshot()` helpers and replaced the inline env dict with `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4027f9988320a4737bd22be15bfc)