### PR TITLE
Document Codex memory directory guidance

### DIFF
--- a/.codex/memory/README.md
+++ b/.codex/memory/README.md
@@ -33,6 +33,7 @@ tests, scripts, and skill instructions; it never overrides them.
 
 ## Maintenance Rules
 
+- Keep the required structure present: `README.md`, `index.yml`, and `repo/`, `tasks/`, `goals/`, `branches/`, `sessions/`, and `archive/` folders, each with its own `README.md`.
 - Prefer canonical docs over memory when facts disagree.
 - Record stable claims with explicit `source_refs`, review dates, and invalidation triggers.
 - Keep temporary findings in `sessions/`, `tasks/`, or `branches/` until promotion is reviewed.
@@ -40,5 +41,6 @@ tests, scripts, and skill instructions; it never overrides them.
   files as durable memory entries.
 - Use `goals/*.yml` inventories for very long Codex goals; keep progress evidence compact and link
   the active task descriptor instead of copying task memory into the goal file.
-- Do not store secrets, credentials, personal data, raw logs, or speculative assumptions here.
+- Do not store secrets, credentials, tokens, personal data, customer data, proprietary external content, raw logs, or speculative assumptions here.
+- Seed `repo/` only with stable, sourced claims; keep task-local guesses and unverified observations in narrower tiers until they expire or are deliberately promoted.
 - Run `python build/scripts/docs/check-codex-memory.py --summary` after memory changes.

--- a/.codex/memory/archive/README.md
+++ b/.codex/memory/archive/README.md
@@ -7,14 +7,40 @@ tags:
   - memory
   - archive
 confidence: high
-freshness: 2026-06-19
+freshness: fresh
 source_refs:
-  - docs/ai/codex/quickstart.md
+  - docs/ai/codex/memory-system.md
   - .codex/skills/_shared/codex-execution-contract.md
 review_after: 2026-09-19
+invalidates_when:
+  - Archive-tier audit or loading rules change.
 ---
 
 # Memory Archive
 
 Use this folder for retired memory entries that should remain auditable but should no longer guide
-active Codex work. Include the reason for archival and replacement guidance when archiving an entry.
+active Codex work. Archive memory is retained for traceability, not task routing.
+
+## What Belongs Here
+
+- Superseded repo, task, branch, or session memory that still has audit value.
+- Retired entries with an archival reason, retirement date, and replacement guidance or canonical
+  source reference when one exists.
+- Historical context needed to understand why a memory entry stopped loading.
+
+## What Must Not Be Stored Here
+
+- Active guidance that should still route Codex work.
+- Secrets, credentials, tokens, personal data, customer data, proprietary external content, raw logs,
+  or private environment details.
+- Duplicates of canonical docs or generated reports.
+- Speculative notes that have no audit value after retirement.
+
+## Expiration And Promotion
+
+- Archived entries do not promote automatically. Restore or re-promote only after a fresh source
+  review and index update.
+- Archive entries may be deleted when their audit value expires or a replacement canonical source
+  fully covers the history.
+- Keep archived entries excluded from active loading unless a future audit task explicitly asks for
+  retired memory.

--- a/.codex/memory/branches/README.md
+++ b/.codex/memory/branches/README.md
@@ -7,14 +7,42 @@ tags:
   - memory
   - branches
 confidence: high
-freshness: 2026-06-19
+freshness: fresh
 source_refs:
-  - docs/ai/codex/quickstart.md
+  - docs/ai/codex/memory-system.md
   - .codex/skills/_shared/codex-execution-contract.md
 review_after: 2026-09-19
+invalidates_when:
+  - Branch-tier scope or invalidation rules change.
 ---
 
 # Branch Memory
 
-Use this folder for branch-specific assumptions, validation reuse, merge-order notes, and handoff
-context. Do not treat branch memory as canonical after the branch is merged or abandoned.
+Use this folder for branch-specific context that helps ongoing work on the current Git branch.
+Branch memory is temporary and must not be treated as canonical after the branch merges, is rebased
+beyond recognition, or is abandoned.
+
+## What Belongs Here
+
+- Branch-scoped assumptions, migration order notes, merge sequencing, validation reuse, and handoff
+  context.
+- Notes tied to the branch name and current diff that would be misleading on another branch.
+- Indexed Markdown entries with branch-specific `scope`, `load_when.branches`, review dates, and
+  invalidation triggers.
+
+## What Must Not Be Stored Here
+
+- Repository-wide durable guidance that belongs in `repo/`.
+- Secrets, credentials, tokens, personal data, customer data, proprietary external content, raw logs,
+  or private environment details.
+- User-owned worktree details that should remain in the active conversation only.
+- Speculation that lacks a branch-local decision or source reference.
+
+## Expiration And Promotion
+
+- Branch memory expires when the branch merges, is abandoned, is substantially rewritten, or reaches
+  its review date/invalidation condition.
+- Promote branch memory to `repo/` only when the merged change creates stable, sourced repository
+  behavior that future branches should know.
+- Archive branch memory when the branch history remains useful for audit; otherwise delete it after
+  the branch-specific work is finished.

--- a/.codex/memory/goals/README.md
+++ b/.codex/memory/goals/README.md
@@ -12,14 +12,37 @@ source_refs:
   - docs/ai/codex/memory-system.md
   - .codex/skills/_shared/codex-execution-contract.md
 review_after: 2026-09-19
+invalidates_when:
+  - Goal inventory schema or long-goal progress rules change.
 ---
 
 # Goal Inventories
 
 Use this folder for YAML inventories that let Codex resume very long goals after compaction,
-interruption, or thread continuation.
+interruption, or thread continuation. Goal inventories track progress; they are not durable memory
+entries.
 
-Goal inventories are not indexed memory entries. They should track the objective, current status,
-active task descriptor, progress items, evidence references, next actions, open questions, and
-promotion candidates. Keep durable guidance in indexed Markdown memory; keep the goal file focused
-on progress toward the active objective.
+## What Belongs Here
+
+- `*.yml` goal inventories with objective, status, active task descriptor, progress items, evidence
+  references, next actions, open questions, and promotion candidates.
+- Compact evidence references showing why a progress item is complete, blocked, deferred, or still
+  pending.
+- Links to task descriptors or canonical docs instead of copied task memory.
+
+## What Must Not Be Stored Here
+
+- Secrets, credentials, tokens, personal data, customer data, proprietary external content, raw logs,
+  or large transcripts.
+- Stable repository claims that should be indexed under `repo/`.
+- Unreviewed speculation, task-local guesses, or broad design instructions without source evidence.
+- Durable guidance hidden in progress records; reusable facts require normal memory promotion.
+
+## Expiration And Promotion
+
+- Goal inventories expire when the long-running goal is complete, abandoned, or superseded, or when
+  their review date/invalidation condition is reached.
+- Use promotion candidates only as a review queue. Promotion requires rewriting the claim into an
+  indexed Markdown memory entry with source refs.
+- Archive completed or abandoned inventories when their progress trail remains useful for audit;
+  otherwise remove obsolete inventories in a focused cleanup.

--- a/.codex/memory/repo/README.md
+++ b/.codex/memory/repo/README.md
@@ -1,0 +1,52 @@
+---
+id: codex-memory-repo
+scope: .codex/memory/repo/
+tier: repo
+tags:
+  - codex
+  - memory
+  - repo
+confidence: high
+freshness: fresh
+source_refs:
+  - docs/ai/codex/memory-system.md
+  - .codex/memory/index.yml
+review_after: 2026-09-19
+invalidates_when:
+  - Codex memory layout or repo-tier promotion rules change.
+---
+
+# Repository Memory
+
+Use this folder for durable Meridian repository memory that is stable, sourced, and useful across
+future Codex tasks. Repo memory supplements canonical docs, source, tests, scripts, AGENTS.md files,
+and selected skills; it never overrides those sources.
+
+## What Belongs Here
+
+- Stable repository conventions that are expensive to rediscover and repeatedly useful.
+- Current architecture, validation, AI-guidance, or workflow facts backed by canonical source files.
+- Entries listed in `.codex/memory/index.yml` with matching front matter, review dates,
+  `source_refs`, confidence, freshness, and invalidation triggers.
+- Claims that are expected to remain true beyond the current branch, session, task, or goal.
+
+## What Must Not Be Stored Here
+
+- Speculative observations, task-local guesses, one-off command output, raw logs, or scratch notes.
+- Secrets, credentials, tokens, personal data, customer data, proprietary external content, or
+  environment-specific private details.
+- Branch-only merge notes, session breadcrumbs, unfinished investigation notes, or unsupported
+  conclusions.
+- Durable instructions that conflict with canonical repository docs, source code, tests, direct user
+  instructions, or scoped AGENTS.md guidance.
+
+## Expiration And Promotion
+
+- Every repo entry must define `review_after` and `invalidates_when`; review it before trusting it
+  after the review date or when an invalidation condition occurs.
+- Promote from `sessions/`, `tasks/`, or `branches/` only after the claim is confirmed by current
+  repository evidence and is useful beyond the original scope.
+- Do not promote raw notes directly. Rewrite promoted entries as concise, sourced claims and update
+  `.codex/memory/index.yml` in the same change.
+- Move stale or superseded repo entries to `archive/` when they retain audit value; otherwise remove
+  them with a clear replacement in the index or canonical docs.

--- a/.codex/memory/sessions/README.md
+++ b/.codex/memory/sessions/README.md
@@ -7,14 +7,42 @@ tags:
   - memory
   - sessions
 confidence: high
-freshness: 2026-06-19
+freshness: fresh
 source_refs:
-  - docs/ai/codex/quickstart.md
+  - docs/ai/codex/memory-system.md
   - .codex/skills/_shared/codex-execution-contract.md
 review_after: 2026-09-19
+invalidates_when:
+  - Session-tier scope or promotion rules change.
 ---
 
 # Session Memory
 
 Use this folder for session-local observations, continuation breadcrumbs, and context that should not
-outlive the immediate work unless later promoted with canonical source evidence.
+outlive the immediate work unless later promoted with source evidence.
+
+## What Belongs Here
+
+- Temporary observations from the current Codex session that may help after compaction or thread
+  continuation.
+- Short breadcrumbs about inspected files, skipped routes, local blockers, or validation context for
+  the current session.
+- Session-scoped Markdown entries that are narrow, dated, and clearly non-canonical.
+
+## What Must Not Be Stored Here
+
+- Stable repository guidance that belongs in `repo/`.
+- Secrets, credentials, tokens, personal data, customer data, proprietary external content, raw logs,
+  or long command transcripts.
+- Speculative conclusions presented as facts, task-local guesses that need no continuation, or
+  unrelated worktree notes.
+- Content that should instead live in canonical docs, tests, source code, or issue trackers.
+
+## Expiration And Promotion
+
+- Session memory expires at session end, after compaction when no longer needed, or when the active
+  work moves to a task, branch, or goal inventory.
+- Promote session notes only after verifying them against current repo evidence and deciding whether
+  the correct destination is `tasks/`, `branches/`, `goals/`, or `repo/`.
+- Delete session notes that were only useful for the completed interaction; archive only when an
+  audit trail is genuinely useful.

--- a/.codex/memory/tasks/README.md
+++ b/.codex/memory/tasks/README.md
@@ -7,22 +7,44 @@ tags:
   - memory
   - tasks
 confidence: high
-freshness: 2026-06-19
+freshness: fresh
 source_refs:
-  - docs/ai/codex/quickstart.md
+  - docs/ai/codex/memory-system.md
   - .codex/skills/_shared/codex-execution-contract.md
 review_after: 2026-09-19
+invalidates_when:
+  - Task descriptor schema or task-tier routing rules change.
 ---
 
 # Task Memory
 
-Use this folder for two task-scoped memory surfaces:
+Use this folder for task-scoped memory that helps a named Codex task load only the context it needs.
+Task memory is narrower than repo memory and must not become durable guidance without promotion
+review.
 
-- `*.yml` task descriptors that route the current Codex task by `task_id`, intent, selected skill,
+## What Belongs Here
+
+- `*.yml` task descriptors that route an active Codex task by `task_id`, intent, selected skill,
   work mode, branch, planned paths, and explicit memory tags.
-- Indexed Markdown entries that help future agents continue recurring or active work but are not
-  stable repository facts.
+- Indexed Markdown entries for recurring or active task context that is useful while the named task
+  remains open.
+- Compact promotion candidates that point to source evidence for later review.
 
-Task descriptors are not indexed memory entries and must not contain durable guidance by
-themselves. Promote a Markdown entry to `repo/` only after it is backed by canonical documentation
-and is expected to remain durable.
+## What Must Not Be Stored Here
+
+- Stable repository guidance that already qualifies for `repo/`.
+- Secrets, credentials, tokens, personal data, customer data, proprietary external content, or raw
+  logs.
+- Broad assumptions from unrelated tasks, speculative design notes, or unverified conclusions.
+- Durable facts embedded only in task descriptor YAML files; descriptors are routing inputs, not
+  indexed memory entries.
+
+## Expiration And Promotion
+
+- Task descriptors expire when the task closes, the prompt family stops recurring, or their review
+  date/invalidation condition is reached.
+- Promote task Markdown entries to `repo/` only when current canonical sources support the claim and
+  the guidance will remain useful after the task ends.
+- Move task entries with audit value to `archive/` after completion when they should not continue to
+  guide active work.
+- Delete short-lived task descriptors when they no longer route active or recurring work.


### PR DESCRIPTION
### Motivation

- Make the `.codex/memory/` layout explicit and ensure each memory tier has README guidance describing allowed content, prohibited content, and promotion/expiration rules. 
- Prevent accidental promotion of speculative or sensitive data into repo-tier memory by requiring source-backed, reviewable entries for `repo/`.

### Description

- Added a new `.codex/memory/repo/README.md` that defines what belongs in `repo/`, what must not be stored, and promotion/expiration rules. 
- Expanded and clarified README guidance for `.`codex/memory/` root and the folders `tasks/`, `goals/`, `branches/`, `sessions/`, and `archive/` to state allowed content, prohibited content, and lifecycle (expire/promote/archive) behavior. 
- Updated the root `.codex/memory/README.md` to require the presence of the required structure and to note that `repo/` should be seeded only with stable, sourced claims. 
- Kept all changes as docs-only edits under `.codex/memory/` and updated front-matter metadata in each README to include `id`, `scope`, `tier`, `source_refs`, `review_after`, and `invalidates_when` where applicable.

### Testing

- Ran `python build/scripts/docs/check-codex-memory.py --summary` which passed with no errors or warnings. 
- Ran `git diff --check` against the edited memory READMEs which produced no whitespace/indexing warnings. 
- Verified repository status and staged changes locally before creating the PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3998c5a8208320bae7d264511492a7)