### PR TITLE
docs: standardize shared financial record explorer contract

### DIFF
--- a/docs/product/meridian-design-document.md
+++ b/docs/product/meridian-design-document.md
@@ -2385,17 +2385,29 @@ The standard depth model is:
 | 2 | Side drawer or proof panel | Inspect a selected row without leaving the grid. |
 | 3 | Full record page | Review approvals, evidence, history, related records, and protected actions. |
 
-The shared explorer shell should include:
+The shared explorer shell should follow a standard explorer contract so operators can move across
+financial record types without relearning scope, proof, status, or action semantics:
 
-* scope bar for tenant, fund, legal entity, portfolio, account, book, period, currency, and as-of date where applicable
-* saved-view selector surfaced near the top, not hidden inside advanced filters
-* visible basic filters plus an advanced filter drawer
-* applied filter chips that can be removed quickly
-* summary strip for totals, counts, exceptions, unreconciled items, blockers, stale values, and missing evidence
-* dense but configurable grid with default and optional columns
-* column chooser, grouping, export policy, row actions, and saved column layouts
-* right-side record drawer with action links into evidence, reconciliation, ledger, report usage, and audit trail
-* full record page with record header, proof ribbon, summary cards, tabs, proof panel, audit timeline, Used In, Impacts, and Record Graph sections
+* **Scope bar dimensions:** tenant, fund, legal entity, portfolio, account, book, period, currency,
+  and as-of date. Explorers can hide dimensions that are not meaningful for a record type, but they
+  should not rename them or create explorer-specific substitutes.
+* **Shared states:** evidence missing, unreconciled, approved, blocked, stale, restated, report-used,
+  and close-impacting. These states must use the same definitions, icons, tooltips, filtering
+  semantics, proof-ribbon summaries, and audit vocabulary across browser and WPF surfaces.
+* **Standard actions:** inspect proof, open full record, compare versions, export allowed view,
+  attach evidence, assign exception, and request approval. Explorer-specific actions can extend this
+  set only after the common actions remain visible and permission-aware.
+* **Required subcomponents:** `ExplorerShell`, `ScopeBar`, `SavedViewSelector`, `FilterBar`,
+  `ExplorerGrid`, `RecordDrawer`, `ProofRibbon`, `ProofPanel`, `ColumnChooser`, and
+  `AuditTimeline`. These components are the minimum reusable contract for a Financial Record
+  Explorer and should be backed by shared filters, saved views, record identifiers, evidence links,
+  approval state, audit events, and read models.
+* **Baseline shell affordances:** saved-view selector surfaced near the top, visible basic filters
+  plus an advanced filter drawer, removable applied filter chips, a summary strip for totals and
+  exception counts, dense configurable grids with default and optional columns, grouping, export
+  policy, row actions, saved column layouts, right-side record drawers, and full record pages with
+  record headers, proof ribbons, summary cards, tabs, proof panels, audit timelines, Used In,
+  Impacts, and Record Graph sections.
 
 Record Graph does not need to be visually elaborate in the first slice. A structured tree is enough
 when it clearly shows how a fund event, journal, position, instrument, cash flow, report line,
@@ -2408,7 +2420,8 @@ review. Both surfaces must share filters, saved views, status definitions, proof
 record identifiers, audit events, evidence links, approval states, and read models. Presentation can
 differ; business state cannot.
 
-The implementation sequence should stay conservative:
+The implementation sequence should stay conservative and preserve a clear initial explorer
+sequence:
 
 1. Build the reusable explorer framework: `ExplorerShell`, `ScopeBar`, `SavedViewSelector`,
    `FilterBar`, `ExplorerGrid`, `RecordDrawer`, `ProofRibbon`, `ProofPanel`, `ColumnChooser`, and
@@ -2420,8 +2433,11 @@ The implementation sequence should stay conservative:
 4. Build Security & Instrument Explorer third with instrument list, identifier map, term status,
    source conflicts, held positions, evidence links, valuation status, expected cash flows, and
    accounting classification.
-5. Connect all three through a Proof Trail that can move from Instrument to Position, Transaction,
-   Reconciliation, Journal, Report Line, Evidence, and Audit Event.
+5. Build Report-Line Provenance Explorer fourth so governed reporting can trace each report line
+   through calculation inputs, approved source records, ledger impact, evidence packets, versions,
+   approvals, restatements, and audit events.
+6. Connect the first four explorers through a Proof Trail that can move from Instrument to Position,
+   Transaction, Reconciliation, Journal, Report Line, Evidence, and Audit Event.
 
 This is a planned productization target, not a completion claim. The roadmap item
 `W5X-FREX-001` tracks the delivery slice that turns the existing accounting-record and

--- a/docs/product/meridian-design-document.md
+++ b/docs/product/meridian-design-document.md
@@ -2396,7 +2396,7 @@ financial record types without relearning scope, proof, status, or action semant
   semantics, proof-ribbon summaries, and audit vocabulary across browser and WPF surfaces.
 * **Standard actions:** inspect proof, open full record, compare versions, export allowed view,
   attach evidence, assign exception, and request approval. Explorer-specific actions can extend this
-  set only after the common actions remain visible and permission-aware.
+  set, provided that the common actions remain visible and permission-aware.
 * **Required subcomponents:** `ExplorerShell`, `ScopeBar`, `SavedViewSelector`, `FilterBar`,
   `ExplorerGrid`, `RecordDrawer`, `ProofRibbon`, `ProofPanel`, `ColumnChooser`, and
   `AuditTimeline`. These components are the minimum reusable contract for a Financial Record


### PR DESCRIPTION
### Motivation

- Provide a reusable, consistent operator surface for Financial Record Explorers so operators do not need to relearn scope, proof, status, or action semantics across record types.  
- Ensure parity of business state and proof semantics across browser and WPF surfaces to enable shared read models and cross-surface workflows.  
- Clarify delivery sequencing so initial explorer rollouts follow a predictable, proof-connected path (Ledger → Portfolio → Security/Instrument → Report-Line Provenance).

### Description

- Updated `docs/product/meridian-design-document.md` v0.17 addendum to replace a free-form shell checklist with a standard explorer contract.  
- Added a `Scope bar dimensions` contract listing tenant, fund, legal entity, portfolio, account, book, period, currency, and as-of date.  
- Defined `Shared states` (evidence missing, unreconciled, approved, blocked, stale, restated, report-used, close-impacting) and `Standard actions` (inspect proof, open full record, compare versions, export allowed view, attach evidence, assign exception, request approval).  
- Specified required reusable subcomponents: `ExplorerShell`, `ScopeBar`, `SavedViewSelector`, `FilterBar`, `ExplorerGrid`, `RecordDrawer`, `ProofRibbon`, `ProofPanel`, `ColumnChooser`, and `AuditTimeline`, and expanded the baseline shell affordances accordingly.  
- Clarified the implementation sequence to add a `Report-Line Provenance Explorer` as the fourth explorer and require connecting the first explorers via a shared Proof Trail.

### Testing

- Ran `git diff --check -- docs/product/meridian-design-document.md` to validate no whitespace or markdown issues, which passed.  
- Verified the working tree with `git status --short` to ensure no unrelated files were edited.  
- No automated unit or integration test changes were required for this docs-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a307c2e2cf08320a157f439e7e61b4c)