### PR TITLE
Clean up Codex memory selection

### DIFF
--- a/build/scripts/docs/check-codex-memory.py
+++ b/build/scripts/docs/check-codex-memory.py
@@ -682,6 +682,7 @@ def validate_entry_shape(root: Path, entry: Any, index_path: Path, seen_ids: set
     if entry.get("freshness") in {"stale", "unknown"}:
         findings.append(Finding("warning", finding_path, f"Memory freshness is {entry.get('freshness')}."))
 
+    tier = entry.get("tier")
     raw_file = entry.get("file")
     if not isinstance(raw_file, str):
         findings.append(Finding("error", finding_path, "file must be a string."))
@@ -700,6 +701,7 @@ def validate_entry_shape(root: Path, entry: Any, index_path: Path, seen_ids: set
         findings.append(Finding("error", finding_path, f"Memory file does not exist: {raw_file}"))
         return entry, findings
 
+    memory_display_path = rel(root, memory_file)
     front_matter, front_findings = parse_front_matter(memory_file)
     findings.extend(front_findings)
     if front_findings:
@@ -1289,13 +1291,6 @@ def select_entries(
 ) -> list[dict[str, Any]]:
     context = build_routing_context(paths, tags, task_descriptor, skills, intents, branches)
     selected, _ = route_entries(entries, context, stale_only)
-    return selected
-    for entry in entries:
-        if stale_only and not entry_is_stale(entry):
-            continue
-        if has_filters and not (matches_paths(entry, paths) or matches_tags(entry, tags)):
-            continue
-        selected.append(entry)
     return selected
 
 


### PR DESCRIPTION
### Motivation
- Remove unreachable legacy selection code path in `select_entries()` so selection is driven by the existing routing pipeline.
- Preserve existing routing behavior through `build_routing_context()` → `route_entries()` while keeping validation intact.

### Description
- Deleted the unreachable legacy loop that ran after the early `return selected` in `select_entries()` so the function now only returns the routed results from `route_entries()`.
- Restored local variables used by entry validation by adding `tier = entry.get("tier")` and `memory_display_path = rel(root, memory_file)` in `validate_entry_shape()` so front-matter checks run without a `NameError` and error messages reference the correct path.
- Did not change the `build_routing_context()` → `route_entries()` behavior or selection logic; only removed dead code and fixed local validation state.

### Testing
- Ran `python -m unittest build.scripts.docs.tests.test_check_codex_memory`, which reports test failures: the test suite currently fails with 2 expectation mismatches related to archive/front-matter validation.
- Ran `python build/scripts/docs/check-codex-memory.py --summary`, which completed successfully (script summary reported pass for the sample repo state).
- Ran `python build/scripts/docs/check-codex-memory.py --task .codex/memory/tasks/example.yml --receipt --summary`, which completed successfully and produced a memory receipt.
- Ran `python build/scripts/docs/check-codex-memory.py --goal .codex/memory/goals/example.yml --receipt --summary`, which also completed successfully and produced a memory receipt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a399ca1b3848320a8f4b7a11f619bd4)