### PR TITLE
Add workstation cockpit acceptance matrix validator

### DIFF
--- a/docs/status/README.md
+++ b/docs/status/README.md
@@ -33,6 +33,7 @@ If a file says it is auto-generated, regenerate it instead of editing it manuall
 | [provider-validation-matrix.md](provider-validation-matrix.md) | `active` | Evidence-backed provider readiness matrix used by readiness docs |
 | [provider-capability-matrix.md](provider-capability-matrix.md) | `active` | Canonical adapter capability/readiness matrix for provider follow-up ownership |
 | [contract-compatibility-matrix.md](contract-compatibility-matrix.md) | `active` | Compatibility, deprecation, and migration policy for workstation/strategy/ledger contracts |
+| [workstation-cockpit-acceptance-matrix.md](workstation-cockpit-acceptance-matrix.md) | `active` | Machine-readable cockpit/governance acceptance matrix mapping routes, UI states, tests, and required evidence artifacts |
 | [production-status.md](production-status.md) | `active` | Current production and pilot-readiness caveats |
 | [kernel-readiness-dashboard.md](kernel-readiness-dashboard.md) | `active` | Single hand-authored DK program status dashboard for subsystem readiness, gate state, and rollback posture |
 | [IMPROVEMENTS.md](IMPROVEMENTS.md) | `active` | Tracked implementation themes and recommended focus areas |

--- a/docs/status/workstation-cockpit-acceptance-matrix.json
+++ b/docs/status/workstation-cockpit-acceptance-matrix.json
@@ -1,0 +1,117 @@
+{
+  "schemaVersion": 1,
+  "matrixId": "workstation-cockpit-governance-acceptance",
+  "lastReviewed": "2026-05-28",
+  "scope": "Machine-readable acceptance matrix for cockpit and governance readiness criteria that must stay mapped to route/API ownership, UI state, automated coverage, and evidence artifacts.",
+  "criteria": [
+    {
+      "id": "cockpit-trading-readiness-posture",
+      "criterion": "Trading readiness summarizes DK1 trust, paper-session continuity, replay status, execution controls, brokerage sync, report-pack readiness, and evidence completeness before an operator accepts paper operation.",
+      "routeOwnership": [
+        { "kind": "api", "route": "/api/workstation/trading/readiness", "owner": "WorkstationEndpoints.GetWorkstationTradingReadiness" },
+        { "kind": "ui", "route": "/trading/readiness", "owner": "OperatorReadinessConsole" }
+      ],
+      "uiBehaviorState": "The readiness console must show Ready, ReviewRequired, Blocked, and loading/error postures with gate-level disabled reasons, work-item details, and route-aware recovery actions.",
+      "automatedTests": [
+        { "project": "tests/Meridian.Tests", "filterableName": "MapWorkstationEndpoints_TradingReadiness_ShouldProjectSharedReadinessAndDegradeWhenEvidenceIsMissing" },
+        { "project": "src/Meridian.Ui/dashboard", "filterableName": "operator-readiness-console.view-model.test.ts > builds the API-first readiness console from shared workstation payloads" },
+        { "project": "tests/Meridian.FSharp.Tests", "filterableName": "Trading readiness overall posture follows canonical gate precedence" }
+      ],
+      "artifacts": [
+        { "kind": "screenshot", "path": "docs/screenshots/workstation/trading-readiness.png", "description": "Readiness console showing current gate states and recovery actions." },
+        { "kind": "packet", "path": "artifacts/provider-validation/_automation/2026-04-27/dk1-pilot-parity-packet.json", "description": "Signed DK1 trust packet that feeds readiness posture." }
+      ]
+    },
+    {
+      "id": "cockpit-operator-inbox-routing",
+      "criterion": "Operator inbox aggregates actionable readiness, reconciliation, brokerage, promotion, Security Master, and report-pack blockers without losing target routes or account scope.",
+      "routeOwnership": [
+        { "kind": "api", "route": "/api/workstation/operator/inbox", "owner": "WorkstationEndpoints.GetWorkstationOperatorInbox" },
+        { "kind": "ui", "route": "/trading/readiness", "owner": "OperatorReadinessConsole.queue" }
+      ],
+      "uiBehaviorState": "The inbox must prioritize critical rows, preserve selected detail, expose retry when the inbox fails, clear stale account-scoped rows while loading a new account, and keep fallback rows visible for triage.",
+      "automatedTests": [
+        { "project": "tests/Meridian.Tests", "filterableName": "MapWorkstationEndpoints_OperatorInbox_ShouldProjectTradingReadinessWorkItemsWithNavigation" },
+        { "project": "tests/Meridian.Tests", "filterableName": "MapWorkstationEndpoints_FundAccountScope_OperatorInboxScopedQueries_ShouldReturnPerAccountBrokerageSyncItemsWithoutCrossAccountLeakage" },
+        { "project": "src/Meridian.Ui/dashboard", "filterableName": "operator-readiness-console.view-model.test.ts > surfaces operator inbox failures while keeping payload fallbacks visible" }
+      ],
+      "artifacts": [
+        { "kind": "screenshot", "path": "docs/screenshots/workstation/operator-inbox.png", "description": "Inbox queue with critical ordering and selected work-item detail." },
+        { "kind": "json", "path": "artifacts/workstation/operator-inbox/latest-response.json", "description": "Captured inbox response used during acceptance review." }
+      ]
+    },
+    {
+      "id": "governance-report-pack-evidence",
+      "criterion": "Governed report-pack evidence must be discoverable from Reporting and linked from cockpit work items before acceptance can claim report output readiness.",
+      "routeOwnership": [
+        { "kind": "ui", "route": "/reporting/evidence", "owner": "EvidenceWorkbenchScreen" },
+        { "kind": "ui", "route": "/reporting/report-packs", "owner": "ReportingScreen.reportPacks" }
+      ],
+      "uiBehaviorState": "Evidence workbench links must preserve subjectKind and subjectId query parameters, and report-pack states must distinguish missing payload, in-review, approved, released, and export-busy states.",
+      "automatedTests": [
+        { "project": "src/Meridian.Ui/dashboard", "filterableName": "workspace.test.ts > builds encoded Evidence Workbench subject routes" },
+        { "project": "src/Meridian.Ui/dashboard", "filterableName": "operator-readiness-console.view-model.test.ts > keeps the headline in review when governed report-pack readiness is missing" },
+        { "project": "src/Meridian.Ui/dashboard", "filterableName": "governance-screen.view-model.test.ts > derives reporting profile selector rows and detail state" }
+      ],
+      "artifacts": [
+        { "kind": "manifest", "path": "artifacts/reporting/latest-report-pack-manifest.json", "description": "Report-pack manifest with template, run, approval, and release metadata." },
+        { "kind": "screenshot", "path": "docs/screenshots/workstation/reporting-evidence.png", "description": "Evidence workbench showing subject-scoped report evidence." }
+      ]
+    },
+    {
+      "id": "governance-reconciliation-break-triage",
+      "criterion": "Reconciliation breaks must be visible as governance work items with deterministic detail, resolve/dismiss action state, narratives, and evidence packet links.",
+      "routeOwnership": [
+        { "kind": "api", "route": "/api/workstation/reconciliation/cases", "owner": "WorkstationEndpoints.Reconciliation" },
+        { "kind": "ui", "route": "/accounting/reconciliation", "owner": "GovernanceScreen.reconciliation" }
+      ],
+      "uiBehaviorState": "The reconciliation lane must render open-break counts, selected detail, resolve/dismiss validation, failure copy, narrative context, and evidence packet actions for the selected run.",
+      "automatedTests": [
+        { "project": "tests/Meridian.Tests", "filterableName": "MapWorkstationEndpoints_OperatorInbox_ShouldIncludeOpenReconciliationBreaks" },
+        { "project": "src/Meridian.Ui/dashboard", "filterableName": "governance-screen.view-model.test.ts > derives reconciliation break action state and live announcements" },
+        { "project": "src/Meridian.Ui/dashboard", "filterableName": "governance-screen.view-model.test.ts > derives reconciliation detail actions from the selected run" }
+      ],
+      "artifacts": [
+        { "kind": "replay-output", "path": "artifacts/reconciliation/latest-break-replay.json", "description": "Replay output proving break queue state and transitions." },
+        { "kind": "screenshot", "path": "docs/screenshots/workstation/accounting-reconciliation.png", "description": "Reconciliation detail with evidence packet actions." }
+      ]
+    },
+    {
+      "id": "cockpit-fund-account-context-continuity",
+      "criterion": "Fund account context must thread through readiness and inbox calls so account-scoped brokerage and reconciliation blockers do not leak across accounts.",
+      "routeOwnership": [
+        { "kind": "api", "route": "/api/workstation/trading/readiness?fundAccountId={fundAccountId}", "owner": "WorkstationEndpoints.GetWorkstationTradingReadiness" },
+        { "kind": "api", "route": "/api/workstation/operator/inbox?fundAccountId={fundAccountId}", "owner": "WorkstationEndpoints.GetWorkstationOperatorInbox" }
+      ],
+      "uiBehaviorState": "Account changes must trigger scoped reloads, abort superseded inbox loads, clear stale rows, and keep the visible account context attached to action metadata.",
+      "automatedTests": [
+        { "project": "tests/Meridian.Tests", "filterableName": "MapWorkstationEndpoints_FundAccountScope_ShouldReturnOnlyRequestedAccountWorkItemsAndPreserveRoutingMetadata" },
+        { "project": "src/Meridian.Ui/dashboard", "filterableName": "operator-readiness-console.view-model.test.ts > clears stale account-scoped inbox rows while loading a new fund account inbox" },
+        { "project": "src/Meridian.Ui/dashboard", "filterableName": "operator-readiness-console.view-model.test.ts > aborts superseded operator inbox loads when the fund account changes" }
+      ],
+      "artifacts": [
+        { "kind": "json", "path": "artifacts/workstation/account-context/readiness-scoped-response.json", "description": "Scoped readiness response for the accepted fund account." },
+        { "kind": "json", "path": "artifacts/workstation/account-context/inbox-scoped-response.json", "description": "Scoped inbox response proving no cross-account leakage." }
+      ]
+    },
+    {
+      "id": "cockpit-replay-and-promotion-continuity",
+      "criterion": "Replay mismatch, stale replay, and promotion-review blockers must keep mirrored run identity, route metadata, and packet continuity across readiness, inbox, and evidence views.",
+      "routeOwnership": [
+        { "kind": "api", "route": "/api/workstation/trading/readiness", "owner": "WorkstationEndpoints.GetWorkstationTradingReadiness" },
+        { "kind": "ui", "route": "/trading/readiness", "owner": "OperatorReadinessConsole.replayAndPromotion" },
+        { "kind": "ui", "route": "/reporting/evidence?subjectKind=strategy-run&subjectId={runId}", "owner": "EvidenceWorkbenchScreen" }
+      ],
+      "uiBehaviorState": "Replay and promotion rows must expose mismatch reasons, stale replay recovery, mirrored run IDs, promotion packet action labels, and selected evidence-panel details.",
+      "automatedTests": [
+        { "project": "src/Meridian.Ui/dashboard", "filterableName": "operator-readiness-console.view-model.test.ts > maps replay mismatch and stale replay gates into the normalized checkpoints" },
+        { "project": "src/Meridian.Ui/dashboard", "filterableName": "operator-readiness-console.view-model.test.ts > keeps mirrored run-handoff identity and route metadata in operator work items" },
+        { "project": "src/Meridian.Ui/dashboard", "filterableName": "operator-readiness-console.view-model.test.ts > preserves route-aware packet continuity for blocker rows across state slices" }
+      ],
+      "artifacts": [
+        { "kind": "replay-output", "path": "artifacts/workstation/replay/latest-readiness-replay.json", "description": "Replay acceptance output with mismatch and freshness metadata." },
+        { "kind": "export-manifest", "path": "artifacts/workstation/promotion/latest-review-packet-manifest.json", "description": "Promotion review packet manifest tied to mirrored run identity." }
+      ]
+    }
+  ]
+}

--- a/docs/status/workstation-cockpit-acceptance-matrix.md
+++ b/docs/status/workstation-cockpit-acceptance-matrix.md
@@ -1,0 +1,44 @@
+# Workstation Cockpit Acceptance Matrix
+
+**Last reviewed:** 2026-05-28  
+**Machine-readable companion:** [`workstation-cockpit-acceptance-matrix.json`](workstation-cockpit-acceptance-matrix.json)  
+**Validator:** `python3 scripts/dev/validate_workstation_cockpit_acceptance_matrix.py`
+
+This matrix maps each cockpit/governance acceptance criterion to its route or API owner,
+required UI behavior/state, filterable automated coverage, and evidence artifact pointer. The JSON
+companion is the source used by CI-friendly validation; update the Markdown and JSON together when a
+criterion, route, test, or artifact expectation changes.
+
+## CI acceptance rule
+
+A criterion is invalid when any of these fields are missing or blank in the JSON companion:
+
+1. at least one route/API owner in `routeOwnership[].route`
+2. at least one automated coverage entry with both `project` and `filterableName`
+3. at least one evidence pointer in `artifacts[].path`
+
+Run the validator before claiming cockpit/governance acceptance evidence:
+
+```bash
+python3 scripts/dev/validate_workstation_cockpit_acceptance_matrix.py
+```
+
+## Matrix
+
+| Criterion ID | Owning route/API | Required UI behavior/state | Required automated tests | Required artifacts |
+| --- | --- | --- | --- | --- |
+| `cockpit-trading-readiness-posture` | `/api/workstation/trading/readiness`; `/trading/readiness` | Readiness console shows Ready, ReviewRequired, Blocked, loading, and error postures with gate-level disabled reasons, work-item details, and route-aware recovery actions. | `tests/Meridian.Tests` filter `MapWorkstationEndpoints_TradingReadiness_ShouldProjectSharedReadinessAndDegradeWhenEvidenceIsMissing`; `src/Meridian.Ui/dashboard` filter `operator-readiness-console.view-model.test.ts > builds the API-first readiness console from shared workstation payloads`; `tests/Meridian.FSharp.Tests` filter `Trading readiness overall posture follows canonical gate precedence` | `docs/screenshots/workstation/trading-readiness.png`; `artifacts/provider-validation/_automation/2026-04-27/dk1-pilot-parity-packet.json` |
+| `cockpit-operator-inbox-routing` | `/api/workstation/operator/inbox`; `/trading/readiness` | Inbox prioritizes critical rows, preserves selected detail, exposes retry when loading fails, clears stale account rows during account changes, and keeps fallback rows visible. | `tests/Meridian.Tests` filter `MapWorkstationEndpoints_OperatorInbox_ShouldProjectTradingReadinessWorkItemsWithNavigation`; `tests/Meridian.Tests` filter `MapWorkstationEndpoints_FundAccountScope_OperatorInboxScopedQueries_ShouldReturnPerAccountBrokerageSyncItemsWithoutCrossAccountLeakage`; `src/Meridian.Ui/dashboard` filter `operator-readiness-console.view-model.test.ts > surfaces operator inbox failures while keeping payload fallbacks visible` | `docs/screenshots/workstation/operator-inbox.png`; `artifacts/workstation/operator-inbox/latest-response.json` |
+| `governance-report-pack-evidence` | `/reporting/evidence`; `/reporting/report-packs` | Evidence links preserve `subjectKind`/`subjectId`; report-pack UI distinguishes missing payload, in-review, approved, released, and export-busy states. | `src/Meridian.Ui/dashboard` filter `workspace.test.ts > builds encoded Evidence Workbench subject routes`; `src/Meridian.Ui/dashboard` filter `operator-readiness-console.view-model.test.ts > keeps the headline in review when governed report-pack readiness is missing`; `src/Meridian.Ui/dashboard` filter `governance-screen.view-model.test.ts > derives reporting profile selector rows and detail state` | `artifacts/reporting/latest-report-pack-manifest.json`; `docs/screenshots/workstation/reporting-evidence.png` |
+| `governance-reconciliation-break-triage` | `/api/workstation/reconciliation/cases`; `/accounting/reconciliation` | Reconciliation lane renders open-break counts, selected detail, resolve/dismiss validation, failure copy, narrative context, and evidence packet actions. | `tests/Meridian.Tests` filter `MapWorkstationEndpoints_OperatorInbox_ShouldIncludeOpenReconciliationBreaks`; `src/Meridian.Ui/dashboard` filter `governance-screen.view-model.test.ts > derives reconciliation break action state and live announcements`; `src/Meridian.Ui/dashboard` filter `governance-screen.view-model.test.ts > derives reconciliation detail actions from the selected run` | `artifacts/reconciliation/latest-break-replay.json`; `docs/screenshots/workstation/accounting-reconciliation.png` |
+| `cockpit-fund-account-context-continuity` | `/api/workstation/trading/readiness?fundAccountId={fundAccountId}`; `/api/workstation/operator/inbox?fundAccountId={fundAccountId}` | Account changes trigger scoped reloads, abort superseded inbox loads, clear stale rows, and keep the visible account context attached to action metadata. | `tests/Meridian.Tests` filter `MapWorkstationEndpoints_FundAccountScope_ShouldReturnOnlyRequestedAccountWorkItemsAndPreserveRoutingMetadata`; `src/Meridian.Ui/dashboard` filter `operator-readiness-console.view-model.test.ts > clears stale account-scoped inbox rows while loading a new fund account inbox`; `src/Meridian.Ui/dashboard` filter `operator-readiness-console.view-model.test.ts > aborts superseded operator inbox loads when the fund account changes` | `artifacts/workstation/account-context/readiness-scoped-response.json`; `artifacts/workstation/account-context/inbox-scoped-response.json` |
+| `cockpit-replay-and-promotion-continuity` | `/api/workstation/trading/readiness`; `/trading/readiness`; `/reporting/evidence?subjectKind=strategy-run&subjectId={runId}` | Replay and promotion rows expose mismatch reasons, stale replay recovery, mirrored run IDs, promotion packet action labels, and selected evidence-panel details. | `src/Meridian.Ui/dashboard` filter `operator-readiness-console.view-model.test.ts > maps replay mismatch and stale replay gates into the normalized checkpoints`; `src/Meridian.Ui/dashboard` filter `operator-readiness-console.view-model.test.ts > keeps mirrored run-handoff identity and route metadata in operator work items`; `src/Meridian.Ui/dashboard` filter `operator-readiness-console.view-model.test.ts > preserves route-aware packet continuity for blocker rows across state slices` | `artifacts/workstation/replay/latest-readiness-replay.json`; `artifacts/workstation/promotion/latest-review-packet-manifest.json` |
+
+## Maintenance notes
+
+- Prefer stable, filterable test names over broad project references so failures can be reproduced
+  with targeted `dotnet test --filter` or dashboard test-name filters.
+- Artifact pointers may reference committed evidence, generated CI artifacts, or expected acceptance
+  outputs; they are pointers for acceptance evidence, not necessarily files committed to the repo.
+- Add a new criterion before claiming a new cockpit/governance acceptance path in roadmap or status
+  docs, then run the validator and include the command in review evidence.

--- a/scripts/dev/validate_workstation_cockpit_acceptance_matrix.py
+++ b/scripts/dev/validate_workstation_cockpit_acceptance_matrix.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Validate the workstation cockpit acceptance matrix for CI gates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MATRIX = REPO_ROOT / "docs" / "status" / "workstation-cockpit-acceptance-matrix.json"
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _non_blank(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def load_matrix(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("matrix root must be a JSON object")
+    return data
+
+
+def validate_matrix(data: dict[str, Any], *, source: Path | None = None) -> list[str]:
+    """Return validation errors for missing ownership, coverage, or artifact pointers."""
+
+    errors: list[str] = []
+    criteria = data.get("criteria")
+    if not isinstance(criteria, list) or not criteria:
+        location = f"{source}: " if source else ""
+        return [f"{location}criteria must be a non-empty array."]
+
+    seen_ids: set[str] = set()
+    for index, criterion in enumerate(criteria):
+        if not isinstance(criterion, dict):
+            errors.append(f"criteria[{index}]: criterion must be an object.")
+            continue
+
+        criterion_id = criterion.get("id") if _non_blank(criterion.get("id")) else f"criteria[{index}]"
+        if _non_blank(criterion.get("id")):
+            if criterion_id in seen_ids:
+                errors.append(f"{criterion_id}: duplicate criterion id.")
+            seen_ids.add(str(criterion_id))
+        else:
+            errors.append(f"criteria[{index}]: missing non-blank id.")
+
+        route_owners = _as_list(criterion.get("routeOwnership"))
+        if not route_owners:
+            errors.append(f"{criterion_id}: missing routeOwnership entries.")
+        elif not any(isinstance(owner, dict) and _non_blank(owner.get("route")) for owner in route_owners):
+            errors.append(f"{criterion_id}: routeOwnership must include at least one non-blank route.")
+
+        tests = _as_list(criterion.get("automatedTests"))
+        if not tests:
+            errors.append(f"{criterion_id}: missing automatedTests entries.")
+        elif not any(
+            isinstance(test, dict)
+            and _non_blank(test.get("project"))
+            and _non_blank(test.get("filterableName"))
+            for test in tests
+        ):
+            errors.append(
+                f"{criterion_id}: automatedTests must include at least one entry with project and filterableName."
+            )
+
+        artifacts = _as_list(criterion.get("artifacts"))
+        if not artifacts:
+            errors.append(f"{criterion_id}: missing artifacts entries.")
+        elif not any(isinstance(artifact, dict) and _non_blank(artifact.get("path")) for artifact in artifacts):
+            errors.append(f"{criterion_id}: artifacts must include at least one non-blank path.")
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--matrix",
+        type=Path,
+        default=DEFAULT_MATRIX,
+        help="Path to workstation-cockpit-acceptance-matrix.json.",
+    )
+    parser.add_argument("--summary", action="store_true", help="Print a concise pass summary.")
+    args = parser.parse_args(argv)
+
+    matrix_path = args.matrix if args.matrix.is_absolute() else REPO_ROOT / args.matrix
+    if not matrix_path.exists():
+        print(f"Acceptance matrix validation failed: {matrix_path} does not exist.", file=sys.stderr)
+        return 1
+
+    try:
+        data = load_matrix(matrix_path)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Acceptance matrix validation failed: could not load {matrix_path}: {exc}", file=sys.stderr)
+        return 1
+
+    errors = validate_matrix(data, source=matrix_path)
+    if errors:
+        print("Acceptance matrix validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f" - {error}", file=sys.stderr)
+        return 1
+
+    criteria_count = len(data.get("criteria", []))
+    if args.summary:
+        print(f"Acceptance matrix validation passed: {criteria_count} criteria checked.")
+    else:
+        print("Acceptance matrix validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_validate_workstation_cockpit_acceptance_matrix.py
+++ b/tests/scripts/test_validate_workstation_cockpit_acceptance_matrix.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "validate_workstation_cockpit_acceptance_matrix.py"
+SPEC = importlib.util.spec_from_file_location("validate_workstation_cockpit_acceptance_matrix", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+module = importlib.util.module_from_spec(SPEC)
+sys.modules["validate_workstation_cockpit_acceptance_matrix"] = module
+SPEC.loader.exec_module(module)
+
+
+def valid_matrix() -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "criteria": [
+            {
+                "id": "criterion-one",
+                "routeOwnership": [{"kind": "api", "route": "/api/workstation/example"}],
+                "automatedTests": [{"project": "tests/Meridian.Tests", "filterableName": "ExampleTests_ShouldPass"}],
+                "artifacts": [{"kind": "json", "path": "artifacts/workstation/example.json"}],
+            }
+        ],
+    }
+
+
+class WorkstationCockpitAcceptanceMatrixValidatorTests(unittest.TestCase):
+    def test_valid_matrix_passes(self) -> None:
+        self.assertEqual([], module.validate_matrix(valid_matrix()))
+
+    def test_rejects_missing_route_ownership(self) -> None:
+        matrix = valid_matrix()
+        matrix["criteria"][0]["routeOwnership"] = []  # type: ignore[index]
+
+        errors = module.validate_matrix(matrix)  # type: ignore[arg-type]
+
+        self.assertTrue(any("missing routeOwnership" in error for error in errors))
+
+    def test_rejects_missing_filterable_test_reference(self) -> None:
+        matrix = valid_matrix()
+        matrix["criteria"][0]["automatedTests"] = [{"project": "tests/Meridian.Tests", "filterableName": " "}]  # type: ignore[index]
+
+        errors = module.validate_matrix(matrix)  # type: ignore[arg-type]
+
+        self.assertTrue(any("automatedTests" in error and "filterableName" in error for error in errors))
+
+    def test_rejects_missing_artifact_pointer(self) -> None:
+        matrix = valid_matrix()
+        matrix["criteria"][0]["artifacts"] = [{"kind": "screenshot", "path": ""}]  # type: ignore[index]
+
+        errors = module.validate_matrix(matrix)  # type: ignore[arg-type]
+
+        self.assertTrue(any("artifacts" in error and "path" in error for error in errors))
+
+    def test_main_accepts_explicit_matrix_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            matrix_path = Path(tmp) / "matrix.json"
+            matrix_path.write_text(
+                '{"schemaVersion":1,"criteria":[{"id":"criterion-one","routeOwnership":[{"route":"/api/example"}],"automatedTests":[{"project":"tests/Meridian.Tests","filterableName":"Example"}],"artifacts":[{"path":"artifacts/example.json"}]}]}',
+                encoding="utf-8",
+            )
+
+            self.assertEqual(0, module.main(["--matrix", str(matrix_path), "--summary"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide a machine-readable acceptance matrix that maps cockpit/governance criteria to owning route/API, required UI behavior/state, required automated tests, and evidence artifacts to make acceptance claims auditable and CI-checkable.
- Prevent incomplete acceptance claims by adding an automated validator that fails CI when a criterion lacks route ownership, test coverage reference, or artifact pointer.

### Description

- Added a JSON machine-readable matrix at `docs/status/workstation-cockpit-acceptance-matrix.json` containing six initial criteria with `routeOwnership`, `uiBehaviorState`, `automatedTests`, and `artifacts` entries. 
- Added a Markdown companion `docs/status/workstation-cockpit-acceptance-matrix.md` that documents the CI rule and points to the JSON companion and validator command. 
- Implemented a CI-friendly validator script `scripts/dev/validate_workstation_cockpit_acceptance_matrix.py` that loads the JSON and fails when criteria are missing `routeOwnership[].route`, `automatedTests` entries with `project`+`filterableName`, or `artifacts[].path`; the script supports an explicit `--matrix` path and `--summary` output for CI logs. 
- Added unit tests `tests/scripts/test_validate_workstation_cockpit_acceptance_matrix.py` covering valid matrix, missing route ownership, missing filterable test reference, missing artifact pointer, and `--matrix` CLI handling, and linked the new matrix from `docs/status/README.md`.

### Testing

- Ran the validator in summary mode with `python3 scripts/dev/validate_workstation_cockpit_acceptance_matrix.py --summary` and it reported success for the committed matrix (`Acceptance matrix validation passed: 6 criteria checked`).
- Ran the unit test suite for the validator with `python3 -m unittest tests/scripts/test_validate_workstation_cockpit_acceptance_matrix.py` and all tests passed (`OK`).
- Performed repository lint/check `git diff --check` on the touched docs and scripts and no check errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a189f597de08320a8f1c25ada6631a2)