### PR TITLE
Add canonical buyer workflow and register it as a mandatory pre-release gate

### DIFF
--- a/docs/operations/canonical-buyer-workflow.md
+++ b/docs/operations/canonical-buyer-workflow.md
@@ -1,0 +1,271 @@
+# Canonical Buyer Workflow (Mandatory Pre-Release Path)
+
+## Purpose and scope
+
+This document defines the single canonical operator path that must be proven before release approval:
+
+1. Trusted data ingestion
+2. Strategy and paper validation
+3. Ledger and reconciliation
+4. Approvals
+5. Governed reporting
+
+The path is **release-gating** and binds browser workstation, WPF workstation, API seams, and retained evidence artifacts.
+
+---
+
+## Stage 1 — Trusted data ingestion
+
+### Required API endpoints
+
+- `GET /api/workstation/data`
+- `GET /api/workstation/trading/readiness`
+- `GET /api/workstation/operator/inbox`
+- `GET /api/workstation/reconciliation/calibration-summary`
+- `GET /api/providers/status`
+- `GET /api/provider-routing/trust-snapshots`
+- `GET /api/quality/dashboard`
+
+### Required operator routes
+
+- **Browser:** `/data/providers`, `/data/quotes`, `/data/watchlist`, `/data/backfills`, `/trading/readiness`
+- **WPF:** `DataShell`, `ProviderHealth`, `ProviderTrust`, and queue-routed readiness work-item handoff into `TradingShell`/`RunRisk`
+
+### Required artifacts
+
+- Wave 1 validation summary + packet + sign-off under `artifacts/provider-validation/_automation/<yyyy-mm-dd>/`
+  - `wave1-validation-summary.json` / `.md`
+  - `dk1-pilot-parity-packet.json` / `.md`
+  - `dk1-operator-signoff.json`
+- Contract packet under `artifacts/contract-review/<yyyy-mm-dd>/contract-review-packet.json`
+
+### Success criteria
+
+- Trading readiness trust gate and provider posture are non-blocking for the release candidate account scope.
+- Operator inbox has no unowned critical provider/data-quality work items.
+- Calibration summary reports no unresolved critical calibration blockers.
+- DK1 packet status is current, packet/sign-off binding validates, and packet date is within the current release evidence window.
+
+### Failure criteria
+
+- Missing/expired DK1 packet or unsigned packet-bound sign-off.
+- Any critical trust/degradation blocker without owner, route, or mitigation evidence.
+- Readiness/inbox inconsistency for account-scoped requests.
+
+### Sign-off checkpoint
+
+- **Owners:** Data Operations + Provider Reliability + Trading Operations.
+- **Evidence to sign:** dated provider-validation packet set + contract compatibility packet.
+
+---
+
+## Stage 2 — Strategy and paper validation
+
+### Required API endpoints
+
+- `POST /api/execution/sessions/create`
+- `GET /api/execution/sessions/{sessionId}/replay`
+- `POST /api/promotion/evaluate`
+- `POST /api/promotion/approve`
+- `GET /api/workstation/trading/readiness`
+- `GET /api/workstation/operator/inbox`
+- `GET /api/workstation/runs/{runId}/review-packet`
+
+### Required operator routes
+
+- **Browser:** `/strategy`, `/strategy/promotions`, `/trading/readiness`, `/trading/orders`, `/trading/positions`
+- **WPF:** `TradingShell`, `RunRisk`, `StrategyShell` plus operator-inbox queue navigation for PaperReplay/ExecutionControl/PromotionReview
+
+### Required artifacts
+
+- Paper-session reliability evidence packet (create → replay verify → stale → re-verify → close)
+- Promotion decision trace with checklist state and audit references
+- Run review packet output per promoted candidate run
+
+### Success criteria
+
+- Replay verification audit is fresh and matched for active paper session.
+- Promotion approval checklist is complete with required rationale/audit references.
+- Readiness acceptance gates align between `/api/workstation/trading` and `/api/workstation/trading/readiness`.
+- Operator inbox and readiness work-item severity/targets are consistent.
+
+### Failure criteria
+
+- Stale or missing replay verification evidence.
+- Promotion approval without checklist completeness and rationale.
+- Cross-endpoint readiness gate drift.
+
+### Sign-off checkpoint
+
+- **Owners:** Trading Operations + Risk & Controls + QA release owner.
+- **Evidence to sign:** paper-session reliability packet + promotion trace packet + run review packet.
+
+---
+
+## Stage 3 — Ledger and reconciliation
+
+### Required API endpoints
+
+- `GET /api/workstation/accounting`
+- `GET /api/workstation/reconciliation/break-queue`
+- `POST /api/workstation/reconciliation/break-queue/{breakId}/review`
+- `POST /api/workstation/reconciliation/break-queue/{breakId}/resolve`
+- `GET /api/workstation/reconciliation/break-queue/{breakId}/audit`
+- `GET /api/workstation/operations/continuity`
+- `GET /api/workstation/operations/continuity/{workflowId}`
+
+### Required operator routes
+
+- **Browser:** `/accounting/reconciliation`, `/accounting/ledger`, `/accounting/operations-continuity`
+- **WPF:** `FundReconciliation`, `FundTrialBalance`, `AccountingShell` with queue-routed reconciliation/break review
+
+### Required artifacts
+
+- Reconciliation case file set under retained reconciliation storage (queue + audit history)
+- Operations continuity timeline evidence (selected workflow detail + timeline + blocker transitions)
+- Account-scoped reconciliation triage log for sampled release candidate runs
+
+### Success criteria
+
+- No unresolved critical reconciliation breaks beyond policy/SLA for release scope.
+- Break lifecycle is auditable end-to-end (open/review/resolve with actor/rationale/timestamps).
+- Operations continuity gates advance without hidden blockers.
+
+### Failure criteria
+
+- Critical unresolved breaks without accountable owner/sign-off route.
+- Missing audit history or non-reproducible resolution rationale.
+- Continuity stage transitions inconsistent with reconciliation state.
+
+### Sign-off checkpoint
+
+- **Owners:** Reconciliation Operations + Fund Operations Governance.
+- **Evidence to sign:** reconciliation case packet + continuity timeline excerpt + calibration summary snapshot.
+
+---
+
+## Stage 4 — Approvals
+
+### Required API endpoints
+
+- `GET /api/workstation/operator/inbox`
+- `GET /api/workstation/operations/continuity/{workflowId}`
+- `POST /api/promotion/approve` (paper/live gate approvals where in scope)
+- Approval-related reconciliation/continuity actions recorded in case audit/timeline payloads
+
+### Required operator routes
+
+- **Browser:** `/accounting/approvals`, `/accounting/operations-continuity`, `/reporting/evidence`
+- **WPF:** approval and queue actions surfaced from `MainShell`/inbox actions into `TradingShell`, `FundReconciliation`, `FundTrialBalance`, and reporting evidence targets
+
+### Required artifacts
+
+- Signed operator approval checklist (promotion + reconciliation + continuity posture)
+- Approval decision trail with actor, rationale, correlation/audit identifiers
+- Evidence-workbench linkage proving source workflow -> approval decision -> governed output dependency
+
+### Success criteria
+
+- All mandatory approval checklist items are complete and signed by required roles.
+- No approval marked complete while upstream critical blockers remain open.
+- Approval trail is durable and reconstructable after restart/refresh.
+
+### Failure criteria
+
+- Missing required approver role, rationale, or audit reference.
+- Approval state inconsistent with reconciliation/trading readiness states.
+
+### Sign-off checkpoint
+
+- **Owners:** Trading Operations + Governance/Fund Ops + Release Manager.
+- **Evidence to sign:** consolidated approval packet with explicit role signatures.
+
+---
+
+## Stage 5 — Governed reporting
+
+### Required API endpoints
+
+- `GET /api/workstation/reporting`
+- `GET /api/fund-structure/report-packs`
+- `POST /api/fund-structure/report-packs` (generation/export workflow)
+- `GET /api/workstation/evidence/subjects`
+- `GET /api/workstation/evidence/templates`
+
+### Required operator routes
+
+- **Browser:** `/reporting/report-packs`, `/reporting/evidence`, `/reporting/exports`
+- **WPF:** reporting/evidence handoff routes consuming shared report-pack and evidence-read model outputs
+
+### Required artifacts
+
+- Report pack output set (manifest/provenance/checksums/artifact bundle)
+- Evidence packet export manifest linking report outputs back to approvals and reconciliation casework
+- Governed report-pack schema compatibility evidence (`schemaVersion=1` expectations)
+
+### Success criteria
+
+- Report pack generated with required schema and lineage/provenance files.
+- Evidence graph/manifest links report outputs to signed approvals and resolved reconciliation state.
+- No schema compatibility or validation failures for release profile.
+
+### Failure criteria
+
+- Missing manifest/provenance/checksum outputs.
+- Report pack generated from unresolved approval/reconciliation posture.
+- Schema mismatch or rejected expected schema version.
+
+### Sign-off checkpoint
+
+- **Owners:** Reporting Operations + Governance/Fund Ops + Compliance approver.
+- **Evidence to sign:** final governed report pack + evidence manifest + approval binding.
+
+---
+
+## End-to-end evidence checklist (release packet)
+
+All release candidates must include and archive these outputs:
+
+1. **Readiness packet**
+   - `artifacts/provider-validation/_automation/<yyyy-mm-dd>/wave1-validation-summary.json`
+   - `artifacts/provider-validation/_automation/<yyyy-mm-dd>/dk1-pilot-parity-packet.json`
+   - `artifacts/provider-validation/_automation/<yyyy-mm-dd>/dk1-operator-signoff.json`
+2. **Reconciliation case packet**
+   - Current break-queue snapshot + audit history export for release-scoped runs
+   - Operations continuity timeline excerpt showing final gate progression
+3. **Approvals packet**
+   - Signed approval checklist with required owner roles and dated signatures
+   - Promotion/reconciliation/continuity decision trail references
+4. **Governed report pack packet**
+   - Report-pack manifest + provenance + checksum outputs
+   - Evidence export manifest linking report outputs to signed approvals and resolved casework
+
+A release cannot be promoted unless **all four packets** are present, internally consistent, and signed.
+
+---
+
+## Validation scripts/runbooks and pass/fail contract
+
+Use existing automation where available. Minimum pre-release run order:
+
+1. `pwsh ./scripts/dev/run-wave1-provider-validation.ps1`
+2. `pwsh ./scripts/dev/generate-dk1-pilot-parity-packet.ps1 -SummaryJsonPath artifacts/provider-validation/_automation/<yyyy-mm-dd>/wave1-validation-summary.json`
+3. `pwsh ./scripts/dev/prepare-dk1-operator-signoff.ps1 -OutputPath artifacts/provider-validation/_automation/<yyyy-mm-dd>/dk1-operator-signoff.json -PacketPath artifacts/provider-validation/_automation/<yyyy-mm-dd>/dk1-pilot-parity-packet.json -Validate`
+4. `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~MapWorkstationEndpoints_TradingReadiness|FullyQualifiedName~MapWorkstationEndpoints_OperatorInbox" --logger "console;verbosity=normal"`
+5. `dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter "FullyQualifiedName~MainPageUiWorkflowTests|FullyQualifiedName~FundLedgerViewModelTests" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger "console;verbosity=normal"`
+6. `python3 scripts/check_contract_compatibility_gate.py --base origin/main --head HEAD --matrix docs/status/contract-compatibility-matrix.md`
+
+### Pass conditions
+
+- Every command exits successfully.
+- Generated artifacts exist in expected folders and are date-aligned with the release window.
+- Focused API and WPF workflow tests pass for readiness/inbox/reconciliation/approval routing.
+- Contract compatibility gate reports no blocking findings.
+
+### Fail conditions
+
+- Any command failure or missing required artifact.
+- Any failing focused readiness/inbox/reconciliation/reporting acceptance test.
+- Any unsigned or invalid operator sign-off output.
+- Any blocking contract-compatibility finding.
+

--- a/docs/status/kernel-readiness-dashboard.md
+++ b/docs/status/kernel-readiness-dashboard.md
@@ -1,6 +1,6 @@
 # Kernel Readiness Dashboard (DK Program)
 
-**Last Updated:** 2026-05-21
+**Last Updated:** 2026-05-27
 **Program Scope:** Delivery Kernel waves DK1-DK2 mapped to Waves 2-4 in [`ROADMAP.md`](ROADMAP.md)  
 **Purpose:** single hand-authored status dashboard for subsystem kernel readiness, gate progression, implementation commitments, and rollback posture.
 
@@ -22,6 +22,7 @@
 - **Cadence:** weekly subsystem review (Mon), cross-subsystem interop review (Wed), operator-readiness review (Fri)
 - **Current operating window:** 2026-04-20 through 2026-06-26
 - **Status publication rule:** update this dashboard at least once per week; release-governance decisions reference this file plus `provider-validation-matrix.md`, and must pass `python3 scripts/check_program_state_consistency.py` before publication.
+- **Mandatory pre-release acceptance gate:** the canonical buyer workflow in [`docs/operations/canonical-buyer-workflow.md`](../operations/canonical-buyer-workflow.md) is required for every release candidate. Release governance must attach all four evidence packets (readiness, reconciliation case, approvals, governed report pack) and record pass/fail against that workflow before sign-off.
 - **Current sync note (2026-05-20):** Wave 1 provider evidence posture was refreshed in [`provider-validation-matrix.md`](./provider-validation-matrix.md) (focused Robinhood polling hardening and capability-claim parity/data-shape audit); the signed DK1 exit evidence baseline remains the packet-bound 2026-04-27 artifact set until a newly generated packet and matching sign-off replace it.
 
 ---
@@ -85,6 +86,7 @@
 - [ ] **Explainability pass:** end-to-end trace from trusted input to governed output is operator-visible.
 - [ ] **Calibration pass:** reconciliation exceptions are tuned with no unresolved critical mismatches.
 - [ ] **Operator sign-off:** Trading + Governance owners sign DK2 readiness.
+- [ ] **Canonical buyer workflow gate:** full trusted-data → strategy/paper → ledger/reconciliation → approvals → governed-reporting path is executed and signed per [`docs/operations/canonical-buyer-workflow.md`](../operations/canonical-buyer-workflow.md).
 
 
 #### Governance/fund-ops scenario gate text (mirrors Wave 4 objective pass/fail)


### PR DESCRIPTION
### Motivation

- Create a single, auditable operator path that gates release promotion across trusted data ingestion, paper/strategy validation, ledger/reconciliation, approvals, and governed reporting.
- Make the release-governance requirement explicit in the kernel readiness surface so DK2 readiness cannot be claimed without the end-to-end signed evidence packets.

### Description

- Add `docs/operations/canonical-buyer-workflow.md` defining the five-stage canonical buyer workflow with exact API endpoints, browser and WPF routes, artifact output locations, stage-level success/failure criteria, and role-based sign-off checkpoints. 
- Add a consolidated end-to-end evidence checklist that requires four packets (readiness, reconciliation case, approvals, governed report pack) and enumerates expected artifact paths such as `artifacts/provider-validation/_automation/<yyyy-mm-dd>/` and report-pack manifests. 
- Provide a minimum validation/runbook sequence reusing existing automation in `scripts/dev/` and list explicit pass/fail conditions for the pre-release gate. 
- Update `docs/status/kernel-readiness-dashboard.md` to register the workflow as a mandatory pre-release acceptance gate, add the DK2 checklist entry referencing the new doc, and refresh the dashboard `Last Updated` date to `2026-05-27`.

### Testing

- No automated tests were executed as part of this change because it is documentation-only; the PR documents a recommended validation command sequence (e.g., `pwsh ./scripts/dev/run-wave1-provider-validation.ps1`, focused `dotnet test` filters, and `python3 scripts/check_contract_compatibility_gate.py`) that release owners should run when validating a release candidate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a175177f75c8320adc022ad98ef6d22)