### PR TITLE
Preserve corporate actions and trading parameters on same-security reselection

### DIFF
--- a/src/Meridian.Ui/dashboard/src/screens/governance-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/governance-screen.view-model.ts
@@ -522,14 +522,18 @@ export function useSecurityMasterViewModel(
   }, [searchDelayMs, services]);
 
   const selectSecurity = useCallback(async (securityId: string) => {
+    const isReselect = securityId === selectedSecurityId;
     setSelectedSecurityId(securityId);
     setIdentity(null);
     setIdentityError(null);
     setIdentityLoading(true);
-    setCorporateActions(null);
-    setCorporateActionsError(null);
-    setTradingParameters(null);
-    setTradingParametersError(null);
+
+    if (!isReselect) {
+      setCorporateActions(null);
+      setCorporateActionsError(null);
+      setTradingParameters(null);
+      setTradingParametersError(null);
+    }
 
     try {
       const detail = await services.getIdentity(securityId);
@@ -539,7 +543,7 @@ export function useSecurityMasterViewModel(
     } finally {
       setIdentityLoading(false);
     }
-  }, [services]);
+  }, [selectedSecurityId, services]);
 
   const resolveConflict = useCallback(async (
     conflictId: string,


### PR DESCRIPTION
### Motivation
- Reselecting the same security could clear corporate action and trading parameter state while the refetch effect is keyed to `selectedSecurityId`, causing empty drill-in panels even when data exists.

### Description
- Add an `isReselect` guard in `selectSecurity` so corporate actions and trading parameters are only cleared when a different security is selected.
- Add `selectedSecurityId` to the `selectSecurity` callback dependency array to keep dependencies consistent with the new guard.
- Modified file: `src/Meridian.Ui/dashboard/src/screens/governance-screen.view-model.ts`.

### Testing
- Ran the targeted dashboard test command `npm run test -- --run governance-screen.view-model`, which failed in this environment because `vitest` is not installed or available on PATH.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ab0efc408320a0a828c0945a070a)