### PR TITLE
Harden local provider credential key permissions (owner-only on non-Windows)

### DIFF
--- a/src/Meridian.DataIntegration/Credentials/FileProviderCredentialStore.cs
+++ b/src/Meridian.DataIntegration/Credentials/FileProviderCredentialStore.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Runtime.Versioning;
+using System.Security;
 using Meridian.Contracts.Configuration;
 using Meridian.Storage.Archival;
 
@@ -569,15 +570,68 @@ public sealed class FileProviderCredentialStore : IProviderCredentialStore
     private byte[] GetOrCreateLocalKey(CancellationToken ct)
     {
         Directory.CreateDirectory(_directoryPath);
+        HardenLocalDirectoryPermissions(_directoryPath);
+
         if (File.Exists(_keyPath))
         {
+            HardenLocalKeyPermissions(_keyPath);
             return File.ReadAllBytes(_keyPath);
         }
 
         var key = RandomNumberGenerator.GetBytes(32);
         AtomicFileWriter.WriteAsync(_keyPath, key, ct).GetAwaiter().GetResult();
+        HardenLocalKeyPermissions(_keyPath);
         TrySetHidden(_keyPath);
         return key;
+    }
+
+    private static void HardenLocalDirectoryPermissions(string path)
+        => HardenUnixPermissions(
+            path,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute,
+            "provider credential directory");
+
+    private static void HardenLocalKeyPermissions(string path)
+        => HardenUnixPermissions(
+            path,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite,
+            "provider credential local key");
+
+    private static void HardenUnixPermissions(string path, UnixFileMode ownerOnlyMode, string description)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        try
+        {
+            var currentMode = File.GetUnixFileMode(path);
+            if ((currentMode & ~ownerOnlyMode) == 0 && (currentMode & ownerOnlyMode) == ownerOnlyMode)
+            {
+                return;
+            }
+
+            File.SetUnixFileMode(path, ownerOnlyMode);
+            currentMode = File.GetUnixFileMode(path);
+            if ((currentMode & ~ownerOnlyMode) != 0 || (currentMode & ownerOnlyMode) != ownerOnlyMode)
+            {
+                throw new SecurityException($"The {description} at '{path}' is not restricted to the current user.");
+            }
+        }
+        catch (Exception ex) when (ex is PlatformNotSupportedException or NotSupportedException)
+        {
+            // Some non-Windows filesystems do not expose Unix mode APIs. The vault remains
+            // encrypted, but permission hardening cannot be verified on this platform.
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            throw new SecurityException($"The {description} at '{path}' could not be restricted to the current user.", ex);
+        }
+        catch (IOException ex)
+        {
+            throw new SecurityException($"The {description} at '{path}' could not be verified for owner-only permissions.", ex);
+        }
     }
 
     private static void TrySetHidden(string path)

--- a/src/Meridian.DataIntegration/README.md
+++ b/src/Meridian.DataIntegration/README.md
@@ -74,7 +74,18 @@ Use this README to understand the module before editing source files. Update the
 
 QuickBooks accounting-system integration lives in this module. The adapter family imports chart-of-accounts, journal-entry, and trial-balance evidence as read-only reconciliation input through `IAccountingSystemProvider`, refreshes OAuth access tokens through the server-side QuickBooks client seam, records connection verification posture, maps provider-vault credentials into the QuickBooks connection store, and leaves posting/export disabled. UI Shared registers the Data Integration providers and connection store; it does not own QuickBooks transport, credential persistence mapping, or import mapping.
 
-Provider credential catalog, credential-store contracts, vault, status, and OAuth record ownership also lives in this module. Application and UI layers may orchestrate setup, testing, token refresh, and endpoint projection, but provider credential descriptors, encrypted local storage, validation metadata, verification metadata, expiration policy records, OAuth token records, and provider-environment normalization must stay behind the `Meridian.DataIntegration.Credentials` seam. Saved provider secrets are written to the encrypted local vault with rotation metadata and verification-required state; environment fallback is for Development/Test or explicit migration override only and is disabled for packaged/customer builds.
+Provider credential catalog, credential-store contracts, vault, status, and OAuth record ownership
+also lives in this module. Application and UI layers may orchestrate setup, testing, token
+refresh, and endpoint projection, but provider credential descriptors, encrypted local storage,
+validation metadata, verification metadata, expiration policy records, OAuth token records, and
+provider-environment normalization must stay behind the `Meridian.DataIntegration.Credentials`
+seam. Saved provider secrets are written to the encrypted local vault with rotation metadata and
+verification-required state; environment fallback is for Development/Test or explicit migration
+override only and is disabled for packaged/customer builds. On Windows, the vault payload is
+protected with current-user DPAPI. On non-Windows systems, the vault payload is protected with
+AES-GCM using a local key under the data-root `.mdc` directory; the `.mdc` directory is hardened
+to owner-only access and the local key file is created or repaired to owner-read/write only before
+reuse so group and world accounts cannot read it.
 `ProviderCredentialCatalog` also owns the value-free provider setup metadata projected to UI clients:
 credential field identifiers, labels, required flags, input kinds, safe help text, action routes,
 and allowed/default environments. Do not move stored credential values or environment variable

--- a/tests/Meridian.Tests/Application/Config/ProviderCredentialStoreTests.cs
+++ b/tests/Meridian.Tests/Application/Config/ProviderCredentialStoreTests.cs
@@ -201,6 +201,65 @@ public sealed class ProviderCredentialStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task GetOrCreateLocalKey_NonWindows_CreatesOwnerOnlyKeyAndDirectoryPermissions()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var store = new FileProviderCredentialStore(_root);
+
+        await store.SaveAsync(new ProviderCredentialSaveRequest(
+            "alpaca",
+            new Dictionary<string, string?>
+            {
+                ["KeyId"] = "owner-only-key-id",
+                ["SecretKey"] = "owner-only-secret"
+            },
+            Environment: "paper",
+            Actor: "test-operator"));
+
+        var mdcPath = Path.Combine(_root, ".mdc");
+        var keyPath = Path.Combine(mdcPath, "provider-credentials.key");
+
+        File.Exists(keyPath).Should().BeTrue();
+        Directory.Exists(mdcPath).Should().BeTrue();
+        AssertOwnerOnlyPermissions(keyPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        AssertOwnerOnlyPermissions(mdcPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+    }
+
+    [Fact]
+    public async Task GetOrCreateLocalKey_NonWindows_RepairsPermissiveExistingKeyBeforeReuse()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var store = new FileProviderCredentialStore(_root);
+        await store.SaveAsync(new ProviderCredentialSaveRequest(
+            "alpaca",
+            new Dictionary<string, string?>
+            {
+                ["KeyId"] = "repair-key-id",
+                ["SecretKey"] = "repair-secret"
+            },
+            Environment: "paper",
+            Actor: "test-operator"));
+
+        var keyPath = Path.Combine(_root, ".mdc", "provider-credentials.key");
+        File.SetUnixFileMode(keyPath,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+
+        var read = await store.ReadForProviderAsync("alpaca");
+
+        read.Should().NotBeNull();
+        read!.Get("SecretKey").Should().Be("repair-secret");
+        AssertOwnerOnlyPermissions(keyPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
+
+    [Fact]
     public async Task ReadForProviderAsync_UsesEnvironmentAsReadOnlyLegacyFallback()
     {
         using var env = new EnvironmentScope("POLYGON_API_KEY", "legacy-polygon-key");
@@ -278,6 +337,18 @@ public sealed class ProviderCredentialStoreTests : IDisposable
         auditText.Should().Contain("\"action\":\"delete\"");
         auditText.Should().Contain("\"actor\":\"test-operator\"");
         auditText.Should().NotContain("finnhub-secret");
+    }
+
+    private static void AssertOwnerOnlyPermissions(string path, UnixFileMode expectedMode)
+    {
+        var mode = File.GetUnixFileMode(path);
+        mode.Should().Be(expectedMode);
+        mode.Should().NotHaveFlag(UnixFileMode.GroupRead);
+        mode.Should().NotHaveFlag(UnixFileMode.GroupWrite);
+        mode.Should().NotHaveFlag(UnixFileMode.GroupExecute);
+        mode.Should().NotHaveFlag(UnixFileMode.OtherRead);
+        mode.Should().NotHaveFlag(UnixFileMode.OtherWrite);
+        mode.Should().NotHaveFlag(UnixFileMode.OtherExecute);
     }
 
     private sealed class EnvironmentScope : IDisposable


### PR DESCRIPTION
### Motivation
- Prevent accidental exposure of the local AES-GCM key and credential vault on non-Windows systems by enforcing owner-only filesystem permissions for the `.mdc` directory and the local key file used to protect the vault.
- Use platform-appropriate APIs for permission hardening and provide guarded fallbacks on platforms that do not expose Unix-mode APIs.
- Repair overly-permissive existing key files before reuse or surface a clear `SecurityException` when verification cannot be completed.
- Add automated tests that validate the intended non-Windows behavior and document the runtime protection semantics in the module README.

### Description
- Updated `src/Meridian.DataIntegration/Credentials/FileProviderCredentialStore.cs` to call `HardenLocalDirectoryPermissions(_directoryPath)` and `HardenLocalKeyPermissions(_keyPath)` from `GetOrCreateLocalKey`, and to repair/validate permissions on existing keys before reuse.
- Introduced `HardenUnixPermissions`, `HardenLocalDirectoryPermissions`, and `HardenLocalKeyPermissions` helpers that use `File.GetUnixFileMode` / `File.SetUnixFileMode` on non-Windows and throw `SecurityException` on unrecoverable permission verification failures while catching `PlatformNotSupportedException` for filesystems that don’t expose Unix modes.
- Maintained best-effort `TrySetHidden` behavior and preserved existing AES-GCM/DPAPI protection logic; DPAPI remains the Windows path and local AES-GCM + key file is the non-Windows path.
- Added tests in `tests/Meridian.Tests/Application/Config/ProviderCredentialStoreTests.cs` that are conditional on non-Windows and verify the created `.mdc` directory and `provider-credentials.key` file are owner-only and that a permissive existing key is repaired before reuse.
- Updated `src/Meridian.DataIntegration/README.md` to document the Windows DPAPI protection path and the hardened non-Windows local-key path under `.mdc`.

### Testing
- Ran `git diff --check` which reported no issues for the staged changes.
- Executed the implementation-assurance dry-run with `python3 .codex/skills/meridian-implementation-assurance/scripts/run_evals.py --all --dry-run --summary` which succeeded for the local eval cases.
- Produced the skill rubric with `score_eval.py` to record evidence and a follow-up note about the environment limitation.
- Attempted to run the targeted unit tests via `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj -c Release --filter "FullyQualifiedName~ProviderCredentialStoreTests" /p:EnableWindowsTargeting=true` but the `dotnet` CLI was not available in the execution container, so the xUnit tests were not executed here (tests were added and are ready to run in a .NET 10 SDK environment and are conditional on non-Windows OS when asserting Unix file modes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a306da5c6c08320b5213cc38b4585c5)