### PR TITLE
Unify portfolio/ledger workflow status with drift detection and remediation hints

### DIFF
--- a/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
+++ b/src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs
@@ -35,6 +35,27 @@ public enum TradingAcceptanceGateStatusDto
     Unknown = 99
 }
 
+[JsonConverter(typeof(JsonStringEnumConverter<PortfolioLedgerWorkflowStatusDto>))]
+public enum PortfolioLedgerWorkflowStatusDto
+{
+    Ready = 0,
+    Partial = 1,
+    Blocked = 2,
+    DriftDetected = 3,
+    AwaitingReconciliation = 4
+}
+
+public sealed record PortfolioLedgerDriftDto(
+    string DriftType,
+    string Detail,
+    string RemediationHint);
+
+public sealed record PortfolioLedgerWorkflowStatusSnapshotDto(
+    PortfolioLedgerWorkflowStatusDto PortfolioLedgerReview,
+    PortfolioLedgerWorkflowStatusDto Reconciliation,
+    IReadOnlyList<PortfolioLedgerDriftDto> Drifts,
+    string Summary);
+
 public sealed record OperatorWorkItemDto(
     string WorkItemId,
     OperatorWorkItemKindDto Kind,
@@ -310,6 +331,8 @@ public sealed record TradingOperatorReadinessDto(
     public string SnapshotVersion { get; init; } = string.Empty;
 
     public ProviderPromotionChecklistDto? ProviderPromotionChecklist { get; init; }
+
+    public PortfolioLedgerWorkflowStatusSnapshotDto? PortfolioLedgerWorkflowStatus { get; init; }
 }
 
 public sealed record StrategyRunReviewPacketDto(

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -2599,7 +2599,7 @@ public static partial class WorkstationEndpoints
             CriticalCount: criticalCount,
             WarningCount: warningCount,
             ReviewCount: reviewCount,
-            Summary: BuildOperatorInboxSummary(items, criticalCount, warningCount));
+            Summary: BuildOperatorInboxSummary(items, criticalCount, warningCount, readiness.PortfolioLedgerWorkflowStatus));
     }
 
     private static void RecordOperatorInboxContinuityMetrics(IReadOnlyList<OperatorWorkItemDto> items)
@@ -2844,7 +2844,8 @@ public static partial class WorkstationEndpoints
     private static string BuildOperatorInboxSummary(
         IReadOnlyCollection<OperatorWorkItemDto> items,
         int criticalCount,
-        int warningCount)
+        int warningCount,
+        PortfolioLedgerWorkflowStatusSnapshotDto? statusSnapshot)
     {
         if (items.Count == 0)
         {
@@ -2853,15 +2854,15 @@ public static partial class WorkstationEndpoints
 
         if (criticalCount > 0)
         {
-            return $"{criticalCount} critical and {warningCount} warning work item(s) need review.";
+            return $"{criticalCount} critical and {warningCount} warning work item(s) need review. {statusSnapshot?.Summary}".Trim();
         }
 
         if (warningCount > 0)
         {
-            return $"{warningCount} warning work item(s) need review.";
+            return $"{warningCount} warning work item(s) need review. {statusSnapshot?.Summary}".Trim();
         }
 
-        return $"{items.Count} informational work item(s) are available.";
+        return $"{items.Count} informational work item(s) are available. {statusSnapshot?.Summary}".Trim();
     }
 
     private static string BuildOperatorInboxScopedId(string prefix, string scope)

--- a/src/Meridian.Ui.Shared/Services/PortfolioLedgerWorkflowStatusService.cs
+++ b/src/Meridian.Ui.Shared/Services/PortfolioLedgerWorkflowStatusService.cs
@@ -1,0 +1,63 @@
+using Meridian.Contracts.Workstation;
+
+namespace Meridian.Ui.Shared.Services;
+
+public static class PortfolioLedgerWorkflowStatusService
+{
+    public static PortfolioLedgerWorkflowStatusSnapshotDto Compute(
+        IReadOnlyList<TradingAcceptanceGateDto> acceptanceGates,
+        IReadOnlyList<OperatorWorkItemDto> workItems)
+    {
+        var drifts = new List<PortfolioLedgerDriftDto>();
+        if (acceptanceGates.Any(static g => g.GateId == "replay" && g.Status != TradingAcceptanceGateStatusDto.Ready))
+        {
+            drifts.Add(new PortfolioLedgerDriftDto(
+                "positions",
+                "Replay evidence no longer aligns with active session position/order coverage.",
+                "Rerun replay verification for the active paper session."));
+        }
+
+        if (workItems.Any(static w => w.Kind == OperatorWorkItemKindDto.BrokerageSync && w.Tone != OperatorWorkItemToneDto.Success))
+        {
+            drifts.Add(new PortfolioLedgerDriftDto(
+                "cash",
+                "Brokerage synchronization indicates stale or degraded balance alignment.",
+                "Refresh brokerage sync and confirm account cash totals before acceptance."));
+        }
+
+        if (workItems.Any(static w => w.Kind == OperatorWorkItemKindDto.ReconciliationBreak && w.Tone is OperatorWorkItemToneDto.Warning or OperatorWorkItemToneDto.Critical))
+        {
+            drifts.Add(new PortfolioLedgerDriftDto(
+                "ledger-postings",
+                "Open reconciliation exceptions indicate ledger posting mismatch risk.",
+                "Resolve or sign off open reconciliation breaks and rerun reconciliation evidence."));
+        }
+
+        var reconciliationGate = acceptanceGates.FirstOrDefault(static g => g.GateId == "reconciliation");
+        var reviewGate = acceptanceGates.FirstOrDefault(static g => g.GateId == "report-pack");
+
+        var portfolio = drifts.Count > 0
+            ? PortfolioLedgerWorkflowStatusDto.DriftDetected
+            : MapGateStatus(reviewGate?.Status ?? TradingAcceptanceGateStatusDto.Unknown, awaitReconOnReview: false);
+
+        var reconciliation = drifts.Any(d => d.DriftType == "ledger-postings")
+            ? PortfolioLedgerWorkflowStatusDto.AwaitingReconciliation
+            : MapGateStatus(reconciliationGate?.Status ?? TradingAcceptanceGateStatusDto.Unknown, awaitReconOnReview: true);
+
+        var summary = drifts.Count == 0
+            ? "Portfolio/ledger workflow posture is aligned with shared acceptance evidence."
+            : $"{drifts.Count} drift signal(s) require remediation before promoting portfolio/ledger readiness.";
+
+        return new PortfolioLedgerWorkflowStatusSnapshotDto(portfolio, reconciliation, drifts, summary);
+    }
+
+    private static PortfolioLedgerWorkflowStatusDto MapGateStatus(TradingAcceptanceGateStatusDto status, bool awaitReconOnReview)
+        => status switch
+        {
+            TradingAcceptanceGateStatusDto.Ready => PortfolioLedgerWorkflowStatusDto.Ready,
+            TradingAcceptanceGateStatusDto.Blocked => PortfolioLedgerWorkflowStatusDto.Blocked,
+            TradingAcceptanceGateStatusDto.ReviewRequired when awaitReconOnReview => PortfolioLedgerWorkflowStatusDto.AwaitingReconciliation,
+            TradingAcceptanceGateStatusDto.ReviewRequired => PortfolioLedgerWorkflowStatusDto.Partial,
+            _ => PortfolioLedgerWorkflowStatusDto.Partial
+        };
+}

--- a/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
@@ -85,6 +85,7 @@ public sealed class TradingOperatorReadinessService
             riskRuleStatuses,
             auditEntries);
         var overallStatus = EvaluateOverallPosture(acceptanceGates);
+        var portfolioLedgerWorkflowStatus = PortfolioLedgerWorkflowStatusService.Compute(acceptanceGates, workItems);
         var evidenceCompleteness = BuildEvidenceCompleteness(acceptanceGates, workItems);
         var warnings = BuildWarnings(workItems);
         var snapshotVersion = BuildSnapshotVersion(
@@ -124,7 +125,8 @@ public sealed class TradingOperatorReadinessService
             ReportPack = reportPack,
             SnapshotMaterializedAt = asOf,
             SnapshotVersion = snapshotVersion,
-            ProviderPromotionChecklist = BuildProviderPromotionChecklist(trustGate, replay, asOf)
+            ProviderPromotionChecklist = BuildProviderPromotionChecklist(trustGate, replay, asOf),
+            PortfolioLedgerWorkflowStatus = portfolioLedgerWorkflowStatus
         };
 
         ValidateRequiredReadinessFields(readiness);


### PR DESCRIPTION
### Motivation
- Provide a single, shared portfolio/ledger status model consumed by trading readiness and operator inbox projections so clients do not reinterpret local readiness gates.
- Surface explicit drift detection for key totals (positions, cash, ledger postings) and map each drift to a remediation hint to guide operator actions.
- Ensure the portfolio/ledger review and reconciliation stages are available as gate-level evidence for acceptance flows and inbox summaries.

### Description
- Added new DTOs to the readiness contract: `PortfolioLedgerWorkflowStatusDto`, `PortfolioLedgerDriftDto`, and `PortfolioLedgerWorkflowStatusSnapshotDto` in `src/Meridian.Contracts/Workstation/TradingOperatorReadinessDtos.cs` to represent unified workflow states and drift hints.
- Implemented `PortfolioLedgerWorkflowStatusService` in `src/Meridian.Ui.Shared/Services/PortfolioLedgerWorkflowStatusService.cs` which computes `PortfolioLedgerWorkflowStatusSnapshotDto` from shared `acceptanceGates` and `workItems` and emits drift entries for `positions`, `cash`, and `ledger-postings` with remediation hints.
- Wired the unified status into the trading readiness projection by calling `PortfolioLedgerWorkflowStatusService.Compute(...)` and attaching the result to `TradingOperatorReadinessDto.PortfolioLedgerWorkflowStatus` in `src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs`.
- Updated operator inbox summary generation to include the unified `PortfolioLedgerWorkflowStatus` snapshot so inbox text and navigation use the same canonical view in `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs`.

### Testing
- Attempted to run the focused endpoint readiness tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~MapWorkstationEndpoints_TradingReadiness" --logger "console;verbosity=minimal"`, but the run was blocked because the environment lacks the .NET SDK (`/bin/bash: dotnet: command not found`).
- No automated tests were executed successfully in this environment due to the missing `dotnet` CLI; code compiles locally in a normal dev environment should be validated by running the same focused test filter and broader test suite (`make test` / `dotnet test`) before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a175f5ab80083208cb0d6a3157be35b)