### PR TITLE
Bound slow test lanes

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -883,6 +883,7 @@ Meridian-main
 │   ├── labeler.yml
 │   ├── labels.yml
 │   ├── markdown-link-check-config.json
+│   ├── PULL_REQUEST_TEMPLATE.md
 │   ├── pull_request_template.md
 │   ├── pull_request_template_desktop.md
 │   └── spellcheck-config.yml

--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -883,7 +883,6 @@ Meridian-main
 │   ├── labeler.yml
 │   ├── labels.yml
 │   ├── markdown-link-check-config.json
-│   ├── PULL_REQUEST_TEMPLATE.md
 │   ├── pull_request_template.md
 │   ├── pull_request_template_desktop.md
 │   └── spellcheck-config.yml
@@ -3197,9 +3196,12 @@ Meridian-main
 │   │   │   ├── IConfigurationProvider.cs
 │   │   │   ├── IConfigValidator.cs
 │   │   │   ├── ProviderConnectionsConfig.cs
+│   │   │   ├── ProviderModulesConfig.cs
 │   │   │   ├── SensitiveValueMasker.cs
 │   │   │   ├── SyntheticMarketDataConfig.cs
 │   │   │   └── ValidatedConfig.cs
+│   │   ├── Contracts
+│   │   │   └── IProviderCredentialStore.cs
 │   │   ├── Diagnostics
 │   │   │   └── RuntimeDiagnosticRedactor.cs
 │   │   ├── Exceptions
@@ -4074,6 +4076,7 @@ Meridian-main
 │   │   ├── Backfill
 │   │   │   └── BackfillJob.cs
 │   │   ├── AttributeCredentialResolver.cs
+│   │   ├── ConfigurableProviderModuleBase.cs
 │   │   ├── CredentialSchemaRegistry.cs
 │   │   ├── CredentialValidator.cs
 │   │   ├── DataSourceAttribute.cs
@@ -4089,10 +4092,14 @@ Meridian-main
 │   │   ├── IProviderFamilyAdapter.cs
 │   │   ├── IProviderMetadata.cs
 │   │   ├── IProviderModule.cs
+│   │   ├── IProviderModuleConnectionProbe.cs
+│   │   ├── IProviderModuleCredentialHints.cs
+│   │   ├── IProviderModuleSettingsSchema.cs
 │   │   ├── IRealtimeDataSource.cs
 │   │   ├── Meridian.ProviderSdk.csproj
 │   │   ├── PluginLoaderService.cs
 │   │   ├── ProviderHttpUtilities.cs
+│   │   ├── ProviderModuleContext.cs
 │   │   ├── ProviderModuleLoader.cs
 │   │   ├── ProviderRoutingModels.cs
 │   │   ├── README.md
@@ -4491,7 +4498,12 @@ Meridian-main
 │   │   │   │   │       └── meridian-mark.svg
 │   │   │   │   ├── components
 │   │   │   │   │   ├── data
+│   │   │   │   │   │   ├── add-provider-drawer.tsx
 │   │   │   │   │   │   ├── backfill-validation-dashboard.tsx
+│   │   │   │   │   │   ├── edit-provider-drawer.tsx
+│   │   │   │   │   │   ├── provider-capability-badges.tsx
+│   │   │   │   │   │   ├── provider-setup-panel.test.tsx
+│   │   │   │   │   │   ├── provider-setup-panel.tsx
 │   │   │   │   │   │   ├── symbol-universe-manager.test.tsx
 │   │   │   │   │   │   └── symbol-universe-manager.tsx
 │   │   │   │   │   ├── meridian
@@ -4604,6 +4616,8 @@ Meridian-main
 │   │   │   │   │   │   ├── storage.test.ts
 │   │   │   │   │   │   ├── storage.ts
 │   │   │   │   │   │   └── types.ts
+│   │   │   │   │   ├── provider-setup
+│   │   │   │   │   │   └── use-provider-setup.ts
 │   │   │   │   │   ├── api-errors.test.ts
 │   │   │   │   │   ├── api-errors.ts
 │   │   │   │   │   ├── api.extensibility.test.ts
@@ -4721,7 +4735,8 @@ Meridian-main
 │   │   │   │   │   ├── render.tsx
 │   │   │   │   │   └── setup.ts
 │   │   │   │   ├── types
-│   │   │   │   │   └── covered-call.types.ts
+│   │   │   │   │   ├── covered-call.types.ts
+│   │   │   │   │   └── provider-setup.ts
 │   │   │   │   ├── app-shell.view-model.test.ts
 │   │   │   │   ├── app-shell.view-model.ts
 │   │   │   │   ├── app.test.tsx
@@ -4953,6 +4968,7 @@ Meridian-main
 │   │   │   ├── ProviderCredentialEndpoints.cs
 │   │   │   ├── ProviderEndpoints.cs
 │   │   │   ├── ProviderExtendedEndpoints.cs
+│   │   │   ├── ProviderModuleEndpoints.cs
 │   │   │   ├── ProviderRoutingEndpoints.cs
 │   │   │   ├── QuantLabEndpoints.cs
 │   │   │   ├── ReplayEndpoints.cs
@@ -5049,6 +5065,7 @@ Meridian-main
 │   │   │   ├── IBackfillProviderConfigAuditReader.cs
 │   │   │   ├── InMemoryOperatorInboxService.cs
 │   │   │   ├── InvestmentAccountingTransactionLabService.cs
+│   │   │   ├── IProviderModuleSetupService.cs
 │   │   │   ├── LedgerAmountProvenanceService.cs
 │   │   │   ├── MultiAssetCoverageReadService.cs
 │   │   │   ├── OmsIntegrationService.cs
@@ -5059,7 +5076,10 @@ Meridian-main
 │   │   │   ├── PortfolioLedgerWorkflowStatusService.cs
 │   │   │   ├── PrivateCapitalFundEventCommandCenterService.cs
 │   │   │   ├── ProviderConnectionLifecycleService.cs
+│   │   │   ├── ProviderCredentialStore.cs
 │   │   │   ├── ProviderLedgerReconciliationService.cs
+│   │   │   ├── ProviderModuleSetupModels.cs
+│   │   │   ├── ProviderModuleSetupService.cs
 │   │   │   ├── ProviderNavigationRouteMapper.cs
 │   │   │   ├── ProviderReadinessService.cs
 │   │   │   ├── ReconciliationApiService.cs
@@ -6091,7 +6111,9 @@ Meridian-main
 │   │   │   │   ├── PreflightCheckerTests.cs
 │   │   │   │   └── RuntimeDiagnosticRedactorTests.cs
 │   │   │   ├── Ui
-│   │   │   │   └── ConfigStoreTests.cs
+│   │   │   │   ├── ConfigStoreTests.cs
+│   │   │   │   ├── ProviderCredentialStoreTests.cs
+│   │   │   │   └── ProviderModuleSetupServiceTests.cs
 │   │   │   ├── Wizard
 │   │   │   │   └── WizardConfigurationStepTests.cs
 │   │   │   ├── DirectLendingServiceTests.cs

--- a/docs/status/TODO.md
+++ b/docs/status/TODO.md
@@ -167,8 +167,8 @@ Total items: **190**
 | `src/Meridian.Ui/dashboard/src/screens/settings-screen.test.tsx` | 1616 | `NOTE` | ❌ | note: "Reviewed from the Settings Provider Connection Center runtime evidence panel." |
 | `src/Meridian.Ui/dashboard/src/screens/settings-screen.test.tsx` | 1663 | `NOTE` | ❌ | note: "Marked from the Settings Provider Connection Center for replay after mapping changes." |
 | `src/Meridian.Ui/dashboard/src/screens/settings-screen.test.tsx` | 1683 | `NOTE` | ❌ | note: "Ignored from the Settings Provider Connection Center after operator review." |
-| `src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx` | 1459 | `NOTE` | ❌ | note: "Approved from the Settings Provider Connection Center promotion readiness panel.", |
-| `src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx` | 1586 | `NOTE` | ❌ | note: providerRuntimeQuarantineActionNote(action) |
+| `src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx` | 1468 | `NOTE` | ❌ | note: "Approved from the Settings Provider Connection Center promotion readiness panel.", |
+| `src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx` | 1595 | `NOTE` | ❌ | note: providerRuntimeQuarantineActionNote(action) |
 | `src/Meridian.Ui/dashboard/src/screens/w4-acceptance-parity.test.ts` | 429 | `NOTE` | ❌ | note: "Close evidence reviewed." |
 | `src/Meridian.Ui/dashboard/src/screens/w4-acceptance-parity.test.ts` | 437 | `NOTE` | ❌ | note: "Published to investor portal." |
 | `src/Meridian.Ui/dashboard/src/types.ts` | 3924 | `NOTE` | ❌ | note: string; |

--- a/docs/status/api-contract-coverage-dashboard.json
+++ b/docs/status/api-contract-coverage-dashboard.json
@@ -2,13 +2,13 @@
   "dashboard": "api-contract-coverage",
   "title": "API Contract Coverage Dashboard",
   "generated_at": "1970-01-01T00:00:00+00:00",
-  "score_percent": 100.0,
-  "endpoint_coverage_percent": 100.0,
+  "score_percent": 99.2,
+  "endpoint_coverage_percent": 98.6,
   "contract_coverage_percent": 100.0,
   "summary": {
-    "endpoint_count": 580,
+    "endpoint_count": 588,
     "documented_endpoint_count": 580,
-    "undocumented_endpoint_count": 0,
+    "undocumented_endpoint_count": 8,
     "workstation_contract_count": 779,
     "documented_workstation_contract_count": 779,
     "undocumented_workstation_contract_count": 0
@@ -2677,6 +2677,54 @@
       "path": "/api/providers/dashboard",
       "source": "src/Meridian.Ui.Shared/Endpoints/ProviderExtendedEndpoints.cs:278",
       "documented": true
+    },
+    {
+      "method": "GET",
+      "path": "/api/providers/modules",
+      "source": "src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:23",
+      "documented": false
+    },
+    {
+      "method": "GET",
+      "path": "/api/providers/modules/catalogue",
+      "source": "src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:40",
+      "documented": false
+    },
+    {
+      "method": "POST",
+      "path": "/api/providers/modules",
+      "source": "src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:56",
+      "documented": false
+    },
+    {
+      "method": "PUT",
+      "path": "/api/providers/modules/{moduleId}",
+      "source": "src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:82",
+      "documented": false
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/providers/modules/{moduleId}",
+      "source": "src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:110",
+      "documented": false
+    },
+    {
+      "method": "PUT",
+      "path": "/api/providers/modules/{moduleId}/enabled",
+      "source": "src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:135",
+      "documented": false
+    },
+    {
+      "method": "POST",
+      "path": "/api/providers/modules/{moduleId}/test",
+      "source": "src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:158",
+      "documented": false
+    },
+    {
+      "method": "POST",
+      "path": "/api/providers/restart",
+      "source": "src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:177",
+      "documented": false
     },
     {
       "method": "GET",

--- a/docs/status/api-contract-coverage-dashboard.json
+++ b/docs/status/api-contract-coverage-dashboard.json
@@ -2,13 +2,13 @@
   "dashboard": "api-contract-coverage",
   "title": "API Contract Coverage Dashboard",
   "generated_at": "1970-01-01T00:00:00+00:00",
-  "score_percent": 99.2,
-  "endpoint_coverage_percent": 98.6,
+  "score_percent": 100.0,
+  "endpoint_coverage_percent": 100.0,
   "contract_coverage_percent": 100.0,
   "summary": {
     "endpoint_count": 588,
-    "documented_endpoint_count": 580,
-    "undocumented_endpoint_count": 8,
+    "documented_endpoint_count": 588,
+    "undocumented_endpoint_count": 0,
     "workstation_contract_count": 779,
     "documented_workstation_contract_count": 779,
     "undocumented_workstation_contract_count": 0
@@ -2682,49 +2682,49 @@
       "method": "GET",
       "path": "/api/providers/modules",
       "source": "src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:23",
-      "documented": false
+      "documented": true
     },
     {
       "method": "GET",
       "path": "/api/providers/modules/catalogue",
       "source": "src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:40",
-      "documented": false
+      "documented": true
     },
     {
       "method": "POST",
       "path": "/api/providers/modules",
       "source": "src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:56",
-      "documented": false
+      "documented": true
     },
     {
       "method": "PUT",
       "path": "/api/providers/modules/{moduleId}",
       "source": "src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:82",
-      "documented": false
+      "documented": true
     },
     {
       "method": "DELETE",
       "path": "/api/providers/modules/{moduleId}",
       "source": "src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:110",
-      "documented": false
+      "documented": true
     },
     {
       "method": "PUT",
       "path": "/api/providers/modules/{moduleId}/enabled",
       "source": "src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:135",
-      "documented": false
+      "documented": true
     },
     {
       "method": "POST",
       "path": "/api/providers/modules/{moduleId}/test",
       "source": "src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:158",
-      "documented": false
+      "documented": true
     },
     {
       "method": "POST",
       "path": "/api/providers/restart",
       "source": "src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:177",
-      "documented": false
+      "documented": true
     },
     {
       "method": "GET",

--- a/docs/status/api-contract-coverage-dashboard.md
+++ b/docs/status/api-contract-coverage-dashboard.md
@@ -11,10 +11,10 @@ Tracks whether mapped API routes and workstation DTO contracts are visible in th
 
 | Metric | Value |
 |---|---:|
-| Weighted score | 100.0% |
-| Endpoint coverage | 100.0% |
+| Weighted score | 99.2% |
+| Endpoint coverage | 98.6% |
 | Workstation contract coverage | 100.0% |
-| Endpoints documented | 580 / 580 |
+| Endpoints documented | 580 / 588 |
 | Workstation contracts documented | 779 / 779 |
 
 ## Endpoint Coverage
@@ -368,8 +368,16 @@ Tracks whether mapped API routes and workstation DTO contracts are visible in th
 | `GET` | `/api/providers/ib/status` | Documented | `src/Meridian.Ui.Shared/Endpoints/IBEndpoints.cs:24` |
 | `GET` | `/api/providers/latency` | Documented | `src/Meridian.Ui.Shared/Endpoints/StatusEndpoints.cs:129` |
 | `GET` | `/api/providers/metrics` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderEndpoints.cs:451` |
+| `GET` | `/api/providers/modules` | Gap | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:23` |
+| `POST` | `/api/providers/modules` | Gap | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:56` |
+| `GET` | `/api/providers/modules/catalogue` | Gap | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:40` |
+| `DELETE` | `/api/providers/modules/{moduleId}` | Gap | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:110` |
+| `PUT` | `/api/providers/modules/{moduleId}` | Gap | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:82` |
+| `PUT` | `/api/providers/modules/{moduleId}/enabled` | Gap | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:135` |
+| `POST` | `/api/providers/modules/{moduleId}/test` | Gap | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:158` |
 | `GET` | `/api/providers/rate-limits` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderExtendedEndpoints.cs:111` |
 | `GET` | `/api/providers/readiness` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderEndpoints.cs:347` |
+| `POST` | `/api/providers/restart` | Gap | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:177` |
 | `GET` | `/api/providers/status` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderEndpoints.cs:359` |
 | `POST` | `/api/providers/switch` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderExtendedEndpoints.cs:164` |
 | `DELETE` | `/api/providers/{providerId}/credentials` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderConnectionEndpoints.cs:87` |
@@ -1388,7 +1396,7 @@ Tracks whether mapped API routes and workstation DTO contracts are visible in th
 
 ## Follow-up Queue
 
-No API contract coverage gaps detected.
+- Document or intentionally suppress 8 mapped endpoint gap(s).
 
 ---
 

--- a/docs/status/api-contract-coverage-dashboard.md
+++ b/docs/status/api-contract-coverage-dashboard.md
@@ -11,10 +11,10 @@ Tracks whether mapped API routes and workstation DTO contracts are visible in th
 
 | Metric | Value |
 |---|---:|
-| Weighted score | 99.2% |
-| Endpoint coverage | 98.6% |
+| Weighted score | 100.0% |
+| Endpoint coverage | 100.0% |
 | Workstation contract coverage | 100.0% |
-| Endpoints documented | 580 / 588 |
+| Endpoints documented | 588 / 588 |
 | Workstation contracts documented | 779 / 779 |
 
 ## Endpoint Coverage
@@ -368,16 +368,16 @@ Tracks whether mapped API routes and workstation DTO contracts are visible in th
 | `GET` | `/api/providers/ib/status` | Documented | `src/Meridian.Ui.Shared/Endpoints/IBEndpoints.cs:24` |
 | `GET` | `/api/providers/latency` | Documented | `src/Meridian.Ui.Shared/Endpoints/StatusEndpoints.cs:129` |
 | `GET` | `/api/providers/metrics` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderEndpoints.cs:451` |
-| `GET` | `/api/providers/modules` | Gap | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:23` |
-| `POST` | `/api/providers/modules` | Gap | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:56` |
-| `GET` | `/api/providers/modules/catalogue` | Gap | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:40` |
-| `DELETE` | `/api/providers/modules/{moduleId}` | Gap | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:110` |
-| `PUT` | `/api/providers/modules/{moduleId}` | Gap | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:82` |
-| `PUT` | `/api/providers/modules/{moduleId}/enabled` | Gap | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:135` |
-| `POST` | `/api/providers/modules/{moduleId}/test` | Gap | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:158` |
+| `GET` | `/api/providers/modules` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:23` |
+| `POST` | `/api/providers/modules` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:56` |
+| `GET` | `/api/providers/modules/catalogue` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:40` |
+| `DELETE` | `/api/providers/modules/{moduleId}` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:110` |
+| `PUT` | `/api/providers/modules/{moduleId}` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:82` |
+| `PUT` | `/api/providers/modules/{moduleId}/enabled` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:135` |
+| `POST` | `/api/providers/modules/{moduleId}/test` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:158` |
 | `GET` | `/api/providers/rate-limits` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderExtendedEndpoints.cs:111` |
 | `GET` | `/api/providers/readiness` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderEndpoints.cs:347` |
-| `POST` | `/api/providers/restart` | Gap | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:177` |
+| `POST` | `/api/providers/restart` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderModuleEndpoints.cs:177` |
 | `GET` | `/api/providers/status` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderEndpoints.cs:359` |
 | `POST` | `/api/providers/switch` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderExtendedEndpoints.cs:164` |
 | `DELETE` | `/api/providers/{providerId}/credentials` | Documented | `src/Meridian.Ui.Shared/Endpoints/ProviderConnectionEndpoints.cs:87` |
@@ -1396,7 +1396,7 @@ Tracks whether mapped API routes and workstation DTO contracts are visible in th
 
 ## Follow-up Queue
 
-- Document or intentionally suppress 8 mapped endpoint gap(s).
+No API contract coverage gaps detected.
 
 ---
 

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,17 +5,17 @@
 
 ## Overall Coverage
 
-**2500 / 7122** items documented (**35.1%**) &mdash; Grade: **F**
+**2511 / 7142** items documented (**35.2%**) &mdash; Grade: **F**
 
 ```text
-[=======-------------] 35.1%
+[=======-------------] 35.2%
 ```
 
 ## Coverage by Category
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 2379 | 6627 | 35.9% | F |
+| Public Classes / Interfaces | 2390 | 6647 | 36.0% | F |
 | API Endpoints | 107 | 348 | 30.7% | F |
 | Configuration Options | 3 | 136 | 2.2% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |
@@ -23,7 +23,7 @@
 
 ## Undocumented Items
 
-### Public Classes / Interfaces (4248 undocumented)
+### Public Classes / Interfaces (4257 undocumented)
 
 | Item | Location |
 | ------ | ---------- |
@@ -77,7 +77,7 @@
 | `ExecutionStatistics` | `src/Meridian.Application/Scheduling/BackfillExecutionLog.cs:185` |
 | `ProviderUsageStats` | `src/Meridian.Application/Scheduling/BackfillExecutionLog.cs:218` |
 | `SymbolExecutionResult` | `src/Meridian.Application/Scheduling/BackfillExecutionLog.cs:234` |
-| ... and 4198 more | |
+| ... and 4207 more | |
 
 ### API Endpoints (241 undocumented)
 
@@ -193,7 +193,7 @@
 
 ## Recommendations
 
-1. **Public Classes / Interfaces**: 4248 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
+1. **Public Classes / Interfaces**: 4257 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
 2. **API Endpoints**: 241 endpoint(s) missing from `docs/reference/api-reference.md`. Run the endpoint audit and update the API reference table.
 3. **Configuration Options**: 133 config key(s) not found in `docs/generated/configuration-schema.md`. Re-run the configuration schema generator to synchronise.
 

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 533,
-  "total_lines": 85474,
+  "total_lines": 85496,
   "orphaned_count": 203,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2128,7 +2128,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7148,
+      "line_count": 7170,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 533,
-  "total_lines": 85496,
+  "total_lines": 85497,
   "orphaned_count": 203,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2128,7 +2128,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7170,
+      "line_count": 7171,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 533 |
-| Total lines | 85,474 |
+| Total lines | 85,496 |
 | Average file size (lines) | 160.4 |
 | Orphaned files | 203 |
 | Files without headings | 38 |

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 533 |
-| Total lines | 85,496 |
+| Total lines | 85,497 |
 | Average file size (lines) | 160.4 |
 | Orphaned files | 203 |
 | Files without headings | 38 |

--- a/docs/status/wpf-screen-development-tracker.json
+++ b/docs/status/wpf-screen-development-tracker.json
@@ -7,7 +7,7 @@
     "name": "scripts/generate-diagrams.mjs --tracker-only",
     "version": "1.0.0"
   },
-  "sourceFingerprint": "b7c08cdd8835",
+  "sourceFingerprint": "8d6ee90b481d",
   "baselineDate": "2026-06-17",
   "summary": {
     "screenCount": 92,

--- a/docs/status/wpf-screen-development-tracker.md
+++ b/docs/status/wpf-screen-development-tracker.md
@@ -15,7 +15,7 @@ do_not_edit: true
 
 This tracker is generated from the live WPF shell registry, the maintained desktop screenshot index, and a text scan of `tests/Meridian.Wpf.Tests` for route, page, and view-model references. It tracks source-derived evidence only; roadmap priority and product scope still belong in `docs/roadmap/data/*.yml` and the design document.
 
-- Source fingerprint: `b7c08cdd8835`
+- Source fingerprint: `8d6ee90b481d`
 - Baseline date for open Gantt tasks: `2026-06-17`
 - Registered WPF screens: `92`
 - Open automated tasks: `77`

--- a/src/Meridian.Infrastructure/Adapters/Stooq/StooqHistoricalDataProvider.cs
+++ b/src/Meridian.Infrastructure/Adapters/Stooq/StooqHistoricalDataProvider.cs
@@ -36,6 +36,14 @@ public sealed class StooqHistoricalDataProvider : BaseHistoricalDataProvider
     {
     }
 
+    internal StooqHistoricalDataProvider(
+        HttpClient? httpClient,
+        ILogger? log,
+        bool enableResilience)
+        : base(httpClient, log, enableResilience)
+    {
+    }
+
     /// <summary>
     /// Stooq uses lowercase symbols with dots replaced by dashes.
     /// </summary>

--- a/src/Meridian.Ui.Services/Services/BackfillProviderConfigService.cs
+++ b/src/Meridian.Ui.Services/Services/BackfillProviderConfigService.cs
@@ -16,15 +16,24 @@ namespace Meridian.Ui.Services;
 public sealed class BackfillProviderConfigService : IBackfillProviderConfigAuditReader
 {
     private static readonly Lazy<BackfillProviderConfigService> _instance = new(() => new BackfillProviderConfigService());
-    private readonly ApiClientService _apiClient;
+    private readonly Func<CancellationToken, Task<BackfillProviderStatusDto[]?>> _fetchProviderStatusesAsync;
     private readonly List<ProviderConfigAuditEntryDto> _auditLog = new();
     private readonly object _auditLock = new();
 
     public static BackfillProviderConfigService Instance => _instance.Value;
 
     private BackfillProviderConfigService()
+        : this(ct => ApiClientService.Instance.GetAsync<BackfillProviderStatusDto[]>(
+            "/api/backfill/providers/statuses",
+            ct))
     {
-        _apiClient = ApiClientService.Instance;
+    }
+
+    internal BackfillProviderConfigService(
+        Func<CancellationToken, Task<BackfillProviderStatusDto[]?>> fetchProviderStatusesAsync)
+    {
+        _fetchProviderStatusesAsync = fetchProviderStatusesAsync
+            ?? throw new ArgumentNullException(nameof(fetchProviderStatusesAsync));
     }
 
     /// <summary>
@@ -421,8 +430,7 @@ public sealed class BackfillProviderConfigService : IBackfillProviderConfigAudit
 
         try
         {
-            var statuses = await _apiClient.GetAsync<BackfillProviderStatusDto[]>(
-                "/api/backfill/providers/statuses", ct);
+            var statuses = await _fetchProviderStatusesAsync(ct);
 
             if (statuses != null)
             {

--- a/src/Meridian.Ui.Services/Services/SystemHealthService.cs
+++ b/src/Meridian.Ui.Services/Services/SystemHealthService.cs
@@ -13,16 +13,26 @@ namespace Meridian.Ui.Services;
 public sealed class SystemHealthService
 {
     private static readonly Lazy<SystemHealthService> _instance = new(() => new SystemHealthService());
+    private readonly ISystemHealthApiClient _apiClient;
+
     public static SystemHealthService Instance => _instance.Value;
 
-    private SystemHealthService() { }
+    private SystemHealthService()
+        : this(new ApiClientSystemHealthApiClient(ApiClientService.Instance))
+    {
+    }
+
+    internal SystemHealthService(ISystemHealthApiClient apiClient)
+    {
+        _apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
+    }
 
     /// <summary>
     /// Gets overall system health summary.
     /// </summary>
     public async Task<SystemHealthSummary?> GetHealthSummaryAsync(CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<SystemHealthSummary>(UiApiRoutes.HealthSummary, ct);
+        return await _apiClient.GetAsync<SystemHealthSummary>(UiApiRoutes.HealthSummary, ct);
     }
 
     /// <summary>
@@ -30,7 +40,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<List<ProviderHealth>?> GetProviderHealthAsync(CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<List<ProviderHealth>>(UiApiRoutes.HealthProviders, ct);
+        return await _apiClient.GetAsync<List<ProviderHealth>>(UiApiRoutes.HealthProviders, ct);
     }
 
     /// <summary>
@@ -38,7 +48,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<ProviderReadinessSummaryDto?> GetProviderReadinessAsync(CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<ProviderReadinessSummaryDto>(UiApiRoutes.ProviderReadiness, ct);
+        return await _apiClient.GetAsync<ProviderReadinessSummaryDto>(UiApiRoutes.ProviderReadiness, ct);
     }
 
     /// <summary>
@@ -46,7 +56,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<ProviderDiagnostics?> GetProviderDiagnosticsAsync(string provider, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<ProviderDiagnostics>(BuildProviderDiagnosticsRoute(provider), ct);
+        return await _apiClient.GetAsync<ProviderDiagnostics>(BuildProviderDiagnosticsRoute(provider), ct);
     }
 
     /// <summary>
@@ -54,7 +64,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<StorageHealth?> GetStorageHealthAsync(CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<StorageHealth>(UiApiRoutes.HealthStorage, ct);
+        return await _apiClient.GetAsync<StorageHealth>(UiApiRoutes.HealthStorage, ct);
     }
 
     /// <summary>
@@ -62,7 +72,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<List<SystemEvent>?> GetRecentEventsAsync(int limit = 50, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<List<SystemEvent>>(BuildRecentEventsRoute(limit), ct);
+        return await _apiClient.GetAsync<List<SystemEvent>>(BuildRecentEventsRoute(limit), ct);
     }
 
     /// <summary>
@@ -70,7 +80,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<SystemMetrics?> GetSystemMetricsAsync(CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<SystemMetrics>(UiApiRoutes.HealthMetrics, ct);
+        return await _apiClient.GetAsync<SystemMetrics>(UiApiRoutes.HealthMetrics, ct);
     }
 
     /// <summary>
@@ -78,7 +88,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<ConnectionTestResult?> TestConnectionAsync(string provider, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.PostAsync<ConnectionTestResult>(BuildProviderTestRoute(provider), null, ct);
+        return await _apiClient.PostAsync<ConnectionTestResult>(BuildProviderTestRoute(provider), null, ct);
     }
 
     /// <summary>
@@ -86,7 +96,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<DiagnosticBundle?> GenerateDiagnosticBundleAsync(CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.PostAsync<DiagnosticBundle>(UiApiRoutes.HealthDiagnosticsBundle, null, ct);
+        return await _apiClient.PostAsync<DiagnosticBundle>(UiApiRoutes.HealthDiagnosticsBundle, null, ct);
     }
 
     internal static string BuildProviderDiagnosticsRoute(string provider)
@@ -99,6 +109,22 @@ public sealed class SystemHealthService
 
     internal static string BuildProviderTestRoute(string provider)
         => UiApiRoutes.WithParam(UiApiRoutes.HealthProviderTest, "provider", provider);
+}
+
+internal interface ISystemHealthApiClient
+{
+    Task<T?> GetAsync<T>(string endpoint, CancellationToken ct = default) where T : class;
+
+    Task<T?> PostAsync<T>(string endpoint, object? body = null, CancellationToken ct = default) where T : class;
+}
+
+internal sealed class ApiClientSystemHealthApiClient(ApiClientService apiClient) : ISystemHealthApiClient
+{
+    public Task<T?> GetAsync<T>(string endpoint, CancellationToken ct = default) where T : class
+        => apiClient.GetAsync<T>(endpoint, ct);
+
+    public Task<T?> PostAsync<T>(string endpoint, object? body = null, CancellationToken ct = default) where T : class
+        => apiClient.PostAsync<T>(endpoint, body, ct);
 }
 
 // DTO classes for system health

--- a/tests/Meridian.Backtesting.Tests/CorporateActionAdjustmentServiceTests.cs
+++ b/tests/Meridian.Backtesting.Tests/CorporateActionAdjustmentServiceTests.cs
@@ -232,7 +232,7 @@ public sealed class CorporateActionAdjustmentServiceTests
             new CorporateActionDto(Guid.NewGuid(), securityId, "Dividend", new DateOnly(2024, 9, 1), null, 1m, "USD", null, null, null, null, null, null, null)
         ]);
 
-        var bars = Enumerable.Range(0, 50_000)
+        var bars = Enumerable.Range(0, 5_000)
             .Select(i => CreateBar("SPY", new DateOnly(2020, 1, 1).AddDays(i), 100m + i, 101m + i, 99m + i, 100.5m + i, 1_000 + i))
             .ToArray();
 

--- a/tests/Meridian.Tests/Application/Backfill/HistoricalProviderContractTests.cs
+++ b/tests/Meridian.Tests/Application/Backfill/HistoricalProviderContractTests.cs
@@ -385,7 +385,7 @@ public class HistoricalProviderContractTests
     {
         // Arrange
         var httpClient = CreateMockHttpClient("Error", HttpStatusCode.InternalServerError);
-        var provider = new StooqHistoricalDataProvider(httpClient);
+        var provider = new StooqHistoricalDataProvider(httpClient, log: null, enableResilience: false);
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<DataProviderException>(

--- a/tests/Meridian.Tests/Architecture/LayerBoundaryTests.cs
+++ b/tests/Meridian.Tests/Architecture/LayerBoundaryTests.cs
@@ -24,7 +24,7 @@ namespace Meridian.Tests.Architecture;
 public sealed class LayerBoundaryTests
 {
     // Build the architecture model once per test class.
-    private static readonly ArchModel Architecture = new ArchLoader()
+    private static readonly Lazy<ArchModel> Architecture = new(() => new ArchLoader()
         .LoadAssemblies(
             // Leaf / shared contracts
             typeof(Meridian.Contracts.Domain.ProviderId).Assembly,
@@ -38,7 +38,7 @@ public sealed class LayerBoundaryTests
             typeof(Meridian.Ui.Services.Services.Reconciliation.ReconciliationApiService).Assembly,
             // Infrastructure (adapters, providers, resilience)
             typeof(Meridian.Infrastructure.Adapters.Core.ProviderTemplate).Assembly)
-        .Build();
+        .Build());
 
     // ------------------------------------------------------------------ //
     //  Contracts — leaf project (no upstream dependencies)                //
@@ -58,7 +58,7 @@ public sealed class LayerBoundaryTests
                 Types().That().ResideInNamespaceMatching(@"^Meridian\.Domain\."))
             .Because("Contracts is a leaf project that must have zero upstream project dependencies (ADR-001).");
 
-        rule.Check(Architecture);
+        rule.Check(Architecture.Value);
     }
 
     [Fact]
@@ -70,7 +70,7 @@ public sealed class LayerBoundaryTests
                 Types().That().ResideInAssemblyMatching(@"^Meridian\.Infrastructure$"))
             .Because("Contracts is a leaf project that must have zero upstream project dependencies (ADR-001).");
 
-        rule.Check(Architecture);
+        rule.Check(Architecture.Value);
     }
 
     // ------------------------------------------------------------------ //
@@ -80,13 +80,15 @@ public sealed class LayerBoundaryTests
     [Fact]
     public void Domain_ShouldNot_DependOn_Infrastructure()
     {
-        var rule = Types()
-            .That().ResideInNamespaceMatching(@"^Meridian\.Domain\.")
-            .Should().NotDependOnAny(
-                Types().That().ResideInAssemblyMatching(@"^Meridian\.Infrastructure$"))
-            .Because("Domain types must remain independent of Infrastructure to preserve the dependency inversion principle.");
+        var domainAssembly = typeof(Meridian.Domain.Events.MarketEvent).Assembly;
 
-        rule.Check(Architecture);
+        var forbiddenReferences = domainAssembly
+            .GetReferencedAssemblies()
+            .Where(reference => reference.Name is "Meridian.Infrastructure")
+            .Select(reference => reference.Name)
+            .ToArray();
+
+        Assert.Empty(forbiddenReferences);
     }
 
     // ------------------------------------------------------------------ //
@@ -102,7 +104,7 @@ public sealed class LayerBoundaryTests
                 Types().That().ResideInNamespaceMatching(@"^Meridian\.Domain\."))
             .Because("ProviderSdk must only reference Contracts to stay thin and reusable (ADR-001).");
 
-        rule.Check(Architecture);
+        rule.Check(Architecture.Value);
     }
 
     [Fact]
@@ -114,7 +116,7 @@ public sealed class LayerBoundaryTests
                 Types().That().ResideInAssemblyMatching(@"^Meridian\.Infrastructure$"))
             .Because("ProviderSdk must only reference Contracts to stay thin and reusable (ADR-001).");
 
-        rule.Check(Architecture);
+        rule.Check(Architecture.Value);
     }
 
     // ------------------------------------------------------------------ //
@@ -130,7 +132,7 @@ public sealed class LayerBoundaryTests
                 Types().That().ResideInNamespace("Meridian.Infrastructure.Adapters.Polygon"))
             .Because("Provider adapters must not cross-reference peer adapters to keep them independently deployable.");
 
-        rule.Check(Architecture);
+        rule.Check(Architecture.Value);
     }
 
     [Fact]
@@ -142,7 +144,7 @@ public sealed class LayerBoundaryTests
                 Types().That().ResideInNamespace("Meridian.Infrastructure.Adapters.Alpaca"))
             .Because("Provider adapters must not cross-reference peer adapters to keep them independently deployable.");
 
-        rule.Check(Architecture);
+        rule.Check(Architecture.Value);
     }
 
     [Fact]
@@ -154,7 +156,7 @@ public sealed class LayerBoundaryTests
                 Types().That().ResideInNamespace("Meridian.Infrastructure.Adapters.Alpaca"))
             .Because("Provider adapters must not cross-reference peer adapters to keep them independently deployable.");
 
-        rule.Check(Architecture);
+        rule.Check(Architecture.Value);
     }
 
     // ------------------------------------------------------------------ //
@@ -244,6 +246,6 @@ public sealed class LayerBoundaryTests
             .Because("UI reconciliation services should consume application-owned workflows instead of orchestrating infrastructure reconciliation storage directly.")
             .WithoutRequiringPositiveResults();
 
-        rule.Check(Architecture);
+        rule.Check(Architecture.Value);
     }
 }

--- a/tests/Meridian.Tests/Storage/WriteAheadLogTests.cs
+++ b/tests/Meridian.Tests/Storage/WriteAheadLogTests.cs
@@ -262,7 +262,7 @@ public sealed class WriteAheadLogTests : IAsyncDisposable
         var recordCount = Bound(recordCountSeed, minInclusive: 1, maxInclusive: 120);
         var duplicateModulo = Bound(duplicateModuloSeed, minInclusive: 1, maxInclusive: 12);
 
-        await using (var wal = new WriteAheadLog(scenarioDir, new WalOptions { SyncMode = WalSyncMode.EveryWrite }))
+        await using (var wal = new WriteAheadLog(scenarioDir, new WalOptions { SyncMode = WalSyncMode.NoSync }))
         {
             await wal.InitializeAsync();
             for (var i = 0; i < recordCount; i++)

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.Infrastructure.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.Infrastructure.cs
@@ -62,7 +62,9 @@ public sealed partial class WorkstationEndpointsTests
         UserRole? currentUserRole = null,
         string? currentUserRoleProfileName = null,
         string? currentUserCompanyId = "tenant-test",
-        string currentUserName = "ops-user")
+        string currentUserName = "ops-user",
+        bool? mapLedgerApi = null,
+        [System.Runtime.CompilerServices.CallerFilePath] string callerFilePath = "")
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
@@ -121,10 +123,20 @@ public sealed partial class WorkstationEndpointsTests
         }
 
         app.MapWorkstationEndpoints(jsonOptions);
-        app.MapLedgerEndpoints(jsonOptions);
+        if (mapLedgerApi ?? IsLedgerEndpointTestFile(callerFilePath))
+        {
+            app.MapLedgerEndpoints(jsonOptions);
+        }
 
         await app.StartAsync();
         return app;
+    }
+
+    private static bool IsLedgerEndpointTestFile(string callerFilePath)
+    {
+        var fileName = Path.GetFileName(callerFilePath);
+        return string.Equals(fileName, "WorkstationEndpointsTests.Wave4.cs", StringComparison.Ordinal) ||
+            string.Equals(fileName, "WorkstationEndpointsTests.AccountingConfiguration.cs", StringComparison.Ordinal);
     }
 
     private static void RegisterRunReadServices(IServiceCollection services)

--- a/tests/Meridian.Ui.Tests/Services/BackfillProviderConfigServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/BackfillProviderConfigServiceTests.cs
@@ -25,10 +25,13 @@ public sealed class BackfillProviderConfigServiceTests
         a.Should().BeSameAs(b);
     }
 
+    private static BackfillProviderConfigService CreateService()
+        => new(_ => Task.FromResult<BackfillProviderStatusDto[]?>([]));
+
     [Fact]
     public async Task GetProviderMetadataAsync_ReturnsAllKnownProviders()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
 
         var metadata = await service.GetProviderMetadataAsync();
 
@@ -42,7 +45,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task GetProviderMetadataAsync_EachProviderHasRequiredFields()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
 
         var metadata = await service.GetProviderMetadataAsync();
 
@@ -59,7 +62,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task GetProviderStatusesAsync_WithNullConfig_ReturnsDefaults()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
 
         var statuses = await service.GetProviderStatusesAsync(null);
 
@@ -75,7 +78,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task GetProviderStatusesAsync_SortedByPriority()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
 
         var statuses = await service.GetProviderStatusesAsync(null);
 
@@ -89,7 +92,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task GetProviderStatusesAsync_WithCustomConfig_UsesConfigValues()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
 
         var config = new BackfillProvidersConfigDto
         {
@@ -113,7 +116,8 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task GetFallbackChainAsync_OnlyIncludesEnabledProviders()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = new BackfillProviderConfigService(_ =>
+            Task.FromResult<BackfillProviderStatusDto[]?>([]));
 
         var config = new BackfillProvidersConfigDto
         {
@@ -131,7 +135,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task GetFallbackChainAsync_WithAllDefaults_ReturnsAllProviders()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
 
         var chain = await service.GetFallbackChainAsync(null);
 
@@ -141,7 +145,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task GenerateDryRunPlanAsync_ReturnsSymbolPlans()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
         var symbols = new[] { "SPY", "AAPL" };
 
         var plan = await service.GenerateDryRunPlanAsync(null, symbols);
@@ -156,7 +160,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task GenerateDryRunPlanAsync_EachSymbolHasProviderSequence()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
         var symbols = new[] { "MSFT" };
 
         var plan = await service.GenerateDryRunPlanAsync(null, symbols);
@@ -168,7 +172,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task GenerateDryRunPlanAsync_WithAllDisabled_ReturnsValidationError()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
         var config = new BackfillProvidersConfigDto
         {
             Alpaca = new BackfillProviderOptionsDto { Enabled = false },
@@ -190,7 +194,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task GenerateDryRunPlanAsync_DetectsDuplicatePriorities()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
         var config = new BackfillProvidersConfigDto
         {
             Alpaca = new BackfillProviderOptionsDto { Enabled = true, Priority = 10 },
@@ -205,7 +209,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public void RecordAuditEntry_AddsEntry()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
         var initialCount = service.GetAuditLog().Count;
 
         service.RecordAuditEntry("test-provider", "test-action", "old", "new");
@@ -218,7 +222,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public void GetAuditLog_RespectsMaxEntries()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
 
         // Add multiple entries
         for (int i = 0; i < 10; i++)
@@ -233,7 +237,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public void GetAuditLog_OrderedByTimestampDescending()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
         service.RecordAuditEntry("first", "create", null, "v1");
         service.RecordAuditEntry("second", "create", null, "v2");
 
@@ -245,7 +249,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task GetDefaultOptionsAsync_ReturnsMatchingDefaults()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
 
         var defaults = await service.GetDefaultOptionsAsync("alpaca");
 
@@ -257,7 +261,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task GetDefaultOptionsAsync_UnknownProvider_ReturnsGenericDefaults()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
 
         var defaults = await service.GetDefaultOptionsAsync("unknown-provider");
 
@@ -267,7 +271,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task GetProviderStatusesAsync_ConfigSourceBadge_IsDefault_WhenNoOverrides()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
 
         var statuses = await service.GetProviderStatusesAsync(null);
 
@@ -280,7 +284,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task GetProviderStatusesAsync_ConfigSourceBadge_IsUser_WhenOverridden()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
         var config = new BackfillProvidersConfigDto
         {
             Alpaca = new BackfillProviderOptionsDto
@@ -302,7 +306,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task GetProviderMetadataAsync_SomeProvidersHaveFeatureFlags()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
 
         var metadata = await service.GetProviderMetadataAsync();
 
@@ -314,7 +318,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task GetProviderFeatureFlagsAsync_ReturnsFlags()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
 
         var flags = await service.GetProviderFeatureFlagsAsync("alpaca");
 
@@ -325,7 +329,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task GetProviderFeatureFlagsAsync_UnknownProvider_ReturnsEmptyDictionary()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
 
         var flags = await service.GetProviderFeatureFlagsAsync("nonexistent");
 
@@ -335,7 +339,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task IsProviderFeatureEnabledAsync_ReturnsTrueForKnownFlag()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
 
         var result = await service.IsProviderFeatureEnabledAsync("polygon", "supportsAggregates");
 
@@ -345,7 +349,7 @@ public sealed class BackfillProviderConfigServiceTests
     [Fact]
     public async Task IsProviderFeatureEnabledAsync_ReturnsFalseForUnknownFlag()
     {
-        var service = BackfillProviderConfigService.Instance;
+        var service = CreateService();
 
         var result = await service.IsProviderFeatureEnabledAsync("alpaca", "nonexistentFlag");
 

--- a/tests/Meridian.Ui.Tests/Services/SystemHealthServiceTests.cs
+++ b/tests/Meridian.Ui.Tests/Services/SystemHealthServiceTests.cs
@@ -215,7 +215,7 @@ public sealed class SystemHealthServiceTests
     public async Task GetHealthSummaryAsync_WithoutCancellation_AcceptsDefaultToken()
     {
         // Arrange
-        var service = SystemHealthService.Instance;
+        var service = new SystemHealthService(new NullSystemHealthApiClient());
 
         // Act - Call without cancellation token (uses default)
         // API is unavailable in test environment; method should return null gracefully
@@ -351,5 +351,20 @@ public sealed class SystemHealthServiceTests
 
         // Assert - Verify async behavior
         await act.Should().ThrowAsync<Exception>();
+    }
+
+    private sealed class NullSystemHealthApiClient : ISystemHealthApiClient
+    {
+        public Task<T?> GetAsync<T>(string endpoint, CancellationToken ct = default) where T : class
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult<T?>(null);
+        }
+
+        public Task<T?> PostAsync<T>(string endpoint, object? body = null, CancellationToken ct = default) where T : class
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult<T?>(null);
+        }
     }
 }

--- a/tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj
+++ b/tests/Meridian.Wpf.Tests/Meridian.Wpf.Tests.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <EnableFullWpfBuild Condition="'$(EnableFullWpfBuild)' == ''">false</EnableFullWpfBuild>
     <!-- Detect Windows platform -->
     <IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>
     <IsWindows Condition="'$(IsWindows)' != 'true' AND $([MSBuild]::IsOSPlatform('Windows'))">true</IsWindows>
     <IsWindows Condition="'$(IsWindows)' != 'true' AND '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'True'">true</IsWindows>
     <IsWindows Condition="'$(IsWindows)' == ''">false</IsWindows>
+    <EnableFullWpfBuild Condition="'$(EnableFullWpfBuild)' == '' AND '$(IsWindows)' == 'true'">true</EnableFullWpfBuild>
+    <EnableFullWpfBuild Condition="'$(EnableFullWpfBuild)' == ''">false</EnableFullWpfBuild>
   </PropertyGroup>
 
   <!-- Windows-only: keep the target graph stable even when full test compilation is disabled -->
@@ -18,7 +19,7 @@
     <IsTestProject>true</IsTestProject>
     <UseWPF>true</UseWPF>
     <OutputType>Library</OutputType>
-    <!-- Full WPF test sources are opt-in, but restore/build should agree on the Windows target framework. -->
+    <!-- Full WPF test sources are enabled by default on Windows; non-Windows keeps the stub target below. -->
     <EnableDefaultCompileItems Condition="'$(EnableFullWpfBuild)' != 'true'">false</EnableDefaultCompileItems>
   </PropertyGroup>
 

--- a/tests/Meridian.Wpf.Tests/Services/MessagingServiceTests.cs
+++ b/tests/Meridian.Wpf.Tests/Services/MessagingServiceTests.cs
@@ -42,7 +42,8 @@ public sealed class MessagingServiceTests
     {
         var svc = Svc;
         bool eventRaised = false;
-        void Handler(object? sender, string msg) { eventRaised = true; }
+        void Handler(object? sender, string msg)
+        { eventRaised = true; }
         svc.MessageReceived += Handler;
 
         svc.Send("");
@@ -85,7 +86,8 @@ public sealed class MessagingServiceTests
         var svc = Svc;
         var messageName = "AlsoEvent-" + Guid.NewGuid();
         string? receivedMsg = null;
-        void Handler(object? sender, string msg) { receivedMsg = msg; }
+        void Handler(object? sender, string msg)
+        { receivedMsg = msg; }
         svc.MessageReceived += Handler;
 
         svc.SendNamed(messageName);

--- a/tests/Meridian.Wpf.Tests/Services/NavigationServiceTests.cs
+++ b/tests/Meridian.Wpf.Tests/Services/NavigationServiceTests.cs
@@ -1,9 +1,9 @@
-using System.Runtime.ExceptionServices;
 using System.Windows.Controls;
 using Meridian.Contracts.Workstation;
 using Meridian.Wpf.Models;
 using Meridian.Wpf.Contracts;
 using Meridian.Wpf.Services;
+using Meridian.Wpf.Tests.Support;
 using Meridian.Wpf.Views;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -24,23 +24,6 @@ public sealed class NavigationServiceTests : IDisposable
     public NavigationServiceTests()
     {
         NavigationService.Instance.ResetForTests();
-    }
-
-    /// <summary>
-    /// Runs an action on a dedicated STA thread. Required for tests that create WPF UI objects.
-    /// </summary>
-    private static void RunOnSta(Action action)
-    {
-        ExceptionDispatchInfo? captured = null;
-        var thread = new Thread(() =>
-        {
-            try { action(); }
-            catch (Exception ex) { captured = ExceptionDispatchInfo.Capture(ex); }
-        });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
-        captured?.Throw();
     }
 
     public void Dispose()
@@ -64,7 +47,7 @@ public sealed class NavigationServiceTests : IDisposable
     [Fact]
     public void Initialize_WithValidFrame_ShouldSetFrame()
     {
-        RunOnSta(() =>
+        WpfTestThread.Run(() =>
         {
             // Arrange
             var service = NavigationService.Instance;
@@ -120,7 +103,7 @@ public sealed class NavigationServiceTests : IDisposable
     [Fact]
     public void NavigateTo_WithUnregisteredPageTag_ShouldReturnFalse()
     {
-        RunOnSta(() =>
+        WpfTestThread.Run(() =>
         {
             // Arrange
             var service = NavigationService.Instance;
@@ -163,7 +146,7 @@ public sealed class NavigationServiceTests : IDisposable
     [Fact]
     public void CreatePageContent_WithWorkspaceScope_ShouldResolvePageFromScope()
     {
-        RunOnSta(() =>
+        WpfTestThread.Run(() =>
         {
             var service = NavigationService.Instance;
             var scopedPage = new WorkspaceCapabilityHomePage();
@@ -182,7 +165,7 @@ public sealed class NavigationServiceTests : IDisposable
     [Fact]
     public void NavigateTo_WithWorkspaceScope_ShouldResolvePageFromScope()
     {
-        RunOnSta(() =>
+        WpfTestThread.Run(() =>
         {
             var service = NavigationService.Instance;
             var frame = new Frame();
@@ -372,7 +355,7 @@ public sealed class NavigationServiceTests : IDisposable
     [InlineData("Blotter", "PositionBlotter")]
     public void NavigateTo_WithAlias_ShouldStoreCanonicalPageTag(string alias, string canonicalPageTag)
     {
-        RunOnSta(() =>
+        WpfTestThread.Run(() =>
         {
             var service = NavigationService.Instance;
             var frame = new Frame();
@@ -393,7 +376,7 @@ public sealed class NavigationServiceTests : IDisposable
     [Fact]
     public void NavigateTo_WithOperationsCloseAlias_ShouldStoreFundLedgerAndKeepReportPackContext()
     {
-        RunOnSta(() =>
+        WpfTestThread.Run(() =>
         {
             var service = NavigationService.Instance;
             var frame = new Frame();
@@ -414,7 +397,7 @@ public sealed class NavigationServiceTests : IDisposable
     [Fact]
     public void NavigateTo_WithParameterizedEvidenceWorkbenchTarget_ShouldStoreCanonicalAuditTrailPage()
     {
-        RunOnSta(() =>
+        WpfTestThread.Run(() =>
         {
             var service = NavigationService.Instance;
             var frame = new Frame();
@@ -444,7 +427,7 @@ public sealed class NavigationServiceTests : IDisposable
     [Fact]
     public void CreatePageContent_WithParameterizedEvidenceWorkbenchTarget_ShouldCreateCanonicalAuditTrailContent()
     {
-        RunOnSta(() =>
+        WpfTestThread.Run(() =>
         {
             var service = NavigationService.Instance;
 
@@ -473,7 +456,7 @@ public sealed class NavigationServiceTests : IDisposable
     [Fact]
     public void NavigateTo_WithValidPageTag_ShouldNavigateAndRaiseEvent()
     {
-        RunOnSta(() =>
+        WpfTestThread.Run(() =>
         {
             // Arrange
             var service = NavigationService.Instance;
@@ -511,7 +494,7 @@ public sealed class NavigationServiceTests : IDisposable
     [Fact]
     public void GetBreadcrumbs_AfterNavigation_ShouldContainEntry()
     {
-        RunOnSta(() =>
+        WpfTestThread.Run(() =>
         {
             // Arrange
             var service = NavigationService.Instance;

--- a/tests/Meridian.Wpf.Tests/Services/PendingOperationsQueueServiceTests.cs
+++ b/tests/Meridian.Wpf.Tests/Services/PendingOperationsQueueServiceTests.cs
@@ -82,7 +82,8 @@ public sealed class PendingOperationsQueueServiceTests
         // Arrange
         var service = PendingOperationsQueueService.Instance;
         // Drain existing items
-        while (service.Dequeue() != null) { }
+        while (service.Dequeue() != null)
+        { }
         var initialCount = service.PendingCount;
 
         // Act
@@ -100,7 +101,8 @@ public sealed class PendingOperationsQueueServiceTests
     {
         // Arrange
         var service = PendingOperationsQueueService.Instance;
-        while (service.Dequeue() != null) { }
+        while (service.Dequeue() != null)
+        { }
         service.Enqueue("test-dequeue", "payload-data");
 
         // Act
@@ -117,7 +119,8 @@ public sealed class PendingOperationsQueueServiceTests
     {
         // Arrange
         var service = PendingOperationsQueueService.Instance;
-        while (service.Dequeue() != null) { }
+        while (service.Dequeue() != null)
+        { }
 
         // Act
         var result = service.Dequeue();
@@ -131,7 +134,8 @@ public sealed class PendingOperationsQueueServiceTests
     {
         // Arrange
         var service = PendingOperationsQueueService.Instance;
-        while (service.Dequeue() != null) { }
+        while (service.Dequeue() != null)
+        { }
         service.Enqueue("peek-test", null);
 
         // Act
@@ -152,7 +156,8 @@ public sealed class PendingOperationsQueueServiceTests
     {
         // Arrange
         var service = PendingOperationsQueueService.Instance;
-        while (service.Dequeue() != null) { }
+        while (service.Dequeue() != null)
+        { }
         service.Enqueue("op-1", null);
         service.Enqueue("op-2", null);
 
@@ -164,7 +169,8 @@ public sealed class PendingOperationsQueueServiceTests
         all.Count.Should().BeGreaterThanOrEqualTo(2);
 
         // Cleanup
-        while (service.Dequeue() != null) { }
+        while (service.Dequeue() != null)
+        { }
     }
 
     [Fact]
@@ -243,7 +249,8 @@ public sealed class PendingOperationsQueueServiceTests
     {
         // Arrange
         var service = PendingOperationsQueueService.Instance;
-        while (service.Dequeue() != null) { }
+        while (service.Dequeue() != null)
+        { }
 
         var processedItems = new List<string>();
         service.RegisterHandler("process-test", payload =>
@@ -271,7 +278,8 @@ public sealed class PendingOperationsQueueServiceTests
     {
         // Arrange
         var service = PendingOperationsQueueService.Instance;
-        while (service.Dequeue() != null) { }
+        while (service.Dequeue() != null)
+        { }
 
         service.RegisterHandler("fail-test", _ => throw new InvalidOperationException("Test failure"));
         service.Enqueue(new PendingOperation { OperationType = "fail-test", MaxRetries = 3 });

--- a/tests/Meridian.Wpf.Tests/Support/WpfTestThread.cs
+++ b/tests/Meridian.Wpf.Tests/Support/WpfTestThread.cs
@@ -6,6 +6,7 @@ namespace Meridian.Wpf.Tests.Support;
 
 internal static class WpfTestThread
 {
+    private static readonly TimeSpan DispatchTimeout = TimeSpan.FromMinutes(2);
     private static readonly object Sync = new();
     private static Thread? _thread;
     private static Dispatcher? _dispatcher;
@@ -16,7 +17,7 @@ internal static class WpfTestThread
         EnsureStarted();
         ExceptionDispatchInfo? captured = null;
 
-        _dispatcher!.Invoke(() =>
+        InvokeWithTimeout(() =>
         {
             try
             {
@@ -35,7 +36,13 @@ internal static class WpfTestThread
     public static void Run(Func<Task> action)
     {
         EnsureStarted();
-        _dispatcher!.InvokeAsync(action).Task.Unwrap().GetAwaiter().GetResult();
+        var task = _dispatcher!.InvokeAsync(action).Task.Unwrap();
+        if (!task.Wait(DispatchTimeout))
+        {
+            throw new TimeoutException($"WPF test action did not complete within {DispatchTimeout.TotalSeconds:N0} seconds.");
+        }
+
+        task.GetAwaiter().GetResult();
         DrainDispatcher();
     }
 
@@ -68,13 +75,27 @@ internal static class WpfTestThread
             _thread.SetApartmentState(ApartmentState.STA);
             _thread.IsBackground = true;
             _thread.Start();
-            Ready.Wait();
+            if (!Ready.Wait(DispatchTimeout))
+            {
+                throw new TimeoutException($"WPF test dispatcher did not start within {DispatchTimeout.TotalSeconds:N0} seconds.");
+            }
         }
     }
 
     private static void DrainDispatcher()
     {
-        _dispatcher!.Invoke(() => { }, DispatcherPriority.ApplicationIdle);
-        _dispatcher.Invoke(() => { }, DispatcherPriority.ContextIdle);
+        InvokeWithTimeout(() => { }, DispatcherPriority.ApplicationIdle);
+        InvokeWithTimeout(() => { }, DispatcherPriority.ContextIdle);
+    }
+
+    private static void InvokeWithTimeout(Action action, DispatcherPriority priority = DispatcherPriority.Normal)
+    {
+        var operation = _dispatcher!.InvokeAsync(action, priority);
+        if (!operation.Task.Wait(DispatchTimeout))
+        {
+            throw new TimeoutException($"WPF dispatcher operation did not complete within {DispatchTimeout.TotalSeconds:N0} seconds.");
+        }
+
+        operation.Task.GetAwaiter().GetResult();
     }
 }

--- a/tests/Meridian.Wpf.Tests/ViewModels/QuantScriptViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/QuantScriptViewModelTests.cs
@@ -37,11 +37,11 @@ public sealed class QuantScriptViewModelTests
         IScriptRunner? runner = null,
         IQuantScriptCompiler? compiler = null)
     {
-        var fakeRunner   = runner   ?? new FakeScriptRunner();
+        var fakeRunner = runner ?? new FakeScriptRunner();
         var fakeCompiler = compiler ?? new FakeQuantScriptCompiler();
-        var plotQueue    = new PlotQueue();
-        var layout       = new StubLayoutService();
-        var options      = Options.Create(new QuantScriptOptions { ScriptsDirectory = Path.GetTempPath() });
+        var plotQueue = new PlotQueue();
+        var layout = new StubLayoutService();
+        var options = Options.Create(new QuantScriptOptions { ScriptsDirectory = Path.GetTempPath() });
         var notebookStore = new QuantScriptNotebookStore(options.Value);
         var templateCatalog = new QuantScriptTemplateCatalogService(NullLogger<QuantScriptTemplateCatalogService>.Instance);
         var strategyRunWorkspace = new StrategyRunWorkspaceService(
@@ -52,7 +52,7 @@ public sealed class QuantScriptViewModelTests
             ConfigService.Instance,
             strategyRunWorkspace,
             NullLogger<QuantScriptExecutionHistoryService>.Instance);
-        var logger       = NullLogger<QuantScriptViewModel>.Instance;
+        var logger = NullLogger<QuantScriptViewModel>.Instance;
 
         return new QuantScriptViewModel(
             fakeRunner,

--- a/tests/Meridian.Wpf.Tests/ViewModels/TradingWorkspaceShellViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/TradingWorkspaceShellViewModelTests.cs
@@ -299,10 +299,10 @@ public sealed class TradingWorkspaceShellViewModelTests
     [Fact]
     public void ResolveOperatorWorkItemActionId_MapsTopBlockerTaxonomyToConsistentRepairRoutes()
     {
-        var replay = new OperatorWorkItemDto("replay-stale", OperatorWorkItemKindDto.PaperReplay, "Replay stale", "Replay evidence is stale.", OperatorWorkItemToneDto.Warning, new DateTimeOffset(2026,5,1,0,0,0,TimeSpan.Zero));
-        var signoff = new OperatorWorkItemDto("signoff-missing", OperatorWorkItemKindDto.ProviderTrustGate, "Missing sign-off", "Missing operator sign-off evidence.", OperatorWorkItemToneDto.Critical, new DateTimeOffset(2026,5,1,0,0,1,TimeSpan.Zero));
-        var provider = new OperatorWorkItemDto("provider-trust-degraded", OperatorWorkItemKindDto.ProviderTrustGate, "Provider trust degraded", "Provider trust degraded.", OperatorWorkItemToneDto.Critical, new DateTimeOffset(2026,5,1,0,0,2,TimeSpan.Zero));
-        var brokerage = new OperatorWorkItemDto("brokerage-sync-incomplete", OperatorWorkItemKindDto.BrokerageSync, "Brokerage sync incomplete", "Brokerage sync incomplete.", OperatorWorkItemToneDto.Critical, new DateTimeOffset(2026,5,1,0,0,3,TimeSpan.Zero), TargetRoute: $"{UiApiRoutes.FundAccountBrokerageSyncAccounts}?fundAccountId=9c37d51f-2eba-40f5-9c86-6c9eb3863b8b", TargetPageTag: "TradingShell");
+        var replay = new OperatorWorkItemDto("replay-stale", OperatorWorkItemKindDto.PaperReplay, "Replay stale", "Replay evidence is stale.", OperatorWorkItemToneDto.Warning, new DateTimeOffset(2026, 5, 1, 0, 0, 0, TimeSpan.Zero));
+        var signoff = new OperatorWorkItemDto("signoff-missing", OperatorWorkItemKindDto.ProviderTrustGate, "Missing sign-off", "Missing operator sign-off evidence.", OperatorWorkItemToneDto.Critical, new DateTimeOffset(2026, 5, 1, 0, 0, 1, TimeSpan.Zero));
+        var provider = new OperatorWorkItemDto("provider-trust-degraded", OperatorWorkItemKindDto.ProviderTrustGate, "Provider trust degraded", "Provider trust degraded.", OperatorWorkItemToneDto.Critical, new DateTimeOffset(2026, 5, 1, 0, 0, 2, TimeSpan.Zero));
+        var brokerage = new OperatorWorkItemDto("brokerage-sync-incomplete", OperatorWorkItemKindDto.BrokerageSync, "Brokerage sync incomplete", "Brokerage sync incomplete.", OperatorWorkItemToneDto.Critical, new DateTimeOffset(2026, 5, 1, 0, 0, 3, TimeSpan.Zero), TargetRoute: $"{UiApiRoutes.FundAccountBrokerageSyncAccounts}?fundAccountId=9c37d51f-2eba-40f5-9c86-6c9eb3863b8b", TargetPageTag: "TradingShell");
 
         TradingWorkspaceShellPresentationService.ResolveOperatorWorkItemActionId(replay).Should().Be("ReplayVerification");
         TradingWorkspaceShellPresentationService.ResolveOperatorWorkItemActionId(signoff).Should().Be("ProviderHealth");

--- a/tests/Meridian.Wpf.Tests/Views/FullNavigationSweepTests.cs
+++ b/tests/Meridian.Wpf.Tests/Views/FullNavigationSweepTests.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using System.Windows.Threading;
 using System.Windows.Media;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Meridian.Wpf.Services;
 using Meridian.Wpf.Tests.Support;
 
@@ -29,6 +30,7 @@ public sealed class FullNavigationSweepTests
 
             configureServices.Should().NotBeNull();
             AppServiceTestHost.InvokeConfigureServices(configureServices!, services);
+            ConfigureOfflineServiceOverrides(services);
 
             using var serviceProvider = services.BuildServiceProvider();
             var navigationService = NavigationService.Instance;
@@ -121,6 +123,12 @@ public sealed class FullNavigationSweepTests
 
             failures.Should().BeEmpty(string.Join(Environment.NewLine, failures));
         });
+    }
+
+    private static void ConfigureOfflineServiceOverrides(IServiceCollection services)
+    {
+        services.RemoveAll<IWorkstationReconciliationApiClient>();
+        services.AddSingleton<IWorkstationReconciliationApiClient, FakeWorkstationReconciliationApiClient>();
     }
 
     private static string GetNavigationFailureDetail(

--- a/tests/Meridian.Wpf.Tests/Views/WorkspaceDeepPageChromeTests.cs
+++ b/tests/Meridian.Wpf.Tests/Views/WorkspaceDeepPageChromeTests.cs
@@ -12,22 +12,22 @@ public sealed class WorkspaceDeepPageChromeTests
     [Fact]
     public void WorkspaceDeepPageHostPage_ShouldToggleHostedShellState()
     {
-            WpfTestThread.Run(() =>
-            {
-                RunMatUiAutomationFacade.EnsureApplicationResources();
+        WpfTestThread.Run(() =>
+        {
+            RunMatUiAutomationFacade.EnsureApplicationResources();
 
             var navigationService = (Meridian.Wpf.Services.NavigationService)Activator.CreateInstance(
-                typeof(Meridian.Wpf.Services.NavigationService),
-                nonPublic: true)!;
+                    typeof(Meridian.Wpf.Services.NavigationService),
+                    nonPublic: true)!;
 
             var hostedPage = new Page();
             var hostPage = new WorkspaceDeepPageHostPage(
-                navigationService,
-                shellContextService: null,
-                pageTag: "EventReplay",
-                hostedPage,
-                navigationParameter: null,
-                presentationMode: WorkspaceChromePresentationMode.Docked);
+                    navigationService,
+                    shellContextService: null,
+                    pageTag: "EventReplay",
+                    hostedPage,
+                    navigationParameter: null,
+                    presentationMode: WorkspaceChromePresentationMode.Docked);
 
             var window = new Window
             {


### PR DESCRIPTION
## Summary
- Enable the full WPF test project by default on Windows and route STA/navigation work through bounded `WpfTestThread` dispatch instead of unbounded joins.
- Add test seams/fakes for UI services that previously waited on offline `localhost:8080`, and keep the WPF navigation sweep offline for reconciliation API calls.
- Reduce avoidable slow-test cost: direct domain assembly reference check, narrower workstation endpoint app mapping, smaller corporate-action sample, `NoSync` WAL property breadth, and resilience-disabled Stooq 500 test coverage.

## Validation
- `dotnet test tests\Meridian.Wpf.Tests\Meridian.Wpf.Tests.csproj --logger "console;verbosity=minimal"` -> passed 1,714 tests in 4m58s.
- `dotnet test tests\Meridian.Ui.Tests\Meridian.Ui.Tests.csproj --no-build --filter "FullyQualifiedName~SystemHealthServiceTests|FullyQualifiedName~BackfillProviderConfigServiceTests" --logger "console;verbosity=minimal"` -> passed 65 tests in 304ms.
- `dotnet test tests\Meridian.Tests\Meridian.Tests.csproj --no-build --filter "FullyQualifiedName~WorkstationEndpointsTests" --logger "console;verbosity=minimal"` -> passed 265 tests in 2m10s.
- `dotnet test tests\Meridian.Tests\Meridian.Tests.csproj --no-build --filter "FullyQualifiedName~LayerBoundaryTests.Domain_ShouldNot_DependOn_Infrastructure|FullyQualifiedName~WriteAheadLogTests.Scenario_WalReplay_GeneratedUncommittedStreamsReplayOnceInSequence|FullyQualifiedName~HistoricalProviderContractTests.Stooq_WithHttpError_ThrowsDataProviderException" --logger "console;verbosity=minimal"` -> passed 3 tests in 5s.
- `dotnet test tests\Meridian.Backtesting.Tests\Meridian.Backtesting.Tests.csproj --no-build --filter "FullyQualifiedName~CorporateActionAdjustmentServiceTests.AdjustAsync_StreamedLargeHistory_IsEquivalentToBatch" --logger "console;verbosity=minimal"` -> passed 1 test in 1s.
- `dotnet format whitespace Meridian.sln --verify-no-changes --verbosity minimal --no-restore` -> passed.
- With Node 20.19.0 prepended and Git Bash because native WSL bash required an update: `bash scripts/ci.sh` -> `Meridian CI completed successfully.`


<!-- phase:PR9 -->
