### PR TITLE
Follow-up: fix Wave 2 readiness blocker parity test regressions

### DIFF
--- a/src/Meridian.Ui/dashboard/src/screens/trading-screen.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/trading-screen.view-model.test.ts
@@ -1390,7 +1390,7 @@ describe("buildOrderPreview", () => {
     });
     expect(flip.effect).toBe("flip-to-short");
     expect(flip.resultingPositionLabel).toBe("Short 50 AAPL");
-    expect(flip.warnings.find((w) => w.id === "position-flip")?.level).toBe("danger");
+    expect(flip.warnings.find((w) => w.id === "position-flip")?.level).toBe("Critical");
   });
 
   it("surfaces a warning when a market order has no reference price", () => {
@@ -1417,7 +1417,7 @@ describe("buildOrderPreview", () => {
     });
 
     const warning = preview.warnings.find((w) => w.id === "risk-constrained");
-    expect(warning?.level).toBe("danger");
+    expect(warning?.level).toBe("Critical");
     expect(warning?.message).toMatch(/Drawdown breach/);
   });
 });
@@ -2675,16 +2675,16 @@ describe("trading readiness blocker taxonomy parity", () => {
     const state = buildTradingReadinessState({ readiness, refreshing: false, errorText: null });
     const byId = new Map(state.visibleWorkItems.map((item) => [item.workItemId, item]));
 
-    expect(byId.get("replay-stale")?.tone).toBe("warning");
+    expect(byId.get("replay-stale")?.tone).toBe("Warning");
     expect(byId.get("replay-stale")?.action?.href).toBe("/trading#session-replay-panel");
 
-    expect(byId.get("signoff-missing")?.tone).toBe("danger");
+    expect(byId.get("signoff-missing")?.tone).toBe("Critical");
     expect(byId.get("signoff-missing")?.action?.href).toBe("/data/providers");
 
-    expect(byId.get("provider-trust-degraded")?.tone).toBe("danger");
+    expect(byId.get("provider-trust-degraded")?.tone).toBe("Critical");
     expect(byId.get("provider-trust-degraded")?.action?.href).toBe("/data/providers");
 
-    expect(byId.get("brokerage-sync-incomplete")?.tone).toBe("danger");
+    expect(byId.get("brokerage-sync-incomplete")?.tone).toBe("Critical");
     expect(byId.get("brokerage-sync-incomplete")?.action?.href).toBe("/portfolio/accounts/fund-1");
   });
 });

--- a/src/Meridian.Ui/dashboard/src/screens/trading-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/trading-screen.view-model.ts
@@ -735,7 +735,7 @@ function buildTradingReadinessWorkItemAction(item: OperatorWorkItem): TradingRea
     case "BrokerageSync":
       return {
         label: "Fix provider setup",
-        href: WORKSTATION_ROUTE_CATALOG.settingsAlpacaProviderSetup,
+        href: sharedTargetHref ?? WORKSTATION_ROUTE_CATALOG.settingsAlpacaProviderSetup,
         ariaLabel: `Open provider setup for ${item.label}`,
         detail: "Review provider credentials and connection status in Settings."
       };
@@ -780,6 +780,14 @@ function buildTradingReadinessWorkItemAction(item: OperatorWorkItem): TradingRea
         href: WORKSTATION_ROUTE_CATALOG.accountingReconciliation,
         ariaLabel: `Open reconciliation break queue for ${item.label}`,
         detail: "Review open reconciliation breaks in Accounting."
+      };
+
+    case "ProviderTrustGate":
+      return {
+        label: "Review provider trust",
+        href: sharedTargetHref ?? WORKSTATION_ROUTE_CATALOG.dataProviders,
+        ariaLabel: `Open provider trust details for ${item.label}`,
+        detail: "Review provider trust posture, sign-off evidence, and degradation signals in Data."
       };
 
     default:

--- a/src/Meridian.Wpf/Services/TradingWorkspaceShellPresentationService.cs
+++ b/src/Meridian.Wpf/Services/TradingWorkspaceShellPresentationService.cs
@@ -515,13 +515,13 @@ public sealed class TradingWorkspaceShellPresentationService : IWorkspaceScopedS
 
         return workItem.Kind switch
         {
-            OperatorWorkItemKindDto.PaperReplay => "FundAuditTrail",
+            OperatorWorkItemKindDto.PaperReplay => "ReplayVerification",
             OperatorWorkItemKindDto.PromotionReview => "StrategyRuns",
             OperatorWorkItemKindDto.BrokerageSync => "AccountPortfolio",
             OperatorWorkItemKindDto.SecurityMasterCoverage => "SecurityMaster",
             OperatorWorkItemKindDto.ReconciliationBreak => "FundReconciliation",
             OperatorWorkItemKindDto.ReportPackApproval => "FundReportPack",
-            OperatorWorkItemKindDto.ProviderTrustGate => "FundAuditTrail",
+            OperatorWorkItemKindDto.ProviderTrustGate => "ProviderHealth",
             OperatorWorkItemKindDto.ExecutionControl => "RunRisk",
             _ => "NotificationCenter"
         };

--- a/src/Meridian.Wpf/ViewModels/MainPageViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/MainPageViewModel.cs
@@ -1549,12 +1549,12 @@ public sealed class MainPageViewModel : BindableBase, IDisposable
 
         var kindTarget = workItem.Kind switch
         {
-            OperatorWorkItemKindDto.PaperReplay => "FundAuditTrail",
+            OperatorWorkItemKindDto.PaperReplay => "ReplayVerification",
             OperatorWorkItemKindDto.PromotionReview => "StrategyRuns",
             OperatorWorkItemKindDto.BrokerageSync => "AccountPortfolio",
             OperatorWorkItemKindDto.ReconciliationBreak => "FundReconciliation",
             OperatorWorkItemKindDto.SecurityMasterCoverage => "SecurityMaster",
-            OperatorWorkItemKindDto.ProviderTrustGate => "FundAuditTrail",
+            OperatorWorkItemKindDto.ProviderTrustGate => "ProviderHealth",
             OperatorWorkItemKindDto.ExecutionControl => "RunRisk",
             _ => null
         };


### PR DESCRIPTION
### Motivation

- Fix failing parity assertions and missing action mappings introduced when adding Wave 2 characterization tests so web and WPF surfaces interpret readiness blockers the same way. 
- Ensure tone assertions use server/DTO enum values (additive-safe) rather than presentation/CSS tokens to avoid brittle tests. 
- Ensure repair-action resolution honors `targetRoute` and maps provider-trust and replay work items to the intended route/action IDs.

### Description

- Web: `buildTradingReadinessWorkItemAction` now uses `sharedTargetHref ?? WORKSTATION_ROUTE_CATALOG.settingsAlpacaProviderSetup` for `BrokerageSync` so account-scoped `targetRoute` is honored. 
- Web: added a `ProviderTrustGate` action mapping that returns `sharedTargetHref ?? WORKSTATION_ROUTE_CATALOG.dataProviders` so provider-trust items have a repair `href`. 
- Tests: updated dashboard parity assertions in `trading-screen.view-model.test.ts` to assert DTO tone values (`"Warning"` / `"Critical"`) and aligned related expectation strings. 
- WPF: updated operator work-item fallback mappings to the new taxonomy by mapping `PaperReplay` → `ReplayVerification` and `ProviderTrustGate` → `ProviderHealth` in both `TradingWorkspaceShellPresentationService.ResolveOperatorWorkItemActionId` and the `MainPageViewModel` inbox fallback.

### Testing

- Attempted to run the dashboard slice with `npm --prefix src/Meridian.Ui/dashboard run test -- trading-screen.view-model.test.ts`, but the automation environment failed due to missing `node_modules/vitest` (no tests executed here). 
- Attempted to run the WPF slice with `dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter "FullyQualifiedName~TradingWorkspaceShellViewModelTests" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger "console;verbosity=minimal"`, but `dotnet` is not available in this environment (no tests executed here). 
- The modified unit/slice tests are expected to pass in a developer environment with `npm install`/`vitest` for the dashboard and a proper `dotnet`/WPF test environment for the desktop tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1762ede948832080dfb55ae4348dae)