### PR TITLE
Add curated buyer security diligence packet documentation

### DIFF
--- a/docs/security/buyer-packet/architecture-summary.md
+++ b/docs/security/buyer-packet/architecture-summary.md
@@ -1,0 +1,75 @@
+# Meridian Buyer Security Packet — Architecture Summary
+
+- **Document Owner:** Security Architecture
+- **Version:** 2026.05.27.1
+- **Last Reviewed:** 2026-05-27
+- **Next Review Due:** 2026-08-31
+- **Classification:** Buyer Diligence / Controlled Distribution
+
+## Purpose
+This summary describes Meridian's high-level system boundaries, principal data flows, and trust boundaries so a buyer diligence team can evaluate architecture-driven security risk.
+
+## System Boundaries
+
+### In Scope Components
+- **Core Host (`src/Meridian/`)**: Runtime orchestration, CLI workflows, diagnostics, and control-plane entry points.
+- **Desktop Operator Shell (`src/Meridian.Wpf/`)**: WPF operator experience for trading, accounting, reporting, strategy, data, and settings workflows.
+- **Browser Workstation (`src/Meridian.Ui/dashboard` + `src/Meridian.Ui/wwwroot/workstation/`)**: Operator-facing browser UI surface.
+- **Shared API and Read Models (`src/Meridian.Ui.Services/`, `src/Meridian.Ui.Shared/`)**: Shared service and contract layer consumed by desktop and browser surfaces.
+- **Provider and ingestion paths**: Market data, historical data, symbol search, and statement ingest interfaces.
+- **Storage and artifacts**: Local data stores, package workflows, replay artifacts, and evidence outputs.
+
+### Out of Scope Components
+- Third-party provider infrastructure (broker/exchange APIs and upstream SaaS backends).
+- End-user endpoint operating system controls outside Meridian process boundaries.
+- Non-Meridian mobile clients (mobile lane intentionally excluded from product scope).
+
+## High-Level Data Flows
+1. **Ingress / acquisition**
+   - Operator configures providers and symbol scope.
+   - Meridian fetches stream/historical/reference payloads through provider adapters.
+2. **Normalization / processing**
+   - Inbound payloads are normalized into shared contracts/read models.
+   - Validation and diagnostics annotate quality and readiness posture.
+3. **Storage / replay / packaging**
+   - Data is persisted to managed local stores/artifacts.
+   - Replay and package commands produce recoverable evidence outputs.
+4. **Presentation / operator decisioning**
+   - Desktop and browser workstation surfaces query API/read-model layers.
+   - Trading readiness, inbox/reconciliation, and reporting workflows expose state for operator action.
+5. **Governance / evidence**
+   - Validation scripts and status artifacts capture operator sign-off evidence, posture summaries, and route-scoped checks.
+
+## Trust Boundaries
+
+### Boundary A — External Provider Boundary
+- **Crossing:** Internet-facing provider API traffic into Meridian provider clients.
+- **Key Risks:** Untrusted payloads, spoofed responses, schema drift, degraded upstream trust.
+- **Core Controls:** Adapter-level validation, explicit provider calibration workflows, command-scoped checks, and degradations surfaced to operator workflows.
+
+### Boundary B — Operator Access Boundary
+- **Crossing:** Human operators invoking desktop/browser workflows and administrative commands.
+- **Key Risks:** Over-privileged use, unsafe operational actions, accidental destructive workflows.
+- **Core Controls:** Role-oriented workstation segmentation, workflow-specific runbooks, and auditable evidence/output artifacts.
+
+### Boundary C — Service/Storage Boundary
+- **Crossing:** Application service layer writes to local persistence/artifact roots.
+- **Key Risks:** Integrity loss, tampering, stale replay evidence, backup gaps.
+- **Core Controls:** Validation/repair commands, deterministic package/statement workflows, and documented restore/testing playbooks.
+
+### Boundary D — Change/Automation Boundary
+- **Crossing:** CI/dev automation and scripted workflows introducing deployable artifacts.
+- **Key Risks:** Unreviewed code, dependency drift, weak release hygiene.
+- **Core Controls:** Pre-PR test profiles, focused validation slices, retention/cleanup automation, and evidence-capturing workflow scripts.
+
+## Security Design Posture (Current)
+- Security controls are concentrated in **workflow guardrails, provider validation, diagnostic observability, and evidence-producing operational scripts**.
+- Meridian favors **auditable operator workflows** over opaque background automation for high-impact actions.
+- Security readiness is reviewed as part of ongoing docs/status artifacts and gate-specific evidence packets.
+
+## Freshness and Quarterly Refresh Checklist
+- [ ] Reconfirm in-scope component list against current module map.
+- [ ] Revalidate all trust boundaries and data-flow assumptions against current endpoints/workflows.
+- [ ] Verify boundary controls map to current scripts/tests and status dashboards.
+- [ ] Update version, review dates, and owner if responsibilities changed.
+- [ ] Record changes in `document-index.md` revision notes.

--- a/docs/security/buyer-packet/control-mapping.md
+++ b/docs/security/buyer-packet/control-mapping.md
@@ -1,0 +1,36 @@
+# Meridian Buyer Security Packet — SOC 2 Control Mapping
+
+- **Document Owner:** Security & Compliance
+- **Version:** 2026.05.27.1
+- **Last Reviewed:** 2026-05-27
+- **Next Review Due:** 2026-08-31
+- **Classification:** Buyer Diligence / Controlled Distribution
+
+## Mapping Notes
+- This is a buyer-facing summary map, not a formal attestation report.
+- Criteria align to common SOC 2 Trust Services Criteria families (CC-series and related availability/confidentiality themes).
+- Evidence artifacts reference Meridian docs, scripts, and commandable workflows suitable for diligence walkthroughs.
+
+| SOC 2 Criterion (Summary) | Meridian Control Activity | Evidence Artifact Examples |
+|---|---|---|
+| CC1/CC2 Control environment & governance | Security ownership, documented operational guidance, route/workflow governance references | `docs/security/README.md`, `docs/plans/current-direction-and-status.md`, buyer packet `document-index.md` |
+| CC3 Risk assessment | Threat modeling and current-state risk documentation | `docs/security/threat-model-current-state.md`, buyer packet `threat-model-summary.md` |
+| CC4 Monitoring activities | Diagnostics commands, health checks, operator readiness/inbox visibility | CLI diagnostics help/usage docs, paper-trading readiness probes, status dashboards |
+| CC5 Control activities (change management) | PR-gated changes with focused validation and pre-PR checks | Build/test command references, CI logs, targeted test artifacts |
+| CC6 Logical access controls | Role-oriented workstation surfaces and controlled command execution | Access workflow documentation, operator runbooks, environment configs |
+| CC7 System operations/security events | Incident triage/recovery scripts and evidence-generation workflows | Incident notes, provider validation outputs, replay verification artifacts |
+| CC8 Change management | Versioned docs/scripts with review history and retained artifacts | Git history, release notes, quarterly packet refresh checklist completion |
+| CC9 Risk mitigation (vendor/dependency) | Provider calibration, dependency scans, vulnerability triage/remediation | `docs/security/known-vulnerabilities.md`, remediation notes, provider calibration outputs |
+| A1 Availability | Health endpoints, replay recoverability, backup/package validation workflows | `/healthz` checks, replay endpoint evidence, package validation outputs |
+| C1 Confidentiality (as applicable) | Controlled distribution of sensitive ops/security docs and least-privilege operations | Buyer packet classification tags, access-control procedures, audit evidence |
+
+## Evidence Packet Maintenance Expectations
+- Every mapped row must have at least one currently discoverable artifact.
+- Stale or deprecated artifact links must be replaced during quarterly refresh.
+- Material control changes require map updates in the same change window.
+
+## Freshness and Quarterly Refresh Checklist
+- [ ] Validate each SOC2 row against at least one current evidence artifact.
+- [ ] Replace stale evidence paths and mark deprecated references.
+- [ ] Reconfirm criterion language and control descriptions with security owner.
+- [ ] Update metadata and revision tracking in `document-index.md`.

--- a/docs/security/buyer-packet/document-index.md
+++ b/docs/security/buyer-packet/document-index.md
@@ -1,0 +1,31 @@
+# Meridian Buyer Security Packet — Document Index
+
+- **Packet Owner:** Security & Compliance
+- **Packet Version:** 2026.05.27.1
+- **Last Reviewed:** 2026-05-27
+- **Next Quarterly Review Due:** 2026-08-31
+- **Distribution:** Buyer Diligence / Controlled Distribution
+
+## Artifact Inventory
+
+| Document | Purpose | Owner | Version | Last Reviewed | Next Review Due |
+|---|---|---|---|---|---|
+| `architecture-summary.md` | System boundaries, key data flows, trust boundaries | Security Architecture | 2026.05.27.1 | 2026-05-27 | 2026-08-31 |
+| `threat-model-summary.md` | Current threat posture, mitigations, residual risk | Application Security | 2026.05.27.1 | 2026-05-27 | 2026-08-31 |
+| `vulnerability-management.md` | Scan cadence, triage SLA, remediation policy | Security Operations | 2026.05.27.1 | 2026-05-27 | 2026-08-31 |
+| `operational-controls.md` | Access, change, backup/recovery, incident controls | Platform Operations | 2026.05.27.1 | 2026-05-27 | 2026-08-31 |
+| `control-mapping.md` | SOC2 criteria to Meridian controls and evidence | Security & Compliance | 2026.05.27.1 | 2026-05-27 | 2026-08-31 |
+| `document-index.md` | Packet manifest, freshness governance, revision tracking | Security & Compliance | 2026.05.27.1 | 2026-05-27 | 2026-08-31 |
+
+## Quarterly Refresh Checklist (Auditable Freshness)
+- [ ] Confirm each artifact metadata block has updated **Version**, **Last Reviewed**, and **Next Review Due**.
+- [ ] Validate owner assignments are still correct for each document.
+- [ ] Recheck cross-document consistency (architecture, threat, controls, vulnerabilities, mapping).
+- [ ] Verify at least one live evidence artifact per control-mapping row.
+- [ ] Add a new revision entry below with reviewer and change summary.
+- [ ] Archive/replace obsolete references and note rationale in revision log.
+
+## Revision Log
+| Date | Version | Reviewer | Summary of Changes |
+|---|---|---|---|
+| 2026-05-27 | 2026.05.27.1 | Codex Agent (initial draft) | Created buyer packet directory and seeded six diligence artifacts with quarterly freshness metadata/checklists. |

--- a/docs/security/buyer-packet/operational-controls.md
+++ b/docs/security/buyer-packet/operational-controls.md
@@ -1,0 +1,39 @@
+# Meridian Buyer Security Packet — Operational Controls
+
+- **Document Owner:** Platform Operations
+- **Version:** 2026.05.27.1
+- **Last Reviewed:** 2026-05-27
+- **Next Review Due:** 2026-08-31
+- **Classification:** Buyer Diligence / Controlled Distribution
+
+## Access Control
+- Access to operational workflows is controlled through role-oriented responsibilities across trading, portfolio, accounting, reporting, strategy, data, and settings surfaces.
+- Administrative and high-impact actions are executed through explicit commands/scripts that leave observable outputs/artifacts.
+- Credential- and connectivity-related checks are available via focused diagnostics/configuration commands for controlled verification.
+
+## Change Control
+- Code and configuration changes are routed through branch/PR workflows with required review and targeted validation commands.
+- Change validation uses narrowest-scope tests first, then broader bundles where shared contracts/routes are impacted.
+- Evidence of change safety is retained through build/test outputs and scripted workflow artifacts.
+
+## Backup and Recovery
+- Data/package/import workflows support export/import and validation routines for recoverability.
+- Replay, package validation, and WAL-repair style commands support integrity checks and recovery preparation.
+- Artifact retention policies on automation outputs preserve recent recovery-relevant evidence while controlling storage growth.
+
+## Incident Response
+- Incident triage is supported by diagnostics endpoints/commands, operator inbox/readiness views, and status dashboards.
+- Response playbooks rely on repeatable scripts and evidence packet generation for post-incident verification.
+- Recovery confidence is reinforced through replay verification, provider validation gates, and sign-off artifacts.
+
+## Control Operation Assurance
+- Operational controls are periodically exercised through normal runbooks and dedicated validation scripts.
+- Control failures or drift trigger documented remediation and packet refresh updates.
+- Freshness metadata ensures due diligence consumers can verify control statements are current.
+
+## Freshness and Quarterly Refresh Checklist
+- [ ] Confirm access-control narrative matches current role/surface model.
+- [ ] Revalidate change-control gates and current pre-PR/test workflows.
+- [ ] Verify backup/recovery command paths and retention assumptions remain accurate.
+- [ ] Reconcile incident-response section with latest operational runbooks.
+- [ ] Update metadata and `document-index.md` revision details.

--- a/docs/security/buyer-packet/threat-model-summary.md
+++ b/docs/security/buyer-packet/threat-model-summary.md
@@ -1,0 +1,54 @@
+# Meridian Buyer Security Packet — Threat Model Summary
+
+- **Document Owner:** Application Security
+- **Version:** 2026.05.27.1
+- **Last Reviewed:** 2026-05-27
+- **Next Review Due:** 2026-08-31
+- **Classification:** Buyer Diligence / Controlled Distribution
+
+## Scope and Method
+This summary captures Meridian's current practical threat posture across data ingestion, operator workflows, and evidence/reporting surfaces. It reflects the actively maintained security references under `docs/security/` and current workflow architecture.
+
+## Current Threat Posture (Condensed)
+
+### 1) Upstream Data/Provider Threats
+- **Threats:** Malformed payloads, stale feeds, provider outages, degraded trust in market/reference inputs.
+- **Impact:** Incorrect readiness posture, polluted downstream analysis, false confidence in execution pathways.
+- **Current Mitigations:** Provider validation runs, degradation calibration workflows, route-scoped readiness checks, and operator-visible posture signals.
+
+### 2) Unauthorized or Unsafe Operator Actions
+- **Threats:** Excessive permissions, accidental misuse of high-impact commands, weak separation of duties.
+- **Impact:** Data loss, incorrect account actions, untracked operational changes.
+- **Current Mitigations:** Command discoverability with explicit flags, surface-specific workflows (Trading/Portfolio/Accounting/Reporting/Strategy/Data/Settings), and evidence-producing scripted runbooks.
+
+### 3) Data Integrity and Replay-Evidence Drift
+- **Threats:** Corrupt write-ahead logs, stale replay verification, package/statement ingest mismatch.
+- **Impact:** Inability to reconstruct events, broken readiness assertions, weakened audit trail.
+- **Current Mitigations:** WAL repair/validation workflows, replay endpoints and parity packet generation paths, and explicit statement/package validation commands.
+
+### 4) Build/Release Supply-Chain Risk
+- **Threats:** Dependency vulnerabilities, insecure build automation, insufficient pre-release checks.
+- **Impact:** Introduction of exploitable code paths or unstable deployments.
+- **Current Mitigations:** Standardized build/test command lanes, pre-PR profiles, targeted test slices for changed routes/workspaces, and retained automation artifacts.
+
+### 5) Incident Detection and Recovery Gaps
+- **Threats:** Slow triage, incomplete evidence, inconsistent incident handling.
+- **Impact:** Prolonged exposure and delayed containment/recovery.
+- **Current Mitigations:** Diagnostics command surface, operator-inbox/readiness workflows, health endpoints, and documented operational workflows for repeatable recovery.
+
+## Residual Risk Themes
+- Dependence on external providers remains a structural risk; Meridian mitigates but cannot eliminate upstream compromise/outage risk.
+- Human-in-the-loop operator workflows reduce blind automation risk but require ongoing runbook quality and training discipline.
+- Evidence freshness is central: stale validation artifacts materially reduce assurance confidence.
+
+## Planned Maturity Focus
+- Tighten formalized threat-library mapping to every high-impact route/workflow.
+- Expand continuous evidence freshness checks so stale packets are auto-flagged.
+- Continue hardening provider calibration governance gates and incident response drill cadence.
+
+## Freshness and Quarterly Refresh Checklist
+- [ ] Reconcile this summary with latest `docs/security/threat-model-current-state.md` updates.
+- [ ] Confirm all listed mitigations still map to active commands/scripts/tests.
+- [ ] Add/remove residual risk themes based on current incidents and retrospectives.
+- [ ] Update owner/version/last-reviewed metadata.
+- [ ] Update revision row in `document-index.md`.

--- a/docs/security/buyer-packet/vulnerability-management.md
+++ b/docs/security/buyer-packet/vulnerability-management.md
@@ -1,0 +1,50 @@
+# Meridian Buyer Security Packet — Vulnerability Management
+
+- **Document Owner:** Security Operations
+- **Version:** 2026.05.27.1
+- **Last Reviewed:** 2026-05-27
+- **Next Review Due:** 2026-08-31
+- **Classification:** Buyer Diligence / Controlled Distribution
+
+## Policy Intent
+Meridian maintains a vulnerability management process combining scheduled scanning, risk-based triage, and tracked remediation with evidence suitable for buyer diligence.
+
+## Scan Cadence
+- **Dependency and package review:** At least weekly and on every release candidate.
+- **Code and configuration security checks:** On pull requests for changed surfaces and in pre-release validation bundles.
+- **Workflow/script integrity checks:** With each quarterly security packet refresh and after major automation changes.
+- **Event-driven scans:** Triggered after major ecosystem CVEs or critical provider/security advisories.
+
+## Triage SLA (Target)
+- **Critical (remote exploit/high-confidence compromise path):** triage in 1 business day.
+- **High (material security weakness with realistic exploit path):** triage in 3 business days.
+- **Medium (bounded impact or constrained exploitability):** triage in 10 business days.
+- **Low (limited impact/hard-to-exploit):** triage in 20 business days.
+
+Triage includes severity confirmation, exploitability context, affected-surface enumeration, compensating controls, and remediation assignment.
+
+## Remediation Policy
+- **Critical:** fix or apply compensating controls immediately; target production remediation within 7 calendar days.
+- **High:** target remediation within 30 calendar days.
+- **Medium:** target remediation within 90 calendar days or next planned release cycle.
+- **Low:** backlog with documented acceptance rationale and periodic re-evaluation.
+
+Any exception requires documented risk acceptance with owner, expiration date, and review trigger.
+
+## Validation and Closure Requirements
+A vulnerability item is closed only when:
+1. Fix/control is implemented.
+2. Verification test/check demonstrates risk is reduced.
+3. Evidence artifact (ticket, test output, runbook output, or security note) is linked.
+4. Related packet docs are updated when control posture meaningfully changed.
+
+## Governance and Reporting
+- Security owner publishes periodic status snapshots to internal documentation/evidence lanes.
+- Open critical/high vulnerabilities and overdue remediation items are reviewed in operational governance checkpoints.
+- Buyer packet entries are refreshed quarterly to keep SLAs and policy language aligned with actual practice.
+
+## Freshness and Quarterly Refresh Checklist
+- [ ] Confirm cadence and SLA values still reflect active operating policy.
+- [ ] Sample recent vulnerability items for SLA adherence and evidence completeness.
+- [ ] Reconcile policy with latest security remediation notes in `docs/security/`.
+- [ ] Update metadata fields and revision log entry in `document-index.md`.


### PR DESCRIPTION
### Motivation
- Provide a single, curated buyer diligence packet that surfaces architecture, threat posture, vulnerability process, operational controls, and SOC2-aligned control mapping for security reviews.
- Make packet artifacts auditable and easy to validate by adding explicit metadata fields (`Document Owner`, `Version`, `Last Reviewed`, `Next Review Due`).
- Ensure packet freshness is verifiable by including a quarterly refresh checklist in every artifact and a packet-level revision log for evidence retention.

### Description
- Add a new packet directory `docs/security/buyer-packet/` containing six artifacts: `architecture-summary.md`, `threat-model-summary.md`, `vulnerability-management.md`, `operational-controls.md`, `control-mapping.md`, and `document-index.md`.
- Each artifact includes owner/version/date metadata, a quarterly freshness checklist, and guidance notes mapping Meridian controls to evidence artifacts where applicable.
- `control-mapping.md` provides a buyer-facing SOC 2 Trust Services Criteria → Meridian control activity → example evidence mapping to guide diligence walkthroughs.
- `document-index.md` serves as the packet manifest and includes an auditable revision log entry for the initial draft and packet-level quarterly checklist items.

### Testing
- Ran `git status --short` to confirm the new packet directory appears in repository working state and the command completed successfully.
- Ran `wc -l docs/security/buyer-packet/*.md` to verify files were created and report line counts, and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17518196908320aec06d6597d27933)