### PR TITLE
Add ownership lifecycle validation for update/replace and add tests/endpoints

### DIFF
--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -64,13 +64,13 @@ flowchart LR
 - `InMemoryFundStructureService`
   - Command handling: implements the full `IFundStructureService` creation, ownership lifecycle, validation, and assignment surface.
   - Query projection: organization graph, legacy fund graph, advisory, fund operating, accounting, and cash-flow views.
-  - Validation/policy: delegates pure portfolio-parent rules to `IFundStructurePolicyService`; owns existence checks, ownership-link lifecycle checks, and cycle validation.
+  - Validation/policy: delegates pure portfolio-parent rules to `IFundStructurePolicyService`; owns existence checks, policy-backed ownership-link lifecycle checks for updates/replacements, and cycle validation.
   - Workflow orchestration: parent-link creation, ownership projection rebuilds after link lifecycle changes, shared-data synchronization, cross-service composition with account/security-master services.
   - Storage concerns: snapshot capture/load/save via `IFundStructureStateStore`, including updated, expired, and replacement ownership links.
 - `PostgresFundStructureService`
   - Command handling: implements the same `IFundStructureService` creation, ownership lifecycle, validation, and assignment surface over `IFundStructureStore`.
   - Query projection: mirrors the in-memory graph, advisory, fund operating, and accounting projections; cash-flow view remains unsupported and returns `null`.
-  - Validation/policy: reuses `FundStructurePolicyService` for pure rules and service-local ownership existence/cycle validation for persisted links.
+  - Validation/policy: reuses `FundStructurePolicyService` for pure rules and service-local ownership existence/cycle validation for persisted links, including update and replacement mutations before rows are upserted.
   - Workflow orchestration: loads a mutable snapshot, applies lifecycle mutations, rebuilds ownership projections, and upserts changed rows through the store.
   - Storage concerns: persists organizations, businesses, clients, funds, sleeves, vehicles, entities, portfolios, ownership links, and assignments via `IFundStructureStore`.
 - `InMemoryFundAccountService` (peer)

--- a/src/Meridian.Application/FundStructure/InMemoryFundStructureService.cs
+++ b/src/Meridian.Application/FundStructure/InMemoryFundStructureService.cs
@@ -595,6 +595,7 @@ public sealed class InMemoryFundStructureService : INonProductionOnlyService, IF
                 EffectiveTo = request.EffectiveTo,
                 Notes = request.Notes
             };
+            ValidateOwnershipLinkMutationLocked(updated, existing.OwnershipLinkId);
             _ownershipLinks[updated.OwnershipLinkId] = updated;
             RebuildOwnershipProjectionsLocked();
             result = (updated, CaptureSnapshotLocked());
@@ -673,17 +674,7 @@ public sealed class InMemoryFundStructureService : INonProductionOnlyService, IF
                 throw new InvalidOperationException("Replacement expiration cannot be earlier than the replaced link's effective-from timestamp.");
             }
 
-            _ownershipLinks[existing.OwnershipLinkId] = existing with { EffectiveTo = replacedEffectiveTo };
-            if (parentKind == FundStructureNodeKindDto.Account)
-            {
-                _linkedAccountIds.Add(request.ParentNodeId);
-            }
-
-            if (childKind == FundStructureNodeKindDto.Account)
-            {
-                _linkedAccountIds.Add(request.ChildNodeId);
-            }
-
+            var expired = existing with { EffectiveTo = replacedEffectiveTo };
             var replacement = new OwnershipLinkDto(
                 request.ReplacementOwnershipLinkId,
                 request.ParentNodeId,
@@ -694,6 +685,28 @@ public sealed class InMemoryFundStructureService : INonProductionOnlyService, IF
                 request.EffectiveFrom,
                 EffectiveTo: null,
                 request.Notes);
+
+            var existingLinksForValidation = _ownershipLinks.Values
+                .Select(link => link.OwnershipLinkId == existing.OwnershipLinkId ? expired : link)
+                .ToList();
+            ValidateOwnershipLinkMutationLocked(
+                replacement,
+                replacement.OwnershipLinkId,
+                existingLinksForValidation,
+                parentKind,
+                childKind);
+
+            _ownershipLinks[existing.OwnershipLinkId] = expired;
+            if (parentKind == FundStructureNodeKindDto.Account)
+            {
+                _linkedAccountIds.Add(request.ParentNodeId);
+            }
+
+            if (childKind == FundStructureNodeKindDto.Account)
+            {
+                _linkedAccountIds.Add(request.ChildNodeId);
+            }
+
             _ownershipLinks[replacement.OwnershipLinkId] = replacement;
             RebuildOwnershipProjectionsLocked();
             result = (replacement, CaptureSnapshotLocked());
@@ -3676,6 +3689,37 @@ public sealed class InMemoryFundStructureService : INonProductionOnlyService, IF
         {
             throw new InvalidOperationException($"Entity {entityId} was not found.");
         }
+    }
+
+
+    private void ValidateOwnershipLinkMutationLocked(
+        OwnershipLinkDto candidate,
+        Guid linkIdBeingMutated,
+        IReadOnlyCollection<OwnershipLinkDto>? existingLinksOverride = null,
+        FundStructureNodeKindDto? knownParentKind = null,
+        FundStructureNodeKindDto? knownChildKind = null)
+    {
+        var parentKind = knownParentKind ?? ResolveStoredNodeKindForMutationLocked(candidate.ParentNodeId, "Parent");
+        var childKind = knownChildKind ?? ResolveStoredNodeKindForMutationLocked(candidate.ChildNodeId, "Child");
+        var nodeKinds = CaptureNodeKindsLocked();
+        nodeKinds[candidate.ParentNodeId] = parentKind;
+        nodeKinds[candidate.ChildNodeId] = childKind;
+        _policyService.ValidateOwnershipLink(
+            candidate,
+            parentKind,
+            childKind,
+            existingLinksOverride ?? _ownershipLinks.Values.Where(link => link.OwnershipLinkId != linkIdBeingMutated).ToList(),
+            nodeKinds);
+    }
+
+    private FundStructureNodeKindDto ResolveStoredNodeKindForMutationLocked(Guid nodeId, string role)
+    {
+        if (TryGetStoredNodeKindLocked(nodeId, out var kind))
+        {
+            return kind;
+        }
+
+        throw new InvalidOperationException($"{role} node {nodeId} was not found.");
     }
 
     private Dictionary<Guid, FundStructureNodeKindDto> CaptureNodeKindsLocked()

--- a/src/Meridian.Application/FundStructure/PostgresFundStructureService.cs
+++ b/src/Meridian.Application/FundStructure/PostgresFundStructureService.cs
@@ -431,6 +431,7 @@ public sealed class PostgresFundStructureService : IFundStructureService
                 EffectiveTo = request.EffectiveTo,
                 Notes = request.Notes
             };
+            ValidateOwnershipLinkMutation(snap, updated, existing.OwnershipLinkId);
             snap.OwnershipLinks[updated.OwnershipLinkId] = updated;
             RebuildOwnershipProjections(snap);
             await PersistChangedAsync(snap, ct).ConfigureAwait(false);
@@ -490,10 +491,7 @@ public sealed class PostgresFundStructureService : IFundStructureService
             if (replacedEffectiveTo < existing.EffectiveFrom)
                 throw new InvalidOperationException("Replacement expiration cannot be earlier than the replaced link's effective-from timestamp.");
 
-            snap.OwnershipLinks[existing.OwnershipLinkId] = existing with { EffectiveTo = replacedEffectiveTo };
-            if (parentKind == FundStructureNodeKindDto.Account) snap.LinkedAccountIds.Add(request.ParentNodeId);
-            if (childKind == FundStructureNodeKindDto.Account) snap.LinkedAccountIds.Add(request.ChildNodeId);
-
+            var expired = existing with { EffectiveTo = replacedEffectiveTo };
             var replacement = new OwnershipLinkDto(
                 request.ReplacementOwnershipLinkId,
                 request.ParentNodeId,
@@ -504,6 +502,22 @@ public sealed class PostgresFundStructureService : IFundStructureService
                 request.EffectiveFrom,
                 EffectiveTo: null,
                 request.Notes);
+
+            var existingLinksForValidation = snap.OwnershipLinks.Values
+                .Select(link => link.OwnershipLinkId == existing.OwnershipLinkId ? expired : link)
+                .ToList();
+            ValidateOwnershipLinkMutation(
+                snap,
+                replacement,
+                replacement.OwnershipLinkId,
+                existingLinksForValidation,
+                parentKind,
+                childKind);
+
+            snap.OwnershipLinks[existing.OwnershipLinkId] = expired;
+            if (parentKind == FundStructureNodeKindDto.Account) snap.LinkedAccountIds.Add(request.ParentNodeId);
+            if (childKind == FundStructureNodeKindDto.Account) snap.LinkedAccountIds.Add(request.ChildNodeId);
+
             snap.OwnershipLinks[replacement.OwnershipLinkId] = replacement;
             RebuildOwnershipProjections(snap);
             await PersistChangedAsync(snap, ct).ConfigureAwait(false);
@@ -1230,6 +1244,38 @@ public sealed class PostgresFundStructureService : IFundStructureService
         {
             snap.InvestmentPortfolios[parentPortfolio.InvestmentPortfolioId] = parentPortfolio with { AccountIds = AppendUnique(parentPortfolio.AccountIds, link.ChildNodeId) };
         }
+    }
+
+
+    private void ValidateOwnershipLinkMutation(
+        MutableSnapshot snap,
+        OwnershipLinkDto candidate,
+        Guid linkIdBeingMutated,
+        IReadOnlyCollection<OwnershipLinkDto>? existingLinksOverride = null,
+        FundStructureNodeKindDto? knownParentKind = null,
+        FundStructureNodeKindDto? knownChildKind = null)
+    {
+        var parentKind = knownParentKind ?? ResolveNodeKindForMutation(snap, candidate.ParentNodeId, "Parent");
+        var childKind = knownChildKind ?? ResolveNodeKindForMutation(snap, candidate.ChildNodeId, "Child");
+        var nodeKinds = CaptureNodeKinds(snap);
+        nodeKinds[candidate.ParentNodeId] = parentKind;
+        nodeKinds[candidate.ChildNodeId] = childKind;
+        _policy.ValidateOwnershipLink(
+            candidate,
+            parentKind,
+            childKind,
+            existingLinksOverride ?? snap.OwnershipLinks.Values.Where(link => link.OwnershipLinkId != linkIdBeingMutated).ToList(),
+            nodeKinds);
+    }
+
+    private static FundStructureNodeKindDto ResolveNodeKindForMutation(MutableSnapshot snap, Guid nodeId, string role)
+    {
+        if (TryGetNodeKind(snap, nodeId, out var kind))
+        {
+            return kind;
+        }
+
+        throw new InvalidOperationException($"{role} node {nodeId} was not found.");
     }
 
     // ── Static utilities ──────────────────────────────────────────────────────

--- a/tests/Meridian.FundStructure.Tests/InMemoryFundStructureServiceTests.cs
+++ b/tests/Meridian.FundStructure.Tests/InMemoryFundStructureServiceTests.cs
@@ -327,6 +327,30 @@ public sealed class InMemoryFundStructureServiceTests
     }
 
     [Fact]
+    public async Task UpdateOwnershipLinkAsync_WhenRelationshipNoLongerMatchesNodeKinds_ThrowsInvalidOperation()
+    {
+        var fixture = await CreateHybridFixtureAsync();
+        var now = new DateTimeOffset(2026, 04, 07, 0, 0, 0, TimeSpan.Zero);
+        var linkId = Guid.NewGuid();
+
+        await fixture.StructureService.LinkNodesAsync(new LinkFundStructureNodesRequest(
+            linkId,
+            fixture.FundId,
+            fixture.DirectFundPortfolioId,
+            OwnershipRelationshipTypeDto.AllocatesTo,
+            now,
+            "test"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.StructureService.UpdateOwnershipLinkAsync(
+            new UpdateOwnershipLinkRequest(
+                linkId,
+                OwnershipRelationshipTypeDto.Owns,
+                now,
+                "test",
+                Notes: "invalid relationship mutation")));
+    }
+
+    [Fact]
     public async Task ReplaceOwnershipLinkAsync_ExpiresOriginalAndCreatesReplacementInActiveGraph()
     {
         var fixture = await CreateHybridFixtureAsync();
@@ -363,6 +387,37 @@ public sealed class InMemoryFundStructureServiceTests
         Assert.DoesNotContain(activeGraph.OwnershipLinks, link => link.OwnershipLinkId == originalLinkId);
         Assert.Contains(activeGraph.OwnershipLinks, link => link.OwnershipLinkId == replacementLinkId);
         Assert.Equal(now.AddDays(1), allLinksGraph.OwnershipLinks.Single(link => link.OwnershipLinkId == originalLinkId).EffectiveTo);
+    }
+
+    [Fact]
+    public async Task ReplaceOwnershipLinkAsync_WhenReplacementRelationshipNoLongerMatchesNodeKinds_ThrowsInvalidOperation()
+    {
+        var fixture = await CreateHybridFixtureAsync();
+        var now = new DateTimeOffset(2026, 04, 07, 0, 0, 0, TimeSpan.Zero);
+        var originalLinkId = Guid.NewGuid();
+
+        await fixture.StructureService.LinkNodesAsync(new LinkFundStructureNodesRequest(
+            originalLinkId,
+            fixture.FundId,
+            fixture.DirectFundPortfolioId,
+            OwnershipRelationshipTypeDto.AllocatesTo,
+            now,
+            "test"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.StructureService.ReplaceOwnershipLinkAsync(
+            new ReplaceOwnershipLinkRequest(
+                originalLinkId,
+                Guid.NewGuid(),
+                fixture.FundId,
+                fixture.DirectFundPortfolioId,
+                OwnershipRelationshipTypeDto.Owns,
+                now.AddDays(1),
+                "test",
+                Notes: "invalid replacement")));
+
+        var graph = await fixture.StructureService.GetOrganizationStructureAsync(
+            new OrganizationStructureQuery(OrganizationId: fixture.OrganizationId, ActiveOnly: false, AsOf: now.AddDays(2)));
+        Assert.Null(graph.OwnershipLinks.Single(link => link.OwnershipLinkId == originalLinkId).EffectiveTo);
     }
 
     [Fact]

--- a/tests/Meridian.Tests/Integration/EndpointTests/FundStructureEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/FundStructureEndpointTests.cs
@@ -121,7 +121,7 @@ public sealed class FundStructureEndpointTests
             $"/api/fund-structure/links/{linkId}",
             new UpdateOwnershipLinkRequest(
                 Guid.Empty,
-                OwnershipRelationshipTypeDto.Owns,
+                OwnershipRelationshipTypeDto.AllocatesTo,
                 now,
                 "endpoint-test",
                 OwnershipPercent: 60m,
@@ -147,13 +147,87 @@ public sealed class FundStructureEndpointTests
 
         updated.Should().NotBeNull();
         updated!.OwnershipLinkId.Should().Be(linkId);
-        updated.RelationshipType.Should().Be(OwnershipRelationshipTypeDto.Owns);
+        updated.RelationshipType.Should().Be(OwnershipRelationshipTypeDto.AllocatesTo);
         updated.OwnershipPercent.Should().Be(60m);
         validation.Should().NotBeNull();
         validation!.IsValid.Should().BeTrue();
         expired.Should().NotBeNull();
         expired!.EffectiveTo.Should().Be(now.AddDays(1));
         expired.Notes.Should().Be("endpoint expiration");
+    }
+
+    [Fact]
+    public async Task OwnershipLifecycleReplaceEndpoint_CreatesReplacementLink()
+    {
+        var structureService = _fixture.Services.GetRequiredService<IFundStructureService>();
+        var organizationId = Guid.NewGuid();
+        var businessId = Guid.NewGuid();
+        var fundId = Guid.NewGuid();
+        var portfolioId = Guid.NewGuid();
+        var linkId = Guid.NewGuid();
+        var replacementLinkId = Guid.NewGuid();
+        var now = new DateTimeOffset(2026, 04, 13, 0, 0, 0, TimeSpan.Zero);
+
+        await structureService.CreateOrganizationAsync(new CreateOrganizationRequest(
+            organizationId,
+            $"ORG-{Guid.NewGuid():N}"[..12].ToUpperInvariant(),
+            "Ownership Replace Endpoint Organization",
+            "USD",
+            now,
+            "endpoint-test"));
+        await structureService.CreateBusinessAsync(new CreateBusinessRequest(
+            businessId,
+            organizationId,
+            BusinessKindDto.FundManager,
+            $"BUS-{Guid.NewGuid():N}"[..12].ToUpperInvariant(),
+            "Ownership Replace Endpoint Business",
+            "USD",
+            now,
+            "endpoint-test"));
+        await structureService.CreateFundAsync(new CreateFundRequest(
+            fundId,
+            $"FND-{Guid.NewGuid():N}"[..12].ToUpperInvariant(),
+            "Ownership Replace Endpoint Fund",
+            "USD",
+            now,
+            "endpoint-test",
+            BusinessId: businessId));
+        await structureService.CreateInvestmentPortfolioAsync(new CreateInvestmentPortfolioRequest(
+            portfolioId,
+            businessId,
+            $"PRT-{Guid.NewGuid():N}"[..12].ToUpperInvariant(),
+            "Ownership Replace Endpoint Portfolio",
+            "USD",
+            now,
+            "endpoint-test",
+            FundId: fundId));
+        await structureService.LinkNodesAsync(new LinkFundStructureNodesRequest(
+            linkId,
+            fundId,
+            portfolioId,
+            OwnershipRelationshipTypeDto.AllocatesTo,
+            now,
+            "endpoint-test",
+            Notes: "endpoint replace original"));
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/fund-structure/links/{linkId}/replace",
+            new ReplaceOwnershipLinkRequest(
+                Guid.Empty,
+                replacementLinkId,
+                fundId,
+                portfolioId,
+                OwnershipRelationshipTypeDto.AllocatesTo,
+                now.AddDays(1),
+                "endpoint-test",
+                Notes: "endpoint replacement"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var replacement = await response.Content.ReadFromJsonAsync<OwnershipLinkDto>();
+        replacement.Should().NotBeNull();
+        replacement!.OwnershipLinkId.Should().Be(replacementLinkId);
+        replacement.EffectiveFrom.Should().Be(now.AddDays(1));
+        replacement.Notes.Should().Be("endpoint replacement");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Ensure ownership-link lifecycle mutations re-run policy validation so updates and replacements cannot produce invalid parent/child relationship types or cycles.
- Surface the same validation semantics across in-memory and PostgreSQL-backed services and the public endpoints so UI/API and persistence behavior are consistent.
- Provide regression and endpoint coverage to prevent regressions during future refactors or persistence migrations.

### Description
- Reintroduced policy-backed checks for update and replacement mutations by adding `ValidateOwnershipLinkMutationLocked` in `InMemoryFundStructureService` and `ValidateOwnershipLinkMutation` in `PostgresFundStructureService`, and invoking them before applying `UpdateOwnershipLinkAsync` and `ReplaceOwnershipLinkAsync` changes.
- Ensure replacement validation runs against a snapshot where the original link is treated as expired so the new link is validated against the effective link set before persisting the replacement.
- Added regression tests `UpdateOwnershipLinkAsync_WhenRelationshipNoLongerMatchesNodeKinds_ThrowsInvalidOperation` and `ReplaceOwnershipLinkAsync_WhenReplacementRelationshipNoLongerMatchesNodeKinds_ThrowsInvalidOperation` in `tests/Meridian.FundStructure.Tests/InMemoryFundStructureServiceTests.cs` and added endpoint tests for the replace route plus aligned ownership lifecycle endpoint assertions in `tests/Meridian.Tests/Integration/EndpointTests/FundStructureEndpointTests.cs`.
- Updated `docs/architecture/module-map.md` to document that ownership lifecycle validation is policy-backed and enforced in both service implementations.

### Testing
- Ran `git diff --check` to validate source changes and it completed without warnings.
- Attempted targeted unit and integration runs with `dotnet test` for `Meridian.FundStructure.Tests` and `Meridian.Tests` but execution was blocked because the .NET SDK is not available in this environment; tests were added and should pass locally or in CI when `dotnet` is available using the provided filters.
- Executed the implementation-assurance rubric via `python3 .codex/skills/meridian-implementation-assurance/scripts/score_eval.py` which produced a report (Total Score: 9/10) and lists the blocked `dotnet` validation as a failed check with follow-up instructions to run the targeted `dotnet test` commands after installing the SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19ea75e03083209fae3373f63a0185)