### PR TITLE
Split provider setup UX metadata into ProviderSetupExperienceCatalog

### DIFF
--- a/src/Meridian.Application/ProviderRouting/ProviderSetupService.cs
+++ b/src/Meridian.Application/ProviderRouting/ProviderSetupService.cs
@@ -44,6 +44,7 @@ public sealed class ProviderSetupService
             return Failure(displayName, $"Provider '{request.Kind}' is not in the credential catalog.");
         }
 
+        var experience = ProviderSetupExperienceCatalog.Find(descriptor.ProviderId);
         var normalizedCapabilities = NormalizeCapabilities(request.Capabilities);
         var sourceType = ResolveSourceType(normalizedCapabilities);
         var environment = descriptor.NormalizeEnvironment(request.Environment);
@@ -107,7 +108,15 @@ public sealed class ProviderSetupService
                 CredentialSource: credentialStatus.CredentialSource,
                 CredentialReference: credentialReference,
                 Environment: string.IsNullOrWhiteSpace(credentialStatus.Environment) ? null : credentialStatus.Environment,
-                Warnings: warnings.ToArray());
+                Warnings: warnings.ToArray(),
+                DisplayGroup: experience.DisplayGroup,
+                ShortDescription: experience.ShortDescription,
+                HelpText: experience.HelpText,
+                SetupSteps: experience.SetupSteps.ToArray(),
+                WarningCopy: experience.WarningCopy,
+                AffectedWorkflows: experience.AffectedWorkflows.ToArray(),
+                DocsLinks: experience.DocsLinks.ToArray(),
+                RecoveryActionLabel: experience.RecoveryActionLabel);
         }
 
         if (sourceKind is null)
@@ -196,7 +205,15 @@ public sealed class ProviderSetupService
             CredentialSource: credentialStatus.CredentialSource,
             CredentialReference: credentialReference,
             Environment: string.IsNullOrWhiteSpace(credentialStatus.Environment) ? null : credentialStatus.Environment,
-            Warnings: warnings.ToArray());
+            Warnings: warnings.ToArray(),
+            DisplayGroup: experience.DisplayGroup,
+            ShortDescription: experience.ShortDescription,
+            HelpText: experience.HelpText,
+            SetupSteps: experience.SetupSteps.ToArray(),
+            WarningCopy: experience.WarningCopy,
+            AffectedWorkflows: experience.AffectedWorkflows.ToArray(),
+            DocsLinks: experience.DocsLinks.ToArray(),
+            RecoveryActionLabel: experience.RecoveryActionLabel);
     }
 
     private static ProviderSetupResult Failure(string providerName, string error)

--- a/src/Meridian.Contracts/Api/ProviderSetupApiModels.cs
+++ b/src/Meridian.Contracts/Api/ProviderSetupApiModels.cs
@@ -30,4 +30,12 @@ public sealed record ProviderSetupResult(
     ProviderCredentialSourceDto? CredentialSource = null,
     string? CredentialReference = null,
     string? Environment = null,
-    string[]? Warnings = null);
+    string[]? Warnings = null,
+    string? DisplayGroup = null,
+    string? ShortDescription = null,
+    string? HelpText = null,
+    string[]? SetupSteps = null,
+    string? WarningCopy = null,
+    string[]? AffectedWorkflows = null,
+    string[]? DocsLinks = null,
+    string? RecoveryActionLabel = null);

--- a/src/Meridian.Contracts/Configuration/ProviderConnectionDtos.cs
+++ b/src/Meridian.Contracts/Configuration/ProviderConnectionDtos.cs
@@ -94,7 +94,14 @@ public sealed record ProviderConnectionRowDto(
     string RecommendedAction,
     string ActionHref,
     IReadOnlyList<ProviderCredentialFieldMetadataDto>? CredentialFields = null,
-    IReadOnlyList<ProviderEnvironmentOptionDto>? EnvironmentOptions = null);
+    IReadOnlyList<ProviderEnvironmentOptionDto>? EnvironmentOptions = null,
+    string? DisplayGroup = null,
+    string? ShortDescription = null,
+    string? HelpText = null,
+    IReadOnlyList<string>? SetupSteps = null,
+    string? WarningCopy = null,
+    IReadOnlyList<string>? DocsLinks = null,
+    string? RecoveryActionLabel = null);
 
 public sealed record ProviderCredentialUpsertRequestDto(
     IReadOnlyDictionary<string, string?>? Credentials,

--- a/src/Meridian.DataIntegration/Credentials/FileProviderCredentialStore.cs
+++ b/src/Meridian.DataIntegration/Credentials/FileProviderCredentialStore.cs
@@ -228,11 +228,12 @@ public sealed class FileProviderCredentialStore : IProviderCredentialStore
         ProviderCredentialCatalogEntry descriptor,
         ProviderCredentialReadResult? readResult)
     {
+        var displayName = ProviderSetupExperienceCatalog.Find(descriptor.ProviderId).DisplayName;
         if (!descriptor.RequiresCredentials)
         {
             return new ProviderCredentialStoreStatus(
                 descriptor.ProviderId,
-                descriptor.DisplayName,
+                displayName,
                 ProviderCredentialStateDto.NotRequired,
                 ProviderCredentialSourceDto.NotRequired,
                 ProviderVerificationStateDto.NotRequired,
@@ -283,7 +284,7 @@ public sealed class FileProviderCredentialStore : IProviderCredentialStore
 
         return new ProviderCredentialStoreStatus(
             descriptor.ProviderId,
-            descriptor.DisplayName,
+            displayName,
             credentialState,
             credentialSource,
             verificationState,

--- a/src/Meridian.DataIntegration/Credentials/ProviderCredentialCatalog.cs
+++ b/src/Meridian.DataIntegration/Credentials/ProviderCredentialCatalog.cs
@@ -9,8 +9,6 @@ public static class ProviderCredentialCatalog
     [
         new(
             ProviderId: "alpaca",
-            DisplayName: "Alpaca",
-            Capability: ProviderConnectionCapabilityDto.DataAndBrokerage,
             RequiredFields:
             [
                 new ProviderCredentialFieldDefinition(
@@ -21,112 +19,57 @@ public static class ProviderCredentialCatalog
                     EnvironmentNames: [AlpacaCredentialEnvironment.SecretKeyName, ..AlpacaCredentialEnvironment.SecretKeyAliases])
             ],
             EnvironmentNames: [AlpacaCredentialEnvironment.TradingEnvironmentName],
-            DefaultEnvironment: AlpacaCredentialEnvironment.PaperEnvironment,
-            AffectedWorkflows:
-            [
-                "Trading readiness",
-                "Portfolio brokerage sync",
-                "Backfill fallback chain"
-            ],
-            RecommendedActionWhenMissing: "Add Alpaca paper API keys and verify /v2/account.",
-            ActionHref: "/settings#alpaca-provider-setup"),
+            DefaultEnvironment: AlpacaCredentialEnvironment.PaperEnvironment),
         new(
             ProviderId: "polygon",
-            DisplayName: "Polygon.io",
-            Capability: ProviderConnectionCapabilityDto.Data,
             RequiredFields:
             [
                 new ProviderCredentialFieldDefinition("ApiKey", ["POLYGON_API_KEY"])
-            ],
-            AffectedWorkflows: ["Historical backfill", "Market data validation"],
-            RecommendedActionWhenMissing: "Add the Polygon API key before routing data repair through Polygon."),
+            ]),
         new(
             ProviderId: "finnhub",
-            DisplayName: "Finnhub",
-            Capability: ProviderConnectionCapabilityDto.Data,
             RequiredFields:
             [
                 new ProviderCredentialFieldDefinition("ApiKey", ["FINNHUB_API_KEY"])
-            ],
-            AffectedWorkflows: ["Historical backfill", "Market data validation"],
-            RecommendedActionWhenMissing: "Add the Finnhub API key before enabling Finnhub as a repair source."),
+            ]),
         new(
             ProviderId: "tiingo",
-            DisplayName: "Tiingo",
-            Capability: ProviderConnectionCapabilityDto.Data,
             RequiredFields:
             [
                 new ProviderCredentialFieldDefinition("ApiKey", ["TIINGO_API_TOKEN", "TIINGO_API_KEY"])
-            ],
-            AffectedWorkflows: ["Historical backfill", "Market data validation"],
-            RecommendedActionWhenMissing: "Add the Tiingo token before using Tiingo for continuity repair."),
+            ]),
         new(
             ProviderId: "alphavantage",
-            DisplayName: "Alpha Vantage",
-            Capability: ProviderConnectionCapabilityDto.Data,
             RequiredFields:
             [
                 new ProviderCredentialFieldDefinition("ApiKey", ["ALPHA_VANTAGE_API_KEY", "ALPHAVANTAGE_API_KEY"])
-            ],
-            AffectedWorkflows: ["Historical backfill", "Market data validation"],
-            RecommendedActionWhenMissing: "Add the Alpha Vantage API key before using it as a fallback source."),
+            ]),
         new(
             ProviderId: "nasdaqdatalink",
-            DisplayName: "Nasdaq Data Link",
-            Capability: ProviderConnectionCapabilityDto.Data,
             RequiredFields:
             [
                 new ProviderCredentialFieldDefinition("ApiKey", ["NASDAQ_DATA_LINK_API_KEY", "NASDAQ_API_KEY"])
-            ],
-            AffectedWorkflows: ["Reference data", "Historical backfill"],
-            RecommendedActionWhenMissing: "Add the Nasdaq Data Link API key before routing reference-data repair."),
+            ]),
         new(
             ProviderId: "openfigi",
-            DisplayName: "OpenFIGI",
-            Capability: ProviderConnectionCapabilityDto.Data,
             RequiredFields:
             [
                 new ProviderCredentialFieldDefinition("ApiKey", ["OPENFIGI_API_KEY"])
-            ],
-            AffectedWorkflows: ["Security master resolution", "Reference data"],
-            RecommendedActionWhenMissing: "Add the OpenFIGI API key before enabling identifier repair."),
+            ]),
         new(
             ProviderId: "plaid",
-            DisplayName: "Plaid",
-            Capability: ProviderConnectionCapabilityDto.Data,
             RequiredFields:
             [
                 new ProviderCredentialFieldDefinition("ClientId", ["PLAID_CLIENT_ID"]),
                 new ProviderCredentialFieldDefinition("Secret", ["PLAID_SECRET", "PLAID_SANDBOX_SECRET", "PLAID_DEVELOPMENT_SECRET"])
             ],
             EnvironmentNames: ["PLAID_ENV", "PLAID_ENVIRONMENT"],
-            DefaultEnvironment: "sandbox",
-            AffectedWorkflows:
-            [
-                "Bank cash reconciliation",
-                "Treasury account verification",
-                "Investment account evidence",
-                "Sandbox transfer authorization"
-            ],
-            RecommendedActionWhenMissing: "Add Plaid client credentials before linking bank accounts or syncing Plaid evidence.",
-            ActionHref: "/settings#plaid-provider-setup"),
+            DefaultEnvironment: "sandbox"),
         new(
             ProviderId: "quickbooks-fixture",
-            DisplayName: "QuickBooks Fixture",
-            Capability: ProviderConnectionCapabilityDto.AccountingSystem,
-            RequiredFields: [],
-            AffectedWorkflows:
-            [
-                "External GL reconciliation",
-                "Accounting records evidence",
-                "Close-package trial balance review"
-            ],
-            RecommendedActionWhenMissing: "No credential action required; use the fixture to preview external GL reconciliation.",
-            ActionHref: "/settings#provider-quickbooks-fixture-connection"),
+            RequiredFields: []),
         new(
             ProviderId: "quickbooks",
-            DisplayName: "QuickBooks Online",
-            Capability: ProviderConnectionCapabilityDto.AccountingSystem,
             RequiredFields:
             [
                 new ProviderCredentialFieldDefinition("ClientId", ["QUICKBOOKS_CLIENT_ID", "QBO_CLIENT_ID"]),
@@ -136,43 +79,19 @@ public static class ProviderCredentialCatalog
                 new ProviderCredentialFieldDefinition("CompanyName", ["QUICKBOOKS_COMPANY_NAME", "QBO_COMPANY_NAME"], Required: false)
             ],
             EnvironmentNames: ["QUICKBOOKS_ENVIRONMENT"],
-            DefaultEnvironment: "sandbox",
-            AffectedWorkflows:
-            [
-                "External GL reconciliation",
-                "Accounting records evidence",
-                "Close-package trial balance review"
-            ],
-            RecommendedActionWhenMissing: "Add QuickBooks Online OAuth client ID, client secret, refresh token, and company realm ID before importing read-only GL evidence.",
-            ActionHref: "/settings#provider-quickbooks-connection"),
+            DefaultEnvironment: "sandbox"),
         new(
             ProviderId: "ib",
-            DisplayName: "Interactive Brokers",
-            Capability: ProviderConnectionCapabilityDto.DataAndBrokerage,
-            RequiredFields: [],
-            AffectedWorkflows: ["Trading readiness", "Brokerage sync", "Live market data"],
-            RecommendedActionWhenMissing: "Confirm IB Gateway is available before routing live brokerage workflows."),
+            RequiredFields: []),
         new(
             ProviderId: "yahoo",
-            DisplayName: "Yahoo Finance",
-            Capability: ProviderConnectionCapabilityDto.Data,
-            RequiredFields: [],
-            AffectedWorkflows: ["Historical backfill fallback"],
-            RecommendedActionWhenMissing: "No credential action required; monitor provider health before relying on fallback data."),
+            RequiredFields: []),
         new(
             ProviderId: "stooq",
-            DisplayName: "Stooq",
-            Capability: ProviderConnectionCapabilityDto.Data,
-            RequiredFields: [],
-            AffectedWorkflows: ["Historical backfill fallback"],
-            RecommendedActionWhenMissing: "No credential action required; monitor data coverage before relying on fallback data."),
+            RequiredFields: []),
         new(
             ProviderId: "synthetic",
-            DisplayName: "Synthetic",
-            Capability: ProviderConnectionCapabilityDto.Data,
-            RequiredFields: [],
-            AffectedWorkflows: ["Offline simulation", "Demo mode"],
-            RecommendedActionWhenMissing: "No credential action required for synthetic data.")
+            RequiredFields: [])
     ];
 
     private static readonly IReadOnlyDictionary<string, string> Aliases = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -203,174 +122,15 @@ public static class ProviderCredentialCatalog
         return Aliases.TryGetValue(trimmed, out var canonical) ? canonical : trimmed.ToLowerInvariant();
     }
 
-    public static IReadOnlyList<ProviderCredentialFieldMetadataDto> BuildCredentialFields(ProviderCredentialCatalogEntry entry)
-    {
-        ArgumentNullException.ThrowIfNull(entry);
-
-        return entry.RequiredFields
-            .Select(field => new ProviderCredentialFieldMetadataDto(
-                field.Name,
-                LabelCredentialField(field.Name),
-                field.Required,
-                ResolveCredentialInputKind(field.Name),
-                ResolveCredentialPlaceholder(field),
-                ResolveCredentialHelpText(entry.ProviderId, field)))
-            .ToArray();
-    }
-
-    public static IReadOnlyList<ProviderEnvironmentOptionDto> BuildEnvironmentOptions(ProviderCredentialCatalogEntry entry)
-    {
-        ArgumentNullException.ThrowIfNull(entry);
-
-        var environments = ResolveAllowedEnvironments(entry);
-        if (environments.Count == 0)
-        {
-            return [];
-        }
-
-        var defaultEnvironment = entry.NormalizeEnvironment(entry.DefaultEnvironment);
-        return environments
-            .Select(environment =>
-            {
-                var normalized = entry.NormalizeEnvironment(environment);
-                return new ProviderEnvironmentOptionDto(
-                    normalized,
-                    LabelEnvironment(normalized),
-                    string.Equals(normalized, defaultEnvironment, StringComparison.OrdinalIgnoreCase),
-                    ResolveEnvironmentHelpText(entry.ProviderId, normalized));
-            })
-            .GroupBy(option => option.Value, StringComparer.OrdinalIgnoreCase)
-            .Select(group => group.First())
-            .ToArray();
-    }
-
-    private static IReadOnlyList<string> ResolveAllowedEnvironments(ProviderCredentialCatalogEntry entry)
-        => entry.ProviderId.ToLowerInvariant() switch
-        {
-            "alpaca" => [AlpacaCredentialEnvironment.PaperEnvironment, AlpacaCredentialEnvironment.LiveEnvironment],
-            "plaid" => ["sandbox", "development", "production"],
-            "quickbooks" => ["sandbox", "production"],
-            _ when !string.IsNullOrWhiteSpace(entry.DefaultEnvironment) => [entry.DefaultEnvironment],
-            _ => []
-        };
-
-    private static ProviderCredentialInputKindDto ResolveCredentialInputKind(string fieldName)
-    {
-        if (fieldName.Contains("Url", StringComparison.OrdinalIgnoreCase) ||
-            fieldName.Contains("Endpoint", StringComparison.OrdinalIgnoreCase))
-        {
-            return ProviderCredentialInputKindDto.Url;
-        }
-
-        if (fieldName.Equals("RealmId", StringComparison.OrdinalIgnoreCase) ||
-            fieldName.Equals("CompanyName", StringComparison.OrdinalIgnoreCase))
-        {
-            return ProviderCredentialInputKindDto.Text;
-        }
-
-        return ProviderCredentialInputKindDto.Password;
-    }
-
-    private static string LabelCredentialField(string fieldName)
-        => fieldName switch
-        {
-            "ApiKey" => "API key",
-            "KeyId" => "Key ID",
-            "SecretKey" => "Secret key",
-            "ClientId" => "Client ID",
-            "ClientSecret" => "Client secret",
-            "RefreshToken" => "Refresh token",
-            "RealmId" => "Company realm ID",
-            "CompanyName" => "Company name",
-            "Secret" => "Secret",
-            _ => SplitPascalCase(fieldName)
-        };
-
-    private static string? ResolveCredentialPlaceholder(ProviderCredentialFieldDefinition field)
-        => field.EnvironmentNames.FirstOrDefault()
-           ?? (field.Required ? "Stored server-side and masked after save" : "Optional");
-
-    private static string ResolveCredentialHelpText(string providerId, ProviderCredentialFieldDefinition field)
-        => ProviderCredentialCatalog.NormalizeProviderId(providerId) switch
-        {
-            "alpaca" => "Stored in Meridian's encrypted local provider store for Alpaca account verification.",
-            "plaid" => "Used server-side to create Plaid link tokens and retain bank evidence.",
-            "quickbooks" => field.Name switch
-            {
-                "ClientId" => "Stored in Meridian's encrypted local provider store for OAuth token refresh.",
-                "ClientSecret" => "Used only server-side for OAuth token refresh.",
-                "RefreshToken" => "Token exchange refreshes read-only API access and stores rotated tokens locally.",
-                "RealmId" => "Selects the QuickBooks Online company to read.",
-                "CompanyName" => "Optional display label for the selected QuickBooks company.",
-                _ => "Stored in Meridian's encrypted local provider store and masked after save."
-            },
-            _ when field.Required => "Stored in Meridian's encrypted local provider store and masked after save.",
-            _ => "Optional provider metadata; no secret value is displayed after save."
-        };
-
-    private static string LabelEnvironment(string value)
-        => value switch
-        {
-            "paper" => "Paper",
-            "live" => "Live",
-            "sandbox" => "Sandbox",
-            "development" => "Development",
-            "production" => "Production",
-            _ => SplitPascalCase(value)
-        };
-
-    private static string ResolveEnvironmentHelpText(string providerId, string environment)
-        => ProviderCredentialCatalog.NormalizeProviderId(providerId) switch
-        {
-            "alpaca" when environment.Equals(AlpacaCredentialEnvironment.LiveEnvironment, StringComparison.OrdinalIgnoreCase)
-                => "Live Alpaca credentials remain gated by live-routing acknowledgement and execution controls.",
-            "alpaca" => "Paper is the default Alpaca environment for setup and verification.",
-            "plaid" when environment.Equals("production", StringComparison.OrdinalIgnoreCase)
-                => "Production Plaid credentials are used only for server-owned link and evidence sync flows.",
-            "plaid" => "Plaid sandbox and development environments support institution linking and evidence tests.",
-            "quickbooks" when environment.Equals("production", StringComparison.OrdinalIgnoreCase)
-                => "Production QuickBooks Online access remains read-only GL evidence import.",
-            "quickbooks" => "QuickBooks sandbox is the default for read-only GL evidence setup.",
-            _ => "Provider environment selected for server-side credential verification."
-        };
-
-    private static string SplitPascalCase(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return "Credential";
-        }
-
-        var chars = new List<char>(value.Length + 8);
-        for (var index = 0; index < value.Length; index++)
-        {
-            var current = value[index];
-            if (index > 0 && char.IsUpper(current) && !char.IsWhiteSpace(value[index - 1]))
-            {
-                chars.Add(' ');
-            }
-
-            chars.Add(current);
-        }
-
-        return new string(chars.ToArray());
-    }
 }
 
 public sealed record ProviderCredentialCatalogEntry(
     string ProviderId,
-    string DisplayName,
-    ProviderConnectionCapabilityDto Capability,
     IReadOnlyList<ProviderCredentialFieldDefinition> RequiredFields,
     IReadOnlyList<string>? EnvironmentNames = null,
-    string? DefaultEnvironment = null,
-    IReadOnlyList<string>? AffectedWorkflows = null,
-    string RecommendedActionWhenMissing = "Add and verify credentials before using this provider for repair.",
-    string? ActionHref = null)
+    string? DefaultEnvironment = null)
 {
     public bool RequiresCredentials => RequiredFields.Count > 0;
-
-    public string ResolvedActionHref => ActionHref ?? $"/settings#provider-{ProviderId}-connection";
 
     public string NormalizeEnvironment(string? value)
     {

--- a/src/Meridian.DataIntegration/Credentials/ProviderSetupExperienceCatalog.cs
+++ b/src/Meridian.DataIntegration/Credentials/ProviderSetupExperienceCatalog.cs
@@ -1,0 +1,138 @@
+using Meridian.Core.Config;
+using Meridian.Contracts.Configuration;
+
+namespace Meridian.DataIntegration.Credentials;
+
+public static class ProviderSetupExperienceCatalog
+{
+    private static readonly IReadOnlyList<ProviderSetupExperienceCatalogEntry> Entries =
+    [
+        new("alpaca", "Alpaca", ProviderConnectionCapabilityDto.DataAndBrokerage, "Brokerage and market data", "Connect Alpaca paper trading for account verification and market-data routing.", "Use paper keys first. Live credentials remain gated by verification and execution controls.", ["Create or open an Alpaca paper account.", "Copy the API key ID and secret key into Meridian.", "Verify /v2/account before routing brokerage workflows."], "Live Alpaca credentials must remain gated until certification passes.", ["Trading readiness", "Portfolio brokerage sync", "Backfill fallback chain"], ["docs/operators/README.md"], "Add Alpaca paper API keys and verify /v2/account.", "/settings#alpaca-provider-setup", "Verify Alpaca credentials"),
+        new("polygon", "Polygon.io", ProviderConnectionCapabilityDto.Data, "Market data", "Configure Polygon for historical repair and market-data validation.", "Store the Polygon API key in Meridian's encrypted provider vault.", ["Paste the Polygon API key.", "Save credentials.", "Run provider verification before using Polygon for repair."], null, ["Historical backfill", "Market data validation"], ["docs/operators/README.md"], "Add the Polygon API key before routing data repair through Polygon.", null, "Verify Polygon credentials"),
+        new("finnhub", "Finnhub", ProviderConnectionCapabilityDto.Data, "Market data", "Configure Finnhub as a continuity and validation data source.", "Store the Finnhub API key in Meridian's encrypted provider vault.", ["Paste the Finnhub API key.", "Save credentials.", "Review provider health before enabling repair routing."], null, ["Historical backfill", "Market data validation"], ["docs/operators/README.md"], "Add the Finnhub API key before enabling Finnhub as a repair source.", null, "Verify Finnhub credentials"),
+        new("tiingo", "Tiingo", ProviderConnectionCapabilityDto.Data, "Market data", "Configure Tiingo as a continuity repair source.", "Store the Tiingo token in Meridian's encrypted provider vault.", ["Paste the Tiingo token.", "Save credentials.", "Review data coverage before enabling fallback routing."], null, ["Historical backfill", "Market data validation"], ["docs/operators/README.md"], "Add the Tiingo token before using Tiingo for continuity repair.", null, "Verify Tiingo credentials"),
+        new("alphavantage", "Alpha Vantage", ProviderConnectionCapabilityDto.Data, "Market data", "Configure Alpha Vantage as a fallback market-data source.", "Store the Alpha Vantage API key in Meridian's encrypted provider vault.", ["Paste the Alpha Vantage API key.", "Save credentials.", "Confirm fallback routing limits before use."], null, ["Historical backfill", "Market data validation"], ["docs/operators/README.md"], "Add the Alpha Vantage API key before using it as a fallback source.", null, "Verify Alpha Vantage credentials"),
+        new("nasdaqdatalink", "Nasdaq Data Link", ProviderConnectionCapabilityDto.Data, "Reference data", "Configure Nasdaq Data Link for reference-data and historical repair.", "Store the Nasdaq Data Link API key in Meridian's encrypted provider vault.", ["Paste the Nasdaq Data Link API key.", "Save credentials.", "Review reference-data routing before use."], null, ["Reference data", "Historical backfill"], ["docs/operators/README.md"], "Add the Nasdaq Data Link API key before routing reference-data repair.", null, "Verify Nasdaq Data Link credentials"),
+        new("openfigi", "OpenFIGI", ProviderConnectionCapabilityDto.Data, "Reference data", "Configure OpenFIGI for security-master identifier repair.", "Store the OpenFIGI API key in Meridian's encrypted provider vault.", ["Paste the OpenFIGI API key.", "Save credentials.", "Review identifier repair readiness."], null, ["Security master resolution", "Reference data"], ["docs/operators/README.md"], "Add the OpenFIGI API key before enabling identifier repair.", null, "Verify OpenFIGI credentials"),
+        new("plaid", "Plaid", ProviderConnectionCapabilityDto.Data, "Bank connectivity", "Link bank and investment accounts for retained cash and evidence workflows.", "Plaid credentials are used server-side for link-token creation and evidence sync.", ["Select the Plaid environment.", "Save client ID and secret.", "Open Link to connect institutions."], "Production Plaid credentials should only be used for governed evidence sync flows.", ["Bank cash reconciliation", "Treasury account verification", "Investment account evidence", "Sandbox transfer authorization"], ["docs/operators/README.md"], "Add Plaid client credentials before linking bank accounts or syncing Plaid evidence.", "/settings#plaid-provider-setup", "Open Plaid Link"),
+        new("quickbooks-fixture", "QuickBooks Fixture", ProviderConnectionCapabilityDto.AccountingSystem, "Accounting systems", "Preview external GL reconciliation with the built-in fixture.", "No credential action is required for fixture evidence.", ["Enable the fixture connection.", "Import trial-balance evidence.", "Compare fixture results in reconciliation views."], null, ["External GL reconciliation", "Accounting records evidence", "Close-package trial balance review"], ["docs/operators/README.md"], "No credential action required; use the fixture to preview external GL reconciliation.", "/settings#provider-quickbooks-fixture-connection", "Open fixture connection"),
+        new("quickbooks", "QuickBooks Online", ProviderConnectionCapabilityDto.AccountingSystem, "Accounting systems", "Connect QuickBooks Online for read-only GL evidence import.", "OAuth values are stored server-side and used only for read-only accounting evidence import.", ["Select sandbox or production.", "Save OAuth client, refresh token, realm, and optional company label.", "Verify read-only company access before importing GL evidence."], "Posting and export remain disabled; QuickBooks access is read-only.", ["External GL reconciliation", "Accounting records evidence", "Close-package trial balance review"], ["docs/operators/README.md"], "Add QuickBooks Online OAuth client ID, client secret, refresh token, and company realm ID before importing read-only GL evidence.", "/settings#provider-quickbooks-connection", "Verify QuickBooks connection"),
+        new("ib", "Interactive Brokers", ProviderConnectionCapabilityDto.DataAndBrokerage, "Brokerage and market data", "Connect Interactive Brokers Gateway for brokerage and market-data workflows.", "Confirm Gateway availability before routing live workflows.", ["Start IB Gateway.", "Confirm endpoint settings.", "Verify provider health before routing workflows."], "Live brokerage routing remains gated by execution controls.", ["Trading readiness", "Brokerage sync", "Live market data"], ["docs/operators/README.md"], "Confirm IB Gateway is available before routing live brokerage workflows.", null, "Check IB Gateway"),
+        new("yahoo", "Yahoo Finance", ProviderConnectionCapabilityDto.Data, "Fallback data", "Use Yahoo Finance as a no-credential historical fallback.", "Monitor coverage before relying on fallback data.", ["Enable the provider.", "Review health and coverage.", "Use as a fallback only when primary sources are unavailable."], null, ["Historical backfill fallback"], ["docs/operators/README.md"], "No credential action required; monitor provider health before relying on fallback data.", null, "Review Yahoo health"),
+        new("stooq", "Stooq", ProviderConnectionCapabilityDto.Data, "Fallback data", "Use Stooq as a no-credential historical fallback.", "Monitor data coverage before relying on fallback data.", ["Enable the provider.", "Review health and coverage.", "Use as a fallback only when primary sources are unavailable."], null, ["Historical backfill fallback"], ["docs/operators/README.md"], "No credential action required; monitor data coverage before relying on fallback data.", null, "Review Stooq health"),
+        new("synthetic", "Synthetic", ProviderConnectionCapabilityDto.Data, "Simulation", "Use deterministic synthetic data for offline simulation and demos.", "Synthetic data is not market evidence.", ["Select synthetic data.", "Run offline workflows.", "Do not use synthetic rows as retained source evidence."], null, ["Offline simulation", "Demo mode"], ["docs/operators/README.md"], "No credential action required for synthetic data.", null, "Open synthetic setup")
+    ];
+
+    public static ProviderSetupExperienceCatalogEntry Find(string providerId)
+        => Entries.FirstOrDefault(entry => string.Equals(entry.ProviderId, ProviderCredentialCatalog.NormalizeProviderId(providerId), StringComparison.OrdinalIgnoreCase))
+           ?? ProviderSetupExperienceCatalogEntry.Default(ProviderCredentialCatalog.NormalizeProviderId(providerId));
+
+    public static IReadOnlyList<ProviderCredentialFieldMetadataDto> BuildCredentialFields(ProviderCredentialCatalogEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        return entry.RequiredFields.Select(field => new ProviderCredentialFieldMetadataDto(field.Name, LabelCredentialField(field.Name), field.Required, ResolveCredentialInputKind(field.Name), field.EnvironmentNames.FirstOrDefault() ?? (field.Required ? "Stored server-side and masked after save" : "Optional"), ResolveCredentialHelpText(entry.ProviderId, field))).ToArray();
+    }
+
+    public static IReadOnlyList<ProviderEnvironmentOptionDto> BuildEnvironmentOptions(ProviderCredentialCatalogEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        var environments = ResolveAllowedEnvironments(entry);
+        if (environments.Count == 0) return [];
+        var defaultEnvironment = entry.NormalizeEnvironment(entry.DefaultEnvironment);
+        return environments.Select(environment =>
+        {
+            var normalized = entry.NormalizeEnvironment(environment);
+            return new ProviderEnvironmentOptionDto(normalized, LabelEnvironment(normalized), string.Equals(normalized, defaultEnvironment, StringComparison.OrdinalIgnoreCase), ResolveEnvironmentHelpText(entry.ProviderId, normalized));
+        }).GroupBy(option => option.Value, StringComparer.OrdinalIgnoreCase).Select(group => group.First()).ToArray();
+    }
+
+    private static IReadOnlyList<string> ResolveAllowedEnvironments(ProviderCredentialCatalogEntry entry)
+        => entry.ProviderId.ToLowerInvariant() switch
+        {
+            "alpaca" => [AlpacaCredentialEnvironment.PaperEnvironment, AlpacaCredentialEnvironment.LiveEnvironment],
+            "plaid" => ["sandbox", "development", "production"],
+            "quickbooks" => ["sandbox", "production"],
+            _ when !string.IsNullOrWhiteSpace(entry.DefaultEnvironment) => [entry.DefaultEnvironment],
+            _ => []
+        };
+
+    private static ProviderCredentialInputKindDto ResolveCredentialInputKind(string fieldName)
+        => fieldName.Contains("Url", StringComparison.OrdinalIgnoreCase) || fieldName.Contains("Endpoint", StringComparison.OrdinalIgnoreCase)
+            ? ProviderCredentialInputKindDto.Url
+            : fieldName.Equals("RealmId", StringComparison.OrdinalIgnoreCase) || fieldName.Equals("CompanyName", StringComparison.OrdinalIgnoreCase)
+                ? ProviderCredentialInputKindDto.Text
+                : ProviderCredentialInputKindDto.Password;
+
+    private static string LabelCredentialField(string fieldName)
+        => fieldName switch
+        {
+            "ApiKey" => "API key", "KeyId" => "Key ID", "SecretKey" => "Secret key", "ClientId" => "Client ID", "ClientSecret" => "Client secret", "RefreshToken" => "Refresh token", "RealmId" => "Company realm ID", "CompanyName" => "Company name", "Secret" => "Secret", _ => SplitPascalCase(fieldName)
+        };
+
+    private static string ResolveCredentialHelpText(string providerId, ProviderCredentialFieldDefinition field)
+        => ProviderCredentialCatalog.NormalizeProviderId(providerId) switch
+        {
+            "alpaca" => "Stored in Meridian's encrypted local provider store for Alpaca account verification.",
+            "plaid" => "Used server-side to create Plaid link tokens and retain bank evidence.",
+            "quickbooks" => field.Name switch
+            {
+                "ClientId" => "Stored in Meridian's encrypted local provider store for OAuth token refresh.",
+                "ClientSecret" => "Used only server-side for OAuth token refresh.",
+                "RefreshToken" => "Token exchange refreshes read-only API access and stores rotated tokens locally.",
+                "RealmId" => "Selects the QuickBooks Online company to read.",
+                "CompanyName" => "Optional display label for the selected QuickBooks company.",
+                _ => "Stored in Meridian's encrypted local provider store and masked after save."
+            },
+            _ when field.Required => "Stored in Meridian's encrypted local provider store and masked after save.",
+            _ => "Optional provider metadata; no secret value is displayed after save."
+        };
+
+    private static string LabelEnvironment(string value)
+        => value switch { "paper" => "Paper", "live" => "Live", "sandbox" => "Sandbox", "development" => "Development", "production" => "Production", _ => SplitPascalCase(value) };
+
+    private static string ResolveEnvironmentHelpText(string providerId, string environment)
+        => ProviderCredentialCatalog.NormalizeProviderId(providerId) switch
+        {
+            "alpaca" when environment.Equals(AlpacaCredentialEnvironment.LiveEnvironment, StringComparison.OrdinalIgnoreCase) => "Live Alpaca credentials remain gated by live-routing acknowledgement and execution controls.",
+            "alpaca" => "Paper is the default Alpaca environment for setup and verification.",
+            "plaid" when environment.Equals("production", StringComparison.OrdinalIgnoreCase) => "Production Plaid credentials are used only for server-owned link and evidence sync flows.",
+            "plaid" => "Plaid sandbox and development environments support institution linking and evidence tests.",
+            "quickbooks" when environment.Equals("production", StringComparison.OrdinalIgnoreCase) => "Production QuickBooks Online access remains read-only GL evidence import.",
+            "quickbooks" => "QuickBooks sandbox is the default for read-only GL evidence setup.",
+            _ => "Provider environment selected for server-side credential verification."
+        };
+
+    private static string SplitPascalCase(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return "Credential";
+        var chars = new List<char>(value.Length + 8);
+        for (var index = 0; index < value.Length; index++)
+        {
+            var current = value[index];
+            if (index > 0 && char.IsUpper(current) && !char.IsWhiteSpace(value[index - 1])) chars.Add(' ');
+            chars.Add(current);
+        }
+        return new string(chars.ToArray());
+    }
+}
+
+public sealed record ProviderSetupExperienceCatalogEntry(
+    string ProviderId,
+    string DisplayName,
+    ProviderConnectionCapabilityDto Capability,
+    string DisplayGroup,
+    string ShortDescription,
+    string HelpText,
+    IReadOnlyList<string> SetupSteps,
+    string? WarningCopy,
+    IReadOnlyList<string> AffectedWorkflows,
+    IReadOnlyList<string> DocsLinks,
+    string RecommendedActionWhenMissing,
+    string? ActionHref,
+    string RecoveryActionLabel)
+{
+    public string ResolvedActionHref => ActionHref ?? $"/settings#provider-{ProviderId}-connection";
+
+    public static ProviderSetupExperienceCatalogEntry Default(string providerId)
+        => new(providerId, providerId, ProviderConnectionCapabilityDto.Data, "Provider", "Configure provider credentials.", "Add and verify credentials before using this provider for repair.", ["Add credentials.", "Save setup.", "Verify provider readiness."], null, [], [], "Add and verify credentials before using this provider for repair.", null, "Verify provider");
+}

--- a/src/Meridian.DataIntegration/README.md
+++ b/src/Meridian.DataIntegration/README.md
@@ -23,7 +23,8 @@ This module belongs to the Design Module layer. Keep changes within that ownersh
 ## Key folders and files
 
 - `src/Meridian.DataIntegration` - registered source module root.
-- `Credentials/ProviderCredentialCatalog.cs` - canonical provider credential descriptors, field mappings, environment normalization, and credential-source projection.
+- `Credentials/ProviderCredentialCatalog.cs` - canonical provider credential descriptors, aliases, field mappings, environment fallback names, environment normalization, and credential-source projection.
+- `Credentials/ProviderSetupExperienceCatalog.cs` - value-free provider setup experience metadata such as display groups, help copy, setup steps, warnings, affected workflows, docs links, and recovery labels.
 - `Credentials/ICredentialStore.cs` - provider-neutral credential-store contract, credential metadata, validation result, and common credential extension helpers.
 - `Credentials/IProviderCredentialStore.cs` - provider-neutral encrypted credential store contract and mutation/read result models.
 - `Credentials/FileProviderCredentialStore.cs` - local encrypted provider credential vault with audit metadata, verification status, and environment fallback handling.
@@ -75,10 +76,14 @@ Use this README to understand the module before editing source files. Update the
 QuickBooks accounting-system integration lives in this module. The adapter family imports chart-of-accounts, journal-entry, and trial-balance evidence as read-only reconciliation input through `IAccountingSystemProvider`, refreshes OAuth access tokens through the server-side QuickBooks client seam, records connection verification posture, maps provider-vault credentials into the QuickBooks connection store, and leaves posting/export disabled. UI Shared registers the Data Integration providers and connection store; it does not own QuickBooks transport, credential persistence mapping, or import mapping.
 
 Provider credential catalog, credential-store contracts, vault, status, and OAuth record ownership also lives in this module. Application and UI layers may orchestrate setup, testing, token refresh, and endpoint projection, but provider credential descriptors, encrypted local storage, validation metadata, verification metadata, expiration policy records, OAuth token records, and provider-environment normalization must stay behind the `Meridian.DataIntegration.Credentials` seam. Saved provider secrets are written to the encrypted local vault with rotation metadata and verification-required state; environment fallback is for Development/Test or explicit migration override only and is disabled for packaged/customer builds.
-`ProviderCredentialCatalog` also owns the value-free provider setup metadata projected to UI clients:
-credential field identifiers, labels, required flags, input kinds, safe help text, action routes,
-and allowed/default environments. Do not move stored credential values or environment variable
-contents into that metadata projection.
+`ProviderCredentialCatalog` owns stable credential metadata only: provider IDs, aliases,
+required credential field identifiers, read-only environment-variable fallback names, and
+provider environment normalization/defaults. User-facing setup copy lives separately in
+`ProviderSetupExperienceCatalog`, which projects display groups, short descriptions, help text,
+setup steps, warnings, affected workflows, docs links, recovery labels, credential field labels,
+input kinds, safe help text, action routes, and allowed/default environment options to UI clients.
+Do not move stored credential values or environment variable contents into either metadata
+projection.
 
 Market-event filtering and provider-depth-buffer self-tests live in this module because they
 validate and route provider-ingested event streams before higher-level application orchestration.

--- a/src/Meridian.Ui.Shared/Endpoints/ProviderCredentialEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ProviderCredentialEndpoints.cs
@@ -50,7 +50,7 @@ public static class ProviderCredentialEndpoints
                 Status: isValid ? "Valid" : "Invalid",
                 ErrorMessage: isValid
                     ? null
-                    : $"Credentials for {descriptor.DisplayName} are incomplete or invalid.",
+                    : $"Credentials for {ProviderSetupExperienceCatalog.Find(descriptor.ProviderId).DisplayName} are incomplete or invalid.",
                 LastVerified: DateTime.UtcNow,
                 Details: new Dictionary<string, string>
                 {

--- a/src/Meridian.Ui.Shared/Services/ProviderConnectionLifecycleService.cs
+++ b/src/Meridian.Ui.Shared/Services/ProviderConnectionLifecycleService.cs
@@ -245,14 +245,15 @@ public sealed class ProviderConnectionLifecycleService
         ProviderCredentialStoreStatus status,
         ProviderMetrics? metrics)
     {
+        var experience = ProviderSetupExperienceCatalog.Find(descriptor.ProviderId);
         var health = ResolveHealth(status, metrics);
         var lastSuccessfulAt = status.LastSuccessfulAt ?? (metrics?.IsConnected == true ? metrics.Timestamp : null);
         var lastFailureAt = status.LastFailureAt ?? (metrics is { IsConnected: false, ConnectionFailures: > 0 } ? metrics.Timestamp : null);
 
         return new ProviderConnectionRowDto(
             ProviderId: descriptor.ProviderId,
-            DisplayName: descriptor.DisplayName,
-            Capability: descriptor.Capability,
+            DisplayName: experience.DisplayName,
+            Capability: experience.Capability,
             CredentialState: status.CredentialState,
             CredentialSource: status.CredentialSource,
             VerificationState: status.VerificationState,
@@ -265,11 +266,18 @@ public sealed class ProviderConnectionLifecycleService
             MaskedKeyPreview: status.MaskedKeyPreview,
             Environment: status.Environment,
             ExternalAccountId: status.ExternalAccountId,
-            AffectedWorkflows: descriptor.AffectedWorkflows ?? [],
-            RecommendedAction: ResolveRecommendedAction(descriptor, status, health),
-            ActionHref: descriptor.ResolvedActionHref,
-            CredentialFields: ProviderCredentialCatalog.BuildCredentialFields(descriptor),
-            EnvironmentOptions: ProviderCredentialCatalog.BuildEnvironmentOptions(descriptor));
+            AffectedWorkflows: experience.AffectedWorkflows,
+            RecommendedAction: ResolveRecommendedAction(experience, status, health),
+            ActionHref: experience.ResolvedActionHref,
+            CredentialFields: ProviderSetupExperienceCatalog.BuildCredentialFields(descriptor),
+            EnvironmentOptions: ProviderSetupExperienceCatalog.BuildEnvironmentOptions(descriptor),
+            DisplayGroup: experience.DisplayGroup,
+            ShortDescription: experience.ShortDescription,
+            HelpText: experience.HelpText,
+            SetupSteps: experience.SetupSteps,
+            WarningCopy: experience.WarningCopy,
+            DocsLinks: experience.DocsLinks,
+            RecoveryActionLabel: experience.RecoveryActionLabel);
     }
 
     private static ProviderContinuityHealthDto ResolveHealth(
@@ -305,7 +313,7 @@ public sealed class ProviderConnectionLifecycleService
     }
 
     private static string ResolveRecommendedAction(
-        ProviderCredentialCatalogEntry descriptor,
+        ProviderSetupExperienceCatalogEntry experience,
         ProviderCredentialStoreStatus status,
         ProviderContinuityHealthDto health)
     {
@@ -316,7 +324,7 @@ public sealed class ProviderConnectionLifecycleService
 
         if (status.CredentialState is ProviderCredentialStateDto.Missing or ProviderCredentialStateDto.Partial)
         {
-            return descriptor.RecommendedActionWhenMissing;
+            return experience.RecommendedActionWhenMissing;
         }
 
         if (status.CredentialState == ProviderCredentialStateDto.Invalid)

--- a/src/Meridian.Ui.Shared/Services/ProviderReadinessService.cs
+++ b/src/Meridian.Ui.Shared/Services/ProviderReadinessService.cs
@@ -57,6 +57,7 @@ public sealed class ProviderReadinessService
             var connection = FindConnection(connections, providerId);
             var source = FindSource(configuredProviders, providerId);
             var providerMetrics = FindMetrics(metrics, providerId, source);
+            var experience = descriptor is null ? ProviderSetupExperienceCatalog.Find(providerId) : ProviderSetupExperienceCatalog.Find(descriptor.ProviderId);
             var degradationScore = scorer?.GetScore(providerId).CompositeScore;
             var isEnabled = source?.Enabled ?? connection is not null || descriptor is not null;
             var isConnected = providerMetrics is not null
@@ -69,8 +70,8 @@ public sealed class ProviderReadinessService
 
             rows.Add(new ProviderReadinessRowDto(
                 ProviderId: descriptor?.ProviderId ?? providerId,
-                DisplayName: connection?.DisplayName ?? descriptor?.DisplayName ?? source?.Name ?? providerId,
-                Capability: connection?.Capability ?? descriptor?.Capability ?? ProviderConnectionCapabilityDto.Data,
+                DisplayName: connection?.DisplayName ?? experience.DisplayName ?? source?.Name ?? providerId,
+                Capability: connection?.Capability ?? experience.Capability,
                 Status: status,
                 CredentialState: connection?.CredentialState ?? (descriptor?.RequiresCredentials == true ? ProviderCredentialStateDto.Missing : ProviderCredentialStateDto.NotRequired),
                 CredentialSource: connection?.CredentialSource ?? (descriptor?.RequiresCredentials == true ? ProviderCredentialSourceDto.None : ProviderCredentialSourceDto.NotRequired),
@@ -87,13 +88,13 @@ public sealed class ProviderReadinessService
                 MaskedKeyPreview: connection?.MaskedKeyPreview,
                 Environment: connection?.Environment ?? descriptor?.DefaultEnvironment,
                 ExternalAccountId: connection?.ExternalAccountId,
-                AffectedWorkflows: connection?.AffectedWorkflows ?? descriptor?.AffectedWorkflows ?? [],
-                RecommendedAction: ResolveRecommendedAction(status, connection, descriptor, degradationScore),
-                ActionHref: connection?.ActionHref ?? descriptor?.ResolvedActionHref ?? "/settings#providers",
+                AffectedWorkflows: connection?.AffectedWorkflows ?? experience.AffectedWorkflows,
+                RecommendedAction: ResolveRecommendedAction(status, connection, experience, degradationScore),
+                ActionHref: connection?.ActionHref ?? experience.ResolvedActionHref,
                 Evidence: BuildEvidence(providerId, connection, providerMetrics, degradationScore, plaidItems, plaidAccounts),
-                RecoveryActions: BuildRecoveryActions(providerId, status, connection, descriptor),
-                CredentialFields: descriptor is null ? [] : ProviderCredentialCatalog.BuildCredentialFields(descriptor),
-                EnvironmentOptions: descriptor is null ? [] : ProviderCredentialCatalog.BuildEnvironmentOptions(descriptor)));
+                RecoveryActions: BuildRecoveryActions(providerId, status, connection, experience),
+                CredentialFields: descriptor is null ? [] : ProviderSetupExperienceCatalog.BuildCredentialFields(descriptor),
+                EnvironmentOptions: descriptor is null ? [] : ProviderSetupExperienceCatalog.BuildEnvironmentOptions(descriptor)));
         }
 
         var ordered = rows
@@ -196,15 +197,15 @@ public sealed class ProviderReadinessService
     private static string ResolveRecommendedAction(
         ProviderReadinessStatusDto status,
         ProviderConnectionRowDto? connection,
-        ProviderCredentialCatalogEntry? descriptor,
+        ProviderSetupExperienceCatalogEntry experience,
         double? degradationScore)
         => status switch
         {
             ProviderReadinessStatusDto.Ready => "No provider readiness action required.",
-            ProviderReadinessStatusDto.Blocked => connection?.RecommendedAction ?? descriptor?.RecommendedActionWhenMissing ?? "Repair provider credentials before routing dependent workflows.",
+            ProviderReadinessStatusDto.Blocked => connection?.RecommendedAction ?? experience.RecommendedActionWhenMissing,
             ProviderReadinessStatusDto.Degraded when degradationScore is not null => "Review degradation evidence and fallback routing before accepting downstream readiness.",
             ProviderReadinessStatusDto.Degraded => "Review provider health and fallback routing before accepting downstream readiness.",
-            _ => connection?.RecommendedAction ?? descriptor?.RecommendedActionWhenMissing ?? "Review provider setup before routing dependent workflows."
+            _ => connection?.RecommendedAction ?? experience.RecommendedActionWhenMissing
         };
 
     private static IReadOnlyList<ProviderReadinessEvidenceDto> BuildEvidence(
@@ -261,9 +262,9 @@ public sealed class ProviderReadinessService
         string providerId,
         ProviderReadinessStatusDto status,
         ProviderConnectionRowDto? connection,
-        ProviderCredentialCatalogEntry? descriptor)
+        ProviderSetupExperienceCatalogEntry experience)
     {
-        var target = connection?.ActionHref ?? descriptor?.ResolvedActionHref ?? "/settings#providers";
+        var target = connection?.ActionHref ?? experience.ResolvedActionHref;
         var actions = new List<ProviderRecoveryActionDto>
         {
             new($"provider.{providerId}.open-setup", "Open setup", target, RequiresMutation: false)

--- a/tests/Meridian.Tests/Application/Config/ProviderCredentialStoreTests.cs
+++ b/tests/Meridian.Tests/Application/Config/ProviderCredentialStoreTests.cs
@@ -134,7 +134,7 @@ public sealed class ProviderCredentialStoreTests : IDisposable
 
         descriptor.Should().NotBeNull();
         descriptor!.ProviderId.Should().Be("plaid");
-        descriptor.ResolvedActionHref.Should().Be("/settings#plaid-provider-setup");
+        ProviderSetupExperienceCatalog.Find(descriptor.ProviderId).ResolvedActionHref.Should().Be("/settings#plaid-provider-setup");
         status.Environment.Should().Be(expectedEnvironment);
         status.CredentialState.Should().Be(ProviderCredentialStateDto.Configured);
     }
@@ -164,7 +164,7 @@ public sealed class ProviderCredentialStoreTests : IDisposable
 
         descriptor.Should().NotBeNull();
         descriptor!.RequiresCredentials.Should().BeTrue();
-        descriptor.ResolvedActionHref.Should().Be("/settings#provider-quickbooks-connection");
+        ProviderSetupExperienceCatalog.Find(descriptor.ProviderId).ResolvedActionHref.Should().Be("/settings#provider-quickbooks-connection");
         status.Environment.Should().Be("production");
         status.CredentialState.Should().Be(ProviderCredentialStateDto.Configured);
         status.MissingFields.Should().BeEmpty();
@@ -278,6 +278,50 @@ public sealed class ProviderCredentialStoreTests : IDisposable
         auditText.Should().Contain("\"action\":\"delete\"");
         auditText.Should().Contain("\"actor\":\"test-operator\"");
         auditText.Should().NotContain("finnhub-secret");
+    }
+
+    [Fact]
+    public void ProviderCatalogs_EnvironmentFallbackMetadata_DoesNotDriveUserFacingSetupCopy()
+    {
+        var descriptor = ProviderCredentialCatalog.Find("plaid-api");
+
+        descriptor.Should().NotBeNull();
+        descriptor!.RequiredFields.SelectMany(field => field.EnvironmentNames).Should().Contain("PLAID_SANDBOX_SECRET");
+
+        var experience = ProviderSetupExperienceCatalog.Find(descriptor.ProviderId);
+        experience.DisplayName.Should().Be("Plaid");
+        experience.ShortDescription.Should().Contain("Link bank and investment accounts");
+        experience.HelpText.Should().NotContain("PLAID_SANDBOX_SECRET");
+        experience.SetupSteps.Should().Contain(step => step.Contains("Open Link", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task SaveAsync_UserFacingSetupCopy_DoesNotAffectCredentialPersistence()
+    {
+        var store = new FileProviderCredentialStore(_root);
+        var experience = ProviderSetupExperienceCatalog.Find("quickbooks-online");
+
+        await store.SaveAsync(new ProviderCredentialSaveRequest(
+            "quickbooks-online",
+            new Dictionary<string, string?>
+            {
+                ["ClientId"] = "qbo-client-id",
+                ["ClientSecret"] = "qbo-client-secret",
+                ["RefreshToken"] = "qbo-refresh-token",
+                ["RealmId"] = "9130359087654321"
+            },
+            Environment: "sandbox",
+            Actor: "test-operator"));
+
+        var read = await store.ReadForProviderAsync("quickbooks");
+        var vaultText = await File.ReadAllTextAsync(store.VaultPath);
+
+        read.Should().NotBeNull();
+        read!.Get("ClientId").Should().Be("qbo-client-id");
+        read.Get("RealmId").Should().Be("9130359087654321");
+        vaultText.Should().NotContain(experience.ShortDescription);
+        vaultText.Should().NotContain(experience.HelpText);
+        vaultText.Should().NotContain(experience.RecoveryActionLabel);
     }
 
     private sealed class EnvironmentScope : IDisposable


### PR DESCRIPTION
### Motivation
- Separate stable credential metadata from user-facing setup copy so credential persistence can evolve without affecting UX text. 
- Provide a dedicated catalog for end-user setup experience (display group, help text, steps, warnings, docs links, recovery labels) so handlers keep behavior and state. 
- Compose credential metadata, UX copy, and handler state at read-model and endpoint boundaries to simplify UI surfaces and keep catalogs value-free.

### Description
- Trimmed `ProviderCredentialCatalog` to own only stable credential metadata: `ProviderId`, aliases, `RequiredFields`, environment fallback names, and environment normalization/defaults. 
- Added `ProviderSetupExperienceCatalog` (`src/Meridian.DataIntegration/Credentials/ProviderSetupExperienceCatalog.cs`) containing UX metadata such as `DisplayGroup`, `ShortDescription`, `HelpText`, `SetupSteps`, `WarningCopy`, `AffectedWorkflows`, `DocsLinks`, and `RecoveryActionLabel`. 
- Updated composition points so read models/endpoints return a single DTO that merges credential metadata, UX metadata, and runtime handler/state; specifically changed `ProviderConnectionLifecycleService.BuildRow`, `ProviderReadinessService`, and `ProviderSetupService` to use the experience catalog and return the additional UX fields. 
- Extended contracts to carry the UX fields in `ProviderSetupResult` and `ProviderConnectionRowDto` and moved credential field label/help/environments projection into the experience catalog helpers; also updated `FileProviderCredentialStore` to source display name from the experience catalog for status projection. 
- Added tests (`tests/Meridian.Tests/Application/Config/ProviderCredentialStoreTests.cs`) that assert environment-fallback names remain in the credential catalog while user-facing copy is driven by the experience catalog and that UX copy is not persisted into the credential vault, and updated module README to document the split.

### Testing
- Ran repository validation `git diff --check` which reported no whitespace or index issues. 
- Attempted to run the narrow unit tests with `dotnet test tests/Meridian.Tests --filter ProviderCredentialStoreTests` but `dotnet` is not available in this environment so the test run was not executed. 
- New regression tests were added to `ProviderCredentialStoreTests` to verify that credential metadata and UX copy are independently owned but those tests were not executed here due to the unavailable `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a306e412bc48320b51428fff76eed47)