### PR TITLE
Fail desktop screenshot workflow on partial capture failures

### DIFF
--- a/scripts/dev/run-desktop-workflow.ps1
+++ b/scripts/dev/run-desktop-workflow.ps1
@@ -1475,9 +1475,10 @@ try {
             throw 'Capture stage failed: no screenshots were captured successfully.'
         }
         elseif ($captureFailed -gt 0) {
-            $captureStage.status = 'partial'
+            $captureStage.status = 'failed'
             $captureStage.errors = @("Failed steps: $captureFailed")
-            $stageStatuses['capture'] = 'partial'
+            $stageStatuses['capture'] = 'failed'
+            throw "Capture stage failed: $captureFailed step(s) failed."
         }
         else {
             $captureStage.status = 'succeeded'


### PR DESCRIPTION
### Motivation
- Ensure the desktop screenshot workflow surfaces partial capture failures as an actual error so CI/docs-refresh runs cannot silently succeed when one or more screenshot steps fail, restoring the previous fail-fast gate behavior.

### Description
- Update `scripts/dev/run-desktop-workflow.ps1` so the capture branch for `($captureFailed -gt 0)` sets the stage status to `failed`, updates `$stageStatuses['capture']` to `failed`, and `throw`s an error (`throw "Capture stage failed: $captureFailed step(s) failed."`) instead of marking the stage `partial` and continuing.

### Testing
- Performed a targeted source review and inspected the change with `git diff` and `nl` to validate the modified lines in `scripts/dev/run-desktop-workflow.ps1`; the change was committed with message `Fail desktop workflow when any capture step fails` (no runtime PowerShell execution was performed in this Linux environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ab0ec4888320b6652df878148736)