### PR TITLE
Batch file searches in backfill endpoints to avoid per-symbol full scans

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/BackfillValidationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/BackfillValidationEndpoints.cs
@@ -42,14 +42,20 @@ public static class BackfillValidationEndpoints
             try
             {
                 var results = new List<BackfillValidationResult>();
+                var distinctSymbols = symbols.Select(s => s.Symbol).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+                var searchResult = await searchService.SearchFilesAsync(
+                    new FileSearchQuery(Symbols: distinctSymbols, Take: 10_000),
+                    ct);
+                var filesBySymbol = searchResult.Results
+                    .GroupBy(r => r.Symbol, StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(g => g.Key, g => g.ToArray(), StringComparer.OrdinalIgnoreCase);
 
-                foreach (var symbol in symbols.Select(s => s.Symbol).Distinct())
+                foreach (var symbol in distinctSymbols)
                 {
-                    var searchResult = await searchService.SearchFilesAsync(
-                        new FileSearchQuery(Symbols: [symbol], Take: 10_000),
-                        ct);
+                    filesBySymbol.TryGetValue(symbol, out var symbolFiles);
+                    symbolFiles ??= [];
 
-                    if (searchResult.TotalMatches == 0)
+                    if (symbolFiles.Length == 0)
                     {
                         results.Add(new BackfillValidationResult(
                             Symbol: symbol,
@@ -62,9 +68,9 @@ public static class BackfillValidationEndpoints
                         continue;
                     }
 
-                    var tradingDates = GetTradingDates(searchResult.Results);
-                    var completeness = CalculateSymbolCompleteness(searchResult.Results);
-                    var gaps = DetectSymbolGaps(searchResult.Results, symbol);
+                    var tradingDates = GetTradingDates(symbolFiles);
+                    var completeness = CalculateSymbolCompleteness(symbolFiles);
+                    var gaps = DetectSymbolGaps(symbolFiles, symbol);
                     var totalDays = tradingDates.Count == 0
                         ? 0
                         : CalculateExpectedTradingDays(tradingDates.First(), tradingDates.Last());
@@ -179,12 +185,14 @@ public static class BackfillValidationEndpoints
             {
                 try
                 {
-                    foreach (var symbol in symbols.Select(s => s.Symbol))
+                    var distinctSymbols = symbols.Select(s => s.Symbol).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+                    var result = await searchService.SearchFilesAsync(
+                        new FileSearchQuery(Symbols: distinctSymbols, Take: 10_000),
+                        ct);
+
+                    foreach (var symbolGroup in result.Results.GroupBy(r => r.Symbol, StringComparer.OrdinalIgnoreCase))
                     {
-                        var result = await searchService.SearchFilesAsync(
-                            new FileSearchQuery(Symbols: [symbol], Take: 10_000),
-                            ct);
-                        allGaps.AddRange(DetectSymbolGaps(result.Results, symbol));
+                        allGaps.AddRange(DetectSymbolGaps(symbolGroup, symbolGroup.Key));
                     }
                 }
                 catch { /* non-critical */ }
@@ -219,12 +227,14 @@ public static class BackfillValidationEndpoints
             {
                 try
                 {
-                    foreach (var symbol in symbols.Select(s => s.Symbol))
+                    var distinctSymbols = symbols.Select(s => s.Symbol).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+                    var result = await searchService.SearchFilesAsync(
+                        new FileSearchQuery(Symbols: distinctSymbols, Take: 10_000),
+                        ct);
+
+                    foreach (var symbolGroup in result.Results.GroupBy(r => r.Symbol, StringComparer.OrdinalIgnoreCase))
                     {
-                        var result = await searchService.SearchFilesAsync(
-                            new FileSearchQuery(Symbols: [symbol], Take: 10_000),
-                            ct);
-                        completenessScores[symbol] = CalculateSymbolCompleteness(result.Results);
+                        completenessScores[symbolGroup.Key] = CalculateSymbolCompleteness(symbolGroup);
                     }
                 }
                 catch { /* non-critical */ }


### PR DESCRIPTION
### Motivation
- The all-symbol backfill endpoints (`/api/backfill/validation`, `/api/backfill/gaps`, `/api/backfill/completeness`) were invoking `SearchFilesAsync` once per configured symbol while `SearchFilesAsync` enumerates all data files first, producing an O(symbols * files) storage-scan amplification and an availability risk.

### Description
- Replace per-symbol `SearchFilesAsync` calls with a single batched `SearchFilesAsync` using the distinct symbol list, then group results in-memory by symbol. 
- Update the validation, gaps, and completeness handlers in `src/Meridian.Ui.Shared/Endpoints/BackfillValidationEndpoints.cs` to read from the grouped results for per-symbol calculations (completeness, gaps, trading dates) while preserving response shapes.
- Leave the single-symbol endpoint (`BackfillValidationBySymbol`) behavior intact and keep changes localized to the backfill endpoints.

### Testing
- Attempted to build the modified project with `dotnet build src/Meridian.Ui.Shared/Meridian.Ui.Shared.csproj -c Debug`, which failed because the environment lacks `dotnet` (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1804403090832080c9342f9466e165)