### PR TITLE
fix: keep options overwrite Sortino ratio finite

### DIFF
--- a/src/Meridian.Backtesting.Sdk/Strategies/OptionsOverwrite/OptionsOverwriteMetricsCalculator.cs
+++ b/src/Meridian.Backtesting.Sdk/Strategies/OptionsOverwrite/OptionsOverwriteMetricsCalculator.cs
@@ -164,7 +164,7 @@ public static class OptionsOverwriteMetricsCalculator
 
         var downside = dailyReturns.Where(r => r < dailyRfr).ToArray();
         if (downside.Length == 0)
-            return double.PositiveInfinity;
+            return 0.0;
 
         double downsideVariance = downside.Sum(r => (r - dailyRfr) * (r - dailyRfr)) / downside.Length;
         double downsideVol = Math.Sqrt(downsideVariance * TradingDaysPerYear);

--- a/tests/Meridian.Backtesting.Tests/OptionsOverwriteStrategyTests.cs
+++ b/tests/Meridian.Backtesting.Tests/OptionsOverwriteStrategyTests.cs
@@ -480,6 +480,7 @@ public sealed class OptionsOverwriteStrategyTests
             var curve = BuildEquityCurve(100_000m, 252, 0.001); // ~25 % annual return
             var metrics = OptionsOverwriteMetricsCalculator.Calculate([], curve, 0.04);
             metrics.Cagr.Should().BePositive();
+            double.IsFinite(metrics.SortinoRatio).Should().BeTrue();
         }
 
         [Fact]


### PR DESCRIPTION
### Motivation
- Prevent `OptionsOverwriteMetrics` from containing non-finite values (e.g. `double.PositiveInfinity`) for the Sortino ratio which breaks default `System.Text.Json` serialization and downstream consumers.

### Description
- Update `SortinoRatio` in `src/Meridian.Backtesting.Sdk/Strategies/OptionsOverwrite/OptionsOverwriteMetricsCalculator.cs` to return a finite sentinel `0.0` when there are no downside returns instead of `double.PositiveInfinity`.
- Add a focused regression assertion in `tests/Meridian.Backtesting.Tests/OptionsOverwriteStrategyTests.cs` to assert `double.IsFinite(metrics.SortinoRatio)` for a steadily growing equity curve.

### Testing
- Attempted to run the focused tests with `dotnet test tests/Meridian.Backtesting.Tests/Meridian.Backtesting.Tests.csproj --filter "FullyQualifiedName~MetricsCalculatorTests" --logger "console;verbosity=normal"` but the run failed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8a46043083208311fb4718bcc9a1)