### PR TITLE
Security Master Passport Workbench — governed-write integrity follow-ups (#2004 review)

### DIFF
--- a/docs/plans/security-master-passport-workbench.md
+++ b/docs/plans/security-master-passport-workbench.md
@@ -146,6 +146,21 @@ the same atomic open→resolved CAS (`ResolveConflictRequest.ChosenWinnerSource`
 `SecurityMasterConflict.Resolved*`), so the durable winner and the close commit together; the override
 key is a best-effort display mirror whose failure is logged, not surfaced.
 
+**D2d (AMENDED — governed-write integrity follow-ups).** Four post-merge review findings closed the
+remaining governance/correctness gaps on the write surface: (1) **Workflow binding** — the revision
+record persists the submitting `WorkflowId` (bound on `Draft → Submitted`), and `ApproveRevisionAsync`
+rejects an approval whose `WorkflowId` differs, so a revision cannot be approved through an unrelated,
+already-approvable workflow lane. (2) **Independent reviewer** — `SubmitForApprovalAsync` no longer
+defaults a blank reviewer to the submitter; it requires a non-blank reviewer distinct from the actor
+(the gate only checks reviewer-matches-assigned, not independence), removing the self-approval path.
+(3) **Winner-candidate validation** — `ResolveSourceConflictAsync` rejects a `ChosenWinnerSource` that
+is not one of the conflict's two competing sources (`CurrentWinningSource` / `ChallengerSource` — the
+same pair the authority policy decides between), so an acknowledged deviation cannot record a typo or
+arbitrary source as the winner. (4) **Publish metadata** — the revision record carries the edit's
+`FieldPath`/`EffectiveFrom`, and `PublishRevisionAsync` emits the stored effective date and changed
+field (not publish-time / empty) so the Phase 3 period-aware/restatement handlers can scope impact
+analysis to the actual, possibly back-dated, edit.
+
 **D3 — Publish a domain event; the ledger accounting-period status is the lock authority; edits route by tri-state period status, never silent mutation (Unknown #3 — RESOLVED).**
 `PublishRevisionAsync` invokes ordered `IEnumerable<ISecurityMasterRevisionPublishedHandler>` after
 the durable append: **per-security projection rebuild** (`SecurityProjectionRebuildHandler`, which

--- a/docs/status/TODO.md
+++ b/docs/status/TODO.md
@@ -1,6 +1,6 @@
 # TODO / FIXME / HACK / NOTE Scan
 
-Total items: **194**
+Total items: **196**
 
 | File | Line | Tag | Linked Issue | Text |
 | --- | ---: | --- | :---: | --- |
@@ -182,9 +182,11 @@ Total items: **194**
 | `tests/Meridian.Tests/Application/Backfill/BackfillWorkerServiceTests.cs` | 86 | `NOTE` | ❌ | // NOTE: Using null! dependencies - we only verify that ArgumentOutOfRangeException is not thrown |
 | `tests/Meridian.Tests/Application/Pipeline/FSharpEventValidatorTests.cs` | 72 | `NOTE` | ❌ | // Note: Trade.ctor only checks Price > 0, so $2,000,000 is constructible. |
 | `tests/Meridian.Tests/DataIntegration/Monitoring/DataQuality/DataFreshnessSlaMonitorTests.cs` | 525 | `NOTE` | ❌ | // NOTE: Actual result depends on current time, so we check the logic is working |
-| `tests/Meridian.Tests/SecurityMaster/Workbench/SecurityMasterWorkbenchCommandServiceTests.cs` | 169 | `NOTE` | ❌ | Note: "Ready for review."); |
-| `tests/Meridian.Tests/SecurityMaster/Workbench/SecurityMasterWorkbenchCommandServiceTests.cs` | 195 | `NOTE` | ❌ | Note: "Submit through gate.", |
-| `tests/Meridian.Tests/SecurityMaster/Workbench/SecurityMasterWorkbenchCommandServiceTests.cs` | 221 | `NOTE` | ❌ | Note: "Submit through gate.", |
+| `tests/Meridian.Tests/SecurityMaster/Workbench/SecurityMasterWorkbenchCommandServiceTests.cs` | 227 | `NOTE` | ❌ | Note: "Ready for review."); |
+| `tests/Meridian.Tests/SecurityMaster/Workbench/SecurityMasterWorkbenchCommandServiceTests.cs` | 253 | `NOTE` | ❌ | Note: "Submit through gate.", |
+| `tests/Meridian.Tests/SecurityMaster/Workbench/SecurityMasterWorkbenchCommandServiceTests.cs` | 282 | `NOTE` | ❌ | Note: "Submit.", |
+| `tests/Meridian.Tests/SecurityMaster/Workbench/SecurityMasterWorkbenchCommandServiceTests.cs` | 307 | `NOTE` | ❌ | Note: "Submit.", |
+| `tests/Meridian.Tests/SecurityMaster/Workbench/SecurityMasterWorkbenchCommandServiceTests.cs` | 331 | `NOTE` | ❌ | Note: "Submit through gate.", |
 | `tests/Meridian.Tests/Storage/StorageChecksumServiceTests.cs` | 121 | `NOTE` | ❌ | // NOTE: File.WriteAllTextAsync uses UTF-8 with BOM by default on some platforms, |
 | `tests/Meridian.Tests/Strategies/ReconciliationBreakQueueRepositoryTests.cs` | 374 | `NOTE` | ❌ | Note: "Automation suggested reopened-case resolution.", |
 | `tests/Meridian.Tests/Ui/EvidenceWorkflowFabricTests.cs` | 4098 | `NOTE` | ❌ | Note: "Delivered after approval.", |

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 534,
-  "total_lines": 86128,
+  "total_lines": 86143,
   "orphaned_count": 204,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2785,7 +2785,7 @@
     },
     {
       "path": "docs/plans/security-master-passport-workbench.md",
-      "line_count": 580,
+      "line_count": 595,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 534 |
-| Total lines | 86,128 |
+| Total lines | 86,143 |
 | Average file size (lines) | 161.3 |
 | Orphaned files | 204 |
 | Files without headings | 38 |

--- a/src/Meridian.Application/SecurityMaster/ISecurityMasterRevisionStore.cs
+++ b/src/Meridian.Application/SecurityMaster/ISecurityMasterRevisionStore.cs
@@ -14,6 +14,19 @@ public interface ISecurityMasterRevisionStore
     /// <summary>Creates a new <see cref="SecurityMasterRevisionStateDto.Draft"/> revision for a security.</summary>
     Task<SecurityMasterRevisionRecord> CreateDraftAsync(Guid securityId, string actor, CancellationToken ct = default);
 
+    /// <summary>
+    /// Creates a Draft revision carrying the field-edit metadata (path, effective date, justification)
+    /// so a later publish can emit the correct effective-from and changed-field set for downstream
+    /// (period-aware / restatement) impact analysis instead of defaulting to publish time.
+    /// </summary>
+    Task<SecurityMasterRevisionRecord> CreateDraftAsync(
+        Guid securityId,
+        string actor,
+        string fieldPath,
+        DateTimeOffset fieldEffectiveFrom,
+        string fieldJustification,
+        CancellationToken ct = default);
+
     /// <summary>Returns the revision, or <c>null</c> when no revision with that id exists.</summary>
     Task<SecurityMasterRevisionRecord?> GetAsync(Guid revisionId, CancellationToken ct = default);
 
@@ -21,12 +34,15 @@ public interface ISecurityMasterRevisionStore
     /// Atomically transitions a revision from <paramref name="expected"/> to <paramref name="next"/>.
     /// Throws <see cref="SecurityMasterRevisionStateException"/> when the revision is missing or its
     /// current state is not <paramref name="expected"/> (a concurrent or out-of-order transition).
+    /// When <paramref name="workflowIdForSubmit"/> is supplied on a Draft→Submitted transition, it is
+    /// durably bound to the revision so approval can be restricted to that same workflow lane.
     /// </summary>
     Task<SecurityMasterRevisionRecord> TransitionAsync(
         Guid revisionId,
         SecurityMasterRevisionStateDto expected,
         SecurityMasterRevisionStateDto next,
         string actor,
+        Guid? workflowIdForSubmit = null,
         CancellationToken ct = default);
 }
 
@@ -37,7 +53,11 @@ public sealed record SecurityMasterRevisionRecord(
     SecurityMasterRevisionStateDto State,
     string Actor,
     DateTimeOffset CreatedAt,
-    DateTimeOffset UpdatedAt);
+    DateTimeOffset UpdatedAt,
+    Guid? WorkflowId = null,
+    string? FieldPath = null,
+    DateTimeOffset? FieldEffectiveFrom = null,
+    string? FieldJustification = null);
 
 /// <summary>
 /// Raised when a revision lifecycle transition is attempted out of order — e.g. publishing a revision
@@ -64,6 +84,23 @@ public sealed class InMemorySecurityMasterRevisionStore : ISecurityMasterRevisio
     private readonly ConcurrentDictionary<Guid, SecurityMasterRevisionRecord> _revisions = new();
 
     public Task<SecurityMasterRevisionRecord> CreateDraftAsync(Guid securityId, string actor, CancellationToken ct = default)
+        => CreateDraftCore(securityId, actor, fieldPath: null, fieldEffectiveFrom: null, fieldJustification: null);
+
+    public Task<SecurityMasterRevisionRecord> CreateDraftAsync(
+        Guid securityId,
+        string actor,
+        string fieldPath,
+        DateTimeOffset fieldEffectiveFrom,
+        string fieldJustification,
+        CancellationToken ct = default)
+        => CreateDraftCore(securityId, actor, fieldPath, fieldEffectiveFrom, fieldJustification);
+
+    private Task<SecurityMasterRevisionRecord> CreateDraftCore(
+        Guid securityId,
+        string actor,
+        string? fieldPath,
+        DateTimeOffset? fieldEffectiveFrom,
+        string? fieldJustification)
     {
         var now = DateTimeOffset.UtcNow;
         var record = new SecurityMasterRevisionRecord(
@@ -72,7 +109,11 @@ public sealed class InMemorySecurityMasterRevisionStore : ISecurityMasterRevisio
             State: SecurityMasterRevisionStateDto.Draft,
             Actor: actor,
             CreatedAt: now,
-            UpdatedAt: now);
+            UpdatedAt: now,
+            WorkflowId: null,
+            FieldPath: fieldPath,
+            FieldEffectiveFrom: fieldEffectiveFrom,
+            FieldJustification: fieldJustification);
         _revisions[record.RevisionId] = record;
         return Task.FromResult(record);
     }
@@ -88,6 +129,7 @@ public sealed class InMemorySecurityMasterRevisionStore : ISecurityMasterRevisio
         SecurityMasterRevisionStateDto expected,
         SecurityMasterRevisionStateDto next,
         string actor,
+        Guid? workflowIdForSubmit = null,
         CancellationToken ct = default)
     {
         if (!_revisions.TryGetValue(revisionId, out var existing))
@@ -102,7 +144,12 @@ public sealed class InMemorySecurityMasterRevisionStore : ISecurityMasterRevisio
                 revisionId, $"expected state {expected} but the revision is {existing.State}.");
         }
 
-        var updated = existing with { State = next, Actor = actor, UpdatedAt = DateTimeOffset.UtcNow };
+        // Bind the submitting workflow only on the Draft→Submitted transition; other transitions
+        // preserve the existing binding so approval can be restricted to the same lane.
+        var workflowId = next == SecurityMasterRevisionStateDto.Submitted && workflowIdForSubmit.HasValue
+            ? workflowIdForSubmit
+            : existing.WorkflowId;
+        var updated = existing with { State = next, Actor = actor, UpdatedAt = DateTimeOffset.UtcNow, WorkflowId = workflowId };
 
         // Compare-and-set: only the caller whose view still matches the stored record wins; a
         // concurrent transition that already advanced the revision loses and is rejected.

--- a/src/Meridian.Application/SecurityMaster/SecurityMasterWorkbenchCommandService.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterWorkbenchCommandService.cs
@@ -115,9 +115,13 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
         };
         await _overrides.PatchAsync(request.SecurityId, patch, request.Actor, ct).ConfigureAwait(false);
 
-        // Open a durable Draft revision so the governed lifecycle (submit → approve → publish) is
-        // anchored to a real, server-issued revision id rather than a transient client value.
-        var revision = await _revisions.CreateDraftAsync(request.SecurityId, request.Actor, ct).ConfigureAwait(false);
+        // Open a durable Draft revision carrying the field-edit metadata so the governed lifecycle
+        // (submit → approve → publish) is anchored to a real, server-issued revision id, and publish
+        // can later emit the correct effective-date and changed-field set for downstream impact
+        // analysis rather than defaulting to publish time.
+        var revision = await _revisions.CreateDraftAsync(
+            request.SecurityId, request.Actor, request.FieldPath, request.EffectiveFrom, request.Justification, ct)
+            .ConfigureAwait(false);
 
         _logger.LogInformation(
             "Security Master field edit staged for {SecurityId} field {FieldPath} as draft revision {RevisionId} at version {Version} by {Actor}",
@@ -170,6 +174,11 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
             .FirstOrDefault(a => a.Conflict.ConflictId == request.ConflictId)
             ?? throw new InvalidOperationException(
                 $"Conflict '{request.ConflictId}' was not found for security '{request.SecurityId}'.");
+
+        // The chosen winner must be one of the conflict's two competing sources (the same pair the
+        // authority policy decides between). Without this, an acknowledged deviation would let a typo
+        // or arbitrary source name close the conflict and record a "winner" that was never in conflict.
+        EnsureChosenWinnerIsCandidate(assessment, request.ChosenWinnerSource);
 
         var providerConfidence = snapshot.InstrumentPassport?.ProviderConfidence
             ?? Array.Empty<InstrumentPassportProviderConfidenceDto>();
@@ -260,10 +269,26 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
 
         if (request.WorkflowId is { } workflowId)
         {
+            // A governed submission must name an INDEPENDENT reviewer. Defaulting a blank reviewer to
+            // the submitter would create a self-approval path, because the approval gate only checks
+            // the approving reviewer matches the assigned reviewer — it does not enforce independence.
+            if (string.IsNullOrWhiteSpace(request.Reviewer))
+            {
+                throw new ArgumentException(
+                    "An independent reviewer is required to submit a Security Master revision for approval.",
+                    nameof(request));
+            }
+            if (string.Equals(request.Reviewer.Trim(), request.Actor?.Trim(), StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException(
+                    "The reviewer must be independent from the submitter; self-approval is not permitted.",
+                    nameof(request));
+            }
+
             var dto = new OperationsSubmitApprovalRequestDto(
                 ExpectedVersion: request.ExpectedWorkflowVersion,
                 Actor: request.Actor,
-                Reviewer: string.IsNullOrWhiteSpace(request.Reviewer) ? request.Actor : request.Reviewer!,
+                Reviewer: request.Reviewer!,
                 Rationale: rationale,
                 ReportPackId: request.ReportPackId ?? string.Empty);
 
@@ -274,13 +299,15 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
                     $"Submit for approval was blocked ({result.ErrorCode}): {result.ErrorMessage}");
             }
 
-            // Advance the durable revision lifecycle only after the gate accepts the submission.
+            // Advance the durable revision lifecycle only after the gate accepts the submission, and
+            // bind the submitting workflow so approval can be restricted to this same lane.
             await _revisions.TransitionAsync(
                 request.RevisionId,
                 SecurityMasterRevisionStateDto.Draft,
                 SecurityMasterRevisionStateDto.Submitted,
                 request.Actor,
-                ct).ConfigureAwait(false);
+                workflowIdForSubmit: workflowId,
+                ct: ct).ConfigureAwait(false);
 
             _logger.LogInformation(
                 "Security Master revision {RevisionId} for {SecurityId} submitted through approval gate workflow {WorkflowId}",
@@ -296,7 +323,7 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
             SecurityMasterRevisionStateDto.Draft,
             SecurityMasterRevisionStateDto.Submitted,
             request.Actor,
-            ct).ConfigureAwait(false);
+            ct: ct).ConfigureAwait(false);
 
         _logger.LogInformation(
             "Security Master revision {RevisionId} for {SecurityId} submitted for approval (no workflow context) by {Actor}",
@@ -314,8 +341,17 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
 
         // Preflight the revision BEFORE mutating the approval gate (same orphaned-lane reasoning as
         // SubmitForApprovalAsync); the TransitionAsync CAS below is the authority on concurrency.
-        await EnsureRevisionInStateAsync(
+        var revision = await EnsureRevisionInStateAsync(
             request.RevisionId, request.SecurityId, SecurityMasterRevisionStateDto.Submitted, ct).ConfigureAwait(false);
+
+        // Approval must run through the SAME workflow the revision was submitted to. Otherwise a
+        // caller could approve revision A via an unrelated, already-approvable workflow lane.
+        if (revision.WorkflowId != request.WorkflowId)
+        {
+            throw new SecurityMasterRevisionStateException(
+                request.RevisionId,
+                $"was submitted through workflow '{revision.WorkflowId:D}' but approval was attempted via workflow '{request.WorkflowId:D}'.");
+        }
 
         var dto = new OperationsApprovalDecisionRequestDto(
             ExpectedVersion: request.ExpectedWorkflowVersion,
@@ -338,7 +374,7 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
             SecurityMasterRevisionStateDto.Submitted,
             SecurityMasterRevisionStateDto.Approved,
             request.Actor,
-            ct).ConfigureAwait(false);
+            ct: ct).ConfigureAwait(false);
 
         var currentVersion = await GetCurrentVersionAsync(request.SecurityId, ct).ConfigureAwait(false);
 
@@ -359,7 +395,7 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
         // A revision may only be published if it was actually approved through the governed gate and
         // belongs to this security. This blocks an arbitrary revision id from triggering downstream
         // publish side effects.
-        await EnsureRevisionInStateAsync(
+        var revision = await EnsureRevisionInStateAsync(
             request.RevisionId, request.SecurityId, SecurityMasterRevisionStateDto.Approved, ct).ConfigureAwait(false);
 
         var currentVersion = await GetCurrentVersionAsync(request.SecurityId, ct).ConfigureAwait(false);
@@ -368,12 +404,15 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
             .GetTrustSnapshotAsync(request.SecurityId, fundProfileId: null, ct)
             .ConfigureAwait(false);
 
+        // Carry the edit's effective date and changed field from the durable revision so period-aware
+        // / restatement handlers can scope impact analysis to the actual (possibly back-dated) edit
+        // rather than to publish time. AffectedLedgerBookIds resolution is Phase 3 (kept empty here).
         var evt = new SecurityMasterRevisionPublishedEvent(
             SecurityId: request.SecurityId,
             RevisionId: request.RevisionId,
             Version: currentVersion,
-            EffectiveFrom: DateTimeOffset.UtcNow,
-            ChangedFields: [],
+            EffectiveFrom: revision.FieldEffectiveFrom ?? DateTimeOffset.UtcNow,
+            ChangedFields: revision.FieldPath is { } fieldPath ? [fieldPath] : [],
             DownstreamImpact: snapshot?.DownstreamImpact ?? EmptyDownstreamImpact(),
             AffectedLedgerBookIds: [],
             Actor: request.Actor,
@@ -412,7 +451,7 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
             SecurityMasterRevisionStateDto.Approved,
             SecurityMasterRevisionStateDto.Published,
             request.Actor,
-            ct).ConfigureAwait(false);
+            ct: ct).ConfigureAwait(false);
 
         _logger.LogInformation(
             "Published Security Master revision {RevisionId} for {SecurityId} by {Actor} ({HandlerCount} handlers)",
@@ -431,6 +470,27 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
     {
         var events = await _eventStore.LoadAsync(securityId, ct).ConfigureAwait(false);
         return events.Count == 0 ? 0L : events.Max(static e => e.StreamVersion);
+    }
+
+    /// <summary>
+    /// Rejects a chosen winner that is not one of the conflict's two competing sources. The authority
+    /// policy only ever picks between <c>CurrentWinningSource</c> and <c>ChallengerSource</c>, so a
+    /// value outside that pair (a typo or arbitrary source) must never be allowed to close the conflict.
+    /// </summary>
+    internal static void EnsureChosenWinnerIsCandidate(
+        SecurityMasterConflictAssessmentDto assessment, string? chosenWinnerSource)
+    {
+        var chosen = chosenWinnerSource?.Trim() ?? string.Empty;
+        var isCandidate =
+            string.Equals(chosen, assessment.CurrentWinningSource?.Trim(), StringComparison.OrdinalIgnoreCase)
+            || string.Equals(chosen, assessment.ChallengerSource?.Trim(), StringComparison.OrdinalIgnoreCase);
+        if (!isCandidate)
+        {
+            throw new ArgumentException(
+                $"Chosen winner source '{chosenWinnerSource}' is not one of the conflict's candidate sources " +
+                $"('{assessment.CurrentWinningSource}', '{assessment.ChallengerSource}').",
+                nameof(chosenWinnerSource));
+        }
     }
 
     private async Task<SecurityMasterRevisionRecord> EnsureRevisionInStateAsync(

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/InMemorySecurityMasterRevisionStoreTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/InMemorySecurityMasterRevisionStoreTests.cs
@@ -85,4 +85,63 @@ public sealed class InMemorySecurityMasterRevisionStoreTests
 
         (await store.GetAsync(Guid.NewGuid())).Should().BeNull();
     }
+
+    [Fact]
+    public async Task Transition_DraftToSubmitted_BindsWorkflowId()
+    {
+        var store = new InMemorySecurityMasterRevisionStore();
+        var draft = await store.CreateDraftAsync(SecurityId, "ops.analyst");
+        var workflowId = Guid.NewGuid();
+
+        await store.TransitionAsync(
+            draft.RevisionId, SecurityMasterRevisionStateDto.Draft, SecurityMasterRevisionStateDto.Submitted,
+            "ops.analyst", workflowIdForSubmit: workflowId);
+
+        (await store.GetAsync(draft.RevisionId))!.WorkflowId.Should().Be(workflowId);
+    }
+
+    [Fact]
+    public async Task Transition_DraftToSubmitted_WithoutWorkflow_LeavesBindingNull()
+    {
+        var store = new InMemorySecurityMasterRevisionStore();
+        var draft = await store.CreateDraftAsync(SecurityId, "ops.analyst");
+
+        await store.TransitionAsync(
+            draft.RevisionId, SecurityMasterRevisionStateDto.Draft, SecurityMasterRevisionStateDto.Submitted, "ops.analyst");
+
+        (await store.GetAsync(draft.RevisionId))!.WorkflowId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Transition_NonSubmitTransition_DoesNotRebindWorkflow()
+    {
+        var store = new InMemorySecurityMasterRevisionStore();
+        var draft = await store.CreateDraftAsync(SecurityId, "ops.analyst");
+        var submitWorkflowId = Guid.NewGuid();
+        await store.TransitionAsync(
+            draft.RevisionId, SecurityMasterRevisionStateDto.Draft, SecurityMasterRevisionStateDto.Submitted,
+            "ops.analyst", workflowIdForSubmit: submitWorkflowId);
+
+        // A later transition carrying a different workflow id must not overwrite the submit binding.
+        await store.TransitionAsync(
+            draft.RevisionId, SecurityMasterRevisionStateDto.Submitted, SecurityMasterRevisionStateDto.Approved,
+            "ops.reviewer", workflowIdForSubmit: Guid.NewGuid());
+
+        (await store.GetAsync(draft.RevisionId))!.WorkflowId.Should().Be(submitWorkflowId);
+    }
+
+    [Fact]
+    public async Task CreateDraft_WithFieldMetadata_PersistsFieldEdit()
+    {
+        var store = new InMemorySecurityMasterRevisionStore();
+        var effectiveFrom = new DateTimeOffset(2026, 03, 31, 0, 0, 0, TimeSpan.Zero);
+
+        var draft = await store.CreateDraftAsync(
+            SecurityId, "ops.analyst", "EconomicDefinition.Coupon", effectiveFrom, "Corrected coupon.");
+
+        draft.FieldPath.Should().Be("EconomicDefinition.Coupon");
+        draft.FieldEffectiveFrom.Should().Be(effectiveFrom);
+        draft.FieldJustification.Should().Be("Corrected coupon.");
+        draft.WorkflowId.Should().BeNull();
+    }
 }

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/SecurityMasterWorkbenchCommandServiceTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/SecurityMasterWorkbenchCommandServiceTests.cs
@@ -99,11 +99,15 @@ public sealed class SecurityMasterWorkbenchCommandServiceTests
         result.ChangeEntry.EffectiveAtUtc.Should().Be(effectiveFrom);
         result.ChangeEntry.ChangedFields.Should().Contain("EconomicDefinition.Coupon");
 
-        // A durable Draft revision is opened with a real, server-issued id (not a transient client value).
+        // A durable Draft revision is opened with a real, server-issued id (not a transient client
+        // value), carrying the field-edit metadata so a later publish can scope downstream impact.
         var stored = await harness.Revisions.GetAsync(result.RevisionId);
         stored.Should().NotBeNull();
         stored!.State.Should().Be(SecurityMasterRevisionStateDto.Draft);
         stored.SecurityId.Should().Be(SecurityId);
+        stored.FieldPath.Should().Be("EconomicDefinition.Coupon");
+        stored.FieldEffectiveFrom.Should().Be(effectiveFrom);
+        stored.FieldJustification.Should().Be("Corrected coupon per agent term sheet.");
 
         // The edit is staged purely as an override read-model annotation. It must NOT be appended to
         // the economic event stream — that stream is replayed verbatim to rebuild the passport, so a
@@ -154,6 +158,60 @@ public sealed class SecurityMasterWorkbenchCommandServiceTests
             .Should().ThrowAsync<SecurityMasterConcurrencyException>();
     }
 
+    // ---- ResolveSourceConflict (winner-candidate validation) ----------------------------------
+
+    [Theory]
+    [InlineData("Edgar")]        // the current winning source
+    [InlineData("edgar")]        // case-insensitive
+    [InlineData("  Edgar  ")]    // whitespace-tolerant
+    [InlineData("Polygon")]      // the challenger source
+    public void EnsureChosenWinnerIsCandidate_ValidCandidate_DoesNotThrow(string chosen)
+    {
+        var assessment = BuildAssessment(currentSource: "Edgar", challengerSource: "Polygon");
+
+        var act = () => SecurityMasterWorkbenchCommandService.EnsureChosenWinnerIsCandidate(assessment, chosen);
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData("Bloomberg")]    // never in conflict
+    [InlineData("Edgr")]         // typo
+    [InlineData("")]             // empty
+    public void EnsureChosenWinnerIsCandidate_NonCandidate_Throws(string chosen)
+    {
+        var assessment = BuildAssessment(currentSource: "Edgar", challengerSource: "Polygon");
+
+        var act = () => SecurityMasterWorkbenchCommandService.EnsureChosenWinnerIsCandidate(assessment, chosen);
+
+        act.Should().Throw<ArgumentException>("an arbitrary or mistyped source must not be allowed to close the conflict");
+    }
+
+    private static SecurityMasterConflictAssessmentDto BuildAssessment(string currentSource, string challengerSource)
+        => new(
+            Conflict: new SecurityMasterConflict(
+                ConflictId: Guid.NewGuid(),
+                SecurityId: SecurityId,
+                ConflictKind: "IdentifierAmbiguity",
+                FieldPath: "Identifiers.Cusip",
+                ProviderA: currentSource,
+                ValueA: "value-a",
+                ProviderB: challengerSource,
+                ValueB: "value-b",
+                DetectedAt: DateTimeOffset.UnixEpoch,
+                Status: "Open"),
+            CurrentWinningValue: "value-a",
+            ChallengerValue: "value-b",
+            CurrentWinningSource: currentSource,
+            ChallengerSource: challengerSource,
+            Recommendation: SecurityMasterConflictRecommendationKind.PreserveWinner,
+            RecommendedResolution: "Resolve",
+            RecommendedWinner: currentSource,
+            ImpactSeverity: SecurityMasterImpactSeverity.Low,
+            ImpactSummary: "summary",
+            ImpactDetail: "detail",
+            IsBulkEligible: false);
+
     // ---- Submit / Approve through the gate ----------------------------------------------------
 
     [Fact]
@@ -202,10 +260,62 @@ public sealed class SecurityMasterWorkbenchCommandServiceTests
         var result = await harness.Service.SubmitForApprovalAsync(request);
 
         result.State.Should().Be(SecurityMasterRevisionStateDto.Submitted);
-        (await harness.Revisions.GetAsync(revisionId))!.State.Should().Be(SecurityMasterRevisionStateDto.Submitted);
+        var stored = await harness.Revisions.GetAsync(revisionId);
+        stored!.State.Should().Be(SecurityMasterRevisionStateDto.Submitted);
+        stored.WorkflowId.Should().Be(workflowId, "the submitting workflow is bound so approval is restricted to this lane");
         harness.Workflow.Verify(
             w => w.SubmitForApprovalAsync(workflowId, It.IsAny<OperationsSubmitApprovalRequestDto>(), It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task Submit_WithWorkflow_BlankReviewer_ThrowsBeforeGate()
+    {
+        var workflowId = Guid.NewGuid();
+        var harness = new Harness(currentVersion: 2);
+        var revisionId = await harness.SeedRevisionAsync(SecurityMasterRevisionStateDto.Draft);
+
+        var request = new SubmitSecurityMasterRevisionRequest(
+            SecurityId: SecurityId,
+            RevisionId: revisionId,
+            Actor: "ops.analyst",
+            Note: "Submit.",
+            FundProfileId: null,
+            WorkflowId: workflowId,
+            ExpectedWorkflowVersion: 2,
+            Reviewer: "   ", // blank — would otherwise default to the submitter
+            ReportPackId: "rp-1");
+
+        await harness.Service.Invoking(s => s.SubmitForApprovalAsync(request))
+            .Should().ThrowAsync<ArgumentException>();
+        harness.Workflow.Verify(
+            w => w.SubmitForApprovalAsync(It.IsAny<Guid>(), It.IsAny<OperationsSubmitApprovalRequestDto>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Submit_WithWorkflow_ReviewerEqualsSubmitter_ThrowsBeforeGate()
+    {
+        var workflowId = Guid.NewGuid();
+        var harness = new Harness(currentVersion: 2);
+        var revisionId = await harness.SeedRevisionAsync(SecurityMasterRevisionStateDto.Draft);
+
+        var request = new SubmitSecurityMasterRevisionRequest(
+            SecurityId: SecurityId,
+            RevisionId: revisionId,
+            Actor: "ops.analyst",
+            Note: "Submit.",
+            FundProfileId: null,
+            WorkflowId: workflowId,
+            ExpectedWorkflowVersion: 2,
+            Reviewer: "OPS.ANALYST", // same actor, different case — self-approval attempt
+            ReportPackId: "rp-1");
+
+        await harness.Service.Invoking(s => s.SubmitForApprovalAsync(request))
+            .Should().ThrowAsync<ArgumentException>();
+        harness.Workflow.Verify(
+            w => w.SubmitForApprovalAsync(It.IsAny<Guid>(), It.IsAny<OperationsSubmitApprovalRequestDto>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
@@ -258,11 +368,40 @@ public sealed class SecurityMasterWorkbenchCommandServiceTests
     }
 
     [Fact]
+    public async Task Approve_WorkflowMismatch_Throws_BeforeTouchingGate()
+    {
+        var submitWorkflowId = Guid.NewGuid();
+        var unrelatedWorkflowId = Guid.NewGuid();
+        var harness = new Harness(currentVersion: 4);
+        var revisionId = await harness.SeedRevisionAsync(
+            SecurityMasterRevisionStateDto.Submitted, workflowId: submitWorkflowId);
+
+        // Approve via an unrelated, already-approvable workflow lane.
+        var request = new ApproveSecurityMasterRevisionRequest(
+            SecurityId: SecurityId,
+            RevisionId: revisionId,
+            WorkflowId: unrelatedWorkflowId,
+            ExpectedWorkflowVersion: 4,
+            Actor: "ops.reviewer",
+            Reviewer: "ops.reviewer",
+            Rationale: "Approved.",
+            ReportPackId: "rp-1");
+
+        await harness.Service.Invoking(s => s.ApproveRevisionAsync(request))
+            .Should().ThrowAsync<SecurityMasterRevisionStateException>();
+        harness.Workflow.Verify(
+            w => w.ApproveWorkflowAsync(It.IsAny<Guid>(), It.IsAny<OperationsApprovalDecisionRequestDto>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        (await harness.Revisions.GetAsync(revisionId))!.State.Should().Be(SecurityMasterRevisionStateDto.Submitted);
+    }
+
+    [Fact]
     public async Task Approve_RoutesThroughApprovalGate_AndReturnsApproved()
     {
         var workflowId = Guid.NewGuid();
         var harness = new Harness(currentVersion: 4);
-        var revisionId = await harness.SeedRevisionAsync(SecurityMasterRevisionStateDto.Submitted);
+        var revisionId = await harness.SeedRevisionAsync(
+            SecurityMasterRevisionStateDto.Submitted, workflowId: workflowId);
         harness.Workflow
             .Setup(w => w.ApproveWorkflowAsync(workflowId, It.IsAny<OperationsApprovalDecisionRequestDto>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(SuccessTransition(newVersion: 5));
@@ -291,7 +430,8 @@ public sealed class SecurityMasterWorkbenchCommandServiceTests
     {
         var workflowId = Guid.NewGuid();
         var harness = new Harness(currentVersion: 4);
-        var revisionId = await harness.SeedRevisionAsync(SecurityMasterRevisionStateDto.Submitted);
+        var revisionId = await harness.SeedRevisionAsync(
+            SecurityMasterRevisionStateDto.Submitted, workflowId: workflowId);
         harness.Workflow
             .Setup(w => w.ApproveWorkflowAsync(workflowId, It.IsAny<OperationsApprovalDecisionRequestDto>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new OperationsTransitionResultDto(false, "BLOCKED", "Independent reviewer required.", null, [], []));
@@ -332,6 +472,28 @@ public sealed class SecurityMasterWorkbenchCommandServiceTests
         result.RestatementCandidates.Should().BeEmpty();
         result.InvalidatedProjections.Should().HaveCount(2);
         (await harness.Revisions.GetAsync(revisionId))!.State.Should().Be(SecurityMasterRevisionStateDto.Published);
+    }
+
+    [Fact]
+    public async Task Publish_FieldEditRevision_EmitsEventWithStoredEffectiveDateAndChangedField()
+    {
+        var effectiveFrom = new DateTimeOffset(2026, 03, 31, 0, 0, 0, TimeSpan.Zero);
+        var handler = new RecordingHandler(order: 10);
+        var harness = new Harness(currentVersion: 4, handlers: [handler]);
+        var revisionId = await harness.SeedFieldEditRevisionAsync(
+            "EconomicDefinition.Coupon", effectiveFrom, "Corrected coupon.");
+
+        var request = new PublishSecurityMasterRevisionRequest(
+            SecurityId: SecurityId,
+            RevisionId: revisionId,
+            Actor: "ops.analyst",
+            ApproverActor: "ops.reviewer");
+
+        await harness.Service.PublishRevisionAsync(request);
+
+        var evt = handler.Received.Should().ContainSingle().Subject;
+        evt.EffectiveFrom.Should().Be(effectiveFrom, "the published event must carry the edit's effective date, not publish time");
+        evt.ChangedFields.Should().Equal("EconomicDefinition.Coupon");
     }
 
     [Fact]
@@ -432,8 +594,13 @@ public sealed class SecurityMasterWorkbenchCommandServiceTests
                 NullLogger<SecurityMasterWorkbenchCommandService>.Instance);
         }
 
-        /// <summary>Seeds a revision advanced to <paramref name="state"/> and returns its id.</summary>
-        public async Task<Guid> SeedRevisionAsync(SecurityMasterRevisionStateDto state, string actor = "ops.analyst")
+        /// <summary>
+        /// Seeds a revision advanced to <paramref name="state"/> and returns its id. When
+        /// <paramref name="workflowId"/> is supplied it is bound on the Draft→Submitted transition so
+        /// approval-binding checks can be exercised.
+        /// </summary>
+        public async Task<Guid> SeedRevisionAsync(
+            SecurityMasterRevisionStateDto state, string actor = "ops.analyst", Guid? workflowId = null)
         {
             var draft = await Revisions.CreateDraftAsync(SecurityId, actor);
             var id = draft.RevisionId;
@@ -442,7 +609,9 @@ public sealed class SecurityMasterWorkbenchCommandServiceTests
                 return id;
             }
 
-            await Revisions.TransitionAsync(id, SecurityMasterRevisionStateDto.Draft, SecurityMasterRevisionStateDto.Submitted, actor);
+            await Revisions.TransitionAsync(
+                id, SecurityMasterRevisionStateDto.Draft, SecurityMasterRevisionStateDto.Submitted, actor,
+                workflowIdForSubmit: workflowId);
             if (state == SecurityMasterRevisionStateDto.Submitted)
             {
                 return id;
@@ -455,6 +624,17 @@ public sealed class SecurityMasterWorkbenchCommandServiceTests
             }
 
             await Revisions.TransitionAsync(id, SecurityMasterRevisionStateDto.Approved, SecurityMasterRevisionStateDto.Published, actor);
+            return id;
+        }
+
+        /// <summary>Seeds an Approved revision carrying field-edit metadata (path + effective date).</summary>
+        public async Task<Guid> SeedFieldEditRevisionAsync(
+            string fieldPath, DateTimeOffset effectiveFrom, string justification, string actor = "ops.analyst")
+        {
+            var draft = await Revisions.CreateDraftAsync(SecurityId, actor, fieldPath, effectiveFrom, justification);
+            var id = draft.RevisionId;
+            await Revisions.TransitionAsync(id, SecurityMasterRevisionStateDto.Draft, SecurityMasterRevisionStateDto.Submitted, actor);
+            await Revisions.TransitionAsync(id, SecurityMasterRevisionStateDto.Submitted, SecurityMasterRevisionStateDto.Approved, actor);
             return id;
         }
     }


### PR DESCRIPTION
<!-- phase:PR7 -->

> `<!-- phase:PR7 -->` above declares the roadmap scope tier (`src/**` + `tests/**` + `docs/**`) for the `scope-gate` check.

## Summary

Closes the four governed-write integrity gaps Codex flagged on **#2004** after it had merged, so they did not make the original cut. All four touch only the Phase 2 command surface (`SecurityMasterWorkbenchCommandService` + `ISecurityMasterRevisionStore`), which has no endpoint wired yet (Phase 4), so there is no live exploit — but two are P1 governance gaps now sitting in `main`.

- **P1 — Bind approvals to the submitted workflow.** `SecurityMasterRevisionRecord` now persists the submitting `WorkflowId`, bound on the `Draft → Submitted` transition. `ApproveRevisionAsync` rejects an approval whose `WorkflowId` differs from the bound one, so a revision can no longer be approved through an unrelated, already-approvable workflow lane.
- **P1 — Enforce an independent reviewer.** `SubmitForApprovalAsync` no longer defaults a blank reviewer to the submitting actor; it requires a non-blank reviewer that is distinct from the actor (the operations-continuity gate only checks reviewer-matches-assigned, not independence), removing the self-approval path.
- **P2 — Validate the chosen winner.** `ResolveSourceConflictAsync` rejects a `ChosenWinnerSource` that is not one of the conflict's two competing sources (`CurrentWinningSource` / `ChallengerSource` — the same pair the authority policy decides between), so an acknowledged deviation can no longer close a conflict with a typo'd or arbitrary winner.
- **P2 — Persist field metadata for publish.** The revision record carries the edit's `FieldPath`/`EffectiveFrom`; `PublishRevisionAsync` emits the stored effective date and changed field instead of publish-time/empty, so the Phase 3 period-aware/restatement handlers can scope impact analysis to the actual (possibly back-dated) edit.

## Reason

Post-merge automated review on #2004 surfaced two P1 governance findings (workflow lane-hopping, reviewer self-approval) and two P2 correctness findings (invalid conflict winner, lost publish metadata). Each is grounded against real source (the authority policy only ever picks between `CurrentWinningSource`/`ChallengerSource`; the approval gate does not enforce reviewer independence). Design doc `D2d` records the follow-ups.

## Testing performed

- [ ] `bash scripts/ci.sh` — not run locally (no .NET toolchain in this environment); CI is the authoritative compile/test
- [x] Relevant unit tests were added or updated — revision-store workflow-binding + field-metadata tests, submit reviewer-independence tests, approve workflow-mismatch test, publish-metadata test, and a directly-tested `EnsureChosenWinnerIsCandidate` helper
- [ ] Relevant integration tests were added or updated — N/A (no endpoint surface in this slice)
- [ ] GitHub Actions `quality-gate` passed — runs on this PR as the authoritative gate

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019qm7pxZJDPsXViBkoHw7R2)_