### PR TITLE
[PR #1709 Follow-up] Fix report-pack submit transition to PendingApproval

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
@@ -523,7 +523,7 @@ public static class FundStructureEndpoints
             return svc is null ? WorkspaceServiceUnavailable() : Results.Json(svc.Create(fundProfileId, fundAccountId, period, templateId, actor), jsonOptions, statusCode: StatusCodes.Status201Created);
         });
 
-        group.MapPost("/reporting/packs/{reportId:guid}/submit", (Guid reportId, string actor, string role, HttpContext context) => TransitionPack(context, reportId, ReportPackWorkflowStateDto.InReview, actor, role));
+        group.MapPost("/reporting/packs/{reportId:guid}/submit", (Guid reportId, string actor, string role, HttpContext context) => TransitionPack(context, reportId, ReportPackWorkflowStateDto.PendingApproval, actor, role));
         group.MapPost("/reporting/packs/{reportId:guid}/approve", (Guid reportId, string actor, string role, HttpContext context) => TransitionPack(context, reportId, ReportPackWorkflowStateDto.Approved, actor, role));
         group.MapPost("/reporting/packs/{reportId:guid}/publish", (Guid reportId, string actor, string role, HttpContext context) => TransitionPack(context, reportId, ReportPackWorkflowStateDto.Published, actor, role));
 


### PR DESCRIPTION
### Motivation
- Repair a P1 regression where the submit endpoint still referenced the removed `InReview` lifecycle state, leaving `/reporting/packs/{id}/submit` without a valid transition target after the workflow enum was changed.

### Description
- Updated the submit route mapping in `src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs` to call `TransitionPack(..., ReportPackWorkflowStateDto.PendingApproval, ...)` instead of the removed `ReportPackWorkflowStateDto.InReview`.

### Testing
- Attempted to run the focused test filter `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ReportPackWorkflowServiceTests"`, but the environment lacks the `dotnet` SDK so automated tests could not be executed here (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a176193c3a88320bfbe81171a7c1a89)