### PR TITLE
Fix preflight replay indexing for default BySymbol storage layout

### DIFF
--- a/src/Meridian.Application/Backtesting/BacktestPreflightService.cs
+++ b/src/Meridian.Application/Backtesting/BacktestPreflightService.cs
@@ -10,6 +10,17 @@ namespace Meridian.Application.Backtesting;
 public sealed class BacktestPreflightService : IBacktestPreflightService
 {
     private static readonly string[] KnownReplayDataTypes = ["bars", "quotes", "book", "trades"];
+    private static readonly Dictionary<string, string> ReplayDataTypeAliases = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["bars"] = "bars",
+        ["historicalbar"] = "bars",
+        ["quotes"] = "quotes",
+        ["bboquote"] = "quotes",
+        ["book"] = "book",
+        ["l2snapshot"] = "book",
+        ["trades"] = "trades",
+        ["trade"] = "trades"
+    };
 
     public Task<BacktestPreflightReportV2Dto> RunAsync(BacktestPreflightRequestDto request, CancellationToken ct = default)
     {
@@ -138,20 +149,7 @@ public sealed class BacktestPreflightService : IBacktestPreflightService
 
         foreach (var file in Directory.EnumerateFiles(dataRoot, "*.jsonl*", SearchOption.AllDirectories))
         {
-            var name = Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(file));
-            var tokens = name.Split(['_', '.'], StringSplitOptions.RemoveEmptyEntries);
-            if (tokens.Length < 3)
-                continue;
-
-            var symbol = tokens[0].Trim().ToUpperInvariant();
-            if (!symbolSet.Contains(symbol))
-                continue;
-
-            var type = tokens[1].Trim().ToLowerInvariant();
-            if (!KnownReplayDataTypes.Contains(type))
-                continue;
-
-            if (!DateOnly.TryParse(tokens[2], out var date))
+            if (!TryParseReplayFile(file, dataRoot, symbolSet, out var symbol, out var type, out var date))
                 continue;
 
             if (date < from || date > to)
@@ -169,6 +167,64 @@ public sealed class BacktestPreflightService : IBacktestPreflightService
         }
 
         return dict;
+    }
+
+    private static bool TryParseReplayFile(string file, string dataRoot, HashSet<string> symbolSet, out string symbol, out string type, out DateOnly date)
+    {
+        symbol = string.Empty;
+        type = string.Empty;
+        date = default;
+
+        var relativePath = Path.GetRelativePath(dataRoot, file);
+        var pathTokens = relativePath.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries);
+        if (pathTokens.Length >= 3)
+        {
+            var bySymbolCandidate = pathTokens[0].Trim().ToUpperInvariant();
+            var bySymbolTypeToken = pathTokens[1].Trim();
+            var bySymbolDateToken = Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(pathTokens[^1]));
+            if (symbolSet.Contains(bySymbolCandidate) &&
+                TryNormalizeReplayType(bySymbolTypeToken, out var bySymbolType) &&
+                DateOnly.TryParse(bySymbolDateToken, out var bySymbolDate))
+            {
+                symbol = bySymbolCandidate;
+                type = bySymbolType;
+                date = bySymbolDate;
+                return true;
+            }
+        }
+
+        var name = Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(file));
+        var tokens = name.Split(['_', '.'], StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length < 3)
+            return false;
+
+        var flatSymbol = tokens[0].Trim().ToUpperInvariant();
+        if (!symbolSet.Contains(flatSymbol))
+            return false;
+
+        if (!TryNormalizeReplayType(tokens[1], out var flatType))
+            return false;
+
+        if (!DateOnly.TryParse(tokens[2], out var flatDate))
+            return false;
+
+        symbol = flatSymbol;
+        type = flatType;
+        date = flatDate;
+        return true;
+    }
+
+    private static bool TryNormalizeReplayType(string rawType, out string normalizedType)
+    {
+        normalizedType = string.Empty;
+        if (string.IsNullOrWhiteSpace(rawType))
+            return false;
+
+        var compactType = rawType.Trim().Replace("_", string.Empty, StringComparison.Ordinal).ToLowerInvariant();
+        if (!ReplayDataTypeAliases.TryGetValue(compactType, out normalizedType))
+            return false;
+
+        return true;
     }
 
     private static string[] ResolveRequiredTypes(IReadOnlyList<string>? requestedTypes, string? executionModel)

--- a/tests/Meridian.Backtesting.Tests/BacktestPreflightServiceTests.cs
+++ b/tests/Meridian.Backtesting.Tests/BacktestPreflightServiceTests.cs
@@ -104,6 +104,31 @@ public sealed class BacktestPreflightServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task RunAsync_OrderBookExecution_WithBySymbolStorageLayout_IsCompatible()
+    {
+        Directory.CreateDirectory(Path.Combine(_dataRoot, "AAPL", "HistoricalBar"));
+        Directory.CreateDirectory(Path.Combine(_dataRoot, "AAPL", "BboQuote"));
+        Directory.CreateDirectory(Path.Combine(_dataRoot, "AAPL", "Trade"));
+        Directory.CreateDirectory(Path.Combine(_dataRoot, "AAPL", "L2Snapshot"));
+        File.WriteAllText(Path.Combine(_dataRoot, "AAPL", "HistoricalBar", "2024-01-03.jsonl"), "{}\n");
+        File.WriteAllText(Path.Combine(_dataRoot, "AAPL", "BboQuote", "2024-01-03.jsonl"), "{}\n");
+        File.WriteAllText(Path.Combine(_dataRoot, "AAPL", "Trade", "2024-01-03.jsonl"), "{}\n");
+        File.WriteAllText(Path.Combine(_dataRoot, "AAPL", "L2Snapshot", "2024-01-03.jsonl"), "{}\n");
+
+        var sut = new BacktestPreflightService();
+        var report = await sut.RunAsync(new BacktestPreflightRequestDto(
+            From: new DateOnly(2024, 1, 1),
+            To: new DateOnly(2024, 1, 31),
+            DataRoot: _dataRoot,
+            Symbols: ["AAPL"],
+            RequiredExecutionModel: "OrderBook"));
+
+        report.IsReadyToRun.Should().BeTrue();
+        report.Checks.Should().Contain(c => c.Name == "Execution Model Compatibility" && c.Status == BacktestPreflightCheckStatusDto.Passed);
+        report.Checks.Should().Contain(c => c.Name == "Replay Coverage" && c.Status == BacktestPreflightCheckStatusDto.Passed);
+    }
+
+    [Fact]
     public async Task RunAsync_Cancelled_ThrowsOperationCanceledException()
     {
         var sut = new BacktestPreflightService();


### PR DESCRIPTION
### Motivation
- The preflight replay coverage indexer only recognized flat filenames like `SYMBOL_type_date.jsonl` and a small set of simplified aliases, which skipped valid files stored using the repository default `BySymbol` layout (`{root}/{symbol}/{type}/{date}.jsonl`).
- Stored event type names are produced from `evt.Type.ToString()` (e.g. `HistoricalBar`, `BboQuote`, `L2Snapshot`, `Trade`) and did not match the new simplified aliases, causing false missing-coverage warnings and hard failures for `OrderBook` execution.
- The intent is to restore compatibility with existing storage naming while preserving the preflight trust-gate semantics (including the `book` requirement for `OrderBook`).

### Description
- Added a normalization map `ReplayDataTypeAliases` to map storage event-type names (`HistoricalBar`, `BboQuote`, `L2Snapshot`, `Trade`, etc.) to preflight buckets (`bars`, `quotes`, `book`, `trades`) in `BacktestPreflightService`.
- Replaced the filename-only parsing in `IndexReplayData` with a new `TryParseReplayFile` helper that accepts both the default `BySymbol` directory layout (`SYMBOL/Type/date.jsonl`) and flat filename layouts (`SYMBOL_type_date.jsonl`).
- Implemented `TryNormalizeReplayType` to canonicalize raw type tokens (case, underscores) and resolve them via `ReplayDataTypeAliases` before indexing.
- Added a regression test `RunAsync_OrderBookExecution_WithBySymbolStorageLayout_IsCompatible` in `tests/Meridian.Backtesting.Tests/BacktestPreflightServiceTests.cs` that creates `BySymbol`-organized files and verifies `OrderBook` preflight compatibility passes.

### Testing
- A targeted test run was attempted with `dotnet test --filter "FullyQualifiedName~BacktestPreflightServiceTests"`, but the execution environment lacks the .NET SDK (`dotnet: command not found`), so automated tests could not be executed here.
- A new unit test was added at `tests/Meridian.Backtesting.Tests/BacktestPreflightServiceTests.cs:RunAsync_OrderBookExecution_WithBySymbolStorageLayout_IsCompatible` to cover the default storage layout scenario.
- Changes touch `src/Meridian.Application/Backtesting/BacktestPreflightService.cs` (indexing and normalization) and the test file; the fix is minimal and focused on parsing/indexing logic so existing trust-gate behavior is preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb889b8e9083208b38deff8ea40e68)