### PR TITLE
Fix strategy workflow lookup in research shell

### DIFF
--- a/src/Meridian.Wpf/Services/ResearchWorkspaceShellPresentationService.cs
+++ b/src/Meridian.Wpf/Services/ResearchWorkspaceShellPresentationService.cs
@@ -456,7 +456,8 @@ public sealed class ResearchWorkspaceShellPresentationService
                 .ConfigureAwait(false);
 
             return summary.Workspaces.FirstOrDefault(static workspace =>
-                string.Equals(workspace.WorkspaceId, "research", StringComparison.OrdinalIgnoreCase));
+                string.Equals(workspace.WorkspaceId, "strategy", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(workspace.WorkspaceId, "research", StringComparison.OrdinalIgnoreCase));
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {


### PR DESCRIPTION
### Motivation
- The workspace migration emits Strategy summaries with `WorkspaceId = "strategy"` but the WPF presentation service still filtered for `"research"`, causing live Strategy workflow state to be ignored and a stale fallback to be shown.

### Description
- Update `GetResearchWorkflowSummaryAsync` in `src/Meridian.Wpf/Services/ResearchWorkspaceShellPresentationService.cs` to prefer `WorkspaceId == "strategy"` while still accepting the legacy `"research"` id for compatibility.

### Testing
- Attempted to run the focused WPF test slice with `dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter "FullyQualifiedName~ResearchWorkspaceShellPageTests" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true`, but the run could not execute because `dotnet` is not installed in this environment (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cf4201e88320951aa196cad80774)