### PR TITLE
Add evidence vault lifecycle/linkage DTOs, storage lookup, and vault-search endpoint

### DIFF
--- a/src/Meridian.Contracts/Workstation/EvidenceWorkflowDtos.cs
+++ b/src/Meridian.Contracts/Workstation/EvidenceWorkflowDtos.cs
@@ -80,6 +80,26 @@ public sealed record EvidenceVaultIdentityDto(
     int SchemaVersion,
     string StorageKind);
 
+public sealed record EvidenceLifecycleMetadataDto(
+    DateTimeOffset? RetainUntil,
+    bool LegalHold,
+    DateTimeOffset? ExpiresAt,
+    IReadOnlyList<string> AccessPolicyTags);
+
+public sealed record EvidenceSubjectLinkageDto(
+    string? EvidenceSubject,
+    string? RunId,
+    string? PeriodId,
+    string? ReportPackId,
+    string? ReconciliationCaseId);
+
+public sealed record EvidenceVaultLookupRequestDto(
+    string? EvidenceSubject,
+    string? RunId,
+    string? PeriodId,
+    string? ReportPackId,
+    string? ReconciliationCaseId);
+
 public sealed record EvidenceEndpointErrorDto(
     string Code,
     string Message,
@@ -131,7 +151,11 @@ public sealed record EvidenceTemplateDto(
 public sealed record EvidencePacketExportRequest(
     string? RequestedBy,
     string? Reason,
-    bool IncludeWarnings = true);
+    bool IncludeWarnings = true)
+{
+    public EvidenceLifecycleMetadataDto? Lifecycle { get; init; }
+    public EvidenceSubjectLinkageDto? Linkage { get; init; }
+}
 
 public sealed record EvidencePacketExportResponse(
     string SubjectKind,

--- a/src/Meridian.Ui.Shared/Endpoints/EvidenceEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/EvidenceEndpoints.cs
@@ -170,6 +170,15 @@ public static class EvidenceEndpoints
         .WithName("GetWorkstationEvidenceTemplates")
         .Produces<IReadOnlyList<EvidenceTemplateDto>>(200);
 
+        group.MapPost("/vault/search", async (EvidenceVaultLookupRequestDto request, HttpContext context) =>
+        {
+            var store = context.RequestServices.GetRequiredService<IEvidenceArtifactStore>();
+            var result = await store.FindByLinkageAsync(request, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(result, jsonOptions);
+        })
+        .WithName("SearchWorkstationEvidenceVault")
+        .Produces<IReadOnlyList<EvidenceVaultIdentityDto>>(200);
+
         return app;
     }
 

--- a/src/Meridian.Ui.Shared/Evidence/FileEvidenceArtifactStore.cs
+++ b/src/Meridian.Ui.Shared/Evidence/FileEvidenceArtifactStore.cs
@@ -25,6 +25,10 @@ public interface IEvidenceArtifactStore
     Task<EvidenceManifestFile?> TryOpenManifestByVaultIdAsync(
         string vaultId,
         CancellationToken ct = default);
+
+    Task<IReadOnlyList<EvidenceVaultIdentityDto>> FindByLinkageAsync(
+        EvidenceVaultLookupRequestDto request,
+        CancellationToken ct = default);
 }
 
 public sealed record EvidenceManifestFile(
@@ -82,7 +86,9 @@ public sealed class FileEvidenceArtifactStore : IEvidenceArtifactStore
             Edges: packet.Edges,
             Actions: packet.Actions,
             Warnings: request.IncludeWarnings ? packet.Warnings : [],
-            VaultIdentity: null);
+            VaultIdentity: null,
+            Lifecycle: request.Lifecycle,
+            Linkage: request.Linkage);
         var retainedExportJson = JsonSerializer.Serialize(manifest, _jsonOptions);
         var contentHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(retainedExportJson))).ToLowerInvariant();
         var vaultIdentity = new EvidenceVaultIdentityDto(
@@ -175,6 +181,64 @@ public sealed class FileEvidenceArtifactStore : IEvidenceArtifactStore
         return Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "Meridian");
+    }
+
+    public async Task<IReadOnlyList<EvidenceVaultIdentityDto>> FindByLinkageAsync(
+        EvidenceVaultLookupRequestDto request,
+        CancellationToken ct = default)
+    {
+        var vaultDir = Path.Combine(_rootDirectory, "_vault");
+        if (!Directory.Exists(vaultDir))
+        {
+            return [];
+        }
+
+        var matches = new List<EvidenceVaultIdentityDto>();
+        foreach (var indexPath in Directory.EnumerateFiles(vaultDir, "*.json"))
+        {
+            ct.ThrowIfCancellationRequested();
+            var identity = await TryReadVaultIdentityAsync(indexPath, ct).ConfigureAwait(false);
+            if (identity is null)
+            {
+                continue;
+            }
+
+            var manifestPath = ResolveVaultManifestPath(identity, identity.VaultId);
+            if (manifestPath is null || !File.Exists(manifestPath))
+            {
+                continue;
+            }
+
+            var linkage = await TryReadLinkageAsync(manifestPath, ct).ConfigureAwait(false);
+            if (MatchesLookup(request, linkage, identity))
+            {
+                matches.Add(identity);
+            }
+        }
+
+        return matches.OrderByDescending(x => x.RetainedAt).ToArray();
+    }
+
+    private static bool MatchesLookup(EvidenceVaultLookupRequestDto request, EvidenceSubjectLinkageDto? linkage, EvidenceVaultIdentityDto identity)
+    {
+        if (!string.IsNullOrWhiteSpace(request.EvidenceSubject) && !string.Equals(request.EvidenceSubject, linkage?.EvidenceSubject, StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (!string.IsNullOrWhiteSpace(request.RunId) && !string.Equals(request.RunId, linkage?.RunId, StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (!string.IsNullOrWhiteSpace(request.PeriodId) && !string.Equals(request.PeriodId, linkage?.PeriodId, StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (!string.IsNullOrWhiteSpace(request.ReportPackId) && !string.Equals(request.ReportPackId, linkage?.ReportPackId, StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (!string.IsNullOrWhiteSpace(request.ReconciliationCaseId) && !string.Equals(request.ReconciliationCaseId, linkage?.ReconciliationCaseId, StringComparison.OrdinalIgnoreCase))
+            return false;
+        return true;
+    }
+
+    private async Task<EvidenceSubjectLinkageDto?> TryReadLinkageAsync(string manifestPath, CancellationToken ct)
+    {
+        await using var stream = File.OpenRead(manifestPath);
+        var manifest = await JsonSerializer.DeserializeAsync<EvidenceManifestDto>(stream, _jsonOptions, ct).ConfigureAwait(false);
+        return manifest?.Linkage;
     }
 
     private static string SanitizePathSegment(string value)
@@ -427,5 +491,7 @@ public sealed class FileEvidenceArtifactStore : IEvidenceArtifactStore
         IReadOnlyList<EvidenceEdgeDto> Edges,
         IReadOnlyList<WorkflowActionDto> Actions,
         IReadOnlyList<string> Warnings,
-        EvidenceVaultIdentityDto? VaultIdentity);
+        EvidenceVaultIdentityDto? VaultIdentity,
+        EvidenceLifecycleMetadataDto? Lifecycle,
+        EvidenceSubjectLinkageDto? Linkage);
 }

--- a/tests/Meridian.Tests/Ui/EvidenceWorkflowFabricTests.cs
+++ b/tests/Meridian.Tests/Ui/EvidenceWorkflowFabricTests.cs
@@ -483,6 +483,31 @@ public sealed class EvidenceWorkflowFabricTests
             IsRouteOnlyArtifact(artifact, "ledger-trial-balance", "/api/workstation/runs/run-ledger-proof/ledger/trial-balance"));
     }
 
+    [Fact]
+    public async Task EvidenceEndpoints_VaultSearch_FindsBundlesByRunReportPackAndReconciliationCase()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"evidence-vault-search-{Guid.NewGuid():N}");
+        await using var app = await CreateEvidenceAppAsync(root);
+        var client = app.GetTestClient();
+
+        await client.PostAsJsonAsync(
+            "/api/workstation/evidence/subjects/report-pack/current/export-manifest",
+            new EvidencePacketExportRequest("operator", "seed")
+            {
+                Linkage = new EvidenceSubjectLinkageDto("report-pack/current", "run-123", "period-2026-05", "rp-55", "case-77")
+            });
+
+        var response = await client.PostAsJsonAsync(
+            "/api/workstation/evidence/vault/search",
+            new EvidenceVaultLookupRequestDto(null, "run-123", null, "rp-55", "case-77"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var matches = await response.Content.ReadFromJsonAsync<IReadOnlyList<EvidenceVaultIdentityDto>>(ServerJsonOptions);
+        matches.Should().NotBeNull();
+        matches!.Should().ContainSingle();
+        matches[0].SubjectKind.Should().Be("report-pack");
+        matches[0].SubjectId.Should().Be("current");
+    }
+
     private static EvidenceGraphService CreateGraphService(IReadOnlyList<IEvidenceContributor> contributors)
     {
         var services = new ServiceCollection().BuildServiceProvider();


### PR DESCRIPTION
### Motivation

- Provide a foundation for immutable, content-addressed evidence bundles with lifecycle controls (retention, legal hold, expiration, access tags) and stable linkage keys for retrieval by subject, run, period, report-pack, or reconciliation case. 
- Enable programmatic retrieval of retained evidence bundles for governance workflows (approvals, close, reconciliation sign-off) and downstream integrity/retention processing.

### Description

- Add contract DTOs `EvidenceLifecycleMetadataDto`, `EvidenceSubjectLinkageDto`, and `EvidenceVaultLookupRequestDto`, and extend `EvidencePacketExportRequest` to carry `Lifecycle` and `Linkage` metadata. 
- Extend `IEvidenceArtifactStore` with `FindByLinkageAsync` and persist lifecycle/linkage into manifest payloads; implement lookup in `FileEvidenceArtifactStore` by scanning `_vault` index entries and matching manifest linkage. 
- Include linkage and lifecycle in the serialized manifest and produce a content-addressed vault ID using SHA-256 of the manifest payload when writing manifests in `WriteManifestAsync`. 
- Add a new retrieval endpoint `POST /api/workstation/evidence/vault/search` that accepts `EvidenceVaultLookupRequestDto` and returns matching `EvidenceVaultIdentityDto` records. 
- Add an integration-style test `EvidenceEndpoints_VaultSearch_FindsBundlesByRunReportPackAndReconciliationCase` that exports a manifest with linkage metadata and validates lookup by run/report-pack/reconciliation-case.

### Testing

- Added test `EvidenceEndpoints_VaultSearch_FindsBundlesByRunReportPackAndReconciliationCase` to `EvidenceWorkflowFabricTests` and included it with the code changes. 
- Attempted to run the targeted test via `dotnet test --filter "FullyQualifiedName~EvidenceWorkflowFabricTests"`, but the run failed because `dotnet` is not available in this environment (`/bin/bash: dotnet: command not found`). 
- No other automated test runs were executed in this environment; the new test is included and should pass when run in a normal .NET-enabled CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1753403d188320afe96980a6b9a75b)