### PR TITLE
fix(security): enforce QuantScript safe-mode API restrictions

### DIFF
--- a/src/Meridian.QuantScript/Compilation/RoslynScriptCompiler.cs
+++ b/src/Meridian.QuantScript/Compilation/RoslynScriptCompiler.cs
@@ -38,6 +38,17 @@ public sealed class RoslynScriptCompiler : IQuantScriptCompiler
         @"(?<name>Default|Min|Max|Description)\s*=\s*(?<value>(""[^""]*""|[^,]+))",
         RegexOptions.Compiled);
 
+
+    private static readonly string[] UnsafeApiMarkers =
+    [
+        "System.IO.",
+        "System.Net.",
+        "System.Diagnostics.Process",
+        "System.Environment",
+        "System.Reflection",
+        "Microsoft.Win32"
+    ];
+
     private readonly ConcurrentDictionary<string, Script<object>> _cache = new();
     private readonly IOptions<QuantScriptOptions> _options;
     private readonly ILogger<RoslynScriptCompiler> _logger;
@@ -73,6 +84,17 @@ public sealed class RoslynScriptCompiler : IQuantScriptCompiler
             return await Task.Run(() =>
             {
                 var sw = System.Diagnostics.Stopwatch.StartNew();
+
+                if (!_options.Value.EnableUnsafeScripts && TryGetUnsafeMarker(source, out var marker))
+                {
+                    var diagnostic = new ScriptDiagnostic(
+                        "Error",
+                        $"Safe mode blocks use of '{marker}'. Set EnableUnsafeScripts=true to allow this script.",
+                        1,
+                        1);
+                    return new ScriptCompilationResult(false, sw.Elapsed, [diagnostic]);
+                }
+
                 var script = BuildScript(source);
                 var compilation = script.GetCompilation();
                 var diagnostics = compilation.GetDiagnostics(cts.Token);
@@ -188,6 +210,22 @@ public sealed class RoslynScriptCompiler : IQuantScriptCompiler
         }
 
         public override string? ResolveReference(string path, string? baseFilePath) => null;
+    }
+
+
+    private static bool TryGetUnsafeMarker(string source, out string marker)
+    {
+        foreach (var candidate in UnsafeApiMarkers)
+        {
+            if (source.Contains(candidate, StringComparison.Ordinal))
+            {
+                marker = candidate;
+                return true;
+            }
+        }
+
+        marker = string.Empty;
+        return false;
     }
 
     /// <inheritdoc/>

--- a/tests/Meridian.QuantScript.Tests/RoslynScriptCompilerTests.cs
+++ b/tests/Meridian.QuantScript.Tests/RoslynScriptCompilerTests.cs
@@ -148,6 +148,30 @@ public sealed class RoslynScriptCompilerTests
         result.Diagnostics.Should().NotBeEmpty();
     }
 
+
+    [Fact]
+    public async Task CompileAsync_SafeMode_BlocksSystemIoAccess()
+    {
+        var compiler = BuildCompiler(new QuantScriptOptions { EnableUnsafeScripts = false });
+        var source = "var text = System.IO.File.ReadAllText(\"/tmp/a.txt\");";
+
+        var result = await compiler.CompileAsync(source);
+
+        result.Success.Should().BeFalse();
+        result.Diagnostics.Should().Contain(d => d.Message.Contains("System.IO", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task CompileAsync_UnsafeMode_AllowsSystemIoAccessSyntax()
+    {
+        var compiler = BuildCompiler(new QuantScriptOptions { EnableUnsafeScripts = true });
+        var source = "var text = System.IO.File.ReadAllText(\"/tmp/a.txt\");";
+
+        var result = await compiler.CompileAsync(source);
+
+        result.Success.Should().BeTrue();
+    }
+
     [Fact]
     public async Task CompileAsync_UnsafeMode_AllowsScriptLevelAssemblyReferences()
     {


### PR DESCRIPTION
### Motivation
- The QuantScript safe mode claimed to deny File/Network/Process access via `EnableUnsafeScripts=false` but compilation/execution paths did not enforce that flag, allowing scripts to reference dangerous framework APIs and #r/#load directives.
- Preventing accidental or malicious scripts from accessing local files, environment variables, network, or starting processes is critical to avoid credential disclosure and arbitrary code execution under the desktop user.

### Description
- Added a small static `UnsafeApiMarkers` list and a `TryGetUnsafeMarker` helper to detect high-risk API usage (e.g. `System.IO.`, `System.Net.`, `System.Diagnostics.Process`, `System.Environment`, `System.Reflection`, `Microsoft.Win32`) in script source in `src/Meridian.QuantScript/Compilation/RoslynScriptCompiler.cs`.
- Enforced `EnableUnsafeScripts` during compilation by returning a clear `ScriptCompilationResult` failure when safe mode is active and a marker is present, with a diagnostic explaining how to opt into unsafe mode.
- Preserved existing safe-mode resolvers (`RestrictedMetadataReferenceResolver` and `RestrictedSourceReferenceResolver`) and retained normal compilation/caching flow for allowed scripts.
- Added focused unit tests to `tests/Meridian.QuantScript.Tests/RoslynScriptCompilerTests.cs` that assert safe mode blocks `System.IO` usage and unsafe mode allows the same syntax.

### Testing
- Added unit tests: `CompileAsync_SafeMode_BlocksSystemIoAccess` and `CompileAsync_UnsafeMode_AllowsSystemIoAccessSyntax` in `tests/Meridian.QuantScript.Tests/RoslynScriptCompilerTests.cs`.
- Attempted to run the focused tests with `dotnet test tests/Meridian.QuantScript.Tests/Meridian.QuantScript.Tests.csproj --filter "FullyQualifiedName~CompileAsync_SafeMode_BlocksSystemIoAccess|FullyQualifiedName~CompileAsync_UnsafeMode_AllowsSystemIoAccessSyntax" --logger "console;verbosity=normal"`, but the execution environment does not have the .NET SDK installed (`dotnet: command not found`).
- The change is intentionally minimal and targets pre-compilation detection to avoid adding runtime surface or altering script execution semantics for scripts that are allowed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb889bf3248320aa1f33784a3b29b2)