### PR TITLE
Add policy-backed close controls and governed reopen requirements

### DIFF
--- a/src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflow.cs
+++ b/src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflow.cs
@@ -520,7 +520,7 @@ public sealed class OperationsContinuityWorkflow
         {
             blockers.Add(new OperationsWorkflowBlockerDto(
                 "LEDGER_PERIOD_CLOSED",
-                "Ledger posting into a closed or hard-closed period requires a governed adjustment path.",
+                "Ledger posting into a closed or hard-closed period requires a governed reopen path before adjustment posting.",
                 OperationsGateKeyDto.LedgerPosting,
                 "Critical",
                 evidenceLinks));
@@ -802,6 +802,16 @@ public sealed class OperationsContinuityWorkflow
             return CreateReportPackMismatchBlocker(request.ReportPackId);
         }
 
+        if (request.ChecklistControlApprovals is null || request.ChecklistControlApprovals.Count == 0)
+        {
+            return new OperationsWorkflowBlockerDto(
+                "CLOSE_CHECKLIST_CONTROL_APPROVALS_REQUIRED",
+                "Close orchestration requires control approvals for close checklist items.",
+                OperationsGateKeyDto.Approval,
+                "Critical",
+                []);
+        }
+
         return null;
     }
 
@@ -872,6 +882,16 @@ public sealed class OperationsContinuityWorkflow
         if (!IsRequestedReportPackReady(request.ReportPackId))
         {
             return CreateReportPackMismatchBlocker(request.ReportPackId);
+        }
+
+        if (request.ChecklistControlApprovals is null || request.ChecklistControlApprovals.Count == 0)
+        {
+            return new OperationsWorkflowBlockerDto(
+                "CLOSE_CHECKLIST_CONTROL_APPROVALS_REQUIRED",
+                "Close orchestration requires control approvals for close checklist items.",
+                OperationsGateKeyDto.Approval,
+                "Critical",
+                []);
         }
 
         return null;
@@ -1010,11 +1030,14 @@ public sealed class OperationsContinuityWorkflow
 
         if (!request.IsGovernedAdmin ||
             string.IsNullOrWhiteSpace(request.Rationale) ||
-            string.IsNullOrWhiteSpace(request.IncidentId))
+            string.IsNullOrWhiteSpace(request.IncidentId) ||
+            string.IsNullOrWhiteSpace(request.Justification) ||
+            string.IsNullOrWhiteSpace(request.ApprovalReference) ||
+            string.IsNullOrWhiteSpace(request.ImpactSummary))
         {
             return new OperationsWorkflowBlockerDto(
                 "REOPEN_GOVERNANCE_METADATA_REQUIRED",
-                "Reopening requires governed administrator authority, rationale, and linked incident metadata.",
+                "Reopening requires governed administrator authority, rationale, incident metadata, justification, approval reference, and impact summary.",
                 OperationsGateKeyDto.Approval,
                 "Critical",
                 []);

--- a/src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflowService.cs
+++ b/src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflowService.cs
@@ -1092,6 +1092,9 @@ public sealed class OperationsContinuityWorkflowService : IOperationsContinuityW
                 gate.GateKey,
                 $"{DisplayName(gate.GateKey)} close gate",
                 gate.CompletedBy ?? "accounting-operator",
+                RequiredEvidence: "Evidence link and gate completion audit",
+                RequiredApprovalCount: gate.GateKey == OperationsGateKeyDto.Approval ? 2 : 1,
+                ExpiresOn: dueBase.AddDays(index + 5),
                 dueBase.AddDays(index),
                 status,
                 gate.Blockers.FirstOrDefault()?.Message,
@@ -1291,7 +1294,7 @@ public sealed class OperationsContinuityWorkflowService : IOperationsContinuityW
         {
             blockers.Add(new OperationsWorkflowBlockerDto(
                 "LEDGER_PERIOD_CLOSED",
-                "Ledger posting into a closed or hard-closed period requires a governed adjustment path.",
+                "Ledger posting into a closed or hard-closed period requires a governed reopen path before adjustment posting.",
                 OperationsGateKeyDto.LedgerPosting,
                 "Critical",
                 evidenceLinks));

--- a/src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs
+++ b/src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs
@@ -568,6 +568,7 @@ public sealed record OperationsCloseWorkflowRequestDto(
     string Actor,
     string Rationale,
     string ReportPackId,
+    IReadOnlyList<OperationsChecklistControlApprovalDto>? ChecklistControlApprovals = null,
     string? CorrelationId = null,
     IReadOnlyList<OperationsEvidenceLinkDto>? EvidenceLinks = null);
 
@@ -577,8 +578,16 @@ public sealed record OperationsReopenWorkflowRequestDto(
     string Rationale,
     string IncidentId,
     bool IsGovernedAdmin,
+    string? Justification = null,
+    string? ApprovalReference = null,
+    string? ImpactSummary = null,
     string? CorrelationId = null,
     IReadOnlyList<OperationsEvidenceLinkDto>? EvidenceLinks = null);
+
+public sealed record OperationsChecklistControlApprovalDto(
+    string TaskId,
+    string ApprovedBy,
+    DateTimeOffset ApprovedAtUtc);
 
 public sealed record OperationsTransitionResultDto(
     bool Success,
@@ -635,6 +644,9 @@ public sealed record OperationsCloseChecklistTaskDto(
     OperationsGateKeyDto Gate,
     string Label,
     string Owner,
+    string RequiredEvidence,
+    int RequiredApprovalCount,
+    DateOnly? ExpiresOn,
     DateOnly? DueDate,
     string Status,
     string? BlockingReason,


### PR DESCRIPTION
### Motivation
- Represent close checklist items as policy-backed controls so close requires explicit evidence and approvals before finalization. 
- Enforce a governed reopen path that requires justification, approval reference, and an impact summary when reopening a closed workflow. 
- Ensure ledger posting guards clearly route closed-period posting attempts through governed reopen flows, and surface richer control posture to operator inbox/reporting surfaces.

### Description
- Added checklist control payloads and richer checklist task shape by extending `OperationsCloseWorkflowRequestDto`, `OperationsReopenWorkflowRequestDto`, and `OperationsCloseChecklistTaskDto` with control/approval metadata (`ChecklistControlApprovals`, `Justification`, `ApprovalReference`, `ImpactSummary`, `RequiredEvidence`, `RequiredApprovalCount`, `ExpiresOn`). (`src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs`)
- Block final close and approval transitions unless control approvals are provided by validating `ChecklistControlApprovals` in `GetCloseTransitionBlocker`/approval checks. (`src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflow.cs`)
- Emit control posture on the close checklist projection by populating `RequiredEvidence`, `RequiredApprovalCount`, and `ExpiresOn` in `BuildChecklist` so operator inbox and reporting surfaces can show blocker-level detail. (`src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflowService.cs`)
- Strengthened reopen validation to require `Justification`, `ApprovalReference`, and `ImpactSummary` and updated ledger closed-period blocker messaging to direct adjustments through a governed reopen flow. (`src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflow.cs`, `src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflowService.cs`)

### Testing
- Attempted to run focused integration/unit tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~OperationsContinuityWorkflowServiceTests"`, but the environment does not have `dotnet` installed so the test run could not be executed (`bash: command not found: dotnet`).
- Existing `OperationsContinuityWorkflowService` and endpoint tests reference the close/reopen flows and should be exercised in CI or a developer environment with the .NET SDK to validate close success, blocked close, reopen approved/denied, and ledger-posting guards.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a175f5cd4a88320aa5d82cecf3e8a81)