### PR TITLE
Prevent ManageUsers privilege escalation in account upsert

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/AuthEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/AuthEndpoints.cs
@@ -216,6 +216,15 @@ public static class AuthEndpoints
                         return ToAuthorizationFailure(auth.StatusCode.Value);
                     }
 
+                    var accountGrantFailure = ValidateAssignableAccountMutation(
+                        request.Role,
+                        request.PermissionNames,
+                        auth.Permissions);
+                    if (accountGrantFailure is not null)
+                    {
+                        return accountGrantFailure;
+                    }
+
                     try
                     {
                         var result = await accountStore.UpsertAsync(request, auth.Actor, ct).ConfigureAwait(false);
@@ -646,15 +655,48 @@ public static class AuthEndpoints
         }
         else
         {
-            return new ManageUsersActor(string.Empty, StatusCodes.Status401Unauthorized);
+            return new ManageUsersActor(string.Empty, StatusCodes.Status401Unauthorized, UserPermission.None);
         }
 
         if ((currentPermissions & UserPermission.ManageUsers) != UserPermission.ManageUsers)
         {
-            return new ManageUsersActor(actor ?? requestedBy, StatusCodes.Status403Forbidden);
+            return new ManageUsersActor(actor ?? requestedBy, StatusCodes.Status403Forbidden, currentPermissions);
         }
 
-        return new ManageUsersActor(actor ?? requestedBy, null);
+        return new ManageUsersActor(actor ?? requestedBy, null, currentPermissions);
+    }
+
+    private static IResult? ValidateAssignableAccountMutation(
+        string role,
+        IReadOnlyList<string>? permissionNames,
+        UserPermission actorPermissions)
+    {
+        if (!Enum.TryParse<UserRole>(role?.Trim(), ignoreCase: true, out var parsedRole))
+        {
+            return Results.BadRequest(new { error = $"Unknown role '{role}'." });
+        }
+
+        UserPermission requestedPermissions;
+        if (permissionNames is { Count: > 0 })
+        {
+            if (!RolePermissions.TryParsePermissionNames(permissionNames, out requestedPermissions, out var invalid)
+                || invalid.Count > 0)
+            {
+                return Results.BadRequest(new { error = $"Unknown permissions: {string.Join(", ", invalid)}." });
+            }
+        }
+        else
+        {
+            requestedPermissions = RolePermissions.For(parsedRole);
+        }
+
+        var ungrantablePermissions = requestedPermissions & ~actorPermissions;
+        if (ungrantablePermissions != UserPermission.None)
+        {
+            return EndpointHelpers.Forbidden();
+        }
+
+        return null;
     }
 
     private static IResult ToAuthorizationFailure(int statusCode)
@@ -662,7 +704,7 @@ public static class AuthEndpoints
             ? Results.Unauthorized()
             : EndpointHelpers.Forbidden();
 
-    private sealed record ManageUsersActor(string Actor, int? StatusCode);
+    private sealed record ManageUsersActor(string Actor, int? StatusCode, UserPermission Permissions);
 }
 
 /// <summary>Login request body for JSON clients.</summary>

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -37,7 +37,9 @@ Ownership lifecycle mutation routes under `/api/fund-structure/links/{id}` requi
 
 Auth endpoints expose governed user-account administration, password reset, account disable, session
 revocation, account audit, role-profile administration, and scoped access assignment administration from
-the shared workstation host while delegating identity state to `Meridian.Identity`. `EndpointAuthorization`
+the shared workstation host while delegating identity state to `Meridian.Identity`. Account upserts require
+`ManageUsers` and may only grant permissions already held by the current caller, including permissions
+expanded from a requested built-in role when the request omits an explicit permission override. `EndpointAuthorization`
 keeps the existing global role checks for compatibility and adds scoped authorization helpers so
 governance-core routes can require a permission on a specific organization, fund, portfolio, legal
 entity, or account.

--- a/tests/Meridian.Tests/Integration/EndpointTests/RoleAuthorizationTests.cs
+++ b/tests/Meridian.Tests/Integration/EndpointTests/RoleAuthorizationTests.cs
@@ -725,10 +725,58 @@ public sealed class RoleAuthorizationTests : EndpointIntegrationTestBase
     }
 
     [Fact]
+    public async Task AuthAccounts_DelegatedManageUsersCannotGrantUnheldAdminPermissions()
+    {
+        var username = $"delegated-admin-{Guid.NewGuid():N}";
+        using var delegatedClient = Fixture.CreatePermittedClient(UserPermission.ManageUsers);
+
+        var createResponse = await delegatedClient.PutAsJsonAsync(
+            $"/api/auth/accounts/{username}",
+            new UserAccountUpsertRequestDto(
+                Username: username,
+                Role: nameof(UserRole.Admin),
+                RoleProfileName: null,
+                PermissionNames: null,
+                NewPassword: "initial-pass",
+                PasswordHash: null,
+                IsDisabled: false,
+                PasswordResetRequired: false,
+                RequestedBy: "delegated-account-admin",
+                Rationale: "Attempt to grant full admin from delegated user administration.",
+                CorrelationId: "auth-account-admin-escalation"));
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task AuthAccounts_DelegatedManageUsersCannotGrantExplicitUnheldPermissions()
+    {
+        var username = $"delegated-trader-{Guid.NewGuid():N}";
+        using var delegatedClient = Fixture.CreatePermittedClient(UserPermission.ManageUsers);
+
+        var createResponse = await delegatedClient.PutAsJsonAsync(
+            $"/api/auth/accounts/{username}",
+            new UserAccountUpsertRequestDto(
+                Username: username,
+                Role: nameof(UserRole.TradeDesk),
+                RoleProfileName: null,
+                PermissionNames: [nameof(UserPermission.ExecuteTrades)],
+                NewPassword: "initial-pass",
+                PasswordHash: null,
+                IsDisabled: false,
+                PasswordResetRequired: false,
+                RequestedBy: "delegated-account-admin",
+                Rationale: "Attempt to grant trading authority from delegated user administration.",
+                CorrelationId: "auth-account-trade-escalation"));
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
     public async Task AuthAccounts_WithManageUsers_AdministersAccountLifecycleAndRevokesSessions()
     {
         var username = $"ops-{Guid.NewGuid():N}";
-        using var adminClient = Fixture.CreatePermittedClient(UserPermission.ManageUsers);
+        using var adminClient = Fixture.CreatePermittedClient(UserPermission.ManageUsers, UserPermission.ViewTrades);
 
         var createResponse = await adminClient.PutAsJsonAsync(
             $"/api/auth/accounts/{username}",


### PR DESCRIPTION
### Motivation
- Close an RBAC vulnerability where callers with `UserPermission.ManageUsers` could create or update accounts with role-expanded or explicit high-impact permissions (including `Admin`) they do not themselves hold.
- Ensure governed account mutations cannot be used for privilege escalation when deployments delegate `ManageUsers` to non-admin roles.
- Add regression coverage so future changes cannot reintroduce the same unchecked grant behavior.

### Description
- Add a permission-check gate in the account upsert endpoint by calling a new `ValidateAssignableAccountMutation` routine before `UpsertAsync` in `src/Meridian.Ui.Shared/Endpoints/AuthEndpoints.cs`, rejecting requests that try to assign permissions the caller does not hold.
- Extend `ResolveManageUsersActor` to return the caller's resolved `UserPermission` mask and propagate it to the validation routine, and update the `ManageUsersActor` record to include `Permissions`.
- Implement `ValidateAssignableAccountMutation` to parse the requested role/permissionNames (or expand built-in role defaults via `RolePermissions.For`) and return `Forbidden` for any permission that the caller does not already hold, and `BadRequest` for unknown inputs.
- Add two integration tests in `tests/Meridian.Tests/Integration/EndpointTests/RoleAuthorizationTests.cs`: `AuthAccounts_DelegatedManageUsersCannotGrantUnheldAdminPermissions` and `AuthAccounts_DelegatedManageUsersCannotGrantExplicitUnheldPermissions` to assert delegated `ManageUsers` callers are forbidden from granting Admin defaults or explicit unheld permissions.
- Update `src/Meridian.Ui.Shared/README.md` to document that account upserts require `ManageUsers` and may only grant permissions already held by the caller (including permissions expanded from a requested built-in role when no explicit permission list is provided).

### Testing
- Ran `git diff --check` to validate the patch formatting and it passed.
- Attempted `dotnet test` for the `RoleAuthorizationTests` filter but it was blocked in this environment because `dotnet` is not installed (`dotnet: command not found`).
- Ran `python3 build/scripts/docs/validate-doc-hashes.py --summary` which reported repository-wide doc/source hash drift unrelated to this change (validation failed); no test failures were introduced by the change itself in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26ba0162c48320bcd2502f903c875c)