### PR TITLE
Fix: emit TrueBreak for unmatched/mismatched positions in canonical reconciliation

### DIFF
--- a/src/Meridian.Application/Reconciliation/CanonicalReconciliationEngine.cs
+++ b/src/Meridian.Application/Reconciliation/CanonicalReconciliationEngine.cs
@@ -82,12 +82,23 @@ public sealed class ReconciliationMatchingEngine
         var breaks = new List<BreakRecord>();
 
         var allPositions = run.SourceSnapshots.SelectMany(s => s.Positions).ToArray();
-        var exactGroups = allPositions.GroupBy(p => (p.InstrumentCanonicalId, p.Quantity, p.Price, p.MarketValue));
-        foreach (var group in exactGroups.Where(g => g.Count() > 1))
+        var groupedByInstrument = allPositions.GroupBy(static p => p.InstrumentCanonicalId);
+        foreach (var instrumentGroup in groupedByInstrument)
         {
-            var ev = new MatchEvidence(Guid.NewGuid().ToString("N"), "exact-position-v1", "Exact", "Exact position tuple match.", 0m, new Dictionary<string, string>());
-            evidence.Add(ev);
-            matches.Add(new MatchGroup(Guid.NewGuid().ToString("N"), BreakClassification.Matched, ev.RuleId, group.Select(p => p.PositionId).ToArray(), Array.Empty<string>(), [ev.EvidenceId]));
+            var exactGroups = instrumentGroup.GroupBy(static p => (p.Quantity, p.Price, p.MarketValue)).ToArray();
+            foreach (var exactGroup in exactGroups.Where(static g => g.Count() > 1))
+            {
+                var exactEvidence = new MatchEvidence(Guid.NewGuid().ToString("N"), "exact-position-v1", "Exact", "Exact position tuple match.", 0m, new Dictionary<string, string>());
+                evidence.Add(exactEvidence);
+                matches.Add(new MatchGroup(Guid.NewGuid().ToString("N"), BreakClassification.Matched, exactEvidence.RuleId, exactGroup.Select(p => p.PositionId).ToArray(), Array.Empty<string>(), [exactEvidence.EvidenceId]));
+            }
+
+            if (exactGroups.Length > 1 || exactGroups[0].Count() == 1)
+            {
+                var breakEvidence = new MatchEvidence(Guid.NewGuid().ToString("N"), "true-break-position-v1", "Exact", "Position has no exact cross-source match.", null, new Dictionary<string, string>());
+                evidence.Add(breakEvidence);
+                breaks.Add(new BreakRecord(Guid.NewGuid().ToString("N"), BreakClassification.TrueBreak, breakEvidence.RuleId, "No exact matching position candidate found.", run.SourceSnapshots.Select(s => s.SnapshotId).ToArray(), [breakEvidence.EvidenceId]));
+            }
         }
 
         var allCash = run.SourceSnapshots.SelectMany(s => s.CashEntries).ToArray();

--- a/tests/Meridian.Tests/Application/Reconciliation/CanonicalReconciliationMatchingEngineTests.cs
+++ b/tests/Meridian.Tests/Application/Reconciliation/CanonicalReconciliationMatchingEngineTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using Meridian.Application.Reconciliation;
+using Meridian.Domain.Reconciliation;
+
+namespace Meridian.Tests.Application.Reconciliation;
+
+public sealed class CanonicalReconciliationMatchingEngineTests
+{
+    [Fact]
+    public void Run_WhenSinglePositionExists_EmitsTrueBreak()
+    {
+        var engine = new ReconciliationMatchingEngine();
+        var run = CreateRun([
+            CreateSnapshot("prime", ReconciliationSourceType.Prime, [CreatePosition("p1", "AAPL", 10m, 100m, 1000m)])
+        ]);
+
+        var result = engine.Run(run, CreateTolerances());
+
+        result.matches.Should().BeEmpty();
+        result.breaks.Should().ContainSingle(b => b.Classification == BreakClassification.TrueBreak && b.RuleId == "true-break-position-v1");
+    }
+
+    [Fact]
+    public void Run_WhenInstrumentHasMismatchedPositionTuples_EmitsTrueBreak()
+    {
+        var engine = new ReconciliationMatchingEngine();
+        var run = CreateRun([
+            CreateSnapshot("prime", ReconciliationSourceType.Prime, [CreatePosition("p1", "AAPL", 10m, 100m, 1000m)]),
+            CreateSnapshot("custodian", ReconciliationSourceType.Custodian, [CreatePosition("p2", "AAPL", 11m, 100m, 1100m)])
+        ]);
+
+        var result = engine.Run(run, CreateTolerances());
+
+        result.matches.Should().BeEmpty();
+        result.breaks.Should().ContainSingle(b => b.Classification == BreakClassification.TrueBreak && b.RuleId == "true-break-position-v1");
+    }
+
+    private static MatchingTolerances CreateTolerances() => new(0m, 0m, 0m, 0m, TimeSpan.FromMinutes(5));
+
+    private static ReconciliationRun CreateRun(IReadOnlyList<DataSourceSnapshot> snapshots) =>
+        new(Guid.NewGuid(), new DateOnly(2026, 5, 28), DateTimeOffset.UtcNow, false, 1, "recon:2026-05-28", snapshots);
+
+    private static DataSourceSnapshot CreateSnapshot(string id, ReconciliationSourceType sourceType, IReadOnlyList<NormalizedPosition> positions) =>
+        new(id, sourceType, DateTimeOffset.UtcNow, "v1", positions, Array.Empty<NormalizedCashEntry>());
+
+    private static NormalizedPosition CreatePosition(string id, string canonicalId, decimal quantity, decimal price, decimal marketValue) =>
+        new(id, canonicalId, null, null, canonicalId, null, quantity, price, marketValue, "USD", DateTimeOffset.UtcNow, id);
+}


### PR DESCRIPTION
### Motivation
- Reconcile positions must not be silently dropped: the previous engine only emitted `Matched` groups for exact duplicate position tuples and ignored singleton or mismatched position groups, which can hide missing or altered positions from break queues and governance checks.

### Description
- Updated `ReconciliationMatchingEngine.Run` in `src/Meridian.Application/Reconciliation/CanonicalReconciliationEngine.cs` to group positions by `InstrumentCanonicalId`, preserve exact-tuple match behavior, and emit a `TrueBreak` when an instrument has no exact cross-source match.
- Added a new position break evidence/rule id `true-break-position-v1` and a corresponding `BreakRecord` with reason `No exact matching position candidate found.` for unmatched or mismatched position groups.
- Added focused regression tests in `tests/Meridian.Tests/Application/Reconciliation/CanonicalReconciliationMatchingEngineTests.cs` that assert a single-source singleton position and an instrument with mismatched tuples both produce a `TrueBreak` and no `MatchGroup`.

### Testing
- A unit test file was added covering the new behaviors (`CanonicalReconciliationMatchingEngineTests`), but runtime test execution was not possible in this environment because `dotnet` is not available here (attempted `dotnet test ... --filter FullyQualifiedName~CanonicalReconciliationMatchingEngineTests` and it failed with `dotnet: command not found`).
- No automated test run completed in this environment; the tests are included and ready to run in a normal .NET-enabled CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17d236f09483208fbe1bf5dd471803)