### PR TITLE
Add WPF feature module registration tests

### DIFF
--- a/tests/Meridian.Wpf.Tests/Features/Accounting/AccountingFeatureModuleTests.cs
+++ b/tests/Meridian.Wpf.Tests/Features/Accounting/AccountingFeatureModuleTests.cs
@@ -1,0 +1,98 @@
+using Meridian.DataIntegration.AccountingSystem.QuickBooks;
+using Meridian.FinancialOperations.AccountingClose;
+using Meridian.FinancialOperations.AccountingSystem;
+using Meridian.FinancialOperations.Ledger;
+using Meridian.FinancialOperations.OperationsContinuity;
+using Meridian.FinancialOperations.PrivateCapital;
+using Meridian.ProviderSdk.AccountingSystem;
+using Meridian.Ui.Services.Services.Accounting;
+using Meridian.Wpf.Features.Accounting;
+using Meridian.Wpf.Services;
+using Meridian.Wpf.ViewModels;
+using Meridian.Wpf.ViewModels.Accounting;
+using Meridian.Wpf.Views;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Wpf.Tests.Features.Accounting;
+
+public sealed class AccountingFeatureModuleTests
+{
+    [Fact]
+    public void DescribePages_ReturnsExpectedPageTagsWithoutDuplicates()
+    {
+        DesktopFeatureModuleTestAssertions.AssertPageTags(
+            new AccountingFeatureModule(),
+            "AccountingShell",
+            "FundStructureSetup",
+            "FundLedger",
+            "RunLedger",
+            "RunCashFlow",
+            "FundBanking",
+            "FundCashFinancing",
+            "FundAccountingConfigure",
+            "FundTrialBalance",
+            "LedgerExplorer",
+            "FundReconciliation",
+            "FundAuditTrail",
+            "SecurityInstrumentExplorer");
+    }
+
+    [Fact]
+    public void DescribeWorkspace_ReturnsAccountingWorkspaceShell()
+    {
+        var workspace = DesktopFeatureModuleTestAssertions.AssertWorkspace(new AccountingFeatureModule(), "accounting", "AccountingShell");
+
+        workspace.ShellDefinition.ViewModelType.Should().Be(typeof(AccountingWorkspaceShellViewModel));
+        workspace.ShellDefinition.StateProviderType.Should().Be(typeof(AccountingWorkspaceShellStateProvider));
+    }
+
+    [Fact]
+    public void DeclareCapabilities_ReturnsNoFeatureCapabilityKeys()
+    {
+        DesktopFeatureModuleTestAssertions.AssertNoCapabilities(new AccountingFeatureModule());
+    }
+
+    [Fact]
+    public void Register_AddsAccountingViewModelsPagesAndServicesWithIntendedLifetimes()
+    {
+        var services = new ServiceCollection();
+
+        new AccountingFeatureModule().Register(services);
+
+        DesktopFeatureModuleTestAssertions.AssertRegistered<AccountingWorkspaceShellStateProvider>(services, ServiceLifetime.Transient);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<AccountingWorkspaceShellViewModel>(services, ServiceLifetime.Transient);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<AccountingWorkspaceShellPage>(services, ServiceLifetime.Transient);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<AccountingConfigureViewModel>(services, ServiceLifetime.Transient);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<AccountingConfigurePage>(services, ServiceLifetime.Transient);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<AccountingCloseViewModel>(services, ServiceLifetime.Transient);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<AccountingPostingService>(services, ServiceLifetime.Singleton);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<TrialBalanceProjectionService>(services, ServiceLifetime.Singleton);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<MonthEndCloseStateMachine>(services, ServiceLifetime.Singleton);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<IAccountingProjectionQueryService, AccountingProjectionQueryService>(services, ServiceLifetime.Singleton);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<FileAccountingConfigurationStore>(services, ServiceLifetime.Singleton);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<IAccountingConfigurationService, AccountingConfigurationService>(services, ServiceLifetime.Singleton);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<IManualJournalEntryDraftStore>(services, ServiceLifetime.Singleton);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<IManualJournalEntryWorkbenchService>(services, ServiceLifetime.Singleton);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<ICapitalAccountWorkbenchService>(services, ServiceLifetime.Singleton);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<IPrivateCapitalCloseCockpitService>(services, ServiceLifetime.Singleton);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<IAccountingPolicyService, AccountingPolicyService>(services, ServiceLifetime.Singleton);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<IAccountingBasisProjectionService, AccountingBasisProjectionService>(services, ServiceLifetime.Singleton);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<IAccountingJournalDraftService, AccountingJournalDraftService>(services, ServiceLifetime.Singleton);
+        services.Should().Contain(descriptor => descriptor.ServiceType == typeof(IAccountingSystemProvider) && descriptor.ImplementationType == typeof(QuickBooksFixtureAccountingProvider) && descriptor.Lifetime == ServiceLifetime.Singleton);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<AccountingSystemIntegrationService>(services, ServiceLifetime.Singleton);
+    }
+
+    [Theory]
+    [InlineData("AccountingShell", "AccountingShell", "accounting")]
+    [InlineData("GovernanceShell", "AccountingShell", "accounting")]
+    [InlineData("AccountingWorkspace", "AccountingShell", "accounting")]
+    [InlineData("OperationsContinuity", "FundLedger", "accounting")]
+    [InlineData("OperationsClose", "FundLedger", "accounting")]
+    [InlineData("EvidenceWorkbench", "FundAuditTrail", "accounting")]
+    [InlineData("AccountingApprovals", "FundAuditTrail", "accounting")]
+    [InlineData("LedgerInspector", "RunLedger", "accounting")]
+    public void ShellRegistry_ResolvesAccountingAliasesAndRootNavigationTags(string requestedTag, string canonicalTag, string workspaceId)
+    {
+        DesktopFeatureModuleTestAssertions.AssertRouteResolves(requestedTag, canonicalTag, workspaceId);
+    }
+}

--- a/tests/Meridian.Wpf.Tests/Features/Data/DataFeatureModuleTests.cs
+++ b/tests/Meridian.Wpf.Tests/Features/Data/DataFeatureModuleTests.cs
@@ -1,0 +1,84 @@
+using Meridian.Wpf.Features.Data;
+using Meridian.Wpf.Features.Data.Shell;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Wpf.Tests.Features.Data;
+
+public sealed class DataFeatureModuleTests
+{
+    [Fact]
+    public void DescribePages_ReturnsExpectedPageTagsWithoutDuplicates()
+    {
+        DesktopFeatureModuleTestAssertions.AssertPageTags(
+            new DataFeatureModule(),
+            "DataShell",
+            "Provider",
+            "Backfill",
+            "Symbols",
+            "Storage",
+            "DataExport",
+            "DataSources",
+            "ProviderHealth",
+            "DataQuality",
+            "SecurityMaster",
+            "SymbolMapping",
+            "SymbolStorage",
+            "Schedules",
+            "CollectionSessions",
+            "PackageManager",
+            "DataBrowser",
+            "DataCalendar",
+            "DataSampling",
+            "TimeSeriesAlignment",
+            "IndexSubscription",
+            "Options",
+            "AddProviderWizard",
+            "ArchiveHealth",
+            "StorageOptimization",
+            "RetentionAssurance");
+    }
+
+    [Fact]
+    public void DescribeWorkspace_ReturnsDataWorkspaceShell()
+    {
+        var workspace = DesktopFeatureModuleTestAssertions.AssertWorkspace(new DataFeatureModule(), "data", "DataShell");
+
+        workspace.ShellDefinition.ViewModelType.Should().Be(typeof(DataWorkspaceShellViewModel));
+        workspace.ShellDefinition.StateProviderType.Should().Be(typeof(DataWorkspaceShellStateProvider));
+        workspace.ShellDefinition.DefaultPanes.Select(static pane => pane.PageTag)
+            .Should().Equal("Provider", "Backfill", "Storage", "DataQuality");
+    }
+
+    [Fact]
+    public void DeclareCapabilities_ReturnsStableDataCapabilityKeys()
+    {
+        DesktopFeatureModuleTestAssertions.AssertCapabilityKeys(
+            new DataFeatureModule(),
+            "desktop.data.workspace",
+            "desktop.data.security-master",
+            "desktop.data.retention");
+    }
+
+    [Fact]
+    public void Register_AddsDataShellServicesViewModelAndPageWithIntendedLifetimes()
+    {
+        var services = new ServiceCollection();
+
+        new DataFeatureModule().Register(services);
+
+        DesktopFeatureModuleTestAssertions.AssertRegistered<IDataWorkspaceShellSnapshotService, DataWorkspaceShellSnapshotService>(services, ServiceLifetime.Scoped);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<IDataWorkspaceShellPresentationService, DataWorkspaceShellPresentationService>(services, ServiceLifetime.Scoped);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<DataWorkspaceShellViewModel>(services, ServiceLifetime.Transient);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<DataWorkspaceShellPage>(services, ServiceLifetime.Transient);
+    }
+
+    [Theory]
+    [InlineData("DataShell", "DataShell", "data")]
+    [InlineData("DataOperationsShell", "DataShell", "data")]
+    [InlineData("DataOperationsWorkspace", "DataShell", "data")]
+    [InlineData("Providers", "Provider", "data")]
+    public void ShellRegistry_ResolvesDataAliasesAndRootNavigationTags(string requestedTag, string canonicalTag, string workspaceId)
+    {
+        DesktopFeatureModuleTestAssertions.AssertRouteResolves(requestedTag, canonicalTag, workspaceId);
+    }
+}

--- a/tests/Meridian.Wpf.Tests/Features/DesktopFeatureModuleTestAssertions.cs
+++ b/tests/Meridian.Wpf.Tests/Features/DesktopFeatureModuleTestAssertions.cs
@@ -1,0 +1,79 @@
+using Meridian.Core.Config;
+using Meridian.Wpf.Features;
+using Meridian.Wpf.Models;
+using Meridian.Wpf.Shell.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Wpf.Tests.Features;
+
+internal static class DesktopFeatureModuleTestAssertions
+{
+    public static void AssertPageTags(IDesktopFeatureModule module, params string[] expectedPageTags)
+    {
+        var pages = module.DescribePages();
+
+        pages.Select(static page => page.PageTag).Should().Equal(expectedPageTags);
+        pages.Select(static page => page.PageTag).Should().OnlyHaveUniqueItems();
+        pages.SelectMany(static page => page.Aliases).Where(static alias => !string.IsNullOrWhiteSpace(alias)).Should().OnlyHaveUniqueItems();
+    }
+
+    public static WorkspaceCapabilityDescriptor AssertWorkspace(
+        IDesktopFeatureModule module,
+        string expectedWorkspaceId,
+        string expectedHomePageTag)
+    {
+        var workspace = module.DescribeWorkspace();
+
+        workspace.Should().NotBeNull();
+        workspace!.Workspace.Id.Should().Be(expectedWorkspaceId);
+        workspace.Workspace.HomePageTag.Should().Be(expectedHomePageTag);
+        workspace.ShellDefinition.WorkspaceId.Should().Be(expectedWorkspaceId);
+        workspace.ShellDefinition.DefaultPanes.Should().NotBeEmpty();
+        workspace.Pages.Select(static page => page.PageTag).Should().OnlyHaveUniqueItems();
+
+        return workspace;
+    }
+
+    public static void AssertCapabilityKeys(IDesktopFeatureModule module, params string[] expectedCapabilityKeys)
+    {
+        var capabilities = module.DeclareCapabilities();
+
+        capabilities.Select(static capability => capability.CapabilityKey).Should().Equal(expectedCapabilityKeys);
+        capabilities.Select(static capability => capability.CapabilityKey).Should().OnlyHaveUniqueItems();
+    }
+
+    public static void AssertNoCapabilities(IDesktopFeatureModule module)
+        => module.DeclareCapabilities().Should().BeEmpty();
+
+    public static void AssertRegistered<TService>(IServiceCollection services, ServiceLifetime lifetime)
+        where TService : class
+    {
+        services.Should().Contain(
+            descriptor => descriptor.ServiceType == typeof(TService) && descriptor.Lifetime == lifetime,
+            $"{typeof(TService).Name} should be registered with {lifetime} lifetime");
+    }
+
+    public static void AssertRegistered<TService, TImplementation>(IServiceCollection services, ServiceLifetime lifetime)
+        where TService : class
+        where TImplementation : class, TService
+    {
+        services.Should().Contain(
+            descriptor => descriptor.ServiceType == typeof(TService) &&
+                          descriptor.ImplementationType == typeof(TImplementation) &&
+                          descriptor.Lifetime == lifetime,
+            $"{typeof(TService).Name} should resolve to {typeof(TImplementation).Name} with {lifetime} lifetime");
+    }
+
+    public static void AssertRouteResolves(string requestedTag, string expectedCanonicalTag, string expectedWorkspaceId)
+    {
+        var registry = new ShellRouteRegistry(ShellPageRegistryBuilder.BuildDefault());
+
+        var route = registry.GetRoute(requestedTag);
+
+        route.Should().NotBeNull();
+        route!.PageTag.Should().Be(expectedCanonicalTag);
+        route.WorkspaceId.Should().Be(expectedWorkspaceId);
+        registry.GetCanonicalPageTag(requestedTag).Should().Be(expectedCanonicalTag);
+        registry.InferWorkspaceIdForPageTag(requestedTag).Should().Be(expectedWorkspaceId);
+    }
+}

--- a/tests/Meridian.Wpf.Tests/Features/Home/HomeFeatureModuleTests.cs
+++ b/tests/Meridian.Wpf.Tests/Features/Home/HomeFeatureModuleTests.cs
@@ -1,0 +1,44 @@
+using Meridian.Wpf.Features.Home;
+using Meridian.Wpf.ViewModels;
+using Meridian.Wpf.Views;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Wpf.Tests.Features.Home;
+
+public sealed class HomeFeatureModuleTests
+{
+    [Fact]
+    public void DescribePages_ReturnsExpectedPageTagsWithoutDuplicates()
+    {
+        var module = new HomeFeatureModule();
+
+        DesktopFeatureModuleTestAssertions.AssertPageTags(module, "HomeWorkspace");
+        module.DescribeWorkspace().Should().BeNull();
+    }
+
+    [Fact]
+    public void DeclareCapabilities_ReturnsNoFeatureCapabilityKeys()
+    {
+        DesktopFeatureModuleTestAssertions.AssertNoCapabilities(new HomeFeatureModule());
+    }
+
+    [Fact]
+    public void Register_AddsHomeViewModelAndPageAsTransient()
+    {
+        var services = new ServiceCollection();
+
+        new HomeFeatureModule().Register(services);
+
+        DesktopFeatureModuleTestAssertions.AssertRegistered<HomeWorkspaceViewModel>(services, ServiceLifetime.Transient);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<HomeWorkspacePage>(services, ServiceLifetime.Transient);
+    }
+
+    [Theory]
+    [InlineData("HomeWorkspace", "HomeWorkspace", "strategy")]
+    [InlineData("Home", "HomeWorkspace", "strategy")]
+    [InlineData("WorkstationHome", "HomeWorkspace", "strategy")]
+    public void ShellRegistry_ResolvesHomeAliases(string requestedTag, string canonicalTag, string workspaceId)
+    {
+        DesktopFeatureModuleTestAssertions.AssertRouteResolves(requestedTag, canonicalTag, workspaceId);
+    }
+}

--- a/tests/Meridian.Wpf.Tests/Features/Portfolio/PortfolioFeatureModuleTests.cs
+++ b/tests/Meridian.Wpf.Tests/Features/Portfolio/PortfolioFeatureModuleTests.cs
@@ -1,0 +1,62 @@
+using Meridian.Wpf.Features.Portfolio;
+using Meridian.Wpf.Features.Portfolio.Shell;
+using Meridian.Wpf.Services;
+using Meridian.Wpf.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Wpf.Tests.Features.Portfolio;
+
+public sealed class PortfolioFeatureModuleTests
+{
+    [Fact]
+    public void DescribePages_ReturnsExpectedPageTagsWithoutDuplicates()
+    {
+        DesktopFeatureModuleTestAssertions.AssertPageTags(
+            new PortfolioFeatureModule(),
+            "PortfolioShell",
+            "AccountPortfolio",
+            "AggregatePortfolio",
+            "RunPortfolio",
+            "PortfolioExplorer",
+            "FundPortfolio",
+            "FundAccounts",
+            "PortfolioImport",
+            "DirectLending");
+    }
+
+    [Fact]
+    public void DescribeWorkspace_ReturnsPortfolioWorkspaceShell()
+    {
+        var workspace = DesktopFeatureModuleTestAssertions.AssertWorkspace(new PortfolioFeatureModule(), "portfolio", "PortfolioShell");
+
+        workspace.ShellDefinition.ViewModelType.Should().Be(typeof(PortfolioWorkspaceShellViewModel));
+        workspace.ShellDefinition.StateProviderType.Should().Be(typeof(PortfolioWorkspaceShellStateProvider));
+    }
+
+    [Fact]
+    public void DeclareCapabilities_ReturnsNoFeatureCapabilityKeys()
+    {
+        DesktopFeatureModuleTestAssertions.AssertNoCapabilities(new PortfolioFeatureModule());
+    }
+
+    [Fact]
+    public void Register_AddsPortfolioShellStateViewModelAndPageAsTransient()
+    {
+        var services = new ServiceCollection();
+
+        new PortfolioFeatureModule().Register(services);
+
+        DesktopFeatureModuleTestAssertions.AssertRegistered<PortfolioWorkspaceShellStateProvider>(services, ServiceLifetime.Transient);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<PortfolioWorkspaceShellViewModel>(services, ServiceLifetime.Transient);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<PortfolioWorkspaceShellPage>(services, ServiceLifetime.Transient);
+    }
+
+    [Theory]
+    [InlineData("PortfolioShell", "PortfolioShell", "portfolio")]
+    [InlineData("PortfolioInspector", "RunPortfolio", "portfolio")]
+    [InlineData("PortfolioExplorer", "PortfolioExplorer", "portfolio")]
+    public void ShellRegistry_ResolvesPortfolioAliasesAndRootNavigationTags(string requestedTag, string canonicalTag, string workspaceId)
+    {
+        DesktopFeatureModuleTestAssertions.AssertRouteResolves(requestedTag, canonicalTag, workspaceId);
+    }
+}

--- a/tests/Meridian.Wpf.Tests/Features/Reporting/ReportingFeatureModuleTests.cs
+++ b/tests/Meridian.Wpf.Tests/Features/Reporting/ReportingFeatureModuleTests.cs
@@ -1,0 +1,60 @@
+using Meridian.Wpf.Features.Reporting;
+using Meridian.Wpf.Features.Reporting.Shell;
+using Meridian.Wpf.Services;
+using Meridian.Wpf.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Wpf.Tests.Features.Reporting;
+
+public sealed class ReportingFeatureModuleTests
+{
+    [Fact]
+    public void DescribePages_ReturnsExpectedPageTagsWithoutDuplicates()
+    {
+        DesktopFeatureModuleTestAssertions.AssertPageTags(
+            new ReportingFeatureModule(),
+            "ReportingShell",
+            "FundReportPack",
+            "ReportRunStatus",
+            "ReportLineProvenanceExplorer",
+            "Dashboard",
+            "AnalysisExport",
+            "AnalysisExportWizard",
+            "ExportPresets");
+    }
+
+    [Fact]
+    public void DescribeWorkspace_ReturnsReportingWorkspaceShell()
+    {
+        var workspace = DesktopFeatureModuleTestAssertions.AssertWorkspace(new ReportingFeatureModule(), "reporting", "ReportingShell");
+
+        workspace.ShellDefinition.ViewModelType.Should().Be(typeof(ReportingWorkspaceShellViewModel));
+        workspace.ShellDefinition.StateProviderType.Should().Be(typeof(ReportingWorkspaceShellStateProvider));
+    }
+
+    [Fact]
+    public void DeclareCapabilities_ReturnsNoFeatureCapabilityKeys()
+    {
+        DesktopFeatureModuleTestAssertions.AssertNoCapabilities(new ReportingFeatureModule());
+    }
+
+    [Fact]
+    public void Register_AddsReportingShellStateViewModelAndPageAsTransient()
+    {
+        var services = new ServiceCollection();
+
+        new ReportingFeatureModule().Register(services);
+
+        DesktopFeatureModuleTestAssertions.AssertRegistered<ReportingWorkspaceShellStateProvider>(services, ServiceLifetime.Transient);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<ReportingWorkspaceShellViewModel>(services, ServiceLifetime.Transient);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<ReportingWorkspaceShellPage>(services, ServiceLifetime.Transient);
+    }
+
+    [Theory]
+    [InlineData("ReportingShell", "ReportingShell", "reporting")]
+    [InlineData("ReportLineProvenanceExplorer", "ReportLineProvenanceExplorer", "reporting")]
+    public void ShellRegistry_ResolvesReportingRootNavigationTags(string requestedTag, string canonicalTag, string workspaceId)
+    {
+        DesktopFeatureModuleTestAssertions.AssertRouteResolves(requestedTag, canonicalTag, workspaceId);
+    }
+}

--- a/tests/Meridian.Wpf.Tests/Features/Settings/SettingsFeatureModuleTests.cs
+++ b/tests/Meridian.Wpf.Tests/Features/Settings/SettingsFeatureModuleTests.cs
@@ -1,0 +1,75 @@
+using Meridian.Wpf.Features.Settings;
+using Meridian.Wpf.Features.Settings.Shell;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Wpf.Tests.Features.Settings;
+
+public sealed class SettingsFeatureModuleTests
+{
+    [Fact]
+    public void DescribePages_ReturnsExpectedPageTagsWithoutDuplicates()
+    {
+        DesktopFeatureModuleTestAssertions.AssertPageTags(
+            new SettingsFeatureModule(),
+            "SettingsShell",
+            "Settings",
+            "CredentialManagement",
+            "SystemHealth",
+            "Diagnostics",
+            "ServiceManager",
+            "AdminMaintenance",
+            "EnvironmentDesigner",
+            "MessagingHub",
+            "NotificationCenter",
+            "ActivityLog",
+            "KeyboardShortcuts",
+            "Help",
+            "SetupWizard",
+            "Workspaces",
+            "WorkflowLibrary",
+            "Welcome");
+    }
+
+    [Fact]
+    public void DescribeWorkspace_ReturnsSettingsWorkspaceShell()
+    {
+        var workspace = DesktopFeatureModuleTestAssertions.AssertWorkspace(new SettingsFeatureModule(), "settings", "SettingsShell");
+
+        workspace.ShellDefinition.ViewModelType.Should().Be(typeof(SettingsWorkspaceShellViewModel));
+        workspace.ShellDefinition.StateProviderType.Should().Be(typeof(SettingsWorkspaceShellStateProvider));
+        workspace.ShellDefinition.DefaultPanes.Select(static pane => pane.PageTag)
+            .Should().Equal("Settings", "Diagnostics", "SystemHealth", "NotificationCenter");
+    }
+
+    [Fact]
+    public void DeclareCapabilities_ReturnsStableSettingsCapabilityKeys()
+    {
+        DesktopFeatureModuleTestAssertions.AssertCapabilityKeys(
+            new SettingsFeatureModule(),
+            "desktop.settings.workspace",
+            "desktop.settings.capabilities",
+            "desktop.settings.workflow-library");
+    }
+
+    [Fact]
+    public void Register_AddsSettingsShellServicesViewModelAndPageWithIntendedLifetimes()
+    {
+        var services = new ServiceCollection();
+
+        new SettingsFeatureModule().Register(services);
+
+        DesktopFeatureModuleTestAssertions.AssertRegistered<ISettingsWorkspaceShellSnapshotService, SettingsWorkspaceShellSnapshotService>(services, ServiceLifetime.Scoped);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<ISettingsWorkspaceShellPresentationService, SettingsWorkspaceShellPresentationService>(services, ServiceLifetime.Scoped);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<SettingsWorkspaceShellViewModel>(services, ServiceLifetime.Transient);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<SettingsWorkspaceShellPage>(services, ServiceLifetime.Transient);
+    }
+
+    [Theory]
+    [InlineData("SettingsShell", "SettingsShell", "settings")]
+    [InlineData("Preferences", "Settings", "settings")]
+    [InlineData("Alerts", "NotificationCenter", "settings")]
+    public void ShellRegistry_ResolvesSettingsAliasesAndRootNavigationTags(string requestedTag, string canonicalTag, string workspaceId)
+    {
+        DesktopFeatureModuleTestAssertions.AssertRouteResolves(requestedTag, canonicalTag, workspaceId);
+    }
+}

--- a/tests/Meridian.Wpf.Tests/Features/Strategy/StrategyFeatureModuleTests.cs
+++ b/tests/Meridian.Wpf.Tests/Features/Strategy/StrategyFeatureModuleTests.cs
@@ -1,0 +1,65 @@
+using Meridian.Wpf.Features.Strategy;
+using Meridian.Wpf.Services;
+using Meridian.Wpf.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Wpf.Tests.Features.Strategy;
+
+public sealed class StrategyFeatureModuleTests
+{
+    [Fact]
+    public void DescribePages_ReturnsExpectedPageTagsWithoutDuplicates()
+    {
+        DesktopFeatureModuleTestAssertions.AssertPageTags(
+            new StrategyFeatureModule(),
+            "StrategyShell",
+            "Backtest",
+            "StrategyRuns",
+            "RunDetail",
+            "Charts",
+            "RunMat",
+            "BatchBacktest",
+            "AdvancedAnalytics",
+            "QuantScript",
+            "LeanIntegration",
+            "EventReplay",
+            "Watchlist");
+    }
+
+    [Fact]
+    public void DescribeWorkspace_ReturnsStrategyWorkspaceShell()
+    {
+        var workspace = DesktopFeatureModuleTestAssertions.AssertWorkspace(new StrategyFeatureModule(), "strategy", "StrategyShell");
+
+        workspace.ShellDefinition.ViewModelType.Should().Be(typeof(StrategyWorkspaceShellViewModel));
+        workspace.ShellDefinition.StateProviderType.Should().Be(typeof(StrategyWorkspaceShellStateProvider));
+    }
+
+    [Fact]
+    public void DeclareCapabilities_ReturnsNoFeatureCapabilityKeys()
+    {
+        DesktopFeatureModuleTestAssertions.AssertNoCapabilities(new StrategyFeatureModule());
+    }
+
+    [Fact]
+    public void Register_DoesNotAddFeatureSpecificDescriptorsBecauseStrategyShellUsesSharedShellRegistration()
+    {
+        var services = new ServiceCollection();
+
+        new StrategyFeatureModule().Register(services);
+
+        services.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("StrategyShell", "StrategyShell", "strategy")]
+    [InlineData("ResearchShell", "StrategyShell", "strategy")]
+    [InlineData("ResearchWorkspace", "StrategyShell", "strategy")]
+    [InlineData("BacktestStudio", "Backtest", "strategy")]
+    [InlineData("RunBrowser", "StrategyRuns", "strategy")]
+    [InlineData("ResearchAutomation", "RunMat", "strategy")]
+    public void ShellRegistry_ResolvesStrategyAliasesAndRootNavigationTags(string requestedTag, string canonicalTag, string workspaceId)
+    {
+        DesktopFeatureModuleTestAssertions.AssertRouteResolves(requestedTag, canonicalTag, workspaceId);
+    }
+}

--- a/tests/Meridian.Wpf.Tests/Features/Trading/TradingFeatureModuleTests.cs
+++ b/tests/Meridian.Wpf.Tests/Features/Trading/TradingFeatureModuleTests.cs
@@ -1,0 +1,65 @@
+using Meridian.Wpf.Features.Trading;
+using Meridian.Wpf.Services;
+using Meridian.Wpf.ViewModels;
+using Meridian.Wpf.Views;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Wpf.Tests.Features.Trading;
+
+public sealed class TradingFeatureModuleTests
+{
+    [Fact]
+    public void DescribePages_ReturnsExpectedPageTagsWithoutDuplicates()
+    {
+        DesktopFeatureModuleTestAssertions.AssertPageTags(
+            new TradingFeatureModule(),
+            "TradingShell",
+            "LiveData",
+            "OrderBook",
+            "PositionBlotter",
+            "RunRisk",
+            "TradingHours");
+    }
+
+    [Fact]
+    public void DescribeWorkspace_ReturnsTradingWorkspaceShell()
+    {
+        var workspace = DesktopFeatureModuleTestAssertions.AssertWorkspace(new TradingFeatureModule(), "trading", "TradingShell");
+
+        workspace.ShellDefinition.ViewModelType.Should().Be(typeof(TradingWorkspaceShellViewModel));
+        workspace.ShellDefinition.StateProviderType.Should().Be(typeof(TradingWorkspaceShellStateProvider));
+        workspace.ShellDefinition.DefaultPanes.Select(static pane => pane.PageTag)
+            .Should().Equal("LiveData", "OrderBook", "PositionBlotter", "RunRisk", "TradingHours");
+    }
+
+    [Fact]
+    public void DeclareCapabilities_ReturnsStableTradingCapabilityKeys()
+    {
+        DesktopFeatureModuleTestAssertions.AssertCapabilityKeys(
+            new TradingFeatureModule(),
+            "desktop.trading.workspace",
+            "desktop.trading.hours");
+    }
+
+    [Fact]
+    public void Register_AddsTradingShellServicesViewModelAndPageWithIntendedLifetimes()
+    {
+        var services = new ServiceCollection();
+
+        new TradingFeatureModule().Register(services);
+
+        DesktopFeatureModuleTestAssertions.AssertRegistered<TradingWorkspaceShellPresentationService>(services, ServiceLifetime.Scoped);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<TradingWorkspaceShellStateProvider>(services, ServiceLifetime.Transient);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<TradingWorkspaceShellViewModel>(services, ServiceLifetime.Transient);
+        DesktopFeatureModuleTestAssertions.AssertRegistered<TradingWorkspaceShellPage>(services, ServiceLifetime.Transient);
+    }
+
+    [Theory]
+    [InlineData("TradingShell", "TradingShell", "trading")]
+    [InlineData("TradingWorkspace", "TradingShell", "trading")]
+    [InlineData("Blotter", "PositionBlotter", "trading")]
+    public void ShellRegistry_ResolvesTradingAliasesAndRootNavigationTags(string requestedTag, string canonicalTag, string workspaceId)
+    {
+        DesktopFeatureModuleTestAssertions.AssertRouteResolves(requestedTag, canonicalTag, workspaceId);
+    }
+}


### PR DESCRIPTION
### Motivation

- Add narrow, module-level tests for each desktop feature module to reduce regressions in page registration, workspace ownership, capability declarations, and DI registration.
- Provide a shared assertion helper to standardize checks across feature-module tests and avoid duplication.
- Exercise shell routing for route-heavy modules so alias and root navigation tags remain resolvable in the desktop shell.

### Description

- Add `tests/Meridian.Wpf.Tests/Features/DesktopFeatureModuleTestAssertions.cs` with reusable assertions for page-tag uniqueness, workspace descriptor checks, capability-key checks, DI registration lifetime checks, and shell-route resolution.
- Add focused test classes under `tests/Meridian.Wpf.Tests/Features/` for `Home`, `Trading`, `Portfolio`, `Accounting`, `Reporting`, `Strategy`, `Data`, and `Settings` that instantiate the module and verify `DescribePages()`, `DescribeWorkspace()`, `DeclareCapabilities()`, and `Register(IServiceCollection)` behavior.
- Tests assert expected page tag lists and aliases (no duplicates), presence and correctness of workspace shell definitions and default panes where applicable, and stable capability keys where modules declare them.
- Add route-resolution assertions that validate `ShellRouteRegistry` resolves compatibility aliases and parameterized/canonical page tags for route-heavy surfaces.

### Testing

- Ran a repository static check with `git diff --check -- tests/Meridian.Wpf.Tests/Features`, which passed.
- Attempted to run the focused test filter with `dotnet test tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj -c Release --filter "FullyQualifiedName~FeatureModuleTests" /p:EnableWindowsTargeting=true`, but the execution environment lacks `dotnet`, so tests could not be executed locally.
- Attempted to run `pwsh ./tools/codex/test-gap-scan.ps1`, but `pwsh` is not available in this container, so that scan could not be run.
- Performed static symbol and reference inspections (type and interface lookups) to validate test usages and imports and found no unresolved type references in the added tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32da7cd20c8320b474c6d40b68ed4b)