### PR TITLE
Redact sensitive details from IB status endpoint

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/IBEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/IBEndpoints.cs
@@ -27,7 +27,6 @@ public static class IBEndpoints
             var socketConfig = config.IB;
             var clientPortalConfig = config.IBClientPortal;
             var buildMode = GetBuildMode();
-            var runtimeTarget = socketConfig?.UsePaperTrading ?? true ? "paper" : "live";
             var socketReady = socketConfig is not null
                 && !string.IsNullOrWhiteSpace(socketConfig.Host)
                 && socketConfig.Port > 0
@@ -42,7 +41,6 @@ public static class IBEndpoints
                 provider = "Interactive Brokers",
                 ibApiAvailable = isIBApiAvailable,
                 buildMode,
-                runtimeTarget,
                 buildInstructions = buildMode switch
                 {
                     "guidance" => "Build with -p:EnableIbApiVendor=true (preferred) and place the official vendor SDK under external/IBApi. Legacy -p:DefineConstants=IBAPI remains supported. Use -p:EnableIbApiSmoke=true only for compile-only verification.",
@@ -53,17 +51,11 @@ public static class IBEndpoints
                 {
                     configured = socketConfig is not null,
                     ready = socketReady,
-                    host = socketConfig?.Host,
-                    port = socketConfig?.Port,
-                    clientId = socketConfig?.ClientId,
-                    paper = socketConfig?.UsePaperTrading ?? true
                 },
                 clientPortal = new
                 {
                     enabled = clientPortalConfig?.Enabled ?? false,
                     ready = clientPortalReady,
-                    baseUrl = clientPortalConfig?.BaseUrl,
-                    allowSelfSignedCertificates = clientPortalConfig?.AllowSelfSignedCertificates ?? false
                 },
                 connectionPorts = new
                 {


### PR DESCRIPTION
### Motivation

- The IB status endpoint previously serialized configuration-derived connection details (TWS/Gateway host, port, clientId, paper/live mode, Client Portal BaseUrl and certificate flag), which leaks internal broker topology and potentially sensitive userinfo.
- The goal is to keep the endpoint useful for coarse readiness and capability checks while preventing disclosure of internal addresses or credentials.

### Description

- Remove serialization of socket-level details (`host`, `port`, `clientId`, `paper`) from the `/api/providers/ib/status` response in `src/Meridian.Ui.Shared/Endpoints/IBEndpoints.cs`.
- Remove serialization of Client Portal configuration fields (`baseUrl`, `allowSelfSignedCertificates`) and the `runtimeTarget` field so only non-sensitive booleans remain.
- Preserve non-sensitive metadata such as `provider`, `buildMode`, `buildInstructions`, capability/limit sections, and documented default connection ports to retain operational usefulness.

### Testing

- No automated tests were executed in this environment because the required .NET tooling was unavailable; an attempted command `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter FullyQualifiedName~IBEndpointTests --no-restore` failed with `dotnet: command not found`.
- A static review of `src/Meridian.Ui.Shared/Endpoints/IBEndpoints.cs` was performed to confirm the sensitive fields are no longer serialized in the JSON response.
- No automated regressions were run due to the missing runtime in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1808ccd4488320baa196019d8af823)