### PR TITLE
Add typed statement normalization results

### DIFF
--- a/src/Meridian.Application/Commands/StatementCommands.cs
+++ b/src/Meridian.Application/Commands/StatementCommands.cs
@@ -33,7 +33,7 @@ internal sealed class StatementCommands : ICliCommand
             if (CliArguments.HasFlag(args, "--statement-import"))
             {
                 var result = await svc.ImportAsync(sourceKind, sourcePath, ct).ConfigureAwait(false);
-                Console.WriteLine($"Imported statement batch {result.ImportId} with {result.RowCount} row(s).");
+                Console.WriteLine($"Imported statement batch {result.ImportId} with {result.RowCount} row(s): positions={result.Positions.Count}, cash={result.CashBalances.Count}, transactions={result.Transactions.Count}.");
                 return CliResult.Ok();
             }
 

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -44,6 +44,7 @@ application service contracts consumed by host and UI surfaces.
 
 ## API contract notes
 
+- Statement reconciliation imports return typed normalized collections for positions, cash balances, transactions, security references, and source-row references. The import path keeps legacy canonical rows in adapter infrastructure only while application orchestration consumes the typed result shape.
 - Options-chain provider IDs are normalized with trim plus invariant lowercase before deduplication, health lookup, fallback detection, logging, and metrics.
 
 ## Diagrams

--- a/src/Meridian.Application/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.Application/Reconciliation/StatementReconciliationService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Meridian.Domain.Reconciliation;
 
 namespace Meridian.Application.Reconciliation;
@@ -17,6 +18,7 @@ public sealed class StatementReconciliationService
 
     public Task<string> ValidateAsync(string sourceKind, string sourcePath, CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
         var normalizedSourceKind = ValidateSourceAccess(sourceKind, sourcePath);
         if (RequiresCanonicalStatementSchema(normalizedSourceKind))
         {
@@ -26,18 +28,27 @@ public sealed class StatementReconciliationService
         return Task.FromResult($"Statement source '{normalizedSourceKind}:{sourcePath}' passed local file accessibility checks.");
     }
 
-    public Task<(string ImportId, int RowCount)> ImportAsync(string sourceKind, string sourcePath, CancellationToken ct)
+    public async Task<NormalizedStatementImportResult> ImportAsync(string sourceKind, string sourcePath, CancellationToken ct)
     {
         var normalizedSourceKind = ValidateSourceAccess(sourceKind, sourcePath);
+        ct.ThrowIfCancellationRequested();
         if (RequiresCanonicalStatementSchema(normalizedSourceKind))
         {
-            ValidateCanonicalStatementHeader(sourcePath);
+            return await ReadNormalizedStatementImportAsync(normalizedSourceKind, sourcePath, ct).ConfigureAwait(false);
         }
 
-        var content = File.ReadAllText(sourcePath);
+        var content = await File.ReadAllTextAsync(sourcePath, ct).ConfigureAwait(false);
         var id = DeterministicFingerprint.Compute($"{normalizedSourceKind}|{sourcePath}|{content}");
-        var rowCount = Math.Max(0, File.ReadLines(sourcePath).Count() - 1);
-        return Task.FromResult<(string, int)>((id, rowCount));
+        var sourceRows = File.ReadLines(sourcePath)
+            .Select((line, index) => CreateSourceRowReference(id, index + 1, line, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["sourceKind"] = normalizedSourceKind,
+                ["sourcePath"] = sourcePath,
+                ["rawLine"] = line
+            }))
+            .ToList();
+
+        return new NormalizedStatementImportResult(id, normalizedSourceKind, sourcePath, sourceRows.Count, [], [], [], [], sourceRows);
     }
 
     public Task<(string ImportId, int MatchCount, int UnresolvedCount)> ReconcileAsync(string sourceKind, string sourcePath, CancellationToken ct)
@@ -53,6 +64,7 @@ public sealed class StatementReconciliationService
         CancellationToken ct = default)
     {
         var normalizedSourceKind = ValidateSourceAccess(sourceKind, sourcePath);
+        ct.ThrowIfCancellationRequested();
         return Task.FromResult(CreateExternalStatementCases(normalizedSourceKind, sourcePath));
     }
 
@@ -100,6 +112,144 @@ public sealed class StatementReconciliationService
             cases);
     }
 
+    private static async Task<NormalizedStatementImportResult> ReadNormalizedStatementImportAsync(
+        string normalizedSourceKind,
+        string sourcePath,
+        CancellationToken ct)
+    {
+        ValidateCanonicalStatementHeader(sourcePath);
+
+        var content = await File.ReadAllTextAsync(sourcePath, ct).ConfigureAwait(false);
+        var importId = DeterministicFingerprint.Compute($"{normalizedSourceKind}|{sourcePath}|{content}");
+        var positions = new List<StatementPosition>();
+        var cashBalances = new List<StatementCashBalance>();
+        var transactions = new List<StatementTransaction>();
+        var securities = new List<StatementSecurityReference>();
+        var sourceRows = new List<StatementSourceRowReference>();
+        var lines = File.ReadLines(sourcePath).Skip(1);
+        var rowNumber = 1;
+        foreach (var line in lines)
+        {
+            ct.ThrowIfCancellationRequested();
+            rowNumber++;
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var p = ParseCanonicalStatementLine(line, rowNumber);
+            sourceRows.Add(p.SourceRow);
+            if (!string.IsNullOrWhiteSpace(p.Security.UnresolvedIdentifier) || !string.IsNullOrWhiteSpace(p.Security.SecurityId))
+            {
+                securities.Add(p.Security);
+            }
+
+            switch (ToStatementRowKind(p.TransactionType))
+            {
+                case StatementRowKind.Position:
+                    positions.Add(new StatementPosition(
+                        importId,
+                        rowNumber,
+                        p.SourceRow.SourceRowHash,
+                        p.RawSnapshot,
+                        p.AccountId,
+                        p.ExternalAccountId,
+                        p.Security.SecurityId,
+                        p.Security.UnresolvedIdentifier,
+                        p.Currency,
+                        p.Quantity,
+                        p.Price,
+                        p.MarketValue,
+                        p.TradeDate,
+                        p.SettlementDate));
+                    break;
+                case StatementRowKind.CashBalance:
+                    cashBalances.Add(new StatementCashBalance(
+                        importId,
+                        rowNumber,
+                        p.SourceRow.SourceRowHash,
+                        p.RawSnapshot,
+                        p.AccountId,
+                        p.ExternalAccountId,
+                        p.Currency,
+                        p.Amount,
+                        p.TradeDate,
+                        p.SettlementDate));
+                    break;
+                default:
+                    transactions.Add(new StatementTransaction(
+                        importId,
+                        rowNumber,
+                        p.SourceRow.SourceRowHash,
+                        p.RawSnapshot,
+                        p.AccountId,
+                        p.ExternalAccountId,
+                        p.Security.SecurityId,
+                        p.Security.UnresolvedIdentifier,
+                        p.Currency,
+                        p.Quantity,
+                        p.Price,
+                        p.MarketValue,
+                        p.TradeDate,
+                        p.SettlementDate,
+                        p.Amount,
+                        p.FeesCommission,
+                        p.TransactionType,
+                        p.ExternalReference));
+                    break;
+            }
+        }
+
+        return new NormalizedStatementImportResult(importId, normalizedSourceKind, sourcePath, sourceRows.Count, positions, cashBalances, transactions, securities, sourceRows);
+
+        ParsedStatementLine ParseCanonicalStatementLine(string line, int currentRowNumber)
+        {
+            var parts = line.Split(',', StringSplitOptions.TrimEntries);
+            if (parts.Length < CanonicalStatementColumns.Length)
+            {
+                throw new InvalidDataException($"Statement row {currentRowNumber} has {parts.Length} columns; expected at least {CanonicalStatementColumns.Length}.");
+            }
+
+            var account = parts[0];
+            var symbol = parts[1];
+            var quantity = decimal.Parse(parts[2], CultureInfo.InvariantCulture);
+            var price = decimal.Parse(parts[3], CultureInfo.InvariantCulture);
+            var cashAmount = decimal.Parse(parts[4], CultureInfo.InvariantCulture);
+            var activityType = parts[5];
+            var tradeDate = DateOnly.Parse(parts[6], CultureInfo.InvariantCulture);
+            var sourceRow = CreateSourceRowReference(importId, currentRowNumber, line, CreateRawSnapshot(importId, normalizedSourceKind, sourcePath, currentRowNumber, line, parts));
+            var snapshot = sourceRow.RawSnapshot;
+            var securityId = GetOptional(parts, 9);
+            var unresolvedIdentifier = GetOptional(parts, 10) ?? (string.IsNullOrWhiteSpace(symbol) ? null : symbol);
+            var currency = GetOptional(parts, 11) ?? "USD";
+            var marketValue = GetOptionalDecimal(parts, 12) ?? price * quantity;
+            var settlementDate = GetOptionalDate(parts, 13);
+            var amount = GetOptionalDecimal(parts, 14) ?? (cashAmount == 0m ? marketValue : cashAmount);
+            var feesCommission = GetOptionalDecimal(parts, 15) ?? 0m;
+            var externalReference = GetOptional(parts, 16);
+            var externalAccountId = GetOptional(parts, 8) ?? account;
+            var accountId = GetOptional(parts, 7) ?? account;
+            var security = new StatementSecurityReference(importId, currentRowNumber, sourceRow.SourceRowHash, snapshot, securityId, unresolvedIdentifier, currency);
+
+            return new ParsedStatementLine(
+                sourceRow,
+                snapshot,
+                security,
+                accountId,
+                externalAccountId,
+                currency,
+                quantity,
+                price,
+                marketValue,
+                tradeDate,
+                settlementDate,
+                amount,
+                feesCommission,
+                activityType,
+                externalReference);
+        }
+    }
+
     private static IReadOnlyList<NormalizedStatementRow> ReadCanonicalStatementRows(string normalizedSourceKind, string sourcePath)
     {
         ValidateCanonicalStatementHeader(sourcePath);
@@ -125,11 +275,11 @@ public sealed class StatementReconciliationService
 
             var account = parts[0];
             var symbol = parts[1];
-            var quantity = decimal.Parse(parts[2]);
-            var price = decimal.Parse(parts[3]);
-            var cashAmount = decimal.Parse(parts[4]);
+            var quantity = decimal.Parse(parts[2], CultureInfo.InvariantCulture);
+            var price = decimal.Parse(parts[3], CultureInfo.InvariantCulture);
+            var cashAmount = decimal.Parse(parts[4], CultureInfo.InvariantCulture);
             var activityType = parts[5];
-            var tradeDate = DateOnly.Parse(parts[6]);
+            var tradeDate = DateOnly.Parse(parts[6], CultureInfo.InvariantCulture);
             var rowFingerprint = DeterministicFingerprint.Compute($"{importId}|{rowNumber}|{line}");
             rows.Add(new NormalizedStatementRow(
                 $"{importId}:{rowNumber}",
@@ -138,7 +288,7 @@ public sealed class StatementReconciliationService
                 quantity,
                 cashAmount == 0m ? price * quantity : cashAmount,
                 new DateTimeOffset(tradeDate.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero),
-                "USD",
+                GetOptional(parts, 11) ?? "USD",
                 rowFingerprint,
                 new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                 {
@@ -147,7 +297,8 @@ public sealed class StatementReconciliationService
                     ["sourcePath"] = sourcePath,
                     ["account"] = account,
                     ["activityType"] = activityType,
-                    ["rowNumber"] = rowNumber.ToString()
+                    ["rowNumber"] = rowNumber.ToString(),
+                    ["rawLine"] = line
                 }));
         }
 
@@ -169,6 +320,75 @@ public sealed class StatementReconciliationService
             throw new InvalidDataException("Statement source must use the canonical external statement header: account,symbol,quantity,price,cashAmount,activityType,tradeDate.");
         }
     }
+
+    private static StatementSourceRowReference CreateSourceRowReference(
+        string importId,
+        int rowNumber,
+        string line,
+        IReadOnlyDictionary<string, string> rawSnapshot)
+        => new(importId, rowNumber, DeterministicFingerprint.Compute($"{importId}|{rowNumber}|{line}"), rawSnapshot);
+
+    private static IReadOnlyDictionary<string, string> CreateRawSnapshot(
+        string importId,
+        string normalizedSourceKind,
+        string sourcePath,
+        int rowNumber,
+        string line,
+        string[] parts)
+    {
+        var snapshot = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["importId"] = importId,
+            ["sourceKind"] = normalizedSourceKind,
+            ["sourcePath"] = sourcePath,
+            ["account"] = parts[0],
+            ["symbol"] = parts[1],
+            ["quantity"] = parts[2],
+            ["price"] = parts[3],
+            ["cashAmount"] = parts[4],
+            ["activityType"] = parts[5],
+            ["tradeDate"] = parts[6],
+            ["rowNumber"] = rowNumber.ToString(),
+            ["rawLine"] = line
+        };
+
+        AddOptional(snapshot, "accountId", parts, 7);
+        AddOptional(snapshot, "externalAccountId", parts, 8);
+        AddOptional(snapshot, "securityId", parts, 9);
+        AddOptional(snapshot, "unresolvedIdentifier", parts, 10);
+        AddOptional(snapshot, "currency", parts, 11);
+        AddOptional(snapshot, "marketValue", parts, 12);
+        AddOptional(snapshot, "settlementDate", parts, 13);
+        AddOptional(snapshot, "amount", parts, 14);
+        AddOptional(snapshot, "feesCommission", parts, 15);
+        AddOptional(snapshot, "externalReference", parts, 16);
+        return snapshot;
+    }
+
+    private static void AddOptional(Dictionary<string, string> snapshot, string key, string[] parts, int index)
+    {
+        var value = GetOptional(parts, index);
+        if (value is not null)
+        {
+            snapshot[key] = value;
+        }
+    }
+
+    private static string? GetOptional(string[] parts, int index)
+    {
+        if (parts.Length <= index || string.IsNullOrWhiteSpace(parts[index]))
+        {
+            return null;
+        }
+
+        return parts[index];
+    }
+
+    private static decimal? GetOptionalDecimal(string[] parts, int index) =>
+        GetOptional(parts, index) is { } value ? decimal.Parse(value, CultureInfo.InvariantCulture) : null;
+
+    private static DateOnly? GetOptionalDate(string[] parts, int index) =>
+        GetOptional(parts, index) is { } value ? DateOnly.Parse(value, CultureInfo.InvariantCulture) : null;
 
     private static StatementRowKind ToStatementRowKind(string activityType)
     {
@@ -251,6 +471,23 @@ public sealed class StatementReconciliationService
 
         return (matches, cases);
     }
+
+    private sealed record ParsedStatementLine(
+        StatementSourceRowReference SourceRow,
+        IReadOnlyDictionary<string, string> RawSnapshot,
+        StatementSecurityReference Security,
+        string AccountId,
+        string ExternalAccountId,
+        string Currency,
+        decimal Quantity,
+        decimal Price,
+        decimal MarketValue,
+        DateOnly TradeDate,
+        DateOnly? SettlementDate,
+        decimal Amount,
+        decimal FeesCommission,
+        string TransactionType,
+        string? ExternalReference);
 }
 
 public sealed record ExternalStatementCaseIntakeResult(

--- a/src/Meridian.Domain/README.md
+++ b/src/Meridian.Domain/README.md
@@ -30,6 +30,10 @@ This layer owns domain concepts without depending on application orchestration, 
 
 Use this module for domain behavior that should remain stable across providers, storage, execution, and UI projections.
 
+## API contract notes
+
+- Statement reconciliation domain models include typed normalized positions, cash balances, transactions, security references, and source-row references. Each normalized entity carries `StatementRunId`, `SourceRowNumber`, `SourceRowHash`, and `RawSnapshot` traceability fields so downstream reconciliation evidence can be tied back to the raw statement line.
+
 ## Diagrams
 
 See `DIA-ASSURANCE-LOOP` in `docs/source/data/diagram-index.yml`.

--- a/src/Meridian.Domain/Reconciliation/StatementEntities.cs
+++ b/src/Meridian.Domain/Reconciliation/StatementEntities.cs
@@ -10,6 +10,80 @@ public sealed record CanonicalStatementImport(
     int RawRowCount,
     int NormalizedRowCount);
 
+public sealed record StatementSourceRowReference(
+    string StatementRunId,
+    int SourceRowNumber,
+    string SourceRowHash,
+    IReadOnlyDictionary<string, string> RawSnapshot);
+
+public sealed record StatementSecurityReference(
+    string StatementRunId,
+    int SourceRowNumber,
+    string SourceRowHash,
+    IReadOnlyDictionary<string, string> RawSnapshot,
+    string? SecurityId,
+    string? UnresolvedIdentifier,
+    string Currency);
+
+public sealed record StatementPosition(
+    string StatementRunId,
+    int SourceRowNumber,
+    string SourceRowHash,
+    IReadOnlyDictionary<string, string> RawSnapshot,
+    string AccountId,
+    string ExternalAccountId,
+    string? SecurityId,
+    string? UnresolvedIdentifier,
+    string Currency,
+    decimal Quantity,
+    decimal Price,
+    decimal MarketValue,
+    DateOnly TradeDate,
+    DateOnly? SettlementDate);
+
+public sealed record StatementCashBalance(
+    string StatementRunId,
+    int SourceRowNumber,
+    string SourceRowHash,
+    IReadOnlyDictionary<string, string> RawSnapshot,
+    string AccountId,
+    string ExternalAccountId,
+    string Currency,
+    decimal Amount,
+    DateOnly TradeDate,
+    DateOnly? SettlementDate);
+
+public sealed record StatementTransaction(
+    string StatementRunId,
+    int SourceRowNumber,
+    string SourceRowHash,
+    IReadOnlyDictionary<string, string> RawSnapshot,
+    string AccountId,
+    string ExternalAccountId,
+    string? SecurityId,
+    string? UnresolvedIdentifier,
+    string Currency,
+    decimal Quantity,
+    decimal Price,
+    decimal MarketValue,
+    DateOnly TradeDate,
+    DateOnly? SettlementDate,
+    decimal Amount,
+    decimal FeesCommission,
+    string TransactionType,
+    string? ExternalReference);
+
+public sealed record NormalizedStatementImportResult(
+    string ImportId,
+    string SourceKind,
+    string SourcePath,
+    int RowCount,
+    IReadOnlyList<StatementPosition> Positions,
+    IReadOnlyList<StatementCashBalance> CashBalances,
+    IReadOnlyList<StatementTransaction> Transactions,
+    IReadOnlyList<StatementSecurityReference> Securities,
+    IReadOnlyList<StatementSourceRowReference> SourceRows);
+
 public sealed record CanonicalStatementRow(
     string ImportId,
     int SourceRowNumber,

--- a/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
@@ -30,6 +30,80 @@ public sealed class StatementReconciliationServiceTests
     }
 
     [Fact]
+    public async Task ImportAsync_Returns_Typed_Normalized_Broker_Collections_With_Source_Trace()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "account,symbol,quantity,price,cashAmount,activityType,tradeDate,accountId,externalAccountId,securityId,unresolvedIdentifier,currency,marketValue,settlementDate,amount,feesCommission,externalReference",
+                "EXT-A1,SPY,10,500,0,position,2026-05-29,ACC-1,EXT-A1,SEC-SPY,,USD,5000,2026-06-01,5000,0,POS-1",
+                "EXT-A1,,0,0,125.25,cash,2026-05-29,ACC-1,EXT-A1,,,USD,0,2026-05-29,125.25,0,CASH-1",
+                "EXT-A1,QQQ,2,400,0,buy,2026-05-30,ACC-1,EXT-A1,,QQQ,USD,800,2026-06-02,800,1.25,TXN-1"
+            ]);
+
+            var result = await svc.ImportAsync("broker", filePath, CancellationToken.None);
+
+            Assert.Equal(3, result.RowCount);
+            Assert.Single(result.Positions);
+            Assert.Single(result.CashBalances);
+            Assert.Single(result.Transactions);
+            Assert.Equal("ACC-1", result.Positions[0].AccountId);
+            Assert.Equal("EXT-A1", result.Positions[0].ExternalAccountId);
+            Assert.Equal("SEC-SPY", result.Positions[0].SecurityId);
+            Assert.Equal(5000m, result.Positions[0].MarketValue);
+            Assert.Equal(new DateOnly(2026, 6, 1), result.Positions[0].SettlementDate);
+            Assert.Equal(result.ImportId, result.Positions[0].StatementRunId);
+            Assert.False(string.IsNullOrWhiteSpace(result.Positions[0].SourceRowHash));
+            Assert.Equal(125.25m, result.CashBalances[0].Amount);
+            Assert.Equal(result.ImportId, result.CashBalances[0].StatementRunId);
+            Assert.False(string.IsNullOrWhiteSpace(result.CashBalances[0].SourceRowHash));
+            Assert.Equal("buy", result.Transactions[0].TransactionType);
+            Assert.Equal(1.25m, result.Transactions[0].FeesCommission);
+            Assert.Equal("TXN-1", result.Transactions[0].ExternalReference);
+            Assert.Equal(result.ImportId, result.Transactions[0].StatementRunId);
+            Assert.False(string.IsNullOrWhiteSpace(result.Transactions[0].SourceRowHash));
+            Assert.Equal(result.ImportId, result.Securities[0].StatementRunId);
+            Assert.False(string.IsNullOrWhiteSpace(result.Securities[0].SourceRowHash));
+            Assert.All(result.SourceRows, row =>
+            {
+                Assert.Equal(result.ImportId, row.StatementRunId);
+                Assert.False(string.IsNullOrWhiteSpace(row.SourceRowHash));
+                Assert.True(row.RawSnapshot.ContainsKey("rawLine"));
+            });
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public async Task ImportAsync_Observes_Cancellation_Before_Normalization()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "account,symbol,quantity,price,cashAmount,activityType,tradeDate",
+                "A1,SPY,10,500,0,position,2026-05-29"
+            ]);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => svc.ImportAsync("broker", filePath, cts.Token));
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Fact]
     public async Task ValidateAsync_ThrowsWhenLocalFileMissing()
     {
         var svc = new StatementReconciliationService();


### PR DESCRIPTION
### Motivation

- Provide strongly-typed, traceable normalized statement entities so downstream reconciliation, matching, and UI orchestration can consume structured positions, cash balances, and transactions instead of raw canonical rows.
- Preserve source traceability (import/run id, source row number, per-row hash and raw snapshot) so every normalized entity can be traced back to the original statement line for audit and evidence.
- Capture common accounting fields (account IDs, external account IDs, security id / unresolved identifier, currency, quantity, price, market value, trade/settlement dates, amounts, fees, external reference) in the normalized shape to simplify later reconciliation and ledger linking.
- Keep the existing `CanonicalStatementRow` for adapter/backwards-compatibility while moving application services to the typed normalized result shape.

### Description

- Added typed domain records in `src/Meridian.Domain/Reconciliation/StatementEntities.cs`: `StatementPosition`, `StatementCashBalance`, `StatementTransaction`, `StatementSecurityReference`, `StatementSourceRowReference`, and `NormalizedStatementImportResult` while leaving `CanonicalStatementRow` available.
- Updated `src/Meridian.Application/Reconciliation/StatementReconciliationService.cs` so `ImportAsync` now returns `NormalizedStatementImportResult` and added `ReadNormalizedStatementImportAsync` to parse canonical rows into typed collections with source-row hashing and raw snapshots; preserved legacy canonical reading paths for non-canonical sources.
- Added helpers for raw-snapshot construction, optional-field parsing, culture-invariant numeric/date parsing, and cancellation checks during import/normalization.
- Updated CLI feedback in `src/Meridian.Application/Commands/StatementCommands.cs` to print typed collection counts and extended tests in `tests/Meridian.Tests/StatementReconciliationServiceTests.cs` to assert typed outputs, accounting fields, source-trace fields, and cancellation behavior; also updated Domain/Application READMEs to document the new contract.

### Testing

- Ran `python3 build/scripts/docs/validate-source-readmes.py --summary`, which reported no errors for source READMEs (succeeded).
- Ran `python3 build/scripts/docs/mark-stale-docs.py --summary`, which marked affected modules as stale due to README/source changes (succeeded and produced a stale-docs report).
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary`, which failed due to repository-wide source/readme hash drift (expected because READMEs were intentionally updated and the generated manifest must be refreshed after review).
- Attempted `dotnet test` for the targeted `StatementReconciliationServiceTests` but the .NET SDK was not available in the execution environment so the unit tests could not be run here (not run: `dotnet` missing).
- Ran the local evaluation harness `python3 .codex/skills/meridian-implementation-assurance/scripts/score_eval.py` with a prepared rubric and produced a Skill Eval Report (9/10 pass) while noting the blocking follow-up that `dotnet` must be run in an environment with the .NET SDK to validate tests fully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a188ee210b48320a97991bc47a6980f)