### PR TITLE
Guard provider health refresh concurrency and cancellation

### DIFF
--- a/src/Meridian.Ui.Services/Services/ProviderHealthService.cs
+++ b/src/Meridian.Ui.Services/Services/ProviderHealthService.cs
@@ -17,16 +17,34 @@ public sealed class ProviderHealthService : IDisposable
 {
     private static readonly Lazy<ProviderHealthService> _instance = new(() => new ProviderHealthService());
     private readonly ApiClientService _apiClient;
+    private readonly Func<CancellationToken, Task<ApiResponse<ProviderHealthResponse>>> _healthFetcher;
+    private readonly SemaphoreSlim _refreshGate = new(1, 1);
     private readonly Timer _updateTimer;
     private readonly ConcurrentDictionary<string, ProviderHealthData> _providerHealth = new();
     private readonly ConcurrentDictionary<string, List<HealthHistoryPoint>> _healthHistory = new();
+    private CancellationTokenSource _monitoringCts = new();
     private bool _disposed;
 
     public static ProviderHealthService Instance => _instance.Value;
 
     private ProviderHealthService()
+        : this(ApiClientService.Instance, null)
     {
-        _apiClient = ApiClientService.Instance;
+    }
+
+    internal ProviderHealthService(Func<CancellationToken, Task<ApiResponse<ProviderHealthResponse>>> healthFetcher)
+        : this(ApiClientService.Instance, healthFetcher)
+    {
+    }
+
+    private ProviderHealthService(
+        ApiClientService apiClient,
+        Func<CancellationToken, Task<ApiResponse<ProviderHealthResponse>>>? healthFetcher)
+    {
+        _apiClient = apiClient;
+        _healthFetcher = healthFetcher ?? (ct => _apiClient.GetWithResponseAsync<ProviderHealthResponse>(
+            "/api/providers/health",
+            ct));
         _updateTimer = new Timer(5000);
         _updateTimer.Elapsed += OnTimerElapsed;
         _updateTimer.AutoReset = true;
@@ -47,6 +65,15 @@ public sealed class ProviderHealthService : IDisposable
     /// </summary>
     public void StartMonitoring()
     {
+        if (_disposed)
+            return;
+
+        if (_monitoringCts.IsCancellationRequested)
+        {
+            _monitoringCts.Dispose();
+            _monitoringCts = new CancellationTokenSource();
+        }
+
         _updateTimer.Start();
     }
 
@@ -56,16 +83,30 @@ public sealed class ProviderHealthService : IDisposable
     public void StopMonitoring()
     {
         _updateTimer.Stop();
+        _monitoringCts.Cancel();
     }
 
-    private async void OnTimerElapsed(object? sender, ElapsedEventArgs e)
+    private void OnTimerElapsed(object? sender, ElapsedEventArgs e)
     {
-        if (_disposed)
+        _ = RunTimerRefreshAsync();
+    }
+
+    internal Task TriggerMonitoringRefreshForTestsAsync()
+    {
+        return RunTimerRefreshAsync();
+    }
+
+    private async Task RunTimerRefreshAsync()
+    {
+        if (_disposed || _monitoringCts.IsCancellationRequested)
             return;
 
         try
         {
-            await RefreshHealthDataAsync();
+            await RefreshHealthDataAsync(_monitoringCts.Token, skipIfBusy: true);
+        }
+        catch (OperationCanceledException) when (_monitoringCts.IsCancellationRequested)
+        {
         }
         catch (Exception ex)
         {
@@ -176,81 +217,100 @@ public sealed class ProviderHealthService : IDisposable
         };
     }
 
-    private async Task RefreshHealthDataAsync(CancellationToken ct = default)
+    private async Task RefreshHealthDataAsync(CancellationToken ct = default, bool skipIfBusy = false)
     {
-        var response = await _apiClient.GetWithResponseAsync<ProviderHealthResponse>(
-            "/api/providers/health",
-            ct);
+        var entered = skipIfBusy
+            ? await _refreshGate.WaitAsync(0, ct)
+            : await WaitForRefreshGateAsync(ct);
 
-        if (response.Success && response.Data?.Providers != null)
+        if (!entered)
+            return;
+
+        try
         {
-            foreach (var provider in response.Data.Providers)
+            ct.ThrowIfCancellationRequested();
+            var response = await _healthFetcher(ct);
+
+            if (response.Success && response.Data?.Providers != null)
             {
-                var healthData = new ProviderHealthData
+                foreach (var provider in response.Data.Providers)
                 {
-                    ProviderId = provider.ProviderId,
-                    ProviderName = provider.ProviderName,
-                    IsConnected = provider.IsConnected,
-                    LifecycleState = provider.LifecycleState,
-                    WebSocketState = provider.WebSocketState,
-                    IsReconnecting = provider.IsReconnecting,
-                    LastHeartbeatReceivedAt = provider.LastHeartbeatReceivedAt,
-                    LastMessageReceivedAt = provider.LastMessageReceivedAt,
-                    LastReconnectAttemptAt = provider.LastReconnectAttemptAt,
-                    ReconnectAttempts = provider.ReconnectAttempts,
-                    LastFailureKind = provider.LastFailureKind,
-                    LastUpdated = DateTime.UtcNow,
-                    OverallScore = CalculateOverallScore(provider),
-                    Metrics = new HealthMetrics
+                    var healthData = new ProviderHealthData
                     {
-                        ConnectionStabilityScore = provider.ConnectionStabilityScore,
-                        AverageLatencyMs = provider.AverageLatencyMs,
-                        LatencyP99Ms = provider.LatencyP99Ms,
-                        LatencyConsistencyScore = provider.LatencyConsistencyScore,
-                        DataCompletenessPercent = provider.DataCompletenessPercent,
-                        ReconnectsLastHour = provider.ReconnectsLastHour,
-                        ReconnectionScore = CalculateReconnectionScore(provider.ReconnectsLastHour),
-                        UptimePercent = provider.UptimePercent,
-                        MessagesPerSecond = provider.MessagesPerSecond,
-                        ErrorsLastHour = provider.ErrorsLastHour
-                    },
-                    Breakdown = CalculateBreakdown(provider)
-                };
+                        ProviderId = provider.ProviderId,
+                        ProviderName = provider.ProviderName,
+                        IsConnected = provider.IsConnected,
+                        LifecycleState = provider.LifecycleState,
+                        WebSocketState = provider.WebSocketState,
+                        IsReconnecting = provider.IsReconnecting,
+                        LastHeartbeatReceivedAt = provider.LastHeartbeatReceivedAt,
+                        LastMessageReceivedAt = provider.LastMessageReceivedAt,
+                        LastReconnectAttemptAt = provider.LastReconnectAttemptAt,
+                        ReconnectAttempts = provider.ReconnectAttempts,
+                        LastFailureKind = provider.LastFailureKind,
+                        LastUpdated = DateTime.UtcNow,
+                        OverallScore = CalculateOverallScore(provider),
+                        Metrics = new HealthMetrics
+                        {
+                            ConnectionStabilityScore = provider.ConnectionStabilityScore,
+                            AverageLatencyMs = provider.AverageLatencyMs,
+                            LatencyP99Ms = provider.LatencyP99Ms,
+                            LatencyConsistencyScore = provider.LatencyConsistencyScore,
+                            DataCompletenessPercent = provider.DataCompletenessPercent,
+                            ReconnectsLastHour = provider.ReconnectsLastHour,
+                            ReconnectionScore = CalculateReconnectionScore(provider.ReconnectsLastHour),
+                            UptimePercent = provider.UptimePercent,
+                            MessagesPerSecond = provider.MessagesPerSecond,
+                            ErrorsLastHour = provider.ErrorsLastHour
+                        },
+                        Breakdown = CalculateBreakdown(provider)
+                    };
 
-                _providerHealth[provider.ProviderId] = healthData;
+                    _providerHealth[provider.ProviderId] = healthData;
 
-                // Update history
-                var history = _healthHistory.GetOrAdd(provider.ProviderId, _ => new List<HealthHistoryPoint>());
+                    // Update history
+                    var history = _healthHistory.GetOrAdd(provider.ProviderId, _ => new List<HealthHistoryPoint>());
 
-                lock (history)
-                {
-                    history.Add(new HealthHistoryPoint
+                    lock (history)
                     {
-                        Timestamp = DateTime.UtcNow,
-                        OverallScore = healthData.OverallScore,
-                        LatencyMs = provider.AverageLatencyMs,
-                        CompletenessPercent = provider.DataCompletenessPercent
-                    });
+                        history.Add(new HealthHistoryPoint
+                        {
+                            Timestamp = DateTime.UtcNow,
+                            OverallScore = healthData.OverallScore,
+                            LatencyMs = provider.AverageLatencyMs,
+                            CompletenessPercent = provider.DataCompletenessPercent
+                        });
 
-                    // Keep only last 24 hours
-                    var cutoff = DateTime.UtcNow.AddHours(-24);
-                    history.RemoveAll(h => h.Timestamp < cutoff);
+                        // Keep only last 24 hours
+                        var cutoff = DateTime.UtcNow.AddHours(-24);
+                        history.RemoveAll(h => h.Timestamp < cutoff);
+                    }
+
+                    // Check for alerts
+                    CheckHealthAlerts(healthData);
                 }
-
-                // Check for alerts
-                CheckHealthAlerts(healthData);
             }
-        }
-        else
-        {
-            // Generate mock data for demo
-            GenerateMockHealthData();
-        }
+            else
+            {
+                // Generate mock data for demo
+                GenerateMockHealthData();
+            }
 
-        HealthUpdated?.Invoke(this, new HealthUpdateEventArgs
+            HealthUpdated?.Invoke(this, new HealthUpdateEventArgs
+            {
+                Providers = _providerHealth.Values.ToList()
+            });
+        }
+        finally
         {
-            Providers = _providerHealth.Values.ToList()
-        });
+            _refreshGate.Release();
+        }
+    }
+
+    private async Task<bool> WaitForRefreshGateAsync(CancellationToken ct)
+    {
+        await _refreshGate.WaitAsync(ct);
+        return true;
     }
 
     private void GenerateMockHealthData()
@@ -429,9 +489,11 @@ public sealed class ProviderHealthService : IDisposable
         if (_disposed)
             return;
         _disposed = true; // Set before stopping so in-flight callbacks exit early
+        _monitoringCts.Cancel();
         _updateTimer.Stop();
         _updateTimer.Elapsed -= OnTimerElapsed;
         _updateTimer.Dispose();
+        _monitoringCts.Dispose();
     }
 }
 

--- a/src/Meridian.Wpf/Services/ConnectionService.cs
+++ b/src/Meridian.Wpf/Services/ConnectionService.cs
@@ -20,9 +20,13 @@ public sealed class ConnectionService : ConnectionServiceBase, IConnectionServic
 {
     private static readonly Lazy<ConnectionService> _instance = new(() => new ConnectionService());
 
+    private readonly SemaphoreSlim _healthCheckGate = new(1, 1);
+    private readonly object _httpClientLock = new();
     private HttpClient _httpClient;
     private Timer? _monitoringTimer;
     private Timer? _reconnectTimer;
+    private CancellationTokenSource _monitoringCts = new();
+    private CancellationTokenSource _reconnectCts = new();
 
     /// <summary>
     /// Gets the singleton instance of the ConnectionService.
@@ -40,15 +44,32 @@ public sealed class ConnectionService : ConnectionServiceBase, IConnectionServic
     /// <inheritdoc />
     protected override async Task<bool> PerformHealthCheckCoreAsync(CancellationToken ct)
     {
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        cts.CancelAfter(TimeSpan.FromSeconds(10));
-        var response = await _httpClient.GetAsync($"{ServiceUrl}/healthz", cts.Token);
-        return response.IsSuccessStatusCode;
+        await _healthCheckGate.WaitAsync(ct);
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(TimeSpan.FromSeconds(10));
+
+            HttpClient client;
+            lock (_httpClientLock)
+            {
+                client = _httpClient;
+            }
+
+            var response = await client.GetAsync($"{ServiceUrl}/healthz", cts.Token);
+            return response.IsSuccessStatusCode;
+        }
+        finally
+        {
+            _healthCheckGate.Release();
+        }
     }
 
     /// <inheritdoc />
     protected override void StartMonitoringTimer(int intervalMs)
     {
+        _monitoringCts.Dispose();
+        _monitoringCts = new CancellationTokenSource();
         _monitoringTimer = new Timer(intervalMs);
         _monitoringTimer.Elapsed += OnMonitoringTimerElapsed;
         _monitoringTimer.AutoReset = true;
@@ -60,6 +81,7 @@ public sealed class ConnectionService : ConnectionServiceBase, IConnectionServic
     {
         if (_monitoringTimer != null)
         {
+            _monitoringCts.Cancel();
             _monitoringTimer.Stop();
             _monitoringTimer.Elapsed -= OnMonitoringTimerElapsed;
             _monitoringTimer.Dispose();
@@ -73,6 +95,8 @@ public sealed class ConnectionService : ConnectionServiceBase, IConnectionServic
         if (_reconnectTimer != null)
             return;
 
+        _reconnectCts.Dispose();
+        _reconnectCts = new CancellationTokenSource();
         _reconnectTimer = new Timer(delayMs);
         _reconnectTimer.Elapsed += OnReconnectTimerElapsed;
         _reconnectTimer.AutoReset = false;
@@ -84,6 +108,7 @@ public sealed class ConnectionService : ConnectionServiceBase, IConnectionServic
     {
         if (_reconnectTimer != null)
         {
+            _reconnectCts.Cancel();
             _reconnectTimer.Stop();
             _reconnectTimer.Elapsed -= OnReconnectTimerElapsed;
             _reconnectTimer.Dispose();
@@ -94,12 +119,23 @@ public sealed class ConnectionService : ConnectionServiceBase, IConnectionServic
     /// <inheritdoc />
     protected override void OnSettingsUpdated(ConnectionSettings settings)
     {
-        var old = _httpClient;
-        _httpClient = new HttpClient
+        _healthCheckGate.Wait();
+        try
         {
-            Timeout = TimeSpan.FromSeconds(settings.ServiceTimeoutSeconds)
-        };
-        old.Dispose();
+            var old = _httpClient;
+            lock (_httpClientLock)
+            {
+                _httpClient = new HttpClient
+                {
+                    Timeout = TimeSpan.FromSeconds(settings.ServiceTimeoutSeconds)
+                };
+            }
+            old.Dispose();
+        }
+        finally
+        {
+            _healthCheckGate.Release();
+        }
     }
 
     /// <inheritdoc />
@@ -117,16 +153,29 @@ public sealed class ConnectionService : ConnectionServiceBase, IConnectionServic
     /// <inheritdoc />
     protected override void DisposePlatformResources()
     {
-        _httpClient.Dispose();
+        _monitoringCts.Cancel();
+        _reconnectCts.Cancel();
+        _healthCheckGate.Wait();
+        try
+        {
+            _httpClient.Dispose();
+        }
+        finally
+        {
+            _healthCheckGate.Release();
+            _healthCheckGate.Dispose();
+            _monitoringCts.Dispose();
+            _reconnectCts.Dispose();
+        }
     }
 
-    private async void OnMonitoringTimerElapsed(object? sender, ElapsedEventArgs e)
+    private void OnMonitoringTimerElapsed(object? sender, ElapsedEventArgs e)
     {
-        await OnMonitoringTimerFired();
+        _ = OnMonitoringTimerFired(_monitoringCts.Token);
     }
 
-    private async void OnReconnectTimerElapsed(object? sender, ElapsedEventArgs e)
+    private void OnReconnectTimerElapsed(object? sender, ElapsedEventArgs e)
     {
-        await OnReconnectTimerFired();
+        _ = OnReconnectTimerFired(_reconnectCts.Token);
     }
 }

--- a/tests/Meridian.Ui.Tests/Services/ProviderHealthServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/ProviderHealthServiceTests.cs
@@ -200,6 +200,129 @@ public sealed class ProviderHealthServiceTests : IDisposable
         Enum.IsDefined(typeof(HealthAlertType), type).Should().BeTrue();
     }
 
+
+    [Fact]
+    public async Task GetAllProviderHealthAsync_SlowEndpoint_CoalescesHealthUpdatedPerRefresh()
+    {
+        var service = new ProviderHealthService(async ct =>
+        {
+            await Task.Delay(50, ct);
+            return CreateHealthResponse("slow-feed");
+        });
+        var events = 0;
+        service.HealthUpdated += (_, args) =>
+        {
+            events++;
+            args.Providers.Should().ContainSingle(p => p.ProviderId == "slow-feed");
+        };
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var providers = await service.GetAllProviderHealthAsync(timeout.Token);
+
+        providers.Should().ContainSingle(p => p.ProviderId == "slow-feed");
+        events.Should().Be(1);
+        service.Dispose();
+    }
+
+    [Fact]
+    public async Task MonitoringRefresh_StopMonitoring_CancelsOutstandingHealthCheck()
+    {
+        using var entered = new ManualResetEventSlim(false);
+        var service = new ProviderHealthService(async ct =>
+        {
+            entered.Set();
+            await Task.Delay(TimeSpan.FromMinutes(1), ct);
+            return CreateHealthResponse("cancelled-feed");
+        });
+
+        service.StartMonitoring();
+        var refresh = service.TriggerMonitoringRefreshForTestsAsync();
+        entered.Wait(TimeSpan.FromSeconds(2)).Should().BeTrue();
+        service.StopMonitoring();
+
+        await refresh;
+        service.Dispose();
+    }
+
+    [Fact]
+    public async Task MonitoringRefresh_Dispose_CancelsOutstandingHealthCheck()
+    {
+        using var entered = new ManualResetEventSlim(false);
+        var service = new ProviderHealthService(async ct =>
+        {
+            entered.Set();
+            await Task.Delay(TimeSpan.FromMinutes(1), ct);
+            return CreateHealthResponse("disposed-feed");
+        });
+
+        service.StartMonitoring();
+        var refresh = service.TriggerMonitoringRefreshForTestsAsync();
+        entered.Wait(TimeSpan.FromSeconds(2)).Should().BeTrue();
+        service.Dispose();
+
+        await refresh;
+    }
+
+    [Fact]
+    public async Task GetAllProviderHealthAsync_ConcurrentRefreshes_DoNotOverlapEndpointCalls()
+    {
+        var activeCalls = 0;
+        var maxActiveCalls = 0;
+        var service = new ProviderHealthService(async ct =>
+        {
+            var active = Interlocked.Increment(ref activeCalls);
+            maxActiveCalls = Math.Max(maxActiveCalls, active);
+            try
+            {
+                await Task.Delay(50, ct);
+                return CreateHealthResponse("serial-feed");
+            }
+            finally
+            {
+                Interlocked.Decrement(ref activeCalls);
+            }
+        });
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await Task.WhenAll(
+            service.GetAllProviderHealthAsync(timeout.Token),
+            service.GetAllProviderHealthAsync(timeout.Token),
+            service.GetAllProviderHealthAsync(timeout.Token));
+
+        maxActiveCalls.Should().Be(1);
+        service.Dispose();
+    }
+
+    private static ApiResponse<ProviderHealthResponse> CreateHealthResponse(string providerId)
+    {
+        return new ApiResponse<ProviderHealthResponse>
+        {
+            Success = true,
+            StatusCode = 200,
+            Data = new ProviderHealthResponse
+            {
+                Providers =
+                [
+                    new ProviderHealthInfo
+                    {
+                        ProviderId = providerId,
+                        ProviderName = providerId,
+                        IsConnected = true,
+                        ConnectionStabilityScore = 99,
+                        AverageLatencyMs = 25,
+                        LatencyP99Ms = 40,
+                        LatencyConsistencyScore = 95,
+                        DataCompletenessPercent = 99,
+                        ReconnectsLastHour = 0,
+                        UptimePercent = 99,
+                        MessagesPerSecond = 1000,
+                        ErrorsLastHour = 0
+                    }
+                ]
+            }
+        };
+    }
+
     public void Dispose()
     {
         // Ensure monitoring is stopped after tests


### PR DESCRIPTION
### Motivation

- Prevent overlapping timer-driven work and hidden `async void` callbacks which caused unbounded concurrent health checks and unsafe `HttpClient` disposal. 
- Ensure health-check work is cancellable when monitoring stops or services are disposed so slow endpoints don't block shutdown. 
- Serialize access to shared `HttpClient` and health-check execution to avoid disposing clients while in use. 
- Provide stable UI updates by coalescing `HealthUpdated` to a single event per completed refresh cycle.

### Description

- Replaced `async void` timer handlers with non-async timer callbacks that dispatch guarded async tasks and pass `CancellationToken` into refresh and reconnect flows. 
- ConnectionService changes: added a `SemaphoreSlim` `_healthCheckGate` to serialize health checks, an `_httpClientLock` to safely swap the `HttpClient`, cancellation sources for monitoring/reconnect timers, and updated `OnMonitoringTimerElapsed`/`OnReconnectTimerElapsed` to call `OnMonitoringTimerFired`/`OnReconnectTimerFired` with tokens; settings updates wait on the gate before replacing the client. 
- ProviderHealthService changes: added an injectable `_healthFetcher` for testing, a `_refreshGate` (a `SemaphoreSlim`) to prevent overlapping refreshes, a `_monitoringCts` for timer cancellation, a `RunTimerRefreshAsync` helper (and `TriggerMonitoringRefreshForTestsAsync` for tests), and logic to skip a refresh when one is already running while ensuring a single `HealthUpdated` event is raised after the refresh completes. 
- Tests: added focused tests in `ProviderHealthServiceTests` that simulate a slow endpoint, verify cancellation when monitoring stops or service is disposed, and assert that concurrent `GetAllProviderHealthAsync` calls do not overlap (ensuring serialization).

### Testing

- Ran repository checks: `git diff --check -- src/Meridian.Wpf/Services/ConnectionService.cs src/Meridian.Ui.Services/Services/ProviderHealthService.cs tests/Meridian.Ui.Tests/Services/ProviderHealthServiceTests.cs` which reported no spacing/whitespace issues. 
- Verified there are no remaining `async void` timer handlers via `rg "async void" src/Meridian.Wpf/Services/ConnectionService.cs src/Meridian.Ui.Services/Services/ProviderHealthService.cs tests/Meridian.Ui.Tests/Services/ProviderHealthServiceTests.cs`. 
- Added unit tests in `tests/Meridian.Ui.Tests/Services/ProviderHealthServiceTests.cs` covering slow endpoint coalescing, stop/dispose cancellation, and non-overlapping concurrent refreshes; these tests were written and included in the test project but not executed in this environment because `dotnet` is not available (`dotnet test` was not run here). 
- Manual code review and local static edits performed to ensure the new gates, cancellation paths, and single `HealthUpdated` emission are in place.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a306cdb07388320a6ec8de4b02deacd)