### PR TITLE
Add WPF Demo/Sample Tour (fixture-backed guided onboarding and Settings entry)

### DIFF
--- a/src/Meridian.Wpf/App.xaml.cs
+++ b/src/Meridian.Wpf/App.xaml.cs
@@ -281,6 +281,7 @@ public partial class App : System.Windows.Application
         services.AddSingleton<IStatusService>(sp => sp.GetRequiredService<WpfServices.ApiStatusService>());
         services.AddSingleton<WpfServices.StatusService>(_ => WpfServices.StatusService.Instance);
         services.AddSingleton<WpfServices.FirstRunService>(_ => WpfServices.FirstRunService.Instance);
+        services.AddSingleton<WpfServices.DemoTourService>(_ => WpfServices.DemoTourService.Instance);
         services.AddSingleton<UserProfileRegistry>();
         services.AddSingleton<LoginSessionService>();
         services.AddSingleton<WpfServices.DesktopAuthenticationSession>();

--- a/src/Meridian.Wpf/MainWindow.xaml
+++ b/src/Meridian.Wpf/MainWindow.xaml
@@ -137,6 +137,11 @@
                                 Orientation="Horizontal"
                                 VerticalAlignment="Center"
                                 Margin="16,0,0,0">
+                        <Button Content="Start Demo / Sample Tour"
+                                Style="{StaticResource PrimaryButtonStyle}"
+                                Command="{Binding StartDemoTourCommand}"
+                                AutomationProperties.AutomationId="StartupStartDemoTourButton"
+                                Margin="0,0,8,0" />
                         <Button Content="Open Welcome"
                                 Style="{StaticResource SecondaryButtonStyle}"
                                 Command="{Binding NavigateCommand}"
@@ -145,6 +150,47 @@
                         <Button Content="Dismiss"
                                 Style="{StaticResource GhostButtonStyle}"
                                 Command="{Binding DismissStartupBannerCommand}" />
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <Border x:Name="DemoTourBanner"
+                    Visibility="{Binding DemoTourVisibility}"
+                    Padding="14,10"
+                    Background="{StaticResource ConsoleAccentBlueAlpha20Brush}"
+                    BorderBrush="{StaticResource InfoColorBrush}"
+                    BorderThickness="0,0,0,1"
+                    AutomationProperties.Name="Demo sample mode guided tour"
+                    AutomationProperties.AutomationId="DemoTourBanner">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0">
+                        <TextBlock Text="{Binding DemoTourStepText}"
+                                   FontWeight="SemiBold"
+                                   Foreground="{StaticResource ConsoleTextPrimaryBrush}" />
+                        <TextBlock Text="{Binding DemoTourDetail}"
+                                   Margin="0,3,0,0"
+                                   Foreground="{StaticResource ConsoleTextSecondaryBrush}"
+                                   TextWrapping="Wrap" />
+                        <TextBlock Text="DEMO / SAMPLE DATA ONLY — not provider-backed operational records."
+                                   Margin="0,5,0,0"
+                                   FontSize="11"
+                                   FontWeight="SemiBold"
+                                   Foreground="{StaticResource InfoColorBrush}" />
+                    </StackPanel>
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" Margin="16,0,0,0">
+                        <Button Content="Next"
+                                Style="{StaticResource SecondaryButtonStyle}"
+                                Command="{Binding NextDemoTourStepCommand}"
+                                AutomationProperties.AutomationId="DemoTourNextButton"
+                                Margin="0,0,8,0" />
+                        <Button Content="End Tour"
+                                Style="{StaticResource GhostButtonStyle}"
+                                Command="{Binding EndDemoTourCommand}"
+                                AutomationProperties.AutomationId="DemoTourEndButton" />
                     </StackPanel>
                 </Grid>
             </Border>

--- a/src/Meridian.Wpf/README.md
+++ b/src/Meridian.Wpf/README.md
@@ -77,6 +77,8 @@ Proof actions that carry shared Financial Record Explorer API hrefs map back to 
 `PortfolioExplorer`, `SecurityInstrumentExplorer`, or `ReportLineProvenanceExplorer` page tags so
 report-line drill-throughs stay route-compatible with the browser workstation.
 
+The desktop shell includes a first-launch and Settings entry point for a fixture-backed Demo / Sample Tour. Starting the tour enables `FixtureModeDetector` fixture mode, selects the connected fixture scenario, and walks operators through Data/provider status, Portfolio records, Accounting reconciliation, retained evidence/audit context, Reporting readiness, and Settings. The global fixture banner and the tour banner label the workflow as demo/sample data only so sample records remain visually distinct from provider-backed operational data.
+
 Keep desktop support aligned with shared contracts and governance posture.
 Convention-based view-model wiring is handled by `Services/ViewModelViewResolver.cs`; shell pages
 that follow the `*Page` to `*ViewModel` naming convention can receive a DI-constructed DataContext

--- a/src/Meridian.Wpf/Services/DemoTourService.cs
+++ b/src/Meridian.Wpf/Services/DemoTourService.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+
+using Meridian.Ui.Services.Services;
+
+namespace Meridian.Wpf.Services;
+
+/// <summary>
+/// Coordinates the safe, fixture-backed desktop tour used for first-launch onboarding and Settings.
+/// </summary>
+public sealed class DemoTourService
+{
+    private static readonly Lazy<DemoTourService> _instance = new(() => new DemoTourService(FixtureModeDetector.Instance, NavigationService.Instance));
+
+    private readonly FixtureModeDetector _fixtureModeDetector;
+    private readonly NavigationService _navigationService;
+    private int _currentStepIndex = -1;
+
+    public static DemoTourService Instance => _instance.Value;
+
+    public DemoTourService(FixtureModeDetector fixtureModeDetector, NavigationService navigationService)
+    {
+        _fixtureModeDetector = fixtureModeDetector ?? throw new ArgumentNullException(nameof(fixtureModeDetector));
+        _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
+    }
+
+    public event EventHandler? TourChanged;
+
+    public IReadOnlyList<DemoTourStep> Steps { get; } =
+    [
+        new(1, "Data/provider status", "DataShell", "Review sample provider health and queue telemetry before any live provider credentials are connected."),
+        new(2, "Portfolio records", "PortfolioShell", "Inspect fixture portfolio records that are isolated from retained source-backed books."),
+        new(3, "Accounting reconciliation", "FundReconciliation", "Walk through safe sample breaks, match context, and close-readiness posture."),
+        new(4, "Evidence/audit context", "FundAuditTrail", "Confirm retained evidence, audit history, and source references are visibly sample-only."),
+        new(5, "Reporting readiness", "ReportingShell", "Preview governed report readiness without publishing provider-backed operational data."),
+        new(6, "Settings", "SettingsShell", "Finish in Settings, where the tour can be restarted and demo/sample mode is clearly labeled.")
+    ];
+
+    public bool IsTourActive => _currentStepIndex >= 0 && _currentStepIndex < Steps.Count;
+
+    public DemoTourStep? CurrentStep => IsTourActive ? Steps[_currentStepIndex] : null;
+
+    public string CurrentStepText => CurrentStep is { } step
+        ? $"Demo/sample tour {step.Sequence} of {Steps.Count}: {step.Title}"
+        : "Demo/sample tour inactive";
+
+    public string CurrentStepDetail => CurrentStep?.Description
+        ?? "Start the guided tour to load fixture data and visit the safe demo workflow.";
+
+    public bool CanMoveNext => IsTourActive && _currentStepIndex < Steps.Count - 1;
+
+    public void StartTour()
+    {
+        _fixtureModeDetector.SetFixtureMode(true);
+        FixtureDataService.Instance.SetScenario(FixtureScenario.Connected);
+        _currentStepIndex = 0;
+        NavigateToCurrentStep();
+        TourChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void MoveNext()
+    {
+        if (!CanMoveNext)
+        {
+            return;
+        }
+
+        _currentStepIndex++;
+        NavigateToCurrentStep();
+        TourChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void EndTour()
+    {
+        _currentStepIndex = -1;
+        TourChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void NavigateToCurrentStep()
+    {
+        if (CurrentStep is { PageTag.Length: > 0 } step)
+        {
+            _navigationService.NavigateTo(step.PageTag);
+        }
+    }
+}
+
+public sealed record DemoTourStep(int Sequence, string Title, string PageTag, string Description);

--- a/src/Meridian.Wpf/ViewModels/MainWindowViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/MainWindowViewModel.cs
@@ -29,6 +29,7 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
     private readonly DesktopAuthenticationSession _authenticationSession;
     private readonly DispatcherTimer _clipboardBannerTimer;
     private readonly DispatcherTimer _startupBannerTimer;
+    private readonly WpfServices.DemoTourService _demoTourService;
 
     private IReadOnlyList<string> _pendingClipboardSymbols = [];
     private Visibility _authenticatedSessionVisibility = Visibility.Collapsed;
@@ -45,6 +46,9 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
     private Visibility _clipboardBannerVisibility = Visibility.Collapsed;
     private string _clipboardBannerText = string.Empty;
     private bool _startupExperienceShown;
+    private Visibility _demoTourVisibility = Visibility.Collapsed;
+    private string _demoTourStepText = string.Empty;
+    private string _demoTourDetail = string.Empty;
 
     public MainWindowViewModel(
         IConnectionService connectionService,
@@ -55,7 +59,8 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
         WpfServices.WatchlistService watchlistService,
         FixtureModeDetector fixtureModeDetector,
         DesktopAuthenticationSession authenticationSession,
-        IStatusService statusService)
+        IStatusService statusService,
+        WpfServices.DemoTourService? demoTourService = null)
     {
         _connectionService = connectionService ?? throw new ArgumentNullException(nameof(connectionService));
         _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
@@ -65,6 +70,7 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
         _watchlistService = watchlistService ?? throw new ArgumentNullException(nameof(watchlistService));
         _fixtureModeDetector = fixtureModeDetector ?? throw new ArgumentNullException(nameof(fixtureModeDetector));
         _authenticationSession = authenticationSession ?? throw new ArgumentNullException(nameof(authenticationSession));
+        _demoTourService = demoTourService ?? WpfServices.DemoTourService.Instance;
 
         StatusBar = new StatusBarViewModel(statusService, notificationService);
 
@@ -75,6 +81,9 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
         LogoutCommand = new RelayCommand(Logout, CanLogout);
         AddClipboardSymbolsCommand = new AsyncRelayCommand(AddPendingSymbolsToWatchlistAsync, () => _pendingClipboardSymbols.Count > 0);
         DismissStartupBannerCommand = new RelayCommand(HideStartupBanner);
+        StartDemoTourCommand = new RelayCommand(StartDemoTour);
+        NextDemoTourStepCommand = new RelayCommand(NextDemoTourStep, () => _demoTourService.CanMoveNext);
+        EndDemoTourCommand = new RelayCommand(EndDemoTour);
         DismissClipboardBannerCommand = new RelayCommand(HideClipboardBanner);
 
         _startupBannerTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(18) };
@@ -83,6 +92,7 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
         _clipboardBannerTimer.Tick += OnClipboardBannerTimerTick;
 
         _fixtureModeDetector.ModeChanged += OnFixtureModeChanged;
+        _demoTourService.TourChanged += OnDemoTourChanged;
         RefreshAuthenticationState();
         UpdateFixtureModeBanner();
     }
@@ -104,6 +114,12 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
     public IAsyncRelayCommand AddClipboardSymbolsCommand { get; }
 
     public IRelayCommand DismissStartupBannerCommand { get; }
+
+    public IRelayCommand StartDemoTourCommand { get; }
+
+    public IRelayCommand NextDemoTourStepCommand { get; }
+
+    public IRelayCommand EndDemoTourCommand { get; }
 
     public IRelayCommand DismissClipboardBannerCommand { get; }
 
@@ -173,6 +189,25 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
         private set => SetProperty(ref _startupBannerDetail, value);
     }
 
+
+    public Visibility DemoTourVisibility
+    {
+        get => _demoTourVisibility;
+        private set => SetProperty(ref _demoTourVisibility, value);
+    }
+
+    public string DemoTourStepText
+    {
+        get => _demoTourStepText;
+        private set => SetProperty(ref _demoTourStepText, value);
+    }
+
+    public string DemoTourDetail
+    {
+        get => _demoTourDetail;
+        private set => SetProperty(ref _demoTourDetail, value);
+    }
+
     public Visibility ClipboardBannerVisibility
     {
         get => _clipboardBannerVisibility;
@@ -223,8 +258,8 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
             ? "Meridian opened in a non-live environment. Validate workflows, data posture, and operator routes here before moving to production credentials or capital."
             : "Review the active operating context, shell mode, and readiness posture before taking live actions.";
         StartupBannerDetail = isNonLiveMode
-            ? "Use Welcome for the full workstation briefing, confirm the mode banner, and keep live-provider changes gated until the environment is intentionally switched."
-            : "Use Welcome for the full workstation briefing, then move through Trading, Portfolio, Accounting, Reporting, Strategy, Data, or Settings from the same governed shell.";
+            ? "Start Demo / Sample Tour to follow fixture provider status, portfolio, reconciliation, audit, reporting, and Settings without touching live data."
+            : "Start Demo / Sample Tour to load clearly labeled sample data, or use Welcome for the full workstation briefing before live actions.";
         StartupBannerVisibility = Visibility.Visible;
 
         _startupBannerTimer.Stop();
@@ -432,6 +467,7 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
         _clipboardBannerTimer.Stop();
         _clipboardBannerTimer.Tick -= OnClipboardBannerTimerTick;
         _fixtureModeDetector.ModeChanged -= OnFixtureModeChanged;
+        _demoTourService.TourChanged -= OnDemoTourChanged;
         StatusBar.Dispose();
     }
 
@@ -484,6 +520,35 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
     private void OnFixtureModeChanged(object? sender, EventArgs e)
     {
         UpdateFixtureModeBanner();
+    }
+
+    private void StartDemoTour()
+    {
+        _demoTourService.StartTour();
+        HideStartupBanner();
+        _notificationService.ShowNotification(
+            "Demo / sample mode active",
+            "Fixture data is loaded for the guided tour. Live provider-backed operational data remains visually separated by the demo banner.",
+            NotificationType.Info,
+            6000);
+    }
+
+    private void NextDemoTourStep()
+    {
+        _demoTourService.MoveNext();
+    }
+
+    private void EndDemoTour()
+    {
+        _demoTourService.EndTour();
+    }
+
+    private void OnDemoTourChanged(object? sender, EventArgs e)
+    {
+        DemoTourVisibility = _demoTourService.IsTourActive ? Visibility.Visible : Visibility.Collapsed;
+        DemoTourStepText = _demoTourService.CurrentStepText;
+        DemoTourDetail = _demoTourService.CurrentStepDetail;
+        NextDemoTourStepCommand.NotifyCanExecuteChanged();
     }
 
     private void OnClipboardBannerTimerTick(object? sender, EventArgs e)

--- a/src/Meridian.Wpf/ViewModels/SettingsViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/SettingsViewModel.cs
@@ -32,6 +32,7 @@ public sealed partial class SettingsViewModel : BindableBase
     private readonly SettingsConfigurationService _settingsConfigService;
     private readonly WpfServices.ISecurityAssetProfileWorkflowClient? _assetProfileClient;
     private readonly WpfServices.IOperationsControlCenterClient? _operationsControlClient;
+    private readonly WpfServices.DemoTourService _demoTourService;
 
     private string _configPath = string.Empty;
     private string _configStatusText = "Valid";
@@ -73,7 +74,8 @@ public sealed partial class SettingsViewModel : BindableBase
         IFeatureCapabilityGate? capabilityGate = null,
         IEnumerable<FeatureCapabilityDescriptor>? capabilityDescriptors = null,
         WpfServices.ISecurityAssetProfileWorkflowClient? assetProfileClient = null,
-        WpfServices.IOperationsControlCenterClient? operationsControlClient = null)
+        WpfServices.IOperationsControlCenterClient? operationsControlClient = null,
+        WpfServices.DemoTourService? demoTourService = null)
     {
         _configService = configService;
         _notificationService = notificationService;
@@ -81,6 +83,7 @@ public sealed partial class SettingsViewModel : BindableBase
         _settingsConfigService = SettingsConfigurationService.Instance;
         _assetProfileClient = assetProfileClient;
         _operationsControlClient = operationsControlClient;
+        _demoTourService = demoTourService ?? WpfServices.DemoTourService.Instance;
         StoredCredentials = new ObservableCollection<CredentialDisplayInfo>();
         RecentActivity = new ObservableCollection<SettingsActivityItem>();
         AssetProfileRows = new ObservableCollection<SettingsAssetProfileRow>();
@@ -107,6 +110,7 @@ public sealed partial class SettingsViewModel : BindableBase
         ManageCredentialsCommand = new RelayCommand(() => WpfServices.NavigationService.Instance.NavigateTo("CredentialManagement"));
         RunSetupWizardCommand = new RelayCommand(() => WpfServices.NavigationService.Instance.NavigateTo("SetupWizard"));
         ConfigureProviderCredentialCommand = new RelayCommand(() => WpfServices.NavigationService.Instance.NavigateTo("AddProviderWizard"));
+        StartDemoTourCommand = new RelayCommand(StartDemoTour);
 
         // Credential commands
         TestCredentialCommand = new RelayCommand<string>(TestCredential);
@@ -156,6 +160,23 @@ public sealed partial class SettingsViewModel : BindableBase
     public ObservableCollection<SettingsOperationsCloseCalendarRow> OperationsCloseCalendarRows { get; }
     public ObservableCollection<FeatureCapabilityToggleViewModel> CapabilityToggles { get; }
     public IReadOnlyList<ShellDensityMode> ShellDensityModes { get; }
+
+    public IRelayCommand StartDemoTourCommand { get; }
+
+    public string DemoModeStatusText => FixtureModeDetector.Instance.IsFixtureMode
+        ? "Demo/sample mode is active. All tour records are fixture data and remain separate from provider-backed operational data."
+        : "Demo/sample mode is off. Start the tour to load safe fixture data and visibly distinguish it from live provider records.";
+
+    private void StartDemoTour()
+    {
+        _demoTourService.StartTour();
+        RaisePropertyChanged(nameof(DemoModeStatusText));
+        _notificationService.ShowNotification(
+            "Demo / sample tour",
+            "Fixture data is now active for the guided workflow. Live provider-backed operational data is not modified.",
+            NotificationType.Info,
+            6000);
+    }
 
     // ── Bindable Properties ───────────────────────────────────────────────────
 

--- a/src/Meridian.Wpf/Views/SettingsPage.xaml
+++ b/src/Meridian.Wpf/Views/SettingsPage.xaml
@@ -39,6 +39,47 @@
                     </StackPanel>
                 </Border>
 
+                <Border Style="{StaticResource CardStyle}"
+                        Margin="0,0,0,16"
+                        BorderBrush="{StaticResource InfoColorBrush}"
+                        AutomationProperties.AutomationId="SettingsDemoSampleModeCard">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="{StaticResource IconData}"
+                                           FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                           FontSize="18"
+                                           Foreground="{StaticResource InfoColorBrush}"
+                                           VerticalAlignment="Center" />
+                                <TextBlock Text="Demo / Sample Mode"
+                                           Style="{StaticResource CardHeaderStyle}"
+                                           Margin="8,0,0,0" />
+                            </StackPanel>
+                            <TextBlock Text="{Binding DemoModeStatusText}"
+                                       Margin="0,8,0,0"
+                                       Foreground="{StaticResource ConsoleTextSecondaryBrush}"
+                                       TextWrapping="Wrap" />
+                            <TextBlock Text="Tour order: Data/provider status → Portfolio records → Accounting reconciliation → Evidence/audit context → Reporting readiness → Settings."
+                                       Margin="0,6,0,0"
+                                       FontSize="12"
+                                       FontWeight="SemiBold"
+                                       Foreground="{StaticResource InfoColorBrush}"
+                                       TextWrapping="Wrap" />
+                        </StackPanel>
+                        <Button Grid.Column="1"
+                                Content="Start Demo / Sample Tour"
+                                Style="{StaticResource PrimaryButtonStyle}"
+                                Command="{Binding StartDemoTourCommand}"
+                                VerticalAlignment="Center"
+                                Margin="16,0,0,0"
+                                AutomationProperties.AutomationId="SettingsStartDemoTourButton" />
+                    </Grid>
+                </Border>
+
                 <TabControl Margin="0,0,0,24"
                             Background="Transparent"
                             BorderThickness="0"

--- a/tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs
@@ -1472,3 +1472,75 @@ public sealed class MainShellViewModelTests
         }
     }
 }
+
+public sealed class DemoTourServiceTests
+{
+    [Fact]
+    public void StartTour_EnablesFixtureModeAndNavigatesOrderedDemoWorkflow()
+    {
+        var navigationService = NavigationService.Instance;
+        navigationService.ResetForTests();
+        navigationService.Initialize(new Frame());
+        var detector = FixtureModeDetector.Instance;
+        detector.SetFixtureMode(false);
+        detector.UpdateBackendReachability(true);
+        var service = new DemoTourService(detector, navigationService);
+
+        service.StartTour();
+
+        detector.IsFixtureMode.Should().BeTrue();
+        service.CurrentStepText.Should().Contain("1 of 6");
+        service.CurrentStep!.PageTag.Should().Be("DataShell");
+        navigationService.GetBreadcrumbs().First().PageTag.Should().Be("DataShell");
+
+        service.MoveNext();
+        service.CurrentStep!.PageTag.Should().Be("PortfolioShell");
+        service.MoveNext();
+        service.CurrentStep!.PageTag.Should().Be("FundReconciliation");
+        service.MoveNext();
+        service.CurrentStep!.PageTag.Should().Be("FundAuditTrail");
+        service.MoveNext();
+        service.CurrentStep!.PageTag.Should().Be("ReportingShell");
+        service.MoveNext();
+        service.CurrentStep!.PageTag.Should().Be("SettingsShell");
+        service.CanMoveNext.Should().BeFalse();
+    }
+
+    [Fact]
+    public void MainWindowStartDemoTourCommand_ShowsTourBannerAndSampleModeCopy()
+    {
+        var vm = MainShellViewModelTestsCreate.CreateMainWindowViewModelForDemoTour();
+
+        vm.StartDemoTourCommand.Execute(null);
+
+        vm.DemoTourVisibility.Should().Be(Visibility.Visible);
+        vm.DemoTourStepText.Should().Contain("Data/provider status");
+        vm.FixtureModeBannerVisibility.Should().Be(Visibility.Visible);
+        FixtureModeDetector.Instance.ModeLabel.Should().Contain("Demo data mode");
+    }
+}
+
+internal static class MainShellViewModelTestsCreate
+{
+    public static MainWindowViewModel CreateMainWindowViewModelForDemoTour()
+    {
+        var navigationService = NavigationService.Instance;
+        navigationService.ResetForTests();
+        navigationService.Initialize(new Frame());
+        var detector = FixtureModeDetector.Instance;
+        detector.SetFixtureMode(false);
+        detector.UpdateBackendReachability(true);
+        var demoTour = new DemoTourService(detector, navigationService);
+        return new MainWindowViewModel(
+            ConnectionService.Instance,
+            navigationService,
+            NotificationService.Instance,
+            MessagingService.Instance,
+            ThemeService.Instance,
+            WatchlistService.Instance,
+            detector,
+            DesktopAuthenticationSessionTests.CreateSession("Development"),
+            Substitute.For<IStatusService>(),
+            demoTour);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a safe, demo-friendly onboarding flow that uses existing fixture/sample-data services so operators can explore key workspaces without touching live provider-backed data.  
- Surface the demo tour at first launch and in `Settings` so operators can intentionally start a clearly labeled sample workflow before using real data.

### Description
- Added a fixture-backed tour coordinator `DemoTourService` that enables fixture mode, selects a connected fixture scenario, and exposes an ordered step list covering Data/provider status, Portfolio records, Accounting reconciliation, Evidence/Audit, Reporting readiness, and Settings via `DemoTourStep` and `DemoTourService` (`src/Meridian.Wpf/Services/DemoTourService.cs`).
- Wired UI entry points and persistent banner: added a `Start Demo / Sample Tour` button to the startup banner and a tour banner overlay in `MainWindow.xaml`, plus `StartDemoTour`, `NextDemoTourStep`, and `EndDemoTour` commands on `MainWindowViewModel` to control the tour and show demo-mode copy (`src/Meridian.Wpf/MainWindow.xaml`, `src/Meridian.Wpf/ViewModels/MainWindowViewModel.cs`).
- Added a `Demo / Sample Mode` card to the `Settings` page with a restart entry point and status copy, and exposed a `StartDemoTourCommand` on `SettingsViewModel` (`src/Meridian.Wpf/Views/SettingsPage.xaml`, `src/Meridian.Wpf/ViewModels/SettingsViewModel.cs`).
- Registered the tour service for DI and documented the feature in the WPF README; also added focused unit tests that validate fixture-mode activation, ordered navigation, and visible tour/banner state (`src/Meridian.Wpf/App.xaml.cs`, `src/Meridian.Wpf/README.md`, `tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs`).

### Testing
- Ran `git diff --check` as a quick validation of whitespace/format issues and it passed with no check failures.  
- Added unit tests `DemoTourServiceTests` (covers `StartTour` enabling fixture mode and ordered navigation, and `MainWindow` tour command showing the tour banner and fixture-banner copy); these tests were added under `tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs` but could not be executed here because the `dotnet` SDK is not available in the execution environment.  
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary` which completed but reported existing repository-wide generated-doc/source hash drift (pre-existing issues in documentation hashes unrelated to the functional change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3081cd4e208320b7d8645af2f90598)