### PR TITLE
Bound cash-flow query day windows to prevent DoS vectors

### DIFF
--- a/src/Meridian.Application/FundStructure/FundStructurePolicyService.cs
+++ b/src/Meridian.Application/FundStructure/FundStructurePolicyService.cs
@@ -4,6 +4,8 @@ namespace Meridian.Application.FundStructure;
 
 public sealed class FundStructurePolicyService : IFundStructurePolicyService
 {
+    public const int MaxCashFlowWindowDays = 3650;
+    public const int MaxCashFlowBucketDays = 365;
     public void EnsureSingleOperatingParent(CreateInvestmentPortfolioRequest request)
     {
         var assignedParents = 0;
@@ -33,9 +35,24 @@ public sealed class FundStructurePolicyService : IFundStructurePolicyService
             throw new ArgumentOutOfRangeException(nameof(query), "ForecastDays must be greater than or equal to zero.");
         }
 
+        if (query.HistoricalDays > MaxCashFlowWindowDays)
+        {
+            throw new ArgumentOutOfRangeException(nameof(query), $"HistoricalDays must be less than or equal to {MaxCashFlowWindowDays}.");
+        }
+
+        if (query.ForecastDays > MaxCashFlowWindowDays)
+        {
+            throw new ArgumentOutOfRangeException(nameof(query), $"ForecastDays must be less than or equal to {MaxCashFlowWindowDays}.");
+        }
+
         if (query.BucketDays <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(query), "BucketDays must be greater than zero.");
+        }
+
+        if (query.BucketDays > MaxCashFlowBucketDays)
+        {
+            throw new ArgumentOutOfRangeException(nameof(query), $"BucketDays must be less than or equal to {MaxCashFlowBucketDays}.");
         }
     }
 }

--- a/tests/Meridian.FundStructure.Tests/FundStructurePolicyServiceTests.cs
+++ b/tests/Meridian.FundStructure.Tests/FundStructurePolicyServiceTests.cs
@@ -1,0 +1,57 @@
+using Meridian.Application.FundStructure;
+using Meridian.Contracts.FundStructure;
+
+namespace Meridian.FundStructure.Tests;
+
+public sealed class FundStructurePolicyServiceTests
+{
+    [Fact]
+    public void ValidateCashFlowQuery_ThrowsWhenHistoricalDaysExceedsMaximum()
+    {
+        var service = new FundStructurePolicyService();
+        var query = CreateQuery(historicalDays: FundStructurePolicyService.MaxCashFlowWindowDays + 1);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => service.ValidateCashFlowQuery(query));
+    }
+
+    [Fact]
+    public void ValidateCashFlowQuery_ThrowsWhenForecastDaysExceedsMaximum()
+    {
+        var service = new FundStructurePolicyService();
+        var query = CreateQuery(forecastDays: FundStructurePolicyService.MaxCashFlowWindowDays + 1);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => service.ValidateCashFlowQuery(query));
+    }
+
+    [Fact]
+    public void ValidateCashFlowQuery_AllowsBoundaryValues()
+    {
+        var service = new FundStructurePolicyService();
+        var query = CreateQuery(
+            historicalDays: FundStructurePolicyService.MaxCashFlowWindowDays,
+            forecastDays: FundStructurePolicyService.MaxCashFlowWindowDays,
+            bucketDays: FundStructurePolicyService.MaxCashFlowBucketDays);
+
+        service.ValidateCashFlowQuery(query);
+    }
+
+    [Fact]
+    public void ValidateCashFlowQuery_ThrowsWhenBucketDaysExceedsMaximum()
+    {
+        var service = new FundStructurePolicyService();
+        var query = CreateQuery(bucketDays: FundStructurePolicyService.MaxCashFlowBucketDays + 1);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => service.ValidateCashFlowQuery(query));
+    }
+
+    private static GovernanceCashFlowQuery CreateQuery(
+        int historicalDays = 7,
+        int forecastDays = 7,
+        int bucketDays = 7)
+        => new(
+            GovernanceScopeKind.Account,
+            AccountId: Guid.NewGuid(),
+            HistoricalDays: historicalDays,
+            ForecastDays: forecastDays,
+            BucketDays: bucketDays);
+}


### PR DESCRIPTION
### Motivation
- The `cash-flow-view` path accepted `historicalDays`, `forecastDays`, and `bucketDays` from query parameters with only lower-bound validation, allowing attacker-controlled inputs to cause `DateTimeOffset.AddDays` overflow or allocate/iterate extremely large bucket lists and thus deny service.
- The change introduces conservative upper limits to prevent overflow and resource exhaustion while preserving expected cash-flow functionality for normal use.

### Description
- Added `public const int MaxCashFlowWindowDays = 3650` and `public const int MaxCashFlowBucketDays = 365` to `FundStructurePolicyService` to centralize policy caps.
- Enforced upper bounds in `ValidateCashFlowQuery` for `HistoricalDays`, `ForecastDays`, and `BucketDays`, throwing `ArgumentOutOfRangeException` when values exceed configured maxima.
- Added focused unit tests in `tests/Meridian.FundStructure.Tests/FundStructurePolicyServiceTests.cs` that assert oversized `HistoricalDays`, `ForecastDays`, and `BucketDays` are rejected and that boundary values are accepted.
- Files changed: `src/Meridian.Application/FundStructure/FundStructurePolicyService.cs` and `tests/Meridian.FundStructure.Tests/FundStructurePolicyServiceTests.cs`.

### Testing
- Added unit tests covering the new boundaries but they were not executed in this environment because `dotnet` is not available; attempted command was `dotnet test tests/Meridian.FundStructure.Tests/Meridian.FundStructure.Tests.csproj --filter FundStructurePolicyServiceTests` which failed with `dotnet: command not found`.
- Repository-level source inspection and targeted searches (`rg`) were used to validate that the new checks will prevent the previously identified `AddDays` overflow and unbounded bucket allocation code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17fed9d0688320a86449c4862f3985)