### PR TITLE
Add StatementRunCreateRequest and content-hash duplicate detection for statement imports

### DIFF
--- a/src/Meridian.Application/Commands/StatementImportCommands.cs
+++ b/src/Meridian.Application/Commands/StatementImportCommands.cs
@@ -1,3 +1,4 @@
+using Meridian.Application.Reconciliation;
 using Meridian.Domain.Reconciliation;
 using Meridian.Infrastructure.Reconciliation;
 using Meridian.Application.ResultTypes;
@@ -32,16 +33,27 @@ public sealed class StatementImportCommands(string dataRoot, ILogger log) : ICli
         var store = new JsonCanonicalStatementStore(dataRoot);
         var service = new CsvBrokerStatementService(store);
 
-        var request = new BrokerStatementImportRequest(broker, path, statementDate);
         if (args.Contains("--statement-validate", StringComparer.OrdinalIgnoreCase))
         {
-            var result = await service.ValidateAsync(request, ct);
+            var result = await service.ValidateAsync(new BrokerStatementImportRequest(broker, path, statementDate), ct);
             Console.WriteLine($"valid={result.IsValid}; rows={result.RowCount}");
             foreach (var error in result.Errors) Console.WriteLine($"error={error}");
             return result.IsValid ? CliResult.Ok() : CliResult.Fail(ErrorCode.ValidationFailed);
         }
 
-        var imported = await service.ImportAsync(request, ct);
+        var runRequest = await StatementRunCreateRequest.FromFileAsync(
+            broker,
+            Get(args, "--statement-source-institution") ?? Get(args, "--statement-custodian") ?? broker,
+            Get(args, "--statement-fund-account-id") ?? "legacy-fund-account",
+            Get(args, "--statement-external-account-id") ?? "legacy-external-account",
+            TryGetDate(args, "--statement-period-start", out var periodStart) ? periodStart : statementDate,
+            TryGetDate(args, "--statement-period-end", out var periodEnd) ? periodEnd : statementDate,
+            path,
+            Get(args, "--statement-mapping-profile-id") ?? "legacy-mapping-profile",
+            Get(args, "--statement-tolerance-profile-id") ?? "legacy-tolerance-profile",
+            Get(args, "--statement-imported-by") ?? Environment.UserName,
+            ct: ct);
+        var imported = await service.ImportAsync(runRequest.ToBrokerStatementImportRequest(), ct);
         Console.WriteLine($"imported={imported.Import.ImportId}; rows={imported.Rows.Count}");
         log.Information("Imported broker statement {ImportId} from {SourcePath}", imported.Import.ImportId, path);
         return CliResult.Ok();
@@ -58,13 +70,21 @@ public sealed class StatementImportCommands(string dataRoot, ILogger log) : ICli
 
     private static bool TryGetStatementDate(string[] args, out DateOnly statementDate)
     {
-        var value = Get(args, "--statement-date");
-        if (string.IsNullOrWhiteSpace(value))
+        if (TryGetDate(args, "--statement-date", out statementDate))
+            return true;
+
+        if (!Has(args, "--statement-date"))
         {
             statementDate = DateOnly.FromDateTime(DateTime.UtcNow);
             return true;
         }
 
-        return DateOnly.TryParse(value, out statementDate);
+        return false;
+    }
+
+    private static bool TryGetDate(string[] args, string key, out DateOnly date)
+    {
+        var value = Get(args, key);
+        return DateOnly.TryParse(value, out date);
     }
 }

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -6,7 +6,7 @@ module_id: SRC-APP
 path: src/Meridian.Application
 status: active
 owner_lane: Runtime Host
-last_reviewed: 2026-05-25
+last_reviewed: 2026-05-28
 ---
 
 # src/Meridian.Application
@@ -44,6 +44,7 @@ application service contracts consumed by host and UI surfaces.
 
 ## API contract notes
 
+- `StatementRunCreateRequest` is the application-level request for creating broker statement reconciliation runs. It computes `SourceFileHash` from file bytes, then derives the duplicate key from fund account, statement period, and that content hash.
 - Options-chain provider IDs are normalized with trim plus invariant lowercase before deduplication, health lookup, fallback detection, logging, and metrics.
 
 ## Diagrams

--- a/src/Meridian.Application/Reconciliation/StatementRunCreateRequest.cs
+++ b/src/Meridian.Application/Reconciliation/StatementRunCreateRequest.cs
@@ -1,0 +1,87 @@
+using System.Security.Cryptography;
+using Meridian.Domain.Reconciliation;
+
+namespace Meridian.Application.Reconciliation;
+
+public sealed record StatementRunCreateRequest(
+    string Broker,
+    string SourceInstitution,
+    string FundAccountId,
+    string ExternalAccountId,
+    DateOnly StatementPeriodStart,
+    DateOnly StatementPeriodEnd,
+    string SourcePath,
+    string OriginalFileName,
+    string MappingProfileId,
+    string ToleranceProfileId,
+    string ImportedBy,
+    string SourceFileHash)
+{
+    public string DuplicateKey => StatementDuplicateKey.Create(FundAccountId, StatementPeriodStart, StatementPeriodEnd, SourceFileHash);
+
+    public static async Task<StatementRunCreateRequest> FromFileAsync(
+        string broker,
+        string sourceInstitution,
+        string fundAccountId,
+        string externalAccountId,
+        DateOnly statementPeriodStart,
+        DateOnly statementPeriodEnd,
+        string sourcePath,
+        string mappingProfileId,
+        string toleranceProfileId,
+        string importedBy,
+        string? originalFileName = null,
+        CancellationToken ct = default)
+    {
+        ValidateRequired(nameof(broker), broker);
+        ValidateRequired(nameof(sourceInstitution), sourceInstitution);
+        ValidateRequired(nameof(fundAccountId), fundAccountId);
+        ValidateRequired(nameof(externalAccountId), externalAccountId);
+        ValidateRequired(nameof(sourcePath), sourcePath);
+        ValidateRequired(nameof(mappingProfileId), mappingProfileId);
+        ValidateRequired(nameof(toleranceProfileId), toleranceProfileId);
+        ValidateRequired(nameof(importedBy), importedBy);
+
+        if (statementPeriodEnd < statementPeriodStart)
+            throw new ArgumentException("Statement period end must be on or after statement period start.", nameof(statementPeriodEnd));
+
+        await using var stream = File.OpenRead(sourcePath);
+        var hashBytes = await SHA256.HashDataAsync(stream, ct).ConfigureAwait(false);
+        var sourceFileHash = Convert.ToHexString(hashBytes);
+
+        return new StatementRunCreateRequest(
+            broker.Trim(),
+            sourceInstitution.Trim(),
+            fundAccountId.Trim(),
+            externalAccountId.Trim(),
+            statementPeriodStart,
+            statementPeriodEnd,
+            sourcePath,
+            string.IsNullOrWhiteSpace(originalFileName) ? Path.GetFileName(sourcePath) : originalFileName.Trim(),
+            mappingProfileId.Trim(),
+            toleranceProfileId.Trim(),
+            importedBy.Trim(),
+            sourceFileHash);
+    }
+
+    public BrokerStatementImportRequest ToBrokerStatementImportRequest()
+        => new(
+            Broker,
+            SourceInstitution,
+            FundAccountId,
+            ExternalAccountId,
+            StatementPeriodStart,
+            StatementPeriodEnd,
+            SourcePath,
+            OriginalFileName,
+            MappingProfileId,
+            ToleranceProfileId,
+            ImportedBy,
+            SourceFileHash);
+
+    private static void ValidateRequired(string parameterName, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException($"{parameterName} is required.", parameterName);
+    }
+}

--- a/src/Meridian.Domain/README.md
+++ b/src/Meridian.Domain/README.md
@@ -6,7 +6,7 @@ module_id: SRC-DOMAIN
 path: src/Meridian.Domain
 status: active
 owner_lane: Data Confidence and Validation
-last_reviewed: 2026-05-20
+last_reviewed: 2026-05-28
 ---
 
 # src/Meridian.Domain
@@ -29,6 +29,10 @@ This layer owns domain concepts without depending on application orchestration, 
 ## Important workflows
 
 Use this module for domain behavior that should remain stable across providers, storage, execution, and UI projections.
+
+## API contract notes
+
+- Broker statement runs carry broker, source institution, fund account, external account, statement period, source path, original file name, mapping profile, tolerance profile, importer, and source file hash metadata. Duplicate statement detection is keyed deterministically from fund account, statement period, and content-derived source file hash rather than the source path.
 
 ## Diagrams
 

--- a/src/Meridian.Domain/Reconciliation/BrokerStatementModels.cs
+++ b/src/Meridian.Domain/Reconciliation/BrokerStatementModels.cs
@@ -1,6 +1,102 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
 namespace Meridian.Domain.Reconciliation;
 
-public sealed record BrokerStatementImportRequest(string Broker, string SourcePath, DateOnly StatementDate);
+public sealed record StatementRunRequest(
+    string Broker,
+    string SourceInstitution,
+    string FundAccountId,
+    string ExternalAccountId,
+    DateOnly StatementPeriodStart,
+    DateOnly StatementPeriodEnd,
+    string SourcePath,
+    string OriginalFileName,
+    string MappingProfileId,
+    string ToleranceProfileId,
+    string ImportedBy,
+    string SourceFileHash)
+{
+    public string DuplicateKey => StatementDuplicateKey.Create(FundAccountId, StatementPeriodStart, StatementPeriodEnd, SourceFileHash);
+}
+
+public sealed record BrokerStatementImportRequest(
+    string Broker,
+    string SourceInstitution,
+    string FundAccountId,
+    string ExternalAccountId,
+    DateOnly StatementPeriodStart,
+    DateOnly StatementPeriodEnd,
+    string SourcePath,
+    string OriginalFileName,
+    string MappingProfileId,
+    string ToleranceProfileId,
+    string ImportedBy,
+    string SourceFileHash)
+{
+    public BrokerStatementImportRequest(string broker, string sourcePath, DateOnly statementDate)
+        : this(
+            broker,
+            broker,
+            string.Empty,
+            string.Empty,
+            statementDate,
+            statementDate,
+            sourcePath,
+            Path.GetFileName(sourcePath),
+            string.Empty,
+            string.Empty,
+            "system",
+            string.Empty)
+    {
+    }
+
+    public DateOnly StatementDate => StatementPeriodEnd;
+
+    public string DuplicateKey => StatementDuplicateKey.Create(FundAccountId, StatementPeriodStart, StatementPeriodEnd, SourceFileHash);
+
+    public BrokerStatementImportRequest WithSourceFileHash(string sourceFileHash)
+        => this with { SourceFileHash = sourceFileHash };
+
+    public StatementRunRequest ToStatementRunRequest()
+        => new(
+            Broker,
+            SourceInstitution,
+            FundAccountId,
+            ExternalAccountId,
+            StatementPeriodStart,
+            StatementPeriodEnd,
+            SourcePath,
+            OriginalFileName,
+            MappingProfileId,
+            ToleranceProfileId,
+            ImportedBy,
+            SourceFileHash);
+}
+
+public static class StatementDuplicateKey
+{
+    public static string Create(
+        string fundAccountId,
+        DateOnly statementPeriodStart,
+        DateOnly statementPeriodEnd,
+        string sourceFileHash)
+    {
+        var material = string.Join(
+            '|',
+            Normalize(fundAccountId),
+            statementPeriodStart.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            statementPeriodEnd.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            Normalize(sourceFileHash));
+
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(material));
+        return Convert.ToHexString(bytes);
+    }
+
+    private static string Normalize(string value)
+        => value.Trim().ToUpperInvariant();
+}
 
 public sealed record BrokerStatementValidationResult(bool IsValid, IReadOnlyList<string> Errors, int RowCount);
 

--- a/src/Meridian.Domain/Reconciliation/StatementEntities.cs
+++ b/src/Meridian.Domain/Reconciliation/StatementEntities.cs
@@ -8,7 +8,20 @@ public sealed record CanonicalStatementImport(
     string SourcePath,
     string SourceChecksum,
     int RawRowCount,
-    int NormalizedRowCount);
+    int NormalizedRowCount)
+{
+    public string SourceInstitution { get; init; } = string.Empty;
+    public string FundAccountId { get; init; } = string.Empty;
+    public string ExternalAccountId { get; init; } = string.Empty;
+    public DateOnly StatementPeriodStart { get; init; } = StatementDate;
+    public DateOnly StatementPeriodEnd { get; init; } = StatementDate;
+    public string OriginalFileName { get; init; } = string.Empty;
+    public string MappingProfileId { get; init; } = string.Empty;
+    public string ToleranceProfileId { get; init; } = string.Empty;
+    public string ImportedBy { get; init; } = "system";
+    public string SourceFileHash { get; init; } = SourceChecksum;
+    public string DuplicateKey { get; init; } = string.Empty;
+}
 
 public sealed record CanonicalStatementRow(
     string ImportId,

--- a/src/Meridian.Infrastructure/README.md
+++ b/src/Meridian.Infrastructure/README.md
@@ -6,7 +6,7 @@ module_id: SRC-INFRASTRUCTURE
 path: src/Meridian.Infrastructure
 status: active
 owner_lane: Data Confidence and Validation
-last_reviewed: 2026-05-22
+last_reviewed: 2026-05-28
 ---
 
 # src/Meridian.Infrastructure
@@ -44,6 +44,10 @@ Streaming failover state is updated from explicit success, failure, and latency 
 to the periodic evaluator. Cancellation is propagated as cancellation, not treated as a provider
 failure. Backfill orchestration stores dependency job IDs on each job so chained jobs resume only
 after all upstream dependencies complete.
+
+Broker statement imports hash the source file bytes and persist the resulting content hash with a
+deterministic duplicate key derived from fund account, statement period, and source hash. Source
+paths and original file names remain provenance metadata, not duplicate-detection inputs.
 
 ## Diagrams
 

--- a/src/Meridian.Infrastructure/Reconciliation/BrokerStatementInfrastructure.cs
+++ b/src/Meridian.Infrastructure/Reconciliation/BrokerStatementInfrastructure.cs
@@ -8,6 +8,7 @@ namespace Meridian.Infrastructure.Reconciliation;
 public interface ICanonicalStatementStore
 {
     Task<bool> ImportExistsByChecksumAsync(string checksum, CancellationToken ct = default);
+    Task<bool> ImportExistsByDuplicateKeyAsync(string duplicateKey, CancellationToken ct = default);
     Task SaveImportAsync(CanonicalStatementImport import, IReadOnlyList<CanonicalStatementRow> rows, CancellationToken ct = default);
     Task<IReadOnlyList<CanonicalStatementImport>> ListImportsAsync(CancellationToken ct = default);
 }
@@ -18,6 +19,18 @@ public sealed class JsonCanonicalStatementStore(string dataRoot) : ICanonicalSta
 
     public Task<bool> ImportExistsByChecksumAsync(string checksum, CancellationToken ct = default)
         => Task.FromResult(Directory.Exists(_folder) && Directory.EnumerateFiles(_folder, "*.json").Any(path => File.ReadAllText(path).Contains(checksum, StringComparison.Ordinal)));
+
+    public Task<bool> ImportExistsByDuplicateKeyAsync(string duplicateKey, CancellationToken ct = default)
+    {
+        if (!Directory.Exists(_folder))
+            return Task.FromResult(false);
+
+        var exists = Directory.EnumerateFiles(_folder, "*.json")
+            .Select(path => JsonSerializer.Deserialize<ImportEnvelope>(File.ReadAllText(path))?.import)
+            .Any(import => string.Equals(import?.DuplicateKey, duplicateKey, StringComparison.Ordinal));
+
+        return Task.FromResult(exists);
+    }
 
     public async Task SaveImportAsync(CanonicalStatementImport import, IReadOnlyList<CanonicalStatementRow> rows, CancellationToken ct = default)
     {
@@ -61,22 +74,43 @@ public sealed class CsvBrokerStatementService(ICanonicalStatementStore store) : 
 
     public async Task<BrokerStatementImportResult> ImportAsync(BrokerStatementImportRequest request, CancellationToken ct = default)
     {
-        var content = await File.ReadAllTextAsync(request.SourcePath, ct).ConfigureAwait(false);
-        var checksum = Hash(content);
-        if (await store.ImportExistsByChecksumAsync(checksum, ct).ConfigureAwait(false))
-            throw new InvalidOperationException("Statement already imported (checksum match).");
+        var fileBytes = await File.ReadAllBytesAsync(request.SourcePath, ct).ConfigureAwait(false);
+        var content = Encoding.UTF8.GetString(fileBytes);
+        var sourceFileHash = string.IsNullOrWhiteSpace(request.SourceFileHash) ? HashBytes(fileBytes) : request.SourceFileHash.Trim().ToUpperInvariant();
+        var duplicateKey = StatementDuplicateKey.Create(
+            request.FundAccountId,
+            request.StatementPeriodStart,
+            request.StatementPeriodEnd,
+            sourceFileHash);
 
-        var importId = Guid.NewGuid().ToString("N");
-        var rows = ParseRows(content, request, importId).ToList();
+        if (await store.ImportExistsByDuplicateKeyAsync(duplicateKey, ct).ConfigureAwait(false))
+            throw new InvalidOperationException("Statement already imported (fund account, statement period, and source file hash match).");
+
+        var importId = duplicateKey;
+        var normalizedRequest = request.WithSourceFileHash(sourceFileHash);
+        var rows = ParseRows(content, normalizedRequest, importId).ToList();
         var import = new CanonicalStatementImport(
             importId,
-            request.Broker,
-            request.StatementDate,
+            normalizedRequest.Broker,
+            normalizedRequest.StatementPeriodEnd,
             DateTimeOffset.UtcNow,
-            request.SourcePath,
-            checksum,
+            normalizedRequest.SourcePath,
+            sourceFileHash,
             rows.Count,
-            rows.Count);
+            rows.Count)
+        {
+            SourceInstitution = normalizedRequest.SourceInstitution,
+            FundAccountId = normalizedRequest.FundAccountId,
+            ExternalAccountId = normalizedRequest.ExternalAccountId,
+            StatementPeriodStart = normalizedRequest.StatementPeriodStart,
+            StatementPeriodEnd = normalizedRequest.StatementPeriodEnd,
+            OriginalFileName = normalizedRequest.OriginalFileName,
+            MappingProfileId = normalizedRequest.MappingProfileId,
+            ToleranceProfileId = normalizedRequest.ToleranceProfileId,
+            ImportedBy = normalizedRequest.ImportedBy,
+            SourceFileHash = sourceFileHash,
+            DuplicateKey = duplicateKey
+        };
         await store.SaveImportAsync(import, rows, ct).ConfigureAwait(false);
         return new BrokerStatementImportResult(import, rows);
     }
@@ -95,8 +129,11 @@ public sealed class CsvBrokerStatementService(ICanonicalStatementStore store) : 
     }
 
     private static string Hash(string input)
+        => HashBytes(Encoding.UTF8.GetBytes(input));
+
+    private static string HashBytes(byte[] input)
     {
-        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        var bytes = SHA256.HashData(input);
         return Convert.ToHexString(bytes);
     }
 }

--- a/tests/Meridian.Tests/Reconciliation/StatementImportAndMatchingTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/StatementImportAndMatchingTests.cs
@@ -1,3 +1,4 @@
+using Meridian.Application.Reconciliation;
 using Meridian.Domain.Reconciliation;
 using Meridian.Infrastructure.Reconciliation;
 
@@ -6,7 +7,7 @@ namespace Meridian.Tests.Reconciliation;
 public sealed class StatementImportAndMatchingTests
 {
     [Fact]
-    public async Task Import_is_idempotent_by_checksum()
+    public async Task Import_is_idempotent_by_duplicate_key()
     {
         var root = Path.Combine(Path.GetTempPath(), $"meridian-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(root);
@@ -29,6 +30,87 @@ public sealed class StatementImportAndMatchingTests
         var service = new CsvBrokerStatementService(new JsonCanonicalStatementStore(root));
         var result = await service.ValidateAsync(new BrokerStatementImportRequest("samplebroker", path, new DateOnly(2026, 1, 31)));
         Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public async Task Statement_run_request_hashes_file_contents_and_uses_period_duplicate_key()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"meridian-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        var firstPath = Path.Combine(root, "statement-a.csv");
+        var secondPath = Path.Combine(root, "statement-b.csv");
+        const string content = "account,symbol,quantity,price,cashAmount,activityType,tradeDate\nA1,SPY,10,500,5000,BUY,2026-01-02\n";
+        await File.WriteAllTextAsync(firstPath, content);
+        await File.WriteAllTextAsync(secondPath, content);
+
+        var first = await StatementRunCreateRequest.FromFileAsync(
+            "samplebroker",
+            "samplecustodian",
+            "fund-account-1",
+            "external-account-1",
+            new DateOnly(2026, 1, 1),
+            new DateOnly(2026, 1, 31),
+            firstPath,
+            "sample-mapping",
+            "default-tolerance",
+            "operator@example.test");
+        var second = await StatementRunCreateRequest.FromFileAsync(
+            "samplebroker",
+            "samplecustodian",
+            "fund-account-1",
+            "external-account-1",
+            new DateOnly(2026, 1, 1),
+            new DateOnly(2026, 1, 31),
+            secondPath,
+            "sample-mapping",
+            "default-tolerance",
+            "operator@example.test");
+
+        Assert.Equal(first.SourceFileHash, second.SourceFileHash);
+        Assert.Equal(first.DuplicateKey, second.DuplicateKey);
+        Assert.DoesNotContain(firstPath, first.SourceFileHash);
+    }
+
+    [Fact]
+    public async Task Import_detects_duplicates_by_fund_account_period_and_source_file_hash()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"meridian-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        var firstPath = Path.Combine(root, "statement-a.csv");
+        var secondPath = Path.Combine(root, "statement-b.csv");
+        const string content = "account,symbol,quantity,price,cashAmount,activityType,tradeDate\nA1,SPY,10,500,5000,BUY,2026-01-02\n";
+        await File.WriteAllTextAsync(firstPath, content);
+        await File.WriteAllTextAsync(secondPath, content);
+
+        var service = new CsvBrokerStatementService(new JsonCanonicalStatementStore(root));
+        var first = await StatementRunCreateRequest.FromFileAsync(
+            "samplebroker",
+            "samplecustodian",
+            "fund-account-1",
+            "external-account-1",
+            new DateOnly(2026, 1, 1),
+            new DateOnly(2026, 1, 31),
+            firstPath,
+            "sample-mapping",
+            "default-tolerance",
+            "operator@example.test");
+        var second = await StatementRunCreateRequest.FromFileAsync(
+            "samplebroker",
+            "samplecustodian",
+            "fund-account-1",
+            "external-account-1",
+            new DateOnly(2026, 1, 1),
+            new DateOnly(2026, 1, 31),
+            secondPath,
+            "sample-mapping",
+            "default-tolerance",
+            "operator@example.test");
+
+        var imported = await service.ImportAsync(first.ToBrokerStatementImportRequest());
+
+        Assert.Equal(first.SourceFileHash, imported.Import.SourceFileHash);
+        Assert.Equal(first.DuplicateKey, imported.Import.DuplicateKey);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.ImportAsync(second.ToBrokerStatementImportRequest()));
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Strengthen statement import metadata and make duplicate detection deterministic by using fund account + statement period + a content-derived file hash rather than the file path alone.
- Provide an application-level request model to validate required fields and compute the content hash from file bytes so callers do not need to manage hashing logic.

### Description
- Added a domain-level `StatementRunRequest` and kept `BrokerStatementImportRequest` as a compatibility shim with additional fields including `SourceInstitution`, `FundAccountId`, `ExternalAccountId`, `StatementPeriodStart`, `StatementPeriodEnd`, `OriginalFileName`, `MappingProfileId`, `ToleranceProfileId`, `ImportedBy`, and `SourceFileHash` (`src/Meridian.Domain/Reconciliation/BrokerStatementModels.cs`).
- Added deterministic duplicate-key creation via `StatementDuplicateKey.Create(FundAccountId, StatementPeriodStart, StatementPeriodEnd, SourceFileHash)` and kept a `WithSourceFileHash` helper on the shim for normalization.
- Introduced `StatementRunCreateRequest` at the application level that validates inputs, computes `SourceFileHash` from file bytes (SHA-256), and converts to `BrokerStatementImportRequest` (`src/Meridian.Application/Reconciliation/StatementRunCreateRequest.cs`).
- Updated infrastructure import flow to compute/normalize the `SourceFileHash` from file contents, detect duplicates via the duplicate key, persist expanded `CanonicalStatementImport` metadata (including `SourceFileHash`, account ids, mapping/tolerance ids, importer, and `DuplicateKey`), and expose an `ImportExistsByDuplicateKeyAsync` store method (`src/Meridian.Infrastructure/Reconciliation/BrokerStatementInfrastructure.cs` and `src/Meridian.Domain/Reconciliation/StatementEntities.cs`).
- Wired CLI import to call `StatementRunCreateRequest.FromFileAsync(...)` for imports while keeping legacy validation compatible with the existing `BrokerStatementImportRequest` shim (`src/Meridian.Application/Commands/StatementImportCommands.cs`).
- Added regression tests that assert hashing is content-based (two different paths with identical bytes yield the same `SourceFileHash`) and that imports are rejected when duplicate key matches (`tests/Meridian.Tests/Reconciliation/StatementImportAndMatchingTests.cs`).
- Updated module READMEs to document the new request shape and duplicate-detection semantics (`src/Meridian.Application/README.md`, `src/Meridian.Domain/README.md`, `src/Meridian.Infrastructure/README.md`).

### Testing
- Ran `git diff --check` which produced no check failures (success).
- Attempted to run the focused unit tests with `dotnet test --filter "FullyQualifiedName~StatementImportAndMatchingTests"`, but the `dotnet` CLI is not available in this execution environment so the xUnit run was blocked (manual/CI run required). 
- Ran the docs tooling `python3 build/scripts/docs/validate-doc-hashes.py --summary` which surfaced a pre-existing, repository-wide source-doc hash drift unrelated to the functional change (investigation / source-doc renderer refresh recommended). 
- Executed the local assurance rubric tool `python3 .codex/skills/meridian-implementation-assurance/scripts/score_eval.py` with a conservative scoring payload which produced a pass-level summary (9/10) and recorded two failed checks: missing `dotnet` for running the targeted tests and the pre-existing doc-hash drift, with follow-ups to run tests in a .NET-enabled environment and refresh the source-doc hash manifest.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a188e86e70c8320816e78ce41d8e8c8)