### PR TITLE
Harden shared reconciliation casework lifecycle

### DIFF
--- a/src/Meridian.FSharp.Ledger/README.md
+++ b/src/Meridian.FSharp.Ledger/README.md
@@ -6,7 +6,7 @@ module_id: SRC-FSHARP-LEDGER
 path: src/Meridian.FSharp.Ledger
 status: active
 owner_lane: Governance and Ledger
-last_reviewed: 2026-05-20
+last_reviewed: 2026-05-28
 ---
 
 # src/Meridian.FSharp.Ledger
@@ -32,7 +32,7 @@ Use this module for ledger calculations and deterministic reconciliation rules t
 ## API contract notes
 
 - `LedgerInterop.ClassifyBreakFacts` trims string fields before mapping DTOs into `RawBreakFacts`, so classification is stable for equivalent break facts that differ only by surrounding whitespace.
-- `ReconciliationCaseWorkflowInterop` exposes C#-friendly transition and provider-ledger checks while keeping the lifecycle rule table pure.
+- `ReconciliationCaseWorkflowInterop` exposes C#-friendly transition and provider-ledger checks while keeping the lifecycle rule table pure. The shared Accounting casework lifecycle maps legacy review flows onto `Investigating`, `Resolved`, `SignedOff`, and privileged `Reopened` states so browser, WPF, and repository wrappers use one deterministic transition table.
 
 ## Diagrams
 

--- a/src/Meridian.FSharp.Ledger/ReconciliationCaseWorkflow.fs
+++ b/src/Meridian.FSharp.Ledger/ReconciliationCaseWorkflow.fs
@@ -63,12 +63,12 @@ module ReconciliationCaseWorkflow =
             let transition =
                 match input.Action, input.LifecycleState with
                 | "StartReview", "Open"
-                | "StartReview", "Reopened" -> Some("InReview", "InReview")
-                | "RequestApproval", "InReview" -> Some("AwaitingApproval", "InReview")
-                | "Approve", "AwaitingApproval" -> Some("Approved", "InReview")
-                | "Post", "Approved" -> Some("Posted", "Resolved")
-                | "Reopen", "Posted"
-                | "Reopen", "Approved" -> Some("Reopened", "Open")
+                | "StartReview", "Reopened" -> Some("Investigating", "InReview")
+                | "RequestApproval", "Investigating"
+                | "RequestApproval", "AwaitingEvidence" -> Some("Resolved", "Resolved")
+                | "Approve", "Resolved" -> Some("SignedOff", "SignedOff")
+                | "Post", "SignedOff" -> Some("SignedOff", "SignedOff")
+                | "Reopen", "SignedOff" -> Some("Reopened", "Open")
                 | "Supersede", state when state <> "Superseded" -> Some("Superseded", "Dismissed")
                 | _ -> None
 
@@ -76,9 +76,9 @@ module ReconciliationCaseWorkflow =
             | None -> fail "Illegal transition." "IllegalTransition" input
             | Some _ when input.Action = "Approve"
                           && String.Equals(input.ReviewedBy, input.Actor, StringComparison.OrdinalIgnoreCase) ->
-                fail "Approver must differ from reviewer." "DualReviewRequired" input
-            | Some _ when input.Action = "Reopen" && input.LifecycleState = "Approved" ->
-                fail "Cannot reopen from approved prior to posting." "ReopenNotAllowed" input
+                fail "Signer must differ from resolver." "DualReviewRequired" input
+            | Some _ when input.Action = "Reopen" && input.LifecycleState <> "SignedOff" ->
+                fail "Only signed-off cases can be reopened." "ReopenNotAllowed" input
             | Some(next, status) -> success next status
 
 module ProviderLedgerReconciliationRules =

--- a/src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs
+++ b/src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs
@@ -89,31 +89,32 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 return false;
             }
 
-            _items[item.BreakId] = StampComputedFields(item, item.DetectedAt);
+            var normalized = NormalizeLegacyCaseState(item);
+            _items[item.BreakId] = StampComputedFields(normalized, normalized.DetectedAt);
             await PersistSnapshotAsync(ct).ConfigureAwait(false);
             await AppendAuditAsync(new ReconciliationBreakQueueAuditEvent(
                 EventId: Guid.NewGuid().ToString("N"),
                 BreakId: item.BreakId,
                 EventType: "CaseCreated",
                 PreviousStatus: null,
-                NewStatus: item.Status,
+                NewStatus: normalized.Status,
                 PreviousLifecycleState: null,
-                NewLifecycleState: item.LifecycleState,
+                NewLifecycleState: normalized.LifecycleState,
                 OccurredAt: item.DetectedAt,
-                AssignedTo: item.AssignedTo,
-                ReviewedBy: item.ReviewedBy,
-                ResolvedBy: item.ResolvedBy,
-                Note: item.ResolutionNote,
-                ExceptionRoute: item.ExceptionRoute,
-                ToleranceBand: item.ToleranceBand,
-                RequiredSignoffRole: item.RequiredSignoffRole,
-                SignoffStatus: item.SignoffStatus,
-                ExternalAccountId: item.ExternalAccountId,
-                CustodianId: item.CustodianId,
-                UpstreamSyncCursor: item.UpstreamSyncCursor,
-                Actor: item.AssignedTo ?? item.ReviewedBy ?? item.ResolvedBy,
+                AssignedTo: normalized.AssignedTo,
+                ReviewedBy: normalized.ReviewedBy,
+                ResolvedBy: normalized.ResolvedBy,
+                Note: normalized.ResolutionNote,
+                ExceptionRoute: normalized.ExceptionRoute,
+                ToleranceBand: normalized.ToleranceBand,
+                RequiredSignoffRole: normalized.RequiredSignoffRole,
+                SignoffStatus: normalized.SignoffStatus,
+                ExternalAccountId: normalized.ExternalAccountId,
+                CustodianId: normalized.CustodianId,
+                UpstreamSyncCursor: normalized.UpstreamSyncCursor,
+                Actor: normalized.AssignedTo ?? normalized.ReviewedBy ?? normalized.ResolvedBy,
                 BeforePayload: null,
-                AfterPayload: JsonSerializer.Serialize(item, _jsonOptions)), ct).ConfigureAwait(false);
+                AfterPayload: JsonSerializer.Serialize(normalized, _jsonOptions)), ct).ConfigureAwait(false);
 
             return true;
         }
@@ -131,7 +132,7 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
         try
         {
             await EnsureLoadedAsync(ct).ConfigureAwait(false);
-            _items![item.BreakId] = item;
+            _items![item.BreakId] = NormalizeLegacyCaseState(item);
             await PersistSnapshotAsync(ct).ConfigureAwait(false);
         }
         finally
@@ -203,7 +204,7 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 ReviewedBy = request.ReviewedBy,
                 ReviewedAt = now,
                 ResolutionNote = request.ReviewNote,
-                SignoffStatus = "in-review"
+                SignoffStatus = "investigating"
             };
 
             updated = StampComputedFields(updated, now);
@@ -285,26 +286,21 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
             {
                 return approval;
             }
-            var updated = request.Status == ReconciliationBreakQueueStatus.Dismissed
-                ? approval.Item with
-                {
-                    Status = request.Status,
-                    ResolvedBy = request.ResolvedBy,
-                    ResolvedAt = now,
-                    ResolutionNote = request.ResolutionNote,
-                    SignoffStatus = "dismissed",
-                    SignoffHistory = (item.SignoffHistory ?? []).Concat(
-                    [
-                        new ReconciliationCaseSignoffRecord(request.ResolvedBy, item.RequiredSignoffRole ?? "operator", request.Status.ToString(), request.OperatorRationale, now)
-                    ]).ToArray()
-                }
-                : approval.Item with
-                {
-                    ResolvedBy = request.ResolvedBy,
-                    ResolvedAt = now,
-                    ResolutionNote = request.ResolutionNote,
-                    SignoffStatus = "awaiting-approval"
-                };
+            var updated = approval.Item with
+            {
+                Status = ReconciliationBreakQueueStatus.Resolved,
+                LifecycleState = ReconciliationCaseLifecycleState.Resolved,
+                ResolvedBy = request.ResolvedBy,
+                ResolvedAt = now,
+                ResolutionNote = request.ResolutionNote,
+                RootCauseCode = approval.Item.RootCauseCode ?? (request.Status == ReconciliationBreakQueueStatus.Dismissed ? "DismissedFalsePositive" : null),
+                ResolutionCode = approval.Item.ResolutionCode ?? (request.Status == ReconciliationBreakQueueStatus.Dismissed ? "DismissedFalsePositive" : "LegacyResolved"),
+                SignoffStatus = request.Status == ReconciliationBreakQueueStatus.Dismissed ? "dismissed-false-positive" : "ready-for-signoff",
+                SignoffHistory = (item.SignoffHistory ?? []).Concat(
+                [
+                    new ReconciliationCaseSignoffRecord(request.ResolvedBy, item.RequiredSignoffRole ?? "operator", request.Status == ReconciliationBreakQueueStatus.Dismissed ? "DismissedFalsePositive" : request.Status.ToString(), request.OperatorRationale, now)
+                ]).ToArray()
+            };
 
             updated = StampComputedFields(updated, now);
             _items[request.BreakId] = updated;
@@ -312,7 +308,7 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
             await AppendAuditAsync(new ReconciliationBreakQueueAuditEvent(
                 EventId: Guid.NewGuid().ToString("N"),
                 BreakId: request.BreakId,
-                EventType: request.Status == ReconciliationBreakQueueStatus.Resolved ? "Resolved" : "Closed",
+                EventType: request.Status == ReconciliationBreakQueueStatus.Resolved ? "Resolved" : "ResolutionSet",
                 PreviousStatus: item.Status,
                 NewStatus: updated.Status,
                 PreviousLifecycleState: item.LifecycleState,
@@ -568,7 +564,9 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
         await using var stream = File.OpenRead(_snapshotPath);
         var snapshot = await JsonSerializer.DeserializeAsync<BreakQueueSnapshot>(stream, _jsonOptions, ct).ConfigureAwait(false);
         var loaded = snapshot?.Items ?? [];
-        _items = loaded.ToDictionary(static item => item.BreakId, StringComparer.OrdinalIgnoreCase);
+        _items = loaded
+            .Select(NormalizeLegacyCaseState)
+            .ToDictionary(static item => item.BreakId, StringComparer.OrdinalIgnoreCase);
     }
 
     private async Task PersistSnapshotAsync(CancellationToken ct)
@@ -598,14 +596,26 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
         {
             ReconciliationCaseworkAction.Assign when string.IsNullOrWhiteSpace(command.Assignee)
                 => Invalid(item, "Assignee is required.", ReconciliationBreakQueueTransitionErrorCode.MissingActor),
+            ReconciliationCaseworkAction.TransitionStatus when command.Status is null
+                => Invalid(item, "Target lifecycle status is required.", ReconciliationBreakQueueTransitionErrorCode.IllegalTransition),
+            ReconciliationCaseworkAction.TransitionStatus when !IsLegalLifecycleTransition(item.LifecycleState, command.Status.Value)
+                => Invalid(item, $"Cannot transition case from {item.LifecycleState} to {command.Status}.", ReconciliationBreakQueueTransitionErrorCode.IllegalTransition),
             ReconciliationCaseworkAction.TransitionStatus when command.Status == ReconciliationCaseLifecycleState.Investigating && string.IsNullOrWhiteSpace(item.AssignedTo) && string.IsNullOrWhiteSpace(command.Assignee)
                 => Invalid(item, "Assignment is required before investigation.", ReconciliationBreakQueueTransitionErrorCode.MissingActor),
             ReconciliationCaseworkAction.TransitionStatus when command.Status == ReconciliationCaseLifecycleState.AwaitingEvidence && string.IsNullOrWhiteSpace(command.Note)
                 => Invalid(item, "Evidence request note is required before awaiting evidence.", ReconciliationBreakQueueTransitionErrorCode.MissingEvidence),
+            ReconciliationCaseworkAction.TransitionStatus when command.Status == ReconciliationCaseLifecycleState.Resolved && string.IsNullOrWhiteSpace(item.RootCauseCode) && string.IsNullOrWhiteSpace(command.RootCauseCode)
+                => Invalid(item, "Root cause code is required before resolution.", ReconciliationBreakQueueTransitionErrorCode.MissingRootCause),
+            ReconciliationCaseworkAction.TransitionStatus when command.Status == ReconciliationCaseLifecycleState.Resolved && string.IsNullOrWhiteSpace(item.ResolutionCode) && string.IsNullOrWhiteSpace(command.ResolutionCode)
+                => Invalid(item, "Resolution code is required before resolution.", ReconciliationBreakQueueTransitionErrorCode.MissingResolutionCode),
+            ReconciliationCaseworkAction.Resolve when item.LifecycleState is not (ReconciliationCaseLifecycleState.Investigating or ReconciliationCaseLifecycleState.AwaitingEvidence or ReconciliationCaseLifecycleState.Reopened)
+                => Invalid(item, $"Cannot resolve case from {item.LifecycleState}.", ReconciliationBreakQueueTransitionErrorCode.IllegalTransition),
             ReconciliationCaseworkAction.Resolve when string.IsNullOrWhiteSpace(item.RootCauseCode) && string.IsNullOrWhiteSpace(command.RootCauseCode)
                 => Invalid(item, "Root cause code is required before resolution.", ReconciliationBreakQueueTransitionErrorCode.MissingRootCause),
             ReconciliationCaseworkAction.Resolve when string.IsNullOrWhiteSpace(item.ResolutionCode) && string.IsNullOrWhiteSpace(command.ResolutionCode)
                 => Invalid(item, "Resolution code is required before resolution.", ReconciliationBreakQueueTransitionErrorCode.MissingResolutionCode),
+            ReconciliationCaseworkAction.SignOff when item.LifecycleState != ReconciliationCaseLifecycleState.Resolved
+                => Invalid(item, "Only resolved cases can be signed off.", ReconciliationBreakQueueTransitionErrorCode.IllegalTransition),
             ReconciliationCaseworkAction.SignOff when string.Equals(item.ResolvedBy, command.Actor, StringComparison.OrdinalIgnoreCase)
                 => Invalid(item, "Resolver and signer must be different operators.", ReconciliationBreakQueueTransitionErrorCode.ResolverSignerConflict),
             ReconciliationCaseworkAction.Reopen when item.LifecycleState != ReconciliationCaseLifecycleState.SignedOff
@@ -619,6 +629,50 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
     private static ReconciliationBreakQueueTransitionResult Invalid(ReconciliationBreakQueueItem? item, string error, ReconciliationBreakQueueTransitionErrorCode code)
         => new(ReconciliationBreakQueueTransitionStatus.ValidationFailed, item, error, code);
 
+    private static bool IsLegalLifecycleTransition(ReconciliationCaseLifecycleState current, ReconciliationCaseLifecycleState next)
+        => current == next || (current, next) switch
+        {
+            (ReconciliationCaseLifecycleState.Open, ReconciliationCaseLifecycleState.Investigating) => true,
+            (ReconciliationCaseLifecycleState.Reopened, ReconciliationCaseLifecycleState.Investigating) => true,
+            (ReconciliationCaseLifecycleState.Investigating, ReconciliationCaseLifecycleState.AwaitingEvidence) => true,
+            (ReconciliationCaseLifecycleState.AwaitingEvidence, ReconciliationCaseLifecycleState.Investigating) => true,
+            (ReconciliationCaseLifecycleState.Investigating, ReconciliationCaseLifecycleState.Resolved) => true,
+            (ReconciliationCaseLifecycleState.AwaitingEvidence, ReconciliationCaseLifecycleState.Resolved) => true,
+            (ReconciliationCaseLifecycleState.Reopened, ReconciliationCaseLifecycleState.Resolved) => true,
+            (ReconciliationCaseLifecycleState.Resolved, ReconciliationCaseLifecycleState.SignedOff) => true,
+            (ReconciliationCaseLifecycleState.SignedOff, ReconciliationCaseLifecycleState.Reopened) => true,
+            _ => false
+        };
+
+    private static ReconciliationBreakQueueItem NormalizeLegacyCaseState(ReconciliationBreakQueueItem item)
+    {
+        var lifecycle = item.LifecycleState == ReconciliationCaseLifecycleState.InReview
+            ? ReconciliationCaseLifecycleState.Investigating
+            : item.LifecycleState;
+        var status = item.Status;
+        var resolutionCode = item.ResolutionCode;
+        var rootCauseCode = item.RootCauseCode;
+        var signoffStatus = item.SignoffStatus;
+
+        if (item.Status == ReconciliationBreakQueueStatus.Dismissed)
+        {
+            lifecycle = ReconciliationCaseLifecycleState.Resolved;
+            status = ReconciliationBreakQueueStatus.Resolved;
+            resolutionCode ??= "DismissedFalsePositive";
+            rootCauseCode ??= "DismissedFalsePositive";
+            signoffStatus ??= "dismissed-false-positive";
+        }
+
+        return item with
+        {
+            LifecycleState = lifecycle,
+            Status = status,
+            ResolutionCode = resolutionCode,
+            RootCauseCode = rootCauseCode,
+            SignoffStatus = signoffStatus
+        };
+    }
+
     private static ReconciliationBreakQueueItem ApplyCaseworkMutation(ReconciliationBreakQueueItem item, ReconciliationCaseworkCommand command, DateTimeOffset now)
     {
         var comments = (item.Comments ?? []).ToList();
@@ -630,7 +684,21 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
             case ReconciliationCaseworkAction.ChangePriority:
                 return item with { Priority = command.Priority ?? item.Priority, LastUpdatedAt = now };
             case ReconciliationCaseworkAction.TransitionStatus:
-                return item with { LifecycleState = command.Status ?? item.LifecycleState, Status = MapQueueStatus(command.Status ?? item.LifecycleState, item.Status), LifecycleRationale = command.Note, LastUpdatedAt = now };
+                var lifecycle = command.Status ?? item.LifecycleState;
+                return item with
+                {
+                    LifecycleState = lifecycle,
+                    Status = MapQueueStatus(lifecycle, item.Status),
+                    AssignedTo = command.Assignee ?? item.AssignedTo,
+                    AssigneeId = command.Assignee ?? item.AssigneeId,
+                    AssigneeDisplayName = command.Assignee ?? item.AssigneeDisplayName,
+                    RootCauseCode = command.RootCauseCode ?? item.RootCauseCode,
+                    ResolutionCode = command.ResolutionCode ?? item.ResolutionCode,
+                    ResolvedBy = lifecycle == ReconciliationCaseLifecycleState.Resolved ? command.Actor : item.ResolvedBy,
+                    ResolvedAt = lifecycle == ReconciliationCaseLifecycleState.Resolved ? now : item.ResolvedAt,
+                    LifecycleRationale = command.Note,
+                    LastUpdatedAt = now
+                };
             case ReconciliationCaseworkAction.AddComment:
                 comments.Add(new ReconciliationCaseComment(command.CommentId ?? Guid.NewGuid().ToString("N"), command.ParentCommentId, command.Actor, command.Actor, command.Visibility, command.Note ?? string.Empty, command.EvidenceLinks ?? [], now));
                 evidence.AddRange(command.EvidenceLinks ?? []);

--- a/src/Meridian.Strategies/Services/ReconciliationCaseWorkflowService.cs
+++ b/src/Meridian.Strategies/Services/ReconciliationCaseWorkflowService.cs
@@ -23,7 +23,7 @@ public sealed class ReconciliationCaseWorkflowService : IReconciliationCaseWorkf
             Actor = command.Actor,
             Reason = command.Reason,
             EvidenceReferenceCount = command.EvidenceReferences?.Count ?? 0,
-            ReviewedBy = item.ReviewedBy ?? string.Empty
+            ReviewedBy = item.ResolvedBy ?? item.ReviewedBy ?? string.Empty
         });
 
         if (!decision.IsValid)

--- a/tests/Meridian.Tests/Strategies/ReconciliationBreakQueueRepositoryTests.cs
+++ b/tests/Meridian.Tests/Strategies/ReconciliationBreakQueueRepositoryTests.cs
@@ -39,16 +39,45 @@ public sealed class ReconciliationBreakQueueRepositoryTests
 
         var review = await repo.StartReviewAsync(new ReviewReconciliationBreakRequest(item.BreakId, "alice", "alice", "triage"));
         review.Status.Should().Be(ReconciliationBreakQueueTransitionStatus.Success);
-        review.Item!.LifecycleState.Should().Be(ReconciliationCaseLifecycleState.InReview);
+        review.Item!.LifecycleState.Should().Be(ReconciliationCaseLifecycleState.Investigating);
 
         var closed = await repo.ResolveAsync(new ResolveReconciliationBreakRequest(item.BreakId, ReconciliationBreakQueueStatus.Resolved, "bob", "resolved", "evidence packet #42"));
         closed.Status.Should().Be(ReconciliationBreakQueueTransitionStatus.Success);
-        closed.Item!.LifecycleState.Should().Be(ReconciliationCaseLifecycleState.AwaitingApproval);
+        closed.Item!.LifecycleState.Should().Be(ReconciliationCaseLifecycleState.Resolved);
+        closed.Item.ResolutionCode.Should().Be("LegacyResolved");
         closed.Item.SignoffHistory.Should().NotBeNullOrEmpty();
         closed.Item.StateTransitions.Should().HaveCountGreaterThanOrEqualTo(2);
 
         var timestamps = closed.Item.StateTransitions!.Select(t => t.OccurredAt).ToArray();
         timestamps.Should().BeInAscendingOrder();
+    }
+
+    [Fact]
+    public async Task Legacy_states_are_migrated_to_shared_casework_lifecycle()
+    {
+        var repo = CreateRepository(out _);
+        var inReview = CreateItem(status: ReconciliationBreakQueueStatus.InReview) with
+        {
+            LifecycleState = ReconciliationCaseLifecycleState.InReview,
+            AssignedTo = "ops-a"
+        };
+        var dismissed = CreateItem(status: ReconciliationBreakQueueStatus.Dismissed) with
+        {
+            LifecycleState = ReconciliationCaseLifecycleState.Superseded
+        };
+
+        await repo.CreateIfMissingAsync(inReview);
+        await repo.CreateIfMissingAsync(dismissed);
+
+        var migratedReview = await repo.GetByIdAsync(inReview.BreakId);
+        migratedReview!.LifecycleState.Should().Be(ReconciliationCaseLifecycleState.Investigating);
+        migratedReview.Status.Should().Be(ReconciliationBreakQueueStatus.InReview);
+
+        var migratedDismissed = await repo.GetByIdAsync(dismissed.BreakId);
+        migratedDismissed!.LifecycleState.Should().Be(ReconciliationCaseLifecycleState.Resolved);
+        migratedDismissed.Status.Should().Be(ReconciliationBreakQueueStatus.Resolved);
+        migratedDismissed.RootCauseCode.Should().Be("DismissedFalsePositive");
+        migratedDismissed.ResolutionCode.Should().Be("DismissedFalsePositive");
     }
 
     [Fact]

--- a/tests/Meridian.Tests/Strategies/ReconciliationCaseWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Strategies/ReconciliationCaseWorkflowServiceTests.cs
@@ -22,7 +22,7 @@ public sealed class ReconciliationCaseWorkflowServiceTests
     public void Apply_rejects_missing_actor_evidence_and_dual_review_violation()
     {
         var svc = new ReconciliationCaseWorkflowService();
-        var item = Seed() with { LifecycleState = ReconciliationCaseLifecycleState.AwaitingApproval, ReviewedBy = "same" };
+        var item = Seed() with { LifecycleState = ReconciliationCaseLifecycleState.Resolved, ReviewedBy = "same" };
         svc.Apply(item, new ReconciliationCaseTransitionCommand(item.BreakId, ReconciliationCaseTransitionAction.Approve, "", "ok", ["ev"]), DateTimeOffset.UtcNow)
             .ErrorCode.Should().Be(ReconciliationBreakQueueTransitionErrorCode.MissingActor);
         svc.Apply(item, new ReconciliationCaseTransitionCommand(item.BreakId, ReconciliationCaseTransitionAction.Approve, "same", "ok", []), DateTimeOffset.UtcNow)


### PR DESCRIPTION
### Motivation
- Converge reconciliation casework into a single shared Accounting workflow so browser, WPF and backend consumers observe the same lifecycle and validation rules.
- Preserve compatibility with existing review/resolve callers while migrating legacy states (`InReview`/`Dismissed`) into the hardened lifecycle.
- Add deterministic guardrails (assignment, evidence, taxonomy, sign-off separation, privileged reopen, optimistic concurrency) to reduce operator errors and make SLA behavior consistent.

### Description
- Replace the F# transition table to map legacy review/wrappers into the hardened lifecycle (StartReview -> `Investigating`, RequestApproval/resolve -> `Resolved`, Approve -> `SignedOff`, privileged reopen -> `Reopened`) in `src/Meridian.FSharp.Ledger/ReconciliationCaseWorkflow.fs`.
- Update the C# bridge to use resolver-aware dual-control checks (`ReviewedBy` now falls back to `ResolvedBy`) in `src/Meridian.Strategies/Services/ReconciliationCaseWorkflowService.cs`.
- Normalize legacy queue items during create/load/save so `InReview` -> `Investigating` and `Dismissed` -> `Resolved` with `DismissedFalsePositive` taxonomy, and serialize the normalized payload into audit events in `src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs`.
- Harden casework validation in `FileReconciliationBreakQueueRepository.cs` by adding `IsLegalLifecycleTransition`, richer `TransitionStatus` validation, resolution prerequisites, signer/resolver separation, privileged reopen checks, and improved resolve handling (sets `ResolutionCode = LegacyResolved` for legacy resolve paths).
- Expand and adjust unit tests to reflect the migrated lifecycle and compatibility behavior in `tests/Meridian.Tests/Strategies/ReconciliationBreakQueueRepositoryTests.cs` and `tests/Meridian.Tests/Strategies/ReconciliationCaseWorkflowServiceTests.cs`.
- Document the shared lifecycle mapping in the F# ledger README `src/Meridian.FSharp.Ledger/README.md` so the policy is discoverable by consumers and reviewers.

### Testing
- Ran browser-workstation tests: `npm --prefix src/Meridian.Ui/dashboard test -- --run src/lib/workstation-endpoints.test.ts` and the targeted Vitest file passed (15 tests passed).
- Ran local checks: `git diff --check` reported no issues.
- Attempted `dotnet` unit verification: `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ReconciliationBreakQueueRepositoryTests|FullyQualifiedName~ReconciliationCaseWorkflowServiceTests|FullyQualifiedName~MapWorkstationEndpoints"` could not be executed in this environment because `dotnet` is not available (validation not run here).
- Ran docs/hash validation: `python3 build/scripts/docs/validate-doc-hashes.py --summary` which reported repository-wide source-doc hash drift (pre-existing across many modules) and flagged that generated-doc baselines should be refreshed after documentation review; this is an advisory artifact and not a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a189107f7b48320a42b8864bb099d01)