### PR TITLE
Enforce calculation-note on ReportPackLineProvenance and tighten publication validation

### DIFF
--- a/src/Meridian.Contracts/README.md
+++ b/src/Meridian.Contracts/README.md
@@ -64,8 +64,8 @@ requests, explicit rejection requests with reason, actor/role, and optional evid
 and restatement requests with approver, prior-version, changed-line, and evidence-link metadata.
 Pilot readiness contracts also carry W4 acceptance evidence categories and roles so acceptance proof
 can be distinguished from evidence-vault manifest/export support in serialized artifacts.
-Report-line provenance carries the reported value plus run, source-session, ledger-entry,
-provider-event, Security Master definition, reconciliation-case, reconciliation-run,
+Report-line provenance carries the reported value plus calculation note, run, source-session,
+ledger-entry, provider-event, Security Master definition, reconciliation-case, reconciliation-run,
 reconciliation-outcome, and approval pointers so each retained line can be traced back to the source
 workflow evidence before publication. Generated report-pack lineage pointers also carry optional display labels, source-system
 tags, related ledger or journal evidence IDs, line amounts, latest evidence timestamps, and API

--- a/src/Meridian.Contracts/Workstation/FundOperationsWorkspaceDtos.cs
+++ b/src/Meridian.Contracts/Workstation/FundOperationsWorkspaceDtos.cs
@@ -447,6 +447,7 @@ public sealed record ReportPackLineProvenanceDto(
     string SourceKind,
     string SourceId,
     string EvidenceId,
+    string? CalculationNote = null,
     string? RunId = null,
     string? LedgerEntryId = null,
     string? ReconciliationCaseId = null,

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -83,7 +83,8 @@ validation, submission, approval, review rejection, publication, restatement, hi
 routes backed by shared contracts; review rejection records the reason, actor/role metadata, and
 optional evidence links, and rejected packs must return through draft, validation, submission, and
 approval before publication. Restatement changed lines must carry evidence links before the workflow
-can advance. Publication also rejects line provenance that omits the reported value or lacks a run,
+can advance. Publication also rejects line provenance that omits the reported value or calculation note, fails
+to name the report line/source/evidence identifiers during normalization, or lacks a run,
 source-session, ledger-entry, reconciliation-case, or reconciliation-run pointer, and each retained
 line must carry ledger, provider-event, Security Master definition, reconciliation-outcome, and
 approval references before publication. That keeps value-level report lineage enforceable in the

--- a/src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs
@@ -170,8 +170,14 @@ public sealed class ReportPackWorkflowService
             throw new KeyNotFoundException("report pack not found");
         }
 
+        var normalizedEvidenceLinks = NormalizeEvidenceLinks(evidenceLinks);
+        if (normalizedEvidenceLinks.Count == 0)
+        {
+            throw new ArgumentException("Publication requires retained evidence links.", nameof(evidenceLinks));
+        }
+
         EnsureLineProvenanceTraceable(record.LineProvenance ?? []);
-        EnsureNoOrphanEvidence(record.LineProvenance ?? [], evidenceLinks);
+        EnsureNoOrphanEvidence(record.LineProvenance ?? [], normalizedEvidenceLinks);
         var transitioned = TransitionCore(reportId, ReportPackWorkflowStateDto.Published, actor, role, note);
         var next = transitioned with
         {
@@ -181,7 +187,7 @@ public sealed class ReportPackWorkflowService
                 evidenceHash.Trim(),
                 signedOffBy.Trim(),
                 DateTimeOffset.UtcNow,
-                NormalizeEvidenceLinks(evidenceLinks))
+                normalizedEvidenceLinks)
         };
         _records[reportId] = next;
         return next;
@@ -211,19 +217,37 @@ public sealed class ReportPackWorkflowService
         if (!allowed) throw new UnauthorizedAccessException($"Role '{role}' cannot transition to {target}.");
     }
 
-    private static IReadOnlyList<ReportPackLineProvenanceDto> NormalizeLineProvenance(IReadOnlyList<ReportPackLineProvenanceDto>? lineProvenance) =>
-        lineProvenance?
-            .Where(static item =>
-                !string.IsNullOrWhiteSpace(item.LineKey) &&
-                !string.IsNullOrWhiteSpace(item.SourceKind) &&
-                !string.IsNullOrWhiteSpace(item.SourceId) &&
-                !string.IsNullOrWhiteSpace(item.EvidenceId))
+    private static IReadOnlyList<ReportPackLineProvenanceDto> NormalizeLineProvenance(IReadOnlyList<ReportPackLineProvenanceDto>? lineProvenance)
+    {
+        if (lineProvenance is null || lineProvenance.Count == 0)
+        {
+            return [];
+        }
+
+        var invalidLines = lineProvenance
+            .Select(static (item, index) => new
+            {
+                DisplayKey = string.IsNullOrWhiteSpace(item.LineKey) ? $"entry #{index + 1}" : item.LineKey.Trim(),
+                MissingFields = MissingRequiredLineProvenanceFields(item).ToArray()
+            })
+            .Where(static item => item.MissingFields.Length > 0)
+            .Select(static item => $"{item.DisplayKey} ({string.Join(", ", item.MissingFields)})")
+            .ToArray();
+        if (invalidLines.Length > 0)
+        {
+            throw new ArgumentException(
+                $"Report pack line provenance requires report line, source kind, source ID, evidence ID, and calculation note: {string.Join("; ", invalidLines)}.",
+                nameof(lineProvenance));
+        }
+
+        return lineProvenance
             .Select(static item => item with
             {
                 LineKey = item.LineKey.Trim(),
                 SourceKind = item.SourceKind.Trim(),
                 SourceId = item.SourceId.Trim(),
                 EvidenceId = item.EvidenceId.Trim(),
+                CalculationNote = item.CalculationNote!.Trim(),
                 RunId = string.IsNullOrWhiteSpace(item.RunId) ? null : item.RunId.Trim(),
                 LedgerEntryId = string.IsNullOrWhiteSpace(item.LedgerEntryId) ? null : item.LedgerEntryId.Trim(),
                 ReconciliationCaseId = string.IsNullOrWhiteSpace(item.ReconciliationCaseId) ? null : item.ReconciliationCaseId.Trim(),
@@ -236,7 +260,36 @@ public sealed class ReportPackWorkflowService
                 ReconciliationOutcome = string.IsNullOrWhiteSpace(item.ReconciliationOutcome) ? null : item.ReconciliationOutcome.Trim(),
                 ApprovalId = string.IsNullOrWhiteSpace(item.ApprovalId) ? null : item.ApprovalId.Trim()
             })
-            .ToArray() ?? [];
+            .ToArray();
+    }
+
+    private static IEnumerable<string> MissingRequiredLineProvenanceFields(ReportPackLineProvenanceDto item)
+    {
+        if (string.IsNullOrWhiteSpace(item.LineKey))
+        {
+            yield return "report line";
+        }
+
+        if (string.IsNullOrWhiteSpace(item.SourceKind))
+        {
+            yield return "source kind";
+        }
+
+        if (string.IsNullOrWhiteSpace(item.SourceId))
+        {
+            yield return "source ID";
+        }
+
+        if (string.IsNullOrWhiteSpace(item.EvidenceId))
+        {
+            yield return "evidence ID";
+        }
+
+        if (string.IsNullOrWhiteSpace(item.CalculationNote))
+        {
+            yield return "calculation note";
+        }
+    }
 
     private static IReadOnlyList<ReportPackEvidenceLinkDto> NormalizeEvidenceLinks(IReadOnlyList<ReportPackEvidenceLinkDto> evidenceLinks) =>
         evidenceLinks
@@ -266,6 +319,17 @@ public sealed class ReportPackWorkflowService
         {
             throw new InvalidOperationException(
                 $"Report pack line provenance requires report values for: {string.Join(", ", missingValues.Order(StringComparer.OrdinalIgnoreCase))}.");
+        }
+
+        var missingCalculationNotes = lineProvenance
+            .Where(static line => string.IsNullOrWhiteSpace(line.CalculationNote))
+            .Select(static line => line.LineKey)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (missingCalculationNotes.Length > 0)
+        {
+            throw new InvalidOperationException(
+                $"Report pack line provenance requires calculation notes for: {string.Join(", ", missingCalculationNotes.Order(StringComparer.OrdinalIgnoreCase))}.");
         }
 
         var missingSourcePointers = lineProvenance

--- a/tests/Meridian.Tests/Application/Services/FundOperationsWorkspaceReadServiceTests.cs
+++ b/tests/Meridian.Tests/Application/Services/FundOperationsWorkspaceReadServiceTests.cs
@@ -179,9 +179,18 @@ public sealed class FundOperationsWorkspaceReadServiceTests
                     "ledger",
                     "ledger-entry-1",
                     "evidence-ledger-1",
+                    CalculationNote: "NAV total ties to the retained ledger entry and matched reconciliation evidence.",
                     RunId: "run-restatement-1",
                     LedgerEntryId: "ledger-entry-1",
-                    ReportValue: "1250000")
+                    ReconciliationCaseId: "case-restatement-1",
+                    ReportValue: "1250000",
+                    SourceSessionId: "session-restatement-1",
+                    ReconciliationRunId: "recon-run-restatement-1",
+                    ProviderEventId: "provider-event-restatement-1",
+                    SecurityMasterId: "security-master-nav",
+                    SecurityDefinitionId: "security-definition-nav",
+                    ReconciliationOutcome: "matched",
+                    ApprovalId: "approval-restatement-1")
             ]);
         workflowService.Transition(report.ReportId, ReportPackWorkflowStateDto.Validated, "reviewer", "reviewer");
         workflowService.Transition(report.ReportId, ReportPackWorkflowStateDto.PendingApproval, "reviewer", "reviewer");

--- a/tests/Meridian.Tests/Integration/EndpointTests/PilotAcceptanceHarnessTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/PilotAcceptanceHarnessTests.cs
@@ -687,6 +687,7 @@ public sealed class PilotAcceptanceHarnessTests
                 "ledger",
                 ledgerEvidenceId,
                 ledgerEvidenceId,
+                CalculationNote: "Cash trial-balance line uses retained ledger evidence matched to reconciliation casework before pilot publication.",
                 RunId: seed.PaperRunId,
                 LedgerEntryId: ledgerEvidenceId,
                 ReconciliationCaseId: $"casework/{reconciliationRunId}",

--- a/tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs
@@ -89,6 +89,53 @@ public sealed class ReportPackWorkflowServiceTests
     }
 
     [Fact]
+    public void Create_RejectsIncompleteLineProvenanceInsteadOfDroppingEntries()
+    {
+        var svc = new ReportPackWorkflowService();
+
+        Action missingLine = () => svc.Create(
+            "fund-a",
+            "acct-1",
+            "2026-03",
+            new VersionedReportTemplateIdDto("board-pack", 1),
+            "author",
+            [CompleteLineProvenance(" ", "ledger-evidence-1")]);
+
+        Action missingSourceId = () => svc.Create(
+            "fund-a",
+            "acct-1",
+            "2026-03",
+            new VersionedReportTemplateIdDto("board-pack", 1),
+            "author",
+            [CompleteLineProvenance("trial-balance.cash", "ledger-evidence-1") with { SourceId = " " }]);
+
+        Action missingEvidenceId = () => svc.Create(
+            "fund-a",
+            "acct-1",
+            "2026-03",
+            new VersionedReportTemplateIdDto("board-pack", 1),
+            "author",
+            [CompleteLineProvenance("trial-balance.cash", " ")]);
+
+        Action missingCalculationNote = () => svc.Create(
+            "fund-a",
+            "acct-1",
+            "2026-03",
+            new VersionedReportTemplateIdDto("board-pack", 1),
+            "author",
+            [CompleteLineProvenance("trial-balance.cash", "ledger-evidence-1") with { CalculationNote = " " }]);
+
+        missingLine.Should().Throw<ArgumentException>()
+            .WithMessage("Report pack line provenance requires report line, source kind, source ID, evidence ID, and calculation note: entry #1 (report line).*");
+        missingSourceId.Should().Throw<ArgumentException>()
+            .WithMessage("Report pack line provenance requires report line, source kind, source ID, evidence ID, and calculation note: trial-balance.cash (source ID).*");
+        missingEvidenceId.Should().Throw<ArgumentException>()
+            .WithMessage("Report pack line provenance requires report line, source kind, source ID, evidence ID, and calculation note: trial-balance.cash (evidence ID).*");
+        missingCalculationNote.Should().Throw<ArgumentException>()
+            .WithMessage("Report pack line provenance requires report line, source kind, source ID, evidence ID, and calculation note: trial-balance.cash (calculation note).*");
+    }
+
+    [Fact]
     public void Publish_RequiresReportValueAndSourcePointerForLineProvenance()
     {
         var svc = new ReportPackWorkflowService();
@@ -98,7 +145,7 @@ public sealed class ReportPackWorkflowServiceTests
             "2026-03",
             new VersionedReportTemplateIdDto("board-pack", 1),
             "author",
-            [new ReportPackLineProvenanceDto("trial-balance.cash", "ledger", "ledger-entry-1", "ledger-evidence-1", LedgerEntryId: "ledger-entry-1")]);
+            [new ReportPackLineProvenanceDto("trial-balance.cash", "ledger", "ledger-entry-1", "ledger-evidence-1", CalculationNote: "Ledger cash subtotal ties to journal entry ledger-entry-1.", LedgerEntryId: "ledger-entry-1")]);
         svc.Transition(missingValue.ReportId, ReportPackWorkflowStateDto.InReview, "reviewer", "reviewer");
         svc.Transition(missingValue.ReportId, ReportPackWorkflowStateDto.Approved, "approver", "approver");
 
@@ -121,7 +168,7 @@ public sealed class ReportPackWorkflowServiceTests
             "2026-03",
             new VersionedReportTemplateIdDto("board-pack", 1),
             "author",
-            [new ReportPackLineProvenanceDto("trial-balance.nav", "report", "nav-line-1", "nav-evidence-1", ReportValue: "125.00")]);
+            [new ReportPackLineProvenanceDto("trial-balance.nav", "report", "nav-line-1", "nav-evidence-1", CalculationNote: "NAV line copied from approved report worksheet.", ReportValue: "125.00")]);
         svc.Transition(missingPointer.ReportId, ReportPackWorkflowStateDto.InReview, "reviewer", "reviewer");
         svc.Transition(missingPointer.ReportId, ReportPackWorkflowStateDto.Approved, "approver", "approver");
 
@@ -208,13 +255,19 @@ public sealed class ReportPackWorkflowServiceTests
             [new ReportPackEvidenceLinkDto("ledger-evidence-1", "Line evidence", "/evidence/ledger-evidence-1", "reporting")]);
 
         var line = published.LineProvenance.Should().ContainSingle().Subject;
+        line.RunId.Should().Be("run-1");
         line.LedgerEntryId.Should().Be("ledger-entry-1");
+        line.ReconciliationCaseId.Should().Be("case-1");
+        line.EvidenceId.Should().Be("ledger-evidence-1");
+        line.CalculationNote.Should().Be("trial-balance.cash uses retained ledger and reconciliation support from ledger-evidence-1.");
         line.ProviderEventId.Should().Be("provider-event-1");
         line.SecurityMasterId.Should().Be("security-1");
         line.SecurityDefinitionId.Should().Be("definition-1");
         line.ReconciliationRunId.Should().Be("recon-run-1");
         line.ReconciliationOutcome.Should().Be("matched");
         line.ApprovalId.Should().Be("approval-1");
+        published.Publication.Should().NotBeNull();
+        published.Publication!.EvidenceLinks.Should().ContainSingle(link => link.EvidenceId == line.EvidenceId);
         published.State.Should().Be(ReportPackWorkflowStateDto.Published);
     }
 
@@ -235,6 +288,7 @@ public sealed class ReportPackWorkflowServiceTests
                     " paper-session ",
                     " session-1 ",
                     " session-evidence-1 ",
+                    CalculationNote: " Trial balance NAV equals assets less liabilities after reconciliation. ",
                     RunId: " run-1 ",
                     ReportValue: " 125.00 ",
                     SourceSessionId: " paper-session-1 ",
@@ -252,6 +306,7 @@ public sealed class ReportPackWorkflowServiceTests
                 "paper-session",
                 "session-1",
                 "session-evidence-1",
+                CalculationNote: "Trial balance NAV equals assets less liabilities after reconciliation.",
                 RunId: "run-1",
                 ReportValue: "125.00",
                 SourceSessionId: "paper-session-1",
@@ -521,6 +576,7 @@ public sealed class ReportPackWorkflowServiceTests
             "ledger",
             "ledger-entry-1",
             evidenceId,
+            CalculationNote: $"{lineKey} uses retained ledger and reconciliation support from {evidenceId}.",
             RunId: "run-1",
             LedgerEntryId: "ledger-entry-1",
             ReconciliationCaseId: "case-1",


### PR DESCRIPTION
### Motivation

- Prevent silent dropping of incomplete provenance entries and ensure every retained report line carries an operator-readable `CalculationNote` alongside source/evidence pointers so publication lineage is traceable. 
- Surface validation errors early (during normalization/create) and require that publication evidence manifest contains all referenced line evidence IDs.

### Description

- Added a nullable `CalculationNote` field to `ReportPackLineProvenanceDto` in `src/Meridian.Contracts/Workstation/FundOperationsWorkspaceDtos.cs` and updated README docs to document the requirement. 
- Reworked `NormalizeLineProvenance` in `src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs` to reject incomplete entries (report line, source kind, source id, evidence id, or calculation note) with an `ArgumentException` and added `MissingRequiredLineProvenanceFields` to enumerate missing fields. 
- Extended `EnsureLineProvenanceTraceable` to enforce presence of `CalculationNote` per line and changed publication logic to normalize retained evidence links first, require the normalized list to be non-empty, and use it for orphan-evidence checks. 
- Added/updated tests in `tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs`, and updated related fixtures in `tests/Meridian.Tests/Application/Services/FundOperationsWorkspaceReadServiceTests.cs` and `tests/Meridian.Tests/Integration/EndpointTests/PilotAcceptanceHarnessTests.cs` to cover the new validation and successful publication scenarios that include run, ledger, reconciliation-case, evidence id, and calculation-note details.

### Testing

- `git diff --check` was run and returned clean results. 
- Attempted `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~ReportPackWorkflowServiceTests" --logger "console;verbosity=normal"`, but the command was blocked in this environment because `dotnet` is not installed (`/bin/bash: line 1: dotnet: command not found`).
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary` which reported repository-wide README/source hash drift (pre-existing across many modules, including the touched modules), so doc-hash alignment was not refreshed in this focused change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19e3a0cc7c832091ee9e70508db79e)