### PR TITLE
Relax retained-artifact canonical linkage validation to avoid false blocking

### DIFF
--- a/src/Meridian.Ui.Shared/Evidence/EvidencePacketValidationService.cs
+++ b/src/Meridian.Ui.Shared/Evidence/EvidencePacketValidationService.cs
@@ -308,15 +308,22 @@ public sealed class EvidencePacketValidationService
         {
             foreach (var artifact in node.ArtifactRefs.Where(static artifact => artifact.Retained))
             {
-                if (string.IsNullOrWhiteSpace(artifact.CanonicalSubjectKind) || string.IsNullOrWhiteSpace(artifact.CanonicalSubjectId))
+                var hasCanonicalKind = !string.IsNullOrWhiteSpace(artifact.CanonicalSubjectKind);
+                var hasCanonicalId = !string.IsNullOrWhiteSpace(artifact.CanonicalSubjectId);
+                if (hasCanonicalKind != hasCanonicalId)
                 {
                     issues.Add(new EvidenceValidationIssueDto(
                         Code: "retained-artifact-missing-canonical-subject",
                         Severity: EvidenceValidationSeverityDto.Critical,
-                        Message: $"Retained artifact '{artifact.ArtifactId}' is missing canonical subject linkage.",
+                        Message: $"Retained artifact '{artifact.ArtifactId}' must provide both canonical subject kind and canonical subject id when either field is present.",
                         EvidenceId: node.EvidenceId,
                         EvidenceKind: node.Kind,
                         SourceSystem: node.SourceSystem));
+                    continue;
+                }
+
+                if (!hasCanonicalKind)
+                {
                     continue;
                 }
 

--- a/tests/Meridian.Tests/Ui/EvidenceWorkflowFabricTests.cs
+++ b/tests/Meridian.Tests/Ui/EvidenceWorkflowFabricTests.cs
@@ -250,7 +250,7 @@ public sealed class EvidenceWorkflowFabricTests
     }
 
     [Fact]
-    public void EvidencePacketValidationService_BlocksWhenRetainedArtifactsMissCanonicalSubject()
+    public void EvidencePacketValidationService_DoesNotBlockWhenRetainedArtifactsOmitCanonicalSubject()
     {
         var subject = Subject(EvidenceSubjectResolver.ReportPackKind, "current");
         var node = Node(
@@ -270,11 +270,10 @@ public sealed class EvidenceWorkflowFabricTests
             new HashSet<string>(["report"], StringComparer.OrdinalIgnoreCase),
             enforceNoOrphanRule: false);
 
-        result.Completeness.Status.Should().Be(EvidenceStatusDto.Blocked);
-        result.Completeness.BlockingIssueCount.Should().BeGreaterThan(0);
-        result.Completeness.ValidationIssues.Should().Contain(issue =>
-            issue.Code == "retained-artifact-missing-canonical-subject" &&
-            issue.Severity == EvidenceValidationSeverityDto.Critical);
+        result.Completeness.Status.Should().Be(EvidenceStatusDto.Ready);
+        result.Completeness.BlockingIssueCount.Should().Be(0);
+        result.Completeness.ValidationIssues.Should().NotContain(issue =>
+            issue.Code == "retained-artifact-missing-canonical-subject");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- A recent change made any retained artifact missing `CanonicalSubjectKind` or `CanonicalSubjectId` a Critical validation failure, but the shared `Artifact(...)` helper and many contributors still emit retained artifacts without those optional fields, causing otherwise-valid packets to be marked `Blocked`.

### Description
- Update `ApplyCanonicalSubjectLinkageIssues` in `src/Meridian.Ui.Shared/Evidence/EvidencePacketValidationService.cs` so retained artifacts are only treated as a Critical issue when canonical linkage is partially present (one field provided but the other missing), while artifacts that omit both canonical fields are accepted.
- Keep the existing check that rejects unsupported canonical kinds when both canonical fields are present.
- Adjust the focused test in `tests/Meridian.Tests/Ui/EvidenceWorkflowFabricTests.cs` to assert that a retained artifact omitting both canonical fields does not force packet completeness to `Blocked` and does not emit the `retained-artifact-missing-canonical-subject` issue.

### Testing
- Updated unit test `EvidencePacketValidationService_DoesNotBlockWhenRetainedArtifactsOmitCanonicalSubject` verifies the new behavior via assertions in `tests/Meridian.Tests/Ui/EvidenceWorkflowFabricTests.cs`.
- Attempted a focused test run with `dotnet test --filter "FullyQualifiedName~EvidencePacketValidationService_DoesNotBlockWhenRetainedArtifactsOmitCanonicalSubject"` but test execution could not be performed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17d105f5488320848f985217aa85fc)