### PR TITLE
fix(execution): include Reg T margin debt in margin-call equity

### DIFF
--- a/src/Meridian.Execution/Services/PaperTradingPortfolio.cs
+++ b/src/Meridian.Execution/Services/PaperTradingPortfolio.cs
@@ -296,7 +296,9 @@ public sealed class PaperTradingPortfolio : IMultiAccountPortfolioState
             if (account.MarginModel is null || account.Positions.Count == 0)
                 return MarginCallStatus.NoMarginRequired(accountId);
 
-            var equity = account.Cash + account.LongMarketValue;
+            var marginBorrowed = account.Positions.Values.Sum(static p => p.MarginBorrowed);
+            var effectiveCash = account.Cash - marginBorrowed;
+            var equity = effectiveCash + account.LongMarketValue;
             var posRequirements = new List<MarginRequirement>();
 
             foreach (var (symbol, pos) in account.Positions)
@@ -315,7 +317,7 @@ public sealed class PaperTradingPortfolio : IMultiAccountPortfolioState
                     kv => kv.Value.ToExecutionPosition(),
                     StringComparer.OrdinalIgnoreCase),
                 prices,
-                account.Cash);
+                effectiveCash);
 
             var isCall = portfolioReq.IsMarginCall;
             var deficiency = isCall ? Math.Abs(portfolioReq.ExcessLiquidity) : 0m;

--- a/tests/Meridian.Tests/Execution/PaperTradingPortfolioTests.cs
+++ b/tests/Meridian.Tests/Execution/PaperTradingPortfolioTests.cs
@@ -634,6 +634,21 @@ public sealed class PaperTradingPortfolioMarginRulesTests
     }
 
     [Fact]
+    public void CheckMarginStatus_RegTLongPosition_TriggersMarginCall_WhenLoanConsumesEquity()
+    {
+        var portfolio = BuildRegTPortfolio(10_000m);
+        portfolio.ApplyFill("margin-1", BuildFill("AAPL", OrderSide.Buy, qty: 200, price: 100m));
+
+        var status = portfolio.CheckMarginStatus("margin-1",
+            new Dictionary<string, decimal> { ["AAPL"] = 50m });
+
+        status.IsMarginCall.Should().BeTrue();
+        status.PortfolioRequirement.MaintenanceMargin.Should().Be(2_500m);
+        status.PortfolioRequirement.ExcessLiquidity.Should().Be(-2_500m);
+        status.MarginDeficiency.Should().Be(2_500m);
+    }
+
+    [Fact]
     public void CheckMarginStatus_LongPosition_MarginCall_WhenPricePlumeges()
     {
         // $20 000 cash, buy 200 shares @ $100 on 50 % Reg T margin


### PR DESCRIPTION
### Motivation

- The Reg T flow recorded broker-funded loans in `Position.MarginBorrowed` but margin-status evaluation omitted that liability, causing leveraged long accounts to appear healthier than they are. 
- This could allow under-margined portfolios to escape automated margin-call or liquidation checks because equity was overstated.

### Description

- Subtract outstanding `MarginBorrowed` across positions when computing account cash used for equity by adding `var marginBorrowed = account.Positions.Values.Sum(p => p.MarginBorrowed);` and `var effectiveCash = account.Cash - marginBorrowed`.
- Compute equity as `effectiveCash + account.LongMarketValue` and pass `effectiveCash` into `CalculatePortfolioRequirement` so portfolio-level maintenance/ExcessLiquidity reflects the loan liability.
- Add a focused regression test `CheckMarginStatus_RegTLongPosition_TriggersMarginCall_WhenLoanConsumesEquity` that reproduces the leveraged-long scenario and asserts a margin call and expected deficiency.

### Testing

- Added a unit test in `tests/Meridian.Tests/Execution/PaperTradingPortfolioTests.cs` covering the leveraged Reg T scenario but it was not executed here due to environment limitations. 
- Attempted targeted test run with `dotnet test ... --filter "FullyQualifiedName~CheckMarginStatus_RegTLongPosition_TriggersMarginCall_WhenLoanConsumesEquity"` but the run failed because `dotnet` is not available in this container. 
- No other automated test runs were performed in this environment; the change is localized to `src/Meridian.Execution/Services/PaperTradingPortfolio.cs` and accompanied by the new unit test for CI to validate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4027049083208026cddc836144fa)