### PR TITLE
fix: restore rubric output detection for markdown/string trace content

### DIFF
--- a/.codex/skills/meridian-implementation-assurance/scripts/run_evals.py
+++ b/.codex/skills/meridian-implementation-assurance/scripts/run_evals.py
@@ -174,21 +174,30 @@ def check_ran_score_eval(cmds: list[str]) -> bool:
     return any("score_eval" in cmd for cmd in cmds)
 
 
-def _contains_key(obj: Any, key: str) -> bool:
-    """Recursively check whether a nested dict/list contains the given key name."""
+def _contains_rubric_marker(obj: Any, marker: str) -> bool:
+    """Recursively check whether nested content contains a rubric marker.
+
+    Supports both structured JSON keys and string payloads (stdout/messages)
+    where rubric labels are commonly rendered as Markdown text.
+    """
+    marker_folded = marker.casefold()
+
     if isinstance(obj, dict):
-        if key in obj:
+        if any(k.casefold() == marker_folded for k in obj):
             return True
-        return any(_contains_key(v, key) for v in obj.values())
+        return any(_contains_rubric_marker(v, marker) for v in obj.values())
     if isinstance(obj, list):
-        return any(_contains_key(item, key) for item in obj)
+        return any(_contains_rubric_marker(item, marker) for item in obj)
+    if isinstance(obj, str):
+        return marker_folded in obj.casefold()
     return False
 
 
 def check_produced_rubric_output(events: list[dict]) -> bool:
     """Did the run produce a rubric score output (via score_eval.py or inline JSON)?"""
     return any(
-        _contains_key(e, "behavior_correctness") or _contains_key(e, "Behavior Correctness")
+        _contains_rubric_marker(e, "behavior_correctness")
+        or _contains_rubric_marker(e, "Behavior Correctness")
         for e in events
     )
 


### PR DESCRIPTION
### Motivation
- The eval harness stopped detecting rubric output when it was emitted as Markdown or inline JSON stored in string fields because detection only inspected nested JSON key names.
- This caused valid eval runs to fail with `no rubric output detected in trace` when `score_eval.py` produced rubric tables in stdout or assistant message content.

### Description
- Replaced the `_contains_key` helper with `_contains_rubric_marker` in `./.codex/skills/meridian-implementation-assurance/scripts/run_evals.py` to perform case-insensitive marker detection. 
- The new helper searches nested dictionary keys and list items and also scans string values for case-insensitive substring matches so Markdown rubric text is detected. 
- Updated `check_produced_rubric_output()` to use `_contains_rubric_marker` for both `behavior_correctness` and `Behavior Correctness` markers. 
- Change is scoped to the eval harness and does not affect production application code.

### Testing
- Ran a focused smoke test that imports the updated module and asserts detection for Markdown rubric text, structured JSON key form, and non-rubric strings using the command `python3 - <<'PY' ...` (inline assertions); the script printed `ok` indicating success. 
- Verified the updated file with a quick line-number inspection using `nl -ba .codex/skills/meridian-implementation-assurance/scripts/run_evals.py | sed -n '170,230p'` to confirm the new helper and checks are present. 
- No other automated test suites were changed; the fix is minimal and limited to the eval tooling logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8a46b9f48320bec36ca3caf1c8ff)