### PR TITLE
Add WPF role-based layout presets and persist desktop layout preferences

### DIFF
--- a/src/Meridian.Ui.Services/README.md
+++ b/src/Meridian.Ui.Services/README.md
@@ -45,6 +45,10 @@ OMS/EMS integration API handlers are registered from `Services/Integrations/` an
 Settings configuration keeps the retained built-in profile id `research` for compatibility, but
 renders it as `Strategy` so browser and WPF settings surfaces do not reintroduce `Research` as a
 root workspace label.
+Desktop shell preferences now also carry WPF role layout preset selection, startup workspace,
+panel visibility, grid density, default filters, and shell density. Built-in role presets stay
+within the canonical visible workspace roots: Trading, Portfolio, Accounting, Reporting, Strategy,
+Data, and Settings.
 Setup wizard presets follow the same compatibility pattern: the retained `researcher` preset id
 remains available for callers, while the visible preset name is `Strategy Analyst`.
 Command palette workspace entries emit canonical page tags for visible roots; `Open Strategy

--- a/src/Meridian.Ui.Services/Services/DesktopShellPreferences.cs
+++ b/src/Meridian.Ui.Services/Services/DesktopShellPreferences.cs
@@ -13,7 +13,42 @@ public enum ShellDensityMode : byte
 /// Persisted desktop shell preferences consumed by the WPF workstation shell.
 /// </summary>
 public sealed record DesktopShellPreferences(
-    ShellDensityMode ShellDensityMode)
+    ShellDensityMode ShellDensityMode,
+    string SelectedLayoutPresetId,
+    string StartupWorkspace,
+    bool IsSummaryPanelVisible,
+    bool IsInspectorPanelVisible,
+    bool IsActivityPanelVisible,
+    string GridDensity,
+    string DefaultFilterSet)
 {
-    public static DesktopShellPreferences Default { get; } = new(ShellDensityMode.Standard);
+    public const string DefaultLayoutPresetId = "portfolio-manager";
+    public const string DefaultStartupWorkspace = "Portfolio";
+    public const string DefaultGridDensity = "Comfortable";
+    public const string DefaultFilterSet = "Open work";
+
+    public static DesktopShellPreferences Default { get; } = new(
+        ShellDensityMode.Standard,
+        DefaultLayoutPresetId,
+        DefaultStartupWorkspace,
+        IsSummaryPanelVisible: true,
+        IsInspectorPanelVisible: true,
+        IsActivityPanelVisible: true,
+        DefaultGridDensity,
+        DefaultFilterSet);
 }
+
+/// <summary>
+/// Built-in role layout preset surfaced in the WPF Settings workspace.
+/// </summary>
+public sealed record DesktopLayoutPreset(
+    string Id,
+    string Name,
+    string Description,
+    string StartupWorkspace,
+    ShellDensityMode ShellDensityMode,
+    bool IsSummaryPanelVisible,
+    bool IsInspectorPanelVisible,
+    bool IsActivityPanelVisible,
+    string GridDensity,
+    string DefaultFilterSet);

--- a/src/Meridian.Ui.Services/Services/SettingsConfigurationService.cs
+++ b/src/Meridian.Ui.Services/Services/SettingsConfigurationService.cs
@@ -29,6 +29,54 @@ public sealed class SettingsConfigurationService
 
     public event EventHandler<DesktopShellPreferences>? DesktopShellPreferencesChanged;
 
+    private static readonly IReadOnlyList<DesktopLayoutPreset> BuiltInDesktopLayoutPresets =
+    [
+        new DesktopLayoutPreset(
+            "portfolio-manager",
+            "Portfolio Manager",
+            "Starts in Portfolio with balanced review chrome, open-decision filters, and comfortable grids for allocation oversight.",
+            "Portfolio",
+            ShellDensityMode.Standard,
+            IsSummaryPanelVisible: true,
+            IsInspectorPanelVisible: true,
+            IsActivityPanelVisible: true,
+            "Comfortable",
+            "Open work"),
+        new DesktopLayoutPreset(
+            "fund-accountant",
+            "Fund Accountant",
+            "Starts in Accounting with dense reconciliation grids, retained evidence visible, and close-readiness filters.",
+            "Accounting",
+            ShellDensityMode.Compact,
+            IsSummaryPanelVisible: true,
+            IsInspectorPanelVisible: true,
+            IsActivityPanelVisible: true,
+            "Dense",
+            "Close blockers"),
+        new DesktopLayoutPreset(
+            "data-operator",
+            "Data Operator",
+            "Starts in Data with diagnostics and activity visible for provider health, ingestion, and exception triage.",
+            "Data",
+            ShellDensityMode.Compact,
+            IsSummaryPanelVisible: true,
+            IsInspectorPanelVisible: true,
+            IsActivityPanelVisible: true,
+            "Dense",
+            "Data exceptions"),
+        new DesktopLayoutPreset(
+            "evaluator-demo",
+            "Evaluator Demo",
+            "Starts in Reporting with simplified panels and demo-ready filters for guided stakeholder walkthroughs.",
+            "Reporting",
+            ShellDensityMode.Standard,
+            IsSummaryPanelVisible: true,
+            IsInspectorPanelVisible: false,
+            IsActivityPanelVisible: false,
+            "Comfortable",
+            "Demo highlights")
+    ];
+
     private SettingsConfigurationService()
     {
         // Seed built-in profiles
@@ -231,6 +279,43 @@ public sealed class SettingsConfigurationService
         return (int)Math.Round(requestsPerMinute, MidpointRounding.AwayFromZero);
     }
 
+    /// <summary>Gets built-in desktop role layout presets.</summary>
+    public IReadOnlyList<DesktopLayoutPreset> GetDesktopLayoutPresets() => BuiltInDesktopLayoutPresets;
+
+    public DesktopLayoutPreset GetDesktopLayoutPreset(string? presetId)
+        => BuiltInDesktopLayoutPresets.FirstOrDefault(preset => string.Equals(preset.Id, presetId, StringComparison.OrdinalIgnoreCase))
+            ?? BuiltInDesktopLayoutPresets[0];
+
+    public void ApplyDesktopLayoutPreset(string? presetId)
+    {
+        var preset = GetDesktopLayoutPreset(presetId);
+        SetDesktopShellPreferences(new DesktopShellPreferences(
+            preset.ShellDensityMode,
+            preset.Id,
+            preset.StartupWorkspace,
+            preset.IsSummaryPanelVisible,
+            preset.IsInspectorPanelVisible,
+            preset.IsActivityPanelVisible,
+            preset.GridDensity,
+            preset.DefaultFilterSet));
+    }
+
+    public void SetDesktopShellPreferences(DesktopShellPreferences preferences)
+    {
+        ArgumentNullException.ThrowIfNull(preferences);
+
+        lock (_desktopPreferencesGate)
+        {
+            EnsureDesktopShellPreferencesLoaded();
+            PersistDesktopShellPreferencesCore(preferences);
+            _desktopShellPreferences = preferences;
+        }
+
+        DesktopShellPreferencesChanged?.Invoke(this, preferences);
+    }
+
+    public void ResetDesktopShellPreferences() => SetDesktopShellPreferences(DesktopShellPreferences.Default);
+
     /// <summary>Gets all configuration profiles (built-in + custom).</summary>
     public IReadOnlyList<ConfigProfile> GetProfiles() => _profiles.AsReadOnly();
 
@@ -379,7 +464,7 @@ public sealed class SettingsConfigurationService
             var model = JsonSerializer.Deserialize<DesktopShellPreferencesStorageModel>(json, DesktopShellJsonOptions);
             _desktopShellPreferences = model is null
                 ? DesktopShellPreferences.Default
-                : new DesktopShellPreferences(ResolveShellDensityMode(model));
+                : ResolveDesktopShellPreferences(model);
         }
         catch
         {
@@ -402,12 +487,37 @@ public sealed class SettingsConfigurationService
 
         var model = new DesktopShellPreferencesStorageModel
         {
-            ShellDensityMode = preferences.ShellDensityMode.ToString()
+            ShellDensityMode = preferences.ShellDensityMode.ToString(),
+            SelectedLayoutPresetId = preferences.SelectedLayoutPresetId,
+            StartupWorkspace = preferences.StartupWorkspace,
+            IsSummaryPanelVisible = preferences.IsSummaryPanelVisible,
+            IsInspectorPanelVisible = preferences.IsInspectorPanelVisible,
+            IsActivityPanelVisible = preferences.IsActivityPanelVisible,
+            GridDensity = preferences.GridDensity,
+            DefaultFilterSet = preferences.DefaultFilterSet
         };
         var json = JsonSerializer.Serialize(model, DesktopShellJsonOptions);
         var temporaryPath = $"{path}.{Guid.NewGuid():N}.tmp";
         File.WriteAllText(temporaryPath, json, Encoding.UTF8);
         File.Move(temporaryPath, path, overwrite: true);
+    }
+
+    private static DesktopShellPreferences ResolveDesktopShellPreferences(DesktopShellPreferencesStorageModel model)
+    {
+        var densityMode = ResolveShellDensityMode(model);
+        var preset = BuiltInDesktopLayoutPresets.FirstOrDefault(candidate =>
+            string.Equals(candidate.Id, model.SelectedLayoutPresetId, StringComparison.OrdinalIgnoreCase));
+        var fallback = preset ?? BuiltInDesktopLayoutPresets[0];
+
+        return new DesktopShellPreferences(
+            densityMode,
+            string.IsNullOrWhiteSpace(model.SelectedLayoutPresetId) ? fallback.Id : model.SelectedLayoutPresetId!,
+            ResolveWorkspace(model.StartupWorkspace, fallback.StartupWorkspace),
+            model.IsSummaryPanelVisible ?? fallback.IsSummaryPanelVisible,
+            model.IsInspectorPanelVisible ?? fallback.IsInspectorPanelVisible,
+            model.IsActivityPanelVisible ?? fallback.IsActivityPanelVisible,
+            string.IsNullOrWhiteSpace(model.GridDensity) ? fallback.GridDensity : model.GridDensity!,
+            string.IsNullOrWhiteSpace(model.DefaultFilterSet) ? fallback.DefaultFilterSet : model.DefaultFilterSet!);
     }
 
     private static ShellDensityMode ResolveShellDensityMode(DesktopShellPreferencesStorageModel model)
@@ -424,6 +534,13 @@ public sealed class SettingsConfigurationService
             false => ShellDensityMode.Standard,
             null => ShellDensityMode.Standard
         };
+    }
+
+    private static string ResolveWorkspace(string? workspace, string fallback)
+    {
+        var allowed = new[] { "Trading", "Portfolio", "Accounting", "Reporting", "Strategy", "Data", "Settings" };
+        return allowed.FirstOrDefault(candidate => string.Equals(candidate, workspace, StringComparison.OrdinalIgnoreCase))
+            ?? fallback;
     }
 
     private static string GetDesktopPreferencesFilePath()
@@ -447,6 +564,20 @@ public sealed class SettingsConfigurationService
     private sealed class DesktopShellPreferencesStorageModel
     {
         public string? ShellDensityMode { get; init; }
+
+        public string? SelectedLayoutPresetId { get; init; }
+
+        public string? StartupWorkspace { get; init; }
+
+        public bool? IsSummaryPanelVisible { get; init; }
+
+        public bool? IsInspectorPanelVisible { get; init; }
+
+        public bool? IsActivityPanelVisible { get; init; }
+
+        public string? GridDensity { get; init; }
+
+        public string? DefaultFilterSet { get; init; }
 
         public bool? IsCompactMode { get; init; }
     }

--- a/src/Meridian.Wpf/README.md
+++ b/src/Meridian.Wpf/README.md
@@ -82,7 +82,12 @@ Convention-based view-model wiring is handled by `Services/ViewModelViewResolver
 that follow the `*Page` to `*ViewModel` naming convention can receive a DI-constructed DataContext
 without page-specific registration, while pages that set their own DataContext remain authoritative.
 Runtime desktop capability toggles are declared by feature modules and surfaced in Settings through
-the feature capability gate. The Security Master page projects the workstation trust
+the feature capability gate. Settings also owns role-based WPF layout presets for Portfolio Manager,
+Fund Accountant, Data Operator, and Evaluator Demo personas. The selected preset and basic desktop
+layout preferences--startup workspace, panel visibility, grid density, default filters, and shell
+density--persist in the external desktop shell preferences file under the resolved local app-data
+path, and the visible reset-to-default action restores the Portfolio Manager baseline without
+changing the root navigation taxonomy. The Security Master page projects the workstation trust
 snapshot's `scheduleBook` and `openLotReadModel` payloads into operator-visible schedule, factor,
 provenance, and open-lot review sections.
 The Settings page also surfaces governed Security Master asset profiles for WPF operators. It lists

--- a/src/Meridian.Wpf/ViewModels/SettingsViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/SettingsViewModel.cs
@@ -63,6 +63,13 @@ public sealed partial class SettingsViewModel : BindableBase
     private string _writeBufferSize = "64";
     private bool _isMetricsEnabled = true;
     private bool _isDebugLoggingEnabled;
+    private string _selectedLayoutPresetId = DesktopShellPreferences.DefaultLayoutPresetId;
+    private string _startupWorkspace = DesktopShellPreferences.DefaultStartupWorkspace;
+    private bool _isSummaryPanelVisible = true;
+    private bool _isInspectorPanelVisible = true;
+    private bool _isActivityPanelVisible = true;
+    private string _gridDensity = DesktopShellPreferences.DefaultGridDensity;
+    private string _defaultFilterSet = DesktopShellPreferences.DefaultFilterSet;
     private string _apiBaseUrl = "http://localhost:8080";
     private string _statusRefreshInterval = "2";
 
@@ -95,6 +102,9 @@ public sealed partial class SettingsViewModel : BindableBase
             ShellDensityMode.Standard,
             ShellDensityMode.Compact
         ];
+        DesktopLayoutPresets = _settingsConfigService.GetDesktopLayoutPresets();
+        StartupWorkspaceOptions = ["Trading", "Portfolio", "Accounting", "Reporting", "Strategy", "Data", "Settings"];
+        GridDensityOptions = ["Comfortable", "Dense"];
 
         if (capabilityGate is not null)
         {
@@ -156,6 +166,9 @@ public sealed partial class SettingsViewModel : BindableBase
     public ObservableCollection<SettingsOperationsCloseCalendarRow> OperationsCloseCalendarRows { get; }
     public ObservableCollection<FeatureCapabilityToggleViewModel> CapabilityToggles { get; }
     public IReadOnlyList<ShellDensityMode> ShellDensityModes { get; }
+    public IReadOnlyList<DesktopLayoutPreset> DesktopLayoutPresets { get; }
+    public IReadOnlyList<string> StartupWorkspaceOptions { get; }
+    public IReadOnlyList<string> GridDensityOptions { get; }
 
     // ── Bindable Properties ───────────────────────────────────────────────────
 
@@ -277,12 +290,12 @@ public sealed partial class SettingsViewModel : BindableBase
 
             RaisePropertyChanged(nameof(ShellDensityDescriptionText));
 
-            if (_loadingDesktopPreferences)
+            if (_loadingDesktopPreferences || _isPopulatingConfig)
             {
                 return;
             }
 
-            _settingsConfigService.SetShellDensityMode(value);
+            PersistDesktopPreferences();
             MarkDirty();
         }
     }
@@ -290,6 +303,70 @@ public sealed partial class SettingsViewModel : BindableBase
     public string ShellDensityDescriptionText => SelectedShellDensityMode == ShellDensityMode.Compact
         ? "Compact trims duplicate chrome and above-fold padding in shared workstation shells."
         : "Standard keeps the full shell summary and spacing for review-heavy sessions.";
+
+    public string SelectedLayoutPresetId
+    {
+        get => _selectedLayoutPresetId;
+        set
+        {
+            if (!SetProperty(ref _selectedLayoutPresetId, value))
+            {
+                return;
+            }
+
+            RaisePropertyChanged(nameof(SelectedLayoutPreset));
+            RaisePropertyChanged(nameof(SelectedLayoutPresetDescription));
+
+            if (_loadingDesktopPreferences)
+            {
+                return;
+            }
+
+            ApplySelectedDesktopLayoutPreset(value);
+            MarkDirty();
+        }
+    }
+
+    public DesktopLayoutPreset SelectedLayoutPreset
+        => _settingsConfigService.GetDesktopLayoutPreset(SelectedLayoutPresetId);
+
+    public string SelectedLayoutPresetDescription => SelectedLayoutPreset.Description;
+
+    public string StartupWorkspace
+    {
+        get => _startupWorkspace;
+        set => SetDesktopPreferenceProperty(ref _startupWorkspace, value);
+    }
+
+    public bool IsSummaryPanelVisible
+    {
+        get => _isSummaryPanelVisible;
+        set => SetDesktopPreferenceProperty(ref _isSummaryPanelVisible, value);
+    }
+
+    public bool IsInspectorPanelVisible
+    {
+        get => _isInspectorPanelVisible;
+        set => SetDesktopPreferenceProperty(ref _isInspectorPanelVisible, value);
+    }
+
+    public bool IsActivityPanelVisible
+    {
+        get => _isActivityPanelVisible;
+        set => SetDesktopPreferenceProperty(ref _isActivityPanelVisible, value);
+    }
+
+    public string GridDensity
+    {
+        get => _gridDensity;
+        set => SetDesktopPreferenceProperty(ref _gridDensity, value);
+    }
+
+    public string DefaultFilterSet
+    {
+        get => _defaultFilterSet;
+        set => SetDesktopPreferenceProperty(ref _defaultFilterSet, value);
+    }
 
     /// <summary>
     /// Whether Windows notifications are enabled.
@@ -401,7 +478,7 @@ public sealed partial class SettingsViewModel : BindableBase
         _loadingDesktopPreferences = true;
         try
         {
-            SelectedShellDensityMode = _settingsConfigService.GetShellDensityMode();
+            ApplyDesktopPreferences(_settingsConfigService.GetDesktopShellPreferences());
         }
         finally
         {
@@ -644,6 +721,8 @@ public sealed partial class SettingsViewModel : BindableBase
             defaultConfig.Derivatives = existingConfig.Derivatives;
 
             await _configService.WriteConfigAsync(defaultConfig);
+            _settingsConfigService.ResetDesktopShellPreferences();
+            ApplyDesktopPreferences(_settingsConfigService.GetDesktopShellPreferences());
             await LoadConfigAsync(false);
             _notificationService.ShowNotification("Reset Complete", "Settings have been reset to defaults.", NotificationType.Success);
         }
@@ -700,7 +779,6 @@ public sealed partial class SettingsViewModel : BindableBase
             ApiBaseUrl = config.IBClientPortal?.BaseUrl ?? "http://localhost:8080";
             StatusRefreshInterval = settings.StatusRefreshIntervalSeconds.ToString();
             IsNotificationsEnabled = settings.NotificationsEnabled;
-            SelectedShellDensityMode = settings.CompactMode ? ShellDensityMode.Compact : ShellDensityMode.Standard;
             ThemeIndex = string.Equals(settings.Theme, "Dark", StringComparison.OrdinalIgnoreCase) ? 2 : string.Equals(settings.Theme, "Light", StringComparison.OrdinalIgnoreCase) ? 1 : 0;
             AccentColorIndex = 0;
             MaxConcurrentDownloads = settings.MaxReconnectAttempts.ToString();
@@ -768,6 +846,72 @@ public sealed partial class SettingsViewModel : BindableBase
         return result;
     }
 
+    private void ApplySelectedDesktopLayoutPreset(string? presetId)
+    {
+        var preset = _settingsConfigService.GetDesktopLayoutPreset(presetId);
+        var preferences = new DesktopShellPreferences(
+            preset.ShellDensityMode,
+            preset.Id,
+            preset.StartupWorkspace,
+            preset.IsSummaryPanelVisible,
+            preset.IsInspectorPanelVisible,
+            preset.IsActivityPanelVisible,
+            preset.GridDensity,
+            preset.DefaultFilterSet);
+        _settingsConfigService.SetDesktopShellPreferences(preferences);
+        ApplyDesktopPreferences(preferences);
+    }
+
+    private void ApplyDesktopPreferences(DesktopShellPreferences preferences)
+    {
+        _loadingDesktopPreferences = true;
+        try
+        {
+            SelectedShellDensityMode = preferences.ShellDensityMode;
+            SelectedLayoutPresetId = preferences.SelectedLayoutPresetId;
+            StartupWorkspace = preferences.StartupWorkspace;
+            IsSummaryPanelVisible = preferences.IsSummaryPanelVisible;
+            IsInspectorPanelVisible = preferences.IsInspectorPanelVisible;
+            IsActivityPanelVisible = preferences.IsActivityPanelVisible;
+            GridDensity = preferences.GridDensity;
+            DefaultFilterSet = preferences.DefaultFilterSet;
+        }
+        finally
+        {
+            _loadingDesktopPreferences = false;
+        }
+    }
+
+    private void PersistDesktopPreferences()
+    {
+        if (_loadingDesktopPreferences || _isPopulatingConfig)
+        {
+            return;
+        }
+
+        _settingsConfigService.SetDesktopShellPreferences(new DesktopShellPreferences(
+            SelectedShellDensityMode,
+            SelectedLayoutPresetId,
+            StartupWorkspace,
+            IsSummaryPanelVisible,
+            IsInspectorPanelVisible,
+            IsActivityPanelVisible,
+            GridDensity,
+            DefaultFilterSet));
+    }
+
+    private bool SetDesktopPreferenceProperty<T>(ref T field, T value, string? propertyName = null)
+    {
+        if (!SetProperty(ref field, value, propertyName))
+        {
+            return false;
+        }
+
+        PersistDesktopPreferences();
+        MarkDirty();
+        return true;
+    }
+
     private bool CanSaveConfig() => HasUnsavedChanges && IsConfigValid;
     private void MarkDirty()
     {
@@ -792,7 +936,8 @@ public sealed partial class SettingsViewModel : BindableBase
                 ? 1
                 : 0;
         AccentColorIndex = 0;
-        SelectedShellDensityMode = defaultConfig.Settings?.CompactMode == true ? ShellDensityMode.Compact : ShellDensityMode.Standard;
+        _settingsConfigService.ResetDesktopShellPreferences();
+        ApplyDesktopPreferences(_settingsConfigService.GetDesktopShellPreferences());
         IsNotificationsEnabled = defaultConfig.Settings?.NotificationsEnabled ?? true;
         MaxConcurrentDownloads = "4";
         WriteBufferSize = "64";

--- a/src/Meridian.Wpf/Views/SettingsPage.xaml
+++ b/src/Meridian.Wpf/Views/SettingsPage.xaml
@@ -848,6 +848,85 @@
                     </StackPanel>
                 </Border>
 
+                <!-- Role layout presets -->
+                <Border Style="{StaticResource CardStyle}" Margin="0,0,0,24">
+                    <StackPanel>
+                        <TextBlock Text="Role Layout Presets" Style="{StaticResource CardHeaderStyle}" Margin="0,0,0,8" />
+                        <TextBlock Text="Choose a WPF workstation preset for common operating personas. Top-level navigation remains Trading, Portfolio, Accounting, Reporting, Strategy, Data, and Settings."
+                                   Style="{StaticResource CardDescriptionStyle}"
+                                   TextWrapping="Wrap"
+                                   Margin="0,0,0,16" />
+
+                        <StackPanel Margin="0,0,0,12">
+                            <TextBlock Text="Preset" Style="{StaticResource FormLabelStyle}" Margin="0,0,0,4" />
+                            <ComboBox Style="{StaticResource FormComboBoxStyle}"
+                                      ItemsSource="{Binding DesktopLayoutPresets}"
+                                      SelectedValuePath="Id"
+                                      SelectedValue="{Binding SelectedLayoutPresetId, Mode=TwoWay}"
+                                      AutomationProperties.AutomationId="SettingsRoleLayoutPresetCombo">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding Name}" FontWeight="SemiBold" />
+                                            <TextBlock Text="{Binding Description}"
+                                                       Foreground="{StaticResource ConsoleTextMutedBrush}"
+                                                       FontSize="11"
+                                                       TextWrapping="Wrap" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                            <TextBlock Text="{Binding SelectedLayoutPresetDescription}"
+                                       Style="{StaticResource CardDescriptionStyle}"
+                                       TextWrapping="Wrap"
+                                       Margin="0,8,0,0" />
+                        </StackPanel>
+
+                        <Grid Margin="0,0,0,12">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <StackPanel Grid.Column="0" Margin="0,0,12,0">
+                                <TextBlock Text="Startup Workspace" Style="{StaticResource FormLabelStyle}" Margin="0,0,0,4" />
+                                <ComboBox Style="{StaticResource FormComboBoxStyle}"
+                                          ItemsSource="{Binding StartupWorkspaceOptions}"
+                                          SelectedItem="{Binding StartupWorkspace, Mode=TwoWay}"
+                                          AutomationProperties.AutomationId="SettingsStartupWorkspaceCombo" />
+                            </StackPanel>
+                            <StackPanel Grid.Column="1">
+                                <TextBlock Text="Grid Density" Style="{StaticResource FormLabelStyle}" Margin="0,0,0,4" />
+                                <ComboBox Style="{StaticResource FormComboBoxStyle}"
+                                          ItemsSource="{Binding GridDensityOptions}"
+                                          SelectedItem="{Binding GridDensity, Mode=TwoWay}"
+                                          AutomationProperties.AutomationId="SettingsGridDensityCombo" />
+                            </StackPanel>
+                        </Grid>
+
+                        <StackPanel Margin="0,0,0,12">
+                            <TextBlock Text="Default Filters" Style="{StaticResource FormLabelStyle}" Margin="0,0,0,4" />
+                            <TextBox Style="{StaticResource FormTextBoxStyle}"
+                                     Text="{Binding DefaultFilterSet, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                     AutomationProperties.AutomationId="SettingsDefaultFiltersTextBox" />
+                        </StackPanel>
+
+                        <WrapPanel Margin="0,4,0,0">
+                            <CheckBox Content="Summary panel"
+                                      IsChecked="{Binding IsSummaryPanelVisible, Mode=TwoWay}"
+                                      Margin="0,0,16,8"
+                                      AutomationProperties.AutomationId="SettingsSummaryPanelToggle" />
+                            <CheckBox Content="Inspector panel"
+                                      IsChecked="{Binding IsInspectorPanelVisible, Mode=TwoWay}"
+                                      Margin="0,0,16,8"
+                                      AutomationProperties.AutomationId="SettingsInspectorPanelToggle" />
+                            <CheckBox Content="Activity panel"
+                                      IsChecked="{Binding IsActivityPanelVisible, Mode=TwoWay}"
+                                      Margin="0,0,16,8"
+                                      AutomationProperties.AutomationId="SettingsActivityPanelToggle" />
+                        </WrapPanel>
+                    </StackPanel>
+                </Border>
+
                 <!-- Appearance -->
                 <Border Style="{StaticResource CardStyle}" Margin="0,0,0,24">
                     <StackPanel>

--- a/tests/Meridian.Wpf.Tests/Services/DesktopLayoutPreferencesTests.cs
+++ b/tests/Meridian.Wpf.Tests/Services/DesktopLayoutPreferencesTests.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using Meridian.Ui.Services.Services;
+
+namespace Meridian.Wpf.Tests.Services;
+
+public sealed class DesktopLayoutPreferencesTests : IDisposable
+{
+    private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), "meridian-layout-prefs-" + Guid.NewGuid().ToString("N"));
+    private readonly string _preferencesPath;
+
+    public DesktopLayoutPreferencesTests()
+    {
+        Directory.CreateDirectory(_tempRoot);
+        _preferencesPath = Path.Combine(_tempRoot, "desktop-shell-preferences.json");
+        SettingsConfigurationService.SetDesktopPreferencesFilePathOverrideForTests(_preferencesPath);
+    }
+
+    [Fact]
+    public void BuiltInLayoutPresets_ShouldCoverCommonPersonasWithoutChangingRootNavigation()
+    {
+        var presets = SettingsConfigurationService.Instance.GetDesktopLayoutPresets();
+
+        presets.Select(preset => preset.Name).Should().BeSupersetOf(new[]
+        {
+            "Portfolio Manager",
+            "Fund Accountant",
+            "Data Operator",
+            "Evaluator Demo"
+        });
+        presets.Select(preset => preset.StartupWorkspace).Should().OnlyContain(workspace =>
+            workspace is "Trading" or "Portfolio" or "Accounting" or "Reporting" or "Strategy" or "Data" or "Settings");
+    }
+
+    [Fact]
+    public void ApplyDesktopLayoutPreset_ShouldPersistSelectedPresetAndBasicPreferences()
+    {
+        var service = SettingsConfigurationService.Instance;
+
+        service.ApplyDesktopLayoutPreset("fund-accountant");
+        SettingsConfigurationService.SetDesktopPreferencesFilePathOverrideForTests(_preferencesPath);
+
+        var reloaded = SettingsConfigurationService.Instance.GetDesktopShellPreferences();
+
+        reloaded.SelectedLayoutPresetId.Should().Be("fund-accountant");
+        reloaded.StartupWorkspace.Should().Be("Accounting");
+        reloaded.ShellDensityMode.Should().Be(ShellDensityMode.Compact);
+        reloaded.GridDensity.Should().Be("Dense");
+        reloaded.DefaultFilterSet.Should().Be("Close blockers");
+        reloaded.IsSummaryPanelVisible.Should().BeTrue();
+        reloaded.IsInspectorPanelVisible.Should().BeTrue();
+        reloaded.IsActivityPanelVisible.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SetDesktopShellPreferences_ShouldPersistManualLayoutOverrides()
+    {
+        var service = SettingsConfigurationService.Instance;
+        var preferences = new DesktopShellPreferences(
+            ShellDensityMode.Standard,
+            "custom-operator",
+            "Data",
+            IsSummaryPanelVisible: false,
+            IsInspectorPanelVisible: true,
+            IsActivityPanelVisible: false,
+            "Dense",
+            "Provider warnings");
+
+        service.SetDesktopShellPreferences(preferences);
+        var json = File.ReadAllText(_preferencesPath);
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        root.GetProperty("selectedLayoutPresetId").GetString().Should().Be("custom-operator");
+        root.GetProperty("startupWorkspace").GetString().Should().Be("Data");
+        root.GetProperty("gridDensity").GetString().Should().Be("Dense");
+        root.GetProperty("defaultFilterSet").GetString().Should().Be("Provider warnings");
+        root.GetProperty("isSummaryPanelVisible").GetBoolean().Should().BeFalse();
+        root.GetProperty("isInspectorPanelVisible").GetBoolean().Should().BeTrue();
+        root.GetProperty("isActivityPanelVisible").GetBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ResetDesktopShellPreferences_ShouldRestorePortfolioManagerDefaults()
+    {
+        var service = SettingsConfigurationService.Instance;
+        service.ApplyDesktopLayoutPreset("data-operator");
+
+        service.ResetDesktopShellPreferences();
+        var preferences = service.GetDesktopShellPreferences();
+
+        preferences.SelectedLayoutPresetId.Should().Be("portfolio-manager");
+        preferences.StartupWorkspace.Should().Be("Portfolio");
+        preferences.ShellDensityMode.Should().Be(ShellDensityMode.Standard);
+        preferences.GridDensity.Should().Be("Comfortable");
+        preferences.DefaultFilterSet.Should().Be("Open work");
+    }
+
+    [Fact]
+    public void SettingsPage_ShouldExposeRolePresetControlsAndResetAction()
+    {
+        var xaml = File.ReadAllText(Path.Combine("src", "Meridian.Wpf", "Views", "SettingsPage.xaml"));
+
+        xaml.Should().Contain("Role Layout Presets");
+        xaml.Should().Contain("SettingsRoleLayoutPresetCombo");
+        xaml.Should().Contain("SettingsStartupWorkspaceCombo");
+        xaml.Should().Contain("SettingsGridDensityCombo");
+        xaml.Should().Contain("Reset to Defaults");
+        xaml.Should().Contain("Trading, Portfolio, Accounting, Reporting, Strategy, Data, and Settings");
+    }
+
+    public void Dispose()
+    {
+        SettingsConfigurationService.SetDesktopPreferencesFilePathOverrideForTests(null);
+        if (Directory.Exists(_tempRoot))
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide common, role-focused WPF workstation layouts for common personas (Portfolio Manager, Fund Accountant, Data Operator, Evaluator Demo) so operators can pick a sensible workspace baseline quickly.
- Persist basic layout and presentation preferences (preset id, startup workspace, panel visibility, grid density, default filters, shell density) so the desktop experience is stable across sessions.
- Surface a visible reset-to-default action in Settings that restores the Portfolio Manager baseline while keeping the top-level navigation unchanged.

### Description

- Added a persisted desktop shell model `DesktopShellPreferences` and a `DesktopLayoutPreset` record to carry preset metadata and defaults. (see `src/Meridian.Ui.Services/Services/DesktopShellPreferences.cs`).
- Introduced built-in role presets and new APIs on `SettingsConfigurationService` to list, apply, persist, and reset layout presets (`GetDesktopLayoutPresets`, `GetDesktopLayoutPreset`, `ApplyDesktopLayoutPreset`, `SetDesktopShellPreferences`, `ResetDesktopShellPreferences`). (see `src/Meridian.Ui.Services/Services/SettingsConfigurationService.cs`).
- Wired `SettingsViewModel` to expose preset selection, startup workspace, panel visibility, grid density, default filter set, and to persist/load preferences via the settings service; added `ApplyDesktopPreferences`, `PersistDesktopPreferences`, and `ApplySelectedDesktopLayoutPreset` helper flows. (see `src/Meridian.Wpf/ViewModels/SettingsViewModel.cs`).
- Added a Settings UI card titled "Role Layout Presets" with controls bound to the above view-model properties and preserved the canonical top-level navigation labels. (see `src/Meridian.Wpf/Views/SettingsPage.xaml`).
- Updated WPF and Ui.Services READMEs to document the new preference behavior and added focused unit tests covering presets, persistence, reset, and Settings XAML presence. (see `tests/Meridian.Wpf.Tests/Services/DesktopLayoutPreferencesTests.cs`).

### Testing

- Ran `git diff --check` which reported no whitespace or check failures (passed).
- Added focused unit tests `DesktopLayoutPreferencesTests` that validate built-in presets, persistence, reset behavior, and presence of Settings XAML controls, but `dotnet test` could not be executed in this environment because `dotnet` is not available so the tests were not run here.
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary` which reported repository-wide documentation hash drift unrelated to this change; this is an existing repo validation output and not caused by these functional changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3081c6458c83209bdcc9c6bd0c12c0)