### PR TITLE
Add provider setup state projection and routing gating

### DIFF
--- a/src/Meridian.Application/ProviderRouting/ProviderRoutingMapper.cs
+++ b/src/Meridian.Application/ProviderRouting/ProviderRoutingMapper.cs
@@ -222,9 +222,9 @@ internal static class ProviderRoutingConfigExtensions
                 ConnectionId: cfg.DataSources.DefaultRealTimeSourceId!,
                 Target: new ProviderBindingTarget(),
                 Priority: 100,
-                Enabled: true,
+                Enabled: false,
                 FailoverConnectionIds: ResolveLegacyFailover(cfg, cfg.DataSources.DefaultRealTimeSourceId!),
-                Notes: "Synthesized from legacy default real-time source."));
+                Notes: "Synthesized from legacy default real-time source; disabled until provider setup is verified."));
         }
 
         if (!bindings.Any(b => b.Capability == ProviderCapabilityKind.HistoricalBars) &&
@@ -236,9 +236,9 @@ internal static class ProviderRoutingConfigExtensions
                 ConnectionId: cfg.DataSources.DefaultHistoricalSourceId!,
                 Target: new ProviderBindingTarget(),
                 Priority: 100,
-                Enabled: true,
+                Enabled: false,
                 FailoverConnectionIds: ResolveLegacyFailover(cfg, cfg.DataSources.DefaultHistoricalSourceId!),
-                Notes: "Synthesized from legacy default historical source."));
+                Notes: "Synthesized from legacy default historical source; disabled until provider setup is verified."));
         }
 
         return bindings;

--- a/src/Meridian.Application/ProviderRouting/ProviderSetupService.cs
+++ b/src/Meridian.Application/ProviderRouting/ProviderSetupService.cs
@@ -346,8 +346,8 @@ public sealed class ProviderSetupService
                 ConnectionId: providerId,
                 Target: new ProviderBindingTarget(),
                 Priority: priority,
-                Enabled: true,
-                Notes: "Seeded by provider setup."));
+                Enabled: false,
+                Notes: "Seeded by provider setup; disabled until credentials are verified and explicit routing approval is recorded."));
             seeded.Add(bindingId);
         }
 

--- a/src/Meridian.Contracts/Configuration/ProviderConnectionDtos.cs
+++ b/src/Meridian.Contracts/Configuration/ProviderConnectionDtos.cs
@@ -53,6 +53,20 @@ public enum ProviderContinuityHealthDto
 }
 
 [JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ProviderSetupStateDto
+{
+    NotStarted,
+    CredentialsMissing,
+    CredentialsSavedVerificationRequired,
+    VerificationFailed,
+    VerifiedRoutingDisabled,
+    ReadyReadOnly,
+    ReadyPaper,
+    LiveRequiresApproval,
+    LiveReady
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum ProviderCredentialInputKindDto
 {
     Text,
@@ -94,7 +108,10 @@ public sealed record ProviderConnectionRowDto(
     string RecommendedAction,
     string ActionHref,
     IReadOnlyList<ProviderCredentialFieldMetadataDto>? CredentialFields = null,
-    IReadOnlyList<ProviderEnvironmentOptionDto>? EnvironmentOptions = null);
+    IReadOnlyList<ProviderEnvironmentOptionDto>? EnvironmentOptions = null,
+    ProviderSetupStateDto SetupState = ProviderSetupStateDto.NotStarted,
+    string SetupStateExplanation = "Provider setup has not started.",
+    string? RoutingDisabledReason = null);
 
 public sealed record ProviderCredentialUpsertRequestDto(
     IReadOnlyDictionary<string, string?>? Credentials,
@@ -109,7 +126,9 @@ public sealed record ProviderCredentialMutationResultDto(
     ProviderContinuityHealthDto Health,
     string? MaskedKeyPreview,
     string? Environment,
-    IReadOnlyList<string> Warnings);
+    IReadOnlyList<string> Warnings,
+    ProviderSetupStateDto SetupState = ProviderSetupStateDto.NotStarted,
+    string SetupStateExplanation = "Provider setup has not started.");
 
 public sealed record ProviderCredentialVerificationResultDto(
     string ProviderId,
@@ -119,4 +138,6 @@ public sealed record ProviderCredentialVerificationResultDto(
     DateTimeOffset? LastVerifiedAt,
     string? LastError,
     string? ExternalAccountId,
-    IReadOnlyList<string> Warnings);
+    IReadOnlyList<string> Warnings,
+    ProviderSetupStateDto SetupState = ProviderSetupStateDto.NotStarted,
+    string SetupStateExplanation = "Provider setup has not started.");

--- a/src/Meridian.Contracts/Configuration/ProviderSetupStateProjection.cs
+++ b/src/Meridian.Contracts/Configuration/ProviderSetupStateProjection.cs
@@ -1,0 +1,67 @@
+namespace Meridian.Contracts.Configuration;
+
+public static class ProviderSetupStateProjection
+{
+    public static ProviderSetupProjectionDto Project(
+        ProviderCredentialStateDto credentialState,
+        ProviderVerificationStateDto verificationState,
+        string? environment,
+        string? connectionMode,
+        bool bindingEnabled,
+        bool liveApproved = false)
+    {
+        var env = environment?.Trim();
+        var mode = connectionMode?.Trim();
+        var isLive = EqualsIgnoreCase(env, "live") || EqualsIgnoreCase(mode, "Live");
+        var isPaper = EqualsIgnoreCase(env, "paper") || EqualsIgnoreCase(mode, "Paper");
+        var requiresCredentials = credentialState is not ProviderCredentialStateDto.NotRequired;
+
+        if (credentialState is ProviderCredentialStateDto.Missing or ProviderCredentialStateDto.Partial)
+        {
+            return Projection(ProviderSetupStateDto.CredentialsMissing, "Required credential fields are missing.", "Routing disabled until required credentials are saved.");
+        }
+
+        if (verificationState == ProviderVerificationStateDto.Failed || credentialState == ProviderCredentialStateDto.Invalid)
+        {
+            return Projection(ProviderSetupStateDto.VerificationFailed, "Credential verification failed. Re-enter credentials and verify this provider.", "Routing disabled until provider verification succeeds.");
+        }
+
+        if (requiresCredentials && verificationState is ProviderVerificationStateDto.NotVerified or ProviderVerificationStateDto.Stale)
+        {
+            return Projection(ProviderSetupStateDto.CredentialsSavedVerificationRequired, "Credentials saved. Verify before using this provider.", "Routing disabled until saved credentials are verified.");
+        }
+
+        if (isLive && !liveApproved)
+        {
+            return Projection(ProviderSetupStateDto.LiveRequiresApproval, "Live endpoint selected. Routing remains disabled until approval.", "Live endpoint selected. Routing remains disabled until approval.");
+        }
+
+        if (!bindingEnabled)
+        {
+            return Projection(ProviderSetupStateDto.VerifiedRoutingDisabled, "Provider verified, but routing bindings are disabled.", "Routing binding is disabled.");
+        }
+
+        if (isLive)
+        {
+            return Projection(ProviderSetupStateDto.LiveReady, "Provider verified for live workflows.", null);
+        }
+
+        if (isPaper)
+        {
+            return Projection(ProviderSetupStateDto.ReadyPaper, "Provider verified for paper workflows.", null);
+        }
+
+        return Projection(ProviderSetupStateDto.ReadyReadOnly, "Provider verified for read-only workflows.", null);
+    }
+
+    private static ProviderSetupProjectionDto Projection(ProviderSetupStateDto state, string explanation, string? routingDisabledReason)
+        => new(state, explanation, routingDisabledReason);
+
+    private static bool EqualsIgnoreCase(string? value, string expected)
+        => string.Equals(value, expected, StringComparison.OrdinalIgnoreCase);
+}
+
+public sealed record ProviderSetupProjectionDto(
+    ProviderSetupStateDto State,
+    string Explanation,
+    string? RoutingDisabledReason);

--- a/src/Meridian.Ui.Shared/Services/ProviderConnectionLifecycleService.cs
+++ b/src/Meridian.Ui.Shared/Services/ProviderConnectionLifecycleService.cs
@@ -246,6 +246,12 @@ public sealed class ProviderConnectionLifecycleService
         ProviderMetrics? metrics)
     {
         var health = ResolveHealth(status, metrics);
+        var setup = ProviderSetupStateProjection.Project(
+            status.CredentialState,
+            status.VerificationState,
+            status.Environment ?? descriptor.DefaultEnvironment,
+            descriptor.DefaultEnvironment?.Equals("paper", StringComparison.OrdinalIgnoreCase) == true ? "Paper" : "ReadOnly",
+            bindingEnabled: false);
         var lastSuccessfulAt = status.LastSuccessfulAt ?? (metrics?.IsConnected == true ? metrics.Timestamp : null);
         var lastFailureAt = status.LastFailureAt ?? (metrics is { IsConnected: false, ConnectionFailures: > 0 } ? metrics.Timestamp : null);
 
@@ -269,7 +275,10 @@ public sealed class ProviderConnectionLifecycleService
             RecommendedAction: ResolveRecommendedAction(descriptor, status, health),
             ActionHref: descriptor.ResolvedActionHref,
             CredentialFields: ProviderCredentialCatalog.BuildCredentialFields(descriptor),
-            EnvironmentOptions: ProviderCredentialCatalog.BuildEnvironmentOptions(descriptor));
+            EnvironmentOptions: ProviderCredentialCatalog.BuildEnvironmentOptions(descriptor),
+            SetupState: setup.State,
+            SetupStateExplanation: setup.Explanation,
+            RoutingDisabledReason: setup.RoutingDisabledReason);
     }
 
     private static ProviderContinuityHealthDto ResolveHealth(
@@ -335,26 +344,36 @@ public sealed class ProviderConnectionLifecycleService
     private static ProviderCredentialMutationResultDto BuildMutationResult(
         ProviderCredentialStoreStatus status,
         IReadOnlyList<string> warnings)
-        => new(
-            status.ProviderId,
-            status.CredentialState,
-            status.CredentialSource,
-            status.VerificationState,
-            ResolveHealth(status, metrics: null),
-            status.MaskedKeyPreview,
-            status.Environment,
-            warnings);
+        {
+            var setup = ProviderSetupStateProjection.Project(
+                status.CredentialState,
+                status.VerificationState,
+                status.Environment,
+                null,
+                bindingEnabled: false);
+            return new ProviderCredentialMutationResultDto(
+                status.ProviderId,
+                status.CredentialState,
+                status.CredentialSource,
+                status.VerificationState,
+                ResolveHealth(status, metrics: null),
+                status.MaskedKeyPreview,
+                status.Environment,
+                warnings,
+                setup.State,
+                setup.Explanation);
+        }
 
     private static IReadOnlyList<string> BuildSaveWarnings(ProviderCredentialStoreStatus status)
     {
         var warnings = new List<string>
         {
             "Credentials were saved to the encrypted local Meridian store; user environment variables were not changed.",
-            "Rotation metadata was recorded; verify the provider before routing dependent workflows."
+            "Credentials saved. Verify before using this provider."
         };
         if (status.Environment?.Equals(AlpacaCredentialEnvironment.LiveEnvironment, StringComparison.OrdinalIgnoreCase) == true)
         {
-            warnings.Add("Live endpoint selected. Paper remains the default for new Alpaca credential setup.");
+            warnings.Add("Live endpoint selected. Routing remains disabled until approval.");
         }
 
         if (status.CredentialState is ProviderCredentialStateDto.Missing or ProviderCredentialStateDto.Partial)

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx
@@ -3437,6 +3437,9 @@ export function SettingsScreen({
                         <SettingsFieldRow label="Routing bindings" value={row.routingBindingsLabel} tone="muted" />
                         <SettingsFieldRow label="Trust score" value={row.trustScoreLabel} tone={row.healthTone} />
                         <SettingsFieldRow label="Production gate" value={row.productionStateLabel} tone={row.productionStateLabel === "Production ready" ? "success" : "warning"} />
+                        <SettingsFieldRow label="Setup state" value={row.setupStateLabel} tone={row.routingDisabledReason ? "warning" : "success"} />
+                        <SettingsFieldRow label="Setup warning" value={row.setupStateExplanation} tone={row.routingDisabledReason ? "warning" : "success"} />
+                        <SettingsFieldRow label="Disabled reason" value={row.routingDisabledReason ?? "Routing available"} tone={row.routingDisabledReason ? "warning" : "success"} />
                         <SettingsFieldRow label="Affected workflows" value={row.affectedWorkflowsLabel} tone="default" />
                       </dl>
                       {inlineProviderManagementEnabled ? (
@@ -4637,6 +4640,9 @@ function ProviderInlineActionPanel({
     displayName: string;
     affectedWorkflowsLabel: string;
     productionStateLabel: string;
+    setupStateLabel: string;
+    setupStateExplanation: string;
+    routingDisabledReason: string | null;
     fallbackLabel: string;
     environmentOptions: ProviderEnvironmentOption[];
   };
@@ -4770,7 +4776,7 @@ function ProviderInlineActionPanel({
         </div>
       ) : null}
       <div className="rounded-sm border border-border/60 bg-background/40 px-2 py-2 text-xs text-muted-foreground">
-        Impact summary: {row.affectedWorkflowsLabel} · Production gate {row.productionStateLabel} · Failover {row.fallbackLabel}
+        Impact summary: {row.affectedWorkflowsLabel} · Setup {row.setupStateLabel} · {row.setupStateExplanation} · Routing {row.routingDisabledReason ?? "available"}
       </div>
       {state.testLatencyLabel ? <div className="text-xs text-muted-foreground">Latest test latency: {state.testLatencyLabel}</div> : null}
       {state.statusMessage ? (

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.view-model.test.ts
@@ -1480,3 +1480,57 @@ function deferred<T>() {
   });
   return { promise, resolve, reject };
 }
+
+describe("provider setup state projection", () => {
+  it("surfaces disabled reasons and warning copy for saved but unverified credentials", () => {
+    const vm = buildSettingsScreenViewModel({
+      session,
+      overview,
+      providerConnections: [{
+        ...providerConnections[0],
+        credentialState: "Configured",
+        verificationState: "NotVerified",
+        environment: "paper",
+        setupState: "CredentialsSavedVerificationRequired",
+        setupStateExplanation: "Credentials saved. Verify before using this provider.",
+        routingDisabledReason: "Routing disabled until saved credentials are verified."
+      }],
+      providerRoutingConnections,
+      providerRoutingBindings: providerRoutingBindings.map((binding) => ({ ...binding, enabled: false })),
+      providerRoutingTrustSnapshots
+    });
+
+    const alpaca = vm.providerConnectionCenter.groups.flatMap((group) => group.rows).find((row) => row.providerId === "alpaca");
+    expect(alpaca?.setupStateLabel).toBe("Credentials Saved Verification Required");
+    expect(alpaca?.setupStateExplanation).toBe("Credentials saved. Verify before using this provider.");
+    expect(alpaca?.routingDisabledReason).toBe("Routing disabled until saved credentials are verified.");
+  });
+
+  it("requires live approval separately from verified live credentials", () => {
+    const vm = buildSettingsScreenViewModel({
+      session,
+      overview,
+      providerConnections: [{
+        ...providerConnections[0],
+        credentialState: "Configured",
+        verificationState: "Verified",
+        environment: "live",
+        setupState: undefined,
+        setupStateExplanation: undefined,
+        routingDisabledReason: undefined
+      }],
+      providerRoutingConnections: providerRoutingConnections.map((connection) => ({
+        ...connection,
+        connectionMode: "Live",
+        productionReady: false
+      })),
+      providerRoutingBindings,
+      providerRoutingTrustSnapshots
+    });
+
+    const alpaca = vm.providerConnectionCenter.groups.flatMap((group) => group.rows).find((row) => row.providerId === "alpaca");
+    expect(alpaca?.setupStateLabel).toBe("Live Requires Approval");
+    expect(alpaca?.setupStateExplanation).toBe("Live endpoint selected. Routing remains disabled until approval.");
+    expect(alpaca?.routingDisabledReason).toBe("Live endpoint selected. Routing remains disabled until approval.");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.view-model.ts
@@ -37,6 +37,9 @@ import type {
   ProviderRoutingBinding,
   ProviderRoutingConnection,
   ProviderRoutingTrustSnapshot,
+  ProviderSetupState,
+  ProviderVerificationState,
+  ProviderCredentialState,
   StrategyWorkspaceResponse,
   SessionInfo,
   SystemOverviewResponse,
@@ -816,6 +819,9 @@ export interface SettingsProviderConnectionRow {
   routingBindingsLabel: string;
   trustScoreLabel: string;
   productionStateLabel: string;
+  setupStateLabel: string;
+  setupStateExplanation: string;
+  routingDisabledReason: string | null;
   affectedWorkflowsLabel: string;
   affectedWorkflows: string[];
   recommendedAction: string;
@@ -1902,6 +1908,49 @@ function buildProviderConnectionCenter(
   };
 }
 
+
+function projectProviderSetupState({
+  credentialState,
+  verificationState,
+  environment,
+  connectionMode,
+  bindingEnabled,
+  productionReady
+}: {
+  credentialState: ProviderCredentialState;
+  verificationState: ProviderVerificationState;
+  environment?: string | null;
+  connectionMode?: string | null;
+  bindingEnabled: boolean;
+  productionReady?: boolean;
+}): { state: ProviderSetupState; explanation: string; routingDisabledReason: string | null } {
+  const isLive = environment?.toLowerCase() === "live" || connectionMode?.toLowerCase() === "live";
+  const isPaper = environment?.toLowerCase() === "paper" || connectionMode?.toLowerCase() === "paper";
+  const requiresCredentials = credentialState !== "NotRequired";
+  if (credentialState === "Missing" || credentialState === "Partial") {
+    return { state: "CredentialsMissing", explanation: "Required credential fields are missing.", routingDisabledReason: "Routing disabled until required credentials are saved." };
+  }
+  if (credentialState === "Invalid" || verificationState === "Failed") {
+    return { state: "VerificationFailed", explanation: "Credential verification failed. Re-enter credentials and verify this provider.", routingDisabledReason: "Routing disabled until provider verification succeeds." };
+  }
+  if (requiresCredentials && (verificationState === "NotVerified" || verificationState === "Stale")) {
+    return { state: "CredentialsSavedVerificationRequired", explanation: "Credentials saved. Verify before using this provider.", routingDisabledReason: "Routing disabled until saved credentials are verified." };
+  }
+  if (isLive && !productionReady) {
+    return { state: "LiveRequiresApproval", explanation: "Live endpoint selected. Routing remains disabled until approval.", routingDisabledReason: "Live endpoint selected. Routing remains disabled until approval." };
+  }
+  if (!bindingEnabled) {
+    return { state: "VerifiedRoutingDisabled", explanation: "Provider verified, but routing bindings are disabled.", routingDisabledReason: "Routing binding is disabled." };
+  }
+  if (isLive) return { state: "LiveReady", explanation: "Provider verified for live workflows.", routingDisabledReason: null };
+  if (isPaper) return { state: "ReadyPaper", explanation: "Provider verified for paper workflows.", routingDisabledReason: null };
+  return { state: "ReadyReadOnly", explanation: "Provider verified for read-only workflows.", routingDisabledReason: null };
+}
+
+function providerSetupStateLabel(state: ProviderSetupState): string {
+  return state.replace(/([a-z])([A-Z])/g, "$1 $2");
+}
+
 function buildProviderConnectionRow(
   row: ProviderConnectionRow,
   routingContext: ProviderRoutingRowContext
@@ -1914,6 +1963,14 @@ function buildProviderConnectionRow(
     : routingCapabilityLabels.length > 0
       ? routingCapabilityLabels
       : ["Workflow impact not declared"];
+  const setup = projectProviderSetupState({
+    credentialState: row.credentialState,
+    verificationState: row.verificationState,
+    environment: row.environment,
+    connectionMode: routingContext.connection?.connectionMode,
+    bindingEnabled: routingContext.bindings.some((binding) => binding.enabled),
+    productionReady: routingContext.connection?.productionReady
+  });
   return {
     providerId: row.providerId,
     rowAnchorId: row.providerId === "alpaca" ? "alpaca-provider-setup" : `provider-${row.providerId}-connection`,
@@ -1948,6 +2005,9 @@ function buildProviderConnectionRow(
     routingBindingsLabel: providerRoutingBindingsLabel(routingContext.bindings),
     trustScoreLabel: providerRoutingTrustScoreLabel(routingContext.trustSnapshot),
     productionStateLabel: providerRoutingProductionStateLabel(routingContext.connection),
+    setupStateLabel: providerSetupStateLabel(row.setupState ?? setup.state),
+    setupStateExplanation: row.setupStateExplanation ?? setup.explanation,
+    routingDisabledReason: row.routingDisabledReason ?? setup.routingDisabledReason,
     affectedWorkflowsLabel: workflows.join(", "),
     affectedWorkflows: workflows,
     recommendedAction: row.recommendedAction,
@@ -1970,6 +2030,15 @@ function buildProviderRoutingConnectionRow(
     ? connection.productionReady ? "success" : "warning"
     : "success";
   const workflows = routingCapabilityLabels.length > 0 ? routingCapabilityLabels : ["Routing capability not bound"];
+  const bindingEnabled = routingContext.bindings.some((binding) => binding.enabled);
+  const setup = projectProviderSetupState({
+    credentialState: credentialConfigured ? "Configured" : "NotRequired",
+    verificationState: connection.productionReady ? "Verified" : "NotVerified",
+    environment: credentialReferenceEnvironmentLabel(connection.credentialReference).toLowerCase(),
+    connectionMode: connection.connectionMode,
+    bindingEnabled,
+    productionReady: connection.productionReady
+  });
 
   return {
     providerId: connection.connectionId,
@@ -1999,6 +2068,9 @@ function buildProviderRoutingConnectionRow(
     routingBindingsLabel: providerRoutingBindingsLabel(routingContext.bindings),
     trustScoreLabel: providerRoutingTrustScoreLabel(routingContext.trustSnapshot),
     productionStateLabel: providerRoutingProductionStateLabel(connection),
+    setupStateLabel: providerSetupStateLabel(setup.state),
+    setupStateExplanation: setup.explanation,
+    routingDisabledReason: setup.routingDisabledReason,
     affectedWorkflowsLabel: workflows.join(", "),
     affectedWorkflows: workflows,
     recommendedAction: providerRoutingRecommendedAction(connection, routingContext),

--- a/src/Meridian.Ui/dashboard/src/types.ts
+++ b/src/Meridian.Ui/dashboard/src/types.ts
@@ -2043,6 +2043,8 @@ export interface ChiefOfStaffEvidenceBundle {
   traceArtifacts: EvidenceArtifactRef[];
   completenessStatus: EvidenceStatus;
   warnings: string[];
+  setupState?: ProviderSetupState;
+  setupStateExplanation?: string;
 }
 
 export interface ChiefOfStaffSession {
@@ -2260,6 +2262,16 @@ export type ProviderCredentialSource =
   | "NotRequired";
 export type ProviderVerificationState = "NotRequired" | "NotVerified" | "Verified" | "Failed" | "Stale";
 export type ProviderContinuityHealth = "Unknown" | "Healthy" | "Warning" | "Degraded" | "Blocked";
+export type ProviderSetupState =
+  | "NotStarted"
+  | "CredentialsMissing"
+  | "CredentialsSavedVerificationRequired"
+  | "VerificationFailed"
+  | "VerifiedRoutingDisabled"
+  | "ReadyReadOnly"
+  | "ReadyPaper"
+  | "LiveRequiresApproval"
+  | "LiveReady";
 export type ProviderReadinessStatus = "Ready" | "Review" | "Degraded" | "Blocked" | "Unknown";
 export type ProviderReadinessEvidenceKind = "Credential" | "Connection" | "Validation" | "Degradation" | "Plaid" | "Routing";
 export type ProviderCredentialInputKind = "Text" | "Password" | "Url";
@@ -2301,6 +2313,9 @@ export interface ProviderConnectionRow {
   actionHref: string;
   credentialFields?: ProviderCredentialFieldMetadata[] | null;
   environmentOptions?: ProviderEnvironmentOption[] | null;
+  setupState?: ProviderSetupState;
+  setupStateExplanation?: string;
+  routingDisabledReason?: string | null;
 }
 
 export interface ProviderCredentialUpsertRequest {
@@ -2371,6 +2386,9 @@ export interface ProviderReadinessRow {
   recoveryActions: ProviderRecoveryAction[];
   credentialFields?: ProviderCredentialFieldMetadata[] | null;
   environmentOptions?: ProviderEnvironmentOption[] | null;
+  setupState?: ProviderSetupState;
+  setupStateExplanation?: string;
+  routingDisabledReason?: string | null;
 }
 
 export interface ProviderReadinessEvidence {

--- a/tests/Meridian.Wpf.Tests/ViewModels/ProviderViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/ProviderViewModelTests.cs
@@ -121,3 +121,52 @@ public sealed class ProviderViewModelTests
             RateLimitPerHour = "100"
         };
 }
+
+public sealed class ProviderSetupStateProjectionTests
+{
+    [Fact]
+    public void Project_ShouldRequireVerificationAfterSavingCredentials()
+    {
+        var projection = Meridian.Contracts.Configuration.ProviderSetupStateProjection.Project(
+            Meridian.Contracts.Configuration.ProviderCredentialStateDto.Configured,
+            Meridian.Contracts.Configuration.ProviderVerificationStateDto.NotVerified,
+            environment: "paper",
+            connectionMode: "Paper",
+            bindingEnabled: false);
+
+        projection.State.Should().Be(Meridian.Contracts.Configuration.ProviderSetupStateDto.CredentialsSavedVerificationRequired);
+        projection.Explanation.Should().Be("Credentials saved. Verify before using this provider.");
+        projection.RoutingDisabledReason.Should().Be("Routing disabled until saved credentials are verified.");
+    }
+
+    [Fact]
+    public void Project_ShouldKeepLiveProviderDisabledUntilSeparateApproval()
+    {
+        var projection = Meridian.Contracts.Configuration.ProviderSetupStateProjection.Project(
+            Meridian.Contracts.Configuration.ProviderCredentialStateDto.Configured,
+            Meridian.Contracts.Configuration.ProviderVerificationStateDto.Verified,
+            environment: "live",
+            connectionMode: "Live",
+            bindingEnabled: true,
+            liveApproved: false);
+
+        projection.State.Should().Be(Meridian.Contracts.Configuration.ProviderSetupStateDto.LiveRequiresApproval);
+        projection.Explanation.Should().Be("Live endpoint selected. Routing remains disabled until approval.");
+        projection.RoutingDisabledReason.Should().Be("Live endpoint selected. Routing remains disabled until approval.");
+    }
+
+    [Fact]
+    public void Project_ShouldMarkPaperProviderReadyAfterVerificationAndEnabledBinding()
+    {
+        var projection = Meridian.Contracts.Configuration.ProviderSetupStateProjection.Project(
+            Meridian.Contracts.Configuration.ProviderCredentialStateDto.Configured,
+            Meridian.Contracts.Configuration.ProviderVerificationStateDto.Verified,
+            environment: "paper",
+            connectionMode: "Paper",
+            bindingEnabled: true);
+
+        projection.State.Should().Be(Meridian.Contracts.Configuration.ProviderSetupStateDto.ReadyPaper);
+        projection.Explanation.Should().Be("Provider verified for paper workflows.");
+        projection.RoutingDisabledReason.Should().BeNull();
+    }
+}


### PR DESCRIPTION
### Motivation
- Define explicit provider setup states (NotStarted, CredentialsMissing, CredentialsSavedVerificationRequired, VerificationFailed, VerifiedRoutingDisabled, ReadyReadOnly, ReadyPaper, LiveRequiresApproval, LiveReady) to make provider onboarding and routing posture deterministic. 
- Project setup readiness from credential state, verification state, environment/connection mode, binding enablement, and live-approval to drive UI messaging and safe defaults. 
- Ensure live or mutating routing is gated by an explicit approval step separate from saving credentials.

### Description
- Add a typed setup-state enum and projection: `ProviderSetupStateDto` and `ProviderSetupStateProjection.Project(...)` that maps credential/verification/environment/connection mode/binding and `liveApproved` into the named states and short user-facing explanations. 
- Surface the projection in DTOs by extending provider connection and credential mutation/verification DTOs with `SetupState`, `SetupStateExplanation`, and `RoutingDisabledReason`, and populate them from `ProviderConnectionLifecycleService`. 
- Change save warnings and messages to include the concise copy: "Credentials saved. Verify before using this provider." and "Live endpoint selected. Routing remains disabled until approval.", and add the user-facing explanation "Provider verified for paper workflows." where applicable. 
- Disable seeded routing bindings by default (newly seeded bindings and legacy synthesized bindings are created with `Enabled: false` and explanatory notes) so routing is not auto-enabled for unverified or live providers. 
- Wire the setup-state into the browser Settings provider connection center and inline provider panels so UI rows show `Setup state`, `Setup warning`, and `Disabled reason`, and add a small JS projection helper to compute labels where the backend value is absent. 
- Add tests: a WPF unit test class that exercises `ProviderSetupStateProjection` scenarios and browser dashboard unit tests that assert setup-state labels, warning copy, and routing-disabled reasons are shown in the Settings view model.

### Testing
- Ran the focused browser unit tests: `npm --prefix src/Meridian.Ui/dashboard run test -- settings-screen.view-model.test.ts`, and the added tests passed. 
- Installed dashboard dependencies with `npm --prefix src/Meridian.Ui/dashboard install` and ran the dashboard build `npm --prefix src/Meridian.Ui/dashboard run build`; the focused tests passed but the full build surfaced a TypeScript/Vite typing issue around Vitest 4 `poolOptions` in `vite.config.ts` in this environment (typing change, unrelated to the projection logic). 
- Added WPF unit tests exercising the projection logic; `dotnet test` could not be executed in this container because `dotnet` is not available here, but the tests are included for CI/Windows run. 
- Performed local TypeScript checks for the dashboard test surface and validated the new types in `src/Meridian.Ui/dashboard/src/types.ts` (focused `tsc`/test runs used during development).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a306e4493a883208d2e4001d07570fe)