### PR TITLE
Harden CI artifact summary parsing

### DIFF
--- a/build/scripts/ci/summarize-ci-artifacts.py
+++ b/build/scripts/ci/summarize-ci-artifacts.py
@@ -101,12 +101,26 @@ def load_dotnet_summary(path: Path | None) -> tuple[list[str], list[str]]:
     if path is None or not path.exists():
         return [], []
 
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    failed_projects = [
-        f"{result['name']} ({result['path']}) exited {result['exit_code']}"
-        for result in payload.get("results", [])
-        if result.get("exit_code") != 0
-    ]
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return [], ["Failed to read or parse .NET test summary."]
+    if not isinstance(payload, dict):
+        return [], ["Invalid .NET test summary format."]
+
+    failed_projects = []
+    results = payload.get("results", [])
+    if not isinstance(results, list):
+        results = []
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        exit_code = result.get("exit_code")
+        if exit_code is None or exit_code == 0:
+            continue
+        name = result.get("name", "Unknown")
+        result_path = result.get("path", "Unknown")
+        failed_projects.append(f"{name} ({result_path}) exited {exit_code}")
     totals = [
         f"Total .NET slices: {payload.get('total', 0)}",
         f"Passed: {payload.get('passed', 0)}",

--- a/tests/scripts/test_ci_summary.py
+++ b/tests/scripts/test_ci_summary.py
@@ -57,6 +57,29 @@ class CiSummaryTests(unittest.TestCase):
         self.assertIn("Total .NET slices: 2", totals)
         self.assertEqual(failed, ["ui (tests/Meridian.Ui.Tests/Meridian.Ui.Tests.csproj) exited 1"])
 
+    def test_load_dotnet_summary_handles_malformed_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "summary.json"
+            path.write_text("{", encoding="utf-8")
+
+            totals, failed = MODULE.load_dotnet_summary(path)
+
+        self.assertEqual(totals, [])
+        self.assertEqual(failed, ["Failed to read or parse .NET test summary."])
+
+    def test_load_dotnet_summary_handles_partial_result_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "summary.json"
+            path.write_text(
+                json.dumps({"results": [{"exit_code": 1}, "invalid", {"path": "tests/example.csproj"}]}),
+                encoding="utf-8",
+            )
+
+            totals, failed = MODULE.load_dotnet_summary(path)
+
+        self.assertIn("Total .NET slices: 0", totals)
+        self.assertEqual(failed, ["Unknown (Unknown) exited 1"])
+
     def test_build_summary_includes_lane_result_and_failure_lines(self) -> None:
         summary = MODULE.build_summary(
             lane="verify-dotnet",


### PR DESCRIPTION
## Summary
- Follow-up to Gemini review feedback on PR #1999 after that PR was already merged.
- Harden `load_dotnet_summary` against malformed, non-object, and partial .NET test summary JSON.
- Add focused coverage for malformed JSON and incomplete result entries.

## Validation
- `python -m unittest tests.scripts.test_ci_summary tests.scripts.test_lane_manifest tests.scripts.test_meridian_ci_workflow tests.scripts.test_targeted_test_workflow tests.scripts.test_windows_desktop_build_workflow`
- `python build/scripts/ci/check-lane-manifest.py --summary`
- `C:\Program Files\Git\bin\bash.exe scripts/ci.sh --lane verify-workflows`

## Notes
- PR #1999 is already merged, so this is a narrow follow-up branch from latest `origin/main`.
- The other two Gemini comments were already addressed on the merged branch: defensive lane-id lookup and visible stderr from CI summary generation.