### PR TITLE
fix: enforce lot-size validation on primary paper execution path

### DIFF
--- a/src/Meridian.Execution/PaperTradingGateway.cs
+++ b/src/Meridian.Execution/PaperTradingGateway.cs
@@ -1,4 +1,6 @@
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
+using Meridian.Contracts.SecurityMaster;
 using Meridian.Execution.Sdk;
 using Microsoft.Extensions.Logging;
 
@@ -11,12 +13,15 @@ namespace Meridian.Execution;
 public sealed class PaperTradingGateway : IExecutionGateway
 {
     private readonly ILogger<PaperTradingGateway> _logger;
+    private readonly ISecurityMasterQueryService? _securityMaster;
+    private readonly ConcurrentDictionary<string, TradingParametersDto?> _tradingParamsCache = new(StringComparer.OrdinalIgnoreCase);
     private bool _connected;
     private int _fillSequence;
 
-    public PaperTradingGateway(ILogger<PaperTradingGateway> logger)
+    public PaperTradingGateway(ILogger<PaperTradingGateway> logger, ISecurityMasterQueryService? securityMaster = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _securityMaster = securityMaster;
     }
 
     /// <inheritdoc />
@@ -45,6 +50,12 @@ public sealed class PaperTradingGateway : IExecutionGateway
     public Task<ExecutionReport> SubmitOrderAsync(OrderRequest request, CancellationToken ct = default)
     {
         var fillSeq = Interlocked.Increment(ref _fillSequence);
+
+        var lotSizeError = await ValidateLotSizeAsync(request, ct).ConfigureAwait(false);
+        if (lotSizeError is not null)
+        {
+            throw new InvalidOperationException(lotSizeError);
+        }
 
         if (request.Type is OrderType.MarketOnOpen or OrderType.MarketOnClose or OrderType.LimitOnOpen or OrderType.LimitOnClose)
         {
@@ -129,4 +140,63 @@ public sealed class PaperTradingGateway : IExecutionGateway
         await Task.CompletedTask;
         yield break;
     }
+
+    private async Task<string?> ValidateLotSizeAsync(OrderRequest request, CancellationToken ct)
+    {
+        var tradingParams = await TryGetTradingParamsAsync(request.Symbol, ct).ConfigureAwait(false);
+        if (tradingParams?.LotSize is not { } lotSize || lotSize <= 0m)
+        {
+            return null;
+        }
+
+        var absQty = Math.Abs(request.Quantity);
+        return absQty % lotSize == 0m
+            ? null
+            : $"Order quantity {absQty} is not a valid multiple of the lot-size {lotSize} for {request.Symbol}.";
+    }
+
+    private async Task<TradingParametersDto?> TryGetTradingParamsAsync(string symbol, CancellationToken ct)
+    {
+        if (_securityMaster is null || string.IsNullOrWhiteSpace(symbol))
+        {
+            return null;
+        }
+
+        if (_tradingParamsCache.TryGetValue(symbol, out var cached))
+        {
+            return cached;
+        }
+
+        try
+        {
+            var security = await _securityMaster.GetByIdentifierAsync(
+                SecurityIdentifierKind.Ticker,
+                symbol,
+                provider: null,
+                ct).ConfigureAwait(false);
+
+            if (security is null)
+            {
+                _tradingParamsCache[symbol] = null;
+                return null;
+            }
+
+            var tradingParams = await _securityMaster.GetTradingParametersAsync(
+                security.SecurityId,
+                DateTimeOffset.UtcNow,
+                ct).ConfigureAwait(false);
+
+            _tradingParamsCache[symbol] = tradingParams;
+            return tradingParams;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "PaperTradingGateway lot-size validation skipped for {Symbol} due to Security Master lookup failure.",
+                symbol);
+            _tradingParamsCache[symbol] = null;
+            return null;
+        }
+    }
+
 }

--- a/src/Meridian/UiServer.cs
+++ b/src/Meridian/UiServer.cs
@@ -167,7 +167,8 @@ public sealed class UiServer : IAsyncDisposable
         });
         builder.Services.AddSingleton<IExecutionGateway>(sp =>
             new Meridian.Execution.PaperTradingGateway(
-                sp.GetRequiredService<ILogger<Meridian.Execution.PaperTradingGateway>>()));
+                sp.GetRequiredService<ILogger<Meridian.Execution.PaperTradingGateway>>(),
+                sp.GetService<ISecurityMasterQueryService>()));
 
         // Register OpenAPI/Swagger services
         builder.Services.AddEndpointsApiExplorer();

--- a/tests/Meridian.Tests/Execution/PaperExecutionGatewayLotSizeTests.cs
+++ b/tests/Meridian.Tests/Execution/PaperExecutionGatewayLotSizeTests.cs
@@ -1,0 +1,98 @@
+using FluentAssertions;
+using Meridian.Contracts.SecurityMaster;
+using Meridian.Execution.Sdk;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Meridian.Tests.Execution;
+
+public sealed class PaperExecutionGatewayLotSizeTests
+{
+    [Fact]
+    public async Task SubmitOrderAsync_WithSecurityMaster_SubLotQuantity_Throws()
+    {
+        var sm = new StubSecurityMaster(securityId: Guid.NewGuid(), lotSize: 100m);
+        var gateway = new Meridian.Execution.PaperTradingGateway(NullLogger<Meridian.Execution.PaperTradingGateway>.Instance, sm);
+
+        var act = async () => await gateway.SubmitOrderAsync(MarketBuy("XYZ", 150));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*lot-size*");
+    }
+
+    [Fact]
+    public async Task SubmitOrderAsync_WithSecurityMaster_ValidLot_Accepts()
+    {
+        var sm = new StubSecurityMaster(securityId: Guid.NewGuid(), lotSize: 100m);
+        var gateway = new Meridian.Execution.PaperTradingGateway(NullLogger<Meridian.Execution.PaperTradingGateway>.Instance, sm);
+
+        var report = await gateway.SubmitOrderAsync(MarketBuy("XYZ", 200));
+
+        report.OrderStatus.Should().Be(OrderStatus.Filled);
+        report.FilledQuantity.Should().Be(200m);
+    }
+
+    private static OrderRequest MarketBuy(string symbol, decimal qty) => new()
+    {
+        Symbol = symbol,
+        Side = OrderSide.Buy,
+        Type = OrderType.Market,
+        Quantity = qty,
+        TimeInForce = TimeInForce.Day
+    };
+
+    private sealed class StubSecurityMaster : ISecurityMasterQueryService
+    {
+        private readonly Guid? _securityId;
+        private readonly decimal? _lotSize;
+
+        public StubSecurityMaster(Guid? securityId, decimal? lotSize)
+        {
+            _securityId = securityId;
+            _lotSize = lotSize;
+        }
+
+        public Task<SecurityDetailDto?> GetByIdentifierAsync(SecurityIdentifierKind kind, string value, string? provider, CancellationToken ct = default)
+        {
+            if (_securityId is null)
+                return Task.FromResult<SecurityDetailDto?>(null);
+
+            var detail = new SecurityDetailDto(
+                SecurityId: _securityId.Value,
+                AssetClass: "Equity",
+                Status: SecurityStatusDto.Active,
+                DisplayName: value,
+                Currency: "USD",
+                CommonTerms: System.Text.Json.JsonDocument.Parse("{}").RootElement,
+                AssetSpecificTerms: System.Text.Json.JsonDocument.Parse("{}").RootElement,
+                Identifiers: Array.Empty<SecurityIdentifierDto>(),
+                Aliases: Array.Empty<SecurityAliasDto>(),
+                Version: 1L,
+                EffectiveFrom: DateTimeOffset.UtcNow.AddYears(-1),
+                EffectiveTo: null);
+            return Task.FromResult<SecurityDetailDto?>(detail);
+        }
+
+        public Task<TradingParametersDto?> GetTradingParametersAsync(Guid securityId, DateTimeOffset asOf, CancellationToken ct = default)
+        {
+            var dto = new TradingParametersDto(
+                SecurityId: securityId,
+                LotSize: _lotSize,
+                TickSize: null,
+                PriceBandLower: null,
+                PriceBandUpper: null,
+                EffectiveFrom: DateTimeOffset.UtcNow.AddDays(-1),
+                EffectiveTo: null);
+            return Task.FromResult<TradingParametersDto?>(dto);
+        }
+
+        public Task<IReadOnlyList<SecurityCorporateActionDto>> ListCorporateActionsAsync(Guid securityId, DateTimeOffset from, DateTimeOffset to, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<SecurityCorporateActionDto>>(Array.Empty<SecurityCorporateActionDto>());
+
+        public Task<IReadOnlyList<SecurityPriceBandDto>> ListPriceBandsAsync(Guid securityId, DateTimeOffset from, DateTimeOffset to, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<SecurityPriceBandDto>>(Array.Empty<SecurityPriceBandDto>());
+
+        public Task<IReadOnlyList<SecurityStatusTransitionDto>> ListStatusHistoryAsync(Guid securityId, DateTimeOffset from, DateTimeOffset to, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<SecurityStatusTransitionDto>>(Array.Empty<SecurityStatusTransitionDto>());
+    }
+}


### PR DESCRIPTION
### Motivation
- The primary order submission path (`IOrderManager -> IExecutionGateway`) bypassed the newly added lot-size checks that were implemented only on the adapter `IOrderGateway`, allowing sub-lot orders to be accepted through the main API path. 
- Ensure consistent lot-size enforcement across both the adapter gateway and the execution gateway used by the OMS and `/api/execution/orders/submit`. 

### Description
- Added best-effort Security Master-backed lot-size validation to `Meridian.Execution.PaperTradingGateway.SubmitOrderAsync`, returning an error (thrown `InvalidOperationException`) for sub-lot quantities before any simulated fill. 
- Implemented `TryGetTradingParamsAsync` with caching and `ValidateLotSizeAsync` helper to resolve `TradingParametersDto` from `ISecurityMasterQueryService` and compute lot-size multiples. 
- Preserved non-blocking behavior when Security Master is unavailable by catching lookup failures, logging a warning, and allowing orders to proceed when trading parameters cannot be resolved. 
- Wired `UiServer` DI so the `IExecutionGateway` registration passes `ISecurityMasterQueryService` into the paper gateway, enabling lot-size validation on the main OMS/API path. 
- Added focused tests `tests/Meridian.Tests/Execution/PaperExecutionGatewayLotSizeTests.cs` that assert sub-lot rejection and valid-lot acceptance on the execution gateway. 

### Testing
- Added unit tests for the execution gateway lot-size behavior (`PaperExecutionGatewayLotSizeTests`), which were created in the test tree and validate both rejection and acceptance scenarios. 
- Attempted to run the targeted test command `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~PaperExecutionGatewayLotSizeTests" --logger "console;verbosity=minimal"`, but the execution environment does not have `dotnet` installed so automated test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8a45fa9483208c5ebb59491d9d8a)