### PR TITLE
fix: clamp cash-flow bucketDays to safe date range

### DIFF
--- a/src/Meridian.Strategies/Services/CashFlowProjectionService.cs
+++ b/src/Meridian.Strategies/Services/CashFlowProjectionService.cs
@@ -50,7 +50,7 @@ public sealed class CashFlowProjectionService
 
             var effectiveAsOf = asOf ?? run.StartedAt;
             var effectiveCcy = string.IsNullOrWhiteSpace(currency) ? DefaultCurrency : currency!;
-            var effectiveBuckets = Math.Max(1, bucketDays ?? DefaultBucketDays);
+            var effectiveBuckets = ClampBucketDays(effectiveAsOf, bucketDays ?? DefaultBucketDays);
 
             var cashFlows = run.Metrics?.CashFlows ?? [];
             var entries = BuildEntries(cashFlows, effectiveCcy);
@@ -73,6 +73,16 @@ public sealed class CashFlowProjectionService
         }
 
         return null;
+    }
+
+    private static int ClampBucketDays(DateTimeOffset asOf, int requestedBucketDays)
+    {
+        var minBucketDays = 1;
+        var maxBucketDays = Math.Max(
+            minBucketDays,
+            (int)Math.Floor((DateTimeOffset.MaxValue - asOf).TotalDays));
+
+        return Math.Clamp(requestedBucketDays, minBucketDays, maxBucketDays);
     }
 
     private static CashFlowEntryDto[] BuildEntries(

--- a/tests/Meridian.Tests/Strategies/CashFlowProjectionTests.cs
+++ b/tests/Meridian.Tests/Strategies/CashFlowProjectionTests.cs
@@ -149,6 +149,23 @@ public sealed class CashFlowProjectionTests
         narrowBuckets.Ladder.Buckets.Count.Should().BeGreaterThanOrEqualTo(wideBuckets.Ladder.Buckets.Count);
     }
 
+    [Fact]
+    public async Task GetAsync_BucketDays_TooLarge_IsClampedToSafeRange()
+    {
+        var store = new StrategyRunStore();
+        var run = BuildRunWithMixedFlows("cf-buckets-clamped-1");
+        await store.RecordRunAsync(run);
+
+        var service = new CashFlowProjectionService(store);
+        var asOf = run.StartedAt;
+        var maxBucketDays = Math.Max(1, (int)Math.Floor((DateTimeOffset.MaxValue - asOf).TotalDays));
+
+        var result = await service.GetAsync("cf-buckets-clamped-1", asOf: asOf, bucketDays: int.MaxValue);
+
+        result.Should().NotBeNull();
+        result!.Ladder.BucketDays.Should().Be(maxBucketDays);
+    }
+
     // -----------------------------------------------------------------------
     // Event kind mapping
     // -----------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Registering `CashFlowProjectionService` made the `GET /api/portfolio/{runId}/cash-flows` path exercise the projection code with `bucketDays` taken directly from the query string, enabling an attacker-controlled large value to trigger `DateTimeOffset.AddDays` overflow and cause HTTP 500s. 
- The change introduces an upper-bound validation to prevent availability issues while preserving normal behavior for typical bucket sizes.

### Description
- Added a helper `ClampBucketDays(DateTimeOffset asOf, int requestedBucketDays)` that computes a safe upper bound from `DateTimeOffset.MaxValue - asOf` and clamps the requested bucket size to the range `[1, maxBucketDays]` using `Math.Clamp`.
- Replaced the previous `Math.Max(1, bucketDays ?? DefaultBucketDays)` with `ClampBucketDays(effectiveAsOf, bucketDays ?? DefaultBucketDays)` in `CashFlowProjectionService.GetAsync` so the F# ladder builder never receives an out-of-range bucket size.
- Added a regression unit test `GetAsync_BucketDays_TooLarge_IsClampedToSafeRange` in `tests/Meridian.Tests/Strategies/CashFlowProjectionTests.cs` to assert that an oversized `bucketDays` value is clamped to the safe maximum.

### Testing
- Attempted to run the focused unit tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~CashFlowProjectionTests"`, but the environment lacks the .NET SDK and the command failed with `/bin/bash: dotnet: command not found` so tests could not be executed here.
- A regression test was added to the test suite to cover the clamping behavior and should pass in CI or a local environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4027eb8c8320aec9c1b416b5adf0)