### PR TITLE
Validate Codex memory front matter metadata

### DIFF
--- a/build/scripts/docs/check-codex-memory.py
+++ b/build/scripts/docs/check-codex-memory.py
@@ -35,6 +35,19 @@ REQUIRED_FIELDS = {
     "review_after",
     "invalidates_when",
 }
+FRONT_MATTER_REQUIRED_FIELDS = {
+    "id",
+    "tier",
+    "scope",
+    "file",
+    "tags",
+    "confidence",
+    "freshness",
+    "source_refs",
+    "review_after",
+    "invalidates_when",
+}
+FRONT_MATTER_MATCH_FIELDS = FRONT_MATTER_REQUIRED_FIELDS
 LOAD_WHEN_LIST_FIELDS = {"skills", "paths", "intents", "branches", "tags"}
 LOAD_WHEN_TASK_FIELDS = {"ids", "work_modes", "intents", "paths"}
 EXCLUDE_WHEN_FIELDS = {"skills", "paths", "intents", "branches", "tags", "task_ids"}
@@ -139,14 +152,29 @@ def dump_yaml(data: Any, indent: int = 0) -> str:
         prefix = " " * indent
         if isinstance(data, dict):
             for key, value in data.items():
-                if isinstance(value, (dict, list)):
+                if isinstance(value, list) and not value:
+                    lines.append(f"{prefix}{key}: []")
+                elif isinstance(value, dict) and not value:
+                    lines.append(f"{prefix}{key}: {{}}")
+                elif isinstance(value, (dict, list)):
                     lines.append(f"{prefix}{key}:")
                     lines.append(dump_yaml(value, indent + 2).rstrip())
                 else:
                     lines.append(f"{prefix}{key}: {format_scalar(value)}")
         elif isinstance(data, list):
             for item in data:
-                if isinstance(item, (dict, list)):
+                if isinstance(item, dict):
+                    item_lines = dump_yaml(item, indent + 2).rstrip().splitlines()
+                    if not item_lines:
+                        lines.append(f"{prefix}- {{}}")
+                    else:
+                        first = item_lines[0]
+                        child_prefix = " " * (indent + 2)
+                        if first.startswith(child_prefix):
+                            first = first[len(child_prefix):]
+                        lines.append(f"{prefix}- {first}")
+                        lines.extend(item_lines[1:])
+                elif isinstance(item, list):
                     lines.append(f"{prefix}-")
                     lines.append(dump_yaml(item, indent + 2).rstrip())
                 else:
@@ -304,6 +332,8 @@ def validate_source_refs(root: Path, entry: dict[str, Any], path: str) -> list[F
     if findings:
         return findings
     assert isinstance(source_refs, list)
+    if not source_refs:
+        return [Finding("error", path, "source_refs must include at least one source reference.")]
 
     for source_ref in source_refs:
         if "://" in source_ref or source_ref.startswith("#"):
@@ -434,17 +464,34 @@ def validate_entry_shape(root: Path, entry: Any, index_path: Path, seen_ids: set
     if front_findings:
         return entry, findings
 
-    for field in REQUIRED_FIELDS:
+    memory_display_path = rel(root, memory_file)
+    for field in sorted(FRONT_MATTER_REQUIRED_FIELDS):
         if field not in front_matter:
-            findings.append(Finding("error", rel(root, memory_file), f"Memory front matter is missing {field}."))
-    for field in ("id", "tier", "scope", "file", "confidence", "freshness", "review_after"):
+            findings.append(Finding("error", memory_display_path, f"Memory front matter is missing {field}."))
+
+    if "source_refs" in front_matter:
+        findings.extend(validate_source_refs(root, front_matter, memory_display_path))
+    if "confidence" in front_matter and front_matter.get("confidence") not in ALLOWED_CONFIDENCE:
+        findings.append(
+            Finding("error", memory_display_path, f"Unknown front matter confidence: {front_matter.get('confidence')}")
+        )
+    if "freshness" in front_matter and front_matter.get("freshness") not in ALLOWED_FRESHNESS:
+        findings.append(
+            Finding("error", memory_display_path, f"Unknown front matter freshness: {front_matter.get('freshness')}")
+        )
+    if "review_after" in front_matter:
+        findings.extend(validate_review_after(front_matter.get("review_after"), memory_display_path))
+
+    for field in sorted(FRONT_MATTER_MATCH_FIELDS):
+        if field not in front_matter:
+            continue
         front_value = normalize_metadata_value(front_matter.get(field))
         entry_value = normalize_metadata_value(entry.get(field))
-        if field in front_matter and front_value != entry_value:
+        if front_value != entry_value:
             findings.append(
                 Finding(
                     "error",
-                    rel(root, memory_file),
+                    memory_display_path,
                     f"Front matter {field} does not match index value {entry_value!r}.",
                 )
             )

--- a/build/scripts/docs/tests/test_check_codex_memory.py
+++ b/build/scripts/docs/tests/test_check_codex_memory.py
@@ -247,6 +247,99 @@ class CheckCodexMemoryTests(unittest.TestCase):
 
             self.assertTrue(any("missing YAML front matter" in finding.message for finding in findings))
 
+    def test_front_matter_missing_required_metadata_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_valid_memory_tree(root)
+            entry = valid_entry().replace("source_refs:\n  - docs/ai/tooling/README.md\n", "")
+            write(root / ".codex" / "memory" / "repo" / "validation.md", memory_file_from_entry(entry))
+
+            findings, _ = check_codex_memory.collect_findings(root)
+
+            self.assertTrue(
+                any("Memory front matter is missing source_refs" in finding.message for finding in findings)
+            )
+
+    def test_front_matter_mismatched_id_and_file_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_valid_memory_tree(root)
+            entry = valid_entry().replace("id: repo:validation", "id: repo:other", 1).replace(
+                "file: .codex/memory/repo/validation.md",
+                "file: .codex/memory/repo/other.md",
+                1,
+            )
+            write(root / ".codex" / "memory" / "repo" / "validation.md", memory_file_from_entry(entry))
+
+            findings, _ = check_codex_memory.collect_findings(root)
+            messages = finding_messages(findings)
+
+            self.assertTrue(
+                any("Front matter id does not match index value 'repo:validation'" in message for message in messages)
+            )
+            self.assertTrue(
+                any(
+                    "Front matter file does not match index value '.codex/memory/repo/validation.md'" in message
+                    for message in messages
+                )
+            )
+
+    def test_front_matter_mismatched_list_metadata_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_valid_memory_tree(root)
+            write(root / "docs" / "ai" / "other.md", "# Other source\n")
+            entry = valid_entry().replace("  - validation", "  - other", 1).replace(
+                "  - docs/ai/tooling/README.md",
+                "  - docs/ai/other.md",
+                1,
+            ).replace("  - Validation commands change.", "  - Other commands change.", 1)
+            write(root / ".codex" / "memory" / "repo" / "validation.md", memory_file_from_entry(entry))
+
+            findings, _ = check_codex_memory.collect_findings(root)
+            messages = finding_messages(findings)
+
+            self.assertTrue(any("Front matter tags does not match index value" in message for message in messages))
+            self.assertTrue(
+                any("Front matter source_refs does not match index value" in message for message in messages)
+            )
+            self.assertTrue(
+                any("Front matter invalidates_when does not match index value" in message for message in messages)
+            )
+
+    def test_empty_source_refs_fail_for_index_and_front_matter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_valid_memory_tree(root)
+            index = valid_index().replace(
+                "source_refs:\n      - docs/ai/tooling/README.md", "source_refs: []"
+            )
+            entry = valid_entry().replace("source_refs:\n  - docs/ai/tooling/README.md", "source_refs: []")
+            write(root / ".codex" / "memory" / "index.yml", index)
+            write(root / ".codex" / "memory" / "repo" / "validation.md", memory_file_from_entry(entry))
+
+            findings, _ = check_codex_memory.collect_findings(root)
+
+            self.assertTrue(
+                any("source_refs must include at least one source reference" in finding.message for finding in findings)
+            )
+
+    def test_front_matter_invalid_confidence_freshness_and_review_date_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_valid_memory_tree(root)
+            entry = valid_entry().replace("confidence: high", "confidence: certain", 1).replace(
+                "freshness: fresh", "freshness: ancient", 1
+            ).replace("review_after: 2999-01-01", "review_after: soon", 1)
+            write(root / ".codex" / "memory" / "repo" / "validation.md", memory_file_from_entry(entry))
+
+            findings, _ = check_codex_memory.collect_findings(root)
+            messages = finding_messages(findings)
+
+            self.assertTrue(any("Unknown front matter confidence: certain" in message for message in messages))
+            self.assertTrue(any("Unknown front matter freshness: ancient" in message for message in messages))
+            self.assertTrue(any("review_after is not a valid ISO date: soon" in message for message in messages))
+
     def test_unknown_tier_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
### Motivation

- Ensure every indexed Markdown memory entry includes the required YAML front matter and that that front matter matches the corresponding `.codex/memory/index.yml` entry to avoid missed/misrouted memory and stale/invalid metadata.
- Catch common authoring problems early (empty `source_refs`, invalid `confidence`/`freshness` values, bad `review_after` dates) so tooling and routing remain deterministic and auditable.

### Description

- Added `FRONT_MATTER_REQUIRED_FIELDS` and `FRONT_MATTER_MATCH_FIELDS` and extended `validate_entry_shape` to check that indexed memory files include required front-matter fields and to compare front-matter values to index values, reporting mismatches. 
- Made `validate_source_refs` require at least one source reference and verify repo-relative source paths exist. 
- Added front-matter validations for `confidence` and `freshness` against allowed enums and for `review_after` using ISO date parsing and warnings for past dates. 
- Improved the fallback `dump_yaml` implementation to emit empty lists/maps and render list-of-mapping entries sensibly when PyYAML is not available, and added focused tests in `build/scripts/docs/tests/test_check_codex_memory.py` that exercise missing/mismatched front-matter, empty `source_refs`, and invalid enum/date values.

### Testing

- Ran the focused unit tests `python -m unittest build/scripts/docs/tests/test_check_codex_memory.py` and all tests passed (27 tests, OK). 
- Exercised the CLI validations: `python build/scripts/docs/check-codex-memory.py --summary`, `--task ... --receipt --summary`, and `--goal ... --receipt --summary`, all producing expected pass/receipt outputs. 
- Ran `git diff --check` to ensure no whitespace/formatting issues and validated the changes with the repo validation flow; no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3998cc13d8832092d3fd3ce5bcb6fa)