### PR TITLE
Add ReportPackRestatementRequestDto and enforce restatement validation; update endpoint and tests

### DIFF
--- a/src/Meridian.Contracts/README.md
+++ b/src/Meridian.Contracts/README.md
@@ -61,7 +61,7 @@ Report-pack workflow contracts carry the W4 governed lifecycle states `Draft`, `
 `Approved`, and `Published` plus governed publication metadata: sign-off actor, evidence hash,
 retained manifest path, retained evidence links, report-line provenance, create requests, publish
 requests, explicit rejection requests with reason, actor/role, and optional evidence-link metadata,
-and restatement requests with approver, prior-version, changed-line, and evidence-link metadata.
+and restatement requests with reason, approver, prior-version, corrected-version, changed-section, changed-line, and evidence-link metadata.
 Pilot readiness contracts also carry W4 acceptance evidence categories and roles so acceptance proof
 can be distinguished from evidence-vault manifest/export support in serialized artifacts.
 Report-line provenance carries the reported value plus run, source-session, ledger-entry,

--- a/src/Meridian.Contracts/Workstation/FundOperationsWorkspaceDtos.cs
+++ b/src/Meridian.Contracts/Workstation/FundOperationsWorkspaceDtos.cs
@@ -483,12 +483,22 @@ public sealed record ReportPackCreateRequestDto(
     string Period,
     VersionedReportTemplateIdDto TemplateId,
     IReadOnlyList<ReportPackLineProvenanceDto>? LineProvenance = null);
-public sealed record ReportPackRestatementMetadataDto(
-    string ReasonCode,
-    string Approver,
+public sealed record ReportPackRestatementRequestDto(
+    string Reason,
     Guid PriorVersionReportId,
+    Guid CorrectedVersionReportId,
+    IReadOnlyList<string> ChangedSections,
     IReadOnlyList<ReportPackChangedLineDto> ChangedLines,
-    IReadOnlyList<ReportPackEvidenceLinkDto>? EvidenceLinks = null);
+    string Approver,
+    IReadOnlyList<ReportPackEvidenceLinkDto> EvidenceLinks);
+public sealed record ReportPackRestatementMetadataDto(
+    string Reason,
+    Guid PriorVersionReportId,
+    Guid CorrectedVersionReportId,
+    IReadOnlyList<string> ChangedSections,
+    IReadOnlyList<ReportPackChangedLineDto> ChangedLines,
+    string Approver,
+    IReadOnlyList<ReportPackEvidenceLinkDto> EvidenceLinks);
 public sealed record ReportPackRejectionMetadataDto(
     string Reason,
     string Actor,

--- a/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
@@ -6,6 +6,7 @@ using Meridian.Contracts.Workstation;
 using Meridian.Ui.Shared.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
 
@@ -815,7 +816,7 @@ public static class FundStructureEndpoints
 
         group.MapPost("/reporting/packs/{reportId:guid}/archive", (Guid reportId, HttpContext context) => TransitionPack(context, reportId, ReportPackWorkflowStateDto.Archived));
 
-        group.MapPost("/reporting/packs/{reportId:guid}/restate", (Guid reportId, string reasonCode, Guid priorVersionReportId, ReportPackChangedLineDto[] changedLines, HttpContext context) =>
+        group.MapPost("/reporting/packs/{reportId:guid}/restate", (Guid reportId, [FromBody] ReportPackRestatementRequestDto request, HttpContext context) =>
         {
             if (!HasReportingWorkflowPermission(context))
             {
@@ -835,7 +836,7 @@ public static class FundStructureEndpoints
 
             try
             {
-                return Results.Json(svc.Restate(reportId, actor, role, reasonCode, actor, priorVersionReportId, changedLines), jsonOptions);
+                return Results.Json(svc.Restate(reportId, actor, role, request), jsonOptions);
             }
             catch (Exception ex) when (ex is ArgumentException or UnauthorizedAccessException or InvalidOperationException or KeyNotFoundException)
             {

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -82,8 +82,10 @@ artifacts alone. The shared fund-structure endpoints expose report-pack workflow
 validation, submission, approval, review rejection, publication, restatement, history, and archival
 routes backed by shared contracts; review rejection records the reason, actor/role metadata, and
 optional evidence links, and rejected packs must return through draft, validation, submission, and
-approval before publication. Restatement changed lines must carry evidence links before the workflow
-can advance. Publication also rejects line provenance that omits the reported value or lacks a run,
+approval before publication. Restatement requests must provide a reason, prior-version report id,
+corrected-version report id, changed sections, changed lines, approver, and retained evidence links;
+restatement changed lines must carry evidence links before the workflow can advance. Publication
+also rejects line provenance that omits the reported value or lacks a run,
 source-session, ledger-entry, reconciliation-case, or reconciliation-run pointer, and each retained
 line must carry ledger, provider-event, Security Master definition, reconciliation-outcome, and
 approval references before publication. That keeps value-level report lineage enforceable in the

--- a/src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs
@@ -116,11 +116,54 @@ public sealed class ReportPackWorkflowService
         return Reject(reportId, request.Reason, request.Actor, request.ActorRole, request.EvidenceLinks);
     }
 
-    public ReportPackWorkflowRecordDto Restate(Guid reportId, string actor, string role, string reasonCode, string approver, Guid priorVersionReportId, IReadOnlyList<ReportPackChangedLineDto> changedLines)
+    public ReportPackWorkflowRecordDto Restate(Guid reportId, string actor, string role, ReportPackRestatementRequestDto request)
     {
-        if (string.IsNullOrWhiteSpace(reasonCode)) throw new ArgumentException("reasonCode is required");
-        if (changedLines.Count == 0) throw new ArgumentException("changedLines are required");
-        var linesWithoutEvidence = changedLines
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Reason);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Approver);
+        if (request.PriorVersionReportId == Guid.Empty)
+        {
+            throw new ArgumentException("priorVersionReportId is required", nameof(request));
+        }
+
+        if (request.CorrectedVersionReportId == Guid.Empty)
+        {
+            throw new ArgumentException("correctedVersionReportId is required", nameof(request));
+        }
+
+        ArgumentNullException.ThrowIfNull(request.ChangedSections);
+        ArgumentNullException.ThrowIfNull(request.ChangedLines);
+        ArgumentNullException.ThrowIfNull(request.EvidenceLinks);
+        var changedSections = request.ChangedSections
+            .Where(static section => !string.IsNullOrWhiteSpace(section))
+            .Select(static section => section.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (changedSections.Length == 0)
+        {
+            throw new ArgumentException("changedSections are required", nameof(request));
+        }
+
+        if (request.ChangedLines.Count == 0)
+        {
+            throw new ArgumentException("changedLines are required", nameof(request));
+        }
+
+        var evidenceLinks = NormalizeEvidenceLinks(request.EvidenceLinks);
+        if (evidenceLinks.Count == 0)
+        {
+            throw new ArgumentException("Restatement requires evidence links.", nameof(request));
+        }
+
+        var normalizedChangedLines = request.ChangedLines
+            .Select(static line => line with
+            {
+                LineKey = line.LineKey?.Trim() ?? string.Empty,
+                PreviousValue = line.PreviousValue?.Trim() ?? string.Empty,
+                CurrentValue = line.CurrentValue?.Trim() ?? string.Empty
+            })
+            .ToArray();
+        var linesWithoutEvidence = normalizedChangedLines
             .Where(static line => line.EvidenceLinks is null || line.EvidenceLinks.Count == 0 || line.EvidenceLinks.All(static link => string.IsNullOrWhiteSpace(link.EvidenceId)))
             .Select(static line => line.LineKey)
             .ToArray();
@@ -129,19 +172,49 @@ public sealed class ReportPackWorkflowService
             throw new ArgumentException($"Restatement changed lines require evidence links: {string.Join(", ", linesWithoutEvidence)}.");
         }
 
-        var transitioned = Transition(reportId, ReportPackWorkflowStateDto.Restated, actor, role, note: reasonCode);
-        var evidenceLinks = changedLines
-            .SelectMany(static line => line.EvidenceLinks ?? [])
-            .GroupBy(static link => link.EvidenceId, StringComparer.OrdinalIgnoreCase)
-            .Select(static group => group.First())
-            .ToArray();
+        var reason = request.Reason.Trim();
+        var transitioned = Transition(reportId, ReportPackWorkflowStateDto.Restated, actor, role, note: reason);
         var next = transitioned with
         {
             Version = transitioned.Version + 1,
-            Restatement = new ReportPackRestatementMetadataDto(reasonCode, approver, priorVersionReportId, changedLines, evidenceLinks)
+            Restatement = new ReportPackRestatementMetadataDto(
+                reason,
+                request.PriorVersionReportId,
+                request.CorrectedVersionReportId,
+                changedSections,
+                normalizedChangedLines,
+                request.Approver.Trim(),
+                evidenceLinks)
         };
         _records[reportId] = next;
         return next;
+    }
+
+    public ReportPackWorkflowRecordDto Restate(
+        Guid reportId,
+        string actor,
+        string role,
+        string reasonCode,
+        string approver,
+        Guid priorVersionReportId,
+        IReadOnlyList<ReportPackChangedLineDto> changedLines)
+    {
+        var evidenceLinks = changedLines
+            .SelectMany(static line => line.EvidenceLinks ?? [])
+            .ToArray();
+
+        return Restate(
+            reportId,
+            actor,
+            role,
+            new ReportPackRestatementRequestDto(
+                reasonCode,
+                priorVersionReportId,
+                reportId,
+                changedLines.Select(static line => line.LineKey).Where(static lineKey => !string.IsNullOrWhiteSpace(lineKey)).ToArray(),
+                changedLines,
+                approver,
+                evidenceLinks));
     }
 
     public ReportPackWorkflowRecordDto Publish(

--- a/tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs
@@ -1,6 +1,16 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
 using FluentAssertions;
+using Meridian.Contracts.Auth;
 using Meridian.Contracts.Workstation;
+using Meridian.Ui.Shared.Endpoints;
 using Meridian.Ui.Shared.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Meridian.Tests.Ui;
 
@@ -402,60 +412,92 @@ public sealed class ReportPackWorkflowServiceTests
     }
 
     [Fact]
-    public void Restate_RequiresLineageAndReasonMetadata()
+    public void Restate_PublishedPackWithCompleteRequest_RetainsRestatementMetadata()
     {
         var svc = new ReportPackWorkflowService();
-        var created = svc.Create("fund-a", "acct-1", "2026-03", new VersionedReportTemplateIdDto("board-pack", 1), "author");
-        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.InReview, "reviewer", "reviewer");
-        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Approved, "approver", "approver");
-        svc.Publish(
-            created.ReportId,
-            "publisher",
-            "publisher",
-            "controller",
-            "sha256:abc123",
-            "manifest-1",
-            "vault/report-packs/manifest-1.json",
-            [new ReportPackEvidenceLinkDto("report-pack-1", "Report pack manifest", "/evidence/report-pack-1", "reporting")]);
+        var created = CreatePublishedPack(svc);
+        var correctedReportId = Guid.NewGuid();
+        var request = CompleteRestatementRequest(created.ReportId, correctedReportId);
 
-        var restated = svc.Restate(created.ReportId, "approver", "approver", "pricing-correction", "chief-approver", created.ReportId,
-            [new ReportPackChangedLineDto("line-1", "100", "125", [new ReportPackEvidenceLinkDto("pricing-evidence-1", "Pricing correction", "/evidence/pricing-evidence-1", "pricing")])]);
+        var restated = svc.Restate(created.ReportId, "approver", "approver", request);
 
         restated.State.Should().Be(ReportPackWorkflowStateDto.Restated);
-        restated.Restatement.Should().NotBeNull();
-        restated.Restatement!.ChangedLines.Should().ContainSingle();
-        restated.Restatement.EvidenceLinks.Should().ContainSingle(link => link.EvidenceId == "pricing-evidence-1");
         restated.Version.Should().Be(2);
+        restated.Restatement.Should().BeEquivalentTo(new ReportPackRestatementMetadataDto(
+            "pricing-correction",
+            created.ReportId,
+            correctedReportId,
+            ["NAV", "Trial balance"],
+            request.ChangedLines,
+            "chief-approver",
+            request.EvidenceLinks));
+    }
+
+    [Fact]
+    public void Restate_PublishedPackWithoutCorrectedVersion_RejectsRequest()
+    {
+        var svc = new ReportPackWorkflowService();
+        var created = CreatePublishedPack(svc);
+        var request = CompleteRestatementRequest(created.ReportId, Guid.Empty);
+
+        Action act = () => svc.Restate(created.ReportId, "approver", "approver", request);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("correctedVersionReportId is required*");
+    }
+
+    [Fact]
+    public void Restate_PublishedPackWithoutChangedSections_RejectsRequest()
+    {
+        var svc = new ReportPackWorkflowService();
+        var created = CreatePublishedPack(svc);
+        var request = CompleteRestatementRequest(created.ReportId, Guid.NewGuid()) with { ChangedSections = [] };
+
+        Action act = () => svc.Restate(created.ReportId, "approver", "approver", request);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("changedSections are required*");
     }
 
     [Fact]
     public void Restate_RejectsChangedLinesWithoutEvidenceLinks()
     {
         var svc = new ReportPackWorkflowService();
-        var created = svc.Create("fund-a", "acct-1", "2026-03", new VersionedReportTemplateIdDto("board-pack", 1), "author");
-        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.InReview, "reviewer", "reviewer");
-        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Approved, "approver", "approver");
-        svc.Publish(
-            created.ReportId,
-            "publisher",
-            "publisher",
-            "controller",
-            "sha256:abc123",
-            "manifest-1",
-            "vault/report-packs/manifest-1.json",
-            [new ReportPackEvidenceLinkDto("report-pack-1", "Report pack manifest", "/evidence/report-pack-1", "reporting")]);
+        var created = CreatePublishedPack(svc);
+        var request = CompleteRestatementRequest(created.ReportId, Guid.NewGuid()) with
+        {
+            ChangedLines = [new ReportPackChangedLineDto("line-1", "100", "125")]
+        };
 
-        Action act = () => svc.Restate(
-            created.ReportId,
-            "approver",
-            "approver",
-            "pricing-correction",
-            "chief-approver",
-            created.ReportId,
-            [new ReportPackChangedLineDto("line-1", "100", "125")]);
+        Action act = () => svc.Restate(created.ReportId, "approver", "approver", request);
 
         act.Should().Throw<ArgumentException>()
             .WithMessage("Restatement changed lines require evidence links: line-1.");
+    }
+
+    [Fact]
+    public async Task Endpoint_RestateRequestBody_EnforcesPermissionAndWorkflowRoleValidation()
+    {
+        var svc = new ReportPackWorkflowService();
+        var created = CreatePublishedPack(svc);
+        var request = CompleteRestatementRequest(created.ReportId, Guid.NewGuid());
+
+        await using var forbiddenApp = await CreateReportingEndpointAppAsync(svc, UserRole.ReadOnly, UserPermission.ViewAnalytics);
+        var forbidden = await forbiddenApp.GetTestClient().PostAsJsonAsync(
+            $"/api/fund-structure/reporting/packs/{created.ReportId:D}/restate",
+            request,
+            JsonOptions);
+        forbidden.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        await using var roleMismatchApp = await CreateReportingEndpointAppAsync(svc, UserRole.Accounting, UserPermission.ManageStrategies);
+        var roleMismatch = await roleMismatchApp.GetTestClient().PostAsJsonAsync(
+            $"/api/fund-structure/reporting/packs/{created.ReportId:D}/restate",
+            request,
+            JsonOptions);
+        roleMismatch.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await roleMismatch.Content.ReadFromJsonAsync<Dictionary<string, JsonElement>>(JsonOptions);
+        problem.Should().NotBeNull();
+        problem!["detail"].GetString().Should().Be("Role 'Accounting' cannot transition to Restated.");
     }
 
     [Fact]
@@ -488,6 +530,63 @@ public sealed class ReportPackWorkflowServiceTests
             entry.FromState == ReportPackWorkflowStateDto.Published &&
             entry.ToState == ReportPackWorkflowStateDto.Archived);
     }
+
+    private static ReportPackWorkflowRecordDto CreatePublishedPack(ReportPackWorkflowService svc)
+    {
+        var created = svc.Create("fund-a", "acct-1", "2026-03", new VersionedReportTemplateIdDto("board-pack", 1), "author");
+        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.InReview, "reviewer", "reviewer");
+        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Approved, "approver", "approver");
+        return svc.Publish(
+            created.ReportId,
+            "publisher",
+            "publisher",
+            "controller",
+            "sha256:abc123",
+            "manifest-1",
+            "vault/report-packs/manifest-1.json",
+            [new ReportPackEvidenceLinkDto("report-pack-1", "Report pack manifest", "/evidence/report-pack-1", "reporting")]);
+    }
+
+    private static ReportPackRestatementRequestDto CompleteRestatementRequest(Guid priorVersionReportId, Guid correctedVersionReportId) =>
+        new(
+            "pricing-correction",
+            priorVersionReportId,
+            correctedVersionReportId,
+            ["NAV", "Trial balance"],
+            [new ReportPackChangedLineDto(
+                "line-1",
+                "100",
+                "125",
+                [new ReportPackEvidenceLinkDto("pricing-evidence-1", "Pricing correction", "/evidence/pricing-evidence-1", "pricing")])],
+            "chief-approver",
+            [new ReportPackEvidenceLinkDto("approval-evidence-1", "Restatement approval", "/evidence/approval-evidence-1", "approval")]);
+
+    private static async Task<WebApplication> CreateReportingEndpointAppAsync(
+        ReportPackWorkflowService svc,
+        UserRole role,
+        UserPermission permissions)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development
+        });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton(svc);
+
+        var app = builder.Build();
+        app.Use(async (context, next) =>
+        {
+            context.Items[LoginSessionMiddleware.CurrentUserKey] = "endpoint-user";
+            context.Items[LoginSessionMiddleware.CurrentUserRoleKey] = role;
+            context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] = permissions;
+            await next();
+        });
+        app.MapFundStructureEndpoints(JsonOptions);
+        await app.StartAsync();
+        return app;
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     private static ReportPackWorkflowRecordDto CreateApprovedPack(
         ReportPackWorkflowService svc,


### PR DESCRIPTION
### Motivation
- Capture richer restatement intent and provenance by introducing a request DTO that includes reason, prior/corrected report ids, changed sections, changed lines, approver, and evidence links.  
- Preserve the same required restatement fields on persisted workflow records so restatement metadata is durable and queryable.  
- Ensure the HTTP endpoint accepts an explicit body DTO and that the workflow service validates required fields and actor/role permissions before transitioning a published pack to `Restated`.

### Description
- Added `ReportPackRestatementRequestDto` and expanded `ReportPackRestatementMetadataDto` with fields `Reason`, `PriorVersionReportId`, `CorrectedVersionReportId`, `ChangedSections`, `ChangedLines`, `Approver`, and `EvidenceLinks` in `src/Meridian.Contracts/Workstation/FundOperationsWorkspaceDtos.cs`.  
- Updated the singular endpoint `/api/fund-structure/reporting/packs/{reportId:guid}/restate` to bind the new request DTO from the request body and pass it into `ReportPackWorkflowService.Restate` in `src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs`.  
- Reworked `ReportPackWorkflowService.Restate` in `src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs` to accept the new request DTO, normalize inputs, and validate non-empty `Reason`, `Approver`, `PriorVersionReportId`, `CorrectedVersionReportId`, `ChangedSections`, `ChangedLines`, and retained `EvidenceLinks`, and to enforce per-line evidence links.  
- Added unit/endpoint tests in `tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs` covering a complete restatement request, missing corrected version, missing changed sections, changed-line evidence validation, and endpoint permission/role validation, and added test helpers for published-pack setup and request construction.  
- Updated `src/Meridian.Contracts/README.md` and `src/Meridian.Ui.Shared/README.md` to document the expanded restatement contract and endpoint expectations.

### Testing
- Ran `git diff --check` which produced no whitespace or diff-check errors and passed.  
- Attempted to run the focused tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ReportPackWorkflowServiceTests" /p:EnableWindowsTargeting=true --logger "console;verbosity=normal"` but the host environment does not have `dotnet` available so the test run could not be executed.  
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary` which executed but reported repository-wide source/README hash drift (existing broad doc-hash failures, including the touched `src/Meridian.Contracts` and `src/Meridian.Ui.Shared` modules) that should be reviewed as part of doc-hash alignment.  
- New tests were added and are present in-tree but their execution and compilation verification remain unvalidated in this environment due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19e3a173cc8320849ba201849e9318)