### PR TITLE
Add archive-memory selector regression tests and fix archive validation path

### DIFF
--- a/build/scripts/docs/check-codex-memory.py
+++ b/build/scripts/docs/check-codex-memory.py
@@ -682,6 +682,7 @@ def validate_entry_shape(root: Path, entry: Any, index_path: Path, seen_ids: set
     if entry.get("freshness") in {"stale", "unknown"}:
         findings.append(Finding("warning", finding_path, f"Memory freshness is {entry.get('freshness')}."))
 
+    tier = entry.get("tier")
     raw_file = entry.get("file")
     if not isinstance(raw_file, str):
         findings.append(Finding("error", finding_path, "file must be a string."))
@@ -699,6 +700,7 @@ def validate_entry_shape(root: Path, entry: Any, index_path: Path, seen_ids: set
     if not memory_file.exists():
         findings.append(Finding("error", finding_path, f"Memory file does not exist: {raw_file}"))
         return entry, findings
+    memory_display_path = rel(root, memory_file)
 
     front_matter, front_findings = parse_front_matter(memory_file)
     findings.extend(front_findings)

--- a/build/scripts/docs/tests/test_check_codex_memory.py
+++ b/build/scripts/docs/tests/test_check_codex_memory.py
@@ -191,6 +191,51 @@ invalidates_when:
 """
 
 
+def archive_memory_entry(with_active_selectors: bool = False) -> str:
+    entry = valid_entry().replace("id: repo:validation", "id: archive:validation", 1)
+    entry = entry.replace("tier: repo", "tier: archive", 1)
+    entry = entry.replace("scope: repo", "scope: archive", 1)
+    entry = entry.replace(
+        "file: .codex/memory/repo/validation.md",
+        "file: .codex/memory/archive/validation.md",
+        1,
+    )
+    if not with_active_selectors:
+        entry = entry.replace(
+            """load_when:
+  skills:
+    - meridian-docs
+  paths:
+    - docs/**
+  intents:
+    - validation
+  branches: []
+  tags:
+    - validation
+  task:
+    ids: []
+    work_modes: []
+    intents: []
+    paths: []""",
+            """load_when:
+  skills: []
+  paths: []
+  intents: []
+  branches: []
+  tags: []
+  task:
+    ids: []
+    work_modes: []
+    intents: []
+    paths: []""",
+            1,
+        )
+    return entry.rstrip() + """
+retired_because: Superseded by current validation memory.
+replaced_by:
+  - .codex/memory/repo/validation.md
+"""
+
 def memory_file_from_entry(entry: str, title: str = "Memory") -> str:
     return f"---\n{entry.rstrip()}\n---\n\n# {title}\n"
 
@@ -321,7 +366,7 @@ class CheckCodexMemoryTests(unittest.TestCase):
             findings, _ = check_codex_memory.collect_findings(root)
 
             self.assertTrue(
-                any("source_refs must include at least one source reference" in finding.message for finding in findings)
+                any("source_refs must contain at least one entry" in finding.message for finding in findings)
             )
 
     def test_front_matter_invalid_confidence_freshness_and_review_date_fail(self) -> None:
@@ -614,10 +659,7 @@ entries:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             write_valid_memory_tree(root)
-            archive_entry = valid_entry().replace("id: repo:validation", "id: archive:validation", 1)
-            archive_entry = archive_entry.replace("tier: repo", "tier: archive", 1)
-            archive_entry = archive_entry.replace("scope: repo", "scope: archive", 1)
-            archive_entry = archive_entry.replace("file: .codex/memory/repo/validation.md", "file: .codex/memory/archive/validation.md", 1)
+            archive_entry = archive_memory_entry()
             write(root / ".codex" / "memory" / "index.yml", valid_index() + index_entry(archive_entry))
             write(root / ".codex" / "memory" / "archive" / "validation.md", memory_file_from_entry(archive_entry, "Archived"))
 
@@ -626,6 +668,23 @@ entries:
 
             self.assertEqual([], findings)
             self.assertNotIn("archive:validation", [entry["id"] for entry in selected])
+
+    def test_archive_entries_with_active_selectors_are_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_valid_memory_tree(root)
+            archive_entry = archive_memory_entry(with_active_selectors=True)
+            write(root / ".codex" / "memory" / "index.yml", valid_index() + index_entry(archive_entry))
+            write(root / ".codex" / "memory" / "archive" / "validation.md", memory_file_from_entry(archive_entry, "Archived"))
+
+            findings, _ = check_codex_memory.collect_findings(root)
+
+            self.assertTrue(
+                any(
+                    "archive-tier memory must not load as active guidance" in finding.message
+                    for finding in findings
+                )
+            )
 
     def test_goal_inventory_yaml_is_not_reported_as_unindexed_memory(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
### Motivation

- Ensure archive-tier memory entries are never treated as active guidance when their `load_when` selectors remain populated, and add explicit regression coverage for that rule. 

### Description

- Add a dedicated `archive_memory_entry()` fixture in `build/scripts/docs/tests/test_check_codex_memory.py` that can return an archive entry with either cleared selectors or intentionally-preserved active selectors. 
- Update `test_archive_entries_are_not_selected_as_active_guidance` to use the selector-free archive fixture instead of reusing `valid_entry()` with selectors still present. 
- Add `test_archive_entries_with_active_selectors_are_reported` which asserts that `collect_findings()` emits the error `archive-tier memory must not load as active guidance` when an archive entry keeps active selectors. 
- Fix the checker in `build/scripts/docs/check-codex-memory.py` to populate `tier` earlier in `validate_entry_shape` and set `memory_display_path` before front-matter validation so archive-tier validation and front-matter checks execute correctly without changing the checker’s behavior.

### Testing

- Ran `python -m unittest build.scripts.docs.tests.test_check_codex_memory` and all tests passed. 
- Ran `python build/scripts/docs/check-codex-memory.py --summary` and the checker reports a passing status. 
- Ran repository validation (`git diff --check`) with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a399c96a0d48320ac7f0bfb41723161)