### PR TITLE
docs: narrow AI workflow mirror guidance

### DIFF
--- a/.agents/skills/_shared/project-context.md
+++ b/.agents/skills/_shared/project-context.md
@@ -1,8 +1,8 @@
 # Meridian — Shared Project Context
 
-> **Canonical reference.** Update this file first when Meridian's product framing, workstation
-> routing, runtime semantics, or key architecture guidance changes; mirrored Codex and GitHub AI
-> surfaces should follow from here.
+> **Canonical project context.** Update this file when Meridian's product framing, workstation
+> routing, runtime semantics, or key architecture guidance changes. Shared workflow policy and
+> mirror-review rules live in `docs/ai/assistant-workflow-contract.md`.
 >
 > **Last verified:** 2026-06-16
 > **Primary grounding docs:** `README.md`, `docs/roadmap/data/*.yml`,
@@ -53,6 +53,7 @@
 
 Read these before changing skills, agents, or workflow guidance:
 
+- `docs/ai/assistant-workflow-contract.md` for shared workflow policy and minimal mirror-review rules
 - `README.md`
 - `docs/roadmap/README.md`
 - `docs/roadmap/data/*.yml`

--- a/.claude/skills/_shared/project-context.md
+++ b/.claude/skills/_shared/project-context.md
@@ -1,8 +1,8 @@
 # Meridian — Shared Project Context
 
-> **Canonical reference.** Update this file first when Meridian's product framing, workstation
-> routing, runtime semantics, or key architecture guidance changes; mirrored Codex and GitHub AI
-> surfaces should follow from here.
+> **Canonical project context.** Update this file when Meridian's product framing, workstation
+> routing, runtime semantics, or key architecture guidance changes. Shared workflow policy and
+> mirror-review rules live in `docs/ai/assistant-workflow-contract.md`.
 >
 > **Last verified:** 2026-06-16
 > **Primary grounding docs:** `README.md`, `docs/roadmap/data/*.yml`,
@@ -52,6 +52,7 @@
 
 Read these before changing skills, agents, or workflow guidance:
 
+- `docs/ai/assistant-workflow-contract.md` for shared workflow policy and minimal mirror-review rules
 - `README.md`
 - `docs/roadmap/README.md`
 - `docs/roadmap/data/*.yml`

--- a/.codex/skills/_shared/codex-execution-contract.md
+++ b/.codex/skills/_shared/codex-execution-contract.md
@@ -92,12 +92,13 @@ python3 build/python/cli/buildctl.py build --project Meridian.sln --configuratio
   operator-facing behavior changes.
 - Prefer existing docs over new docs.
 - Put Codex-specific docs under `docs/ai/codex/`.
-- For shared development or validation workflow changes, keep the Codex-loaded baseline and mirrored
-  assistant surfaces aligned: `AGENTS.md`, `CLAUDE.md`, `.codex/AGENTS.md`,
-  `.codex/skills/_shared/project-context.md`, `.codex/skills/_shared/codex-execution-contract.md`,
-  `.github/copilot-instructions.md`, `.github/agents/implementation-assurance-agent.md`,
-  `.github/workflows/README.md`, `docs/engineering/README.md`, `docs/start/README.md`,
-  `.claude/skills/_shared/project-context.md`, and `.agents/skills/_shared/project-context.md`.
+- For shared development or validation workflow changes, update
+  `docs/ai/assistant-workflow-contract.md` first. Then review only minimal mirrors that teach the
+  same rule: `docs/ai/codex/quickstart.md`, this Codex contract,
+  `.codex/skills/_shared/project-context.md`, `CLAUDE.md`, `.github/copilot-instructions.md`,
+  `.github/agents/implementation-assurance-agent.md`, `.agents/skills/_shared/project-context.md`,
+  and `.claude/skills/_shared/project-context.md` when present and still used. Keep mirror edits
+  short and host-specific.
 - For registered `src/**` modules, use `docs/source/data/source-modules.yml` to identify the
   module README, update required docs when behavior changes, then run
   `python3 build/scripts/docs/validate-doc-hashes.py --summary`. If source/docs alignment was

--- a/.codex/skills/_shared/project-context.md
+++ b/.codex/skills/_shared/project-context.md
@@ -47,7 +47,8 @@ repeating the same facts in every `SKILL.md`.
 
 ## Planning Anchors
 
-Use these together before changing AI guidance, routing, or workflow-oriented skills:
+Use these together before changing AI guidance, routing, or workflow-oriented skills. Minimal
+mirror-review rules live in `docs/ai/assistant-workflow-contract.md`.
 
 - `AGENTS.md`
 - `CLAUDE.md`

--- a/.github/agents/implementation-assurance-agent.md
+++ b/.github/agents/implementation-assurance-agent.md
@@ -42,7 +42,8 @@ Use this lane whenever the task creates or updates an agent or skill package.
 - Inspect only the relevant Meridian instinct files when local learned behavior would help; treat them as hints to verify against the repository, not policy to copy blindly.
 - Keep primary skill files concise and imperative. Move detailed reference material into `references/`, deterministic helpers into `scripts/`, and output resources into `assets/`.
 - Preserve host-specific metadata rules. For Codex repo-local skills, keep frontmatter minimal (`name`, `description`). For portable Claude packages, preserve the package metadata required by that host.
-- Keep mirrored Codex, Claude, and GitHub guidance aligned when a shared workflow or policy changes.
+- For shared workflow or policy changes, update `docs/ai/assistant-workflow-contract.md` first;
+  mirror only short Codex, Claude, or GitHub host mechanics that teach the same rule.
 - Avoid auxiliary files inside skill folders unless they are required by the host format or directly support execution.
 - When `agents/openai.yaml` exists, regenerate or update it so it still matches the skill instructions.
 - Validate the package after editing and run representative checks for any added or changed scripts.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,7 +71,8 @@ Always do the following before opening a PR:
 3. Run tests relevant to touched code.
 4. Update docs when behavior, interfaces, or workflows change.
 5. Keep PR title/body in sync with final implemented behavior.
-6. Keep provider-specific guidance aligned with `docs/ai/assistant-workflow-contract.md`.
+6. Keep Copilot-specific guidance short and aligned with `docs/ai/assistant-workflow-contract.md`;
+   do not duplicate shared mirror-review policy here.
 7. When editing `src/**`, read the nearest source README and keep `docs/source/data/*.yml`
    synchronized when module ownership, validation, roadmap mapping, diagrams, or TODO scope changes.
 8. If editing shared handoff, manifest, or AI work-mode guidance, run `python build/scripts/docs/check-ai-handoff.py --strict`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,8 +107,9 @@ gh workflow run targeted-test.yml --ref <branch> -f dotnet_project=tests/Meridia
 - `.claude/plugins/` - checked-in Claude plugin packages with plugin manifests, agents, and skills.
 - `.claude/skills/_shared/project-context.md` - canonical Claude-side project grounding.
 
-Keep Claude-specific files focused on host mechanics and discovery. Shared policy belongs in
-`docs/ai/assistant-workflow-contract.md`; broad routing belongs in generated navigation docs.
+Keep Claude-specific files focused on host mechanics and discovery. Shared policy and the
+minimal mirror-review rule belong in `docs/ai/assistant-workflow-contract.md`; broad routing belongs
+in generated navigation docs.
 
 ## Orchestration and Multi-Agent Dispatch
 

--- a/docs/ai/assistant-workflow-contract.md
+++ b/docs/ai/assistant-workflow-contract.md
@@ -343,6 +343,13 @@ Use this checklist when changing any AI-related asset:
       or root compatibility files.
 - [ ] Confirm whether the change is shared policy, host-specific mechanics, or generated content.
 - [ ] Update the shared source first when the rule is provider-agnostic.
+- [ ] After updating this contract, review only the minimal mirror files that teach the same workflow
+      rule: `docs/ai/codex/quickstart.md`, `.codex/skills/_shared/codex-execution-contract.md`,
+      `.codex/skills/_shared/project-context.md`, `CLAUDE.md`, `.github/copilot-instructions.md`,
+      `.github/agents/implementation-assurance-agent.md`, `.agents/skills/_shared/project-context.md`,
+      and `.claude/skills/_shared/project-context.md` when that file is present and still used.
+      Keep mirror edits short by linking back to this contract and summarizing only host-specific
+      behavior.
 - [ ] Update only the provider-specific files that need host mechanics or discoverability links.
 - [ ] Keep shared project context mirrored across `.codex/skills/_shared/project-context.md`,
       `.claude/skills/_shared/project-context.md`, and `.agents/skills/_shared/project-context.md`

--- a/docs/ai/codex/quickstart.md
+++ b/docs/ai/codex/quickstart.md
@@ -18,11 +18,9 @@ still lives in `../assistant-workflow-contract.md`.
    `Workflow: <lane>; Skill: <skill-or-none>; Context loaded: <files/docs>; Next evidence: <next source>.`
 4. Treat root `AGENTS.md`, `CLAUDE.md`, `.codex/skills/_shared/project-context.md`, and
    `.codex/skills/_shared/codex-execution-contract.md` as the Codex-loaded development baseline.
-   When a shared development, validation, workflow, prompt, skill, or agent rule changes, also
-   inspect and synchronize `.github/copilot-instructions.md`,
-   `.github/agents/implementation-assurance-agent.md`, `.github/workflows/README.md`,
-   `docs/engineering/README.md`, `docs/start/README.md`,
-   `.claude/skills/_shared/project-context.md`, and `.agents/skills/_shared/project-context.md`.
+   When `../assistant-workflow-contract.md` changes, keep this page and the Codex shared files as
+   short host-specific mirrors; review the other mirror files named by the canonical contract only
+   when they teach the same workflow rule.
 5. Read `../navigation/README.md` and `../generated/repo-navigation.md` for large-repo routing.
 6. For stakeholder/product-scoped tasks, read `../product/meridian-design-document.md` before planning updates.
 7. For broad generation, domain modeling, workflow design, or architecture-sensitive refactors, load the MDIF spine: `../../architecture/meridian-development-intelligence-framework.md`, `../../architecture/meridian-vision.md`, `../../architecture/meridian-domain-model.md`, `../../domain/README.md`, and the relevant pack in `../context/README.md`.


### PR DESCRIPTION
### Motivation
- Ensure the canonical assistant workflow (`docs/ai/assistant-workflow-contract.md`) is the source of truth for provider-agnostic rules and to avoid drift across host-specific mirrors. 
- Reduce duplication by requiring reviewers to change only the minimal host-specific mirror files that actually teach the same workflow rule and to keep those mirror edits short and host-specific.

### Description
- Add a minimal mirror-review rule to `docs/ai/assistant-workflow-contract.md` that lists the specific mirrors to review after contract changes and requires short, host-specific edits.  
- Update Codex mirrors to point back to the canonical contract by editing `docs/ai/codex/quickstart.md` and `.codex/skills/_shared/codex-execution-contract.md` and add a brief pointer in `.codex/skills/_shared/project-context.md`.  
- Tighten host guidance and mirror brevity in `CLAUDE.md`, `.github/copilot-instructions.md`, and `.github/agents/implementation-assurance-agent.md`, and clarify project-context vs workflow-policy ownership in `.agents/skills/_shared/project-context.md` and `.claude/skills/_shared/project-context.md`.  
- Changes are documentation-only and intentionally minimal in scope to avoid touching unrelated start, engineering, generated, or broader docs.

### Testing
- Ran `python3 build/scripts/docs/check-ai-inventory.py --summary` which passed.  
- Ran `python3 build/scripts/docs/check-codex-skills.py --summary` and `python3 build/scripts/docs/validate-docs-structure.py --top-level ai --summary` which both passed.  
- Ran `python3 build/scripts/docs/check-ai-contract-drift.py --canonical docs/ai/contract-policy.json --mirror docs/ai/copilot/contract-policy.mirror.json --mirror docs/ai/claude/contract-policy.mirror.json` which passed.  
- Ran `python3 build/scripts/docs/repair-links.py --summary` which reported a pre-existing unrelated broken link at `docs/ai/copilot/instructions.md:53` pointing to `../../../src/Meridian.Ui/wwwroot/workstation/` and was left unchanged because it is out of this change's minimal mirror scope; `git diff --check` and targeted whitespace/diff checks for edited files passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3468782ca483208798c70e72ecda07)