### PR TITLE
Add structured WPF shell navigation panel

### DIFF
--- a/src/Meridian.Wpf/MainWindow.xaml
+++ b/src/Meridian.Wpf/MainWindow.xaml
@@ -247,8 +247,108 @@
             </Border>
         </StackPanel>
 
-        <Frame x:Name="RootFrame"
-               Grid.Row="1"
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="300" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <Border Background="{StaticResource ConsoleBackgroundMediumBrush}"
+                    BorderBrush="{StaticResource ConsoleBorderBrush}"
+                    BorderThickness="0,0,1,0"
+                    Padding="12"
+                    AutomationProperties.Name="Structured shell navigation"
+                    AutomationProperties.AutomationId="ShellStructuredLeftNavigation">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <ItemsControl ItemsSource="{Binding NavigationSections}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="0,0,0,16"
+                                            AutomationProperties.Name="{Binding AutomationName}"
+                                            AutomationProperties.AutomationId="{Binding AutomationId}">
+                                    <TextBlock Text="{Binding DisplayLabel}"
+                                               FontSize="12"
+                                               FontWeight="SemiBold"
+                                               Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                               Margin="0,0,0,8" />
+
+                                    <TextBlock Text="{Binding EmptyText}"
+                                               Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                               FontSize="12"
+                                               TextWrapping="Wrap"
+                                               Margin="2,0,2,8">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Visibility" Value="Collapsed" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding HasItems}" Value="False">
+                                                        <Setter Property="Visibility" Value="Visible" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+
+                                    <ItemsControl ItemsSource="{Binding Items}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Button Command="{Binding DataContext.NavigateCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                        CommandParameter="{Binding PageTag}"
+                                                        Style="{StaticResource GhostButtonStyle}"
+                                                        HorizontalContentAlignment="Stretch"
+                                                        Padding="8"
+                                                        Margin="0,0,0,4"
+                                                        AutomationProperties.Name="{Binding AutomationName}"
+                                                        AutomationProperties.AutomationId="{Binding AutomationId}">
+                                                    <StackPanel>
+                                                        <TextBlock Text="{Binding DisplayLabel}" FontWeight="SemiBold" Foreground="{StaticResource ConsoleTextPrimaryBrush}" />
+                                                        <TextBlock Text="{Binding MetaLine}" FontSize="11" Foreground="{StaticResource ConsoleTextMutedBrush}" TextTrimming="CharacterEllipsis" />
+                                                    </StackPanel>
+                                                </Button>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+
+                                    <ItemsControl ItemsSource="{Binding WorkspaceGroups}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Expander Header="{Binding DisplayLabel}"
+                                                          IsExpanded="True"
+                                                          Margin="0,0,0,6"
+                                                          AutomationProperties.Name="{Binding DisplayLabel}"
+                                                          AutomationProperties.AutomationId="{Binding AutomationId}">
+                                                    <ItemsControl ItemsSource="{Binding Items}">
+                                                        <ItemsControl.ItemTemplate>
+                                                            <DataTemplate>
+                                                                <Button Command="{Binding DataContext.NavigateCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                                        CommandParameter="{Binding PageTag}"
+                                                                        Style="{StaticResource GhostButtonStyle}"
+                                                                        HorizontalContentAlignment="Stretch"
+                                                                        Padding="8"
+                                                                        Margin="0,0,0,4"
+                                                                        AutomationProperties.Name="{Binding AutomationName}"
+                                                                        AutomationProperties.AutomationId="{Binding AutomationId}">
+                                                                    <StackPanel>
+                                                                        <TextBlock Text="{Binding DisplayLabel}" FontWeight="SemiBold" Foreground="{StaticResource ConsoleTextPrimaryBrush}" />
+                                                                        <TextBlock Text="{Binding WorkflowLabel}" FontSize="11" Foreground="{StaticResource ConsoleTextMutedBrush}" TextTrimming="CharacterEllipsis" />
+                                                                    </StackPanel>
+                                                                </Button>
+                                                            </DataTemplate>
+                                                        </ItemsControl.ItemTemplate>
+                                                    </ItemsControl>
+                                                </Expander>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+            </Border>
+
+            <Frame x:Name="RootFrame"
+               Grid.Column="1"
                AllowDrop="True"
                Background="{DynamicResource ShellWindowBackgroundBrush}"
                NavigationUIVisibility="Hidden"
@@ -257,6 +357,7 @@
                DragOver="OnRootFrameDragOver"
                DragLeave="OnRootFrameDragLeave"
                Drop="OnRootFrameDrop" />
+        </Grid>
 
         <!-- Drop overlay: shown while a file drag is in progress over the window -->
         <Grid x:Name="DropOverlay"

--- a/src/Meridian.Wpf/Models/ShellNavigationCatalog.cs
+++ b/src/Meridian.Wpf/Models/ShellNavigationCatalog.cs
@@ -176,6 +176,90 @@ public static partial class ShellNavigationCatalog
     public static string GetPageTitle(string pageTag)
         => GetPage(pageTag)?.Title ?? GetCanonicalPageTag(pageTag);
 
+    public static IReadOnlyList<ShellNavigationPanelSection> BuildNavigationPanel(
+        IEnumerable<string>? favoritePageTags = null,
+        IEnumerable<string>? recentPageTags = null)
+    {
+        var favorites = ResolveNavigationItems(favoritePageTags);
+        var recents = ResolveNavigationItems(recentPageTags);
+        var workspaceGroups = WorkspaceCapabilities
+            .Select(capability => new ShellNavigationWorkspaceGroup(
+                WorkspaceId: capability.Workspace.Id,
+                DisplayLabel: capability.Workspace.Title,
+                AutomationId: $"ShellNavigationWorkspace_{capability.Workspace.Id}",
+                Items: capability.Pages
+                    .Where(static page => !page.HideFromDefaultPalette)
+                    .OrderBy(static page => page.VisibilityTier)
+                    .ThenBy(static page => page.SectionLabel, StringComparer.OrdinalIgnoreCase)
+                    .ThenBy(static page => page.Order)
+                    .ThenBy(static page => page.Title, StringComparer.OrdinalIgnoreCase)
+                    .Select(ToNavigationPanelItem)
+                    .ToArray()))
+            .ToArray();
+
+        return
+        [
+            new ShellNavigationPanelSection(
+                ShellNavigationSectionIds.Favorites,
+                "Favorites",
+                "ShellNavigationSection_Favorites",
+                "Favorites navigation section",
+                "No favorites yet. Pin critical operator workflows here.",
+                favorites,
+                Array.Empty<ShellNavigationWorkspaceGroup>()),
+            new ShellNavigationPanelSection(
+                ShellNavigationSectionIds.Recent,
+                "Recent",
+                "ShellNavigationSection_Recent",
+                "Recent navigation section",
+                "No recent pages yet. Open a workspace to build history.",
+                recents,
+                Array.Empty<ShellNavigationWorkspaceGroup>()),
+            new ShellNavigationPanelSection(
+                ShellNavigationSectionIds.WorkspaceMenu,
+                "Workspace Menu",
+                "ShellNavigationSection_WorkspaceMenu",
+                "Workspace menu navigation section",
+                "No workspace pages are registered.",
+                Array.Empty<ShellNavigationPanelItem>(),
+                workspaceGroups)
+        ];
+    }
+
+    private static IReadOnlyList<ShellNavigationPanelItem> ResolveNavigationItems(IEnumerable<string>? pageTags)
+    {
+        if (pageTags is null)
+        {
+            return Array.Empty<ShellNavigationPanelItem>();
+        }
+
+        return pageTags
+            .Select(GetPage)
+            .Where(static page => page is not null && !page.HideFromDefaultPalette)
+            .Select(static page => page!)
+            .DistinctBy(static page => page.PageTag, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static page => page.VisibilityTier)
+            .ThenBy(static page => page.Order)
+            .ThenBy(static page => page.Title, StringComparer.OrdinalIgnoreCase)
+            .Select(ToNavigationPanelItem)
+            .ToArray();
+    }
+
+    private static ShellNavigationPanelItem ToNavigationPanelItem(ShellPageDescriptor page)
+    {
+        var workspace = GetWorkspace(page.WorkspaceId);
+        return new ShellNavigationPanelItem(
+            PageTag: page.PageTag,
+            DisplayLabel: page.Title,
+            Description: page.Subtitle,
+            WorkspaceId: page.WorkspaceId,
+            WorkspaceLabel: workspace?.Title ?? page.WorkspaceId,
+            WorkflowLabel: page.SectionLabel,
+            Glyph: page.Glyph,
+            SearchAliases: page.Aliases,
+            SearchKeywords: page.SearchKeywords);
+    }
+
     private static IReadOnlyDictionary<string, ShellPageDescriptor> BuildPageLookup()
     {
         var lookup = new Dictionary<string, ShellPageDescriptor>(StringComparer.OrdinalIgnoreCase);

--- a/src/Meridian.Wpf/Models/ShellNavigationPanelModels.cs
+++ b/src/Meridian.Wpf/Models/ShellNavigationPanelModels.cs
@@ -1,0 +1,53 @@
+namespace Meridian.Wpf.Models;
+
+public static class ShellNavigationSectionIds
+{
+    public const string Favorites = "favorites";
+    public const string Recent = "recent";
+    public const string WorkspaceMenu = "workspace-menu";
+}
+
+public sealed record ShellNavigationPanelItem(
+    string PageTag,
+    string DisplayLabel,
+    string Description,
+    string WorkspaceId,
+    string WorkspaceLabel,
+    string WorkflowLabel,
+    string Glyph,
+    IReadOnlyList<string> SearchAliases,
+    IReadOnlyList<string> SearchKeywords)
+{
+    public string AutomationId => $"ShellNavigationItem_{PageTag}";
+
+    public string AutomationName => $"Open {DisplayLabel}";
+
+    public string MetaLine
+    {
+        get
+        {
+            var parts = new[] { WorkspaceLabel, WorkflowLabel }
+                .Where(static part => !string.IsNullOrWhiteSpace(part));
+
+            return string.Join(" · ", parts);
+        }
+    }
+}
+
+public sealed record ShellNavigationWorkspaceGroup(
+    string WorkspaceId,
+    string DisplayLabel,
+    string AutomationId,
+    IReadOnlyList<ShellNavigationPanelItem> Items);
+
+public sealed record ShellNavigationPanelSection(
+    string Id,
+    string DisplayLabel,
+    string AutomationId,
+    string AutomationName,
+    string EmptyText,
+    IReadOnlyList<ShellNavigationPanelItem> Items,
+    IReadOnlyList<ShellNavigationWorkspaceGroup> WorkspaceGroups)
+{
+    public bool HasItems => Items.Count > 0 || WorkspaceGroups.Any(static group => group.Items.Count > 0);
+}

--- a/src/Meridian.Wpf/README.md
+++ b/src/Meridian.Wpf/README.md
@@ -23,6 +23,10 @@ Keep shared contracts and read-model logic in shared UI services when browser an
 the behavior. The seven operator workspaces now register through feature modules under
 `src/Meridian.Wpf/Features/` so new workspace-level navigation and shell ownership lands in the
 matching module before it expands through the older flat page folders.
+The main shell also projects those registered pages into a structured left navigation panel with
+Favorites, Recent, and Workspace Menu sections. Visible workspace roots remain limited to Trading,
+Portfolio, Accounting, Reporting, Strategy, Data, and Settings; legacy route aliases and keywords
+stay search metadata rather than primary labels.
 
 ## Key folders and files
 

--- a/src/Meridian.Wpf/ViewModels/MainWindowViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/MainWindowViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.Input;
 using Meridian.Ui.Services;
 using Meridian.Ui.Services.Services;
 using Meridian.Wpf.Contracts;
+using Meridian.Wpf.Models;
 using Meridian.Wpf.Services;
 using WpfServices = Meridian.Wpf.Services;
 
@@ -90,6 +91,8 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
     public event EventHandler? LogoutRequested;
 
     public StatusBarViewModel StatusBar { get; }
+
+    public IReadOnlyList<ShellNavigationPanelSection> NavigationSections { get; } = ShellNavigationCatalog.BuildNavigationPanel();
 
     public IRelayCommand<string> NavigateCommand { get; }
 

--- a/tests/Meridian.Wpf.Tests/Models/ShellNavigationCatalogTests.cs
+++ b/tests/Meridian.Wpf.Tests/Models/ShellNavigationCatalogTests.cs
@@ -467,3 +467,78 @@ public sealed class ShellNavigationCatalogTests
         }
     }
 }
+
+public sealed class ShellNavigationPanelCatalogTests
+{
+    [Fact]
+    public void BuildNavigationPanel_EmptyFavoritesAndRecents_ShouldExposeEmptyStateSections()
+    {
+        var sections = ShellNavigationCatalog.BuildNavigationPanel();
+
+        sections.Select(static section => section.Id)
+            .Should()
+            .Equal(
+                ShellNavigationSectionIds.Favorites,
+                ShellNavigationSectionIds.Recent,
+                ShellNavigationSectionIds.WorkspaceMenu);
+
+        sections[0].HasItems.Should().BeFalse();
+        sections[0].AutomationId.Should().Be("ShellNavigationSection_Favorites");
+        sections[1].HasItems.Should().BeFalse();
+        sections[1].AutomationId.Should().Be("ShellNavigationSection_Recent");
+    }
+
+    [Fact]
+    public void BuildNavigationPanel_WorkspaceMenu_ShouldGroupByCanonicalRootWorkspaceOrder()
+    {
+        var workspaceMenu = ShellNavigationCatalog.BuildNavigationPanel()
+            .Single(static section => section.Id == ShellNavigationSectionIds.WorkspaceMenu);
+
+        workspaceMenu.WorkspaceGroups.Select(static group => group.WorkspaceId)
+            .Should()
+            .Equal("trading", "portfolio", "accounting", "reporting", "strategy", "data", "settings");
+
+        workspaceMenu.WorkspaceGroups.Should().OnlyContain(static group => group.Items.All(item => item.WorkspaceId == group.WorkspaceId));
+        workspaceMenu.WorkspaceGroups.Select(static group => group.DisplayLabel)
+            .Should()
+            .Equal("Trading", "Portfolio", "Accounting", "Reporting", "Strategy", "Data", "Settings");
+    }
+
+    [Fact]
+    public void BuildNavigationPanel_WorkspaceItems_ShouldSortByVisibilityWorkflowOrderThenLabel()
+    {
+        var strategy = ShellNavigationCatalog.BuildNavigationPanel()
+            .Single(static section => section.Id == ShellNavigationSectionIds.WorkspaceMenu)
+            .WorkspaceGroups.Single(static group => group.WorkspaceId == "strategy");
+
+        var expected = ShellNavigationCatalog.WorkspaceCapabilities
+            .Single(static capability => capability.Workspace.Id == "strategy")
+            .Pages
+            .Where(static page => !page.HideFromDefaultPalette)
+            .OrderBy(static page => page.VisibilityTier)
+            .ThenBy(static page => page.SectionLabel, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static page => page.Order)
+            .ThenBy(static page => page.Title, StringComparer.OrdinalIgnoreCase)
+            .Select(static page => page.PageTag);
+
+        strategy.Items.Select(static item => item.PageTag).Should().Equal(expected);
+    }
+
+    [Fact]
+    public void BuildNavigationPanel_FavoritesAndRecents_ShouldCanonicalizeAliasesAndKeepAliasesSearchOnly()
+    {
+        var sections = ShellNavigationCatalog.BuildNavigationPanel(
+            favoritePageTags: ["ResearchShell", "Backtest"],
+            recentPageTags: ["Blotter", "TradingShell"]);
+
+        var favorites = sections.Single(static section => section.Id == ShellNavigationSectionIds.Favorites);
+        favorites.Items.Select(static item => item.PageTag).Should().Equal("StrategyShell", "Backtest");
+        favorites.Items.Should().OnlyContain(static item => !item.DisplayLabel.Contains("ResearchShell", StringComparison.OrdinalIgnoreCase));
+        favorites.Items.Single(static item => item.PageTag == "StrategyShell")
+            .SearchAliases.Should().Contain("ResearchShell");
+
+        var recents = sections.Single(static section => section.Id == ShellNavigationSectionIds.Recent);
+        recents.Items.Select(static item => item.PageTag).Should().Equal("TradingShell", "PositionBlotter");
+        recents.Items.Should().OnlyContain(static item => !item.DisplayLabel.Contains("Blotter", StringComparison.OrdinalIgnoreCase));
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a structured, persistent left navigation panel in the WPF shell that groups pages by workspace and operator workflow and surfaces Favorites and Recent sections for faster operator access.
- Keep display labels human-friendly while preserving legacy aliases/keywords as search metadata for command/search palettes.
- Ensure navigation is aligned to the canonical root workspaces: `Trading`, `Portfolio`, `Accounting`, `Reporting`, `Strategy`, `Data`, and `Settings` and include accessibility metadata for automation tests and assistive tech.

### Description

- Added navigation panel model types in `src/Meridian.Wpf/Models/ShellNavigationPanelModels.cs` including `ShellNavigationPanelSection`, `ShellNavigationPanelItem`, `ShellNavigationWorkspaceGroup`, and `ShellNavigationSectionIds` plus automation id/name helpers.
- Projected existing shell pages into a navigation panel with `ShellNavigationCatalog.BuildNavigationPanel(...)` in `src/Meridian.Wpf/Models/ShellNavigationCatalog.cs`, preserving aliases as `SearchAliases`, grouping by workspace via `WorkspaceCapabilities`, and sorting by visibility/workflow/order/title.
- Rendered a persistent left navigation panel in the shell XAML by updating `src/Meridian.Wpf/MainWindow.xaml` to host the panel (bound to `NavigationSections`) and added automation properties (`AutomationProperties.Name`/`AutomationId`) on sections, workspace groups, and items.
- Exposed `NavigationSections` from `MainWindowViewModel` in `src/Meridian.Wpf/ViewModels/MainWindowViewModel.cs` for binding and added a short README note documenting the new left navigation behavior in `src/Meridian.Wpf/README.md`.
- Added unit tests `ShellNavigationPanelCatalogTests` to `tests/Meridian.Wpf.Tests/Models/ShellNavigationCatalogTests.cs` covering empty favorites/recents, canonical workspace grouping/order, sorting rules, and alias canonicalization for favorites/recents.

### Testing

- Ran `git diff --check` to validate edits and it passed successfully.
- Added focused unit tests for `BuildNavigationPanel` in `tests/Meridian.Wpf.Tests/Models/ShellNavigationCatalogTests.cs` but the environment could not execute `.NET` tests here because `dotnet` is not available (`dotnet: command not found`).
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary` which reported repository-wide documentation/source hash drift (pre-existing in the workspace and including `src/Meridian.Wpf` after the README update), so docs hashes will need review in CI or a developer environment.
- Attempted to run `pwsh ./tools/codex/mvvm-compliance-check.ps1` but `pwsh` is not available in this environment; recommend running the MVVM compliance and unit tests in a developer machine or CI that has `pwsh` and `dotnet` installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a306a7210348320aee392b58d8aa675)