### PR TITLE
fix(historical): require explicit date bounds on historical bars endpoint

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/HistoricalEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/HistoricalEndpoints.cs
@@ -116,6 +116,16 @@ public static class HistoricalEndpoints
                 return Results.BadRequest(new { error = "Symbol is required" });
             }
 
+            if (!from.HasValue || !to.HasValue)
+            {
+                return Results.BadRequest(new { error = "from and to date bounds are required" });
+            }
+
+            if (to.Value < from.Value)
+            {
+                return Results.BadRequest(new { error = "to must be on or after from" });
+            }
+
             var interval = intervalMinutes ?? 5;
             if (interval <= 0 || interval > 1440)
             {

--- a/tests/Meridian.Tests/Integration/EndpointTests/HistoricalEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/HistoricalEndpointTests.cs
@@ -229,9 +229,9 @@ public sealed class HistoricalEndpointTests
     #region GET /api/historical/{symbol}/bars - Aggregated OHLCV
 
     [Fact]
-    public async Task GetSymbolBars_WithSymbol_ReturnsOk()
+    public async Task GetSymbolBars_WithSymbolAndDateRange_ReturnsOk()
     {
-        var response = await _client.GetAsync("/api/historical/SPY/bars?intervalMinutes=5");
+        var response = await _client.GetAsync("/api/historical/SPY/bars?intervalMinutes=5&from=2024-01-01&to=2024-01-02");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType!.MediaType.Should().Be("application/json");
@@ -248,21 +248,17 @@ public sealed class HistoricalEndpointTests
     }
 
     [Fact]
-    public async Task GetSymbolBars_DefaultIntervalIsFiveMinutes()
+    public async Task GetSymbolBars_WithoutDateBounds_ReturnsBadRequest()
     {
         var response = await _client.GetAsync("/api/historical/SPY/bars");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        var content = await response.Content.ReadAsStringAsync();
-        var doc = JsonDocument.Parse(content);
-        doc.RootElement.GetProperty("intervalMinutes").GetInt32().Should().Be(5);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
     public async Task GetSymbolBars_WithInvalidInterval_ReturnsBadRequest()
     {
-        var response = await _client.GetAsync("/api/historical/SPY/bars?intervalMinutes=0");
+        var response = await _client.GetAsync("/api/historical/SPY/bars?intervalMinutes=0&from=2024-01-01&to=2024-01-02");
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
@@ -270,7 +266,17 @@ public sealed class HistoricalEndpointTests
     [Fact]
     public async Task GetSymbolBars_WithExcessiveInterval_ReturnsBadRequest()
     {
-        var response = await _client.GetAsync("/api/historical/SPY/bars?intervalMinutes=99999");
+        var response = await _client.GetAsync("/api/historical/SPY/bars?intervalMinutes=99999&from=2024-01-01&to=2024-01-02");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+
+    [Fact]
+    public async Task GetSymbolBars_WithInvalidDateRange_ReturnsBadRequest()
+    {
+        var response = await _client.GetAsync(
+            "/api/historical/SPY/bars?intervalMinutes=5&from=2024-01-31&to=2024-01-01");
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }


### PR DESCRIPTION
### Motivation

- The `GET /api/historical/{symbol}/bars` endpoint could be invoked without `from`/`to` bounds which allowed the service to scan/decompress/parse all historical files before applying the `maxBars` cap, creating an availability risk on large stores. 

### Description

- Add request validation in `src/Meridian.Ui.Shared/Endpoints/HistoricalEndpoints.cs` to require both `from` and `to` query parameters and to validate that `to` is on or after `from`. 
- Preserve existing interval and `maxBars` validation so behavior for bounded requests is unchanged. 
- Update integration tests in `tests/Meridian.Tests/Integration/EndpointTests/HistoricalEndpointTests.cs` to use bounded ranges for success cases, assert a `400 Bad Request` when bounds are omitted, and add a test asserting `400` for `to < from`. 
- Files changed: `src/Meridian.Ui.Shared/Endpoints/HistoricalEndpoints.cs` and `tests/Meridian.Tests/Integration/EndpointTests/HistoricalEndpointTests.cs`.

### Testing

- Updated integration tests under `tests/Meridian.Tests/Integration/EndpointTests` to reflect the new required bounds and added a test for invalid date ordering. 
- An attempt was made to run the endpoint tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter FullyQualifiedName~HistoricalEndpointTests`, but execution failed due to the environment lacking the .NET SDK (`dotnet: command not found`). 
- No automated test run results are available from this environment, but the test suite was updated to assert the new validation behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18043fafa48320952ef5dcad4b3273)