### PR TITLE
Add Family Office route and view-model; wire into workspace nav and command palette

### DIFF
--- a/src/Meridian.Ui/dashboard/README.md
+++ b/src/Meridian.Ui/dashboard/README.md
@@ -108,9 +108,12 @@ shared run evidence instead of recalculating attribution, drawdown, or fill sema
 
 Portfolio now includes `/portfolio/family-office`, a family-office route that keeps route metadata,
 summary labels, empty states, disabled reasons, and ownership graph/table accessibility labels in the
-Family Office view-model seam. The React screen renders household net worth, entity and asset-class
-breakdowns, cash/liability posture, private assets, unfunded commitments, reconciliation breaks,
-stale valuation warnings, and a keyboard-navigable ownership graph with a dense table fallback.
+Family Office view-model seam. The screen view model now derives summary panels and ownership graph
+rows from a family-office entity structure shaped like the shared `FamilyOfficeOverviewDto`/
+`FamilyEntityDto` contracts, so React renders entity, asset, commitment, reconciliation, and stale
+valuation projections instead of carrying a separate graph fixture. The workspace navigation and
+command palette surface the route from their route-catalog/view-model seams so discovery labels
+remain centralized.
 
 ## Diagrams
 

--- a/src/Meridian.Ui/dashboard/src/app.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.test.tsx
@@ -492,7 +492,7 @@ describe("App", () => {
     await user.keyboard("{Control>}k{/Control}");
     expect(screen.getByRole("dialog", { name: "Open workstation command" })).toBeInTheDocument();
     expect(screen.getByLabelText("Focus actions: 4 focus actions")).toBeInTheDocument();
-    expect(screen.getByRole("navigation", { name: "25 workstation commands" })).toBeInTheDocument();
+    expect(screen.getByRole("navigation", { name: "26 workstation commands" })).toBeInTheDocument();
     expect(screen.getAllByRole("link", {
       name: "Settings: Brokerage sync failed. Account sync failed after the last provider heartbeat. Fix provider setup."
     }).some((link) => link.getAttribute("href") === "/settings#alpaca-provider-setup")).toBe(true);

--- a/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.test.tsx
@@ -11,12 +11,12 @@ describe("CommandPalette", () => {
 
     expect(screen.getByRole("dialog", { name: "Open workstation command" })).toBeInTheDocument();
     expect(screen.getByText("Route to common operator workflows and canonical workspaces. Current: Portfolio.")).toBeInTheDocument();
-    expect(screen.getByRole("navigation", { name: "21 workstation commands" })).toBeInTheDocument();
+    expect(screen.getByRole("navigation", { name: "22 workstation commands" })).toBeInTheDocument();
     expect(screen.getByText("Esc to close")).toBeInTheDocument();
     expect(screen.getByRole("searchbox", { name: "Search command palette" })).toHaveFocus();
-    expect(screen.getByText("21 commands available")).toBeInTheDocument();
+    expect(screen.getByText("22 commands available")).toBeInTheDocument();
     expect(screen.getByLabelText("Workspaces: 7 workspaces")).toBeInTheDocument();
-    expect(screen.getByLabelText("Quick routes: 14 quick routes")).toBeInTheDocument();
+    expect(screen.getByLabelText("Quick routes: 15 quick routes")).toBeInTheDocument();
     expect(screen.getByLabelText("Route /portfolio")).toBeInTheDocument();
     expect(screen.getByLabelText("Portfolio, current workspace")).toHaveAttribute("aria-current", "page");
   });
@@ -80,7 +80,7 @@ describe("CommandPalette", () => {
 
     await user.type(screen.getByRole("searchbox", { name: "Search command palette" }), "settings");
 
-    expect(screen.getByText("2 of 21 commands match")).toBeInTheDocument();
+    expect(screen.getByText("2 of 22 commands match")).toBeInTheDocument();
     expect(screen.getByLabelText("Workspaces: 1 workspace")).toBeInTheDocument();
     expect(screen.getByLabelText("Quick routes: 1 quick route")).toBeInTheDocument();
     expect(screen.getByLabelText("Open Settings workspace")).toBeInTheDocument();
@@ -140,7 +140,7 @@ describe("CommandPalette", () => {
 
     await user.type(screen.getByRole("searchbox", { name: "Search command palette" }), "missing command");
 
-    expect(screen.getByText("0 of 21 commands match")).toBeInTheDocument();
+    expect(screen.getByText("0 of 22 commands match")).toBeInTheDocument();
     const search = screen.getByRole("searchbox", { name: "Search command palette" });
     expect(search).toHaveAttribute("aria-describedby", "command-palette-filter-count command-palette-empty-state-detail");
     expect(screen.getByText("Empty")).toBeInTheDocument();
@@ -162,7 +162,7 @@ describe("CommandPalette", () => {
 
     expect(search).toHaveValue("");
     expect(search).toHaveFocus();
-    expect(screen.getByText("21 commands available")).toBeInTheDocument();
+    expect(screen.getByText("22 commands available")).toBeInTheDocument();
     expect(screen.queryByText("No matching commands")).not.toBeInTheDocument();
   });
 
@@ -187,7 +187,7 @@ describe("CommandPalette", () => {
       { initialEntries: ["/data/quotes?symbol=MSFT"] }
     );
 
-    expect(screen.getByRole("navigation", { name: "22 workstation commands" })).toBeInTheDocument();
+    expect(screen.getByRole("navigation", { name: "23 workstation commands" })).toBeInTheDocument();
     expect(screen.getByLabelText("Focus actions: 1 focus action")).toBeInTheDocument();
     expect(screen.getByText(/1 ranked focus action available\./)).toBeInTheDocument();
     expect(screen.getByLabelText(
@@ -275,7 +275,7 @@ describe("CommandPalette", () => {
       { initialEntries: ["/trading"] }
     );
 
-    expect(screen.getByRole("navigation", { name: "23 commands" })).toBeInTheDocument();
+    expect(screen.getByRole("navigation", { name: "24 commands" })).toBeInTheDocument();
     expect(screen.getByText("1 workflow action - 1 preset")).toBeInTheDocument();
     expect(screen.getByLabelText("Review Security Master, Data Provider Recovery")).toHaveAttribute("href", "/accounting/security-master");
 

--- a/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.view-model.test.ts
@@ -8,12 +8,12 @@ describe("command palette view model", () => {
   it("marks the current workspace and setup anchor from the active route", () => {
     const model = buildCommandPaletteViewModel("/settings#alpaca-provider-setup");
 
-    expect(model.itemCountLabel).toBe("7 workspaces - 14 quick routes");
-    expect(model.commandListLabel).toBe("21 workstation commands");
-    expect(model.filteredItemCountLabel).toBe("21 commands available");
+    expect(model.itemCountLabel).toBe("7 workspaces - 15 quick routes");
+    expect(model.commandListLabel).toBe("22 workstation commands");
+    expect(model.filteredItemCountLabel).toBe("22 commands available");
     expect(model.commandGroups.map((group) => `${group.label}:${group.countLabel}`)).toEqual([
       "Workspaces:7 workspaces",
-      "Quick routes:14 quick routes"
+      "Quick routes:15 quick routes"
     ]);
     expect(model.activeWorkspaceLabel).toBe("Current: Settings");
     expect(model.routeSummary).toBe("Route to common operator workflows and canonical workspaces. Current: Settings.");
@@ -40,13 +40,13 @@ describe("command palette view model", () => {
       commandLabel: "Stay on Alpaca provider setup",
       active: true
     });
-    expect(model.filteredItems).toHaveLength(21);
+    expect(model.filteredItems).toHaveLength(22);
   });
 
   it("filters commands by workspace, route, status, and description text", () => {
     const model = buildCommandPaletteViewModel("/settings", undefined, {}, "preview portfolio");
 
-    expect(model.filteredItemCountLabel).toBe("1 of 21 commands match");
+    expect(model.filteredItemCountLabel).toBe("1 of 22 commands match");
     expect(model.filteredItems.map((item) => item.id)).toEqual(["portfolio"]);
     expect(model.commandGroups).toEqual([
       expect.objectContaining({
@@ -85,15 +85,15 @@ describe("command palette view model", () => {
       ]
     });
 
-    expect(model.itemCountLabel).toBe("2 focus actions - 7 workspaces - 14 quick routes");
-    expect(model.commandListLabel).toBe("23 workstation commands");
+    expect(model.itemCountLabel).toBe("2 focus actions - 7 workspaces - 15 quick routes");
+    expect(model.commandListLabel).toBe("24 workstation commands");
     expect(model.routeSummary).toBe(
       "Route to common operator workflows and canonical workspaces. Current: Data. 2 ranked focus actions available."
     );
     expect(model.commandGroups.map((group) => `${group.label}:${group.countLabel}`)).toEqual([
       "Focus actions:2 focus actions",
       "Workspaces:7 workspaces",
-      "Quick routes:14 quick routes"
+      "Quick routes:15 quick routes"
     ]);
     expect(model.initialFocusItemId).toBe("focus:work-item:brokerage-sync");
     expect(model.items[0]).toMatchObject({
@@ -161,10 +161,10 @@ describe("command palette view model", () => {
   it("exposes a searchable empty state when commands do not match", () => {
     const model = buildCommandPaletteViewModel("/settings", undefined, {}, "not-a-command");
 
-    expect(model.items).toHaveLength(21);
+    expect(model.items).toHaveLength(22);
     expect(model.filteredItems).toEqual([]);
     expect(model.commandGroups).toEqual([]);
-    expect(model.filteredItemCountLabel).toBe("0 of 21 commands match");
+    expect(model.filteredItemCountLabel).toBe("0 of 22 commands match");
     expect(model.searchDescribedBy).toBe("command-palette-filter-count command-palette-empty-state-detail");
     expect(model.emptyState).toEqual({
       id: "command-palette-empty-state",
@@ -190,17 +190,28 @@ describe("command palette view model", () => {
   it("keeps quick routes available when workspace metadata is missing", () => {
     const model = buildCommandPaletteViewModel("/trading", []);
 
-    expect(model.items).toHaveLength(14);
-    expect(model.commandListLabel).toBe("14 workstation commands");
-    expect(model.itemCountLabel).toBe("0 workspaces - 14 quick routes");
+    expect(model.items).toHaveLength(15);
+    expect(model.commandListLabel).toBe("15 workstation commands");
+    expect(model.itemCountLabel).toBe("0 workspaces - 15 quick routes");
     expect(model.routeSummary).toBe("Route to common operator workflows and canonical workspaces. No active workspace.");
     expect(model.initialFocusItemId).toBe("route:trading-readiness");
     expect(model.emptyState).toBeNull();
   });
 
-  it("exposes covered-call and price-alert route commands", () => {
+  it("exposes family-office, covered-call, and price-alert route commands", () => {
+    const familyOfficeModel = buildCommandPaletteViewModel("/portfolio/family-office", undefined, {}, "family office");
     const coveredCallModel = buildCommandPaletteViewModel("/strategy/covered-call", undefined, {}, "covered call");
     const priceAlertsModel = buildCommandPaletteViewModel("/data/alerts", undefined, {}, "price alerts");
+
+    expect(familyOfficeModel.filteredItems.map((item) => item.id)).toContain("route:portfolio-family-office");
+    expect(familyOfficeModel.items.find((item) => item.id === "route:portfolio-family-office")).toMatchObject({
+      kind: "route",
+      label: "Family office",
+      route: "/portfolio/family-office",
+      statusLabel: "Current",
+      commandLabel: "Stay on Family office",
+      active: true
+    });
 
     expect(coveredCallModel.filteredItems.map((item) => item.id)).toContain("route:strategy-covered-call");
     expect(coveredCallModel.items.find((item) => item.id === "route:strategy-covered-call")).toMatchObject({
@@ -409,8 +420,8 @@ describe("command palette view model", () => {
       }
     });
 
-    expect(model.itemCountLabel).toBe("7 workspaces - 14 quick routes - 1 preset - 3 workflow actions");
-    expect(model.commandListLabel).toBe("25 commands");
+    expect(model.itemCountLabel).toBe("7 workspaces - 15 quick routes - 1 preset - 3 workflow actions");
+    expect(model.commandListLabel).toBe("26 commands");
     expect(model.backendStatusLabel).toBe("3 workflow actions - 1 preset");
     expect(model.items.find((item) => item.id === "workflow:accounting-reconciliation-review:workflow.accounting.review-reconciliation-breaks")).toMatchObject({
       kind: "workflow",
@@ -633,7 +644,7 @@ describe("command palette view model", () => {
       workflowError: "Request failed for /api/workstation/workflows (503)"
     });
 
-    expect(model.items).toHaveLength(21);
+    expect(model.items).toHaveLength(22);
     expect(model.backendStatusLabel).toBe("Workflow library unavailable");
     expect(model.routeSummary).toBe(
       "Route through shared backend workflow commands. Current: Settings. Workflow library unavailable; local route commands remain available."

--- a/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.view-model.ts
@@ -149,6 +149,12 @@ const LOCAL_ROUTE_COMMANDS: CommandPaletteRouteDefinition[] = [
     route: WORKSTATION_ROUTE_CATALOG.portfolioBrokerageSync
   },
   {
+    id: "portfolio-family-office",
+    label: "Family office",
+    description: "Review family net worth, entity ownership, asset-class exposure, commitments, breaks, and stale valuations.",
+    route: WORKSTATION_ROUTE_CATALOG.portfolioFamilyOffice
+  },
+  {
     id: "accounting-reconciliation",
     label: "Reconciliation breaks",
     description: "Work position breaks, sign-off detail, and reconciliation recovery.",

--- a/src/Meridian.Ui/dashboard/src/components/meridian/workspace-nav.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/workspace-nav.view-model.test.ts
@@ -50,6 +50,23 @@ describe("workspace nav view model", () => {
     });
   });
 
+  it("surfaces the family-office route under Portfolio", () => {
+    const model = buildWorkspaceNavViewModel("/portfolio/family-office");
+    const portfolio = model.items.find((item) => item.key === "portfolio");
+
+    expect(portfolio?.subItems.map((item) => item.route)).toEqual([
+      "/portfolio/attribution",
+      "/portfolio/brokerage-sync",
+      "/portfolio/family-office"
+    ]);
+    expect(portfolio?.subItems.find((item) => item.route === "/portfolio/family-office")).toMatchObject({
+      label: "Family office",
+      active: true,
+      ariaCurrent: "page",
+      ariaLabel: "Family office, current page"
+    });
+  });
+
   it("surfaces the accounting ledger lane as a first-class subroute", () => {
     const model = buildWorkspaceNavViewModel("/accounting/ledger");
     const accounting = model.items.find((item) => item.key === "accounting");

--- a/src/Meridian.Ui/dashboard/src/components/meridian/workspace-nav.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/workspace-nav.view-model.ts
@@ -66,7 +66,8 @@ const WORKSPACE_SUBROUTES: Partial<Record<WorkspaceKey, { label: string; route: 
   ],
   portfolio: [
     { label: "Attribution", route: WORKSTATION_ROUTE_CATALOG.portfolioAttribution },
-    { label: "Brokerage sync", route: WORKSTATION_ROUTE_CATALOG.portfolioBrokerageSync }
+    { label: "Brokerage sync", route: WORKSTATION_ROUTE_CATALOG.portfolioBrokerageSync },
+    { label: "Family office", route: WORKSTATION_ROUTE_CATALOG.portfolioFamilyOffice }
   ],
   accounting: [
     { label: "Continuity", route: WORKSTATION_ROUTE_CATALOG.accountingOperationsContinuity },

--- a/src/Meridian.Ui/dashboard/src/screens/family-office-screen.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/family-office-screen.view-model.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildFamilyOfficeScreenViewModel, selectAdjacentFamilyOfficeNode } from "@/screens/family-office-screen.view-model";
+import {
+  buildFamilyOfficeScreenViewModel,
+  selectAdjacentFamilyOfficeNode,
+  type FamilyOfficeEntityStructure
+} from "@/screens/family-office-screen.view-model";
 
 const requiredPanelLabels = [
   "Total family net worth",
@@ -38,6 +42,80 @@ describe("buildFamilyOfficeScreenViewModel", () => {
     expect(vm.ownershipGraph.nodes.length).toBeGreaterThan(1);
     expect(vm.ownershipGraph.edges.length).toBe(vm.ownershipGraph.nodes.filter((node) => node.parentId !== null).length);
     expect(vm.ownershipGraph.nodes.every((node) => node.selectAriaLabel && node.detailPanelId)).toBe(true);
+  });
+
+  it("derives panels and graph rows from the family-office entity structure", () => {
+    const entityStructure: FamilyOfficeEntityStructure = {
+      familyOfficeId: "root-family",
+      displayName: "Root Family Office",
+      baseCurrency: "USD",
+      asOfDate: "2026-05-29",
+      entities: [
+        {
+          entityId: "root-family",
+          displayName: "Root Family Office",
+          entityType: "family-office",
+          parentEntityId: null,
+          ownershipPercent: 100,
+          netWorth: 10_000_000,
+          cash: 1_500_000,
+          liabilities: 500_000,
+          privateAssetValue: 2_000_000,
+          unfundedCommitments: 250_000,
+          reconciliationBreakCount: 1,
+          staleValuationWarningCount: 1,
+          detail: "Root entity for custom structure."
+        },
+        {
+          entityId: "trust-a",
+          displayName: "Trust A",
+          entityType: "trust",
+          parentEntityId: "root-family",
+          ownershipPercent: 60,
+          netWorth: 6_000_000,
+          cash: 900_000,
+          liabilities: 100_000,
+          privateAssetValue: 2_000_000,
+          unfundedCommitments: 250_000,
+          reconciliationBreakCount: 1,
+          staleValuationWarningCount: 1,
+          detail: "Trust A owns the private sleeve."
+        }
+      ],
+      assetClassExposures: [
+        { assetClass: "Cash", value: 1_500_000 },
+        { assetClass: "Private equity", value: 2_000_000 }
+      ],
+      privateAssets: [
+        {
+          assetId: "trust-a-private-sleeve",
+          entityId: "trust-a",
+          displayName: "Trust A private sleeve",
+          assetType: "Private equity",
+          value: 2_000_000,
+          valuationStatus: "stale"
+        }
+      ],
+      commitments: [
+        { commitmentId: "commitment-a", entityId: "trust-a", vehicleName: "PE Vehicle A", unfundedAmount: 250_000 }
+      ]
+    };
+
+    const vm = buildFamilyOfficeScreenViewModel("trust-a", entityStructure);
+
+    expect(vm.statusChips).toContainEqual({ label: "Entity source", value: "Root Family Office" });
+    expect(vm.panels.find((panel) => panel.id === "total-family-net-worth")).toMatchObject({
+      value: "$10.0M",
+      detail: expect.stringContaining("Root Family Office")
+    });
+    expect(vm.panels.find((panel) => panel.id === "entity-breakdown")?.value).toBe("2 entities");
+    expect(vm.panels.find((panel) => panel.id === "asset-class-breakdown")?.value).toBe("2 classes");
+    expect(vm.panels.find((panel) => panel.id === "unfunded-commitments")?.value).toBe("$250.0K");
+    expect(vm.ownershipGraph.nodes.map((node) => node.id)).toEqual(["root-family", "trust-a", "trust-a-private-sleeve"]);
+    expect(vm.ownershipGraph.edges.map((edge) => edge.label)).toEqual([
+      "60% ownership from Root Family Office to Trust A",
+      "Trust A private sleeve is held by Trust A"
+    ]);
   });
 
   it("selects adjacent graph nodes deterministically for keyboard navigation", () => {

--- a/src/Meridian.Ui/dashboard/src/screens/family-office-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/family-office-screen.view-model.ts
@@ -1,6 +1,7 @@
 import { WORKSTATION_ROUTE_CATALOG } from "@/lib/workspace";
 
 export type FamilyOfficeTone = "default" | "success" | "warning" | "danger";
+export type FamilyOfficeEntityType = "family-office" | "trust" | "llc" | "foundation" | "direct-accounts";
 
 export interface FamilyOfficeRouteMetadata {
   path: string;
@@ -21,6 +22,54 @@ export interface FamilyOfficePanelViewModel {
   tone: FamilyOfficeTone;
   emptyState: string;
   ariaLabel: string;
+}
+
+export interface FamilyOfficeEntityNode {
+  entityId: string;
+  displayName: string;
+  entityType: FamilyOfficeEntityType;
+  parentEntityId: string | null;
+  ownershipPercent: number;
+  netWorth: number;
+  cash: number;
+  liabilities: number;
+  privateAssetValue: number;
+  unfundedCommitments: number;
+  reconciliationBreakCount: number;
+  staleValuationWarningCount: number;
+  detail: string;
+}
+
+export interface FamilyOfficeAssetClassExposure {
+  assetClass: string;
+  value: number;
+}
+
+export interface FamilyOfficePrivateAssetSummary {
+  assetId: string;
+  entityId: string;
+  displayName: string;
+  assetType: string;
+  value: number;
+  valuationStatus: "current" | "stale" | "missing-evidence";
+}
+
+export interface FamilyOfficeCommitmentSummary {
+  commitmentId: string;
+  entityId: string;
+  vehicleName: string;
+  unfundedAmount: number;
+}
+
+export interface FamilyOfficeEntityStructure {
+  familyOfficeId: string;
+  displayName: string;
+  baseCurrency: string;
+  asOfDate: string;
+  entities: FamilyOfficeEntityNode[];
+  assetClassExposures: FamilyOfficeAssetClassExposure[];
+  privateAssets: FamilyOfficePrivateAssetSummary[];
+  commitments: FamilyOfficeCommitmentSummary[];
 }
 
 export interface FamilyOfficeOwnershipNode {
@@ -82,161 +131,121 @@ const FAMILY_OFFICE_ROUTE_METADATA: FamilyOfficeRouteMetadata = {
   disabledReason: null
 };
 
-const FAMILY_OFFICE_PANELS: Omit<FamilyOfficePanelViewModel, "ariaLabel">[] = [
-  {
-    id: "total-family-net-worth",
-    label: "Total family net worth",
-    value: "$128.4M",
-    detail: "Consolidated household NAV after liabilities and unfunded commitments.",
-    tone: "success",
-    emptyState: "No household NAV feed has been connected."
-  },
-  {
-    id: "entity-breakdown",
-    label: "Entity breakdown",
-    value: "5 entities",
-    detail: "Trusts, holding companies, operating LLCs, and direct family accounts mapped to beneficial owners.",
-    tone: "default",
-    emptyState: "No ownership entities have been mapped."
-  },
-  {
-    id: "asset-class-breakdown",
-    label: "Asset-class breakdown",
-    value: "9 classes",
-    detail: "Public equity, fixed income, cash, real estate, venture, private credit, operating assets, collectibles, and alternatives.",
-    tone: "default",
-    emptyState: "No asset-class taxonomy is available."
-  },
-  {
-    id: "cash-and-liabilities",
-    label: "Cash and liabilities",
-    value: "$14.2M / $8.7M",
-    detail: "Available cash and short-term liabilities across custody, treasury, and operating accounts.",
-    tone: "warning",
-    emptyState: "Cash and liability ledgers have not been reconciled."
-  },
-  {
-    id: "private-assets",
-    label: "Private assets",
-    value: "$42.6M",
-    detail: "Private equity, venture funds, direct real estate, and operating-company marks pending valuation review.",
-    tone: "warning",
-    emptyState: "No private asset register is available."
-  },
-  {
-    id: "unfunded-commitments",
-    label: "Unfunded commitments",
-    value: "$11.4M",
-    detail: "Remaining capital calls across private funds and direct investment side letters.",
-    tone: "danger",
-    emptyState: "Commitment schedule is unavailable."
-  },
-  {
-    id: "unresolved-reconciliation-breaks",
-    label: "Unresolved reconciliation breaks",
-    value: "7 breaks",
-    detail: "Custody, capital-call, and private valuation differences requiring operator resolution.",
-    tone: "danger",
-    emptyState: "No reconciliation queue has loaded."
-  },
-  {
-    id: "stale-valuation-warnings",
-    label: "Stale valuation warnings",
-    value: "4 warnings",
-    detail: "Private marks older than policy thresholds or missing independent valuation evidence.",
-    tone: "warning",
-    emptyState: "No stale valuation policy data has loaded."
-  }
-];
+const DEFAULT_FAMILY_OFFICE_ENTITY_STRUCTURE: FamilyOfficeEntityStructure = {
+  familyOfficeId: "family-holdco",
+  displayName: "Meridian Family HoldCo",
+  baseCurrency: "USD",
+  asOfDate: "2026-05-29",
+  entities: [
+    {
+      entityId: "family-holdco",
+      displayName: "Meridian Family HoldCo",
+      entityType: "family-office",
+      parentEntityId: null,
+      ownershipPercent: 100,
+      netWorth: 128_400_000,
+      cash: 14_200_000,
+      liabilities: 8_700_000,
+      privateAssetValue: 42_600_000,
+      unfundedCommitments: 11_400_000,
+      reconciliationBreakCount: 7,
+      staleValuationWarningCount: 4,
+      detail: "Consolidated beneficial ownership across family entities."
+    },
+    {
+      entityId: "alpha-trust",
+      displayName: "Alpha Family Trust",
+      entityType: "trust",
+      parentEntityId: "family-holdco",
+      ownershipPercent: 42,
+      netWorth: 54_100_000,
+      cash: 6_100_000,
+      liabilities: 1_300_000,
+      privateAssetValue: 31_900_000,
+      unfundedCommitments: 11_400_000,
+      reconciliationBreakCount: 2,
+      staleValuationWarningCount: 1,
+      detail: "Public markets, cash reserves, and private fund LP interests."
+    },
+    {
+      entityId: "beta-llc",
+      displayName: "Beta Holdings LLC",
+      entityType: "llc",
+      parentEntityId: "family-holdco",
+      ownershipPercent: 30,
+      netWorth: 38_700_000,
+      cash: 2_700_000,
+      liabilities: 4_900_000,
+      privateAssetValue: 23_600_000,
+      unfundedCommitments: 0,
+      reconciliationBreakCount: 3,
+      staleValuationWarningCount: 3,
+      detail: "Operating-company and real-estate holdings with stale-mark warnings."
+    },
+    {
+      entityId: "gamma-foundation",
+      displayName: "Gamma Foundation",
+      entityType: "foundation",
+      parentEntityId: "family-holdco",
+      ownershipPercent: 17,
+      netWorth: 21_300_000,
+      cash: 2_200_000,
+      liabilities: 700_000,
+      privateAssetValue: 4_600_000,
+      unfundedCommitments: 0,
+      reconciliationBreakCount: 0,
+      staleValuationWarningCount: 0,
+      detail: "Restricted charitable assets and investment policy allocations."
+    },
+    {
+      entityId: "direct-accounts",
+      displayName: "Direct Family Accounts",
+      entityType: "direct-accounts",
+      parentEntityId: "family-holdco",
+      ownershipPercent: 11,
+      netWorth: 14_300_000,
+      cash: 3_200_000,
+      liabilities: 1_800_000,
+      privateAssetValue: 2_500_000,
+      unfundedCommitments: 0,
+      reconciliationBreakCount: 2,
+      staleValuationWarningCount: 0,
+      detail: "Personal brokerage, treasury, and liability accounts."
+    }
+  ],
+  assetClassExposures: [
+    { assetClass: "Public equity", value: 24_800_000 },
+    { assetClass: "Fixed income", value: 18_100_000 },
+    { assetClass: "Cash", value: 14_200_000 },
+    { assetClass: "Real estate", value: 23_600_000 },
+    { assetClass: "Venture", value: 12_400_000 },
+    { assetClass: "Private credit", value: 9_600_000 },
+    { assetClass: "Operating assets", value: 7_100_000 },
+    { assetClass: "Collectibles", value: 3_200_000 },
+    { assetClass: "Alternatives", value: 15_400_000 }
+  ],
+  privateAssets: [
+    { assetId: "private-funds", entityId: "alpha-trust", displayName: "Private fund sleeve", assetType: "Private funds", value: 31_900_000, valuationStatus: "missing-evidence" },
+    { assetId: "real-estate", entityId: "beta-llc", displayName: "Real estate sleeve", assetType: "Real estate", value: 23_600_000, valuationStatus: "stale" },
+    { assetId: "operating-assets", entityId: "gamma-foundation", displayName: "Operating asset sleeve", assetType: "Operating assets", value: 4_600_000, valuationStatus: "current" },
+    { assetId: "direct-collectibles", entityId: "direct-accounts", displayName: "Collectibles sleeve", assetType: "Collectibles", value: 2_500_000, valuationStatus: "current" }
+  ],
+  commitments: [
+    { commitmentId: "alpha-pe-2026", entityId: "alpha-trust", vehicleName: "Alpha PE Fund VII", unfundedAmount: 8_600_000 },
+    { commitmentId: "alpha-credit-2025", entityId: "alpha-trust", vehicleName: "Alpha Private Credit II", unfundedAmount: 2_800_000 }
+  ]
+};
 
-const FAMILY_OFFICE_OWNERSHIP_NODES: Array<Omit<FamilyOfficeOwnershipNode, "rowClassName" | "isSelected" | "expanded" | "detailPanelId" | "selectAriaLabel" | "ariaLabel">> = [
-  {
-    id: "family-holdco",
-    label: "Meridian Family HoldCo",
-    type: "family",
-    value: "$128.4M",
-    percentage: "100%",
-    detail: "Consolidated beneficial ownership across family entities.",
-    parentId: null,
-    tone: "success"
-  },
-  {
-    id: "alpha-trust",
-    label: "Alpha Family Trust",
-    type: "entity",
-    value: "$54.1M",
-    percentage: "42%",
-    detail: "Public markets, cash reserves, and private fund LP interests.",
-    parentId: "family-holdco",
-    tone: "default"
-  },
-  {
-    id: "beta-llc",
-    label: "Beta Holdings LLC",
-    type: "entity",
-    value: "$38.7M",
-    percentage: "30%",
-    detail: "Operating-company and real-estate holdings with stale-mark warnings.",
-    parentId: "family-holdco",
-    tone: "warning"
-  },
-  {
-    id: "gamma-foundation",
-    label: "Gamma Foundation",
-    type: "entity",
-    value: "$21.3M",
-    percentage: "17%",
-    detail: "Restricted charitable assets and investment policy allocations.",
-    parentId: "family-holdco",
-    tone: "default"
-  },
-  {
-    id: "direct-accounts",
-    label: "Direct Family Accounts",
-    type: "entity",
-    value: "$14.3M",
-    percentage: "11%",
-    detail: "Personal brokerage, treasury, and liability accounts.",
-    parentId: "family-holdco",
-    tone: "warning"
-  },
-  {
-    id: "private-funds",
-    label: "Private fund sleeve",
-    type: "asset",
-    value: "$31.9M",
-    percentage: "25%",
-    detail: "$11.4M unfunded with two capital-call breaks.",
-    parentId: "alpha-trust",
-    tone: "danger"
-  },
-  {
-    id: "real-estate",
-    label: "Real estate sleeve",
-    type: "asset",
-    value: "$23.6M",
-    percentage: "18%",
-    detail: "Four assets; three marks are past the valuation freshness policy.",
-    parentId: "beta-llc",
-    tone: "warning"
-  }
-];
-
-const FAMILY_OFFICE_OWNERSHIP_EDGES: FamilyOfficeOwnershipEdge[] = FAMILY_OFFICE_OWNERSHIP_NODES
-  .filter((node) => node.parentId !== null)
-  .map((node) => ({
-    id: `${node.parentId}-${node.id}`,
-    fromId: node.parentId ?? "",
-    toId: node.id,
-    label: `${node.percentage} ownership from ${node.parentId} to ${node.label}`
-  }));
-
-export function buildFamilyOfficeScreenViewModel(selectedNodeId: string | null = null): FamilyOfficeScreenViewModel {
-  const stableSelectedNodeId = FAMILY_OFFICE_OWNERSHIP_NODES.some((node) => node.id === selectedNodeId)
+export function buildFamilyOfficeScreenViewModel(
+  selectedNodeId: string | null = null,
+  entityStructure: FamilyOfficeEntityStructure = DEFAULT_FAMILY_OFFICE_ENTITY_STRUCTURE
+): FamilyOfficeScreenViewModel {
+  const baseNodes = buildOwnershipNodes(entityStructure);
+  const stableSelectedNodeId = baseNodes.some((node) => node.id === selectedNodeId)
     ? selectedNodeId
-    : FAMILY_OFFICE_OWNERSHIP_NODES[0]?.id ?? null;
+    : baseNodes[0]?.id ?? null;
   const detailPanelId = "family-office-ownership-detail";
-  const nodes = FAMILY_OFFICE_OWNERSHIP_NODES.map((node) => {
+  const nodes = baseNodes.map((node) => {
     const selected = node.id === stableSelectedNodeId;
     return {
       ...node,
@@ -255,15 +264,13 @@ export function buildFamilyOfficeScreenViewModel(selectedNodeId: string | null =
     statusChips: [
       { label: "Workspace", value: FAMILY_OFFICE_ROUTE_METADATA.workspaceLabel },
       { label: "Route", value: FAMILY_OFFICE_ROUTE_METADATA.path },
+      { label: "Entity source", value: entityStructure.displayName },
       { label: "Graph mode", value: "Keyboard accessible" }
     ],
-    panels: FAMILY_OFFICE_PANELS.map((panel) => ({
-      ...panel,
-      ariaLabel: `${panel.label}: ${panel.value}. ${panel.detail}`
-    })),
+    panels: buildFamilyOfficePanels(entityStructure),
     ownershipGraph: {
       title: "Ownership graph",
-      description: "Navigate family entities and asset sleeves as a graph, or switch to the dense table fallback for assistive technology and audit review.",
+      description: "Navigate the family-office entity structure and private-asset sleeves as a graph, or switch to the dense table fallback for assistive technology and audit review.",
       ariaLabel: "Family office ownership graph",
       keyboardInstructions: "Use Arrow keys, Home, and End to move between ownership nodes. Press Enter or Space to inspect the focused node. Use the table view for a dense accessible fallback.",
       tableFallbackLabel: "Family office ownership table fallback",
@@ -275,32 +282,181 @@ export function buildFamilyOfficeScreenViewModel(selectedNodeId: string | null =
       selectedNodeId: stableSelectedNodeId,
       selectedNode,
       nodes,
-      edges: FAMILY_OFFICE_OWNERSHIP_EDGES
+      edges: buildOwnershipEdges(entityStructure)
     }
   };
 }
 
 export function selectAdjacentFamilyOfficeNode(
   currentNodeId: string | null,
-  direction: "next" | "previous" | "first" | "last"
+  direction: "next" | "previous" | "first" | "last",
+  entityStructure: FamilyOfficeEntityStructure = DEFAULT_FAMILY_OFFICE_ENTITY_STRUCTURE
 ): string | null {
-  if (FAMILY_OFFICE_OWNERSHIP_NODES.length === 0) {
+  const nodeOrder = buildOwnershipNodes(entityStructure).map((node) => node.id);
+  if (nodeOrder.length === 0) {
     return null;
   }
 
-  const currentIndex = FAMILY_OFFICE_OWNERSHIP_NODES.findIndex((node) => node.id === currentNodeId);
+  const currentIndex = nodeOrder.findIndex((nodeId) => nodeId === currentNodeId);
   const safeIndex = currentIndex >= 0 ? currentIndex : 0;
 
   switch (direction) {
     case "first":
-      return FAMILY_OFFICE_OWNERSHIP_NODES[0].id;
+      return nodeOrder[0];
     case "last":
-      return FAMILY_OFFICE_OWNERSHIP_NODES[FAMILY_OFFICE_OWNERSHIP_NODES.length - 1].id;
+      return nodeOrder[nodeOrder.length - 1];
     case "previous":
-      return FAMILY_OFFICE_OWNERSHIP_NODES[Math.max(0, safeIndex - 1)].id;
+      return nodeOrder[Math.max(0, safeIndex - 1)];
     case "next":
-      return FAMILY_OFFICE_OWNERSHIP_NODES[Math.min(FAMILY_OFFICE_OWNERSHIP_NODES.length - 1, safeIndex + 1)].id;
+      return nodeOrder[Math.min(nodeOrder.length - 1, safeIndex + 1)];
   }
+}
+
+function buildFamilyOfficePanels(entityStructure: FamilyOfficeEntityStructure): FamilyOfficePanelViewModel[] {
+  const root = entityStructure.entities.find((entity) => entity.entityId === entityStructure.familyOfficeId) ?? entityStructure.entities[0] ?? null;
+  const totalNetWorth = root?.netWorth ?? sum(entityStructure.entities.map((entity) => entity.netWorth));
+  const totalCash = root?.cash ?? sum(entityStructure.entities.map((entity) => entity.cash));
+  const totalLiabilities = root?.liabilities ?? sum(entityStructure.entities.map((entity) => entity.liabilities));
+  const privateAssetValue = root?.privateAssetValue ?? sum(entityStructure.privateAssets.map((asset) => asset.value));
+  const unfundedCommitments = root?.unfundedCommitments ?? sum(entityStructure.commitments.map((commitment) => commitment.unfundedAmount));
+  const breakCount = root?.reconciliationBreakCount ?? sum(entityStructure.entities.map((entity) => entity.reconciliationBreakCount));
+  const staleWarningCount = root?.staleValuationWarningCount
+    ?? entityStructure.privateAssets.filter((asset) => asset.valuationStatus !== "current").length;
+  const entityKinds = uniqueCount(entityStructure.entities.map((entity) => entity.entityType));
+
+  const panels: Omit<FamilyOfficePanelViewModel, "ariaLabel">[] = [
+    {
+      id: "total-family-net-worth",
+      label: "Total family net worth",
+      value: formatCurrency(totalNetWorth),
+      detail: `Consolidated ${entityStructure.displayName} NAV after liabilities and unfunded commitments as of ${entityStructure.asOfDate}.`,
+      tone: "success",
+      emptyState: "No household NAV feed has been connected."
+    },
+    {
+      id: "entity-breakdown",
+      label: "Entity breakdown",
+      value: formatCountLabel(entityStructure.entities.length, "entity", "entities"),
+      detail: `${formatCountLabel(entityKinds, "entity type", "entity types")} across trusts, holding companies, operating LLCs, foundations, and direct accounts mapped to beneficial owners.`,
+      tone: entityStructure.entities.length > 0 ? "default" : "warning",
+      emptyState: "No ownership entities have been mapped."
+    },
+    {
+      id: "asset-class-breakdown",
+      label: "Asset-class breakdown",
+      value: formatCountLabel(entityStructure.assetClassExposures.length, "class", "classes"),
+      detail: entityStructure.assetClassExposures.map((exposure) => exposure.assetClass).join(", ") || "No asset-class taxonomy is available.",
+      tone: entityStructure.assetClassExposures.length > 0 ? "default" : "warning",
+      emptyState: "No asset-class taxonomy is available."
+    },
+    {
+      id: "cash-and-liabilities",
+      label: "Cash and liabilities",
+      value: `${formatCurrency(totalCash)} / ${formatCurrency(totalLiabilities)}`,
+      detail: "Available cash and short-term liabilities across custody, treasury, and operating accounts.",
+      tone: totalLiabilities > 0 ? "warning" : "success",
+      emptyState: "Cash and liability ledgers have not been reconciled."
+    },
+    {
+      id: "private-assets",
+      label: "Private assets",
+      value: formatCurrency(privateAssetValue),
+      detail: `${formatCountLabel(entityStructure.privateAssets.length, "private asset")} tied to the entity structure and valuation evidence status.`,
+      tone: staleWarningCount > 0 ? "warning" : "success",
+      emptyState: "No private asset register is available."
+    },
+    {
+      id: "unfunded-commitments",
+      label: "Unfunded commitments",
+      value: formatCurrency(unfundedCommitments),
+      detail: `${formatCountLabel(entityStructure.commitments.length, "capital commitment")} across private funds and direct investment side letters.`,
+      tone: unfundedCommitments > 0 ? "danger" : "success",
+      emptyState: "Commitment schedule is unavailable."
+    },
+    {
+      id: "unresolved-reconciliation-breaks",
+      label: "Unresolved reconciliation breaks",
+      value: formatCountLabel(breakCount, "break"),
+      detail: "Custody, capital-call, and private valuation differences requiring operator resolution.",
+      tone: breakCount > 0 ? "danger" : "success",
+      emptyState: "No reconciliation queue has loaded."
+    },
+    {
+      id: "stale-valuation-warnings",
+      label: "Stale valuation warnings",
+      value: formatCountLabel(staleWarningCount, "warning"),
+      detail: "Private marks older than policy thresholds or missing independent valuation evidence.",
+      tone: staleWarningCount > 0 ? "warning" : "success",
+      emptyState: "No stale valuation policy data has loaded."
+    }
+  ];
+
+  return panels.map((panel) => ({
+    ...panel,
+    ariaLabel: `${panel.label}: ${panel.value}. ${panel.detail}`
+  }));
+}
+
+function buildOwnershipNodes(entityStructure: FamilyOfficeEntityStructure): Array<Omit<FamilyOfficeOwnershipNode, "rowClassName" | "isSelected" | "expanded" | "detailPanelId" | "selectAriaLabel" | "ariaLabel">> {
+  const totalNetWorth = entityStructure.entities.find((entity) => entity.entityId === entityStructure.familyOfficeId)?.netWorth
+    ?? sum(entityStructure.entities.map((entity) => entity.netWorth));
+  const entityNodes = entityStructure.entities.map((entity) => ({
+    id: entity.entityId,
+    label: entity.displayName,
+    type: entity.parentEntityId === null ? "family" as const : "entity" as const,
+    value: formatCurrency(entity.netWorth),
+    percentage: formatPercent(entity.ownershipPercent),
+    detail: entity.detail,
+    parentId: entity.parentEntityId,
+    tone: entityTone(entity)
+  }));
+  const assetNodes = entityStructure.privateAssets
+    .filter((asset) => asset.valuationStatus !== "current")
+    .map((asset) => ({
+      id: asset.assetId,
+      label: asset.displayName,
+      type: "asset" as const,
+      value: formatCurrency(asset.value),
+      percentage: formatPercent(totalNetWorth === 0 ? 0 : (asset.value / totalNetWorth) * 100),
+      detail: `${asset.assetType} held by ${entityDisplayName(entityStructure, asset.entityId)}. ${asset.valuationStatus === "stale" ? "Valuation is past the freshness policy." : "Independent valuation evidence is missing."}`,
+      parentId: asset.entityId,
+      tone: asset.valuationStatus === "missing-evidence" ? "danger" as const : "warning" as const
+    }));
+
+  return [...entityNodes, ...assetNodes];
+}
+
+function buildOwnershipEdges(entityStructure: FamilyOfficeEntityStructure): FamilyOfficeOwnershipEdge[] {
+  const entityEdges = entityStructure.entities
+    .filter((entity) => entity.parentEntityId !== null)
+    .map((entity) => ({
+      id: `${entity.parentEntityId}-${entity.entityId}`,
+      fromId: entity.parentEntityId ?? "",
+      toId: entity.entityId,
+      label: `${formatPercent(entity.ownershipPercent)} ownership from ${entityDisplayName(entityStructure, entity.parentEntityId)} to ${entity.displayName}`
+    }));
+  const assetEdges = entityStructure.privateAssets
+    .filter((asset) => asset.valuationStatus !== "current")
+    .map((asset) => ({
+      id: `${asset.entityId}-${asset.assetId}`,
+      fromId: asset.entityId,
+      toId: asset.assetId,
+      label: `${asset.displayName} is held by ${entityDisplayName(entityStructure, asset.entityId)}`
+    }));
+
+  return [...entityEdges, ...assetEdges];
+}
+
+function entityTone(entity: FamilyOfficeEntityNode): FamilyOfficeTone {
+  if (entity.reconciliationBreakCount > 0 && entity.unfundedCommitments > 0) {
+    return "danger";
+  }
+
+  if (entity.staleValuationWarningCount > 0 || entity.liabilities > 0) {
+    return "warning";
+  }
+
+  return entity.parentEntityId === null ? "success" : "default";
 }
 
 function ownershipToneRowClassName(tone: FamilyOfficeTone): string {
@@ -314,4 +470,38 @@ function ownershipToneRowClassName(tone: FamilyOfficeTone): string {
     default:
       return "";
   }
+}
+
+function entityDisplayName(entityStructure: FamilyOfficeEntityStructure, entityId: string | null): string {
+  return entityStructure.entities.find((entity) => entity.entityId === entityId)?.displayName ?? "Unmapped entity";
+}
+
+function formatCurrency(value: number): string {
+  const absoluteValue = Math.abs(value);
+  const sign = value < 0 ? "-" : "";
+  if (absoluteValue >= 1_000_000) {
+    return `${sign}$${(absoluteValue / 1_000_000).toFixed(1)}M`;
+  }
+
+  if (absoluteValue >= 1_000) {
+    return `${sign}$${(absoluteValue / 1_000).toFixed(1)}K`;
+  }
+
+  return `${sign}$${absoluteValue.toFixed(0)}`;
+}
+
+function formatPercent(value: number): string {
+  return Number.isInteger(value) ? `${value}%` : `${value.toFixed(1)}%`;
+}
+
+function formatCountLabel(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function uniqueCount(values: string[]): number {
+  return new Set(values).size;
+}
+
+function sum(values: number[]): number {
+  return values.reduce((total, value) => total + value, 0);
 }


### PR DESCRIPTION
### Motivation

- Introduce a Family Office workstation lane that surfaces household net worth, entity ownership, private assets, commitments, and reconciliation warnings in the browser view-model seam without duplicating server-side logic.
- Expose the new route across navigation and the command palette so the route is discoverable and accessible alongside existing workspaces and quick routes.

### Description

- Add a new `FamilyOfficeEntityStructure` model and implement `buildFamilyOfficeScreenViewModel`, including `buildFamilyOfficePanels`, `buildOwnershipNodes`, `buildOwnershipEdges`, `entityTone`, and formatting helpers to derive panels and an ownership graph from an entity structure; default sample structure is provided as `DEFAULT_FAMILY_OFFICE_ENTITY_STRUCTURE`.
- Add programmatic support for a `/portfolio/family-office` local route in `LOCAL_ROUTE_COMMANDS` and register it as a subroute under `portfolio` in the workspace nav view model so the navigation and command palette include the new route.
- Update selection/navigation helpers so `selectAdjacentFamilyOfficeNode` and ownership node construction operate against a provided `FamilyOfficeEntityStructure` (defaulting to the built-in sample) and produce stable selection, nodes, and edges.
- Update tests and README to reflect the new route and view-model behavior, and adjust command counts/labels where the addition increments command/route totals.

### Testing

- Ran unit tests for the dashboard UI view-models and components (Vitest suites covering `command-palette`, `command-palette.view-model`, `workspace-nav.view-model`, and `family-office-screen.view-model`); the updated tests executed and passed.
- Verified component-level tests that assert command palette counts and workspace navigation include the new family-office route and that family-office view-model tests validate panel values, graph nodes/edges, and keyboard navigation; all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19b7993f9083209d31434df4637e9b)