### PR TITLE
Tighten direct-lending command idempotency and reject mismatched CommandId reuse

### DIFF
--- a/src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.cs
+++ b/src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.cs
@@ -278,11 +278,22 @@ public sealed partial class PostgresDirectLendingStateStore : IDirectLendingStat
         await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
         await using var transaction = await connection.BeginTransactionAsync(IsolationLevel.Serializable, ct).ConfigureAwait(false);
 
-        if (metadata.CommandId is Guid commandId &&
-            await CommandAlreadyAppliedAsync(connection, transaction, loanId, commandId, ct).ConfigureAwait(false))
+        if (metadata.CommandId is Guid commandId)
         {
-            await transaction.CommitAsync(ct).ConfigureAwait(false);
-            return;
+            var duplicateStatus = await GetDuplicateCommandStatusAsync(connection, transaction, loanId, commandId, eventType, payload, ct).ConfigureAwait(false);
+            if (duplicateStatus is DuplicateCommandStatus.Matching)
+            {
+                await transaction.CommitAsync(ct).ConfigureAwait(false);
+                return;
+            }
+
+            if (duplicateStatus is DuplicateCommandStatus.Mismatched)
+            {
+                throw new DirectLendingCommandException(
+                    new DirectLendingCommandError(
+                        DirectLendingErrorCode.Conflict,
+                        $"Direct lending command id {commandId} was already used for a different mutation on loan {loanId}."));
+            }
         }
 
         var currentVersion = await LoadCurrentVersionAsync(connection, transaction, loanId, ct).ConfigureAwait(false);
@@ -304,18 +315,21 @@ public sealed partial class PostgresDirectLendingStateStore : IDirectLendingStat
         await transaction.CommitAsync(ct).ConfigureAwait(false);
     }
 
-    private async Task<bool> CommandAlreadyAppliedAsync(
+    private async Task<DuplicateCommandStatus> GetDuplicateCommandStatusAsync(
         NpgsqlConnection connection,
         NpgsqlTransaction transaction,
         Guid loanId,
         Guid commandId,
+        string eventType,
+        JsonDocument payload,
         CancellationToken ct)
     {
         await using var command = connection.CreateCommand();
         command.Transaction = transaction;
         command.CommandText =
             $"""
-            select 1
+            select event_type,
+                   payload_json::text
             from {Qualified("loan_event")}
             where loan_id = @loan_id
               and command_id = @command_id
@@ -324,8 +338,27 @@ public sealed partial class PostgresDirectLendingStateStore : IDirectLendingStat
         command.Parameters.AddWithValue("loan_id", loanId);
         command.Parameters.AddWithValue("command_id", commandId);
 
-        var existing = await command.ExecuteScalarAsync(ct).ConfigureAwait(false);
-        return existing is not null;
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        if (!await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            return DuplicateCommandStatus.None;
+        }
+
+        var existingEventType = reader.GetString(0);
+        var existingPayloadJson = reader.GetString(1);
+        var incomingPayloadJson = payload.RootElement.GetRawText();
+
+        return string.Equals(existingEventType, eventType, StringComparison.Ordinal) &&
+               string.Equals(existingPayloadJson, incomingPayloadJson, StringComparison.Ordinal)
+            ? DuplicateCommandStatus.Matching
+            : DuplicateCommandStatus.Mismatched;
+    }
+
+    private enum DuplicateCommandStatus
+    {
+        None = 0,
+        Matching = 1,
+        Mismatched = 2
     }
 
     private async Task AppendLedgerJournalEntriesAsync(

--- a/tests/Meridian.DirectLending.Tests/DirectLendingPostgresIntegrationTests.cs
+++ b/tests/Meridian.DirectLending.Tests/DirectLendingPostgresIntegrationTests.cs
@@ -87,6 +87,44 @@ public sealed class DirectLendingPostgresIntegrationTests
         history.Count(item => item.EventType == "loan.principal-payment-applied").Should().Be(1);
     }
 
+
+    [DirectLendingDatabaseFact]
+    public async Task CommandService_ShouldRejectDuplicateCommandId_WhenMutationDiffers()
+    {
+        await using var db = await DirectLendingPostgresTestDatabase.CreateOrSkipAsync();
+        if (db is null)
+        {
+            return;
+        }
+
+        var created = await db.Service.CreateLoanAsync(BuildCreateRequest());
+        await db.Service.ActivateLoanAsync(created.LoanId, new ActivateLoanRequest(new DateOnly(2026, 3, 22)));
+
+        var commandId = Guid.NewGuid();
+        var metadata = new DirectLendingCommandMetadataDto(
+            CausationId: Guid.NewGuid(),
+            CorrelationId: Guid.NewGuid(),
+            CommandId: commandId,
+            SourceSystem: "integration-tests",
+            ReplayFlag: false);
+
+        var first = await db.CommandService.ApplyPrincipalPaymentAsync(
+            created.LoanId,
+            new ApplyPrincipalPaymentRequest(50_000m, new DateOnly(2026, 4, 1), "wire-dup-2"),
+            metadata);
+        var second = await db.CommandService.ApplyPrincipalPaymentAsync(
+            created.LoanId,
+            new ApplyPrincipalPaymentRequest(10_000m, new DateOnly(2026, 4, 2), "wire-dup-3"),
+            metadata);
+
+        first.Error.Should().BeNull();
+        second.Error.Should().NotBeNull();
+        second.Error!.Code.Should().Be(DirectLendingErrorCode.Conflict);
+
+        var history = await db.Service.GetHistoryAsync(created.LoanId);
+        history.Count(item => item.EventType == "loan.principal-payment-applied").Should().Be(1);
+    }
+
     [DirectLendingDatabaseFact]
     public async Task AppendOperationsWorkflowAuditAsync_ShouldReturnLinearHashChainedStream()
     {


### PR DESCRIPTION
### Motivation
- Fix a vulnerability where reusing a previously-seen `CommandId` could cause `SaveAsync` to silently skip persistence while the caller still returned a successful DTO. 
- Ensure idempotency is safe by verifying a duplicate `CommandId` actually corresponds to the same persisted mutation (event type + payload). 
- Preserve legitimate retry semantics by still short-circuiting when the incoming command exactly matches the previously persisted event.

### Description
- Replace the earlier presence-only duplicate check with `GetDuplicateCommandStatusAsync(...)` which reads the persisted `event_type` and `payload_json` and compares them to the incoming `eventType` and `payload`.
- Update `SaveAsync(...)` to: short-circuit and commit the transaction when the duplicate status is `Matching`, and throw a `DirectLendingCommandException` with `DirectLendingErrorCode.Conflict` when the duplicate status is `Mismatched`.
- Introduce a `DuplicateCommandStatus` enum (`None`, `Matching`, `Mismatched`) to represent the duplicate-check outcome.
- Add an integration test `CommandService_ShouldRejectDuplicateCommandId_WhenMutationDiffers` in `tests/Meridian.DirectLending.Tests/DirectLendingPostgresIntegrationTests.cs` asserting that reusing the same `CommandId` with a different principal-payment payload returns a `Conflict` error and only one event is persisted.

### Testing
- Added an integration test `CommandService_ShouldRejectDuplicateCommandId_WhenMutationDiffers` to cover the new conflict path; the test is included in `tests/Meridian.DirectLending.Tests`.
- Attempted to run the targeted tests via `dotnet test` for the two duplicate-command scenarios but the runner failed because the environment is missing the .NET SDK (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17fedab9748320aca80d0b40879740)