### PR TITLE
fix: validate corporate action payload before append

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
@@ -395,6 +395,12 @@ public static class SecurityMasterEndpoints
                 return Results.BadRequest("Corporate action SecurityId must match route parameter");
             }
 
+            var validationError = ValidateCorporateAction(dto);
+            if (validationError is not null)
+            {
+                return Results.BadRequest(validationError);
+            }
+
             await eventStore.AppendCorporateActionAsync(dto, ct).ConfigureAwait(false);
             return Results.Ok();
         })
@@ -485,6 +491,31 @@ public static class SecurityMasterEndpoints
         .WithName("PatchSecurityPreferredTerms")
         .Produces<SecurityDetailDto>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status404NotFound);
+    }
+
+    private static string? ValidateCorporateAction(CorporateActionDto dto)
+    {
+        if (string.Equals(dto.EventType, "StockSplit", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!dto.SplitRatio.HasValue)
+            {
+                return "StockSplit corporate actions must include SplitRatio.";
+            }
+
+            if (dto.SplitRatio.Value <= 0m || dto.SplitRatio.Value > 1_000m)
+            {
+                return "StockSplit SplitRatio must be greater than 0 and less than or equal to 1000.";
+            }
+        }
+
+        if (string.Equals(dto.EventType, "Dividend", StringComparison.OrdinalIgnoreCase) &&
+            dto.DividendPerShare.HasValue &&
+            dto.DividendPerShare.Value < 0m)
+        {
+            return "DividendPerShare must be greater than or equal to 0.";
+        }
+
+        return null;
     }
 
     private static SecurityMasterIngestStatusResponse ToIngestStatusResponse(


### PR DESCRIPTION
### Motivation
- Prevent unsafe corporate-action data from being persisted and later used by the backtest adjustment path which can divide by zero or produce corrupted adjusted prices.
- Block simple malicious or accidental inputs (zero/negative/huge split ratios, negative dividends) at the API boundary before they reach the event store and backtesting engine.

### Description
- Added server-side validation to the security-master corporate-action append endpoint in `src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs` to validate incoming `CorporateActionDto` payloads before calling `AppendCorporateActionAsync`.
- Introduced `ValidateCorporateAction(CorporateActionDto)` which enforces that `StockSplit` events include `SplitRatio` and that `SplitRatio` is > 0 and <= 1000, and that `Dividend` events do not have negative `DividendPerShare` values.
- The endpoint now returns `400 Bad Request` with a clear error message when a corporate-action payload fails validation.

### Testing
- Performed static verification of the modified route and helper function to ensure validation runs before persistence and that clear messages are returned for invalid payloads.
- No automated unit or integration tests were executed in this change; the patch is minimal and focused on input validation only.
- The patch is limited to `src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs` and does not alter backtest adjustment logic or other flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8a467d488320ab5d157c8b9b2ce3)