### PR TITLE
Fix direct lending duplicate payload comparison

### DIFF
--- a/src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.cs
+++ b/src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.cs
@@ -329,7 +329,7 @@ public sealed partial class PostgresDirectLendingStateStore : IDirectLendingStat
         command.CommandText =
             $"""
             select event_type,
-                   payload::text
+                   payload = cast(@payload as jsonb)
             from {Qualified("loan_event")}
             where loan_id = @loan_id
               and command_id = @command_id
@@ -337,6 +337,7 @@ public sealed partial class PostgresDirectLendingStateStore : IDirectLendingStat
             """;
         command.Parameters.AddWithValue("loan_id", loanId);
         command.Parameters.AddWithValue("command_id", commandId);
+        command.Parameters.AddWithValue("payload", payload.RootElement.GetRawText());
 
         await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
         if (!await reader.ReadAsync(ct).ConfigureAwait(false))
@@ -345,11 +346,9 @@ public sealed partial class PostgresDirectLendingStateStore : IDirectLendingStat
         }
 
         var existingEventType = reader.GetString(0);
-        var existingPayloadJson = reader.GetString(1);
-        var incomingPayloadJson = payload.RootElement.GetRawText();
+        var payloadMatches = reader.GetBoolean(1);
 
-        return string.Equals(existingEventType, eventType, StringComparison.Ordinal) &&
-               string.Equals(existingPayloadJson, incomingPayloadJson, StringComparison.Ordinal)
+        return string.Equals(existingEventType, eventType, StringComparison.Ordinal) && payloadMatches
             ? DuplicateCommandStatus.Matching
             : DuplicateCommandStatus.Mismatched;
     }


### PR DESCRIPTION
### Motivation
- Prevent false conflicts when retrying direct-lending commands by normalizing how stored and incoming JSON payloads are compared for duplicate `CommandId` checks.

### Description
- Update `GetDuplicateCommandStatusAsync` in `src/Meridian.Storage/DirectLending/PostgresDirectLendingStateStore.cs` to compare the stored `payload` column against `cast(@payload as jsonb)` in SQL and return the boolean match from the database instead of comparing `jsonb::text` to the incoming raw JSON text.
- Add a `payload` SQL parameter populated from `payload.RootElement.GetRawText()` and use the returned boolean `payload = cast(@payload as jsonb)` together with the existing `event_type` check to decide idempotent match vs conflict.
- Keep the existing idempotency and conflict semantics unchanged while moving JSON normalization into the Postgres comparison to avoid differences from canonical `jsonb::text` rendering.

### Testing
- Attempted to run the targeted integration tests with `dotnet test tests/Meridian.DirectLending.Tests/Meridian.DirectLending.Tests.csproj --filter "FullyQualifiedName~DirectLendingPostgresIntegrationTests.CommandService_ShouldTreatDuplicateCommandIdAsIdempotent|FullyQualifiedName~DirectLendingPostgresIntegrationTests.CommandService_ShouldRejectDuplicateCommandId_WhenMutationDiffers"`, but the run could not be executed because `dotnet` is not available in this environment (`/bin/bash: dotnet: command not found`).
- Ran repository doc-validation commands `python3 build/scripts/docs/mark-stale-docs.py --write --summary` and `python3 build/scripts/docs/validate-doc-hashes.py --summary`, which reported pre-existing repo-wide source-doc hash drift; generated-doc updates were not included in this PR to keep the change focused.
- Executed the internal eval script `python3 .codex/skills/meridian-implementation-assurance/scripts/score_eval.py` with a Scenario A scorecard (total 8/10) and noted the only blocker is missing local `dotnet` for the integration tests; `git diff --check` returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18944fbbb0832080acbd48dc93f268)