### PR TITLE
Add ETL preview/list/test modes, SFTP readiness & post-processing, and CSV schema updates

### DIFF
--- a/src/Meridian.Application/Commands/EtlCommands.cs
+++ b/src/Meridian.Application/Commands/EtlCommands.cs
@@ -18,7 +18,7 @@ internal sealed class EtlCommands : ICliCommand
     }
 
     public bool CanHandle(string[] args)
-        => CliArguments.HasFlag(args, "--etl-import") || CliArguments.HasFlag(args, "--etl-export") || CliArguments.HasFlag(args, "--etl-roundtrip") || CliArguments.HasFlag(args, "--etl-resume");
+        => CliArguments.HasFlag(args, "--etl-import") || CliArguments.HasFlag(args, "--etl-export") || CliArguments.HasFlag(args, "--etl-roundtrip") || CliArguments.HasFlag(args, "--etl-resume") || CliArguments.HasFlag(args, "--etl-preview") || CliArguments.HasFlag(args, "--etl-list-files") || CliArguments.HasFlag(args, "--etl-test-connection");
 
     public async Task<CliResult> ExecuteAsync(string[] args, CancellationToken ct = default)
     {
@@ -36,6 +36,25 @@ internal sealed class EtlCommands : ICliCommand
 
         if (!TryBuildDefinition(args, out var definition))
             return CliResult.Fail(ErrorCode.RequiredFieldMissing);
+
+        if (CliArguments.HasFlag(args, "--etl-preview") || CliArguments.HasFlag(args, "--etl-list-files") || CliArguments.HasFlag(args, "--etl-test-connection"))
+        {
+            var preview = startup.GetRequiredService<EtlPreviewService>();
+            var sampleRows = int.TryParse(CliArguments.GetValue(args, "--etl-preview-sample-rows"), out var parsedSampleRows) ? parsedSampleRows : 10;
+            var result = await preview.PreviewAsync(definition, sampleRows, ct).ConfigureAwait(false);
+            foreach (var file in result.Files)
+            {
+                Console.WriteLine($"{file.SourceFile.Name}: {file.Disposition}; Records={file.RecordCount}; Hash={file.FileHashSha256}");
+                if (!CliArguments.HasFlag(args, "--etl-list-files"))
+                {
+                    foreach (var issue in file.Issues)
+                        Console.WriteLine($"  {issue.Severity}: {issue.Field}: {issue.Message}");
+                }
+            }
+            foreach (var error in result.Errors)
+                Console.Error.WriteLine(error);
+            return result.Success ? CliResult.Ok() : CliResult.Fail(ErrorCode.Unknown);
+        }
 
         var job = await svc.CreateJobAsync(definition, ct).ConfigureAwait(false);
         var run = await svc.RunAsync(job.JobId, ct).ConfigureAwait(false);
@@ -74,7 +93,10 @@ internal sealed class EtlCommands : ICliCommand
                 Username = CliArguments.GetValue(args, "--etl-source-username"),
                 SecretRef = CliArguments.GetValue(args, "--etl-source-secret-ref"),
                 HostKeySha256Fingerprint = CliArguments.GetValue(args, "--etl-source-host-key-sha256"),
-                DeleteAfterSuccess = CliArguments.HasFlag(args, "--etl-delete-source")
+                DeleteAfterSuccess = CliArguments.HasFlag(args, "--etl-delete-source"),
+                PostProcessingAction = ParsePostProcessingAction(CliArguments.GetValue(args, "--etl-source-post-processing")),
+                ArchiveLocation = CliArguments.GetValue(args, "--etl-source-archive-path"),
+                ErrorLocation = CliArguments.GetValue(args, "--etl-source-error-path")
             },
             Destination = new EtlDestinationDefinition
             {
@@ -99,6 +121,16 @@ internal sealed class EtlCommands : ICliCommand
 
     private static EtlSourceKind ParseSourceKind(string value)
         => value.Equals("sftp", StringComparison.OrdinalIgnoreCase) ? EtlSourceKind.Sftp : EtlSourceKind.Local;
+
+    private static EtlSourcePostProcessingAction ParsePostProcessingAction(string? value)
+        => value?.ToLowerInvariant() switch
+        {
+            "delete" => EtlSourcePostProcessingAction.Delete,
+            "archive" or "move-to-archive" => EtlSourcePostProcessingAction.MoveToArchive,
+            "error" or "move-to-error" => EtlSourcePostProcessingAction.MoveToError,
+            "done" or "write-done-marker" => EtlSourcePostProcessingAction.WriteDoneMarker,
+            _ => EtlSourcePostProcessingAction.LeaveInPlace
+        };
 
     private static EtlDestinationKind ParseDestinationKind(string value)
         => value.ToLowerInvariant() switch

--- a/src/Meridian.Application/Composition/Features/EtlFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/EtlFeatureRegistration.cs
@@ -35,6 +35,9 @@ internal sealed class EtlFeatureRegistration : IServiceFeatureRegistration
         services.AddSingleton<IPartnerSchemaRegistry, PartnerSchemaRegistry>();
         services.AddSingleton<IPartnerFileParser, CsvPartnerFileParser>();
         services.AddSingleton<EtlNormalizationService>();
+        services.AddSingleton<EtlPreviewService>();
+        services.AddSingleton<ISftpCapabilityService, SftpCapabilityService>();
+        services.AddSingleton<ISftpCredentialResolver, EnvironmentSftpCredentialResolver>();
         services.AddSingleton<ISftpClientFactory, SftpClientFactory>();
         services.AddSingleton<IEtlSourceReader, LocalFileSourceReader>();
         services.AddSingleton<IEtlSourceReader, SftpFileSourceReader>();

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -42,6 +42,10 @@ and UI presentation concerns in their owning layers.
   export service now lives in `Meridian.DataIntegration.Etl`. The ETL job-definition store and
   SFTP publisher port contracts live in `Meridian.Contracts.Etl`, and the local JSON-backed
   job-definition store implementation lives in `Meridian.Storage.Etl`.
+  SFTP transaction-file onboarding now includes non-mutating preview/list/test CLI modes,
+  schema-aware CSV sampling for `bank.statement.csv.v1` and `bank.transactions.csv.v1`, explicit
+  source post-processing options, and runtime SFTP capability checks so operators can validate
+  connectivity, host-key pinning, and file shape before committing an import.
 - `Integrations/` - provider integration template catalog, setup persistence, dry-run
   orchestration, and activation readiness. The catalog seeds the first no-code template pack for
   manual CSV upload, custodian positions, brokerage transactions, and fixed income security master.

--- a/src/Meridian.Contracts/Etl/EtlModels.cs
+++ b/src/Meridian.Contracts/Etl/EtlModels.cs
@@ -33,6 +33,24 @@ public enum EtlTransferMode : byte
 }
 
 [JsonConverter(typeof(JsonStringEnumConverter))]
+public enum EtlSourcePostProcessingAction : byte
+{
+    LeaveInPlace = 0,
+    Delete = 1,
+    MoveToArchive = 2,
+    MoveToError = 3,
+    WriteDoneMarker = 4
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum EtlPreviewDisposition : byte
+{
+    Ready = 0,
+    Warning = 1,
+    Error = 2
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum EtlPackageFormat : byte
 {
     Zip = 0,
@@ -127,6 +145,15 @@ public sealed class EtlSourceDefinition
 
     [JsonPropertyName("deleteAfterSuccess")]
     public bool DeleteAfterSuccess { get; init; }
+
+    [JsonPropertyName("postProcessingAction")]
+    public EtlSourcePostProcessingAction PostProcessingAction { get; init; } = EtlSourcePostProcessingAction.LeaveInPlace;
+
+    [JsonPropertyName("archiveLocation")]
+    public string? ArchiveLocation { get; init; }
+
+    [JsonPropertyName("errorLocation")]
+    public string? ErrorLocation { get; init; }
 
     [JsonPropertyName("hostKeySha256Fingerprint")]
     public string? HostKeySha256Fingerprint { get; init; }
@@ -317,6 +344,7 @@ public interface IEtlSourceReader
     EtlSourceKind Kind { get; }
     Task<IReadOnlyList<EtlRemoteFile>> ListFilesAsync(EtlSourceDefinition source, CancellationToken ct = default);
     Task<EtlStagedFile> StageFileAsync(string jobId, EtlSourceDefinition source, EtlRemoteFile file, CancellationToken ct = default);
+    Task PostProcessFileAsync(EtlSourceDefinition source, EtlRemoteFile file, bool succeeded, CancellationToken ct = default);
 }
 
 /// <summary>Parses a staged partner file into record envelopes.</summary>
@@ -324,7 +352,67 @@ public interface IPartnerFileParser
 {
     string SchemaId { get; }
     bool CanParse(EtlStagedFile file);
-    IAsyncEnumerable<PartnerRecordEnvelope> ParseAsync(EtlStagedFile file, EtlCheckpointToken? checkpoint, CancellationToken ct = default);
+    IAsyncEnumerable<PartnerRecordEnvelope> ParseAsync(EtlStagedFile file, string schemaId, EtlCheckpointToken? checkpoint, CancellationToken ct = default);
+}
+
+public sealed class EtlFilePreviewIssue
+{
+    [JsonPropertyName("severity")]
+    public required string Severity { get; init; }
+
+    [JsonPropertyName("field")]
+    public required string Field { get; init; }
+
+    [JsonPropertyName("message")]
+    public required string Message { get; init; }
+
+    [JsonPropertyName("rowNumber")]
+    public int? RowNumber { get; init; }
+}
+
+public sealed class EtlFilePreview
+{
+    [JsonPropertyName("sourceFile")]
+    public required EtlRemoteFile SourceFile { get; init; }
+
+    [JsonPropertyName("schemaId")]
+    public required string SchemaId { get; init; }
+
+    [JsonPropertyName("disposition")]
+    public EtlPreviewDisposition Disposition { get; init; }
+
+    [JsonPropertyName("recordCount")]
+    public int RecordCount { get; init; }
+
+    [JsonPropertyName("sampleRows")]
+    public IReadOnlyList<IReadOnlyDictionary<string, string?>> SampleRows { get; init; } = [];
+
+    [JsonPropertyName("issues")]
+    public IReadOnlyList<EtlFilePreviewIssue> Issues { get; init; } = [];
+
+    [JsonPropertyName("fileHashSha256")]
+    public string? FileHashSha256 { get; init; }
+
+    [JsonPropertyName("idempotencyKey")]
+    public string? IdempotencyKey { get; init; }
+}
+
+public sealed class EtlPreviewResult
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; init; }
+
+    [JsonPropertyName("sourceKind")]
+    public EtlSourceKind SourceKind { get; init; }
+
+    [JsonPropertyName("schemaId")]
+    public required string SchemaId { get; init; }
+
+    [JsonPropertyName("files")]
+    public IReadOnlyList<EtlFilePreview> Files { get; init; } = [];
+
+    [JsonPropertyName("errors")]
+    public IReadOnlyList<string> Errors { get; init; } = [];
 }
 
 /// <summary>Resolves CSV column schemas by partner schema ID.</summary>

--- a/src/Meridian.Contracts/README.md
+++ b/src/Meridian.Contracts/README.md
@@ -662,12 +662,14 @@ and WPF consumers should depend on this contract rather than the Application-lay
 Environment Design service contracts also live in `Services/` and return DTOs from
 `EnvironmentDesign/`; browser, WPF, and host composition should depend on those contracts while the
 Workflow module provides the current local-first `EnvironmentDesignerService` implementation.
-ETL contracts include `EtlJobDefinition`, run/export result payloads, `IEtlJobDefinitionStore`,
-and `ISftpFilePublisher`. Keep the SFTP publisher port contract-owned so the Data
-Integration-owned export service can target SFTP without depending on Infrastructure, while the
-Infrastructure adapter implements transport-specific publishing details. SFTP source and
-destination definitions carry `hostKeySha256Fingerprint` so shared job definitions can pin remote
-server identity without leaking transport-library types into Contracts.
+ETL contracts include `EtlJobDefinition`, run/export/preview result payloads,
+`IEtlJobDefinitionStore`, and `ISftpFilePublisher`. Keep the SFTP publisher port contract-owned so
+Data Integration-owned services can target SFTP without depending on Infrastructure, while the
+Infrastructure adapter implements transport-specific connection, staging, post-processing, and
+publishing details. SFTP source and destination definitions carry `hostKeySha256Fingerprint` so
+shared job definitions can pin remote server identity without leaking transport-library types into
+Contracts. Source definitions also carry post-processing intent so local and SFTP readers can leave,
+delete, archive, error-route, or mark completed files consistently after a successful import.
 
 Event-pipeline metrics and monitoring delivery contracts live in `Monitoring/` under
 `Meridian.Contracts.Monitoring`. Keep `IEventMetrics`, `MetricsSnapshot`, and

--- a/src/Meridian.DataIntegration/Etl/EtlNormalizationService.cs
+++ b/src/Meridian.DataIntegration/Etl/EtlNormalizationService.cs
@@ -29,6 +29,38 @@ public sealed class PartnerSchemaRegistry : IPartnerSchemaRegistry
                     ["sequence"] = "sequence",
                     ["aggressor"] = "aggressor"
                 }
+            },
+            ["bank.statement.csv.v1"] = new()
+            {
+                SchemaId = "bank.statement.csv.v1",
+                HasHeaderRow = true,
+                Delimiter = ',',
+                Columns = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["transaction_date"] = "transaction_date",
+                    ["value_date"] = "value_date",
+                    ["amount"] = "amount",
+                    ["currency"] = "currency",
+                    ["transaction_type"] = "transaction_type",
+                    ["description"] = "description",
+                    ["reference"] = "reference",
+                    ["closing_balance"] = "closing_balance"
+                }
+            },
+            ["bank.transactions.csv.v1"] = new()
+            {
+                SchemaId = "bank.transactions.csv.v1",
+                HasHeaderRow = true,
+                Delimiter = ',',
+                Columns = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["transaction_date"] = "transaction_date",
+                    ["amount"] = "amount",
+                    ["currency"] = "currency",
+                    ["transaction_type"] = "transaction_type",
+                    ["description"] = "description",
+                    ["reference"] = "reference"
+                }
             }
         };
 

--- a/src/Meridian.DataIntegration/Etl/EtlPreviewService.cs
+++ b/src/Meridian.DataIntegration/Etl/EtlPreviewService.cs
@@ -1,0 +1,151 @@
+using System.Security.Cryptography;
+using Meridian.Contracts.Etl;
+
+namespace Meridian.DataIntegration.Etl;
+
+public sealed class EtlPreviewService
+{
+    private readonly IEnumerable<IEtlSourceReader> _sourceReaders;
+    private readonly IPartnerFileParser _parser;
+    private readonly IPartnerSchemaRegistry _schemas;
+
+    public EtlPreviewService(
+        IEnumerable<IEtlSourceReader> sourceReaders,
+        IPartnerFileParser parser,
+        IPartnerSchemaRegistry schemas)
+    {
+        _sourceReaders = sourceReaders;
+        _parser = parser;
+        _schemas = schemas;
+    }
+
+    public async Task<EtlPreviewResult> PreviewAsync(
+        EtlJobDefinition definition,
+        int sampleRowLimit = 10,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        sampleRowLimit = Math.Clamp(sampleRowLimit, 1, 100);
+
+        if (!_schemas.IsSupported(definition.PartnerSchemaId))
+        {
+            return new EtlPreviewResult
+            {
+                Success = false,
+                SourceKind = definition.Source.Kind,
+                SchemaId = definition.PartnerSchemaId,
+                Errors = [$"Unsupported ETL schema '{definition.PartnerSchemaId}'."]
+            };
+        }
+
+        var reader = _sourceReaders.FirstOrDefault(candidate => candidate.Kind == definition.Source.Kind);
+        if (reader is null)
+        {
+            return new EtlPreviewResult
+            {
+                Success = false,
+                SourceKind = definition.Source.Kind,
+                SchemaId = definition.PartnerSchemaId,
+                Errors = [$"No ETL source reader is registered for kind '{definition.Source.Kind}'."]
+            };
+        }
+
+        var files = await reader.ListFilesAsync(definition.Source, ct).ConfigureAwait(false);
+        var previews = new List<EtlFilePreview>();
+        var errors = new List<string>();
+        var previewJobId = $"preview-{definition.JobId}-{DateTimeOffset.UtcNow:yyyyMMddHHmmss}";
+        foreach (var file in files)
+        {
+            try
+            {
+                var staged = await reader.StageFileAsync(previewJobId, definition.Source, file, ct).ConfigureAwait(false);
+                previews.Add(await PreviewFileAsync(staged, file, definition.PartnerSchemaId, sampleRowLimit, ct).ConfigureAwait(false));
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                errors.Add($"{file.Name}: {ex.Message}");
+                previews.Add(new EtlFilePreview
+                {
+                    SourceFile = file,
+                    SchemaId = definition.PartnerSchemaId,
+                    Disposition = EtlPreviewDisposition.Error,
+                    Issues = [new EtlFilePreviewIssue { Severity = "Error", Field = "file", Message = ex.Message }]
+                });
+            }
+        }
+
+        return new EtlPreviewResult
+        {
+            Success = errors.Count == 0 && previews.All(preview => preview.Disposition != EtlPreviewDisposition.Error),
+            SourceKind = definition.Source.Kind,
+            SchemaId = definition.PartnerSchemaId,
+            Files = previews,
+            Errors = errors
+        };
+    }
+
+    private async Task<EtlFilePreview> PreviewFileAsync(
+        EtlStagedFile staged,
+        EtlRemoteFile sourceFile,
+        string schemaId,
+        int sampleRowLimit,
+        CancellationToken ct)
+    {
+        var schema = _schemas.GetCsvSchema(schemaId);
+        var requiredHeaders = schema.Columns.Keys.ToArray();
+        var sampleRows = new List<IReadOnlyDictionary<string, string?>>();
+        var issues = new List<EtlFilePreviewIssue>();
+        var recordCount = 0;
+
+        await foreach (var row in _parser.ParseAsync(staged, schemaId, checkpoint: null, ct).ConfigureAwait(false))
+        {
+            recordCount++;
+            if (sampleRows.Count < sampleRowLimit)
+                sampleRows.Add(row.Fields);
+        }
+
+        if (recordCount == 0)
+        {
+            issues.Add(new EtlFilePreviewIssue { Severity = "Error", Field = "file", Message = "The file did not contain any data rows." });
+        }
+
+        if (sampleRows.Count > 0)
+        {
+            var headers = sampleRows[0].Keys.ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (var required in requiredHeaders)
+            {
+                if (!headers.Contains(required))
+                {
+                    issues.Add(new EtlFilePreviewIssue
+                    {
+                        Severity = "Error",
+                        Field = required,
+                        Message = $"Required field '{required}' is missing from the file header.",
+                        RowNumber = 1
+                    });
+                }
+            }
+        }
+
+        var hash = await ComputeSha256Async(staged.StagedPath, ct).ConfigureAwait(false);
+        return new EtlFilePreview
+        {
+            SourceFile = sourceFile,
+            SchemaId = schemaId,
+            Disposition = issues.Any(issue => string.Equals(issue.Severity, "Error", StringComparison.OrdinalIgnoreCase))
+                ? EtlPreviewDisposition.Error
+                : EtlPreviewDisposition.Ready,
+            RecordCount = recordCount,
+            SampleRows = sampleRows,
+            Issues = issues,
+            FileHashSha256 = hash,
+            IdempotencyKey = $"etl-preview|{schemaId}|{sourceFile.Name}|{hash}"
+        };
+    }
+
+    private static async Task<string> ComputeSha256Async(string path, CancellationToken ct)
+    {
+        await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, useAsync: true);
+        return Convert.ToHexString(await SHA256.HashDataAsync(stream, ct).ConfigureAwait(false));
+    }
+}

--- a/src/Meridian.DataIntegration/Etl/EtlServices.cs
+++ b/src/Meridian.DataIntegration/Etl/EtlServices.cs
@@ -146,7 +146,7 @@ public sealed class EtlJobOrchestrator
                 var staged = await reader.StageFileAsync(jobId, definition.Source, file, ct).ConfigureAwait(false);
                 await _auditStore.WriteEventAsync(jobId, new EtlAuditEvent { Stage = "staged", Message = $"Staged {file.Name}." }, ct).ConfigureAwait(false);
 
-                await foreach (var record in _parser.ParseAsync(staged, checkpoint, ct).ConfigureAwait(false))
+                await foreach (var record in _parser.ParseAsync(staged, definition.PartnerSchemaId, checkpoint, ct).ConfigureAwait(false))
                 {
                     processed++;
                     var outcome = await _normalizer.NormalizeAsync(definition, record, ct).ConfigureAwait(false);
@@ -200,8 +200,7 @@ public sealed class EtlJobOrchestrator
                         CapturedAtUtc = DateTime.UtcNow
                     };
                 }
-                if (definition.Source.DeleteAfterSuccess && definition.Source.Kind == EtlSourceKind.Local && File.Exists(file.Path))
-                    File.Delete(file.Path);
+                await reader.PostProcessFileAsync(definition.Source, file, succeeded: true, ct).ConfigureAwait(false);
             }
 
             await _pipeline.FlushAsync(ct).ConfigureAwait(false);

--- a/src/Meridian.Infrastructure/Etl/CsvPartnerFileParser.cs
+++ b/src/Meridian.Infrastructure/Etl/CsvPartnerFileParser.cs
@@ -11,14 +11,13 @@ public sealed class CsvPartnerFileParser : IPartnerFileParser
         _schemas = schemas;
     }
 
-    public string SchemaId => "partner.trades.csv.v1";
+    public string SchemaId => "csv";
 
     public bool CanParse(EtlStagedFile file)
         => Path.GetExtension(file.FileName).Equals(".csv", StringComparison.OrdinalIgnoreCase);
 
-    public async IAsyncEnumerable<PartnerRecordEnvelope> ParseAsync(EtlStagedFile file, EtlCheckpointToken? checkpoint, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+    public async IAsyncEnumerable<PartnerRecordEnvelope> ParseAsync(EtlStagedFile file, string schemaId, EtlCheckpointToken? checkpoint, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
     {
-        var schemaId = SchemaId;
         var schema = _schemas.GetCsvSchema(schemaId);
         using var reader = new StreamReader(file.StagedPath);
         string[]? headers = null;

--- a/src/Meridian.Infrastructure/Etl/LocalFileSourceReader.cs
+++ b/src/Meridian.Infrastructure/Etl/LocalFileSourceReader.cs
@@ -40,4 +40,37 @@ public sealed class LocalFileSourceReader : IEtlSourceReader
         await using var stream = new FileStream(file.Path, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, useAsync: true);
         return await _stagingStore.StageAsync(jobId, file, stream, ct).ConfigureAwait(false);
     }
+
+    public Task PostProcessFileAsync(EtlSourceDefinition source, EtlRemoteFile file, bool succeeded, CancellationToken ct = default)
+    {
+        if (!succeeded)
+        {
+            return Task.CompletedTask;
+        }
+
+        var action = source.DeleteAfterSuccess ? EtlSourcePostProcessingAction.Delete : source.PostProcessingAction;
+        switch (action)
+        {
+            case EtlSourcePostProcessingAction.Delete when File.Exists(file.Path):
+                File.Delete(file.Path);
+                break;
+            case EtlSourcePostProcessingAction.MoveToArchive when !string.IsNullOrWhiteSpace(source.ArchiveLocation):
+                MoveLocalFile(file.Path, source.ArchiveLocation);
+                break;
+            case EtlSourcePostProcessingAction.WriteDoneMarker:
+                File.WriteAllText(file.Path + ".done", DateTimeOffset.UtcNow.ToString("O"));
+                break;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static void MoveLocalFile(string path, string directory)
+    {
+        Directory.CreateDirectory(directory);
+        var destination = Path.Combine(directory, Path.GetFileName(path));
+        if (File.Exists(destination))
+            File.Delete(destination);
+        File.Move(path, destination);
+    }
 }

--- a/src/Meridian.Infrastructure/Etl/Sftp/ISftpClientFactory.cs
+++ b/src/Meridian.Infrastructure/Etl/Sftp/ISftpClientFactory.cs
@@ -25,6 +25,8 @@ public interface ISftpClient : IDisposable
     void UploadFile(Stream input, string path, bool canOverwrite);
     bool Exists(string path);
     void CreateDirectory(string path);
+    void RenameFile(string oldPath, string newPath);
+    void DeleteFile(string path);
 }
 
 /// <summary>
@@ -70,6 +72,8 @@ internal sealed class SshNetSftpClient(Renci.SshNet.SftpClient inner) : ISftpCli
     public void UploadFile(Stream input, string path, bool canOverwrite) => inner.UploadFile(input, path, canOverwrite);
     public bool Exists(string path) => inner.Exists(path);
     public void CreateDirectory(string path) => inner.CreateDirectory(path);
+    public void RenameFile(string oldPath, string newPath) => inner.RenameFile(oldPath, newPath);
+    public void DeleteFile(string path) => inner.DeleteFile(path);
     public void Dispose() => inner.Dispose();
 
     public IEnumerable<ISftpFileEntry> ListDirectory(string path)

--- a/src/Meridian.Infrastructure/Etl/Sftp/SftpCredentialResolver.cs
+++ b/src/Meridian.Infrastructure/Etl/Sftp/SftpCredentialResolver.cs
@@ -1,0 +1,84 @@
+using Meridian.Contracts.Etl;
+
+namespace Meridian.Infrastructure.Etl.Sftp;
+
+public sealed record SftpCredentialMaterial(string Username, string Password);
+
+public interface ISftpCredentialResolver
+{
+    ValueTask<SftpCredentialMaterial> ResolveAsync(EtlSourceDefinition source, CancellationToken ct = default);
+}
+
+public sealed class EnvironmentSftpCredentialResolver : ISftpCredentialResolver
+{
+    public ValueTask<SftpCredentialMaterial> ResolveAsync(EtlSourceDefinition source, CancellationToken ct = default)
+    {
+        _ = ct;
+        if (string.IsNullOrWhiteSpace(source.Username))
+            throw new InvalidOperationException("SFTP username is required.");
+
+        if (string.IsNullOrWhiteSpace(source.SecretRef))
+            throw new InvalidOperationException("SFTP secretRef is required.");
+
+        var secretRef = source.SecretRef.Trim();
+        var password = secretRef.StartsWith("env:", StringComparison.OrdinalIgnoreCase)
+            ? Environment.GetEnvironmentVariable(secretRef[4..])
+            : secretRef;
+
+        if (string.IsNullOrEmpty(password))
+            throw new InvalidOperationException($"SFTP secretRef '{source.SecretRef}' did not resolve to a password.");
+
+        return ValueTask.FromResult(new SftpCredentialMaterial(source.Username.Trim(), password));
+    }
+}
+
+public sealed record SftpCapabilityStatus(
+    bool RealSftpEnabled,
+    bool SourceKindIsSftp,
+    bool HasSftpUri,
+    bool HasUsername,
+    bool HasSecretRef,
+    bool HasHostKeyFingerprint,
+    bool Ready,
+    IReadOnlyList<string> Issues);
+
+public interface ISftpCapabilityService
+{
+    SftpCapabilityStatus Evaluate(EtlSourceDefinition source);
+}
+
+public sealed class SftpCapabilityService : ISftpCapabilityService
+{
+    public SftpCapabilityStatus Evaluate(EtlSourceDefinition source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        var issues = new List<string>();
+        var hasSftpUri = Uri.TryCreate(source.Location, UriKind.Absolute, out var uri) &&
+            string.Equals(uri.Scheme, "sftp", StringComparison.OrdinalIgnoreCase);
+        if (source.Kind != EtlSourceKind.Sftp)
+            issues.Add("Source kind is not SFTP.");
+        if (!hasSftpUri)
+            issues.Add("SFTP source location must be a full sftp:// URI.");
+        if (string.IsNullOrWhiteSpace(source.Username))
+            issues.Add("SFTP username is missing.");
+        if (string.IsNullOrWhiteSpace(source.SecretRef))
+            issues.Add("SFTP secretRef is missing.");
+        if (string.IsNullOrWhiteSpace(source.HostKeySha256Fingerprint))
+            issues.Add("SFTP hostKeySha256Fingerprint is missing.");
+#if SFTP
+        var enabled = true;
+#else
+        var enabled = false;
+        issues.Add("Real SFTP support is disabled in this build. Build with /p:EnableSftp=true.");
+#endif
+        return new SftpCapabilityStatus(
+            enabled,
+            source.Kind == EtlSourceKind.Sftp,
+            hasSftpUri,
+            !string.IsNullOrWhiteSpace(source.Username),
+            !string.IsNullOrWhiteSpace(source.SecretRef),
+            !string.IsNullOrWhiteSpace(source.HostKeySha256Fingerprint),
+            issues.Count == 0,
+            issues);
+    }
+}

--- a/src/Meridian.Infrastructure/Etl/SftpFileSourceReader.cs
+++ b/src/Meridian.Infrastructure/Etl/SftpFileSourceReader.cs
@@ -8,19 +8,22 @@ public sealed class SftpFileSourceReader : IEtlSourceReader
 {
     private readonly EtlStagingStore _stagingStore;
     private readonly ISftpClientFactory _clientFactory;
+    private readonly ISftpCredentialResolver _credentialResolver;
 
-    public SftpFileSourceReader(EtlStagingStore stagingStore, ISftpClientFactory clientFactory)
+    public SftpFileSourceReader(EtlStagingStore stagingStore, ISftpClientFactory clientFactory, ISftpCredentialResolver credentialResolver)
     {
         _stagingStore = stagingStore;
         _clientFactory = clientFactory;
+        _credentialResolver = credentialResolver;
     }
 
     public EtlSourceKind Kind => EtlSourceKind.Sftp;
 
-    public Task<IReadOnlyList<EtlRemoteFile>> ListFilesAsync(EtlSourceDefinition source, CancellationToken ct = default)
+    public async Task<IReadOnlyList<EtlRemoteFile>> ListFilesAsync(EtlSourceDefinition source, CancellationToken ct = default)
     {
         var uri = ParseUri(source.Location);
-        using var client = CreateClient(source, uri);
+        var credential = await _credentialResolver.ResolveAsync(source, ct).ConfigureAwait(false);
+        using var client = CreateClient(source, uri, credential);
         client.Connect();
         try
         {
@@ -37,7 +40,7 @@ public sealed class SftpFileSourceReader : IEtlSourceReader
                     LastModifiedUtc = f.LastWriteTimeUtc
                 })
                 .ToList();
-            return Task.FromResult<IReadOnlyList<EtlRemoteFile>>(files);
+            return files;
         }
         finally
         {
@@ -48,7 +51,8 @@ public sealed class SftpFileSourceReader : IEtlSourceReader
     public async Task<EtlStagedFile> StageFileAsync(string jobId, EtlSourceDefinition source, EtlRemoteFile file, CancellationToken ct = default)
     {
         var uri = ParseUri(source.Location);
-        using var client = CreateClient(source, uri);
+        var credential = await _credentialResolver.ResolveAsync(source, ct).ConfigureAwait(false);
+        using var client = CreateClient(source, uri, credential);
         client.Connect();
         var tempPath = Path.Combine(Path.GetTempPath(), "meridian-sftp-" + Guid.NewGuid().ToString("N") + ".tmp");
         try
@@ -68,13 +72,64 @@ public sealed class SftpFileSourceReader : IEtlSourceReader
         }
     }
 
-    private ISftpClient CreateClient(EtlSourceDefinition source, Uri uri)
+
+    public async Task PostProcessFileAsync(EtlSourceDefinition source, EtlRemoteFile file, bool succeeded, CancellationToken ct = default)
+    {
+        if (!succeeded || source.PostProcessingAction == EtlSourcePostProcessingAction.LeaveInPlace)
+        {
+            return;
+        }
+
+        var uri = ParseUri(source.Location);
+        var credential = await _credentialResolver.ResolveAsync(source, ct).ConfigureAwait(false);
+        using var client = CreateClient(source, uri, credential);
+        client.Connect();
+        try
+        {
+            switch (source.PostProcessingAction)
+            {
+                case EtlSourcePostProcessingAction.Delete:
+                    client.DeleteFile(file.Path);
+                    break;
+                case EtlSourcePostProcessingAction.MoveToArchive:
+                    MoveRemoteFile(client, file, source.ArchiveLocation);
+                    break;
+                case EtlSourcePostProcessingAction.MoveToError:
+                    MoveRemoteFile(client, file, source.ErrorLocation);
+                    break;
+                case EtlSourcePostProcessingAction.WriteDoneMarker:
+                    using (var marker = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(DateTimeOffset.UtcNow.ToString("O"))))
+                    {
+                        client.UploadFile(marker, file.Path + ".done", canOverwrite: true);
+                    }
+                    break;
+            }
+        }
+        finally
+        {
+            client.Disconnect();
+        }
+    }
+
+    private static void MoveRemoteFile(ISftpClient client, EtlRemoteFile file, string? remoteDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(remoteDirectory))
+            throw new InvalidOperationException("Remote post-processing move requires an archive or error location.");
+
+        var normalizedDirectory = remoteDirectory.TrimEnd('/');
+        if (!client.Exists(normalizedDirectory))
+            client.CreateDirectory(normalizedDirectory);
+
+        client.RenameFile(file.Path, normalizedDirectory + "/" + file.Name);
+    }
+
+    private ISftpClient CreateClient(EtlSourceDefinition source, Uri uri, SftpCredentialMaterial credential)
     {
         return _clientFactory.Create(SftpConnectionOptions.Create(
             uri.Host,
             uri.Port > 0 ? uri.Port : 22,
-            source.Username ?? string.Empty,
-            source.SecretRef ?? string.Empty,
+            credential.Username,
+            credential.Password,
             source.HostKeySha256Fingerprint));
     }
 

--- a/src/Meridian.Infrastructure/README.md
+++ b/src/Meridian.Infrastructure/README.md
@@ -80,6 +80,10 @@ ETL SFTP publishing is an Infrastructure adapter implementation of the Contracts
 only owns transport connection, pinned host-key verification, directory creation, and upload
 mechanics. SFTP source and destination definitions must provide a SHA-256 host-key fingerprint so
 imports and exports fail closed before trusting a remote server identity.
+SFTP source imports now resolve credentials through `ISftpCredentialResolver` before opening a
+session, expose `ISftpCapabilityService` for runtime readiness diagnostics, and support explicit
+post-import source handling (`leave`, `delete`, `archive`, `error`, or `.done` marker) without
+weakening the pinned-host-key requirement.
 
 Broker statement imports hash the source file bytes and persist the resulting content hash with a
 deterministic duplicate key derived from fund account, statement period, and source hash. Source

--- a/tests/Meridian.Tests/Application/Commands/EtlCommandsTests.cs
+++ b/tests/Meridian.Tests/Application/Commands/EtlCommandsTests.cs
@@ -12,6 +12,9 @@ public sealed class EtlCommandsTests
     [InlineData("--etl-export")]
     [InlineData("--etl-roundtrip")]
     [InlineData("--etl-resume")]
+    [InlineData("--etl-preview")]
+    [InlineData("--etl-list-files")]
+    [InlineData("--etl-test-connection")]
     public void CanHandle_WithEtlFlags_ReturnsTrue(string flag)
     {
         var command = new EtlCommands("config/appsettings.json", Serilog.Log.Logger);
@@ -67,5 +70,38 @@ public sealed class EtlCommandsTests
         definition.Destination.Location.Should().Be("output");
         definition.Symbols.Should().Equal("AAPL", "MSFT");
         definition.PublishNormalizedExtract.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryBuildDefinition_WithSftpPreviewArgs_BuildsSourceSafetyOptions()
+    {
+        var result = EtlCommands.TryBuildDefinition(
+            [
+                "--etl-preview",
+                "--etl-source-kind",
+                "sftp",
+                "--etl-source-path",
+                "sftp://bank.example.com/inbound",
+                "--etl-schema",
+                "bank.statement.csv.v1",
+                "--etl-source-username",
+                "feed-user",
+                "--etl-source-secret-ref",
+                "env:BANK_PASSWORD",
+                "--etl-source-host-key-sha256",
+                "00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF",
+                "--etl-source-post-processing",
+                "archive",
+                "--etl-source-archive-path",
+                "/archive"
+            ],
+            out var definition);
+
+        result.Should().BeTrue();
+        definition.PartnerSchemaId.Should().Be("bank.statement.csv.v1");
+        definition.Source.Kind.Should().Be(EtlSourceKind.Sftp);
+        definition.Source.PostProcessingAction.Should().Be(EtlSourcePostProcessingAction.MoveToArchive);
+        definition.Source.ArchiveLocation.Should().Be("/archive");
+        definition.Source.SecretRef.Should().Be("env:BANK_PASSWORD");
     }
 }

--- a/tests/Meridian.Tests/DataIntegration/Etl/EtlPreviewServiceTests.cs
+++ b/tests/Meridian.Tests/DataIntegration/Etl/EtlPreviewServiceTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using Meridian.Contracts.Etl;
+using Meridian.DataIntegration.Etl;
+using Meridian.Infrastructure.Etl;
+using Meridian.Storage.Etl;
+
+namespace Meridian.Tests.DataIntegration.Etl;
+
+public sealed class EtlPreviewServiceTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "meridian-etl-preview-tests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task PreviewAsync_ForBankStatementCsv_ReturnsSamplesAndIdempotencyHash()
+    {
+        Directory.CreateDirectory(_root);
+        var input = Path.Combine(_root, "input");
+        Directory.CreateDirectory(input);
+        await File.WriteAllTextAsync(
+            Path.Combine(input, "bank.csv"),
+            "transaction_date,value_date,amount,currency,transaction_type,description,reference,closing_balance\n2026-06-05,2026-06-05,-2500.00,USD,ACH,Management fee,FEE-1,948750.25\n");
+
+        var registry = new PartnerSchemaRegistry();
+        var service = new EtlPreviewService(
+            [new LocalFileSourceReader(new EtlStagingStore(_root))],
+            new CsvPartnerFileParser(registry),
+            registry);
+
+        var result = await service.PreviewAsync(new EtlJobDefinition
+        {
+            JobId = "preview-bank",
+            FlowDirection = EtlFlowDirection.Import,
+            PartnerSchemaId = "bank.statement.csv.v1",
+            LogicalSourceName = "bank",
+            Source = new EtlSourceDefinition { Kind = EtlSourceKind.Local, Location = input, FilePattern = "*.csv" },
+            Destination = new EtlDestinationDefinition { Kind = EtlDestinationKind.StorageCatalog }
+        });
+
+        result.Success.Should().BeTrue();
+        result.Files.Should().ContainSingle();
+        var file = result.Files[0];
+        file.Disposition.Should().Be(EtlPreviewDisposition.Ready);
+        file.RecordCount.Should().Be(1);
+        file.SampleRows.Should().ContainSingle(row => row["reference"] == "FEE-1");
+        file.FileHashSha256.Should().NotBeNullOrWhiteSpace();
+        file.IdempotencyKey.Should().Contain("bank.statement.csv.v1");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, true);
+    }
+}

--- a/tests/Meridian.Tests/Infrastructure/Etl/CsvPartnerFileParserTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Etl/CsvPartnerFileParserTests.cs
@@ -27,7 +27,7 @@ public sealed class CsvPartnerFileParserTests : IDisposable
         };
 
         var rows = new List<PartnerRecordEnvelope>();
-        await foreach (var row in parser.ParseAsync(staged, new EtlCheckpointToken { CurrentFileChecksum = "abc123", CurrentRecordIndex = 1 }))
+        await foreach (var row in parser.ParseAsync(staged, "partner.trades.csv.v1", new EtlCheckpointToken { CurrentFileChecksum = "abc123", CurrentRecordIndex = 1 }))
         {
             rows.Add(row);
         }

--- a/tests/Meridian.Tests/Infrastructure/Etl/SftpCapabilityServiceTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Etl/SftpCapabilityServiceTests.cs
@@ -1,0 +1,25 @@
+using FluentAssertions;
+using Meridian.Contracts.Etl;
+using Meridian.Infrastructure.Etl.Sftp;
+
+namespace Meridian.Tests.Infrastructure.Etl;
+
+public sealed class SftpCapabilityServiceTests
+{
+    [Fact]
+    public void Evaluate_WhenRequiredSettingsAreMissing_ReturnsActionableIssues()
+    {
+        var service = new SftpCapabilityService();
+
+        var status = service.Evaluate(new EtlSourceDefinition
+        {
+            Kind = EtlSourceKind.Sftp,
+            Location = "relative/path"
+        });
+
+        status.Ready.Should().BeFalse();
+        status.Issues.Should().Contain(issue => issue.Contains("sftp://", StringComparison.OrdinalIgnoreCase));
+        status.Issues.Should().Contain(issue => issue.Contains("username", StringComparison.OrdinalIgnoreCase));
+        status.Issues.Should().Contain(issue => issue.Contains("hostKeySha256Fingerprint", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/tests/Meridian.Tests/Infrastructure/Etl/SftpInfrastructureTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Etl/SftpInfrastructureTests.cs
@@ -15,7 +15,7 @@ public sealed class SftpInfrastructureTests : IDisposable
     public async Task ListFilesAsync_WithoutPinnedHostKey_ShouldFailClosedBeforeConnecting()
     {
         var factory = new RecordingSftpClientFactory(new RecordingSftpClient());
-        var reader = new SftpFileSourceReader(new EtlStagingStore(_root), factory);
+        var reader = new SftpFileSourceReader(new EtlStagingStore(_root), factory, new EnvironmentSftpCredentialResolver());
         var source = new EtlSourceDefinition
         {
             Kind = EtlSourceKind.Sftp,
@@ -44,7 +44,7 @@ public sealed class SftpInfrastructureTests : IDisposable
             ]
         };
         var factory = new RecordingSftpClientFactory(client);
-        var reader = new SftpFileSourceReader(new EtlStagingStore(_root), factory);
+        var reader = new SftpFileSourceReader(new EtlStagingStore(_root), factory, new EnvironmentSftpCredentialResolver());
         var source = new EtlSourceDefinition
         {
             Kind = EtlSourceKind.Sftp,
@@ -128,6 +128,8 @@ public sealed class SftpInfrastructureTests : IDisposable
         }
         public bool Exists(string path) => true;
         public void CreateDirectory(string path) { }
+        public void RenameFile(string oldPath, string newPath) { }
+        public void DeleteFile(string path) { }
         public void Dispose() { }
     }
 

--- a/tests/Meridian.Tests/Ui/BankFeedTransportServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/BankFeedTransportServiceTests.cs
@@ -236,5 +236,8 @@ public sealed class BankFeedTransportServiceTests : IDisposable
                 SizeBytes = new FileInfo(_stagedPath).Length
             });
         }
+
+        public Task PostProcessFileAsync(EtlSourceDefinition source, EtlRemoteFile file, bool succeeded, CancellationToken ct = default)
+            => Task.CompletedTask;
     }
 }


### PR DESCRIPTION
### Motivation
- Provide non-mutating preview/list/test modes so operators can validate source connectivity, host-key pinning, and file shape before committing imports.
- Extend CSV schema coverage to include bank statement/transaction formats and return sample rows and idempotency-friendly hashes for onboarding validation.
- Offer explicit source post-processing options and runtime SFTP capability checks to allow safe, auditable handling of source files after successful imports.

### Description
- Add `EtlPreviewService` and preview DTOs (`EtlFilePreview`, `EtlPreviewResult`, `EtlFilePreviewIssue`) and wire CLI flags `--etl-preview`, `--etl-list-files`, and `--etl-test-connection` into `EtlCommands` to print file previews and issues.
- Extend contracts with `EtlSourcePostProcessingAction` and `EtlPreviewDisposition`, and add `postProcessingAction`, `archiveLocation`, and `errorLocation` to `EtlSourceDefinition` so readers can express post-import intent.
- Implement SFTP credential resolution and capability checks via `ISftpCredentialResolver`/`EnvironmentSftpCredentialResolver` and `ISftpCapabilityService`, add `RenameFile`/`DeleteFile` to `ISftpClient`, and register `EtlPreviewService`, `ISftpCapabilityService`, and `ISftpCredentialResolver` in DI.
- Update parsing and orchestration: change parser signature to `ParseAsync(staged, schemaId, ...)`, update `CsvPartnerFileParser`, call `PostProcessFileAsync` from `EtlJobOrchestrator`, and implement post-processing for local and SFTP readers (delete, move-to-archive, move-to-error, write-done-marker).
- Add CSV schemas for `bank.statement.csv.v1` and `bank.transactions.csv.v1` in `PartnerSchemaRegistry` and compute file SHA-256 hashes and idempotency keys in previews.

### Testing
- Updated and ran unit tests including `EtlCommandsTests`, `CsvPartnerFileParserTests`, `EtlPreviewServiceTests`, `SftpCapabilityServiceTests`, and `SftpInfrastructureTests` to cover CLI flags, parser signature changes, preview behavior, and SFTP readiness checks.
- Added `EtlPreviewServiceTests` and `SftpCapabilityServiceTests` to exercise local preview sampling and capability evaluation respectively.
- Executed the full unit test suite via `dotnet test` in CI, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39c55f22b88320a0b72adf64cb6ac9)