### PR TITLE
Add fund-ops cash orchestration primitives and service

### DIFF
--- a/src/Meridian.Contracts/Workstation/CashOperationsDtos.cs
+++ b/src/Meridian.Contracts/Workstation/CashOperationsDtos.cs
@@ -1,0 +1,38 @@
+namespace Meridian.Contracts.Workstation;
+
+public enum CashSyncSourceAvailability : byte { Unknown = 0, Available = 1, Delayed = 2, Offline = 3 }
+public enum StpProcessingState : byte { Received = 0, Validated = 1, Approved = 2, QueuedForSettlement = 3, Settled = 4, Exception = 5 }
+
+public sealed record CashSyncWindow(
+    string Region,
+    string TimeZoneId,
+    TimeOnly WindowStart,
+    TimeOnly WindowEnd,
+    IReadOnlyDictionary<string, CashSyncSourceAvailability> SourceAvailability,
+    IReadOnlyList<Guid> AccountIds);
+
+public sealed record SyncCompletenessResult(Guid AccountId, string Counterparty, int ExpectedRecords, int ReceivedRecords, bool IsComplete, string Detail);
+public sealed record DeltaOutlierResult(Guid AccountId, string MetricName, decimal PriorDayValue, decimal CurrentValue, decimal Delta, decimal DeltaRatio, bool IsOutlier, string Detail);
+public sealed record SyncValidationResult(bool Passed, IReadOnlyList<SyncCompletenessResult> CompletenessChecks, IReadOnlyList<DeltaOutlierResult> OutlierChecks, IReadOnlyList<string> Warnings);
+
+public sealed record PaymentInstruction(Guid InstructionId, Guid AccountId, string Currency, decimal Amount, DateOnly TradeDate, DateOnly ValueDate, string Counterparty, string Reference);
+public sealed record SettlementInstruction(Guid InstructionId, Guid AccountId, string Currency, decimal GrossAmount, DateOnly SettlementDate, string Counterparty, string SettlementMethod, string Reference);
+public sealed record CouponEvent(Guid EventId, Guid AccountId, string SecurityId, string Currency, decimal CouponAmount, DateOnly ExDate, DateOnly PayDate);
+public sealed record ApprovalStep(int Sequence, string RoleOrQueue, bool DualControlRequired, decimal? AmountThreshold, string? Currency, Guid? AccountId, string? RiskBucket);
+
+public sealed record ApprovalPolicy(
+    decimal? MinimumAmount,
+    decimal? HighValueThreshold,
+    IReadOnlySet<string>? AllowedCurrencies,
+    IReadOnlySet<Guid>? RoutedAccountIds,
+    IReadOnlySet<string>? RoutedRiskBuckets,
+    bool RequireDualControl);
+
+public sealed record ApprovalDecision(string Queue, bool DualControlRequired, IReadOnlyList<string> Reasons);
+
+public sealed record FxConversionReference(string BaseCurrency, string QuoteCurrency, decimal Rate, DateTimeOffset AsOfUtc, string Source);
+
+public sealed record CashFlowProjectionPoint(Guid AccountId, string Currency, DateOnly Date, decimal ExpectedInflow, decimal ExpectedOutflow, decimal NetFlow, decimal RunningBalance, bool LiquidityWarning, string WarningDetail);
+public sealed record CashForecastResult(DateOnly AsOfDate, IReadOnlyList<CashFlowProjectionPoint> Timeline, IReadOnlyList<string> Warnings);
+
+public sealed record StpStateTransition(Guid InstructionId, StpProcessingState State, DateTimeOffset AtUtc, string Detail, string? BreakQueueReason = null);

--- a/src/Meridian.Ui.Shared/Services/CashOperationsOrchestratorService.cs
+++ b/src/Meridian.Ui.Shared/Services/CashOperationsOrchestratorService.cs
@@ -1,0 +1,162 @@
+using Meridian.Contracts.Workstation;
+
+namespace Meridian.Ui.Shared.Services;
+
+public sealed class CashOperationsOrchestratorService
+{
+    public IReadOnlyList<CashSyncWindow> BuildDailySyncWindows(
+        DateTimeOffset nowUtc,
+        IReadOnlyList<CashSyncWindow> configuredWindows)
+    {
+        ArgumentNullException.ThrowIfNull(configuredWindows);
+
+        return configuredWindows
+            .Where(window => window.SourceAvailability.Values.Any(v => v is CashSyncSourceAvailability.Available or CashSyncSourceAvailability.Delayed))
+            .OrderBy(window => ResolveWindowStartUtc(nowUtc, window))
+            .ToArray();
+    }
+
+    public SyncValidationResult ValidateSync(
+        IReadOnlyList<SyncCompletenessResult> completeness,
+        IReadOnlyList<DeltaOutlierResult> outliers)
+    {
+        ArgumentNullException.ThrowIfNull(completeness);
+        ArgumentNullException.ThrowIfNull(outliers);
+
+        var warnings = new List<string>();
+        if (completeness.Any(c => !c.IsComplete)) warnings.Add("Completeness gaps detected.");
+        if (outliers.Any(o => o.IsOutlier)) warnings.Add("Outlier deltas exceed policy threshold.");
+
+        return new SyncValidationResult(warnings.Count == 0, completeness, outliers, warnings);
+    }
+
+    public ApprovalDecision EvaluateApproval(
+        decimal amount,
+        string currency,
+        Guid accountId,
+        string riskBucket,
+        ApprovalPolicy policy)
+    {
+        ArgumentNullException.ThrowIfNull(currency);
+        ArgumentNullException.ThrowIfNull(riskBucket);
+        ArgumentNullException.ThrowIfNull(policy);
+
+        var reasons = new List<string>();
+        var queue = "ops-standard";
+        var dualControl = policy.RequireDualControl;
+
+        if (policy.MinimumAmount is { } min && amount < min)
+        {
+            reasons.Add($"Amount {amount} below minimum {min}.");
+            queue = "ops-review";
+        }
+
+        if (policy.HighValueThreshold is { } high && amount >= high)
+        {
+            reasons.Add($"Amount {amount} reached high-value threshold {high}.");
+            queue = "risk-approval";
+            dualControl = true;
+        }
+
+        if (policy.AllowedCurrencies is { Count: > 0 } currencies && !currencies.Contains(currency, StringComparer.OrdinalIgnoreCase))
+        {
+            reasons.Add($"Currency {currency} requires treasury routing.");
+            queue = "treasury-approval";
+        }
+
+        if (policy.RoutedAccountIds is { Count: > 0 } accounts && accounts.Contains(accountId))
+        {
+            reasons.Add("Account-specific override route applied.");
+            queue = "account-approval";
+        }
+
+        if (policy.RoutedRiskBuckets is { Count: > 0 } risks && risks.Contains(riskBucket, StringComparer.OrdinalIgnoreCase))
+        {
+            reasons.Add($"Risk bucket {riskBucket} requires risk routing.");
+            queue = "risk-approval";
+            dualControl = true;
+        }
+
+        return new ApprovalDecision(queue, dualControl, reasons);
+    }
+
+    public DateOnly ResolveSettlementDateWithCutoff(DateTimeOffset bookingTimeLocal, TimeOnly cutoffLocal, int normalSettlementLagDays)
+    {
+        var tradeDate = DateOnly.FromDateTime(bookingTimeLocal.Date);
+        var sameDayAllowed = TimeOnly.FromDateTime(bookingTimeLocal.DateTime) <= cutoffLocal;
+        var lag = sameDayAllowed ? normalSettlementLagDays : normalSettlementLagDays + 1;
+        return tradeDate.AddDays(Math.Max(0, lag));
+    }
+
+    public CashForecastResult BuildCashForecast(
+        DateOnly asOf,
+        IReadOnlyDictionary<(Guid AccountId, string Currency), decimal> openingBalances,
+        IReadOnlyList<PaymentInstruction> payments,
+        IReadOnlyList<SettlementInstruction> settlements,
+        IReadOnlyList<CouponEvent> coupons,
+        IReadOnlyList<FxConversionReference> fx,
+        decimal liquidityWarningThreshold)
+    {
+        var timeline = new List<CashFlowProjectionPoint>();
+        var warnings = new List<string>();
+        var fxMap = fx.ToDictionary(x => (x.BaseCurrency.ToUpperInvariant(), x.QuoteCurrency.ToUpperInvariant()), x => x.Rate);
+
+        foreach (var bucket in openingBalances)
+        {
+            var accountId = bucket.Key.AccountId;
+            var currency = bucket.Key.Currency;
+            var running = bucket.Value;
+            for (var i = 0; i < 5; i++)
+            {
+                var day = asOf.AddDays(i);
+                var inflow = coupons.Where(c => c.AccountId == accountId && c.Currency.Equals(currency, StringComparison.OrdinalIgnoreCase) && c.PayDate == day).Sum(c => c.CouponAmount);
+                var outflow = payments.Where(p => p.AccountId == accountId && p.Currency.Equals(currency, StringComparison.OrdinalIgnoreCase) && p.ValueDate == day).Sum(p => p.Amount)
+                    + settlements.Where(s => s.AccountId == accountId && s.Currency.Equals(currency, StringComparison.OrdinalIgnoreCase) && s.SettlementDate == day).Sum(s => s.GrossAmount);
+
+                var net = inflow - outflow;
+                running += net;
+                var warn = running < liquidityWarningThreshold;
+                var detail = warn ? $"Projected balance {running} {currency} is below threshold {liquidityWarningThreshold}." : "";
+                if (warn) warnings.Add($"{accountId} {currency} {day:yyyy-MM-dd}: {detail}");
+
+                timeline.Add(new CashFlowProjectionPoint(accountId, currency, day, inflow, outflow, net, running, warn, detail));
+            }
+        }
+
+        _ = fxMap; // reserved for cross-currency normalization in follow-up integration.
+        return new CashForecastResult(asOf, timeline.OrderBy(t => t.Date).ThenBy(t => t.AccountId).ToArray(), warnings);
+    }
+
+    public IReadOnlyList<StpStateTransition> BuildStpTrail(Guid instructionId, bool validationPassed, bool approved, bool settled, string? exceptionReason)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var trail = new List<StpStateTransition> { new(instructionId, StpProcessingState.Received, now, "Instruction received.") };
+        if (!validationPassed)
+        {
+            trail.Add(new(instructionId, StpProcessingState.Exception, now, "Validation failed.", exceptionReason ?? "validation-failed"));
+            return trail;
+        }
+
+        trail.Add(new(instructionId, StpProcessingState.Validated, now, "Validation passed."));
+        if (!approved)
+        {
+            trail.Add(new(instructionId, StpProcessingState.Exception, now, "Approval missing.", exceptionReason ?? "approval-pending"));
+            return trail;
+        }
+
+        trail.Add(new(instructionId, StpProcessingState.Approved, now, "Approved by policy chain."));
+        trail.Add(new(instructionId, StpProcessingState.QueuedForSettlement, now, "Queued for settlement."));
+        trail.Add(new(instructionId, settled ? StpProcessingState.Settled : StpProcessingState.Exception, now,
+            settled ? "Settled." : "Settlement failed.", settled ? null : exceptionReason ?? "settlement-failed"));
+        return trail;
+    }
+
+    private static DateTimeOffset ResolveWindowStartUtc(DateTimeOffset nowUtc, CashSyncWindow window)
+    {
+        var tz = TimeZoneInfo.FindSystemTimeZoneById(window.TimeZoneId);
+        var localNow = TimeZoneInfo.ConvertTime(nowUtc, tz);
+        var localDateTime = localNow.Date + window.WindowStart.ToTimeSpan();
+        var offset = tz.GetUtcOffset(localDateTime);
+        return new DateTimeOffset(localDateTime, offset).ToUniversalTime();
+    }
+}

--- a/tests/Meridian.Tests/Ui/CashOperationsOrchestratorServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/CashOperationsOrchestratorServiceTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using Meridian.Contracts.Workstation;
+using Meridian.Ui.Shared.Services;
+
+namespace Meridian.Tests.Ui;
+
+public sealed class CashOperationsOrchestratorServiceTests
+{
+    [Fact]
+    public void BuildDailySyncWindows_FiltersUnavailableSources()
+    {
+        var sut = new CashOperationsOrchestratorService();
+        var windows = new[]
+        {
+            new CashSyncWindow("US", "UTC", new TimeOnly(12,0), new TimeOnly(13,0), new Dictionary<string, CashSyncSourceAvailability>{{"A", CashSyncSourceAvailability.Offline}}, [Guid.NewGuid()]),
+            new CashSyncWindow("EU", "UTC", new TimeOnly(8,0), new TimeOnly(9,0), new Dictionary<string, CashSyncSourceAvailability>{{"B", CashSyncSourceAvailability.Available}}, [Guid.NewGuid()])
+        };
+
+        var result = sut.BuildDailySyncWindows(DateTimeOffset.UtcNow, windows);
+        result.Should().HaveCount(1);
+        result[0].Region.Should().Be("EU");
+    }
+
+    [Fact]
+    public void EvaluateApproval_HighValueAndRiskBucket_RequiresDualControl()
+    {
+        var sut = new CashOperationsOrchestratorService();
+        var policy = new ApprovalPolicy(0, 1_000_000m, new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "USD" }, null, new HashSet<string>(StringComparer.OrdinalIgnoreCase){"high"}, false);
+
+        var decision = sut.EvaluateApproval(2_000_000m, "USD", Guid.NewGuid(), "high", policy);
+        decision.Queue.Should().Be("risk-approval");
+        decision.DualControlRequired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ResolveSettlementDateWithCutoff_AfterCutoff_PushesOneBusinessDay()
+    {
+        var sut = new CashOperationsOrchestratorService();
+        var booking = new DateTimeOffset(2026, 5, 27, 18, 0, 0, TimeSpan.Zero);
+        var result = sut.ResolveSettlementDateWithCutoff(booking, new TimeOnly(17, 0), 2);
+        result.Should().Be(new DateOnly(2026, 5, 30));
+    }
+
+    [Fact]
+    public void BuildStpTrail_InvalidValidation_FallsBackToException()
+    {
+        var sut = new CashOperationsOrchestratorService();
+        var trail = sut.BuildStpTrail(Guid.NewGuid(), validationPassed: false, approved: false, settled: false, exceptionReason: "missing counterparty");
+        trail.Should().ContainSingle(t => t.State == StpProcessingState.Exception);
+        trail[^1].BreakQueueReason.Should().Be("missing counterparty");
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a central orchestrator and DTOs to schedule and validate daily cash syncs across regions/timezones and heterogeneous source availability. 
- Add first-class models for cash movements, approvals, FX references, forecasting, and STP state to enable straight-through processing and exception routing into the break queue.

### Description
- Added new contract DTOs in `src/Meridian.Contracts/Workstation/CashOperationsDtos.cs` including `CashSyncWindow`, `SyncCompletenessResult`, `DeltaOutlierResult`, `PaymentInstruction`, `SettlementInstruction`, `CouponEvent`, `ApprovalStep`, `ApprovalPolicy`, `ApprovalDecision`, `FxConversionReference`, `CashFlowProjectionPoint`, `CashForecastResult`, and `StpStateTransition` plus enums `CashSyncSourceAvailability` and `StpProcessingState`.
- Implemented `CashOperationsOrchestratorService` in `src/Meridian.Ui.Shared/Services/CashOperationsOrchestratorService.cs` with key operations: `BuildDailySyncWindows` (region/timezone ordering & source-availability filtering), `ValidateSync` (completeness + outlier aggregation), `EvaluateApproval` (policy-based routing with dual-control escalation), `ResolveSettlementDateWithCutoff` (cutoff-aware settlement lag), `BuildCashForecast` (multi-currency short-term cash ladder and liquidity warnings), and `BuildStpTrail` (STP state transitions with exception -> break-queue reason carry-through).
- Added focused unit tests in `tests/Meridian.Tests/Ui/CashOperationsOrchestratorServiceTests.cs` covering sync-window filtering, approval routing/dual-control, cutoff settlement behavior, and STP exception fallback.

### Testing
- Added unit tests for `CashOperationsOrchestratorService` (`CashOperationsOrchestratorServiceTests`) which exercise the key behaviors described above.
- Attempted to run the focused test command `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~CashOperationsOrchestratorServiceTests" --logger "console;verbosity=minimal"`, but the test run could not execute in this environment because `dotnet` is not installed (command failed: `dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17583f953c8320a15d327454976ff9)