### PR TITLE
Add cash sync orchestration with validation, approval chains, forecasting and STP

### DIFF
--- a/src/Meridian.Ui.Shared/Services/CashSyncOrchestrationService.cs
+++ b/src/Meridian.Ui.Shared/Services/CashSyncOrchestrationService.cs
@@ -1,0 +1,232 @@
+namespace Meridian.Ui.Shared.Services;
+
+public sealed record SourceAvailabilityWindow(string SourceId, TimeOnly StartLocal, TimeOnly EndLocal, bool IsAvailable);
+
+public sealed record RegionalSyncWindow(
+    string Region,
+    string TimeZoneId,
+    TimeOnly SyncStartLocal,
+    TimeOnly SyncEndLocal,
+    IReadOnlyList<SourceAvailabilityWindow> Sources);
+
+public sealed record SyncAccountSnapshot(
+    string AccountId,
+    string Counterparty,
+    string Currency,
+    decimal ClosingBalance,
+    decimal NetDelta,
+    DateOnly BusinessDate,
+    bool IsComplete);
+
+public sealed record SyncValidationIssue(string Code, string Message, string Severity);
+
+public sealed record SyncValidationResult(bool Passed, IReadOnlyList<SyncValidationIssue> Issues);
+
+public sealed record FxConversionReference(string BaseCurrency, string QuoteCurrency, decimal Rate, DateTimeOffset AsOf);
+
+public sealed record PaymentInstruction(
+    string InstructionId,
+    string AccountId,
+    string Counterparty,
+    string Currency,
+    decimal Amount,
+    DateOnly ValueDate,
+    string Purpose,
+    string Status);
+
+public sealed record SettlementInstruction(
+    string InstructionId,
+    string AccountId,
+    string Currency,
+    decimal GrossAmount,
+    DateOnly TradeDate,
+    DateOnly SettlementDate,
+    DateTimeOffset CutoffAt,
+    string Status);
+
+public sealed record CouponEvent(
+    string EventId,
+    string SecurityId,
+    string AccountId,
+    string Currency,
+    decimal Amount,
+    DateOnly ExDate,
+    DateOnly PayDate,
+    string Status);
+
+public sealed record ApprovalStep(
+    string StepId,
+    string Role,
+    string Approver,
+    bool IsRequired,
+    bool IsApproved,
+    DateTimeOffset? DecidedAt);
+
+public sealed record ApprovalPolicy(
+    decimal DualControlThreshold,
+    IReadOnlyDictionary<string, decimal> CurrencyThresholds,
+    IReadOnlyDictionary<string, decimal> AccountThresholds,
+    IReadOnlySet<string> HighRiskCounterparties);
+
+public sealed record ApprovalDecision(bool RequiresDualControl, IReadOnlyList<ApprovalStep> Steps);
+
+public sealed record CashForecastPoint(DateOnly Date, string AccountId, string Currency, decimal ExpectedInflow, decimal ExpectedOutflow, decimal Net);
+
+public sealed record LiquidityWarning(string AccountId, string Currency, DateOnly Date, decimal ProjectedNet, string Message);
+
+public sealed record StpTransitionResult(string EntityId, string State, string? ExceptionReason, bool RoutedToBreakQueue);
+
+public interface ICashSyncOrchestrationService
+{
+    bool IsSyncWindowOpen(DateTimeOffset utcNow, RegionalSyncWindow window);
+    SyncValidationResult ValidateCompleteness(IEnumerable<SyncAccountSnapshot> snapshots);
+    SyncValidationResult ValidateOutliers(IEnumerable<SyncAccountSnapshot> currentDay, IEnumerable<SyncAccountSnapshot> priorDay, decimal outlierThreshold);
+    ApprovalDecision BuildApprovalChain(PaymentInstruction paymentInstruction, ApprovalPolicy policy, string primaryApprover, string secondaryApprover);
+    DateOnly ResolveSettlementDate(DateOnly tradeDate, TimeOnly localCutoff, TimeOnly submittedAtLocal, int standardSettlementDays);
+    IReadOnlyList<CashForecastPoint> BuildCashLadder(DateOnly startDate, int horizonDays, IEnumerable<PaymentInstruction> payments, IEnumerable<SettlementInstruction> settlements, IEnumerable<CouponEvent> coupons);
+    IReadOnlyList<LiquidityWarning> BuildLiquidityWarnings(IEnumerable<CashForecastPoint> ladder, decimal minimumNetThreshold);
+    StpTransitionResult AdvanceStpState(string entityId, bool validated, bool approved, string? exceptionReason);
+}
+
+public sealed class CashSyncOrchestrationService : ICashSyncOrchestrationService
+{
+    public bool IsSyncWindowOpen(DateTimeOffset utcNow, RegionalSyncWindow window)
+    {
+        var localNow = TimeZoneInfo.ConvertTime(utcNow, TimeZoneInfo.FindSystemTimeZoneById(window.TimeZoneId));
+        var inWindow = localNow.TimeOfDay >= window.SyncStartLocal.ToTimeSpan() && localNow.TimeOfDay <= window.SyncEndLocal.ToTimeSpan();
+        var sourcesReady = window.Sources.All(source => source.IsAvailable && localNow.TimeOfDay >= source.StartLocal.ToTimeSpan() && localNow.TimeOfDay <= source.EndLocal.ToTimeSpan());
+        return inWindow && sourcesReady;
+    }
+
+    public SyncValidationResult ValidateCompleteness(IEnumerable<SyncAccountSnapshot> snapshots)
+    {
+        var issues = snapshots
+            .Where(snapshot => !snapshot.IsComplete)
+            .Select(snapshot => new SyncValidationIssue("completeness", $"{snapshot.AccountId}/{snapshot.Counterparty} is incomplete for {snapshot.BusinessDate:yyyy-MM-dd}.", "Error"))
+            .ToList();
+
+        return new SyncValidationResult(issues.Count == 0, issues);
+    }
+
+    public SyncValidationResult ValidateOutliers(IEnumerable<SyncAccountSnapshot> currentDay, IEnumerable<SyncAccountSnapshot> priorDay, decimal outlierThreshold)
+    {
+        var priorByKey = priorDay.ToDictionary(item => $"{item.AccountId}|{item.Counterparty}|{item.Currency}");
+        var issues = new List<SyncValidationIssue>();
+
+        foreach (var current in currentDay)
+        {
+            var key = $"{current.AccountId}|{current.Counterparty}|{current.Currency}";
+            if (!priorByKey.TryGetValue(key, out var prior) || prior.NetDelta == 0m)
+            {
+                continue;
+            }
+
+            var jump = Math.Abs((current.NetDelta - prior.NetDelta) / prior.NetDelta);
+            if (jump >= outlierThreshold)
+            {
+                issues.Add(new SyncValidationIssue("outlier", $"Delta jump for {current.AccountId}/{current.Currency} was {jump:P1} vs prior day.", "Warning"));
+            }
+        }
+
+        return new SyncValidationResult(issues.Count == 0, issues);
+    }
+
+    public ApprovalDecision BuildApprovalChain(PaymentInstruction paymentInstruction, ApprovalPolicy policy, string primaryApprover, string secondaryApprover)
+    {
+        var currencyThreshold = policy.CurrencyThresholds.TryGetValue(paymentInstruction.Currency, out var cThreshold) ? cThreshold : decimal.MaxValue;
+        var accountThreshold = policy.AccountThresholds.TryGetValue(paymentInstruction.AccountId, out var aThreshold) ? aThreshold : decimal.MaxValue;
+        var threshold = Math.Min(policy.DualControlThreshold, Math.Min(currencyThreshold, accountThreshold));
+
+        var highRisk = policy.HighRiskCounterparties.Contains(paymentInstruction.Counterparty);
+        var requiresDual = highRisk || Math.Abs(paymentInstruction.Amount) >= threshold;
+
+        var steps = new List<ApprovalStep>
+        {
+            new(Guid.NewGuid().ToString("N"), "Primary", primaryApprover, true, false, null)
+        };
+
+        if (requiresDual)
+        {
+            steps.Add(new ApprovalStep(Guid.NewGuid().ToString("N"), "Secondary", secondaryApprover, true, false, null));
+        }
+
+        return new ApprovalDecision(requiresDual, steps);
+    }
+
+    public DateOnly ResolveSettlementDate(DateOnly tradeDate, TimeOnly localCutoff, TimeOnly submittedAtLocal, int standardSettlementDays)
+    {
+        var days = submittedAtLocal > localCutoff ? standardSettlementDays + 1 : standardSettlementDays;
+        return tradeDate.AddDays(days);
+    }
+
+    public IReadOnlyList<CashForecastPoint> BuildCashLadder(DateOnly startDate, int horizonDays, IEnumerable<PaymentInstruction> payments, IEnumerable<SettlementInstruction> settlements, IEnumerable<CouponEvent> coupons)
+    {
+        var horizonEnd = startDate.AddDays(horizonDays);
+        var points = new Dictionary<string, CashForecastPoint>();
+
+        static string Key(DateOnly d, string acct, string ccy) => $"{d:yyyyMMdd}|{acct}|{ccy}";
+
+        void Add(DateOnly date, string accountId, string currency, decimal inflow, decimal outflow)
+        {
+            if (date < startDate || date > horizonEnd) return;
+            var key = Key(date, accountId, currency);
+            if (!points.TryGetValue(key, out var existing))
+            {
+                existing = new CashForecastPoint(date, accountId, currency, 0m, 0m, 0m);
+            }
+
+            var next = existing with
+            {
+                ExpectedInflow = existing.ExpectedInflow + inflow,
+                ExpectedOutflow = existing.ExpectedOutflow + outflow,
+                Net = existing.Net + inflow - outflow
+            };
+            points[key] = next;
+        }
+
+        foreach (var payment in payments)
+        {
+            if (payment.Amount >= 0m) Add(payment.ValueDate, payment.AccountId, payment.Currency, payment.Amount, 0m);
+            else Add(payment.ValueDate, payment.AccountId, payment.Currency, 0m, Math.Abs(payment.Amount));
+        }
+
+        foreach (var settlement in settlements)
+        {
+            if (settlement.GrossAmount >= 0m) Add(settlement.SettlementDate, settlement.AccountId, settlement.Currency, settlement.GrossAmount, 0m);
+            else Add(settlement.SettlementDate, settlement.AccountId, settlement.Currency, 0m, Math.Abs(settlement.GrossAmount));
+        }
+
+        foreach (var coupon in coupons)
+        {
+            Add(coupon.PayDate, coupon.AccountId, coupon.Currency, coupon.Amount, 0m);
+        }
+
+        return points.Values.OrderBy(point => point.Date).ThenBy(point => point.AccountId).ThenBy(point => point.Currency).ToArray();
+    }
+
+    public IReadOnlyList<LiquidityWarning> BuildLiquidityWarnings(IEnumerable<CashForecastPoint> ladder, decimal minimumNetThreshold)
+        => ladder
+            .Where(point => point.Net < minimumNetThreshold)
+            .Select(point => new LiquidityWarning(point.AccountId, point.Currency, point.Date, point.Net, $"Projected net {point.Net} is below threshold {minimumNetThreshold}."))
+            .ToArray();
+
+    public StpTransitionResult AdvanceStpState(string entityId, bool validated, bool approved, string? exceptionReason)
+    {
+        if (!string.IsNullOrWhiteSpace(exceptionReason))
+        {
+            return new StpTransitionResult(entityId, "Exception", exceptionReason, true);
+        }
+
+        if (!validated)
+        {
+            return new StpTransitionResult(entityId, "ValidationPending", null, false);
+        }
+
+        if (!approved)
+        {
+            return new StpTransitionResult(entityId, "ApprovalPending", null, false);
+        }
+
+        return new StpTransitionResult(entityId, "Settled", null, false);
+    }
+}

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -94,6 +94,8 @@ public static class WorkstationServiceCollectionExtensions
         services.TryAddSingleton(BrokeragePortfolioSyncOptions.Default);
         services.TryAddSingleton<BrokeragePortfolioSyncService>();
 
+        services.TryAddSingleton<ICashSyncOrchestrationService, CashSyncOrchestrationService>();
+
         services.TryAddSingleton(Dk1TrustGateReadinessOptions.Default);
         services.TryAddSingleton<Dk1TrustGateReadinessService>();
         services.TryAddSingleton<TradingOperatorReadinessService>();

--- a/tests/Meridian.Tests/Services/CashSyncOrchestrationServiceTests.cs
+++ b/tests/Meridian.Tests/Services/CashSyncOrchestrationServiceTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using Meridian.Ui.Shared.Services;
+
+namespace Meridian.Tests.Services;
+
+public sealed class CashSyncOrchestrationServiceTests
+{
+    private readonly CashSyncOrchestrationService _service = new();
+
+    [Fact]
+    public void ValidateCompleteness_WhenIncompleteSnapshotExists_ReturnsError()
+    {
+        var result = _service.ValidateCompleteness([
+            new SyncAccountSnapshot("acct-1", "cp-a", "USD", 100m, 20m, new DateOnly(2026, 5, 27), true),
+            new SyncAccountSnapshot("acct-2", "cp-b", "EUR", 200m, 30m, new DateOnly(2026, 5, 27), false)
+        ]);
+
+        result.Passed.Should().BeFalse();
+        result.Issues.Should().ContainSingle(issue => issue.Code == "completeness");
+    }
+
+    [Fact]
+    public void ValidateOutliers_WhenDeltaJumpExceedsThreshold_ReturnsWarning()
+    {
+        var prior = new[] { new SyncAccountSnapshot("acct-1", "cp-a", "USD", 100m, 10m, new DateOnly(2026, 5, 26), true) };
+        var current = new[] { new SyncAccountSnapshot("acct-1", "cp-a", "USD", 110m, 30m, new DateOnly(2026, 5, 27), true) };
+
+        var result = _service.ValidateOutliers(current, prior, 1.5m);
+
+        result.Passed.Should().BeFalse();
+        result.Issues.Should().ContainSingle(issue => issue.Code == "outlier");
+    }
+
+    [Fact]
+    public void BuildApprovalChain_HighRiskOrThreshold_ShouldRequireDualControl()
+    {
+        var payment = new PaymentInstruction("p-1", "acct-1", "cp-risk", "USD", 200_000m, new DateOnly(2026, 5, 27), "Margin", "New");
+        var policy = new ApprovalPolicy(
+            DualControlThreshold: 100_000m,
+            CurrencyThresholds: new Dictionary<string, decimal> { ["USD"] = 150_000m },
+            AccountThresholds: new Dictionary<string, decimal> { ["acct-1"] = 250_000m },
+            HighRiskCounterparties: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "cp-risk" });
+
+        var decision = _service.BuildApprovalChain(payment, policy, "alice", "bob");
+
+        decision.RequiresDualControl.Should().BeTrue();
+        decision.Steps.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void BuildCashLadder_AndWarnings_ShouldProjectAndFlagLiquidity()
+    {
+        var ladder = _service.BuildCashLadder(
+            new DateOnly(2026, 5, 27),
+            7,
+            [new PaymentInstruction("p-1", "acct-1", "USD", -500m, new DateOnly(2026, 5, 28), "Fee", "Submitted")],
+            [new SettlementInstruction("s-1", "acct-1", "USD", 100m, new DateOnly(2026, 5, 27), new DateOnly(2026, 5, 28), DateTimeOffset.UtcNow, "Matched")],
+            [new CouponEvent("c-1", "sec-1", "acct-1", "USD", 10m, new DateOnly(2026, 5, 27), new DateOnly(2026, 5, 29), "Projected")]);
+
+        ladder.Should().NotBeEmpty();
+        var warnings = _service.BuildLiquidityWarnings(ladder, -100m);
+        warnings.Should().Contain(w => w.AccountId == "acct-1" && w.Currency == "USD");
+    }
+
+    [Theory]
+    [InlineData(true, true, null, "Settled", false)]
+    [InlineData(false, false, null, "ValidationPending", false)]
+    [InlineData(true, false, null, "ApprovalPending", false)]
+    [InlineData(true, true, "failed enrichment", "Exception", true)]
+    public void AdvanceStpState_TransitionsAsExpected(bool validated, bool approved, string? reason, string expectedState, bool expectedBreakQueue)
+    {
+        var result = _service.AdvanceStpState("entity-1", validated, approved, reason);
+
+        result.State.Should().Be(expectedState);
+        result.RoutedToBreakQueue.Should().Be(expectedBreakQueue);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a scheduler/orchestrator for daily sync windows that respects regional/timezone windows and per-source availability. 
- Add validation gates (completeness and prior-day outlier detection), structured cash movement objects, and approval-chain logic to support governed cash processing. 
- Support multi-currency/cutoff-aware settlement logic and a short-term cash ladder/forecast to surface liquidity warnings and drive STP routing and break-queue fallback.

### Description
- Introduced `ICashSyncOrchestrationService` and `CashSyncOrchestrationService` in `src/Meridian.Ui.Shared/Services/CashSyncOrchestrationService.cs` implementing: `IsSyncWindowOpen`, `ValidateCompleteness`, `ValidateOutliers`, `BuildApprovalChain`, `ResolveSettlementDate`, `BuildCashLadder`, `BuildLiquidityWarnings`, and `AdvanceStpState`.
- Added domain records for cash flows and controls: `PaymentInstruction`, `SettlementInstruction`, `CouponEvent`, `ApprovalStep`, `ApprovalPolicy`, `FxConversionReference`, `CashForecastPoint`, `LiquidityWarning`, and related validation/decision DTOs.
- Implemented approval-chain/dual-control policy evaluation using amount thresholds with currency/account/counterparty overrides, and cutoff-aware settlement date resolution that is sensitive to local cutoff times.
- Registered the orchestration service in DI via `WorkstationServiceCollectionExtensions` and added focused unit tests in `tests/Meridian.Tests/Services/CashSyncOrchestrationServiceTests.cs` covering completeness/outlier validation, approval decision logic, ladder projection + warnings, and STP transitions.

### Testing
- Added unit tests exercising `ValidateCompleteness`, `ValidateOutliers`, `BuildApprovalChain`, `BuildCashLadder`/`BuildLiquidityWarnings`, and `AdvanceStpState` in `tests/Meridian.Tests/Services/CashSyncOrchestrationServiceTests.cs`.
- Attempted to run the focused test command `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~CashSyncOrchestrationServiceTests" --logger "console;verbosity=minimal"` but the execution environment lacked the .NET SDK (`dotnet: command not found`), so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17583220dc8320b653b362f35155a6)