### PR TITLE
test(direct-lending): fix prepayment penalty endpoint test assertions

### DIFF
--- a/tests/Meridian.Tests/Ui/DirectLendingEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/DirectLendingEndpointsTests.cs
@@ -50,7 +50,7 @@ public sealed class DirectLendingEndpointsTests
         accrualResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var penaltyResponse = await client.PostAsJsonAsync(
-            $"/api/loans/{created.LoanId}/prepayment-penalty",
+            $"/api/loans/{created.LoanId}/prepayment-penalties",
             new ChargePrepaymentPenaltyRequest(200_000m, new DateOnly(2026, 3, 24), "prepay-rebuild"));
         penaltyResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
@@ -82,7 +82,7 @@ public sealed class DirectLendingEndpointsTests
 
         var projectedRevisions = await client.GetFromJsonAsync<List<ServicingRevisionDto>>($"/api/loans/{created.LoanId}/projections/revisions");
         projectedRevisions.Should().NotBeNull();
-        projectedRevisions!.Should().HaveCount(2);
+        projectedRevisions!.Should().HaveCount(3);
 
         var projectedAccruals = await client.GetFromJsonAsync<List<DailyAccrualEntryDto>>($"/api/loans/{created.LoanId}/projections/accruals");
         projectedAccruals.Should().NotBeNull();
@@ -216,5 +216,6 @@ public sealed class DirectLendingEndpointsTests
                 CommitmentFeeRate: 0.03m,
                 DefaultRateSpreadBps: 200m,
                 PrepaymentAllowed: true,
-                CovenantsJson: "{\"interestCoverage\": \">= 2.0x\"}"));
+                CovenantsJson: "{\"interestCoverage\": \">= 2.0x\"}",
+                PrepaymentPenaltyRate: 0.02m));
 }


### PR DESCRIPTION
### Motivation
- Repair a broken UI test that was introduced alongside the direct-lending rebuilder change so the test actually exercises the registered endpoint and validates the rebuilder behavior.
- Ensure the test's expected penalty value is produced by the fixture data so assertions reflect real behavior.
- Keep the change test-only so production code and behavior remain unchanged.

### Description
- Updated the test to call the registered plural endpoint by changing the request path to `"/api/loans/{created.LoanId}/prepayment-penalties"` in `DirectLendingEndpoints_ShouldCreateAndFetchLoanLifecycle`.
- Set `PrepaymentPenaltyRate: 0.02m` in the test `BuildCreateRequest()` `DirectLendingTermsDto` so the charged penalty produces the expected non-zero result.
- Adjusted the expected servicing revisions count assertion from `2` to `3` to account for the additional servicing revision created by the prepayment-penalty command.
- This PR changes only `tests/Meridian.Tests/Ui/DirectLendingEndpointsTests.cs` and makes no production code modifications.

### Testing
- Attempted a targeted test run with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~DirectLendingEndpointsTests" --no-restore -v minimal` but it failed in this environment due to `dotnet: command not found` so runtime tests could not be executed here.
- Static inspection and local edits were performed to verify the test path, fixture terms, and assertion updates are consistent with the registered endpoint and penalty calculation logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a8f883f88320b9677f06a7f80e4d)