### PR TITLE
Fix request lifecycle invalidate leaving status stuck running

### DIFF
--- a/src/Meridian.Ui/dashboard/src/hooks/use-request-lifecycle.test.ts
+++ b/src/Meridian.Ui/dashboard/src/hooks/use-request-lifecycle.test.ts
@@ -91,6 +91,35 @@ describe("useRequestLifecycle", () => {
     expect(next?.version).toBeGreaterThan(first!.version);
   });
 
+  it("Scenario_FullRefreshInvalidatesSubsidiaryRequest_ClearsRunningStatus", () => {
+    const { result } = renderHook(() => useRequestLifecycle({ operation: "trading refresh" }));
+
+    let subsidiary: ReturnType<typeof result.current.start>;
+    act(() => {
+      subsidiary = result.current.start();
+    });
+
+    expect(subsidiary).not.toBeNull();
+    expect(result.current.status.phase).toBe("running");
+    expect(result.current.status.inFlight).toBe(true);
+
+    act(() => {
+      result.current.invalidate();
+    });
+
+    expect(result.current.status.phase).toBe("stale");
+    expect(result.current.status.inFlight).toBe(false);
+    expect(result.current.status.message).toBe("An older refresh response was discarded.");
+
+    act(() => {
+      expect(result.current.finish(subsidiary!)).toBe(false);
+    });
+
+    expect(result.current.status.phase).toBe("stale");
+    expect(result.current.status.inFlight).toBe(false);
+    expect(result.current.status.staleDiscardCount).toBe(1);
+  });
+
   it("Scenario_RetryableProviderFailure_ExposesBackoffMetadataForUserStatus", () => {
     const { result } = renderHook(() => useRequestLifecycle({
       operation: "provider routing refresh",

--- a/src/Meridian.Ui/dashboard/src/hooks/use-request-lifecycle.ts
+++ b/src/Meridian.Ui/dashboard/src/hooks/use-request-lifecycle.ts
@@ -148,7 +148,18 @@ export function useRequestLifecycle({
     controllerRef.current?.abort();
     controllerRef.current = null;
     inFlightRef.current = false;
-  }, []);
+    if (mountedRef.current) {
+      const settledAt = new Date().toISOString();
+      setStatus((current) => ({
+        ...current,
+        phase: current.inFlight ? "stale" : current.phase,
+        inFlight: false,
+        version: versionRef.current,
+        message: current.inFlight ? staleMessage : current.message,
+        settledAt: current.inFlight ? settledAt : current.settledAt
+      }));
+    }
+  }, [staleMessage]);
 
   const start = useCallback((options: StartRequestOptions = {}): RequestLifecycleToken | null => {
     if (!mountedRef.current) {


### PR DESCRIPTION
### Motivation

- Prevent a UI state inconsistency where calling `invalidate()` could leave the exported lifecycle `status` as `{ phase: "running", inFlight: true }` even after the request was aborted or superseded.
- This was reachable when a full refresh invalidated subsidiary lifecycles (e.g. via `useWorkstationData`) and a later stale settlement preserved a running status.

### Description

- Update `invalidate()` in `src/Meridian.Ui/dashboard/src/hooks/use-request-lifecycle.ts` to update the exported `status` when an in-flight request is superseded, clearing `inFlight`, updating `version`, setting `settledAt`, and marking the phase/message as `stale` when appropriate.
- Preserve existing behavior for `abort()`, `start()`, `succeed()`, `fail()`, and `finish()` aside from ensuring `invalidate()` leaves the public state consistent.
- Add a regression test `Scenario_FullRefreshInvalidatesSubsidiaryRequest_ClearsRunningStatus` in `src/Meridian.Ui/dashboard/src/hooks/use-request-lifecycle.test.ts` that starts a subsidiary request, calls `invalidate()`, verifies the status is cleared and `stale`, and asserts a later stale `finish()` does not restore a running state.

### Testing

- Ran `npm --prefix src/Meridian.Ui/dashboard ci` which completed successfully.
- Ran `npm --prefix src/Meridian.Ui/dashboard run test:vitest -- src/hooks/use-request-lifecycle.test.ts` and the test file passed (5 tests passed).
- Ran `npm --prefix src/Meridian.Ui/dashboard run build` which failed due to pre-existing TypeScript type/export drift in other dashboard files unrelated to this hook change (build errors listed in local build output).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18d42a93d883208fb70675b129ad1f)