### PR TITLE
Wire W4 acceptance filter into pilot readiness artifacts

### DIFF
--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -78,7 +78,9 @@ evidence hash, retained manifest metadata, and retained evidence links for every
 provenance pointer so browser and WPF clients do not invent local lifecycle or no-orphan-evidence
 rules. The shared W4 acceptance filter keeps governed report-pack acceptance evidence separate from
 evidence-vault manifest/export support so pilot readiness cannot mark W4 done from support
-artifacts alone. The shared fund-structure endpoints expose report-pack workflow creation,
+artifacts alone, and pilot artifacts should pass through that filter before serialization so the
+`GovernedReportPack` stage gate reflects the shared acceptance/support split. The shared
+fund-structure endpoints expose report-pack workflow creation,
 validation, submission, approval, review rejection, publication, restatement, history, and archival
 routes backed by shared contracts; review rejection records the reason, actor/role metadata, and
 optional evidence links, and rejected packs must return through draft, validation, submission, and

--- a/src/Meridian.Ui.Shared/Services/Acceptance/W4AcceptanceFilter.cs
+++ b/src/Meridian.Ui.Shared/Services/Acceptance/W4AcceptanceFilter.cs
@@ -56,6 +56,18 @@ public sealed class W4AcceptanceFilter
             BuildDetail(status, missingAcceptance, missingSupport, supportEvidence.Length));
     }
 
+    public PilotReadinessArtifactDto ApplyToArtifact(PilotReadinessArtifactDto artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var evaluation = Evaluate(artifact);
+        return artifact with
+        {
+            StageGates = ApplyToGovernedReportPackGate(artifact.StageGates, evaluation),
+            W4Acceptance = evaluation
+        };
+    }
+
     public PilotReadinessStageGateDto ApplyToGovernedReportPackGate(
         PilotReadinessStageGateDto gate,
         PilotW4AcceptanceEvaluationDto evaluation)

--- a/tests/Meridian.Tests/Integration/EndpointTests/PilotAcceptanceHarnessTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/PilotAcceptanceHarnessTests.cs
@@ -181,10 +181,8 @@ public sealed class PilotAcceptanceHarnessTests
             reportPack.ReportId.ToString("D"),
             reportPack.Artifacts);
         var w4Filter = pilot.App.Services.GetRequiredService<W4AcceptanceFilter>();
-        var w4Acceptance = w4Filter.Evaluate(w4Evidence);
-        w4Acceptance.IsDone.Should().BeTrue();
 
-        var stageGates = w4Filter.ApplyToGovernedReportPackGate(BuildPilotStageGates(
+        var stageGates = BuildPilotStageGates(
             seed,
             promotion.AuditReference,
             session.SessionId,
@@ -193,7 +191,7 @@ public sealed class PilotAcceptanceHarnessTests
             continuity.Run.Summary.RunId,
             portfolioEvidenceId!,
             ledgerEvidenceId!,
-            reportPack.ReportId.ToString("D")), w4Acceptance);
+            reportPack.ReportId.ToString("D"));
         var evidenceGraph = BuildPilotEvidenceGraph(
             seed,
             promotion.AuditReference,
@@ -207,7 +205,7 @@ public sealed class PilotAcceptanceHarnessTests
             .Concat(BuildW4AcceptanceGraph(workflow, reconciliation.Summary.ReconciliationRunId))
             .ToArray();
 
-        var artifact = new PilotReadinessArtifactDto(
+        var artifact = w4Filter.ApplyToArtifact(new PilotReadinessArtifactDto(
             GeneratedAtUtc: DateTimeOffset.UtcNow,
             ProviderEvidenceId: FeedEvidenceId,
             DatasetEvidenceId: DatasetEvidenceId,
@@ -226,9 +224,10 @@ public sealed class PilotAcceptanceHarnessTests
             EvidenceGraph: evidenceGraph)
         {
             LedgerArtifactRefs = ledgerArtifactRefs,
-            W4Evidence = w4Evidence,
-            W4Acceptance = w4Acceptance
-        };
+            W4Evidence = w4Evidence
+        });
+        artifact.W4Acceptance.Should().NotBeNull();
+        artifact.W4Acceptance!.IsDone.Should().BeTrue();
 
         var artifactPath = await WritePilotReadinessArtifactAsync(artifact);
         var markdownPath = Path.Combine(Path.GetDirectoryName(artifactPath)!, "pilot-readiness.md");
@@ -312,6 +311,52 @@ public sealed class PilotAcceptanceHarnessTests
         gate.Status.Should().Be(PilotReadinessStageStatusDto.ReviewRequired);
         gate.EvidenceIds.Should().BeEmpty("support manifests are not W4 acceptance evidence");
         gate.SupportEvidenceIds.Should().Contain("evidence-vault/pilot-report/manifest.json");
+    }
+
+    [Fact]
+    public void W4AcceptanceFilter_ArtifactPathSupportEvidenceOnly_DemotesGovernedReportPackGate()
+    {
+        var filter = new W4AcceptanceFilter();
+        var supportOnly = new[]
+        {
+            new PilotAcceptanceEvidenceDto(
+                PilotAcceptanceEvidenceCategoryDto.EvidenceVaultManifestExportSupport,
+                PilotAcceptanceEvidenceRoleDto.Support,
+                "evidence-vault/pilot-report/manifest.json",
+                "Evidence-vault retained manifest")
+        };
+
+        var artifact = filter.ApplyToArtifact(CreatePilotReadinessArtifact(
+            [CreateGovernedReportPackGate()],
+            supportOnly));
+
+        artifact.AllStagesReady.Should().BeFalse();
+        artifact.W4Acceptance.Should().NotBeNull();
+        artifact.W4Acceptance!.IsDone.Should().BeFalse();
+        var governedReportPackGate = artifact.StageGates.Should().ContainSingle().Which;
+        governedReportPackGate.Status.Should().Be(PilotReadinessStageStatusDto.ReviewRequired);
+        governedReportPackGate.EvidenceIds.Should().BeEmpty("support evidence must not be promoted into the acceptance evidence lane");
+        governedReportPackGate.SupportEvidenceIds.Should().Contain("evidence-vault/pilot-report/manifest.json");
+    }
+
+    [Theory]
+    [MemberData(nameof(MissingEndToEndAcceptanceEvidence))]
+    public void W4AcceptanceFilter_MissingEndToEndAcceptanceCategory_CannotReportDone(
+        PilotAcceptanceEvidenceCategoryDto missingCategory)
+    {
+        var filter = new W4AcceptanceFilter();
+        var evidence = CreateCompleteW4Evidence()
+            .Where(item => item.Category != missingCategory)
+            .ToArray();
+
+        var evaluation = filter.Evaluate(evidence);
+        var gate = filter.ApplyToGovernedReportPackGate(CreateGovernedReportPackGate(), evaluation);
+
+        evaluation.IsDone.Should().BeFalse();
+        evaluation.Status.Should().Be(PilotReadinessStageStatusDto.ReviewRequired);
+        evaluation.MissingAcceptanceCategories.Should().Contain(missingCategory);
+        gate.Status.Should().Be(PilotReadinessStageStatusDto.ReviewRequired);
+        gate.Blockers.Should().Contain(blocker => blocker.Contains(missingCategory.ToString(), StringComparison.Ordinal));
     }
 
     [Fact]
@@ -759,6 +804,9 @@ public sealed class PilotAcceptanceHarnessTests
         new($"approval/{workflow.ReportId:D}", $"publication/{workflow.ReportId:D}", "published-by")
     ];
 
+    public static IEnumerable<object[]> MissingEndToEndAcceptanceEvidence =>
+        W4AcceptanceFilter.RequiredAcceptanceCategories.Select(category => new object[] { category });
+
     private static IReadOnlyList<PilotAcceptanceEvidenceDto> CreateCompleteW4Evidence() =>
     [
         new(PilotAcceptanceEvidenceCategoryDto.ReconciliationCasework, PilotAcceptanceEvidenceRoleDto.Acceptance, "casework/recon-run-001", "Reconciliation casework"),
@@ -768,6 +816,30 @@ public sealed class PilotAcceptanceHarnessTests
         new(PilotAcceptanceEvidenceCategoryDto.RestatementReadiness, PilotAcceptanceEvidenceRoleDto.Acceptance, "restatement-ready/report-pack-001", "Restatement readiness"),
         new(PilotAcceptanceEvidenceCategoryDto.EvidenceVaultManifestExportSupport, PilotAcceptanceEvidenceRoleDto.Support, "evidence-vault/report-pack-001/manifest.json", "Manifest/export support")
     ];
+
+    private static PilotReadinessArtifactDto CreatePilotReadinessArtifact(
+        IReadOnlyList<PilotReadinessStageGateDto> stageGates,
+        IReadOnlyList<PilotAcceptanceEvidenceDto> w4Evidence) =>
+        new(
+            GeneratedAtUtc: DateTimeOffset.Parse("2026-04-11T16:00:00Z"),
+            ProviderEvidenceId: FeedEvidenceId,
+            DatasetEvidenceId: DatasetEvidenceId,
+            ResearchRunId: "backtest-run-001",
+            ComparedRunIds: ["backtest-run-001", "paper-run-001"],
+            PromotionAuditId: "promotion-audit-001",
+            PaperSessionId: "paper-session-001",
+            ReplayVerificationAuditId: "replay-verification-001",
+            ReconciliationRunId: "recon-run-001",
+            ContinuityRunId: "continuity-run-001",
+            PortfolioEvidenceId: "portfolio-evidence-001",
+            LedgerEvidenceId: "ledger-evidence-001",
+            ReportPackId: "report-pack-001",
+            ReportPackRelatedRunIds: ["backtest-run-001", "paper-run-001"],
+            StageGates: stageGates,
+            EvidenceGraph: [])
+        {
+            W4Evidence = w4Evidence
+        };
 
     private static PilotReadinessStageGateDto CreateGovernedReportPackGate() =>
         new(


### PR DESCRIPTION
### Motivation
- Ensure the W4 (governance) acceptance path treats evidence-vault manifest/export items as supporting artifacts rather than acceptance evidence so `GovernedReportPack` readiness cannot be marked Done from support-only artifacts.
- Centralize the W4 evaluation so pilot readiness artifacts are produced from the same shared acceptance rules used by server readiness projections.

### Description
- Added `PilotReadinessArtifactDto ApplyToArtifact(PilotReadinessArtifactDto)` to `W4AcceptanceFilter` so artifacts are evaluated and the `GovernedReportPack` gate receives separated `EvidenceIds` (acceptance) and `SupportEvidenceIds` (support).
- Updated the pilot acceptance harness in `PilotAcceptanceHarnessTests.cs` to pass the assembled `PilotReadinessArtifactDto` through the shared `W4AcceptanceFilter` before serialization and assertions.
- Added tests that assert support-only evidence does not report Done and that missing any required end-to-end acceptance category prevents reporting Done, plus a theory enumerating required acceptance categories to validate gaps.
- Documented the expectation in `src/Meridian.Ui.Shared/README.md` that pilot artifacts should pass through the shared W4 filter so the `GovernedReportPack` stage reflects the acceptance/support split.

### Testing
- Ran `git diff --check` which returned no new whitespace/format issues for the touched files.
- Ran `python3 build/scripts/docs/validate-source-readmes.py --summary` which passed for source READMEs.
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary` which reported pre-existing repository-wide documentation hash drift unrelated to this change (validation failed because many modules are already out-of-sync).
- Attempted to run `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~PilotAcceptanceHarnessTests" --logger "console;verbosity=normal"` but the `dotnet` SDK was not available in the execution environment so the integration tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19e3a637dc832089e030f5f3aa42b8)