### PR TITLE
Add balance impact preview to manual journal workbench

### DIFF
--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.test.tsx
@@ -2918,6 +2918,9 @@ describe("AccountingScreen", () => {
     expect(screen.getByRole("region", { name: "Accounting workbench context" })).toHaveTextContent("Journal entry workbench");
     expect(screen.getByRole("heading", { name: "Manual journal entry workbench" })).toBeInTheDocument();
     expect(screen.getByRole("region", { name: "Manual journal entry - balanced double-entry" })).toHaveTextContent("Totals");
+    expect(screen.getByRole("heading", { name: "Balance impact preview" })).toBeInTheDocument();
+    expect(screen.getByText("This draft increases the debit-normal account balance by $100.")).toBeInTheDocument();
+    expect(screen.getByText("This draft increases the credit-normal account balance by $100.")).toBeInTheDocument();
     expect(screen.getByDisplayValue("2026-06-30")).toBeInTheDocument();
     expect(screen.getByDisplayValue("Manual close adjustment")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Microsoft Corp./ })).toBeInTheDocument();

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.tsx
@@ -6278,6 +6278,60 @@ function ManualJournalEntryWorkbenchPanel({ view }: { view: ManualJournalEntryWo
             </div>
           </section>
 
+          <section className="rounded-md border border-border/70 bg-secondary/20 p-3" aria-labelledby="manual-je-balance-impact-heading">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div>
+                <h4 id="manual-je-balance-impact-heading" className="text-sm font-semibold text-foreground">Balance impact preview</h4>
+                <p className="text-xs text-muted-foreground">
+                  See how the draft will move each ledger account before saving, validating, or submitting approval.
+                </p>
+              </div>
+              <Badge variant={view.balanceImpactRows.length > 0 ? "success" : "warning"} dot>
+                {view.balanceImpactRows.length} account{view.balanceImpactRows.length === 1 ? "" : "s"}
+              </Badge>
+            </div>
+            <div className="mt-3 overflow-x-auto">
+              {view.balanceImpactRows.length > 0 ? (
+                <table className="accounting-journal-table">
+                  <thead>
+                    <tr>
+                      <th>Ledger account</th>
+                      <th>Debit entry</th>
+                      <th>Credit entry</th>
+                      <th>Balance effect</th>
+                      <th>Agency cue</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {view.balanceImpactRows.map((row) => (
+                      <tr key={row.id}>
+                        <td>
+                          <div className="font-semibold text-foreground">{row.accountName}</div>
+                          <div className="font-mono text-[11px] text-muted-foreground">{row.accountPath} / {row.accountType}</div>
+                        </td>
+                        <td className="font-mono text-right">{row.debitLabel}</td>
+                        <td className="font-mono text-right">{row.creditLabel}</td>
+                        <td>
+                          <Badge variant={row.tone === "warning" ? "warning" : row.tone === "success" ? "success" : "outline"}>
+                            {row.netEffectLabel}
+                          </Badge>
+                        </td>
+                        <td className="text-xs text-muted-foreground">
+                          <span className="block">{row.balanceDirectionLabel}</span>
+                          <span className="mt-1 block font-mono">{row.lineCountLabel}</span>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              ) : (
+                <p role="status" className="rounded border border-warning/30 bg-warning/10 px-3 py-2 text-sm text-warning">
+                  Select at least one GL account and amount to preview account-level balance impact.
+                </p>
+              )}
+            </div>
+          </section>
+
           <div className="rounded-md border border-border/70 bg-secondary/20 p-3">
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <div>

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.test.ts
@@ -4483,10 +4483,32 @@ describe("accounting-screen view model", () => {
     expect(result.current.totalDebitsLabel).toBe("$100");
     expect(result.current.totalCreditsLabel).toBe("$100");
     expect(result.current.balanceStatusLabel).toBe("Balanced");
+    expect(result.current.balanceImpactRows).toEqual([
+      expect.objectContaining({
+        accountPath: "Assets:Cash",
+        accountName: "Cash",
+        debitLabel: "$100",
+        creditLabel: "$0",
+        netEffectLabel: "+$100",
+        balanceDirectionLabel: "This draft increases the debit-normal account balance by $100."
+      }),
+      expect.objectContaining({
+        accountPath: "Income:Interest",
+        accountName: "Interest Income",
+        debitLabel: "$0",
+        creditLabel: "$100",
+        netEffectLabel: "+$100",
+        balanceDirectionLabel: "This draft increases the credit-normal account balance by $100."
+      })
+    ]);
     act(() => result.current.updateLine("line-debit", { amount: 125 }));
     expect(result.current.totalDebitsLabel).toBe("$125");
     expect(result.current.totalCreditsLabel).toBe("$100");
     expect(result.current.balanceStatusLabel).toBe("Out by $25");
+    expect(result.current.balanceImpactRows.find((row) => row.accountPath === "Assets:Cash")).toMatchObject({
+      netEffectLabel: "+$125",
+      balanceDirectionLabel: "This draft increases the debit-normal account balance by $125."
+    });
     expect(result.current.canSubmit).toBe(false);
     act(() => result.current.updateLine("line-credit", { amount: 125 }));
     expect(result.current.totalDebitsLabel).toBe("$125");

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts
@@ -145,6 +145,7 @@ import type {
   UpsertPostingRuleRequest,
   ActivateAccountingConfigurationRequest,
   AttachManualJournalEntryEvidenceRequest,
+  ChartOfAccountsNode,
   JournalEntryLifecycleAction,
   JournalEntryLifecycleActionRequest,
   JournalEntryLifecycleActionResult,
@@ -1763,6 +1764,7 @@ export interface ManualJournalEntryWorkbenchViewModel {
   imbalanceLabel: string;
   balanceStatusLabel: string;
   balanceStatusTone: "success" | "warning";
+  balanceImpactRows: ManualJournalBalanceImpactRowViewModel[];
   treasuryContextLabel: string;
   privateCapitalActivity: ManualJournalPrivateCapitalActivityViewModel;
   validationIssues: AccountingConfigurationIssueViewModel[];
@@ -1798,6 +1800,19 @@ export interface ManualJournalEntryWorkbenchViewModel {
   save: () => Promise<void>;
   validate: () => Promise<void>;
   submit: () => Promise<void>;
+}
+
+export interface ManualJournalBalanceImpactRowViewModel {
+  id: string;
+  accountPath: string;
+  accountName: string;
+  accountType: string;
+  debitLabel: string;
+  creditLabel: string;
+  netEffectLabel: string;
+  balanceDirectionLabel: string;
+  lineCountLabel: string;
+  tone: "success" | "warning" | "default";
 }
 
 export interface OperationalExceptionWorkbenchMetricViewModel {
@@ -7719,6 +7734,7 @@ export function useManualJournalEntryWorkbenchViewModel(
     return [...serverIssues, ...localBadges];
   }, [draft.evidenceAttachments, draft.lines, draft.validationIssues]);
   const balancedDraft = withManualJournalTotals(draft);
+  const balanceImpactRows = buildManualJournalBalanceImpactRows(balancedDraft, workbench?.chartOfAccounts ?? []);
   const hasEvidence = (balancedDraft.evidenceLinks?.length ?? 0) > 0 || (balancedDraft.evidenceAttachments?.length ?? 0) > 0;
   const canSubmit = balancedDraft.validationIssues.every((issue) => issue.severity !== "Critical") && Math.abs(balancedDraft.imbalance) === 0 && balancedDraft.lines.length >= 2 && hasEvidence;
   const balanceStatusLabel = Math.abs(balancedDraft.imbalance) === 0 ? "Balanced" : "Out by " + formatCurrency(Math.abs(balancedDraft.imbalance));
@@ -7766,6 +7782,7 @@ export function useManualJournalEntryWorkbenchViewModel(
     imbalanceLabel: `Imbalance ${formatCurrency(balancedDraft.imbalance)}`,
     balanceStatusLabel,
     balanceStatusTone: Math.abs(balancedDraft.imbalance) === 0 ? "success" : "warning",
+    balanceImpactRows,
     treasuryContextLabel,
     privateCapitalActivity,
     validationIssues,
@@ -8835,6 +8852,67 @@ function withManualJournalTotals(draft: ManualJournalEntryDraft): ManualJournalE
     totalCredits,
     imbalance: totalDebits - totalCredits
   };
+}
+
+function buildManualJournalBalanceImpactRows(
+  draft: ManualJournalEntryDraft,
+  chartOfAccounts: ChartOfAccountsNode[]
+): ManualJournalBalanceImpactRowViewModel[] {
+  const accountsByPath = new Map(chartOfAccounts.map((account) => [account.path, account]));
+  const groups = new Map<string, { debit: number; credit: number; count: number }>();
+
+  for (const line of draft.lines) {
+    const accountPath = line.accountPath.trim();
+    if (!accountPath) {
+      continue;
+    }
+
+    const current = groups.get(accountPath) ?? { debit: 0, credit: 0, count: 0 };
+    const amount = Number.isFinite(line.amount) ? Math.max(line.amount, 0) : 0;
+    if (line.side === "Debit") {
+      current.debit += amount;
+    } else {
+      current.credit += amount;
+    }
+
+    current.count += 1;
+    groups.set(accountPath, current);
+  }
+
+  return [...groups.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([accountPath, totals]) => {
+      const account = accountsByPath.get(accountPath);
+      const normalBalanceSide = manualJournalNormalBalanceSide(account?.accountType);
+      const netEffect = normalBalanceSide === "Debit"
+        ? totals.debit - totals.credit
+        : totals.credit - totals.debit;
+      const direction = netEffect > 0 ? "increases" : netEffect < 0 ? "decreases" : "does not change";
+      const absoluteEffect = formatCurrency(Math.abs(netEffect));
+
+      return {
+        id: accountPath,
+        accountPath,
+        accountName: account?.accountName ?? accountPath,
+        accountType: account?.accountType ?? "Unclassified",
+        debitLabel: formatCurrency(totals.debit),
+        creditLabel: formatCurrency(totals.credit),
+        netEffectLabel: `${netEffect >= 0 ? "+" : "-"}${absoluteEffect}`,
+        balanceDirectionLabel: `This draft ${direction} the ${normalBalanceSide.toLowerCase()}-normal account balance by ${absoluteEffect}.`,
+        lineCountLabel: `${totals.count} line${totals.count === 1 ? "" : "s"}`,
+        tone: netEffect === 0 ? "default" : totals.debit > 0 && totals.credit > 0 ? "warning" : "success"
+      };
+    });
+}
+
+function manualJournalNormalBalanceSide(accountType?: string | null): AccountingTemplateLineSide {
+  const normalized = (accountType ?? "").toLowerCase();
+  return normalized.includes("liabil")
+    || normalized.includes("equity")
+    || normalized.includes("revenue")
+    || normalized.includes("income")
+    ? "Credit"
+    : "Debit";
 }
 
 function formatManualJournalTreasuryContext(draft: ManualJournalEntryDraft): string {


### PR DESCRIPTION
### Motivation
- Users need high-agency visibility into how their manual journal drafts will affect ledger balances before saving, validating, or submitting for approval.
- Provide an inline, account-level preview so operators can anticipate debit/credit effects and evidence/approval gating without posting to the ledger.

### Description
- Added a computed `balanceImpactRows` view-model to `useManualJournalEntryWorkbenchViewModel` that aggregates draft lines by GL account and reports debit/credit totals, net effect, normal-balance direction, and line counts using `buildManualJournalBalanceImpactRows` and `manualJournalNormalBalanceSide`.
- Exposed the new row view model type `ManualJournalBalanceImpactRowViewModel` and wired it into the manual journal workbench return payload.
- Rendered a new "Balance impact preview" panel in the browser accounting workbench to show the per-account debit/credit totals, a net-effect badge, a human-readable balance-direction cue, and a line-count cue.
- Added and updated focused tests to assert the balance-impact computation and UI rendering update when line amounts change.
- Key files changed: `src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts`, `src/Meridian.Ui/dashboard/src/screens/accounting-screen.tsx`, and the corresponding tests `src/.../accounting-screen.view-model.test.ts` and `src/.../accounting-screen.test.tsx`.

### Testing
- Ran the focused Vitest suite: `npm --prefix src/Meridian.Ui/dashboard run test:vitest -- src/screens/accounting-screen.view-model.test.ts src/screens/accounting-screen.test.tsx`, and the targeted run completed successfully with the test files passing (the run reported 111 tests passed across the focused files).
- Ran repository checks including `git diff --check` to ensure no trailing whitespace/check failures; the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39ddc5fca08320bcf968c04cf6d4e0)