### PR TITLE
Add explicit report-pack Rejected model, Reject API and review-state reject flow

### DIFF
--- a/src/Meridian.Contracts/README.md
+++ b/src/Meridian.Contracts/README.md
@@ -60,8 +60,9 @@ provenance exists but approved identity or accounting mapping proof is still mis
 Report-pack workflow contracts carry the W4 governed lifecycle states `Draft`, `InReview`,
 `Approved`, and `Published` plus governed publication metadata: sign-off actor, evidence hash,
 retained manifest path, retained evidence links, report-line provenance, create requests, publish
-requests, explicit rejection requests with reason, actor/role, and optional evidence-link metadata,
-and restatement requests with approver, prior-version, changed-line, and evidence-link metadata.
+requests, explicit `Rejected` state support, explicit review-state rejection requests with reason,
+actor/role, and optional evidence-link metadata, and restatement requests with approver,
+prior-version, changed-line, and evidence-link metadata.
 Pilot readiness contracts also carry W4 acceptance evidence categories and roles so acceptance proof
 can be distinguished from evidence-vault manifest/export support in serialized artifacts.
 Report-line provenance carries the reported value plus run, source-session, ledger-entry,

--- a/src/Meridian.Contracts/Workstation/FundOperationsWorkspaceDtos.cs
+++ b/src/Meridian.Contracts/Workstation/FundOperationsWorkspaceDtos.cs
@@ -429,6 +429,7 @@ public enum ReportPackWorkflowStateDto
     Published = 4,
     Restated = 5,
     Archived = 6,
+    /// <summary>Reviewer-returned report pack that must be resubmitted before approval and publication.</summary>
     Rejected = 7,
     PendingApproval = 8
 }
@@ -465,6 +466,7 @@ public sealed record ReportPackPublicationManifestDto(
     string SignedOffBy,
     DateTimeOffset SignedOffAt,
     IReadOnlyList<ReportPackEvidenceLinkDto> EvidenceLinks);
+/// <summary>Request payload for publishing an approved report pack into retained evidence storage.</summary>
 public sealed record ReportPackPublishRequestDto(
     string SignedOffBy,
     string EvidenceHash,
@@ -472,6 +474,7 @@ public sealed record ReportPackPublishRequestDto(
     string RetainedManifestPath,
     IReadOnlyList<ReportPackEvidenceLinkDto> EvidenceLinks,
     string? Note = null);
+/// <summary>Request payload for rejecting an in-review report pack with reviewer metadata and supporting evidence.</summary>
 public sealed record ReportPackRejectRequestDto(
     string Reason,
     string Actor,
@@ -483,12 +486,14 @@ public sealed record ReportPackCreateRequestDto(
     string Period,
     VersionedReportTemplateIdDto TemplateId,
     IReadOnlyList<ReportPackLineProvenanceDto>? LineProvenance = null);
+/// <summary>Durable metadata captured when a published report pack is restated.</summary>
 public sealed record ReportPackRestatementMetadataDto(
     string ReasonCode,
     string Approver,
     Guid PriorVersionReportId,
     IReadOnlyList<ReportPackChangedLineDto> ChangedLines,
     IReadOnlyList<ReportPackEvidenceLinkDto>? EvidenceLinks = null);
+/// <summary>Durable rejection decision retained on a report pack after review-state rejection.</summary>
 public sealed record ReportPackRejectionMetadataDto(
     string Reason,
     string Actor,

--- a/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
@@ -739,6 +739,7 @@ public static class FundStructureEndpoints
             }
         })
         .WithName("RejectReportingPackWorkflow")
+        .Accepts<ReportPackRejectRequestDto>("application/json")
         .Produces<ReportPackWorkflowRecordDto>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status400BadRequest)
         .Produces(StatusCodes.Status401Unauthorized)

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -80,10 +80,10 @@ rules. The shared W4 acceptance filter keeps governed report-pack acceptance evi
 evidence-vault manifest/export support so pilot readiness cannot mark W4 done from support
 artifacts alone. The shared fund-structure endpoints expose report-pack workflow creation,
 validation, submission, approval, review rejection, publication, restatement, history, and archival
-routes backed by shared contracts; review rejection records the reason, actor/role metadata, and
-optional evidence links, and rejected packs must return through draft, validation, submission, and
-approval before publication. Restatement changed lines must carry evidence links before the workflow
-can advance. Publication also rejects line provenance that omits the reported value or lacks a run,
+routes backed by shared contracts; review rejection is valid from `InReview`, records the reason,
+actor/role metadata, and optional evidence links, and rejected packs must return through draft,
+submission, and approval before publication. Restatement changed lines must carry evidence links before
+the workflow can advance. Publication also rejects line provenance that omits the reported value or lacks a run,
 source-session, ledger-entry, reconciliation-case, or reconciliation-run pointer, and each retained
 line must carry ledger, provider-event, Security Master definition, reconciliation-outcome, and
 approval references before publication. That keeps value-level report lineage enforceable in the

--- a/src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs
@@ -34,8 +34,8 @@ public sealed class ReportPackWorkflowService
         {
             [ReportPackWorkflowStateDto.Draft] = [ReportPackWorkflowStateDto.InReview, ReportPackWorkflowStateDto.Validated],
             [ReportPackWorkflowStateDto.Validated] = [ReportPackWorkflowStateDto.InReview, ReportPackWorkflowStateDto.PendingApproval, ReportPackWorkflowStateDto.Draft],
-            [ReportPackWorkflowStateDto.InReview] = [ReportPackWorkflowStateDto.Approved, ReportPackWorkflowStateDto.PendingApproval, ReportPackWorkflowStateDto.Draft],
-            [ReportPackWorkflowStateDto.PendingApproval] = [ReportPackWorkflowStateDto.Approved, ReportPackWorkflowStateDto.Rejected, ReportPackWorkflowStateDto.Draft],
+            [ReportPackWorkflowStateDto.InReview] = [ReportPackWorkflowStateDto.Approved, ReportPackWorkflowStateDto.PendingApproval, ReportPackWorkflowStateDto.Rejected, ReportPackWorkflowStateDto.Draft],
+            [ReportPackWorkflowStateDto.PendingApproval] = [ReportPackWorkflowStateDto.Approved, ReportPackWorkflowStateDto.Draft],
             [ReportPackWorkflowStateDto.Rejected] = [ReportPackWorkflowStateDto.Draft],
             [ReportPackWorkflowStateDto.Approved] = [ReportPackWorkflowStateDto.Published],
             [ReportPackWorkflowStateDto.Published] = [ReportPackWorkflowStateDto.Restated, ReportPackWorkflowStateDto.Archived],

--- a/tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs
@@ -278,8 +278,7 @@ public sealed class ReportPackWorkflowServiceTests
     {
         var svc = new ReportPackWorkflowService();
         var created = svc.Create("fund-a", "acct-1", "2026-03", new VersionedReportTemplateIdDto("board-pack", 1), "author");
-        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Validated, "reviewer", "reviewer");
-        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.PendingApproval, "reviewer", "reviewer");
+        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.InReview, "reviewer", "reviewer");
 
         var rejected = svc.Reject(
             created.ReportId,
@@ -310,8 +309,7 @@ public sealed class ReportPackWorkflowServiceTests
 
         if (startingState == ReportPackWorkflowStateDto.Published)
         {
-            svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Validated, "reviewer", "reviewer");
-            svc.Transition(created.ReportId, ReportPackWorkflowStateDto.PendingApproval, "reviewer", "reviewer");
+            svc.Transition(created.ReportId, ReportPackWorkflowStateDto.InReview, "reviewer", "reviewer");
             svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Approved, "approver", "approver");
             svc.Publish(
                 created.ReportId,
@@ -335,8 +333,7 @@ public sealed class ReportPackWorkflowServiceTests
     {
         var svc = new ReportPackWorkflowService();
         var created = svc.Create("fund-a", "acct-1", "2026-03", new VersionedReportTemplateIdDto("board-pack", 1), "author");
-        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Validated, "reviewer", "reviewer");
-        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.PendingApproval, "reviewer", "reviewer");
+        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.InReview, "reviewer", "reviewer");
 
         Action act = () => svc.Reject(created.ReportId, "needs reviewer remediation", "operator", "operator");
 
@@ -349,15 +346,14 @@ public sealed class ReportPackWorkflowServiceTests
     {
         var svc = new ReportPackWorkflowService();
         var created = svc.Create("fund-a", "acct-1", "2026-03", new VersionedReportTemplateIdDto("board-pack", 1), "author");
-        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Validated, "reviewer", "reviewer");
-        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.PendingApproval, "reviewer", "reviewer");
+        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.InReview, "reviewer", "reviewer");
 
         var rejected = svc.Reject(created.ReportId, "missing controller sign-off evidence", "senior-reviewer", "reviewer");
 
         rejected.AuditTrail.Should().ContainSingle(entry =>
             entry.Actor == "senior-reviewer" &&
             entry.Action == "rejected" &&
-            entry.FromState == ReportPackWorkflowStateDto.PendingApproval &&
+            entry.FromState == ReportPackWorkflowStateDto.InReview &&
             entry.ToState == ReportPackWorkflowStateDto.Rejected &&
             entry.Note == "missing controller sign-off evidence");
     }
@@ -367,8 +363,7 @@ public sealed class ReportPackWorkflowServiceTests
     {
         var svc = new ReportPackWorkflowService();
         var created = svc.Create("fund-a", "acct-1", "2026-03", new VersionedReportTemplateIdDto("board-pack", 1), "author");
-        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Validated, "reviewer", "reviewer");
-        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.PendingApproval, "reviewer", "reviewer");
+        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.InReview, "reviewer", "reviewer");
         svc.Reject(created.ReportId, "missing controller sign-off evidence", "senior-reviewer", "reviewer");
 
         Action publishRejected = () => svc.Publish(
@@ -385,8 +380,7 @@ public sealed class ReportPackWorkflowServiceTests
             .WithMessage("invalid transition Rejected -> Published");
 
         svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Draft, "author", "operator");
-        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Validated, "reviewer", "reviewer");
-        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.PendingApproval, "reviewer", "reviewer");
+        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.InReview, "reviewer", "reviewer");
         svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Approved, "approver", "approver");
         var published = svc.Publish(
             created.ReportId,


### PR DESCRIPTION
### Motivation

- Make report-pack rejection an explicit, first-class part of the W4 lifecycle so review rejections carry structured metadata and prevent accidental publication until resubmitted. 
- Keep the contract-owned rejection vocabulary and endpoint-level audit metadata aligned so both browser and WPF surfaces, and service tests, use the same semantics.

### Description

- Add documentation and XML summaries for the `Rejected` lifecycle and rejection payloads in `src/Meridian.Contracts/Workstation/FundOperationsWorkspaceDtos.cs` and expose durable `ReportPackRejectionMetadataDto` and `ReportPackRejectRequestDto` semantics. 
- Permit reviewer rejection directly from the review state by updating the allowed transitions in `src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs` so `InReview` -> `Rejected` is valid and `Rejected` must be resubmitted through draft/review/approval before publish. 
- Keep/implement `Reject(...)` overloads that validate reason/actor/role, append an audit event, and store normalized evidence links in `ReportPackWorkflowRecordDto` in `src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs`. 
- Expose the reject route and request shape in `src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs` by accepting `ReportPackRejectRequestDto` at `/reporting/packs/{reportId:guid}/reject` and wiring actor/role resolution. 
- Update tests in `tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs` and module READMEs (`src/Meridian.Contracts/README.md`, `src/Meridian.Ui.Shared/README.md`) to reflect the explicit `Rejected` state and `InReview`-only reject behavior.

### Testing

- Ran `git diff --check` which reported no problems for the changed files. 
- Attempted `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter FullyQualifiedName~ReportPackWorkflowServiceTests /p:EnableWindowsTargeting=true`, but execution was blocked because `dotnet` is not available in this environment. 
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary` which surfaced pre-existing repository-wide source/README hash drift (many modules) including the touched contract module; this is a known docs-hash gate that requires follow-up review before refreshing the manifest. 
- Unit tests in `tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs` were updated to cover: rejection from review, rejection forbidden from draft/published states, invalid-role rejection, audit-trail contents after reject, and preventing publish for rejected records until resubmitted through the lifecycle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19e3a2884083209b31d0c49ab5e6fd)