### PR TITLE
Add WPF Home workspace and ViewModel as shell launch checkpoint

### DIFF
--- a/src/Meridian.Wpf/Features/DesktopFeatureModuleRegistry.cs
+++ b/src/Meridian.Wpf/Features/DesktopFeatureModuleRegistry.cs
@@ -9,6 +9,7 @@ public static class DesktopFeatureModuleRegistry
 {
     private static readonly IDesktopFeatureModule[] Modules =
     [
+        new Home.HomeFeatureModule(),
         new Trading.TradingFeatureModule(),
         new Portfolio.PortfolioFeatureModule(),
         new Accounting.AccountingFeatureModule(),

--- a/src/Meridian.Wpf/Features/Home/HomeFeatureModule.cs
+++ b/src/Meridian.Wpf/Features/Home/HomeFeatureModule.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using Meridian.Wpf.Models;
+using Meridian.Wpf.Shell.Services;
+using Meridian.Wpf.ViewModels;
+using Meridian.Wpf.Views;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Wpf.Features.Home;
+
+public sealed class HomeFeatureModule : IDesktopFeatureModule
+{
+    private static readonly IReadOnlyList<ShellPageDescriptor> Pages =
+    [
+        ShellPageRegistryBuilder.Page<HomeWorkspacePage>(
+            "HomeWorkspace",
+            "Home",
+            "Review operational readiness before opening deep workspaces.",
+            "strategy",
+            "Launchpad",
+            "\uE80F",
+            -10,
+            ShellNavigationVisibilityTier.Primary,
+            ["home", "launch", "readiness", "provider", "reconciliation", "approvals", "reporting"],
+            ["TradingShell", "PortfolioShell", "AccountingShell", "ReportingShell", "StrategyShell", "DataShell", "SettingsShell"],
+            ["Home", "WorkstationHome"],
+            hideFromDefaultPalette: true)
+    ];
+
+    public void Register(IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddTransient<HomeWorkspaceViewModel>();
+        services.AddTransient<HomeWorkspacePage>();
+    }
+
+    public IReadOnlyList<ShellPageDescriptor> DescribePages() => Pages;
+}

--- a/src/Meridian.Wpf/README.md
+++ b/src/Meridian.Wpf/README.md
@@ -34,7 +34,7 @@ matching module before it expands through the older flat page folders.
 
 ## Important workflows
 
-Application startup now shows `StartupWindow` before the main shell. The startup view model validates
+Application startup now shows `StartupWindow` before the main shell. After authentication, the main shell defaults to `HomeWorkspace`, a source-backed WPF launch checkpoint that groups provider health, data freshness, reconciliation, approvals, accounting/reporting readiness, and recent activity before operators enter deeper task workspaces. The startup view model validates
 credentials through the Identity-owned `UserProfileRegistry` and `LoginSessionService`, keeps the
 desktop session in `DesktopAuthenticationSession`, and opens `MainWindow` only after a configured
 operator signs in or an unconfigured optional-development session is explicitly accepted. WPF reads

--- a/src/Meridian.Wpf/ViewModels/HomeWorkspaceViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/HomeWorkspaceViewModel.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
+using Meridian.Contracts.Workstation;
+using Meridian.Ui.Services;
+using Meridian.Ui.Shared.Services;
+using Meridian.Wpf.Contracts;
+using Meridian.Wpf.Models;
+using Meridian.Wpf.Services;
+
+namespace Meridian.Wpf.ViewModels;
+
+public sealed class HomeWorkspaceViewModel : BindableBase
+{
+    private readonly INavigationService _navigationService;
+    private readonly WorkstationWorkflowSummaryService? _workflowSummaryService;
+    private readonly FundContextService? _fundContextService;
+    private readonly WorkstationOperatingContextService? _operatingContextService;
+    private readonly ObservableCollection<HomeWorkspaceSectionViewModel> _sections = [];
+    private readonly ObservableCollection<HomeWorkspaceNavigationItem> _workspaceNavigationItems = [];
+    private readonly ObservableCollection<HomeWorkspaceActivityItem> _recentActivity = [];
+    private string _summaryText = "Review operational readiness before opening a deep workspace.";
+    private string _generatedAtText = "Not refreshed";
+    private bool _isLoading;
+
+    public HomeWorkspaceViewModel(
+        INavigationService navigationService,
+        WorkstationWorkflowSummaryService? workflowSummaryService = null,
+        FundContextService? fundContextService = null,
+        WorkstationOperatingContextService? operatingContextService = null)
+    {
+        _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
+        _workflowSummaryService = workflowSummaryService;
+        _fundContextService = fundContextService;
+        _operatingContextService = operatingContextService;
+
+        Sections = new ReadOnlyObservableCollection<HomeWorkspaceSectionViewModel>(_sections);
+        WorkspaceNavigationItems = new ReadOnlyObservableCollection<HomeWorkspaceNavigationItem>(_workspaceNavigationItems);
+        RecentActivity = new ReadOnlyObservableCollection<HomeWorkspaceActivityItem>(_recentActivity);
+        RefreshCommand = new AsyncRelayCommand(RefreshAsync, () => !IsLoading);
+
+        foreach (var item in BuildWorkspaceNavigationItems(_navigationService))
+        {
+            _workspaceNavigationItems.Add(item);
+        }
+
+        ApplySummary(BuildFallbackSummary());
+    }
+
+    public ReadOnlyObservableCollection<HomeWorkspaceSectionViewModel> Sections { get; }
+
+    public ReadOnlyObservableCollection<HomeWorkspaceNavigationItem> WorkspaceNavigationItems { get; }
+
+    public ReadOnlyObservableCollection<HomeWorkspaceActivityItem> RecentActivity { get; }
+
+    public IAsyncRelayCommand RefreshCommand { get; }
+
+    public string SummaryText
+    {
+        get => _summaryText;
+        private set => SetProperty(ref _summaryText, value);
+    }
+
+    public string GeneratedAtText
+    {
+        get => _generatedAtText;
+        private set => SetProperty(ref _generatedAtText, value);
+    }
+
+    public bool IsLoading
+    {
+        get => _isLoading;
+        private set
+        {
+            if (SetProperty(ref _isLoading, value))
+            {
+                RefreshCommand.NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    public async Task RefreshAsync(CancellationToken ct = default)
+    {
+        if (IsLoading)
+        {
+            return;
+        }
+
+        IsLoading = true;
+        try
+        {
+            ApplySummary(_workflowSummaryService is null
+                ? BuildFallbackSummary()
+                : await LoadSharedSummaryAsync(ct).ConfigureAwait(true));
+        }
+        catch
+        {
+            ApplySummary(BuildFallbackSummary("Shared home summary unavailable; deterministic launch guidance is shown."));
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    public static IReadOnlyList<HomeWorkspaceSectionViewModel> BuildSections(IReadOnlyList<WorkspaceWorkflowSummary> summaries)
+    {
+        ArgumentNullException.ThrowIfNull(summaries);
+        return new[]
+        {
+            CreateSection("Provider health", "Provider and service degradation that can block acquisition or execution.", "ProviderHealth", summaries, "data", "trading"),
+            CreateSection("Data freshness", "Acquisition, validation, and source-evidence currency before downstream work.", "DataQuality", summaries, "data"),
+            CreateSection("Reconciliation", "Cash, position, trade, and ledger breaks requiring investigation.", "FundReconciliation", summaries, "accounting", "portfolio"),
+            CreateSection("Approvals", "Human review and sign-off queues before records become governed outputs.", "AccountingApprovals", summaries, "accounting", "trading"),
+            CreateSection("Accounting/reporting readiness", "Close package, ledger evidence, and report-pack publication posture.", "FundReportPack", summaries, "accounting", "reporting"),
+            CreateSection("Recent activity", "Strategy, trading, settings, and operator workflow changes worth reviewing.", "StrategyShell", summaries, "strategy", "settings")
+        };
+    }
+
+    private async Task<OperatorWorkflowHomeSummary> LoadSharedSummaryAsync(CancellationToken ct)
+    {
+        var operatingContext = _operatingContextService?.CurrentContext;
+        var fund = _fundContextService?.CurrentFundProfile;
+        return await _workflowSummaryService!.GetAsync(
+            hasOperatingContext: operatingContext is not null || fund is not null,
+            operatingContextDisplayName: operatingContext?.DisplayName,
+            fundProfileId: fund?.FundProfileId,
+            fundAccountId: WorkstationOperatingContextScopeResolver.ResolveFundAccountIdString(operatingContext),
+            fundDisplayName: fund?.DisplayName,
+            ct: ct).ConfigureAwait(false);
+    }
+
+    private OperatorWorkflowHomeSummary BuildFallbackSummary(string? detail = null)
+    {
+        var summaries = ShellNavigationCatalog.Workspaces.Select(workspace => new WorkspaceWorkflowSummary(
+            workspace.Id,
+            workspace.Title,
+            "Launch ready",
+            detail ?? $"Open {workspace.Title} when this home checkpoint indicates your next task.",
+            WorkspaceTone.Info,
+            new WorkflowNextAction($"Open {workspace.Title}", workspace.Description, workspace.HomePageTag, WorkspaceTone.Primary),
+            new WorkflowBlockerSummary("home-fallback", "Shared summary pending", "Refresh when services finish starting to load source-backed workflow posture.", WorkspaceTone.Info, false),
+            [])).ToArray();
+
+        return new OperatorWorkflowHomeSummary(DateTimeOffset.UtcNow, false, "Startup", "No fund scope selected", summaries);
+    }
+
+    private void ApplySummary(OperatorWorkflowHomeSummary summary)
+    {
+        SummaryText = $"{summary.OperatingContextLabel} • {summary.FundDisplayName} • {summary.AssuranceScore.Status} ({summary.AssuranceScore.Score}/100)";
+        GeneratedAtText = $"Updated {summary.GeneratedAt.LocalDateTime:g}";
+
+        _sections.Clear();
+        foreach (var section in BuildSections(summary.Workspaces))
+        {
+            _sections.Add(section);
+        }
+
+        _recentActivity.Clear();
+        foreach (var item in summary.Workspaces
+            .OrderByDescending(static workspace => SeverityRank(workspace.StatusTone))
+            .ThenBy(static workspace => workspace.WorkspaceTitle, StringComparer.OrdinalIgnoreCase)
+            .Take(5)
+            .Select(static workspace => new HomeWorkspaceActivityItem(
+                workspace.WorkspaceTitle,
+                workspace.StatusLabel,
+                workspace.StatusDetail,
+                workspace.StatusTone)))
+        {
+            _recentActivity.Add(item);
+        }
+    }
+
+    private static HomeWorkspaceSectionViewModel CreateSection(
+        string title,
+        string description,
+        string targetPageTag,
+        IReadOnlyList<WorkspaceWorkflowSummary> summaries,
+        params string[] workspaceIds)
+    {
+        var selected = summaries
+            .Where(summary => workspaceIds.Contains(summary.WorkspaceId, StringComparer.OrdinalIgnoreCase))
+            .OrderByDescending(static summary => SeverityRank(summary.PrimaryBlocker.Tone))
+            .ThenByDescending(static summary => SeverityRank(summary.StatusTone))
+            .ThenBy(static summary => summary.WorkspaceTitle, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        IReadOnlyList<HomeWorkspaceSummaryItem> items = selected.Length == 0
+            ? new[] { new HomeWorkspaceSummaryItem("No source summary", "Shared workflow summary has not produced this section yet.", WorkspaceTone.Neutral, "Unmeasured", false) }
+            : selected.Select(static summary => new HomeWorkspaceSummaryItem(
+                summary.WorkspaceTitle,
+                summary.PrimaryBlocker.IsBlocking ? summary.PrimaryBlocker.Detail : summary.StatusDetail,
+                HighestSeverityTone(summary.StatusTone, summary.PrimaryBlocker.Tone),
+                summary.PrimaryBlocker.IsBlocking ? summary.PrimaryBlocker.Label : summary.StatusLabel,
+                summary.PrimaryBlocker.IsBlocking)).ToArray();
+
+        return new HomeWorkspaceSectionViewModel(title, description, targetPageTag, items);
+    }
+
+    private static IReadOnlyList<HomeWorkspaceNavigationItem> BuildWorkspaceNavigationItems(INavigationService navigationService)
+        => ShellNavigationCatalog.Workspaces
+            .Select(workspace => new HomeWorkspaceNavigationItem(
+                workspace.Title,
+                workspace.Summary,
+                workspace.HomePageTag,
+                new RelayCommand(() => navigationService.NavigateTo(workspace.HomePageTag))))
+            .ToArray();
+
+    private static string HighestSeverityTone(string left, string right)
+        => SeverityRank(left) >= SeverityRank(right) ? left : right;
+
+    private static int SeverityRank(string? tone) => tone switch
+    {
+        WorkspaceTone.Danger => 4,
+        WorkspaceTone.Warning => 3,
+        WorkspaceTone.Info => 2,
+        WorkspaceTone.Success => 1,
+        _ => 0
+    };
+}
+
+public sealed record HomeWorkspaceSectionViewModel(
+    string Title,
+    string Description,
+    string TargetPageTag,
+    IReadOnlyList<HomeWorkspaceSummaryItem> Items);
+
+public sealed record HomeWorkspaceSummaryItem(
+    string Title,
+    string Detail,
+    string Tone,
+    string StatusLabel,
+    bool IsBlocking);
+
+public sealed record HomeWorkspaceNavigationItem(
+    string Title,
+    string Detail,
+    string TargetPageTag,
+    IRelayCommand NavigateCommand);
+
+public sealed record HomeWorkspaceActivityItem(
+    string WorkspaceTitle,
+    string Label,
+    string Detail,
+    string Tone);

--- a/src/Meridian.Wpf/ViewModels/MainPageViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/MainPageViewModel.cs
@@ -23,7 +23,7 @@ namespace Meridian.Wpf.ViewModels;
 public sealed class MainPageViewModel : BindableBase, IDisposable
 {
     private const string DefaultWorkspace = "strategy";
-    private const string DefaultPageTag = "StrategyShell";
+    private const string DefaultPageTag = "HomeWorkspace";
 
     private readonly INavigationService _navigationService;
     private readonly NavigationService? _wpfNavigationService;
@@ -48,8 +48,8 @@ public sealed class MainPageViewModel : BindableBase, IDisposable
 
     private string _currentWorkspace = DefaultWorkspace;
     private string _currentPageTag = DefaultPageTag;
-    private string _currentPageTitle = "Strategy Workspace";
-    private string _currentPageSubtitle = "Configure backtests, review runs, and monitor strategy outcomes.";
+    private string _currentPageTitle = "Home";
+    private string _currentPageSubtitle = "Review operational readiness before opening deep task workspaces.";
     private bool _tickerStripVisible;
     private WorkstationOperatingContext? _selectedOperatingContext;
     private BoundedWindowMode _selectedWindowMode = BoundedWindowMode.DockFloat;

--- a/src/Meridian.Wpf/Views/HomeWorkspacePage.xaml
+++ b/src/Meridian.Wpf/Views/HomeWorkspacePage.xaml
@@ -1,0 +1,113 @@
+<Page x:Class="Meridian.Wpf.Views.HomeWorkspacePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:controls="clr-namespace:Meridian.Wpf.Controls"
+      mc:Ignorable="d"
+      d:DesignHeight="900"
+      d:DesignWidth="1400"
+      Loaded="OnLoaded"
+      Background="{DynamicResource ConsoleBackgroundBrush}"
+      AutomationProperties.AutomationId="HomeWorkspacePage"
+      AutomationProperties.Name="Home workspace">
+    <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="24">
+        <StackPanel MaxWidth="1400">
+            <Border Style="{StaticResource WorkstationPageBandStyle}" Padding="24" Margin="0,0,0,16">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel>
+                        <TextBlock Text="Home" Style="{StaticResource PageTitleStyle}" />
+                        <TextBlock Text="Start here for provider health, data freshness, reconciliation, approvals, accounting/reporting readiness, and recent activity before opening deep task workspaces."
+                                   Style="{StaticResource CardDescriptionStyle}" TextWrapping="Wrap" Margin="0,6,0,0" />
+                        <TextBlock Text="{Binding SummaryText}" Style="{StaticResource CardDescriptionStyle}" Margin="0,12,0,0" />
+                        <TextBlock Text="{Binding GeneratedAtText}" Style="{StaticResource CardDescriptionStyle}" Margin="0,4,0,0" />
+                    </StackPanel>
+                    <Button Grid.Column="1" Content="Refresh" Command="{Binding RefreshCommand}" Padding="18,8" VerticalAlignment="Top" />
+                </Grid>
+            </Border>
+
+            <ItemsControl ItemsSource="{Binding Sections}" AutomationProperties.AutomationId="HomeWorkspaceSections">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border Style="{StaticResource WorkstationTablePanelStyle}" Width="430" MinHeight="230" Margin="0,0,16,16" Padding="16">
+                            <StackPanel>
+                                <controls:SectionHeaderBar Title="{Binding Title}" Subtitle="{Binding Description}" BadgeText="Readiness" BadgeTone="Info" />
+                                <ItemsControl ItemsSource="{Binding Items}" Margin="0,12,0,0">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border BorderBrush="{StaticResource ConsoleBorderBrush}" BorderThickness="0,0,0,1" Padding="0,8">
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <StackPanel>
+                                                        <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
+                                                        <TextBlock Text="{Binding Detail}" TextWrapping="Wrap" Style="{StaticResource CardDescriptionStyle}" Margin="0,3,0,0" />
+                                                    </StackPanel>
+                                                    <controls:ToneBadge Grid.Column="1" Text="{Binding StatusLabel}" Tone="{Binding Tone}" Margin="12,0,0,0" />
+                                                </Grid>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+
+            <Border Style="{StaticResource WorkstationPageBandStyle}" Padding="18" Margin="0,4,0,16">
+                <StackPanel>
+                    <TextBlock Text="Open root workspace" Style="{StaticResource CardHeaderStyle}" />
+                    <ItemsControl ItemsSource="{Binding WorkspaceNavigationItems}" Margin="0,12,0,0">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><WrapPanel /></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Button Command="{Binding NavigateCommand}" Margin="0,0,10,10" Padding="14,10" MinWidth="150">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
+                                        <TextBlock Text="{Binding Detail}" TextWrapping="Wrap" FontSize="11" Opacity="0.75" />
+                                    </StackPanel>
+                                </Button>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+
+            <Border Style="{StaticResource WorkstationTablePanelStyle}" Padding="18">
+                <StackPanel>
+                    <TextBlock Text="Recent activity" Style="{StaticResource CardHeaderStyle}" />
+                    <ItemsControl ItemsSource="{Binding RecentActivity}" Margin="0,10,0,0">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Grid Margin="0,0,0,10">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="180" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Text="{Binding WorkspaceTitle}" FontWeight="SemiBold" />
+                                    <TextBlock Grid.Column="1" Text="{Binding Detail}" TextWrapping="Wrap" />
+                                    <controls:ToneBadge Grid.Column="2" Text="{Binding Label}" Tone="{Binding Tone}" Margin="12,0,0,0" />
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/src/Meridian.Wpf/Views/HomeWorkspacePage.xaml.cs
+++ b/src/Meridian.Wpf/Views/HomeWorkspacePage.xaml.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using Meridian.Wpf.ViewModels;
+
+namespace Meridian.Wpf.Views;
+
+public partial class HomeWorkspacePage : Page
+{
+    private readonly HomeWorkspaceViewModel _viewModel;
+
+    public HomeWorkspacePage(HomeWorkspaceViewModel viewModel)
+    {
+        InitializeComponent();
+        _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+        DataContext = _viewModel;
+    }
+
+    private async void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        await _viewModel.RefreshAsync();
+    }
+}

--- a/tests/Meridian.Wpf.Tests/ViewModels/HomeWorkspaceViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/HomeWorkspaceViewModelTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Meridian.Contracts.Workstation;
+using Meridian.Ui.Services.Contracts;
+using Meridian.Wpf.Contracts;
+using Meridian.Wpf.Models;
+using Meridian.Wpf.ViewModels;
+using System.Windows.Controls;
+
+namespace Meridian.Wpf.Tests.ViewModels;
+
+public sealed class HomeWorkspaceViewModelTests
+{
+    [Fact]
+    public void WorkspaceNavigationItems_ExposeCanonicalRootWorkspaces()
+    {
+        var navigation = new StubNavigationService();
+        var viewModel = new HomeWorkspaceViewModel(navigation);
+
+        viewModel.WorkspaceNavigationItems.Select(static item => item.Title)
+            .Should()
+            .Equal("Trading", "Portfolio", "Accounting", "Reporting", "Strategy", "Data", "Settings");
+
+        viewModel.WorkspaceNavigationItems.Select(static item => item.TargetPageTag)
+            .Should()
+            .Equal("TradingShell", "PortfolioShell", "AccountingShell", "ReportingShell", "StrategyShell", "DataShell", "SettingsShell");
+    }
+
+    [Fact]
+    public void WorkspaceNavigationCommand_NavigatesToTargetShell()
+    {
+        var navigation = new StubNavigationService();
+        var viewModel = new HomeWorkspaceViewModel(navigation);
+
+        viewModel.WorkspaceNavigationItems.Single(static item => item.Title == "Accounting").NavigateCommand.Execute(null);
+
+        navigation.LastPageTag.Should().Be("AccountingShell");
+    }
+
+    [Fact]
+    public void BuildSections_GroupsRequiredStatusAreasAndOrdersBySeverity()
+    {
+        var summaries = new[]
+        {
+            Summary("data", "Data", WorkspaceTone.Info, WorkspaceTone.Danger, true),
+            Summary("trading", "Trading", WorkspaceTone.Warning, WorkspaceTone.Info, false),
+            Summary("accounting", "Accounting", WorkspaceTone.Info, WorkspaceTone.Warning, true),
+            Summary("reporting", "Reporting", WorkspaceTone.Success, WorkspaceTone.Neutral, false),
+            Summary("portfolio", "Portfolio", WorkspaceTone.Warning, WorkspaceTone.Neutral, false),
+            Summary("strategy", "Strategy", WorkspaceTone.Info, WorkspaceTone.Neutral, false),
+            Summary("settings", "Settings", WorkspaceTone.Success, WorkspaceTone.Neutral, false)
+        };
+
+        var sections = HomeWorkspaceViewModel.BuildSections(summaries);
+
+        sections.Select(static section => section.Title).Should().Equal(
+            "Provider health",
+            "Data freshness",
+            "Reconciliation",
+            "Approvals",
+            "Accounting/reporting readiness",
+            "Recent activity");
+        sections[0].Items.Select(static item => item.Title).Should().Equal("Data", "Trading");
+        sections[0].Items[0].Tone.Should().Be(WorkspaceTone.Danger);
+        sections[0].Items[0].IsBlocking.Should().BeTrue();
+    }
+
+    private static WorkspaceWorkflowSummary Summary(string id, string title, string statusTone, string blockerTone, bool blocking)
+        => new(
+            id,
+            title,
+            $"{title} status",
+            $"{title} detail",
+            statusTone,
+            new WorkflowNextAction($"Open {title}", "detail", $"{title}Shell", WorkspaceTone.Primary),
+            new WorkflowBlockerSummary($"{id}-blocker", $"{title} blocker", $"{title} blocker detail", blockerTone, blocking),
+            []);
+
+    private sealed class StubNavigationService : INavigationService
+    {
+        public string? LastPageTag { get; private set; }
+        public bool IsInitialized => true;
+        public bool CanGoBack => false;
+        public event EventHandler<NavigationEventArgs>? Navigated;
+        public void Initialize(Frame frame) { }
+        public bool NavigateTo(string pageTag, object? parameter = null)
+        {
+            LastPageTag = pageTag;
+            Navigated?.Invoke(this, new NavigationEventArgs { PageTag = pageTag, Parameter = parameter });
+            return true;
+        }
+        public bool NavigateTo(Type pageType, object? parameter = null) => true;
+        public void GoBack() { }
+        public Type? GetPageType(string pageTag) => null;
+        public IReadOnlyList<NavigationEntry> GetBreadcrumbs() => [];
+        public IReadOnlyCollection<string> GetRegisteredPages() => [];
+        public bool IsPageRegistered(string pageTag) => true;
+    }
+}

--- a/tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs
@@ -102,7 +102,7 @@ public sealed class MainShellViewModelTests
     }
 
     [Fact]
-    public void ActivateShell_WhenHistoryIsEmpty_NavigatesToStrategyWorkspace()
+    public void ActivateShell_WhenHistoryIsEmpty_NavigatesToHomeWorkspace()
     {
         WpfTestThread.Run(() =>
         {
@@ -110,8 +110,8 @@ public sealed class MainShellViewModelTests
 
             vm.ActivateShell();
 
-            vm.CurrentPageTag.Should().Be("StrategyShell");
-            vm.CurrentPageTitle.Should().Be("Strategy Workspace");
+            vm.CurrentPageTag.Should().Be("HomeWorkspace");
+            vm.CurrentPageTitle.Should().Be("Home");
             vm.BackButtonVisibility.Should().Be(Visibility.Collapsed);
         });
     }


### PR DESCRIPTION
### Motivation
- Provide an operator-facing launch checkpoint that appears before deep task workspaces to surface high-level operational posture (provider health, data freshness, reconciliation, approvals, accounting/reporting readiness, and recent activity). 
- Reuse shared read models/services to avoid duplicating business logic by consuming `WorkstationWorkflowSummaryService`, `FundContextService`, and operating-context services when available. 
- Make it easy to jump into the seven canonical workspaces (`Trading`, `Portfolio`, `Accounting`, `Reporting`, `Strategy`, `Data`, `Settings`) from a single home surface so operators can triage before entering detailed workflows. 

### Description
- Add a new page `HomeWorkspacePage` and XAML view at `src/Meridian.Wpf/Views/HomeWorkspacePage.xaml` with a refresh action, summary band, grouped readiness sections, root-workspace navigation buttons, and a recent-activity panel. 
- Add `HomeWorkspaceViewModel` at `src/Meridian.Wpf/ViewModels/HomeWorkspaceViewModel.cs` which loads the shared operator home summary via `WorkstationWorkflowSummaryService` when available, falls back to deterministic startup guidance, orders items by severity, and exposes navigation commands to canonical shell targets. 
- Register the page through a new desktop feature module `src/Meridian.Wpf/Features/Home/HomeFeatureModule.cs` and include it in `DesktopFeatureModuleRegistry` so the page participates in the shell page registry without adding a new visible root workspace. 
- Make the shell open `HomeWorkspace` by default on empty history by updating `MainPageViewModel` (`DefaultPageTag` and page title/subtitle), add focused view-model tests under `tests/Meridian.Wpf.Tests/ViewModels/HomeWorkspaceViewModelTests.cs`, and document the startup checkpoint in `src/Meridian.Wpf/README.md`. 

### Testing
- Code-check: `git diff --check` passed for the modified files. 
- Unit tests: new focused view-model tests were added for canonical root navigation and severity grouping, but `dotnet test` could not be executed in this environment because `dotnet` is not available so the tests were not run here. 
- MVVM/lint checks: `pwsh ./tools/codex/mvvm-compliance-check.ps1` could not be executed because `pwsh` is not available in this environment. 
- Docs validation: `python3 build/scripts/docs/validate-doc-hashes.py --summary` reported repository-wide docs/source hash drift (preexisting in this checkout) which must be resolved by the docs owners; this is a repo-level issue and not specific to the new Home workspace code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3081be54fc832092dd78b65da76a70)