### PR TITLE
Fix statement validation for truncated required cells

### DIFF
--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -49,8 +49,9 @@ application service contracts consumed by host and UI surfaces.
 
 - Options-chain provider IDs are normalized with trim plus invariant lowercase before deduplication, health lookup, fallback detection, logging, and metrics.
 - Statement validation checks source accessibility, account/profile references, duplicate imports,
-  invariant date/decimal parsing, currency/activity/security resolution, and statement-period
-  alignment through application-layer DTOs rather than relying only on exceptions.
+  invariant date/decimal parsing, currency/activity/security resolution, missing or truncated
+  required cells, and statement-period alignment through application-layer DTOs rather than relying
+  only on exceptions.
 
 ## Diagrams
 

--- a/src/Meridian.Application/Reconciliation/StatementValidationService.cs
+++ b/src/Meridian.Application/Reconciliation/StatementValidationService.cs
@@ -321,9 +321,14 @@ public sealed class StatementValidationService(IStatementValidationReferenceData
         out string value)
     {
         value = string.Empty;
-        if (!mapping.TryGetValue(field, out var sourceColumn) || !headerLookup.TryGetValue(sourceColumn, out var index) || index >= values.Count)
+        if (!mapping.TryGetValue(field, out var sourceColumn) || !headerLookup.TryGetValue(sourceColumn, out var index))
         {
             return false;
+        }
+
+        if (index >= values.Count)
+        {
+            return true;
         }
 
         value = values[index].Trim();

--- a/tests/Meridian.Tests/Application/Reconciliation/StatementValidationServiceTests.cs
+++ b/tests/Meridian.Tests/Application/Reconciliation/StatementValidationServiceTests.cs
@@ -96,6 +96,37 @@ public sealed class StatementValidationServiceTests
     }
 
     [Fact]
+    public async Task ValidateAsync_Truncated_Row_Treats_Absent_Required_Cell_As_Missing_Blocker()
+    {
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "account,securityIdentifier,quantity,price,cashAmount,activityCode,tradeDate,currency",
+                "A1,AAPL,10,150.25,1502.50,BUY,2026-05-15"
+            ]);
+            var service = new StatementValidationService(new FakeStatementValidationReferenceData());
+
+            var result = await service.ValidateAsync(CreateRequest(filePath));
+
+            Assert.True(result.IsBlocked);
+            Assert.Contains(result.Issues, issue =>
+                issue.Code == StatementValidationIssueCode.MissingRequiredField
+                && issue.Severity == StatementValidationIssueSeverity.Blocker
+                && issue.RowNumber == 2
+                && issue.Field == StatementValidationFields.Currency);
+            Assert.DoesNotContain(result.Issues, issue =>
+                issue.Code == StatementValidationIssueCode.UnsupportedCurrency
+                && issue.RowNumber == 2);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Fact]
     public async Task ValidateAsync_Can_Promote_Policy_Controlled_Soft_Issues_To_Blockers()
     {
         var filePath = Path.GetTempFileName();


### PR DESCRIPTION
### Motivation

- Prevent truncated CSV rows from silently bypassing required-field checks by treating mapped columns that are past the row value count as present-but-blank so they produce `MissingRequiredField` blockers. 
- Ensure downstream checks (currency/activity/security resolution) do not run for truly absent cells, avoiding false soft-issue reports for missing trailing columns. 

### Description

- Update `TryGetMappedValue` in `src/Meridian.Application/Reconciliation/StatementValidationService.cs` to return `true` with an empty value when a mapped header index exists but `index >= values.Count`, causing the required-field loop to detect blank required cells. 
- Add a regression test `ValidateAsync_Truncated_Row_Treats_Absent_Required_Cell_As_Missing_Blocker` to `tests/Meridian.Tests/Application/Reconciliation/StatementValidationServiceTests.cs` that verifies a row missing the trailing `currency` cell becomes a blocker and does not generate an `UnsupportedCurrency` soft issue. 
- Document the behavior in `src/Meridian.Application/README.md` under API contract notes to mention missing/truncated required-cell validation. 

### Testing

- `git diff --check` was run and reported no diff/whitespace errors.  
- Targeted unit tests were added but `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~StatementValidationServiceTests" /p:EnableWindowsTargeting=true` could not be executed in this environment because `dotnet` is not available.  
- Repository doc-hash probes (`python3 build/scripts/docs/mark-stale-docs.py --write --summary` and `python3 build/scripts/docs/validate-doc-hashes.py --summary`) were exercised; they reported existing source-doc hash drift and generated stale-doc changes that were not included in this PR to keep the change focused.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a189451a074832083fda70c38a30784)