### PR TITLE
Harden evidence vault search to reject empty lookups

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/EvidenceEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/EvidenceEndpoints.cs
@@ -172,15 +172,30 @@ public static class EvidenceEndpoints
 
         group.MapPost("/vault/search", async (EvidenceVaultLookupRequestDto request, HttpContext context) =>
         {
+            if (!HasLookupCriteria(request))
+            {
+                return Results.BadRequest(Error(
+                    "invalid-evidence-vault-lookup",
+                    "Evidence vault search requires at least one lookup field."));
+            }
+
             var store = context.RequestServices.GetRequiredService<IEvidenceArtifactStore>();
             var result = await store.FindByLinkageAsync(request, context.RequestAborted).ConfigureAwait(false);
             return Results.Json(result, jsonOptions);
         })
         .WithName("SearchWorkstationEvidenceVault")
-        .Produces<IReadOnlyList<EvidenceVaultIdentityDto>>(200);
+        .Produces<IReadOnlyList<EvidenceVaultIdentityDto>>(200)
+        .Produces<EvidenceEndpointErrorDto>(400);
 
         return app;
     }
+
+    private static bool HasLookupCriteria(EvidenceVaultLookupRequestDto request)
+        => !string.IsNullOrWhiteSpace(request.EvidenceSubject)
+           || !string.IsNullOrWhiteSpace(request.RunId)
+           || !string.IsNullOrWhiteSpace(request.PeriodId)
+           || !string.IsNullOrWhiteSpace(request.ReportPackId)
+           || !string.IsNullOrWhiteSpace(request.ReconciliationCaseId);
 
     private static async Task<IResult> ResolvePacketAsync(
         string subjectKind,

--- a/tests/Meridian.Tests/Ui/EvidenceWorkflowFabricTests.cs
+++ b/tests/Meridian.Tests/Ui/EvidenceWorkflowFabricTests.cs
@@ -532,6 +532,20 @@ public sealed class EvidenceWorkflowFabricTests
     }
 
     [Fact]
+    public async Task EvidenceEndpoints_VaultSearch_RejectsEmptyLookup()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"evidence-vault-search-empty-{Guid.NewGuid():N}");
+        await using var app = await CreateEvidenceAppAsync(root);
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/api/workstation/evidence/vault/search",
+            new EvidenceVaultLookupRequestDto(null, null, null, null, null));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
     public async Task EvidenceEndpoints_VaultSearch_FindsBundlesByRunReportPackAndReconciliationCase()
     {
         var root = Path.Combine(Path.GetTempPath(), $"evidence-vault-search-{Guid.NewGuid():N}");


### PR DESCRIPTION
### Motivation

- The `/api/workstation/evidence/vault/search` endpoint could be called with an empty lookup body and would match every retained vault entry, exposing vault identifiers/routes and enabling archive-wide enumeration and heavy archive scanning. 
- The change prevents accidental or malicious empty lookups from enumerating retained evidence and reduces archive-dependent resource consumption.

### Description

- Validate the incoming lookup at the API boundary by adding `HasLookupCriteria` and rejecting requests with no non-empty lookup fields, returning `400 Bad Request` and a specific evidence error code. (modified `src/Meridian.Ui.Shared/Endpoints/EvidenceEndpoints.cs`)
- Preserve existing behavior for valid lookups by only short-circuiting when all lookup fields are blank and otherwise delegating to `IEvidenceArtifactStore.FindByLinkageAsync`. (modified `src/Meridian.Ui.Shared/Endpoints/EvidenceEndpoints.cs`)
- Add endpoint metadata to declare the `400` error response for the vault search route. (modified `src/Meridian.Ui.Shared/Endpoints/EvidenceEndpoints.cs`)
- Add a regression test `EvidenceEndpoints_VaultSearch_RejectsEmptyLookup` that posts an all-empty `EvidenceVaultLookupRequestDto` and asserts a `400` response. (modified `tests/Meridian.Tests/Ui/EvidenceWorkflowFabricTests.cs`)

### Testing

- Added the focused unit test `EvidenceEndpoints_VaultSearch_RejectsEmptyLookup` to verify the empty lookup is rejected. 
- Attempted to run the vault-search test subset with `dotnet test --filter "EvidenceEndpoints_VaultSearch_"` but the execution failed due to the environment lacking the .NET SDK (`dotnet: command not found`), so tests were not executed here. 
- The change is minimal and localized to the endpoint input validation and tests to keep behavior intact for non-empty lookups.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17fdb38d0c83209ce23236ed0d44a6)