### PR TITLE
Fix misleading portfolio/ledger readiness status when gates are blocked or partial

### DIFF
--- a/src/Meridian.Ui.Shared/Services/PortfolioLedgerWorkflowStatusService.cs
+++ b/src/Meridian.Ui.Shared/Services/PortfolioLedgerWorkflowStatusService.cs
@@ -36,17 +36,26 @@ public static class PortfolioLedgerWorkflowStatusService
         var reconciliationGate = acceptanceGates.FirstOrDefault(static g => g.GateId == "reconciliation");
         var reviewGate = acceptanceGates.FirstOrDefault(static g => g.GateId == "report-pack");
 
-        var portfolio = drifts.Count > 0
-            ? PortfolioLedgerWorkflowStatusDto.DriftDetected
-            : MapGateStatus(reviewGate?.Status ?? TradingAcceptanceGateStatusDto.Unknown, awaitReconOnReview: false);
+        var portfolioGateStatus = MapGateStatus(reviewGate?.Status ?? TradingAcceptanceGateStatusDto.Unknown, awaitReconOnReview: false);
+        var portfolio = portfolioGateStatus == PortfolioLedgerWorkflowStatusDto.Blocked
+            ? PortfolioLedgerWorkflowStatusDto.Blocked
+            : drifts.Count > 0
+                ? PortfolioLedgerWorkflowStatusDto.DriftDetected
+                : portfolioGateStatus;
 
-        var reconciliation = drifts.Any(d => d.DriftType == "ledger-postings")
-            ? PortfolioLedgerWorkflowStatusDto.AwaitingReconciliation
-            : MapGateStatus(reconciliationGate?.Status ?? TradingAcceptanceGateStatusDto.Unknown, awaitReconOnReview: true);
+        var reconciliationGateStatus = MapGateStatus(reconciliationGate?.Status ?? TradingAcceptanceGateStatusDto.Unknown, awaitReconOnReview: true);
+        var reconciliation = reconciliationGateStatus == PortfolioLedgerWorkflowStatusDto.Blocked
+            ? PortfolioLedgerWorkflowStatusDto.Blocked
+            : drifts.Any(d => d.DriftType == "ledger-postings")
+                ? PortfolioLedgerWorkflowStatusDto.AwaitingReconciliation
+                : reconciliationGateStatus;
 
-        var summary = drifts.Count == 0
-            ? "Portfolio/ledger workflow posture is aligned with shared acceptance evidence."
-            : $"{drifts.Count} drift signal(s) require remediation before promoting portfolio/ledger readiness.";
+        var summary = portfolio is PortfolioLedgerWorkflowStatusDto.Blocked or PortfolioLedgerWorkflowStatusDto.Partial
+            || reconciliation is PortfolioLedgerWorkflowStatusDto.Blocked or PortfolioLedgerWorkflowStatusDto.Partial
+            ? "Portfolio/ledger workflow posture requires acceptance-gate review before promotion."
+            : drifts.Count == 0
+                ? "Portfolio/ledger workflow posture is aligned with shared acceptance evidence."
+                : $"{drifts.Count} drift signal(s) require remediation before promoting portfolio/ledger readiness.";
 
         return new PortfolioLedgerWorkflowStatusSnapshotDto(portfolio, reconciliation, drifts, summary);
     }

--- a/tests/Meridian.Tests/Ui/PortfolioLedgerWorkflowStatusServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/PortfolioLedgerWorkflowStatusServiceTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using Meridian.Contracts.Workstation;
+using Meridian.Ui.Shared.Services;
+
+namespace Meridian.Tests.Ui;
+
+public sealed class PortfolioLedgerWorkflowStatusServiceTests
+{
+    [Fact]
+    public void Compute_ShouldKeepBlockedGateStatus_WhenDriftSignalsExist()
+    {
+        var gates = new[]
+        {
+            new TradingAcceptanceGateDto("report-pack", "Report pack", TradingAcceptanceGateStatusDto.Blocked, "blocked")
+        };
+
+        var workItems = new[]
+        {
+            new OperatorWorkItemDto(
+                "sync-1",
+                OperatorWorkItemKindDto.BrokerageSync,
+                "Brokerage sync requires attention",
+                "Cash drift",
+                OperatorWorkItemToneDto.Warning,
+                DateTimeOffset.UtcNow)
+        };
+
+        var snapshot = PortfolioLedgerWorkflowStatusService.Compute(gates, workItems);
+
+        snapshot.PortfolioLedgerReview.Should().Be(PortfolioLedgerWorkflowStatusDto.Blocked);
+    }
+
+    [Fact]
+    public void Compute_ShouldNotReportAligned_WhenGateRequiresReviewWithoutDrift()
+    {
+        var gates = new[]
+        {
+            new TradingAcceptanceGateDto("report-pack", "Report pack", TradingAcceptanceGateStatusDto.ReviewRequired, "review required"),
+            new TradingAcceptanceGateDto("reconciliation", "Reconciliation", TradingAcceptanceGateStatusDto.Ready, "ready")
+        };
+
+        var snapshot = PortfolioLedgerWorkflowStatusService.Compute(gates, Array.Empty<OperatorWorkItemDto>());
+
+        snapshot.PortfolioLedgerReview.Should().Be(PortfolioLedgerWorkflowStatusDto.Partial);
+        snapshot.Summary.Should().Be("Portfolio/ledger workflow posture requires acceptance-gate review before promotion.");
+    }
+}


### PR DESCRIPTION
### Motivation

- Portfolio/ledger readiness could be misreported as "DriftDetected" or "AwaitingReconciliation" while underlying acceptance gates were `Blocked` or `Partial`, producing contradictory operator-facing summaries and inbox messages.
- The summary message emitted "aligned" whenever no drift signals existed even if gate-derived statuses required review, which can confuse operators about true readiness.

### Description

- Preserve gate-derived `Blocked` precedence by computing `MapGateStatus(...)` first and keeping `Blocked` for both portfolio review and reconciliation axes before applying drift-derived states in `src/Meridian.Ui.Shared/Services/PortfolioLedgerWorkflowStatusService.cs`.
- Update summary generation so the service emits a review-required message when either axis is `Partial` or `Blocked`, and only emits the aligned message when neither axis requires review and there are no drifts.
- Add focused unit tests in `tests/Meridian.Tests/Ui/PortfolioLedgerWorkflowStatusServiceTests.cs` that assert a blocked `report-pack` gate remains `Blocked` despite drift signals and that a review-required gate without drift does not report an aligned posture.

### Testing

- Added unit tests `PortfolioLedgerWorkflowStatusServiceTests` which exercise the two regression cases and compile-time assertions via `FluentAssertions` in `tests/Meridian.Tests/Ui/PortfolioLedgerWorkflowStatusServiceTests.cs`.
- Attempted to run the focused test filter (`dotnet test ... --filter FullyQualifiedName~PortfolioLedgerWorkflowStatusServiceTests`) but the environment lacks the `dotnet` SDK so automated execution could not be completed here (tests are present and ready to run in a proper .NET environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17d236cbd8832083e8c622b24dac5d)