### PR TITLE
docs: add tenant-profile design guidance and cross-link to core extensibility model

### DIFF
--- a/docs/architecture/core-extensibility-model.md
+++ b/docs/architecture/core-extensibility-model.md
@@ -38,6 +38,21 @@ evidence expectations, but they must attach to these objects instead of replacin
 | Domain extensions | Tenant object attributes and descriptors | Layer around stable objects without ungoverned identity. |
 | Tenant templates | Profile bundles for onboarding | Activate governed configuration; do not create separate products. |
 
+## Tenant-Profile Configuration
+
+Tenant profiles are an extensibility-layer packaging pattern, not a license to fork core financial
+records. The product design section
+[`Tenant-Profile Design`](../product/meridian-design-document.md#111-tenant-profile-design) defines
+the supported profile examples, profile-configurable surfaces, non-forkable foundations, Settings UI
+concepts, and migration expectations. Engineering implementations should model profile selection,
+preview, import, activation review, and migration history as governed configuration state that
+reuses the stable core object vocabulary above.
+
+Profile bundles may configure labels, workflows, rules, evidence checklists, report templates,
+permissions, saved views, dashboards, and default workspaces. They must not replace ledger
+invariants, audit event contracts, evidence-retention requirements, approval controls, record
+identifiers, or shared source-of-record rules.
+
 ## Governed Foundations
 
 These foundations are intentionally not fully configurable:

--- a/docs/product/meridian-design-document.md
+++ b/docs/product/meridian-design-document.md
@@ -128,10 +128,16 @@ Meridian should be one platform with configurable tenant profiles, not separate 
 Example profiles:
 
 * Fund Administrator Profile
+* Private Fund CFO Profile
 * RIA Profile
-* Single Family Office Profile
+* Family Office Profile
+* Investment Accounting Team Profile
 * Private Credit / Alternative Asset Profile
 * Hybrid Institutional Profile
+
+The tenant-profile boundary is defined in [Section 11.1 Tenant-Profile Design](#111-tenant-profile-design) and
+mirrored by the engineering guardrails in
+[`docs/architecture/core-extensibility-model.md`](../architecture/core-extensibility-model.md#tenant-profile-configuration).
 
 The platform must also support scoped authority inside those profiles. A user is not only
 "Accounting" or "Administrator"; production authorization must be able to answer whether that user
@@ -1558,6 +1564,51 @@ These should remain governed and consistent:
 * Data lineage model
 * Approval evidence model
 * Immutable record preservation
+
+### 11.1 Tenant-Profile Design
+
+Tenant profiles are governed configuration bundles that tune Meridian for common operating models
+without creating separate products or tenant-specific forks. Supported profile examples include:
+
+* fund administrator
+* private fund CFO
+* RIA
+* family office
+* investment accounting team
+
+Profiles may configure the tenant-facing vocabulary and operating posture around the stable core:
+labels, workflows, rules, evidence checklists, report templates, permissions, saved views,
+dashboards, and default workspaces. These settings should be versioned, scoped, reviewable, and
+exportable as tenant-template bundles so an implementation team can explain which assumptions are
+active for each tenant, fund, household, legal entity, or operating organization.
+
+Profiles may not fork the shared financial record foundations. Ledger invariants, the audit event
+model, evidence retention, approval controls, record identifiers, and shared source-of-record rules
+must remain common platform behavior. Profile-specific terminology can rename a view or checklist,
+but it cannot make a journal entry unbalanced, remove approval evidence, rewrite retained lineage,
+replace record IDs, or create a private source-of-record hierarchy outside Meridian's governed model.
+
+Settings should expose profile configuration as a governed operator workflow:
+
+* **Profile selection** — choose a baseline profile during tenant setup or controlled reconfiguration,
+  with clear scope, owner, effective date, and impacted workspaces.
+* **Profile preview** — show label, workflow, rule, evidence, report, permission, saved-view,
+  dashboard, and default-workspace changes before activation.
+* **Template import** — import profile templates from approved configuration bundles, validate schema
+  compatibility, and retain source, version, checksum, and approval metadata.
+* **Governance review** — require authorized review for profile activation, high-impact changes,
+  permission expansion, evidence checklist reduction, report-template changes, and source-priority
+  assumptions.
+
+When a tenant changes profile assumptions, Meridian should treat the change as a migration rather
+than a cosmetic preference update. Migration rules should include an impact assessment, immutable
+retention of the prior profile version, explicit mapping from old labels/workflows/rules/templates to
+new ones, compatibility checks for open tasks and in-flight approvals, report-template versioning,
+saved-view/dashboard remapping, permission-delta review, replay or revalidation requirements for
+evidence-sensitive outputs, and a cutover/audit event that records who approved the change, when it
+became effective, and which tenant scopes were affected. Historical records should continue to
+resolve against the profile version that governed them unless a reviewed migration explicitly
+reclassifies them with retained evidence.
 
 ---
 


### PR DESCRIPTION
### Motivation

- Provide a clear tenant-profile design surface so Meridian can support common operating models (fund administrator, private fund CFO, RIA, family office, investment accounting team) from one core platform. 
- Make explicit which tenant configuration surfaces are safe to tune and which foundational rules must remain governed to avoid tenant-specific forks. 
- Surface UI and migration expectations so tenant profile changes are treated as governed migrations with auditability and compatibility checks.

### Description

- Added `11.1 Tenant-Profile Design` to `docs/product/meridian-design-document.md` describing supported profile examples, configurable surfaces (labels, workflows, rules, evidence checklists, report templates, permissions, saved views, dashboards, default workspaces), non-forkable foundations (ledger invariants, audit event model, evidence retention, approval controls, record identifiers, shared source-of-record rules), Settings UI concepts, and migration rules. 
- Extended the product strategy example profiles list to include `Private Fund CFO`, `Family Office`, and `Investment Accounting Team`, and cross-linked the new profile section to the architecture guidance. 
- Added a `Tenant-Profile Configuration` section to `docs/architecture/core-extensibility-model.md` that references the product design guidance and reiterates engineering guardrails for profile bundles so implementations model selection, preview, import, activation review, and migration history as governed configuration state. 
- Changes are documentation-only and do not modify runtime code or behavior.

### Testing

- Ran the narrow docs validation check `git diff --check -- docs/product/meridian-design-document.md docs/architecture/core-extensibility-model.md` which completed with no issues. 
- Verified working tree status with `git status --short` and committed the documentation changes as `docs: add tenant profile design guidance`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a307c431d7483208e5c1f596ca491a4)