### PR TITLE
Persist fund account operational_status in Postgres store

### DIFF
--- a/src/Meridian.Storage/FundAccounts/Migrations/001_fund_accounts.sql
+++ b/src/Meridian.Storage/FundAccounts/Migrations/001_fund_accounts.sql
@@ -24,6 +24,7 @@ create table if not exists __SCHEMA__.account_definition (
     ledger_reference    text,
     strategy_id         text,
     run_id              text,
+    operational_status  text        not null default 'Active',
     -- Extended settlement details (nullable; present for Custody and Bank types)
     custodian_details   jsonb,
     bank_details        jsonb,

--- a/src/Meridian.Storage/FundAccounts/Migrations/002_add_operational_status.sql
+++ b/src/Meridian.Storage/FundAccounts/Migrations/002_add_operational_status.sql
@@ -1,0 +1,3 @@
+-- Ensure operational status persists for account-level mutation policy checks.
+ALTER TABLE IF EXISTS __SCHEMA__.account_definition
+    ADD COLUMN IF NOT EXISTS operational_status text NOT NULL DEFAULT 'Active';

--- a/src/Meridian.Storage/FundAccounts/PostgresFundAccountStore.cs
+++ b/src/Meridian.Storage/FundAccounts/PostgresFundAccountStore.cs
@@ -40,12 +40,12 @@ public sealed class PostgresFundAccountStore : IFundAccountStore
                 (account_id, account_type, entity_id, fund_id, sleeve_id, vehicle_id,
                  account_code, display_name, base_currency, institution, is_active,
                  effective_from, effective_to, portfolio_id, ledger_reference,
-                 strategy_id, run_id, custodian_details, bank_details, updated_at)
+                 strategy_id, run_id, operational_status, custodian_details, bank_details, updated_at)
             VALUES
                 (@account_id, @account_type, @entity_id, @fund_id, @sleeve_id, @vehicle_id,
                  @account_code, @display_name, @base_currency, @institution, @is_active,
                  @effective_from, @effective_to, @portfolio_id, @ledger_reference,
-                 @strategy_id, @run_id, @custodian_details::jsonb, @bank_details::jsonb, now())
+                 @strategy_id, @run_id, @operational_status, @custodian_details::jsonb, @bank_details::jsonb, now())
             ON CONFLICT (account_id) DO UPDATE SET
                 account_type        = EXCLUDED.account_type,
                 entity_id           = EXCLUDED.entity_id,
@@ -63,6 +63,7 @@ public sealed class PostgresFundAccountStore : IFundAccountStore
                 ledger_reference    = EXCLUDED.ledger_reference,
                 strategy_id         = EXCLUDED.strategy_id,
                 run_id              = EXCLUDED.run_id,
+                operational_status  = EXCLUDED.operational_status,
                 custodian_details   = EXCLUDED.custodian_details,
                 bank_details        = EXCLUDED.bank_details,
                 updated_at          = now()
@@ -84,6 +85,7 @@ public sealed class PostgresFundAccountStore : IFundAccountStore
         cmd.Parameters.AddWithValue("ledger_reference", (object?)account.LedgerReference ?? DBNull.Value);
         cmd.Parameters.AddWithValue("strategy_id", (object?)account.StrategyId ?? DBNull.Value);
         cmd.Parameters.AddWithValue("run_id", (object?)account.RunId ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("operational_status", account.OperationalStatus.ToString());
         cmd.Parameters.AddWithValue("custodian_details",
             account.CustodianDetails is not null ? JsonSerializer.Serialize(account.CustodianDetails, JsonOpts) : DBNull.Value);
         cmd.Parameters.AddWithValue("bank_details",
@@ -100,7 +102,7 @@ public sealed class PostgresFundAccountStore : IFundAccountStore
             SELECT account_id, account_type, entity_id, fund_id, sleeve_id, vehicle_id,
                    account_code, display_name, base_currency, institution, is_active,
                    effective_from, effective_to, portfolio_id, ledger_reference,
-                   strategy_id, run_id, custodian_details, bank_details
+                   strategy_id, run_id, operational_status, custodian_details, bank_details
             FROM {Qualified("account_definition")}
             WHERE account_id = @account_id
             """;
@@ -120,7 +122,7 @@ public sealed class PostgresFundAccountStore : IFundAccountStore
             SELECT account_id, account_type, entity_id, fund_id, sleeve_id, vehicle_id,
                    account_code, display_name, base_currency, institution, is_active,
                    effective_from, effective_to, portfolio_id, ledger_reference,
-                   strategy_id, run_id, custodian_details, bank_details
+                   strategy_id, run_id, operational_status, custodian_details, bank_details
             FROM {Qualified("account_definition")}
             WHERE 1=1
             """);
@@ -208,7 +210,7 @@ public sealed class PostgresFundAccountStore : IFundAccountStore
             LedgerReference: reader.IsDBNull(reader.GetOrdinal("ledger_reference")) ? null : reader.GetString(reader.GetOrdinal("ledger_reference")),
             StrategyId: reader.IsDBNull(reader.GetOrdinal("strategy_id")) ? null : reader.GetString(reader.GetOrdinal("strategy_id")),
             RunId: reader.IsDBNull(reader.GetOrdinal("run_id")) ? null : reader.GetString(reader.GetOrdinal("run_id")),
-            OperationalStatus: AccountOperationalStatusDto.Active,
+            OperationalStatus: Enum.Parse<AccountOperationalStatusDto>(reader.GetString(reader.GetOrdinal("operational_status"))),
             CustodianDetails: custodianJson is not null ? JsonSerializer.Deserialize<CustodianAccountDetailsDto>(custodianJson, JsonOpts) : null,
             BankDetails: bankJson is not null ? JsonSerializer.Deserialize<BankAccountDetailsDto>(bankJson, JsonOpts) : null);
     }


### PR DESCRIPTION
### Motivation
- The Postgres-backed fund account store never persisted `operational_status` and always reconstructed accounts as `Active`, which allowed Closed/Suspended accounts to bypass service-level mutation guards.
- Restore correct status persistence so `EnsureAllowed` and other policy checks cannot be circumvented by a persistence mismatch.

### Description
- Add `operational_status` to the baseline schema in `src/Meridian.Storage/FundAccounts/Migrations/001_fund_accounts.sql` with a default of `'Active'` to ensure new deployments store the status.
- Add a forward migration `src/Meridian.Storage/FundAccounts/Migrations/002_add_operational_status.sql` that runs `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` to remediate existing databases non-destructively.
- Include `operational_status` in the `INSERT`/upsert and `SELECT` SQL paths in `src/Meridian.Storage/FundAccounts/PostgresFundAccountStore.cs` and add the `@operational_status` parameter on writes.
- Hydrate `AccountSummaryDto.OperationalStatus` from the database value in `ReadAccountSummary` instead of hard-coding `Active`, restoring status-driven enforcement in the service layer.

### Testing
- Attempted to run `dotnet --version` and `dotnet test` but the environment lacks the .NET SDK, so automated tests could not be executed in this container (`dotnet: command not found`).
- Static inspection of the modified SQL and store code was performed to verify the read/write/parse paths include `operational_status` and the new migration covers existing schemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17fed9e70883209881430d70734f85)