### PR TITLE
Fail-closed on stale replay freshness in trading readiness

### DIFF
--- a/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
@@ -253,19 +253,23 @@ public sealed class TradingOperatorReadinessService
                 workItemId: BuildWorkItemId("paper-replay-mismatch", replay.SessionId),
                 scope: replay.SessionId);
         }
-        else if (IsReplayCoverageStale(activeSession, replay))
+        else
         {
-            PrometheusMetrics.RecordRunContinuityStaleProjection("api", "replay-stale");
-            AddWorkItem(
-                workItems,
-                OperatorWorkItemKindDto.PaperReplay,
-                "Paper replay verification stale",
-                BuildReplayCoverageDetail(activeSession, replay),
-                OperatorWorkItemToneDto.Warning,
-                replay.SessionId,
-                auditReference: replay.VerificationAuditId,
-                workItemId: BuildWorkItemId("paper-replay-stale", replay.SessionId),
-                scope: replay.SessionId);
+            var replayFreshness = EvaluateReplayFreshness(activeSession, replay);
+            if (replayFreshness.IsStale)
+            {
+                PrometheusMetrics.RecordRunContinuityStaleProjection("api", "replay-stale");
+                AddWorkItem(
+                    workItems,
+                    OperatorWorkItemKindDto.PaperReplay,
+                    "Paper replay verification stale",
+                    replayFreshness.Detail,
+                    OperatorWorkItemToneDto.Critical,
+                    replay.SessionId,
+                    auditReference: replay.VerificationAuditId,
+                    workItemId: BuildWorkItemId("paper-replay-stale", replay.SessionId),
+                    scope: replay.SessionId);
+            }
         }
 
         return new PaperSessionReadiness(sessions, activeSession, replay);
@@ -1209,15 +1213,18 @@ public sealed class TradingOperatorReadinessService
                 AuditReference: replay.VerificationAuditId);
         }
 
-        if (IsReplayCoverageStale(activeSession, replay))
+        var replayFreshness = EvaluateReplayFreshness(activeSession, replay);
+        if (replayFreshness.IsStale)
         {
             return new TradingAcceptanceGateDto(
                 GateId: "replay",
                 Label: "Replay verified",
-                Status: TradingAcceptanceGateStatusDto.ReviewRequired,
-                Detail: BuildReplayCoverageDetail(activeSession, replay),
+                Status: TradingAcceptanceGateStatusDto.Blocked,
+                Detail: replayFreshness.Detail,
                 SessionId: replay.SessionId,
-                AuditReference: replay.VerificationAuditId);
+                AuditReference: replay.VerificationAuditId,
+                Reason: "REPLAY_FRESHNESS_STALE",
+                RequiredNextAction: replayFreshness.RequiredNextAction);
         }
 
         return new TradingAcceptanceGateDto(
@@ -1229,43 +1236,23 @@ public sealed class TradingOperatorReadinessService
             AuditReference: replay.VerificationAuditId);
     }
 
-    private static bool IsReplayCoverageStale(
-        TradingPaperSessionReadinessDto activeSession,
-        TradingReplayReadinessDto replay)
-        => !string.Equals(activeSession.SessionId, replay.SessionId, StringComparison.OrdinalIgnoreCase) ||
-           activeSession.FillCount != replay.ComparedFillCount ||
-           activeSession.OrderCount != replay.ComparedOrderCount ||
-           activeSession.LedgerEntryCount != replay.ComparedLedgerEntryCount;
-
-    private static string BuildReplayCoverageDetail(
+    private static ReplayFreshnessEvaluation EvaluateReplayFreshness(
         TradingPaperSessionReadinessDto activeSession,
         TradingReplayReadinessDto replay)
     {
-        if (!string.Equals(activeSession.SessionId, replay.SessionId, StringComparison.OrdinalIgnoreCase))
-        {
-            return $"Replay verification covers session {replay.SessionId}, but the active paper session is {activeSession.SessionId}.";
-        }
-
-        var differences = new List<string>(capacity: 3);
-        if (activeSession.FillCount != replay.ComparedFillCount)
-        {
-            differences.Add($"fills active={activeSession.FillCount}, verified={replay.ComparedFillCount}");
-        }
-
-        if (activeSession.OrderCount != replay.ComparedOrderCount)
-        {
-            differences.Add($"orders active={activeSession.OrderCount}, verified={replay.ComparedOrderCount}");
-        }
-
-        if (activeSession.LedgerEntryCount != replay.ComparedLedgerEntryCount)
-        {
-            differences.Add($"ledger active={activeSession.LedgerEntryCount}, verified={replay.ComparedLedgerEntryCount}");
-        }
-
-        return differences.Count == 0
-            ? $"Replay verification for paper session {activeSession.SessionId} is no longer aligned with the active session."
-            : $"Replay verification for paper session {activeSession.SessionId} is stale ({string.Join("; ", differences)}). Run replay verification again before accepting cockpit readiness.";
+        var drift = ReplayDriftDetector.Assess(
+            activeSession.SessionId,
+            activeSession.FillCount,
+            activeSession.OrderCount,
+            activeSession.LedgerEntryCount,
+            replay.SessionId,
+            replay.ComparedFillCount,
+            replay.ComparedOrderCount,
+            replay.ComparedLedgerEntryCount);
+        return new ReplayFreshnessEvaluation(drift.IsDrifted, drift.Detail, drift.RequiredNextAction);
     }
+
+    private sealed record ReplayFreshnessEvaluation(bool IsStale, string Detail, string RequiredNextAction);
 
     private static TradingAcceptanceGateDto BuildAuditControlGate(
         TradingControlReadinessDto controls,


### PR DESCRIPTION
### Motivation
- Ensure a single authoritative replay-freshness evaluator compares active session counters against the last verification audit so readiness projection uses one source of truth.
- Enforce fail-closed behavior when replay freshness is stale so the trading cockpit and operator inbox surface explicit, actionable blockers instead of soft warnings.
- Surface canonical drift detail and operator next-action hints so inbox navigation and acceptance gates direct operators to rerun replay or repair brokerage sync.

### Description
- Added `EvaluateReplayFreshness(...)` in `TradingOperatorReadinessService` that delegates to `ReplayDriftDetector.Assess(...)` and returns a `ReplayFreshnessEvaluation` record. (file: `src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs`)
- Replaced prior coverage-stale branching with the centralized freshness check and used its `Detail` and `RequiredNextAction` for work-item text and gate guidance.
- Changed replay acceptance gate behavior so stale freshness now yields `TradingAcceptanceGateStatusDto.Blocked`, sets `Reason: "REPLAY_FRESHNESS_STALE"`, and populates `RequiredNextAction` from the evaluator.
- Elevated stale-replay operator work items to `Critical` tone and recorded the stale projection with `PrometheusMetrics.RecordRunContinuityStaleProjection("api", "replay-stale")` to make inbox blocking explicit and actionable.

### Testing
- Intended focused endpoint/unit validation: `MapWorkstationEndpoints_TradingReadiness_ShouldRequireReplayRefreshWhenSessionChangesAfterVerification` and `MapWorkstationEndpoints_OperatorInbox_ShouldProjectTradingReadinessWorkItemsWithNavigation` via filtered test run against `tests/Meridian.Tests/Meridian.Tests.csproj`.
- Attempt to run the focused `dotnet test` failed in this environment because the `dotnet` runtime is not available (`/bin/bash: dotnet: command not found`), so automated tests were not executed here.
- Manual code inspection and static checks performed locally against the changed file to ensure the new evaluator is used consistently and required DTO fields (`Reason`, `RequiredNextAction`) are populated where applicable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a175f57f67483208377494ff75dd3a2)