### PR TITLE
Fix sign-off metadata path handling in Wave 1 validation script

### DIFF
--- a/scripts/dev/run-wave1-provider-validation.ps1
+++ b/scripts/dev/run-wave1-provider-validation.ps1
@@ -368,6 +368,17 @@ $failedResults = @($results | Where-Object status -eq "failed")
 $jsonPath = Join-Path $summaryDir "wave1-validation-summary.json"
 $mdPath = Join-Path $summaryDir "wave1-validation-summary.md"
 
+$signoffMetadataPath = ""
+if (-not [string]::IsNullOrWhiteSpace($OperatorSignoffPath)) {
+    $resolvedSignoffPath = [System.IO.Path]::GetFullPath($OperatorSignoffPath)
+    if ($resolvedSignoffPath.StartsWith($repoRoot + [System.IO.Path]::DirectorySeparatorChar, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $signoffMetadataPath = $resolvedSignoffPath.Substring($repoRoot.Length + 1).Replace('\', '/')
+    }
+    else {
+        $signoffMetadataPath = $resolvedSignoffPath.Replace('\', '/')
+    }
+}
+
 $evidenceSchema = [ordered]@{
     version = "1.0"
     generatedAtUtc = (Get-Date).ToUniversalTime().ToString("O")
@@ -375,7 +386,7 @@ $evidenceSchema = [ordered]@{
     summaryMarkdownPath = $mdPath.Substring($repoRoot.Length + 1).Replace('\', '/')
     packetJsonPath = (Join-Path $summaryDir "dk1-pilot-parity-packet.json").Substring($repoRoot.Length + 1).Replace('\', '/')
     packetMarkdownPath = (Join-Path $summaryDir "dk1-pilot-parity-packet.md").Substring($repoRoot.Length + 1).Replace('\', '/')
-    signoffMetadataPath = if ([string]::IsNullOrWhiteSpace($OperatorSignoffPath)) { "" } else { [System.IO.Path]::GetFullPath($OperatorSignoffPath).Substring($repoRoot.Length + 1).Replace('\', '/') }
+    signoffMetadataPath = $signoffMetadataPath
 }
 
 $summary = [ordered]@{


### PR DESCRIPTION
### Motivation
- The evidence schema generation assumed `OperatorSignoffPath` was repo-relative and used `.Substring($repoRoot.Length + 1)`, which can throw `ArgumentOutOfRangeException` or produce truncated misleading paths for valid sign-off files located outside the repository.
- The change aims to make evidence metadata generation robust for both in-repo and external sign-off files while preserving repo-relative output when appropriate.

### Description
- Precompute a safe `$signoffMetadataPath` by resolving the operator sign-off with `[System.IO.Path]::GetFullPath($OperatorSignoffPath)` and normalizing separators to `/`.
- If the resolved sign-off path starts with `$repoRoot` plus the platform directory separator, emit a repo-relative substring; otherwise emit the normalized absolute path.
- Replace the previous inline `Substring(...)` expression in the `$evidenceSchema` with the precomputed `$signoffMetadataPath` to avoid out-of-range substring calls and misleading truncation.

### Testing
- No runtime PowerShell tests were run because `pwsh` is not available in the current environment. 
- Performed automated static verification by inspecting the updated file with `git diff -- scripts/dev/run-wave1-provider-validation.ps1` to confirm the intended replacement succeeded. 
- Confirmed the change was committed successfully with `git commit` and validated the modified lines via `rg`/`sed` file inspection commands.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f3dce1ea88320b680d01f69404982)