### PR TITLE
Shared WPF EmptyStatePanel: severity badge and primary/secondary actions

### DIFF
--- a/src/Meridian.Wpf/Controls/EmptyStatePanel.xaml
+++ b/src/Meridian.Wpf/Controls/EmptyStatePanel.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:Meridian.Wpf.Controls"
              x:Name="Root"
              mc:Ignorable="d"
              MinHeight="150"
@@ -37,32 +38,71 @@
                    Text="{Binding Title}"
                    Style="{StaticResource EmptyStateTitleStyle}"
                    AutomationProperties.AutomationId="{Binding TitleAutomationId}" />
+        <local:ToneBadge x:Name="SeverityBadge"
+                         Text="{Binding Severity}"
+                         Tone="{Binding SeverityTone}"
+                         Margin="0,8,0,0"
+                         HorizontalAlignment="Center"
+                         BadgeAutomationId="{Binding SeverityAutomationId}">
+            <local:ToneBadge.Style>
+                <Style TargetType="{x:Type local:ToneBadge}">
+                    <Setter Property="Visibility" Value="Visible" />
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding Severity}" Value="{x:Null}">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Severity}" Value="">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </local:ToneBadge.Style>
+        </local:ToneBadge>
         <TextBlock x:Name="DescriptionText"
                    Text="{Binding Description}"
                    Style="{StaticResource EmptyStateDescriptionStyle}"
                    Margin="0,8,0,0"
                    AutomationProperties.AutomationId="{Binding DescriptionAutomationId}" />
 
-        <Button x:Name="ActionButton"
-                Content="{Binding ActionText}"
-                Command="{Binding ActionCommand}"
-                Margin="0,16,0,0"
-                HorizontalAlignment="Center"
-                AutomationProperties.AutomationId="{Binding ActionButtonAutomationId}"
-                AutomationProperties.Name="{Binding ActionText}">
-            <Button.Style>
-                <Style TargetType="Button" BasedOn="{StaticResource PrimaryButtonStyle}">
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding ActionCommand}" Value="{x:Null}">
-                            <Setter Property="Visibility" Value="Collapsed" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding ActionText}" Value="">
-                            <Setter Property="Visibility" Value="Collapsed" />
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </Button.Style>
-        </Button>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,16,0,0">
+            <Button x:Name="ActionButton"
+                    Content="{Binding ActionText}"
+                    Command="{Binding ActionCommand}"
+                    AutomationProperties.AutomationId="{Binding ActionButtonAutomationId}"
+                    AutomationProperties.Name="{Binding ActionText}">
+                <Button.Style>
+                    <Style TargetType="Button" BasedOn="{StaticResource PrimaryButtonStyle}">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding ActionCommand}" Value="{x:Null}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding ActionText}" Value="">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Style>
+            </Button>
+            <Button x:Name="SecondaryActionButton"
+                    Content="{Binding SecondaryActionText}"
+                    Command="{Binding SecondaryActionCommand}"
+                    Margin="8,0,0,0"
+                    AutomationProperties.AutomationId="{Binding SecondaryActionButtonAutomationId}"
+                    AutomationProperties.Name="{Binding SecondaryActionText}">
+                <Button.Style>
+                    <Style TargetType="Button" BasedOn="{StaticResource SecondaryButtonStyle}">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding SecondaryActionCommand}" Value="{x:Null}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding SecondaryActionText}" Value="">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Style>
+            </Button>
+        </StackPanel>
     </StackPanel>
     </Border>
 </UserControl>

--- a/src/Meridian.Wpf/Controls/EmptyStatePanel.xaml.cs
+++ b/src/Meridian.Wpf/Controls/EmptyStatePanel.xaml.cs
@@ -2,8 +2,56 @@ using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Controls;
 using System.Windows.Input;
+using Meridian.Wpf.Models;
 
 namespace Meridian.Wpf.Controls;
+
+public static class EmptyStateMessages
+{
+    public static readonly EmptyStateMessage NoProviderConfigured = new(
+        "No provider configured",
+        "Connect a market data provider before running imports, live views, or backfills.",
+        "Setup",
+        WorkspaceTone.Warning);
+
+    public static readonly EmptyStateMessage NoRecordsImported = new(
+        "No records imported",
+        "Import records or load fixture data before reviewing this grid.",
+        "Empty",
+        WorkspaceTone.Neutral);
+
+    public static readonly EmptyStateMessage NoSelectedAccountOrPortfolio = new(
+        "No account or portfolio selected",
+        "Select an account or portfolio to show retained positions, balances, and workflow actions.",
+        "Selection needed",
+        WorkspaceTone.Warning);
+
+    public static readonly EmptyStateMessage StaleData = new(
+        "Data may be stale",
+        "Refresh this view before making operational decisions.",
+        "Stale",
+        WorkspaceTone.Warning);
+
+    public static readonly EmptyStateMessage NoReconciliationRun = new(
+        "No reconciliation run yet",
+        "Run reconciliation to compare source evidence with retained accounting records.",
+        "Action needed",
+        WorkspaceTone.Warning);
+
+    public static readonly EmptyStateMessage NoReportsGenerated = new(
+        "No reports generated",
+        "Generate a governed report pack before reviewing report outputs or distribution evidence.",
+        "Empty",
+        WorkspaceTone.Neutral);
+
+    public static readonly EmptyStateMessage FixtureDataAvailable = new(
+        "Fixture data is available",
+        "Load demo data to explore the workflow without connecting production providers.",
+        "Demo available",
+        WorkspaceTone.Info);
+}
+
+public sealed record EmptyStateMessage(string Title, string Description, string Severity = "", string SeverityTone = WorkspaceTone.Neutral);
 
 public partial class EmptyStatePanel : UserControl
 {
@@ -26,6 +74,18 @@ public partial class EmptyStatePanel : UserControl
     public static readonly DependencyProperty ActionCommandProperty =
         DependencyProperty.Register(nameof(ActionCommand), typeof(ICommand), typeof(EmptyStatePanel), new PropertyMetadata(null));
 
+    public static readonly DependencyProperty SecondaryActionTextProperty =
+        DependencyProperty.Register(nameof(SecondaryActionText), typeof(string), typeof(EmptyStatePanel), new PropertyMetadata(string.Empty));
+
+    public static readonly DependencyProperty SecondaryActionCommandProperty =
+        DependencyProperty.Register(nameof(SecondaryActionCommand), typeof(ICommand), typeof(EmptyStatePanel), new PropertyMetadata(null));
+
+    public static readonly DependencyProperty SeverityProperty =
+        DependencyProperty.Register(nameof(Severity), typeof(string), typeof(EmptyStatePanel), new PropertyMetadata(string.Empty));
+
+    public static readonly DependencyProperty SeverityToneProperty =
+        DependencyProperty.Register(nameof(SeverityTone), typeof(string), typeof(EmptyStatePanel), new PropertyMetadata(WorkspaceTone.Neutral));
+
     public static readonly DependencyProperty PanelAutomationIdProperty =
         DependencyProperty.Register(
             nameof(PanelAutomationId),
@@ -44,6 +104,12 @@ public partial class EmptyStatePanel : UserControl
 
     public static readonly DependencyProperty ActionButtonAutomationIdProperty =
         DependencyProperty.Register(nameof(ActionButtonAutomationId), typeof(string), typeof(EmptyStatePanel), new PropertyMetadata("EmptyStateAction"));
+
+    public static readonly DependencyProperty SecondaryActionButtonAutomationIdProperty =
+        DependencyProperty.Register(nameof(SecondaryActionButtonAutomationId), typeof(string), typeof(EmptyStatePanel), new PropertyMetadata("EmptyStateSecondaryAction"));
+
+    public static readonly DependencyProperty SeverityAutomationIdProperty =
+        DependencyProperty.Register(nameof(SeverityAutomationId), typeof(string), typeof(EmptyStatePanel), new PropertyMetadata("EmptyStateSeverity"));
 
     public EmptyStatePanel()
     {
@@ -82,6 +148,30 @@ public partial class EmptyStatePanel : UserControl
         set => SetValue(ActionCommandProperty, value);
     }
 
+    public string SecondaryActionText
+    {
+        get => (string)GetValue(SecondaryActionTextProperty);
+        set => SetValue(SecondaryActionTextProperty, value);
+    }
+
+    public ICommand? SecondaryActionCommand
+    {
+        get => (ICommand?)GetValue(SecondaryActionCommandProperty);
+        set => SetValue(SecondaryActionCommandProperty, value);
+    }
+
+    public string Severity
+    {
+        get => (string)GetValue(SeverityProperty);
+        set => SetValue(SeverityProperty, value);
+    }
+
+    public string SeverityTone
+    {
+        get => (string)GetValue(SeverityToneProperty);
+        set => SetValue(SeverityToneProperty, value);
+    }
+
     public string PanelAutomationId
     {
         get => (string)GetValue(PanelAutomationIdProperty);
@@ -110,6 +200,18 @@ public partial class EmptyStatePanel : UserControl
     {
         get => (string)GetValue(ActionButtonAutomationIdProperty);
         set => SetValue(ActionButtonAutomationIdProperty, value);
+    }
+
+    public string SecondaryActionButtonAutomationId
+    {
+        get => (string)GetValue(SecondaryActionButtonAutomationIdProperty);
+        set => SetValue(SecondaryActionButtonAutomationIdProperty, value);
+    }
+
+    public string SeverityAutomationId
+    {
+        get => (string)GetValue(SeverityAutomationIdProperty);
+        set => SetValue(SeverityAutomationIdProperty, value);
     }
 
     private static void OnPanelAutomationIdChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/src/Meridian.Wpf/README.md
+++ b/src/Meridian.Wpf/README.md
@@ -480,6 +480,7 @@ Keep WPF views declarative and move loading, disabled, preview, empty-state, and
 behavior into view models. Do not duplicate product logic that belongs in shared UI services.
 When telemetry, latency, order-flow, or preview data is unavailable, show an explicit unmeasured or
 unavailable state rather than seeded sample numbers or plausible-looking derived metrics.
+Use `Controls/EmptyStatePanel` for reusable missing-data states; it supports title, explanation, severity, and up to two actions for provider setup, import, selection, freshness, reconciliation, reporting, and fixture-data recovery paths.
 
 ## Related docs
 

--- a/src/Meridian.Wpf/Views/AccountPortfolioPage.xaml
+++ b/src/Meridian.Wpf/Views/AccountPortfolioPage.xaml
@@ -2,6 +2,7 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:workstation="clr-namespace:Meridian.Wpf.Workstation.Controls"
+      xmlns:controls="clr-namespace:Meridian.Wpf.Controls"
       Background="{DynamicResource ShellWindowBackgroundBrush}"
       Loaded="OnPageLoaded"
       Unloaded="OnPageUnloaded"
@@ -151,41 +152,19 @@
                                                           InspectorAutomationId="AccountPortfolioSelectionInspector"
                                                           ControlAutomationId="AccountPortfolioWorkbench">
                 <workstation:WorkstationTableInspectorControl.EmptyContent>
-                    <Border MinHeight="300"
-                            Padding="28"
-                            Background="{StaticResource ConsoleBackgroundLightBrush}"
-                            BorderBrush="{StaticResource ConsoleBorderBrush}"
-                            BorderThickness="1"
-                            CornerRadius="8"
-                            Visibility="{Binding IsPositionsEmptyStateVisible, Converter={StaticResource BoolToVisibilityConverter}}"
-                            AutomationProperties.AutomationId="AccountPositionsEmptyStatePanel"
-                            AutomationProperties.Name="{Binding PositionsEmptyStateTitle}">
-                        <StackPanel HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    MaxWidth="460">
-                            <TextBlock Text="{Binding PositionsEmptyStateTitle}"
-                                       FontSize="16"
-                                       FontWeight="SemiBold"
-                                       TextAlignment="Center"
-                                       TextWrapping="Wrap"
-                                       Foreground="{StaticResource ConsoleTextPrimaryBrush}"
-                                       AutomationProperties.AutomationId="AccountPositionsEmptyStateTitle" />
-                            <TextBlock Margin="0,8,0,16"
-                                       Text="{Binding PositionsEmptyStateDetail}"
-                                       TextWrapping="Wrap"
-                                       TextAlignment="Center"
-                                       Foreground="{StaticResource ConsoleTextMutedBrush}"
-                                       AutomationProperties.AutomationId="AccountPositionsEmptyStateDetail" />
-                            <Button Content="Refresh Account"
-                                    Command="{Binding RefreshCommand}"
-                                    IsEnabled="{Binding CanRefreshAccount}"
-                                    ToolTip="{Binding RefreshTooltip}"
-                                    ToolTipService.ShowOnDisabled="True"
-                                    HorizontalAlignment="Center"
-                                    MinWidth="132"
-                                    AutomationProperties.AutomationId="AccountPositionsEmptyStateRefreshButton" />
-                        </StackPanel>
-                    </Border>
+                    <controls:EmptyStatePanel MinHeight="300"
+                                              Visibility="{Binding IsPositionsEmptyStateVisible, Converter={StaticResource BoolToVisibilityConverter}}"
+                                              Title="{Binding PositionsEmptyStateTitle}"
+                                              Description="{Binding PositionsEmptyStateDetail}"
+                                              Severity="Selection needed"
+                                              SeverityTone="Warning"
+                                              IconGlyph="&#xE946;"
+                                              ActionText="Refresh Account"
+                                              ActionCommand="{Binding RefreshCommand}"
+                                              PanelAutomationId="AccountPositionsEmptyStatePanel"
+                                              TitleAutomationId="AccountPositionsEmptyStateTitle"
+                                              DescriptionAutomationId="AccountPositionsEmptyStateDetail"
+                                              ActionButtonAutomationId="AccountPositionsEmptyStateRefreshButton" />
                 </workstation:WorkstationTableInspectorControl.EmptyContent>
 
                 <workstation:WorkstationTableInspectorControl.InspectorContent>

--- a/src/Meridian.Wpf/Views/AggregatePortfolioPage.xaml
+++ b/src/Meridian.Wpf/Views/AggregatePortfolioPage.xaml
@@ -2,6 +2,7 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:workstation="clr-namespace:Meridian.Wpf.Workstation.Controls"
+      xmlns:controls="clr-namespace:Meridian.Wpf.Controls"
       Background="{DynamicResource ShellWindowBackgroundBrush}"
       Loaded="OnPageLoaded"
       Unloaded="OnPageUnloaded"
@@ -157,40 +158,19 @@
                 </workstation:WorkstationTableInspectorControl.TableHeaderContent>
 
                 <workstation:WorkstationTableInspectorControl.EmptyContent>
-                    <Border MinHeight="300"
-                            Padding="28"
-                            Background="{StaticResource ConsoleBackgroundLightBrush}"
-                            BorderBrush="{StaticResource ConsoleBorderBrush}"
-                            BorderThickness="1"
-                            CornerRadius="8"
-                            Visibility="{Binding IsPositionsEmptyStateVisible, Converter={StaticResource BoolToVisibilityConverter}}"
-                            AutomationProperties.AutomationId="AggregatePositionsEmptyStatePanel"
-                            AutomationProperties.Name="{Binding PositionsEmptyStateTitle}">
-                        <StackPanel HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    MaxWidth="480">
-                            <TextBlock Text="{Binding PositionsEmptyStateTitle}"
-                                       FontSize="16"
-                                       FontWeight="SemiBold"
-                                       TextAlignment="Center"
-                                       TextWrapping="Wrap"
-                                       Foreground="{StaticResource ConsoleTextPrimaryBrush}"
-                                       AutomationProperties.AutomationId="AggregatePositionsEmptyStateTitle" />
-                            <TextBlock Margin="0,8,0,16"
-                                       Text="{Binding PositionsEmptyStateDetail}"
-                                       TextWrapping="Wrap"
-                                       TextAlignment="Center"
-                                       Foreground="{StaticResource ConsoleTextMutedBrush}"
-                                       AutomationProperties.AutomationId="AggregatePositionsEmptyStateDetail" />
-                            <Button Content="Refresh Portfolio"
-                                    Command="{Binding RefreshCommand}"
-                                    ToolTip="{Binding RefreshTooltip}"
-                                    ToolTipService.ShowOnDisabled="True"
-                                    HorizontalAlignment="Center"
-                                    MinWidth="140"
-                                    AutomationProperties.AutomationId="AggregatePositionsEmptyStateRefreshButton" />
-                        </StackPanel>
-                    </Border>
+                    <controls:EmptyStatePanel MinHeight="300"
+                                              Visibility="{Binding IsPositionsEmptyStateVisible, Converter={StaticResource BoolToVisibilityConverter}}"
+                                              Title="{Binding PositionsEmptyStateTitle}"
+                                              Description="{Binding PositionsEmptyStateDetail}"
+                                              Severity="Selection needed"
+                                              SeverityTone="Warning"
+                                              IconGlyph="&#xE946;"
+                                              ActionText="Refresh Portfolio"
+                                              ActionCommand="{Binding RefreshCommand}"
+                                              PanelAutomationId="AggregatePositionsEmptyStatePanel"
+                                              TitleAutomationId="AggregatePositionsEmptyStateTitle"
+                                              DescriptionAutomationId="AggregatePositionsEmptyStateDetail"
+                                              ActionButtonAutomationId="AggregatePositionsEmptyStateRefreshButton" />
                 </workstation:WorkstationTableInspectorControl.EmptyContent>
 
                 <workstation:WorkstationTableInspectorControl.InspectorContent>

--- a/src/Meridian.Wpf/Views/WorkflowLibraryPage.xaml
+++ b/src/Meridian.Wpf/Views/WorkflowLibraryPage.xaml
@@ -1,6 +1,7 @@
 <Page x:Class="Meridian.Wpf.Views.WorkflowLibraryPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:controls="clr-namespace:Meridian.Wpf.Controls"
       Background="{DynamicResource ShellWindowBackgroundBrush}"
       AutomationProperties.Name="Workflow library">
 
@@ -72,45 +73,22 @@
                 </Grid>
             </Border>
 
-            <Border Visibility="{Binding HasWorkflows, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=Invert}"
-                    Style="{StaticResource CardStyle}"
-                    Padding="28"
-                    Margin="0,0,0,20"
-                    AutomationProperties.AutomationId="WorkflowLibraryEmptyStatePanel"
-                    AutomationProperties.Name="{Binding EmptyStateTitle}">
-                <StackPanel HorizontalAlignment="Center">
-                    <TextBlock Text="&#xE8FD;"
-                               FontFamily="{StaticResource SymbolThemeFontFamily}"
-                               FontSize="36"
-                               Foreground="{StaticResource ConsoleTextMutedBrush}"
-                               HorizontalAlignment="Center"
-                               Margin="0,0,0,12" />
-                    <TextBlock Text="{Binding EmptyStateTitle}"
-                               Style="{StaticResource EmptyStateTitleStyle}"
-                               HorizontalAlignment="Center"
-                               AutomationProperties.AutomationId="WorkflowLibraryEmptyStateTitle" />
-                    <TextBlock Text="{Binding EmptyStateDetail}"
-                               Style="{StaticResource EmptyStateDescriptionStyle}"
-                               TextWrapping="Wrap"
-                               TextAlignment="Center"
-                               MaxWidth="520"
-                               HorizontalAlignment="Center"
-                               Margin="0,6,0,16"
-                               AutomationProperties.AutomationId="WorkflowLibraryEmptyStateDetail" />
-                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                        <Button Content="{Binding EmptyStateActionText}"
-                                Command="{Binding ClearSearchCommand}"
-                                Style="{StaticResource SecondaryButtonStyle}"
-                                Visibility="{Binding HasActiveSearch, Converter={StaticResource BoolToVisibilityConverter}}"
-                                AutomationProperties.AutomationId="WorkflowLibraryEmptyStateClearSearchButton" />
-                        <Button Content="Refresh library"
-                                Command="{Binding RefreshCommand}"
-                                Style="{StaticResource GhostButtonStyle}"
-                                Margin="8,0,0,0"
-                                AutomationProperties.AutomationId="WorkflowLibraryEmptyStateRefreshButton" />
-                    </StackPanel>
-                </StackPanel>
-            </Border>
+            <controls:EmptyStatePanel Visibility="{Binding HasWorkflows, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=Invert}"
+                                      Margin="0,0,0,20"
+                                      Title="{Binding EmptyStateTitle}"
+                                      Description="{Binding EmptyStateDetail}"
+                                      Severity="Fixture/demo data available"
+                                      SeverityTone="Info"
+                                      IconGlyph="&#xE8FD;"
+                                      ActionText="Refresh library"
+                                      ActionCommand="{Binding RefreshCommand}"
+                                      SecondaryActionText="{Binding EmptyStateActionText}"
+                                      SecondaryActionCommand="{Binding ClearSearchCommand}"
+                                      PanelAutomationId="WorkflowLibraryEmptyStatePanel"
+                                      TitleAutomationId="WorkflowLibraryEmptyStateTitle"
+                                      DescriptionAutomationId="WorkflowLibraryEmptyStateDetail"
+                                      ActionButtonAutomationId="WorkflowLibraryEmptyStateRefreshButton"
+                                      SecondaryActionButtonAutomationId="WorkflowLibraryEmptyStateClearSearchButton" />
 
             <ItemsControl ItemsSource="{Binding Workflows}">
                 <ItemsControl.ItemTemplate>

--- a/tests/Meridian.Wpf.Tests/Views/ApplicationPrimitiveControlsTests.cs
+++ b/tests/Meridian.Wpf.Tests/Views/ApplicationPrimitiveControlsTests.cs
@@ -25,14 +25,20 @@ public sealed class ApplicationPrimitiveControlsTests
             {
                 Title = "No approvals queued",
                 Description = "The current fund has no retained approval work.",
+                Severity = "No reconciliation run",
+                SeverityTone = WorkspaceTone.Warning,
                 IconGlyph = "\uE946",
                 ActionText = "Refresh approvals",
                 ActionCommand = emptyAction,
+                SecondaryActionText = "Open setup",
+                SecondaryActionCommand = queueAction,
                 PanelAutomationId = "EmptyStateTest",
                 IconAutomationId = "EmptyStateIconTest",
                 TitleAutomationId = "EmptyStateTitleTest",
                 DescriptionAutomationId = "EmptyStateDescriptionTest",
-                ActionButtonAutomationId = "EmptyStateActionTest"
+                ActionButtonAutomationId = "EmptyStateActionTest",
+                SecondaryActionButtonAutomationId = "EmptyStateSecondaryActionTest",
+                SeverityAutomationId = "EmptyStateSeverityTest"
             };
             var iconButton = new IconTextButton
             {
@@ -102,8 +108,13 @@ public sealed class ApplicationPrimitiveControlsTests
                 AutomationProperties.GetAutomationId(Get<TextBlock>(emptyState, "TitleText")).Should().Be("EmptyStateTitleTest");
                 AutomationProperties.GetAutomationId(Get<TextBlock>(emptyState, "DescriptionText")).Should().Be("EmptyStateDescriptionTest");
                 AutomationProperties.GetAutomationId(Get<Button>(emptyState, "ActionButton")).Should().Be("EmptyStateActionTest");
+                AutomationProperties.GetAutomationId(Get<ToneBadge>(emptyState, "SeverityBadge")).Should().Be("EmptyStateSeverityTest");
+                AutomationProperties.GetAutomationId(Get<Button>(emptyState, "SecondaryActionButton")).Should().Be("EmptyStateSecondaryActionTest");
                 Get<TextBlock>(emptyState, "TitleText").Text.Should().Be("No approvals queued");
+                Get<ToneBadge>(emptyState, "SeverityBadge").Text.Should().Be("No reconciliation run");
+                Get<ToneBadge>(emptyState, "SeverityBadge").Tone.Should().Be(WorkspaceTone.Warning);
                 Get<Button>(emptyState, "ActionButton").Command.Should().BeSameAs(emptyAction);
+                Get<Button>(emptyState, "SecondaryActionButton").Command.Should().BeSameAs(queueAction);
 
                 AutomationProperties.GetAutomationId(iconButton).Should().Be("IconTextButtonTest");
                 AutomationProperties.GetName(iconButton).Should().Be("Refresh");
@@ -344,6 +355,8 @@ public sealed class ApplicationPrimitiveControlsTests
             try
             {
                 Get<Button>(emptyWithoutCommand, "ActionButton").Visibility.Should().Be(Visibility.Collapsed);
+                Get<Button>(emptyWithoutCommand, "SecondaryActionButton").Visibility.Should().Be(Visibility.Collapsed);
+                Get<ToneBadge>(emptyWithoutCommand, "SeverityBadge").Visibility.Should().Be(Visibility.Collapsed);
                 Get<Button>(emptyWithoutText, "ActionButton").Visibility.Should().Be(Visibility.Collapsed);
                 Get<Button>(queueWithoutCommand, "ActionButton").Visibility.Should().Be(Visibility.Collapsed);
                 Get<Button>(queueWithoutText, "ActionButton").Visibility.Should().Be(Visibility.Collapsed);
@@ -355,6 +368,18 @@ public sealed class ApplicationPrimitiveControlsTests
                 window.Close();
             }
         });
+    }
+
+    [Fact]
+    public void EmptyStateMessages_ShouldCoverCommonMissingDataCasesInPlainEnglish()
+    {
+        EmptyStateMessages.NoProviderConfigured.Title.Should().Be("No provider configured");
+        EmptyStateMessages.NoRecordsImported.Description.Should().Contain("Import records");
+        EmptyStateMessages.NoSelectedAccountOrPortfolio.Title.Should().Contain("account or portfolio");
+        EmptyStateMessages.StaleData.Description.Should().Contain("Refresh this view");
+        EmptyStateMessages.NoReconciliationRun.Title.Should().Contain("No reconciliation run");
+        EmptyStateMessages.NoReportsGenerated.Description.Should().Contain("Generate a governed report pack");
+        EmptyStateMessages.FixtureDataAvailable.Title.Should().Contain("Fixture data");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Audit WPF views for blank/empty panels and provide a single reusable primitive to avoid silent empty grids and improve operator guidance. 
- Present plain-English recovery copy for common missing-data cases (no provider, no imports, no selection, stale data, no reconciliation, no reports, fixture/demo data) and expose one or two actionable commands so operators have clear next steps.

### Description
- Extended `Controls/EmptyStatePanel` (XAML + code-behind) to add an optional severity `ToneBadge`, `SecondaryActionText`/`SecondaryActionCommand`, and corresponding automation-id properties while keeping optional elements collapsed when absent. 
- Introduced `EmptyStateMessages` (shared plain-English messages) for common missing-data cases and an `EmptyStateMessage` record type for reuse across view-models. 
- Replaced repeated inline empty-state markup with the shared `EmptyStatePanel` in `Views/AccountPortfolioPage.xaml`, `Views/AggregatePortfolioPage.xaml`, and `Views/WorkflowLibraryPage.xaml` and wired reasonable severity/action defaults. 
- Updated `src/Meridian.Wpf/README.md` to document the new shared empty-state guidance and added/updated `tests/Meridian.Wpf.Tests/Views/ApplicationPrimitiveControlsTests.cs` to cover the new automation contracts, severity badge, and secondary-action behavior.

### Testing
- Ran `git diff --check` which passed. 
- Added/updated `tests/Meridian.Wpf.Tests/Views/ApplicationPrimitiveControlsTests` to assert automation ids, severity badge text/tone, and that optional actions collapse when missing, but `dotnet test` could not be executed in this environment because `dotnet` is not installed. 
- Attempted `pwsh` validation scripts (`./tools/codex/component-inventory.ps1`, `./tools/codex/shared-pattern-suggest.ps1`, `./tools/codex/mvvm-compliance-check.ps1`) but they could not run because `pwsh` is not available in this environment. 
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary`, which executed but reported existing repository-wide documentation/source hash drift (including `src/Meridian.Wpf`), which is pre-existing and unrelated to functional changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3081c51a088320b7eaa06db99a7a9e)