### PR TITLE
ci: preserve complete desktop screenshot artifacts

### DIFF
--- a/.github/workflows/desktop-screenshot-capture.yml
+++ b/.github/workflows/desktop-screenshot-capture.yml
@@ -108,6 +108,56 @@ jobs:
             Write-Host "[INFO] Captured $($captures.Count) desktop screenshot(s) in '$outputDir'."
           }
 
+      - name: Prepare complete screenshot artifact
+        if: ${{ always() }}
+        shell: pwsh
+        run: |
+          $artifactDir = "artifacts/desktop-screenshot-capture/all-screenshots"
+          New-Item -ItemType Directory -Force -Path $artifactDir | Out-Null
+          $entries = @()
+
+          function Copy-ScreenshotSet {
+            param(
+              [Parameter(Mandatory = $true)][string]$SourceRoot,
+              [Parameter(Mandatory = $true)][string]$Bucket
+            )
+
+            if ([string]::IsNullOrWhiteSpace($SourceRoot) -or -not (Test-Path -LiteralPath $SourceRoot)) {
+              Write-Host "[INFO] Screenshot source '$SourceRoot' was not found; skipping '$Bucket'."
+              return
+            }
+
+            $resolvedSourceRoot = [System.IO.Path]::GetFullPath($SourceRoot)
+            foreach ($capture in @(Get-ChildItem -LiteralPath $resolvedSourceRoot -Filter '*.png' -File -Recurse -ErrorAction SilentlyContinue)) {
+              $relativePath = [System.IO.Path]::GetRelativePath($resolvedSourceRoot, $capture.FullName)
+              $destination = Join-Path (Join-Path $artifactDir $Bucket) $relativePath
+              $destinationParent = Split-Path -Parent $destination
+              if (-not [string]::IsNullOrWhiteSpace($destinationParent)) {
+                New-Item -ItemType Directory -Force -Path $destinationParent | Out-Null
+              }
+
+              Copy-Item -LiteralPath $capture.FullName -Destination $destination -Force
+              $script:entries += [ordered]@{
+                bucket = $Bucket
+                source = $capture.FullName
+                artifactPath = $destination
+                bytes = $capture.Length
+                lastWriteTimeUtc = $capture.LastWriteTimeUtc.ToString('O')
+              }
+            }
+          }
+
+          Copy-ScreenshotSet -SourceRoot "${{ steps.validate_output_dir.outputs.safe_output_dir }}" -Bucket "catalog"
+          Copy-ScreenshotSet -SourceRoot "artifacts/desktop-workflows" -Bucket "workflow-runs"
+
+          [ordered]@{
+            generatedAtUtc = (Get-Date).ToUniversalTime().ToString('O')
+            screenshotCount = $entries.Count
+            screenshots = $entries
+          } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $artifactDir 'screenshot-artifact-manifest.json') -Encoding utf8
+
+          Write-Host "[INFO] Prepared $($entries.Count) screenshot file(s) for the complete desktop screenshot artifact."
+
       - name: Commit and push results
         if: ${{ success() && inputs.commit == true }}
         shell: pwsh
@@ -151,5 +201,14 @@ jobs:
         with:
           name: desktop-screenshots-${{ github.run_number }}
           path: ${{ steps.validate_output_dir.outputs.safe_output_dir }}/*.png
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload complete screenshot artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: desktop-screenshots-complete-${{ github.run_number }}
+          path: artifacts/desktop-screenshot-capture/all-screenshots/
           if-no-files-found: ignore
           retention-days: 14

--- a/docs/development/desktop-workflow-automation.md
+++ b/docs/development/desktop-workflow-automation.md
@@ -51,10 +51,12 @@ For migration context and replacement mappings, see:
 | `manual-research-and-trading` | Research, backtesting, Quant Script, and trading flow | Included in the generated user manual |
 | `manual-governance` | Governance, ledger, notifications, and reference data flow | Included in the generated user manual |
 
-The `Refresh UI Screenshots` GitHub workflow derives its desktop matrix from this same catalog via
-`scripts/dev/screenshot_workflow_plan.py`. A workflow named `screenshot-catalog` runs for catalog
-captures, and any workflow with `includeInManual: true` is automatically included when the manual
-screenshot group is selected. The web capture set is planned from
+The `Desktop Screenshot Capture` GitHub workflow runs the `screenshot-catalog` workflow for catalog
+captures and can commit refreshed PNGs under `docs/screenshots/desktop/`. Each hosted run also
+prepares a `desktop-screenshots-complete-<run-number>` artifact under
+`artifacts/desktop-screenshot-capture/all-screenshots/` that mirrors every captured PNG from both
+the requested catalog output and the timestamped `artifacts/desktop-workflows/` run bundles, plus a
+`screenshot-artifact-manifest.json` index of those files. The web capture set is planned from
 `scripts/dev/web-screenshot-routes.json`, so screenshot additions should be made in the definition
 files rather than by editing the workflow matrix directly. Strategy Designer is part of that web
 evidence lane through `/workstation/strategy/designer`; keep its screenshot route paired with

--- a/docs/generated/workflow-command-reference.md
+++ b/docs/generated/workflow-command-reference.md
@@ -17,10 +17,10 @@
 ## desktop-screenshot-catalog
 
 - Owners: @desktop-shell, @operator-experience
-- Expected artifacts: docs/screenshots/desktop, artifacts/desktop-workflows
+- Expected artifacts: docs/screenshots/desktop, artifacts/desktop-workflows, artifacts/desktop-screenshot-capture/all-screenshots
 - Owner lane: Workstation Shell and UX
 - Refresh trigger: desktop screenshot capture workflow or manual screenshot refresh
-- Canonical output roots: docs/screenshots/desktop, artifacts/desktop-workflows
+- Canonical output roots: docs/screenshots/desktop, artifacts/desktop-workflows, artifacts/desktop-screenshot-capture/all-screenshots
 - Retention: timestamped-run-retention (maxAgeDays=14, retainLatest=10)
 - Commands:
   - `pwsh -File ./scripts/dev/run-desktop-workflow.ps1 -Workflow screenshot-catalog -ScreenshotDirectory docs/screenshots/desktop`

--- a/docs/status/workflow-manifest.json
+++ b/docs/status/workflow-manifest.json
@@ -82,7 +82,8 @@
       ],
       "expectedArtifacts": [
         "docs/screenshots/desktop",
-        "artifacts/desktop-workflows"
+        "artifacts/desktop-workflows",
+        "artifacts/desktop-screenshot-capture/all-screenshots"
       ],
       "validationChecks": [
         {
@@ -100,7 +101,8 @@
         },
         "canonicalOutputRoots": [
           "docs/screenshots/desktop",
-          "artifacts/desktop-workflows"
+          "artifacts/desktop-workflows",
+          "artifacts/desktop-screenshot-capture/all-screenshots"
         ],
         "driftChecks": {
           "enforceMissing": false,


### PR DESCRIPTION
### Motivation
- Ensure every desktop screenshot captured by the hosted run is preserved as a single, discoverable artifact in addition to the committed catalog PNGs for easier troubleshooting and evidence collection.
- Provide a machine-readable index describing which files were included so downstream consumers (debugging, QA, or Evidence Vault workflows) can locate run-scoped screenshots reliably.

### Description
- Added a new assembly step to `.github/workflows/desktop-screenshot-capture.yml` that copies PNGs from the requested catalog output and from timestamped run bundles into `artifacts/desktop-screenshot-capture/all-screenshots/` and writes a `screenshot-artifact-manifest.json` index. 
- Added a new artifact upload `desktop-screenshots-complete-<run-number>` so the complete screenshot bundle is uploaded for every run. 
- Updated documentation in `docs/development/desktop-workflow-automation.md` to describe the new complete artifact and `screenshot-artifact-manifest.json`. 
- Updated generated references and workflow manifest entries in `docs/generated/workflow-command-reference.md` and `docs/status/workflow-manifest.json` to list `artifacts/desktop-screenshot-capture/all-screenshots` as an expected/canonical output root.

### Testing
- Ran `python3 build/scripts/docs/generate-workflow-manifest.py` to regenerate and validate the manifest, which completed successfully. 
- Validated the updated workflow YAML parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/desktop-screenshot-capture.yml")'`, which succeeded. 
- Ran `git diff --check` to check whitespace/patch issues, which reported clean. 
- Ran `python3 build/scripts/ci/check-workflow-hygiene.py`, which reported a pre-existing documentation hygiene issue unrelated to this change (`docs/development/wpf-implementation-notes.md` contains manual workflow inventory wording).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186cb1a39c8320984c75f3008c9bb9)