### PR TITLE
Restore reconciliation contract catalog compatibility

### DIFF
--- a/src/Meridian.Application/Reconciliation/ReconciliationContractCatalog.cs
+++ b/src/Meridian.Application/Reconciliation/ReconciliationContractCatalog.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+
+namespace Meridian.Application.Reconciliation;
+
+public enum ReconciliationContractVersion
+{
+    V1 = 1,
+}
+
+public static class ReconciliationContractCatalog
+{
+    public const string BreakWorkflowContract = "meridian.reconciliation.break-workflow";
+
+    private static readonly IReadOnlyDictionary<string, ReconciliationContractVersion> SupportedContracts =
+        new Dictionary<string, ReconciliationContractVersion>(StringComparer.Ordinal)
+        {
+            [BreakWorkflowContract] = ReconciliationContractVersion.V1,
+        };
+
+    public static bool IsSupported(string contractName, ReconciliationContractVersion requestedVersion)
+    {
+        if (string.IsNullOrWhiteSpace(contractName))
+        {
+            return false;
+        }
+
+        return SupportedContracts.TryGetValue(contractName, out var supportedVersion)
+               && supportedVersion == requestedVersion;
+    }
+}


### PR DESCRIPTION
### Motivation

- Restore compile-time compatibility for existing tests and callers after the reconciliation contract catalog/version types were removed during the reconciliation API refactor.

### Description

- Reintroduced `ReconciliationContractVersion` and `ReconciliationContractCatalog` in `src/Meridian.Application/Reconciliation/ReconciliationContractCatalog.cs` and added the known identifier `BreakWorkflowContract` and a supported-contract map pinned to `V1`.
- Implemented `IsSupported(string contractName, ReconciliationContractVersion requestedVersion)` with guards for empty/unknown contract names and exact-version matching.

### Testing

- Attempted to run the focused test command `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ReconciliationContractsTests"`, but the environment lacks the `dotnet` tool and the run failed with `/bin/bash: dotnet: command not found`.
- The fix was committed on the branch as `cbe536e9`; CI should run the full test suite to validate compilation and behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1762d311e08320adf8afe178ae782b)