### PR TITLE
Optimize DenseDataGrid selection sync and empty-state checks

### DIFF
--- a/src/Meridian.Wpf/Workstation/Controls/CollectionSynchronizationHelper.cs
+++ b/src/Meridian.Wpf/Workstation/Controls/CollectionSynchronizationHelper.cs
@@ -1,0 +1,192 @@
+using System.Collections;
+using System.Collections.ObjectModel;
+
+namespace Meridian.Wpf.Workstation.Controls;
+
+internal static class CollectionSynchronizationHelper
+{
+    public static IEnumerable? GetRuntimeRows(object? table)
+    {
+        if (table is null)
+        {
+            return null;
+        }
+
+        var tableType = table.GetType();
+        while (tableType is not null)
+        {
+            var rowsProperty = tableType.GetProperty("Rows", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.DeclaredOnly);
+            if (rowsProperty?.GetValue(table) is IEnumerable runtimeRows)
+            {
+                return runtimeRows;
+            }
+
+            tableType = tableType.BaseType;
+        }
+
+        return null;
+    }
+
+    public static bool HasItems(IEnumerable? items)
+        => TryGetCount(items, out var count) ? count > 0 : HasAny(items);
+
+    public static bool TryGetCount(IEnumerable? items, out int count)
+    {
+        switch (items)
+        {
+            case null:
+                count = 0;
+                return true;
+            case ICollection collection:
+                count = collection.Count;
+                return true;
+        }
+
+        var itemsType = items.GetType();
+        foreach (var interfaceType in itemsType.GetInterfaces().Prepend(itemsType))
+        {
+            if (!interfaceType.IsGenericType)
+            {
+                continue;
+            }
+
+            var definition = interfaceType.GetGenericTypeDefinition();
+            if (definition != typeof(ICollection<>) && definition != typeof(IReadOnlyCollection<>))
+            {
+                continue;
+            }
+
+            var countProperty = interfaceType.GetProperty(nameof(ICollection<object>.Count));
+            if (countProperty?.GetValue(items) is int genericCount)
+            {
+                count = genericCount;
+                return true;
+            }
+        }
+
+        count = 0;
+        return false;
+    }
+
+    public static bool ContainsAnyByReference(IEnumerable? source, IEnumerable? candidates)
+    {
+        if (source is null || candidates is null)
+        {
+            return false;
+        }
+
+        HashSet<object> sourceItems = new(ReferenceEqualityComparer.Instance);
+        foreach (var item in source)
+        {
+            if (item is not null)
+            {
+                sourceItems.Add(item);
+            }
+        }
+
+        foreach (var candidate in candidates)
+        {
+            if (candidate is not null && sourceItems.Contains(candidate))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static bool AnyMissingByReference(IEnumerable? source, IList selectedItems)
+    {
+        if (selectedItems.Count == 0)
+        {
+            return false;
+        }
+
+        if (source is null)
+        {
+            return true;
+        }
+
+        HashSet<object> sourceItems = new(ReferenceEqualityComparer.Instance);
+        foreach (var item in source)
+        {
+            if (item is not null)
+            {
+                sourceItems.Add(item);
+            }
+        }
+
+        foreach (var selectedItem in selectedItems)
+        {
+            if (selectedItem is null || !sourceItems.Contains(selectedItem))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static void SynchronizeByReference(ObservableCollection<object> target, IEnumerable source)
+    {
+        var desired = source.Cast<object>().ToList();
+
+        for (var index = target.Count - 1; index >= 0; index--)
+        {
+            if (!desired.Contains(target[index], ReferenceEqualityComparer.Instance))
+            {
+                target.RemoveAt(index);
+            }
+        }
+
+        for (var index = 0; index < desired.Count; index++)
+        {
+            var desiredItem = desired[index];
+            var existingIndex = IndexOfReference(target, desiredItem);
+            if (existingIndex == index)
+            {
+                continue;
+            }
+
+            if (existingIndex >= 0)
+            {
+                target.Move(existingIndex, index);
+            }
+            else
+            {
+                target.Insert(index, desiredItem);
+            }
+        }
+    }
+
+    private static bool HasAny(IEnumerable? items)
+    {
+        if (items is null)
+        {
+            return false;
+        }
+
+        var enumerator = items.GetEnumerator();
+        try
+        {
+            return enumerator.MoveNext();
+        }
+        finally
+        {
+            (enumerator as IDisposable)?.Dispose();
+        }
+    }
+
+    private static int IndexOfReference(IList target, object item)
+    {
+        for (var index = 0; index < target.Count; index++)
+        {
+            if (ReferenceEquals(target[index], item))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+}

--- a/src/Meridian.Wpf/Workstation/Controls/DenseDataGridControl.xaml.cs
+++ b/src/Meridian.Wpf/Workstation/Controls/DenseDataGridControl.xaml.cs
@@ -1,7 +1,6 @@
 using System.Collections;
 using System.Collections.Specialized;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -121,6 +120,9 @@ public partial class DenseDataGridControl : UserControl
         }
     }
 
+    private IEnumerable? GetRows()
+        => CollectionSynchronizationHelper.GetRuntimeRows(Table);
+
     private void RebuildColumns()
     {
         var gridView = new GridView
@@ -150,7 +152,7 @@ public partial class DenseDataGridControl : UserControl
     {
         DetachRowsCollection();
 
-        _observedRows = Table?.Rows as INotifyCollectionChanged;
+        _observedRows = GetRows() as INotifyCollectionChanged;
         if (_observedRows is not null)
         {
             _observedRows.CollectionChanged += OnRowsChanged;
@@ -160,7 +162,33 @@ public partial class DenseDataGridControl : UserControl
     private void OnRowsChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         UpdateEmptyState();
-        MirrorSelectedRows();
+        if (SelectedRowsMayHaveChanged(e))
+        {
+            MirrorSelectedRows();
+        }
+    }
+
+    private bool SelectedRowsMayHaveChanged(NotifyCollectionChangedEventArgs e)
+    {
+        if (RowsList is null)
+        {
+            return false;
+        }
+
+        if (e.Action is NotifyCollectionChangedAction.Remove or NotifyCollectionChangedAction.Replace)
+        {
+            return CollectionSynchronizationHelper.ContainsAnyByReference(e.OldItems, SelectedItems)
+                || CollectionSynchronizationHelper.ContainsAnyByReference(e.OldItems, RowsList.SelectedItems);
+        }
+
+        if (e.Action is NotifyCollectionChangedAction.Reset)
+        {
+            var rows = GetRows();
+            return CollectionSynchronizationHelper.AnyMissingByReference(rows, RowsList.SelectedItems)
+                || (SelectedItems is not null && CollectionSynchronizationHelper.AnyMissingByReference(rows, SelectedItems));
+        }
+
+        return false;
     }
 
     private void DetachRowsCollection()
@@ -181,7 +209,7 @@ public partial class DenseDataGridControl : UserControl
             return;
         }
 
-        var hasRows = Table?.Rows is IEnumerable rows && rows.Cast<object>().Any();
+        var hasRows = CollectionSynchronizationHelper.HasItems(GetRows());
         EmptyPanel.Visibility = hasRows ? Visibility.Collapsed : Visibility.Visible;
     }
 
@@ -196,10 +224,6 @@ public partial class DenseDataGridControl : UserControl
             return;
         }
 
-        selectedItems.Clear();
-        foreach (var selectedItem in RowsList.SelectedItems.Cast<object>())
-        {
-            selectedItems.Add(selectedItem);
-        }
+        CollectionSynchronizationHelper.SynchronizeByReference(selectedItems, RowsList.SelectedItems);
     }
 }

--- a/tests/Meridian.Wpf.Tests/Views/WorkstationPrimitiveControlsTests.cs
+++ b/tests/Meridian.Wpf.Tests/Views/WorkstationPrimitiveControlsTests.cs
@@ -1,4 +1,7 @@
+using System.Collections;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Reflection;
 using System.IO;
 using System.Windows;
 using System.Windows.Automation;
@@ -259,6 +262,116 @@ public sealed class WorkstationPrimitiveControlsTests
     }
 
     [Fact]
+    public void DenseDataGridControl_ShouldUseNativeCountsForLargeRowCollections()
+    {
+        var helperType = typeof(DenseDataGridControl).Assembly.GetType(
+            "Meridian.Wpf.Workstation.Controls.CollectionSynchronizationHelper", throwOnError: true)!;
+        var hasItems = helperType.GetMethod("HasItems", BindingFlags.Static | BindingFlags.Public)!;
+
+        hasItems.Invoke(null, [new CountingRows(100_000)]).Should().Be(true);
+        hasItems.Invoke(null, [new CountingRows(0)]).Should().Be(false);
+    }
+
+    [Fact]
+    public void DenseDataGridControl_ShouldPreserveMultiSelectionWithoutLowValueMirrorChurn()
+    {
+        WpfTestThread.Run(() =>
+        {
+            RunMatUiAutomationFacade.EnsureApplicationResources();
+
+            var tableRows = new ObservableCollection<RowFixture>
+            {
+                new("Polygon.io", "Healthy"),
+                new("Alpaca", "Degraded"),
+                new("IEX", "Healthy")
+            };
+            var selectedRows = new ObservableCollection<object>();
+            var denseGrid = new DenseDataGridControl
+            {
+                Table = new WorkstationTableModel<RowFixture>(
+                    tableRows,
+                    [new("Provider", nameof(RowFixture.Name), 120), new("Status", nameof(RowFixture.Status), 100)],
+                    "Provider readiness table"),
+                SelectionMode = SelectionMode.Extended,
+                SelectedItems = selectedRows
+            };
+
+            var window = Show(denseGrid);
+            try
+            {
+                var rowsList = denseGrid.FindName("RowsList").Should().BeOfType<ListView>().Subject;
+                rowsList.SelectedItems.Add(tableRows[0]);
+                rowsList.SelectedItems.Add(tableRows[2]);
+                selectedRows.Should().ContainInOrder(tableRows[0], tableRows[2]);
+
+                var resetEvents = 0;
+                var changedEvents = 0;
+                selectedRows.CollectionChanged += (_, args) =>
+                {
+                    changedEvents++;
+                    if (args.Action == NotifyCollectionChangedAction.Reset)
+                    {
+                        resetEvents++;
+                    }
+                };
+
+                tableRows.Add(new RowFixture("Cboe", "Healthy"));
+                tableRows.RemoveAt(1);
+
+                changedEvents.Should().Be(0);
+                resetEvents.Should().Be(0);
+                selectedRows.Should().ContainInOrder(tableRows[0], tableRows[1]);
+
+                tableRows.RemoveAt(1);
+
+                selectedRows.Should().ContainSingle().Which.Should().BeSameAs(tableRows[0]);
+                resetEvents.Should().Be(0);
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    [Fact]
+    public void DenseDataGridControl_ShouldUpdateEmptyStateFromCollectionCountTransitions()
+    {
+        WpfTestThread.Run(() =>
+        {
+            RunMatUiAutomationFacade.EnsureApplicationResources();
+
+            var tableRows = new ObservableCollection<RowFixture>();
+            var denseGrid = new DenseDataGridControl
+            {
+                Table = new WorkstationTableModel<RowFixture>(
+                    tableRows,
+                    [new("Provider", nameof(RowFixture.Name), 120)],
+                    "Provider readiness table")
+            };
+
+            var window = Show(denseGrid);
+            try
+            {
+                var emptyPanel = denseGrid.FindName("EmptyPanel").Should().BeOfType<Border>().Subject;
+                emptyPanel.Visibility.Should().Be(Visibility.Visible);
+
+                tableRows.Add(new RowFixture("Polygon.io", "Healthy"));
+                denseGrid.UpdateLayout();
+                emptyPanel.Visibility.Should().Be(Visibility.Collapsed);
+
+                tableRows.Clear();
+                denseGrid.UpdateLayout();
+                emptyPanel.Visibility.Should().Be(Visibility.Visible);
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    [Fact]
     public void DenseDataGridSource_ShouldUseCompactInstitutionalTableChrome()
     {
         var xaml = File.ReadAllText(RunMatUiAutomationFacade.GetRepoFilePath(
@@ -345,6 +458,17 @@ public sealed class WorkstationPrimitiveControlsTests
         window.UpdateLayout();
         element.UpdateLayout();
         return window;
+    }
+
+    private sealed class CountingRows(int count) : IReadOnlyCollection<object>
+    {
+        public int Count { get; } = count;
+
+        public IEnumerator<object> GetEnumerator()
+            => throw new InvalidOperationException("Native count checks should not enumerate large row collections.");
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
     }
 
     private sealed record RowFixture(string Name, string Status);


### PR DESCRIPTION
### Motivation
- Prevent expensive enumeration of large row sets when calculating empty-state by using native count checks where available.  
- Reduce selection-mirroring churn by only updating bound `SelectedItems` when the row collection changes actually affect selection.  
- Provide a single low-churn synchronization primitive so other workstation tables can share the same stable behavior and make selection diffs reference-based.

### Description
- Added `CollectionSynchronizationHelper` with `GetRuntimeRows`, `HasItems`/`TryGetCount`, `ContainsAnyByReference`, `AnyMissingByReference`, and `SynchronizeByReference` to centralize runtime row lookup, count checks, and reference-based collection diffs.  
- Updated `DenseDataGridControl` to use `GetRuntimeRows()` for observed subscriptions, `CollectionSynchronizationHelper.HasItems(GetRows())` in `UpdateEmptyState`, conditional mirroring via a new `SelectedRowsMayHaveChanged` check in `OnRowsChanged`, and diff-based synchronization via `CollectionSynchronizationHelper.SynchronizeByReference` in `MirrorSelectedRows`.  
- Added focused WPF tests in `WorkstationPrimitiveControlsTests` covering `DenseDataGridControl_ShouldUseNativeCountsForLargeRowCollections`, `DenseDataGridControl_ShouldPreserveMultiSelectionWithoutLowValueMirrorChurn`, and `DenseDataGridControl_ShouldUpdateEmptyStateFromCollectionCountTransitions` to validate large-collection count usage, multi-selection preservation, and empty-state transitions.

### Testing
- Ran `git diff --check` on the modified files to validate formatting and whitespace checks, which passed locally.  
- Attempted to run `dotnet test` for the WPF test filter (`WorkstationPrimitiveControlsTests`) but execution was blocked in this environment because `dotnet` is not available here; tests are included and should be executed on Windows CI with `dotnet test` and `EnableFullWpfBuild=true`.  
- Resource/test-gap scripts (`./tools/codex/resource-review.ps1` and `./tools/codex/test-gap-scan.ps1`) could not be executed here because PowerShell (`pwsh`) is not available in this environment; please run those on the normal developer/CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a306cd721588320b7b917c250cbdf46)