### PR TITLE
Validate provider credential fields

### DIFF
--- a/src/Meridian.DataIntegration/Credentials/FileProviderCredentialStore.cs
+++ b/src/Meridian.DataIntegration/Credentials/FileProviderCredentialStore.cs
@@ -77,6 +77,7 @@ public sealed class FileProviderCredentialStore : IProviderCredentialStore
     {
         ArgumentNullException.ThrowIfNull(request);
         var descriptor = RequireDescriptor(request.ProviderId);
+        var normalizedCredentials = NormalizeCredentialFields(descriptor, request.Credentials ?? new Dictionary<string, string?>());
         var now = DateTimeOffset.UtcNow;
 
         await _gate.WaitAsync(ct).ConfigureAwait(false);
@@ -86,7 +87,7 @@ public sealed class FileProviderCredentialStore : IProviderCredentialStore
             vault.Providers.TryGetValue(descriptor.ProviderId, out var existing);
 
             var fields = new Dictionary<string, string>(existing?.Fields ?? new Dictionary<string, string>(), StringComparer.OrdinalIgnoreCase);
-            foreach (var (key, value) in request.Credentials)
+            foreach (var (key, value) in normalizedCredentials)
             {
                 if (string.IsNullOrWhiteSpace(key))
                 {
@@ -223,6 +224,42 @@ public sealed class FileProviderCredentialStore : IProviderCredentialStore
     private static ProviderCredentialCatalogEntry RequireDescriptor(string providerId)
         => ProviderCredentialCatalog.Find(providerId)
            ?? throw new ArgumentException($"Provider '{providerId}' is not in the provider credential catalog.", nameof(providerId));
+
+    private static IReadOnlyDictionary<string, string?> NormalizeCredentialFields(
+        ProviderCredentialCatalogEntry descriptor,
+        IReadOnlyDictionary<string, string?> credentials)
+    {
+        var allowedFields = descriptor.RequiredFields.ToDictionary(
+            static field => field.Name,
+            static field => field.Name,
+            StringComparer.OrdinalIgnoreCase);
+        var normalized = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        var unknownFields = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (key, value) in credentials)
+        {
+            var trimmedKey = key?.Trim();
+            if (string.IsNullOrWhiteSpace(trimmedKey))
+            {
+                continue;
+            }
+
+            if (!allowedFields.TryGetValue(trimmedKey, out var canonicalName))
+            {
+                unknownFields.Add(trimmedKey);
+                continue;
+            }
+
+            normalized[canonicalName] = value;
+        }
+
+        if (unknownFields.Count > 0)
+        {
+            throw new ProviderCredentialValidationException(descriptor.ProviderId, unknownFields.ToArray());
+        }
+
+        return normalized;
+    }
 
     private static ProviderCredentialStoreStatus BuildStatus(
         ProviderCredentialCatalogEntry descriptor,

--- a/src/Meridian.DataIntegration/Credentials/IProviderCredentialStore.cs
+++ b/src/Meridian.DataIntegration/Credentials/IProviderCredentialStore.cs
@@ -24,6 +24,25 @@ public sealed record ProviderCredentialSaveRequest(
     string? Actor = null,
     IReadOnlyDictionary<string, string>? Metadata = null);
 
+public sealed class ProviderCredentialValidationException : Exception
+{
+    public ProviderCredentialValidationException(string providerId, IReadOnlyList<string> unknownFields)
+        : base(BuildMessage(providerId, unknownFields))
+    {
+        ProviderId = providerId;
+        UnknownFields = unknownFields;
+    }
+
+    public string ProviderId { get; }
+
+    public IReadOnlyList<string> UnknownFields { get; }
+
+    private static string BuildMessage(string providerId, IReadOnlyList<string> unknownFields)
+        => unknownFields.Count == 0
+            ? $"Credential fields are invalid for provider '{providerId}'."
+            : $"Credential fields are not recognized for provider '{providerId}': {string.Join(", ", unknownFields)}.";
+}
+
 public sealed record ProviderCredentialVerificationUpdate(
     string ProviderId,
     bool Success,

--- a/src/Meridian.Ui.Shared/Endpoints/ProviderConnectionEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ProviderConnectionEndpoints.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Meridian.Contracts.Api;
 using Meridian.Identity.Auth;
 using Meridian.Contracts.Configuration;
+using Meridian.DataIntegration.Credentials;
 using Meridian.Ui.Shared.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -44,6 +45,10 @@ public static class ProviderConnectionEndpoints
             {
                 var result = await service.SaveCredentialsAsync(providerId, request, context.RequestAborted).ConfigureAwait(false);
                 return Results.Json(result, jsonOptions);
+            }
+            catch (ProviderCredentialValidationException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message, unknownFields = ex.UnknownFields });
             }
             catch (ArgumentException ex)
             {

--- a/src/Meridian.Ui.Shared/Services/ProviderConnectionLifecycleService.cs
+++ b/src/Meridian.Ui.Shared/Services/ProviderConnectionLifecycleService.cs
@@ -57,7 +57,7 @@ public sealed class ProviderConnectionLifecycleService
     {
         ArgumentNullException.ThrowIfNull(request);
         var descriptor = RequireDescriptor(providerId);
-        var credentials = request.Credentials ?? new Dictionary<string, string?>();
+        var credentials = NormalizeCredentialFields(descriptor, request.Credentials ?? new Dictionary<string, string?>());
 
         await _credentialStore.SaveAsync(
             new ProviderCredentialSaveRequest(
@@ -238,6 +238,42 @@ public sealed class ProviderConnectionLifecycleService
                 ExternalAccountId: read.ExternalAccountId,
                 Warnings: ["Alpaca account verification failed; downstream brokerage sync remains blocked."]);
         }
+    }
+
+    private static IReadOnlyDictionary<string, string?> NormalizeCredentialFields(
+        ProviderCredentialCatalogEntry descriptor,
+        IReadOnlyDictionary<string, string?> credentials)
+    {
+        var allowedFields = descriptor.RequiredFields.ToDictionary(
+            static field => field.Name,
+            static field => field.Name,
+            StringComparer.OrdinalIgnoreCase);
+        var normalized = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        var unknownFields = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (key, value) in credentials)
+        {
+            var trimmedKey = key?.Trim();
+            if (string.IsNullOrWhiteSpace(trimmedKey))
+            {
+                continue;
+            }
+
+            if (!allowedFields.TryGetValue(trimmedKey, out var canonicalName))
+            {
+                unknownFields.Add(trimmedKey);
+                continue;
+            }
+
+            normalized[canonicalName] = value;
+        }
+
+        if (unknownFields.Count > 0)
+        {
+            throw new ProviderCredentialValidationException(descriptor.ProviderId, unknownFields.ToArray());
+        }
+
+        return normalized;
     }
 
     private static ProviderConnectionRowDto BuildRow(

--- a/tests/Meridian.Tests/Application/Config/ProviderCredentialStoreTests.cs
+++ b/tests/Meridian.Tests/Application/Config/ProviderCredentialStoreTests.cs
@@ -201,6 +201,103 @@ public sealed class ProviderCredentialStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task SaveAsync_UnknownCredentialFields_AreRejectedAndDoNotUpdateVaultOrAudit()
+    {
+        var store = new FileProviderCredentialStore(_root);
+        await store.SaveAsync(new ProviderCredentialSaveRequest(
+            "alpaca",
+            new Dictionary<string, string?>
+            {
+                ["KeyId"] = "known-key",
+                ["SecretKey"] = "known-secret"
+            },
+            Environment: "paper",
+            Actor: "test-operator"));
+
+        var act = () => store.SaveAsync(new ProviderCredentialSaveRequest(
+            "alpaca",
+            new Dictionary<string, string?>
+            {
+                ["KeyId"] = "replacement-key",
+                ["AccessToken"] = "unknown-secret"
+            },
+            Environment: "paper",
+            Actor: "test-operator"));
+
+        var exception = await act.Should().ThrowAsync<ProviderCredentialValidationException>();
+        exception.Which.UnknownFields.Should().ContainSingle().Which.Should().Be("AccessToken");
+        var read = await store.ReadForProviderAsync("alpaca");
+        read.Should().NotBeNull();
+        read!.Get("KeyId").Should().Be("known-key");
+        read.Get("AccessToken").Should().BeNull();
+
+        var vaultText = await File.ReadAllTextAsync(store.VaultPath);
+        var auditText = await File.ReadAllTextAsync(Path.Combine(_root, ".mdc", "provider-credentials.audit.jsonl"));
+        vaultText.Should().NotContain("unknown-secret");
+        auditText.Should().NotContain("AccessToken");
+        auditText.Should().NotContain("unknown-secret");
+    }
+
+    [Fact]
+    public async Task SaveAsync_KnownCredentialFields_AreCaseInsensitiveAndStoredCanonically()
+    {
+        var store = new FileProviderCredentialStore(_root);
+
+        await store.SaveAsync(new ProviderCredentialSaveRequest(
+            "alpaca",
+            new Dictionary<string, string?>
+            {
+                ["keyid"] = "case-key",
+                ["SECRETKEY"] = "case-secret"
+            },
+            Environment: "paper",
+            Actor: "test-operator"));
+
+        var read = await store.ReadForProviderAsync("alpaca");
+        var status = await store.GetStatusAsync("alpaca");
+
+        read.Should().NotBeNull();
+        read!.Credentials.Keys.Should().BeEquivalentTo(["KeyId", "SecretKey"]);
+        read.Get("KeyId").Should().Be("case-key");
+        read.Get("SecretKey").Should().Be("case-secret");
+        status.PresentFields.Should().BeEquivalentTo(["KeyId", "SecretKey"]);
+    }
+
+    [Fact]
+    public async Task SaveAsync_BlankKnownCredentialField_RemovesExistingValue()
+    {
+        var store = new FileProviderCredentialStore(_root);
+        await store.SaveAsync(new ProviderCredentialSaveRequest(
+            "alpaca",
+            new Dictionary<string, string?>
+            {
+                ["KeyId"] = "remove-key",
+                ["SecretKey"] = "remove-secret"
+            },
+            Environment: "paper",
+            Actor: "test-operator"));
+
+        await store.SaveAsync(new ProviderCredentialSaveRequest(
+            "alpaca",
+            new Dictionary<string, string?>
+            {
+                ["secretkey"] = "   "
+            },
+            Environment: "paper",
+            Actor: "test-operator"));
+
+        var read = await store.ReadForProviderAsync("alpaca");
+        var status = await store.GetStatusAsync("alpaca");
+
+        read.Should().NotBeNull();
+        read!.Get("KeyId").Should().Be("remove-key");
+        read.Get("SecretKey").Should().BeNull();
+        status.CredentialState.Should().Be(ProviderCredentialStateDto.Partial);
+        status.MissingFields.Should().ContainSingle().Which.Should().Be("SecretKey");
+    }
+
+
+    [Fact]
     public async Task ReadForProviderAsync_UsesEnvironmentAsReadOnlyLegacyFallback()
     {
         using var env = new EnvironmentScope("POLYGON_API_KEY", "legacy-polygon-key");

--- a/tests/Meridian.Tests/Ui/ProviderConnectionEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/ProviderConnectionEndpointsTests.cs
@@ -76,6 +76,75 @@ public sealed class ProviderConnectionEndpointsTests
     }
 
     [Fact]
+    public async Task PutProviderCredentials_UnknownCredentialFields_ReturnsBadRequestWithoutPersistingValues()
+    {
+        await using var app = await CreateAppAsync(_ => { });
+        var store = (FileProviderCredentialStore)app.Services.GetRequiredService<IProviderCredentialStore>();
+        await app.GetTestClient().PutAsync(
+            "/api/providers/alpaca/credentials",
+            JsonContent(new { credentials = new { KeyId = "safe-key", SecretKey = "safe-secret" }, environment = "paper" }));
+
+        var response = await app.GetTestClient().PutAsync(
+            "/api/providers/alpaca/credentials",
+            JsonContent(new { credentials = new { KeyId = "replacement-key", AccessToken = "unknown-secret" }, environment = "paper" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("AccessToken");
+        var read = await store.ReadForProviderAsync("alpaca");
+        read.Should().NotBeNull();
+        read!.Get("KeyId").Should().Be("safe-key");
+        read.Get("AccessToken").Should().BeNull();
+
+        var vaultText = await File.ReadAllTextAsync(store.VaultPath);
+        var auditText = await File.ReadAllTextAsync(Path.Combine(Path.GetDirectoryName(store.VaultPath)!, "provider-credentials.audit.jsonl"));
+        vaultText.Should().NotContain("unknown-secret");
+        auditText.Should().NotContain("AccessToken");
+        auditText.Should().NotContain("unknown-secret");
+    }
+
+    [Fact]
+    public async Task PutProviderCredentials_KnownCredentialFields_AreCaseInsensitive()
+    {
+        await using var app = await CreateAppAsync(_ => { });
+        var store = (FileProviderCredentialStore)app.Services.GetRequiredService<IProviderCredentialStore>();
+
+        var response = await app.GetTestClient().PutAsync(
+            "/api/providers/alpaca/credentials",
+            JsonContent(new { credentials = new { keyid = "case-key", SECRETKEY = "case-secret" }, environment = "paper" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var read = await store.ReadForProviderAsync("alpaca");
+        read.Should().NotBeNull();
+        read!.Credentials.Keys.Should().BeEquivalentTo(["KeyId", "SecretKey"]);
+        read.Get("KeyId").Should().Be("case-key");
+        read.Get("SecretKey").Should().Be("case-secret");
+    }
+
+    [Fact]
+    public async Task PutProviderCredentials_BlankKnownCredentialField_RemovesExistingValue()
+    {
+        await using var app = await CreateAppAsync(_ => { });
+        var store = (FileProviderCredentialStore)app.Services.GetRequiredService<IProviderCredentialStore>();
+        await app.GetTestClient().PutAsync(
+            "/api/providers/alpaca/credentials",
+            JsonContent(new { credentials = new { KeyId = "keep-key", SecretKey = "remove-secret" }, environment = "paper" }));
+
+        var response = await app.GetTestClient().PutAsync(
+            "/api/providers/alpaca/credentials",
+            JsonContent(new { credentials = new { secretkey = "" }, environment = "paper" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var read = await store.ReadForProviderAsync("alpaca");
+        read.Should().NotBeNull();
+        read!.Get("KeyId").Should().Be("keep-key");
+        read.Get("SecretKey").Should().BeNull();
+        var result = await ReadAsync<ProviderCredentialMutationResultDto>(response);
+        result.CredentialState.Should().Be(ProviderCredentialStateDto.Partial);
+    }
+
+
+    [Fact]
     public async Task PostProviderVerify_UsesStoredAlpacaCredentialsAndRecordsAccount()
     {
         using var env = AlpacaEnvScope.Clear();


### PR DESCRIPTION
### Motivation
- Ensure only cataloged provider credential keys are persisted and avoid accidental leakage or schema drift from unknown fields.
- Fail fast on unknown credential keys so callers get a clear validation result instead of silently ignoring or persisting unexpected data.
- Add defensive checks at the store level so non-UI callers cannot persist unknown credential keys.
- Preserve existing behavior that submitting a known but blank value removes the stored value.

### Description
- Normalize incoming credential keys against the provider catalog and reject unknown keys by throwing a new `ProviderCredentialValidationException` that carries the provider id and unknown field names. (changes in `ProviderConnectionLifecycleService` and new exception in `IProviderCredentialStore`).
- Apply the same normalization and validation inside `FileProviderCredentialStore.SaveAsync` so non-UI callers are protected from unknown fields and canonicalize accepted key casing before persisting. (`FileProviderCredentialStore.cs`).
- Map `ProviderCredentialValidationException` to HTTP 400 with an `unknownFields` array in the provider credential endpoint so API clients receive structured validation errors. (`ProviderConnectionEndpoints.cs`).
- Preserve blank-field removal semantics: submitting a known field with an empty/whitespace value still removes the existing stored value (no behavioral change to deletion logic). (`FileProviderCredentialStore.cs`).
- Add tests covering unknown-field rejection, case-insensitive known fields being stored with canonical names, blank-field removal, and verification that rejected unknown values do not appear in vault or audit files. (tests added to `tests/Meridian.Tests/Application/Config/ProviderCredentialStoreTests.cs` and `tests/Meridian.Tests/Ui/ProviderConnectionEndpointsTests.cs`).

### Testing
- `git diff --check` was run and returned clean results.
- `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "ProviderCredentialStoreTests|ProviderConnectionEndpointsTests"` was attempted but blocked because `dotnet` is not installed in this environment, so the added tests were not executed here.
- New automated tests were added to `tests/Meridian.Tests/Application/Config/ProviderCredentialStoreTests.cs` and `tests/Meridian.Tests/Ui/ProviderConnectionEndpointsTests.cs` and should be run in CI or a local environment with the .NET SDK to verify the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a306da7884083209b01eae5db3d4a39)