### PR TITLE
Secure WPF manual journal lifecycle actions

### DIFF
--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -275,8 +275,8 @@
       "id": "SRC-WPF",
       "path": "src/Meridian.Wpf",
       "readme": "src/Meridian.Wpf/README.md",
-      "readme_hash": "b44d8b1f1b2ef375f2c5684d60b4b201d47e3316d21bd17f012a1aa38557c86d",
-      "source_hash": "b5ce70c50b7a8c66fdf73dd8453bcd2bf2b9ce00f5668f5baa977317cd85b55d"
+      "readme_hash": "ae57a9416e3e8b8503439ac50924028a09707320c2369c1a3aeff7cd6c0d2123",
+      "source_hash": "1c290a3980ce1b5704658c617e99cd67b26a78ca9b1e71d62c57fcfb02f93ac3"
     }
   ],
   "schema": {

--- a/src/Meridian.Wpf/README.md
+++ b/src/Meridian.Wpf/README.md
@@ -57,7 +57,10 @@ balances, accrued expenses, prepaid expenses, expenses, amortization, deferrals,
 reversals, capital calls, distributions, subscriptions, redemptions, LP transfers, and management
 fees, builds governed posting-rule journal draft candidate previews through the shared posting
 candidate service without posting to the ledger, exposes approve, post, reverse, rebook, and
-close-lock lifecycle buttons over the shared journal-entry lifecycle service, shows read-only
+close-lock lifecycle buttons over the shared journal-entry lifecycle service only for authenticated
+operators with `AdminMaintenance`, passes the desktop session actor into those lifecycle requests,
+and forwards retained draft evidence without generating WPF-local approval, posting, correction, or
+close-lock evidence links, shows read-only
 external GL evidence and retained package readiness, projects
 close/evidence/reconciliation posture from shared operations continuity when available, and creates
 fund-scoped accounting-basis policy records through the Financial Operations policy service.

--- a/src/Meridian.Wpf/ViewModels/Accounting/AccountingConfigureViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/Accounting/AccountingConfigureViewModel.cs
@@ -7,6 +7,7 @@ using Meridian.Contracts.Ledger;
 using Meridian.Contracts.Workstation;
 using Meridian.FinancialOperations.AccountingSystem;
 using Meridian.FinancialOperations.Ledger;
+using Meridian.Identity.Auth;
 using Meridian.Ui.Shared.Services;
 using Meridian.Wpf.Models;
 using Meridian.Wpf.Services;
@@ -152,6 +153,7 @@ public sealed class AccountingConfigureViewModel : Meridian.Wpf.ViewModels.Binda
     private readonly IAccountingPolicyService? _accountingPolicyService;
     private readonly IAccountingPostingCandidateService? _accountingPostingCandidateService;
     private readonly IManualJournalEntryLifecycleService? _manualJournalEntryLifecycleService;
+    private readonly DesktopAuthenticationSession? _authenticationSession;
 
     private AccountingConfigurationWorkspaceDto? _configuration;
     private ManualJournalEntryDraftDto? _selectedDraft;
@@ -196,7 +198,8 @@ public sealed class AccountingConfigureViewModel : Meridian.Wpf.ViewModels.Binda
         IAccountingPolicyService? accountingPolicyService = null,
         ICapitalAccountWorkbenchService? capitalAccountWorkbenchService = null,
         IAccountingPostingCandidateService? accountingPostingCandidateService = null,
-        IManualJournalEntryLifecycleService? manualJournalEntryLifecycleService = null)
+        IManualJournalEntryLifecycleService? manualJournalEntryLifecycleService = null,
+        DesktopAuthenticationSession? authenticationSession = null)
     {
         _fundContextService = fundContextService ?? throw new ArgumentNullException(nameof(fundContextService));
         _configurationService = configurationService ?? throw new ArgumentNullException(nameof(configurationService));
@@ -210,6 +213,7 @@ public sealed class AccountingConfigureViewModel : Meridian.Wpf.ViewModels.Binda
         _accountingPostingCandidateService = accountingPostingCandidateService;
         _manualJournalEntryLifecycleService = manualJournalEntryLifecycleService
             ?? manualJournalEntryWorkbenchService as IManualJournalEntryLifecycleService;
+        _authenticationSession = authenticationSession;
 
         RefreshCommand = new AsyncRelayCommand(() => RefreshAsync());
         SeedBaselineConfigurationCommand = new AsyncRelayCommand(() => SeedBaselineConfigurationAsync());
@@ -777,9 +781,15 @@ public sealed class AccountingConfigureViewModel : Meridian.Wpf.ViewModels.Binda
             return;
         }
 
+        if (!TryAuthorizeManualJournalLifecycleAction(action, out var actor, out var authorizationMessage))
+        {
+            ManualJournalLifecycleStatusText = authorizationMessage;
+            return;
+        }
+
         try
         {
-            var request = BuildManualJournalLifecycleRequest(_selectedDraft, action);
+            var request = BuildManualJournalLifecycleRequest(_selectedDraft, action, actor);
             var result = await _manualJournalEntryLifecycleService
                 .ApplyLifecycleActionAsync(request, ct)
                 .ConfigureAwait(false);
@@ -1141,7 +1151,8 @@ public sealed class AccountingConfigureViewModel : Meridian.Wpf.ViewModels.Binda
 
     private JournalEntryLifecycleActionRequestDto BuildManualJournalLifecycleRequest(
         ManualJournalEntryDraftDto draft,
-        JournalEntryLifecycleActionDto action)
+        JournalEntryLifecycleActionDto action,
+        string actor)
     {
         var notes = action switch
         {
@@ -1156,43 +1167,60 @@ public sealed class AccountingConfigureViewModel : Meridian.Wpf.ViewModels.Binda
             draft.JournalEntryId,
             draft.FundProfileId,
             action,
-            DefaultActor,
+            actor,
             draft.Version,
             notes,
             CorrelationId: $"wpf-manual-je-{action.ToString().ToLowerInvariant()}",
-            EvidenceLinks: BuildManualJournalLifecycleEvidenceLinks(draft, action),
+            EvidenceLinks: BuildManualJournalLifecycleEvidenceLinks(draft),
             RebookLines: action == JournalEntryLifecycleActionDto.Rebook
                 ? BuildManualJournalRebookLines(draft)
                 : []);
     }
 
-    private static IReadOnlyList<string> BuildManualJournalLifecycleEvidenceLinks(
-        ManualJournalEntryDraftDto draft,
-        JournalEntryLifecycleActionDto action)
+    private bool TryAuthorizeManualJournalLifecycleAction(
+        JournalEntryLifecycleActionDto action,
+        out string actor,
+        out string message)
     {
-        var journalId = draft.JournalEntryId.ToString("D");
-        var period = string.IsNullOrWhiteSpace(draft.PeriodId)
-            ? draft.AccountingDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
-            : draft.PeriodId;
-        var actionToken = action.ToString().ToLowerInvariant();
-        var required = action switch
-        {
-            JournalEntryLifecycleActionDto.Approve => $"approval://manual-je/{journalId}/review-approval/{period}",
-            JournalEntryLifecycleActionDto.Post => $"posting://manual-je/{journalId}/ledger-posting-review/{period}",
-            JournalEntryLifecycleActionDto.Reverse => $"correction://manual-je/{journalId}/reversal-review/{period}",
-            JournalEntryLifecycleActionDto.Rebook => $"correction://manual-je/{journalId}/rebook-review/{period}",
-            JournalEntryLifecycleActionDto.LockAfterClose => $"close://manual-je/{journalId}/period-lock-close-certification/{period}",
-            JournalEntryLifecycleActionDto.Reject => $"rejection://manual-je/{journalId}/review-rejection/{period}",
-            _ => $"review://manual-je/{journalId}/{actionToken}/{period}"
-        };
+        actor = string.Empty;
+        message = string.Empty;
 
-        return draft.EvidenceLinks
-            .Append(required)
+        if (action == JournalEntryLifecycleActionDto.Validate)
+        {
+            actor = ResolveDesktopActor();
+            return true;
+        }
+
+        if (_authenticationSession?.CurrentPermissions is not UserPermission permissions ||
+            (permissions & UserPermission.AdminMaintenance) != UserPermission.AdminMaintenance)
+        {
+            message = "Manual journal lifecycle action is blocked: AdminMaintenance permission is required for approval, posting, correction, and close-lock actions.";
+            return false;
+        }
+
+        actor = ResolveDesktopActor();
+        if (string.IsNullOrWhiteSpace(actor))
+        {
+            message = "Manual journal lifecycle action is blocked: authenticated desktop actor could not be resolved.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private string ResolveDesktopActor()
+    {
+        var actor = _authenticationSession?.CurrentActor;
+        return string.IsNullOrWhiteSpace(actor) ? DefaultActor : actor.Trim();
+    }
+
+    private static IReadOnlyList<string> BuildManualJournalLifecycleEvidenceLinks(
+        ManualJournalEntryDraftDto draft)
+        => draft.EvidenceLinks
             .Where(static link => !string.IsNullOrWhiteSpace(link))
             .Select(static link => link.Trim())
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
-    }
 
     private static IReadOnlyList<ManualJournalEntryLineDto> BuildManualJournalRebookLines(ManualJournalEntryDraftDto draft)
         => draft.Lines

--- a/tests/Meridian.Wpf.Tests/ViewModels/AccountingConfigureViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/AccountingConfigureViewModelTests.cs
@@ -5,6 +5,7 @@ using Meridian.Contracts.Workstation;
 using Meridian.DataIntegration.AccountingSystem.QuickBooks;
 using Meridian.FinancialOperations.AccountingSystem;
 using Meridian.FinancialOperations.Ledger;
+using Meridian.Identity.Auth;
 using Meridian.Ui.Shared.Services;
 using Meridian.Wpf.Models;
 using Meridian.Wpf.Services;
@@ -449,7 +450,14 @@ public sealed class AccountingConfigureViewModelTests : IDisposable
             VehicleIds: ["vehicle-master"],
             IsDefault: true));
         await fundContext.SelectFundProfileAsync(profile.FundProfileId);
-        var harness = CreateHarness(fundContext);
+        using var env = new DesktopAuthenticationSessionTests.EnvironmentVariableScope()
+            .Set("MDC_USERS", DesktopAuthenticationSessionTests.HashedDesktopAdminUsersJson())
+            .Set("MDC_USERNAME", null)
+            .Set("MDC_PASSWORD_HASH", null)
+            .Set("MDC_AUTH_MODE", null);
+        var session = DesktopAuthenticationSessionTests.CreateSession("Production");
+        session.SignIn("desktop-admin", "pw").Succeeded.Should().BeTrue();
+        var harness = CreateHarness(fundContext, session);
 
         await harness.ViewModel.LoadAsync();
         await harness.ViewModel.SeedBaselineConfigurationAsync();
@@ -457,6 +465,7 @@ public sealed class AccountingConfigureViewModelTests : IDisposable
         harness.ViewModel.DraftAmount = 275m;
         await harness.ViewModel.SaveManualJournalDraftAsync();
         await harness.ViewModel.SubmitManualJournalDraftAsync();
+        await RetainLifecycleEvidenceAsync(harness, profile.FundProfileId);
 
         await harness.ViewModel.ApplyManualJournalLifecycleActionAsync(JournalEntryLifecycleActionDto.Approve);
         harness.ViewModel.ManualJournalLifecycleStatusText.Should().Contain("Approve");
@@ -490,6 +499,42 @@ public sealed class AccountingConfigureViewModelTests : IDisposable
             draft.EntryType == ManualJournalEntryTypeDto.Reversal
             && draft.ReversalOfJournalEntryId == reversed.JournalEntryId
             && draft.Status == ManualJournalEntryStatusDto.Draft);
+    }
+
+
+    [Fact]
+    public async Task ManualJournalLifecycleCommands_WithoutAdminMaintenance_FailClosedBeforeSharedService()
+    {
+        Directory.CreateDirectory(_root);
+        var fundContext = new FundContextService(Path.Combine(_root, "fund-context.json"));
+        var profile = await fundContext.UpsertProfileAsync(new FundProfileDetail(
+            FundProfileId: "alpha-fund",
+            DisplayName: "Alpha Fund",
+            LegalEntityName: "Alpha Fund LP",
+            BaseCurrency: "USD",
+            DefaultWorkspaceId: "accounting",
+            DefaultLandingPageTag: "FundAccountingConfigure",
+            DefaultLedgerScope: FundLedgerScope.Consolidated,
+            EntityIds: ["entity-alpha"],
+            SleeveIds: ["sleeve-credit"],
+            VehicleIds: ["vehicle-master"],
+            IsDefault: true));
+        await fundContext.SelectFundProfileAsync(profile.FundProfileId);
+        var harness = CreateHarness(fundContext);
+
+        await harness.ViewModel.LoadAsync();
+        await harness.ViewModel.SeedBaselineConfigurationAsync();
+        harness.ViewModel.SelectedEntryType = ManualJournalEntryTypeDto.CapitalCall;
+        harness.ViewModel.DraftAmount = 275m;
+        await harness.ViewModel.SaveManualJournalDraftAsync();
+        await harness.ViewModel.SubmitManualJournalDraftAsync();
+
+        await harness.ViewModel.ApplyManualJournalLifecycleActionAsync(JournalEntryLifecycleActionDto.Approve);
+
+        harness.ViewModel.ManualJournalLifecycleStatusText.Should().Contain("AdminMaintenance permission is required");
+        var reloadedDraftStore = new FileManualJournalEntryDraftStore(harness.DraftsPath);
+        var retainedDrafts = await reloadedDraftStore.ListAsync(profile.FundProfileId);
+        retainedDrafts.Should().ContainSingle(draft => draft.Status == ManualJournalEntryStatusDto.Submitted);
     }
 
     [Fact]
@@ -590,7 +635,7 @@ public sealed class AccountingConfigureViewModelTests : IDisposable
         }
     }
 
-    private AccountingConfigureHarness CreateHarness(FundContextService fundContext)
+    private AccountingConfigureHarness CreateHarness(FundContextService fundContext, DesktopAuthenticationSession? authenticationSession = null)
     {
         var configurationPath = Path.Combine(_root, "accounting-configuration.json");
         var draftsPath = Path.Combine(_root, "manual-journal-drafts.json");
@@ -617,9 +662,40 @@ public sealed class AccountingConfigureViewModelTests : IDisposable
             fundOperationsWorkspaceReadService: null,
             policyService,
             capitalAccountWorkbenchService,
-            postingCandidateService);
+            postingCandidateService,
+            authenticationSession: authenticationSession);
 
         return new AccountingConfigureHarness(viewModel, configurationPath, draftsPath, postingCandidateService);
+    }
+
+
+    private static async Task RetainLifecycleEvidenceAsync(
+        AccountingConfigureHarness harness,
+        string fundProfileId)
+    {
+        var draftStore = new FileManualJournalEntryDraftStore(harness.DraftsPath);
+        var draft = (await draftStore.ListAsync(fundProfileId))
+            .Single(item => item.Status == ManualJournalEntryStatusDto.Submitted);
+        var journalId = draft.JournalEntryId.ToString("D");
+        var retainedEvidence = draft.EvidenceLinks
+            .Concat([
+                $"evidence://manual-je/{journalId}/retained-review-approval",
+                $"evidence://manual-je/{journalId}/retained-ledger-posting-review",
+                $"evidence://manual-je/{journalId}/retained-reversal-correction-review",
+                $"evidence://manual-je/{journalId}/retained-period-lock-close-certification"
+            ])
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var retained = draft with
+        {
+            EvidenceLinks = retainedEvidence,
+            Version = draft.Version + 1
+        };
+
+        await draftStore.SaveAsync(retained);
+        typeof(AccountingConfigureViewModel)
+            .GetField("_selectedDraft", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(harness.ViewModel, retained);
     }
 
     private sealed record AccountingConfigureHarness(


### PR DESCRIPTION
### Motivation
- The WPF accounting page called the shared manual journal lifecycle service directly with a hard-coded actor and auto-generated evidence links, allowing desktop users to bypass the HTTP endpoint's `AdminMaintenance` authorization gate and evidence provenance checks. 
- This change closes that authorization and evidence-control bypass so lifecycle transitions (approve/post/reverse/rebook/lock) require the same privileged desktop permission semantics as server endpoints. 

### Description
- Inject `DesktopAuthenticationSession` into `AccountingConfigureViewModel` and require `AdminMaintenance` for non-validation lifecycle actions via `TryAuthorizeManualJournalLifecycleAction`. 
- Use the resolved desktop actor in lifecycle requests instead of the previous `DefaultActor`. 
- Stop fabricating WPF-local approval/posting/correction/close evidence URIs and forward only retained draft evidence links to the shared lifecycle service. 
- Add view-model tests that cover the authorized lifecycle happy path (with retained evidence) and a fail-closed unauthorized path, and update the WPF README to document the new authorization/evidence behavior while refreshing the SRC-WPF source-hash manifest. 

### Testing
- Ran `git diff --check` to validate whitespace/lint-level diffs and confirm the working tree edits (no check failures). 
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --write-module SRC-WPF --summary` to refresh and validate the SRC-WPF README/source hash for the module. 
- Attempted `dotnet test` for the WPF test project (`tests/Meridian.Wpf.Tests`) but the environment lacks the .NET SDK so the command could not run (`dotnet: command not found`). 
- `python3 build/scripts/docs/validate-doc-hashes.py --summary` (full docs validation) remained blocked by pre-existing multi-module doc/source hash drift outside this change and was not run to completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36429dcc148320a5f2265c0e97b9b5)