### PR TITLE
Seed statement-originated breaks into reconciliation queue with source metadata and audit events

### DIFF
--- a/src/Meridian.Contracts/README.md
+++ b/src/Meridian.Contracts/README.md
@@ -76,7 +76,7 @@ Direct lending command result codes distinguish validation failures, missing agg
 optimistic concurrency conflicts, and idempotency/command conflicts so persistence stores can return
 operator-safe failure reasons without parsing exception text.
 
-Accounting reconciliation casework contracts are shared here: break queue items carry assignee, priority, SLA policy/state/timestamps, age band, taxonomy, threaded comments, evidence counts, sign-off/reopen metadata, and optimistic concurrency versions. New casework command, bulk-triage, SLA policy, and audit-compatible payloads must remain additive so browser and WPF workstation clients use the same Accounting workflow.
+Accounting reconciliation casework contracts are shared here: break queue items carry assignee, priority, SLA policy/state/timestamps, age band, taxonomy, threaded comments, evidence counts, sign-off/reopen metadata, source-origin metadata, and optimistic concurrency versions. New casework command, bulk-triage, SLA policy, and audit-compatible payloads must remain additive so browser and WPF workstation clients use the same Accounting workflow.
 
 ## Diagrams
 

--- a/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
+++ b/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
@@ -423,7 +423,13 @@ public sealed record ReconciliationBreakQueueItem(
     IReadOnlyList<string>? EvidenceLinks = null,
     int CommentCount = 0,
     int EvidenceCount = 0,
-    DateTimeOffset? LastActivityAt = null);
+    DateTimeOffset? LastActivityAt = null,
+    string? SourceType = null,
+    string? SourceSystem = null,
+    string? SourceReference = null,
+    string? SourceImportId = null,
+    string? SourceBreakId = null,
+    string? SourceFingerprint = null);
 
 
 public sealed record ReconciliationCaseComment(

--- a/src/Meridian.Strategies/README.md
+++ b/src/Meridian.Strategies/README.md
@@ -29,7 +29,7 @@ This layer should preserve strategy lineage from research through paper validati
 ## Important workflows
 
 Use this module for strategy run evidence, promotion lineage, and research-to-paper continuity.
-Reconciliation break queue persistence also owns shared Accounting casework lifecycle enforcement: assignment before investigation, evidence notes for awaiting-evidence, taxonomy before resolution, dual-control sign-off, privileged reopen, SLA computation, immutable audit events, threaded comments, and idempotent bulk triage.
+Reconciliation break queue persistence also owns shared Accounting casework lifecycle enforcement: assignment before investigation, evidence notes for awaiting-evidence, taxonomy before resolution, dual-control sign-off, privileged reopen, SLA computation, immutable audit events with source metadata, threaded comments, and idempotent bulk triage.
 Reconciliation also projects Security Master accounting inputs for Operations Continuity: fixed
 coupon accruals, expected journal previews, and factor-schedule principal paydowns are generated
 from resolved Security Master economic definitions before ledger/reconciliation gate posture is

--- a/src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs
+++ b/src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs
@@ -113,7 +113,9 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 UpstreamSyncCursor: item.UpstreamSyncCursor,
                 Actor: item.AssignedTo ?? item.ReviewedBy ?? item.ResolvedBy,
                 BeforePayload: null,
-                AfterPayload: JsonSerializer.Serialize(item, _jsonOptions)), ct).ConfigureAwait(false);
+                AfterPayload: JsonSerializer.Serialize(item, _jsonOptions),
+                Source: item.SourceType,
+                Reason: item.SourceReference), ct).ConfigureAwait(false);
 
             return true;
         }
@@ -209,6 +211,35 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
             updated = StampComputedFields(updated, now);
             _items[request.BreakId] = updated;
             await PersistSnapshotAsync(ct).ConfigureAwait(false);
+            if (!string.Equals(item.AssignedTo, updated.AssignedTo, StringComparison.OrdinalIgnoreCase))
+            {
+                await AppendAuditAsync(new ReconciliationBreakQueueAuditEvent(
+                    EventId: Guid.NewGuid().ToString("N"),
+                    BreakId: request.BreakId,
+                    EventType: "Assigned",
+                    PreviousStatus: item.Status,
+                    NewStatus: updated.Status,
+                    PreviousLifecycleState: item.LifecycleState,
+                    NewLifecycleState: updated.LifecycleState,
+                    OccurredAt: now,
+                    AssignedTo: request.AssignedTo,
+                    ReviewedBy: request.ReviewedBy,
+                    ResolvedBy: null,
+                    Note: request.ReviewNote,
+                    ExceptionRoute: updated.ExceptionRoute,
+                    ToleranceBand: updated.ToleranceBand,
+                    RequiredSignoffRole: updated.RequiredSignoffRole,
+                    SignoffStatus: updated.SignoffStatus,
+                    ExternalAccountId: updated.ExternalAccountId,
+                    CustodianId: updated.CustodianId,
+                    UpstreamSyncCursor: updated.UpstreamSyncCursor,
+                    Actor: request.ReviewedBy,
+                    BeforePayload: JsonSerializer.Serialize(item, _jsonOptions),
+                    AfterPayload: JsonSerializer.Serialize(updated, _jsonOptions),
+                    Source: updated.SourceType,
+                    Reason: updated.SourceReference), ct).ConfigureAwait(false);
+            }
+
             await AppendAuditAsync(new ReconciliationBreakQueueAuditEvent(
                 EventId: Guid.NewGuid().ToString("N"),
                 BreakId: request.BreakId,
@@ -231,7 +262,9 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 UpstreamSyncCursor: updated.UpstreamSyncCursor,
                 Actor: request.ReviewedBy,
                 BeforePayload: JsonSerializer.Serialize(item, _jsonOptions),
-                AfterPayload: JsonSerializer.Serialize(updated, _jsonOptions)), ct).ConfigureAwait(false);
+                AfterPayload: JsonSerializer.Serialize(updated, _jsonOptions),
+                Source: updated.SourceType,
+                Reason: updated.SourceReference), ct).ConfigureAwait(false);
 
             return new ReconciliationBreakQueueTransitionResult(ReconciliationBreakQueueTransitionStatus.Success, updated);
         }
@@ -312,7 +345,7 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
             await AppendAuditAsync(new ReconciliationBreakQueueAuditEvent(
                 EventId: Guid.NewGuid().ToString("N"),
                 BreakId: request.BreakId,
-                EventType: request.Status == ReconciliationBreakQueueStatus.Resolved ? "Resolved" : "Closed",
+                EventType: request.Status == ReconciliationBreakQueueStatus.Resolved ? "Resolved" : "Dismissed",
                 PreviousStatus: item.Status,
                 NewStatus: updated.Status,
                 PreviousLifecycleState: item.LifecycleState,
@@ -331,7 +364,9 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 UpstreamSyncCursor: updated.UpstreamSyncCursor,
                 Actor: request.ResolvedBy,
                 BeforePayload: JsonSerializer.Serialize(item, _jsonOptions),
-                AfterPayload: JsonSerializer.Serialize(updated, _jsonOptions)), ct).ConfigureAwait(false);
+                AfterPayload: JsonSerializer.Serialize(updated, _jsonOptions),
+                Source: updated.SourceType,
+                Reason: updated.SourceReference), ct).ConfigureAwait(false);
 
             return new ReconciliationBreakQueueTransitionResult(ReconciliationBreakQueueTransitionStatus.Success, updated);
         }
@@ -730,7 +765,7 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
     private static string ToAuditEventType(ReconciliationCaseworkAction action)
         => action switch
         {
-            ReconciliationCaseworkAction.Assign => "AssigneeChanged",
+            ReconciliationCaseworkAction.Assign => "Assigned",
             ReconciliationCaseworkAction.ChangePriority => "PriorityChanged",
             ReconciliationCaseworkAction.TransitionStatus => "StatusChanged",
             ReconciliationCaseworkAction.AddComment => "CommentAdded",
@@ -739,7 +774,7 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
             ReconciliationCaseworkAction.SetRootCause => "RootCauseSet",
             ReconciliationCaseworkAction.SetResolution => "ResolutionSet",
             ReconciliationCaseworkAction.LinkEvidence => "EvidenceLinked",
-            ReconciliationCaseworkAction.SignOff => "SignOff",
+            ReconciliationCaseworkAction.SignOff => "SignedOff",
             ReconciliationCaseworkAction.Reopen => "Reopen",
             ReconciliationCaseworkAction.Resolve => "ResolutionSet",
             _ => action.ToString()

--- a/src/Meridian.Ui.Services/README.md
+++ b/src/Meridian.Ui.Services/README.md
@@ -30,7 +30,7 @@ contracts aligned with shared UI models and compatibility gates.
 
 Use this module when changing workstation endpoint behavior, operator workflow read models,
 readiness projections, or UI-service orchestration consumed by browser and WPF clients.
-Accounting reconciliation casework endpoints are shared workstation behavior, not client-specific UI logic. Preserve compatibility wrappers for legacy review/resolve calls while routing assign, lifecycle, taxonomy, comments, sign-off, reopen, audit, and bulk triage through shared contracts.
+Accounting reconciliation casework endpoints are shared workstation behavior, not client-specific UI logic. Preserve compatibility wrappers for legacy review/resolve calls while routing assign, lifecycle, taxonomy, comments, sign-off, reopen, audit, and bulk triage through shared contracts. Statement break read models are projected into shared `StatementBreakDto` records so the break queue can seed statement-originated cases without depending on infrastructure records.
 
 ## Diagrams
 

--- a/src/Meridian.Ui.Services/Services/Reconciliation/ReconciliationApiService.cs
+++ b/src/Meridian.Ui.Services/Services/Reconciliation/ReconciliationApiService.cs
@@ -1,3 +1,4 @@
+using Meridian.Contracts.Workstation;
 using Meridian.Infrastructure.Reconciliation;
 using Meridian.Ui.Shared.Contracts.Reconciliation;
 
@@ -18,6 +19,27 @@ public sealed class ReconciliationApiService(ICanonicalStatementStore importStor
     public async Task<IReadOnlyList<StatementRunExceptionDto>> ListOpenExceptionsAsync(CancellationToken ct = default)
         => (await breakStore.ListOpenAsync(ct)).Select(x => new StatementRunExceptionDto(x.BreakId, x.RunId, x.ImportId, x.SourceReference, x.BreakCode, x.Category, x.Delta, x.Tolerance, x.ToleranceBreached, x.CreatedAtUtc.ToString("O"), x.Status)).ToList();
 
+    public async Task<IReadOnlyList<StatementBreakDto>> ListOpenStatementBreaksAsync(CancellationToken ct = default)
+        => (await breakStore.ListOpenAsync(ct)).Select(x => new StatementBreakDto(
+            BreakId: x.BreakId,
+            BreakType: MapStatementBreakType(x.Category, x.BreakCode),
+            Severity: x.ToleranceBreached ? StatementValidationSeverity.Error : StatementValidationSeverity.Warning,
+            MatchTier: StatementMatchTier.Manual,
+            StatementReference: x.SourceReference,
+            Description: $"{x.Category} break {x.BreakCode} requires statement reconciliation review.",
+            StatementAmount: x.Delta,
+            BookAmount: null,
+            Delta: x.Delta,
+            Tolerance: x.Tolerance,
+            Currency: null,
+            CreatedAtUtc: x.CreatedAtUtc,
+            Status: x.Status,
+            InternalReference: x.RunId,
+            Owner: null,
+            LastObservedAtUtc: x.CreatedAtUtc,
+            RecommendedAction: "ReviewAndResolve",
+            EvidenceLink: $"/api/workstation/reconciliation/exceptions/{Uri.EscapeDataString(x.BreakId)}")).ToList();
+
     public async Task<IReadOnlyList<ReconciliationCaseSummaryDto>> ListOpenCasesAsync(CancellationToken ct = default)
         => (await caseStore.ListAsync(ct)).Where(c => c.Status == "Open").Select(c => new ReconciliationCaseSummaryDto(c.CaseId, c.ImportId, c.Status, c.Reason, c.Confidence, c.Rationale, c.CreatedAtUtc.ToString("O"))).ToList();
 
@@ -36,5 +58,29 @@ public sealed class ReconciliationApiService(ICanonicalStatementStore importStor
                 BlockerReason: "Unresolved breaks remain in the reconciliation queue.",
                 EvidenceLinks: group.Select(c => $"/api/workstation/reconciliation/cases/{Uri.EscapeDataString(c.CaseId)}").ToList()))
             .ToList();
+    }
+
+    private static StatementBreakType MapStatementBreakType(string category, string breakCode)
+    {
+        if (category.Equals("position", StringComparison.OrdinalIgnoreCase))
+        {
+            return breakCode.Contains("missing", StringComparison.OrdinalIgnoreCase)
+                ? StatementBreakType.MissingBookPosition
+                : StatementBreakType.PositionQuantityMismatch;
+        }
+
+        if (category.Equals("cash", StringComparison.OrdinalIgnoreCase))
+        {
+            return StatementBreakType.CashBalanceMismatch;
+        }
+
+        if (category.Equals("transaction", StringComparison.OrdinalIgnoreCase))
+        {
+            return breakCode.Contains("missing", StringComparison.OrdinalIgnoreCase)
+                ? StatementBreakType.MissingBookTransaction
+                : StatementBreakType.TransactionAmountMismatch;
+        }
+
+        return StatementBreakType.ValidationFailure;
     }
 }

--- a/src/Meridian.Ui.Shared/Contracts/Reconciliation/IReconciliationApiService.cs
+++ b/src/Meridian.Ui.Shared/Contracts/Reconciliation/IReconciliationApiService.cs
@@ -1,3 +1,5 @@
+using Meridian.Contracts.Workstation;
+
 namespace Meridian.Ui.Shared.Contracts.Reconciliation;
 
 public interface IReconciliationApiService
@@ -6,6 +8,8 @@ public interface IReconciliationApiService
     Task<IReadOnlyList<StatementRunSummaryDto>> ListStatementRunsAsync(CancellationToken ct = default);
     Task<StatementRunSummaryDto?> GetStatementRunAsync(string runId, CancellationToken ct = default);
     Task<IReadOnlyList<StatementRunExceptionDto>> ListOpenExceptionsAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<StatementBreakDto>> ListOpenStatementBreaksAsync(CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<StatementBreakDto>>([]);
     Task<IReadOnlyList<ReconciliationCaseSummaryDto>> ListOpenCasesAsync(CancellationToken ct = default);
     Task<IReadOnlyList<ReconciliationQueueAccountStatusDto>> ListQueueStatusAsync(CancellationToken ct = default);
 }

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Reconciliation.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Reconciliation.cs
@@ -147,9 +147,10 @@ public static partial class WorkstationEndpoints
             HttpContext context,
             [FromServices] StrategyRunReadService? readService,
             [FromServices] IReconciliationRunService? reconciliationService,
+            [FromServices] IReconciliationApiService? statementService,
             [FromServices] IReconciliationBreakQueueRepository? repository) =>
         {
-            await EnsureBreakQueueSeededAsync(readService, reconciliationService, repository, context.RequestAborted).ConfigureAwait(false);
+            await EnsureBreakQueueSeededAsync(readService, reconciliationService, statementService, repository, context.RequestAborted).ConfigureAwait(false);
             var items = await GetBreakQueueItemsAsync(repository, status, fundAccountId, context.RequestAborted).ConfigureAwait(false);
             items = items
                 .Where(item => string.IsNullOrWhiteSpace(team) || string.Equals(item.Team, team, StringComparison.OrdinalIgnoreCase))
@@ -166,9 +167,10 @@ public static partial class WorkstationEndpoints
             HttpContext context,
             [FromServices] StrategyRunReadService? readService,
             [FromServices] IReconciliationRunService? reconciliationService,
+            [FromServices] IReconciliationApiService? statementService,
             [FromServices] IReconciliationBreakQueueRepository? repository) =>
         {
-            await EnsureBreakQueueSeededAsync(readService, reconciliationService, repository, context.RequestAborted).ConfigureAwait(false);
+            await EnsureBreakQueueSeededAsync(readService, reconciliationService, statementService, repository, context.RequestAborted).ConfigureAwait(false);
             if (repository is null)
             {
                 return Results.Problem("Reconciliation break queue repository is not registered.", statusCode: StatusCodes.Status501NotImplemented);
@@ -185,10 +187,11 @@ public static partial class WorkstationEndpoints
             HttpContext context,
             [FromServices] StrategyRunReadService? readService,
             [FromServices] IReconciliationRunService? reconciliationService,
+            [FromServices] IReconciliationApiService? statementService,
             [FromServices] IReconciliationBreakQueueRepository? repository) =>
         {
             var asOf = DateTimeOffset.UtcNow;
-            await EnsureBreakQueueSeededAsync(readService, reconciliationService, repository, context.RequestAborted).ConfigureAwait(false);
+            await EnsureBreakQueueSeededAsync(readService, reconciliationService, statementService, repository, context.RequestAborted).ConfigureAwait(false);
             var items = await GetBreakQueueItemsAsync(repository, status: null, fundAccountId: null, context.RequestAborted).ConfigureAwait(false);
             var summary = BuildReconciliationCalibrationSummary(items, asOf);
             return Results.Json(summary, jsonOptions);
@@ -201,9 +204,10 @@ public static partial class WorkstationEndpoints
             HttpContext context,
             [FromServices] StrategyRunReadService? readService,
             [FromServices] IReconciliationRunService? reconciliationService,
+            [FromServices] IReconciliationApiService? statementService,
             [FromServices] IReconciliationBreakQueueRepository? repository) =>
         {
-            await EnsureBreakQueueSeededAsync(readService, reconciliationService, repository, context.RequestAborted).ConfigureAwait(false);
+            await EnsureBreakQueueSeededAsync(readService, reconciliationService, statementService, repository, context.RequestAborted).ConfigureAwait(false);
             if (repository is null)
             {
                 return Results.Problem("Reconciliation break queue repository is not registered.", statusCode: StatusCodes.Status501NotImplemented);
@@ -225,6 +229,7 @@ public static partial class WorkstationEndpoints
             HttpContext context,
             [FromServices] StrategyRunReadService? readService,
             [FromServices] IReconciliationRunService? reconciliationService,
+            [FromServices] IReconciliationApiService? statementService,
             [FromServices] IReconciliationBreakQueueRepository? repository) =>
         {
             if (!HasReconciliationMutationPermission(context))
@@ -244,7 +249,7 @@ public static partial class WorkstationEndpoints
 
             var trustedRequest = request with { ReviewedBy = currentUser };
 
-            await EnsureBreakQueueSeededAsync(readService, reconciliationService, repository, context.RequestAborted).ConfigureAwait(false);
+            await EnsureBreakQueueSeededAsync(readService, reconciliationService, statementService, repository, context.RequestAborted).ConfigureAwait(false);
             var transition = await ReviewBreakAsync(repository, trustedRequest, context.RequestAborted).ConfigureAwait(false);
             return transition.Status switch
             {
@@ -266,6 +271,7 @@ public static partial class WorkstationEndpoints
             HttpContext context,
             [FromServices] StrategyRunReadService? readService,
             [FromServices] IReconciliationRunService? reconciliationService,
+            [FromServices] IReconciliationApiService? statementService,
             [FromServices] IReconciliationBreakQueueRepository? repository) =>
         {
             if (!HasReconciliationMutationPermission(context))
@@ -294,7 +300,7 @@ public static partial class WorkstationEndpoints
 
             var trustedRequest = request with { ResolvedBy = currentUser };
 
-            await EnsureBreakQueueSeededAsync(readService, reconciliationService, repository, context.RequestAborted).ConfigureAwait(false);
+            await EnsureBreakQueueSeededAsync(readService, reconciliationService, statementService, repository, context.RequestAborted).ConfigureAwait(false);
             var transition = await ResolveBreakAsync(repository, trustedRequest, context.RequestAborted).ConfigureAwait(false);
             return transition.Status switch
             {

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Meridian.Application.Monitoring;
@@ -5845,10 +5846,140 @@ public static partial class WorkstationEndpoints
                         ExplainabilitySummary: reconciliationBreak.Reason,
                         RoutingTarget: "/accounting/reconciliation",
                         RoutingDetail: $"Review reconciliation break {breakId} in accounting queue.",
-                        RecommendedAction: "ReviewAndResolve"),
+                        RecommendedAction: "ReviewAndResolve",
+                        SourceType: "provider-ledger",
+                        SourceSystem: "provider-ledger-reconciliation",
+                        SourceReference: reconciliationBreak.CheckId,
+                        SourceBreakId: reconciliationBreak.CheckId,
+                        SourceFingerprint: ComputeReconciliationSourceFingerprint("provider-ledger", run.RunId, reconciliationBreak.CheckId, reconciliationBreak.Category.ToString(), reconciliationBreak.Reason, reconciliationBreak.Variance.ToString(CultureInfo.InvariantCulture))),
                     ct).ConfigureAwait(false);
             }
         }
+    }
+
+    private static async Task SeedStatementBreakQueueAsync(
+        IReconciliationBreakQueueRepository repository,
+        IReadOnlyList<StatementBreakDto> statementBreaks,
+        CancellationToken ct)
+    {
+        foreach (var statementBreak in statementBreaks.Where(static item => IsOpenStatementBreak(item.Status)))
+        {
+            var item = MapStatementBreakToQueueItem(statementBreak);
+            await repository.CreateIfMissingAsync(item, ct).ConfigureAwait(false);
+        }
+    }
+
+    private static ReconciliationBreakQueueItem MapStatementBreakToQueueItem(StatementBreakDto statementBreak)
+    {
+        var observedAt = statementBreak.LastObservedAtUtc ?? statementBreak.CreatedAtUtc ?? DateTimeOffset.UtcNow;
+        var variance = Math.Abs(statementBreak.Delta ?? ((statementBreak.StatementAmount ?? 0m) - (statementBreak.BookAmount ?? 0m)));
+        var category = MapStatementBreakCategory(statementBreak.BreakType);
+        var severity = MapStatementBreakSeverity(statementBreak.Severity, variance, statementBreak.Tolerance);
+        var routing = ResolveReconciliationExceptionRouting(category, severity, variance);
+        var fingerprint = ComputeStatementBreakFingerprint(statementBreak);
+        var sourceReference = NormalizeMetadata(statementBreak.StatementReference) ?? NormalizeMetadata(statementBreak.InternalReference) ?? statementBreak.BreakId;
+
+        return new ReconciliationBreakQueueItem(
+            BreakId: $"statement:{fingerprint}",
+            RunId: NormalizeMetadata(statementBreak.InternalReference) ?? "statement-reconciliation",
+            StrategyName: "Statement reconciliation",
+            Category: category,
+            Status: ReconciliationBreakQueueStatus.Open,
+            Variance: variance,
+            Reason: NormalizeMetadata(statementBreak.Description) ?? $"Statement {statementBreak.BreakType?.ToString() ?? "break"} requires review.",
+            AssignedTo: NormalizeMetadata(statementBreak.Owner),
+            DetectedAt: statementBreak.CreatedAtUtc ?? observedAt,
+            LastUpdatedAt: observedAt,
+            Severity: severity,
+            ExceptionRoute: routing.ExceptionRoute,
+            ToleranceProfileId: routing.ToleranceProfileId,
+            ToleranceBand: statementBreak.Tolerance ?? routing.ToleranceBand,
+            RequiredSignoffRole: routing.RequiredSignoffRole,
+            SignoffStatus: routing.SignoffStatus,
+            ExplainabilitySummary: statementBreak.Description,
+            RoutingTarget: "/accounting/reconciliation/statements",
+            RoutingDetail: $"Review statement reconciliation break {sourceReference ?? statementBreak.BreakId ?? fingerprint} in accounting queue.",
+            RecommendedAction: NormalizeMetadata(statementBreak.RecommendedAction) ?? "ReviewAndResolve",
+            SourceType: "statement",
+            SourceSystem: "statement-reconciliation",
+            SourceReference: sourceReference,
+            SourceImportId: ExtractStatementImportId(statementBreak.StatementReference),
+            SourceBreakId: statementBreak.BreakId,
+            SourceFingerprint: fingerprint,
+            EvidenceLinks: string.IsNullOrWhiteSpace(statementBreak.EvidenceLink) ? null : [statementBreak.EvidenceLink],
+            EvidenceCount: string.IsNullOrWhiteSpace(statementBreak.EvidenceLink) ? 0 : 1);
+    }
+
+    private static bool IsOpenStatementBreak(string? status)
+        => string.IsNullOrWhiteSpace(status) ||
+           status.Equals("open", StringComparison.OrdinalIgnoreCase) ||
+           status.Equals("review", StringComparison.OrdinalIgnoreCase) ||
+           status.Equals("inreview", StringComparison.OrdinalIgnoreCase) ||
+           status.Equals("in-review", StringComparison.OrdinalIgnoreCase);
+
+    private static ReconciliationBreakCategory MapStatementBreakCategory(StatementBreakType? breakType)
+        => breakType switch
+        {
+            StatementBreakType.MissingStatementPosition or StatementBreakType.MissingBookPosition or StatementBreakType.PositionQuantityMismatch or StatementBreakType.PositionMarketValueMismatch
+                => ReconciliationBreakCategory.MissingPortfolioCoverage,
+            StatementBreakType.MissingStatementCash or StatementBreakType.MissingBookCash or StatementBreakType.CashBalanceMismatch
+                => ReconciliationBreakCategory.CashMismatch,
+            StatementBreakType.SecurityIdentifierMismatch or StatementBreakType.ClassificationMismatch
+                => ReconciliationBreakCategory.ClassificationGap,
+            StatementBreakType.ValidationFailure or StatementBreakType.DuplicateStatementItem
+                => ReconciliationBreakCategory.MissingLedgerCoverage,
+            _ => ReconciliationBreakCategory.ExternalStatementMismatch
+        };
+
+    private static ReconciliationBreakSeverity MapStatementBreakSeverity(StatementValidationSeverity? severity, decimal variance, decimal? tolerance)
+        => severity switch
+        {
+            StatementValidationSeverity.Critical => ReconciliationBreakSeverity.Critical,
+            StatementValidationSeverity.Error => ReconciliationBreakSeverity.High,
+            StatementValidationSeverity.Warning => ReconciliationBreakSeverity.Medium,
+            StatementValidationSeverity.Info => ReconciliationBreakSeverity.Info,
+            _ when tolerance.HasValue && variance > tolerance.Value * 10m => ReconciliationBreakSeverity.High,
+            _ => ReconciliationBreakSeverity.Medium
+        };
+
+    private static string ComputeStatementBreakFingerprint(StatementBreakDto statementBreak)
+        => ComputeReconciliationSourceFingerprint(
+            "statement",
+            NormalizeStatementReference(statementBreak.StatementReference),
+            statementBreak.BreakType?.ToString(),
+            statementBreak.Currency,
+            (statementBreak.Delta ?? 0m).ToString(CultureInfo.InvariantCulture),
+            (statementBreak.Tolerance ?? 0m).ToString(CultureInfo.InvariantCulture),
+            NormalizeMetadata(statementBreak.Description));
+
+    private static string? ExtractStatementImportId(string? value)
+    {
+        var normalized = NormalizeMetadata(value);
+        var separator = normalized?.IndexOf(':');
+        return separator is > 0 ? normalized![..separator.Value] : null;
+    }
+
+    private static string NormalizeStatementReference(string? value)
+    {
+        var normalized = NormalizeMetadata(value);
+        if (normalized is null)
+        {
+            return string.Empty;
+        }
+
+        var separator = normalized.LastIndexOf(':');
+        return separator >= 0 && separator + 1 < normalized.Length
+            ? normalized[(separator + 1)..]
+            : normalized;
+    }
+
+    private static string? NormalizeMetadata(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string ComputeReconciliationSourceFingerprint(params string?[] parts)
+    {
+        var payload = string.Join("|", parts.Select(static part => part?.Trim().ToUpperInvariant() ?? string.Empty));
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(payload))).ToLowerInvariant();
     }
 
     private sealed record ReconciliationExceptionRouting(
@@ -5917,30 +6048,41 @@ public static partial class WorkstationEndpoints
     {
         var readService = services.GetService<StrategyRunReadService>();
         var reconciliationService = services.GetService<IReconciliationRunService>();
+        var statementService = services.GetService<IReconciliationApiService>();
         var repository = services.GetService<IReconciliationBreakQueueRepository>();
-        await EnsureBreakQueueSeededAsync(readService, reconciliationService, repository, ct).ConfigureAwait(false);
+        await EnsureBreakQueueSeededAsync(readService, reconciliationService, statementService, repository, ct).ConfigureAwait(false);
     }
 
-    private static async Task EnsureBreakQueueSeededAsync(
+    private static Task EnsureBreakQueueSeededAsync(
         StrategyRunReadService? readService,
         IReconciliationRunService? reconciliationService,
         IReconciliationBreakQueueRepository? repository,
         CancellationToken ct)
+        => EnsureBreakQueueSeededAsync(readService, reconciliationService, null, repository, ct);
+
+    private static async Task EnsureBreakQueueSeededAsync(
+        StrategyRunReadService? readService,
+        IReconciliationRunService? reconciliationService,
+        IReconciliationApiService? statementService,
+        IReconciliationBreakQueueRepository? repository,
+        CancellationToken ct)
     {
-        if (readService is null || reconciliationService is null)
+        if (readService is not null && reconciliationService is not null)
         {
-            return;
+            var runs = await readService.GetRunsAsync(ct: ct).ConfigureAwait(false);
+            if (runs.Count > 0)
+            {
+                var reconciliations = await Task.WhenAll(
+                    runs.Select(run => reconciliationService.GetLatestForRunAsync(run.RunId, ct))).ConfigureAwait(false);
+                await SeedBreakQueueAsync(repository, runs, reconciliations, ct).ConfigureAwait(false);
+            }
         }
 
-        var runs = await readService.GetRunsAsync(ct: ct).ConfigureAwait(false);
-        if (runs.Count == 0)
+        if (repository is not null && statementService is not null)
         {
-            return;
+            var statementBreaks = await statementService.ListOpenStatementBreaksAsync(ct).ConfigureAwait(false);
+            await SeedStatementBreakQueueAsync(repository, statementBreaks, ct).ConfigureAwait(false);
         }
-
-        var reconciliations = await Task.WhenAll(
-            runs.Select(run => reconciliationService.GetLatestForRunAsync(run.RunId, ct))).ConfigureAwait(false);
-        await SeedBreakQueueAsync(repository, runs, reconciliations, ct).ConfigureAwait(false);
     }
 
     private static async Task<IReadOnlyList<ReconciliationBreakQueueItem>> GetBreakQueueItemsAsync(

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -52,7 +52,7 @@ latest detail so repeated provider-ledger variances can be controlled as account
 Reconciliation details also emit provider-to-Security-Master confidence passports for every
 provider position, preserving the resolution path, confidence score, validation issue codes, and
 identifier-conflict evidence alongside the persisted accounting detail.
-Reconciliation casework hardening is a shared Accounting workflow: break queue read models now carry owner, priority, SLA policy/due-warning-breach state, business age, taxonomy codes, comment/evidence counts, sign-off/reopen metadata, and optimistic concurrency versions. Lifecycle mutations flow through shared workstation endpoints with immutable audit events and compatibility review/resolve wrappers so WPF and browser clients consume the same casework state.
+Reconciliation casework hardening is a shared Accounting workflow: break queue read models now carry owner, priority, SLA policy/due-warning-breach state, business age, taxonomy codes, comment/evidence counts, sign-off/reopen metadata, source-origin metadata, and optimistic concurrency versions. Lifecycle mutations flow through shared workstation endpoints with immutable audit events and compatibility review/resolve wrappers so WPF and browser clients consume the same casework state. Statement-originated breaks project into the same queue with stable material fingerprints so repeated imports of the same statement do not create duplicate open cases; provider-ledger breaks continue to carry provider-ledger source metadata.
 
 Fund-structure endpoints expose `/api/fund-structure/ledger-mapping-view` as the shared accounting
 control surface for account ledger mappings. The endpoint returns server-derived assignment source,

--- a/src/Meridian.Ui/dashboard/README.md
+++ b/src/Meridian.Ui/dashboard/README.md
@@ -52,8 +52,8 @@ resolve locally. Execution-control and promotion-review items carrying the share
 `/api/workstation/trading/readiness` route land on `/trading`, while paper-replay items keep the
 session replay panel hash target so replay verification remains directly actionable.
 Accounting reconciliation break detail preserves shared queue metadata such as exception route,
-tolerance profile, required sign-off role/status, and decision note so browser recovery posture
-matches the retained WPF Fund Ledger detail panel.
+tolerance profile, required sign-off role/status, source origin/fingerprint, and decision note so
+browser recovery posture matches the retained WPF Fund Ledger detail panel.
 Operations Continuity close-checklist fields mirror the shared workstation DTO, including required
 approval counts, expiration dates, and close-readiness blockers, so the browser reads the same
 approval gate state enforced by the API and WPF clients.

--- a/src/Meridian.Ui/dashboard/src/types.ts
+++ b/src/Meridian.Ui/dashboard/src/types.ts
@@ -1452,6 +1452,12 @@ export interface ReconciliationBreakQueueItem {
   commentCount?: number;
   evidenceCount?: number;
   lastActivityAt?: string | null;
+  sourceType?: string | null;
+  sourceSystem?: string | null;
+  sourceReference?: string | null;
+  sourceImportId?: string | null;
+  sourceBreakId?: string | null;
+  sourceFingerprint?: string | null;
 }
 
 export interface ReconciliationCaseComment {

--- a/tests/Meridian.Tests/Strategies/ReconciliationBreakQueueRepositoryTests.cs
+++ b/tests/Meridian.Tests/Strategies/ReconciliationBreakQueueRepositoryTests.cs
@@ -61,8 +61,12 @@ public sealed class ReconciliationBreakQueueRepositoryTests
         await repo.ResolveAsync(new ResolveReconciliationBreakRequest(item.BreakId, ReconciliationBreakQueueStatus.Resolved, "ops", "resolved", "packet evidence"));
 
         var history = await repo.GetAuditHistoryAsync(item.BreakId);
-        history.Should().HaveCount(3);
+        history.Should().HaveCount(4);
         history.Select(x => x.OccurredAt).Should().BeInAscendingOrder();
+        history.Select(x => x.EventType).Should().Contain("CaseCreated");
+        history.Select(x => x.EventType).Should().Contain("Assigned");
+        history.Select(x => x.EventType).Should().Contain("ReviewStarted");
+        history.Select(x => x.EventType).Should().Contain("Resolved");
 
         var auditPath = Path.Combine(root, "reconciliation-break-queue-audit.jsonl");
         var lines = await File.ReadAllLinesAsync(auditPath);
@@ -152,7 +156,7 @@ public sealed class ReconciliationBreakQueueRepositoryTests
         comment.Item.EvidenceCount.Should().Be(1);
 
         var history = await repo.GetAuditHistoryAsync(item.BreakId);
-        history.Should().Contain(e => e.EventType == "AssigneeChanged" && e.CommandId is not null && e.CorrelationId is not null && e.SchemaVersion == 1);
+        history.Should().Contain(e => e.EventType == "Assigned" && e.CommandId is not null && e.CorrelationId is not null && e.SchemaVersion == 1);
         history.Should().Contain(e => e.EventType == "CommentAdded" && e.AfterPayload is not null);
     }
 
@@ -179,6 +183,7 @@ public sealed class ReconciliationBreakQueueRepositoryTests
         var signoff = await repo.ApplyCaseworkCommandAsync(Command(resolved.Item, ReconciliationCaseworkAction.SignOff) with { Actor = "controller-b", Note = "Independent review complete." });
         signoff.Status.Should().Be(ReconciliationBreakQueueTransitionStatus.Success);
         signoff.Item!.LifecycleState.Should().Be(ReconciliationCaseLifecycleState.SignedOff);
+        (await repo.GetAuditHistoryAsync(item.BreakId)).Should().Contain(e => e.EventType == "SignedOff");
 
         var reopenWithoutReason = await repo.ApplyCaseworkCommandAsync(Command(signoff.Item, ReconciliationCaseworkAction.Reopen) with { Actor = "controller-manager", Privileged = true });
         reopenWithoutReason.ErrorCode.Should().Be(ReconciliationBreakQueueTransitionErrorCode.MissingReason);

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -3616,7 +3616,50 @@ public sealed partial class WorkstationEndpointsTests
             !string.IsNullOrWhiteSpace(item.ExceptionRoute) &&
             !string.IsNullOrWhiteSpace(item.ToleranceProfileId) &&
             !string.IsNullOrWhiteSpace(item.RequiredSignoffRole) &&
-            !string.IsNullOrWhiteSpace(item.SignoffStatus));
+            !string.IsNullOrWhiteSpace(item.SignoffStatus) &&
+            item.SourceType == "provider-ledger" &&
+            item.SourceFingerprint != null);
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_BreakQueueRoute_ShouldSeedStatementBreaksOnceWithSourceMetadata()
+    {
+        await using var app = await CreateAppAsync(services =>
+        {
+            services.AddSingleton<IReconciliationApiService>(new StubReconciliationApiService());
+        });
+
+        var client = app.GetTestClient();
+        var first = await client.GetFromJsonAsync<List<ReconciliationBreakQueueItem>>(
+            UiApiRoutes.ReconciliationBreakQueue,
+            ServerJsonOptions);
+        var second = await client.GetFromJsonAsync<List<ReconciliationBreakQueueItem>>(
+            UiApiRoutes.ReconciliationBreakQueue,
+            ServerJsonOptions);
+
+        first.Should().NotBeNull();
+        second.Should().NotBeNull();
+        second!.Should().ContainSingle(item =>
+            item.SourceType == "statement" &&
+            item.SourceSystem == "statement-reconciliation" &&
+            item.SourceImportId == "import-1" &&
+            item.SourceBreakId == "break-1" &&
+            item.SourceReference == "import-1:row-42" &&
+            item.BreakId.StartsWith("statement:", StringComparison.OrdinalIgnoreCase) &&
+            item.AssignedTo == "statement-owner" &&
+            item.Severity == ReconciliationBreakSeverity.High &&
+            item.ToleranceBand == 1m &&
+            item.RequiredSignoffRole == "Fund operations lead" &&
+            item.SignoffStatus == "pending-signoff" &&
+            item.ResolutionNote is null);
+        first!.Count(item => item.SourceType == "statement").Should().Be(1);
+        second.Count(item => item.SourceType == "statement").Should().Be(1);
+
+        var statementBreak = second.Single(item => item.SourceType == "statement");
+        var audit = await client.GetFromJsonAsync<List<ReconciliationBreakQueueAuditEvent>>(
+            UiApiRoutes.WithParam(UiApiRoutes.ReconciliationBreakAudit, "breakId", statementBreak.BreakId),
+            ServerJsonOptions);
+        audit.Should().ContainSingle(e => e.EventType == "CaseCreated" && e.Source == "statement");
     }
 
     [Fact]
@@ -7485,6 +7528,52 @@ public sealed partial class WorkstationEndpointsTests
                     ToleranceBreached: true,
                     CreatedAtUtc: "2026-05-27T12:02:00Z",
                     Status: "Open")
+            ]);
+        }
+
+        public Task<IReadOnlyList<StatementBreakDto>> ListOpenStatementBreaksAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult<IReadOnlyList<StatementBreakDto>>(
+            [
+                new(
+                    BreakId: "break-1",
+                    BreakType: StatementBreakType.CashBalanceMismatch,
+                    Severity: StatementValidationSeverity.Error,
+                    MatchTier: StatementMatchTier.Manual,
+                    StatementReference: "import-1:row-42",
+                    Description: "Statement cash delta exceeds tolerance.",
+                    StatementAmount: 110m,
+                    BookAmount: 100m,
+                    Delta: 10m,
+                    Tolerance: 1m,
+                    Currency: "USD",
+                    CreatedAtUtc: DateTimeOffset.Parse("2026-05-27T12:02:00Z"),
+                    Status: "Open",
+                    InternalReference: "statement-run-1",
+                    Owner: "statement-owner",
+                    LastObservedAtUtc: DateTimeOffset.Parse("2026-05-27T12:05:00Z"),
+                    RecommendedAction: "ReviewAndResolve",
+                    EvidenceLink: "evidence://statement/break-1"),
+                new(
+                    BreakId: "break-duplicate-import",
+                    BreakType: StatementBreakType.CashBalanceMismatch,
+                    Severity: StatementValidationSeverity.Error,
+                    MatchTier: StatementMatchTier.Manual,
+                    StatementReference: "import-2:row-42",
+                    Description: "Statement cash delta exceeds tolerance.",
+                    StatementAmount: 110m,
+                    BookAmount: 100m,
+                    Delta: 10m,
+                    Tolerance: 1m,
+                    Currency: "USD",
+                    CreatedAtUtc: DateTimeOffset.Parse("2026-05-27T12:06:00Z"),
+                    Status: "Open",
+                    InternalReference: "statement-run-2",
+                    Owner: "statement-owner",
+                    LastObservedAtUtc: DateTimeOffset.Parse("2026-05-27T12:07:00Z"),
+                    RecommendedAction: "ReviewAndResolve",
+                    EvidenceLink: "evidence://statement/break-duplicate")
             ]);
         }
 


### PR DESCRIPTION
### Motivation
- Allow statement-originated reconciliation breaks to project into the existing reconciliation break queue so browser/WPF operator surfaces and governance tooling can treat statement cases the same as provider-ledger cases while preserving stable keys and avoiding duplicate open cases across repeated imports.
- Preserve existing queue fields (stable id, status, owner, severity, tolerance profile, required sign-off, decision note, audit history) while adding source-origin metadata and material fingerprinting for deduplication.

### Description
- Added source-origin fields to the shared queue DTO: `SourceType`, `SourceSystem`, `SourceReference`, `SourceImportId`, `SourceBreakId`, and `SourceFingerprint` in `ReconciliationBreakQueueItem`. (`src/Meridian.Contracts/Workstation/ReconciliationDtos.cs`)
- Seed statement-originated breaks into the existing queue by mapping `StatementBreakDto` -> `ReconciliationBreakQueueItem` with routing, tolerance, sign-off metadata, normalized source references, and a stable fingerprint computed with SHA-256 to avoid duplicate open cases across repeated imports. (`src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs`)
- Wire the workstation endpoints to consult an `IReconciliationApiService` to retrieve open statement breaks and call the seeding projection alongside existing provider-ledger seeding. (`src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Reconciliation.cs`, `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs`)
- Implement `ListOpenStatementBreaksAsync` and a mapping helper in the UI services layer to project persisted infrastructure break records into `StatementBreakDto` for queue seeding. (`src/Meridian.Ui.Services/Services/Reconciliation/ReconciliationApiService.cs`, `src/Meridian.Ui.Shared/Contracts/Reconciliation/IReconciliationApiService.cs`)
- Extend `FileReconciliationBreakQueueRepository` audit appends and case-create/save paths to include `Source`/`Reason` metadata and emit explicit audit event types for assignment (`Assigned`), review (`ReviewStarted`), resolution/dismissal (`Resolved`/`Dismissed`), and sign-off (`SignedOff`). (`src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs`)
- Add helpers for statement-fingerprint computation, metadata normalization, category/severity mapping, and idempotent seeding logic. (`src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs`)
- Update browser TypeScript types to include the new source fields so the dashboard can surface origin and fingerprint details. (`src/Meridian.Ui/dashboard/src/types.ts`)
- Update README/module docs to mention source-origin metadata and statement break projection behavior. (multiple README updates)
- Add/adjust unit/integration test assertions to validate: (1) statement breaks are seeded once with source metadata and a stable statement fingerprint, and (2) audit history contains the expected event names including assignment and sign-off. (`tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs`, `tests/Meridian.Tests/Strategies/ReconciliationBreakQueueRepositoryTests.cs`)

### Testing
- Ran repository checks: `git diff --check` (passed with no whitespace/errors reported).
- Attempted targeted unit tests for affected areas with `dotnet test --filter "FullyQualifiedName~ReconciliationBreakQueueRepositoryTests|FullyQualifiedName~WorkstationEndpointsTests"`, but execution was blocked because the `dotnet` CLI is not available in this environment (reported and recorded).
- Ran documentation hash validation `python3 build/scripts/docs/validate-doc-hashes.py --summary`, which reported pre-existing broad source/docs hash drift across many modules unrelated to the scoped change (documented in the validation output).
- Emitted an implementation-assurance rubric report via the local scoring script to summarize evidence and gaps; the score report indicates behavioral correctness and documentation sync while noting the blocked .NET test run as a follow-up item.

All code changes are in the listed files and unit/integration tests were updated to assert the new seeding and audit behaviors; running the .NET test filters in an environment with the .NET SDK will validate behavioral assertions end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a189114fdd48320808a4432202cf8cf)