### PR TITLE
Validate direct lending Security Master lineage

### DIFF
--- a/src/Meridian.Application/DirectLending/LoanAccountingProjector.cs
+++ b/src/Meridian.Application/DirectLending/LoanAccountingProjector.cs
@@ -2,11 +2,13 @@ using System.Text.Json;
 using Meridian.Application.Ledger;
 using Meridian.Contracts.DirectLending;
 using Meridian.Contracts.Ledger;
+using Meridian.Contracts.SecurityMaster;
 using Meridian.Ledger;
 using Meridian.Storage.DirectLending;
 using Meridian.Storage.Ledger;
 using LedgerAccount = Meridian.Ledger.LedgerAccount;
 using LedgerAccountType = Meridian.Ledger.LedgerAccountType;
+using SecurityMasterQueryService = Meridian.Application.SecurityMaster.ISecurityMasterQueryService;
 
 namespace Meridian.Application.DirectLending;
 
@@ -14,13 +16,16 @@ public sealed class LoanAccountingProjector
 {
     private readonly ILedgerJournalStore? _journalStore;
     private readonly IAccountingPolicyService _accountingPolicyService;
+    private readonly SecurityMasterQueryService? _securityMasterQueryService;
 
     public LoanAccountingProjector(
         ILedgerJournalStore? journalStore,
-        IAccountingPolicyService accountingPolicyService)
+        IAccountingPolicyService accountingPolicyService,
+        SecurityMasterQueryService? securityMasterQueryService = null)
     {
         _journalStore = journalStore;
         _accountingPolicyService = accountingPolicyService;
+        _securityMasterQueryService = securityMasterQueryService;
     }
 
     public async Task<IReadOnlyList<LedgerJournalEntryWrite>> ProjectAsync(
@@ -168,7 +173,9 @@ public sealed class LoanAccountingProjector
             return [];
         }
 
-        var securityLineage = BuildSecurityMasterPostingLineage(securityReference, eventType);
+        var securityLineage = await ResolveSecurityMasterPostingLineageAsync(securityReference, eventType, ct).ConfigureAwait(false);
+        instrumentSymbol = securityLineage.Symbol;
+        lines = ApplyAuthoritativeInstrumentSymbol(lines, instrumentSymbol);
 
         var entry = new JournalEntry(
             journalEntryId,
@@ -178,7 +185,7 @@ public sealed class LoanAccountingProjector
             new JournalEntryMetadata(
                 ActivityType: eventType,
                 Symbol: instrumentSymbol,
-                SecurityId: securityReference!.SecurityId,
+                SecurityId: securityLineage.SecurityId,
                 FinancialAccountId: loanId.ToString("D"),
                 Institution: "DirectLending",
                 Tags: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -246,9 +253,29 @@ public sealed class LoanAccountingProjector
                string.Equals(status, "SoftClosed", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static (string Provenance, string Lineage) BuildSecurityMasterPostingLineage(
+    private static List<LedgerEntry> ApplyAuthoritativeInstrumentSymbol(
+        IReadOnlyList<LedgerEntry> lines,
+        string instrumentSymbol) =>
+        lines
+            .Select(line => new LedgerEntry(
+                line.EntryId,
+                line.JournalEntryId,
+                line.Timestamp,
+                line.Account with
+                {
+                    Symbol = IsDirectLendingInstrumentAccount(line.Account.Name)
+                        ? instrumentSymbol
+                        : null
+                },
+                line.Debit,
+                line.Credit,
+                line.Description))
+            .ToList();
+
+    private async Task<(Guid SecurityId, string Symbol, string Provenance, string Lineage)> ResolveSecurityMasterPostingLineageAsync(
         DirectLendingSecurityMasterReferenceDto? reference,
-        string eventType)
+        string eventType,
+        CancellationToken ct)
     {
         if (reference is null)
         {
@@ -266,8 +293,8 @@ public sealed class LoanAccountingProjector
                     $"Direct-lending ledger event '{eventType}' requires a resolved Security Master security id before posting."));
         }
 
-        var symbol = NormalizeSymbol(reference.Symbol);
-        if (symbol is null)
+        var requestedSymbol = NormalizeSymbol(reference.Symbol);
+        if (requestedSymbol is null)
         {
             throw new DirectLendingCommandException(
                 new DirectLendingCommandError(
@@ -275,36 +302,80 @@ public sealed class LoanAccountingProjector
                     $"Direct-lending ledger event '{eventType}' requires a Security Master symbol before posting."));
         }
 
-        if (!string.Equals(reference.Status, "Active", StringComparison.OrdinalIgnoreCase))
+        if (_securityMasterQueryService is null)
         {
             throw new DirectLendingCommandException(
                 new DirectLendingCommandError(
                     DirectLendingErrorCode.Validation,
-                    $"Direct-lending ledger event '{eventType}' requires an active Security Master reference before posting."));
+                    $"Direct-lending ledger event '{eventType}' requires an authoritative Security Master lookup before posting."));
         }
 
-        if (string.IsNullOrWhiteSpace(reference.Provenance) ||
-            string.IsNullOrWhiteSpace(reference.ApprovalReference) ||
-            string.IsNullOrWhiteSpace(reference.LedgerMappingReference))
+        var security = await _securityMasterQueryService.GetByIdAsync(reference.SecurityId, ct).ConfigureAwait(false);
+        if (security is null)
         {
             throw new DirectLendingCommandException(
                 new DirectLendingCommandError(
                     DirectLendingErrorCode.Validation,
-                    $"Direct-lending ledger event '{eventType}' requires Security Master provenance, approval, and ledger mapping evidence before posting."));
+                    $"Direct-lending ledger event '{eventType}' references Security Master security '{reference.SecurityId}' but no authoritative record exists."));
         }
 
-        var securityId = reference.SecurityId.ToString("N");
-        var provenance = $"security-master:{securityId};{reference.Provenance.Trim()};approved:true";
+        if (security.Status != SecurityStatusDto.Active)
+        {
+            throw new DirectLendingCommandException(
+                new DirectLendingCommandError(
+                    DirectLendingErrorCode.Validation,
+                    $"Direct-lending ledger event '{eventType}' requires an active authoritative Security Master record before posting."));
+        }
+
+        if (!SecurityMasterRecordContainsSymbol(security, requestedSymbol))
+        {
+            throw new DirectLendingCommandException(
+                new DirectLendingCommandError(
+                    DirectLendingErrorCode.Validation,
+                    $"Direct-lending ledger event '{eventType}' Security Master symbol '{requestedSymbol}' does not match the authoritative Security Master record for '{reference.SecurityId}'."));
+        }
+
+        var securityId = security.SecurityId.ToString("N");
+        var provenance = $"security-master:{securityId};server-resolved:true;status:{security.Status};version:{security.Version}";
         var lineage = string.Join(
             ':',
-            symbol,
+            requestedSymbol,
             securityId,
-            reference.LedgerMappingReference.Trim(),
-            reference.ApprovalReference.Trim(),
-            "security-status:active",
+            $"ledger-map:direct-lending:{requestedSymbol}:{securityId}",
+            $"sm-approval:security-master-active:{securityId}",
+            $"security-status:{security.Status}",
             provenance);
-        return (provenance, lineage);
+        return (security.SecurityId, requestedSymbol, provenance, lineage);
     }
+
+    private static bool SecurityMasterRecordContainsSymbol(SecurityDetailDto security, string symbol)
+    {
+        if (TokenMatches(security.DisplayName, symbol))
+        {
+            return true;
+        }
+
+        foreach (var identifier in security.Identifiers)
+        {
+            if (TokenMatches(identifier.Value, symbol) || TokenMatches(identifier.NormalizedValue, symbol))
+            {
+                return true;
+            }
+        }
+
+        foreach (var alias in security.Aliases)
+        {
+            if (alias.IsEnabled && TokenMatches(alias.AliasValue, symbol))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TokenMatches(string? value, string symbol) =>
+        string.Equals(NormalizeSymbol(value), symbol, StringComparison.OrdinalIgnoreCase);
 
     private static bool IsDirectLendingInstrumentAccount(string account) =>
         !string.Equals(account, "Cash", StringComparison.OrdinalIgnoreCase);

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -32,9 +32,10 @@ and UI presentation concerns in their owning layers.
   failures. Ledger-impacting commands project balanced `LedgerJournalEntryWrite` records before
   persistence and pass them to the direct-lending state store with the same generated loan event id
   as ledger source lineage. Loan terms that produce ledger postings must carry a
-  `DirectLendingSecurityMasterReferenceDto`; the projector stamps the resolved Security Master id,
-  symbol, approval, provenance, active status, and ledger-mapping reference on central ledger writes
-  before the posting guard accepts direct-lending instrument lines.
+  `DirectLendingSecurityMasterReferenceDto`; the projector re-resolves that reference through the
+  authoritative Security Master query service and then stamps server-derived Security Master id,
+  symbol, approval, provenance, active status, and direct-lending ledger-mapping evidence on central
+  ledger writes before the posting guard accepts direct-lending instrument lines.
 - `OperationsContinuity/` - account-period continuity aggregate, command transitions, audit
   timeline, and server-derived gate status for broker, Security Master, ledger, reconciliation,
   and approval close lanes. Approval and close commands enforce shared close-checklist control

--- a/tests/Meridian.Tests/Application/DirectLending/AccrualLedgerServiceTests.cs
+++ b/tests/Meridian.Tests/Application/DirectLending/AccrualLedgerServiceTests.cs
@@ -1,12 +1,15 @@
+using System.Text.Json;
 using FluentAssertions;
 using Meridian.Application.DirectLending;
 using Meridian.Application.Ledger;
 using Meridian.Contracts.DirectLending;
 using Meridian.Contracts.FundStructure;
 using Meridian.Contracts.Ledger;
+using Meridian.Contracts.SecurityMaster;
 using Meridian.Ledger;
 using Meridian.Storage.DirectLending;
 using Meridian.Storage.Ledger;
+using NSubstitute;
 
 namespace Meridian.Tests.Application.DirectLending;
 
@@ -115,9 +118,40 @@ public sealed class AccrualLedgerServiceTests
     {
         var projector = new LoanAccountingProjector(
             new PeriodOnlyLedgerJournalStore(period),
-            new AccountingPolicyService());
+            new AccountingPolicyService(),
+            BuildSecurityMasterQueryService());
         return new AccrualLedgerService(projector);
     }
+
+    private static Meridian.Application.SecurityMaster.ISecurityMasterQueryService BuildSecurityMasterQueryService()
+    {
+        var service = Substitute.For<Meridian.Application.SecurityMaster.ISecurityMasterQueryService>();
+        service.GetByIdAsync(Guid.Parse("99999999-9999-9999-9999-999999999999"), Arg.Any<CancellationToken>())
+            .Returns(BuildSecurityMasterDetail());
+        return service;
+    }
+
+    private static SecurityDetailDto BuildSecurityMasterDetail() =>
+        new(
+            SecurityId: Guid.Parse("99999999-9999-9999-9999-999999999999"),
+            AssetClass: "CustomAsset",
+            Status: SecurityStatusDto.Active,
+            DisplayName: "Northwind Senior Term Loan",
+            Currency: "USD",
+            CommonTerms: JsonSerializer.SerializeToElement(new { displayName = "Northwind Senior Term Loan", currency = "USD" }),
+            AssetSpecificTerms: JsonSerializer.SerializeToElement(new { facility = "Northwind" }),
+            Identifiers:
+            [
+                new SecurityIdentifierDto(
+                    SecurityIdentifierKind.InternalCode,
+                    "NWTERM26",
+                    IsPrimary: true,
+                    ValidFrom: DateTimeOffset.Parse("2026-03-22T00:00:00Z"))
+            ],
+            Aliases: [],
+            Version: 4,
+            EffectiveFrom: DateTimeOffset.Parse("2026-03-22T00:00:00Z"),
+            EffectiveTo: null);
 
     private static LedgerAccountingPeriod BuildOpenPeriod() =>
         new(
@@ -180,7 +214,14 @@ public sealed class AccrualLedgerServiceTests
             CommitmentFeeRate: 0.0025m,
             DefaultRateSpreadBps: null,
             PrepaymentAllowed: true,
-            CovenantsJson: null);
+            CovenantsJson: null,
+            SecurityMasterReference: new DirectLendingSecurityMasterReferenceDto(
+                SecurityId: Guid.Parse("99999999-9999-9999-9999-999999999999"),
+                Symbol: "NWTERM26",
+                Provenance: "source:security-master;definition:loan-facility",
+                ApprovalReference: "sm-approval:nwterm26-controller",
+                LedgerMappingReference: "ledger-map:nwterm26-direct-lending",
+                Status: "Active"));
 
         return new LoanContractDetailDto(
             LoanId: loanId,

--- a/tests/Meridian.Tests/Application/DirectLending/PostgresDirectLendingCommandServiceTests.cs
+++ b/tests/Meridian.Tests/Application/DirectLending/PostgresDirectLendingCommandServiceTests.cs
@@ -5,6 +5,7 @@ using Meridian.Application.Ledger;
 using Meridian.Contracts.DirectLending;
 using Meridian.Contracts.FundStructure;
 using Meridian.Contracts.Ledger;
+using Meridian.Contracts.SecurityMaster;
 using Meridian.Storage.DirectLending;
 using Meridian.Storage.Ledger;
 using NSubstitute;
@@ -55,7 +56,7 @@ public sealed class PostgresDirectLendingCommandServiceTests
             stateStore,
             Substitute.For<IDirectLendingOperationsStore>(),
             queryService,
-            new LoanAccountingProjector(BuildLedgerJournalStore(), new AccountingPolicyService()),
+            new LoanAccountingProjector(BuildLedgerJournalStore(), new AccountingPolicyService(), BuildSecurityMasterQueryService()),
             new DirectLendingOptions { CurrentEventSchemaVersion = 3 });
 
         var result = await service.PostDailyAccrualAsync(
@@ -83,9 +84,9 @@ public sealed class PostgresDirectLendingCommandServiceTests
         write.Entry.Metadata.Tags.Should().ContainKey("sourceEventId")
             .WhoseValue.Should().Be(capturedEventId.ToString("D"));
         write.Entry.Metadata.Tags.Should().ContainKey("securityMasterProvenance")
-            .WhoseValue.Should().Contain("approved:true");
+            .WhoseValue.Should().Contain("server-resolved:true");
         write.Entry.Metadata.Tags.Should().ContainKey("securityMasterLineage")
-            .WhoseValue.Should().Contain("ledger-map:nwterm26-direct-lending");
+            .WhoseValue.Should().Contain("ledger-map:direct-lending:NWTERM26");
         write.Entry.Lines
             .Where(static line => !string.Equals(line.Account.Name, "Cash", StringComparison.OrdinalIgnoreCase))
             .Should()
@@ -108,7 +109,7 @@ public sealed class PostgresDirectLendingCommandServiceTests
             stateStore,
             Substitute.For<IDirectLendingOperationsStore>(),
             queryService,
-            new LoanAccountingProjector(BuildLedgerJournalStore(), new AccountingPolicyService()),
+            new LoanAccountingProjector(BuildLedgerJournalStore(), new AccountingPolicyService(), BuildSecurityMasterQueryService()),
             new DirectLendingOptions { CurrentEventSchemaVersion = 3 });
 
         var act = () => service.PostDailyAccrualAsync(
@@ -117,6 +118,61 @@ public sealed class PostgresDirectLendingCommandServiceTests
 
         await act.Should().ThrowAsync<DirectLendingCommandException>()
             .WithMessage("*requires a Security Master reference before posting*");
+        await stateStore.DidNotReceiveWithAnyArgs().SaveAsync(
+            default,
+            default,
+            default,
+            default!,
+            default!,
+            default!,
+            default,
+            default,
+            default!,
+            default!,
+            default,
+            default,
+            default);
+    }
+
+
+    [Fact]
+    public async Task PostDailyAccrualAsync_RejectsForgedSecurityMasterReferenceMissingFromAuthoritativeStore()
+    {
+        var loanId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var baselineContract = BuildContract(loanId);
+        var contract = baselineContract with
+        {
+            CurrentTerms = baselineContract.CurrentTerms with
+            {
+                SecurityMasterReference = new DirectLendingSecurityMasterReferenceDto(
+                    SecurityId: Guid.Parse("11111111-2222-3333-4444-555555555555"),
+                    Symbol: "FORGEDTERM26",
+                    Provenance: "source:attacker;approved:true",
+                    ApprovalReference: "sm-approval:attacker-controlled-ticket",
+                    LedgerMappingReference: "ledger-map:forgedterm26-direct-lending",
+                    Status: "Active")
+            }
+        };
+        var servicing = BuildServicing(loanId);
+
+        var stateStore = Substitute.For<IDirectLendingStateStore>();
+        var queryService = Substitute.For<IDirectLendingQueryService>();
+        queryService.LoadAggregateAsync(loanId, Arg.Any<CancellationToken>())
+            .Returns(new PersistedDirectLendingState(loanId, 7, contract, servicing));
+
+        var service = new PostgresDirectLendingCommandService(
+            stateStore,
+            Substitute.For<IDirectLendingOperationsStore>(),
+            queryService,
+            new LoanAccountingProjector(BuildLedgerJournalStore(), new AccountingPolicyService(), BuildSecurityMasterQueryService()),
+            new DirectLendingOptions { CurrentEventSchemaVersion = 3 });
+
+        var act = () => service.PostDailyAccrualAsync(
+            loanId,
+            new PostDailyAccrualRequest(new DateOnly(2026, 3, 24)));
+
+        await act.Should().ThrowAsync<DirectLendingCommandException>()
+            .WithMessage("*no authoritative record exists*");
         await stateStore.DidNotReceiveWithAnyArgs().SaveAsync(
             default,
             default,
@@ -160,6 +216,36 @@ public sealed class PostgresDirectLendingCommandServiceTests
 
         return store;
     }
+
+    private static Meridian.Application.SecurityMaster.ISecurityMasterQueryService BuildSecurityMasterQueryService()
+    {
+        var service = Substitute.For<Meridian.Application.SecurityMaster.ISecurityMasterQueryService>();
+        service.GetByIdAsync(Guid.Parse("99999999-9999-9999-9999-999999999999"), Arg.Any<CancellationToken>())
+            .Returns(BuildSecurityMasterDetail());
+        return service;
+    }
+
+    private static SecurityDetailDto BuildSecurityMasterDetail() =>
+        new(
+            SecurityId: Guid.Parse("99999999-9999-9999-9999-999999999999"),
+            AssetClass: "CustomAsset",
+            Status: SecurityStatusDto.Active,
+            DisplayName: "Northwind Senior Term Loan",
+            Currency: "USD",
+            CommonTerms: JsonSerializer.SerializeToElement(new { displayName = "Northwind Senior Term Loan", currency = "USD" }),
+            AssetSpecificTerms: JsonSerializer.SerializeToElement(new { facility = "Northwind" }),
+            Identifiers:
+            [
+                new SecurityIdentifierDto(
+                    SecurityIdentifierKind.InternalCode,
+                    "NWTERM26",
+                    IsPrimary: true,
+                    ValidFrom: DateTimeOffset.Parse("2026-03-22T00:00:00Z"))
+            ],
+            Aliases: [],
+            Version: 4,
+            EffectiveFrom: DateTimeOffset.Parse("2026-03-22T00:00:00Z"),
+            EffectiveTo: null);
 
     private static LoanContractDetailDto BuildContract(Guid loanId, bool includeSecurityMasterReference = true)
     {


### PR DESCRIPTION
### Motivation
- Prevent a trust-boundary vulnerability where caller-supplied `DirectLendingSecurityMasterReferenceDto` fields were treated as authoritative and produced approved/active ledger lineage. 
- Ensure ledger postings are attributed only after authoritative server-side Security Master resolution and active-status/symbol validation.

### Description
- Inject the authoritative Security Master query service into `LoanAccountingProjector` and re-resolve `SecurityMasterReference` server-side before emitting ledger journal metadata. 
- Replace caller-provided lineage with server-derived lineage and provenance (including `server-resolved:true`, authoritative `security-id`, active-status and direct-lending ledger-mapping tokens) and stamp the resolved `SecurityId` and symbol into journal metadata. 
- Apply the resolved symbol to instrument ledger lines via `ApplyAuthoritativeInstrumentSymbol` so line-level symbols match the authoritative Security Master record. 
- Add tests and test fixtures to assert rejection of forged/missing Security Master references and to provide an authoritative Security Master query response for legitimate paths, and document the server-side re-resolution requirement in the application README. 

### Testing
- Ran `git diff --check` which reported no style/conflict errors for the change. 
- Attempted to run `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~DirectLending"` but execution was blocked because `dotnet` is not installed in the environment. 
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary`, which completed and reported broad existing documentation hash-drift across many modules (not caused by these functional fixes) and should be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a8a923538832099c864d30b4f1957)