### PR TITLE
Add Fund Event Command Center design section to Meridian design document

### DIFF
--- a/docs/product/meridian-design-document.md
+++ b/docs/product/meridian-design-document.md
@@ -465,6 +465,93 @@ reconciliation, exception management, accounting operations, close support, work
 audit evidence into a shared Accounting/Reporting operator surface. This is planned productization,
 not a completion claim; W1-W5 remain the closed evidence baseline.
 
+### Fund Event Command Center
+
+The Fund Event Command Center is a planned private-capital operating surface for creating,
+reviewing, reconciling, approving, reporting, and locking fund events as auditable operational
+records. It should remain roadmap-candidate language until the roadmap registry accepts a matching
+item and evidence gates; do not present it as shipped, accepted, or part of the closed W1-W5
+baseline before that registry acceptance exists.
+
+#### Supported Event Types
+
+The initial event taxonomy should support these fund-event records:
+
+* Formation
+* Close
+* Subscription
+* Capital call
+* Contribution receipt
+* Investment
+* Distribution
+* Valuation
+* Fee
+* Expense
+* Tax request
+* Audit request
+* Dissolution
+* Wind-down
+
+#### Event Lifecycle States
+
+Every command-center event should move through explicit, auditable lifecycle states:
+
+* Draft
+* Evidence pending
+* Validation blocked
+* Reconciliation blocked
+* Journal pending
+* Approval pending
+* Report pending
+* Delivered
+* Locked
+* Amended
+* Restated
+
+#### Event Detail Page Layout
+
+Each event detail page should use a consistent evidence-first layout:
+
+* **Event header:** fund, vehicle, entity, event type, materiality, owner, effective date, due date,
+  current lifecycle state, and amendment/restatement lineage.
+* **Proof ribbon:** compact readiness indicators for evidence completeness, validation,
+  reconciliation, journal state, approval state, report use, lock state, and audit coverage.
+* **Evidence panel:** source documents, import runs, administrator files, signed notices, source
+  hashes, lineage references, reviewer notes, retention class, and legal-hold markers.
+* **Ledger impact:** journal drafts, posted journals, reversals, accruals, realized/unrealized
+  effects, cash movements, book/period scope, and blocked-posting reasons.
+* **Capital-account impact:** investor allocations, commitments, contributions, distributions, fees,
+  expenses, tax lots where relevant, capital roll-forward, and statement-line effects.
+* **Workflow tasks:** assignments, due dates, blocker reasons, reviewer decisions, approval chain,
+  escalation history, and segregation-of-duties checks.
+* **Report usage:** report packs, investor statements, notices, tax/audit support files, board
+  packages, delivery status, recipient entitlement scope, and amendment/restatement dependencies.
+* **Audit timeline:** immutable event history for creation, evidence receipt, validation,
+  reconciliation, journal actions, approvals, report generation, delivery, locks, amendments,
+  restatements, and evidence-retention actions.
+
+#### Workspace Entry Points
+
+The command center should be reachable from existing root operator workspaces without introducing a
+new root navigation lane:
+
+* **Portfolio:** open event records from fund, vehicle, holding, investment, valuation,
+  distribution, and liquidity-review contexts.
+* **Accounting:** open event records from close cockpit, ledger explorer, journal queues,
+  capital-account workbench, reconciliation cases, and period-lock workflows.
+* **Reporting:** open event records from package builders, investor statements, notices, tax/audit
+  support requests, delivery evidence, amendment, and restatement workflows.
+* **Data:** open event records from import runs, administrator files, provider validation, lineage
+  manifests, reconciliation inputs, source-evidence repair, and certified dataset release flows.
+
+#### Roadmap Candidate Boundary
+
+Use this feature as a roadmap candidate only until a registry-backed item is accepted. Candidate
+acceptance should name the owning roadmap ID, event registry schema, lifecycle transition rules,
+workspace routes, evidence requirements, audit-event coverage, reporting dependencies, and validation
+commands. Until then, documents and product copy should say "planned Fund Event Command Center" or
+"roadmap candidate" rather than "implemented", "accepted", or "available".
+
 ---
 
 ## 5.3 Treasury & Payments


### PR DESCRIPTION
### Motivation

- Introduce a planned Fund Event Command Center as a first-class operating surface for creating, reviewing, reconciling, approving, reporting, and locking fund events as auditable operational records. 
- Provide a clear, consistent taxonomy and lifecycle for fund events to support accounting, reporting, and audit workflows across private-capital funds. 
- Keep the feature explicitly scoped as a roadmap candidate until a registry-backed acceptance and evidence gates are added. 

### Description

- Added a new `Fund Event Command Center` section to `docs/product/meridian-design-document.md` that defines the command-center concept and scope. 
- Defined the supported event types: formation, close, subscription, capital call, contribution receipt, investment, distribution, valuation, fee, expense, tax request, audit request, dissolution, and wind-down. 
- Enumerated event lifecycle states: draft, evidence pending, validation blocked, reconciliation blocked, journal pending, approval pending, report pending, delivered, locked, amended, and restated. 
- Specified the event detail page layout and workspace entry points, covering `event header`, `proof ribbon`, `evidence panel`, `ledger impact`, `capital-account impact`, `workflow tasks`, `report usage`, `audit timeline`, and entry points from `Portfolio`, `Accounting`, `Reporting`, and `Data`; and added roadmap-candidate boundary language. 

### Testing

- Ran `git diff --check -- docs/product/meridian-design-document.md` to validate the markdown change (no issues found). 
- This is a documentation-only change so no build or unit tests were required or run against production code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a307c312d2c83208ca558cbedf4cda3)