### PR TITLE
Add FamilyOfficeReadService and workstation family-office endpoints

### DIFF
--- a/src/Meridian.Ui.Shared/Contracts/FamilyOfficeContracts.cs
+++ b/src/Meridian.Ui.Shared/Contracts/FamilyOfficeContracts.cs
@@ -22,6 +22,28 @@ public sealed record FamilyOfficeOverviewDto(
 /// <summary>
 /// Consolidated family balance sheet with evidence fields retained for operator review.
 /// </summary>
+
+/// <summary>
+/// Common endpoint state for family-office workstation reads, including empty and degraded guidance.
+/// </summary>
+public sealed record FamilyOfficeEndpointStateDto(
+    bool IsEmpty,
+    string? EmptyStateGuidance,
+    IReadOnlyList<string> Warnings,
+    DateTimeOffset GeneratedAtUtc);
+
+public sealed record FamilyOfficeBalanceSheetResponseDto(
+    FamilyBalanceSheetDto BalanceSheet,
+    FamilyOfficeEndpointStateDto State);
+
+public sealed record FamilyOfficeEntitiesResponseDto(
+    IReadOnlyList<FamilyEntityDto> Entities,
+    FamilyOfficeEndpointStateDto State);
+
+public sealed record FamilyOfficeOwnershipGraphResponseDto(
+    FamilyOwnershipGraphDto OwnershipGraph,
+    FamilyOfficeEndpointStateDto State);
+
 public sealed record FamilyBalanceSheetDto(
     string FamilyOfficeId,
     string BaseCurrency,

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.FamilyOffice.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.FamilyOffice.cs
@@ -1,0 +1,77 @@
+using Meridian.Ui.Shared.Contracts;
+using Meridian.Ui.Shared.Serialization;
+using Meridian.Ui.Shared.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Ui.Shared.Endpoints;
+
+public static partial class WorkstationEndpoints
+{
+    private static void MapFamilyOfficeEndpoints(RouteGroupBuilder group)
+    {
+        var familyOffice = group.MapGroup("/family-office")
+            .WithTags("Workstation Family Office");
+
+        familyOffice.MapGet("/overview", async (HttpContext context) =>
+        {
+            var service = context.RequestServices.GetService<FamilyOfficeReadService>();
+            if (service is null)
+            {
+                return Results.Problem("Family-office read service is not registered.", statusCode: StatusCodes.Status501NotImplemented);
+            }
+
+            var overview = await service.GetOverviewAsync(context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(overview, FamilyOfficeJsonContext.Default.FamilyOfficeOverviewDto);
+        })
+        .WithName("GetWorkstationFamilyOfficeOverview")
+        .Produces<FamilyOfficeOverviewDto>(200)
+        .Produces(501);
+
+        familyOffice.MapGet("/balance-sheet", async (HttpContext context) =>
+        {
+            var service = context.RequestServices.GetService<FamilyOfficeReadService>();
+            if (service is null)
+            {
+                return Results.Problem("Family-office read service is not registered.", statusCode: StatusCodes.Status501NotImplemented);
+            }
+
+            var balanceSheet = await service.GetBalanceSheetAsync(context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(balanceSheet, FamilyOfficeJsonContext.Default.FamilyOfficeBalanceSheetResponseDto);
+        })
+        .WithName("GetWorkstationFamilyOfficeBalanceSheet")
+        .Produces<FamilyOfficeBalanceSheetResponseDto>(200)
+        .Produces(501);
+
+        familyOffice.MapGet("/entities", async (HttpContext context) =>
+        {
+            var service = context.RequestServices.GetService<FamilyOfficeReadService>();
+            if (service is null)
+            {
+                return Results.Problem("Family-office read service is not registered.", statusCode: StatusCodes.Status501NotImplemented);
+            }
+
+            var entities = await service.GetEntitiesAsync(context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(entities, FamilyOfficeJsonContext.Default.FamilyOfficeEntitiesResponseDto);
+        })
+        .WithName("GetWorkstationFamilyOfficeEntities")
+        .Produces<FamilyOfficeEntitiesResponseDto>(200)
+        .Produces(501);
+
+        familyOffice.MapGet("/ownership-graph", async (HttpContext context) =>
+        {
+            var service = context.RequestServices.GetService<FamilyOfficeReadService>();
+            if (service is null)
+            {
+                return Results.Problem("Family-office read service is not registered.", statusCode: StatusCodes.Status501NotImplemented);
+            }
+
+            var ownershipGraph = await service.GetOwnershipGraphAsync(context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(ownershipGraph, FamilyOfficeJsonContext.Default.FamilyOfficeOwnershipGraphResponseDto);
+        })
+        .WithName("GetWorkstationFamilyOfficeOwnershipGraph")
+        .Produces<FamilyOfficeOwnershipGraphResponseDto>(200)
+        .Produces(501);
+    }
+}

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -87,6 +87,7 @@ public static partial class WorkstationEndpoints
         MapStrategyDesignerEndpoints(group, jsonOptions);
         MapStrategyEngineEndpoints(group, jsonOptions);
         MapFeatureCapabilityEndpoints(group, jsonOptions);
+        MapFamilyOfficeEndpoints(group);
 
         group.MapGet("/workflow-summary", async (
             bool? hasOperatingContext,

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -45,10 +45,13 @@ Run comparison endpoints consume contract-owned compare and diff payloads from
 `Meridian.Contracts.Workstation`; keep request/result schema additions in contracts and let this
 layer focus on endpoint validation, dependency resolution, and service orchestration.
 Single-family-office workstation contracts live in `Contracts/FamilyOfficeContracts.cs` with a
-matching `Serialization/FamilyOfficeJsonContext.cs` source-generated JSON context. Family-office
-financial summaries must carry source-system, source-document, as-of, valuation, evidence
-completeness, reconciliation, and review metadata so browser and WPF operators can trace values
-back to governed evidence without client-local schema forks.
+matching `Serialization/FamilyOfficeJsonContext.cs` source-generated JSON context. The shared
+`FamilyOfficeReadService` assembles the workstation overview from fund-structure, fund-account,
+portfolio, ledger, and reconciliation read seams and exposes `/api/workstation/family-office/*`
+endpoint reads for overview, balance sheet, entities, and ownership graph. Family-office financial
+summaries must carry source-system, source-document, as-of, valuation, evidence completeness,
+reconciliation, review metadata, empty-state guidance, and degraded-state warnings so browser and
+WPF operators can trace values back to governed evidence without client-local schema forks.
 Diff responses now include strategy id/version metadata, lineage relation, compatibility level,
 engine/mode context, artifact completeness, and warnings so operators can compare strategy
 versions and execution engines without inferring risk from run names alone.

--- a/src/Meridian.Ui.Shared/Serialization/FamilyOfficeJsonContext.cs
+++ b/src/Meridian.Ui.Shared/Serialization/FamilyOfficeJsonContext.cs
@@ -14,6 +14,10 @@ namespace Meridian.Ui.Shared.Serialization;
     PropertyNameCaseInsensitive = true,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(FamilyOfficeOverviewDto))]
+[JsonSerializable(typeof(FamilyOfficeEndpointStateDto))]
+[JsonSerializable(typeof(FamilyOfficeBalanceSheetResponseDto))]
+[JsonSerializable(typeof(FamilyOfficeEntitiesResponseDto))]
+[JsonSerializable(typeof(FamilyOfficeOwnershipGraphResponseDto))]
 [JsonSerializable(typeof(FamilyBalanceSheetDto))]
 [JsonSerializable(typeof(FamilyEntityDto))]
 [JsonSerializable(typeof(IReadOnlyList<FamilyEntityDto>))]

--- a/src/Meridian.Ui.Shared/Services/FamilyOfficeReadService.cs
+++ b/src/Meridian.Ui.Shared/Services/FamilyOfficeReadService.cs
@@ -1,0 +1,665 @@
+using Meridian.Application.FundAccounts;
+using Meridian.Application.FundStructure;
+using Meridian.Contracts.FundStructure;
+using Meridian.Contracts.Workstation;
+using Meridian.Strategies.Services;
+using Meridian.Ui.Shared.Contracts;
+
+namespace Meridian.Ui.Shared.Services;
+
+/// <summary>
+/// Assembles the cross-surface single-family-office read model from existing structure,
+/// account, portfolio, ledger, and reconciliation seams.
+/// </summary>
+public sealed class FamilyOfficeReadService
+{
+    private const string EmptyStateGuidance = "Configure a FamilyOffice client and link its entities, funds, accounts, ownership percentages, statements, valuations, and evidence before using the family-office workstation.";
+    private static readonly DateOnly FallbackAsOfDate = new(1970, 1, 1);
+
+    private readonly IFundStructureService? _fundStructureService;
+    private readonly IFundAccountService? _fundAccountService;
+    private readonly StrategyRunReadService? _strategyRunReadService;
+    private readonly TimeProvider _timeProvider;
+
+    public FamilyOfficeReadService(
+        IFundStructureService? fundStructureService,
+        IFundAccountService? fundAccountService,
+        StrategyRunReadService? strategyRunReadService = null,
+        TimeProvider? timeProvider = null)
+    {
+        _fundStructureService = fundStructureService;
+        _fundAccountService = fundAccountService;
+        _strategyRunReadService = strategyRunReadService;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public async Task<FamilyOfficeOverviewDto> GetOverviewAsync(CancellationToken ct = default)
+    {
+        var generatedAt = _timeProvider.GetUtcNow();
+        if (_fundStructureService is null)
+        {
+            return BuildEmptyOverview(generatedAt, ["Family-office structure service is not registered."]);
+        }
+
+        var graph = await _fundStructureService
+            .GetOrganizationStructureAsync(new OrganizationStructureQuery(ActiveOnly: true, AsOf: generatedAt), ct)
+            .ConfigureAwait(false);
+
+        var familyClients = graph.Clients
+            .Where(static client => client.ClientSegmentKind == ClientSegmentKind.FamilyOffice)
+            .OrderBy(static client => client.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (familyClients.Length == 0)
+        {
+            return BuildEmptyOverview(generatedAt, ["No FamilyOffice client segment is configured in the fund-structure graph."]);
+        }
+
+        var warnings = new List<string>();
+        var familyClient = familyClients[0];
+        if (familyClients.Length > 1)
+        {
+            warnings.Add("Multiple FamilyOffice clients are configured; this read service currently projects the first active family-office client.");
+        }
+
+        var asOfDate = DateOnly.FromDateTime(generatedAt.UtcDateTime);
+        var relevant = SelectRelevantGraph(graph, familyClient);
+        var entities = BuildEntities(relevant, warnings);
+        var ownershipGraph = BuildOwnershipGraph(relevant, asOfDate);
+        var evidenceLinks = BuildStructureEvidenceLinks(relevant, asOfDate);
+        var accountContexts = await BuildAccountContextsAsync(relevant.Accounts, generatedAt, ct).ConfigureAwait(false);
+        var accounts = accountContexts.Select(static context => context.Summary).ToArray();
+        var publicAssets = BuildPublicAssets(accountContexts, warnings);
+        var privateAssets = BuildPrivateAssets(relevant, asOfDate, warnings);
+        var commitments = BuildCommitments(relevant, asOfDate, warnings);
+        var balanceSheet = BuildBalanceSheet(familyClient, accountContexts, privateAssets, commitments, warnings, generatedAt, asOfDate);
+        var readiness = BuildReadiness(warnings, evidenceLinks, generatedAt, accounts, entities.Count, balanceSheet);
+
+        return new FamilyOfficeOverviewDto(
+            FamilyOfficeId: familyClient.ClientId.ToString("D"),
+            DisplayName: familyClient.Name,
+            BaseCurrency: familyClient.BaseCurrency,
+            AsOfDate: asOfDate,
+            BalanceSheet: balanceSheet,
+            Entities: entities,
+            OwnershipGraph: ownershipGraph,
+            Accounts: accounts,
+            PublicAssets: publicAssets,
+            PrivateAssets: privateAssets,
+            CapitalCommitments: commitments,
+            RecentCapitalActivity: [],
+            Readiness: readiness,
+            EvidenceLinks: evidenceLinks);
+    }
+
+    public async Task<FamilyOfficeBalanceSheetResponseDto> GetBalanceSheetAsync(CancellationToken ct = default)
+    {
+        var overview = await GetOverviewAsync(ct).ConfigureAwait(false);
+        return new FamilyOfficeBalanceSheetResponseDto(overview.BalanceSheet, BuildEndpointState(overview));
+    }
+
+    public async Task<FamilyOfficeEntitiesResponseDto> GetEntitiesAsync(CancellationToken ct = default)
+    {
+        var overview = await GetOverviewAsync(ct).ConfigureAwait(false);
+        return new FamilyOfficeEntitiesResponseDto(overview.Entities, BuildEndpointState(overview));
+    }
+
+    public async Task<FamilyOfficeOwnershipGraphResponseDto> GetOwnershipGraphAsync(CancellationToken ct = default)
+    {
+        var overview = await GetOverviewAsync(ct).ConfigureAwait(false);
+        return new FamilyOfficeOwnershipGraphResponseDto(overview.OwnershipGraph, BuildEndpointState(overview));
+    }
+
+    private static FamilyOfficeEndpointStateDto BuildEndpointState(FamilyOfficeOverviewDto overview)
+    {
+        var isEmpty = overview.Entities.Count == 0;
+        return new FamilyOfficeEndpointStateDto(
+            IsEmpty: isEmpty,
+            EmptyStateGuidance: isEmpty ? EmptyStateGuidance : null,
+            Warnings: overview.Readiness.Blockers,
+            GeneratedAtUtc: overview.Readiness.GeneratedAtUtc);
+    }
+
+    private FamilyOfficeOverviewDto BuildEmptyOverview(DateTimeOffset generatedAt, IReadOnlyList<string> warnings)
+    {
+        var asOfDate = DateOnly.FromDateTime(generatedAt.UtcDateTime);
+        var stateEvidence = new FamilyOfficeEvidenceLinkDto(
+            EvidenceId: "family-office-empty-state",
+            SourceSystem: "fund-structure",
+            SourceDocumentId: null,
+            Label: "Family-office configuration is missing",
+            EvidenceType: "configuration-guidance",
+            Route: "/settings/fund-structure",
+            CapturedAtUtc: generatedAt,
+            AsOfDate: asOfDate,
+            ValuationDate: null,
+            CompletenessStatus: "Missing");
+
+        var balanceSheet = new FamilyBalanceSheetDto(
+            FamilyOfficeId: "family-office-unconfigured",
+            BaseCurrency: "USD",
+            TotalAssets: 0m,
+            TotalLiabilities: 0m,
+            NetWorth: 0m,
+            LiquidAssets: 0m,
+            MarketableSecurities: 0m,
+            PrivateAssets: 0m,
+            RealAssets: 0m,
+            CashAndEquivalents: 0m,
+            UnfundedCommitments: 0m,
+            SourceSystem: "empty-state",
+            SourceDocumentId: null,
+            AsOfDate: asOfDate,
+            ValuationDate: null,
+            EvidenceCompleteness: "Missing",
+            ReconciliationStatus: "NotConfigured",
+            LastReviewedBy: null,
+            LastReviewedAtUtc: null);
+
+        var readiness = new FamilyOfficeReadinessDto(
+            Status: "NotConfigured",
+            EvidenceCompleteness: "Missing",
+            ReconciliationStatus: "NotConfigured",
+            OpenExceptionCount: warnings.Count,
+            ItemsNeedingReviewCount: warnings.Count,
+            GeneratedAtUtc: generatedAt,
+            LastReviewedBy: null,
+            LastReviewedAtUtc: null,
+            Blockers: [EmptyStateGuidance, .. warnings],
+            EvidenceLinks: [stateEvidence]);
+
+        return new FamilyOfficeOverviewDto(
+            FamilyOfficeId: "family-office-unconfigured",
+            DisplayName: "Family office setup required",
+            BaseCurrency: "USD",
+            AsOfDate: asOfDate,
+            BalanceSheet: balanceSheet,
+            Entities: [],
+            OwnershipGraph: new FamilyOwnershipGraphDto(asOfDate, [], [], [stateEvidence]),
+            Accounts: [],
+            PublicAssets: [],
+            PrivateAssets: [],
+            CapitalCommitments: [],
+            RecentCapitalActivity: [],
+            Readiness: readiness,
+            EvidenceLinks: [stateEvidence]);
+    }
+
+    private static RelevantFamilyGraph SelectRelevantGraph(OrganizationStructureGraphDto graph, ClientSummaryDto familyClient)
+    {
+        var clientId = familyClient.ClientId;
+        var business = graph.Businesses.FirstOrDefault(b => b.BusinessId == familyClient.BusinessId);
+        var portfolios = graph.InvestmentPortfolios.Where(p => p.ClientId == clientId || (business is not null && p.BusinessId == business.BusinessId)).ToArray();
+        var funds = graph.Funds.Where(f => business is not null && f.BusinessId == business.BusinessId).ToArray();
+        var fundIds = funds.Select(static fund => fund.FundId).ToHashSet();
+        var portfolioEntityIds = portfolios.Select(static portfolio => portfolio.EntityId).OfType<Guid>().ToHashSet();
+        var fundEntityIds = funds.SelectMany(static fund => fund.EntityIds).ToHashSet();
+        var entityIds = portfolioEntityIds.Concat(fundEntityIds).ToHashSet();
+        var accounts = graph.Accounts
+            .Where(account =>
+                (account.EntityId.HasValue && entityIds.Contains(account.EntityId.Value)) ||
+                (account.FundId.HasValue && fundIds.Contains(account.FundId.Value)) ||
+                portfolios.Any(portfolio => portfolio.AccountIds.Contains(account.AccountId)) ||
+                funds.Any(fund => fund.AccountIds.Contains(account.AccountId)))
+            .OrderBy(static account => account.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        entityIds.UnionWith(accounts.Select(static account => account.EntityId).OfType<Guid>());
+        var entities = graph.Entities.Where(entity => entityIds.Contains(entity.EntityId)).ToArray();
+        var nodeIds = new HashSet<Guid>([clientId]);
+        if (business is not null) nodeIds.Add(business.BusinessId);
+        foreach (var fund in funds) nodeIds.Add(fund.FundId);
+        foreach (var portfolio in portfolios) nodeIds.Add(portfolio.InvestmentPortfolioId);
+        foreach (var entity in entities) nodeIds.Add(entity.EntityId);
+        foreach (var account in accounts) nodeIds.Add(account.AccountId);
+
+        var links = graph.OwnershipLinks
+            .Where(link => nodeIds.Contains(link.ParentNodeId) || nodeIds.Contains(link.ChildNodeId))
+            .OrderBy(static link => link.EffectiveFrom)
+            .ThenBy(static link => link.OwnershipLinkId)
+            .ToArray();
+        var assignments = graph.Assignments.Where(assignment => nodeIds.Contains(assignment.NodeId)).ToArray();
+
+        return new RelevantFamilyGraph(familyClient, business, funds, entities, portfolios, accounts, links, assignments);
+    }
+
+    private static IReadOnlyList<FamilyEntityDto> BuildEntities(RelevantFamilyGraph graph, List<string> warnings)
+    {
+        var linksByChild = graph.OwnershipLinks
+            .GroupBy(static link => link.ChildNodeId)
+            .ToDictionary(static group => group.Key, static group => group.First());
+        var entities = new List<FamilyEntityDto>();
+
+        AddEntity(graph.Client.ClientId, graph.Client.Name, "FamilyOfficeClient", null, null, graph.Client.BaseCurrency, graph.Business?.BusinessId, null, false, graph.Client.EffectiveFrom);
+        if (graph.Business is not null)
+        {
+            AddEntity(graph.Business.BusinessId, graph.Business.Name, graph.Business.BusinessKind.ToString(), null, null, graph.Business.BaseCurrency, graph.Business.OrganizationId, null, true, graph.Business.EffectiveFrom);
+        }
+
+        foreach (var fund in graph.Funds)
+        {
+            AddEntity(fund.FundId, fund.Name, "Fund", null, null, fund.BaseCurrency, fund.BusinessId, linksByChild.GetValueOrDefault(fund.FundId)?.OwnershipPercent, true, fund.EffectiveFrom);
+        }
+
+        foreach (var entity in graph.LegalEntities)
+        {
+            AddEntity(entity.EntityId, entity.Name, entity.EntityType.ToString(), entity.Jurisdiction, null, entity.BaseCurrency, linksByChild.GetValueOrDefault(entity.EntityId)?.ParentNodeId, linksByChild.GetValueOrDefault(entity.EntityId)?.OwnershipPercent, false, entity.EffectiveFrom);
+        }
+
+        foreach (var account in graph.Accounts)
+        {
+            AddEntity(account.AccountId, account.DisplayName, $"Account:{account.AccountType}", null, null, account.BaseCurrency, account.EntityId ?? account.FundId, linksByChild.GetValueOrDefault(account.AccountId)?.OwnershipPercent, false, account.EffectiveFrom);
+        }
+
+        if (entities.Any(static entity => entity.ParentEntityId is not null && entity.OwnershipPercent is null))
+        {
+            warnings.Add("One or more entity ownership mappings are missing ownership percentages.");
+        }
+
+        return entities
+            .OrderBy(static entity => entity.EntityType, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static entity => entity.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        void AddEntity(Guid id, string name, string type, string? jurisdiction, string? taxResidency, string currency, Guid? parentId, decimal? ownership, bool operating, DateTimeOffset effectiveFrom)
+        {
+            entities.Add(new FamilyEntityDto(
+                EntityId: id.ToString("D"),
+                DisplayName: name,
+                EntityType: type,
+                Jurisdiction: jurisdiction,
+                TaxResidency: taxResidency,
+                BaseCurrency: currency,
+                ParentEntityId: parentId?.ToString("D"),
+                OwnershipPercent: ownership,
+                IsOperatingEntity: operating,
+                EvidenceLinks:
+                [
+                    new FamilyOfficeEvidenceLinkDto(
+                        EvidenceId: $"fund-structure:{id:D}",
+                        SourceSystem: "fund-structure",
+                        SourceDocumentId: null,
+                        Label: $"{type} structure record effective {effectiveFrom:yyyy-MM-dd}",
+                        EvidenceType: "structure-record",
+                        Route: "/settings/fund-structure",
+                        CapturedAtUtc: effectiveFrom,
+                        AsOfDate: DateOnly.FromDateTime(effectiveFrom.UtcDateTime),
+                        ValuationDate: null,
+                        CompletenessStatus: "Complete")
+                ]));
+        }
+    }
+
+    private async Task<IReadOnlyList<AccountContext>> BuildAccountContextsAsync(IReadOnlyList<AccountSummaryDto> accounts, DateTimeOffset generatedAt, CancellationToken ct)
+    {
+        var contexts = new List<AccountContext>(accounts.Count);
+        if (_fundAccountService is null)
+        {
+            return contexts;
+        }
+
+        foreach (var account in accounts)
+        {
+            ct.ThrowIfCancellationRequested();
+            var snapshot = await _fundAccountService.GetLatestBalanceSnapshotAsync(account.AccountId, ct).ConfigureAwait(false);
+            var reconciliationRuns = await _fundAccountService.GetReconciliationRunsAsync(account.AccountId, ct).ConfigureAwait(false);
+            var openBreaks = await _fundAccountService.GetOpenBreaksAsync(account.AccountId, ct).ConfigureAwait(false);
+            var readiness = await _fundAccountService.GetReadinessAsync(account.AccountId, ct).ConfigureAwait(false);
+            StrategyRunDetail? runDetail = null;
+            if (_strategyRunReadService is not null && !string.IsNullOrWhiteSpace(account.RunId))
+            {
+                runDetail = await _strategyRunReadService.GetRunDetailAsync(account.RunId, ct).ConfigureAwait(false);
+            }
+
+            contexts.Add(BuildAccountContext(account, snapshot, reconciliationRuns, openBreaks, readiness, runDetail, generatedAt));
+        }
+
+        return contexts;
+    }
+
+    private static AccountContext BuildAccountContext(
+        AccountSummaryDto account,
+        AccountBalanceSnapshotDto? snapshot,
+        IReadOnlyList<AccountReconciliationRunDto> reconciliationRuns,
+        IReadOnlyList<AccountReconciliationBreakDto> openBreaks,
+        AccountReadinessSnapshotDto? readiness,
+        StrategyRunDetail? runDetail,
+        DateTimeOffset generatedAt)
+    {
+        var asOfDate = snapshot?.AsOfDate ?? (runDetail?.Portfolio is not null ? DateOnly.FromDateTime(runDetail.Portfolio.AsOf.UtcDateTime) : DateOnly.FromDateTime(generatedAt.UtcDateTime));
+        var cash = snapshot?.CashBalance ?? runDetail?.Portfolio?.Cash ?? 0m;
+        var marketValue = snapshot?.SecuritiesMarketValue ?? runDetail?.Portfolio?.LongMarketValue ?? 0m;
+        var accrued = snapshot?.AccruedInterest ?? 0m;
+        var totalEquity = cash + marketValue + accrued + (snapshot?.PendingSettlement ?? 0m);
+        var reconciliationStatus = ResolveReconciliationStatus(reconciliationRuns, openBreaks);
+        var evidenceCompleteness = ResolveEvidenceCompleteness(snapshot?.ExternalReference, readiness);
+        var source = snapshot?.Source ?? (runDetail?.Portfolio is null ? "fund-account" : "portfolio-read-service");
+
+        var summary = new FamilyAccountSummaryDto(
+            AccountId: account.AccountId.ToString("D"),
+            EntityId: (account.EntityId ?? account.FundId ?? account.AccountId).ToString("D"),
+            DisplayName: account.DisplayName,
+            AccountType: account.AccountType.ToString(),
+            Custodian: account.Institution,
+            ProviderAccountId: account.CustodianDetails?.SubAccountNumber ?? account.BankDetails?.AccountNumber,
+            Currency: snapshot?.Currency ?? account.BaseCurrency,
+            CashBalance: cash,
+            MarketValue: marketValue,
+            AccruedIncome: accrued,
+            TotalEquity: totalEquity,
+            SourceSystem: source,
+            SourceDocumentId: snapshot?.ExternalReference,
+            AsOfDate: asOfDate,
+            ValuationDate: snapshot?.AsOfDate,
+            EvidenceCompleteness: evidenceCompleteness,
+            ReconciliationStatus: reconciliationStatus,
+            LastReviewedBy: null,
+            LastReviewedAtUtc: null);
+
+        return new AccountContext(account, summary, snapshot, reconciliationRuns, openBreaks, readiness, runDetail);
+    }
+
+    private static IReadOnlyList<FamilyAssetSummaryDto> BuildPublicAssets(IReadOnlyList<AccountContext> accounts, List<string> warnings)
+    {
+        var assets = new List<FamilyAssetSummaryDto>();
+        var netWorth = accounts.Sum(static account => account.Summary.TotalEquity);
+        foreach (var account in accounts)
+        {
+            var portfolio = account.RunDetail?.Portfolio;
+            if (portfolio is null)
+            {
+                if (account.Summary.MarketValue > 0m)
+                {
+                    assets.Add(new FamilyAssetSummaryDto(
+                        AssetId: $"account-securities:{account.Account.AccountId:D}",
+                        EntityId: account.Summary.EntityId,
+                        AccountId: account.Summary.AccountId,
+                        DisplayName: $"{account.Summary.DisplayName} marketable securities",
+                        AssetClass: "MarketableSecurities",
+                        Symbol: null,
+                        Currency: account.Summary.Currency,
+                        Quantity: 1m,
+                        MarketValue: account.Summary.MarketValue,
+                        CostBasis: account.Summary.MarketValue,
+                        UnrealizedGainLoss: 0m,
+                        PercentOfNetWorth: Percent(account.Summary.MarketValue, netWorth),
+                        SourceSystem: account.Summary.SourceSystem,
+                        SourceDocumentId: account.Summary.SourceDocumentId,
+                        AsOfDate: account.Summary.AsOfDate,
+                        ValuationDate: account.Summary.ValuationDate,
+                        EvidenceCompleteness: account.Summary.EvidenceCompleteness,
+                        ReconciliationStatus: account.Summary.ReconciliationStatus,
+                        LastReviewedBy: null,
+                        LastReviewedAtUtc: null));
+                }
+
+                continue;
+            }
+
+            foreach (var position in portfolio.Positions)
+            {
+                var marketValue = Math.Abs(position.Quantity) * position.AverageCostBasis + position.UnrealizedPnl;
+                assets.Add(new FamilyAssetSummaryDto(
+                    AssetId: $"position:{portfolio.RunId}:{position.Symbol}",
+                    EntityId: account.Summary.EntityId,
+                    AccountId: account.Summary.AccountId,
+                    DisplayName: position.Security?.DisplayName ?? position.Symbol,
+                    AssetClass: position.Security?.AssetClass ?? "PublicSecurity",
+                    Symbol: position.Symbol,
+                    Currency: account.Summary.Currency,
+                    Quantity: position.Quantity,
+                    MarketValue: marketValue,
+                    CostBasis: Math.Abs(position.Quantity) * position.AverageCostBasis,
+                    UnrealizedGainLoss: position.UnrealizedPnl,
+                    PercentOfNetWorth: Percent(marketValue, netWorth),
+                    SourceSystem: "portfolio-read-service",
+                    SourceDocumentId: portfolio.RunId,
+                    AsOfDate: DateOnly.FromDateTime(portfolio.AsOf.UtcDateTime),
+                    ValuationDate: DateOnly.FromDateTime(portfolio.AsOf.UtcDateTime),
+                    EvidenceCompleteness: position.Security is null ? "Partial" : "Complete",
+                    ReconciliationStatus: account.Summary.ReconciliationStatus,
+                    LastReviewedBy: null,
+                    LastReviewedAtUtc: null));
+            }
+        }
+
+        if (accounts.Any(static account => account.Summary.MarketValue > 0m) && assets.Count == 0)
+        {
+            warnings.Add("Account market values exist but no portfolio position read model is available for asset-level drilldown.");
+        }
+
+        return assets.OrderByDescending(static asset => asset.MarketValue).ToArray();
+    }
+
+    private static IReadOnlyList<PrivateAssetSummaryDto> BuildPrivateAssets(RelevantFamilyGraph graph, DateOnly asOfDate, List<string> warnings)
+    {
+        var privateAssignments = graph.Assignments
+            .Where(static assignment => assignment.AssignmentType.Equals("PrivateAssetMark", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        if (privateAssignments.Length == 0)
+        {
+            warnings.Add("No private asset marks are configured for the family-office entity graph.");
+            return [];
+        }
+
+        return privateAssignments.Select(assignment => new PrivateAssetSummaryDto(
+            PrivateAssetId: assignment.AssignmentId.ToString("D"),
+            EntityId: assignment.NodeId.ToString("D"),
+            DisplayName: assignment.AssignmentReference,
+            AssetType: "PrivateAsset",
+            Currency: graph.Client.BaseCurrency,
+            CurrentValue: 0m,
+            CommitmentAmount: null,
+            CalledCapital: null,
+            DistributedCapital: null,
+            ValuationMethod: "AssignmentReference",
+            SourceSystem: "fund-structure-assignment",
+            SourceDocumentId: assignment.AssignmentReference,
+            AsOfDate: asOfDate,
+            ValuationDate: null,
+            EvidenceCompleteness: "Partial",
+            ReconciliationStatus: "NotReconciled",
+            LastReviewedBy: null,
+            LastReviewedAtUtc: null)).ToArray();
+    }
+
+    private static IReadOnlyList<CapitalCommitmentDto> BuildCommitments(RelevantFamilyGraph graph, DateOnly asOfDate, List<string> warnings)
+    {
+        var commitmentAssignments = graph.Assignments
+            .Where(static assignment => assignment.AssignmentType.Equals("CapitalCommitment", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        if (commitmentAssignments.Length == 0)
+        {
+            warnings.Add("No unfunded commitment source is configured for the family-office entity graph.");
+            return [];
+        }
+
+        return commitmentAssignments.Select(assignment => new CapitalCommitmentDto(
+            CommitmentId: assignment.AssignmentId.ToString("D"),
+            EntityId: assignment.NodeId.ToString("D"),
+            VehicleName: assignment.AssignmentReference,
+            Strategy: "PrivateMarkets",
+            Currency: graph.Client.BaseCurrency,
+            CommitmentAmount: 0m,
+            CalledAmount: 0m,
+            UnfundedAmount: 0m,
+            DistributedAmount: 0m,
+            CurrentNav: 0m,
+            VintageYear: null,
+            SourceSystem: "fund-structure-assignment",
+            SourceDocumentId: assignment.AssignmentReference,
+            AsOfDate: asOfDate,
+            ValuationDate: null,
+            EvidenceCompleteness: "Partial",
+            ReconciliationStatus: "NotReconciled",
+            LastReviewedBy: null,
+            LastReviewedAtUtc: null)).ToArray();
+    }
+
+    private static FamilyBalanceSheetDto BuildBalanceSheet(
+        ClientSummaryDto familyClient,
+        IReadOnlyList<AccountContext> accounts,
+        IReadOnlyList<PrivateAssetSummaryDto> privateAssets,
+        IReadOnlyList<CapitalCommitmentDto> commitments,
+        List<string> warnings,
+        DateTimeOffset generatedAt,
+        DateOnly asOfDate)
+    {
+        var cash = accounts.Sum(static account => account.Summary.CashBalance);
+        var securities = accounts.Sum(static account => account.Summary.MarketValue);
+        var privateValue = privateAssets.Sum(static asset => asset.CurrentValue) + commitments.Sum(static commitment => commitment.CurrentNav);
+        var liabilities = accounts.Sum(static account => account.RunDetail?.Ledger?.LiabilityBalance ?? 0m);
+        var totalAssets = cash + securities + accounts.Sum(static account => account.Summary.AccruedIncome) + privateValue;
+        var latestAsOf = accounts.Select(static account => account.Summary.AsOfDate).DefaultIfEmpty(asOfDate).Max();
+        var staleCutoff = DateOnly.FromDateTime(generatedAt.UtcDateTime).AddDays(-2);
+        if (accounts.Any(account => account.Summary.AsOfDate < staleCutoff))
+        {
+            warnings.Add("One or more account or asset values are stale compared with the current workstation date.");
+        }
+
+        if (accounts.Any(static account => !account.Summary.ReconciliationStatus.Equals("Reconciled", StringComparison.OrdinalIgnoreCase)))
+        {
+            warnings.Add("One or more accounts are unreconciled or have open reconciliation breaks.");
+        }
+
+        if (accounts.Any(static account => !account.Summary.EvidenceCompleteness.Equals("Complete", StringComparison.OrdinalIgnoreCase)))
+        {
+            warnings.Add("One or more balances, valuations, or reconciliations are missing complete evidence.");
+        }
+
+        return new FamilyBalanceSheetDto(
+            FamilyOfficeId: familyClient.ClientId.ToString("D"),
+            BaseCurrency: familyClient.BaseCurrency,
+            TotalAssets: totalAssets,
+            TotalLiabilities: liabilities,
+            NetWorth: totalAssets - liabilities,
+            LiquidAssets: cash + securities,
+            MarketableSecurities: securities,
+            PrivateAssets: privateValue,
+            RealAssets: 0m,
+            CashAndEquivalents: cash,
+            UnfundedCommitments: commitments.Sum(static commitment => commitment.UnfundedAmount),
+            SourceSystem: "family-office-read-service",
+            SourceDocumentId: null,
+            AsOfDate: latestAsOf,
+            ValuationDate: latestAsOf == FallbackAsOfDate ? null : latestAsOf,
+            EvidenceCompleteness: accounts.All(static account => account.Summary.EvidenceCompleteness == "Complete") ? "Complete" : "Partial",
+            ReconciliationStatus: accounts.All(static account => account.Summary.ReconciliationStatus == "Reconciled") ? "Reconciled" : "NeedsReview",
+            LastReviewedBy: null,
+            LastReviewedAtUtc: null);
+    }
+
+    private static FamilyOwnershipGraphDto BuildOwnershipGraph(RelevantFamilyGraph graph, DateOnly asOfDate)
+    {
+        var nodes = new List<FamilyOwnershipNodeDto>
+        {
+            new(graph.Client.ClientId.ToString("D"), graph.Client.Name, "FamilyOfficeClient", graph.Client.ClientId.ToString("D"), null, graph.Client.BaseCurrency)
+        };
+        if (graph.Business is not null)
+        {
+            nodes.Add(new FamilyOwnershipNodeDto(graph.Business.BusinessId.ToString("D"), graph.Business.Name, graph.Business.BusinessKind.ToString(), graph.Business.BusinessId.ToString("D"), null, graph.Business.BaseCurrency));
+        }
+        nodes.AddRange(graph.Funds.Select(static fund => new FamilyOwnershipNodeDto(fund.FundId.ToString("D"), fund.Name, "Fund", fund.FundId.ToString("D"), null, fund.BaseCurrency)));
+        nodes.AddRange(graph.LegalEntities.Select(static entity => new FamilyOwnershipNodeDto(entity.EntityId.ToString("D"), entity.Name, entity.EntityType.ToString(), entity.EntityId.ToString("D"), entity.Jurisdiction, entity.BaseCurrency)));
+        nodes.AddRange(graph.Accounts.Select(static account => new FamilyOwnershipNodeDto(account.AccountId.ToString("D"), account.DisplayName, $"Account:{account.AccountType}", account.AccountId.ToString("D"), null, account.BaseCurrency)));
+
+        var edges = graph.OwnershipLinks.Select(static link => new FamilyOwnershipEdgeDto(
+            EdgeId: link.OwnershipLinkId.ToString("D"),
+            SourceNodeId: link.ParentNodeId.ToString("D"),
+            TargetNodeId: link.ChildNodeId.ToString("D"),
+            RelationshipType: link.RelationshipType.ToString(),
+            OwnershipPercent: link.OwnershipPercent,
+            EffectiveFrom: DateOnly.FromDateTime(link.EffectiveFrom.UtcDateTime),
+            EffectiveTo: link.EffectiveTo is null ? null : DateOnly.FromDateTime(link.EffectiveTo.Value.UtcDateTime),
+            SourceDocumentId: link.Notes)).ToArray();
+
+        return new FamilyOwnershipGraphDto(asOfDate, nodes.DistinctBy(static node => node.NodeId).ToArray(), edges, BuildStructureEvidenceLinks(graph, asOfDate));
+    }
+
+    private static IReadOnlyList<FamilyOfficeEvidenceLinkDto> BuildStructureEvidenceLinks(RelevantFamilyGraph graph, DateOnly asOfDate)
+        =>
+        [
+            new FamilyOfficeEvidenceLinkDto(
+                EvidenceId: $"fund-structure-family-office:{graph.Client.ClientId:D}",
+                SourceSystem: "fund-structure",
+                SourceDocumentId: null,
+                Label: "Family-office structure graph",
+                EvidenceType: "structure-graph",
+                Route: "/settings/fund-structure",
+                CapturedAtUtc: graph.Client.EffectiveFrom,
+                AsOfDate: asOfDate,
+                ValuationDate: null,
+                CompletenessStatus: graph.OwnershipLinks.All(static link => link.OwnershipPercent.HasValue) ? "Complete" : "Partial")
+        ];
+
+    private static FamilyOfficeReadinessDto BuildReadiness(
+        IReadOnlyList<string> warnings,
+        IReadOnlyList<FamilyOfficeEvidenceLinkDto> evidenceLinks,
+        DateTimeOffset generatedAt,
+        IReadOnlyList<FamilyAccountSummaryDto> accounts,
+        int entityCount,
+        FamilyBalanceSheetDto balanceSheet)
+    {
+        var distinctWarnings = warnings.Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(static warning => warning, StringComparer.OrdinalIgnoreCase).ToArray();
+        var status = entityCount == 0 ? "NotConfigured" : distinctWarnings.Length == 0 ? "Ready" : "Degraded";
+        return new FamilyOfficeReadinessDto(
+            Status: status,
+            EvidenceCompleteness: balanceSheet.EvidenceCompleteness,
+            ReconciliationStatus: balanceSheet.ReconciliationStatus,
+            OpenExceptionCount: accounts.Count(static account => account.ReconciliationStatus != "Reconciled"),
+            ItemsNeedingReviewCount: distinctWarnings.Length,
+            GeneratedAtUtc: generatedAt,
+            LastReviewedBy: null,
+            LastReviewedAtUtc: null,
+            Blockers: distinctWarnings,
+            EvidenceLinks: evidenceLinks);
+    }
+
+    private static string ResolveReconciliationStatus(IReadOnlyList<AccountReconciliationRunDto> runs, IReadOnlyList<AccountReconciliationBreakDto> breaks)
+    {
+        if (breaks.Count > 0)
+        {
+            return "OpenBreaks";
+        }
+
+        var latest = runs.OrderByDescending(static run => run.RequestedAt).FirstOrDefault();
+        if (latest is null)
+        {
+            return "NotReconciled";
+        }
+
+        return latest.TotalBreaks == 0 && latest.Status.Equals("Completed", StringComparison.OrdinalIgnoreCase)
+            ? "Reconciled"
+            : latest.Status;
+    }
+
+    private static string ResolveEvidenceCompleteness(string? sourceDocumentId, AccountReadinessSnapshotDto? readiness)
+    {
+        if (readiness is { IsReady: false })
+        {
+            return "Partial";
+        }
+
+        return string.IsNullOrWhiteSpace(sourceDocumentId) ? "Missing" : "Complete";
+    }
+
+    private static decimal Percent(decimal value, decimal total) => total == 0m ? 0m : decimal.Round(value / total * 100m, 4);
+
+    private sealed record RelevantFamilyGraph(
+        ClientSummaryDto Client,
+        BusinessSummaryDto? Business,
+        IReadOnlyList<FundSummaryDto> Funds,
+        IReadOnlyList<LegalEntitySummaryDto> LegalEntities,
+        IReadOnlyList<InvestmentPortfolioSummaryDto> Portfolios,
+        IReadOnlyList<AccountSummaryDto> Accounts,
+        IReadOnlyList<OwnershipLinkDto> OwnershipLinks,
+        IReadOnlyList<FundStructureAssignmentDto> Assignments);
+
+    private sealed record AccountContext(
+        AccountSummaryDto Account,
+        FamilyAccountSummaryDto Summary,
+        AccountBalanceSnapshotDto? Snapshot,
+        IReadOnlyList<AccountReconciliationRunDto> ReconciliationRuns,
+        IReadOnlyList<AccountReconciliationBreakDto> OpenBreaks,
+        AccountReadinessSnapshotDto? Readiness,
+        StrategyRunDetail? RunDetail);
+}

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -128,6 +128,10 @@ public static class WorkstationServiceCollectionExtensions
         });
         services.TryAddSingleton<LedgerAmountProvenanceService>();
         services.TryAddSingleton<FundOperationsWorkspaceReadService>();
+        services.TryAddSingleton(sp => new FamilyOfficeReadService(
+            sp.GetService<IFundStructureService>(),
+            sp.GetService<Meridian.Application.FundAccounts.IFundAccountService>(),
+            sp.GetService<StrategyRunReadService>()));
         services.TryAddSingleton<IOperationsStatusDerivationService, OperationsStatusDerivationService>();
         services.TryAddSingleton<IOperationsContinuityRepository>(sp =>
         {

--- a/tests/Meridian.Tests/Ui/FamilyOfficeReadServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/FamilyOfficeReadServiceTests.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using System.Net.Http.Json;
+using Meridian.Application.FundAccounts;
+using Meridian.Application.FundStructure;
+using Meridian.Contracts.FundStructure;
+using Meridian.Ui.Shared.Contracts;
+using Meridian.Ui.Shared.Services;
+
+namespace Meridian.Tests.Ui;
+
+public sealed class FamilyOfficeReadServiceTests
+{
+    [Fact]
+    public async Task GetOverviewAsync_WhenNoFamilyOfficeConfigured_ReturnsEmptyStateGuidance()
+    {
+        var fundAccounts = new InMemoryFundAccountService();
+        var fundStructure = new InMemoryFundStructureService(fundAccounts);
+        var service = new FamilyOfficeReadService(fundStructure, fundAccounts);
+
+        var overview = await service.GetOverviewAsync(CancellationToken.None);
+
+        Assert.Equal("NotConfigured", overview.Readiness.Status);
+        Assert.Empty(overview.Entities);
+        Assert.Contains("Configure a FamilyOffice client", overview.Readiness.Blockers[0]);
+        Assert.Equal("Missing", overview.BalanceSheet.EvidenceCompleteness);
+    }
+
+    [Fact]
+    public async Task GetOverviewAsync_AssemblesBalancesOwnershipAndDegradedWarnings()
+    {
+        var fundAccounts = new InMemoryFundAccountService();
+        var fundStructure = new InMemoryFundStructureService(fundAccounts);
+        var now = DateTimeOffset.Parse("2026-05-29T12:00:00Z");
+        var organizationId = Guid.NewGuid();
+        var businessId = Guid.NewGuid();
+        var clientId = Guid.NewGuid();
+        var fundId = Guid.NewGuid();
+        var entityId = Guid.NewGuid();
+        var accountId = Guid.NewGuid();
+
+        await fundStructure.CreateOrganizationAsync(new CreateOrganizationRequest(
+            organizationId, "ORG", "Meridian Family Office", "USD", now.AddYears(-1), "test"), CancellationToken.None);
+        await fundStructure.CreateBusinessAsync(new CreateBusinessRequest(
+            businessId, organizationId, BusinessKindDto.Hybrid, "SFO", "SFO Advisers", "USD", now.AddYears(-1), "test"), CancellationToken.None);
+        await fundStructure.CreateClientAsync(new CreateClientRequest(
+            clientId, businessId, "FAM", "Founders Family", "USD", now.AddYears(-1), "test", ClientSegmentKind: ClientSegmentKind.FamilyOffice), CancellationToken.None);
+        await fundStructure.CreateFundAsync(new CreateFundRequest(
+            fundId, "FND", "Founders Holdings", "USD", now.AddYears(-1), "test", BusinessId: businessId), CancellationToken.None);
+        await fundStructure.CreateLegalEntityAsync(new CreateLegalEntityRequest(
+            entityId, LegalEntityTypeDto.LimitedPartner, "TRUST", "Founders Trust", "US-DE", "USD", now.AddYears(-1), "test"), CancellationToken.None);
+        await fundStructure.LinkNodesAsync(new LinkFundStructureNodesRequest(
+            Guid.NewGuid(), clientId, fundId, OwnershipRelationshipTypeDto.Owns, now.AddYears(-1), "test", OwnershipPercent: 100m), CancellationToken.None);
+        await fundStructure.LinkNodesAsync(new LinkFundStructureNodesRequest(
+            Guid.NewGuid(), fundId, entityId, OwnershipRelationshipTypeDto.Owns, now.AddYears(-1), "test"), CancellationToken.None);
+
+        await fundAccounts.CreateAccountAsync(new CreateAccountRequest(
+            accountId,
+            AccountTypeDto.Custody,
+            "CUST-1",
+            "Main Custody",
+            "USD",
+            now.AddYears(-1),
+            "test",
+            FundId: fundId,
+            EntityId: entityId,
+            Institution: "Test Custodian"), CancellationToken.None);
+        await fundAccounts.RecordBalanceSnapshotAsync(new RecordAccountBalanceSnapshotRequest(
+            accountId,
+            new DateOnly(2026, 5, 25),
+            "USD",
+            CashBalance: 250_000m,
+            Source: "custodian",
+            SecuritiesMarketValue: 750_000m,
+            AccruedInterest: 1_250m,
+            ExternalReference: "statement-20260525"), CancellationToken.None);
+
+        var service = new FamilyOfficeReadService(fundStructure, fundAccounts, timeProvider: new FixedTimeProvider(now));
+
+        var overview = await service.GetOverviewAsync(CancellationToken.None);
+
+        Assert.Equal(clientId.ToString("D"), overview.FamilyOfficeId);
+        Assert.Contains(overview.Entities, entity => entity.EntityId == entityId.ToString("D"));
+        Assert.Contains(overview.OwnershipGraph.Edges, edge => edge.OwnershipPercent == 100m);
+        Assert.Single(overview.Accounts);
+        Assert.Equal(250_000m, overview.BalanceSheet.CashAndEquivalents);
+        Assert.Equal(750_000m, overview.BalanceSheet.MarketableSecurities);
+        Assert.Equal("Degraded", overview.Readiness.Status);
+        Assert.Contains(overview.Readiness.Blockers, warning => warning.Contains("stale", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(overview.Readiness.Blockers, warning => warning.Contains("ownership", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(overview.Readiness.Blockers, warning => warning.Contains("unreconciled", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/tests/Meridian.Tests/Ui/WorkstationFamilyOfficeEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationFamilyOfficeEndpointsTests.cs
@@ -1,0 +1,40 @@
+using System.Net;
+using System.Net.Http.Json;
+using Meridian.Ui.Shared.Contracts;
+using Meridian.Ui.Shared.Services;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Tests.Ui;
+
+public sealed partial class WorkstationEndpointsTests
+{
+    [Fact]
+    public async Task MapWorkstationEndpoints_FamilyOfficeEndpoints_ShouldReturnEmptyStateGuidance()
+    {
+        await using var app = await CreateAppAsync(services =>
+        {
+            services.AddSingleton(new FamilyOfficeReadService(
+                fundStructureService: null,
+                fundAccountService: null));
+        });
+
+        var client = app.GetTestClient();
+        var overview = await client.GetFromJsonAsync<FamilyOfficeOverviewDto>(
+            "/api/workstation/family-office/overview",
+            ServerJsonOptions,
+            CancellationToken.None);
+        var entitiesResponse = await client.GetFromJsonAsync<FamilyOfficeEntitiesResponseDto>(
+            "/api/workstation/family-office/entities",
+            ServerJsonOptions,
+            CancellationToken.None);
+
+        Assert.NotNull(overview);
+        Assert.Equal("NotConfigured", overview!.Readiness.Status);
+        Assert.Contains("Configure a FamilyOffice client", overview.Readiness.Blockers[0]);
+        Assert.NotNull(entitiesResponse);
+        Assert.True(entitiesResponse!.State.IsEmpty);
+        Assert.Equal(HttpStatusCode.OK, (await client.GetAsync("/api/workstation/family-office/balance-sheet", CancellationToken.None)).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await client.GetAsync("/api/workstation/family-office/ownership-graph", CancellationToken.None)).StatusCode);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a shared application/service-layer read surface that assembles a family-office overview (entities, ownership, accounts, balances, asset marks, commitments, reconciliation and evidence posture) for the workstation surfaces.
- Reuse existing fund-structure, fund-account, portfolio/ledger, and reconciliation read seams instead of duplicating calculations so browser and WPF clients share the same authoritative projection.
- Surface empty-state guidance and degraded-state warnings when configuration, ownership mappings, evidence, or reconciliations are missing or stale.

### Description
- Added `FamilyOfficeReadService` which queries `IFundStructureService`, `IFundAccountService`, optional `StrategyRunReadService`, and composes `FamilyOfficeOverviewDto`, `FamilyBalanceSheetDto`, entity lists, ownership graph, account summaries, public/private asset projections, commitments, readiness, and evidence links (file: `src/Meridian.Ui.Shared/Services/FamilyOfficeReadService.cs`).
- Introduced endpoint DTOs and endpoint state wrappers `FamilyOfficeEndpointStateDto`, `FamilyOfficeBalanceSheetResponseDto`, `FamilyOfficeEntitiesResponseDto`, and `FamilyOfficeOwnershipGraphResponseDto` and registered them in the source-generated JSON context (files: `src/Meridian.Ui.Shared/Contracts/FamilyOfficeContracts.cs`, `src/Meridian.Ui.Shared/Serialization/FamilyOfficeJsonContext.cs`).
- Added workstation endpoint group under `/api/workstation/family-office` with routes `GET /overview`, `GET /balance-sheet`, `GET /entities`, and `GET /ownership-graph`, and hooked the mapper into the shared `MapWorkstationEndpoints` registration (file: `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.FamilyOffice.cs` and small edit to `WorkstationEndpoints.cs`).
- Registered the read service in the shared DI graph and documented the service/endpoint behavior in the `Ui.Shared` README (file: `src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs` and README update). Tests were added exercising the service and endpoint wiring (files: `tests/Meridian.Tests/Ui/FamilyOfficeReadServiceTests.cs` and `tests/Meridian.Tests/Ui/WorkstationFamilyOfficeEndpointsTests.cs`).

### Testing
- Attempted unit/integration run with `dotnet test` for the new tests but `dotnet` is not available in the execution container so C# tests were not executed in this environment (failed: `dotnet: command not found`).
- `git diff --check` returned clean (no whitespace/merge-style issues) and staged/committed the change locally during the rollout (verification performed in the workspace).
- Documentation checks: `python3 build/scripts/docs/validate-source-readmes.py --summary` passed and `python3 build/scripts/docs/mark-stale-docs.py --write --summary` completed (it reported pre-existing stale source-doc entries but made no unintended report-file changes).
- Doc hash validation: `python3 build/scripts/docs/validate-doc-hashes.py --summary` surfaced pre-existing broad source/readme hash-drift errors in the repository (these are upstream doc-hash drift issues and not specific regressions caused by these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19660609008320bf3dfa7a6ea7b8c5)