### PR TITLE
Prevent tenant/company ID collisions in latest-import cache key

### DIFF
--- a/src/Meridian.FinancialOperations/AccountingSystem/AccountingSystemIntegrationService.cs
+++ b/src/Meridian.FinancialOperations/AccountingSystem/AccountingSystemIntegrationService.cs
@@ -1424,7 +1424,7 @@ public sealed class AccountingSystemIntegrationService
         Guid? ledgerBookId,
         string? tenantId = null,
         string? companyId = null)
-        => $"{NormalizeProviderId(providerId)}|{NormalizeFundProfileId(fundProfileId)}|{ledgerBookId?.ToString("D") ?? "none"}|{BuildTenantPackageScope(tenantId, companyId)}";
+        => $"{NormalizeProviderId(providerId)}|{NormalizeFundProfileId(fundProfileId)}|{ledgerBookId?.ToString("D") ?? "none"}|{BuildTenantCacheScope(tenantId, companyId)}";
 
     private static string MappingProfileKey(
         string providerId,
@@ -1492,6 +1492,24 @@ public sealed class AccountingSystemIntegrationService
         }
 
         return $"tenant-{SanitizeId(normalizedTenantId ?? "default")}-company-{SanitizeId(normalizedCompanyId ?? "default")}";
+    }
+
+    private static string BuildTenantCacheScope(string? tenantId, string? companyId)
+    {
+        var normalizedTenantId = NormalizeOptional(tenantId);
+        var normalizedCompanyId = NormalizeOptional(companyId);
+        if (normalizedTenantId is null && normalizedCompanyId is null)
+        {
+            return string.Empty;
+        }
+
+        return $"tenant:{LengthPrefixedCacheSegment(normalizedTenantId)}|company:{LengthPrefixedCacheSegment(normalizedCompanyId)}";
+    }
+
+    private static string LengthPrefixedCacheSegment(string? value)
+    {
+        var segment = value ?? "default";
+        return $"{segment.Length}:{segment}";
     }
 
     private static DateOnly CurrentMonthStart()

--- a/tests/Meridian.Tests/Ui/AccountingSystemIntegrationServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/AccountingSystemIntegrationServiceTests.cs
@@ -1797,6 +1797,32 @@ public sealed class AccountingSystemIntegrationServiceTests
         betaReconciliation.PeriodEnd.Should().Be(betaLatest.Summary.PeriodEnd);
     }
 
+    [Fact]
+    public async Task LatestImport_DoesNotReuseImportsWhenTenantOrCompanyIdsSanitizeToSamePackageScope()
+    {
+        var service = CreateService(CreateMatchedQuickBooksFixtureLedgerStore());
+
+        var alphaImport = await service.ImportAsync(new AccountingSystemImportRequestDto(
+            "quickbooks-fixture",
+            FundProfileId: "default-fund",
+            LedgerBookId: ExternalGlLedgerBookId,
+            PeriodStart: new DateOnly(2026, 2, 1),
+            PeriodEnd: new DateOnly(2026, 2, 28),
+            TenantId: "tenant-a",
+            CompanyId: "company_1"));
+        var betaLatest = await service.GetLatestImportAsync(
+            "quickbooks-fixture",
+            "default-fund",
+            ExternalGlLedgerBookId,
+            tenantId: "tenant_a",
+            companyId: "company-1");
+
+        betaLatest.Summary.TenantId.Should().Be("tenant_a");
+        betaLatest.Summary.CompanyId.Should().Be("company-1");
+        betaLatest.Summary.PeriodEnd.Should().Be(new DateOnly(2026, 1, 31));
+        betaLatest.Summary.ImportId.Should().NotBe(alphaImport.Summary.ImportId);
+    }
+
 
     [Theory]
     [InlineData("xero-fixture", "xero-default-fund-certified", "090", "xero-bank-001", 179_050)]


### PR DESCRIPTION
### Motivation

- The previous cache key used a filename-oriented sanitized tenant/company scope (`SanitizeId`) which is lossy and can collapse distinct identifiers (e.g. `tenant-a` vs `tenant_a`), allowing cross-tenant reuse/overwrite of persisted external-GL import previews.
- The change preserves the sanitized scope used for export/package IDs (which is appropriate for filenames/display) while ensuring the cache key is non-lossy for security/isolation.

### Description

- `ImportKey` now uses a distinct, non-lossy tenant cache scope by calling `BuildTenantCacheScope` instead of the filename-oriented `BuildTenantPackageScope` in `AccountingSystemIntegrationService.cs`.
- Added `BuildTenantCacheScope` and `LengthPrefixedCacheSegment` helpers to produce length-prefixed raw normalized segments (`"<len>:<value>"`) for tenant and company in the cache key so punctuation-preserving IDs remain distinct.
- Kept the existing `BuildTenantPackageScope` and `SanitizeId` for package/export ID generation to preserve filename-safe behavior where appropriate.
- Added a regression unit test `LatestImport_DoesNotReuseImportsWhenTenantOrCompanyIdsSanitizeToSamePackageScope` to `AccountingSystemIntegrationServiceTests.cs` that verifies imports are not reused when tenant/company IDs would collide under the old sanitizer.

### Testing

- Ran `git diff --check` to verify no whitespace/patch errors and it succeeded.
- Attempted to run the narrow unit tests with `dotnet test --filter "FullyQualifiedName~AccountingSystemIntegrationServiceTests.LatestImport"` but this was blocked because `dotnet` is not installed in the execution environment, so automated test execution could not be completed here.
- Added the focused regression test to the existing test suite to be executed in CI or a local environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37ff6b91a0832095f7166bf5326cc9)