### PR TITLE
Harden desktop workflow executable path resolution

### DIFF
--- a/scripts/dev/run-desktop-workflow.ps1
+++ b/scripts/dev/run-desktop-workflow.ps1
@@ -80,49 +80,6 @@ function Get-ConfigBool {
     return $Fallback
 }
 
-function Resolve-DesktopExecutablePath {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$PreferredPath,
-        [Parameter(Mandatory = $true)]
-        [string]$ProjectPath,
-        [Parameter(Mandatory = $true)]
-        [string]$Configuration,
-        [Parameter(Mandatory = $true)]
-        [string]$ExeName
-    )
-
-    if (Test-Path -LiteralPath $PreferredPath -PathType Leaf) {
-        return [System.IO.Path]::GetFullPath($PreferredPath)
-    }
-
-    $projectDirectory = Split-Path -Parent $ProjectPath
-    $projectRoot = if ([System.IO.Path]::IsPathRooted($projectDirectory)) {
-        [System.IO.Path]::GetFullPath($projectDirectory)
-    }
-    else {
-        [System.IO.Path]::GetFullPath((Join-Path $repoRoot $projectDirectory))
-    }
-
-    $configurationRoot = Join-Path $projectRoot "bin/$Configuration"
-    if (-not (Test-Path -LiteralPath $configurationRoot -PathType Container)) {
-        return [System.IO.Path]::GetFullPath($PreferredPath)
-    }
-
-    $candidates = @(
-        Get-ChildItem -LiteralPath $configurationRoot -Filter $ExeName -Recurse -File -ErrorAction SilentlyContinue |
-            Sort-Object LastWriteTimeUtc -Descending
-    )
-
-    if ($candidates.Count -gt 0) {
-        $resolvedCandidate = [System.IO.Path]::GetFullPath($candidates[0].FullName)
-        Write-Warn "Expected desktop executable path '$PreferredPath' was not found; using discovered binary '$resolvedCandidate'."
-        return $resolvedCandidate
-    }
-
-    return [System.IO.Path]::GetFullPath($PreferredPath)
-}
-
 function Get-MeridianWindowFromProcess {
     param(
         [System.Diagnostics.Process]$Process
@@ -918,7 +875,6 @@ New-Item -ItemType Directory -Force -Path $runDirectory, $logDirectory, $screens
 $stdoutPath = Join-Path $logDirectory 'stdout.log'
 $stderrPath = Join-Path $logDirectory 'stderr.log'
 $exePath = Get-MeridianProjectBinaryPath -RepoRoot $repoRoot -ProjectPath $resolvedProjectPath -Configuration $resolvedConfiguration -Framework $resolvedFramework -BinaryName $resolvedExeName -IsolationKey $buildIsolationKey
-$exePath = Resolve-DesktopExecutablePath -PreferredPath $exePath -ProjectPath $resolvedProjectPath -Configuration $resolvedConfiguration -ExeName $resolvedExeName
 $manifest = [ordered]@{
     workflow = [ordered]@{
         name = $workflowDefinition.name


### PR DESCRIPTION
### Motivation
- Prevent a pre-build fallback resolver from allowing a stale or attacker-planted non-isolated `bin/<Configuration>` executable to be launched instead of the intended isolated build output. 
- Preserve the build-isolation mechanism by keeping the launcher tied to the isolation-aware path produced by `Get-MeridianProjectBinaryPath`.

### Description
- Removed the `Resolve-DesktopExecutablePath` fallback function from `scripts/dev/run-desktop-workflow.ps1` that recursively searched `bin/<Configuration>` for an executable. 
- Removed the pre-build call that replaced `$exePath` with the discovered non-isolated candidate so `$exePath` now remains the isolation-aware path returned by `Get-MeridianProjectBinaryPath`.
- Kept the rest of the build and launch flow unchanged so the isolated `dotnet build` still writes to the intended `artifacts/bin/<isolation-key>/...` output.

### Testing
- Verified the change with `git diff` to confirm the resolver function and its call site were removed. (succeeded)
- Ran repository searches (`rg`) and file inspections (`nl`) to confirm the call site and function no longer exist. (succeeded)
- Attempted a PowerShell syntax parse with `pwsh` but the environment lacks `pwsh`, so a formal parse check could not be executed in this container. (skipped)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ab10f9b88320aec5b46781aaf99f)