### PR TITLE
Add WPF shell workspace tabs

### DIFF
--- a/src/Meridian.Wpf/MainWindow.xaml
+++ b/src/Meridian.Wpf/MainWindow.xaml
@@ -247,16 +247,110 @@
             </Border>
         </StackPanel>
 
-        <Frame x:Name="RootFrame"
-               Grid.Row="1"
-               AllowDrop="True"
-               Background="{DynamicResource ShellWindowBackgroundBrush}"
-               NavigationUIVisibility="Hidden"
-               Navigated="OnRootFrameNavigated"
-               DragEnter="OnRootFrameDragEnter"
-               DragOver="OnRootFrameDragOver"
-               DragLeave="OnRootFrameDragLeave"
-               Drop="OnRootFrameDrop" />
+        <Grid Grid.Row="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <Border Grid.Row="0"
+                    Background="{StaticResource ConsoleBackgroundMediumBrush}"
+                    BorderBrush="{StaticResource ConsoleBorderBrush}"
+                    BorderThickness="0,0,0,1"
+                    Padding="10,6"
+                    AutomationProperties.Name="Open workspace tabs"
+                    AutomationProperties.AutomationId="WorkspaceTabStrip">
+                <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                              VerticalScrollBarVisibility="Disabled">
+                    <ItemsControl ItemsSource="{Binding OpenTabs}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Margin="0,0,6,0"
+                                        Padding="10,6"
+                                        CornerRadius="8"
+                                        BorderThickness="1">
+                                    <Border.Style>
+                                        <Style TargetType="Border">
+                                            <Setter Property="Background" Value="{StaticResource ConsoleBackgroundLightBrush}" />
+                                            <Setter Property="BorderBrush" Value="{StaticResource ConsoleBorderBrush}" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsActive}" Value="True">
+                                                    <Setter Property="Background" Value="{StaticResource PremiumPanelBrush}" />
+                                                    <Setter Property="BorderBrush" Value="{StaticResource InfoColorBrush}" />
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding RequiresAttention}" Value="True">
+                                                    <Setter Property="BorderBrush" Value="{StaticResource WarningColorBrush}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Style>
+                                    <StackPanel Orientation="Horizontal"
+                                                VerticalAlignment="Center">
+                                        <Button Command="{Binding DataContext.ActivateTabCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                CommandParameter="{Binding}"
+                                                Style="{StaticResource GhostButtonStyle}"
+                                                Padding="0"
+                                                ToolTip="{Binding WorkspaceId}">
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="{Binding Title}"
+                                                           FontSize="12"
+                                                           FontWeight="SemiBold"
+                                                           Foreground="{StaticResource ConsoleTextPrimaryBrush}"
+                                                           TextTrimming="CharacterEllipsis"
+                                                           MaxWidth="180"
+                                                           VerticalAlignment="Center" />
+                                                <TextBlock Text="*"
+                                                           Margin="3,0,0,0"
+                                                           Foreground="{StaticResource WarningColorBrush}"
+                                                           VerticalAlignment="Center">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="Visibility" Value="Collapsed" />
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsDirty}" Value="True">
+                                                                    <Setter Property="Visibility" Value="Visible" />
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </StackPanel>
+                                        </Button>
+                                        <Button Command="{Binding DataContext.CloseTabCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                CommandParameter="{Binding}"
+                                                Style="{StaticResource GhostButtonStyle}"
+                                                Padding="4,0"
+                                                Margin="6,0,0,0"
+                                                ToolTip="Close tab"
+                                                AutomationProperties.Name="Close workspace tab">
+                                            <TextBlock Text="&#xE711;"
+                                                       FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                                       FontSize="10" />
+                                        </Button>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+            </Border>
+
+            <Frame x:Name="RootFrame"
+                   Grid.Row="1"
+                   AllowDrop="True"
+                   Background="{DynamicResource ShellWindowBackgroundBrush}"
+                   NavigationUIVisibility="Hidden"
+                   Navigated="OnRootFrameNavigated"
+                   DragEnter="OnRootFrameDragEnter"
+                   DragOver="OnRootFrameDragOver"
+                   DragLeave="OnRootFrameDragLeave"
+                   Drop="OnRootFrameDrop" />
+        </Grid>
 
         <!-- Drop overlay: shown while a file drag is in progress over the window -->
         <Grid x:Name="DropOverlay"

--- a/src/Meridian.Wpf/README.md
+++ b/src/Meridian.Wpf/README.md
@@ -278,6 +278,11 @@ the icon asset documentation maps those compatibility names to canonical Strateg
 Accounting, and Settings operator labels.
 `WorkspaceService` uses that same seam for persisted session and layout restore while keeping only
 older template aliases such as monitoring, storage-admin, and analysis-export local to the service.
+`DesktopShellSessionService` now owns first-class workspace tabs for the WPF shell: navigation
+activates an existing canonical page tab when one is already open, otherwise it opens a new tab with
+the route, title, workspace id, dirty/attention flags, and close capability needed by the main
+window tab strip. Session restore rehydrates the persisted open-page list into these tabs before the
+active page is navigated.
 Strategy shell presentation defaults also emit the canonical `strategy` workspace id while retaining
 legacy research aliases for restored workflow summaries.
 Workspace shell copy and automation names use canonical Strategy/Data shell constants instead of

--- a/src/Meridian.Wpf/Shell/Root/DesktopShellCoordinator.cs
+++ b/src/Meridian.Wpf/Shell/Root/DesktopShellCoordinator.cs
@@ -40,6 +40,16 @@ public sealed class DesktopShellCoordinator
             .ConfigureAwait(false);
     }
 
+    public bool NavigateToWorkspaceTab(string pageTag)
+    {
+        if (string.IsNullOrWhiteSpace(pageTag))
+        {
+            return false;
+        }
+
+        return _sessionService.NavigateToTab(pageTag);
+    }
+
     private static void ValidateWorkspaceCapabilityRegistrations(
         IShellPageRegistry pageRegistry,
         IServiceProvider serviceProvider,

--- a/src/Meridian.Wpf/Shell/Session/DesktopShellSessionService.cs
+++ b/src/Meridian.Wpf/Shell/Session/DesktopShellSessionService.cs
@@ -1,16 +1,65 @@
 using System;
+using System.Collections.ObjectModel;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Meridian.Ui.Services;
 using Meridian.Wpf.Models;
 using Meridian.Wpf.Services;
+using Meridian.Wpf.ViewModels;
 
 namespace Meridian.Wpf.Shell.Session;
 
 public sealed record DesktopShellSessionRestorePlan(
     string? DeferredPageTag,
-    string TargetPageTag);
+    string TargetPageTag,
+    IReadOnlyList<ShellWorkspaceTab> OpenTabs);
+
+public sealed class ShellWorkspaceTab : BindableBase
+{
+    private bool _isActive;
+    private bool _isDirty;
+    private bool _requiresAttention;
+
+    public ShellWorkspaceTab(string pageTag, string title, string? workspaceId, bool canClose = true)
+    {
+        PageTag = string.IsNullOrWhiteSpace(pageTag)
+            ? throw new ArgumentException("A page tag is required.", nameof(pageTag))
+            : ShellNavigationCatalog.GetCanonicalPageTag(pageTag);
+        Title = string.IsNullOrWhiteSpace(title) ? PageTag : title.Trim();
+        WorkspaceId = string.IsNullOrWhiteSpace(workspaceId)
+            ? ShellNavigationCatalog.InferWorkspaceIdForPageTag(PageTag)
+            : workspaceId.Trim();
+        CanClose = canClose;
+    }
+
+    public string PageTag { get; }
+
+    public string Title { get; }
+
+    public string? WorkspaceId { get; }
+
+    public bool CanClose { get; }
+
+    public bool IsActive
+    {
+        get => _isActive;
+        internal set => SetProperty(ref _isActive, value);
+    }
+
+    public bool IsDirty
+    {
+        get => _isDirty;
+        set => SetProperty(ref _isDirty, value);
+    }
+
+    public bool RequiresAttention
+    {
+        get => _requiresAttention;
+        set => SetProperty(ref _requiresAttention, value);
+    }
+}
 
 public sealed class DesktopShellSessionService
 {
@@ -19,6 +68,9 @@ public sealed class DesktopShellSessionService
     private readonly WorkstationOperatingContextService _operatingContextService;
     private readonly NavigationService _navigationService;
     private readonly Meridian.Wpf.Services.LoggingService _loggingService;
+    private readonly ObservableCollection<ShellWorkspaceTab> _openTabs = [];
+    private readonly ReadOnlyObservableCollection<ShellWorkspaceTab> _openTabsView;
+    private ShellWorkspaceTab? _activeTab;
 
     public DesktopShellSessionService(
         WorkspaceService workspaceService,
@@ -32,6 +84,119 @@ public sealed class DesktopShellSessionService
         _operatingContextService = operatingContextService ?? throw new ArgumentNullException(nameof(operatingContextService));
         _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
         _loggingService = loggingService ?? throw new ArgumentNullException(nameof(loggingService));
+        _openTabsView = new ReadOnlyObservableCollection<ShellWorkspaceTab>(_openTabs);
+    }
+
+    public event EventHandler? TabsChanged;
+
+    public ReadOnlyObservableCollection<ShellWorkspaceTab> OpenTabs => _openTabsView;
+
+    public ShellWorkspaceTab? ActiveTab
+    {
+        get => _activeTab;
+        private set
+        {
+            if (ReferenceEquals(_activeTab, value))
+            {
+                return;
+            }
+
+            if (_activeTab is not null)
+            {
+                _activeTab.IsActive = false;
+            }
+
+            _activeTab = value;
+            if (_activeTab is not null)
+            {
+                _activeTab.IsActive = true;
+            }
+
+            TabsChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    public ShellWorkspaceTab ActivateOrOpenTab(string pageTag)
+    {
+        var canonicalPageTag = ShellNavigationCatalog.GetCanonicalPageTag(pageTag);
+        var existing = _openTabs.FirstOrDefault(tab =>
+            string.Equals(tab.PageTag, canonicalPageTag, StringComparison.OrdinalIgnoreCase));
+        if (existing is not null)
+        {
+            ActiveTab = existing;
+            return existing;
+        }
+
+        var tab = CreateTab(canonicalPageTag);
+        _openTabs.Add(tab);
+        ActiveTab = tab;
+        TabsChanged?.Invoke(this, EventArgs.Empty);
+        return tab;
+    }
+
+    public bool NavigateToTab(string pageTag)
+    {
+        var tab = ActivateOrOpenTab(pageTag);
+        return _navigationService.NavigateTo(tab.PageTag);
+    }
+
+    public bool ActivateTab(ShellWorkspaceTab? tab)
+    {
+        if (tab is null || !_openTabs.Contains(tab))
+        {
+            return false;
+        }
+
+        ActiveTab = tab;
+        return _navigationService.NavigateTo(tab.PageTag);
+    }
+
+    public bool CloseTab(ShellWorkspaceTab? tab)
+    {
+        if (tab is null || !tab.CanClose || !_openTabs.Contains(tab))
+        {
+            return false;
+        }
+
+        var closedIndex = _openTabs.IndexOf(tab);
+        var wasActive = ReferenceEquals(tab, ActiveTab);
+        _openTabs.Remove(tab);
+        if (wasActive)
+        {
+            ActiveTab = _openTabs.Count == 0
+                ? null
+                : _openTabs[Math.Min(closedIndex, _openTabs.Count - 1)];
+            if (ActiveTab is not null)
+            {
+                _navigationService.NavigateTo(ActiveTab.PageTag);
+            }
+        }
+
+        TabsChanged?.Invoke(this, EventArgs.Empty);
+        return true;
+    }
+
+    public void RestoreTabs(IEnumerable<WorkspacePage>? pages, string? activePageTag)
+    {
+        _openTabs.Clear();
+
+        foreach (var page in pages ?? [])
+        {
+            var canonicalPageTag = ShellNavigationCatalog.GetCanonicalPageTag(page.PageTag);
+            if (string.IsNullOrWhiteSpace(page.PageTag) ||
+                _openTabs.Any(tab => string.Equals(tab.PageTag, canonicalPageTag, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            _openTabs.Add(CreateTab(canonicalPageTag, page.Title));
+        }
+
+        var targetPageTag = string.IsNullOrWhiteSpace(activePageTag)
+            ? _openTabs.FirstOrDefault()?.PageTag
+            : ShellNavigationCatalog.GetCanonicalPageTag(activePageTag);
+        ActiveTab = _openTabs.FirstOrDefault(tab => string.Equals(tab.PageTag, targetPageTag, StringComparison.OrdinalIgnoreCase));
+        TabsChanged?.Invoke(this, EventArgs.Empty);
     }
 
     public void SaveWorkspaceSession(DesktopWindowBounds bounds, bool shellIsOpen)
@@ -47,7 +212,7 @@ public sealed class DesktopShellSessionService
 
             var operatingContextKey = _operatingContextService.CurrentContext?.ContextKey
                 ?? _fundContextService.CurrentFundProfile?.FundProfileId;
-            var currentPage = _navigationService.GetCurrentPageTag();
+            var currentPage = ActiveTab?.PageTag ?? _navigationService.GetCurrentPageTag();
             var activeWorkspace = _workspaceService.ActiveWorkspace;
             var existing = _workspaceService.GetLastSessionStateForContext(operatingContextKey);
 
@@ -56,7 +221,9 @@ public sealed class DesktopShellSessionService
                 ActivePageTag = currentPage ?? "Dashboard",
                 ActiveWorkspaceId = activeWorkspace?.Id,
                 ActiveFilters = existing?.ActiveFilters ?? new Dictionary<string, string>(),
-                OpenPages = existing?.OpenPages ?? new List<WorkspacePage>(),
+                OpenPages = _openTabs.Count > 0
+                    ? _openTabs.Select(ToWorkspacePage).ToList()
+                    : existing?.OpenPages ?? new List<WorkspacePage>(),
                 WindowBounds = new WindowBounds
                 {
                     X = bounds.Left,
@@ -160,7 +327,12 @@ public sealed class DesktopShellSessionService
                 ? session.ActivePageTag
                 : null;
 
-            return new DesktopShellSessionRestorePlan(deferredPageTag, targetPageTag);
+            var restoredPages = session?.OpenPages?.Count > 0
+                ? session.OpenPages
+                : new List<WorkspacePage> { new() { PageTag = targetPageTag, Title = ShellNavigationCatalog.GetPageTitle(targetPageTag) } };
+            RestoreTabs(restoredPages, targetPageTag);
+
+            return new DesktopShellSessionRestorePlan(deferredPageTag, targetPageTag, OpenTabs.ToArray());
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -184,4 +356,22 @@ public sealed class DesktopShellSessionService
 
     public Task LoadWorkspacesAsync(CancellationToken ct = default)
         => _workspaceService.LoadWorkspacesAsync(ct);
+
+    private static ShellWorkspaceTab CreateTab(string pageTag, string? title = null)
+    {
+        var canonicalPageTag = ShellNavigationCatalog.GetCanonicalPageTag(pageTag);
+        return new ShellWorkspaceTab(
+            canonicalPageTag,
+            string.IsNullOrWhiteSpace(title) ? ShellNavigationCatalog.GetPageTitle(canonicalPageTag) : title,
+            ShellNavigationCatalog.InferWorkspaceIdForPageTag(canonicalPageTag),
+            canClose: true);
+    }
+
+    private static WorkspacePage ToWorkspacePage(ShellWorkspaceTab tab)
+        => new()
+        {
+            PageTag = tab.PageTag,
+            Title = tab.Title,
+            IsDefault = false
+        };
 }

--- a/src/Meridian.Wpf/ViewModels/MainWindowViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/MainWindowViewModel.cs
@@ -5,6 +5,8 @@ using CommunityToolkit.Mvvm.Input;
 using Meridian.Ui.Services;
 using Meridian.Ui.Services.Services;
 using Meridian.Wpf.Contracts;
+using Meridian.Wpf.Shell.Root;
+using Meridian.Wpf.Shell.Session;
 using Meridian.Wpf.Services;
 using WpfServices = Meridian.Wpf.Services;
 
@@ -27,6 +29,8 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
     private readonly WpfServices.WatchlistService _watchlistService;
     private readonly FixtureModeDetector _fixtureModeDetector;
     private readonly DesktopAuthenticationSession _authenticationSession;
+    private readonly DesktopShellCoordinator? _shellCoordinator;
+    private readonly DesktopShellSessionService? _shellSessionService;
     private readonly DispatcherTimer _clipboardBannerTimer;
     private readonly DispatcherTimer _startupBannerTimer;
 
@@ -55,7 +59,9 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
         WpfServices.WatchlistService watchlistService,
         FixtureModeDetector fixtureModeDetector,
         DesktopAuthenticationSession authenticationSession,
-        IStatusService statusService)
+        IStatusService statusService,
+        DesktopShellCoordinator? shellCoordinator = null,
+        DesktopShellSessionService? shellSessionService = null)
     {
         _connectionService = connectionService ?? throw new ArgumentNullException(nameof(connectionService));
         _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
@@ -65,6 +71,8 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
         _watchlistService = watchlistService ?? throw new ArgumentNullException(nameof(watchlistService));
         _fixtureModeDetector = fixtureModeDetector ?? throw new ArgumentNullException(nameof(fixtureModeDetector));
         _authenticationSession = authenticationSession ?? throw new ArgumentNullException(nameof(authenticationSession));
+        _shellCoordinator = shellCoordinator;
+        _shellSessionService = shellSessionService;
 
         StatusBar = new StatusBarViewModel(statusService, notificationService);
 
@@ -76,6 +84,8 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
         AddClipboardSymbolsCommand = new AsyncRelayCommand(AddPendingSymbolsToWatchlistAsync, () => _pendingClipboardSymbols.Count > 0);
         DismissStartupBannerCommand = new RelayCommand(HideStartupBanner);
         DismissClipboardBannerCommand = new RelayCommand(HideClipboardBanner);
+        ActivateTabCommand = new RelayCommand<ShellWorkspaceTab>(ActivateTab);
+        CloseTabCommand = new RelayCommand<ShellWorkspaceTab>(CloseTab);
 
         _startupBannerTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(18) };
         _startupBannerTimer.Tick += OnStartupBannerTimerTick;
@@ -83,6 +93,11 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
         _clipboardBannerTimer.Tick += OnClipboardBannerTimerTick;
 
         _fixtureModeDetector.ModeChanged += OnFixtureModeChanged;
+        if (_shellSessionService is not null)
+        {
+            _shellSessionService.TabsChanged += OnShellTabsChanged;
+        }
+
         RefreshAuthenticationState();
         UpdateFixtureModeBanner();
     }
@@ -106,6 +121,14 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
     public IRelayCommand DismissStartupBannerCommand { get; }
 
     public IRelayCommand DismissClipboardBannerCommand { get; }
+
+    public IReadOnlyList<ShellWorkspaceTab> OpenTabs => _shellSessionService?.OpenTabs ?? Array.Empty<ShellWorkspaceTab>();
+
+    public ShellWorkspaceTab? ActiveTab => _shellSessionService?.ActiveTab;
+
+    public IRelayCommand<ShellWorkspaceTab> ActivateTabCommand { get; }
+
+    public IRelayCommand<ShellWorkspaceTab> CloseTabCommand { get; }
 
     public Visibility AuthenticatedSessionVisibility
     {
@@ -432,6 +455,11 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
         _clipboardBannerTimer.Stop();
         _clipboardBannerTimer.Tick -= OnClipboardBannerTimerTick;
         _fixtureModeDetector.ModeChanged -= OnFixtureModeChanged;
+        if (_shellSessionService is not null)
+        {
+            _shellSessionService.TabsChanged -= OnShellTabsChanged;
+        }
+
         StatusBar.Dispose();
     }
 
@@ -514,7 +542,26 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
             return;
         }
 
-        _navigationService.NavigateTo(pageTag);
+        if (_shellCoordinator?.NavigateToWorkspaceTab(pageTag) != true)
+        {
+            _navigationService.NavigateTo(pageTag);
+        }
+    }
+
+    private void ActivateTab(ShellWorkspaceTab? tab)
+    {
+        _shellSessionService?.ActivateTab(tab);
+    }
+
+    private void CloseTab(ShellWorkspaceTab? tab)
+    {
+        _shellSessionService?.CloseTab(tab);
+    }
+
+    private void OnShellTabsChanged(object? sender, EventArgs e)
+    {
+        RaisePropertyChanged(nameof(OpenTabs));
+        RaisePropertyChanged(nameof(ActiveTab));
     }
 
     private async Task StartCollectorAsync()

--- a/tests/Meridian.Wpf.Tests/Shell/DesktopShellSessionServiceTests.cs
+++ b/tests/Meridian.Wpf.Tests/Shell/DesktopShellSessionServiceTests.cs
@@ -1,0 +1,139 @@
+using System.IO;
+using System.Windows.Controls;
+using Meridian.Ui.Services;
+using Meridian.Wpf.Models;
+using Meridian.Wpf.Services;
+using Meridian.Wpf.Shell.Session;
+using Meridian.Wpf.Tests.Support;
+
+namespace Meridian.Wpf.Tests.Shell;
+
+public sealed class DesktopShellSessionServiceTests : IDisposable
+{
+    private readonly string _settingsFilePath = Path.Combine(
+        Path.GetTempPath(),
+        "Meridian.Wpf.Tests",
+        "desktop-shell-session-service-tests",
+        $"{Guid.NewGuid():N}.workspace-data.json");
+
+    public DesktopShellSessionServiceTests()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_settingsFilePath)!);
+        WorkspaceService.SetSettingsFilePathOverrideForTests(_settingsFilePath);
+    }
+
+    public void Dispose()
+    {
+        NavigationService.Instance.ResetForTests();
+        WorkspaceService.SetSettingsFilePathOverrideForTests(null);
+        if (File.Exists(_settingsFilePath))
+        {
+            File.Delete(_settingsFilePath);
+        }
+    }
+
+    [Fact]
+    public void ActivateOrOpenTab_ReusesExistingTabForCanonicalPage()
+    {
+        var service = CreateService();
+
+        var first = service.ActivateOrOpenTab("StrategyShell");
+        var second = service.ActivateOrOpenTab("ResearchShell");
+
+        second.Should().BeSameAs(first);
+        service.OpenTabs.Should().ContainSingle();
+        service.ActiveTab.Should().Be(first);
+        first.PageTag.Should().Be("StrategyShell");
+    }
+
+    [Fact]
+    public void CloseTab_ActivatesNeighborWhenActiveTabCloses()
+    {
+        WpfTestThread.Run(() =>
+        {
+            var service = CreateServiceWithFrame();
+            var strategy = service.ActivateOrOpenTab("StrategyShell");
+            var settings = service.ActivateOrOpenTab("Settings");
+
+            service.CloseTab(settings).Should().BeTrue();
+
+            service.OpenTabs.Should().ContainSingle().Which.Should().Be(strategy);
+            service.ActiveTab.Should().Be(strategy);
+            strategy.IsActive.Should().BeTrue();
+        });
+    }
+
+    [Fact]
+    public void NavigateToTab_OpensAndReactivatesTabsThroughNavigation()
+    {
+        WpfTestThread.Run(() =>
+        {
+            var service = CreateServiceWithFrame();
+
+            service.NavigateToTab("StrategyShell").Should().BeTrue();
+            service.NavigateToTab("Settings").Should().BeTrue();
+            service.NavigateToTab("StrategyShell").Should().BeTrue();
+
+            service.OpenTabs.Select(tab => tab.PageTag).Should().Equal("StrategyShell", "Settings");
+            service.ActiveTab!.PageTag.Should().Be("StrategyShell");
+            NavigationService.Instance.GetCurrentPageTag().Should().Be("StrategyShell");
+        });
+    }
+
+    [Fact]
+    public async Task BuildRestorePlanForContextAsync_RestoresPersistedTabsAndActiveTab()
+    {
+        var workspaceService = CreateWorkspaceService();
+        await workspaceService.SaveSessionStateAsync(
+            new SessionState
+            {
+                ActivePageTag = "Settings",
+                ActiveWorkspaceId = "settings",
+                OpenPages =
+                [
+                    new WorkspacePage { PageTag = "StrategyShell", Title = "Strategy Workspace" },
+                    new WorkspacePage { PageTag = "Settings", Title = "Settings" }
+                ]
+            },
+            "fund:alpha");
+
+        var service = CreateService(workspaceService);
+        var plan = await service.BuildRestorePlanForContextAsync(
+            new WorkstationOperatingContext
+            {
+                ScopeKind = OperatingContextScopeKind.Fund,
+                ScopeId = "alpha",
+                DefaultWorkspaceId = "strategy",
+                DefaultLandingPageTag = "StrategyShell"
+            },
+            _ => "StrategyShell");
+
+        plan.Should().NotBeNull();
+        plan!.TargetPageTag.Should().Be("Settings");
+        plan.OpenTabs.Select(tab => tab.PageTag).Should().Equal("StrategyShell", "Settings");
+        service.ActiveTab!.PageTag.Should().Be("Settings");
+    }
+
+    private DesktopShellSessionService CreateService(WorkspaceService? workspaceService = null)
+        => new(
+            workspaceService ?? CreateWorkspaceService(),
+            new FundContextService(Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.funds.json")),
+            new WorkstationOperatingContextService(new FundContextService(Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.funds.json"))),
+            NavigationService.Instance,
+            LoggingService.Instance);
+
+    private DesktopShellSessionService CreateServiceWithFrame()
+    {
+        NavigationService.Instance.ResetForTests();
+        NavigationService.Instance.Initialize(new Frame());
+        return CreateService();
+    }
+
+    private WorkspaceService CreateWorkspaceService()
+    {
+        var service = (WorkspaceService)Activator.CreateInstance(typeof(WorkspaceService), nonPublic: true)!;
+        service.ResetForTests();
+        service.LoadWorkspacesAsync().GetAwaiter().GetResult();
+        return service;
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide first-class, tabbed workspace sessions in the WPF shell so navigation can reuse or open workspace tabs and persist/restore open tabs as part of the user session.
- Keep routing and view-resolution centralized while exposing tab affordances (activate, close, dirty/attention) to the main window so operator workflows remain discoverable and restorable.

### Description

- Added a tab model `ShellWorkspaceTab` with canonical `PageTag`, `Title`, `WorkspaceId`, `IsDirty`, `RequiresAttention`, and `CanClose`, and integrated it into `DesktopShellSessionService` to track `OpenTabs` and `ActiveTab`. (See `src/Meridian.Wpf/Shell/Session/DesktopShellSessionService.cs`.)
- Extended session restore/save to persist `OpenPages` from the tab collection and to rehydrate tabs during `BuildRestorePlanForContextAsync`. (See `DesktopShellSessionService` changes.)
- Routed shell navigation through tab activation: `DesktopShellCoordinator.NavigateToWorkspaceTab` calls the session service to reuse or open tabs, and `MainWindowViewModel` prefers the coordinator path before falling back to direct navigation. (See `src/Meridian.Wpf/Shell/Root/DesktopShellCoordinator.cs` and `src/Meridian.Wpf/ViewModels/MainWindowViewModel.cs`.)
- Added a tab strip above the root workspace host in `MainWindow.xaml` bound to `OpenTabs` with activate/close commands and visual states for active/dirty/attention tabs. (See `src/Meridian.Wpf/MainWindow.xaml`.)
- Kept view resolution centralized (no changes to `ViewModelViewResolver` behavior) and documented the feature in `src/Meridian.Wpf/README.md`.
- Added focused unit tests for canonical tab reuse, activation/close behavior, navigation reactivation, and session restore in `tests/Meridian.Wpf.Tests/Shell/DesktopShellSessionServiceTests.cs`.

### Testing

- Ran `git diff --check` on the changed files; the check passed for the modified files (`src/Meridian.Wpf/...`).
- Added unit tests `DesktopShellSessionServiceTests` but running the test runner (`dotnet test ...`) could not be executed in this environment because `dotnet` is not available, so test execution is pending in CI or a developer machine. (`dotnet test ...` returned `dotnet: command not found`.)
- Attempted `pwsh ./tools/codex/mvvm-compliance-check.ps1` but `pwsh` was not available in this environment, so MVVM compliance checks were not run here.
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary`; it executed but reported existing repository-wide documentation hash drift unrelated to these changes (generated docs/hash mismatches) that should be resolved separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a306a6b76d48320882e302107034300)