### PR TITLE
Add implementation slices to SFO MVP design

### DIFF
--- a/docs/plans/sfo-mvp-implementation-design.md
+++ b/docs/plans/sfo-mvp-implementation-design.md
@@ -79,6 +79,15 @@ ledger activity, reconciliation status, and report-pack output.
 4. **One golden path:** prove onboarding -> imports/documents -> account/private-asset setup -> capital activity -> reconciliation -> report pack -> stakeholder access review.
 5. **Conservative readiness language:** SFO MVP status should remain planned/in-progress until the golden path has focused tests and operator acceptance evidence.
 
+## Implementation Slices
+
+| Slice | Goal | Workspaces touched | Acceptance evidence |
+| --- | --- | --- | --- |
+| 1. Shared SFO model | Define the concept contracts, identifiers, lifecycle state, and `EvidenceLink` relationships needed by all operator surfaces. | Portfolio, Accounting, Reporting, Data, Settings | Contract tests or schema fixtures show every core concept can carry evidence references and workspace ownership metadata. |
+| 2. Onboarding and ownership graph | Create one family-office fixture with family members, entities, ownership nodes/edges, and account assignments. | Accounting, Settings, Portfolio | Operator fixture proves entity setup, role assignment, ownership rollup, and account-to-entity lineage without creating a new root workspace. |
+| 3. Private assets and capital activity | Attach private-asset records, valuation evidence, capital notices, ledger impact, and reconciliation status to the fixture. | Portfolio, Accounting, Data | Import/reconciliation evidence traces each private asset and capital activity item back to source documents or provider/custodian feeds. |
+| 4. Report pack and stakeholder room | Generate a report pack from approved balance-sheet, holdings, exposure, capital-activity, and exception evidence. | Reporting, Settings, Data | Access-policy tests or acceptance notes prove only authorized stakeholders can view the appropriate report-pack sections and evidence appendix. |
+
 ## Out Of Scope For MVP
 
 - Legal advice or legal-document drafting.


### PR DESCRIPTION
### Motivation
- Provide concrete, testable implementation slices for the Single-Family-Office (SFO) MVP so work can be scoped into developer-sized increments and focused acceptance evidence. 
- Ground the SFO scope in Meridian’s evidence-backed investment-operations direction and reuse existing workspaces rather than adding a new root navigation area.

### Description
- Updated `docs/plans/sfo-mvp-implementation-design.md` to add an "Implementation Slices" section that defines four slices: Shared SFO model; Onboarding and ownership graph; Private assets and capital activity; and Report pack and stakeholder room. 
- Enumerated and retained the ten core SFO concepts (`FamilyOfficeEntity`, `FamilyMember`, `OwnershipNode`, `OwnershipEdge`, `FamilyOfficeAccount`, `PrivateAsset`, `CapitalActivity`, `FamilyReportPack`, `StakeholderAccessPolicy`, `EvidenceLink`) and mapped each to the existing `Portfolio`, `Accounting`, `Reporting`, `Data`, and `Settings` workspaces. 
- Reaffirmed explicit MVP exclusions including legal advice, tax advice, native mobile apps, full estate planning, full bill payment, and broad live-broker expansion. 
- Cross-referenced `docs/plans/current-direction-and-status.md`, `docs/plans/evidence-backed-investment-operations-plan.md`, and `docs/status/production-status.md` for alignment and claim-discipline.

### Testing
- Ran the docs-only validation `git diff --check -- docs/plans/sfo-mvp-implementation-design.md` which succeeded with no issues. 
- Verified the updated file `docs/plans/sfo-mvp-implementation-design.md` renders the new "Implementation Slices" table and preserved existing anchors and cross-references.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19b55de4c4832084e10959c3a0911c)