### PR TITLE
Wire fund structure setup workflow endpoints

### DIFF
--- a/src/Meridian.Contracts/Api/UiApiRoutes.cs
+++ b/src/Meridian.Contracts/Api/UiApiRoutes.cs
@@ -646,6 +646,8 @@ public static class UiApiRoutes
     public const string ReportingPackWorkflowPublish = "/api/fund-structure/reporting/packs/{reportId}/publish";
     public const string ReportingPackWorkflowRestate = "/api/fund-structure/reporting/packs/{reportId}/restatements";
     public const string ReportingPackWorkflowArchive = "/api/fund-structure/reporting/packs/{reportId}/archive";
+    public const string FundStructureSetupDraftValidate = "/api/fund-structure/setup-drafts/validate";
+    public const string FundStructureSetupDraftCreate = "/api/fund-structure/setup-drafts/create";
     public const string FundStructureLedgerMappingAssignments = "/api/fund-structure/ledger-mapping-assignments";
 
     // Fund account brokerage read-side sync endpoints

--- a/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
@@ -24,7 +24,16 @@ public static class FundStructureEndpoints
             if (workflow is null)
                 return ServiceUnavailable();
 
-            var draft = JsonSerializer.Deserialize<FundStructureSetupDraftDto>(body.GetRawText(), jsonOptions);
+            FundStructureSetupDraftDto? draft;
+            try
+            {
+                draft = JsonSerializer.Deserialize<FundStructureSetupDraftDto>(body.GetRawText(), jsonOptions);
+            }
+            catch (JsonException ex)
+            {
+                return Results.Problem($"Setup draft is invalid JSON. {ex.Message}", statusCode: StatusCodes.Status400BadRequest);
+            }
+
             var result = workflow.Preview(draft);
             return Results.Json(result, jsonOptions);
         })

--- a/src/Meridian.Ui/dashboard/src/lib/api.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api.ts
@@ -1768,9 +1768,9 @@ export interface FundStructureSetupResult {
 }
 
 export async function validateFundStructureSetupDraft(draft: FundStructureSetupDraft, options: ApiRequestOptions = {}): Promise<FundStructureSetupPreview> {
-  return postJson<FundStructureSetupPreview>("/api/fund-structure/setup-drafts/validate", draft, options);
+  return postJson<FundStructureSetupPreview>(FUND_STRUCTURE_API_ENDPOINTS.setupDraftValidate, draft, options);
 }
 
 export async function createFundStructureSetupDraft(draft: FundStructureSetupDraft, options: ApiRequestOptions = {}): Promise<FundStructureSetupResult> {
-  return postJson<FundStructureSetupResult>("/api/fund-structure/setup-drafts/create", draft, options);
+  return postJson<FundStructureSetupResult>(FUND_STRUCTURE_API_ENDPOINTS.setupDraftCreate, draft, options);
 }

--- a/src/Meridian.Ui/dashboard/src/lib/workstation-endpoints.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/workstation-endpoints.test.ts
@@ -217,6 +217,8 @@ describe("workstation API endpoint catalog", () => {
     );
     expect(AUTH_API_ENDPOINTS.roles).toBe("/api/auth/roles");
     expect(AUTH_API_ENDPOINTS.roleProfiles).toBe("/api/auth/role-profiles");
+    expect(FUND_STRUCTURE_API_ENDPOINTS.setupDraftValidate).toBe("/api/fund-structure/setup-drafts/validate");
+    expect(FUND_STRUCTURE_API_ENDPOINTS.setupDraftCreate).toBe("/api/fund-structure/setup-drafts/create");
     expect(FUND_STRUCTURE_API_ENDPOINTS.ledgerMappingWorkbench).toBe("/api/fund-structure/ledger-mapping-view");
     expect(FUND_STRUCTURE_API_ENDPOINTS.ledgerMappingAssignments).toBe("/api/fund-structure/ledger-mapping-assignments");
     expect(FUND_STRUCTURE_API_ENDPOINTS.transactionLabPreview).toBe("/api/fund-structure/accounting/transaction-lab/preview");

--- a/src/Meridian.Ui/dashboard/src/lib/workstation-endpoints.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/workstation-endpoints.ts
@@ -33,6 +33,8 @@ export const AUTH_API_ENDPOINTS = {
 } as const;
 
 export const FUND_STRUCTURE_API_ENDPOINTS = {
+  setupDraftValidate: "/api/fund-structure/setup-drafts/validate",
+  setupDraftCreate: "/api/fund-structure/setup-drafts/create",
   ledgerMappingWorkbench: "/api/fund-structure/ledger-mapping-view",
   ledgerMappingAssignments: "/api/fund-structure/ledger-mapping-assignments",
   transactionLabPreview: "/api/fund-structure/accounting/transaction-lab/preview"


### PR DESCRIPTION
### Motivation
- Centralize and surface the shared entity-setup workflow for operator-driven onboarding so both WPF and browser clients call the same server-owned orchestration instead of reimplementing setup sequencing in the UI. 
- Provide stable, discoverable API routes for validate/create setup-drafts and include them in the canonical endpoint catalog so clients use the shared route constants. 
- Make endpoint JSON handling consistent by returning proper bad-request diagnostics for invalid setup drafts before attempting preview/create work. 

### Description
- Added canonical route constants for the setup-draft endpoints in `src/Meridian.Contracts/Api/UiApiRoutes.cs` as `FundStructureSetupDraftValidate` and `FundStructureSetupDraftCreate`. 
- Hardened the validate endpoint in `src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs` to handle invalid JSON consistently and to use the shared `FundStructureSetupWorkflowService` preview path. 
- Extended the browser endpoint catalog `FUND_STRUCTURE_API_ENDPOINTS` in `src/Meridian.Ui/dashboard/src/lib/workstation-endpoints.ts` with `setupDraftValidate` and `setupDraftCreate`, and migrated the client API calls in `src/Meridian.Ui/dashboard/src/lib/api.ts` to use those constants. 
- Updated the workstation endpoint catalog test `src/Meridian.Ui/dashboard/src/lib/workstation-endpoints.test.ts` to assert the new entries. 

### Testing
- Ran `npm --prefix src/Meridian.Ui/dashboard ci` which completed and installed dependencies successfully (no vulnerabilities found). — succeeded. 
- Ran Vitest for the affected browser files with `npm --prefix src/Meridian.Ui/dashboard run test -- entity-setup-wizard.test.tsx src/lib/workstation-endpoints.test.ts` and the two test files passed (`16 tests` total). — succeeded. 
- Ran `python3 build/scripts/docs/validate-source-readmes.py --summary` to validate source READMEs for touched modules. — succeeded. 
- Ran `git diff --check` to verify no whitespace/check issues. — succeeded. 
- Attempted targeted .NET tests (WPF and integration) but `dotnet` is not available in this environment so those `dotnet test` runs were not executed here; they should be run in CI or a developer environment to fully validate server-side behavior. — not run due to environment limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19ea743ce08320b0de2a532a88c0c8)