### PR TITLE
Add canonical reconciliation domain and multi-stage matching orchestration

### DIFF
--- a/src/Meridian.Application/Reconciliation/CanonicalReconciliationEngine.cs
+++ b/src/Meridian.Application/Reconciliation/CanonicalReconciliationEngine.cs
@@ -1,0 +1,181 @@
+using Meridian.Domain.Reconciliation;
+
+namespace Meridian.Application.Reconciliation;
+
+public interface IReconciliationSourceAdapter
+{
+    ReconciliationSourceType SourceType { get; }
+
+    Task<DataSourceSnapshot> CaptureSnapshotAsync(ReconciliationIngestionRequest request, CancellationToken ct);
+}
+
+public interface IReconciliationIngestionScheduler
+{
+    Task<IReadOnlyList<DataSourceSnapshot>> CaptureAsync(
+        IReadOnlyList<IReconciliationSourceAdapter> adapters,
+        ReconciliationIngestionRequest request,
+        CancellationToken ct);
+}
+
+public sealed record ReconciliationIngestionRequest(
+    DateOnly BusinessDate,
+    DateTimeOffset RunTimestampUtc,
+    string BaseCurrency,
+    int SnapshotVersion);
+
+public interface IInstrumentMappingService
+{
+    string ResolveCanonicalId(string? cusip, string? isin, string? ticker, string? internalId);
+}
+
+public interface IFxRateProvider
+{
+    decimal Convert(decimal amount, string fromCurrency, string toCurrency, DateTimeOffset atUtc);
+}
+
+public interface IAccountingCalendar
+{
+    DateOnly ResolvePeriod(DateTimeOffset postedAtUtc);
+}
+
+public sealed class ReconciliationNormalizationService(
+    IInstrumentMappingService instrumentMapping,
+    IFxRateProvider fxRateProvider,
+    IAccountingCalendar accountingCalendar)
+{
+    public NormalizedPosition NormalizePosition(NormalizedPosition input, string baseCurrency, DateTimeOffset runTimestampUtc)
+    {
+        var canonical = instrumentMapping.ResolveCanonicalId(input.Cusip, input.Isin, input.Ticker, input.InternalSecurityId);
+        var fx = fxRateProvider.Convert(1m, input.Currency, baseCurrency, runTimestampUtc);
+        return input with
+        {
+            InstrumentCanonicalId = canonical,
+            MarketValue = decimal.Round(input.MarketValue * fx, 6),
+            Currency = baseCurrency,
+            AsOfUtc = runTimestampUtc
+        };
+    }
+
+    public NormalizedCashEntry NormalizeCashEntry(NormalizedCashEntry input, string baseCurrency, DateTimeOffset runTimestampUtc)
+    {
+        var amountBase = fxRateProvider.Convert(input.Amount, input.Currency, baseCurrency, runTimestampUtc);
+        return input with
+        {
+            AmountBase = decimal.Round(amountBase, 6),
+            BaseCurrency = baseCurrency,
+            PostedAtUtc = runTimestampUtc,
+            AccountingPeriod = accountingCalendar.ResolvePeriod(runTimestampUtc)
+        };
+    }
+}
+
+public sealed record MatchingTolerances(decimal Quantity, decimal Price, decimal MarketValue, decimal CashAmount, TimeSpan TimingWindow);
+
+public sealed class ReconciliationMatchingEngine
+{
+    public (IReadOnlyList<MatchGroup> matches, IReadOnlyList<BreakRecord> breaks, IReadOnlyList<MatchEvidence> evidence) Run(
+        ReconciliationRun run,
+        MatchingTolerances tolerances)
+    {
+        var evidence = new List<MatchEvidence>();
+        var matches = new List<MatchGroup>();
+        var breaks = new List<BreakRecord>();
+
+        var allPositions = run.SourceSnapshots.SelectMany(s => s.Positions).ToArray();
+        var exactGroups = allPositions.GroupBy(p => (p.InstrumentCanonicalId, p.Quantity, p.Price, p.MarketValue));
+        foreach (var group in exactGroups.Where(g => g.Count() > 1))
+        {
+            var ev = new MatchEvidence(Guid.NewGuid().ToString("N"), "exact-position-v1", "Exact", "Exact position tuple match.", 0m, new Dictionary<string, string>());
+            evidence.Add(ev);
+            matches.Add(new MatchGroup(Guid.NewGuid().ToString("N"), BreakClassification.Matched, ev.RuleId, group.Select(p => p.PositionId).ToArray(), Array.Empty<string>(), [ev.EvidenceId]));
+        }
+
+        var allCash = run.SourceSnapshots.SelectMany(s => s.CashEntries).ToArray();
+        foreach (var candidate in allCash)
+        {
+            var near = allCash.Where(other => other.CashEntryId != candidate.CashEntryId && Math.Abs(other.AmountBase - candidate.AmountBase) <= tolerances.CashAmount).ToArray();
+            if (near.Length > 0)
+            {
+                var timeDelta = near.Min(other => Math.Abs((other.PostedAtUtc - candidate.PostedAtUtc).TotalMinutes));
+                var classification = timeDelta <= tolerances.TimingWindow.TotalMinutes ? BreakClassification.MatchedWithinTolerance : BreakClassification.PotentialBreak;
+                var ruleId = classification == BreakClassification.MatchedWithinTolerance ? "tolerance-cash-v1" : "timing-window-v1";
+                var ev = new MatchEvidence(Guid.NewGuid().ToString("N"), ruleId, "Tolerance", "Cash amount/timing tolerance evaluation.", (decimal?)timeDelta, new Dictionary<string, string>());
+                evidence.Add(ev);
+                matches.Add(new MatchGroup(Guid.NewGuid().ToString("N"), classification, ev.RuleId, Array.Empty<string>(), near.Append(candidate).Select(c => c.CashEntryId).Distinct().ToArray(), [ev.EvidenceId]));
+            }
+            else
+            {
+                var fuzzyHit = allCash.FirstOrDefault(other => other.CashEntryId != candidate.CashEntryId &&
+                    (!string.IsNullOrWhiteSpace(candidate.CounterpartyReference) && string.Equals(candidate.CounterpartyReference, other.CounterpartyReference, StringComparison.OrdinalIgnoreCase) ||
+                     !string.IsNullOrWhiteSpace(candidate.SettlementId) && string.Equals(candidate.SettlementId, other.SettlementId, StringComparison.OrdinalIgnoreCase) ||
+                     !string.IsNullOrWhiteSpace(candidate.Comment) && !string.IsNullOrWhiteSpace(other.Comment) && other.Comment.Contains(candidate.Comment, StringComparison.OrdinalIgnoreCase)));
+
+                if (fuzzyHit is not null)
+                {
+                    var ev = new MatchEvidence(Guid.NewGuid().ToString("N"), "fuzzy-reference-v1", "Fuzzy", "Reference-level fuzzy hit.", null, new Dictionary<string, string>());
+                    evidence.Add(ev);
+                    matches.Add(new MatchGroup(Guid.NewGuid().ToString("N"), BreakClassification.PotentialBreak, ev.RuleId, Array.Empty<string>(), [candidate.CashEntryId, fuzzyHit.CashEntryId], [ev.EvidenceId]));
+                }
+                else
+                {
+                    var ev = new MatchEvidence(Guid.NewGuid().ToString("N"), "true-break-v1", "Fuzzy", "No exact/tolerance/fuzzy evidence available.", null, new Dictionary<string, string>());
+                    evidence.Add(ev);
+                    breaks.Add(new BreakRecord(Guid.NewGuid().ToString("N"), BreakClassification.TrueBreak, ev.RuleId, "No matching candidate found.", run.SourceSnapshots.Select(s => s.SnapshotId).ToArray(), [ev.EvidenceId]));
+                }
+            }
+        }
+
+        return (matches, breaks, evidence);
+    }
+}
+
+public sealed class DefaultReconciliationIngestionScheduler : IReconciliationIngestionScheduler
+{
+    public async Task<IReadOnlyList<DataSourceSnapshot>> CaptureAsync(
+        IReadOnlyList<IReconciliationSourceAdapter> adapters,
+        ReconciliationIngestionRequest request,
+        CancellationToken ct)
+    {
+        var snapshots = new List<DataSourceSnapshot>();
+        foreach (var adapter in adapters.OrderBy(static a => a.SourceType))
+        {
+            snapshots.Add(await adapter.CaptureSnapshotAsync(request, ct).ConfigureAwait(false));
+        }
+
+        return snapshots;
+    }
+}
+
+public sealed class ReconciliationRunOrchestrator(
+    IReconciliationIngestionScheduler scheduler,
+    IReadOnlyList<IReconciliationSourceAdapter> adapters,
+    ReconciliationMatchingEngine matchingEngine)
+{
+    private readonly Dictionary<string, ReconciliationRun> _runByIdempotencyKey = new(StringComparer.OrdinalIgnoreCase);
+
+    public async Task<(ReconciliationRun run, IReadOnlyList<MatchGroup> matches, IReadOnlyList<BreakRecord> breaks, IReadOnlyList<MatchEvidence> evidence)> RunDailyAsync(
+        DateOnly businessDate,
+        DateTimeOffset runTimestampUtc,
+        string baseCurrency,
+        bool rerun,
+        MatchingTolerances tolerances,
+        CancellationToken ct)
+    {
+        var key = $"recon:{businessDate:yyyy-MM-dd}";
+        var priorExists = _runByIdempotencyKey.TryGetValue(key, out var prior);
+        if (priorExists && !rerun)
+        {
+            var cached = matchingEngine.Run(prior!, tolerances);
+            return (prior!, cached.matches, cached.breaks, cached.evidence);
+        }
+
+        var snapshotVersion = priorExists ? prior!.SnapshotVersion + 1 : 1;
+        var request = new ReconciliationIngestionRequest(businessDate, runTimestampUtc, baseCurrency, snapshotVersion);
+        var snapshots = await scheduler.CaptureAsync(adapters, request, ct).ConfigureAwait(false);
+        var run = new ReconciliationRun(Guid.NewGuid(), businessDate, runTimestampUtc, rerun, snapshotVersion, key, snapshots);
+        _runByIdempotencyKey[key] = run;
+
+        var result = matchingEngine.Run(run, tolerances);
+        return (run, result.matches, result.breaks, result.evidence);
+    }
+}

--- a/src/Meridian.Domain/Reconciliation/CanonicalReconciliation.cs
+++ b/src/Meridian.Domain/Reconciliation/CanonicalReconciliation.cs
@@ -1,0 +1,86 @@
+namespace Meridian.Domain.Reconciliation;
+
+public enum ReconciliationSourceType
+{
+    Prime,
+    Custodian,
+    Administrator,
+    InternalLedger
+}
+
+public enum BreakClassification
+{
+    Matched,
+    MatchedWithinTolerance,
+    PotentialBreak,
+    TrueBreak
+}
+
+public sealed record ReconciliationRun(
+    Guid RunId,
+    DateOnly BusinessDate,
+    DateTimeOffset RunTimestampUtc,
+    bool IsRerun,
+    int SnapshotVersion,
+    string IdempotencyKey,
+    IReadOnlyList<DataSourceSnapshot> SourceSnapshots);
+
+public sealed record DataSourceSnapshot(
+    string SnapshotId,
+    ReconciliationSourceType SourceType,
+    DateTimeOffset CapturedAtUtc,
+    string Version,
+    IReadOnlyList<NormalizedPosition> Positions,
+    IReadOnlyList<NormalizedCashEntry> CashEntries);
+
+public sealed record NormalizedPosition(
+    string PositionId,
+    string InstrumentCanonicalId,
+    string? Cusip,
+    string? Isin,
+    string? Ticker,
+    string? InternalSecurityId,
+    decimal Quantity,
+    decimal Price,
+    decimal MarketValue,
+    string Currency,
+    DateTimeOffset AsOfUtc,
+    string SourceReference);
+
+public sealed record NormalizedCashEntry(
+    string CashEntryId,
+    string AccountId,
+    decimal Amount,
+    string Currency,
+    decimal AmountBase,
+    string BaseCurrency,
+    DateTimeOffset PostedAtUtc,
+    DateOnly AccountingPeriod,
+    string SourceReference,
+    string? CounterpartyReference = null,
+    string? SettlementId = null,
+    string? Comment = null);
+
+public sealed record MatchGroup(
+    string MatchGroupId,
+    BreakClassification Classification,
+    string RuleId,
+    IReadOnlyList<string> PositionIds,
+    IReadOnlyList<string> CashEntryIds,
+    IReadOnlyList<string> EvidenceIds);
+
+public sealed record BreakRecord(
+    string BreakId,
+    BreakClassification Classification,
+    string RuleId,
+    string Reason,
+    IReadOnlyList<string> SnapshotIds,
+    IReadOnlyList<string> EvidenceIds);
+
+public sealed record MatchEvidence(
+    string EvidenceId,
+    string RuleId,
+    string Stage,
+    string Narrative,
+    decimal? NumericDelta,
+    IReadOnlyDictionary<string, string> Attributes);


### PR DESCRIPTION
### Motivation
- Provide a canonical reconciliation domain and pipeline to support daily fund reconciliation across prime, custodian, administrator, and internal ledger sources.
- Enable deterministic, auditable matching with normalization (IDs, FX, accounting-period alignment), multi-stage matching, and idempotent daily-run orchestration with rerun/snapshot versioning.

### Description
- Added a canonical domain module with `ReconciliationRun`, `DataSourceSnapshot`, `NormalizedPosition`, `NormalizedCashEntry`, `MatchGroup`, `BreakRecord`, `MatchEvidence`, and enums `ReconciliationSourceType`/`BreakClassification` in `src/Meridian.Domain/Reconciliation/CanonicalReconciliation.cs`.
- Introduced connector and ingestion contracts `IReconciliationSourceAdapter`, `IReconciliationIngestionScheduler`, and a default scheduler in `src/Meridian.Application/Reconciliation/CanonicalReconciliationEngine.cs` to capture ordered snapshots from prime/custodian/admin/internal-ledger adapters.
- Implemented `ReconciliationNormalizationService` leveraging `IInstrumentMappingService`, `IFxRateProvider`, and `IAccountingCalendar` to resolve instrument canonical IDs, convert currencies to a base currency at run timestamp, and align accounting periods.
- Implemented a staged `ReconciliationMatchingEngine` performing exact position matching, tolerance-based cash/ timing matching, and fuzzy/reference matching while emitting `MatchEvidence` and rule IDs; added `MatchingTolerances` and an idempotent `ReconciliationRunOrchestrator` with snapshot-version bump and rerun support.

### Testing
- Attempted to run focused reconciliation tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~Reconciliation" --logger "console;verbosity=minimal"`, but the environment lacks `dotnet` and the command could not be executed.
- No automated tests were executed successfully in this runtime; repository changes were committed and the code was added under `src/Meridian.Domain/Reconciliation/` and `src/Meridian.Application/Reconciliation/` for downstream CI validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17583e65488320bdfb07f4f4e5fa0c)