### PR TITLE
Add operator ownership review panel

### DIFF
--- a/src/Meridian.Contracts/FundStructure/OwnershipReviewDtos.cs
+++ b/src/Meridian.Contracts/FundStructure/OwnershipReviewDtos.cs
@@ -1,0 +1,52 @@
+using System.Text.Json.Serialization;
+
+namespace Meridian.Contracts.FundStructure;
+
+[JsonConverter(typeof(JsonStringEnumConverter<OwnershipReviewValidationStateDto>))]
+public enum OwnershipReviewValidationStateDto
+{
+    Valid,
+    Warning,
+    Blocking
+}
+
+public sealed record OwnershipReviewEffectiveWindowDto(
+    DateTimeOffset EffectiveFrom,
+    DateTimeOffset? EffectiveTo,
+    bool IsActiveAsOf,
+    string DisplayLabel);
+
+public sealed record OwnershipLifecycleCommandDto(
+    string Label,
+    string Endpoint,
+    bool IsEnabled,
+    string DisabledReason);
+
+public sealed record OwnershipReviewLinkDto(
+    Guid OwnershipLinkId,
+    string NodeDisplayLabel,
+    string ParentLabel,
+    string ChildLabel,
+    string RelationshipLabel,
+    decimal? Percent,
+    bool IsPrimary,
+    OwnershipReviewEffectiveWindowDto EffectiveWindow,
+    OwnershipReviewValidationStateDto ValidationState,
+    IReadOnlyList<string> BlockingMessages,
+    IReadOnlyList<string> SuggestedRemediationActions,
+    IReadOnlyList<OwnershipLifecycleCommandDto> LifecycleCommands);
+
+public sealed record OwnershipReviewSummaryDto(
+    int TotalLinkCount,
+    int ActiveLinkCount,
+    int InvalidLinkCount,
+    decimal ExplicitOwnershipPercentTotal,
+    string RollupSummary,
+    IReadOnlyList<string> BlockingMessages);
+
+public sealed record OwnershipReviewModelDto(
+    DateTimeOffset AsOf,
+    IReadOnlyList<OwnershipReviewLinkDto> Links,
+    OwnershipReviewSummaryDto Summary,
+    string EmptyStateTitle,
+    string EmptyStateDetail);

--- a/src/Meridian.Contracts/README.md
+++ b/src/Meridian.Contracts/README.md
@@ -30,6 +30,8 @@ or provider implementations.
 
 ## Important workflows
 
+Ownership review contracts in `FundStructure/OwnershipReviewDtos.cs` define the shared setup-time ownership read model, validation state, lifecycle command affordances, effective windows, blockers, and remediation actions used by WPF and browser surfaces.
+
 Treat additive and breaking changes as cross-module compatibility work. Operations Continuity
 workflow DTOs publish the shared broker intake, Security Master, ledger posting, reconciliation,
 approval, close, and audit vocabulary consumed by both browser and WPF workstation clients. Keep

--- a/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
@@ -348,6 +348,50 @@ public static class FundStructureEndpoints
         .WithName("GetLegacyFundStructureGraph")
         .Produces<FundStructureGraphDto>(StatusCodes.Status200OK);
 
+        group.MapGet("/ownership-review", async (HttpContext context) =>
+        {
+            var service = ResolveService(context);
+            if (service is null)
+                return ServiceUnavailable();
+
+            var reviewService = context.RequestServices.GetService<IOwnershipReviewReadService>()
+                ?? new OwnershipReviewReadService();
+            var q = context.Request.Query;
+            var asOf = ParseDateTimeOffset(q["asOf"]);
+            var query = new FundStructureQuery(
+                FundId: ParseGuid(q["fundId"]),
+                NodeId: ParseGuid(q["nodeId"]),
+                NodeKind: ParseNodeKind(q["nodeKind"]),
+                ActiveOnly: ParseActiveOnly(q["activeOnly"]),
+                AsOf: asOf);
+
+            var graph = await service.GetFundStructureGraphAsync(query, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(reviewService.Project(graph, asOf), jsonOptions);
+        })
+        .WithName("GetOwnershipReview")
+        .Produces<OwnershipReviewModelDto>(StatusCodes.Status200OK);
+
+        group.MapPost("/links/{ownershipLinkId:guid}/edit", (Guid ownershipLinkId) =>
+            Results.Problem(
+                $"Ownership link {ownershipLinkId} cannot be edited until backend lifecycle methods are enabled.",
+                statusCode: StatusCodes.Status501NotImplemented))
+        .WithName("EditOwnershipLink")
+        .Produces(StatusCodes.Status501NotImplemented);
+
+        group.MapPost("/links/{ownershipLinkId:guid}/expire", (Guid ownershipLinkId) =>
+            Results.Problem(
+                $"Ownership link {ownershipLinkId} cannot be expired until backend lifecycle methods are enabled.",
+                statusCode: StatusCodes.Status501NotImplemented))
+        .WithName("ExpireOwnershipLink")
+        .Produces(StatusCodes.Status501NotImplemented);
+
+        group.MapPost("/links/{ownershipLinkId:guid}/replace", (Guid ownershipLinkId) =>
+            Results.Problem(
+                $"Ownership link {ownershipLinkId} cannot be replaced until backend lifecycle methods are enabled.",
+                statusCode: StatusCodes.Status501NotImplemented))
+        .WithName("ReplaceOwnershipLink")
+        .Produces(StatusCodes.Status501NotImplemented);
+
         group.MapGet("/businesses/{businessId:guid}/advisory-view", async (Guid businessId, HttpContext context) =>
         {
             var service = ResolveService(context);

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -29,6 +29,8 @@ compatibility across `src/Meridian.Ui.Services`, `src/Meridian.Ui/dashboard`, an
 
 ## Important workflows
 
+The shared `OwnershipReviewReadService` projects `FundStructureGraphDto` into the operator ownership review model and backs `/api/fund-structure/ownership-review`, keeping setup ownership validation out of UI-specific code.
+
 Preserve cross-surface compatibility when evolving shared read models. Keep ledger/reconciliation
 source-of-truth services authoritative. Workstation endpoint registration is split by domain through
 `WorkstationEndpoints.*.cs` partial files. Keep the root `WorkstationEndpoints.cs` file as the

--- a/src/Meridian.Ui.Shared/Services/OwnershipReviewReadService.cs
+++ b/src/Meridian.Ui.Shared/Services/OwnershipReviewReadService.cs
@@ -1,0 +1,167 @@
+using Meridian.Contracts.FundStructure;
+
+namespace Meridian.Ui.Shared.Services;
+
+public interface IOwnershipReviewReadService
+{
+    OwnershipReviewModelDto Project(FundStructureGraphDto graph, DateTimeOffset? asOf = null);
+}
+
+public sealed class OwnershipReviewReadService : IOwnershipReviewReadService
+{
+    private const string EmptyTitle = "Ownership setup incomplete";
+    private const string EmptyDetail = "Create ownership links before completing setup so operators can see who owns, advises, operates, clears, custodies, or allocates each node.";
+
+    public OwnershipReviewModelDto Project(FundStructureGraphDto graph, DateTimeOffset? asOf = null)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+
+        var effectiveAsOf = asOf ?? DateTimeOffset.UtcNow;
+        var nodes = graph.Nodes.ToDictionary(node => node.NodeId);
+        var links = graph.OwnershipLinks
+            .OrderBy(link => ResolveNodeLabel(nodes, link.ParentNodeId))
+            .ThenBy(link => ResolveNodeLabel(nodes, link.ChildNodeId))
+            .ThenBy(link => link.RelationshipType.ToString(), StringComparer.Ordinal)
+            .ThenBy(link => link.OwnershipLinkId)
+            .Select(link => ProjectLink(link, nodes, effectiveAsOf))
+            .ToArray();
+
+        var invalidLinks = links.Where(link => link.ValidationState == OwnershipReviewValidationStateDto.Blocking).ToArray();
+        var activeLinks = links.Where(link => link.EffectiveWindow.IsActiveAsOf).ToArray();
+        var percentTotal = activeLinks.Sum(link => link.Percent ?? 0m);
+        var blockers = invalidLinks.SelectMany(link => link.BlockingMessages).Distinct(StringComparer.Ordinal).ToArray();
+        var rollupSummary = links.Length == 0
+            ? "No ownership links have been configured."
+            : $"{activeLinks.Length} active of {links.Length} ownership links; {invalidLinks.Length} blocking; {percentTotal:0.##}% explicit active ownership.";
+
+        return new OwnershipReviewModelDto(
+            effectiveAsOf,
+            links,
+            new OwnershipReviewSummaryDto(
+                links.Length,
+                activeLinks.Length,
+                invalidLinks.Length,
+                percentTotal,
+                rollupSummary,
+                blockers),
+            EmptyTitle,
+            EmptyDetail);
+    }
+
+    private static OwnershipReviewLinkDto ProjectLink(
+        OwnershipLinkDto link,
+        IReadOnlyDictionary<Guid, FundStructureNodeDto> nodes,
+        DateTimeOffset asOf)
+    {
+        var parentLabel = ResolveNodeLabel(nodes, link.ParentNodeId);
+        var childLabel = ResolveNodeLabel(nodes, link.ChildNodeId);
+        var relationshipLabel = FormatRelationship(link.RelationshipType);
+        var isActive = link.EffectiveFrom <= asOf && (link.EffectiveTo is null || link.EffectiveTo >= asOf);
+        var blockers = BuildBlockingMessages(link, nodes).ToArray();
+        var remediation = BuildRemediationActions(link, nodes, blockers, isActive).ToArray();
+        var validation = blockers.Length > 0
+            ? OwnershipReviewValidationStateDto.Blocking
+            : isActive
+                ? OwnershipReviewValidationStateDto.Valid
+                : OwnershipReviewValidationStateDto.Warning;
+
+        return new OwnershipReviewLinkDto(
+            link.OwnershipLinkId,
+            $"{parentLabel} {relationshipLabel} {childLabel}",
+            parentLabel,
+            childLabel,
+            relationshipLabel,
+            link.OwnershipPercent,
+            link.IsPrimary,
+            new OwnershipReviewEffectiveWindowDto(
+                link.EffectiveFrom,
+                link.EffectiveTo,
+                isActive,
+                FormatEffectiveWindow(link.EffectiveFrom, link.EffectiveTo, isActive)),
+            validation,
+            blockers,
+            remediation,
+            BuildLifecycleCommands(link.OwnershipLinkId));
+    }
+
+    private static IEnumerable<string> BuildBlockingMessages(
+        OwnershipLinkDto link,
+        IReadOnlyDictionary<Guid, FundStructureNodeDto> nodes)
+    {
+        if (!nodes.ContainsKey(link.ParentNodeId))
+            yield return "Parent node is missing from the fund-structure graph.";
+
+        if (!nodes.ContainsKey(link.ChildNodeId))
+            yield return "Child node is missing from the fund-structure graph.";
+
+        if (link.ParentNodeId == link.ChildNodeId)
+            yield return "Parent and child cannot be the same node.";
+
+        if (link.OwnershipPercent is < 0m or > 100m)
+            yield return "Ownership percent must be between 0 and 100.";
+
+        if (link.EffectiveTo is not null && link.EffectiveTo < link.EffectiveFrom)
+            yield return "Effective end must be on or after the effective start.";
+    }
+
+    private static IEnumerable<string> BuildRemediationActions(
+        OwnershipLinkDto link,
+        IReadOnlyDictionary<Guid, FundStructureNodeDto> nodes,
+        IReadOnlyCollection<string> blockers,
+        bool isActive)
+    {
+        if (!nodes.ContainsKey(link.ParentNodeId))
+            yield return "Select an existing parent node or recreate the missing parent before setup completion.";
+
+        if (!nodes.ContainsKey(link.ChildNodeId))
+            yield return "Select an existing child node or recreate the missing child before setup completion.";
+
+        if (link.ParentNodeId == link.ChildNodeId)
+            yield return "Replace this link with distinct parent and child nodes.";
+
+        if (link.OwnershipPercent is < 0m or > 100m)
+            yield return "Edit the percent to a value from 0 through 100, or leave it blank when the relationship is non-economic.";
+
+        if (link.EffectiveTo is not null && link.EffectiveTo < link.EffectiveFrom)
+            yield return "Expire the link at a date after the start date, or replace it with a corrected effective window.";
+
+        if (blockers.Count == 0 && !isActive)
+            yield return "Review whether this historical or future-dated link should be replaced by an active ownership link.";
+
+        if (blockers.Count == 0 && isActive)
+            yield return "No remediation required.";
+    }
+
+    private static IReadOnlyList<OwnershipLifecycleCommandDto> BuildLifecycleCommands(Guid ownershipLinkId)
+    {
+        var encodedId = Uri.EscapeDataString(ownershipLinkId.ToString());
+        var disabledReason = "Backend ownership lifecycle methods are not enabled for this environment yet.";
+        return
+        [
+            new OwnershipLifecycleCommandDto("Edit", $"/api/fund-structure/links/{encodedId}/edit", false, disabledReason),
+            new OwnershipLifecycleCommandDto("Expire", $"/api/fund-structure/links/{encodedId}/expire", false, disabledReason),
+            new OwnershipLifecycleCommandDto("Replace", $"/api/fund-structure/links/{encodedId}/replace", false, disabledReason)
+        ];
+    }
+
+    private static string ResolveNodeLabel(IReadOnlyDictionary<Guid, FundStructureNodeDto> nodes, Guid nodeId)
+        => nodes.TryGetValue(nodeId, out var node)
+            ? $"{node.Name} ({node.Kind})"
+            : $"Missing node {nodeId:N}";
+
+    private static string FormatRelationship(OwnershipRelationshipTypeDto relationship)
+        => relationship switch
+        {
+            OwnershipRelationshipTypeDto.ClearsFor => "clears for",
+            OwnershipRelationshipTypeDto.CustodiesFor => "custodies for",
+            OwnershipRelationshipTypeDto.AllocatesTo => "allocates to",
+            _ => relationship.ToString().ToLowerInvariant()
+        };
+
+    private static string FormatEffectiveWindow(DateTimeOffset effectiveFrom, DateTimeOffset? effectiveTo, bool isActive)
+    {
+        var end = effectiveTo?.ToString("yyyy-MM-dd") ?? "open-ended";
+        var status = isActive ? "active" : "inactive";
+        return $"{effectiveFrom:yyyy-MM-dd} to {end} ({status})";
+    }
+}

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -67,6 +67,7 @@ public static class WorkstationServiceCollectionExtensions
         services.TryAddSingleton<ImmutableAuditLogService>();
         services.TryAddSingleton<AccessReviewService>();
         services.TryAddSingleton<IFundAccountTraversalQueryService, FundAccountTraversalQueryService>();
+        services.TryAddSingleton<IOwnershipReviewReadService, OwnershipReviewReadService>();
 
         services.TryAddSingleton<IStrategyRepository, StrategyRunStore>();
         services.TryAddSingleton<PromotionRecordStoreOptions>(sp =>

--- a/src/Meridian.Ui/dashboard/README.md
+++ b/src/Meridian.Ui/dashboard/README.md
@@ -55,6 +55,8 @@ Portfolio run evidence, Trading recent fills, Data backfill queue rows, and Secu
 
 ## Important workflows
 
+The Settings lane includes the operator ownership review panel fed by `/api/fund-structure/ownership-review`, with active/as-of rollup summary, invalid-link warnings, selected-link inspection, and disabled edit/expire/replace affordances until backend lifecycle support is enabled.
+
 This is the active operator UI lane; keep shared contract parity with the WPF desktop. Security
 Master Governance detail uses the workstation trust snapshot's `scheduleBook` and
 `openLotReadModel` projections for cash-flow schedules, factor provenance, and open-lot exposure

--- a/src/Meridian.Ui/dashboard/src/app.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.test.tsx
@@ -65,6 +65,7 @@ function mockWorkstationData(overrides: Partial<WorkstationDataSnapshot>) {
     ledgerMappingWorkbench: null,
     operationsApprovalPolicyMatrix: null,
     operationsCloseCalendar: null,
+    ownershipReview: null,
     brokeragePortfolio: null,
     workflowLibrary: null,
     workflowPresets: null,

--- a/src/Meridian.Ui/dashboard/src/app.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.tsx
@@ -102,6 +102,7 @@ function AppShell() {
     ledgerMappingWorkbench,
     operationsApprovalPolicyMatrix,
     operationsCloseCalendar,
+    ownershipReview,
     brokeragePortfolio,
     workflowLibrary,
     workflowPresets,
@@ -402,6 +403,7 @@ function AppShell() {
                       ledgerMappingWorkbench={ledgerMappingWorkbench}
                       operationsApprovalPolicyMatrix={operationsApprovalPolicyMatrix}
                       operationsCloseCalendar={operationsCloseCalendar}
+                      ownershipReview={ownershipReview}
                       onFeatureCapabilityToggle={updateFeatureCapability}
                       onRefresh={refresh}
                       onProviderRoutingRefresh={refreshProviderRouting}

--- a/src/Meridian.Ui/dashboard/src/hooks/use-workstation-data.ts
+++ b/src/Meridian.Ui/dashboard/src/hooks/use-workstation-data.ts
@@ -6,6 +6,7 @@ import {
   getGovernanceWorkspace,
   getAlpacaConnectionStatus,
   getLedgerMappingWorkbench,
+  getOwnershipReview,
   getOperationsApprovalPolicyMatrix,
   getOperationsCloseCalendar,
   getProviderConnections,
@@ -37,6 +38,7 @@ import type {
   LedgerMappingWorkbench,
   OperationsApprovalPolicyMatrix,
   OperationsCloseCalendar,
+  OwnershipReviewModel,
   PortfolioWorkspaceResponse,
   ProviderConnectionRow,
   ProviderRoutingBinding,
@@ -76,6 +78,7 @@ interface WorkstationDataState {
   ledgerMappingWorkbench: LedgerMappingWorkbench | null;
   operationsApprovalPolicyMatrix: OperationsApprovalPolicyMatrix | null;
   operationsCloseCalendar: OperationsCloseCalendar | null;
+  ownershipReview: OwnershipReviewModel | null;
   brokeragePortfolio: BrokerageHouseholdPortfolio | null;
   workflowLibrary: WorkflowLibrary | null;
   workflowPresets: WorkflowPresetLibrary | null;
@@ -111,6 +114,7 @@ const initialState: WorkstationDataState = {
   ledgerMappingWorkbench: null,
   operationsApprovalPolicyMatrix: null,
   operationsCloseCalendar: null,
+  ownershipReview: null,
   brokeragePortfolio: null,
   workflowLibrary: null,
   workflowPresets: null,
@@ -215,6 +219,7 @@ export function useWorkstationData() {
       ledgerMappingWorkbench,
       operationsApprovalPolicyMatrix,
       operationsCloseCalendar,
+      ownershipReview,
       brokeragePortfolio,
       workflowLibrary,
       workflowPresets,
@@ -238,6 +243,7 @@ export function useWorkstationData() {
       getLedgerMappingWorkbench(requestOptions),
       getOperationsApprovalPolicyMatrix(requestOptions),
       getOperationsCloseCalendar({}, requestOptions),
+      getOwnershipReview(requestOptions),
       getBrokerageHouseholdPortfolio("alpaca", requestOptions),
       getWorkflowLibrary(requestOptions),
       getWorkflowPresets(requestOptions),
@@ -297,6 +303,7 @@ export function useWorkstationData() {
       ledgerMappingWorkbench: readWorkspace(["settings"], ledgerMappingWorkbench),
       operationsApprovalPolicyMatrix: readWorkspace(["settings"], operationsApprovalPolicyMatrix),
       operationsCloseCalendar: readWorkspace(["settings"], operationsCloseCalendar),
+      ownershipReview: readWorkspace(["settings"], ownershipReview),
       brokeragePortfolio: readWorkspace(["portfolio"], brokeragePortfolio),
       workflowLibrary: readWorkflow(workflowLibrary),
       workflowPresets: readWorkflow(workflowPresets),

--- a/src/Meridian.Ui/dashboard/src/lib/api.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api.ts
@@ -125,6 +125,7 @@ import type {
   LedgerMappingAssignmentRequest,
   LedgerMappingAssignmentResult,
   LedgerMappingWorkbench,
+  OwnershipReviewModel,
   OperationsApprovalPolicyMatrix,
   OperationsApprovalPolicyRuleUpsertRequest,
   OperationsApprovalPolicyRuleUpsertResult,
@@ -559,6 +560,14 @@ export function rollbackSecurityAssetProfile(
 
 export function getLedgerMappingWorkbench(options: ApiRequestOptions = {}) {
   return getJson<LedgerMappingWorkbench>(FUND_STRUCTURE_API_ENDPOINTS.ledgerMappingWorkbench, options);
+}
+
+export function getOwnershipReview(options: ApiRequestOptions & { asOf?: string } = {}) {
+  const { asOf, ...requestOptions } = options;
+  const endpoint = asOf
+    ? `${FUND_STRUCTURE_API_ENDPOINTS.ownershipReview}?asOf=${encodeURIComponent(asOf)}`
+    : FUND_STRUCTURE_API_ENDPOINTS.ownershipReview;
+  return getJson<OwnershipReviewModel>(endpoint, requestOptions);
 }
 
 export function assignLedgerMapping(request: LedgerMappingAssignmentRequest, options: ApiRequestOptions = {}) {

--- a/src/Meridian.Ui/dashboard/src/lib/workstation-endpoints.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/workstation-endpoints.ts
@@ -35,6 +35,10 @@ export const AUTH_API_ENDPOINTS = {
 export const FUND_STRUCTURE_API_ENDPOINTS = {
   ledgerMappingWorkbench: "/api/fund-structure/ledger-mapping-view",
   ledgerMappingAssignments: "/api/fund-structure/ledger-mapping-assignments",
+  ownershipReview: "/api/fund-structure/ownership-review",
+  ownershipLinkEdit: "/api/fund-structure/links/{ownershipLinkId}/edit",
+  ownershipLinkExpire: "/api/fund-structure/links/{ownershipLinkId}/expire",
+  ownershipLinkReplace: "/api/fund-structure/links/{ownershipLinkId}/replace",
   transactionLabPreview: "/api/fund-structure/accounting/transaction-lab/preview"
 } as const;
 

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.test.tsx
@@ -9,6 +9,7 @@ import type {
   LedgerMappingWorkbench,
   OperationsApprovalPolicyMatrix,
   OperationsCloseCalendar,
+  OwnershipReviewModel,
   PortfolioWorkspaceResponse,
   ProviderConnectionRow,
   ProviderRoutingBinding,
@@ -394,6 +395,60 @@ const securityAssetProfiles: SecurityAssetProfileDefinition[] = [
   }
 ];
 
+const ownershipReview: OwnershipReviewModel = {
+  asOf: "2026-05-29T00:00:00Z",
+  emptyStateTitle: "Ownership setup incomplete",
+  emptyStateDetail: "Create ownership links before completing setup.",
+  summary: {
+    totalLinkCount: 1,
+    activeLinkCount: 1,
+    invalidLinkCount: 1,
+    explicitOwnershipPercentTotal: 120,
+    rollupSummary: "1 active of 1 ownership links; 1 blocking; 120% explicit active ownership.",
+    blockingMessages: ["Ownership percent must be between 0 and 100."]
+  },
+  links: [
+    {
+      ownershipLinkId: "00000000-0000-0000-0000-000000000001",
+      nodeDisplayLabel: "Alpha Fund owns Core Sleeve",
+      parentLabel: "Alpha Fund (Fund)",
+      childLabel: "Core Sleeve (Sleeve)",
+      relationshipLabel: "owns",
+      percent: 120,
+      isPrimary: true,
+      effectiveWindow: {
+        effectiveFrom: "2026-01-01T00:00:00Z",
+        effectiveTo: null,
+        isActiveAsOf: true,
+        displayLabel: "2026-01-01 to open-ended (active)"
+      },
+      validationState: "Blocking",
+      blockingMessages: ["Ownership percent must be between 0 and 100."],
+      suggestedRemediationActions: ["Edit the percent to a value from 0 through 100."],
+      lifecycleCommands: [
+        {
+          label: "Edit",
+          endpoint: "/api/fund-structure/links/00000000-0000-0000-0000-000000000001/edit",
+          isEnabled: false,
+          disabledReason: "Backend ownership lifecycle methods are not enabled for this environment yet."
+        },
+        {
+          label: "Expire",
+          endpoint: "/api/fund-structure/links/00000000-0000-0000-0000-000000000001/expire",
+          isEnabled: false,
+          disabledReason: "Backend ownership lifecycle methods are not enabled for this environment yet."
+        },
+        {
+          label: "Replace",
+          endpoint: "/api/fund-structure/links/00000000-0000-0000-0000-000000000001/replace",
+          isEnabled: false,
+          disabledReason: "Backend ownership lifecycle methods are not enabled for this environment yet."
+        }
+      ]
+    }
+  ]
+};
+
 describe("SettingsScreen", () => {
   beforeEach(() => {
     apiMocks.approveSecurityAssetProfile.mockReset();
@@ -433,6 +488,31 @@ describe("SettingsScreen", () => {
     expect(within(eventRow).getByText("Provider health")).toBeInTheDocument();
     expect(within(eventDetail).getByText("Brokerage sync delayed.")).toBeInTheDocument();
     expect(within(eventDetail).getByText("Provider health / evt-1")).toBeInTheDocument();
+  });
+
+
+  it("renders ownership review warnings and disabled lifecycle commands", () => {
+    renderWithRouter(<SettingsScreen session={session} overview={overview} ownershipReview={ownershipReview} />);
+
+    expect(screen.getByRole("table", { name: "Ownership graph table" })).toHaveTextContent("Alpha Fund owns Core Sleeve");
+    expect(screen.getByText("1 active of 1 ownership links; 1 blocking; 120% explicit active ownership.")).toBeInTheDocument();
+    expect(screen.getByText("Ownership percent must be between 0 and 100.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Expire" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Replace" })).toBeDisabled();
+  });
+
+  it("renders ownership empty state before setup completion", () => {
+    renderWithRouter(
+      <SettingsScreen
+        session={session}
+        overview={overview}
+        ownershipReview={{ ...ownershipReview, links: [], summary: { ...ownershipReview.summary, totalLinkCount: 0, activeLinkCount: 0, invalidLinkCount: 0, explicitOwnershipPercentTotal: 0, rollupSummary: "No ownership links have been configured." } }}
+      />
+    );
+
+    expect(screen.getByText("Ownership setup incomplete")).toBeInTheDocument();
+    expect(screen.getByText("Create ownership links before completing setup.")).toBeInTheDocument();
   });
 
   it("renders profile authentication posture with authority handoffs", () => {

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx
@@ -34,6 +34,7 @@ import type {
   OperationsApprovalPolicyMatrix,
   OperationsApprovalPolicyMatrixRow,
   OperationsCloseCalendar,
+  OwnershipReviewModel,
   OperationsCloseCalendarItem,
   RolePermissionCatalog,
   SecurityAssetProfileDefinition,
@@ -67,6 +68,7 @@ interface SettingsScreenProps {
   ledgerMappingWorkbench?: LedgerMappingWorkbench | null;
   operationsApprovalPolicyMatrix?: OperationsApprovalPolicyMatrix | null;
   operationsCloseCalendar?: OperationsCloseCalendar | null;
+  ownershipReview?: OwnershipReviewModel | null;
   providerRoutingRefreshing?: boolean;
   onFeatureCapabilityToggle?: (capabilityKey: string, isEnabled: boolean) => Promise<void> | void;
   onRefresh?: () => Promise<void> | void;
@@ -330,6 +332,7 @@ export function SettingsScreen({
   ledgerMappingWorkbench = null,
   operationsApprovalPolicyMatrix = null,
   operationsCloseCalendar = null,
+  ownershipReview = null,
   providerRoutingRefreshing = false,
   onFeatureCapabilityToggle,
   onRefresh,
@@ -368,6 +371,14 @@ export function SettingsScreen({
     canClear: vm.alpacaConnectionPanel.canClear
   });
   const recentEventsVm = useSettingsRecentEventsSelectionViewModel(vm.recentEventsSection);
+  const [selectedOwnershipLinkId, setSelectedOwnershipLinkId] = useState<string | null>(null);
+  const [ownershipActiveOnly, setOwnershipActiveOnly] = useState(false);
+  const [ownershipAsOfDate, setOwnershipAsOfDate] = useState(() => ownershipReview?.asOf.slice(0, 10) ?? "");
+  const filteredOwnershipLinks = (ownershipReview?.links ?? []).filter((link) => !ownershipActiveOnly || link.effectiveWindow.isActiveAsOf);
+  const selectedOwnershipLink = filteredOwnershipLinks.find((link) => link.ownershipLinkId === selectedOwnershipLinkId)
+    ?? filteredOwnershipLinks.find((link) => link.validationState === "Blocking")
+    ?? filteredOwnershipLinks[0]
+    ?? null;
   const [providerSearch, setProviderSearch] = useState("");
   const [providerCapabilityFilter, setProviderCapabilityFilter] = useState<"all" | "brokerage" | "data">("all");
   const [providerHealthFilter, setProviderHealthFilter] = useState<"all" | "healthy" | "warning" | "blocked">("all");
@@ -1670,6 +1681,112 @@ export function SettingsScreen({
           </CardContent>
         </Card>
       </section>
+
+      <Card id="operator-ownership-review" className="panel-surface scroll-mt-6 border border-border/70">
+        <CardHeader>
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <div className="eyebrow-label">Setup ownership</div>
+              <CardTitle className="mt-2 flex items-center gap-2 text-base">
+                <GitBranch className="h-4 w-4 text-primary" aria-hidden="true" />
+                Operator ownership review
+              </CardTitle>
+              <CardDescription className="mt-2">
+                Ownership state from /api/fund-structure/ownership-review must be explicit before setup completion.
+              </CardDescription>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <SettingsChip label="Active" value={ownershipReview ? String(ownershipReview.summary.activeLinkCount) : "—"} />
+              <SettingsChip label="Invalid" value={ownershipReview ? String(ownershipReview.summary.invalidLinkCount) : "—"} />
+              <SettingsChip label="Rollup" value={ownershipReview ? `${ownershipReview.summary.explicitOwnershipPercentTotal.toFixed(2)}%` : "—"} />
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3 rounded-xl border border-border/70 bg-muted/20 p-3 text-sm text-muted-foreground md:grid-cols-[1fr_auto_auto] md:items-end">
+            <div>{ownershipReview?.summary.rollupSummary ?? "Ownership review is loading or unavailable."}</div>
+            <label className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-foreground">
+              <input type="checkbox" checked={ownershipActiveOnly} onChange={(event) => setOwnershipActiveOnly(event.target.checked)} />
+              Active as of
+            </label>
+            <label className="grid gap-1 text-xs font-semibold uppercase tracking-wide text-foreground">
+              As-of date
+              <Input type="date" value={ownershipAsOfDate || ownershipReview?.asOf.slice(0, 10) || ""} onChange={(event) => setOwnershipAsOfDate(event.target.value)} className="h-8 min-w-40" />
+            </label>
+          </div>
+          {!ownershipReview || filteredOwnershipLinks.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-warning/50 bg-warning/10 p-4">
+              <div className="font-semibold text-foreground">{ownershipReview?.emptyStateTitle ?? "Ownership setup incomplete"}</div>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {ownershipReview?.emptyStateDetail ?? "Create ownership links before completing setup."}
+              </p>
+            </div>
+          ) : (
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1.6fr)_minmax(280px,0.9fr)]">
+              <div className="overflow-hidden rounded-xl border border-border/70">
+                <table className="min-w-full divide-y divide-border/70 text-sm" aria-label="Ownership graph table">
+                  <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+                    <tr>
+                      <th className="px-3 py-2 text-left">Link</th>
+                      <th className="px-3 py-2 text-left">Window</th>
+                      <th className="px-3 py-2 text-right">Percent</th>
+                      <th className="px-3 py-2 text-left">Validation</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border/70">
+                    {filteredOwnershipLinks.map((link) => (
+                      <tr key={link.ownershipLinkId} className={cn("cursor-pointer", selectedOwnershipLink?.ownershipLinkId === link.ownershipLinkId && "bg-primary/10")} onClick={() => setSelectedOwnershipLinkId(link.ownershipLinkId)}>
+                        <td className="px-3 py-2">
+                          <button type="button" className="text-left font-medium text-foreground" onClick={() => setSelectedOwnershipLinkId(link.ownershipLinkId)}>
+                            {link.nodeDisplayLabel}
+                          </button>
+                          <div className="text-xs text-muted-foreground">{link.isPrimary ? "Primary" : "Secondary"}</div>
+                        </td>
+                        <td className="px-3 py-2 text-muted-foreground">{link.effectiveWindow.displayLabel}</td>
+                        <td className="px-3 py-2 text-right">{link.percent == null ? "—" : `${link.percent.toFixed(2)}%`}</td>
+                        <td className="px-3 py-2">
+                          <Badge variant={link.validationState === "Blocking" ? "danger" : link.validationState === "Warning" ? "outline" : "success"}>
+                            {link.validationState}
+                          </Badge>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <div className="rounded-xl border border-border/70 p-4" aria-label="Selected ownership link inspector">
+                <div className="font-semibold text-foreground">Selected-link inspector</div>
+                <dl className="mt-3 space-y-2 text-sm">
+                  <SettingsFieldRow label="Parent" value={selectedOwnershipLink?.parentLabel ?? "—"} tone="default" />
+                  <SettingsFieldRow label="Relationship" value={selectedOwnershipLink?.relationshipLabel ?? "—"} tone="muted" />
+                  <SettingsFieldRow label="Child" value={selectedOwnershipLink?.childLabel ?? "—"} tone="default" />
+                </dl>
+                {(selectedOwnershipLink?.blockingMessages.length ?? 0) > 0 && (
+                  <div className="mt-4 rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm">
+                    <div className="font-semibold text-destructive">Invalid-link warnings</div>
+                    <ul className="mt-2 list-disc space-y-1 pl-5 text-muted-foreground">
+                      {selectedOwnershipLink?.blockingMessages.map((message) => <li key={message}>{message}</li>)}
+                    </ul>
+                  </div>
+                )}
+                <div className="mt-4 text-sm">
+                  <div className="font-semibold text-foreground">Suggested remediation</div>
+                  <ul className="mt-2 list-disc space-y-1 pl-5 text-muted-foreground">
+                    {(selectedOwnershipLink?.suggestedRemediationActions ?? ["Select an ownership link to inspect remediation."]).map((action) => <li key={action}>{action}</li>)}
+                  </ul>
+                </div>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {(selectedOwnershipLink?.lifecycleCommands ?? []).map((command) => (
+                    <Button key={command.label} type="button" variant="outline" size="sm" disabled={!command.isEnabled} title={command.disabledReason}>
+                      {command.label}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
       <Card id="fund-operations-control-center" className="panel-surface scroll-mt-6 border border-border/70">
         <CardHeader>

--- a/src/Meridian.Ui/dashboard/src/types.ts
+++ b/src/Meridian.Ui/dashboard/src/types.ts
@@ -3335,3 +3335,51 @@ export interface DataFetchResult {
   bars: PriceBar[];
   rowCount: number;
 }
+
+export type OwnershipReviewValidationState = "Valid" | "Warning" | "Blocking";
+
+export interface OwnershipReviewEffectiveWindow {
+  effectiveFrom: string;
+  effectiveTo?: string | null;
+  isActiveAsOf: boolean;
+  displayLabel: string;
+}
+
+export interface OwnershipLifecycleCommand {
+  label: string;
+  endpoint: string;
+  isEnabled: boolean;
+  disabledReason: string;
+}
+
+export interface OwnershipReviewLink {
+  ownershipLinkId: string;
+  nodeDisplayLabel: string;
+  parentLabel: string;
+  childLabel: string;
+  relationshipLabel: string;
+  percent?: number | null;
+  isPrimary: boolean;
+  effectiveWindow: OwnershipReviewEffectiveWindow;
+  validationState: OwnershipReviewValidationState;
+  blockingMessages: string[];
+  suggestedRemediationActions: string[];
+  lifecycleCommands: OwnershipLifecycleCommand[];
+}
+
+export interface OwnershipReviewSummary {
+  totalLinkCount: number;
+  activeLinkCount: number;
+  invalidLinkCount: number;
+  explicitOwnershipPercentTotal: number;
+  rollupSummary: string;
+  blockingMessages: string[];
+}
+
+export interface OwnershipReviewModel {
+  asOf: string;
+  links: OwnershipReviewLink[];
+  summary: OwnershipReviewSummary;
+  emptyStateTitle: string;
+  emptyStateDetail: string;
+}

--- a/src/Meridian.Wpf/README.md
+++ b/src/Meridian.Wpf/README.md
@@ -34,6 +34,8 @@ matching module before it expands through the older flat page folders.
 
 ## Important workflows
 
+The setup wizard includes an ownership review panel that loads `/api/fund-structure/ownership-review`, lists ownership links, shows the selected-link inspector, surfaces validation blockers, and keeps lifecycle commands disabled until backend edit/expire/replace methods are enabled.
+
 Keep desktop support aligned with shared contracts and governance posture.
 Convention-based view-model wiring is handled by `Services/ViewModelViewResolver.cs`; shell pages
 that follow the `*Page` to `*ViewModel` naming convention can receive a DI-constructed DataContext

--- a/src/Meridian.Wpf/Services/SetupWizardStateService.cs
+++ b/src/Meridian.Wpf/Services/SetupWizardStateService.cs
@@ -4,11 +4,13 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Meridian.Application.Config;
 using Meridian.Contracts.Configuration;
+using Meridian.Contracts.FundStructure;
 using Meridian.Ui.Services;
 using Meridian.Ui.Services.Services;
 using Microsoft.Extensions.Logging;
@@ -25,6 +27,8 @@ public interface ISetupWizardStateService
     IReadOnlyList<SetupPreset> GetSetupPresets();
 
     Task<SetupWizardConfigurationState> LoadConfigurationAsync(CancellationToken ct = default);
+
+    Task<OwnershipReviewModelDto> GetOwnershipReviewAsync(DateTimeOffset? asOf = null, CancellationToken ct = default);
 
     SetupWizardApiKeyState LoadStoredApiKeys();
 
@@ -172,6 +176,23 @@ public sealed class SetupWizardStateService : ISetupWizardStateService
         }
     }
 
+    public async Task<OwnershipReviewModelDto> GetOwnershipReviewAsync(DateTimeOffset? asOf = null, CancellationToken ct = default)
+    {
+        var path = asOf is null
+            ? "/api/fund-structure/ownership-review"
+            : $"/api/fund-structure/ownership-review?asOf={Uri.EscapeDataString(asOf.Value.ToString("O"))}";
+
+        try
+        {
+            return await _httpClient.GetFromJsonAsync<OwnershipReviewModelDto>(path, cancellationToken: ct).ConfigureAwait(false)
+                ?? CreateUnavailableOwnershipReview(asOf);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return CreateUnavailableOwnershipReview(asOf, ex.Message);
+        }
+    }
+
     public SetupWizardApiKeyState LoadStoredApiKeys()
         => new(
             Environment.GetEnvironmentVariable("NASDAQDATALINK__APIKEY", EnvironmentVariableTarget.User) ?? string.Empty,
@@ -278,6 +299,16 @@ public sealed class SetupWizardStateService : ISetupWizardStateService
         SaveApiKey("NASDAQDATALINK__APIKEY", nasdaqDataLinkApiKey);
         SaveApiKey("OPENFIGI__APIKEY", openFigiApiKey);
     }
+
+    private static OwnershipReviewModelDto CreateUnavailableOwnershipReview(DateTimeOffset? asOf, string? detail = null)
+        => new(
+            asOf ?? DateTimeOffset.UtcNow,
+            Array.Empty<OwnershipReviewLinkDto>(),
+            new OwnershipReviewSummaryDto(0, 0, 0, 0m, "Ownership review is not available yet.", Array.Empty<string>()),
+            "Ownership setup unavailable",
+            detail is null
+                ? "The setup wizard could not load ownership state from /api/fund-structure/ownership-review."
+                : $"The setup wizard could not load ownership state from /api/fund-structure/ownership-review. {detail}");
 
     private static void SaveApiKey(string variableName, string value)
     {

--- a/src/Meridian.Wpf/ViewModels/SetupWizardViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/SetupWizardViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
+using Meridian.Contracts.FundStructure;
 using Meridian.Ui.Services;
 using Meridian.Ui.Services.Services;
 using Meridian.Wpf.Services;
@@ -31,6 +32,10 @@ public sealed class SetupWizardViewModel : BindableBase
     private string _presetStatusText = string.Empty;
     private string _validationStatusText = string.Empty;
     private bool _isBusy;
+    private OwnershipReviewLinkDto? _selectedOwnershipLink;
+    private string _ownershipReviewTitle = "Ownership setup incomplete";
+    private string _ownershipReviewDetail = "Ownership state has not been loaded yet.";
+    private string _ownershipRollupSummary = "No ownership review loaded.";
 
     public SetupWizardViewModel(
         ISetupWizardStateService stateService,
@@ -52,11 +57,16 @@ public sealed class SetupWizardViewModel : BindableBase
         OpenInstructionsCommand = new RelayCommand(
             () => _linkLauncher.Open(InstructionsUrl),
             CanRunCommand);
+        EditOwnershipCommand = new RelayCommand(() => { }, CanRunOwnershipLifecycleCommand);
+        ExpireOwnershipCommand = new RelayCommand(() => { }, CanRunOwnershipLifecycleCommand);
+        ReplaceOwnershipCommand = new RelayCommand(() => { }, CanRunOwnershipLifecycleCommand);
     }
 
     public ObservableCollection<string> ProviderOptions { get; } = new();
 
     public ObservableCollection<SetupPreset> Presets { get; } = new();
+
+    public ObservableCollection<OwnershipReviewLinkDto> OwnershipLinks { get; } = new();
 
     public AsyncRelayCommand LoadCommand { get; }
 
@@ -71,6 +81,12 @@ public sealed class SetupWizardViewModel : BindableBase
     public RelayCommand UseDefaultStorageCommand { get; }
 
     public RelayCommand OpenInstructionsCommand { get; }
+
+    public RelayCommand EditOwnershipCommand { get; }
+
+    public RelayCommand ExpireOwnershipCommand { get; }
+
+    public RelayCommand ReplaceOwnershipCommand { get; }
 
     public string ConfigPath
     {
@@ -138,6 +154,40 @@ public sealed class SetupWizardViewModel : BindableBase
         private set => SetProperty(ref _validationStatusText, value);
     }
 
+    public OwnershipReviewLinkDto? SelectedOwnershipLink
+    {
+        get => _selectedOwnershipLink;
+        set
+        {
+            if (!SetProperty(ref _selectedOwnershipLink, value))
+            {
+                return;
+            }
+
+            EditOwnershipCommand.NotifyCanExecuteChanged();
+            ExpireOwnershipCommand.NotifyCanExecuteChanged();
+            ReplaceOwnershipCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    public string OwnershipReviewTitle
+    {
+        get => _ownershipReviewTitle;
+        private set => SetProperty(ref _ownershipReviewTitle, value);
+    }
+
+    public string OwnershipReviewDetail
+    {
+        get => _ownershipReviewDetail;
+        private set => SetProperty(ref _ownershipReviewDetail, value);
+    }
+
+    public string OwnershipRollupSummary
+    {
+        get => _ownershipRollupSummary;
+        private set => SetProperty(ref _ownershipRollupSummary, value);
+    }
+
     public bool IsBusy
     {
         get => _isBusy;
@@ -155,6 +205,9 @@ public sealed class SetupWizardViewModel : BindableBase
             SaveAndContinueCommand.NotifyCanExecuteChanged();
             UseDefaultStorageCommand.NotifyCanExecuteChanged();
             OpenInstructionsCommand.NotifyCanExecuteChanged();
+            EditOwnershipCommand.NotifyCanExecuteChanged();
+            ExpireOwnershipCommand.NotifyCanExecuteChanged();
+            ReplaceOwnershipCommand.NotifyCanExecuteChanged();
         }
     }
 
@@ -182,6 +235,7 @@ public sealed class SetupWizardViewModel : BindableBase
             NasdaqApiKey = apiKeys.NasdaqDataLinkApiKey;
             OpenFigiApiKey = apiKeys.OpenFigiApiKey;
 
+            await LoadOwnershipReviewAsync();
             await EnsureBackendAvailableAsync();
         });
     }
@@ -223,6 +277,19 @@ public sealed class SetupWizardViewModel : BindableBase
                 await _notificationSink.NotifyErrorAsync("Setup Preset", $"Failed to apply preset: {ex.Message}");
             }
         });
+    }
+
+    private async Task LoadOwnershipReviewAsync()
+    {
+        var review = await _stateService.GetOwnershipReviewAsync().ConfigureAwait(false);
+        ReplaceItems(OwnershipLinks, review.Links);
+        SelectedOwnershipLink = OwnershipLinks.FirstOrDefault(link => link.ValidationState == OwnershipReviewValidationStateDto.Blocking)
+            ?? OwnershipLinks.FirstOrDefault();
+        OwnershipReviewTitle = OwnershipLinks.Count == 0 ? review.EmptyStateTitle : "Ownership review";
+        OwnershipReviewDetail = OwnershipLinks.Count == 0
+            ? review.EmptyStateDetail
+            : $"Selected ownership link: {SelectedOwnershipLink?.NodeDisplayLabel ?? "none"}.";
+        OwnershipRollupSummary = review.Summary.RollupSummary;
     }
 
     private async Task RefreshBackendStatusAsync()
@@ -362,6 +429,9 @@ public sealed class SetupWizardViewModel : BindableBase
     }
 
     private bool CanRunCommand() => !IsBusy;
+
+    private bool CanRunOwnershipLifecycleCommand()
+        => !IsBusy && SelectedOwnershipLink?.LifecycleCommands.Any(command => command.IsEnabled) == true;
 
     private async Task RunBusyAsync(Func<Task> action)
     {

--- a/src/Meridian.Wpf/Views/SetupWizardPage.xaml
+++ b/src/Meridian.Wpf/Views/SetupWizardPage.xaml
@@ -118,7 +118,68 @@
 
             <Border Style="{StaticResource CardStyle}" Margin="0,0,0,24">
                 <StackPanel>
-                    <TextBlock Text="Step 3 · Configure providers and storage" Style="{StaticResource CardHeaderStyle}" Margin="0,0,0,12" />
+                    <TextBlock Text="Step 3 · Review ownership before setup completion" Style="{StaticResource CardHeaderStyle}" Margin="0,0,0,12" />
+                    <TextBlock Text="{Binding OwnershipReviewTitle}" Foreground="{StaticResource ConsoleTextPrimaryBrush}" FontWeight="SemiBold" Margin="0,0,0,4" />
+                    <TextBlock Text="{Binding OwnershipReviewDetail}" Foreground="{StaticResource ConsoleTextSecondaryBrush}" TextWrapping="Wrap" Margin="0,0,0,8" />
+                    <TextBlock Text="{Binding OwnershipRollupSummary}" Foreground="{StaticResource ConsoleTextMutedBrush}" TextWrapping="Wrap" Margin="0,0,0,16" />
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="2*" />
+                            <ColumnDefinition Width="16" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <ListBox x:Name="OwnershipLinksList"
+                                 ItemsSource="{Binding OwnershipLinks}"
+                                 SelectedItem="{Binding SelectedOwnershipLink, Mode=TwoWay}"
+                                 MinHeight="180"
+                                 Grid.Column="0"
+                                 AutomationProperties.Name="Ownership tree list">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <Border Padding="8" BorderBrush="{StaticResource ConsoleBorderBrush}" BorderThickness="0,0,0,1">
+                                        <StackPanel>
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="{Binding ValidationState}" FontWeight="SemiBold" Margin="0,0,8,0" />
+                                                <TextBlock Text="{Binding NodeDisplayLabel}" FontWeight="SemiBold" />
+                                            </StackPanel>
+                                            <TextBlock Text="{Binding EffectiveWindow.DisplayLabel}" Foreground="{StaticResource ConsoleTextMutedBrush}" />
+                                            <TextBlock Text="{Binding Percent, StringFormat=Percent: {0:0.##}%}" Foreground="{StaticResource ConsoleTextMutedBrush}" />
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+
+                        <Border Grid.Column="2" BorderBrush="{StaticResource ConsoleBorderBrush}" BorderThickness="1" CornerRadius="10" Padding="12"
+                                AutomationProperties.Name="Selected ownership link inspector">
+                            <StackPanel>
+                                <TextBlock Text="Selected-link inspector" FontWeight="SemiBold" Margin="0,0,0,8" />
+                                <TextBlock Text="{Binding SelectedOwnershipLink.ParentLabel}" Foreground="{StaticResource ConsoleTextPrimaryBrush}" />
+                                <TextBlock Text="{Binding SelectedOwnershipLink.RelationshipLabel}" Foreground="{StaticResource ConsoleTextMutedBrush}" />
+                                <TextBlock Text="{Binding SelectedOwnershipLink.ChildLabel}" Foreground="{StaticResource ConsoleTextPrimaryBrush}" Margin="0,0,0,8" />
+                                <TextBlock Text="Validation" FontWeight="SemiBold" />
+                                <TextBlock Text="{Binding SelectedOwnershipLink.ValidationState}" Foreground="{StaticResource ConsoleTextMutedBrush}" Margin="0,0,0,8" />
+                                <ItemsControl ItemsSource="{Binding SelectedOwnershipLink.BlockingMessages}" Margin="0,0,0,8" />
+                                <TextBlock Text="Suggested remediation" FontWeight="SemiBold" />
+                                <ItemsControl ItemsSource="{Binding SelectedOwnershipLink.SuggestedRemediationActions}" Margin="0,0,0,12" />
+                                <WrapPanel>
+                                    <Button Content="Edit" Command="{Binding EditOwnershipCommand}" Style="{StaticResource SecondaryButtonStyle}" Margin="0,0,8,0" />
+                                    <Button Content="Expire" Command="{Binding ExpireOwnershipCommand}" Style="{StaticResource SecondaryButtonStyle}" Margin="0,0,8,0" />
+                                    <Button Content="Replace" Command="{Binding ReplaceOwnershipCommand}" Style="{StaticResource SecondaryButtonStyle}" />
+                                </WrapPanel>
+                                <TextBlock Text="Commands activate when backend ownership lifecycle endpoints are available."
+                                           Foreground="{StaticResource ConsoleTextMutedBrush}" TextWrapping="Wrap" Margin="0,8,0,0" />
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+                </StackPanel>
+            </Border>
+
+            <Border Style="{StaticResource CardStyle}" Margin="0,0,0,24">
+                <StackPanel>
+                    <TextBlock Text="Step 4 · Configure providers and storage" Style="{StaticResource CardHeaderStyle}" Margin="0,0,0,12" />
                     <TextBlock Text="Choose your default data provider and where data will be stored."
                                Foreground="{StaticResource ConsoleTextSecondaryBrush}" Margin="0,0,0,16" />
 
@@ -161,7 +222,7 @@
 
             <Border Style="{StaticResource CardStyle}">
                 <StackPanel>
-                    <TextBlock Text="Step 4 · Add API keys (optional)" Style="{StaticResource CardHeaderStyle}" Margin="0,0,0,12" />
+                    <TextBlock Text="Step 5 · Add API keys (optional)" Style="{StaticResource CardHeaderStyle}" Margin="0,0,0,12" />
                     <TextBlock Text="Provide API keys for premium providers. Keys are stored in your user environment variables."
                                Foreground="{StaticResource ConsoleTextSecondaryBrush}" Margin="0,0,0,16" />
 

--- a/tests/Meridian.Tests/Ui/Services/OwnershipReviewReadServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/Services/OwnershipReviewReadServiceTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using Meridian.Contracts.FundStructure;
+using Meridian.Ui.Shared.Services;
+
+namespace Meridian.Tests.Ui.Services;
+
+/// <summary>
+/// Protects the operator setup scenario where ownership state must be explicit before setup completion.
+/// </summary>
+public sealed class OwnershipReviewReadServiceTests
+{
+    [Fact]
+    public void Project_StableGraph_OrdersLinksAndBuildsRollupSummary()
+    {
+        var service = new OwnershipReviewReadService();
+        var asOf = DateTimeOffset.Parse("2026-05-29T00:00:00Z");
+        var fund = Node("00000000-0000-0000-0000-000000000001", FundStructureNodeKindDto.Fund, "ALPHA", "Alpha Fund");
+        var sleeve = Node("00000000-0000-0000-0000-000000000002", FundStructureNodeKindDto.Sleeve, "CORE", "Core Sleeve");
+        var account = Node("00000000-0000-0000-0000-000000000003", FundStructureNodeKindDto.Account, "PB", "Prime Brokerage");
+        var graph = new FundStructureGraphDto(
+            [account, sleeve, fund],
+            [
+                Link("00000000-0000-0000-0000-000000000012", sleeve.NodeId, account.NodeId, 25m),
+                Link("00000000-0000-0000-0000-000000000011", fund.NodeId, sleeve.NodeId, 75m)
+            ],
+            []);
+
+        var review = service.Project(graph, asOf);
+
+        review.Links.Select(link => link.NodeDisplayLabel).Should().Equal(
+            "Alpha Fund (Fund) owns Core Sleeve (Sleeve)",
+            "Core Sleeve (Sleeve) owns Prime Brokerage (Account)");
+        review.Summary.ActiveLinkCount.Should().Be(2);
+        review.Summary.ExplicitOwnershipPercentTotal.Should().Be(100m);
+        review.Summary.RollupSummary.Should().Contain("2 active of 2 ownership links");
+    }
+
+    [Fact]
+    public void Project_EmptyGraph_ReturnsOperatorEmptyState()
+    {
+        var service = new OwnershipReviewReadService();
+
+        var review = service.Project(new FundStructureGraphDto([], [], []), DateTimeOffset.Parse("2026-05-29T00:00:00Z"));
+
+        review.Links.Should().BeEmpty();
+        review.EmptyStateTitle.Should().Be("Ownership setup incomplete");
+        review.Summary.RollupSummary.Should().Be("No ownership links have been configured.");
+    }
+
+    [Fact]
+    public void Project_InvalidOwnershipLink_ReturnsBlockingWarningsAndRemediation()
+    {
+        var service = new OwnershipReviewReadService();
+        var fund = Node("00000000-0000-0000-0000-000000000001", FundStructureNodeKindDto.Fund, "ALPHA", "Alpha Fund");
+        var missingChild = Guid.Parse("00000000-0000-0000-0000-000000000099");
+        var graph = new FundStructureGraphDto(
+            [fund],
+            [new OwnershipLinkDto(Guid.Parse("00000000-0000-0000-0000-000000000021"), fund.NodeId, missingChild, OwnershipRelationshipTypeDto.Owns, 120m, true, DateTimeOffset.Parse("2026-01-01T00:00:00Z"), null, null)],
+            []);
+
+        var review = service.Project(graph, DateTimeOffset.Parse("2026-05-29T00:00:00Z"));
+
+        review.Summary.InvalidLinkCount.Should().Be(1);
+        review.Links[0].ValidationState.Should().Be(OwnershipReviewValidationStateDto.Blocking);
+        review.Links[0].BlockingMessages.Should().Contain("Child node is missing from the fund-structure graph.");
+        review.Links[0].BlockingMessages.Should().Contain("Ownership percent must be between 0 and 100.");
+        review.Links[0].SuggestedRemediationActions.Should().Contain(action => action.Contains("existing child node"));
+    }
+
+    private static FundStructureNodeDto Node(
+        string id,
+        FundStructureNodeKindDto kind,
+        string code,
+        string name)
+        => new(Guid.Parse(id), kind, code, name, null, true, DateTimeOffset.Parse("2026-01-01T00:00:00Z"), null);
+
+    private static OwnershipLinkDto Link(string id, Guid parentId, Guid childId, decimal percent)
+        => new(
+            Guid.Parse(id),
+            parentId,
+            childId,
+            OwnershipRelationshipTypeDto.Owns,
+            percent,
+            true,
+            DateTimeOffset.Parse("2026-01-01T00:00:00Z"),
+            null,
+            null);
+}

--- a/tests/Meridian.Wpf.Tests/ViewModels/SetupWizardViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/SetupWizardViewModelTests.cs
@@ -1,3 +1,4 @@
+using Meridian.Contracts.FundStructure;
 using Meridian.Ui.Services;
 using Meridian.Ui.Services.Services;
 using Meridian.Wpf.Services;
@@ -86,6 +87,48 @@ public sealed class SetupWizardViewModelTests
         viewModel.ValidationStatusText.Should().Be("Configuration saved and backend verified. Opening Research Workspace...");
     }
 
+
+    [Fact]
+    public async Task LoadAsync_WhenOwnershipReviewHasInvalidLink_SelectsInvalidLinkAndDisablesLifecycleCommands()
+    {
+        var state = new FakeSetupWizardStateService
+        {
+            OwnershipReview = CreateOwnershipReview(OwnershipReviewValidationStateDto.Blocking)
+        };
+        var viewModel = CreateViewModel(state);
+
+        await viewModel.LoadAsync();
+
+        viewModel.OwnershipLinks.Should().HaveCount(1);
+        viewModel.SelectedOwnershipLink.Should().NotBeNull();
+        viewModel.SelectedOwnershipLink!.ValidationState.Should().Be(OwnershipReviewValidationStateDto.Blocking);
+        viewModel.OwnershipRollupSummary.Should().Contain("blocking");
+        viewModel.EditOwnershipCommand.CanExecute(null).Should().BeFalse();
+        viewModel.ExpireOwnershipCommand.CanExecute(null).Should().BeFalse();
+        viewModel.ReplaceOwnershipCommand.CanExecute(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenOwnershipReviewIsEmpty_ShowsOwnershipEmptyState()
+    {
+        var state = new FakeSetupWizardStateService
+        {
+            OwnershipReview = new OwnershipReviewModelDto(
+                DateTimeOffset.Parse("2026-05-29T00:00:00Z"),
+                Array.Empty<OwnershipReviewLinkDto>(),
+                new OwnershipReviewSummaryDto(0, 0, 0, 0m, "No ownership links have been configured.", Array.Empty<string>()),
+                "Ownership setup incomplete",
+                "Create ownership links before completing setup.")
+        };
+        var viewModel = CreateViewModel(state);
+
+        await viewModel.LoadAsync();
+
+        viewModel.OwnershipLinks.Should().BeEmpty();
+        viewModel.OwnershipReviewTitle.Should().Be("Ownership setup incomplete");
+        viewModel.OwnershipReviewDetail.Should().Contain("Create ownership links");
+    }
+
     [Fact]
     public async Task ApplyPresetCommand_UsesFirstSupportedRecommendedProvider()
     {
@@ -101,6 +144,35 @@ public sealed class SetupWizardViewModelTests
         viewModel.SelectedProvider.Should().Be("Alpaca");
         viewModel.PresetStatusText.Should().Contain("Applied \"Minimal Setup\" preset");
         notification.SuccessMessages.Should().Contain(message => message.Contains("Minimal Setup"));
+    }
+
+    private static OwnershipReviewModelDto CreateOwnershipReview(OwnershipReviewValidationStateDto state)
+    {
+        var command = new OwnershipLifecycleCommandDto(
+            "Edit",
+            "/api/fund-structure/links/00000000-0000-0000-0000-000000000001/edit",
+            false,
+            "Backend ownership lifecycle methods are not enabled for this environment yet.");
+        var link = new OwnershipReviewLinkDto(
+            Guid.Parse("00000000-0000-0000-0000-000000000001"),
+            "Alpha Fund owns Alpha Sleeve",
+            "Alpha Fund (Fund)",
+            "Alpha Sleeve (Sleeve)",
+            "owns",
+            100m,
+            true,
+            new OwnershipReviewEffectiveWindowDto(DateTimeOffset.Parse("2026-01-01T00:00:00Z"), null, true, "2026-01-01 to open-ended (active)"),
+            state,
+            state == OwnershipReviewValidationStateDto.Blocking ? ["Parent node is missing from the fund-structure graph."] : [],
+            state == OwnershipReviewValidationStateDto.Blocking ? ["Select an existing parent node before setup completion."] : ["No remediation required."],
+            [command]);
+
+        return new OwnershipReviewModelDto(
+            DateTimeOffset.Parse("2026-05-29T00:00:00Z"),
+            [link],
+            new OwnershipReviewSummaryDto(1, 1, state == OwnershipReviewValidationStateDto.Blocking ? 1 : 0, 100m, "1 active of 1 ownership links; 0 blocking; 100% explicit active ownership.", Array.Empty<string>()),
+            "Ownership setup incomplete",
+            "Create ownership links before completing setup.");
     }
 
     private static SetupWizardViewModel CreateViewModel(
@@ -141,6 +213,8 @@ public sealed class SetupWizardViewModelTests
         public SetupWizardSaveResult SaveResult { get; init; } =
             new(true, "Configuration saved.");
 
+        public OwnershipReviewModelDto OwnershipReview { get; init; } = CreateOwnershipReview(OwnershipReviewValidationStateDto.Valid);
+
         public IReadOnlyList<SetupPreset> GetSetupPresets()
             =>
             [
@@ -163,6 +237,9 @@ public sealed class SetupWizardViewModelTests
                 "Synthetic",
                 "data",
                 "Loaded existing valid configuration."));
+
+        public Task<OwnershipReviewModelDto> GetOwnershipReviewAsync(DateTimeOffset? asOf = null, CancellationToken ct = default)
+            => Task.FromResult(OwnershipReview);
 
         public SetupWizardApiKeyState LoadStoredApiKeys()
             => new("nasdaq-key", "figi-key");


### PR DESCRIPTION
### Motivation

- Make operator ownership explicit during setup so operators can see ownership links, validation blockers, and remediation before completing setup flows. 

### Description

- Add shared ownership read-model contracts under `src/Meridian.Contracts/FundStructure/OwnershipReviewDtos.cs` capturing link labels, percent, primary flag, effective window, validation state, blocking messages, remediation actions, and lifecycle command affordances. 
- Implement `OwnershipReviewReadService` in `src/Meridian.Ui.Shared/Services/` that projects `FundStructureGraphDto` into the ownership review model with deterministic ordering, active/as-of rollups, validation detection, and disabled lifecycle command metadata. 
- Expose `/api/fund-structure/ownership-review` and placeholder lifecycle endpoints (`/links/{id}/edit|expire|replace`) in `src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs`, and register the read service in the shared DI graph. 
- Add WPF setup-wizard UI, view-model, and service wiring to surface the ownership review (tree/list, selected-link inspector, validation badges, disabled lifecycle commands) under `src/Meridian.Wpf/Views/SetupWizardPage.xaml`, `src/Meridian.Wpf/ViewModels/SetupWizardViewModel.cs`, and `src/Meridian.Wpf/Services/SetupWizardStateService.cs`. 
- Add browser Settings panel support (API client, types, hook wiring, and Settings UI) feeding the same `/api/fund-structure/ownership-review` projection and rendering the table, active/as-of filter, rollup summary, invalid-link warnings, inspector, remediation list, and disabled lifecycle affordances. 
- Add tests covering the projection service, WPF view-model behavior, and browser rendering/interaction cases, and update module READMEs describing the new ownership review seam. 

### Testing

- Ran the browser unit suite: `npm --prefix src/Meridian.Ui/dashboard test -- --run src/screens/settings-screen.test.tsx` and the Settings ownership tests passed (Vitest: 27/27 tests passed). 
- Ran the dashboard build: `npm --prefix src/Meridian.Ui/dashboard run build` which encountered pre-existing TypeScript contract/typing drift outside the ownership change and did not fully succeed in this container. 
- Attempted C# test/CLI validation but `dotnet` was not available in the runtime, so server-side .NET tests could not be executed here. 
- Ran docs validation: `python3 build/scripts/docs/validate-doc-hashes.py --summary` which reported repository-wide source README/hash drift (pre-existing) and is noted as advisory. 
- Produced an implementation-assurance evaluation using the local rubric script yielding a score of `9/10` with the outstanding follow-up: run C# tests in a .NET 10 environment and reconcile broader dashboard type-contract drift before a full browser build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19bc322dac8320a069e6d4daf2fdcb)