### PR TITLE
Fix DK1 sign-off binding to current packet output

### DIFF
--- a/scripts/dev/generate-dk1-pilot-parity-packet.ps1
+++ b/scripts/dev/generate-dk1-pilot-parity-packet.ps1
@@ -220,14 +220,13 @@ function Test-ApprovedDecision {
     return @("approved", "signed", "complete", "completed") -contains $Decision.Trim().ToLowerInvariant()
 }
 
-function Get-ExistingPacketReview {
-    param([Parameter(Mandatory)][string]$Path)
+function Get-PacketReview {
+    param(
+        [Parameter(Mandatory)][object]$Packet,
+        [Parameter(Mandatory)][string]$Path
+    )
 
-    if (-not (Test-Path -LiteralPath $Path)) {
-        return $null
-    }
-
-    $packet = Get-Content -Raw -LiteralPath $Path | ConvertFrom-Json
+    $packet = $Packet
     $sampleReview = Get-ObjectPropertyValue -Object $packet -Name "sampleReview"
     $requiredSampleCountValue = Get-ObjectPropertyValue -Object $sampleReview -Name "requiredCount"
     $requiredSampleCount = if ($null -ne $requiredSampleCountValue) { [int]$requiredSampleCountValue } else { 0 }
@@ -669,20 +668,7 @@ foreach ($doc in $incompleteDocs) {
 $packetStatus = if ($blockers.Count -eq 0) { "ready-for-operator-review" } else { "blocked" }
 $jsonPath = Join-Path $summaryDir "dk1-pilot-parity-packet.json"
 $mdPath = Join-Path $summaryDir "dk1-pilot-parity-packet.md"
-$reviewedPacket = Get-ExistingPacketReview -Path $jsonPath
-$operatorSignoff = Get-OperatorSignoffPacket `
-    -Path $OperatorSignoffPath `
-    -RequiredOwners $requiredOperatorOwners `
-    -ExpectedPacketReview $reviewedPacket
-
 $packetGeneratedAtUtc = (Get-Date).ToUniversalTime().ToString("O")
-if ($operatorSignoff.validForDk1Exit -and $null -ne $operatorSignoff.packetReview) {
-    $reviewedGeneratedAtUtc = Get-ObjectPropertyValue -Object $operatorSignoff.packetReview -Name "generatedAtUtc"
-    $reviewedGeneratedAtUtcText = [string]$reviewedGeneratedAtUtc
-    if (-not [string]::IsNullOrWhiteSpace($reviewedGeneratedAtUtcText)) {
-        $packetGeneratedAtUtc = $reviewedGeneratedAtUtc
-    }
-}
 
 $packet = [ordered]@{
     generatedAtUtc = $packetGeneratedAtUtc
@@ -728,9 +714,16 @@ $packet = [ordered]@{
         missingRequirements = $thresholdContractMissingRequirements
     }
     evidenceDocuments = @($docReviews)
-    operatorSignoff = $operatorSignoff
+    operatorSignoff = $null
     blockers = @($blockers)
 }
+
+$expectedPacketReview = Get-PacketReview -Packet $packet -Path $jsonPath
+$operatorSignoff = Get-OperatorSignoffPacket `
+    -Path $OperatorSignoffPath `
+    -RequiredOwners $requiredOperatorOwners `
+    -ExpectedPacketReview $expectedPacketReview
+$packet.operatorSignoff = $operatorSignoff
 
 if (Test-MeridianCheckpointStepShouldRun -Context $checkpoint -StepId "write-dk1-packet-json") {
     Start-MeridianCheckpointStep -Context $checkpoint -StepId "write-dk1-packet-json" -Description "Write DK1 pilot parity packet JSON."


### PR DESCRIPTION
### Motivation
- Prevent a stale-binding integrity flaw where operator sign-offs were validated against a previously written on-disk `dk1-pilot-parity-packet.json` instead of the packet produced in the current run, which could allow a prior approval to be reapplied to changed evidence.

### Description
- Replace the prior-on-disk review flow by adding `Get-PacketReview` which computes the expected packet review from the in-memory `packet` instead of reading a historical file.
- Assemble the `packet` first, derive `ExpectedPacketReview` from that in-memory object, then call `Get-OperatorSignoffPacket` to validate sign-off and attach the result to the final packet written to `dk1-pilot-parity-packet.json` in `scripts/dev/generate-dk1-pilot-parity-packet.ps1`.
- Remove the previous behavior that could overwrite the newly generated packet's `generatedAtUtc` from values embedded in the sign-off payload to preserve current-run timestamp integrity.
- Change is limited to `scripts/dev/generate-dk1-pilot-parity-packet.ps1` and keeps the existing output JSON shape while hardening binding semantics.

### Testing
- Ran `python3 -m unittest tests.scripts.test_generate_dk1_pilot_parity_packet -v`, and the test module executed with both tests skipped because the environment lacks `pwsh` (result: `OK (skipped=2)`).
- Verified the script no longer reads a prior `dk1-pilot-parity-packet.json` to compute `ExpectedPacketReview` and that `operatorSignoff` is computed against the in-memory packet prior to writing the final JSON.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb86a9a8988320bf2796c3ba22771a)