### PR TITLE
Add statement break classifier

### DIFF
--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -25,6 +25,8 @@ and UI presentation concerns in their owning layers.
 ## Key folders and files
 
 - `Commands/` - CLI command handlers and operator workflows.
+- `Reconciliation/` - statement intake, canonical matching, materiality-aware break
+  classification, recommended actions, and case creation gates.
 - `OperationsContinuity/` - account-period continuity aggregate, command transitions, audit
   timeline, and server-derived gate status for broker, Security Master, ledger, reconciliation,
   and approval close lanes. Approval and close commands enforce shared close-checklist control
@@ -44,6 +46,9 @@ application service contracts consumed by host and UI surfaces.
 
 ## API contract notes
 
+- Statement reconciliation classifies broker and custodian breaks before case creation; only
+  material unresolved breaks are promoted into casework, with severity and recommended action
+  stored in the classification result.
 - Options-chain provider IDs are normalized with trim plus invariant lowercase before deduplication, health lookup, fallback detection, logging, and metrics.
 
 ## Diagrams

--- a/src/Meridian.Application/Reconciliation/StatementBreakClassifier.cs
+++ b/src/Meridian.Application/Reconciliation/StatementBreakClassifier.cs
@@ -1,0 +1,251 @@
+using Meridian.Contracts.Workstation;
+using Meridian.Domain.Reconciliation;
+
+namespace Meridian.Application.Reconciliation;
+
+/// <summary>
+/// Canonical statement reconciliation break types used by broker, custodian, and internal ledger workflows.
+/// </summary>
+public enum StatementBreakClassificationType : byte
+{
+    MissingInternalPosition = 0,
+    MissingBrokerPosition = 1,
+    PositionQuantityVariance = 2,
+    CashBalanceVariance = 3,
+    MissingInternalTransaction = 4,
+    MissingBrokerTransaction = 5,
+    TransactionTimingVariance = 6,
+    SecurityMappingBreak = 7,
+    AccountMappingBreak = 8,
+    CurrencyMismatch = 9,
+    FeeOrTaxVariance = 10
+}
+
+/// <summary>
+/// Recommended operator action for a classified statement reconciliation break.
+/// </summary>
+public enum StatementBreakRecommendedAction : byte
+{
+    MapSecurity = 0,
+    ReviewCashPosting = 1,
+    InspectLedgerTransaction = 2,
+    VerifySettlementDate = 3,
+    RequestBrokerClarification = 4
+}
+
+/// <summary>
+/// Materiality and workflow settings used to decide severity and whether a break should become casework.
+/// </summary>
+public sealed record StatementBreakWorkflowPolicy(
+    decimal PositionQuantityMateriality = 0.0001m,
+    decimal CashMateriality = 0.01m,
+    decimal TransactionMateriality = 0.01m,
+    decimal FeeOrTaxMateriality = 0.01m,
+    bool CreateCasesForLowSeverityBreaks = false)
+{
+    public static StatementBreakWorkflowPolicy Default { get; } = new();
+}
+
+/// <summary>
+/// Input evidence for a single broker statement break classification.
+/// </summary>
+public sealed record StatementBreakClassificationRequest(
+    StatementBreakClassificationType BreakType,
+    decimal? StatementAmount = null,
+    decimal? InternalAmount = null,
+    decimal? QuantityDelta = null,
+    string? StatementCurrency = null,
+    string? InternalCurrency = null,
+    string Status = "Open",
+    bool IsOptionalMetadata = false,
+    StatementBreakWorkflowPolicy? Policy = null)
+{
+    public static StatementBreakClassificationRequest FromStatementRow(NormalizedStatementRow row)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+
+        var breakType = row.Kind switch
+        {
+            StatementRowKind.CashBalance => StatementBreakClassificationType.CashBalanceVariance,
+            StatementRowKind.Fee => StatementBreakClassificationType.FeeOrTaxVariance,
+            StatementRowKind.Transaction or StatementRowKind.Dividend => StatementBreakClassificationType.MissingInternalTransaction,
+            _ when string.IsNullOrWhiteSpace(row.Symbol) => StatementBreakClassificationType.SecurityMappingBreak,
+            _ => StatementBreakClassificationType.PositionQuantityVariance
+        };
+
+        return new StatementBreakClassificationRequest(
+            breakType,
+            StatementAmount: row.Amount,
+            InternalAmount: null,
+            QuantityDelta: row.Quantity,
+            StatementCurrency: row.Currency,
+            InternalCurrency: row.RawSnapshot.TryGetValue("internalCurrency", out var internalCurrency) ? internalCurrency : row.Currency,
+            Status: row.RawSnapshot.TryGetValue("status", out var status) ? status : "Open",
+            IsOptionalMetadata: row.RawSnapshot.TryGetValue("optionalMetadata", out var optionalMetadata)
+                && bool.TryParse(optionalMetadata, out var parsedOptionalMetadata)
+                && parsedOptionalMetadata);
+    }
+}
+
+/// <summary>
+/// Classification output stored on a break and consumed by case queue creation.
+/// </summary>
+public sealed record StatementBreakClassificationResult(
+    StatementBreakClassificationType BreakType,
+    ReconciliationBreakSeverity Severity,
+    StatementBreakRecommendedAction RecommendedAction,
+    string RecommendedActionText,
+    bool IsMaterial,
+    bool IsUnresolved,
+    bool ShouldCreateCaseQueueItem,
+    decimal AbsoluteVariance,
+    string WorkflowRationale);
+
+/// <summary>
+/// Assigns canonical break type, materiality-aware severity, and operator guidance for statement reconciliation breaks.
+/// </summary>
+public sealed class StatementBreakClassifier
+{
+    public StatementBreakClassificationResult Classify(StatementBreakClassificationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var policy = request.Policy ?? StatementBreakWorkflowPolicy.Default;
+        var absoluteVariance = CalculateAbsoluteVariance(request);
+        var currencyMismatch = HasCurrencyMismatch(request);
+        var isMaterial = IsMaterial(request, policy, absoluteVariance, currencyMismatch);
+        var severity = ResolveSeverity(request, isMaterial, currencyMismatch);
+        var action = ResolveRecommendedAction(request.BreakType);
+        var isUnresolved = IsUnresolved(request.Status);
+        var shouldCreateCase = isMaterial
+            && isUnresolved
+            && (severity >= ReconciliationBreakSeverity.Medium || policy.CreateCasesForLowSeverityBreaks);
+
+        return new StatementBreakClassificationResult(
+            request.BreakType,
+            severity,
+            action,
+            ToRecommendedActionText(action),
+            isMaterial,
+            isUnresolved,
+            shouldCreateCase,
+            absoluteVariance,
+            BuildRationale(request.BreakType, severity, action, isMaterial, isUnresolved));
+    }
+
+    private static decimal CalculateAbsoluteVariance(StatementBreakClassificationRequest request)
+    {
+        if (request.QuantityDelta.HasValue && IsPositionBreak(request.BreakType))
+        {
+            return Math.Abs(request.QuantityDelta.Value);
+        }
+
+        if (request.StatementAmount.HasValue && request.InternalAmount.HasValue)
+        {
+            return Math.Abs(request.StatementAmount.Value - request.InternalAmount.Value);
+        }
+
+        if (request.StatementAmount.HasValue)
+        {
+            return Math.Abs(request.StatementAmount.Value);
+        }
+
+        if (request.InternalAmount.HasValue)
+        {
+            return Math.Abs(request.InternalAmount.Value);
+        }
+
+        return 0m;
+    }
+
+    private static bool HasCurrencyMismatch(StatementBreakClassificationRequest request) =>
+        request.BreakType == StatementBreakClassificationType.CurrencyMismatch
+        || (!string.IsNullOrWhiteSpace(request.StatementCurrency)
+            && !string.IsNullOrWhiteSpace(request.InternalCurrency)
+            && !string.Equals(request.StatementCurrency.Trim(), request.InternalCurrency.Trim(), StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsMaterial(
+        StatementBreakClassificationRequest request,
+        StatementBreakWorkflowPolicy policy,
+        decimal absoluteVariance,
+        bool currencyMismatch) => request.BreakType switch
+        {
+            StatementBreakClassificationType.SecurityMappingBreak or StatementBreakClassificationType.AccountMappingBreak
+                => !request.IsOptionalMetadata,
+            StatementBreakClassificationType.CurrencyMismatch => currencyMismatch,
+            StatementBreakClassificationType.MissingInternalPosition or StatementBreakClassificationType.MissingBrokerPosition
+                => absoluteVariance >= policy.PositionQuantityMateriality,
+            StatementBreakClassificationType.PositionQuantityVariance => absoluteVariance >= policy.PositionQuantityMateriality,
+            StatementBreakClassificationType.CashBalanceVariance => absoluteVariance >= policy.CashMateriality,
+            StatementBreakClassificationType.MissingInternalTransaction or StatementBreakClassificationType.MissingBrokerTransaction
+                => absoluteVariance >= policy.TransactionMateriality,
+            StatementBreakClassificationType.TransactionTimingVariance => true,
+            StatementBreakClassificationType.FeeOrTaxVariance => absoluteVariance >= policy.FeeOrTaxMateriality,
+            _ => false
+        };
+
+    private static ReconciliationBreakSeverity ResolveSeverity(
+        StatementBreakClassificationRequest request,
+        bool isMaterial,
+        bool currencyMismatch) => request.BreakType switch
+        {
+            StatementBreakClassificationType.SecurityMappingBreak or StatementBreakClassificationType.AccountMappingBreak
+                when request.IsOptionalMetadata => ReconciliationBreakSeverity.Low,
+            StatementBreakClassificationType.SecurityMappingBreak or StatementBreakClassificationType.AccountMappingBreak
+                => ReconciliationBreakSeverity.High,
+            StatementBreakClassificationType.CurrencyMismatch when currencyMismatch => ReconciliationBreakSeverity.High,
+            StatementBreakClassificationType.MissingInternalPosition or StatementBreakClassificationType.MissingBrokerPosition or StatementBreakClassificationType.PositionQuantityVariance
+                => isMaterial ? ReconciliationBreakSeverity.High : ReconciliationBreakSeverity.Low,
+            StatementBreakClassificationType.CashBalanceVariance
+                => isMaterial ? ReconciliationBreakSeverity.High : ReconciliationBreakSeverity.Low,
+            StatementBreakClassificationType.TransactionTimingVariance or StatementBreakClassificationType.FeeOrTaxVariance
+                => isMaterial ? ReconciliationBreakSeverity.Medium : ReconciliationBreakSeverity.Low,
+            StatementBreakClassificationType.MissingInternalTransaction or StatementBreakClassificationType.MissingBrokerTransaction
+                => isMaterial ? ReconciliationBreakSeverity.Medium : ReconciliationBreakSeverity.Low,
+            _ => ReconciliationBreakSeverity.Low
+        };
+
+    private static StatementBreakRecommendedAction ResolveRecommendedAction(StatementBreakClassificationType breakType) => breakType switch
+    {
+        StatementBreakClassificationType.SecurityMappingBreak => StatementBreakRecommendedAction.MapSecurity,
+        StatementBreakClassificationType.AccountMappingBreak => StatementBreakRecommendedAction.RequestBrokerClarification,
+        StatementBreakClassificationType.CashBalanceVariance or StatementBreakClassificationType.CurrencyMismatch => StatementBreakRecommendedAction.ReviewCashPosting,
+        StatementBreakClassificationType.TransactionTimingVariance => StatementBreakRecommendedAction.VerifySettlementDate,
+        StatementBreakClassificationType.MissingInternalTransaction or StatementBreakClassificationType.MissingBrokerTransaction or StatementBreakClassificationType.FeeOrTaxVariance
+            => StatementBreakRecommendedAction.InspectLedgerTransaction,
+        _ => StatementBreakRecommendedAction.RequestBrokerClarification
+    };
+
+    public static string ToRecommendedActionText(StatementBreakRecommendedAction action) => action switch
+    {
+        StatementBreakRecommendedAction.MapSecurity => "map security",
+        StatementBreakRecommendedAction.ReviewCashPosting => "review cash posting",
+        StatementBreakRecommendedAction.InspectLedgerTransaction => "inspect ledger transaction",
+        StatementBreakRecommendedAction.VerifySettlementDate => "verify settlement date",
+        StatementBreakRecommendedAction.RequestBrokerClarification => "request broker clarification",
+        _ => "request broker clarification"
+    };
+
+    public static bool IsUnresolved(string? status) => status switch
+    {
+        null => true,
+        _ when status.Equals("Open", StringComparison.OrdinalIgnoreCase) => true,
+        _ when status.Equals("Investigating", StringComparison.OrdinalIgnoreCase) => true,
+        _ when status.Equals("InReview", StringComparison.OrdinalIgnoreCase) => true,
+        _ when status.Equals("PartialMatch", StringComparison.OrdinalIgnoreCase) => true,
+        _ => false
+    };
+
+    private static bool IsPositionBreak(StatementBreakClassificationType breakType) => breakType is
+        StatementBreakClassificationType.MissingInternalPosition or
+        StatementBreakClassificationType.MissingBrokerPosition or
+        StatementBreakClassificationType.PositionQuantityVariance;
+
+    private static string BuildRationale(
+        StatementBreakClassificationType breakType,
+        ReconciliationBreakSeverity severity,
+        StatementBreakRecommendedAction action,
+        bool isMaterial,
+        bool isUnresolved) =>
+        $"{breakType} classified as {severity}; material={isMaterial}; unresolved={isUnresolved}; recommended action={action}.";
+}

--- a/src/Meridian.Application/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.Application/Reconciliation/StatementReconciliationService.cs
@@ -1,9 +1,11 @@
+using Meridian.Contracts.Workstation;
 using Meridian.Domain.Reconciliation;
 
 namespace Meridian.Application.Reconciliation;
 
 public sealed class StatementReconciliationService
 {
+    private readonly StatementBreakClassifier _breakClassifier = new();
     private static readonly string[] CanonicalStatementColumns =
     [
         "account",
@@ -211,18 +213,24 @@ public sealed class StatementReconciliationService
                 continue;
             }
 
+            var classification = _breakClassifier.Classify(StatementBreakClassificationRequest.FromStatementRow(row));
+            if (!classification.ShouldCreateCaseQueueItem)
+            {
+                continue;
+            }
+
             cases.Add(new ReconciliationCase(
                 $"case:{row.RowId}",
                 row.Fingerprint,
                 "Open",
-                "No deterministic match candidate met confidence threshold.",
+                classification.WorkflowRationale,
                 0.35m,
-                "No deterministic match candidate met confidence threshold.",
+                classification.WorkflowRationale,
                 DateTimeOffset.UtcNow,
                 [new ReconciliationCaseHistoryEntry(DateTimeOffset.UtcNow, "None", "Open", "Case created from statement reconciliation service.")])
             {
                 Owner = "fund-ops",
-                Priority = row.Kind is StatementRowKind.CashBalance or StatementRowKind.Transaction ? "High" : "Normal",
+                Priority = ToCasePriority(classification.Severity),
                 DueAtUtc = DateTimeOffset.UtcNow.AddBusinessDays(2),
                 CommentThreads =
                 [
@@ -232,7 +240,7 @@ public sealed class StatementReconciliationService
                         [
                             new ReconciliationCaseComment(
                                 Guid.NewGuid().ToString("N"),
-                                $"Created from {row.RawSnapshot.GetValueOrDefault("sourceKind", "external")} statement row {row.RawSnapshot.GetValueOrDefault("rowNumber", row.RowId)}.",
+                                $"Created from {row.RawSnapshot.GetValueOrDefault("sourceKind", "external")} statement row {row.RawSnapshot.GetValueOrDefault("rowNumber", row.RowId)}. Recommended action: {classification.RecommendedActionText}.",
                                 "system",
                                 DateTimeOffset.UtcNow)
                         ])
@@ -244,13 +252,20 @@ public sealed class StatementReconciliationService
                         "ExternalStatementCaseCreated",
                         DateTimeOffset.UtcNow,
                         "system",
-                        "Case created from broker/custodian statement intake.")
+                        $"Case created for {classification.BreakType} with {classification.Severity} severity.")
                 ]
             });
         }
 
         return (matches, cases);
     }
+
+    private static string ToCasePriority(ReconciliationBreakSeverity severity) => severity switch
+    {
+        ReconciliationBreakSeverity.High or ReconciliationBreakSeverity.Critical => "High",
+        ReconciliationBreakSeverity.Medium => "Normal",
+        _ => "Low"
+    };
 }
 
 public sealed record ExternalStatementCaseIntakeResult(

--- a/tests/Meridian.Tests/Reconciliation/StatementBreakClassifierTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/StatementBreakClassifierTests.cs
@@ -1,0 +1,130 @@
+using Meridian.Application.Reconciliation;
+using Meridian.Contracts.Workstation;
+using Meridian.Domain.Reconciliation;
+
+namespace Meridian.Tests.Reconciliation;
+
+public sealed class StatementBreakClassifierTests
+{
+    [Theory]
+    [InlineData(StatementBreakClassificationType.MissingInternalPosition)]
+    [InlineData(StatementBreakClassificationType.MissingBrokerPosition)]
+    [InlineData(StatementBreakClassificationType.PositionQuantityVariance)]
+    [InlineData(StatementBreakClassificationType.CashBalanceVariance)]
+    [InlineData(StatementBreakClassificationType.MissingInternalTransaction)]
+    [InlineData(StatementBreakClassificationType.MissingBrokerTransaction)]
+    [InlineData(StatementBreakClassificationType.TransactionTimingVariance)]
+    [InlineData(StatementBreakClassificationType.SecurityMappingBreak)]
+    [InlineData(StatementBreakClassificationType.AccountMappingBreak)]
+    [InlineData(StatementBreakClassificationType.CurrencyMismatch)]
+    [InlineData(StatementBreakClassificationType.FeeOrTaxVariance)]
+    public void Classify_SupportsCanonicalStatementBreakTypes(StatementBreakClassificationType breakType)
+    {
+        var classifier = new StatementBreakClassifier();
+
+        var result = classifier.Classify(new StatementBreakClassificationRequest(
+            breakType,
+            StatementAmount: 100m,
+            InternalAmount: 0m,
+            QuantityDelta: 1m,
+            StatementCurrency: "USD",
+            InternalCurrency: breakType == StatementBreakClassificationType.CurrencyMismatch ? "EUR" : "USD"));
+
+        Assert.Equal(breakType, result.BreakType);
+        Assert.NotEqual(default, result.WorkflowRationale);
+    }
+
+    [Theory]
+    [InlineData(StatementBreakClassificationType.MissingInternalPosition)]
+    [InlineData(StatementBreakClassificationType.MissingBrokerPosition)]
+    [InlineData(StatementBreakClassificationType.PositionQuantityVariance)]
+    [InlineData(StatementBreakClassificationType.CashBalanceVariance)]
+    public void Classify_AssignsHighSeverityToMaterialCashAndPositionBreaks(StatementBreakClassificationType breakType)
+    {
+        var classifier = new StatementBreakClassifier();
+
+        var result = classifier.Classify(new StatementBreakClassificationRequest(
+            breakType,
+            StatementAmount: 125m,
+            InternalAmount: 0m,
+            QuantityDelta: 5m));
+
+        Assert.Equal(ReconciliationBreakSeverity.High, result.Severity);
+        Assert.True(result.IsMaterial);
+        Assert.True(result.ShouldCreateCaseQueueItem);
+    }
+
+    [Theory]
+    [InlineData(StatementBreakClassificationType.TransactionTimingVariance, StatementBreakRecommendedAction.VerifySettlementDate)]
+    [InlineData(StatementBreakClassificationType.FeeOrTaxVariance, StatementBreakRecommendedAction.InspectLedgerTransaction)]
+    public void Classify_AssignsMediumSeverityToTransactionTimingAndFeeDifferences(
+        StatementBreakClassificationType breakType,
+        StatementBreakRecommendedAction expectedAction)
+    {
+        var classifier = new StatementBreakClassifier();
+
+        var result = classifier.Classify(new StatementBreakClassificationRequest(
+            breakType,
+            StatementAmount: 25m,
+            InternalAmount: 0m));
+
+        Assert.Equal(ReconciliationBreakSeverity.Medium, result.Severity);
+        Assert.Equal(expectedAction, result.RecommendedAction);
+        Assert.True(result.ShouldCreateCaseQueueItem);
+    }
+
+    [Theory]
+    [InlineData(StatementBreakClassificationType.SecurityMappingBreak)]
+    [InlineData(StatementBreakClassificationType.AccountMappingBreak)]
+    public void Classify_AssignsLowSeverityToOptionalUnmappedMetadataAndSuppressesCaseQueue(
+        StatementBreakClassificationType breakType)
+    {
+        var classifier = new StatementBreakClassifier();
+
+        var result = classifier.Classify(new StatementBreakClassificationRequest(
+            breakType,
+            IsOptionalMetadata: true));
+
+        Assert.Equal(ReconciliationBreakSeverity.Low, result.Severity);
+        Assert.False(result.IsMaterial);
+        Assert.False(result.ShouldCreateCaseQueueItem);
+    }
+
+    [Fact]
+    public void Classify_SuppressesCaseQueueForResolvedMaterialBreaks()
+    {
+        var classifier = new StatementBreakClassifier();
+
+        var result = classifier.Classify(new StatementBreakClassificationRequest(
+            StatementBreakClassificationType.CashBalanceVariance,
+            StatementAmount: 100m,
+            InternalAmount: 0m,
+            Status: "Resolved"));
+
+        Assert.True(result.IsMaterial);
+        Assert.False(result.IsUnresolved);
+        Assert.False(result.ShouldCreateCaseQueueItem);
+    }
+
+    [Fact]
+    public void FromStatementRow_ClassifiesCashRowsForCashPostingReview()
+    {
+        var row = new NormalizedStatementRow(
+            "row-1",
+            StatementRowKind.CashBalance,
+            string.Empty,
+            0m,
+            250m,
+            DateTimeOffset.UtcNow,
+            "USD",
+            "fingerprint",
+            new Dictionary<string, string>());
+
+        var result = new StatementBreakClassifier().Classify(StatementBreakClassificationRequest.FromStatementRow(row));
+
+        Assert.Equal(StatementBreakClassificationType.CashBalanceVariance, result.BreakType);
+        Assert.Equal(StatementBreakRecommendedAction.ReviewCashPosting, result.RecommendedAction);
+        Assert.Equal("review cash posting", result.RecommendedActionText);
+        Assert.True(result.ShouldCreateCaseQueueItem);
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a canonical, materiality-aware classifier for statement reconciliation breaks so the system can assign break type, severity, and recommended operator action and only promote material unresolved breaks into casework.

### Description
- Add `StatementBreakClassifier` and related types in `src/Meridian.Application/Reconciliation/StatementBreakClassifier.cs`, implementing the requested canonical break types, `StatementBreakWorkflowPolicy` materiality settings, severity rules (high for cash/position material breaks, medium for timing/fee differences, low for optional unmapped metadata), unresolved detection, and recommended actions (`map security`, `review cash posting`, `inspect ledger transaction`, `verify settlement date`, `request broker clarification`).
- Wire the classifier into `StatementReconciliationService.MatchRows` in `src/Meridian.Application/Reconciliation/StatementReconciliationService.cs` to gate case creation so only material unresolved breaks create case queue items and to populate case rationale, severity-derived priority mapping, and recommended-action text in case comments and audit events.
- Add focused xUnit tests in `tests/Meridian.Tests/Reconciliation/StatementBreakClassifierTests.cs` covering all canonical break types, materiality/severity rules, optional-unmapped suppression, resolved-break suppression, and `FromStatementRow` mapping, and update `src/Meridian.Application/README.md` to document the reconciliation classification/case-creation gate.

### Testing
- Ran repository consistency check with `git diff --check`, which passed.
- Ran the evaluation dry-run with `python3 .codex/skills/meridian-implementation-assurance/scripts/run_evals.py --all --dry-run --json`, which completed successfully.
- Ran the assurance rubric `score_eval.py` to produce a summary; automated `.NET` unit tests targeted at `StatementBreakClassifierTests` could not be executed in this environment because the `dotnet` CLI is not installed, and the follow-up is to run `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~StatementBreakClassifierTests|FullyQualifiedName~StatementReconciliationServiceTests" /p:EnableWindowsTargeting=true --logger "console;verbosity=normal"` in an environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1891129d0c83208ecb1f7fcaef5a54)