### PR TITLE
Add reconciliation contract/versioning and resilience primitives

### DIFF
--- a/src/Meridian.Application/Reconciliation/ReconciliationContracts.cs
+++ b/src/Meridian.Application/Reconciliation/ReconciliationContracts.cs
@@ -1,0 +1,46 @@
+namespace Meridian.Application.Reconciliation;
+
+public enum ReconciliationContractVersion
+{
+    V1 = 1
+}
+
+public enum ReconciliationMessageKind
+{
+    ReconciliationRequested,
+    ReconciliationCompleted,
+    BreakRaised,
+    BreakTransitioned,
+    ApprovalPolicyEvaluated
+}
+
+public sealed record ReconciliationContractEnvelope(
+    string ContractName,
+    ReconciliationContractVersion ContractVersion,
+    ReconciliationMessageKind MessageKind,
+    string CorrelationId,
+    string CausationId,
+    string IdempotencyKey,
+    DateTimeOffset OccurredAtUtc,
+    string Producer,
+    string Tenant,
+    string Counterparty,
+    IReadOnlyDictionary<string, string>? Tags = null);
+
+public static class ReconciliationContractCatalog
+{
+    public const string RequestContract = "meridian.reconciliation.request";
+    public const string ResultContract = "meridian.reconciliation.result";
+    public const string BreakWorkflowContract = "meridian.reconciliation.break-workflow";
+    public const string ApprovalPolicyContract = "meridian.reconciliation.approval-policy";
+
+    public static bool IsSupported(string contractName, ReconciliationContractVersion version)
+    {
+        if (version != ReconciliationContractVersion.V1)
+        {
+            return false;
+        }
+
+        return contractName is RequestContract or ResultContract or BreakWorkflowContract or ApprovalPolicyContract;
+    }
+}

--- a/src/Meridian.Application/Reconciliation/ReconciliationOrchestrationResilience.cs
+++ b/src/Meridian.Application/Reconciliation/ReconciliationOrchestrationResilience.cs
@@ -1,0 +1,39 @@
+namespace Meridian.Application.Reconciliation;
+
+public sealed record ReconciliationOrchestrationResilienceOptions(
+    int MaxRetries = 3,
+    TimeSpan RetryBaseDelay = default,
+    int MaxInFlightJobs = 32,
+    bool DeadLetterEnabled = true)
+{
+    public TimeSpan RetryBaseDelay { get; init; } = RetryBaseDelay == default ? TimeSpan.FromSeconds(2) : RetryBaseDelay;
+
+    public TimeSpan GetRetryDelay(int attempt)
+    {
+        var normalizedAttempt = Math.Clamp(attempt, 1, MaxRetries);
+        return TimeSpan.FromMilliseconds(RetryBaseDelay.TotalMilliseconds * Math.Pow(2, normalizedAttempt - 1));
+    }
+
+    public bool ShouldDeadLetter(int attempt, Exception _) => DeadLetterEnabled && attempt >= MaxRetries;
+}
+
+public sealed record ReconciliationRolloutTarget(
+    string Client,
+    string Team,
+    string Counterparty);
+
+public sealed class ReconciliationFeatureFlagPolicy
+{
+    private readonly HashSet<string> _enabledClients = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _enabledTeams = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _enabledCounterparties = new(StringComparer.OrdinalIgnoreCase);
+
+    public void EnableClient(string client) => _enabledClients.Add(client);
+    public void EnableTeam(string team) => _enabledTeams.Add(team);
+    public void EnableCounterparty(string counterparty) => _enabledCounterparties.Add(counterparty);
+
+    public bool IsEnabled(ReconciliationRolloutTarget target)
+        => _enabledClients.Contains(target.Client)
+           || _enabledTeams.Contains(target.Team)
+           || _enabledCounterparties.Contains(target.Counterparty);
+}

--- a/tests/Meridian.Tests/Reconciliation/ReconciliationContractsTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/ReconciliationContractsTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Meridian.Application.Reconciliation;
+
+namespace Meridian.Tests.Reconciliation;
+
+public sealed class ReconciliationContractsTests
+{
+    [Fact]
+    public void IsSupported_KnownContractAtV1_ReturnsTrue()
+    {
+        var isSupported = ReconciliationContractCatalog.IsSupported(
+            ReconciliationContractCatalog.BreakWorkflowContract,
+            ReconciliationContractVersion.V1);
+
+        isSupported.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsSupported_UnknownContract_ReturnsFalse()
+    {
+        var isSupported = ReconciliationContractCatalog.IsSupported(
+            "meridian.reconciliation.unknown",
+            ReconciliationContractVersion.V1);
+
+        isSupported.Should().BeFalse();
+    }
+
+    [Fact]
+    public void FeatureFlagPolicy_EnablesByClientTeamOrCounterparty()
+    {
+        var policy = new ReconciliationFeatureFlagPolicy();
+        policy.EnableTeam("Ops-West");
+
+        var target = new ReconciliationRolloutTarget("Client-A", "Ops-West", "Broker-X");
+
+        policy.IsEnabled(target).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(1, 2)]
+    [InlineData(2, 4)]
+    [InlineData(3, 8)]
+    public void ResilienceOptions_GetRetryDelay_UsesExponentialBackoff(int attempt, int expectedSeconds)
+    {
+        var options = new ReconciliationOrchestrationResilienceOptions(MaxRetries: 5, RetryBaseDelay: TimeSpan.FromSeconds(2));
+
+        var delay = options.GetRetryDelay(attempt);
+
+        delay.Should().Be(TimeSpan.FromSeconds(expectedSeconds));
+    }
+}


### PR DESCRIPTION
### Motivation
- Establish a canonical, versioned message envelope and contract catalog for all reconciliation inbound/outbound payloads to enable stable evolution and contract checks.
- Provide orchestration resilience building blocks (retry/backoff, dead-letter decision hook, in-flight throttling) to support robust job processing, idempotency, and backpressure strategies.
- Add a minimal rollout/feature-flag model keyed by client/team/counterparty to permit phased rollouts and safe cutovers.

### Description
- Added `src/Meridian.Application/Reconciliation/ReconciliationContracts.cs` which defines `ReconciliationContractVersion`, `ReconciliationMessageKind`, `ReconciliationContractEnvelope`, and `ReconciliationContractCatalog` with supported-contract checks for request/result/break-workflow/approval-policy.
- Added `src/Meridian.Application/Reconciliation/ReconciliationOrchestrationResilience.cs` which defines `ReconciliationOrchestrationResilienceOptions` (retry/backoff, `ShouldDeadLetter`), `ReconciliationRolloutTarget`, and `ReconciliationFeatureFlagPolicy` for client/team/counterparty rollout checks.
- Added unit tests in `tests/Meridian.Tests/Reconciliation/ReconciliationContractsTests.cs` that validate contract support, feature-flag targeting behavior, and exponential backoff math for `GetRetryDelay`.
- These changes provide the canonical shapes and primitives required by subsequent work for idempotency keys, DLQ wiring, metrics/log correlation, backfill/replay orchestration, and approval-policy enforcement.

### Testing
- Added focused unit tests: `ReconciliationContractsTests` covering `ReconciliationContractCatalog.IsSupported`, `ReconciliationFeatureFlagPolicy.IsEnabled`, and `ReconciliationOrchestrationResilienceOptions.GetRetryDelay`.
- Attempted to run the focused test slice with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ReconciliationContractsTests" --logger "console;verbosity=minimal"`, but the command failed in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`).
- Test files are present and intended to run as part of the normal CI/build where the .NET SDK is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17584375e4832080661e1935b43bcc)