### PR TITLE
Add bounds for workflow preset persistence

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -147,7 +147,16 @@ public static partial class WorkstationEndpoints
                 return Results.Problem("Workflow preset service is not registered.", statusCode: StatusCodes.Status501NotImplemented);
             }
 
-            var result = await service.SaveAsync(request, context.RequestAborted).ConfigureAwait(false);
+            WorkflowPresetMutationResult result;
+            try
+            {
+                result = await service.SaveAsync(request, context.RequestAborted).ConfigureAwait(false);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+
             return result.Success
                 ? Results.Json(result.Preset, jsonOptions)
                 : Results.BadRequest(new { error = result.Error });
@@ -168,9 +177,18 @@ public static partial class WorkstationEndpoints
                 return Results.Problem("Workflow preset service is not registered.", statusCode: StatusCodes.Status501NotImplemented);
             }
 
-            var result = await service
-                .SaveAsync(request with { PresetId = presetId }, context.RequestAborted)
-                .ConfigureAwait(false);
+            WorkflowPresetMutationResult result;
+            try
+            {
+                result = await service
+                    .SaveAsync(request with { PresetId = presetId }, context.RequestAborted)
+                    .ConfigureAwait(false);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+
             return result.Success
                 ? Results.Json(result.Preset, jsonOptions)
                 : Results.BadRequest(new { error = result.Error });

--- a/src/Meridian.Ui.Shared/Workflows/WorkflowPresetService.cs
+++ b/src/Meridian.Ui.Shared/Workflows/WorkflowPresetService.cs
@@ -7,6 +7,12 @@ namespace Meridian.Ui.Shared.Workflows;
 /// </summary>
 public sealed class WorkflowPresetService
 {
+    private const int MaxPresets = 250;
+    private const int MaxPresetIdLength = 128;
+    private const int MaxNameLength = 120;
+    private const int MaxDescriptionLength = 1024;
+    private const int MaxTagLength = 64;
+
     private readonly IWorkflowActionCatalog _catalog;
     private readonly IWorkflowPresetStore _store;
 
@@ -43,6 +49,11 @@ public sealed class WorkflowPresetService
             var presetId = NormalizePresetId(request.PresetId, request.Name);
             var list = current.ToList();
             var index = list.FindIndex(preset => string.Equals(preset.PresetId, presetId, StringComparison.OrdinalIgnoreCase));
+            if (index < 0 && list.Count >= MaxPresets)
+            {
+                throw new InvalidOperationException($"Workflow preset limit ({MaxPresets}) has been reached.");
+            }
+
             var existing = index >= 0 ? list[index] : null;
             saved = BuildPreset(request, presetId, existing, now);
 
@@ -159,6 +170,26 @@ public sealed class WorkflowPresetService
             return "Workflow id is required.";
         }
 
+        if (request.Name.Trim().Length > MaxNameLength)
+        {
+            return $"Preset name cannot exceed {MaxNameLength} characters.";
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.PresetId) && request.PresetId.Trim().Length > MaxPresetIdLength)
+        {
+            return $"Preset id cannot exceed {MaxPresetIdLength} characters.";
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Description) && request.Description.Trim().Length > MaxDescriptionLength)
+        {
+            return $"Preset description cannot exceed {MaxDescriptionLength} characters.";
+        }
+
+        if ((request.Tags ?? []).Any(static tag => !string.IsNullOrWhiteSpace(tag) && tag.Trim().Length > MaxTagLength))
+        {
+            return $"Preset tags cannot exceed {MaxTagLength} characters.";
+        }
+
         var workflow = FindWorkflow(request.WorkflowId);
         if (workflow is null)
         {
@@ -235,7 +266,7 @@ public sealed class WorkflowPresetService
             .Split('-', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
         return string.IsNullOrWhiteSpace(normalized)
             ? $"workflow-preset-{Guid.NewGuid():N}"
-            : normalized;
+            : normalized[..Math.Min(normalized.Length, MaxPresetIdLength)];
     }
 
     private static string? NormalizeOptional(string? value)
@@ -248,6 +279,7 @@ public sealed class WorkflowPresetService
         => (tags ?? [])
             .Select(static tag => tag.Trim())
             .Where(static tag => !string.IsNullOrWhiteSpace(tag))
+            .Select(tag => tag.Length <= MaxTagLength ? tag : tag[..MaxTagLength])
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(static tag => tag, StringComparer.OrdinalIgnoreCase)
             .Take(16)

--- a/tests/Meridian.Tests/Ui/WorkflowLibraryEndpointTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkflowLibraryEndpointTests.cs
@@ -166,6 +166,70 @@ public sealed class WorkflowLibraryEndpointTests
     }
 
     [Fact]
+    public async Task MapWorkstationEndpoints_WorkflowPresets_ShouldRejectOversizedPayloadFields()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "meridian-tests", "workflow-presets", Guid.NewGuid().ToString("N"));
+        await using var app = await CreateWorkflowPresetAppAsync(root);
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/api/workstation/workflows/presets",
+            new WorkflowPresetSaveRequest(
+                PresetId: new string('p', 129),
+                Name: "Valid name",
+                Description: null,
+                WorkflowId: "data-provider-recovery",
+                ActionId: null,
+                Tags: [],
+                IsPinned: false),
+            ServerJsonOptions);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("cannot exceed 128");
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_WorkflowPresets_ShouldRejectNewPresetWhenLimitReached()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "meridian-tests", "workflow-presets", Guid.NewGuid().ToString("N"));
+        await using var app = await CreateWorkflowPresetAppAsync(root);
+        var client = app.GetTestClient();
+
+        for (var i = 0; i < 250; i++)
+        {
+            var saveResponse = await client.PostAsJsonAsync(
+                "/api/workstation/workflows/presets",
+                new WorkflowPresetSaveRequest(
+                    PresetId: $"preset-{i}",
+                    Name: $"Preset {i}",
+                    Description: null,
+                    WorkflowId: "data-provider-recovery",
+                    ActionId: null,
+                    Tags: [],
+                    IsPinned: false),
+                ServerJsonOptions);
+            saveResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        var overflowResponse = await client.PostAsJsonAsync(
+            "/api/workstation/workflows/presets",
+            new WorkflowPresetSaveRequest(
+                PresetId: "preset-overflow",
+                Name: "Preset overflow",
+                Description: null,
+                WorkflowId: "data-provider-recovery",
+                ActionId: null,
+                Tags: [],
+                IsPinned: false),
+            ServerJsonOptions);
+
+        overflowResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await overflowResponse.Content.ReadAsStringAsync();
+        body.Should().Contain("limit (250)");
+    }
+
+    [Fact]
     public async Task FileWorkflowPresetStore_LoadAsync_ShouldHonorCancellation()
     {
         var root = Path.Combine(Path.GetTempPath(), "meridian-tests", "workflow-presets", Guid.NewGuid().ToString("N"));


### PR DESCRIPTION
### Motivation
- Prevent an unauthenticated-but-authorized caller from consuming unbounded disk, memory, and CPU by repeatedly saving arbitrarily large workflow presets to the single JSON snapshot. 

### Description
- Add length and count limits in `WorkflowPresetService`: `MaxPresets = 250`, `MaxPresetIdLength = 128`, `MaxNameLength = 120`, `MaxDescriptionLength = 1024`, and `MaxTagLength = 64`. 
- Enforce the preset count limit inside `SaveAsync` and return validation failures when payload fields exceed configured maxima. 
- Cap normalized preset id length in `NormalizePresetId` and truncate oversized tags in `NormalizeTags`. 
- Surface `InvalidOperationException` caused by limit violations as HTTP `400 BadRequest` in the POST/PUT endpoints in `WorkstationEndpoints.cs`. 
- Add regression tests in `tests/Meridian.Tests/Ui/WorkflowLibraryEndpointTests.cs` to verify oversized-field rejection and rejection when the preset limit is reached. 

### Testing
- Added tests `MapWorkstationEndpoints_WorkflowPresets_ShouldRejectOversizedPayloadFields` and `MapWorkstationEndpoints_WorkflowPresets_ShouldRejectNewPresetWhenLimitReached` to `tests/Meridian.Tests/Ui/WorkflowLibraryEndpointTests.cs` but did not run them locally due to environment limitations. 
- Attempted to run `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~WorkflowLibraryEndpointTests" --logger "console;verbosity=minimal"` but the container reported `dotnet: command not found`, so automated test execution could not be completed here. 
- The change is limited and localized to `src/Meridian.Ui.Shared/Workflows/WorkflowPresetService.cs`, `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs`, and the corresponding test file. Git commit contains these edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17471295008320a36c65701b1cb501)