### PR TITLE
Preserve permission overrides in login sessions

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/AuthEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/AuthEndpoints.cs
@@ -185,11 +185,7 @@ public static class AuthEndpoints
         if (ctxUser is null || ctxRole is null)
             return null;
 
-        return new UserProfile(ctxUser, ctxRole.Value)
-        {
-            // Permissions are already computed from Role, but we can cross-check with stored items
-            // if they differ due to future customisation; for now they match the role exactly.
-        };
+        return new UserProfile(ctxUser, ctxRole.Value, PermissionOverride: ctxPerms);
     }
 }
 

--- a/src/Meridian.Ui.Shared/LoginSessionService.cs
+++ b/src/Meridian.Ui.Shared/LoginSessionService.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Security.Cryptography;
-using Meridian.Contracts.Auth;
 using Meridian.Ui.Shared.Endpoints;
 using Microsoft.Extensions.Hosting;
 
@@ -11,6 +10,8 @@ namespace Meridian.Ui.Shared;
 /// User accounts are resolved via <see cref="UserProfileRegistry"/> which supports both
 /// the legacy single-user environment variable pattern (MDC_USERNAME / MDC_PASSWORD) and the
 /// multi-user pattern (MDC_USERS JSON array).
+/// Sessions retain the authenticated profile rather than reconstructing it per request, preserving
+/// account-specific permission overrides without adding per-request permission parsing.
 /// Authentication defaults to optional in Development/Test and required elsewhere.
 /// Use MDC_AUTH_MODE=optional|required|auto to override the default environment-based mode.
 /// </summary>
@@ -42,7 +43,7 @@ public sealed class LoginSessionService(IHostEnvironment environment, UserProfil
             return null;
 
         var token = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
-        _sessions[token] = new SessionEntry(profile.Username, profile.Role, DateTimeOffset.UtcNow + SessionDuration);
+        _sessions[token] = new SessionEntry(profile, DateTimeOffset.UtcNow + SessionDuration);
         PruneExpiredSessions();
         return token;
     }
@@ -79,7 +80,7 @@ public sealed class LoginSessionService(IHostEnvironment environment, UserProfil
             return null;
         }
 
-        return new UserProfile(entry.Username, entry.Role);
+        return entry.Profile;
     }
 
     /// <summary>
@@ -97,5 +98,5 @@ public sealed class LoginSessionService(IHostEnvironment environment, UserProfil
         }
     }
 
-    private sealed record SessionEntry(string Username, UserRole Role, DateTimeOffset ExpiresAt);
+    private sealed record SessionEntry(UserProfile Profile, DateTimeOffset ExpiresAt);
 }

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -84,6 +84,14 @@ See `DIA-BROWSER-WORKSTATION` in `docs/source/data/diagram-index.yml`.
 - No registry-backed TODOs are open for this module.
 <!-- source-todos:end -->
 
+## Security and credentials
+
+`LoginSessionService` stores the authenticated `UserProfile` for each in-memory session so
+account-specific permission overrides and role profile names from `MDC_USERS` remain authoritative
+for `/api/auth/me` and endpoint authorization checks. Do not reconstruct session users from only the
+built-in role label, because that would reapply the full built-in role permission mask and bypass
+configured restrictions.
+
 ## Validation
 
 ```bash

--- a/tests/Meridian.Tests/Integration/EndpointTests/RoleAuthorizationTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/RoleAuthorizationTests.cs
@@ -387,4 +387,61 @@ public sealed class RoleAuthorizationTests : EndpointIntegrationTestBase
             Environment.SetEnvironmentVariable("MDC_USERS", null);
         }
     }
+
+    [Fact]
+    public async Task AuthMe_WithCustomAdminPermissionOverride_DoesNotRegainBuiltInAdminPermissions()
+    {
+        const string usersJson = """[{"username":"limited-admin","password":"pw","role":"Admin","roleProfileName":"Limited Admin","permissions":["ViewMarketData"]}]""";
+        Environment.SetEnvironmentVariable("MDC_USERS", usersJson);
+        try
+        {
+            using var loginContent = new StringContent(
+                JsonSerializer.Serialize(new { Username = "limited-admin", Password = "pw" }),
+                Encoding.UTF8,
+                "application/json");
+
+            using var cookieClient = Fixture.CreateNoRedirectClient();
+            var loginResp = await cookieClient.PostAsync("/api/auth/login", loginContent);
+            loginResp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var loginBody = await loginResp.Content.ReadFromJsonAsync<JsonElement>(JsonOpts);
+            GetPermissionNames(loginBody).Should().BeEquivalentTo([nameof(UserPermission.ViewMarketData)]);
+
+            var sessionCookie = loginResp.Headers
+                .Where(h => h.Key.Equals("Set-Cookie", StringComparison.OrdinalIgnoreCase))
+                .SelectMany(h => h.Value)
+                .FirstOrDefault(v => v.Contains("mdc-session"));
+
+            sessionCookie.Should().NotBeNullOrWhiteSpace("a session cookie must be set after login");
+
+            using var meRequest = new HttpRequestMessage(HttpMethod.Get, "/api/auth/me");
+            meRequest.Headers.Add("Cookie", sessionCookie);
+            var meResp = await cookieClient.SendAsync(meRequest);
+
+            meResp.StatusCode.Should().Be(HttpStatusCode.OK);
+            var meBody = await meResp.Content.ReadFromJsonAsync<JsonElement>(JsonOpts);
+            meBody.TryGetProperty("role", out var role).Should().BeTrue();
+            role.GetString().Should().Be(nameof(UserRole.Admin));
+            meBody.TryGetProperty("roleProfileName", out var roleProfileName).Should().BeTrue();
+            roleProfileName.GetString().Should().Be("Limited Admin");
+            var mePermissionNames = GetPermissionNames(meBody);
+            mePermissionNames.Should().BeEquivalentTo([nameof(UserPermission.ViewMarketData)]);
+            mePermissionNames.Should().NotContain(nameof(UserPermission.ManageCredentials));
+            mePermissionNames.Should().NotContain(nameof(UserPermission.ExecuteTrades));
+            mePermissionNames.Should().NotContain(nameof(UserPermission.ManageUsers));
+            mePermissionNames.Should().NotContain(nameof(UserPermission.AdminMaintenance));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MDC_USERS", null);
+        }
+    }
+
+    private static string[] GetPermissionNames(JsonElement? body)
+    {
+        body.Should().NotBeNull();
+        body!.Value.TryGetProperty("permissionNames", out var permissionNames).Should().BeTrue();
+        return permissionNames.EnumerateArray().Select(permission => permission.GetString()!).ToArray();
+    }
+
 }


### PR DESCRIPTION
### Motivation
- Fix an authorization regression where per-user `PermissionOverride` values were dropped when sessions were created, causing users to regain their built-in role permissions and enabling privilege escalation.
- Ensure authenticated sessions preserve the full `UserProfile` (including `PermissionOverride` and `RoleProfileName`) so endpoint authorization and `/api/auth/me` remain consistent with configured account restrictions.

### Description
- Store the full authenticated `UserProfile` in session entries by changing `LoginSessionService` to keep `SessionEntry(UserProfile Profile, DateTimeOffset ExpiresAt)` and to save `profile` instead of `username`/`role` when creating sessions (`src/Meridian.Ui.Shared/LoginSessionService.cs`).
- Return the stored profile from `GetSessionProfile` so `PermissionOverride` is preserved for subsequent requests (`src/Meridian.Ui.Shared/LoginSessionService.cs`).
- When falling back to middleware-provided context items, propagate middleware-provided permissions into the reconstructed `UserProfile` by setting `PermissionOverride: ctxPerms` in `ResolveCurrentProfile` (`src/Meridian.Ui.Shared/Endpoints/AuthEndpoints.cs`).
- Add an integration regression test `AuthMe_WithCustomAdminPermissionOverride_DoesNotRegainBuiltInAdminPermissions` that verifies an `Admin`-labeled account limited to `ViewMarketData` does not regain admin privileges after login (`tests/Meridian.Tests/Integration/EndpointTests/RoleAuthorizationTests.cs`).
- Document the session invariant in the UI shared module README to warn against reconstructing session users from only the role label (`src/Meridian.Ui.Shared/README.md`).

### Testing
- Attempted to run the focused endpoint tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~RoleAuthorizationTests" /p:EnableWindowsTargeting=true`, but execution was blocked because `dotnet` is not available in the environment (manual run required in CI/dev machine).  The new test was added but could not be executed here.
- Ran `python3 build/scripts/docs/validate-source-readmes.py --summary` which passed for source README validation.
- Ran the implementation-assurance dry-run `python3 .codex/skills/meridian-implementation-assurance/scripts/run_evals.py --all --dry-run --json` which completed successfully in dry-run mode.
- Ran `git diff --check` which passed with no whitespace or check errors.
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary` which failed due to repository-wide source/doc hash drift unrelated to this change and requiring a separate docs refresh; this is a repo-level maintenance issue and not caused by the security fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18437e16388320af59c31c0750be4f)