### PR TITLE
Reconciliation: avoid premature sign-off on RequestApproval

### DIFF
--- a/src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs
+++ b/src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs
@@ -278,20 +278,26 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
             {
                 return approval;
             }
-            var updated = approval.Item with
-            {
-                Status = request.Status,
-                ResolvedBy = request.ResolvedBy,
-                ResolvedAt = now,
-                ResolutionNote = request.ResolutionNote,
-                SignoffStatus = request.Status == ReconciliationBreakQueueStatus.Resolved
-                    ? "signed-off"
-                    : "dismissed",
-                SignoffHistory = (item.SignoffHistory ?? []).Concat(
-                [
-                    new ReconciliationCaseSignoffRecord(request.ResolvedBy, item.RequiredSignoffRole ?? "operator", request.Status.ToString(), request.OperatorRationale, now)
-                ]).ToArray()
-            };
+            var updated = request.Status == ReconciliationBreakQueueStatus.Dismissed
+                ? approval.Item with
+                {
+                    Status = request.Status,
+                    ResolvedBy = request.ResolvedBy,
+                    ResolvedAt = now,
+                    ResolutionNote = request.ResolutionNote,
+                    SignoffStatus = "dismissed",
+                    SignoffHistory = (item.SignoffHistory ?? []).Concat(
+                    [
+                        new ReconciliationCaseSignoffRecord(request.ResolvedBy, item.RequiredSignoffRole ?? "operator", request.Status.ToString(), request.OperatorRationale, now)
+                    ]).ToArray()
+                }
+                : approval.Item with
+                {
+                    ResolvedBy = request.ResolvedBy,
+                    ResolvedAt = now,
+                    ResolutionNote = request.ResolutionNote,
+                    SignoffStatus = "awaiting-approval"
+                };
 
             _items[request.BreakId] = updated with { Score = ComputeScore(updated), SlaDueAt = ComputeSlaDueAt(updated), SlaBreached = IsSlaBreached(updated) };
             await PersistSnapshotAsync(ct).ConfigureAwait(false);

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -3822,9 +3822,9 @@ public sealed partial class WorkstationEndpointsTests
 
         var resolved = await resolve.Content.ReadFromJsonAsync<ReconciliationBreakQueueItem>(ServerJsonOptions);
         resolved.Should().NotBeNull();
-        resolved!.Status.Should().Be(ReconciliationBreakQueueStatus.Resolved);
+        resolved!.Status.Should().Be(ReconciliationBreakQueueStatus.InReview);
         resolved.ResolvedBy.Should().Be("ops-user");
-        resolved.SignoffStatus.Should().Be("signed-off");
+        resolved.SignoffStatus.Should().Be("awaiting-approval");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation

- Resolve flow previously applied a `RequestApproval` transition but then immediately persisted the break as `Resolved` with `SignoffStatus = "signed-off"`, collapsing the intended four-eye approval gate.
- This could cause governance and reporting code to count items as approved without a separate approver or `Approve`/`Post` transitions being applied.

### Description

- Change `FileReconciliationBreakQueueRepository.ResolveAsync` to preserve the approval lane by not marking successful `RequestApproval` results as terminal `Resolved`/`signed-off`, and instead set `SignoffStatus = "awaiting-approval"` for resolved requests while keeping `Dismissed` behavior unchanged.
- Keep the repository to use the workflow output `approval.Item` for lifecycle fields and only apply terminal resolution fields when the action legitimately produces them (dismiss still records `SignoffHistory` and `SignoffStatus = "dismissed"`).
- Update the endpoint test `MapWorkstationEndpoints_BreakQueueResolveRoute_ShouldRequireReviewBeforeResolve` expectations to assert the item remains `InReview`/`awaiting-approval` after a resolve request that triggers `RequestApproval`.
- Leave downstream audit and summary emission paths intact so counts continue to reflect the corrected `SignoffStatus` values.

### Testing

- Attempted to run the targeted unit test with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter FullyQualifiedName~MapWorkstationEndpoints_BreakQueueResolveRoute_ShouldRequireReviewBeforeResolve --no-restore`, but the environment lacks `dotnet`, so the test run failed with `dotnet: command not found`.
- No automated tests were executed in this environment due to the runtime limitation; code changes include an updated unit test expectation to be exercised in CI or a local environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18049058608320b133a951331fd9d0)