### PR TITLE
Fix null-currency crash in settlement default enforcement

### DIFF
--- a/src/Meridian.FSharp/Domain/SettlementInstructionCommands.fs
+++ b/src/Meridian.FSharp/Domain/SettlementInstructionCommands.fs
@@ -46,6 +46,8 @@ module SettlementInstructionCommands =
     let validateAddInstruction (existing: SettlementInstruction list) (candidate: SettlementInstruction) =
         if not (effectiveWindowValid candidate) then
             err "SETTLEMENT_EFFECTIVE_WINDOW_INVALID" "EffectiveToUtc must be greater than EffectiveFromUtc when present."
+        elif String.IsNullOrWhiteSpace(candidate.Currency) then
+            err "SETTLEMENT_CURRENCY_REQUIRED" "Settlement instruction currency is required."
         elif candidate.IsClosed then
             err "SETTLEMENT_ACCOUNT_STATUS_CLOSED" "Cannot add settlement instruction for a closed account detail state."
         else
@@ -69,7 +71,7 @@ module SettlementInstructionCommands =
         else
             let sameScope x =
                 x.AccountId = candidate.AccountId
-                && x.Currency.Equals(candidate.Currency, StringComparison.OrdinalIgnoreCase)
+                && String.Equals(x.Currency, candidate.Currency, StringComparison.OrdinalIgnoreCase)
                 && x.CounterpartyScope = candidate.CounterpartyScope
                 && not x.IsClosed
                 && overlaps x candidate

--- a/tests/Meridian.FSharp.Tests/SettlementInstructionCommandsTests.fs
+++ b/tests/Meridian.FSharp.Tests/SettlementInstructionCommandsTests.fs
@@ -51,10 +51,44 @@ module SettlementInstructionCommandsTests =
         | Error e -> failwithf "Unexpected error: %s" e.Code
 
     [<Fact>]
+    let ``rejects null currency`` () =
+        let account = AccountId(Guid.NewGuid())
+        let candidate =
+            { mk account SettlementDetailType.BankWire (DateTimeOffset.Parse("2026-01-10T00:00:00Z")) None false None with
+                Currency = null }
+
+        match addSettlementInstructionCommand [] candidate with
+        | Error e -> e.Code |> should equal "SETTLEMENT_CURRENCY_REQUIRED"
+        | Ok _ -> failwith "Expected currency validation error"
+
+    [<Fact>]
+    let ``rejects whitespace currency`` () =
+        let account = AccountId(Guid.NewGuid())
+        let candidate =
+            { mk account SettlementDetailType.BankWire (DateTimeOffset.Parse("2026-01-10T00:00:00Z")) None false None with
+                Currency = "   " }
+
+        match addSettlementInstructionCommand [] candidate with
+        | Error e -> e.Code |> should equal "SETTLEMENT_CURRENCY_REQUIRED"
+        | Ok _ -> failwith "Expected currency validation error"
+
+    [<Fact>]
     let ``rejects default collision for same scope and overlapping window`` () =
         let account = AccountId(Guid.NewGuid())
         let existing = mk account SettlementDetailType.BankWire (DateTimeOffset.Parse("2026-01-01T00:00:00Z")) None true None
         let candidate = mk account SettlementDetailType.Custody (DateTimeOffset.Parse("2026-02-01T00:00:00Z")) None true None
         match addSettlementInstructionCommand [ existing ] candidate with
+        | Error e -> e.Code |> should equal "SETTLEMENT_DEFAULT_COLLISION"
+        | Ok _ -> failwith "Expected default collision"
+
+    [<Fact>]
+    let ``set default handles historical null currency without null reference`` () =
+        let account = AccountId(Guid.NewGuid())
+        let existingDefault =
+            { mk account SettlementDetailType.BankWire (DateTimeOffset.Parse("2026-01-01T00:00:00Z")) None true None with
+                Currency = null }
+        let target = mk account SettlementDetailType.Custody (DateTimeOffset.Parse("2026-02-01T00:00:00Z")) None false None
+
+        match setDefaultSettlementInstructionCommand [ existingDefault; target ] target.InstructionId with
         | Error e -> e.Code |> should equal "SETTLEMENT_DEFAULT_COLLISION"
         | Ok _ -> failwith "Expected default collision"


### PR DESCRIPTION
### Motivation
- The default-management flow could throw `NullReferenceException` when an existing `SettlementInstruction.Currency` was `null`, making default enforcement crash for valid callers.
- The change prevents poisoning of account settlement state by rejecting null/blank currencies early and making comparisons null-safe.

### Description
- Added a currency presence check in `validateAddInstruction` to reject `null` or whitespace `Currency` with `SETTLEMENT_CURRENCY_REQUIRED` in `src/Meridian.FSharp/Domain/SettlementInstructionCommands.fs`.
- Replaced the instance `x.Currency.Equals(...)` call with the null-safe `String.Equals(x.Currency, candidate.Currency, StringComparison.OrdinalIgnoreCase)` in the default-scope comparison to avoid dereferencing `null`.
- Extended unit tests in `tests/Meridian.FSharp.Tests/SettlementInstructionCommandsTests.fs` to cover `null` currency, whitespace currency, and a historical-null-currency `setDefault` scenario to assert errors rather than crashes.

### Testing
- Added unit tests for the new currency validation and null-safety cases in `tests/Meridian.FSharp.Tests/SettlementInstructionCommandsTests.fs` but they were not executed here due to the environment lacking the .NET SDK.
- Attempted to run `dotnet test tests/Meridian.FSharp.Tests/Meridian.FSharp.Tests.fsproj --filter "FullyQualifiedName~SettlementInstructionCommandsTests" --logger "console;verbosity=normal"` and it failed with `/bin/bash: dotnet: command not found` in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb889b702c8320be3ad8964e094e3f)