### PR TITLE
feat(workstation): add collateral exposure snapshot endpoint and service

### DIFF
--- a/src/Meridian.Contracts/Workstation/CollateralExposureDtos.cs
+++ b/src/Meridian.Contracts/Workstation/CollateralExposureDtos.cs
@@ -1,0 +1,44 @@
+namespace Meridian.Contracts.Workstation;
+
+public sealed record ExposureSnapshotDto(
+    DateTimeOffset AsOfUtc,
+    string IngestionMode,
+    IReadOnlyList<CounterpartyExposureDto> Counterparties,
+    IReadOnlyList<ThresholdBreachDto> Breaches,
+    IReadOnlyList<CollateralCallDto> CollateralCalls,
+    IReadOnlyList<ExposureTrendPointDto> Trend);
+
+public sealed record CounterpartyExposureDto(
+    string Counterparty,
+    decimal NetExposure,
+    decimal GrossExposure,
+    decimal CollateralBalance,
+    decimal HaircutAdjustedCollateral,
+    MarginRequirementDto MarginRequirement,
+    bool CollateralSufficient,
+    IReadOnlyList<ProductExposureDto> Products);
+
+public sealed record ProductExposureDto(string ProductType, decimal NetExposure, decimal GrossExposure);
+
+public sealed record MarginRequirementDto(decimal InitialMargin, decimal VariationMargin, decimal TotalRequired);
+
+public sealed record HaircutRuleDto(string AssetClass, decimal HaircutPercent, decimal AdvanceRatePercent);
+
+public sealed record CollateralCallDto(
+    string CallId,
+    string Counterparty,
+    decimal RequiredAmount,
+    decimal PostedAmount,
+    DateTimeOffset DueByUtc,
+    string Status,
+    string Reason);
+
+public sealed record ThresholdBreachDto(
+    string Counterparty,
+    string ThresholdLevel,
+    decimal ObservedExposure,
+    decimal LimitExposure,
+    DateTimeOffset DetectedAtUtc,
+    string Message);
+
+public sealed record ExposureTrendPointDto(DateTimeOffset AsOfUtc, decimal NetExposure, decimal CollateralCoverageRatio);

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -281,6 +281,14 @@ public static partial class WorkstationEndpoints
         .WithName("GetWorkstationTradingReadiness")
         .Produces<TradingOperatorReadinessDto>(200);
 
+        group.MapGet("/collateral/exposure", (HttpContext context) =>
+        {
+            var service = context.RequestServices.GetRequiredService<CollateralExposureService>();
+            return Results.Json(service.BuildSnapshot(), jsonOptions);
+        })
+        .WithName("GetWorkstationCollateralExposure")
+        .Produces<ExposureSnapshotDto>(200);
+
         group.MapGet("/operator/inbox", async (Guid? fundAccountId, HttpContext context) =>
         {
             var inbox = await BuildOperatorInboxAsync(fundAccountId, context).ConfigureAwait(false);

--- a/src/Meridian.Ui.Shared/Services/CollateralExposureService.cs
+++ b/src/Meridian.Ui.Shared/Services/CollateralExposureService.cs
@@ -1,0 +1,103 @@
+using Meridian.Contracts.Workstation;
+
+namespace Meridian.Ui.Shared.Services;
+
+public sealed class CollateralExposureService
+{
+    private static readonly IReadOnlyList<HaircutRuleDto> HaircutRules =
+    [
+        new("cash", 0.00m, 100m),
+        new("treasury", 0.02m, 98m),
+        new("equity", 0.15m, 85m),
+        new("credit", 0.20m, 80m)
+    ];
+
+    public ExposureSnapshotDto BuildSnapshot()
+    {
+        var asOf = DateTimeOffset.UtcNow;
+        var counterparties = new[]
+        {
+            BuildCounterparty("CP-ALPHA", 12_400_000m, 19_800_000m, 15_100_000m, 8_700_000m, 4_200_000m, 2_100_000m),
+            BuildCounterparty("CP-BETA", 6_500_000m, 11_900_000m, 6_900_000m, 3_900_000m, 2_400_000m, 1_100_000m)
+        };
+
+        var breaches = BuildThresholdBreaches(counterparties, asOf);
+        var calls = BuildCollateralCalls(counterparties, asOf);
+        var trend = Enumerable.Range(0, 12)
+            .Select(i =>
+            {
+                var t = asOf.AddMinutes(-5 * (11 - i));
+                var net = counterparties.Sum(c => c.NetExposure) * (0.95m + (i * 0.005m));
+                var coverage = counterparties.Sum(c => c.HaircutAdjustedCollateral) / Math.Max(1m, net);
+                return new ExposureTrendPointDto(t, decimal.Round(net, 2), decimal.Round(coverage, 4));
+            })
+            .ToArray();
+
+        return new ExposureSnapshotDto(asOf, "micro-batch:5m", counterparties, breaches, calls, trend);
+    }
+
+    private static CounterpartyExposureDto BuildCounterparty(string name, decimal net, decimal gross, decimal collateral, decimal repo, decimal swap, decimal margin)
+    {
+        var marginReq = new MarginRequirementDto(gross * 0.10m, net * 0.05m, gross * 0.10m + net * 0.05m);
+        var adjusted = ApplyHaircuts(collateral);
+        return new CounterpartyExposureDto(
+            name,
+            net,
+            gross,
+            collateral,
+            adjusted,
+            marginReq,
+            adjusted >= marginReq.TotalRequired,
+            [
+                new ProductExposureDto("repo", repo, repo * 1.45m),
+                new ProductExposureDto("swap", swap, swap * 1.55m),
+                new ProductExposureDto("margin", margin, margin * 1.35m)
+            ]);
+    }
+
+    private static decimal ApplyHaircuts(decimal collateralBalance)
+    {
+        var buckets = new Dictionary<string, decimal>
+        {
+            ["cash"] = collateralBalance * 0.35m,
+            ["treasury"] = collateralBalance * 0.30m,
+            ["equity"] = collateralBalance * 0.20m,
+            ["credit"] = collateralBalance * 0.15m
+        };
+
+        return decimal.Round(HaircutRules.Sum(rule => buckets[rule.AssetClass] * (rule.AdvanceRatePercent / 100m)), 2);
+    }
+
+    private static IReadOnlyList<ThresholdBreachDto> BuildThresholdBreaches(IReadOnlyList<CounterpartyExposureDto> counterparties, DateTimeOffset asOf)
+    {
+        const decimal earlyWarn = 12_000_000m;
+        const decimal hardLimit = 18_000_000m;
+
+        return counterparties
+            .SelectMany(cp => new[]
+            {
+                cp.GrossExposure >= hardLimit
+                    ? new ThresholdBreachDto(cp.Counterparty, "hard", cp.GrossExposure, hardLimit, asOf, "Hard breach: reduce exposure and post collateral.")
+                    : null,
+                cp.GrossExposure >= earlyWarn
+                    ? new ThresholdBreachDto(cp.Counterparty, "warning", cp.GrossExposure, earlyWarn, asOf, "Early warning: escalate collateral monitoring.")
+                    : null
+            })
+            .Where(x => x is not null)
+            .Cast<ThresholdBreachDto>()
+            .ToArray();
+    }
+
+    private static IReadOnlyList<CollateralCallDto> BuildCollateralCalls(IReadOnlyList<CounterpartyExposureDto> counterparties, DateTimeOffset asOf)
+        => counterparties
+            .Where(cp => !cp.CollateralSufficient)
+            .Select(cp => new CollateralCallDto(
+                $"CALL-{cp.Counterparty}-{asOf:yyyyMMddHHmm}",
+                cp.Counterparty,
+                decimal.Round(cp.MarginRequirement.TotalRequired - cp.HaircutAdjustedCollateral, 2),
+                0m,
+                asOf.AddHours(2),
+                "pending",
+                "Haircut-adjusted collateral below required margin."))
+            .ToArray();
+}

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -97,6 +97,7 @@ public static class WorkstationServiceCollectionExtensions
         services.TryAddSingleton(Dk1TrustGateReadinessOptions.Default);
         services.TryAddSingleton<Dk1TrustGateReadinessService>();
         services.TryAddSingleton<TradingOperatorReadinessService>();
+        services.TryAddSingleton<CollateralExposureService>();
         services.TryAddSingleton<RiskRuleRuntimeService>();
         services.TryAddSingleton<StrategyRunReviewPacketService>();
         services.TryAddSingleton<BacktestToLivePromoter>();

--- a/tests/Meridian.Tests/Ui/WorkstationCollateralExposureEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationCollateralExposureEndpointsTests.cs
@@ -1,0 +1,31 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Meridian.Contracts.Workstation;
+using Meridian.Ui.Shared.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Tests.Ui;
+
+public sealed partial class WorkstationEndpointsTests
+{
+    [Fact]
+    public async Task MapWorkstationEndpoints_CollateralExposure_ShouldReturnSnapshotWithThresholdsAndCalls()
+    {
+        await using var app = await CreateAppAsync(services =>
+        {
+            services.AddSingleton<CollateralExposureService>();
+        });
+
+        var client = app.GetTestClient();
+        var response = await client.GetAsync("/api/workstation/collateral/exposure");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ExposureSnapshotDto>(ServerJsonOptions);
+        payload.Should().NotBeNull();
+        payload!.Counterparties.Should().NotBeEmpty();
+        payload.Breaches.Should().NotBeEmpty();
+        payload.Trend.Should().HaveCount(12);
+        payload.IngestionMode.Should().StartWith("micro-batch");
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a first-pass collateral domain contract and backend surface to support exposure monitoring, haircut-adjusted collateral sufficiency checks, threshold detection, and dashboard/time-series views.
- Offer a micro-batch-friendly ingestion simulation and an API contract so the UI and ops alerting can be wired in subsequent slices.

### Description
- Add collateral DTOs representing `ExposureSnapshot`, `CounterpartyExposure`, `MarginRequirement`, `HaircutRule`, `CollateralCall`, `ThresholdBreach`, and trend points at `src/Meridian.Contracts/Workstation/CollateralExposureDtos.cs`.
- Implement `CollateralExposureService` that computes net/gross exposures, product-level decomposition, applies haircuts, detects early-warning/hard breaches, and produces collateral calls and a 12-point trend at `src/Meridian.Ui.Shared/Services/CollateralExposureService.cs`.
- Expose the snapshot via a new workstation endpoint `GET /api/workstation/collateral/exposure` added to `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` and register the service in the shared DI graph in `src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs`.
- Add endpoint coverage at `tests/Meridian.Tests/Ui/WorkstationCollateralExposureEndpointsTests.cs` validating payload shape and key assertions (counterparties, breaches, trend length, ingestion mode).

### Testing
- Added an automated endpoint test `MapWorkstationEndpoints_CollateralExposure_ShouldReturnSnapshotWithThresholdsAndCalls` in `tests/Meridian.Tests/Ui/WorkstationCollateralExposureEndpointsTests.cs` but it was not executed in this environment.
- Attempted to run `dotnet test --filter "FullyQualifiedName~CollateralExposure"` but the run failed in the container due to `dotnet` not being available (`dotnet: command not found`).
- No other automated tests were executed in this rollout; the new test is present for CI to run in an environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1758330d348320a38a4e97152ebcaa)