### PR TITLE
Add priority scoring for operator inbox work items

### DIFF
--- a/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
+++ b/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
@@ -58,6 +58,16 @@ public sealed record OperatorWorkItemDto(
 
     /// <summary>Alias for <see cref="Detail"/> to satisfy operator-triage surface naming.</summary>
     public string Description => Detail;
+
+    /// <summary>
+    /// Deterministic priority score used by workstation clients to sort actionable queue items.
+    /// </summary>
+    public int PriorityScore { get; init; }
+
+    /// <summary>
+    /// Human-readable breakdown of the priority score factors for triage explainability.
+    /// </summary>
+    public string? PriorityExplanation { get; init; }
 }
 
 public sealed record OperatorInboxDto(

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -2485,8 +2485,10 @@ public static partial class WorkstationEndpoints
                 .OrderByDescending(static item => item.Tone)
                 .ThenByDescending(static item => item.CreatedAt)
                 .First())
-            .OrderByDescending(static item => item.Tone)
-            .ThenByDescending(static item => item.CreatedAt)
+            .Select(item => OperatorInboxPriorityScoringService.ApplyScore(item, asOf))
+            .OrderByDescending(static item => item.PriorityScore)
+            .ThenByDescending(static item => item.Tone)
+            .ThenBy(static item => item.CreatedAt)
             .ThenBy(static item => item.WorkItemId, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 

--- a/src/Meridian.Ui.Shared/Services/OperatorInboxPriorityScoringService.cs
+++ b/src/Meridian.Ui.Shared/Services/OperatorInboxPriorityScoringService.cs
@@ -1,0 +1,41 @@
+using System.Globalization;
+using Meridian.Contracts.Workstation;
+
+namespace Meridian.Ui.Shared.Services;
+
+internal static class OperatorInboxPriorityScoringService
+{
+    public static OperatorWorkItemDto ApplyScore(OperatorWorkItemDto item, DateTimeOffset asOf)
+    {
+        var severityScore = item.Tone switch
+        {
+            OperatorWorkItemToneDto.Critical => 600,
+            OperatorWorkItemToneDto.Warning => 350,
+            OperatorWorkItemToneDto.Info => 120,
+            OperatorWorkItemToneDto.Success => 0,
+            _ => 0
+        };
+
+        var ageHours = Math.Max(0d, (asOf - item.CreatedAt).TotalHours);
+        var ageScore = Math.Min(220, (int)Math.Round(ageHours * 4d, MidpointRounding.AwayFromZero));
+
+        var accountScopeScore = item.FundAccountId.HasValue ? 80 : 20;
+        var replayStalenessScore = item.Kind == OperatorWorkItemKindDto.PaperReplay ? 140 : 0;
+        var reconciliationScore = item.Kind == OperatorWorkItemKindDto.ReconciliationBreak
+            ? Math.Min(180, (int)Math.Round(ageHours * 6d, MidpointRounding.AwayFromZero))
+            : 0;
+
+        var total = severityScore + ageScore + accountScopeScore + replayStalenessScore + reconciliationScore;
+        var explanation =
+            $"severity={severityScore}; ageHours={ageHours.ToString("0.0", CultureInfo.InvariantCulture)} => {ageScore}; " +
+            $"accountScope={(item.FundAccountId.HasValue ? "scoped" : "global")} => {accountScopeScore}; " +
+            $"replay={(replayStalenessScore > 0 ? "stale-risk" : "n/a")} => {replayStalenessScore}; " +
+            $"reconciliationAge={reconciliationScore}.";
+
+        return item with
+        {
+            PriorityScore = total,
+            PriorityExplanation = explanation
+        };
+    }
+}

--- a/src/Meridian.Wpf/Shell/ViewModels/OperatorInboxViewModel.cs
+++ b/src/Meridian.Wpf/Shell/ViewModels/OperatorInboxViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Meridian.Contracts.Workstation;
 using Meridian.Wpf.Models;
@@ -12,6 +13,7 @@ public sealed class OperatorInboxViewModel : BindableBase
     private string _error = "Operator queue has not refreshed yet.";
     private OperatorWorkItemDto? _primaryWorkItem;
     private string _targetPageTag = "NotificationCenter";
+    private IReadOnlyList<OperatorInboxLaneGroup> _laneGroups = [];
 
     public OperatorInboxDto? Inbox => _inbox;
 
@@ -43,6 +45,8 @@ public sealed class OperatorInboxViewModel : BindableBase
 
     public string TargetText => _targetPageTag;
 
+    public IReadOnlyList<OperatorInboxLaneGroup> LaneGroups => _laneGroups;
+
     public int ReviewCount => _inbox?.ReviewCount ?? 0;
 
     public string Tone => ResolveTone(_inbox);
@@ -60,6 +64,7 @@ public sealed class OperatorInboxViewModel : BindableBase
             : error;
         _primaryWorkItem = GetPrimaryWorkItem(inbox);
         _targetPageTag = resolveTargetPageTag(_primaryWorkItem) ?? "NotificationCenter";
+        _laneGroups = BuildLaneGroups(inbox);
 
         RaisePropertyChanged(nameof(Inbox));
         RaisePropertyChanged(nameof(PrimaryWorkItem));
@@ -69,14 +74,24 @@ public sealed class OperatorInboxViewModel : BindableBase
         RaisePropertyChanged(nameof(TargetText));
         RaisePropertyChanged(nameof(ReviewCount));
         RaisePropertyChanged(nameof(Tone));
+        RaisePropertyChanged(nameof(LaneGroups));
     }
 
     public static OperatorWorkItemDto? GetPrimaryWorkItem(OperatorInboxDto? inbox)
         => inbox?.Items
-            .OrderByDescending(item => item.Tone == OperatorWorkItemToneDto.Critical)
+            .OrderByDescending(item => item.PriorityScore)
+            .ThenByDescending(item => item.Tone == OperatorWorkItemToneDto.Critical)
             .ThenByDescending(item => item.Tone == OperatorWorkItemToneDto.Warning)
             .ThenBy(item => item.CreatedAt)
             .FirstOrDefault();
+
+    private static IReadOnlyList<OperatorInboxLaneGroup> BuildLaneGroups(OperatorInboxDto? inbox)
+        => inbox?.Items
+            .OrderByDescending(item => item.PriorityScore)
+            .ThenBy(item => item.CreatedAt)
+            .GroupBy(item => string.IsNullOrWhiteSpace(item.Workspace) ? "Trading" : item.Workspace)
+            .Select(group => new OperatorInboxLaneGroup(group.Key, group.ToArray()))
+            .ToArray() ?? [];
 
     public static string ResolveTone(OperatorInboxDto? inbox)
     {
@@ -100,3 +115,5 @@ public sealed class OperatorInboxViewModel : BindableBase
             : WorkspaceTone.Success;
     }
 }
+
+public sealed record OperatorInboxLaneGroup(string Lane, IReadOnlyList<OperatorWorkItemDto> Items);

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -2785,7 +2785,8 @@ public sealed partial class WorkstationEndpointsTests
         inbox.CriticalCount.Should().Be(inbox.Items.Count(item => item.Tone == OperatorWorkItemToneDto.Critical));
         inbox.WarningCount.Should().Be(inbox.Items.Count(item => item.Tone == OperatorWorkItemToneDto.Warning));
         inbox.ReviewCount.Should().Be(inbox.CriticalCount + inbox.WarningCount);
-        inbox.Items.Should().BeInDescendingOrder(item => item.Tone);
+        inbox.Items.Should().OnlyContain(item => item.PriorityScore > 0 && !string.IsNullOrWhiteSpace(item.PriorityExplanation));
+        inbox.Items.Should().BeInDescendingOrder(item => item.PriorityScore);
     }
 
     [Fact]
@@ -2818,7 +2819,8 @@ public sealed partial class WorkstationEndpointsTests
         inbox.CriticalCount.Should().Be(inbox.Items.Count(item => item.Tone == OperatorWorkItemToneDto.Critical));
         inbox.WarningCount.Should().Be(inbox.Items.Count(item => item.Tone == OperatorWorkItemToneDto.Warning));
         inbox.ReviewCount.Should().Be(inbox.CriticalCount + inbox.WarningCount);
-        inbox.Items.Should().BeInDescendingOrder(item => item.Tone);
+        inbox.Items.Should().BeInDescendingOrder(item => item.PriorityScore);
+        inbox.Items.Should().OnlyContain(item => item.PriorityScore > 0 && !string.IsNullOrWhiteSpace(item.PriorityExplanation));
     }
 
     [Fact]
@@ -2842,7 +2844,8 @@ public sealed partial class WorkstationEndpointsTests
         inbox.Should().NotBeNull();
         inbox!.Items.Should().Contain(item => item.WorkItemId == "paper-session-missing");
         inbox.Items.Should().Contain(item => item.Kind == OperatorWorkItemKindDto.ReconciliationBreak);
-        inbox.Items.Should().BeInDescendingOrder(item => item.Tone);
+        inbox.Items.Should().BeInDescendingOrder(item => item.PriorityScore);
+        inbox.Items.Should().OnlyContain(item => item.PriorityScore > 0 && !string.IsNullOrWhiteSpace(item.PriorityExplanation));
         inbox.Items.Should().OnlyContain(item =>
             !string.IsNullOrWhiteSpace(item.Title) &&
             !string.IsNullOrWhiteSpace(item.Detail) &&

--- a/tests/Meridian.Wpf.Tests/ViewModels/ShellPresentationViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/ShellPresentationViewModelTests.cs
@@ -41,7 +41,11 @@ public sealed class ShellPresentationViewModelTests
             Detail: "Cash mismatch needs review.",
             Tone: OperatorWorkItemToneDto.Warning,
             CreatedAt: DateTimeOffset.UtcNow.AddMinutes(-10),
-            TargetPageTag: "FundReconciliation");
+            TargetPageTag: "FundReconciliation")
+        {
+            PriorityScore = 520,
+            PriorityExplanation = "warning lane"
+        };
         var critical = new OperatorWorkItemDto(
             WorkItemId: "critical-1",
             Kind: OperatorWorkItemKindDto.PaperReplay,
@@ -49,7 +53,11 @@ public sealed class ShellPresentationViewModelTests
             Detail: "Session changed after audit.",
             Tone: OperatorWorkItemToneDto.Critical,
             CreatedAt: DateTimeOffset.UtcNow,
-            TargetPageTag: "TradingShell");
+            TargetPageTag: "TradingShell")
+        {
+            PriorityScore = 860,
+            PriorityExplanation = "critical lane"
+        };
         var inbox = new OperatorInboxDto(
             DateTimeOffset.UtcNow,
             [warning, critical],
@@ -65,6 +73,8 @@ public sealed class ShellPresentationViewModelTests
         viewModel.Summary.Should().Be("2 work items need review.");
         viewModel.Tone.Should().Be(WorkspaceTone.Danger);
         viewModel.TargetText.Should().Be("TradingShell");
+        viewModel.LaneGroups.Should().HaveCount(2);
+        viewModel.LaneGroups.First().Items.First().WorkItemId.Should().Be("critical-1");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Provide deterministic, explainable priority ordering for `/api/workstation/operator/inbox` so operator triage surfaces surface the most urgent actionable items first using readiness severity, reconciliation break age, account scope, and replay staleness.
- Expose a human-readable explanation so clients (desktop + browser) can show why a work item was scored and make triage transparent.
- Preserve backwards compatibility for existing clients by adding additive DTO fields and keeping existing enums/fields unchanged.

### Description
- Added additive triage metadata to the operator work-item DTO by introducing `PriorityScore` and `PriorityExplanation` on `OperatorWorkItemDto` in `src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs`.
- Implemented a deterministic scoring service `OperatorInboxPriorityScoringService` in `src/Meridian.Ui.Shared/Services/OperatorInboxPriorityScoringService.cs` that computes a score from severity, age, account scope, replay staleness, and reconciliation-aging and returns an explainable breakdown string.
- Applied scoring during inbox projection in `BuildOperatorInboxAsync` inside `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` and changed ordering to sort by `PriorityScore` (with deterministic tie-breakers preserved).
- Updated WPF presentation to use score-driven selection and grouping by action lane by changing `OperatorInboxViewModel` in `src/Meridian.Wpf/Shell/ViewModels/OperatorInboxViewModel.cs` to pick the primary work item by `PriorityScore` and expose `LaneGroups` for lane-based UI rendering and one-click routing.
- Extended regression tests to assert score projection and ordering in `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` and updated focused WPF view-model tests in `tests/Meridian.Wpf.Tests/ViewModels/ShellPresentationViewModelTests.cs` to validate primary selection and lane grouping by score.

### Testing
- Updated tests: `tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs` and `tests/Meridian.Wpf.Tests/ViewModels/ShellPresentationViewModelTests.cs` were modified to validate `PriorityScore`/`PriorityExplanation` presence and score-based ordering.
- Attempted to run the targeted endpoint slice with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~MapWorkstationEndpoints_OperatorInbox" --logger "console;verbosity=minimal"`, but the command could not be executed in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`).
- Attempted to run the focused WPF view-model slice with `dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter "FullyQualifiedName~OperatorInboxViewModel" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger "console;verbosity=minimal"`, but this also failed in this environment for the same `dotnet` availability limitation.
- All changes are additive to DTOs (compatibility-safe) and include deterministic ordering/tiebreakers; local test execution should be possible in a developer environment with `dotnet` available by running the same `dotnet test` commands above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a174e1fac508320bd4bd1b61b0c4653)