### PR TITLE
[PR #1713 follow-up] Add checklist control approvals to approval DTOs

### DIFF
--- a/src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs
+++ b/src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs
@@ -542,6 +542,7 @@ public sealed record OperationsSubmitApprovalRequestDto(
     string Reviewer,
     string Rationale,
     string ReportPackId,
+    IReadOnlyList<OperationsChecklistControlApprovalDto>? ChecklistControlApprovals = null,
     string? CorrelationId = null,
     IReadOnlyList<OperationsEvidenceLinkDto>? EvidenceLinks = null);
 
@@ -551,6 +552,7 @@ public sealed record OperationsApprovalDecisionRequestDto(
     string Reviewer,
     string Rationale,
     string ReportPackId,
+    IReadOnlyList<OperationsChecklistControlApprovalDto>? ChecklistControlApprovals = null,
     string? CorrelationId = null,
     IReadOnlyList<OperationsEvidenceLinkDto>? EvidenceLinks = null);
 


### PR DESCRIPTION
### Motivation
- Workflow guards in `OperationsContinuityWorkflow` reference `ChecklistControlApprovals` on approval requests, but the approval DTOs did not include that member, causing a P1 build break; the change aligns the contract shape with the guard logic so approval flows can carry checklist control approvals.

### Description
- Added `IReadOnlyList<OperationsChecklistControlApprovalDto>? ChecklistControlApprovals = null` to `OperationsSubmitApprovalRequestDto` and `OperationsApprovalDecisionRequestDto` in `src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs` so the DTOs match the checks performed by `GetSubmitForApprovalTransitionBlocker` and `GetApproveTransitionBlocker`.

### Testing
- Attempted to run the focused test filter `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~OperationsContinuityWorkflowServiceTests"`, but the test run could not be executed in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17618e16d48320bde2205eea581808)