### PR TITLE
Harden compliance endpoints against header spoofing

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/Compliance/ComplianceEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/Compliance/ComplianceEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Meridian.Application.Compliance;
+using Meridian.Contracts.Auth;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,10 +26,12 @@ public static class ComplianceEndpoints
 
             var evt = auditLog.Append(actor, request);
             return Results.Json(new { allowed = true, reason = decision.Reason, auditEventId = evt.EventId, hash = evt.Hash }, options: jsonOptions);
-        });
+        })
+        .AddEndpointFilter(EndpointAuthorization.Require(UserPermission.ManageUsers));
 
         app.MapGet("/api/compliance/audit/extract", (ImmutableAuditLogService auditLog) =>
-            Results.Ok(new { integrityValid = auditLog.VerifyIntegrity(), events = auditLog.GetAll() }));
+            Results.Ok(new { integrityValid = auditLog.VerifyIntegrity(), events = auditLog.GetAll() }))
+            .AddEndpointFilter(EndpointAuthorization.Require(UserPermission.ManageUsers));
 
         app.MapGet("/api/compliance/controls/attestation", (ImmutableAuditLogService auditLog) =>
             Results.Ok(new
@@ -42,7 +45,8 @@ public static class ComplianceEndpoints
                     "Segregation-of-duties policy checks"
                 },
                 integrityValid = auditLog.VerifyIntegrity()
-            }));
+            }))
+            .AddEndpointFilter(EndpointAuthorization.Require(UserPermission.ManageUsers));
 
         app.MapPost("/api/compliance/access-reviews/run", (
             AccessReviewRunRequest request,
@@ -50,19 +54,31 @@ public static class ComplianceEndpoints
         {
             var result = reviews.ReviewDormantPermissions(request.ActorId, request.ReviewedBy, request.CurrentRoles, request.LastUsedAtUtc);
             return Results.Ok(result);
-        });
+        })
+        .AddEndpointFilter(EndpointAuthorization.Require(UserPermission.ManageUsers));
 
-        app.MapGet("/api/compliance/access-reviews", (AccessReviewService reviews) => Results.Ok(reviews.GetReviews()));
+        app.MapGet("/api/compliance/access-reviews", (AccessReviewService reviews) => Results.Ok(reviews.GetReviews()))
+            .AddEndpointFilter(EndpointAuthorization.Require(UserPermission.ManageUsers));
 
         return app;
     }
 
     private static ActorContext BuildActorContext(HttpContext http)
     {
-        var actorId = http.Request.Headers["X-Actor-Id"].FirstOrDefault() ?? "anonymous";
-        var roles = http.Request.Headers["X-Actor-Roles"].FirstOrDefault()?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? [];
+        var actorId = EndpointAuthorization.TryResolveActor(http, out var currentActor)
+            ? currentActor
+            : "anonymous";
+
+        var roles = http.Items.TryGetValue(LoginSessionMiddleware.CurrentUserRoleKey, out var currentRole) && currentRole is UserRole role
+            ? [role.ToString()]
+            : [];
+
         var team = http.Request.Headers["X-Actor-Team"].FirstOrDefault();
-        var mfa = bool.TryParse(http.Request.Headers["X-Actor-Mfa"].FirstOrDefault(), out var parsed) && parsed;
+        var mfa = http.User.Claims.Any(claim =>
+            (claim.Type.Equals("amr", StringComparison.OrdinalIgnoreCase) ||
+             claim.Type.Equals("acr", StringComparison.OrdinalIgnoreCase) ||
+             claim.Type.Equals("mfa", StringComparison.OrdinalIgnoreCase)) &&
+            claim.Value.Contains("mfa", StringComparison.OrdinalIgnoreCase));
 
         return new ActorContext(actorId, roles, team, http.Connection.RemoteIpAddress?.ToString(), http.Request.Headers["X-Device-Id"].FirstOrDefault(), mfa);
     }


### PR DESCRIPTION
### Motivation
- Close an authorization and audit-integrity bypass where compliance endpoints trusted caller-supplied `X-Actor-*` headers for identity, roles, and MFA, allowing low-privilege sessions to spoof privileged actions and fraudulent audit entries.

### Description
- Require session-backed RBAC for all compliance endpoints by adding `EndpointAuthorization.Require(UserPermission.ManageUsers)` to evaluate, audit/extract, controls attestation, and access-review routes.
- Replace header-driven actor construction with trusted session sources: resolve actor via `EndpointAuthorization.TryResolveActor(...)` and derive roles from `LoginSessionMiddleware` `HttpContext.Items` instead of `X-Actor-Roles` headers.
- Stop trusting `X-Actor-Mfa` and derive MFA satisfaction from authenticated user claims (`amr`/`acr`/`mfa`) to enforce server-validated step-up state.
- Import `Meridian.Contracts.Auth` and adapt `BuildActorContext` to return an `ActorContext` sourced from server-side authentication state.

### Testing
- Performed source-level verification of the updated `ComplianceEndpoints` file and confirmed the endpoint filters and `BuildActorContext` changes are present and syntactically integrated.
- No automated .NET unit or integration tests were executed in this environment because the container lacks the .NET SDK, so runtime validation was not performed.
- Recommend running `dotnet test` (unit/integration) and exercising the affected API routes against an authenticated server during CI to validate behavior and RBAC enforcement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17d23709408320b502fec10a60f535)