### PR TITLE
Centralize corporate action append validation

### DIFF
--- a/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
@@ -246,6 +246,7 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
             services.AddSingleton<Meridian.Application.SecurityMaster.ISecurityMasterQueryService>(sp => sp.GetRequiredService<SecurityMasterQueryService>());
             services.AddSingleton<Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService>(sp => sp.GetRequiredService<SecurityMasterQueryService>());
             services.AddSingleton<ISecurityValidationService, SecurityValidationService>();
+            services.AddSingleton<ICorporateActionCommandService, CorporateActionCommandService>();
             services.AddSingleton<IBondReferenceService, BondProjectionService>();
             services.AddSingleton<IOptionReferenceService, OptionProjectionService>();
             services.AddSingleton<IOptionChainImportService>(sp => (OptionProjectionService)sp.GetRequiredService<IOptionReferenceService>());
@@ -302,6 +303,7 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
         services.TryAddSingleton<ISecurityMasterImportService, NullSecurityMasterImportService>();
         services.TryAddSingleton<ISecurityMasterIngestStatusService>(sp => (ISecurityMasterIngestStatusService)sp.GetRequiredService<ISecurityMasterImportService>());
         services.TryAddSingleton<ISecurityValidationService, NullSecurityValidationService>();
+        services.TryAddSingleton<ICorporateActionCommandService, NullCorporateActionCommandService>();
         services.TryAddSingleton<ISecurityMasterEventStore, NullSecurityMasterEventStore>();
         services.TryAddSingleton<IOperatorOverridesStore, NullOperatorOverridesStore>();
         services.TryAddSingleton<IUflProjectionRebuilder, NullUflProjectionRebuilder>();

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -232,7 +232,10 @@ and UI presentation concerns in their owning layers.
   are governed by `SecurityAssetProfileGovernanceService`, which merges seeded starter definitions
   with storage-root persisted drafts, approvals, rollback-created versions, and audit lineage.
   Security Master validation messages use operator-review wording for override audit remediation so
-  application-layer guidance does not expose legacy Governance workspace language.
+  application-layer guidance does not expose legacy Governance workspace language. Corporate-action
+  appends are routed through `CorporateActionCommandService` so HTTP endpoints, imports, provider
+  backfills, and future UI commands share the same validation, append, and structured audit path
+  before the event store is touched.
   `SecurityMasterOperationalReadinessService` layers operational readiness on top of the shared
   asset-class catalog, validator registry, and governed profile catalog for equities, options,
   futures, FX, fixed income, direct loans, structured/private `CustomAsset`, and `OtherSecurity`

--- a/src/Meridian.Application/SecurityMaster/CorporateActionCommandService.cs
+++ b/src/Meridian.Application/SecurityMaster/CorporateActionCommandService.cs
@@ -1,0 +1,91 @@
+using Meridian.Contracts.SecurityMaster;
+using Meridian.Storage.SecurityMaster;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Application.SecurityMaster;
+
+public interface ICorporateActionCommandService
+{
+    Task<CorporateActionAppendResult> AppendAsync(Guid securityId, CorporateActionDto action, string? actor, string source, CancellationToken ct = default);
+}
+
+public sealed record CorporateActionAppendResult(bool Succeeded, string? ValidationError = null)
+{
+    public static CorporateActionAppendResult Success { get; } = new(true);
+
+    public static CorporateActionAppendResult Invalid(string validationError) => new(false, validationError);
+}
+
+public sealed class CorporateActionCommandService : ICorporateActionCommandService
+{
+    private readonly ISecurityMasterEventStore _eventStore;
+    private readonly ILogger<CorporateActionCommandService> _logger;
+
+    public CorporateActionCommandService(
+        ISecurityMasterEventStore eventStore,
+        ILogger<CorporateActionCommandService> logger)
+    {
+        _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<CorporateActionAppendResult> AppendAsync(
+        Guid securityId,
+        CorporateActionDto action,
+        string? actor,
+        string source,
+        CancellationToken ct = default)
+    {
+        if (action.SecurityId != securityId)
+        {
+            return CorporateActionAppendResult.Invalid("Corporate action SecurityId must match route parameter.");
+        }
+
+        var validationError = Validate(action);
+        if (validationError is not null)
+        {
+            return CorporateActionAppendResult.Invalid(validationError);
+        }
+
+        await _eventStore.AppendCorporateActionAsync(action, ct).ConfigureAwait(false);
+        _logger.LogInformation(
+            "Security Master corporate action appended for {SecurityId} with event type {EventType}, corp action {CorporateActionId}, source {Source}, actor {Actor}.",
+            securityId,
+            action.EventType,
+            action.CorpActId,
+            string.IsNullOrWhiteSpace(source) ? "unspecified" : source,
+            string.IsNullOrWhiteSpace(actor) ? "system" : actor);
+
+        return CorporateActionAppendResult.Success;
+    }
+
+    public static string? Validate(CorporateActionDto action)
+    {
+        if (string.IsNullOrWhiteSpace(action.EventType))
+        {
+            return "Corporate actions must include EventType.";
+        }
+
+        if (string.Equals(action.EventType, "StockSplit", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!action.SplitRatio.HasValue)
+            {
+                return "StockSplit corporate actions must include SplitRatio.";
+            }
+
+            if (action.SplitRatio.Value <= 0m || action.SplitRatio.Value > 1_000m)
+            {
+                return "StockSplit SplitRatio must be greater than 0 and less than or equal to 1000.";
+            }
+        }
+
+        if (string.Equals(action.EventType, "Dividend", StringComparison.OrdinalIgnoreCase) &&
+            action.DividendPerShare.HasValue &&
+            action.DividendPerShare.Value < 0m)
+        {
+            return "DividendPerShare must be greater than or equal to 0.";
+        }
+
+        return null;
+    }
+}

--- a/src/Meridian.Application/SecurityMaster/NullSecurityMasterServices.cs
+++ b/src/Meridian.Application/SecurityMaster/NullSecurityMasterServices.cs
@@ -118,6 +118,20 @@ public sealed class NullSecurityMasterService : Meridian.Contracts.SecurityMaste
         => NotConfigured<SecurityAliasDto>();
 }
 
+
+public sealed class NullCorporateActionCommandService : ICorporateActionCommandService
+{
+    public Task<CorporateActionAppendResult> AppendAsync(
+        Guid securityId,
+        CorporateActionDto action,
+        string? actor,
+        string source,
+        CancellationToken ct = default)
+        => Task.FromException<CorporateActionAppendResult>(new InvalidOperationException(
+            "Security Master is not configured. " +
+            "Set the MERIDIAN_SECURITY_MASTER_CONNECTION_STRING environment variable to enable this feature."));
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Conflict service — returns empty lists (no conflicts to show when not configured)
 // ──────────────────────────────────────────────────────────────────────────────

--- a/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
@@ -3,7 +3,6 @@ using Meridian.Contracts.Api;
 using Meridian.Identity.Auth;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.ReferenceData.SecurityMaster;
-using Meridian.Storage.SecurityMaster;
 using Meridian.Ui.Shared.Services;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Builder;
@@ -610,22 +609,17 @@ public static class SecurityMasterEndpoints
             Guid securityId,
             CorporateActionDto dto,
             HttpContext context,
-            [FromServices] ISecurityMasterEventStore eventStore,
+            [FromServices] AppSecurityMaster.ICorporateActionCommandService corporateActionService,
             CancellationToken ct) =>
         {
-            if (dto.SecurityId != securityId)
-            {
-                return Results.BadRequest("Corporate action SecurityId must match route parameter");
-            }
+            var actor = context.Items[LoginSessionMiddleware.CurrentUserKey] as string;
+            var result = await corporateActionService
+                .AppendAsync(securityId, dto, actor, "http", ct)
+                .ConfigureAwait(false);
 
-            var validationError = ValidateCorporateAction(dto);
-            if (validationError is not null)
-            {
-                return Results.BadRequest(validationError);
-            }
-
-            await eventStore.AppendCorporateActionAsync(dto, ct).ConfigureAwait(false);
-            return Results.Ok();
+            return result.Succeeded
+                ? Results.Ok()
+                : Results.BadRequest(result.ValidationError);
         })
         .WithName("AppendSecurityMasterCorporateAction")
         .Accepts<CorporateActionDto>("application/json")
@@ -889,31 +883,6 @@ public static class SecurityMasterEndpoints
         return (permissions & UserPermission.ModifySecurityMaster) != UserPermission.ModifySecurityMaster
             ? Results.Forbid()
             : null;
-    }
-
-    private static string? ValidateCorporateAction(CorporateActionDto dto)
-    {
-        if (string.Equals(dto.EventType, "StockSplit", StringComparison.OrdinalIgnoreCase))
-        {
-            if (!dto.SplitRatio.HasValue)
-            {
-                return "StockSplit corporate actions must include SplitRatio.";
-            }
-
-            if (dto.SplitRatio.Value <= 0m || dto.SplitRatio.Value > 1_000m)
-            {
-                return "StockSplit SplitRatio must be greater than 0 and less than or equal to 1000.";
-            }
-        }
-
-        if (string.Equals(dto.EventType, "Dividend", StringComparison.OrdinalIgnoreCase) &&
-            dto.DividendPerShare.HasValue &&
-            dto.DividendPerShare.Value < 0m)
-        {
-            return "DividendPerShare must be greater than or equal to 0.";
-        }
-
-        return null;
     }
 
     private static SecurityMasterIngestStatusResponse ToIngestStatusResponse(

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -83,6 +83,13 @@ under `/api/workstation/financial-record-explorers/{explorerId}` for `ledger`, `
 `security-instrument`, and `report-line-provenance`. `FinancialRecordExplorerReadService` composes
 source-backed strategy run ledger, portfolio, Security Master, report-pack line provenance,
 delivery history, evidence, reconciliation, reporting, and audit projections into the shared DTO.
+The Security & Instrument Explorer remains productized as a thin shared-read-model surface: it uses
+`SecurityMasterWorkbenchQueryService`, `IAssetOperationsQueryService`, and report-line provenance
+from `FinancialRecordExplorerReadService` for instrument identity, provider evidence,
+AssetOperations readiness, ledger impact, and report usage instead of asking browser or WPF clients
+to rebuild those relationships locally. Corporate-action mutations posted through shared Security
+Master endpoints delegate validation and append auditing to the application-owned
+`ICorporateActionCommandService`.
 The ledger explorer carries canonical `LedgerDimensionSetDto` scope into row cells, drill-in fields,
 and dimension filter chips so browser and WPF users can inspect fund, entity, sleeve, strategy,
 portfolio, book, account, investor, capital-account, instrument, tax-lot, cost-center,

--- a/src/Meridian.Ui/dashboard/src/components/meridian/financial-record-explorer.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/financial-record-explorer.test.tsx
@@ -102,6 +102,27 @@ describe("FinancialRecordExplorerShell", () => {
     expect(screen.getByRole("textbox", { name: "Search Ledger Explorer" })).toHaveValue("aapl");
   });
 
+  it("renders Security & Instrument Explorer DTO fields used by WPF parity proof", async () => {
+    const user = userEvent.setup();
+    renderExplorer(undefined, createSecurityInstrumentExplorerDto());
+
+    expect(screen.getByRole("heading", { name: "Security & Instrument Explorer" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Apple Inc." })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "96%" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Ready" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "1 projection" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("row", { name: /apple inc.*96%.*ready.*1 projection/i }));
+
+    const detail = screen.getByLabelText("Apple Inc. proof detail");
+    expect(within(detail).getByText("Instrument Identity")).toBeInTheDocument();
+    expect(within(detail).getByText("Provider Evidence")).toBeInTheDocument();
+    expect(within(detail).getByText("AssetOperations Readiness")).toBeInTheDocument();
+    expect(within(detail).getByText("Ledger Impact")).toBeInTheDocument();
+    expect(within(detail).getByText("Report Usage")).toBeInTheDocument();
+    expect(within(detail).getByRole("link", { name: "Open instrument passport" })).toHaveAttribute("href", "/api/workstation/security-master/securities/11111111-1111-1111-1111-111111111111/passport");
+  });
+
   it("shows blocked source state with disabled actions instead of synthetic rows", () => {
     renderExplorer(undefined, {
       ...createExplorerDto(),
@@ -148,6 +169,84 @@ function renderExplorer(
       <div>Fallback static content</div>
     </FinancialRecordExplorerShell>
   );
+}
+
+function createSecurityInstrumentExplorerDto(): FinancialRecordExplorerDto {
+  const securityHref = "/api/workstation/security-master/securities/11111111-1111-1111-1111-111111111111";
+  const passportHref = `${securityHref}/passport`;
+  const operationsHref = "/api/workstation/assets/11111111-1111-1111-1111-111111111111/operations";
+  const reportHref = "/api/workstation/financial-record-explorers/report-line-provenance?lineKey=holdings.aapl.market-value&sourceId=AAPL";
+  const detail = {
+    recordId: "security:11111111-1111-1111-1111-111111111111",
+    recordType: "security-instrument",
+    title: "Apple Inc.",
+    subtitle: "AAPL · USD · Equity",
+    description: "Security Master identity with provider, operations, ledger, and report proof.",
+    tone: "Success" as const,
+    fields: [
+      { label: "Instrument Identity", value: "Apple Inc. / AAPL", detail: "SecurityId 11111111-1111-1111-1111-111111111111.", tone: "Success" as const },
+      { label: "Provider Evidence", value: "Polygon primary · 96%", detail: passportHref, tone: "Success" as const },
+      { label: "AssetOperations Readiness", value: "Ready", detail: operationsHref, tone: "Success" as const },
+      { label: "Ledger Impact", value: "1 projection", detail: "Ledger projection retained for the instrument.", tone: "Info" as const },
+      { label: "Report Usage", value: "1 report line", detail: reportHref, tone: "Info" as const }
+    ],
+    proofActions: [
+      { actionId: "open-security-master", label: "Open Security Master", description: "Open Security Master detail.", href: securityHref, isEnabled: true, disabledReason: "", tone: "Success" as const },
+      { actionId: "open-instrument-passport", label: "Open instrument passport", description: "Open provider evidence.", href: passportHref, isEnabled: true, disabledReason: "", tone: "Success" as const },
+      { actionId: "open-asset-operations", label: "Open AssetOperations", description: "Open operations readiness.", href: operationsHref, isEnabled: true, disabledReason: "", tone: "Info" as const },
+      { actionId: "open-report-line-provenance", label: "Open report-line provenance", description: "Open report usage.", href: reportHref, isEnabled: true, disabledReason: "", tone: "Info" as const }
+    ],
+    usedIn: [
+      { relationshipId: "portfolio", label: "Portfolio position", description: "Portfolio uses Apple Inc.", href: "/api/workstation/financial-record-explorers/portfolio", tone: "Info" as const },
+      { relationshipId: "ledger", label: "Ledger trial balance", description: "Ledger projection uses Apple Inc.", href: "/api/workstation/financial-record-explorers/ledger", tone: "Info" as const },
+      { relationshipId: "report", label: "Report-line provenance", description: "Board pack reports Apple Inc.", href: reportHref, tone: "Info" as const }
+    ],
+    impacts: [
+      { relationshipId: "passport", label: "Instrument passport", description: "Provider confidence and identity evidence.", href: passportHref, tone: "Success" as const },
+      { relationshipId: "operations", label: "AssetOperations readiness", description: "Cash-flow and reconciliation readiness.", href: operationsHref, tone: "Success" as const },
+      { relationshipId: "ledger", label: "Ledger projection", description: "Ledger impact is retained.", href: "/api/workstation/runs/run-1/ledger/journal", tone: "Info" as const }
+    ],
+    fullRecordHref: securityHref
+  };
+
+  return {
+    explorerId: "security-instrument",
+    title: "Security & Instrument Explorer",
+    description: "Explore Security Master references used by retained accounting and portfolio records.",
+    sourceState: "Source-backed Security Master references from run run-1.",
+    isBlocked: false,
+    blockedReason: "",
+    scopeItems: [{ label: "Run", value: "run-1", tone: "Info" }],
+    savedViews: [{ viewId: "system-security-instrument-default", label: "Security references", description: "Default security view.", isSystem: true, isActive: true, filters: [], searchText: "" }],
+    summaryItems: [{ label: "Securities", value: "1", detail: "Distinct resolved instruments.", tone: "Default" }],
+    filters: [{ filterId: "coverage", label: "Coverage", value: "Resolved", operator: "equals", tone: "Info" }],
+    columns: [
+      { columnId: "security", header: "Security", cellKind: "text", width: 220, isRightAligned: false },
+      { columnId: "identifierConfidence", header: "Identifier Confidence", cellKind: "text", width: 170, isRightAligned: false },
+      { columnId: "operations", header: "Operations", cellKind: "text", width: 140, isRightAligned: false },
+      { columnId: "cashFlow", header: "Cash Flow", cellKind: "text", width: 120, isRightAligned: false },
+      { columnId: "ledger", header: "Ledger", cellKind: "text", width: 120, isRightAligned: false }
+    ],
+    rows: [{
+      recordId: "security:11111111-1111-1111-1111-111111111111",
+      recordType: "security-instrument",
+      label: "Apple Inc.",
+      source: "AAPL",
+      status: "Resolved",
+      tone: "Success",
+      cells: [
+        { columnId: "security", displayValue: "Apple Inc.", rawValue: "Apple Inc.", tone: "Success", linkHref: securityHref },
+        { columnId: "identifierConfidence", displayValue: "96%", rawValue: "0.96", tone: "Success", linkHref: passportHref },
+        { columnId: "operations", displayValue: "Ready", rawValue: "Ready", tone: "Success", linkHref: operationsHref },
+        { columnId: "cashFlow", displayValue: "1 projected", rawValue: "1", tone: "Info", linkHref: operationsHref },
+        { columnId: "ledger", displayValue: "1 projection", rawValue: "1", tone: "Info", linkHref: "/api/workstation/runs/run-1/ledger/journal" }
+      ],
+      detail
+    }],
+    selectedRecord: detail,
+    proofActions: [],
+    recordGraph: { nodes: [], edges: [] }
+  };
 }
 
 function createExplorerDto(overrides: Partial<FinancialRecordExplorerDto> = {}): FinancialRecordExplorerDto {

--- a/tests/Meridian.Tests/SecurityMaster/CorporateActionCommandServiceTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/CorporateActionCommandServiceTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using Meridian.Application.SecurityMaster;
+using Meridian.Contracts.SecurityMaster;
+using Meridian.Storage.SecurityMaster;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Meridian.Tests.SecurityMaster;
+
+public sealed class CorporateActionCommandServiceTests
+{
+    private static readonly Guid SecurityId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    [Fact]
+    public async Task AppendAsync_ValidAction_AppendsThroughEventStoreAndAuditsSource()
+    {
+        var store = Substitute.For<ISecurityMasterEventStore>();
+        var service = new CorporateActionCommandService(store, NullLogger<CorporateActionCommandService>.Instance);
+        var action = CreateAction("Dividend", dividendPerShare: 0.24m);
+
+        var result = await service.AppendAsync(SecurityId, action, "ops.user", "provider-backfill");
+
+        result.Succeeded.Should().BeTrue();
+        result.ValidationError.Should().BeNull();
+        await store.Received(1).AppendCorporateActionAsync(action, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AppendAsync_InvalidAction_ReturnsValidationErrorWithoutAppending()
+    {
+        var store = Substitute.For<ISecurityMasterEventStore>();
+        var service = new CorporateActionCommandService(store, NullLogger<CorporateActionCommandService>.Instance);
+        var action = CreateAction("StockSplit", splitRatio: 0m);
+
+        var result = await service.AppendAsync(SecurityId, action, "ops.user", "http");
+
+        result.Succeeded.Should().BeFalse();
+        result.ValidationError.Should().Be("StockSplit SplitRatio must be greater than 0 and less than or equal to 1000.");
+        await store.DidNotReceiveWithAnyArgs().AppendCorporateActionAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task AppendAsync_RouteSecurityMismatch_ReturnsValidationErrorWithoutAppending()
+    {
+        var store = Substitute.For<ISecurityMasterEventStore>();
+        var service = new CorporateActionCommandService(store, NullLogger<CorporateActionCommandService>.Instance);
+        var action = CreateAction("Dividend", dividendPerShare: 0.24m) with
+        {
+            SecurityId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+        };
+
+        var result = await service.AppendAsync(SecurityId, action, "ops.user", "import");
+
+        result.Succeeded.Should().BeFalse();
+        result.ValidationError.Should().Be("Corporate action SecurityId must match route parameter.");
+        await store.DidNotReceiveWithAnyArgs().AppendCorporateActionAsync(default!, default);
+    }
+
+    private static CorporateActionDto CreateAction(
+        string eventType,
+        decimal? dividendPerShare = null,
+        decimal? splitRatio = null)
+        => new(
+            Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            SecurityId,
+            eventType,
+            new DateOnly(2026, 3, 15),
+            new DateOnly(2026, 3, 31),
+            dividendPerShare,
+            "USD",
+            splitRatio,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+}

--- a/tests/Meridian.Wpf.Tests/ViewModels/FinancialRecordExplorerViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/FinancialRecordExplorerViewModelTests.cs
@@ -191,6 +191,30 @@ public sealed class FinancialRecordExplorerViewModelTests
         actions.Select(static action => action.TargetPageTag).Should().Contain(["SecurityMaster", "FundAuditTrail"]);
     }
 
+
+    [Fact]
+    public void BuildPresentation_SecurityInstrumentExplorer_ShouldPreserveSharedDtoParityFields()
+    {
+        var dto = CreateSecurityInstrumentExplorerDto();
+
+        var presentation = FinancialRecordExplorerViewModel.BuildPresentation(dto);
+        var inspector = FinancialRecordExplorerViewModel.BuildRecordInspector(dto.SelectedRecord!);
+        var actions = dto.SelectedRecord!.ProofActions
+            .Select(FinancialRecordExplorerViewModel.FinancialRecordExplorerActionModel.FromDto)
+            .ToArray();
+
+        presentation.Rows.Should().ContainSingle(row =>
+            row.Cells["security"] == "Apple Inc." &&
+            row.Cells["identifierConfidence"] == "96%" &&
+            row.Cells["operations"] == "Ready" &&
+            row.Cells["ledger"] == "1 projection");
+        presentation.Table.Columns.Select(static column => column.BindingPath).Should().Contain(
+            ["Cells[security]", "Cells[identifierConfidence]", "Cells[operations]", "Cells[cashFlow]", "Cells[ledger]"]);
+        inspector.Facts.Select(static fact => fact.Label).Should().Contain(
+            ["Instrument Identity", "Provider Evidence", "AssetOperations Readiness", "Ledger Impact", "Report Usage"]);
+        actions.Select(static action => action.TargetPageTag).Should().Contain(["SecurityMaster", "FundAuditTrail", "ReportLineProvenanceExplorer"]);
+    }
+
     [Theory]
     [InlineData("LedgerExplorer", "ledger")]
     [InlineData("PortfolioExplorer", "portfolio")]
@@ -241,6 +265,92 @@ public sealed class FinancialRecordExplorerViewModelTests
         action.IsEnabled.Should().BeTrue();
         action.TargetPageTag.Should().Be(expectedPageTag);
         action.DisabledReason.Should().BeEmpty();
+    }
+
+
+    private static FinancialRecordExplorerDto CreateSecurityInstrumentExplorerDto()
+    {
+        const string securityHref = "/api/workstation/security-master/securities/11111111-1111-1111-1111-111111111111";
+        const string passportHref = "/api/workstation/security-master/securities/11111111-1111-1111-1111-111111111111/passport";
+        const string operationsHref = "/api/workstation/assets/11111111-1111-1111-1111-111111111111/operations";
+        const string reportHref = "/api/workstation/financial-record-explorers/report-line-provenance?lineKey=holdings.aapl.market-value&sourceId=AAPL";
+        var detail = new FinancialRecordExplorerSelectedRecordDto(
+            "security:11111111-1111-1111-1111-111111111111",
+            "security-instrument",
+            "Apple Inc.",
+            "AAPL · USD · Equity",
+            "Security Master identity with provider, operations, ledger, and report proof.",
+            FinancialRecordExplorerTone.Success,
+            Fields:
+            [
+                new("Instrument Identity", "Apple Inc. / AAPL", "SecurityId 11111111-1111-1111-1111-111111111111.", FinancialRecordExplorerTone.Success),
+                new("Provider Evidence", "Polygon primary · 96%", passportHref, FinancialRecordExplorerTone.Success),
+                new("AssetOperations Readiness", "Ready", operationsHref, FinancialRecordExplorerTone.Success),
+                new("Ledger Impact", "1 projection", "Ledger projection retained for the instrument.", FinancialRecordExplorerTone.Info),
+                new("Report Usage", "1 report line", reportHref, FinancialRecordExplorerTone.Info)
+            ],
+            ProofActions:
+            [
+                new("open-security-master", "Open Security Master", "Open Security Master detail.", securityHref, Tone: FinancialRecordExplorerTone.Success),
+                new("open-instrument-passport", "Open instrument passport", "Open provider evidence.", passportHref, Tone: FinancialRecordExplorerTone.Success),
+                new("open-asset-operations", "Open AssetOperations", "Open operations readiness.", operationsHref, Tone: FinancialRecordExplorerTone.Info),
+                new("open-report-line-provenance", "Open report-line provenance", "Open report usage.", reportHref, Tone: FinancialRecordExplorerTone.Info)
+            ],
+            UsedIn:
+            [
+                new("portfolio", "Portfolio position", "Portfolio uses Apple Inc.", "/api/workstation/financial-record-explorers/portfolio", FinancialRecordExplorerTone.Info),
+                new("ledger", "Ledger trial balance", "Ledger projection uses Apple Inc.", "/api/workstation/financial-record-explorers/ledger", FinancialRecordExplorerTone.Info),
+                new("report", "Report-line provenance", "Board pack reports Apple Inc.", reportHref, FinancialRecordExplorerTone.Info)
+            ],
+            Impacts:
+            [
+                new("passport", "Instrument passport", "Provider confidence and identity evidence.", passportHref, FinancialRecordExplorerTone.Success),
+                new("operations", "AssetOperations readiness", "Cash-flow and reconciliation readiness.", operationsHref, FinancialRecordExplorerTone.Success),
+                new("ledger", "Ledger projection", "Ledger impact is retained.", "/api/workstation/runs/run-1/ledger/journal", FinancialRecordExplorerTone.Info)
+            ],
+            FullRecordHref: securityHref);
+
+        return new FinancialRecordExplorerDto(
+            "security-instrument",
+            "Security & Instrument Explorer",
+            "Explore Security Master references used by retained accounting and portfolio records.",
+            "Source-backed Security Master references from run run-1.",
+            IsBlocked: false,
+            BlockedReason: string.Empty,
+            ScopeItems: [new("Run", "run-1")],
+            SavedViews: [new("system-security-instrument-default", "Security references", "Default security view.", IsSystem: true, IsActive: true, Filters: [])],
+            SummaryItems: [new("Securities", "1", "Distinct resolved instruments.")],
+            Filters: [new("coverage", "Coverage", "Resolved")],
+            Columns:
+            [
+                new("security", "Security", Width: 220),
+                new("identifierConfidence", "Identifier Confidence", Width: 170),
+                new("operations", "Operations", Width: 140),
+                new("cashFlow", "Cash Flow", Width: 120),
+                new("ledger", "Ledger", Width: 120)
+            ],
+            Rows:
+            [
+                new(
+                    "security:11111111-1111-1111-1111-111111111111",
+                    "security-instrument",
+                    "Apple Inc.",
+                    "AAPL",
+                    "Resolved",
+                    FinancialRecordExplorerTone.Success,
+                    Cells:
+                    [
+                        new("security", "Apple Inc.", "Apple Inc.", FinancialRecordExplorerTone.Success, securityHref),
+                        new("identifierConfidence", "96%", "0.96", FinancialRecordExplorerTone.Success, passportHref),
+                        new("operations", "Ready", "Ready", FinancialRecordExplorerTone.Success, operationsHref),
+                        new("cashFlow", "1 projected", "1", FinancialRecordExplorerTone.Info, operationsHref),
+                        new("ledger", "1 projection", "1", FinancialRecordExplorerTone.Info, "/api/workstation/runs/run-1/ledger/journal")
+                    ],
+                    detail)
+            ],
+            SelectedRecord: detail,
+            ProofActions: [],
+            RecordGraph: new FinancialRecordExplorerRecordGraphDto([], []));
     }
 
     private static FinancialRecordExplorerDto CreateExplorerDto(


### PR DESCRIPTION
### Motivation
- Centralize corporate-action append validation and audit behind an application-owned service so HTTP endpoints, imports, provider backfills, and future UI commands share the same validation and audit path.
- Keep the Security & Instrument Explorer as a thin, shared read-model surface produced by `FinancialRecordExplorerReadService`, `SecurityMasterWorkbenchQueryService`, and `IAssetOperationsQueryService` rather than adding browser- or WPF-specific reconstruction logic.
- Provide a focused parity proof that browser and WPF render the same Security & Instrument Explorer DTO fields for instrument identity, provider evidence, asset-operations readiness, ledger impact, and report usage.

### Description
- Added `ICorporateActionCommandService` and `CorporateActionCommandService` to the Application layer, implementing unified validation, append to `ISecurityMasterEventStore`, and structured audit logging (`src/Meridian.Application/SecurityMaster/CorporateActionCommandService.cs`).
- Rewired the Security Master corporate-action endpoint to delegate to the new application service and removed inline endpoint validation, and added a `NullCorporateActionCommandService` fallback for unconfigured deployments (`src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs`, `src/Meridian.Application/SecurityMaster/NullSecurityMasterServices.cs`).
- Registered the new service in composition and the null fallback in `StorageFeatureRegistration` so configured deployments use the concrete service and unconfigured environments fail-closed (`src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs`).
- Added focused unit tests for the command service and a parity proof in both browser and WPF test suites that assert the same Security & Instrument Explorer DTO fields are rendered; updated browser test fixtures and WPF view-model tests, and updated READMEs to document the shared command path and thin explorer posture (`tests/Meridian.Tests/SecurityMaster/CorporateActionCommandServiceTests.cs`, modified dashboard and WPF tests and READMEs).

### Testing
- Ran `npm --prefix src/Meridian.Ui/dashboard install` which completed successfully and installed dashboard test dependencies locally.
- Ran the focused browser test `npm --prefix src/Meridian.Ui/dashboard run test -- financial-record-explorer.test.tsx` and the test file passed (7 tests passed, 0 failed).
- Ran repo checks `git diff --check` and `python build/scripts/docs/validate-source-readmes.py --summary`, both completed with no issues reported.
- Attempted targeted .NET test run for the new service (`dotnet test ...`), but `.NET` was not available in this environment so the `dotnet`-based tests were not executed here (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3953e30a8c8320afa2e11d4ca57c5b)