### PR TITLE
Scope governance lifecycle projection to fund's own workflows

### DIFF
--- a/src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs
+++ b/src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs
@@ -1418,7 +1418,7 @@ public sealed class FundOperationsWorkspaceReadService
                 .Where(summary => accountIds.Contains(summary.FundAccountId))
                 .ToArray();
 
-            activeWorkflowSummary = (scopedSummaries.Length > 0 ? scopedSummaries : summaries)
+            activeWorkflowSummary = scopedSummaries
                 .OrderByDescending(static item => item.UpdatedAtUtc)
                 .FirstOrDefault();
 


### PR DESCRIPTION
### Motivation
- Fix a cross-fund information disclosure where `BuildGovernanceLifecycleProjectionAsync` could pick the newest operations workflow globally and return another fund's workflow id/status/approval/evidence/audit data inside a different fund's workspace projection.

### Description
- Restrict workflow selection in `src/Meridian.Ui.Shared/Services/FundOperationsWorkspaceReadService.cs` to only consider `OperationsContinuityWorkflowSummaryDto` entries whose `FundAccountId` matches the requested fund's account IDs and remove the previous fallback that selected the newest workflow globally.

### Testing
- Attempted to run the focused unit tests with `dotnet test --filter FundOperationsWorkspaceReadServiceTests`, but `dotnet` is not available in this environment (`dotnet: command not found`), so automated tests could not be executed here; the fix is a single-line scope change and should be validated by the existing test suite in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17fedb1484832099ed24b8ef8d93f9)