### PR TITLE
Accounting close: posting, FX translation, projections, and UI audit drill-through

### DIFF
--- a/src/Meridian.Application/AccountingClose/AccountingCloseModels.cs
+++ b/src/Meridian.Application/AccountingClose/AccountingCloseModels.cs
@@ -10,9 +10,29 @@ public enum ClosePeriodState
     Closed
 }
 
-public sealed record FxRate(string FromCurrency, string ToCurrency, DateOnly RateDate, decimal Rate, string SourceEventId);
+public sealed record LedgerDefinition(
+    string LedgerId,
+    string DisplayName,
+    string FunctionalCurrency,
+    string ReportingCurrency);
 
-public sealed record JournalLine(string AccountCode, decimal Amount, string Currency, bool IsDebit);
+public sealed record FxRate(
+    string FromCurrency,
+    string ToCurrency,
+    DateOnly RateDate,
+    decimal Rate,
+    string SourceEventId,
+    string RateId = "",
+    DateTimeOffset? ObservedAt = null);
+
+public sealed record JournalLine(
+    string AccountCode,
+    decimal Amount,
+    string Currency,
+    bool IsDebit,
+    string SourceEventId = "",
+    string ApprovalId = "",
+    string Memo = "");
 
 public sealed record JournalEntry(
     Guid JournalEntryId,
@@ -20,7 +40,10 @@ public sealed record JournalEntry(
     DateOnly TradeDate,
     string SourceEventId,
     string Description,
-    ImmutableArray<JournalLine> Lines);
+    ImmutableArray<JournalLine> Lines,
+    DateOnly? AccountingPeriod = null,
+    DateTimeOffset? CreatedAt = null,
+    string CreatedBy = "system");
 
 public sealed record TranslationAdjustment(
     Guid AdjustmentId,
@@ -30,17 +53,72 @@ public sealed record TranslationAdjustment(
     decimal FunctionalAmount,
     decimal ReportingAmount,
     decimal AdjustmentAmount,
-    string SourceEventId);
+    string SourceEventId,
+    string FromCurrency = "",
+    string ToCurrency = "",
+    string RateId = "",
+    string ApprovalId = "");
 
-public sealed record CloseEvidence(bool TrialBalanceSignedOff, bool ReconciliationSignedOff, bool ApprovalsCompleted);
+public sealed record CloseEvidenceCheck(
+    string CheckId,
+    string Label,
+    bool Required,
+    bool Passed,
+    string SourceEventId,
+    string ApprovalId,
+    string Detail);
+
+public sealed record CloseEvidence(
+    bool TrialBalanceSignedOff,
+    bool ReconciliationSignedOff,
+    bool ApprovalsCompleted,
+    ImmutableArray<CloseEvidenceCheck> Checks = default)
+{
+    public ImmutableArray<CloseEvidenceCheck> NormalizedChecks => Checks.IsDefault ? ImmutableArray<CloseEvidenceCheck>.Empty : Checks;
+}
 
 public sealed record ClosePeriod(
     string LedgerId,
     DateOnly Period,
     ClosePeriodState State,
     CloseEvidence Evidence,
-    ImmutableArray<string> Blockers);
+    ImmutableArray<string> Blockers,
+    DateTimeOffset? LockedAt = null,
+    string? ClosedBy = null)
+{
+    public bool IsLocked => State == ClosePeriodState.Closed || LockedAt is not null;
+}
 
-public sealed record TrialBalanceLine(string AccountCode, decimal Debit, decimal Credit, decimal Net);
-public sealed record RollForwardLine(string AccountCode, decimal OpeningBalance, decimal Activity, decimal TranslationAdjustment, decimal ClosingBalance);
-public sealed record SourceLinkedAuditLine(Guid JournalEntryId, string SourceEventId, string ApprovalId);
+public sealed record TrialBalanceLine(
+    string AccountCode,
+    decimal Debit,
+    decimal Credit,
+    decimal Net,
+    ImmutableArray<string> SourceEventIds = default,
+    ImmutableArray<string> ApprovalIds = default);
+
+public sealed record RollForwardLine(
+    string AccountCode,
+    decimal OpeningBalance,
+    decimal Activity,
+    decimal TranslationAdjustment,
+    decimal ClosingBalance,
+    ImmutableArray<string> SourceEventIds = default,
+    ImmutableArray<string> ApprovalIds = default);
+
+public sealed record SourceLinkedAuditLine(
+    Guid JournalEntryId,
+    string SourceEventId,
+    string ApprovalId,
+    DateOnly? AccountingPeriod = null,
+    string Description = "",
+    ImmutableArray<string> AccountCodes = default);
+
+public sealed record JournalPostingResult(
+    string LedgerId,
+    ImmutableArray<JournalEntry> PostedEntries,
+    ImmutableArray<SourceLinkedAuditLine> AuditLines,
+    ImmutableArray<string> RejectedReasons)
+{
+    public bool Accepted => RejectedReasons.IsDefaultOrEmpty;
+}

--- a/src/Meridian.Application/AccountingClose/AccountingCloseServices.cs
+++ b/src/Meridian.Application/AccountingClose/AccountingCloseServices.cs
@@ -1,39 +1,205 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Meridian.Application.AccountingClose;
 
 public sealed class AccountingPostingService
 {
-    private readonly ConcurrentDictionary<string, ImmutableArray<JournalEntry>> _journals = new();
+    private readonly ConcurrentDictionary<string, ImmutableArray<JournalEntry>> _journals = new(StringComparer.OrdinalIgnoreCase);
 
     public ImmutableArray<JournalEntry> Post(string ledgerId, IEnumerable<JournalEntry> entries)
     {
-        var ordered = entries.OrderBy(static e => e.TradeDate).ThenBy(static e => e.JournalEntryId).ToImmutableArray();
-        _journals[ledgerId] = ordered;
-        return ordered;
+        var result = PostWithResult(ledgerId, entries);
+        if (!result.Accepted)
+        {
+            throw new InvalidOperationException(string.Join(" ", result.RejectedReasons));
+        }
+
+        return result.PostedEntries;
     }
 
-    public ImmutableArray<JournalEntry> Replay(string ledgerId) => _journals.TryGetValue(ledgerId, out var entries) ? entries : ImmutableArray<JournalEntry>.Empty;
+    public JournalPostingResult PostWithResult(
+        string ledgerId,
+        IEnumerable<JournalEntry> entries,
+        ClosePeriod? closePeriod = null)
+    {
+        if (string.IsNullOrWhiteSpace(ledgerId))
+        {
+            throw new ArgumentException("Ledger id is required.", nameof(ledgerId));
+        }
 
-    public ImmutableArray<SourceLinkedAuditLine> Audit(string ledgerId) => Replay(ledgerId)
-        .Select(static e => new SourceLinkedAuditLine(e.JournalEntryId, e.SourceEventId, $"approval-{e.JournalEntryId:N}"))
-        .ToImmutableArray();
+        ArgumentNullException.ThrowIfNull(entries);
+
+        var rejected = ImmutableArray.CreateBuilder<string>();
+        if (closePeriod?.IsLocked == true)
+        {
+            rejected.Add($"Accounting period {closePeriod.Period:yyyy-MM-dd} for ledger {closePeriod.LedgerId} is locked.");
+        }
+
+        var normalized = entries
+            .Select(entry => NormalizeEntry(ledgerId, entry))
+            .OrderBy(static entry => entry.AccountingPeriod ?? entry.TradeDate)
+            .ThenBy(static entry => entry.TradeDate)
+            .ThenBy(static entry => entry.JournalEntryId)
+            .ToImmutableArray();
+
+        foreach (var entry in normalized)
+        {
+            if (entry.Lines.IsDefaultOrEmpty)
+            {
+                rejected.Add($"Journal entry {entry.JournalEntryId:D} has no lines.");
+                continue;
+            }
+
+            foreach (var currencyGroup in entry.Lines.GroupBy(static line => NormalizeCurrency(line.Currency)))
+            {
+                var debit = currencyGroup.Where(static line => line.IsDebit).Sum(static line => line.Amount);
+                var credit = currencyGroup.Where(static line => !line.IsDebit).Sum(static line => line.Amount);
+                if (decimal.Round(debit - credit, 2, MidpointRounding.AwayFromZero) != 0m)
+                {
+                    rejected.Add($"Journal entry {entry.JournalEntryId:D} is out of balance for {currencyGroup.Key}: debits {debit:0.00}, credits {credit:0.00}.");
+                }
+            }
+        }
+
+        if (rejected.Count > 0)
+        {
+            return new JournalPostingResult(ledgerId, ImmutableArray<JournalEntry>.Empty, ImmutableArray<SourceLinkedAuditLine>.Empty, rejected.ToImmutable());
+        }
+
+        _journals.AddOrUpdate(
+            ledgerId,
+            normalized,
+            (_, current) => current.Concat(normalized)
+                .OrderBy(static entry => entry.AccountingPeriod ?? entry.TradeDate)
+                .ThenBy(static entry => entry.TradeDate)
+                .ThenBy(static entry => entry.JournalEntryId)
+                .ToImmutableArray());
+
+        var posted = Replay(ledgerId);
+        return new JournalPostingResult(ledgerId, posted, BuildAudit(posted), ImmutableArray<string>.Empty);
+    }
+
+    public ImmutableArray<JournalEntry> Replay(string ledgerId)
+        => _journals.TryGetValue(ledgerId, out var entries) ? entries : ImmutableArray<JournalEntry>.Empty;
+
+    public ImmutableArray<SourceLinkedAuditLine> Audit(string ledgerId) => BuildAudit(Replay(ledgerId));
+
+    private static JournalEntry NormalizeEntry(string ledgerId, JournalEntry entry)
+        => entry with
+        {
+            LedgerId = ledgerId,
+            AccountingPeriod = entry.AccountingPeriod ?? new DateOnly(entry.TradeDate.Year, entry.TradeDate.Month, 1),
+            Lines = entry.Lines.IsDefault ? ImmutableArray<JournalLine>.Empty : entry.Lines
+        };
+
+    private static ImmutableArray<SourceLinkedAuditLine> BuildAudit(IEnumerable<JournalEntry> entries)
+        => entries
+            .Select(static entry => new SourceLinkedAuditLine(
+                entry.JournalEntryId,
+                entry.SourceEventId,
+                ResolveApprovalId(entry),
+                entry.AccountingPeriod,
+                entry.Description,
+                entry.Lines.IsDefault
+                    ? ImmutableArray<string>.Empty
+                    : entry.Lines.Select(static line => line.AccountCode).Distinct(StringComparer.OrdinalIgnoreCase).Order(StringComparer.OrdinalIgnoreCase).ToImmutableArray()))
+            .ToImmutableArray();
+
+    private static string ResolveApprovalId(JournalEntry entry)
+        => entry.Lines.IsDefault
+            ? $"approval-{entry.JournalEntryId:N}"
+            : entry.Lines.Select(static line => line.ApprovalId).FirstOrDefault(static approval => !string.IsNullOrWhiteSpace(approval))
+                ?? $"approval-{entry.JournalEntryId:N}";
+
+    private static string NormalizeCurrency(string currency)
+        => string.IsNullOrWhiteSpace(currency) ? "UNSPECIFIED" : currency.Trim().ToUpperInvariant();
 }
 
 public sealed class FxTranslationService
 {
     public TranslationAdjustment Translate(string ledgerId, DateOnly period, string accountCode, decimal functionalAmount, FxRate rate)
     {
+        ArgumentNullException.ThrowIfNull(rate);
+
         var reportingAmount = decimal.Round(functionalAmount * rate.Rate, 2, MidpointRounding.AwayFromZero);
         var adjustment = reportingAmount - functionalAmount;
-        return new TranslationAdjustment(Guid.NewGuid(), ledgerId, period, accountCode, functionalAmount, reportingAmount, adjustment, rate.SourceEventId);
+        var adjustmentId = CreateDeterministicId(ledgerId, period, accountCode, functionalAmount, reportingAmount, rate);
+        return new TranslationAdjustment(
+            adjustmentId,
+            ledgerId,
+            period,
+            accountCode,
+            functionalAmount,
+            reportingAmount,
+            adjustment,
+            rate.SourceEventId,
+            rate.FromCurrency,
+            rate.ToCurrency,
+            string.IsNullOrWhiteSpace(rate.RateId) ? rate.SourceEventId : rate.RateId);
+    }
+
+    public ImmutableArray<TranslationAdjustment> TranslateTrialBalance(
+        string ledgerId,
+        DateOnly period,
+        IEnumerable<TrialBalanceLine> lines,
+        FxRate rate)
+    {
+        ArgumentNullException.ThrowIfNull(lines);
+        return lines
+            .OrderBy(static line => line.AccountCode, StringComparer.OrdinalIgnoreCase)
+            .Select(line => Translate(ledgerId, period, line.AccountCode, line.Net, rate))
+            .ToImmutableArray();
+    }
+
+    private static Guid CreateDeterministicId(
+        string ledgerId,
+        DateOnly period,
+        string accountCode,
+        decimal functionalAmount,
+        decimal reportingAmount,
+        FxRate rate)
+    {
+        var input = string.Join('|', ledgerId, period.ToString("yyyy-MM-dd"), accountCode, functionalAmount, reportingAmount, rate.FromCurrency, rate.ToCurrency, rate.RateDate.ToString("yyyy-MM-dd"), rate.Rate, rate.SourceEventId, rate.RateId);
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        return new Guid(hash[..16]);
     }
 }
 
 public sealed class MonthEndCloseStateMachine
 {
     public ClosePeriod Transition(ClosePeriod current, CloseEvidence evidence, bool isTrialBalanceBalanced)
+    {
+        ArgumentNullException.ThrowIfNull(evidence);
+
+        if (current.State == ClosePeriodState.Closed)
+        {
+            return current;
+        }
+
+        var blockers = BuildBlockers(evidence, isTrialBalanceBalanced);
+        var nextState = current.State switch
+        {
+            ClosePeriodState.Open => ClosePeriodState.Validating,
+            ClosePeriodState.Validating when blockers.Count == 0 => ClosePeriodState.Closed,
+            ClosePeriodState.Validating => ClosePeriodState.Blocked,
+            ClosePeriodState.Blocked when blockers.Count == 0 => ClosePeriodState.Closed,
+            ClosePeriodState.Blocked => ClosePeriodState.Blocked,
+            _ => current.State
+        };
+
+        return current with
+        {
+            State = nextState,
+            Evidence = evidence,
+            Blockers = blockers.ToImmutable(),
+            LockedAt = nextState == ClosePeriodState.Closed ? DateTimeOffset.UtcNow : current.LockedAt
+        };
+    }
+
+    private static ImmutableArray<string>.Builder BuildBlockers(CloseEvidence evidence, bool isTrialBalanceBalanced)
     {
         var blockers = ImmutableArray.CreateBuilder<string>();
         if (!isTrialBalanceBalanced)
@@ -56,15 +222,12 @@ public sealed class MonthEndCloseStateMachine
             blockers.Add("Approval evidence missing.");
         }
 
-        var nextState = blockers.Count switch
+        foreach (var check in evidence.NormalizedChecks.Where(static check => check.Required && !check.Passed))
         {
-            0 when current.State is ClosePeriodState.Validating or ClosePeriodState.Open => ClosePeriodState.Closed,
-            0 => current.State,
-            _ when current.State == ClosePeriodState.Open => ClosePeriodState.Validating,
-            _ => ClosePeriodState.Blocked
-        };
+            blockers.Add($"{check.Label} evidence check failed: {check.Detail}");
+        }
 
-        return current with { State = nextState, Evidence = evidence, Blockers = blockers.ToImmutable() };
+        return blockers;
     }
 }
 
@@ -72,23 +235,41 @@ public sealed class TrialBalanceProjectionService
 {
     public ImmutableArray<TrialBalanceLine> BuildTrialBalance(IEnumerable<JournalEntry> entries)
     {
-        return entries
-            .SelectMany(static entry => entry.Lines)
-            .GroupBy(static line => line.AccountCode)
-            .Select(group =>
+        ArgumentNullException.ThrowIfNull(entries);
+
+        var buckets = new Dictionary<string, TrialBalanceAccumulator>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in entries)
+        {
+            if (entry.Lines.IsDefaultOrEmpty)
             {
-                var debit = group.Where(static line => line.IsDebit).Sum(static line => line.Amount);
-                var credit = group.Where(static line => !line.IsDebit).Sum(static line => line.Amount);
-                return new TrialBalanceLine(group.Key, debit, credit, debit - credit);
-            })
-            .OrderBy(static line => line.AccountCode)
+                continue;
+            }
+
+            foreach (var line in entry.Lines)
+            {
+                if (!buckets.TryGetValue(line.AccountCode, out var accumulator))
+                {
+                    accumulator = new TrialBalanceAccumulator(line.AccountCode);
+                    buckets[line.AccountCode] = accumulator;
+                }
+
+                accumulator.Add(entry, line);
+            }
+        }
+
+        return buckets.Values
+            .OrderBy(static accumulator => accumulator.AccountCode, StringComparer.OrdinalIgnoreCase)
+            .Select(static accumulator => accumulator.ToLine())
             .ToImmutableArray();
     }
 
     public bool IsBalanced(IEnumerable<TrialBalanceLine> lines)
     {
-        var totalDebit = lines.Sum(static line => line.Debit);
-        var totalCredit = lines.Sum(static line => line.Credit);
+        ArgumentNullException.ThrowIfNull(lines);
+
+        var materialized = lines.ToArray();
+        var totalDebit = materialized.Sum(static line => line.Debit);
+        var totalCredit = materialized.Sum(static line => line.Credit);
         return decimal.Round(totalDebit - totalCredit, 2, MidpointRounding.AwayFromZero) == 0m;
     }
 
@@ -97,20 +278,85 @@ public sealed class TrialBalanceProjectionService
         IEnumerable<TrialBalanceLine> activity,
         IEnumerable<TranslationAdjustment> fx)
     {
-        var map = opening.ToDictionary(static x => x.AccountCode, static x => x.Net);
-        foreach (var line in activity)
+        ArgumentNullException.ThrowIfNull(opening);
+        ArgumentNullException.ThrowIfNull(activity);
+        ArgumentNullException.ThrowIfNull(fx);
+
+        var openingRows = opening.ToArray();
+        var activityRows = activity.ToArray();
+        var fxRows = fx.ToArray();
+        var accountCodes = openingRows.Select(static row => row.AccountCode)
+            .Concat(activityRows.Select(static row => row.AccountCode))
+            .Concat(fxRows.Select(static row => row.AccountCode))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Order(StringComparer.OrdinalIgnoreCase);
+
+        return accountCodes.Select(accountCode =>
         {
-            map.TryGetValue(line.AccountCode, out var current);
-            map[line.AccountCode] = current + line.Net;
+            var openingBalance = openingRows.Where(row => string.Equals(row.AccountCode, accountCode, StringComparison.OrdinalIgnoreCase)).Sum(static row => row.Net);
+            var activityBalance = activityRows.Where(row => string.Equals(row.AccountCode, accountCode, StringComparison.OrdinalIgnoreCase)).Sum(static row => row.Net);
+            var adjustment = fxRows.Where(row => string.Equals(row.AccountCode, accountCode, StringComparison.OrdinalIgnoreCase)).Sum(static row => row.AdjustmentAmount);
+            var sourceEventIds = activityRows.Where(row => string.Equals(row.AccountCode, accountCode, StringComparison.OrdinalIgnoreCase))
+                .SelectMany(static row => row.SourceEventIds.IsDefault ? ImmutableArray<string>.Empty : row.SourceEventIds)
+                .Concat(fxRows.Where(row => string.Equals(row.AccountCode, accountCode, StringComparison.OrdinalIgnoreCase)).Select(static row => row.SourceEventId))
+                .Where(static value => !string.IsNullOrWhiteSpace(value))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Order(StringComparer.OrdinalIgnoreCase)
+                .ToImmutableArray();
+            var approvalIds = activityRows.Where(row => string.Equals(row.AccountCode, accountCode, StringComparison.OrdinalIgnoreCase))
+                .SelectMany(static row => row.ApprovalIds.IsDefault ? ImmutableArray<string>.Empty : row.ApprovalIds)
+                .Where(static value => !string.IsNullOrWhiteSpace(value))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Order(StringComparer.OrdinalIgnoreCase)
+                .ToImmutableArray();
+            return new RollForwardLine(accountCode, openingBalance, activityBalance, adjustment, openingBalance + activityBalance + adjustment, sourceEventIds, approvalIds);
+        }).ToImmutableArray();
+    }
+}
+internal sealed class TrialBalanceAccumulator
+{
+    private readonly HashSet<string> _sourceEventIds = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _approvalIds = new(StringComparer.OrdinalIgnoreCase);
+
+    public TrialBalanceAccumulator(string accountCode)
+    {
+        AccountCode = accountCode;
+    }
+
+    public string AccountCode { get; }
+    public decimal Debit { get; private set; }
+    public decimal Credit { get; private set; }
+
+    public void Add(JournalEntry entry, JournalLine line)
+    {
+        if (line.IsDebit)
+        {
+            Debit += line.Amount;
+        }
+        else
+        {
+            Credit += line.Amount;
         }
 
-        var fxMap = fx.GroupBy(static x => x.AccountCode).ToDictionary(static g => g.Key, static g => g.Sum(static x => x.AdjustmentAmount));
-        return map.Select(kvp =>
+        AddIfPresent(entry.SourceEventId, _sourceEventIds);
+        AddIfPresent(line.SourceEventId, _sourceEventIds);
+        AddIfPresent(line.ApprovalId, _approvalIds);
+    }
+
+    public TrialBalanceLine ToLine()
+        => new(
+            AccountCode,
+            Debit,
+            Credit,
+            Debit - Credit,
+            _sourceEventIds.Order(StringComparer.OrdinalIgnoreCase).ToImmutableArray(),
+            _approvalIds.Order(StringComparer.OrdinalIgnoreCase).ToImmutableArray());
+
+    private static void AddIfPresent(string value, HashSet<string> target)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
         {
-            fxMap.TryGetValue(kvp.Key, out var adj);
-            var openingBalance = opening.FirstOrDefault(x => x.AccountCode == kvp.Key)?.Net ?? 0m;
-            var closing = kvp.Value + adj;
-            return new RollForwardLine(kvp.Key, openingBalance, kvp.Value - openingBalance, adj, closing);
-        }).OrderBy(static x => x.AccountCode).ToImmutableArray();
+            target.Add(value.Trim());
+        }
     }
 }

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -25,6 +25,7 @@ and UI presentation concerns in their owning layers.
 ## Key folders and files
 
 - `Commands/` - CLI command handlers and operator workflows.
+- `AccountingClose/` - journal posting, deterministic ledger replay, FX translation adjustments, trial-balance/roll-forward projections, source-event audit linkage, and month-end close state gates.
 - `Reconciliation/` - statement intake, canonical matching, materiality-aware break
   classification, recommended actions, and case creation gates.
 - `OperationsContinuity/` - account-period continuity aggregate, command transitions, audit
@@ -47,7 +48,10 @@ and UI presentation concerns in their owning layers.
 ## Important workflows
 
 Use this module when changing command behavior, workflow orchestration, feature registration, or
-application service contracts consumed by host and UI surfaces.
+application service contracts consumed by host and UI surfaces. Accounting close workflows now require
+source-linked balanced journal postings, deterministic replay order, FX rate lineage, trial-balance
+evidence, reconciliation sign-off, approvals, and required evidence checks before a period can lock as
+closed.
 
 ## API contract notes
 

--- a/src/Meridian.Ui.Services/README.md
+++ b/src/Meridian.Ui.Services/README.md
@@ -15,6 +15,9 @@ last_reviewed: 2026-05-25
 
 UI services contains workstation endpoints, UI projections, and operator workflow service support.
 
+
+`Services/Accounting/AccountingProjectionQueryService.cs` exposes shared accounting close projections for desktop and browser surfaces: trial balance, roll-forward, source-linked audit rows, and close-state evidence gates.
+
 ## Layer responsibility
 
 This module owns backend read-model and workflow surfaces for operator UI clients. Keep endpoint

--- a/src/Meridian.Ui.Services/Services/Accounting/AccountingProjectionQueryService.cs
+++ b/src/Meridian.Ui.Services/Services/Accounting/AccountingProjectionQueryService.cs
@@ -8,17 +8,24 @@ public interface IAccountingProjectionQueryService
     ImmutableArray<TrialBalanceLine> GetTrialBalance(string ledgerId);
     ImmutableArray<RollForwardLine> GetRollForward(string ledgerId);
     ImmutableArray<SourceLinkedAuditLine> GetAuditLines(string ledgerId);
+    SourceLinkedAuditLine? GetAuditLine(string ledgerId, Guid journalEntryId);
+    AccountingCloseProjection GetCloseProjection(string ledgerId, DateOnly period, CloseEvidence evidence);
 }
 
 public sealed class AccountingProjectionQueryService : IAccountingProjectionQueryService
 {
     private readonly AccountingPostingService _postingService;
     private readonly TrialBalanceProjectionService _projectionService;
+    private readonly MonthEndCloseStateMachine _closeStateMachine;
 
-    public AccountingProjectionQueryService(AccountingPostingService postingService, TrialBalanceProjectionService projectionService)
+    public AccountingProjectionQueryService(
+        AccountingPostingService postingService,
+        TrialBalanceProjectionService projectionService,
+        MonthEndCloseStateMachine? closeStateMachine = null)
     {
         _postingService = postingService;
         _projectionService = projectionService;
+        _closeStateMachine = closeStateMachine ?? new MonthEndCloseStateMachine();
     }
 
     public ImmutableArray<TrialBalanceLine> GetTrialBalance(string ledgerId)
@@ -32,4 +39,27 @@ public sealed class AccountingProjectionQueryService : IAccountingProjectionQuer
 
     public ImmutableArray<SourceLinkedAuditLine> GetAuditLines(string ledgerId)
         => _postingService.Audit(ledgerId);
+
+    public SourceLinkedAuditLine? GetAuditLine(string ledgerId, Guid journalEntryId)
+        => GetAuditLines(ledgerId).FirstOrDefault(line => line.JournalEntryId == journalEntryId);
+
+    public AccountingCloseProjection GetCloseProjection(string ledgerId, DateOnly period, CloseEvidence evidence)
+    {
+        var trialBalance = GetTrialBalance(ledgerId);
+        var rollForward = GetRollForward(ledgerId);
+        var audit = GetAuditLines(ledgerId);
+        var balanced = _projectionService.IsBalanced(trialBalance);
+        var closePeriod = new ClosePeriod(ledgerId, period, ClosePeriodState.Validating, evidence, []);
+        var state = _closeStateMachine.Transition(closePeriod, evidence, balanced);
+        return new AccountingCloseProjection(ledgerId, period, state, balanced, trialBalance, rollForward, audit);
+    }
 }
+
+public sealed record AccountingCloseProjection(
+    string LedgerId,
+    DateOnly Period,
+    ClosePeriod ClosePeriod,
+    bool TrialBalanceBalanced,
+    ImmutableArray<TrialBalanceLine> TrialBalance,
+    ImmutableArray<RollForwardLine> RollForward,
+    ImmutableArray<SourceLinkedAuditLine> AuditTrail);

--- a/src/Meridian.Ui/dashboard/README.md
+++ b/src/Meridian.Ui/dashboard/README.md
@@ -106,3 +106,7 @@ endpoint contracts for behavior also consumed by WPF or host workflows.
 - `docs/source/generated/source-module-index.md`
 
 Browser reconciliation route helpers include the shared Accounting casework family for assignment, lifecycle transitions, comments, taxonomy, sign-off, reopen, audit, bulk triage, and bulk status/result lookup; keep these helpers aligned with `UiApiRoutes` and WPF consumers.
+
+## Accounting close browser surface
+
+The Accounting route reuses governance ledger views and now includes trial-balance source-event and approval drill-through affordances. Keep browser-only rendering in `src/screens/governance-screen.tsx` and shared accounting close contracts in `src/features/accounting/accountingCloseModels.ts`.

--- a/src/Meridian.Ui/dashboard/src/features/accounting/accountingCloseModels.ts
+++ b/src/Meridian.Ui/dashboard/src/features/accounting/accountingCloseModels.ts
@@ -5,6 +5,8 @@ export interface TrialBalanceRow {
   debit: number;
   credit: number;
   net: number;
+  sourceEventIds?: string[];
+  approvalIds?: string[];
 }
 
 export interface RollForwardRow {
@@ -13,10 +15,34 @@ export interface RollForwardRow {
   activity: number;
   translationAdjustment: number;
   closingBalance: number;
+  sourceEventIds?: string[];
+  approvalIds?: string[];
 }
 
 export interface AuditDrillThroughRow {
   journalEntryId: string;
   sourceEventId: string;
   approvalId: string;
+  accountingPeriod?: string | null;
+  description?: string | null;
+  accountCodes?: string[];
+}
+
+export interface CloseEvidenceCheck {
+  checkId: string;
+  label: string;
+  required: boolean;
+  passed: boolean;
+  sourceEventId: string;
+  approvalId: string;
+  detail: string;
+}
+
+export interface ClosePeriodProjection {
+  ledgerId: string;
+  period: string;
+  state: CloseWorkflowState;
+  blockers: string[];
+  trialBalanceBalanced: boolean;
+  evidenceChecks: CloseEvidenceCheck[];
 }

--- a/src/Meridian.Ui/dashboard/src/screens/governance-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/governance-screen.tsx
@@ -841,15 +841,33 @@ export function GovernanceScreen({ data }: GovernanceScreenProps) {
                   />
                   {reconciliation.trialBalanceView.selectedDetail ? (
                     <div id={reconciliation.trialBalanceView.detailPanelId} className="min-w-0">
-                      <EntitySummary
-                        eyebrow={reconciliation.trialBalanceView.selectedDetail.eyebrow}
-                        title={reconciliation.trialBalanceView.selectedDetail.title}
-                        subtitle={reconciliation.trialBalanceView.selectedDetail.subtitle}
-                        description={reconciliation.trialBalanceView.selectedDetail.description}
-                        status={<Badge variant={reconciliation.trialBalanceView.selectedDetail.statusVariant} dot>{reconciliation.trialBalanceView.selectedDetail.statusLabel}</Badge>}
-                        fields={reconciliation.trialBalanceView.selectedDetail.fields}
-                        ariaLabel={reconciliation.trialBalanceView.selectedDetail.ariaLabel}
-                      />
+                      <>
+                        <EntitySummary
+                          eyebrow={reconciliation.trialBalanceView.selectedDetail.eyebrow}
+                          title={reconciliation.trialBalanceView.selectedDetail.title}
+                          subtitle={reconciliation.trialBalanceView.selectedDetail.subtitle}
+                          description={reconciliation.trialBalanceView.selectedDetail.description}
+                          status={<Badge variant={reconciliation.trialBalanceView.selectedDetail.statusVariant} dot>{reconciliation.trialBalanceView.selectedDetail.statusLabel}</Badge>}
+                          fields={reconciliation.trialBalanceView.selectedDetail.fields}
+                          ariaLabel={reconciliation.trialBalanceView.selectedDetail.ariaLabel}
+                        />
+                        <div className="mt-3 flex flex-wrap gap-2" aria-label="Trial balance audit drill-through actions">
+                          {reconciliation.trialBalanceView.selectedDetail.auditDrillThroughHref ? (
+                            <Button asChild size="sm" variant="secondary">
+                              <Link to={reconciliation.trialBalanceView.selectedDetail.auditDrillThroughHref}>
+                                {reconciliation.trialBalanceView.selectedDetail.auditDrillThroughLabel}
+                              </Link>
+                            </Button>
+                          ) : (
+                            <span className="text-xs text-muted-foreground">{reconciliation.trialBalanceView.selectedDetail.auditDrillThroughLabel}</span>
+                          )}
+                          {reconciliation.trialBalanceView.selectedDetail.approvalDrillThroughHref ? (
+                            <Button asChild size="sm" variant="outline">
+                              <Link to={reconciliation.trialBalanceView.selectedDetail.approvalDrillThroughHref}>Open approval evidence</Link>
+                            </Button>
+                          ) : null}
+                        </div>
+                      </>
                     </div>
                   ) : (
                     <aside

--- a/src/Meridian.Ui/dashboard/src/screens/governance-screen.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/governance-screen.view-model.test.ts
@@ -1002,6 +1002,34 @@ describe("governance-screen view model", () => {
     });
   });
 
+  it("adds source-event and approval drill-through details to trial-balance selections", () => {
+    const state = buildGovernanceTrialBalanceViewState({
+      runId: "run-42",
+      rows: [
+        {
+          accountName: "Cash",
+          accountType: "Asset",
+          symbol: null,
+          financialAccountId: "acct-cash",
+          balance: 120500,
+          entryCount: 12,
+          security: null,
+          sourceEventIds: ["evt-cash-1"],
+          approvalIds: ["approval-cash-1"]
+        } as unknown as LedgerTrialBalanceLine
+      ],
+      loading: false,
+      error: null
+    });
+
+    expect(state.selectedDetail?.fields).toEqual(expect.arrayContaining([
+      { label: "Source events", value: "evt-cash-1" },
+      { label: "Approvals", value: "approval-cash-1" }
+    ]));
+    expect(state.selectedDetail?.auditDrillThroughHref).toBe("/accounting/audit?sourceEventId=evt-cash-1");
+    expect(state.selectedDetail?.approvalDrillThroughHref).toBe("/accounting/approvals?approvalId=approval-cash-1");
+  });
+
   it("filters trial-balance rows by basis and builds a basis bridge", () => {
     const state = buildGovernanceTrialBalanceViewState({
       runId: "run-42",

--- a/src/Meridian.Ui/dashboard/src/screens/governance-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/governance-screen.view-model.ts
@@ -873,6 +873,9 @@ export interface GovernanceTrialBalanceDetailViewState {
   statusVariant: "outline" | "success" | "danger";
   ariaLabel: string;
   fields: Array<{ label: string; value: string }>;
+  auditDrillThroughLabel: string;
+  auditDrillThroughHref: string | null;
+  approvalDrillThroughHref: string | null;
 }
 
 export interface GovernanceBasisBridgeRowViewModel {
@@ -3410,11 +3413,16 @@ function buildTrialBalanceDetail(
   const statusVariant = line.balanceTone === "danger" ? "danger" : line.balanceTone === "success" ? "success" : "outline";
   const statusLabel = line.balanceTone === "danger" ? "Credit / payable" : line.balanceTone === "success" ? "Debit / asset" : "Flat";
 
+  const sourceEventIds = readStringArrayField(line, "sourceEventIds");
+  const approvalIds = readStringArrayField(line, "approvalIds");
+  const firstSourceEventId = sourceEventIds[0] ?? null;
+  const firstApprovalId = approvalIds[0] ?? null;
+
   return {
     eyebrow: "Trial-balance detail",
     title: line.accountLabel,
     subtitle: `${line.accountTypeLabel} · ${financialAccountId}`,
-    description: `${line.accountLabel} contributes ${line.balanceLabel} across ${line.entryCountLabel} ledger entr${line.entryCount === 1 ? "y" : "ies"} for ${runLabel}.`,
+    description: `${line.accountLabel} contributes ${line.balanceLabel} across ${line.entryCountLabel} ledger entr${line.entryCount === 1 ? "y" : "ies"} for ${runLabel}. Source events and approvals stay attached for audit drill-through.`,
     statusLabel,
     statusVariant,
     ariaLabel: `Trial-balance detail for ${line.accountLabel}`,
@@ -3426,9 +3434,29 @@ function buildTrialBalanceDetail(
       { label: "Entries", value: line.entryCountLabel },
       { label: "Financial account", value: financialAccountId },
       { label: "Security", value: securityLabel },
+      { label: "Source events", value: sourceEventIds.length > 0 ? sourceEventIds.join(", ") : "No source events linked" },
+      { label: "Approvals", value: approvalIds.length > 0 ? approvalIds.join(", ") : "No approvals linked" },
       { label: "Run", value: runLabel }
-    ]
+    ],
+    auditDrillThroughLabel: firstSourceEventId ? `Open source event ${firstSourceEventId}` : "No source-event drill-through available",
+    auditDrillThroughHref: firstSourceEventId ? `/accounting/audit?sourceEventId=${encodeURIComponent(firstSourceEventId)}` : null,
+    approvalDrillThroughHref: firstApprovalId ? `/accounting/approvals?approvalId=${encodeURIComponent(firstApprovalId)}` : null
   };
+}
+
+function readStringArrayField(value: unknown, fieldName: string): string[] {
+  if (!value || typeof value !== "object" || !(fieldName in value)) {
+    return [];
+  }
+
+  const field = (value as Record<string, unknown>)[fieldName];
+  if (!Array.isArray(field)) {
+    return [];
+  }
+
+  return field
+    .map((item) => typeof item === "string" ? item.trim() : "")
+    .filter((item) => item.length > 0);
 }
 
 function buildTrialBalanceAnnouncement({

--- a/src/Meridian.Wpf/Features/Accounting/AccountingFeatureModule.cs
+++ b/src/Meridian.Wpf/Features/Accounting/AccountingFeatureModule.cs
@@ -1,6 +1,7 @@
 using Meridian.Wpf.Models;
 using Meridian.Wpf.Services;
 using Meridian.Wpf.ViewModels;
+using Meridian.Wpf.ViewModels.Accounting;
 using Meridian.Wpf.Views;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -17,6 +18,7 @@ public sealed class AccountingFeatureModule : IDesktopFeatureModule
         services.AddTransient<GovernanceWorkspaceShellStateProvider>();
         services.AddTransient<GovernanceWorkspaceShellViewModel>();
         services.AddTransient<GovernanceWorkspaceShellPage>();
+        services.AddTransient<AccountingCloseViewModel>();
     }
 
     public IReadOnlyList<ShellPageDescriptor> DescribePages() => Capability.Pages;

--- a/src/Meridian.Wpf/README.md
+++ b/src/Meridian.Wpf/README.md
@@ -93,3 +93,7 @@ behavior into view models. Do not duplicate product logic that belongs in shared
 - `src/Meridian.Ui.Shared/README.md`
 - `docs/development/wpf-implementation-notes.md`
 - `docs/source/generated/source-module-index.md`
+
+## Accounting close operator views
+
+The WPF accounting lane uses `AccountingCloseViewModel` to surface trial-balance rows, roll-forward rows, close-state text, and audit drill-through details from the shared UI services projection layer. Keep posting/translation business rules in `src/Meridian.Application/AccountingClose/` and avoid moving close gating into XAML code-behind.

--- a/src/Meridian.Wpf/ViewModels/Accounting/AccountingCloseViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/Accounting/AccountingCloseViewModel.cs
@@ -4,32 +4,139 @@ using Meridian.Ui.Services.Services.Accounting;
 
 namespace Meridian.Wpf.ViewModels.Accounting;
 
-public sealed class AccountingCloseViewModel
+public sealed class AccountingCloseViewModel : Meridian.Wpf.ViewModels.BindableBase
 {
     private readonly IAccountingProjectionQueryService _queryService;
+    private ClosePeriodState _closeState = ClosePeriodState.Open;
+    private string _closeStateText = "Open";
+    private string _trialBalanceStatusText = "Trial balance has not loaded.";
+    private string _selectedAuditDetailText = "Select a journal audit row to inspect source-event and approval linkage.";
+    private SourceLinkedAuditLine? _selectedAuditLine;
 
     public AccountingCloseViewModel(IAccountingProjectionQueryService queryService)
     {
-        _queryService = queryService;
+        _queryService = queryService ?? throw new ArgumentNullException(nameof(queryService));
     }
 
     public ObservableCollection<TrialBalanceLine> TrialBalance { get; } = [];
     public ObservableCollection<RollForwardLine> RollForward { get; } = [];
     public ObservableCollection<SourceLinkedAuditLine> AuditTrail { get; } = [];
 
-    public ClosePeriodState CloseState { get; private set; } = ClosePeriodState.Open;
+    public ClosePeriodState CloseState
+    {
+        get => _closeState;
+        private set
+        {
+            if (_closeState == value)
+            {
+                return;
+            }
+
+            _closeState = value;
+            RaisePropertyChanged();
+        }
+    }
+
+    public string CloseStateText
+    {
+        get => _closeStateText;
+        private set
+        {
+            if (string.Equals(_closeStateText, value, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _closeStateText = value;
+            RaisePropertyChanged();
+        }
+    }
+
+    public string TrialBalanceStatusText
+    {
+        get => _trialBalanceStatusText;
+        private set
+        {
+            if (string.Equals(_trialBalanceStatusText, value, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _trialBalanceStatusText = value;
+            RaisePropertyChanged();
+        }
+    }
+
+    public SourceLinkedAuditLine? SelectedAuditLine
+    {
+        get => _selectedAuditLine;
+        set
+        {
+            if (Equals(_selectedAuditLine, value))
+            {
+                return;
+            }
+
+            _selectedAuditLine = value;
+            SelectedAuditDetailText = value is null
+                ? "Select a journal audit row to inspect source-event and approval linkage."
+                : $"Journal {value.JournalEntryId:D} links source {value.SourceEventId} to approval {value.ApprovalId}.";
+            RaisePropertyChanged();
+        }
+    }
+
+    public string SelectedAuditDetailText
+    {
+        get => _selectedAuditDetailText;
+        private set
+        {
+            if (string.Equals(_selectedAuditDetailText, value, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _selectedAuditDetailText = value;
+            RaisePropertyChanged();
+        }
+    }
 
     public void Load(string ledgerId)
     {
         TrialBalance.Clear();
-        foreach (var line in _queryService.GetTrialBalance(ledgerId)) TrialBalance.Add(line);
+        foreach (var line in _queryService.GetTrialBalance(ledgerId))
+        {
+            TrialBalance.Add(line);
+        }
 
         RollForward.Clear();
-        foreach (var line in _queryService.GetRollForward(ledgerId)) RollForward.Add(line);
+        foreach (var line in _queryService.GetRollForward(ledgerId))
+        {
+            RollForward.Add(line);
+        }
 
         AuditTrail.Clear();
-        foreach (var line in _queryService.GetAuditLines(ledgerId)) AuditTrail.Add(line);
+        foreach (var line in _queryService.GetAuditLines(ledgerId))
+        {
+            AuditTrail.Add(line);
+        }
+
+        TrialBalanceStatusText = TrialBalance.Count == 0
+            ? "No trial-balance lines are available for the selected ledger."
+            : $"{TrialBalance.Count} trial-balance line{(TrialBalance.Count == 1 ? string.Empty : "s")} loaded with source-event drill-through.";
     }
 
-    public void SetCloseState(ClosePeriodState state) => CloseState = state;
+    public void ApplyCloseProjection(AccountingCloseProjection projection)
+    {
+        ArgumentNullException.ThrowIfNull(projection);
+        SetCloseState(projection.ClosePeriod.State);
+        TrialBalanceStatusText = projection.TrialBalanceBalanced
+            ? "Trial balance is balanced and eligible for close evidence review."
+            : "Trial balance is out of balance; close workflow remains blocked until corrected.";
+    }
+
+    public void SetCloseState(ClosePeriodState state)
+    {
+        CloseState = state;
+        CloseStateText = state.ToString();
+    }
 }

--- a/tests/Meridian.Tests/AccountingCloseServicesTests.cs
+++ b/tests/Meridian.Tests/AccountingCloseServicesTests.cs
@@ -5,48 +5,99 @@ using Xunit;
 
 namespace Meridian.Tests;
 
+/// <summary>
+/// Guards month-end accounting close scenarios where FX rates, posting balance, source-event lineage,
+/// period locks, and evidence gates must remain deterministic for operator replay.
+/// </summary>
 public sealed class AccountingCloseServicesTests
 {
     [Fact]
-    public void FxTranslation_ComputesAdjustmentDeterministically()
+    public void Scenario_MonthEndFxTranslation_ReplayUsesStableAdjustmentIdAndRateLineage()
     {
         var service = new FxTranslationService();
-        var rate = new FxRate("EUR", "USD", new DateOnly(2026, 03, 31), 1.10m, "fx:ecb:20260331");
+        var rate = new FxRate("EUR", "USD", new DateOnly(2026, 03, 31), 1.10m, "fx:ecb:20260331", "ECB-EURUSD-20260331");
 
-        var result = service.Translate("ledger-a", new DateOnly(2026, 03, 31), "Cash", 100m, rate);
+        var first = service.Translate("ledger-a", new DateOnly(2026, 03, 31), "Cash", 100m, rate);
+        var replay = service.Translate("ledger-a", new DateOnly(2026, 03, 31), "Cash", 100m, rate);
 
-        result.ReportingAmount.Should().Be(110m);
-        result.AdjustmentAmount.Should().Be(10m);
-        result.SourceEventId.Should().Be("fx:ecb:20260331");
+        first.ReportingAmount.Should().Be(110m);
+        first.AdjustmentAmount.Should().Be(10m);
+        first.SourceEventId.Should().Be("fx:ecb:20260331");
+        first.RateId.Should().Be("ECB-EURUSD-20260331");
+        replay.AdjustmentId.Should().Be(first.AdjustmentId);
     }
 
     [Fact]
-    public void TrialBalance_DetectsOutOfBalance()
+    public void Scenario_MonthEndTrialBalance_OutOfBalanceActivityBlocksCloseEvidence()
     {
         var projection = new TrialBalanceProjectionService();
         var entries = ImmutableArray.Create(
-            new JournalEntry(Guid.NewGuid(), "ledger-a", new DateOnly(2026, 03, 31), "evt-1", "accrual", ImmutableArray.Create(new JournalLine("Cash", 100m, "USD", true))),
-            new JournalEntry(Guid.NewGuid(), "ledger-a", new DateOnly(2026, 03, 31), "evt-2", "offset", ImmutableArray.Create(new JournalLine("Revenue", 90m, "USD", false))));
+            NewEntry("evt-1", "approval-1", new JournalLine("Cash", 100m, "USD", true, "evt-1", "approval-1")),
+            NewEntry("evt-2", "approval-2", new JournalLine("Revenue", 90m, "USD", false, "evt-2", "approval-2")));
 
         var trial = projection.BuildTrialBalance(entries);
+        var stateMachine = new MonthEndCloseStateMachine();
+        var validating = new ClosePeriod("ledger-a", new DateOnly(2026, 03, 31), ClosePeriodState.Validating, new CloseEvidence(true, true, true), []);
+
+        var next = stateMachine.Transition(validating, new CloseEvidence(true, true, true), projection.IsBalanced(trial));
 
         projection.IsBalanced(trial).Should().BeFalse();
+        next.State.Should().Be(ClosePeriodState.Blocked);
+        next.Blockers.Should().Contain("Trial balance is out of balance.");
     }
 
     [Fact]
-    public void CloseStateMachine_BlocksWhenEvidenceMissing()
+    public void Scenario_MonthEndPosting_OutOfBalanceJournalIsRejectedBeforeReplay()
+    {
+        var posting = new AccountingPostingService();
+        var entry = NewEntry("evt-oob", "approval-oob", new JournalLine("Cash", 100m, "USD", true, "evt-oob", "approval-oob"));
+
+        var result = posting.PostWithResult("ledger-a", [entry]);
+
+        result.Accepted.Should().BeFalse();
+        result.RejectedReasons.Should().ContainSingle(reason => reason.Contains("out of balance", StringComparison.OrdinalIgnoreCase));
+        posting.Replay("ledger-a").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Scenario_MonthEndPosting_ClosedPeriodRejectsLateJournal()
+    {
+        var posting = new AccountingPostingService();
+        var lockedPeriod = new ClosePeriod(
+            "ledger-a",
+            new DateOnly(2026, 03, 01),
+            ClosePeriodState.Closed,
+            new CloseEvidence(true, true, true),
+            [],
+            DateTimeOffset.Parse("2026-04-01T00:00:00Z"),
+            "controller");
+
+        var result = posting.PostWithResult("ledger-a", [BalancedEntry("evt-late", "approval-late")], lockedPeriod);
+
+        result.Accepted.Should().BeFalse();
+        result.RejectedReasons.Should().ContainSingle(reason => reason.Contains("locked", StringComparison.OrdinalIgnoreCase));
+        posting.Replay("ledger-a").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Scenario_MonthEndClose_EvidenceChecksGateClosedState()
     {
         var stateMachine = new MonthEndCloseStateMachine();
-        var current = new ClosePeriod("ledger-a", new DateOnly(2026, 03, 31), ClosePeriodState.Open, new CloseEvidence(false, false, false), []);
+        var current = new ClosePeriod("ledger-a", new DateOnly(2026, 03, 31), ClosePeriodState.Validating, new CloseEvidence(false, false, false), []);
+        var evidence = new CloseEvidence(
+            TrialBalanceSignedOff: true,
+            ReconciliationSignedOff: true,
+            ApprovalsCompleted: true,
+            Checks: ImmutableArray.Create(new CloseEvidenceCheck("packet", "Controller packet", true, false, "evt-close", "approval-close", "Controller approval is pending.")));
 
-        var next = stateMachine.Transition(current, new CloseEvidence(true, false, true), isTrialBalanceBalanced: true);
+        var next = stateMachine.Transition(current, evidence, isTrialBalanceBalanced: true);
 
-        next.State.Should().Be(ClosePeriodState.Validating);
-        next.Blockers.Should().ContainSingle().Which.Should().Contain("Reconciliation");
+        next.State.Should().Be(ClosePeriodState.Blocked);
+        next.Blockers.Should().ContainSingle(reason => reason.Contains("Controller packet", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
-    public void CloseStateMachine_ClosesWhenAllGatesPass()
+    public void Scenario_MonthEndClose_AllGatesPassingLocksThePeriod()
     {
         var stateMachine = new MonthEndCloseStateMachine();
         var current = new ClosePeriod("ledger-a", new DateOnly(2026, 03, 31), ClosePeriodState.Validating, new CloseEvidence(true, true, true), []);
@@ -55,21 +106,47 @@ public sealed class AccountingCloseServicesTests
 
         next.State.Should().Be(ClosePeriodState.Closed);
         next.Blockers.Should().BeEmpty();
+        next.IsLocked.Should().BeTrue();
     }
 
     [Fact]
-    public void PostingReplay_RemainsDeterministicByDateThenId()
+    public void Scenario_MonthEndPosting_ReplayOrdersByPeriodDateAndJournalIdWithAuditLineage()
     {
         var posting = new AccountingPostingService();
         var idB = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
         var idA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
         posting.Post("ledger-a", [
-            new JournalEntry(idB, "ledger-a", new DateOnly(2026, 03, 02), "evt-b", "b", ImmutableArray.Create(new JournalLine("Cash", 1m, "USD", true))),
-            new JournalEntry(idA, "ledger-a", new DateOnly(2026, 03, 02), "evt-a", "a", ImmutableArray.Create(new JournalLine("Cash", 1m, "USD", true)))
+            BalancedEntry("evt-b", "approval-b", idB),
+            BalancedEntry("evt-a", "approval-a", idA)
         ]);
 
         var replay = posting.Replay("ledger-a");
+        var audit = posting.Audit("ledger-a");
         replay[0].JournalEntryId.Should().Be(idA);
         replay[1].JournalEntryId.Should().Be(idB);
+        audit[0].SourceEventId.Should().Be("evt-a");
+        audit[0].ApprovalId.Should().Be("approval-a");
+        audit[0].AccountCodes.Should().BeEquivalentTo("Cash", "Revenue");
     }
+
+    private static JournalEntry BalancedEntry(string sourceEventId, string approvalId, Guid? journalEntryId = null)
+        => new(
+            journalEntryId ?? Guid.NewGuid(),
+            "ledger-a",
+            new DateOnly(2026, 03, 02),
+            sourceEventId,
+            "balanced accrual",
+            ImmutableArray.Create(
+                new JournalLine("Cash", 100m, "USD", true, sourceEventId, approvalId),
+                new JournalLine("Revenue", 100m, "USD", false, sourceEventId, approvalId)));
+
+    private static JournalEntry NewEntry(string sourceEventId, string approvalId, params JournalLine[] lines)
+        => new(
+            Guid.NewGuid(),
+            "ledger-a",
+            new DateOnly(2026, 03, 31),
+            sourceEventId,
+            "month-end source event",
+            lines.Select(line => string.IsNullOrWhiteSpace(line.ApprovalId) ? line with { ApprovalId = approvalId } : line).ToImmutableArray());
 }


### PR DESCRIPTION
### Motivation

- Add robust accounting close primitives so journals, FX translation, and month-end close gating carry source-event and approval lineage for audit and replayability. 
- Enforce deterministic posting and translation behavior to make operator close workflows reproducible and safe to lock periods. 
- Surface trial-balance, roll-forward, close-state, and audit drill-through to both WPF and browser workstations so operators can trace balances back to source events and approvals.

### Description

- Extended domain models in `src/Meridian.Application/AccountingClose/` adding `LedgerDefinition`, enriched `FxRate`, `JournalEntry`/`JournalLine` fields, `TranslationAdjustment`, `CloseEvidence`/`CloseEvidenceCheck`, `ClosePeriod`, `TrialBalanceLine`, `RollForwardLine`, `SourceLinkedAuditLine`, and `JournalPostingResult` in `AccountingCloseModels.cs`.
- Implemented posting/translation/close logic in `AccountingCloseServices.cs`: added `AccountingPostingService.PostWithResult` to validate balanced journals and reject locked periods, deterministic replay ordering by period/date/id, `FxTranslationService` with deterministic adjustment Id generation, `MonthEndCloseStateMachine` gating with evidence checks, and `TrialBalanceProjectionService` that preserves source-event/approval lineage.
- Exposed shared projection and close queries via `IAccountingProjectionQueryService` and `AccountingProjectionQueryService` in `src/Meridian.Ui.Services/Services/Accounting/AccountingProjectionQueryService.cs`, including `GetTrialBalance`, `GetRollForward`, `GetAuditLines`, `GetAuditLine`, and `GetCloseProjection`.
- Added WPF view-model and registration: `AccountingCloseViewModel` surfaces `TrialBalance`, `RollForward`, `AuditTrail`, and close-state and was registered in the accounting feature module (`AccountingFeatureModule.cs`).
- Browser/UI changes: added typed browser models `src/features/accounting/accountingCloseModels.ts`, enhanced governance trial-balance detail to include source-event and approval drill-through links and rendered actions in `src/screens/governance-screen.tsx` and view-model wiring in `src/screens/governance-screen.view-model.ts`.
- Tests and docs: added scenario-focused tests in `tests/Meridian.Tests/AccountingCloseServicesTests.cs` covering FX determinism, out-of-balance detection, period-lock rejection, evidence gating, deterministic replay and audit lineage; added a dashboard view-model test for audit drill-through; updated related README files to document responsibilities and workflow expectations.

### Testing

- Ran `npm --prefix src/Meridian.Ui/dashboard ci` which completed successfully (dependencies installed).
- Ran dashboard unit tests `npm --prefix src/Meridian.Ui/dashboard run test -- --run src/screens/governance-screen.view-model.test.ts src/screens/governance-screen.test.tsx` which passed (both spec files ran; total tests passed: 71).
- Ran `git diff --check` which reported no remaining diff-check failures after whitespace fixes.
- Known validation gaps due to the execution environment: `dotnet` is not available so `dotnet build` / `dotnet test` for the C# test projects could not be executed (commands attempted: `dotnet build src/Meridian.Application/Meridian.Application.csproj` and `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter FullyQualifiedName~AccountingCloseServicesTests`), and `pwsh ./tools/codex/mvvm-compliance-check.ps1` could not run because PowerShell is not installed here.
- Browser build `npm --prefix src/Meridian.Ui/dashboard run build` failed due to pre-existing TypeScript API drift in the dashboard workspace (duplicate `StatementRun*` types and missing reconciliation API exports in `src/lib/api.ts` / `src/lib/api.reconciliation.test.ts`), which is unrelated to the accounting changes and should be resolved in a follow-up fix before CI artifact packaging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18a009fbf88320973f7b0370bcdbaa)