### PR TITLE
Add ShadowBook valuation service with variance detection and reconciliation gating

### DIFF
--- a/src/Meridian.Strategies/Services/ShadowBookValuationService.cs
+++ b/src/Meridian.Strategies/Services/ShadowBookValuationService.cs
@@ -1,0 +1,152 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using Meridian.Contracts.Workstation;
+
+namespace Meridian.Strategies.Services;
+
+public interface IShadowBookValuationService
+{
+    Task<ShadowBookValuationResult> RunAsync(ShadowBookValuationRequest request, CancellationToken ct = default);
+}
+
+public sealed record ShadowBookValuationRequest(
+    string AccountId,
+    string StrategyProfile,
+    DateOnly PeriodEnd,
+    IReadOnlyList<ShadowBookPositionInput> Positions,
+    IReadOnlyDictionary<string, decimal> PricesBySymbol,
+    IReadOnlyDictionary<string, decimal> FxRatesByCurrency,
+    decimal Fees,
+    decimal Accruals,
+    decimal ExternalReferenceNav,
+    bool BlockCloseOnBreach,
+    string OperatorId);
+
+public sealed record ShadowBookPositionInput(string Symbol, decimal Quantity, string PriceCurrency);
+public sealed record ShadowBookVarianceThresholds(decimal AbsoluteMateriality, decimal BpsMateriality);
+public sealed record ShadowBookRunSnapshot(string RunId, string VersionHash, DateTimeOffset CreatedAt, string AccountId, DateOnly PeriodEnd, decimal ShadowNav, decimal ExternalNav, decimal VarianceAmount, decimal VarianceBps, bool Breached);
+public sealed record ShadowBookValuationResult(ShadowBookRunSnapshot Snapshot, bool CloseBlocked, ReconciliationBreakQueueItem? EmittedBreak);
+
+public sealed class ShadowBookValuationService : IShadowBookValuationService
+{
+    private readonly IReconciliationBreakQueueRepository _breakQueueRepository;
+    private readonly Dictionary<string, ShadowBookVarianceThresholds> _thresholds;
+    private readonly List<ShadowBookRunSnapshot> _snapshots = [];
+
+    public ShadowBookValuationService(IReconciliationBreakQueueRepository breakQueueRepository, IReadOnlyDictionary<string, ShadowBookVarianceThresholds>? thresholds = null)
+    {
+        _breakQueueRepository = breakQueueRepository;
+        _thresholds = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["default"] = new ShadowBookVarianceThresholds(100m, 25m)
+        };
+
+        if (thresholds is not null)
+        {
+            foreach (var pair in thresholds)
+            {
+                _thresholds[pair.Key] = pair.Value;
+            }
+        }
+    }
+
+    public Task<ShadowBookValuationResult> RunAsync(ShadowBookValuationRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var threshold = _thresholds.TryGetValue(request.StrategyProfile, out var configured)
+            ? configured
+            : _thresholds["default"];
+
+        decimal gross = 0m;
+        foreach (var position in request.Positions.OrderBy(p => p.Symbol, StringComparer.Ordinal))
+        {
+            var px = request.PricesBySymbol[position.Symbol];
+            var fx = request.FxRatesByCurrency.GetValueOrDefault(position.PriceCurrency, 1m);
+            gross += position.Quantity * px * fx;
+        }
+
+        var shadowNav = gross - request.Fees + request.Accruals;
+        var varianceAmount = shadowNav - request.ExternalReferenceNav;
+        var varianceBps = request.ExternalReferenceNav == 0m ? 0m : varianceAmount / request.ExternalReferenceNav * 10_000m;
+        var breached = Math.Abs(varianceAmount) >= threshold.AbsoluteMateriality || Math.Abs(varianceBps) >= threshold.BpsMateriality;
+
+        var hash = ComputeHash(request, shadowNav, varianceAmount, varianceBps);
+        var snapshot = new ShadowBookRunSnapshot(Guid.NewGuid().ToString("N"), hash, DateTimeOffset.UtcNow, request.AccountId, request.PeriodEnd, shadowNav, request.ExternalReferenceNav, varianceAmount, varianceBps, breached);
+        _snapshots.Add(snapshot);
+
+        ReconciliationBreakQueueItem? emittedBreak = null;
+        if (breached)
+        {
+            emittedBreak = new ReconciliationBreakQueueItem(
+                BreakId: $"shadow-nav:{request.AccountId}:{request.PeriodEnd:yyyyMMdd}:{hash[..12]}",
+                RunId: $"shadow-nav-{request.PeriodEnd:yyyyMMdd}",
+                StrategyName: request.StrategyProfile,
+                Category: ReconciliationBreakCategory.AmountMismatch,
+                Status: ReconciliationBreakQueueStatus.Open,
+                Variance: varianceAmount,
+                Reason: $"Shadow NAV variance breached ({varianceAmount.ToString("F2", CultureInfo.InvariantCulture)} / {varianceBps.ToString("F1", CultureInfo.InvariantCulture)} bps)",
+                DetectedAt: DateTimeOffset.UtcNow,
+                LastUpdatedAt: DateTimeOffset.UtcNow,
+                Severity: Math.Abs(varianceBps) >= threshold.BpsMateriality * 2 ? ReconciliationBreakSeverity.Critical : ReconciliationBreakSeverity.High,
+                ExceptionRoute: "accounting/reconciliation/shadow-nav",
+                ToleranceBand: threshold.AbsoluteMateriality,
+                RequiredSignoffRole: "Fund accounting",
+                SignoffStatus: "pending-signoff",
+                FundAccountId: request.AccountId,
+                ExplainabilitySummary: $"version={snapshot.VersionHash[..12]}, shadowNav={shadowNav.ToString("F2", CultureInfo.InvariantCulture)}, externalNav={request.ExternalReferenceNav.ToString("F2", CultureInfo.InvariantCulture)}",
+                CustodianId: null,
+                UpstreamSyncCursor: snapshot.VersionHash,
+                AssignedTo: request.OperatorId,
+                ReviewedBy: null,
+                ReviewedAt: null,
+                ResolvedBy: null,
+                ResolvedAt: null,
+                ResolutionNote: $"Policy threshold breached for strategy profile '{request.StrategyProfile}'.",
+                LifecycleState: ReconciliationCaseLifecycleState.Detected,
+                LifecycleRationale: "Auto-generated from shadow-book valuation variance.",
+                StateTransitions: []);
+        }
+
+        return PersistAndReturnAsync(emittedBreak, snapshot, request.BlockCloseOnBreach && breached, ct);
+    }
+
+    private async Task<ShadowBookValuationResult> PersistAndReturnAsync(ReconciliationBreakQueueItem? emittedBreak, ShadowBookRunSnapshot snapshot, bool closeBlocked, CancellationToken ct)
+    {
+        if (emittedBreak is not null)
+        {
+            await _breakQueueRepository.CreateIfMissingAsync(emittedBreak, ct).ConfigureAwait(false);
+        }
+
+        return new ShadowBookValuationResult(snapshot, closeBlocked, emittedBreak);
+    }
+
+    private static string ComputeHash(ShadowBookValuationRequest request, decimal nav, decimal varianceAmount, decimal varianceBps)
+    {
+        var builder = new StringBuilder();
+        builder.Append(request.AccountId).Append('|').Append(request.StrategyProfile).Append('|').Append(request.PeriodEnd.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)).Append('|');
+        foreach (var p in request.Positions.OrderBy(x => x.Symbol, StringComparer.Ordinal))
+        {
+            builder.Append(p.Symbol).Append(':').Append(p.Quantity.ToString("G29", CultureInfo.InvariantCulture)).Append(':').Append(p.PriceCurrency).Append('|');
+        }
+
+        foreach (var px in request.PricesBySymbol.OrderBy(x => x.Key, StringComparer.Ordinal))
+        {
+            builder.Append("px:").Append(px.Key).Append('=').Append(px.Value.ToString("G29", CultureInfo.InvariantCulture)).Append('|');
+        }
+
+        foreach (var fx in request.FxRatesByCurrency.OrderBy(x => x.Key, StringComparer.Ordinal))
+        {
+            builder.Append("fx:").Append(fx.Key).Append('=').Append(fx.Value.ToString("G29", CultureInfo.InvariantCulture)).Append('|');
+        }
+
+        builder.Append(request.Fees.ToString("G29", CultureInfo.InvariantCulture)).Append('|')
+            .Append(request.Accruals.ToString("G29", CultureInfo.InvariantCulture)).Append('|')
+            .Append(request.ExternalReferenceNav.ToString("G29", CultureInfo.InvariantCulture)).Append('|')
+            .Append(nav.ToString("G29", CultureInfo.InvariantCulture)).Append('|')
+            .Append(varianceAmount.ToString("G29", CultureInfo.InvariantCulture)).Append('|')
+            .Append(varianceBps.ToString("G29", CultureInfo.InvariantCulture));
+
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(builder.ToString()))).ToLowerInvariant();
+    }
+}

--- a/tests/Meridian.Tests/Strategies/ShadowBookValuationServiceTests.cs
+++ b/tests/Meridian.Tests/Strategies/ShadowBookValuationServiceTests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using Meridian.Strategies.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Meridian.Tests.Strategies;
+
+public sealed class ShadowBookValuationServiceTests
+{
+    [Fact]
+    public async Task RunAsync_IsDeterministic_ForEquivalentInputs()
+    {
+        var repo = new FileReconciliationBreakQueueRepository(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")), NullLogger<FileReconciliationBreakQueueRepository>.Instance);
+        var service = new ShadowBookValuationService(repo);
+
+        var request = BuildRequest(externalNav: 2_000_000m);
+        var first = await service.RunAsync(request);
+        var second = await service.RunAsync(request with { OperatorId = "operator-b" });
+
+        first.Snapshot.VersionHash.Should().Be(second.Snapshot.VersionHash);
+        first.Snapshot.ShadowNav.Should().Be(second.Snapshot.ShadowNav);
+    }
+
+    [Fact]
+    public async Task RunAsync_Breach_EmitsBreak_AndBlocksCloseWhenPolicyEnabled()
+    {
+        var repo = new FileReconciliationBreakQueueRepository(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")), NullLogger<FileReconciliationBreakQueueRepository>.Instance);
+        var service = new ShadowBookValuationService(repo, new Dictionary<string, ShadowBookVarianceThresholds>
+        {
+            ["Macro"] = new ShadowBookVarianceThresholds(5m, 1m)
+        });
+
+        var result = await service.RunAsync(BuildRequest(externalNav: 1_000_000m));
+
+        result.Snapshot.Breached.Should().BeTrue();
+        result.EmittedBreak.Should().NotBeNull();
+        result.CloseBlocked.Should().BeTrue();
+        var queue = await repo.GetAllAsync();
+        queue.Should().ContainSingle(item => item.BreakId == result.EmittedBreak!.BreakId);
+    }
+
+    [Fact]
+    public async Task RunAsync_WithinThreshold_DoesNotEmitBreak()
+    {
+        var repo = new FileReconciliationBreakQueueRepository(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")), NullLogger<FileReconciliationBreakQueueRepository>.Instance);
+        var service = new ShadowBookValuationService(repo, new Dictionary<string, ShadowBookVarianceThresholds>
+        {
+            ["Macro"] = new ShadowBookVarianceThresholds(100_000m, 10_000m)
+        });
+
+        var result = await service.RunAsync(BuildRequest(externalNav: 2_060_000m) with { BlockCloseOnBreach = false });
+
+        result.Snapshot.Breached.Should().BeFalse();
+        result.EmittedBreak.Should().BeNull();
+        result.CloseBlocked.Should().BeFalse();
+    }
+
+    private static ShadowBookValuationRequest BuildRequest(decimal externalNav) => new(
+        AccountId: "acct-001",
+        StrategyProfile: "Macro",
+        PeriodEnd: new DateOnly(2026, 3, 31),
+        Positions:
+        [
+            new ShadowBookPositionInput("AAPL", 1000m, "USD"),
+            new ShadowBookPositionInput("SAP", 500m, "EUR")
+        ],
+        PricesBySymbol: new Dictionary<string, decimal> { ["AAPL"] = 180m, ["SAP"] = 130m },
+        FxRatesByCurrency: new Dictionary<string, decimal> { ["USD"] = 1m, ["EUR"] = 1.1m },
+        Fees: 2_500m,
+        Accruals: 10_000m,
+        ExternalReferenceNav: externalNav,
+        BlockCloseOnBreach: true,
+        OperatorId: "operator-a");
+}


### PR DESCRIPTION
### Motivation
- Provide a service to compute period-end shadow NAV from internal positions, prices, FX, fees, and accruals for independent valuation and audit evidence.
- Produce deterministic run snapshots (version hashes) so valuations are reproducible and comparable across runs.
- Detect material variances versus external/reference NAV using per-profile materiality thresholds and surface exceptions into the reconciliation/casework flow so operator sign-off and gating can be applied.

### Description
- Add `IShadowBookValuationService` and `ShadowBookValuationService` which computes `ShadowNav`, variance, and a deterministic SHA-256 version hash over canonicalized inputs/outputs in `src/Meridian.Strategies/Services/ShadowBookValuationService.cs`.
- Introduce request/result models and `ShadowBookVarianceThresholds` and snapshot record types (`ShadowBookRunSnapshot`) to capture deterministic metadata and breach state.
- Implement per-profile threshold lookup and breach detection (absolute and bps materiality) and emit a `ReconciliationBreakQueueItem` populated with `Variance`, `Reason`, `ToleranceBand`, `FundAccountId`, `ExplainabilitySummary`, sign-off posture, and `UpstreamSyncCursor`, and persist it via `IReconciliationBreakQueueRepository.CreateIfMissingAsync`.
- Return a `CloseBlocked` flag in the result when policy requires fail-closed behavior on threshold breaches, and add targeted unit tests in `tests/Meridian.Tests/Strategies/ShadowBookValuationServiceTests.cs` covering determinism, breach emission and gating, and non-breach behavior.

### Testing
- Added unit tests that assert valuation reproducibility, threshold breach behavior (break emission + `CloseBlocked`) and non-breach behavior; the tests exercise the `FileReconciliationBreakQueueRepository` in-process test repository.
- Attempted to run the focused tests with `dotnet test --filter "FullyQualifiedName~ShadowBookValuationServiceTests"`, but the test run could not be executed in this environment because `dotnet` was not available (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17533e6d9883209c9da4f0ca8c6fa6)