### PR TITLE
Fix LastPersistedOrderUpdateAt calculation to use per-order CreatedAt fallback

### DIFF
--- a/src/Meridian.Execution/Services/PaperSessionPersistenceService.cs
+++ b/src/Meridian.Execution/Services/PaperSessionPersistenceService.cs
@@ -377,11 +377,7 @@ public sealed class PaperSessionPersistenceService
             ? persistedFills.Max(fill => fill.Timestamp)
             : (DateTimeOffset?)null;
         var lastPersistedOrderUpdateAt = persistedOrders.Count > 0
-            ? persistedOrders
-                .Where(order => order.LastUpdatedAt.HasValue)
-                .Select(order => order.LastUpdatedAt!.Value)
-                .DefaultIfEmpty(persistedOrders.Max(order => order.CreatedAt))
-                .Max()
+            ? persistedOrders.Max(order => order.LastUpdatedAt ?? order.CreatedAt)
             : (DateTimeOffset?)null;
         if (_store is not null)
         {

--- a/tests/Meridian.Tests/Execution/PaperSessionPersistenceServiceTests.cs
+++ b/tests/Meridian.Tests/Execution/PaperSessionPersistenceServiceTests.cs
@@ -849,6 +849,46 @@ public sealed class PaperSessionReplayTests : IDisposable
     }
 
     [Fact]
+    public async Task VerifyReplayAsync_WhenLatestOrderHasNoLastUpdatedAt_UsesCreatedAtForTimestamp()
+    {
+        var store = BuildStore();
+        var service = Build(store);
+        var summary = await service.CreateSessionAsync(new CreatePaperSessionDto("strat-order-ts", null, 100_000m, ["AAPL"]));
+
+        var olderUpdatedAt = new DateTimeOffset(2026, 1, 1, 10, 0, 0, TimeSpan.Zero);
+        var newerCreatedAt = olderUpdatedAt.AddHours(2);
+
+        await service.RecordOrderUpdateAsync(summary.SessionId, new OrderState
+        {
+            OrderId = "order-older-updated",
+            Symbol = "AAPL",
+            Side = OrderSide.Buy,
+            Type = OrderType.Market,
+            Quantity = 1m,
+            Status = OrderStatus.Accepted,
+            CreatedAt = olderUpdatedAt.AddMinutes(-10),
+            LastUpdatedAt = olderUpdatedAt
+        });
+
+        await service.RecordOrderUpdateAsync(summary.SessionId, new OrderState
+        {
+            OrderId = "order-newer-created",
+            Symbol = "AAPL",
+            Side = OrderSide.Buy,
+            Type = OrderType.Market,
+            Quantity = 1m,
+            Status = OrderStatus.Accepted,
+            CreatedAt = newerCreatedAt,
+            LastUpdatedAt = null
+        });
+
+        var verification = await service.VerifyReplayAsync(summary.SessionId);
+
+        verification.Should().NotBeNull();
+        verification!.LastPersistedOrderUpdateAt.Should().Be(newerCreatedAt);
+    }
+
+    [Fact]
     public async Task VerifyReplayAsync_WhenPersistedOrderHistoryDiffers_ReturnsMismatchWithCounts()
     {
         await using var auditTrail = new ExecutionAuditTrailService(


### PR DESCRIPTION
### Motivation
- The prior replay verification logic computed `LastPersistedOrderUpdateAt` by only considering `LastUpdatedAt` values and falling back to the maximum `CreatedAt` only when no `LastUpdatedAt` existed, which can under-report the latest persisted order activity when newer orders lack `LastUpdatedAt`.
- The intent is to ensure replay evidence reports the true latest persisted order time by treating each order's timestamp as `LastUpdatedAt ?? CreatedAt` before taking the maximum.

### Description
- Update `VerifyReplayAsync` in `src/Meridian.Execution/Services/PaperSessionPersistenceService.cs` to compute `LastPersistedOrderUpdateAt` as `persistedOrders.Max(order => order.LastUpdatedAt ?? order.CreatedAt)`.
- Add a regression unit test `VerifyReplayAsync_WhenLatestOrderHasNoLastUpdatedAt_UsesCreatedAtForTimestamp` to `tests/Meridian.Tests/Execution/PaperSessionPersistenceServiceTests.cs` that exercises the mixed-case (older order with `LastUpdatedAt`, newer order with only `CreatedAt`).
- The change is minimal and preserves existing behavior for stores with no orders while ensuring correct timestamps when orders have nullable `LastUpdatedAt`.

### Testing
- A targeted unit test was added (`VerifyReplayAsync_WhenLatestOrderHasNoLastUpdatedAt_UsesCreatedAtForTimestamp`) to cover the reported scenario and assert the newer `CreatedAt` is used.
- I attempted to run the specific test with `dotnet test --filter "FullyQualifiedName~VerifyReplayAsync_WhenLatestOrderHasNoLastUpdatedAt_UsesCreatedAtForTimestamp"`, but the execution environment lacks the `dotnet` SDK so the test could not be executed here (command failed with `dotnet: command not found`).
- The fix is implemented as a straightforward LINQ expression change and the added test encodes the expected behavior for CI to validate on a proper .NET environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cf4200a883208047a288e095399d)