### PR TITLE
Add reporting orchestration contracts, lineage metadata, and approval workflow scaffolding

### DIFF
--- a/src/Meridian.Application/Reporting/DefaultReportingTemplateCatalog.cs
+++ b/src/Meridian.Application/Reporting/DefaultReportingTemplateCatalog.cs
@@ -1,0 +1,36 @@
+using System.Collections.Immutable;
+
+namespace Meridian.Application.Reporting;
+
+public sealed class DefaultReportingTemplateCatalog : IReportingTemplateCatalog
+{
+    private readonly IReadOnlyDictionary<string, ReportingTemplateMetadata> templates = new Dictionary<string, ReportingTemplateMetadata>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["investor-monthly-statement"] = new(
+            "investor-monthly-statement",
+            ReportingTemplateFamily.InvestorStatement,
+            "Investor Monthly Statement",
+            "1.0.0",
+            ["cover", "performance", "positions", "flows"],
+            ImmutableDictionary<string, string>.Empty.Add("audience", "investor")),
+        ["sec-13f-packet"] = new(
+            "sec-13f-packet",
+            ReportingTemplateFamily.SecFilingPacket,
+            "SEC 13F Filing Packet",
+            "1.0.0",
+            ["cover", "holdings", "attestation"],
+            ImmutableDictionary<string, string>.Empty.Add("audience", "regulator")),
+        ["shadow-nav-daily-pack"] = new(
+            "shadow-nav-daily-pack",
+            ReportingTemplateFamily.ShadowNavPack,
+            "Shadow NAV Daily Pack",
+            "1.0.0",
+            ["cover", "valuation", "breaks", "signoff"],
+            ImmutableDictionary<string, string>.Empty.Add("audience", "ops"))
+    };
+
+    public ReportingTemplateMetadata Get(string templateId)
+        => templates.TryGetValue(templateId, out var value)
+            ? value
+            : throw new KeyNotFoundException($"Unknown reporting template '{templateId}'.");
+}

--- a/src/Meridian.Application/Reporting/ReportingContracts.cs
+++ b/src/Meridian.Application/Reporting/ReportingContracts.cs
@@ -1,0 +1,64 @@
+using System.Collections.Immutable;
+
+namespace Meridian.Application.Reporting;
+
+public enum ReportingRunTrigger
+{
+    AdHoc,
+    Scheduled
+}
+
+public enum ReportingRunStatus
+{
+    Draft,
+    InReview,
+    Approved,
+    Released,
+    Failed
+}
+
+public enum ReportingTemplateFamily
+{
+    InvestorStatement,
+    SecFilingPacket,
+    ShadowNavPack
+}
+
+public sealed record ReportingTemplateMetadata(
+    string TemplateId,
+    ReportingTemplateFamily Family,
+    string Name,
+    string Version,
+    ImmutableArray<string> Sections,
+    ImmutableDictionary<string, string> Tags);
+
+public sealed record ReportingOutputManifest(
+    string RunId,
+    string TemplateId,
+    DateOnly AsOfDate,
+    ReportingRunStatus Status,
+    ImmutableArray<ReportingSectionManifest> Sections,
+    ImmutableArray<string> Artifacts);
+
+public sealed record ReportingSectionManifest(
+    string SectionId,
+    string DatasetSnapshotId,
+    string ReconciliationCheckpointId,
+    string Hash);
+
+public sealed record ReportingJobContract(
+    string JobId,
+    string TemplateId,
+    DateOnly AsOfDate,
+    ReportingRunTrigger Trigger,
+    int MaxRetries,
+    string RequestedBy,
+    DateTimeOffset RequestedAtUtc,
+    string? CronExpression = null);
+
+public sealed record ReportingRunAuditEntry(
+    string RunId,
+    DateTimeOffset TimestampUtc,
+    string Action,
+    string Actor,
+    string Notes);

--- a/src/Meridian.Application/Reporting/ReportingOrchestrationService.cs
+++ b/src/Meridian.Application/Reporting/ReportingOrchestrationService.cs
@@ -1,0 +1,131 @@
+using System.Collections.Frozen;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Meridian.Application.Reporting;
+
+public interface IReportingOrchestrationService
+{
+    Task<ReportingOutputManifest> ExecuteAsync(ReportingJobContract contract, CancellationToken cancellationToken);
+    IReadOnlyList<ReportingRunAuditEntry> GetAudit(string runId);
+    Task<bool> TransitionApprovalAsync(string runId, ReportingRunStatus target, string actor, string role, string notes, CancellationToken cancellationToken);
+}
+
+public interface IReportingTemplateCatalog
+{
+    ReportingTemplateMetadata Get(string templateId);
+}
+
+public sealed class ReportingOrchestrationService : IReportingOrchestrationService
+{
+    private static readonly FrozenDictionary<ReportingRunStatus, string[]> AllowedRoles = new Dictionary<ReportingRunStatus, string[]>
+    {
+        [ReportingRunStatus.InReview] = ["Reviewer", "OperationsLead"],
+        [ReportingRunStatus.Approved] = ["OperationsLead", "ComplianceOfficer"],
+        [ReportingRunStatus.Released] = ["OperationsLead"]
+    }.ToFrozenDictionary();
+
+    private readonly IReportingTemplateCatalog catalog;
+    private readonly ConcurrentDictionary<string, ReportingOutputManifest> manifests = new();
+    private readonly ConcurrentDictionary<string, List<ReportingRunAuditEntry>> audits = new();
+
+    public ReportingOrchestrationService(IReportingTemplateCatalog catalog)
+    {
+        this.catalog = catalog;
+    }
+
+    public Task<ReportingOutputManifest> ExecuteAsync(ReportingJobContract contract, CancellationToken cancellationToken)
+    {
+        var template = catalog.Get(contract.TemplateId);
+        var runId = $"{contract.JobId}-{contract.AsOfDate:yyyyMMdd}";
+        Exception? lastError = null;
+
+        for (var attempt = 0; attempt <= contract.MaxRetries; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var sections = template.Sections.Select(section =>
+                {
+                    var snapshot = $"snap-{section}-{contract.AsOfDate:yyyyMMdd}";
+                    var checkpoint = $"recon-{section}-{contract.AsOfDate:yyyyMMdd}";
+                    return new ReportingSectionManifest(section, snapshot, checkpoint, ComputeHash(runId, section, snapshot, checkpoint));
+                }).ToImmutableArray();
+
+                var manifest = new ReportingOutputManifest(
+                    runId,
+                    contract.TemplateId,
+                    contract.AsOfDate,
+                    ReportingRunStatus.Draft,
+                    sections,
+                    [
+                        $"{runId}.json",
+                        $"{runId}.pdf"
+                    ]);
+
+                manifests[runId] = manifest;
+                AppendAudit(runId, "RunGenerated", contract.RequestedBy, $"trigger={contract.Trigger}; attempt={attempt + 1}");
+                return Task.FromResult(manifest);
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+                AppendAudit(runId, "RunFailed", contract.RequestedBy, $"attempt={attempt + 1}; error={ex.Message}");
+            }
+        }
+
+        throw new InvalidOperationException($"Reporting run failed after {contract.MaxRetries + 1} attempts.", lastError);
+    }
+
+    public IReadOnlyList<ReportingRunAuditEntry> GetAudit(string runId)
+        => audits.TryGetValue(runId, out var entries) ? entries.AsReadOnly() : [];
+
+    public Task<bool> TransitionApprovalAsync(string runId, ReportingRunStatus target, string actor, string role, string notes, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!manifests.TryGetValue(runId, out var current))
+        {
+            return Task.FromResult(false);
+        }
+
+        if (!IsTransitionAllowed(current.Status, target))
+        {
+            return Task.FromResult(false);
+        }
+
+        if (AllowedRoles.TryGetValue(target, out var roles) && !roles.Contains(role, StringComparer.OrdinalIgnoreCase))
+        {
+            AppendAudit(runId, "ApprovalDenied", actor, $"target={target}; role={role}; notes={notes}");
+            return Task.FromResult(false);
+        }
+
+        var updated = current with { Status = target };
+        manifests[runId] = updated;
+        AppendAudit(runId, "ApprovalTransition", actor, $"{current.Status}->{target}; role={role}; notes={notes}");
+        return Task.FromResult(true);
+    }
+
+    private static bool IsTransitionAllowed(ReportingRunStatus from, ReportingRunStatus to)
+        => (from, to) switch
+        {
+            (ReportingRunStatus.Draft, ReportingRunStatus.InReview) => true,
+            (ReportingRunStatus.InReview, ReportingRunStatus.Approved) => true,
+            (ReportingRunStatus.Approved, ReportingRunStatus.Released) => true,
+            _ => false
+        };
+
+    private void AppendAudit(string runId, string action, string actor, string notes)
+    {
+        var queue = audits.GetOrAdd(runId, static _ => []);
+        queue.Add(new ReportingRunAuditEntry(runId, DateTimeOffset.UtcNow, action, actor, notes));
+    }
+
+    private static string ComputeHash(params string[] values)
+    {
+        var joined = string.Join('|', values);
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(joined));
+        return Convert.ToHexString(bytes);
+    }
+}

--- a/src/Meridian.Ui.Services/Services/Reporting/ReportingStatusProjectionService.cs
+++ b/src/Meridian.Ui.Services/Services/Reporting/ReportingStatusProjectionService.cs
@@ -1,0 +1,43 @@
+using Meridian.Application.Reporting;
+
+namespace Meridian.Ui.Services.Services.Reporting;
+
+public sealed record ReportingStatusProjection(
+    string RunId,
+    string TemplateId,
+    string Family,
+    string Status,
+    int SectionCount,
+    int LineageLinkedSections,
+    IReadOnlyList<ReportingRunAuditEntry> AuditTrail);
+
+public interface IReportingStatusProjectionService
+{
+    ReportingStatusProjection Project(ReportingOutputManifest manifest, IReadOnlyList<ReportingRunAuditEntry> audit);
+}
+
+public sealed class ReportingStatusProjectionService : IReportingStatusProjectionService
+{
+    public ReportingStatusProjection Project(ReportingOutputManifest manifest, IReadOnlyList<ReportingRunAuditEntry> audit)
+    {
+        var lineageLinkedSections = manifest.Sections.Count(s => !string.IsNullOrWhiteSpace(s.DatasetSnapshotId)
+            && !string.IsNullOrWhiteSpace(s.ReconciliationCheckpointId));
+
+        return new ReportingStatusProjection(
+            manifest.RunId,
+            manifest.TemplateId,
+            ResolveFamily(manifest.TemplateId),
+            manifest.Status.ToString(),
+            manifest.Sections.Length,
+            lineageLinkedSections,
+            audit);
+    }
+
+    private static string ResolveFamily(string templateId)
+    {
+        if (templateId.StartsWith("investor", StringComparison.OrdinalIgnoreCase)) return ReportingTemplateFamily.InvestorStatement.ToString();
+        if (templateId.StartsWith("sec", StringComparison.OrdinalIgnoreCase)) return ReportingTemplateFamily.SecFilingPacket.ToString();
+        if (templateId.StartsWith("shadow", StringComparison.OrdinalIgnoreCase)) return ReportingTemplateFamily.ShadowNavPack.ToString();
+        return "Unknown";
+    }
+}

--- a/tests/Meridian.Tests/Reporting/ReportingOrchestrationServiceTests.cs
+++ b/tests/Meridian.Tests/Reporting/ReportingOrchestrationServiceTests.cs
@@ -1,0 +1,45 @@
+using FluentAssertions;
+using Meridian.Application.Reporting;
+
+namespace Meridian.Tests.Reporting;
+
+public sealed class ReportingOrchestrationServiceTests
+{
+    [Fact]
+    public async Task ExecuteAsync_IsDeterministicForSameContract()
+    {
+        var sut = new ReportingOrchestrationService(new DefaultReportingTemplateCatalog());
+        var contract = new ReportingJobContract("job-1", "investor-monthly-statement", new DateOnly(2026, 5, 1), ReportingRunTrigger.AdHoc, 0, "alice", DateTimeOffset.UtcNow);
+
+        var first = await sut.ExecuteAsync(contract, CancellationToken.None);
+        var second = await sut.ExecuteAsync(contract, CancellationToken.None);
+
+        first.RunId.Should().Be(second.RunId);
+        first.Sections.Select(s => s.Hash).Should().Equal(second.Sections.Select(s => s.Hash));
+    }
+
+    [Fact]
+    public async Task TransitionApprovalAsync_EnforcesGateAndRole()
+    {
+        var sut = new ReportingOrchestrationService(new DefaultReportingTemplateCatalog());
+        var contract = new ReportingJobContract("job-2", "sec-13f-packet", new DateOnly(2026, 5, 2), ReportingRunTrigger.AdHoc, 0, "alice", DateTimeOffset.UtcNow);
+        var manifest = await sut.ExecuteAsync(contract, CancellationToken.None);
+
+        (await sut.TransitionApprovalAsync(manifest.RunId, ReportingRunStatus.Released, "bob", "Reviewer", "skip", CancellationToken.None)).Should().BeFalse();
+        (await sut.TransitionApprovalAsync(manifest.RunId, ReportingRunStatus.InReview, "bob", "Reviewer", "review", CancellationToken.None)).Should().BeTrue();
+        (await sut.TransitionApprovalAsync(manifest.RunId, ReportingRunStatus.Approved, "cora", "ComplianceOfficer", "approved", CancellationToken.None)).Should().BeTrue();
+        (await sut.TransitionApprovalAsync(manifest.RunId, ReportingRunStatus.Released, "dan", "OperationsLead", "release", CancellationToken.None)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ProducesScheduledRunAudit()
+    {
+        var sut = new ReportingOrchestrationService(new DefaultReportingTemplateCatalog());
+        var contract = new ReportingJobContract("sched-1", "shadow-nav-daily-pack", new DateOnly(2026, 5, 3), ReportingRunTrigger.Scheduled, 1, "scheduler", DateTimeOffset.UtcNow, "0 0 * * 1-5");
+
+        var manifest = await sut.ExecuteAsync(contract, CancellationToken.None);
+        var audit = sut.GetAudit(manifest.RunId);
+
+        audit.Should().ContainSingle(e => e.Action == "RunGenerated" && e.Notes.Contains("trigger=Scheduled"));
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce first-class reporting domain contracts and metadata so reporting jobs, templates, and output manifests can be defined and validated from `src/Meridian.Application`.
- Provide an orchestration surface that supports deterministic ad-hoc and scheduled runs with retry/failure handling and an audit trail for operational observability.
- Capture per-section data-lineage links to dataset snapshots and reconciliation checkpoints so UI and governance surfaces can show lineage coverage.
- Provide a minimal approval workflow (draft → in-review → approved → released) with role-gated transitions to enforce governance gates.

### Description
- Added domain contracts in `src/Meridian.Application/Reporting/ReportingContracts.cs` for job requests, template metadata, output manifests, section-level lineage, statuses, and run audit entries.
- Implemented `ReportingOrchestrationService` in `src/Meridian.Application/Reporting/ReportingOrchestrationService.cs` which performs deterministic section manifest generation, a retry loop, audit entry capture, in-memory manifest storage, and role-gated approval transitions.
- Added `DefaultReportingTemplateCatalog` in `src/Meridian.Application/Reporting/DefaultReportingTemplateCatalog.cs` with initial template families for `InvestorStatement`, `SecFilingPacket`, and `ShadowNavPack` and section lists.
- Exposed a UI projection via `src/Meridian.Ui.Services/Services/Reporting/ReportingStatusProjectionService.cs` to translate a `ReportingOutputManifest` + audit into a lightweight status projection consumable by WPF/browser surfaces.
- Added focused unit tests in `tests/Meridian.Tests/Reporting/ReportingOrchestrationServiceTests.cs` covering deterministic regeneration, approval gate/role enforcement, and scheduled-run audit note presence.

### Testing
- Added unit tests `ReportingOrchestrationServiceTests` with three cases: `ExecuteAsync_IsDeterministicForSameContract`, `TransitionApprovalAsync_EnforcesGateAndRole`, and `ExecuteAsync_ProducesScheduledRunAudit` located under `tests/Meridian.Tests/Reporting/`.
- Attempted to run the focused test slice with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ReportingOrchestrationServiceTests" --logger "console;verbosity=minimal"` but the execution environment reported `dotnet: command not found`, so automated tests were not executed here.
- The changes compile-time shape and tests are provided for CI/local validation where `dotnet` is available; CI should run the new test filter to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1758299e808320b2dec64ccf424fb4)