### PR TITLE
Stop write-on-read: make `ScoreAsync` side-effect free and add regression test

### DIFF
--- a/src/Meridian.Storage/Services/DataQualityService.cs
+++ b/src/Meridian.Storage/Services/DataQualityService.cs
@@ -70,7 +70,6 @@ public sealed class DataQualityService : IDataQualityService
         );
 
         _scoreCache[path] = score;
-        await PersistTrendPointAsync(path, score, ct);
         return score;
     }
 
@@ -332,19 +331,6 @@ public sealed class DataQualityService : IDataQualityService
 
         _trendCache[cacheKey] = trend;
         return trend;
-    }
-
-    private async Task PersistTrendPointAsync(string path, DataQualityScore score, CancellationToken ct)
-    {
-        var point = new QualityTrendPoint(
-            Symbol: ExtractSymbol(path),
-            Date: DateOnly.FromDateTime(score.EvaluatedAt.UtcDateTime.Date),
-            Provider: ExtractProvider(path),
-            ScoredAt: score.EvaluatedAt,
-            OverallScore: score.OverallScore,
-            DimensionScores: score.Dimensions.ToDictionary(d => d.Name, d => d.Score, StringComparer.OrdinalIgnoreCase));
-
-        await _trendStore.AppendAsync(point, ct);
     }
 
     private static Dictionary<string, double> AverageDimensions(IEnumerable<QualityTrendPoint> points)

--- a/tests/Meridian.Tests/Application/Monitoring/QualityTrendCalculationTests.cs
+++ b/tests/Meridian.Tests/Application/Monitoring/QualityTrendCalculationTests.cs
@@ -8,6 +8,32 @@ namespace Meridian.Tests.Application.Monitoring;
 public sealed class QualityTrendCalculationTests
 {
     [Fact]
+    public async Task ScoreAsync_DoesNotPersistTrendPoints()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"meridian-quality-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        var filePath = Path.Combine(tempRoot, "sample.jsonl");
+        await File.WriteAllTextAsync(filePath, "{\"symbol\":\"AAPL\",\"timestamp\":\"2026-01-01T00:00:00Z\",\"price\":100}\n");
+
+        try
+        {
+            var store = new InMemoryQualityTrendStore(Array.Empty<QualityTrendPoint>());
+            var sut = new DataQualityService(new StorageOptions { RootPath = tempRoot }, trendStore: store);
+
+            _ = await sut.ScoreAsync(filePath);
+
+            store.AppendCount.Should().Be(0);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public async Task GetTrendAsync_ImprovingFixture_ReportsImprovingDimensionsAndPositiveSlope()
     {
         var now = DateTimeOffset.UtcNow;
@@ -100,6 +126,7 @@ public sealed class QualityTrendCalculationTests
     private sealed class InMemoryQualityTrendStore : IQualityTrendStore
     {
         private readonly List<QualityTrendPoint> _points;
+        public int AppendCount { get; private set; }
 
         public InMemoryQualityTrendStore(IEnumerable<QualityTrendPoint> points)
         {
@@ -108,6 +135,7 @@ public sealed class QualityTrendCalculationTests
 
         public Task AppendAsync(QualityTrendPoint point, CancellationToken ct = default)
         {
+            AppendCount++;
             _points.Add(point);
             return Task.CompletedTask;
         }


### PR DESCRIPTION
### Motivation
- Read-only endpoints (`/api/storage/quality/*`, provider explainability) invoked `ScoreAsync` which unconditionally persisted a trend point, allowing repeated GETs to append unbounded rows to `quality/trend-points.jsonl` and corrupt/expand telemetry.
- Remove this write-on-read behavior so scoring and source-ranking remain safe for GET-backed flows and cannot be used to amplify writes.

### Description
- Removed the unconditional call to the trend persistence path from `DataQualityService.ScoreAsync`, keeping scoring read-only and preserving the existing `_scoreCache` behavior.
- Deleted the now-unused `PersistTrendPointAsync` helper that appended `QualityTrendPoint` records on every score operation.
- Added a regression test `ScoreAsync_DoesNotPersistTrendPoints` in `tests/Meridian.Tests/Application/Monitoring/QualityTrendCalculationTests.cs` to assert that calling `ScoreAsync` does not append to the trend store.
- Extended the in-memory test `IQualityTrendStore` implementation with an `AppendCount` counter to make the assertion explicit and prevent regressions.

### Testing
- Attempted to run the focused unit tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~QualityTrendCalculationTests" --logger "console;verbosity=normal"`, but the execution environment lacks the .NET SDK (`dotnet: command not found`), so automated test execution could not be performed here.
- Existing test-suite references and the new regression test were added to the repository so CI or a local developer with the .NET SDK can run the full unit tests (`make test` / `dotnet test`) to validate behavior in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb86a9598c832092fcd59109017260)