### PR TITLE
Secure workstation statement-run imports and server-side hashing

### DIFF
--- a/docs/operations/reconciliation-operations.md
+++ b/docs/operations/reconciliation-operations.md
@@ -27,6 +27,18 @@ Use the `--statement-broker` / `--statement-date` form when importing the suppor
 local-file accessibility and reconciliation probe; non-local statement adapters are not registered
 in the current command surface.
 
+## Workstation statement-run staging
+
+The workstation statement-run creation API accepts only regular files staged under the configured
+reconciliation import root before the request is submitted. Set
+`MERIDIAN_STATEMENT_IMPORT_ROOT` to the approved operator drop folder for workstation uploads; when
+it is not set, the local host defaults to
+`data/reconciliation/statement-import-staging` under the application base directory. The API
+canonicalizes the submitted path, verifies it remains inside that root, rejects directories and
+links, enforces a 100 MB per-file bound, and computes the SHA-256 hash server-side instead of
+trusting caller-provided checksum metadata. The `ImportedBy` audit field is also derived from the
+authenticated workstation session rather than from the request payload.
+
 ## Artifacts
 
 - `reconciliation/statement-imports/*.json`: import metadata, canonical rows, raw+normalized row counts, source checksum.

--- a/src/Meridian.Ui.Services/Services/Reconciliation/ReconciliationApiService.cs
+++ b/src/Meridian.Ui.Services/Services/Reconciliation/ReconciliationApiService.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using Meridian.Contracts.Workstation;
 using Meridian.Domain.Reconciliation;
 using Meridian.Infrastructure.Reconciliation;
@@ -5,11 +6,41 @@ using Meridian.Ui.Shared.Contracts.Reconciliation;
 
 namespace Meridian.Ui.Services.Services.Reconciliation;
 
-public sealed class ReconciliationApiService(
-    ICanonicalStatementStore importStore,
-    IReconciliationCaseStore caseStore,
-    IReconciliationBreakStore breakStore) : IReconciliationApiService
+public sealed class ReconciliationApiService : IReconciliationApiService
 {
+    internal const long MaxStatementSourceFileBytes = 100L * 1024L * 1024L;
+    private const string ImportRootEnvironmentVariable = "MERIDIAN_STATEMENT_IMPORT_ROOT";
+
+    private readonly ICanonicalStatementStore importStore;
+    private readonly IReconciliationCaseStore caseStore;
+    private readonly IReconciliationBreakStore breakStore;
+    private readonly string statementImportRoot;
+
+    public ReconciliationApiService(
+        ICanonicalStatementStore importStore,
+        IReconciliationCaseStore caseStore,
+        IReconciliationBreakStore breakStore)
+        : this(importStore, caseStore, breakStore, ResolveDefaultStatementImportRoot())
+    {
+    }
+
+    public ReconciliationApiService(
+        ICanonicalStatementStore importStore,
+        IReconciliationCaseStore caseStore,
+        IReconciliationBreakStore breakStore,
+        string statementImportRoot)
+    {
+        ArgumentNullException.ThrowIfNull(importStore);
+        ArgumentNullException.ThrowIfNull(caseStore);
+        ArgumentNullException.ThrowIfNull(breakStore);
+        ArgumentException.ThrowIfNullOrWhiteSpace(statementImportRoot);
+
+        this.importStore = importStore;
+        this.caseStore = caseStore;
+        this.breakStore = breakStore;
+        this.statementImportRoot = NormalizeDirectoryPath(statementImportRoot);
+    }
+
     public async Task<IReadOnlyList<StatementImportSummaryDto>> ListImportsAsync(CancellationToken ct = default)
         => (await importStore.ListImportsAsync(ct).ConfigureAwait(false))
             .Select(static import => new StatementImportSummaryDto(
@@ -31,9 +62,8 @@ public sealed class ReconciliationApiService(
         ArgumentNullException.ThrowIfNull(request);
         ValidateCreateRequest(request);
 
-        var sourceFileHash = string.IsNullOrWhiteSpace(request.SourceFileHash)
-            ? await ComputeSourceFileHashAsync(request.SourcePath, ct).ConfigureAwait(false)
-            : request.SourceFileHash.Trim().ToUpperInvariant();
+        var sourceFile = ResolveStatementSourceFile(request.SourcePath);
+        var sourceFileHash = await ComputeSourceFileHashAsync(sourceFile.FullName, ct).ConfigureAwait(false);
         var importId = StatementDuplicateKey.Create(
             request.FundAccountId,
             request.StatementPeriodStart,
@@ -45,7 +75,7 @@ public sealed class ReconciliationApiService(
             request.Broker.Trim(),
             request.StatementPeriodEnd,
             DateTimeOffset.UtcNow,
-            request.SourcePath.Trim(),
+            sourceFile.FullName,
             sourceFileHash,
             RawRowCount: 0,
             NormalizedRowCount: 0)
@@ -56,7 +86,7 @@ public sealed class ReconciliationApiService(
             StatementPeriodStart = request.StatementPeriodStart,
             StatementPeriodEnd = request.StatementPeriodEnd,
             OriginalFileName = string.IsNullOrWhiteSpace(request.OriginalFileName)
-                ? Path.GetFileName(request.SourcePath)
+                ? sourceFile.Name
                 : request.OriginalFileName.Trim(),
             MappingProfileId = request.MappingProfileId.Trim(),
             ToleranceProfileId = request.ToleranceProfileId.Trim(),
@@ -345,11 +375,76 @@ public sealed class ReconciliationApiService(
         }
     }
 
+    private FileInfo ResolveStatementSourceFile(string sourcePath)
+    {
+        var fullPath = Path.GetFullPath(sourcePath.Trim());
+        if (!IsPathInsideDirectory(fullPath, statementImportRoot))
+        {
+            throw new ArgumentException("Statement source file must be staged under the configured reconciliation import root.", nameof(sourcePath));
+        }
+
+        var sourceFile = new FileInfo(fullPath);
+        if (!sourceFile.Exists)
+        {
+            throw new FileNotFoundException("Statement source file was not found in the configured reconciliation import root.", fullPath);
+        }
+
+        if ((sourceFile.Attributes & FileAttributes.Directory) != 0 || (sourceFile.Attributes & FileAttributes.ReparsePoint) != 0)
+        {
+            throw new ArgumentException("Statement source must be a regular file and cannot be a directory or link.", nameof(sourcePath));
+        }
+
+        if (sourceFile.Length > MaxStatementSourceFileBytes)
+        {
+            throw new ArgumentException($"Statement source file exceeds the {MaxStatementSourceFileBytes} byte workstation import limit.", nameof(sourcePath));
+        }
+
+        return sourceFile;
+    }
+
     private static async Task<string> ComputeSourceFileHashAsync(string sourcePath, CancellationToken ct)
     {
-        await using var stream = File.OpenRead(sourcePath);
-        var hash = await System.Security.Cryptography.SHA256.HashDataAsync(stream, ct).ConfigureAwait(false);
+        var options = new FileStreamOptions
+        {
+            Access = FileAccess.Read,
+            Mode = FileMode.Open,
+            Options = FileOptions.Asynchronous | FileOptions.SequentialScan,
+            Share = FileShare.Read,
+            BufferSize = 64 * 1024
+        };
+
+        await using var stream = new FileStream(sourcePath, options);
+        if (!stream.CanSeek || stream.Length > MaxStatementSourceFileBytes)
+        {
+            throw new ArgumentException("Statement source must be a bounded regular file.", nameof(sourcePath));
+        }
+
+        var hash = await SHA256.HashDataAsync(stream, ct).ConfigureAwait(false);
         return Convert.ToHexString(hash);
+    }
+
+    private static string ResolveDefaultStatementImportRoot()
+    {
+        var configuredRoot = Environment.GetEnvironmentVariable(ImportRootEnvironmentVariable);
+        return string.IsNullOrWhiteSpace(configuredRoot)
+            ? Path.Combine(AppContext.BaseDirectory, "data", "reconciliation", "statement-import-staging")
+            : configuredRoot;
+    }
+
+    private static string NormalizeDirectoryPath(string path)
+    {
+        var fullPath = Path.GetFullPath(path.Trim());
+        return fullPath.EndsWith(Path.DirectorySeparatorChar)
+            ? fullPath
+            : fullPath + Path.DirectorySeparatorChar;
+    }
+
+    private static bool IsPathInsideDirectory(string path, string directory)
+    {
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return path.StartsWith(directory, comparison);
     }
 
     private static StatementBreakType MapBreakType(string breakCode)

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Reconciliation.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Reconciliation.cs
@@ -138,18 +138,27 @@ public static partial class WorkstationEndpoints
                 return EndpointHelpers.Forbidden();
             }
 
+            if (!TryResolveCurrentUser(context, out var currentUser))
+            {
+                return Results.Unauthorized();
+            }
+
             if (service is null)
             {
                 return Results.Problem("Reconciliation API service is not registered.", statusCode: StatusCodes.Status501NotImplemented);
             }
 
-            var detail = await service.CreateStatementRunAsync(request, context.RequestAborted).ConfigureAwait(false);
+            var trustedRequest = request with { ImportedBy = currentUser, SourceFileHash = null };
+            var detail = await service.CreateStatementRunAsync(trustedRequest, context.RequestAborted).ConfigureAwait(false);
             return detail is null ? Results.NotFound() : Results.Json(detail, jsonOptions, statusCode: StatusCodes.Status201Created);
         })
+        .RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy)
         .WithName("CreateStatementRun")
         .Produces<StatementRunDto>(201)
+        .Produces(401)
         .Produces(403)
         .Produces(404)
+        .Produces(429)
         .Produces(501);
 
         group.MapGet(WorkstationSubroute(UiApiRoutes.ReconciliationStatementRunById), async (

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -1362,18 +1362,27 @@ public static partial class WorkstationEndpoints
                 return EndpointHelpers.Forbidden();
             }
 
+            if (!TryResolveCurrentUser(context, out var currentUser))
+            {
+                return Results.Unauthorized();
+            }
+
             if (service is null)
             {
                 return Results.Problem("Reconciliation API service is not registered.", statusCode: StatusCodes.Status501NotImplemented);
             }
 
-            var detail = await service.CreateStatementRunAsync(request, context.RequestAborted).ConfigureAwait(false);
+            var trustedRequest = request with { ImportedBy = currentUser, SourceFileHash = null };
+            var detail = await service.CreateStatementRunAsync(trustedRequest, context.RequestAborted).ConfigureAwait(false);
             return detail is null ? Results.NotFound() : Results.Json(detail, jsonOptions, statusCode: StatusCodes.Status201Created);
         })
+        .RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy)
         .WithName("CreateStatementRun")
         .Produces<StatementRunDto>(201)
+        .Produces(401)
         .Produces(403)
         .Produces(404)
+        .Produces(429)
         .Produces(501);
 
         group.MapGet(WorkstationSubroute(UiApiRoutes.ReconciliationStatementRunById), async (

--- a/tests/Meridian.Tests/Ui/ReconciliationApiServiceSecurityTests.cs
+++ b/tests/Meridian.Tests/Ui/ReconciliationApiServiceSecurityTests.cs
@@ -1,0 +1,141 @@
+using System.Security.Cryptography;
+using FluentAssertions;
+using Meridian.Contracts.Workstation;
+using Meridian.Domain.Reconciliation;
+using Meridian.Infrastructure.Reconciliation;
+using Meridian.Ui.Services.Services.Reconciliation;
+
+namespace Meridian.Tests.Ui;
+
+public sealed class ReconciliationApiServiceSecurityTests
+{
+    [Fact]
+    public async Task CreateStatementRunAsync_SourcePathOutsideImportRoot_ShouldRejectWithoutUsingCallerHash()
+    {
+        var importRoot = CreateTempDirectory("statement-import-root");
+        var outsideRoot = CreateTempDirectory("statement-outside-root");
+        var outsideFile = Path.Combine(outsideRoot, "statement.csv");
+        await File.WriteAllTextAsync(outsideFile, "outside statement content");
+        var service = CreateService(importRoot);
+
+        var act = async () => await service.CreateStatementRunAsync(CreateRequest(outsideFile, sourceFileHash: "CALLERHASH"));
+
+        await act.Should()
+            .ThrowAsync<ArgumentException>()
+            .WithMessage("*configured reconciliation import root*");
+    }
+
+    [Fact]
+    public async Task CreateStatementRunAsync_StagedSourcePath_ShouldComputeHashAndPersistCanonicalPath()
+    {
+        var importRoot = CreateTempDirectory("statement-import-root");
+        var sourceFile = Path.Combine(importRoot, "statement.csv");
+        await File.WriteAllTextAsync(sourceFile, "account,symbol,quantity\nfund-1,MSFT,10\n");
+        var store = new RecordingCanonicalStatementStore();
+        var service = CreateService(importRoot, store);
+
+        var run = await service.CreateStatementRunAsync(CreateRequest(sourceFile, importedBy: "ops-user", sourceFileHash: "CALLERHASH"));
+
+        var expectedHash = Convert.ToHexString(SHA256.HashData(await File.ReadAllBytesAsync(sourceFile)));
+        run.Should().NotBeNull();
+        run!.SourceFileHash.Should().Be(expectedHash);
+        store.SavedImports.Should().ContainSingle();
+        store.SavedImports[0].SourcePath.Should().Be(Path.GetFullPath(sourceFile));
+        store.SavedImports[0].SourceFileHash.Should().Be(expectedHash);
+        store.SavedImports[0].ImportedBy.Should().Be("ops-user");
+    }
+
+    [Fact]
+    public async Task CreateStatementRunAsync_OversizedStagedSourcePath_ShouldRejectBeforeHashing()
+    {
+        var importRoot = CreateTempDirectory("statement-import-root");
+        var sourceFile = Path.Combine(importRoot, "oversized.csv");
+        await using (var stream = new FileStream(sourceFile, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+        {
+            stream.SetLength(100L * 1024L * 1024L + 1L);
+        }
+        var service = CreateService(importRoot);
+
+        var act = async () => await service.CreateStatementRunAsync(CreateRequest(sourceFile));
+
+        await act.Should()
+            .ThrowAsync<ArgumentException>()
+            .WithMessage("*workstation import limit*");
+    }
+
+    private static ReconciliationApiService CreateService(
+        string importRoot,
+        RecordingCanonicalStatementStore? store = null)
+        => new(
+            store ?? new RecordingCanonicalStatementStore(),
+            new EmptyReconciliationCaseStore(),
+            new EmptyReconciliationBreakStore(),
+            importRoot);
+
+    private static StatementRunCreateDto CreateRequest(
+        string sourcePath,
+        string importedBy = "operator",
+        string? sourceFileHash = null)
+        => new(
+            Broker: "samplebroker",
+            SourceInstitution: "Sample Custodian",
+            FundAccountId: "fund-1",
+            ExternalAccountId: "ext-1",
+            StatementPeriodStart: new DateOnly(2026, 5, 1),
+            StatementPeriodEnd: new DateOnly(2026, 5, 27),
+            SourcePath: sourcePath,
+            OriginalFileName: "statement.csv",
+            MappingProfileId: "mapping-v1",
+            ToleranceProfileId: "tolerance-v1",
+            ImportedBy: importedBy,
+            SourceFileHash: sourceFileHash);
+
+    private static string CreateTempDirectory(string prefix)
+    {
+        var path = Path.Combine(Path.GetTempPath(), "meridian-tests", prefix, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private sealed class RecordingCanonicalStatementStore : ICanonicalStatementStore
+    {
+        public List<CanonicalStatementImport> SavedImports { get; } = [];
+
+        public Task<bool> ImportExistsByChecksumAsync(string checksum, CancellationToken ct = default)
+            => Task.FromResult(false);
+
+        public Task<bool> ImportExistsByDuplicateKeyAsync(string duplicateKey, CancellationToken ct = default)
+            => Task.FromResult(false);
+
+        public Task SaveImportAsync(CanonicalStatementImport import, IReadOnlyList<CanonicalStatementRow> rows, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            SavedImports.Add(import);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<CanonicalStatementImport>> ListImportsAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<CanonicalStatementImport>>(SavedImports);
+    }
+
+    private sealed class EmptyReconciliationCaseStore : IReconciliationCaseStore
+    {
+        public Task SaveAsync(ReconciliationCase reconciliationCase, CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task<ReconciliationCase?> GetAsync(string caseId, CancellationToken ct = default)
+            => Task.FromResult<ReconciliationCase?>(null);
+
+        public Task<IReadOnlyList<ReconciliationCase>> ListAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<ReconciliationCase>>([]);
+    }
+
+    private sealed class EmptyReconciliationBreakStore : IReconciliationBreakStore
+    {
+        public Task WriteAsync(IReadOnlyList<ReconciliationBreakRecord> records, CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task<IReadOnlyList<ReconciliationBreakRecord>> ListOpenAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<ReconciliationBreakRecord>>([]);
+    }
+}

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -3408,11 +3408,14 @@ public sealed partial class WorkstationEndpointsTests
                 OriginalFileName: "statement.csv",
                 MappingProfileId: "mapping-v1",
                 ToleranceProfileId: "tolerance-v1",
-                ImportedBy: "ops-user",
-                SourceFileHash: "ABC123"),
+                ImportedBy: "spoofed-user",
+                SourceFileHash: "CALLERHASH"),
             ServerJsonOptions);
         createdResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        service.CreatedRequests.Should().ContainSingle(request => request.FundAccountId == "fund-1");
+        service.CreatedRequests.Should().ContainSingle(request =>
+            request.FundAccountId == "fund-1"
+            && request.ImportedBy == "ops-user"
+            && request.SourceFileHash is null);
 
         var exceptions = await client.GetFromJsonAsync<List<StatementRunExceptionDto>>(
             UiApiRoutes.ReconciliationStatementExceptions,


### PR DESCRIPTION
### Motivation
- Prevent caller-controlled filesystem access and expensive hashing via the workstation statement-run creation API by constraining imports to a staged root and computing hashes server-side.
- Ensure audit integrity by deriving `ImportedBy` from the authenticated session and by applying the standard mutation rate limiter on the new endpoint.

### Description
- Reconciler service: added a configurable/import-root-aware resolution flow with `MERIDIAN_STATEMENT_IMPORT_ROOT`, canonicalization/containment checks, regular-file/link rejection, and a 100 MB per-file bound, and replaced direct `File.OpenRead(request.SourcePath)` with a bounded async `FileStream` and server-side SHA-256 computation. (see `src/Meridian.Ui.Services/Services/Reconciliation/ReconciliationApiService.cs`).
- Endpoints: POST `/api/workstation/reconciliation/statement-runs` now requires the resolved caller identity (`TryResolveCurrentUser`), clears caller-provided `SourceFileHash`, sets `ImportedBy` from the session, and applies the `UiEndpoints.MutationRateLimitPolicy` with `401`/`429` response metadata (see `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints*.cs`).
- Tests and docs: added focused security tests covering outside-root rejection, staged-file hashing and persistence, and oversized-file rejection (`tests/Meridian.Tests/Ui/ReconciliationApiServiceSecurityTests.cs`), updated an endpoint integration test to assert actor/hash normalization, and documented the staging-root behavior in `docs/operations/reconciliation-operations.md`.

### Testing
- Attempted to run the focused .NET tests: `dotnet test ... --filter "FullyQualifiedName~ReconciliationApiServiceSecurityTests|FullyQualifiedName~MapWorkstationEndpoints_ReconciliationStatementRoutes_ShouldUseCanonicalSharedRoutes"` but the run was blocked because `dotnet` is not installed in the execution environment. (manual run required in a .NET-enabled environment). 
- Verified repository hygiene and docs tooling: ran `git diff --check` (no issues) and `python3 build/scripts/docs/mark-stale-docs.py --summary` (succeeded and reported stale modules as expected). 
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary` which completed but reported pre-existing repository-wide source/README hash drift unrelated to this patch. 
- Ran the implementation-assurance eval dry-run `python3 .codex/skills/meridian-implementation-assurance/scripts/run_evals.py --all --dry-run --json` (dry-run succeeded). 
- Produced a local assurance score using the skill harness `score_eval.py` with a produced JSON summary; note the fail reason: `dotnet` was not available and doc-hash validation reports repo-wide drift; follow-up recommends running the filtered tests in a .NET-enabled environment and reconciling the source-doc manifest with the owning renderer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18d96dab348320b6c3a2ae61edb269)