### PR TITLE
Optimize order book heatmap render loop

### DIFF
--- a/src/Meridian.Wpf/ViewModels/OrderBookHeatmapViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/OrderBookHeatmapViewModel.cs
@@ -43,6 +43,7 @@ public sealed class OrderBookHeatmapViewModel : BindableBase
     private double _priceMin;
     private double _priceMax;
     private double _controlHeight = 200.0;
+    private long _renderVersion;
 
     // ── Packed Bgra32 color constants: (A<<24)|(R<<16)|(G<<8)|B ───────────────
 
@@ -56,6 +57,12 @@ public sealed class OrderBookHeatmapViewModel : BindableBase
     public ObservableCollection<PriceLabelViewModel> PriceLabels { get; } = new();
 
     /// <summary>
+    /// Monotonic version incremented whenever inputs that affect the rendered bitmap change.
+    /// The WPF control uses this as a lightweight dirty flag so idle timer ticks do not redraw.
+    /// </summary>
+    public long RenderVersion => _renderVersion;
+
+    /// <summary>
     /// Called by the UserControl code-behind whenever the control is resized so
     /// price-label Y positions stay accurate.
     /// </summary>
@@ -63,6 +70,7 @@ public sealed class OrderBookHeatmapViewModel : BindableBase
     {
         _controlHeight = height > 0 ? height : 200.0;
         UpdatePriceLabels();
+        _renderVersion++;
     }
 
     /// <summary>
@@ -136,6 +144,7 @@ public sealed class OrderBookHeatmapViewModel : BindableBase
         _priceMax = highestAsk + margin;
 
         UpdatePriceLabels();
+        _renderVersion++;
     }
 
     // ── Hot path — NO allocations, NO LINQ ────────────────────────────────────

--- a/src/Meridian.Wpf/Views/OrderBookHeatmapControl.xaml.cs
+++ b/src/Meridian.Wpf/Views/OrderBookHeatmapControl.xaml.cs
@@ -16,8 +16,8 @@ namespace Meridian.Wpf.Views;
 /// • <see cref="_pixelBuffer"/> (int[]) is reused every frame; filled by
 ///   <see cref="OrderBookHeatmapViewModel.RenderFrame"/> and then bulk-copied to the
 ///   BackBuffer via <c>Marshal.Copy</c>.
-/// • The render loop runs at 30 fps on the UI thread via <see cref="DispatcherTimer"/>
-///   so WriteableBitmap Lock/Unlock never crosses thread boundaries.
+/// • The render loop runs at a modest cadence on the UI thread via <see cref="DispatcherTimer"/>
+///   and only redraws when the view-model render version changes, so idle ticks avoid bitmap work.
 /// • Business logic lives entirely in <see cref="OrderBookHeatmapViewModel"/>;
 ///   this file is limited to lifecycle + bitmap plumbing.
 /// </summary>
@@ -25,6 +25,7 @@ public partial class OrderBookHeatmapControl : System.Windows.Controls.UserContr
 {
     private WriteableBitmap? _bitmap;
     private int[]? _pixelBuffer;
+    private long _lastRenderedVersion = -1;
 
     private readonly DispatcherTimer _renderTimer;
 
@@ -34,20 +35,21 @@ public partial class OrderBookHeatmapControl : System.Windows.Controls.UserContr
 
         _renderTimer = new DispatcherTimer(DispatcherPriority.Render)
         {
-            Interval = TimeSpan.FromMilliseconds(33) // ~30 fps
+            Interval = TimeSpan.FromMilliseconds(66) // ~15 fps; dirty-version gated for idle snapshots
         };
         _renderTimer.Tick += OnRenderTick;
+        IsVisibleChanged += OnIsVisibleChanged;
     }
 
     // ── Lifecycle ─────────────────────────────────────────────────────────────
 
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
-        _renderTimer.Start();
-
         // Create the initial bitmap if the control is already sized.
         if (ActualWidth > 1 && ActualHeight > 1)
             RecreateBuffer((int)ActualWidth, (int)ActualHeight);
+
+        UpdateRenderTimerState();
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
@@ -55,6 +57,7 @@ public partial class OrderBookHeatmapControl : System.Windows.Controls.UserContr
         _renderTimer.Stop();
         _bitmap = null;
         _pixelBuffer = null;
+        _lastRenderedVersion = -1;
     }
 
     private void OnSizeChanged(object sender, SizeChangedEventArgs e)
@@ -63,6 +66,15 @@ public partial class OrderBookHeatmapControl : System.Windows.Controls.UserContr
         int h = (int)e.NewSize.Height;
         if (w > 1 && h > 1)
             RecreateBuffer(w, h);
+        else
+            ReleaseBuffer();
+
+        UpdateRenderTimerState();
+    }
+
+    private void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        UpdateRenderTimerState();
     }
 
     // ── Buffer management ─────────────────────────────────────────────────────
@@ -74,9 +86,41 @@ public partial class OrderBookHeatmapControl : System.Windows.Controls.UserContr
 
         _bitmap = new WriteableBitmap(w, h, 96, 96, PixelFormats.Bgra32, null);
         _pixelBuffer = new int[w * h];
+        _lastRenderedVersion = -1;
         HeatmapImage.Source = _bitmap;
 
         (DataContext as OrderBookHeatmapViewModel)?.SetControlHeight(h);
+    }
+
+    private void ReleaseBuffer()
+    {
+        _bitmap = null;
+        _pixelBuffer = null;
+        _lastRenderedVersion = -1;
+        HeatmapImage.Source = null;
+    }
+
+    private void UpdateRenderTimerState()
+    {
+        if (IsLoaded && IsVisible && HasValidBitmapSize())
+            _renderTimer.Start();
+        else
+            _renderTimer.Stop();
+    }
+
+    private bool HasValidBitmapSize()
+    {
+        return _bitmap is { PixelWidth: > 1, PixelHeight: > 1 } && _pixelBuffer is { Length: > 0 };
+    }
+
+    internal static bool TryObserveRenderVersion(OrderBookHeatmapViewModel vm, ref long lastRenderedVersion)
+    {
+        long currentVersion = vm.RenderVersion;
+        if (currentVersion == lastRenderedVersion)
+            return false;
+
+        lastRenderedVersion = currentVersion;
+        return true;
     }
 
     // ── Render loop ───────────────────────────────────────────────────────────
@@ -84,7 +128,13 @@ public partial class OrderBookHeatmapControl : System.Windows.Controls.UserContr
     private void OnRenderTick(object? sender, EventArgs e)
     {
         var vm = DataContext as OrderBookHeatmapViewModel;
-        if (vm is null || _bitmap is null || _pixelBuffer is null)
+        if (vm is null || _bitmap is null || _pixelBuffer is null || !IsVisible || !HasValidBitmapSize())
+        {
+            UpdateRenderTimerState();
+            return;
+        }
+
+        if (!TryObserveRenderVersion(vm, ref _lastRenderedVersion))
             return;
 
         int w = _bitmap.PixelWidth;

--- a/tests/Meridian.Wpf.Tests/ViewModels/OrderBookHeatmapViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/OrderBookHeatmapViewModelTests.cs
@@ -1,0 +1,44 @@
+using Meridian.Wpf.Models;
+using Meridian.Wpf.ViewModels;
+using Meridian.Wpf.Views;
+
+namespace Meridian.Wpf.Tests.ViewModels;
+
+public sealed class OrderBookHeatmapViewModelTests
+{
+    [Fact]
+    public void RenderVersion_IncrementsWhenSnapshotOrControlHeightChanges()
+    {
+        var viewModel = new OrderBookHeatmapViewModel();
+        long initialVersion = viewModel.RenderVersion;
+
+        viewModel.SetControlHeight(240);
+
+        viewModel.RenderVersion.Should().Be(initialVersion + 1);
+
+        viewModel.UpdateFromSnapshot(
+            new[] { new OrderBookDisplayLevel { RawPrice = 100.00m, RawSize = 10 } },
+            new[] { new OrderBookDisplayLevel { RawPrice = 100.05m, RawSize = 12 } });
+
+        viewModel.RenderVersion.Should().Be(initialVersion + 2);
+    }
+
+    [Fact]
+    public void TryObserveRenderVersion_ReturnsFalseForRepeatedTicksWithoutSnapshotChanges()
+    {
+        var viewModel = new OrderBookHeatmapViewModel();
+        long observedVersion = -1;
+
+        OrderBookHeatmapControl.TryObserveRenderVersion(viewModel, ref observedVersion).Should().BeTrue();
+
+        OrderBookHeatmapControl.TryObserveRenderVersion(viewModel, ref observedVersion).Should().BeFalse(
+            "a second timer tick with the same render version must skip RenderFrame and bitmap copy work");
+
+        viewModel.UpdateFromSnapshot(
+            new[] { new OrderBookDisplayLevel { RawPrice = 100.00m, RawSize = 10 } },
+            new[] { new OrderBookDisplayLevel { RawPrice = 100.05m, RawSize = 12 } });
+
+        OrderBookHeatmapControl.TryObserveRenderVersion(viewModel, ref observedVersion).Should().BeTrue();
+        OrderBookHeatmapControl.TryObserveRenderVersion(viewModel, ref observedVersion).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce unnecessary UI work and CPU during idle heatmap ticks by avoiding full-frame copies when the underlying snapshot has not changed.
- Prevent wasted rendering when the control is not visible, unloaded, or has no valid bitmap size, and reduce default frame cadence to lower steady-state load.

### Description
- Add a monotonic `RenderVersion` counter to `OrderBookHeatmapViewModel` that is incremented from `UpdateFromSnapshot` and `SetControlHeight` so consumers can detect dirty state via `vm.RenderVersion`.
- Gate the control render path in `OrderBookHeatmapControl.OnRenderTick` so `RenderFrame`, `Marshal.Copy`, and `AddDirtyRect` are skipped when the observed version has not changed by introducing `TryObserveRenderVersion` and `_lastRenderedVersion`.
- Pause or stop the `DispatcherTimer` when the control is unloaded, not visible, collapsed, or has no valid bitmap size, and add `UpdateRenderTimerState`, `HasValidBitmapSize`, `ReleaseBuffer`, and `OnIsVisibleChanged` helpers.
- Reduce timer cadence from ~30 fps to ~15 fps and add a small characterization test class `tests/Meridian.Wpf.Tests/ViewModels/OrderBookHeatmapViewModelTests.cs` that verifies `RenderVersion` increments and that repeated observations without snapshot changes return `false`.

### Testing
- Added unit tests in `tests/Meridian.Wpf.Tests/ViewModels/OrderBookHeatmapViewModelTests.cs` covering `RenderVersion` increments and `TryObserveRenderVersion` behavior.
- Repository checks (`git diff --check` / `git diff --cached --check`) ran cleanly for the changed files.
- Attempted to run `dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj --filter "FullyQualifiedName~OrderBookHeatmapViewModelTests"`, but the test invocation could not be executed in this environment because `dotnet` is not available; the new tests are expected to pass on the CI/Windows test host.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a306cd208648320bf4e64991dc4e2ed)