### PR TITLE
Fix continuation CompileTime telemetry in ScriptRunner

### DIFF
--- a/src/Meridian.QuantScript/Compilation/ScriptRunner.cs
+++ b/src/Meridian.QuantScript/Compilation/ScriptRunner.cs
@@ -135,7 +135,6 @@ public sealed class ScriptRunner : IScriptRunner
         var runtimeDiagnostics = new List<ScriptDiagnostic>();
         ScriptExecutionCheckpoint? nextCheckpoint = checkpoint;
         var runPlotQueue = new PlotQueue();
-        TimeSpan continuationCompileTime = TimeSpan.Zero;
 
         await Task.Run(async () =>
         {
@@ -154,12 +153,9 @@ public sealed class ScriptRunner : IScriptRunner
                 }
                 else
                 {
-                    var continuationCompileWatch = Stopwatch.StartNew();
                     scriptState = await checkpoint.ScriptState
                         .ContinueWithAsync(source, cancellationToken: runCt)
                         .ConfigureAwait(false);
-                    continuationCompileWatch.Stop();
-                    continuationCompileTime = continuationCompileWatch.Elapsed;
                 }
 
                 nextCheckpoint = new ScriptExecutionCheckpoint(scriptState, globals);
@@ -173,12 +169,6 @@ public sealed class ScriptRunner : IScriptRunner
             }
             catch (CompilationErrorException ex)
             {
-                if (checkpoint is not null)
-                {
-                    continuationCompileTime = continuationCompileTime == TimeSpan.Zero
-                        ? wallClock.Elapsed
-                        : continuationCompileTime;
-                }
                 continuationDiagnostics = ex.Diagnostics
                     .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
                     .Select(MapDiagnostic)
@@ -235,9 +225,6 @@ public sealed class ScriptRunner : IScriptRunner
         }
 
         var resultSuccess = runtimeError is null && continuationDiagnostics.Count == 0 && runtimeDiagnostics.Count == 0;
-        if (checkpoint is not null)
-            compileTime = continuationCompileTime;
-
         return new ScriptRunResult(
             Success: resultSuccess,
             Elapsed: wallClock.Elapsed,

--- a/tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs
+++ b/tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs
@@ -341,6 +341,22 @@ public sealed class ScriptRunnerTests
     }
 
     [Fact]
+    public async Task ContinueWithAsync_CompileTime_RemainsZeroWhenRuntimeWorkExists()
+    {
+        var runner = BuildRunner();
+
+        var first = await runner.RunAsync("var x = 41;", NoParams);
+        var second = await runner.ContinueWithAsync(
+            "System.Threading.Thread.Sleep(25); x += 1; Print(x);",
+            first.Checkpoint!,
+            NoParams);
+
+        second.Success.Should().BeTrue();
+        second.CompileTime.Should().Be(TimeSpan.Zero);
+        second.Elapsed.Should().BeGreaterThan(second.CompileTime);
+    }
+
+    [Fact]
     public async Task ContinueWithAsync_CompilationFailure_PreservesPreviousCheckpoint()
     {
         var runner = BuildRunner();


### PR DESCRIPTION
### Motivation
- Continuation runs measured compilation time by timing `ScriptState.ContinueWithAsync`, which performs both compilation and execution, causing execution latency to be misattributed to compile time.
- This produced misleading telemetry and diagnostics for notebook continuation cells without affecting security or script semantics.

### Description
- Removed the continuation-specific `Stopwatch` that wrapped `checkpoint.ScriptState.ContinueWithAsync` so execution time is no longer included in compilation timing.
- Removed fallback logic that assigned a wall-clock-derived value to continuation compile timing on continuation compilation exceptions.
- Kept continuation `CompileTime` behavior consistent with fresh runs by leaving continuation compile time at `TimeSpan.Zero` unless a compiler-provided value is available.
- Added a regression unit test `ContinueWithAsync_CompileTime_RemainsZeroWhenRuntimeWorkExists` to assert that runtime work in a continuation (e.g., `Thread.Sleep`) does not change the reported `CompileTime`.

### Testing
- Added a focused unit test in `tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs` which asserts continuation compile time remains `TimeSpan.Zero` when the continuation body does runtime work; this test is included in the PR.
- Attempted to run the targeted continuation tests via `dotnet test --filter "FullyQualifiedName~ContinueWithAsync"`, but test execution in the automation environment failed because the `dotnet` SDK is not available (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cf41dd4c83208be8c42df9b888eb)