### PR TITLE
Add provider credential verifier interface and adapters

### DIFF
--- a/src/Meridian.Ui.Shared/Services/ProviderConnectionLifecycleService.cs
+++ b/src/Meridian.Ui.Shared/Services/ProviderConnectionLifecycleService.cs
@@ -1,38 +1,31 @@
-using System.Net.Http.Json;
-using System.Text.Json.Serialization;
 using Meridian.Core.Config;
 using Meridian.Application.Config.Credentials;
 using Meridian.DataIntegration.Credentials;
 using Meridian.DataIntegration.Monitoring;
 using Meridian.Contracts.Configuration;
-using Meridian.ProviderSdk.AccountingSystem;
 using Microsoft.Extensions.Logging;
 
 namespace Meridian.Ui.Shared.Services;
 
 public sealed class ProviderConnectionLifecycleService
 {
-    private const string AlpacaPaperTradingApiEndpoint = "https://paper-api.alpaca.markets/v2";
-    private const string AlpacaLiveTradingApiEndpoint = "https://api.alpaca.markets/v2";
-
     private readonly IProviderCredentialStore _credentialStore;
     private readonly ConfigStore _configStore;
-    private readonly IHttpClientFactory? _httpClientFactory;
-    private readonly IReadOnlyList<IAccountingSystemProvider> _accountingSystemProviders;
+    private readonly IReadOnlyDictionary<string, IProviderCredentialVerifier> _credentialVerifiers;
     private readonly ILogger<ProviderConnectionLifecycleService> _logger;
 
     public ProviderConnectionLifecycleService(
         IProviderCredentialStore credentialStore,
         ConfigStore configStore,
         ILogger<ProviderConnectionLifecycleService> logger,
-        IHttpClientFactory? httpClientFactory = null,
-        IEnumerable<IAccountingSystemProvider>? accountingSystemProviders = null)
+        IEnumerable<IProviderCredentialVerifier>? credentialVerifiers = null)
     {
         _credentialStore = credentialStore ?? throw new ArgumentNullException(nameof(credentialStore));
         _configStore = configStore ?? throw new ArgumentNullException(nameof(configStore));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _httpClientFactory = httpClientFactory;
-        _accountingSystemProviders = accountingSystemProviders?.ToArray() ?? [];
+        _credentialVerifiers = (credentialVerifiers ?? [])
+            .GroupBy(verifier => ProviderCredentialCatalog.NormalizeProviderId(verifier.ProviderId), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
     }
 
     public async Task<IReadOnlyList<ProviderConnectionRowDto>> GetConnectionsAsync(CancellationToken ct = default)
@@ -105,46 +98,29 @@ public sealed class ProviderConnectionLifecycleService
                 Warnings: ["Add the required credential fields before verification."]);
         }
 
-        if (descriptor.ProviderId.Equals("alpaca", StringComparison.OrdinalIgnoreCase))
+        if (_credentialVerifiers.TryGetValue(descriptor.ProviderId, out var verifier))
         {
-            return await VerifyAlpacaAsync(read, ct).ConfigureAwait(false);
+            var result = await verifier.VerifyAsync(read, ct).ConfigureAwait(false);
+            if (result.Success || result.VerificationState == ProviderVerificationStateDto.Failed)
+            {
+                await _credentialStore.RecordVerificationAsync(
+                    new ProviderCredentialVerificationUpdate(
+                        descriptor.ProviderId,
+                        result.Success,
+                        ErrorMessage: result.LastError,
+                        ExternalAccountId: result.ExternalAccountId,
+                        VerifiedAt: result.LastVerifiedAt ?? DateTimeOffset.UtcNow,
+                        Actor: "browser-workstation"),
+                    ct).ConfigureAwait(false);
+            }
+
+            return result;
         }
 
-        var accountingVerification = _accountingSystemProviders
-            .FirstOrDefault(provider => string.Equals(provider.ProviderId, descriptor.ProviderId, StringComparison.OrdinalIgnoreCase))
-            as IAccountingSystemConnectionVerifier;
-        if (accountingVerification is not null)
-        {
-            var result = await accountingVerification.VerifyConnectionAsync(ct).ConfigureAwait(false);
-            return new ProviderCredentialVerificationResultDto(
-                descriptor.ProviderId,
-                result.Success,
-                result.Success ? ProviderVerificationStateDto.Verified : ProviderVerificationStateDto.Failed,
-                result.Success ? ProviderContinuityHealthDto.Healthy : ProviderContinuityHealthDto.Blocked,
-                result.VerifiedAtUtc,
-                result.LastError,
-                result.ExternalCompanyId,
-                result.Warnings);
-        }
-
-        var verifiedAt = DateTimeOffset.UtcNow;
-        await _credentialStore.RecordVerificationAsync(
-            new ProviderCredentialVerificationUpdate(
-                descriptor.ProviderId,
-                Success: true,
-                VerifiedAt: verifiedAt,
-                Actor: "browser-workstation"),
-            ct).ConfigureAwait(false);
-
-        return new ProviderCredentialVerificationResultDto(
-            descriptor.ProviderId,
-            Success: true,
-            ProviderVerificationStateDto.Verified,
-            ProviderContinuityHealthDto.Healthy,
-            LastVerifiedAt: verifiedAt,
-            LastError: null,
-            ExternalAccountId: null,
-            Warnings: ["Credential presence was verified locally; provider-specific live connectivity checks can be added behind this shared route."]);
+        _logger.LogInformation(
+            "Provider credential verification unavailable for {ProviderId}; credentials were not marked verified.",
+            descriptor.ProviderId);
+        return ProviderCredentialVerifierResults.Unavailable(descriptor.ProviderId);
     }
 
     public async Task<ProviderCredentialMutationResultDto> DeleteCredentialsAsync(
@@ -156,88 +132,6 @@ public sealed class ProviderConnectionLifecycleService
         await _credentialStore.DeleteAsync(descriptor.ProviderId, actor ?? "browser-workstation", ct).ConfigureAwait(false);
         var status = await _credentialStore.GetStatusAsync(descriptor.ProviderId, ct).ConfigureAwait(false);
         return BuildMutationResult(status, BuildDeleteWarnings(status));
-    }
-
-    private async Task<ProviderCredentialVerificationResultDto> VerifyAlpacaAsync(
-        ProviderCredentialReadResult read,
-        CancellationToken ct)
-    {
-        var keyId = read.Get("KeyId");
-        var secretKey = read.Get("SecretKey");
-        var environment = AlpacaCredentialEnvironment.NormalizeTradingEnvironment(read.Environment);
-        if (string.IsNullOrWhiteSpace(keyId) || string.IsNullOrWhiteSpace(secretKey))
-        {
-            return new ProviderCredentialVerificationResultDto(
-                "alpaca",
-                Success: false,
-                ProviderVerificationStateDto.NotVerified,
-                ProviderContinuityHealthDto.Blocked,
-                LastVerifiedAt: null,
-                LastError: "Alpaca key id and secret key are required.",
-                ExternalAccountId: null,
-                Warnings: ["Add Alpaca paper API keys before verification."]);
-        }
-
-        try
-        {
-            using var client = _httpClientFactory?.CreateClient(nameof(ProviderConnectionLifecycleService)) ?? new HttpClient();
-            using var request = new HttpRequestMessage(HttpMethod.Get, $"{AlpacaTradingApiEndpoint(environment)}/account");
-            request.Headers.TryAddWithoutValidation("APCA-API-KEY-ID", keyId);
-            request.Headers.TryAddWithoutValidation("APCA-API-SECRET-KEY", secretKey);
-
-            using var response = await client.SendAsync(request, ct).ConfigureAwait(false);
-            if (!response.IsSuccessStatusCode)
-            {
-                throw new InvalidOperationException($"status {(int)response.StatusCode} ({response.ReasonPhrase ?? response.StatusCode.ToString()})");
-            }
-
-            var account = await response.Content.ReadFromJsonAsync<AlpacaAccountVerificationResponse>(cancellationToken: ct)
-                .ConfigureAwait(false);
-            var accountId = FirstNonBlank(account?.AccountNumber, account?.Id, "unknown");
-            var verifiedAt = DateTimeOffset.UtcNow;
-            await _credentialStore.RecordVerificationAsync(
-                new ProviderCredentialVerificationUpdate(
-                    "alpaca",
-                    Success: true,
-                    ExternalAccountId: accountId,
-                    VerifiedAt: verifiedAt,
-                    Actor: "browser-workstation"),
-                ct).ConfigureAwait(false);
-
-            return new ProviderCredentialVerificationResultDto(
-                "alpaca",
-                Success: true,
-                ProviderVerificationStateDto.Verified,
-                ProviderContinuityHealthDto.Healthy,
-                LastVerifiedAt: verifiedAt,
-                LastError: null,
-                ExternalAccountId: accountId,
-                Warnings: BuildAlpacaWarnings(environment));
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            var message = $"Alpaca /v2/account verification failed: {ex.Message}";
-            _logger.LogWarning(ex, "Provider connection center Alpaca verification failed for {Environment}", environment);
-            var verifiedAt = DateTimeOffset.UtcNow;
-            await _credentialStore.RecordVerificationAsync(
-                new ProviderCredentialVerificationUpdate(
-                    "alpaca",
-                    Success: false,
-                    ErrorMessage: message,
-                    VerifiedAt: verifiedAt,
-                    Actor: "browser-workstation"),
-                ct).ConfigureAwait(false);
-
-            return new ProviderCredentialVerificationResultDto(
-                "alpaca",
-                Success: false,
-                ProviderVerificationStateDto.Failed,
-                ProviderContinuityHealthDto.Blocked,
-                LastVerifiedAt: verifiedAt,
-                LastError: message,
-                ExternalAccountId: read.ExternalAccountId,
-                Warnings: ["Alpaca account verification failed; downstream brokerage sync remains blocked."]);
-        }
     }
 
     private static ProviderConnectionRowDto BuildRow(
@@ -379,20 +273,4 @@ public sealed class ProviderConnectionLifecycleService
         => ProviderCredentialCatalog.Find(providerId)
            ?? throw new ArgumentException($"Provider '{providerId}' is not in the provider credential catalog.", nameof(providerId));
 
-    private static string AlpacaTradingApiEndpoint(string environment)
-        => environment.Equals(AlpacaCredentialEnvironment.LiveEnvironment, StringComparison.OrdinalIgnoreCase)
-            ? AlpacaLiveTradingApiEndpoint
-            : AlpacaPaperTradingApiEndpoint;
-
-    private static IReadOnlyList<string> BuildAlpacaWarnings(string environment)
-        => environment.Equals(AlpacaCredentialEnvironment.LiveEnvironment, StringComparison.OrdinalIgnoreCase)
-            ? ["Live Alpaca endpoint verified. Paper remains the default and live actions remain gated by execution controls."]
-            : [];
-
-    private static string? FirstNonBlank(params string?[] values)
-        => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value))?.Trim();
-
-    private sealed record AlpacaAccountVerificationResponse(
-        [property: JsonPropertyName("id")] string? Id,
-        [property: JsonPropertyName("account_number")] string? AccountNumber);
 }

--- a/src/Meridian.Ui.Shared/Services/ProviderCredentialVerifiers.cs
+++ b/src/Meridian.Ui.Shared/Services/ProviderCredentialVerifiers.cs
@@ -1,0 +1,283 @@
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Meridian.Core.Config;
+using Meridian.Contracts.Configuration;
+using Meridian.Contracts.Plaid;
+using Meridian.DataIntegration.Credentials;
+using Meridian.ProviderSdk.AccountingSystem;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Ui.Shared.Services;
+
+public interface IProviderCredentialVerifier
+{
+    string ProviderId { get; }
+
+    Task<ProviderCredentialVerificationResultDto> VerifyAsync(
+        ProviderCredentialReadResult credentials,
+        CancellationToken ct);
+}
+
+public sealed class AlpacaCredentialVerifier : IProviderCredentialVerifier
+{
+    private const string AlpacaPaperTradingApiEndpoint = "https://paper-api.alpaca.markets/v2";
+    private const string AlpacaLiveTradingApiEndpoint = "https://api.alpaca.markets/v2";
+
+    private readonly IProviderCredentialStore _credentialStore;
+    private readonly IHttpClientFactory? _httpClientFactory;
+    private readonly ILogger<AlpacaCredentialVerifier> _logger;
+
+    public AlpacaCredentialVerifier(
+        IProviderCredentialStore credentialStore,
+        ILogger<AlpacaCredentialVerifier> logger,
+        IHttpClientFactory? httpClientFactory = null)
+    {
+        _credentialStore = credentialStore ?? throw new ArgumentNullException(nameof(credentialStore));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public string ProviderId => "alpaca";
+
+    public async Task<ProviderCredentialVerificationResultDto> VerifyAsync(
+        ProviderCredentialReadResult credentials,
+        CancellationToken ct)
+    {
+        var keyId = credentials.Get("KeyId");
+        var secretKey = credentials.Get("SecretKey");
+        var environment = AlpacaCredentialEnvironment.NormalizeTradingEnvironment(credentials.Environment);
+        if (string.IsNullOrWhiteSpace(keyId) || string.IsNullOrWhiteSpace(secretKey))
+        {
+            return new ProviderCredentialVerificationResultDto(
+                ProviderId,
+                Success: false,
+                ProviderVerificationStateDto.NotVerified,
+                ProviderContinuityHealthDto.Blocked,
+                LastVerifiedAt: null,
+                LastError: "Alpaca key id and secret key are required.",
+                ExternalAccountId: null,
+                Warnings: ["Add Alpaca paper API keys before verification."]);
+        }
+
+        try
+        {
+            using var client = _httpClientFactory?.CreateClient(nameof(ProviderConnectionLifecycleService)) ?? new HttpClient();
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"{AlpacaTradingApiEndpoint(environment)}/account");
+            request.Headers.TryAddWithoutValidation("APCA-API-KEY-ID", keyId);
+            request.Headers.TryAddWithoutValidation("APCA-API-SECRET-KEY", secretKey);
+
+            using var response = await client.SendAsync(request, ct).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new InvalidOperationException($"status {(int)response.StatusCode} ({response.ReasonPhrase ?? response.StatusCode.ToString()})");
+            }
+
+            var account = await response.Content.ReadFromJsonAsync<AlpacaAccountVerificationResponse>(cancellationToken: ct)
+                .ConfigureAwait(false);
+            var accountId = FirstNonBlank(account?.AccountNumber, account?.Id, "unknown");
+            var verifiedAt = DateTimeOffset.UtcNow;
+            await RecordAsync(true, null, accountId, verifiedAt, ct).ConfigureAwait(false);
+
+            return new ProviderCredentialVerificationResultDto(
+                ProviderId,
+                Success: true,
+                ProviderVerificationStateDto.Verified,
+                ProviderContinuityHealthDto.Healthy,
+                LastVerifiedAt: verifiedAt,
+                LastError: null,
+                ExternalAccountId: accountId,
+                Warnings: BuildAlpacaWarnings(environment));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            var message = $"Alpaca /v2/account verification failed: {Redact(ex.Message, keyId, secretKey)}";
+            _logger.LogWarning("Provider connection center Alpaca verification failed for {Environment}: {Error}", environment, message);
+            var verifiedAt = DateTimeOffset.UtcNow;
+            await RecordAsync(false, message, null, verifiedAt, ct).ConfigureAwait(false);
+
+            return new ProviderCredentialVerificationResultDto(
+                ProviderId,
+                Success: false,
+                ProviderVerificationStateDto.Failed,
+                ProviderContinuityHealthDto.Blocked,
+                LastVerifiedAt: verifiedAt,
+                LastError: message,
+                ExternalAccountId: credentials.ExternalAccountId,
+                Warnings: ["Alpaca account verification failed; downstream brokerage sync remains blocked."]);
+        }
+    }
+
+
+    private static string Redact(string message, params string?[] secrets)
+    {
+        var redacted = message;
+        foreach (var secret in secrets.Where(static value => !string.IsNullOrWhiteSpace(value)))
+        {
+            redacted = redacted.Replace(secret!, "[redacted]", StringComparison.Ordinal);
+        }
+
+        return redacted;
+    }
+
+    private Task RecordAsync(bool success, string? error, string? externalAccountId, DateTimeOffset verifiedAt, CancellationToken ct)
+        => _credentialStore.RecordVerificationAsync(
+            new ProviderCredentialVerificationUpdate(
+                ProviderId,
+                success,
+                ErrorMessage: error,
+                ExternalAccountId: externalAccountId,
+                VerifiedAt: verifiedAt,
+                Actor: "browser-workstation"),
+            ct);
+
+    private static string AlpacaTradingApiEndpoint(string environment)
+        => environment.Equals(AlpacaCredentialEnvironment.LiveEnvironment, StringComparison.OrdinalIgnoreCase)
+            ? AlpacaLiveTradingApiEndpoint
+            : AlpacaPaperTradingApiEndpoint;
+
+    private static IReadOnlyList<string> BuildAlpacaWarnings(string environment)
+        => environment.Equals(AlpacaCredentialEnvironment.LiveEnvironment, StringComparison.OrdinalIgnoreCase)
+            ? ["Live Alpaca endpoint verified. Paper remains the default and live actions remain gated by execution controls."]
+            : [];
+
+    private static string? FirstNonBlank(params string?[] values)
+        => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value))?.Trim();
+
+    private sealed record AlpacaAccountVerificationResponse(
+        [property: JsonPropertyName("id")] string? Id,
+        [property: JsonPropertyName("account_number")] string? AccountNumber);
+}
+
+public sealed class QuickBooksCredentialVerifier : IProviderCredentialVerifier
+{
+    private readonly IEnumerable<IAccountingSystemProvider> _accountingSystemProviders;
+
+    public QuickBooksCredentialVerifier(IEnumerable<IAccountingSystemProvider> accountingSystemProviders)
+    {
+        _accountingSystemProviders = accountingSystemProviders ?? throw new ArgumentNullException(nameof(accountingSystemProviders));
+    }
+
+    public string ProviderId => "quickbooks";
+
+    public async Task<ProviderCredentialVerificationResultDto> VerifyAsync(ProviderCredentialReadResult credentials, CancellationToken ct)
+    {
+        var verifier = _accountingSystemProviders
+            .FirstOrDefault(provider => string.Equals(provider.ProviderId, ProviderId, StringComparison.OrdinalIgnoreCase))
+            as IAccountingSystemConnectionVerifier;
+        if (verifier is null)
+        {
+            return ProviderCredentialVerifierResults.Unavailable(ProviderId);
+        }
+
+        var result = await verifier.VerifyConnectionAsync(ct).ConfigureAwait(false);
+        return new ProviderCredentialVerificationResultDto(
+            ProviderId,
+            result.Success,
+            result.Success ? ProviderVerificationStateDto.Verified : ProviderVerificationStateDto.Failed,
+            result.Success ? ProviderContinuityHealthDto.Healthy : ProviderContinuityHealthDto.Blocked,
+            result.VerifiedAtUtc,
+            result.LastError,
+            result.ExternalCompanyId,
+            result.Warnings);
+    }
+}
+
+public sealed class PlaidCredentialVerifier : IProviderCredentialVerifier
+{
+    private readonly IPlaidClient? _client;
+
+    public PlaidCredentialVerifier(IPlaidClient? client = null)
+    {
+        _client = client;
+    }
+
+    public string ProviderId => "plaid";
+
+    public async Task<ProviderCredentialVerificationResultDto> VerifyAsync(ProviderCredentialReadResult credentials, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        var clientId = credentials.Get("ClientId");
+        var secret = credentials.Get("Secret");
+        if (string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(secret))
+        {
+            return new ProviderCredentialVerificationResultDto(
+                ProviderId,
+                false,
+                ProviderVerificationStateDto.NotVerified,
+                ProviderContinuityHealthDto.Blocked,
+                null,
+                "Plaid client id and secret are required.",
+                null,
+                ["Add Plaid client credentials before verification."]);
+        }
+
+        if (_client is null)
+        {
+            return ProviderCredentialVerifierResults.Unavailable(ProviderId);
+        }
+
+        try
+        {
+            var environment = ParsePlaidEnvironment(credentials.Environment);
+            var result = await _client.SearchInstitutionsAsync(
+                new PlaidClientCredentials(clientId, secret, environment),
+                "Chase",
+                [PlaidProductDto.Transactions],
+                ["US"],
+                ct).ConfigureAwait(false);
+            var verifiedAt = DateTimeOffset.UtcNow;
+            return new ProviderCredentialVerificationResultDto(
+                ProviderId,
+                true,
+                ProviderVerificationStateDto.Verified,
+                ProviderContinuityHealthDto.Healthy,
+                verifiedAt,
+                null,
+                result.RequestId,
+                ["Plaid institution search succeeded; stored external id is the safe Plaid request id, not a secret."]);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return new ProviderCredentialVerificationResultDto(
+                ProviderId,
+                false,
+                ProviderVerificationStateDto.Failed,
+                ProviderContinuityHealthDto.Blocked,
+                DateTimeOffset.UtcNow,
+                $"Plaid credential verification failed: {Redact(ex.Message, clientId, secret)}",
+                null,
+                ["Plaid remains unavailable until client credentials and environment are repaired."]);
+        }
+    }
+
+
+    private static string Redact(string message, params string?[] secrets)
+    {
+        var redacted = message;
+        foreach (var secret in secrets.Where(static value => !string.IsNullOrWhiteSpace(value)))
+        {
+            redacted = redacted.Replace(secret!, "[redacted]", StringComparison.Ordinal);
+        }
+
+        return redacted;
+    }
+
+    private static PlaidEnvironmentDto ParsePlaidEnvironment(string? environment)
+        => Enum.TryParse<PlaidEnvironmentDto>(environment, ignoreCase: true, out var parsed)
+            ? parsed
+            : PlaidEnvironmentDto.Sandbox;
+}
+
+public static class ProviderCredentialVerifierResults
+{
+    public static ProviderCredentialVerificationResultDto Unavailable(string providerId)
+        => new(
+            ProviderCredentialCatalog.NormalizeProviderId(providerId),
+            Success: false,
+            ProviderVerificationStateDto.NotVerified,
+            ProviderContinuityHealthDto.Warning,
+            LastVerifiedAt: null,
+            LastError: "Verification unavailable for this provider.",
+            ExternalAccountId: null,
+            Warnings: ["Verification unavailable: Meridian has credentials for this provider, but no safe provider-specific verifier is registered yet."]);
+}

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -151,6 +151,9 @@ public static class WorkstationServiceCollectionExtensions
         services.TryAddSingleton<BrokerageConnectionService>();
         services.TryAddSingleton<AlpacaBrokerageConnectionService>();
         services.TryAddSingleton<ProviderConnectionLifecycleService>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IProviderCredentialVerifier, AlpacaCredentialVerifier>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IProviderCredentialVerifier, QuickBooksCredentialVerifier>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IProviderCredentialVerifier, PlaidCredentialVerifier>());
         services.TryAddSingleton<ProviderReadinessService>();
         services.TryAddSingleton<IQuickBooksOnlineConnectionStore, QuickBooksOnlineProviderCredentialConnectionStore>();
         services.AddHttpClient<IQuickBooksOnlineClient, QuickBooksOnlineHttpClient>();

--- a/tests/Meridian.Tests/Ui/ProviderConnectionEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/ProviderConnectionEndpointsTests.cs
@@ -139,6 +139,7 @@ public sealed class ProviderConnectionEndpointsTests
         {
             services.AddSingleton<IAccountingSystemProvider>(sp =>
                 new FakeQuickBooksAccountingVerifier(sp.GetRequiredService<IProviderCredentialStore>()));
+            services.AddSingleton<IProviderCredentialVerifier, QuickBooksCredentialVerifier>();
         });
 
         await app.GetTestClient().PutAsync(
@@ -200,6 +201,74 @@ public sealed class ProviderConnectionEndpointsTests
         rawConnections.Should().NotContain("qbo-refresh-token");
     }
 
+
+
+    [Fact]
+    public async Task PostProviderVerify_WithoutRegisteredVerifier_ReturnsUnavailableWithoutMarkingVerified()
+    {
+        await using var app = await CreateAppAsync(_ => { });
+        await app.GetTestClient().PutAsync(
+            "/api/providers/polygon/credentials",
+            JsonContent(new { credentials = new { ApiKey = "polygon-secret" } }));
+
+        var response = await app.GetTestClient().PostAsync("/api/providers/polygon/verify", JsonContent(new { }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await ReadAsync<ProviderCredentialVerificationResultDto>(response);
+        result.Success.Should().BeFalse();
+        result.VerificationState.Should().Be(ProviderVerificationStateDto.NotVerified);
+        result.LastError.Should().Contain("Verification unavailable");
+        result.Warnings.Should().Contain(warning => warning.Contains("no safe provider-specific verifier", StringComparison.OrdinalIgnoreCase));
+
+        var rows = await ReadAsync<ProviderConnectionRowDto[]>(
+            await app.GetTestClient().GetAsync("/api/providers/connections"));
+        rows.Single(row => row.ProviderId == "polygon").CredentialState.Should().Be(ProviderCredentialStateDto.Configured);
+    }
+
+    [Fact]
+    public async Task PostProviderVerify_FailedAlpacaVerificationRedactsSecrets()
+    {
+        using var env = AlpacaEnvScope.Clear();
+        await using var app = await CreateAppAsync(services =>
+        {
+            services.AddSingleton<IHttpClientFactory>(_ => new StubHttpClientFactory(new ThrowingSecretHandler("verify-key", "verify-secret")));
+        });
+
+        await app.GetTestClient().PutAsync(
+            "/api/providers/alpaca/credentials",
+            JsonContent(new { credentials = new { KeyId = "verify-key", SecretKey = "verify-secret" }, environment = "paper" }));
+
+        var response = await app.GetTestClient().PostAsync("/api/providers/alpaca/verify", JsonContent(new { }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await ReadAsync<ProviderCredentialVerificationResultDto>(response);
+        result.Success.Should().BeFalse();
+        result.VerificationState.Should().Be(ProviderVerificationStateDto.Failed);
+        result.LastError.Should().NotContain("verify-key");
+        result.LastError.Should().NotContain("verify-secret");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_CancelledVerifier_PropagatesCancellation()
+    {
+        await using var app = await CreateAppAsync(services =>
+        {
+            services.AddSingleton<IProviderCredentialVerifier, CancellingPlaidVerifier>();
+        });
+        await app.Services.GetRequiredService<IProviderCredentialStore>().SaveAsync(
+            new ProviderCredentialSaveRequest(
+                "plaid",
+                new Dictionary<string, string?> { ["ClientId"] = "plaid-client", ["Secret"] = "plaid-secret" },
+                "sandbox"));
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var service = app.Services.GetRequiredService<ProviderConnectionLifecycleService>();
+        Func<Task> act = () => service.VerifyAsync("plaid", cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
     private static async Task<WebApplication> CreateAppAsync(
         Action<IServiceCollection> configureServices,
         UserPermission permissions = UserPermission.ManageCredentials)
@@ -217,7 +286,9 @@ public sealed class ProviderConnectionEndpointsTests
         builder.Services.AddSingleton<IProviderCredentialStore>(_ => new FileProviderCredentialStore(Path.Combine(root, "data")));
         builder.Services.AddSingleton(new ConfigStore(configPath));
         builder.Services.AddSingleton(NullLogger<ProviderConnectionLifecycleService>.Instance);
+        builder.Services.AddSingleton(NullLogger<AlpacaCredentialVerifier>.Instance);
         builder.Services.AddSingleton<ProviderConnectionLifecycleService>();
+        builder.Services.AddSingleton<IProviderCredentialVerifier, AlpacaCredentialVerifier>();
         builder.Services.AddRateLimiter(options =>
         {
             options.AddPolicy(UiEndpoints.MutationRateLimitPolicy, _ =>
@@ -280,6 +351,23 @@ public sealed class ProviderConnectionEndpointsTests
     private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
     {
         public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    private sealed class ThrowingSecretHandler(string keyId, string secretKey) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => throw new InvalidOperationException($"upstream echoed {keyId} and {secretKey}");
+    }
+
+    private sealed class CancellingPlaidVerifier : IProviderCredentialVerifier
+    {
+        public string ProviderId => "plaid";
+
+        public Task<ProviderCredentialVerificationResultDto> VerifyAsync(ProviderCredentialReadResult credentials, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            throw new InvalidOperationException("Expected cancellation before verification.");
+        }
     }
 
     private sealed class FakeQuickBooksAccountingVerifier : IAccountingSystemProvider, IAccountingSystemConnectionVerifier


### PR DESCRIPTION
### Motivation
- Centralize provider-specific credential verification behind a reusable interface to avoid hard-coded checks and enable safe, pluggable live/connectivity checks. 
- Move Alpaca verification out of `ProviderConnectionLifecycleService` and provide a consistent behavior for providers that do not have a verifier. 
- Ensure verification results redact secrets and only persist safe metadata (external ids, timestamps, warnings, failure categories). 

### Description
- Added `IProviderCredentialVerifier` interface with `string ProviderId` and `Task<ProviderCredentialVerificationResultDto> VerifyAsync(ProviderCredentialReadResult, CancellationToken)` in `src/Meridian.Ui.Shared/Services/ProviderCredentialVerifiers.cs`. 
- Implemented verifier adapters: `AlpacaCredentialVerifier`, `QuickBooksCredentialVerifier`, and `PlaidCredentialVerifier` with lightweight, safe checks, redaction of secrets, and recording of safe verification metadata. 
- Updated `ProviderConnectionLifecycleService` to resolve and delegate to verifiers by canonical provider id, persist verifier results safely, and return a clear unavailable state (`ProviderCredentialVerifierResults.Unavailable`) when no verifier is registered instead of implicitly marking credentials verified. 
- Registered verifiers in DI via `WorkstationServiceCollectionExtensions` using `services.TryAddEnumerable(ServiceDescriptor.Singleton<IProviderCredentialVerifier, ...>())`. 
- Added and extended endpoint tests in `tests/Meridian.Tests/Ui/ProviderConnectionEndpointsTests.cs` to cover verifier lookup, successful verification delegation (QuickBooks/Alpaca), unavailable verification (Polygon), failed verification with secret redaction (Alpaca), and cancellation propagation for verifier calls. 

### Testing
- Ran `git diff --check` on changed files (`src/Meridian.Ui.Shared/Services/ProviderCredentialVerifiers.cs`, `src/Meridian.Ui.Shared/Services/ProviderConnectionLifecycleService.cs`, `src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs`, `tests/Meridian.Tests/Ui/ProviderConnectionEndpointsTests.cs`) with no whitespace/format issues detected. 
- Attempted to run the focused unit tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter FullyQualifiedName~ProviderConnectionEndpointsTests`, but the `dotnet` CLI was not available in the execution environment so automated test execution was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a306e3492ac8320a0fe06f825e0f5ba)