### PR TITLE
fix: enforce canonical screenshot output containment

### DIFF
--- a/.github/workflows/desktop-screenshot-capture.yml
+++ b/.github/workflows/desktop-screenshot-capture.yml
@@ -77,13 +77,19 @@ jobs:
             exit 1
           }
 
-          $normalized = ($requested -replace '\\', '/')
-          if ($normalized -ne $baseDir -and -not $normalized.StartsWith("$baseDir/")) {
-            Write-Error "output_dir must stay within '$baseDir'. Received '$normalized'."
+          $repoRoot = [System.IO.Path]::GetFullPath($env:GITHUB_WORKSPACE)
+          $baseFull = [System.IO.Path]::GetFullPath((Join-Path $repoRoot $baseDir))
+          $candidateFull = [System.IO.Path]::GetFullPath((Join-Path $repoRoot $requested))
+
+          $basePrefix = $baseFull.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+          $basePrefix = "$basePrefix$([System.IO.Path]::DirectorySeparatorChar)"
+          if ($candidateFull -ne $baseFull -and -not $candidateFull.StartsWith($basePrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+            Write-Error "output_dir must stay within '$baseDir'. Received '$requested'."
             exit 1
           }
 
-          "safe_output_dir=$normalized" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          $safeRelative = [System.IO.Path]::GetRelativePath($repoRoot, $candidateFull) -replace '\\', '/'
+          "safe_output_dir=$safeRelative" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
       - name: Capture desktop screenshots
         id: capture_desktop
         shell: pwsh

--- a/.github/workflows/web-screenshot-capture.yml
+++ b/.github/workflows/web-screenshot-capture.yml
@@ -106,16 +106,18 @@ jobs:
 import os
 from pathlib import Path
 
-print(Path(os.environ["REQUESTED_OUTPUT_DIR"]).as_posix())
+repo_root = Path(os.environ["GITHUB_WORKSPACE"]).resolve()
+base_dir = (repo_root / "docs/screenshots/web").resolve()
+candidate = (repo_root / os.environ["REQUESTED_OUTPUT_DIR"]).resolve()
+
+try:
+    candidate.relative_to(base_dir)
+except ValueError:
+    raise SystemExit(f"::error::output_dir must stay within 'docs/screenshots/web'. Received '{os.environ['REQUESTED_OUTPUT_DIR']}'.")
+
+print(candidate.relative_to(repo_root).as_posix())
 PYTHON
 )"
-          case "$resolved" in
-            "$BASE_DIR"|"$BASE_DIR"/*) ;;
-            *)
-              echo "::error::output_dir must stay within '$BASE_DIR'. Received '$resolved'."
-              exit 1
-              ;;
-          esac
 
           echo "safe_output_dir=$resolved" >> "$GITHUB_OUTPUT"
       - name: Capture web screenshots


### PR DESCRIPTION
### Motivation

- The workflows performed lexical prefix checks on `output_dir` values which allowed path traversal (e.g. `docs/screenshots/web/../..`) to escape the intended screenshot directories and permit writes/deletes/uploads outside `docs/screenshots/*`.

### Description

- Hardened the web screenshot workflow by resolving `GITHUB_WORKSPACE`, `docs/screenshots/web`, and the requested path with Python `Path.resolve()` and rejecting candidates that are not canonically contained under the web base directory, then emitting a repo-relative `safe_output_dir`.
- Hardened the desktop screenshot workflow by canonicalizing `repoRoot`, `baseDir`, and the candidate with `GetFullPath`/`Join-Path`, enforcing containment using a normalized base prefix comparison (ordinal, case-insensitive), and emitting a normalized repo-relative `safe_output_dir` with forward slashes.
- Both workflows continue to reject absolute paths and now perform real canonical containment checks rather than lexical prefix comparisons, ensuring downstream `find`, `Get-ChildItem`, script invocations, commits, and artifact uploads operate only inside the intended screenshot trees.

### Testing

- Ran `git diff --check` which reported no whitespace or diff errors and returned success.
- Verified repository status with `git -C /workspace/Meridian-main status --short` which indicated only the intended workflow files were modified.
- Inspected the modified workflow fragments (`.github/workflows/web-screenshot-capture.yml` and `.github/workflows/desktop-screenshot-capture.yml`) to confirm the new canonicalization logic was present and correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1805f019888320a53fe0a46c2098b4)