### PR TITLE
fix: preserve symbol search cancellation propagation

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/Core/BaseSymbolSearchProvider.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/BaseSymbolSearchProvider.cs
@@ -211,10 +211,10 @@ public abstract class BaseSymbolSearchProvider : IFilterableSymbolSearchProvider
         if (!HasValidCredentials())
             return Array.Empty<SymbolSearchResult>();
 
+        await RateLimiter.WaitForSlotAsync(ct).ConfigureAwait(false);
+
         try
         {
-            await RateLimiter.WaitForSlotAsync(ct).ConfigureAwait(false);
-
             var url = BuildSearchUrl(query, assetType, exchange);
             using var response = await Http.GetAsync(url, ct).ConfigureAwait(false);
 

--- a/tests/Meridian.Tests/Infrastructure/Providers/RobinhoodSymbolSearchProviderTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/RobinhoodSymbolSearchProviderTests.cs
@@ -89,7 +89,7 @@ public sealed class RobinhoodSymbolSearchProviderTests
     }
 
     [Fact]
-    public async Task SearchAsync_WithCancellation_ReturnsEmpty()
+    public async Task SearchAsync_WithCancellation_ThrowsOperationCanceledException()
     {
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
@@ -99,10 +99,9 @@ public sealed class RobinhoodSymbolSearchProviderTests
         using var httpClient = new HttpClient(handler);
         using var provider = new RobinhoodSymbolSearchProvider(httpClient: httpClient);
 
-        // BaseSymbolSearchProvider catches all exceptions (including cancellation) and returns empty
-        var results = await provider.SearchAsync("AAPL", 10, cts.Token);
+        Func<Task> act = () => provider.SearchAsync("AAPL", 10, cts.Token);
 
-        results.Should().BeEmpty();
+        await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- A recent change moved `RateLimiter.WaitForSlotAsync(ct)` inside a broad `try/catch (Exception)`, causing `OperationCanceledException` from caller-supplied cancellation tokens to be swallowed and converted to an empty search result. 
- Restore the prior behavior so cancellations propagate to callers while keeping existing non-cancellation error handling.

### Description
- Move `RateLimiter.WaitForSlotAsync(ct)` back outside the broad `try/catch` in `BaseSymbolSearchProvider.SearchAsync` so cancellation from the rate-limiter wait is not caught and suppressed. 
- Update `tests/Meridian.Tests/Infrastructure/Providers/RobinhoodSymbolSearchProviderTests.cs` to assert that cancellation throws `OperationCanceledException` instead of returning an empty list. 
- The change is minimal and scoped to cancellation semantics only and does not alter non-cancellation error logging or handling.

### Testing
- Attempted to run the focused unit tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~RobinhoodSymbolSearchProviderTests" --logger "console;verbosity=minimal"`, but the environment does not have `dotnet` installed, so the test run could not be executed (`/bin/bash: dotnet: command not found`).
- No automated tests were executed successfully in this environment; the change is limited and covered by the updated unit test which should pass when run in a proper .NET-enabled CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8a46a428832096ed388c0ce99994)