### PR TITLE
Fix dual-path consumer cancellation token wiring

### DIFF
--- a/src/Meridian.Application/Pipeline/DualPathEventPipeline.cs
+++ b/src/Meridian.Application/Pipeline/DualPathEventPipeline.cs
@@ -131,13 +131,13 @@ public sealed class DualPathEventPipeline : IMarketEventPublisher, IBackpressure
         {
             // Start one long-running consumer per ring buffer.
             _tradeConsumer = Task.Factory.StartNew(
-                () => ConsumeTradesAsync(),
+                () => ConsumeTradesAsync(_cts.Token),
                 _cts.Token,
                 TaskCreationOptions.LongRunning,
                 TaskScheduler.Default).Unwrap();
 
             _quoteConsumer = Task.Factory.StartNew(
-                () => ConsumeQuotesAsync(),
+                () => ConsumeQuotesAsync(_cts.Token),
                 _cts.Token,
                 TaskCreationOptions.LongRunning,
                 TaskScheduler.Default).Unwrap();


### PR DESCRIPTION
### Motivation
- Restore correct disposal behavior in `DualPathEventPipeline` so long-running trade/quote consumer tasks observe the pipeline cancellation and do not leak after `DisposeAsync` is invoked.

### Description
- Pass the pipeline cancellation token into both consumer startup delegates by changing the `Task.Factory.StartNew` calls to invoke `ConsumeTradesAsync(_cts.Token)` and `ConsumeQuotesAsync(_cts.Token)` in `src/Meridian.Application/Pipeline/DualPathEventPipeline.cs`.

### Testing
- Could not run the .NET unit tests in this environment because `dotnet` is not installed, so validation was performed via static inspection and `git` diff to confirm the consumers now receive `_cts.Token` and the change is limited to the startup wiring.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a807ee108320979692bbdba67fe2)