### PR TITLE
Update Codex memory routing catalog

### DIFF
--- a/.codex/memory/index.yml
+++ b/.codex/memory/index.yml
@@ -52,6 +52,66 @@ schema:
     - branches
     - tags
     - task_ids
+  task_descriptor_fields:
+    - task_id
+    - selected_skill
+    - intent
+    - work_mode
+    - branch
+    - planned_paths
+    - memory_tags
+  routing_selectors:
+    skills:
+      source_fields:
+        - load_when.skills
+        - exclude_when.skills
+      descriptor_fields:
+        - selected_skill
+      match: exact skill name match.
+    paths:
+      source_fields:
+        - load_when.paths
+        - load_when.task.paths
+        - exclude_when.paths
+      descriptor_fields:
+        - planned_paths
+      match: fnmatch-style repo-relative glob.
+    intents:
+      source_fields:
+        - load_when.intents
+        - load_when.task.intents
+        - exclude_when.intents
+      descriptor_fields:
+        - intent
+      match: exact intent label match.
+    branches:
+      source_fields:
+        - load_when.branches
+        - exclude_when.branches
+      descriptor_fields:
+        - branch
+      match: exact branch name match; branch-tier entries must include their branch scope.
+    tags:
+      source_fields:
+        - tags
+        - load_when.tags
+        - exclude_when.tags
+      descriptor_fields:
+        - memory_tags
+      match: exact tag match across entry tags and explicit routing tags.
+    task_descriptor:
+      source_fields:
+        - load_when.task.ids
+        - load_when.task.work_modes
+        - load_when.task.intents
+        - load_when.task.paths
+        - exclude_when.task_ids
+      descriptor_fields:
+        - task_id
+        - work_mode
+        - intent
+        - planned_paths
+      match: exact task id, exact work mode, exact intent, or planned-path glob.
 areas:
   repo:
     path: .codex/memory/repo


### PR DESCRIPTION
### Motivation
- Make `.codex/memory/index.yml` a clearer machine-readable routing catalog that surfaces task-descriptor fields and explicit routing selector metadata for reliable memory loading. 
- Ensure the index schema documents required fields and selectors so automated validators and runtime routing can match skills, paths, intents, branches, tags, and task descriptors.

### Description
- Added `task_descriptor_fields` listing `task_id`, `selected_skill`, `intent`, `work_mode`, `branch`, `planned_paths`, and `memory_tags` to the index schema. 
- Added `routing_selectors` with machine-readable selector definitions for `skills`, `paths`, `intents`, `branches`, `tags`, and `task_descriptor`, including `source_fields`, `descriptor_fields`, and match semantics. 
- Kept and verified the top-level keys such as `version`, `memory_root`, `schema.required_fields`, `schema.active_tiers`, `schema.disabled_tiers`, `schema.allowed_confidence`, `schema.allowed_freshness`, `schema.load_when_fields`, `schema.exclude_when_fields`, `areas`, and `entries` are present and unchanged in intent. 
- Changed file: `.codex/memory/index.yml` to include the new metadata and selector documentation.

### Testing
- Ran `python build/scripts/docs/check-codex-memory.py --summary` and it passed with no errors or warnings. 
- Ran `python build/scripts/docs/check-codex-memory.py --task .codex/memory/tasks/example.yml --receipt --summary` and it produced a successful routing receipt with the expected selected/dereferenced entries. 
- Ran `python build/scripts/docs/check-codex-memory.py --goal .codex/memory/goals/example.yml --receipt --summary` and it passed validation for the goal inventory. 
- Verified index formatting with `git diff --check -- .codex/memory/index.yml` which reported no check failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3998c82efc8320baf6246188f8af4c)