### PR TITLE
Harden DK1 trust-gate contract validation for malformed packets

### DIFF
--- a/src/Meridian.Ui.Shared/Services/Dk1TrustGateReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/Dk1TrustGateReadinessService.cs
@@ -422,6 +422,11 @@ public sealed class Dk1TrustGateReadinessService
 
         if (string.Equals(contract.Status, "validated", StringComparison.OrdinalIgnoreCase))
         {
+            if (!IsContractPayloadComplete(contract))
+            {
+                blockers.Add($"DK1 {label} contract is validated but missing required contract fields.");
+            }
+
             return;
         }
 
@@ -429,6 +434,28 @@ public sealed class Dk1TrustGateReadinessService
             ? $": missing {string.Join(", ", contract.MissingRequirements)}"
             : ".";
         blockers.Add($"DK1 {label} contract is {contract.Status}{missing}");
+    }
+
+    private static bool IsContractPayloadComplete(TradingTrustGateContractReadinessDto contract)
+    {
+        if (string.IsNullOrWhiteSpace(contract.DocumentPath))
+        {
+            return false;
+        }
+
+        if (contract.ContractId == "trust-rationale")
+        {
+            return contract.RequiredPayloadFields.Count > 0 &&
+                   contract.RequiredReasonCodes.Count > 0;
+        }
+
+        if (contract.ContractId == "baseline-threshold")
+        {
+            return contract.RequiredMetrics.Count > 0 &&
+                   contract.FpFnReviewRequired.HasValue;
+        }
+
+        return true;
     }
 
     private static IReadOnlyList<TradingTrustGateSampleReviewDto> ReadSampleReviews(JsonElement? element)

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -1384,6 +1384,49 @@ public sealed class WorkstationEndpointsTests
     }
 
     [Fact]
+    public async Task Dk1TrustGateReadinessService_WithValidatedContractMissingRequiredFields_ShouldBlockReview()
+    {
+        var automationRoot = Path.Combine(
+            Path.GetTempPath(),
+            "meridian-tests",
+            "dk1-malformed-contract-packet",
+            Guid.NewGuid().ToString("N"));
+        WriteReadyDk1Packet(
+            automationRoot,
+            """
+            {
+              "requiredOwners": [ "Data Operations", "Provider Reliability", "Trading" ],
+              "status": "signed",
+              "requiredBeforeDk1Exit": true,
+              "signedOwners": [ "Data Operations", "Provider Reliability", "Trading" ],
+              "missingOwners": []
+            }
+            """,
+            includeContractReview: false);
+
+        var packetPath = Path.Combine(automationRoot, "unit-ready", "dk1-pilot-parity-packet.json");
+        var malformedPacket = File.ReadAllText(packetPath).Replace(
+            "\"operatorSignoff\":",
+            """
+            "trustRationaleContract": { "status": "validated" },
+            "baselineThresholdContract": { "status": "validated" },
+            "operatorSignoff":
+            """);
+        File.WriteAllText(packetPath, malformedPacket);
+
+        var service = new Dk1TrustGateReadinessService(
+            new Dk1TrustGateReadinessOptions(automationRoot),
+            NullLogger<Dk1TrustGateReadinessService>.Instance);
+
+        var readiness = await service.GetCurrentAsync();
+
+        readiness.ReadyForOperatorReview.Should().BeTrue();
+        readiness.OperatorSignoffStatus.Should().Be("signed");
+        readiness.Blockers.Should().Contain("DK1 explainability contract is validated but missing required contract fields.");
+        readiness.Blockers.Should().Contain("DK1 calibration contract is validated but missing required contract fields.");
+    }
+
+    [Fact]
     public async Task MapWorkstationEndpoints_WithSecurityLookup_ShouldExposeSecurityCoverageInBootstrapPayloads()
     {
         await using var app = await CreateAppAsync(services =>


### PR DESCRIPTION
### Motivation
- Prevent a malformed or tampered DK1 parity packet from bypassing the trust-gate by claiming `status: "validated"` while omitting required contract payload fields. 
- Ensure readiness is only reported Ready when contract payload contents meet minimal contract-specific expectations, not just the packet-provided status.

### Description
- Update `Dk1TrustGateReadinessService` to verify validated contracts include required content by adding `IsContractPayloadComplete(...)` and invoking it from `AddContractBlocker` so `status == "validated"` no longer auto-passes without required fields. 
- `IsContractPayloadComplete` requires a non-empty `documentPath` and enforces contract-specific presence: `trust-rationale` must have `RequiredPayloadFields` and `RequiredReasonCodes`, and `baseline-threshold` must have `RequiredMetrics` and an explicit `FpFnReviewRequired` flag. 
- Add a regression test `Dk1TrustGateReadinessService_WithValidatedContractMissingRequiredFields_ShouldBlockReview` which writes a malformed packet where both contracts declare `"validated"` but omit required fields and asserts blockers are produced. 
- Modified files: `src/Meridian.Ui.Shared/Services/Dk1TrustGateReadinessService.cs` and `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs`.

### Testing
- Added a focused unit test `Dk1TrustGateReadinessService_WithValidatedContractMissingRequiredFields_ShouldBlockReview` that reproduces the malformed-packet scenario and asserts expected blockers are present. 
- Attempted to run the targeted test via `dotnet test` but the execution environment lacked the .NET SDK (`/bin/bash: dotnet: command not found`), so the new test was not executed here. 
- The change was implemented by code inspection and a defensive regression test was included to validate behavior in CI or a local environment with `dotnet` available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb889c233c8320a55a6d83c0635023)