### PR TITLE
[PR #1697 follow-up] Fix resolve audit actor compile break

### DIFF
--- a/src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs
+++ b/src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs
@@ -219,7 +219,7 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 ExternalAccountId: updated.ExternalAccountId,
                 CustodianId: updated.CustodianId,
                 UpstreamSyncCursor: updated.UpstreamSyncCursor,
-                Actor: request.ReviewedBy,
+                Actor: request.ResolvedBy,
                 BeforePayload: JsonSerializer.Serialize(item, _jsonOptions),
                 AfterPayload: JsonSerializer.Serialize(updated, _jsonOptions)), ct).ConfigureAwait(false);
 
@@ -316,7 +316,7 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 ExternalAccountId: updated.ExternalAccountId,
                 CustodianId: updated.CustodianId,
                 UpstreamSyncCursor: updated.UpstreamSyncCursor,
-                Actor: request.ReviewedBy,
+                Actor: request.ResolvedBy,
                 BeforePayload: JsonSerializer.Serialize(item, _jsonOptions),
                 AfterPayload: JsonSerializer.Serialize(updated, _jsonOptions)), ct).ConfigureAwait(false);
 


### PR DESCRIPTION
### Motivation
- Fix a compile-time error in the strategies project where the resolve-path audit event referenced a non-existent `ReviewedBy` property on `ResolveReconciliationBreakRequest` instead of the resolver identity exposed as `ResolvedBy`.

### Description
- Replaced usages of `request.ReviewedBy` with `request.ResolvedBy` when populating the `Actor` field on reconciliation audit events in `src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs` to ensure the resolve/closure audit records use the correct resolver identity.

### Testing
- Attempted focused unit test run with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ReconciliationBreakQueueRepositoryTests"` but the `dotnet` CLI was unavailable in this environment (`dotnet: command not found`), so no automated tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1762f7cfd08320bc6f9bd12e5d197e)