### PR TITLE
Sanitize report-pack restatement evidence routes

### DIFF
--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -69,7 +69,8 @@ validation, submission, approval, review rejection, publication, restatement, hi
 routes backed by shared contracts; review rejection records the reason, actor/role metadata, and
 optional evidence links, and rejected packs must return through draft, validation, submission, and
 approval before publication. Restatement changed lines must carry evidence links before the workflow
-can advance. Publication also rejects line provenance that omits the reported value or lacks a run,
+can advance, and evidence routes are normalized to same-origin absolute paths before those links are
+stored. Publication also rejects line provenance that omits the reported value or lacks a run,
 source-session, ledger-entry, reconciliation-case, or reconciliation-run pointer, and each retained
 line must carry ledger, provider-event, Security Master definition, reconciliation-outcome, and
 approval references before publication. That keeps value-level report lineage enforceable in the

--- a/src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs
@@ -118,6 +118,7 @@ public sealed class ReportPackWorkflowService
 
     public ReportPackWorkflowRecordDto Restate(Guid reportId, string actor, string role, string reasonCode, string approver, Guid priorVersionReportId, IReadOnlyList<ReportPackChangedLineDto> changedLines)
     {
+        ArgumentNullException.ThrowIfNull(changedLines);
         if (string.IsNullOrWhiteSpace(reasonCode)) throw new ArgumentException("reasonCode is required");
         if (changedLines.Count == 0) throw new ArgumentException("changedLines are required");
         var linesWithoutEvidence = changedLines
@@ -129,8 +130,9 @@ public sealed class ReportPackWorkflowService
             throw new ArgumentException($"Restatement changed lines require evidence links: {string.Join(", ", linesWithoutEvidence)}.");
         }
 
+        var normalizedChangedLines = NormalizeChangedLines(changedLines);
         var transitioned = Transition(reportId, ReportPackWorkflowStateDto.Restated, actor, role, note: reasonCode);
-        var evidenceLinks = changedLines
+        var evidenceLinks = normalizedChangedLines
             .SelectMany(static line => line.EvidenceLinks ?? [])
             .GroupBy(static link => link.EvidenceId, StringComparer.OrdinalIgnoreCase)
             .Select(static group => group.First())
@@ -138,7 +140,7 @@ public sealed class ReportPackWorkflowService
         var next = transitioned with
         {
             Version = transitioned.Version + 1,
-            Restatement = new ReportPackRestatementMetadataDto(reasonCode, approver, priorVersionReportId, changedLines, evidenceLinks)
+            Restatement = new ReportPackRestatementMetadataDto(reasonCode, approver, priorVersionReportId, normalizedChangedLines, evidenceLinks)
         };
         _records[reportId] = next;
         return next;
@@ -238,6 +240,17 @@ public sealed class ReportPackWorkflowService
             })
             .ToArray() ?? [];
 
+    private static IReadOnlyList<ReportPackChangedLineDto> NormalizeChangedLines(IReadOnlyList<ReportPackChangedLineDto> changedLines) =>
+        changedLines
+            .Select(static line => line with
+            {
+                LineKey = line.LineKey.Trim(),
+                PreviousValue = line.PreviousValue.Trim(),
+                CurrentValue = line.CurrentValue.Trim(),
+                EvidenceLinks = NormalizeEvidenceLinks(line.EvidenceLinks ?? [])
+            })
+            .ToArray();
+
     private static IReadOnlyList<ReportPackEvidenceLinkDto> NormalizeEvidenceLinks(IReadOnlyList<ReportPackEvidenceLinkDto> evidenceLinks) =>
         evidenceLinks
             .Where(static link => !string.IsNullOrWhiteSpace(link.EvidenceId))
@@ -249,11 +262,29 @@ public sealed class ReportPackWorkflowService
                 {
                     EvidenceId = link.EvidenceId.Trim(),
                     Label = string.IsNullOrWhiteSpace(link.Label) ? link.EvidenceId.Trim() : link.Label.Trim(),
-                    Route = string.IsNullOrWhiteSpace(link.Route) ? null : link.Route.Trim(),
+                    Route = NormalizeEvidenceRoute(link.Route),
                     Source = string.IsNullOrWhiteSpace(link.Source) ? "report-pack" : link.Source.Trim()
                 };
             })
             .ToArray();
+
+    private static string? NormalizeEvidenceRoute(string? route)
+    {
+        if (string.IsNullOrWhiteSpace(route))
+        {
+            return null;
+        }
+
+        var trimmed = route.Trim();
+        if (!trimmed.StartsWith('/', StringComparison.Ordinal) ||
+            trimmed.StartsWith("//", StringComparison.Ordinal) ||
+            !Uri.TryCreate(trimmed, UriKind.Relative, out _))
+        {
+            throw new ArgumentException("Evidence link routes must be same-origin absolute paths.", nameof(route));
+        }
+
+        return trimmed;
+    }
 
     private static void EnsureLineProvenanceTraceable(IReadOnlyList<ReportPackLineProvenanceDto> lineProvenance)
     {

--- a/src/Meridian.Ui/dashboard/README.md
+++ b/src/Meridian.Ui/dashboard/README.md
@@ -88,7 +88,11 @@ validation, or case-state rules.
 Operations Continuity close-checklist fields mirror the shared workstation DTO, including required
 approval counts, expiration dates, and close-readiness blockers, so the browser reads the same
 approval gate state enforced by the API and WPF clients.
-Reporting workspace status rows consume shared template metadata and recent run projections for investor statements, SEC filing packets, and shadow NAV packs; React renders approval status, retry attempts, audit actions, and lineage completeness rather than reimplementing report orchestration rules.
+Reporting workspace status rows consume shared template metadata and recent run projections for
+investor statements, SEC filing packets, and shadow NAV packs; React renders approval status, retry
+attempts, audit actions, and lineage completeness rather than reimplementing report orchestration
+rules. Restatement evidence links are rendered only after the view model confirms the shared route is
+a same-origin absolute path.
 
 ## Diagrams
 

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.view-model.test.ts
@@ -313,6 +313,38 @@ describe("useReportingScreenViewModel", () => {
     ]);
   });
 
+  it("drops unsafe restatement evidence routes before rendering anchor hrefs", () => {
+    const state = buildRestatementReviewPanel([
+      {
+        ...restatedReporting.workflowRecords![0],
+        restatement: {
+          ...restatedReporting.workflowRecords![0].restatement!,
+          changedLines: [
+            {
+              ...restatedReporting.workflowRecords![0].restatement!.changedLines[0],
+              evidenceLinks: [
+                {
+                  evidenceId: "pricing-evidence-1",
+                  label: "Pricing override",
+                  route: "javascript:fetch('/api/reporting/packs',{credentials:'include'})",
+                  source: "pricing"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]);
+
+    expect(state.changedLines).toEqual([
+      expect.objectContaining({
+        lineKey: "nav.total",
+        evidenceLabel: "1 evidence link",
+        evidenceHref: null
+      })
+    ]);
+  });
+
   it("builds an empty restatement review state when no restated workflow record is loaded", () => {
     const state = buildRestatementReviewPanel([]);
 

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.view-model.ts
@@ -575,9 +575,23 @@ function buildRestatementChangedLineRow(line: ReportingWorkflowChangedLine, inde
     lineKey: line.lineKey,
     valueBridge: `${line.previousValue} -> ${line.currentValue}`,
     evidenceLabel: `${evidenceCount} evidence link${evidenceCount === 1 ? "" : "s"}`,
-    evidenceHref: firstEvidence?.route ?? null,
+    evidenceHref: normalizeSameOriginEvidenceHref(firstEvidence?.route),
     ariaLabel: `${line.lineKey} changed from ${line.previousValue} to ${line.currentValue} with ${evidenceCount} evidence link${evidenceCount === 1 ? "" : "s"}`
   };
+}
+
+function normalizeSameOriginEvidenceHref(route: string | null | undefined): string | null {
+  const trimmed = route?.trim();
+  if (!trimmed || !trimmed.startsWith("/") || trimmed.startsWith("//")) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(trimmed, "https://meridian.local");
+    return parsed.origin === "https://meridian.local" ? `${parsed.pathname}${parsed.search}${parsed.hash}` : null;
+  } catch {
+    return null;
+  }
 }
 
 function countRestatementEvidence(selected: ReportingWorkflowRecord | null, changedLines: ReportingWorkflowChangedLine[]): number {

--- a/tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs
@@ -458,6 +458,40 @@ public sealed class ReportPackWorkflowServiceTests
             .WithMessage("Restatement changed lines require evidence links: line-1.");
     }
 
+    [Theory]
+    [InlineData("javascript:fetch('/api/reporting/packs',{credentials:'include'})")]
+    [InlineData("data:text/html,<script>alert(1)</script>")]
+    [InlineData("https://evil.example/reporting/evidence")]
+    [InlineData("//evil.example/reporting/evidence")]
+    public void Restate_RejectsUnsafeEvidenceRoutes(string route)
+    {
+        var svc = new ReportPackWorkflowService();
+        var created = svc.Create("fund-a", "acct-1", "2026-03", new VersionedReportTemplateIdDto("board-pack", 1), "author");
+        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.InReview, "reviewer", "reviewer");
+        svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Approved, "approver", "approver");
+        svc.Publish(
+            created.ReportId,
+            "publisher",
+            "publisher",
+            "controller",
+            "sha256:abc123",
+            "manifest-1",
+            "vault/report-packs/manifest-1.json",
+            [new ReportPackEvidenceLinkDto("report-pack-1", "Report pack manifest", "/evidence/report-pack-1", "reporting")]);
+
+        Action act = () => svc.Restate(
+            created.ReportId,
+            "approver",
+            "approver",
+            "pricing-correction",
+            "chief-approver",
+            created.ReportId,
+            [new ReportPackChangedLineDto("line-1", "100", "125", [new ReportPackEvidenceLinkDto("pricing-evidence-1", "Pricing correction", route, "pricing")])]);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Evidence link routes must be same-origin absolute paths.*");
+    }
+
     [Fact]
     public void Transition_ArchivesPublishedOrRestatedPacksOnly()
     {


### PR DESCRIPTION
### Motivation
- Fix a stored-XSS risk where user-supplied restatement `Route` values could reach a rendered `<a href>` and execute `javascript:`/external/protocol URLs in the workstation UI.  
- Enforce a same-origin evidence-route contract so only safe, same-origin absolute paths are persisted and presented.  
- Add defense-in-depth by validating at the shared workflow service boundary and again in the dashboard view model before rendering.

### Description
- Backend: in `ReportingWorkflowService.Restate` normalize `changedLines` before storing by adding `NormalizeChangedLines` and `NormalizeEvidenceRoute`, which trims values and rejects routes that are not same-origin absolute paths (must start with `'/'`, must not start with `'//'`, and must be a relative URI); unsafe routes cause an `ArgumentException` and are not stored.  
- Frontend: in `reporting-screen.view-model.ts` add `normalizeSameOriginEvidenceHref` and use it so the view-model only forwards same-origin absolute paths into `evidenceHref`, mapping unsafe/foreign/protocol routes to `null` (no clickable href).  
- Tests: add server-side regression `Restate_RejectsUnsafeEvidenceRoutes` (theory) to `ReportPackWorkflowServiceTests.cs` and add a dashboard unit test `drops unsafe restatement evidence routes before rendering anchor hrefs` to `reporting-screen.view-model.test.ts`.  
- Docs: update `src/Meridian.Ui.Shared/README.md` and `src/Meridian.Ui/dashboard/README.md` to document the evidence-route normalization / same-origin contract.

### Testing
- Ran the dashboard unit suite for the touched files with `npm --prefix src/Meridian.Ui/dashboard run test:vitest -- src/screens/reporting-screen.view-model.test.ts src/screens/reporting-screen.test.tsx`, which completed successfully (all included tests passed).  
- Ran `npm --prefix src/Meridian.Ui/dashboard run build` for smoke compile; this command failed due to pre-existing unrelated TypeScript contract/type drift outside this fix.  
- Ran `python3 build/scripts/docs/validate-source-readmes.py --summary` which passed for the modified READMEs; `python3 build/scripts/docs/validate-doc-hashes.py --summary` reported existing repository-wide source/readme hash drift unrelated to this change.  
- Attempted `dotnet test` for the C# unit tests but the container lacked `dotnet`, so those backend tests could not be executed here; the new C# theory test was added to cover unsafe-route rejection at the workflow layer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18eb1515bc83209b7461748162c69d)