### PR TITLE
Require fund node check in fund account traversal to prevent data leakage

### DIFF
--- a/src/Meridian.Application/FundStructure/FundAccountTraversalQueryService.cs
+++ b/src/Meridian.Application/FundStructure/FundAccountTraversalQueryService.cs
@@ -39,6 +39,11 @@ public sealed class FundAccountTraversalQueryService : IFundAccountTraversalQuer
     private async Task<IReadOnlyList<AccountSummaryDto>> BuildSnapshotAsync(Guid fundId, CancellationToken ct)
     {
         var graph = await _fundStructureService.GetOrganizationStructureAsync(new OrganizationStructureQuery(), ct).ConfigureAwait(false);
+        if (!graph.Funds.Any(fund => fund.FundId == fundId))
+        {
+            return Array.Empty<AccountSummaryDto>();
+        }
+
         var accountNodeIds = graph.OwnershipLinks
             .Where(link => link.ParentNodeId == fundId)
             .Where(link => link.RelationshipType == OwnershipRelationshipTypeDto.Owns)

--- a/tests/Meridian.Tests/Application/FundStructure/FundAccountTraversalQueryServiceTests.cs
+++ b/tests/Meridian.Tests/Application/FundStructure/FundAccountTraversalQueryServiceTests.cs
@@ -37,6 +37,41 @@ public sealed class FundAccountTraversalQueryServiceTests
     }
 
     [Fact]
+    public async Task NonFundNodeWithOwnsLink_ReturnsNoAccounts()
+    {
+        var fundId = Guid.NewGuid();
+        var nonFundNodeId = Guid.NewGuid();
+        var account = CreateAccount(Guid.NewGuid(), fundId, AccountTypeDto.Bank, true, "Sensitive");
+
+        var graph = BuildGraph(new[] { fundId }, new[] { account }) with
+        {
+            Clients = new[]
+            {
+                new ClientSummaryDto(
+                    nonFundNodeId,
+                    Guid.Empty,
+                    "CLIENT-1",
+                    "Client",
+                    null,
+                    true,
+                    DateTimeOffset.UtcNow,
+                    null,
+                    Array.Empty<Guid>())
+            },
+            OwnershipLinks = new[]
+            {
+                new OwnershipLinkDto(Guid.NewGuid(), nonFundNodeId, account.AccountId, OwnershipRelationshipTypeDto.Owns, null, true, DateTimeOffset.UtcNow, null, null)
+            }
+        };
+
+        var service = CreateSut(graph);
+
+        var result = await service.GetFundAccountsAsync(nonFundNodeId, AccountTypeDto.Bank, activeOnly: true);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task MixedStates_ActiveOnlyFiltersSuspendedAndClosed()
     {
         var fundId = Guid.NewGuid();


### PR DESCRIPTION
### Motivation
- The `/api/funds/{fundId}/accounts` traversal previously accepted any GUID and followed `Owns` links, which could return account summaries (including custodian/bank details) for non-fund node IDs.
- The change closes an access-control gap by ensuring only bona fide Fund nodes are used for fund-scoped account discovery.

### Description
- Added a guard in `FundAccountTraversalQueryService.BuildSnapshotAsync` to return an empty result when the requested `fundId` is not present in `graph.Funds` before evaluating `OwnershipLinks` traversal (`src/Meridian.Application/FundStructure/FundAccountTraversalQueryService.cs`).
- Added a regression unit test `NonFundNodeWithOwnsLink_ReturnsNoAccounts` to ensure a non-fund node with an `Owns` link does not return account summaries (`tests/Meridian.Tests/Application/FundStructure/FundAccountTraversalQueryServiceTests.cs`).
- The change is minimal and preserves existing filtering behavior for account type and active status in `GetFundAccountsAsync`.

### Testing
- Added the unit test `NonFundNodeWithOwnsLink_ReturnsNoAccounts` covering the regression scenario and existing fund-account filters; this test is expected to pass in CI or a local .NET environment when run against the modified code using `dotnet test`.
- Attempted to run `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~FundAccountTraversalQueryServiceTests"`, but the execution environment lacked `dotnet` and the command failed with `dotnet: command not found` (no automated run could be completed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f3f5b8d4c8320837a7ee5d4ef4a45)