### PR TITLE
Standardize continuity correlation keys across operations continuity and reconciliation payloads

### DIFF
--- a/src/Meridian.Application/OperationsContinuity/OperationsContinuityRepositories.cs
+++ b/src/Meridian.Application/OperationsContinuity/OperationsContinuityRepositories.cs
@@ -59,7 +59,8 @@ public sealed record OperationsWorkflowAuditDraft(
     string Actor,
     string? Rationale,
     string? CorrelationId,
-    IReadOnlyList<OperationsEvidenceLinkDto> References);
+    IReadOnlyList<OperationsEvidenceLinkDto> References,
+    OperationsContinuityCorrelationKeysDto? CorrelationKeys = null);
 
 public sealed class InMemoryOperationsContinuityRepository : IOperationsContinuityRepository
 {

--- a/src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflow.cs
+++ b/src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflow.cs
@@ -672,6 +672,7 @@ public sealed class OperationsContinuityWorkflow
         EnsureUtc(now);
 
         BreakCases = request.BreakCases?.ToList() ?? [];
+        EnsureBreakCaseLineage(BreakCases);
         var openCriticalBreaks = BreakCases.Count(static item =>
             !IsClosedBreakStatus(item.Status) &&
             string.Equals(item.Severity, "Critical", StringComparison.OrdinalIgnoreCase));
@@ -685,6 +686,24 @@ public sealed class OperationsContinuityWorkflow
             evidenceLinks,
             now,
             request.Actor);
+    }
+
+    private static void EnsureBreakCaseLineage(IReadOnlyList<OperationsBreakCaseDto> breakCases)
+    {
+        foreach (var breakCase in breakCases)
+        {
+            var keys = breakCase.CorrelationKeys;
+            if (keys is null)
+            {
+                throw new InvalidOperationException($"Reconciliation break '{breakCase.BreakId}' is missing continuity correlation keys.");
+            }
+
+            if (string.IsNullOrWhiteSpace(keys.RunId))
+            {
+                throw new InvalidOperationException($"Reconciliation break '{breakCase.BreakId}' must include run lineage.");
+            }
+
+        }
     }
 
     public OperationsWorkflowBlockerDto? ResolveBreakCase(

--- a/src/Meridian.Application/OperationsContinuity/OperationsWorkflowAuditHashing.cs
+++ b/src/Meridian.Application/OperationsContinuity/OperationsWorkflowAuditHashing.cs
@@ -36,6 +36,7 @@ internal static class OperationsWorkflowAuditHashing
             draft.Actor,
             draft.Rationale,
             draft.CorrelationId,
+            draft.CorrelationKeys,
             draft.References,
             previousHash);
 
@@ -54,6 +55,7 @@ internal static class OperationsWorkflowAuditHashing
             draft.Actor,
             draft.Rationale,
             draft.CorrelationId,
+            draft.CorrelationKeys,
             draft.References,
             previousHash,
             currentHash);
@@ -115,6 +117,7 @@ internal static class OperationsWorkflowAuditHashing
                 entry.Actor,
                 entry.Rationale,
                 entry.CorrelationId,
+                entry.CorrelationKeys,
                 entry.References,
                 entry.PreviousHash);
 
@@ -149,6 +152,7 @@ internal static class OperationsWorkflowAuditHashing
         string actor,
         string? rationale,
         string? correlationId,
+        OperationsContinuityCorrelationKeysDto? correlationKeys,
         IReadOnlyList<OperationsEvidenceLinkDto> references,
         string? previousHash)
     {
@@ -167,6 +171,7 @@ internal static class OperationsWorkflowAuditHashing
             actor,
             rationale,
             correlationId,
+            correlationKeys,
             references,
             previousHash);
         var canonicalJson = JsonSerializer.Serialize(hashInput, HashJsonOptions);
@@ -188,6 +193,7 @@ internal static class OperationsWorkflowAuditHashing
         string Actor,
         string? Rationale,
         string? CorrelationId,
+        OperationsContinuityCorrelationKeysDto? CorrelationKeys,
         IReadOnlyList<OperationsEvidenceLinkDto> References,
         string? PreviousHash);
 }

--- a/src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs
+++ b/src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs
@@ -676,6 +676,7 @@ public sealed record OperationsTimelineEntryDto(
     string Actor,
     string? Rationale,
     string? CorrelationId,
+    OperationsContinuityCorrelationKeysDto? CorrelationKeys,
     IReadOnlyList<OperationsEvidenceLinkDto> References,
     string? PreviousHash,
     string CurrentHash);
@@ -695,6 +696,7 @@ public sealed record OperationsWorkflowAuditDto(
     string Actor,
     string? Rationale,
     string? CorrelationId,
+    OperationsContinuityCorrelationKeysDto? CorrelationKeys,
     IReadOnlyList<OperationsEvidenceLinkDto> References,
     string? PreviousHash,
     string CurrentHash);
@@ -715,7 +717,16 @@ public sealed record OperationsBreakCaseDto(
     string? SecurityId,
     string? Symbol,
     string? SuggestedAction,
-    IReadOnlyList<OperationsEvidenceLinkDto> EvidenceLinks);
+    IReadOnlyList<OperationsEvidenceLinkDto> EvidenceLinks,
+    OperationsContinuityCorrelationKeysDto? CorrelationKeys = null);
+
+public sealed record OperationsContinuityCorrelationKeysDto(
+    string? RunId = null,
+    Guid? FundAccountId = null,
+    string? PortfolioSnapshotId = null,
+    string? LedgerBatchId = null,
+    string? LedgerPostingGroupId = null,
+    string? ReconciliationCaseId = null);
 
 public sealed record OperationsApprovalDto(
     string ApprovalId,

--- a/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
+++ b/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
@@ -129,7 +129,8 @@ public sealed record ReconciliationBreakDto(
     ReconciliationBreakSeverity Severity,
     string Reason,
     DateTimeOffset? ExpectedAsOf,
-    DateTimeOffset? ActualAsOf);
+    DateTimeOffset? ActualAsOf,
+    OperationsContinuityCorrelationKeysDto? CorrelationKeys = null);
 
 /// <summary>
 /// Security Master coverage issue attached to a reconciliation run.

--- a/src/Meridian.Ui.Shared/Services/OperationsContinuityReconciliationBridge.cs
+++ b/src/Meridian.Ui.Shared/Services/OperationsContinuityReconciliationBridge.cs
@@ -132,7 +132,10 @@ public sealed class OperationsContinuityReconciliationBridge : IOperationsContin
                 SecurityId: null,
                 Symbol: null,
                 SuggestedAction: breakRow.Reason,
-                reconciliationEvidence));
+                reconciliationEvidence,
+                breakRow.CorrelationKeys ?? new OperationsContinuityCorrelationKeysDto(
+                    RunId: detail.Summary.RunId,
+                    ReconciliationCaseId: BuildBreakId(detail.Summary.ReconciliationRunId, breakRow.CheckId))));
 
         var securityCoverageBreaks = (detail.SecurityCoverageIssues ?? Array.Empty<ReconciliationSecurityCoverageIssueDto>())
             .Select(issue => new OperationsBreakCaseDto(
@@ -156,7 +159,10 @@ public sealed class OperationsContinuityReconciliationBridge : IOperationsContin
                     issue.EvidenceLink,
                     "security-master-coverage",
                     "Security Master coverage evidence",
-                    detail.Summary.CreatedAt)));
+                    detail.Summary.CreatedAt),
+                new OperationsContinuityCorrelationKeysDto(
+                    RunId: detail.Summary.RunId,
+                    ReconciliationCaseId: BuildIssueBreakId(detail.Summary.ReconciliationRunId, "security-coverage", issue.Source, issue.Symbol, issue.Code))));
 
         var securityAccountingBreaks = (detail.SecurityMasterAccountingIssues ?? Array.Empty<SecurityMasterAccountingIssueDto>())
             .Select(issue => new OperationsBreakCaseDto(
@@ -182,7 +188,10 @@ public sealed class OperationsContinuityReconciliationBridge : IOperationsContin
                     issue.EvidenceLink,
                     "security-master-accounting",
                     "Security Master accounting evidence",
-                    detail.Summary.CreatedAt)));
+                    detail.Summary.CreatedAt),
+                new OperationsContinuityCorrelationKeysDto(
+                    RunId: detail.Summary.RunId,
+                    ReconciliationCaseId: BuildIssueBreakId(detail.Summary.ReconciliationRunId, "security-accounting", issue.Source, issue.Symbol, issue.Code))));
 
         return reconciliationBreaks
             .Concat(securityCoverageBreaks)


### PR DESCRIPTION
### Motivation
- Provide a single, shared continuity correlation key set (run, fund account, portfolio snapshot, ledger batch/posting group, reconciliation case) so lineage can be carried end‑to‑end in contracts and UI models.
- Propagate continuity identifiers from reconciliation output into the operations continuity workflow and audit timeline so operator drill‑ins and timeline/audit projections surface lineage.
- Enforce an invariant that reconciliation breaks reference originating run lineage where available to prevent orphaned/reduced lineage during reconciliation processing.

### Description
- Added a shared DTO `OperationsContinuityCorrelationKeysDto` to `src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs` to hold continuity keys (run, fund account, portfolio snapshot, ledger batch/posting group, reconciliation case).
- Extended `OperationsBreakCaseDto`, `OperationsTimelineEntryDto`, and `OperationsWorkflowAuditDto` to carry `CorrelationKeys` so timeline/audit projections include continuity metadata.
- Extended `ReconciliationBreakDto` to include `CorrelationKeys` to allow reconciliation engine output to carry lineage through the bridge.
- Propagated correlation keys in `OperationsContinuityReconciliationBridge` when mapping `ReconciliationRunDetail` into `OperationsBreakCaseDto`, with a fallback that seeds `RunId` + `ReconciliationCaseId` when upstream keys are missing.
- Added `EnsureBreakCaseLineage` invariant in `OperationsContinuityWorkflow.RunReconciliation` to require `RunId` lineage on every reconciliation break and throw a clear `InvalidOperationException` when missing.
- Included `CorrelationKeys` in `OperationsWorkflowAuditDraft` and the canonical audit hash computation in `OperationsWorkflowAuditHashing` so continuity keys are part of append-only audit content and integrity checks.
- Updated application repository/draft types to accept the new `CorrelationKeys` field.

### Testing
- Attempted to run targeted unit tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~OperationsContinuityWorkflowServiceTests|FullyQualifiedName~WorkstationEndpointsTests" --logger "console;verbosity=minimal"` but the run failed in the environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`).
- No other automated test runs were executed in this environment; the change is committed and ready for CI validation where the full .NET toolchain is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a175f5960e88320bc3d86a3bab6f4ea)