### PR TITLE
Add desktop screen maturity inventory

### DIFF
--- a/docs/plans/desktop-workstation-screen-blueprint.checklist.json
+++ b/docs/plans/desktop-workstation-screen-blueprint.checklist.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "blueprintPath": "docs/plans/desktop-workstation-screen-blueprint.md",
   "status": "draft-tracking",
   "generatedBy": "scripts/dev/desktop_screen_blueprint_checklist.py",
@@ -9,6 +9,14 @@
     "implemented",
     "blocked",
     "deferred"
+  ],
+  "allowedMaturityLabels": [
+    "Ready",
+    "Active but partial",
+    "Fixture/demo-backed",
+    "UI shell only",
+    "TBI",
+    "Needs verification"
   ],
   "screens": [
     {
@@ -35,6 +43,14 @@
       ],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~SecurityMasterViewModelTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Ready",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/ViewModels/SecurityMasterViewModelTests.cs",
+          "summary": "Focused WPF tests plus status inventory support the delivered Security Master desktop workbench; readiness is not based on the XAML page alone."
+        }
       ]
     },
     {
@@ -55,6 +71,14 @@
       ],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~WorkstationPageSmokeTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Fixture/demo-backed",
+      "maturityEvidence": [
+        {
+          "kind": "wpf-view-model",
+          "path": "src/Meridian.Wpf/ViewModels/LiveDataViewerViewModel.cs",
+          "summary": "Desktop view-model implementation exists, but current inventory evidence is fixture/demo-oriented rather than a full operator acceptance claim."
+        }
       ]
     },
     {
@@ -69,6 +93,14 @@
       "workflowCoverage": [],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~WatchlistViewModelTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Active but partial",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/ViewModels/WatchlistViewModelTests.cs",
+          "summary": "Focused WPF view-model coverage exists; broader workflow acceptance is not recorded."
+        }
       ]
     },
     {
@@ -94,6 +126,14 @@
       ],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~BatchBacktestViewModelTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Active but partial",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/ViewModels/BatchBacktestViewModelTests.cs",
+          "summary": "Batch backtest WPF view-model tests cover the replay/backtest surface while unification and launch/preflight remain open."
+        }
       ]
     },
     {
@@ -120,6 +160,14 @@
       ],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~StrategyRunBrowserViewModelTests|FullyQualifiedName~ResearchWorkspaceShellPageTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Active but partial",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/ViewModels/StrategyRunBrowserViewModelTests.cs",
+          "summary": "Focused Strategy Run browser tests and shell tests support the Research screen, with deeper workflow acceptance still open."
+        }
       ]
     },
     {
@@ -132,6 +180,14 @@
       "workflowCoverage": [],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~QuantScriptViewModelTests|FullyQualifiedName~StrategyRunWorkspaceServiceTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "TBI",
+      "maturityEvidence": [
+        {
+          "kind": "status-evidence",
+          "path": "docs/status/FEATURE_INVENTORY.md",
+          "summary": "Status inventory keeps strategy-aware launch/preflight and Backtest Studio unification open; no screen-specific WPF implementation evidence is listed."
+        }
       ]
     },
     {
@@ -153,6 +209,14 @@
       ],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~TradingWorkspaceShellViewModelTests|FullyQualifiedName~TradingWorkspaceShellPageTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Active but partial",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/ViewModels/TradingWorkspaceShellViewModelTests.cs",
+          "summary": "Trading shell view-model coverage supports the paper cockpit baseline, but live/broader broker validation remains open."
+        }
       ]
     },
     {
@@ -174,6 +238,14 @@
       ],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~TradingWorkspaceShellViewModelTests|FullyQualifiedName~PositionBlotterViewModelTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Needs verification",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/ViewModels/TradingWorkspaceShellViewModelTests.cs",
+          "summary": "Evidence is shared with the Trading shell and position blotter rather than a live-trading-specific acceptance proof."
+        }
       ]
     },
     {
@@ -189,6 +261,14 @@
       "workflowCoverage": [],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~AccountPortfolioViewModelTests|FullyQualifiedName~AggregatePortfolioViewModelTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Active but partial",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/ViewModels/AccountPortfolioViewModelTests.cs",
+          "summary": "Focused portfolio view-model coverage exists while broader paper/live history continuity remains open."
+        }
       ]
     },
     {
@@ -209,6 +289,14 @@
       ],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~PositionBlotterViewModelTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Active but partial",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/ViewModels/PositionBlotterViewModelTests.cs",
+          "summary": "Position blotter tests support exposure review and action-readiness behavior; broader acceptance remains partial."
+        }
       ]
     },
     {
@@ -229,6 +317,14 @@
       ],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~RunMatViewModelTests|FullyQualifiedName~TradingWorkspaceShellPageTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Active but partial",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/ViewModels/RunMatViewModelTests.cs",
+          "summary": "Focused RunMat risk view-model tests cover current desktop risk behavior; this is not a complete enterprise risk module claim."
+        }
       ]
     },
     {
@@ -250,6 +346,14 @@
       ],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~FundLedgerViewModelTests|FullyQualifiedName~FundReconciliationWorkbenchServiceTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Active but partial",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/Services/FundReconciliationWorkbenchServiceTests.cs",
+          "summary": "Focused reconciliation workbench service tests back the screen while non-run/external-statement workflows remain incomplete."
+        }
       ]
     },
     {
@@ -272,6 +376,14 @@
       ],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~AnalysisExportViewModelTests|FullyQualifiedName~DataExportViewModelTests|FullyQualifiedName~ExportPresetsViewModelTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Active but partial",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/ViewModels/AnalysisExportViewModelTests.cs",
+          "summary": "Export/reporting view-model tests support current report-pack/export surfaces while expanded report templates remain open."
+        }
       ]
     },
     {
@@ -298,6 +410,14 @@
       ],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~BackfillViewModelTests|FullyQualifiedName~DataQualityViewModelCharacterizationTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Active but partial",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/ViewModels/BackfillViewModelTests.cs",
+          "summary": "Backfill and data-quality WPF tests support the data-repair surface while deeper cross-workspace acceptance remains open."
+        }
       ]
     },
     {
@@ -319,6 +439,14 @@
       ],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~SystemHealthViewModelTests|FullyQualifiedName~SystemHealthPageSmokeTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Active but partial",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/ViewModels/SystemHealthViewModelTests.cs",
+          "summary": "System-health focused tests support diagnostics behavior while full operational workflow acceptance is partial."
+        }
       ]
     },
     {
@@ -333,6 +461,14 @@
       "workflowCoverage": [],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~WorkflowLibraryViewModelTests|FullyQualifiedName~WorkstationWorkflowSummaryServiceTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "UI shell only",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/ViewModels/WorkflowLibraryViewModelTests.cs",
+          "summary": "Workflow library view-model coverage supports shell/list composition, but no full automation execution acceptance is listed."
+        }
       ]
     },
     {
@@ -348,6 +484,14 @@
       "workflowCoverage": [],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~ActivityLogViewModelTests|FullyQualifiedName~MessagingHubViewModelTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Active but partial",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/ViewModels/ActivityLogViewModelTests.cs",
+          "summary": "Activity/messaging view-model tests support audit/activity display while broader governed evidence workflows remain incomplete."
+        }
       ]
     },
     {
@@ -362,6 +506,14 @@
       "workflowCoverage": [],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~NotificationCenterViewModelTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Active but partial",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/ViewModels/NotificationCenterViewModelTests.cs",
+          "summary": "Notification Center tests cover retained history/filter recovery, but broader alert workflow acceptance remains partial."
+        }
       ]
     },
     {
@@ -383,6 +535,14 @@
       ],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~PositionBlotterViewModelTests|FullyQualifiedName~TradingWorkspaceShellViewModelTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Needs verification",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/ViewModels/PositionBlotterViewModelTests.cs",
+          "summary": "Current evidence is position-blotter/trading-shell coverage, not a dedicated order-management acceptance proof."
+        }
       ]
     },
     {
@@ -397,6 +557,14 @@
       "workflowCoverage": [],
       "validationCommands": [
         "dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter \"FullyQualifiedName~OrderBookViewModelTests\" /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true --logger \"console;verbosity=normal\""
+      ],
+      "maturity": "Active but partial",
+      "maturityEvidence": [
+        {
+          "kind": "focused-test",
+          "path": "tests/Meridian.Wpf.Tests/ViewModels/OrderBookViewModelTests.cs",
+          "summary": "Order book view-model tests support market-depth behavior while broader trading acceptance is still partial."
+        }
       ]
     }
   ]

--- a/docs/plans/desktop-workstation-screen-blueprint.md
+++ b/docs/plans/desktop-workstation-screen-blueprint.md
@@ -19,9 +19,17 @@ python ./scripts/dev/desktop_screen_blueprint_checklist.py --summary
 ```
 
 Each checklist row has a stable `desktop-screen-*` ID, root workspace, implementation status,
-source evidence paths, workflow coverage, and the narrow validation command to run when that screen
-changes. Desktop workflow steps can reference those IDs with `blueprintChecklistIds` so screenshot
-and manual automation stay traceable back to the blueprint.
+maturity label, source evidence paths, workflow coverage, and the narrow validation command to run
+when that screen changes. Desktop workflow steps can reference those IDs with
+`blueprintChecklistIds` so screenshot and manual automation stay traceable back to the blueprint.
+
+Maturity labels use a controlled vocabulary: `Ready`, `Active but partial`,
+`Fixture/demo-backed`, `UI shell only`, `TBI`, and `Needs verification`. Every maturity label must
+name evidence from at least one permitted source: WPF view-model/service implementation under
+`src/Meridian.Wpf/`, shared endpoint/read-model contracts under `src/Meridian.Ui.Services/` or
+`src/Meridian.Ui.Shared/`, focused tests under `tests/`, acceptance evidence under `docs/status/`
+or `artifacts/`, or screenshots under `docs/screenshots/desktop/`. Do not treat the existence of a
+XAML page alone as maturity evidence.
 
 The design target is an institutional workstation:
 

--- a/scripts/dev/desktop_screen_blueprint_checklist.py
+++ b/scripts/dev/desktop_screen_blueprint_checklist.py
@@ -17,6 +17,14 @@ DEFAULT_CHECKLIST_PATH = REPO_ROOT / "docs" / "plans" / "desktop-workstation-scr
 DEFAULT_WORKFLOWS_PATH = REPO_ROOT / "scripts" / "dev" / "desktop-workflows.json"
 VALID_STATUSES = {"planned", "partial", "implemented", "blocked", "deferred"}
 VALID_ROOT_WORKSPACES = {"Trading", "Portfolio", "Accounting", "Reporting", "Strategy", "Data", "Settings"}
+VALID_MATURITY_LABELS = {
+    "Ready",
+    "Active but partial",
+    "Fixture/demo-backed",
+    "UI shell only",
+    "TBI",
+    "Needs verification",
+}
 ID_PATTERN = re.compile(r"^desktop-screen-[a-z0-9]+(?:-[a-z0-9]+)*$")
 
 
@@ -28,6 +36,21 @@ def _load_json(path: Path) -> dict[str, Any]:
 
 def _normalize_path(value: str) -> str:
     return value.replace("\\", "/").strip()
+
+
+def _is_allowed_maturity_evidence_path(path_text: str) -> bool:
+    if path_text.startswith("src/Meridian.Wpf/"):
+        return any(segment in path_text for segment in ("/ViewModels/", "/Services/", "/Shell/ViewModels/"))
+    return path_text.startswith(
+        (
+            "src/Meridian.Ui.Services/",
+            "src/Meridian.Ui.Shared/",
+            "tests/",
+            "docs/status/",
+            "artifacts/",
+            "docs/screenshots/desktop/",
+        )
+    )
 
 
 def _workflow_step_index(workflows: dict[str, Any]) -> tuple[dict[tuple[str, str, str], dict[str, Any]], set[str]]:
@@ -69,6 +92,13 @@ def validate_checklist(checklist_path: Path, workflows_path: Path) -> tuple[list
         errors.append("Checklist must contain a non-empty screens array.")
         screens = []
 
+    allowed_maturity_labels = checklist.get("allowedMaturityLabels", [])
+    if set(allowed_maturity_labels) != VALID_MATURITY_LABELS:
+        errors.append(
+            "Checklist allowedMaturityLabels must match the controlled maturity vocabulary: "
+            f"{', '.join(sorted(VALID_MATURITY_LABELS))}."
+        )
+
     workflow_index, workflow_blueprint_ids = _workflow_step_index(workflows)
     ids: set[str] = set()
     titles: set[str] = set()
@@ -79,6 +109,7 @@ def validate_checklist(checklist_path: Path, workflows_path: Path) -> tuple[list
         screen_id = str(screen.get("id", "")).strip()
         title = str(screen.get("title", "")).strip()
         status = str(screen.get("status", "")).strip()
+        maturity = str(screen.get("maturity", "")).strip()
         root_workspace = str(screen.get("rootWorkspace", "")).strip()
         heading = str(screen.get("blueprintHeading", "")).strip()
 
@@ -98,6 +129,9 @@ def validate_checklist(checklist_path: Path, workflows_path: Path) -> tuple[list
 
         if status not in VALID_STATUSES:
             errors.append(f"{screen_id or prefix} has invalid status '{status}'.")
+
+        if maturity not in VALID_MATURITY_LABELS:
+            errors.append(f"{screen_id or prefix} has invalid maturity '{maturity}'.")
 
         if root_workspace not in VALID_ROOT_WORKSPACES:
             errors.append(f"{screen_id or prefix} has invalid rootWorkspace '{root_workspace}'.")
@@ -122,6 +156,31 @@ def validate_checklist(checklist_path: Path, workflows_path: Path) -> tuple[list
                 continue
             if not (REPO_ROOT / path_text).exists():
                 errors.append(f"{screen_id or prefix} implementation path does not exist: {path_text}")
+
+        maturity_evidence = screen.get("maturityEvidence", [])
+        if not isinstance(maturity_evidence, list) or not maturity_evidence:
+            errors.append(f"{screen_id or prefix} must list at least one maturityEvidence item.")
+            maturity_evidence = []
+
+        for evidence_index, evidence in enumerate(maturity_evidence, start=1):
+            evidence_prefix = f"{screen_id or prefix} maturityEvidence[{evidence_index}]"
+            evidence_path = _normalize_path(str(evidence.get("path", "")))
+            evidence_kind = str(evidence.get("kind", "")).strip()
+            evidence_summary = str(evidence.get("summary", "")).strip()
+
+            if not evidence_kind:
+                errors.append(f"{evidence_prefix} is missing kind.")
+            if not evidence_summary:
+                errors.append(f"{evidence_prefix} is missing summary.")
+            if not evidence_path:
+                errors.append(f"{evidence_prefix} is missing path.")
+                continue
+            if not _is_allowed_maturity_evidence_path(evidence_path):
+                errors.append(
+                    f"{evidence_prefix} path is not an allowed maturity evidence source: {evidence_path}"
+                )
+            if not (REPO_ROOT / evidence_path).exists():
+                errors.append(f"{evidence_prefix} path does not exist: {evidence_path}")
 
         workflow_coverage = screen.get("workflowCoverage", [])
         if not isinstance(workflow_coverage, list):
@@ -157,6 +216,7 @@ def validate_checklist(checklist_path: Path, workflows_path: Path) -> tuple[list
         errors.append(f"Checklist is missing workflowCoverage for workflow-referenced id: {missing_id}")
 
     status_counts = Counter(str(screen.get("status", "")).strip() for screen in screens)
+    maturity_counts = Counter(str(screen.get("maturity", "")).strip() for screen in screens)
     workspace_counts = Counter(str(screen.get("rootWorkspace", "")).strip() for screen in screens)
     coverage_count = sum(1 for screen in screens if screen.get("workflowCoverage"))
 
@@ -166,6 +226,7 @@ def validate_checklist(checklist_path: Path, workflows_path: Path) -> tuple[list
         "screenCount": len(screens),
         "workflowCoveredScreenCount": coverage_count,
         "statusCounts": dict(sorted(status_counts.items())),
+        "maturityCounts": dict(sorted(maturity_counts.items())),
         "workspaceCounts": dict(sorted(workspace_counts.items())),
     }
 
@@ -178,6 +239,9 @@ def _print_summary(summary: dict[str, Any]) -> None:
     print("Status counts:")
     for status, count in summary["statusCounts"].items():
         print(f"  {status}: {count}")
+    print("Maturity counts:")
+    for maturity, count in summary["maturityCounts"].items():
+        print(f"  {maturity}: {count}")
     print("Workspace counts:")
     for workspace, count in summary["workspaceCounts"].items():
         print(f"  {workspace}: {count}")


### PR DESCRIPTION
### Motivation
- Make the desktop screen blueprint explicitly evidence-backed by adding a maturity column and a controlled vocabulary so readiness claims are traceable to code/tests/docs/screenshots rather than inferred from XAML alone.
- Prevent misleading acceptance claims by requiring each maturity label to point at one of the approved evidence sources (WPF view-models/services, shared UI endpoints/contracts, focused tests, status/acceptance docs or captured screenshots).

### Description
- Added a controlled maturity vocabulary and per-screen `maturity` + `maturityEvidence` entries to `docs/plans/desktop-workstation-screen-blueprint.checklist.json` and populated every screen with an appropriate label and an evidence pointer.
- Updated `docs/plans/desktop-workstation-screen-blueprint.md` to document the maturity column, the allowed labels (`Ready`, `Active but partial`, `Fixture/demo-backed`, `UI shell only`, `TBI`, `Needs verification`) and the permitted evidence sources and the rule that XAML existence is not sufficient evidence.
- Extended the checklist validator `scripts/dev/desktop_screen_blueprint_checklist.py` to enforce the controlled vocabulary, require and validate `maturityEvidence` items, allow only approved evidence path prefixes, and include maturity counts in the summary output.
- Kept existing workflowCoverage, implementationPaths, and validation commands; added an `allowedMaturityLabels` section to the checklist so the validator can confirm the checklist is using the canonical vocabulary.

### Testing
- Ran `python ./scripts/dev/desktop_screen_blueprint_checklist.py --summary` and observed the checklist summary output (completed successfully).
- Ran `python -m py_compile scripts/dev/desktop_screen_blueprint_checklist.py` to ensure the validator script is syntactically valid (succeeded).
- Ran `git diff --check` on the modified files to ensure no whitespace/format problems (no check failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19bc9c8474832085d0bbf23465b69d)