### PR TITLE
Add guardrails for intraday backfill request size

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/BackfillEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/BackfillEndpoints.cs
@@ -18,6 +18,8 @@ public static class BackfillEndpoints
 {
     // Symbols should be 1-20 uppercase alphanumeric chars, dots, or hyphens
     private static readonly Regex SymbolPattern = new(@"^[A-Za-z0-9.\-]{1,20}$", RegexOptions.Compiled);
+    private const int MaxIntradaySpanDays = 31;
+    private const int MaxIntradaySymbolCount = 10;
 
     /// <summary>
     /// Maps all backfill API endpoints.
@@ -286,6 +288,29 @@ public static class BackfillEndpoints
 
         if (req.To.HasValue && req.To.Value > DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1)))
             return Results.BadRequest(new { error = "To date cannot be in the future." });
+
+        if (request.Granularity.IsIntraday())
+        {
+            if (req.Symbols.Length > MaxIntradaySymbolCount)
+            {
+                return Results.BadRequest(new
+                {
+                    error = $"Intraday backfill supports at most {MaxIntradaySymbolCount} symbols per request."
+                });
+            }
+
+            if (req.From.HasValue && req.To.HasValue)
+            {
+                var spanDays = req.To.Value.DayNumber - req.From.Value.DayNumber + 1;
+                if (spanDays > MaxIntradaySpanDays)
+                {
+                    return Results.BadRequest(new
+                    {
+                        error = $"Intraday backfill date range cannot exceed {MaxIntradaySpanDays} days."
+                    });
+                }
+            }
+        }
 
         try
         {

--- a/tests/Meridian.Tests/Integration/EndpointTests/BackfillEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/BackfillEndpointTests.cs
@@ -189,6 +189,47 @@ public sealed class BackfillEndpointTests
         body.Should().Contain("1 Minute");
     }
 
+    [Fact]
+    public async Task RunBackfill_WithIntradayTooManySymbols_ReturnsBadRequest()
+    {
+        var symbols = Enumerable.Range(1, 11).Select(i => $"SYM{i}").ToArray();
+        var payload = new
+        {
+            Symbols = symbols,
+            Provider = "yahoo",
+            Granularity = "1Min",
+            From = "2026-01-01",
+            To = "2026-01-02"
+        };
+        var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+        var response = await _client.PostAsync("/api/backfill/run", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Intraday backfill supports at most 10 symbols");
+    }
+
+    [Fact]
+    public async Task RunBackfill_WithIntradayRangeExceedingLimit_ReturnsBadRequest()
+    {
+        var payload = new
+        {
+            Symbols = new[] { "SPY" },
+            Provider = "yahoo",
+            Granularity = "1Min",
+            From = "2026-01-01",
+            To = "2026-02-15"
+        };
+        var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+        var response = await _client.PostAsync("/api/backfill/run", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Intraday backfill date range cannot exceed 31 days");
+    }
+
     #endregion
 
     #region POST /api/backfill/run/preview - Validation
@@ -202,6 +243,26 @@ public sealed class BackfillEndpointTests
         var response = await _client.PostAsync("/api/backfill/run/preview", content);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task PreviewBackfill_WithIntradayRangeExceedingLimit_ReturnsBadRequest()
+    {
+        var payload = new
+        {
+            Symbols = new[] { "SPY" },
+            Provider = "yahoo",
+            Granularity = "5Min",
+            From = "2026-01-01",
+            To = "2026-02-15"
+        };
+        var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+        var response = await _client.PostAsync("/api/backfill/run/preview", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Intraday backfill date range cannot exceed 31 days");
     }
 
     #endregion


### PR DESCRIPTION
### Motivation
- Prevent a single authenticated intraday backfill request from expanding into a large number of provider chunk requests and exhausting memory/IO by bounding attacker-controlled inputs.
- Apply minimal, API-layer guardrails so existing provider implementations are preserved while reducing risk from wide intraday windows.

### Description
- Add intraday limits in `BackfillEndpoints`: introduce `MaxIntradaySpanDays = 31` and `MaxIntradaySymbolCount = 10` and enforce them in `ValidateBackfillRequest` for requests where `request.Granularity.IsIntraday()`; these checks run before delegating to `backfill.ValidateRequest` and return clear `400` messages when exceeded (file: `src/Meridian.Ui.Shared/Endpoints/BackfillEndpoints.cs`).
- Preserve existing daily/backfill behavior and provider support checks; the change only restricts intraday request scope at the API boundary.
- Add integration tests that exercise the new validation paths for both `/api/backfill/run` and `/api/backfill/run/preview` to assert rejection when symbol-count or date-span limits are exceeded (file: `tests/Meridian.Tests/Integration/EndpointTests/BackfillEndpointTests.cs`).

### Testing
- Added focused integration tests under `tests/Meridian.Tests/Integration/EndpointTests/BackfillEndpointTests.cs` covering intraday symbol-count and date-range rejections and a preview re-run test, which should pass in CI.
- Attempted to run `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~BackfillEndpointTests"`, but the run failed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).
- Local/CI test run is required to validate the added tests; the change is minimal and targets only input validation at the endpoint layer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb889c6b60832084425eb899dbdbf7)