### PR TITLE
Ref-count duplicate market-data subscriptions in FailoverAwareMarketDataClient

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/Failover/FailoverAwareMarketDataClient.cs
+++ b/src/Meridian.Infrastructure/Adapters/Failover/FailoverAwareMarketDataClient.cs
@@ -40,6 +40,8 @@ public sealed class FailoverAwareMarketDataClient : IMarketDataClient
     private readonly ConcurrentDictionary<string, SymbolConfig> _activeTradeSubscriptions = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, int> _depthSubIds = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, int> _tradeSubIds = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, int> _depthSubscriberCounts = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, int> _tradeSubscriberCounts = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Creates a new failover-aware client.
@@ -103,7 +105,10 @@ public sealed class FailoverAwareMarketDataClient : IMarketDataClient
         ArgumentNullException.ThrowIfNull(cfg);
 
         if (_depthSubIds.TryGetValue(cfg.Symbol, out var existingId))
+        {
+            _depthSubscriberCounts.AddOrUpdate(cfg.Symbol, 1, static (_, current) => current + 1);
             return existingId;
+        }
 
         try
         {
@@ -112,6 +117,7 @@ public sealed class FailoverAwareMarketDataClient : IMarketDataClient
             {
                 _activeDepthSubscriptions[cfg.Symbol] = cfg;
                 _depthSubIds[cfg.Symbol] = id;
+                _depthSubscriberCounts[cfg.Symbol] = 1;
                 _failoverService.RecordSuccess(_activeProviderId);
             }
             return id;
@@ -127,13 +133,25 @@ public sealed class FailoverAwareMarketDataClient : IMarketDataClient
 
     public void UnsubscribeMarketDepth(int subscriptionId)
     {
-        // Find and remove the symbol for this subscription ID
+        var shouldUnsubscribeUpstream = true;
         var symbol = _depthSubIds.FirstOrDefault(kvp => kvp.Value == subscriptionId).Key;
         if (symbol != null)
         {
-            _activeDepthSubscriptions.TryRemove(symbol, out _);
-            _depthSubIds.TryRemove(symbol, out _);
+            if (_depthSubscriberCounts.TryGetValue(symbol, out var subscriberCount) && subscriberCount > 1)
+            {
+                _depthSubscriberCounts[symbol] = subscriberCount - 1;
+                shouldUnsubscribeUpstream = false;
+            }
+            else
+            {
+                _depthSubscriberCounts.TryRemove(symbol, out _);
+                _activeDepthSubscriptions.TryRemove(symbol, out _);
+                _depthSubIds.TryRemove(symbol, out _);
+            }
         }
+
+        if (!shouldUnsubscribeUpstream)
+            return;
 
         try
         {
@@ -150,7 +168,10 @@ public sealed class FailoverAwareMarketDataClient : IMarketDataClient
         ArgumentNullException.ThrowIfNull(cfg);
 
         if (_tradeSubIds.TryGetValue(cfg.Symbol, out var existingId))
+        {
+            _tradeSubscriberCounts.AddOrUpdate(cfg.Symbol, 1, static (_, current) => current + 1);
             return existingId;
+        }
 
         try
         {
@@ -159,6 +180,7 @@ public sealed class FailoverAwareMarketDataClient : IMarketDataClient
             {
                 _activeTradeSubscriptions[cfg.Symbol] = cfg;
                 _tradeSubIds[cfg.Symbol] = id;
+                _tradeSubscriberCounts[cfg.Symbol] = 1;
                 _failoverService.RecordSuccess(_activeProviderId);
             }
             return id;
@@ -174,12 +196,25 @@ public sealed class FailoverAwareMarketDataClient : IMarketDataClient
 
     public void UnsubscribeTrades(int subscriptionId)
     {
+        var shouldUnsubscribeUpstream = true;
         var symbol = _tradeSubIds.FirstOrDefault(kvp => kvp.Value == subscriptionId).Key;
         if (symbol != null)
         {
-            _activeTradeSubscriptions.TryRemove(symbol, out _);
-            _tradeSubIds.TryRemove(symbol, out _);
+            if (_tradeSubscriberCounts.TryGetValue(symbol, out var subscriberCount) && subscriberCount > 1)
+            {
+                _tradeSubscriberCounts[symbol] = subscriberCount - 1;
+                shouldUnsubscribeUpstream = false;
+            }
+            else
+            {
+                _tradeSubscriberCounts.TryRemove(symbol, out _);
+                _activeTradeSubscriptions.TryRemove(symbol, out _);
+                _tradeSubIds.TryRemove(symbol, out _);
+            }
         }
+
+        if (!shouldUnsubscribeUpstream)
+            return;
 
         try
         {

--- a/tests/Meridian.Tests/Infrastructure/Providers/FailoverAwareMarketDataClientTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/FailoverAwareMarketDataClientTests.cs
@@ -173,6 +173,22 @@ public sealed class FailoverAwareMarketDataClientTests : IAsyncLifetime
     }
 
     [Fact]
+    public void UnsubscribeMarketDepth_DuplicateSubscribers_OnlyUnsubscribesUpstreamAfterLastRelease()
+    {
+        var cfg = new SymbolConfig("SPY", SubscribeDepth: true);
+        var firstId = _sut.SubscribeMarketDepth(cfg);
+        var secondId = _sut.SubscribeMarketDepth(cfg);
+
+        firstId.Should().Be(secondId);
+
+        _sut.UnsubscribeMarketDepth(firstId);
+        _primaryClient.UnsubscribedDepthIds.Should().BeEmpty("a duplicate subscriber is still attached to the shared upstream subscription");
+
+        _sut.UnsubscribeMarketDepth(secondId);
+        _primaryClient.UnsubscribedDepthIds.Should().ContainSingle().Which.Should().Be(firstId);
+    }
+
+    [Fact]
     public void UnsubscribeTrades_DelegatesToActiveClient()
     {
         var cfg = new SymbolConfig("AAPL", SubscribeTrades: true);
@@ -181,6 +197,22 @@ public sealed class FailoverAwareMarketDataClientTests : IAsyncLifetime
         _sut.UnsubscribeTrades(id);
 
         _primaryClient.UnsubscribedTradeIds.Should().Contain(id);
+    }
+
+    [Fact]
+    public void UnsubscribeTrades_DuplicateSubscribers_OnlyUnsubscribesUpstreamAfterLastRelease()
+    {
+        var cfg = new SymbolConfig("AAPL", SubscribeTrades: true);
+        var firstId = _sut.SubscribeTrades(cfg);
+        var secondId = _sut.SubscribeTrades(cfg);
+
+        firstId.Should().Be(secondId);
+
+        _sut.UnsubscribeTrades(firstId);
+        _primaryClient.UnsubscribedTradeIds.Should().BeEmpty("a duplicate subscriber is still attached to the shared upstream subscription");
+
+        _sut.UnsubscribeTrades(secondId);
+        _primaryClient.UnsubscribedTradeIds.Should().ContainSingle().Which.Should().Be(firstId);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- The failover wrapper previously returned a shared upstream subscription ID for duplicate symbol subscribes but treated unsubscribes as single-owner, allowing one consumer to cancel data for others and drop failover resubscribe state. 
- Introduce minimal ownership tracking so deduplication remains but upstream unsubscribe only occurs when the final consumer releases the subscription.

### Description
- Added per-symbol reference counters ` _depthSubscriberCounts` and `_tradeSubscriberCounts` to `FailoverAwareMarketDataClient` to track duplicate subscribers. 
- Increment the counter on duplicate subscribe (via `AddOrUpdate`) and initialize it to `1` on the first upstream subscribe while keeping the existing dedupe return value. 
- On unsubscribe, decrement the counter and only forward the upstream `Unsubscribe*` call and remove active-tracking state when the counter reaches zero. 
- Added regression tests in `tests/Meridian.Tests/Infrastructure/Providers/FailoverAwareMarketDataClientTests.cs` to assert that duplicate subscribers do not trigger an upstream unsubscribe until the last release.

### Testing
- Attempted to run the focused unit tests with `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~FailoverAwareMarketDataClientTests"`, but execution failed due to the environment missing the `dotnet` SDK (`/bin/bash: dotnet: command not found`).
- New tests were added to the repository but could not be executed in this environment; they should be run in CI or a local dev environment with the .NET SDK to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f3dce0f9483209a328704a8b34bf1)