### PR TITLE
Add reporting hub, period switcher, and grid diff features

### DIFF
--- a/src/Meridian.Contracts/Workstation/FundOperationsWorkspaceDtos.cs
+++ b/src/Meridian.Contracts/Workstation/FundOperationsWorkspaceDtos.cs
@@ -1218,7 +1218,55 @@ public sealed record ReportWriterGridDefinitionDto(
     int? TopN = null,
     string? SortBy = null,
     bool SortDescending = true,
-    IReadOnlyList<ReportWriterFilterDefinitionDto>? Filters = null);
+    IReadOnlyList<ReportWriterFilterDefinitionDto>? Filters = null,
+    IReadOnlyList<ReportWriterFormatRuleDto>? FormatRules = null,
+    ReportWriterChartDefinitionDto? Chart = null);
+
+[JsonConverter(typeof(JsonStringEnumConverter<ReportWriterCellStyleDto>))]
+public enum ReportWriterCellStyleDto
+{
+    None = 0,
+    Success = 1,
+    Warning = 2,
+    Danger = 3,
+    Info = 4
+}
+
+public sealed record ReportWriterFormatRuleDto(
+    string Column,
+    ReportWriterFilterOperatorDto Operator,
+    ReportWriterCellStyleDto Style,
+    string? Value = null,
+    string? Label = null);
+
+[JsonConverter(typeof(JsonStringEnumConverter<ReportWriterChartTypeDto>))]
+public enum ReportWriterChartTypeDto
+{
+    Bar = 0,
+    StackedBar = 1,
+    Line = 2,
+    Area = 3,
+    Pie = 4
+}
+
+public sealed record ReportWriterChartDefinitionDto(
+    ReportWriterChartTypeDto Type,
+    string CategoryField,
+    IReadOnlyList<string> ValueColumns,
+    string? Title = null);
+
+public sealed record ReportWriterChartSeriesDto(
+    string Key,
+    string Label,
+    IReadOnlyList<decimal> Values);
+
+public sealed record ReportWriterChartRenderDto(
+    ReportWriterChartTypeDto Type,
+    string Title,
+    string CategoryField,
+    IReadOnlyList<string> Categories,
+    IReadOnlyList<ReportWriterChartSeriesDto> Series,
+    IReadOnlyList<string> Warnings);
 
 public sealed record ReportWriterGridColumnDto(
     string Key,
@@ -1227,7 +1275,8 @@ public sealed record ReportWriterGridColumnDto(
 
 public sealed record ReportWriterGridRowDto(
     string RowKey,
-    IReadOnlyDictionary<string, string> Values);
+    IReadOnlyDictionary<string, string> Values,
+    IReadOnlyDictionary<string, ReportWriterCellStyleDto>? StyleHints = null);
 
 public sealed record ReportWriterMetricLineageDto(
     string Name,
@@ -1277,7 +1326,50 @@ public sealed record ReportWriterGridRenderDto(
     IReadOnlyList<string> Warnings,
     ReportWriterGridLineageDto? Lineage = null,
     IReadOnlyList<ReportWriterGridDataDictionaryFieldDto>? DataDictionary = null,
-    IReadOnlyList<ReportWriterGridValidationCheckDto>? ValidationChecks = null);
+    IReadOnlyList<ReportWriterGridValidationCheckDto>? ValidationChecks = null,
+    ReportWriterChartRenderDto? Chart = null);
+
+[JsonConverter(typeof(JsonStringEnumConverter<ReportWriterDiffRowStateDto>))]
+public enum ReportWriterDiffRowStateDto
+{
+    Unchanged = 0,
+    Changed = 1,
+    Added = 2,
+    Removed = 3
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter<ReportWriterDiffDirectionDto>))]
+public enum ReportWriterDiffDirectionDto
+{
+    Flat = 0,
+    Up = 1,
+    Down = 2
+}
+
+public sealed record ReportWriterGridDiffCellDto(
+    string Column,
+    string? PriorValue,
+    string? CurrentValue,
+    string? Delta,
+    ReportWriterDiffDirectionDto Direction);
+
+public sealed record ReportWriterGridDiffRowDto(
+    string RowKey,
+    ReportWriterDiffRowStateDto State,
+    IReadOnlyDictionary<string, string> PriorValues,
+    IReadOnlyDictionary<string, string> CurrentValues,
+    IReadOnlyList<ReportWriterGridDiffCellDto> Cells);
+
+public sealed record ReportWriterGridDiffDto(
+    string GridId,
+    string Title,
+    IReadOnlyList<ReportWriterGridColumnDto> Columns,
+    IReadOnlyList<ReportWriterGridDiffRowDto> Rows,
+    IReadOnlyList<string> Warnings,
+    int AddedRowCount,
+    int RemovedRowCount,
+    int ChangedRowCount,
+    int UnchangedRowCount);
 
 [JsonConverter(typeof(JsonStringEnumConverter<ReportAccessModeDto>))]
 public enum ReportAccessModeDto

--- a/src/Meridian.Reporting/ReportSnapshotDiffEngine.cs
+++ b/src/Meridian.Reporting/ReportSnapshotDiffEngine.cs
@@ -1,0 +1,179 @@
+using System.Globalization;
+using Meridian.Contracts.Workstation;
+
+namespace Meridian.Reporting;
+
+/// <summary>
+/// Produces a deterministic period-over-period comparison between two rendered report-writer grids.
+/// Rows are matched by <see cref="ReportWriterGridRowDto.RowKey"/>; numeric cells carry a signed delta and
+/// direction so the UI can present "prior / current / Δ" columns without re-querying the source data.
+/// </summary>
+public static class ReportSnapshotDiffEngine
+{
+    public static ReportWriterGridDiffDto Diff(
+        ReportWriterGridRenderDto prior,
+        ReportWriterGridRenderDto current)
+    {
+        ArgumentNullException.ThrowIfNull(prior);
+        ArgumentNullException.ThrowIfNull(current);
+
+        var warnings = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        var gridId = string.IsNullOrWhiteSpace(current.GridId) ? prior.GridId : current.GridId;
+        var title = string.IsNullOrWhiteSpace(current.Title) ? prior.Title : current.Title;
+
+        if (!string.Equals(prior.GridId, current.GridId, StringComparison.OrdinalIgnoreCase))
+        {
+            warnings.Add($"Compared grids have different identifiers ('{prior.GridId}' vs '{current.GridId}'); rows are matched by row key only.");
+        }
+
+        var columns = current.Columns is { Count: > 0 } ? current.Columns : prior.Columns;
+        var priorColumnKeys = prior.Columns.Select(static column => column.Key).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var currentColumnKeys = current.Columns.Select(static column => column.Key).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (!priorColumnKeys.SetEquals(currentColumnKeys))
+        {
+            warnings.Add("Compared grids have different column sets; comparison is limited to shared columns where values are present.");
+        }
+
+        var priorByKey = BuildRowLookup(prior.Rows, "prior", warnings);
+        var currentByKey = BuildRowLookup(current.Rows, "current", warnings);
+        var columnKeys = columns.Select(static column => column.Key).ToArray();
+
+        var diffRows = new List<ReportWriterGridDiffRowDto>(current.Rows.Count + prior.Rows.Count);
+        var added = 0;
+        var removed = 0;
+        var changed = 0;
+        var unchanged = 0;
+
+        // Walk current rows in their rendered order so the comparison preserves the live report layout.
+        foreach (var currentRow in current.Rows)
+        {
+            priorByKey.TryGetValue(currentRow.RowKey, out var priorRow);
+            var cells = BuildCells(columnKeys, priorRow?.Values, currentRow.Values);
+            var state = priorRow is null
+                ? ReportWriterDiffRowStateDto.Added
+                : RowsDiffer(cells)
+                    ? ReportWriterDiffRowStateDto.Changed
+                    : ReportWriterDiffRowStateDto.Unchanged;
+
+            switch (state)
+            {
+                case ReportWriterDiffRowStateDto.Added:
+                    added++;
+                    break;
+                case ReportWriterDiffRowStateDto.Changed:
+                    changed++;
+                    break;
+                default:
+                    unchanged++;
+                    break;
+            }
+
+            diffRows.Add(new ReportWriterGridDiffRowDto(
+                currentRow.RowKey,
+                state,
+                priorRow?.Values ?? EmptyValues,
+                currentRow.Values,
+                cells));
+        }
+
+        // Rows present only in the prior snapshot are appended in their original order as removals.
+        foreach (var priorRow in prior.Rows)
+        {
+            if (currentByKey.ContainsKey(priorRow.RowKey))
+            {
+                continue;
+            }
+
+            removed++;
+            diffRows.Add(new ReportWriterGridDiffRowDto(
+                priorRow.RowKey,
+                ReportWriterDiffRowStateDto.Removed,
+                priorRow.Values,
+                EmptyValues,
+                BuildCells(columnKeys, priorRow.Values, currentValues: null)));
+        }
+
+        return new ReportWriterGridDiffDto(
+            gridId,
+            title,
+            columns,
+            diffRows,
+            warnings.ToArray(),
+            added,
+            removed,
+            changed,
+            unchanged);
+    }
+
+    private static readonly IReadOnlyDictionary<string, string> EmptyValues =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    private static Dictionary<string, ReportWriterGridRowDto> BuildRowLookup(
+        IReadOnlyList<ReportWriterGridRowDto> rows,
+        string side,
+        ISet<string> warnings)
+    {
+        var lookup = new Dictionary<string, ReportWriterGridRowDto>(rows.Count, StringComparer.Ordinal);
+        foreach (var row in rows)
+        {
+            if (lookup.ContainsKey(row.RowKey))
+            {
+                warnings.Add($"Duplicate row key '{row.RowKey}' in the {side} snapshot; the first occurrence was used for comparison.");
+                continue;
+            }
+
+            lookup[row.RowKey] = row;
+        }
+
+        return lookup;
+    }
+
+    private static IReadOnlyList<ReportWriterGridDiffCellDto> BuildCells(
+        IReadOnlyList<string> columnKeys,
+        IReadOnlyDictionary<string, string>? priorValues,
+        IReadOnlyDictionary<string, string>? currentValues)
+    {
+        var cells = new List<ReportWriterGridDiffCellDto>(columnKeys.Count);
+        foreach (var column in columnKeys)
+        {
+            var priorValue = priorValues is not null && priorValues.TryGetValue(column, out var priorRaw) ? priorRaw : null;
+            var currentValue = currentValues is not null && currentValues.TryGetValue(column, out var currentRaw) ? currentRaw : null;
+
+            string? delta = null;
+            var direction = ReportWriterDiffDirectionDto.Flat;
+            if (TryParse(priorValue, out var priorNumber) && TryParse(currentValue, out var currentNumber))
+            {
+                var change = currentNumber - priorNumber;
+                delta = FormatDecimal(change);
+                direction = change switch
+                {
+                    > 0m => ReportWriterDiffDirectionDto.Up,
+                    < 0m => ReportWriterDiffDirectionDto.Down,
+                    _ => ReportWriterDiffDirectionDto.Flat
+                };
+            }
+
+            cells.Add(new ReportWriterGridDiffCellDto(column, priorValue, currentValue, delta, direction));
+        }
+
+        return cells;
+    }
+
+    private static bool RowsDiffer(IReadOnlyList<ReportWriterGridDiffCellDto> cells) =>
+        cells.Any(static cell => !string.Equals(cell.PriorValue ?? string.Empty, cell.CurrentValue ?? string.Empty, StringComparison.Ordinal));
+
+    private static bool TryParse(string? value, out decimal number)
+    {
+        if (!string.IsNullOrWhiteSpace(value) &&
+            decimal.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out number))
+        {
+            return true;
+        }
+
+        number = 0m;
+        return false;
+    }
+
+    private static string FormatDecimal(decimal value) =>
+        value.ToString("0.######", CultureInfo.InvariantCulture);
+}

--- a/src/Meridian.Reporting/ReportWriterGridEngine.cs
+++ b/src/Meridian.Reporting/ReportWriterGridEngine.cs
@@ -57,6 +57,9 @@ public static class ReportWriterGridEngine
                 : RenderAggregateRows(grid, filteredRows, dimensions, metrics, formulas, warnings);
         }
 
+        renderedRows = ApplyFormatRules(grid, renderedRows, warnings);
+        var chart = BuildChart(grid, columnList, renderedRows);
+
         var lineage = BuildLineage(rows.Count, filteredRows.Count, renderedRows.Count, dimensions, metrics, formulas, filters);
 
         var dataDictionary = BuildDataDictionary(columnList, renderedRows, lineage);
@@ -71,8 +74,115 @@ public static class ReportWriterGridEngine
             warnings.ToArray(),
             lineage,
             dataDictionary,
-            validationChecks);
+            validationChecks,
+            chart);
     }
+
+    private static IReadOnlyList<ReportWriterGridRowDto> ApplyFormatRules(
+        ReportWriterGridDefinitionDto grid,
+        IReadOnlyList<ReportWriterGridRowDto> rows,
+        ISet<string> warnings)
+    {
+        var rules = NormalizeFormatRules(grid.FormatRules);
+        if (rules.Length == 0 || rows.Count == 0)
+        {
+            return rows;
+        }
+
+        return rows
+            .Select(row =>
+            {
+                Dictionary<string, ReportWriterCellStyleDto>? hints = null;
+                foreach (var rule in rules)
+                {
+                    var probe = new ReportWriterFilterDefinitionDto(rule.Column, rule.Operator, rule.Value, rule.Label);
+                    if (!MatchesFilter(row.Values, probe, warnings))
+                    {
+                        continue;
+                    }
+
+                    hints ??= new Dictionary<string, ReportWriterCellStyleDto>(StringComparer.OrdinalIgnoreCase);
+                    // Later rules win for the same column, mirroring spreadsheet rule precedence.
+                    hints[rule.Column] = rule.Style;
+                }
+
+                return hints is null ? row : row with { StyleHints = hints };
+            })
+            .ToArray();
+    }
+
+    private static ReportWriterChartRenderDto? BuildChart(
+        ReportWriterGridDefinitionDto grid,
+        IReadOnlyList<ReportWriterGridColumnDto> columns,
+        IReadOnlyList<ReportWriterGridRowDto> rows)
+    {
+        var chart = grid.Chart;
+        if (chart is null)
+        {
+            return null;
+        }
+
+        var warnings = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        var title = string.IsNullOrWhiteSpace(chart.Title) ? grid.Title?.Trim() ?? grid.GridId.Trim() : chart.Title.Trim();
+        var categoryField = chart.CategoryField?.Trim() ?? string.Empty;
+        var valueColumns = (chart.ValueColumns ?? [])
+            .Where(static column => !string.IsNullOrWhiteSpace(column))
+            .Select(static column => column.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (categoryField.Length == 0)
+        {
+            warnings.Add($"Chart for grid '{grid.GridId}' has no category field; chart was not rendered.");
+        }
+
+        if (valueColumns.Length == 0)
+        {
+            warnings.Add($"Chart for grid '{grid.GridId}' has no value columns; chart was not rendered.");
+        }
+
+        if (categoryField.Length == 0 || valueColumns.Length == 0)
+        {
+            return new ReportWriterChartRenderDto(chart.Type, title, categoryField, [], [], warnings.ToArray());
+        }
+
+        var labelByKey = columns
+            .GroupBy(static column => column.Key, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(static group => group.Key, static group => group.First().Label, StringComparer.OrdinalIgnoreCase);
+        var categories = rows
+            .Select(row => row.Values.TryGetValue(categoryField, out var value) ? value : string.Empty)
+            .ToArray();
+        var series = new List<ReportWriterChartSeriesDto>(valueColumns.Length);
+        foreach (var column in valueColumns)
+        {
+            if (!labelByKey.ContainsKey(column))
+            {
+                warnings.Add($"Chart value column '{column}' is not a rendered grid column; series read raw row values.");
+            }
+
+            var values = rows
+                .Select(row =>
+                    row.Values.TryGetValue(column, out var raw) &&
+                    decimal.TryParse(raw, NumberStyles.Number, CultureInfo.InvariantCulture, out var number)
+                        ? number
+                        : 0m)
+                .ToArray();
+            series.Add(new ReportWriterChartSeriesDto(column, labelByKey.TryGetValue(column, out var label) ? label : column, values));
+        }
+
+        return new ReportWriterChartRenderDto(chart.Type, title, categoryField, categories, series, warnings.ToArray());
+    }
+
+    private static ReportWriterFormatRuleDto[] NormalizeFormatRules(IReadOnlyList<ReportWriterFormatRuleDto>? rules) =>
+        rules?
+            .Where(static rule => !string.IsNullOrWhiteSpace(rule.Column))
+            .Select(static rule => rule with
+            {
+                Column = rule.Column.Trim(),
+                Value = string.IsNullOrWhiteSpace(rule.Value) ? null : rule.Value.Trim(),
+                Label = string.IsNullOrWhiteSpace(rule.Label) ? null : rule.Label.Trim()
+            })
+            .ToArray() ?? [];
 
     private static IReadOnlyList<ReportWriterGridRowDto> RenderDetailRows(
         ReportWriterGridDefinitionDto grid,

--- a/src/Meridian.Ui/dashboard/src/components/meridian/report-writer-chart-preview.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/report-writer-chart-preview.tsx
@@ -1,0 +1,79 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { buildChartViz } from "@/lib/report-writer-grid-format";
+import type { ReportWriterChartRender } from "@/types";
+
+export interface ReportWriterChartPreviewProps {
+  chart: ReportWriterChartRender;
+  className?: string;
+}
+
+const SERIES_COLORS = [
+  "bg-primary/70",
+  "bg-success/70",
+  "bg-warning/70",
+  "bg-danger/70"
+];
+
+/**
+ * Dependency-free inline chart preview for a rendered report-writer grid. Shows each
+ * category as a row of magnitude bars (one per series), sized by {@link buildChartViz}.
+ * Keeps the report's chart visible alongside its table without pulling in a chart library.
+ */
+export function ReportWriterChartPreview({ chart, className }: ReportWriterChartPreviewProps) {
+  const viz = buildChartViz(chart);
+  if (viz.categories.length === 0 || chart.series.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn("mt-2 rounded-sm border border-border/60 bg-secondary/25 px-2 py-2 text-xs", className)}
+      aria-label={`${chart.title} chart preview`}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="eyebrow-label">Chart · {chart.title}</div>
+        <Badge variant="outline">{chart.type}</Badge>
+      </div>
+      <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
+        {chart.series.map((series, index) => (
+          <span key={series.key} className="flex items-center gap-1 text-[10px] text-muted-foreground">
+            <span className={cn("inline-block h-2 w-2 rounded-sm", SERIES_COLORS[index % SERIES_COLORS.length])} aria-hidden="true" />
+            {series.label || series.key}
+          </span>
+        ))}
+      </div>
+      <ul className="mt-2 space-y-1.5">
+        {viz.categories.map((category) => (
+          <li key={category.category} className="grid grid-cols-[6rem_1fr] items-center gap-2">
+            <span className="truncate text-[11px] text-muted-foreground" title={category.category}>
+              {category.category}
+            </span>
+            <span className="space-y-1">
+              {category.bars.map((bar, index) => (
+                <span key={bar.seriesKey} className="flex items-center gap-2">
+                  <span className="h-2 flex-1 overflow-hidden rounded-sm bg-background/60">
+                    <span
+                      className={cn(
+                        "block h-full rounded-sm",
+                        SERIES_COLORS[index % SERIES_COLORS.length],
+                        bar.isNegative && "opacity-50"
+                      )}
+                      style={{ width: `${bar.widthPct}%` }}
+                    />
+                  </span>
+                  <span className="w-16 text-right font-mono text-[10px] text-foreground" title={String(bar.value)}>
+                    {bar.value}
+                  </span>
+                </span>
+              ))}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {chart.warnings.length > 0 ? (
+        <p className="mt-2 text-[10px] text-warning">{chart.warnings.join("; ")}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/meridian/report-writer-grid-diff-view.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/report-writer-grid-diff-view.tsx
@@ -1,0 +1,94 @@
+import { ArrowDown, ArrowUp } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { ReportWriterDiffRowState, ReportWriterGridDiff } from "@/types";
+
+export interface ReportWriterGridDiffViewProps {
+  diff: ReportWriterGridDiff;
+  maxRows?: number;
+  className?: string;
+}
+
+const STATE_BADGE: Record<ReportWriterDiffRowState, "success" | "warning" | "danger" | "outline"> = {
+  Added: "success",
+  Removed: "danger",
+  Changed: "warning",
+  Unchanged: "outline"
+};
+
+const STATE_LABEL: Record<ReportWriterDiffRowState, string> = {
+  Added: "Added",
+  Removed: "Removed",
+  Changed: "Changed",
+  Unchanged: "Unchanged"
+};
+
+/**
+ * Renders a period-over-period grid diff: one row per matched/added/removed row, with the
+ * current value and a signed delta per numeric column. Consumes the output of
+ * {@link "@/lib/report-writer-grid-diff".buildReportWriterGridDiff}.
+ */
+export function ReportWriterGridDiffView({ diff, maxRows = 6, className }: ReportWriterGridDiffViewProps) {
+  const rows = diff.rows.slice(0, maxRows);
+
+  return (
+    <div className={cn("rounded-sm border border-border/60 bg-background/35 px-2 py-2 text-xs", className)} aria-label={`${diff.title} comparison`}>
+      <p className="text-[11px] text-muted-foreground">
+        {diff.changedRowCount} changed · {diff.addedRowCount} added · {diff.removedRowCount} removed · {diff.unchangedRowCount} unchanged
+      </p>
+      <div className="mt-2 max-h-56 overflow-auto rounded-sm border border-border/60">
+        <table className="min-w-full table-fixed text-left text-xs">
+          <thead className="bg-secondary/40 text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            <tr>
+              <th scope="col" className="min-w-20 px-2 py-1.5 font-semibold">Change</th>
+              {diff.columns.map((column) => (
+                <th key={column.key} scope="col" className="min-w-28 px-2 py-1.5 font-semibold">
+                  <span className="block truncate" title={column.label}>{column.label}</span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={`${row.state}:${row.rowKey}`} className="border-t border-border/50">
+                <td className="px-2 py-1.5">
+                  <Badge variant={STATE_BADGE[row.state]}>{STATE_LABEL[row.state]}</Badge>
+                </td>
+                {row.cells.map((cell) => {
+                  const display = cell.currentValue ?? cell.priorValue ?? "";
+                  const hasDelta = cell.delta !== null && cell.direction !== "Flat";
+                  return (
+                    <td key={`${row.rowKey}:${cell.column}`} className="px-2 py-1.5 font-mono text-foreground">
+                      <span className="flex items-center gap-1">
+                        <span className="block truncate" title={display}>{display}</span>
+                        {hasDelta ? (
+                          <span
+                            className={cn(
+                              "inline-flex items-center gap-0.5 text-[10px]",
+                              cell.direction === "Up" ? "text-success" : "text-danger"
+                            )}
+                            title={`Delta ${cell.delta}`}
+                          >
+                            {cell.direction === "Up" ? (
+                              <ArrowUp className="h-3 w-3" aria-hidden="true" />
+                            ) : (
+                              <ArrowDown className="h-3 w-3" aria-hidden="true" />
+                            )}
+                            {cell.delta}
+                          </span>
+                        ) : null}
+                      </span>
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {diff.warnings.length > 0 ? (
+        <p className="mt-2 text-[10px] text-warning">{diff.warnings.join("; ")}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/meridian/reporting-hub.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/reporting-hub.tsx
@@ -1,0 +1,87 @@
+import { ArrowUpRight, FileText } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import type { ReportingHubModel, ReportingHubTone } from "@/lib/reporting-hub";
+
+export interface ReportingHubProps {
+  model: ReportingHubModel;
+  className?: string;
+}
+
+const toneClasses: Record<ReportingHubTone, string> = {
+  success: "text-success",
+  warning: "text-warning",
+  danger: "text-danger",
+  muted: "text-muted-foreground"
+};
+
+/**
+ * Report-first overview for the reporting workspace: one card per template family
+ * answering "is this current, and where do I open it?" — the question most users
+ * bring to a reporting tool, distinct from the production queue below.
+ */
+export function ReportingHub({ model, className }: ReportingHubProps) {
+  if (model.isEmpty) {
+    return null;
+  }
+
+  return (
+    <section role="region" aria-label="Report hub" className={className}>
+      <Card className="panel-surface">
+        <CardHeader>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="min-w-0">
+              <div className="eyebrow-label">Report hub</div>
+              <CardTitle>Reports by family</CardTitle>
+              <CardDescription>
+                Find a report, confirm it is current, and open the latest output without scanning the run queue.
+              </CardDescription>
+            </div>
+            <Badge variant={model.attentionCount > 0 ? "warning" : "success"}>{model.summaryLabel}</Badge>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <ul className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {model.cards.map((card) => (
+              <li
+                key={card.family}
+                aria-label={card.ariaLabel}
+                className="flex h-full flex-col gap-2 rounded-md border border-border/70 bg-secondary/20 px-3 py-3"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <span className="min-w-0 break-words font-semibold text-foreground">{card.family}</span>
+                  <Badge variant={card.badgeVariant}>{card.statusLabel}</Badge>
+                </div>
+                <p className={cn("text-xs leading-5", toneClasses[card.statusTone])}>{card.approvedAsOfLabel}</p>
+                <p className="text-[11px] leading-4 text-muted-foreground">
+                  {card.detail}
+                  {card.latestRunId ? (
+                    <>
+                      {" · latest "}
+                      <span className="font-mono">{card.latestAsOfLabel}</span>
+                    </>
+                  ) : null}
+                </p>
+                <div className="mt-auto pt-1">
+                  {card.openHref ? (
+                    <Button asChild variant="outline" size="sm">
+                      <a href={card.openHref} aria-label={`${card.openLabel} for ${card.family}`}>
+                        <FileText className="h-4 w-4" aria-hidden="true" />
+                        {card.openLabel}
+                        <ArrowUpRight className="h-3.5 w-3.5" aria-hidden="true" />
+                      </a>
+                    </Button>
+                  ) : (
+                    <span className="text-[11px] italic text-muted-foreground">No output to open yet</span>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/meridian/reporting-period-switcher.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/reporting-period-switcher.tsx
@@ -1,0 +1,113 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import {
+  buildReportingPeriodOptions,
+  formatReportingPeriodLabel,
+  isIsoDate,
+  shiftIsoDate
+} from "@/lib/reporting-periods";
+
+export interface ReportingPeriodSwitcherProps {
+  asOfDate: string;
+  onSelect: (asOfDate: string) => void;
+  disabled?: boolean;
+  className?: string;
+  label?: string;
+}
+
+/**
+ * Compact "as of" period control: nudge the reporting as-of date by month, jump to a
+ * preset period (prev day/month/quarter/year), or pick a custom date — without leaving
+ * the run surface. The component is presentational; all period math lives in
+ * {@link "@/lib/reporting-periods"}.
+ */
+export function ReportingPeriodSwitcher({
+  asOfDate,
+  onSelect,
+  disabled = false,
+  className,
+  label = "Run as of"
+}: ReportingPeriodSwitcherProps) {
+  const valid = isIsoDate(asOfDate);
+  const presets = buildReportingPeriodOptions(asOfDate).filter((option) => option.id !== "current");
+
+  function handleStep(amount: number) {
+    if (!valid || disabled) {
+      return;
+    }
+
+    onSelect(shiftIsoDate(asOfDate, "month", amount));
+  }
+
+  return (
+    <div
+      role="group"
+      aria-label="Reporting period switcher"
+      className={cn(
+        "flex flex-wrap items-center gap-2 rounded-md border border-border/70 bg-background/25 px-3 py-2",
+        className
+      )}
+    >
+      <span className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">{label}</span>
+      <span className="font-mono text-sm text-foreground" aria-live="polite">
+        {valid ? formatReportingPeriodLabel(asOfDate) : asOfDate}
+      </span>
+      <span className="flex items-center gap-1">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Previous month"
+          disabled={!valid || disabled}
+          onClick={() => handleStep(-1)}
+        >
+          <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Next month"
+          disabled={!valid || disabled}
+          onClick={() => handleStep(1)}
+        >
+          <ChevronRight className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      </span>
+      <span className="flex flex-wrap items-center gap-1">
+        {presets.map((option) => (
+          <Button
+            key={option.id}
+            type="button"
+            variant="outline"
+            size="sm"
+            aria-label={`${option.label}: ${option.description}`}
+            aria-pressed={asOfDate === option.asOfDate}
+            disabled={disabled}
+            onClick={() => onSelect(option.asOfDate)}
+          >
+            {option.label}
+          </Button>
+        ))}
+      </span>
+      <label className="flex items-center gap-1">
+        <span className="sr-only">Custom as-of date</span>
+        <Input
+          type="date"
+          value={valid ? asOfDate : ""}
+          disabled={disabled}
+          aria-label="Custom as-of date"
+          className="h-8 w-[9.5rem]"
+          onChange={(event) => {
+            const next = event.target.value;
+            if (isIsoDate(next)) {
+              onSelect(next);
+            }
+          }}
+        />
+      </label>
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/lib/report-writer-grid-diff.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/report-writer-grid-diff.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { buildReportWriterGridDiff } from "@/lib/report-writer-grid-diff";
+import type { ReportWriterGridColumn, ReportWriterGridRender, ReportWriterGridRow } from "@/types";
+
+function column(key: string): ReportWriterGridColumn {
+  return { key, label: key, role: "dimension" };
+}
+
+function row(rowKey: string, values: Record<string, string>): ReportWriterGridRow {
+  return { rowKey, values };
+}
+
+function render(
+  gridId: string,
+  columns: ReportWriterGridColumn[],
+  rows: ReportWriterGridRow[]
+): ReportWriterGridRender {
+  return { gridId, title: gridId, kind: "Pivot", columns, rows, warnings: [] };
+}
+
+describe("report-writer grid diff", () => {
+  it("classifies added, removed, changed, and unchanged rows with deltas", () => {
+    const prior = render("holdings", [column("sector"), column("marketValue")], [
+      row("Technology", { sector: "Technology", marketValue: "100" }),
+      row("Rates", { sector: "Rates", marketValue: "40" }),
+      row("Cash", { sector: "Cash", marketValue: "25" })
+    ]);
+    const current = render("holdings", [column("sector"), column("marketValue")], [
+      row("Technology", { sector: "Technology", marketValue: "150" }),
+      row("Rates", { sector: "Rates", marketValue: "40" }),
+      row("Credit", { sector: "Credit", marketValue: "60" })
+    ]);
+
+    const diff = buildReportWriterGridDiff(prior, current);
+
+    expect(diff.changedRowCount).toBe(1);
+    expect(diff.unchangedRowCount).toBe(1);
+    expect(diff.addedRowCount).toBe(1);
+    expect(diff.removedRowCount).toBe(1);
+    expect(diff.warnings).toHaveLength(0);
+
+    const technology = diff.rows.find((item) => item.rowKey === "Technology")!;
+    expect(technology.state).toBe("Changed");
+    const technologyDelta = technology.cells.find((cell) => cell.column === "marketValue")!;
+    expect(technologyDelta.priorValue).toBe("100");
+    expect(technologyDelta.currentValue).toBe("150");
+    expect(technologyDelta.delta).toBe("50");
+    expect(technologyDelta.direction).toBe("Up");
+
+    expect(diff.rows.find((item) => item.rowKey === "Rates")!.state).toBe("Unchanged");
+    expect(diff.rows.find((item) => item.rowKey === "Credit")!.state).toBe("Added");
+
+    const cash = diff.rows.find((item) => item.rowKey === "Cash")!;
+    expect(cash.state).toBe("Removed");
+    expect(cash.cells.find((cell) => cell.column === "marketValue")!.currentValue).toBeNull();
+  });
+
+  it("orders current rows before removed rows", () => {
+    const prior = render("g", [column("sector"), column("marketValue")], [
+      row("Cash", { sector: "Cash", marketValue: "25" }),
+      row("Technology", { sector: "Technology", marketValue: "100" })
+    ]);
+    const current = render("g", [column("sector"), column("marketValue")], [
+      row("Technology", { sector: "Technology", marketValue: "100" })
+    ]);
+
+    const diff = buildReportWriterGridDiff(prior, current);
+
+    expect(diff.rows.map((item) => item.rowKey)).toEqual(["Technology", "Cash"]);
+    expect(diff.rows[diff.rows.length - 1].state).toBe("Removed");
+  });
+
+  it("warns when the column sets differ", () => {
+    const prior = render("g", [column("sector"), column("marketValue")], [
+      row("Technology", { sector: "Technology", marketValue: "100" })
+    ]);
+    const current = render("g", [column("sector"), column("pnl")], [
+      row("Technology", { sector: "Technology", pnl: "10" })
+    ]);
+
+    const diff = buildReportWriterGridDiff(prior, current);
+
+    expect(diff.warnings.some((warning) => warning.toLowerCase().includes("different column sets"))).toBe(true);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/lib/report-writer-grid-diff.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/report-writer-grid-diff.ts
@@ -1,0 +1,167 @@
+/**
+ * Client-side period-over-period diff of two rendered report-writer grids.
+ *
+ * Mirrors the server-side ReportSnapshotDiffEngine (Meridian.Reporting) so the
+ * browser can show "prior / current / Δ" comparisons without a round trip: rows
+ * are matched by row key, numeric cells carry a signed delta and direction, and
+ * rows are classified Added / Removed / Changed / Unchanged.
+ */
+import type {
+  ReportWriterDiffDirection,
+  ReportWriterDiffRowState,
+  ReportWriterGridColumn,
+  ReportWriterGridDiff,
+  ReportWriterGridDiffCell,
+  ReportWriterGridDiffRow,
+  ReportWriterGridRender,
+  ReportWriterGridRow
+} from "@/types";
+
+const EMPTY_VALUES: Record<string, string> = {};
+
+function tryParseNumber(value: string | null | undefined): number | null {
+  if (value == null) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    return null;
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function formatDelta(value: number): string {
+  // Match the server formatter's 6-decimal precision without trailing zeros.
+  return String(Math.round(value * 1e6) / 1e6);
+}
+
+function buildRowLookup(
+  rows: ReportWriterGridRow[],
+  side: string,
+  warnings: Set<string>
+): Map<string, ReportWriterGridRow> {
+  const lookup = new Map<string, ReportWriterGridRow>();
+  for (const row of rows) {
+    if (lookup.has(row.rowKey)) {
+      warnings.add(`Duplicate row key '${row.rowKey}' in the ${side} snapshot; the first occurrence was used for comparison.`);
+      continue;
+    }
+
+    lookup.set(row.rowKey, row);
+  }
+
+  return lookup;
+}
+
+function buildCells(
+  columnKeys: string[],
+  priorValues: Record<string, string> | null,
+  currentValues: Record<string, string> | null
+): ReportWriterGridDiffCell[] {
+  return columnKeys.map((column) => {
+    const priorValue = priorValues && column in priorValues ? priorValues[column] : null;
+    const currentValue = currentValues && column in currentValues ? currentValues[column] : null;
+
+    let delta: string | null = null;
+    let direction: ReportWriterDiffDirection = "Flat";
+    const priorNumber = tryParseNumber(priorValue);
+    const currentNumber = tryParseNumber(currentValue);
+    if (priorNumber !== null && currentNumber !== null) {
+      const change = currentNumber - priorNumber;
+      delta = formatDelta(change);
+      direction = change > 0 ? "Up" : change < 0 ? "Down" : "Flat";
+    }
+
+    return { column, priorValue, currentValue, delta, direction };
+  });
+}
+
+function rowsDiffer(cells: ReportWriterGridDiffCell[]): boolean {
+  return cells.some((cell) => (cell.priorValue ?? "") !== (cell.currentValue ?? ""));
+}
+
+export function buildReportWriterGridDiff(
+  prior: ReportWriterGridRender,
+  current: ReportWriterGridRender
+): ReportWriterGridDiff {
+  const warnings = new Set<string>();
+  const gridId = current.gridId.trim().length > 0 ? current.gridId : prior.gridId;
+  const title = current.title.trim().length > 0 ? current.title : prior.title;
+
+  if (current.gridId.toLowerCase() !== prior.gridId.toLowerCase()) {
+    warnings.add(`Compared grids have different identifiers ('${prior.gridId}' vs '${current.gridId}'); rows are matched by row key only.`);
+  }
+
+  const columns: ReportWriterGridColumn[] = current.columns.length > 0 ? current.columns : prior.columns;
+  const priorColumnKeys = new Set(prior.columns.map((column) => column.key.toLowerCase()));
+  const currentColumnKeys = new Set(current.columns.map((column) => column.key.toLowerCase()));
+  if (priorColumnKeys.size !== currentColumnKeys.size || [...priorColumnKeys].some((key) => !currentColumnKeys.has(key))) {
+    warnings.add("Compared grids have different column sets; comparison is limited to shared columns where values are present.");
+  }
+
+  const priorByKey = buildRowLookup(prior.rows, "prior", warnings);
+  const currentByKey = buildRowLookup(current.rows, "current", warnings);
+  const columnKeys = columns.map((column) => column.key);
+
+  const rows: ReportWriterGridDiffRow[] = [];
+  let added = 0;
+  let removed = 0;
+  let changed = 0;
+  let unchanged = 0;
+
+  // Walk current rows in rendered order so the diff preserves the live layout.
+  for (const currentRow of current.rows) {
+    const priorRow = priorByKey.get(currentRow.rowKey) ?? null;
+    const cells = buildCells(columnKeys, priorRow?.values ?? null, currentRow.values);
+    let state: ReportWriterDiffRowState;
+    if (!priorRow) {
+      state = "Added";
+      added += 1;
+    } else if (rowsDiffer(cells)) {
+      state = "Changed";
+      changed += 1;
+    } else {
+      state = "Unchanged";
+      unchanged += 1;
+    }
+
+    rows.push({
+      rowKey: currentRow.rowKey,
+      state,
+      priorValues: priorRow?.values ?? EMPTY_VALUES,
+      currentValues: currentRow.values,
+      cells
+    });
+  }
+
+  // Rows only present in the prior snapshot are appended as removals.
+  for (const priorRow of prior.rows) {
+    if (currentByKey.has(priorRow.rowKey)) {
+      continue;
+    }
+
+    removed += 1;
+    rows.push({
+      rowKey: priorRow.rowKey,
+      state: "Removed",
+      priorValues: priorRow.values,
+      currentValues: EMPTY_VALUES,
+      cells: buildCells(columnKeys, priorRow.values, null)
+    });
+  }
+
+  return {
+    gridId,
+    title,
+    columns,
+    rows,
+    warnings: [...warnings],
+    addedRowCount: added,
+    removedRowCount: removed,
+    changedRowCount: changed,
+    unchangedRowCount: unchanged
+  };
+}

--- a/src/Meridian.Ui/dashboard/src/lib/report-writer-grid-format.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/report-writer-grid-format.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { buildChartViz, cellStyleClassName, resolveCellStyle } from "@/lib/report-writer-grid-format";
+import type { ReportWriterChartRender } from "@/types";
+
+describe("report-writer grid formatting", () => {
+  it("resolves cell style hints, treating None and missing as no style", () => {
+    const row = { styleHints: { pnl: "Danger" as const, weight: "None" as const } };
+    expect(resolveCellStyle(row, "pnl")).toBe("Danger");
+    expect(resolveCellStyle(row, "weight")).toBeNull();
+    expect(resolveCellStyle(row, "missing")).toBeNull();
+    expect(resolveCellStyle({}, "pnl")).toBeNull();
+  });
+
+  it("maps cell styles to theme classes", () => {
+    expect(cellStyleClassName("Danger")).toContain("text-danger");
+    expect(cellStyleClassName("Success")).toContain("text-success");
+    expect(cellStyleClassName("Warning")).toContain("text-warning");
+    expect(cellStyleClassName("Info")).toContain("text-primary");
+    expect(cellStyleClassName("None")).toBe("");
+    expect(cellStyleClassName(null)).toBe("");
+  });
+
+  it("normalizes chart geometry relative to the largest absolute value", () => {
+    const chart: ReportWriterChartRender = {
+      type: "Bar",
+      title: "Sector",
+      categoryField: "sector",
+      categories: ["Technology", "Rates"],
+      series: [
+        { key: "marketValue", label: "Market value", values: [100, 40] },
+        { key: "pnl", label: "PnL", values: [10, -2] }
+      ],
+      warnings: []
+    };
+
+    const viz = buildChartViz(chart);
+
+    expect(viz.maxAbs).toBe(100);
+    expect(viz.hasNegative).toBe(true);
+    expect(viz.categories).toHaveLength(2);
+
+    const technology = viz.categories[0];
+    expect(technology.category).toBe("Technology");
+    expect(technology.bars[0]).toMatchObject({ seriesKey: "marketValue", value: 100, widthPct: 100, isNegative: false });
+    expect(technology.bars[1]).toMatchObject({ seriesKey: "pnl", value: 10, widthPct: 10 });
+
+    const rates = viz.categories[1];
+    expect(rates.bars[1]).toMatchObject({ value: -2, widthPct: 2, isNegative: true });
+  });
+
+  it("handles an all-zero chart without dividing by zero", () => {
+    const chart: ReportWriterChartRender = {
+      type: "Line",
+      title: "Flat",
+      categoryField: "month",
+      categories: ["Jan", ""],
+      series: [{ key: "v", label: "V", values: [0, 0] }],
+      warnings: []
+    };
+
+    const viz = buildChartViz(chart);
+    expect(viz.maxAbs).toBe(0);
+    expect(viz.hasNegative).toBe(false);
+    expect(viz.categories[0].bars[0].widthPct).toBe(0);
+    expect(viz.categories[1].category).toBe("(blank)");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/lib/report-writer-grid-format.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/report-writer-grid-format.ts
@@ -1,0 +1,95 @@
+/**
+ * Presentation helpers for rendering report-writer grids: conditional-formatting
+ * cell styling and a dependency-free inline chart geometry. Pure and unit-tested
+ * so the React table/chart components stay thin.
+ */
+import type {
+  ReportWriterCellStyle,
+  ReportWriterChartRender,
+  ReportWriterGridRow
+} from "@/types";
+
+const CELL_STYLE_CLASSES: Record<Exclude<ReportWriterCellStyle, "None">, string> = {
+  Success: "bg-success/10 text-success",
+  Warning: "bg-warning/12 text-warning",
+  Danger: "bg-danger/10 text-danger",
+  // No dedicated "info" palette token in the dashboard theme; primary reads as informational.
+  Info: "bg-primary/10 text-primary"
+};
+
+export function resolveCellStyle(
+  row: Pick<ReportWriterGridRow, "styleHints">,
+  columnKey: string
+): ReportWriterCellStyle | null {
+  const hint = row.styleHints?.[columnKey];
+  return hint && hint !== "None" ? hint : null;
+}
+
+export function cellStyleClassName(style: ReportWriterCellStyle | null | undefined): string {
+  if (!style || style === "None") {
+    return "";
+  }
+
+  return CELL_STYLE_CLASSES[style];
+}
+
+export interface ChartBar {
+  seriesKey: string;
+  seriesLabel: string;
+  value: number;
+  /** Magnitude as a 0-100 percentage of the largest absolute value across the chart. */
+  widthPct: number;
+  isNegative: boolean;
+}
+
+export interface ChartCategory {
+  category: string;
+  bars: ChartBar[];
+}
+
+export interface ChartViz {
+  categories: ChartCategory[];
+  maxAbs: number;
+  hasNegative: boolean;
+}
+
+/**
+ * Normalizes a chart render into bar geometry: one group per category, one bar per
+ * series, each sized relative to the largest absolute value in the chart. Works as a
+ * compact magnitude view for every chart type the engine emits (bar, line, area, pie).
+ */
+export function buildChartViz(chart: ReportWriterChartRender): ChartViz {
+  const categories = chart.categories ?? [];
+  const series = chart.series ?? [];
+
+  let maxAbs = 0;
+  let hasNegative = false;
+  for (const seriesItem of series) {
+    for (const value of seriesItem.values ?? []) {
+      const magnitude = Math.abs(value);
+      if (magnitude > maxAbs) {
+        maxAbs = magnitude;
+      }
+
+      if (value < 0) {
+        hasNegative = true;
+      }
+    }
+  }
+
+  const built: ChartCategory[] = categories.map((category, index) => ({
+    category: category.length > 0 ? category : "(blank)",
+    bars: series.map((seriesItem) => {
+      const value = seriesItem.values?.[index] ?? 0;
+      return {
+        seriesKey: seriesItem.key,
+        seriesLabel: seriesItem.label || seriesItem.key,
+        value,
+        widthPct: maxAbs === 0 ? 0 : Math.round((Math.abs(value) / maxAbs) * 100),
+        isNegative: value < 0
+      };
+    })
+  }));
+
+  return { categories: built, maxAbs, hasNegative };
+}

--- a/src/Meridian.Ui/dashboard/src/lib/reporting-hub.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/reporting-hub.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReportingHubModel,
+  type ReportingHubRunInput,
+  type ReportingHubTemplateInput
+} from "@/lib/reporting-hub";
+
+function run(overrides: Partial<ReportingHubRunInput>): ReportingHubRunInput {
+  return {
+    templateId: "tmpl",
+    family: "Performance",
+    status: "Released",
+    asOfDateLabel: "2026-06-30",
+    runIdLabel: "run-1",
+    drilldownLinks: [],
+    ...overrides
+  };
+}
+
+function template(overrides: Partial<ReportingHubTemplateInput>): ReportingHubTemplateInput {
+  return {
+    templateName: "perf",
+    name: "Performance Report",
+    family: "Performance",
+    ...overrides
+  };
+}
+
+describe("reporting hub model", () => {
+  it("groups runs by family, picks the most recent run, and surfaces approved as-of", () => {
+    const model = buildReportingHubModel(
+      [
+        run({ family: "Performance", status: "Draft", asOfDateLabel: "2026-06-30", runIdLabel: "perf-jun" }),
+        run({ family: "Performance", status: "Released", asOfDateLabel: "2026-05-31", runIdLabel: "perf-may" }),
+        run({ family: "Holdings", status: "Approved", asOfDateLabel: "2026-06-30", runIdLabel: "hold-jun" })
+      ],
+      [
+        template({ family: "Performance", templateName: "perf" }),
+        template({ family: "Holdings", templateName: "holdings", name: "Holdings Report" })
+      ]
+    );
+
+    expect(model.cards.map((card) => card.family)).toEqual(["Holdings", "Performance"]);
+
+    const performance = model.cards.find((card) => card.family === "Performance")!;
+    // Latest run is the June draft; readiness reflects that, but the approved line points at May.
+    expect(performance.latestRunId).toBe("perf-jun");
+    expect(performance.readiness).toBe("Draft");
+    expect(performance.needsAttention).toBe(true);
+    expect(performance.approvedAsOfLabel).toBe("Approved as of May 31, 2026");
+    expect(performance.runCount).toBe(2);
+
+    const holdings = model.cards.find((card) => card.family === "Holdings")!;
+    expect(holdings.readiness).toBe("Approved");
+    expect(holdings.isCurrent).toBe(true);
+    expect(holdings.approvedAsOfLabel).toBe("Approved as of Jun 30, 2026");
+  });
+
+  it("resolves the open link from the latest run's first browser-navigable drilldown", () => {
+    const model = buildReportingHubModel(
+      [
+        run({
+          family: "Performance",
+          status: "Released",
+          asOfDateLabel: "2026-06-30",
+          drilldownLinks: [
+            { href: "/api/raw", label: "Manifest", isBrowserNavigable: false },
+            { href: "/reporting/runs/perf-jun", label: "Run", isBrowserNavigable: true }
+          ]
+        })
+      ],
+      [template({ family: "Performance" })]
+    );
+
+    const performance = model.cards[0];
+    expect(performance.openHref).toBe("/reporting/runs/perf-jun");
+    expect(performance.openLabel).toBe("Open latest output");
+  });
+
+  it("represents families that have templates but no runs", () => {
+    const model = buildReportingHubModel([], [template({ family: "Audit", templateName: "audit-pack" })]);
+
+    const audit = model.cards[0];
+    expect(audit.readiness).toBe("NoRuns");
+    expect(audit.runCount).toBe(0);
+    expect(audit.openHref).toBeNull();
+    expect(audit.latestAsOfLabel).toBe("—");
+    expect(audit.approvedAsOfLabel).toBe("No approved output yet");
+    expect(audit.needsAttention).toBe(true);
+  });
+
+  it("summarizes current vs. attention counts", () => {
+    const model = buildReportingHubModel(
+      [
+        run({ family: "Performance", status: "Released" }),
+        run({ family: "Holdings", status: "Failed" })
+      ],
+      [
+        template({ family: "Performance" }),
+        template({ family: "Holdings", templateName: "holdings" })
+      ]
+    );
+
+    expect(model.totalFamilies).toBe(2);
+    expect(model.currentCount).toBe(1);
+    expect(model.attentionCount).toBe(1);
+    expect(model.summaryLabel).toBe("1 of 2 families current · 1 need attention");
+  });
+
+  it("is empty when nothing is configured", () => {
+    const model = buildReportingHubModel([], []);
+    expect(model.isEmpty).toBe(true);
+    expect(model.summaryLabel).toBe("No report families are configured yet.");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/lib/reporting-hub.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/reporting-hub.ts
@@ -1,0 +1,206 @@
+/**
+ * Builds the "Report Hub" overview model for the reporting workspace.
+ *
+ * The reporting screen is organized around the production queue (runs awaiting
+ * approval / delivery), which suits the ops lead but not the analyst or PM who
+ * just wants to answer "which report do I need, is it current, and where do I
+ * open it?". This module derives a report-first model grouped by template family
+ * — the navigation unit users actually think in — with a readiness signal and a
+ * direct link to the latest output.
+ *
+ * It is pure: callers pass the already-shaped view-model rows (or any structural
+ * subset), and it returns a deterministic model that is trivial to unit-test.
+ */
+import { compareIsoDate, formatReportingPeriodLabel } from "@/lib/reporting-periods";
+
+export type ReportingHubReadiness =
+  | "Released"
+  | "Approved"
+  | "InReview"
+  | "Draft"
+  | "Failed"
+  | "NoRuns";
+
+export type ReportingHubTone = "success" | "warning" | "danger" | "muted";
+export type ReportingHubBadgeVariant = "success" | "warning" | "danger" | "outline";
+
+export interface ReportingHubRunInput {
+  templateId: string;
+  family: string;
+  status: string;
+  asOfDateLabel: string;
+  runIdLabel: string;
+  drilldownLinks: ReadonlyArray<{
+    href: string;
+    label: string;
+    isBrowserNavigable: boolean;
+  }>;
+}
+
+export interface ReportingHubTemplateInput {
+  templateName: string;
+  name: string;
+  family: string;
+}
+
+export interface ReportingHubCard {
+  family: string;
+  templateCount: number;
+  runCount: number;
+  readiness: ReportingHubReadiness;
+  statusLabel: string;
+  statusTone: ReportingHubTone;
+  badgeVariant: ReportingHubBadgeVariant;
+  latestRunId: string | null;
+  latestAsOfLabel: string;
+  latestStatusLabel: string | null;
+  approvedAsOfLabel: string;
+  isCurrent: boolean;
+  needsAttention: boolean;
+  openHref: string | null;
+  openLabel: string | null;
+  detail: string;
+  ariaLabel: string;
+}
+
+export interface ReportingHubModel {
+  cards: ReportingHubCard[];
+  totalFamilies: number;
+  currentCount: number;
+  attentionCount: number;
+  summaryLabel: string;
+  isEmpty: boolean;
+}
+
+interface ReadinessPresentation {
+  readiness: ReportingHubReadiness;
+  statusLabel: string;
+  statusTone: ReportingHubTone;
+  badgeVariant: ReportingHubBadgeVariant;
+}
+
+function presentReadiness(status: string | null): ReadinessPresentation {
+  switch ((status ?? "").trim().toLowerCase()) {
+    case "released":
+      return { readiness: "Released", statusLabel: "Released", statusTone: "success", badgeVariant: "success" };
+    case "approved":
+      return { readiness: "Approved", statusLabel: "Approved", statusTone: "success", badgeVariant: "success" };
+    case "inreview":
+    case "in review":
+      return { readiness: "InReview", statusLabel: "In review", statusTone: "warning", badgeVariant: "warning" };
+    case "draft":
+      return { readiness: "Draft", statusLabel: "Draft", statusTone: "muted", badgeVariant: "outline" };
+    case "failed":
+      return { readiness: "Failed", statusLabel: "Failed", statusTone: "danger", badgeVariant: "danger" };
+    default:
+      return { readiness: "NoRuns", statusLabel: "No runs yet", statusTone: "muted", badgeVariant: "outline" };
+  }
+}
+
+function isApprovedStatus(status: string): boolean {
+  const normalized = status.trim().toLowerCase();
+  return normalized === "approved" || normalized === "released";
+}
+
+// Most recent first: ISO as-of dates compare correctly; non-ISO fallbacks sort stably after.
+function byMostRecent(left: ReportingHubRunInput, right: ReportingHubRunInput): number {
+  return compareIsoDate(right.asOfDateLabel, left.asOfDateLabel);
+}
+
+function resolveOpenLink(run: ReportingHubRunInput): { href: string; label: string } | null {
+  const navigable = run.drilldownLinks.find((link) => link.isBrowserNavigable && link.href.trim().length > 0);
+  if (!navigable) {
+    return null;
+  }
+
+  return { href: navigable.href, label: "Open latest output" };
+}
+
+function countUnit(count: number, singular: string): string {
+  return `${count} ${singular}${count === 1 ? "" : "s"}`;
+}
+
+function buildCard(
+  family: string,
+  runs: ReportingHubRunInput[],
+  templateNames: Set<string>
+): ReportingHubCard {
+  const sortedRuns = [...runs].sort(byMostRecent);
+  const latestRun = sortedRuns[0] ?? null;
+  const latestApproved = sortedRuns.find((run) => isApprovedStatus(run.status)) ?? null;
+  const presentation = presentReadiness(latestRun?.status ?? null);
+  const openLink = latestRun ? resolveOpenLink(latestRun) : null;
+
+  const isCurrent = presentation.readiness === "Released" || presentation.readiness === "Approved";
+  const approvedAsOfLabel = latestApproved
+    ? `Approved as of ${formatReportingPeriodLabel(latestApproved.asOfDateLabel)}`
+    : "No approved output yet";
+  const latestAsOfLabel = latestRun ? formatReportingPeriodLabel(latestRun.asOfDateLabel) : "—";
+  const detail = `${countUnit(templateNames.size, "template")} · ${countUnit(runs.length, "run")}`;
+
+  return {
+    family,
+    templateCount: templateNames.size,
+    runCount: runs.length,
+    readiness: presentation.readiness,
+    statusLabel: presentation.statusLabel,
+    statusTone: presentation.statusTone,
+    badgeVariant: presentation.badgeVariant,
+    latestRunId: latestRun?.runIdLabel ?? null,
+    latestAsOfLabel,
+    latestStatusLabel: latestRun ? presentation.statusLabel : null,
+    approvedAsOfLabel,
+    isCurrent,
+    needsAttention: !isCurrent,
+    openHref: openLink?.href ?? null,
+    openLabel: openLink?.label ?? null,
+    detail,
+    ariaLabel: `${family} reporting family: ${presentation.statusLabel}. ${approvedAsOfLabel}. ${detail}.`
+  };
+}
+
+export function buildReportingHubModel(
+  runs: readonly ReportingHubRunInput[],
+  templates: readonly ReportingHubTemplateInput[]
+): ReportingHubModel {
+  const runsByFamily = new Map<string, ReportingHubRunInput[]>();
+  const templatesByFamily = new Map<string, Set<string>>();
+
+  for (const template of templates) {
+    const family = template.family?.trim() || "Uncategorized";
+    const names = templatesByFamily.get(family) ?? new Set<string>();
+    names.add(template.templateName || template.name);
+    templatesByFamily.set(family, names);
+  }
+
+  for (const run of runs) {
+    const family = run.family?.trim() || "Uncategorized";
+    const familyRuns = runsByFamily.get(family) ?? [];
+    familyRuns.push(run);
+    runsByFamily.set(family, familyRuns);
+    if (!templatesByFamily.has(family)) {
+      templatesByFamily.set(family, new Set<string>());
+    }
+  }
+
+  const families = [...templatesByFamily.keys()].sort((left, right) => left.localeCompare(right));
+  const cards = families.map((family) =>
+    buildCard(family, runsByFamily.get(family) ?? [], templatesByFamily.get(family) ?? new Set<string>())
+  );
+
+  const currentCount = cards.filter((card) => card.isCurrent).length;
+  const attentionCount = cards.length - currentCount;
+  const familyWord = cards.length === 1 ? "family" : "families";
+  const summaryLabel = cards.length === 0
+    ? "No report families are configured yet."
+    : `${currentCount} of ${cards.length} ${familyWord} current · ${attentionCount} need attention`;
+
+  return {
+    cards,
+    totalFamilies: cards.length,
+    currentCount,
+    attentionCount,
+    summaryLabel,
+    isEmpty: cards.length === 0
+  };
+}

--- a/src/Meridian.Ui/dashboard/src/lib/reporting-periods.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/reporting-periods.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReportingPeriodOptions,
+  compareIsoDate,
+  formatReportingPeriodLabel,
+  isIsoDate,
+  parseIsoDate,
+  shiftIsoDate,
+  todayIsoDate
+} from "@/lib/reporting-periods";
+
+describe("reporting period math", () => {
+  it("validates ISO calendar dates including month-length bounds", () => {
+    expect(isIsoDate("2026-06-24")).toBe(true);
+    expect(isIsoDate("2024-02-29")).toBe(true);
+    expect(isIsoDate("2026-02-29")).toBe(false);
+    expect(isIsoDate("2026-13-01")).toBe(false);
+    expect(isIsoDate("2026-06-31")).toBe(false);
+    expect(isIsoDate("not-a-date")).toBe(false);
+    expect(parseIsoDate("2026-06-24")).toEqual({ year: 2026, month: 6, day: 24 });
+  });
+
+  it("shifts by calendar days across month and year boundaries", () => {
+    expect(shiftIsoDate("2026-01-01", "day", -1)).toBe("2025-12-31");
+    expect(shiftIsoDate("2026-06-24", "day", 7)).toBe("2026-07-01");
+  });
+
+  it("clamps the day when shifting by month, quarter, and year", () => {
+    expect(shiftIsoDate("2026-03-31", "month", -1)).toBe("2026-02-28");
+    expect(shiftIsoDate("2024-03-31", "month", -1)).toBe("2024-02-29");
+    expect(shiftIsoDate("2026-06-30", "month", -1)).toBe("2026-05-30");
+    expect(shiftIsoDate("2026-12-31", "quarter", -1)).toBe("2026-09-30");
+    expect(shiftIsoDate("2024-02-29", "year", -1)).toBe("2023-02-28");
+  });
+
+  it("throws on an invalid anchor", () => {
+    expect(() => shiftIsoDate("2026-02-30", "month", -1)).toThrow();
+  });
+
+  it("formats period labels in UTC", () => {
+    expect(formatReportingPeriodLabel("2026-05-31")).toBe("May 31, 2026");
+    expect(formatReportingPeriodLabel("invalid")).toBe("invalid");
+  });
+
+  it("compares ISO dates without timezone effects", () => {
+    expect(compareIsoDate("2026-05-31", "2026-06-01")).toBeLessThan(0);
+    expect(compareIsoDate("2026-06-01", "2026-05-31")).toBeGreaterThan(0);
+    expect(compareIsoDate("2026-06-01", "2026-06-01")).toBe(0);
+  });
+
+  it("builds quick-pick options anchored on the current as-of date", () => {
+    const options = buildReportingPeriodOptions("2026-06-30");
+    expect(options.map((option) => option.id)).toEqual([
+      "current",
+      "prev-day",
+      "prev-month",
+      "prev-quarter",
+      "prev-year"
+    ]);
+    expect(options[0].asOfDate).toBe("2026-06-30");
+    expect(options.find((option) => option.id === "prev-month")?.asOfDate).toBe("2026-05-30");
+    expect(options.find((option) => option.id === "prev-quarter")?.asOfDate).toBe("2026-03-30");
+    expect(options.find((option) => option.id === "prev-year")?.asOfDate).toBe("2025-06-30");
+    expect(options.find((option) => option.id === "prev-month")?.description).toBe("May 30, 2026");
+  });
+
+  it("returns no options for an invalid anchor", () => {
+    expect(buildReportingPeriodOptions("nonsense")).toEqual([]);
+  });
+
+  it("derives today's ISO date in UTC from a fixed clock", () => {
+    expect(todayIsoDate(new Date("2026-06-24T23:30:00Z"))).toBe("2026-06-24");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/lib/reporting-periods.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/reporting-periods.ts
@@ -1,0 +1,159 @@
+/**
+ * Pure period math for the reporting "as of" period switcher.
+ *
+ * All functions operate on ISO calendar dates (yyyy-mm-dd) in UTC so that period
+ * shifts are deterministic and free of local-timezone drift. Month/quarter/year
+ * shifts clamp the day to the target month length (e.g. Mar 31 - 1 month = Feb 28/29),
+ * matching how finance users expect period-end as-of dates to behave.
+ */
+
+export type ReportingPeriodUnit = "day" | "month" | "quarter" | "year";
+
+export interface ReportingPeriodOption {
+  id: string;
+  label: string;
+  asOfDate: string;
+  description: string;
+}
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const PERIOD_LABEL_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  timeZone: "UTC"
+});
+
+function pad2(value: number): string {
+  return value.toString().padStart(2, "0");
+}
+
+function pad4(value: number): string {
+  return value.toString().padStart(4, "0");
+}
+
+function daysInMonth(year: number, month: number): number {
+  // month is 1-based; day 0 of the next month is the last day of this month.
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+function toIsoDate(year: number, month: number, day: number): string {
+  return `${pad4(year)}-${pad2(month)}-${pad2(day)}`;
+}
+
+export interface ParsedIsoDate {
+  year: number;
+  month: number;
+  day: number;
+}
+
+export function parseIsoDate(value: string): ParsedIsoDate | null {
+  if (typeof value !== "string" || !ISO_DATE_PATTERN.test(value)) {
+    return null;
+  }
+
+  const [year, month, day] = value.split("-").map((part) => Number.parseInt(part, 10));
+  if (month < 1 || month > 12) {
+    return null;
+  }
+
+  if (day < 1 || day > daysInMonth(year, month)) {
+    return null;
+  }
+
+  return { year, month, day };
+}
+
+export function isIsoDate(value: string): boolean {
+  return parseIsoDate(value) !== null;
+}
+
+export function shiftIsoDate(anchor: string, unit: ReportingPeriodUnit, amount: number): string {
+  const parsed = parseIsoDate(anchor);
+  if (!parsed) {
+    throw new Error(`Invalid ISO date: ${anchor}`);
+  }
+
+  const { year, month, day } = parsed;
+  if (unit === "day") {
+    const shifted = new Date(Date.UTC(year, month - 1, day + amount));
+    return toIsoDate(shifted.getUTCFullYear(), shifted.getUTCMonth() + 1, shifted.getUTCDate());
+  }
+
+  const monthDelta = unit === "month" ? amount : unit === "quarter" ? amount * 3 : amount * 12;
+  const absoluteMonth = year * 12 + (month - 1) + monthDelta;
+  const newYear = Math.floor(absoluteMonth / 12);
+  const newMonth = (absoluteMonth % 12) + 1;
+  const newDay = Math.min(day, daysInMonth(newYear, newMonth));
+  return toIsoDate(newYear, newMonth, newDay);
+}
+
+export function formatReportingPeriodLabel(asOfDate: string): string {
+  const parsed = parseIsoDate(asOfDate);
+  if (!parsed) {
+    return asOfDate;
+  }
+
+  return PERIOD_LABEL_FORMATTER.format(new Date(Date.UTC(parsed.year, parsed.month - 1, parsed.day)));
+}
+
+/**
+ * Compares two ISO dates without timezone effects.
+ * Returns a negative number when {@link left} is earlier, positive when later, 0 when equal.
+ */
+export function compareIsoDate(left: string, right: string): number {
+  const a = parseIsoDate(left);
+  const b = parseIsoDate(right);
+  if (!a || !b) {
+    return left.localeCompare(right);
+  }
+
+  return (
+    a.year - b.year ||
+    a.month - b.month ||
+    a.day - b.day
+  );
+}
+
+const PRESET_DEFINITIONS: ReadonlyArray<{ id: string; label: string; unit: ReportingPeriodUnit; amount: number }> = [
+  { id: "prev-day", label: "Prev day", unit: "day", amount: -1 },
+  { id: "prev-month", label: "Prev month", unit: "month", amount: -1 },
+  { id: "prev-quarter", label: "Prev quarter", unit: "quarter", amount: -1 },
+  { id: "prev-year", label: "Prev year", unit: "year", amount: -1 }
+];
+
+/**
+ * Builds the quick-pick period options shown by the switcher, anchored on the current as-of date.
+ * The first option is always the anchor itself ("Current"); the rest step backwards by day/month/quarter/year.
+ */
+export function buildReportingPeriodOptions(anchor: string): ReportingPeriodOption[] {
+  if (!isIsoDate(anchor)) {
+    return [];
+  }
+
+  const options: ReportingPeriodOption[] = [
+    {
+      id: "current",
+      label: "Current",
+      asOfDate: anchor,
+      description: formatReportingPeriodLabel(anchor)
+    }
+  ];
+
+  for (const preset of PRESET_DEFINITIONS) {
+    const asOfDate = shiftIsoDate(anchor, preset.unit, preset.amount);
+    options.push({
+      id: preset.id,
+      label: preset.label,
+      asOfDate,
+      description: formatReportingPeriodLabel(asOfDate)
+    });
+  }
+
+  return options;
+}
+
+export function todayIsoDate(now: Date = new Date()): string {
+  return toIsoDate(now.getUTCFullYear(), now.getUTCMonth() + 1, now.getUTCDate());
+}

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
@@ -10,6 +10,7 @@ import { Select } from "@/components/ui/select";
 import { StatusBanner } from "@/components/ui/status-banner";
 import { FinancialRecordExplorerShell } from "@/components/meridian/financial-record-explorer";
 import { MetricCard } from "@/components/meridian/metric-card";
+import { ReportingPeriodSwitcher } from "@/components/meridian/reporting-period-switcher";
 import { DenseDataTable, type DenseDataTableColumn } from "@/components/meridian/ui-kit-primitives";
 import {
   apiPostJson,
@@ -31,6 +32,7 @@ import {
 } from "@/lib/api";
 import { describeApiError } from "@/lib/api-errors";
 import { cn } from "@/lib/utils";
+import { todayIsoDate } from "@/lib/reporting-periods";
 import { evidenceWorkbenchPath, WORKSTATION_ROUTE_CATALOG } from "@/lib/workspace";
 import { FUND_STRUCTURE_API_ENDPOINTS, WORKSTATION_API_ENDPOINTS, reportingRunReportWriterGridEndpoint } from "@/lib/workstation-endpoints";
 import {
@@ -276,6 +278,7 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
   const [scheduleDraft, setScheduleDraft] = useState<ReportingScheduleDraftState>(() => buildDefaultReportingScheduleDraft(data?.reporting ?? null));
   const [exportsRunDraft, setExportsRunDraft] = useState<ExportsReportRunDraftState>(() => buildDefaultExportsReportRunDraft(data?.reporting ?? null));
   const [templateRunDatasetSourceId, setTemplateRunDatasetSourceId] = useState(() => buildDefaultReportWriterDatasetSourceId(data?.reporting ?? null));
+  const [templateRunAsOfDate, setTemplateRunAsOfDate] = useState<string>(() => todayIsoDate());
   const [writerDrafts, setWriterDrafts] = useState<Record<string, ReportWriterDraftState>>({});
   const [writerDraftSettings, setWriterDraftSettings] = useState<Record<string, Partial<ReportWriterDraftSettings>>>({});
   const [writerCustomFormulas, setWriterCustomFormulas] = useState<Record<string, Partial<ReportWriterCustomFormulaDraft>>>({});
@@ -408,7 +411,7 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
 
     await executeTemplateRun(template, {
       templateId: template.templateName,
-      asOfDate: new Date().toISOString().slice(0, 10),
+      asOfDate: templateRunAsOfDate,
       maxRetries: 0,
       datasetSourceId: template.hasWriterGrids ? normalizeOptionalDatasetSourceId(templateRunDatasetSourceId) : null
     }, template.runActionLabel);
@@ -2220,6 +2223,14 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
             <CardDescription>Investor statements, SEC packets, and shadow NAV packs share the same run contract.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-2">
+            <ReportingPeriodSwitcher
+              asOfDate={templateRunAsOfDate}
+              onSelect={setTemplateRunAsOfDate}
+              disabled={Boolean(runningTemplateRunId)}
+            />
+            <p className="text-[11px] leading-4 text-muted-foreground">
+              On-demand template runs use this as-of period. Switch periods to regenerate the same report for a prior month, quarter, or year.
+            </p>
             {vm.templateRows.map((template) => (
               <div key={template.id} className="rounded-md border border-border/70 bg-secondary/20 px-3 py-2">
                 <div className="flex flex-wrap items-center justify-between gap-2">

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
@@ -12,6 +12,7 @@ import { FinancialRecordExplorerShell } from "@/components/meridian/financial-re
 import { MetricCard } from "@/components/meridian/metric-card";
 import { ReportingPeriodSwitcher } from "@/components/meridian/reporting-period-switcher";
 import { ReportingHub } from "@/components/meridian/reporting-hub";
+import { ReportWriterChartPreview } from "@/components/meridian/report-writer-chart-preview";
 import { DenseDataTable, type DenseDataTableColumn } from "@/components/meridian/ui-kit-primitives";
 import {
   apiPostJson,
@@ -35,6 +36,7 @@ import { describeApiError } from "@/lib/api-errors";
 import { cn } from "@/lib/utils";
 import { todayIsoDate } from "@/lib/reporting-periods";
 import { buildReportingHubModel } from "@/lib/reporting-hub";
+import { cellStyleClassName, resolveCellStyle } from "@/lib/report-writer-grid-format";
 import { evidenceWorkbenchPath, WORKSTATION_ROUTE_CATALOG } from "@/lib/workspace";
 import { FUND_STRUCTURE_API_ENDPOINTS, WORKSTATION_API_ENDPOINTS, reportingRunReportWriterGridEndpoint } from "@/lib/workstation-endpoints";
 import {
@@ -4566,7 +4568,10 @@ function ReportWriterPreviewTable({ grid, preview }: { grid: ReportingWriterGrid
             {rows.length > 0 ? rows.map((row) => (
               <tr key={row.rowKey} className="border-t border-border/50">
                 {preview.columns.map((column) => (
-                  <td key={`${row.rowKey}:${column.key}`} className="px-2 py-1.5 font-mono text-foreground">
+                  <td
+                    key={`${row.rowKey}:${column.key}`}
+                    className={cn("px-2 py-1.5 font-mono text-foreground", cellStyleClassName(resolveCellStyle(row, column.key)))}
+                  >
                     <span className="block truncate" title={row.values[column.key] ?? ""}>{row.values[column.key] ?? ""}</span>
                   </td>
                 ))}
@@ -4581,6 +4586,7 @@ function ReportWriterPreviewTable({ grid, preview }: { grid: ReportingWriterGrid
           </tbody>
         </table>
       </div>
+      {preview.chart ? <ReportWriterChartPreview chart={preview.chart} /> : null}
       {lineage ? (
         <div className="mt-2 rounded-sm border border-border/60 bg-secondary/25 px-2 py-2 text-xs" aria-label={`${grid.title} preview audit trace`}>
           <div className="eyebrow-label">Audit trace</div>

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
@@ -1,5 +1,5 @@
 import { type DragEvent, type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
-import { CheckCircle2, ChevronLeft, ChevronRight, Eye, FileText, Filter, GripVertical, Landmark, Network, PencilLine, Plus, RotateCcw, Send, Trash2, XCircle } from "lucide-react";
+import { BarChart2, CheckCircle2, ChevronLeft, ChevronRight, Eye, FileText, Filter, GripVertical, Landmark, Network, Palette, PencilLine, Plus, RotateCcw, Send, Trash2, XCircle } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -75,8 +75,12 @@ import type {
   ReportTemplateDecisionRequest,
   ReportTemplateDraftRequest,
   ReportWriterAggregateFunction,
+  ReportWriterCellStyle,
+  ReportWriterChartDefinition,
+  ReportWriterChartType,
   ReportWriterFilterDefinition,
   ReportWriterFilterOperator,
+  ReportWriterFormatRule,
   ReportWriterGridDefinition,
   ReportWriterGridKind,
   ReportWriterGridRender,
@@ -145,6 +149,22 @@ type ReportingScheduleDraftField =
   | "deliveryMode"
   | "deliveryNote";
 type ExportsReportRunDraftField = "templateRowId" | "asOfDate" | "maxRetries" | "requestedBy" | "datasetSourceId";
+type ReportWriterChartDraftField = "type" | "categoryField" | "valueColumns";
+
+interface ReportWriterChartDraft {
+  enabled: boolean;
+  type: ReportWriterChartType;
+  categoryField: string;
+  valueColumns: string;
+}
+
+interface ReportWriterFormatRuleDraft {
+  id: string;
+  column: string;
+  operator: ReportWriterFilterOperator;
+  value: string;
+  style: ReportWriterCellStyle;
+}
 
 interface ReportWriterDraftSettings {
   name: string;
@@ -300,6 +320,8 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
   const [brandingDraft, setBrandingDraft] = useState<ReportBrandingDraftState>(() => buildDefaultReportBrandingDraft(data?.reporting ?? null));
   const [writerPreviewByGridId, setWriterPreviewByGridId] = useState<Record<string, ReportWriterGridRender | null>>({});
   const [writerPreviousPreviewByGridId, setWriterPreviousPreviewByGridId] = useState<Record<string, ReportWriterGridRender | null>>({});
+  const [writerChartDrafts, setWriterChartDrafts] = useState<Record<string, ReportWriterChartDraft>>({});
+  const [writerFormatRuleDrafts, setWriterFormatRuleDrafts] = useState<Record<string, ReportWriterFormatRuleDraft[]>>({});
   const livePortfolioRefreshInFlight = useRef(false);
   const reportWriterDatasetSources = data?.reporting.reportWriterDatasetSources ?? [];
   const livePortfolioViews = data?.reporting.livePortfolioViews ?? [];
@@ -582,6 +604,14 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
     };
   }
 
+  function getWriterChartDraft(grid: ReportingWriterGridRow): ReportWriterChartDraft {
+    return writerChartDrafts[grid.id] ?? { enabled: false, type: "Bar", categoryField: "", valueColumns: "" };
+  }
+
+  function getWriterFormatRules(grid: ReportingWriterGridRow): ReportWriterFormatRuleDraft[] {
+    return writerFormatRuleDrafts[grid.id] ?? [];
+  }
+
   function updateWriterDraftSetting(
     grid: ReportingWriterGridRow,
     field: ReportWriterDraftSettingsField,
@@ -629,6 +659,46 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
     setWriterCustomDatasetText((current) => ({
       ...current,
       [grid.id]: value
+    }));
+    setWriterPreviewByGridId((current) => clearWriterPreview(current, grid.id));
+  }
+
+  function updateWriterChartDraft(grid: ReportingWriterGridRow, field: ReportWriterChartDraftField | "enabled", value: string) {
+    setWriterChartDrafts((current) => {
+      const existing = current[grid.id] ?? { enabled: false, type: "Bar" as ReportWriterChartType, categoryField: "", valueColumns: "" };
+      return {
+        ...current,
+        [grid.id]: field === "enabled"
+          ? { ...existing, enabled: value === "true" }
+          : { ...existing, [field]: value }
+      };
+    });
+    setWriterPreviewByGridId((current) => clearWriterPreview(current, grid.id));
+  }
+
+  function addWriterFormatRule(grid: ReportingWriterGridRow) {
+    const id = `rule-${Date.now()}`;
+    setWriterFormatRuleDrafts((current) => ({
+      ...current,
+      [grid.id]: [...(current[grid.id] ?? []), { id, column: "", operator: "GreaterThan" as ReportWriterFilterOperator, value: "", style: "Warning" as ReportWriterCellStyle }]
+    }));
+    setWriterPreviewByGridId((current) => clearWriterPreview(current, grid.id));
+  }
+
+  function removeWriterFormatRule(grid: ReportingWriterGridRow, ruleId: string) {
+    setWriterFormatRuleDrafts((current) => ({
+      ...current,
+      [grid.id]: (current[grid.id] ?? []).filter((rule) => rule.id !== ruleId)
+    }));
+    setWriterPreviewByGridId((current) => clearWriterPreview(current, grid.id));
+  }
+
+  function updateWriterFormatRule(grid: ReportingWriterGridRow, ruleId: string, field: keyof Omit<ReportWriterFormatRuleDraft, "id">, value: string) {
+    setWriterFormatRuleDrafts((current) => ({
+      ...current,
+      [grid.id]: (current[grid.id] ?? []).map((rule) =>
+        rule.id === ruleId ? { ...rule, [field]: value } : rule
+      )
     }));
     setWriterPreviewByGridId((current) => clearWriterPreview(current, grid.id));
   }
@@ -850,7 +920,9 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
       grid,
       getWriterCurrentZones(grid),
       settings,
-      customDataset?.rows ?? retainedDatasetRows);
+      customDataset?.rows ?? retainedDatasetRows,
+      getWriterChartDraft(grid),
+      getWriterFormatRules(grid));
     setWriterPreviewStatus({
       id: grid.id,
       label: "Preview report-writer grid",
@@ -2187,6 +2259,8 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
                     grid={grid}
                     settings={getWriterDraftSettings(grid)}
                     customFormula={getWriterCustomFormula(grid)}
+                    chartDraft={getWriterChartDraft(grid)}
+                    formatRules={getWriterFormatRules(grid)}
                     datasetSources={reportWriterDatasetSources}
                     isSaving={savingWriterDraftId === grid.id}
                     isPreviewing={previewingWriterDraftId === grid.id}
@@ -2198,13 +2272,17 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
                     onTokenRemove={removeWriterZoneToken}
                     onTokenMove={moveWriterZoneToken}
                     onReset={resetWriterGrid}
-                  onSettingsChange={updateWriterDraftSetting}
-                  onCustomFormulaChange={updateWriterCustomFormula}
-                  customDatasetText={writerCustomDatasetText[grid.id] ?? ""}
-                  onCustomDatasetChange={updateWriterCustomDataset}
-                  onPreview={previewWriterGrid}
-                  onSave={saveWriterGridDraft}
-                />
+                    onSettingsChange={updateWriterDraftSetting}
+                    onCustomFormulaChange={updateWriterCustomFormula}
+                    customDatasetText={writerCustomDatasetText[grid.id] ?? ""}
+                    onCustomDatasetChange={updateWriterCustomDataset}
+                    onChartDraftChange={updateWriterChartDraft}
+                    onFormatRuleAdd={addWriterFormatRule}
+                    onFormatRuleRemove={removeWriterFormatRule}
+                    onFormatRuleChange={updateWriterFormatRule}
+                    onPreview={previewWriterGrid}
+                    onSave={saveWriterGridDraft}
+                  />
                 ))}
               </div>
               {writerPreviewStatus ? (
@@ -4128,6 +4206,8 @@ interface ReportWriterDesignerGridProps {
   grid: ReportingWriterGridRow;
   settings: ReportWriterDraftSettings;
   customFormula: ReportWriterCustomFormulaDraft;
+  chartDraft: ReportWriterChartDraft;
+  formatRules: ReportWriterFormatRuleDraft[];
   datasetSources: ReportWriterDatasetSource[];
   customDatasetText: string;
   isSaving: boolean;
@@ -4143,6 +4223,10 @@ interface ReportWriterDesignerGridProps {
   onSettingsChange: (grid: ReportingWriterGridRow, field: ReportWriterDraftSettingsField, value: string) => void;
   onCustomFormulaChange: (grid: ReportingWriterGridRow, field: ReportWriterCustomFormulaField, value: string) => void;
   onCustomDatasetChange: (grid: ReportingWriterGridRow, value: string) => void;
+  onChartDraftChange: (grid: ReportingWriterGridRow, field: ReportWriterChartDraftField | "enabled", value: string) => void;
+  onFormatRuleAdd: (grid: ReportingWriterGridRow) => void;
+  onFormatRuleRemove: (grid: ReportingWriterGridRow, ruleId: string) => void;
+  onFormatRuleChange: (grid: ReportingWriterGridRow, ruleId: string, field: keyof Omit<ReportWriterFormatRuleDraft, "id">, value: string) => void;
   onPreview: (grid: ReportingWriterGridRow) => void | Promise<void>;
   onSave: (grid: ReportingWriterGridRow) => void | Promise<void>;
 }
@@ -4151,6 +4235,8 @@ function ReportWriterDesignerGrid({
   grid,
   settings,
   customFormula,
+  chartDraft,
+  formatRules,
   datasetSources,
   customDatasetText,
   isSaving,
@@ -4166,6 +4252,10 @@ function ReportWriterDesignerGrid({
   onSettingsChange,
   onCustomFormulaChange,
   onCustomDatasetChange,
+  onChartDraftChange,
+  onFormatRuleAdd,
+  onFormatRuleRemove,
+  onFormatRuleChange,
   onPreview,
   onSave
 }: ReportWriterDesignerGridProps) {
@@ -4512,6 +4602,152 @@ function ReportWriterDesignerGrid({
             />
           </label>
         </div>
+      </div>
+      <div className="mt-3 rounded-md border border-border/70 bg-background/25 px-2.5 py-2">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-1.5">
+            <Palette className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+            <div className="eyebrow-label">Conditional formatting</div>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            aria-label={`Add conditional formatting rule for ${grid.title}`}
+            onClick={() => onFormatRuleAdd(grid)}
+          >
+            <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+            Add rule
+          </Button>
+        </div>
+        {formatRules.length > 0 ? (
+          <div className="mt-2 space-y-2">
+            {formatRules.map((rule) => (
+              <div key={rule.id} className="grid gap-2 md:grid-cols-[1fr_0.8fr_0.8fr_0.8fr_auto] items-end">
+                <label className="space-y-1">
+                  <span className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Column</span>
+                  <Select
+                    value={rule.column}
+                    onChange={(event) => onFormatRuleChange(grid, rule.id, "column", event.target.value)}
+                    aria-label={`Formatting rule column for ${grid.title}`}
+                  >
+                    <option value="">Select column</option>
+                    {grid.sourceFields.map((field) => (
+                      <option key={field.id} value={field.fieldName ?? field.label}>{field.label}</option>
+                    ))}
+                  </Select>
+                </label>
+                <label className="space-y-1">
+                  <span className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Operator</span>
+                  <Select
+                    value={rule.operator}
+                    onChange={(event) => onFormatRuleChange(grid, rule.id, "operator", event.target.value)}
+                    aria-label={`Formatting rule operator for ${grid.title}`}
+                  >
+                    <option value="Equals">=</option>
+                    <option value="NotEquals">≠</option>
+                    <option value="GreaterThan">&gt;</option>
+                    <option value="GreaterThanOrEqual">&gt;=</option>
+                    <option value="LessThan">&lt;</option>
+                    <option value="LessThanOrEqual">&lt;=</option>
+                    <option value="Contains">Contains</option>
+                    <option value="IsBlank">Is blank</option>
+                    <option value="IsNotBlank">Is not blank</option>
+                  </Select>
+                </label>
+                <label className="space-y-1">
+                  <span className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Value</span>
+                  <Input
+                    value={rule.value}
+                    onChange={(event) => onFormatRuleChange(grid, rule.id, "value", event.target.value)}
+                    aria-label={`Formatting rule value for ${grid.title}`}
+                    className="font-mono"
+                    disabled={isBlankFilterOperator(rule.operator)}
+                  />
+                </label>
+                <label className="space-y-1">
+                  <span className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Style</span>
+                  <Select
+                    value={rule.style}
+                    onChange={(event) => onFormatRuleChange(grid, rule.id, "style", event.target.value)}
+                    aria-label={`Formatting rule style for ${grid.title}`}
+                  >
+                    <option value="Success">Success</option>
+                    <option value="Warning">Warning</option>
+                    <option value="Danger">Danger</option>
+                    <option value="Info">Info</option>
+                  </Select>
+                </label>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  aria-label={`Remove formatting rule from ${grid.title}`}
+                  onClick={() => onFormatRuleRemove(grid, rule.id)}
+                >
+                  <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="mt-2 text-xs text-muted-foreground">No rules. Add a rule to highlight cells by value.</p>
+        )}
+      </div>
+      <div className="mt-3 rounded-md border border-border/70 bg-background/25 px-2.5 py-2">
+        <div className="flex items-center gap-1.5">
+          <BarChart2 className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+          <div className="eyebrow-label">Inline chart</div>
+        </div>
+        <label className="mt-2 flex items-center gap-2 cursor-pointer">
+          <Checkbox
+            checked={chartDraft.enabled}
+            onCheckedChange={(checked) => onChartDraftChange(grid, "enabled", String(checked === true))}
+            aria-label={`Enable inline chart for ${grid.title}`}
+          />
+          <span className="text-xs text-foreground">Enable inline chart</span>
+        </label>
+        {chartDraft.enabled ? (
+          <div className="mt-2 grid gap-2 md:grid-cols-[0.6fr_1fr_1.4fr]">
+            <label className="space-y-1">
+              <span className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Type</span>
+              <Select
+                value={chartDraft.type}
+                onChange={(event) => onChartDraftChange(grid, "type", event.target.value)}
+                aria-label={`Chart type for ${grid.title}`}
+              >
+                <option value="Bar">Bar</option>
+                <option value="StackedBar">Stacked bar</option>
+                <option value="Line">Line</option>
+                <option value="Area">Area</option>
+                <option value="Pie">Pie</option>
+              </Select>
+            </label>
+            <label className="space-y-1">
+              <span className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Category field</span>
+              <Select
+                value={chartDraft.categoryField}
+                onChange={(event) => onChartDraftChange(grid, "categoryField", event.target.value)}
+                aria-label={`Chart category field for ${grid.title}`}
+              >
+                <option value="">Select field</option>
+                {grid.sourceFields.map((field) => (
+                  <option key={field.id} value={field.fieldName ?? field.label}>{field.label}</option>
+                ))}
+              </Select>
+            </label>
+            <label className="space-y-1">
+              <span className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Value columns (comma-separated)</span>
+              <Input
+                value={chartDraft.valueColumns}
+                onChange={(event) => onChartDraftChange(grid, "valueColumns", event.target.value)}
+                aria-label={`Chart value columns for ${grid.title}`}
+                className="font-mono"
+                placeholder="marketValue, pnl"
+              />
+            </label>
+          </div>
+        ) : null}
       </div>
       <div className="mt-3 flex flex-wrap justify-end gap-2">
         <Button
@@ -5571,9 +5807,11 @@ function buildRenderReportTemplateRequest(
   grid: ReportingWriterGridRow,
   zones: Record<ReportWriterDropZone, ReportingWriterToken[]>,
   settings: ReportWriterDraftSettings,
-  customDatasetRows: Record<string, string>[] | null = null
+  customDatasetRows: Record<string, string>[] | null = null,
+  chartDraft?: ReportWriterChartDraft | null,
+  formatRules?: ReportWriterFormatRuleDraft[] | null
 ): RenderReportTemplateRequest {
-  const gridDefinition = buildReportWriterGridDefinition(grid, zones, settings);
+  const gridDefinition = buildReportWriterGridDefinition(grid, zones, settings, chartDraft, formatRules);
   return {
     templateId: {
       name: grid.templateId,
@@ -5593,7 +5831,9 @@ function buildRenderReportTemplateRequest(
 function buildReportWriterGridDefinition(
   grid: ReportingWriterGridRow,
   zones: Record<ReportWriterDropZone, ReportingWriterToken[]>,
-  settings: ReportWriterDraftSettings
+  settings: ReportWriterDraftSettings,
+  chartDraft?: ReportWriterChartDraft | null,
+  formatRules?: ReportWriterFormatRuleDraft[] | null
 ): ReportWriterGridDefinition {
   const kind = normalizeReportWriterGridKind(settings.gridKind);
   const metrics = normalizeWriterMetrics(zones.metrics, kind);
@@ -5608,8 +5848,32 @@ function buildReportWriterGridDefinition(
     topN: kind === "TopN" ? parseReportWriterTopN(settings.topN) : null,
     sortBy: kind === "Contribution" ? "contributionAbsPercent" : grid.sortBy,
     sortDescending: grid.sortDescending,
-    filters: buildWriterFilters(settings)
+    filters: buildWriterFilters(settings),
+    formatRules: buildWriterFormatRules(formatRules),
+    chart: buildWriterChartDefinition(chartDraft)
   };
+}
+
+function buildWriterFormatRules(drafts: ReportWriterFormatRuleDraft[] | null | undefined): ReportWriterFormatRule[] | null {
+  if (!drafts || drafts.length === 0) return null;
+  const valid = drafts.filter((d) => d.column.trim().length > 0);
+  if (valid.length === 0) return null;
+  return valid.map((d) => ({
+    column: d.column.trim(),
+    operator: d.operator,
+    value: d.value || null,
+    style: d.style
+  }));
+}
+
+function buildWriterChartDefinition(draft: ReportWriterChartDraft | null | undefined): ReportWriterChartDefinition | null {
+  if (!draft?.enabled || !draft.categoryField.trim()) return null;
+  const valueColumns = draft.valueColumns
+    .split(",")
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0);
+  if (valueColumns.length === 0) return null;
+  return { type: draft.type, categoryField: draft.categoryField.trim(), valueColumns };
 }
 
 function buildReportWriterPreviewRows(

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
@@ -13,6 +13,7 @@ import { MetricCard } from "@/components/meridian/metric-card";
 import { ReportingPeriodSwitcher } from "@/components/meridian/reporting-period-switcher";
 import { ReportingHub } from "@/components/meridian/reporting-hub";
 import { ReportWriterChartPreview } from "@/components/meridian/report-writer-chart-preview";
+import { ReportWriterGridDiffView } from "@/components/meridian/report-writer-grid-diff-view";
 import { DenseDataTable, type DenseDataTableColumn } from "@/components/meridian/ui-kit-primitives";
 import {
   apiPostJson,
@@ -37,6 +38,7 @@ import { cn } from "@/lib/utils";
 import { todayIsoDate } from "@/lib/reporting-periods";
 import { buildReportingHubModel } from "@/lib/reporting-hub";
 import { cellStyleClassName, resolveCellStyle } from "@/lib/report-writer-grid-format";
+import { buildReportWriterGridDiff } from "@/lib/report-writer-grid-diff";
 import { evidenceWorkbenchPath, WORKSTATION_ROUTE_CATALOG } from "@/lib/workspace";
 import { FUND_STRUCTURE_API_ENDPOINTS, WORKSTATION_API_ENDPOINTS, reportingRunReportWriterGridEndpoint } from "@/lib/workstation-endpoints";
 import {
@@ -297,6 +299,7 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
   const [livePortfolioRefreshStatus, setLivePortfolioRefreshStatus] = useState<ReportingCommandStatus | null>(null);
   const [brandingDraft, setBrandingDraft] = useState<ReportBrandingDraftState>(() => buildDefaultReportBrandingDraft(data?.reporting ?? null));
   const [writerPreviewByGridId, setWriterPreviewByGridId] = useState<Record<string, ReportWriterGridRender | null>>({});
+  const [writerPreviousPreviewByGridId, setWriterPreviousPreviewByGridId] = useState<Record<string, ReportWriterGridRender | null>>({});
   const livePortfolioRefreshInFlight = useRef(false);
   const reportWriterDatasetSources = data?.reporting.reportWriterDatasetSources ?? [];
   const livePortfolioViews = data?.reporting.livePortfolioViews ?? [];
@@ -859,9 +862,14 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
     try {
       const result = await renderReportTemplate(request);
       const renderedGrid = result.grids?.find((item) => item.gridId === grid.gridId) ?? result.grids?.[0] ?? null;
+      const previousPreview = writerPreviewByGridId[grid.id] ?? null;
       setWriterPreviewByGridId((current) => ({
         ...current,
         [grid.id]: renderedGrid
+      }));
+      setWriterPreviousPreviewByGridId((current) => ({
+        ...current,
+        [grid.id]: previousPreview
       }));
       setWriterPreviewStatus({
         id: grid.id,
@@ -2183,6 +2191,7 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
                     isSaving={savingWriterDraftId === grid.id}
                     isPreviewing={previewingWriterDraftId === grid.id}
                     preview={writerPreviewByGridId[grid.id] ?? null}
+                    previousPreview={writerPreviousPreviewByGridId[grid.id] ?? null}
                     getZoneTokens={getWriterZoneTokens}
                     onTokenDragStart={handleWriterTokenDragStart}
                     onZoneDrop={handleWriterZoneDrop}
@@ -4124,6 +4133,7 @@ interface ReportWriterDesignerGridProps {
   isSaving: boolean;
   isPreviewing: boolean;
   preview: ReportWriterGridRender | null;
+  previousPreview: ReportWriterGridRender | null;
   getZoneTokens: (grid: ReportingWriterGridRow, zone: ReportWriterDropZone) => ReportingWriterToken[];
   onTokenDragStart: (event: DragEvent<HTMLElement>, token: ReportingWriterToken, origin?: ReportWriterTokenDragOrigin | null) => void;
   onZoneDrop: (event: DragEvent<HTMLElement>, grid: ReportingWriterGridRow, zone: ReportWriterDropZone) => void;
@@ -4146,6 +4156,7 @@ function ReportWriterDesignerGrid({
   isSaving,
   isPreviewing,
   preview,
+  previousPreview,
   getZoneTokens,
   onTokenDragStart,
   onZoneDrop,
@@ -4530,17 +4541,21 @@ function ReportWriterDesignerGrid({
         </Button>
       </div>
       {preview ? (
-        <ReportWriterPreviewTable grid={grid} preview={preview} />
+        <ReportWriterPreviewTable grid={grid} preview={preview} previousPreview={previousPreview} />
       ) : null}
     </div>
   );
 }
 
-function ReportWriterPreviewTable({ grid, preview }: { grid: ReportingWriterGridRow; preview: ReportWriterGridRender }) {
+function ReportWriterPreviewTable({ grid, preview, previousPreview }: { grid: ReportingWriterGridRow; preview: ReportWriterGridRender; previousPreview?: ReportWriterGridRender | null }) {
   const rows = preview.rows.slice(0, 5);
   const lineage = preview.lineage;
   const dataDictionary = preview.dataDictionary ?? [];
   const validationChecks = preview.validationChecks ?? [];
+  const comparison = previousPreview ? buildReportWriterGridDiff(previousPreview, preview) : null;
+  const comparisonChangeCount = comparison
+    ? comparison.addedRowCount + comparison.removedRowCount + comparison.changedRowCount
+    : 0;
   return (
     <div className="mt-3 rounded-md border border-border/70 bg-background/35 px-2.5 py-2" aria-label={`${grid.title} live preview`}>
       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -4587,6 +4602,16 @@ function ReportWriterPreviewTable({ grid, preview }: { grid: ReportingWriterGrid
         </table>
       </div>
       {preview.chart ? <ReportWriterChartPreview chart={preview.chart} /> : null}
+      {comparison ? (
+        <details className="mt-2 rounded-sm border border-border/60 bg-secondary/20 px-2 py-1.5 text-xs">
+          <summary className="cursor-pointer select-none text-[11px] font-semibold text-foreground">
+            Changes since previous preview ({comparisonChangeCount} changed)
+          </summary>
+          <div className="mt-2">
+            <ReportWriterGridDiffView diff={comparison} />
+          </div>
+        </details>
+      ) : null}
       {lineage ? (
         <div className="mt-2 rounded-sm border border-border/60 bg-secondary/25 px-2 py-2 text-xs" aria-label={`${grid.title} preview audit trace`}>
           <div className="eyebrow-label">Audit trace</div>

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
@@ -1,4 +1,4 @@
-import { type DragEvent, type KeyboardEvent, useEffect, useRef, useState } from "react";
+import { type DragEvent, type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
 import { CheckCircle2, ChevronLeft, ChevronRight, Eye, FileText, Filter, GripVertical, Landmark, Network, PencilLine, Plus, RotateCcw, Send, Trash2, XCircle } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
@@ -11,6 +11,7 @@ import { StatusBanner } from "@/components/ui/status-banner";
 import { FinancialRecordExplorerShell } from "@/components/meridian/financial-record-explorer";
 import { MetricCard } from "@/components/meridian/metric-card";
 import { ReportingPeriodSwitcher } from "@/components/meridian/reporting-period-switcher";
+import { ReportingHub } from "@/components/meridian/reporting-hub";
 import { DenseDataTable, type DenseDataTableColumn } from "@/components/meridian/ui-kit-primitives";
 import {
   apiPostJson,
@@ -33,6 +34,7 @@ import {
 import { describeApiError } from "@/lib/api-errors";
 import { cn } from "@/lib/utils";
 import { todayIsoDate } from "@/lib/reporting-periods";
+import { buildReportingHubModel } from "@/lib/reporting-hub";
 import { evidenceWorkbenchPath, WORKSTATION_ROUTE_CATALOG } from "@/lib/workspace";
 import { FUND_STRUCTURE_API_ENDPOINTS, WORKSTATION_API_ENDPOINTS, reportingRunReportWriterGridEndpoint } from "@/lib/workstation-endpoints";
 import {
@@ -268,6 +270,10 @@ const reportingProfileColumns: DenseDataTableColumn<ReportingProfileRow>[] = [
 export function ReportingScreen({ data, onRefreshLivePortfolioViews }: ReportingScreenProps) {
   const { pathname } = useLocation();
   const vm = useReportingScreenViewModel(data?.reporting ?? null, undefined, pathname);
+  const hubModel = useMemo(
+    () => buildReportingHubModel(vm.runStatusRows, vm.templateRows),
+    [vm.runStatusRows, vm.templateRows]
+  );
   const reportPackProfileButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const shouldFocusReportPackProfile = useRef(false);
   const [runActionStatus, setRunActionStatus] = useState<ReportingCommandStatus | null>(null);
@@ -1403,6 +1409,8 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
           <MetricCard key={metric.id} {...metric} />
         ))}
       </section>
+
+      <ReportingHub model={hubModel} />
 
       <section role="region" aria-label="Reporting access audit">
         <Card className="panel-surface" aria-label={vm.accessAudit.ariaLabel}>

--- a/src/Meridian.Ui/dashboard/src/types.ts
+++ b/src/Meridian.Ui/dashboard/src/types.ts
@@ -4388,6 +4388,10 @@ export type ReportWriterFilterOperator =
   | "IsNotBlank";
 export type ReportAccessMode = "Private" | "Restricted" | "CompanyWide";
 export type ReportAccessPrincipalKind = "User" | "Group" | "Company";
+export type ReportWriterCellStyle = "None" | "Success" | "Warning" | "Danger" | "Info";
+export type ReportWriterChartType = "Bar" | "StackedBar" | "Line" | "Area" | "Pie";
+export type ReportWriterDiffRowState = "Unchanged" | "Changed" | "Added" | "Removed";
+export type ReportWriterDiffDirection = "Flat" | "Up" | "Down";
 
 export interface VersionedReportTemplateId {
   name: string;
@@ -4431,6 +4435,38 @@ export interface ReportWriterGridDefinition {
   sortBy?: string | null;
   sortDescending?: boolean;
   filters?: ReportWriterFilterDefinition[] | null;
+  formatRules?: ReportWriterFormatRule[] | null;
+  chart?: ReportWriterChartDefinition | null;
+}
+
+export interface ReportWriterFormatRule {
+  column: string;
+  operator: ReportWriterFilterOperator;
+  style: ReportWriterCellStyle;
+  value?: string | null;
+  label?: string | null;
+}
+
+export interface ReportWriterChartDefinition {
+  type: ReportWriterChartType;
+  categoryField: string;
+  valueColumns: string[];
+  title?: string | null;
+}
+
+export interface ReportWriterChartSeries {
+  key: string;
+  label: string;
+  values: number[];
+}
+
+export interface ReportWriterChartRender {
+  type: ReportWriterChartType;
+  title: string;
+  categoryField: string;
+  categories: string[];
+  series: ReportWriterChartSeries[];
+  warnings: string[];
 }
 
 export interface ReportWriterGridColumn {
@@ -4442,6 +4478,7 @@ export interface ReportWriterGridColumn {
 export interface ReportWriterGridRow {
   rowKey: string;
   values: Record<string, string>;
+  styleHints?: Record<string, ReportWriterCellStyle> | null;
 }
 
 export interface ReportWriterMetricLineage {
@@ -4499,6 +4536,35 @@ export interface ReportWriterGridRender {
   lineage?: ReportWriterGridLineage | null;
   dataDictionary?: ReportWriterGridDataDictionaryField[] | null;
   validationChecks?: ReportWriterGridValidationCheck[] | null;
+  chart?: ReportWriterChartRender | null;
+}
+
+export interface ReportWriterGridDiffCell {
+  column: string;
+  priorValue?: string | null;
+  currentValue?: string | null;
+  delta?: string | null;
+  direction: ReportWriterDiffDirection;
+}
+
+export interface ReportWriterGridDiffRow {
+  rowKey: string;
+  state: ReportWriterDiffRowState;
+  priorValues: Record<string, string>;
+  currentValues: Record<string, string>;
+  cells: ReportWriterGridDiffCell[];
+}
+
+export interface ReportWriterGridDiff {
+  gridId: string;
+  title: string;
+  columns: ReportWriterGridColumn[];
+  rows: ReportWriterGridDiffRow[];
+  warnings: string[];
+  addedRowCount: number;
+  removedRowCount: number;
+  changedRowCount: number;
+  unchangedRowCount: number;
 }
 
 export interface ReportAccessPrincipal {

--- a/tests/Meridian.Tests/Reporting/ReportSnapshotDiffEngineTests.cs
+++ b/tests/Meridian.Tests/Reporting/ReportSnapshotDiffEngineTests.cs
@@ -1,0 +1,106 @@
+using FluentAssertions;
+using Meridian.Contracts.Workstation;
+using Meridian.Reporting;
+
+namespace Meridian.Tests.Reporting;
+
+public sealed class ReportSnapshotDiffEngineTests
+{
+    [Fact]
+    public void Diff_ClassifiesAddedRemovedChangedAndUnchangedRows()
+    {
+        var prior = Render(
+            "holdings",
+            "Holdings",
+            [Col("sector"), Col("marketValue")],
+            Row("Technology", ("sector", "Technology"), ("marketValue", "100")),
+            Row("Rates", ("sector", "Rates"), ("marketValue", "40")),
+            Row("Cash", ("sector", "Cash"), ("marketValue", "25")));
+        var current = Render(
+            "holdings",
+            "Holdings",
+            [Col("sector"), Col("marketValue")],
+            Row("Technology", ("sector", "Technology"), ("marketValue", "150")),
+            Row("Rates", ("sector", "Rates"), ("marketValue", "40")),
+            Row("Credit", ("sector", "Credit"), ("marketValue", "60")));
+
+        var diff = ReportSnapshotDiffEngine.Diff(prior, current);
+
+        diff.ChangedRowCount.Should().Be(1);
+        diff.UnchangedRowCount.Should().Be(1);
+        diff.AddedRowCount.Should().Be(1);
+        diff.RemovedRowCount.Should().Be(1);
+        diff.Warnings.Should().BeEmpty();
+
+        var technology = diff.Rows.Single(row => row.RowKey == "Technology");
+        technology.State.Should().Be(ReportWriterDiffRowStateDto.Changed);
+        var technologyDelta = technology.Cells.Single(cell => cell.Column == "marketValue");
+        technologyDelta.PriorValue.Should().Be("100");
+        technologyDelta.CurrentValue.Should().Be("150");
+        technologyDelta.Delta.Should().Be("50");
+        technologyDelta.Direction.Should().Be(ReportWriterDiffDirectionDto.Up);
+
+        diff.Rows.Single(row => row.RowKey == "Rates").State.Should().Be(ReportWriterDiffRowStateDto.Unchanged);
+
+        var credit = diff.Rows.Single(row => row.RowKey == "Credit");
+        credit.State.Should().Be(ReportWriterDiffRowStateDto.Added);
+        credit.Cells.Single(cell => cell.Column == "marketValue").PriorValue.Should().BeNull();
+
+        var cash = diff.Rows.Single(row => row.RowKey == "Cash");
+        cash.State.Should().Be(ReportWriterDiffRowStateDto.Removed);
+        cash.Cells.Single(cell => cell.Column == "marketValue").CurrentValue.Should().BeNull();
+    }
+
+    [Fact]
+    public void Diff_OrdersCurrentRowsBeforeRemovedRows()
+    {
+        var prior = Render(
+            "g",
+            "G",
+            [Col("sector"), Col("marketValue")],
+            Row("Cash", ("sector", "Cash"), ("marketValue", "25")),
+            Row("Technology", ("sector", "Technology"), ("marketValue", "100")));
+        var current = Render(
+            "g",
+            "G",
+            [Col("sector"), Col("marketValue")],
+            Row("Technology", ("sector", "Technology"), ("marketValue", "100")));
+
+        var diff = ReportSnapshotDiffEngine.Diff(prior, current);
+
+        diff.Rows.Select(row => row.RowKey).Should().Equal("Technology", "Cash");
+        diff.Rows[^1].State.Should().Be(ReportWriterDiffRowStateDto.Removed);
+    }
+
+    [Fact]
+    public void Diff_AddsWarningForDifferingColumnSets()
+    {
+        var prior = Render(
+            "g",
+            "G",
+            [Col("sector"), Col("marketValue")],
+            Row("Technology", ("sector", "Technology"), ("marketValue", "100")));
+        var current = Render(
+            "g",
+            "G",
+            [Col("sector"), Col("pnl")],
+            Row("Technology", ("sector", "Technology"), ("pnl", "10")));
+
+        var diff = ReportSnapshotDiffEngine.Diff(prior, current);
+
+        diff.Warnings.Should().Contain(warning =>
+            warning.Contains("different column sets", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static ReportWriterGridColumnDto Col(string key) => new(key, key, "dimension");
+
+    private static ReportWriterGridRowDto Row(string rowKey, params (string Key, string Value)[] values) =>
+        new(rowKey, values.ToDictionary(static value => value.Key, static value => value.Value, StringComparer.OrdinalIgnoreCase));
+
+    private static ReportWriterGridRenderDto Render(
+        string gridId,
+        string title,
+        IReadOnlyList<ReportWriterGridColumnDto> columns,
+        params ReportWriterGridRowDto[] rows) =>
+        new(gridId, title, ReportWriterGridKindDto.Pivot, columns, rows, Array.Empty<string>());
+}

--- a/tests/Meridian.Tests/Reporting/ReportWriterGridEngineTests.cs
+++ b/tests/Meridian.Tests/Reporting/ReportWriterGridEngineTests.cs
@@ -363,6 +363,111 @@ public sealed class ReportWriterGridEngineTests
             filter.Label == "Core strategy only");
     }
 
+    [Fact]
+    public void RenderGrids_AppliesConditionalFormattingStyleHints()
+    {
+        var rows = new[]
+        {
+            Row(("security", "AAPL"), ("pnl", "15")),
+            Row(("security", "TLT"), ("pnl", "-3")),
+            Row(("security", "CASH"), ("pnl", "0"))
+        };
+        var grids = new[]
+        {
+            new ReportWriterGridDefinitionDto(
+                "pnl-detail",
+                "PnL Detail",
+                ReportWriterGridKindDto.Detail,
+                RowFields: ["security"],
+                Metrics: [new ReportWriterMetricDefinitionDto("pnl", "pnl")],
+                FormatRules:
+                [
+                    new ReportWriterFormatRuleDto("pnl", ReportWriterFilterOperatorDto.LessThan, ReportWriterCellStyleDto.Danger, "0"),
+                    new ReportWriterFormatRuleDto("pnl", ReportWriterFilterOperatorDto.GreaterThan, ReportWriterCellStyleDto.Success, "0")
+                ])
+        };
+
+        var rendered = ReportWriterGridEngine.RenderGrids(grids, rows).Single();
+
+        var winner = rendered.Rows.Single(row => row.Values["security"] == "AAPL");
+        winner.StyleHints.Should().NotBeNull();
+        winner.StyleHints!["pnl"].Should().Be(ReportWriterCellStyleDto.Success);
+        var loser = rendered.Rows.Single(row => row.Values["security"] == "TLT");
+        loser.StyleHints.Should().NotBeNull();
+        loser.StyleHints!["pnl"].Should().Be(ReportWriterCellStyleDto.Danger);
+        rendered.Rows.Single(row => row.Values["security"] == "CASH").StyleHints.Should().BeNull();
+        rendered.Warnings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RenderGrids_BuildsInlineChartFromRenderedRows()
+    {
+        var rows = new[]
+        {
+            Row(("sector", "Technology"), ("marketValue", "100"), ("pnl", "10")),
+            Row(("sector", "Rates"), ("marketValue", "40"), ("pnl", "-2"))
+        };
+        var grids = new[]
+        {
+            new ReportWriterGridDefinitionDto(
+                "sector-pivot",
+                "Sector Pivot",
+                ReportWriterGridKindDto.Pivot,
+                RowFields: ["sector"],
+                Metrics:
+                [
+                    new ReportWriterMetricDefinitionDto("marketValue", "marketValue"),
+                    new ReportWriterMetricDefinitionDto("pnl", "pnl")
+                ],
+                SortBy: "marketValue",
+                Chart: new ReportWriterChartDefinitionDto(
+                    ReportWriterChartTypeDto.Bar,
+                    "sector",
+                    ["marketValue", "pnl"]))
+        };
+
+        var rendered = ReportWriterGridEngine.RenderGrids(grids, rows).Single();
+
+        rendered.Chart.Should().NotBeNull();
+        rendered.Chart!.Type.Should().Be(ReportWriterChartTypeDto.Bar);
+        rendered.Chart.Title.Should().Be("Sector Pivot");
+        rendered.Chart.CategoryField.Should().Be("sector");
+        rendered.Chart.Categories.Should().Equal("Technology", "Rates");
+        rendered.Chart.Series.Should().HaveCount(2);
+        rendered.Chart.Series.Single(series => series.Key == "marketValue").Values.Should().Equal(100m, 40m);
+        rendered.Chart.Series.Single(series => series.Key == "pnl").Values.Should().Equal(10m, -2m);
+        rendered.Chart.Warnings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RenderGrids_ChartWithUnknownValueColumnRetainsWarning()
+    {
+        var rows = new[]
+        {
+            Row(("sector", "Technology"), ("marketValue", "100"))
+        };
+        var grids = new[]
+        {
+            new ReportWriterGridDefinitionDto(
+                "sector-pivot",
+                "Sector Pivot",
+                ReportWriterGridKindDto.Pivot,
+                RowFields: ["sector"],
+                Metrics: [new ReportWriterMetricDefinitionDto("marketValue", "marketValue")],
+                Chart: new ReportWriterChartDefinitionDto(
+                    ReportWriterChartTypeDto.Line,
+                    "sector",
+                    ["marketValue", "missingColumn"]))
+        };
+
+        var rendered = ReportWriterGridEngine.RenderGrids(grids, rows).Single();
+
+        rendered.Chart.Should().NotBeNull();
+        rendered.Chart!.Warnings.Should().Contain(warning =>
+            warning.Contains("missingColumn", StringComparison.OrdinalIgnoreCase));
+        rendered.Chart.Series.Single(series => series.Key == "missingColumn").Values.Should().Equal(0m);
+    }
+
     private static IReadOnlyDictionary<string, string> Row(params (string Key, string Value)[] values) =>
         values.ToDictionary(static value => value.Key, static value => value.Value, StringComparer.OrdinalIgnoreCase);
 }


### PR DESCRIPTION
## Summary

Adds three major reporting UI features to the dashboard:

1. **Reporting Hub** – A report-first overview organized by template family, answering "which report do I need, is it current, and where do I open it?" Displays readiness signals (Released/Approved/InReview/Draft/Failed) and direct links to the latest output, complementing the production-queue-focused run list below.

2. **Reporting Period Switcher** – A compact "as of" date control for navigating reporting periods by month, jumping to presets (previous day/month/quarter/year), or picking a custom ISO date, without leaving the run surface.

3. **Report Writer Grid Diff** – Period-over-period comparison of rendered grids, matching rows by key and computing signed deltas for numeric cells. Classifies rows as Added/Removed/Changed/Unchanged and includes inline chart preview and conditional formatting support.

## Reason

These features improve the reporting workspace UX by:
- Shifting focus from production queue to report availability and currency (hub)
- Enabling quick period navigation without modal dialogs (switcher)
- Allowing analysts to compare snapshots without re-querying source data (diff)

All three are pure, deterministic, and unit-tested, keeping presentation logic out of React components.

## Changes

### Server-side (.NET)

- **`ReportSnapshotDiffEngine.cs`** (new) – Deterministic period-over-period diff engine matching rows by key, computing deltas, and classifying row states.
- **`ReportWriterGridEngine.cs`** (modified) – Added `ApplyFormatRules()` to apply conditional formatting style hints and `BuildChart()` to render inline charts from grid definitions.
- **`FundOperationsWorkspaceDtos.cs`** (modified) – Added `ReportWriterFormatRuleDto`, `ReportWriterChartDefinitionDto`, `ReportWriterChartRenderDto`, `ReportWriterCellStyleDto`, and `ReportWriterChartTypeDto` contracts; extended `ReportWriterGridDefinitionDto` and `ReportWriterGridRowDto` with format rules, chart definitions, and style hints.

### Client-side (TypeScript/React)

- **`reporting-hub.ts`** (new) – Pure model builder grouping runs by template family, computing readiness, and resolving open links.
- **`reporting-periods.ts`** (new) – Pure period math for ISO date validation, shifting (day/month/quarter/year with day clamping), formatting, and preset generation.
- **`report-writer-grid-diff.ts`** (new) – Client-side diff builder mirroring the server engine; matches rows, computes deltas, and classifies states.
- **`report-writer-grid-format.ts`** (new) – Presentation helpers for cell styling and chart geometry normalization.
- **`reporting-hub.tsx`** (new) – React component rendering report cards by family with readiness badges and open links.
- **`reporting-period-switcher.tsx`** (new) – React component for month navigation and preset selection.
- **`report-writer-grid-diff-view.tsx`** (new) – React component rendering period-over-period comparison with delta columns.
- **`report-writer-chart-preview.tsx`** (new) – Dependency-free inline chart preview using normalized bar geometry.
- **`reporting-screen.tsx`** (modified) – Integrated hub, switcher, diff view, and chart preview components.
- **`types.ts`** (modified) – Added type definitions for cell styles, chart types, diff row states, and diff directions.

### Tests

- **`reporting-hub.test.ts`** (new) – Unit tests for hub model building, readiness classification, and open-link resolution.
- **`reporting-periods.test.ts`** (new) – Unit tests for ISO date parsing, validation, shifting with day clamping, and preset generation.
- **`report-writer-grid-diff.test.ts`** (new) – Unit tests for row classification, delta computation, and warning generation.
- **`report-writer-grid-format.test.ts`** (

https://claude.ai/code/session_01QPcXaJoJcARGPMXisBWgVp