### PR TITLE
Add additive statement reconciliation workstation DTOs and compatibility tests

### DIFF
--- a/docs/status/contract-compatibility-matrix.md
+++ b/docs/status/contract-compatibility-matrix.md
@@ -174,6 +174,7 @@ Use this section for every potential contract-breaking change. Entries must be a
 - 2026-05-27: Added `WorkstationEndpointContractCompatibilityTests` in `tests/Meridian.Tests/Ui/` to snapshot critical readiness/inbox/replay/report-pack DTO fingerprints, enforce enum member/value stability for backward compatibility, and assert additive-only top-level payload evolution for workstation readiness, operator inbox, and replay verification payloads. CI now fails contract lanes when these critical payloads drift without explicit snapshot/versioning updates and migration handling notes.
 
 - 2026-05-27: Expanded evidence packet/workstation completeness contracts with additive diagnostics fields (`EvidenceCompletenessDto.BlockingIssueCount`, `WarningIssueCount`, `OrphanEvidenceIds`, plus matching `EvidenceCompletenessSummaryDto` counters) and retained-artifact canonical subject linkage (`EvidenceArtifactRefDto.CanonicalSubjectKind`/`CanonicalSubjectId`). Changes are additive-only; older clients may ignore new nullable fields but should treat new critical validation issues as blocking readiness/promotion gates.
+- 2026-05-28: Added additive statement reconciliation workstation DTOs for source/run evidence, normalized positions/cash/transactions, match summaries, breaks, validation issues, and operator cases. The payloads are contract-only and transport-safe; existing clients can ignore the new DTO family until route surfaces begin returning it.
 
 ## Pull Request Author Checklist
 

--- a/src/Meridian.Contracts/README.md
+++ b/src/Meridian.Contracts/README.md
@@ -66,6 +66,12 @@ controller workflows can treat provider-ledger variances as accounting-grade cas
 detail contract also carries Security Master confidence passports for provider positions, including
 resolution source, confidence score, validation issue codes, and identifier-conflict evidence.
 
+Statement reconciliation payloads live under `Workstation/StatementReconciliationDtos.cs` and keep
+source-file evidence, mapping/tolerance profile versions, normalized positions, cash, transactions,
+match summaries, breaks, and operator cases in the shared contract lane. Keep these DTOs additive and
+transport-safe so browser, WPF, retained evidence, and automation consumers can reconcile custodian
+statements without referencing application, UI, or infrastructure types.
+
 Direct lending command result codes distinguish validation failures, missing aggregates,
 optimistic concurrency conflicts, and idempotency/command conflicts so persistence stores can return
 operator-safe failure reasons without parsing exception text.

--- a/src/Meridian.Contracts/Workstation/StatementReconciliationDtos.cs
+++ b/src/Meridian.Contracts/Workstation/StatementReconciliationDtos.cs
@@ -1,0 +1,243 @@
+using System.Text.Json.Serialization;
+
+namespace Meridian.Contracts.Workstation;
+
+/// <summary>
+/// Lifecycle state for a statement reconciliation run shared by workstation clients.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<StatementRunStatus>))]
+public enum StatementRunStatus : byte
+{
+    Unknown = 0,
+    PendingValidation = 1,
+    Validating = 2,
+    ValidationFailed = 3,
+    Importing = 4,
+    Reconciling = 5,
+    ReviewRequired = 6,
+    Completed = 7,
+    Failed = 8,
+    Canceled = 9
+}
+
+/// <summary>
+/// Severity for source validation issues found before or during statement normalization.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<StatementValidationSeverity>))]
+public enum StatementValidationSeverity : byte
+{
+    Info = 0,
+    Warning = 1,
+    Error = 2,
+    Critical = 3
+}
+
+/// <summary>
+/// Confidence tier assigned to a statement item matched against Meridian books and activity.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<StatementMatchTier>))]
+public enum StatementMatchTier : byte
+{
+    Unknown = 0,
+    Exact = 1,
+    WithinTolerance = 2,
+    Probable = 3,
+    Manual = 4,
+    Unmatched = 5
+}
+
+/// <summary>
+/// Canonical category for a statement reconciliation break.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<StatementBreakType>))]
+public enum StatementBreakType : byte
+{
+    Unknown = 0,
+    MissingStatementPosition = 1,
+    MissingBookPosition = 2,
+    PositionQuantityMismatch = 3,
+    PositionMarketValueMismatch = 4,
+    MissingStatementCash = 5,
+    MissingBookCash = 6,
+    CashBalanceMismatch = 7,
+    MissingStatementTransaction = 8,
+    MissingBookTransaction = 9,
+    TransactionAmountMismatch = 10,
+    SecurityIdentifierMismatch = 11,
+    TimingMismatch = 12,
+    ClassificationMismatch = 13,
+    DuplicateStatementItem = 14,
+    ValidationFailure = 15
+}
+
+/// <summary>
+/// Source metadata for a broker, custodian, or administrator statement payload.
+/// </summary>
+public sealed record StatementSourceDto(
+    string? SourceId,
+    string? SourceKind,
+    string? SourceSystem,
+    string? AccountId,
+    string? AccountName,
+    string? Currency,
+    DateOnly? PeriodStart,
+    DateOnly? PeriodEnd,
+    DateTimeOffset? StatementAsOfUtc = null,
+    string? CustodianId = null,
+    string? ExternalAccountId = null);
+
+/// <summary>
+/// Validation issue raised while reading, mapping, or normalizing a statement source.
+/// </summary>
+public sealed record StatementValidationIssueDto(
+    string? IssueId,
+    StatementValidationSeverity? Severity,
+    string? Code,
+    string? Message,
+    int? SourceRowNumber = null,
+    string? SourceColumn = null,
+    string? RawValue = null,
+    string? RecommendedAction = null,
+    string? EvidenceLink = null);
+
+/// <summary>
+/// Canonical position row normalized from a statement source.
+/// </summary>
+public sealed record StatementNormalizedPositionDto(
+    string? RowId,
+    string? AccountId,
+    string? Symbol,
+    decimal? Quantity,
+    decimal? MarketPrice,
+    decimal? MarketValue,
+    string? Currency,
+    DateTimeOffset? AsOfUtc,
+    string? Fingerprint,
+    string? SecurityId = null,
+    string? Cusip = null,
+    string? Isin = null,
+    string? Sedol = null,
+    string? SourceReference = null);
+
+/// <summary>
+/// Canonical cash-balance row normalized from a statement source.
+/// </summary>
+public sealed record StatementNormalizedCashDto(
+    string? RowId,
+    string? AccountId,
+    string? Currency,
+    decimal? Amount,
+    DateTimeOffset? AsOfUtc,
+    string? Fingerprint,
+    string? CashType = null,
+    string? SourceReference = null);
+
+/// <summary>
+/// Canonical transaction row normalized from a statement source.
+/// </summary>
+public sealed record StatementNormalizedTransactionDto(
+    string? RowId,
+    string? AccountId,
+    string? ActivityType,
+    DateOnly? TradeDate,
+    decimal? Amount,
+    string? Currency,
+    string? Fingerprint,
+    DateOnly? SettleDate = null,
+    string? ExternalTransactionId = null,
+    string? Symbol = null,
+    decimal? Quantity = null,
+    decimal? Price = null,
+    string? Description = null,
+    string? SourceReference = null);
+
+/// <summary>
+/// Aggregate matching posture for a statement reconciliation run.
+/// </summary>
+public sealed record StatementMatchSummaryDto(
+    int? StatementItemCount,
+    int? MatchedItemCount,
+    int? AutoMatchedItemCount,
+    int? ManualMatchedItemCount,
+    int? ReviewRequiredItemCount,
+    int? BreakCount,
+    int? PositionBreakCount,
+    int? CashBreakCount,
+    int? TransactionBreakCount,
+    StatementMatchTier? HighestUnresolvedTier = null,
+    decimal? MatchedNotional = null,
+    decimal? UnmatchedNotional = null,
+    string? BaseCurrency = null);
+
+/// <summary>
+/// Open or resolved variance between normalized statement data and Meridian books/activity.
+/// </summary>
+public sealed record StatementBreakDto(
+    string? BreakId,
+    StatementBreakType? BreakType,
+    StatementValidationSeverity? Severity,
+    StatementMatchTier? MatchTier,
+    string? StatementReference,
+    string? Description,
+    decimal? StatementAmount,
+    decimal? BookAmount,
+    decimal? Delta,
+    decimal? Tolerance,
+    string? Currency,
+    DateTimeOffset? CreatedAtUtc,
+    string? Status,
+    string? InternalReference = null,
+    string? Owner = null,
+    DateTimeOffset? LastObservedAtUtc = null,
+    string? RecommendedAction = null,
+    string? EvidenceLink = null);
+
+/// <summary>
+/// Operator case opened to investigate and close one or more statement reconciliation breaks.
+/// </summary>
+public sealed record StatementReconciliationCaseDto(
+    string? CaseId,
+    string? RunId,
+    string? Status,
+    string? Priority,
+    string? Title,
+    string? Summary,
+    IReadOnlyList<string>? BreakIds,
+    DateTimeOffset? CreatedAtUtc,
+    DateTimeOffset? LastUpdatedAtUtc,
+    string? LastUpdatedBy,
+    string? Owner = null,
+    DateTimeOffset? DueAtUtc = null,
+    DateTimeOffset? ResolvedAtUtc = null,
+    string? ResolutionCode = null,
+    string? ResolutionSummary = null,
+    string? EvidenceLink = null);
+
+/// <summary>
+/// Shared workstation payload for a statement reconciliation run and its normalized evidence.
+/// </summary>
+public sealed record StatementRunDto(
+    string? RunId,
+    StatementRunStatus? Status,
+    StatementSourceDto? Source,
+    DateTimeOffset? StartedAtUtc,
+    DateTimeOffset? CompletedAtUtc,
+    string? SourceFileName,
+    string? SourceFileHash,
+    string? MappingProfileId,
+    int? MappingProfileVersion,
+    string? ToleranceProfileId,
+    int? ToleranceProfileVersion,
+    string? ImportedBy,
+    DateTimeOffset? ImportedAtUtc,
+    IReadOnlyList<StatementValidationIssueDto>? ValidationIssues,
+    IReadOnlyList<StatementNormalizedPositionDto>? Positions,
+    IReadOnlyList<StatementNormalizedCashDto>? CashBalances,
+    IReadOnlyList<StatementNormalizedTransactionDto>? Transactions,
+    StatementMatchSummaryDto? MatchSummary,
+    IReadOnlyList<StatementBreakDto>? Breaks,
+    IReadOnlyList<StatementReconciliationCaseDto>? Cases,
+    string? ImportId = null,
+    string? FundProfileId = null,
+    Guid? FundAccountId = null,
+    string? Notes = null);

--- a/tests/Meridian.Tests/Contracts/LedgerReconciliationContractCompatibilityTests.cs
+++ b/tests/Meridian.Tests/Contracts/LedgerReconciliationContractCompatibilityTests.cs
@@ -94,6 +94,79 @@ public sealed class LedgerReconciliationContractCompatibilityTests
             "PayloadId", "Schema", "Correlation", "CreatedAt", "Producer", "Direction", "IdempotencyKey", "Payload");
     }
 
+
+    [Fact]
+    public void StatementReconciliationRun_WebAndRetainedConsumers_SerializeEvidenceAndNormalizedPayloads()
+    {
+        var dto = BuildStatementRunDto();
+
+        var json = JsonSerializer.Serialize(dto, JsonOptions);
+
+        Assert.Contains("\"runId\":\"statement-run-1\"", json);
+        Assert.Contains("\"status\":\"ReviewRequired\"", json);
+        Assert.Contains("\"sourceFileName\":\"custodian-statement.csv\"", json);
+        Assert.Contains("\"sourceFileHash\":\"sha256:statement-source\"", json);
+        Assert.Contains("\"mappingProfileId\":\"map-custodian-v1\"", json);
+        Assert.Contains("\"mappingProfileVersion\":3", json);
+        Assert.Contains("\"toleranceProfileId\":\"tol-equity-cash\"", json);
+        Assert.Contains("\"toleranceProfileVersion\":2", json);
+        Assert.Contains("\"importedBy\":\"ops@example.com\"", json);
+        Assert.Contains("\"importedAtUtc\":\"2026-01-05T12:00:00+00:00\"", json);
+        Assert.Contains("\"positions\"", json);
+        Assert.Contains("\"cashBalances\"", json);
+        Assert.Contains("\"transactions\"", json);
+        Assert.Contains("\"breaks\"", json);
+        Assert.Contains("\"cases\"", json);
+
+        Assert.DoesNotContain("\"SourceFileName\"", json);
+        Assert.DoesNotContain("\"MappingProfileId\"", json);
+    }
+
+    [Fact]
+    public void AdditiveOnlyContractShape_GuardForStatementReconciliationDtos()
+    {
+        AssertMembers(typeof(StatementRunDto),
+            "RunId", "Status", "Source", "StartedAtUtc", "CompletedAtUtc", "SourceFileName",
+            "SourceFileHash", "MappingProfileId", "MappingProfileVersion", "ToleranceProfileId",
+            "ToleranceProfileVersion", "ImportedBy", "ImportedAtUtc", "ValidationIssues",
+            "Positions", "CashBalances", "Transactions", "MatchSummary", "Breaks", "Cases",
+            "ImportId", "FundProfileId", "FundAccountId", "Notes");
+
+        AssertMembers(typeof(StatementSourceDto),
+            "SourceId", "SourceKind", "SourceSystem", "AccountId", "AccountName", "Currency",
+            "PeriodStart", "PeriodEnd", "StatementAsOfUtc", "CustodianId", "ExternalAccountId");
+
+        AssertMembers(typeof(StatementValidationIssueDto),
+            "IssueId", "Severity", "Code", "Message", "SourceRowNumber", "SourceColumn",
+            "RawValue", "RecommendedAction", "EvidenceLink");
+
+        AssertMembers(typeof(StatementNormalizedPositionDto),
+            "RowId", "AccountId", "Symbol", "Quantity", "MarketPrice", "MarketValue",
+            "Currency", "AsOfUtc", "Fingerprint", "SecurityId", "Cusip", "Isin", "Sedol", "SourceReference");
+
+        AssertMembers(typeof(StatementNormalizedCashDto),
+            "RowId", "AccountId", "Currency", "Amount", "AsOfUtc", "Fingerprint", "CashType", "SourceReference");
+
+        AssertMembers(typeof(StatementNormalizedTransactionDto),
+            "RowId", "AccountId", "ActivityType", "TradeDate", "Amount", "Currency", "Fingerprint",
+            "SettleDate", "ExternalTransactionId", "Symbol", "Quantity", "Price", "Description", "SourceReference");
+
+        AssertMembers(typeof(StatementMatchSummaryDto),
+            "StatementItemCount", "MatchedItemCount", "AutoMatchedItemCount", "ManualMatchedItemCount",
+            "ReviewRequiredItemCount", "BreakCount", "PositionBreakCount", "CashBreakCount",
+            "TransactionBreakCount", "HighestUnresolvedTier", "MatchedNotional", "UnmatchedNotional", "BaseCurrency");
+
+        AssertMembers(typeof(StatementBreakDto),
+            "BreakId", "BreakType", "Severity", "MatchTier", "StatementReference", "Description",
+            "StatementAmount", "BookAmount", "Delta", "Tolerance", "Currency", "CreatedAtUtc",
+            "Status", "InternalReference", "Owner", "LastObservedAtUtc", "RecommendedAction", "EvidenceLink");
+
+        AssertMembers(typeof(StatementReconciliationCaseDto),
+            "CaseId", "RunId", "Status", "Priority", "Title", "Summary", "BreakIds", "CreatedAtUtc",
+            "LastUpdatedAtUtc", "LastUpdatedBy", "Owner", "DueAtUtc", "ResolvedAtUtc", "ResolutionCode",
+            "ResolutionSummary", "EvidenceLink");
+    }
+
     [Fact]
     public void ReconciliationEnvelope_SerializesCanonicalVersionAndCorrelationShape()
     {
@@ -124,6 +197,131 @@ public sealed class LedgerReconciliationContractCompatibilityTests
         var expected = expectedMembers.OrderBy(x => x).ToArray();
         Assert.Equal(expected, actual);
     }
+
+
+    private static StatementRunDto BuildStatementRunDto() => new(
+        RunId: "statement-run-1",
+        Status: StatementRunStatus.ReviewRequired,
+        Source: new StatementSourceDto(
+            SourceId: "source-1",
+            SourceKind: "custodian",
+            SourceSystem: "PrimeBroker",
+            AccountId: "acct-1",
+            AccountName: "Alpha Prime",
+            Currency: "USD",
+            PeriodStart: DateOnly.Parse("2026-01-01"),
+            PeriodEnd: DateOnly.Parse("2026-01-05"),
+            StatementAsOfUtc: DateTimeOffset.Parse("2026-01-05T11:59:00Z")),
+        StartedAtUtc: DateTimeOffset.Parse("2026-01-05T12:00:00Z"),
+        CompletedAtUtc: null,
+        SourceFileName: "custodian-statement.csv",
+        SourceFileHash: "sha256:statement-source",
+        MappingProfileId: "map-custodian-v1",
+        MappingProfileVersion: 3,
+        ToleranceProfileId: "tol-equity-cash",
+        ToleranceProfileVersion: 2,
+        ImportedBy: "ops@example.com",
+        ImportedAtUtc: DateTimeOffset.Parse("2026-01-05T12:00:00Z"),
+        ValidationIssues:
+        [
+            new StatementValidationIssueDto(
+                IssueId: "issue-1",
+                Severity: StatementValidationSeverity.Warning,
+                Code: "UNKNOWN_COLUMN",
+                Message: "Statement included an unmapped memo column.",
+                SourceRowNumber: 4,
+                SourceColumn: "memo",
+                RecommendedAction: "Review mapping profile before promotion.")
+        ],
+        Positions:
+        [
+            new StatementNormalizedPositionDto(
+                RowId: "row-position-1",
+                AccountId: "acct-1",
+                Symbol: "MSFT",
+                Quantity: 10m,
+                MarketPrice: 420m,
+                MarketValue: 4200m,
+                Currency: "USD",
+                AsOfUtc: DateTimeOffset.Parse("2026-01-05T11:59:00Z"),
+                Fingerprint: "fp-position-1",
+                Cusip: "594918104")
+        ],
+        CashBalances:
+        [
+            new StatementNormalizedCashDto(
+                RowId: "row-cash-1",
+                AccountId: "acct-1",
+                Currency: "USD",
+                Amount: 1250m,
+                AsOfUtc: DateTimeOffset.Parse("2026-01-05T11:59:00Z"),
+                Fingerprint: "fp-cash-1",
+                CashType: "settled")
+        ],
+        Transactions:
+        [
+            new StatementNormalizedTransactionDto(
+                RowId: "row-transaction-1",
+                AccountId: "acct-1",
+                ActivityType: "buy",
+                TradeDate: DateOnly.Parse("2026-01-03"),
+                Amount: -4200m,
+                Currency: "USD",
+                Fingerprint: "fp-transaction-1",
+                SettleDate: DateOnly.Parse("2026-01-05"),
+                ExternalTransactionId: "txn-1",
+                Symbol: "MSFT",
+                Quantity: 10m,
+                Price: 420m)
+        ],
+        MatchSummary: new StatementMatchSummaryDto(
+            StatementItemCount: 3,
+            MatchedItemCount: 2,
+            AutoMatchedItemCount: 2,
+            ManualMatchedItemCount: 0,
+            ReviewRequiredItemCount: 1,
+            BreakCount: 1,
+            PositionBreakCount: 0,
+            CashBreakCount: 1,
+            TransactionBreakCount: 0,
+            HighestUnresolvedTier: StatementMatchTier.Probable,
+            MatchedNotional: 4200m,
+            UnmatchedNotional: 25m,
+            BaseCurrency: "USD"),
+        Breaks:
+        [
+            new StatementBreakDto(
+                BreakId: "break-1",
+                BreakType: StatementBreakType.CashBalanceMismatch,
+                Severity: StatementValidationSeverity.Warning,
+                MatchTier: StatementMatchTier.Probable,
+                StatementReference: "row-cash-1",
+                Description: "Statement cash differs from book cash by tolerance breach.",
+                StatementAmount: 1250m,
+                BookAmount: 1225m,
+                Delta: 25m,
+                Tolerance: 1m,
+                Currency: "USD",
+                CreatedAtUtc: DateTimeOffset.Parse("2026-01-05T12:01:00Z"),
+                Status: "Open")
+        ],
+        Cases:
+        [
+            new StatementReconciliationCaseDto(
+                CaseId: "case-1",
+                RunId: "statement-run-1",
+                Status: "Open",
+                Priority: "Normal",
+                Title: "Cash variance review",
+                Summary: "Review the custodian cash balance variance.",
+                BreakIds: ["break-1"],
+                CreatedAtUtc: DateTimeOffset.Parse("2026-01-05T12:02:00Z"),
+                LastUpdatedAtUtc: DateTimeOffset.Parse("2026-01-05T12:02:00Z"),
+                LastUpdatedBy: "ops@example.com")
+        ],
+        ImportId: "import-1",
+        FundProfileId: "fund-1",
+        FundAccountId: Guid.Parse("22222222-2222-2222-2222-222222222222"));
 
     private static FundLedgerSummary BuildFundLedgerSummary() => new(
         FundProfileId: "fund-1",


### PR DESCRIPTION
### Motivation

- Provide a shared, transport-safe contract surface for statement/custodian reconciliation evidence and normalized payloads consumed by workstation clients and automation. 
- Surface importer evidence (file name/hash), mapping/tolerance profile versions, and importer metadata so clients can reliably render and audit statement ingest runs. 
- Keep contracts additive and backward-compatible so older clients can ignore new fields without runtime breaks. 

### Description

- Added a new contract file `src/Meridian.Contracts/Workstation/StatementReconciliationDtos.cs` containing enums and DTO records for `StatementRunDto`, `StatementRunStatus`, `StatementSourceDto`, `StatementValidationIssueDto`, `StatementValidationSeverity`, `StatementNormalizedPositionDto`, `StatementNormalizedCashDto`, `StatementNormalizedTransactionDto`, `StatementMatchSummaryDto`, `StatementMatchTier`, `StatementBreakDto`, `StatementBreakType`, and `StatementReconciliationCaseDto`. 
- Included the requested evidence fields on `StatementRunDto`: `SourceFileName`, `SourceFileHash`, `MappingProfileId`, `MappingProfileVersion`, `ToleranceProfileId`, `ToleranceProfileVersion`, `ImportedBy`, and `ImportedAtUtc`. 
- Made DTOs transport-safe and additive by keeping records/fields nullable or optional where appropriate to satisfy v1 compatibility rules. 
- Added contract-level tests in `tests/Meridian.Tests/Contracts/LedgerReconciliationContractCompatibilityTests.cs` to assert JSON casing/serialization for statement runs and to guard additive-only contract shape for the new DTO family. 
- Updated `src/Meridian.Contracts/README.md` and `docs/status/contract-compatibility-matrix.md` with a short note routing statement reconciliation payloads through the shared workstation contract lane. 

### Testing

- Ran the contract compatibility gate with `python3 scripts/check_contract_compatibility_gate.py --base HEAD~1 --head HEAD` and iterated until the gate passed (ensured new DTO members are optional/null-safe). (passed) 
- Generated the contract review packet with `python3 scripts/generate_contract_review_packet.py --base HEAD~1 --head HEAD` to produce a review artifact for interop review. (passed) 
- Ran the repository diff check `git diff --check` to validate there are no whitespace/patch issues. (passed) 
- Attempted to run the narrow workstation contract tests via `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~LedgerReconciliationContractCompatibilityTests"` but `dotnet` is not available in this environment so the test run could not be executed here (environment limitation). (not run) 
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary`, which reported pre-existing repo-wide source/README hash drift unrelated to this change; this is an existing repo state that should be reviewed separately. (not passed: repo-wide doc-hash drift)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18797218b883209869a761ee5d7aae)