### PR TITLE
Add break-case lifecycle, scoring, SLA, immutable audit payloads and bulk action DTOs

### DIFF
--- a/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
+++ b/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
@@ -287,13 +287,13 @@ public enum ReconciliationBreakQueueStatus : byte
 [JsonConverter(typeof(JsonStringEnumConverter<ReconciliationCaseLifecycleState>))]
 public enum ReconciliationCaseLifecycleState : byte
 {
-    Opened = 0,
-    Triaged = 1,
-    Calibrated = 2,
-    Approved = 3,
-    Escalated = 4,
-    Closed = 5,
-    Superseded = 6
+    New = 0,
+    Classified = 1,
+    Assigned = 2,
+    Investigating = 3,
+    PendingExternal = 4,
+    Resolved = 5,
+    Closed = 6
 }
 
 /// <summary>
@@ -337,7 +337,16 @@ public sealed record ReconciliationBreakQueueItem(
     string? RoutingTarget = null,
     string? RoutingDetail = null,
     string? RecommendedAction = null,
-    ReconciliationCaseLifecycleState LifecycleState = ReconciliationCaseLifecycleState.Opened,
+    int PriorityScore = 0,
+    string? PriorityBand = null,
+    decimal MaterialityScore = 0m,
+    decimal AgeScore = 0m,
+    decimal CounterpartyCriticalityScore = 0m,
+    decimal RecurringPatternScore = 0m,
+    DateTimeOffset? SlaDueAt = null,
+    DateTimeOffset? LastEscalatedAt = null,
+    bool IsSlaBreached = false,
+    ReconciliationCaseLifecycleState LifecycleState = ReconciliationCaseLifecycleState.New,
     string? LifecycleRationale = null,
     string? ExternalAccountId = null,
     string? CustodianId = null,
@@ -406,7 +415,8 @@ public sealed record ReviewReconciliationBreakRequest(
     string BreakId,
     string AssignedTo,
     string ReviewedBy,
-    string? ReviewNote = null);
+    string? ReviewNote = null,
+    string? Team = null);
 
 /// <summary>
 /// Request to resolve or dismiss a break with audit metadata.
@@ -416,4 +426,25 @@ public sealed record ResolveReconciliationBreakRequest(
     ReconciliationBreakQueueStatus Status,
     string ResolvedBy,
     string ResolutionNote,
-    string OperatorRationale);
+    string OperatorRationale,
+    string? DispositionCode = null);
+
+
+public sealed record ReconciliationBreakWorkflowActionRequest(
+    string BreakId,
+    string Actor,
+    string ActionType,
+    string? AssignedTo = null,
+    string? EvidenceNote = null,
+    string? LinkedDocument = null,
+    string? CommentTemplate = null,
+    string? DispositionCode = null,
+    ReconciliationCaseLifecycleState? TargetLifecycleState = null);
+
+public sealed record ReconciliationBreakBulkActionRequest(
+    IReadOnlyList<string> BreakIds,
+    string Actor,
+    string ActionType,
+    string? AssignedTo = null,
+    string? CommentTemplate = null,
+    ReconciliationCaseLifecycleState? TargetLifecycleState = null);

--- a/src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs
+++ b/src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs
@@ -82,7 +82,7 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 return false;
             }
 
-            _items[item.BreakId] = item;
+            _items[item.BreakId] = ApplyScoringAndSla(item);
             await PersistSnapshotAsync(ct).ConfigureAwait(false);
             await AppendAuditAsync(new ReconciliationBreakQueueAuditEvent(
                 EventId: Guid.NewGuid().ToString("N"),
@@ -103,7 +103,10 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 SignoffStatus: item.SignoffStatus,
                 ExternalAccountId: item.ExternalAccountId,
                 CustodianId: item.CustodianId,
-                UpstreamSyncCursor: item.UpstreamSyncCursor), ct).ConfigureAwait(false);
+                UpstreamSyncCursor: item.UpstreamSyncCursor,
+                Actor: item.AssignedTo ?? item.ReviewedBy ?? item.ResolvedBy,
+                BeforePayload: null,
+                AfterPayload: JsonSerializer.Serialize(item, _jsonOptions)), ct).ConfigureAwait(false);
 
             return true;
         }
@@ -186,14 +189,15 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 LastUpdatedAt = now,
                 ResolutionNote = request.ReviewNote,
                 SignoffStatus = "in-review",
-                LifecycleState = ReconciliationCaseLifecycleState.Triaged,
+                LifecycleState = ReconciliationCaseLifecycleState.Investigating,
                 LifecycleRationale = request.ReviewNote,
                 StateTransitions = (item.StateTransitions ?? []).Concat(
                 [
-                    new ReconciliationCaseStateTransition(Guid.NewGuid().ToString("N"), item.LifecycleState, ReconciliationCaseLifecycleState.Triaged, request.ReviewedBy, request.ReviewNote, now)
+                    new ReconciliationCaseStateTransition(Guid.NewGuid().ToString("N"), item.LifecycleState, ReconciliationCaseLifecycleState.Investigating, request.ReviewedBy, request.ReviewNote, now)
                 ]).ToArray()
             };
 
+            updated = ApplyScoringAndSla(updated);
             _items[request.BreakId] = updated;
             await PersistSnapshotAsync(ct).ConfigureAwait(false);
             await AppendAuditAsync(new ReconciliationBreakQueueAuditEvent(
@@ -215,7 +219,10 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 SignoffStatus: updated.SignoffStatus,
                 ExternalAccountId: updated.ExternalAccountId,
                 CustodianId: updated.CustodianId,
-                UpstreamSyncCursor: updated.UpstreamSyncCursor), ct).ConfigureAwait(false);
+                UpstreamSyncCursor: updated.UpstreamSyncCursor,
+                Actor: request.ReviewedBy,
+                BeforePayload: JsonSerializer.Serialize(item, _jsonOptions),
+                AfterPayload: JsonSerializer.Serialize(updated, _jsonOptions)), ct).ConfigureAwait(false);
 
             return new ReconciliationBreakQueueTransitionResult(ReconciliationBreakQueueTransitionStatus.Success, updated);
         }
@@ -275,8 +282,8 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                     ? "pending-signoff"
                     : "dismissed",
                 LifecycleState = request.Status == ReconciliationBreakQueueStatus.Resolved
-                    ? ReconciliationCaseLifecycleState.Closed
-                    : ReconciliationCaseLifecycleState.Superseded,
+                    ? ReconciliationCaseLifecycleState.Resolved
+                    : ReconciliationCaseLifecycleState.Resolved,
                 LifecycleRationale = request.OperatorRationale,
                 SignoffHistory = (item.SignoffHistory ?? []).Concat(
                 [
@@ -284,10 +291,11 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 ]).ToArray(),
                 StateTransitions = (item.StateTransitions ?? []).Concat(
                 [
-                    new ReconciliationCaseStateTransition(Guid.NewGuid().ToString("N"), item.LifecycleState, request.Status == ReconciliationBreakQueueStatus.Resolved ? ReconciliationCaseLifecycleState.Closed : ReconciliationCaseLifecycleState.Superseded, request.ResolvedBy, request.OperatorRationale, now)
+                    new ReconciliationCaseStateTransition(Guid.NewGuid().ToString("N"), item.LifecycleState, request.Status == ReconciliationBreakQueueStatus.Resolved ? ReconciliationCaseLifecycleState.Resolved : ReconciliationCaseLifecycleState.Resolved, request.ResolvedBy, request.OperatorRationale, now)
                 ]).ToArray()
             };
 
+            updated = ApplyScoringAndSla(updated);
             _items[request.BreakId] = updated;
             await PersistSnapshotAsync(ct).ConfigureAwait(false);
             await AppendAuditAsync(new ReconciliationBreakQueueAuditEvent(
@@ -309,7 +317,10 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 SignoffStatus: updated.SignoffStatus,
                 ExternalAccountId: updated.ExternalAccountId,
                 CustodianId: updated.CustodianId,
-                UpstreamSyncCursor: updated.UpstreamSyncCursor), ct).ConfigureAwait(false);
+                UpstreamSyncCursor: updated.UpstreamSyncCursor,
+                Actor: request.ReviewedBy,
+                BeforePayload: JsonSerializer.Serialize(item, _jsonOptions),
+                AfterPayload: JsonSerializer.Serialize(updated, _jsonOptions)), ct).ConfigureAwait(false);
 
             return new ReconciliationBreakQueueTransitionResult(ReconciliationBreakQueueTransitionStatus.Success, updated);
         }
@@ -391,6 +402,31 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
     {
         var line = JsonSerializer.Serialize(auditEvent, _jsonOptions);
         await AtomicFileWriter.AppendLinesAsync(_auditPath, [line], ct).ConfigureAwait(false);
+    }
+
+
+
+    private static ReconciliationBreakQueueItem ApplyScoringAndSla(ReconciliationBreakQueueItem item)
+    {
+        var ageHours = Math.Max(0d, (DateTimeOffset.UtcNow - item.DetectedAt).TotalHours);
+        var ageScore = (decimal)Math.Min(25d, ageHours / 4d);
+        var materialityScore = Math.Min(40m, Math.Abs(item.Variance) / 2500m);
+        var counterpartyScore = string.IsNullOrWhiteSpace(item.CustodianId) ? 5m : 20m;
+        var recurringScore = string.IsNullOrWhiteSpace(item.UpstreamSyncCursor) ? 5m : 15m;
+        var total = (int)Math.Clamp(materialityScore + ageScore + counterpartyScore + recurringScore, 0m, 100m);
+        var band = total >= 80 ? "P1" : total >= 60 ? "P2" : total >= 40 ? "P3" : "P4";
+        var slaDue = item.DetectedAt.AddHours(total >= 80 ? 4 : total >= 60 ? 8 : 24);
+        return item with
+        {
+            PriorityScore = total,
+            PriorityBand = band,
+            MaterialityScore = materialityScore,
+            AgeScore = ageScore,
+            CounterpartyCriticalityScore = counterpartyScore,
+            RecurringPatternScore = recurringScore,
+            SlaDueAt = slaDue,
+            IsSlaBreached = DateTimeOffset.UtcNow > slaDue
+        };
     }
 
     private sealed record BreakQueueSnapshot(IReadOnlyList<ReconciliationBreakQueueItem> Items);

--- a/src/Meridian.Strategies/Services/IReconciliationBreakQueueRepository.cs
+++ b/src/Meridian.Strategies/Services/IReconciliationBreakQueueRepository.cs
@@ -52,4 +52,7 @@ public sealed record ReconciliationBreakQueueAuditEvent(
     string? SignoffStatus = null,
     string? ExternalAccountId = null,
     string? CustodianId = null,
-    string? UpstreamSyncCursor = null);
+    string? UpstreamSyncCursor = null,
+    string? Actor = null,
+    string? BeforePayload = null,
+    string? AfterPayload = null);

--- a/tests/Meridian.Tests/Strategies/ReconciliationBreakQueueRepositoryTests.cs
+++ b/tests/Meridian.Tests/Strategies/ReconciliationBreakQueueRepositoryTests.cs
@@ -39,11 +39,11 @@ public sealed class ReconciliationBreakQueueRepositoryTests
 
         var review = await repo.StartReviewAsync(new ReviewReconciliationBreakRequest(item.BreakId, "alice", "alice", "triage"));
         review.Status.Should().Be(ReconciliationBreakQueueTransitionStatus.Success);
-        review.Item!.LifecycleState.Should().Be(ReconciliationCaseLifecycleState.Triaged);
+        review.Item!.LifecycleState.Should().Be(ReconciliationCaseLifecycleState.Investigating);
 
         var closed = await repo.ResolveAsync(new ResolveReconciliationBreakRequest(item.BreakId, ReconciliationBreakQueueStatus.Resolved, "bob", "resolved", "evidence packet #42"));
         closed.Status.Should().Be(ReconciliationBreakQueueTransitionStatus.Success);
-        closed.Item!.LifecycleState.Should().Be(ReconciliationCaseLifecycleState.Closed);
+        closed.Item!.LifecycleState.Should().Be(ReconciliationCaseLifecycleState.Resolved);
         closed.Item.SignoffHistory.Should().NotBeNullOrEmpty();
         closed.Item.StateTransitions.Should().HaveCountGreaterThanOrEqualTo(2);
 


### PR DESCRIPTION
### Motivation
- Introduce a richer break-case lifecycle and operational scoring so reconciliation breaks can be classified, prioritized, routed, and tracked through a deterministic lifecycle. 
- Capture immutable, auditable event snapshots for every state/action change so operators and governance can reconstruct what changed, when, and who acted. 
- Surface SLA and priority metadata so UIs and operator workflows can alert on stale or high-priority breaks and support bulk/operational actions. 

### Description
- Replaced the old reconciliation case lifecycle with new break-case states by adding the `ReconciliationCaseLifecycleState` values `New`, `Classified`, `Assigned`, `Investigating`, `PendingExternal`, `Resolved`, and `Closed` in `ReconciliationDtos.cs`. 
- Extended `ReconciliationBreakQueueItem` to carry scoring and SLA metadata (`PriorityScore`, `PriorityBand`, `MaterialityScore`, `AgeScore`, `CounterpartyCriticalityScore`, `RecurringPatternScore`, `SlaDueAt`, `IsSlaBreached`) and added team/disposition/bulk/workflow action request records (`ReviewReconciliationBreakRequest` extended with `Team`, `ResolveReconciliationBreakRequest` with `DispositionCode`, plus `ReconciliationBreakWorkflowActionRequest` and `ReconciliationBreakBulkActionRequest`). 
- Expanded the audit event contract `ReconciliationBreakQueueAuditEvent` to include immutable audit fields `Actor`, `BeforePayload`, and `AfterPayload` so each transition records actor and payload snapshots. 
- Updated the file-backed repository `FileReconciliationBreakQueueRepository` to compute rule-driven scoring and SLA values via a new `ApplyScoringAndSla` helper and to apply scoring on create/review/resolve transitions. 
- Modified review/resolve transitions to map into the new lifecycle states and to append audit entries that include `Actor`, `BeforePayload`, and `AfterPayload` JSON snapshots. 
- Updated repository-level tests in `ReconciliationBreakQueueRepositoryTests` to assert the renamed lifecycle states used by review/resolve flows. 

### Testing
- Updated unit tests in `tests/Meridian.Tests/Strategies/ReconciliationBreakQueueRepositoryTests.cs` to reflect new lifecycle state names and behavior and validated locally by inspecting updated test expectations (tests were modified in this change). 
- Attempted a targeted test run with `dotnet test --filter "FullyQualifiedName~ReconciliationBreakQueueRepositoryTests"`, but the execution environment lacks the `dotnet` runtime so the test run could not be executed here. 
- Repository changes are limited to DTOs, the file-backed repository, and tests to minimize surface area for integration; recommend running the full test suite (`dotnet test`) in a CI environment to validate platform builds and integration with the UI endpoints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17583ec0fc8320b49501554796075c)