### PR TITLE
Fix expired future lifecycle/front-month precedence bug

### DIFF
--- a/src/Meridian.Application/Futures/FutureProjectionService.cs
+++ b/src/Meridian.Application/Futures/FutureProjectionService.cs
@@ -42,8 +42,10 @@ public sealed class FutureProjectionService : IFutureReferenceService
     public async Task<IReadOnlyList<FutureReferenceDto>> GetExpiryLadderAsync(string rootSymbol, CancellationToken ct = default)
     {
         var all = await GetByRootSymbolAsync(rootSymbol, ct).ConfigureAwait(false);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
         return all
             .Where(r => r.LifecycleStat is not FutureLifecycleStat.Expired and not FutureLifecycleStat.Retired)
+            .Where(r => r.ExpiryDate >= today)
             .OrderBy(r => r.ExpiryDate)
             .ToArray();
     }

--- a/src/Meridian.Storage/SecurityMaster/PostgresSecurityMasterStore.cs
+++ b/src/Meridian.Storage/SecurityMaster/PostgresSecurityMasterStore.cs
@@ -1236,8 +1236,8 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
         var lastTradingDate = GetOptionalDateOnly(record.AssetSpecificTerms, "lastTradingDt") ?? expiryDate;
         var lifecycleStat =
             record.EffectiveTo.HasValue ? "Retired" :
-            isRollTarget ? "RollTarget" :
             expiryDate.Value < DateOnly.FromDateTime(DateTime.UtcNow) ? "Expired" :
+            isRollTarget ? "RollTarget" :
             "Active";
 
         await using var command = connection.CreateCommand();

--- a/tests/Meridian.Tests/Futures/FutureProjectionServiceTests.cs
+++ b/tests/Meridian.Tests/Futures/FutureProjectionServiceTests.cs
@@ -9,13 +9,14 @@ namespace Meridian.Tests.Futures;
 public sealed class FutureProjectionServiceTests
 {
     [Fact]
-    public async Task GetExpiryLadderAsync_ExcludesRetiredContracts()
+    public async Task GetExpiryLadderAsync_ExcludesRetiredAndExpiredContracts()
     {
         IReadOnlyList<FutureProjectionRow> rows =
         [
             MakeRow(Guid.NewGuid(), "ES", "ESZ6", new DateOnly(2026, 12, 19), false, "Active"),
             MakeRow(Guid.NewGuid(), "ES", "ESH7", new DateOnly(2027, 3, 19), false, "Active"),
-            MakeRow(Guid.NewGuid(), "ES", "ESH5", new DateOnly(2025, 3, 21), false, "Retired")
+            MakeRow(Guid.NewGuid(), "ES", "ESH5", new DateOnly(2025, 3, 21), false, "Retired"),
+            MakeRow(Guid.NewGuid(), "ES", "ESM6", new DateOnly(2026, 6, 19), false, "Expired")
         ];
 
         var projectionStore = Substitute.For<IFutureReferenceProjectionStore>();
@@ -69,6 +70,26 @@ public sealed class FutureProjectionServiceTests
         frontMonth!.PrimaryIdentifier.Should().Be("ESU6");
     }
 
+
+    [Fact]
+    public async Task GetFrontMonthAsync_IgnoresPastExpiryRollTargetsEvenWhenLifecycleIsRollTarget()
+    {
+        IReadOnlyList<FutureProjectionRow> rows =
+        [
+            MakeRow(Guid.NewGuid(), "ES", "ESM5", new DateOnly(2025, 6, 20), true, "RollTarget"),
+            MakeRow(Guid.NewGuid(), "ES", "ESU6", new DateOnly(2026, 9, 18), false, "Active")
+        ];
+
+        var projectionStore = Substitute.For<IFutureReferenceProjectionStore>();
+        projectionStore.GetByRootSymbolAsync("ES", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(rows));
+        var service = new FutureProjectionService(Substitute.For<ISecurityMasterStore>(), projectionStore);
+
+        var frontMonth = await service.GetFrontMonthAsync("ES");
+
+        frontMonth.Should().NotBeNull();
+        frontMonth!.PrimaryIdentifier.Should().Be("ESU6");
+    }
     [Fact]
     public async Task GetExpiryLadderAsync_ReturnsEmpty_ForBlankRootSymbol()
     {


### PR DESCRIPTION
### Motivation
- Prevent expired futures from being persisted or selected as the front-month when a user-supplied `isRollTarget` flag is present, which could poison `/api/reference-data/futures/front-month` with past-expiry contracts. 

### Description
- In `PostgresSecurityMasterStore.UpsertFutureProjectionAsync` adjusted lifecycle precedence so expiry is checked before honoring `isRollTarget`, ensuring past-expiry futures are recorded as `Expired` rather than `RollTarget`. 
- Hardened `FutureProjectionService.GetExpiryLadderAsync` to explicitly filter out rows whose `ExpiryDate` is before today in addition to excluding `Retired`/`Expired` lifecycle values. 
- Kept `GetFrontMonthAsync` behavior (prefer valid roll targets over active contracts) but made it operate over the new expiry-filtered ladder. 
- Added and updated unit tests in `tests/Meridian.Tests/Futures/FutureProjectionServiceTests.cs` to assert expired contracts are excluded and that a past-expiry `RollTarget` is not chosen as front month. 

### Testing
- Attempted to run the focused unit tests with `dotnet test --filter "FullyQualifiedName~FutureProjectionServiceTests"`, but the environment lacks the .NET SDK (`dotnet: command not found`), so automated tests could not be executed here. 
- The change includes new/updated test assertions covering the ladder exclusion and poisoned-roll-target scenario (tests added to `FutureProjectionServiceTests`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a174713c2f883208805dbeecfd9df32)