### PR TITLE
Fix operator inbox token normalization stack allocation DoS risk

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text;
 using System.Text.Json;
 using Meridian.Application.Monitoring;
 using Meridian.Application.OperationsContinuity;
@@ -40,6 +41,7 @@ public static partial class WorkstationEndpoints
 {
     private const int MaxRunComparisonRequestIds = 10;
     private const int SecurityCoveragePreviewLimit = 5;
+    private const int MaxOperatorInboxTokenLength = 256;
     private const string WorkstationApiRoutePrefix = "/api/workstation";
 
     public static void MapWorkstationEndpoints(this WebApplication app, JsonSerializerOptions jsonOptions)
@@ -3016,32 +3018,45 @@ public static partial class WorkstationEndpoints
 
     private static string NormalizeOperatorInboxToken(string value)
     {
-        Span<char> buffer = stackalloc char[value.Length];
-        var length = 0;
-        var previousWasSeparator = false;
-
-        foreach (var character in value.Trim())
+        var trimmed = value.Trim();
+        if (trimmed.Length == 0)
         {
+            return string.Empty;
+        }
+
+        var output = new StringBuilder(Math.Min(trimmed.Length, MaxOperatorInboxTokenLength));
+        var previousWasSeparator = false;
+        var producedCharacters = 0;
+
+        foreach (var character in trimmed)
+        {
+            if (producedCharacters >= MaxOperatorInboxTokenLength)
+            {
+                break;
+            }
+
             if (char.IsLetterOrDigit(character))
             {
-                buffer[length++] = char.ToLowerInvariant(character);
+                output.Append(char.ToLowerInvariant(character));
                 previousWasSeparator = false;
+                producedCharacters++;
                 continue;
             }
 
-            if (!previousWasSeparator && length > 0)
+            if (!previousWasSeparator && output.Length > 0)
             {
-                buffer[length++] = '-';
+                output.Append('-');
                 previousWasSeparator = true;
+                producedCharacters++;
             }
         }
 
-        if (length > 0 && buffer[length - 1] == '-')
+        if (output.Length > 0 && output[^1] == '-')
         {
-            length--;
+            output.Length--;
         }
 
-        return new string(buffer[..length]);
+        return output.ToString();
     }
 
     private static string BuildTradingBrokerageNotes(


### PR DESCRIPTION
### Motivation

- A stack-allocation based normalizer in the operator inbox path could allocate `stackalloc char[value.Length]` from untrusted persisted `BreakId` values and cause a process-fatal `StackOverflowException` for large inputs. 
- The goal is to remove the unbounded stack allocation and bound the normalized token size while preserving the token-shaping behavior.

### Description

- Replaced the unsafe `stackalloc`-based `NormalizeOperatorInboxToken` implementation with a heap-backed `StringBuilder` implementation that respects a maximum output length. 
- Introduced a `MaxOperatorInboxTokenLength` constant set to `256` and stop producing characters once the cap is reached to prevent unbounded work for attacker-controlled inputs. 
- Preserved existing behavior: trim input, lowercase alphanumeric characters, collapse non-alphanumerics into a single `-` separator, and trim trailing separators, and return an empty string for empty/whitespace input.

### Testing

- Attempted to run the .NET toolchain (`dotnet --version`) and build in this environment but `dotnet` is not available, so no compile or unit-test execution could be performed here. 
- Performed source-level verification and static inspection of `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` to confirm the `stackalloc` usage was removed and the cap was added, and that the normalization semantics remain equivalent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1809e78ce48320b592e84f7b44cea2)