### PR TITLE
Validate fund structure ownership links

### DIFF
--- a/src/Meridian.Application/FundStructure/FundStructurePolicyService.cs
+++ b/src/Meridian.Application/FundStructure/FundStructurePolicyService.cs
@@ -21,6 +21,69 @@ public sealed class FundStructurePolicyService : IFundStructurePolicyService
         }
     }
 
+    public void ValidateOwnershipLink(
+        OwnershipLinkDto candidate,
+        FundStructureNodeKindDto parentKind,
+        FundStructureNodeKindDto childKind,
+        IReadOnlyCollection<OwnershipLinkDto> existingLinks,
+        IReadOnlyDictionary<Guid, FundStructureNodeKindDto> nodeKinds)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+        ArgumentNullException.ThrowIfNull(existingLinks);
+        ArgumentNullException.ThrowIfNull(nodeKinds);
+
+        if (candidate.ParentNodeId == candidate.ChildNodeId)
+        {
+            throw new InvalidOperationException("Ownership parent and child must be different nodes.");
+        }
+
+        ValidateOwnershipWindow(candidate.EffectiveFrom, candidate.EffectiveTo);
+        EnsureRelationshipIsCompatible(candidate.RelationshipType, parentKind, childKind);
+        EnsurePrimaryUniqueness(candidate, existingLinks);
+        EnsureOwnershipPercent(candidate, existingLinks);
+        EnsureNoActiveCycle(candidate, existingLinks);
+        EnsureKnownKinds(existingLinks, nodeKinds);
+    }
+
+    public void ValidateOwnershipWindow(DateTimeOffset effectiveFrom, DateTimeOffset? effectiveTo)
+    {
+        if (effectiveTo.HasValue && effectiveTo.Value < effectiveFrom)
+        {
+            throw new InvalidOperationException("Ownership EffectiveTo cannot precede EffectiveFrom.");
+        }
+    }
+
+    public void ValidateOwnershipReplacement(OwnershipLinkDto existingLink, OwnershipLinkDto replacementLink)
+    {
+        ArgumentNullException.ThrowIfNull(existingLink);
+        ArgumentNullException.ThrowIfNull(replacementLink);
+
+        ValidateOwnershipWindow(existingLink.EffectiveFrom, existingLink.EffectiveTo);
+        ValidateOwnershipWindow(replacementLink.EffectiveFrom, replacementLink.EffectiveTo);
+
+        if (existingLink.OwnershipLinkId == replacementLink.OwnershipLinkId)
+        {
+            throw new InvalidOperationException("Replacement ownership links must use a new identifier.");
+        }
+
+        if (existingLink.ParentNodeId != replacementLink.ParentNodeId
+            || existingLink.ChildNodeId != replacementLink.ChildNodeId
+            || existingLink.RelationshipType != replacementLink.RelationshipType)
+        {
+            throw new InvalidOperationException("Replacement ownership links must amend the same parent, child, and relationship type.");
+        }
+
+        if (!existingLink.EffectiveTo.HasValue)
+        {
+            throw new InvalidOperationException("The existing ownership link must be expired before replacement.");
+        }
+
+        if (existingLink.EffectiveTo.Value > replacementLink.EffectiveFrom)
+        {
+            throw new InvalidOperationException("Replacement ownership windows cannot overlap the expired link.");
+        }
+    }
+
     public void ValidateCashFlowQuery(GovernanceCashFlowQuery query)
     {
         ArgumentNullException.ThrowIfNull(query);
@@ -54,5 +117,166 @@ public sealed class FundStructurePolicyService : IFundStructurePolicyService
         {
             throw new ArgumentOutOfRangeException(nameof(query), $"BucketDays must be less than or equal to {MaxCashFlowBucketDays}.");
         }
+    }
+
+    private static void EnsureRelationshipIsCompatible(
+        OwnershipRelationshipTypeDto relationshipType,
+        FundStructureNodeKindDto parentKind,
+        FundStructureNodeKindDto childKind)
+    {
+        var compatible = relationshipType switch
+        {
+            OwnershipRelationshipTypeDto.Owns =>
+                (parentKind, childKind) is (FundStructureNodeKindDto.Organization, FundStructureNodeKindDto.Business)
+                    or (FundStructureNodeKindDto.Client, FundStructureNodeKindDto.InvestmentPortfolio)
+                    or (FundStructureNodeKindDto.Fund, FundStructureNodeKindDto.Vehicle)
+                    or (FundStructureNodeKindDto.Fund, FundStructureNodeKindDto.Entity)
+                    or (FundStructureNodeKindDto.Vehicle, FundStructureNodeKindDto.InvestmentPortfolio)
+                    or (FundStructureNodeKindDto.Entity, FundStructureNodeKindDto.Vehicle)
+                    or (FundStructureNodeKindDto.Entity, FundStructureNodeKindDto.InvestmentPortfolio)
+                    or (FundStructureNodeKindDto.Fund, FundStructureNodeKindDto.Account)
+                    or (FundStructureNodeKindDto.Vehicle, FundStructureNodeKindDto.Account)
+                    or (FundStructureNodeKindDto.Entity, FundStructureNodeKindDto.Account),
+            OwnershipRelationshipTypeDto.Advises =>
+                (parentKind, childKind) is (FundStructureNodeKindDto.Business, FundStructureNodeKindDto.Client),
+            OwnershipRelationshipTypeDto.Operates =>
+                (parentKind, childKind) is (FundStructureNodeKindDto.Business, FundStructureNodeKindDto.Fund)
+                    or (FundStructureNodeKindDto.Business, FundStructureNodeKindDto.InvestmentPortfolio)
+                    or (FundStructureNodeKindDto.Fund, FundStructureNodeKindDto.Account)
+                    or (FundStructureNodeKindDto.Sleeve, FundStructureNodeKindDto.Account)
+                    or (FundStructureNodeKindDto.Vehicle, FundStructureNodeKindDto.Account)
+                    or (FundStructureNodeKindDto.InvestmentPortfolio, FundStructureNodeKindDto.Account),
+            OwnershipRelationshipTypeDto.ClearsFor or OwnershipRelationshipTypeDto.CustodiesFor =>
+                childKind == FundStructureNodeKindDto.Account && IsAccountRelationshipParent(parentKind),
+            OwnershipRelationshipTypeDto.AllocatesTo =>
+                (parentKind, childKind) is (FundStructureNodeKindDto.Fund, FundStructureNodeKindDto.Sleeve)
+                    or (FundStructureNodeKindDto.Fund, FundStructureNodeKindDto.InvestmentPortfolio)
+                    or (FundStructureNodeKindDto.Sleeve, FundStructureNodeKindDto.InvestmentPortfolio),
+            _ => false
+        };
+
+        if (!compatible)
+        {
+            throw new InvalidOperationException(
+                $"Relationship {relationshipType} is not compatible with parent kind {parentKind} and child kind {childKind}.");
+        }
+    }
+
+    private static bool IsAccountRelationshipParent(FundStructureNodeKindDto parentKind) =>
+        parentKind is FundStructureNodeKindDto.Fund
+            or FundStructureNodeKindDto.Sleeve
+            or FundStructureNodeKindDto.Vehicle
+            or FundStructureNodeKindDto.Entity
+            or FundStructureNodeKindDto.InvestmentPortfolio;
+
+    private static void EnsurePrimaryUniqueness(
+        OwnershipLinkDto candidate,
+        IReadOnlyCollection<OwnershipLinkDto> existingLinks)
+    {
+        if (!candidate.IsPrimary)
+        {
+            return;
+        }
+
+        var overlaps = existingLinks.Any(link =>
+            link.OwnershipLinkId != candidate.OwnershipLinkId
+            && link.IsPrimary
+            && link.ChildNodeId == candidate.ChildNodeId
+            && link.RelationshipType == candidate.RelationshipType
+            && WindowsOverlap(candidate, link));
+
+        if (overlaps)
+        {
+            throw new InvalidOperationException(
+                "Only one active primary ownership link is allowed for the same child and relationship type.");
+        }
+    }
+
+    private static void EnsureOwnershipPercent(
+        OwnershipLinkDto candidate,
+        IReadOnlyCollection<OwnershipLinkDto> existingLinks)
+    {
+        if (candidate.OwnershipPercent is < 0m or > 100m)
+        {
+            throw new InvalidOperationException("Ownership percentages must be between 0 and 100.");
+        }
+
+        if (!candidate.OwnershipPercent.HasValue || !RelationshipUsesPercent(candidate.RelationshipType))
+        {
+            return;
+        }
+
+        var siblingTotal = existingLinks
+            .Where(link => link.OwnershipLinkId != candidate.OwnershipLinkId)
+            .Where(link => link.ParentNodeId == candidate.ParentNodeId)
+            .Where(link => link.RelationshipType == candidate.RelationshipType)
+            .Where(link => link.OwnershipPercent.HasValue)
+            .Where(link => WindowsOverlap(candidate, link))
+            .Sum(link => link.OwnershipPercent!.Value);
+
+        if (siblingTotal + candidate.OwnershipPercent.Value > 100m)
+        {
+            throw new InvalidOperationException(
+                "Active sibling ownership percentages cannot exceed 100 for the same parent and relationship type.");
+        }
+    }
+
+    private static void EnsureNoActiveCycle(
+        OwnershipLinkDto candidate,
+        IReadOnlyCollection<OwnershipLinkDto> existingLinks)
+    {
+        var activeLinks = existingLinks
+            .Where(link => link.OwnershipLinkId != candidate.OwnershipLinkId)
+            .Where(link => IsActiveAt(link, candidate.EffectiveFrom))
+            .ToList();
+
+        var visited = new HashSet<Guid>();
+        var stack = new Stack<Guid>();
+        stack.Push(candidate.ChildNodeId);
+
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            if (!visited.Add(current))
+            {
+                continue;
+            }
+
+            foreach (var next in activeLinks.Where(link => link.ParentNodeId == current).Select(link => link.ChildNodeId))
+            {
+                if (next == candidate.ParentNodeId)
+                {
+                    throw new InvalidOperationException("Ownership links cannot create cycles through active links.");
+                }
+
+                stack.Push(next);
+            }
+        }
+    }
+
+    private static void EnsureKnownKinds(
+        IReadOnlyCollection<OwnershipLinkDto> existingLinks,
+        IReadOnlyDictionary<Guid, FundStructureNodeKindDto> nodeKinds)
+    {
+        foreach (var link in existingLinks)
+        {
+            if (!nodeKinds.ContainsKey(link.ParentNodeId) || !nodeKinds.ContainsKey(link.ChildNodeId))
+            {
+                throw new InvalidOperationException("Ownership validation requires node kind metadata for every active link.");
+            }
+        }
+    }
+
+    private static bool RelationshipUsesPercent(OwnershipRelationshipTypeDto relationshipType) =>
+        relationshipType is OwnershipRelationshipTypeDto.Owns or OwnershipRelationshipTypeDto.AllocatesTo;
+
+    private static bool IsActiveAt(OwnershipLinkDto link, DateTimeOffset instant) =>
+        link.EffectiveFrom <= instant && (!link.EffectiveTo.HasValue || link.EffectiveTo.Value > instant);
+
+    private static bool WindowsOverlap(OwnershipLinkDto left, OwnershipLinkDto right)
+    {
+        var leftTo = left.EffectiveTo ?? DateTimeOffset.MaxValue;
+        var rightTo = right.EffectiveTo ?? DateTimeOffset.MaxValue;
+        return left.EffectiveFrom < rightTo && right.EffectiveFrom < leftTo;
     }
 }

--- a/src/Meridian.Application/FundStructure/IFundStructurePolicyService.cs
+++ b/src/Meridian.Application/FundStructure/IFundStructurePolicyService.cs
@@ -5,5 +5,14 @@ namespace Meridian.Application.FundStructure;
 public interface IFundStructurePolicyService
 {
     void EnsureSingleOperatingParent(CreateInvestmentPortfolioRequest request);
+    void ValidateOwnershipLink(
+        OwnershipLinkDto candidate,
+        FundStructureNodeKindDto parentKind,
+        FundStructureNodeKindDto childKind,
+        IReadOnlyCollection<OwnershipLinkDto> existingLinks,
+        IReadOnlyDictionary<Guid, FundStructureNodeKindDto> nodeKinds);
+
+    void ValidateOwnershipWindow(DateTimeOffset effectiveFrom, DateTimeOffset? effectiveTo);
+    void ValidateOwnershipReplacement(OwnershipLinkDto existingLink, OwnershipLinkDto replacementLink);
     void ValidateCashFlowQuery(GovernanceCashFlowQuery query);
 }

--- a/src/Meridian.Application/FundStructure/InMemoryFundStructureService.cs
+++ b/src/Meridian.Application/FundStructure/InMemoryFundStructureService.cs
@@ -542,6 +542,16 @@ public sealed class InMemoryFundStructureService : INonProductionOnlyService, IF
                     $"Ownership link {request.OwnershipLinkId} already exists.");
             }
 
+            var nodeKinds = CaptureNodeKindsLocked();
+            nodeKinds[request.ParentNodeId] = parentKind.Value;
+            nodeKinds[request.ChildNodeId] = childKind.Value;
+            _policyService.ValidateOwnershipLink(
+                link,
+                parentKind.Value,
+                childKind.Value,
+                _ownershipLinks.Values.ToList(),
+                nodeKinds);
+
             if (parentKind == FundStructureNodeKindDto.Account)
             {
                 _linkedAccountIds.Add(request.ParentNodeId);
@@ -3518,6 +3528,27 @@ public sealed class InMemoryFundStructureService : INonProductionOnlyService, IF
         {
             throw new InvalidOperationException($"Entity {entityId} was not found.");
         }
+    }
+
+    private Dictionary<Guid, FundStructureNodeKindDto> CaptureNodeKindsLocked()
+    {
+        var nodeKinds = new Dictionary<Guid, FundStructureNodeKindDto>();
+        foreach (var nodeId in _organizations.Keys) nodeKinds[nodeId] = FundStructureNodeKindDto.Organization;
+        foreach (var nodeId in _businesses.Keys) nodeKinds[nodeId] = FundStructureNodeKindDto.Business;
+        foreach (var nodeId in _clients.Keys) nodeKinds[nodeId] = FundStructureNodeKindDto.Client;
+        foreach (var nodeId in _funds.Keys) nodeKinds[nodeId] = FundStructureNodeKindDto.Fund;
+        foreach (var nodeId in _sleeves.Keys) nodeKinds[nodeId] = FundStructureNodeKindDto.Sleeve;
+        foreach (var nodeId in _vehicles.Keys) nodeKinds[nodeId] = FundStructureNodeKindDto.Vehicle;
+        foreach (var nodeId in _entities.Keys) nodeKinds[nodeId] = FundStructureNodeKindDto.Entity;
+        foreach (var nodeId in _investmentPortfolios.Keys) nodeKinds[nodeId] = FundStructureNodeKindDto.InvestmentPortfolio;
+        foreach (var nodeId in _linkedAccountIds) nodeKinds[nodeId] = FundStructureNodeKindDto.Account;
+        foreach (var link in _ownershipLinks.Values)
+        {
+            nodeKinds.TryAdd(link.ParentNodeId, FundStructureNodeKindDto.Account);
+            nodeKinds.TryAdd(link.ChildNodeId, FundStructureNodeKindDto.Account);
+        }
+
+        return nodeKinds;
     }
 
     private OwnershipLinkDto CreateAutoLinkLocked(

--- a/src/Meridian.Application/FundStructure/PostgresFundStructureService.cs
+++ b/src/Meridian.Application/FundStructure/PostgresFundStructureService.cs
@@ -387,6 +387,16 @@ public sealed class PostgresFundStructureService : IFundStructureService
                 EffectiveTo: null,
                 request.Notes);
 
+            var nodeKinds = CaptureNodeKinds(snap);
+            nodeKinds[request.ParentNodeId] = parentKind.Value;
+            nodeKinds[request.ChildNodeId] = childKind.Value;
+            _policy.ValidateOwnershipLink(
+                link,
+                parentKind.Value,
+                childKind.Value,
+                snap.OwnershipLinks.Values.ToList(),
+                nodeKinds);
+
             if (parentKind == FundStructureNodeKindDto.Account) snap.LinkedAccountIds.Add(request.ParentNodeId);
             if (childKind == FundStructureNodeKindDto.Account) snap.LinkedAccountIds.Add(request.ChildNodeId);
 
@@ -949,6 +959,27 @@ public sealed class PostgresFundStructureService : IFundStructureService
     }
 
     // ── Static utilities ──────────────────────────────────────────────────────
+
+    private static Dictionary<Guid, FundStructureNodeKindDto> CaptureNodeKinds(MutableSnapshot snap)
+    {
+        var nodeKinds = new Dictionary<Guid, FundStructureNodeKindDto>();
+        foreach (var nodeId in snap.Organizations.Keys) nodeKinds[nodeId] = FundStructureNodeKindDto.Organization;
+        foreach (var nodeId in snap.Businesses.Keys) nodeKinds[nodeId] = FundStructureNodeKindDto.Business;
+        foreach (var nodeId in snap.Clients.Keys) nodeKinds[nodeId] = FundStructureNodeKindDto.Client;
+        foreach (var nodeId in snap.Funds.Keys) nodeKinds[nodeId] = FundStructureNodeKindDto.Fund;
+        foreach (var nodeId in snap.Sleeves.Keys) nodeKinds[nodeId] = FundStructureNodeKindDto.Sleeve;
+        foreach (var nodeId in snap.Vehicles.Keys) nodeKinds[nodeId] = FundStructureNodeKindDto.Vehicle;
+        foreach (var nodeId in snap.Entities.Keys) nodeKinds[nodeId] = FundStructureNodeKindDto.Entity;
+        foreach (var nodeId in snap.InvestmentPortfolios.Keys) nodeKinds[nodeId] = FundStructureNodeKindDto.InvestmentPortfolio;
+        foreach (var nodeId in snap.LinkedAccountIds) nodeKinds[nodeId] = FundStructureNodeKindDto.Account;
+        foreach (var link in snap.OwnershipLinks.Values)
+        {
+            nodeKinds.TryAdd(link.ParentNodeId, FundStructureNodeKindDto.Account);
+            nodeKinds.TryAdd(link.ChildNodeId, FundStructureNodeKindDto.Account);
+        }
+
+        return nodeKinds;
+    }
 
     private static OwnershipLinkDto MakeAutoLink(Guid parentId, Guid childId, OwnershipRelationshipTypeDto rel, DateTimeOffset from, string? notes) =>
         new(Guid.NewGuid(), parentId, childId, rel, OwnershipPercent: null, IsPrimary: true, from, EffectiveTo: null, notes);

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -86,8 +86,11 @@ and UI presentation concerns in their owning layers.
   are governed by `SecurityAssetProfileGovernanceService`, which merges seeded starter definitions
   with storage-root persisted drafts, approvals, rollback-created versions, and audit lineage.
 - `FundStructure/` - organization, fund, portfolio, account, ledger-group, cash-flow, and ledger
-  mapping workbench orchestration. Ledger mapping resolution stays server-side and reuses
-  fund-structure assignments before falling back to account ledger references.
+  mapping workbench orchestration. Ownership-link policy validation prevents invalid setup graphs
+  by blocking self-parenting, active cycles, incompatible relationship types, overlapping primary
+  links, invalid percentage ownership, sibling percentage over-allocation, and invalid effective
+  windows before graph mutations are persisted. Ledger mapping resolution stays server-side and
+  reuses fund-structure assignments before falling back to account ledger references.
 - `FundAccounts/` - internal account balance snapshots, statement intake, account readiness, and
   provider-link history. Balance snapshots preserve optional realized and unrealized P&L values so
   shared provider-ledger reconciliation can compare broker marks with retained internal book

--- a/tests/Meridian.FundStructure.Tests/FundStructurePolicyServiceTests.cs
+++ b/tests/Meridian.FundStructure.Tests/FundStructurePolicyServiceTests.cs
@@ -7,6 +7,169 @@ namespace Meridian.FundStructure.Tests;
 public sealed class FundStructurePolicyServiceTests
 {
     [Fact]
+    public void ValidateOwnershipLink_ThrowsWhenParentAndChildAreSameNode()
+    {
+        var service = new FundStructurePolicyService();
+        var nodeId = Guid.NewGuid();
+        var link = CreateLink(nodeId, nodeId, OwnershipRelationshipTypeDto.Owns);
+
+        Assert.Throws<InvalidOperationException>(() => service.ValidateOwnershipLink(
+            link,
+            FundStructureNodeKindDto.Organization,
+            FundStructureNodeKindDto.Organization,
+            [],
+            new Dictionary<Guid, FundStructureNodeKindDto> { [nodeId] = FundStructureNodeKindDto.Organization }));
+    }
+
+    [Fact]
+    public void ValidateOwnershipLink_ThrowsWhenActiveLinksWouldCreateCycle()
+    {
+        var service = new FundStructurePolicyService();
+        var organizationId = Guid.NewGuid();
+        var businessId = Guid.NewGuid();
+        var existing = CreateLink(
+            businessId,
+            organizationId,
+            OwnershipRelationshipTypeDto.Owns,
+            effectiveFrom: new DateTimeOffset(2026, 01, 01, 0, 0, 0, TimeSpan.Zero));
+        var candidate = CreateLink(
+            organizationId,
+            businessId,
+            OwnershipRelationshipTypeDto.Owns,
+            effectiveFrom: new DateTimeOffset(2026, 01, 02, 0, 0, 0, TimeSpan.Zero));
+
+        Assert.Throws<InvalidOperationException>(() => service.ValidateOwnershipLink(
+            candidate,
+            FundStructureNodeKindDto.Organization,
+            FundStructureNodeKindDto.Business,
+            [existing],
+            new Dictionary<Guid, FundStructureNodeKindDto>
+            {
+                [organizationId] = FundStructureNodeKindDto.Organization,
+                [businessId] = FundStructureNodeKindDto.Business
+            }));
+    }
+
+    [Fact]
+    public void ValidateOwnershipLink_ThrowsWhenRelationshipTypeDoesNotMatchNodeKinds()
+    {
+        var service = new FundStructurePolicyService();
+        var organizationId = Guid.NewGuid();
+        var fundId = Guid.NewGuid();
+        var link = CreateLink(organizationId, fundId, OwnershipRelationshipTypeDto.CustodiesFor);
+
+        Assert.Throws<InvalidOperationException>(() => service.ValidateOwnershipLink(
+            link,
+            FundStructureNodeKindDto.Organization,
+            FundStructureNodeKindDto.Fund,
+            [],
+            new Dictionary<Guid, FundStructureNodeKindDto>
+            {
+                [organizationId] = FundStructureNodeKindDto.Organization,
+                [fundId] = FundStructureNodeKindDto.Fund
+            }));
+    }
+
+    [Fact]
+    public void ValidateOwnershipLink_ThrowsWhenPrimaryLinkOverlapsForSameChildAndRelationship()
+    {
+        var service = new FundStructurePolicyService();
+        var organizationId = Guid.NewGuid();
+        var otherOrganizationId = Guid.NewGuid();
+        var businessId = Guid.NewGuid();
+        var existing = CreateLink(organizationId, businessId, OwnershipRelationshipTypeDto.Owns, isPrimary: true);
+        var candidate = CreateLink(otherOrganizationId, businessId, OwnershipRelationshipTypeDto.Owns, isPrimary: true);
+
+        Assert.Throws<InvalidOperationException>(() => service.ValidateOwnershipLink(
+            candidate,
+            FundStructureNodeKindDto.Organization,
+            FundStructureNodeKindDto.Business,
+            [existing],
+            new Dictionary<Guid, FundStructureNodeKindDto>
+            {
+                [organizationId] = FundStructureNodeKindDto.Organization,
+                [otherOrganizationId] = FundStructureNodeKindDto.Organization,
+                [businessId] = FundStructureNodeKindDto.Business
+            }));
+    }
+
+    [Theory]
+    [InlineData(-0.01)]
+    [InlineData(100.01)]
+    public void ValidateOwnershipLink_ThrowsWhenOwnershipPercentIsOutOfRange(double percent)
+    {
+        var service = new FundStructurePolicyService();
+        var fundId = Guid.NewGuid();
+        var entityId = Guid.NewGuid();
+        var link = CreateLink(fundId, entityId, OwnershipRelationshipTypeDto.Owns, ownershipPercent: (decimal)percent);
+
+        Assert.Throws<InvalidOperationException>(() => service.ValidateOwnershipLink(
+            link,
+            FundStructureNodeKindDto.Fund,
+            FundStructureNodeKindDto.Entity,
+            [],
+            new Dictionary<Guid, FundStructureNodeKindDto>
+            {
+                [fundId] = FundStructureNodeKindDto.Fund,
+                [entityId] = FundStructureNodeKindDto.Entity
+            }));
+    }
+
+    [Fact]
+    public void ValidateOwnershipLink_ThrowsWhenActiveSiblingOwnershipPercentagesExceedOneHundred()
+    {
+        var service = new FundStructurePolicyService();
+        var fundId = Guid.NewGuid();
+        var firstEntityId = Guid.NewGuid();
+        var secondEntityId = Guid.NewGuid();
+        var existing = CreateLink(fundId, firstEntityId, OwnershipRelationshipTypeDto.Owns, ownershipPercent: 60m);
+        var candidate = CreateLink(fundId, secondEntityId, OwnershipRelationshipTypeDto.Owns, ownershipPercent: 50m);
+
+        Assert.Throws<InvalidOperationException>(() => service.ValidateOwnershipLink(
+            candidate,
+            FundStructureNodeKindDto.Fund,
+            FundStructureNodeKindDto.Entity,
+            [existing],
+            new Dictionary<Guid, FundStructureNodeKindDto>
+            {
+                [fundId] = FundStructureNodeKindDto.Fund,
+                [firstEntityId] = FundStructureNodeKindDto.Entity,
+                [secondEntityId] = FundStructureNodeKindDto.Entity
+            }));
+    }
+
+    [Fact]
+    public void ValidateOwnershipWindow_ThrowsWhenEffectiveToPrecedesEffectiveFrom()
+    {
+        var service = new FundStructurePolicyService();
+        var effectiveFrom = new DateTimeOffset(2026, 01, 02, 0, 0, 0, TimeSpan.Zero);
+        var effectiveTo = effectiveFrom.AddDays(-1);
+
+        Assert.Throws<InvalidOperationException>(() => service.ValidateOwnershipWindow(effectiveFrom, effectiveTo));
+    }
+
+    [Fact]
+    public void ValidateOwnershipReplacement_ThrowsWhenReplacementOverlapsExpiredWindow()
+    {
+        var service = new FundStructurePolicyService();
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+        var existing = CreateLink(
+            parentId,
+            childId,
+            OwnershipRelationshipTypeDto.Owns,
+            effectiveFrom: new DateTimeOffset(2026, 01, 01, 0, 0, 0, TimeSpan.Zero),
+            effectiveTo: new DateTimeOffset(2026, 02, 01, 0, 0, 0, TimeSpan.Zero));
+        var replacement = CreateLink(
+            parentId,
+            childId,
+            OwnershipRelationshipTypeDto.Owns,
+            effectiveFrom: new DateTimeOffset(2026, 01, 15, 0, 0, 0, TimeSpan.Zero));
+
+        Assert.Throws<InvalidOperationException>(() => service.ValidateOwnershipReplacement(existing, replacement));
+    }
+
+    [Fact]
     public void ValidateCashFlowQuery_ThrowsWhenHistoricalDaysExceedsMaximum()
     {
         var service = new FundStructurePolicyService();
@@ -55,4 +218,23 @@ public sealed class FundStructurePolicyServiceTests
             HistoricalDays: historicalDays,
             ForecastDays: forecastDays,
             BucketDays: bucketDays);
+
+    private static OwnershipLinkDto CreateLink(
+        Guid parentId,
+        Guid childId,
+        OwnershipRelationshipTypeDto relationshipType,
+        decimal? ownershipPercent = null,
+        bool isPrimary = false,
+        DateTimeOffset? effectiveFrom = null,
+        DateTimeOffset? effectiveTo = null) =>
+        new(
+            Guid.NewGuid(),
+            parentId,
+            childId,
+            relationshipType,
+            ownershipPercent,
+            isPrimary,
+            effectiveFrom ?? new DateTimeOffset(2026, 01, 01, 0, 0, 0, TimeSpan.Zero),
+            effectiveTo,
+            Notes: null);
 }

--- a/tests/Meridian.FundStructure.Tests/InMemoryFundStructureServiceTests.cs
+++ b/tests/Meridian.FundStructure.Tests/InMemoryFundStructureServiceTests.cs
@@ -92,6 +92,165 @@ public sealed class InMemoryFundStructureServiceTests
     }
 
     [Fact]
+    public async Task LinkNodesAsync_WhenParentAndChildAreSameNode_ThrowsInvalidOperation()
+    {
+        var service = CreateStructureService();
+        var now = new DateTimeOffset(2026, 01, 01, 0, 0, 0, TimeSpan.Zero);
+        var organization = await service.CreateOrganizationAsync(new CreateOrganizationRequest(
+            Guid.NewGuid(),
+            "ORG",
+            "Meridian Wealth",
+            "USD",
+            now,
+            "test"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.LinkNodesAsync(new LinkFundStructureNodesRequest(
+            Guid.NewGuid(),
+            organization.OrganizationId,
+            organization.OrganizationId,
+            OwnershipRelationshipTypeDto.Owns,
+            now,
+            "test")));
+    }
+
+    [Fact]
+    public async Task LinkNodesAsync_WhenRelationshipIsIncompatibleWithNodeKinds_ThrowsInvalidOperation()
+    {
+        var service = CreateStructureService();
+        var now = new DateTimeOffset(2026, 01, 01, 0, 0, 0, TimeSpan.Zero);
+        var organization = await service.CreateOrganizationAsync(new CreateOrganizationRequest(
+            Guid.NewGuid(),
+            "ORG",
+            "Meridian Wealth",
+            "USD",
+            now,
+            "test"));
+        var business = await service.CreateBusinessAsync(new CreateBusinessRequest(
+            Guid.NewGuid(),
+            organization.OrganizationId,
+            BusinessKindDto.FundManager,
+            "BUS",
+            "Meridian Funds",
+            "USD",
+            now,
+            "test"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.LinkNodesAsync(new LinkFundStructureNodesRequest(
+            Guid.NewGuid(),
+            organization.OrganizationId,
+            business.BusinessId,
+            OwnershipRelationshipTypeDto.CustodiesFor,
+            now,
+            "test")));
+    }
+
+    [Fact]
+    public async Task LinkNodesAsync_WhenPrimaryLinkAlreadyActiveForChildAndRelationship_ThrowsInvalidOperation()
+    {
+        var service = CreateStructureService();
+        var now = new DateTimeOffset(2026, 01, 01, 0, 0, 0, TimeSpan.Zero);
+        var firstOrganization = await service.CreateOrganizationAsync(new CreateOrganizationRequest(
+            Guid.NewGuid(),
+            "ORG-1",
+            "First Organization",
+            "USD",
+            now,
+            "test"));
+        var secondOrganization = await service.CreateOrganizationAsync(new CreateOrganizationRequest(
+            Guid.NewGuid(),
+            "ORG-2",
+            "Second Organization",
+            "USD",
+            now,
+            "test"));
+        var business = await service.CreateBusinessAsync(new CreateBusinessRequest(
+            Guid.NewGuid(),
+            firstOrganization.OrganizationId,
+            BusinessKindDto.FundManager,
+            "BUS",
+            "Meridian Funds",
+            "USD",
+            now,
+            "test"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.LinkNodesAsync(new LinkFundStructureNodesRequest(
+            Guid.NewGuid(),
+            secondOrganization.OrganizationId,
+            business.BusinessId,
+            OwnershipRelationshipTypeDto.Owns,
+            now,
+            "test",
+            IsPrimary: true)));
+    }
+
+    [Fact]
+    public async Task LinkNodesAsync_WhenSiblingOwnershipPercentagesWouldExceedOneHundred_ThrowsInvalidOperation()
+    {
+        var service = CreateStructureService();
+        var now = new DateTimeOffset(2026, 01, 01, 0, 0, 0, TimeSpan.Zero);
+        var organization = await service.CreateOrganizationAsync(new CreateOrganizationRequest(
+            Guid.NewGuid(),
+            "ORG",
+            "Meridian Wealth",
+            "USD",
+            now,
+            "test"));
+        var business = await service.CreateBusinessAsync(new CreateBusinessRequest(
+            Guid.NewGuid(),
+            organization.OrganizationId,
+            BusinessKindDto.FundManager,
+            "BUS",
+            "Meridian Funds",
+            "USD",
+            now,
+            "test"));
+        var fund = await service.CreateFundAsync(new CreateFundRequest(
+            Guid.NewGuid(),
+            business.BusinessId,
+            "FUND",
+            "Flagship Fund",
+            "USD",
+            now,
+            "test"));
+        var firstEntity = await service.CreateLegalEntityAsync(new CreateLegalEntityRequest(
+            Guid.NewGuid(),
+            LegalEntityTypeDto.LimitedPartner,
+            "LP-1",
+            "First Limited Partner",
+            "US",
+            "USD",
+            now,
+            "test"));
+        var secondEntity = await service.CreateLegalEntityAsync(new CreateLegalEntityRequest(
+            Guid.NewGuid(),
+            LegalEntityTypeDto.LimitedPartner,
+            "LP-2",
+            "Second Limited Partner",
+            "US",
+            "USD",
+            now,
+            "test"));
+
+        await service.LinkNodesAsync(new LinkFundStructureNodesRequest(
+            Guid.NewGuid(),
+            fund.FundId,
+            firstEntity.EntityId,
+            OwnershipRelationshipTypeDto.Owns,
+            now,
+            "test",
+            OwnershipPercent: 60m));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.LinkNodesAsync(new LinkFundStructureNodesRequest(
+            Guid.NewGuid(),
+            fund.FundId,
+            secondEntity.EntityId,
+            OwnershipRelationshipTypeDto.Owns,
+            now,
+            "test",
+            OwnershipPercent: 50m)));
+    }
+
+    [Fact]
     public async Task GetOrganizationStructureAsync_ReturnsAdvisorAndFundBusinessesUnderOneOrganization()
     {
         var fixture = await CreateHybridFixtureAsync();


### PR DESCRIPTION
### Motivation
- Prevent creation of invalid ownership graphs by validating ownership links at the policy level before mutations are applied.
- Enforce domain rules such as no self-parenting, no active cycles, relationship-type/kind compatibility, primary-link uniqueness, percentage bounds and sibling totals, and valid effective windows so downstream projections and ledger mapping stay correct.

### Description
- Added ownership validation APIs to `IFundStructurePolicyService`: `ValidateOwnershipLink`, `ValidateOwnershipWindow`, and `ValidateOwnershipReplacement`, and expanded the interface contract accordingly.
- Implemented `FundStructurePolicyService` checks for self-parenting, active-cycle detection, relationship-kind compatibility, single-active-primary uniqueness, ownership percent range checks and sibling-sum constraints, effective-window validation, and replacement-window overlap rules (see `src/Meridian.Application/FundStructure/FundStructurePolicyService.cs`).
- Wired the shared validators into both `InMemoryFundStructureService.LinkNodesAsync` and `PostgresFundStructureService.LinkNodesAsync` so link creation runs the same policy before applying or persisting links, and added `CaptureNodeKinds` helpers to gather node-kind metadata used by validators (see `src/Meridian.Application/FundStructure/InMemoryFundStructureService.cs` and `src/Meridian.Application/FundStructure/PostgresFundStructureService.cs`).
- Added unit tests exercising the policy (`tests/Meridian.FundStructure.Tests/FundStructurePolicyServiceTests.cs`) and service-level tests verifying `LinkNodesAsync` rejects invalid requests (`tests/Meridian.FundStructure.Tests/InMemoryFundStructureServiceTests.cs`), and updated `src/Meridian.Application/README.md` to document the ownership-graph validation behavior.

### Testing
- Ran `git diff --check` and static checks on the edited files (passed with no whitespace errors).
- Attempted to run the focused test filter with `dotnet test tests/Meridian.FundStructure.Tests/Meridian.FundStructure.Tests.csproj --filter "FullyQualifiedName~FundStructurePolicyServiceTests|FullyQualifiedName~InMemoryFundStructureServiceTests" /p:EnableWindowsTargeting=true`, but the environment does not have `dotnet` installed so tests could not be executed here.
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary`, which reported repository-wide README/source-hash drift (expected because source READMEs need refresh after module edits); this is an existing repo-wide condition and not caused solely by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19bc2e88648320bea0a051bfb89202)