### PR TITLE
Improve Codex skill display names

### DIFF
--- a/.codex/skills/dense-data-grid-inspector-panel/agents/openai.yaml
+++ b/.codex/skills/dense-data-grid-inspector-panel/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Dense Data Grid Inspector"
+  display_name: "Build Dense Grids"
   short_description: "Build virtualized grids with inspector panels"
   default_prompt: "Use $dense-data-grid-inspector-panel to implement dense grid and inspector workflows that scale to large Meridian datasets."

--- a/.codex/skills/desktop-test-generation/agents/openai.yaml
+++ b/.codex/skills/desktop-test-generation/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Desktop Test Generation"
+  display_name: "Generate Desktop Tests"
   short_description: "Generate WPF view model and workflow tests"
   default_prompt: "Use $desktop-test-generation to add focused Meridian WPF tests for view models, commands, services, bindings, and workflow states."

--- a/.codex/skills/diagnostics-audit-timeline/agents/openai.yaml
+++ b/.codex/skills/diagnostics-audit-timeline/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Diagnostics Audit Timeline"
+  display_name: "Build Audit Timelines"
   short_description: "Build diagnostics and audit timelines"
   default_prompt: "Use $diagnostics-audit-timeline to implement diagnostics panels, audit timelines, evidence trails, and operator triage surfaces."

--- a/.codex/skills/meridian-archive-organizer/agents/openai.yaml
+++ b/.codex/skills/meridian-archive-organizer/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Meridian Archive Organizer"
+  display_name: "Organize Archives"
   short_description: "Archive stale files and tidy repo layout"
   default_prompt: "Use $meridian-archive-organizer to classify stale Meridian files with evidence and move them into the right archive bucket."

--- a/.codex/skills/meridian-blueprint/agents/openai.yaml
+++ b/.codex/skills/meridian-blueprint/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Meridian Blueprint"
+  display_name: "Blueprint Meridian"
   short_description: "Create code-ready Meridian design specs"
   default_prompt: "Use $meridian-blueprint to turn this Meridian feature into a code-ready design grounded in the current workstation and fund-ops architecture."

--- a/.codex/skills/meridian-brainstorm/agents/openai.yaml
+++ b/.codex/skills/meridian-brainstorm/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Meridian Brainstorm"
+  display_name: "Brainstorm Meridian"
   short_description: "Generate Meridian product and architecture ideas"
   default_prompt: "Use $meridian-brainstorm to generate Meridian-native ideas that fit the current workstation, governance, and fund-ops direction."

--- a/.codex/skills/meridian-browser-workstation/agents/openai.yaml
+++ b/.codex/skills/meridian-browser-workstation/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Meridian Browser Workstation"
+  display_name: "Build Browser Workstation"
   short_description: "Guide browser dashboard TypeScript/React work"
   default_prompt: "Use $meridian-browser-workstation to implement or review TypeScript/React changes in src/Meridian.Ui/dashboard with Meridian UI guardrails and dashboard-local validation."

--- a/.codex/skills/meridian-cleanup/agents/openai.yaml
+++ b/.codex/skills/meridian-cleanup/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Meridian Cleanup"
+  display_name: "Clean Up Meridian"
   short_description: "Clean Meridian code without behavior drift"
   default_prompt: "Use $meridian-cleanup to make this Meridian area easier to maintain without changing behavior or breaking shared contracts."

--- a/.codex/skills/meridian-code-architecture/agents/openai.yaml
+++ b/.codex/skills/meridian-code-architecture/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Meridian Code Architecture"
+  display_name: "Review Architecture"
   short_description: "Check Meridian architecture boundaries"
   default_prompt: "Use $meridian-code-architecture to review this Meridian module architecture for boundary drift and validation needs."

--- a/.codex/skills/meridian-code-review/agents/openai.yaml
+++ b/.codex/skills/meridian-code-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Meridian Code Review"
+  display_name: "Review Code"
   short_description: "Review Meridian changes for bugs and regressions"
   default_prompt: "Use $meridian-code-review to review this Meridian change for bugs, regressions, architecture drift, and missing tests."

--- a/.codex/skills/meridian-codex-skill-builder/agents/openai.yaml
+++ b/.codex/skills/meridian-codex-skill-builder/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Meridian Codex Skill Builder"
+  display_name: "Build Codex Skills"
   short_description: "Package Codex skills with evals"
   default_prompt: "Use $meridian-codex-skill-builder to create or audit a Meridian Codex skill package with scripts, evals, routing, and catalog coverage."

--- a/.codex/skills/meridian-contract-governance/agents/openai.yaml
+++ b/.codex/skills/meridian-contract-governance/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Meridian Contract Governance"
+  display_name: "Govern Contracts"
   short_description: "Trace shared contract impact"
   default_prompt: "Use $meridian-contract-governance to map this Meridian contract change across services, UI surfaces, tests, and docs."

--- a/.codex/skills/meridian-docs/agents/openai.yaml
+++ b/.codex/skills/meridian-docs/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Meridian Docs"
+  display_name: "Maintain Docs"
   short_description: "Keep Meridian docs accurate and scoped"
   default_prompt: "Use $meridian-docs to update Meridian documentation with repo-grounded evidence, minimal edits, narrow validation, and current desktop-app guidance."

--- a/.codex/skills/meridian-implementation-assurance/agents/openai.yaml
+++ b/.codex/skills/meridian-implementation-assurance/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Meridian Implementation Assurance"
+  display_name: "Ship With Evidence"
   short_description: "Ship Meridian changes with evidence gates"
   default_prompt: "Use $meridian-implementation-assurance to implement and verify this Meridian change with narrow validation, explicit evidence, performance review, and docs sync."

--- a/.codex/skills/meridian-provider-builder/agents/openai.yaml
+++ b/.codex/skills/meridian-provider-builder/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Meridian Provider Builder"
+  display_name: "Build Providers"
   short_description: "Build Meridian providers and adapter scaffolds"
   default_prompt: "Use $meridian-provider-builder to build or extend this Meridian provider while matching current provider SDK and resilience patterns."

--- a/.codex/skills/meridian-repo-navigation/agents/openai.yaml
+++ b/.codex/skills/meridian-repo-navigation/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Meridian Repo Navigation"
+  display_name: "Orient in Meridian"
   short_description: "Orient AI work inside Meridian"
   default_prompt: "Use $meridian-repo-navigation to classify this task, route it to the owning subsystem, and name the first files and docs to inspect."

--- a/.codex/skills/meridian-roadmap-strategist/agents/openai.yaml
+++ b/.codex/skills/meridian-roadmap-strategist/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Meridian Roadmap Strategist"
+  display_name: "Refresh Roadmaps"
   short_description: "Refresh Meridian roadmap and target-state docs"
   default_prompt: "Use $meridian-roadmap-strategist to refresh Meridian roadmap or target-state docs using the current workstation, provider-confidence, and governance delivery waves."

--- a/.codex/skills/meridian-simulated-user-panel/agents/openai.yaml
+++ b/.codex/skills/meridian-simulated-user-panel/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Meridian Simulated User Panel"
+  display_name: "Simulate User Panels"
   short_description: "Run manifest-driven, multi-mode user panels"
   default_prompt: "Use $meridian-simulated-user-panel with a review manifest to critique this Meridian artifact in design_partner, release_gate, or usability_lab mode and return rubric-backed owner actions."

--- a/.codex/skills/meridian-test-writer/agents/openai.yaml
+++ b/.codex/skills/meridian-test-writer/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Meridian Test Writer"
+  display_name: "Write Meridian Tests"
   short_description: "Write scenario-first Meridian regression tests"
   default_prompt: "Use $meridian-test-writer to add Meridian tests grounded in a real operator or market scenario across the full relevant code path."

--- a/.codex/skills/modular-desktop-mvvm/agents/openai.yaml
+++ b/.codex/skills/modular-desktop-mvvm/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Modular Desktop MVVM"
+  display_name: "Build Desktop MVVM"
   short_description: "Implement modular WPF MVVM workstation changes"
   default_prompt: "Use $modular-desktop-mvvm to implement this Meridian desktop change with reusable MVVM modules, tests, and resource guardrails."

--- a/.codex/skills/performance-resource-review/agents/openai.yaml
+++ b/.codex/skills/performance-resource-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Performance Resource Review"
+  display_name: "Review Resource Risk"
   short_description: "Review Meridian changes for resource risk"
   default_prompt: "Use $performance-resource-review to scan this Meridian change for memory, CPU, I/O, rendering, concurrency, and lifecycle risks."

--- a/.codex/skills/provider-management-workflow/agents/openai.yaml
+++ b/.codex/skills/provider-management-workflow/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Provider Management Workflow"
+  display_name: "Manage Providers"
   short_description: "Build secure provider management workflows"
   default_prompt: "Use $provider-management-workflow to implement provider setup, credential, health, degradation, or validation workflows in Meridian."

--- a/.codex/skills/research-data-acquisition/agents/openai.yaml
+++ b/.codex/skills/research-data-acquisition/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Research Data Acquisition"
+  display_name: "Acquire Research Data"
   short_description: "Build research data acquisition workflows"
   default_prompt: "Use $research-data-acquisition to add a research-data acquisition flow with provider reuse, cancellation, paging, lineage, and tests."

--- a/.codex/skills/safe-refactoring/agents/openai.yaml
+++ b/.codex/skills/safe-refactoring/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Safe Refactoring"
+  display_name: "Refactor Safely"
   short_description: "Refactor Meridian code without behavior drift"
   default_prompt: "Use $safe-refactoring to plan and execute this Meridian refactor incrementally while preserving behavior and tests."

--- a/.codex/skills/shared-component-extraction/agents/openai.yaml
+++ b/.codex/skills/shared-component-extraction/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Shared Component Extraction"
+  display_name: "Extract Shared Components"
   short_description: "Extract reusable desktop controls and view models"
   default_prompt: "Use $shared-component-extraction to consolidate repeated Meridian desktop patterns into reusable controls, commands, services, or view models."

--- a/.codex/skills/workstation-screen-composition/agents/openai.yaml
+++ b/.codex/skills/workstation-screen-composition/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Workstation Screen Composition"
+  display_name: "Compose Workstation Screens"
   short_description: "Compose desktop workspaces from shared primitives"
   default_prompt: "Use $workstation-screen-composition to design or implement this workstation screen from shared layout, command, state, and navigation primitives."


### PR DESCRIPTION
### Motivation
- Make repository-local Codex skills easier to scan in the Codex UI by using shorter, action-oriented `display_name` labels. 
- Preserve existing invocation semantics and routing so implicit/explicit skill triggers remain unchanged. 
- Keep UI metadata concise to improve progressive-disclosure matching without changing skill behavior.

### Description
- Updated the `display_name` field in `agents/openai.yaml` for 26 repo-local skills under `.codex/skills/*/agents/openai.yaml` to shorter, verb-led labels (examples: `Build Codex Skills`, `Build Providers`, `Orient in Meridian`).
- Preserved each skill's `short_description`, `default_prompt`, and the stable `$skill-name` identifiers referenced in `SKILL.md` and routing.
- This change is metadata-only (UI-facing) and does not modify any `SKILL.md` frontmatter `name` or `description` values, scripts, or skill workflows.

### Testing
- Ran `python build/scripts/docs/check-codex-skills.py --summary` and it passed.
- Ran `python build/scripts/docs/check-ai-inventory.py --summary` and it passed.
- Ran `python build/scripts/docs/validate-skill-packages.py` and the validation passed.
- Ran the skill-package audit and eval dry-run for the skill builder with `python .codex/skills/meridian-codex-skill-builder/scripts/skill_package_audit.py --skill meridian-codex-skill-builder --summary` and `python .codex/skills/meridian-codex-skill-builder/scripts/run_evals.py --all --dry-run --summary`, and both passed; `git diff --check` returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32c3b7e00883209c1a9e9dbc4bf626)