### PR TITLE
Add compliance RBAC, step-up controls, immutable audit log, and API endpoints

### DIFF
--- a/src/Meridian.Application/Compliance/ComplianceModels.cs
+++ b/src/Meridian.Application/Compliance/ComplianceModels.cs
@@ -1,0 +1,82 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Meridian.Application.Compliance;
+
+public enum SensitiveAction
+{
+    RuleEdit,
+    BreakClosure,
+    PaymentRelease,
+    OverrideApproval
+}
+
+public sealed record ActorContext(
+    string ActorId,
+    string[] Roles,
+    string? Team,
+    string? SourceIp,
+    string? DeviceId,
+    bool MfaSatisfied);
+
+public sealed record ComplianceActionRequest(
+    SensitiveAction Action,
+    string ObjectType,
+    string ObjectId,
+    string? BeforeStateJson,
+    string? AfterStateJson,
+    string CorrelationId,
+    string? EntityId,
+    string? RequestedByActorId = null,
+    string[]? AdditionalApproverIds = null);
+
+public sealed record AuditEvent(
+    string EventId,
+    DateTimeOffset OccurredAtUtc,
+    string ActorId,
+    SensitiveAction Action,
+    string ObjectType,
+    string ObjectId,
+    string? BeforeStateJson,
+    string? AfterStateJson,
+    string? SourceIp,
+    string? DeviceId,
+    string CorrelationId,
+    string? EntityId,
+    string Hash,
+    string? PreviousHash);
+
+public sealed record AccessReviewRecord(
+    string ReviewId,
+    DateTimeOffset ReviewedAtUtc,
+    string ReviewedBy,
+    string ActorId,
+    string[] RemovedRoles,
+    string Reason);
+
+public static class AuditHash
+{
+    public static string Compute(AuditEvent evt)
+    {
+        var raw = JsonSerializer.Serialize(new
+        {
+            evt.EventId,
+            evt.OccurredAtUtc,
+            evt.ActorId,
+            evt.Action,
+            evt.ObjectType,
+            evt.ObjectId,
+            evt.BeforeStateJson,
+            evt.AfterStateJson,
+            evt.SourceIp,
+            evt.DeviceId,
+            evt.CorrelationId,
+            evt.EntityId,
+            evt.PreviousHash
+        });
+
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(raw));
+        return Convert.ToHexString(bytes);
+    }
+}

--- a/src/Meridian.Application/Compliance/ComplianceServices.cs
+++ b/src/Meridian.Application/Compliance/ComplianceServices.cs
@@ -1,0 +1,129 @@
+using System.Collections.Concurrent;
+
+namespace Meridian.Application.Compliance;
+
+public interface ICompliancePolicyEngine
+{
+    (bool Allowed, string Reason) Evaluate(ActorContext actor, ComplianceActionRequest request);
+}
+
+public sealed class CompliancePolicyEngine : ICompliancePolicyEngine
+{
+    private static readonly Dictionary<SensitiveAction, string[]> RequiredRoles = new()
+    {
+        [SensitiveAction.RuleEdit] = ["RulesAdmin"],
+        [SensitiveAction.BreakClosure] = ["ReconciliationOfficer"],
+        [SensitiveAction.PaymentRelease] = ["TreasuryOperator"],
+        [SensitiveAction.OverrideApproval] = ["OverrideApprover"]
+    };
+
+    public (bool Allowed, string Reason) Evaluate(ActorContext actor, ComplianceActionRequest request)
+    {
+        if (!RequiredRoles.TryGetValue(request.Action, out var requiredRoles))
+        {
+            return (false, "Unknown action.");
+        }
+
+        if (!actor.Roles.Intersect(requiredRoles).Any())
+        {
+            return (false, "Missing required privileged role.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.RequestedByActorId) &&
+            request.RequestedByActorId.Equals(actor.ActorId, StringComparison.OrdinalIgnoreCase))
+        {
+            return (false, "Segregation of duties violation: requester cannot self-approve.");
+        }
+
+        if (request.Action is SensitiveAction.PaymentRelease or SensitiveAction.OverrideApproval)
+        {
+            if (!actor.MfaSatisfied)
+            {
+                return (false, "Step-up requirement failed: MFA required.");
+            }
+
+            var approvers = request.AdditionalApproverIds ?? [];
+            if (approvers.Distinct(StringComparer.OrdinalIgnoreCase).Count() < 2)
+            {
+                return (false, "Step-up requirement failed: dual approval required.");
+            }
+        }
+
+        return (true, "Allowed");
+    }
+}
+
+public sealed class ImmutableAuditLogService
+{
+    private readonly ConcurrentQueue<AuditEvent> _events = new();
+
+    public AuditEvent Append(ActorContext actor, ComplianceActionRequest request)
+    {
+        var previousHash = _events.LastOrDefault()?.Hash;
+        var pending = new AuditEvent(
+            EventId: $"audit-{Guid.NewGuid():N}",
+            OccurredAtUtc: DateTimeOffset.UtcNow,
+            ActorId: actor.ActorId,
+            Action: request.Action,
+            ObjectType: request.ObjectType,
+            ObjectId: request.ObjectId,
+            BeforeStateJson: request.BeforeStateJson,
+            AfterStateJson: request.AfterStateJson,
+            SourceIp: actor.SourceIp,
+            DeviceId: actor.DeviceId,
+            CorrelationId: request.CorrelationId,
+            EntityId: request.EntityId,
+            Hash: string.Empty,
+            PreviousHash: previousHash);
+
+        var hashed = pending with { Hash = AuditHash.Compute(pending) };
+        _events.Enqueue(hashed);
+        return hashed;
+    }
+
+    public IReadOnlyList<AuditEvent> GetAll() => _events.ToArray();
+
+    public bool VerifyIntegrity()
+    {
+        string? expectedPrevious = null;
+        foreach (var evt in _events)
+        {
+            if (!string.Equals(expectedPrevious, evt.PreviousHash, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (!string.Equals(AuditHash.Compute(evt with { Hash = string.Empty }), evt.Hash, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            expectedPrevious = evt.Hash;
+        }
+
+        return true;
+    }
+}
+
+public sealed class AccessReviewService
+{
+    private readonly List<AccessReviewRecord> _reviews = [];
+
+    public AccessReviewRecord ReviewDormantPermissions(string actorId, string reviewedBy, string[] currentRoles, DateTimeOffset lastUsedAtUtc)
+    {
+        var isDormant = lastUsedAtUtc < DateTimeOffset.UtcNow.AddDays(-90);
+        var removed = isDormant ? currentRoles : [];
+        var review = new AccessReviewRecord(
+            ReviewId: $"access-{Guid.NewGuid():N}",
+            ReviewedAtUtc: DateTimeOffset.UtcNow,
+            ReviewedBy: reviewedBy,
+            ActorId: actorId,
+            RemovedRoles: removed,
+            Reason: isDormant ? "Dormant permissions cleanup." : "No dormant permissions.");
+
+        _reviews.Add(review);
+        return review;
+    }
+
+    public IReadOnlyList<AccessReviewRecord> GetReviews() => _reviews;
+}

--- a/src/Meridian.Ui.Shared/Endpoints/Compliance/ComplianceEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/Compliance/ComplianceEndpoints.cs
@@ -1,0 +1,71 @@
+using System.Text.Json;
+using Meridian.Application.Compliance;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Ui.Shared.Endpoints;
+
+public static class ComplianceEndpoints
+{
+    public static WebApplication MapComplianceEndpoints(this WebApplication app, JsonSerializerOptions jsonOptions)
+    {
+        app.MapPost("/api/compliance/actions/evaluate", (
+            HttpContext http,
+            ComplianceActionRequest request,
+            ICompliancePolicyEngine policy,
+            ImmutableAuditLogService auditLog) =>
+        {
+            var actor = BuildActorContext(http);
+            var decision = policy.Evaluate(actor, request);
+            if (!decision.Allowed)
+            {
+                return Results.Json(new { allowed = false, reason = decision.Reason }, statusCode: StatusCodes.Status403Forbidden, options: jsonOptions);
+            }
+
+            var evt = auditLog.Append(actor, request);
+            return Results.Json(new { allowed = true, reason = decision.Reason, auditEventId = evt.EventId, hash = evt.Hash }, options: jsonOptions);
+        });
+
+        app.MapGet("/api/compliance/audit/extract", (ImmutableAuditLogService auditLog) =>
+            Results.Ok(new { integrityValid = auditLog.VerifyIntegrity(), events = auditLog.GetAll() }));
+
+        app.MapGet("/api/compliance/controls/attestation", (ImmutableAuditLogService auditLog) =>
+            Results.Ok(new
+            {
+                generatedAtUtc = DateTimeOffset.UtcNow,
+                controls = new[]
+                {
+                    "RBAC matrix for sensitive actions",
+                    "Step-up controls with privileged role, dual approval, and MFA hook",
+                    "Immutable append-only audit chain",
+                    "Segregation-of-duties policy checks"
+                },
+                integrityValid = auditLog.VerifyIntegrity()
+            }));
+
+        app.MapPost("/api/compliance/access-reviews/run", (
+            AccessReviewRunRequest request,
+            AccessReviewService reviews) =>
+        {
+            var result = reviews.ReviewDormantPermissions(request.ActorId, request.ReviewedBy, request.CurrentRoles, request.LastUsedAtUtc);
+            return Results.Ok(result);
+        });
+
+        app.MapGet("/api/compliance/access-reviews", (AccessReviewService reviews) => Results.Ok(reviews.GetReviews()));
+
+        return app;
+    }
+
+    private static ActorContext BuildActorContext(HttpContext http)
+    {
+        var actorId = http.Request.Headers["X-Actor-Id"].FirstOrDefault() ?? "anonymous";
+        var roles = http.Request.Headers["X-Actor-Roles"].FirstOrDefault()?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? [];
+        var team = http.Request.Headers["X-Actor-Team"].FirstOrDefault();
+        var mfa = bool.TryParse(http.Request.Headers["X-Actor-Mfa"].FirstOrDefault(), out var parsed) && parsed;
+
+        return new ActorContext(actorId, roles, team, http.Connection.RemoteIpAddress?.ToString(), http.Request.Headers["X-Device-Id"].FirstOrDefault(), mfa);
+    }
+}
+
+public sealed record AccessReviewRunRequest(string ActorId, string ReviewedBy, string[] CurrentRoles, DateTimeOffset LastUsedAtUtc);

--- a/src/Meridian.Ui.Shared/Endpoints/UiEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/UiEndpoints.cs
@@ -243,6 +243,7 @@ public static class UiEndpoints
         // Paper trading cockpit endpoints
         app.MapExecutionEndpoints(jsonOptions);
         app.MapRiskEndpoints(jsonOptions);
+        app.MapComplianceEndpoints(jsonOptions);
 
         // Promotion workflow endpoints (Backtest → Paper → Live)
         app.MapPromotionEndpoints(jsonOptions);

--- a/src/Meridian/UiServer.cs
+++ b/src/Meridian/UiServer.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Security.Cryptography;
 using System.Text;
+using Meridian.Application.Compliance;
 using Meridian.Application.Composition;
 using Meridian.Application.Composition.Startup;
 using Meridian.Application.Config;
@@ -126,6 +127,9 @@ public sealed class UiServer : IAsyncDisposable
                 sp.GetRequiredService<ILogger<JsonlFilePaperSessionStore>>()));
         builder.Services.AddSingleton<PaperSessionPersistenceService>();
         builder.Services.AddSingleton<StrategyLifecycleManager>();
+        builder.Services.AddSingleton<ICompliancePolicyEngine, CompliancePolicyEngine>();
+        builder.Services.AddSingleton<ImmutableAuditLogService>();
+        builder.Services.AddSingleton<AccessReviewService>();
 
         // Execution layer — paper trading gateway wired for cockpit endpoints
         builder.Services.AddSingleton<IOrderGateway>(sp =>

--- a/tests/Meridian.Tests/Compliance/CompliancePolicyEngineTests.cs
+++ b/tests/Meridian.Tests/Compliance/CompliancePolicyEngineTests.cs
@@ -1,0 +1,59 @@
+using Meridian.Application.Compliance;
+
+namespace Meridian.Tests.Compliance;
+
+public sealed class CompliancePolicyEngineTests
+{
+    [Fact]
+    public void PaymentRelease_RequiresRoleDualApprovalAndMfa()
+    {
+        var policy = new CompliancePolicyEngine();
+        var actor = new ActorContext("approver-1", ["TreasuryOperator"], "Treasury", "127.0.0.1", "dev1", MfaSatisfied: true);
+        var request = new ComplianceActionRequest(
+            SensitiveAction.PaymentRelease,
+            "Payment",
+            "payment-1",
+            "{}",
+            "{\"status\":\"released\"}",
+            "corr-1",
+            "fund-1",
+            RequestedByActorId: "requester-1",
+            AdditionalApproverIds: ["approver-2", "approver-3"]);
+
+        var result = policy.Evaluate(actor, request);
+        Assert.True(result.Allowed);
+    }
+
+    [Fact]
+    public void SegregationOfDuties_BlocksSelfApproval()
+    {
+        var policy = new CompliancePolicyEngine();
+        var actor = new ActorContext("approver-1", ["OverrideApprover"], "Risk", "127.0.0.1", "dev1", MfaSatisfied: true);
+        var request = new ComplianceActionRequest(
+            SensitiveAction.OverrideApproval,
+            "Override",
+            "ovr-1",
+            null,
+            "{}",
+            "corr-2",
+            "fund-1",
+            RequestedByActorId: "approver-1",
+            AdditionalApproverIds: ["approver-2", "approver-3"]);
+
+        var result = policy.Evaluate(actor, request);
+        Assert.False(result.Allowed);
+    }
+
+    [Fact]
+    public void AuditLog_HashChain_VerifiesIntegrity()
+    {
+        var audit = new ImmutableAuditLogService();
+        var actor = new ActorContext("ops-1", ["RulesAdmin"], "Ops", "10.0.0.1", "laptop", true);
+
+        audit.Append(actor, new ComplianceActionRequest(SensitiveAction.RuleEdit, "Rule", "rule-1", "{\"limit\":10}", "{\"limit\":15}", "corr-a", "entity-a"));
+        audit.Append(actor, new ComplianceActionRequest(SensitiveAction.RuleEdit, "Rule", "rule-2", "{\"limit\":20}", "{\"limit\":25}", "corr-b", "entity-a"));
+
+        Assert.True(audit.VerifyIntegrity());
+        Assert.Equal(2, audit.GetAll().Count);
+    }
+}


### PR DESCRIPTION
### Motivation

- Introduce a compliance domain to enforce RBAC for high-risk actions (rule edits, break closures, payment releases, override approvals) and capture full actor/context for auditability.
- Enforce step-up controls for high-risk operations including dual-approval and MFA checks plus segregation-of-duties guards.
- Provide a tamper-evident, append-only audit mechanism and expose compliance/reporting endpoints so controls and extracts can be consumed by operators and automation.
- Add a simple access-review automation to detect and clean dormant permissions as part of periodic review workflows.

### Description

- Added compliance models describing `SensitiveAction`, `ActorContext`, `ComplianceActionRequest`, `AuditEvent`, and `AccessReviewRecord` in `src/Meridian.Application/Compliance/ComplianceModels.cs` and a deterministic `AuditHash` helper for chained hashing.
- Implemented `CompliancePolicyEngine` with an RBAC matrix, segregation-of-duties checks, and step-up requirements, plus `ImmutableAuditLogService` (append-only, chained-hash verification) and `AccessReviewService` in `src/Meridian.Application/Compliance/ComplianceServices.cs`.
- Exposed API endpoints under `/api/compliance/*` for action evaluation, audit extracts, control attestations, and access-review runs in `src/Meridian.Ui.Shared/Endpoints/Compliance/ComplianceEndpoints.cs` and wired the compliance endpoints into the shared endpoint map in `src/Meridian.Ui.Shared/Endpoints/UiEndpoints.cs`.
- Registered compliance services (`ICompliancePolicyEngine`, `ImmutableAuditLogService`, `AccessReviewService`) in DI during server startup in `src/Meridian/UiServer.cs` and added focused unit tests in `tests/Meridian.Tests/Compliance/CompliancePolicyEngineTests.cs` covering RBAC/SoD behavior and audit-chain integrity.

### Testing

- Added unit tests exercising step-up/MFA + dual-approval (`PaymentRelease_RequiresRoleDualApprovalAndMfa`), segregation-of-duties denial (`SegregationOfDuties_BlocksSelfApproval`), and audit hash-chain verification (`AuditLog_HashChain_VerifiesIntegrity`) in `tests/Meridian.Tests/Compliance/CompliancePolicyEngineTests.cs`.
- Attempted to run the focused test command `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~CompliancePolicyEngineTests" --logger "console;verbosity=minimal"` but execution failed in this environment because `dotnet` is not available (`dotnet: command not found`).
- No other automated test runs were executed in this container; CI should run the full test suite (including the new compliance tests) to validate integration and compilation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a175841d3ac8320859bf13a0fa2d1bc)