### PR TITLE
Improve Codex workspace guidance (.codex/AGENTS.md, .codex/config.toml)

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,13 +1,77 @@
-# Meridian Codex Desktop Workstation Instructions
+# Meridian Codex Workspace Instructions
 
-Use this file for Codex-specific desktop implementation behavior. Keep repository-wide guidance in
-the root `AGENTS.md`, `CLAUDE.md`, and `.codex/skills/_shared/project-context.md`.
-For multi-lane AI work, route coordination and handoff format through
-`docs/ai/agent-handoff-checklist.md` and keep host-specific Codex docs aligned to it.
-Select a mode from `docs/ai/work-modes.md` before implementation and initialize
-`docs/ai/parallel-task-manifest-template.md` before concurrent lane execution.
+This file applies to files under `.codex/`. Keep repository-wide guidance in the root
+`AGENTS.md`, `CLAUDE.md`, `.codex/skills/_shared/project-context.md`, and
+`.codex/skills/_shared/codex-execution-contract.md`. Keep this file focused on Codex-local
+configuration, skills, prompts, checklists, agents, and environment definitions.
 
-## Default Implementation Rules
+Codex discovers `AGENTS.md` files from the project root down to the current working directory, so
+this file is a narrower override for `.codex/**` work. If a nested Codex directory later needs
+stricter rules, add a closer `AGENTS.md` or `AGENTS.override.md` rather than expanding this file.
+
+## Start Gate
+
+- Run `git status --short` before editing and preserve unrelated user-owned changes.
+- Read `.codex/skills/_shared/project-context.md` before changing Codex guidance that references
+  product scope, active surfaces, commands, roadmap direction, or canonical terminology.
+- Read `.codex/skills/_shared/codex-execution-contract.md` before changing skills, agents,
+  prompts, hooks, config, or automation guidance.
+- For source-facing guidance changes, verify the referenced source path, README, command, or script
+  exists before documenting it as current.
+- Prefer targeted edits over broad rewrites. Do not reformat generated, archived, or unrelated
+  Codex assets.
+- For multi-lane AI work, route coordination and handoff format through
+  `docs/ai/agent-handoff-checklist.md`; select a mode from `docs/ai/work-modes.md`; and initialize
+  `docs/ai/parallel-task-manifest-template.md` before concurrent lane execution.
+
+## Codex Configuration Rules
+
+- `.codex/config.toml` is the repository-local default configuration. Keep it conservative and
+  fail-closed; do not set unattended full-access defaults there.
+- Prefer top-level Codex configuration keys that are documented by the current Codex configuration
+  reference. Avoid experimental keys unless the file comment labels them as provisional.
+- Keep `sandbox_mode = "workspace-write"` and `approval_policy = "on-request"` as the default
+  baseline unless the user explicitly asks for a different repository policy.
+- Do not store credentials, tokens, endpoint secrets, user-specific machine paths, or personal model
+  preferences in repository-local config.
+- If an operator needs broader access, document it as a user-profile override rather than changing
+  shared repository defaults.
+- When changing TOML, parse it with Python `tomllib` or another TOML parser before committing.
+
+## Skill, Agent, And Prompt Maintenance
+
+- Use existing Meridian skills before adding new ones; add a new skill only when the workflow is
+  reusable, distinct, and too detailed for a prompt or checklist.
+- Keep skill descriptions trigger-oriented and short enough for reliable selection.
+- Put shared project facts in `.codex/skills/_shared/project-context.md` instead of duplicating them
+  across multiple skills or agents.
+- Keep execution rules in `.codex/skills/_shared/codex-execution-contract.md` when they apply to
+  most Codex skills.
+- Keep `.codex/agents/*.toml` aligned with their matching `.codex/skills/*/SKILL.md` when an agent
+  is a thin specialization of a skill.
+- Use lowercase `.codex/` paths in new guidance and links unless citing legacy text verbatim.
+- Do not add a prompt, checklist, or agent without a discoverability path in `.codex/skills/README.md`
+  or the appropriate docs/AI index when the asset is meant for broad reuse.
+
+## Desktop Implementation Routing
+
+Use these Codex-local skills before making desktop or workstation implementation changes from a
+`.codex/**` prompt or checklist:
+
+- `modular-desktop-mvvm` for new or changed WPF view/view-model/service implementation.
+- `workstation-screen-composition` before adding a new workspace or large screen.
+- `shared-component-extraction` when repeated UI or view-model patterns appear.
+- `provider-management-workflow` for provider setup, credentials, health, degradation, or validation
+  workflows.
+- `research-data-acquisition` for research ingestion, symbol discovery, backfill, import, or dataset
+  preparation workflows.
+- `dense-data-grid-inspector-panel` for dense tables, grid selection, details, and inspector panels.
+- `diagnostics-audit-timeline` for diagnostics, timeline, evidence, or audit surfaces.
+- `performance-resource-review` before finalizing broad UI, provider, data, or workflow changes.
+- `safe-refactoring` for behavior-preserving consolidation or cleanup.
+- `desktop-test-generation` when adding or repairing WPF tests.
+
+## Implementation Guardrails
 
 - Prefer reusable modules over screen-specific implementations.
 - Use MVVM consistently: views declare UI, view models own presentation state, services own workflow
@@ -20,21 +84,18 @@ Select a mode from `docs/ai/work-modes.md` before implementation and initialize
 - Avoid large risky rewrites. Prefer incremental changes with narrow tests and a rollback path.
 - Add or update tests for every meaningful view model, command, service, mapping, or workflow change.
 - Avoid unnecessary package dependencies and one-off framework choices.
-- Document assumptions and tradeoffs in the final response or the nearest design doc when they
-  affect architecture, performance, resource use, or operator workflow.
+- Document assumptions and tradeoffs in the final response or nearest design doc when they affect
+  architecture, performance, resource use, or operator workflow.
 
-## Internal Design Questions
+## Internal Review Questions
 
-Before editing, answer these internally:
+Before editing implementation guidance, prompts, or checklists, answer these internally:
 
-1. Can this be a shared component?
-2. Can this be a shared view model?
-3. Can this be a shared command?
-4. Can this reuse an existing service?
-5. Can this be tested without the UI?
-6. Can this scale to large data?
-7. Can this avoid unnecessary memory or CPU use?
-8. Can this be safely refactored later?
+1. Can this be a shared component, view model, command, or service?
+2. Can this be tested without the UI?
+3. Can this scale to large data without unnecessary memory or CPU use?
+4. Can this remain behavior-preserving unless the user explicitly asks for behavior change?
+5. Can this be safely refactored or rolled back later?
 
 ## Resource Guardrails
 
@@ -51,25 +112,9 @@ Before editing, answer these internally:
 - Lifecycle: dispose closeable view models, stop subscriptions when panels close, release provider
   connections, clean temporary research datasets, and define cache retention policies.
 
-## Required Skill Routing
-
-- Use `modular-desktop-mvvm` for new or changed WPF view/view-model/service implementation.
-- Use `workstation-screen-composition` before adding a new workspace or large screen.
-- Use `shared-component-extraction` when repeated UI or view-model patterns appear.
-- Use `provider-management-workflow` for provider setup, credentials, health, degradation, or
-  validation workflows.
-- Use `research-data-acquisition` for research ingestion, symbol discovery, backfill, import, or
-  dataset-preparation workflows.
-- Use `dense-data-grid-inspector-panel` for dense tables, grid selection, details, and inspector
-  panels.
-- Use `diagnostics-audit-timeline` for diagnostics, timeline, evidence, or audit surfaces.
-- Use `performance-resource-review` before finalizing broad UI, provider, data, or workflow changes.
-- Use `safe-refactoring` for behavior-preserving consolidation or cleanup.
-- Use `desktop-test-generation` when adding or repairing WPF tests.
-
 ## Local Quality Scripts
 
-Run focused scripts from the repository root:
+Run focused scripts from the repository root when they cover the changed surface:
 
 ```powershell
 pwsh ./tools/codex/run-codex-quality-suite.ps1 -Fast -MarkdownPath artifacts/codex/codex-quality-suite.fast.md
@@ -80,3 +125,13 @@ pwsh ./tools/codex/resource-review.ps1
 ```
 
 Generator scripts are dry-run by default. Use `-Apply` only after reviewing the planned output.
+
+## Validation Expectations
+
+- Markdown-only Codex guidance edits: run `git diff --check -- <changed-files>`.
+- TOML edits: run a TOML parser over each changed `.toml` file.
+- Skill, agent, prompt, or AI workflow edits: also run the AI tooling gates from
+  `.codex/skills/_shared/codex-execution-contract.md` when available, or report exactly why they
+  were not run.
+- Command guidance edits: verify the referenced script, Make target, project, or `--help` output
+  before describing the command as current.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,22 @@
 # Repository-local Codex defaults must fail closed. Individual operators can
 # override these settings in their user profile when a task genuinely needs
-# broader filesystem access or unattended execution.
+# broader filesystem access, unattended execution, or personal model choices.
+
+# Keep filesystem and approval posture conservative for shared project config.
+# Documented Codex values include: read-only, workspace-write, danger-full-access.
 sandbox_mode = "workspace-write"
 
+# Keep command escalation interactive by default. Operators who need automation
+# should override this in their own Codex home, not in repository-local config.
 approval_policy = "on-request"
+
+# Allow the root AGENTS.md plus the narrower .codex/AGENTS.md guidance to fit
+# comfortably while still limiting accidental instruction bloat.
+project_doc_max_bytes = 65536
+
+# Allow legacy agent shims to remain discoverable when a directory lacks
+# AGENTS.md / AGENTS.override.md. Prefer AGENTS.md for new directory-scoped rules.
+project_doc_fallback_filenames = ["CLAUDE.md"]
+
+# Project-local config should stay free of secrets and machine-specific values.
+# Do not add API keys, tokens, user-only paths, or personal model preferences here.


### PR DESCRIPTION
### Motivation

- Provide clearer, repository-scoped guidance for Codex work under `.codex/` so agent-driven edits and prompts follow conservative, discoverable rules. 
- Ensure repository-local Codex configuration defaults are fail-closed and document safe override patterns to avoid accidental escalation of filesystem or automation privileges.

### Description

- Expanded `.codex/AGENTS.md` into a scoped “Codex Workspace Instructions” document that adds a `Start Gate`, explicit `Codex Configuration Rules`, skill/agent/prompt maintenance guidance, desktop implementation routing, internal review questions, resource guardrails, local quality scripts, and validation expectations. 
- Added routing and coordination notes for multi-lane AI work referencing `docs/ai/agent-handoff-checklist.md`, `docs/ai/work-modes.md`, and `docs/ai/parallel-task-manifest-template.md`. 
- Updated `.codex/config.toml` to document conservative defaults and keep `sandbox_mode = "workspace-write"` and `approval_policy = "on-request"`, and to add `project_doc_max_bytes` and `project_doc_fallback_filenames` guidance. 
- Kept guidance conservative about secrets, machine-specific values, and where operators should place user-level overrides instead of changing repo-local config.

### Testing

- Parsed the updated TOML with Python `tomllib` via `python3` and the file parsed successfully. 
- Ran `git diff --check -- .codex/AGENTS.md .codex/config.toml` and lint/check returned clean for the changed files. 
- Ran the AI contract drift check with `python3 build/scripts/docs/check-ai-contract-drift.py --canonical docs/ai/contract-policy.json --mirror docs/ai/copilot/contract-policy.mirror.json --mirror docs/ai/claude/contract-policy.mirror.json --routing-rules docs/ai/codex/prompt-route-rules.json --routing-host-doc docs/ai/codex/README.md --routing-host-doc docs/ai/assistant-workflow-contract.md` which passed. 
- Attempted `make ai-verify` but it was blocked because `dotnet` is not installed in `PATH` in this environment, and `make ai-arch-check` ran but failed due to pre-existing repository architecture findings unrelated to these docs/config changes (reported as 78 critical and 522 warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a274f6713148320834065b58da39e7b)