### PR TITLE
Protect provider-routing endpoints behind ManageCredentials permission

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/ProviderRoutingEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ProviderRoutingEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Meridian.Application.ProviderRouting;
 using Meridian.Contracts.Api;
+using Meridian.Contracts.Auth;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 
@@ -19,6 +20,11 @@ public static class ProviderRoutingEndpoints
             ProviderConnectionService service,
             HttpContext context) =>
         {
+            if (!HasManageCredentialsPermission(context))
+            {
+                return EndpointHelpers.Forbidden();
+            }
+
             var result = await service.GetConnectionsAsync(context.RequestAborted).ConfigureAwait(false);
             return Results.Json(result, jsonOptions);
         })
@@ -30,6 +36,11 @@ public static class ProviderRoutingEndpoints
             ProviderBindingService service,
             HttpContext context) =>
         {
+            if (!HasManageCredentialsPermission(context))
+            {
+                return EndpointHelpers.Forbidden();
+            }
+
             var result = await service.GetBindingsAsync(context.RequestAborted).ConfigureAwait(false);
             return Results.Json(result, jsonOptions);
         })
@@ -41,6 +52,11 @@ public static class ProviderRoutingEndpoints
             ProviderTrustScoringService service,
             HttpContext context) =>
         {
+            if (!HasManageCredentialsPermission(context))
+            {
+                return EndpointHelpers.Forbidden();
+            }
+
             var result = await service.GetTrustSnapshotsAsync(context.RequestAborted).ConfigureAwait(false);
             return Results.Json(result, jsonOptions);
         })
@@ -53,6 +69,11 @@ public static class ProviderRoutingEndpoints
             ProviderRouteExplainabilityService service,
             HttpContext context) =>
         {
+            if (!HasManageCredentialsPermission(context))
+            {
+                return EndpointHelpers.Forbidden();
+            }
+
             var result = await service.PreviewAsync(request, context.RequestAborted).ConfigureAwait(false);
             return Results.Json(result, jsonOptions);
         })
@@ -60,4 +81,7 @@ public static class ProviderRoutingEndpoints
         .WithDescription("Previews the selected provider route for a capability request.")
         .Produces<RoutePreviewResponse>(StatusCodes.Status200OK);
     }
+
+    private static bool HasManageCredentialsPermission(HttpContext context)
+        => EndpointAuthorization.HasPermission(context, UserPermission.ManageCredentials);
 }


### PR DESCRIPTION
### Motivation
- The new provider-routing read endpoints returned provider connection and routing metadata (including credential references and account identifiers) without any permission check, creating an access-control bypass relative to the existing provider connection endpoints.

### Description
- Add a fail-closed `ManageCredentials` permission gate to all provider-routing routes (`connections`, `bindings`, `trust snapshots`, and `route preview`) that returns `EndpointHelpers.Forbidden()` when absent.
- Reuse existing authorization helpers by importing `Meridian.Contracts.Auth` and adding a local `HasManageCredentialsPermission(HttpContext)` helper that calls `EndpointAuthorization.HasPermission(..., UserPermission.ManageCredentials)`.

### Testing
- No automated runtime tests were executed because the environment lacks the .NET SDK ( `dotnet` reported as not found ), so no `dotnet test` run was possible; the change was validated via static inspection and diff review and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1802871e208320baab8c6306b0e043)