### PR TITLE
Reject duplicate statement CSV headers

### DIFF
--- a/src/Meridian.Application/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.Application/Reconciliation/StatementReconciliationService.cs
@@ -355,6 +355,7 @@ public sealed class StatementReconciliationService
         }
 
         var actual = header.Split(',', StringSplitOptions.TrimEntries);
+        EnsureUniqueStatementHeaderColumns(actual, StatementMappingProfileRegistry.CanonicalCsvV1ProfileId);
         if (!CanonicalCsvHeaderPrefixMatches(actual))
         {
             throw new InvalidDataException("Statement source must use the canonical external statement header: account,symbol,quantity,price,cashAmount,activityType,tradeDate.");
@@ -371,6 +372,7 @@ public sealed class StatementReconciliationService
         }
 
         var actual = header.Split(',', StringSplitOptions.TrimEntries);
+        EnsureUniqueStatementHeaderColumns(actual, profile.ProfileId);
         if (profile.ProfileId.Equals(StatementMappingProfileRegistry.CanonicalCsvV1ProfileId, StringComparison.OrdinalIgnoreCase)
             && !CanonicalCsvHeaderPrefixMatches(actual))
         {
@@ -390,6 +392,24 @@ public sealed class StatementReconciliationService
         return profile;
     }
 
+    private static void EnsureUniqueStatementHeaderColumns(string[] header, string profileId)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var duplicates = new List<string>();
+        foreach (var column in header.Where(column => !string.IsNullOrWhiteSpace(column)))
+        {
+            if (!seen.Add(column) && !duplicates.Contains(column, StringComparer.OrdinalIgnoreCase))
+            {
+                duplicates.Add(column);
+            }
+        }
+
+        if (duplicates.Count > 0)
+        {
+            throw new InvalidDataException($"Statement source contains duplicate columns for mapping profile '{profileId}': {string.Join(", ", duplicates)}.");
+        }
+    }
+
     private static bool CanonicalCsvHeaderPrefixMatches(string[] actual)
     {
         var canonicalColumns = StatementMappingProfileRegistry.Defaults
@@ -407,7 +427,10 @@ public sealed class StatementReconciliationService
         var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < header.Length; i++)
         {
-            map[header[i]] = i < parts.Length ? parts[i] : string.Empty;
+            if (!map.TryAdd(header[i], i < parts.Length ? parts[i] : string.Empty))
+            {
+                throw new InvalidDataException($"Statement source contains duplicate column '{header[i]}'.");
+            }
         }
 
         return map;

--- a/tests/Meridian.Tests/Reconciliation/StatementFixtureScenarioTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/StatementFixtureScenarioTests.cs
@@ -27,6 +27,31 @@ public sealed class StatementFixtureScenarioTests
     }
 
     [Fact]
+    public async Task Scenario_MonthEndShadowedStatementHeader_ReconciliationRejectsDuplicateCanonicalColumns()
+    {
+        var source = Path.Combine(Path.GetTempPath(), $"meridian-shadowed-statement-{Guid.NewGuid():N}.csv");
+        await File.WriteAllLinesAsync(source,
+        [
+            "account,symbol,quantity,price,cashAmount,activityType,tradeDate,quantity",
+            "A1,SPY,10,500,0,position,2026-05-29,0"
+        ]);
+        try
+        {
+            var service = new StatementReconciliationService();
+
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(async () =>
+                await service.ReconcileAsync("broker", source, CancellationToken.None));
+
+            Assert.Contains("duplicate columns", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("quantity", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(source);
+        }
+    }
+
+    [Fact]
     public async Task Scenario_MonthEndDuplicateStatement_ValidationCreatesDuplicateBlocker()
     {
         var path = FixturePath("statement-clean-reconciles.csv");


### PR DESCRIPTION
### Motivation
- Prevent header-name shadowing in statement CSV parsing which allowed later duplicate columns to overwrite canonical fields and alter reconciliation values.

### Description
- Validate CSV headers for duplicates by adding `EnsureUniqueStatementHeaderColumns` and invoking it from `ValidateCanonicalStatementHeader` and `ValidateStatementHeader` so duplicate names are rejected before prefix/required checks run.
- Harden `BuildColumnMap` to use `TryAdd` and throw an `InvalidDataException` on duplicate header entries so duplicates cannot silently overwrite earlier values.
- Add a regression test `Scenario_MonthEndShadowedStatementHeader_ReconciliationRejectsDuplicateCanonicalColumns` in `tests/Meridian.Tests/Reconciliation/StatementFixtureScenarioTests.cs` that asserts duplicate canonical columns (e.g. trailing `quantity`) are rejected.
- Files changed: `src/Meridian.Application/Reconciliation/StatementReconciliationService.cs` and `tests/Meridian.Tests/Reconciliation/StatementFixtureScenarioTests.cs`.

### Testing
- Ran static check `git diff --check` which produced no whitespace/patch errors.
- Attempted to run the narrowed test filter with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~StatementFixtureScenarioTests" --logger "console;verbosity=normal"` but test execution was blocked because `dotnet` is not available in the execution environment; CI should run the full test matrix to verify.
- Added an automated regression test that exercises the duplicate-header behavior and should pass when run in CI or a developer machine with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18d848531c83208d771ff2ba0ba691)