### PR TITLE
Expand financing and capital structure capability scope

### DIFF
--- a/docs/product/meridian-design-document.md
+++ b/docs/product/meridian-design-document.md
@@ -686,8 +686,19 @@ Evaluate Opportunity
 * Mezzanine debt
 * Margin facilities
 * Mortgage analysis
+* Synthetic financing analysis
+* Total return swaps and contract-for-difference financing
+* Repo and reverse repo financing
+* Securities lending and stock borrow financing
+* Derivatives-based leverage and financing overlays
+* Preferred equity, convertible instruments, and payment-in-kind structures
+* Subscription lines, NAV facilities, and capital-call facilities
+* Asset-backed lending, receivables financing, and factoring
+* Sale-leaseback and lease financing
+* Securitization and collateralized financing structures
+* Intercompany loans and sponsor support arrangements
 * Capital stack modeling
-* Senior / junior / mezzanine / equity layers
+* Senior / junior / mezzanine / preferred equity / common equity layers
 * Refinancing analysis
 * Debt service coverage
 * Interest coverage
@@ -695,6 +706,9 @@ Evaluate Opportunity
 * DSCR analysis
 * Covenant tracking
 * Borrowing base analysis
+* Collateral, haircut, margin, and eligibility analysis
+* Financing cost attribution and effective leverage monitoring
+* Counterparty exposure and rehypothecation tracking
 
 ---
 
@@ -1002,7 +1016,7 @@ Functional domains describe business capabilities. Bounded contexts define owner
 | Financial Operations              | Reconciliations, breaks, exceptions, operational reviews, adjustments, close checklists, evidence packages             |
 | Treasury & Payments               | Bank accounts, cash balances, payment requests, ACH, wires, capital calls, distributions, payment approvals            |
 | Alternative Assets                | Real estate, private credit, private equity, structured assets, valuation inputs, asset-level cash flows               |
-| Financing & Capital Structure     | Debt facilities, loan agreements, capital stacks, covenants, debt schedules, leverage analysis                         |
+| Financing & Capital Structure     | Debt facilities, synthetic financing, loan agreements, capital stacks, covenants, collateral terms, debt schedules, leverage analysis |
 | Planning & Forecasting            | Forecast models, scenarios, assumptions, stress tests, planning cases, decision records                                |
 | Research & Analytics              | Research notes, watchlists, investment theses, backtests, strategy runs, analytical workspaces                         |
 | Risk Management                   | Risk rules, metrics, limits, exposure calculations, concentration checks, breaches                                     |

--- a/docs/product/meridian-design-document.md
+++ b/docs/product/meridian-design-document.md
@@ -687,7 +687,7 @@ Evaluate Opportunity
 * Margin facilities
 * Mortgage analysis
 * Synthetic financing analysis
-* Total return swaps and contract-for-difference financing
+* Total return swap and contract-for-difference financing
 * Repo and reverse repo financing
 * Securities lending and stock borrow financing
 * Derivatives-based leverage and financing overlays


### PR DESCRIPTION
### Motivation

- Broaden the Financing & Capital Structure capability set to cover synthetic and other advanced financing instruments and monitoring needs missing from the existing design document. 
- Capture product intent to support additional financing patterns used in capital-structure analysis and risk/operational monitoring.

### Description

- Expanded the `Capabilities` list in `docs/product/meridian-design-document.md` to include synthetic financing, TRS/CFD financing, repo/reverse-repo, securities lending, derivatives-based leverage overlays, preferred/convertible/PIK instruments, subscription/NAV/capital-call facilities, asset-backed and lease financing, securitization, intercompany/sponsor support, and additional collateral/haircut/margin/cost and counterparty monitoring items. 
- Updated the bounded-context map entry for `Financing & Capital Structure` in `docs/product/meridian-design-document.md` to mention synthetic financing and collateral terms explicitly. 
- Change is limited to the product design document and is strictly documentation-level scope.

### Testing

- Ran the docs validation check `git diff --check -- docs/product/meridian-design-document.md`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2752af734c8320a9df8e098114e972)