### PR TITLE
Validate EffectiveRateCap >= EffectiveRateFloor on direct-lending terms

### DIFF
--- a/src/Meridian.Application/DirectLending/DirectLendingServiceSupport.cs
+++ b/src/Meridian.Application/DirectLending/DirectLendingServiceSupport.cs
@@ -47,6 +47,11 @@ internal static class DirectLendingServiceSupport
             return new DirectLendingCommandError(DirectLendingErrorCode.Validation, "Floating-rate terms require an interest index name.");
         }
 
+        if (terms.EffectiveRateFloor is { } floor && terms.EffectiveRateCap is { } cap && cap < floor)
+        {
+            return new DirectLendingCommandError(DirectLendingErrorCode.Validation, "Effective rate cap must be greater than or equal to the effective rate floor.");
+        }
+
         return null;
     }
 

--- a/src/Meridian.Application/DirectLending/InMemoryDirectLendingService.cs
+++ b/src/Meridian.Application/DirectLending/InMemoryDirectLendingService.cs
@@ -489,6 +489,11 @@ public sealed partial class InMemoryDirectLendingService : IDirectLendingService
         {
             throw new DirectLendingCommandException(new DirectLendingCommandError(DirectLendingErrorCode.Validation, "Floating-rate terms require an interest index name."));
         }
+
+        if (terms.EffectiveRateFloor is { } floor && terms.EffectiveRateCap is { } cap && cap < floor)
+        {
+            throw new DirectLendingCommandException(new DirectLendingCommandError(DirectLendingErrorCode.Validation, "Effective rate cap must be greater than or equal to the effective rate floor."));
+        }
     }
 
     private static LoanTermsVersionDto CreateTermsVersion(

--- a/tests/Meridian.Tests/Application/DirectLendingServiceTests.cs
+++ b/tests/Meridian.Tests/Application/DirectLendingServiceTests.cs
@@ -120,6 +120,38 @@ public sealed class DirectLendingServiceTests
         servicing.LastPaymentDate.Should().Be(new DateOnly(2026, 3, 25));
     }
 
+    [Fact]
+    public async Task CreateLoanAsync_WithEffectiveRateCapBelowFloor_ShouldFailValidation()
+    {
+        var service = new InMemoryDirectLendingService();
+        var request = BuildCreateRequest() with
+        {
+            Terms = BuildTerms(effectiveRateFloor: 0.09m, effectiveRateCap: 0.05m)
+        };
+
+        var act = () => service.CreateLoanAsync(request);
+
+        var ex = await Assert.ThrowsAsync<DirectLendingCommandException>(act);
+        ex.Error.Code.Should().Be(DirectLendingErrorCode.Validation);
+        ex.Error.Message.Should().Contain("Effective rate cap");
+    }
+
+    [Fact]
+    public async Task AmendTermsAsync_WithEffectiveRateCapBelowFloor_ShouldFailValidation()
+    {
+        var service = new InMemoryDirectLendingService();
+        var detail = await service.CreateLoanAsync(BuildCreateRequest());
+        var request = new AmendLoanTermsRequest(
+            BuildTerms(effectiveRateFloor: 0.09m, effectiveRateCap: 0.05m),
+            "invalid bounds");
+
+        var act = () => service.AmendTermsAsync(detail.LoanId, request);
+
+        var ex = await Assert.ThrowsAsync<DirectLendingCommandException>(act);
+        ex.Error.Code.Should().Be(DirectLendingErrorCode.Validation);
+        ex.Error.Message.Should().Contain("Effective rate cap");
+    }
+
     private static CreateLoanRequest BuildCreateRequest(RateTypeKind rateTypeKind = RateTypeKind.Fixed) =>
         new(
             LoanId: Guid.NewGuid(),
@@ -130,7 +162,9 @@ public sealed class DirectLendingServiceTests
 
     private static DirectLendingTermsDto BuildTerms(
         decimal commitmentAmount = 1_000_000m,
-        RateTypeKind rateTypeKind = RateTypeKind.Fixed) =>
+        RateTypeKind rateTypeKind = RateTypeKind.Fixed,
+        decimal? effectiveRateFloor = null,
+        decimal? effectiveRateCap = null) =>
         new(
             OriginationDate: new DateOnly(2026, 3, 22),
             MaturityDate: new DateOnly(2029, 3, 22),
@@ -148,5 +182,7 @@ public sealed class DirectLendingServiceTests
             CommitmentFeeRate: 0.03m,
             DefaultRateSpreadBps: 200m,
             PrepaymentAllowed: true,
-            CovenantsJson: "{\"leverage\": \"<= 4.5x\"}");
+            CovenantsJson: "{\"leverage\": \"<= 4.5x\"}",
+            EffectiveRateFloor: effectiveRateFloor,
+            EffectiveRateCap: effectiveRateCap);
 }


### PR DESCRIPTION
### Motivation
- The daily accrual path now calls `ApplyRateBounds` which throws when `EffectiveRateCap < EffectiveRateFloor`, but `ValidateTerms` did not reject that invalid combination, causing accrual endpoints to surface unhandled `ArgumentException` 500s for affected loans.
- Prevent storing invalid persisted terms so accrual processing does not later fail for a single loan and cause availability/behavior issues.

### Description
- Added a validation check in `DirectLendingServiceSupport.ValidateTerms` that returns a `DirectLendingCommandError` when `EffectiveRateCap` is present and less than `EffectiveRateFloor`.
- Mirrored the same guard in `InMemoryDirectLendingService.ValidateTerms` to keep in-memory service behavior consistent with command validation.
- Added regression tests `CreateLoanAsync_WithEffectiveRateCapBelowFloor_ShouldFailValidation` and `AmendTermsAsync_WithEffectiveRateCapBelowFloor_ShouldFailValidation` in `DirectLendingServiceTests` to ensure invalid bounds fail fast.
- Extended the test helper `BuildTerms` to accept `EffectiveRateFloor` and `EffectiveRateCap` so tests can exercise the new validation.

### Testing
- Added unit tests in `tests/Meridian.Tests/Application/DirectLendingServiceTests.cs` covering create and amend flows with invalid cap/floor bounds; these tests are included in the repo but were not executed in this environment.
- Attempted to run `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~DirectLendingServiceTests"`, but the environment lacks `dotnet` so the test invocation failed with `/bin/bash: dotnet: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8a485720832086f3251a1396c3ff)