### PR TITLE
Add SOC 2 compliance workspace under docs/security

### DIFF
--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -8,6 +8,11 @@ Security-related documentation for the Meridian.
 |----------|-------------|
 | [Known Vulnerabilities](known-vulnerabilities.md) | Assessed and accepted dependency vulnerabilities with documented mitigations |
 | [Threat Model (Current State)](threat-model-current-state.md) | Current trust boundaries, attack surfaces, mitigations, and severity calibration |
+| [SOC 2 Compliance Workspace](compliance/) | SOC 2 program scope, control matrix, evidence calendar, and roadmap for procurement/audit reviewers |
+| [SOC 2 Scope](compliance/soc2-scope.md) | In-scope systems and trust-boundary coverage for SOC 2 readiness |
+| [SOC 2 Control Matrix](compliance/soc2-control-matrix.md) | Trust Services Criteria mapping to Meridian controls, owners, and evidence sources |
+| [SOC 2 Evidence Calendar](compliance/soc2-evidence-calendar.md) | Monthly and quarterly cadence for SOC evidence collection and review ownership |
+| [SOC 2 Roadmap](compliance/soc2-roadmap.md) | Dated milestones for readiness, Type I, remediation, and Type II observation period |
 
 ## Security Practices
 

--- a/docs/security/compliance/soc2-control-matrix.md
+++ b/docs/security/compliance/soc2-control-matrix.md
@@ -1,0 +1,25 @@
+# SOC 2 Control Matrix (Meridian)
+
+**Last Updated:** 2026-05-27  
+**Control Framework:** AICPA Trust Services Criteria (TSC)
+
+This matrix maps relevant SOC 2 criteria families to implemented Meridian controls and evidence sources.
+
+| TSC Family | Meridian control statement | Control owner | Evidence source(s) |
+|---|---|---|---|
+| CC1 (Control Environment) | Security, operations, and development responsibilities are documented and routed through runbooks, architecture docs, and ownership workflows. | Engineering Manager | `docs/architecture/module-map.md`; `docs/operations/operator-runbook.md`; `docs/plans/current-direction-and-status.md` |
+| CC2 (Communication & Information) | Security and operational changes are communicated through maintained docs, status dashboards, and evidence packets. | Program Manager | `docs/status/doc-health-dashboard.md`; `docs/status/evidence/wave2-cockpit-evidence-packet.md`; `docs/security/README.md` |
+| CC3 (Risk Assessment) | Threat and abuse scenarios are documented and severity-calibrated with explicit assumptions and residual risk notes. | Security Lead | `docs/security/threat-model-current-state.md`; `docs/security/known-vulnerabilities.md` |
+| CC4 (Monitoring Activities) | Operational health, provider posture, and validation gates are periodically reviewed with documented outputs. | Operations Lead | `docs/status/kernel-readiness-dashboard.md`; `docs/status/provider-validation-matrix.md`; `docs/operations/service-level-objectives.md` |
+| CC5 (Control Activities) | Change workflows require build/test checks and focused validation for impacted areas before release/promotion. | Release Manager | `docs/developer/build-test-run.md`; `docs/development/desktop-testing-guide.md`; `docs/development/build-observability.md` |
+| CC6 (Logical & Physical Access) | Authentication and permission controls gate sensitive endpoints and credential workflows; role-based access is enforced on key mutation routes. | Security Lead | `docs/security/threat-model-current-state.md`; `docs/operations/provider-credential-management.md`; `docs/operations/live-execution-controls.md` |
+| CC7 (System Operations) | Platform operations follow preflight, deployment, reconciliation, and incident-oriented runbooks with clear operator steps. | Operations Lead | `docs/operations/preflight-checklist.md`; `docs/operations/deployment.md`; `docs/operations/reconciliation-runbook.md` |
+| CC8 (Change Management) | CI/CD and release automation include repeatable build/test workflows, diagnostics, and artifact traceability. | DevEx Lead | `docs/development/build-observability.md`; `docs/operations/msix-packaging.md`; `.github/workflows/security.yml` |
+| CC9 (Risk Mitigation) | Provider degradation policy, calibration, and promotion evidence mitigate external data/integration risk before trust promotion. | Data Platform Lead | `docs/operations/provider-degradation-policy.md`; `docs/operations/provider-degradation-calibration.md`; `docs/status/evidence/dk1-pilot-parity-runbook.md` |
+| A1 (Availability) | High-availability, SLO, and recovery operational guidance define uptime objectives and recovery expectations. | Operations Lead | `docs/operations/high-availability.md`; `docs/operations/service-level-objectives.md`; `docs/operations/cleanup-and-maintenance.md` |
+| C1 (Confidentiality) | Credential handling and sensitive configuration practices define restricted handling expectations for secrets and integration data. | Security Lead | `docs/operations/provider-credential-management.md`; `docs/reference/environment-variables.md`; `docs/security/threat-model-current-state.md` |
+
+## Notes for audit preparation
+
+- For each control row, attach execution-period artifacts (logs, screenshots, test reports, approval records) in the SOC evidence repository when available.
+- Keep control owners aligned to named roles, then map to specific individuals in the audit engagement roster.

--- a/docs/security/compliance/soc2-evidence-calendar.md
+++ b/docs/security/compliance/soc2-evidence-calendar.md
@@ -1,0 +1,36 @@
+# SOC 2 Evidence Calendar (Meridian)
+
+**Last Updated:** 2026-05-27
+
+This cadence defines minimum evidence collection frequency and review ownership for SOC readiness, Type I preparation, and Type II sustainment.
+
+## Monthly cadence
+
+| Evidence stream | Collection action | Owner | Due (monthly) |
+|---|---|---|---|
+| Access control posture | Capture auth/RBAC configuration snapshot, permission changes, and credential workflow checks. | Security Lead | 5th business day |
+| Vulnerability and dependency posture | Record current vulnerability status, accepted risks, and remediation deltas. | Security Lead | 5th business day |
+| Change-management evidence | Archive build/test/security workflow runs and release validation evidence. | Release Manager | 7th business day |
+| Operations runbook execution | Capture preflight/deployment/reconciliation runbook artifacts for the period. | Operations Lead | 7th business day |
+| Provider governance | Archive provider validation outcomes and degradation/promotion decisions. | Data Platform Lead | 10th business day |
+
+## Quarterly cadence
+
+| Evidence stream | Collection action | Owner | Due (quarterly) |
+|---|---|---|---|
+| Threat model review | Revalidate trust boundaries, attack surfaces, and residual risks. | Security Lead | Quarter +10 business days |
+| Scope and control matrix review | Confirm in-scope systems, control ownership, and evidence source integrity. | Security Lead + Engineering Manager | Quarter +10 business days |
+| DR/availability review | Validate SLO posture and high-availability/recovery assumptions. | Operations Lead | Quarter +12 business days |
+| Vendor/provider risk review | Review provider endpoint governance, credential workflows, and calibration policy updates. | Data Platform Lead | Quarter +12 business days |
+| Executive compliance checkpoint | Review evidence completeness, gaps, and remediation commitments. | Program Manager | Quarter +15 business days |
+
+## Evidence packaging standards
+
+- Store each monthly and quarterly packet under a dated folder structure (e.g., `YYYY/MM` and `YYYY/Q#`).
+- Include source links to Meridian docs plus generated artifacts (logs, CI reports, screenshots, approvals).
+- Maintain reviewer sign-off per packet (preparer + reviewer).
+
+## Escalation SLA
+
+- Missing monthly evidence older than 10 business days is escalated to Engineering Manager.
+- Missing quarterly evidence older than 15 business days is escalated to executive sponsor.

--- a/docs/security/compliance/soc2-roadmap.md
+++ b/docs/security/compliance/soc2-roadmap.md
@@ -1,0 +1,46 @@
+# SOC 2 Program Roadmap (Meridian)
+
+**Last Updated:** 2026-05-27
+
+## Program timeline
+
+| Milestone | Target window | Outcome |
+|---|---|---|
+| Readiness assessment | 2026-06-15 to 2026-07-10 | Baseline gap assessment, scoped controls, evidence owners, and remediations backlog. |
+| Type I audit window | 2026-08-17 to 2026-09-11 | Point-in-time design assessment of Security baseline controls (+ Availability/Confidentiality if in scope contractually). |
+| Remediation sprint | 2026-09-14 to 2026-10-23 | Close Type I findings, harden evidence workflows, and finalize Type II operational packet templates. |
+| Type II observation period | 2026-11-01 to 2027-05-31 (7 months) | Demonstrate sustained control operation over a 6–12 month window with recurring evidence and reviewer sign-offs. |
+
+## Milestone detail
+
+### 1) Readiness assessment (June–July 2026)
+
+- Finalize scope boundaries for API, operator surfaces, storage, provider integrations, and CI/CD.
+- Complete control-matrix ownership assignment.
+- Launch monthly and quarterly evidence calendar operations.
+- Produce readiness report with prioritized gaps and remediation owners.
+
+### 2) Type I audit window (August–September 2026)
+
+- Freeze control descriptions and evidence source inventory.
+- Provide auditor walk-through packet (architecture, threat model, runbooks, test/change records).
+- Capture auditor questions and formalize Type I findings.
+
+### 3) Remediation sprint (September–October 2026)
+
+- Resolve identified control-design or documentation gaps.
+- Backfill missing evidence artifacts and review records.
+- Validate high-risk controls (access, change, operations, provider governance) with spot checks.
+
+### 4) Type II observation period (November 2026–May 2027)
+
+- Execute monthly and quarterly evidence capture without missed cycles.
+- Run quarterly compliance checkpoints and corrective-action tracking.
+- Prepare final Type II evidence binders and management assertions.
+
+## Exit criteria by phase
+
+- **Readiness complete:** scope + matrix + calendar approved by Security Lead and Engineering Manager.
+- **Type I complete:** report issued with remediation backlog triaged by severity/owner/date.
+- **Remediation complete:** all high-severity findings closed or risk-accepted with sponsor sign-off.
+- **Type II complete:** continuous evidence over observation period with no material control failure.

--- a/docs/security/compliance/soc2-scope.md
+++ b/docs/security/compliance/soc2-scope.md
@@ -1,0 +1,85 @@
+# SOC 2 Scope Definition (Meridian)
+
+**Last Updated:** 2026-05-27  
+**Program Owner:** Security & Platform Engineering
+
+## Objective
+
+Define the Meridian systems and workflows that are in scope for SOC 2 readiness and audit execution, aligned to the Trust Services Criteria (Security as baseline, with Availability and Confidentiality where contracted).
+
+## In-Scope System Boundaries
+
+### 1) API host and backend command/runtime services
+
+- Core host runtime (`src/Meridian/`) including API surfaces, orchestration, command handlers, and endpoint authorization behavior.
+- Shared workstation endpoint surfaces under `src/Meridian.Ui.Shared/Endpoints/*` and related application service layers.
+- Authentication/session controls, RBAC permission checks, and rate-limiting behaviors documented in the current threat model.
+
+Initial evidence pointers:
+- `docs/security/threat-model-current-state.md`
+- `docs/operations/operator-runbook.md`
+- `docs/operations/live-execution-controls.md`
+- `docs/operations/preflight-checklist.md`
+
+### 2) Operator interfaces (WPF + browser workstation)
+
+- Desktop operator surface (`src/Meridian.Wpf/`) used for trading, portfolio, accounting, reporting, strategy, data, and settings workflows.
+- Browser operator surface (`src/Meridian.Ui/dashboard/`) and built workstation asset lane (`src/Meridian.Ui/wwwroot/workstation/`).
+- Role-aware operator flows and command execution paths that can mutate production-like state.
+
+Initial evidence pointers:
+- `docs/development/wpf-implementation-notes.md`
+- `docs/operations/workstation-governance-approval-runbook.md`
+- `docs/status/evidence/wave2-cockpit-evidence-packet.md`
+
+### 3) Storage and data integrity surfaces
+
+- Local and managed storage paths used for JSONL/Parquet, WAL, package import/export, and replay artifacts.
+- Database-backed state (fund operations, reconciliation, account/business records) and storage migration/maintenance workflows.
+- Data package lifecycle controls (create/list/validate/import/delete) and path-containment protections.
+
+Initial evidence pointers:
+- `docs/operations/reconciliation-operations.md`
+- `docs/operations/reconciliation-runbook.md`
+- `docs/operations/portable-data-packager.md`
+- `docs/operations/fund-ops-persistence-cutover-runbook.md`
+
+### 4) Provider and integration boundary controls
+
+- Provider adapters and credentialed integrations (market data, brokerage, historical/backfill, statement and ETL ingress paths).
+- Provider degradation calibration, promotion gates, and validation packets.
+- External endpoint governance for integration host/port configuration.
+
+Initial evidence pointers:
+- `docs/operations/provider-credential-management.md`
+- `docs/operations/provider-degradation-policy.md`
+- `docs/operations/provider-degradation-calibration.md`
+- `docs/status/provider-validation-matrix.md`
+- `docs/status/evidence/dk1-pilot-parity-runbook.md`
+
+### 5) CI/CD and release workflows
+
+- Build/test/security gates from local automation and GitHub workflow execution.
+- Security scanning and dependency/audit checks.
+- Packaging/install artifacts for operator deployment pathways (MSIX and related publish outputs).
+
+Initial evidence pointers:
+- `docs/development/build-observability.md`
+- `docs/development/documentation-automation.md`
+- `docs/operations/deployment.md`
+- `docs/operations/msix-packaging.md`
+- `docs/status/doc-health-dashboard.md`
+
+## Out-of-Scope (Current Program Iteration)
+
+- Mobile clients (iOS, Android, MAUI, React Native, Flutter).
+- Third-party systems not controlled by Meridian engineering (covered via vendor-management evidence instead of direct control testing).
+- Historical archive-only docs/artifacts not tied to active operational control execution.
+
+## Scope Governance
+
+- Scope changes require approval by Security Lead + Engineering Manager.
+- Any new production-significant subsystem must be tagged as:
+  - **In scope now**, or
+  - **Deferred with risk acceptance + target inclusion milestone**.
+- Scope is reviewed quarterly alongside SOC evidence cadence.


### PR DESCRIPTION
### Motivation

- Provide a discoverable SOC 2 program workspace for procurement and audit reviewers that centralizes scope, controls, evidence cadence, and roadmap.  
- Seed the SOC 2 artifacts with initial evidence pointers into existing security, operations, and status documentation to accelerate readiness and auditor walkthroughs.  
- Create a lightweight governance surface to assign owners and recurring evidence duties ahead of a Type I audit window.

### Description

- Add `docs/security/compliance/soc2-scope.md` defining in-scope systems (API host/runtime, WPF/browser operator surfaces, storage, provider integrations, and CI/CD) with initial evidence pointers.  
- Add `docs/security/compliance/soc2-control-matrix.md` mapping AICPA Trust Services Criteria to Meridian control statements with named owner roles and referenced evidence sources.  
- Add `docs/security/compliance/soc2-evidence-calendar.md` defining monthly and quarterly evidence collection cadence, packaging standards, and escalation SLAs with owners.  
- Add `docs/security/compliance/soc2-roadmap.md` with dated milestones for readiness assessment, Type I audit window, remediation sprint, and a 6–12 month Type II observation period (implemented as a 7-month window).  
- Update `docs/security/README.md` to link the new SOC 2 workspace and the four SOC documents for quick discovery by procurement/audit reviewers.

### Testing

- Verified new files exist and content with `nl -ba docs/security/compliance/*.md` and confirmed README links render with `sed -n` checks.  
- Confirmed repository status and staged changes with `git status --short` and successfully committed the documentation with `git commit -m "Add SOC 2 compliance workspace documentation"`.  
- Recorded PR metadata using the repository `make_pr` helper to capture the PR title/body for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1751738ec8832088417d13bdd7fbd9)