### PR TITLE
Fix false Pass validation for incomplete backfills

### DIFF
--- a/src/Meridian.Application/Backfill/HistoricalBackfillService.cs
+++ b/src/Meridian.Application/Backfill/HistoricalBackfillService.cs
@@ -152,8 +152,18 @@ public sealed class HistoricalBackfillService
                     {
                         _log.Debug("Skipping {Symbol}: fully covered by checkpoint through {LastCompleted}", symbol, lastCompleted);
                         skippedSymbols.Add(symbol);
-                        var checkpointBarCount = checkpointBarCounts is not null && checkpointBarCounts.TryGetValue(symbol, out var cpCount) ? cpCount : 0L;
-                        validationSignals.Add(SymbolValidationSignal.PassSkipped(symbol, checkpointBarCount, lastCompleted));
+                        if (checkpointBarCounts is not null && checkpointBarCounts.TryGetValue(symbol, out var cpCount) && cpCount > 0)
+                        {
+                            validationSignals.Add(SymbolValidationSignal.PassSkipped(symbol, cpCount, lastCompleted));
+                        }
+                        else
+                        {
+                            validationSignals.Add(SymbolValidationSignal.Warn(
+                                symbol,
+                                null,
+                                lastCompleted,
+                                "Checkpoint coverage exists but bar-count evidence is missing; cannot assert completeness."));
+                        }
                         return;
                     }
                     // Advance the start date to the day after the last checkpoint.
@@ -167,6 +177,7 @@ public sealed class HistoricalBackfillService
                     _log.Information("Starting backfill for {Symbol} via {Provider}", symbol, provider.DisplayName);
                 }
 
+                DateOnly? firstBarDate = null;
                 DateOnly? lastBarDate = null;
                 long symbolBars = 0;
                 if (request.Granularity.IsIntraday())
@@ -187,6 +198,8 @@ public sealed class HistoricalBackfillService
                         symbolBars++;
 
                         var barDate = DateOnly.FromDateTime(bar.EndTime.UtcDateTime);
+                        if (firstBarDate is null || barDate < firstBarDate.Value)
+                            firstBarDate = barDate;
                         if (lastBarDate is null || barDate > lastBarDate.Value)
                             lastBarDate = barDate;
                     }
@@ -201,6 +214,8 @@ public sealed class HistoricalBackfillService
                         _metrics.IncHistoricalBars();
                         Interlocked.Increment(ref barsWritten);
                         symbolBars++;
+                        if (firstBarDate is null || bar.SessionDate < firstBarDate.Value)
+                            firstBarDate = bar.SessionDate;
                         if (lastBarDate is null || bar.SessionDate > lastBarDate.Value)
                             lastBarDate = bar.SessionDate;
                     }
@@ -220,8 +235,16 @@ public sealed class HistoricalBackfillService
                 }
 
                 // Emit validation signal.
-                if (symbolBars > 0)
+                var coversRequestedRange =
+                    symbolBars > 0 &&
+                    firstBarDate.HasValue &&
+                    (effectiveFrom is null || firstBarDate.Value <= effectiveFrom.Value) &&
+                    (!request.To.HasValue || (lastBarDate.HasValue && lastBarDate.Value >= request.To.Value));
+
+                if (coversRequestedRange)
                     validationSignals.Add(SymbolValidationSignal.Pass(symbol, symbolBars, effectiveFrom, lastBarDate));
+                else if (symbolBars > 0)
+                    validationSignals.Add(SymbolValidationSignal.Warn(symbol, effectiveFrom, request.To, "Provider returned partial bars that do not cover the requested date range"));
                 else
                     validationSignals.Add(SymbolValidationSignal.Warn(symbol, effectiveFrom, request.To, "Provider returned zero bars for the requested date range"));
             }

--- a/tests/Meridian.Tests/Application/Backfill/ParallelBackfillServiceTests.cs
+++ b/tests/Meridian.Tests/Application/Backfill/ParallelBackfillServiceTests.cs
@@ -921,6 +921,25 @@ public sealed class ParallelBackfillServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task RunAsync_WhenRequestedToIsNotReached_EmitsWarnSignal()
+    {
+        var provider = new ControllableProvider("test", (symbol, from, to, ct) =>
+        {
+            IReadOnlyList<HistoricalBar> bars = [new(symbol, new DateOnly(2024, 1, 2), 1m, 1m, 1m, 1m, 10)];
+            return Task.FromResult(bars);
+        });
+
+        var svc = new HistoricalBackfillService([provider]);
+        var request = new AppBackfillRequest("test", ["SPY"], From: new DateOnly(2024, 1, 1), To: new DateOnly(2024, 1, 31));
+
+        var result = await svc.RunAsync(request, _pipeline);
+
+        var signal = result.SymbolValidationSignals.Should().ContainSingle(s => s.Symbol == "SPY").Which;
+        signal.Status.Should().Be("Warn");
+        signal.Reason.Should().Contain("partial bars");
+    }
+
+    [Fact]
     public async Task RunAsync_FailedSymbol_EmitsFailSignal()
     {
         // Arrange — TSLA always throws
@@ -988,6 +1007,35 @@ public sealed class ParallelBackfillServiceTests : IAsyncLifetime
 
             // AAPL was fetched without a checkpoint-to-request gap: effectiveFrom == original From
             aaplSignal.EffectiveFrom.Should().Be(new DateOnly(2024, 1, 1));
+        }
+        finally
+        {
+            if (Directory.Exists(testRoot))
+                Directory.Delete(testRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_SkippedSymbolWithoutBarCount_EmitsWarnSignal()
+    {
+        var testRoot = Path.Combine(Path.GetTempPath(), $"mdc_sig_{Guid.NewGuid():N}");
+        try
+        {
+            var provider = new ControllableProvider("test", (symbol, ct) =>
+                Task.FromResult<IReadOnlyList<HistoricalBar>>(new[] { MakeBar(symbol) }));
+
+            var checkpointStore = new BackfillStatusStore(testRoot);
+            var toDate = new DateOnly(2024, 1, 31);
+            await checkpointStore.WriteSymbolCheckpointAsync("SPY", toDate);
+
+            var svc = new HistoricalBackfillService([provider], checkpointStore: checkpointStore);
+            var request = new AppBackfillRequest("test", ["SPY"], From: new DateOnly(2024, 1, 1), To: toDate, ResumeFromCheckpoint: true);
+
+            var result = await svc.RunAsync(request, _pipeline);
+
+            var signal = result.SymbolValidationSignals.Should().ContainSingle(s => s.Symbol == "SPY").Which;
+            signal.Status.Should().Be("Warn");
+            signal.Reason.Should().Contain("bar-count evidence is missing");
         }
         finally
         {


### PR DESCRIPTION
### Motivation
- The backfill validation logic marked symbols `Pass` when any bar was returned or when a date-only checkpoint existed without bar-count evidence, which can falsely signal completeness to operators.
- Because provider responses are treated as untrusted, the validator must ensure returned bars actually cover the requested date range and that resume skips have bar-count evidence before claiming `Pass`.

### Description
- Tighten resume/skip handling in `HistoricalBackfillService` so a skipped symbol only yields `PassSkipped` when a positive checkpoint bar-count exists and otherwise emits a `Warn` with an explanatory reason (file: `src/Meridian.Application/Backfill/HistoricalBackfillService.cs`).
- Track both `firstBarDate` and `lastBarDate` for fetched symbols and only emit `Pass` when returned bars cover the requested range (including `To` when provided); emit `Warn` for partial coverage (file: `src/Meridian.Application/Backfill/HistoricalBackfillService.cs`).
- Add focused regression tests exercising partial-provider responses and skipped resumes without sidecar bar-counts (file: `tests/Meridian.Tests/Application/Backfill/ParallelBackfillServiceTests.cs`).

### Testing
- Added unit tests: `RunAsync_WhenRequestedToIsNotReached_EmitsWarnSignal` and `RunAsync_SkippedSymbolWithoutBarCount_EmitsWarnSignal` in `tests/Meridian.Tests/Application/Backfill/ParallelBackfillServiceTests.cs` (not yet executed in this environment).
- Attempted to run the new tests via `dotnet test ...`, but the runner failed because `dotnet` is not available in this execution environment (`/bin/bash: dotnet: command not found`).
- No automated tests were successfully executed here due to the missing runtime; the changes are minimal and covered by the added unit tests for later CI validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d10f8e388320bbd42ce5e8c11a5e)