### PR TITLE
Harden collateral ingestion endpoints against queue abuse

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -128,21 +128,42 @@ public static partial class WorkstationEndpoints
             IReadOnlyList<CollateralInputRow> rows,
             HttpContext context) =>
         {
+            if (!HasOperationsContinuityMutationPermission(context))
+            {
+                return Results.Forbid();
+            }
+
+            const int maxRowsPerRequest = 1_000;
+            if (rows.Count > maxRowsPerRequest)
+            {
+                return Results.BadRequest(new { error = $"A maximum of {maxRowsPerRequest} collateral rows can be ingested per request." });
+            }
+
             var buffer = context.RequestServices.GetService<CollateralIngestionBuffer>();
             if (buffer is null)
             {
                 return Results.Accepted(value: new { ingested = 0, buffered = false });
             }
 
+            var ingested = 0;
             foreach (var row in rows)
             {
-                buffer.Ingest(row);
+                if (!buffer.TryIngest(row))
+                {
+                    return Results.StatusCode(StatusCodes.Status429TooManyRequests);
+                }
+
+                ingested++;
             }
 
-            return Results.Accepted(value: new { ingested = rows.Count, buffered = true });
+            return Results.Accepted(value: new { ingested, buffered = true });
         })
         .WithName("IngestCollateralRows")
-        .Produces(202);
+        .Produces(202)
+        .Produces(400)
+        .Produces(403)
+        .Produces(429)
+        .RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy);
 
         group.MapGet("/workflows/presets", async (HttpContext context) =>
         {
@@ -303,13 +324,19 @@ public static partial class WorkstationEndpoints
 
         group.MapGet("/collateral/exposure", (HttpContext context) =>
         {
+            if (!HasOperationsContinuityReadPermission(context))
+            {
+                return Results.Forbid();
+            }
+
             var service = context.RequestServices.GetRequiredService<CollateralExposureService>();
             var buffer = context.RequestServices.GetService<CollateralIngestionBuffer>();
             var rows = buffer?.DrainBatch(5_000) ?? [];
             return Results.Json(BuildCollateralExposureSnapshot(service, rows), jsonOptions);
         })
         .WithName("GetWorkstationCollateralExposure")
-        .Produces<ExposureSnapshotDto>(200);
+        .Produces<ExposureSnapshotDto>(200)
+        .Produces(403);
 
         group.MapGet("/operator/inbox", async (Guid? fundAccountId, HttpContext context) =>
         {

--- a/src/Meridian.Ui.Shared/Services/CollateralExposureService.cs
+++ b/src/Meridian.Ui.Shared/Services/CollateralExposureService.cs
@@ -125,9 +125,21 @@ public sealed class CollateralExposureService
 
 public sealed class CollateralIngestionBuffer
 {
+    private const int MaxBufferedRows = 20_000;
     private readonly ConcurrentQueue<CollateralInputRow> _buffer = new();
 
-    public void Ingest(CollateralInputRow row) => _buffer.Enqueue(row);
+    public int BufferedCount => _buffer.Count;
+
+    public bool TryIngest(CollateralInputRow row)
+    {
+        if (_buffer.Count >= MaxBufferedRows)
+        {
+            return false;
+        }
+
+        _buffer.Enqueue(row);
+        return true;
+    }
 
     public IReadOnlyList<CollateralInputRow> DrainBatch(int maxItems = 500)
     {

--- a/tests/Meridian.Tests/Ui/CollateralExposureServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/CollateralExposureServiceTests.cs
@@ -24,4 +24,24 @@ public sealed class CollateralExposureServiceTests
         breaches.Should().ContainSingle();
         breaches[0].Severity.Should().Be(ThresholdSeverity.HardBreach);
     }
+
+    [Fact]
+    public void CollateralIngestionBuffer_RejectsRowsWhenCapacityReached()
+    {
+        var buffer = new CollateralIngestionBuffer();
+
+        var accepted = 0;
+        for (var index = 0; index < 20_001; index++)
+        {
+            var row = new CollateralInputRow(DateTimeOffset.UtcNow, $"CPTY-{index}", "repo", 1m, 1m, 1m, "cash", 1m, 0m);
+            if (buffer.TryIngest(row))
+            {
+                accepted++;
+            }
+        }
+
+        accepted.Should().Be(20_000);
+        buffer.BufferedCount.Should().Be(20_000);
+    }
+
 }


### PR DESCRIPTION
### Motivation
- A newly-added workstation collateral ingestion flow exposed a process-wide unbounded `ConcurrentQueue` reachable from authenticated HTTP endpoints, allowing authenticated users to exhaust server memory and degrade availability.
- The POST ingest and GET exposure endpoints lacked per-endpoint authorization checks, request-size limits, and effective rate/backpressure controls.
- The goal is to prevent authenticated DoS from large or repeated ingestion requests while preserving the ingestion/exposure workflow for authorized operator users.

### Description
- Added permission checks to the workstation collateral endpoints by returning `403` when `HasOperationsContinuityMutationPermission(context)` (ingest) or `HasOperationsContinuityReadPermission(context)` (exposure) is not satisfied, and surfaced those status codes in the endpoint metadata, which limits access to authorized operator roles; changed `POST /api/workstation/collateral/ingest` and `GET /api/workstation/collateral/exposure` in `WorkstationEndpoints.cs` accordingly.
- Added per-request input validation on ingest with `const int maxRowsPerRequest = 1_000` returning `400` when exceeded, applied `.RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy)` to the ingestion endpoint, and return `429` when the buffer cannot accept more rows.\
- Replaced the unbounded enqueue semantics with bounded `TryIngest` behavior in `CollateralIngestionBuffer` by adding `MaxBufferedRows = 20_000`, `BufferedCount` for observability, and a `bool TryIngest(CollateralInputRow)` that rejects new rows when capacity is reached.\
- Added a focused unit test `CollateralIngestionBuffer_RejectsRowsWhenCapacityReached` to `CollateralExposureServiceTests` that asserts the buffer accepts at most `20_000` rows and exposes `BufferedCount`.

### Testing
- A targeted unit test was added (`tests/Meridian.Tests/Ui/CollateralExposureServiceTests.cs`) to validate buffer capacity behavior and it was committed with the change but was not executed in this environment because `dotnet` is not available here.\
- Attempted to run `dotnet test --filter "FullyQualifiedName~CollateralExposureServiceTests"` but the command failed with `/bin/bash: dotnet: command not found`, so automated test execution could not be completed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17d2372e1883209ca53a2ba0a2d6e5)