### PR TITLE
Add resumable statement reconciliation orchestrator, queue-status DTO and UI guidance

### DIFF
--- a/src/Meridian.Application/Commands/StatementCommands.cs
+++ b/src/Meridian.Application/Commands/StatementCommands.cs
@@ -8,7 +8,8 @@ internal sealed class StatementCommands : ICliCommand
     public bool CanHandle(string[] args)
         => CliArguments.HasFlag(args, "--statement-import")
            || CliArguments.HasFlag(args, "--statement-validate")
-           || CliArguments.HasFlag(args, "--statement-reconcile");
+           || CliArguments.HasFlag(args, "--statement-reconcile")
+           || CliArguments.HasFlag(args, "--statement-orchestrate");
 
     public async Task<CliResult> ExecuteAsync(string[] args, CancellationToken ct = default)
     {
@@ -18,6 +19,8 @@ internal sealed class StatementCommands : ICliCommand
             return CliResult.Fail(ErrorCode.RequiredFieldMissing);
 
         var svc = new StatementReconciliationService();
+        var accountIdRaw = CliArguments.GetValue(args, "--statement-account-id");
+        var resume = CliArguments.HasFlag(args, "--statement-resume");
         try
         {
             if (CliArguments.HasFlag(args, "--statement-validate"))
@@ -31,6 +34,22 @@ internal sealed class StatementCommands : ICliCommand
             {
                 var result = await svc.ImportAsync(sourceKind, sourcePath, ct).ConfigureAwait(false);
                 Console.WriteLine($"Imported statement batch {result.ImportId} with {result.RowCount} row(s).");
+                return CliResult.Ok();
+            }
+
+            if (CliArguments.HasFlag(args, "--statement-orchestrate"))
+            {
+                if (!Guid.TryParse(accountIdRaw, out var accountId))
+                {
+                    Console.WriteLine("--statement-account-id <guid> is required for --statement-orchestrate.");
+                    return CliResult.Fail(ErrorCode.ValidationFailed);
+                }
+
+                var orchestrator = new StatementReconciliationOrchestrator(
+                    svc,
+                    new InMemoryStatementReconciliationCheckpointStore());
+                var result = await orchestrator.RunAsync(accountId, sourceKind, sourcePath, resume, ct).ConfigureAwait(false);
+                Console.WriteLine($"Orchestration status for {result.AccountId}: {result.Status}; stage={result.CurrentStage}; unresolved={result.UnresolvedCount}.");
                 return CliResult.Ok();
             }
 

--- a/src/Meridian.Application/Reconciliation/StatementReconciliationOrchestrator.cs
+++ b/src/Meridian.Application/Reconciliation/StatementReconciliationOrchestrator.cs
@@ -1,0 +1,130 @@
+using System.Collections.Concurrent;
+
+namespace Meridian.Application.Reconciliation;
+
+public enum StatementReconciliationStage
+{
+    NotStarted,
+    Validate,
+    Import,
+    Reconcile,
+    Completed,
+    Failed
+}
+
+public sealed record StatementReconciliationCheckpoint(
+    Guid AccountId,
+    string SourceKind,
+    string SourcePath,
+    StatementReconciliationStage LastCompletedStage,
+    StatementReconciliationStage CurrentStage,
+    string Status,
+    string? LastError,
+    string? ImportId,
+    int ImportedRowCount,
+    int MatchCount,
+    int UnresolvedCount,
+    DateTimeOffset UpdatedAtUtc);
+
+public interface IStatementReconciliationCheckpointStore
+{
+    Task<StatementReconciliationCheckpoint?> GetAsync(Guid accountId, CancellationToken ct);
+    Task UpsertAsync(StatementReconciliationCheckpoint checkpoint, CancellationToken ct);
+}
+
+public sealed class InMemoryStatementReconciliationCheckpointStore : IStatementReconciliationCheckpointStore
+{
+    private readonly ConcurrentDictionary<Guid, StatementReconciliationCheckpoint> _checkpoints = new();
+    public Task<StatementReconciliationCheckpoint?> GetAsync(Guid accountId, CancellationToken ct) =>
+        Task.FromResult(_checkpoints.TryGetValue(accountId, out var cp) ? cp : null);
+
+    public Task UpsertAsync(StatementReconciliationCheckpoint checkpoint, CancellationToken ct)
+    {
+        _checkpoints[checkpoint.AccountId] = checkpoint;
+        return Task.CompletedTask;
+    }
+}
+
+public sealed class StatementReconciliationOrchestrator(
+    StatementReconciliationService service,
+    IStatementReconciliationCheckpointStore checkpointStore)
+{
+    public async Task<StatementReconciliationCheckpoint> RunAsync(
+        Guid accountId,
+        string sourceKind,
+        string sourcePath,
+        bool resume,
+        CancellationToken ct)
+    {
+        var checkpoint = await checkpointStore.GetAsync(accountId, ct).ConfigureAwait(false);
+        var lastCompleted = resume ? checkpoint?.LastCompletedStage ?? StatementReconciliationStage.NotStarted : StatementReconciliationStage.NotStarted;
+
+        var state = new StatementReconciliationCheckpoint(
+            accountId,
+            sourceKind,
+            sourcePath,
+            lastCompleted,
+            StatementReconciliationStage.Validate,
+            "Running",
+            null,
+            checkpoint?.ImportId,
+            checkpoint?.ImportedRowCount ?? 0,
+            checkpoint?.MatchCount ?? 0,
+            checkpoint?.UnresolvedCount ?? 0,
+            DateTimeOffset.UtcNow);
+
+        try
+        {
+            if (lastCompleted < StatementReconciliationStage.Validate)
+            {
+                await service.ValidateAsync(sourceKind, sourcePath, ct).ConfigureAwait(false);
+                state = state with { LastCompletedStage = StatementReconciliationStage.Validate, CurrentStage = StatementReconciliationStage.Import, UpdatedAtUtc = DateTimeOffset.UtcNow };
+                await checkpointStore.UpsertAsync(state, ct).ConfigureAwait(false);
+            }
+
+            if (state.LastCompletedStage < StatementReconciliationStage.Import)
+            {
+                var import = await service.ImportAsync(sourceKind, sourcePath, ct).ConfigureAwait(false);
+                state = state with
+                {
+                    LastCompletedStage = StatementReconciliationStage.Import,
+                    CurrentStage = StatementReconciliationStage.Reconcile,
+                    ImportId = import.ImportId,
+                    ImportedRowCount = import.RowCount,
+                    UpdatedAtUtc = DateTimeOffset.UtcNow
+                };
+                await checkpointStore.UpsertAsync(state, ct).ConfigureAwait(false);
+            }
+
+            if (state.LastCompletedStage < StatementReconciliationStage.Reconcile)
+            {
+                var reconciliation = await service.ReconcileAsync(sourceKind, sourcePath, ct).ConfigureAwait(false);
+                state = state with
+                {
+                    LastCompletedStage = StatementReconciliationStage.Reconcile,
+                    CurrentStage = StatementReconciliationStage.Completed,
+                    Status = "Completed",
+                    ImportId = reconciliation.ImportId,
+                    MatchCount = reconciliation.MatchCount,
+                    UnresolvedCount = reconciliation.UnresolvedCount,
+                    UpdatedAtUtc = DateTimeOffset.UtcNow
+                };
+                await checkpointStore.UpsertAsync(state, ct).ConfigureAwait(false);
+            }
+
+            return state;
+        }
+        catch (Exception ex)
+        {
+            var failed = state with
+            {
+                CurrentStage = StatementReconciliationStage.Failed,
+                Status = "Failed",
+                LastError = ex.Message,
+                UpdatedAtUtc = DateTimeOffset.UtcNow
+            };
+            await checkpointStore.UpsertAsync(failed, ct).ConfigureAwait(false);
+            return failed;
+        }
+    }
+}

--- a/src/Meridian.Ui.Services/Services/Reconciliation/ReconciliationApiService.cs
+++ b/src/Meridian.Ui.Services/Services/Reconciliation/ReconciliationApiService.cs
@@ -7,6 +7,7 @@ public interface IReconciliationApiService
 {
     Task<IReadOnlyList<StatementImportSummaryDto>> ListImportsAsync(CancellationToken ct = default);
     Task<IReadOnlyList<ReconciliationCaseSummaryDto>> ListOpenCasesAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<ReconciliationQueueAccountStatusDto>> ListQueueStatusAsync(CancellationToken ct = default);
 }
 
 public sealed class ReconciliationApiService(ICanonicalStatementStore importStore, IReconciliationCaseStore caseStore) : IReconciliationApiService
@@ -16,4 +17,21 @@ public sealed class ReconciliationApiService(ICanonicalStatementStore importStor
 
     public async Task<IReadOnlyList<ReconciliationCaseSummaryDto>> ListOpenCasesAsync(CancellationToken ct = default)
         => (await caseStore.ListAsync(ct)).Where(c => c.Status == "Open").Select(c => new ReconciliationCaseSummaryDto(c.CaseId, c.ImportId, c.Status, c.Reason, c.Confidence, c.Rationale, c.CreatedAtUtc.ToString("O"))).ToList();
+
+    public async Task<IReadOnlyList<ReconciliationQueueAccountStatusDto>> ListQueueStatusAsync(CancellationToken ct = default)
+    {
+        var openCases = (await caseStore.ListAsync(ct).ConfigureAwait(false)).Where(c => c.Status == "Open").ToList();
+        return openCases
+            .GroupBy(c => c.ImportId)
+            .Select(group => new ReconciliationQueueAccountStatusDto(
+                AccountId: Guid.Empty,
+                AccountCode: group.Key,
+                QueueState: group.Any(c => c.Confidence < 0.5m) ? "Blocked" : "Review",
+                UnresolvedBreakCount: group.Count(),
+                SignOffReady: false,
+                NextBestAction: "Resolve open reconciliation breaks before operator sign-off.",
+                BlockerReason: "Unresolved breaks remain in the reconciliation queue.",
+                EvidenceLinks: group.Select(c => $"/api/workstation/reconciliation/cases/{Uri.EscapeDataString(c.CaseId)}").ToList()))
+            .ToList();
+    }
 }

--- a/src/Meridian.Ui.Shared/Contracts/Reconciliation/StatementImportContracts.cs
+++ b/src/Meridian.Ui.Shared/Contracts/Reconciliation/StatementImportContracts.cs
@@ -16,3 +16,13 @@ public sealed record ReconciliationCaseSummaryDto(
     decimal Confidence,
     string Rationale,
     string CreatedAtUtc);
+
+public sealed record ReconciliationQueueAccountStatusDto(
+    Guid AccountId,
+    string AccountCode,
+    string QueueState,
+    int UnresolvedBreakCount,
+    bool SignOffReady,
+    string NextBestAction,
+    string BlockerReason,
+    IReadOnlyList<string> EvidenceLinks);

--- a/src/Meridian.Ui.Shared/Endpoints/FundAccountEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/FundAccountEndpoints.cs
@@ -6,6 +6,7 @@ using Meridian.Contracts.Auth;
 using Meridian.Contracts.FundStructure;
 using Meridian.Contracts.Workstation;
 using Meridian.Ui.Shared.Services;
+using Meridian.Ui.Shared.Contracts.Reconciliation;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -549,6 +550,37 @@ public static class FundAccountEndpoints
         })
         .WithName("GetAccountReconciliationRuns")
         .Produces<IReadOnlyList<AccountReconciliationRunDto>>(StatusCodes.Status200OK);
+
+
+        group.MapGet("/{accountId:guid}/reconciliation-queue-status", async (Guid accountId, HttpContext context) =>
+        {
+            var queryService = ResolveQueryService(context);
+            if (queryService is null)
+                return ServiceUnavailable();
+
+            var runs = await queryService.GetReconciliationRunsAsync(accountId, context.RequestAborted).ConfigureAwait(false);
+            var latestRun = runs.OrderByDescending(run => run.AsOfDate).FirstOrDefault();
+            var unresolvedBreaks = latestRun is null
+                ? 0
+                : (await queryService.GetReconciliationResultsAsync(latestRun.ReconciliationRunId, context.RequestAborted).ConfigureAwait(false))
+                    .Count(result => !string.Equals(result.Status, "Matched", StringComparison.OrdinalIgnoreCase));
+
+            var payload = new ReconciliationQueueAccountStatusDto(
+                AccountId: accountId,
+                AccountCode: latestRun?.AccountCode ?? "unknown",
+                QueueState: unresolvedBreaks == 0 ? "Ready" : "Blocked",
+                UnresolvedBreakCount: unresolvedBreaks,
+                SignOffReady: unresolvedBreaks == 0 && latestRun is not null,
+                NextBestAction: unresolvedBreaks == 0 ? "Proceed with operator sign-off." : "Resolve unresolved breaks before sign-off.",
+                BlockerReason: unresolvedBreaks == 0 ? "None" : "One or more unresolved reconciliation breaks remain.",
+                EvidenceLinks: latestRun is null
+                    ? Array.Empty<string>()
+                    : [ $"/api/fund-accounts/reconciliation-runs/{latestRun.ReconciliationRunId}/results" ]);
+
+            return Results.Json(payload, jsonOptions);
+        })
+        .WithName("GetAccountReconciliationQueueStatus")
+        .Produces<ReconciliationQueueAccountStatusDto>(StatusCodes.Status200OK);
 
         group.MapGet("/reconciliation-runs/{runId:guid}/results", async (Guid runId, HttpContext context) =>
         {

--- a/src/Meridian.Wpf/ViewModels/FundLedgerViewModel.Reconciliation.cs
+++ b/src/Meridian.Wpf/ViewModels/FundLedgerViewModel.Reconciliation.cs
@@ -61,6 +61,9 @@ public sealed partial class FundLedgerViewModel
     private string _reconciliationDetailBreakAmountText = "-";
     private string _reconciliationDetailSecurityIssuesText = "0";
     private string _reconciliationBreakQueueEmptyStateText = "No strategy-run breaks are queued for this fund.";
+    private string _reconciliationNextBestActionText = "Select a break to view the recommended next action.";
+    private string _reconciliationBlockerReasonText = "No blocker is selected.";
+    private string _reconciliationEvidenceLinksText = "Evidence links appear after selecting a break.";
     private string _reconciliationRunsEmptyStateText = "No reconciliation runs are available for this fund.";
     private FundReconciliationBreakQueueRow? _selectedBreakQueueItem;
     private FundReconciliationRunRow? _selectedReconciliationRun;
@@ -146,6 +149,7 @@ public sealed partial class FundLedgerViewModel
             }
 
             NotifyReconciliationDerivedStateChanged();
+            UpdateReconciliationOperatorGuidance();
             if (!_isApplyingReconciliationSelection && _selectedReconciliationQueueView == FundReconciliationQueueView.BreakQueue)
             {
                 _ = LoadSelectedReconciliationDetailAsync();
@@ -379,6 +383,25 @@ public sealed partial class FundLedgerViewModel
     {
         get => _reconciliationBreakQueueEmptyStateText;
         private set => SetProperty(ref _reconciliationBreakQueueEmptyStateText, value);
+    }
+
+
+    public string ReconciliationNextBestActionText
+    {
+        get => _reconciliationNextBestActionText;
+        private set => SetProperty(ref _reconciliationNextBestActionText, value);
+    }
+
+    public string ReconciliationBlockerReasonText
+    {
+        get => _reconciliationBlockerReasonText;
+        private set => SetProperty(ref _reconciliationBlockerReasonText, value);
+    }
+
+    public string ReconciliationEvidenceLinksText
+    {
+        get => _reconciliationEvidenceLinksText;
+        private set => SetProperty(ref _reconciliationEvidenceLinksText, value);
     }
 
     public string ReconciliationRunsEmptyStateText
@@ -1179,6 +1202,25 @@ public sealed partial class FundLedgerViewModel
         {
             target.Add(item);
         }
+    }
+
+    private void UpdateReconciliationOperatorGuidance()
+    {
+        if (SelectedBreakQueueItem is null)
+        {
+            ReconciliationNextBestActionText = "Select a break to view the recommended next action.";
+            ReconciliationBlockerReasonText = "No blocker is selected.";
+            ReconciliationEvidenceLinksText = "Evidence links appear after selecting a break.";
+            return;
+        }
+
+        ReconciliationNextBestActionText = SelectedBreakQueueItem.Status is ReconciliationBreakQueueStatus.Open
+            ? "Review evidence, assign owner, and move the break to InReview."
+            : "Capture operator decision and finalize resolution notes.";
+        ReconciliationBlockerReasonText = string.IsNullOrWhiteSpace(SelectedBreakQueueItem.Summary)
+            ? "Awaiting break summary from workstation host."
+            : SelectedBreakQueueItem.Summary;
+        ReconciliationEvidenceLinksText = $"/api/workstation/reconciliation/break-queue/{SelectedBreakQueueItem.BreakId}";
     }
 
     private static string HumanizeLedgerScope(FundLedgerScope scope)

--- a/tests/Meridian.Tests/Application/Reconciliation/StatementReconciliationOrchestratorTests.cs
+++ b/tests/Meridian.Tests/Application/Reconciliation/StatementReconciliationOrchestratorTests.cs
@@ -1,0 +1,42 @@
+using Meridian.Application.Reconciliation;
+
+namespace Meridian.Tests.Application.Reconciliation;
+
+public sealed class StatementReconciliationOrchestratorTests
+{
+    [Fact]
+    public async Task RunAsync_Completes_All_Stages_And_Persists_Checkpoint()
+    {
+        var store = new InMemoryStatementReconciliationCheckpointStore();
+        var service = new StatementReconciliationService();
+        var orchestrator = new StatementReconciliationOrchestrator(service, store);
+
+        var path = Path.GetTempFileName();
+        await File.WriteAllLinesAsync(path, ["a,b", "1,2"]);
+
+        try
+        {
+            var result = await orchestrator.RunAsync(Guid.NewGuid(), "local", path, resume: false, CancellationToken.None);
+            Assert.Equal(StatementReconciliationStage.Completed, result.CurrentStage);
+            Assert.Equal("Completed", result.Status);
+            Assert.True(result.ImportedRowCount > 0);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_Records_Failure_For_Missing_File()
+    {
+        var store = new InMemoryStatementReconciliationCheckpointStore();
+        var orchestrator = new StatementReconciliationOrchestrator(new StatementReconciliationService(), store);
+
+        var result = await orchestrator.RunAsync(Guid.NewGuid(), "local", "./missing.csv", resume: false, CancellationToken.None);
+
+        Assert.Equal(StatementReconciliationStage.Failed, result.CurrentStage);
+        Assert.Equal("Failed", result.Status);
+        Assert.NotNull(result.LastError);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a resumable orchestration layer that sequences `--statement-validate` → `--statement-import` → `--statement-reconcile` so long-running statement ingestion and matching can be resumed per-account after partial failures.
- Surface per-account queue state and sign-off readiness to operator surfaces so the desktop can show next-best actions, blocker reasons, and evidence links for reconciliation breaks.
- Wire orchestration control into the existing CLI and read-model stack so automation, operator workflows, and the Fund Ledger UI can consume checkpointed progress and queue projections.

### Description

- Added `StatementReconciliationOrchestrator`, a checkpoint model (`StatementReconciliationCheckpoint`), a lightweight `IStatementReconciliationCheckpointStore` and an in-memory implementation to persist per-account stage, status, errors and counts (`src/Meridian.Application/Reconciliation/StatementReconciliationOrchestrator.cs`).
- Extended the statement CLI handling to support `--statement-orchestrate`, `--statement-account-id` and `--statement-resume` and to invoke the orchestrator when requested (`src/Meridian.Application/Commands/StatementCommands.cs`).
- Added a queue/status read-model DTO `ReconciliationQueueAccountStatusDto` and extended the reconciliation API service with `ListQueueStatusAsync` to project queue state from open cases (`src/Meridian.Ui.Shared/Contracts/Reconciliation/StatementImportContracts.cs`, `src/Meridian.Ui.Services/Services/Reconciliation/ReconciliationApiService.cs`).
- Exposed a fund-account endpoint `GET /api/fund-accounts/{accountId}/reconciliation-queue-status` that returns unresolved break counts, sign-off readiness, next-best action, blocker reason and evidence links (`src/Meridian.Ui.Shared/Endpoints/FundAccountEndpoints.cs`).
- Enhanced the Fund Ledger reconciliation view model with operator guidance fields (`ReconciliationNextBestActionText`, `ReconciliationBlockerReasonText`, `ReconciliationEvidenceLinksText`) and an updater that refreshes guidance on break selection (`src/Meridian.Wpf/ViewModels/FundLedgerViewModel.Reconciliation.cs`).
- Added unit tests that exercise orchestration success and partial-failure checkpoint behavior (`tests/Meridian.Tests/Application/Reconciliation/StatementReconciliationOrchestratorTests.cs`).

### Testing

- Added unit tests for the orchestrator at `tests/Meridian.Tests/Application/Reconciliation/StatementReconciliationOrchestratorTests.cs` that validate successful stage progression and failure capture into checkpoints.
- Attempted to run the focused test via `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~StatementReconciliationOrchestratorTests"`, but the automation environment does not have `dotnet` installed so the test run could not be executed (command failed with `dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a174e252f9c832090f9e598b732fdc3)