### PR TITLE
Improve CI test result aggregation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,7 +23,7 @@ scope.
 
 | Workflow | File | Trigger | Purpose | Artifacts |
 | --- | --- | --- | --- | --- |
-| CI | `ci.yml` | Pull requests, pushes to `main`, nightly, manual | Restores `Meridian.sln`, verifies formatting and warning-suppression inventory, builds the focused `Meridian.WebWorkstation.slnf` lane, runs non-integration .NET tests, tests and builds the dashboard with lockfile-strict `npm ci`, scans secrets, validates source-doc determinism, and runs nightly/manual verify-full coverage on `main`. | .NET TRX and coverage artifacts |
+| CI | `ci.yml` | Pull requests, pushes to `main`, nightly, manual | Restores `Meridian.sln`, verifies formatting and warning-suppression inventory, builds the focused `Meridian.WebWorkstation.slnf` lane, runs every configured non-integration .NET test project through the aggregate `run-dotnet-ci-tests.py` runner so one failing project does not hide later failures, tests and builds the dashboard with lockfile-strict `npm ci`, scans secrets, validates source-doc determinism, and runs nightly/manual verify-full coverage on `main`. | .NET TRX and coverage artifacts |
 | Targeted Test | `targeted-test.yml` | Manual only | Runs one selected .NET test project plus a required `dotnet test --filter` on a GitHub-hosted runner when local machine capacity, locks, or long-running suites make local validation impractical. Inputs are validated and limited to repo-relative `tests/` project paths and normal filter expressions for the failing slice. | Targeted TRX results |
 | Golden Path Validation | `golden-path-validation.yml` | Golden-path contract, browser W4, WPF W4, or manual changes | Blocks pilot acceptance on browser `test:w4` parity and Windows `Category=W4Acceptance` desktop coverage before running `PilotAcceptanceHarnessTests`, validating the pilot readiness dashboard renderer, and uploading evidence bundles. | `pilot-acceptance-evidence`, `wpf-w4-acceptance-evidence` |
 | Windows Desktop Build | `windows-desktop-build.yml` | WPF or WPF dependency changes, pushes to `main`, manual | Builds the real WPF app on Windows, runs WPF tests, and smoke-publishes the desktop executable. Path filters include the WPF project-reference closure so shared service, reporting, storage, workflow, and related dependency changes trigger the lane. | WPF TRX results and desktop smoke publish output |
@@ -68,7 +68,7 @@ dotnet restore Meridian.sln /p:EnableWindowsTargeting=true
 dotnet format Meridian.sln --verify-no-changes --verbosity minimal --no-restore
 python3 build/scripts/ci/check-warning-suppressions.py
 dotnet build Meridian.WebWorkstation.slnf -c Release --no-restore /p:EnableWindowsTargeting=true /p:UseAppHost=false
-dotnet test tests/Meridian.Tests/Meridian.Tests.csproj -c Release --no-restore --filter "Category!=Integration&Category!=Performance" /p:EnableWindowsTargeting=true
+python3 build/scripts/ci/run-dotnet-ci-tests.py --configuration Release --filter "Category!=Integration&Category!=Performance" --results-dir artifacts/test-results/dotnet
 npm ci --prefix src/Meridian.Ui/dashboard --include=optional
 npm --prefix src/Meridian.Ui/dashboard run test
 npm --prefix src/Meridian.Ui/dashboard run build
@@ -134,6 +134,6 @@ python3 build/scripts/docs/generate-workflow-manifest.py
 - Manual screenshot and manual-generation workflows are artifact-only; repository writes should be
   made from a reviewed local or PR workflow, not from those capture jobs.
 - PR and branch workflows cancel superseded runs.
-- Build/test workflows use explicit restore, build, and test phases.
+- Build/test workflows use explicit restore, build, and test phases; the CI .NET lane aggregates per-project test results before failing so each run reports all broken configured test slices.
 - Generated outputs stay under ignored `artifacts/`, `bin/`, `obj/`, `publish/`, `dist/`, or `TestResults/` paths.
 - Publish smoke artifacts are uploaded for inspection, and desktop installer tag runs publish packaged installer assets to GitHub Releases.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,13 +92,22 @@ jobs:
 
       - name: Run non-integration tests
         run: |
-          dotnet test tests/Meridian.Tests/Meridian.Tests.csproj -c Release --no-restore --filter "Category!=Integration&Category!=Performance" --logger "trx;LogFilePrefix=core" --results-directory artifacts/test-results/dotnet /p:EnableWindowsTargeting=true
-          dotnet test tests/Meridian.FSharp.Tests/Meridian.FSharp.Tests.fsproj -c Release --no-restore --filter "Category!=Integration&Category!=Performance" --logger "trx;LogFilePrefix=fsharp" --results-directory artifacts/test-results/dotnet /p:EnableWindowsTargeting=true
-          dotnet test tests/Meridian.Ui.Tests/Meridian.Ui.Tests.csproj -c Release --no-restore --filter "Category!=Integration&Category!=Performance" --logger "trx;LogFilePrefix=ui" --results-directory artifacts/test-results/dotnet /p:EnableWindowsTargeting=true
-          dotnet test tests/Meridian.Backtesting.Tests/Meridian.Backtesting.Tests.csproj -c Release --no-restore --filter "Category!=Integration&Category!=Performance" --logger "trx;LogFilePrefix=backtesting" --results-directory artifacts/test-results/dotnet /p:EnableWindowsTargeting=true
-          dotnet test tests/Meridian.DirectLending.Tests/Meridian.DirectLending.Tests.csproj -c Release --no-restore --filter "Category!=Integration&Category!=Performance" --logger "trx;LogFilePrefix=directlending" --results-directory artifacts/test-results/dotnet /p:EnableWindowsTargeting=true
-          dotnet test tests/Meridian.FundStructure.Tests/Meridian.FundStructure.Tests.csproj -c Release --no-restore --filter "Category!=Integration&Category!=Performance" --logger "trx;LogFilePrefix=fundstructure" --results-directory artifacts/test-results/dotnet /p:EnableWindowsTargeting=true
-          dotnet test tests/Meridian.QuantScript.Tests/Meridian.QuantScript.Tests.csproj -c Release --no-restore --filter "Category!=Integration&Category!=Performance" --logger "trx;LogFilePrefix=quantscript" --results-directory artifacts/test-results/dotnet /p:EnableWindowsTargeting=true
+          python3 build/scripts/ci/run-dotnet-ci-tests.py \
+            --configuration Release \
+            --filter "Category!=Integration&Category!=Performance" \
+            --results-dir artifacts/test-results/dotnet \
+            --summary-output artifacts/test-results/dotnet/ci-dotnet-test-summary.md \
+            --json-output artifacts/test-results/dotnet/ci-dotnet-test-summary.json
+
+      - name: Publish .NET test summary
+        if: always()
+        run: |
+          SUMMARY_PATH=artifacts/test-results/dotnet/ci-dotnet-test-summary.md
+          if [ -f "$SUMMARY_PATH" ]; then
+            cat "$SUMMARY_PATH" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No .NET test summary was produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Validate status docs delivery claims
         run: |
@@ -143,7 +152,7 @@ jobs:
           python3 build/scripts/docs/check-validation-floor.py --summary-json docs/status/docs-automation-summary.json --route-json docs/status/prompt-route-lint-report.json --summary
 
       - name: Upload .NET test results
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
           name: ci-dotnet-${{ github.run_number }}

--- a/build/scripts/ci/run-dotnet-ci-tests.py
+++ b/build/scripts/ci/run-dotnet-ci-tests.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Run Meridian's CI .NET test projects and report all failures.
+
+The GitHub Actions CI lane should not stop at the first failing test project: a
+single run is more useful when it identifies every broken test slice and uploads
+a compact summary alongside TRX artifacts. This runner executes each configured
+project, records every exit code, writes JSON/Markdown summaries, and exits
+non-zero only after all projects have been attempted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_TEST_PROJECTS = [
+    ("core", "tests/Meridian.Tests/Meridian.Tests.csproj"),
+    ("fsharp", "tests/Meridian.FSharp.Tests/Meridian.FSharp.Tests.fsproj"),
+    ("ui", "tests/Meridian.Ui.Tests/Meridian.Ui.Tests.csproj"),
+    ("backtesting", "tests/Meridian.Backtesting.Tests/Meridian.Backtesting.Tests.csproj"),
+    ("directlending", "tests/Meridian.DirectLending.Tests/Meridian.DirectLending.Tests.csproj"),
+    ("fundstructure", "tests/Meridian.FundStructure.Tests/Meridian.FundStructure.Tests.csproj"),
+    ("quantscript", "tests/Meridian.QuantScript.Tests/Meridian.QuantScript.Tests.csproj"),
+]
+
+
+@dataclass(frozen=True)
+class TestProject:
+    name: str
+    path: str
+
+
+@dataclass(frozen=True)
+class TestResult:
+    name: str
+    path: str
+    exit_code: int
+    command: list[str]
+
+    @property
+    def status(self) -> str:
+        return "passed" if self.exit_code == 0 else "failed"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Meridian .NET CI test projects with aggregate reporting.")
+    parser.add_argument("--configuration", default="Release", help="dotnet test configuration.")
+    parser.add_argument(
+        "--filter",
+        default="Category!=Integration&Category!=Performance",
+        help="dotnet test filter expression.",
+    )
+    parser.add_argument(
+        "--results-dir",
+        default="artifacts/test-results/dotnet",
+        help="Directory where TRX files and summaries should be written.",
+    )
+    parser.add_argument(
+        "--summary-output",
+        default="artifacts/test-results/dotnet/ci-dotnet-test-summary.md",
+        help="Markdown summary output path.",
+    )
+    parser.add_argument(
+        "--json-output",
+        default="artifacts/test-results/dotnet/ci-dotnet-test-summary.json",
+        help="JSON summary output path.",
+    )
+    parser.add_argument(
+        "--project",
+        action="append",
+        default=[],
+        metavar="NAME=PATH",
+        help="Override/default-add a test project entry. Repeatable; when present, replaces defaults.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print commands and write summaries without running tests.")
+    return parser.parse_args()
+
+
+def parse_project_entries(entries: Sequence[str]) -> list[TestProject]:
+    if not entries:
+        return [TestProject(name=name, path=path) for name, path in DEFAULT_TEST_PROJECTS]
+
+    projects: list[TestProject] = []
+    for entry in entries:
+        if "=" not in entry:
+            raise ValueError(f"Project entry '{entry}' must use NAME=PATH format.")
+        name, path = entry.split("=", 1)
+        name = name.strip()
+        path = path.strip()
+        if not name or not path:
+            raise ValueError(f"Project entry '{entry}' must include non-empty NAME and PATH values.")
+        projects.append(TestProject(name=name, path=path))
+    return projects
+
+
+def build_dotnet_test_command(
+    project: TestProject,
+    *,
+    configuration: str,
+    test_filter: str,
+    results_dir: Path,
+) -> list[str]:
+    return [
+        "dotnet",
+        "test",
+        project.path,
+        "-c",
+        configuration,
+        "--no-restore",
+        "--filter",
+        test_filter,
+        "--logger",
+        f"trx;LogFilePrefix={project.name}",
+        "--results-directory",
+        str(results_dir),
+        "/p:EnableWindowsTargeting=true",
+    ]
+
+
+def run_tests(
+    projects: Sequence[TestProject],
+    *,
+    configuration: str,
+    test_filter: str,
+    results_dir: Path,
+    dry_run: bool,
+) -> list[TestResult]:
+    results: list[TestResult] = []
+    for project in projects:
+        command = build_dotnet_test_command(
+            project,
+            configuration=configuration,
+            test_filter=test_filter,
+            results_dir=results_dir,
+        )
+        print(f"::group::dotnet test {project.name}", flush=True)
+        print(" ".join(command), flush=True)
+        if dry_run:
+            exit_code = 0
+        else:
+            completed = subprocess.run(command, check=False)
+            exit_code = completed.returncode
+        print(f"::endgroup::", flush=True)
+        results.append(TestResult(project.name, project.path, exit_code, command))
+    return results
+
+
+def write_summaries(results: Sequence[TestResult], *, summary_output: Path, json_output: Path) -> None:
+    summary_output.parent.mkdir(parents=True, exist_ok=True)
+    json_output.parent.mkdir(parents=True, exist_ok=True)
+
+    failed = [result for result in results if result.exit_code != 0]
+    payload = {
+        "total": len(results),
+        "passed": len(results) - len(failed),
+        "failed": len(failed),
+        "results": [asdict(result) | {"status": result.status} for result in results],
+    }
+    json_output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    lines = [
+        "### .NET CI test project summary",
+        "",
+        f"- Total projects: {payload['total']}",
+        f"- Passed: {payload['passed']}",
+        f"- Failed: {payload['failed']}",
+        "",
+        "| Project | Status | Exit code |",
+        "| --- | --- | ---: |",
+    ]
+    for result in results:
+        icon = "✅" if result.exit_code == 0 else "❌"
+        lines.append(f"| `{result.path}` | {icon} {result.status} | {result.exit_code} |")
+    summary_output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        projects = parse_project_entries(args.project)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    results_dir = Path(args.results_dir)
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    results = run_tests(
+        projects,
+        configuration=args.configuration,
+        test_filter=args.filter,
+        results_dir=results_dir,
+        dry_run=args.dry_run,
+    )
+    write_summaries(results, summary_output=Path(args.summary_output), json_output=Path(args.json_output))
+
+    failed = [result for result in results if result.exit_code != 0]
+    if failed:
+        print("Failing .NET test projects:", file=sys.stderr)
+        for result in failed:
+            print(f"- {result.name}: {result.path} exited {result.exit_code}", file=sys.stderr)
+        return 1
+
+    print(f"All {len(results)} .NET test projects passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_run_dotnet_ci_tests.py
+++ b/tests/scripts/test_run_dotnet_ci_tests.py
@@ -1,0 +1,74 @@
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "build" / "scripts" / "ci" / "run-dotnet-ci-tests.py"
+SPEC = importlib.util.spec_from_file_location("run_dotnet_ci_tests", SCRIPT_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class RunDotnetCiTestsTests(unittest.TestCase):
+    def test_default_projects_are_used_when_no_overrides_are_supplied(self):
+        projects = MODULE.parse_project_entries([])
+
+        self.assertEqual(
+            [project.name for project in projects],
+            [
+                "core",
+                "fsharp",
+                "ui",
+                "backtesting",
+                "directlending",
+                "fundstructure",
+                "quantscript",
+            ],
+        )
+
+    def test_build_dotnet_test_command_uses_ci_filter_and_trx_prefix(self):
+        project = MODULE.TestProject("core", "tests/Meridian.Tests/Meridian.Tests.csproj")
+        results_dir = Path("artifacts/test-results/dotnet")
+
+        command = MODULE.build_dotnet_test_command(
+            project,
+            configuration="Release",
+            test_filter="Category!=Integration&Category!=Performance",
+            results_dir=results_dir,
+        )
+
+        self.assertEqual(command[:4], ["dotnet", "test", "tests/Meridian.Tests/Meridian.Tests.csproj", "-c"])
+        self.assertIn("--no-restore", command)
+        self.assertIn("Category!=Integration&Category!=Performance", command)
+        self.assertIn("trx;LogFilePrefix=core", command)
+        self.assertIn("/p:EnableWindowsTargeting=true", command)
+
+    def test_write_summaries_records_all_project_statuses(self):
+        with self.subTest("summary output"):
+            tmp_path = Path("artifacts/test-results/unit-summary")
+            tmp_path.mkdir(parents=True, exist_ok=True)
+            summary_output = tmp_path / "summary.md"
+            json_output = tmp_path / "summary.json"
+
+            results = [
+                MODULE.TestResult("core", "tests/Meridian.Tests/Meridian.Tests.csproj", 0, ["dotnet", "test"]),
+                MODULE.TestResult("ui", "tests/Meridian.Ui.Tests/Meridian.Ui.Tests.csproj", 1, ["dotnet", "test"]),
+            ]
+
+            MODULE.write_summaries(results, summary_output=summary_output, json_output=json_output)
+
+            payload = json.loads(json_output.read_text(encoding="utf-8"))
+            self.assertEqual(payload["total"], 2)
+            self.assertEqual(payload["passed"], 1)
+            self.assertEqual(payload["failed"], 1)
+            summary = summary_output.read_text(encoding="utf-8")
+            self.assertIn("tests/Meridian.Tests/Meridian.Tests.csproj", summary)
+            self.assertIn("tests/Meridian.Ui.Tests/Meridian.Ui.Tests.csproj", summary)
+            self.assertIn("❌ failed", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Make the CI pipeline more robust so a single failing test project does not hide later failures and operators get a complete view of test failures in one run. 
- Provide machine-readable and human-readable summaries for CI test results to simplify triage and artifact collection. 
- Keep local developer workflows and documentation aligned with the CI changes.

### Description
- Add a reusable CI test runner `build/scripts/ci/run-dotnet-ci-tests.py` that runs every configured non-integration .NET test project, captures per-project exit codes, prints grouped command output, supports `--dry-run` and `--project NAME=PATH` overrides, and writes JSON and Markdown summaries. 
- Update the CI workflow `.github/workflows/ci.yml` to invoke the aggregate runner, publish the generated Markdown summary into the GitHub Actions job summary, and upload .NET test/build artifacts on every run (not only on failure). 
- Update workflow docs `.github/workflows/README.md` to document the new runner and the local equivalent command. 
- Add unit tests `tests/scripts/test_run_dotnet_ci_tests.py` covering default project selection, `dotnet` command construction, and summary generation.

### Testing
- Ran unit tests with `python3 -m unittest tests/scripts/test_run_dotnet_ci_tests.py` and they passed. 
- Verified the runner compiles via `python3 -m py_compile build/scripts/ci/run-dotnet-ci-tests.py` and the check passed. 
- Exercised the runner in dry-run mode with `python3 build/scripts/ci/run-dotnet-ci-tests.py --dry-run --results-dir artifacts/test-results/dotnet-dry-run --summary-output artifacts/test-results/dotnet-dry-run/summary.md --json-output artifacts/test-results/dotnet-dry-run/summary.json` and it produced the expected Markdown/JSON summaries. 
- Ran CI hygiene checks with `python3 build/scripts/ci/check-workflow-hygiene.py` and they passed. 
- Ran the implementation-assurance eval dry-run with `python3 .codex/skills/meridian-implementation-assurance/scripts/run_evals.py --all --dry-run --summary` and scored the example via `python3 .codex/skills/meridian-implementation-assurance/scripts/score_eval.py --scenario A --scores '{"behavior_correctness":2,"validation_evidence":2,"performance_safety":2,"documentation_sync":2,"traceable_summary":2}'`; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31a57fb3b08320be934ca7d4907fda)