### PR TITLE
Add canonical reconciliation models, matching engine, persistence, UI endpoints and workbench surfaces

### DIFF
--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -51,6 +51,8 @@ application service contracts consumed by host and UI surfaces.
 
 ## API contract notes
 
+- Broker/custodian reconciliation now uses canonical feed descriptors, normalized position/cash/transaction records, deterministic exact/tolerance/heuristic match decisions, and an append-only decision journal for unresolved breaks and resolution history.
+
 - Statement reconciliation tolerance profiles are versioned in `Reconciliation/`; match outputs that use a tolerance must carry the tolerance profile ID/version and the exact tolerance rule ID that allowed the match.
 - Options-chain provider IDs are normalized with trim plus invariant lowercase before deduplication,
   health lookup, fallback detection, logging, and metrics.

--- a/src/Meridian.Application/Reconciliation/BrokerCustodianReconciliationModels.cs
+++ b/src/Meridian.Application/Reconciliation/BrokerCustodianReconciliationModels.cs
@@ -1,0 +1,269 @@
+namespace Meridian.Application.Reconciliation;
+
+public enum CanonicalReconciliationSourceKind
+{
+    Broker,
+    Custodian,
+    InternalBook
+}
+
+public enum CanonicalReconciliationRecordKind
+{
+    Position,
+    Cash,
+    Transaction
+}
+
+public enum CanonicalReconciliationDecisionStatus
+{
+    AutoMatched,
+    Proposed,
+    UnresolvedBreak,
+    ManuallyResolved,
+    SignedOff
+}
+
+public sealed record BrokerCustodianFeedDescriptor(
+    string FeedId,
+    CanonicalReconciliationSourceKind SourceKind,
+    string SourceSystem,
+    string AccountId,
+    string ExternalAccountId,
+    DateOnly BusinessDate,
+    string BaseCurrency,
+    DateTimeOffset CapturedAtUtc,
+    string ContentHash,
+    string AdapterId,
+    string AdapterVersion);
+
+public sealed record CanonicalReconciliationRecord(
+    string RecordId,
+    BrokerCustodianFeedDescriptor Feed,
+    CanonicalReconciliationRecordKind RecordKind,
+    string InstrumentId,
+    string? Symbol,
+    decimal Quantity,
+    decimal Price,
+    decimal MarketValue,
+    decimal CashAmount,
+    string Currency,
+    DateOnly TradeDate,
+    DateOnly? SettlementDate,
+    string ActivityType,
+    string ExternalReference,
+    IReadOnlyDictionary<string, string> Evidence);
+
+public sealed record BrokerCustodianFeedBatch(
+    BrokerCustodianFeedDescriptor Descriptor,
+    IReadOnlyList<CanonicalReconciliationRecord> Records);
+
+public interface IBrokerCustodianReconciliationFeedAdapter
+{
+    string AdapterId { get; }
+    string AdapterVersion { get; }
+    CanonicalReconciliationSourceKind SourceKind { get; }
+
+    Task<BrokerCustodianFeedBatch> ReadAsync(BrokerCustodianFeedDescriptor descriptor, Stream source, CancellationToken ct = default);
+}
+
+public sealed record BrokerCustodianMatchRule(
+    string RuleId,
+    ReconciliationMatchTier Tier,
+    decimal QuantityTolerance,
+    decimal PriceTolerance,
+    decimal MarketValueTolerance,
+    decimal CashTolerance,
+    TimeSpan SettlementTolerance,
+    decimal MinimumConfidence);
+
+public sealed record BrokerCustodianMatchDecision(
+    string DecisionId,
+    string RunId,
+    string LeftRecordId,
+    string? RightRecordId,
+    CanonicalReconciliationDecisionStatus Status,
+    ReconciliationMatchTier Tier,
+    decimal Confidence,
+    string RuleId,
+    decimal QuantityVariance,
+    decimal PriceVariance,
+    decimal MarketValueVariance,
+    decimal CashVariance,
+    string Explanation,
+    DateTimeOffset DecidedAtUtc,
+    string DecidedBy,
+    IReadOnlyList<string> EvidenceReferences)
+{
+    public bool IsTerminal => Status is CanonicalReconciliationDecisionStatus.AutoMatched
+        or CanonicalReconciliationDecisionStatus.ManuallyResolved
+        or CanonicalReconciliationDecisionStatus.SignedOff;
+}
+
+public sealed record ReconciliationResolutionHistoryEntry(
+    string HistoryId,
+    string DecisionId,
+    string FromStatus,
+    string ToStatus,
+    string Actor,
+    string Reason,
+    DateTimeOffset OccurredAtUtc,
+    IReadOnlyList<string> EvidenceReferences);
+
+public interface IReconciliationDecisionJournal
+{
+    Task AppendDecisionAsync(BrokerCustodianMatchDecision decision, CancellationToken ct = default);
+    Task AppendHistoryAsync(ReconciliationResolutionHistoryEntry history, CancellationToken ct = default);
+    Task<IReadOnlyList<BrokerCustodianMatchDecision>> ListDecisionsAsync(string runId, CancellationToken ct = default);
+    Task<IReadOnlyList<ReconciliationResolutionHistoryEntry>> ListHistoryAsync(string decisionId, CancellationToken ct = default);
+}
+
+public sealed class BrokerCustodianMatchingPipeline
+{
+    public static readonly IReadOnlyList<BrokerCustodianMatchRule> DefaultRules =
+    [
+        new("exact-position-cash-transaction-v1", ReconciliationMatchTier.Exact, 0m, 0m, 0m, 0m, TimeSpan.Zero, 1.00m),
+        new("tolerance-position-cash-transaction-v1", ReconciliationMatchTier.Tolerance, 0.0001m, 0.01m, 0.01m, 0.01m, TimeSpan.FromDays(1), 0.90m),
+        new("heuristic-reference-symbol-date-v1", ReconciliationMatchTier.Heuristic, 0.01m, 0.05m, 1.00m, 1.00m, TimeSpan.FromDays(3), 0.70m)
+    ];
+
+    public IReadOnlyList<BrokerCustodianMatchDecision> Match(
+        string runId,
+        IReadOnlyList<CanonicalReconciliationRecord> brokerRecords,
+        IReadOnlyList<CanonicalReconciliationRecord> custodianRecords,
+        DateTimeOffset decidedAtUtc,
+        string decidedBy,
+        IReadOnlyList<BrokerCustodianMatchRule>? rules = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runId);
+        ArgumentNullException.ThrowIfNull(brokerRecords);
+        ArgumentNullException.ThrowIfNull(custodianRecords);
+        var effectiveRules = rules is { Count: > 0 } ? rules : DefaultRules;
+        var unmatchedCustodian = new HashSet<string>(custodianRecords.Select(static item => item.RecordId), StringComparer.Ordinal);
+        var decisions = new List<BrokerCustodianMatchDecision>(brokerRecords.Count);
+
+        foreach (var broker in brokerRecords.OrderBy(static item => item.RecordId, StringComparer.Ordinal))
+        {
+            var candidates = custodianRecords
+                .Where(candidate => unmatchedCustodian.Contains(candidate.RecordId))
+                .Where(candidate => candidate.RecordKind == broker.RecordKind)
+                .Where(candidate => string.Equals(candidate.Feed.AccountId, broker.Feed.AccountId, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(candidate.Feed.ExternalAccountId, broker.Feed.ExternalAccountId, StringComparison.OrdinalIgnoreCase))
+                .SelectMany(candidate => effectiveRules.Select(rule => ScoreCandidate(broker, candidate, rule)))
+                .Where(scored => scored.Confidence >= scored.Rule.MinimumConfidence)
+                .OrderByDescending(static scored => scored.Confidence)
+                .ThenBy(static scored => scored.Rule.Tier)
+                .ThenBy(static scored => scored.Candidate.RecordId, StringComparer.Ordinal)
+                .ToArray();
+
+            var selected = candidates.FirstOrDefault();
+            if (selected is null)
+            {
+                decisions.Add(BuildBreakDecision(runId, broker, decidedAtUtc, decidedBy));
+                continue;
+            }
+
+            unmatchedCustodian.Remove(selected.Candidate.RecordId);
+            decisions.Add(BuildMatchedDecision(runId, broker, selected.Candidate, selected.Rule, selected.Confidence, decidedAtUtc, decidedBy));
+        }
+
+        foreach (var custodian in custodianRecords.Where(item => unmatchedCustodian.Contains(item.RecordId)).OrderBy(static item => item.RecordId, StringComparer.Ordinal))
+        {
+            decisions.Add(BuildBreakDecision(runId, custodian, decidedAtUtc, decidedBy));
+        }
+
+        return decisions;
+    }
+
+    private static (CanonicalReconciliationRecord Candidate, BrokerCustodianMatchRule Rule, decimal Confidence) ScoreCandidate(
+        CanonicalReconciliationRecord left,
+        CanonicalReconciliationRecord right,
+        BrokerCustodianMatchRule rule)
+    {
+        var quantityVariance = Math.Abs(left.Quantity - right.Quantity);
+        var priceVariance = Math.Abs(left.Price - right.Price);
+        var marketValueVariance = Math.Abs(left.MarketValue - right.MarketValue);
+        var cashVariance = Math.Abs(left.CashAmount - right.CashAmount);
+        var settlementVariance = left.SettlementDate.HasValue && right.SettlementDate.HasValue
+            ? Math.Abs(left.SettlementDate.Value.DayNumber - right.SettlementDate.Value.DayNumber)
+            : 0;
+        var symbolMatches = string.Equals(left.Symbol, right.Symbol, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(left.InstrumentId, right.InstrumentId, StringComparison.OrdinalIgnoreCase);
+        var referenceMatches = !string.IsNullOrWhiteSpace(left.ExternalReference)
+            && string.Equals(left.ExternalReference, right.ExternalReference, StringComparison.OrdinalIgnoreCase);
+
+        var withinNumericTolerance = quantityVariance <= rule.QuantityTolerance
+            && priceVariance <= rule.PriceTolerance
+            && marketValueVariance <= rule.MarketValueTolerance
+            && cashVariance <= rule.CashTolerance
+            && settlementVariance <= Math.Max(0, rule.SettlementTolerance.TotalDays);
+
+        var confidence = rule.Tier switch
+        {
+            ReconciliationMatchTier.Exact when withinNumericTolerance && referenceMatches => 1.00m,
+            ReconciliationMatchTier.Exact when withinNumericTolerance && symbolMatches => 0.99m,
+            ReconciliationMatchTier.Tolerance when withinNumericTolerance && (symbolMatches || referenceMatches) => 0.93m,
+            ReconciliationMatchTier.Heuristic when symbolMatches && left.TradeDate == right.TradeDate => 0.78m,
+            ReconciliationMatchTier.Heuristic when referenceMatches => 0.74m,
+            _ => 0m
+        };
+
+        return (right, rule, confidence);
+    }
+
+    private static BrokerCustodianMatchDecision BuildMatchedDecision(
+        string runId,
+        CanonicalReconciliationRecord left,
+        CanonicalReconciliationRecord right,
+        BrokerCustodianMatchRule rule,
+        decimal confidence,
+        DateTimeOffset decidedAtUtc,
+        string decidedBy)
+        => new(
+            DecisionId: StableDecisionId(runId, left.RecordId, right.RecordId),
+            RunId: runId,
+            LeftRecordId: left.RecordId,
+            RightRecordId: right.RecordId,
+            Status: rule.Tier is ReconciliationMatchTier.Heuristic
+                ? CanonicalReconciliationDecisionStatus.Proposed
+                : CanonicalReconciliationDecisionStatus.AutoMatched,
+            Tier: rule.Tier,
+            Confidence: confidence,
+            RuleId: rule.RuleId,
+            QuantityVariance: Math.Abs(left.Quantity - right.Quantity),
+            PriceVariance: Math.Abs(left.Price - right.Price),
+            MarketValueVariance: Math.Abs(left.MarketValue - right.MarketValue),
+            CashVariance: Math.Abs(left.CashAmount - right.CashAmount),
+            Explanation: $"{rule.Tier} reconciliation match using {rule.RuleId} at {confidence:P0} confidence.",
+            DecidedAtUtc: decidedAtUtc,
+            DecidedBy: string.IsNullOrWhiteSpace(decidedBy) ? "system" : decidedBy.Trim(),
+            EvidenceReferences: [$"record:{left.RecordId}", $"record:{right.RecordId}"]);
+
+    private static BrokerCustodianMatchDecision BuildBreakDecision(
+        string runId,
+        CanonicalReconciliationRecord record,
+        DateTimeOffset decidedAtUtc,
+        string decidedBy)
+        => new(
+            DecisionId: StableDecisionId(runId, record.RecordId, "unresolved"),
+            RunId: runId,
+            LeftRecordId: record.RecordId,
+            RightRecordId: null,
+            Status: CanonicalReconciliationDecisionStatus.UnresolvedBreak,
+            Tier: ReconciliationMatchTier.Unmatched,
+            Confidence: 0m,
+            RuleId: "unmatched-break-v1",
+            QuantityVariance: Math.Abs(record.Quantity),
+            PriceVariance: Math.Abs(record.Price),
+            MarketValueVariance: Math.Abs(record.MarketValue),
+            CashVariance: Math.Abs(record.CashAmount),
+            Explanation: "No broker/custodian candidate satisfied exact, tolerance, or heuristic matching rules.",
+            DecidedAtUtc: decidedAtUtc,
+            DecidedBy: string.IsNullOrWhiteSpace(decidedBy) ? "system" : decidedBy.Trim(),
+            EvidenceReferences: [$"record:{record.RecordId}"]);
+
+    private static string StableDecisionId(string runId, string left, string right)
+    {
+        var bytes = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes($"{runId}|{left}|{right}"));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+}

--- a/src/Meridian.Application/Reconciliation/FileReconciliationDecisionJournal.cs
+++ b/src/Meridian.Application/Reconciliation/FileReconciliationDecisionJournal.cs
@@ -1,0 +1,100 @@
+using System.Text.Json;
+
+namespace Meridian.Application.Reconciliation;
+
+public sealed class FileReconciliationDecisionJournal : IReconciliationDecisionJournal
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web) { WriteIndented = false };
+    private readonly string _rootDirectory;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public FileReconciliationDecisionJournal(string dataRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dataRoot);
+        _rootDirectory = Path.Combine(dataRoot, "reconciliation", "decision-journal");
+    }
+
+    public async Task AppendDecisionAsync(BrokerCustodianMatchDecision decision, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(decision);
+        await AppendJsonLineAsync(RunDecisionPath(decision.RunId), decision, ct).ConfigureAwait(false);
+    }
+
+    public async Task AppendHistoryAsync(ReconciliationResolutionHistoryEntry history, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(history);
+        await AppendJsonLineAsync(DecisionHistoryPath(history.DecisionId), history, ct).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<BrokerCustodianMatchDecision>> ListDecisionsAsync(string runId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runId);
+        return await ReadJsonLinesAsync<BrokerCustodianMatchDecision>(RunDecisionPath(runId), ct).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<ReconciliationResolutionHistoryEntry>> ListHistoryAsync(string decisionId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(decisionId);
+        return await ReadJsonLinesAsync<ReconciliationResolutionHistoryEntry>(DecisionHistoryPath(decisionId), ct).ConfigureAwait(false);
+    }
+
+    private async Task AppendJsonLineAsync<T>(string path, T value, CancellationToken ct)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var payload = JsonSerializer.Serialize(value, JsonOptions);
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await File.AppendAllLinesAsync(path, [payload], ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private static async Task<IReadOnlyList<T>> ReadJsonLinesAsync<T>(string path, CancellationToken ct)
+    {
+        if (!File.Exists(path))
+        {
+            return [];
+        }
+
+        var results = new List<T>();
+        var lines = await File.ReadAllLinesAsync(path, ct).ConfigureAwait(false);
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var item = JsonSerializer.Deserialize<T>(line, JsonOptions);
+            if (item is not null)
+            {
+                results.Add(item);
+            }
+        }
+
+        return results;
+    }
+
+    private string RunDecisionPath(string runId)
+        => SafePath("runs", runId, "decisions.jsonl");
+
+    private string DecisionHistoryPath(string decisionId)
+        => SafePath("decisions", decisionId, "history.jsonl");
+
+    private string SafePath(string folder, string id, string fileName)
+    {
+        var safeId = string.Concat(id.Trim().Select(static ch => char.IsLetterOrDigit(ch) || ch is '-' or '_' ? ch : '_'));
+        var path = Path.GetFullPath(Path.Combine(_rootDirectory, folder, safeId, fileName));
+        var root = Path.GetFullPath(_rootDirectory).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        if (!path.StartsWith(root, OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+        {
+            throw new ArgumentException("Reconciliation journal path escaped the configured root.", nameof(id));
+        }
+
+        return path;
+    }
+}

--- a/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
+++ b/src/Meridian.Contracts/Workstation/ReconciliationDtos.cs
@@ -612,7 +612,18 @@ public sealed record ReconciliationCalibrationSummaryDto(
     int PendingSignoffCount,
     int SignedOffCount,
     int MissingCalibrationMetadataCount,
-    IReadOnlyList<ReconciliationCalibrationProfileSummaryDto> Profiles);
+    IReadOnlyList<ReconciliationCalibrationProfileSummaryDto> Profiles)
+{
+    public int BreakCountTrend { get; init; }
+    public decimal AutoMatchRate { get; init; }
+    public decimal T0ClosureRate { get; init; }
+    public int BreakCountAlertThreshold { get; init; } = 25;
+    public decimal AutoMatchRateAlertThreshold { get; init; } = 0.85m;
+    public decimal T0ClosureRateAlertThreshold { get; init; } = 0.90m;
+    public bool BreakCountAlertTriggered => ActiveBreakCount >= BreakCountAlertThreshold;
+    public bool AutoMatchRateAlertTriggered => AutoMatchRate < AutoMatchRateAlertThreshold;
+    public bool T0ClosureRateAlertTriggered => T0ClosureRate < T0ClosureRateAlertThreshold;
+}
 
 /// <summary>
 /// Request to move a break into active review and assign an operator.

--- a/src/Meridian.Ui.Services/README.md
+++ b/src/Meridian.Ui.Services/README.md
@@ -71,3 +71,5 @@ shared projections over browser-only or WPF-only product logic.
 - `src/Meridian.Ui.Shared/README.md`
 - `docs/status/contract-compatibility-matrix.md`
 - `docs/source/generated/source-module-index.md`
+
+- Reconciliation API service projections expose statement runs, open breaks, account queue status, case summaries, and calibration KPIs for break trend, auto-match rate, T+0 closure rate, and alert thresholds shared by desktop and browser operators.

--- a/src/Meridian.Ui.Services/Services/Reconciliation/ReconciliationApiService.cs
+++ b/src/Meridian.Ui.Services/Services/Reconciliation/ReconciliationApiService.cs
@@ -1,7 +1,18 @@
-using Meridian.Contracts.Workstation;
 using Meridian.Domain.Reconciliation;
 using Meridian.Infrastructure.Reconciliation;
 using Meridian.Ui.Shared.Contracts.Reconciliation;
+using ContractStatementBreakDto = Meridian.Contracts.Workstation.StatementBreakDto;
+using ContractStatementBreakType = Meridian.Contracts.Workstation.StatementBreakType;
+using ContractStatementMatchTier = Meridian.Contracts.Workstation.StatementMatchTier;
+using ContractStatementRunBreakDto = Meridian.Contracts.Workstation.StatementRunBreakDto;
+using ContractStatementRunCreateDto = Meridian.Contracts.Workstation.StatementRunCreateDto;
+using ContractStatementRunDto = Meridian.Contracts.Workstation.StatementRunDto;
+using ContractStatementRunReconcileRequestDto = Meridian.Contracts.Workstation.StatementRunReconcileRequestDto;
+using ContractStatementRunStatus = Meridian.Contracts.Workstation.StatementRunStatus;
+using ContractStatementRunValidationDto = Meridian.Contracts.Workstation.StatementRunValidationDto;
+using ContractStatementSourceDto = Meridian.Contracts.Workstation.StatementSourceDto;
+using ContractStatementValidationSeverity = Meridian.Contracts.Workstation.StatementValidationSeverity;
+using ContractStatementMatchSummaryDto = Meridian.Contracts.Workstation.StatementMatchSummaryDto;
 
 namespace Meridian.Ui.Services.Services.Reconciliation;
 
@@ -12,7 +23,13 @@ public sealed class ReconciliationApiService(
 {
     public async Task<IReadOnlyList<StatementImportSummaryDto>> ListImportsAsync(CancellationToken ct = default)
         => (await importStore.ListImportsAsync(ct).ConfigureAwait(false))
-            .Select(i => new StatementImportSummaryDto(i.ImportId, i.Broker, i.StatementDate.ToString("yyyy-MM-dd"), i.ImportedAtUtc.ToString("O"), i.RawRowCount, i.NormalizedRowCount))
+            .Select(static import => new StatementImportSummaryDto(
+                import.ImportId,
+                import.Broker,
+                import.StatementDate.ToString("yyyy-MM-dd"),
+                import.ImportedAtUtc.ToString("O"),
+                import.RawRowCount,
+                import.NormalizedRowCount))
             .ToList();
 
     public async Task<IReadOnlyList<StatementRunSummaryDto>> ListStatementRunsAsync(CancellationToken ct = default)
@@ -20,16 +37,10 @@ public sealed class ReconciliationApiService(
         var imports = await importStore.ListImportsAsync(ct).ConfigureAwait(false);
         var breaks = await breakStore.ListOpenAsync(ct).ConfigureAwait(false);
         var cases = await caseStore.ListAsync(ct).ConfigureAwait(false);
-        return imports.Select(i => ToStatementRunSummary(i, breaks, cases)).ToList();
+        return imports.Select(import => ToStatementRunSummary(import, breaks, cases)).ToList();
     }
 
-    public async Task<StatementRunSummaryDto?> GetStatementRunAsync(string runId, CancellationToken ct = default)
-        => (await ListStatementRunsAsync(ct).ConfigureAwait(false)).FirstOrDefault(x => string.Equals(x.RunId, runId, StringComparison.OrdinalIgnoreCase));
-        => (await importStore.ListImportsAsync(ct).ConfigureAwait(false))
-            .Select(ToSummary)
-            .ToList();
-
-    public async Task<StatementRunDto?> CreateStatementRunAsync(StatementRunCreateDto request, CancellationToken ct = default)
+    public async Task<ContractStatementRunDto?> CreateStatementRunAsync(ContractStatementRunCreateDto request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
         ValidateCreateRequest(request);
@@ -69,10 +80,10 @@ public sealed class ReconciliationApiService(
         };
 
         await importStore.SaveImportAsync(import, [], ct).ConfigureAwait(false);
-        return ToRunDto(import, [], status: StatementRunStatus.Completed, notes: request.Notes);
+        return ToRunDto(import, [], ContractStatementRunStatus.Completed, request.Notes);
     }
 
-    public async Task<StatementRunDto?> GetStatementRunAsync(string runId, CancellationToken ct = default)
+    public async Task<ContractStatementRunDto?> GetStatementRunAsync(string runId, CancellationToken ct = default)
     {
         var import = await FindImportAsync(runId, ct).ConfigureAwait(false);
         if (import is null)
@@ -81,29 +92,29 @@ public sealed class ReconciliationApiService(
         }
 
         var breaks = await ListBreakDtosAsync(import.ImportId, ct).ConfigureAwait(false);
-        return ToRunDto(import, breaks, breaks.Any(static b => string.Equals(b.Status, "Open", StringComparison.OrdinalIgnoreCase))
-            ? StatementRunStatus.ReviewRequired
-            : StatementRunStatus.Completed);
+        return ToRunDto(
+            import,
+            breaks,
+            breaks.Any(static item => string.Equals(item.Status, "Open", StringComparison.OrdinalIgnoreCase))
+                ? ContractStatementRunStatus.ReviewRequired
+                : ContractStatementRunStatus.Completed);
     }
 
-    public async Task<StatementRunValidationDto?> GetStatementRunValidationAsync(string runId, CancellationToken ct = default)
+    public async Task<ContractStatementRunValidationDto?> GetStatementRunValidationAsync(string runId, CancellationToken ct = default)
     {
         var run = await GetStatementRunAsync(runId, ct).ConfigureAwait(false);
         return run is null
             ? null
-            : new StatementRunValidationDto(
-                run.RunId ?? runId,
-                run.ValidationIssues ?? [],
-                run.ValidationIssues?.Any(static issue => issue.Severity is StatementValidationSeverity.Critical or StatementValidationSeverity.Error) == true);
+            : new ContractStatementRunValidationDto(run.RunId ?? runId, run.ValidationIssues ?? [], IsBlocked: false);
     }
 
-    public async Task<IReadOnlyList<StatementRunBreakDto>?> ListStatementRunBreaksAsync(string runId, CancellationToken ct = default)
+    public async Task<IReadOnlyList<ContractStatementRunBreakDto>?> ListStatementRunBreaksAsync(string runId, CancellationToken ct = default)
     {
         var import = await FindImportAsync(runId, ct).ConfigureAwait(false);
         return import is null ? null : await ListBreakDtosAsync(import.ImportId, ct).ConfigureAwait(false);
     }
 
-    public async Task<StatementRunDto?> ReconcileStatementRunAsync(string runId, StatementRunReconcileRequestDto request, CancellationToken ct = default)
+    public async Task<ContractStatementRunDto?> ReconcileStatementRunAsync(string runId, ContractStatementRunReconcileRequestDto request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
         var import = await FindImportAsync(runId, ct).ConfigureAwait(false);
@@ -113,62 +124,86 @@ public sealed class ReconciliationApiService(
         }
 
         var breaks = await ListBreakDtosAsync(import.ImportId, ct).ConfigureAwait(false);
-        return ToRunDto(import, breaks, breaks.Count == 0 ? StatementRunStatus.Completed : StatementRunStatus.ReviewRequired);
+        return ToRunDto(import, breaks, breaks.Count == 0 ? ContractStatementRunStatus.Completed : ContractStatementRunStatus.ReviewRequired);
     }
 
     public async Task<IReadOnlyList<StatementRunExceptionDto>> ListOpenExceptionsAsync(CancellationToken ct = default)
         => (await breakStore.ListOpenAsync(ct).ConfigureAwait(false))
-            .Select(x => new StatementRunExceptionDto(x.BreakId, x.RunId, x.ImportId, x.SourceReference, x.BreakCode, x.Category, x.Delta, x.Tolerance, x.ToleranceBreached, x.CreatedAtUtc.ToString("O"), x.Status))
+            .Select(static item => new StatementRunExceptionDto(
+                item.BreakId,
+                item.RunId,
+                item.ImportId,
+                item.SourceReference,
+                item.BreakCode,
+                item.Category,
+                item.Delta,
+                item.Tolerance,
+                item.ToleranceBreached,
+                item.CreatedAtUtc.ToString("O"),
+                item.Status))
             .ToList();
 
-    public async Task<IReadOnlyList<StatementBreakDto>> ListOpenStatementBreaksAsync(CancellationToken ct = default)
-        => (await breakStore.ListOpenAsync(ct)).Select(x => new StatementBreakDto(
-            BreakId: x.BreakId,
-            BreakType: MapStatementBreakType(x.Category, x.BreakCode),
-            Severity: x.ToleranceBreached ? StatementValidationSeverity.Error : StatementValidationSeverity.Warning,
-            MatchTier: StatementMatchTier.Manual,
-            StatementReference: x.SourceReference,
-            Description: $"{x.Category} break {x.BreakCode} requires statement reconciliation review.",
-            StatementAmount: x.Delta,
-            BookAmount: null,
-            Delta: x.Delta,
-            Tolerance: x.Tolerance,
-            Currency: null,
-            CreatedAtUtc: x.CreatedAtUtc,
-            Status: x.Status,
-            InternalReference: x.RunId,
-            Owner: null,
-            LastObservedAtUtc: x.CreatedAtUtc,
-            RecommendedAction: "ReviewAndResolve",
-            EvidenceLink: $"/api/workstation/reconciliation/exceptions/{Uri.EscapeDataString(x.BreakId)}")).ToList();
+    public async Task<IReadOnlyList<ContractStatementBreakDto>> ListOpenStatementBreaksAsync(CancellationToken ct = default)
+        => (await breakStore.ListOpenAsync(ct).ConfigureAwait(false))
+            .Select(static item => new ContractStatementBreakDto(
+                BreakId: item.BreakId,
+                BreakType: MapBreakType(item.BreakCode),
+                Severity: item.ToleranceBreached ? ContractStatementValidationSeverity.Error : ContractStatementValidationSeverity.Warning,
+                MatchTier: ContractStatementMatchTier.Manual,
+                StatementReference: item.SourceReference,
+                Description: $"{item.Category} break {item.BreakCode} requires statement reconciliation review.",
+                StatementAmount: item.Delta,
+                BookAmount: null,
+                Delta: item.Delta,
+                Tolerance: item.Tolerance,
+                Currency: null,
+                CreatedAtUtc: item.CreatedAtUtc,
+                Status: item.Status,
+                InternalReference: item.RunId,
+                Owner: null,
+                LastObservedAtUtc: item.CreatedAtUtc,
+                RecommendedAction: "ReviewAndResolve",
+                EvidenceLink: $"/api/workstation/reconciliation/exceptions/{Uri.EscapeDataString(item.BreakId)}"))
+            .ToList();
 
     public async Task<IReadOnlyList<ReconciliationCaseSummaryDto>> ListOpenCasesAsync(CancellationToken ct = default)
         => (await caseStore.ListAsync(ct).ConfigureAwait(false))
-            .Where(c => c.Status == "Open")
-            .Select(c => new ReconciliationCaseSummaryDto(c.CaseId, c.ImportId, c.Status, c.Reason, c.Confidence, c.Rationale, c.CreatedAtUtc.ToString("O")))
+            .Where(static item => string.Equals(item.Status, "Open", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(item.Status, "InReview", StringComparison.OrdinalIgnoreCase))
+            .Select(ToCaseSummary)
             .ToList();
 
     public async Task<IReadOnlyList<ReconciliationQueueAccountStatusDto>> ListQueueStatusAsync(CancellationToken ct = default)
     {
-        var openCases = (await caseStore.ListAsync(ct).ConfigureAwait(false)).Where(c => c.Status == "Open").ToList();
-        return openCases
-            .GroupBy(c => c.ImportId)
-            .Select(group => new ReconciliationQueueAccountStatusDto(
-                AccountId: Guid.Empty,
-                AccountCode: group.Key,
-                QueueState: group.Any(c => c.Confidence < 0.5m) ? "Blocked" : "Review",
-                UnresolvedBreakCount: group.Count(),
-                SignOffReady: false,
-                NextBestAction: "Resolve open reconciliation breaks before operator sign-off.",
-                BlockerReason: "Unresolved breaks remain in the reconciliation queue.",
-                EvidenceLinks: group.Select(c => $"/api/workstation/reconciliation/cases/{Uri.EscapeDataString(c.CaseId)}").ToList()))
+        var breaks = await breakStore.ListOpenAsync(ct).ConfigureAwait(false);
+        var cases = await caseStore.ListAsync(ct).ConfigureAwait(false);
+        return breaks
+            .GroupBy(static item => string.IsNullOrWhiteSpace(item.ImportId) ? item.RunId : item.ImportId, StringComparer.OrdinalIgnoreCase)
+            .Select(group =>
+            {
+                var relatedCases = cases.Where(c => string.Equals(c.ImportId, group.Key, StringComparison.OrdinalIgnoreCase)).ToArray();
+                var criticalCount = group.Count(static item => item.ToleranceBreached);
+                return new ReconciliationQueueAccountStatusDto(
+                    AccountId: Guid.Empty,
+                    AccountCode: group.Key,
+                    QueueState: criticalCount > 0 ? "Blocked" : "Review",
+                    UnresolvedBreakCount: group.Count(),
+                    SignOffReady: group.Count() == 0 && relatedCases.All(static c => string.Equals(c.Status, "Resolved", StringComparison.OrdinalIgnoreCase)),
+                    NextBestAction: criticalCount > 0
+                        ? "Assign critical reconciliation breaks and capture resolution evidence."
+                        : "Review open reconciliation breaks before operator sign-off.",
+                    BlockerReason: criticalCount > 0
+                        ? "Tolerance-breached breaks remain unresolved."
+                        : "Unresolved breaks remain in the reconciliation queue.",
+                    EvidenceLinks: group.Select(item => $"/api/workstation/reconciliation/break-queue/{Uri.EscapeDataString(item.BreakId)}").ToList());
+            })
             .ToList();
     }
 
     private static StatementRunSummaryDto ToStatementRunSummary(
-        Meridian.Domain.Reconciliation.CanonicalStatementImport import,
-        IReadOnlyList<Meridian.Domain.Reconciliation.ReconciliationBreakRecord> breaks,
-        IReadOnlyList<Meridian.Domain.Reconciliation.ReconciliationCase> cases)
+        CanonicalStatementImport import,
+        IReadOnlyList<ReconciliationBreakRecord> breaks,
+        IReadOnlyList<ReconciliationCase> cases)
     {
         var relatedBreaks = breaks
             .Where(item => string.Equals(item.ImportId, import.ImportId, StringComparison.OrdinalIgnoreCase)
@@ -177,7 +212,7 @@ public sealed class ReconciliationApiService(
         var relatedCases = cases
             .Where(item => string.Equals(item.ImportId, import.ImportId, StringComparison.OrdinalIgnoreCase))
             .ToArray();
-        var openExceptionCount = relatedBreaks.Count(item => string.Equals(item.Status, "Open", StringComparison.OrdinalIgnoreCase));
+        var openExceptionCount = relatedBreaks.Count(static item => string.Equals(item.Status, "Open", StringComparison.OrdinalIgnoreCase));
         var matchedCount = Math.Max(0, import.NormalizedRowCount - relatedBreaks.Length);
         var evidenceLink = BuildEvidenceLink(import, relatedBreaks, relatedCases, matchedCount);
 
@@ -194,45 +229,30 @@ public sealed class ReconciliationApiService(
     }
 
     private static StatementRunEvidenceLinkDto BuildEvidenceLink(
-        Meridian.Domain.Reconciliation.CanonicalStatementImport import,
-        IReadOnlyList<Meridian.Domain.Reconciliation.ReconciliationBreakRecord> breaks,
-        IReadOnlyList<Meridian.Domain.Reconciliation.ReconciliationCase> cases,
+        CanonicalStatementImport import,
+        IReadOnlyList<ReconciliationBreakRecord> breaks,
+        IReadOnlyList<ReconciliationCase> cases,
         int matchedCount)
     {
         var runId = import.ImportId;
-        var breakIds = breaks
-            .Select(static item => item.BreakId)
-            .Where(static id => !string.IsNullOrWhiteSpace(id))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(static id => id, StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-        var caseIds = cases
-            .Select(static item => item.CaseId)
-            .Where(static id => !string.IsNullOrWhiteSpace(id))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(static id => id, StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-        var sourceFileHash = FirstNonEmpty(import.SourceFileHash, import.SourceChecksum);
-        var brokerCustodian = FirstNonEmpty(import.SourceInstitution, import.Broker);
-        var account = FirstNonEmpty(import.ExternalAccountId, import.FundAccountId);
-        var validationSummary = "Passed: 0 issue(s), 0 error(s), 0 warning(s).";
-        var matchSummary = $"{matchedCount}/{import.NormalizedRowCount} item(s) matched; {breakIds.Length} break(s); {caseIds.Length} case(s).";
+        var breakIds = breaks.Select(static item => item.BreakId).Where(static id => !string.IsNullOrWhiteSpace(id)).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(static id => id, StringComparer.OrdinalIgnoreCase).ToArray();
+        var caseIds = cases.Select(static item => item.CaseId).Where(static id => !string.IsNullOrWhiteSpace(id)).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(static id => id, StringComparer.OrdinalIgnoreCase).ToArray();
 
         return new StatementRunEvidenceLinkDto(
             EvidenceId: $"statement-run:{runId}",
             EvidenceRoute: $"/api/workstation/evidence/statement-run/{Uri.EscapeDataString(runId)}",
             RunId: runId,
-            SourceFileHash: sourceFileHash,
-            BrokerCustodian: brokerCustodian,
-            Account: account,
+            SourceFileHash: FirstNonEmpty(import.SourceFileHash, import.SourceChecksum),
+            BrokerCustodian: FirstNonEmpty(import.SourceInstitution, import.Broker),
+            Account: FirstNonEmpty(import.ExternalAccountId, import.FundAccountId),
             StatementPeriodStart: import.StatementPeriodStart.ToString("yyyy-MM-dd"),
             StatementPeriodEnd: import.StatementPeriodEnd.ToString("yyyy-MM-dd"),
             MappingProfileId: FirstNonEmpty(import.MappingProfileId, "unknown"),
             MappingProfileVersion: 1,
             ToleranceProfileId: FirstNonEmpty(import.ToleranceProfileId, "statement-default"),
             ToleranceProfileVersion: 1,
-            ValidationSummary: validationSummary,
-            MatchSummary: matchSummary,
+            ValidationSummary: "Passed: 0 issue(s), 0 error(s), 0 warning(s).",
+            MatchSummary: $"{matchedCount}/{import.NormalizedRowCount} item(s) matched; {breakIds.Length} break(s); {caseIds.Length} case(s).",
             BreakIds: breakIds,
             CaseIds: caseIds,
             ImportedBy: FirstNonEmpty(import.ImportedBy, "system"),
@@ -241,10 +261,6 @@ public sealed class ReconciliationApiService(
             ReconciledAtUtc: import.ImportedAtUtc.ToString("O"));
     }
 
-    private static string FirstNonEmpty(params string?[] values)
-        => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value))?.Trim() ?? string.Empty;
-
-    private static StatementBreakType MapStatementBreakType(string category, string breakCode)
     private async Task<CanonicalStatementImport?> FindImportAsync(string runId, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(runId))
@@ -256,43 +272,31 @@ public sealed class ReconciliationApiService(
             .FirstOrDefault(import => string.Equals(import.ImportId, runId, StringComparison.OrdinalIgnoreCase));
     }
 
-    private async Task<IReadOnlyList<StatementRunBreakDto>> ListBreakDtosAsync(string runId, CancellationToken ct)
+    private async Task<IReadOnlyList<ContractStatementRunBreakDto>> ListBreakDtosAsync(string runId, CancellationToken ct)
         => (await breakStore.ListOpenAsync(ct).ConfigureAwait(false))
-            .Where(breakRecord => string.Equals(breakRecord.RunId, runId, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(breakRecord.ImportId, runId, StringComparison.OrdinalIgnoreCase))
-            .Select(static breakRecord => new StatementRunBreakDto(
-                breakRecord.BreakId,
-                breakRecord.RunId,
-                breakRecord.ImportId,
-                breakRecord.SourceReference,
-                MapBreakType(breakRecord.BreakCode),
-                breakRecord.Category,
-                breakRecord.Delta,
-                breakRecord.Tolerance,
-                breakRecord.ToleranceBreached,
-                breakRecord.CreatedAtUtc,
-                breakRecord.Status))
+            .Where(item => string.Equals(item.RunId, runId, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(item.ImportId, runId, StringComparison.OrdinalIgnoreCase))
+            .Select(static item => new ContractStatementRunBreakDto(
+                item.BreakId,
+                item.RunId,
+                item.ImportId,
+                item.SourceReference,
+                MapBreakType(item.BreakCode),
+                item.Category,
+                item.Delta,
+                item.Tolerance,
+                item.ToleranceBreached,
+                item.CreatedAtUtc,
+                item.Status))
             .ToList();
 
-    private static StatementRunSummaryDto ToSummary(CanonicalStatementImport import) =>
-        new(
-            import.ImportId,
-            import.ImportId,
-            StatementRunStatus.Completed,
-            import.ImportedAtUtc,
-            import.ImportedAtUtc,
-            import.NormalizedRowCount,
-            0,
-            0,
-            0);
-
-    private static StatementRunDto ToRunDto(
+    private static ContractStatementRunDto ToRunDto(
         CanonicalStatementImport import,
-        IReadOnlyList<StatementRunBreakDto> breaks,
-        StatementRunStatus status,
+        IReadOnlyList<ContractStatementRunBreakDto> breaks,
+        ContractStatementRunStatus status,
         string? notes = null)
     {
-        var source = new StatementSourceDto(
+        var source = new ContractStatementSourceDto(
             SourceId: import.ImportId,
             SourceKind: import.Broker,
             SourceSystem: import.SourceInstitution,
@@ -305,12 +309,12 @@ public sealed class ReconciliationApiService(
             CustodianId: import.SourceInstitution,
             ExternalAccountId: import.ExternalAccountId);
 
-        return new StatementRunDto(
+        return new ContractStatementRunDto(
             RunId: import.ImportId,
             Status: status,
             Source: source,
             StartedAtUtc: import.ImportedAtUtc,
-            CompletedAtUtc: status is StatementRunStatus.Completed ? import.ImportedAtUtc : null,
+            CompletedAtUtc: status is ContractStatementRunStatus.Completed ? import.ImportedAtUtc : null,
             SourceFileName: import.OriginalFileName,
             SourceFileHash: import.SourceFileHash,
             MappingProfileId: import.MappingProfileId,
@@ -323,30 +327,30 @@ public sealed class ReconciliationApiService(
             Positions: [],
             CashBalances: [],
             Transactions: [],
-            MatchSummary: new StatementMatchSummaryDto(
+            MatchSummary: new ContractStatementMatchSummaryDto(
                 StatementItemCount: import.NormalizedRowCount,
                 MatchedItemCount: Math.Max(0, import.NormalizedRowCount - breaks.Count),
                 AutoMatchedItemCount: Math.Max(0, import.NormalizedRowCount - breaks.Count),
                 ManualMatchedItemCount: 0,
                 ReviewRequiredItemCount: breaks.Count,
                 BreakCount: breaks.Count,
-                PositionBreakCount: breaks.Count(static b => b.BreakType is StatementBreakType.PositionMarketValueMismatch or StatementBreakType.PositionQuantityMismatch),
-                CashBreakCount: breaks.Count(static b => b.BreakType is StatementBreakType.CashBalanceMismatch),
-                TransactionBreakCount: breaks.Count(static b => b.BreakType is StatementBreakType.TransactionAmountMismatch)),
-            Breaks: breaks.Select(static b => new StatementBreakDto(
-                b.BreakId,
-                b.BreakType,
-                b.ToleranceBreached ? StatementValidationSeverity.Error : StatementValidationSeverity.Warning,
-                b.ToleranceBreached ? StatementMatchTier.Unmatched : StatementMatchTier.WithinTolerance,
-                b.SourceReference,
-                b.Category,
-                b.Delta,
+                PositionBreakCount: breaks.Count(static item => item.BreakType is ContractStatementBreakType.PositionMarketValueMismatch or ContractStatementBreakType.PositionQuantityMismatch),
+                CashBreakCount: breaks.Count(static item => item.BreakType is ContractStatementBreakType.CashBalanceMismatch),
+                TransactionBreakCount: breaks.Count(static item => item.BreakType is ContractStatementBreakType.TransactionAmountMismatch)),
+            Breaks: breaks.Select(static item => new ContractStatementBreakDto(
+                item.BreakId,
+                item.BreakType,
+                item.ToleranceBreached ? ContractStatementValidationSeverity.Error : ContractStatementValidationSeverity.Warning,
+                item.ToleranceBreached ? ContractStatementMatchTier.Unmatched : ContractStatementMatchTier.WithinTolerance,
+                item.SourceReference,
+                item.Category,
+                item.Delta,
                 null,
-                b.Delta,
-                b.Tolerance,
+                item.Delta,
+                item.Tolerance,
                 null,
-                b.CreatedAtUtc,
-                b.Status)).ToList(),
+                item.CreatedAtUtc,
+                item.Status)).ToList(),
             Cases: [],
             ImportId: import.ImportId,
             FundProfileId: import.FundAccountId,
@@ -354,7 +358,31 @@ public sealed class ReconciliationApiService(
             Notes: notes);
     }
 
-    private static void ValidateCreateRequest(StatementRunCreateDto request)
+    private static ReconciliationCaseSummaryDto ToCaseSummary(ReconciliationCase item)
+        => new(
+            item.CaseId,
+            item.ImportId,
+            item.Status,
+            item.Reason,
+            item.Confidence,
+            item.Rationale,
+            item.CreatedAtUtc.ToString("O"),
+            Assignee: item.Owner,
+            Priority: item.Priority,
+            SlaDueAtUtc: item.DueAtUtc?.ToString("O"),
+            SlaBreachedAtUtc: item.SlaBreachedAtUtc?.ToString("O"),
+            SlaState: item.SlaBreachedAtUtc.HasValue ? "Breached" : "OnTrack",
+            BusinessAgeHours: Math.Max(0, (DateTimeOffset.UtcNow - item.CreatedAtUtc).TotalHours),
+            ResolutionCode: item.Resolution?.ResolutionCode,
+            ResolutionNote: item.Resolution?.Summary,
+            SignedOffBy: item.Resolution?.SignedOffBy,
+            SignedOffAtUtc: item.Resolution?.SignedOffAtUtc?.ToString("O"),
+            Version: item.History.Count + item.AuditEvents.Count);
+
+    private static string FirstNonEmpty(params string?[] values)
+        => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value))?.Trim() ?? string.Empty;
+
+    private static void ValidateCreateRequest(ContractStatementRunCreateDto request)
     {
         if (request.StatementPeriodEnd < request.StatementPeriodStart)
         {
@@ -387,33 +415,33 @@ public sealed class ReconciliationApiService(
         return Convert.ToHexString(hash);
     }
 
-    private static StatementBreakType MapBreakType(string breakCode)
+    private static ContractStatementBreakType MapBreakType(string breakCode)
     {
         if (breakCode.Contains("cash", StringComparison.OrdinalIgnoreCase))
         {
-            return StatementBreakType.CashBalanceMismatch;
+            return ContractStatementBreakType.CashBalanceMismatch;
         }
 
-        if (breakCode.Contains("transaction", StringComparison.OrdinalIgnoreCase))
+        if (breakCode.Contains("transaction", StringComparison.OrdinalIgnoreCase) || breakCode.Contains("txn", StringComparison.OrdinalIgnoreCase))
         {
-            return StatementBreakType.TransactionAmountMismatch;
+            return ContractStatementBreakType.TransactionAmountMismatch;
         }
 
-        if (breakCode.Contains("security", StringComparison.OrdinalIgnoreCase))
+        if (breakCode.Contains("security", StringComparison.OrdinalIgnoreCase) || breakCode.Contains("symbol", StringComparison.OrdinalIgnoreCase))
         {
-            return StatementBreakType.SecurityIdentifierMismatch;
+            return ContractStatementBreakType.SecurityIdentifierMismatch;
         }
 
-        if (breakCode.Contains("quantity", StringComparison.OrdinalIgnoreCase))
+        if (breakCode.Contains("quantity", StringComparison.OrdinalIgnoreCase) || breakCode.Contains("qty", StringComparison.OrdinalIgnoreCase))
         {
-            return StatementBreakType.PositionQuantityMismatch;
+            return ContractStatementBreakType.PositionQuantityMismatch;
         }
 
         if (breakCode.Contains("position", StringComparison.OrdinalIgnoreCase))
         {
-            return StatementBreakType.PositionMarketValueMismatch;
+            return ContractStatementBreakType.PositionMarketValueMismatch;
         }
 
-        return StatementBreakType.Unknown;
+        return ContractStatementBreakType.Unknown;
     }
 }

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -6338,8 +6338,22 @@ public static partial class WorkstationEndpoints
             PendingSignoffCount: pendingSignoffCount,
             SignedOffCount: signedOffCount,
             MissingCalibrationMetadataCount: missingCalibrationMetadataCount,
-            Profiles: profiles);
+            Profiles: profiles)
+        {
+            BreakCountTrend = activeBreakCount - resolvedBreakCount,
+            AutoMatchRate = CalculateAutoMatchRate(totalBreakCount, activeBreakCount),
+            T0ClosureRate = CalculateT0ClosureRate(totalBreakCount, resolvedBreakCount, dismissedBreakCount),
+            BreakCountAlertThreshold = 25,
+            AutoMatchRateAlertThreshold = 0.85m,
+            T0ClosureRateAlertThreshold = 0.90m
+        };
     }
+
+    private static decimal CalculateAutoMatchRate(int totalBreakCount, int activeBreakCount)
+        => totalBreakCount <= 0 ? 1m : decimal.Round((decimal)Math.Max(0, totalBreakCount - activeBreakCount) / totalBreakCount, 4);
+
+    private static decimal CalculateT0ClosureRate(int totalBreakCount, int resolvedBreakCount, int dismissedBreakCount)
+        => totalBreakCount <= 0 ? 1m : decimal.Round((decimal)(resolvedBreakCount + dismissedBreakCount) / totalBreakCount, 4);
 
     private static ReconciliationCalibrationProfileSummaryDto BuildCalibrationProfileSummary(
         IGrouping<(string Profile, string Route), ReconciliationBreakQueueItem> group)

--- a/src/Meridian.Ui/dashboard/README.md
+++ b/src/Meridian.Ui/dashboard/README.md
@@ -96,6 +96,8 @@ npm --prefix src/Meridian.Ui/dashboard run build
 
 ## Change rules
 
+- Governance reconciliation views include queue actions plus calibration KPI widgets for break trend, auto-match rate, T+0 closure rate, and threshold warnings sourced from shared workstation contracts.
+
 Do not create mobile-first workflows or native mobile clients. Prefer shared read models and
 endpoint contracts for behavior also consumed by WPF or host workflows.
 

--- a/src/Meridian.Ui/dashboard/src/lib/api.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api.ts
@@ -68,8 +68,6 @@ import type {
   StatementRunException,
   StatementRunSummary,
   ReconciliationCaseworkCommand,
-  StatementRunException,
-  StatementRunSummary,
   ResolveReconciliationBreakRequest,
   ResolveConflictRequest,
   ReviewReconciliationBreakRequest,
@@ -932,17 +930,21 @@ export function getReconciliationRun(reconciliationRunId: string) {
   return getJson<unknown>(reconciliationRunEndpoint(reconciliationRunId));
 }
 
-export function getReconciliationStatementRuns() {
-  return getJson<StatementRunSummary[]>(reconciliationStatementRunsEndpoint());
+export function getReconciliationStatementRuns(options: ApiRequestOptions = {}) {
+  return getJson<StatementRunSummary[]>(reconciliationStatementRunsEndpoint(), options);
 }
 
-export function getReconciliationStatementRun(runId: string) {
-  return getJson<StatementRunSummary>(reconciliationStatementRunEndpoint(runId));
+export function getReconciliationStatementRun(runId: string, options: ApiRequestOptions = {}) {
+  return getJson<StatementRunSummary>(reconciliationStatementRunEndpoint(runId), options);
 }
 
-export function getReconciliationStatementExceptions() {
-  return getJson<StatementRunException[]>(reconciliationStatementExceptionsEndpoint());
+export function getReconciliationStatementExceptions(options: ApiRequestOptions = {}) {
+  return getJson<StatementRunException[]>(reconciliationStatementExceptionsEndpoint(), options);
 }
+
+export const getStatementRuns = getReconciliationStatementRuns;
+export const getStatementRun = getReconciliationStatementRun;
+export const getStatementRunExceptions = getReconciliationStatementExceptions;
 
 export function getReconciliationBreakQueue(status?: string, fundAccountId?: string) {
   return getJson<ReconciliationBreakQueueItem[]>(reconciliationBreakQueueEndpoint({ status, fundAccountId }));

--- a/src/Meridian.Ui/dashboard/src/lib/dev-fixtures.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/dev-fixtures.ts
@@ -962,6 +962,15 @@ const fixtureCalibrationSummary: ReconciliationCalibrationSummary = {
   pendingSignoffCount: 1,
   signedOffCount: 2,
   missingCalibrationMetadataCount: 0,
+  breakCountTrend: 1,
+  autoMatchRate: 0.86,
+  t0ClosureRate: 0.67,
+  breakCountAlertThreshold: 25,
+  autoMatchRateAlertThreshold: 0.85,
+  t0ClosureRateAlertThreshold: 0.9,
+  breakCountAlertTriggered: false,
+  autoMatchRateAlertTriggered: false,
+  t0ClosureRateAlertTriggered: true,
   profiles: [
     {
       toleranceProfileId: "tp-cash-variance",

--- a/src/Meridian.Ui/dashboard/src/screens/governance-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/governance-screen.tsx
@@ -1626,7 +1626,7 @@ function CalibrationSummaryPanel({ view }: { view: CalibrationSummaryViewModel }
             <BookCheck className="h-4 w-4 text-primary" />
             Calibration summary
           </CardTitle>
-          <CardDescription>Tolerance profile health across all active reconciliation break routes.</CardDescription>
+          <CardDescription>Tolerance profile health, break trend, auto-match rate, and T+0 closure rate across active reconciliation routes.</CardDescription>
         </div>
         <Button
           type="button"
@@ -1667,7 +1667,7 @@ function CalibrationSummaryPanel({ view }: { view: CalibrationSummaryViewModel }
               </div>
               <span className="shrink-0 font-mono text-xs text-muted-foreground">as of {view.asOfLabel}</span>
             </div>
-            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-9">
               {view.metricRows.map((metric) => (
                 <div
                   key={metric.id}

--- a/src/Meridian.Ui/dashboard/src/screens/governance-screen.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/governance-screen.view-model.test.ts
@@ -705,6 +705,12 @@ describe("governance-screen view model", () => {
       pendingSignoffCount: 3,
       signedOffCount: 4,
       missingCalibrationMetadataCount: 1,
+      breakCountTrend: 2,
+      autoMatchRate: 0.875,
+      t0ClosureRate: 0.75,
+      breakCountAlertTriggered: false,
+      autoMatchRateAlertTriggered: false,
+      t0ClosureRateAlertTriggered: true,
       profiles: [
         {
           toleranceProfileId: "profile-cash",
@@ -748,6 +754,9 @@ describe("governance-screen view model", () => {
       expect.objectContaining({ id: "critical-open", label: "Critical open", value: 1, tone: "warning" }),
       expect.objectContaining({ id: "pending-signoff", label: "Pending sign-off", value: 3, tone: "warning" }),
       expect.objectContaining({ id: "signed-off", label: "Signed off", value: 4, tone: "default" }),
+      expect.objectContaining({ id: "break-trend", label: "Break trend", value: 2, tone: "default" }),
+      expect.objectContaining({ id: "auto-match", label: "Auto-match %", value: 88, tone: "default" }),
+      expect.objectContaining({ id: "t0-closure", label: "T+0 closure %", value: 75, tone: "warning" }),
       expect.objectContaining({ id: "missing-metadata", label: "Missing metadata", value: 1, tone: "warning" })
     ]);
     expect(state.profileRows[0].ariaLabel).toContain("profile-cash");

--- a/src/Meridian.Ui/dashboard/src/screens/governance-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/governance-screen.view-model.ts
@@ -4047,6 +4047,9 @@ function buildCalibrationSummaryMetrics(
     buildCalibrationSummaryMetric("critical-open", "Critical open", criticalOpenBreakCount, criticalOpenBreakCount > 0),
     buildCalibrationSummaryMetric("pending-signoff", "Pending sign-off", pendingSignoffCount, pendingSignoffCount > 0),
     buildCalibrationSummaryMetric("signed-off", "Signed off", signedOffCount, false),
+    buildCalibrationSummaryMetric("break-trend", "Break trend", summary?.breakCountTrend ?? 0, summary?.breakCountAlertTriggered ?? false),
+    buildCalibrationSummaryMetric("auto-match", "Auto-match %", Math.round((summary?.autoMatchRate ?? 1) * 100), summary?.autoMatchRateAlertTriggered ?? false),
+    buildCalibrationSummaryMetric("t0-closure", "T+0 closure %", Math.round((summary?.t0ClosureRate ?? 1) * 100), summary?.t0ClosureRateAlertTriggered ?? false),
     buildCalibrationSummaryMetric("missing-metadata", "Missing metadata", missingMetadataCount, missingMetadataCount > 0)
   ];
 }

--- a/src/Meridian.Ui/dashboard/src/types.ts
+++ b/src/Meridian.Ui/dashboard/src/types.ts
@@ -2529,6 +2529,15 @@ export interface ReconciliationCalibrationSummary {
   pendingSignoffCount: number;
   signedOffCount: number;
   missingCalibrationMetadataCount: number;
+  breakCountTrend?: number;
+  autoMatchRate?: number;
+  t0ClosureRate?: number;
+  breakCountAlertThreshold?: number;
+  autoMatchRateAlertThreshold?: number;
+  t0ClosureRateAlertThreshold?: number;
+  breakCountAlertTriggered?: boolean;
+  autoMatchRateAlertTriggered?: boolean;
+  t0ClosureRateAlertTriggered?: boolean;
   profiles: ReconciliationCalibrationProfile[];
 }
 

--- a/src/Meridian.Wpf/README.md
+++ b/src/Meridian.Wpf/README.md
@@ -34,6 +34,8 @@ matching module before it expands through the older flat page folders.
 
 ## Important workflows
 
+- Fund reconciliation workbench surfaces break queue casework, sign-off posture, and calibration KPIs (break trend, auto-match rate, T+0 closure) without moving matching logic into WPF view models.
+
 Keep desktop support aligned with shared contracts and governance posture.
 Convention-based view-model wiring is handled by `Services/ViewModelViewResolver.cs`; shell pages
 that follow the `*Page` to `*ViewModel` naming convention can receive a DI-constructed DataContext

--- a/src/Meridian.Wpf/Services/FundReconciliationWorkbenchService.cs
+++ b/src/Meridian.Wpf/Services/FundReconciliationWorkbenchService.cs
@@ -271,8 +271,22 @@ public sealed class FundReconciliationWorkbenchService : IFundReconciliationWork
             PendingSignoffCount: pendingSignoffCount,
             SignedOffCount: signedOffCount,
             MissingCalibrationMetadataCount: missingCalibrationMetadataCount,
-            Profiles: profiles);
+            Profiles: profiles)
+        {
+            BreakCountTrend = activeBreakCount - resolvedBreakCount,
+            AutoMatchRate = CalculateAutoMatchRate(totalBreakCount, activeBreakCount),
+            T0ClosureRate = CalculateT0ClosureRate(totalBreakCount, resolvedBreakCount, dismissedBreakCount),
+            BreakCountAlertThreshold = 25,
+            AutoMatchRateAlertThreshold = 0.85m,
+            T0ClosureRateAlertThreshold = 0.90m
+        };
     }
+    private static decimal CalculateAutoMatchRate(int totalBreakCount, int activeBreakCount)
+        => totalBreakCount <= 0 ? 1m : decimal.Round((decimal)Math.Max(0, totalBreakCount - activeBreakCount) / totalBreakCount, 4);
+
+    private static decimal CalculateT0ClosureRate(int totalBreakCount, int resolvedBreakCount, int dismissedBreakCount)
+        => totalBreakCount <= 0 ? 1m : decimal.Round((decimal)(resolvedBreakCount + dismissedBreakCount) / totalBreakCount, 4);
+
     private static FundReconciliationBreakQueueRow MapBreakQueueRow(
         ReconciliationBreakQueueItem item,
         IReadOnlyDictionary<string, string> runNames)

--- a/src/Meridian.Wpf/ViewModels/FundLedgerViewModel.Reconciliation.cs
+++ b/src/Meridian.Wpf/ViewModels/FundLedgerViewModel.Reconciliation.cs
@@ -930,9 +930,10 @@ public sealed partial class FundLedgerViewModel
         }
 
         ReconciliationCalibrationStatusText = FormatCalibrationStatus(summary.Status);
+        var kpiSummary = $"Break trend {summary.BreakCountTrend:+#;-#;0}; auto-match {summary.AutoMatchRate:P0}; T+0 closure {summary.T0ClosureRate:P0}.";
         ReconciliationCalibrationSummaryText = string.IsNullOrWhiteSpace(summary.Summary)
-            ? "Calibration summary did not include operator guidance."
-            : summary.Summary;
+            ? kpiSummary
+            : $"{summary.Summary} {kpiSummary}";
         ReconciliationCalibrationProfilesText = snapshot.CalibrationProfiles.Count.ToString("N0");
         ReconciliationCalibrationPendingSignoffText = summary.PendingSignoffCount.ToString("N0");
         ReconciliationCalibrationMissingMetadataText = summary.MissingCalibrationMetadataCount.ToString("N0");

--- a/tests/Meridian.Tests/Reconciliation/BrokerCustodianMatchingPipelineTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/BrokerCustodianMatchingPipelineTests.cs
@@ -1,0 +1,117 @@
+using FluentAssertions;
+using Meridian.Application.Reconciliation;
+
+namespace Meridian.Tests.Reconciliation;
+
+public sealed class BrokerCustodianMatchingPipelineTests
+{
+    [Fact]
+    public void Match_WhenRecordsAlignExactly_ShouldAutoMatchWithExactTier()
+    {
+        var now = new DateTimeOffset(2026, 5, 28, 10, 0, 0, TimeSpan.Zero);
+        var broker = CreateRecord("broker-1", CanonicalReconciliationSourceKind.Broker, quantity: 100m, price: 10m, marketValue: 1_000m, cash: 0m);
+        var custodian = CreateRecord("custodian-1", CanonicalReconciliationSourceKind.Custodian, quantity: 100m, price: 10m, marketValue: 1_000m, cash: 0m);
+
+        var decisions = new BrokerCustodianMatchingPipeline().Match("run-1", [broker], [custodian], now, "ops@example.test");
+
+        decisions.Should().ContainSingle();
+        decisions[0].Status.Should().Be(CanonicalReconciliationDecisionStatus.AutoMatched);
+        decisions[0].Tier.Should().Be(ReconciliationMatchTier.Exact);
+        decisions[0].Confidence.Should().Be(1.00m);
+        decisions[0].RuleId.Should().Be("exact-position-cash-transaction-v1");
+    }
+
+    [Fact]
+    public void Match_WhenOnlyHeuristicRuleFits_ShouldProposeDecisionForOperatorReview()
+    {
+        var now = new DateTimeOffset(2026, 5, 28, 10, 0, 0, TimeSpan.Zero);
+        var broker = CreateRecord("broker-1", CanonicalReconciliationSourceKind.Broker, quantity: 100m, price: 10m, marketValue: 1_000m, cash: 0m, reference: "BRK-1");
+        var custodian = CreateRecord("custodian-1", CanonicalReconciliationSourceKind.Custodian, quantity: 100.5m, price: 10.2m, marketValue: 1_020m, cash: 0m, reference: "CST-1");
+
+        var decisions = new BrokerCustodianMatchingPipeline().Match("run-1", [broker], [custodian], now, "ops@example.test");
+
+        decisions.Should().ContainSingle();
+        decisions[0].Status.Should().Be(CanonicalReconciliationDecisionStatus.Proposed);
+        decisions[0].Tier.Should().Be(ReconciliationMatchTier.Heuristic);
+        decisions[0].Confidence.Should().BeGreaterThanOrEqualTo(0.70m);
+    }
+
+    [Fact]
+    public async Task FileReconciliationDecisionJournal_ShouldAppendImmutableDecisionsAndResolutionHistory()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "meridian-recon-journal-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var now = new DateTimeOffset(2026, 5, 28, 10, 0, 0, TimeSpan.Zero);
+            var decision = new BrokerCustodianMatchingPipeline().Match(
+                "run-1",
+                [CreateRecord("broker-1", CanonicalReconciliationSourceKind.Broker, quantity: 100m, price: 10m, marketValue: 1_000m, cash: 0m)],
+                [],
+                now,
+                "ops@example.test").Single();
+            var history = new ReconciliationResolutionHistoryEntry(
+                "history-1",
+                decision.DecisionId,
+                decision.Status.ToString(),
+                CanonicalReconciliationDecisionStatus.ManuallyResolved.ToString(),
+                "ops@example.test",
+                "Matched to custodian correction ticket.",
+                now.AddMinutes(5),
+                decision.EvidenceReferences);
+            var journal = new FileReconciliationDecisionJournal(root);
+
+            await journal.AppendDecisionAsync(decision);
+            await journal.AppendHistoryAsync(history);
+
+            (await journal.ListDecisionsAsync("run-1")).Should().ContainSingle().Which.Status.Should().Be(CanonicalReconciliationDecisionStatus.UnresolvedBreak);
+            (await journal.ListHistoryAsync(decision.DecisionId)).Should().ContainSingle().Which.ToStatus.Should().Be("ManuallyResolved");
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    private static CanonicalReconciliationRecord CreateRecord(
+        string recordId,
+        CanonicalReconciliationSourceKind sourceKind,
+        decimal quantity,
+        decimal price,
+        decimal marketValue,
+        decimal cash,
+        string reference = "EXT-1")
+    {
+        var descriptor = new BrokerCustodianFeedDescriptor(
+            FeedId: $"feed-{sourceKind}",
+            SourceKind: sourceKind,
+            SourceSystem: sourceKind.ToString(),
+            AccountId: "fund-account-1",
+            ExternalAccountId: "external-account-1",
+            BusinessDate: new DateOnly(2026, 5, 28),
+            BaseCurrency: "USD",
+            CapturedAtUtc: new DateTimeOffset(2026, 5, 28, 9, 0, 0, TimeSpan.Zero),
+            ContentHash: "HASH",
+            AdapterId: "test-adapter",
+            AdapterVersion: "1");
+
+        return new CanonicalReconciliationRecord(
+            RecordId: recordId,
+            Feed: descriptor,
+            RecordKind: CanonicalReconciliationRecordKind.Position,
+            InstrumentId: "SEC-AAPL",
+            Symbol: "AAPL",
+            Quantity: quantity,
+            Price: price,
+            MarketValue: marketValue,
+            CashAmount: cash,
+            Currency: "USD",
+            TradeDate: new DateOnly(2026, 5, 28),
+            SettlementDate: new DateOnly(2026, 5, 29),
+            ActivityType: "Position",
+            ExternalReference: reference,
+            Evidence: new Dictionary<string, string> { ["sourceRow"] = recordId });
+    }
+}

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -3789,6 +3789,10 @@ public sealed partial class WorkstationEndpointsTests
             profile.TotalBreakCount > 0 &&
             profile.PendingSignoffCount > 0);
         summary.Summary.Should().Contain("reconciliation");
+        summary.BreakCountTrend.Should().BeGreaterThanOrEqualTo(0);
+        summary.AutoMatchRate.Should().BeInRange(0m, 1m);
+        summary.T0ClosureRate.Should().BeInRange(0m, 1m);
+        summary.BreakCountAlertThreshold.Should().BeGreaterThan(0);
     }
 
     [Fact]
@@ -3857,6 +3861,9 @@ public sealed partial class WorkstationEndpointsTests
         summary.SignedOffCount.Should().Be(summary.TotalBreakCount);
         summary.Profiles.Should().OnlyContain(profile => profile.PendingSignoffCount == 0);
         summary.Summary.Should().Contain("ready for governance sign-off");
+        summary.BreakCountTrend.Should().BeLessThanOrEqualTo(0);
+        summary.T0ClosureRate.Should().Be(1m);
+        summary.T0ClosureRateAlertTriggered.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/Meridian.Wpf.Tests/Support/FakeWorkstationReconciliationApiClient.cs
+++ b/tests/Meridian.Wpf.Tests/Support/FakeWorkstationReconciliationApiClient.cs
@@ -176,8 +176,22 @@ internal sealed class FakeWorkstationReconciliationApiClient : IWorkstationRecon
             PendingSignoffCount: pendingSignoffCount,
             SignedOffCount: signedOffCount,
             MissingCalibrationMetadataCount: missingMetadataCount,
-            Profiles: profiles);
+            Profiles: profiles)
+        {
+            BreakCountTrend = activeItems.Length - items.Count(static item => item.Status == ReconciliationBreakQueueStatus.Resolved),
+            AutoMatchRate = CalculateAutoMatchRate(items.Length, activeItems.Length),
+            T0ClosureRate = CalculateT0ClosureRate(
+                items.Length,
+                items.Count(static item => item.Status == ReconciliationBreakQueueStatus.Resolved),
+                items.Count(static item => item.Status == ReconciliationBreakQueueStatus.Dismissed))
+        };
     }
+
+    private static decimal CalculateAutoMatchRate(int totalBreakCount, int activeBreakCount)
+        => totalBreakCount <= 0 ? 1m : decimal.Round((decimal)Math.Max(0, totalBreakCount - activeBreakCount) / totalBreakCount, 4);
+
+    private static decimal CalculateT0ClosureRate(int totalBreakCount, int resolvedBreakCount, int dismissedBreakCount)
+        => totalBreakCount <= 0 ? 1m : decimal.Round((decimal)(resolvedBreakCount + dismissedBreakCount) / totalBreakCount, 4);
 
     private static string BuildCalibrationSummaryText(
         int totalBreakCount,


### PR DESCRIPTION
### Motivation

- Provide a canonical reconciliation surface and pipeline for broker/custodian feeds so statement imports, matching, breaks, and casework are deterministic and auditable. 
- Implement multi-tier matching (exact / tolerance / heuristic) with confidence scoring to increase auto-match rates while preserving operator explainability. 
- Persist match decisions, unresolved breaks, and immutable resolution/audit history so operator actions and sign-offs are traceable. 
- Surface reconciliation queue, casework actions, KPIs and calibration summaries to both the browser dashboard and WPF operator workbench through shared `Ui.Services` endpoints and shared DTOs. 

### Description

- Added canonical reconciliation domain models, adapters and ingestion seams under `src/Meridian.Application/Reconciliation` including `ReconciliationMatchingEngine`, `ReconciliationNormalizationService`, `StatementMatchingEngine` and tolerance/profile types. 
- Implemented provider/infrastructure components under `src/Meridian.Infrastructure/Reconciliation` including `ICanonicalStatementStore`, `IReconciliationBreakStore`, `IReconciliationCaseStore`, a `CsvBrokerStatementService`, `StatementMatchingService`, and JSON-backed file stores (`JsonCanonicalStatementStore`, `JsonReconciliationBreakStore`, `JsonReconciliationCaseStore`). 
- Implemented `ReconciliationApiService` in `src/Meridian.Ui.Services/Services/Reconciliation/ReconciliationApiService.cs` and hooked operator-facing endpoints in `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Reconciliation.cs` (list runs, create/run statement runs, break queue, review/resolve/assign actions, calibration summary, audit history, and bulk casework). 
- Wired WPF and browser surfaces to the shared API/read-models by updating `FundLedgerViewModel` (reconciliation workbench) and adding dashboard components and view-models in `src/Meridian.Ui/dashboard` for calibration widgets, break queue, statement runs, actions and KPI trend snapshots. 
- Added persistence and immutable audit append behavior for case saves and case-history (uses `AtomicFileWriter`/JSONL audit append) and ensured tolerance profile and rule IDs are stamped into match evidence and match artifacts. 
- Kept API/contract compatibility by placing shared DTOs in `src/Meridian.Ui.Shared/Contracts/Reconciliation` and `src/Meridian.Contracts/Workstation` and updated workstation endpoint routing constants in `src/Meridian.Ui/dashboard/src/lib/workstation-endpoints.ts`. 

### Testing

- Narrow validation attempted: build the UI services project with `dotnet build src/Meridian.Ui.Services/Meridian.Ui.Services.csproj /p:EnableWindowsTargeting=true --no-restore`. Result: failed to run because `dotnet` was not available in the execution environment (`/bin/bash: line 1: dotnet: command not found`). 
- No automated test suites were executed in this session due to the missing .NET SDK; repository contains focused tests covering reconciliation logic (e.g. `tests/Meridian.Tests/Reconciliation/*`, `tests/Meridian.Tests/Strategies/ReconciliationBreakQueueRepositoryTests.cs`, and `tests/Meridian.Wpf.Tests/Support/FakeWorkstationReconciliationApiClient.cs`) which should be run in CI or a local environment with the .NET toolchain. 
- Suggested narrow validation commands to run in CI or locally: `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "Category!=Integration"`, `dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj /p:EnableWindowsTargeting=true`, and `npm --prefix src/Meridian.Ui/dashboard run test` for the dashboard; these will validate matching logic, endpoint contracts, and UI integration respectively.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18a006d64883208a370ae3e6766add)