### PR TITLE
Follow-up: add validate endpoint to align report-pack submit with new lifecycle

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
@@ -523,6 +523,7 @@ public static class FundStructureEndpoints
             return svc is null ? WorkspaceServiceUnavailable() : Results.Json(svc.Create(fundProfileId, fundAccountId, period, templateId, actor), jsonOptions, statusCode: StatusCodes.Status201Created);
         });
 
+        group.MapPost("/reporting/packs/{reportId:guid}/validate", (Guid reportId, string actor, string role, HttpContext context) => TransitionPack(context, reportId, ReportPackWorkflowStateDto.Validated, actor, role));
         group.MapPost("/reporting/packs/{reportId:guid}/submit", (Guid reportId, string actor, string role, HttpContext context) => TransitionPack(context, reportId, ReportPackWorkflowStateDto.PendingApproval, actor, role));
         group.MapPost("/reporting/packs/{reportId:guid}/approve", (Guid reportId, string actor, string role, HttpContext context) => TransitionPack(context, reportId, ReportPackWorkflowStateDto.Approved, actor, role));
         group.MapPost("/reporting/packs/{reportId:guid}/publish", (Guid reportId, string actor, string role, HttpContext context) => TransitionPack(context, reportId, ReportPackWorkflowStateDto.Published, actor, role));


### PR DESCRIPTION
### Motivation
- Restore a valid transition target after removing `InReview` by aligning the HTTP endpoints with the updated lifecycle (`Draft -> Validated -> PendingApproval -> ...`) so `/reporting/packs/{id}/submit` no longer lacks a valid prior state.

### Description
- Added `POST /reporting/packs/{reportId:guid}/validate` mapped to `ReportPackWorkflowStateDto.Validated` in `src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs` and kept `POST /reporting/packs/{reportId:guid}/submit` mapped to `ReportPackWorkflowStateDto.PendingApproval` to reflect the new state machine.

### Testing
- Attempted a focused test run with `dotnet test` for the `ReportPackWorkflowServiceTests`, but the automation environment lacks the .NET SDK (`dotnet: command not found`), so no automated test results were produced here and CI/local runs should exercise the updated route and `ReportPackWorkflowService` transitions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1762d723a88320a1829377db952be4)