### PR TITLE
Secure ledger mapping assignment endpoint

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
@@ -232,13 +232,22 @@ public static class FundStructureEndpoints
                 return Results.Problem(validationError, statusCode: StatusCodes.Status400BadRequest);
             }
 
+            if (!HasLedgerMappingAssignmentPermission(context))
+            {
+                return EndpointAuthorization.TryGetPermissions(context, out _)
+                    ? EndpointHelpers.Forbidden()
+                    : Results.Unauthorized();
+            }
+
+            if (!EndpointAuthorization.TryResolveActor(context, out var actor))
+            {
+                return Results.Unauthorized();
+            }
+
             var service = ResolveService(context);
             if (service is null)
                 return ServiceUnavailable();
 
-            var actor = EndpointAuthorization.TryResolveActor(context, out var authenticatedActor)
-                ? authenticatedActor
-                : request!.RequestedBy.Trim();
             var effectiveFrom = request!.EffectiveFrom ?? DateTimeOffset.UtcNow;
             var beforeView = await service.GetAccountingViewAsync(
                     new AccountingStructureQuery(ActiveOnly: true, AsOf: effectiveFrom),
@@ -907,6 +916,9 @@ public static class FundStructureEndpoints
 
     private static FundOperationsWorkspaceReadService? ResolveWorkspaceService(HttpContext context) =>
         context.RequestServices.GetService<FundOperationsWorkspaceReadService>();
+
+    private static bool HasLedgerMappingAssignmentPermission(HttpContext context)
+        => EndpointAuthorization.HasAnyPermission(context, UserPermission.ManageDirectLending, UserPermission.AdminMaintenance);
 
     private static bool HasReportingWorkflowPermission(HttpContext context)
         => EndpointAuthorization.HasAnyPermission(context, UserPermission.ManageStrategies, UserPermission.AdminMaintenance);

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -211,7 +211,9 @@ and WPF clients do not duplicate close sign-off evidence logic.
 Fund-structure endpoints expose `/api/fund-structure/ledger-mapping-view` as the shared accounting
 control surface for account ledger mappings. The endpoint returns server-derived assignment source,
 unmapped-account issue codes, and recommended action so browser and WPF surfaces do not invent
-client-local mapping or posting readiness rules.
+client-local mapping or posting readiness rules. Ledger mapping assignment mutations require an
+authenticated operator with `ManageDirectLending` or `AdminMaintenance`, and audit attribution must
+come from the resolved session actor rather than client-supplied request fields.
 Auth endpoints expose `/api/auth/role-profiles` as the governed write path for custom authority
 profiles. The shared file-backed role-profile store persists profile grants under the storage root,
 merges custom profiles into `/api/auth/roles`, and feeds `UserProfileRegistry` so configured

--- a/tests/Meridian.Tests/Integration/EndpointTests/FundStructureEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/FundStructureEndpointTests.cs
@@ -337,41 +337,115 @@ public sealed class FundStructureEndpointTests
     }
 
     [Fact]
-    public async Task AssignLedgerMapping_WithAuditEvidence_UpdatesWorkbenchMapping()
+    public async Task AssignLedgerMapping_WithAccountingSession_UpdatesWorkbenchMappingAndUsesAuthenticatedActor()
+    {
+        var originalUsers = Environment.GetEnvironmentVariable("MDC_USERS");
+        Environment.SetEnvironmentVariable(
+            "MDC_USERS",
+            """[{"username":"fund-ops","password":"test-pass","role":"Accounting"}]""");
+
+        try
+        {
+            var seed = await SeedFundWorkspaceAsync();
+            var sessionCookie = await LoginAndGetSessionCookieAsync("fund-ops", "test-pass");
+            var request = new LedgerMappingAssignmentRequestDto(
+                AccountId: seed.BankAccountId,
+                LedgerGroupId: "ENDPOINT-ALT",
+                RequestedBy: "spoofed-client-actor",
+                Rationale: "Move the operating cash account to the reviewed close ledger.",
+                EffectiveFrom: new DateTimeOffset(2026, 4, 11, 0, 0, 0, TimeSpan.Zero),
+                CorrelationId: "ledger-map-endpoint-test",
+                AssignmentId: Guid.NewGuid());
+
+            using var httpRequest = new HttpRequestMessage(HttpMethod.Post, "/api/fund-structure/ledger-mapping-assignments")
+            {
+                Content = JsonContent.Create(request)
+            };
+            httpRequest.Headers.Add("Cookie", sessionCookie);
+
+            var response = await _client.SendAsync(httpRequest);
+
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+            var result = await response.Content.ReadFromJsonAsync<LedgerMappingAssignmentResultDto>();
+
+            result.Should().NotBeNull();
+            result!.Assignment.NodeId.Should().Be(seed.BankAccountId);
+            result.Assignment.AssignmentType.Should().Be("LedgerGroup");
+            result.Assignment.AssignmentReference.Should().Be("ENDPOINT-ALT");
+            result.Account.Mapping.LedgerGroupId.Value.Should().Be("ENDPOINT-ALT");
+            result.Account.Mapping.Source.Should().Be(LedgerMappingSourceDto.AccountAssignment);
+            result.AuditEvent.Should().Match<LedgerMappingAssignmentAuditEventDto>(audit =>
+                audit.EventType == "ledger-mapping-assigned" &&
+                audit.Actor == "fund-ops" &&
+                audit.Rationale == "Move the operating cash account to the reviewed close ledger." &&
+                audit.CorrelationId == "ledger-map-endpoint-test" &&
+                audit.FromLedgerGroupId == "ENDPOINT-TB" &&
+                audit.ToLedgerGroupId == "ENDPOINT-ALT");
+            result.Workbench.Accounts.Should().Contain(account =>
+                account.AccountId == seed.BankAccountId &&
+                account.Mapping.LedgerGroupId.Value == "ENDPOINT-ALT");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MDC_USERS", originalUsers);
+        }
+    }
+
+    [Fact]
+    public async Task AssignLedgerMapping_WithReadOnlySession_ReturnsForbidden()
+    {
+        var originalUsers = Environment.GetEnvironmentVariable("MDC_USERS");
+        Environment.SetEnvironmentVariable(
+            "MDC_USERS",
+            """[{"username":"read-only","password":"test-pass","role":"ReadOnly"}]""");
+
+        try
+        {
+            var seed = await SeedFundWorkspaceAsync();
+            var sessionCookie = await LoginAndGetSessionCookieAsync("read-only", "test-pass");
+            var request = new LedgerMappingAssignmentRequestDto(
+                AccountId: seed.BankAccountId,
+                LedgerGroupId: "ENDPOINT-ALT",
+                RequestedBy: "read-only",
+                Rationale: "Attempt to alter ledger mapping without fund accounting authority.",
+                EffectiveFrom: new DateTimeOffset(2026, 4, 11, 0, 0, 0, TimeSpan.Zero),
+                CorrelationId: "ledger-map-readonly-test",
+                AssignmentId: Guid.NewGuid());
+
+            using var httpRequest = new HttpRequestMessage(HttpMethod.Post, "/api/fund-structure/ledger-mapping-assignments")
+            {
+                Content = JsonContent.Create(request)
+            };
+            httpRequest.Headers.Add("Cookie", sessionCookie);
+
+            var response = await _client.SendAsync(httpRequest);
+
+            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MDC_USERS", originalUsers);
+        }
+    }
+
+    [Fact]
+    public async Task AssignLedgerMapping_WithoutSession_ReturnsUnauthorizedInsteadOfTrustingRequestedBy()
     {
         var seed = await SeedFundWorkspaceAsync();
         var request = new LedgerMappingAssignmentRequestDto(
             AccountId: seed.BankAccountId,
             LedgerGroupId: "ENDPOINT-ALT",
-            RequestedBy: "fund-ops",
-            Rationale: "Move the operating cash account to the reviewed close ledger.",
+            RequestedBy: "client-supplied-actor",
+            Rationale: "Attempt to alter ledger mapping without an authenticated session.",
             EffectiveFrom: new DateTimeOffset(2026, 4, 11, 0, 0, 0, TimeSpan.Zero),
-            CorrelationId: "ledger-map-endpoint-test",
+            CorrelationId: "ledger-map-unauthenticated-test",
             AssignmentId: Guid.NewGuid());
 
         var response = await _client.PostAsJsonAsync(
             "/api/fund-structure/ledger-mapping-assignments",
             request);
 
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var result = await response.Content.ReadFromJsonAsync<LedgerMappingAssignmentResultDto>();
-
-        result.Should().NotBeNull();
-        result!.Assignment.NodeId.Should().Be(seed.BankAccountId);
-        result.Assignment.AssignmentType.Should().Be("LedgerGroup");
-        result.Assignment.AssignmentReference.Should().Be("ENDPOINT-ALT");
-        result.Account.Mapping.LedgerGroupId.Value.Should().Be("ENDPOINT-ALT");
-        result.Account.Mapping.Source.Should().Be(LedgerMappingSourceDto.AccountAssignment);
-        result.AuditEvent.Should().Match<LedgerMappingAssignmentAuditEventDto>(audit =>
-            audit.EventType == "ledger-mapping-assigned" &&
-            audit.Actor == "fund-ops" &&
-            audit.Rationale == "Move the operating cash account to the reviewed close ledger." &&
-            audit.CorrelationId == "ledger-map-endpoint-test" &&
-            audit.FromLedgerGroupId == "ENDPOINT-TB" &&
-            audit.ToLedgerGroupId == "ENDPOINT-ALT");
-        result.Workbench.Accounts.Should().Contain(account =>
-            account.AccountId == seed.BankAccountId &&
-            account.Mapping.LedgerGroupId.Value == "ENDPOINT-ALT");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
     [Fact]
@@ -733,6 +807,22 @@ public sealed class FundStructureEndpointTests
                 description))
             .ToArray();
         ledger.Post(new JournalEntry(journalId, timestamp, description, ledgerLines));
+    }
+
+    private async Task<string> LoginAndGetSessionCookieAsync(string username, string password)
+    {
+        var loginResponse = await _client.PostAsJsonAsync(
+            "/api/auth/login",
+            new { Username = username, Password = password });
+
+        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var sessionCookie = loginResponse.Headers
+            .Where(header => header.Key.Equals("Set-Cookie", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(header => header.Value)
+            .FirstOrDefault(value => value.Contains("mdc-session", StringComparison.OrdinalIgnoreCase));
+
+        sessionCookie.Should().NotBeNullOrWhiteSpace("ledger mapping assignments require an authenticated fund-accounting session");
+        return sessionCookie!;
     }
 
     private static Guid TranslateFundProfileId(string fundProfileId)


### PR DESCRIPTION
### Motivation

- Close an RBAC bypass where `POST /api/fund-structure/ledger-mapping-assignments` could be used by any authenticated user to change ledger mappings. 
- Ensure audit attribution is authoritative by using the resolved session actor instead of falling back to a client-supplied `RequestedBy` value. 
- Add regression coverage and documentation so the authorization contract is explicit and protected in future changes. 

### Description

- Added a permission gate and actor resolution to the ledger-mapping assignment handler in `src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs`, returning `401` for unauthenticated requests and `403` for authenticated users without the required permission. 
- Removed the fallback that trusted `request.RequestedBy` for audit attribution and now always uses the resolved session actor when building the `AssignFundStructureNodeRequest`. 
- Added `HasLedgerMappingAssignmentPermission` helper that requires `UserPermission.ManageDirectLending` or `UserPermission.AdminMaintenance` for ledger mapping mutations. 
- Added integration tests in `tests/Meridian.Tests/Integration/EndpointTests/FundStructureEndpointTests.cs` covering an authorized Accounting session (success), a ReadOnly session (forbidden), and an unauthenticated request (unauthorized), plus a test helper `LoginAndGetSessionCookieAsync`. 
- Documented the authorization and audit-attribution contract in `src/Meridian.Ui.Shared/README.md`. 

### Testing

- Ran `git diff --check` and local static validations to ensure no formatting or diff issues (passed). 
- Ran a repository-local Python static check that inspects the ledger-mapping handler for the presence of the permission gate and actor-resolution (passed). 
- Added integration tests but `dotnet test` could not be executed in this environment because the .NET SDK is not available (`dotnet: command not found`), so the new tests were not run here (tests are included and should be executed in CI or a developer environment with the SDK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18d97cdf908320b03435279c644883)