### PR TITLE
Fix resolve audit actor in FileReconciliationBreakQueueRepository

### DIFF
--- a/src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs
+++ b/src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs
@@ -219,7 +219,7 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 ExternalAccountId: updated.ExternalAccountId,
                 CustodianId: updated.CustodianId,
                 UpstreamSyncCursor: updated.UpstreamSyncCursor,
-                Actor: request.ReviewedBy,
+                Actor: request.ResolvedBy,
                 BeforePayload: JsonSerializer.Serialize(item, _jsonOptions),
                 AfterPayload: JsonSerializer.Serialize(updated, _jsonOptions)), ct).ConfigureAwait(false);
 


### PR DESCRIPTION
### Motivation
- Fix a compile-blocking regression where the resolve/close audit event used `request.ReviewedBy` even though `ResolveReconciliationBreakRequest` exposes `ResolvedBy`, which caused the strategies project to fail to compile.

### Description
- Replace `Actor: request.ReviewedBy` with `Actor: request.ResolvedBy` in `src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs` and commit the change.

### Testing
- Attempted the focused unit test `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ReconciliationBreakQueueRepositoryTests"`, but the run could not execute because the environment does not have the `dotnet` CLI installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1762c26e608320817c892590350727)