### PR TITLE
Scope canonical-subject validation to vault-retained artifacts

### DIFF
--- a/src/Meridian.Ui.Shared/Evidence/EvidencePacketValidationService.cs
+++ b/src/Meridian.Ui.Shared/Evidence/EvidencePacketValidationService.cs
@@ -308,6 +308,12 @@ public sealed class EvidencePacketValidationService
         {
             foreach (var artifact in node.ArtifactRefs.Where(static artifact => artifact.Retained))
             {
+                var hasVaultRetentionLocator = !string.IsNullOrWhiteSpace(artifact.Path);
+                if (!hasVaultRetentionLocator)
+                {
+                    continue;
+                }
+
                 if (string.IsNullOrWhiteSpace(artifact.CanonicalSubjectKind) || string.IsNullOrWhiteSpace(artifact.CanonicalSubjectId))
                 {
                     issues.Add(new EvidenceValidationIssueDto(

--- a/tests/Meridian.Tests/Ui/EvidenceWorkflowFabricTests.cs
+++ b/tests/Meridian.Tests/Ui/EvidenceWorkflowFabricTests.cs
@@ -277,6 +277,33 @@ public sealed class EvidenceWorkflowFabricTests
             issue.Severity == EvidenceValidationSeverityDto.Critical);
     }
 
+
+    [Fact]
+    public void EvidencePacketValidationService_DoesNotBlockRetainedRouteArtifactsWithoutCanonicalSubject()
+    {
+        var subject = Subject(EvidenceSubjectResolver.ReportPackKind, "current");
+        var node = Node(
+            subject,
+            "report",
+            "report-pack",
+            EvidenceStatusDto.Ready,
+            artifacts:
+            [
+                new EvidenceArtifactRefDto("a1", "report-pack", null, "/api/workstation/evidence/export/manifest", DateTimeOffset.UtcNow, null, true)
+            ]);
+        var service = new EvidencePacketValidationService();
+
+        var result = service.Validate(
+            [node],
+            [],
+            new HashSet<string>(["report"], StringComparer.OrdinalIgnoreCase),
+            enforceNoOrphanRule: false);
+
+        result.Completeness.Status.Should().Be(EvidenceStatusDto.Ready);
+        result.Completeness.ValidationIssues.Should().NotContain(issue =>
+            issue.Code == "retained-artifact-missing-canonical-subject");
+    }
+
     [Fact]
     public async Task EvidenceGraphService_DuringCancelledReview_PreservesCancellation()
     {


### PR DESCRIPTION
### Motivation
- Prevent route-only retained artifact references from being treated as blocking validation failures during evidence packet validation.  
- Preserve the intent to block truly persisted/vault-addressable retained artifacts that are missing canonical subject linkage.  

### Description
- In `EvidencePacketValidationService.ApplyCanonicalSubjectLinkageIssues` only consider retained artifacts that include a vault retention locator by checking `artifact.Path` before enforcing `CanonicalSubjectKind`/`CanonicalSubjectId` linkage.  
- Added a regression test `EvidencePacketValidationService_DoesNotBlockRetainedRouteArtifactsWithoutCanonicalSubject` in `tests/Meridian.Tests/Ui/EvidenceWorkflowFabricTests.cs` to ensure route-only retained artifacts (route set, path null) do not block completeness.  
- Kept existing tests that verify path-based retained artifacts without canonical linkage still produce a blocking `retained-artifact-missing-canonical-subject` issue.  

### Testing
- Added the new unit test `EvidencePacketValidationService_DoesNotBlockRetainedRouteArtifactsWithoutCanonicalSubject` alongside existing `EvidenceWorkflowFabricTests` cases that cover ledger/report-pack artifact behaviors.  
- Attempted to run the focused test slice with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~EvidenceWorkflowFabricTests" --logger "console;verbosity=minimal"`, but the run failed in this environment with `/bin/bash: line 1: dotnet: command not found`.  
- Recommendation: run the same `dotnet test` filter above in CI or a local dev environment with the .NET SDK to validate the new regression test and overall packet validation behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1762d5f85c832096c190d77b2dd198)