### PR TITLE
docs: align Codex memory workflow guidance

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -19,9 +19,18 @@ stricter rules, add a closer `AGENTS.md` or `AGENTS.override.md` rather than exp
   domain modeling, workflow design, or architecture-sensitive implementation.
 - Read `.codex/skills/_shared/codex-execution-contract.md` before changing skills, agents,
   prompts, hooks, config, or automation guidance.
+- For memory-aware Codex tasks, inspect `.codex/memory/index.yml` before loading durable memory.
+  Use a matching `.codex/memory/tasks/<task-id>.yml` descriptor for named scopes and a
+  `.codex/memory/goals/<goal-id>.yml` inventory for long-running work that spans compaction,
+  continuation, or multiple implementation passes. Load only entries selected by the descriptor,
+  current intent, selected skill, changed paths, branch, or explicit tags; prefer canonical docs,
+  source, tests, scripts, scoped `AGENTS.md`, and selected `SKILL.md` files over memory if they
+  disagree.
 - Read `docs/ai/codex/memory-system.md`, `.codex/memory/index.yml`, and relevant
   `.codex/memory/tasks/*.yml` descriptors or `.codex/memory/goals/*.yml` inventories before
-  changing Codex memory entries, routing metadata, or memory validation tooling.
+  changing Codex memory entries, routing metadata, or memory validation tooling. Emit compact
+  memory receipts with selected IDs, match reasons, stale warnings, active-goal progress count, and
+  task or branch scope skips when memory routing is used.
 - When changing Codex development behavior or validation workflow, keep the Codex-loaded baseline
   and mirrored assistant surfaces synchronized: root `AGENTS.md`, `CLAUDE.md`,
   `docs/ai/codex/quickstart.md`, `.codex/skills/_shared/*`,

--- a/.codex/skills/_shared/codex-execution-contract.md
+++ b/.codex/skills/_shared/codex-execution-contract.md
@@ -10,10 +10,12 @@ Use this file as the Codex-only execution standard for Meridian skill runs. It c
 - Choose the smallest safe task scope that satisfies the request.
 - For implementation tasks, identify whether docs, tests, catalogs, or generated metadata must
   move with the code change before editing.
-- For memory-aware Codex tasks, inspect `.codex/memory/index.yml` and, when a scoped task is known,
-  route through a `.codex/memory/tasks/<task-id>.yml` descriptor. Load only entries selected by the
-  current task descriptor, intent, skill, changed paths, branch, or explicit tags. Canonical docs
-  and selected skills remain authoritative when memory disagrees. Use
+- For memory-aware Codex tasks, inspect `.codex/memory/index.yml` before loading durable memory.
+  When the work has a named scope, issue, prompt family, or planned-path boundary, route through a
+  `.codex/memory/tasks/<task-id>.yml` descriptor. Load only entries selected by the descriptor,
+  current intent, selected skill, changed paths, branch, or explicit tags; never bulk-load the
+  memory store. Canonical docs, source code, tests, scripts, applicable `AGENTS.md` files, and
+  selected `SKILL.md` files remain authoritative when memory disagrees. Use
   `python build/scripts/docs/check-codex-memory.py --task <descriptor> --receipt --summary` or the
   corresponding `--goal <inventory> --receipt --summary` command to produce the user-visible
   reference/dereference receipt.

--- a/.codex/skills/_shared/project-context.md
+++ b/.codex/skills/_shared/project-context.md
@@ -52,6 +52,8 @@ Use these together before changing AI guidance, routing, or workflow-oriented sk
 - `.codex/skills/_shared/codex-execution-contract.md`
 - `docs/ai/codex/memory-system.md`
 - `.codex/memory/index.yml`
+- `.codex/memory/tasks/*.yml`
+- `.codex/memory/goals/*.yml`
 - `.github/copilot-instructions.md`
 - `.github/agents/implementation-assurance-agent.md`
 - `.github/workflows/README.md`
@@ -76,6 +78,25 @@ Use these together before changing AI guidance, routing, or workflow-oriented sk
 - `docs/prompts/repo-maintenance-prompts.md`
 - `docs/roadmap/README.md`
 - `docs/roadmap/data/roadmap-items.yml`
+
+## Codex Memory Routing
+
+- For memory-aware Codex tasks, inspect `.codex/memory/index.yml` before loading durable memory.
+- Use `.codex/memory/tasks/<task-id>.yml` descriptors when the task has a named scope, prompt
+  family, issue, or planned-path boundary; use `.codex/memory/goals/<goal-id>.yml` inventories for
+  long-running goals that need progress, evidence, blockers, next actions, and promotion candidates
+  across compaction or continuation.
+- Load only memory entries selected by the descriptor, current intent, selected skill, changed
+  paths, branch, or explicit tags. Do not load the full memory store as startup context.
+- Canonical docs, source code, tests, scripts, applicable `AGENTS.md` files, and selected
+  `SKILL.md` files remain authoritative when memory is stale or conflicts.
+- When memory routing is used, include a compact receipt with selected memory IDs, match reasons,
+  stale warnings, active-goal progress count, and task or branch entries skipped because scope did
+  not match.
+- After changing `.codex/memory/index.yml`, indexed Markdown entries, task descriptors, goal
+  inventories, or memory validation tooling, run `python build/scripts/docs/check-codex-memory.py
+  --summary`; use `--task <descriptor> --receipt --summary` or `--goal <inventory> --receipt
+  --summary` when validating task or goal routing.
 
 ## Source Documentation Mesh
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,12 +49,21 @@ Keep it short and route detailed work to the canonical Meridian guidance sources
 6. Use the narrowest validation command that covers the files changed.
 7. If local machine capacity, restore, or MSBuild locks block validation, push the branch and use the manual GitHub-hosted `Targeted Test` workflow with a repo-relative test project under `tests/` plus `dotnet_filter` before retrying broad local scripts.
 8. Update docs and AI indexes in the same change when behavior, workflow, prompt, skill, or agent guidance changes.
-9. For Codex memory changes, update `.codex/memory/index.yml` plus the indexed Markdown entry, task
-   descriptor, or goal inventory, keep user/global tiers disabled unless explicitly opted in, use
-   `--receipt` when routing memory for a task or long goal, and run
+9. For memory-aware Codex tasks, inspect `.codex/memory/index.yml` before loading durable
+   memory. If the work has a named scope, route through the matching
+   `.codex/memory/tasks/<task-id>.yml` descriptor; if it is long-running, use the relevant
+   `.codex/memory/goals/<goal-id>.yml` inventory for progress, evidence, next actions, blockers,
+   and promotion candidates. Load only the selected entries that match the descriptor, current
+   intent, selected skill, changed paths, branch, or explicit tags; prefer canonical docs, source,
+   tests, scripts, scoped `AGENTS.md`, and selected `SKILL.md` files when memory disagrees.
+10. Emit compact memory receipts when memory routing is used: selected IDs, match reasons, stale
+   warnings, active-goal progress count, and task or branch entries skipped because scope did not
+   match. For Codex memory changes, update `.codex/memory/index.yml` plus the indexed Markdown
+   entry, task descriptor, or goal inventory, keep user/global tiers disabled unless explicitly opted
+   in, use `--receipt` for task or goal routing, and run
    `python build/scripts/docs/check-codex-memory.py --summary`.
-10. For Codex development workflow changes, keep `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, `.github/agents/implementation-assurance-agent.md`, `.github/workflows/README.md`, `docs/engineering/README.md`, `docs/start/README.md`, `.codex/skills/_shared/*`, `.claude/skills/_shared/project-context.md`, and `.agents/skills/_shared/project-context.md` synchronized when they teach the same rule.
-11. For documentation rebuild work, update the new canonical audience path first, then archive or redirect older hand-authored material in reviewable batches.
+11. For Codex development workflow changes, keep `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, `.github/agents/implementation-assurance-agent.md`, `.github/workflows/README.md`, `docs/engineering/README.md`, `docs/start/README.md`, `.codex/skills/_shared/*`, `.claude/skills/_shared/project-context.md`, and `.agents/skills/_shared/project-context.md` synchronized when they teach the same rule.
+12. For documentation rebuild work, update the new canonical audience path first, then archive or redirect older hand-authored material in reviewable batches.
 
 ## Command Discovery
 

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -19,7 +19,13 @@ For every AI/systems task in this repository, use this canonical order:
 5. `docs/engineering/README.md` or `docs/product/README.md` / `docs/operators/README.md` as applicable
 6. `docs/documentation-ownership.md` for archive/generation ownership
 7. `docs/documentation-inventory.md` to update migration state and phase notes
-8. Targeted validation command set (`check-*` and structure checks)
+8. For memory-aware Codex tasks, inspect `.codex/memory/index.yml`; route named scopes through
+   `.codex/memory/tasks/<task-id>.yml`; route long-running work through
+   `.codex/memory/goals/<goal-id>.yml`; load only selected entries; emit compact receipts; and keep
+   canonical docs, source, tests, scripts, scoped `AGENTS.md`, and selected skills authoritative
+   over memory.
+9. Targeted validation command set (`check-*` and structure checks), including
+   `python build/scripts/docs/check-codex-memory.py --summary` after Codex memory changes
 
 Classify AI/doc changes in this rebuild model:
 

--- a/docs/ai/assistant-workflow-contract.md
+++ b/docs/ai/assistant-workflow-contract.md
@@ -493,8 +493,14 @@ Use this checklist when changing any AI-related asset:
 - [ ] Use [`working-memory.md`](working-memory.md) for concurrent implementation state so active
       claims, inspected files, assumptions, validation reuse, and codebase drift remain explicit.
 - [ ] Use [`codex/memory-system.md`](codex/memory-system.md) and `.codex/memory/index.yml` only for
-      Codex repo-local memory. Do not read or write user/global memory tiers without explicit future
-      opt-in.
+      Codex repo-local memory. For memory-aware Codex tasks, inspect the index before loading
+      durable memory; use `.codex/memory/tasks/<task-id>.yml` descriptors for named scopes; use
+      `.codex/memory/goals/<goal-id>.yml` inventories for long-running goals; load only entries
+      selected by descriptor, intent, skill, path, branch, or explicit tags; emit compact receipts
+      for selected IDs, match reasons, stale warnings, goal progress, and scope skips; prefer
+      canonical docs, source, tests, scripts, scoped `AGENTS.md`, and selected skills over memory;
+      and run `python build/scripts/docs/check-codex-memory.py --summary` after memory changes. Do
+      not read or write user/global memory tiers without explicit future opt-in.
 - [ ] Update [`tooling/README.md`](tooling/README.md) when AI script discovery, validation lanes,
       or safe-usage guidance changes.
 - [ ] Keep all assistant surfaces aligned to the current operator taxonomy: browser dashboard and

--- a/docs/ai/codex/README.md
+++ b/docs/ai/codex/README.md
@@ -321,10 +321,13 @@ task-stop evidence checks.
 - Keep the startup context receipt and tool/context change notice in the Codex execution contract
   and quickstart so users can see the active lane, loaded context, next evidence, and reason for
   meaningful tool or context expansion.
-- Use `.codex/memory/index.yml` selectively when a task descriptor, current intent, selected skill,
-  changed paths, branch, or explicit tags match a memory entry. Use `--receipt` for user-visible
-  reference/dereference notices, add `--explain` when scope sensitivity needs full routing detail,
-  and keep canonical docs and selected skills authoritative when memory disagrees.
+- Inspect `.codex/memory/index.yml` for memory-aware tasks before loading durable memory. Use
+  `.codex/memory/tasks/<task-id>.yml` descriptors for named scopes, issues, prompt families, or
+  planned-path boundaries, and load only entries selected by the descriptor, current intent,
+  selected skill, changed paths, branch, or explicit tags. Use `--receipt` for compact
+  user-visible reference/dereference notices, add `--explain` when scope sensitivity needs full
+  routing detail, and keep canonical docs, source, tests, scripts, scoped `AGENTS.md`, and selected
+  skills authoritative when memory disagrees.
 - Use `.codex/memory/goals/*.yml` inventories for very long Codex goals that need progress,
   evidence, next actions, and active task descriptor state across compaction or continuation. Update
   them through `--record-goal-progress` so the checker validates the write and prints a memory
@@ -378,8 +381,8 @@ Use the Codex skill checker for fast local drift detection:
 
 ```bash
 python3 build/scripts/docs/check-codex-memory.py --summary
-python3 build/scripts/docs/check-codex-memory.py --task .codex/memory/tasks/example.yml --explain --summary
-python3 build/scripts/docs/check-codex-memory.py --goal .codex/memory/goals/example.yml --explain --summary
+python3 build/scripts/docs/check-codex-memory.py --task .codex/memory/tasks/example.yml --receipt --summary
+python3 build/scripts/docs/check-codex-memory.py --goal .codex/memory/goals/example.yml --receipt --summary
 python3 build/scripts/docs/check-codex-skills.py --summary
 python3 build/scripts/docs/check-codex-skills.py --json-output docs/generated/codex-skills-check.json
 python3 build/scripts/docs/validate-roadmap-registry.py --summary

--- a/docs/ai/codex/quickstart.md
+++ b/docs/ai/codex/quickstart.md
@@ -23,11 +23,13 @@ still lives in `../assistant-workflow-contract.md`.
    `.github/agents/implementation-assurance-agent.md`, `.github/workflows/README.md`,
    `docs/engineering/README.md`, `docs/start/README.md`,
    `.claude/skills/_shared/project-context.md`, and `.agents/skills/_shared/project-context.md`.
-   For memory-aware tasks, inspect `.codex/memory/index.yml`; when the work has a named scope, use
-   a `.codex/memory/tasks/<task-id>.yml` descriptor and load only entries selected by the descriptor,
-   current intent, skill, changed paths, branch, or explicit tags. For very long goals, also use a
-   `.codex/memory/goals/<goal-id>.yml` progress inventory. Include a compact memory receipt for
-   selected IDs, match reasons, stale warnings, goal progress, and task/branch scope skips.
+   For memory-aware tasks, inspect `.codex/memory/index.yml` before loading durable memory; when
+   the work has a named scope, use a `.codex/memory/tasks/<task-id>.yml` descriptor and load only
+   entries selected by the descriptor, current intent, skill, changed paths, branch, or explicit
+   tags. For very long goals, also use a `.codex/memory/goals/<goal-id>.yml` progress inventory.
+   Include a compact memory receipt for selected IDs, match reasons, stale warnings, goal progress,
+   and task/branch scope skips. Prefer canonical docs, source, tests, scripts, scoped `AGENTS.md`,
+   and selected `SKILL.md` files when memory disagrees.
 5. Read `../navigation/README.md` and `../generated/repo-navigation.md` for large-repo routing.
 6. For stakeholder/product-scoped tasks, read `../product/meridian-design-document.md` before planning updates.
 7. For broad generation, domain modeling, workflow design, or architecture-sensitive refactors, load the MDIF spine: `../../architecture/meridian-development-intelligence-framework.md`, `../../architecture/meridian-vision.md`, `../../architecture/meridian-domain-model.md`, `../../domain/README.md`, and the relevant pack in `../context/README.md`.
@@ -139,9 +141,10 @@ and uses `MeridianBuildIsolationKey` output roots by default.
 - Agent orchestration: start lane planning with `../parallel-task-manifest-template.md` when multiple skills/surfaces are in scope.
 - Working memory: use `../working-memory.md` to track task-local active claims, inspected files,
   assumptions, codebase drift, merge order, and validation reuse during concurrent changes.
-- Codex memory: use `.codex/memory/index.yml` only as a selective repo-local memory catalog; use
-  task descriptors plus `--explain` for scoped memory routing; use goal inventories for long-running
-  progress tracking; follow `memory-system.md` for promotion, staleness, and disabled user/global
+- Codex memory: inspect `.codex/memory/index.yml` only as a selective repo-local memory catalog;
+  use task descriptors plus `--receipt` for scoped memory routing; use goal inventories for
+  long-running progress tracking; load only selected entries; follow `memory-system.md` for
+  promotion, staleness, disabled user/global tiers, and canonical-doc precedence over memory
   tiers.
 - Parallel development workflows: keep each lane scoped to unique path sets and document handoff boundaries.
 - Token/context management: load only startup checks then escalate context only by phase; use one lane at a time.


### PR DESCRIPTION
### Motivation

- Make Codex and shared AI workflow docs consistent so agents use the repo-local memory system safely and predictably.
- Ensure memory is loaded only when appropriate, scoped by task descriptors or goal inventories, and that canonical docs remain authoritative over memory.
- Add clear routing, receipt, and validation rules so memory edits are auditable and validated by the existing tooling.

### Description

- Updated root `AGENTS.md` and `.codex/AGENTS.md` to require inspecting `.codex/memory/index.yml` for memory-aware tasks and to document using task descriptors and goal inventories, selective loading, canonical-doc precedence, and compact memory receipts.
- Expanded `.codex/skills/_shared/project-context.md` with a dedicated "Codex Memory Routing" section and referenced task descriptor/goal inventory paths.
- Tightened the Codex execution contract in `.codex/skills/_shared/codex-execution-contract.md` to mandate index inspection, descriptor-based routing, never bulk-loading the memory store, and using receipt-producing memory checks (use `--receipt`).
- Aligned `docs/ai/codex/quickstart.md`, `docs/ai/codex/README.md`, `docs/ai/README.md`, and `docs/ai/assistant-workflow-contract.md` to the same behavior, including examples and validator guidance using `check-codex-memory.py` with `--receipt` for task/goal routing.
- Files changed: `AGENTS.md`, `.codex/AGENTS.md`, `.codex/skills/_shared/project-context.md`, `.codex/skills/_shared/codex-execution-contract.md`, `docs/ai/codex/quickstart.md`, `docs/ai/codex/README.md`, `docs/ai/README.md`, and `docs/ai/assistant-workflow-contract.md`.

### Testing

- Ran `python build/scripts/docs/check-codex-memory.py --summary` and it passed with no errors or warnings.
- Ran `python build/scripts/docs/check-codex-memory.py --task .codex/memory/tasks/example.yml --receipt --summary` and the task routing check passed and emitted a compact memory receipt.
- Ran `python build/scripts/docs/check-codex-memory.py --goal .codex/memory/goals/example.yml --receipt --summary` and the goal inventory check passed and emitted a compact memory receipt.
- Ran `git diff --check` (docs-only whitespace/lint checks) against the modified files and it returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3998d3851883208f124a31d3984949)