### PR TITLE
Harden fund ownership lifecycle RBAC

### DIFF
--- a/src/Meridian.Contracts/Auth/RolePermissions.cs
+++ b/src/Meridian.Contracts/Auth/RolePermissions.cs
@@ -29,7 +29,8 @@ public static class RolePermissions
         UserPermission.ViewSecurityMaster |
         UserPermission.ModifySecurityMaster |
         UserPermission.ViewDirectLending |
-        UserPermission.ManageDirectLending;
+        UserPermission.ManageDirectLending |
+        UserPermission.ManageFundStructure;
 
     private const UserPermission DeveloperPermissions =
         AdminPermissions & ~UserPermission.ManageUsers;
@@ -61,7 +62,8 @@ public static class RolePermissions
         UserPermission.ExportData |
         UserPermission.ViewStrategies |
         UserPermission.ViewDirectLending |
-        UserPermission.ManageDirectLending;
+        UserPermission.ManageDirectLending |
+        UserPermission.ManageFundStructure;
 
     private const UserPermission ExecutivePermissions =
         UserPermission.ViewMarketData |
@@ -212,6 +214,7 @@ public static class RolePermissions
         UserPermission.ViewStrategies or UserPermission.ManageStrategies => "Strategy",
         UserPermission.ViewSecurityMaster or UserPermission.ModifySecurityMaster => "Security Master",
         UserPermission.ViewDirectLending or UserPermission.ManageDirectLending => "Direct lending",
+        UserPermission.ManageFundStructure => "Fund structure",
         _ => "Other"
     };
 
@@ -239,6 +242,7 @@ public static class RolePermissions
         UserPermission.ModifySecurityMaster => "Create or update Security Master entries.",
         UserPermission.ViewDirectLending => "View direct-lending contracts and positions.",
         UserPermission.ManageDirectLending => "Create and service direct-lending contracts.",
+        UserPermission.ManageFundStructure => "Create or modify fund-structure ownership and governance records.",
         _ => permission.ToString()
     };
 }

--- a/src/Meridian.Contracts/Auth/UserPermission.cs
+++ b/src/Meridian.Contracts/Auth/UserPermission.cs
@@ -84,4 +84,8 @@ public enum UserPermission : long
 
     /// <summary>Create and service direct-lending contracts.</summary>
     ManageDirectLending = 1L << 21,
+
+    // ── Fund structure / governance ────────────────────────────────────────────
+    /// <summary>Create or modify fund-structure ownership and governance records.</summary>
+    ManageFundStructure = 1L << 22,
 }

--- a/src/Meridian.Contracts/README.md
+++ b/src/Meridian.Contracts/README.md
@@ -6,7 +6,7 @@ module_id: SRC-CONTRACTS
 path: src/Meridian.Contracts
 status: active
 owner_lane: Contract Compatibility
-last_reviewed: 2026-05-29
+last_reviewed: 2026-05-30
 ---
 
 # src/Meridian.Contracts
@@ -89,8 +89,10 @@ server-owned broker-staging readiness, required approvals, blockers, evidence id
 broker action before any paper/live movement is routed.
 
 Auth contracts include the role and permission catalog plus custom role-profile upsert payloads.
-Keep role-profile requests, result envelopes, and audit-event metadata in contracts so browser,
-desktop, and endpoint tests share the same authority-configuration vocabulary.
+`ManageFundStructure` covers governance-impacting ownership lifecycle mutations so ReadOnly and
+analytics-only sessions cannot alter fund-structure relationship records. Keep role-profile
+requests, result envelopes, and audit-event metadata in contracts so browser, desktop, and endpoint
+tests share the same authority-configuration vocabulary.
 
 Operations approval policy contracts include a shared approval policy matrix for close governance,
 governed approval-policy rule upsert requests, result envelopes, and audit-event metadata.

--- a/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs
@@ -265,8 +265,11 @@ public static class FundStructureEndpoints
             }
         })
         .WithName("UpdateOwnershipLink")
+        .AddEndpointFilter(EndpointAuthorization.Require(UserPermission.ManageFundStructure))
         .Produces<OwnershipLinkDto>(StatusCodes.Status200OK)
-        .Produces(StatusCodes.Status400BadRequest);
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status403Forbidden);
 
         group.MapPost("/links/{ownershipLinkId:guid}/expire", async (Guid ownershipLinkId, JsonElement body, HttpContext context) =>
         {
@@ -292,8 +295,11 @@ public static class FundStructureEndpoints
             }
         })
         .WithName("ExpireOwnershipLink")
+        .AddEndpointFilter(EndpointAuthorization.Require(UserPermission.ManageFundStructure))
         .Produces<OwnershipLinkDto>(StatusCodes.Status200OK)
-        .Produces(StatusCodes.Status400BadRequest);
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status403Forbidden);
 
         group.MapPost("/links/{ownershipLinkId:guid}/replace", async (Guid ownershipLinkId, JsonElement body, HttpContext context) =>
         {
@@ -319,8 +325,11 @@ public static class FundStructureEndpoints
             }
         })
         .WithName("ReplaceOwnershipLink")
+        .AddEndpointFilter(EndpointAuthorization.Require(UserPermission.ManageFundStructure))
         .Produces<OwnershipLinkDto>(StatusCodes.Status201Created)
-        .Produces(StatusCodes.Status400BadRequest);
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status403Forbidden);
 
         group.MapPost("/links/validate", async (JsonElement body, HttpContext context) =>
         {

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -6,7 +6,7 @@ module_id: SRC-UI-SHARED
 path: src/Meridian.Ui.Shared
 status: active
 owner_lane: Workstation Shell and UX
-last_reviewed: 2026-05-29
+last_reviewed: 2026-05-30
 ---
 
 # src/Meridian.Ui.Shared
@@ -30,6 +30,7 @@ compatibility across `src/Meridian.Ui.Services`, `src/Meridian.Ui/dashboard`, an
 ## Important workflows
 
 `FundStructureSetupWorkflowService` backs `/api/fund-structure/setup-drafts/validate` and `/api/fund-structure/setup-drafts/create`, composing `IFundStructureService` commands once for browser and WPF entity setup instead of duplicating setup sequencing in clients.
+Ownership lifecycle mutation routes under `/api/fund-structure/links/{id}` require the session-derived `ManageFundStructure` permission before updating, expiring, or replacing governance-impacting ownership links.
 
 
 Preserve cross-surface compatibility when evolving shared read models. Keep ledger/reconciliation

--- a/tests/Meridian.Tests/Integration/EndpointTests/FundStructureEndpointTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/FundStructureEndpointTests.cs
@@ -7,12 +7,17 @@ using Meridian.Application.FundAccounts;
 using Meridian.Application.FundStructure;
 using Meridian.Backtesting.Sdk;
 using Meridian.Contracts.FundStructure;
+using Meridian.Contracts.Auth;
 using Meridian.Contracts.Workstation;
 using Meridian.Ui.Shared.Services;
+using Meridian.Ui.Shared.Endpoints;
 using Meridian.Ledger;
 using Meridian.Strategies.Interfaces;
 using Meridian.Strategies.Models;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Builder;
 using Xunit;
 
 namespace Meridian.Tests.Integration.EndpointTests;
@@ -68,7 +73,9 @@ public sealed class FundStructureEndpointTests
     [Fact]
     public async Task OwnershipLifecycleEndpoints_UpdateExpireAndValidateGraph()
     {
-        var structureService = _fixture.Services.GetRequiredService<IFundStructureService>();
+        await using var app = await CreateFundStructureAuthorizationAppAsync(UserPermission.ManageFundStructure);
+        var client = app.GetTestClient();
+        var structureService = app.Services.GetRequiredService<IFundStructureService>();
         var organizationId = Guid.NewGuid();
         var businessId = Guid.NewGuid();
         var fundId = Guid.NewGuid();
@@ -117,7 +124,7 @@ public sealed class FundStructureEndpointTests
             now,
             "endpoint-test"));
 
-        var updateResponse = await _client.PutAsJsonAsync(
+        var updateResponse = await client.PutAsJsonAsync(
             $"/api/fund-structure/links/{linkId}",
             new UpdateOwnershipLinkRequest(
                 Guid.Empty,
@@ -127,10 +134,10 @@ public sealed class FundStructureEndpointTests
                 OwnershipPercent: 60m,
                 IsPrimary: true,
                 Notes: "endpoint update"));
-        var validateResponse = await _client.PostAsJsonAsync(
+        var validateResponse = await client.PostAsJsonAsync(
             "/api/fund-structure/links/validate",
             new ValidateOwnershipGraphRequest(AsOf: now.AddHours(1)));
-        var expireResponse = await _client.PostAsJsonAsync(
+        var expireResponse = await client.PostAsJsonAsync(
             $"/api/fund-structure/links/{linkId}/expire",
             new ExpireOwnershipLinkRequest(
                 Guid.Empty,
@@ -154,6 +161,61 @@ public sealed class FundStructureEndpointTests
         expired.Should().NotBeNull();
         expired!.EffectiveTo.Should().Be(now.AddDays(1));
         expired.Notes.Should().Be("endpoint expiration");
+    }
+
+
+    [Fact]
+    public async Task OwnershipLifecycleEndpoints_ReadOnlyAuthenticatedOperator_ReturnsForbiddenAndDoesNotMutate()
+    {
+        // Scenario: fund-governance tampering attempt during an accounting close.
+        await using var app = await CreateFundStructureAuthorizationAppAsync(UserPermission.ViewAnalytics);
+        var client = app.GetTestClient();
+        var structureService = app.Services.GetRequiredService<IFundStructureService>();
+        var seed = await SeedOwnershipLinkAsync(structureService);
+
+        var updateResponse = await client.PutAsJsonAsync(
+            $"/api/fund-structure/links/{seed.LinkId}",
+            new UpdateOwnershipLinkRequest(
+                Guid.Empty,
+                OwnershipRelationshipTypeDto.Owns,
+                seed.EffectiveFrom,
+                "readonly-operator",
+                OwnershipPercent: 60m,
+                IsPrimary: true,
+                Notes: "unauthorized update"));
+        var expireResponse = await client.PostAsJsonAsync(
+            $"/api/fund-structure/links/{seed.LinkId}/expire",
+            new ExpireOwnershipLinkRequest(
+                Guid.Empty,
+                seed.EffectiveFrom.AddDays(1),
+                "readonly-operator",
+                "unauthorized expiration"));
+        var replaceResponse = await client.PostAsJsonAsync(
+            $"/api/fund-structure/links/{seed.LinkId}/replace",
+            new ReplaceOwnershipLinkRequest(
+                Guid.Empty,
+                Guid.NewGuid(),
+                seed.FundId,
+                seed.PortfolioId,
+                OwnershipRelationshipTypeDto.Owns,
+                seed.EffectiveFrom.AddDays(2),
+                "readonly-operator",
+                OwnershipPercent: 100m,
+                IsPrimary: true,
+                Notes: "unauthorized replacement"));
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        expireResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        replaceResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        var graph = await structureService.GetOwnershipGraphAsync(seed.EffectiveFrom.AddDays(3));
+        graph.Links.Should().HaveCount(1);
+        var unchanged = graph.Links.Single(link => link.OwnershipLinkId == seed.LinkId);
+        unchanged.RelationshipType.Should().Be(OwnershipRelationshipTypeDto.AllocatesTo);
+        unchanged.OwnershipPercent.Should().BeNull();
+        unchanged.IsPrimary.Should().BeFalse();
+        unchanged.EffectiveTo.Should().BeNull();
+        unchanged.Notes.Should().Be("endpoint-test");
     }
 
     [Fact]
@@ -950,6 +1012,82 @@ public sealed class FundStructureEndpointTests
         ledger.Post(new JournalEntry(journalId, timestamp, description, ledgerLines));
     }
 
+
+    private static async Task<WebApplication> CreateFundStructureAuthorizationAppAsync(UserPermission currentUserPermissions)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton<IFundAccountService, InMemoryFundAccountService>();
+        builder.Services.AddSingleton<IFundStructureService>(sp =>
+            new InMemoryFundStructureService(
+                sp.GetRequiredService<IFundAccountService>(),
+                persistencePath: null));
+
+        var app = builder.Build();
+        app.Use(async (context, next) =>
+        {
+            context.Items[LoginSessionMiddleware.CurrentUserKey] = "readonly-fund-operator";
+            context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] = currentUserPermissions;
+            await next(context);
+        });
+        app.MapFundStructureEndpoints(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        await app.StartAsync();
+        return app;
+    }
+
+    private static async Task<SeededOwnershipLink> SeedOwnershipLinkAsync(IFundStructureService structureService)
+    {
+        var organizationId = Guid.NewGuid();
+        var businessId = Guid.NewGuid();
+        var fundId = Guid.NewGuid();
+        var portfolioId = Guid.NewGuid();
+        var linkId = Guid.NewGuid();
+        var now = new DateTimeOffset(2026, 04, 12, 0, 0, 0, TimeSpan.Zero);
+
+        await structureService.CreateOrganizationAsync(new CreateOrganizationRequest(
+            organizationId,
+            $"ORG-{Guid.NewGuid():N}"[..12].ToUpperInvariant(),
+            "Ownership Endpoint Organization",
+            "USD",
+            now,
+            "endpoint-test"));
+        await structureService.CreateBusinessAsync(new CreateBusinessRequest(
+            businessId,
+            organizationId,
+            BusinessKindDto.FundManager,
+            $"BUS-{Guid.NewGuid():N}"[..12].ToUpperInvariant(),
+            "Ownership Endpoint Business",
+            "USD",
+            now,
+            "endpoint-test"));
+        await structureService.CreateFundAsync(new CreateFundRequest(
+            fundId,
+            $"FND-{Guid.NewGuid():N}"[..12].ToUpperInvariant(),
+            "Ownership Endpoint Fund",
+            "USD",
+            now,
+            "endpoint-test",
+            BusinessId: businessId));
+        await structureService.CreateInvestmentPortfolioAsync(new CreateInvestmentPortfolioRequest(
+            portfolioId,
+            businessId,
+            $"PRT-{Guid.NewGuid():N}"[..12].ToUpperInvariant(),
+            "Ownership Endpoint Portfolio",
+            "USD",
+            now,
+            "endpoint-test",
+            FundId: fundId));
+        await structureService.LinkNodesAsync(new LinkFundStructureNodesRequest(
+            linkId,
+            fundId,
+            portfolioId,
+            OwnershipRelationshipTypeDto.AllocatesTo,
+            now,
+            "endpoint-test"));
+
+        return new SeededOwnershipLink(fundId, portfolioId, linkId, now);
+    }
+
     private async Task<string> LoginAndGetSessionCookieAsync(string username, string password)
     {
         var loginResponse = await _client.PostAsJsonAsync(
@@ -973,4 +1111,10 @@ public sealed class FundStructureEndpointTests
         string FundProfileId,
         string DisplayName,
         Guid BankAccountId);
+
+    private sealed record SeededOwnershipLink(
+        Guid FundId,
+        Guid PortfolioId,
+        Guid LinkId,
+        DateTimeOffset EffectiveFrom);
 }


### PR DESCRIPTION
### Motivation
- Prevent low-privilege authenticated sessions from mutating fund governance data by making ownership lifecycle mutations require an explicit permission. 
- Close an authorization gap where update/expire/replace handlers called `IFundStructureService` directly without per-endpoint RBAC, allowing ReadOnly/analytics roles to persist governance changes.

### Description
- Add a new permission flag `UserPermission.ManageFundStructure` in `src/Meridian.Contracts/Auth/UserPermission.cs` and register it in the role catalog. 
- Grant `ManageFundStructure` to the admin/developer masks and include it for the Accounting role in `src/Meridian.Contracts/Auth/RolePermissions.cs`. 
- Require the new permission on the ownership lifecycle endpoints by adding `AddEndpointFilter(EndpointAuthorization.Require(UserPermission.ManageFundStructure))` to the `PUT /api/fund-structure/links/{id}`, `POST /api/fund-structure/links/{id}/expire`, and `POST /api/fund-structure/links/{id}/replace` handlers in `src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs` and add `401/403` metadata. 
- Add an integration test `OwnershipLifecycleEndpoints_ReadOnlyAuthenticatedOperator_ReturnsForbiddenAndDoesNotMutate` to `tests/Meridian.Tests/Integration/EndpointTests/FundStructureEndpointTests.cs` that exercises a low-privilege session and verifies `403` and that the ownership link remains unchanged. 
- Update README notes in `src/Meridian.Ui.Shared/README.md` and `src/Meridian.Contracts/README.md` to document the new `ManageFundStructure` permission and its intent. 

### Testing
- Ran static and repository checks: `git diff --check` and repository grep searches to confirm the new permission appears where expected (`rg` for `ManageFundStructure` and added endpoint filters); those checks passed. 
- Added an integration test that exercises the protection path; test code added to `tests/Meridian.Tests/Integration/EndpointTests/FundStructureEndpointTests.cs`. 
- Attempted to run the narrow test command `dotnet test ... --filter "FullyQualifiedName~FundStructureEndpointTests"`, but `dotnet` is not available in this environment so runtime test execution could not be performed; the change is committed and ready for CI to run the integration test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a3a66ffc8832082976eac8efebd21)