### PR TITLE
Update Codex project configuration and register local agent profiles

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -10,6 +10,15 @@ sandbox_mode = "workspace-write"
 # should override this in their own Codex home, not in repository-local config.
 approval_policy = "on-request"
 
+# Meridian work often depends on current external API/tooling behavior. Keep the
+# web-search surface live by default; operator-specific domain limits belong in
+# user-level profiles.
+web_search = "live"
+
+# Anchor project discovery on the Meridian solution first, then fall back to the
+# Git checkout marker when Codex searches parent directories for .codex folders.
+project_root_markers = ["Meridian.sln", ".git"]
+
 # Allow the root AGENTS.md plus the narrower .codex/AGENTS.md guidance to fit
 # comfortably while still limiting accidental instruction bloat.
 project_doc_max_bytes = 65536
@@ -19,7 +28,32 @@ project_doc_max_bytes = 65536
 project_doc_fallback_filenames = ["CLAUDE.md"]
 
 # Project-local config should stay free of secrets and machine-specific values.
-# Do not add API keys, tokens, user-only paths, or personal model preferences here.
+# Do not add API keys, tokens, user-only paths, provider overrides, telemetry,
+# notifications, or personal model preferences here.
+
+[features]
+# Meridian keeps many reusable specialist profiles in .codex/agents. Enable the
+# stable multi-agent surface while keeping concurrency bounded below.
+multi_agent = true
+child_agents_md = true
+
+[features.multi_agent_v2]
+enabled = true
+max_concurrent_threads_per_session = 6
+min_wait_timeout_ms = 10000
+default_wait_timeout_ms = 30000
+max_wait_timeout_ms = 3600000
+usage_hint_enabled = true
+usage_hint_text = "Use Meridian specialist agents only for explicit delegation or parallel work; keep ownership disjoint and preserve user-owned changes."
+
+[skills]
+include_instructions = true
+
+[skills.bundled]
+enabled = true
+
+[tools.web_search]
+context_size = "medium"
 
 # Keep project-local subagent orchestration bounded. Specialist profiles live
 # in .codex/agents/ and inherit these conservative defaults unless an operator
@@ -27,3 +61,79 @@ project_doc_fallback_filenames = ["CLAUDE.md"]
 [agents]
 max_threads = 6
 max_depth = 1
+job_max_runtime_seconds = 3600
+
+[agents."dense-data-grid-inspector-panel"]
+config_file = "agents/dense-data-grid-inspector-panel.toml"
+
+[agents."desktop-test-generation"]
+config_file = "agents/desktop-test-generation.toml"
+
+[agents."diagnostics-audit-timeline"]
+config_file = "agents/diagnostics-audit-timeline.toml"
+
+[agents."meridian-archive-organizer"]
+config_file = "agents/meridian-archive-organizer.toml"
+
+[agents."meridian-blueprint"]
+config_file = "agents/meridian-blueprint.toml"
+
+[agents."meridian-brainstorm"]
+config_file = "agents/meridian-brainstorm.toml"
+
+[agents."meridian-browser-workstation"]
+config_file = "agents/meridian-browser-workstation.toml"
+
+[agents."meridian-cleanup"]
+config_file = "agents/meridian-cleanup.toml"
+
+[agents."meridian-code-review"]
+config_file = "agents/meridian-code-review.toml"
+
+[agents."meridian-docs"]
+config_file = "agents/meridian-docs.toml"
+
+[agents."meridian-implementation-assurance"]
+config_file = "agents/meridian-implementation-assurance.toml"
+
+[agents."meridian-navigation"]
+config_file = "agents/meridian-navigation.toml"
+
+[agents."meridian-provider-builder"]
+config_file = "agents/meridian-provider-builder.toml"
+
+[agents."meridian-repo-navigation"]
+config_file = "agents/meridian-repo-navigation.toml"
+
+[agents."meridian-roadmap-strategist"]
+config_file = "agents/meridian-roadmap-strategist.toml"
+
+[agents."meridian-simulated-user-panel"]
+config_file = "agents/meridian-simulated-user-panel.toml"
+
+[agents."meridian-test-writer"]
+config_file = "agents/meridian-test-writer.toml"
+
+[agents."meridian-user-panel"]
+config_file = "agents/meridian-user-panel.toml"
+
+[agents."modular-desktop-mvvm"]
+config_file = "agents/modular-desktop-mvvm.toml"
+
+[agents."performance-resource-review"]
+config_file = "agents/performance-resource-review.toml"
+
+[agents."provider-management-workflow"]
+config_file = "agents/provider-management-workflow.toml"
+
+[agents."research-data-acquisition"]
+config_file = "agents/research-data-acquisition.toml"
+
+[agents."safe-refactoring"]
+config_file = "agents/safe-refactoring.toml"
+
+[agents."shared-component-extraction"]
+config_file = "agents/shared-component-extraction.toml"
+
+[agents."workstation-screen-composition"]
+config_file = "agents/workstation-screen-composition.toml"

--- a/docs/ai/codex/README.md
+++ b/docs/ai/codex/README.md
@@ -16,7 +16,7 @@ For documentation work, start from the rebuilt canonical docs model:
 
 | Surface | Purpose |
 | --- | --- |
-| [`.codex/config.toml`](../../../.codex/config.toml) | Repository-local Codex sandbox, approval, and bounded subagent defaults |
+| [`.codex/config.toml`](../../../.codex/config.toml) | Repository-local Codex sandbox, approval, search, skill loading, and bounded subagent role defaults |
 | [`quickstart.md`](quickstart.md) | First-10-minutes Codex task routing, proof matrix, and dirty-worktree protocol |
 | [`advanced-configuration.md`](advanced-configuration.md) | Advanced Codex local-client configuration patterns for profiles, providers, sandboxes, hooks, telemetry, notifications, and TUI options |
 | [`prompt-execution-trace.md`](prompt-execution-trace.md) | One-page prompt-to-execution diagram and execution-path refinements |

--- a/docs/ai/codex/advanced-configuration.md
+++ b/docs/ai/codex/advanced-configuration.md
@@ -344,6 +344,10 @@ project_root_markers = []
 - Configure subagent roles under `[agents]` in `config.toml` and keep role definitions user- or
   project-appropriate. In Meridian, repository-local role and skill inventory starts from
   [`README.md`](README.md) and `.codex/agents/`.
+- Keep `.codex/config.toml` as the shared registration point for repo-local Codex agent profile
+  files. Each `[agents.<role>]` table should point at the matching `.codex/agents/<role>.toml` file,
+  while model choices, provider routing, credentials, telemetry, and machine notifications stay in
+  user-level profiles.
 
 ## Observability, Metrics, And Feedback
 


### PR DESCRIPTION
### Motivation
- Align repository-local Codex defaults with Meridian workflows by keeping a conservative sandbox/approval posture while enabling safe repo-level search, skill-loading, and bounded multi-agent orchestration. 
- Make `.codex` the authoritative registration point for repo-local specialist agent profiles so local `.codex/agents/*.toml` entries are discoverable and consistently configured. 
- Clarify documentation and guardrails to prevent secrets, provider routing, telemetry, or personal model preferences from being placed in project-local config. 

### Description
- Updated `.codex/config.toml` to add `web_search = "live"`, `project_root_markers = ["Meridian.sln",".git"]`, enable `[features]` (including `multi_agent` and `features.multi_agent_v2` settings), enable bundled skill instructions under `[skills]`, set web-search `context_size`, and add conservative `[agents]` defaults (`max_threads`, `max_depth`, `job_max_runtime_seconds`) plus explicit `[agents."<role>"]` tables that point to the existing `.codex/agents/*.toml` files. 
- Registered all existing specialist profiles by adding `[agents."<name>"] config_file = "agents/<name>.toml"` entries so repository-local roles map to the corresponding `.codex/agents` TOML files. 
- Updated docs: `docs/ai/codex/README.md` to describe the expanded role of `.codex/config.toml` (sandbox, approval, search, skill loading, and bounded agent role defaults) and `docs/ai/codex/advanced-configuration.md` to document that `[agents.<role>]` entries should point to `.codex/agents/<role>.toml` while model/provider/credential choices remain in user-level profiles. 

### Testing
- Parsed `.codex/config.toml` with `tomllib` to ensure valid TOML (passed). 
- Validated `.codex/config.toml` against the OpenAI Codex config schema at `https://developers.openai.com/codex/config-schema.json` using `jsonschema` (passed). 
- Verified every registered `.codex/agents/*.toml` exists and parses with `tomllib` (passed). 
- Ran repository AI/docs checks: `python3 build/scripts/docs/check-ai-inventory.py --summary`, `python3 build/scripts/docs/check-codex-skills.py --summary`, `python3 build/scripts/docs/validate-docs-structure.py --top-level ai --summary`, and the contract drift check `python3 build/scripts/docs/check-ai-contract-drift.py --canonical docs/ai/contract-policy.json --mirror docs/ai/copilot/contract-policy.mirror.json --mirror docs/ai/claude/contract-policy.mirror.json --routing-rules docs/ai/codex/prompt-route-rules.json --routing-host-doc docs/ai/codex/README.md --routing-host-doc docs/ai/assistant-workflow-contract.md` (all passed). 
- `make ai-verify` was blocked in this environment because `dotnet` is not present on PATH (environment-specific blocker). 
- `make ai-arch-check` surfaced existing architecture baseline findings unrelated to these config/docs edits (failed but out-of-scope for this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283b8863888320ab63e9308e502220)