### PR TITLE
Add monthly SLO review template, error-budget runbook, and publication workflow

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -10,7 +10,9 @@ Guides for deploying, monitoring, and maintaining the Meridian in production.
 | [Operator Runbook](operator-runbook.md) | Day-to-day operational procedures |
 | [Performance Tuning](performance-tuning.md) | Optimization and performance guidance |
 | [High Availability](high-availability.md) | High-availability configuration |
-| [Service Level Objectives](service-level-objectives.md) | SLO definitions and monitoring |
+| [Service Level Objectives](service-level-objectives.md) | SLO definitions, monitoring, and monthly publication workflow |
+| [SLO Review Template](slo-review-template.md) | Monthly SLO compliance, burn-rate, incident, and action review template |
+| [Error Budget Policy Runbook](error-budget-policy-runbook.md) | Deployment freeze and reliability sprint trigger policy |
 | [Portable Data Packager](portable-data-packager.md) | Creating and importing data packages |
 | [MSIX Packaging](msix-packaging.md) | Desktop application packaging |
 | [Web Workstation Installer](web-workstation-installer.md) | Browser workstation local app installation |

--- a/docs/operations/error-budget-policy-runbook.md
+++ b/docs/operations/error-budget-policy-runbook.md
@@ -1,0 +1,81 @@
+# Error Budget Policy Runbook
+
+This runbook operationalizes the error-budget policy in [Service Level Objectives](./service-level-objectives.md) and defines explicit deployment-freeze and reliability-sprint triggers.
+
+## Scope
+
+- Applies to all production-impacting changes across ingestion, data quality, availability, freshness, storage, and provider connectivity planes.
+- Uses the monthly SLO report format in [Monthly SLO Review Template](./slo-review-template.md).
+
+## Trigger Matrix
+
+### A) Deployment Freeze Triggers
+
+A **deployment freeze** starts immediately when any condition is true:
+
+1. **Budget remaining < 25%** for any critical SLO at any point in the month.
+2. **Burn-rate critical alert** fires at P1 threshold for 6h or 24h windows and is not resolved within 60 minutes.
+3. **Any unmitigated P1 breach** of a zero-tolerance SLO (`SLO-ST-001`) or collector uptime (`SLO-AV-001`) during market hours.
+4. **Two P2 breaches of the same SLO within 7 days** indicating instability trend.
+
+Freeze policy while active:
+
+- Block feature deployments and schema-changing migrations.
+- Allow only incident mitigation, rollback, observability, and reliability fixes.
+- Require Reliability Lead + Incident Commander approval for any exception.
+
+### B) Reliability Sprint Triggers
+
+A **mandatory reliability sprint** starts (or is scheduled for next sprint start) when any condition is true:
+
+1. **Budget remaining < 10%** for any critical SLO.
+2. **Budget exhausted** for any SLO.
+3. **Two or more P1 incidents in a calendar month** tied to the same subsystem.
+4. **Launch gate at risk:** streak cannot reach 3 compliant months without mitigation completion.
+
+Reliability sprint minimum outcomes:
+
+- Top three budget-burn drivers remediated or mitigated.
+- Alert noise/threshold review completed.
+- Postmortems complete for all P1/P2 incidents in period.
+- Updated monthly report published under `docs/status/slo-reports/`.
+
+## Response Workflow
+
+1. Confirm trigger details in dashboards + alert history.
+2. Open incident ticket and tag `slo-budget`.
+3. Announce freeze/sprint mode in operator channel.
+4. Assign owners:
+   - Incident Commander
+   - Reliability Lead
+   - Service owner(s) for affected SLOs
+5. Execute mitigations and record evidence links.
+6. Update monthly SLO report and launch-gate streak table.
+7. Lift freeze only after criteria are met.
+
+## Freeze Exit Criteria
+
+All conditions must be true:
+
+- No active unmitigated P1 SLO breach.
+- Budget remaining for impacted SLOs is stabilized above 25% or approved exception is documented.
+- Corrective actions for root cause are scheduled with owners/dates.
+- A linked postmortem exists for every P1/P2 incident that contributed.
+
+## Reliability Sprint Exit Criteria
+
+All conditions must be true:
+
+- Mitigations for all critical breaches are implemented or explicitly accepted by leadership with dated risk acceptance.
+- Next-month burn-rate projection is within budget envelope.
+- Monthly report and operator runbook references are updated.
+
+## Evidence and Reporting
+
+- Primary monthly artifact: `docs/status/slo-reports/YYYY-MM-slo-review.md`
+- Include:
+  - Compliance summary
+  - Budget + burn-rate table
+  - Incident/postmortem links
+  - Action register and owners
+  - Launch gate streak status

--- a/docs/operations/operator-runbook.md
+++ b/docs/operations/operator-runbook.md
@@ -2,6 +2,24 @@
 
 Use [Provider Confidence Baseline](../providers/provider-confidence-baseline.md) as the source of truth for what Meridian validates offline today for Polygon, NYSE, Interactive Brokers, and StockSharp. This runbook focuses on operator workflows and deliberately avoids implying broader provider readiness than the repo evidence supports.
 
+
+## SLO Escalation Ownership and Postmortem Linkage
+
+When SLO alerts fire, use this ownership model:
+
+| Priority | Primary owner | Secondary owner | Initial SLA | Required artifact |
+|---|---|---|---|---|
+| P1 | Incident Commander (on-call) | Reliability Lead | Acknowledge <= 5 minutes | Linked postmortem within 2 business days |
+| P2 | Service Owner (affected subsystem) | Reliability Lead | Acknowledge <= 15 minutes | Linked postmortem or incident review within 5 business days |
+
+Required linkage rules:
+
+1. Every P1/P2 SLO incident must include a postmortem link in the monthly SLO report (`docs/status/slo-reports/YYYY-MM-slo-review.md`).
+2. If no postmortem exists yet, mark the incident as **unmitigated** and keep launch gate status as failed.
+3. Incident action items must map to owners and due dates and be recorded in the monthly action register.
+
+See [Error Budget Policy Runbook](./error-budget-policy-runbook.md) for deployment freeze and reliability sprint triggers.
+
 ## Startup
 
 ### Headless / Test Mode

--- a/docs/operations/service-level-objectives.md
+++ b/docs/operations/service-level-objectives.md
@@ -205,6 +205,22 @@ At the start of each month:
 4. Adjust alert thresholds if burn rate is too noisy
 5. Update incident priority mappings if needed
 
+
+### Monthly Report Publication
+
+Publish one dated report per month under `docs/status/slo-reports/` using [`slo-review-template.md`](./slo-review-template.md).
+
+Recommended filename format: `YYYY-MM-slo-review.md`.
+
+**Collection workflow (manual or automation script wrapper):**
+
+1. Capture monitoring exports for the month window (`/metrics`, `/status`, `/healthz`) into `artifacts/slo/YYYY-MM/`.
+2. Compute compliance and error-budget burn from the captured data.
+3. Link all P1/P2 incidents to postmortems and mitigation actions.
+4. Publish the completed report to `docs/status/slo-reports/YYYY-MM-slo-review.md`.
+
+**Launch gate:** shipping readiness requires **3 consecutive monthly SLO reviews with no unmitigated critical breach**.
+
 ---
 
 ## Monitoring Implementation

--- a/docs/operations/slo-review-template.md
+++ b/docs/operations/slo-review-template.md
@@ -1,0 +1,71 @@
+# Monthly SLO Review Template
+
+Use this template for monthly reliability reviews driven by the SLO catalog in [Service Level Objectives](./service-level-objectives.md).
+
+- **Review month (UTC):** `YYYY-MM`
+- **Review owner:** `Primary on-call / Reliability lead`
+- **Date published:** `YYYY-MM-DD`
+- **Source window:** `YYYY-MM-01 00:00:00Z` to `<next-month>-01 00:00:00Z`
+- **Report path:** `docs/status/slo-reports/YYYY-MM-slo-review.md`
+
+## 1) Compliance Summary
+
+| SLO ID | Metric | Target | Actual | Status (Met / Breached / At Risk) | Notes |
+|---|---|---|---|---|---|
+| SLO-ING-001 | `mdc_provider_latency_seconds` (P95/P99) | P95 < 2s, P99 < 5s | `...` | `...` | `...` |
+| SLO-ING-002 | Drop rate | < 0.1% daily | `...` | `...` | `...` |
+| SLO-DC-001 | Completeness | >= 95% daily | `...` | `...` | `...` |
+| SLO-DC-002 | Gap duration | No gap > 5m | `...` | `...` | `...` |
+| SLO-AV-001 | Uptime | 99.9% market hours | `...` | `...` | `...` |
+| SLO-AV-002 | Health checks | 99.5% healthy | `...` | `...` | `...` |
+| SLO-DF-001 | Freshness | P95 < 60s | `...` | `...` | `...` |
+| SLO-DF-002 | Backfill freshness | <= 30m after close | `...` | `...` | `...` |
+| SLO-ST-001 | Write reliability | 0 write errors | `...` | `...` | `...` |
+| SLO-ST-002 | Storage capacity | >= 20% free | `...` | `...` | `...` |
+| SLO-PC-001 | Provider availability | 99.5% connected | `...` | `...` | `...` |
+| SLO-PC-002 | Failover time | <= 30s | `...` | `...` | `...` |
+
+## 2) Error Budget and Burn-Rate Review
+
+| SLO ID | Monthly Budget | Budget Consumed | Budget Remaining | Max Burn Rate (1h/6h/24h) | Triggered Thresholds |
+|---|---:|---:|---:|---|---|
+| `SLO-*` | `...` | `...` | `...` | `...` | `...` |
+
+- **Top burn-rate contributor(s):**
+  - `...`
+- **Was a freeze or reliability sprint triggered this month?** `Yes/No`
+- **If yes, reference runbook actions:** `docs/operations/error-budget-policy-runbook.md#...`
+
+## 3) Incident Review Linkage
+
+| Incident ID | Priority (P1/P2) | Related SLO(s) | User impact summary | Postmortem link | Follow-up action IDs |
+|---|---|---|---|---|---|
+| `INC-YYYY-MM-###` | `P1/P2` | `SLO-*` | `...` | `docs/status/incidents/...` | `ACT-...` |
+
+- Confirm every P1/P2 incident has a linked postmortem artifact.
+- Confirm every critical breach has mitigation owner + due date.
+
+## 4) Action Register
+
+| Action ID | Trigger | Owner | Due date | Severity | Status | Evidence link |
+|---|---|---|---|---|---|---|
+| `ACT-YYYY-MM-01` | `SLO critical breach` | `Team/Role` | `YYYY-MM-DD` | `Critical/High/Medium` | `Open/In Progress/Closed` | `...` |
+
+## 5) Launch Gate Check
+
+> **Gate:** 3 consecutive monthly SLO reviews with no unmitigated critical breach.
+
+| Month | Critical breach present? | Mitigated within month? | Counts toward streak? |
+|---|---|---|---|
+| `YYYY-MM` | `Yes/No` | `Yes/No` | `Yes/No` |
+| `YYYY-MM` | `Yes/No` | `Yes/No` | `Yes/No` |
+| `YYYY-MM` | `Yes/No` | `Yes/No` | `Yes/No` |
+
+- **Current streak:** `N / 3`
+- **Launch gate status:** `PASS/FAIL`
+
+## 6) Approvals
+
+- **Reliability lead sign-off:** `Name, date`
+- **Operations lead sign-off:** `Name, date`
+- **Product/Program sign-off (if launch gate affected):** `Name, date`

--- a/docs/status/slo-reports/README.md
+++ b/docs/status/slo-reports/README.md
@@ -1,0 +1,25 @@
+# Monthly SLO Reports
+
+Store one report per month using:
+
+- Filename: `YYYY-MM-slo-review.md`
+- Template: [`docs/operations/slo-review-template.md`](../../operations/slo-review-template.md)
+
+## Publication Workflow
+
+1. Collect metrics for the monthly UTC window.
+2. Fill out the template sections (compliance, burn rate, incidents, actions, launch gate).
+3. Commit the report in this folder.
+
+## Manual Collection Commands
+
+Run these against a running local or production-representative host and store outputs under `artifacts/slo/YYYY-MM/`.
+
+```bash
+mkdir -p artifacts/slo/YYYY-MM
+curl -sS http://localhost:8080/metrics > artifacts/slo/YYYY-MM/metrics.prom
+curl -sS http://localhost:8080/status > artifacts/slo/YYYY-MM/status.json
+curl -sS http://localhost:8080/healthz > artifacts/slo/YYYY-MM/healthz.txt
+```
+
+For incident linkage, export P1/P2 incident IDs and postmortem references from your incident tracker and copy into the monthly report.


### PR DESCRIPTION
### Motivation

- Standardize monthly SLO reviews and ensure a repeatable output for compliance, burn-rate, incidents, and actions. 
- Define clear, automated-triggerable responses (deployment freeze / reliability sprint) to error-budget exhaustion and high burn rates. 
- Provide a documented collection and publication workflow so monthly reports are captured and archived under `docs/status/slo-reports/`. 
- Clarify escalation ownership and postmortem linkage so critical incidents are tracked and gate decisions are auditable.

### Description

- Added a monthly review template at `docs/operations/slo-review-template.md` that captures compliance, error-budget/burn-rate, incident-to-postmortem linkage, action register, approvals, and a launch-gate streak check (3 consecutive compliant months). 
- Added an operational `docs/operations/error-budget-policy-runbook.md` that defines explicit deployment-freeze and reliability-sprint triggers, response workflow, and exit criteria. 
- Updated `docs/operations/service-level-objectives.md` to document the monthly report publication workflow, recommended collection steps, and the explicit launch gate requirement. 
- Updated `docs/operations/operator-runbook.md` to define P1/P2 escalation ownership, SLAs for acknowledge/postmortem linkage, and rules for marking incidents as unmitigated when postmortems are missing; and updated `docs/operations/README.md` to surface the new artifacts. 
- Added `docs/status/slo-reports/README.md` to prescribe filename conventions and simple manual collection commands (`/metrics`, `/status`, `/healthz`) and where to store monthly artifacts.

### Testing

- Documentation-only changes; no automated code tests were required or run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17517a03748320b895fcdd012806d3)