### PR TITLE
Require independent Security Master casework sign-off

### DIFF
--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -281,9 +281,9 @@ corporate-action, factor-schedule, or asset-class capability checks require cont
 Held-security Security Master exception cases also feed the close-readiness Security Master
 component, so unresolved conflicts, stale mappings, or pending override approvals cannot hide
 behind a green provider-ledger comparison.
-Approved Security Master operator overrides now move their durable exception case through review,
-resolution, and steward sign-off so close readiness and report-line provenance can distinguish
-pending override casework from approved definition evidence.
+Approved Security Master operator overrides now move their durable exception case through review and
+resolution, then remain ready for an independent steward sign-off so close readiness and report-line
+provenance can distinguish pending sign-off casework from approved definition evidence.
 Ledger amount provenance drilldowns now preserve related reconciliation case materiality and aging
 metadata, including severity, variance, tolerance band, sign-off actors, SLA state, age band, and
 business-age hours, so report-line click-throughs can show whether a retained amount is still

--- a/src/Meridian.Ui.Shared/Services/SecurityMasterExceptionCaseworkService.cs
+++ b/src/Meridian.Ui.Shared/Services/SecurityMasterExceptionCaseworkService.cs
@@ -105,33 +105,6 @@ public sealed class SecurityMasterExceptionCaseworkService
                 resolve.Error);
             return;
         }
-
-        if (resolve.Item is null)
-        {
-            return;
-        }
-
-        var signOff = await _breakQueueRepository.ApplyCaseworkCommandAsync(
-                new ReconciliationCaseworkCommand(
-                    existing.BreakId,
-                    ReconciliationCaseworkAction.SignOff,
-                    actor,
-                    $"security-master-conflict-signoff:{existing.BreakId}:{conflict.ConflictId:N}",
-                    $"security-master-conflict:{conflict.ConflictId:N}",
-                    "security-master-casework",
-                    resolve.Item.Version,
-                    Reason: "Security Master conflict resolution includes steward sign-off.",
-                    Note: request.Reason ?? $"Security Master conflict {conflict.ConflictId:N} resolved.",
-                    Privileged: string.Equals(resolve.Item.ResolvedBy, actor, StringComparison.OrdinalIgnoreCase)),
-                ct)
-            .ConfigureAwait(false);
-        if (signOff.Status != ReconciliationBreakQueueTransitionStatus.Success)
-        {
-            _logger.LogWarning(
-                "Could not sign off Security Master conflict case {BreakId}: {Error}",
-                existing.BreakId,
-                signOff.Error);
-        }
     }
 
     public async Task SeedOperatorOverrideCaseAsync(
@@ -159,7 +132,7 @@ public sealed class SecurityMasterExceptionCaseworkService
             return;
         }
 
-        var resolvedBy = NormalizeActor(overrides.ReviewedBy) ?? NormalizeActor(actor);
+        var resolvedBy = NormalizeOptionalActor(overrides.ReviewedBy) ?? NormalizeActor(actor);
         if (existing.Status == ReconciliationBreakQueueStatus.Open)
         {
             var review = await _breakQueueRepository.StartReviewAsync(
@@ -167,7 +140,7 @@ public sealed class SecurityMasterExceptionCaseworkService
                         existing.BreakId,
                         existing.AssignedTo ?? resolvedBy,
                         resolvedBy,
-                        "Security Master override selected for approval sign-off.",
+                        "Security Master override selected for approval resolution.",
                         "Security Master"),
                     ct)
                 .ConfigureAwait(false);
@@ -197,33 +170,6 @@ public sealed class SecurityMasterExceptionCaseworkService
                 existing.BreakId,
                 resolve.Error);
             return;
-        }
-
-        if (resolve.Item is null)
-        {
-            return;
-        }
-
-        var signOff = await _breakQueueRepository.ApplyCaseworkCommandAsync(
-                new ReconciliationCaseworkCommand(
-                    existing.BreakId,
-                    ReconciliationCaseworkAction.SignOff,
-                    resolvedBy,
-                    $"security-master-override-signoff:{existing.BreakId}:{overrides.SecurityId:N}",
-                    $"security-master-override:{overrides.SecurityId:N}",
-                    "security-master-casework",
-                    resolve.Item.Version,
-                    Reason: "Security Master operator override approval includes steward sign-off.",
-                    Note: overrides.ReasonCode ?? "Security Master operator override approved.",
-                    Privileged: string.Equals(resolve.Item.ResolvedBy, resolvedBy, StringComparison.OrdinalIgnoreCase)),
-                ct)
-            .ConfigureAwait(false);
-        if (signOff.Status != ReconciliationBreakQueueTransitionStatus.Success)
-        {
-            _logger.LogWarning(
-                "Could not sign off Security Master override case {BreakId}: {Error}",
-                existing.BreakId,
-                signOff.Error);
         }
     }
 
@@ -301,7 +247,7 @@ public sealed class SecurityMasterExceptionCaseworkService
             ExceptionRoute: "security-master/operator-overrides",
             ToleranceProfileId: "security-master-override",
             RequiredSignoffRole: "Security Master steward",
-            SignoffStatus: isApproved ? "signed-off" : "pending-signoff",
+            SignoffStatus: isApproved ? "ready-for-signoff" : "pending-signoff",
             FundAccountId: null,
             ExplainabilitySummary: string.Join(
                 ", ",
@@ -312,7 +258,7 @@ public sealed class SecurityMasterExceptionCaseworkService
             RoutingTarget: route,
             RoutingDetail: overrides.SecurityId.ToString("D"),
             RecommendedAction: "Approve, reject, or remove the operator override before governed ledger, reconciliation, or report workflows consume it.",
-            LifecycleState: isApproved ? ReconciliationCaseLifecycleState.Posted : ReconciliationCaseLifecycleState.Open,
+            LifecycleState: isApproved ? ReconciliationCaseLifecycleState.Resolved : ReconciliationCaseLifecycleState.Open,
             LifecycleRationale: isApproved
                 ? "Security Master operator override is approved."
                 : "Auto-generated from a pending Security Master operator override.",
@@ -320,9 +266,7 @@ public sealed class SecurityMasterExceptionCaseworkService
             CustodianId: null,
             UpstreamSyncCursor: $"security-master-override:{overrides.SecurityId:N}:{overrides.UpdatedAt:O}:{overrides.ApprovalStatus}",
             LastUpstreamSyncAt: overrides.UpdatedAt,
-            SignoffHistory: isApproved && !string.IsNullOrWhiteSpace(overrides.ReviewedBy) && overrides.ReviewedAt.HasValue
-                ? [new ReconciliationCaseSignoffRecord(overrides.ReviewedBy, "Security Master steward", "Resolved", overrides.ReasonCode, overrides.ReviewedAt.Value)]
-                : null,
+            SignoffHistory: null,
             Team: "Security Master",
             StateTransitions: []);
     }
@@ -334,5 +278,8 @@ public sealed class SecurityMasterExceptionCaseworkService
         => $"security-master:override:{securityId:N}";
 
     private static string NormalizeActor(string? actor)
-        => string.IsNullOrWhiteSpace(actor) ? DefaultActor : actor.Trim();
+        => NormalizeOptionalActor(actor) ?? DefaultActor;
+
+    private static string? NormalizeOptionalActor(string? actor)
+        => string.IsNullOrWhiteSpace(actor) ? null : actor.Trim();
 }

--- a/tests/Meridian.Tests/Ui/SecurityMasterExceptionCaseworkServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/SecurityMasterExceptionCaseworkServiceTests.cs
@@ -64,7 +64,7 @@ public sealed class SecurityMasterExceptionCaseworkServiceTests
     }
 
     [Fact]
-    public async Task ApplyResolvedConflictAsync_TransitionsDurableCaseThroughReviewAndResolution()
+    public async Task ApplyResolvedConflictAsync_TransitionsDurableCaseThroughReviewAndResolutionWithoutSignOff()
     {
         var root = CreateTempRoot();
         try
@@ -81,13 +81,15 @@ public sealed class SecurityMasterExceptionCaseworkServiceTests
 
             var item = await repository.GetByIdAsync($"security-master:conflict:{conflict.ConflictId:N}");
             item.Should().NotBeNull();
-            item!.Status.Should().Be(ReconciliationBreakQueueStatus.SignedOff);
-            item.LifecycleState.Should().Be(ReconciliationCaseLifecycleState.SignedOff);
+            item!.Status.Should().Be(ReconciliationBreakQueueStatus.Resolved);
+            item.LifecycleState.Should().Be(ReconciliationCaseLifecycleState.Resolved);
             item.ResolvedBy.Should().Be("approver");
-            item.SignoffStatus.Should().Be("signed-off");
+            item.SignedOffBy.Should().BeNull();
+            item.SignoffStatus.Should().Be("ready-for-signoff");
             item.SignoffHistory.Should().ContainSingle(record =>
                 record.Actor == "approver" &&
-                record.Role == "Security Master steward");
+                record.Role == "Security Master steward" &&
+                record.Status == ReconciliationBreakQueueStatus.Resolved.ToString());
 
             var auditTypes = (await repository.GetAuditHistoryAsync(item.BreakId))
                 .Select(entry => entry.EventType)
@@ -95,7 +97,7 @@ public sealed class SecurityMasterExceptionCaseworkServiceTests
             auditTypes.Should().Contain("CaseCreated");
             auditTypes.Should().Contain("ReviewStarted");
             auditTypes.Should().Contain("Resolved");
-            auditTypes.Should().Contain("SignedOff");
+            auditTypes.Should().NotContain("SignedOff");
         }
         finally
         {
@@ -155,7 +157,7 @@ public sealed class SecurityMasterExceptionCaseworkServiceTests
     }
 
     [Fact]
-    public async Task SeedOperatorOverrideCaseAsync_ApprovedOverrideSignsOffExistingCasework()
+    public async Task SeedOperatorOverrideCaseAsync_ApprovedOverrideResolvesExistingCaseworkWithoutSignOff()
     {
         var root = CreateTempRoot();
         try
@@ -188,21 +190,78 @@ public sealed class SecurityMasterExceptionCaseworkServiceTests
 
             var item = await repository.GetByIdAsync($"security-master:override:{securityId:N}");
             item.Should().NotBeNull();
-            item!.Status.Should().Be(ReconciliationBreakQueueStatus.SignedOff);
-            item.LifecycleState.Should().Be(ReconciliationCaseLifecycleState.SignedOff);
+            item!.Status.Should().Be(ReconciliationBreakQueueStatus.Resolved);
+            item.LifecycleState.Should().Be(ReconciliationCaseLifecycleState.Resolved);
             item.ResolvedBy.Should().Be("security-steward");
-            item.SignedOffBy.Should().Be("security-steward");
-            item.SignoffStatus.Should().Be("signed-off");
+            item.SignedOffBy.Should().BeNull();
+            item.SignoffStatus.Should().Be("ready-for-signoff");
             item.SignoffHistory.Should().Contain(record =>
                 record.Actor == "security-steward" &&
-                record.Role == "Security Master steward");
+                record.Role == "Security Master steward" &&
+                record.Status == ReconciliationBreakQueueStatus.Resolved.ToString());
 
             var auditTypes = (await repository.GetAuditHistoryAsync(item.BreakId))
                 .Select(static entry => entry.EventType)
                 .ToArray();
             auditTypes.Should().Contain("ReviewStarted");
             auditTypes.Should().Contain("Resolved");
-            auditTypes.Should().Contain("SignedOff");
+            auditTypes.Should().NotContain("SignedOff");
+        }
+        finally
+        {
+            DeleteTempRoot(root);
+        }
+    }
+
+    [Fact]
+    public async Task SeedOperatorOverrideCaseAsync_ApprovedOverrideWithoutReviewerFallsBackToRequesterAndWaitsForSignOff()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var repository = BuildRepository(root);
+            var service = BuildService(repository);
+            var securityId = Guid.NewGuid();
+            var createdAt = DateTimeOffset.UtcNow.AddMinutes(-10);
+            var pending = new OperatorOverridesDto(
+                securityId,
+                new Dictionary<string, string> { ["sector"] = "Technology" },
+                "analyst",
+                createdAt)
+            {
+                ApprovalStatus = SecurityOverrideApprovalStatusDto.Pending,
+                ReasonCode = "CLASSIFICATION_CORRECTION"
+            };
+            await service.SeedOperatorOverrideCaseAsync(pending, "analyst");
+
+            var approved = pending with
+            {
+                UpdatedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+                ApprovalStatus = SecurityOverrideApprovalStatusDto.Approved,
+                ReviewedBy = null,
+                ReviewedAt = null
+            };
+
+            await service.SeedOperatorOverrideCaseAsync(approved, "analyst");
+
+            var item = await repository.GetByIdAsync($"security-master:override:{securityId:N}");
+            item.Should().NotBeNull();
+            item!.Status.Should().Be(ReconciliationBreakQueueStatus.Resolved);
+            item.LifecycleState.Should().Be(ReconciliationCaseLifecycleState.Resolved);
+            item.ResolvedBy.Should().Be("analyst");
+            item.SignedOffBy.Should().BeNull();
+            item.SignoffStatus.Should().Be("ready-for-signoff");
+            item.SignoffHistory.Should().Contain(record =>
+                record.Actor == "analyst" &&
+                record.Status == ReconciliationBreakQueueStatus.Resolved.ToString());
+            item.SignoffHistory.Should().NotContain(record =>
+                string.Equals(record.Actor, "security-master-casework", StringComparison.OrdinalIgnoreCase));
+
+            var auditTypes = (await repository.GetAuditHistoryAsync(item.BreakId))
+                .Select(static entry => entry.EventType)
+                .ToArray();
+            auditTypes.Should().Contain("Resolved");
+            auditTypes.Should().NotContain("SignedOff");
         }
         finally
         {


### PR DESCRIPTION
### Motivation
- Prevent automatic same-actor steward sign-off for Security Master conflicts and operator overrides so governed casework requires an independent steward review before durable sign-off.
- Avoid self-asserted privileged sign-off and stop falling back to the service account when a reviewer identity is missing, preserving dual-control and provenance guarantees.

### Description
- Stop issuing automatic `ReconciliationCaseworkAction.SignOff` for resolved Security Master conflicts and approved operator overrides so cases remain `Resolved`/`ready-for-signoff` instead of immediately becoming `SignedOff` (changes in `src/Meridian.Ui.Shared/Services/SecurityMasterExceptionCaseworkService.cs`).
- Ensure approved-override reviewer fallback no longer normalizes missing `ReviewedBy` to the service account by adding `NormalizeOptionalActor` and using it when computing `resolvedBy` (same service file).
- Change the override-case builder to report approved cases as `ready-for-signoff` with `LifecycleState = Resolved` and clear `SignoffHistory` so an independent steward must sign off (same service file).
- Update regression tests to reflect the independent-sign-off posture and add a test for the missing-reviewer fallback case in `tests/Meridian.Tests/Ui/SecurityMasterExceptionCaseworkServiceTests.cs`, and update the module README to document the behavior change (`src/Meridian.Ui.Shared/README.md`).

### Testing
- Ran repository static checks (`git diff --check`) and a targeted Python marker check that validated the service no longer emits automatic `SignOff` commands and that `ready-for-signoff` posture exists, which passed.
- Updated unit tests in `tests/Meridian.Tests/Ui/SecurityMasterExceptionCaseworkServiceTests.cs` to assert the new `Resolved`/`ready-for-signoff` outcome and added a test for approved overrides without `ReviewedBy` falling back to the requester and awaiting sign-off; these tests were added but could not be executed in the environment because `dotnet` was not available.
- Verified README text was updated to note that approved overrides remain ready for independent steward sign-off (documentation change validated via diff).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a192f1d896c8320aa2b2b30417556da)