### PR TITLE
fix(pipeline): restore non-blocking TryPublish contract

### DIFF
--- a/src/Meridian.Application/Pipeline/EventPipeline.cs
+++ b/src/Meridian.Application/Pipeline/EventPipeline.cs
@@ -447,10 +447,6 @@ public sealed class EventPipeline : IMarketEventPublisher, IBackpressureSignal, 
     /// Attempts to publish an event to the pipeline without blocking.
     /// Returns false if the queue is full (event will be dropped based on FullMode).
     /// </summary>
-    /// <remarks>
-    /// When WAL is enabled, this method appends the event to the WAL before queue handoff.
-    /// If WAL persistence fails, the event is treated as dropped and the method returns false.
-    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryPublish(in MarketEvent evt)
     {
@@ -467,25 +463,7 @@ public sealed class EventPipeline : IMarketEventPublisher, IBackpressureSignal, 
             return false;
         }
 
-        TracedMarketEvent tracedEvent;
-        try
-        {
-            tracedEvent = PrepareTracedEventForPublishAsync(evt, CancellationToken.None)
-                .AsTask()
-                .GetAwaiter()
-                .GetResult();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex,
-                "Failed to append event to WAL in TryPublish for {EventType}/{Symbol}; event dropped",
-                evt.Type,
-                evt.EffectiveSymbol);
-            RecordDrop(in evt);
-            return false;
-        }
-
-        var written = _channel.Writer.TryWrite(tracedEvent);
+        var written = _channel.Writer.TryWrite(CaptureTraceContext(evt));
 
         if (written)
         {


### PR DESCRIPTION
### Motivation

- A recent change made `EventPipeline.TryPublish` synchronously wait on async WAL persistence via `PrepareTracedEventForPublishAsync(...).AsTask().GetAwaiter().GetResult()`, which violated the `IMarketEventPublisher.TryPublish` non-blocking hot-path contract. 
- The blocking behavior can allow slow or contended WAL I/O to stall provider threads and amplify disk writes through retry loops, causing availability loss under backpressure.

### Description

- Removed the synchronous WAL preparation from `src/Meridian.Application/Pipeline/EventPipeline.cs` so `TryPublish` no longer blocks on WAL I/O. 
- Restored the hot-path to perform a non-blocking channel enqueue using `CaptureTraceContext(evt)` and `_channel.Writer.TryWrite(...)`. 
- Removed outdated remarks asserting WAL append happened before queue handoff; `PublishAsync`/consumer-side WAL append and commit logic remain unchanged.

### Testing

- No automated `dotnet` tests were executed in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`), so no unit/integration test run results are available for this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17fedaabe883208cb75663243fcc97)