### PR TITLE
Dashboard: bind health banner and operational tiles to live status

### DIFF
--- a/src/Meridian.Wpf/ViewModels/DashboardViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/DashboardViewModel.cs
@@ -175,7 +175,7 @@ public sealed class DashboardViewModel : BindableBase, IDisposable, IPageActionB
     private string _currentThroughputText = "--";
     public string CurrentThroughputText { get => _currentThroughputText; private set => SetProperty(ref _currentThroughputText, value); }
 
-    private string _dataHealthText = "--";
+    private string _dataHealthText = "Awaiting live status";
     public string DataHealthText { get => _dataHealthText; private set => SetProperty(ref _dataHealthText, value); }
 
     private Brush _dataHealthForeground;
@@ -701,6 +701,11 @@ public sealed class DashboardViewModel : BindableBase, IDisposable, IPageActionB
         else
         {
             DroppedRateText = "0.00%";
+            DataHealthText = "100.0%";
+            DataQualityText = "100.0%";
+            DataHealthForeground = _successBrush;
+            DataHealthIconGlyph = _iconSuccess;
+            DataHealthIconForeground = _successBrush;
         }
 
         IntegrityRateText = $"{status.Integrity} gaps";
@@ -752,8 +757,44 @@ public sealed class DashboardViewModel : BindableBase, IDisposable, IPageActionB
 
         LastUpdateText = $"Last update: {DateTime.Now:HH:mm:ss}";
         LastDataUpdateText = $"Last update: {DateTime.Now:HH:mm:ss}";
+
+        UpdateOperationalMetricsFromLiveStatus(status);
+        UpdatePortfolioServiceStatuses(status);
+
     }
 
+
+    private void UpdateOperationalMetricsFromLiveStatus(SimpleStatus status)
+    {
+        if (OperationsMetrics.Count < 8)
+        {
+            return;
+        }
+
+        OperationsMetrics[0].Value = PublishedCount;
+        OperationsMetrics[0].Detail = $"Provider: {SelectedDataSourceText}";
+        OperationsMetrics[1].Value = DroppedCount;
+        OperationsMetrics[1].Detail = $"Drop rate {DroppedRateText}";
+        OperationsMetrics[2].Value = IntegrityCount;
+        OperationsMetrics[2].Detail = IntegrityRateText;
+        OperationsMetrics[3].Value = DateTime.Now.ToString("HH:mm:ss");
+        OperationsMetrics[3].Detail = LastUpdateText.Replace("Last update: ", string.Empty, StringComparison.Ordinal);
+    }
+
+    private void UpdatePortfolioServiceStatuses(SimpleStatus status)
+    {
+        var connected = status.Provider?.IsConnected == true;
+        var state = connected ? "connected" : "disconnected";
+        var stateBrush = connected ? _successBrush : _errorBrush;
+        for (var i = 0; i < PortfolioDataServiceStatuses.Count; i++)
+        {
+            if (PortfolioDataServiceStatuses[i].ServiceName.Contains("Pricing", StringComparison.OrdinalIgnoreCase))
+            {
+                PortfolioDataServiceStatuses[i].State = state;
+                PortfolioDataServiceStatuses[i].StatusBrush = stateBrush;
+            }
+        }
+    }
     private void UpdateStaleIndicator(bool isStale)
     {
         if (_statusService.SecondsSinceLastUpdate is { } seconds)

--- a/src/Meridian.Wpf/Views/DashboardPage.xaml
+++ b/src/Meridian.Wpf/Views/DashboardPage.xaml
@@ -319,15 +319,15 @@
 
                         <StackPanel Grid.Column="0">
                             <StackPanel Orientation="Horizontal">
-                                <Ellipse Width="9" Height="9" Fill="{StaticResource SuccessColorBrush}" VerticalAlignment="Center" />
-                                <TextBlock Text="Holdings and data-quality controls current"
+                                <Ellipse Width="9" Height="9" Fill="{Binding DataHealthForeground}" VerticalAlignment="Center" />
+                                <TextBlock Text="{Binding DataHealthText}"
                                            Style="{StaticResource BodyStrongTextBlockStyle}"
                                            Margin="8,0,0,0" />
                             </StackPanel>
-                            <TextBlock Text="Pricing coverage current · Security master checks clear · Ledger export ready · Reference data synchronized"
+                            <TextBlock Text="{Binding LastUpdateText}"
                                        FontFamily="{StaticResource MeridianDataFontFamily}"
                                        FontSize="12"
-                                       Foreground="{StaticResource ConsoleTextSecondaryBrush}"
+                                       Foreground="{Binding LastUpdateForeground}"
                                        Margin="17,6,0,0" />
                         </StackPanel>
 


### PR DESCRIPTION
### Motivation
- Fix a regression where the dashboard UI showed seeded/demo-only healthy state and a hard-coded success banner that could mask real telemetry and outages. 
- Restore an operator-facing monitoring surface that reflects live provider/collector status and data-health instead of static copy. 

### Description
- Replaced static footer copy in `src/Meridian.Wpf/Views/DashboardPage.xaml` with bindings to `DataHealthText`, `DataHealthForeground`, `LastUpdateText`, and `LastUpdateForeground` so the health banner reflects live ViewModel state. 
- Adjusted `DashboardViewModel` defaults so `DataHealthText` is meaningful before live updates and ensured the zero-drop case sets explicit health text/foreground and icons. 
- Added `UpdateOperationalMetricsFromLiveStatus` and `UpdatePortfolioServiceStatuses` in `src/Meridian.Wpf/ViewModels/DashboardViewModel.cs` and call them from `ApplyLiveStatus` to refresh `OperationsMetrics` and pricing service badge state from incoming `SimpleStatus`. 

### Testing
- Attempted to run the focused WPF dashboard smoke tests with `dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter "FullyQualifiedName~DashboardPageSmokeTests" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true`, but the environment lacked the `dotnet` tool resulting in `/bin/bash: dotnet: command not found`. 
- No other automated test runs were executed in this environment due to the missing .NET SDK tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cd198d988320b1909aa6a3e59989)