### PR TITLE
Add accounting close domain, posting/translation services, projections, UI surfaces and tests

### DIFF
--- a/src/Meridian.Application/AccountingClose/AccountingCloseModels.cs
+++ b/src/Meridian.Application/AccountingClose/AccountingCloseModels.cs
@@ -1,0 +1,46 @@
+using System.Collections.Immutable;
+
+namespace Meridian.Application.AccountingClose;
+
+public enum ClosePeriodState
+{
+    Open,
+    Validating,
+    Blocked,
+    Closed
+}
+
+public sealed record FxRate(string FromCurrency, string ToCurrency, DateOnly RateDate, decimal Rate, string SourceEventId);
+
+public sealed record JournalLine(string AccountCode, decimal Amount, string Currency, bool IsDebit);
+
+public sealed record JournalEntry(
+    Guid JournalEntryId,
+    string LedgerId,
+    DateOnly TradeDate,
+    string SourceEventId,
+    string Description,
+    ImmutableArray<JournalLine> Lines);
+
+public sealed record TranslationAdjustment(
+    Guid AdjustmentId,
+    string LedgerId,
+    DateOnly Period,
+    string AccountCode,
+    decimal FunctionalAmount,
+    decimal ReportingAmount,
+    decimal AdjustmentAmount,
+    string SourceEventId);
+
+public sealed record CloseEvidence(bool TrialBalanceSignedOff, bool ReconciliationSignedOff, bool ApprovalsCompleted);
+
+public sealed record ClosePeriod(
+    string LedgerId,
+    DateOnly Period,
+    ClosePeriodState State,
+    CloseEvidence Evidence,
+    ImmutableArray<string> Blockers);
+
+public sealed record TrialBalanceLine(string AccountCode, decimal Debit, decimal Credit, decimal Net);
+public sealed record RollForwardLine(string AccountCode, decimal OpeningBalance, decimal Activity, decimal TranslationAdjustment, decimal ClosingBalance);
+public sealed record SourceLinkedAuditLine(Guid JournalEntryId, string SourceEventId, string ApprovalId);

--- a/src/Meridian.Application/AccountingClose/AccountingCloseServices.cs
+++ b/src/Meridian.Application/AccountingClose/AccountingCloseServices.cs
@@ -1,0 +1,116 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+
+namespace Meridian.Application.AccountingClose;
+
+public sealed class AccountingPostingService
+{
+    private readonly ConcurrentDictionary<string, ImmutableArray<JournalEntry>> _journals = new();
+
+    public ImmutableArray<JournalEntry> Post(string ledgerId, IEnumerable<JournalEntry> entries)
+    {
+        var ordered = entries.OrderBy(static e => e.TradeDate).ThenBy(static e => e.JournalEntryId).ToImmutableArray();
+        _journals[ledgerId] = ordered;
+        return ordered;
+    }
+
+    public ImmutableArray<JournalEntry> Replay(string ledgerId) => _journals.TryGetValue(ledgerId, out var entries) ? entries : ImmutableArray<JournalEntry>.Empty;
+
+    public ImmutableArray<SourceLinkedAuditLine> Audit(string ledgerId) => Replay(ledgerId)
+        .Select(static e => new SourceLinkedAuditLine(e.JournalEntryId, e.SourceEventId, $"approval-{e.JournalEntryId:N}"))
+        .ToImmutableArray();
+}
+
+public sealed class FxTranslationService
+{
+    public TranslationAdjustment Translate(string ledgerId, DateOnly period, string accountCode, decimal functionalAmount, FxRate rate)
+    {
+        var reportingAmount = decimal.Round(functionalAmount * rate.Rate, 2, MidpointRounding.AwayFromZero);
+        var adjustment = reportingAmount - functionalAmount;
+        return new TranslationAdjustment(Guid.NewGuid(), ledgerId, period, accountCode, functionalAmount, reportingAmount, adjustment, rate.SourceEventId);
+    }
+}
+
+public sealed class MonthEndCloseStateMachine
+{
+    public ClosePeriod Transition(ClosePeriod current, CloseEvidence evidence, bool isTrialBalanceBalanced)
+    {
+        var blockers = ImmutableArray.CreateBuilder<string>();
+        if (!isTrialBalanceBalanced)
+        {
+            blockers.Add("Trial balance is out of balance.");
+        }
+
+        if (!evidence.TrialBalanceSignedOff)
+        {
+            blockers.Add("Trial balance sign-off missing.");
+        }
+
+        if (!evidence.ReconciliationSignedOff)
+        {
+            blockers.Add("Reconciliation sign-off missing.");
+        }
+
+        if (!evidence.ApprovalsCompleted)
+        {
+            blockers.Add("Approval evidence missing.");
+        }
+
+        var nextState = blockers.Count switch
+        {
+            0 when current.State is ClosePeriodState.Validating or ClosePeriodState.Open => ClosePeriodState.Closed,
+            0 => current.State,
+            _ when current.State == ClosePeriodState.Open => ClosePeriodState.Validating,
+            _ => ClosePeriodState.Blocked
+        };
+
+        return current with { State = nextState, Evidence = evidence, Blockers = blockers.ToImmutable() };
+    }
+}
+
+public sealed class TrialBalanceProjectionService
+{
+    public ImmutableArray<TrialBalanceLine> BuildTrialBalance(IEnumerable<JournalEntry> entries)
+    {
+        return entries
+            .SelectMany(static entry => entry.Lines)
+            .GroupBy(static line => line.AccountCode)
+            .Select(group =>
+            {
+                var debit = group.Where(static line => line.IsDebit).Sum(static line => line.Amount);
+                var credit = group.Where(static line => !line.IsDebit).Sum(static line => line.Amount);
+                return new TrialBalanceLine(group.Key, debit, credit, debit - credit);
+            })
+            .OrderBy(static line => line.AccountCode)
+            .ToImmutableArray();
+    }
+
+    public bool IsBalanced(IEnumerable<TrialBalanceLine> lines)
+    {
+        var totalDebit = lines.Sum(static line => line.Debit);
+        var totalCredit = lines.Sum(static line => line.Credit);
+        return decimal.Round(totalDebit - totalCredit, 2, MidpointRounding.AwayFromZero) == 0m;
+    }
+
+    public ImmutableArray<RollForwardLine> BuildRollForward(
+        IEnumerable<TrialBalanceLine> opening,
+        IEnumerable<TrialBalanceLine> activity,
+        IEnumerable<TranslationAdjustment> fx)
+    {
+        var map = opening.ToDictionary(static x => x.AccountCode, static x => x.Net);
+        foreach (var line in activity)
+        {
+            map.TryGetValue(line.AccountCode, out var current);
+            map[line.AccountCode] = current + line.Net;
+        }
+
+        var fxMap = fx.GroupBy(static x => x.AccountCode).ToDictionary(static g => g.Key, static g => g.Sum(static x => x.AdjustmentAmount));
+        return map.Select(kvp =>
+        {
+            fxMap.TryGetValue(kvp.Key, out var adj);
+            var openingBalance = opening.FirstOrDefault(x => x.AccountCode == kvp.Key)?.Net ?? 0m;
+            var closing = kvp.Value + adj;
+            return new RollForwardLine(kvp.Key, openingBalance, kvp.Value - openingBalance, adj, closing);
+        }).OrderBy(static x => x.AccountCode).ToImmutableArray();
+    }
+}

--- a/src/Meridian.Ui.Services/Services/Accounting/AccountingProjectionQueryService.cs
+++ b/src/Meridian.Ui.Services/Services/Accounting/AccountingProjectionQueryService.cs
@@ -1,0 +1,35 @@
+using System.Collections.Immutable;
+using Meridian.Application.AccountingClose;
+
+namespace Meridian.Ui.Services.Services.Accounting;
+
+public interface IAccountingProjectionQueryService
+{
+    ImmutableArray<TrialBalanceLine> GetTrialBalance(string ledgerId);
+    ImmutableArray<RollForwardLine> GetRollForward(string ledgerId);
+    ImmutableArray<SourceLinkedAuditLine> GetAuditLines(string ledgerId);
+}
+
+public sealed class AccountingProjectionQueryService : IAccountingProjectionQueryService
+{
+    private readonly AccountingPostingService _postingService;
+    private readonly TrialBalanceProjectionService _projectionService;
+
+    public AccountingProjectionQueryService(AccountingPostingService postingService, TrialBalanceProjectionService projectionService)
+    {
+        _postingService = postingService;
+        _projectionService = projectionService;
+    }
+
+    public ImmutableArray<TrialBalanceLine> GetTrialBalance(string ledgerId)
+        => _projectionService.BuildTrialBalance(_postingService.Replay(ledgerId));
+
+    public ImmutableArray<RollForwardLine> GetRollForward(string ledgerId)
+    {
+        var trial = GetTrialBalance(ledgerId);
+        return _projectionService.BuildRollForward([], trial, []);
+    }
+
+    public ImmutableArray<SourceLinkedAuditLine> GetAuditLines(string ledgerId)
+        => _postingService.Audit(ledgerId);
+}

--- a/src/Meridian.Ui/dashboard/src/features/accounting/accountingCloseModels.ts
+++ b/src/Meridian.Ui/dashboard/src/features/accounting/accountingCloseModels.ts
@@ -1,0 +1,22 @@
+export type CloseWorkflowState = 'open' | 'validating' | 'blocked' | 'closed';
+
+export interface TrialBalanceRow {
+  accountCode: string;
+  debit: number;
+  credit: number;
+  net: number;
+}
+
+export interface RollForwardRow {
+  accountCode: string;
+  openingBalance: number;
+  activity: number;
+  translationAdjustment: number;
+  closingBalance: number;
+}
+
+export interface AuditDrillThroughRow {
+  journalEntryId: string;
+  sourceEventId: string;
+  approvalId: string;
+}

--- a/src/Meridian.Wpf/ViewModels/Accounting/AccountingCloseViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/Accounting/AccountingCloseViewModel.cs
@@ -1,0 +1,35 @@
+using System.Collections.ObjectModel;
+using Meridian.Application.AccountingClose;
+using Meridian.Ui.Services.Services.Accounting;
+
+namespace Meridian.Wpf.ViewModels.Accounting;
+
+public sealed class AccountingCloseViewModel
+{
+    private readonly IAccountingProjectionQueryService _queryService;
+
+    public AccountingCloseViewModel(IAccountingProjectionQueryService queryService)
+    {
+        _queryService = queryService;
+    }
+
+    public ObservableCollection<TrialBalanceLine> TrialBalance { get; } = [];
+    public ObservableCollection<RollForwardLine> RollForward { get; } = [];
+    public ObservableCollection<SourceLinkedAuditLine> AuditTrail { get; } = [];
+
+    public ClosePeriodState CloseState { get; private set; } = ClosePeriodState.Open;
+
+    public void Load(string ledgerId)
+    {
+        TrialBalance.Clear();
+        foreach (var line in _queryService.GetTrialBalance(ledgerId)) TrialBalance.Add(line);
+
+        RollForward.Clear();
+        foreach (var line in _queryService.GetRollForward(ledgerId)) RollForward.Add(line);
+
+        AuditTrail.Clear();
+        foreach (var line in _queryService.GetAuditLines(ledgerId)) AuditTrail.Add(line);
+    }
+
+    public void SetCloseState(ClosePeriodState state) => CloseState = state;
+}

--- a/tests/Meridian.Tests/AccountingCloseServicesTests.cs
+++ b/tests/Meridian.Tests/AccountingCloseServicesTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Immutable;
+using FluentAssertions;
+using Meridian.Application.AccountingClose;
+using Xunit;
+
+namespace Meridian.Tests;
+
+public sealed class AccountingCloseServicesTests
+{
+    [Fact]
+    public void FxTranslation_ComputesAdjustmentDeterministically()
+    {
+        var service = new FxTranslationService();
+        var rate = new FxRate("EUR", "USD", new DateOnly(2026, 03, 31), 1.10m, "fx:ecb:20260331");
+
+        var result = service.Translate("ledger-a", new DateOnly(2026, 03, 31), "Cash", 100m, rate);
+
+        result.ReportingAmount.Should().Be(110m);
+        result.AdjustmentAmount.Should().Be(10m);
+        result.SourceEventId.Should().Be("fx:ecb:20260331");
+    }
+
+    [Fact]
+    public void TrialBalance_DetectsOutOfBalance()
+    {
+        var projection = new TrialBalanceProjectionService();
+        var entries = ImmutableArray.Create(
+            new JournalEntry(Guid.NewGuid(), "ledger-a", new DateOnly(2026, 03, 31), "evt-1", "accrual", ImmutableArray.Create(new JournalLine("Cash", 100m, "USD", true))),
+            new JournalEntry(Guid.NewGuid(), "ledger-a", new DateOnly(2026, 03, 31), "evt-2", "offset", ImmutableArray.Create(new JournalLine("Revenue", 90m, "USD", false))));
+
+        var trial = projection.BuildTrialBalance(entries);
+
+        projection.IsBalanced(trial).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CloseStateMachine_BlocksWhenEvidenceMissing()
+    {
+        var stateMachine = new MonthEndCloseStateMachine();
+        var current = new ClosePeriod("ledger-a", new DateOnly(2026, 03, 31), ClosePeriodState.Open, new CloseEvidence(false, false, false), []);
+
+        var next = stateMachine.Transition(current, new CloseEvidence(true, false, true), isTrialBalanceBalanced: true);
+
+        next.State.Should().Be(ClosePeriodState.Validating);
+        next.Blockers.Should().ContainSingle().Which.Should().Contain("Reconciliation");
+    }
+
+    [Fact]
+    public void CloseStateMachine_ClosesWhenAllGatesPass()
+    {
+        var stateMachine = new MonthEndCloseStateMachine();
+        var current = new ClosePeriod("ledger-a", new DateOnly(2026, 03, 31), ClosePeriodState.Validating, new CloseEvidence(true, true, true), []);
+
+        var next = stateMachine.Transition(current, new CloseEvidence(true, true, true), isTrialBalanceBalanced: true);
+
+        next.State.Should().Be(ClosePeriodState.Closed);
+        next.Blockers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void PostingReplay_RemainsDeterministicByDateThenId()
+    {
+        var posting = new AccountingPostingService();
+        var idB = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        var idA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        posting.Post("ledger-a", [
+            new JournalEntry(idB, "ledger-a", new DateOnly(2026, 03, 02), "evt-b", "b", ImmutableArray.Create(new JournalLine("Cash", 1m, "USD", true))),
+            new JournalEntry(idA, "ledger-a", new DateOnly(2026, 03, 02), "evt-a", "a", ImmutableArray.Create(new JournalLine("Cash", 1m, "USD", true)))
+        ]);
+
+        var replay = posting.Replay("ledger-a");
+        replay[0].JournalEntryId.Should().Be(idA);
+        replay[1].JournalEntryId.Should().Be(idB);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide accounting domain scaffolding to support deterministic journal posting, FX translation, and month-end close flows for reliable auditability and replay.
- Expose trial balance, roll‑forward, and audit drill-through projections so operator UIs and dashboards can surface balances, translation adjustments, and linked source events.
- Implement a guarded month-end close workflow (open → validating → blocked → closed) with evidence checks to gate closing until reconciliation and approvals are complete.

### Description
- Added domain models in `src/Meridian.Application/AccountingClose/AccountingCloseModels.cs` including `JournalEntry`, `JournalLine`, `FxRate`, `TranslationAdjustment`, `TrialBalanceLine`, `RollForwardLine`, `SourceLinkedAuditLine`, `ClosePeriod` and `CloseEvidence`.
- Implemented services in `src/Meridian.Application/AccountingClose/AccountingCloseServices.cs` including `AccountingPostingService` (deterministic `Post`/`Replay` and `Audit`), `FxTranslationService` (deterministic rounding/adjustment), `TrialBalanceProjectionService` (trial balance, balance check, roll‑forward) and `MonthEndCloseStateMachine` (evidence/blocker derivation and state transitions).
- Exposed a UI-facing query service in `src/Meridian.Ui.Services/Services/Accounting/AccountingProjectionQueryService.cs` implementing `IAccountingProjectionQueryService` to return trial balance, roll‑forward, and audit lines to UI layers.
- Added an operator view model `AccountingCloseViewModel` at `src/Meridian.Wpf/ViewModels/Accounting/AccountingCloseViewModel.cs` to load trial balance, roll‑forward, audit trail and track close state, and added browser dashboard type models at `src/Meridian.Ui/dashboard/src/features/accounting/accountingCloseModels.ts` for front-end integration.
- Added focused unit tests in `tests/Meridian.Tests/AccountingCloseServicesTests.cs` covering FX translation rounding/source linkage, out‑of‑balance detection, close state gating, and deterministic posting/replay ordering.

### Testing
- Added unit tests at `tests/Meridian.Tests/AccountingCloseServicesTests.cs` that exercise FX translation, trial balance projection, close state transitions, and posting replay ordering and are ready to run in the project test runner.
- Attempted to run `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~AccountingCloseServicesTests" --logger "console;verbosity=minimal"` in the rollout environment and it failed due to the environment missing the .NET SDK (`dotnet: command not found`).
- No CI results are available in this environment; the added tests should be executed in a developer environment or CI pipeline with .NET SDK present using `dotnet test` to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17582c028083209dda700daf9aee40)