### PR TITLE
Preserve MarketEvent provenance by bypassing DualPath hot-path reconstitution for trades/quotes

### DIFF
--- a/src/Meridian.Application/Pipeline/DualPathEventPipeline.cs
+++ b/src/Meridian.Application/Pipeline/DualPathEventPipeline.cs
@@ -296,25 +296,6 @@ public sealed class DualPathEventPipeline : IMarketEventPublisher, IBackpressure
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryRouteTrade(in MarketEvent evt)
     {
-        if (evt.Payload is not Trade trade)
-            return _slowPath.TryPublish(in evt); // Unknown payload — fall back
-
-        var symbolId = _symbolTable.GetOrAdd(evt.EffectiveSymbol);
-        var raw = new RawTradeEvent(
-            timestampTicks: evt.Timestamp.UtcTicks,
-            symbolHash: symbolId,
-            price: trade.Price,
-            size: trade.Size,
-            aggressor: (byte)trade.Aggressor,
-            sequence: evt.Sequence);
-
-        if (_tradeBuffer.TryWrite(in raw))
-        {
-            Interlocked.Increment(ref _hotTradePublished);
-            return true;
-        }
-
-        // Ring buffer full — fall back to slow path to avoid data loss.
         Interlocked.Increment(ref _hotTradeFallbacks);
         return _slowPath.TryPublish(in evt);
     }
@@ -322,29 +303,10 @@ public sealed class DualPathEventPipeline : IMarketEventPublisher, IBackpressure
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryRouteQuote(in MarketEvent evt)
     {
-        if (evt.Payload is not BboQuotePayload quote)
-            return _slowPath.TryPublish(in evt); // Unknown payload — fall back
-
-        var symbolId = _symbolTable.GetOrAdd(evt.EffectiveSymbol);
-        var raw = new RawQuoteEvent(
-            timestampTicks: evt.Timestamp.UtcTicks,
-            symbolHash: symbolId,
-            bidPrice: quote.BidPrice,
-            bidSize: quote.BidSize,
-            askPrice: quote.AskPrice,
-            askSize: quote.AskSize,
-            sequence: evt.Sequence);
-
-        if (_quoteBuffer.TryWrite(in raw))
-        {
-            Interlocked.Increment(ref _hotQuotePublished);
-            return true;
-        }
-
-        // Ring buffer full — fall back to slow path to avoid data loss.
         Interlocked.Increment(ref _hotQuoteFallbacks);
         return _slowPath.TryPublish(in evt);
     }
+
 
     // -------------------------------------------------------------------------
     // Consumer loops

--- a/tests/Meridian.Tests/Application/Pipeline/DualPathEventPipelineTests.cs
+++ b/tests/Meridian.Tests/Application/Pipeline/DualPathEventPipelineTests.cs
@@ -73,7 +73,8 @@ public class DualPathEventPipelineTests : IAsyncLifetime
 
         await WaitForSinkCount(1, timeout: TimeSpan.FromSeconds(5));
 
-        _pipeline.HotTradePublished.Should().Be(1);
+        _pipeline.HotTradePublished.Should().Be(0);
+        _pipeline.HotTradeFallbacks.Should().Be(1);
         _sink.ReceivedEvents.Should().ContainSingle(e => e.Symbol == "SPY");
     }
 
@@ -85,7 +86,8 @@ public class DualPathEventPipelineTests : IAsyncLifetime
 
         await WaitForSinkCount(1, timeout: TimeSpan.FromSeconds(5));
 
-        _pipeline.HotQuotePublished.Should().Be(1);
+        _pipeline.HotQuotePublished.Should().Be(0);
+        _pipeline.HotQuoteFallbacks.Should().Be(1);
         _sink.ReceivedEvents.Should().ContainSingle(e => e.Symbol == "AAPL");
     }
 
@@ -210,7 +212,8 @@ public class DualPathEventPipelineTests : IAsyncLifetime
 
         await WaitForSinkCount(count, timeout: TimeSpan.FromSeconds(5));
 
-        _pipeline.HotTradePublished.Should().Be(count);
+        _pipeline.HotTradePublished.Should().Be(0);
+        _pipeline.HotTradeFallbacks.Should().Be(count);
         _sink.ReceivedEvents.Should().HaveCount(count);
     }
 
@@ -228,7 +231,8 @@ public class DualPathEventPipelineTests : IAsyncLifetime
 
         await WaitForSinkCount(1, timeout: TimeSpan.FromSeconds(5));
 
-        _pipeline.HotTradePublished.Should().Be(1);
+        _pipeline.HotTradePublished.Should().Be(0);
+        _pipeline.HotTradeFallbacks.Should().Be(1);
         _sink.ReceivedEvents.Should().ContainSingle(e => e.Symbol == "SPY");
     }
 
@@ -242,7 +246,8 @@ public class DualPathEventPipelineTests : IAsyncLifetime
 
         await WaitForSinkCount(1, timeout: TimeSpan.FromSeconds(5));
 
-        _pipeline.HotQuotePublished.Should().Be(1);
+        _pipeline.HotQuotePublished.Should().Be(0);
+        _pipeline.HotQuoteFallbacks.Should().Be(1);
         _sink.ReceivedEvents.Should().ContainSingle(e => e.Symbol == "AAPL");
     }
 
@@ -294,7 +299,7 @@ public class DualPathEventPipelineTests : IAsyncLifetime
     {
         _pipeline.TryPublish(CreateTradeEvent("SPY", seq: 1));
         await WaitForConsumed(1, timeout: TimeSpan.FromSeconds(5));
-        _pipeline.HotTradeConsumed.Should().BeGreaterThanOrEqualTo(1);
+        _pipeline.HotTradeConsumed.Should().Be(0);
     }
 
     [Fact]
@@ -302,7 +307,7 @@ public class DualPathEventPipelineTests : IAsyncLifetime
     {
         _pipeline.TryPublish(CreateQuoteEvent("AAPL", seq: 1));
         await WaitForQuoteConsumed(1, timeout: TimeSpan.FromSeconds(5));
-        _pipeline.HotQuoteConsumed.Should().BeGreaterThanOrEqualTo(1);
+        _pipeline.HotQuoteConsumed.Should().Be(0);
     }
 
     #endregion
@@ -319,8 +324,10 @@ public class DualPathEventPipelineTests : IAsyncLifetime
         await WaitForSinkCount(3, timeout: TimeSpan.FromSeconds(5));
 
         _sink.ReceivedEvents.Should().HaveCount(3);
-        _pipeline.HotTradePublished.Should().Be(1);
-        _pipeline.HotQuotePublished.Should().Be(1);
+        _pipeline.HotTradePublished.Should().Be(0);
+        _pipeline.HotTradeFallbacks.Should().Be(1);
+        _pipeline.HotQuotePublished.Should().Be(0);
+        _pipeline.HotQuoteFallbacks.Should().Be(1);
     }
 
     #endregion


### PR DESCRIPTION
### Motivation
- A hot-path optimization in `DualPathEventPipeline` reconstituted `MarketEvent` trades and quotes from reduced structs and thereby dropped provenance, canonicalization, security-master and trace metadata, which can collapse deduplication domains and corrupt audit provenance.
- The change aims to remove the unsafe metadata-stripping hot path for `MarketEvent`-typed trade/quote publishes so provider/source/canonical metadata is preserved end-to-end.

### Description
- Updated `TryRouteTrade` and `TryRouteQuote` in `src/Meridian.Application/Pipeline/DualPathEventPipeline.cs` to bypass the zero-copy hot-path reconstitution and instead delegate `MarketEvent`-typed trade/quote publishes to the slow-path (`_slowPath`) while incrementing the appropriate fallback counters.
- Adjusted unit expectations in `tests/Meridian.Tests/Application/Pipeline/DualPathEventPipelineTests.cs` to reflect the safe routing behavior where `MarketEvent` trade/quote publishes increment fallback counters rather than hot-publish counters, and consumed hot-path counts remain zero for those `MarketEvent` calls.
- The change is intentionally minimal and local to routing logic so original `MarketEvent` instances retain `Source`, canonical/security fields, trace ids, payload venue/stream/conditions, and the existing slow-path persistence remains unchanged.

### Testing
- Attempted to run the `DualPathEventPipeline` unit tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter DualPathEventPipelineTests --no-restore` but the environment lacks the .NET SDK so the test run could not be executed (`dotnet: command not found`).
- Static inspection and targeted test updates were applied to align expectations with the new safe routing behavior; the modified tests reflect the intended behavior change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17fed9ec048320b9ba55a633f3be94)