### PR TITLE
fix(pipeline): restore WAL durability boundary in TryPublish

### DIFF
--- a/src/Meridian.Application/Pipeline/EventPipeline.cs
+++ b/src/Meridian.Application/Pipeline/EventPipeline.cs
@@ -443,12 +443,8 @@ public sealed class EventPipeline : IMarketEventPublisher, IBackpressureSignal, 
     /// Returns false if the queue is full (event will be dropped based on FullMode).
     /// </summary>
     /// <remarks>
-    /// WAL writes are deferred to the consumer task to preserve the non-blocking contract of
-    /// this method. Events enqueued via this path carry <c>WalSequence == 0</c>; the consumer
-    /// detects this and appends the event to the WAL before forwarding it to the storage sink,
-    /// maintaining the same durability guarantee as <see cref="PublishAsync"/> at the cost of a
-    /// slightly larger crash-recovery window. Callers that require the event to be WAL-persisted
-    /// before this call returns should use <see cref="PublishAsync"/> instead.
+    /// When WAL is enabled, this method appends the event to the WAL before queue handoff.
+    /// If WAL persistence fails, the event is treated as dropped and the method returns false.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryPublish(in MarketEvent evt)
@@ -466,9 +462,23 @@ public sealed class EventPipeline : IMarketEventPublisher, IBackpressureSignal, 
             return false;
         }
 
-        // Capture trace context synchronously — WAL write is deferred to the consumer.
-        // The consumer checks WalSequence == 0 and appends to the WAL before sink persistence.
-        var tracedEvent = CaptureTraceContext(evt);
+        TracedMarketEvent tracedEvent;
+        try
+        {
+            tracedEvent = PrepareTracedEventForPublishAsync(evt, CancellationToken.None)
+                .AsTask()
+                .GetAwaiter()
+                .GetResult();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to append event to WAL in TryPublish for {EventType}/{Symbol}; event dropped",
+                evt.Type,
+                evt.EffectiveSymbol);
+            RecordDrop(in evt);
+            return false;
+        }
 
         var written = _channel.Writer.TryWrite(tracedEvent);
 


### PR DESCRIPTION
### Motivation
- A recent change deferred WAL persistence from `TryPublish` to the consumer, allowing `TryPublish` to return success before durable WAL persistence and creating a window where accepted events could be lost or a WAL I/O error in the consumer could fault the single consumer and halt persistence. 
- The change restores the original durability contract for hot-path callers that expect `TryPublish` to ensure WAL persistence when WAL is enabled.

### Description
- Updated the `TryPublish` XML remarks to state that when WAL is enabled the method appends to the WAL before queue handoff and will return `false` on WAL failure. 
- Changed `TryPublish` to synchronously call `PrepareTracedEventForPublishAsync(...).GetAwaiter().GetResult()` to obtain a `TracedMarketEvent` that includes a WAL sequence when WAL is configured. 
- Added a `try/catch` around the WAL append path in `TryPublish` that logs the failure, calls `RecordDrop(in evt)`, and returns `false` on WAL errors so callers are not told the event was accepted when it was not durably persisted.

### Testing
- Attempted to run `.NET` test tooling but `dotnet` is not available in the execution environment so no automated `dotnet test` runs were performed (environment limitation). 
- Performed static inspection of `EventPipeline.cs` and grep-based validation to confirm `TryPublish` now invokes `PrepareTracedEventForPublishAsync` synchronously and contains the WAL error handling path. 
- Verified the source diff updates the doc comment and inlined WAL append/exception handling in `TryPublish` and did not modify consumer WAL/commit logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f842b7725c832087cc8d46313b27cf)