### PR TITLE
Wave 2 readiness blocker parity: freeze enum and add web + WPF characterization tests

### DIFF
--- a/src/Meridian.Ui/dashboard/src/screens/trading-screen.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/trading-screen.view-model.test.ts
@@ -2653,3 +2653,38 @@ describe("green cockpit: ReadyForPaperOperation proof", () => {
     expect(state.hasOperatorAttention).toBe(true);
   });
 });
+
+describe("trading readiness blocker taxonomy parity", () => {
+  it("keeps blocker severity and repair routes aligned for core Wave 2 blockers", () => {
+    const readiness: TradingOperatorReadiness = {
+      ...blockedReadiness,
+      overallStatus: "Blocked",
+      acceptanceGates: [
+        { gateId: "replay", label: "Replay", status: "ReviewRequired", detail: "Replay evidence is stale.", sessionId: "sess-1", runId: null, auditReference: "audit-replay" },
+        { gateId: "trust-gate", label: "Provider trust", status: "Blocked", detail: "Operator sign-off evidence is missing.", sessionId: null, runId: null, auditReference: "audit-trust" },
+        { gateId: "brokerage-sync", label: "Brokerage sync", status: "Blocked", detail: "Brokerage sync is incomplete.", sessionId: null, runId: null, auditReference: "audit-sync" }
+      ],
+      workItems: [
+        { workItemId: "replay-stale", kind: "PaperReplay", label: "Replay stale", detail: "Replay verification is stale.", tone: "Warning", createdAt: "2026-05-01T00:00:00Z", runId: "run-1", fundAccountId: null, auditReference: "audit-replay" },
+        { workItemId: "signoff-missing", kind: "ProviderTrustGate", label: "Sign-off missing", detail: "Missing operator sign-off evidence.", tone: "Critical", createdAt: "2026-05-01T00:00:01Z", runId: null, fundAccountId: null, auditReference: "audit-trust" },
+        { workItemId: "provider-trust-degraded", kind: "ProviderTrustGate", label: "Provider trust degraded", detail: "Provider trust gate is degraded.", tone: "Critical", createdAt: "2026-05-01T00:00:02Z", runId: null, fundAccountId: null, auditReference: "audit-trust-2" },
+        { workItemId: "brokerage-sync-incomplete", kind: "BrokerageSync", label: "Brokerage sync incomplete", detail: "Brokerage sync is incomplete.", tone: "Critical", createdAt: "2026-05-01T00:00:03Z", runId: null, fundAccountId: "fund-1", auditReference: "audit-sync", targetRoute: "/api/fund-accounts/fund-1/brokerage-sync", targetPageTag: "AccountPortfolio" }
+      ]
+    };
+
+    const state = buildTradingReadinessState({ readiness, refreshing: false, errorText: null });
+    const byId = new Map(state.visibleWorkItems.map((item) => [item.workItemId, item]));
+
+    expect(byId.get("replay-stale")?.tone).toBe("warning");
+    expect(byId.get("replay-stale")?.action?.href).toBe("/trading#session-replay-panel");
+
+    expect(byId.get("signoff-missing")?.tone).toBe("danger");
+    expect(byId.get("signoff-missing")?.action?.href).toBe("/data/providers");
+
+    expect(byId.get("provider-trust-degraded")?.tone).toBe("danger");
+    expect(byId.get("provider-trust-degraded")?.action?.href).toBe("/data/providers");
+
+    expect(byId.get("brokerage-sync-incomplete")?.tone).toBe("danger");
+    expect(byId.get("brokerage-sync-incomplete")?.action?.href).toBe("/portfolio/accounts/fund-1");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/types.ts
+++ b/src/Meridian.Ui/dashboard/src/types.ts
@@ -293,7 +293,7 @@ export type OperatorWorkItemKind =
   | "LedgerPeriodClose";
 
 export type OperatorWorkItemTone = "Info" | "Success" | "Warning" | "Critical";
-export type TradingAcceptanceGateStatus = "Ready" | "ReviewRequired" | "Blocked";
+export type TradingAcceptanceGateStatus = "Ready" | "ReviewRequired" | "Blocked" | "Unknown";
 
 export interface OperatorWorkItem {
   workItemId: string;

--- a/tests/Meridian.Wpf.Tests/ViewModels/TradingWorkspaceShellViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/TradingWorkspaceShellViewModelTests.cs
@@ -227,6 +227,21 @@ public sealed class TradingWorkspaceShellViewModelTests
         actionId.Should().Be("AccountPortfolio");
     }
 
+
+    [Fact]
+    public void ResolveOperatorWorkItemActionId_MapsTopBlockerTaxonomyToConsistentRepairRoutes()
+    {
+        var replay = new OperatorWorkItemDto("replay-stale", OperatorWorkItemKindDto.PaperReplay, "Replay stale", "Replay evidence is stale.", OperatorWorkItemToneDto.Warning, new DateTimeOffset(2026,5,1,0,0,0,TimeSpan.Zero));
+        var signoff = new OperatorWorkItemDto("signoff-missing", OperatorWorkItemKindDto.ProviderTrustGate, "Missing sign-off", "Missing operator sign-off evidence.", OperatorWorkItemToneDto.Critical, new DateTimeOffset(2026,5,1,0,0,1,TimeSpan.Zero));
+        var provider = new OperatorWorkItemDto("provider-trust-degraded", OperatorWorkItemKindDto.ProviderTrustGate, "Provider trust degraded", "Provider trust degraded.", OperatorWorkItemToneDto.Critical, new DateTimeOffset(2026,5,1,0,0,2,TimeSpan.Zero));
+        var brokerage = new OperatorWorkItemDto("brokerage-sync-incomplete", OperatorWorkItemKindDto.BrokerageSync, "Brokerage sync incomplete", "Brokerage sync incomplete.", OperatorWorkItemToneDto.Critical, new DateTimeOffset(2026,5,1,0,0,3,TimeSpan.Zero), TargetRoute: $"{UiApiRoutes.FundAccountBrokerageSyncAccounts}?fundAccountId=9c37d51f-2eba-40f5-9c86-6c9eb3863b8b", TargetPageTag: "TradingShell");
+
+        TradingWorkspaceShellPresentationService.ResolveOperatorWorkItemActionId(replay).Should().Be("ReplayVerification");
+        TradingWorkspaceShellPresentationService.ResolveOperatorWorkItemActionId(signoff).Should().Be("ProviderHealth");
+        TradingWorkspaceShellPresentationService.ResolveOperatorWorkItemActionId(provider).Should().Be("ProviderHealth");
+        TradingWorkspaceShellPresentationService.ResolveOperatorWorkItemActionId(brokerage).Should().Be("AccountPortfolio");
+    }
+
     [Fact]
     public void ResolveOperatorWorkItemActionId_WithLedgerPeriodClose_OpensReconciliation()
     {


### PR DESCRIPTION
### Motivation

- Prevent silent contract breakage by making the client-side readiness enum additive-safe for Wave 2 evolution and explicitly covering the `Unknown` server value. 
- Ensure trading readiness and operator-inbox blocker taxonomy (stale replay, missing sign-off, provider trust degradation, brokerage sync incomplete) is interpreted the same way in both the browser dashboard and WPF shell. 
- Add targeted characterization tests that assert severity, repair routes, and routed action IDs so UI repair workflows remain consistent across surfaces.

### Description

- Updated the browser dashboard DTO/type to include an additive-safe member by adding `"Unknown"` to `TradingAcceptanceGateStatus` in `src/Meridian.Ui/dashboard/src/types.ts`.
- Added a focused web characterization/parity test asserting severity labels and expected repair `href`s for the core Wave 2 blockers in `src/Meridian.Ui/dashboard/src/screens/trading-screen.view-model.test.ts`.
- Added a focused WPF unit test that validates the same blocker taxonomy maps to the intended presentation action IDs (`ReplayVerification`, `ProviderHealth`, `AccountPortfolio`) in `tests/Meridian.Wpf.Tests/ViewModels/TradingWorkspaceShellViewModelTests.cs`.
- Small test scaffolding to exercise `buildTradingReadinessState` expectations and `TradingWorkspaceShellPresentationService.ResolveOperatorWorkItemActionId` routing were added to lock in behavior across web and desktop.

### Testing

- Attempted to run the WPF test slice with `dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter "FullyQualifiedName~TradingWorkspaceShellViewModelTests" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger "console;verbosity=minimal"`, but the environment lacks `dotnet` so the command failed (no tests executed here).
- Attempted to run the dashboard test with `cd src/Meridian.Ui/dashboard && npm run test -- trading-screen.view-model.test.ts`, but the environment lacked `node_modules/vitest` and the run failed (no tests executed here).
- Both test runs failed due to the automation environment missing runtime/test dependencies; the added tests are unit/slice tests that should pass in a developer environment with `dotnet` and `npm install`/`vitest` available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a175f58108083208094c322aeb4ce25)