### PR TITLE
Add aggregated portfolio summary endpoint and 5-second refresh orchestration

### DIFF
--- a/src/Meridian.Contracts/Workstation/WorkstationBootstrapDtos.cs
+++ b/src/Meridian.Contracts/Workstation/WorkstationBootstrapDtos.cs
@@ -312,6 +312,25 @@ public sealed record WorkstationPortfolioPayload(
     IReadOnlyList<WorkstationPortfolioRunRow> Runs,
     object? CashFlow);
 
+
+
+public sealed record WorkstationPortfolioSummaryTelemetry(
+    long RefreshLatencyMs,
+    int PayloadSizeBytes,
+    bool IsStale,
+    string? StaleReason,
+    string AsOfUtc);
+
+public sealed record WorkstationPortfolioSummaryPayload(
+    string FundAccountId,
+    string StrategyId,
+    string Entity,
+    IReadOnlyList<WorkstationMetricCard> ConsolidatedCards,
+    IReadOnlyList<WorkstationTradingPositionRow> Positions,
+    WorkstationTradingRiskState Risk,
+    WorkstationPortfolioSummaryTelemetry Telemetry,
+    IReadOnlyDictionary<string, string> DrillThroughRoutes);
+
 // ---------------------------------------------------------------------------
 // /api/workstation/data and /api/workstation/data-operations
 // ---------------------------------------------------------------------------

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -327,6 +327,14 @@ public static partial class WorkstationEndpoints
         .WithName("GetWorkstationPortfolio")
         .Produces<WorkstationPortfolioPayload>(200);
 
+        group.MapGet("/portfolio/summary", async (string? fundAccountId, string? strategyId, string? entity, HttpContext context) =>
+        {
+            var payload = await BuildPortfolioSummaryPayloadAsync(context, fundAccountId, strategyId, entity).ConfigureAwait(false);
+            return Results.Json(payload, jsonOptions);
+        })
+        .WithName("GetWorkstationPortfolioSummary")
+        .Produces<WorkstationPortfolioSummaryPayload>(200);
+
         MapOperationsContinuityEndpoints(group, jsonOptions);
 
         group.MapGet(WorkstationSubroute(UiApiRoutes.OperationsContinuity), async (
@@ -3716,6 +3724,39 @@ public static partial class WorkstationEndpoints
             Brokerage: brokerage,
             Runs: runs,
             CashFlow: BuildGovernanceWorkspaceCashFlowSummary(runDetailsForCashFlow));
+    }
+
+    private static async Task<WorkstationPortfolioSummaryPayload> BuildPortfolioSummaryPayloadAsync(HttpContext context, string? fundAccountId, string? strategyId, string? entity)
+    {
+        var started = DateTimeOffset.UtcNow;
+        var basePayload = await BuildPortfolioPayloadAsync(context).ConfigureAwait(false);
+        var cards = new List<WorkstationMetricCard>(basePayload.Metrics)
+        {
+            new("portfolio-exposure", "Gross Exposure", basePayload.Risk.GrossExposure, "live", "default"),
+            new("portfolio-net-exposure", "Net Exposure", basePayload.Risk.NetExposure, "live", "default")
+        };
+
+        var serialized = JsonSerializer.Serialize(basePayload);
+        var stale = string.Equals(basePayload.Brokerage.Connection, "Disconnected", StringComparison.OrdinalIgnoreCase);
+
+        return new WorkstationPortfolioSummaryPayload(
+            FundAccountId: string.IsNullOrWhiteSpace(fundAccountId) ? "all" : fundAccountId!,
+            StrategyId: string.IsNullOrWhiteSpace(strategyId) ? "all" : strategyId!,
+            Entity: string.IsNullOrWhiteSpace(entity) ? "portfolio" : entity!,
+            ConsolidatedCards: cards,
+            Positions: basePayload.Positions,
+            Risk: basePayload.Risk,
+            Telemetry: new WorkstationPortfolioSummaryTelemetry(
+                RefreshLatencyMs: (long)Math.Max(0, (DateTimeOffset.UtcNow - started).TotalMilliseconds),
+                PayloadSizeBytes: System.Text.Encoding.UTF8.GetByteCount(serialized),
+                IsStale: stale,
+                StaleReason: stale ? "brokerage-disconnected" : null,
+                AsOfUtc: DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture)),
+            DrillThroughRoutes: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["positions"] = $"/portfolio/positions?fundAccountId={Uri.EscapeDataString(string.IsNullOrWhiteSpace(fundAccountId) ? "all" : fundAccountId!)}&strategyId={Uri.EscapeDataString(string.IsNullOrWhiteSpace(strategyId) ? "all" : strategyId!)}&entity={Uri.EscapeDataString(string.IsNullOrWhiteSpace(entity) ? "portfolio" : entity!)}",
+                ["trades"] = $"/trading?fundAccountId={Uri.EscapeDataString(string.IsNullOrWhiteSpace(fundAccountId) ? "all" : fundAccountId!)}&strategyId={Uri.EscapeDataString(string.IsNullOrWhiteSpace(strategyId) ? "all" : strategyId!)}"
+            });
     }
 
     private static async Task<WorkstationGovernancePayload> BuildGovernancePayloadAsync(HttpContext context)

--- a/src/Meridian.Ui/dashboard/src/hooks/use-workstation-data.ts
+++ b/src/Meridian.Ui/dashboard/src/hooks/use-workstation-data.ts
@@ -503,7 +503,7 @@ export function useWorkstationData() {
   }, [refreshProviderRouting]);
 
   useEffect(() => {
-    const id = setInterval(() => { void refreshPortfolio(); }, 60_000);
+    const id = setInterval(() => { void refreshPortfolio(); }, 5_000);
     return () => clearInterval(id);
   }, [refreshPortfolio]);
 

--- a/src/Meridian.Ui/dashboard/src/lib/workstation-endpoints.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/workstation-endpoints.ts
@@ -6,6 +6,7 @@ export const WORKSTATION_API_ENDPOINTS = {
   tradingReadiness: "/api/workstation/trading/readiness",
   operatorInbox: "/api/workstation/operator/inbox",
   portfolio: "/api/workstation/portfolio",
+  portfolioSummary: "/api/workstation/portfolio/summary",
   data: "/api/workstation/data",
   accounting: "/api/workstation/accounting",
   reporting: "/api/workstation/reporting",

--- a/src/Meridian.Wpf/ViewModels/PositionBlotterViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/PositionBlotterViewModel.cs
@@ -318,7 +318,7 @@ public sealed class PositionBlotterViewModel : BindableBase, IDisposable
 
         _refreshTimer = new DispatcherTimer
         {
-            Interval = TimeSpan.FromSeconds(30)
+            Interval = TimeSpan.FromSeconds(5)
         };
         _refreshTimer.Tick += (_, _) =>
         {


### PR DESCRIPTION
### Motivation
- Provide a single, consolidated portfolio summary payload keyed by `fundAccountId`, `strategyId`, and `entity` to simplify dashboard cards and drill-through flows.
- Surface operational telemetry (refresh latency, payload size, stale-data detection) so operators and SRE can monitor refresh health and staleness.
- Reduce UI-visible data staleness by tightening periodic refresh cadence for browser and desktop surfaces to a 5-second cadence.

### Description
- Added `WorkstationPortfolioSummaryPayload` and `WorkstationPortfolioSummaryTelemetry` DTOs to `src/Meridian.Contracts/Workstation/WorkstationBootstrapDtos.cs` to model consolidated cards, positions, risk, telemetry, and drill-through routes.
- Added a new `GET /api/workstation/portfolio/summary` endpoint and `BuildPortfolioSummaryPayloadAsync` in `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` that builds the consolidated payload, computes telemetry (`RefreshLatencyMs`, `PayloadSizeBytes`, `IsStale`, `StaleReason`, `AsOfUtc`) and emits filter-preserving drill-through links.
- Extended frontend endpoint constants in `src/Meridian.Ui/dashboard/src/lib/workstation-endpoints.ts` to include the new `portfolioSummary` route and updated the browser refresh hook in `src/Meridian.Ui/dashboard/src/hooks/use-workstation-data.ts` to poll portfolio data every 5 seconds.
- Updated desktop shell periodic refresh in `src/Meridian.Wpf/ViewModels/PositionBlotterViewModel.cs` to a 5-second `DispatcherTimer` interval so the WPF blotter matches the tighter refresh cadence while preserving existing `/api/workstation/portfolio` behaviour.

### Testing
- Ran `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~MapWorkstationEndpoints_PortfolioWorkspace_ShouldReturnTypedPayloadWithRunsAndPositions"` but it failed to run in the environment because `dotnet` was not available.
- Ran dashboard unit tests with `npm run test -- --run src/hooks/use-workstation-data.test.ts src/lib/workstation-endpoints.test.ts` but the run failed due to missing dashboard dev dependencies (`vitest` module not installed) in the container environment.
- No endpoint- or UI-specific automated tests were executed successfully in this run due to the above environment limitations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17582533d48320abcaf64769e36efd)