### PR TITLE
Sanitize Wave 1 provider-validation summary path metadata

### DIFF
--- a/scripts/dev/run-wave1-provider-validation.ps1
+++ b/scripts/dev/run-wave1-provider-validation.ps1
@@ -184,6 +184,23 @@ $activeProviderRows = @(
     }
 )
 
+
+function Convert-ToSummarySafeText {
+    param(
+        [Parameter(Mandatory=$true)]
+        [AllowEmptyString()]
+        [string]$Text
+    )
+
+    $normalized = $Text
+    if (-not [string]::IsNullOrWhiteSpace($repoRoot)) {
+        $escapedRepoRoot = [Regex]::Escape($repoRoot)
+        $normalized = [Regex]::Replace($normalized, $escapedRepoRoot, '{repo-root}', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    }
+
+    return $normalized
+}
+
 $pilotReplaySampleSet = @(
     [ordered]@{
         id = "DK1-ALPACA-QUOTE-GOLDEN"
@@ -280,6 +297,7 @@ function Invoke-Step {
     $commandText = ($Step.Command | ForEach-Object {
         if ($_ -match '\s') { '"{0}"' -f $_ } else { $_ }
     }) -join ' '
+    $commandText = Convert-ToSummarySafeText -Text $commandText
 
     Write-Host "==> $($Step.Name)"
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
@@ -305,7 +323,7 @@ function Invoke-Step {
         durationSeconds = [Math]::Round($stopwatch.Elapsed.TotalSeconds, 2)
         command = $commandText
         logPath = $logPath.Substring($repoRoot.Length + 1).Replace('\', '/')
-        tail = ($output | Select-Object -Last 20) -join [Environment]::NewLine
+        tail = Convert-ToSummarySafeText -Text (($output | Select-Object -Last 20) -join [Environment]::NewLine)
     }
 }
 
@@ -384,7 +402,7 @@ $summary = [ordered]@{
     dateStamp = $DateStamp
     runId = "wave1-provider-validation-$DateStamp"
     configuration = $Configuration
-    repoRoot = $repoRoot
+    repoRoot = "{repo-root}"
     scope = "Active Wave 1 provider confidence, checkpoint resumability, and Parquet Level 2 flush proof"
     result = if ($failedResults.Count -eq 0) { "passed" } else { "failed" }
     readinessImpact = [ordered]@{


### PR DESCRIPTION
### Motivation
- Prevent accidental disclosure of developer workstation absolute paths and usernames in provider-validation artifacts written under `artifacts/provider-validation` by the Wave 1 validation script. 
- The `run-wave1-provider-validation.ps1` script previously serialized `repoRoot`, step `command` text, and log `tail` output into `wave1-validation-summary.json`, which could contain user-specific absolute Windows paths.

### Description
- Add a `Convert-ToSummarySafeText` helper in `scripts/dev/run-wave1-provider-validation.ps1` that redacts occurrences of the absolute `$repoRoot` with the marker `{repo-root}`. 
- Apply the sanitizer to serialized step `command` strings and step `tail` log snippets so emitted summaries retain diagnostics but not workstation paths. 
- Replace the emitted `repoRoot` property in the generated summary payload with the constant `{repo-root}` to avoid writing an absolute path into the committed JSON. 
- Keep the changes minimal and focused to preserve existing behavior of the validation workflow except for redaction of path metadata.

### Testing
- Performed static verification by inspecting `scripts/dev/run-wave1-provider-validation.ps1` and confirming the sanitizer is defined and applied to `command` and `tail` fields. 
- Verified the summary `repoRoot` field is replaced with `"{repo-root}"` and reviewed the resulting diff produced by the change. 
- Ran repository queries (`rg`, `nl`, `sed`, `git status`) to validate the targeted serialization points were patched successfully and committed. 
- No runtime PowerShell or `dotnet` test execution was performed in this environment; therefore no runtime tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f3f5b338c8320a76c9d259b5e974c)