### PR TITLE
Add statement mapping profiles and profile-driven CSV parsing

### DIFF
--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -36,6 +36,7 @@ and UI presentation concerns in their owning layers.
   fund-structure assignments before falling back to account ledger references.
 - `Services/` - application use cases and orchestration services.
 - `Composition/` - application feature registration and service wiring.
+- `Reconciliation/` - statement reconciliation workflows, external statement mapping profiles, case intake, and match orchestration.
 
 ## Important workflows
 
@@ -45,6 +46,7 @@ application service contracts consumed by host and UI surfaces.
 ## API contract notes
 
 - Options-chain provider IDs are normalized with trim plus invariant lowercase before deduplication, health lookup, fallback detection, logging, and metrics.
+- Statement reconciliation intake uses `StatementMappingProfileRegistry` to resolve broker/custodian CSV fields into canonical account, security identifier, quantity, price, cash amount, activity type, trade date, settlement date, currency, fees/commission, and external transaction ID fields. The `canonical-csv-v1` profile preserves the existing fixture header, while `sample-broker-csv-v1` documents a broker-shaped CSV mapping.
 
 ## Diagrams
 

--- a/src/Meridian.Application/Reconciliation/StatementMappingProfiles.cs
+++ b/src/Meridian.Application/Reconciliation/StatementMappingProfiles.cs
@@ -1,0 +1,195 @@
+using System.Globalization;
+
+namespace Meridian.Application.Reconciliation;
+
+public enum StatementCanonicalField
+{
+    Account,
+    SecurityIdentifier,
+    Quantity,
+    Price,
+    CashAmount,
+    ActivityType,
+    TradeDate,
+    SettlementDate,
+    Currency,
+    FeesCommission,
+    ExternalTransactionId
+}
+
+public sealed record StatementFieldMapping(
+    StatementCanonicalField CanonicalField,
+    string SourceColumn,
+    bool Required = true);
+
+public sealed record StatementTransactionCodeMapping(
+    string SourceCode,
+    string CanonicalActivityType);
+
+public sealed record StatementMappingProfile(
+    string ProfileId,
+    string DisplayName,
+    IReadOnlyList<StatementFieldMapping> FieldMappings,
+    IReadOnlyList<StatementTransactionCodeMapping> TransactionCodeMappings)
+{
+    public StatementFieldMapping? FindField(StatementCanonicalField field) =>
+        FieldMappings.FirstOrDefault(mapping => mapping.CanonicalField == field);
+
+    public string MapActivityType(string activityType)
+    {
+        var mapped = TransactionCodeMappings.FirstOrDefault(mapping =>
+            string.Equals(mapping.SourceCode, activityType, StringComparison.OrdinalIgnoreCase));
+        return mapped?.CanonicalActivityType ?? activityType;
+    }
+}
+
+public sealed class StatementMappingProfileRegistry
+{
+    public const string CanonicalCsvV1ProfileId = "canonical-csv-v1";
+    public const string SampleBrokerCsvV1ProfileId = "sample-broker-csv-v1";
+
+    private readonly Dictionary<string, StatementMappingProfile> _profiles;
+
+    public StatementMappingProfileRegistry(IEnumerable<StatementMappingProfile> profiles)
+    {
+        _profiles = profiles.ToDictionary(profile => profile.ProfileId, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public static StatementMappingProfileRegistry Defaults { get; } = new(CreateDefaultProfiles());
+
+    public StatementMappingProfile Resolve(string? profileId)
+    {
+        var effectiveProfileId = string.IsNullOrWhiteSpace(profileId) ? CanonicalCsvV1ProfileId : profileId.Trim();
+        if (_profiles.TryGetValue(effectiveProfileId, out var profile))
+        {
+            return profile;
+        }
+
+        throw new NotSupportedException($"Statement mapping profile '{profileId}' is not registered.");
+    }
+
+    public StatementMappingProfile ResolveForSourceKind(string normalizedSourceKind, string? profileId = null)
+    {
+        if (!string.IsNullOrWhiteSpace(profileId))
+        {
+            return Resolve(profileId);
+        }
+
+        return Resolve(normalizedSourceKind switch
+        {
+            "sample-broker" => SampleBrokerCsvV1ProfileId,
+            _ => CanonicalCsvV1ProfileId
+        });
+    }
+
+    public IReadOnlyList<StatementMappingProfile> ListProfiles() =>
+        _profiles.Values.OrderBy(profile => profile.ProfileId, StringComparer.OrdinalIgnoreCase).ToArray();
+
+    private static IReadOnlyList<StatementMappingProfile> CreateDefaultProfiles() =>
+    [
+        new StatementMappingProfile(
+            CanonicalCsvV1ProfileId,
+            "Canonical CSV v1",
+            [
+                new(StatementCanonicalField.Account, "account"),
+                new(StatementCanonicalField.SecurityIdentifier, "symbol"),
+                new(StatementCanonicalField.Quantity, "quantity"),
+                new(StatementCanonicalField.Price, "price"),
+                new(StatementCanonicalField.CashAmount, "cashAmount"),
+                new(StatementCanonicalField.ActivityType, "activityType"),
+                new(StatementCanonicalField.TradeDate, "tradeDate"),
+                new(StatementCanonicalField.SettlementDate, "settlementDate", Required: false),
+                new(StatementCanonicalField.Currency, "currency", Required: false),
+                new(StatementCanonicalField.FeesCommission, "feesCommission", Required: false),
+                new(StatementCanonicalField.ExternalTransactionId, "externalTransactionId", Required: false)
+            ],
+            [
+                new("position", "position"),
+                new("cash", "cash"),
+                new("cashbalance", "cashbalance"),
+                new("trade", "trade"),
+                new("fee", "fee"),
+                new("dividend", "dividend"),
+                new("div", "dividend")
+            ]),
+        new StatementMappingProfile(
+            SampleBrokerCsvV1ProfileId,
+            "Sample broker CSV v1",
+            [
+                new(StatementCanonicalField.Account, "BrokerAccount"),
+                new(StatementCanonicalField.SecurityIdentifier, "Ticker"),
+                new(StatementCanonicalField.Quantity, "Units"),
+                new(StatementCanonicalField.Price, "ExecutionPrice"),
+                new(StatementCanonicalField.CashAmount, "NetCash"),
+                new(StatementCanonicalField.ActivityType, "TxnCode"),
+                new(StatementCanonicalField.TradeDate, "TradeDate"),
+                new(StatementCanonicalField.SettlementDate, "SettleDate", Required: false),
+                new(StatementCanonicalField.Currency, "CCY", Required: false),
+                new(StatementCanonicalField.FeesCommission, "Commission", Required: false),
+                new(StatementCanonicalField.ExternalTransactionId, "BrokerTransactionId", Required: false)
+            ],
+            [
+                new("POS", "position"),
+                new("CASH", "cash"),
+                new("BUY", "trade"),
+                new("SELL", "trade"),
+                new("FEE", "fee"),
+                new("DIV", "dividend")
+            ])
+    ];
+}
+
+internal sealed class StatementMappedCsvRow
+{
+    private readonly IReadOnlyDictionary<string, string> _valuesByColumn;
+
+    public StatementMappedCsvRow(StatementMappingProfile profile, IReadOnlyDictionary<string, string> valuesByColumn)
+    {
+        Profile = profile;
+        _valuesByColumn = valuesByColumn;
+    }
+
+    public StatementMappingProfile Profile { get; }
+
+    public string GetRequired(StatementCanonicalField field, int rowNumber)
+    {
+        var value = GetOptional(field);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidDataException($"Statement row {rowNumber} is missing required mapped field '{field}'.");
+        }
+
+        return value;
+    }
+
+    public string? GetOptional(StatementCanonicalField field)
+    {
+        var mapping = Profile.FindField(field);
+        if (mapping is null || !_valuesByColumn.TryGetValue(mapping.SourceColumn, out var value))
+        {
+            return null;
+        }
+
+        return value;
+    }
+
+    public decimal GetRequiredDecimal(StatementCanonicalField field, int rowNumber) =>
+        decimal.Parse(GetRequired(field, rowNumber), NumberStyles.Number, CultureInfo.InvariantCulture);
+
+    public DateOnly GetRequiredDate(StatementCanonicalField field, int rowNumber) =>
+        DateOnly.Parse(GetRequired(field, rowNumber), CultureInfo.InvariantCulture);
+
+    public Dictionary<string, string> ToCanonicalSnapshot()
+    {
+        var snapshot = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var mapping in Profile.FieldMappings)
+        {
+            if (_valuesByColumn.TryGetValue(mapping.SourceColumn, out var value))
+            {
+                snapshot[mapping.CanonicalField.ToString()] = value;
+            }
+        }
+
+        return snapshot;
+    }
+}

--- a/src/Meridian.Application/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.Application/Reconciliation/StatementReconciliationService.cs
@@ -4,23 +4,19 @@ namespace Meridian.Application.Reconciliation;
 
 public sealed class StatementReconciliationService
 {
-    private static readonly string[] CanonicalStatementColumns =
-    [
-        "account",
-        "symbol",
-        "quantity",
-        "price",
-        "cashAmount",
-        "activityType",
-        "tradeDate"
-    ];
+    private readonly StatementMappingProfileRegistry _mappingProfiles;
+
+    public StatementReconciliationService(StatementMappingProfileRegistry? mappingProfiles = null)
+    {
+        _mappingProfiles = mappingProfiles ?? StatementMappingProfileRegistry.Defaults;
+    }
 
     public Task<string> ValidateAsync(string sourceKind, string sourcePath, CancellationToken ct)
     {
         var normalizedSourceKind = ValidateSourceAccess(sourceKind, sourcePath);
         if (RequiresCanonicalStatementSchema(normalizedSourceKind))
         {
-            ValidateCanonicalStatementHeader(sourcePath);
+            ValidateStatementHeader(normalizedSourceKind, sourcePath);
         }
 
         return Task.FromResult($"Statement source '{normalizedSourceKind}:{sourcePath}' passed local file accessibility checks.");
@@ -31,7 +27,7 @@ public sealed class StatementReconciliationService
         var normalizedSourceKind = ValidateSourceAccess(sourceKind, sourcePath);
         if (RequiresCanonicalStatementSchema(normalizedSourceKind))
         {
-            ValidateCanonicalStatementHeader(sourcePath);
+            ValidateStatementHeader(normalizedSourceKind, sourcePath);
         }
 
         var content = File.ReadAllText(sourcePath);
@@ -67,8 +63,9 @@ public sealed class StatementReconciliationService
         var normalizedSourceKind = sourceKind.Trim().ToLowerInvariant();
         if (!string.Equals(normalizedSourceKind, "local", StringComparison.Ordinal)
             && !string.Equals(normalizedSourceKind, "broker", StringComparison.Ordinal)
-            && !string.Equals(normalizedSourceKind, "custodian", StringComparison.Ordinal))
-            throw new NotSupportedException($"Statement source kind '{sourceKind}' is not supported. Use 'local', 'broker', or 'custodian'.");
+            && !string.Equals(normalizedSourceKind, "custodian", StringComparison.Ordinal)
+            && !string.Equals(normalizedSourceKind, "sample-broker", StringComparison.Ordinal))
+            throw new NotSupportedException($"Statement source kind '{sourceKind}' is not supported. Use 'local', 'broker', 'custodian', or 'sample-broker'.");
 
         if (!File.Exists(sourcePath))
             throw new FileNotFoundException($"Statement source file '{sourcePath}' was not found.", sourcePath);
@@ -78,9 +75,10 @@ public sealed class StatementReconciliationService
 
     private static bool RequiresCanonicalStatementSchema(string normalizedSourceKind) =>
         string.Equals(normalizedSourceKind, "broker", StringComparison.Ordinal)
-        || string.Equals(normalizedSourceKind, "custodian", StringComparison.Ordinal);
+        || string.Equals(normalizedSourceKind, "custodian", StringComparison.Ordinal)
+        || string.Equals(normalizedSourceKind, "sample-broker", StringComparison.Ordinal);
 
-    private ExternalStatementCaseIntakeResult CreateExternalStatementCases(string normalizedSourceKind, string sourcePath)
+    private ExternalStatementCaseIntakeResult CreateExternalStatementCases(string normalizedSourceKind, string sourcePath, string? mappingProfileId = null)
     {
         if (!RequiresCanonicalStatementSchema(normalizedSourceKind))
         {
@@ -89,10 +87,10 @@ public sealed class StatementReconciliationService
             return new ExternalStatementCaseIntakeResult(importId, normalizedSourceKind, sourcePath, 0, 0, []);
         }
 
-        var rows = ReadCanonicalStatementRows(normalizedSourceKind, sourcePath);
+        var rows = ReadCanonicalStatementRows(normalizedSourceKind, sourcePath, mappingProfileId);
         var (matches, cases) = MatchRows(rows);
         return new ExternalStatementCaseIntakeResult(
-            rows.Count == 0 ? DeterministicFingerprint.Compute($"{normalizedSourceKind}|{sourcePath}") : rows[0].RawSnapshot["importId"],
+            rows.Count == 0 ? DeterministicFingerprint.Compute($"{normalizedSourceKind}|{mappingProfileId}|{sourcePath}") : rows[0].RawSnapshot["importId"],
             normalizedSourceKind,
             sourcePath,
             rows.Count,
@@ -100,13 +98,59 @@ public sealed class StatementReconciliationService
             cases);
     }
 
-    private static IReadOnlyList<NormalizedStatementRow> ReadCanonicalStatementRows(string normalizedSourceKind, string sourcePath)
+    public Task<string> ValidateAsync(string sourceKind, string sourcePath, string mappingProfileId, CancellationToken ct)
     {
-        ValidateCanonicalStatementHeader(sourcePath);
+        var normalizedSourceKind = ValidateSourceAccess(sourceKind, sourcePath);
+        if (RequiresCanonicalStatementSchema(normalizedSourceKind))
+        {
+            ValidateStatementHeader(normalizedSourceKind, sourcePath, mappingProfileId);
+        }
+
+        var profile = _mappingProfiles.ResolveForSourceKind(normalizedSourceKind, mappingProfileId);
+        return Task.FromResult($"Statement source '{normalizedSourceKind}:{sourcePath}' passed local file accessibility checks using mapping profile '{profile.ProfileId}'.");
+    }
+
+    public Task<(string ImportId, int RowCount)> ImportAsync(string sourceKind, string sourcePath, string mappingProfileId, CancellationToken ct)
+    {
+        var normalizedSourceKind = ValidateSourceAccess(sourceKind, sourcePath);
+        if (RequiresCanonicalStatementSchema(normalizedSourceKind))
+        {
+            ValidateStatementHeader(normalizedSourceKind, sourcePath, mappingProfileId);
+        }
+
+        var profile = _mappingProfiles.ResolveForSourceKind(normalizedSourceKind, mappingProfileId);
+        var content = File.ReadAllText(sourcePath);
+        var id = DeterministicFingerprint.Compute($"{normalizedSourceKind}|{profile.ProfileId}|{sourcePath}|{content}");
+        var rowCount = Math.Max(0, File.ReadLines(sourcePath).Count() - 1);
+        return Task.FromResult<(string, int)>((id, rowCount));
+    }
+
+    public Task<(string ImportId, int MatchCount, int UnresolvedCount)> ReconcileAsync(string sourceKind, string sourcePath, string mappingProfileId, CancellationToken ct)
+    {
+        var normalizedSourceKind = ValidateSourceAccess(sourceKind, sourcePath);
+        var intake = CreateExternalStatementCases(normalizedSourceKind, sourcePath, mappingProfileId);
+        return Task.FromResult((intake.ImportId, intake.MatchCount, intake.Cases.Count));
+    }
+
+    public Task<ExternalStatementCaseIntakeResult> CreateExternalStatementCasesAsync(
+        string sourceKind,
+        string sourcePath,
+        string mappingProfileId,
+        CancellationToken ct = default)
+    {
+        var normalizedSourceKind = ValidateSourceAccess(sourceKind, sourcePath);
+        return Task.FromResult(CreateExternalStatementCases(normalizedSourceKind, sourcePath, mappingProfileId));
+    }
+
+    private IReadOnlyList<NormalizedStatementRow> ReadCanonicalStatementRows(string normalizedSourceKind, string sourcePath, string? mappingProfileId = null)
+    {
+        var profile = _mappingProfiles.ResolveForSourceKind(normalizedSourceKind, mappingProfileId);
+        ValidateStatementHeader(normalizedSourceKind, sourcePath, profile.ProfileId);
 
         var content = File.ReadAllText(sourcePath);
-        var importId = DeterministicFingerprint.Compute($"{normalizedSourceKind}|{sourcePath}|{content}");
+        var importId = DeterministicFingerprint.Compute($"{normalizedSourceKind}|{profile.ProfileId}|{sourcePath}|{content}");
         var rows = new List<NormalizedStatementRow>();
+        var header = File.ReadLines(sourcePath).First().Split(',', StringSplitOptions.TrimEntries);
         var lines = File.ReadLines(sourcePath).Skip(1);
         var rowNumber = 1;
         foreach (var line in lines)
@@ -118,19 +162,39 @@ public sealed class StatementReconciliationService
             }
 
             var parts = line.Split(',', StringSplitOptions.TrimEntries);
-            if (parts.Length < CanonicalStatementColumns.Length)
+            if (parts.Length < header.Length)
             {
-                throw new InvalidDataException($"Statement row {rowNumber} has {parts.Length} columns; expected at least {CanonicalStatementColumns.Length}.");
+                throw new InvalidDataException($"Statement row {rowNumber} has {parts.Length} columns; expected at least {header.Length} for mapping profile '{profile.ProfileId}'.");
             }
 
-            var account = parts[0];
-            var symbol = parts[1];
-            var quantity = decimal.Parse(parts[2]);
-            var price = decimal.Parse(parts[3]);
-            var cashAmount = decimal.Parse(parts[4]);
-            var activityType = parts[5];
-            var tradeDate = DateOnly.Parse(parts[6]);
+            var mapped = new StatementMappedCsvRow(profile, BuildColumnMap(header, parts));
+            var account = mapped.GetRequired(StatementCanonicalField.Account, rowNumber);
+            var symbol = mapped.GetRequired(StatementCanonicalField.SecurityIdentifier, rowNumber);
+            var quantity = mapped.GetRequiredDecimal(StatementCanonicalField.Quantity, rowNumber);
+            var price = mapped.GetRequiredDecimal(StatementCanonicalField.Price, rowNumber);
+            var cashAmount = mapped.GetRequiredDecimal(StatementCanonicalField.CashAmount, rowNumber);
+            var activityType = profile.MapActivityType(mapped.GetRequired(StatementCanonicalField.ActivityType, rowNumber));
+            var tradeDate = mapped.GetRequiredDate(StatementCanonicalField.TradeDate, rowNumber);
+            var settlementDate = mapped.GetOptional(StatementCanonicalField.SettlementDate);
+            var currency = mapped.GetOptional(StatementCanonicalField.Currency);
+            var feesCommission = mapped.GetOptional(StatementCanonicalField.FeesCommission);
+            var externalTransactionId = mapped.GetOptional(StatementCanonicalField.ExternalTransactionId);
             var rowFingerprint = DeterministicFingerprint.Compute($"{importId}|{rowNumber}|{line}");
+            var rawSnapshot = mapped.ToCanonicalSnapshot();
+            rawSnapshot["importId"] = importId;
+            rawSnapshot["sourceKind"] = normalizedSourceKind;
+            rawSnapshot["sourcePath"] = sourcePath;
+            rawSnapshot["mappingProfileId"] = profile.ProfileId;
+            rawSnapshot["account"] = account;
+            rawSnapshot["symbol"] = symbol;
+            rawSnapshot["activityType"] = activityType;
+            rawSnapshot["tradeDate"] = tradeDate.ToString("O");
+            rawSnapshot["rowNumber"] = rowNumber.ToString();
+            if (!string.IsNullOrWhiteSpace(settlementDate)) rawSnapshot["settlementDate"] = settlementDate;
+            if (!string.IsNullOrWhiteSpace(currency)) rawSnapshot["currency"] = currency;
+            if (!string.IsNullOrWhiteSpace(feesCommission)) rawSnapshot["feesCommission"] = feesCommission;
+            if (!string.IsNullOrWhiteSpace(externalTransactionId)) rawSnapshot["externalTransactionId"] = externalTransactionId;
+
             rows.Add(new NormalizedStatementRow(
                 $"{importId}:{rowNumber}",
                 ToStatementRowKind(activityType),
@@ -138,24 +202,17 @@ public sealed class StatementReconciliationService
                 quantity,
                 cashAmount == 0m ? price * quantity : cashAmount,
                 new DateTimeOffset(tradeDate.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero),
-                "USD",
+                string.IsNullOrWhiteSpace(currency) ? "USD" : currency,
                 rowFingerprint,
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    ["importId"] = importId,
-                    ["sourceKind"] = normalizedSourceKind,
-                    ["sourcePath"] = sourcePath,
-                    ["account"] = account,
-                    ["activityType"] = activityType,
-                    ["rowNumber"] = rowNumber.ToString()
-                }));
+                rawSnapshot));
         }
 
         return rows;
     }
 
-    private static void ValidateCanonicalStatementHeader(string sourcePath)
+    private void ValidateStatementHeader(string normalizedSourceKind, string sourcePath, string? mappingProfileId = null)
     {
+        var profile = _mappingProfiles.ResolveForSourceKind(normalizedSourceKind, mappingProfileId);
         var header = File.ReadLines(sourcePath).FirstOrDefault();
         if (string.IsNullOrWhiteSpace(header))
         {
@@ -163,11 +220,44 @@ public sealed class StatementReconciliationService
         }
 
         var actual = header.Split(',', StringSplitOptions.TrimEntries);
-        if (actual.Length < CanonicalStatementColumns.Length
-            || !CanonicalStatementColumns.SequenceEqual(actual.Take(CanonicalStatementColumns.Length), StringComparer.OrdinalIgnoreCase))
+        if (profile.ProfileId.Equals(StatementMappingProfileRegistry.CanonicalCsvV1ProfileId, StringComparison.OrdinalIgnoreCase)
+            && !CanonicalCsvHeaderPrefixMatches(actual))
         {
             throw new InvalidDataException("Statement source must use the canonical external statement header: account,symbol,quantity,price,cashAmount,activityType,tradeDate.");
         }
+
+        var actualColumns = actual.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var missingColumns = profile.FieldMappings
+            .Where(mapping => mapping.Required && !actualColumns.Contains(mapping.SourceColumn))
+            .Select(mapping => mapping.SourceColumn)
+            .ToArray();
+        if (missingColumns.Length > 0)
+        {
+            throw new InvalidDataException($"Statement source is missing required columns for mapping profile '{profile.ProfileId}': {string.Join(", ", missingColumns)}.");
+        }
+    }
+
+    private static bool CanonicalCsvHeaderPrefixMatches(string[] actual)
+    {
+        var canonicalColumns = StatementMappingProfileRegistry.Defaults
+            .Resolve(StatementMappingProfileRegistry.CanonicalCsvV1ProfileId)
+            .FieldMappings
+            .Where(mapping => mapping.Required)
+            .Select(mapping => mapping.SourceColumn)
+            .ToArray();
+        return actual.Length >= canonicalColumns.Length
+            && canonicalColumns.SequenceEqual(actual.Take(canonicalColumns.Length), StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static IReadOnlyDictionary<string, string> BuildColumnMap(string[] header, string[] parts)
+    {
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < header.Length; i++)
+        {
+            map[header[i]] = i < parts.Length ? parts[i] : string.Empty;
+        }
+
+        return map;
     }
 
     private static StatementRowKind ToStatementRowKind(string activityType)

--- a/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
@@ -54,4 +54,77 @@ public sealed class StatementReconciliationServiceTests
             File.Delete(filePath);
         }
     }
+
+    [Fact]
+    public void StatementMappingProfileRegistry_Exposes_Canonical_And_Sample_Broker_Profiles()
+    {
+        var registry = StatementMappingProfileRegistry.Defaults;
+
+        var canonical = registry.Resolve(StatementMappingProfileRegistry.CanonicalCsvV1ProfileId);
+        var sampleBroker = registry.Resolve(StatementMappingProfileRegistry.SampleBrokerCsvV1ProfileId);
+
+        Assert.Equal("account", canonical.FindField(StatementCanonicalField.Account)?.SourceColumn);
+        Assert.Equal("symbol", canonical.FindField(StatementCanonicalField.SecurityIdentifier)?.SourceColumn);
+        Assert.Equal("cashAmount", canonical.FindField(StatementCanonicalField.CashAmount)?.SourceColumn);
+        Assert.Equal("BrokerAccount", sampleBroker.FindField(StatementCanonicalField.Account)?.SourceColumn);
+        Assert.Equal("Ticker", sampleBroker.FindField(StatementCanonicalField.SecurityIdentifier)?.SourceColumn);
+        Assert.Equal("Commission", sampleBroker.FindField(StatementCanonicalField.FeesCommission)?.SourceColumn);
+        Assert.Equal("trade", sampleBroker.MapActivityType("BUY"));
+        Assert.Equal("dividend", sampleBroker.MapActivityType("DIV"));
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_Uses_Selected_SampleBrokerMappingProfile()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "BrokerAccount,Ticker,Units,ExecutionPrice,NetCash,TxnCode,TradeDate,SettleDate,CCY,Commission,BrokerTransactionId",
+                "BRK-1,MSFT,12,410,0,POS,2026-05-27,2026-05-29,EUR,0,EXT-1",
+                "BRK-1,MSFT,0,0,18.25,DIV,2026-05-28,2026-05-30,EUR,0,EXT-2"
+            ]);
+
+            var validation = await svc.ValidateAsync("broker", filePath, StatementMappingProfileRegistry.SampleBrokerCsvV1ProfileId, CancellationToken.None);
+            var result = await svc.ReconcileAsync("broker", filePath, StatementMappingProfileRegistry.SampleBrokerCsvV1ProfileId, CancellationToken.None);
+            var intake = await svc.CreateExternalStatementCasesAsync("broker", filePath, StatementMappingProfileRegistry.SampleBrokerCsvV1ProfileId, CancellationToken.None);
+
+            Assert.Contains(StatementMappingProfileRegistry.SampleBrokerCsvV1ProfileId, validation);
+            Assert.Equal(1, result.MatchCount);
+            Assert.Equal(1, result.UnresolvedCount);
+            Assert.Equal(2, intake.RowCount);
+            Assert.Single(intake.Cases);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_Throws_When_SelectedMappingProfile_RequiredColumnIsMissing()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "BrokerAccount,Units,ExecutionPrice,NetCash,TxnCode,TradeDate",
+                "BRK-1,12,410,0,POS,2026-05-27"
+            ]);
+
+            var ex = await Assert.ThrowsAsync<InvalidDataException>(() =>
+                svc.ValidateAsync("broker", filePath, StatementMappingProfileRegistry.SampleBrokerCsvV1ProfileId, CancellationToken.None));
+
+            Assert.Contains("sample-broker-csv-v1", ex.Message);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
 }


### PR DESCRIPTION
### Motivation
- Support multiple broker/custodian CSV shapes by mapping source columns into canonical reconciliation fields instead of hard-coding a single header.
- Provide a default `canonical-csv-v1` profile to preserve existing fixture-style behavior while allowing vendor-specific profiles like `sample-broker-csv-v1`. 
- Capture additional canonical fields (settlement date, currency, fees/commission, external transaction id) and transaction-code mappings for robust intake.

### Description
- Add `src/Meridian.Application/Reconciliation/StatementMappingProfiles.cs` which defines `StatementCanonicalField`, `StatementFieldMapping`, `StatementTransactionCodeMapping`, `StatementMappingProfile`, `StatementMappingProfileRegistry`, default profiles (`canonical-csv-v1` and `sample-broker-csv-v1`), and `StatementMappedCsvRow` helpers. 
- Update `StatementReconciliationService` to accept an injectable `StatementMappingProfileRegistry`, add mapping-profile-aware overloads for `ValidateAsync`, `ImportAsync`, `ReconcileAsync`, and `CreateExternalStatementCasesAsync`, and route CSV parsing through `ReadCanonicalStatementRows(..., mappingProfileId)` so rows are built from the selected profile. 
- Preserve existing canonical CSV contract by keeping `canonical-csv-v1` semantics via `CanonicalCsvHeaderPrefixMatches` while validating required columns for other profiles, and map the following canonical entities: account, security identifier, quantity, price, cash amount, activity type, trade date, settlement date, currency, fees/commission, and external transaction ID. 
- Add unit tests in `tests/Meridian.Tests/StatementReconciliationServiceTests.cs` that validate registry contents, a sample-broker parsing scenario, and missing-required-column failure handling. 
- Update `src/Meridian.Application/README.md` to document the reconciliation mapping profiles and note that `canonical-csv-v1` preserves prior behavior.

### Testing
- Ran `python3 build/scripts/docs/mark-stale-docs.py --summary` which completed and marked source-readme drift for review (targeted README update was applied). 
- Executed the implementation-assurance rubric via `python3 .codex/skills/meridian-implementation-assurance/scripts/score_eval.py` and produced a Skill Eval Report scoring 9/10 with the follow-up: run unit tests in a .NET-enabled environment. 
- Attempted to run the narrow unit test filter with `dotnet test --filter "FullyQualifiedName~StatementReconciliationServiceTests|FullyQualifiedName~StatementReconciliationOrchestratorTests"` but `dotnet` is not available in this container so tests could not be executed here; the new/updated tests are included and expected to pass when run in a .NET-enabled CI or developer environment. 
- Ran `git diff --check` and local doc checks as part of validation; no blocking syntax issues were detected in the modified source files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a188e880b688320a011f8722b93ce5d)