### PR TITLE
Refactor Settings screen to use shared UI primitives and semantic tones

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/ui/panel-surface.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/panel-surface.tsx
@@ -1,4 +1,5 @@
 import { forwardRef } from "react";
+import { semanticPanelToneClass, type SemanticTone } from "@/components/ui/semantic-tone";
 import { cn } from "@/lib/utils";
 
 export interface PanelSurfaceProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -8,15 +9,7 @@ export interface PanelSurfaceProps extends React.HTMLAttributes<HTMLDivElement> 
   tone?: PanelSurfaceTone;
 }
 
-export type PanelSurfaceTone = "default" | "success" | "warning" | "danger" | "muted";
-
-const toneClasses: Record<PanelSurfaceTone, string> = {
-  default: "border-border bg-card",
-  success: "border-success/35 bg-success/10",
-  warning: "border-warning/35 bg-warning/10",
-  danger: "border-danger/35 bg-danger/10",
-  muted: "border-border/70 bg-secondary/25"
-};
+export type PanelSurfaceTone = SemanticTone;
 
 export const PanelSurface = forwardRef<HTMLDivElement, PanelSurfaceProps>(
   ({ className, elevated = false, flat = false, raised = false, tone = "default", ...props }, ref) => (
@@ -24,8 +17,8 @@ export const PanelSurface = forwardRef<HTMLDivElement, PanelSurfaceProps>(
       ref={ref}
       className={cn(
         "rounded-[var(--radius-card,0.5rem)] border text-card-foreground shadow-[var(--shadow-panel)]",
-        toneClasses[tone],
-        raised && "bg-muted/35",
+        semanticPanelToneClass[tone],
+        raised && tone === "default" && "bg-muted/35",
         elevated && "shadow-[var(--shadow-float)]",
         flat && "shadow-none",
         className

--- a/src/Meridian.Ui/dashboard/src/components/ui/panel-surface.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/panel-surface.tsx
@@ -5,14 +5,26 @@ export interface PanelSurfaceProps extends React.HTMLAttributes<HTMLDivElement> 
   elevated?: boolean;
   flat?: boolean;
   raised?: boolean;
+  tone?: PanelSurfaceTone;
 }
 
+export type PanelSurfaceTone = "default" | "success" | "warning" | "danger" | "muted";
+
+const toneClasses: Record<PanelSurfaceTone, string> = {
+  default: "border-border bg-card",
+  success: "border-success/35 bg-success/10",
+  warning: "border-warning/35 bg-warning/10",
+  danger: "border-danger/35 bg-danger/10",
+  muted: "border-border/70 bg-secondary/25"
+};
+
 export const PanelSurface = forwardRef<HTMLDivElement, PanelSurfaceProps>(
-  ({ className, elevated = false, flat = false, raised = false, ...props }, ref) => (
+  ({ className, elevated = false, flat = false, raised = false, tone = "default", ...props }, ref) => (
     <div
       ref={ref}
       className={cn(
-        "rounded-[var(--radius-card,0.5rem)] border border-border bg-card text-card-foreground shadow-[var(--shadow-panel)]",
+        "rounded-[var(--radius-card,0.5rem)] border text-card-foreground shadow-[var(--shadow-panel)]",
+        toneClasses[tone],
         raised && "bg-muted/35",
         elevated && "shadow-[var(--shadow-float)]",
         flat && "shadow-none",

--- a/src/Meridian.Ui/dashboard/src/components/ui/primitives.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/primitives.test.tsx
@@ -26,7 +26,14 @@ describe("design-system UI primitives", () => {
   it("maps semantic panel tones to shared token classes", () => {
     render(<PanelSurface tone="success" aria-label="Verified provider">Provider ready</PanelSurface>);
 
-    expect(screen.getByLabelText("Verified provider")).toHaveClass("border-success/35", "bg-success/10");
+    expect(screen.getByLabelText("Verified provider")).toHaveClass("border-success/30", "bg-success/10");
+  });
+
+  it("does not apply raised background over non-default semantic tones", () => {
+    render(<PanelSurface tone="danger" raised aria-label="Live provider acknowledgement">Live provider acknowledgement</PanelSurface>);
+
+    expect(screen.getByLabelText("Live provider acknowledgement")).toHaveClass("border-danger/35", "bg-danger/10");
+    expect(screen.getByLabelText("Live provider acknowledgement")).not.toHaveClass("bg-muted/35");
   });
 
   it("toggles checkbox and switch primitives", async () => {

--- a/src/Meridian.Ui/dashboard/src/components/ui/primitives.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/primitives.test.tsx
@@ -23,6 +23,12 @@ describe("design-system UI primitives", () => {
     expect(screen.getByText("Security Master")).toHaveAttribute("aria-current", "page");
   });
 
+  it("maps semantic panel tones to shared token classes", () => {
+    render(<PanelSurface tone="success" aria-label="Verified provider">Provider ready</PanelSurface>);
+
+    expect(screen.getByLabelText("Verified provider")).toHaveClass("border-success/35", "bg-success/10");
+  });
+
   it("toggles checkbox and switch primitives", async () => {
     const user = userEvent.setup();
     const onCheckboxChange = vi.fn();

--- a/src/Meridian.Ui/dashboard/src/components/ui/semantic-tone.ts
+++ b/src/Meridian.Ui/dashboard/src/components/ui/semantic-tone.ts
@@ -1,0 +1,24 @@
+export type SemanticTone = "default" | "success" | "warning" | "danger" | "muted";
+
+export const semanticPanelToneClass: Record<SemanticTone, string> = {
+  default: "border-border/70 bg-secondary/30",
+  success: "border-success/30 bg-success/10",
+  warning: "border-warning/35 bg-warning/10",
+  danger: "border-danger/35 bg-danger/10",
+  muted: "border-border/70 bg-secondary/25"
+};
+
+export const semanticTextToneClass: Record<SemanticTone, string> = {
+  default: "text-foreground",
+  success: "text-success",
+  warning: "text-warning",
+  danger: "text-danger",
+  muted: "text-muted-foreground"
+};
+
+export const semanticBorderToneClass: Record<Exclude<SemanticTone, "muted">, string> = {
+  default: "border-border/70",
+  success: "border-success/30",
+  warning: "border-warning/30",
+  danger: "border-danger/30"
+};

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.test.tsx
@@ -1988,6 +1988,7 @@ describe("SettingsScreen", () => {
     const liveEndpoint = screen.getByRole("radio", { name: "Use Alpaca live endpoint for production brokerage verification" });
     expect(paperEndpoint).toBeChecked();
     expect(liveEndpoint).not.toBeChecked();
+    expect(within(screen.getByRole("radiogroup", { name: "Alpaca trading environment" })).getByText("Default")).toHaveClass("border-paper/35", "bg-paper/12", "text-paper");
     expect(paperEndpoint).toHaveAccessibleDescription(/Paper endpoint for workstation validation.*Paper endpoint selected/s);
     expect(liveEndpoint).toHaveAccessibleDescription(/Live endpoint for production brokerage verification.*Paper endpoint selected/s);
     expect(screen.getByText("Enter Alpaca credentials")).toBeInTheDocument();
@@ -2026,7 +2027,9 @@ describe("SettingsScreen", () => {
     await user.type(screen.getByPlaceholderText("ALPACA_SECRET_KEY"), "secret");
 
     const submit = screen.getByRole("button", { name: /connect and test/i });
-    expect(screen.getByRole("checkbox", { name: "Acknowledge live Alpaca endpoint before testing credentials" })).not.toBeChecked();
+    const liveAcknowledgement = screen.getByRole("checkbox", { name: "Acknowledge live Alpaca endpoint before testing credentials" });
+    expect(liveAcknowledgement).not.toBeChecked();
+    expect(liveAcknowledgement.closest("[class*='border-danger/35']")).toBeInTheDocument();
     expect(screen.getByText("Live endpoint review required")).toBeInTheDocument();
     expect(submit).toBeDisabled();
     expect(submit).toHaveAttribute(

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.test.tsx
@@ -2029,7 +2029,7 @@ describe("SettingsScreen", () => {
     const submit = screen.getByRole("button", { name: /connect and test/i });
     const liveAcknowledgement = screen.getByRole("checkbox", { name: "Acknowledge live Alpaca endpoint before testing credentials" });
     expect(liveAcknowledgement).not.toBeChecked();
-    expect(liveAcknowledgement.closest("[class*='border-danger/35']")).toBeInTheDocument();
+    expect(liveAcknowledgement.closest("[class*='border-danger/35']")).toHaveClass("text-danger");
     expect(screen.getByText("Live endpoint review required")).toBeInTheDocument();
     expect(submit).toBeDisabled();
     expect(submit).toHaveAttribute(
@@ -2041,6 +2041,26 @@ describe("SettingsScreen", () => {
 
     expect(submit).toBeEnabled();
     expect(screen.getByText("Credentials ready for test")).toBeInTheDocument();
+  });
+
+  it("keeps live provider routing acknowledgement text emphasized as danger", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(
+      <SettingsScreen
+        session={session}
+        overview={overview}
+        providerConnections={providerConnections}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Edit Alpaca credentials" }));
+    fireEvent.change(screen.getByLabelText("Alpaca environment"), { target: { value: "live" } });
+
+    const liveRoutingAcknowledgement = screen.getByRole("checkbox", {
+      name: "I understand this save updates live provider routing credentials."
+    });
+
+    expect(liveRoutingAcknowledgement.closest("[class*='border-danger/35']")).toHaveClass("text-danger");
   });
 
   it("explains disabled Alpaca form controls while a credential request is running", async () => {

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx
@@ -4027,7 +4027,7 @@ export function SettingsScreen({
               </fieldset>
             </div>
             {alpacaForm.liveAcknowledgement.visible ? (
-              <PanelSurface tone="danger" className={cn("px-3 py-3", alpacaForm.liveAcknowledgement.disabled && "opacity-60")}>
+              <PanelSurface tone="danger" className={cn("px-3 py-3 text-danger", alpacaForm.liveAcknowledgement.disabled && "opacity-60")}>
                 <Checkbox
                   id={alpacaForm.liveAcknowledgement.id}
                   checked={alpacaForm.liveAcknowledgement.checked}
@@ -5208,7 +5208,7 @@ function ProviderInlineActionPanel({
             </Select>
           </label>
           {state.environment === "live" ? (
-            <PanelSurface tone="danger" className="px-2 py-2">
+            <PanelSurface tone="danger" className="px-2 py-2 text-danger">
               <Checkbox
                 checked={state.liveAcknowledged}
                 onCheckedChange={onLiveAcknowledgementChange}

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx
@@ -4,8 +4,13 @@ import { Link } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { FieldSupportText, joinDescribedByIds } from "@/components/ui/field-support";
 import { Input } from "@/components/ui/input";
+import { PanelSurface, type PanelSurfaceTone } from "@/components/ui/panel-surface";
+import { Select } from "@/components/ui/select";
+import { semanticBorderToneClass, semanticPanelToneClass, semanticTextToneClass } from "@/components/ui/semantic-tone";
+import { StatusBanner } from "@/components/ui/status-banner";
 import { DenseDataTable, type DenseDataTableColumn } from "@/components/meridian/ui-kit-primitives";
 import { WorkspaceFilterBar, WorkspaceTabStrip } from "@/components/meridian/workspace-primitives";
 import {
@@ -307,61 +312,19 @@ const emptyProviderRuntimeEvidenceState: ProviderRuntimeEvidenceState = {
   quarantine: null
 };
 
-const systemToneClass = {
-  default: "border-border/70",
-  success: "border-success/30",
-  warning: "border-warning/30",
-  danger: "border-danger/30"
-} as const;
+const environmentBadgeVariant = (tone: "paper" | "live"): React.ComponentProps<typeof Badge>["variant"] => (tone === "live" ? "live" : "paper");
 
-const eventToneClass = {
-  default: "border-border/70 bg-secondary/25",
-  warning: "border-warning/35 bg-warning/10",
-  danger: "border-danger/35 bg-danger/10"
-} as const;
 
-const itemToneClass = {
-  default: "text-foreground",
-  success: "text-success",
-  warning: "text-warning",
-  danger: "text-danger",
-  muted: "text-muted-foreground"
-} as const;
-
-const diagnosticToneClass = {
-  default: "border-border/70 bg-secondary/30",
-  success: "border-success/30 bg-success/10",
-  warning: "border-warning/35 bg-warning/10",
-  danger: "border-danger/35 bg-danger/10"
-} as const;
-
-const formReadinessTextClass = {
-  default: "text-muted-foreground",
-  success: "text-success",
-  warning: "text-warning",
-  danger: "text-danger"
-} as const;
+const systemToneClass = semanticBorderToneClass;
+const eventToneClass = semanticPanelToneClass;
+const itemToneClass = semanticTextToneClass;
+const diagnosticToneClass = semanticPanelToneClass;
+const formReadinessTextClass = semanticTextToneClass;
+const requirementToneClass = semanticPanelToneClass;
+const setupStepToneClass = semanticPanelToneClass;
 
 const emptyProviderInlineValues: Record<ProviderInlineField, string> = {};
 
-const requirementToneClass = {
-  success: "border-success/30 bg-success/10 text-success",
-  warning: "border-warning/35 bg-warning/10 text-warning",
-  muted: "border-border/70 bg-secondary/25 text-muted-foreground"
-} as const;
-
-const environmentOptionClass = {
-  paper: {
-    selected: "border-paper/40 bg-paper/10 text-paper",
-    idle: "border-border/70 bg-secondary/25 text-foreground hover:border-paper/35 hover:bg-paper/10",
-    badge: "border-paper/30 bg-paper/10 text-paper"
-  },
-  live: {
-    selected: "border-live-env/40 bg-live-env/10 text-live-env",
-    idle: "border-border/70 bg-secondary/25 text-foreground hover:border-live-env/35 hover:bg-live-env/10",
-    badge: "border-live-env/35 bg-live-env/10 text-live-env"
-  }
-} as const;
 
 function AlpacaCredentialField({
   field,
@@ -401,13 +364,6 @@ function AlpacaCredentialField({
     </label>
   );
 }
-
-const setupStepToneClass = {
-  success: "border-success/30 bg-success/10",
-  warning: "border-warning/35 bg-warning/10",
-  danger: "border-danger/35 bg-danger/10",
-  muted: "border-border/70 bg-secondary/25"
-} as const;
 
 const recentEventColumns: DenseDataTableColumn<SettingsRecentEventTableRow>[] = [
   {
@@ -2464,11 +2420,12 @@ export function SettingsScreen({
       />
 
       <section className="grid gap-4 xl:grid-cols-[0.95fr_1.05fr]">
-        <Card
+        <PanelSurface
           id="profile-authentication"
           role="region"
           aria-label={vm.profileAuthenticationPanel.regionLabel}
-          className={cn("panel-surface scroll-mt-6 border", diagnosticToneClass[vm.profileAuthenticationPanel.statusTone])}
+          className="scroll-mt-6"
+          tone={vm.profileAuthenticationPanel.statusTone}
         >
           <CardHeader>
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -2555,9 +2512,9 @@ export function SettingsScreen({
               ))}
             </div>
           </CardContent>
-        </Card>
+        </PanelSurface>
 
-        <Card className={cn("panel-surface border", systemToneClass[vm.systemTone])}>
+        <PanelSurface tone={vm.systemTone}>
           <CardHeader>
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div>
@@ -2592,7 +2549,7 @@ export function SettingsScreen({
               </p>
             )}
           </CardContent>
-        </Card>
+        </PanelSurface>
       </section>
 
       <Card
@@ -3976,9 +3933,9 @@ export function SettingsScreen({
         </CardContent>
       </Card>
 
-      <Card
+      <PanelSurface
         id="alpaca-provider-setup"
-        className={cn("panel-surface scroll-mt-6 border", diagnosticToneClass[vm.alpacaConnectionPanel.statusTone])}
+        className="scroll-mt-6" tone={vm.alpacaConnectionPanel.statusTone}
       >
         <CardHeader>
           <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
@@ -4024,7 +3981,7 @@ export function SettingsScreen({
                       htmlFor={option.id}
                       className={cn(
                         "relative grid min-h-[4.75rem] cursor-pointer gap-1 rounded-md border px-3 py-2 transition-colors",
-                        option.isSelected ? environmentOptionClass[option.tone].selected : environmentOptionClass[option.tone].idle,
+                        option.isSelected ? "border-primary/50 bg-primary/10" : "border-border/70 bg-secondary/25 hover:border-primary/35 hover:bg-primary/10",
                         option.disabled && "cursor-not-allowed opacity-60"
                       )}
                     >
@@ -4048,9 +4005,7 @@ export function SettingsScreen({
                       <span className="pointer-events-none absolute inset-0 rounded-md peer-focus-visible:ring-2 peer-focus-visible:ring-primary/40" aria-hidden="true" />
                       <span className="flex items-center justify-between gap-2">
                         <span className="font-semibold text-foreground">{option.label}</span>
-                        <span className={cn("rounded-sm border px-2 py-0.5 font-mono text-[10px] uppercase", environmentOptionClass[option.tone].badge)}>
-                          {option.badgeLabel}
-                        </span>
+                        <Badge variant={environmentBadgeVariant(option.tone)}>{option.badgeLabel}</Badge>
                       </span>
                       <span id={option.descriptionId} className="text-[11px] font-normal leading-4 text-muted-foreground">
                         {option.description}
@@ -4072,40 +4027,28 @@ export function SettingsScreen({
               </fieldset>
             </div>
             {alpacaForm.liveAcknowledgement.visible ? (
-              <label
-                htmlFor={alpacaForm.liveAcknowledgement.id}
-                className={cn(
-                  "flex items-start gap-3 rounded-md border border-live-env/35 bg-live-env/10 px-3 py-3 text-sm text-live-env",
-                  alpacaForm.liveAcknowledgement.disabled && "opacity-60"
-                )}
-              >
-                <input
+              <PanelSurface tone="danger" className={cn("px-3 py-3", alpacaForm.liveAcknowledgement.disabled && "opacity-60")}>
+                <Checkbox
                   id={alpacaForm.liveAcknowledgement.id}
-                  type="checkbox"
                   checked={alpacaForm.liveAcknowledgement.checked}
                   disabled={alpacaForm.liveAcknowledgement.disabled}
                   required={alpacaForm.liveAcknowledgement.required}
-                  onChange={(event) => alpacaForm.setLiveAcknowledged(event.target.checked)}
+                  onCheckedChange={alpacaForm.setLiveAcknowledged}
                   aria-label={alpacaForm.liveAcknowledgement.ariaLabel}
                   aria-describedby={joinDescribedByIds(
                     alpacaForm.liveAcknowledgement.descriptionId,
                     alpacaForm.liveAcknowledgement.disabledReasonId,
                     alpacaForm.formPanelId
                   )}
-                  className="mt-0.5 h-4 w-4 shrink-0 accent-[hsl(var(--live-env))]"
+                  label={alpacaForm.liveAcknowledgement.label}
+                  hint={<span id={alpacaForm.liveAcknowledgement.descriptionId}>{alpacaForm.liveAcknowledgement.detail}</span>}
                 />
-                <span className="min-w-0">
-                  <span className="block font-semibold text-foreground">{alpacaForm.liveAcknowledgement.label}</span>
-                  <span id={alpacaForm.liveAcknowledgement.descriptionId} className="mt-1 block text-xs leading-5 text-muted-foreground">
-                    {alpacaForm.liveAcknowledgement.detail}
-                  </span>
-                  <FieldSupportText
-                    disabledReason={alpacaForm.liveAcknowledgement.disabledReason}
-                    disabledReasonId={alpacaForm.liveAcknowledgement.disabledReasonId ?? undefined}
-                    disabledReasonClassName="mt-1 block"
-                  />
-                </span>
-              </label>
+                <FieldSupportText
+                  disabledReason={alpacaForm.liveAcknowledgement.disabledReason}
+                  disabledReasonId={alpacaForm.liveAcknowledgement.disabledReasonId ?? undefined}
+                  disabledReasonClassName="mt-1 block"
+                />
+              </PanelSurface>
             ) : null}
             <div
               id={alpacaForm.formPanelId}
@@ -4184,9 +4127,7 @@ export function SettingsScreen({
               <SettingsFieldRow label="Verified" value={vm.alpacaConnectionPanel.verifiedAtLabel} tone="muted" />
             </dl>
             {vm.alpacaConnectionPanel.warnings.length > 0 ? (
-              <div className="rounded-md border border-warning/35 bg-warning/10 px-3 py-2 text-xs leading-5 text-warning">
-                {vm.alpacaConnectionPanel.warnings[0]}
-              </div>
+              <StatusBanner tone="warning" title={vm.alpacaConnectionPanel.warnings[0]} />
             ) : null}
             <div
               role="list"
@@ -4229,7 +4170,7 @@ export function SettingsScreen({
             </div>
           </div>
         </CardContent>
-      </Card>
+      </PanelSurface>
 
       <section className="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
         <Card id="diagnostic-endpoints" className="panel-surface scroll-mt-6">
@@ -4281,18 +4222,14 @@ export function SettingsScreen({
                 />
               </div>
             ) : (
-              <div
+              <PanelSurface
                 role={vm.recentEventsSection.state === "unavailable" ? "alert" : "status"}
-                className={cn(
-                  "rounded-md border px-4 py-4",
-                  vm.recentEventsSection.state === "unavailable"
-                    ? "border-danger/35 bg-danger/10"
-                    : "border-border/70 bg-secondary/25"
-                )}
+                tone={vm.recentEventsSection.state === "unavailable" ? "danger" : "muted"}
+                className="px-4 py-4"
               >
                 <div className="text-sm font-semibold text-foreground">{vm.recentEventsSection.statusLabel}</div>
                 <p className="mt-2 text-sm leading-6 text-muted-foreground">{vm.recentEventsSection.statusDetail}</p>
-              </div>
+              </PanelSurface>
             )}
           </CardContent>
         </Card>
@@ -5257,10 +5194,9 @@ function ProviderInlineActionPanel({
           )}
           <label className="grid gap-1 text-xs font-medium text-muted-foreground">
             Environment
-            <select
+            <Select
               value={state.environment}
               onChange={(event) => onEnvironmentChange(event.target.value)}
-              className="h-9 rounded-md border border-border/70 bg-background px-2 text-sm text-foreground"
               disabled={busy}
               aria-label={`${row.displayName} environment`}
             >
@@ -5269,19 +5205,17 @@ function ProviderInlineActionPanel({
                   {option.label}
                 </option>
               ))}
-            </select>
+            </Select>
           </label>
           {state.environment === "live" ? (
-            <label className="flex items-start gap-2 rounded-md border border-live-env/35 bg-live-env/10 px-2 py-2 text-xs text-live-env">
-              <input
-                type="checkbox"
+            <PanelSurface tone="danger" className="px-2 py-2">
+              <Checkbox
                 checked={state.liveAcknowledged}
-                onChange={(event) => onLiveAcknowledgementChange(event.target.checked)}
-                className="mt-0.5 h-4 w-4 shrink-0 accent-[hsl(var(--live-env))]"
+                onCheckedChange={onLiveAcknowledgementChange}
                 disabled={busy}
+                label="I understand this save updates live provider routing credentials."
               />
-              <span>I understand this save updates live provider routing credentials.</span>
-            </label>
+            </PanelSurface>
           ) : null}
         </div>
       ) : null}
@@ -5547,9 +5481,9 @@ function ProviderIntegrationRuntimePanel({
                       {record.capability} · {formatProviderRuntimeUtcMinute(record.createdAt)} · {formatProviderRuntimeNumber(record.validationErrors.length)} issues
                     </p>
                     {latestDecision ? (
-                      <p className="mt-1 text-[11px] leading-4 text-success">
+                      <Badge variant="success" className="mt-1">
                         Decision: {providerRuntimeQuarantineActionLabel(latestDecision.action)} by {latestDecision.reviewedBy} · {formatProviderRuntimeUtcMinute(latestDecision.reviewedAt)}
-                      </p>
+                      </Badge>
                     ) : null}
                   </div>
                   <div className="flex flex-wrap justify-end gap-2">


### PR DESCRIPTION
### Motivation
- Reduce one-off, screen-local CSS tone maps and unify semantic tone handling into shared design-system primitives.  
- Let view-models continue to emit semantic tones (`"success" | "warning" | "danger" | "muted" | "default"`) while letting shared primitives translate those tones to classes.  
- Replace duplicated environment/live/panel styling in Settings with `Badge`, `PanelSurface`, `StatusBanner`, `Checkbox`, and `Select` primitives to improve consistency and maintainability.  

### Description
- Added a `tone` prop to `PanelSurface` and a `semantic-tone.ts` module that maps semantic tones to shared token classes so components can render semantic variants instead of inline class strings (`src/components/ui/panel-surface.tsx`, `src/components/ui/semantic-tone.ts`).  
- Replaced several Settings-screen local tone maps and inline environment/live class strings with the shared primitives (`PanelSurface`, `Badge`, `StatusBanner`, `Checkbox`, `Select`) and the semantic tone mappings in `src/screens/settings-screen.tsx`.  
- Converted live-environment acknowledgement and provider-environment UI to use shared `PanelSurface` + `Checkbox`/`Select` primitives and replaced a few inline tone boxes with `StatusBanner` to keep visual tokens centralized.  
- Updated/added focused tests to prove the Settings screen uses shared semantic variants and that `PanelSurface` maps tone→class correctly (`src/screens/settings-screen.test.tsx`, `src/components/ui/primitives.test.tsx`).  

### Testing
- Ran the focused tests with `npm --prefix src/Meridian.Ui/dashboard run test -- src/screens/settings-screen.test.tsx src/components/ui/primitives.test.tsx`, and they passed.  
- Ran the full dashboard test suite with `npm --prefix src/Meridian.Ui/dashboard run test`; the run progressed through the batched runner but encountered a pre-existing Reporting screen date-format expectation mismatch (expected `May 17, 1:15 PM`, rendered `May 17, 8:15 PM`), causing a failure unrelated to the Settings refactor.  
- Built the dashboard with `npm --prefix src/Meridian.Ui/dashboard run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3468968ff48320bf2952cbc1709d49)