### PR TITLE
Harden OMS endpoint permissions and replay handling

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/OmsIntegrationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/OmsIntegrationEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Meridian.Contracts.Auth;
 using Meridian.Ui.Shared.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -11,18 +12,60 @@ public static class OmsIntegrationEndpoints
     {
         var group = app.MapGroup("/api/oms");
 
-        group.MapPost("/ingest", (OmsInboundMessage request, OmsIntegrationService service) => Results.Json(service.Ingest(request), jsonOptions));
-        group.MapGet("/messages", (OmsIntegrationService service) => Results.Json(service.Snapshot(), jsonOptions));
-
-        group.MapGet("/adapters/diagnostics", () => Results.Json(new[]
+        group.MapPost("/ingest", (HttpContext context, OmsInboundMessage request, OmsIntegrationService service) =>
         {
-            new OmsAdapterDiagnostics("fix", "tcp", 0, "healthy", DateTimeOffset.UtcNow),
-            new OmsAdapterDiagnostics("sftp", "file-transfer", 1, "retrying", DateTimeOffset.UtcNow),
-            new OmsAdapterDiagnostics("file-drop", "local", 0, "healthy", DateTimeOffset.UtcNow)
-        }, jsonOptions));
+            if (!EndpointAuthorization.HasPermission(context, UserPermission.ManageOrders))
+            {
+                return Results.Forbid();
+            }
 
-        group.MapPost("/excel/sync", (OmsSyncRequest request, OmsIntegrationService service) => Results.Json(service.ResolveSyncConflict(request), jsonOptions));
-        group.MapGet("/audit", (int? take, OmsIntegrationService service) => Results.Json(service.AuditTrail(take ?? 200), jsonOptions));
+            return Results.Json(service.Ingest(request), jsonOptions);
+        });
+
+        group.MapGet("/messages", (HttpContext context, OmsIntegrationService service) =>
+        {
+            if (!EndpointAuthorization.HasPermission(context, UserPermission.ViewTrades))
+            {
+                return Results.Forbid();
+            }
+
+            return Results.Json(service.Snapshot(), jsonOptions);
+        });
+
+        group.MapGet("/adapters/diagnostics", (HttpContext context) =>
+        {
+            if (!EndpointAuthorization.HasPermission(context, UserPermission.ViewDiagnostics))
+            {
+                return Results.Forbid();
+            }
+
+            return Results.Json(new[]
+            {
+                new OmsAdapterDiagnostics("fix", "tcp", 0, "healthy", DateTimeOffset.UtcNow),
+                new OmsAdapterDiagnostics("sftp", "file-transfer", 1, "retrying", DateTimeOffset.UtcNow),
+                new OmsAdapterDiagnostics("file-drop", "local", 0, "healthy", DateTimeOffset.UtcNow)
+            }, jsonOptions);
+        });
+
+        group.MapPost("/excel/sync", (HttpContext context, OmsSyncRequest request, OmsIntegrationService service) =>
+        {
+            if (!EndpointAuthorization.HasPermission(context, UserPermission.ManageOrders))
+            {
+                return Results.Forbid();
+            }
+
+            return Results.Json(service.ResolveSyncConflict(request), jsonOptions);
+        });
+
+        group.MapGet("/audit", (HttpContext context, int? take, OmsIntegrationService service) =>
+        {
+            if (!EndpointAuthorization.HasPermission(context, UserPermission.ViewDiagnostics))
+            {
+                return Results.Forbid();
+            }
+
+            return Results.Json(service.AuditTrail(take ?? 200), jsonOptions);
+        });
 
         return app;
     }

--- a/src/Meridian.Ui.Shared/Services/OmsIntegrationService.cs
+++ b/src/Meridian.Ui.Shared/Services/OmsIntegrationService.cs
@@ -6,6 +6,9 @@ namespace Meridian.Ui.Shared.Services;
 
 public sealed class OmsIntegrationService
 {
+    private const int MaxTrackedMessages = 10_000;
+    private const int MaxAuditEntries = 20_000;
+
     private readonly ConcurrentDictionary<string, OmsInboundMessage> _messages = new(StringComparer.Ordinal);
     private readonly ConcurrentQueue<OmsIntegrationAuditEntry> _audit = new();
 
@@ -14,10 +17,15 @@ public sealed class OmsIntegrationService
         ArgumentNullException.ThrowIfNull(message);
         var dedupKey = string.IsNullOrWhiteSpace(message.DeduplicationKey) ? ComputeKey(message) : message.DeduplicationKey.Trim();
         var normalized = message with { DeduplicationKey = dedupKey };
-        var isReplay = _messages.ContainsKey(dedupKey);
-        _messages[dedupKey] = normalized;
-        _audit.Enqueue(new OmsIntegrationAuditEntry(DateTimeOffset.UtcNow, dedupKey, isReplay ? "replay" : "ingest", message.SourceSystem, message.CorrelationId));
-        return new OmsIngestionResult(dedupKey, isReplay, isReplay ? "Replay-safe duplicate ignored." : "Accepted.");
+        if (_messages.TryAdd(dedupKey, normalized))
+        {
+            TrimMessagesIfRequired();
+            EnqueueAudit(new OmsIntegrationAuditEntry(DateTimeOffset.UtcNow, dedupKey, "ingest", message.SourceSystem, message.CorrelationId));
+            return new OmsIngestionResult(dedupKey, false, "Accepted.");
+        }
+
+        EnqueueAudit(new OmsIntegrationAuditEntry(DateTimeOffset.UtcNow, dedupKey, "replay", message.SourceSystem, message.CorrelationId));
+        return new OmsIngestionResult(dedupKey, true, "Replay-safe duplicate ignored.");
     }
 
     public IReadOnlyCollection<OmsInboundMessage> Snapshot() => _messages.Values.ToArray();
@@ -27,8 +35,34 @@ public sealed class OmsIntegrationService
     {
         var winner = request.PullRecord.UpdatedAtUtc >= request.PushRecord.UpdatedAtUtc ? request.PullRecord : request.PushRecord;
         var mode = request.Mode.Equals("push", StringComparison.OrdinalIgnoreCase) ? "push" : "pull";
-        _audit.Enqueue(new OmsIntegrationAuditEntry(DateTimeOffset.UtcNow, request.EntityId, "sync-resolve", "excel-bridge", request.CorrelationId));
+        EnqueueAudit(new OmsIntegrationAuditEntry(DateTimeOffset.UtcNow, request.EntityId, "sync-resolve", "excel-bridge", request.CorrelationId));
         return new OmsSyncConflictResult(mode, winner, "timestamp-precedence");
+    }
+
+    private void EnqueueAudit(OmsIntegrationAuditEntry entry)
+    {
+        _audit.Enqueue(entry);
+        while (_audit.Count > MaxAuditEntries && _audit.TryDequeue(out _))
+        {
+        }
+    }
+
+    private void TrimMessagesIfRequired()
+    {
+        if (_messages.Count <= MaxTrackedMessages)
+        {
+            return;
+        }
+
+        foreach (var key in _messages.Keys)
+        {
+            if (_messages.Count <= MaxTrackedMessages)
+            {
+                break;
+            }
+
+            _messages.TryRemove(key, out _);
+        }
     }
 
     private static string ComputeKey(OmsInboundMessage msg)

--- a/tests/Meridian.Tests/Ui/OmsIntegrationServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/OmsIntegrationServiceTests.cs
@@ -20,6 +20,24 @@ public sealed class OmsIntegrationServiceTests
     }
 
     [Fact]
+    public void Ingest_Replay_DoesNotOverwriteExistingMessage()
+    {
+        var service = new OmsIntegrationService();
+        var first = new OmsInboundMessage("oms-a", "ord-1", "fill", DateTimeOffset.UtcNow, "hash-1", "stable-key", "corr-1");
+        var replay = new OmsInboundMessage("oms-b", "ord-99", "cancel", DateTimeOffset.UtcNow.AddMinutes(1), "hash-2", "stable-key", "corr-2");
+
+        service.Ingest(first);
+        var result = service.Ingest(replay);
+
+        result.ReplayDetected.Should().BeTrue();
+        var snapshot = service.Snapshot().Should().ContainSingle().Subject;
+        snapshot.SourceSystem.Should().Be("oms-a");
+        snapshot.ExternalOrderId.Should().Be("ord-1");
+        snapshot.EventType.Should().Be("fill");
+        snapshot.PayloadHash.Should().Be("hash-1");
+    }
+
+    [Fact]
     public void ResolveSyncConflict_UsesTimestampPrecedence()
     {
         var service = new OmsIntegrationService();


### PR DESCRIPTION
### Motivation

- Close a high-risk authorization and state-manipulation vuln where `/api/oms` was exposed without per-route RBAC so low-privilege authenticated users could read/mutate OMS data. 
- Prevent replay submissions from overwriting canonical messages by fixing idempotency semantics in the in-process store. 
- Mitigate unbounded process-memory growth from unbounded singleton collections used for messages and audit entries.

### Description

- Added per-route permission checks in `OmsIntegrationEndpoints.MapOmsIntegrationEndpoints` so mutating routes require `UserPermission.ManageOrders`, message reads require `UserPermission.ViewTrades`, and diagnostics/audit reads require `UserPermission.ViewDiagnostics` (file: `src/Meridian.Ui.Shared/Endpoints/OmsIntegrationEndpoints.cs`).
- Preserved first-accepted message for a deduplication key by switching to `ConcurrentDictionary.TryAdd` and returning a replay result without overwriting the stored entry in `OmsIntegrationService.Ingest` (file: `src/Meridian.Ui.Shared/Services/OmsIntegrationService.cs`).
- Added bounded retention to in-memory collections with `MaxTrackedMessages` and `MaxAuditEntries`, plus helper methods `TrimMessagesIfRequired` and `EnqueueAudit` to limit memory growth (file: `src/Meridian.Ui.Shared/Services/OmsIntegrationService.cs`).
- Added a regression unit test `Ingest_Replay_DoesNotOverwriteExistingMessage` to `tests/Meridian.Tests/Ui/OmsIntegrationServiceTests.cs` that verifies duplicate submissions do not replace the original canonical message.

### Testing

- Added an xUnit test `Ingest_Replay_DoesNotOverwriteExistingMessage` in `tests/Meridian.Tests/Ui/OmsIntegrationServiceTests.cs` but could not run the test suite in this environment because `dotnet` is not installed; attempted command: `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter OmsIntegrationServiceTests --no-restore` which failed with `dotnet: command not found`.
- Static inspections and local file validation were performed to ensure the endpoint checks and `TryAdd`/trimming logic were applied to the intended files. 
- No automated test run succeeded in this environment due to the missing .NET SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17fdb0fb7c832085f6ae1553268420)