### PR TITLE
Fix WPF settings save/reset to preserve existing config

### DIFF
--- a/src/Meridian.Wpf/ViewModels/SettingsViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/SettingsViewModel.cs
@@ -593,7 +593,19 @@ public sealed class SettingsViewModel : BindableBase
 
         try
         {
-            await _configService.WriteConfigAsync(new AppConfigDto());
+            var existingConfig = await _configService.LoadConfigFromDiskAsync();
+            var defaultConfig = new AppConfigDto();
+            defaultConfig.Symbols = existingConfig.Symbols;
+            defaultConfig.Alpaca = existingConfig.Alpaca;
+            defaultConfig.Polygon = existingConfig.Polygon;
+            defaultConfig.IB = existingConfig.IB;
+            defaultConfig.IBClientPortal = existingConfig.IBClientPortal;
+            defaultConfig.Backfill = existingConfig.Backfill;
+            defaultConfig.DataSources = existingConfig.DataSources;
+            defaultConfig.SymbolGroups = existingConfig.SymbolGroups;
+            defaultConfig.Derivatives = existingConfig.Derivatives;
+
+            await _configService.WriteConfigAsync(defaultConfig);
             await LoadConfigAsync(false);
             _notificationService.ShowNotification("Reset Complete", "Settings have been reset to defaults.", NotificationType.Success);
         }
@@ -665,24 +677,27 @@ public sealed class SettingsViewModel : BindableBase
         }
     }
 
-    private AppConfigDto BuildConfigDtoFromSettings()
+    private AppConfigDto BuildConfigDtoFromSettings(AppConfigDto existingConfig)
     {
+        ArgumentNullException.ThrowIfNull(existingConfig);
+
         var interval = int.TryParse(StatusRefreshInterval, out var parsedInterval) ? parsedInterval : 2;
         var maxReconnect = int.TryParse(MaxConcurrentDownloads, out var parsedMaxReconnect) ? parsedMaxReconnect : 10;
-        return new AppConfigDto
+
+        existingConfig.IBClientPortal ??= new IBClientPortalOptionsDto();
+        existingConfig.IBClientPortal.BaseUrl = ApiBaseUrl;
+        existingConfig.Compress = WriteBufferSize != "0";
+        existingConfig.Settings = new AppSettingsDto
         {
-            IBClientPortal = new IBClientPortalOptionsDto { BaseUrl = ApiBaseUrl },
-            Compress = WriteBufferSize != "0",
-            Settings = new AppSettingsDto
-            {
-                Theme = ThemeIndex switch { 1 => "Light", 2 => "Dark", _ => "System" },
-                NotificationsEnabled = IsNotificationsEnabled,
-                CompactMode = SelectedShellDensityMode == ShellDensityMode.Compact,
-                AutoReconnectEnabled = IsMetricsEnabled,
-                MaxReconnectAttempts = maxReconnect,
-                StatusRefreshIntervalSeconds = interval
-            }
+            Theme = ThemeIndex switch { 1 => "Light", 2 => "Dark", _ => "System" },
+            NotificationsEnabled = IsNotificationsEnabled,
+            CompactMode = SelectedShellDensityMode == ShellDensityMode.Compact,
+            AutoReconnectEnabled = IsMetricsEnabled,
+            MaxReconnectAttempts = maxReconnect,
+            StatusRefreshIntervalSeconds = interval
         };
+
+        return existingConfig;
     }
 
     private async Task SaveConfigAsync() => await SaveOrApplyConfigAsync("Configuration Saved");
@@ -696,7 +711,9 @@ public sealed class SettingsViewModel : BindableBase
             return;
         }
 
-        await _configService.WriteConfigAsync(BuildConfigDtoFromSettings());
+        var existingConfig = await _configService.LoadConfigFromDiskAsync();
+        var updatedConfig = BuildConfigDtoFromSettings(existingConfig);
+        await _configService.WriteConfigAsync(updatedConfig);
         HasUnsavedChanges = false;
         _notificationService.ShowNotification(messageTitle, "Settings have been written to disk.", NotificationType.Success);
     }


### PR DESCRIPTION
### Motivation
- Prevent the settings save/apply flow from overwriting the entire configuration file with a partial DTO and thereby losing provider, symbol, storage, and credential sections. 
- Ensure the reset-to-defaults action behaves like its UI prompt by preserving symbols and credential-bearing/provider sections. 
- Make the settings-to-config workflow merge changes into the existing `AppConfigDto` instead of constructing a new, partial config object.

### Description
- Updated `ResetToDefaultsAsync` to load the current config and write a default scaffold that preserves `Symbols`, `Alpaca`, `Polygon`, `IB`, `IBClientPortal`, `Backfill`, `DataSources`, `SymbolGroups`, and `Derivatives` before applying defaults. 
- Changed `BuildConfigDtoFromSettings` to accept an `AppConfigDto existingConfig`, mutate only settings-related fields (`IBClientPortal.BaseUrl`, `Compress`, and `Settings`) and return the merged DTO. 
- Updated save/apply code to `LoadConfigFromDiskAsync()`, call the new `BuildConfigDtoFromSettings(existingConfig)`, and write the merged result via `_configService.WriteConfigAsync(...)` so unrelated sections are retained. 
- Added an `ArgumentNullException.ThrowIfNull(existingConfig)` guard in `BuildConfigDtoFromSettings` to document the expectation of a non-null base config.

### Testing
- Attempted to run .NET build/tests but could not execute them in this environment because `dotnet` is not installed (`dotnet: command not found`).
- Performed static validation by reviewing the updated diff and verifying the save, apply, and reset code paths now load and merge the existing `AppConfigDto` rather than writing a partial object. 
- Committed the change with a focused message: `Fix settings save/reset to preserve existing config`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17d237077883208786cbfdfc80e83f)