### PR TITLE
Refactor desktop feature module registry to declarative factories and add tests

### DIFF
--- a/src/Meridian.Wpf/Features/DesktopFeatureModuleRegistry.cs
+++ b/src/Meridian.Wpf/Features/DesktopFeatureModuleRegistry.cs
@@ -7,16 +7,16 @@ namespace Meridian.Wpf.Features;
 
 public static class DesktopFeatureModuleRegistry
 {
-    private static readonly IDesktopFeatureModule[] Modules =
+    private static readonly Func<IDesktopFeatureModule>[] ModuleFactories =
     [
-        new Home.HomeFeatureModule(),
-        new Trading.TradingFeatureModule(),
-        new Portfolio.PortfolioFeatureModule(),
-        new Accounting.AccountingFeatureModule(),
-        new Reporting.ReportingFeatureModule(),
-        new Strategy.StrategyFeatureModule(),
-        new Data.DataFeatureModule(),
-        new Settings.SettingsFeatureModule()
+        DesktopFeature.Module<Home.HomeFeatureModule>(),
+        DesktopFeature.Module<Trading.TradingFeatureModule>(),
+        DesktopFeature.Module<Portfolio.PortfolioFeatureModule>(),
+        DesktopFeature.Module<Accounting.AccountingFeatureModule>(),
+        DesktopFeature.Module<Reporting.ReportingFeatureModule>(),
+        DesktopFeature.Module<Strategy.StrategyFeatureModule>(),
+        DesktopFeature.Module<Data.DataFeatureModule>(),
+        DesktopFeature.Module<Settings.SettingsFeatureModule>()
     ];
 
     public static IServiceCollection AddMeridianWpfFeatureModules(this IServiceCollection services)
@@ -25,7 +25,7 @@ public static class DesktopFeatureModuleRegistry
 
         services.AddSingleton(ShellPageRegistryBuilder.BuildDefault());
 
-        foreach (var module in Modules)
+        foreach (var module in GetModules())
         {
             module.Register(services);
         }
@@ -48,13 +48,21 @@ public static class DesktopFeatureModuleRegistry
         return services.AddMeridianWpfFeatureModules();
     }
 
-    public static IReadOnlyList<IDesktopFeatureModule> GetModules() => Modules;
+    public static IReadOnlyList<IDesktopFeatureModule> GetModules()
+        => ModuleFactories.Select(static createModule => createModule()).ToArray();
 
     public static IReadOnlyList<FeatureCapabilityDescriptor> GetCapabilities()
-        => Modules
+        => GetModules()
             .SelectMany(static module => module.DeclareCapabilities())
             .GroupBy(static capability => capability.CapabilityKey, StringComparer.OrdinalIgnoreCase)
             .Select(static group => group.First())
             .OrderBy(static capability => capability.DisplayName, StringComparer.OrdinalIgnoreCase)
             .ToArray();
+}
+
+public static class DesktopFeature
+{
+    public static Func<IDesktopFeatureModule> Module<T>()
+        where T : IDesktopFeatureModule, new()
+        => static () => new T();
 }

--- a/tests/Meridian.Wpf.Tests/Features/DesktopFeatureModuleRegistryTests.cs
+++ b/tests/Meridian.Wpf.Tests/Features/DesktopFeatureModuleRegistryTests.cs
@@ -1,0 +1,47 @@
+using Meridian.Wpf.Features;
+
+namespace Meridian.Wpf.Tests.Features;
+
+public sealed class DesktopFeatureModuleRegistryTests
+{
+    [Fact]
+    public void GetModules_ShouldReturnAllExpectedModulesInStableStartupOrder()
+    {
+        DesktopFeatureModuleRegistry.GetModules()
+            .Select(static module => module.GetType())
+            .Should()
+            .Equal(
+                typeof(Meridian.Wpf.Features.Home.HomeFeatureModule),
+                typeof(Meridian.Wpf.Features.Trading.TradingFeatureModule),
+                typeof(Meridian.Wpf.Features.Portfolio.PortfolioFeatureModule),
+                typeof(Meridian.Wpf.Features.Accounting.AccountingFeatureModule),
+                typeof(Meridian.Wpf.Features.Reporting.ReportingFeatureModule),
+                typeof(Meridian.Wpf.Features.Strategy.StrategyFeatureModule),
+                typeof(Meridian.Wpf.Features.Data.DataFeatureModule),
+                typeof(Meridian.Wpf.Features.Settings.SettingsFeatureModule));
+    }
+
+    [Fact]
+    public void GetModules_ShouldReturnFreshModulesFromDeclarativeFactories()
+    {
+        var first = DesktopFeatureModuleRegistry.GetModules();
+        var second = DesktopFeatureModuleRegistry.GetModules();
+
+        first.Select(static module => module.GetType()).Should().Equal(second.Select(static module => module.GetType()));
+        first.Zip(second, static (left, right) => ReferenceEquals(left, right))
+            .Should()
+            .OnlyContain(static sameInstance => sameInstance is false);
+    }
+
+    [Fact]
+    public void GetCapabilities_ShouldKeepCapabilityKeysUniqueAfterAggregation()
+    {
+        var duplicateKeys = DesktopFeatureModuleRegistry.GetCapabilities()
+            .GroupBy(static capability => capability.CapabilityKey, StringComparer.OrdinalIgnoreCase)
+            .Where(static group => group.Count() > 1)
+            .Select(static group => group.Key)
+            .ToArray();
+
+        duplicateKeys.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
### Motivation
- Preserve deterministic WPF startup module order while making module registration declarative and easier to reason about. 
- Introduce a small, type-safe factory helper so modules can be declared as `DesktopFeature.Module<T>()` instead of `new ...FeatureModule()` to reduce direct constructor churn. 
- Keep behavior unchanged (no source generation) and make future registry maintenance safer without changing startup ordering semantics.

### Description
- Replaced the concrete `IDesktopFeatureModule[] Modules` with a `Func<IDesktopFeatureModule>[] ModuleFactories` and changed registration to materialize modules via `GetModules()` so instances are created from the declarative factories. 
- Added the helper `DesktopFeature.Module<T>() where T : IDesktopFeatureModule, new()` to produce `Func<IDesktopFeatureModule>` factories. 
- Updated capability aggregation to call `GetModules()` so declared capabilities are collected from freshly materialized modules. 
- Added `tests/Meridian.Wpf.Tests/Features/DesktopFeatureModuleRegistryTests.cs` asserting expected module presence, stable startup order, factories produce fresh instances, and aggregated capability keys remain unique.

### Testing
- `git diff --check` passed with no whitespace or index errors. 
- `python3 build/scripts/docs/validate-doc-hashes.py --summary` was run and reported pre-existing repository-wide README/source hash drift unrelated to this focused change. 
- `dotnet test ...` (targeted WPF tests) was not run in this environment because `dotnet` is not available on `PATH`, so the new tests were added but not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32dd0999bc832098c9e00a013ff188)