### PR TITLE
Harden reconciliation casework lifecycle controls

### DIFF
--- a/src/Meridian.Strategies/README.md
+++ b/src/Meridian.Strategies/README.md
@@ -6,7 +6,7 @@ module_id: SRC-STRATEGIES
 path: src/Meridian.Strategies
 status: active
 owner_lane: Strategy and Research
-last_reviewed: 2026-05-27
+last_reviewed: 2026-05-28
 ---
 
 # src/Meridian.Strategies
@@ -29,7 +29,7 @@ This layer should preserve strategy lineage from research through paper validati
 ## Important workflows
 
 Use this module for strategy run evidence, promotion lineage, and research-to-paper continuity.
-Reconciliation break queue persistence also owns shared Accounting casework lifecycle enforcement: assignment before investigation, evidence notes for awaiting-evidence, taxonomy before resolution, dual-control sign-off, privileged reopen, SLA computation, immutable audit events with source metadata, threaded comments, and idempotent bulk triage.
+Reconciliation break queue persistence also owns shared Accounting casework lifecycle enforcement: assignment before investigation, evidence notes for awaiting-evidence, taxonomy before resolution, sign-off only after resolved cases have taxonomy, evidence, ready-for-signoff state, and independent dual-control review, privileged reopen only from trusted admin-derived commands, SLA computation, immutable audit events with source metadata, threaded comments, and idempotent bulk triage.
 Reconciliation also projects Security Master accounting inputs for Operations Continuity: fixed
 coupon accruals, expected journal previews, and factor-schedule principal paydowns are generated
 from resolved Security Master economic definitions before ledger/reconciliation gate posture is

--- a/src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs
+++ b/src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs
@@ -633,6 +633,8 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 => Invalid(item, "Assignee is required.", ReconciliationBreakQueueTransitionErrorCode.MissingActor),
             ReconciliationCaseworkAction.TransitionStatus when command.Status is null
                 => Invalid(item, "Target lifecycle status is required.", ReconciliationBreakQueueTransitionErrorCode.IllegalTransition),
+            ReconciliationCaseworkAction.TransitionStatus when command.Status == ReconciliationCaseLifecycleState.SignedOff || command.Status == ReconciliationCaseLifecycleState.Reopened
+                => Invalid(item, "Use the governed sign-off or privileged reopen action for closed lifecycle states.", ReconciliationBreakQueueTransitionErrorCode.IllegalTransition),
             ReconciliationCaseworkAction.TransitionStatus when !IsLegalLifecycleTransition(item.LifecycleState, command.Status.Value)
                 => Invalid(item, $"Cannot transition case from {item.LifecycleState} to {command.Status}.", ReconciliationBreakQueueTransitionErrorCode.IllegalTransition),
             ReconciliationCaseworkAction.TransitionStatus when command.Status == ReconciliationCaseLifecycleState.Investigating && string.IsNullOrWhiteSpace(item.AssignedTo) && string.IsNullOrWhiteSpace(command.Assignee)
@@ -651,6 +653,10 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
                 => Invalid(item, "Resolution code is required before resolution.", ReconciliationBreakQueueTransitionErrorCode.MissingResolutionCode),
             ReconciliationCaseworkAction.SignOff when item.LifecycleState != ReconciliationCaseLifecycleState.Resolved
                 => Invalid(item, "Only resolved cases can be signed off.", ReconciliationBreakQueueTransitionErrorCode.IllegalTransition),
+            ReconciliationCaseworkAction.SignOff when !IsReadyForSignOff(item)
+                => Invalid(item, "Resolved cases require taxonomy, evidence, and ready-for-signoff state before sign-off.", ReconciliationBreakQueueTransitionErrorCode.MissingEvidence),
+            ReconciliationCaseworkAction.SignOff when !HasIndependentDualControlReview(item)
+                => Invalid(item, "Resolved cases require independent dual-control review before sign-off.", ReconciliationBreakQueueTransitionErrorCode.DualReviewRequired),
             ReconciliationCaseworkAction.SignOff when string.Equals(item.ResolvedBy, command.Actor, StringComparison.OrdinalIgnoreCase)
                 => Invalid(item, "Resolver and signer must be different operators.", ReconciliationBreakQueueTransitionErrorCode.ResolverSignerConflict),
             ReconciliationCaseworkAction.Reopen when item.LifecycleState != ReconciliationCaseLifecycleState.SignedOff
@@ -663,6 +669,17 @@ public sealed class FileReconciliationBreakQueueRepository : IReconciliationBrea
 
     private static ReconciliationBreakQueueTransitionResult Invalid(ReconciliationBreakQueueItem? item, string error, ReconciliationBreakQueueTransitionErrorCode code)
         => new(ReconciliationBreakQueueTransitionStatus.ValidationFailed, item, error, code);
+
+    private static bool IsReadyForSignOff(ReconciliationBreakQueueItem item)
+        => string.Equals(item.SignoffStatus, "ready-for-signoff", StringComparison.OrdinalIgnoreCase) &&
+           !string.IsNullOrWhiteSpace(item.RootCauseCode) &&
+           !string.IsNullOrWhiteSpace(item.ResolutionCode) &&
+           (item.EvidenceCount > 0 || (item.EvidenceLinks?.Count ?? 0) > 0);
+
+    private static bool HasIndependentDualControlReview(ReconciliationBreakQueueItem item)
+        => !string.IsNullOrWhiteSpace(item.ReviewedBy) &&
+           !string.IsNullOrWhiteSpace(item.ResolvedBy) &&
+           !string.Equals(item.ReviewedBy, item.ResolvedBy, StringComparison.OrdinalIgnoreCase);
 
     private static bool IsLegalLifecycleTransition(ReconciliationCaseLifecycleState current, ReconciliationCaseLifecycleState next)
         => current == next || (current, next) switch

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -6313,7 +6313,12 @@ public static partial class WorkstationEndpoints
             return Results.Problem("Reconciliation break queue repository is not registered.", statusCode: StatusCodes.Status501NotImplemented);
         }
 
-        var trusted = request with { Actor = currentUser, Source = string.IsNullOrWhiteSpace(request.Source) ? "workstation-api" : request.Source };
+        var trusted = request with
+        {
+            Actor = currentUser,
+            Source = string.IsNullOrWhiteSpace(request.Source) ? "workstation-api" : request.Source,
+            Privileged = HasGovernedWorkflowReopenPermission(context)
+        };
         var transition = await repository.ApplyCaseworkCommandAsync(trusted, context.RequestAborted).ConfigureAwait(false);
         return transition.Status switch
         {

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -6,7 +6,7 @@ module_id: SRC-UI-SHARED
 path: src/Meridian.Ui.Shared
 status: active
 owner_lane: Workstation Shell and UX
-last_reviewed: 2026-05-25
+last_reviewed: 2026-05-28
 ---
 
 # src/Meridian.Ui.Shared
@@ -92,6 +92,11 @@ account-specific permission overrides and role profile names from `MDC_USERS` re
 for `/api/auth/me` and endpoint authorization checks. Do not reconstruct session users from only the
 built-in role label, because that would reapply the full built-in role permission mask and bypass
 configured restrictions.
+
+Reconciliation casework endpoints must derive trusted operator fields from the authenticated
+session. In particular, governed reopen privilege is admin-derived at the endpoint boundary and
+must not trust a client-supplied `Privileged` flag; sign-off and closed lifecycle transitions remain
+enforced in the shared repository workflow guardrails.
 
 ## Validation
 

--- a/tests/Meridian.Tests/Strategies/ReconciliationBreakQueueRepositoryTests.cs
+++ b/tests/Meridian.Tests/Strategies/ReconciliationBreakQueueRepositoryTests.cs
@@ -193,7 +193,15 @@ public sealed class ReconciliationBreakQueueRepositoryTests
     public async Task Resolve_signoff_reopen_and_bulk_dry_run_follow_shared_casework_rules()
     {
         var repo = CreateRepository(out _);
-        var item = CreateItem(ReconciliationBreakQueueStatus.Open) with { AssignedTo = "controller-a" };
+        var item = CreateItem(ReconciliationBreakQueueStatus.InReview) with
+        {
+            AssignedTo = "controller-a",
+            ReviewedBy = "controller-reviewer",
+            LifecycleState = ReconciliationCaseLifecycleState.Investigating,
+            SignoffStatus = "investigating",
+            EvidenceLinks = ["evidence://close/packet-1"],
+            EvidenceCount = 1
+        };
         await repo.CreateIfMissingAsync(item);
         var current = (await repo.GetByIdAsync(item.BreakId))!;
 
@@ -239,6 +247,54 @@ public sealed class ReconciliationBreakQueueRepositoryTests
 
         var retry = await repo.ApplyBulkCaseworkAsync(dryRunRequest with { Priority = ReconciliationCasePriority.Low });
         retry.Should().BeEquivalentTo(dryRun);
+    }
+
+
+    [Fact]
+    public async Task Casework_rejects_signedoff_transition_and_incomplete_signoff_evidence()
+    {
+        var repo = CreateRepository(out _);
+        var item = CreateItem(ReconciliationBreakQueueStatus.InReview) with
+        {
+            AssignedTo = "controller-a",
+            ReviewedBy = "controller-reviewer",
+            LifecycleState = ReconciliationCaseLifecycleState.Investigating,
+            RootCauseCode = "BrokerCashTiming",
+            ResolutionCode = "LedgerAdjusted",
+            EvidenceLinks = ["evidence://close/packet-1"],
+            EvidenceCount = 1,
+            SignoffStatus = "investigating"
+        };
+        await repo.CreateIfMissingAsync(item);
+        var current = (await repo.GetByIdAsync(item.BreakId))!;
+
+        var directSignedOff = await repo.ApplyCaseworkCommandAsync(Command(current, ReconciliationCaseworkAction.TransitionStatus) with
+        {
+            Status = ReconciliationCaseLifecycleState.SignedOff,
+            Note = "Attempt direct sign-off."
+        });
+        directSignedOff.Status.Should().Be(ReconciliationBreakQueueTransitionStatus.ValidationFailed);
+        directSignedOff.ErrorCode.Should().Be(ReconciliationBreakQueueTransitionErrorCode.IllegalTransition);
+
+        var resolvedWithoutEvidence = CreateItem(ReconciliationBreakQueueStatus.Resolved) with
+        {
+            LifecycleState = ReconciliationCaseLifecycleState.Resolved,
+            ReviewedBy = "controller-reviewer",
+            ResolvedBy = "controller-a",
+            RootCauseCode = "BrokerCashTiming",
+            ResolutionCode = "LedgerAdjusted",
+            SignoffStatus = "ready-for-signoff"
+        };
+        await repo.CreateIfMissingAsync(resolvedWithoutEvidence);
+        var missingEvidenceItem = (await repo.GetByIdAsync(resolvedWithoutEvidence.BreakId))!;
+
+        var missingEvidence = await repo.ApplyCaseworkCommandAsync(Command(missingEvidenceItem, ReconciliationCaseworkAction.SignOff) with
+        {
+            Actor = "controller-b",
+            Note = "Independent review complete."
+        });
+        missingEvidence.Status.Should().Be(ReconciliationBreakQueueTransitionStatus.ValidationFailed);
+        missingEvidence.ErrorCode.Should().Be(ReconciliationBreakQueueTransitionErrorCode.MissingEvidence);
     }
 
     [Fact]

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -3871,6 +3871,75 @@ public sealed partial class WorkstationEndpointsTests
     }
 
     [Fact]
+    public async Task MapWorkstationEndpoints_CaseworkRoutes_ShouldRejectLifecycleAndPrivilegedSpoofing()
+    {
+        await using var app = await CreateAppAsync(currentUserPermissions: UserPermission.ModifySecurityMaster);
+        var repo = app.Services.GetRequiredService<IReconciliationBreakQueueRepository>();
+        var now = DateTimeOffset.UtcNow;
+        var openBreak = new ReconciliationBreakQueueItem(
+            BreakId: $"open-{Guid.NewGuid():N}",
+            RunId: "run-casework-spoof",
+            StrategyName: "reconciliation",
+            Category: ReconciliationBreakCategory.CashMismatch,
+            Status: ReconciliationBreakQueueStatus.Open,
+            Variance: 10m,
+            Reason: "variance",
+            AssignedTo: null,
+            DetectedAt: now,
+            LastUpdatedAt: now);
+        var signedOffBreak = openBreak with
+        {
+            BreakId = $"signed-{Guid.NewGuid():N}",
+            Status = ReconciliationBreakQueueStatus.SignedOff,
+            LifecycleState = ReconciliationCaseLifecycleState.SignedOff,
+            ReviewedBy = "controller-reviewer",
+            ResolvedBy = "controller-a",
+            SignedOffBy = "controller-b",
+            RootCauseCode = "BrokerCashTiming",
+            ResolutionCode = "LedgerAdjusted",
+            EvidenceLinks = ["evidence://close/packet-1"],
+            EvidenceCount = 1,
+            SignoffStatus = "signed-off"
+        };
+        await repo.CreateIfMissingAsync(openBreak);
+        await repo.CreateIfMissingAsync(signedOffBreak);
+        openBreak = (await repo.GetByIdAsync(openBreak.BreakId))!;
+        signedOffBreak = (await repo.GetByIdAsync(signedOffBreak.BreakId))!;
+
+        var client = app.GetTestClient();
+
+        var directSignedOff = await client.PostAsJsonAsync(
+            $"/api/workstation/reconciliation/break-queue/{openBreak.BreakId}/transition",
+            new ReconciliationCaseworkCommand(
+                openBreak.BreakId,
+                ReconciliationCaseworkAction.TransitionStatus,
+                "spoofed-user",
+                Guid.NewGuid().ToString("N"),
+                Guid.NewGuid().ToString("N"),
+                "unit-test",
+                openBreak.Version,
+                Status: ReconciliationCaseLifecycleState.SignedOff,
+                Note: "Attempt direct signed-off transition."),
+            ServerJsonOptions);
+        directSignedOff.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var spoofedPrivilegedReopen = await client.PostAsJsonAsync(
+            $"/api/workstation/reconciliation/break-queue/{signedOffBreak.BreakId}/reopen",
+            new ReconciliationCaseworkCommand(
+                signedOffBreak.BreakId,
+                ReconciliationCaseworkAction.Reopen,
+                "spoofed-user",
+                Guid.NewGuid().ToString("N"),
+                Guid.NewGuid().ToString("N"),
+                "unit-test",
+                signedOffBreak.Version,
+                Reason: "Late broker correction.",
+                Privileged: true),
+            ServerJsonOptions);
+        spoofedPrivilegedReopen.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
     public async Task MapWorkstationEndpoints_RunContinuityRoute_ShouldReturnSharedContinuityPayload()
     {
         await using var app = await CreateAppAsync(services =>


### PR DESCRIPTION
### Motivation
- Close a security gap where reconciliation casework endpoints trusted caller-supplied `Privileged` and lifecycle `Status`, allowing non-admin users to sign off or reopen cases and bypass governance controls.

### Description
- Endpoint boundary: `ApplyReconciliationCaseworkEndpointAsync` now derives trusted operator fields (overwriting `Actor`/`Source`) and sets `Privileged` from an admin-only check via `HasGovernedWorkflowReopenPermission(context)` before dispatching to the repository (`src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs`).
- Repository validation: `ValidateCaseworkCommand` now rejects direct `TransitionStatus` into closed lifecycle states (`SignedOff`/`Reopened`) and enforces sign-off readiness by checking `SignoffStatus`, `RootCauseCode`, `ResolutionCode`, and presence of evidence, plus an independent dual-control review helper before allowing `SignOff` (`src/Meridian.Strategies/Services/FileReconciliationBreakQueueRepository.cs`).
- New helpers: added `IsReadyForSignOff` and `HasIndependentDualControlReview` to centralize sign-off readiness logic and keep mutation logic unchanged except for the added guards.
- Tests & docs: added repository and endpoint regression tests that exercise direct signed-off transitions and spoofed privileged reopen attempts, and updated module READMEs to document the endpoint trust boundary and lifecycle requirements (`tests/.../ReconciliationBreakQueueRepositoryTests.cs`, `tests/.../WorkstationEndpointsTests.cs`, `src/Meridian.Strategies/README.md`, `src/Meridian.Ui.Shared/README.md`).

### Testing
- Ran repository and workspace checks: `git diff --check` succeeded and code committed as "Harden reconciliation casework lifecycle controls".
- Documentation tooling: `python3 build/scripts/docs/mark-stale-docs.py --summary` ran and reported stale-docs entries (pre-existing repo-wide drift) but completed successfully for this change.
- Self-evaluation: ran the implementation-assurance rubric via `python3 .codex/skills/meridian-implementation-assurance/scripts/score_eval.py` and produced a pass report (9/10) with the note that `dotnet` tests could not be executed in this container.
- Unit tests: targeted `dotnet test` for the affected tests was prepared (`--filter FullyQualifiedName~ReconciliationBreakQueueRepositoryTests|FullyQualifiedName~WorkstationEndpointsTests.MapWorkstationEndpoints_CaseworkRoutes_ShouldRejectLifecycleAndPrivilegedSpoofing`) but was not run because `dotnet` is not installed in this environment (blocked); added tests are included in the change and should pass when run in a .NET-enabled CI/job.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1897a3e84083208ecc175b8d498747)