### PR TITLE
Support CSV + XLSX parsing and SFTP discovery for ETL ingestion

### DIFF
--- a/src/Meridian.Contracts/Etl/EtlModels.cs
+++ b/src/Meridian.Contracts/Etl/EtlModels.cs
@@ -318,7 +318,11 @@ public interface IPartnerFileParser
 {
     string SchemaId { get; }
     bool CanParse(EtlStagedFile file);
-    IAsyncEnumerable<PartnerRecordEnvelope> ParseAsync(EtlStagedFile file, EtlCheckpointToken? checkpoint, CancellationToken ct = default);
+    IAsyncEnumerable<PartnerRecordEnvelope> ParseAsync(
+        EtlStagedFile file,
+        EtlCheckpointToken? checkpoint,
+        string? schemaId = null,
+        CancellationToken ct = default);
 }
 
 /// <summary>Resolves CSV column schemas by partner schema ID.</summary>

--- a/src/Meridian.Contracts/README.md
+++ b/src/Meridian.Contracts/README.md
@@ -1182,6 +1182,10 @@ See `DIA-ASSURANCE-LOOP` in `docs/source/data/diagram-index.yml`.
 | `TODO-SRC-CONTRACTS-001` | Complete W5 accounting record evidence-chain contract coverage | done | high |
 <!-- source-todos:end -->
 
+## API and contract notes
+
+`IPartnerFileParser.ParseAsync` accepts an optional partner schema id so ETL orchestrators can route CSV and Excel workbook rows through the persisted mapping schema while retaining checkpoint-aware streaming envelopes.
+
 ## Validation
 
 ```bash

--- a/src/Meridian.DataIntegration/Etl/EtlServices.cs
+++ b/src/Meridian.DataIntegration/Etl/EtlServices.cs
@@ -146,7 +146,7 @@ public sealed class EtlJobOrchestrator
                 var staged = await reader.StageFileAsync(jobId, definition.Source, file, ct).ConfigureAwait(false);
                 await _auditStore.WriteEventAsync(jobId, new EtlAuditEvent { Stage = "staged", Message = $"Staged {file.Name}." }, ct).ConfigureAwait(false);
 
-                await foreach (var record in _parser.ParseAsync(staged, checkpoint, ct).ConfigureAwait(false))
+                await foreach (var record in _parser.ParseAsync(staged, checkpoint, definition.PartnerSchemaId, ct).ConfigureAwait(false))
                 {
                     processed++;
                     var outcome = await _normalizer.NormalizeAsync(definition, record, ct).ConfigureAwait(false);

--- a/src/Meridian.DataIntegration/README.md
+++ b/src/Meridian.DataIntegration/README.md
@@ -188,7 +188,7 @@ from Application ETL abstractions/implementations into this module and now use t
 `Meridian.DataIntegration.Etl` namespace. `IEtlJobDefinitionStore` and `ISftpFilePublisher` moved
 to `Meridian.Contracts.Etl`, and the local JSON-backed `EtlJobDefinitionStore` moved to
 `Meridian.Storage.Etl`. Application now keeps composition and concrete runtime adapters for its
-ingestion-job lifecycle and event pipeline while Data Integration owns ETL job orchestration.
+ingestion-job lifecycle and event pipeline while Data Integration owns ETL job orchestration. ETL job orchestration passes the persisted partner schema id into the parser so CSV, XLSX, local, and SFTP ingestion share the same mapped normalization boundary.
 
 `IEventCanonicalizer`, `EventCanonicalizer`, `ICanonicalSecurityIdLookup`,
 `ConditionCodeMapper`, `VenueMicMapper`, `ICanonicalizationMetrics`,

--- a/src/Meridian.Infrastructure/Etl/CsvPartnerFileParser.cs
+++ b/src/Meridian.Infrastructure/Etl/CsvPartnerFileParser.cs
@@ -1,9 +1,16 @@
+using System.IO.Compression;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
 using Meridian.Contracts.Etl;
 
 namespace Meridian.Infrastructure.Etl;
 
 public sealed class CsvPartnerFileParser : IPartnerFileParser
 {
+    private static readonly XNamespace Spreadsheet = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+    private static readonly XNamespace Relationships = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+    private static readonly XNamespace PackageRelationships = "http://schemas.openxmlformats.org/package/2006/relationships";
+
     private readonly IPartnerSchemaRegistry _schemas;
 
     public CsvPartnerFileParser(IPartnerSchemaRegistry schemas)
@@ -14,12 +21,46 @@ public sealed class CsvPartnerFileParser : IPartnerFileParser
     public string SchemaId => "partner.trades.csv.v1";
 
     public bool CanParse(EtlStagedFile file)
-        => Path.GetExtension(file.FileName).Equals(".csv", StringComparison.OrdinalIgnoreCase);
-
-    public async IAsyncEnumerable<PartnerRecordEnvelope> ParseAsync(EtlStagedFile file, EtlCheckpointToken? checkpoint, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
     {
-        var schemaId = SchemaId;
-        var schema = _schemas.GetCsvSchema(schemaId);
+        var extension = Path.GetExtension(file.FileName);
+        return extension.Equals(".csv", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".xlsx", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public async IAsyncEnumerable<PartnerRecordEnvelope> ParseAsync(
+        EtlStagedFile file,
+        EtlCheckpointToken? checkpoint,
+        string? schemaId = null,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var resolvedSchemaId = string.IsNullOrWhiteSpace(schemaId) ? SchemaId : schemaId!;
+        var schema = _schemas.GetCsvSchema(resolvedSchemaId);
+        var extension = Path.GetExtension(file.FileName);
+
+        if (extension.Equals(".xlsx", StringComparison.OrdinalIgnoreCase))
+        {
+            foreach (var row in ParseWorkbook(file, schema, resolvedSchemaId, checkpoint))
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return row;
+            }
+
+            yield break;
+        }
+
+        await foreach (var row in ParseCsvAsync(file, schema, resolvedSchemaId, checkpoint, ct).ConfigureAwait(false))
+        {
+            yield return row;
+        }
+    }
+
+    private static async IAsyncEnumerable<PartnerRecordEnvelope> ParseCsvAsync(
+        EtlStagedFile file,
+        CsvSchemaDefinition schema,
+        string schemaId,
+        EtlCheckpointToken? checkpoint,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
         using var reader = new StreamReader(file.StagedPath);
         string[]? headers = null;
         long recordIndex = 0;
@@ -36,27 +77,164 @@ public sealed class CsvPartnerFileParser : IPartnerFileParser
         while ((line = await reader.ReadLineAsync(ct).ConfigureAwait(false)) is not null)
         {
             recordIndex++;
-            if (checkpoint?.CurrentFileChecksum == file.ChecksumSha256 && checkpoint.CurrentRecordIndex.HasValue && recordIndex <= checkpoint.CurrentRecordIndex.Value)
+            if (ShouldSkip(checkpoint, file.ChecksumSha256, recordIndex))
                 continue;
 
             var values = SplitCsvLine(line, schema.Delimiter).ToArray();
             headers ??= schema.Columns.Keys.ToArray();
-            var fields = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
-            for (var i = 0; i < headers.Length && i < values.Length; i++)
+            yield return BuildEnvelope(file, schemaId, recordIndex, headers, values, line);
+        }
+    }
+
+    private static IEnumerable<PartnerRecordEnvelope> ParseWorkbook(
+        EtlStagedFile file,
+        CsvSchemaDefinition schema,
+        string schemaId,
+        EtlCheckpointToken? checkpoint)
+    {
+        using var archive = ZipFile.OpenRead(file.StagedPath);
+        var sharedStrings = ReadSharedStrings(archive);
+        var sheetEntry = ResolveFirstWorksheetEntry(archive)
+            ?? throw new InvalidOperationException($"Excel workbook '{file.FileName}' does not contain a readable worksheet.");
+
+        using var sheetStream = sheetEntry.Open();
+        var sheet = XDocument.Load(sheetStream);
+        string[]? headers = null;
+        long recordIndex = 0;
+
+        foreach (var row in sheet.Descendants(Spreadsheet + "sheetData").Elements(Spreadsheet + "row"))
+        {
+            var values = ReadRowValues(row, sharedStrings).ToArray();
+            if (values.Length == 0 || values.All(string.IsNullOrWhiteSpace))
+                continue;
+
+            if (schema.HasHeaderRow && headers is null)
             {
-                fields[headers[i]] = values[i];
+                headers = values;
+                continue;
             }
 
-            yield return new PartnerRecordEnvelope
-            {
-                PartnerSchemaId = schemaId,
-                SourceFileName = file.FileName,
-                SourceFileChecksum = file.ChecksumSha256,
-                RecordIndex = recordIndex,
-                Fields = fields,
-                RawLine = line
-            };
+            recordIndex++;
+            if (ShouldSkip(checkpoint, file.ChecksumSha256, recordIndex))
+                continue;
+
+            headers ??= schema.Columns.Keys.ToArray();
+            yield return BuildEnvelope(file, schemaId, recordIndex, headers, values, string.Join(',', values.Select(EscapeCsvCell)));
         }
+    }
+
+    private static PartnerRecordEnvelope BuildEnvelope(
+        EtlStagedFile file,
+        string schemaId,
+        long recordIndex,
+        IReadOnlyList<string> headers,
+        IReadOnlyList<string> values,
+        string? rawLine)
+    {
+        var fields = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < headers.Count && i < values.Count; i++)
+        {
+            fields[headers[i]] = values[i];
+        }
+
+        return new PartnerRecordEnvelope
+        {
+            PartnerSchemaId = schemaId,
+            SourceFileName = file.FileName,
+            SourceFileChecksum = file.ChecksumSha256,
+            RecordIndex = recordIndex,
+            Fields = fields,
+            RawLine = rawLine
+        };
+    }
+
+    private static bool ShouldSkip(EtlCheckpointToken? checkpoint, string checksum, long recordIndex)
+        => checkpoint?.CurrentFileChecksum == checksum
+           && checkpoint.CurrentRecordIndex.HasValue
+           && recordIndex <= checkpoint.CurrentRecordIndex.Value;
+
+    private static ZipArchiveEntry? ResolveFirstWorksheetEntry(ZipArchive archive)
+    {
+        var workbookEntry = archive.GetEntry("xl/workbook.xml");
+        var relsEntry = archive.GetEntry("xl/_rels/workbook.xml.rels");
+        if (workbookEntry is null || relsEntry is null)
+            return archive.GetEntry("xl/worksheets/sheet1.xml");
+
+        using var workbookStream = workbookEntry.Open();
+        using var relsStream = relsEntry.Open();
+        var workbook = XDocument.Load(workbookStream);
+        var rels = XDocument.Load(relsStream);
+        var firstSheet = workbook.Descendants(Spreadsheet + "sheet").FirstOrDefault();
+        var relationshipId = firstSheet?.Attribute(Relationships + "id")?.Value;
+        if (string.IsNullOrWhiteSpace(relationshipId))
+            return archive.GetEntry("xl/worksheets/sheet1.xml");
+
+        var target = rels.Descendants(PackageRelationships + "Relationship")
+            .FirstOrDefault(x => string.Equals(x.Attribute("Id")?.Value, relationshipId, StringComparison.Ordinal))
+            ?.Attribute("Target")?.Value;
+        if (string.IsNullOrWhiteSpace(target))
+            return archive.GetEntry("xl/worksheets/sheet1.xml");
+
+        var normalized = target.StartsWith("/", StringComparison.Ordinal)
+            ? target.TrimStart('/')
+            : $"xl/{target}";
+        return archive.GetEntry(normalized.Replace("//", "/"));
+    }
+
+    private static string[] ReadSharedStrings(ZipArchive archive)
+    {
+        var entry = archive.GetEntry("xl/sharedStrings.xml");
+        if (entry is null)
+            return [];
+
+        using var stream = entry.Open();
+        var document = XDocument.Load(stream);
+        return document.Descendants(Spreadsheet + "si")
+            .Select(si => string.Concat(si.Descendants(Spreadsheet + "t").Select(t => t.Value)))
+            .ToArray();
+    }
+
+    private static IEnumerable<string> ReadRowValues(XElement row, IReadOnlyList<string> sharedStrings)
+    {
+        var cells = row.Elements(Spreadsheet + "c").ToList();
+        var nextColumn = 1;
+        foreach (var cell in cells)
+        {
+            var column = GetColumnIndex(cell.Attribute("r")?.Value) ?? nextColumn;
+            while (nextColumn < column)
+            {
+                yield return string.Empty;
+                nextColumn++;
+            }
+
+            yield return ReadCellValue(cell, sharedStrings);
+            nextColumn = column + 1;
+        }
+    }
+
+    private static string ReadCellValue(XElement cell, IReadOnlyList<string> sharedStrings)
+    {
+        var value = cell.Element(Spreadsheet + "v")?.Value ?? cell.Element(Spreadsheet + "is")?.Value ?? string.Empty;
+        var type = cell.Attribute("t")?.Value;
+        if (type == "s" && int.TryParse(value, out var sharedStringIndex) && sharedStringIndex >= 0 && sharedStringIndex < sharedStrings.Count)
+            return sharedStrings[sharedStringIndex];
+        return value;
+    }
+
+    private static int? GetColumnIndex(string? cellReference)
+    {
+        if (string.IsNullOrWhiteSpace(cellReference))
+            return null;
+
+        var index = 0;
+        foreach (var ch in cellReference)
+        {
+            if (!char.IsLetter(ch))
+                break;
+            index = (index * 26) + char.ToUpperInvariant(ch) - 'A' + 1;
+        }
+
+        return index == 0 ? null : index;
     }
 
     private static IEnumerable<string> SplitCsvLine(string line, char delimiter)
@@ -93,4 +271,9 @@ public sealed class CsvPartnerFileParser : IPartnerFileParser
         values.Add(current.ToString());
         return values;
     }
+
+    private static string EscapeCsvCell(string value)
+        => value.Contains(',') || value.Contains('"') || value.Contains('\n')
+            ? $"\"{value.Replace("\"", "\"\"")}\""
+            : value;
 }

--- a/src/Meridian.Infrastructure/Etl/LocalFileSourceReader.cs
+++ b/src/Meridian.Infrastructure/Etl/LocalFileSourceReader.cs
@@ -16,8 +16,10 @@ public sealed class LocalFileSourceReader : IEtlSourceReader
 
     public Task<IReadOnlyList<EtlRemoteFile>> ListFilesAsync(EtlSourceDefinition source, CancellationToken ct = default)
     {
-        var pattern = string.IsNullOrWhiteSpace(source.FilePattern) ? "*.csv" : source.FilePattern!;
-        var files = Directory.EnumerateFiles(source.Location, pattern, SearchOption.TopDirectoryOnly)
+        var pattern = string.IsNullOrWhiteSpace(source.FilePattern) ? "*.csv;*.xlsx" : source.FilePattern!;
+        var files = ExpandPatterns(pattern)
+            .SelectMany(p => Directory.EnumerateFiles(source.Location, p, SearchOption.TopDirectoryOnly))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
             .Select(path =>
             {
@@ -40,4 +42,7 @@ public sealed class LocalFileSourceReader : IEtlSourceReader
         await using var stream = new FileStream(file.Path, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, useAsync: true);
         return await _stagingStore.StageAsync(jobId, file, stream, ct).ConfigureAwait(false);
     }
+
+    private static IEnumerable<string> ExpandPatterns(string pattern)
+        => pattern.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 }

--- a/src/Meridian.Infrastructure/Etl/SftpFileSourceReader.cs
+++ b/src/Meridian.Infrastructure/Etl/SftpFileSourceReader.cs
@@ -22,10 +22,10 @@ public sealed class SftpFileSourceReader : IEtlSourceReader
         var uri = ParseUri(source.Location);
         using var client = CreateClient(source, uri);
         client.Connect();
-        var pattern = string.IsNullOrWhiteSpace(source.FilePattern) ? ".csv" : source.FilePattern!;
+        var pattern = string.IsNullOrWhiteSpace(source.FilePattern) ? "*.csv;*.xlsx" : source.FilePattern!;
         var files = client.ListDirectory(uri.AbsolutePath)
             .Where(f => !f.IsDirectory && !f.IsSymbolicLink)
-            .Where(f => Matches(f.Name, pattern))
+            .Where(f => MatchesAny(f.Name, pattern))
             .OrderBy(f => f.Name, StringComparer.OrdinalIgnoreCase)
             .Select(f => new EtlRemoteFile
             {
@@ -63,6 +63,11 @@ public sealed class SftpFileSourceReader : IEtlSourceReader
         => new(location.StartsWith("sftp://", StringComparison.OrdinalIgnoreCase)
             ? location
             : throw new InvalidOperationException("SFTP source paths must be full sftp:// URIs in v1."));
+
+    private static bool MatchesAny(string fileName, string pattern)
+        => pattern
+            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Any(part => Matches(fileName, part));
 
     private static bool Matches(string fileName, string pattern)
         => pattern.StartsWith("*.", StringComparison.Ordinal)

--- a/src/Meridian.Infrastructure/README.md
+++ b/src/Meridian.Infrastructure/README.md
@@ -77,7 +77,9 @@ complete.
 
 ETL SFTP publishing is an Infrastructure adapter implementation of the Contracts-owned
 `ISftpFilePublisher` port. Data Integration owns export behavior and composes the port; this layer
-only owns transport connection, directory creation, and upload mechanics.
+only owns transport connection, directory creation, and upload mechanics. Local and SFTP ETL source
+readers discover both CSV and XLSX partner files by default, with semicolon-delimited file patterns
+for scoped exchanges.
 
 Broker statement imports hash the source file bytes and persist the resulting content hash with a
 deterministic duplicate key derived from fund account, statement period, and source hash. Source

--- a/tests/Meridian.Tests/DataIntegration/Etl/EtlJobOrchestratorTests.cs
+++ b/tests/Meridian.Tests/DataIntegration/Etl/EtlJobOrchestratorTests.cs
@@ -52,7 +52,7 @@ public sealed class EtlJobOrchestratorTests : IDisposable
             FlowDirection = EtlFlowDirection.Import,
             PartnerSchemaId = "partner.trades.csv.v1",
             LogicalSourceName = "partner-a",
-            Source = new EtlSourceDefinition { Kind = EtlSourceKind.Local, Location = inputDir, FilePattern = "*.csv" },
+            Source = new EtlSourceDefinition { Kind = EtlSourceKind.Local, Location = inputDir, FilePattern = "*.csv;*.xlsx" },
             Destination = new EtlDestinationDefinition { Kind = EtlDestinationKind.StorageCatalog },
             ContinueOnRecordError = true
         });

--- a/tests/Meridian.Tests/Infrastructure/Etl/CsvPartnerFileParserTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Etl/CsvPartnerFileParserTests.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using FluentAssertions;
 using Meridian.Contracts.Etl;
 using Meridian.DataIntegration.Etl;
@@ -35,6 +36,78 @@ public sealed class CsvPartnerFileParserTests : IDisposable
         rows.Should().HaveCount(1);
         rows[0].Fields["symbol"].Should().Be("AAPL");
         rows[0].RecordIndex.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ParseAsync_ParsesExcelWorkbookRows()
+    {
+        Directory.CreateDirectory(_root);
+        var path = Path.Combine(_root, "input.xlsx");
+        CreateWorkbook(path);
+
+        var parser = new CsvPartnerFileParser(new PartnerSchemaRegistry());
+        var staged = new EtlStagedFile
+        {
+            OriginalPath = path,
+            StagedPath = path,
+            FileName = "input.xlsx",
+            ChecksumSha256 = "xlsx123",
+            SizeBytes = new FileInfo(path).Length
+        };
+
+        var rows = new List<PartnerRecordEnvelope>();
+        await foreach (var row in parser.ParseAsync(staged, new EtlCheckpointToken { CurrentFileChecksum = "xlsx123", CurrentRecordIndex = 1 }))
+        {
+            rows.Add(row);
+        }
+
+        rows.Should().HaveCount(1);
+        rows[0].PartnerSchemaId.Should().Be("partner.trades.csv.v1");
+        rows[0].Fields["symbol"].Should().Be("MSFT");
+        rows[0].Fields["price"].Should().Be("401.25");
+        rows[0].RecordIndex.Should().Be(2);
+    }
+
+    private static void CreateWorkbook(string path)
+    {
+        using var archive = ZipFile.Open(path, ZipArchiveMode.Create);
+        WriteEntry(archive, "xl/workbook.xml", """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+              <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1" /></sheets>
+            </workbook>
+            """);
+        WriteEntry(archive, "xl/_rels/workbook.xml.rels", """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+              <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml" />
+            </Relationships>
+            """);
+        WriteEntry(archive, "xl/sharedStrings.xml", """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+              <si><t>timestamp</t></si><si><t>symbol</t></si><si><t>price</t></si><si><t>size</t></si><si><t>venue</t></si><si><t>sequence</t></si><si><t>aggressor</t></si>
+              <si><t>2026-01-01T00:00:00Z</t></si><si><t>AAPL</t></si><si><t>XNAS</t></si><si><t>BUY</t></si>
+              <si><t>2026-01-01T00:00:01Z</t></si><si><t>MSFT</t></si><si><t>SELL</t></si>
+            </sst>
+            """);
+        WriteEntry(archive, "xl/worksheets/sheet1.xml", """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+              <sheetData>
+                <row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c><c r="C1" t="s"><v>2</v></c><c r="D1" t="s"><v>3</v></c><c r="E1" t="s"><v>4</v></c><c r="F1" t="s"><v>5</v></c><c r="G1" t="s"><v>6</v></c></row>
+                <row r="2"><c r="A2" t="s"><v>7</v></c><c r="B2" t="s"><v>8</v></c><c r="C2"><v>100.5</v></c><c r="D2"><v>10</v></c><c r="E2" t="s"><v>9</v></c><c r="F2"><v>1</v></c><c r="G2" t="s"><v>10</v></c></row>
+                <row r="3"><c r="A3" t="s"><v>11</v></c><c r="B3" t="s"><v>12</v></c><c r="C3"><v>401.25</v></c><c r="D3"><v>20</v></c><c r="E3" t="s"><v>9</v></c><c r="F3"><v>2</v></c><c r="G3" t="s"><v>13</v></c></row>
+              </sheetData>
+            </worksheet>
+            """);
+    }
+
+    private static void WriteEntry(ZipArchive archive, string name, string content)
+    {
+        var entry = archive.CreateEntry(name);
+        using var writer = new StreamWriter(entry.Open());
+        writer.Write(content.Trim());
     }
 
     public void Dispose()


### PR DESCRIPTION
### Motivation
- Add operator-friendly ingestion for CSV and Excel workbook payloads and let ETL orchestration route rows through the persisted partner schema instead of the parser-only default. 
- Make local and SFTP source readers discover common spreadsheet formats by default and allow semicolon-delimited file-patterns for scoped exchanges.

### Description
- Extend `IPartnerFileParser.ParseAsync` to accept an optional `schemaId` and update `EtlJobOrchestrator` to pass `definition.PartnerSchemaId` into the parser. 
- Replace the CSV-only parser with a unified `CsvPartnerFileParser` that also reads `.xlsx` workbooks (Zip/OpenXML read, shared-strings lookup, worksheet discovery, sparse-cell handling) while preserving checkpoint-aware envelopes, cancellation, and raw-line reconstruction for workbook rows. 
- Update `LocalFileSourceReader` and `SftpFileSourceReader` to default to `*.csv;*.xlsx`, support semicolon-delimited patterns, and add matching helpers to check multiple patterns. 
- Add/adjust unit tests to cover Excel workbook parsing and orchestrator multi-pattern behavior (`tests/Meridian.Tests/Infrastructure/Etl/CsvPartnerFileParserTests.cs` and `tests/Meridian.Tests/DataIntegration/Etl/EtlJobOrchestratorTests.cs`) and refresh module README notes describing schema-aware CSV/XLSX ingestion.

### Testing
- `git diff --check` was run and returned no check failures. 
- An attempt to run the focused test filter with `dotnet test --filter "FullyQualifiedName~CsvPartnerFileParserTests|FullyQualifiedName~EtlJobOrchestratorTests"` was performed but could not complete because `dotnet` is not available in this execution environment. 
- Unit tests were added/updated to exercise CSV and XLSX parsing and orchestrator discovery, but automated test execution remains pending in an environment with the .NET SDK available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39bc9ea7c08320865df84227b0fe33)