### PR TITLE
Add reconciliation domain, normalization, matching engine, and daily orchestrator

### DIFF
--- a/src/Meridian.Application/Reconciliation/ReconciliationContracts.cs
+++ b/src/Meridian.Application/Reconciliation/ReconciliationContracts.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Meridian.Contracts.Domain.Reconciliation;
+
+namespace Meridian.Application.Reconciliation;
+
+public sealed record ReconciliationPollingSchedule(TimeSpan PollInterval, TimeSpan Timeout);
+
+public sealed record ReconciliationSourcePayload(
+    string SourceId,
+    ReconciliationSourceType SourceType,
+    IReadOnlyList<RawPositionRecord> RawPositions,
+    IReadOnlyList<RawCashRecord> RawCashEntries,
+    DateTimeOffset CapturedAt,
+    string Version);
+
+public sealed record RawPositionRecord(
+    string PositionId,
+    string? Cusip,
+    string? Isin,
+    string? Ticker,
+    string? InternalSecurityId,
+    decimal Quantity,
+    decimal Price,
+    decimal MarketValue,
+    string Currency,
+    DateTimeOffset AsOfTimestamp);
+
+public sealed record RawCashRecord(
+    string CashEntryId,
+    string AccountId,
+    string? CounterpartyReference,
+    string? SettlementId,
+    string? Comments,
+    decimal Amount,
+    string Currency,
+    DateTimeOffset BookingTimestamp);
+
+public interface IReconciliationSourceAdapter
+{
+    string AdapterId { get; }
+    ReconciliationSourceType SourceType { get; }
+    Task<ReconciliationSourcePayload> PollAsync(CancellationToken cancellationToken);
+}
+
+public interface IPrimeBrokerSourceAdapter : IReconciliationSourceAdapter;
+public interface ICustodianSourceAdapter : IReconciliationSourceAdapter;
+public interface IAdministratorSourceAdapter : IReconciliationSourceAdapter;
+public interface IInternalLedgerSourceAdapter : IReconciliationSourceAdapter;
+
+public interface IReconciliationSourceIngestionScheduler
+{
+    Task<IReadOnlyList<ReconciliationSourcePayload>> IngestScheduledAsync(
+        IReadOnlyList<IReconciliationSourceAdapter> adapters,
+        ReconciliationPollingSchedule schedule,
+        CancellationToken cancellationToken);
+}
+
+public interface IInstrumentMappingService
+{
+    string ResolveInstrumentKey(string? cusip, string? isin, string? ticker, string? internalSecurityId);
+}
+
+public interface IFxConversionService
+{
+    decimal GetFxRate(string fromCurrency, string toCurrency, DateTimeOffset timestamp);
+}
+
+public interface IAccountingPeriodService
+{
+    DateOnly ResolvePeriod(DateTimeOffset bookingTimestamp, string sourceId);
+    DateTimeOffset AlignTimestamp(DateTimeOffset timestamp, string sourceId);
+}

--- a/src/Meridian.Application/Reconciliation/ReconciliationEngine.cs
+++ b/src/Meridian.Application/Reconciliation/ReconciliationEngine.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Meridian.Contracts.Domain.Reconciliation;
+
+namespace Meridian.Application.Reconciliation;
+
+public sealed record MatchingTolerance(decimal Quantity, decimal Price, decimal MarketValue, decimal CashAmount, TimeSpan TimingWindow);
+
+public sealed record ReconciliationRuleContext(MatchingTolerance Tolerance, IReadOnlyDictionary<string, string> RuleIdsByStage);
+
+public interface IReconciliationRunRepository
+{
+    Task<bool> ExistsAsync(DateOnly accountingPeriod, string snapshotVersion, CancellationToken cancellationToken);
+    Task SaveAsync(ReconciliationRun run, IReadOnlyList<MatchGroup> matches, IReadOnlyList<BreakRecord> breaks, CancellationToken cancellationToken);
+}
+
+public sealed class ReconciliationNormalizer(
+    IInstrumentMappingService instrumentMappingService,
+    IFxConversionService fxConversionService,
+    IAccountingPeriodService accountingPeriodService)
+{
+    public DataSourceSnapshot Normalize(ReconciliationSourcePayload payload, string baseCurrency)
+    {
+        var positions = payload.RawPositions.Select(raw =>
+        {
+            var aligned = accountingPeriodService.AlignTimestamp(raw.AsOfTimestamp, payload.SourceId);
+            var fxRate = fxConversionService.GetFxRate(raw.Currency, baseCurrency, aligned);
+            return new NormalizedPosition(
+                raw.PositionId,
+                instrumentMappingService.ResolveInstrumentKey(raw.Cusip, raw.Isin, raw.Ticker, raw.InternalSecurityId),
+                raw.Cusip,
+                raw.Isin,
+                raw.Ticker,
+                raw.InternalSecurityId,
+                raw.Quantity,
+                raw.Price,
+                raw.MarketValue * fxRate,
+                raw.Currency,
+                baseCurrency,
+                fxRate,
+                aligned);
+        }).ToArray();
+
+        var cashEntries = payload.RawCashEntries.Select(raw =>
+        {
+            var aligned = accountingPeriodService.AlignTimestamp(raw.BookingTimestamp, payload.SourceId);
+            var fxRate = fxConversionService.GetFxRate(raw.Currency, baseCurrency, aligned);
+            return new NormalizedCashEntry(
+                raw.CashEntryId,
+                raw.AccountId,
+                raw.CounterpartyReference,
+                raw.SettlementId,
+                raw.Comments,
+                raw.Amount,
+                raw.Currency,
+                baseCurrency,
+                fxRate,
+                raw.Amount * fxRate,
+                aligned,
+                accountingPeriodService.ResolvePeriod(aligned, payload.SourceId));
+        }).ToArray();
+
+        return new DataSourceSnapshot(payload.SourceId, payload.SourceType, payload.SourceId, payload.CapturedAt, payload.Version, positions, cashEntries);
+    }
+}
+
+public sealed class ReconciliationMatchingEngine
+{
+    public (IReadOnlyList<MatchGroup> Matches, IReadOnlyList<BreakRecord> Breaks) Execute(
+        ReconciliationRun run,
+        IReadOnlyList<DataSourceSnapshot> snapshots,
+        ReconciliationRuleContext rules)
+    {
+        var allPositions = snapshots.SelectMany(s => s.Positions).ToArray();
+        var allCash = snapshots.SelectMany(s => s.CashEntries).ToArray();
+        var groups = new List<MatchGroup>();
+        var breaks = new List<BreakRecord>();
+
+        foreach (var positionSet in allPositions.GroupBy(p => p.InstrumentKey))
+        {
+            var stage = "Exact";
+            var outcome = ReconciliationOutcome.PotentialBreak;
+            var evidence = new Dictionary<string, string>();
+
+            if (positionSet.Select(p => p.Quantity).Distinct().Count() == 1 &&
+                positionSet.Select(p => p.MarketValue).Distinct().Count() == 1)
+            {
+                outcome = ReconciliationOutcome.Matched;
+                evidence["exact.position"] = "Quantity and MV identical across sources.";
+            }
+            else if (WithinTolerance(positionSet, rules.Tolerance, out var toleranceEvidence))
+            {
+                stage = "Tolerance";
+                outcome = ReconciliationOutcome.MatchedWithinTolerance;
+                evidence["tolerance.position"] = toleranceEvidence;
+            }
+            else
+            {
+                stage = "Fuzzy";
+                var fuzzy = allCash.Where(c => c.CounterpartyReference?.Contains(positionSet.Key, StringComparison.OrdinalIgnoreCase) == true
+                                            || c.SettlementId?.Contains(positionSet.Key, StringComparison.OrdinalIgnoreCase) == true
+                                            || c.Comments?.Contains(positionSet.Key, StringComparison.OrdinalIgnoreCase) == true).Take(3).ToArray();
+                if (fuzzy.Length > 0)
+                {
+                    outcome = ReconciliationOutcome.PotentialBreak;
+                    evidence["fuzzy.reference"] = $"Found {fuzzy.Length} linked cash references for manual review.";
+                }
+                else
+                {
+                    outcome = ReconciliationOutcome.TrueBreak;
+                    evidence["fuzzy.reference"] = "No corroborating references found.";
+                }
+            }
+
+            var matchGroup = new MatchGroup(
+                Guid.NewGuid(),
+                outcome,
+                stage,
+                ResolveRuleIds(rules, stage),
+                evidence,
+                positionSet.ToArray(),
+                Array.Empty<NormalizedCashEntry>(),
+                run.RunTimestamp);
+            groups.Add(matchGroup);
+
+            if (outcome is ReconciliationOutcome.PotentialBreak or ReconciliationOutcome.TrueBreak)
+            {
+                breaks.Add(new BreakRecord(Guid.NewGuid(), matchGroup.MatchGroupId, outcome, "POSITION_BREAK", $"{stage} stage break for {positionSet.Key}", matchGroup.RuleIds, evidence, run.RunTimestamp));
+            }
+        }
+
+        return (groups, breaks);
+    }
+
+    private static bool WithinTolerance(IEnumerable<NormalizedPosition> positions, MatchingTolerance tolerance, out string evidence)
+    {
+        var list = positions.ToList();
+        var qtySpread = list.Max(p => p.Quantity) - list.Min(p => p.Quantity);
+        var mvSpread = list.Max(p => p.MarketValue) - list.Min(p => p.MarketValue);
+        if (Math.Abs(qtySpread) <= tolerance.Quantity && Math.Abs(mvSpread) <= tolerance.MarketValue)
+        {
+            evidence = $"Quantity spread {qtySpread}, MV spread {mvSpread}.";
+            return true;
+        }
+
+        evidence = $"Quantity spread {qtySpread}, MV spread {mvSpread} exceeded tolerance.";
+        return false;
+    }
+
+    private static IReadOnlyList<string> ResolveRuleIds(ReconciliationRuleContext rules, string stage)
+        => rules.RuleIdsByStage.TryGetValue(stage, out var id) ? [id] : ["UNSPECIFIED_RULE"];
+}
+
+public sealed class DailyReconciliationOrchestrator(
+    IReconciliationSourceIngestionScheduler scheduler,
+    ReconciliationNormalizer normalizer,
+    ReconciliationMatchingEngine matchingEngine,
+    IReconciliationRunRepository repository)
+{
+    public async Task<ReconciliationRun> RunAsync(
+        DateOnly accountingPeriod,
+        string snapshotVersion,
+        bool forceRerun,
+        string trigger,
+        string baseCurrency,
+        ReconciliationPollingSchedule schedule,
+        ReconciliationRuleContext rules,
+        IReadOnlyList<IReconciliationSourceAdapter> adapters,
+        CancellationToken cancellationToken)
+    {
+        if (!forceRerun && await repository.ExistsAsync(accountingPeriod, snapshotVersion, cancellationToken).ConfigureAwait(false))
+        {
+            throw new InvalidOperationException($"Reconciliation run already exists for {accountingPeriod} snapshot {snapshotVersion}.");
+        }
+
+        var payloads = await scheduler.IngestScheduledAsync(adapters, schedule, cancellationToken).ConfigureAwait(false);
+        var snapshots = payloads.Select(p => normalizer.Normalize(p, baseCurrency)).ToArray();
+
+        var run = new ReconciliationRun(Guid.NewGuid(), DateTimeOffset.UtcNow, accountingPeriod, snapshotVersion, forceRerun, trigger, snapshots);
+        var (matches, breaks) = matchingEngine.Execute(run, snapshots, rules);
+        await repository.SaveAsync(run, matches, breaks, cancellationToken).ConfigureAwait(false);
+        return run;
+    }
+}

--- a/src/Meridian.Contracts/Domain/Reconciliation/ReconciliationDomainModels.cs
+++ b/src/Meridian.Contracts/Domain/Reconciliation/ReconciliationDomainModels.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+
+namespace Meridian.Contracts.Domain.Reconciliation;
+
+public enum ReconciliationSourceType
+{
+    Prime,
+    Custodian,
+    Administrator,
+    InternalLedger
+}
+
+public enum ReconciliationOutcome
+{
+    Matched,
+    MatchedWithinTolerance,
+    PotentialBreak,
+    TrueBreak
+}
+
+public sealed record ReconciliationRun(
+    Guid RunId,
+    DateTimeOffset RunTimestamp,
+    DateOnly AccountingPeriod,
+    string SnapshotVersion,
+    bool IsRerun,
+    string Trigger,
+    IReadOnlyList<DataSourceSnapshot> SourceSnapshots);
+
+public sealed record DataSourceSnapshot(
+    string SourceId,
+    ReconciliationSourceType SourceType,
+    string AdapterId,
+    DateTimeOffset CapturedAt,
+    string Version,
+    IReadOnlyList<NormalizedPosition> Positions,
+    IReadOnlyList<NormalizedCashEntry> CashEntries);
+
+public sealed record NormalizedPosition(
+    string PositionId,
+    string InstrumentKey,
+    string? Cusip,
+    string? Isin,
+    string? Ticker,
+    string? InternalSecurityId,
+    decimal Quantity,
+    decimal Price,
+    decimal MarketValue,
+    string LocalCurrency,
+    string BaseCurrency,
+    decimal FxRateToBase,
+    DateTimeOffset AsOfTimestamp);
+
+public sealed record NormalizedCashEntry(
+    string CashEntryId,
+    string AccountId,
+    string? CounterpartyReference,
+    string? SettlementId,
+    string? Comments,
+    decimal Amount,
+    string LocalCurrency,
+    string BaseCurrency,
+    decimal FxRateToBase,
+    decimal BaseAmount,
+    DateTimeOffset BookingTimestamp,
+    DateOnly AccountingPeriod);
+
+public sealed record MatchGroup(
+    Guid MatchGroupId,
+    ReconciliationOutcome Outcome,
+    string Stage,
+    IReadOnlyList<string> RuleIds,
+    IReadOnlyDictionary<string, string> Evidence,
+    IReadOnlyList<NormalizedPosition> Positions,
+    IReadOnlyList<NormalizedCashEntry> CashEntries,
+    DateTimeOffset EvaluatedAt);
+
+public sealed record BreakRecord(
+    Guid BreakId,
+    Guid MatchGroupId,
+    ReconciliationOutcome Outcome,
+    string BreakCode,
+    string Description,
+    IReadOnlyList<string> RuleIds,
+    IReadOnlyDictionary<string, string> Evidence,
+    DateTimeOffset CreatedAt);


### PR DESCRIPTION
### Motivation

- Implement a canonical reconciliation domain and pipeline to ingest multiple source types, normalize records, perform staged matching, and produce auditable breaks as an idempotent daily run.
- Provide clear DI contracts so source adapters, FX/instrument mapping, accounting-period alignment, scheduler, and persistence can be implemented independently.

### Description

- Adds domain models in `Meridian.Contracts.Domain.Reconciliation` including `ReconciliationRun`, `DataSourceSnapshot`, `NormalizedPosition`, `NormalizedCashEntry`, `MatchGroup`, `BreakRecord`, and enums `ReconciliationSourceType` and `ReconciliationOutcome`.
- Introduces source and ingestion contracts in `src/Meridian.Application/Reconciliation/ReconciliationContracts.cs` including `IReconciliationSourceAdapter` variants, `IReconciliationSourceIngestionScheduler`, `IInstrumentMappingService`, `IFxConversionService`, `IAccountingPeriodService`, and payload record types `RawPositionRecord`/`RawCashRecord`.
- Implements a normalization layer `ReconciliationNormalizer` that maps raw payloads into normalized snapshots (instrument key resolution, FX conversion to base currency, timestamp alignment, and accounting-period resolution).
- Implements `ReconciliationMatchingEngine` with staged matching logic: exact pass, tolerance-based pass (quantity/MV spreads via `MatchingTolerance`), and fuzzy/reference pass (counterparty refs, settlement IDs, comments), and emits `MatchGroup` and `BreakRecord` with rule IDs and evidence.
- Adds `DailyReconciliationOrchestrator` to orchestrate scheduled ingestion, run normalization + matching, and persist runs with idempotent snapshot-version guard via `IReconciliationRunRepository`.

### Testing

- Attempted a focused verification build with `dotnet build src/Meridian.Application/Meridian.Application.csproj -v minimal` but the environment does not have the `dotnet` tool installed so the build could not be executed (`/bin/bash: dotnet: command not found`).
- No further automated tests were executed in this environment; the change is scaffolded with interfaces to allow unit and integration tests against adapters, normalizer, matching engine, and orchestrator in a proper .NET-enabled CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17582ff2cc832085c589d8cffea800)