### PR TITLE
Restore crash-safe atomic appends for dead-letter and dropped-event audit logs

### DIFF
--- a/src/Meridian.Application/Pipeline/DeadLetterSink.cs
+++ b/src/Meridian.Application/Pipeline/DeadLetterSink.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
@@ -7,6 +6,7 @@ using Meridian.Application.Serialization;
 using Meridian.Contracts.Domain;
 using Meridian.Domain.Events;
 using Meridian.Infrastructure.Contracts;
+using Meridian.Storage.Archival;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -154,28 +154,9 @@ public sealed class DeadLetterSink : IAsyncDisposable
     }
 
 
-    private static async Task AppendJsonLineAsync(string path, string json, CancellationToken ct)
+    private static Task AppendJsonLineAsync(string path, string json, CancellationToken ct)
     {
-        var directory = Path.GetDirectoryName(path);
-        if (!string.IsNullOrEmpty(directory))
-        {
-            Directory.CreateDirectory(directory);
-        }
-
-        await using var stream = new FileStream(
-            path,
-            FileMode.Append,
-            FileAccess.Write,
-            FileShare.Read,
-            bufferSize: 65536,
-            FileOptions.Asynchronous);
-        await using var writer = new StreamWriter(
-            stream,
-            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
-            bufferSize: 65536,
-            leaveOpen: false);
-        await writer.WriteLineAsync(json).ConfigureAwait(false);
-        await writer.FlushAsync().ConfigureAwait(false);
+        return AtomicFileWriter.AppendLinesAsync(path, new[] { json }, ct);
     }
 
     private static JsonSerializerOptions CreateJsonOptions()

--- a/src/Meridian.Application/Pipeline/DroppedEventAuditTrail.cs
+++ b/src/Meridian.Application/Pipeline/DroppedEventAuditTrail.cs
@@ -1,9 +1,9 @@
 using System.Collections.Concurrent;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Meridian.Contracts.Domain;
 using Meridian.Domain.Events;
+using Meridian.Storage.Archival;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -98,28 +98,9 @@ public sealed class DroppedEventAuditTrail : IAsyncDisposable
     }
 
 
-    private static async Task AppendJsonLineAsync(string path, string json, CancellationToken ct)
+    private static Task AppendJsonLineAsync(string path, string json, CancellationToken ct)
     {
-        var directory = Path.GetDirectoryName(path);
-        if (!string.IsNullOrEmpty(directory))
-        {
-            Directory.CreateDirectory(directory);
-        }
-
-        await using var stream = new FileStream(
-            path,
-            FileMode.Append,
-            FileAccess.Write,
-            FileShare.Read,
-            bufferSize: 65536,
-            FileOptions.Asynchronous);
-        await using var writer = new StreamWriter(
-            stream,
-            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
-            bufferSize: 65536,
-            leaveOpen: false);
-        await writer.WriteLineAsync(json).ConfigureAwait(false);
-        await writer.FlushAsync().ConfigureAwait(false);
+        return AtomicFileWriter.AppendLinesAsync(path, new[] { json }, ct);
     }
 
     public async ValueTask DisposeAsync()


### PR DESCRIPTION
### Motivation
- A recent change replaced the copy-on-write atomic append with an in-place `FileMode.Append` write, which can leave partial/truncated JSONL records if the process crashes during a large append and thus weakens audit evidence integrity. 
- The intent is to restore crash-consistent behavior for forensic audit files so dropped/rejected event logs are never left corrupted by interrupted writes.

### Description
- Replaced the direct in-place append helpers with `AtomicFileWriter.AppendLinesAsync(path, new[] { json }, ct)` in `DeadLetterSink` and `DroppedEventAuditTrail` to restore copy-on-write + atomic rename semantics. 
- Added the `using Meridian.Storage.Archival;` import in both files to access the `AtomicFileWriter` API. 
- Removed now-unused `System.Text` imports after removing the local `StreamWriter`-based append helpers.

### Testing
- No automated .NET build or test run was executed in this environment because the .NET SDK/runtime was not available, so no runtime tests were performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17fedac4b4832094ef3beefb7b926f)