### PR TITLE
fix(security): avoid covered-call command drops on queue overflow

### DIFF
--- a/src/Meridian.Ui.Shared/Services/CoveredCall/CoveredCallBacktestService.cs
+++ b/src/Meridian.Ui.Shared/Services/CoveredCall/CoveredCallBacktestService.cs
@@ -38,7 +38,7 @@ public sealed class CoveredCallBacktestService : ICoveredCallBacktestService, IH
 
     private static readonly BoundedChannelOptions RunQueueOptions = new(capacity: 512)
     {
-        FullMode = BoundedChannelFullMode.DropWrite,
+        FullMode = BoundedChannelFullMode.Wait,
         SingleReader = true,
         SingleWriter = false
     };


### PR DESCRIPTION
### Motivation
- Prevent a denial-of-service scenario where the bounded covered-call command channel used `BoundedChannelFullMode.DropWrite`, which can silently discard commands and leave runs stuck in `RunPhase.Queued` and never pruned.

### Description
- Change `RunQueueOptions.FullMode` from `BoundedChannelFullMode.DropWrite` to `BoundedChannelFullMode.Wait` in `src/Meridian.Ui.Shared/Services/CoveredCall/CoveredCallBacktestService.cs` so writes block until space is available and accepted runs are guaranteed to be enqueued.

### Testing
- No automated tests were run in this environment because the .NET SDK/runtime was unavailable (`dotnet` not found), so validation was limited to source inspection (`git diff`, `nl`) and committing the one-line fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17feda73d883209319d475f17ed2d2)