### PR TITLE
Add provider setup handler abstraction and registry

### DIFF
--- a/src/Meridian.Application/Composition/Features/ProviderRoutingFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/ProviderRoutingFeatureRegistration.cs
@@ -1,4 +1,5 @@
 using Meridian.Application.ProviderRouting;
+using Meridian.DataIntegration.Credentials;
 using Meridian.ProviderSdk;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -18,6 +19,11 @@ internal sealed class ProviderRoutingFeatureRegistration : IServiceFeatureRegist
 
         services.TryAddSingleton<ProviderConnectionService>();
         services.TryAddSingleton<ProviderBindingService>();
+        foreach (var handler in DefaultProviderSetupHandlers.Create())
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IProviderSetupHandler), handler));
+        }
+        services.TryAddSingleton<IProviderSetupRegistry, ProviderSetupRegistry>();
         services.TryAddSingleton<ProviderSetupService>();
         services.TryAddSingleton<KernelObservabilityService>();
         services.TryAddSingleton<ProviderRoutingService>();

--- a/src/Meridian.Application/ProviderRouting/ProviderSetupService.cs
+++ b/src/Meridian.Application/ProviderRouting/ProviderSetupService.cs
@@ -16,11 +16,13 @@ public sealed class ProviderSetupService
 
     private readonly UI.ConfigStore _store;
     private readonly IProviderCredentialStore _credentialStore;
+    private readonly IProviderSetupRegistry _setupRegistry;
 
-    public ProviderSetupService(UI.ConfigStore store, IProviderCredentialStore credentialStore)
+    public ProviderSetupService(UI.ConfigStore store, IProviderCredentialStore credentialStore, IProviderSetupRegistry setupRegistry)
     {
         _store = store;
         _credentialStore = credentialStore;
+        _setupRegistry = setupRegistry;
     }
 
     public async Task<ProviderSetupResult> ConfigureAsync(ProviderSetupRequest request, CancellationToken ct = default)
@@ -33,12 +35,13 @@ public sealed class ProviderSetupService
             return Failure(string.Empty, "Provider display name is required.");
         }
 
-        if (!TryResolveProviderKind(request.Kind, out var sourceKind, out var providerFamilyId, out var credentialOnly, out var providerError))
+        var handler = _setupRegistry.Find(request.Kind ?? string.Empty);
+        if (handler is null)
         {
-            return Failure(displayName, providerError);
+            return Failure(displayName, $"Provider '{request.Kind}' is not yet supported by the local data-source configuration model.");
         }
 
-        var descriptor = ProviderCredentialCatalog.Find(providerFamilyId);
+        var descriptor = ProviderCredentialCatalog.Find(handler.Descriptor.ProviderId);
         if (descriptor is null)
         {
             return Failure(displayName, $"Provider '{request.Kind}' is not in the credential catalog.");
@@ -46,14 +49,29 @@ public sealed class ProviderSetupService
 
         var normalizedCapabilities = NormalizeCapabilities(request.Capabilities);
         var sourceType = ResolveSourceType(normalizedCapabilities);
-        var environment = descriptor.NormalizeEnvironment(request.Environment);
+        var setupContext = new ProviderSetupContext(
+            handler.Descriptor.ProviderId,
+            displayName,
+            normalizedCapabilities,
+            request.Environment,
+            request.ApiKey,
+            request.ApiSecret,
+            request.Endpoint);
+        var validation = handler.Validate(setupContext);
+        if (!validation.Success)
+        {
+            return Failure(displayName, validation.Error ?? "Provider setup validation failed.");
+        }
+
+        var environment = validation.NormalizedEnvironment ?? descriptor.NormalizeEnvironment(request.Environment);
         var referenceEnvironment = string.IsNullOrWhiteSpace(environment) ? "default" : environment;
         var credentialReference = descriptor.RequiresCredentials
             ? $"vault:{descriptor.ProviderId}/{referenceEnvironment}"
             : null;
         var warnings = new List<string>();
 
-        var submittedCredentials = BuildCredentialMap(descriptor, request);
+        var submittedCredentials = new Dictionary<string, string?>(validation.Credentials ?? new Dictionary<string, string?>(), StringComparer.OrdinalIgnoreCase);
+        warnings.AddRange(validation.Warnings ?? Array.Empty<string>());
         ProviderCredentialStoreStatus credentialStatus;
         if (submittedCredentials.Count > 0)
         {
@@ -87,13 +105,10 @@ public sealed class ProviderSetupService
             warnings.Add("Credential setup is incomplete; required credential fields are missing.");
         }
 
-        if (descriptor.ProviderId.Equals("alpaca", StringComparison.OrdinalIgnoreCase) &&
-            credentialStatus.Environment?.Equals("live", StringComparison.OrdinalIgnoreCase) == true)
-        {
-            warnings.Add("Alpaca is configured for a live environment; keep live trading and production routing gated until verification and certification pass.");
-        }
+        var execution = handler.BuildExecution(setupContext, credentialStatus);
+        warnings.AddRange(execution.Warnings);
 
-        if (credentialOnly)
+        if (execution.CredentialOnly)
         {
             return new ProviderSetupResult(
                 Success: true,
@@ -110,6 +125,7 @@ public sealed class ProviderSetupService
                 Warnings: warnings.ToArray());
         }
 
+        var sourceKind = execution.DataSourceKind;
         if (sourceKind is null)
         {
             return Failure(displayName, $"Provider '{request.Kind}' is not yet supported by the local data-source configuration model.");
@@ -148,8 +164,8 @@ public sealed class ProviderSetupService
             ProviderFamilyId: descriptor.ProviderId,
             DisplayName: displayName,
             ConnectionType: ProviderConnectionType.DataVendor,
-            ConnectionMode: ResolveConnectionMode(credentialStatus.Environment, normalizedCapabilities),
-            Enabled: true,
+            ConnectionMode: execution.ConnectionMode,
+            Enabled: execution.EnableBindings,
             CredentialReference: credentialReference,
             Tags: normalizedCapabilities,
             Description: $"Configured from the provider setup form for {displayName}.",
@@ -166,7 +182,7 @@ public sealed class ProviderSetupService
             connections.Add(connection);
         }
 
-        var seededBindingIds = SeedBindings(providerId, normalizedCapabilities, sourceType, sourcePriority, bindings);
+        var seededBindingIds = SeedBindings(providerId, normalizedCapabilities, sourceType, sourcePriority, execution.EnableBindings, bindings);
         var nextDataSources = dataSources with
         {
             Sources = sources.ToArray(),
@@ -208,44 +224,6 @@ public sealed class ProviderSetupService
             Error: error,
             Warnings: Array.Empty<string>());
 
-    private static bool TryResolveProviderKind(
-        string? kind,
-        out DataSourceKind? sourceKind,
-        out string providerFamilyId,
-        out bool credentialOnly,
-        out string error)
-    {
-        var normalizedKind = NormalizeProviderKind(kind);
-        error = string.Empty;
-        credentialOnly = false;
-        (sourceKind, providerFamilyId, credentialOnly) = normalizedKind switch
-        {
-            "alpaca" => ((DataSourceKind?)DataSourceKind.Alpaca, "alpaca", false),
-            "polygon" => ((DataSourceKind?)DataSourceKind.Polygon, "polygon", false),
-            "yahoo" or "yahoofinance" => ((DataSourceKind?)DataSourceKind.Yahoo, "yahoo", false),
-            "interactivebrokers" or "ib" => ((DataSourceKind?)DataSourceKind.IB, "ib", false),
-            "synthetic" or "custom" => ((DataSourceKind?)DataSourceKind.Synthetic, "synthetic", false),
-            "plaid" or "plaidapi" => ((DataSourceKind?)null, "plaid", true),
-            _ => ((DataSourceKind?)null, string.Empty, false)
-        };
-
-        if (!string.IsNullOrWhiteSpace(providerFamilyId))
-        {
-            return true;
-        }
-
-        error = $"Provider '{kind}' is not yet supported by the local data-source configuration model.";
-        return false;
-    }
-
-    private static string NormalizeProviderKind(string? kind)
-    {
-        var normalized = (kind ?? string.Empty).Trim().ToLowerInvariant();
-        return normalized.Replace("-", string.Empty, StringComparison.Ordinal)
-            .Replace("_", string.Empty, StringComparison.Ordinal)
-            .Replace(" ", string.Empty, StringComparison.Ordinal);
-    }
-
     private static DataSourceType ResolveSourceType(IReadOnlyList<string> capabilities)
     {
         var hasStreaming = capabilities.Any(capability => ResolvesCapability(capability, ProviderCapabilityKind.RealtimeMarketData));
@@ -265,42 +243,6 @@ public sealed class ProviderSetupService
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(capability => capability, StringComparer.OrdinalIgnoreCase)
             .ToArray() ?? Array.Empty<string>();
-
-    private static Dictionary<string, string?> BuildCredentialMap(
-        ProviderCredentialCatalogEntry descriptor,
-        ProviderSetupRequest request)
-    {
-        var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
-        var apiKey = NullIfBlank(request.ApiKey);
-        var apiSecret = NullIfBlank(request.ApiSecret);
-
-        if (descriptor.ProviderId.Equals("alpaca", StringComparison.OrdinalIgnoreCase))
-        {
-            if (apiKey is not null)
-            {
-                values["KeyId"] = apiKey;
-            }
-
-            if (apiSecret is not null)
-            {
-                values["SecretKey"] = apiSecret;
-            }
-
-            return values;
-        }
-
-        if (descriptor.RequiredFields.Count > 0 && apiKey is not null)
-        {
-            values[descriptor.RequiredFields[0].Name] = apiKey;
-        }
-
-        if (descriptor.RequiredFields.Count > 1 && apiSecret is not null)
-        {
-            values[descriptor.RequiredFields[1].Name] = apiSecret;
-        }
-
-        return values;
-    }
 
     private static string BuildProviderId(
         string providerFamilyId,
@@ -333,6 +275,7 @@ public sealed class ProviderSetupService
         IReadOnlyList<string> capabilities,
         DataSourceType sourceType,
         int priority,
+        bool enabled,
         List<ProviderBindingConfig> bindings)
     {
         var capabilityKinds = ResolveCapabilityKinds(capabilities, sourceType);
@@ -346,7 +289,7 @@ public sealed class ProviderSetupService
                 ConnectionId: providerId,
                 Target: new ProviderBindingTarget(),
                 Priority: priority,
-                Enabled: true,
+                Enabled: enabled,
                 Notes: "Seeded by provider setup."));
             seeded.Add(bindingId);
         }
@@ -437,32 +380,6 @@ public sealed class ProviderSetupService
 
         bool Exists(string id)
             => bindings.Any(binding => string.Equals(binding.BindingId, id, StringComparison.OrdinalIgnoreCase));
-    }
-
-    private static ProviderConnectionMode ResolveConnectionMode(
-        string? environment,
-        IReadOnlyList<string> capabilities)
-    {
-        if (environment is not null)
-        {
-            if (environment.Equals("live", StringComparison.OrdinalIgnoreCase) ||
-                environment.Equals("production", StringComparison.OrdinalIgnoreCase))
-            {
-                return ProviderConnectionMode.Live;
-            }
-
-            if (environment.Equals("paper", StringComparison.OrdinalIgnoreCase) ||
-                environment.Equals("sandbox", StringComparison.OrdinalIgnoreCase))
-            {
-                return ProviderConnectionMode.Paper;
-            }
-        }
-
-        return capabilities.Any(capability => ResolvesCapability(capability, ProviderCapabilityKind.RealtimeMarketData)) ||
-               capabilities.Any(capability => ResolvesCapability(capability, ProviderCapabilityKind.HistoricalBars)) ||
-               capabilities.Any(capability => ResolvesCapability(capability, ProviderCapabilityKind.ReferenceData))
-            ? ProviderConnectionMode.ReadOnly
-            : ProviderConnectionMode.Research;
     }
 
     private static IBOptions BuildInteractiveBrokersOptions(string? endpoint)

--- a/src/Meridian.DataIntegration/Credentials/ProviderSetupHandlers.cs
+++ b/src/Meridian.DataIntegration/Credentials/ProviderSetupHandlers.cs
@@ -1,0 +1,248 @@
+using Meridian.Contracts.Configuration;
+using Meridian.Core.Config;
+using Meridian.ProviderSdk;
+
+namespace Meridian.DataIntegration.Credentials;
+
+public interface IProviderSetupHandler
+{
+    ProviderSetupDescriptor Descriptor { get; }
+    bool CanHandle(string providerIdOrAlias);
+    ProviderSetupValidationResult Validate(ProviderSetupContext context);
+    ProviderSetupExecutionResult BuildExecution(ProviderSetupContext context, ProviderCredentialStoreStatus credentialStatus);
+}
+
+public sealed record ProviderSetupContext(
+    string ProviderIdOrAlias,
+    string DisplayName,
+    IReadOnlyList<string> Capabilities,
+    string? Environment,
+    string? ApiKey = null,
+    string? ApiSecret = null,
+    string? Endpoint = null,
+    bool LiveAcknowledged = false);
+
+public sealed record ProviderSetupDescriptor(
+    string ProviderId,
+    IReadOnlyList<string> Aliases,
+    IReadOnlyList<ProviderCredentialFieldMetadataDto> AcceptedCredentialFields,
+    IReadOnlyList<ProviderEnvironmentOptionDto> EnvironmentOptions,
+    bool SupportsVerification,
+    ProviderConnectionMode DefaultRoutingMode,
+    bool EnableBindingsImmediately,
+    bool CredentialOnly = false,
+    DataSourceKind? DataSourceKind = null,
+    IReadOnlyList<string>? SetupWarnings = null);
+
+public sealed record ProviderSetupValidationResult(
+    bool Success,
+    string? Error = null,
+    IReadOnlyDictionary<string, string?>? Credentials = null,
+    string? NormalizedEnvironment = null,
+    IReadOnlyList<string>? Warnings = null)
+{
+    public static ProviderSetupValidationResult Failure(string error) => new(false, error);
+}
+
+public sealed record ProviderSetupExecutionResult(
+    DataSourceKind? DataSourceKind,
+    ProviderConnectionMode ConnectionMode,
+    bool EnableBindings,
+    bool CredentialOnly,
+    IReadOnlyList<string> Warnings);
+
+public interface IProviderSetupRegistry
+{
+    IReadOnlyList<IProviderSetupHandler> Handlers { get; }
+    IProviderSetupHandler? Find(string providerIdOrAlias);
+}
+
+public sealed class ProviderSetupRegistry : IProviderSetupRegistry
+{
+    private readonly IReadOnlyList<IProviderSetupHandler> _handlers;
+
+    public ProviderSetupRegistry(IEnumerable<IProviderSetupHandler> handlers)
+    {
+        _handlers = handlers.ToArray();
+    }
+
+    public IReadOnlyList<IProviderSetupHandler> Handlers => _handlers;
+
+    public IProviderSetupHandler? Find(string providerIdOrAlias)
+        => _handlers.FirstOrDefault(handler => handler.CanHandle(providerIdOrAlias));
+}
+
+public abstract class ProviderSetupHandlerBase : IProviderSetupHandler
+{
+    private readonly ProviderCredentialCatalogEntry _catalogEntry;
+
+    protected ProviderSetupHandlerBase(
+        string providerId,
+        IReadOnlyList<string> aliases,
+        bool supportsVerification,
+        ProviderConnectionMode defaultRoutingMode,
+        bool enableBindingsImmediately,
+        bool credentialOnly = false,
+        DataSourceKind? dataSourceKind = null,
+        IReadOnlyList<string>? setupWarnings = null)
+    {
+        _catalogEntry = ProviderCredentialCatalog.Find(providerId)
+            ?? throw new InvalidOperationException($"Provider '{providerId}' is not in the credential catalog.");
+        Descriptor = new ProviderSetupDescriptor(
+            _catalogEntry.ProviderId,
+            aliases,
+            ProviderCredentialCatalog.BuildCredentialFields(_catalogEntry),
+            ProviderCredentialCatalog.BuildEnvironmentOptions(_catalogEntry),
+            supportsVerification,
+            defaultRoutingMode,
+            enableBindingsImmediately,
+            credentialOnly,
+            dataSourceKind,
+            setupWarnings ?? []);
+    }
+
+    public ProviderSetupDescriptor Descriptor { get; }
+
+    public bool CanHandle(string providerIdOrAlias)
+    {
+        var normalized = NormalizeAlias(providerIdOrAlias);
+        return string.Equals(normalized, NormalizeAlias(Descriptor.ProviderId), StringComparison.OrdinalIgnoreCase) ||
+               Descriptor.Aliases.Any(alias => string.Equals(normalized, NormalizeAlias(alias), StringComparison.OrdinalIgnoreCase)) ||
+               string.Equals(ProviderCredentialCatalog.NormalizeProviderId(providerIdOrAlias), Descriptor.ProviderId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public virtual ProviderSetupValidationResult Validate(ProviderSetupContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        var credentials = BuildCredentialMap(context);
+        var environment = _catalogEntry.NormalizeEnvironment(context.Environment);
+        return new ProviderSetupValidationResult(true, Credentials: credentials, NormalizedEnvironment: environment, Warnings: []);
+    }
+
+    public virtual ProviderSetupExecutionResult BuildExecution(ProviderSetupContext context, ProviderCredentialStoreStatus credentialStatus)
+    {
+        var mode = ResolveConnectionMode(credentialStatus.Environment, context.Capabilities, Descriptor.DefaultRoutingMode);
+        return new ProviderSetupExecutionResult(Descriptor.DataSourceKind, mode, Descriptor.EnableBindingsImmediately, Descriptor.CredentialOnly, Descriptor.SetupWarnings);
+    }
+
+    protected virtual IReadOnlyDictionary<string, string?> BuildCredentialMap(ProviderSetupContext context)
+    {
+        var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        AddIfPresent(values, 0, context.ApiKey);
+        AddIfPresent(values, 1, context.ApiSecret);
+        return values;
+    }
+
+    protected ProviderCredentialCatalogEntry CatalogEntry => _catalogEntry;
+
+    protected static string? NullIfBlank(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    protected void AddIfPresent(IDictionary<string, string?> values, int fieldIndex, string? value)
+    {
+        var trimmed = NullIfBlank(value);
+        if (trimmed is not null && CatalogEntry.RequiredFields.Count > fieldIndex)
+        {
+            values[CatalogEntry.RequiredFields[fieldIndex].Name] = trimmed;
+        }
+    }
+
+    private static ProviderConnectionMode ResolveConnectionMode(string? environment, IReadOnlyList<string> capabilities, ProviderConnectionMode fallback)
+    {
+        if (environment is not null)
+        {
+            if (environment.Equals("live", StringComparison.OrdinalIgnoreCase) || environment.Equals("production", StringComparison.OrdinalIgnoreCase))
+            {
+                return ProviderConnectionMode.Live;
+            }
+
+            if (environment.Equals("paper", StringComparison.OrdinalIgnoreCase) || environment.Equals("sandbox", StringComparison.OrdinalIgnoreCase))
+            {
+                return ProviderConnectionMode.Paper;
+            }
+        }
+
+        return capabilities.Count > 0 ? ProviderConnectionMode.ReadOnly : fallback;
+    }
+
+    private static string NormalizeAlias(string? value)
+        => (value ?? string.Empty).Trim().ToLowerInvariant()
+            .Replace("-", string.Empty, StringComparison.Ordinal)
+            .Replace("_", string.Empty, StringComparison.Ordinal)
+            .Replace(" ", string.Empty, StringComparison.Ordinal);
+}
+
+public sealed class AlpacaProviderSetupHandler : ProviderSetupHandlerBase
+{
+    public AlpacaProviderSetupHandler()
+        : base("alpaca", ["alpaca-api"], true, ProviderConnectionMode.Paper, false, dataSourceKind: DataSourceKind.Alpaca)
+    {
+    }
+
+    protected override IReadOnlyDictionary<string, string?> BuildCredentialMap(ProviderSetupContext context)
+    {
+        var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        var apiKey = NullIfBlank(context.ApiKey);
+        var apiSecret = NullIfBlank(context.ApiSecret);
+        if (apiKey is not null) values["KeyId"] = apiKey;
+        if (apiSecret is not null) values["SecretKey"] = apiSecret;
+        return values;
+    }
+
+    public override ProviderSetupExecutionResult BuildExecution(ProviderSetupContext context, ProviderCredentialStoreStatus credentialStatus)
+    {
+        var warnings = Descriptor.SetupWarnings.ToList();
+        if (credentialStatus.Environment?.Equals("live", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            warnings.Add("Alpaca is configured for a live environment; keep live trading and production routing gated until verification and certification pass.");
+        }
+
+        var baseResult = base.BuildExecution(context, credentialStatus);
+        return baseResult with { EnableBindings = credentialStatus.VerificationState == ProviderVerificationStateDto.Verified, Warnings = warnings };
+    }
+}
+
+public sealed class PolygonProviderSetupHandler : ProviderSetupHandlerBase
+{
+    public PolygonProviderSetupHandler()
+        : base("polygon", ["polygonio", "polygon-io"], true, ProviderConnectionMode.ReadOnly, false, dataSourceKind: DataSourceKind.Polygon)
+    {
+    }
+}
+
+public sealed class PlaidProviderSetupHandler : ProviderSetupHandlerBase
+{
+    public PlaidProviderSetupHandler()
+        : base("plaid", ["plaidapi", "plaid-api"], true, ProviderConnectionMode.ReadOnly, false, credentialOnly: true)
+    {
+    }
+}
+
+public sealed class QuickBooksProviderSetupHandler : ProviderSetupHandlerBase
+{
+    public QuickBooksProviderSetupHandler()
+        : base("quickbooks", ["qbo", "quickbooks-online"], true, ProviderConnectionMode.ReadOnly, false, credentialOnly: true)
+    {
+    }
+}
+
+public sealed class GenericReadOnlyDataProviderSetupHandler : ProviderSetupHandlerBase
+{
+    public GenericReadOnlyDataProviderSetupHandler(string providerId, DataSourceKind? dataSourceKind = null, IReadOnlyList<string>? aliases = null)
+        : base(providerId, aliases ?? [], false, ProviderConnectionMode.ReadOnly, true, dataSourceKind: dataSourceKind)
+    {
+    }
+}
+
+public static class DefaultProviderSetupHandlers
+{
+    public static IReadOnlyList<IProviderSetupHandler> Create()
+        =>
+        [
+            new AlpacaProviderSetupHandler(),
+            new PolygonProviderSetupHandler(),
+            new PlaidProviderSetupHandler(),
+            new QuickBooksProviderSetupHandler(),
+            new GenericReadOnlyDataProviderSetupHandler("yahoo", DataSourceKind.Yahoo, ["yahoo-finance", "yahoofinance"]),
+            new GenericReadOnlyDataProviderSetupHandler("synthetic", DataSourceKind.Synthetic, ["custom"])
+        ];
+}

--- a/src/Meridian.DataIntegration/README.md
+++ b/src/Meridian.DataIntegration/README.md
@@ -24,6 +24,7 @@ This module belongs to the Design Module layer. Keep changes within that ownersh
 
 - `src/Meridian.DataIntegration` - registered source module root.
 - `Credentials/ProviderCredentialCatalog.cs` - canonical provider credential descriptors, field mappings, environment normalization, and credential-source projection.
+- `Credentials/ProviderSetupHandlers.cs` - provider setup handler contracts, default handler registry, and provider-specific setup policy for accepted fields, environments, warnings, routing mode, verification support, and binding enablement.
 - `Credentials/ICredentialStore.cs` - provider-neutral credential-store contract, credential metadata, validation result, and common credential extension helpers.
 - `Credentials/IProviderCredentialStore.cs` - provider-neutral encrypted credential store contract and mutation/read result models.
 - `Credentials/FileProviderCredentialStore.cs` - local encrypted provider credential vault with audit metadata, verification status, and environment fallback handling.
@@ -74,11 +75,8 @@ Use this README to understand the module before editing source files. Update the
 
 QuickBooks accounting-system integration lives in this module. The adapter family imports chart-of-accounts, journal-entry, and trial-balance evidence as read-only reconciliation input through `IAccountingSystemProvider`, refreshes OAuth access tokens through the server-side QuickBooks client seam, records connection verification posture, maps provider-vault credentials into the QuickBooks connection store, and leaves posting/export disabled. UI Shared registers the Data Integration providers and connection store; it does not own QuickBooks transport, credential persistence mapping, or import mapping.
 
-Provider credential catalog, credential-store contracts, vault, status, and OAuth record ownership also lives in this module. Application and UI layers may orchestrate setup, testing, token refresh, and endpoint projection, but provider credential descriptors, encrypted local storage, validation metadata, verification metadata, expiration policy records, OAuth token records, and provider-environment normalization must stay behind the `Meridian.DataIntegration.Credentials` seam. Saved provider secrets are written to the encrypted local vault with rotation metadata and verification-required state; environment fallback is for Development/Test or explicit migration override only and is disabled for packaged/customer builds.
-`ProviderCredentialCatalog` also owns the value-free provider setup metadata projected to UI clients:
-credential field identifiers, labels, required flags, input kinds, safe help text, action routes,
-and allowed/default environments. Do not move stored credential values or environment variable
-contents into that metadata projection.
+Provider setup handler contracts, the default provider setup registry, provider credential catalog, credential-store contracts, vault, status, and OAuth record ownership also lives in this module. Application and UI layers may orchestrate setup, testing, token refresh, and endpoint projection, but provider credential descriptors, encrypted local storage, validation metadata, verification metadata, expiration policy records, OAuth token records, and provider-environment normalization must stay behind the `Meridian.DataIntegration.Credentials` seam. Saved provider secrets are written to the encrypted local vault with rotation metadata and verification-required state; environment fallback is for Development/Test or explicit migration override only and is disabled for packaged/customer builds.
+`ProviderCredentialCatalog` owns value-free provider credential metadata, while `IProviderSetupHandler` implementations own provider-specific setup behavior such as accepted setup fields, environment options, default routing mode, verification support, setup warnings, and whether newly seeded bindings are enabled immediately or wait for verification. Do not move stored credential values or environment variable contents into either metadata projection.
 
 Market-event filtering and provider-depth-buffer self-tests live in this module because they
 validate and route provider-ingested event streams before higher-level application orchestration.

--- a/src/Meridian.Ui.Shared/Services/ProviderConnectionLifecycleService.cs
+++ b/src/Meridian.Ui.Shared/Services/ProviderConnectionLifecycleService.cs
@@ -19,6 +19,7 @@ public sealed class ProviderConnectionLifecycleService
     private readonly ConfigStore _configStore;
     private readonly IHttpClientFactory? _httpClientFactory;
     private readonly IReadOnlyList<IAccountingSystemProvider> _accountingSystemProviders;
+    private readonly IProviderSetupRegistry _setupRegistry;
     private readonly ILogger<ProviderConnectionLifecycleService> _logger;
 
     public ProviderConnectionLifecycleService(
@@ -26,13 +27,15 @@ public sealed class ProviderConnectionLifecycleService
         ConfigStore configStore,
         ILogger<ProviderConnectionLifecycleService> logger,
         IHttpClientFactory? httpClientFactory = null,
-        IEnumerable<IAccountingSystemProvider>? accountingSystemProviders = null)
+        IEnumerable<IAccountingSystemProvider>? accountingSystemProviders = null,
+        IProviderSetupRegistry? setupRegistry = null)
     {
         _credentialStore = credentialStore ?? throw new ArgumentNullException(nameof(credentialStore));
         _configStore = configStore ?? throw new ArgumentNullException(nameof(configStore));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _httpClientFactory = httpClientFactory;
         _accountingSystemProviders = accountingSystemProviders?.ToArray() ?? [];
+        _setupRegistry = setupRegistry ?? new ProviderSetupRegistry(DefaultProviderSetupHandlers.Create());
     }
 
     public async Task<IReadOnlyList<ProviderConnectionRowDto>> GetConnectionsAsync(CancellationToken ct = default)
@@ -249,6 +252,8 @@ public sealed class ProviderConnectionLifecycleService
         var lastSuccessfulAt = status.LastSuccessfulAt ?? (metrics?.IsConnected == true ? metrics.Timestamp : null);
         var lastFailureAt = status.LastFailureAt ?? (metrics is { IsConnected: false, ConnectionFailures: > 0 } ? metrics.Timestamp : null);
 
+        var setupDescriptor = ResolveSetupDescriptor(descriptor);
+
         return new ProviderConnectionRowDto(
             ProviderId: descriptor.ProviderId,
             DisplayName: descriptor.DisplayName,
@@ -268,8 +273,8 @@ public sealed class ProviderConnectionLifecycleService
             AffectedWorkflows: descriptor.AffectedWorkflows ?? [],
             RecommendedAction: ResolveRecommendedAction(descriptor, status, health),
             ActionHref: descriptor.ResolvedActionHref,
-            CredentialFields: ProviderCredentialCatalog.BuildCredentialFields(descriptor),
-            EnvironmentOptions: ProviderCredentialCatalog.BuildEnvironmentOptions(descriptor));
+            CredentialFields: setupDescriptor.AcceptedCredentialFields,
+            EnvironmentOptions: setupDescriptor.EnvironmentOptions);
     }
 
     private static ProviderContinuityHealthDto ResolveHealth(
@@ -378,6 +383,10 @@ public sealed class ProviderConnectionLifecycleService
     private static ProviderCredentialCatalogEntry RequireDescriptor(string providerId)
         => ProviderCredentialCatalog.Find(providerId)
            ?? throw new ArgumentException($"Provider '{providerId}' is not in the provider credential catalog.", nameof(providerId));
+
+    private ProviderSetupDescriptor ResolveSetupDescriptor(ProviderCredentialCatalogEntry descriptor)
+        => _setupRegistry.Find(descriptor.ProviderId)?.Descriptor
+           ?? new GenericReadOnlyDataProviderSetupHandler(descriptor.ProviderId).Descriptor;
 
     private static string AlpacaTradingApiEndpoint(string environment)
         => environment.Equals(AlpacaCredentialEnvironment.LiveEnvironment, StringComparison.OrdinalIgnoreCase)

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -150,6 +150,11 @@ public static class WorkstationServiceCollectionExtensions
         services.TryAddSingleton(BrokerageConnectionOptions.RobinhoodFromEnvironment());
         services.TryAddSingleton<BrokerageConnectionService>();
         services.TryAddSingleton<AlpacaBrokerageConnectionService>();
+        foreach (var handler in DefaultProviderSetupHandlers.Create())
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IProviderSetupHandler), handler));
+        }
+        services.TryAddSingleton<IProviderSetupRegistry, ProviderSetupRegistry>();
         services.TryAddSingleton<ProviderConnectionLifecycleService>();
         services.TryAddSingleton<ProviderReadinessService>();
         services.TryAddSingleton<IQuickBooksOnlineConnectionStore, QuickBooksOnlineProviderCredentialConnectionStore>();

--- a/tests/Meridian.Tests/Ui/ProviderRoutingEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/ProviderRoutingEndpointsTests.cs
@@ -356,8 +356,39 @@ public sealed class ProviderRoutingEndpointsTests
         configJson.Should().Contain("Yahoo Historical");
     }
 
+
+    [Fact]
+    public async Task ConfigureProvider_UsesRegisteredHandlerWithoutChangingSetupService()
+    {
+        await using var app = await CreateAppAsync(registerServices: services =>
+        {
+            services.AddSingleton<IProviderSetupHandler>(new FakeProviderSetupHandler());
+        });
+
+        var response = await app.GetTestClient().PostAsync(UiApiRoutes.ProviderConfigure, JsonContent(new
+        {
+            kind = "fake-finnhub",
+            displayName = "Fake Finnhub",
+            apiKey = "fake-handler-key",
+            environment = "paper",
+            capabilities = new[] { "reference" }
+        }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = Deserialize<ProviderSetupResult>(await response.Content.ReadAsStringAsync());
+        result.Success.Should().BeTrue();
+        result.ProviderId.Should().Be("finnhub");
+        result.ConnectionId.Should().BeNull();
+        result.Warnings.Should().Contain("Fake handler warning from DI.");
+
+        var stored = await app.Services.GetRequiredService<IProviderCredentialStore>().ReadForProviderAsync("finnhub");
+        stored.Should().NotBeNull();
+        stored!.Get("ApiKey").Should().Be("fake-handler-key");
+    }
+
     private static async Task<WebApplication> CreateAppAsync(
-        UserPermission? permissions = UserPermission.ManageProviders | UserPermission.ManageCredentials)
+        UserPermission? permissions = UserPermission.ManageProviders | UserPermission.ManageCredentials,
+        Action<IServiceCollection>? registerServices = null)
     {
         var root = Path.Combine(Path.GetTempPath(), "meridian-tests", "provider-routing-endpoints", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
@@ -373,6 +404,11 @@ public sealed class ProviderRoutingEndpointsTests
         builder.Services.AddSingleton(new ApplicationConfigStore(configPath));
         builder.Services.AddSingleton(new SharedConfigStore(configPath));
         builder.Services.AddSingleton<IProviderCredentialStore>(_ => new FileProviderCredentialStore(dataRoot));
+        foreach (var handler in DefaultProviderSetupHandlers.Create())
+        {
+            builder.Services.AddSingleton(typeof(IProviderSetupHandler), handler);
+        }
+        builder.Services.AddSingleton<IProviderSetupRegistry, ProviderSetupRegistry>();
         builder.Services.AddSingleton<ProviderSetupService>();
         builder.Services.AddSingleton<ProviderConnectionService>();
         builder.Services.AddSingleton<ProviderBindingService>();
@@ -383,6 +419,7 @@ public sealed class ProviderRoutingEndpointsTests
         builder.Services.AddSingleton<IBestOfBreedProviderSelector, BestOfBreedProviderSelector>();
         builder.Services.AddSingleton<ProviderRouteExplainabilityService>();
         builder.Services.AddSingleton<ProviderTrustScoringService>();
+        registerServices?.Invoke(builder.Services);
         builder.Services.AddRateLimiter(options =>
         {
             options.AddPolicy(UiEndpoints.MutationRateLimitPolicy, _ =>
@@ -519,4 +556,31 @@ public sealed class ProviderRoutingEndpointsTests
             return ValueTask.FromResult<object?>(null);
         }
     }
+
+    private sealed class FakeProviderSetupHandler : IProviderSetupHandler
+    {
+        public ProviderSetupDescriptor Descriptor { get; } = new(
+            "finnhub",
+            ["fake-finnhub"],
+            ProviderCredentialCatalog.BuildCredentialFields(ProviderCredentialCatalog.Find("finnhub")!),
+            [],
+            SupportsVerification: false,
+            DefaultRoutingMode: ProviderConnectionMode.ReadOnly,
+            EnableBindingsImmediately: false,
+            CredentialOnly: true);
+
+        public bool CanHandle(string providerIdOrAlias)
+            => providerIdOrAlias.Equals("fake-finnhub", StringComparison.OrdinalIgnoreCase);
+
+        public ProviderSetupValidationResult Validate(ProviderSetupContext context)
+            => new(
+                true,
+                Credentials: new Dictionary<string, string?> { ["ApiKey"] = context.ApiKey },
+                NormalizedEnvironment: "paper",
+                Warnings: ["Fake handler warning from DI."]);
+
+        public ProviderSetupExecutionResult BuildExecution(ProviderSetupContext context, ProviderCredentialStoreStatus credentialStatus)
+            => new(null, ProviderConnectionMode.ReadOnly, EnableBindings: false, CredentialOnly: true, []);
+    }
+
 }


### PR DESCRIPTION
### Motivation

- Introduce a programmable, DI-discoverable abstraction for provider setup so provider-specific behavior is owned by handlers instead of hard-coded in orchestration services.
- Move credential mapping, environment normalization, verification hints, routing-mode, warnings, and binding enablement policy out of `ProviderSetupService` and `ProviderConnectionLifecycleService` and into per-provider handlers.

### Description

- Added `src/Meridian.DataIntegration/Credentials/ProviderSetupHandlers.cs` with `IProviderSetupHandler`, `ProviderSetupContext`, `ProviderSetupDescriptor`, `ProviderSetupValidationResult`, `ProviderSetupExecutionResult`, `IProviderSetupRegistry`, `ProviderSetupRegistry`, `ProviderSetupHandlerBase`, and default handler implementations for `Alpaca`, `Polygon`, `Plaid`, `QuickBooks`, and a `GenericReadOnlyDataProviderSetupHandler`, plus `DefaultProviderSetupHandlers.Create()` factory.
- Refactored `ProviderSetupService` to depend on `IProviderSetupRegistry` and to delegate validation, credential mapping, execution-time routing mode, credential-only behavior, warnings, and binding enablement to the resolved handler instead of switching on provider ids.
- Updated `ProviderConnectionLifecycleService` to use handler descriptors for credential field metadata and environment options and to accept/resolve an `IProviderSetupRegistry` for descriptor resolution.
- Registered handlers and `ProviderSetupRegistry` in DI in application composition and workstation shared services (`ProviderRoutingFeatureRegistration` and `WorkstationServiceCollectionExtensions`), and updated `src/Meridian.DataIntegration/README.md` to document the handler ownership boundary.
- Added a test in `tests/Meridian.Tests/Ui/ProviderRoutingEndpointsTests.cs` that proves a fake provider handler can be registered via DI and used by the existing `ProviderSetupService`/endpoints without changing orchestration code.

### Testing

- Ran `git diff --check` which succeeded without new whitespace/path issues.
- Attempted to run the endpoint-focused test filter with `dotnet test ... --filter "FullyQualifiedName~ProviderRoutingEndpointsTests"` but the run was blocked because `dotnet` was not available in this execution environment.
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary` which reported pre-existing repository-wide docs/source hash drift unrelated to this change and therefore failed; documentation README in `src/Meridian.DataIntegration` was updated as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a306e2c3f0883208eb0ab0998d11347)