### PR TITLE
Honor report-pack validation in trading readiness gate

### DIFF
--- a/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs
@@ -631,12 +631,25 @@ public sealed class TradingOperatorReadinessService
             return null;
         }
 
-        var status = snapshot.Warnings.Count == 0 && snapshot.Artifacts.Count > 0
-            ? TradingAcceptanceGateStatusDto.Ready
-            : TradingAcceptanceGateStatusDto.ReviewRequired;
-        var detail = status == TradingAcceptanceGateStatusDto.Ready
-            ? $"Report pack {snapshot.ReportId:D} retains {snapshot.Artifacts.Count} artifact(s) and links to run {matchedRunId}."
-            : $"Report pack {snapshot.ReportId:D} links to run {matchedRunId}, but {snapshot.Warnings.Count} warning(s) require review.";
+        var warningIssueCount = snapshot.ValidationIssues.Count(issue => issue.Severity == GovernanceReportValidationSeverityDto.Warning);
+        var criticalIssueCount = snapshot.ValidationIssues.Count(issue => issue.Severity == GovernanceReportValidationSeverityDto.Critical);
+        var hasArtifacts = snapshot.Artifacts.Count > 0;
+        var status = !hasArtifacts
+            ? TradingAcceptanceGateStatusDto.ReviewRequired
+            : criticalIssueCount > 0
+                ? TradingAcceptanceGateStatusDto.Blocked
+                : snapshot.Status != GovernanceReportPackStatusDto.Validated || warningIssueCount > 0 || snapshot.Warnings.Count > 0
+                    ? TradingAcceptanceGateStatusDto.ReviewRequired
+                    : TradingAcceptanceGateStatusDto.Ready;
+        var detail = status switch
+        {
+            TradingAcceptanceGateStatusDto.Ready =>
+                $"Report pack {snapshot.ReportId:D} retains {snapshot.Artifacts.Count} artifact(s), is {snapshot.Status}, and links to run {matchedRunId}.",
+            TradingAcceptanceGateStatusDto.Blocked =>
+                $"Report pack {snapshot.ReportId:D} links to run {matchedRunId}, but {criticalIssueCount} critical validation issue(s) block readiness.",
+            _ =>
+                $"Report pack {snapshot.ReportId:D} links to run {matchedRunId}, but status {snapshot.Status} with {warningIssueCount} warning validation issue(s) and {snapshot.Warnings.Count} legacy warning(s) requires review."
+        };
 
         return new TradingReportPackReadinessDto(
             Status: status,

--- a/tests/Meridian.Tests/Ui/TradingOperatorReadinessServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/TradingOperatorReadinessServiceTests.cs
@@ -447,6 +447,97 @@ public sealed class TradingOperatorReadinessServiceTests
             item.WorkItemId.StartsWith("paper-replay-mismatch", StringComparison.OrdinalIgnoreCase));
     }
 
+
+    [Fact]
+    public void BuildReportPackReadinessForRuns_WithCriticalValidationIssue_ShouldBlockReadiness()
+    {
+        var snapshot = CreateReportPackSnapshot(
+            status: GovernanceReportPackStatusDto.ReviewRequired,
+            warnings: [],
+            validationIssues:
+            [
+                new FundReportPackValidationIssueDto(
+                    Code: "report-pack.missing-ledger-postings",
+                    Severity: GovernanceReportValidationSeverityDto.Critical,
+                    Title: "Missing ledger postings",
+                    Message: "Missing ledger postings for as-of snapshot.")
+            ]);
+
+        var readiness = InvokeBuildReportPackReadinessForRuns(snapshot, ["run-1"]);
+
+        readiness.Should().NotBeNull();
+        readiness!.Status.Should().Be(TradingAcceptanceGateStatusDto.Blocked);
+        readiness.Detail.Should().Contain("critical validation issue", StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildReportPackReadinessForRuns_WithValidatedStatusAndNoIssues_ShouldMarkReady()
+    {
+        var snapshot = CreateReportPackSnapshot(
+            status: GovernanceReportPackStatusDto.Validated,
+            warnings: [],
+            validationIssues: []);
+
+        var readiness = InvokeBuildReportPackReadinessForRuns(snapshot, ["run-1"]);
+
+        readiness.Should().NotBeNull();
+        readiness!.Status.Should().Be(TradingAcceptanceGateStatusDto.Ready);
+    }
+
+
+    private static TradingReportPackReadinessDto? InvokeBuildReportPackReadinessForRuns(
+        FundReportPackSnapshotDto snapshot,
+        IReadOnlyList<string> candidateRunIds)
+    {
+        var method = typeof(TradingOperatorReadinessService).GetMethod(
+            "BuildReportPackReadinessForRuns",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull();
+        return (TradingReportPackReadinessDto?)method!.Invoke(null, [snapshot, candidateRunIds, null]);
+    }
+
+    private static FundReportPackSnapshotDto CreateReportPackSnapshot(
+        GovernanceReportPackStatusDto status,
+        IReadOnlyList<string> warnings,
+        IReadOnlyList<FundReportPackValidationIssueDto> validationIssues)
+        => new(
+            ReportId: Guid.NewGuid(),
+            FundProfileId: "fund-1",
+            DisplayName: "Fund 1",
+            ReportKind: GovernanceReportKindDto.TrialBalance,
+            Currency: "USD",
+            AsOf: new DateTimeOffset(2026, 5, 1, 0, 0, 0, TimeSpan.Zero),
+            GeneratedAt: new DateTimeOffset(2026, 5, 1, 1, 0, 0, TimeSpan.Zero),
+            TotalNetAssets: 100m,
+            AuditActor: "ops",
+            CorrelationId: "corr-1",
+            DecisionRationale: null,
+            Provenance: new FundReportPackProvenanceDto(
+                RelatedRunIds: ["run-1"],
+                JournalEntryCount: 0,
+                LedgerEntryCount: 0,
+                TrialBalanceLineCount: 1,
+                ReconciliationRunCount: 0,
+                OpenReconciliationBreakCount: 0,
+                SecurityResolvedCount: 0,
+                SecurityMissingCount: 0,
+                LineagePointers: [],
+                SourceSnapshotHash: new string('a', 64)),
+            Artifacts:
+            [
+                new FundReportPackArtifactDto(
+                    ArtifactKind: "trial-balance",
+                    Format: GovernanceReportArtifactFormatDto.Json,
+                    RelativePath: "trial-balance.json",
+                    SizeBytes: 10,
+                    ChecksumSha256: new string('b', 64))
+            ],
+            Warnings: warnings)
+        {
+            Status = status,
+            ValidationIssues = validationIssues
+        };
+
     private static ExecutionAuditTrailService CreateAuditTrail(string scenario)
     {
         var root = Path.Combine(


### PR DESCRIPTION
### Motivation

- The trading readiness gate previously considered only legacy `Warnings` and artifact presence, which could mark a report pack `Ready` even when persisted `ValidationIssues` (including `Critical`) or non-`Validated` `Status` existed, undermining governance controls.

### Description

- Update `TradingOperatorReadinessService.BuildReportPackReadinessForRuns` to count `ValidationIssues` by severity and incorporate `snapshot.Status` and those counts into the readiness decision.
- Readiness now returns `Blocked` when any `Critical` validation issue is present, `ReviewRequired` when artifacts are missing or `Status != Validated` or warning issues/legacy warnings exist, and `Ready` only when artifacts exist, `Status == Validated`, and there are no warning/critical validation issues or legacy warnings; detail messages were enhanced to include validation context.
- Added unit tests in `tests/Meridian.Tests/Ui/TradingOperatorReadinessServiceTests.cs` to assert that a critical validation issue yields `Blocked` and that a validated, issue-free snapshot yields `Ready`.
- Files changed: `src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs` and `tests/Meridian.Tests/Ui/TradingOperatorReadinessServiceTests.cs`.

### Testing

- Added focused unit tests (`TradingOperatorReadinessServiceTests`) covering critical and validated scenarios but running `dotnet test Meridian.sln --no-restore --filter TradingOperatorReadinessServiceTests` in this environment failed because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18015bb7508320baf00a3a101e2cda)