### PR TITLE
Scope ledger period check in DailyAccrualWorker to loan's ledger book

### DIFF
--- a/src/Meridian.Application/DirectLending/DailyAccrualWorker.cs
+++ b/src/Meridian.Application/DirectLending/DailyAccrualWorker.cs
@@ -103,7 +103,7 @@ public sealed class DailyAccrualWorker : BackgroundService
                     continue;
                 }
 
-                var postingCheck = await CheckPostingDateAsync(accrualDate, ct).ConfigureAwait(false);
+                var postingCheck = await CheckPostingDateAsync(loanId, accrualDate, ct).ConfigureAwait(false);
                 if (postingCheck is not null && !string.Equals(postingCheck, "Allowed", StringComparison.Ordinal))
                 {
                     await RoutePeriodBlockedAsync(loanId, accrualDate, postingCheck, ct).ConfigureAwait(false);
@@ -146,14 +146,31 @@ public sealed class DailyAccrualWorker : BackgroundService
             accrualDate, posted, skipped, failed);
     }
 
-    private async Task<string?> CheckPostingDateAsync(DateOnly accrualDate, CancellationToken ct)
+    private async Task<string?> CheckPostingDateAsync(Guid loanId, DateOnly accrualDate, CancellationToken ct)
     {
         if (_ledgerJournalStore is null)
         {
             return null;
         }
 
-        var periods = await _ledgerJournalStore.ListPeriodsAsync(ct: ct).ConfigureAwait(false);
+        var aggregateEntries = await _ledgerJournalStore.GetByAggregateAsync(loanId, ct).ConfigureAwait(false);
+        var latestAggregatePeriodId = aggregateEntries
+            .OrderByDescending(static entry => entry.GlobalSequence)
+            .Select(static entry => (Guid?)entry.PeriodId)
+            .FirstOrDefault();
+
+        if (!latestAggregatePeriodId.HasValue)
+        {
+            return null;
+        }
+
+        var scopedPeriod = await _ledgerJournalStore.GetPeriodAsync(latestAggregatePeriodId.Value, ct).ConfigureAwait(false);
+        if (scopedPeriod?.LedgerBookId is not Guid ledgerBookId)
+        {
+            return null;
+        }
+
+        var periods = await _ledgerJournalStore.ListPeriodsAsync(ledgerBookId: ledgerBookId, ct: ct).ConfigureAwait(false);
         var periodDtos = periods.Select(static period => new AccountingPeriodDto(
             period.PeriodId,
             period.FiscalYear,


### PR DESCRIPTION
### Motivation
- Fix a security/control bug where `DailyAccrualWorker` was calling the posting-date check against all accounting periods, allowing unrelated ledger periods to incorrectly block or allow accrual postings.
- Ensure the posting-date decision is evaluated in the correct ledger-book context for the loan to preserve accounting-period controls and prevent cross-ledger poisoning.

### Description
- Change the posting-date call site to pass `loanId` by updating the call to `CheckPostingDateAsync(loanId, accrualDate, ct)`.
- Implement `CheckPostingDateAsync(Guid loanId, DateOnly accrualDate, CancellationToken ct)` to: resolve the loan's latest aggregate journal entry via `GetByAggregateAsync`, obtain the associated period with `GetPeriodAsync`, derive the `ledgerBookId`, and then call `ListPeriodsAsync(ledgerBookId: ledgerBookId, ct: ct)` before invoking `LedgerInterop.CheckPostingDate`.
- Preserve fail-open semantics by returning `null` when no scoped period or ledger book can be determined, avoiding behavior changes when ledger context is not available.
- Keep the operator inbox routing and existing logging/metrics behavior unchanged.

### Testing
- Attempted to run unit tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "Category!=Integration" --logger "console;verbosity=minimal"`, but the run failed in this environment because `dotnet` is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a174712a5388320a31a80212315b86e)