### PR TITLE
Add private asset DTOs, evidence model, read-model stores, and tests

### DIFF
--- a/src/Meridian.Application/PrivateAssets/PrivateAssetReadModelStore.cs
+++ b/src/Meridian.Application/PrivateAssets/PrivateAssetReadModelStore.cs
@@ -1,0 +1,292 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Meridian.Contracts.PrivateAssets;
+using Meridian.Storage.Archival;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Application.PrivateAssets;
+
+public interface IPrivateAssetReadModelStore
+{
+    Task UpsertAsync(PrivateAssetDto asset, DateOnly asOfDate, CancellationToken ct = default);
+    Task<PrivateAssetReadModelDto?> GetAsync(string privateAssetId, DateOnly asOfDate, CancellationToken ct = default);
+    Task<IReadOnlyList<PrivateAssetReadModelDto>> ListAsync(string? owningEntityId = null, DateOnly? asOfDate = null, CancellationToken ct = default);
+    Task<bool> DeleteAsync(string privateAssetId, CancellationToken ct = default);
+}
+
+public sealed class PrivateAssetReadModelValidator
+{
+    public const int DefaultStaleNavDays = 120;
+
+    private readonly int _staleNavDays;
+
+    public PrivateAssetReadModelValidator(int staleNavDays = DefaultStaleNavDays)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(staleNavDays);
+        _staleNavDays = staleNavDays;
+    }
+
+    public IReadOnlyList<PrivateAssetValidationWarningDto> Validate(PrivateAssetDto asset, DateOnly asOfDate)
+    {
+        ArgumentNullException.ThrowIfNull(asset);
+
+        var warnings = new List<PrivateAssetValidationWarningDto>(capacity: 5);
+        if (asset.ValuationDate is null)
+        {
+            warnings.Add(new PrivateAssetValidationWarningDto(
+                PrivateAssetValidationWarningCodeDto.MissingValuationDate,
+                "Private asset is missing a valuation date for the latest NAV.",
+                "Warning",
+                nameof(PrivateAssetEvidenceKindDto.ValuationMemo)));
+        }
+        else if (asset.ValuationDate.Value.AddDays(_staleNavDays) < asOfDate)
+        {
+            warnings.Add(new PrivateAssetValidationWarningDto(
+                PrivateAssetValidationWarningCodeDto.StaleNav,
+                $"Latest NAV is older than {_staleNavDays} days relative to {asOfDate:yyyy-MM-dd}.",
+                "Warning",
+                nameof(PrivateAssetEvidenceKindDto.ValuationMemo)));
+        }
+
+        if (string.IsNullOrWhiteSpace(asset.OwningEntityId))
+        {
+            warnings.Add(new PrivateAssetValidationWarningDto(
+                PrivateAssetValidationWarningCodeDto.MissingOwnerEntity,
+                "Private asset is missing an owning entity id.",
+                "Warning"));
+        }
+
+        if (asset.CommitmentSchedule is not { Count: > 0 })
+        {
+            warnings.Add(new PrivateAssetValidationWarningDto(
+                PrivateAssetValidationWarningCodeDto.MissingCommitmentSchedule,
+                "Private asset is missing a commitment schedule.",
+                "Warning",
+                nameof(PrivateAssetEvidenceKindDto.CommitmentSchedule)));
+        }
+
+        if (asset.EvidenceLinks is not { Count: > 0 })
+        {
+            warnings.Add(new PrivateAssetValidationWarningDto(
+                PrivateAssetValidationWarningCodeDto.MissingEvidence,
+                "Private asset is missing retained evidence links for statements, notices, tax, subscription, side-letter, or valuation documents.",
+                "Warning"));
+        }
+
+        return warnings;
+    }
+
+    public PrivateAssetReadModelDto Project(PrivateAssetDto asset, DateOnly asOfDate, DateTimeOffset refreshedAtUtc)
+        => new(asset, Validate(asset, asOfDate), refreshedAtUtc);
+}
+
+public sealed class InMemoryPrivateAssetReadModelStore : IPrivateAssetReadModelStore
+{
+    private readonly Dictionary<string, PrivateAssetDto> _assets = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Lock _lock = new();
+    private readonly PrivateAssetReadModelValidator _validator;
+    private readonly TimeProvider _clock;
+
+    public InMemoryPrivateAssetReadModelStore(PrivateAssetReadModelValidator? validator = null, TimeProvider? clock = null)
+    {
+        _validator = validator ?? new PrivateAssetReadModelValidator();
+        _clock = clock ?? TimeProvider.System;
+    }
+
+    public Task UpsertAsync(PrivateAssetDto asset, DateOnly asOfDate, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(asset);
+        ArgumentException.ThrowIfNullOrWhiteSpace(asset.PrivateAssetId);
+        ct.ThrowIfCancellationRequested();
+
+        lock (_lock)
+        {
+            _assets[asset.PrivateAssetId] = asset;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<PrivateAssetReadModelDto?> GetAsync(string privateAssetId, DateOnly asOfDate, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(privateAssetId);
+        ct.ThrowIfCancellationRequested();
+
+        lock (_lock)
+        {
+            return Task.FromResult(_assets.TryGetValue(privateAssetId, out var asset)
+                ? _validator.Project(asset, asOfDate, _clock.GetUtcNow())
+                : null);
+        }
+    }
+
+    public Task<IReadOnlyList<PrivateAssetReadModelDto>> ListAsync(string? owningEntityId = null, DateOnly? asOfDate = null, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var effectiveAsOfDate = asOfDate ?? DateOnly.FromDateTime(_clock.GetUtcNow().UtcDateTime);
+
+        lock (_lock)
+        {
+            var rows = _assets.Values
+                .Where(asset => string.IsNullOrWhiteSpace(owningEntityId) || string.Equals(asset.OwningEntityId, owningEntityId, StringComparison.OrdinalIgnoreCase))
+                .OrderBy(static asset => asset.AssetName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(static asset => asset.PrivateAssetId, StringComparer.OrdinalIgnoreCase)
+                .Select(asset => _validator.Project(asset, effectiveAsOfDate, _clock.GetUtcNow()))
+                .ToArray();
+            return Task.FromResult<IReadOnlyList<PrivateAssetReadModelDto>>(rows);
+        }
+    }
+
+    public Task<bool> DeleteAsync(string privateAssetId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(privateAssetId);
+        ct.ThrowIfCancellationRequested();
+
+        lock (_lock)
+        {
+            return Task.FromResult(_assets.Remove(privateAssetId));
+        }
+    }
+}
+
+public sealed class FilePrivateAssetReadModelStore : IPrivateAssetReadModelStore
+{
+    private readonly string _directory;
+    private readonly ILogger<FilePrivateAssetReadModelStore> _logger;
+    private readonly PrivateAssetReadModelValidator _validator;
+    private readonly TimeProvider _clock;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public FilePrivateAssetReadModelStore(
+        string dataDirectory,
+        ILogger<FilePrivateAssetReadModelStore> logger,
+        PrivateAssetReadModelValidator? validator = null,
+        TimeProvider? clock = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dataDirectory);
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _validator = validator ?? new PrivateAssetReadModelValidator();
+        _clock = clock ?? TimeProvider.System;
+        _directory = Path.Combine(dataDirectory, "private-assets", "read-models");
+        Directory.CreateDirectory(_directory);
+    }
+
+    public async Task UpsertAsync(PrivateAssetDto asset, DateOnly asOfDate, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(asset);
+        ArgumentException.ThrowIfNullOrWhiteSpace(asset.PrivateAssetId);
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var json = JsonSerializer.Serialize(asset, _jsonOptions);
+            await AtomicFileWriter.WriteAsync(GetPath(asset.PrivateAssetId), json, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<PrivateAssetReadModelDto?> GetAsync(string privateAssetId, DateOnly asOfDate, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(privateAssetId);
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var asset = await ReadAssetAsync(GetPath(privateAssetId), ct).ConfigureAwait(false);
+            return asset is null ? null : _validator.Project(asset, asOfDate, _clock.GetUtcNow());
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<PrivateAssetReadModelDto>> ListAsync(string? owningEntityId = null, DateOnly? asOfDate = null, CancellationToken ct = default)
+    {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var effectiveAsOfDate = asOfDate ?? DateOnly.FromDateTime(_clock.GetUtcNow().UtcDateTime);
+            var rows = new List<PrivateAssetReadModelDto>();
+            foreach (var path in Directory.EnumerateFiles(_directory, "*.json", SearchOption.TopDirectoryOnly))
+            {
+                ct.ThrowIfCancellationRequested();
+                var asset = await ReadAssetAsync(path, ct).ConfigureAwait(false);
+                if (asset is null)
+                {
+                    continue;
+                }
+
+                if (!string.IsNullOrWhiteSpace(owningEntityId) && !string.Equals(asset.OwningEntityId, owningEntityId, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                rows.Add(_validator.Project(asset, effectiveAsOfDate, _clock.GetUtcNow()));
+            }
+
+            return rows
+                .OrderBy(static row => row.Asset.AssetName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(static row => row.Asset.PrivateAssetId, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<bool> DeleteAsync(string privateAssetId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(privateAssetId);
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var path = GetPath(privateAssetId);
+            if (!File.Exists(path))
+            {
+                return false;
+            }
+
+            File.Delete(path);
+            return true;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task<PrivateAssetDto?> ReadAssetAsync(string path, CancellationToken ct)
+    {
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            await using var stream = File.OpenRead(path);
+            return await JsonSerializer.DeserializeAsync<PrivateAssetDto>(stream, _jsonOptions, ct).ConfigureAwait(false);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Skipping corrupt private asset read model {Path}", path);
+            return null;
+        }
+    }
+
+    private string GetPath(string privateAssetId) => Path.Combine(_directory, $"{SanitizeFileName(privateAssetId)}.json");
+
+    private static string SanitizeFileName(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var buffer = value.Select(character => invalid.Contains(character) ? '_' : character).ToArray();
+        return new string(buffer);
+    }
+}

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -69,6 +69,7 @@ and UI presentation concerns in their owning layers.
   cash/activity rows, requires row currency equality before broker/custodian auto-match, appends
   reconciliation decision journals through crash-safe copy-on-write JSONL writes, and attaches
   break explanations plus retained statement-row evidence.
+- `PrivateAssets/` - private-asset read-model persistence and validation for private equity, venture, private credit, real estate, direct company, collectible, operating-business, and other holdings. The application layer persists shared contract DTOs and derives warnings for stale NAV, missing valuation dates, missing owner entities, missing commitment schedules, and missing retained evidence links without requiring UI clients to duplicate validation rules.
 - `ProviderRouting/` - relationship-aware provider capability routing. Provider-ledger accounting
   workflows use these capability gates to block missing balance/position/reconciliation feeds and
   degrade corporate-action or factor-schedule support when the account's provider route cannot

--- a/src/Meridian.Contracts/PrivateAssets/PrivateAssetContractsJsonContext.cs
+++ b/src/Meridian.Contracts/PrivateAssets/PrivateAssetContractsJsonContext.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Meridian.Contracts.PrivateAssets;
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    PropertyNameCaseInsensitive = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(PrivateAssetDto))]
+[JsonSerializable(typeof(IReadOnlyList<PrivateAssetDto>))]
+[JsonSerializable(typeof(PrivateAssetReadModelDto))]
+[JsonSerializable(typeof(IReadOnlyList<PrivateAssetReadModelDto>))]
+[JsonSerializable(typeof(PrivateAssetEvidenceLinkDto))]
+[JsonSerializable(typeof(IReadOnlyList<PrivateAssetEvidenceLinkDto>))]
+[JsonSerializable(typeof(PrivateAssetCommitmentScheduleEntryDto))]
+[JsonSerializable(typeof(IReadOnlyList<PrivateAssetCommitmentScheduleEntryDto>))]
+[JsonSerializable(typeof(PrivateAssetValidationWarningDto))]
+[JsonSerializable(typeof(IReadOnlyList<PrivateAssetValidationWarningDto>))]
+public sealed partial class PrivateAssetContractsJsonContext : JsonSerializerContext;

--- a/src/Meridian.Contracts/PrivateAssets/PrivateAssetDtos.cs
+++ b/src/Meridian.Contracts/PrivateAssets/PrivateAssetDtos.cs
@@ -1,0 +1,106 @@
+namespace Meridian.Contracts.PrivateAssets;
+
+/// <summary>
+/// Supported private-asset investment categories for fund, family-office, and operating-company books.
+/// </summary>
+public enum PrivateAssetTypeDto
+{
+    PrivateEquityFund,
+    VentureFund,
+    PrivateCredit,
+    RealEstate,
+    DirectCompanyInvestment,
+    Collectible,
+    OperatingBusiness,
+    Other
+}
+
+/// <summary>
+/// Evidence categories accepted for private-asset records. These replace free-form notes for source documents.
+/// </summary>
+public enum PrivateAssetEvidenceKindDto
+{
+    ImportedStatement,
+    CapitalNotice,
+    K1,
+    SideLetter,
+    SubscriptionDocument,
+    ValuationMemo,
+    CommitmentSchedule,
+    Other
+}
+
+/// <summary>
+/// Stable warning codes emitted by the private-asset read-model validator.
+/// </summary>
+public enum PrivateAssetValidationWarningCodeDto
+{
+    StaleNav,
+    MissingValuationDate,
+    MissingOwnerEntity,
+    MissingCommitmentSchedule,
+    MissingEvidence
+}
+
+/// <summary>
+/// Typed evidence link for retained private-asset source documents.
+/// </summary>
+public sealed record PrivateAssetEvidenceLinkDto(
+    PrivateAssetEvidenceKindDto Kind,
+    string EvidenceId,
+    string Label,
+    string? Uri,
+    DateOnly? DocumentDate,
+    string? SourceSystem = null,
+    string? ContentHash = null);
+
+/// <summary>
+/// Expected capital activity used to distinguish commitment coverage from ad-hoc narrative notes.
+/// </summary>
+public sealed record PrivateAssetCommitmentScheduleEntryDto(
+    DateOnly DueDate,
+    decimal Amount,
+    string Currency,
+    string? Description = null,
+    string? EvidenceId = null);
+
+/// <summary>
+/// Shared transport DTO for one private asset and its valuation/evidence posture.
+/// </summary>
+public sealed record PrivateAssetDto(
+    string PrivateAssetId,
+    string AssetName,
+    PrivateAssetTypeDto AssetType,
+    string? OwningEntityId,
+    string? ManagerOrSponsor,
+    decimal CommitmentAmount,
+    decimal CalledCapital,
+    decimal UnfundedCommitment,
+    decimal DistributionsToDate,
+    decimal LatestNav,
+    DateOnly? ValuationDate,
+    string? ValuationSource,
+    decimal? IRR,
+    decimal? MOIC,
+    decimal? TVPI,
+    decimal? DPI,
+    string Currency,
+    IReadOnlyList<PrivateAssetEvidenceLinkDto> EvidenceLinks,
+    IReadOnlyList<PrivateAssetCommitmentScheduleEntryDto>? CommitmentSchedule = null);
+
+/// <summary>
+/// Read-model warning with deterministic code, severity, and remediation text for operator surfaces.
+/// </summary>
+public sealed record PrivateAssetValidationWarningDto(
+    PrivateAssetValidationWarningCodeDto Code,
+    string Message,
+    string Severity,
+    string? EvidenceKind = null);
+
+/// <summary>
+/// Shared private-asset read model containing the source DTO plus derived validation warnings.
+/// </summary>
+public sealed record PrivateAssetReadModelDto(
+    PrivateAssetDto Asset,
+    IReadOnlyList<PrivateAssetValidationWarningDto> Warnings,
+    DateTimeOffset RefreshedAtUtc);

--- a/src/Meridian.Contracts/README.md
+++ b/src/Meridian.Contracts/README.md
@@ -73,6 +73,8 @@ routes back to run continuity, ledger trial-balance, reconciliation, and Securit
 evidence. Keep these fields shared so browser, WPF, and service tests enforce the same publication,
 drilldown, and no-orphan-evidence rules.
 
+Private asset contracts provide shared DTOs for illiquid fund, venture, credit, real estate, direct company, collectible, operating-business, and other holdings. They keep imported statements, capital notices, K-1s, side letters, subscription documents, valuation memos, and commitment schedules as typed evidence links so browser, WPF, persistence, and reporting surfaces do not fall back to unstructured notes. The read models carry server-derived warnings for stale NAV, missing valuation date, missing owner entity, missing commitment schedule, and missing evidence.
+
 Fund-structure contracts include the ledger mapping workbench payload used by accounting and
 governance surfaces to show account-to-ledger-group assignment source, unresolved mapping issues,
 and recommended operator action without requiring clients to duplicate mapping precedence rules.

--- a/tests/Meridian.Tests/PrivateAssets/PrivateAssetReadModelStoreTests.cs
+++ b/tests/Meridian.Tests/PrivateAssets/PrivateAssetReadModelStoreTests.cs
@@ -1,0 +1,210 @@
+using FluentAssertions;
+using Meridian.Application.PrivateAssets;
+using Meridian.Contracts.PrivateAssets;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Meridian.Tests.PrivateAssets;
+
+public sealed class PrivateAssetReadModelStoreTests
+{
+    [Fact]
+    public async Task InMemoryStore_ProjectsPrivateAssetReadModel_WithTypedEvidenceAndNoWarnings()
+    {
+        var store = new InMemoryPrivateAssetReadModelStore(new PrivateAssetReadModelValidator(staleNavDays: 120));
+        var asset = BuildAsset(
+            evidenceLinks:
+            [
+                new PrivateAssetEvidenceLinkDto(
+                    PrivateAssetEvidenceKindDto.ImportedStatement,
+                    "statement-2026-q1",
+                    "Q1 imported capital account statement",
+                    "vault://private-assets/statement-2026-q1",
+                    new DateOnly(2026, 4, 15)),
+                new PrivateAssetEvidenceLinkDto(
+                    PrivateAssetEvidenceKindDto.CapitalNotice,
+                    "capital-notice-2026-05",
+                    "May 2026 capital call notice",
+                    "vault://private-assets/capital-notice-2026-05",
+                    new DateOnly(2026, 5, 1)),
+                new PrivateAssetEvidenceLinkDto(
+                    PrivateAssetEvidenceKindDto.K1,
+                    "k1-2025",
+                    "2025 K-1",
+                    "vault://private-assets/k1-2025",
+                    new DateOnly(2026, 3, 15)),
+                new PrivateAssetEvidenceLinkDto(
+                    PrivateAssetEvidenceKindDto.SideLetter,
+                    "side-letter",
+                    "Most favored nation side letter",
+                    "vault://private-assets/side-letter",
+                    new DateOnly(2024, 1, 15)),
+                new PrivateAssetEvidenceLinkDto(
+                    PrivateAssetEvidenceKindDto.SubscriptionDocument,
+                    "subscription-docs",
+                    "Executed subscription package",
+                    "vault://private-assets/subscription-docs",
+                    new DateOnly(2024, 1, 10)),
+                new PrivateAssetEvidenceLinkDto(
+                    PrivateAssetEvidenceKindDto.ValuationMemo,
+                    "valuation-memo-q1",
+                    "Q1 valuation memo",
+                    "vault://private-assets/valuation-memo-q1",
+                    new DateOnly(2026, 4, 20))
+            ],
+            commitmentSchedule:
+            [
+                new PrivateAssetCommitmentScheduleEntryDto(new DateOnly(2026, 6, 30), 250_000m, "USD", "Expected Q2 call", "capital-notice-2026-05")
+            ]);
+
+        await store.UpsertAsync(asset, new DateOnly(2026, 5, 29));
+
+        var readModel = await store.GetAsync("pa-001", new DateOnly(2026, 5, 29));
+
+        readModel.Should().NotBeNull();
+        readModel!.Asset.AssetType.Should().Be(PrivateAssetTypeDto.PrivateEquityFund);
+        readModel.Asset.EvidenceLinks.Select(static link => link.Kind).Should().Contain([
+            PrivateAssetEvidenceKindDto.ImportedStatement,
+            PrivateAssetEvidenceKindDto.CapitalNotice,
+            PrivateAssetEvidenceKindDto.K1,
+            PrivateAssetEvidenceKindDto.SideLetter,
+            PrivateAssetEvidenceKindDto.SubscriptionDocument,
+            PrivateAssetEvidenceKindDto.ValuationMemo]);
+        readModel.Warnings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task InMemoryStore_EmitsValidationWarnings_ForMissingAndStalePrivateAssetInputs()
+    {
+        var store = new InMemoryPrivateAssetReadModelStore(new PrivateAssetReadModelValidator(staleNavDays: 120));
+        var asset = BuildAsset(
+            owningEntityId: " ",
+            valuationDate: new DateOnly(2025, 12, 31),
+            evidenceLinks: [],
+            commitmentSchedule: []);
+
+        await store.UpsertAsync(asset, new DateOnly(2026, 5, 29));
+
+        var readModel = await store.GetAsync("pa-001", new DateOnly(2026, 5, 29));
+
+        readModel.Should().NotBeNull();
+        readModel!.Warnings.Select(static warning => warning.Code).Should().Contain([
+            PrivateAssetValidationWarningCodeDto.StaleNav,
+            PrivateAssetValidationWarningCodeDto.MissingOwnerEntity,
+            PrivateAssetValidationWarningCodeDto.MissingCommitmentSchedule,
+            PrivateAssetValidationWarningCodeDto.MissingEvidence]);
+        readModel.Warnings.Should().NotContain(static warning => warning.Code == PrivateAssetValidationWarningCodeDto.MissingValuationDate);
+    }
+
+    [Fact]
+    public void Validator_EmitsMissingValuationDateWarning_WhenNavDateIsAbsent()
+    {
+        var validator = new PrivateAssetReadModelValidator(staleNavDays: 120);
+        var asset = BuildAsset(valuationDate: null) with { ValuationDate = null };
+
+        var warnings = validator.Validate(asset, new DateOnly(2026, 5, 29));
+
+        warnings.Select(static warning => warning.Code).Should().Contain(PrivateAssetValidationWarningCodeDto.MissingValuationDate);
+        warnings.Select(static warning => warning.Code).Should().NotContain(PrivateAssetValidationWarningCodeDto.StaleNav);
+    }
+
+    [Fact]
+    public async Task FileStore_PersistsAndFiltersReadModels_ByOwningEntity()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "meridian-private-assets-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var store = new FilePrivateAssetReadModelStore(
+                root,
+                NullLogger<FilePrivateAssetReadModelStore>.Instance,
+                new PrivateAssetReadModelValidator(staleNavDays: 120));
+            await store.UpsertAsync(BuildAsset(privateAssetId: "pa-001", assetName: "Alpha PE", owningEntityId: "entity-a"), new DateOnly(2026, 5, 29));
+            await store.UpsertAsync(BuildAsset(privateAssetId: "pa-002", assetName: "Beta VC", owningEntityId: "entity-b", assetType: PrivateAssetTypeDto.VentureFund), new DateOnly(2026, 5, 29));
+
+            var reloaded = new FilePrivateAssetReadModelStore(
+                root,
+                NullLogger<FilePrivateAssetReadModelStore>.Instance,
+                new PrivateAssetReadModelValidator(staleNavDays: 120));
+
+            var rows = await reloaded.ListAsync("entity-b", new DateOnly(2026, 5, 29));
+
+            rows.Should().ContainSingle();
+            rows[0].Asset.PrivateAssetId.Should().Be("pa-002");
+            rows[0].Asset.AssetType.Should().Be(PrivateAssetTypeDto.VentureFund);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task InMemoryStore_PropagatesCancellation_BeforeMutation()
+    {
+        var store = new InMemoryPrivateAssetReadModelStore();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var act = () => store.UpsertAsync(BuildAsset(), new DateOnly(2026, 5, 29), cts.Token);
+
+        act.Should().Throw<OperationCanceledException>();
+        var rows = await store.ListAsync(asOfDate: new DateOnly(2026, 5, 29));
+        rows.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void PrivateAssetTypeCatalog_CoversSupportedPrivateAssetTypes()
+    {
+        Enum.GetNames<PrivateAssetTypeDto>().Should().BeEquivalentTo([
+            nameof(PrivateAssetTypeDto.PrivateEquityFund),
+            nameof(PrivateAssetTypeDto.VentureFund),
+            nameof(PrivateAssetTypeDto.PrivateCredit),
+            nameof(PrivateAssetTypeDto.RealEstate),
+            nameof(PrivateAssetTypeDto.DirectCompanyInvestment),
+            nameof(PrivateAssetTypeDto.Collectible),
+            nameof(PrivateAssetTypeDto.OperatingBusiness),
+            nameof(PrivateAssetTypeDto.Other)]);
+    }
+
+    private static PrivateAssetDto BuildAsset(
+        string privateAssetId = "pa-001",
+        string assetName = "Alpha PE Fund I",
+        PrivateAssetTypeDto assetType = PrivateAssetTypeDto.PrivateEquityFund,
+        string? owningEntityId = "entity-a",
+        DateOnly? valuationDate = null,
+        IReadOnlyList<PrivateAssetEvidenceLinkDto>? evidenceLinks = null,
+        IReadOnlyList<PrivateAssetCommitmentScheduleEntryDto>? commitmentSchedule = null)
+        => new(
+            PrivateAssetId: privateAssetId,
+            AssetName: assetName,
+            AssetType: assetType,
+            OwningEntityId: owningEntityId,
+            ManagerOrSponsor: "Alpha Sponsor",
+            CommitmentAmount: 1_000_000m,
+            CalledCapital: 600_000m,
+            UnfundedCommitment: 400_000m,
+            DistributionsToDate: 125_000m,
+            LatestNav: 750_000m,
+            ValuationDate: valuationDate ?? new DateOnly(2026, 3, 31),
+            ValuationSource: "Manager statement",
+            IRR: 0.124m,
+            MOIC: 1.35m,
+            TVPI: 1.46m,
+            DPI: 0.21m,
+            Currency: "USD",
+            EvidenceLinks: evidenceLinks ??
+            [
+                new PrivateAssetEvidenceLinkDto(
+                    PrivateAssetEvidenceKindDto.ValuationMemo,
+                    "valuation-memo-q1",
+                    "Q1 valuation memo",
+                    "vault://private-assets/valuation-memo-q1",
+                    new DateOnly(2026, 4, 20))
+            ],
+            CommitmentSchedule: commitmentSchedule ??
+            [
+                new PrivateAssetCommitmentScheduleEntryDto(new DateOnly(2026, 6, 30), 250_000m, "USD", "Expected Q2 call", "valuation-memo-q1")
+            ]);
+}


### PR DESCRIPTION
### Motivation
- Provide shared, typed DTOs and read-model support for private assets so UI and services can treat imported statements, capital notices, K‑1s, side letters, subscription docs, valuation memos, and commitment schedules as structured evidence rather than free‑form notes. 
- Surface deterministic validation warnings for stale NAV, missing valuation date, missing owning entity, missing commitment schedule, and missing evidence so operator surfaces can show actionable readiness signals.

### Description
- Added contract DTOs and enums in `src/Meridian.Contracts/PrivateAssets/` including `PrivateAssetDto`, `PrivateAssetEvidenceLinkDto`, `PrivateAssetCommitmentScheduleEntryDto`, `PrivateAssetReadModelDto`, `PrivateAssetTypeDto`, `PrivateAssetEvidenceKindDto`, and `PrivateAssetValidationWarningCodeDto`. 
- Added JSON source-generation context `PrivateAssetContractsJsonContext` for the new DTOs. 
- Implemented a read-model validator and stores in `src/Meridian.Application/PrivateAssets/PrivateAssetReadModelStore.cs` including `PrivateAssetReadModelValidator`, `InMemoryPrivateAssetReadModelStore`, and `FilePrivateAssetReadModelStore` that use atomic writes, cancellation checks, owner filtering, and skip-on-corrupt-file behavior. 
- Added focused tests under `tests/Meridian.Tests/PrivateAssets/PrivateAssetReadModelStoreTests.cs` covering evidence categorization, warning projection (stale/missing valuation), missing-owner/commitment/evidence warnings, file persistence and filtering by owner, cancellation propagation, and the asset-type catalog. 
- Updated nearby READMEs to document the new Contracts and Application ownership/responsibilities for private-asset DTOs and read-model validation.

### Testing
- Attempted to run the focused unit test filter `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj -c Release --filter FullyQualifiedName~PrivateAssetReadModelStoreTests`, but the `dotnet` SDK is not available in this execution environment so the test run could not be executed. 
- Ran `python3 build/scripts/docs/mark-stale-docs.py --write --summary` which marked affected source README entries as stale for review and succeeded. 
- Ran `python3 build/scripts/docs/validate-source-readmes.py --summary` which passed. 
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary` which failed due to repository-wide source/readme hash drift (the touched READMEs were updated and the global hash manifest needs refresh after review). 
- Ran `git diff --check` which reported no diff-check issues. 
- Executed the implementation-assurance rubric via `python3 .codex/skills/meridian-implementation-assurance/scripts/score_eval.py` with a recommended score profile and recorded a pass at 9/10 with the open follow-up to run the .NET tests in a proper .NET 10 SDK environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19e3aff4c08320a6b06f9d6e599fe6)