### PR TITLE
Add statement tolerance profiles and annotate reconciliation runs/matches with profile+rule IDs

### DIFF
--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -35,6 +35,7 @@ and UI presentation concerns in their owning layers.
   mapping workbench orchestration. Ledger mapping resolution stays server-side and reuses
   fund-structure assignments before falling back to account ledger references.
 - `Services/` - application use cases and orchestration services.
+- `Reconciliation/` - canonical reconciliation matching, statement tolerance profile models, and profile-provider seams that stamp tolerance profile/version/rule evidence on runs and match explanations.
 - `Composition/` - application feature registration and service wiring.
 
 ## Important workflows
@@ -44,6 +45,7 @@ application service contracts consumed by host and UI surfaces.
 
 ## API contract notes
 
+- Statement reconciliation tolerance profiles are versioned in `Reconciliation/`; match outputs that use a tolerance must carry the tolerance profile ID/version and the exact tolerance rule ID that allowed the match.
 - Options-chain provider IDs are normalized with trim plus invariant lowercase before deduplication, health lookup, fallback detection, logging, and metrics.
 
 ## Diagrams

--- a/src/Meridian.Application/Reconciliation/CanonicalReconciliationEngine.cs
+++ b/src/Meridian.Application/Reconciliation/CanonicalReconciliationEngine.cs
@@ -102,46 +102,72 @@ public sealed class ReconciliationMatchingEngine
         var groupedByInstrument = allPositions.GroupBy(static p => p.InstrumentCanonicalId);
         foreach (var instrumentGroup in groupedByInstrument)
         {
-            var exactGroups = instrumentGroup.GroupBy(static p => (p.Quantity, p.Price, p.MarketValue)).ToArray();
+            var positions = instrumentGroup.ToArray();
+            var resolvedPositionIds = new HashSet<string>(StringComparer.Ordinal);
+            var exactGroups = positions.GroupBy(static p => (p.Quantity, p.Price, p.MarketValue)).ToArray();
             foreach (var exactGroup in exactGroups.Where(static g => g.Count() > 1))
             {
+                var exactPositions = exactGroup.ToArray();
                 var exactEvidence = new MatchEvidence(Guid.NewGuid().ToString("N"), "exact-position-v1", "Exact", "Exact position tuple match.", 0m, new Dictionary<string, string>());
                 evidence.Add(exactEvidence);
-                matches.Add(new MatchGroup(Guid.NewGuid().ToString("N"), BreakClassification.Matched, exactEvidence.RuleId, exactGroup.Select(p => p.PositionId).ToArray(), Array.Empty<string>(), [exactEvidence.EvidenceId])
+                matches.Add(new MatchGroup(Guid.NewGuid().ToString("N"), BreakClassification.Matched, exactEvidence.RuleId, exactPositions.Select(p => p.PositionId).ToArray(), Array.Empty<string>(), [exactEvidence.EvidenceId])
                 {
                     ToleranceProfileId = toleranceProfile.ProfileId,
                     ToleranceProfileVersion = toleranceProfile.Version
                 });
+
+                foreach (var position in exactPositions)
+                {
+                    resolvedPositionIds.Add(position.PositionId);
+                }
             }
 
-            if (exactGroups.Length > 1 || exactGroups[0].Count() == 1)
+            var toleranceCandidates = positions
+                .Where(position => !resolvedPositionIds.Contains(position.PositionId))
+                .ToArray();
+            foreach (var toleranceMatch in FindPositionToleranceMatches(toleranceCandidates, toleranceProfile))
             {
-                var positions = instrumentGroup.ToArray();
-                if (TryFindPositionToleranceMatch(positions, toleranceProfile, out var toleratedPositions, out var positionRule, out var positionDelta))
-                {
-                    var toleranceEvidence = new MatchEvidence(
-                        Guid.NewGuid().ToString("N"),
-                        positionRule.RuleId,
-                        "Tolerance",
-                        $"Position tolerance rule {positionRule.RuleId} allowed quantity/price/market value deltas.",
-                        positionDelta,
-                        new Dictionary<string, string>
-                        {
-                            ["toleranceProfileId"] = toleranceProfile.ProfileId,
-                            ["toleranceProfileVersion"] = toleranceProfile.Version.ToString(),
-                            ["toleranceRuleId"] = positionRule.RuleId
-                        });
-                    evidence.Add(toleranceEvidence);
-                    matches.Add(new MatchGroup(Guid.NewGuid().ToString("N"), BreakClassification.MatchedWithinTolerance, toleranceEvidence.RuleId, toleratedPositions.Select(p => p.PositionId).ToArray(), Array.Empty<string>(), [toleranceEvidence.EvidenceId])
+                var toleranceEvidence = new MatchEvidence(
+                    Guid.NewGuid().ToString("N"),
+                    toleranceMatch.Rule.RuleId,
+                    "Tolerance",
+                    $"Position tolerance rule {toleranceMatch.Rule.RuleId} allowed quantity/price/market value deltas.",
+                    toleranceMatch.MaxDelta,
+                    new Dictionary<string, string>
                     {
-                        ToleranceProfileId = toleranceProfile.ProfileId,
-                        ToleranceProfileVersion = toleranceProfile.Version,
-                        ToleranceRuleId = positionRule.RuleId
+                        ["toleranceProfileId"] = toleranceProfile.ProfileId,
+                        ["toleranceProfileVersion"] = toleranceProfile.Version.ToString(),
+                        ["toleranceRuleId"] = toleranceMatch.Rule.RuleId
                     });
-                    continue;
-                }
+                evidence.Add(toleranceEvidence);
+                matches.Add(new MatchGroup(Guid.NewGuid().ToString("N"), BreakClassification.MatchedWithinTolerance, toleranceEvidence.RuleId, toleranceMatch.Positions.Select(p => p.PositionId).ToArray(), Array.Empty<string>(), [toleranceEvidence.EvidenceId])
+                {
+                    ToleranceProfileId = toleranceProfile.ProfileId,
+                    ToleranceProfileVersion = toleranceProfile.Version,
+                    ToleranceRuleId = toleranceMatch.Rule.RuleId
+                });
 
-                var breakEvidence = new MatchEvidence(Guid.NewGuid().ToString("N"), "true-break-position-v1", "Exact", "Position has no exact cross-source match.", null, new Dictionary<string, string>());
+                foreach (var position in toleranceMatch.Positions)
+                {
+                    resolvedPositionIds.Add(position.PositionId);
+                }
+            }
+
+            var unresolvedPositions = positions
+                .Where(position => !resolvedPositionIds.Contains(position.PositionId))
+                .ToArray();
+            if (unresolvedPositions.Length > 0)
+            {
+                var breakEvidence = new MatchEvidence(
+                    Guid.NewGuid().ToString("N"),
+                    "true-break-position-v1",
+                    "Exact",
+                    "Position has no exact cross-source match.",
+                    null,
+                    new Dictionary<string, string>
+                    {
+                        ["unresolvedPositionIds"] = string.Join(",", unresolvedPositions.Select(static position => position.PositionId))
+                    });
                 evidence.Add(breakEvidence);
                 breaks.Add(new BreakRecord(Guid.NewGuid().ToString("N"), BreakClassification.TrueBreak, breakEvidence.RuleId, "No exact matching position candidate found.", effectiveRun.SourceSnapshots.Select(s => s.SnapshotId).ToArray(), [breakEvidence.EvidenceId]));
             }
@@ -227,40 +253,56 @@ public sealed class ReconciliationMatchingEngine
         return null;
     }
 
-    private static bool TryFindPositionToleranceMatch(
+    private static IReadOnlyList<PositionToleranceMatch> FindPositionToleranceMatches(
         IReadOnlyList<NormalizedPosition> positions,
-        StatementToleranceProfile profile,
-        out IReadOnlyList<NormalizedPosition> toleratedPositions,
-        out PositionToleranceRule rule,
-        out decimal maxDelta)
+        StatementToleranceProfile profile)
     {
+        var matches = new List<PositionToleranceMatch>();
+        var resolvedPositionIds = new HashSet<string>(StringComparer.Ordinal);
+
         for (var i = 0; i < positions.Count; i++)
         {
+            var left = positions[i];
+            if (resolvedPositionIds.Contains(left.PositionId))
+            {
+                continue;
+            }
+
             for (var j = i + 1; j < positions.Count; j++)
             {
+                var right = positions[j];
+                if (resolvedPositionIds.Contains(right.PositionId))
+                {
+                    continue;
+                }
+
                 foreach (var candidateRule in profile.PositionRules)
                 {
-                    var left = positions[i];
-                    var right = positions[j];
                     if (!candidateRule.Allows(left.Quantity, right.Quantity, left.MarketValue, right.MarketValue, left.Price, right.Price))
                     {
                         continue;
                     }
 
-                    toleratedPositions = [left, right];
-                    rule = candidateRule;
-                    maxDelta = Math.Max(Math.Abs(left.Quantity - right.Quantity), Math.Max(Math.Abs(left.Price - right.Price), Math.Abs(left.MarketValue - right.MarketValue)));
-                    return true;
+                    resolvedPositionIds.Add(left.PositionId);
+                    resolvedPositionIds.Add(right.PositionId);
+                    matches.Add(new PositionToleranceMatch(
+                        [left, right],
+                        candidateRule,
+                        Math.Max(Math.Abs(left.Quantity - right.Quantity), Math.Max(Math.Abs(left.Price - right.Price), Math.Abs(left.MarketValue - right.MarketValue)))));
+                    break;
+                }
+
+                if (resolvedPositionIds.Contains(left.PositionId))
+                {
+                    break;
                 }
             }
         }
 
-        toleratedPositions = [];
-        rule = new PositionToleranceRule(string.Empty, 0m, 0m, 0m);
-        maxDelta = 0m;
-        return false;
+        return matches;
     }
 
+    private sealed record PositionToleranceMatch(IReadOnlyList<NormalizedPosition> Positions, PositionToleranceRule Rule, decimal MaxDelta);
 }
 
 public sealed class DefaultReconciliationIngestionScheduler : IReconciliationIngestionScheduler

--- a/src/Meridian.Application/Reconciliation/CanonicalReconciliationEngine.cs
+++ b/src/Meridian.Application/Reconciliation/CanonicalReconciliationEngine.cs
@@ -69,19 +69,36 @@ public sealed class ReconciliationNormalizationService(
     }
 }
 
-public sealed record MatchingTolerances(decimal Quantity, decimal Price, decimal MarketValue, decimal CashAmount, TimeSpan TimingWindow);
+public sealed record MatchingTolerances(decimal Quantity, decimal Price, decimal MarketValue, decimal CashAmount, TimeSpan TimingWindow)
+{
+    public StatementToleranceProfile ToStatementToleranceProfile() => new(
+        StatementToleranceProfile.DefaultProfileId,
+        StatementToleranceProfile.DefaultProfileVersion,
+        [new CashToleranceRule("cash-amount-window-v1", CashAmount, null, TimingWindow)],
+        [new PositionToleranceRule("position-quantity-price-value-v1", Quantity, MarketValue, Price)],
+        [new TransactionToleranceRule("transaction-amount-price-settlement-v1", CashAmount, TimingWindow, Price)]);
+}
 
 public sealed class ReconciliationMatchingEngine
 {
     public (IReadOnlyList<MatchGroup> matches, IReadOnlyList<BreakRecord> breaks, IReadOnlyList<MatchEvidence> evidence) Run(
         ReconciliationRun run,
-        MatchingTolerances tolerances)
+        MatchingTolerances tolerances) => Run(run, tolerances.ToStatementToleranceProfile());
+
+    public (IReadOnlyList<MatchGroup> matches, IReadOnlyList<BreakRecord> breaks, IReadOnlyList<MatchEvidence> evidence) Run(
+        ReconciliationRun run,
+        StatementToleranceProfile toleranceProfile)
     {
+        var effectiveRun = run with
+        {
+            ToleranceProfileId = toleranceProfile.ProfileId,
+            ToleranceProfileVersion = toleranceProfile.Version
+        };
         var evidence = new List<MatchEvidence>();
         var matches = new List<MatchGroup>();
         var breaks = new List<BreakRecord>();
 
-        var allPositions = run.SourceSnapshots.SelectMany(s => s.Positions).ToArray();
+        var allPositions = effectiveRun.SourceSnapshots.SelectMany(s => s.Positions).ToArray();
         var groupedByInstrument = allPositions.GroupBy(static p => p.InstrumentCanonicalId);
         foreach (var instrumentGroup in groupedByInstrument)
         {
@@ -90,29 +107,83 @@ public sealed class ReconciliationMatchingEngine
             {
                 var exactEvidence = new MatchEvidence(Guid.NewGuid().ToString("N"), "exact-position-v1", "Exact", "Exact position tuple match.", 0m, new Dictionary<string, string>());
                 evidence.Add(exactEvidence);
-                matches.Add(new MatchGroup(Guid.NewGuid().ToString("N"), BreakClassification.Matched, exactEvidence.RuleId, exactGroup.Select(p => p.PositionId).ToArray(), Array.Empty<string>(), [exactEvidence.EvidenceId]));
+                matches.Add(new MatchGroup(Guid.NewGuid().ToString("N"), BreakClassification.Matched, exactEvidence.RuleId, exactGroup.Select(p => p.PositionId).ToArray(), Array.Empty<string>(), [exactEvidence.EvidenceId])
+                {
+                    ToleranceProfileId = toleranceProfile.ProfileId,
+                    ToleranceProfileVersion = toleranceProfile.Version
+                });
             }
 
             if (exactGroups.Length > 1 || exactGroups[0].Count() == 1)
             {
+                var positions = instrumentGroup.ToArray();
+                if (TryFindPositionToleranceMatch(positions, toleranceProfile, out var toleratedPositions, out var positionRule, out var positionDelta))
+                {
+                    var toleranceEvidence = new MatchEvidence(
+                        Guid.NewGuid().ToString("N"),
+                        positionRule.RuleId,
+                        "Tolerance",
+                        $"Position tolerance rule {positionRule.RuleId} allowed quantity/price/market value deltas.",
+                        positionDelta,
+                        new Dictionary<string, string>
+                        {
+                            ["toleranceProfileId"] = toleranceProfile.ProfileId,
+                            ["toleranceProfileVersion"] = toleranceProfile.Version.ToString(),
+                            ["toleranceRuleId"] = positionRule.RuleId
+                        });
+                    evidence.Add(toleranceEvidence);
+                    matches.Add(new MatchGroup(Guid.NewGuid().ToString("N"), BreakClassification.MatchedWithinTolerance, toleranceEvidence.RuleId, toleratedPositions.Select(p => p.PositionId).ToArray(), Array.Empty<string>(), [toleranceEvidence.EvidenceId])
+                    {
+                        ToleranceProfileId = toleranceProfile.ProfileId,
+                        ToleranceProfileVersion = toleranceProfile.Version,
+                        ToleranceRuleId = positionRule.RuleId
+                    });
+                    continue;
+                }
+
                 var breakEvidence = new MatchEvidence(Guid.NewGuid().ToString("N"), "true-break-position-v1", "Exact", "Position has no exact cross-source match.", null, new Dictionary<string, string>());
                 evidence.Add(breakEvidence);
-                breaks.Add(new BreakRecord(Guid.NewGuid().ToString("N"), BreakClassification.TrueBreak, breakEvidence.RuleId, "No exact matching position candidate found.", run.SourceSnapshots.Select(s => s.SnapshotId).ToArray(), [breakEvidence.EvidenceId]));
+                breaks.Add(new BreakRecord(Guid.NewGuid().ToString("N"), BreakClassification.TrueBreak, breakEvidence.RuleId, "No exact matching position candidate found.", effectiveRun.SourceSnapshots.Select(s => s.SnapshotId).ToArray(), [breakEvidence.EvidenceId]));
             }
         }
 
-        var allCash = run.SourceSnapshots.SelectMany(s => s.CashEntries).ToArray();
+        var allCash = effectiveRun.SourceSnapshots.SelectMany(s => s.CashEntries).ToArray();
         foreach (var candidate in allCash)
         {
-            var near = allCash.Where(other => other.CashEntryId != candidate.CashEntryId && Math.Abs(other.AmountBase - candidate.AmountBase) <= tolerances.CashAmount).ToArray();
+            var near = allCash
+                .Select(other =>
+                {
+                    var rule = FindCashToleranceRule(candidate, other, toleranceProfile, out var allowed);
+                    return new { Cash = other, Rule = rule, Allowed = allowed };
+                })
+                .Where(static item => item.Cash.CashEntryId != candidate.CashEntryId && item.Rule is not null)
+                .ToArray();
             if (near.Length > 0)
             {
-                var timeDelta = near.Min(other => Math.Abs((other.PostedAtUtc - candidate.PostedAtUtc).TotalMinutes));
-                var classification = timeDelta <= tolerances.TimingWindow.TotalMinutes ? BreakClassification.MatchedWithinTolerance : BreakClassification.PotentialBreak;
-                var ruleId = classification == BreakClassification.MatchedWithinTolerance ? "tolerance-cash-v1" : "timing-window-v1";
-                var ev = new MatchEvidence(Guid.NewGuid().ToString("N"), ruleId, "Tolerance", "Cash amount/timing tolerance evaluation.", (decimal?)timeDelta, new Dictionary<string, string>());
+                var first = near[0];
+                var rule = first.Rule!;
+                var timeDelta = Math.Abs((first.Cash.PostedAtUtc - candidate.PostedAtUtc).TotalMinutes);
+                var ev = new MatchEvidence(
+                    Guid.NewGuid().ToString("N"),
+                    rule.RuleId,
+                    "Tolerance",
+                    $"Cash tolerance rule {rule.RuleId} allowed amount/settlement-date delta.",
+                    Math.Abs(first.Cash.AmountBase - candidate.AmountBase),
+                    new Dictionary<string, string>
+                    {
+                        ["allowedTolerance"] = first.Allowed.ToString(),
+                        ["settlementDateDeltaMinutes"] = timeDelta.ToString(),
+                        ["toleranceProfileId"] = toleranceProfile.ProfileId,
+                        ["toleranceProfileVersion"] = toleranceProfile.Version.ToString(),
+                        ["toleranceRuleId"] = rule.RuleId
+                    });
                 evidence.Add(ev);
-                matches.Add(new MatchGroup(Guid.NewGuid().ToString("N"), classification, ev.RuleId, Array.Empty<string>(), near.Append(candidate).Select(c => c.CashEntryId).Distinct().ToArray(), [ev.EvidenceId]));
+                matches.Add(new MatchGroup(Guid.NewGuid().ToString("N"), BreakClassification.MatchedWithinTolerance, ev.RuleId, Array.Empty<string>(), near.Select(item => item.Cash).Append(candidate).Select(c => c.CashEntryId).Distinct().ToArray(), [ev.EvidenceId])
+                {
+                    ToleranceProfileId = toleranceProfile.ProfileId,
+                    ToleranceProfileVersion = toleranceProfile.Version,
+                    ToleranceRuleId = rule.RuleId
+                });
             }
             else
             {
@@ -125,19 +196,71 @@ public sealed class ReconciliationMatchingEngine
                 {
                     var ev = new MatchEvidence(Guid.NewGuid().ToString("N"), "fuzzy-reference-v1", "Fuzzy", "Reference-level fuzzy hit.", null, new Dictionary<string, string>());
                     evidence.Add(ev);
-                    matches.Add(new MatchGroup(Guid.NewGuid().ToString("N"), BreakClassification.PotentialBreak, ev.RuleId, Array.Empty<string>(), [candidate.CashEntryId, fuzzyHit.CashEntryId], [ev.EvidenceId]));
+                    matches.Add(new MatchGroup(Guid.NewGuid().ToString("N"), BreakClassification.PotentialBreak, ev.RuleId, Array.Empty<string>(), [candidate.CashEntryId, fuzzyHit.CashEntryId], [ev.EvidenceId])
+                    {
+                        ToleranceProfileId = toleranceProfile.ProfileId,
+                        ToleranceProfileVersion = toleranceProfile.Version
+                    });
                 }
                 else
                 {
                     var ev = new MatchEvidence(Guid.NewGuid().ToString("N"), "true-break-v1", "Fuzzy", "No exact/tolerance/fuzzy evidence available.", null, new Dictionary<string, string>());
                     evidence.Add(ev);
-                    breaks.Add(new BreakRecord(Guid.NewGuid().ToString("N"), BreakClassification.TrueBreak, ev.RuleId, "No matching candidate found.", run.SourceSnapshots.Select(s => s.SnapshotId).ToArray(), [ev.EvidenceId]));
+                    breaks.Add(new BreakRecord(Guid.NewGuid().ToString("N"), BreakClassification.TrueBreak, ev.RuleId, "No matching candidate found.", effectiveRun.SourceSnapshots.Select(s => s.SnapshotId).ToArray(), [ev.EvidenceId]));
                 }
             }
         }
 
         return (matches, breaks, evidence);
     }
+    private static CashToleranceRule? FindCashToleranceRule(NormalizedCashEntry candidate, NormalizedCashEntry other, StatementToleranceProfile profile, out decimal allowedTolerance)
+    {
+        foreach (var rule in profile.CashRules)
+        {
+            if (rule.Allows(candidate.AmountBase, other.AmountBase, other.PostedAtUtc - candidate.PostedAtUtc, out allowedTolerance))
+            {
+                return rule;
+            }
+        }
+
+        allowedTolerance = 0m;
+        return null;
+    }
+
+    private static bool TryFindPositionToleranceMatch(
+        IReadOnlyList<NormalizedPosition> positions,
+        StatementToleranceProfile profile,
+        out IReadOnlyList<NormalizedPosition> toleratedPositions,
+        out PositionToleranceRule rule,
+        out decimal maxDelta)
+    {
+        for (var i = 0; i < positions.Count; i++)
+        {
+            for (var j = i + 1; j < positions.Count; j++)
+            {
+                foreach (var candidateRule in profile.PositionRules)
+                {
+                    var left = positions[i];
+                    var right = positions[j];
+                    if (!candidateRule.Allows(left.Quantity, right.Quantity, left.MarketValue, right.MarketValue, left.Price, right.Price))
+                    {
+                        continue;
+                    }
+
+                    toleratedPositions = [left, right];
+                    rule = candidateRule;
+                    maxDelta = Math.Max(Math.Abs(left.Quantity - right.Quantity), Math.Max(Math.Abs(left.Price - right.Price), Math.Abs(left.MarketValue - right.MarketValue)));
+                    return true;
+                }
+            }
+        }
+
+        toleratedPositions = [];
+        rule = new PositionToleranceRule(string.Empty, 0m, 0m, 0m);
+        maxDelta = 0m;
+        return false;
+    }
+
 }
 
 public sealed class DefaultReconciliationIngestionScheduler : IReconciliationIngestionScheduler
@@ -174,19 +297,62 @@ public sealed class ReconciliationRunOrchestrator(
     {
         var key = $"recon:{businessDate:yyyy-MM-dd}";
         var priorExists = _runByIdempotencyKey.TryGetValue(key, out var prior);
+        var profile = tolerances.ToStatementToleranceProfile();
         if (priorExists && !rerun)
         {
-            var cached = matchingEngine.Run(prior!, tolerances);
-            return (prior!, cached.matches, cached.breaks, cached.evidence);
+            var cached = matchingEngine.Run(prior!, profile);
+            return (prior! with
+            {
+                ToleranceProfileId = profile.ProfileId,
+                ToleranceProfileVersion = profile.Version
+            }, cached.matches, cached.breaks, cached.evidence);
         }
 
         var snapshotVersion = priorExists ? prior!.SnapshotVersion + 1 : 1;
         var request = new ReconciliationIngestionRequest(businessDate, runTimestampUtc, baseCurrency, snapshotVersion);
         var snapshots = await scheduler.CaptureAsync(adapters, request, ct).ConfigureAwait(false);
-        var run = new ReconciliationRun(Guid.NewGuid(), businessDate, runTimestampUtc, rerun, snapshotVersion, key, snapshots);
+        var run = new ReconciliationRun(Guid.NewGuid(), businessDate, runTimestampUtc, rerun, snapshotVersion, key, snapshots)
+        {
+            ToleranceProfileId = profile.ProfileId,
+            ToleranceProfileVersion = profile.Version
+        };
         _runByIdempotencyKey[key] = run;
 
-        var result = matchingEngine.Run(run, tolerances);
+        var result = matchingEngine.Run(run, profile);
+        return (run, result.matches, result.breaks, result.evidence);
+    }
+
+    public async Task<(ReconciliationRun run, IReadOnlyList<MatchGroup> matches, IReadOnlyList<BreakRecord> breaks, IReadOnlyList<MatchEvidence> evidence)> RunDailyAsync(
+        DateOnly businessDate,
+        DateTimeOffset runTimestampUtc,
+        string baseCurrency,
+        bool rerun,
+        StatementToleranceProfile toleranceProfile,
+        CancellationToken ct)
+    {
+        var key = $"recon:{businessDate:yyyy-MM-dd}";
+        var priorExists = _runByIdempotencyKey.TryGetValue(key, out var prior);
+        if (priorExists && !rerun)
+        {
+            var cached = matchingEngine.Run(prior!, toleranceProfile);
+            return (prior! with
+            {
+                ToleranceProfileId = toleranceProfile.ProfileId,
+                ToleranceProfileVersion = toleranceProfile.Version
+            }, cached.matches, cached.breaks, cached.evidence);
+        }
+
+        var snapshotVersion = priorExists ? prior!.SnapshotVersion + 1 : 1;
+        var request = new ReconciliationIngestionRequest(businessDate, runTimestampUtc, baseCurrency, snapshotVersion);
+        var snapshots = await scheduler.CaptureAsync(adapters, request, ct).ConfigureAwait(false);
+        var run = new ReconciliationRun(Guid.NewGuid(), businessDate, runTimestampUtc, rerun, snapshotVersion, key, snapshots)
+        {
+            ToleranceProfileId = toleranceProfile.ProfileId,
+            ToleranceProfileVersion = toleranceProfile.Version
+        };
+        _runByIdempotencyKey[key] = run;
+
+        var result = matchingEngine.Run(run, toleranceProfile);
         return (run, result.matches, result.breaks, result.evidence);
     }
 }

--- a/src/Meridian.Application/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.Application/Reconciliation/StatementReconciliationService.cs
@@ -207,7 +207,12 @@ public sealed class StatementReconciliationService
         {
             if (row.Kind == StatementRowKind.Position && Math.Abs(row.Quantity) > 0)
             {
-                matches.Add(new ReconciliationMatchLink(row.RowId, "position:auto", null, null, null, null, null, "high", "Symbol and quantity aligned within tolerance window."));
+                matches.Add(new ReconciliationMatchLink(row.RowId, "position:auto", null, null, null, null, null, "high", "Symbol and quantity aligned within tolerance rule position-default-v1.")
+                {
+                    ToleranceProfileId = StatementToleranceProfile.DefaultProfileId,
+                    ToleranceProfileVersion = StatementToleranceProfile.DefaultProfileVersion,
+                    ToleranceRuleId = "position-default-v1"
+                });
                 continue;
             }
 

--- a/src/Meridian.Application/Reconciliation/StatementToleranceProfiles.cs
+++ b/src/Meridian.Application/Reconciliation/StatementToleranceProfiles.cs
@@ -1,0 +1,92 @@
+namespace Meridian.Application.Reconciliation;
+
+public sealed record StatementToleranceProfile(
+    string ProfileId,
+    int Version,
+    IReadOnlyList<CashToleranceRule> CashRules,
+    IReadOnlyList<PositionToleranceRule> PositionRules,
+    IReadOnlyList<TransactionToleranceRule> TransactionRules)
+{
+    public const string DefaultProfileId = "statement-default";
+    public const int DefaultProfileVersion = 1;
+
+    public static StatementToleranceProfile Default { get; } = new(
+        DefaultProfileId,
+        DefaultProfileVersion,
+        [new CashToleranceRule("cash-default-absolute-v1", 0.01m, null, TimeSpan.FromMinutes(5))],
+        [new PositionToleranceRule("position-default-v1", 0.0001m, 0m, 0m)],
+        [new TransactionToleranceRule("transaction-default-v1", 0.01m, TimeSpan.FromDays(0), 0m)]);
+}
+
+public sealed record CashToleranceRule(
+    string RuleId,
+    decimal AbsoluteCashTolerance,
+    decimal? BasisPointCashTolerance,
+    TimeSpan SettlementDateTolerance)
+{
+    public bool Allows(decimal expectedAmountBase, decimal actualAmountBase, TimeSpan settlementDateDelta, out decimal allowedTolerance)
+    {
+        var absolute = Math.Abs(AbsoluteCashTolerance);
+        var bps = BasisPointCashTolerance is { } basisPoints
+            ? Math.Abs(expectedAmountBase) * Math.Abs(basisPoints) / 10_000m
+            : 0m;
+        allowedTolerance = Math.Max(absolute, bps);
+        return Math.Abs(actualAmountBase - expectedAmountBase) <= allowedTolerance
+            && settlementDateDelta.Duration() <= SettlementDateTolerance.Duration();
+    }
+}
+
+public sealed record PositionToleranceRule(
+    string RuleId,
+    decimal QuantityTolerance,
+    decimal MarketValueTolerance,
+    decimal PriceTolerance)
+{
+    public bool Allows(decimal expectedQuantity, decimal actualQuantity, decimal expectedMarketValue, decimal actualMarketValue, decimal expectedPrice, decimal actualPrice) =>
+        Math.Abs(actualQuantity - expectedQuantity) <= Math.Abs(QuantityTolerance)
+        && Math.Abs(actualMarketValue - expectedMarketValue) <= Math.Abs(MarketValueTolerance)
+        && Math.Abs(actualPrice - expectedPrice) <= Math.Abs(PriceTolerance);
+}
+
+public sealed record TransactionToleranceRule(
+    string RuleId,
+    decimal AbsoluteCashTolerance,
+    TimeSpan SettlementDateTolerance,
+    decimal PriceTolerance)
+{
+    public bool Allows(decimal expectedAmount, decimal actualAmount, TimeSpan settlementDateDelta, decimal expectedPrice, decimal actualPrice) =>
+        Math.Abs(actualAmount - expectedAmount) <= Math.Abs(AbsoluteCashTolerance)
+        && settlementDateDelta.Duration() <= SettlementDateTolerance.Duration()
+        && Math.Abs(actualPrice - expectedPrice) <= Math.Abs(PriceTolerance);
+}
+
+public interface IStatementToleranceProfileProvider
+{
+    ValueTask<StatementToleranceProfile> GetProfileAsync(string profileId, CancellationToken ct = default);
+}
+
+public sealed class InMemoryStatementToleranceProfileProvider : IStatementToleranceProfileProvider
+{
+    private readonly IReadOnlyDictionary<string, StatementToleranceProfile> _profiles;
+
+    public InMemoryStatementToleranceProfileProvider(IEnumerable<StatementToleranceProfile>? profiles = null)
+    {
+        var registeredProfiles = profiles ?? new[] { StatementToleranceProfile.Default };
+        _profiles = registeredProfiles
+            .GroupBy(static profile => profile.ProfileId, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(static group => group.Key, static group => group.OrderByDescending(static profile => profile.Version).First(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    public ValueTask<StatementToleranceProfile> GetProfileAsync(string profileId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(profileId);
+        ct.ThrowIfCancellationRequested();
+
+        if (_profiles.TryGetValue(profileId, out var profile))
+        {
+            return ValueTask.FromResult(profile);
+        }
+
+        throw new KeyNotFoundException($"Statement tolerance profile '{profileId}' was not registered.");
+    }
+}

--- a/src/Meridian.Contracts/Domain/Reconciliation/ReconciliationDomainModels.cs
+++ b/src/Meridian.Contracts/Domain/Reconciliation/ReconciliationDomainModels.cs
@@ -26,7 +26,11 @@ public sealed record ReconciliationRun(
     string SnapshotVersion,
     bool IsRerun,
     string Trigger,
-    IReadOnlyList<DataSourceSnapshot> SourceSnapshots);
+    IReadOnlyList<DataSourceSnapshot> SourceSnapshots)
+{
+    public string ToleranceProfileId { get; init; } = string.Empty;
+    public int ToleranceProfileVersion { get; init; }
+}
 
 public sealed record DataSourceSnapshot(
     string SourceId,
@@ -74,7 +78,12 @@ public sealed record MatchGroup(
     IReadOnlyDictionary<string, string> Evidence,
     IReadOnlyList<NormalizedPosition> Positions,
     IReadOnlyList<NormalizedCashEntry> CashEntries,
-    DateTimeOffset EvaluatedAt);
+    DateTimeOffset EvaluatedAt)
+{
+    public string ToleranceProfileId { get; init; } = string.Empty;
+    public int ToleranceProfileVersion { get; init; }
+    public string? ToleranceRuleId { get; init; }
+}
 
 public sealed record BreakRecord(
     Guid BreakId,

--- a/src/Meridian.Domain/Reconciliation/BrokerStatementModels.cs
+++ b/src/Meridian.Domain/Reconciliation/BrokerStatementModels.cs
@@ -11,7 +11,12 @@ public sealed record MatchOutcome(
     string OutcomeType,
     string LinkedEntityId,
     decimal Confidence,
-    string Rationale);
+    string Rationale)
+{
+    public string ToleranceProfileId { get; init; } = string.Empty;
+    public int ToleranceProfileVersion { get; init; }
+    public string? ToleranceRuleId { get; init; }
+}
 
 public interface IBrokerStatementService
 {

--- a/src/Meridian.Domain/Reconciliation/CanonicalReconciliation.cs
+++ b/src/Meridian.Domain/Reconciliation/CanonicalReconciliation.cs
@@ -23,7 +23,11 @@ public sealed record ReconciliationRun(
     bool IsRerun,
     int SnapshotVersion,
     string IdempotencyKey,
-    IReadOnlyList<DataSourceSnapshot> SourceSnapshots);
+    IReadOnlyList<DataSourceSnapshot> SourceSnapshots)
+{
+    public string ToleranceProfileId { get; init; } = string.Empty;
+    public int ToleranceProfileVersion { get; init; }
+}
 
 public sealed record DataSourceSnapshot(
     string SnapshotId,
@@ -67,7 +71,12 @@ public sealed record MatchGroup(
     string RuleId,
     IReadOnlyList<string> PositionIds,
     IReadOnlyList<string> CashEntryIds,
-    IReadOnlyList<string> EvidenceIds);
+    IReadOnlyList<string> EvidenceIds)
+{
+    public string ToleranceProfileId { get; init; } = string.Empty;
+    public int ToleranceProfileVersion { get; init; }
+    public string? ToleranceRuleId { get; init; }
+}
 
 public sealed record BreakRecord(
     string BreakId,

--- a/src/Meridian.Domain/Reconciliation/StatementEntities.cs
+++ b/src/Meridian.Domain/Reconciliation/StatementEntities.cs
@@ -70,7 +70,11 @@ public sealed record StatementReconciliationRun(
     int PositionMatches,
     int CashMatches,
     int TransactionMatches,
-    int OpenExceptionCount);
+    int OpenExceptionCount)
+{
+    public string ToleranceProfileId { get; init; } = string.Empty;
+    public int ToleranceProfileVersion { get; init; }
+}
 
 public sealed record ReconciliationBreakRecord(
     string BreakId,

--- a/src/Meridian.Domain/Reconciliation/StatementReconciliationAggregate.cs
+++ b/src/Meridian.Domain/Reconciliation/StatementReconciliationAggregate.cs
@@ -41,7 +41,12 @@ public sealed record ReconciliationMatchLink(
     string? SessionEvidenceId,
     string? RunEvidenceId,
     string Confidence,
-    string Rationale);
+    string Rationale)
+{
+    public string ToleranceProfileId { get; init; } = string.Empty;
+    public int ToleranceProfileVersion { get; init; }
+    public string? ToleranceRuleId { get; init; }
+}
 
 public enum ReconciliationCaseState { Open, InReview, Resolved, Waived }
 

--- a/src/Meridian.Infrastructure/Reconciliation/BrokerStatementInfrastructure.cs
+++ b/src/Meridian.Infrastructure/Reconciliation/BrokerStatementInfrastructure.cs
@@ -104,6 +104,16 @@ public sealed class CsvBrokerStatementService(ICanonicalStatementStore store) : 
 public sealed record StatementMatchingTolerance(decimal PositionQuantityTolerance, decimal CashAmountTolerance, decimal TransactionAmountTolerance)
 {
     public static StatementMatchingTolerance Default => new(0.0001m, 0.01m, 0.01m);
+
+    public string ToleranceProfileId { get; init; } = "statement-default";
+    public int ToleranceProfileVersion { get; init; } = 1;
+    public string PositionToleranceRuleId { get; init; } = "position-default-v1";
+    public string CashToleranceRuleId { get; init; } = "cash-default-absolute-v1";
+    public string TransactionToleranceRuleId { get; init; } = "transaction-default-v1";
+    public decimal? BasisPointCashTolerance { get; init; }
+    public decimal MarketValueTolerance { get; init; }
+    public TimeSpan SettlementDateTolerance { get; init; }
+    public decimal PriceTolerance { get; init; }
 }
 
 public interface IReconciliationBreakStore
@@ -153,7 +163,17 @@ public sealed class StatementMatchingService
                 _ => MatchTransaction(r, t)
             };
 
-            return new MatchOutcome(r.RawChecksum, ok ? "matched" : code, ok ? $"SRC-{r.SourceRowNumber}" : string.Empty, conf, rationale);
+            var ruleId = ResolveRuleId(r, t);
+            var explanation = ok && !string.IsNullOrWhiteSpace(ruleId)
+                ? $"{rationale} Tolerance rule {ruleId} allowed this match."
+                : rationale;
+
+            return new MatchOutcome(r.RawChecksum, ok ? "matched" : code, ok ? $"SRC-{r.SourceRowNumber}" : string.Empty, conf, explanation)
+            {
+                ToleranceProfileId = t.ToleranceProfileId,
+                ToleranceProfileVersion = t.ToleranceProfileVersion,
+                ToleranceRuleId = ok ? ruleId : null
+            };
         }).ToList();
     }
 
@@ -170,28 +190,62 @@ public sealed class StatementMatchingService
                 BreakCode: x.outcome.OutcomeType,
                 Category: x.row.ActivityType,
                 Delta: Math.Abs(x.row.Quantity) + Math.Abs(x.row.CashAmount),
-                Tolerance: x.row.ActivityType.Equals("cash", StringComparison.OrdinalIgnoreCase) ? t.CashAmountTolerance : t.TransactionAmountTolerance,
+                Tolerance: ResolveToleranceAmount(x.row, t),
                 ToleranceBreached: true,
                 CreatedAtUtc: DateTimeOffset.UtcNow,
                 Status: "Open")).ToList();
+    }
+
+    private static string ResolveRuleId(CanonicalStatementRow row, StatementMatchingTolerance tolerance)
+    {
+        if (row.ActivityType.Equals("position", StringComparison.OrdinalIgnoreCase))
+        {
+            return tolerance.PositionToleranceRuleId;
+        }
+
+        return row.ActivityType.Equals("cash", StringComparison.OrdinalIgnoreCase)
+            ? tolerance.CashToleranceRuleId
+            : tolerance.TransactionToleranceRuleId;
+    }
+
+    private static decimal ResolveToleranceAmount(CanonicalStatementRow row, StatementMatchingTolerance tolerance)
+    {
+        if (row.ActivityType.Equals("cash", StringComparison.OrdinalIgnoreCase))
+        {
+            var basisPointTolerance = tolerance.BasisPointCashTolerance is { } basisPoints
+                ? Math.Abs(row.CashAmount) * Math.Abs(basisPoints) / 10_000m
+                : 0m;
+            return Math.Max(tolerance.CashAmountTolerance, basisPointTolerance);
+        }
+
+        if (row.ActivityType.Equals("position", StringComparison.OrdinalIgnoreCase))
+        {
+            return Math.Max(tolerance.PositionQuantityTolerance, Math.Max(tolerance.MarketValueTolerance, tolerance.PriceTolerance));
+        }
+
+        return Math.Max(tolerance.TransactionAmountTolerance, tolerance.PriceTolerance);
     }
 
     private static (bool,string,string,decimal) MatchPosition(CanonicalStatementRow row, StatementMatchingTolerance tolerance)
     {
         if (string.IsNullOrWhiteSpace(row.Symbol)) return (false, "POS_SYMBOL_MISSING", "Position row missing symbol.", 0.1m);
         if (Math.Abs(row.Quantity) <= tolerance.PositionQuantityTolerance) return (false, "POS_QTY_TOLERANCE_BREACH", "Position quantity within tolerance floor and treated as unresolved.", 0.3m);
-        return (true, "", "Position matched within configured tolerance.", 0.95m);
+        return (true, "", $"Position matched within configured tolerance rule {tolerance.PositionToleranceRuleId}.", 0.95m);
     }
 
     private static (bool,string,string,decimal) MatchCash(CanonicalStatementRow row, StatementMatchingTolerance tolerance)
     {
-        if (Math.Abs(row.CashAmount) <= tolerance.CashAmountTolerance) return (true, "", "Cash movement within tolerance.", 0.9m);
+        var basisPointTolerance = tolerance.BasisPointCashTolerance is { } basisPoints
+            ? Math.Abs(row.CashAmount) * Math.Abs(basisPoints) / 10_000m
+            : 0m;
+        var allowedTolerance = Math.Max(tolerance.CashAmountTolerance, basisPointTolerance);
+        if (Math.Abs(row.CashAmount) <= allowedTolerance) return (true, "", $"Cash movement within tolerance rule {tolerance.CashToleranceRuleId}.", 0.9m);
         return (false, "CASH_TOLERANCE_BREACH", "Cash movement exceeds configured tolerance.", 0.25m);
     }
 
     private static (bool,string,string,decimal) MatchTransaction(CanonicalStatementRow row, StatementMatchingTolerance tolerance)
     {
-        if (Math.Abs(row.Price * row.Quantity) <= tolerance.TransactionAmountTolerance) return (true, "", "Transaction amount within tolerance.", 0.85m);
+        if (Math.Abs(row.Price * row.Quantity) <= tolerance.TransactionAmountTolerance) return (true, "", $"Transaction amount within tolerance rule {tolerance.TransactionToleranceRuleId}.", 0.85m);
         return (false, "TXN_TOLERANCE_BREACH", "Transaction amount exceeds configured tolerance.", 0.25m);
     }
 }

--- a/tests/Meridian.Tests/Application/Reconciliation/CanonicalReconciliationMatchingEngineTests.cs
+++ b/tests/Meridian.Tests/Application/Reconciliation/CanonicalReconciliationMatchingEngineTests.cs
@@ -35,14 +35,115 @@ public sealed class CanonicalReconciliationMatchingEngineTests
         result.breaks.Should().ContainSingle(b => b.Classification == BreakClassification.TrueBreak && b.RuleId == "true-break-position-v1");
     }
 
+
+    [Fact]
+    public void Run_WhenPositionFallsInsideToleranceProfile_RecordsProfileAndRuleEvidence()
+    {
+        var engine = new ReconciliationMatchingEngine();
+        var profile = new StatementToleranceProfile(
+            "month-end-close",
+            3,
+            [],
+            [new PositionToleranceRule("pos-close-qty-price-mv-v3", 1m, 25m, 0.05m)],
+            []);
+        var run = CreateRun([
+            CreateSnapshot("prime", ReconciliationSourceType.Prime, [CreatePosition("p1", "AAPL", 10m, 100m, 1000m)]),
+            CreateSnapshot("custodian", ReconciliationSourceType.Custodian, [CreatePosition("p2", "AAPL", 10.5m, 100.01m, 1005m)])
+        ]);
+
+        var result = engine.Run(run, profile);
+
+        result.breaks.Should().BeEmpty();
+        result.matches.Should().ContainSingle(m =>
+            m.Classification == BreakClassification.MatchedWithinTolerance &&
+            m.ToleranceProfileId == "month-end-close" &&
+            m.ToleranceProfileVersion == 3 &&
+            m.ToleranceRuleId == "pos-close-qty-price-mv-v3");
+        result.evidence.Should().ContainSingle(e =>
+            e.RuleId == "pos-close-qty-price-mv-v3" &&
+            e.Attributes["toleranceRuleId"] == "pos-close-qty-price-mv-v3");
+    }
+
+    [Fact]
+    public void Run_WhenCashFallsInsideBasisPointTolerance_RecordsCashRuleEvidence()
+    {
+        var engine = new ReconciliationMatchingEngine();
+        var profile = new StatementToleranceProfile(
+            "cash-bps-close",
+            2,
+            [new CashToleranceRule("cash-bps-5-v2", 0.01m, 5m, TimeSpan.FromDays(1))],
+            [],
+            []);
+        var asOf = new DateTimeOffset(2026, 5, 28, 12, 0, 0, TimeSpan.Zero);
+        var run = CreateRun([
+            CreateSnapshot("prime", ReconciliationSourceType.Prime, [], [CreateCash("c1", 10000m, asOf)]),
+            CreateSnapshot("custodian", ReconciliationSourceType.Custodian, [], [CreateCash("c2", 10004m, asOf.AddHours(12))])
+        ]);
+
+        var result = engine.Run(run, profile);
+
+        result.breaks.Should().BeEmpty();
+        result.matches.Should().Contain(m =>
+            m.Classification == BreakClassification.MatchedWithinTolerance &&
+            m.ToleranceProfileId == "cash-bps-close" &&
+            m.ToleranceProfileVersion == 2 &&
+            m.ToleranceRuleId == "cash-bps-5-v2");
+        result.evidence.Should().Contain(e =>
+            e.RuleId == "cash-bps-5-v2" &&
+            e.Narrative.Contains("cash-bps-5-v2", StringComparison.Ordinal));
+    }
+
+
+    [Fact]
+    public async Task GetProfileAsync_WhenProfileRegistered_ReturnsLatestVersion()
+    {
+        var provider = new InMemoryStatementToleranceProfileProvider([
+            StatementToleranceProfile.Default,
+            new StatementToleranceProfile("ops", 1, [], [], []),
+            new StatementToleranceProfile("ops", 2, [], [], [])
+        ]);
+
+        var profile = await provider.GetProfileAsync("ops");
+
+        profile.Version.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetProfileAsync_WhenProfileMissing_ThrowsKeyNotFoundException()
+    {
+        var provider = new InMemoryStatementToleranceProfileProvider();
+
+        var act = async () => await provider.GetProfileAsync("missing-profile");
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task GetProfileAsync_WhenCancelled_ThrowsOperationCanceledException()
+    {
+        var provider = new InMemoryStatementToleranceProfileProvider();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var act = async () => await provider.GetProfileAsync(StatementToleranceProfile.DefaultProfileId, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
     private static MatchingTolerances CreateTolerances() => new(0m, 0m, 0m, 0m, TimeSpan.FromMinutes(5));
 
     private static ReconciliationRun CreateRun(IReadOnlyList<DataSourceSnapshot> snapshots) =>
         new(Guid.NewGuid(), new DateOnly(2026, 5, 28), DateTimeOffset.UtcNow, false, 1, "recon:2026-05-28", snapshots);
 
     private static DataSourceSnapshot CreateSnapshot(string id, ReconciliationSourceType sourceType, IReadOnlyList<NormalizedPosition> positions) =>
-        new(id, sourceType, DateTimeOffset.UtcNow, "v1", positions, Array.Empty<NormalizedCashEntry>());
+        CreateSnapshot(id, sourceType, positions, []);
+
+    private static DataSourceSnapshot CreateSnapshot(string id, ReconciliationSourceType sourceType, IReadOnlyList<NormalizedPosition> positions, IReadOnlyList<NormalizedCashEntry> cashEntries) =>
+        new(id, sourceType, DateTimeOffset.UtcNow, "v1", positions, cashEntries);
 
     private static NormalizedPosition CreatePosition(string id, string canonicalId, decimal quantity, decimal price, decimal marketValue) =>
         new(id, canonicalId, null, null, canonicalId, null, quantity, price, marketValue, "USD", DateTimeOffset.UtcNow, id);
+
+    private static NormalizedCashEntry CreateCash(string id, decimal amountBase, DateTimeOffset postedAtUtc) =>
+        new(id, "acct", amountBase, "USD", amountBase, "USD", postedAtUtc, new DateOnly(2026, 5, 28), id);
 }

--- a/tests/Meridian.Tests/Application/Reconciliation/CanonicalReconciliationMatchingEngineTests.cs
+++ b/tests/Meridian.Tests/Application/Reconciliation/CanonicalReconciliationMatchingEngineTests.cs
@@ -65,6 +65,38 @@ public sealed class CanonicalReconciliationMatchingEngineTests
     }
 
     [Fact]
+    public void Run_WhenTolerancePairLeavesPositionOutlier_EmitsToleranceMatchAndTrueBreak()
+    {
+        // Scenario: month-end broker/custodian position comparison where one near-match must not hide an extra lot.
+        var engine = new ReconciliationMatchingEngine();
+        var profile = new StatementToleranceProfile(
+            "month-end-close",
+            3,
+            [],
+            [new PositionToleranceRule("pos-close-qty-price-mv-v3", 0.10m, 10m, 0.10m)],
+            []);
+        var run = CreateRun([
+            CreateSnapshot("prime", ReconciliationSourceType.Prime, [CreatePosition("p1", "AAPL", 10m, 100m, 1000m)]),
+            CreateSnapshot("custodian", ReconciliationSourceType.Custodian,
+            [
+                CreatePosition("p2", "AAPL", 10.05m, 100.01m, 1005m),
+                CreatePosition("p3", "AAPL", 50m, 100m, 5000m)
+            ])
+        ]);
+
+        var result = engine.Run(run, profile);
+
+        result.matches.Should().ContainSingle(m =>
+            m.Classification == BreakClassification.MatchedWithinTolerance &&
+            m.ToleranceRuleId == "pos-close-qty-price-mv-v3" &&
+            m.PositionIds.OrderBy(static id => id).SequenceEqual(new[] { "p1", "p2" }));
+        result.breaks.Should().ContainSingle(b => b.Classification == BreakClassification.TrueBreak && b.RuleId == "true-break-position-v1");
+        result.evidence.Should().ContainSingle(e =>
+            e.RuleId == "true-break-position-v1" &&
+            e.Attributes["unresolvedPositionIds"] == "p3");
+    }
+
+    [Fact]
     public void Run_WhenCashFallsInsideBasisPointTolerance_RecordsCashRuleEvidence()
     {
         var engine = new ReconciliationMatchingEngine();

--- a/tests/Meridian.Tests/Reconciliation/StatementMatchingToleranceTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/StatementMatchingToleranceTests.cs
@@ -21,4 +21,32 @@ public sealed class StatementMatchingToleranceTests
         Assert.Equal("CASH_TOLERANCE_BREACH", outcomes[1].OutcomeType);
         Assert.Equal("TXN_TOLERANCE_BREACH", outcomes[2].OutcomeType);
     }
+
+    [Fact]
+    public void MatchRows_WhenToleranceAllowsMatch_EmbedsProfileVersionAndRuleIdInExplanation()
+    {
+        var tolerance = StatementMatchingTolerance.Default with
+        {
+            ToleranceProfileId = "ops-cash-profile",
+            ToleranceProfileVersion = 4,
+            CashToleranceRuleId = "cash-absolute-ops-v4",
+            BasisPointCashTolerance = 10m
+        };
+        var rows = new[]
+        {
+            new CanonicalStatementRow("i", 1, "acct", "SPY", 0m, 0m, 0.005m, "cash", new DateOnly(2026, 1, 1), "cash-row")
+        };
+
+        var outcomes = new StatementMatchingService().MatchRows(rows, tolerance);
+
+        Assert.Collection(outcomes, outcome =>
+        {
+            Assert.Equal("matched", outcome.OutcomeType);
+            Assert.Equal("ops-cash-profile", outcome.ToleranceProfileId);
+            Assert.Equal(4, outcome.ToleranceProfileVersion);
+            Assert.Equal("cash-absolute-ops-v4", outcome.ToleranceRuleId);
+            Assert.Contains("cash-absolute-ops-v4", outcome.Rationale, StringComparison.Ordinal);
+        });
+    }
+
 }


### PR DESCRIPTION
### Motivation
- Provide a versioned tolerance-profile model so reconciliation can express cash, position, and transaction tolerances (absolute and basis-point), settlement-date windows, and price/market-value tolerances.
- Ensure reconciliation runs and match results carry the tolerance profile ID and version so operator/UI and downstream systems can trace why a match was allowed.
- Record the specific tolerance rule that permitted a match so explanations and audit evidence are unambiguous.

### Description
- Added profile models and provider: `StatementToleranceProfile`, `CashToleranceRule`, `PositionToleranceRule`, `TransactionToleranceRule`, and `IStatementToleranceProfileProvider` with `InMemoryStatementToleranceProfileProvider` at `src/Meridian.Application/Reconciliation/StatementToleranceProfiles.cs` and supporting helpers for rule evaluation.
- Extended domain and contract records to carry tolerance metadata by adding `ToleranceProfileId` and `ToleranceProfileVersion` (and optional `ToleranceRuleId` where applicable) to runs, match groups, match outcomes, and statement-run types in `src/Meridian.Domain/Reconciliation/*` and `src/Meridian.Contracts/Domain/Reconciliation/ReconciliationDomainModels.cs`.
- Reconciler integration: updated `ReconciliationMatchingEngine` to accept or derive a `StatementToleranceProfile`, stamp the run with profile/version, evaluate position/cash tolerance rules, and produce evidence that includes the rule ID; added helper methods `FindCashToleranceRule` and `TryFindPositionToleranceMatch` in `src/Meridian.Application/Reconciliation/CanonicalReconciliationEngine.cs`.
- Statement matcher: updated `StatementMatchingService` to resolve rule IDs, embed `ToleranceProfileId`/`ToleranceProfileVersion`/`ToleranceRuleId` on `MatchOutcome`, and include the rule ID in the match rationale in `src/Meridian.Infrastructure/Reconciliation/BrokerStatementInfrastructure.cs`.
- Application seam: `StatementReconciliationService` now emits `ReconciliationMatchLink` entries annotated with default profile/rule info for deterministic position matches.
- Tests and docs: added unit tests covering profile lookup and tolerance-evidence behavior and updated `src/Meridian.Application/README.md` to document the reconciliation tolerance contract.

### Testing
- Ran `git diff --check` which returned no spacing/blank-line errors after adjustments (passed).
- Ran `python3 build/scripts/docs/validate-source-readmes.py --summary` (passed with 0 errors/warnings).
- Ran the implementation-assurance scoring helper `python3 .codex/skills/meridian-implementation-assurance/scripts/score_eval.py` with a prepared rubric which succeeded and produced a score block (pass); the run recorded that `dotnet` was not available in this environment.
- Attempted targeted `dotnet test` for the new/changed reconciliation tests (filtering `CanonicalReconciliationMatchingEngineTests` and `StatementMatchingToleranceTests`) but the command could not run because `dotnet` is not installed in this environment (blocked).
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary` which reported repository-wide source-hash drift as expected after adding/altering `src/**` files; this requires a docs/hash refresh in CI or a follow-up doc-render step.

Notes: added unit tests that exercise the new tolerance-profile behavior, but they were not executed locally due to the missing .NET SDK; please run `dotnet test tests/Meridian.Tests --filter "FullyQualifiedName~CanonicalReconciliationMatchingEngineTests|FullyQualifiedName~StatementMatchingToleranceTests"` in a developer/CI environment to validate all new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a188ee5ec008320959e74f5473f5b65)