### PR TITLE
Add file-backed repositories for statement reconciliation artifacts

### DIFF
--- a/docs/source/generated/stale-docs.json
+++ b/docs/source/generated/stale-docs.json
@@ -24,7 +24,7 @@
     "version": "1.0.0"
   },
   "source_hash_manifest": "docs/source/generated/source-hash-manifest.json",
-  "stale_count": 21,
+  "stale_count": 28,
   "stale_modules": [
     {
       "module_id": "SRC-APP",
@@ -97,10 +97,12 @@
       "path": "src/Meridian.Domain",
       "readme": "src/Meridian.Domain/README.md",
       "reasons": [
-        "source_hash_drift"
+        "source_hash_drift",
+        "readme_hash_drift"
       ],
       "recommended_actions": [
         "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
         "run validate-doc-hashes.py --write only after the docs/code alignment review is complete"
       ]
     },
@@ -119,6 +121,18 @@
       ]
     },
     {
+      "module_id": "SRC-EXECUTION-SDK",
+      "path": "src/Meridian.Execution.Sdk",
+      "readme": "src/Meridian.Execution.Sdk/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write only after the docs/code alignment review is complete"
+      ]
+    },
+    {
       "module_id": "SRC-FSHARP",
       "path": "src/Meridian.FSharp",
       "readme": "src/Meridian.FSharp/README.md",
@@ -129,6 +143,18 @@
       "recommended_actions": [
         "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
         "review README changes and rerender generated blocks if needed",
+        "run validate-doc-hashes.py --write only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-FSHARP-DIRECTLENDING",
+      "path": "src/Meridian.FSharp.DirectLending.Aggregates",
+      "readme": "src/Meridian.FSharp.DirectLending.Aggregates/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
         "run validate-doc-hashes.py --write only after the docs/code alignment review is complete"
       ]
     },
@@ -147,6 +173,18 @@
       ]
     },
     {
+      "module_id": "SRC-FSHARP-TRADING",
+      "path": "src/Meridian.FSharp.Trading",
+      "readme": "src/Meridian.FSharp.Trading/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write only after the docs/code alignment review is complete"
+      ]
+    },
+    {
       "module_id": "SRC-HOST",
       "path": "src/Meridian",
       "readme": "src/Meridian/README.md",
@@ -157,6 +195,18 @@
       "recommended_actions": [
         "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
         "review README changes and rerender generated blocks if needed",
+        "run validate-doc-hashes.py --write only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-IBAPI-SMOKESTUB",
+      "path": "src/Meridian.IbApi.SmokeStub",
+      "readme": "src/Meridian.IbApi.SmokeStub/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
         "run validate-doc-hashes.py --write only after the docs/code alignment review is complete"
       ]
     },
@@ -187,6 +237,30 @@
       ]
     },
     {
+      "module_id": "SRC-LEDGER",
+      "path": "src/Meridian.Ledger",
+      "readme": "src/Meridian.Ledger/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-MCP",
+      "path": "src/Meridian.Mcp",
+      "readme": "src/Meridian.Mcp/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write only after the docs/code alignment review is complete"
+      ]
+    },
+    {
       "module_id": "SRC-PROVIDER-SDK",
       "path": "src/Meridian.ProviderSdk",
       "readme": "src/Meridian.ProviderSdk/README.md",
@@ -202,6 +276,18 @@
       "module_id": "SRC-QUANTSCRIPT",
       "path": "src/Meridian.QuantScript",
       "readme": "src/Meridian.QuantScript/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-RISK",
+      "path": "src/Meridian.Risk",
+      "readme": "src/Meridian.Risk/README.md",
       "reasons": [
         "source_hash_drift"
       ],

--- a/docs/source/generated/stale-docs.md
+++ b/docs/source/generated/stale-docs.md
@@ -8,7 +8,7 @@ do_not_edit: true
 
 This report marks registered source modules whose code or README hashes differ from the reviewed baseline.
 
-- Stale modules: 21
+- Stale modules: 28
 - Removed module hash entries: 1
 
 | Module | Path | README | Reason |
@@ -18,15 +18,22 @@ This report marks registered source modules whose code or README hashes differ f
 | `SRC-BACKTESTING-SDK` | `src/Meridian.Backtesting.Sdk` | `src/Meridian.Backtesting.Sdk/README.md` | `source_hash_drift` |
 | `SRC-CONTRACTS` | `src/Meridian.Contracts` | `src/Meridian.Contracts/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-CORE` | `src/Meridian.Core` | `src/Meridian.Core/README.md` | `source_hash_drift`, `readme_hash_drift` |
-| `SRC-DOMAIN` | `src/Meridian.Domain` | `src/Meridian.Domain/README.md` | `source_hash_drift` |
+| `SRC-DOMAIN` | `src/Meridian.Domain` | `src/Meridian.Domain/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-EXECUTION` | `src/Meridian.Execution` | `src/Meridian.Execution/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-EXECUTION-SDK` | `src/Meridian.Execution.Sdk` | `src/Meridian.Execution.Sdk/README.md` | `source_hash_drift` |
 | `SRC-FSHARP` | `src/Meridian.FSharp` | `src/Meridian.FSharp/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-FSHARP-DIRECTLENDING` | `src/Meridian.FSharp.DirectLending.Aggregates` | `src/Meridian.FSharp.DirectLending.Aggregates/README.md` | `source_hash_drift` |
 | `SRC-FSHARP-LEDGER` | `src/Meridian.FSharp.Ledger` | `src/Meridian.FSharp.Ledger/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-FSHARP-TRADING` | `src/Meridian.FSharp.Trading` | `src/Meridian.FSharp.Trading/README.md` | `source_hash_drift` |
 | `SRC-HOST` | `src/Meridian` | `src/Meridian/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-IBAPI-SMOKESTUB` | `src/Meridian.IbApi.SmokeStub` | `src/Meridian.IbApi.SmokeStub/README.md` | `source_hash_drift` |
 | `SRC-INFRASTRUCTURE` | `src/Meridian.Infrastructure` | `src/Meridian.Infrastructure/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-INFRASTRUCTURE-CPPTRADER` | `src/Meridian.Infrastructure.CppTrader` | `src/Meridian.Infrastructure.CppTrader/README.md` | `source_hash_drift` |
+| `SRC-LEDGER` | `src/Meridian.Ledger` | `src/Meridian.Ledger/README.md` | `source_hash_drift` |
+| `SRC-MCP` | `src/Meridian.Mcp` | `src/Meridian.Mcp/README.md` | `source_hash_drift` |
 | `SRC-PROVIDER-SDK` | `src/Meridian.ProviderSdk` | `src/Meridian.ProviderSdk/README.md` | `source_hash_drift` |
 | `SRC-QUANTSCRIPT` | `src/Meridian.QuantScript` | `src/Meridian.QuantScript/README.md` | `source_hash_drift` |
+| `SRC-RISK` | `src/Meridian.Risk` | `src/Meridian.Risk/README.md` | `source_hash_drift` |
 | `SRC-STORAGE` | `src/Meridian.Storage` | `src/Meridian.Storage/README.md` | `source_hash_drift` |
 | `SRC-STRATEGIES` | `src/Meridian.Strategies` | `src/Meridian.Strategies/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-UI` | `src/Meridian.Ui` | `src/Meridian.Ui/README.md` | `source_hash_drift` |

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -53,11 +53,11 @@ application service contracts consumed by host and UI surfaces.
 - Statement reconciliation classifies broker and custodian breaks before case creation; only
   material unresolved breaks are promoted into casework, with severity and recommended action
   stored in the classification result.
-- Statement reconciliation imports return typed normalized collections for positions, cash balances, transactions, security references, and source-row references. The import path keeps legacy canonical rows in adapter infrastructure only while application orchestration consumes the typed result shape.
+- Statement reconciliation imports return typed normalized collections for positions, cash balances, transactions, security references, and source-row references. The import path keeps legacy canonical rows in adapter infrastructure only while application orchestration consumes the typed result shape. File-backed statement repositories persist run manifests, validation issues, normalized entities, match results, breaks, and case links under `reconciliation/statement-runs/{runId}/` using atomic JSON writes.
 - Options-chain provider IDs are normalized with trim plus invariant lowercase before deduplication, health lookup, fallback detection, logging, and metrics.
 - Statement validation checks source accessibility, account/profile references, duplicate imports,
   invariant date/decimal parsing, currency/activity/security resolution, and statement-period
-  alignment through application-layer DTOs rather than relying only on exceptions.
+  alignment through application-layer DTOs rather than relying only on exceptions. Statement run manifests retain source file hashes plus mapping/tolerance profile versions for reproducibility, and raw broker files are referenced by source path or approved evidence URI instead of being blindly copied into repository storage.
 
 ## Diagrams
 

--- a/src/Meridian.Application/Reconciliation/StatementRepositories.cs
+++ b/src/Meridian.Application/Reconciliation/StatementRepositories.cs
@@ -1,0 +1,438 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Meridian.Contracts.Workstation;
+using Meridian.Domain.Reconciliation;
+using Meridian.Storage.Archival;
+
+namespace Meridian.Application.Reconciliation;
+
+public interface IStatementRunRepository
+{
+    Task SaveAsync(StatementRunManifest manifest, CancellationToken ct = default);
+    Task<StatementRunManifest?> GetAsync(string runId, CancellationToken ct = default);
+    Task<IReadOnlyList<StatementRunManifest>> ListAsync(string? fundAccountId = null, CancellationToken ct = default);
+}
+
+public interface IStatementValidationIssueRepository
+{
+    Task SaveAsync(string runId, IReadOnlyList<StatementValidationIssueDto> issues, CancellationToken ct = default);
+    Task<IReadOnlyList<StatementValidationIssueDto>> GetAsync(string runId, CancellationToken ct = default);
+}
+
+public interface IStatementNormalizedEntityRepository
+{
+    Task SaveAsync(string runId, StatementNormalizedEntities entities, CancellationToken ct = default);
+    Task<StatementNormalizedEntities?> GetAsync(string runId, CancellationToken ct = default);
+}
+
+public interface IStatementMatchResultRepository
+{
+    Task SaveAsync(string runId, StatementMatchResultArtifact result, CancellationToken ct = default);
+    Task<StatementMatchResultArtifact?> GetAsync(string runId, CancellationToken ct = default);
+}
+
+public sealed record StatementRunManifest(
+    string RunId,
+    string ImportId,
+    string Broker,
+    string SourceInstitution,
+    string FundAccountId,
+    string ExternalAccountId,
+    DateOnly StatementPeriodStart,
+    DateOnly StatementPeriodEnd,
+    DateTimeOffset CreatedAtUtc,
+    string ImportedBy,
+    StatementRawFileEvidenceReference RawFile,
+    StatementProfileVersion MappingProfile,
+    StatementProfileVersion ToleranceProfile,
+    string DuplicateKey,
+    int RawRowCount = 0,
+    int NormalizedRowCount = 0)
+{
+    public static StatementRunManifest FromRequest(
+        string runId,
+        string importId,
+        StatementRunCreateRequest request,
+        string mappingProfileVersion,
+        string toleranceProfileVersion,
+        DateTimeOffset createdAtUtc,
+        int rawRowCount = 0,
+        int normalizedRowCount = 0)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(importId);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(mappingProfileVersion);
+        ArgumentException.ThrowIfNullOrWhiteSpace(toleranceProfileVersion);
+
+        return new StatementRunManifest(
+            runId.Trim(),
+            importId.Trim(),
+            request.Broker,
+            request.SourceInstitution,
+            request.FundAccountId,
+            request.ExternalAccountId,
+            request.StatementPeriodStart,
+            request.StatementPeriodEnd,
+            createdAtUtc,
+            request.ImportedBy,
+            StatementRawFileEvidenceReference.ExternalReference(request.SourcePath, request.OriginalFileName, request.SourceFileHash),
+            new StatementProfileVersion(request.MappingProfileId, mappingProfileVersion),
+            new StatementProfileVersion(request.ToleranceProfileId, toleranceProfileVersion),
+            request.DuplicateKey,
+            rawRowCount,
+            normalizedRowCount);
+    }
+}
+
+public sealed record StatementProfileVersion(string ProfileId, string Version);
+
+public sealed record StatementRawFileEvidenceReference(
+    StatementRawFileRetentionMode RetentionMode,
+    string SourcePath,
+    string OriginalFileName,
+    string SourceFileHash,
+    string? EvidenceUri = null,
+    string PolicyNote = StatementRawFileEvidenceReference.DefaultPolicyNote)
+{
+    public const string DefaultPolicyNote = "Raw broker and custodian files are not copied by this repository. The manifest stores a source path or approved evidence-store reference plus the source file hash for reproducibility.";
+
+    public static StatementRawFileEvidenceReference ExternalReference(
+        string sourcePath,
+        string originalFileName,
+        string sourceFileHash)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourcePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(originalFileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceFileHash);
+
+        return new StatementRawFileEvidenceReference(
+            StatementRawFileRetentionMode.ExternalReferenceOnly,
+            sourcePath.Trim(),
+            originalFileName.Trim(),
+            sourceFileHash.Trim());
+    }
+
+    public static StatementRawFileEvidenceReference EvidenceStoreReference(
+        string sourcePath,
+        string originalFileName,
+        string sourceFileHash,
+        string evidenceUri)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(evidenceUri);
+        return ExternalReference(sourcePath, originalFileName, sourceFileHash) with
+        {
+            RetentionMode = StatementRawFileRetentionMode.EvidenceStoreReference,
+            EvidenceUri = evidenceUri.Trim(),
+            PolicyNote = "Raw file bytes are governed by the configured evidence store. This repository retains only the evidence URI and source file hash."
+        };
+    }
+}
+
+public enum StatementRawFileRetentionMode
+{
+    ExternalReferenceOnly,
+    EvidenceStoreReference
+}
+
+public sealed record StatementNormalizedEntities(
+    string RunId,
+    string ImportId,
+    IReadOnlyList<StatementPosition> Positions,
+    IReadOnlyList<StatementCashBalance> CashBalances,
+    IReadOnlyList<StatementTransaction> Transactions,
+    IReadOnlyList<StatementSecurityReference> Securities,
+    IReadOnlyList<StatementSourceRowReference> SourceRows)
+{
+    public static StatementNormalizedEntities FromImport(string runId, NormalizedStatementImportResult import)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runId);
+        ArgumentNullException.ThrowIfNull(import);
+
+        return new StatementNormalizedEntities(
+            runId.Trim(),
+            import.ImportId,
+            import.Positions,
+            import.CashBalances,
+            import.Transactions,
+            import.Securities,
+            import.SourceRows);
+    }
+}
+
+public sealed record StatementMatchResultArtifact(
+    string RunId,
+    string ImportId,
+    IReadOnlyList<ReconciliationMatchLink> Matches,
+    IReadOnlyList<StatementBreakRecord> Breaks,
+    IReadOnlyList<StatementCaseLink> CaseLinks);
+
+public sealed record StatementBreakRecord(
+    string BreakId,
+    string RunId,
+    string ImportId,
+    string SourceRowHash,
+    StatementBreakClassificationType BreakType,
+    ReconciliationBreakSeverity Severity,
+    StatementBreakRecommendedAction RecommendedAction,
+    decimal AbsoluteVariance,
+    bool IsMaterial,
+    bool IsUnresolved,
+    string Status,
+    string Rationale,
+    DateTimeOffset CreatedAtUtc);
+
+public sealed record StatementCaseLink(
+    string CaseId,
+    string RunId,
+    string ImportId,
+    string? BreakId,
+    string SourceRowHash,
+    string? EvidenceUri,
+    DateTimeOffset LinkedAtUtc,
+    string LinkReason);
+
+public sealed class FileStatementRunRepository : IStatementRunRepository
+{
+    private readonly StatementRepositoryPaths _paths;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public FileStatementRunRepository(string dataDirectory)
+    {
+        _paths = new StatementRepositoryPaths(dataDirectory);
+    }
+
+    public async Task SaveAsync(StatementRunManifest manifest, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+        StatementRepositoryGuard.ValidateRunId(manifest.RunId);
+
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await StatementRepositoryJson.WriteAsync(_paths.ManifestPath(manifest.RunId), manifest, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public Task<StatementRunManifest?> GetAsync(string runId, CancellationToken ct = default)
+    {
+        StatementRepositoryGuard.ValidateRunId(runId);
+        return StatementRepositoryJson.ReadOrDefaultAsync<StatementRunManifest>(_paths.ManifestPath(runId), ct);
+    }
+
+    public async Task<IReadOnlyList<StatementRunManifest>> ListAsync(string? fundAccountId = null, CancellationToken ct = default)
+    {
+        if (!Directory.Exists(_paths.RootDirectory))
+        {
+            return [];
+        }
+
+        var manifests = new List<StatementRunManifest>();
+        foreach (var path in Directory.EnumerateFiles(_paths.RootDirectory, StatementRepositoryPaths.ManifestFileName, SearchOption.AllDirectories))
+        {
+            ct.ThrowIfCancellationRequested();
+            var manifest = await StatementRepositoryJson.ReadOrDefaultAsync<StatementRunManifest>(path, ct).ConfigureAwait(false);
+            if (manifest is null)
+            {
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(fundAccountId)
+                || string.Equals(manifest.FundAccountId, fundAccountId.Trim(), StringComparison.OrdinalIgnoreCase))
+            {
+                manifests.Add(manifest);
+            }
+        }
+
+        return manifests
+            .OrderByDescending(static manifest => manifest.CreatedAtUtc)
+            .ThenBy(static manifest => manifest.RunId, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+}
+
+public sealed class FileStatementValidationIssueRepository : IStatementValidationIssueRepository
+{
+    private readonly StatementRepositoryPaths _paths;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public FileStatementValidationIssueRepository(string dataDirectory)
+    {
+        _paths = new StatementRepositoryPaths(dataDirectory);
+    }
+
+    public async Task SaveAsync(string runId, IReadOnlyList<StatementValidationIssueDto> issues, CancellationToken ct = default)
+    {
+        StatementRepositoryGuard.ValidateRunId(runId);
+        ArgumentNullException.ThrowIfNull(issues);
+
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await StatementRepositoryJson.WriteAsync(_paths.ValidationIssuesPath(runId), issues, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<StatementValidationIssueDto>> GetAsync(string runId, CancellationToken ct = default)
+    {
+        StatementRepositoryGuard.ValidateRunId(runId);
+        return await StatementRepositoryJson.ReadOrDefaultAsync<IReadOnlyList<StatementValidationIssueDto>>(_paths.ValidationIssuesPath(runId), ct)
+            .ConfigureAwait(false) ?? [];
+    }
+}
+
+public sealed class FileStatementNormalizedEntityRepository : IStatementNormalizedEntityRepository
+{
+    private readonly StatementRepositoryPaths _paths;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public FileStatementNormalizedEntityRepository(string dataDirectory)
+    {
+        _paths = new StatementRepositoryPaths(dataDirectory);
+    }
+
+    public async Task SaveAsync(string runId, StatementNormalizedEntities entities, CancellationToken ct = default)
+    {
+        StatementRepositoryGuard.ValidateRunId(runId);
+        ArgumentNullException.ThrowIfNull(entities);
+        if (!string.Equals(runId.Trim(), entities.RunId, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException("Normalized entities must belong to the run being saved.", nameof(entities));
+        }
+
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await StatementRepositoryJson.WriteAsync(_paths.NormalizedEntitiesPath(runId), entities, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public Task<StatementNormalizedEntities?> GetAsync(string runId, CancellationToken ct = default)
+    {
+        StatementRepositoryGuard.ValidateRunId(runId);
+        return StatementRepositoryJson.ReadOrDefaultAsync<StatementNormalizedEntities>(_paths.NormalizedEntitiesPath(runId), ct);
+    }
+}
+
+public sealed class FileStatementMatchResultRepository : IStatementMatchResultRepository
+{
+    private readonly StatementRepositoryPaths _paths;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public FileStatementMatchResultRepository(string dataDirectory)
+    {
+        _paths = new StatementRepositoryPaths(dataDirectory);
+    }
+
+    public async Task SaveAsync(string runId, StatementMatchResultArtifact result, CancellationToken ct = default)
+    {
+        StatementRepositoryGuard.ValidateRunId(runId);
+        ArgumentNullException.ThrowIfNull(result);
+        if (!string.Equals(runId.Trim(), result.RunId, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException("Match results must belong to the run being saved.", nameof(result));
+        }
+
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await StatementRepositoryJson.WriteAsync(_paths.MatchResultsPath(runId), result with { Breaks = [], CaseLinks = [] }, ct).ConfigureAwait(false);
+            await StatementRepositoryJson.WriteAsync(_paths.BreaksPath(runId), result.Breaks, ct).ConfigureAwait(false);
+            await StatementRepositoryJson.WriteAsync(_paths.CaseLinksPath(runId), result.CaseLinks, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<StatementMatchResultArtifact?> GetAsync(string runId, CancellationToken ct = default)
+    {
+        StatementRepositoryGuard.ValidateRunId(runId);
+        var result = await StatementRepositoryJson.ReadOrDefaultAsync<StatementMatchResultArtifact>(_paths.MatchResultsPath(runId), ct).ConfigureAwait(false);
+        if (result is null)
+        {
+            return null;
+        }
+
+        var breaks = await StatementRepositoryJson.ReadOrDefaultAsync<IReadOnlyList<StatementBreakRecord>>(_paths.BreaksPath(runId), ct).ConfigureAwait(false) ?? [];
+        var caseLinks = await StatementRepositoryJson.ReadOrDefaultAsync<IReadOnlyList<StatementCaseLink>>(_paths.CaseLinksPath(runId), ct).ConfigureAwait(false) ?? [];
+        return result with { Breaks = breaks, CaseLinks = caseLinks };
+    }
+}
+
+internal sealed class StatementRepositoryPaths
+{
+    public const string ManifestFileName = "manifest.json";
+
+    public StatementRepositoryPaths(string dataDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dataDirectory);
+        RootDirectory = Path.Combine(dataDirectory, "reconciliation", "statement-runs");
+        Directory.CreateDirectory(RootDirectory);
+    }
+
+    public string RootDirectory { get; }
+
+    public string ManifestPath(string runId) => Path.Combine(RunDirectory(runId), ManifestFileName);
+    public string ValidationIssuesPath(string runId) => Path.Combine(RunDirectory(runId), "validation-issues.json");
+    public string NormalizedEntitiesPath(string runId) => Path.Combine(RunDirectory(runId), "normalized-entities.json");
+    public string MatchResultsPath(string runId) => Path.Combine(RunDirectory(runId), "match-results.json");
+    public string BreaksPath(string runId) => Path.Combine(RunDirectory(runId), "breaks.json");
+    public string CaseLinksPath(string runId) => Path.Combine(RunDirectory(runId), "case-links.json");
+
+    private string RunDirectory(string runId) => Path.Combine(RootDirectory, SafeRunId(runId));
+
+    private static string SafeRunId(string runId)
+    {
+        StatementRepositoryGuard.ValidateRunId(runId);
+        return string.Concat(runId.Trim().Select(static ch => char.IsLetterOrDigit(ch) || ch is '-' or '_' ? ch : '_'));
+    }
+}
+
+internal static class StatementRepositoryJson
+{
+    public static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public static async Task WriteAsync<T>(string path, T value, CancellationToken ct)
+    {
+        var json = JsonSerializer.Serialize(value, Options);
+        await AtomicFileWriter.WriteAsync(path, json, ct).ConfigureAwait(false);
+    }
+
+    public static async Task<T?> ReadOrDefaultAsync<T>(string path, CancellationToken ct)
+    {
+        if (!File.Exists(path))
+        {
+            return default;
+        }
+
+        await using var stream = File.OpenRead(path);
+        return await JsonSerializer.DeserializeAsync<T>(stream, Options, ct).ConfigureAwait(false);
+    }
+}
+
+internal static class StatementRepositoryGuard
+{
+    public static void ValidateRunId(string runId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runId);
+    }
+}
+

--- a/tests/Meridian.Tests/Application/Reconciliation/StatementRepositoryTests.cs
+++ b/tests/Meridian.Tests/Application/Reconciliation/StatementRepositoryTests.cs
@@ -1,0 +1,188 @@
+using FluentAssertions;
+using Meridian.Application.Reconciliation;
+using WorkstationReconciliationBreakSeverity = Meridian.Contracts.Workstation.ReconciliationBreakSeverity;
+using Meridian.Domain.Reconciliation;
+
+namespace Meridian.Tests.Application.Reconciliation;
+
+public sealed class StatementRepositoryTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "meridian-statement-repository-tests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task SaveAsync_persists_manifest_with_hash_profile_versions_and_raw_file_policy_reference()
+    {
+        var repository = new FileStatementRunRepository(_root);
+        var request = new StatementRunCreateRequest(
+            "SampleBroker",
+            "Sample Custodian",
+            "fund-1",
+            "external-1",
+            new DateOnly(2026, 5, 1),
+            new DateOnly(2026, 5, 31),
+            "/secure/inbound/statement.csv",
+            "statement.csv",
+            "sample-broker-csv-v1",
+            "cash-tolerance-v2",
+            "ops@example.test",
+            "ABC123HASH");
+        var manifest = StatementRunManifest.FromRequest(
+            "run-001",
+            "import-001",
+            request,
+            mappingProfileVersion: "sample-broker-csv-v1@2026-05-28",
+            toleranceProfileVersion: "cash-tolerance-v2@2026-05-28",
+            createdAtUtc: new DateTimeOffset(2026, 5, 28, 10, 0, 0, TimeSpan.Zero),
+            rawRowCount: 10,
+            normalizedRowCount: 9);
+
+        await repository.SaveAsync(manifest);
+
+        var loaded = await repository.GetAsync("run-001");
+        loaded.Should().BeEquivalentTo(manifest);
+        loaded!.RawFile.RetentionMode.Should().Be(StatementRawFileRetentionMode.ExternalReferenceOnly);
+        loaded.RawFile.SourcePath.Should().Be("/secure/inbound/statement.csv");
+        loaded.RawFile.SourceFileHash.Should().Be("ABC123HASH");
+        loaded.RawFile.PolicyNote.Should().Contain("not copied");
+        File.Exists(Path.Combine(_root, "reconciliation", "statement-runs", "run-001", "manifest.json")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Repositories_round_trip_validation_entities_matches_breaks_and_case_links()
+    {
+        var validationRepository = new FileStatementValidationIssueRepository(_root);
+        var entityRepository = new FileStatementNormalizedEntityRepository(_root);
+        var matchRepository = new FileStatementMatchResultRepository(_root);
+        var issue = new StatementValidationIssueDto(
+            StatementValidationIssueCode.UnresolvedSecurity,
+            StatementValidationIssueSeverity.Soft,
+            4,
+            "symbol",
+            "Ticker requires review.");
+        var sourceRow = new StatementSourceRowReference(
+            "import-001",
+            4,
+            "row-hash-4",
+            new Dictionary<string, string> { ["sourcePath"] = "/secure/inbound/statement.csv" });
+        var entities = new StatementNormalizedEntities(
+            "run-001",
+            "import-001",
+            Positions:
+            [
+                new StatementPosition(
+                    "import-001",
+                    4,
+                    "row-hash-4",
+                    sourceRow.RawSnapshot,
+                    "fund-1",
+                    "external-1",
+                    null,
+                    "XYZ",
+                    "USD",
+                    100m,
+                    12.34m,
+                    1234m,
+                    new DateOnly(2026, 5, 27),
+                    new DateOnly(2026, 5, 29))
+            ],
+            CashBalances: [],
+            Transactions: [],
+            Securities: [],
+            SourceRows: [sourceRow]);
+        var matchResult = new StatementMatchResultArtifact(
+            "run-001",
+            "import-001",
+            Matches:
+            [
+                new ReconciliationMatchLink(
+                    "import-001:4",
+                    "position-123",
+                    null,
+                    null,
+                    null,
+                    "evidence://session/123",
+                    "evidence://run/001",
+                    "high",
+                    "Symbol and quantity aligned.")
+            ],
+            Breaks:
+            [
+                new StatementBreakRecord(
+                    "break-001",
+                    "run-001",
+                    "import-001",
+                    "row-hash-4",
+                    StatementBreakClassificationType.SecurityMappingBreak,
+                    WorkstationReconciliationBreakSeverity.Medium,
+                    StatementBreakRecommendedAction.MapSecurity,
+                    0m,
+                    true,
+                    true,
+                    "Open",
+                    "Security must be mapped before close.",
+                    new DateTimeOffset(2026, 5, 28, 10, 5, 0, TimeSpan.Zero))
+            ],
+            CaseLinks:
+            [
+                new StatementCaseLink(
+                    "case-001",
+                    "run-001",
+                    "import-001",
+                    "break-001",
+                    "row-hash-4",
+                    "evidence://cases/case-001",
+                    new DateTimeOffset(2026, 5, 28, 10, 6, 0, TimeSpan.Zero),
+                    "Material unresolved break promoted to casework.")
+            ]);
+
+        await validationRepository.SaveAsync("run-001", [issue]);
+        await entityRepository.SaveAsync("run-001", entities);
+        await matchRepository.SaveAsync("run-001", matchResult);
+
+        (await validationRepository.GetAsync("run-001")).Should().BeEquivalentTo([issue]);
+        (await entityRepository.GetAsync("run-001")).Should().BeEquivalentTo(entities);
+        (await matchRepository.GetAsync("run-001")).Should().BeEquivalentTo(matchResult);
+
+        File.Exists(Path.Combine(_root, "reconciliation", "statement-runs", "run-001", "validation-issues.json")).Should().BeTrue();
+        File.Exists(Path.Combine(_root, "reconciliation", "statement-runs", "run-001", "normalized-entities.json")).Should().BeTrue();
+        File.Exists(Path.Combine(_root, "reconciliation", "statement-runs", "run-001", "match-results.json")).Should().BeTrue();
+        File.Exists(Path.Combine(_root, "reconciliation", "statement-runs", "run-001", "breaks.json")).Should().BeTrue();
+        File.Exists(Path.Combine(_root, "reconciliation", "statement-runs", "run-001", "case-links.json")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SaveAsync_observes_cancellation_before_writing_artifacts()
+    {
+        var repository = new FileStatementRunRepository(_root);
+        var manifest = new StatementRunManifest(
+            "run-cancelled",
+            "import-cancelled",
+            "broker",
+            "institution",
+            "fund-1",
+            "external-1",
+            new DateOnly(2026, 5, 1),
+            new DateOnly(2026, 5, 31),
+            DateTimeOffset.UtcNow,
+            "ops",
+            StatementRawFileEvidenceReference.ExternalReference("/secure/inbound/cancelled.csv", "cancelled.csv", "HASH"),
+            new StatementProfileVersion("mapping", "mapping@v1"),
+            new StatementProfileVersion("tolerance", "tolerance@v1"),
+            "duplicate-key");
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var act = async () => await repository.SaveAsync(manifest, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        File.Exists(Path.Combine(_root, "reconciliation", "statement-runs", "run-cancelled", "manifest.json")).Should().BeFalse();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Persist statement-run artifacts (manifest, validation issues, normalized entities, match results, breaks, case links) so reconciliation runs are reproducible and queryable.  
- Use the repository storage patterns already in the codebase (per-run JSON artifacts with atomic write semantics) to avoid partial writes on crash.  
- Retain provenance (source-file hash, mapping/tolerance profile versions, duplicate-key) and make raw-file retention explicit so sensitive broker files are not blindly copied.

### Description

- Added repository interfaces `IStatementRunRepository`, `IStatementValidationIssueRepository`, `IStatementNormalizedEntityRepository`, and `IStatementMatchResultRepository` under `src/Meridian.Application/Reconciliation/` and provided file-backed implementations `FileStatementRunRepository`, `FileStatementValidationIssueRepository`, `FileStatementNormalizedEntityRepository`, and `FileStatementMatchResultRepository`.  
- Implemented manifest and artifact models including `StatementRunManifest`, `StatementRawFileEvidenceReference`, `StatementProfileVersion`, `StatementNormalizedEntities`, `StatementMatchResultArtifact`, `StatementBreakRecord`, and `StatementCaseLink`.  
- Persist artifacts to `reconciliation/statement-runs/{runId}/` with explicit filenames (`manifest.json`, `validation-issues.json`, `normalized-entities.json`, `match-results.json`, `breaks.json`, `case-links.json`) and sanitize `runId` for safe paths.  
- Use `AtomicFileWriter` for crash-safe atomic JSON writes, `JsonSerializerOptions` with string-enum conversion, `SemaphoreSlim` gating for write concurrency, and cancellation-token-aware read/write flows; manifest includes source-file hash and profile versions and supports `ExternalReferenceOnly` vs `EvidenceStoreReference` retention modes.

### Testing

- Created unit tests `tests/Meridian.Tests/Application/Reconciliation/StatementRepositoryTests.cs` covering manifest persistence and metadata, artifacts round-trip (validation/entities/matches/breaks/case-links), artifact file layout, and cancellation-before-write behavior.  
- Ran docs tooling: `python3 build/scripts/docs/mark-stale-docs.py --write --summary` (succeeded and updated stale-doc report) and `python3 build/scripts/docs/validate-doc-hashes.py --summary` (reported source/README hash drift expected for updated module).  
- Ran the implementation-assurance scorer via the repo helper which produced an evaluation (9/10) with the follow-up that the .NET test run could not be executed in this environment.  
- Attempted targeted test run `dotnet test --filter "FullyQualifiedName~StatementRepositoryTests"` but `dotnet` is not available in the container so tests were not executed here; they are included and should pass in an environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18956bdec48320ba7fd4e2c556bc60)