### PR TITLE
Restore safe-mode metadata resolver and block unsafe continuation sources in QuantScript

### DIFF
--- a/src/Meridian.QuantScript/Compilation/RoslynScriptCompiler.cs
+++ b/src/Meridian.QuantScript/Compilation/RoslynScriptCompiler.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
@@ -17,6 +18,7 @@ namespace Meridian.QuantScript.Compilation;
 /// </summary>
 public sealed class RoslynScriptCompiler : IQuantScriptCompiler
 {
+    private static readonly MetadataReferenceResolver SafeMetadataReferenceResolver = new RestrictedMetadataReferenceResolver();
     private static readonly SourceReferenceResolver SafeSourceReferenceResolver = new RestrictedSourceReferenceResolver();
 
     // Parameter comment convention: // @param Name:Label:Default:Min:Max:Description
@@ -90,13 +92,8 @@ public sealed class RoslynScriptCompiler : IQuantScriptCompiler
             {
                 var sw = System.Diagnostics.Stopwatch.StartNew();
 
-                if (!_options.Value.EnableUnsafeScripts && TryGetUnsafeMarker(source, out var marker))
+                if (!_options.Value.EnableUnsafeScripts && TryCreateSafeModeDiagnostic(source) is { } diagnostic)
                 {
-                    var diagnostic = new ScriptDiagnostic(
-                        "Error",
-                        $"Safe mode blocks use of '{marker}' because it is disabled in safe mode. Set EnableUnsafeScripts=true to allow this script.",
-                        1,
-                        1);
                     return new ScriptCompilationResult(false, sw.Elapsed, [diagnostic]);
                 }
 
@@ -174,10 +171,31 @@ public sealed class RoslynScriptCompiler : IQuantScriptCompiler
 
         if (!_options.Value.EnableUnsafeScripts)
         {
-            scriptOptions = scriptOptions.WithSourceResolver(SafeSourceReferenceResolver);
+            scriptOptions = scriptOptions
+                .WithMetadataResolver(SafeMetadataReferenceResolver)
+                .WithSourceResolver(SafeSourceReferenceResolver);
         }
 
         return scriptOptions;
+    }
+
+    private sealed class RestrictedMetadataReferenceResolver : MetadataReferenceResolver
+    {
+        public override bool Equals(object? other) => other is RestrictedMetadataReferenceResolver;
+
+        public override int GetHashCode() => typeof(RestrictedMetadataReferenceResolver).GetHashCode();
+
+        public override PortableExecutableReference? ResolveMissingAssembly(
+            MetadataReference definition,
+            AssemblyIdentity referenceIdentity) => null;
+
+        public override ImmutableArray<PortableExecutableReference> ResolveReference(
+            string reference,
+            string? baseFilePath,
+            MetadataReferenceProperties properties)
+        {
+            return ImmutableArray<PortableExecutableReference>.Empty;
+        }
     }
 
     private sealed class RestrictedSourceReferenceResolver : SourceReferenceResolver
@@ -196,6 +214,16 @@ public sealed class RoslynScriptCompiler : IQuantScriptCompiler
         public override string? ResolveReference(string path, string? baseFilePath) => null;
     }
 
+    internal static ScriptDiagnostic? TryCreateSafeModeDiagnostic(string source)
+    {
+        return TryGetUnsafeMarker(source, out var marker)
+            ? new ScriptDiagnostic(
+                "Error",
+                $"Safe mode blocks use of '{marker}' because it is disabled in safe mode. Set EnableUnsafeScripts=true to allow this script.",
+                1,
+                1)
+            : null;
+    }
 
     private static bool TryGetUnsafeMarker(string source, out string marker)
     {

--- a/src/Meridian.QuantScript/Compilation/ScriptRunner.cs
+++ b/src/Meridian.QuantScript/Compilation/ScriptRunner.cs
@@ -103,8 +103,29 @@ public sealed class ScriptRunner : IScriptRunner
         }
         else
         {
-            // Continuations rely on Roslyn continuation diagnostics from ContinueWithAsync.
             compileTime = TimeSpan.Zero;
+
+            if (!_options.EnableUnsafeScripts && RoslynScriptCompiler.TryCreateSafeModeDiagnostic(source) is { } diagnostic)
+            {
+                return new ScriptRunResult(
+                    Success: false,
+                    Elapsed: wallClock.Elapsed,
+                    CompileTime: compileTime,
+                    PeakMemoryBytes: 0,
+                    CompilationErrors: [diagnostic],
+                    RuntimeDiagnostics: Array.Empty<ScriptDiagnostic>(),
+                    RuntimeError: null,
+                    ConsoleOutput: string.Empty,
+                    Metrics: Array.Empty<KeyValuePair<string, string>>(),
+                    Plots: Array.Empty<PlotRequest>(),
+                    Trades: Array.Empty<ScriptTradeResult>(),
+                    CapturedBacktests: Array.Empty<BacktestResult>(),
+                    RuntimeParameters: Array.Empty<ParameterDescriptor>(),
+                    Checkpoint: checkpoint);
+            }
+
+            // Safe-mode source checks above mirror fresh compilation; remaining
+            // continuations rely on Roslyn diagnostics from ContinueWithAsync.
         }
 
         using var runCts = CancellationTokenSource.CreateLinkedTokenSource(ct);

--- a/tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs
+++ b/tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs
@@ -374,6 +374,28 @@ public sealed class ScriptRunnerTests
         third.ConsoleOutput.Should().Contain("42");
     }
 
+    [Theory]
+    [InlineData("#r \"System.Xml\"\nvar x = 1;", "#r")]
+    [InlineData("#load \"helpers/common.csx\"\nvar x = 1;", "#load")]
+    [InlineData("var text = System.IO.File.ReadAllText(\"/tmp/a.txt\");", "System.IO.")]
+    public async Task ContinueWithAsync_SafeModeBlocksUnsafeContinuationSource_AndPreservesCheckpoint(
+        string continuationSource,
+        string blockedMarker)
+    {
+        var runner = BuildRunner();
+
+        var first = await runner.RunAsync("var x = 41;", NoParams);
+
+        var second = await runner.ContinueWithAsync(continuationSource, first.Checkpoint!, NoParams);
+
+        second.Success.Should().BeFalse();
+        second.CompilationErrors.Should().ContainSingle(d =>
+            d.Message.Contains(blockedMarker, StringComparison.Ordinal) &&
+            d.Message.Contains("disabled in safe mode", StringComparison.OrdinalIgnoreCase));
+        second.RuntimeError.Should().BeNull();
+        second.Checkpoint.Should().BeSameAs(first.Checkpoint);
+    }
+
     [Fact]
     public async Task RunAsync_UsesFreshPerInvocationPlotQueue_NotInjectedQueueState()
     {


### PR DESCRIPTION
### Motivation
- Reinstate the original safe-mode safety boundary so notebook continuations cannot bypass the intended restriction on loading assemblies or local source via `#r`/`#load` or by using unsafe APIs.
- Centralize the safe-mode source scanning so both fresh compilations and continuation runs use the same detection logic.
- Add regression coverage to prevent re-introducing the continuation bypass that would allow loading attacker-controlled assemblies in safe mode.

### Description
- Restored a restricted `MetadataReferenceResolver` (`RestrictedMetadataReferenceResolver`) and wired it into `ScriptOptions` when `EnableUnsafeScripts` is false so Roslyn cannot resolve `#r` references in safe mode (`src/Meridian.QuantScript/Compilation/RoslynScriptCompiler.cs`).
- Introduced a shared helper `TryCreateSafeModeDiagnostic` and changed `CompileAsync` to use it so safe-mode diagnostics for `#r`, `#load`, and unsafe API markers are produced consistently (same file).
- Added an early safe-mode check in the continuation path of `ScriptRunner` so `ContinueWithAsync` runs return a safe-mode diagnostic and preserve the prior checkpoint when continuation source contains blocked markers (`src/Meridian.QuantScript/Compilation/ScriptRunner.cs`).
- Added a regression test `ContinueWithAsync_SafeModeBlocksUnsafeContinuationSource_AndPreservesCheckpoint` covering `#r`, `#load`, and a `System.IO` marker to `tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs`.

### Testing
- Ran repository static checks including `git diff --check` and a local Python validation that confirmed the metadata resolver was restored, the continuation guard is added before `ContinueWithAsync`, and the new regression tests are present (passed).
- Updated unit tests to include a continuation safety regression (`tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs`) to guard the behavior going forward.
- Attempted to run `dotnet test` for the QuantScript tests but was unable to execute them in this environment because `dotnet` is not installed; the change includes tests but full execution of `dotnet test tests/Meridian.QuantScript.Tests/...` was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d87825f1483209a374e05d566500e)