### PR TITLE
Add break lifecycle, scoring, SLA, filters and bulk queue actions

### DIFF
--- a/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
+++ b/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
@@ -287,13 +287,13 @@ public enum ReconciliationBreakQueueStatus : byte
 [JsonConverter(typeof(JsonStringEnumConverter<ReconciliationCaseLifecycleState>))]
 public enum ReconciliationCaseLifecycleState : byte
 {
-    Opened = 0,
-    Triaged = 1,
-    Calibrated = 2,
-    Approved = 3,
-    Escalated = 4,
-    Closed = 5,
-    Superseded = 6
+    New = 0,
+    Classified = 1,
+    Assigned = 2,
+    Investigating = 3,
+    PendingExternal = 4,
+    Resolved = 5,
+    Closed = 6
 }
 
 /// <summary>
@@ -337,14 +337,19 @@ public sealed record ReconciliationBreakQueueItem(
     string? RoutingTarget = null,
     string? RoutingDetail = null,
     string? RecommendedAction = null,
-    ReconciliationCaseLifecycleState LifecycleState = ReconciliationCaseLifecycleState.Opened,
+    ReconciliationCaseLifecycleState LifecycleState = ReconciliationCaseLifecycleState.New,
     string? LifecycleRationale = null,
     string? ExternalAccountId = null,
     string? CustodianId = null,
     string? UpstreamSyncCursor = null,
     DateTimeOffset? LastUpstreamSyncAt = null,
     IReadOnlyList<ReconciliationCaseSignoffRecord>? SignoffHistory = null,
-    IReadOnlyList<ReconciliationCaseStateTransition>? StateTransitions = null);
+    IReadOnlyList<ReconciliationCaseStateTransition>? StateTransitions = null,
+    string? Team = null,
+    string? Counterparty = null,
+    ReconciliationBreakScore? Score = null,
+    DateTimeOffset? SlaDueAt = null,
+    bool SlaBreached = false);
 
 public sealed record ReconciliationCaseSignoffRecord(
     string Actor,
@@ -354,6 +359,19 @@ public sealed record ReconciliationCaseSignoffRecord(
     DateTimeOffset SignedAt,
     string? InvalidatedBySyncCursor = null,
     DateTimeOffset? InvalidatedAt = null);
+
+
+
+public sealed record ReconciliationBreakScore(
+    int SeverityScore,
+    int PriorityScore,
+    decimal MaterialityComponent,
+    double AgeHours,
+    int CounterpartyCriticalityComponent,
+    int RecurringPatternComponent,
+    bool IsHighPriority,
+    DateTimeOffset? SlaDueAt = null,
+    DateTimeOffset? SlaBreachAt = null);
 
 public sealed record ReconciliationCaseStateTransition(
     string TransitionId,
@@ -416,4 +434,13 @@ public sealed record ResolveReconciliationBreakRequest(
     ReconciliationBreakQueueStatus Status,
     string ResolvedBy,
     string ResolutionNote,
-    string OperatorRationale);
+    string OperatorRationale,
+    string? DispositionCode = null);
+
+public sealed record ReconciliationBreakBulkActionRequest(
+    IReadOnlyList<string> BreakIds,
+    string Action,
+    string? Assignee = null,
+    ReconciliationBreakQueueStatus? Status = null,
+    string? CommentTemplate = null,
+    string? Actor = null);

--- a/src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs
+++ b/src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs
@@ -82,7 +82,7 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 return false;
             }
 
-            _items[item.BreakId] = item;
+            _items[item.BreakId] = item with { Score = ComputeScore(item), SlaDueAt = ComputeSlaDueAt(item), SlaBreached = IsSlaBreached(item) };
             await PersistSnapshotAsync(ct).ConfigureAwait(false);
             await AppendAuditAsync(new ReconciliationBreakQueueAuditEvent(
                 EventId: Guid.NewGuid().ToString("N"),
@@ -186,15 +186,15 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 LastUpdatedAt = now,
                 ResolutionNote = request.ReviewNote,
                 SignoffStatus = "in-review",
-                LifecycleState = ReconciliationCaseLifecycleState.Triaged,
+                LifecycleState = ReconciliationCaseLifecycleState.Investigating,
                 LifecycleRationale = request.ReviewNote,
                 StateTransitions = (item.StateTransitions ?? []).Concat(
                 [
-                    new ReconciliationCaseStateTransition(Guid.NewGuid().ToString("N"), item.LifecycleState, ReconciliationCaseLifecycleState.Triaged, request.ReviewedBy, request.ReviewNote, now)
+                    new ReconciliationCaseStateTransition(Guid.NewGuid().ToString("N"), item.LifecycleState, ReconciliationCaseLifecycleState.Investigating, request.ReviewedBy, request.ReviewNote, now)
                 ]).ToArray()
             };
 
-            _items[request.BreakId] = updated;
+            _items[request.BreakId] = updated with { Score = ComputeScore(updated), SlaDueAt = ComputeSlaDueAt(updated), SlaBreached = IsSlaBreached(updated) };
             await PersistSnapshotAsync(ct).ConfigureAwait(false);
             await AppendAuditAsync(new ReconciliationBreakQueueAuditEvent(
                 EventId: Guid.NewGuid().ToString("N"),
@@ -275,8 +275,8 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                     ? "pending-signoff"
                     : "dismissed",
                 LifecycleState = request.Status == ReconciliationBreakQueueStatus.Resolved
-                    ? ReconciliationCaseLifecycleState.Closed
-                    : ReconciliationCaseLifecycleState.Superseded,
+                    ? ReconciliationCaseLifecycleState.Resolved
+                    : ReconciliationCaseLifecycleState.Closed,
                 LifecycleRationale = request.OperatorRationale,
                 SignoffHistory = (item.SignoffHistory ?? []).Concat(
                 [
@@ -284,16 +284,16 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 ]).ToArray(),
                 StateTransitions = (item.StateTransitions ?? []).Concat(
                 [
-                    new ReconciliationCaseStateTransition(Guid.NewGuid().ToString("N"), item.LifecycleState, request.Status == ReconciliationBreakQueueStatus.Resolved ? ReconciliationCaseLifecycleState.Closed : ReconciliationCaseLifecycleState.Superseded, request.ResolvedBy, request.OperatorRationale, now)
+                    new ReconciliationCaseStateTransition(Guid.NewGuid().ToString("N"), item.LifecycleState, request.Status == ReconciliationBreakQueueStatus.Resolved ? ReconciliationCaseLifecycleState.Resolved : ReconciliationCaseLifecycleState.Closed, request.ResolvedBy, request.OperatorRationale, now)
                 ]).ToArray()
             };
 
-            _items[request.BreakId] = updated;
+            _items[request.BreakId] = updated with { Score = ComputeScore(updated), SlaDueAt = ComputeSlaDueAt(updated), SlaBreached = IsSlaBreached(updated) };
             await PersistSnapshotAsync(ct).ConfigureAwait(false);
             await AppendAuditAsync(new ReconciliationBreakQueueAuditEvent(
                 EventId: Guid.NewGuid().ToString("N"),
                 BreakId: request.BreakId,
-                EventType: request.Status.ToString(),
+                EventType: request.Status == ReconciliationBreakQueueStatus.Resolved ? "Resolved" : "Closed",
                 PreviousStatus: item.Status,
                 NewStatus: updated.Status,
                 PreviousLifecycleState: item.LifecycleState,
@@ -392,6 +392,35 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
         var line = JsonSerializer.Serialize(auditEvent, _jsonOptions);
         await AtomicFileWriter.AppendLinesAsync(_auditPath, [line], ct).ConfigureAwait(false);
     }
+
+
+
+    private static ReconciliationBreakScore ComputeScore(ReconciliationBreakQueueItem item)
+    {
+        var materiality = Math.Min(50m, Math.Abs(item.Variance));
+        var ageHours = Math.Max(0d, (DateTimeOffset.UtcNow - item.DetectedAt).TotalHours);
+        var ageComponent = Math.Min(25, (int)Math.Round(ageHours / 4d, MidpointRounding.AwayFromZero));
+        var counterparty = string.IsNullOrWhiteSpace(item.Counterparty) ? 0 : 15;
+        var recurring = item.StateTransitions?.Count(t => t.To == ReconciliationCaseLifecycleState.Investigating) > 1 ? 10 : 0;
+        var severityScore = (int)Math.Min(100, materiality + ageComponent + counterparty + recurring);
+        var priorityScore = Math.Min(100, severityScore + (item.Severity == ReconciliationBreakSeverity.Critical ? 20 : item.Severity == ReconciliationBreakSeverity.High ? 10 : 0));
+        return new ReconciliationBreakScore(severityScore, priorityScore, materiality, ageHours, counterparty, recurring, priorityScore >= 70, ComputeSlaDueAt(item), DateTimeOffset.UtcNow > ComputeSlaDueAt(item) ? DateTimeOffset.UtcNow : null);
+    }
+
+    private static DateTimeOffset ComputeSlaDueAt(ReconciliationBreakQueueItem item)
+    {
+        var hours = item.Severity switch
+        {
+            ReconciliationBreakSeverity.Critical => 4,
+            ReconciliationBreakSeverity.High => 8,
+            ReconciliationBreakSeverity.Medium => 24,
+            _ => 48
+        };
+        return item.DetectedAt.AddHours(hours);
+    }
+
+    private static bool IsSlaBreached(ReconciliationBreakQueueItem item)
+        => item.Status is ReconciliationBreakQueueStatus.Open or ReconciliationBreakQueueStatus.InReview && DateTimeOffset.UtcNow > ComputeSlaDueAt(item);
 
     private sealed record BreakQueueSnapshot(IReadOnlyList<ReconciliationBreakQueueItem> Items);
 }

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Reconciliation.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Reconciliation.cs
@@ -106,6 +106,9 @@ public static partial class WorkstationEndpoints
         group.MapGet(WorkstationSubroute(UiApiRoutes.ReconciliationBreakQueue), async (
             string? status,
             string? fundAccountId,
+            string? team,
+            string? assignee,
+            string? counterparty,
             HttpContext context,
             [FromServices] StrategyRunReadService? readService,
             [FromServices] IReconciliationRunService? reconciliationService,
@@ -113,6 +116,11 @@ public static partial class WorkstationEndpoints
         {
             await EnsureBreakQueueSeededAsync(readService, reconciliationService, repository, context.RequestAborted).ConfigureAwait(false);
             var items = await GetBreakQueueItemsAsync(repository, status, fundAccountId, context.RequestAborted).ConfigureAwait(false);
+            items = items
+                .Where(item => string.IsNullOrWhiteSpace(team) || string.Equals(item.Team, team, StringComparison.OrdinalIgnoreCase))
+                .Where(item => string.IsNullOrWhiteSpace(assignee) || string.Equals(item.AssignedTo, assignee, StringComparison.OrdinalIgnoreCase))
+                .Where(item => string.IsNullOrWhiteSpace(counterparty) || string.Equals(item.Counterparty, counterparty, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
             return Results.Json(items, jsonOptions);
         })
         .WithName("GetReconciliationBreakQueue")
@@ -266,5 +274,57 @@ public static partial class WorkstationEndpoints
         .Produces(401)
         .Produces(403)
         .Produces(404);
+
+
+        group.MapPost("/reconciliation/break-queue/bulk", async (
+            ReconciliationBreakBulkActionRequest request,
+            HttpContext context,
+            [FromServices] IReconciliationBreakQueueRepository? repository) =>
+        {
+            if (!HasReconciliationMutationPermission(context))
+            {
+                return EndpointHelpers.Forbidden();
+            }
+
+            if (repository is null)
+            {
+                return Results.Problem("Reconciliation break queue repository is not registered.", statusCode: StatusCodes.Status501NotImplemented);
+            }
+
+            var actor = string.IsNullOrWhiteSpace(request.Actor) && TryResolveCurrentUser(context, out var currentUser) ? currentUser : request.Actor ?? "system";
+            var updated = new List<ReconciliationBreakQueueItem>();
+            foreach (var breakId in request.BreakIds.Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                var item = await repository.GetByIdAsync(breakId, context.RequestAborted).ConfigureAwait(false);
+                if (item is null)
+                {
+                    continue;
+                }
+
+                var next = item;
+                if (string.Equals(request.Action, "assign", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrWhiteSpace(request.Assignee))
+                {
+                    next = item with { AssignedTo = request.Assignee, LifecycleState = ReconciliationCaseLifecycleState.Assigned, LastUpdatedAt = DateTimeOffset.UtcNow, LifecycleRationale = request.CommentTemplate ?? "Bulk assigned" };
+                }
+                else if (string.Equals(request.Action, "status", StringComparison.OrdinalIgnoreCase) && request.Status.HasValue)
+                {
+                    next = item with { Status = request.Status.Value, LastUpdatedAt = DateTimeOffset.UtcNow, LifecycleRationale = request.CommentTemplate ?? "Bulk status update" };
+                }
+                else if (string.Equals(request.Action, "comment", StringComparison.OrdinalIgnoreCase))
+                {
+                    next = item with { ResolutionNote = request.CommentTemplate, LastUpdatedAt = DateTimeOffset.UtcNow };
+                }
+
+                await repository.SaveAsync(next, context.RequestAborted).ConfigureAwait(false);
+                updated.Add(next);
+            }
+
+            return Results.Json(updated, jsonOptions);
+        })
+        .WithName("BulkUpdateReconciliationBreaks")
+        .Produces<IReadOnlyList<ReconciliationBreakQueueItem>>(200)
+        .Produces(403)
+        .Produces(501);
+
     }
 }


### PR DESCRIPTION
### Motivation
- Introduce an explicit break-case lifecycle and richer operational controls so breaks can be triaged, assigned, investigated, escalated, tracked against SLAs, and closed with audit evidence. 
- Provide programmatic prioritization and bulk operations so operators can focus on material and stale breaks and act efficiently across queues.

### Description
- Added new lifecycle states to the break contract (`ReconciliationCaseLifecycleState`): `New`, `Classified`, `Assigned`, `Investigating`, `PendingExternal`, `Resolved`, and `Closed`, and defaulted queue items to `New` in `ReconciliationBreakQueueItem` in `src/Meridian.Contracts/Workstation/ReconciliationDtos.cs`.
- Extended queue DTOs with team/counterparty metadata and a scoring/SLA contract `ReconciliationBreakScore` plus `Score`, `SlaDueAt`, and `SlaBreached` fields on `ReconciliationBreakQueueItem` to support rule-driven prioritying.
- Added an optional `DispositionCode` to `ResolveReconciliationBreakRequest` and introduced `ReconciliationBreakBulkActionRequest` to support bulk actions (assign, status change, comment template) in the API contract.
- Implemented rule-driven scoring and SLA logic inside the file-backed repository (`FileReconciliationBreakQueueRepository`), computing score components from materiality, age, counterparty signal, and recurring pattern, and wiring score/SLA updates during create/review/resolve transitions.
- Updated break queue endpoints to accept queue-slicing query parameters (`team`, `assignee`, `counterparty`) and added a new bulk endpoint `POST /reconciliation/break-queue/bulk` that applies assign/status/comment actions across multiple break IDs.

### Testing
- Attempted to run the focused unit test for the repository with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ReconciliationBreakQueueRepositoryTests"`, but the run failed in this environment because the `dotnet` CLI was not available (`dotnet: command not found`).
- No other automated tests were executed in this environment; repository changes were committed locally (`Add break lifecycle, scoring, filters, and bulk queue actions`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1758317c34832099936711592cea04)