### PR TITLE
Fix architecture C4 diagram image paths

### DIFF
--- a/docs/architecture/c4-diagrams.md
+++ b/docs/architecture/c4-diagrams.md
@@ -8,19 +8,19 @@ This page is the quickest way to review the current Meridian visual model. The e
 
 ### Level 1 — System Context
 
-![C4 Level 1 Context](../diagrams/c4-level1-context.svg)
+![C4 Level 1 Context](../diagrams/architecture/c4/c4-level1-context.svg)
 
 Shows Meridian in context with operators, the desktop shell, local API seams, external data providers, and storage/analytics edges.
 
 ### Level 2 — Containers
 
-![C4 Level 2 Containers](../diagrams/c4-level2-containers.svg)
+![C4 Level 2 Containers](../diagrams/architecture/c4/c4-level2-containers.svg)
 
 Shows the main deployable containers and major technology boundaries across presentation, application, provider, pipeline, storage, and observability concerns.
 
 ### Level 3 — Components
 
-![C4 Level 3 Components](../diagrams/c4-level3-components.svg)
+![C4 Level 3 Components](../diagrams/architecture/c4/c4-level3-components.svg)
 
 Shows the collector-runtime internals in more detail, including provider clients, domain collectors, pipeline, and storage sinks.
 
@@ -30,25 +30,25 @@ These diagrams sit next to the C4 set and fill in the parts of the repo that are
 
 ### Runtime Hosts And Startup Modes
 
-![Runtime Hosts And Startup Modes](../diagrams/runtime-hosts.svg)
+![Runtime Hosts And Startup Modes](../diagrams/architecture/platform/runtime-hosts.svg)
 
 Shows the runnable projects in the repo and the verified `SharedStartupBootstrapper` / `StartupOrchestrator` flow behind `src/Meridian`, including how desktop, headless, and backfill paths branch.
 
 ### Workstation Delivery
 
-![Workstation Delivery](../diagrams/workstation-delivery.svg)
+![Workstation Delivery](../diagrams/architecture/platform/workstation-delivery.svg)
 
 Shows how WPF pages, Accounting review surfaces, and the desktop-local API seams converge on shared run, portfolio, ledger, cash-flow, reconciliation, and security-reference services.
 
 ### Security Master Lifecycle
 
-![Security Master Lifecycle](../diagrams/security-master-lifecycle.svg)
+![Security Master Lifecycle](../diagrams/workflows/operations/security-master-lifecycle.svg)
 
 Shows the current Security Master product path across import, ingest status, grouped conflict triage, event storage, projections, cache warmup, and workstation/query consumers.
 
 ### Fund Ops And Reconciliation
 
-![Fund Ops And Reconciliation](../diagrams/fund-ops-reconciliation.svg)
+![Fund Ops And Reconciliation](../diagrams/workflows/operations/fund-ops-reconciliation.svg)
 
 Shows the Accounting review loop across workstation services, reconciliation projections, the F# reconciliation engine, and persisted run/break state.
 


### PR DESCRIPTION
### Motivation
- Images embedded in `docs/architecture/c4-diagrams.md` were not rendering because the SVGs were relocated into nested `docs/diagrams/...` subfolders, so the page needed updated relative paths to the current artifacts.

### Description
- Update `docs/architecture/c4-diagrams.md` to reference the relocated diagram files under `../diagrams/architecture/c4/`, `../diagrams/architecture/platform/`, and `../diagrams/workflows/operations/`; only `docs/architecture/c4-diagrams.md` was modified.

### Testing
- Verified image targets exist with a local Python check that iterates the markdown image links (`python3` script used to validate paths) and ran `git diff --check -- docs/architecture/c4-diagrams.md`, both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21d900e6d88320a34c5f90f7a1ac73)