### PR TITLE
Harden closed-account write policy against client-supplied backfill flag

### DIFF
--- a/src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs
+++ b/src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs
@@ -278,7 +278,7 @@ public sealed class InMemoryFundAccountService : IFundAccountService, IAccountMa
         {
             if (_accounts.TryGetValue(request.AccountId, out var stored))
             {
-                EnsureAllowed(stored.Summary, "record-balance-snapshot", request.IsBackfill);
+                EnsureAllowed(stored.Summary, "record-balance-snapshot");
                 stored.Snapshots.Add(dto);
                 snapshot = CaptureSnapshotLocked();
             }
@@ -348,7 +348,7 @@ public sealed class InMemoryFundAccountService : IFundAccountService, IAccountMa
         {
             if (_accounts.TryGetValue(request.AccountId, out var stored))
             {
-                EnsureAllowed(stored.Summary, "ingest-custodian-statement", request.IsBackfill, allowSuspended: true);
+                EnsureAllowed(stored.Summary, "ingest-custodian-statement", allowSuspended: true);
                 stored.CustodianBatches.Add(batch);
                 UpsertCustodianPositions(stored.CustodianPositions, request.Lines);
                 snapshot = CaptureSnapshotLocked();
@@ -378,7 +378,7 @@ public sealed class InMemoryFundAccountService : IFundAccountService, IAccountMa
         {
             if (_accounts.TryGetValue(request.AccountId, out var stored))
             {
-                EnsureAllowed(stored.Summary, "ingest-bank-statement", request.IsBackfill, allowSuspended: true);
+                EnsureAllowed(stored.Summary, "ingest-bank-statement", allowSuspended: true);
                 stored.BankBatches.Add(batch);
                 UpsertBankStatementLines(stored.BankLines, request.Lines);
                 snapshot = CaptureSnapshotLocked();

--- a/tests/Meridian.Tests/Application/FundAccounts/FundAccountServiceTests.cs
+++ b/tests/Meridian.Tests/Application/FundAccounts/FundAccountServiceTests.cs
@@ -351,16 +351,15 @@ public sealed class FundAccountServiceTests
     }
 
     [Theory]
-    [InlineData(AccountOperationalStatusDto.Active, false, false)]
-    [InlineData(AccountOperationalStatusDto.Suspended, false, true)]
-    [InlineData(AccountOperationalStatusDto.Closed, false, true)]
-    [InlineData(AccountOperationalStatusDto.Closed, true, false)]
-    public async Task RecordBalanceSnapshot_EnforcesOperationalStatus(AccountOperationalStatusDto status, bool isBackfill, bool shouldFail)
+    [InlineData(AccountOperationalStatusDto.Active, false)]
+    [InlineData(AccountOperationalStatusDto.Suspended, true)]
+    [InlineData(AccountOperationalStatusDto.Closed, true)]
+    public async Task RecordBalanceSnapshot_EnforcesOperationalStatus(AccountOperationalStatusDto status, bool shouldFail)
     {
         var svc = CreateService();
         var account = await svc.CreateAccountAsync(MakeBankRequest() with { OperationalStatus = status });
         var action = () => svc.RecordBalanceSnapshotAsync(new RecordAccountBalanceSnapshotRequest(
-            account.AccountId, DateOnly.FromDateTime(DateTime.Today), "USD", 100m, "Manual", IsBackfill: isBackfill));
+            account.AccountId, DateOnly.FromDateTime(DateTime.Today), "USD", 100m, "Manual"));
 
         if (shouldFail) await Assert.ThrowsAsync<AccountStatusPolicyException>(action);
         else Assert.NotNull(await action());


### PR DESCRIPTION
### Motivation
- A recent change exposed `IsBackfill` on public request DTOs and used that client-provided boolean to bypass closed-account write restrictions, creating an authorization/business-logic bypass. 
- Backfill intent is an internal/trusted workflow concept and must not be accepted from untrusted client JSON to decide whether closed-account writes are allowed.

### Description
- Stop trusting the client-provided `IsBackfill` flag when enforcing the closed-account policy by removing `request.IsBackfill` from the `EnsureAllowed` calls in `RecordBalanceSnapshotAsync`, `IngestCustodianStatementAsync`, and `IngestBankStatementAsync` in `src/Meridian.Application/FundAccounts/InMemoryFundAccountService.cs` so server-side policy is applied consistently.
- Update the unit test `RecordBalanceSnapshot_EnforcesOperationalStatus` in `tests/Meridian.Tests/Application/FundAccounts/FundAccountServiceTests.cs` to reflect the hardened behavior (closed accounts now fail regardless of client `isBackfill`).
- Intentional minimal surface change: DTOs and HTTP endpoint deserialization were not changed to avoid API breaking; authorization is hardened on the server-side enforcement path.

### Testing
- Attempted to run the focused unit test `RecordBalanceSnapshot_EnforcesOperationalStatus` via `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~RecordBalanceSnapshot_EnforcesOperationalStatus"`, but the environment lacks the .NET SDK/runtime, so the test could not be executed (`dotnet: command not found`).
- The unit test source was updated to match the new server policy expectations; please run `dotnet test` or the project CI to validate the change in a proper .NET-enabled environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a381c3bc8320a5727f099a1516a3)