### PR TITLE
Fix trade/quote backpressure drops in dual-path TryPublish routing

### DIFF
--- a/src/Meridian.Application/Pipeline/DualPathEventPipeline.cs
+++ b/src/Meridian.Application/Pipeline/DualPathEventPipeline.cs
@@ -296,6 +296,24 @@ public sealed class DualPathEventPipeline : IMarketEventPublisher, IBackpressure
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryRouteTrade(in MarketEvent evt)
     {
+        if (evt.Payload is Trade trade)
+        {
+            var symbolHash = _symbolTable.GetOrAdd(evt.Symbol);
+            var raw = new RawTradeEvent(
+                evt.Timestamp.UtcTicks,
+                symbolHash,
+                trade.Price,
+                trade.Size,
+                (int)trade.Aggressor,
+                evt.Sequence);
+
+            if (_tradeBuffer.TryWrite(in raw))
+            {
+                Interlocked.Increment(ref _hotTradePublished);
+                return true;
+            }
+        }
+
         Interlocked.Increment(ref _hotTradeFallbacks);
         return _slowPath.TryPublish(in evt);
     }
@@ -303,6 +321,25 @@ public sealed class DualPathEventPipeline : IMarketEventPublisher, IBackpressure
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryRouteQuote(in MarketEvent evt)
     {
+        if (evt.Payload is BboQuotePayload quote)
+        {
+            var symbolHash = _symbolTable.GetOrAdd(evt.Symbol);
+            var raw = new RawQuoteEvent(
+                evt.Timestamp.UtcTicks,
+                symbolHash,
+                quote.BidPrice,
+                quote.BidSize,
+                quote.AskPrice,
+                quote.AskSize,
+                evt.Sequence);
+
+            if (_quoteBuffer.TryWrite(in raw))
+            {
+                Interlocked.Increment(ref _hotQuotePublished);
+                return true;
+            }
+        }
+
         Interlocked.Increment(ref _hotQuoteFallbacks);
         return _slowPath.TryPublish(in evt);
     }


### PR DESCRIPTION
### Motivation
- A previous change forwarded normal trade and quote `MarketEvent` instances directly to the slow-path `TryPublish`, which is non-blocking and can fail under backpressure, allowing silent drops when producers ignore the boolean return value.
- The intent is to preserve the dual-path burst buffer and lossless wait semantics for the hot path so high-volume feeds cannot corrupt market-data integrity under slow-path pressure.

### Description
- Restored hot-path routing in `DualPathEventPipeline.TryRouteTrade` by encoding `MarketEvent` trade payloads into `RawTradeEvent` and attempting to enqueue into the `_tradeBuffer` before falling back to the slow path, and incrementing `_hotTradePublished` when written to the ring buffer; otherwise `_hotTradeFallbacks` is incremented and the event is forwarded to the slow path.
- Restored hot-path routing in `DualPathEventPipeline.TryRouteQuote` by encoding `MarketEvent` quote payloads into `RawQuoteEvent` and attempting to enqueue into the `_quoteBuffer` before falling back to the slow path, and incrementing `_hotQuotePublished` when written to the ring buffer; otherwise `_hotQuoteFallbacks` is incremented and the event is forwarded to the slow path.
- Changes are localized to `src/Meridian.Application/Pipeline/DualPathEventPipeline.cs` and preserve the existing fallback behavior to the underlying `EventPipeline`.

### Testing
- Attempted to run the pipeline unit tests targeting `DualPathEventPipelineTests` with `dotnet test --filter "FullyQualifiedName~DualPathEventPipelineTests"`, but the test run could not be executed in this environment because `dotnet` is not installed (`dotnet: command not found`).
- The repository contains targeted tests at `tests/Meridian.Tests/Application/Pipeline/DualPathEventPipelineTests.cs` which exercise hot-path fallback and backpressure behavior and should be run in CI or a local dev environment with the .NET SDK to validate the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1805f031b48320a3626e2d3c4aaf4d)