### PR TITLE
Follow-up: add checklist control approvals to approval DTOs

### DIFF
--- a/src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs
+++ b/src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs
@@ -542,6 +542,7 @@ public sealed record OperationsSubmitApprovalRequestDto(
     string Reviewer,
     string Rationale,
     string ReportPackId,
+    IReadOnlyList<OperationsChecklistControlApprovalDto>? ChecklistControlApprovals = null,
     string? CorrelationId = null,
     IReadOnlyList<OperationsEvidenceLinkDto>? EvidenceLinks = null);
 
@@ -551,6 +552,7 @@ public sealed record OperationsApprovalDecisionRequestDto(
     string Reviewer,
     string Rationale,
     string ReportPackId,
+    IReadOnlyList<OperationsChecklistControlApprovalDto>? ChecklistControlApprovals = null,
     string? CorrelationId = null,
     IReadOnlyList<OperationsEvidenceLinkDto>? EvidenceLinks = null);
 


### PR DESCRIPTION
### Motivation
- Fix a high-priority compile/runtime mismatch where approval transition guards reference `ChecklistControlApprovals` but the approval request DTOs did not include that field, causing `Meridian.Application` to fail to build.

### Description
- Add `ChecklistControlApprovals` to `OperationsSubmitApprovalRequestDto` and `OperationsApprovalDecisionRequestDto` in `src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs` so the approval payload matches the workflow guard expectations.

### Testing
- Verified the DTO file was updated and committed (`git status` / inspected `src/Meridian.Contracts/Workstation/OperationsContinuityDtos.cs`) and created a follow-up PR to apply the change, and no `dotnet` build/tests were run in this environment because the .NET SDK is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1761a9f030832088125dc35327c696)