### PR TITLE
fix: apply mutation rate limiting to reconciliation run POST endpoint

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -282,9 +282,11 @@ public static class WorkstationEndpoints
                 ? Results.NotFound()
                 : Results.Json(detail, jsonOptions);
         })
+        .RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy)
         .WithName("CreateReconciliationRun")
         .Produces<ReconciliationRunDetail>(200)
-        .Produces(404);
+        .Produces(404)
+        .Produces(429);
 
         group.MapGet("/reconciliation/runs/{reconciliationRunId}", async (string reconciliationRunId, HttpContext context) =>
         {


### PR DESCRIPTION
### Motivation
- The shared web UI exposes `POST /api/workstation/reconciliation/runs` which stores full reconciliation details in the default in-memory repository without any throttle, allowing repeated calls to grow process memory and cause availability issues; this change applies the existing mutation limiter to reduce that risk.

### Description
- Add `.RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy)` and document `.Produces(429)` on the `POST /api/workstation/reconciliation/runs` route in `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` so high-frequency mutation requests are throttled while preserving successful-path behavior.

### Testing
- Attempted to run the focused unit tests with `dotnet test ... --filter "FullyQualifiedName~WorkstationEndpointsTests&FullyQualifiedName~Reconciliation"`, but the environment lacks the .NET SDK (`dotnet: command not found`), so automated tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb889ba2fc832080b6c0f5e599603a)