### PR TITLE
Add reusable WPF context command toolbar

### DIFF
--- a/src/Meridian.Wpf/README.md
+++ b/src/Meridian.Wpf/README.md
@@ -309,6 +309,7 @@ board, investor, compliance, and fund-ops packets do not surface the legacy Gove
 `WorkspaceCommandSurfaceControl` and `WorkspaceEvidenceStripControl` take explicit automation ID
 properties from the active workspace layout descriptor so shell chrome can be reused without
 depending on ambient `MainPage` bindings.
+Workspace pages can also publish reusable context actions by implementing `IWorkspaceContextCommandProvider` and returning `ContextCommandDescriptor` items with label, glyph, command, disabled reason, importance, busy state, visibility, and automation ID metadata. `MainPageViewModel` mirrors the active page provider into `ActiveWorkspaceContextCommands`, and `ContextCommandToolbarControl` renders those commands in `WorkspaceCommandSurfaceControl` so command availability stays view-model-owned rather than XAML-trigger-owned.
 Modal surfaces should migrate through `WorkspaceDialogChromeControl`; provider API-key setup,
 watchlist saving, and scheduled-job editing now use that shared dialog chrome with stable title,
 subtitle, body, input, and action automation IDs. The control projects its chrome automation ID and

--- a/src/Meridian.Wpf/ViewModels/MainPageViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/MainPageViewModel.cs
@@ -12,6 +12,7 @@ using Meridian.Wpf.Shell.Refresh;
 using Meridian.Wpf.Shell.Services;
 using Meridian.Wpf.Shell.ViewModels;
 using Meridian.Wpf.Services;
+using Meridian.Wpf.Workstation.Commands;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Meridian.Wpf.ViewModels;
@@ -41,6 +42,8 @@ public sealed class MainPageViewModel : BindableBase, IDisposable
     private readonly ShellRefreshCoordinator _shellRefreshCoordinator;
     private readonly MainPageNavigationSectionViewModel _navigationSection = new();
     private readonly MainPageChromeSectionViewModel _chromeSection = new();
+    private readonly ObservableCollection<ContextCommandDescriptor> _activeWorkspaceContextCommands = [];
+    private readonly ReadOnlyObservableCollection<ContextCommandDescriptor> _activeWorkspaceContextCommandsView;
 
     private bool _suppressNavigation;
     private bool _suppressOperatingContextSelection;
@@ -90,6 +93,7 @@ public sealed class MainPageViewModel : BindableBase, IDisposable
         _operatorInboxPresentation = operatorInboxPresentation ?? new OperatorInboxViewModel();
         _workflowSummaryStrip = workflowSummaryStrip ?? new WorkflowSummaryStripViewModel();
         _shellRefreshCoordinator = shellRefreshCoordinator ?? new ShellRefreshCoordinator();
+        _activeWorkspaceContextCommandsView = new ReadOnlyObservableCollection<ContextCommandDescriptor>(_activeWorkspaceContextCommands);
 
         SplitPane = new SplitPaneViewModel(shellRouteRegistry);
         PaneHost = SplitPane;
@@ -176,6 +180,10 @@ public sealed class MainPageViewModel : BindableBase, IDisposable
     public ReadOnlyObservableCollection<PrimaryOperatorWorkflowStep> PrimaryOperatorWorkflowSteps => WorkflowSection.PrimaryOperatorWorkflowSteps;
 
     public ReadOnlyObservableCollection<BoundedWindowMode> WindowModes => _navigationSection.WindowModes;
+
+    public ReadOnlyObservableCollection<ContextCommandDescriptor> ActiveWorkspaceContextCommands => _activeWorkspaceContextCommandsView;
+
+    public Visibility ActiveWorkspaceContextCommandsVisibility => _activeWorkspaceContextCommands.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
 
     internal MainPageNavigationSectionViewModel NavigationSection => _navigationSection;
 
@@ -668,6 +676,22 @@ public sealed class MainPageViewModel : BindableBase, IDisposable
     {
         BackButtonVisibility = _navigationService.CanGoBack ? Visibility.Visible : Visibility.Collapsed;
         GoBackCommand.NotifyCanExecuteChanged();
+    }
+
+
+    public void SetActiveWorkspaceContextCommandSource(object? source)
+    {
+        _activeWorkspaceContextCommands.Clear();
+
+        if (source is IWorkspaceContextCommandProvider provider)
+        {
+            foreach (var command in provider.ContextCommands)
+            {
+                _activeWorkspaceContextCommands.Add(command);
+            }
+        }
+
+        OnPropertyChanged(nameof(ActiveWorkspaceContextCommandsVisibility));
     }
 
     public void Dispose()

--- a/src/Meridian.Wpf/Views/MainPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/MainPage.xaml.cs
@@ -54,6 +54,17 @@ public partial class MainPage : Page
     private void OnContentFrameNavigated(object sender, WpfNavigationEventArgs e)
     {
         _viewModel.SyncNavigationState();
+        _viewModel.SetActiveWorkspaceContextCommandSource(ResolveContextCommandSource(e.Content));
+    }
+
+    private static object? ResolveContextCommandSource(object? content)
+    {
+        if (content is FrameworkElement { DataContext: { } dataContext })
+        {
+            return dataContext;
+        }
+
+        return content;
     }
 
     private bool TryHandleCommandPaletteDirectionalKey(Key key)

--- a/src/Meridian.Wpf/Views/WorkspaceCommandSurfaceControl.xaml
+++ b/src/Meridian.Wpf/Views/WorkspaceCommandSurfaceControl.xaml
@@ -1,6 +1,7 @@
 <UserControl x:Class="Meridian.Wpf.Views.WorkspaceCommandSurfaceControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:workstationControls="clr-namespace:Meridian.Wpf.Workstation.Controls"
              x:Name="Root"
              AutomationProperties.AutomationId="{Binding SurfaceAutomationId, RelativeSource={RelativeSource Self}}"
              AutomationProperties.Name="Workspace Command Surface">
@@ -221,6 +222,9 @@
                     </WrapPanel>
 
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                        <workstationControls:ContextCommandToolbarControl Commands="{Binding ActiveWorkspaceContextCommands}"
+                                                                           Visibility="{Binding ActiveWorkspaceContextCommandsVisibility}"
+                                                                           ToolbarAutomationId="ActiveWorkspaceContextCommandToolbar" />
                         <Button Style="{StaticResource SecondaryButtonStyle}"
                                 ToolTip="Choose operating context"
                                 Margin="0,0,8,0"

--- a/src/Meridian.Wpf/Workstation/Commands/ContextCommandDescriptor.cs
+++ b/src/Meridian.Wpf/Workstation/Commands/ContextCommandDescriptor.cs
@@ -1,0 +1,136 @@
+using System.Windows.Input;
+using Meridian.Wpf.ViewModels;
+
+namespace Meridian.Wpf.Workstation.Commands;
+
+public sealed class ContextCommandDescriptor : BindableBase
+{
+    private string _label = string.Empty;
+    private string _iconGlyph = string.Empty;
+    private ICommand? _command;
+    private object? _commandParameter;
+    private string _disabledReason = string.Empty;
+    private ContextCommandImportance _importance = ContextCommandImportance.Secondary;
+    private string _automationId = string.Empty;
+    private bool _isVisible = true;
+    private bool _isBusy;
+    private string _busyText = string.Empty;
+
+    public string Label
+    {
+        get => _label;
+        set
+        {
+            if (SetProperty(ref _label, value))
+            {
+                OnPropertyChanged(nameof(EffectiveAutomationId));
+                OnPropertyChanged(nameof(EffectiveToolTip));
+            }
+        }
+    }
+
+    public string IconGlyph
+    {
+        get => _iconGlyph;
+        set => SetProperty(ref _iconGlyph, value);
+    }
+
+    public ICommand? Command
+    {
+        get => _command;
+        set => SetProperty(ref _command, value);
+    }
+
+    public object? CommandParameter
+    {
+        get => _commandParameter;
+        set => SetProperty(ref _commandParameter, value);
+    }
+
+    public string DisabledReason
+    {
+        get => _disabledReason;
+        set
+        {
+            if (SetProperty(ref _disabledReason, value))
+            {
+                OnPropertyChanged(nameof(EffectiveToolTip));
+            }
+        }
+    }
+
+    public ContextCommandImportance Importance
+    {
+        get => _importance;
+        set => SetProperty(ref _importance, value);
+    }
+
+    public string AutomationId
+    {
+        get => _automationId;
+        set
+        {
+            if (SetProperty(ref _automationId, value))
+            {
+                OnPropertyChanged(nameof(EffectiveAutomationId));
+            }
+        }
+    }
+
+    public bool IsVisible
+    {
+        get => _isVisible;
+        set => SetProperty(ref _isVisible, value);
+    }
+
+    public bool IsBusy
+    {
+        get => _isBusy;
+        set
+        {
+            if (SetProperty(ref _isBusy, value))
+            {
+                OnPropertyChanged(nameof(EffectiveToolTip));
+            }
+        }
+    }
+
+    public string BusyText
+    {
+        get => _busyText;
+        set
+        {
+            if (SetProperty(ref _busyText, value))
+            {
+                OnPropertyChanged(nameof(EffectiveToolTip));
+            }
+        }
+    }
+
+    public string EffectiveAutomationId => string.IsNullOrWhiteSpace(AutomationId)
+        ? $"ContextCommand{NormalizeAutomationId(Label)}"
+        : AutomationId;
+
+    public string EffectiveToolTip
+    {
+        get
+        {
+            if (IsBusy)
+            {
+                return string.IsNullOrWhiteSpace(BusyText) ? "Working…" : BusyText;
+            }
+
+            return string.IsNullOrWhiteSpace(DisabledReason) ? Label : DisabledReason;
+        }
+    }
+
+    private static string NormalizeAutomationId(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "Action";
+        }
+
+        return new string(value.Where(char.IsLetterOrDigit).ToArray());
+    }
+}

--- a/src/Meridian.Wpf/Workstation/Commands/ContextCommandImportance.cs
+++ b/src/Meridian.Wpf/Workstation/Commands/ContextCommandImportance.cs
@@ -1,0 +1,8 @@
+namespace Meridian.Wpf.Workstation.Commands;
+
+public enum ContextCommandImportance
+{
+    Primary,
+    Secondary,
+    Overflow
+}

--- a/src/Meridian.Wpf/Workstation/Commands/IWorkspaceContextCommandProvider.cs
+++ b/src/Meridian.Wpf/Workstation/Commands/IWorkspaceContextCommandProvider.cs
@@ -1,0 +1,8 @@
+using System.Collections.ObjectModel;
+
+namespace Meridian.Wpf.Workstation.Commands;
+
+public interface IWorkspaceContextCommandProvider
+{
+    ReadOnlyObservableCollection<ContextCommandDescriptor> ContextCommands { get; }
+}

--- a/src/Meridian.Wpf/Workstation/Controls/ContextCommandToolbarControl.xaml
+++ b/src/Meridian.Wpf/Workstation/Controls/ContextCommandToolbarControl.xaml
@@ -1,0 +1,53 @@
+<UserControl x:Class="Meridian.Wpf.Workstation.Controls.ContextCommandToolbarControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="Root"
+             AutomationProperties.AutomationId="{Binding ElementName=Root, Path=ToolbarAutomationId}"
+             AutomationProperties.Name="Workspace context commands">
+    <ItemsControl ItemsSource="{Binding ElementName=Root, Path=Commands}">
+        <ItemsControl.ItemsPanel>
+            <ItemsPanelTemplate>
+                <WrapPanel HorizontalAlignment="Right" />
+            </ItemsPanelTemplate>
+        </ItemsControl.ItemsPanel>
+        <ItemsControl.ItemTemplate>
+            <DataTemplate>
+                <Button Margin="0,0,8,8"
+                        Command="{Binding Command}"
+                        CommandParameter="{Binding CommandParameter}"
+                        ToolTip="{Binding EffectiveToolTip}"
+                        ToolTipService.ShowOnDisabled="True"
+                        AutomationProperties.AutomationId="{Binding EffectiveAutomationId}"
+                        AutomationProperties.Name="{Binding Label}">
+                    <Button.Style>
+                        <Style TargetType="Button" BasedOn="{StaticResource GhostButtonStyle}">
+                            <Setter Property="Visibility" Value="Visible" />
+                            <Setter Property="Padding" Value="12,8" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Importance}" Value="Primary">
+                                    <Setter Property="Background" Value="{StaticResource InfoColorBrush}" />
+                                    <Setter Property="Foreground" Value="White" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding IsVisible}" Value="False">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding IsBusy}" Value="True">
+                                    <Setter Property="Opacity" Value="0.72" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{Binding IconGlyph}"
+                                   FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                   FontSize="14"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,8,0" />
+                        <TextBlock Text="{Binding Label}"
+                                   VerticalAlignment="Center" />
+                    </StackPanel>
+                </Button>
+            </DataTemplate>
+        </ItemsControl.ItemTemplate>
+    </ItemsControl>
+</UserControl>

--- a/src/Meridian.Wpf/Workstation/Controls/ContextCommandToolbarControl.xaml.cs
+++ b/src/Meridian.Wpf/Workstation/Controls/ContextCommandToolbarControl.xaml.cs
@@ -1,0 +1,40 @@
+using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Controls;
+using Meridian.Wpf.Workstation.Commands;
+
+namespace Meridian.Wpf.Workstation.Controls;
+
+public partial class ContextCommandToolbarControl : UserControl
+{
+    public static readonly DependencyProperty CommandsProperty =
+        DependencyProperty.Register(
+            nameof(Commands),
+            typeof(ReadOnlyObservableCollection<ContextCommandDescriptor>),
+            typeof(ContextCommandToolbarControl),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty ToolbarAutomationIdProperty =
+        DependencyProperty.Register(
+            nameof(ToolbarAutomationId),
+            typeof(string),
+            typeof(ContextCommandToolbarControl),
+            new PropertyMetadata("WorkspaceContextCommandToolbar"));
+
+    public ContextCommandToolbarControl()
+    {
+        InitializeComponent();
+    }
+
+    public ReadOnlyObservableCollection<ContextCommandDescriptor>? Commands
+    {
+        get => (ReadOnlyObservableCollection<ContextCommandDescriptor>?)GetValue(CommandsProperty);
+        set => SetValue(CommandsProperty, value);
+    }
+
+    public string ToolbarAutomationId
+    {
+        get => (string)GetValue(ToolbarAutomationIdProperty);
+        set => SetValue(ToolbarAutomationIdProperty, value);
+    }
+}

--- a/tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs
@@ -18,6 +18,7 @@ using Meridian.Wpf.Tests.Services;
 using Meridian.Wpf.Tests.Support;
 using Meridian.Wpf.ViewModels;
 using Meridian.Wpf.Views;
+using Meridian.Wpf.Workstation.Commands;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit.Sdk;
 
@@ -77,6 +78,84 @@ public sealed class MainShellViewModelTests
             fixtureModeDetector,
             authenticationSession ?? DesktopAuthenticationSessionTests.CreateSession("Development"),
             Substitute.For<IStatusService>());
+    }
+
+
+    [Fact]
+    public void ActiveWorkspaceContextCommands_WhenProviderIsActivated_PublishesVisibleCommands()
+    {
+        WpfTestThread.Run(() =>
+        {
+            using var vm = CreateMainPageViewModel();
+            var command = new ContextCommandDescriptor
+            {
+                Label = "Inspect Run",
+                IconGlyph = "\uE8A5",
+                Command = new RelayCommand(() => { }),
+                Importance = ContextCommandImportance.Primary,
+                AutomationId = "InspectRunContextCommand"
+            };
+            var provider = new TestContextCommandProvider(command);
+
+            vm.SetActiveWorkspaceContextCommandSource(provider);
+
+            vm.ActiveWorkspaceContextCommands.Should().ContainSingle().Which.Should().BeSameAs(command);
+            vm.ActiveWorkspaceContextCommandsVisibility.Should().Be(Visibility.Visible);
+        });
+    }
+
+    [Fact]
+    public void ActiveWorkspaceContextCommands_WhenProviderChanges_ReplacesPreviousWorkspaceCommands()
+    {
+        WpfTestThread.Run(() =>
+        {
+            using var vm = CreateMainPageViewModel();
+            var first = new ContextCommandDescriptor { Label = "Open Detail", Command = new RelayCommand(() => { }) };
+            var second = new ContextCommandDescriptor { Label = "Open Ledger", Command = new RelayCommand(() => { }) };
+
+            vm.SetActiveWorkspaceContextCommandSource(new TestContextCommandProvider(first));
+            vm.SetActiveWorkspaceContextCommandSource(new TestContextCommandProvider(second));
+
+            vm.ActiveWorkspaceContextCommands.Should().ContainSingle().Which.Label.Should().Be("Open Ledger");
+            vm.ActiveWorkspaceContextCommands.Should().NotContain(first);
+        });
+    }
+
+    [Fact]
+    public void ActiveWorkspaceContextCommands_WhenSourceDoesNotPublishCommands_ClearsToolbar()
+    {
+        WpfTestThread.Run(() =>
+        {
+            using var vm = CreateMainPageViewModel();
+            vm.SetActiveWorkspaceContextCommandSource(new TestContextCommandProvider(
+                new ContextCommandDescriptor { Label = "Refresh", Command = new RelayCommand(() => { }) }));
+
+            vm.SetActiveWorkspaceContextCommandSource(new object());
+
+            vm.ActiveWorkspaceContextCommands.Should().BeEmpty();
+            vm.ActiveWorkspaceContextCommandsVisibility.Should().Be(Visibility.Collapsed);
+        });
+    }
+
+    [Fact]
+    public void ContextCommandDescriptor_DisabledAndBusyStates_AreViewModelOwned()
+    {
+        var descriptor = new ContextCommandDescriptor
+        {
+            Label = "Compare Runs",
+            AutomationId = "CompareRunsContextCommand",
+            DisabledReason = "Select two runs to compare.",
+            IsVisible = false
+        };
+
+        descriptor.EffectiveAutomationId.Should().Be("CompareRunsContextCommand");
+        descriptor.EffectiveToolTip.Should().Be("Select two runs to compare.");
+        descriptor.IsVisible.Should().BeFalse();
+
+        descriptor.IsBusy = true;
+        descriptor.BusyText = "Comparing selected runs…";
+
+        descriptor.EffectiveToolTip.Should().Be("Comparing selected runs…");
     }
 
     [Fact]
@@ -1470,5 +1549,19 @@ public sealed class MainShellViewModelTests
 
             return Task.FromResult(_inbox);
         }
+    }
+
+
+    private sealed class TestContextCommandProvider : IWorkspaceContextCommandProvider
+    {
+        private readonly ObservableCollection<ContextCommandDescriptor> _commands;
+
+        public TestContextCommandProvider(params ContextCommandDescriptor[] commands)
+        {
+            _commands = new ObservableCollection<ContextCommandDescriptor>(commands);
+            ContextCommands = new ReadOnlyObservableCollection<ContextCommandDescriptor>(_commands);
+        }
+
+        public ReadOnlyObservableCollection<ContextCommandDescriptor> ContextCommands { get; }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a consistent, reusable way for workspace pages to publish context-specific commands so shell chrome does not hard-wire availability or busy/disabled state in XAML. 
- Ensure command availability, disabled reasons, busy state, visibility, and automation IDs are owned by view models so active-workspace switching is deterministic and testable.

### Description
- Add a view-model-first command contract: `ContextCommandDescriptor`, `ContextCommandImportance`, and `IWorkspaceContextCommandProvider` to represent label, glyph, `ICommand`, parameter, disabled reason, importance, busy state, visibility, and automation metadata. 
- Add `ContextCommandToolbarControl` (XAML + code-behind) that binds to a `ReadOnlyObservableCollection<ContextCommandDescriptor>` and renders primary/secondary styling, busy/disabled tooltips, and stable automation IDs. 
- Wire the toolbar into the shell by inserting `ContextCommandToolbarControl` into `WorkspaceCommandSurfaceControl.xaml` and mirror the active page/provider into `MainPageViewModel.ActiveWorkspaceContextCommands` via `SetActiveWorkspaceContextCommandSource`, with `MainPage` resolving the navigated page `DataContext` as the provider. 
- Update `src/Meridian.Wpf/README.md` to document the provider/descriptor/toolbar pattern and add focused unit tests in `tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs` that exercise publication, replacement/clearing on active-workspace changes, visibility/disabled reasons, and busy tooltip behavior.

### Testing
- Ran `git diff --check` to validate whitespace/merge problems and it passed. 
- Added focused unit tests under `tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs` covering `ActiveWorkspaceContextCommands` publication, replacement, clearing, and `ContextCommandDescriptor` tooltip/automation behavior, but `dotnet test` could not be executed in this environment because `dotnet` is not installed here. 
- No other automated test suites were executed in this container; tests are runnable locally or in CI with `dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj -c Release /p:EnableWindowsTargeting=true --filter "FullyQualifiedName~MainShellViewModelTests"`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a306a7a1d54832084b7ad3995892942)