### PR TITLE
Scope posted private-capital activity by tenant

### DIFF
--- a/src/Meridian.Ui.Shared/Services/AccountingConfigurationService.cs
+++ b/src/Meridian.Ui.Shared/Services/AccountingConfigurationService.cs
@@ -3354,7 +3354,7 @@ public sealed class ManualJournalEntryWorkbenchService : IManualJournalEntryWork
         var drafts = await _draftStore.ListAsync(normalizedFundProfileId, ledgerBookId, ct, normalizedTenantId, normalizedCompanyId).ConfigureAwait(false);
         var audit = await _auditStore.ListAsync(normalizedFundProfileId, ledgerBookId, ct, normalizedTenantId, normalizedCompanyId).ConfigureAwait(false);
         var bankTransactions = await ListBankTransactionsAsync(ct).ConfigureAwait(false);
-        var posted = await BuildPostedPrivateCapitalActivityProjectionAsync(normalizedFundProfileId, ledgerBookId, ct).ConfigureAwait(false);
+        var posted = await BuildPostedPrivateCapitalActivityProjectionAsync(normalizedFundProfileId, ledgerBookId, ct, normalizedTenantId, normalizedCompanyId).ConfigureAwait(false);
         var reportPackWorkflowRecords = _reportPackWorkflowService?.ListRecords(200) ?? [];
         var privateCapitalActivity = PrivateCapitalActivityProjectionBuilder.Build(
             new PrivateCapitalActivityProjectionInput(
@@ -3391,7 +3391,7 @@ public sealed class ManualJournalEntryWorkbenchService : IManualJournalEntryWork
         var drafts = await _draftStore.ListAsync(normalizedFundProfileId, ledgerBookId, ct, normalizedTenantId, normalizedCompanyId).ConfigureAwait(false);
         var audit = await _auditStore.ListAsync(normalizedFundProfileId, ledgerBookId, ct, normalizedTenantId, normalizedCompanyId).ConfigureAwait(false);
         var bankTransactions = await ListBankTransactionsAsync(ct).ConfigureAwait(false);
-        var posted = await BuildPostedPrivateCapitalActivityProjectionAsync(normalizedFundProfileId, ledgerBookId, ct).ConfigureAwait(false);
+        var posted = await BuildPostedPrivateCapitalActivityProjectionAsync(normalizedFundProfileId, ledgerBookId, ct, normalizedTenantId, normalizedCompanyId).ConfigureAwait(false);
         var reportPackWorkflowRecords = _reportPackWorkflowService?.ListRecords(200) ?? [];
         return PrivateCapitalActivityProjectionBuilder.Build(
             new PrivateCapitalActivityProjectionInput(
@@ -3407,7 +3407,9 @@ public sealed class ManualJournalEntryWorkbenchService : IManualJournalEntryWork
     private async Task<PostedPrivateCapitalActivityProjection?> BuildPostedPrivateCapitalActivityProjectionAsync(
         string fundProfileId,
         Guid? ledgerBookId,
-        CancellationToken ct)
+        CancellationToken ct,
+        string? tenantId,
+        string? companyId)
     {
         if (_journalStore is null)
         {
@@ -3433,6 +3435,11 @@ public sealed class ManualJournalEntryWorkbenchService : IManualJournalEntryWork
             var records = await _journalStore.GetByPeriodAsync(period.PeriodId, ct).ConfigureAwait(false);
             foreach (var record in records.OrderBy(static item => item.GlobalSequence).ThenBy(static item => item.Entry.Timestamp))
             {
+                if (!MatchesPostedTenantScope(record.Entry.Metadata, tenantId, companyId))
+                {
+                    continue;
+                }
+
                 if (journalEntryIds.Add(record.Entry.JournalEntryId))
                 {
                     ledger.Post(record.Entry);
@@ -3444,6 +3451,36 @@ public sealed class ManualJournalEntryWorkbenchService : IManualJournalEntryWork
         return new PostedPrivateCapitalActivityProjection(
             PrivateCapitalFundEventLedgerProjector.Project(ledger),
             journalEntryCurrencies);
+    }
+
+
+    private static bool MatchesPostedTenantScope(JournalEntryMetadata? metadata, string? tenantId, string? companyId)
+    {
+        var normalizedTenantId = NormalizeOptional(tenantId);
+        var normalizedCompanyId = NormalizeOptional(companyId);
+        if (normalizedTenantId is null && normalizedCompanyId is null)
+        {
+            return true;
+        }
+
+        var tags = metadata?.Tags;
+        return MatchesPostedScopeTag(tags, "tenantId", normalizedTenantId) &&
+               MatchesPostedScopeTag(tags, "companyId", normalizedCompanyId);
+    }
+
+    private static bool MatchesPostedScopeTag(
+        IReadOnlyDictionary<string, string>? tags,
+        string tagName,
+        string? expected)
+    {
+        if (expected is null)
+        {
+            return true;
+        }
+
+        return tags is not null &&
+               tags.TryGetValue(tagName, out var actual) &&
+               string.Equals(NormalizeOptional(actual), expected, StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task<string> ResolveLedgerBookCurrencyAsync(
@@ -4042,6 +4079,8 @@ public sealed class ManualJournalEntryWorkbenchService : IManualJournalEntryWork
         AddMetadataTag(tags, "accountingBasis", draft.AccountingBasis.ToString());
         AddMetadataTag(tags, "ledgerBookId", draft.LedgerBookId?.ToString("D"));
         AddMetadataTag(tags, "periodId", draft.PeriodId);
+        AddMetadataTag(tags, "tenantId", draft.TenantId);
+        AddMetadataTag(tags, "companyId", draft.CompanyId);
         AddMetadataTag(tags, "sourceEventId", postingCommand.SourceEventId?.ToString("D"));
         AddMetadataTag(tags, "sourceJournalEntryId", postingCommand.SourceJournalEntryId?.ToString("D"));
         if (evidenceLinks.Count > 0)

--- a/tests/Meridian.Tests/Ui/AccountingConfigurationServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/AccountingConfigurationServiceTests.cs
@@ -1013,6 +1013,54 @@ public sealed class AccountingConfigurationServiceTests
     }
 
     [Fact]
+    public async Task Scenario_ManualJournalEntryWorkbench_IsolatesPostedPrivateCapitalActivityByTenantAndCompanyScope()
+    {
+        var configuration = CreateService();
+        await SeedManualJournalTenantConfigurationAsync(configuration, "tenant-alpha", "company-shared");
+        await SeedManualJournalTenantConfigurationAsync(configuration, "tenant-beta", "company-shared");
+        var timestamp = DateTimeOffset.UtcNow;
+        var alphaJournalEntryId = Guid.NewGuid();
+        var betaJournalEntryId = Guid.NewGuid();
+        var journalStore = new PostedPrivateCapitalLedgerJournalStore(
+            new LedgerBookRecord(
+                ManualJournalLedgerBookId,
+                "fund-alpha",
+                Guid.NewGuid(),
+                FundStructureNodeKindDto.Fund,
+                "Fund Alpha GAAP book",
+                "USD",
+                timestamp,
+                timestamp),
+            new LedgerAccountingPeriod(
+                ManualJournalPeriodId,
+                ManualJournalLedgerBookId,
+                2026,
+                6,
+                "2026-06",
+                new DateOnly(2026, 6, 1),
+                new DateOnly(2026, 6, 30),
+                "Closed",
+                timestamp,
+                timestamp,
+                1),
+            CreatePostedPrivateCapitalJournalRecord(alphaJournalEntryId, "tenant-alpha", "company-shared", "fund-event:alpha", "capital-account:alpha", 1, timestamp),
+            CreatePostedPrivateCapitalJournalRecord(betaJournalEntryId, "tenant-beta", "company-shared", "fund-event:beta", "capital-account:beta", 2, timestamp));
+        var service = CreateManualJournalEntryWorkbenchService(configuration, journalStore);
+
+        var alphaActivity = await service.GetPrivateCapitalActivityAsync("fund-alpha", ManualJournalLedgerBookId, tenantId: "tenant-alpha", companyId: "company-shared");
+        var betaActivity = await service.GetPrivateCapitalActivityAsync("fund-alpha", ManualJournalLedgerBookId, tenantId: "tenant-beta", companyId: "company-shared");
+        var companyActivity = await service.GetPrivateCapitalActivityAsync("fund-alpha", ManualJournalLedgerBookId, companyId: "company-shared");
+
+        alphaActivity.FundEvents.Should().ContainSingle(item => item.FundEventId == "fund-event:alpha" && item.IsPosted);
+        alphaActivity.FundEvents.Should().NotContain(item => item.FundEventId == "fund-event:beta");
+        alphaActivity.LedgerImpacts.Should().ContainSingle(item => item.FundEventId == "fund-event:alpha");
+        alphaActivity.CapitalAccountSubledgerEntries.Should().ContainSingle(item => item.CapitalAccountId == "capital-account:alpha");
+        betaActivity.FundEvents.Should().ContainSingle(item => item.FundEventId == "fund-event:beta" && item.IsPosted);
+        betaActivity.FundEvents.Should().NotContain(item => item.FundEventId == "fund-event:alpha");
+        companyActivity.FundEvents.Select(item => item.FundEventId).Should().BeEquivalentTo("fund-event:alpha", "fund-event:beta");
+    }
+
+    [Fact]
     public async Task Scenario_ManualJournalEntryLifecycle_SubmitActionRetainsTransition()
     {
         var configuration = CreateService();
@@ -6767,6 +6815,65 @@ public sealed class AccountingConfigurationServiceTests
                 ? transactions.Where(transaction => transaction.EntityId == entityId.Value).ToArray()
                 : transactions);
         }
+    }
+
+
+    private static LedgerJournalEntryRecord CreatePostedPrivateCapitalJournalRecord(
+        Guid journalEntryId,
+        string tenantId,
+        string companyId,
+        string fundEventId,
+        string capitalAccountId,
+        long sequence,
+        DateTimeOffset timestamp)
+    {
+        var cashLedgerEntryId = Guid.NewGuid();
+        var capitalLedgerEntryId = Guid.NewGuid();
+        var journal = new JournalEntry(
+            journalEntryId,
+            timestamp,
+            $"Posted private-capital event {fundEventId}",
+            [
+                new LedgerEntry(
+                    cashLedgerEntryId,
+                    journalEntryId,
+                    timestamp,
+                    new LedgerAccount("Cash", LedgerAccountType.Asset, FinancialAccountId: "entity-master"),
+                    100m,
+                    0m,
+                    $"Posted private-capital event {fundEventId}"),
+                new LedgerEntry(
+                    capitalLedgerEntryId,
+                    journalEntryId,
+                    timestamp,
+                    new LedgerAccount("Capital Contributions", LedgerAccountType.Equity, FinancialAccountId: capitalAccountId),
+                    0m,
+                    100m,
+                    $"Posted private-capital event {fundEventId}")
+            ],
+            new JournalEntryMetadata(
+                ActivityType: "CapitalCall",
+                EffectiveDate: new DateOnly(2026, 6, 30),
+                FundEventId: fundEventId,
+                FundEventType: "CapitalCall",
+                CapitalAccountId: capitalAccountId,
+                Tags: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["tenantId"] = tenantId,
+                    ["companyId"] = companyId,
+                    ["automatedJournalStatus"] = "Posted",
+                    ["automatedJournalApprovalId"] = $"approval:{fundEventId}",
+                    ["evidenceLinks"] = $"/api/workstation/evidence/subjects/private-capital/{fundEventId}"
+                }));
+
+        return new LedgerJournalEntryRecord(
+            journal,
+            Guid.NewGuid(),
+            ManualJournalPeriodId,
+            CommandId: null,
+            CorrelationId: null,
+            GlobalSequence: sequence,
+            CreatedAt: timestamp);
     }
 
     private sealed class WritableManualJournalLedgerJournalStore(


### PR DESCRIPTION
### Motivation
- Prevent tenant-scoped API responses from including posted private-capital journal activity belonging to other tenants when funds or ledger books are shared.
- Ensure posted manual journal entries retain tenant/company provenance so projections and UI surfaces can enforce tenant isolation.

### Description
- Thread `tenantId`/`companyId` into `BuildPostedPrivateCapitalActivityProjectionAsync` and apply tenant/company filtering when replaying posted journal records into the projection via `MatchesPostedTenantScope` and `MatchesPostedScopeTag` helper methods.
- Add `tenantId` and `companyId` metadata tags to newly posted manual journal entries so future reads can filter posted activity by tenant/company.
- Update `GetWorkbenchAsync` and `GetPrivateCapitalActivityAsync` to request a tenant-scoped posted projection and combine it with scoped drafts/audit as before.
- Add a regression test `Scenario_ManualJournalEntryWorkbench_IsolatesPostedPrivateCapitalActivityByTenantAndCompanyScope` that constructs posted journal records with tenant/company tags and asserts tenant-scoped responses include only the appropriate posted events while company-only scope can include both tenants.

### Testing
- Added a regression test under `tests/Meridian.Tests/Ui/AccountingConfigurationServiceTests.cs` covering tenant-scoped posted activity isolation; the test was authored and committed but not executed here due to the local environment lacking the .NET SDK.
- Attempted to run `dotnet test --filter FullyQualifiedName~AccountingConfigurationServiceTests` but execution was blocked with `/bin/bash: dotnet: command not found` in this container, so unit tests remain unrun locally.
- Ran repository validation checks (format and lightweight static changes) before committing; no compile/test failures were observed during static edits in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38f99b3b208320a82a7d4a024ea501)