### PR TITLE
Gate provider setup routing on credential verification

### DIFF
--- a/src/Meridian.Application/ProviderRouting/ProviderSetupService.cs
+++ b/src/Meridian.Application/ProviderRouting/ProviderSetupService.cs
@@ -123,12 +123,28 @@ public sealed class ProviderSetupService
         var bindings = (section.Bindings ?? Array.Empty<ProviderBindingConfig>()).ToList();
         var providerId = BuildProviderId(descriptor.ProviderId, sources, connections);
         var sourcePriority = sources.Count == 0 ? 10 : Math.Max(10, sources.Count * 10 + 10);
+        var intendedConnectionMode = ResolveConnectionMode(credentialStatus.Environment, normalizedCapabilities);
+        var hasExplicitCertification = HasActiveProductionCertification(section, providerId);
+        var routeEnabled = CanActivateRouting(descriptor, credentialStatus);
+        var liveRoutingBlocked = IsLiveMode(intendedConnectionMode) &&
+                                 (!routeEnabled || !hasExplicitCertification);
+        var connectionEnabled = routeEnabled && !liveRoutingBlocked;
+        var connectionMode = liveRoutingBlocked ? ProviderConnectionMode.ReadOnly : intendedConnectionMode;
+        if (descriptor.RequiresCredentials && !routeEnabled)
+        {
+            warnings.Add("Credentials were saved, but provider routing remains disabled until all required credentials are present and verification succeeds.");
+        }
+
+        if (liveRoutingBlocked)
+        {
+            warnings.Add("Credentials were saved, but live provider routing remains disabled until credentials are verified and an explicit provider certification is recorded.");
+        }
 
         sources.Add(new DataSourceConfig(
             Id: providerId,
             Name: displayName,
             Provider: sourceKind.Value,
-            Enabled: true,
+            Enabled: connectionEnabled,
             Type: sourceType,
             Priority: sourcePriority,
             Alpaca: sourceKind.Value == DataSourceKind.Alpaca
@@ -148,12 +164,12 @@ public sealed class ProviderSetupService
             ProviderFamilyId: descriptor.ProviderId,
             DisplayName: displayName,
             ConnectionType: ProviderConnectionType.DataVendor,
-            ConnectionMode: ResolveConnectionMode(credentialStatus.Environment, normalizedCapabilities),
-            Enabled: true,
+            ConnectionMode: connectionMode,
+            Enabled: connectionEnabled,
             CredentialReference: credentialReference,
             Tags: normalizedCapabilities,
             Description: $"Configured from the provider setup form for {displayName}.",
-            ProductionReady: false);
+            ProductionReady: routeEnabled && hasExplicitCertification);
 
         var existingConnectionIndex = connections.FindIndex(c =>
             string.Equals(c.ConnectionId, providerId, StringComparison.OrdinalIgnoreCase));
@@ -166,7 +182,7 @@ public sealed class ProviderSetupService
             connections.Add(connection);
         }
 
-        var seededBindingIds = SeedBindings(providerId, normalizedCapabilities, sourceType, sourcePriority, bindings);
+        var seededBindingIds = SeedBindings(providerId, normalizedCapabilities, sourceType, sourcePriority, connectionEnabled, bindings);
         var nextDataSources = dataSources with
         {
             Sources = sources.ToArray(),
@@ -333,6 +349,7 @@ public sealed class ProviderSetupService
         IReadOnlyList<string> capabilities,
         DataSourceType sourceType,
         int priority,
+        bool enabled,
         List<ProviderBindingConfig> bindings)
     {
         var capabilityKinds = ResolveCapabilityKinds(capabilities, sourceType);
@@ -346,8 +363,10 @@ public sealed class ProviderSetupService
                 ConnectionId: providerId,
                 Target: new ProviderBindingTarget(),
                 Priority: priority,
-                Enabled: true,
-                Notes: "Seeded by provider setup."));
+                Enabled: enabled,
+                Notes: enabled
+                    ? "Seeded by provider setup."
+                    : "Seeded disabled by provider setup pending credential verification and certification."));
             seeded.Add(bindingId);
         }
 
@@ -464,6 +483,29 @@ public sealed class ProviderSetupService
             ? ProviderConnectionMode.ReadOnly
             : ProviderConnectionMode.Research;
     }
+
+    private static bool CanActivateRouting(
+        ProviderCredentialCatalogEntry descriptor,
+        ProviderCredentialStoreStatus credentialStatus)
+    {
+        if (!descriptor.RequiresCredentials)
+        {
+            return true;
+        }
+
+        return credentialStatus.CredentialState == ProviderCredentialStateDto.Verified &&
+               credentialStatus.VerificationState == ProviderVerificationStateDto.Verified &&
+               credentialStatus.MissingFields.Count == 0;
+    }
+
+    private static bool HasActiveProductionCertification(ProviderConnectionsConfig section, string connectionId)
+        => (section.Certifications ?? Array.Empty<ProviderCertificationConfig>()).Any(certification =>
+            string.Equals(certification.ConnectionId, connectionId, StringComparison.OrdinalIgnoreCase) &&
+            certification.ProductionReady &&
+            (certification.ExpiresAt is null || certification.ExpiresAt >= DateTimeOffset.UtcNow));
+
+    private static bool IsLiveMode(ProviderConnectionMode mode)
+        => mode == ProviderConnectionMode.Live;
 
     private static IBOptions BuildInteractiveBrokersOptions(string? endpoint)
     {

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -127,7 +127,9 @@ and UI presentation concerns in their owning layers.
 - `ProviderRouting/` - relationship-aware provider capability routing. Provider-ledger accounting
   workflows use these capability gates to block missing balance/position/reconciliation feeds and
   degrade corporate-action or factor-schedule support when the account's provider route cannot
-  supply the required feed.
+  supply the required feed. Provider setup seeds credential-backed routes disabled by default until
+  required credentials are complete and verified; live routing additionally requires explicit
+  production certification before a live connection mode or active bindings are persisted.
 - `Config/Credentials/` - application-owned credential testing, OAuth refresh, legacy resolver
   compatibility, CLI validation adapters, and composition support. Shared
   configuration JSON options, JSON Schema generation, FluentValidation rules, validation pipeline

--- a/tests/Meridian.Tests/Ui/ProviderRoutingEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/ProviderRoutingEndpointsTests.cs
@@ -85,6 +85,151 @@ public sealed class ProviderRoutingEndpointsTests
     }
 
     [Fact]
+    public async Task ConfigureProvider_LiveAlpacaWithUnverifiedCredentials_DoesNotEnableLiveRouting()
+    {
+        await using var app = await CreateAppAsync();
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsync(UiApiRoutes.ProviderConfigure, JsonContent(new
+        {
+            kind = "alpaca",
+            displayName = "Alpaca Live Setup",
+            apiKey = $"alpaca-live-key-{Guid.NewGuid():N}",
+            apiSecret = $"alpaca-live-secret-{Guid.NewGuid():N}",
+            environment = "live",
+            capabilities = new[] { "streaming", "backfill" }
+        }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var setup = await ReadAsync<ProviderSetupResult>(response);
+        setup.Success.Should().BeTrue();
+        setup.CredentialState.Should().Be(ProviderCredentialStateDto.Configured);
+        setup.Warnings.Should().Contain(warning => warning.Contains("live provider routing remains disabled", StringComparison.OrdinalIgnoreCase));
+
+        var connectionsResponse = await client.GetAsync(UiApiRoutes.ProviderRoutingConnections);
+        connectionsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var connections = await ReadAsync<ProviderConnectionDto[]>(connectionsResponse);
+        connections.Should().ContainSingle(connection =>
+            connection.ConnectionId == "alpaca" &&
+            !connection.Enabled &&
+            connection.ConnectionMode == nameof(ProviderConnectionMode.ReadOnly));
+
+        var bindingsResponse = await client.GetAsync(UiApiRoutes.ProviderRoutingBindings);
+        bindingsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var bindings = await ReadAsync<ProviderBindingDto[]>(bindingsResponse);
+        bindings.Where(binding => binding.ConnectionId == "alpaca").Should().OnlyContain(binding => !binding.Enabled);
+
+        var previewResponse = await client.PostAsync(
+            UiApiRoutes.ProviderRoutingPreview,
+            JsonContent(new RoutePreviewRequest(Capability: "RealtimeMarketData", Symbol: "AAPL")));
+
+        previewResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var preview = await ReadAsync<RoutePreviewResponse>(previewResponse);
+        preview.IsRoutable.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ConfigureProvider_MissingOrPartialCredentials_CreatesNoActiveBinding()
+    {
+        await using var app = await CreateAppAsync();
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsync(UiApiRoutes.ProviderConfigure, JsonContent(new
+        {
+            kind = "alpaca",
+            displayName = "Alpaca Partial Setup",
+            apiKey = $"alpaca-partial-key-{Guid.NewGuid():N}",
+            environment = "paper",
+            capabilities = new[] { "streaming" }
+        }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var setup = await ReadAsync<ProviderSetupResult>(response);
+        setup.CredentialState.Should().Be(ProviderCredentialStateDto.Partial);
+        setup.Warnings.Should().Contain(warning => warning.Contains("routing remains disabled", StringComparison.OrdinalIgnoreCase));
+
+        var bindingsResponse = await client.GetAsync(UiApiRoutes.ProviderRoutingBindings);
+        bindingsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var bindings = await ReadAsync<ProviderBindingDto[]>(bindingsResponse);
+        bindings.Where(binding => binding.ConnectionId == "alpaca").Should().OnlyContain(binding => !binding.Enabled);
+
+        var connectionsResponse = await client.GetAsync(UiApiRoutes.ProviderRoutingConnections);
+        connectionsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var connections = await ReadAsync<ProviderConnectionDto[]>(connectionsResponse);
+        connections.Should().ContainSingle(connection => connection.ConnectionId == "alpaca" && !connection.Enabled);
+    }
+
+    [Fact]
+    public async Task ConfigureProvider_VerifiedCredentialsWithCertification_EnableIntendedLiveConnectionMode()
+    {
+        await using var app = await CreateAppAsync();
+        var client = app.GetTestClient();
+        var credentialStore = app.Services.GetRequiredService<IProviderCredentialStore>();
+        var configStore = app.Services.GetRequiredService<ApplicationConfigStore>();
+
+        await credentialStore.SaveAsync(new ProviderCredentialSaveRequest(
+            "alpaca",
+            new Dictionary<string, string?>
+            {
+                ["KeyId"] = $"alpaca-verified-key-{Guid.NewGuid():N}",
+                ["SecretKey"] = $"alpaca-verified-secret-{Guid.NewGuid():N}"
+            },
+            Environment: "live",
+            Actor: "provider-routing-endpoint-test"));
+        await credentialStore.RecordVerificationAsync(new ProviderCredentialVerificationUpdate(
+            "alpaca",
+            Success: true,
+            ExternalAccountId: "alpaca-live-account",
+            Actor: "provider-routing-endpoint-test"));
+
+        var cfg = configStore.Load();
+        var section = ProviderRoutingConfigExtensions.GetSection(cfg);
+        await configStore.SaveAsync(cfg with
+        {
+            ProviderConnections = section with
+            {
+                Certifications = new[]
+                {
+                    new ProviderCertificationConfig(
+                        ConnectionId: "alpaca",
+                        Status: "Passed",
+                        LastRunAt: DateTimeOffset.UtcNow,
+                        ExpiresAt: DateTimeOffset.UtcNow.AddDays(30),
+                        ProductionReady: true,
+                        Checks: new[] { "Credential verification passed." },
+                        Notes: new[] { "Explicit test certification." })
+                }
+            }
+        });
+
+        var response = await client.PostAsync(UiApiRoutes.ProviderConfigure, JsonContent(new
+        {
+            kind = "alpaca",
+            displayName = "Alpaca Certified Live Setup",
+            environment = "live",
+            capabilities = new[] { "streaming", "backfill" }
+        }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var setup = await ReadAsync<ProviderSetupResult>(response);
+        setup.CredentialState.Should().Be(ProviderCredentialStateDto.Verified);
+        setup.Warnings.Should().NotContain(warning => warning.Contains("routing remains disabled", StringComparison.OrdinalIgnoreCase));
+
+        var connectionsResponse = await client.GetAsync(UiApiRoutes.ProviderRoutingConnections);
+        connectionsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var connections = await ReadAsync<ProviderConnectionDto[]>(connectionsResponse);
+        connections.Should().ContainSingle(connection =>
+            connection.ConnectionId == "alpaca" &&
+            connection.Enabled &&
+            connection.ConnectionMode == nameof(ProviderConnectionMode.Live));
+
+        var bindingsResponse = await client.GetAsync(UiApiRoutes.ProviderRoutingBindings);
+        bindingsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var bindings = await ReadAsync<ProviderBindingDto[]>(bindingsResponse);
+        bindings.Where(binding => binding.ConnectionId == "alpaca").Should().OnlyContain(binding => binding.Enabled);
+    }
+
+    [Fact]
     public async Task ConfigureProvider_WithPolygonCredential_StoresCredentialAndRoutesReferenceData()
     {
         await using var app = await CreateAppAsync();
@@ -116,9 +261,9 @@ public sealed class ProviderRoutingEndpointsTests
 
         previewResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var preview = await ReadAsync<RoutePreviewResponse>(previewResponse);
-        preview.IsRoutable.Should().BeTrue();
-        preview.SelectedConnectionId.Should().Be("polygon");
-        preview.SelectedProviderFamilyId.Should().Be("polygon");
+        preview.IsRoutable.Should().BeFalse("newly saved provider credentials are not routable until verification succeeds");
+        preview.SelectedConnectionId.Should().BeNull();
+        preview.SelectedProviderFamilyId.Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Ensure newly configured credential-backed providers are safe-by-default and cannot enable live routing until credentials are fully verified and an explicit production certification exists for live environments.
- Prevent accidental activation of bindings or live connections when credentials are missing, partial, stale, or unverified.

### Description
- Change provider connection/data-source creation in `ProviderSetupService` so `Enabled` and seeded binding `Enabled` are false unless credential readiness checks pass and live mode has an explicit production certification; live `ConnectionMode` is downgraded to `ReadOnly` when certification/verification is missing.
- Add helper checks `CanActivateRouting`, `HasActiveProductionCertification`, and `IsLiveMode` to centralize readiness logic and certification freshness checks.
- Add two save-time warnings to `ProviderSetupResult` explaining that credentials were persisted but routing (or live routing) remains disabled pending verification/certification.
- Update tests in `tests/Meridian.Tests/Ui/ProviderRoutingEndpointsTests.cs` to cover: unverified live Alpaca remains disabled, partial/missing credentials seed disabled bindings, and verified+certified credentials enable the intended live connection mode; also update the Polygon preview expectation to be unroutable until verification.

### Testing
- New/modified unit tests: `ConfigureProvider_LiveAlpacaWithUnverifiedCredentials_DoesNotEnableLiveRouting`, `ConfigureProvider_MissingOrPartialCredentials_CreatesNoActiveBinding`, and `ConfigureProvider_VerifiedCredentialsWithCertification_EnableIntendedLiveConnectionMode` in `tests/Meridian.Tests/Ui/ProviderRoutingEndpointsTests.cs` (these tests were added to the change set). 
- Ran `git diff --check` to validate whitespace/patch problems, which reported no check failures for the touched files.
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary`, which failed due to pre-existing repo-wide generated-doc/source hash drift and the intentional Application README change; this is an expected documentation-hash validation result requiring repo docs regeneration.
- Attempted to run .NET tooling (`dotnet --info` / full `dotnet test`) but the environment lacks `dotnet`, so the xUnit test suite could not be executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a306da39a548320a55318f1247d7dab)