### PR TITLE
fix(session-stats): prevent overflow in session change percent

### DIFF
--- a/src/Meridian.Contracts/Domain/Models/SessionStats.cs
+++ b/src/Meridian.Contracts/Domain/Models/SessionStats.cs
@@ -34,5 +34,20 @@ public sealed record SessionStats(
     /// Percentage change from the session open to the most recent trade. Returns
     /// <c>null</c> when the open price is zero (cannot compute a percentage).
     /// </summary>
-    public decimal? ChangePercent => Open == 0m ? null : (Last - Open) / Open * 100m;
+    public decimal? ChangePercent => ComputeChangePercent(Open, Last);
+
+    private static decimal? ComputeChangePercent(decimal open, decimal last)
+    {
+        if (open == 0m)
+            return null;
+
+        try
+        {
+            return (last - open) / open * 100m;
+        }
+        catch (OverflowException)
+        {
+            return null;
+        }
+    }
 }

--- a/tests/Meridian.Tests/Domain/Collectors/SessionStatsCollectorTests.cs
+++ b/tests/Meridian.Tests/Domain/Collectors/SessionStatsCollectorTests.cs
@@ -33,6 +33,26 @@ public class SessionStatsCollectorTests
         stats.ChangePercent.Should().Be(0m);
     }
 
+
+    [Fact]
+    public void ChangePercent_WithExtremelySmallOpen_DoesNotThrowAndReturnsNull()
+    {
+        var stats = new SessionStats(
+            Symbol: "AAPL",
+            SessionDate: new DateOnly(2026, 5, 8),
+            Open: 0.0000000000000000000000000001m,
+            High: 1m,
+            Low: 0.0000000000000000000000000001m,
+            Last: 1m,
+            Volume: 1,
+            Vwap: 1m,
+            TradeCount: 2,
+            FirstTradeAt: new DateTimeOffset(2026, 5, 8, 13, 30, 0, TimeSpan.Zero),
+            LastTradeAt: new DateTimeOffset(2026, 5, 8, 13, 31, 0, TimeSpan.Zero));
+
+        stats.ChangePercent.Should().BeNull();
+    }
+
     [Fact]
     public void OnTrade_MultipleTrades_ComputesHighLowVolumeAndVwap()
     {


### PR DESCRIPTION
### Motivation
- Prevent an availability issue where untrusted tiny positive `Open` prices can make `ChangePercent` overflow and throw `OverflowException`, causing live-quote API/UI requests to return 500 until session state resets.

### Description
- Route `SessionStats.ChangePercent` through a helper `ComputeChangePercent` that returns `null` when `open == 0` or when the decimal arithmetic throws `OverflowException`, preserving normal percent computation for valid inputs.
- Add a regression test `ChangePercent_WithExtremelySmallOpen_DoesNotThrowAndReturnsNull` to ensure an extremely small `Open` with a normal `Last` does not throw and yields `null`.

### Testing
- Attempted to run the focused test slice `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~SessionStatsCollectorTests"`, which could not execute in this environment because `dotnet` is not installed and the command failed with `dotnet: command not found` (no automated test run succeeded here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17471298d08320b11402865b0ef078)