### PR TITLE
Fix cross-session leakage in security details local storage

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/meridian/security-details-tracker.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/security-details-tracker.tsx
@@ -39,6 +39,7 @@ const defaultOperatorOverridesService: OperatorOverridesService = {
 
 const STORAGE_PREFIX_OVERRIDES = "meridian.security.overrides.";
 const STORAGE_PREFIX_LOTS = "meridian.security.lots.";
+const STORAGE_NAMESPACE = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 const OVERRIDES_CHANGED_EVENT = "meridian:security-overrides-changed";
 
 interface OverridesChangedDetail {
@@ -74,11 +75,15 @@ function safeLocalStorage(): Storage | null {
   }
 }
 
+function storageKey(prefix: string, securityId: string): string {
+  return `${prefix}${STORAGE_NAMESPACE}.${securityId}`;
+}
+
 function loadOverrides(securityId: string): Record<string, string> {
   const ls = safeLocalStorage();
   if (!ls) return {};
   try {
-    const raw = ls.getItem(STORAGE_PREFIX_OVERRIDES + securityId);
+    const raw = ls.getItem(storageKey(STORAGE_PREFIX_OVERRIDES, securityId));
     if (!raw) return {};
     const parsed = JSON.parse(raw);
     return parsed && typeof parsed === "object" ? (parsed as Record<string, string>) : {};
@@ -91,7 +96,7 @@ function saveOverrides(securityId: string, overrides: Record<string, string>): v
   const ls = safeLocalStorage();
   if (!ls) return;
   try {
-    ls.setItem(STORAGE_PREFIX_OVERRIDES + securityId, JSON.stringify(overrides));
+    ls.setItem(storageKey(STORAGE_PREFIX_OVERRIDES, securityId), JSON.stringify(overrides));
   } catch {
     // ignore quota / serialization errors
   }
@@ -462,7 +467,7 @@ function loadLots(securityId: string): SecurityLot[] {
   const ls = safeLocalStorage();
   if (!ls) return [];
   try {
-    const raw = ls.getItem(STORAGE_PREFIX_LOTS + securityId);
+    const raw = ls.getItem(storageKey(STORAGE_PREFIX_LOTS, securityId));
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
@@ -481,7 +486,7 @@ function saveLots(securityId: string, lots: SecurityLot[]): void {
   const ls = safeLocalStorage();
   if (!ls) return;
   try {
-    ls.setItem(STORAGE_PREFIX_LOTS + securityId, JSON.stringify(lots));
+    ls.setItem(storageKey(STORAGE_PREFIX_LOTS, securityId), JSON.stringify(lots));
   } catch {
     // ignore quota errors
   }


### PR DESCRIPTION
### Motivation
- The security details and lots tracker persisted sensitive per-security overrides and lot data in `localStorage` keyed only by `securityId`, which leaks data across authenticated users sharing the same browser profile. 
- The goal is to prevent automatic reuse of prior user's local UI data after logout/login (or page reload) while preserving offline/in-session persistence and server sync behavior.

### Description
- Add an ephemeral app-instance namespace `STORAGE_NAMESPACE` and a shared `storageKey(...)` helper to compose persisted keys so they are not stable across page loads. 
- Update overrides read/write to use `storageKey(STORAGE_PREFIX_OVERRIDES, securityId)` instead of `STORAGE_PREFIX_OVERRIDES + securityId`. 
- Update lots read/write to use `storageKey(STORAGE_PREFIX_LOTS, securityId)` instead of `STORAGE_PREFIX_LOTS + securityId`. 
- Changes are scoped to `src/Meridian.Ui/dashboard/src/components/meridian/security-details-tracker.tsx` and do not alter server APIs or lot/PL calculations.

### Testing
- Attempted targeted dashboard unit test `npm run test -- security-details-tracker --runInBand` which failed in this environment due to a missing test runtime (`node_modules/vitest/vitest.mjs`), so no automated tests passed.  
- No other automated test runs were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1747129d5c832086dc7b2e76b46355)