### PR TITLE
Shared dense-grid keyboard commands and bindings for WPF tables

### DIFF
--- a/src/Meridian.Wpf/README.md
+++ b/src/Meridian.Wpf/README.md
@@ -104,6 +104,11 @@ posture used by shared workstation continuity endpoints.
 The drill-in uses compact action-strip chrome, shared dense cash-ladder and cash-flow event tables,
 and right-side inspectors for the selected event, ladder bucket, continuity posture, and run actions;
 Security Master remains disabled until a symbol-linked cash-flow event is selected.
+Shared dense workstation grids centralize keyboard behavior in `DenseGridKeyboardCommands` and
+`DenseDataGridControl` rather than per-page key handlers. Grids and table-inspector compositions
+now expose reusable command hooks for Ctrl+F filter focus, Enter selected-row details, Escape detail
+closure, Ctrl+C selected-row copy, Ctrl+Shift+F filter clearing, and Ctrl+J related-record
+navigation; row traversal remains the virtualized list's native Up/Down/Page/Home/End behavior.
 Desktop backtest services register the Backtesting-owned `IBacktestPreflightService` implementation
 and attach it to the singleton `BacktestService`, so WPF strategy runs use the same date-range,
 replay-coverage, execution-model, and optional Security Master preflight checks as shared

--- a/src/Meridian.Wpf/Workstation/Controls/DenseDataGridControl.xaml
+++ b/src/Meridian.Wpf/Workstation/Controls/DenseDataGridControl.xaml
@@ -1,6 +1,7 @@
 <UserControl x:Class="Meridian.Wpf.Workstation.Controls.DenseDataGridControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Meridian.Wpf.Workstation.Controls"
              x:Name="Root">
     <UserControl.Resources>
         <Style x:Key="DenseGridColumnHeaderStyle" TargetType="{x:Type GridViewColumnHeader}">
@@ -41,6 +42,14 @@
     </UserControl.Resources>
 
     <Grid>
+        <Grid.InputBindings>
+            <KeyBinding Key="F" Modifiers="Control" Command="{x:Static controls:DenseGridKeyboardCommands.FocusFilter}" />
+            <KeyBinding Key="Enter" Command="{x:Static controls:DenseGridKeyboardCommands.OpenSelectedDetails}" />
+            <KeyBinding Key="Escape" Command="{x:Static controls:DenseGridKeyboardCommands.CloseDetails}" />
+            <KeyBinding Key="C" Modifiers="Control" Command="ApplicationCommands.Copy" />
+            <KeyBinding Key="F" Modifiers="Control+Shift" Command="{x:Static controls:DenseGridKeyboardCommands.ClearFilters}" />
+            <KeyBinding Key="J" Modifiers="Control" Command="{x:Static controls:DenseGridKeyboardCommands.JumpToRelatedRecords}" />
+        </Grid.InputBindings>
         <ListView x:Name="RowsList"
                   ItemsSource="{Binding ElementName=Root, Path=Table.Rows}"
                   SelectedItem="{Binding ElementName=Root, Path=SelectedItem, Mode=TwoWay}"

--- a/src/Meridian.Wpf/Workstation/Controls/DenseDataGridControl.xaml.cs
+++ b/src/Meridian.Wpf/Workstation/Controls/DenseDataGridControl.xaml.cs
@@ -5,6 +5,9 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
+using System.Windows.Input;
+using System.Reflection;
+using System.Text;
 using Meridian.Wpf.Workstation.Models;
 
 namespace Meridian.Wpf.Workstation.Controls;
@@ -60,11 +63,52 @@ public partial class DenseDataGridControl : UserControl
             typeof(DenseDataGridControl),
             new PropertyMetadata("DenseDataGridEmptyState"));
 
+    public static readonly DependencyProperty FilterTargetProperty =
+        DependencyProperty.Register(
+            nameof(FilterTarget),
+            typeof(UIElement),
+            typeof(DenseDataGridControl),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty OpenSelectedDetailsCommandProperty =
+        DependencyProperty.Register(
+            nameof(OpenSelectedDetailsCommand),
+            typeof(ICommand),
+            typeof(DenseDataGridControl),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty CloseDetailsCommandProperty =
+        DependencyProperty.Register(
+            nameof(CloseDetailsCommand),
+            typeof(ICommand),
+            typeof(DenseDataGridControl),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty ClearFiltersCommandProperty =
+        DependencyProperty.Register(
+            nameof(ClearFiltersCommand),
+            typeof(ICommand),
+            typeof(DenseDataGridControl),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty JumpToRelatedRecordsCommandProperty =
+        DependencyProperty.Register(
+            nameof(JumpToRelatedRecordsCommand),
+            typeof(ICommand),
+            typeof(DenseDataGridControl),
+            new PropertyMetadata(null));
+
     private INotifyCollectionChanged? _observedRows;
 
     public DenseDataGridControl()
     {
         InitializeComponent();
+        CommandBindings.Add(new CommandBinding(DenseGridKeyboardCommands.FocusFilter, ExecuteFocusFilter, CanExecuteFocusFilter));
+        CommandBindings.Add(new CommandBinding(DenseGridKeyboardCommands.OpenSelectedDetails, ExecuteOpenSelectedDetails, CanExecuteOpenSelectedDetails));
+        CommandBindings.Add(new CommandBinding(DenseGridKeyboardCommands.CloseDetails, ExecuteCloseDetails, CanExecuteCloseDetails));
+        CommandBindings.Add(new CommandBinding(ApplicationCommands.Copy, ExecuteCopySelection, CanExecuteCopySelection));
+        CommandBindings.Add(new CommandBinding(DenseGridKeyboardCommands.ClearFilters, ExecuteClearFilters, CanExecuteClearFilters));
+        CommandBindings.Add(new CommandBinding(DenseGridKeyboardCommands.JumpToRelatedRecords, ExecuteJumpToRelatedRecords, CanExecuteJumpToRelatedRecords));
         Loaded += (_, _) => UpdateEmptyState();
         Unloaded += (_, _) => DetachRowsCollection();
     }
@@ -109,6 +153,36 @@ public partial class DenseDataGridControl : UserControl
     {
         get => (string)GetValue(EmptyAutomationIdProperty);
         set => SetValue(EmptyAutomationIdProperty, value);
+    }
+
+    public UIElement? FilterTarget
+    {
+        get => (UIElement?)GetValue(FilterTargetProperty);
+        set => SetValue(FilterTargetProperty, value);
+    }
+
+    public ICommand? OpenSelectedDetailsCommand
+    {
+        get => (ICommand?)GetValue(OpenSelectedDetailsCommandProperty);
+        set => SetValue(OpenSelectedDetailsCommandProperty, value);
+    }
+
+    public ICommand? CloseDetailsCommand
+    {
+        get => (ICommand?)GetValue(CloseDetailsCommandProperty);
+        set => SetValue(CloseDetailsCommandProperty, value);
+    }
+
+    public ICommand? ClearFiltersCommand
+    {
+        get => (ICommand?)GetValue(ClearFiltersCommandProperty);
+        set => SetValue(ClearFiltersCommandProperty, value);
+    }
+
+    public ICommand? JumpToRelatedRecordsCommand
+    {
+        get => (ICommand?)GetValue(JumpToRelatedRecordsCommandProperty);
+        set => SetValue(JumpToRelatedRecordsCommandProperty, value);
     }
 
     private static void OnTableChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -202,4 +276,145 @@ public partial class DenseDataGridControl : UserControl
             selectedItems.Add(selectedItem);
         }
     }
+
+    private void CanExecuteFocusFilter(object sender, CanExecuteRoutedEventArgs e)
+    {
+        e.CanExecute = FilterTarget is not null;
+        e.Handled = true;
+    }
+
+    private void ExecuteFocusFilter(object sender, ExecutedRoutedEventArgs e)
+    {
+        FilterTarget?.Focus();
+        e.Handled = true;
+    }
+
+    private void CanExecuteOpenSelectedDetails(object sender, CanExecuteRoutedEventArgs e)
+    {
+        e.CanExecute = CanExecute(OpenSelectedDetailsCommand, SelectedItem);
+        e.Handled = true;
+    }
+
+    private void ExecuteOpenSelectedDetails(object sender, ExecutedRoutedEventArgs e)
+    {
+        Execute(OpenSelectedDetailsCommand, SelectedItem);
+        e.Handled = true;
+    }
+
+    private void CanExecuteCloseDetails(object sender, CanExecuteRoutedEventArgs e)
+    {
+        e.CanExecute = CanExecute(CloseDetailsCommand, SelectedItem);
+        e.Handled = true;
+    }
+
+    private void ExecuteCloseDetails(object sender, ExecutedRoutedEventArgs e)
+    {
+        Execute(CloseDetailsCommand, SelectedItem);
+        e.Handled = true;
+    }
+
+    private void CanExecuteClearFilters(object sender, CanExecuteRoutedEventArgs e)
+    {
+        e.CanExecute = CanExecute(ClearFiltersCommand, null);
+        e.Handled = true;
+    }
+
+    private void ExecuteClearFilters(object sender, ExecutedRoutedEventArgs e)
+    {
+        Execute(ClearFiltersCommand, null);
+        e.Handled = true;
+    }
+
+    private void CanExecuteJumpToRelatedRecords(object sender, CanExecuteRoutedEventArgs e)
+    {
+        e.CanExecute = CanExecute(JumpToRelatedRecordsCommand, SelectedItem);
+        e.Handled = true;
+    }
+
+    private void ExecuteJumpToRelatedRecords(object sender, ExecutedRoutedEventArgs e)
+    {
+        Execute(JumpToRelatedRecordsCommand, SelectedItem);
+        e.Handled = true;
+    }
+
+    private void CanExecuteCopySelection(object sender, CanExecuteRoutedEventArgs e)
+    {
+        e.CanExecute = RowsList?.SelectedItems.Count > 0;
+        e.Handled = true;
+    }
+
+    private void ExecuteCopySelection(object sender, ExecutedRoutedEventArgs e)
+    {
+        var text = FormatSelectedRowsForClipboard();
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            Clipboard.SetText(text);
+        }
+
+        e.Handled = true;
+    }
+
+    internal string FormatSelectedRowsForClipboard()
+    {
+        if (RowsList is null || RowsList.SelectedItems.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var columns = Table?.Columns ?? Array.Empty<WorkstationTableColumnModel>();
+        var builder = new StringBuilder();
+        if (columns.Count > 0)
+        {
+            builder.AppendLine(string.Join("\t", columns.Select(column => column.Header)));
+        }
+
+        foreach (var selectedItem in RowsList.SelectedItems.Cast<object>())
+        {
+            builder.AppendLine(columns.Count == 0
+                ? Convert.ToString(selectedItem, System.Globalization.CultureInfo.CurrentCulture) ?? string.Empty
+                : string.Join("\t", columns.Select(column => FormatCellValue(selectedItem, column.BindingPath))));
+        }
+
+        return builder.ToString().TrimEnd('\r', '\n');
+    }
+
+    private static string FormatCellValue(object row, string bindingPath)
+    {
+        if (string.IsNullOrWhiteSpace(bindingPath))
+        {
+            return string.Empty;
+        }
+
+        var current = row;
+        foreach (var segment in bindingPath.Split('.'))
+        {
+            var property = current.GetType().GetProperty(segment, BindingFlags.Instance | BindingFlags.Public);
+            if (property is null)
+            {
+                return string.Empty;
+            }
+
+            var value = property.GetValue(current);
+            if (value is null)
+            {
+                return string.Empty;
+            }
+
+            current = value;
+        }
+
+        return Convert.ToString(current, System.Globalization.CultureInfo.CurrentCulture) ?? string.Empty;
+    }
+
+    private static bool CanExecute(ICommand? command, object? parameter)
+        => command is not null && command.CanExecute(parameter);
+
+    private static void Execute(ICommand? command, object? parameter)
+    {
+        if (command?.CanExecute(parameter) == true)
+        {
+            command.Execute(parameter);
+        }
+    }
+
 }

--- a/src/Meridian.Wpf/Workstation/Controls/DenseGridKeyboardCommands.cs
+++ b/src/Meridian.Wpf/Workstation/Controls/DenseGridKeyboardCommands.cs
@@ -1,0 +1,31 @@
+using System.Windows.Input;
+
+namespace Meridian.Wpf.Workstation.Controls;
+
+public static class DenseGridKeyboardCommands
+{
+    public static readonly RoutedUICommand FocusFilter = new(
+        "Focus filter",
+        nameof(FocusFilter),
+        typeof(DenseGridKeyboardCommands));
+
+    public static readonly RoutedUICommand OpenSelectedDetails = new(
+        "Open selected details",
+        nameof(OpenSelectedDetails),
+        typeof(DenseGridKeyboardCommands));
+
+    public static readonly RoutedUICommand CloseDetails = new(
+        "Close details",
+        nameof(CloseDetails),
+        typeof(DenseGridKeyboardCommands));
+
+    public static readonly RoutedUICommand ClearFilters = new(
+        "Clear filters",
+        nameof(ClearFilters),
+        typeof(DenseGridKeyboardCommands));
+
+    public static readonly RoutedUICommand JumpToRelatedRecords = new(
+        "Jump to related records",
+        nameof(JumpToRelatedRecords),
+        typeof(DenseGridKeyboardCommands));
+}

--- a/src/Meridian.Wpf/Workstation/Controls/WorkstationTableInspectorControl.xaml
+++ b/src/Meridian.Wpf/Workstation/Controls/WorkstationTableInspectorControl.xaml
@@ -92,6 +92,11 @@
                                                    SelectedItems="{Binding ElementName=Root, Path=SelectedItems}"
                                                    SelectionMode="{Binding ElementName=Root, Path=SelectionMode}"
                                                    EmptyContent="{Binding ElementName=Root, Path=EmptyContent}"
+                                                   FilterTarget="{Binding ElementName=Root, Path=FilterTarget}"
+                                                   OpenSelectedDetailsCommand="{Binding ElementName=Root, Path=OpenSelectedDetailsCommand}"
+                                                   CloseDetailsCommand="{Binding ElementName=Root, Path=CloseDetailsCommand}"
+                                                   ClearFiltersCommand="{Binding ElementName=Root, Path=ClearFiltersCommand}"
+                                                   JumpToRelatedRecordsCommand="{Binding ElementName=Root, Path=JumpToRelatedRecordsCommand}"
                                                    GridAutomationId="{Binding ElementName=Root, Path=GridAutomationId}"
                                                    EmptyAutomationId="{Binding ElementName=Root, Path=EmptyAutomationId}" />
                 </Border>

--- a/src/Meridian.Wpf/Workstation/Controls/WorkstationTableInspectorControl.xaml.cs
+++ b/src/Meridian.Wpf/Workstation/Controls/WorkstationTableInspectorControl.xaml.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using Meridian.Wpf.Workstation.Models;
 
 namespace Meridian.Wpf.Workstation.Controls;
@@ -133,6 +134,41 @@ public partial class WorkstationTableInspectorControl : UserControl
             typeof(WorkstationTableInspectorControl),
             new PropertyMetadata("WorkstationTableInspector"));
 
+    public static readonly DependencyProperty FilterTargetProperty =
+        DependencyProperty.Register(
+            nameof(FilterTarget),
+            typeof(UIElement),
+            typeof(WorkstationTableInspectorControl),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty OpenSelectedDetailsCommandProperty =
+        DependencyProperty.Register(
+            nameof(OpenSelectedDetailsCommand),
+            typeof(ICommand),
+            typeof(WorkstationTableInspectorControl),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty CloseDetailsCommandProperty =
+        DependencyProperty.Register(
+            nameof(CloseDetailsCommand),
+            typeof(ICommand),
+            typeof(WorkstationTableInspectorControl),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty ClearFiltersCommandProperty =
+        DependencyProperty.Register(
+            nameof(ClearFiltersCommand),
+            typeof(ICommand),
+            typeof(WorkstationTableInspectorControl),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty JumpToRelatedRecordsCommandProperty =
+        DependencyProperty.Register(
+            nameof(JumpToRelatedRecordsCommand),
+            typeof(ICommand),
+            typeof(WorkstationTableInspectorControl),
+            new PropertyMetadata(null));
+
     public WorkstationTableInspectorControl()
     {
         InitializeComponent();
@@ -244,5 +280,35 @@ public partial class WorkstationTableInspectorControl : UserControl
     {
         get => (string)GetValue(ControlAutomationIdProperty);
         set => SetValue(ControlAutomationIdProperty, value);
+    }
+
+    public UIElement? FilterTarget
+    {
+        get => (UIElement?)GetValue(FilterTargetProperty);
+        set => SetValue(FilterTargetProperty, value);
+    }
+
+    public ICommand? OpenSelectedDetailsCommand
+    {
+        get => (ICommand?)GetValue(OpenSelectedDetailsCommandProperty);
+        set => SetValue(OpenSelectedDetailsCommandProperty, value);
+    }
+
+    public ICommand? CloseDetailsCommand
+    {
+        get => (ICommand?)GetValue(CloseDetailsCommandProperty);
+        set => SetValue(CloseDetailsCommandProperty, value);
+    }
+
+    public ICommand? ClearFiltersCommand
+    {
+        get => (ICommand?)GetValue(ClearFiltersCommandProperty);
+        set => SetValue(ClearFiltersCommandProperty, value);
+    }
+
+    public ICommand? JumpToRelatedRecordsCommand
+    {
+        get => (ICommand?)GetValue(JumpToRelatedRecordsCommandProperty);
+        set => SetValue(JumpToRelatedRecordsCommandProperty, value);
     }
 }

--- a/tests/Meridian.Wpf.Tests/Views/WorkstationPrimitiveControlsTests.cs
+++ b/tests/Meridian.Wpf.Tests/Views/WorkstationPrimitiveControlsTests.cs
@@ -3,9 +3,11 @@ using System.IO;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Controls;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using Meridian.Wpf.Workstation.Controls;
 using Meridian.Wpf.Models;
 using Meridian.Wpf.Tests.Support;
-using Meridian.Wpf.Workstation.Controls;
 using Meridian.Wpf.Workstation.Models;
 using TableActivityLogGridControl = Meridian.Wpf.Workstation.Tables.ActivityLogGridControl;
 using TableDenseDataGridControl = Meridian.Wpf.Workstation.Tables.DenseDataGridControl;
@@ -258,6 +260,71 @@ public sealed class WorkstationPrimitiveControlsTests
         });
     }
 
+
+    [Fact]
+    public void DenseDataGridControl_ShouldExposeSharedKeyboardCommandsAndCopySelectedRows()
+    {
+        WpfTestThread.Run(() =>
+        {
+            RunMatUiAutomationFacade.EnsureApplicationResources();
+
+            var tableRows = new ObservableCollection<RowFixture>
+            {
+                new("Polygon.io", "Healthy"),
+                new("Alpaca", "Degraded")
+            };
+            var opened = false;
+            var closed = false;
+            var cleared = false;
+            var jumped = false;
+            var filterBox = new TextBox();
+            var denseGrid = new DenseDataGridControl
+            {
+                Table = new WorkstationTableModel<RowFixture>(
+                    tableRows,
+                    [new("Provider", nameof(RowFixture.Name), 120), new("Status", nameof(RowFixture.Status), 100)],
+                    "Provider readiness table"),
+                FilterTarget = filterBox,
+                OpenSelectedDetailsCommand = new RelayCommand<object?>(_ => opened = true, parameter => parameter is RowFixture),
+                CloseDetailsCommand = new RelayCommand<object?>(_ => closed = true),
+                ClearFiltersCommand = new RelayCommand(() => cleared = true),
+                JumpToRelatedRecordsCommand = new RelayCommand<object?>(_ => jumped = true, parameter => parameter is RowFixture)
+            };
+
+            var window = Show(new StackPanel { Children = { filterBox, denseGrid } });
+            try
+            {
+                var rowsList = denseGrid.FindName("RowsList").Should().BeOfType<ListView>().Subject;
+                rowsList.SelectedItem = tableRows[1];
+
+                denseGrid.CommandBindings.Should().Contain(binding => binding.Command == DenseGridKeyboardCommands.FocusFilter);
+                denseGrid.CommandBindings.Should().Contain(binding => binding.Command == DenseGridKeyboardCommands.OpenSelectedDetails);
+                denseGrid.CommandBindings.Should().Contain(binding => binding.Command == DenseGridKeyboardCommands.CloseDetails);
+                denseGrid.CommandBindings.Should().Contain(binding => binding.Command == ApplicationCommands.Copy);
+                denseGrid.CommandBindings.Should().Contain(binding => binding.Command == DenseGridKeyboardCommands.ClearFilters);
+                denseGrid.CommandBindings.Should().Contain(binding => binding.Command == DenseGridKeyboardCommands.JumpToRelatedRecords);
+
+                DenseGridKeyboardCommands.FocusFilter.Execute(null, denseGrid);
+                filterBox.IsKeyboardFocusWithin.Should().BeTrue();
+
+                DenseGridKeyboardCommands.OpenSelectedDetails.Execute(null, denseGrid);
+                DenseGridKeyboardCommands.CloseDetails.Execute(null, denseGrid);
+                DenseGridKeyboardCommands.ClearFilters.Execute(null, denseGrid);
+                DenseGridKeyboardCommands.JumpToRelatedRecords.Execute(null, denseGrid);
+
+                opened.Should().BeTrue();
+                closed.Should().BeTrue();
+                cleared.Should().BeTrue();
+                jumped.Should().BeTrue();
+                denseGrid.FormatSelectedRowsForClipboard().Should().Be("Provider\tStatus\nAlpaca\tDegraded");
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
     [Fact]
     public void DenseDataGridSource_ShouldUseCompactInstitutionalTableChrome()
     {
@@ -272,6 +339,11 @@ public sealed class WorkstationPrimitiveControlsTests
         xaml.Should().Contain("EmptyContentPresenter");
         xaml.Should().Contain("VirtualizingPanel.VirtualizationMode=\"Recycling\"");
         xaml.Should().Contain("VirtualizingPanel.ScrollUnit=\"Item\"");
+        xaml.Should().Contain("DenseGridKeyboardCommands.FocusFilter");
+        xaml.Should().Contain("DenseGridKeyboardCommands.OpenSelectedDetails");
+        xaml.Should().Contain("Command=\"ApplicationCommands.Copy\"");
+        xaml.Should().Contain("DenseGridKeyboardCommands.ClearFilters");
+        xaml.Should().Contain("DenseGridKeyboardCommands.JumpToRelatedRecords");
     }
 
     [Fact]
@@ -315,6 +387,8 @@ public sealed class WorkstationPrimitiveControlsTests
         xaml.Should().Contain("EmptyContent=\"{Binding ElementName=Root, Path=EmptyContent}\"");
         xaml.Should().Contain("InspectorHeaderContent");
         xaml.Should().Contain("SelectedItems=\"{Binding ElementName=Root, Path=SelectedItems}\"");
+        xaml.Should().Contain("OpenSelectedDetailsCommand=\"{Binding ElementName=Root, Path=OpenSelectedDetailsCommand}\"");
+        xaml.Should().Contain("ClearFiltersCommand=\"{Binding ElementName=Root, Path=ClearFiltersCommand}\"");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Provide a consistent, reusable keyboard UX for dense WPF grids so operators can focus/filter, traverse rows, open/close details, copy selections, clear filters, and jump to related records without per-grid one-offs.
- Prioritize reuse across Accounting reconciliation grids, Portfolio position grids, Data provider/import grids, and Reporting lists by surface-level command hooks and MVVM-friendly bindings.

### Description
- Added `DenseGridKeyboardCommands` with routed commands for `FocusFilter`, `OpenSelectedDetails`, `CloseDetails`, `ClearFilters`, and `JumpToRelatedRecords` (`src/Meridian.Wpf/Workstation/Controls/DenseGridKeyboardCommands.cs`).
- Wired shared key bindings (Ctrl+F, Enter, Escape, Ctrl+C, Ctrl+Shift+F, Ctrl+J) and command bindings into `DenseDataGridControl`, exposed `FilterTarget` and command dependency properties, implemented handlers and a `FormatSelectedRowsForClipboard()` helper for tab-delimited copy (`src/Meridian.Wpf/Workstation/Controls/DenseDataGridControl.xaml(.cs)`).
- Exposed the same command/pass-through properties on `WorkstationTableInspectorControl` so composed table+inspector pages can opt into the shared behavior (`src/Meridian.Wpf/Workstation/Controls/WorkstationTableInspectorControl.xaml(.cs)`).
- Added a focused WPF unit test exercising registration, filter focus, command execution, copy formatting, and XAML contract checks (`tests/Meridian.Wpf.Tests/Views/WorkstationPrimitiveControlsTests.cs`) and documented the contract in the WPF README (`src/Meridian.Wpf/README.md`).

### Testing
- Ran `git diff --check` which produced no issues (passed).
- Ran `python3 build/scripts/docs/validate-source-readmes.py --summary` which completed successfully (passed).
- Attempted to run the targeted WPF test filter and other PS-based checks but `dotnet`/`pwsh` are not available in this environment so `dotnet test` and PowerShell validation scripts could not run (not executed here).
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary` which reported repository-wide documentation/source hash drift unrelated to this change (failed: repo-wide hash mismatches reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3098c7c2888320b7d2034a7453e4ba)