### PR TITLE
Harden Security Master lineage evidence checks

### DIFF
--- a/src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflowService.cs
+++ b/src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflowService.cs
@@ -1649,7 +1649,7 @@ public sealed class OperationsContinuityWorkflowService : IOperationsContinuityW
                         evidence));
                 }
 
-                if (string.IsNullOrWhiteSpace(line.SecurityMasterApprovalReference))
+                if (!HasSecurityMasterApprovalEvidence(line.SecurityMasterApprovalReference))
                 {
                     blockers.Add(CreateJournalCandidateBlocker(
                         "LEDGER_LINE_SECURITY_MASTER_APPROVAL_EVIDENCE_MISSING",
@@ -1723,6 +1723,11 @@ public sealed class OperationsContinuityWorkflowService : IOperationsContinuityW
         }
 
         var mapping = mappingReference.Trim();
+        if (!HasLedgerMappingEvidence(mapping))
+        {
+            return false;
+        }
+
         var resolvedSecurityId = securityId.GetValueOrDefault();
         if (resolvedSecurityId != Guid.Empty &&
             (mapping.Contains(resolvedSecurityId.ToString("D"), StringComparison.OrdinalIgnoreCase) ||
@@ -1734,6 +1739,45 @@ public sealed class OperationsContinuityWorkflowService : IOperationsContinuityW
         return !string.IsNullOrWhiteSpace(symbol) &&
             mapping.Contains(symbol.Trim(), StringComparison.OrdinalIgnoreCase);
     }
+
+    private static bool HasSecurityMasterApprovalEvidence(string? approvalReference) =>
+        ContainsEvidencePrefix(approvalReference, "sm-approval:") ||
+        ContainsEvidencePrefix(approvalReference, "approval:");
+
+    private static bool HasLedgerMappingEvidence(string mappingReference) =>
+        ContainsEvidencePrefix(mappingReference, "ledger-map:") ||
+        ContainsEvidencePrefix(mappingReference, "ledger-mapping:");
+
+    private static bool ContainsEvidencePrefix(string? value, string prefix)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var normalized = value.Trim();
+        var index = normalized.IndexOf(prefix, StringComparison.OrdinalIgnoreCase);
+        while (index >= 0)
+        {
+            var valueStart = index + prefix.Length;
+            if (HasTokenBoundaryBefore(normalized, index) &&
+                valueStart < normalized.Length &&
+                !IsEvidenceDelimiter(normalized[valueStart]))
+            {
+                return true;
+            }
+
+            index = normalized.IndexOf(prefix, valueStart, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    private static bool HasTokenBoundaryBefore(string value, int tokenStart) =>
+        tokenStart == 0 || IsEvidenceDelimiter(value[tokenStart - 1]);
+
+    private static bool IsEvidenceDelimiter(char value) =>
+        char.IsWhiteSpace(value) || value is ':' or ';' or '|' or ',';
 
     private static bool IsInstrumentBearingJournalLine(OperationsLedgerJournalLineDto line)
         => !string.IsNullOrWhiteSpace(line.Symbol) ||

--- a/src/Meridian.Storage/Ledger/LedgerPeriodPostingGuard.cs
+++ b/src/Meridian.Storage/Ledger/LedgerPeriodPostingGuard.cs
@@ -198,13 +198,58 @@ public static class LedgerPeriodPostingGuard
         value.Contains(securityId.ToString("N"), StringComparison.OrdinalIgnoreCase);
 
     private static bool HasApprovalEvidence(string provenance, string lineage) =>
-        provenance.Contains("approved:true", StringComparison.OrdinalIgnoreCase) ||
-        lineage.Contains("sm-approval:", StringComparison.OrdinalIgnoreCase) ||
-        lineage.Contains("approval:", StringComparison.OrdinalIgnoreCase);
+        ContainsDelimitedToken(provenance, "approved:true") ||
+        ContainsEvidencePrefix(lineage, "sm-approval:") ||
+        ContainsEvidencePrefix(lineage, "approval:");
 
     private static bool HasLedgerMappingEvidence(string lineage) =>
-        lineage.Contains("ledger-map:", StringComparison.OrdinalIgnoreCase) ||
-        lineage.Contains("ledger-mapping:", StringComparison.OrdinalIgnoreCase);
+        ContainsEvidencePrefix(lineage, "ledger-map:") ||
+        ContainsEvidencePrefix(lineage, "ledger-mapping:");
+
+    private static bool ContainsDelimitedToken(string value, string token)
+    {
+        var index = value.IndexOf(token, StringComparison.OrdinalIgnoreCase);
+        while (index >= 0)
+        {
+            var tokenEnd = index + token.Length;
+            if (HasTokenBoundaryBefore(value, index) && HasTokenBoundaryAfter(value, tokenEnd))
+            {
+                return true;
+            }
+
+            index = value.IndexOf(token, tokenEnd, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    private static bool ContainsEvidencePrefix(string value, string prefix)
+    {
+        var index = value.IndexOf(prefix, StringComparison.OrdinalIgnoreCase);
+        while (index >= 0)
+        {
+            var valueStart = index + prefix.Length;
+            if (HasTokenBoundaryBefore(value, index) &&
+                valueStart < value.Length &&
+                !IsEvidenceDelimiter(value[valueStart]))
+            {
+                return true;
+            }
+
+            index = value.IndexOf(prefix, valueStart, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    private static bool HasTokenBoundaryBefore(string value, int tokenStart) =>
+        tokenStart == 0 || IsEvidenceDelimiter(value[tokenStart - 1]);
+
+    private static bool HasTokenBoundaryAfter(string value, int tokenEnd) =>
+        tokenEnd == value.Length || IsEvidenceDelimiter(value[tokenEnd]);
+
+    private static bool IsEvidenceDelimiter(char value) =>
+        char.IsWhiteSpace(value) || value is ':' or ';' or '|' or ',';
 
     private static void RequireText(string? value, Guid journalEntryId, string fieldName)
     {

--- a/tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs
@@ -214,7 +214,6 @@ public sealed class OperationsContinuityWorkflowServiceTests
         derivation.Derive(workflow).Should().Be(OperationsWorkflowStatusDto.ReadyForClose);
     }
 
-
     [Fact]
     public void Derive_ShouldUseDeterministicHighestActiveStageOrdering()
     {
@@ -1112,6 +1111,74 @@ public sealed class OperationsContinuityWorkflowServiceTests
     }
 
     [Fact]
+    public async Task PostLedgerEntriesAsync_ShouldRejectForgedSecurityMasterApprovalReference()
+    {
+        var journalStore = new RecordingLedgerJournalStore();
+        var service = CreateService(out _, out var auditStore, journalStore);
+        var workflow = await CreateLedgerValidatedWorkflowAsync(service);
+        var candidate = CreateInstrumentJournalCandidate(workflow.FundAccountId);
+        candidate = candidate with
+        {
+            Lines =
+            [
+                candidate.Lines[0] with { SecurityMasterApprovalReference = "no-sm-approval:denied" },
+                candidate.Lines[1]
+            ]
+        };
+
+        var result = await service.PostLedgerEntriesAsync(workflow.WorkflowId, new OperationsLedgerPostRequestDto(
+            workflow.Version,
+            "ops-user",
+            LedgerBatchId: "ledger-batch-forged-approval-reference",
+            PostingKind: "period-close",
+            PeriodOpen: true,
+            JournalCandidate: candidate));
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be("VALIDATION_FAILED");
+        result.Blockers.Should().ContainSingle(blocker =>
+            blocker.Code == "LEDGER_LINE_SECURITY_MASTER_APPROVAL_EVIDENCE_MISSING");
+        journalStore.Appended.Should().BeEmpty();
+
+        var timeline = await auditStore.GetTimelineAsync(workflow.WorkflowId);
+        timeline.Select(entry => entry.EventType).Should().NotContain("ledger-posted");
+    }
+
+    [Fact]
+    public async Task PostLedgerEntriesAsync_ShouldRejectForgedSecurityMasterLedgerMappingReference()
+    {
+        var journalStore = new RecordingLedgerJournalStore();
+        var service = CreateService(out _, out var auditStore, journalStore);
+        var workflow = await CreateLedgerValidatedWorkflowAsync(service);
+        var candidate = CreateInstrumentJournalCandidate(workflow.FundAccountId);
+        candidate = candidate with
+        {
+            Lines =
+            [
+                candidate.Lines[0] with { LedgerMappingReference = "no-ledger-map:AAPL" },
+                candidate.Lines[1]
+            ]
+        };
+
+        var result = await service.PostLedgerEntriesAsync(workflow.WorkflowId, new OperationsLedgerPostRequestDto(
+            workflow.Version,
+            "ops-user",
+            LedgerBatchId: "ledger-batch-forged-mapping-reference",
+            PostingKind: "period-close",
+            PeriodOpen: true,
+            JournalCandidate: candidate));
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be("VALIDATION_FAILED");
+        result.Blockers.Should().ContainSingle(blocker =>
+            blocker.Code == "LEDGER_LINE_SECURITY_MASTER_MAPPING_MISMATCH");
+        journalStore.Appended.Should().BeEmpty();
+
+        var timeline = await auditStore.GetTimelineAsync(workflow.WorkflowId);
+        timeline.Select(entry => entry.EventType).Should().NotContain("ledger-posted");
+    }
+
+    [Fact]
     public async Task PostLedgerEntriesAsync_ShouldRejectInstrumentAccountLinesWithoutExplicitSecurityMasterLineage()
     {
         var journalStore = new RecordingLedgerJournalStore();
@@ -1558,7 +1625,6 @@ public sealed class OperationsContinuityWorkflowServiceTests
             blocker.Code == "SM_ACCOUNTING_TERMS_INCOMPLETE" &&
             blocker.Gate == OperationsGateKeyDto.SecurityMaster);
     }
-
 
     [Fact]
     public async Task RunReconciliationAsync_WithSecurityAccountingIssues_ShouldReturnDeterministicSecurityMasterBlockerCode()

--- a/tests/Meridian.Tests/Storage/LedgerJournalStoreTests.cs
+++ b/tests/Meridian.Tests/Storage/LedgerJournalStoreTests.cs
@@ -246,6 +246,35 @@ public sealed class LedgerJournalStoreTests
     }
 
     [Fact]
+    public void PostingGuard_InstrumentEntry_RejectsForgedNegativeApprovalEvidence()
+    {
+        var period = BuildAccountingPeriod("Open");
+        var write = BuildInstrumentJournalWrite(
+            period.PeriodId,
+            approvalReferenceOverride: "no-sm-approval:denied",
+            securityMasterProvenanceOverride: "security-master:bce424708f6b4bd39fc7b8763f8b48b1;snapshot:test-source-hash;unapproved:true");
+
+        var act = () => LedgerPeriodPostingGuard.Validate(write, period);
+
+        act.Should().Throw<LedgerValidationException>()
+            .WithMessage("*without approved Security Master evidence*");
+    }
+
+    [Fact]
+    public void PostingGuard_InstrumentEntry_RejectsForgedNegativeLedgerMappingEvidence()
+    {
+        var period = BuildAccountingPeriod("Open");
+        var write = BuildInstrumentJournalWrite(
+            period.PeriodId,
+            ledgerMappingReferenceOverride: "no-ledger-map:AAPL");
+
+        var act = () => LedgerPeriodPostingGuard.Validate(write, period);
+
+        act.Should().Throw<LedgerValidationException>()
+            .WithMessage("*without a Security Master ledger mapping reference*");
+    }
+
+    [Fact]
     public void LedgerJournalMigration_DefinesJournalTablesAndLineageColumns()
     {
         var sql = ReadMigration("V_ledger_001__journal_entries.sql");
@@ -360,18 +389,21 @@ public sealed class LedgerJournalStoreTests
         Guid periodId,
         bool includeSecurityMasterProvenance = true,
         bool includeApprovalEvidence = true,
-        bool includeLedgerMapping = true)
+        bool includeLedgerMapping = true,
+        string? securityMasterProvenanceOverride = null,
+        string? ledgerMappingReferenceOverride = null,
+        string? approvalReferenceOverride = null)
     {
         var journalEntryId = Guid.NewGuid();
         var occurredAt = DateTimeOffset.Parse("2026-01-31T21:00:00Z");
         var securityId = Guid.Parse("BCE42470-8F6B-4BD3-9FC7-B8763F8B48B1");
         const string symbol = "AAPL";
         const string description = "Approved Security Master instrument posting";
-        var mapping = includeLedgerMapping ? "ledger-map:aapl-gaap-securities" : "missing";
-        var approval = includeApprovalEvidence ? "sm-approval:aapl-controller" : "missing";
-        var provenance = includeApprovalEvidence
+        var mapping = ledgerMappingReferenceOverride ?? (includeLedgerMapping ? "ledger-map:aapl-gaap-securities" : "missing");
+        var approval = approvalReferenceOverride ?? (includeApprovalEvidence ? "sm-approval:aapl-controller" : "missing");
+        var provenance = securityMasterProvenanceOverride ?? (includeApprovalEvidence
             ? $"security-master:{securityId:N};snapshot:test-source-hash;approved:true"
-            : $"security-master:{securityId:N};snapshot:test-source-hash";
+            : $"security-master:{securityId:N};snapshot:test-source-hash");
         var tags = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             ["securityMasterLineage"] = $"{symbol}:{securityId:N}:{mapping}:{approval}:{provenance}"


### PR DESCRIPTION
### Motivation
- Prevent forged or negative evidence strings from bypassing Security Master lineage and ledger-mapping guards by replacing loose substring matching with delimiter-aware checks.
- Ensure the operations-continuity endpoint and the storage-level posting guard both require structured, tokenized approval and mapping evidence instead of any substring occurrence.

### Description
- Replace naive `Contains(...)` checks with delimiter-aware helpers in `src/Meridian.Storage/Ledger/LedgerPeriodPostingGuard.cs` (`ContainsDelimitedToken`, `ContainsEvidencePrefix`, token-boundary and delimiter helpers) so `approved:true`, `sm-approval:` and `ledger-map:` are recognized only when they appear as proper evidence tokens/prefixes.
- Tighten `src/Meridian.Application/OperationsContinuity/OperationsContinuityWorkflowService.cs` validation to require `HasSecurityMasterApprovalEvidence` and `HasLedgerMappingEvidence` (uses the same evidence-prefix/tokens semantics) and short-circuit ledger-mapping checks when evidence is not valid.
- Add unit/regression tests that exercise forged negative or misleading strings (`unapproved:true`, `no-sm-approval:denied`, `no-ledger-map:AAPL`) in `tests/Meridian.Tests/Storage/LedgerJournalStoreTests.cs` and `tests/Meridian.Tests/Application/OperationsContinuityWorkflowServiceTests.cs`.
- Changes are intentionally small and backward-compatible with the existing lineage/tag formats while closing the substring-bypass gap.

### Testing
- Ran targeted test subset: `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~LedgerJournalStoreTests|FullyQualifiedName~OperationsContinuityWorkflowServiceTests" --logger "console;verbosity=normal"` after ensuring .NET SDK availability, and all matching tests passed (total test run: 93 passed).
- Re-ran no-build filtered tests: `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --no-build --filter "FullyQualifiedName~LedgerJournalStoreTests|FullyQualifiedName~OperationsContinuityWorkflowServiceTests" --logger "console;verbosity=normal"` and they passed.
- Ran `git diff --check` and ensured no whitespace/format issues were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18e7e1bf708320a53bb916d2bf6937)