### PR TITLE
Improve family-office degraded guidance and consolidate evidence/reconciliation warnings

### DIFF
--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -30,7 +30,10 @@ compatibility across `src/Meridian.Ui.Services`, `src/Meridian.Ui/dashboard`, an
 ## Important workflows
 
 Preserve cross-surface compatibility when evolving shared read models. Keep ledger/reconciliation
-source-of-truth services authoritative. Workstation endpoint registration is split by domain through
+source-of-truth services authoritative. `FamilyOfficeReadService` composes the family-office
+workstation overview from fund-structure, fund-account, reconciliation, and strategy-run read
+services, and emits degraded guidance when linked accounts cannot provide balances, liabilities,
+reconciliation state, or evidence completeness. Workstation endpoint registration is split by domain through
 `WorkstationEndpoints.*.cs` partial files. Keep the root `WorkstationEndpoints.cs` file as the
 coordinator, route new domain-specific endpoint edits to the matching partial file, and avoid
 concurrent branches that both modify the root coordinator or the shared

--- a/src/Meridian.Ui.Shared/Services/FamilyOfficeReadService.cs
+++ b/src/Meridian.Ui.Shared/Services/FamilyOfficeReadService.cs
@@ -67,10 +67,16 @@ public sealed class FamilyOfficeReadService
         var ownershipGraph = BuildOwnershipGraph(relevant, asOfDate);
         var evidenceLinks = BuildStructureEvidenceLinks(relevant, asOfDate);
         var accountContexts = await BuildAccountContextsAsync(relevant.Accounts, generatedAt, ct).ConfigureAwait(false);
+        if (relevant.Accounts.Count > 0 && accountContexts.Count == 0)
+        {
+            warnings.Add("Family-office accounts are linked, but the fund-account read service is unavailable, so balances, cash, liabilities, reconciliation, and evidence completeness cannot be assembled.");
+        }
+
         var accounts = accountContexts.Select(static context => context.Summary).ToArray();
         var publicAssets = BuildPublicAssets(accountContexts, warnings);
         var privateAssets = BuildPrivateAssets(relevant, asOfDate, warnings);
         var commitments = BuildCommitments(relevant, asOfDate, warnings);
+        AddEvidenceAndReconciliationWarnings(accounts, publicAssets, privateAssets, commitments, warnings);
         var balanceSheet = BuildBalanceSheet(familyClient, accountContexts, privateAssets, commitments, warnings, generatedAt, asOfDate);
         var readiness = BuildReadiness(warnings, evidenceLinks, generatedAt, accounts, entities.Count, balanceSheet);
 
@@ -495,6 +501,30 @@ public sealed class FamilyOfficeReadService
             LastReviewedAtUtc: null)).ToArray();
     }
 
+    private static void AddEvidenceAndReconciliationWarnings(
+        IReadOnlyList<FamilyAccountSummaryDto> accounts,
+        IReadOnlyList<FamilyAssetSummaryDto> publicAssets,
+        IReadOnlyList<PrivateAssetSummaryDto> privateAssets,
+        IReadOnlyList<CapitalCommitmentDto> commitments,
+        List<string> warnings)
+    {
+        if (accounts.Any(static account => !account.ReconciliationStatus.Equals("Reconciled", StringComparison.OrdinalIgnoreCase))
+            || publicAssets.Any(static asset => !asset.ReconciliationStatus.Equals("Reconciled", StringComparison.OrdinalIgnoreCase))
+            || privateAssets.Any(static asset => !asset.ReconciliationStatus.Equals("Reconciled", StringComparison.OrdinalIgnoreCase))
+            || commitments.Any(static commitment => !commitment.ReconciliationStatus.Equals("Reconciled", StringComparison.OrdinalIgnoreCase)))
+        {
+            warnings.Add("One or more family-office values are unreconciled or have open reconciliation breaks.");
+        }
+
+        if (accounts.Any(static account => !account.EvidenceCompleteness.Equals("Complete", StringComparison.OrdinalIgnoreCase))
+            || publicAssets.Any(static asset => !asset.EvidenceCompleteness.Equals("Complete", StringComparison.OrdinalIgnoreCase))
+            || privateAssets.Any(static asset => !asset.EvidenceCompleteness.Equals("Complete", StringComparison.OrdinalIgnoreCase))
+            || commitments.Any(static commitment => !commitment.EvidenceCompleteness.Equals("Complete", StringComparison.OrdinalIgnoreCase)))
+        {
+            warnings.Add("One or more balances, asset marks, liabilities, commitments, or reconciliations are missing complete evidence.");
+        }
+    }
+
     private static FamilyBalanceSheetDto BuildBalanceSheet(
         ClientSummaryDto familyClient,
         IReadOnlyList<AccountContext> accounts,
@@ -516,15 +546,6 @@ public sealed class FamilyOfficeReadService
             warnings.Add("One or more account or asset values are stale compared with the current workstation date.");
         }
 
-        if (accounts.Any(static account => !account.Summary.ReconciliationStatus.Equals("Reconciled", StringComparison.OrdinalIgnoreCase)))
-        {
-            warnings.Add("One or more accounts are unreconciled or have open reconciliation breaks.");
-        }
-
-        if (accounts.Any(static account => !account.Summary.EvidenceCompleteness.Equals("Complete", StringComparison.OrdinalIgnoreCase)))
-        {
-            warnings.Add("One or more balances, valuations, or reconciliations are missing complete evidence.");
-        }
 
         return new FamilyBalanceSheetDto(
             FamilyOfficeId: familyClient.ClientId.ToString("D"),

--- a/tests/Meridian.Tests/Ui/FamilyOfficeReadServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/FamilyOfficeReadServiceTests.cs
@@ -90,6 +90,55 @@ public sealed class FamilyOfficeReadServiceTests
         Assert.Contains(overview.Readiness.Blockers, warning => warning.Contains("unreconciled", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public async Task GetOverviewAsync_WhenAccountsExistWithoutFundAccountReadService_ReturnsDegradedGuidance()
+    {
+        var fundAccounts = new InMemoryFundAccountService();
+        var fundStructure = new InMemoryFundStructureService(fundAccounts);
+        var now = DateTimeOffset.Parse("2026-05-29T12:00:00Z");
+        var organizationId = Guid.NewGuid();
+        var businessId = Guid.NewGuid();
+        var clientId = Guid.NewGuid();
+        var fundId = Guid.NewGuid();
+        var entityId = Guid.NewGuid();
+        var accountId = Guid.NewGuid();
+
+        await fundStructure.CreateOrganizationAsync(new CreateOrganizationRequest(
+            organizationId, "ORG", "Meridian Family Office", "USD", now.AddYears(-1), "test"), CancellationToken.None);
+        await fundStructure.CreateBusinessAsync(new CreateBusinessRequest(
+            businessId, organizationId, BusinessKindDto.Hybrid, "SFO", "SFO Advisers", "USD", now.AddYears(-1), "test"), CancellationToken.None);
+        await fundStructure.CreateClientAsync(new CreateClientRequest(
+            clientId, businessId, "FAM", "Founders Family", "USD", now.AddYears(-1), "test", ClientSegmentKind: ClientSegmentKind.FamilyOffice), CancellationToken.None);
+        await fundStructure.CreateFundAsync(new CreateFundRequest(
+            fundId, "FND", "Founders Holdings", "USD", now.AddYears(-1), "test", BusinessId: businessId), CancellationToken.None);
+        await fundStructure.CreateLegalEntityAsync(new CreateLegalEntityRequest(
+            entityId, LegalEntityTypeDto.LimitedPartner, "TRUST", "Founders Trust", "US-DE", "USD", now.AddYears(-1), "test"), CancellationToken.None);
+        await fundStructure.LinkNodesAsync(new LinkFundStructureNodesRequest(
+            Guid.NewGuid(), clientId, fundId, OwnershipRelationshipTypeDto.Owns, now.AddYears(-1), "test", OwnershipPercent: 100m), CancellationToken.None);
+        await fundStructure.LinkNodesAsync(new LinkFundStructureNodesRequest(
+            Guid.NewGuid(), fundId, entityId, OwnershipRelationshipTypeDto.Owns, now.AddYears(-1), "test", OwnershipPercent: 100m), CancellationToken.None);
+        await fundAccounts.CreateAccountAsync(new CreateAccountRequest(
+            accountId,
+            AccountTypeDto.Custody,
+            "CUST-1",
+            "Main Custody",
+            "USD",
+            now.AddYears(-1),
+            "test",
+            FundId: fundId,
+            EntityId: entityId,
+            Institution: "Test Custodian"), CancellationToken.None);
+
+        var service = new FamilyOfficeReadService(fundStructure, fundAccountService: null, timeProvider: new FixedTimeProvider(now));
+
+        var overview = await service.GetOverviewAsync(CancellationToken.None);
+
+        Assert.Equal("Degraded", overview.Readiness.Status);
+        Assert.Empty(overview.Accounts);
+        Assert.Contains(overview.Readiness.Blockers, warning => warning.Contains("fund-account read service is unavailable", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(overview.Readiness.Blockers, warning => warning.Contains("balances, cash, liabilities, reconciliation", StringComparison.OrdinalIgnoreCase));
+    }
+
     private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
     {
         public override DateTimeOffset GetUtcNow() => now;


### PR DESCRIPTION
### Motivation
- Ensure the family-office workstation read surface degrades clearly when linked accounts cannot be read so operators see explicit guidance rather than silent gaps.
- Surface consolidated reconciliation and evidence-completeness warnings across account, public/private asset, and commitment projections so readiness status is traceable to source seams.

### Description
- Add a missing-service degraded warning in `FamilyOfficeReadService` when the fund-structure graph links accounts but the fund-account read service returns no account contexts (`FamilyOfficeReadService` now adds a clear blocker message). 
- Introduce `AddEvidenceAndReconciliationWarnings` to consolidate and emit warnings when any account, public asset, private asset, or commitment is unreconciled or missing evidence, and call it during overview assembly.
- Keep balance-sheet assembly unchanged but rely on existing read seams for cash, marketable securities, liabilities, private marks, and unfunded commitments while using the new warnings to reflect degraded state.
- Document the composition seam and degraded guidance responsibility in `src/Meridian.Ui.Shared/README.md` and add a focused regression test `GetOverviewAsync_WhenAccountsExistWithoutFundAccountReadService_ReturnsDegradedGuidance` in `tests/Meridian.Tests/Ui/FamilyOfficeReadServiceTests.cs`.

### Testing
- Ran `git diff --check` and address-free diff check; result: passed.
- Ran the implementation-assurance rubric via `python3 .codex/skills/meridian-implementation-assurance/scripts/score_eval.py --scenario A ...` to capture evidence and scoring; result: pass (9/10) with a noted environment limitation.
- Attempted targeted xUnit run `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~FamilyOffice" --logger "console;verbosity=normal" /p:EnableWindowsTargeting=true` but the `dotnet` CLI is not available in this environment, so the unit tests could not be executed here; follow-up: run that command in a .NET-enabled environment to verify.
- Ran docs validation `python3 build/scripts/docs/mark-stale-docs.py --write --summary && python3 build/scripts/docs/validate-doc-hashes.py --summary`; result: the script marked stale docs and reported broad pre-existing source/README hash drift across many modules (including the touched shared UI module), which is a pre-existing repo state rather than caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19b79615548320a20042afb1a09ff8)