### PR TITLE
feat: implement Clearwater securities properties and calculations

### DIFF
--- a/src/Meridian.Contracts/FixedIncome/BondReferenceDtos.cs
+++ b/src/Meridian.Contracts/FixedIncome/BondReferenceDtos.cs
@@ -12,6 +12,32 @@ public enum BondLifecycleStat
     Retired
 }
 
+/// Amortization method applied at the account or security level.
+/// Mirrors <c>AmortizationMethod</c> in the F# domain.
+[JsonConverter(typeof(JsonStringEnumConverter<BondAmortizationMethod>))]
+public enum BondAmortizationMethod
+{
+    /// Effective-interest method — income recognised as a constant proportion of book value.
+    ConstantYield,
+    /// Equal daily movement from starting book price to target price.
+    StraightLine,
+    /// Book price held flat; no daily premium/discount recognised.
+    NoAmortization,
+    /// Recognises premium/discount immediately to par; used for auction-rate securities.
+    AuctionRate,
+    /// Expected-yield accounting over remaining life; used for PCI-designated lots.
+    PurchasedCreditImpaired
+}
+
+/// FAS 91-style yield adjustment method for prepaying structured securities.
+[JsonConverter(typeof(JsonStringEnumConverter<BondYieldAdjustmentMethod>))]
+public enum BondYieldAdjustmentMethod
+{
+    Retrospective,
+    Prospective,
+    NoAdjustment
+}
+
 public sealed record BondLifecycleDto(
     Guid SecurityId,
     BondLifecycleStat LifecycleStat,
@@ -19,7 +45,15 @@ public sealed record BondLifecycleDto(
     DateOnly? CallDate,
     DateOnly MaturityDate,
     bool IsCallable,
-    long Version);
+    long Version,
+    // --- Clearwater extended lifecycle fields ---
+    /// <summary>Face/par value; used in market-value calculation: Par × Factor × Price / 100.</summary>
+    decimal? Par = null,
+    string? BondSubclass = null,
+    string? PaymentFrequency = null,
+    DateOnly? LegalFinalMaturity = null,
+    DateOnly? PreRefundDate = null,
+    DateOnly? MandatoryPutDate = null);
 
 public sealed record BondAccrualConventionDto(
     Guid SecurityId,
@@ -32,6 +66,44 @@ public sealed record BondAccrualConventionDto(
     decimal? FloatingSpreadBps,
     long Version);
 
+/// A single instalment in a sinking fund or scheduled principal amortisation schedule.
+public sealed record BondSinkingFundEntryDto(
+    DateOnly SinkDate,
+    decimal Amount);
+
+/// Sinking fund schedule for bonds with contractual principal instalments.
+public sealed record BondSinkingFundDto(
+    Guid SecurityId,
+    IReadOnlyList<BondSinkingFundEntryDto> Schedule,
+    string? SinkFrequency,
+    bool IsProRata,
+    long Version);
+
+/// Inflation index and factor data for TIPS, index-linked GILTs, and similar instruments.
+public sealed record BondInflationLinkedDto(
+    Guid SecurityId,
+    /// <summary>Index series (e.g. "CPI-U", "RPI", "HICPxT").</summary>
+    string? InflationIndex,
+    decimal? BaseIndexValue,
+    DateOnly? BaseDate,
+    decimal? CurrentFactor,
+    DateOnly? FactorDate,
+    /// <summary>Minimum factor floor; 1.0 for US TIPS.</summary>
+    decimal? IndexFloor,
+    long Version);
+
+/// Account or lot-level accounting elections controlling amortization, yield update, and cash-flow source.
+public sealed record BondAccountingElectionsDto(
+    Guid SecurityId,
+    BondAmortizationMethod AmortizationMethod,
+    string? YieldUpdateFrequency,
+    BondYieldAdjustmentMethod? AdjustmentMethod,
+    string? CashFlowSource,
+    bool IgnoreCallDates,
+    bool IgnorePutDates,
+    bool IsLotLevelNoAmortization,
+    long Version);
+
 public sealed record BondReferenceDto(
     Guid SecurityId,
     string DisplayName,
@@ -41,4 +113,7 @@ public sealed record BondReferenceDto(
     string PrimaryIdentifier,
     BondLifecycleDto? Lifecycle,
     BondAccrualConventionDto? AccrualConvention,
-    long Version);
+    long Version,
+    BondSinkingFundDto? SinkingFund = null,
+    BondInflationLinkedDto? InflationLinked = null,
+    BondAccountingElectionsDto? AccountingElections = null);

--- a/src/Meridian.FSharp/Calculations/SecurityCalculations.fs
+++ b/src/Meridian.FSharp/Calculations/SecurityCalculations.fs
@@ -1,0 +1,307 @@
+namespace Meridian.FSharp.Calculations
+
+open System
+open Meridian.FSharp.Domain
+
+/// Day-count fraction calculations per ISDA and market conventions.
+/// Reference: Clearwater Security Types and Calculation Reference Guide (May/June 2026), Section 2.2.
+[<RequireQualifiedAccess>]
+module DayCount =
+
+    /// Actual/360: actual calendar days divided by 360.
+    /// Common for money-market instruments (CP, CD, repo, T-bills).
+    let actual360 (startDate: DateOnly) (endDate: DateOnly) : decimal =
+        let days = (endDate.ToDateTime(TimeOnly.MinValue) - startDate.ToDateTime(TimeOnly.MinValue)).TotalDays
+        decimal days / 360m
+
+    /// Actual/365 Fixed: actual calendar days divided by 365.
+    /// Common for UK gilts, Australian bonds, and some money-market instruments.
+    let actual365 (startDate: DateOnly) (endDate: DateOnly) : decimal =
+        let days = (endDate.ToDateTime(TimeOnly.MinValue) - startDate.ToDateTime(TimeOnly.MinValue)).TotalDays
+        decimal days / 365m
+
+    /// 30/360 (Bond Basis / US): months treated as 30 days, year as 360.
+    /// Default for most US corporate and municipal bonds.
+    let thirty360 (startDate: DateOnly) (endDate: DateOnly) : decimal =
+        let d1 = min startDate.Day 30
+        let d2 = if startDate.Day >= 30 then min endDate.Day 30 else endDate.Day
+        let months = (endDate.Year - startDate.Year) * 12 + (endDate.Month - startDate.Month)
+        let days = d2 - d1
+        decimal (months * 30 + days) / 360m
+
+    /// Actual/Actual (ISDA): actual days in each calendar year, weighted by year length.
+    /// Default for US Treasury notes and bonds.
+    let actualActualIsda (startDate: DateOnly) (endDate: DateOnly) : decimal =
+        if startDate >= endDate then 0m
+        else
+            let start = startDate.ToDateTime(TimeOnly.MinValue)
+            let finish = endDate.ToDateTime(TimeOnly.MinValue)
+            if start.Year = finish.Year then
+                let daysInYear = if DateTime.IsLeapYear start.Year then 366.0 else 365.0
+                decimal (finish - start).Days / decimal daysInYear
+            else
+                let daysInFirstYear = if DateTime.IsLeapYear start.Year then 366.0 else 365.0
+                let daysInLastYear = if DateTime.IsLeapYear finish.Year then 366.0 else 365.0
+                let firstFrac = double (DateTime(start.Year + 1, 1, 1) - start).Days / daysInFirstYear
+                let lastFrac  = double (finish - DateTime(finish.Year, 1, 1)).Days / daysInLastYear
+                let fullYears = finish.Year - start.Year - 1
+                decimal firstFrac + decimal fullYears + decimal lastFrac
+
+    /// Dispatch to the appropriate day-count fraction for the given convention.
+    let fractionFor (convention: DayCountConvention) (startDate: DateOnly) (endDate: DateOnly) : decimal =
+        match convention with
+        | Actual360          -> actual360 startDate endDate
+        | Actual365          -> actual365 startDate endDate
+        | Thirty360          -> thirty360 startDate endDate
+        | Business252        -> actual365 startDate endDate // simplified; full Biz/252 requires trading calendar
+        | OtherDayCount _    -> actual365 startDate endDate // safe fallback
+
+
+/// Core Clearwater-aligned security calculations.
+/// Formulas reference the Clearwater Security Types and Calculation Reference Guide (May/June 2026),
+/// Sections 2.2, 2.3, and Appendix B.
+[<RequireQualifiedAccess>]
+module SecurityCalculations =
+
+    // -----------------------------------------------------------------------
+    // 2.2  Interest and accrual
+    // -----------------------------------------------------------------------
+
+    /// Period interest cash flow:
+    ///   Interest_i = Outstanding_principal_i × Coupon_rate_i × Day-count_fraction_i
+    let interestCashFlow
+        (outstandingPrincipal : decimal)
+        (couponRate           : decimal)
+        (dayCountFraction     : decimal) : decimal =
+        outstandingPrincipal * couponRate * dayCountFraction
+
+    /// Accrued interest from the last coupon date to the evaluation date:
+    ///   Accrued_interest = Principal × Coupon_rate × Accrued_day-count_fraction
+    let accruedInterest
+        (principal       : decimal)
+        (couponRate      : decimal)
+        (lastCouponDate  : DateOnly)
+        (evaluationDate  : DateOnly)
+        (convention      : DayCountConvention) : decimal =
+        if evaluationDate <= lastCouponDate then 0m
+        else
+            let fraction = DayCount.fractionFor convention lastCouponDate evaluationDate
+            principal * couponRate * fraction
+
+    // -----------------------------------------------------------------------
+    // Market value
+    // -----------------------------------------------------------------------
+
+    /// Bond / fixed-income market value for a price quoted per 100:
+    ///   Local_market_value = Par × Factor × Price / 100
+    /// Factor = 1.0 for non-factored bonds; < 1.0 for amortising/prepaying pools.
+    let bondMarketValue (par : decimal) (factor : decimal) (quotedPrice : decimal) : decimal =
+        par * factor * quotedPrice / 100m
+
+    /// Equity or fund market value:
+    ///   Market_value = Shares_or_units × Market_price_or_NAV
+    let equityMarketValue (sharesOrUnits : decimal) (marketPriceOrNav : decimal) : decimal =
+        sharesOrUnits * marketPriceOrNav
+
+    // -----------------------------------------------------------------------
+    // Dirty / clean price
+    // -----------------------------------------------------------------------
+
+    /// Dirty price = Clean price + Accrued interest (full price including interest).
+    let dirtyPrice (cleanPrice : decimal) (accruedInterest : decimal) : decimal =
+        cleanPrice + accruedInterest
+
+    /// Clean price = Dirty price − Accrued interest (quoted flat price).
+    let cleanPrice (dirtyPrice : decimal) (accruedInterest : decimal) : decimal =
+        dirtyPrice - accruedInterest
+
+    // -----------------------------------------------------------------------
+    // 2.3  Amortization methodologies
+    // -----------------------------------------------------------------------
+
+    /// Straight-line daily amortization/accretion amount:
+    ///   Daily_amount = (Target_book_price − Starting_book_price) / Amortization_days
+    /// Positive result → accretion (discount); negative result → amortization (premium).
+    let straightLineDailyAmount
+        (targetBookPrice   : decimal)
+        (startingBookPrice : decimal)
+        (amortizationDays  : int) : decimal =
+        if amortizationDays <= 0 then 0m
+        else (targetBookPrice - startingBookPrice) / decimal amortizationDays
+
+    /// Constant-yield (effective-interest) income for one period:
+    ///   Effective_interest_income = Beginning_amortized_cost × Periodic_yield
+    let constantYieldIncome
+        (beginningAmortizedCost : decimal)
+        (periodicYield          : decimal) : decimal =
+        beginningAmortizedCost * periodicYield
+
+    /// Premium amortization or discount accretion for the period:
+    ///   Amortization_accretion = Effective_interest_income − Contractual_interest_recognized
+    /// Positive result → accretion (discount); negative result → amortization (premium).
+    let amortizationAccretion
+        (effectiveInterestIncome       : decimal)
+        (contractualInterestRecognized : decimal) : decimal =
+        effectiveInterestIncome - contractualInterestRecognized
+
+    // -----------------------------------------------------------------------
+    // Structured / prepaying securities
+    // -----------------------------------------------------------------------
+
+    /// Weighted Average Life:
+    ///   WAL = Σ(Principal_payment_i × Time_to_payment_i) / Σ(Principal_payment_i)
+    /// principalPayments: list of (amount, timeToPaymentYears) tuples.
+    let weightedAverageLife (principalPayments : (decimal * decimal) list) : decimal =
+        let totalPrincipal = principalPayments |> List.sumBy fst
+        if totalPrincipal = 0m then 0m
+        else
+            let weightedSum = principalPayments |> List.sumBy (fun (p, t) -> p * t)
+            weightedSum / totalPrincipal
+
+    // -----------------------------------------------------------------------
+    // Inflation-linked securities
+    // -----------------------------------------------------------------------
+
+    /// Inflation-adjusted principal (e.g. TIPS):
+    ///   Adjusted_principal = Base_units × Inflation_factor
+    /// The Clearwater example: 1,000 units × 1.2 factor = 1,200 adjusted principal.
+    let inflationAdjustedPrincipal (baseUnits : decimal) (inflationFactor : decimal) : decimal =
+        baseUnits * inflationFactor
+
+    /// Inflation-linked market value:
+    ///   Market_value = Base_units × Inflation_factor × Quoted_price / 100
+    let inflationLinkedMarketValue
+        (baseUnits      : decimal)
+        (inflationFactor : decimal)
+        (quotedPrice    : decimal) : decimal =
+        baseUnits * inflationFactor * quotedPrice / 100m
+
+    // -----------------------------------------------------------------------
+    // Purchased Credit Impaired (PCI) lots
+    // -----------------------------------------------------------------------
+
+    /// PCI daily amortization/accretion:
+    ///   Daily_amount = [Beginning_BV × Periodic_yield / Days_in_period] − Daily_interest_income
+    /// Step 1: Periodic total income = Beginning BV × periodic yield.
+    /// Step 2: Daily total income    = Periodic total income / days in period.
+    /// Step 3: Daily amortization    = Daily total income − daily interest income already recognized.
+    let pciDailyAmortization
+        (beginningBookValue  : decimal)
+        (periodicYield       : decimal)
+        (daysInPeriod        : int)
+        (dailyInterestIncome : decimal) : decimal =
+        if daysInPeriod <= 0 then 0m
+        else
+            let periodicTotalIncome = beginningBookValue * periodicYield
+            let dailyTotalIncome    = periodicTotalIncome / decimal daysInPeriod
+            dailyTotalIncome - dailyInterestIncome
+
+    // -----------------------------------------------------------------------
+    // Foreign currency
+    // -----------------------------------------------------------------------
+
+    /// FX remeasurement:
+    ///   Functional_currency_amount = Local_currency_amount × Daily_FX_rate
+    /// Amortization is calculated locally and then remeasured to functional currency.
+    let fxRemeasurement (localAmount : decimal) (fxRate : decimal) : decimal =
+        localAmount * fxRate
+
+    // -----------------------------------------------------------------------
+    // Short-term discount instruments
+    // -----------------------------------------------------------------------
+
+    /// Straight-line daily accretion for CP, CDs, and agency discount notes:
+    ///   Daily_accretion = (Face_value − Purchase_price) / Settlement_to_maturity_days
+    /// Example: purchased at 98, face 100, 90 days → 2 / 90 ≈ 0.0222 per day.
+    let shortTermDailyAccretion
+        (faceValue                  : decimal)
+        (purchasePrice              : decimal)
+        (settlementToMaturityDays   : int) : decimal =
+        if settlementToMaturityDays <= 0 then 0m
+        else (faceValue - purchasePrice) / decimal settlementToMaturityDays
+
+    // -----------------------------------------------------------------------
+    // Repo interest
+    // -----------------------------------------------------------------------
+
+    /// Repo / reverse-repo interest for a period:
+    ///   Repo_interest = Principal × Repo_rate × Day-count_fraction
+    let repoInterest
+        (principal        : decimal)
+        (repoRate         : decimal)
+        (dayCountFraction : decimal) : decimal =
+        principal * repoRate * dayCountFraction
+
+    // -----------------------------------------------------------------------
+    // Callable / putable option in-the-money tests (Section 4.5)
+    // -----------------------------------------------------------------------
+
+    /// Returns true when a callable bond is in-the-money:
+    ///   Purchase_price > Next_call_price → amortize to next call date and price.
+    let isCallInTheMoney (purchasePrice : decimal) (nextCallPrice : decimal) : bool =
+        purchasePrice > nextCallPrice
+
+    /// Returns true when a putable bond is in-the-money:
+    ///   Purchase_price ≤ Next_put_price → amortize to next put date and price.
+    let isPutInTheMoney (purchasePrice : decimal) (nextPutPrice : decimal) : bool =
+        purchasePrice <= nextPutPrice
+
+    // -----------------------------------------------------------------------
+    // Yield solvers
+    // -----------------------------------------------------------------------
+
+    /// Newton-Raphson yield solver.
+    /// Finds the yield Y such that: Price = Σ [ CF_i / (1 + Y/f)^(f × t_i) ]
+    /// cashFlows: list of (timeToPaymentYears, cashFlowAmount).
+    /// Returns None if the price is non-positive, there are no cash flows, or convergence fails.
+    let private newtonRaphsonYield
+        (price              : decimal)
+        (cashFlows          : (decimal * decimal) list)
+        (compoundingFreq    : int)
+        (maxIterations      : int) : decimal option =
+        if cashFlows.IsEmpty || price <= 0m || maxIterations <= 0 then None
+        else
+            let f = double compoundingFreq
+            let pv (y : double) =
+                cashFlows
+                |> List.sumBy (fun (t, cf) ->
+                    double cf / Math.Pow(1.0 + y / f, f * double t))
+
+            let mutable y         = 0.05
+            let mutable converged = false
+            let mutable iter      = 0
+            let target            = double price
+            let tolerance         = 1e-10
+
+            while not converged && iter < maxIterations do
+                let pvY     = pv y
+                let pvYUp   = pv (y + 1e-7)
+                let deriv   = (pvYUp - pvY) / 1e-7
+                if abs deriv < 1e-15 then
+                    iter <- maxIterations
+                else
+                    let yNew = y - (pvY - target) / deriv
+                    if abs (yNew - y) < tolerance then converged <- true
+                    y    <- yNew
+                    iter <- iter + 1
+
+            if converged then Some (decimal y) else None
+
+    /// Purchase/amortization yield — internal rate of return solving:
+    ///   Purchase_dirty_price = Σ [ CF_i / (1 + Y/f)^(f × t_i) ]
+    /// cashFlows: list of (timeToPaymentYears, cashFlowAmount).
+    /// compoundingFrequency: 1 = annual, 2 = semi-annual, 4 = quarterly.
+    let purchaseYield
+        (purchaseDirtyPrice  : decimal)
+        (cashFlows           : (decimal * decimal) list)
+        (compoundingFrequency : int) : decimal option =
+        newtonRaphsonYield purchaseDirtyPrice cashFlows compoundingFrequency 200
+
+    /// Book yield — daily solve from end-of-day book price and current projected cash flows:
+    ///   Current_book_price = PV of current projected cash flows
+    /// Clearwater uses an iterative Newton-Raphson solver internally.
+    let bookYield
+        (currentBookPrice    : decimal)
+        (cashFlows           : (decimal * decimal) list)
+        (compoundingFrequency : int) : decimal option =
+        newtonRaphsonYield currentBookPrice cashFlows compoundingFrequency 200

--- a/src/Meridian.FSharp/Domain/SecurityMaster.fs
+++ b/src/Meridian.FSharp/Domain/SecurityMaster.fs
@@ -180,6 +180,21 @@ type BondSubclass =
     | Convertible
     | InflationLinked
     | FloatingRate
+    // --- Scheduled / structured principal ---
+    /// Bond with contractual sinking fund or mandatory principal instalments.
+    | SinkingFund
+    /// Step-rate bond whose coupon increases per a contractual schedule (may be callable at step dates).
+    | StepRate
+    /// Fixed-rate bond that converts to floating at a specified date.
+    | FixedToFloat
+    // --- Short-term / money-market debt ---
+    /// Variable Rate Demand Note — daily or weekly reset rate; investor may tender on demand.
+    | Vrdn
+    /// Auction Rate Security — rate resets at periodic auction; Clearwater may hold at par.
+    | AuctionRate
+    // --- Bank / leveraged finance ---
+    /// Syndicated or bilateral bank loan; floating rate, principal schedule per credit agreement.
+    | BankLoan
     // --- Asset-backed / structured credit ---
     /// Generic asset-backed security (auto loans, credit cards, student loans, etc.).
     | AssetBacked
@@ -219,18 +234,41 @@ type BondTerms = {
     Seniority: string option
     /// Economic subclass of this bond instrument.
     Subclass: BondSubclass
+    // --- Clearwater Security Master required properties ---
+    /// Face/par value of the bond (e.g. 1000 for a $1,000 par bond).
+    /// Used in market value calculation: Par × Factor × Price / 100.
+    Par: decimal option
+    /// Coupon payment frequency (Annual, SemiAnnual, Quarterly, Monthly, etc.).
+    PaymentFrequency: PaymentFrequency option
+    /// Latest contractual date by which principal is legally due under the governing documents.
+    /// May differ from Maturity for pre-refunded or mandatory-put bonds.
+    LegalFinalMaturity: DateOnly option
+    /// Date to which a pre-refunded municipal bond is called using escrowed proceeds.
+    /// When present, cash flows and amortization target this date rather than final maturity.
+    PreRefundDate: DateOnly option
+    /// Date of a mandatory put feature that obligates the holder to tender at a set price.
+    MandatoryPutDate: DateOnly option
 }
 
 [<RequireQualifiedAccess>]
 module BondTerms =
     let fixedRate maturity couponRate dayCount issuerName =
-        { Maturity = maturity; IssueDate = None; Coupon = BondCouponStructure.Fixed(couponRate, dayCount); IsCallable = false; CallDate = None; IssuerName = issuerName; Seniority = None; Subclass = BondSubclass.Corporate }
+        { Maturity = maturity; IssueDate = None; Coupon = BondCouponStructure.Fixed(couponRate, dayCount)
+          IsCallable = false; CallDate = None; IssuerName = issuerName; Seniority = None
+          Subclass = BondSubclass.Corporate
+          Par = None; PaymentFrequency = None; LegalFinalMaturity = None; PreRefundDate = None; MandatoryPutDate = None }
 
     let floatingRate maturity index spreadBps issuerName =
-        { Maturity = maturity; IssueDate = None; Coupon = BondCouponStructure.Floating(index, spreadBps, None, None, None); IsCallable = false; CallDate = None; IssuerName = issuerName; Seniority = None; Subclass = BondSubclass.FloatingRate }
+        { Maturity = maturity; IssueDate = None; Coupon = BondCouponStructure.Floating(index, spreadBps, None, None, None)
+          IsCallable = false; CallDate = None; IssuerName = issuerName; Seniority = None
+          Subclass = BondSubclass.FloatingRate
+          Par = None; PaymentFrequency = None; LegalFinalMaturity = None; PreRefundDate = None; MandatoryPutDate = None }
 
     let zeroCoupon maturity issuerName =
-        { Maturity = maturity; IssueDate = None; Coupon = BondCouponStructure.ZeroCoupon; IsCallable = false; CallDate = None; IssuerName = issuerName; Seniority = None; Subclass = BondSubclass.Corporate }
+        { Maturity = maturity; IssueDate = None; Coupon = BondCouponStructure.ZeroCoupon
+          IsCallable = false; CallDate = None; IssuerName = issuerName; Seniority = None
+          Subclass = BondSubclass.Corporate
+          Par = None; PaymentFrequency = None; LegalFinalMaturity = None; PreRefundDate = None; MandatoryPutDate = None }
 
     let couponRate (terms: BondTerms) =
         match terms.Coupon with
@@ -332,10 +370,45 @@ type Covenant = {
     Notes: string option
 }
 
+/// A scheduled principal repayment (amortizing or term-loan instalment).
+type PrincipalPaymentEntry = {
+    PaymentDate: DateOnly
+    Amount: decimal
+}
+
 type DirectLoanTerms = {
     Borrower: string
     Maturity: DateOnly option
     Covenants: Covenant list
+    // --- Clearwater bank loan / direct lending properties ---
+    /// Floating rate reference index (e.g. "SOFR", "LIBOR", "EURIBOR").
+    ReferenceIndex: string option
+    /// Spread over the reference index in basis points (e.g. 350 = SOFR + 3.50%).
+    SpreadBps: decimal option
+    /// Current all-in coupon rate (reference rate + spread, subject to floor/cap).
+    CurrentCouponRate: decimal option
+    /// Rate reset frequency (e.g. "Daily", "Monthly", "Quarterly").
+    ResetFrequency: string option
+    /// Contractual or expected principal instalment schedule.
+    PrincipalSchedule: PrincipalPaymentEntry list
+    /// Pricing source for market value (e.g. "IHSMarkit", "Refinitiv", "Client").
+    PricingSource: string option
+}
+
+/// Terms for mutual funds, ETFs, hedge funds, REITs, and closed-end funds.
+/// These instruments generally do not amortize; market value is units × NAV/price.
+type InvestmentFundTerms = {
+    /// Fund category (e.g. "MutualFund", "ETF", "HedgeFund", "REIT", "ClosedEnd").
+    FundType: string option
+    FundFamily: string option
+    /// Currency of the NAV (may differ from the account base currency).
+    NavCurrency: string option
+    /// Distribution policy (Accumulating, Distributing, etc.).
+    DistributionPolicy: DistributionPolicy option
+    /// True for stable-NAV money market and government liquidity funds.
+    IsStableNav: bool option
+    /// Price/NAV data source (e.g. "iMoneyNet", "Bloomberg", "Client").
+    PricingSource: string option
 }
 
 type CommodityTerms = {
@@ -385,6 +458,9 @@ type SecurityKind =
     | CryptoCurrency of CryptoTerms
     | Cfd of CfdTerms
     | Warrant of WarrantTerms
+    /// Mutual fund, ETF, hedge fund, REIT, or closed-end fund.
+    /// Market value = units × NAV (or market price); no amortization in general.
+    | InvestmentFund of InvestmentFundTerms
 
 type Provenance = {
     SourceSystem: string
@@ -445,6 +521,7 @@ module SecurityMasterRecord =
         | SecurityKind.CryptoCurrency _ -> "CryptoCurrency"
         | SecurityKind.Cfd _ -> "Cfd"
         | SecurityKind.Warrant _ -> "Warrant"
+        | SecurityKind.InvestmentFund _ -> "InvestmentFund"
 
     let isActive (record: SecurityMasterRecord) =
         SecurityStatus.isActive record.Status
@@ -513,6 +590,7 @@ module SecurityKind =
         | SecurityKind.CryptoCurrency _ -> "CryptoCurrency"
         | SecurityKind.Cfd _ -> "Cfd"
         | SecurityKind.Warrant _ -> "Warrant"
+        | SecurityKind.InvestmentFund _ -> "InvestmentFund"
 
     let underlyingSecurityId kind =
         match kind with
@@ -540,4 +618,5 @@ module SecurityKind =
         | SecurityKind.OtherSecurity _
         | SecurityKind.DirectLoan _
         | SecurityKind.Commodity _
-        | SecurityKind.CryptoCurrency _ -> false
+        | SecurityKind.CryptoCurrency _
+        | SecurityKind.InvestmentFund _ -> false

--- a/src/Meridian.FSharp/Domain/SecurityMasterCommands.fs
+++ b/src/Meridian.FSharp/Domain/SecurityMasterCommands.fs
@@ -175,6 +175,8 @@ module SecurityMaster =
                 (error "warrant_strike_invalid" "Warrant Strike must be greater than zero when present.")
             @ require (terms.Multiplier |> Option.forall (fun m -> m > 0m))
                 (error "warrant_multiplier_invalid" "Warrant Multiplier must be greater than zero when present.")
+        | SecurityKind.InvestmentFund _ ->
+            []
 
     let private validateIdentifier (identifier: Identifier) =
         []

--- a/src/Meridian.FSharp/Domain/SecurityMasterLegacyUpgrade.fs
+++ b/src/Meridian.FSharp/Domain/SecurityMasterLegacyUpgrade.fs
@@ -232,6 +232,16 @@ module SecurityMasterLegacyUpgrade =
                 RiskCountry = None
                 Taxonomy = None
             }
+        | SecurityKind.InvestmentFund _ ->
+            {
+                AssetClass = AssetClass.Fund
+                Family = None
+                SubType = SecuritySubType.OtherSubType "InvestmentFund"
+                TypeName = "InvestmentFund"
+                IssuerType = None
+                RiskCountry = None
+                Taxonomy = None
+            }
 
     let private termsFromKind (kind: SecurityKind) =
         match kind with
@@ -631,6 +641,17 @@ module SecurityMasterLegacyUpgrade =
                             MarginRequirementPct = None
                             TradingHoursUtc = None
                             CircuitBreakerThresholdPct = None
+                        }
+            }
+        | SecurityKind.InvestmentFund terms ->
+            {
+                SecurityTermModules.empty with
+                    Fund =
+                        Some {
+                            FundFamily = terms.FundFamily
+                            WeightedAverageMaturityDays = None
+                            SweepEligible = None
+                            LiquidityFeeEligible = None
                         }
             }
 

--- a/src/Meridian.FSharp/Domain/SecurityTermModules.fs
+++ b/src/Meridian.FSharp/Domain/SecurityTermModules.fs
@@ -382,6 +382,118 @@ type MultiCalendarTerms = {
     Calendars: CalendarRef list
 }
 
+// ---------------------------------------------------------------------------
+// Clearwater-aligned modules: inflation-linked, sinking fund, accounting elections, PCI
+// ---------------------------------------------------------------------------
+
+/// Inflation index terms for TIPS, index-linked GILTs, and similar instruments.
+/// Supports the Clearwater adjusted-principal calculation: Base_units × Inflation_factor.
+type InflationLinkedTerms = {
+    /// Index series used to adjust principal (e.g. "CPI-U", "RPI", "HICPxT").
+    InflationIndex: string option
+    /// Reference index value at the original issue date.
+    BaseIndexValue: decimal option
+    /// Date of the base index value (usually issue date or original auction date).
+    BaseDate: DateOnly option
+    /// Most recently published factor: Current_index / Base_index.
+    CurrentFactor: decimal option
+    /// As-of date for the current factor.
+    FactorDate: DateOnly option
+    /// Minimum factor floor; 1.0 for US TIPS (principal cannot fall below original par).
+    IndexFloor: decimal option
+}
+
+/// A single principal instalment in a sinking fund or scheduled-amortizing bond.
+type SinkingFundEntry = {
+    SinkDate: DateOnly
+    /// Par amount retired on this date.
+    Amount: decimal
+}
+
+/// Sinking fund schedule module for bonds with contractual principal instalments.
+type SinkingFundTerms = {
+    Schedule: SinkingFundEntry list
+    /// Descriptive frequency label (e.g. "Annual", "SemiAnnual").
+    SinkFrequency: string option
+    /// True when instalments retire bonds pro-rata across all holders via lottery or open-market purchase.
+    IsProRata: bool
+}
+
+/// Amortization method applied at the account or lot level.
+[<RequireQualifiedAccess>]
+type AmortizationMethod =
+    /// Effective-interest method: income recognised as a constant proportion of book value (Clearwater default for most debt).
+    | ConstantYield
+    /// Equal daily movement from starting book price to target price; used for short-dated instruments.
+    | StraightLine
+    /// Book price held flat; no daily premium/discount recognised.
+    | NoAmortization
+    /// Recognises all premium/discount immediately to par when amortization begins; used for ARS.
+    | AuctionRate
+    /// Recognises income using expected yield over remaining life; used for PCI-designated lots.
+    | PurchasedCreditImpaired
+
+/// Frequency at which book yield is reset for prepaying securities.
+[<RequireQualifiedAccess>]
+type YieldUpdateFrequency =
+    | Monthly
+    | Quarterly
+    | Annual
+
+/// FAS 91-style adjustment method for prepaying structured securities.
+[<RequireQualifiedAccess>]
+type YieldAdjustmentMethod =
+    /// Recompute yield using actual cash flows since last adjustment and current projections; record a book-value catch-up.
+    | Retrospective
+    /// Recompute yield using current book value and current future cash flows; no immediate book-value adjustment.
+    | Prospective
+    /// Maintain original amortization curve; no periodic yield adjustment.
+    | NoAdjustment
+
+/// Cash-flow source hierarchy for accounting calculations.
+[<RequireQualifiedAccess>]
+type CashFlowSource =
+    /// Third-party vendor cash flows (e.g. MIAC for agency MBS, Moody's Analytics for other prepaying securities).
+    | VendorProvided
+    /// Client-supplied cash flows; take precedence once established.
+    | ClientProvided
+    /// Clearwater-calculated from Security Master terms (non-prepaying fixed-rate instruments).
+    | SystemCalculated
+    /// Use weighted-average life as a single expected principal repayment.
+    | Wal
+    /// Use legal final maturity as a single bullet repayment when no other source is available.
+    | FinalMaturityFallback
+
+/// Account or lot-level accounting elections controlling amortization, yield updates, and cash-flow source.
+type AccountingElectionsTerms = {
+    AmortizationMethod: AmortizationMethod
+    YieldUpdateFrequency: YieldUpdateFrequency option
+    AdjustmentMethod: YieldAdjustmentMethod option
+    CashFlowSource: CashFlowSource option
+    /// When true, call dates are excluded from the amortization schedule.
+    IgnoreCallDates: bool
+    /// When true, put dates are excluded from the amortization schedule.
+    IgnorePutDates: bool
+    /// Lot-level No Amortization override; supersedes the account-level method for this lot.
+    IsLotLevelNoAmortization: bool
+}
+
+/// Purchased Credit Impaired (PCI) lot designation.
+/// A lot-level accounting election rather than a separate economic security type.
+/// Supports EITF 99-20 / ASC 325-40 and SOP 03-3 / ASC 310-30 models.
+type PciTerms = {
+    /// Accounting basis for the PCI model (e.g. "ASC-310-30", "ASC-325-40").
+    DesignationBasis: string option
+    /// Book value at the time of PCI designation or acquisition.
+    InitialBookValue: decimal option
+    /// Expected yield over the remaining life as of the last update.
+    ExpectedYield: decimal option
+    /// Projected cash flows as (date, amount) pairs; client-supplied or model-derived.
+    ExpectedCashFlows: (DateOnly * decimal) list
+    /// Date of the most recent expected-yield update; updates are prospective for PCI.
+    LastYieldUpdateDate: DateOnly option
+}
+
 type SecurityTermModules = {
     // --- Original 15 modules ---
     Maturity: MaturityTerms option
@@ -409,6 +521,15 @@ type SecurityTermModules = {
     MultiCalendar: MultiCalendarTerms option
     // --- Structured / factorable bond module ---
     StructuredProduct: StructuredProductTerms option
+    // --- Clearwater-aligned modules ---
+    /// Inflation index and factor data for TIPS, index-linked GILTs, and similar instruments.
+    InflationLinked: InflationLinkedTerms option
+    /// Contractual sinking fund or scheduled principal instalment schedule.
+    SinkingFund: SinkingFundTerms option
+    /// Account or lot-level accounting elections (amortization method, yield update frequency, etc.).
+    AccountingElections: AccountingElectionsTerms option
+    /// Purchased Credit Impaired lot designation with expected-yield accounting.
+    Pci: PciTerms option
 }
 
 [<RequireQualifiedAccess>]
@@ -505,4 +626,8 @@ module SecurityTermModules =
         Venue = None
         MultiCalendar = None
         StructuredProduct = None
+        InflationLinked = None
+        SinkingFund = None
+        AccountingElections = None
+        Pci = None
     }

--- a/src/Meridian.FSharp/Interop.SecurityMaster.fs
+++ b/src/Meridian.FSharp/Interop.SecurityMaster.fs
@@ -146,7 +146,13 @@ type SecurityMasterSnapshotWrapper(record: SecurityMasterRecord) =
                    isCallable = terms.IsCallable
                    callDate = terms.CallDate
                    issuerName = terms.IssuerName
-                   seniority = terms.Seniority |})
+                   seniority = terms.Seniority
+                   subclass = terms.Subclass.ToString()
+                   par = terms.Par
+                   paymentFrequency = terms.PaymentFrequency |> Option.map PaymentFrequency.label
+                   legalFinalMaturity = terms.LegalFinalMaturity
+                   preRefundDate = terms.PreRefundDate
+                   mandatoryPutDate = terms.MandatoryPutDate |})
         | SecurityKind.FxSpot terms ->
             JsonSerializer.Serialize(
                 {| schemaVersion = schemaVersion
@@ -233,12 +239,22 @@ type SecurityMasterSnapshotWrapper(record: SecurityMasterRecord) =
                 {| schemaVersion = schemaVersion
                    borrower = terms.Borrower
                    maturity = terms.Maturity
+                   referenceIndex = terms.ReferenceIndex
+                   spreadBps = terms.SpreadBps
+                   currentCouponRate = terms.CurrentCouponRate
+                   resetFrequency = terms.ResetFrequency
+                   pricingSource = terms.PricingSource
                    covenants =
                         terms.Covenants
                         |> List.map (fun covenant ->
                             {| covenantType = covenant.CovenantType
                                threshold = covenant.Threshold
-                               notes = covenant.Notes |}) |})
+                               notes = covenant.Notes |})
+                   principalSchedule =
+                        terms.PrincipalSchedule
+                        |> List.map (fun entry ->
+                            {| paymentDate = entry.PaymentDate
+                               amount = entry.Amount |}) |})
         | SecurityKind.Commodity terms ->
             JsonSerializer.Serialize(
                 {| schemaVersion = schemaVersion
@@ -266,6 +282,15 @@ type SecurityMasterSnapshotWrapper(record: SecurityMasterRecord) =
                    strike = terms.Strike
                    expiry = terms.Expiry
                    multiplier = terms.Multiplier |})
+        | SecurityKind.InvestmentFund terms ->
+            JsonSerializer.Serialize(
+                {| schemaVersion = schemaVersion
+                   fundType = terms.FundType
+                   fundFamily = terms.FundFamily
+                   navCurrency = terms.NavCurrency
+                   distributionPolicy = terms.DistributionPolicy |> Option.map DistributionPolicy.label
+                   isStableNav = terms.IsStableNav
+                   pricingSource = terms.PricingSource |})
 
     let commonTermsJson =
         JsonSerializer.Serialize(

--- a/src/Meridian.FSharp/Meridian.FSharp.fsproj
+++ b/src/Meridian.FSharp/Meridian.FSharp.fsproj
@@ -48,6 +48,7 @@
     <Compile Include="Calculations/Spread.fs" />
     <Compile Include="Calculations/Imbalance.fs" />
     <Compile Include="Calculations/Aggregations.fs" />
+    <Compile Include="Calculations/SecurityCalculations.fs" />
 
     <!-- Canonicalization layer: rule-heavy mapping logic -->
     <Compile Include="Canonicalization/MappingRules.fs" />

--- a/src/Meridian.Instruments/FixedIncome/BondProjectionService.cs
+++ b/src/Meridian.Instruments/FixedIncome/BondProjectionService.cs
@@ -48,7 +48,13 @@ public sealed class BondProjectionService : IBondReferenceService
             projection.CallDate,
             projection.MaturityDate,
             projection.IsCallable,
-            projection.Version);
+            projection.Version,
+            projection.Par,
+            projection.Subclass,
+            projection.PaymentFrequency,
+            projection.LegalFinalMaturity,
+            projection.PreRefundDate,
+            projection.MandatoryPutDate);
     }
 
     public async Task<BondAccrualConventionDto?> GetAccrualConventionAsync(Guid securityId, CancellationToken ct = default)
@@ -132,7 +138,13 @@ public sealed class BondProjectionService : IBondReferenceService
             projection.CallDate,
             projection.MaturityDate.Value,
             projection.IsCallable ?? false,
-            projection.Version);
+            projection.Version,
+            projection.Par,
+            projection.Subclass,
+            projection.PaymentFrequency,
+            projection.LegalFinalMaturity,
+            projection.PreRefundDate,
+            projection.MandatoryPutDate);
     }
 
     private static BondAccrualConventionDto? MapAccrual(BondProjectionRow projection)

--- a/src/Meridian.Storage/SecurityMaster/IBondReferenceProjectionStore.cs
+++ b/src/Meridian.Storage/SecurityMaster/IBondReferenceProjectionStore.cs
@@ -28,7 +28,14 @@ public sealed record BondProjectionRow(
     decimal? FixedCouponRate,
     string? FloatingRateIndex,
     decimal? FloatingSpreadBps,
-    long Version);
+    long Version,
+    // Clearwater extended lifecycle fields.
+    string? Subclass = null,
+    decimal? Par = null,
+    string? PaymentFrequency = null,
+    DateOnly? LegalFinalMaturity = null,
+    DateOnly? PreRefundDate = null,
+    DateOnly? MandatoryPutDate = null);
 
 public sealed record BondLifecycleProjectionRow(
     Guid SecurityId,
@@ -37,7 +44,14 @@ public sealed record BondLifecycleProjectionRow(
     DateOnly? CallDate,
     DateOnly MaturityDate,
     bool IsCallable,
-    long Version);
+    long Version,
+    // Clearwater extended lifecycle fields.
+    string? Subclass = null,
+    decimal? Par = null,
+    string? PaymentFrequency = null,
+    DateOnly? LegalFinalMaturity = null,
+    DateOnly? PreRefundDate = null,
+    DateOnly? MandatoryPutDate = null);
 
 public sealed record BondAccrualConventionProjectionRow(
     Guid SecurityId,

--- a/src/Meridian.Storage/SecurityMaster/Migrations/017_security_master_bond_clearwater_lifecycle_fields.sql
+++ b/src/Meridian.Storage/SecurityMaster/Migrations/017_security_master_bond_clearwater_lifecycle_fields.sql
@@ -1,0 +1,12 @@
+-- Clearwater extended bond lifecycle fields.
+-- Adds par, payment frequency, subclass, and the extended option/redemption dates
+-- (legal final maturity, pre-refund, mandatory put) used by BondLifecycleDto.
+-- Subclass is denormalised here alongside bond_projection so both the joined
+-- reference query and the standalone lifecycle query resolve it from one table.
+alter table __SCHEMA__.bond_lifecycle_projection
+    add column if not exists subclass text null,
+    add column if not exists par numeric null,
+    add column if not exists payment_frequency text null,
+    add column if not exists legal_final_maturity date null,
+    add column if not exists pre_refund_date date null,
+    add column if not exists mandatory_put_date date null;

--- a/src/Meridian.Storage/SecurityMaster/PostgresBondReferenceProjectionStore.cs
+++ b/src/Meridian.Storage/SecurityMaster/PostgresBondReferenceProjectionStore.cs
@@ -74,7 +74,13 @@ public sealed class PostgresBondReferenceProjectionStore : IBondReferenceProject
                    bacp.fixed_coupon_rate,
                    bacp.floating_rate_index,
                    bacp.floating_spread_bps,
-                   bp.version
+                   bp.version,
+                   blp.subclass,
+                   blp.par,
+                   blp.payment_frequency,
+                   blp.legal_final_maturity,
+                   blp.pre_refund_date,
+                   blp.mandatory_put_date
             from {Qualified("bond_projection")} bp
             join {Qualified("securities")} s on s.security_id = bp.security_id
             left join {Qualified("bond_issuer_projection")} bip on bip.security_id = bp.security_id
@@ -111,7 +117,13 @@ public sealed class PostgresBondReferenceProjectionStore : IBondReferenceProject
                 reader.IsDBNull(15) ? null : reader.GetDecimal(15),
                 reader.IsDBNull(16) ? null : reader.GetString(16),
                 reader.IsDBNull(17) ? null : reader.GetDecimal(17),
-                reader.GetInt64(18)));
+                reader.GetInt64(18),
+                reader.IsDBNull(19) ? null : reader.GetString(19),
+                reader.IsDBNull(20) ? null : reader.GetDecimal(20),
+                reader.IsDBNull(21) ? null : reader.GetString(21),
+                reader.IsDBNull(22) ? null : DateOnly.FromDateTime(reader.GetDateTime(22)),
+                reader.IsDBNull(23) ? null : DateOnly.FromDateTime(reader.GetDateTime(23)),
+                reader.IsDBNull(24) ? null : DateOnly.FromDateTime(reader.GetDateTime(24))));
         }
 
         return results;
@@ -129,7 +141,13 @@ public sealed class PostgresBondReferenceProjectionStore : IBondReferenceProject
                    call_date,
                    maturity_date,
                    is_callable,
-                   version
+                   version,
+                   subclass,
+                   par,
+                   payment_frequency,
+                   legal_final_maturity,
+                   pre_refund_date,
+                   mandatory_put_date
             from {Qualified("bond_lifecycle_projection")}
             where security_id = @security_id;
             """;
@@ -148,7 +166,13 @@ public sealed class PostgresBondReferenceProjectionStore : IBondReferenceProject
             reader.IsDBNull(3) ? null : DateOnly.FromDateTime(reader.GetDateTime(3)),
             DateOnly.FromDateTime(reader.GetDateTime(4)),
             reader.GetBoolean(5),
-            reader.GetInt64(6));
+            reader.GetInt64(6),
+            reader.IsDBNull(7) ? null : reader.GetString(7),
+            reader.IsDBNull(8) ? null : reader.GetDecimal(8),
+            reader.IsDBNull(9) ? null : reader.GetString(9),
+            reader.IsDBNull(10) ? null : DateOnly.FromDateTime(reader.GetDateTime(10)),
+            reader.IsDBNull(11) ? null : DateOnly.FromDateTime(reader.GetDateTime(11)),
+            reader.IsDBNull(12) ? null : DateOnly.FromDateTime(reader.GetDateTime(12)));
     }
 
     private async Task<BondAccrualConventionProjectionRow?> GetSingleAccrualAsync(Guid securityId, CancellationToken ct)

--- a/src/Meridian.Storage/SecurityMaster/PostgresSecurityMasterStore.cs
+++ b/src/Meridian.Storage/SecurityMaster/PostgresSecurityMasterStore.cs
@@ -779,16 +779,24 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
         command.CommandText =
             $"""
             insert into {Qualified(BondLifecycleProjectionTable)} (
-                security_id, lifecycle_stat, issue_date, call_date, maturity_date, is_callable, version)
+                security_id, lifecycle_stat, issue_date, call_date, maturity_date, is_callable, version,
+                subclass, par, payment_frequency, legal_final_maturity, pre_refund_date, mandatory_put_date)
             values (
-                @security_id, @lifecycle_stat, @issue_date, @call_date, @maturity_date, @is_callable, @version)
+                @security_id, @lifecycle_stat, @issue_date, @call_date, @maturity_date, @is_callable, @version,
+                @subclass, @par, @payment_frequency, @legal_final_maturity, @pre_refund_date, @mandatory_put_date)
             on conflict (security_id) do update set
                 lifecycle_stat = excluded.lifecycle_stat,
                 issue_date = excluded.issue_date,
                 call_date = excluded.call_date,
                 maturity_date = excluded.maturity_date,
                 is_callable = excluded.is_callable,
-                version = excluded.version;
+                version = excluded.version,
+                subclass = excluded.subclass,
+                par = excluded.par,
+                payment_frequency = excluded.payment_frequency,
+                legal_final_maturity = excluded.legal_final_maturity,
+                pre_refund_date = excluded.pre_refund_date,
+                mandatory_put_date = excluded.mandatory_put_date;
             """;
         command.Parameters.AddWithValue("security_id", projection.SecurityId);
         command.Parameters.AddWithValue("lifecycle_stat", projection.LifecycleStat);
@@ -797,6 +805,12 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
         command.Parameters.AddWithValue("maturity_date", projection.MaturityDate.ToDateTime(TimeOnly.MinValue));
         command.Parameters.AddWithValue("is_callable", projection.IsCallable);
         command.Parameters.AddWithValue("version", projection.Version);
+        command.Parameters.AddWithValue("subclass", (object?)projection.Subclass ?? DBNull.Value);
+        command.Parameters.AddWithValue("par", (object?)projection.Par ?? DBNull.Value);
+        command.Parameters.AddWithValue("payment_frequency", (object?)projection.PaymentFrequency ?? DBNull.Value);
+        command.Parameters.AddWithValue("legal_final_maturity", (object?)projection.LegalFinalMaturity?.ToDateTime(TimeOnly.MinValue) ?? DBNull.Value);
+        command.Parameters.AddWithValue("pre_refund_date", (object?)projection.PreRefundDate?.ToDateTime(TimeOnly.MinValue) ?? DBNull.Value);
+        command.Parameters.AddWithValue("mandatory_put_date", (object?)projection.MandatoryPutDate?.ToDateTime(TimeOnly.MinValue) ?? DBNull.Value);
         await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
     }
 
@@ -941,7 +955,12 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
             dayCountConvention,
             GetOptionalInt(record.CommonTerms, "settlementCycleDays"),
             GetOptionalString(record.CommonTerms, "holidayCalendarId"),
-            record.Version);
+            record.Version,
+            GetOptionalDecimal(record.AssetSpecificTerms, "par"),
+            GetOptionalString(record.AssetSpecificTerms, "paymentFrequency"),
+            GetOptionalDateOnly(record.AssetSpecificTerms, "legalFinalMaturity"),
+            GetOptionalDateOnly(record.AssetSpecificTerms, "preRefundDate"),
+            GetOptionalDateOnly(record.AssetSpecificTerms, "mandatoryPutDate"));
         return true;
     }
 
@@ -1761,7 +1780,13 @@ public sealed class PostgresSecurityMasterStore : ISecurityMasterStore
         string? DayCountConvention,
         int? SettlementCycleDays,
         string? HolidayCalendarId,
-        long Version);
+        long Version,
+        // Clearwater extended lifecycle fields.
+        decimal? Par,
+        string? PaymentFrequency,
+        DateOnly? LegalFinalMaturity,
+        DateOnly? PreRefundDate,
+        DateOnly? MandatoryPutDate);
 
     private sealed record OptionProjectionWriteModel(
         string ContractSymbol,

--- a/tests/Meridian.FSharp.Tests/Meridian.FSharp.Tests.fsproj
+++ b/tests/Meridian.FSharp.Tests/Meridian.FSharp.Tests.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="DomainTests.fs" Condition="'$(FSharpTestSlice)' == 'All' Or '$(FSharpTestSlice)' == 'Domain'" />
     <Compile Include="ValidationTests.fs" Condition="'$(FSharpTestSlice)' == 'All' Or '$(FSharpTestSlice)' == 'Domain'" />
     <Compile Include="CalculationTests.fs" Condition="'$(FSharpTestSlice)' == 'All' Or '$(FSharpTestSlice)' == 'MarketData'" />
+    <Compile Include="SecurityCalculationsTests.fs" Condition="'$(FSharpTestSlice)' == 'All' Or '$(FSharpTestSlice)' == 'MarketData'" />
     <Compile Include="CanonicalizationTests.fs" Condition="'$(FSharpTestSlice)' == 'All' Or '$(FSharpTestSlice)' == 'Domain'" />
     <Compile Include="PipelineTests.fs" Condition="'$(FSharpTestSlice)' == 'All' Or '$(FSharpTestSlice)' == 'MarketData'" />
     <Compile Include="RiskPolicyTests.fs" Condition="'$(FSharpTestSlice)' == 'All' Or '$(FSharpTestSlice)' == 'Domain'" />

--- a/tests/Meridian.FSharp.Tests/SecurityCalculationsTests.fs
+++ b/tests/Meridian.FSharp.Tests/SecurityCalculationsTests.fs
@@ -1,0 +1,243 @@
+/// Unit tests for the Clearwater-aligned security calculations.
+/// Worked examples reference the Clearwater Security Types and Calculation Reference Guide,
+/// Sections 2.2, 2.3, 4.x, and Appendix B.
+module Meridian.FSharp.Tests.SecurityCalculationsTests
+
+open System
+open Xunit
+open FsUnit.Xunit
+open Meridian.FSharp.Domain
+open Meridian.FSharp.Calculations
+
+// ---------------------------------------------------------------------------
+// Day-count conventions (Section 2.2)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``actual360 divides actual days by 360`` () =
+    // 2026-01-01 -> 2026-01-31 is 30 days.
+    DayCount.actual360 (DateOnly(2026, 1, 1)) (DateOnly(2026, 1, 31))
+    |> should equal (30m / 360m)
+
+[<Fact>]
+let ``actual365 divides actual days by 365`` () =
+    DayCount.actual365 (DateOnly(2026, 1, 1)) (DateOnly(2026, 1, 31))
+    |> should equal (30m / 365m)
+
+[<Fact>]
+let ``thirty360 treats a half year as exactly one half`` () =
+    // 30/360: 2026-01-01 -> 2026-07-01 is six 30-day months = 0.5.
+    DayCount.thirty360 (DateOnly(2026, 1, 1)) (DateOnly(2026, 7, 1))
+    |> should equal 0.5m
+
+[<Fact>]
+let ``actualActualIsda returns zero when end precedes start`` () =
+    DayCount.actualActualIsda (DateOnly(2026, 7, 1)) (DateOnly(2026, 1, 1))
+    |> should equal 0m
+
+[<Fact>]
+let ``actualActualIsda within a single non-leap year divides by 365`` () =
+    // 2026 is not a leap year; 2026-01-01 -> 2026-07-01 is 181 days.
+    DayCount.actualActualIsda (DateOnly(2026, 1, 1)) (DateOnly(2026, 7, 1))
+    |> should equal (181m / 365m)
+
+[<Fact>]
+let ``fractionFor dispatches to the matching convention`` () =
+    let start = DateOnly(2026, 1, 1)
+    let finish = DateOnly(2026, 4, 1)
+    DayCount.fractionFor DayCountConvention.Actual360 start finish
+    |> should equal (DayCount.actual360 start finish)
+    DayCount.fractionFor DayCountConvention.Thirty360 start finish
+    |> should equal (DayCount.thirty360 start finish)
+
+// ---------------------------------------------------------------------------
+// Interest and accrual (Section 2.2)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``interestCashFlow multiplies principal coupon and day-count fraction`` () =
+    // 1,000,000 x 5% x 0.5 = 25,000.
+    SecurityCalculations.interestCashFlow 1_000_000m 0.05m 0.5m
+    |> should equal 25_000m
+
+[<Fact>]
+let ``accruedInterest accrues from last coupon to evaluation date`` () =
+    // 30/360 half year: 1,000,000 x 5% x 0.5 = 25,000.
+    SecurityCalculations.accruedInterest
+        1_000_000m 0.05m (DateOnly(2026, 1, 1)) (DateOnly(2026, 7, 1)) DayCountConvention.Thirty360
+    |> should equal 25_000m
+
+[<Fact>]
+let ``accruedInterest is zero on or before the last coupon date`` () =
+    SecurityCalculations.accruedInterest
+        1_000_000m 0.05m (DateOnly(2026, 7, 1)) (DateOnly(2026, 1, 1)) DayCountConvention.Thirty360
+    |> should equal 0m
+
+// ---------------------------------------------------------------------------
+// Market value (Section 2.2)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``bondMarketValue applies Par times Factor times Price over 100`` () =
+    // Non-factored bond at 99.5.
+    SecurityCalculations.bondMarketValue 1_000_000m 1.0m 99.5m
+    |> should equal 995_000m
+
+[<Fact>]
+let ``bondMarketValue scales by the principal factor for amortising pools`` () =
+    // Half the pool outstanding (factor 0.5) at par.
+    SecurityCalculations.bondMarketValue 1_000_000m 0.5m 100m
+    |> should equal 500_000m
+
+[<Fact>]
+let ``equityMarketValue multiplies shares by price`` () =
+    SecurityCalculations.equityMarketValue 100m 25.50m
+    |> should equal 2_550m
+
+// ---------------------------------------------------------------------------
+// Dirty / clean price (Section 2.2)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``dirty and clean price are inverse operations`` () =
+    let dirty = SecurityCalculations.dirtyPrice 99.5m 0.75m
+    dirty |> should equal 100.25m
+    SecurityCalculations.cleanPrice dirty 0.75m |> should equal 99.5m
+
+// ---------------------------------------------------------------------------
+// Amortization (Section 2.3)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``straightLineDailyAmount is negative for a premium bond`` () =
+    // Purchased at 105, amortising to 100 over 100 days => -0.05/day.
+    SecurityCalculations.straightLineDailyAmount 100m 105m 100
+    |> should equal -0.05m
+
+[<Fact>]
+let ``straightLineDailyAmount guards against non-positive day counts`` () =
+    SecurityCalculations.straightLineDailyAmount 100m 105m 0 |> should equal 0m
+
+[<Fact>]
+let ``constantYieldIncome is amortized cost times periodic yield`` () =
+    SecurityCalculations.constantYieldIncome 1_000m 0.025m |> should equal 25m
+
+[<Fact>]
+let ``amortizationAccretion is effective minus contractual interest`` () =
+    // Effective 25 vs contractual 20 => 5 of discount accretion.
+    SecurityCalculations.amortizationAccretion 25m 20m |> should equal 5m
+
+// ---------------------------------------------------------------------------
+// Structured / prepaying securities (Section 2.2)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``weightedAverageLife weights principal by time to payment`` () =
+    // (100 x 1 + 100 x 2) / 200 = 1.5 years.
+    SecurityCalculations.weightedAverageLife [ (100m, 1m); (100m, 2m) ]
+    |> should equal 1.5m
+
+[<Fact>]
+let ``weightedAverageLife is zero when there is no principal`` () =
+    SecurityCalculations.weightedAverageLife [] |> should equal 0m
+
+// ---------------------------------------------------------------------------
+// Inflation-linked securities (Section 4.8)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``inflationAdjustedPrincipal scales base units by the factor`` () =
+    // Guide example: 1,000 units x 1.2 factor = 1,200.
+    SecurityCalculations.inflationAdjustedPrincipal 1_000m 1.2m |> should equal 1_200m
+
+[<Fact>]
+let ``inflationLinkedMarketValue matches the Clearwater TIPS example`` () =
+    // Guide example: 1,000 units, 1.2 factor, price 105 => 1,260; at par => 1,200.
+    SecurityCalculations.inflationLinkedMarketValue 1_000m 1.2m 105m |> should equal 1_260m
+    SecurityCalculations.inflationLinkedMarketValue 1_000m 1.2m 100m |> should equal 1_200m
+
+// ---------------------------------------------------------------------------
+// Purchased credit impaired (Section 4.14)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``pciDailyAmortization is daily total income minus daily interest`` () =
+    // Beginning BV 100,000 x 6% = 6,000 / 30 days = 200/day; minus 15 interest = 185.
+    SecurityCalculations.pciDailyAmortization 100_000m 0.06m 30 15m |> should equal 185m
+
+[<Fact>]
+let ``pciDailyAmortization guards against non-positive periods`` () =
+    SecurityCalculations.pciDailyAmortization 100_000m 0.06m 0 15m |> should equal 0m
+
+// ---------------------------------------------------------------------------
+// Foreign currency (Section 6.3)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``fxRemeasurement multiplies the local amount by the FX rate`` () =
+    SecurityCalculations.fxRemeasurement 1_000m 1.10m |> should equal 1_100m
+
+// ---------------------------------------------------------------------------
+// Short-term discount instruments (Section 4.3)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``shortTermDailyAccretion matches the 98-to-100 over 90-days example`` () =
+    // Guide example: (100 - 98) / 90 per day.
+    SecurityCalculations.shortTermDailyAccretion 100m 98m 90 |> should equal (2m / 90m)
+
+[<Fact>]
+let ``shortTermDailyAccretion guards against non-positive day counts`` () =
+    SecurityCalculations.shortTermDailyAccretion 100m 98m 0 |> should equal 0m
+
+// ---------------------------------------------------------------------------
+// Repo interest (Section 4.11)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``repoInterest is principal times repo rate times day-count fraction`` () =
+    // 1,000,000 x 3% x 0.25 = 7,500.
+    SecurityCalculations.repoInterest 1_000_000m 0.03m 0.25m |> should equal 7_500m
+
+// ---------------------------------------------------------------------------
+// Callable / putable in-the-money tests (Section 4.5)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``isCallInTheMoney is true only above the next call price`` () =
+    SecurityCalculations.isCallInTheMoney 102m 101m |> should equal true
+    SecurityCalculations.isCallInTheMoney 100m 101m |> should equal false
+
+[<Fact>]
+let ``isPutInTheMoney is true at or below the next put price`` () =
+    SecurityCalculations.isPutInTheMoney 99m 100m |> should equal true
+    SecurityCalculations.isPutInTheMoney 100m 100m |> should equal true
+    SecurityCalculations.isPutInTheMoney 101m 100m |> should equal false
+
+// ---------------------------------------------------------------------------
+// Yield solvers (Section 2.2 / 5.5) — iterative, so assert within tolerance.
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``purchaseYield solves a single annual cash flow to its discount rate`` () =
+    // 100 = 105 / (1 + y) => y = 5%.
+    match SecurityCalculations.purchaseYield 100m [ (1.0m, 105.0m) ] 1 with
+    | Some y ->
+        y |> should be (greaterThan 0.0499m)
+        y |> should be (lessThan 0.0501m)
+    | None -> failwith "Expected the solver to converge."
+
+[<Fact>]
+let ``bookYield recovers the coupon when a par bond discounts to 100`` () =
+    // A par bond: two semi-annual 2.5 coupons plus 100 redemption, priced at 100, yields 5%.
+    let cashFlows = [ (0.5m, 2.5m); (1.0m, 102.5m) ]
+    match SecurityCalculations.bookYield 100m cashFlows 2 with
+    | Some y ->
+        y |> should be (greaterThan 0.0499m)
+        y |> should be (lessThan 0.0501m)
+    | None -> failwith "Expected the solver to converge."
+
+[<Fact>]
+let ``yield solvers reject empty cash flows and non-positive prices`` () =
+    SecurityCalculations.purchaseYield 100m [] 1 |> should equal None
+    SecurityCalculations.purchaseYield 0m [ (1.0m, 105.0m) ] 1 |> should equal None

--- a/tests/Meridian.Tests/FixedIncome/BondProjectionServiceTests.cs
+++ b/tests/Meridian.Tests/FixedIncome/BondProjectionServiceTests.cs
@@ -37,7 +37,13 @@ public sealed class BondProjectionServiceTests
                 5.125m,
                 null,
                 null,
-                9));
+                9,
+                Subclass: "Corporate",
+                Par: 1_000_000m,
+                PaymentFrequency: "SemiAnnual",
+                LegalFinalMaturity: new DateOnly(2032, 1, 15),
+                PreRefundDate: new DateOnly(2028, 1, 15),
+                MandatoryPutDate: new DateOnly(2030, 1, 15)));
         projectionStore.GetLifecycleAsync(securityId, Arg.Any<CancellationToken>())
             .Returns(new BondLifecycleProjectionRow(
                 securityId,
@@ -68,6 +74,12 @@ public sealed class BondProjectionServiceTests
         result.Seniority.Should().Be("SeniorUnsecured");
         result.Lifecycle.Should().NotBeNull();
         result.Lifecycle!.LifecycleStat.Should().Be(Meridian.Contracts.FixedIncome.BondLifecycleStat.Callable);
+        result.Lifecycle.Par.Should().Be(1_000_000m);
+        result.Lifecycle.BondSubclass.Should().Be("Corporate");
+        result.Lifecycle.PaymentFrequency.Should().Be("SemiAnnual");
+        result.Lifecycle.LegalFinalMaturity.Should().Be(new DateOnly(2032, 1, 15));
+        result.Lifecycle.PreRefundDate.Should().Be(new DateOnly(2028, 1, 15));
+        result.Lifecycle.MandatoryPutDate.Should().Be(new DateOnly(2030, 1, 15));
         result.AccrualConvention.Should().NotBeNull();
         result.AccrualConvention!.DayCountConvention.Should().Be("30/360");
         result.AccrualConvention.FixedCouponRate.Should().Be(5.125m);
@@ -101,6 +113,42 @@ public sealed class BondProjectionServiceTests
         result.FloatingSpreadBps.Should().Be(125m);
         result.SettlementCycleDays.Should().Be(2);
         result.HolidayCalendarId.Should().Be("TARGET2");
+    }
+
+    [Fact]
+    public async Task GetLifecycleAsync_ReturnsClearwaterExtendedLifecycleFields()
+    {
+        var securityId = Guid.NewGuid();
+        var securityStore = Substitute.For<ISecurityMasterStore>();
+        var projectionStore = Substitute.For<IBondReferenceProjectionStore>();
+        projectionStore.GetLifecycleAsync(securityId, Arg.Any<CancellationToken>())
+            .Returns(new BondLifecycleProjectionRow(
+                securityId,
+                "Callable",
+                new DateOnly(2024, 1, 15),
+                new DateOnly(2029, 1, 15),
+                new DateOnly(2032, 1, 15),
+                true,
+                9,
+                Subclass: "SinkingFund",
+                Par: 5_000_000m,
+                PaymentFrequency: "Quarterly",
+                LegalFinalMaturity: new DateOnly(2033, 1, 15),
+                PreRefundDate: new DateOnly(2027, 1, 15),
+                MandatoryPutDate: new DateOnly(2031, 1, 15)));
+
+        var service = new BondProjectionService(securityStore, projectionStore);
+
+        var result = await service.GetLifecycleAsync(securityId);
+
+        result.Should().NotBeNull();
+        result!.LifecycleStat.Should().Be(Meridian.Contracts.FixedIncome.BondLifecycleStat.Callable);
+        result.Par.Should().Be(5_000_000m);
+        result.BondSubclass.Should().Be("SinkingFund");
+        result.PaymentFrequency.Should().Be("Quarterly");
+        result.LegalFinalMaturity.Should().Be(new DateOnly(2033, 1, 15));
+        result.PreRefundDate.Should().Be(new DateOnly(2027, 1, 15));
+        result.MandatoryPutDate.Should().Be(new DateOnly(2031, 1, 15));
     }
 
     private static SecurityProjectionRecord CreateBondProjection(Guid securityId)


### PR DESCRIPTION
Add all securities-related properties and calculations from the Clearwater
Security Types and Calculation Reference Guide (May/June 2026).

Domain (F#):
- BondSubclass: add SinkingFund, StepRate, FixedToFloat, Vrdn, AuctionRate, BankLoan
- BondTerms: add Par, PaymentFrequency, LegalFinalMaturity, PreRefundDate, MandatoryPutDate
- DirectLoanTerms: add ReferenceIndex, SpreadBps, CurrentCouponRate, ResetFrequency,
  PrincipalSchedule, PricingSource
- New InvestmentFundTerms type and SecurityKind.InvestmentFund case
- SecurityTermModules: add InflationLinkedTerms, SinkingFundTerms, AccountingElectionsTerms,
  PciTerms, AmortizationMethod, YieldUpdateFrequency, YieldAdjustmentMethod, CashFlowSource

Calculations (F#):
- New SecurityCalculations.fs with DayCount module (Actual/360, Actual/365, 30/360,
  Actual/Actual ISDA) and SecurityCalculations module implementing all 14+ Clearwater
  core formulas: accrued interest, bond/equity market value, dirty/clean price,
  straight-line and constant-yield amortization, WAL, inflation-adjusted principal,
  PCI daily amortization, FX remeasurement, short-term accretion, repo interest,
  call/put in-the-money tests, and Newton-Raphson purchase/book yield solvers

Contracts (C#):
- BondAmortizationMethod and BondYieldAdjustmentMethod enums
- BondSinkingFundEntryDto, BondSinkingFundDto, BondInflationLinkedDto,
  BondAccountingElectionsDto records
- Extended BondLifecycleDto with Par, BondSubclass, PaymentFrequency,
  LegalFinalMaturity, PreRefundDate, MandatoryPutDate
- Extended BondReferenceDto with SinkingFund, InflationLinked, AccountingElections

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DcEdifH3RJTRRfcLTXLtfa