### PR TITLE
[PR #1530 Follow-up] Fix startup regression in governance opt-in guard

### DIFF
--- a/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
@@ -245,57 +245,53 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
 
         var useInMemoryGovernanceServices = IsInMemoryGovernanceProfileEnabled();
 
-        if (!useInMemoryGovernanceServices)
+        if (useInMemoryGovernanceServices)
         {
-            throw new InvalidOperationException(
-                "Production-safe startup requires persistence-backed governance domain services. " +
-                "Set MERIDIAN_USE_INMEMORY_GOVERNANCE=true only for local/dev fixture scenarios.");
+            // Local fixture/dev profile: keep in-memory working sets persisted to local snapshots.
+            services.TryAddSingleton<IFundAccountService>(sp =>
+            {
+                var storageOptions = sp.GetRequiredService<StorageOptions>();
+                var persistencePath = Path.Combine(storageOptions.RootPath, "governance", "fund-accounts.json");
+                return new InMemoryFundAccountService(persistencePath);
+            });
+            services.TryAddSingleton<IAccountManagementService>(sp => (IAccountManagementService)sp.GetRequiredService<IFundAccountService>());
+            services.TryAddSingleton<IAccountQueryService>(sp => (IAccountQueryService)sp.GetRequiredService<IFundAccountService>());
+            services.TryAddSingleton<IGovernanceSharedDataAccessService>(sp =>
+                new GovernanceSharedDataAccessService(
+                    sp.GetService<Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService>(),
+                    sp.GetService<HistoricalDataQueryService>(),
+                    sp.GetService<BackfillCoordinator>()));
+            services.TryAddSingleton<IFundStructureService>(sp =>
+            {
+                var storageOptions = sp.GetRequiredService<StorageOptions>();
+                var fundAccountService = sp.GetRequiredService<IFundAccountService>();
+                var sharedDataAccessService = sp.GetService<IGovernanceSharedDataAccessService>();
+                var securityMasterQueryService = sp.GetService<Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService>();
+                var persistencePath = Path.Combine(storageOptions.RootPath, "governance", "fund-structure.json");
+                return new InMemoryFundStructureService(
+                    fundAccountService,
+                    sharedDataAccessService,
+                    securityMasterQueryService,
+                    persistencePath);
+            });
+            services.TryAddSingleton<EnvironmentDesignerService>(sp =>
+            {
+                var storageOptions = sp.GetRequiredService<StorageOptions>();
+                var persistencePath = Path.Combine(storageOptions.RootPath, "governance", "environment-designer.json");
+                return new EnvironmentDesignerService(persistencePath);
+            });
+            services.TryAddSingleton<IEnvironmentDesignService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
+            services.TryAddSingleton<IEnvironmentValidationService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
+            services.TryAddSingleton<IEnvironmentPublishService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
+            services.TryAddSingleton<IEnvironmentRuntimeProjectionService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
+
+            services.TryAddSingleton<IDirectLendingService, InMemoryDirectLendingService>();
+            services.TryAddSingleton<IDirectLendingQueryService, InMemoryDirectLendingService>();
+            services.TryAddSingleton<IDirectLendingCommandService, InMemoryDirectLendingService>();
+            services.TryAddSingleton<IBankingService, InMemoryBankingService>();
+            services.TryAddSingleton<IMoneyMarketFundService, InMemoryMoneyMarketFundService>();
+            services.TryAddSingleton<IMmfLiquidityService>(sp => (IMmfLiquidityService)sp.GetRequiredService<IMoneyMarketFundService>());
         }
-
-        // Local fixture/dev profile: keep in-memory working sets persisted to local snapshots.
-        services.TryAddSingleton<IFundAccountService>(sp =>
-        {
-            var storageOptions = sp.GetRequiredService<StorageOptions>();
-            var persistencePath = Path.Combine(storageOptions.RootPath, "governance", "fund-accounts.json");
-            return new InMemoryFundAccountService(persistencePath);
-        });
-        services.TryAddSingleton<IAccountManagementService>(sp => (IAccountManagementService)sp.GetRequiredService<IFundAccountService>());
-        services.TryAddSingleton<IAccountQueryService>(sp => (IAccountQueryService)sp.GetRequiredService<IFundAccountService>());
-        services.TryAddSingleton<IGovernanceSharedDataAccessService>(sp =>
-            new GovernanceSharedDataAccessService(
-                sp.GetService<Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService>(),
-                sp.GetService<HistoricalDataQueryService>(),
-                sp.GetService<BackfillCoordinator>()));
-        services.TryAddSingleton<IFundStructureService>(sp =>
-        {
-            var storageOptions = sp.GetRequiredService<StorageOptions>();
-            var fundAccountService = sp.GetRequiredService<IFundAccountService>();
-            var sharedDataAccessService = sp.GetService<IGovernanceSharedDataAccessService>();
-            var securityMasterQueryService = sp.GetService<Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService>();
-            var persistencePath = Path.Combine(storageOptions.RootPath, "governance", "fund-structure.json");
-            return new InMemoryFundStructureService(
-                fundAccountService,
-                sharedDataAccessService,
-                securityMasterQueryService,
-                persistencePath);
-        });
-        services.TryAddSingleton<EnvironmentDesignerService>(sp =>
-        {
-            var storageOptions = sp.GetRequiredService<StorageOptions>();
-            var persistencePath = Path.Combine(storageOptions.RootPath, "governance", "environment-designer.json");
-            return new EnvironmentDesignerService(persistencePath);
-        });
-        services.TryAddSingleton<IEnvironmentDesignService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
-        services.TryAddSingleton<IEnvironmentValidationService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
-        services.TryAddSingleton<IEnvironmentPublishService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
-        services.TryAddSingleton<IEnvironmentRuntimeProjectionService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
-
-        services.TryAddSingleton<IDirectLendingService, InMemoryDirectLendingService>();
-        services.TryAddSingleton<IDirectLendingQueryService, InMemoryDirectLendingService>();
-        services.TryAddSingleton<IDirectLendingCommandService, InMemoryDirectLendingService>();
-        services.TryAddSingleton<IBankingService, InMemoryBankingService>();
-        services.TryAddSingleton<IMoneyMarketFundService, InMemoryMoneyMarketFundService>();
-        services.TryAddSingleton<IMmfLiquidityService>(sp => (IMmfLiquidityService)sp.GetRequiredService<IMoneyMarketFundService>());
 
         return services;
     }


### PR DESCRIPTION
### Motivation
- The change aimed to require an explicit opt-in (`MERIDIAN_USE_INMEMORY_GOVERNANCE`) for in-memory governance services and to fail-fast when that opt-in is used in `Production` to avoid unsafe in-memory fallbacks.
- The previous implementation introduced a regression that prevented normal (persistence-backed) startup when the opt-in was not set, which made the app unable to boot in intended default configurations.

### Description
- Updated `StorageFeatureRegistration` so in-memory governance registrations are performed only when `IsInMemoryGovernanceProfileEnabled()` returns `true` (i.e., explicit opt-in in a non-production environment), instead of throwing when the opt-in is not present.
- Removed the unconditional failure path that blocked default persistence-backed startup when `MERIDIAN_USE_INMEMORY_GOVERNANCE` was unset or `false` and moved the in-memory service registrations behind the opt-in check.
- Preserved the production safety guard inside `IsInMemoryGovernanceProfileEnabled()` so that setting the opt-in in `Production` still raises an `InvalidOperationException` and fails fast.
- All changes are localized to `src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs` and maintain the intended DI defaults where persistence-backed services are the default.

### Testing
- No automated .NET builds or tests were executed in this environment because `dotnet` tooling was not available here, so no unit/integration tests were run.
- Performed static/code-path validation by inspection to confirm the three main behaviours: the default unset/`false` opt-in allows persistence-backed startup, `true` opt-in + `Production` throws, and `true` opt-in + non-production registers in-memory services.
- Recommend running `dotnet build` and the focused test targets (for example `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj` with appropriate filters) in CI or a local environment to validate runtime behavior and that startup succeeds with persistence-backed configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10ae54cf888320a86ad49ace96f95c)