### PR TITLE
Add shared Family Office (SFO) DTOs, JSON context, README note, and serialization test

### DIFF
--- a/docs/source/generated/stale-docs.json
+++ b/docs/source/generated/stale-docs.json
@@ -24,7 +24,7 @@
     "version": "1.0.0"
   },
   "source_hash_manifest": "docs/source/generated/source-hash-manifest.json",
-  "stale_count": 23,
+  "stale_count": 28,
   "stale_modules": [
     {
       "module_id": "SRC-APP",
@@ -153,6 +153,18 @@
       ]
     },
     {
+      "module_id": "SRC-FSHARP-DIRECTLENDING",
+      "path": "src/Meridian.FSharp.DirectLending.Aggregates",
+      "readme": "src/Meridian.FSharp.DirectLending.Aggregates/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write only after the docs/code alignment review is complete"
+      ]
+    },
+    {
       "module_id": "SRC-FSHARP-LEDGER",
       "path": "src/Meridian.FSharp.Ledger",
       "readme": "src/Meridian.FSharp.Ledger/README.md",
@@ -167,6 +179,18 @@
       ]
     },
     {
+      "module_id": "SRC-FSHARP-TRADING",
+      "path": "src/Meridian.FSharp.Trading",
+      "readme": "src/Meridian.FSharp.Trading/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write only after the docs/code alignment review is complete"
+      ]
+    },
+    {
       "module_id": "SRC-HOST",
       "path": "src/Meridian",
       "readme": "src/Meridian/README.md",
@@ -177,6 +201,18 @@
       "recommended_actions": [
         "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
         "review README changes and rerender generated blocks if needed",
+        "run validate-doc-hashes.py --write only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-IBAPI-SMOKESTUB",
+      "path": "src/Meridian.IbApi.SmokeStub",
+      "readme": "src/Meridian.IbApi.SmokeStub/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
         "run validate-doc-hashes.py --write only after the docs/code alignment review is complete"
       ]
     },
@@ -221,6 +257,18 @@
       ]
     },
     {
+      "module_id": "SRC-MCP",
+      "path": "src/Meridian.Mcp",
+      "readme": "src/Meridian.Mcp/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write only after the docs/code alignment review is complete"
+      ]
+    },
+    {
       "module_id": "SRC-PROVIDER-SDK",
       "path": "src/Meridian.ProviderSdk",
       "readme": "src/Meridian.ProviderSdk/README.md",
@@ -238,6 +286,18 @@
       "module_id": "SRC-QUANTSCRIPT",
       "path": "src/Meridian.QuantScript",
       "readme": "src/Meridian.QuantScript/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-RISK",
+      "path": "src/Meridian.Risk",
+      "readme": "src/Meridian.Risk/README.md",
       "reasons": [
         "source_hash_drift"
       ],

--- a/docs/source/generated/stale-docs.md
+++ b/docs/source/generated/stale-docs.md
@@ -8,7 +8,7 @@ do_not_edit: true
 
 This report marks registered source modules whose code or README hashes differ from the reviewed baseline.
 
-- Stale modules: 23
+- Stale modules: 28
 - Removed module hash entries: 1
 
 | Module | Path | README | Reason |
@@ -22,13 +22,18 @@ This report marks registered source modules whose code or README hashes differ f
 | `SRC-EXECUTION` | `src/Meridian.Execution` | `src/Meridian.Execution/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-EXECUTION-SDK` | `src/Meridian.Execution.Sdk` | `src/Meridian.Execution.Sdk/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-FSHARP` | `src/Meridian.FSharp` | `src/Meridian.FSharp/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-FSHARP-DIRECTLENDING` | `src/Meridian.FSharp.DirectLending.Aggregates` | `src/Meridian.FSharp.DirectLending.Aggregates/README.md` | `source_hash_drift` |
 | `SRC-FSHARP-LEDGER` | `src/Meridian.FSharp.Ledger` | `src/Meridian.FSharp.Ledger/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-FSHARP-TRADING` | `src/Meridian.FSharp.Trading` | `src/Meridian.FSharp.Trading/README.md` | `source_hash_drift` |
 | `SRC-HOST` | `src/Meridian` | `src/Meridian/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-IBAPI-SMOKESTUB` | `src/Meridian.IbApi.SmokeStub` | `src/Meridian.IbApi.SmokeStub/README.md` | `source_hash_drift` |
 | `SRC-INFRASTRUCTURE` | `src/Meridian.Infrastructure` | `src/Meridian.Infrastructure/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-INFRASTRUCTURE-CPPTRADER` | `src/Meridian.Infrastructure.CppTrader` | `src/Meridian.Infrastructure.CppTrader/README.md` | `source_hash_drift` |
 | `SRC-LEDGER` | `src/Meridian.Ledger` | `src/Meridian.Ledger/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-MCP` | `src/Meridian.Mcp` | `src/Meridian.Mcp/README.md` | `source_hash_drift` |
 | `SRC-PROVIDER-SDK` | `src/Meridian.ProviderSdk` | `src/Meridian.ProviderSdk/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-QUANTSCRIPT` | `src/Meridian.QuantScript` | `src/Meridian.QuantScript/README.md` | `source_hash_drift` |
+| `SRC-RISK` | `src/Meridian.Risk` | `src/Meridian.Risk/README.md` | `source_hash_drift` |
 | `SRC-STORAGE` | `src/Meridian.Storage` | `src/Meridian.Storage/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-STRATEGIES` | `src/Meridian.Strategies` | `src/Meridian.Strategies/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-UI` | `src/Meridian.Ui` | `src/Meridian.Ui/README.md` | `source_hash_drift` |

--- a/src/Meridian.Ui.Shared/Contracts/FamilyOfficeContracts.cs
+++ b/src/Meridian.Ui.Shared/Contracts/FamilyOfficeContracts.cs
@@ -1,0 +1,223 @@
+namespace Meridian.Ui.Shared.Contracts;
+
+/// <summary>
+/// Single-family-office overview payload for browser and desktop operator workstations.
+/// </summary>
+public sealed record FamilyOfficeOverviewDto(
+    string FamilyOfficeId,
+    string DisplayName,
+    string BaseCurrency,
+    DateOnly AsOfDate,
+    FamilyBalanceSheetDto BalanceSheet,
+    IReadOnlyList<FamilyEntityDto> Entities,
+    FamilyOwnershipGraphDto OwnershipGraph,
+    IReadOnlyList<FamilyAccountSummaryDto> Accounts,
+    IReadOnlyList<FamilyAssetSummaryDto> PublicAssets,
+    IReadOnlyList<PrivateAssetSummaryDto> PrivateAssets,
+    IReadOnlyList<CapitalCommitmentDto> CapitalCommitments,
+    IReadOnlyList<CapitalActivityDto> RecentCapitalActivity,
+    FamilyOfficeReadinessDto Readiness,
+    IReadOnlyList<FamilyOfficeEvidenceLinkDto> EvidenceLinks);
+
+/// <summary>
+/// Consolidated family balance sheet with evidence fields retained for operator review.
+/// </summary>
+public sealed record FamilyBalanceSheetDto(
+    string FamilyOfficeId,
+    string BaseCurrency,
+    decimal TotalAssets,
+    decimal TotalLiabilities,
+    decimal NetWorth,
+    decimal LiquidAssets,
+    decimal MarketableSecurities,
+    decimal PrivateAssets,
+    decimal RealAssets,
+    decimal CashAndEquivalents,
+    decimal UnfundedCommitments,
+    string SourceSystem,
+    string? SourceDocumentId,
+    DateOnly AsOfDate,
+    DateOnly? ValuationDate,
+    string EvidenceCompleteness,
+    string ReconciliationStatus,
+    string? LastReviewedBy,
+    DateTimeOffset? LastReviewedAtUtc);
+
+/// <summary>
+/// Legal, trust, fund, household, or operating entity in the family office structure.
+/// </summary>
+public sealed record FamilyEntityDto(
+    string EntityId,
+    string DisplayName,
+    string EntityType,
+    string? Jurisdiction,
+    string? TaxResidency,
+    string BaseCurrency,
+    string? ParentEntityId,
+    decimal? OwnershipPercent,
+    bool IsOperatingEntity,
+    IReadOnlyList<FamilyOfficeEvidenceLinkDto> EvidenceLinks);
+
+/// <summary>
+/// Ownership graph used by operator surfaces to explain control, trust, and entity relationships.
+/// </summary>
+public sealed record FamilyOwnershipGraphDto(
+    DateOnly AsOfDate,
+    IReadOnlyList<FamilyOwnershipNodeDto> Nodes,
+    IReadOnlyList<FamilyOwnershipEdgeDto> Edges,
+    IReadOnlyList<FamilyOfficeEvidenceLinkDto> EvidenceLinks);
+
+public sealed record FamilyOwnershipNodeDto(
+    string NodeId,
+    string DisplayName,
+    string NodeType,
+    string? EntityId,
+    string? Jurisdiction,
+    string? Currency);
+
+public sealed record FamilyOwnershipEdgeDto(
+    string EdgeId,
+    string SourceNodeId,
+    string TargetNodeId,
+    string RelationshipType,
+    decimal? OwnershipPercent,
+    DateOnly? EffectiveFrom,
+    DateOnly? EffectiveTo,
+    string? SourceDocumentId);
+
+public sealed record FamilyAccountSummaryDto(
+    string AccountId,
+    string EntityId,
+    string DisplayName,
+    string AccountType,
+    string? Custodian,
+    string? ProviderAccountId,
+    string Currency,
+    decimal CashBalance,
+    decimal MarketValue,
+    decimal AccruedIncome,
+    decimal TotalEquity,
+    string SourceSystem,
+    string? SourceDocumentId,
+    DateOnly AsOfDate,
+    DateOnly? ValuationDate,
+    string EvidenceCompleteness,
+    string ReconciliationStatus,
+    string? LastReviewedBy,
+    DateTimeOffset? LastReviewedAtUtc);
+
+public sealed record FamilyAssetSummaryDto(
+    string AssetId,
+    string EntityId,
+    string? AccountId,
+    string DisplayName,
+    string AssetClass,
+    string? Symbol,
+    string Currency,
+    decimal Quantity,
+    decimal MarketValue,
+    decimal CostBasis,
+    decimal UnrealizedGainLoss,
+    decimal PercentOfNetWorth,
+    string SourceSystem,
+    string? SourceDocumentId,
+    DateOnly AsOfDate,
+    DateOnly? ValuationDate,
+    string EvidenceCompleteness,
+    string ReconciliationStatus,
+    string? LastReviewedBy,
+    DateTimeOffset? LastReviewedAtUtc);
+
+/// <summary>
+/// Summary for assets that require valuation evidence instead of exchange-traded marks.
+/// </summary>
+public sealed record PrivateAssetSummaryDto(
+    string PrivateAssetId,
+    string EntityId,
+    string DisplayName,
+    string AssetType,
+    string Currency,
+    decimal CurrentValue,
+    decimal? CommitmentAmount,
+    decimal? CalledCapital,
+    decimal? DistributedCapital,
+    string? ValuationMethod,
+    string SourceSystem,
+    string? SourceDocumentId,
+    DateOnly AsOfDate,
+    DateOnly? ValuationDate,
+    string EvidenceCompleteness,
+    string ReconciliationStatus,
+    string? LastReviewedBy,
+    DateTimeOffset? LastReviewedAtUtc);
+
+public sealed record CapitalCommitmentDto(
+    string CommitmentId,
+    string EntityId,
+    string VehicleName,
+    string Strategy,
+    string Currency,
+    decimal CommitmentAmount,
+    decimal CalledAmount,
+    decimal UnfundedAmount,
+    decimal DistributedAmount,
+    decimal CurrentNav,
+    int? VintageYear,
+    string SourceSystem,
+    string? SourceDocumentId,
+    DateOnly AsOfDate,
+    DateOnly? ValuationDate,
+    string EvidenceCompleteness,
+    string ReconciliationStatus,
+    string? LastReviewedBy,
+    DateTimeOffset? LastReviewedAtUtc);
+
+public sealed record CapitalActivityDto(
+    string ActivityId,
+    string CommitmentId,
+    string EntityId,
+    string ActivityType,
+    string Currency,
+    decimal Amount,
+    DateOnly EffectiveDate,
+    DateOnly? NoticeDate,
+    DateOnly? DueDate,
+    string Status,
+    string SourceSystem,
+    string? SourceDocumentId,
+    DateOnly AsOfDate,
+    DateOnly? ValuationDate,
+    string EvidenceCompleteness,
+    string ReconciliationStatus,
+    string? LastReviewedBy,
+    DateTimeOffset? LastReviewedAtUtc);
+
+/// <summary>
+/// Operator readiness projection for whether the family-office workspace can be trusted for decisions.
+/// </summary>
+public sealed record FamilyOfficeReadinessDto(
+    string Status,
+    string EvidenceCompleteness,
+    string ReconciliationStatus,
+    int OpenExceptionCount,
+    int ItemsNeedingReviewCount,
+    DateTimeOffset GeneratedAtUtc,
+    string? LastReviewedBy,
+    DateTimeOffset? LastReviewedAtUtc,
+    IReadOnlyList<string> Blockers,
+    IReadOnlyList<FamilyOfficeEvidenceLinkDto> EvidenceLinks);
+
+/// <summary>
+/// Link to a source document, packet, or operator evidence route backing a family-office value.
+/// </summary>
+public sealed record FamilyOfficeEvidenceLinkDto(
+    string EvidenceId,
+    string SourceSystem,
+    string? SourceDocumentId,
+    string Label,
+    string EvidenceType,
+    string? Route,
+    DateTimeOffset? CapturedAtUtc,
+    DateOnly? AsOfDate,
+    DateOnly? ValuationDate,
+    string? CompletenessStatus);

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -44,6 +44,11 @@ target tags instead of inventing client-local close-workflow routes.
 Run comparison endpoints consume contract-owned compare and diff payloads from
 `Meridian.Contracts.Workstation`; keep request/result schema additions in contracts and let this
 layer focus on endpoint validation, dependency resolution, and service orchestration.
+Single-family-office workstation contracts live in `Contracts/FamilyOfficeContracts.cs` with a
+matching `Serialization/FamilyOfficeJsonContext.cs` source-generated JSON context. Family-office
+financial summaries must carry source-system, source-document, as-of, valuation, evidence
+completeness, reconciliation, and review metadata so browser and WPF operators can trace values
+back to governed evidence without client-local schema forks.
 Diff responses now include strategy id/version metadata, lineage relation, compatibility level,
 engine/mode context, artifact completeness, and warnings so operators can compare strategy
 versions and execution engines without inferring risk from run names alone.

--- a/src/Meridian.Ui.Shared/Serialization/FamilyOfficeJsonContext.cs
+++ b/src/Meridian.Ui.Shared/Serialization/FamilyOfficeJsonContext.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+using Meridian.Infrastructure.Contracts;
+using Meridian.Ui.Shared.Contracts;
+
+namespace Meridian.Ui.Shared.Serialization;
+
+/// <summary>
+/// Source-generated <see cref="JsonSerializerContext"/> for family-office workstation contracts.
+/// Per ADR-014, endpoint serialization must use generated metadata for these payloads.
+/// </summary>
+[ImplementsAdr("ADR-014", "Source-generated JSON context for family-office workstation contracts")]
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    PropertyNameCaseInsensitive = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(FamilyOfficeOverviewDto))]
+[JsonSerializable(typeof(FamilyBalanceSheetDto))]
+[JsonSerializable(typeof(FamilyEntityDto))]
+[JsonSerializable(typeof(IReadOnlyList<FamilyEntityDto>))]
+[JsonSerializable(typeof(FamilyOwnershipGraphDto))]
+[JsonSerializable(typeof(FamilyOwnershipNodeDto))]
+[JsonSerializable(typeof(IReadOnlyList<FamilyOwnershipNodeDto>))]
+[JsonSerializable(typeof(FamilyOwnershipEdgeDto))]
+[JsonSerializable(typeof(IReadOnlyList<FamilyOwnershipEdgeDto>))]
+[JsonSerializable(typeof(FamilyAccountSummaryDto))]
+[JsonSerializable(typeof(IReadOnlyList<FamilyAccountSummaryDto>))]
+[JsonSerializable(typeof(FamilyAssetSummaryDto))]
+[JsonSerializable(typeof(IReadOnlyList<FamilyAssetSummaryDto>))]
+[JsonSerializable(typeof(PrivateAssetSummaryDto))]
+[JsonSerializable(typeof(IReadOnlyList<PrivateAssetSummaryDto>))]
+[JsonSerializable(typeof(CapitalCommitmentDto))]
+[JsonSerializable(typeof(IReadOnlyList<CapitalCommitmentDto>))]
+[JsonSerializable(typeof(CapitalActivityDto))]
+[JsonSerializable(typeof(IReadOnlyList<CapitalActivityDto>))]
+[JsonSerializable(typeof(FamilyOfficeReadinessDto))]
+[JsonSerializable(typeof(IReadOnlyList<string>))]
+[JsonSerializable(typeof(FamilyOfficeEvidenceLinkDto))]
+[JsonSerializable(typeof(IReadOnlyList<FamilyOfficeEvidenceLinkDto>))]
+internal sealed partial class FamilyOfficeJsonContext : JsonSerializerContext;

--- a/tests/Meridian.Tests/Ui/FamilyOfficeContractTests.cs
+++ b/tests/Meridian.Tests/Ui/FamilyOfficeContractTests.cs
@@ -1,0 +1,125 @@
+using System.Text.Json;
+using Meridian.Ui.Shared.Contracts;
+using Meridian.Ui.Shared.Serialization;
+using Xunit;
+
+namespace Meridian.Tests.Ui;
+
+public sealed class FamilyOfficeContractTests
+{
+    [Fact]
+    public void FamilyOfficeJsonContext_ShouldSerializeOverviewWithFinancialEvidenceMetadata()
+    {
+        var overview = new FamilyOfficeOverviewDto(
+            FamilyOfficeId: "sfo-001",
+            DisplayName: "Meridian Family Office",
+            BaseCurrency: "USD",
+            AsOfDate: new DateOnly(2026, 5, 29),
+            BalanceSheet: new FamilyBalanceSheetDto(
+                FamilyOfficeId: "sfo-001",
+                BaseCurrency: "USD",
+                TotalAssets: 125_000_000m,
+                TotalLiabilities: 5_000_000m,
+                NetWorth: 120_000_000m,
+                LiquidAssets: 30_000_000m,
+                MarketableSecurities: 60_000_000m,
+                PrivateAssets: 35_000_000m,
+                RealAssets: 10_000_000m,
+                CashAndEquivalents: 8_000_000m,
+                UnfundedCommitments: 12_500_000m,
+                SourceSystem: "family-ledger",
+                SourceDocumentId: "packet-2026-05",
+                AsOfDate: new DateOnly(2026, 5, 29),
+                ValuationDate: new DateOnly(2026, 5, 28),
+                EvidenceCompleteness: "Complete",
+                ReconciliationStatus: "Matched",
+                LastReviewedBy: "controller@example.com",
+                LastReviewedAtUtc: DateTimeOffset.Parse("2026-05-29T15:00:00Z")),
+            Entities:
+            [
+                new FamilyEntityDto(
+                    EntityId: "entity-trust",
+                    DisplayName: "Trust A",
+                    EntityType: "Trust",
+                    Jurisdiction: "DE",
+                    TaxResidency: "US",
+                    BaseCurrency: "USD",
+                    ParentEntityId: null,
+                    OwnershipPercent: null,
+                    IsOperatingEntity: false,
+                    EvidenceLinks: [])
+            ],
+            OwnershipGraph: new FamilyOwnershipGraphDto(
+                AsOfDate: new DateOnly(2026, 5, 29),
+                Nodes: [new FamilyOwnershipNodeDto("entity-trust", "Trust A", "Trust", "entity-trust", "DE", "USD")],
+                Edges: [],
+                EvidenceLinks: []),
+            Accounts:
+            [
+                new FamilyAccountSummaryDto(
+                    AccountId: "acct-1",
+                    EntityId: "entity-trust",
+                    DisplayName: "Main Custody",
+                    AccountType: "Custody",
+                    Custodian: "Example Custodian",
+                    ProviderAccountId: "EXT-1",
+                    Currency: "USD",
+                    CashBalance: 8_000_000m,
+                    MarketValue: 60_000_000m,
+                    AccruedIncome: 125_000m,
+                    TotalEquity: 68_125_000m,
+                    SourceSystem: "custodian-feed",
+                    SourceDocumentId: "statement-1",
+                    AsOfDate: new DateOnly(2026, 5, 29),
+                    ValuationDate: new DateOnly(2026, 5, 29),
+                    EvidenceCompleteness: "Complete",
+                    ReconciliationStatus: "Matched",
+                    LastReviewedBy: "ops@example.com",
+                    LastReviewedAtUtc: DateTimeOffset.Parse("2026-05-29T14:30:00Z"))
+            ],
+            PublicAssets: [],
+            PrivateAssets: [],
+            CapitalCommitments: [],
+            RecentCapitalActivity: [],
+            Readiness: new FamilyOfficeReadinessDto(
+                Status: "Ready",
+                EvidenceCompleteness: "Complete",
+                ReconciliationStatus: "Matched",
+                OpenExceptionCount: 0,
+                ItemsNeedingReviewCount: 0,
+                GeneratedAtUtc: DateTimeOffset.Parse("2026-05-29T15:05:00Z"),
+                LastReviewedBy: "controller@example.com",
+                LastReviewedAtUtc: DateTimeOffset.Parse("2026-05-29T15:00:00Z"),
+                Blockers: [],
+                EvidenceLinks: []),
+            EvidenceLinks:
+            [
+                new FamilyOfficeEvidenceLinkDto(
+                    EvidenceId: "evidence-1",
+                    SourceSystem: "family-ledger",
+                    SourceDocumentId: "packet-2026-05",
+                    Label: "May close packet",
+                    EvidenceType: "ClosePacket",
+                    Route: "/workstation/reporting/evidence/evidence-1",
+                    CapturedAtUtc: DateTimeOffset.Parse("2026-05-29T14:00:00Z"),
+                    AsOfDate: new DateOnly(2026, 5, 29),
+                    ValuationDate: new DateOnly(2026, 5, 28),
+                    CompletenessStatus: "Complete")
+            ]);
+
+        var json = JsonSerializer.Serialize(overview, FamilyOfficeJsonContext.Default.FamilyOfficeOverviewDto);
+        var roundTripped = JsonSerializer.Deserialize(json, FamilyOfficeJsonContext.Default.FamilyOfficeOverviewDto);
+
+        Assert.Contains("\"sourceSystem\":\"family-ledger\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"evidenceCompleteness\":\"Complete\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"reconciliationStatus\":\"Matched\"", json, StringComparison.Ordinal);
+        Assert.NotNull(roundTripped);
+        Assert.Equal("sfo-001", roundTripped!.FamilyOfficeId);
+        Assert.Equal("family-ledger", roundTripped.BalanceSheet.SourceSystem);
+        Assert.Equal("packet-2026-05", roundTripped.BalanceSheet.SourceDocumentId);
+        Assert.Equal(new DateOnly(2026, 5, 28), roundTripped.BalanceSheet.ValuationDate);
+        Assert.Equal("controller@example.com", roundTripped.BalanceSheet.LastReviewedBy);
+        Assert.Single(roundTripped.Accounts);
+        Assert.Equal("custodian-feed", roundTripped.Accounts[0].SourceSystem);
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce SFO-facing shared DTOs so browser and WPF operator surfaces can consume a single, governed family-office overview and financial-summary projection.
- Ensure every financial summary carries explicit evidence metadata (source, document id, as-of/valuation, completeness, reconciliation, review) so values are traceable to governed evidence sources.
- Keep serialization aligned with repository ADR-014 (source-generated JSON) to avoid reflection at hot paths and preserve cross-surface compatibility.

### Description
- Added `src/Meridian.Ui.Shared/Contracts/FamilyOfficeContracts.cs` containing records for `FamilyOfficeOverviewDto`, `FamilyBalanceSheetDto`, `FamilyEntityDto`, `FamilyOwnershipGraphDto`, `FamilyOwnershipNodeDto`, `FamilyOwnershipEdgeDto`, `FamilyAccountSummaryDto`, `FamilyAssetSummaryDto`, `PrivateAssetSummaryDto`, `CapitalCommitmentDto`, `CapitalActivityDto`, `FamilyOfficeReadinessDto`, and `FamilyOfficeEvidenceLinkDto` with the requested evidence metadata fields.
- Added `src/Meridian.Ui.Shared/Serialization/FamilyOfficeJsonContext.cs` implementing a source-generated `JsonSerializerContext` (camelCase, ignore-null) that covers list types and the new DTOs, and annotates the file with `ImplementsAdr("ADR-014", ...)` to match existing patterns.
- Added a focused unit test `tests/Meridian.Tests/Ui/FamilyOfficeContractTests.cs` that serializes and deserializes a `FamilyOfficeOverviewDto` via the new `FamilyOfficeJsonContext` and asserts the presence and round-trip of evidence metadata.
- Documented the new contract placement and evidence metadata expectation in `src/Meridian.Ui.Shared/README.md` and updated the generated stale-docs report via the repository doc tooling run.

### Testing
- Attempted to run the focused contract test with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~FamilyOfficeContractTests" /p:EnableWindowsTargeting=true --logger "console;verbosity=normal"`, but the `dotnet` SDK is not available in this environment so the test could not be executed.
- Ran the documentation freshness tools `python3 build/scripts/docs/mark-stale-docs.py --write --summary` and `python3 build/scripts/docs/validate-doc-hashes.py --summary`, which updated the stale-docs report but surfaced repository-wide source/README hash drift (document validation errors) that pre-exist this change.
- Verified repository hygiene with `git diff --check` which passed and committed the changes.
- Executed the local evaluation harness scoring script `python3 .codex/skills/meridian-implementation-assurance/scripts/score_eval.py --scenario A --scores '{"behavior_correctness":2,"validation_evidence":1,"performance_safety":2,"documentation_sync":2,"traceable_summary":2}' --failed-check 'dotnet test could not run because dotnet is not installed in the container.' --follow-up 'Run the targeted Meridian.Tests family-office contract test in an environment with the .NET SDK installed.'`, which produced a Skill Eval Report (total 9/10) and recommended running the targeted `dotnet test` in an environment with the .NET SDK to finish validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a196395ddb883208d7266a392fd8534)