### PR TITLE
Scope reconciliation calibration summary to selected fund runs

### DIFF
--- a/src/Meridian.Wpf/Services/FundReconciliationWorkbenchService.cs
+++ b/src/Meridian.Wpf/Services/FundReconciliationWorkbenchService.cs
@@ -78,8 +78,10 @@ public sealed class FundReconciliationWorkbenchService : IFundReconciliationWork
         var runNames = relevantRuns.ToDictionary(run => run.RunId, run => run.StrategyName, StringComparer.OrdinalIgnoreCase);
 
         var breakQueue = await breakQueueTask.ConfigureAwait(false);
-        var breakQueueItems = breakQueue
+        var scopedBreakQueue = breakQueue
             .Where(item => runIds.Contains(item.RunId))
+            .ToArray();
+        var breakQueueItems = scopedBreakQueue
             .Select(item => MapBreakQueueRow(item, runNames))
             .OrderBy(static item => GetBreakQueuePriority(item.Status))
             .ThenByDescending(item => item.Variance)
@@ -92,17 +94,18 @@ public sealed class FundReconciliationWorkbenchService : IFundReconciliationWork
             .ThenByDescending(item => item.SecurityIssueCount)
             .ThenByDescending(item => item.RequestedAt)
             .ToArray();
-        var calibrationProfiles = calibrationSummary?.Profiles
+        var scopedCalibrationSummary = BuildCalibrationSummary(scopedBreakQueue, calibrationSummary);
+        var calibrationProfiles = scopedCalibrationSummary.Profiles
             .Select(MapCalibrationProfileRow)
             .OrderByDescending(item => item.PendingSignoffCount)
             .ThenByDescending(item => item.ActiveBreakCount)
             .ThenBy(item => item.ToleranceProfileId, StringComparer.OrdinalIgnoreCase)
             .ThenBy(item => item.ExceptionRoute, StringComparer.OrdinalIgnoreCase)
-            .ToArray() ?? [];
+            .ToArray();
 
         return new FundReconciliationWorkbenchSnapshot(
             Summary: summary,
-            CalibrationSummary: calibrationSummary,
+            CalibrationSummary: scopedCalibrationSummary,
             CalibrationProfiles: calibrationProfiles,
             BreakQueueItems: breakQueueItems,
             RunRows: runRows,
@@ -202,6 +205,75 @@ public sealed class FundReconciliationWorkbenchService : IFundReconciliationWork
             ct);
     }
 
+
+    private static ReconciliationCalibrationSummaryDto BuildCalibrationSummary(
+        IReadOnlyList<ReconciliationBreakQueueItem> items,
+        ReconciliationCalibrationSummaryDto? baseline)
+    {
+        var asOf = baseline?.AsOf ?? DateTimeOffset.UtcNow;
+        var totalBreakCount = items.Count;
+        var openBreakCount = items.Count(static item => item.Status == ReconciliationBreakQueueStatus.Open);
+        var inReviewBreakCount = items.Count(static item => item.Status == ReconciliationBreakQueueStatus.InReview);
+        var resolvedBreakCount = items.Count(static item => item.Status == ReconciliationBreakQueueStatus.Resolved);
+        var dismissedBreakCount = items.Count(static item => item.Status == ReconciliationBreakQueueStatus.Dismissed);
+        var activeBreakCount = openBreakCount + inReviewBreakCount;
+        var criticalOpenBreakCount = items.Count(static item =>
+            item.Severity == ReconciliationBreakSeverity.Critical &&
+            (item.Status == ReconciliationBreakQueueStatus.Open || item.Status == ReconciliationBreakQueueStatus.InReview));
+        var pendingSignoffCount = items.Count(static item =>
+            string.Equals(item.SignoffStatus, "Pending", StringComparison.OrdinalIgnoreCase));
+        var signedOffCount = items.Count(static item =>
+            string.Equals(item.SignoffStatus, "SignedOff", StringComparison.OrdinalIgnoreCase));
+        var missingCalibrationMetadataCount = items.Count(static item =>
+            string.IsNullOrWhiteSpace(item.ExceptionRoute) ||
+            string.IsNullOrWhiteSpace(item.ToleranceProfileId));
+
+        var profiles = items
+            .GroupBy(static item => (
+                ToleranceProfileId: string.IsNullOrWhiteSpace(item.ToleranceProfileId) ? "unassigned-profile" : item.ToleranceProfileId!,
+                ExceptionRoute: string.IsNullOrWhiteSpace(item.ExceptionRoute) ? "operations-triage" : item.ExceptionRoute!))
+            .Select(group => new ReconciliationCalibrationProfileSummaryDto(
+                ToleranceProfileId: group.Key.ToleranceProfileId,
+                ExceptionRoute: group.Key.ExceptionRoute,
+                HighestSeverity: group.Max(static item => item.Severity),
+                MaxToleranceBand: group.Max(static item => item.ToleranceBand),
+                TotalBreakCount: group.Count(),
+                OpenBreakCount: group.Count(static item => item.Status == ReconciliationBreakQueueStatus.Open),
+                InReviewBreakCount: group.Count(static item => item.Status == ReconciliationBreakQueueStatus.InReview),
+                ResolvedBreakCount: group.Count(static item => item.Status == ReconciliationBreakQueueStatus.Resolved),
+                DismissedBreakCount: group.Count(static item => item.Status == ReconciliationBreakQueueStatus.Dismissed),
+                PendingSignoffCount: group.Count(static item => string.Equals(item.SignoffStatus, "Pending", StringComparison.OrdinalIgnoreCase)),
+                SignedOffCount: group.Count(static item => string.Equals(item.SignoffStatus, "SignedOff", StringComparison.OrdinalIgnoreCase)),
+                LastUpdatedAt: group.Max(static item => item.LastUpdatedAt)))
+            .OrderByDescending(static profile => profile.HighestSeverity)
+            .ThenBy(static profile => profile.ToleranceProfileId, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static profile => profile.ExceptionRoute, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var status = criticalOpenBreakCount > 0
+            ? ReconciliationCalibrationStatusDto.Blocked
+            : pendingSignoffCount > 0 || missingCalibrationMetadataCount > 0
+                ? ReconciliationCalibrationStatusDto.ReviewRequired
+                : ReconciliationCalibrationStatusDto.Ready;
+
+        var summary = $"{activeBreakCount:N0} active break(s) across {profiles.Length:N0} calibration profile(s); {pendingSignoffCount:N0} pending sign-off, {missingCalibrationMetadataCount:N0} missing metadata.";
+
+        return new ReconciliationCalibrationSummaryDto(
+            AsOf: asOf,
+            Status: status,
+            Summary: summary,
+            TotalBreakCount: totalBreakCount,
+            ActiveBreakCount: activeBreakCount,
+            OpenBreakCount: openBreakCount,
+            InReviewBreakCount: inReviewBreakCount,
+            ResolvedBreakCount: resolvedBreakCount,
+            DismissedBreakCount: dismissedBreakCount,
+            CriticalOpenBreakCount: criticalOpenBreakCount,
+            PendingSignoffCount: pendingSignoffCount,
+            SignedOffCount: signedOffCount,
+            MissingCalibrationMetadataCount: missingCalibrationMetadataCount,
+            Profiles: profiles);
+    }
     private static FundReconciliationBreakQueueRow MapBreakQueueRow(
         ReconciliationBreakQueueItem item,
         IReadOnlyDictionary<string, string> runNames)


### PR DESCRIPTION
### Motivation
- Prevent cross-fund information disclosure where the WPF fund reconciliation workbench previously displayed global calibration profile aggregates alongside fund-scoped break rows. 
- The host endpoint returns unscoped calibration aggregates, so the workbench must avoid rendering global profiles for a single-fund view. 
- Apply a minimal client-side change that keeps displayed data scoped to the selected `fundProfileId` without changing host APIs.

### Description
- In `FundReconciliationWorkbenchService.GetSnapshotAsync`, break queue entries are now filtered once into `scopedBreakQueue` containing only runs for the selected `fundProfileId` and reused for all subsequent derivations. 
- Added `BuildCalibrationSummary(IReadOnlyList<ReconciliationBreakQueueItem> items, ReconciliationCalibrationSummaryDto? baseline)` to compute calibration totals, status, missing-metadata counts, and per-profile rollups from the scoped items. 
- Replaced use of `calibrationSummary.Profiles` with `scopedCalibrationSummary` and map profiles from that scoped summary so calibration profiles/counts are fund-scoped.

### Testing
- Attempted to run the focused WPF tests with `dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter "FullyQualifiedName~FundLedgerViewModelTests" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger "console;verbosity=minimal"`, but the run failed in this environment because `dotnet` is not installed (error: `/bin/bash: dotnet: command not found`). 
- No automated tests were successfully executed in this container; the change is intentionally small and localized to `src/Meridian.Wpf/Services/FundReconciliationWorkbenchService.cs` to make focused test runs straightforward in a full-development environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb86a92f348320b07a04d25a07f221)