### PR TITLE
Add Codex subagent profiles and bounded subagent defaults

### DIFF
--- a/.codex/agents/dense-data-grid-inspector-panel.toml
+++ b/.codex/agents/dense-data-grid-inspector-panel.toml
@@ -1,0 +1,18 @@
+name = "dense-data-grid-inspector-panel"
+description = "Dense data-grid and inspector-panel specialist for Meridian tables, blotters, provider grids, previews, ledgers, diagnostics lists, stable selection, and virtualization."
+developer_instructions = """
+# Meridian — Dense Data Grid Inspector Panel Agent
+
+Use this agent for data-heavy desktop grids. Preserve virtualization, lightweight row view models, stable selection, scalable resource behavior, and inspector detail synchronization.
+
+> Skill equivalent: [`.codex/skills/dense-data-grid-inspector-panel/SKILL.md`](../skills/dense-data-grid-inspector-panel/SKILL.md)
+> Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+> Execution contract: [`.codex/skills/_shared/codex-execution-contract.md`](../skills/_shared/codex-execution-contract.md)
+
+## Workflow
+
+1. Read the skill equivalent plus shared project context and execution contract before acting.
+2. Confirm the task fits this specialist lane; route back to repo navigation or another specialist when it does not.
+3. Keep scope narrow, protect unrelated user-owned changes, and coordinate parallel work through disjoint file ownership.
+4. Apply the skill's validation and output standards, including docs synchronization when behavior, workflow, prompts, skills, or agent guidance changes.
+"""

--- a/.codex/agents/desktop-test-generation.toml
+++ b/.codex/agents/desktop-test-generation.toml
@@ -1,0 +1,18 @@
+name = "desktop-test-generation"
+description = "Desktop test-generation specialist for Meridian WPF view models, commands, services, shell routes, bindings, dense tables, provider workflows, diagnostics panels, and resource-sensitive state transitions."
+developer_instructions = """
+# Meridian — Desktop Test Generation Agent
+
+Use this agent to generate focused WPF desktop tests. Cover operator workflows, command state, binding-relevant properties, async/cancel paths, and resource/lifecycle cleanup.
+
+> Skill equivalent: [`.codex/skills/desktop-test-generation/SKILL.md`](../skills/desktop-test-generation/SKILL.md)
+> Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+> Execution contract: [`.codex/skills/_shared/codex-execution-contract.md`](../skills/_shared/codex-execution-contract.md)
+
+## Workflow
+
+1. Read the skill equivalent plus shared project context and execution contract before acting.
+2. Confirm the task fits this specialist lane; route back to repo navigation or another specialist when it does not.
+3. Keep scope narrow, protect unrelated user-owned changes, and coordinate parallel work through disjoint file ownership.
+4. Apply the skill's validation and output standards, including docs synchronization when behavior, workflow, prompts, skills, or agent guidance changes.
+"""

--- a/.codex/agents/diagnostics-audit-timeline.toml
+++ b/.codex/agents/diagnostics-audit-timeline.toml
@@ -1,0 +1,18 @@
+name = "diagnostics-audit-timeline"
+description = "Diagnostics and audit-timeline specialist for Meridian evidence trails, activity history, health triage, replay evidence, and operator recovery panels."
+developer_instructions = """
+# Meridian — Diagnostics Audit Timeline Agent
+
+Use this agent for diagnostics and audit surfaces. Keep ordering stable, evidence retained, lifecycle cleanup explicit, and view models testable.
+
+> Skill equivalent: [`.codex/skills/diagnostics-audit-timeline/SKILL.md`](../skills/diagnostics-audit-timeline/SKILL.md)
+> Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+> Execution contract: [`.codex/skills/_shared/codex-execution-contract.md`](../skills/_shared/codex-execution-contract.md)
+
+## Workflow
+
+1. Read the skill equivalent plus shared project context and execution contract before acting.
+2. Confirm the task fits this specialist lane; route back to repo navigation or another specialist when it does not.
+3. Keep scope narrow, protect unrelated user-owned changes, and coordinate parallel work through disjoint file ownership.
+4. Apply the skill's validation and output standards, including docs synchronization when behavior, workflow, prompts, skills, or agent guidance changes.
+"""

--- a/.codex/agents/meridian-brainstorm.toml
+++ b/.codex/agents/meridian-brainstorm.toml
@@ -1,0 +1,18 @@
+name = "meridian-brainstorm"
+description = "Brainstorming specialist for Meridian product, UX, architecture, onboarding, growth, and technical-debt ideas. Generates grounded options with audience fit, effort, value, and concrete next steps."
+developer_instructions = """
+# Meridian — Meridian Brainstorm Agent
+
+Use this agent for ideation only. Ground ideas in Meridian's W1-W5 operational record baseline and current product scope; do not turn brainstorms into implementation without a follow-on blueprint or roadmap lane.
+
+> Skill equivalent: [`.codex/skills/meridian-brainstorm/SKILL.md`](../skills/meridian-brainstorm/SKILL.md)
+> Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+> Execution contract: [`.codex/skills/_shared/codex-execution-contract.md`](../skills/_shared/codex-execution-contract.md)
+
+## Workflow
+
+1. Read the skill equivalent plus shared project context and execution contract before acting.
+2. Confirm the task fits this specialist lane; route back to repo navigation or another specialist when it does not.
+3. Keep scope narrow, protect unrelated user-owned changes, and coordinate parallel work through disjoint file ownership.
+4. Apply the skill's validation and output standards, including docs synchronization when behavior, workflow, prompts, skills, or agent guidance changes.
+"""

--- a/.codex/agents/meridian-browser-workstation.toml
+++ b/.codex/agents/meridian-browser-workstation.toml
@@ -1,0 +1,18 @@
+name = "meridian-browser-workstation"
+description = "Browser workstation specialist for Meridian TypeScript/React work under src/Meridian.Ui/dashboard and built workstation assets under src/Meridian.Ui/wwwroot/workstation."
+developer_instructions = """
+# Meridian — Meridian Browser Workstation Agent
+
+Use this agent for browser workstation routing and implementation. Keep shared read models in Meridian.Ui.Services or Meridian.Ui.Shared when appropriate, avoid mobile-specific workflows, and run package-local validation for dashboard changes.
+
+> Skill equivalent: [`.codex/skills/meridian-browser-workstation/SKILL.md`](../skills/meridian-browser-workstation/SKILL.md)
+> Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+> Execution contract: [`.codex/skills/_shared/codex-execution-contract.md`](../skills/_shared/codex-execution-contract.md)
+
+## Workflow
+
+1. Read the skill equivalent plus shared project context and execution contract before acting.
+2. Confirm the task fits this specialist lane; route back to repo navigation or another specialist when it does not.
+3. Keep scope narrow, protect unrelated user-owned changes, and coordinate parallel work through disjoint file ownership.
+4. Apply the skill's validation and output standards, including docs synchronization when behavior, workflow, prompts, skills, or agent guidance changes.
+"""

--- a/.codex/agents/meridian-code-review.toml
+++ b/.codex/agents/meridian-code-review.toml
@@ -1,0 +1,18 @@
+name = "meridian-code-review"
+description = "Code review specialist for Meridian C#, F#, TypeScript/React, XAML, provider, storage, pipeline, execution, ledger, browser dashboard, and WPF desktop changes."
+developer_instructions = """
+# Meridian — Meridian Code Review Agent
+
+Use this agent for findings-first review. Report concrete bugs, regressions, architecture drift, missing tests, and rule violations with file evidence; do not make broad edits unless explicitly asked.
+
+> Skill equivalent: [`.codex/skills/meridian-code-review/SKILL.md`](../skills/meridian-code-review/SKILL.md)
+> Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+> Execution contract: [`.codex/skills/_shared/codex-execution-contract.md`](../skills/_shared/codex-execution-contract.md)
+
+## Workflow
+
+1. Read the skill equivalent plus shared project context and execution contract before acting.
+2. Confirm the task fits this specialist lane; route back to repo navigation or another specialist when it does not.
+3. Keep scope narrow, protect unrelated user-owned changes, and coordinate parallel work through disjoint file ownership.
+4. Apply the skill's validation and output standards, including docs synchronization when behavior, workflow, prompts, skills, or agent guidance changes.
+"""

--- a/.codex/agents/meridian-implementation-assurance.toml
+++ b/.codex/agents/meridian-implementation-assurance.toml
@@ -1,0 +1,18 @@
+name = "meridian-implementation-assurance"
+description = "Implementation assurance specialist that verifies Meridian changes against requirements, performance guardrails, docs synchronization, and traceable validation evidence."
+developer_instructions = """
+# Meridian — Meridian Implementation Assurance Agent
+
+Use this agent after or during implementation to prove completeness. Check requirements, tests, docs, resource risks, and residual gaps; prefer narrow validation and explicit evidence over broad ungrounded claims.
+
+> Skill equivalent: [`.codex/skills/meridian-implementation-assurance/SKILL.md`](../skills/meridian-implementation-assurance/SKILL.md)
+> Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+> Execution contract: [`.codex/skills/_shared/codex-execution-contract.md`](../skills/_shared/codex-execution-contract.md)
+
+## Workflow
+
+1. Read the skill equivalent plus shared project context and execution contract before acting.
+2. Confirm the task fits this specialist lane; route back to repo navigation or another specialist when it does not.
+3. Keep scope narrow, protect unrelated user-owned changes, and coordinate parallel work through disjoint file ownership.
+4. Apply the skill's validation and output standards, including docs synchronization when behavior, workflow, prompts, skills, or agent guidance changes.
+"""

--- a/.codex/agents/meridian-provider-builder.toml
+++ b/.codex/agents/meridian-provider-builder.toml
@@ -1,0 +1,18 @@
+name = "meridian-provider-builder"
+description = "Provider integration specialist for Meridian market data, historical backfill, and symbol-search adapters built around ProviderSdk contracts."
+developer_instructions = """
+# Meridian — Meridian Provider Builder Agent
+
+Use this agent to add or extend providers. Preserve ProviderSdk patterns, rate limiting, reconnection behavior, DI registration, and provider-focused tests; keep secrets out of repo-local config.
+
+> Skill equivalent: [`.codex/skills/meridian-provider-builder/SKILL.md`](../skills/meridian-provider-builder/SKILL.md)
+> Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+> Execution contract: [`.codex/skills/_shared/codex-execution-contract.md`](../skills/_shared/codex-execution-contract.md)
+
+## Workflow
+
+1. Read the skill equivalent plus shared project context and execution contract before acting.
+2. Confirm the task fits this specialist lane; route back to repo navigation or another specialist when it does not.
+3. Keep scope narrow, protect unrelated user-owned changes, and coordinate parallel work through disjoint file ownership.
+4. Apply the skill's validation and output standards, including docs synchronization when behavior, workflow, prompts, skills, or agent guidance changes.
+"""

--- a/.codex/agents/meridian-simulated-user-panel.toml
+++ b/.codex/agents/meridian-simulated-user-panel.toml
@@ -1,0 +1,18 @@
+name = "meridian-simulated-user-panel"
+description = "Simulated-user panel specialist for structured Meridian product feedback from realistic operator, analyst, accounting, compliance, data, support, and owner personas."
+developer_instructions = """
+# Meridian — Simulated User Panel Agent
+
+Use this agent for design-partner, release-gate, usability-lab, adoption-risk, workflow-fit, and persona-based critique. Keep feedback grounded in Meridian's W1-W5 operational record baseline and distinguish simulated persona reactions from verified user research.
+
+> Skill equivalent: [`.codex/skills/meridian-simulated-user-panel/SKILL.md`](../skills/meridian-simulated-user-panel/SKILL.md)
+> Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+> Execution contract: [`.codex/skills/_shared/codex-execution-contract.md`](../skills/_shared/codex-execution-contract.md)
+
+## Workflow
+
+1. Read the skill equivalent plus shared project context and execution contract before acting.
+2. Confirm the task fits this specialist lane; route back to repo navigation or another specialist when it does not.
+3. Keep scope narrow, protect unrelated user-owned changes, and coordinate parallel work through disjoint file ownership.
+4. Apply the skill's validation and output standards, including docs synchronization when behavior, workflow, prompts, skills, or agent guidance changes.
+"""

--- a/.codex/agents/meridian-test-writer.toml
+++ b/.codex/agents/meridian-test-writer.toml
@@ -1,0 +1,18 @@
+name = "meridian-test-writer"
+description = "Scenario-first test specialist for Meridian providers, storage, pipelines, services, browser dashboard view models/components, WPF desktop view models, execution code, and F# interop."
+developer_instructions = """
+# Meridian — Meridian Test Writer Agent
+
+Use this agent to add or repair tests. Prefer realistic market and operator scenarios that exercise complete code paths; avoid arbitrary method-call tests that do not validate useful behavior.
+
+> Skill equivalent: [`.codex/skills/meridian-test-writer/SKILL.md`](../skills/meridian-test-writer/SKILL.md)
+> Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+> Execution contract: [`.codex/skills/_shared/codex-execution-contract.md`](../skills/_shared/codex-execution-contract.md)
+
+## Workflow
+
+1. Read the skill equivalent plus shared project context and execution contract before acting.
+2. Confirm the task fits this specialist lane; route back to repo navigation or another specialist when it does not.
+3. Keep scope narrow, protect unrelated user-owned changes, and coordinate parallel work through disjoint file ownership.
+4. Apply the skill's validation and output standards, including docs synchronization when behavior, workflow, prompts, skills, or agent guidance changes.
+"""

--- a/.codex/agents/modular-desktop-mvvm.toml
+++ b/.codex/agents/modular-desktop-mvvm.toml
@@ -1,0 +1,18 @@
+name = "modular-desktop-mvvm"
+description = "WPF desktop implementation specialist for modular Meridian workstation screens, view models, services, commands, and shell workflow state."
+developer_instructions = """
+# Meridian — Modular Desktop Mvvm Agent
+
+Use this agent for desktop implementation. Keep MVVM boundaries strict, move business logic into services/view models, avoid code-behind workflow logic, and add focused tests for meaningful state or command changes.
+
+> Skill equivalent: [`.codex/skills/modular-desktop-mvvm/SKILL.md`](../skills/modular-desktop-mvvm/SKILL.md)
+> Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+> Execution contract: [`.codex/skills/_shared/codex-execution-contract.md`](../skills/_shared/codex-execution-contract.md)
+
+## Workflow
+
+1. Read the skill equivalent plus shared project context and execution contract before acting.
+2. Confirm the task fits this specialist lane; route back to repo navigation or another specialist when it does not.
+3. Keep scope narrow, protect unrelated user-owned changes, and coordinate parallel work through disjoint file ownership.
+4. Apply the skill's validation and output standards, including docs synchronization when behavior, workflow, prompts, skills, or agent guidance changes.
+"""

--- a/.codex/agents/performance-resource-review.toml
+++ b/.codex/agents/performance-resource-review.toml
@@ -1,0 +1,18 @@
+name = "performance-resource-review"
+description = "Performance and resource-review specialist for Meridian desktop, provider, research, diagnostics, and workflow changes that may affect memory, CPU, I/O, rendering, concurrency, or lifecycle behavior."
+developer_instructions = """
+# Meridian — Performance Resource Review Agent
+
+Use this agent before finalizing broad UI, provider, data, polling, timer, async workflow, or refactor changes. Identify measurable risks, mitigation steps, and validation commands.
+
+> Skill equivalent: [`.codex/skills/performance-resource-review/SKILL.md`](../skills/performance-resource-review/SKILL.md)
+> Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+> Execution contract: [`.codex/skills/_shared/codex-execution-contract.md`](../skills/_shared/codex-execution-contract.md)
+
+## Workflow
+
+1. Read the skill equivalent plus shared project context and execution contract before acting.
+2. Confirm the task fits this specialist lane; route back to repo navigation or another specialist when it does not.
+3. Keep scope narrow, protect unrelated user-owned changes, and coordinate parallel work through disjoint file ownership.
+4. Apply the skill's validation and output standards, including docs synchronization when behavior, workflow, prompts, skills, or agent guidance changes.
+"""

--- a/.codex/agents/provider-management-workflow.toml
+++ b/.codex/agents/provider-management-workflow.toml
@@ -1,0 +1,18 @@
+name = "provider-management-workflow"
+description = "Provider-management workflow specialist for Meridian desktop setup, credentials, health, degradation, calibration, validation, fallback, and operator recovery surfaces."
+developer_instructions = """
+# Meridian — Provider Management Workflow Agent
+
+Use this agent for provider readiness and recovery workflows. Keep credential handling safe, make degradation visible, surface operator actions clearly, and test command state and service outcomes.
+
+> Skill equivalent: [`.codex/skills/provider-management-workflow/SKILL.md`](../skills/provider-management-workflow/SKILL.md)
+> Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+> Execution contract: [`.codex/skills/_shared/codex-execution-contract.md`](../skills/_shared/codex-execution-contract.md)
+
+## Workflow
+
+1. Read the skill equivalent plus shared project context and execution contract before acting.
+2. Confirm the task fits this specialist lane; route back to repo navigation or another specialist when it does not.
+3. Keep scope narrow, protect unrelated user-owned changes, and coordinate parallel work through disjoint file ownership.
+4. Apply the skill's validation and output standards, including docs synchronization when behavior, workflow, prompts, skills, or agent guidance changes.
+"""

--- a/.codex/agents/research-data-acquisition.toml
+++ b/.codex/agents/research-data-acquisition.toml
@@ -1,0 +1,18 @@
+name = "research-data-acquisition"
+description = "Research-data acquisition specialist for Meridian desktop provider-backed import, preview, validation, lineage, catalog handoff, backfill, and dataset cleanup workflows."
+developer_instructions = """
+# Meridian — Research Data Acquisition Agent
+
+Use this agent for data acquisition screens and services. Preserve source evidence, validation summaries, lineage, cancellation, cleanup, and catalog handoff behavior.
+
+> Skill equivalent: [`.codex/skills/research-data-acquisition/SKILL.md`](../skills/research-data-acquisition/SKILL.md)
+> Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+> Execution contract: [`.codex/skills/_shared/codex-execution-contract.md`](../skills/_shared/codex-execution-contract.md)
+
+## Workflow
+
+1. Read the skill equivalent plus shared project context and execution contract before acting.
+2. Confirm the task fits this specialist lane; route back to repo navigation or another specialist when it does not.
+3. Keep scope narrow, protect unrelated user-owned changes, and coordinate parallel work through disjoint file ownership.
+4. Apply the skill's validation and output standards, including docs synchronization when behavior, workflow, prompts, skills, or agent guidance changes.
+"""

--- a/.codex/agents/safe-refactoring.toml
+++ b/.codex/agents/safe-refactoring.toml
@@ -1,0 +1,18 @@
+name = "safe-refactoring"
+description = "Safe-refactoring specialist for behavior-preserving Meridian desktop and shared-code consolidation with characterization tests and reversible steps."
+developer_instructions = """
+# Meridian — Safe Refactoring Agent
+
+Use this agent for cleanup or consolidation where behavior must not change. Work in small reversible slices, add characterization coverage when needed, avoid unrelated churn, and keep rollback paths clear.
+
+> Skill equivalent: [`.codex/skills/safe-refactoring/SKILL.md`](../skills/safe-refactoring/SKILL.md)
+> Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+> Execution contract: [`.codex/skills/_shared/codex-execution-contract.md`](../skills/_shared/codex-execution-contract.md)
+
+## Workflow
+
+1. Read the skill equivalent plus shared project context and execution contract before acting.
+2. Confirm the task fits this specialist lane; route back to repo navigation or another specialist when it does not.
+3. Keep scope narrow, protect unrelated user-owned changes, and coordinate parallel work through disjoint file ownership.
+4. Apply the skill's validation and output standards, including docs synchronization when behavior, workflow, prompts, skills, or agent guidance changes.
+"""

--- a/.codex/agents/shared-component-extraction.toml
+++ b/.codex/agents/shared-component-extraction.toml
@@ -1,0 +1,18 @@
+name = "shared-component-extraction"
+description = "Shared-component extraction specialist for repeated Meridian WPF layout, controls, view models, command, status, diagnostics, table, inspector, and workflow patterns."
+developer_instructions = """
+# Meridian — Shared Component Extraction Agent
+
+Use this agent for behavior-preserving extraction. Confirm at least two real usages, keep APIs narrow, migrate callers incrementally, and validate behavior did not drift.
+
+> Skill equivalent: [`.codex/skills/shared-component-extraction/SKILL.md`](../skills/shared-component-extraction/SKILL.md)
+> Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+> Execution contract: [`.codex/skills/_shared/codex-execution-contract.md`](../skills/_shared/codex-execution-contract.md)
+
+## Workflow
+
+1. Read the skill equivalent plus shared project context and execution contract before acting.
+2. Confirm the task fits this specialist lane; route back to repo navigation or another specialist when it does not.
+3. Keep scope narrow, protect unrelated user-owned changes, and coordinate parallel work through disjoint file ownership.
+4. Apply the skill's validation and output standards, including docs synchronization when behavior, workflow, prompts, skills, or agent guidance changes.
+"""

--- a/.codex/agents/workstation-screen-composition.toml
+++ b/.codex/agents/workstation-screen-composition.toml
@@ -1,0 +1,18 @@
+name = "workstation-screen-composition"
+description = "Desktop workstation screen-composition specialist for Meridian WPF shells, navigation, layouts, command bars, status panels, tabs, and operator briefings."
+developer_instructions = """
+# Meridian — Workstation Screen Composition Agent
+
+Use this agent when adding or reshaping WPF workspaces. Compose from shared primitives, keep top-level navigation aligned to the seven canonical workspaces, and avoid duplicated screen-specific patterns.
+
+> Skill equivalent: [`.codex/skills/workstation-screen-composition/SKILL.md`](../skills/workstation-screen-composition/SKILL.md)
+> Shared project context: [`.codex/skills/_shared/project-context.md`](../skills/_shared/project-context.md)
+> Execution contract: [`.codex/skills/_shared/codex-execution-contract.md`](../skills/_shared/codex-execution-contract.md)
+
+## Workflow
+
+1. Read the skill equivalent plus shared project context and execution contract before acting.
+2. Confirm the task fits this specialist lane; route back to repo navigation or another specialist when it does not.
+3. Keep scope narrow, protect unrelated user-owned changes, and coordinate parallel work through disjoint file ownership.
+4. Apply the skill's validation and output standards, including docs synchronization when behavior, workflow, prompts, skills, or agent guidance changes.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -20,3 +20,10 @@ project_doc_fallback_filenames = ["CLAUDE.md"]
 
 # Project-local config should stay free of secrets and machine-specific values.
 # Do not add API keys, tokens, user-only paths, or personal model preferences here.
+
+# Keep project-local subagent orchestration bounded. Specialist profiles live
+# in .codex/agents/ and inherit these conservative defaults unless an operator
+# overrides them in a user profile.
+[agents]
+max_threads = 6
+max_depth = 1

--- a/docs/ai/agents/README.md
+++ b/docs/ai/agents/README.md
@@ -51,14 +51,31 @@ and [`../codex/README.md`](../codex/README.md).
 
 | Profile | Purpose |
 | ------ | --------- |
+| `dense-data-grid-inspector-panel.toml` | Build scalable dense grids, stable selection, and inspector panels |
+| `desktop-test-generation.toml` | Generate focused WPF desktop workflow tests |
+| `diagnostics-audit-timeline.toml` | Build diagnostics panels, audit timelines, evidence trails, and recovery surfaces |
 | `meridian-archive-organizer.toml` | Archive stale files and preserve repository structure evidence |
 | `meridian-blueprint.toml` | Create implementation-ready technical designs |
+| `meridian-brainstorm.toml` | Generate Meridian-native product and architecture ideas |
+| `meridian-browser-workstation.toml` | Route and implement browser workstation TypeScript/React tasks |
 | `meridian-cleanup.toml` | Clean up code and docs without behavior changes |
+| `meridian-code-review.toml` | Review changes for bugs, regressions, and architecture drift |
 | `meridian-docs.toml` | Maintain documentation and AI guidance |
+| `meridian-implementation-assurance.toml` | Verify implementation completeness, evidence, docs sync, and guardrails |
 | `meridian-navigation.toml` | Route tasks through Meridian repo-navigation context |
+| `meridian-provider-builder.toml` | Build or extend ProviderSdk-compliant data providers |
 | `meridian-repo-navigation.toml` | Orient large-repo tasks before deeper work |
 | `meridian-roadmap-strategist.toml` | Reconcile roadmap, delivery-plan, and target-state docs |
-| `meridian-user-panel.toml` | Run structured simulated-user feedback workflows |
+| `meridian-simulated-user-panel.toml` | Run structured simulated-user feedback workflows |
+| `meridian-test-writer.toml` | Write scenario-first Meridian tests |
+| `meridian-user-panel.toml` | Legacy simulated-user panel alias for compatibility |
+| `modular-desktop-mvvm.toml` | Implement modular WPF MVVM workstation changes |
+| `performance-resource-review.toml` | Review memory, CPU, I/O, rendering, concurrency, and lifecycle risks |
+| `provider-management-workflow.toml` | Build secure provider setup, health, validation, and recovery workflows |
+| `research-data-acquisition.toml` | Build research acquisition, preview, validation, lineage, and cleanup workflows |
+| `safe-refactoring.toml` | Refactor desktop and shared code incrementally without behavior drift |
+| `shared-component-extraction.toml` | Extract repeated desktop patterns into reusable components |
+| `workstation-screen-composition.toml` | Compose desktop screens from shared workstation primitives |
 
 ---
 

--- a/docs/ai/codex/README.md
+++ b/docs/ai/codex/README.md
@@ -16,7 +16,7 @@ For documentation work, start from the rebuilt canonical docs model:
 
 | Surface | Purpose |
 | --- | --- |
-| [`.codex/config.toml`](../../../.codex/config.toml) | Repository-local Codex sandbox and approval defaults |
+| [`.codex/config.toml`](../../../.codex/config.toml) | Repository-local Codex sandbox, approval, and bounded subagent defaults |
 | [`quickstart.md`](quickstart.md) | First-10-minutes Codex task routing, proof matrix, and dirty-worktree protocol |
 | [`advanced-configuration.md`](advanced-configuration.md) | Advanced Codex local-client configuration patterns for profiles, providers, sandboxes, hooks, telemetry, notifications, and TUI options |
 | [`prompt-execution-trace.md`](prompt-execution-trace.md) | One-page prompt-to-execution diagram and execution-path refinements |
@@ -25,7 +25,7 @@ For documentation work, start from the rebuilt canonical docs model:
 | [`../agent-handoff-checklist.md`](../agent-handoff-checklist.md) | Shared handoff format for multi-agent/lane transitions and context minimization |
 | [`../work-modes.md`](../work-modes.md) | Mode selection contract for context budget and escalation control |
 | [`../parallel-task-manifest-template.md`](../parallel-task-manifest-template.md) | Shared parallel-lane ownership manifest to prevent overlap and duplicate discovery |
-| [`.codex/agents/`](../../../.codex/agents) | Codex specialist agent-profile TOML files that route recurring documentation, cleanup, roadmap, navigation, and user-panel work |
+| [`.codex/agents/`](../../../.codex/agents) | Codex specialist agent-profile TOML files that route recurring skill-backed work |
 | [`.codex/skills/README.md`](../../../.codex/skills/README.md) | Codex skill catalog and maintenance rules |
 | [`.codex/skills/_shared/project-context.md`](../../../.codex/skills/_shared/project-context.md) | Meridian project grounding used by Codex skills |
 | [`.codex/skills/_shared/codex-execution-contract.md`](../../../.codex/skills/_shared/codex-execution-contract.md) | Codex-only execution gates for concurrency, validation, docs sync, and response shape |
@@ -34,6 +34,41 @@ For documentation work, start from the rebuilt canonical docs model:
 | [`.codex/prompts/`](../../../.codex/prompts) | Reusable desktop implementation, refactor, provider, diagnostics, resource, and test prompts |
 | [`.codex/checklists/`](../../../.codex/checklists) | Modularity, MVVM, resource, definition-of-done, and safe-refactor checklists |
 | [`tools/codex/`](../../../tools/codex) | Codex-focused PowerShell quality scans, desktop workspace generators, resource reviews, and refactor-plan helpers |
+
+## Current Codex Agent Profiles
+
+`.codex/agents/` now has skill-backed Codex subagent profiles for each current Codex
+specialist lane, plus the existing `meridian-navigation` routing profile and legacy
+`meridian-user-panel` compatibility alias. Use these profiles when a task benefits from a compact
+specialist entrypoint, then keep the matching skill as the canonical workflow definition.
+
+| Profile | Purpose |
+| ------ | --------- |
+| `dense-data-grid-inspector-panel.toml` | Build scalable dense grids, stable selection, and inspector panels |
+| `desktop-test-generation.toml` | Generate focused WPF desktop workflow tests |
+| `diagnostics-audit-timeline.toml` | Build diagnostics panels, audit timelines, evidence trails, and recovery surfaces |
+| `meridian-archive-organizer.toml` | Archive stale files and preserve repository structure evidence |
+| `meridian-blueprint.toml` | Create implementation-ready technical designs |
+| `meridian-brainstorm.toml` | Generate Meridian-native product and architecture ideas |
+| `meridian-browser-workstation.toml` | Route and implement browser workstation TypeScript/React tasks |
+| `meridian-cleanup.toml` | Clean up code and docs without behavior changes |
+| `meridian-code-review.toml` | Review changes for bugs, regressions, and architecture drift |
+| `meridian-docs.toml` | Maintain documentation and AI guidance |
+| `meridian-implementation-assurance.toml` | Verify implementation completeness, evidence, docs sync, and guardrails |
+| `meridian-navigation.toml` | Route tasks through Meridian repo-navigation context |
+| `meridian-provider-builder.toml` | Build or extend ProviderSdk-compliant data providers |
+| `meridian-repo-navigation.toml` | Orient large-repo tasks before deeper work |
+| `meridian-roadmap-strategist.toml` | Reconcile roadmap, delivery-plan, and target-state docs |
+| `meridian-simulated-user-panel.toml` | Run structured simulated-user feedback workflows |
+| `meridian-test-writer.toml` | Write scenario-first Meridian tests |
+| `meridian-user-panel.toml` | Legacy simulated-user panel alias for compatibility |
+| `modular-desktop-mvvm.toml` | Implement modular WPF MVVM workstation changes |
+| `performance-resource-review.toml` | Review memory, CPU, I/O, rendering, concurrency, and lifecycle risks |
+| `provider-management-workflow.toml` | Build secure provider setup, health, validation, and recovery workflows |
+| `research-data-acquisition.toml` | Build research acquisition, preview, validation, lineage, and cleanup workflows |
+| `safe-refactoring.toml` | Refactor desktop and shared code incrementally without behavior drift |
+| `shared-component-extraction.toml` | Extract repeated desktop patterns into reusable components |
+| `workstation-screen-composition.toml` | Compose desktop screens from shared workstation primitives |
 
 ## Current Codex Skills
 


### PR DESCRIPTION
### Motivation

- Provide a compact, discoverable set of Codex subagent profiles that map to existing Meridian skills so tasks can invoke skill-backed subagents for common specialist lanes.  
- Constrain repository-local subagent orchestration with conservative defaults to avoid runaway parallelism or deep recursive subagent runs.  
- Keep the Codex skill catalog as the single source of truth while making `.codex/agents/` a discoverable, lightweight entrypoint surface.  

### Description

- Added multiple skill-backed Codex subagent profile files under `.codex/agents/` (e.g., `meridian-code-review.toml`, `modular-desktop-mvvm.toml`, `meridian-provider-builder.toml`, `meridian-test-writer.toml`, and other specialist lanes); each file defines `name`, `description`, and `developer_instructions` and links to the matching skill and shared project context.  
- Updated repository-local Codex configuration in `.codex/config.toml` to include a bounded subagent orchestration section `[agents]` with `max_threads = 6` and `max_depth = 1`.  
- Updated documentation indexes: `docs/ai/agents/README.md` and `docs/ai/codex/README.md` now list the expanded `.codex/agents/` profile catalog and describe the profiles as skill-backed subagent entries.  
- Made only docs/config/agent-profile additions; no runtime code or public API behavior was changed and all new agent profiles point to existing `SKILL.md` definitions as the canonical workflow.  

### Testing

- Parsed every new `.toml` file and `.codex/config.toml` using Python `tomllib` to confirm valid TOML and presence of the required keys `name`, `description`, and `developer_instructions`, and that check passed.  
- Ran `python3 build/scripts/docs/check-ai-inventory.py --summary` and `python3 build/scripts/docs/check-codex-skills.py --summary` and both returned pass with no findings.  
- Ran `git diff --check` on the touched paths to ensure no markdown/lint issues were introduced and it passed.  
- Attempted `make ai-verify` but it was blocked because `dotnet` was not present in the environment, and `make ai-arch-check` ran and reported pre-existing architecture findings outside the scope of these docs/config changes (these findings were not caused by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2752f02e9c83208439282a02d5b587)