### PR TITLE
Guard direct-lending Asset Operations projections with authoritative Security Master validation

### DIFF
--- a/src/Meridian.Application/DirectLending/PostgresDirectLendingCommandService.cs
+++ b/src/Meridian.Application/DirectLending/PostgresDirectLendingCommandService.cs
@@ -2,9 +2,11 @@ using System.Text.Json;
 using Meridian.Application.AssetOperations;
 using Meridian.Contracts.AssetOperations;
 using Meridian.Contracts.DirectLending;
+using Meridian.Contracts.SecurityMaster;
 using Meridian.FSharp.DirectLending.Aggregates;
 using Meridian.FSharp.DirectLendingInterop;
 using Meridian.Storage.DirectLending;
+using SecurityMasterQueryService = Meridian.Application.SecurityMaster.ISecurityMasterQueryService;
 
 namespace Meridian.Application.DirectLending;
 
@@ -16,6 +18,7 @@ public sealed partial class PostgresDirectLendingCommandService : IDirectLending
     private readonly LoanAccountingProjector _loanAccountingProjector;
     private readonly DirectLendingOptions _options;
     private readonly IAssetOperationsCommandService? _assetOperationsCommandService;
+    private readonly SecurityMasterQueryService? _securityMasterQueryService;
 
     public PostgresDirectLendingCommandService(
         IDirectLendingStateStore stateStore,
@@ -23,7 +26,8 @@ public sealed partial class PostgresDirectLendingCommandService : IDirectLending
         IDirectLendingQueryService queryService,
         LoanAccountingProjector loanAccountingProjector,
         DirectLendingOptions options,
-        IAssetOperationsCommandService? assetOperationsCommandService = null)
+        IAssetOperationsCommandService? assetOperationsCommandService = null,
+        SecurityMasterQueryService? securityMasterQueryService = null)
     {
         _stateStore = stateStore;
         _operationsStore = operationsStore;
@@ -31,6 +35,7 @@ public sealed partial class PostgresDirectLendingCommandService : IDirectLending
         _loanAccountingProjector = loanAccountingProjector;
         _options = options;
         _assetOperationsCommandService = assetOperationsCommandService;
+        _securityMasterQueryService = securityMasterQueryService;
     }
 
     public async Task<DirectLendingCommandResult<LoanContractDetailDto>> CreateLoanAsync(CreateLoanRequest request, DirectLendingCommandMetadataDto? metadata = null, CancellationToken ct = default)
@@ -564,6 +569,8 @@ public sealed partial class PostgresDirectLendingCommandService : IDirectLending
             return DirectLendingCommandResult<ProjectionRunDto>.Failure(DirectLendingErrorCode.Validation, "Projection requires at least one source event.");
         }
 
+        await ValidateAssetOperationsProjectionTargetAsync(stored.Contract, ct).ConfigureAwait(false);
+
         var existingRuns = await _operationsStore.GetProjectionRunsAsync(loanId, ct).ConfigureAwait(false);
         var latest = existingRuns.OrderByDescending(static x => x.GeneratedAt).FirstOrDefault();
         var asOf = projectionAsOf ?? DateOnly.FromDateTime(DateTime.UtcNow);
@@ -692,9 +699,14 @@ public sealed partial class PostgresDirectLendingCommandService : IDirectLending
                 null));
         }
 
+        var stored = await _queryService.LoadAggregateAsync(loanId, ct).ConfigureAwait(false);
+        if (stored is not null)
+        {
+            await ValidateAssetOperationsProjectionTargetAsync(stored.Contract, ct).ConfigureAwait(false);
+        }
+
         var run = new ReconciliationRunDto(runId, loanId, latestProjection.ProjectionRunId, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, "Completed");
         var savedRun = await _operationsStore.SaveReconciliationRunAsync(run, results, exceptions, ct).ConfigureAwait(false);
-        var stored = await _queryService.LoadAggregateAsync(loanId, ct).ConfigureAwait(false);
         if (stored is not null)
         {
             await PublishAssetOperationsAsync(
@@ -1406,6 +1418,8 @@ public sealed partial class PostgresDirectLendingCommandService : IDirectLending
         CancellationToken ct = default,
         DirectLendingPersistenceBatch? persistenceBatch = null)
     {
+        await ValidateAssetOperationsProjectionTargetAsync(contract, ct).ConfigureAwait(false);
+
         var eventMetadata = DirectLendingServiceSupport.CreateEventMetadata(metadata, "meridian.direct-lending");
         var eventId = Guid.NewGuid();
         var ledgerJournalEntries = await _loanAccountingProjector.ProjectAsync(
@@ -1443,6 +1457,98 @@ public sealed partial class PostgresDirectLendingCommandService : IDirectLending
 
         await PublishAssetOperationsAsync(contract, metadata, ct).ConfigureAwait(false);
     }
+
+
+    private async Task ValidateAssetOperationsProjectionTargetAsync(LoanContractDetailDto contract, CancellationToken ct)
+    {
+        if (_assetOperationsCommandService is null ||
+            contract.CurrentTerms.SecurityMasterReference is null)
+        {
+            return;
+        }
+
+        var reference = contract.CurrentTerms.SecurityMasterReference;
+        if (reference.SecurityId == Guid.Empty)
+        {
+            ThrowAssetOperationsValidation(
+                $"Direct-lending Asset Operations projection for loan '{contract.LoanId}' requires a resolved Security Master security id.");
+        }
+
+        if (_securityMasterQueryService is null)
+        {
+            ThrowAssetOperationsValidation(
+                $"Direct-lending Asset Operations projection for loan '{contract.LoanId}' requires an authoritative Security Master lookup before publishing.");
+        }
+
+        var security = await _securityMasterQueryService!.GetByIdAsync(reference.SecurityId, ct).ConfigureAwait(false);
+        if (security is null)
+        {
+            ThrowAssetOperationsValidation(
+                $"Direct-lending Asset Operations projection for loan '{contract.LoanId}' references Security Master security '{reference.SecurityId}' but no authoritative record exists.");
+        }
+
+        if (!string.Equals(security!.AssetClass, "DirectLoan", StringComparison.OrdinalIgnoreCase))
+        {
+            ThrowAssetOperationsValidation(
+                $"Direct-lending Asset Operations projection for loan '{contract.LoanId}' requires a DirectLoan Security Master record before publishing.");
+        }
+
+        if (security.Status != SecurityStatusDto.Active)
+        {
+            ThrowAssetOperationsValidation(
+                $"Direct-lending Asset Operations projection for loan '{contract.LoanId}' requires an active authoritative Security Master record before publishing.");
+        }
+
+        var requestedSymbol = NormalizeSecurityMasterSymbol(reference.Symbol);
+        if (requestedSymbol is null)
+        {
+            ThrowAssetOperationsValidation(
+                $"Direct-lending Asset Operations projection for loan '{contract.LoanId}' requires a Security Master symbol before publishing.");
+        }
+
+        if (!SecurityMasterRecordContainsSymbol(security, requestedSymbol))
+        {
+            ThrowAssetOperationsValidation(
+                $"Direct-lending Asset Operations projection for loan '{contract.LoanId}' Security Master symbol '{requestedSymbol}' does not match the authoritative Security Master record for '{reference.SecurityId}'.");
+        }
+    }
+
+    [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+    private static void ThrowAssetOperationsValidation(string message)
+        => throw new DirectLendingCommandException(
+            new DirectLendingCommandError(DirectLendingErrorCode.Validation, message));
+
+    private static bool SecurityMasterRecordContainsSymbol(SecurityDetailDto security, string symbol)
+    {
+        if (TokenMatches(security.DisplayName, symbol))
+        {
+            return true;
+        }
+
+        foreach (var identifier in security.Identifiers)
+        {
+            if (TokenMatches(identifier.Value, symbol) || TokenMatches(identifier.NormalizedValue, symbol))
+            {
+                return true;
+            }
+        }
+
+        foreach (var alias in security.Aliases)
+        {
+            if (alias.IsEnabled && TokenMatches(alias.AliasValue, symbol))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TokenMatches(string? value, string symbol)
+        => string.Equals(NormalizeSecurityMasterSymbol(value), symbol, StringComparison.OrdinalIgnoreCase);
+
+    private static string? NormalizeSecurityMasterSymbol(string? symbol)
+        => string.IsNullOrWhiteSpace(symbol) ? null : symbol.Trim().ToUpperInvariant();
 
     private async Task PublishAssetOperationsAsync(
         LoanContractDetailDto contract,

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -35,7 +35,10 @@ and UI presentation concerns in their owning layers.
   `DirectLendingSecurityMasterReferenceDto`; the projector re-resolves that reference through the
   authoritative Security Master query service and then stamps server-derived Security Master id,
   symbol, approval, provenance, active status, and direct-lending ledger-mapping evidence on central
-  ledger writes before the posting guard accepts direct-lending instrument lines.
+  ledger writes before the posting guard accepts direct-lending instrument lines. Direct-lending
+  Asset Operations projection publishing also fail-closes against that authoritative Security Master
+  lookup and only publishes for active `DirectLoan` records whose server-owned identifiers match the
+  loan terms reference, preventing servicing users from targeting arbitrary Security Master rows.
 - `OperationsContinuity/` - account-period continuity aggregate, command transitions, audit
   timeline, and server-derived gate status for broker, Security Master, ledger, reconciliation,
   and approval close lanes. Approval and close commands enforce shared close-checklist control

--- a/tests/Meridian.Tests/Application/DirectLending/PostgresDirectLendingCommandServiceTests.cs
+++ b/tests/Meridian.Tests/Application/DirectLending/PostgresDirectLendingCommandServiceTests.cs
@@ -88,7 +88,8 @@ public sealed class PostgresDirectLendingCommandServiceTests
             queryService,
             new LoanAccountingProjector(BuildLedgerJournalStore(), new AccountingPolicyService(), BuildSecurityMasterQueryService()),
             new DirectLendingOptions { CurrentEventSchemaVersion = 3 },
-            assetOperations);
+            assetOperations,
+            BuildSecurityMasterQueryService());
 
         var result = await service.RequestProjectionAsync(
             loanId,
@@ -335,6 +336,60 @@ public sealed class PostgresDirectLendingCommandServiceTests
 
 
     [Fact]
+    public async Task CreateLoanAsync_WithAssetOperationsProjection_ShouldRejectForgedSecurityMasterReferenceBeforeStateSave()
+    {
+        var loanId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var baselineContract = BuildContract(loanId);
+        var forgedTerms = baselineContract.CurrentTerms with
+        {
+            SecurityMasterReference = new DirectLendingSecurityMasterReferenceDto(
+                SecurityId: Guid.Parse("11111111-2222-3333-4444-555555555555"),
+                Symbol: "FORGEDTERM26",
+                Provenance: "source:attacker;approved:true",
+                ApprovalReference: "sm-approval:attacker-controlled-ticket",
+                LedgerMappingReference: "ledger-map:forgedterm26-direct-lending",
+                Status: "Active")
+        };
+
+        var stateStore = Substitute.For<IDirectLendingStateStore>();
+        var assetOperations = Substitute.For<IAssetOperationsCommandService>();
+        var service = new PostgresDirectLendingCommandService(
+            stateStore,
+            Substitute.For<IDirectLendingOperationsStore>(),
+            Substitute.For<IDirectLendingQueryService>(),
+            new LoanAccountingProjector(BuildLedgerJournalStore(), new AccountingPolicyService(), BuildSecurityMasterQueryService()),
+            new DirectLendingOptions { CurrentEventSchemaVersion = 3 },
+            assetOperations,
+            BuildSecurityMasterQueryService());
+
+        var act = () => service.CreateLoanAsync(new CreateLoanRequest(
+            loanId,
+            baselineContract.FacilityName,
+            baselineContract.Borrower,
+            baselineContract.EffectiveDate,
+            forgedTerms));
+
+        await act.Should().ThrowAsync<DirectLendingCommandException>()
+            .WithMessage("*no authoritative record exists*");
+        await stateStore.DidNotReceiveWithAnyArgs().SaveAsync(
+            default,
+            default,
+            default,
+            default!,
+            default!,
+            default!,
+            default,
+            default,
+            default!,
+            default!,
+            default,
+            default,
+            default);
+        await assetOperations.DidNotReceiveWithAnyArgs().UpsertProjectionAsync(default!, default!, default);
+    }
+
+
+    [Fact]
     public async Task PostDailyAccrualAsync_RejectsForgedSecurityMasterReferenceMissingFromAuthoritativeStore()
     {
         var loanId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
@@ -427,7 +482,7 @@ public sealed class PostgresDirectLendingCommandServiceTests
     private static SecurityDetailDto BuildSecurityMasterDetail() =>
         new(
             SecurityId: Guid.Parse("99999999-9999-9999-9999-999999999999"),
-            AssetClass: "CustomAsset",
+            AssetClass: "DirectLoan",
             Status: SecurityStatusDto.Active,
             DisplayName: "Northwind Senior Term Loan",
             Currency: "USD",


### PR DESCRIPTION
### Motivation
- Direct-lending writes were publishing Asset Operations projections using a caller-supplied `SecurityMasterReference.SecurityId` without resolving or authorizing the target, allowing a user with `ManageDirectLending` to overwrite Asset Operations rows for arbitrary securities.
- The intent is to close that authorization boundary by ensuring projections are only produced for an authoritative, active `DirectLoan` Security Master record whose server-owned identifiers match the loan reference.

### Description
- Inject `ISecurityMasterQueryService` into `PostgresDirectLendingCommandService` and add `ValidateAssetOperationsProjectionTargetAsync` to authoritatively validate `CurrentTerms.SecurityMasterReference` before publishing Asset Operations projections.
- Call the validator from the durable `SaveAsync` path and from projection/reconciliation flows (`RequestProjectionAsync`, reconciliation path) so writes fail-close before the downstream delete-and-replace projection store is invoked.
- Validator checks that `SecurityId` is non-empty, resolves via `ISecurityMasterQueryService.GetByIdAsync`, that the resolved record has `AssetClass == "DirectLoan"`, is `Active`, and that a matching server-side identifier/symbol exists; failures throw `DirectLendingCommandException` with a `Validation` error code.
- Add a regression test `CreateLoanAsync_WithAssetOperationsProjection_ShouldRejectForgedSecurityMasterReferenceBeforeStateSave` to prove forged `SecurityMasterReference` is rejected before the state save and before any projection upsert is attempted.
- Update `tests` fixtures to supply the `ISecurityMasterQueryService` to the command service tests and correct an existing test security asset class to `DirectLoan` so unit expectations match the new guard.
- Document the new guardrail in `src/Meridian.Application/README.md` describing that Asset Operations publishing fail-closes against authoritative Security Master lookups.

### Testing
- Ran `git diff --check` and fixed no whitespace/merge issues (passed).
- Attempted `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~PostgresDirectLendingCommandServiceTests" --logger "console;verbosity=normal"` but execution was blocked because `dotnet` is not available in the container (`dotnet: command not found`).
- Ran documentation validation `python3 build/scripts/docs/validate-doc-hashes.py --summary` which reported repository-wide documentation/source hash drift (including `src/Meridian.Application`) that must be reconciled separately; this is an existing repo-wide validation failure and not caused by the introduced guard logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21dd9f26688320960bbc72a955d646)