### PR TITLE
Fix Postgres duplicate-command query to use `payload` column

### DIFF
--- a/src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.cs
+++ b/src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.cs
@@ -329,7 +329,7 @@ public sealed partial class PostgresDirectLendingStateStore : IDirectLendingStat
         command.CommandText =
             $"""
             select event_type,
-                   payload_json::text
+                   payload::text
             from {Qualified("loan_event")}
             where loan_id = @loan_id
               and command_id = @command_id


### PR DESCRIPTION
### Motivation
- Fix an availability bug where the duplicate-command check queried a nonexistent `payload_json` column, which caused Postgres-backed direct-lending command saves to fail at runtime when `CommandId` was present.

### Description
- Update `GetDuplicateCommandStatusAsync` in `PostgresDirectLendingStateStore` to select `payload::text` from `loan_event` instead of `payload_json::text`, aligning the query with the table schema and existing insert path while preserving the duplicate-detection logic that compares `event_type` and payload JSON text.

### Testing
- Attempted to run the targeted integration test command `dotnet test tests/Meridian.DirectLending.Tests/Meridian.DirectLending.Tests.csproj --filter "FullyQualifiedName~DirectLendingPostgresIntegrationTests"`, but the run failed because `dotnet` is not available in the execution environment (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1805f0583c8320b67fcac2579d3ae8)