### PR TITLE
Add runtime resilience docs, runbooks, observability manifest, and synthetic load harness

### DIFF
--- a/docs/architecture/operator-observability-dashboard.md
+++ b/docs/architecture/operator-observability-dashboard.md
@@ -1,0 +1,28 @@
+# Operator Observability Dashboard Specification
+
+## Required panels
+
+1. **SLO Burn Rate**
+   - 5m and 1h burn-rate gauges.
+   - Error-budget remaining trend.
+2. **Backlog Growth**
+   - Queue depth by pipeline stage.
+   - Backlog growth velocity and time-to-drain estimate.
+3. **Dependency Degradation Posture**
+   - Provider/storage/checkpoint dependency status matrix.
+   - Circuit-breaker open/half-open/closed counts.
+4. **Latency and Throughput**
+   - p50/p95/p99 processing latency.
+   - Events processed per second baseline vs surge baseline.
+
+## Data sources
+
+- `/metrics` for queue, latency, CPU, memory, retry, dead-letter counters.
+- `/readyz` and `/health/detailed` for dependency-specific degradation flags.
+- Workstation status contracts for operator-facing annotations.
+
+## Alert thresholds
+
+- Burn rate > 2.0 (5m) and > 1.0 (1h): page operator.
+- Queue depth > 80% bound for 10m: scale stateless workers.
+- Dependency unhealthy > 3m: open incident and activate failover runbook.

--- a/docs/architecture/runtime-component-state-boundaries.md
+++ b/docs/architecture/runtime-component-state-boundaries.md
@@ -1,0 +1,52 @@
+# Runtime Component State Boundaries
+
+## Purpose
+
+This document inventories Meridian runtime components and classifies each component as **stateless service** or **stateful dependency** so scaling, resiliency, and failover designs can be implemented consistently.
+
+## Classification rubric
+
+- **Stateless service**: no durable business state retained in-process between requests/events. Can be replaced or scaled horizontally without data migration.
+- **Stateful dependency**: owns durable state, mutable checkpoints, or ordered logs that affect correctness and recovery.
+
+## Stateless services
+
+| Component | Runtime role | Notes |
+| --- | --- | --- |
+| `src/Meridian/Meridian.csproj` host process | API + orchestration host | Stateless when pointed at externalized storage/checkpoints. |
+| `src/Meridian.Ui.Shared` endpoint surface | HTTP route composition, DTO projection | Stateless; sources state from services/providers. |
+| `src/Meridian.Ui.Services` API adapters | UI/host connection and transport logic | Stateless transport + mapping layer. |
+| `src/Meridian.Wpf` desktop shell process | Operator shell and workflow execution | Treat as stateless client runtime; critical state is server-side. |
+| Provider adapters (`IMarketDataClient`, `IHistoricalDataProvider`) | Feed and backfill connectors | Keep sessions ephemeral; reconnect-safe through persisted checkpoints. |
+| Pipeline processors (bounded channels and handlers) | Normalize/transform market events | Must remain replayable from durable input + checkpoints. |
+
+## Stateful dependencies
+
+| Dependency | State ownership | Boundary contract |
+| --- | --- | --- |
+| Write-ahead log (WAL) / event archives | Ordered ingest history and recovery source | Producers append-only; consumers replay idempotently. |
+| Storage sinks (`IStorageSink`) | Durable bars/trades/depth datasets | Versioned schema and integrity validation required. |
+| Checkpoint stores | Cursor/offset progression and replay continuity | Updates must be monotonic and atomic. |
+| Reconciliation and accounting ledgers | Fund accounting truth and break queues | Strict consistency + audit traceability required. |
+| Secrets/config stores | Runtime credentials and environment overlays | Read-only to app at runtime; rotate without rebuild. |
+| Metrics/time-series backend | SLO, latency, backlog, and burn-rate evidence | Centralized sink for autoscaling and dashboarding. |
+
+## Service boundaries
+
+1. **Ingress boundary**: provider adapters -> bounded ingress queues.
+2. **Processing boundary**: processor workers -> normalized event stream.
+3. **Persistence boundary**: storage sink + WAL append with checkpoint updates.
+4. **Operator boundary**: workstation endpoints aggregate read-models only.
+5. **Control boundary**: health/readiness/metrics endpoints expose runtime posture but do not mutate domain state.
+
+## Required reliability controls by boundary
+
+- Ingress: bounded queues + overload shedding + retry with jitter for transient transport errors.
+- Processing: worker concurrency caps + circuit breaker on repeated downstream failures.
+- Persistence: dead-letter capture for non-retriable records and explicit replay tooling.
+- Operator: degraded dependency surfacing in readiness payload and workstation status panels.
+
+## Scaling policy anchors
+
+- Horizontal scale **stateless services** based on queue depth, p95 processing latency, CPU%, memory%, and error budget burn.
+- Scale or fail over **stateful dependencies** only through runbook-governed promotion and verified checkpoints.

--- a/docs/operations/environment-and-deployment-standard.md
+++ b/docs/operations/environment-and-deployment-standard.md
@@ -1,0 +1,29 @@
+# Environment, Secret, and Deployment Standard
+
+## Environment model
+
+Use three deployment tiers with consistent variable names:
+
+- `MERIDIAN_ENVIRONMENT=dev|staging|prod`
+- `MERIDIAN_REGION`
+- `MERIDIAN_INSTANCE_ROLE=api|worker|desktop-gateway`
+
+## Configuration contract
+
+- Non-secret config from environment-specific overlays (`config/appsettings.<env>.json`).
+- Secret values from secret manager references only (no inline plaintext in manifests).
+- All config keys mapped through options binding and validated on startup.
+
+## Secret management rules
+
+- Store provider/API credentials in external secret stores.
+- Inject into runtime via mounted files or environment references.
+- Rotate secrets without image rebuild; support dual-key overlap during rotation.
+- Never emit secret values in logs, metrics labels, or error payloads.
+
+## Promotion standard
+
+1. Build immutable artifact once.
+2. Promote same artifact across environments with env/secret overlays only.
+3. Run readiness gate + synthetic surge validation before production promotion.
+4. Attach evidence packet to release record.

--- a/docs/operations/failover-and-recovery-runbook.md
+++ b/docs/operations/failover-and-recovery-runbook.md
@@ -1,0 +1,43 @@
+# Failover and Recovery Runbook
+
+## Scope
+Critical Meridian runtime services: ingest host, processing workers, storage sink connectivity, and workstation API/readiness surfaces.
+
+## Preconditions
+- Latest deployment manifest and environment overlay committed.
+- Access to metrics (`/metrics`) and health probes (`/healthz`, `/readyz`, `/livez`).
+- Access to checkpoint, dead-letter, and WAL artifacts.
+
+## Failover procedure
+
+1. Confirm degradation trigger: burn-rate alert, backlog growth, or dependency hard-failure.
+2. Freeze risky mutations (new promotion jobs / non-essential backfills).
+3. Shift traffic to standby stateless service pool.
+4. Validate standby readiness (`/readyz`) and liveness (`/livez`) before routing 100% traffic.
+5. Promote stateful dependency replica only after checkpoint and WAL continuity validation.
+
+## Recovery procedure
+
+1. Drain backlog with bounded worker concurrency.
+2. Replay dead-letter queue using idempotent replay tooling.
+3. Reconcile processing offsets against checkpoint store.
+4. Re-enable normal autoscaling targets and clear incident override flags.
+5. Capture post-recovery evidence packet.
+
+## Validation checklist
+
+- [ ] `/healthz` returns healthy payload.
+- [ ] `/readyz` returns HTTP 200 on active instances.
+- [ ] Queue depth returns below steady-state threshold.
+- [ ] p95 processing latency returns to SLO target.
+- [ ] Error rate remains inside budget window.
+- [ ] Dead-letter backlog is zero or within approved exception threshold.
+- [ ] Operator dashboard no longer shows degraded dependency posture.
+
+## Evidence checklist
+
+- Incident timeline (start, mitigation, recovery completion).
+- Autoscaling metric snapshots (queue, latency, CPU, memory).
+- Before/after backlog and error-rate plots.
+- Replay/dead-letter reconciliation output.
+- Operator sign-off with date/time and approver.

--- a/manifests/meridian-runtime-observability.yaml
+++ b/manifests/meridian-runtime-observability.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: meridian-runtime-observability
+  labels:
+    app: meridian
+data:
+  MERIDIAN_AUTOSCALE_SIGNALS: "queue_depth,processing_latency_p95,cpu_usage,memory_usage"
+  MERIDIAN_HEALTH_ENDPOINTS: "/healthz,/readyz,/livez,/metrics"
+  MERIDIAN_RESILIENCY_CONTROLS: "bounded_queues,retry_jitter,circuit_breaker,dead_letter"

--- a/scripts/load/synthetic_load_harness.py
+++ b/scripts/load/synthetic_load_harness.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Simple synthetic load harness for Meridian endpoints.
+
+Simulates baseline and surge load and prints latency/error summaries.
+"""
+from __future__ import annotations
+import argparse
+import concurrent.futures
+import statistics
+import time
+import urllib.request
+
+
+def hit(url: str, timeout: float) -> tuple[bool, float]:
+    start = time.perf_counter()
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            ok = 200 <= response.status < 500
+        return ok, (time.perf_counter() - start) * 1000
+    except Exception:
+        return False, (time.perf_counter() - start) * 1000
+
+
+def run_phase(url: str, requests: int, concurrency: int, timeout: float) -> None:
+    latencies = []
+    failures = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = [pool.submit(hit, url, timeout) for _ in range(requests)]
+        for fut in concurrent.futures.as_completed(futures):
+            ok, latency_ms = fut.result()
+            latencies.append(latency_ms)
+            if not ok:
+                failures += 1
+
+    p95 = statistics.quantiles(latencies, n=20)[18] if len(latencies) >= 20 else max(latencies)
+    print(f"requests={requests} concurrency={concurrency} failures={failures} "
+          f"avg_ms={statistics.mean(latencies):.2f} p95_ms={p95:.2f} max_ms={max(latencies):.2f}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", default="http://localhost:8080/healthz")
+    parser.add_argument("--baseline-requests", type=int, default=200)
+    parser.add_argument("--baseline-concurrency", type=int, default=10)
+    parser.add_argument("--surge-multiplier", type=int, default=10)
+    parser.add_argument("--timeout", type=float, default=2.0)
+    args = parser.parse_args()
+
+    print("phase=baseline")
+    run_phase(args.url, args.baseline_requests, args.baseline_concurrency, args.timeout)
+    print("phase=surge")
+    run_phase(
+        args.url,
+        args.baseline_requests * args.surge_multiplier,
+        args.baseline_concurrency * args.surge_multiplier,
+        args.timeout,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a clear inventory and boundaries for Meridian runtime components so teams can distinguish stateless services from stateful dependencies for scaling and failover decisions.
- Establish standard autoscaling signals, health/readiness endpoints, and resiliency controls to enable consistent probes and operator automation across services.
- Supply operational artifacts (runbooks, deployment/secret standards, dashboard spec, and a load harness) to validate promotions, failover, and surge behavior.

### Description
- Added an architecture inventory that classifies runtime components and service boundaries in `docs/architecture/runtime-component-state-boundaries.md`.
- Added an operator observability dashboard specification covering SLO burn rate, backlog growth, dependency posture, latency/throughput, and alert thresholds in `docs/architecture/operator-observability-dashboard.md`.
- Added environment/secret/deployment standard guidance in `docs/operations/environment-and-deployment-standard.md` and a `Failover and Recovery Runbook` in `docs/operations/failover-and-recovery-runbook.md` with validation and evidence checklists.
- Added a simple synthetic load harness at `scripts/load/synthetic_load_harness.py` to simulate baseline vs 10x surge traffic and report latency/error summaries, and added a deployment-facing observability ConfigMap scaffold in `manifests/meridian-runtime-observability.yaml` listing autoscale signals, health endpoints, and resiliency controls.

### Testing
- Ran `python3 scripts/load/synthetic_load_harness.py --help` to validate the harness CLI interface, which returned the expected usage output and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17582d661c83208653bd83d43c2a1c)