### PR TITLE
Avoid reconciliation governance audit writes on readiness GET

### DIFF
--- a/src/Meridian.Strategies/Services/ReconciliationGovernanceService.cs
+++ b/src/Meridian.Strategies/Services/ReconciliationGovernanceService.cs
@@ -53,7 +53,8 @@ public sealed class ReconciliationGovernanceService(
         ReconciliationPolicyThresholds policy,
         bool waiverRequested,
         bool secondaryApprovalSigned,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        bool writeAudit = true)
     {
         var latest = await repository.GetLatestForRunAsync(runId, ct).ConfigureAwait(false);
         if (latest is null)
@@ -65,7 +66,7 @@ public sealed class ReconciliationGovernanceService(
                 0,
                 0m,
                 false);
-            if (auditStore is not null) await auditStore.AppendAsync(missing, ct).ConfigureAwait(false);
+            if (writeAudit && auditStore is not null) await auditStore.AppendAsync(missing, ct).ConfigureAwait(false);
             return missing;
         }
 
@@ -90,7 +91,7 @@ public sealed class ReconciliationGovernanceService(
             : $"Policy within threshold (open={openCount}, critical={criticalCount}, maxVariance={maxAbsVariance:0.####}).";
 
         var evaluation = new ReconciliationGateEvaluation(status, detail, openCount, criticalCount, maxAbsVariance, secondaryRequired);
-        if (auditStore is not null) await auditStore.AppendAsync(evaluation, ct).ConfigureAwait(false);
+        if (writeAudit && auditStore is not null) await auditStore.AppendAsync(evaluation, ct).ConfigureAwait(false);
         return evaluation;
     }
 

--- a/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
@@ -1034,7 +1034,7 @@ public sealed class TradingOperatorReadinessService
             return null;
         }
 
-        return await governance.EvaluateGateAsync(latestRun.Summary.RunId, new ReconciliationPolicyThresholds(), waiverRequested: false, secondaryApprovalSigned: false, ct).ConfigureAwait(false);
+        return await governance.EvaluateGateAsync(latestRun.Summary.RunId, new ReconciliationPolicyThresholds(), waiverRequested: false, secondaryApprovalSigned: false, ct, writeAudit: false).ConfigureAwait(false);
     }
 
     private static TradingAcceptanceGateDto BuildReconciliationGate(ReconciliationGateEvaluation? evaluation)

--- a/tests/Meridian.Tests/Application/ReconciliationGovernanceServiceTests.cs
+++ b/tests/Meridian.Tests/Application/ReconciliationGovernanceServiceTests.cs
@@ -37,4 +37,52 @@ public sealed class ReconciliationGovernanceServiceTests
         Assert.Equal(TradingAcceptanceGateStatusDto.ReviewRequired, result.Status);
         Assert.True(result.SecondaryApprovalRequired);
     }
+
+    [Fact]
+    public async Task EvaluateGateAsync_DoesNotWriteAudit_WhenWriteAuditDisabled()
+    {
+        var repo = new InMemoryReconciliationRunRepository();
+        var detail = new ReconciliationRunDetail(
+            new ReconciliationRunSummary("rec-3", "run-3", DateTimeOffset.UtcNow, null, null, 0, 1, 0, false, 0.01m, 1),
+            [],
+            []);
+        await repo.SaveAsync(detail);
+
+        var auditStore = new TestReconciliationGovernanceAuditStore();
+        var sut = new ReconciliationGovernanceService(repo, auditStore);
+
+        _ = await sut.EvaluateGateAsync("run-3", new ReconciliationPolicyThresholds(), waiverRequested: false, secondaryApprovalSigned: false, writeAudit: false);
+
+        Assert.Equal(0, auditStore.AppendCount);
+    }
+
+    [Fact]
+    public async Task EvaluateGateAsync_WritesAudit_ByDefault()
+    {
+        var repo = new InMemoryReconciliationRunRepository();
+        var detail = new ReconciliationRunDetail(
+            new ReconciliationRunSummary("rec-4", "run-4", DateTimeOffset.UtcNow, null, null, 0, 1, 0, false, 0.01m, 1),
+            [],
+            []);
+        await repo.SaveAsync(detail);
+
+        var auditStore = new TestReconciliationGovernanceAuditStore();
+        var sut = new ReconciliationGovernanceService(repo, auditStore);
+
+        _ = await sut.EvaluateGateAsync("run-4", new ReconciliationPolicyThresholds(), waiverRequested: false, secondaryApprovalSigned: false);
+
+        Assert.Equal(1, auditStore.AppendCount);
+    }
+
+    private sealed class TestReconciliationGovernanceAuditStore : IReconciliationGovernanceAuditStore
+    {
+        public int AppendCount { get; private set; }
+
+        public Task AppendAsync(ReconciliationGateEvaluation evaluation, CancellationToken ct = default)
+        {
+            AppendCount++;
+            return Task.CompletedTask;
+        }
+    }
+
 }


### PR DESCRIPTION
### Motivation
- The trading readiness endpoint (`GET /trading/readiness`) evaluated the reconciliation governance gate and unconditionally appended a JSONL audit row on every read, creating externally-triggerable write amplification and audit noise. 
- The intent is to prevent frequent polling from growing `artifacts/reconciliation/governance-audit.jsonl` while preserving audit behavior for operator-driven actions.

### Description
- Added an explicit `writeAudit` parameter to `ReconciliationGovernanceService.EvaluateGateAsync` (default `true`) and gated both the missing-run and normal evaluation append calls behind that flag. 
- Updated the readiness read-path in `TradingOperatorReadinessService.ResolveReconciliationGateAsync` to call `EvaluateGateAsync(..., writeAudit: false)` so readiness GETs compute the gate without appending audit rows. 
- Implemented focused unit tests (`EvaluateGateAsync_DoesNotWriteAudit_WhenWriteAuditDisabled` and `EvaluateGateAsync_WritesAudit_ByDefault`) that verify audit writes are skipped when `writeAudit` is `false` and remain enabled by default. 

### Testing
- Added unit tests in `tests/Meridian.Tests/Application/ReconciliationGovernanceServiceTests.cs` covering the new `writeAudit` behavior and existing evaluation cases. 
- Attempted to run the focused test filter with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ReconciliationGovernanceServiceTests" --logger "console;verbosity=normal"`, but execution was not possible in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`). 
- The new tests are included in the repository and should pass in CI or a local environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb86a93e088320abe4090e4c9250c1)