### PR TITLE
fix: enforce MaxOrderNotional for market-style orders (fail-closed when price unknown)

### DIFF
--- a/src/Meridian.Execution/Adapters/BrokerageGatewayAdapter.cs
+++ b/src/Meridian.Execution/Adapters/BrokerageGatewayAdapter.cs
@@ -92,7 +92,10 @@ public sealed class BrokerageGatewayAdapter : IOrderGateway
         if (_configuration.MaxOrderNotional > 0m)
         {
             var effectivePrice = ResolveEffectivePrice(request);
-            if (effectivePrice.HasValue && (request.Quantity * effectivePrice.Value) > _configuration.MaxOrderNotional)
+            if (!effectivePrice.HasValue)
+                return new OrderValidationResult(false, "Unable to evaluate order notional for this order type without a price input.");
+
+            if ((request.Quantity * effectivePrice.Value) > _configuration.MaxOrderNotional)
                 return new OrderValidationResult(false, $"Order notional exceeds configured maximum of {_configuration.MaxOrderNotional}.");
         }
 

--- a/tests/Meridian.Tests/Execution/BrokerageGatewayAdapterTests.cs
+++ b/tests/Meridian.Tests/Execution/BrokerageGatewayAdapterTests.cs
@@ -201,6 +201,29 @@ public sealed class BrokerageGatewayAdapterTests
         result.Reason.Should().Contain("notional");
     }
 
+
+    [Fact]
+    public async Task ValidateOrderAsync_RejectsOrderWhenNotionalCannotBeEvaluated()
+    {
+        var config = new BrokerageConfiguration { MaxOrderNotional = 100m };
+        await using var adapter = new BrokerageGatewayAdapter(
+            CreateMockGateway(),
+            NullLogger<BrokerageGatewayAdapter>.Instance,
+            config);
+        var request = new OrderRequest
+        {
+            Symbol = "AAPL",
+            Side = OrderSide.Buy,
+            Type = SdkOrderType.Market,
+            Quantity = 2m
+        };
+
+        var result = await adapter.ValidateOrderAsync(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Reason.Should().Contain("Unable to evaluate order notional");
+    }
+
     [Fact]
     public async Task ValidateOrderAsync_RejectsOrderWhenOpenOrderLimitReached()
     {


### PR DESCRIPTION
### Motivation
- Close a pre-trade risk-control bypass where `MaxOrderNotional` was skipped if `ResolveEffectivePrice` returned null, allowing oversized market-style orders to pass validation.
- Ensure the configured notional guardrail either applies or conservatively rejects orders whose notional cannot be estimated.

### Description
- Updated `BrokerageGatewayAdapter.ValidateOrderAsync` to return a failure when `_configuration.MaxOrderNotional > 0m` and `ResolveEffectivePrice(request)` is `null`, with the message `"Unable to evaluate order notional for this order type without a price input."`.
- Retained the existing notional rejection behavior when an effective price is available and the computed `price * quantity` exceeds `MaxOrderNotional`.
- Added a regression unit test `ValidateOrderAsync_RejectsOrderWhenNotionalCannotBeEvaluated` in `tests/Meridian.Tests/Execution/BrokerageGatewayAdapterTests.cs` that asserts a market order with no price fields is rejected when `MaxOrderNotional` is configured.

### Testing
- Attempted to run the targeted tests with `dotnet test --filter FullyQualifiedName~BrokerageGatewayAdapterTests --no-restore` but the environment lacks the .NET SDK (`bash: command not found: dotnet`).
- No unit tests were executed in this environment, however a focused regression test was added and should pass under CI or a local environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17fed9ce2c8320b92c8bc709cb9c6d)