### PR TITLE
fix: remove duplicate case-insensitive CFD asset-class mapping

### DIFF
--- a/src/Meridian.Application/SecurityMaster/SecurityMasterCsvParser.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterCsvParser.cs
@@ -20,7 +20,6 @@ public sealed class SecurityMasterCsvParser
         { "CryptoCurrency", "CryptoCurrency" },
         { "Commodity", "Commodity" },
         { "CFD", "Cfd" },
-        { "Cfd", "Cfd" },
         { "Warrant", "Warrant" },
     };
 


### PR DESCRIPTION
### Motivation
- Prevent a `TypeInitializationException` during `SecurityMasterCsvParser` static initialization caused by duplicate keys that compare equal under `StringComparer.OrdinalIgnoreCase`, which made the security-master CSV import endpoint unavailable.

### Description
- Remove the duplicate `"Cfd"` entry from `AssetClassMapping` in `src/Meridian.Application/SecurityMaster/SecurityMasterCsvParser.cs` while keeping the `"CFD" -> "Cfd"` mapping so case-insensitive CSV inputs remain supported.

### Testing
- Attempted to run the focused import tests via `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~SecurityMasterImportServiceTests"`, but the environment lacks `dotnet` so the automated test run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb889b78b8832092a3cb77feeeb883)