### PR TITLE
Add Operational Evidence Graph design addendum and roadmap item

### DIFF
--- a/docs/product/meridian-design-document.md
+++ b/docs/product/meridian-design-document.md
@@ -2530,6 +2530,94 @@ This is a planned product direction, not a completion claim. Roadmap and impleme
 require registry-backed acceptance evidence before stakeholder-facing status can move from planned
 or supported to complete.
 
+### v0.18 Addendum: Operational Evidence Graph Product Surface
+
+The Operational Evidence Graph should become the reusable proof surface that browser and WPF
+workstations can open from any material operating record. It is not a separate compliance module; it
+is the shared navigation, manifest, and proof contract that explains how a retained source became a
+ledger, close, report, delivery, or audit object.
+
+#### Standard Graph Layers
+
+Every graph view, proof drawer, and exported manifest should preserve these layers even when a
+particular subject has no records in a layer yet. Missing required layers must render as
+`review-required` or `blocked`, not as implicit success.
+
+| Layer | Required product meaning | Typical record examples |
+| --- | --- | --- |
+| Source | Original retained input and receipt proof. | Provider payload, administrator file, bank statement, document, source hash, vault object, receipt timestamp. |
+| Normalization | Transformation from source into Meridian-controlled records. | Import run, mapping profile, schema version, extraction confidence, reviewer state, normalized transaction, position, balance, or document field. |
+| Validation | Deterministic checks that make the normalized record usable. | Validation rule, data-quality gate, duplicate check, required-field result, tolerance result, validation reviewer, validation exception. |
+| Reconciliation | Tie-out between expected, source, portfolio, cash, ledger, administrator, or report records. | Reconciliation run, match rule, break, true-break narrative, resolution code, assignment, SLA, approval. |
+| Ledger | Accounting impact and posting control. | Draft journal, posted journal, ledger detail, posting policy, reversal chain, period lock, ledger version. |
+| Capital accounts | Investor-level capital projection and statement lineage. | Commitment, contribution, distribution, allocation, capital-account roll-forward, NAV impact, statement line. |
+| Close | Period readiness, blockers, lock state, and reopen proof. | Close lane, checklist item, blocker, late adjustment, reopen request, period lock, close package. |
+| Reporting | Report number provenance and package approval. | Dataset version, report line, template version, package approval, restatement lineage, report-pack snapshot. |
+| Delivery | Stakeholder publication evidence. | Recipient list, package version, timestamp, channel, delivery artifact, delivery exception. |
+| Audit | Immutable reconstruction support. | Audit event, retained support package, request list, evidence manifest, export hash, reviewer attestation. |
+
+#### Reusable Browser and WPF UI Pattern
+
+The browser workstation in `src/Meridian.Ui/dashboard/` and the WPF workstation in
+`src/Meridian.Wpf/` should consume the same read models and service APIs for all proof surfaces. UI
+implementations may differ in layout mechanics, but the business state, action eligibility, layer
+labels, link semantics, and manifest payload must remain shared.
+
+| Pattern | Purpose | Minimum behavior |
+| --- | --- | --- |
+| Compact proof ribbon | Inline confidence strip for grids, drawers, cards, and command-center rows. | Shows layer coverage, blocker count, evidence freshness, approval posture, export availability, and a one-click route to the side proof drawer. |
+| Side proof drawer | Contextual proof inspection without leaving the operator task. | Shows the selected subject, ordered layer summary, required versus present evidence, key warnings, first-hop links, audit timeline preview, and actions to validate, export, or open the full graph. |
+| Full proof graph page | Deep reconstruction surface for complex investigations and audits. | Provides layered graph navigation, filters by layer/link/status, path tracing from source to output, missing-link highlighting, compare/restatement mode, and stable deep links back to source explorer records. |
+| Exportable evidence manifest | Durable handoff artifact for audit, tax, reporting, admin tie-out, or internal approval. | Exports subject identifiers, node identifiers, link types, source hashes or vault references, generated timestamp, schema version, validation warnings, completeness state, and reviewer/export attestations. |
+
+#### Required Entry Points
+
+Operational Evidence Graph entry points should be available anywhere the operator sees a material
+record whose trust depends on upstream proof. The first implementation candidates should include:
+
+* **Ledger Explorer:** open proof from journal entries, ledger details, reversal chains, posting
+  policies, close locks, report usage, and capital-account impact.
+* **Portfolio Explorer:** open proof from positions, lots, transactions, valuations, cash flows,
+  reconciliation status, ledger impact, instrument links, and report usage.
+* **Report-Line Provenance Explorer:** open proof from a report line, dataset version, package
+  approval, restatement lineage, delivery record, and stakeholder output.
+* **Fund Event Command Center:** open proof from capital calls, distributions, investments, fees,
+  valuations, closings, tax requests, audit requests, wind-downs, approvals, and event blockers.
+* **Evidence Vault:** open proof from request-list items, uploaded documents, extracted fields,
+  confidence reviews, frozen manifests, support packages, and vault object references.
+
+#### Shared Read-Model and Service API Minimums
+
+Shared read models in `src/Meridian.Ui.Shared/` and service APIs in `src/Meridian.Ui.Services/`
+should use stable identifiers and typed links so browser and WPF do not invent incompatible proof
+semantics. At minimum, graph-capable DTOs should carry:
+
+* `subjectKind`, `subjectId`, `tenantId`, `fundId`, `entityId`, `bookId`, `periodId`, and optional
+  `investorId`, `accountId`, `instrumentId`, `portfolioId`, `reportPackId`, `fundEventId`,
+  `evidenceVaultObjectId`, and `auditEventId` when those scopes are relevant.
+* Node identifiers: `evidenceId`, `layer`, `recordKind`, `recordId`, `recordVersion`, `status`,
+  `generatedAt`, `effectiveAt`, `sourceSystem`, `sourceUri` or vault reference, `sourceHash`,
+  `schemaVersion`, `owner`, `reviewer`, `approvalId`, and `warningCodes`.
+* Link identifiers: `edgeId`, `fromEvidenceId`, `toEvidenceId`, `linkType`, `linkStatus`,
+  `createdAt`, `createdBy`, `ruleId`, `confidence`, and optional `materiality`, `tolerance`,
+  `restatementId`, `reversalId`, or `deliveryId`.
+* Standard link types: `derived_from`, `normalized_by`, `validated_by`, `matched_to`,
+  `reconciled_by`, `break_resolved_by`, `posted_to`, `reversed_by`, `allocated_to`,
+  `rolled_forward_to`, `closed_by`, `reopened_by`, `reported_as`, `approved_by`,
+  `delivered_as`, `requested_by`, `satisfies_request`, `attested_by`, `exported_as`, and
+  `audited_by`.
+
+#### Roadmap Acceptance Language
+
+Roadmap candidates that claim the Operational Evidence Graph should stay `planned` until
+implementation evidence exists in the roadmap registry. Candidate acceptance must require shared
+read models and service APIs, at least one browser entry point, at least one WPF entry point or an
+explicit WPF parity plan, exported manifest validation, retained source or vault references, and
+tests proving that missing required evidence remains `review-required` or `blocked`. A candidate may
+move beyond `planned` only when `docs/roadmap/data/roadmap-items.yml` links concrete tests, source
+modules, and implementation paths that prove the graph layers, UI pattern, entry points, identifiers,
+link types, and manifest behavior are implemented rather than only designed.
+
 ---
 
 ## 26. Foundational Product Slice

--- a/docs/roadmap/data/roadmap-items.yml
+++ b/docs/roadmap/data/roadmap-items.yml
@@ -283,6 +283,41 @@ items:
         path: src/Meridian.Ui/dashboard/src/screens/portfolio-screen.view-model.test.ts
     last_reviewed: 2026-06-02
 
+  - id: W5X-OEG-001
+    title: Operational evidence graph product surface
+    wave: W5X
+    stage_gates:
+      - AccountingRecords
+      - PortfolioLedgerReview
+      - GovernedReportPack
+    workspace:
+      - Accounting
+      - Portfolio
+      - Reporting
+      - Data
+    owner_lane: Workstation Shell and UX
+    status: planned
+    health: green
+    priority: high
+    evidence_posture: planned_evidence
+    current_summary: Planned productization candidate for a shared Operational Evidence Graph surface spanning source, normalization, validation, reconciliation, ledger, capital accounts, close, reporting, delivery, and audit layers. Status must remain planned until implementation evidence links concrete shared read models, service APIs, browser and WPF entry points, manifest export behavior, and tests.
+    exit_criteria:
+      - Shared read models in SRC-UI-SHARED and service APIs in SRC-UI-SERVICES define stable subject identifiers, node identifiers, layer values, status values, warning codes, and typed evidence links for browser and WPF consumers without UI-local business rules.
+      - Compact proof ribbon, side proof drawer, full proof graph page, and exportable evidence manifest patterns are implemented from the same contracts with parity across browser and WPF or an explicit WPF parity plan recorded in implementation evidence.
+      - Ledger Explorer, Portfolio Explorer, Report-Line Provenance Explorer, Fund Event Command Center, and Evidence Vault can open graph context for their material records through stable deep links or routed actions.
+      - Evidence manifests include source hashes or vault references, graph schema version, generated timestamp, completeness state, validation warnings, reviewer or export attestation, and typed links from source through audit.
+      - Tests prove that missing required source, validation, reconciliation, ledger, close, reporting, delivery, or audit evidence remains review-required or blocked rather than being represented as complete.
+      - Roadmap status remains planned until this item links implementation paths and concrete evidence entries for the shared contracts, service endpoints, browser surface, WPF surface or parity plan, manifest export, and missing-evidence tests.
+    source_modules:
+      - SRC-UI-SERVICES
+      - SRC-UI-SHARED
+      - SRC-UI-DASHBOARD
+      - SRC-WPF
+    diagrams:
+      - DIA-ASSURANCE-LOOP
+      - DIA-BROWSER-WORKSTATION
+    last_reviewed: 2026-06-15
+
   - id: W5X-FREX-001
     title: Shared financial record explorers
     wave: W5X


### PR DESCRIPTION
### Motivation

- Formalize the Operational Evidence Graph as a shared proof surface that explains how retained sources become ledger, close, report, delivery, or audit objects. 
- Standardize the graph model and UI patterns so browser and WPF workstations share read models, service APIs, and predictable proof semantics. 
- Ensure roadmap gating and acceptance criteria keep the item `planned` until concrete implementation evidence and tests exist.

### Description

- Add a `v0.18 Addendum: Operational Evidence Graph Product Surface` to `docs/product/meridian-design-document.md` defining the standard graph layers (source, normalization, validation, reconciliation, ledger, capital accounts, close, reporting, delivery, audit). 
- Specify a reusable browser/WPF UI pattern: `compact proof ribbon`, `side proof drawer`, `full proof graph page`, and `exportable evidence manifest`. 
- Add required entry points from `Ledger Explorer`, `Portfolio Explorer`, `Report-Line Provenance Explorer`, `Fund Event Command Center`, and `Evidence Vault`, and list minimum shared read-model/service-API identifiers and standard typed link types for `src/Meridian.Ui.Shared/` and `src/Meridian.Ui.Services/`. 
- Add a planned roadmap candidate `W5X-OEG-001` in `docs/roadmap/data/roadmap-items.yml` with explicit exit criteria requiring shared contracts, browser/WPF entry points or parity plan, manifest export, and tests proving missing-evidence is `review-required` or `blocked`.

### Testing

- Ran `git diff --check -- docs/product/meridian-design-document.md docs/roadmap/data/roadmap-items.yml` with no errors. 
- Ran `python3 build/scripts/docs/validate-roadmap-registry.py --summary` which returned `0 error(s), 0 warning(s)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a307c2c21188320bdfbda6d2a6d7386)