### PR TITLE
Add versioned report template registry and governed report-pack workflow

### DIFF
--- a/src/Meridian.Contracts/Workstation/FundOperationsWorkspaceDtos.cs
+++ b/src/Meridian.Contracts/Workstation/FundOperationsWorkspaceDtos.cs
@@ -289,3 +289,36 @@ public sealed record FundReportPackHistoryItemDto(
 
     public int LifecycleEventCount { get; init; }
 }
+
+[JsonConverter(typeof(JsonStringEnumConverter<ReportPackWorkflowStateDto>))]
+public enum ReportPackWorkflowStateDto
+{
+    Draft = 0,
+    InReview = 1,
+    Approved = 2,
+    Published = 3,
+    Restated = 4
+}
+
+public sealed record VersionedReportTemplateIdDto(string Name, int Version);
+public sealed record ReportTemplateParameterDefinitionDto(string Name, bool Required);
+public sealed record ReportTemplateDefinitionDto(VersionedReportTemplateIdDto TemplateId, string DisplayName, IReadOnlyList<ReportTemplateParameterDefinitionDto> Parameters);
+public sealed record RenderReportTemplateRequestDto(VersionedReportTemplateIdDto TemplateId, IReadOnlyDictionary<string, string> Parameters);
+public sealed record RenderReportTemplateResponseDto(VersionedReportTemplateIdDto TemplateId, string RenderedContent, IReadOnlyList<string> MissingRequiredParameters);
+
+public sealed record ReportPackAuditEventDto(DateTimeOffset At, string Actor, string Action, ReportPackWorkflowStateDto FromState, ReportPackWorkflowStateDto ToState, string? Note = null);
+public sealed record ReportPackChangedLineDto(string LineKey, string PreviousValue, string CurrentValue);
+public sealed record ReportPackRestatementMetadataDto(string ReasonCode, string Approver, Guid PriorVersionReportId, IReadOnlyList<ReportPackChangedLineDto> ChangedLines);
+public sealed record ReportPackWorkflowRecordDto(
+    Guid ReportId,
+    string FundProfileId,
+    string FundAccountId,
+    string Period,
+    VersionedReportTemplateIdDto TemplateId,
+    ReportPackWorkflowStateDto State,
+    int Version,
+    DateTimeOffset CreatedAt,
+    string CreatedBy,
+    DateTimeOffset UpdatedAt,
+    IReadOnlyList<ReportPackAuditEventDto> AuditTrail,
+    ReportPackRestatementMetadataDto? Restatement);

--- a/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
@@ -492,6 +492,64 @@ public static class FundStructureEndpoints
         .Produces<IReadOnlyList<FundReportPackHistoryItemDto>>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status400BadRequest);
 
+
+        group.MapPost("/reporting/templates", (ReportTemplateDefinitionDto request, HttpContext context) =>
+        {
+            var registry = context.RequestServices.GetService<ReportTemplateRegistryService>();
+            return registry is null ? WorkspaceServiceUnavailable() : Results.Json(registry.Register(request), jsonOptions, statusCode: StatusCodes.Status201Created);
+        });
+
+        group.MapPost("/reporting/templates/render", (RenderReportTemplateRequestDto request, HttpContext context) =>
+        {
+            var registry = context.RequestServices.GetService<ReportTemplateRegistryService>();
+            if (registry is null)
+            {
+                return WorkspaceServiceUnavailable();
+            }
+
+            try
+            {
+                return Results.Json(registry.Render(request), jsonOptions);
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.Problem(ex.Message, statusCode: StatusCodes.Status400BadRequest);
+            }
+        });
+
+        group.MapPost("/reporting/packs/create", (string fundProfileId, string fundAccountId, string period, VersionedReportTemplateIdDto templateId, string actor, HttpContext context) =>
+        {
+            var svc = context.RequestServices.GetService<ReportPackWorkflowService>();
+            return svc is null ? WorkspaceServiceUnavailable() : Results.Json(svc.Create(fundProfileId, fundAccountId, period, templateId, actor), jsonOptions, statusCode: StatusCodes.Status201Created);
+        });
+
+        group.MapPost("/reporting/packs/{reportId:guid}/submit", (Guid reportId, string actor, string role, HttpContext context) => TransitionPack(context, reportId, ReportPackWorkflowStateDto.InReview, actor, role));
+        group.MapPost("/reporting/packs/{reportId:guid}/approve", (Guid reportId, string actor, string role, HttpContext context) => TransitionPack(context, reportId, ReportPackWorkflowStateDto.Approved, actor, role));
+        group.MapPost("/reporting/packs/{reportId:guid}/publish", (Guid reportId, string actor, string role, HttpContext context) => TransitionPack(context, reportId, ReportPackWorkflowStateDto.Published, actor, role));
+
+        group.MapPost("/reporting/packs/{reportId:guid}/restate", (Guid reportId, string actor, string role, string reasonCode, string approver, Guid priorVersionReportId, ReportPackChangedLineDto[] changedLines, HttpContext context) =>
+        {
+            var svc = context.RequestServices.GetService<ReportPackWorkflowService>();
+            if (svc is null)
+            {
+                return WorkspaceServiceUnavailable();
+            }
+
+            try
+            {
+                return Results.Json(svc.Restate(reportId, actor, role, reasonCode, approver, priorVersionReportId, changedLines), jsonOptions);
+            }
+            catch (Exception ex) when (ex is ArgumentException or UnauthorizedAccessException or InvalidOperationException or KeyNotFoundException)
+            {
+                return Results.Problem(ex.Message, statusCode: StatusCodes.Status400BadRequest);
+            }
+        });
+
+        group.MapGet("/reporting/packs/history", (string period, string fundAccountId, HttpContext context) =>
+        {
+            var svc = context.RequestServices.GetService<ReportPackWorkflowService>();
+            return svc is null ? WorkspaceServiceUnavailable() : Results.Json(svc.GetHistory(period, fundAccountId), jsonOptions);
+        });
         group.MapGet("/report-packs/{reportId:guid}", async (Guid reportId, HttpContext context) =>
         {
             var service = ResolveWorkspaceService(context);
@@ -508,6 +566,24 @@ public static class FundStructureEndpoints
         .Produces(StatusCodes.Status404NotFound);
     }
 
+
+    private static IResult TransitionPack(HttpContext context, Guid reportId, ReportPackWorkflowStateDto target, string actor, string role)
+    {
+        var svc = context.RequestServices.GetService<ReportPackWorkflowService>();
+        if (svc is null)
+        {
+            return WorkspaceServiceUnavailable();
+        }
+
+        try
+        {
+            return Results.Json(svc.Transition(reportId, target, actor, role), statusCode: StatusCodes.Status200OK);
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or InvalidOperationException or KeyNotFoundException)
+        {
+            return Results.Problem(ex.Message, statusCode: StatusCodes.Status400BadRequest);
+        }
+    }
     private static IFundStructureService? ResolveService(HttpContext context) =>
         context.RequestServices.GetService<IFundStructureService>();
 

--- a/src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs
@@ -1,0 +1,101 @@
+using System.Collections.Concurrent;
+using Meridian.Contracts.Workstation;
+
+namespace Meridian.Ui.Shared.Services;
+
+public sealed class ReportTemplateRegistryService
+{
+    private readonly ConcurrentDictionary<string, ReportTemplateDefinitionDto> _templates = new(StringComparer.OrdinalIgnoreCase);
+
+    public ReportTemplateDefinitionDto Register(ReportTemplateDefinitionDto definition)
+    {
+        _templates[ToKey(definition.TemplateId)] = definition;
+        return definition;
+    }
+
+    public ReportTemplateDefinitionDto? Get(VersionedReportTemplateIdDto id) =>
+        _templates.TryGetValue(ToKey(id), out var template) ? template : null;
+
+    public RenderReportTemplateResponseDto Render(RenderReportTemplateRequestDto request)
+    {
+        var template = Get(request.TemplateId) ?? throw new ArgumentException("Template not found.");
+        var missing = template.Parameters.Where(p => p.Required && !request.Parameters.ContainsKey(p.Name)).Select(p => p.Name).ToArray();
+        var rendered = $"template:{template.TemplateId.Name}@v{template.TemplateId.Version};" + string.Join(';', request.Parameters.OrderBy(k => k.Key).Select(kvp => $"{kvp.Key}={kvp.Value}"));
+        return new RenderReportTemplateResponseDto(template.TemplateId, rendered, missing);
+    }
+
+    private static string ToKey(VersionedReportTemplateIdDto id) => $"{id.Name}:{id.Version}";
+}
+
+public sealed class ReportPackWorkflowService
+{
+    private static readonly IReadOnlyDictionary<ReportPackWorkflowStateDto, ReportPackWorkflowStateDto[]> AllowedTransitions =
+        new Dictionary<ReportPackWorkflowStateDto, ReportPackWorkflowStateDto[]>
+        {
+            [ReportPackWorkflowStateDto.Draft] = [ReportPackWorkflowStateDto.InReview],
+            [ReportPackWorkflowStateDto.InReview] = [ReportPackWorkflowStateDto.Approved, ReportPackWorkflowStateDto.Draft],
+            [ReportPackWorkflowStateDto.Approved] = [ReportPackWorkflowStateDto.Published],
+            [ReportPackWorkflowStateDto.Published] = [ReportPackWorkflowStateDto.Restated],
+            [ReportPackWorkflowStateDto.Restated] = []
+        };
+
+    private readonly ConcurrentDictionary<Guid, ReportPackWorkflowRecordDto> _records = new();
+
+    public ReportPackWorkflowRecordDto Create(string fundProfileId, string fundAccountId, string period, VersionedReportTemplateIdDto templateId, string actor)
+    {
+        var id = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+        var record = new ReportPackWorkflowRecordDto(id, fundProfileId, fundAccountId, period, templateId, ReportPackWorkflowStateDto.Draft, 1, now, actor, now,
+            [new ReportPackAuditEventDto(now, actor, "create", ReportPackWorkflowStateDto.Draft, ReportPackWorkflowStateDto.Draft)]
+            , null);
+        _records[id] = record;
+        return record;
+    }
+
+    public ReportPackWorkflowRecordDto Transition(Guid reportId, ReportPackWorkflowStateDto target, string actor, string role, string? note = null)
+    {
+        if (!_records.TryGetValue(reportId, out var record)) throw new KeyNotFoundException("report pack not found");
+        EnsureRole(target, role);
+        if (!AllowedTransitions[record.State].Contains(target)) throw new InvalidOperationException($"invalid transition {record.State} -> {target}");
+        var now = DateTimeOffset.UtcNow;
+        var next = record with
+        {
+            State = target,
+            UpdatedAt = now,
+            AuditTrail = record.AuditTrail.Append(new ReportPackAuditEventDto(now, actor, target.ToString().ToLowerInvariant(), record.State, target, note)).ToArray()
+        };
+        _records[reportId] = next;
+        return next;
+    }
+
+    public ReportPackWorkflowRecordDto Restate(Guid reportId, string actor, string role, string reasonCode, string approver, Guid priorVersionReportId, IReadOnlyList<ReportPackChangedLineDto> changedLines)
+    {
+        if (string.IsNullOrWhiteSpace(reasonCode)) throw new ArgumentException("reasonCode is required");
+        if (changedLines.Count == 0) throw new ArgumentException("changedLines are required");
+        var transitioned = Transition(reportId, ReportPackWorkflowStateDto.Restated, actor, role, note: reasonCode);
+        var next = transitioned with
+        {
+            Version = transitioned.Version + 1,
+            Restatement = new ReportPackRestatementMetadataDto(reasonCode, approver, priorVersionReportId, changedLines)
+        };
+        _records[reportId] = next;
+        return next;
+    }
+
+    public IReadOnlyList<ReportPackWorkflowRecordDto> GetHistory(string period, string fundAccountId) =>
+        _records.Values.Where(x => x.Period == period && x.FundAccountId == fundAccountId).OrderByDescending(x => x.Version).ToArray();
+
+    private static void EnsureRole(ReportPackWorkflowStateDto target, string role)
+    {
+        var normalized = role.Trim().ToLowerInvariant();
+        var allowed = target switch
+        {
+            ReportPackWorkflowStateDto.InReview => normalized is "operator" or "reviewer",
+            ReportPackWorkflowStateDto.Approved => normalized is "approver" or "admin",
+            ReportPackWorkflowStateDto.Published => normalized is "publisher" or "admin",
+            ReportPackWorkflowStateDto.Restated => normalized is "approver" or "admin",
+            _ => true
+        };
+        if (!allowed) throw new UnauthorizedAccessException($"Role '{role}' cannot transition to {target}.");
+    }
+}

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -105,6 +105,8 @@ public static class WorkstationServiceCollectionExtensions
         services.TryAddSingleton<NavAttributionService>();
         services.TryAddSingleton<ReportGenerationService>();
         services.TryAddSingleton<ReportPackValidationService>();
+        services.TryAddSingleton<ReportTemplateRegistryService>();
+        services.TryAddSingleton<ReportPackWorkflowService>();
         services.TryAddSingleton<IGovernanceReportPackRepository>(sp =>
         {
             var logger = sp.GetRequiredService<ILogger<FileGovernanceReportPackRepository>>();

--- a/tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Meridian.Contracts.Workstation;
+using Meridian.Ui.Shared.Services;
+
+namespace Meridian.Tests.Ui;
+
+public sealed class ReportPackWorkflowServiceTests
+{
+    [Fact]
+    public void Transition_AllowsExpectedStateMachineFlow()
+    {
+        var svc = new ReportPackWorkflowService();
+        var created = svc.Create("fund-a", "acct-1", "2026-03", new VersionedReportTemplateIdDto("board-pack", 1), "author");
+
+        var submitted = svc.Transition(created.ReportId, ReportPackWorkflowStateDto.InReview, "reviewer", "reviewer");
+        var approved = svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Approved, "approver", "approver");
+        var published = svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Published, "publisher", "publisher");
+
+        published.State.Should().Be(ReportPackWorkflowStateDto.Published);
+        published.AuditTrail.Should().HaveCount(4);
+    }
+
+    [Fact]
+    public void Transition_RejectsInvalidRole()
+    {
+        var svc = new ReportPackWorkflowService();
+        var created = svc.Create("fund-a", "acct-1", "2026-03", new VersionedReportTemplateIdDto("board-pack", 1), "author");
+
+        Action act = () => svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Approved, "user", "reviewer");
+        act.Should().Throw<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public void Restate_RequiresLineageAndReasonMetadata()
+    {
+        var svc = new ReportPackWorkflowService();
+        var created = svc.Create("fund-a", "acct-1", "2026-03", new VersionedReportTemplateIdDto("board-pack", 1), "author");
+        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.InReview, "reviewer", "reviewer");
+        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Approved, "approver", "approver");
+        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Published, "publisher", "publisher");
+
+        var restated = svc.Restate(created.ReportId, "approver", "approver", "pricing-correction", "chief-approver", created.ReportId,
+            [new ReportPackChangedLineDto("line-1", "100", "125")]);
+
+        restated.State.Should().Be(ReportPackWorkflowStateDto.Restated);
+        restated.Restatement.Should().NotBeNull();
+        restated.Restatement!.ChangedLines.Should().ContainSingle();
+        restated.Version.Should().Be(2);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a versioned report template registry and render pipeline with parameter validation so reports can be authored and rendered deterministically by template name+version.
- Introduce a governed report-pack entity and state machine supporting Draft → InReview → Approved → Published → Restated to satisfy governance, audit trail, and restatement requirements.
- Support restatements that record reason codes, approver attribution, changed-line metadata, and linkage to prior versions for lineage and auditability.

### Description

- Added new DTOs/contracts: `VersionedReportTemplateIdDto`, `ReportTemplateDefinitionDto`, `RenderReportTemplateRequestDto`, `RenderReportTemplateResponseDto`, `ReportPackWorkflowStateDto`, `ReportPackAuditEventDto`, `ReportPackChangedLineDto`, `ReportPackRestatementMetadataDto`, and `ReportPackWorkflowRecordDto` in `src/Meridian.Contracts/Workstation/FundOperationsWorkspaceDtos.cs` to model versioned templates and workflow records.
- Implemented `ReportTemplateRegistryService` that supports registering templates and rendering them with required-parameter validation and returns `MissingRequiredParameters` when applicable (`src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs`).
- Implemented `ReportPackWorkflowService` providing an in-memory workflow with role-gated transitions, an explicit allowed-transitions table, audit trail appends, restatement logic that enforces `reasonCode` + changed-line items + prior-version linking, and history lookup by period/fund account (`src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs`).
- Exposed HTTP endpoints to manage templates and report-pack workflow actions: create/template render, create report-pack, submit/approve/publish/restate, and history listing in `src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs`.
- Registered the new services with DI in `src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs`.
- Added unit tests `ReportPackWorkflowServiceTests` to validate state-machine transitions, permission checks, and restatement lineage integrity (`tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs`).

### Testing

- Added `ReportPackWorkflowService` unit tests in `tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs` covering happy-path transitions, invalid-role rejection, and restatement metadata/lineage assertions; tests are present in the repo.
- Attempted to run the focused test via `dotnet test --filter "FullyQualifiedName~ReportPackWorkflowServiceTests"`, but the execution environment lacked the `dotnet` runtime, so the test run failed with `dotnet: command not found` and could not be executed here.
- The change is self-contained and wired into DI and endpoints; CI or a local environment with the .NET SDK should be used to run `dotnet test` and full build verification (`make test` / `dotnet test`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17533dd768832091ec2f3451d7883c)