### PR TITLE
Move WPF feature registrations into feature modules

### DIFF
--- a/src/Meridian.Wpf/App.xaml.cs
+++ b/src/Meridian.Wpf/App.xaml.cs
@@ -289,11 +289,6 @@ public partial class App : System.Windows.Application
         services.AddSingleton<WpfServices.DesktopAuthenticationSession>();
         services.AddTransient<StartupWindowViewModel>();
         services.AddTransient<StartupWindow>();
-        services.AddSingleton<Meridian.Ui.Services.SetupWizardService>();
-        services.AddSingleton<WpfServices.ISetupWizardStateService, WpfServices.SetupWizardStateService>();
-        services.AddSingleton<WpfServices.ISetupWizardNotificationSink, WpfServices.SetupWizardNotificationSink>();
-        services.AddSingleton<WpfServices.ISetupWizardNavigator, WpfServices.SetupWizardNavigator>();
-        services.AddSingleton<WpfServices.ISetupWizardLinkLauncher, WpfServices.SetupWizardLinkLauncher>();
 
         // ── Onboarding / workspace services ──────────────────────────────────
         services.AddSingleton<Meridian.Ui.Services.OnboardingTourService>(_ => Meridian.Ui.Services.OnboardingTourService.Instance);
@@ -306,30 +301,6 @@ public partial class App : System.Windows.Application
         services.AddSingleton<Meridian.Ui.Services.AlertService>(_ => Meridian.Ui.Services.AlertService.Instance);
         services.AddSingleton<WpfServices.FundContextService>(_ => WpfServices.FundContextService.Instance);
         services.AddSingleton<WpfServices.IFundProfileCatalog>(sp => sp.GetRequiredService<WpfServices.FundContextService>());
-        services.AddSingleton(sp => new InMemoryFundAccountService(
-            Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "Meridian",
-                "fund-accounts.json")));
-        services.AddSingleton<IFundAccountService>(sp => sp.GetRequiredService<InMemoryFundAccountService>());
-        services.AddSingleton<IFundStructureService>(sp => new InMemoryFundStructureService(
-            sp.GetRequiredService<IFundAccountService>(),
-            sharedDataAccessService: null,
-            securityMasterQueryService: sp.GetService<Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService>(),
-            persistencePath: Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "Meridian",
-                "fund-structure.json")));
-        services.AddSingleton<FundStructureSetupWorkflowService>();
-        services.AddSingleton<EnvironmentDesignerService>(_ => new EnvironmentDesignerService(
-            Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "Meridian",
-                "environment-designer.json")));
-        services.AddSingleton<IEnvironmentDesignService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
-        services.AddSingleton<IEnvironmentValidationService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
-        services.AddSingleton<IEnvironmentPublishService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
-        services.AddSingleton<IEnvironmentRuntimeProjectionService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
         services.AddSingleton<WpfServices.WorkstationOperatingContextService>();
         services.AddSingleton<WpfServices.WorkspaceShellContextService>();
         services.AddSingleton<Meridian.Application.UI.ConfigStore>();
@@ -340,37 +311,15 @@ public partial class App : System.Windows.Application
         services.AddSingleton<WpfServices.IWatchlistReader>(sp => sp.GetRequiredService<WpfServices.WatchlistService>());
         services.AddSingleton<WpfServices.ArchiveHealthService>(_ => WpfServices.ArchiveHealthService.Instance);
         services.AddSingleton<WpfServices.SchemaService>(_ => WpfServices.SchemaService.Instance);
-        services.AddSingleton<WpfServices.RunMatService>(_ => WpfServices.RunMatService.Instance);
-        services.AddSingleton<ProviderManagementService>(_ => ProviderManagementService.Instance);
-        services.AddSingleton<AdminMaintenanceServiceBase>(_ => AdminMaintenanceServiceBase.Instance);
-        services.AddSingleton<IAdminMaintenanceService>(sp => sp.GetRequiredService<AdminMaintenanceServiceBase>());
-        services.AddSingleton<AdvancedAnalyticsServiceBase>(_ => new AdvancedAnalyticsServiceBase());
-        services.AddSingleton<SearchService>(_ => SearchService.Instance);
-        services.AddSingleton<WpfServices.FundAccountReadService>();
-        services.AddSingleton<WpfServices.FundLedgerReadService>();
-        services.AddSingleton<WpfServices.ReconciliationReadService>();
-        services.AddSingleton<WpfServices.CashFinancingReadService>();
-        services.AddSingleton<WpfServices.IWorkstationReconciliationApiClient, WpfServices.WorkstationReconciliationApiClient>();
-        services.AddSingleton<WpfServices.IWorkstationSecurityMasterApiClient, WpfServices.WorkstationSecurityMasterApiClient>();
-        services.AddSingleton<WpfServices.ISecurityAssetProfileWorkflowClient, WpfServices.SecurityAssetProfileWorkflowClient>();
-        services.AddSingleton<WpfServices.IOperationsControlCenterClient, WpfServices.OperationsControlCenterClient>();
-        services.AddSingleton<WpfServices.IWorkstationStrategyBriefingApiClient, WpfServices.WorkstationStrategyBriefingApiClient>();
-        services.AddSingleton<WpfServices.IWorkstationOperatorInboxApiClient, WpfServices.WorkstationOperatorInboxApiClient>();
-        services.AddSingleton<WpfServices.IStrategyBriefingWorkspaceService, WpfServices.StrategyBriefingWorkspaceService>();
-        services.AddSingleton<WpfServices.IFundReconciliationWorkbenchService, WpfServices.FundReconciliationWorkbenchService>();
-        services.AddSingleton<WpfServices.IStatementReconciliationWorkbenchService, WpfServices.StatementReconciliationWorkbenchService>();
-
-        // ── Data quality shared services ─────────────────────────────────────
-        services.AddSingleton<IDataQualityApiClient, DataQualityApiClient>();
-        services.AddSingleton<IDataQualityPresentationService, DataQualityPresentationService>();
-        services.AddTransient<IDataQualityRefreshService, DataQualityRefreshService>();
-        RegisterStrategyWorkspaceServices(services);
+        // Strategy workspace services register through StrategyFeatureModule.
 
         // ── Background / infrastructure services ────────────────────────────
         services.AddSingleton<WpfServices.BackgroundTaskSchedulerService>(_ => WpfServices.BackgroundTaskSchedulerService.Instance);
         services.AddSingleton<WpfServices.OfflineTrackingPersistenceService>(_ => WpfServices.OfflineTrackingPersistenceService.Instance);
         services.AddSingleton<WpfServices.PendingOperationsQueueService>(_ => WpfServices.PendingOperationsQueueService.Instance);
         services.AddSingleton<WpfServices.ToastNotificationService>(_ => WpfServices.ToastNotificationService.Instance);
+        services.AddSingleton<WpfServices.TaskbarProgressService>(_ => WpfServices.TaskbarProgressService.Instance);
+        services.AddSingleton<WpfServices.TearOffPanelService>(_ => WpfServices.TearOffPanelService.Instance);
         // C1 fix: register a single SystemTrayService instance under the interface contract;
         //         the concrete type is resolved via the same singleton.
         services.AddSingleton<WpfServices.SystemTrayService>();
@@ -383,127 +332,9 @@ public partial class App : System.Windows.Application
         // ── Catalog-driven WPF shell pages and shell services ───────────────
         services.AddMeridianWpfShell(configuration);
 
-        // ── Additional pages not yet catalog-backed ─────────────────────────
+        // ── Temporary legacy registrations not yet feature-owned ─────────────
         services.AddTransient<FundProfileSelectionPage>();
-        services.AddTransient<Meridian.Ui.Services.DataCalendarService>();
-        services.AddTransient<Meridian.Wpf.ViewModels.SecurityMasterViewModel>();
-        services.AddTransient<PluginManagementPage>();
-        services.AddTransient<QualityArchivePage>();
-
-        services.AddTransient<ClusterStatusPage>();
-
-        // ── Backtesting service ──────────────────────────────────────────────
-        // Registered in RegisterStrategyWorkspaceServices so optional Security Master
-        // collaborators can be attached when that feature is enabled.
-
-        // ── Ui.Services singletons accessed via DI (no static .Instance in pages) ──
-        services.AddSingleton<BackfillProviderConfigService>(_ => BackfillProviderConfigService.Instance);
-        services.AddSingleton<BackfillCheckpointService>(_ => BackfillCheckpointService.Instance);
-        services.AddSingleton<BackfillApiService>();
-        services.AddSingleton<Meridian.Ui.Services.CollectionSessionService>(_ => Meridian.Ui.Services.CollectionSessionService.Instance);
-        services.AddSingleton<Meridian.Ui.Services.ScheduleManagerService>(_ => Meridian.Ui.Services.ScheduleManagerService.Instance);
-        services.AddSingleton<WpfServices.StorageService>(_ => WpfServices.StorageService.Instance);
-        services.AddSingleton<WpfServices.WorkspaceStateTokenStore>();
-        services.AddSingleton<BatchExportSchedulerService>();
-        services.AddSingleton<Meridian.Ui.Services.ActivityFeedService>(_ => Meridian.Ui.Services.ActivityFeedService.Instance);
-        services.AddSingleton<Meridian.Ui.Services.CommandPaletteService>(_ => Meridian.Ui.Services.CommandPaletteService.Instance);
-        services.AddSingleton<Meridian.Ui.Services.SymbolManagementService>(_ => Meridian.Ui.Services.SymbolManagementService.Instance);
-        services.AddSingleton<Meridian.Ui.Services.BackfillService>(_ => Meridian.Ui.Services.BackfillService.Instance);
-        services.AddSingleton<WpfServices.TaskbarProgressService>(_ => WpfServices.TaskbarProgressService.Instance);
-        services.AddSingleton<WpfServices.TearOffPanelService>(_ => WpfServices.TearOffPanelService.Instance);
-
-        // ── ViewModels (transient — new instance per page navigation) ────────
-        services.AddTransient<Meridian.Wpf.ViewModels.BackfillViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.ProviderViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.DataQualityViewModel>();
         services.AddTransient<Meridian.Wpf.ViewModels.FundProfileSelectionViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.FundStructureSetupViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.FundAccountsViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.FundLedgerViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.FinancialRecordExplorerViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.RunMatViewModel>();
-        services.AddTransient(sp => new StrategyRunBrowserViewModel(
-            sp.GetRequiredService<WpfServices.StrategyRunWorkspaceService>(),
-            sp.GetRequiredService<WpfServices.NavigationService>(),
-            sp.GetRequiredService<WpfServices.WorkspaceService>()));
-        services.AddTransient(sp => new StrategyRunDetailViewModel(
-            sp.GetRequiredService<WpfServices.StrategyRunWorkspaceService>(),
-            sp.GetRequiredService<WpfServices.NavigationService>()));
-        services.AddTransient(sp => new StrategyRunPortfolioViewModel(
-            sp.GetRequiredService<WpfServices.StrategyRunWorkspaceService>(),
-            sp.GetRequiredService<WpfServices.NavigationService>()));
-        services.AddTransient(sp => new StrategyRunLedgerViewModel(
-            sp.GetRequiredService<WpfServices.StrategyRunWorkspaceService>(),
-            sp.GetRequiredService<WpfServices.NavigationService>()));
-        services.AddTransient<Meridian.Wpf.ViewModels.CashFlowViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.RunRiskViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.PluginManagementViewModel>();
-        services.AddSingleton<Meridian.Wpf.Services.BacktestDataAvailabilityService>();
-        services.AddTransient<IBatchBacktestService>(sp => new BatchBacktestService(
-            sp.GetRequiredService<ILogger<BatchBacktestService>>(),
-            request =>
-            {
-                var storageOptions = new StorageOptions { RootPath = request.DataRoot };
-                var catalogService = new StorageCatalogService(request.DataRoot, storageOptions);
-                return new BacktestEngine(
-                    sp.GetRequiredService<ILogger<BacktestEngine>>(),
-                    catalogService,
-                    sp.GetService<Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService>(),
-                    sp.GetService<Meridian.Backtesting.ICorporateActionAdjustmentService>(),
-                    sp.GetService<IBacktestPreflightService>());
-            }));
-        services.AddTransient<Meridian.Wpf.ViewModels.BacktestViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.BatchBacktestViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.ChartingPageViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.TickerStripViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.WatchlistViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.SettingsViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.SetupWizardViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.CollectionSessionViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.WorkflowLibraryViewModel>();
-
-        // ── Credential management ────────────────────────────────────────────
-        services.AddSingleton<WpfServices.CredentialService>();
-        services.AddTransient<Meridian.Wpf.ViewModels.CredentialManagementViewModel>();
-        services.AddTransient<Meridian.Wpf.ViewModels.AccountPortfolioViewModel>();
-
-        // ── Quality archive ──────────────────────────────────────────────────
-        services.AddSingleton<Meridian.Ui.Services.Services.IQualityArchiveStore,
-                              Meridian.Ui.Services.Services.QualityArchiveStore>();
-        services.AddTransient<Meridian.Wpf.ViewModels.QualityArchiveViewModel>();
-
-        // ── QuantScript services ─────────────────────────────────────────────
-        services.AddSingleton<Microsoft.Extensions.Options.IOptions<Meridian.QuantScript.QuantScriptOptions>>(sp =>
-        {
-            var configService = sp.GetRequiredService<WpfServices.ConfigService>();
-            var config = configService.LoadConfigAsync().GetAwaiter().GetResult();
-            var resolvedDataRoot = configService.ResolveDataRoot(config);
-            return Microsoft.Extensions.Options.Options.Create(new Meridian.QuantScript.QuantScriptOptions
-            {
-                DefaultDataRoot = resolvedDataRoot,
-                ScriptsDirectory = Path.Combine(AppContext.BaseDirectory, "scripts")
-            });
-        });
-        services.AddSingleton(sp =>
-        {
-            var options = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<Meridian.QuantScript.QuantScriptOptions>>().Value;
-            return new Meridian.Storage.Store.JsonlMarketDataStore(options.DefaultDataRoot);
-        });
-        services.AddSingleton<Meridian.QuantScript.Api.IQuantDataContext,
-                              Meridian.QuantScript.Api.QuantDataContext>();
-        services.AddSingleton<Meridian.QuantScript.Plotting.PlotQueue>();
-        services.AddSingleton<Meridian.QuantScript.Compilation.IQuantScriptCompiler,
-                              Meridian.QuantScript.Compilation.RoslynScriptCompiler>();
-        services.AddSingleton<Meridian.QuantScript.Compilation.IScriptRunner,
-                              Meridian.QuantScript.Compilation.ScriptRunner>();
-        services.AddSingleton<Meridian.QuantScript.Documents.IQuantScriptNotebookStore>(sp =>
-            new Meridian.QuantScript.Documents.QuantScriptNotebookStore(
-                sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<Meridian.QuantScript.QuantScriptOptions>>().Value));
-        services.AddSingleton<WpfServices.IQuantScriptLayoutService,
-                              WpfServices.QuantScriptLayoutService>();
-        services.AddSingleton<WpfServices.QuantScriptTemplateCatalogService>();
-        services.AddSingleton<WpfServices.QuantScriptExecutionHistoryService>();
-        services.AddTransient<Meridian.Wpf.ViewModels.QuantScriptViewModel>();
 
         // ── Plugin loader service ────────────────────────────────────────────
         services.AddSingleton<Meridian.Infrastructure.DataSources.DataSourceRegistry>();
@@ -534,124 +365,6 @@ public partial class App : System.Windows.Application
         public IFileProvider ContentRootFileProvider { get; set; } =
             new PhysicalFileProvider(AppContext.BaseDirectory);
     }
-
-    private static void RegisterStrategyWorkspaceServices(IServiceCollection services)
-    {
-        var securityMasterConnectionString = Environment.GetEnvironmentVariable("MERIDIAN_SECURITY_MASTER_CONNECTION_STRING");
-        if (!string.IsNullOrWhiteSpace(securityMasterConnectionString))
-        {
-            services.AddSingleton(sp => new SecurityMasterOptions
-            {
-                ConnectionString = securityMasterConnectionString,
-                Schema = Environment.GetEnvironmentVariable("MERIDIAN_SECURITY_MASTER_SCHEMA") ?? "security_master",
-                SnapshotIntervalVersions = ParseInt("MERIDIAN_SECURITY_MASTER_SNAPSHOT_INTERVAL", 50),
-                ProjectionReplayBatchSize = ParseInt("MERIDIAN_SECURITY_MASTER_REPLAY_BATCH_SIZE", 500),
-                PreloadProjectionCache = ParseBool("MERIDIAN_SECURITY_MASTER_PRELOAD_CACHE", true),
-                ResolveInactiveByDefault = ParseBool("MERIDIAN_SECURITY_MASTER_RESOLVE_INACTIVE", true)
-            });
-            services.AddSingleton<ISecurityMasterEventStore, PostgresSecurityMasterEventStore>();
-            services.AddSingleton<ISecurityMasterSnapshotStore, PostgresSecurityMasterSnapshotStore>();
-            services.AddSingleton<ISecurityMasterStore, PostgresSecurityMasterStore>();
-            services.AddSingleton<SecurityMasterAggregateRebuilder>();
-            services.AddSingleton<Meridian.Contracts.SecurityMaster.ISecurityMasterService, SecurityMasterService>();
-            services.AddSingleton<Meridian.Contracts.SecurityMaster.ISecurityMasterAmender>(sp =>
-                (Meridian.Contracts.SecurityMaster.ISecurityMasterAmender)sp.GetRequiredService<Meridian.Contracts.SecurityMaster.ISecurityMasterService>());
-            services.AddSingleton<SecurityMasterQueryService>();
-            services.AddSingleton<Meridian.Application.SecurityMaster.ISecurityMasterQueryService>(sp => sp.GetRequiredService<SecurityMasterQueryService>());
-            services.AddSingleton<Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService>(sp => sp.GetRequiredService<SecurityMasterQueryService>());
-            services.AddSingleton<ISecurityMasterRuntimeStatus>(_ => new WpfServices.SecurityMasterRuntimeStatusService(
-                isAvailable: true,
-                availabilityDescription: "Security Master runtime is configured for workstation workflows."));
-
-            // Security Master bulk import services
-            services.AddSingleton<SecurityMasterCsvParser>();
-            services.AddSingleton<ISecurityMasterImportService, SecurityMasterImportService>();
-
-            // Corporate action adjustment for backtesting and live paper trading.
-            services.AddSingleton<ISecurityResolver, SecurityResolver>();
-            services.AddSingleton<Meridian.Backtesting.CorporateActionAdjustmentService>();
-            services.AddSingleton<Meridian.Backtesting.ICorporateActionAdjustmentService>(
-                sp => sp.GetRequiredService<Meridian.Backtesting.CorporateActionAdjustmentService>());
-            services.AddSingleton<Meridian.Application.SecurityMaster.ILivePositionCorporateActionAdjuster>(
-                sp => sp.GetRequiredService<Meridian.Backtesting.CorporateActionAdjustmentService>());
-            services.AddSingleton<ITradingParametersBackfillService, TradingParametersBackfillService>();
-        }
-        else
-        {
-            services.AddSingleton<Meridian.Contracts.SecurityMaster.ISecurityMasterService, NullSecurityMasterService>();
-            services.AddSingleton<Meridian.Contracts.SecurityMaster.ISecurityMasterAmender>(sp =>
-                (Meridian.Contracts.SecurityMaster.ISecurityMasterAmender)sp.GetRequiredService<Meridian.Contracts.SecurityMaster.ISecurityMasterService>());
-            services.AddSingleton<NullSecurityMasterQueryService>();
-            services.AddSingleton<Meridian.Application.SecurityMaster.ISecurityMasterQueryService>(sp =>
-                sp.GetRequiredService<NullSecurityMasterQueryService>());
-            services.AddSingleton<Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService>(sp =>
-                sp.GetRequiredService<NullSecurityMasterQueryService>());
-            services.AddSingleton<ISecurityMasterRuntimeStatus>(sp =>
-                sp.GetRequiredService<NullSecurityMasterQueryService>());
-            services.AddSingleton<ISecurityMasterImportService, NullSecurityMasterImportService>();
-            services.AddSingleton<ITradingParametersBackfillService, NullTradingParametersBackfillService>();
-        }
-
-        services.AddSingleton<ISecurityReferenceLookup, SecurityMasterSecurityReferenceLookup>();
-        services.AddSingleton<IBacktestPreflightService, BacktestPreflightService>();
-
-        // Wire optional Security Master collaborators into the BacktestService singleton when available.
-        services.AddSingleton(sp =>
-        {
-            var svc = WpfServices.BacktestService.Instance;
-            svc.SecurityMasterQueryService = sp.GetService<Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService>();
-            svc.CorporateActionAdjustmentService = sp.GetService<Meridian.Backtesting.ICorporateActionAdjustmentService>();
-            svc.BacktestPreflightService = sp.GetService<IBacktestPreflightService>();
-            return svc;
-        });
-
-        services.AddSingleton<IStrategyRepository, StrategyRunStore>();
-        services.AddSingleton<PromotionRecordStoreOptions>(sp =>
-        {
-            var configService = sp.GetRequiredService<WpfServices.ConfigService>();
-            var config = configService.LoadConfigAsync().GetAwaiter().GetResult();
-            var resolvedDataRoot = configService.ResolveDataRoot(config);
-            return new PromotionRecordStoreOptions(Path.Combine(resolvedDataRoot, "strategies", "promotions"));
-        });
-        services.AddSingleton<IPromotionRecordStore, JsonlPromotionRecordStore>();
-        services.AddSingleton<PortfolioReadService>();
-        services.AddSingleton<LedgerReadService>();
-        services.AddSingleton<StrategyRunReadService>();
-        services.AddSingleton<IReconciliationRunRepository, InMemoryReconciliationRunRepository>();
-        services.AddSingleton<ReconciliationProjectionService>();
-        services.AddSingleton<IReconciliationRunService, ReconciliationRunService>();
-        services.AddSingleton<CashFlowProjectionService>();
-        services.AddSingleton<StrategyRunContinuityService>();
-        services.AddSingleton(BrokeragePortfolioSyncOptions.Default);
-        services.AddSingleton<BrokeragePortfolioSyncService>();
-        services.AddSingleton(Dk1TrustGateReadinessOptions.Default);
-        services.AddSingleton<Dk1TrustGateReadinessService>();
-        services.AddSingleton<TradingOperatorReadinessService>();
-        services.AddSingleton<StrategyRunReviewPacketService>();
-        services.AddWorkflowLibrary();
-        services.AddSingleton<WorkstationWorkflowSummaryService>();
-        services.AddSingleton<Meridian.Strategies.Promotions.BacktestToLivePromoter>();
-        services.AddSingleton<PromotionService>();
-        services.AddSingleton<NavAttributionService>();
-        services.AddSingleton<ReportGenerationService>();
-        services.AddSingleton<FundOperationsWorkspaceReadService>();
-        services.AddSingleton<ISecurityMasterOperatorWorkflowClient, SecurityMasterOperatorWorkflowClient>();
-        services.AddSingleton<WpfServices.StrategyRunWorkspaceService>(sp =>
-        {
-            var service = new WpfServices.StrategyRunWorkspaceService(
-                sp.GetRequiredService<IStrategyRepository>(),
-                sp.GetRequiredService<StrategyRunReadService>(),
-                sp.GetService<BrokerageConfiguration>());
-            WpfServices.StrategyRunWorkspaceService.SetInstance(service);
-            return service;
-        });
-    }
-
-    private static int ParseInt(string name, int defaultValue)
-        => int.TryParse(Environment.GetEnvironmentVariable(name), out var value) ? value : defaultValue;
-
-    private static bool ParseBool(string name, bool defaultValue)
-        => bool.TryParse(Environment.GetEnvironmentVariable(name), out var value) ? value : defaultValue;
 
     /// <summary>
     /// Performs async initialization with proper exception handling.

--- a/src/Meridian.Wpf/Features/Accounting/AccountingFeatureModule.cs
+++ b/src/Meridian.Wpf/Features/Accounting/AccountingFeatureModule.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Meridian.Application.FundStructure;
 using Meridian.FinancialOperations.AccountingClose;
 using Meridian.DataIntegration.AccountingSystem.QuickBooks;
 using Meridian.Contracts.Ledger;
@@ -8,6 +9,7 @@ using Meridian.FinancialOperations.AccountingSystem;
 using Meridian.FinancialOperations.Ledger;
 using Meridian.FinancialOperations.OperationsContinuity;
 using Meridian.FinancialOperations.PrivateCapital;
+using Meridian.PortfolioRecords.FundAccounts;
 using Meridian.ProviderSdk.AccountingSystem;
 using Meridian.Ui.Services.Services.Accounting;
 using Meridian.Ui.Shared.Services;
@@ -33,6 +35,31 @@ public sealed class AccountingFeatureModule : IDesktopFeatureModule
         services.AddTransient<AccountingWorkspaceShellStateProvider>();
         services.AddTransient<AccountingWorkspaceShellViewModel>();
         services.AddTransient<AccountingWorkspaceShellPage>();
+        services.AddSingleton(sp => new InMemoryFundAccountService(
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Meridian",
+                "fund-accounts.json")));
+        services.AddSingleton<IFundAccountService>(sp => sp.GetRequiredService<InMemoryFundAccountService>());
+        services.AddSingleton<IFundStructureService>(sp => new InMemoryFundStructureService(
+            sp.GetRequiredService<IFundAccountService>(),
+            sharedDataAccessService: null,
+            securityMasterQueryService: sp.GetService<Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService>(),
+            persistencePath: Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Meridian",
+                "fund-structure.json")));
+        services.AddSingleton<FundStructureSetupWorkflowService>();
+        services.AddSingleton<FundAccountReadService>();
+        services.AddSingleton<FundLedgerReadService>();
+        services.AddSingleton<ReconciliationReadService>();
+        services.AddSingleton<CashFinancingReadService>();
+        services.AddSingleton<IWorkstationReconciliationApiClient, WorkstationReconciliationApiClient>();
+        services.AddSingleton<IWorkstationSecurityMasterApiClient, WorkstationSecurityMasterApiClient>();
+        services.AddSingleton<ISecurityAssetProfileWorkflowClient, SecurityAssetProfileWorkflowClient>();
+        services.AddSingleton<IOperationsControlCenterClient, OperationsControlCenterClient>();
+        services.AddSingleton<IFundReconciliationWorkbenchService, FundReconciliationWorkbenchService>();
+        services.AddSingleton<IStatementReconciliationWorkbenchService, StatementReconciliationWorkbenchService>();
         services.TryAddSingleton<AccountingPostingService>();
         services.TryAddSingleton<TrialBalanceProjectionService>();
         services.TryAddSingleton<MonthEndCloseStateMachine>();
@@ -73,6 +100,11 @@ public sealed class AccountingFeatureModule : IDesktopFeatureModule
         services.AddTransient<AccountingConfigureViewModel>();
         services.AddTransient<AccountingConfigurePage>();
         services.AddTransient<AccountingCloseViewModel>();
+        services.AddTransient<FundStructureSetupViewModel>();
+        services.AddTransient<FundAccountsViewModel>();
+        services.AddTransient<FundLedgerViewModel>();
+        services.AddTransient<FinancialRecordExplorerViewModel>();
+        services.AddTransient<AccountPortfolioViewModel>();
     }
 
     public IReadOnlyList<ShellPageDescriptor> DescribePages() => Capability.Pages;

--- a/src/Meridian.Wpf/Features/Data/DataFeatureModule.cs
+++ b/src/Meridian.Wpf/Features/Data/DataFeatureModule.cs
@@ -1,10 +1,13 @@
 using Meridian.Core.Config;
 using Meridian.Ui.Services;
+using Meridian.Ui.Services.DataQuality;
+using Meridian.Ui.Services.Services;
 using Meridian.Wpf.Copy;
 using Meridian.Wpf.Features.Data.Shell;
 using Meridian.Wpf.Models;
 using Meridian.Wpf.Services;
 using Meridian.Wpf.Shell.Services;
+using Meridian.Wpf.ViewModels;
 using Meridian.Wpf.Views;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -55,6 +58,32 @@ public sealed class DataFeatureModule : IDesktopFeatureModule
         services.AddWorkspaceScoped<IDataWorkspaceShellPresentationService, DataWorkspaceShellPresentationService>();
         services.AddTransient<DataWorkspaceShellViewModel>();
         services.AddTransient<DataWorkspaceShellPage>();
+        services.AddTransient<DataCalendarService>();
+        services.AddTransient<SecurityMasterViewModel>();
+        services.AddTransient<QualityArchivePage>();
+        services.AddTransient<ClusterStatusPage>();
+        services.AddSingleton<BackfillProviderConfigService>(_ => BackfillProviderConfigService.Instance);
+        services.AddSingleton<BackfillCheckpointService>(_ => BackfillCheckpointService.Instance);
+        services.AddSingleton<BackfillApiService>();
+        services.AddSingleton<CollectionSessionService>(_ => CollectionSessionService.Instance);
+        services.AddSingleton<ScheduleManagerService>(_ => ScheduleManagerService.Instance);
+        services.AddSingleton<Meridian.Wpf.Services.StorageService>(_ => Meridian.Wpf.Services.StorageService.Instance);
+        services.AddSingleton<WorkspaceStateTokenStore>();
+        services.AddSingleton<BatchExportSchedulerService>();
+        services.AddSingleton<ActivityFeedService>(_ => ActivityFeedService.Instance);
+        services.AddSingleton<CommandPaletteService>(_ => CommandPaletteService.Instance);
+        services.AddSingleton<SymbolManagementService>(_ => SymbolManagementService.Instance);
+        services.AddSingleton<BackfillService>(_ => BackfillService.Instance);
+        services.AddSingleton<IDataQualityApiClient, DataQualityApiClient>();
+        services.AddSingleton<IDataQualityPresentationService, DataQualityPresentationService>();
+        services.AddTransient<IDataQualityRefreshService, DataQualityRefreshService>();
+        services.AddTransient<BackfillViewModel>();
+        services.AddTransient<ProviderViewModel>();
+        services.AddTransient<DataQualityViewModel>();
+        services.AddTransient<CollectionSessionViewModel>();
+        services.AddTransient<WatchlistViewModel>();
+        services.AddSingleton<IQualityArchiveStore, QualityArchiveStore>();
+        services.AddTransient<QualityArchiveViewModel>();
     }
 
     public IReadOnlyList<ShellPageDescriptor> DescribePages() => Pages;

--- a/src/Meridian.Wpf/Features/Settings/SettingsFeatureModule.cs
+++ b/src/Meridian.Wpf/Features/Settings/SettingsFeatureModule.cs
@@ -1,10 +1,13 @@
 using Meridian.Core.Config;
 using Meridian.Ui.Services;
+using Meridian.Ui.Services.Services;
+using Meridian.Workflow.EnvironmentDesign;
 using Meridian.Wpf.Copy;
 using Meridian.Wpf.Features.Settings.Shell;
 using Meridian.Wpf.Models;
 using Meridian.Wpf.Services;
 using Meridian.Wpf.Shell.Services;
+using Meridian.Wpf.ViewModels;
 using Meridian.Wpf.Views;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -41,6 +44,31 @@ public sealed class SettingsFeatureModule : IDesktopFeatureModule
         services.AddWorkspaceScoped<ISettingsWorkspaceShellPresentationService, SettingsWorkspaceShellPresentationService>();
         services.AddTransient<SettingsWorkspaceShellViewModel>();
         services.AddTransient<SettingsWorkspaceShellPage>();
+        services.AddSingleton<ProviderManagementService>(_ => ProviderManagementService.Instance);
+        services.AddSingleton<AdminMaintenanceServiceBase>(_ => AdminMaintenanceServiceBase.Instance);
+        services.AddSingleton<IAdminMaintenanceService>(sp => sp.GetRequiredService<AdminMaintenanceServiceBase>());
+        services.AddSingleton<SearchService>(_ => SearchService.Instance);
+        services.AddSingleton<SetupWizardService>();
+        services.AddSingleton<ISetupWizardStateService, SetupWizardStateService>();
+        services.AddSingleton<ISetupWizardNotificationSink, SetupWizardNotificationSink>();
+        services.AddSingleton<ISetupWizardNavigator, SetupWizardNavigator>();
+        services.AddSingleton<ISetupWizardLinkLauncher, SetupWizardLinkLauncher>();
+        services.AddSingleton<EnvironmentDesignerService>(_ => new EnvironmentDesignerService(
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Meridian",
+                "environment-designer.json")));
+        services.AddSingleton<IEnvironmentDesignService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
+        services.AddSingleton<IEnvironmentValidationService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
+        services.AddSingleton<IEnvironmentPublishService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
+        services.AddSingleton<IEnvironmentRuntimeProjectionService>(sp => sp.GetRequiredService<EnvironmentDesignerService>());
+        services.AddTransient<PluginManagementPage>();
+        services.AddTransient<PluginManagementViewModel>();
+        services.AddTransient<SettingsViewModel>();
+        services.AddTransient<SetupWizardViewModel>();
+        services.AddTransient<WorkflowLibraryViewModel>();
+        services.AddSingleton<CredentialService>();
+        services.AddTransient<CredentialManagementViewModel>();
     }
 
     public IReadOnlyList<ShellPageDescriptor> DescribePages() => Pages;

--- a/src/Meridian.Wpf/Features/Strategy/StrategyFeatureModule.cs
+++ b/src/Meridian.Wpf/Features/Strategy/StrategyFeatureModule.cs
@@ -1,4 +1,27 @@
 using Meridian.Wpf.Models;
+using System.IO;
+using Meridian.Application.SecurityMaster;
+using Meridian.Application.Services;
+using Meridian.Backtesting;
+using Meridian.Backtesting.Engine;
+using Meridian.Contracts.Domain.Enums;
+using Meridian.Contracts.SecurityMaster;
+using Meridian.Contracts.Services;
+using Meridian.Execution.Sdk;
+using Meridian.Reporting;
+using Meridian.Storage;
+using Meridian.Storage.SecurityMaster;
+using Meridian.Storage.Services;
+using Meridian.Storage.Store;
+using Meridian.Strategies.Interfaces;
+using Meridian.Strategies.Services;
+using Meridian.Strategies.Storage;
+using Meridian.Ui.Services;
+using Meridian.Ui.Shared.Services;
+using Microsoft.Extensions.Logging;
+using Meridian.Ui.Shared.Workflows;
+using Meridian.Wpf.ViewModels;
+using WpfServices = Meridian.Wpf.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Meridian.Wpf.Features.Strategy;
@@ -10,7 +33,185 @@ public sealed class StrategyFeatureModule : IDesktopFeatureModule
     public void Register(IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
+
+        RegisterStrategyWorkspaceServices(services);
+        services.AddSingleton<AdvancedAnalyticsServiceBase>(_ => new AdvancedAnalyticsServiceBase());
+        services.AddSingleton<WpfServices.RunMatService>(_ => WpfServices.RunMatService.Instance);
+        services.AddTransient<RunMatViewModel>();
+        services.AddTransient(sp => new StrategyRunBrowserViewModel(
+            sp.GetRequiredService<WpfServices.StrategyRunWorkspaceService>(),
+            sp.GetRequiredService<WpfServices.NavigationService>(),
+            sp.GetRequiredService<WpfServices.WorkspaceService>()));
+        services.AddTransient(sp => new StrategyRunDetailViewModel(
+            sp.GetRequiredService<WpfServices.StrategyRunWorkspaceService>(),
+            sp.GetRequiredService<WpfServices.NavigationService>()));
+        services.AddTransient(sp => new StrategyRunPortfolioViewModel(
+            sp.GetRequiredService<WpfServices.StrategyRunWorkspaceService>(),
+            sp.GetRequiredService<WpfServices.NavigationService>()));
+        services.AddTransient(sp => new StrategyRunLedgerViewModel(
+            sp.GetRequiredService<WpfServices.StrategyRunWorkspaceService>(),
+            sp.GetRequiredService<WpfServices.NavigationService>()));
+        services.AddTransient<CashFlowViewModel>();
+        services.AddSingleton<WpfServices.BacktestDataAvailabilityService>();
+        services.AddTransient<IBatchBacktestService>(sp => new BatchBacktestService(
+            sp.GetRequiredService<ILogger<BatchBacktestService>>(),
+            request =>
+            {
+                var storageOptions = new StorageOptions { RootPath = request.DataRoot };
+                var catalogService = new StorageCatalogService(request.DataRoot, storageOptions);
+                return new BacktestEngine(
+                    sp.GetRequiredService<ILogger<BacktestEngine>>(),
+                    catalogService,
+                    sp.GetService<Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService>(),
+                    sp.GetService<Meridian.Backtesting.ICorporateActionAdjustmentService>(),
+                    sp.GetService<IBacktestPreflightService>());
+            }));
+        services.AddTransient<BacktestViewModel>();
+        services.AddTransient<BatchBacktestViewModel>();
+        services.AddTransient<ChartingPageViewModel>();
+        services.AddTransient<TickerStripViewModel>();
+        services.AddSingleton<Microsoft.Extensions.Options.IOptions<Meridian.QuantScript.QuantScriptOptions>>(sp =>
+        {
+            var configService = sp.GetRequiredService<WpfServices.ConfigService>();
+            var config = configService.LoadConfigAsync().GetAwaiter().GetResult();
+            var resolvedDataRoot = configService.ResolveDataRoot(config);
+            return Microsoft.Extensions.Options.Options.Create(new Meridian.QuantScript.QuantScriptOptions
+            {
+                DefaultDataRoot = resolvedDataRoot,
+                ScriptsDirectory = Path.Combine(AppContext.BaseDirectory, "scripts")
+            });
+        });
+        services.AddSingleton(sp =>
+        {
+            var options = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<Meridian.QuantScript.QuantScriptOptions>>().Value;
+            return new JsonlMarketDataStore(options.DefaultDataRoot);
+        });
+        services.AddSingleton<Meridian.QuantScript.Api.IQuantDataContext, Meridian.QuantScript.Api.QuantDataContext>();
+        services.AddSingleton<Meridian.QuantScript.Plotting.PlotQueue>();
+        services.AddSingleton<Meridian.QuantScript.Compilation.IQuantScriptCompiler, Meridian.QuantScript.Compilation.RoslynScriptCompiler>();
+        services.AddSingleton<Meridian.QuantScript.Compilation.IScriptRunner, Meridian.QuantScript.Compilation.ScriptRunner>();
+        services.AddSingleton<Meridian.QuantScript.Documents.IQuantScriptNotebookStore>(sp =>
+            new Meridian.QuantScript.Documents.QuantScriptNotebookStore(
+                sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<Meridian.QuantScript.QuantScriptOptions>>().Value));
+        services.AddSingleton<WpfServices.IQuantScriptLayoutService, WpfServices.QuantScriptLayoutService>();
+        services.AddSingleton<WpfServices.QuantScriptTemplateCatalogService>();
+        services.AddSingleton<WpfServices.QuantScriptExecutionHistoryService>();
+        services.AddTransient<QuantScriptViewModel>();
     }
+
+    private static void RegisterStrategyWorkspaceServices(IServiceCollection services)
+    {
+        var securityMasterConnectionString = Environment.GetEnvironmentVariable("MERIDIAN_SECURITY_MASTER_CONNECTION_STRING");
+        if (!string.IsNullOrWhiteSpace(securityMasterConnectionString))
+        {
+            services.AddSingleton(sp => new SecurityMasterOptions
+            {
+                ConnectionString = securityMasterConnectionString,
+                Schema = Environment.GetEnvironmentVariable("MERIDIAN_SECURITY_MASTER_SCHEMA") ?? "security_master",
+                SnapshotIntervalVersions = ParseInt("MERIDIAN_SECURITY_MASTER_SNAPSHOT_INTERVAL", 50),
+                ProjectionReplayBatchSize = ParseInt("MERIDIAN_SECURITY_MASTER_REPLAY_BATCH_SIZE", 500),
+                PreloadProjectionCache = ParseBool("MERIDIAN_SECURITY_MASTER_PRELOAD_CACHE", true),
+                ResolveInactiveByDefault = ParseBool("MERIDIAN_SECURITY_MASTER_RESOLVE_INACTIVE", true)
+            });
+            services.AddSingleton<ISecurityMasterEventStore, PostgresSecurityMasterEventStore>();
+            services.AddSingleton<ISecurityMasterSnapshotStore, PostgresSecurityMasterSnapshotStore>();
+            services.AddSingleton<ISecurityMasterStore, PostgresSecurityMasterStore>();
+            services.AddSingleton<SecurityMasterAggregateRebuilder>();
+            services.AddSingleton<Meridian.Contracts.SecurityMaster.ISecurityMasterService, SecurityMasterService>();
+            services.AddSingleton<Meridian.Contracts.SecurityMaster.ISecurityMasterAmender>(sp =>
+                (Meridian.Contracts.SecurityMaster.ISecurityMasterAmender)sp.GetRequiredService<Meridian.Contracts.SecurityMaster.ISecurityMasterService>());
+            services.AddSingleton<SecurityMasterQueryService>();
+            services.AddSingleton<Meridian.Application.SecurityMaster.ISecurityMasterQueryService>(sp => sp.GetRequiredService<SecurityMasterQueryService>());
+            services.AddSingleton<Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService>(sp => sp.GetRequiredService<SecurityMasterQueryService>());
+            services.AddSingleton<ISecurityMasterRuntimeStatus>(_ => new WpfServices.SecurityMasterRuntimeStatusService(
+                isAvailable: true,
+                availabilityDescription: "Security Master runtime is configured for workstation workflows."));
+            services.AddSingleton<SecurityMasterCsvParser>();
+            services.AddSingleton<ISecurityMasterImportService, SecurityMasterImportService>();
+            services.AddSingleton<ISecurityResolver, SecurityResolver>();
+            services.AddSingleton<Meridian.Backtesting.CorporateActionAdjustmentService>();
+            services.AddSingleton<Meridian.Backtesting.ICorporateActionAdjustmentService>(
+                sp => sp.GetRequiredService<Meridian.Backtesting.CorporateActionAdjustmentService>());
+            services.AddSingleton<Meridian.Application.SecurityMaster.ILivePositionCorporateActionAdjuster>(
+                sp => sp.GetRequiredService<Meridian.Backtesting.CorporateActionAdjustmentService>());
+            services.AddSingleton<ITradingParametersBackfillService, TradingParametersBackfillService>();
+        }
+        else
+        {
+            services.AddSingleton<Meridian.Contracts.SecurityMaster.ISecurityMasterService, NullSecurityMasterService>();
+            services.AddSingleton<Meridian.Contracts.SecurityMaster.ISecurityMasterAmender>(sp =>
+                (Meridian.Contracts.SecurityMaster.ISecurityMasterAmender)sp.GetRequiredService<Meridian.Contracts.SecurityMaster.ISecurityMasterService>());
+            services.AddSingleton<NullSecurityMasterQueryService>();
+            services.AddSingleton<Meridian.Application.SecurityMaster.ISecurityMasterQueryService>(sp =>
+                sp.GetRequiredService<NullSecurityMasterQueryService>());
+            services.AddSingleton<Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService>(sp =>
+                sp.GetRequiredService<NullSecurityMasterQueryService>());
+            services.AddSingleton<ISecurityMasterRuntimeStatus>(sp =>
+                sp.GetRequiredService<NullSecurityMasterQueryService>());
+            services.AddSingleton<ISecurityMasterImportService, NullSecurityMasterImportService>();
+            services.AddSingleton<ITradingParametersBackfillService, NullTradingParametersBackfillService>();
+        }
+
+        services.AddSingleton<ISecurityReferenceLookup, SecurityMasterSecurityReferenceLookup>();
+        services.AddSingleton<IBacktestPreflightService, BacktestPreflightService>();
+        services.AddSingleton(sp =>
+        {
+            var svc = WpfServices.BacktestService.Instance;
+            svc.SecurityMasterQueryService = sp.GetService<Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService>();
+            svc.CorporateActionAdjustmentService = sp.GetService<Meridian.Backtesting.ICorporateActionAdjustmentService>();
+            svc.BacktestPreflightService = sp.GetService<IBacktestPreflightService>();
+            return svc;
+        });
+        services.AddSingleton<IStrategyRepository, StrategyRunStore>();
+        services.AddSingleton<PromotionRecordStoreOptions>(sp =>
+        {
+            var configService = sp.GetRequiredService<WpfServices.ConfigService>();
+            var config = configService.LoadConfigAsync().GetAwaiter().GetResult();
+            var resolvedDataRoot = configService.ResolveDataRoot(config);
+            return new PromotionRecordStoreOptions(Path.Combine(resolvedDataRoot, "strategies", "promotions"));
+        });
+        services.AddSingleton<IPromotionRecordStore, JsonlPromotionRecordStore>();
+        services.AddSingleton<PortfolioReadService>();
+        services.AddSingleton<LedgerReadService>();
+        services.AddSingleton<StrategyRunReadService>();
+        services.AddSingleton<IReconciliationRunRepository, InMemoryReconciliationRunRepository>();
+        services.AddSingleton<ReconciliationProjectionService>();
+        services.AddSingleton<IReconciliationRunService, ReconciliationRunService>();
+        services.AddSingleton<CashFlowProjectionService>();
+        services.AddSingleton<StrategyRunContinuityService>();
+        services.AddSingleton(BrokeragePortfolioSyncOptions.Default);
+        services.AddSingleton<BrokeragePortfolioSyncService>();
+        services.AddSingleton(Dk1TrustGateReadinessOptions.Default);
+        services.AddSingleton<Dk1TrustGateReadinessService>();
+        services.AddSingleton<TradingOperatorReadinessService>();
+        services.AddSingleton<StrategyRunReviewPacketService>();
+        services.AddWorkflowLibrary();
+        services.AddSingleton<WorkstationWorkflowSummaryService>();
+        services.AddSingleton<WpfServices.IWorkstationStrategyBriefingApiClient, WpfServices.WorkstationStrategyBriefingApiClient>();
+        services.AddSingleton<WpfServices.IWorkstationOperatorInboxApiClient, WpfServices.WorkstationOperatorInboxApiClient>();
+        services.AddSingleton<WpfServices.IStrategyBriefingWorkspaceService, WpfServices.StrategyBriefingWorkspaceService>();
+        services.AddSingleton<Meridian.Strategies.Promotions.BacktestToLivePromoter>();
+        services.AddSingleton<PromotionService>();
+        services.AddSingleton<NavAttributionService>();
+        services.AddSingleton<ReportGenerationService>();
+        services.AddSingleton<FundOperationsWorkspaceReadService>();
+        services.AddSingleton<ISecurityMasterOperatorWorkflowClient, SecurityMasterOperatorWorkflowClient>();
+        services.AddSingleton<WpfServices.StrategyRunWorkspaceService>(sp =>
+        {
+            var service = new WpfServices.StrategyRunWorkspaceService(
+                sp.GetRequiredService<IStrategyRepository>(),
+                sp.GetRequiredService<StrategyRunReadService>(),
+                sp.GetService<BrokerageConfiguration>());
+            WpfServices.StrategyRunWorkspaceService.SetInstance(service);
+            return service;
+        });
+    }
+
+    private static int ParseInt(string name, int defaultValue)
+        => int.TryParse(Environment.GetEnvironmentVariable(name), out var value) ? value : defaultValue;
+
+    private static bool ParseBool(string name, bool defaultValue)
+        => bool.TryParse(Environment.GetEnvironmentVariable(name), out var value) ? value : defaultValue;
 
     public IReadOnlyList<ShellPageDescriptor> DescribePages() => Capability.Pages;
 

--- a/src/Meridian.Wpf/Features/Trading/TradingFeatureModule.cs
+++ b/src/Meridian.Wpf/Features/Trading/TradingFeatureModule.cs
@@ -30,6 +30,7 @@ public sealed class TradingFeatureModule : IDesktopFeatureModule
         services.AddTransient<TradingWorkspaceShellStateProvider>();
         services.AddTransient<TradingWorkspaceShellViewModel>();
         services.AddTransient<TradingWorkspaceShellPage>();
+        services.AddTransient<RunRiskViewModel>();
     }
 
     public IReadOnlyList<ShellPageDescriptor> DescribePages() => Pages;

--- a/tests/Meridian.Wpf.Tests/Features/Accounting/AccountingFeatureServiceRegistrationTests.cs
+++ b/tests/Meridian.Wpf.Tests/Features/Accounting/AccountingFeatureServiceRegistrationTests.cs
@@ -1,0 +1,44 @@
+using Meridian.Wpf.Tests.Features;
+using Meridian.Application.FundStructure;
+using Meridian.FinancialOperations.PrivateCapital;
+using Meridian.PortfolioRecords.FundAccounts;
+using Meridian.Ui.Services.Services.Accounting;
+using Meridian.Ui.Shared.Services;
+using Meridian.Wpf.Features.Accounting;
+using Meridian.Wpf.Services;
+using Meridian.Wpf.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Wpf.Tests.Features.Accounting;
+
+public sealed class AccountingFeatureServiceRegistrationTests
+{
+    [Fact]
+    public void Register_ShouldOwnAccountingFeatureServicesWithConfiguredLifetimes()
+    {
+        var services = new ServiceCollection();
+
+        new AccountingFeatureModule().Register(services);
+
+        services.SingleDescriptor<InMemoryFundAccountService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IFundAccountService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IFundStructureService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<FundStructureSetupWorkflowService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<FundAccountReadService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<FundLedgerReadService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<ReconciliationReadService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<CashFinancingReadService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IWorkstationReconciliationApiClient>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IWorkstationSecurityMasterApiClient>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<ISecurityAssetProfileWorkflowClient>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IOperationsControlCenterClient>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IFundReconciliationWorkbenchService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IStatementReconciliationWorkbenchService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IPrivateCapitalCloseCockpitService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<FundStructureSetupViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<FundAccountsViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<FundLedgerViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<FinancialRecordExplorerViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<AccountPortfolioViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+    }
+}

--- a/tests/Meridian.Wpf.Tests/Features/Data/DataFeatureServiceRegistrationTests.cs
+++ b/tests/Meridian.Wpf.Tests/Features/Data/DataFeatureServiceRegistrationTests.cs
@@ -1,0 +1,45 @@
+using Meridian.Wpf.Tests.Features;
+using Meridian.Ui.Services;
+using Meridian.Ui.Services.DataQuality;
+using Meridian.Ui.Services.Services;
+using Meridian.Wpf.Features.Data;
+using Meridian.Wpf.Services;
+using Meridian.Wpf.ViewModels;
+using Meridian.Wpf.Views;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Wpf.Tests.Features.Data;
+
+public sealed class DataFeatureServiceRegistrationTests
+{
+    [Fact]
+    public void Register_ShouldOwnDataFeatureServicesWithConfiguredLifetimes()
+    {
+        var services = new ServiceCollection();
+
+        new DataFeatureModule().Register(services);
+
+        services.SingleDescriptor<BackfillProviderConfigService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<BackfillCheckpointService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<BackfillApiService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<CollectionSessionService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<ScheduleManagerService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<StorageService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<WorkspaceStateTokenStore>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<BatchExportSchedulerService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<ActivityFeedService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<CommandPaletteService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<SymbolManagementService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<BackfillService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IDataQualityApiClient>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IDataQualityPresentationService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IDataQualityRefreshService>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<BackfillViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<ProviderViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<DataQualityViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<CollectionSessionViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<WatchlistViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<QualityArchivePage>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<QualityArchiveViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+    }
+}

--- a/tests/Meridian.Wpf.Tests/Features/ServiceCollectionRegistrationAssertions.cs
+++ b/tests/Meridian.Wpf.Tests/Features/ServiceCollectionRegistrationAssertions.cs
@@ -1,0 +1,9 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Wpf.Tests.Features;
+
+internal static class ServiceCollectionRegistrationAssertions
+{
+    public static ServiceDescriptor SingleDescriptor<TService>(this IServiceCollection services)
+        => services.Single(descriptor => descriptor.ServiceType == typeof(TService));
+}

--- a/tests/Meridian.Wpf.Tests/Features/Settings/SettingsFeatureServiceRegistrationTests.cs
+++ b/tests/Meridian.Wpf.Tests/Features/Settings/SettingsFeatureServiceRegistrationTests.cs
@@ -1,0 +1,44 @@
+using Meridian.Wpf.Tests.Features;
+using Meridian.Ui.Services;
+using Meridian.Ui.Services.Services;
+using Meridian.Workflow.EnvironmentDesign;
+using Meridian.Wpf.Features.Settings;
+using Meridian.Wpf.Services;
+using Meridian.Wpf.ViewModels;
+using Meridian.Wpf.Views;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Wpf.Tests.Features.Settings;
+
+public sealed class SettingsFeatureServiceRegistrationTests
+{
+    [Fact]
+    public void Register_ShouldOwnSettingsFeatureServicesWithConfiguredLifetimes()
+    {
+        var services = new ServiceCollection();
+
+        new SettingsFeatureModule().Register(services);
+
+        services.SingleDescriptor<ProviderManagementService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<AdminMaintenanceServiceBase>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IAdminMaintenanceService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<SearchService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<SetupWizardService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<ISetupWizardStateService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<ISetupWizardNotificationSink>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<ISetupWizardNavigator>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<ISetupWizardLinkLauncher>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<EnvironmentDesignerService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IEnvironmentDesignService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IEnvironmentValidationService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IEnvironmentPublishService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IEnvironmentRuntimeProjectionService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<CredentialService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<PluginManagementPage>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<PluginManagementViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<SettingsViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<SetupWizardViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<WorkflowLibraryViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<CredentialManagementViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+    }
+}

--- a/tests/Meridian.Wpf.Tests/Features/Strategy/StrategyFeatureServiceRegistrationTests.cs
+++ b/tests/Meridian.Wpf.Tests/Features/Strategy/StrategyFeatureServiceRegistrationTests.cs
@@ -1,0 +1,72 @@
+using Meridian.Wpf.Tests.Features;
+using Meridian.Backtesting;
+using Meridian.Contracts.SecurityMaster;
+using Meridian.Strategies.Interfaces;
+using Meridian.Strategies.Services;
+using Meridian.Ui.Shared.Services;
+using Meridian.Wpf.Features.Strategy;
+using Meridian.Wpf.Services;
+using Meridian.Wpf.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Wpf.Tests.Features.Strategy;
+
+public sealed class StrategyFeatureServiceRegistrationTests
+{
+    [Fact]
+    public void Register_WithoutSecurityMasterConnection_ShouldOwnStrategyServicesWithConfiguredLifetimes()
+    {
+        using var env = new EnvironmentVariableScope().Set("MERIDIAN_SECURITY_MASTER_CONNECTION_STRING", null);
+        var services = new ServiceCollection();
+
+        new StrategyFeatureModule().Register(services);
+
+        services.SingleDescriptor<ISecurityMasterService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<ISecurityMasterImportService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<ITradingParametersBackfillService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IStrategyRepository>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<StrategyRunReadService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<StrategyRunContinuityService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<WorkstationWorkflowSummaryService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IWorkstationStrategyBriefingApiClient>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IWorkstationOperatorInboxApiClient>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<IStrategyBriefingWorkspaceService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<StrategyRunWorkspaceService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<BacktestDataAvailabilityService>().Lifetime.Should().Be(ServiceLifetime.Singleton);
+        services.SingleDescriptor<RunMatViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<StrategyRunBrowserViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<StrategyRunDetailViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<StrategyRunPortfolioViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<StrategyRunLedgerViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<CashFlowViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<BacktestViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<BatchBacktestViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<ChartingPageViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<TickerStripViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+        services.SingleDescriptor<QuantScriptViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly Dictionary<string, string?> _originalValues = new(StringComparer.Ordinal);
+
+        public EnvironmentVariableScope Set(string name, string? value)
+        {
+            if (!_originalValues.ContainsKey(name))
+            {
+                _originalValues[name] = Environment.GetEnvironmentVariable(name);
+            }
+
+            Environment.SetEnvironmentVariable(name, value);
+            return this;
+        }
+
+        public void Dispose()
+        {
+            foreach (var entry in _originalValues)
+            {
+                Environment.SetEnvironmentVariable(entry.Key, entry.Value);
+            }
+        }
+    }
+}

--- a/tests/Meridian.Wpf.Tests/Features/Trading/TradingFeatureServiceRegistrationTests.cs
+++ b/tests/Meridian.Wpf.Tests/Features/Trading/TradingFeatureServiceRegistrationTests.cs
@@ -1,0 +1,19 @@
+using Meridian.Wpf.Features;
+using Meridian.Wpf.Features.Trading;
+using Meridian.Wpf.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Wpf.Tests.Features.Trading;
+
+public sealed class TradingFeatureServiceRegistrationTests
+{
+    [Fact]
+    public void Register_ShouldOwnTradingFeatureServicesWithConfiguredLifetimes()
+    {
+        var services = new ServiceCollection();
+
+        new TradingFeatureModule().Register(services);
+
+        services.SingleDescriptor<RunRiskViewModel>().Lifetime.Should().Be(ServiceLifetime.Transient);
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce App.xaml.cs surface area by moving feature-owned DI registrations into their owning feature modules to improve modularity and ownership clarity.
- Keep only desktop-wide core, shell, and background/infrastructure services in the application host configuration so feature composition is declared by modules.
- Preserve existing service lifetimes and the broad `AppServiceRegistrationTests` safety net while enabling focused, module-level registration tests.

### Description
- Moved feature-owned registrations out of `src/Meridian.Wpf/App.xaml.cs` into the matching modules: `AccountingFeatureModule`, `DataFeatureModule`, `SettingsFeatureModule`, `StrategyFeatureModule`, and `TradingFeatureModule` so each module now registers its own services and view-models (examples: fund-account and reconciliation services into `Features/Accounting`, backfill/data-quality/watchlist services into `Features/Data`, setup-wizard/environment-designer/provider/admin services into `Features/Settings`, strategy/backtest/RunMat/QuantScript services into `Features/Strategy`, and `RunRiskViewModel` into `Features/Trading`).
- Left desktop-wide registrations in `App.xaml.cs` scoped to app core, shell composition (`AddMeridianWpfShell(configuration)`), background/infrastructure services, a small set of temporary legacy registrations, and a plugin loader seam.
- Preserved original service lifetimes exactly while moving registrations and rewired any singleton instances that rely on module composition (e.g., `StrategyRunWorkspaceService` setup moved into the Strategy module to attach optional collaborators).
- Added focused lifetime assertions under `tests/Meridian.Wpf.Tests/Features/` for `Accounting`, `Data`, `Settings`, `Strategy`, and `Trading` to verify moved services register with the intended `Singleton`/`Transient` lifetimes and kept `tests/Meridian.Wpf.Tests/Services/AppServiceRegistrationTests.cs` intact as the full-app safety net.

### Testing
- Ran `git diff --check` which passed with no whitespace/index issues.
- Attempted to run the narrow filtered tests with `dotnet test --filter "FullyQualifiedName~FeatureServiceRegistrationTests|FullyQualifiedName~AppServiceRegistrationTests"` but `dotnet` is not available in the execution environment so the filtered test run could not be executed here.
- Attempted to run `pwsh ./tools/codex/test-gap-scan.ps1` but `pwsh` is not available in the execution environment; recommend running the added focused tests locally or via the repository `Targeted Test` workflow on CI to validate the new tests and full app registration behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32d8a9e7b0832091d13aa2f84461a7)