### PR TITLE
Align fixture validators with roadmap/source schema required fields

### DIFF
--- a/tools/roadmap/validate_roadmap.py
+++ b/tools/roadmap/validate_roadmap.py
@@ -25,7 +25,7 @@ CANONICAL = {
     "evidence_posture": {"none", "draft", "partial", "verified", "audited"},
     "completion_term": {"done", "complete", "completed", "closed", "shipped"},
 }
-REQUIRED_FIELDS = {"id", "status", "health", "priority", "evidence_posture", "completion_term", "owner", "last_updated"}
+REQUIRED_FIELDS = {"id", "title", "owner", "status", "health", "priority", "evidence_posture", "completion_term", "exit_criteria", "links", "created_at", "last_updated"}
 ALLOWED_FIELDS = REQUIRED_FIELDS | {"title", "summary", "exit_criteria", "links", "evidence", "created_at", "target_date", "notes", "extensions"}
 
 

--- a/tools/source_docs/validate_source_readmes.py
+++ b/tools/source_docs/validate_source_readmes.py
@@ -25,7 +25,7 @@ CANONICAL = {
     "evidence_posture": {"none", "draft", "partial", "verified", "audited"},
     "completion_term": {"done", "complete", "completed", "closed", "shipped"},
 }
-REQUIRED_FIELDS = {"id", "name", "status", "health", "priority", "evidence_posture", "completion_term", "owner", "last_updated"}
+REQUIRED_FIELDS = {"id", "name", "owner", "status", "health", "priority", "evidence_posture", "completion_term", "exit_criteria", "links", "created_at", "last_updated"}
 ALLOWED_FIELDS = REQUIRED_FIELDS | {"summary", "exit_criteria", "links", "created_at", "notes", "extensions"}
 
 REQUIRED_FRONT_MATTER_KEYS = ("module_id", "owner", "status", "last_verified")


### PR DESCRIPTION
### Motivation
- Close a validation gap where Python fixture validators accepted JSON missing fields newly required by the strict JSON schemas for roadmap and source-doc documents.

### Description
- Updated `REQUIRED_FIELDS` in `tools/roadmap/validate_roadmap.py` and `tools/source_docs/validate_source_readmes.py` so fixture checks include schema-required keys such as `title`, `exit_criteria`, `links`, `created_at`, and `last_updated` and thus match the committed JSON schemas.

### Testing
- Ran `python3 tools/roadmap/validate_roadmap.py --fixtures-dir tools/roadmap/fixtures` and `python3 tools/source_docs/validate_source_readmes.py --fixtures-dir tools/source_docs/fixtures`, and validators continue to pass valid fixtures and now fail fixtures missing the schema-required keys (tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f3dcdfe3c83208786963f32c723da)