### PR TITLE
Security Master Passport Workbench — Phase 3 slice 1: period-aware restatement resolution

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -2725,7 +2725,9 @@ Meridian-main
 │   │   │   ├── EdgarIngestOrchestrator.cs
 │   │   │   ├── FileSecurityValidationSnapshotStore.cs
 │   │   │   ├── IEdgarIngestOrchestrator.cs
+│   │   │   ├── ILedgerPeriodLockReader.cs
 │   │   │   ├── ILivePositionCorporateActionAdjuster.cs
+│   │   │   ├── IPeriodAwareRestatementResolver.cs
 │   │   │   ├── ISecurityMasterConflictAuthorityPolicy.cs
 │   │   │   ├── ISecurityMasterQueryService.cs
 │   │   │   ├── ISecurityMasterRevisionPublishedHandler.cs
@@ -6542,6 +6544,8 @@ Meridian-main
 │   │   ├── SecurityMaster
 │   │   │   ├── Workbench
 │   │   │   │   ├── InMemorySecurityMasterRevisionStoreTests.cs
+│   │   │   │   ├── LedgerPeriodLockReaderTests.cs
+│   │   │   │   ├── PeriodAwareRestatementResolverTests.cs
 │   │   │   │   ├── SecurityMasterConflictAuthorityPolicyTests.cs
 │   │   │   │   └── SecurityMasterWorkbenchCommandServiceTests.cs
 │   │   │   ├── CorporateActionCommandServiceTests.cs

--- a/docs/plans/security-master-passport-workbench.md
+++ b/docs/plans/security-master-passport-workbench.md
@@ -368,6 +368,20 @@ POST /api/security-master/{securityId:guid}/workbench/publish
   which reports *readiness to close*, not *lock state* — using it as the gate would let a hard-closed
   book be silently mutated. The ledger period status is the same authority `LedgerPeriodPostingGuard`
   enforces, so the workbench can never produce a state the ledger would reject.
+- **Implementation refinement (Phase 3 slice 1 — result-bearing decision via a resolver).** The
+  *result-bearing* part of this handler — deciding `RestatementRequired` and the `RestatementCandidateDto`s
+  the publish reports — is implemented as `IPeriodAwareRestatementResolver`, which the command service
+  calls at publish time, because the `void` `ISecurityMasterRevisionPublishedHandler` fan-out cannot
+  return candidates to the publish result without overloading the handler contract. The default
+  `PeriodAwareRestatementResolver` routes each `evt.AffectedLedgerBookIds` entry by the D3 matrix over
+  the authoritative `ILedgerPeriodLockReader` (hard-closed / indeterminate ⇒ mandatory proposal,
+  empty-candidate ⇒ manual locate; soft-closed ⇒ restate only already-published packs; open ⇒ none).
+  The `void` published-handler seam remains for the pure side effects (`SecurityProjectionRebuildHandler`,
+  `CoverageInvalidationHandler`). Still deferred to later slices: the soft-closed governed adjustment
+  poster (`IGovernedLedgerAdjustmentPoster`), the report-pack `IRestatementCandidateResolver`
+  (defaults to a no-op → manual-locate), and command-service resolution of `evt.AffectedLedgerBookIds`
+  from the passport/impact read (publish currently emits `[]`, so the resolver is a no-op end-to-end
+  until that feed lands — the resolver itself is fully unit-tested with explicit inputs).
 
 ### `SecurityProjectionRebuildHandler` (`Order = 10`) / `CoverageInvalidationHandler` (`Order = 20`)
 - Thin, idempotent. `SecurityProjectionRebuildHandler` rebuilds only the edited security via

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,7 +5,7 @@
 
 ## Overall Coverage
 
-**2545 / 7168** items documented (**35.5%**) &mdash; Grade: **F**
+**2550 / 7175** items documented (**35.5%**) &mdash; Grade: **F**
 
 ```text
 [=======-------------] 35.5%
@@ -15,7 +15,7 @@
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 2424 | 6673 | 36.3% | F |
+| Public Classes / Interfaces | 2429 | 6680 | 36.4% | F |
 | API Endpoints | 107 | 348 | 30.7% | F |
 | Configuration Options | 3 | 136 | 2.2% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |
@@ -23,7 +23,7 @@
 
 ## Undocumented Items
 
-### Public Classes / Interfaces (4249 undocumented)
+### Public Classes / Interfaces (4251 undocumented)
 
 | Item | Location |
 | ------ | ---------- |
@@ -77,7 +77,7 @@
 | `ExecutionStatistics` | `src/Meridian.Application/Scheduling/BackfillExecutionLog.cs:185` |
 | `ProviderUsageStats` | `src/Meridian.Application/Scheduling/BackfillExecutionLog.cs:218` |
 | `SymbolExecutionResult` | `src/Meridian.Application/Scheduling/BackfillExecutionLog.cs:234` |
-| ... and 4199 more | |
+| ... and 4201 more | |
 
 ### API Endpoints (241 undocumented)
 
@@ -193,7 +193,7 @@
 
 ## Recommendations
 
-1. **Public Classes / Interfaces**: 4249 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
+1. **Public Classes / Interfaces**: 4251 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
 2. **API Endpoints**: 241 endpoint(s) missing from `docs/reference/api-reference.md`. Run the endpoint audit and update the API reference table.
 3. **Configuration Options**: 133 config key(s) not found in `docs/generated/configuration-schema.md`. Re-run the configuration schema generator to synchronise.
 

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,11 +1,11 @@
 {
   "total_files": 534,
-  "total_lines": 86143,
+  "total_lines": 86161,
   "orphaned_count": 204,
   "no_heading_count": 38,
   "stale_count": 0,
   "todo_count": 199,
-  "average_lines": 161.3,
+  "average_lines": 161.4,
   "health_score": 83,
   "orphaned_files": [
     ".agents/skills/meridian-archive-organizer/SKILL.md",
@@ -2129,7 +2129,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7204,
+      "line_count": 7208,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -2785,7 +2785,7 @@
     },
     {
       "path": "docs/plans/security-master-passport-workbench.md",
-      "line_count": 595,
+      "line_count": 609,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,8 +20,8 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 534 |
-| Total lines | 86,143 |
-| Average file size (lines) | 161.3 |
+| Total lines | 86,161 |
+| Average file size (lines) | 161.4 |
 | Orphaned files | 204 |
 | Files without headings | 38 |
 | Stale files (>90 days) | 0 |

--- a/src/Meridian.Application/SecurityMaster/ILedgerPeriodLockReader.cs
+++ b/src/Meridian.Application/SecurityMaster/ILedgerPeriodLockReader.cs
@@ -1,0 +1,96 @@
+using Meridian.Contracts.Ledger;
+using Meridian.Storage.Ledger;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Application.SecurityMaster;
+
+/// <summary>
+/// Authoritative read of accounting-period lock status for a date, backing the Security Master
+/// Passport Workbench period-aware propagation (Phase 3). The authority is the ledger accounting
+/// period status (<see cref="LedgerAccountingPeriod"/>.<c>Status</c>), the same source
+/// <c>LedgerPeriodPostingGuard</c> enforces at post-time — not close-readiness.
+///
+/// <para><b>Default-deny:</b> when the covering period is missing, indeterminate, or its status is
+/// unrecognized, the reader returns <see cref="LedgerPeriodStatusDto.HardClosed"/> so an upstream
+/// reference-data edit can never silently mutate a book whose lock state could not be confirmed.</para>
+/// </summary>
+public interface ILedgerPeriodLockReader
+{
+    /// <summary>
+    /// Resolves the accounting period covering <paramref name="date"/> for <paramref name="ledgerBookId"/>
+    /// and returns its lock status; <see cref="LedgerPeriodStatusDto.HardClosed"/> when indeterminate.
+    /// </summary>
+    Task<LedgerPeriodStatusDto> GetPeriodStatusAsync(
+        Guid ledgerBookId, DateOnly date, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Default <see cref="ILedgerPeriodLockReader"/> over <see cref="ILedgerJournalStore"/>, applying the
+/// default-deny posture on any indeterminate state.
+/// </summary>
+public sealed class LedgerPeriodLockReader : ILedgerPeriodLockReader
+{
+    private readonly ILedgerJournalStore _journalStore;
+    private readonly ILogger<LedgerPeriodLockReader> _logger;
+
+    public LedgerPeriodLockReader(
+        ILedgerJournalStore journalStore,
+        ILogger<LedgerPeriodLockReader> logger)
+    {
+        _journalStore = journalStore ?? throw new ArgumentNullException(nameof(journalStore));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<LedgerPeriodStatusDto> GetPeriodStatusAsync(
+        Guid ledgerBookId, DateOnly date, CancellationToken ct = default)
+    {
+        try
+        {
+            var periods = await _journalStore
+                .ListPeriodsAsync(ledgerBookId: ledgerBookId, ct: ct)
+                .ConfigureAwait(false);
+
+            var covering = periods.FirstOrDefault(p => date >= p.StartDate && date <= p.EndDate);
+            if (covering is null)
+            {
+                _logger.LogWarning(
+                    "No accounting period covers {Date} for ledger book {LedgerBookId}; defaulting to HardClosed.",
+                    date, ledgerBookId);
+                return LedgerPeriodStatusDto.HardClosed;
+            }
+
+            return ParseStatus(covering.Status, ledgerBookId, date);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to resolve accounting period status for ledger book {LedgerBookId} at {Date}; defaulting to HardClosed.",
+                ledgerBookId, date);
+            return LedgerPeriodStatusDto.HardClosed;
+        }
+    }
+
+    private LedgerPeriodStatusDto ParseStatus(string status, Guid ledgerBookId, DateOnly date)
+    {
+        if (string.Equals(status, "Open", StringComparison.Ordinal))
+        {
+            return LedgerPeriodStatusDto.Open;
+        }
+
+        if (string.Equals(status, "SoftClosed", StringComparison.Ordinal))
+        {
+            return LedgerPeriodStatusDto.SoftClosed;
+        }
+
+        if (string.Equals(status, "HardClosed", StringComparison.Ordinal))
+        {
+            return LedgerPeriodStatusDto.HardClosed;
+        }
+
+        _logger.LogWarning(
+            "Unrecognized accounting period status '{Status}' for ledger book {LedgerBookId} at {Date}; defaulting to HardClosed.",
+            status, ledgerBookId, date);
+        return LedgerPeriodStatusDto.HardClosed;
+    }
+}

--- a/src/Meridian.Application/SecurityMaster/ILedgerPeriodLockReader.cs
+++ b/src/Meridian.Application/SecurityMaster/ILedgerPeriodLockReader.cs
@@ -28,22 +28,37 @@ public interface ILedgerPeriodLockReader
 /// Default <see cref="ILedgerPeriodLockReader"/> over <see cref="ILedgerJournalStore"/>, applying the
 /// default-deny posture on any indeterminate state.
 /// </summary>
+/// <remarks>
+/// The <see cref="ILedgerJournalStore"/> is an optional dependency: it is only registered when a
+/// durable ledger backend is configured (see <c>LedgerFeatureRegistration</c>, which itself binds the
+/// store via <c>GetService</c>). When no store is present the reader cannot confirm any period's lock
+/// state, so the default-deny posture applies and every date resolves to
+/// <see cref="LedgerPeriodStatusDto.HardClosed"/>.
+/// </remarks>
 public sealed class LedgerPeriodLockReader : ILedgerPeriodLockReader
 {
-    private readonly ILedgerJournalStore _journalStore;
+    private readonly ILedgerJournalStore? _journalStore;
     private readonly ILogger<LedgerPeriodLockReader> _logger;
 
     public LedgerPeriodLockReader(
-        ILedgerJournalStore journalStore,
-        ILogger<LedgerPeriodLockReader> logger)
+        ILogger<LedgerPeriodLockReader> logger,
+        ILedgerJournalStore? journalStore = null)
     {
-        _journalStore = journalStore ?? throw new ArgumentNullException(nameof(journalStore));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _journalStore = journalStore;
     }
 
     public async Task<LedgerPeriodStatusDto> GetPeriodStatusAsync(
         Guid ledgerBookId, DateOnly date, CancellationToken ct = default)
     {
+        if (_journalStore is null)
+        {
+            _logger.LogWarning(
+                "No ledger journal store is registered; cannot confirm period lock for ledger book {LedgerBookId} at {Date}; defaulting to HardClosed.",
+                ledgerBookId, date);
+            return LedgerPeriodStatusDto.HardClosed;
+        }
+
         try
         {
             var periods = await _journalStore

--- a/src/Meridian.Application/SecurityMaster/IPeriodAwareRestatementResolver.cs
+++ b/src/Meridian.Application/SecurityMaster/IPeriodAwareRestatementResolver.cs
@@ -1,0 +1,135 @@
+using Meridian.Contracts.Ledger;
+using Meridian.Contracts.Workstation;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Application.SecurityMaster;
+
+/// <summary>
+/// Phase 3 period-aware propagation: decides, for a published Security Master revision, whether any
+/// affected ledger book is in a closed period and therefore requires a governed restatement proposal
+/// rather than silent mutation. The authoritative lock state is the ledger accounting-period status
+/// (<see cref="ILedgerPeriodLockReader"/>) — the same authority <c>LedgerPeriodPostingGuard</c> enforces.
+///
+/// <para>Routing per book (D3 matrix): <c>Open</c> → immediate propagation (lower-order publish
+/// handlers already applied it), no restatement; <c>SoftClosed</c> → the downstream effect posts as a
+/// governed adjustment (a later slice), and only already-<i>published</i> report packs become
+/// restatement candidates; <c>HardClosed</c> or any indeterminate/default-deny state → no posting and
+/// a mandatory restatement proposal. When a hard-closed book has exposure but no candidate can be
+/// located, the decision still reports <see cref="SecurityMasterRestatementDecision.RestatementRequired"/>
+/// (a manual "locate affected packs" task) — a closed period is never silently completed.</para>
+/// </summary>
+public interface IPeriodAwareRestatementResolver
+{
+    Task<SecurityMasterRestatementDecision> ResolveAsync(
+        SecurityMasterRevisionPublishedEvent publishedEvent, CancellationToken ct = default);
+}
+
+/// <summary>
+/// The restatement outcome a publish reports to the operator: whether a closed-period edit requires
+/// restatement, and the report packs proposed for it (the operator approves each via the existing
+/// governed report-pack restatement path; the workbench only proposes).
+/// </summary>
+public sealed record SecurityMasterRestatementDecision(
+    bool RestatementRequired,
+    IReadOnlyList<RestatementCandidateDto> Candidates);
+
+/// <summary>
+/// Resolves the report packs that consumed a changed line in a locked period covering an upstream
+/// edit, as restatement candidates. The default implementation returns none (report-usage projection
+/// integration is a later slice); an empty result for a hard-closed book is treated as a manual
+/// locate-affected-packs task rather than "no restatement needed".
+/// </summary>
+public interface IRestatementCandidateResolver
+{
+    Task<IReadOnlyList<RestatementCandidateDto>> ResolveAsync(
+        Guid securityId,
+        Guid ledgerBookId,
+        DateOnly effectiveDate,
+        IReadOnlyList<string> changedFields,
+        CancellationToken ct = default);
+}
+
+/// <summary>Default no-op candidate resolver — surfaces no packs until the report-usage projection is wired.</summary>
+public sealed class NullRestatementCandidateResolver : IRestatementCandidateResolver
+{
+    private static readonly IReadOnlyList<RestatementCandidateDto> Empty = [];
+
+    public Task<IReadOnlyList<RestatementCandidateDto>> ResolveAsync(
+        Guid securityId,
+        Guid ledgerBookId,
+        DateOnly effectiveDate,
+        IReadOnlyList<string> changedFields,
+        CancellationToken ct = default)
+        => Task.FromResult(Empty);
+}
+
+/// <summary>
+/// Default <see cref="IPeriodAwareRestatementResolver"/> over the authoritative
+/// <see cref="ILedgerPeriodLockReader"/>. Pure routing — it never posts; it only proposes.
+/// </summary>
+public sealed class PeriodAwareRestatementResolver : IPeriodAwareRestatementResolver
+{
+    private readonly ILedgerPeriodLockReader _lockReader;
+    private readonly IRestatementCandidateResolver _candidateResolver;
+    private readonly ILogger<PeriodAwareRestatementResolver> _logger;
+
+    public PeriodAwareRestatementResolver(
+        ILedgerPeriodLockReader lockReader,
+        IRestatementCandidateResolver candidateResolver,
+        ILogger<PeriodAwareRestatementResolver> logger)
+    {
+        _lockReader = lockReader ?? throw new ArgumentNullException(nameof(lockReader));
+        _candidateResolver = candidateResolver ?? throw new ArgumentNullException(nameof(candidateResolver));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<SecurityMasterRestatementDecision> ResolveAsync(
+        SecurityMasterRevisionPublishedEvent publishedEvent, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(publishedEvent);
+
+        if (publishedEvent.AffectedLedgerBookIds.Count == 0)
+        {
+            return new SecurityMasterRestatementDecision(RestatementRequired: false, Candidates: []);
+        }
+
+        var effectiveDate = DateOnly.FromDateTime(publishedEvent.EffectiveFrom.UtcDateTime);
+        var candidates = new List<RestatementCandidateDto>();
+        var restatementRequired = false;
+
+        foreach (var ledgerBookId in publishedEvent.AffectedLedgerBookIds)
+        {
+            var status = await _lockReader.GetPeriodStatusAsync(ledgerBookId, effectiveDate, ct).ConfigureAwait(false);
+            switch (status)
+            {
+                case LedgerPeriodStatusDto.Open:
+                    // Immediate propagation handled by lower-order publish handlers; nothing to restate.
+                    break;
+
+                case LedgerPeriodStatusDto.SoftClosed:
+                    // The effect posts as a governed adjustment (later slice). Only already-published
+                    // report packs that consumed the line need restating.
+                    candidates.AddRange(await ResolveCandidatesAsync(publishedEvent, ledgerBookId, effectiveDate, ct).ConfigureAwait(false));
+                    break;
+
+                case LedgerPeriodStatusDto.HardClosed:
+                default:
+                    // Hard-closed or any indeterminate/default-deny state: no posting, mandatory proposal.
+                    restatementRequired = true;
+                    candidates.AddRange(await ResolveCandidatesAsync(publishedEvent, ledgerBookId, effectiveDate, ct).ConfigureAwait(false));
+                    _logger.LogInformation(
+                        "Security Master revision {RevisionId} affects hard-closed ledger book {LedgerBookId} at {EffectiveDate}; proposing restatement (no posting).",
+                        publishedEvent.RevisionId, ledgerBookId, effectiveDate);
+                    break;
+            }
+        }
+
+        // Any located candidate (even from a soft-closed book) is a published pack that must be restated.
+        return new SecurityMasterRestatementDecision(restatementRequired || candidates.Count > 0, candidates);
+    }
+
+    private Task<IReadOnlyList<RestatementCandidateDto>> ResolveCandidatesAsync(
+        SecurityMasterRevisionPublishedEvent publishedEvent, Guid ledgerBookId, DateOnly effectiveDate, CancellationToken ct)
+        => _candidateResolver.ResolveAsync(
+            publishedEvent.SecurityId, ledgerBookId, effectiveDate, publishedEvent.ChangedFields, ct);
+}

--- a/src/Meridian.Application/SecurityMaster/SecurityMasterWorkbenchCommandService.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterWorkbenchCommandService.cs
@@ -44,6 +44,7 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
     private readonly ISecurityMasterWorkbenchQueryService _queryService;
     private readonly IOperationsContinuityWorkflowService _approvalWorkflow;
     private readonly ISecurityMasterRevisionStore _revisions;
+    private readonly IPeriodAwareRestatementResolver _restatementResolver;
     private readonly IReadOnlyList<ISecurityMasterRevisionPublishedHandler> _handlers;
     private readonly ILogger<SecurityMasterWorkbenchCommandService> _logger;
 
@@ -55,6 +56,7 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
         ISecurityMasterWorkbenchQueryService queryService,
         IOperationsContinuityWorkflowService approvalWorkflow,
         ISecurityMasterRevisionStore revisions,
+        IPeriodAwareRestatementResolver restatementResolver,
         IEnumerable<ISecurityMasterRevisionPublishedHandler> handlers,
         ILogger<SecurityMasterWorkbenchCommandService> logger)
     {
@@ -65,6 +67,7 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
         _queryService = queryService ?? throw new ArgumentNullException(nameof(queryService));
         _approvalWorkflow = approvalWorkflow ?? throw new ArgumentNullException(nameof(approvalWorkflow));
         _revisions = revisions ?? throw new ArgumentNullException(nameof(revisions));
+        _restatementResolver = restatementResolver ?? throw new ArgumentNullException(nameof(restatementResolver));
         _handlers = (handlers ?? throw new ArgumentNullException(nameof(handlers)))
             .OrderBy(static h => h.Order)
             .ToArray();
@@ -453,16 +456,21 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
             request.Actor,
             ct: ct).ConfigureAwait(false);
 
+        // Period-aware propagation: after the side-effect handlers run, resolve whether any affected
+        // ledger book is in a closed period and therefore needs a governed restatement proposal rather
+        // than silent mutation. The authority is the ledger accounting-period status (default-deny).
+        var restatement = await _restatementResolver.ResolveAsync(evt, ct).ConfigureAwait(false);
+
         _logger.LogInformation(
-            "Published Security Master revision {RevisionId} for {SecurityId} by {Actor} ({HandlerCount} handlers)",
-            request.RevisionId, request.SecurityId, request.Actor, _handlers.Count);
+            "Published Security Master revision {RevisionId} for {SecurityId} by {Actor} ({HandlerCount} handlers, restatementRequired={RestatementRequired})",
+            request.RevisionId, request.SecurityId, request.Actor, _handlers.Count, restatement.RestatementRequired);
 
         return new SecurityMasterPublishResultDto(
             request.SecurityId,
             request.RevisionId,
             currentVersion,
-            RestatementRequired: false,
-            RestatementCandidates: [],
+            RestatementRequired: restatement.RestatementRequired,
+            RestatementCandidates: restatement.Candidates,
             InvalidatedProjections: invalidated);
     }
 

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -231,6 +231,11 @@ public static class WorkstationServiceCollectionExtensions
         services.TryAddScoped<
             Meridian.Application.SecurityMaster.ISecurityMasterWorkbenchCommandService,
             Meridian.Application.SecurityMaster.SecurityMasterWorkbenchCommandService>();
+        // Phase 3 period-aware propagation: the ledger accounting-period status is the lock
+        // authority (default-deny → HardClosed when indeterminate).
+        services.TryAddScoped<
+            Meridian.Application.SecurityMaster.ILedgerPeriodLockReader,
+            Meridian.Application.SecurityMaster.LedgerPeriodLockReader>();
         services.TryAddSingleton<NavAttributionService>();
         services.TryAddSingleton<ReportGenerationService>();
         services.TryAddSingleton<InvestmentAccountingTransactionLabService>();

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -232,10 +232,18 @@ public static class WorkstationServiceCollectionExtensions
             Meridian.Application.SecurityMaster.ISecurityMasterWorkbenchCommandService,
             Meridian.Application.SecurityMaster.SecurityMasterWorkbenchCommandService>();
         // Phase 3 period-aware propagation: the ledger accounting-period status is the lock
-        // authority (default-deny → HardClosed when indeterminate).
+        // authority (default-deny → HardClosed when indeterminate). The restatement resolver routes a
+        // closed-period edit into a governed restatement proposal rather than a silent mutation; the
+        // candidate resolver (report-pack locating) defaults to no-op until the report-usage projection lands.
         services.TryAddScoped<
             Meridian.Application.SecurityMaster.ILedgerPeriodLockReader,
             Meridian.Application.SecurityMaster.LedgerPeriodLockReader>();
+        services.TryAddScoped<
+            Meridian.Application.SecurityMaster.IRestatementCandidateResolver,
+            Meridian.Application.SecurityMaster.NullRestatementCandidateResolver>();
+        services.TryAddScoped<
+            Meridian.Application.SecurityMaster.IPeriodAwareRestatementResolver,
+            Meridian.Application.SecurityMaster.PeriodAwareRestatementResolver>();
         services.TryAddSingleton<NavAttributionService>();
         services.TryAddSingleton<ReportGenerationService>();
         services.TryAddSingleton<InvestmentAccountingTransactionLabService>();

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/LedgerPeriodLockReaderTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/LedgerPeriodLockReaderTests.cs
@@ -1,0 +1,128 @@
+using FluentAssertions;
+using Meridian.Application.SecurityMaster;
+using Meridian.Contracts.Ledger;
+using Meridian.Storage.Ledger;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace Meridian.Tests.SecurityMaster.Workbench;
+
+/// <summary>
+/// Phase 3 period-aware propagation: the ledger accounting-period status is the lock authority, and
+/// any indeterminate state is treated as <see cref="LedgerPeriodStatusDto.HardClosed"/> (default-deny)
+/// so an upstream reference-data edit can never silently mutate a book whose lock state is unknown.
+/// </summary>
+public sealed class LedgerPeriodLockReaderTests
+{
+    private static readonly Guid LedgerBookId = Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+    private static readonly DateOnly InsidePeriod = new(2026, 3, 15);
+    private static readonly DateOnly OutsideAnyPeriod = new(2026, 5, 15);
+
+    [Theory]
+    [InlineData("Open", LedgerPeriodStatusDto.Open)]
+    [InlineData("SoftClosed", LedgerPeriodStatusDto.SoftClosed)]
+    [InlineData("HardClosed", LedgerPeriodStatusDto.HardClosed)]
+    public async Task GetPeriodStatus_MapsCoveringPeriodStatus(string status, LedgerPeriodStatusDto expected)
+    {
+        var store = StoreWithPeriod(status);
+        var reader = new LedgerPeriodLockReader(store, NullLogger<LedgerPeriodLockReader>.Instance);
+
+        var result = await reader.GetPeriodStatusAsync(LedgerBookId, InsidePeriod);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task GetPeriodStatus_NoCoveringPeriod_DefaultsToHardClosed()
+    {
+        var store = StoreWithPeriod("Open");
+        var reader = new LedgerPeriodLockReader(store, NullLogger<LedgerPeriodLockReader>.Instance);
+
+        // The only period covers March 2026; a May date is covered by no period.
+        var result = await reader.GetPeriodStatusAsync(LedgerBookId, OutsideAnyPeriod);
+
+        result.Should().Be(LedgerPeriodStatusDto.HardClosed,
+            "an edit whose period cannot be located must never be treated as postable");
+    }
+
+    [Fact]
+    public async Task GetPeriodStatus_EmptyPeriodList_DefaultsToHardClosed()
+    {
+        var store = Substitute.For<ILedgerJournalStore>();
+        store.ListPeriodsAsync(
+                Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<LedgerAccountingPeriod>());
+        var reader = new LedgerPeriodLockReader(store, NullLogger<LedgerPeriodLockReader>.Instance);
+
+        var result = await reader.GetPeriodStatusAsync(LedgerBookId, InsidePeriod);
+
+        result.Should().Be(LedgerPeriodStatusDto.HardClosed);
+    }
+
+    [Theory]
+    [InlineData("Closing")]
+    [InlineData("Pending")]
+    [InlineData("")]
+    public async Task GetPeriodStatus_UnrecognizedStatus_DefaultsToHardClosed(string status)
+    {
+        var store = StoreWithPeriod(status);
+        var reader = new LedgerPeriodLockReader(store, NullLogger<LedgerPeriodLockReader>.Instance);
+
+        var result = await reader.GetPeriodStatusAsync(LedgerBookId, InsidePeriod);
+
+        result.Should().Be(LedgerPeriodStatusDto.HardClosed,
+            "an unrecognized lock state is indeterminate and must default-deny");
+    }
+
+    [Fact]
+    public async Task GetPeriodStatus_StoreThrows_DefaultsToHardClosed()
+    {
+        var store = Substitute.For<ILedgerJournalStore>();
+        store.ListPeriodsAsync(
+                Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("ledger store unavailable"));
+        var reader = new LedgerPeriodLockReader(store, NullLogger<LedgerPeriodLockReader>.Instance);
+
+        var result = await reader.GetPeriodStatusAsync(LedgerBookId, InsidePeriod);
+
+        result.Should().Be(LedgerPeriodStatusDto.HardClosed,
+            "a failed lock lookup is indeterminate and must default-deny rather than surface an error");
+    }
+
+    [Fact]
+    public async Task GetPeriodStatus_StatusMatchIsCaseSensitive_TreatsLowercaseAsIndeterminate()
+    {
+        // The ledger persists canonical PascalCase status tokens; a lowercase value indicates an
+        // unexpected/foreign source and must not be optimistically treated as Open.
+        var store = StoreWithPeriod("open");
+        var reader = new LedgerPeriodLockReader(store, NullLogger<LedgerPeriodLockReader>.Instance);
+
+        var result = await reader.GetPeriodStatusAsync(LedgerBookId, InsidePeriod);
+
+        result.Should().Be(LedgerPeriodStatusDto.HardClosed);
+    }
+
+    private static ILedgerJournalStore StoreWithPeriod(string status)
+    {
+        var store = Substitute.For<ILedgerJournalStore>();
+        store.ListPeriodsAsync(
+                Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new LedgerAccountingPeriod(
+                    PeriodId: Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd"),
+                    LedgerBookId: LedgerBookId,
+                    FiscalYear: 2026,
+                    PeriodNo: 3,
+                    Label: "2026-P03",
+                    StartDate: new DateOnly(2026, 3, 1),
+                    EndDate: new DateOnly(2026, 3, 31),
+                    Status: status,
+                    OpenedAt: DateTimeOffset.Parse("2026-03-01T00:00:00Z"),
+                    ClosedAt: null,
+                    Version: 1),
+            });
+        return store;
+    }
+}

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/LedgerPeriodLockReaderTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/LedgerPeriodLockReaderTests.cs
@@ -26,7 +26,7 @@ public sealed class LedgerPeriodLockReaderTests
     public async Task GetPeriodStatus_MapsCoveringPeriodStatus(string status, LedgerPeriodStatusDto expected)
     {
         var store = StoreWithPeriod(status);
-        var reader = new LedgerPeriodLockReader(store, NullLogger<LedgerPeriodLockReader>.Instance);
+        var reader = new LedgerPeriodLockReader(NullLogger<LedgerPeriodLockReader>.Instance, store);
 
         var result = await reader.GetPeriodStatusAsync(LedgerBookId, InsidePeriod);
 
@@ -37,7 +37,7 @@ public sealed class LedgerPeriodLockReaderTests
     public async Task GetPeriodStatus_NoCoveringPeriod_DefaultsToHardClosed()
     {
         var store = StoreWithPeriod("Open");
-        var reader = new LedgerPeriodLockReader(store, NullLogger<LedgerPeriodLockReader>.Instance);
+        var reader = new LedgerPeriodLockReader(NullLogger<LedgerPeriodLockReader>.Instance, store);
 
         // The only period covers March 2026; a May date is covered by no period.
         var result = await reader.GetPeriodStatusAsync(LedgerBookId, OutsideAnyPeriod);
@@ -53,7 +53,7 @@ public sealed class LedgerPeriodLockReaderTests
         store.ListPeriodsAsync(
                 Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<LedgerAccountingPeriod>());
-        var reader = new LedgerPeriodLockReader(store, NullLogger<LedgerPeriodLockReader>.Instance);
+        var reader = new LedgerPeriodLockReader(NullLogger<LedgerPeriodLockReader>.Instance, store);
 
         var result = await reader.GetPeriodStatusAsync(LedgerBookId, InsidePeriod);
 
@@ -67,7 +67,7 @@ public sealed class LedgerPeriodLockReaderTests
     public async Task GetPeriodStatus_UnrecognizedStatus_DefaultsToHardClosed(string status)
     {
         var store = StoreWithPeriod(status);
-        var reader = new LedgerPeriodLockReader(store, NullLogger<LedgerPeriodLockReader>.Instance);
+        var reader = new LedgerPeriodLockReader(NullLogger<LedgerPeriodLockReader>.Instance, store);
 
         var result = await reader.GetPeriodStatusAsync(LedgerBookId, InsidePeriod);
 
@@ -82,7 +82,7 @@ public sealed class LedgerPeriodLockReaderTests
         store.ListPeriodsAsync(
                 Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("ledger store unavailable"));
-        var reader = new LedgerPeriodLockReader(store, NullLogger<LedgerPeriodLockReader>.Instance);
+        var reader = new LedgerPeriodLockReader(NullLogger<LedgerPeriodLockReader>.Instance, store);
 
         var result = await reader.GetPeriodStatusAsync(LedgerBookId, InsidePeriod);
 
@@ -96,11 +96,24 @@ public sealed class LedgerPeriodLockReaderTests
         // The ledger persists canonical PascalCase status tokens; a lowercase value indicates an
         // unexpected/foreign source and must not be optimistically treated as Open.
         var store = StoreWithPeriod("open");
-        var reader = new LedgerPeriodLockReader(store, NullLogger<LedgerPeriodLockReader>.Instance);
+        var reader = new LedgerPeriodLockReader(NullLogger<LedgerPeriodLockReader>.Instance, store);
 
         var result = await reader.GetPeriodStatusAsync(LedgerBookId, InsidePeriod);
 
         result.Should().Be(LedgerPeriodStatusDto.HardClosed);
+    }
+
+    [Fact]
+    public async Task GetPeriodStatus_NoJournalStoreRegistered_DefaultsToHardClosed()
+    {
+        // The ledger journal store is an optional dependency: with no durable ledger backend
+        // configured, the reader cannot confirm any lock state and must default-deny.
+        var reader = new LedgerPeriodLockReader(NullLogger<LedgerPeriodLockReader>.Instance, journalStore: null);
+
+        var result = await reader.GetPeriodStatusAsync(LedgerBookId, InsidePeriod);
+
+        result.Should().Be(LedgerPeriodStatusDto.HardClosed,
+            "without a ledger store the lock state is unknowable and must never be treated as postable");
     }
 
     private static ILedgerJournalStore StoreWithPeriod(string status)

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/PeriodAwareRestatementResolverTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/PeriodAwareRestatementResolverTests.cs
@@ -1,0 +1,168 @@
+using FluentAssertions;
+using Meridian.Application.SecurityMaster;
+using Meridian.Contracts.Ledger;
+using Meridian.Contracts.Workstation;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Meridian.Tests.SecurityMaster.Workbench;
+
+/// <summary>
+/// Phase 3 period-aware propagation routing (D3 matrix): a closed period is never silently mutated —
+/// hard-closed (or indeterminate/default-deny) exposure becomes a mandatory restatement proposal, while
+/// open periods propagate without restatement.
+/// </summary>
+public sealed class PeriodAwareRestatementResolverTests
+{
+    private static readonly Guid SecurityId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid BookA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid BookB = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    [Fact]
+    public async Task NoAffectedBooks_NoRestatement_AndDoesNotConsultLockReader()
+    {
+        var lockReader = new FakeLockReader(_ => throw new InvalidOperationException("must not be consulted when no books are affected"));
+        var resolver = NewResolver(lockReader, NoCandidates());
+
+        var decision = await resolver.ResolveAsync(Event(affectedBooks: []));
+
+        decision.RestatementRequired.Should().BeFalse();
+        decision.Candidates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task OpenPeriod_NoRestatement()
+    {
+        var resolver = NewResolver(new FakeLockReader(_ => LedgerPeriodStatusDto.Open), NoCandidates());
+
+        var decision = await resolver.ResolveAsync(Event(affectedBooks: [BookA]));
+
+        decision.RestatementRequired.Should().BeFalse();
+        decision.Candidates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HardClosedPeriod_RequiresRestatement_WithLocatedCandidates()
+    {
+        var candidate = Candidate();
+        var resolver = NewResolver(new FakeLockReader(_ => LedgerPeriodStatusDto.HardClosed), Candidates(candidate));
+
+        var decision = await resolver.ResolveAsync(Event(affectedBooks: [BookA]));
+
+        decision.RestatementRequired.Should().BeTrue();
+        decision.Candidates.Should().ContainSingle().Which.Should().Be(candidate);
+    }
+
+    [Fact]
+    public async Task HardClosedPeriod_NoCandidatesLocated_StillRequiresRestatement()
+    {
+        // Exposure exists but no pack could be located → manual locate-affected-packs task, never silent completion.
+        var resolver = NewResolver(new FakeLockReader(_ => LedgerPeriodStatusDto.HardClosed), NoCandidates());
+
+        var decision = await resolver.ResolveAsync(Event(affectedBooks: [BookA]));
+
+        decision.RestatementRequired.Should().BeTrue();
+        decision.Candidates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SoftClosedPeriod_WithPublishedExposure_ProposesRestatementForThosePacks()
+    {
+        var candidate = Candidate();
+        var resolver = NewResolver(new FakeLockReader(_ => LedgerPeriodStatusDto.SoftClosed), Candidates(candidate));
+
+        var decision = await resolver.ResolveAsync(Event(affectedBooks: [BookA]));
+
+        decision.RestatementRequired.Should().BeTrue("an already-published pack consumed the soft-closed line");
+        decision.Candidates.Should().ContainSingle().Which.Should().Be(candidate);
+    }
+
+    [Fact]
+    public async Task SoftClosedPeriod_NoPublishedExposure_NoRestatement()
+    {
+        // Soft-closed posts as a governed adjustment (a later slice); with no published pack, nothing to restate.
+        var resolver = NewResolver(new FakeLockReader(_ => LedgerPeriodStatusDto.SoftClosed), NoCandidates());
+
+        var decision = await resolver.ResolveAsync(Event(affectedBooks: [BookA]));
+
+        decision.RestatementRequired.Should().BeFalse();
+        decision.Candidates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task MultipleBooks_OneHardClosed_AggregatesToRestatementRequired()
+    {
+        var lockReader = new FakeLockReader(book => book == BookB ? LedgerPeriodStatusDto.HardClosed : LedgerPeriodStatusDto.Open);
+        var resolver = NewResolver(lockReader, NoCandidates());
+
+        var decision = await resolver.ResolveAsync(Event(affectedBooks: [BookA, BookB]));
+
+        decision.RestatementRequired.Should().BeTrue("any hard-closed affected book forces a restatement proposal");
+    }
+
+    // ---- helpers ------------------------------------------------------------------------------
+
+    private static PeriodAwareRestatementResolver NewResolver(
+        ILedgerPeriodLockReader lockReader, IRestatementCandidateResolver candidateResolver)
+        => new(lockReader, candidateResolver, NullLogger<PeriodAwareRestatementResolver>.Instance);
+
+    private static IRestatementCandidateResolver NoCandidates() => new FakeCandidateResolver([]);
+
+    private static IRestatementCandidateResolver Candidates(params RestatementCandidateDto[] candidates)
+        => new FakeCandidateResolver(candidates);
+
+    private static RestatementCandidateDto Candidate()
+        => new(
+            ReportId: Guid.NewGuid(),
+            PriorVersionReportId: Guid.NewGuid(),
+            PeriodLabel: "2026-P03",
+            Summary: "Restate pack for corrected reference data.",
+            ChangedLines: []);
+
+    private static SecurityMasterRevisionPublishedEvent Event(IReadOnlyList<Guid> affectedBooks)
+        => new(
+            SecurityId: SecurityId,
+            RevisionId: Guid.NewGuid(),
+            Version: 7,
+            EffectiveFrom: new DateTimeOffset(2026, 03, 15, 0, 0, 0, TimeSpan.Zero),
+            ChangedFields: ["EconomicDefinition.Coupon"],
+            DownstreamImpact: EmptyImpact(),
+            AffectedLedgerBookIds: affectedBooks,
+            Actor: "ops.analyst",
+            CorrelationId: null);
+
+    private static SecurityMasterDownstreamImpactDto EmptyImpact()
+        => new(
+            FundProfileId: null,
+            IsScoped: false,
+            Severity: SecurityMasterImpactSeverity.None,
+            Summary: "n/a",
+            PortfolioExposureSummary: string.Empty,
+            LedgerExposureSummary: string.Empty,
+            ReconciliationExposureSummary: string.Empty,
+            ReportPackExposureSummary: string.Empty,
+            MatchedRunCount: 0,
+            PortfolioExposureCount: 0,
+            LedgerExposureCount: 0,
+            ReconciliationExposureCount: 0,
+            ReportPackExposureCount: 0,
+            Links: []);
+
+    private sealed class FakeLockReader : ILedgerPeriodLockReader
+    {
+        private readonly Func<Guid, LedgerPeriodStatusDto> _map;
+        public FakeLockReader(Func<Guid, LedgerPeriodStatusDto> map) => _map = map;
+
+        public Task<LedgerPeriodStatusDto> GetPeriodStatusAsync(Guid ledgerBookId, DateOnly date, CancellationToken ct = default)
+            => Task.FromResult(_map(ledgerBookId));
+    }
+
+    private sealed class FakeCandidateResolver : IRestatementCandidateResolver
+    {
+        private readonly IReadOnlyList<RestatementCandidateDto> _candidates;
+        public FakeCandidateResolver(IReadOnlyList<RestatementCandidateDto> candidates) => _candidates = candidates;
+
+        public Task<IReadOnlyList<RestatementCandidateDto>> ResolveAsync(
+            Guid securityId, Guid ledgerBookId, DateOnly effectiveDate, IReadOnlyList<string> changedFields, CancellationToken ct = default)
+            => Task.FromResult(_candidates);
+    }
+}

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/SecurityMasterWorkbenchCommandServiceTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/SecurityMasterWorkbenchCommandServiceTests.cs
@@ -497,6 +497,34 @@ public sealed class SecurityMasterWorkbenchCommandServiceTests
     }
 
     [Fact]
+    public async Task Publish_ClosedPeriodExposure_FlowsRestatementDecisionIntoResult()
+    {
+        var harness = new Harness(currentVersion: 4);
+        var revisionId = await harness.SeedRevisionAsync(SecurityMasterRevisionStateDto.Approved);
+        var candidate = new RestatementCandidateDto(
+            ReportId: Guid.NewGuid(),
+            PriorVersionReportId: Guid.NewGuid(),
+            PeriodLabel: "2026-P03",
+            Summary: "Restate Q1 NAV pack for corrected coupon.",
+            ChangedLines: []);
+        harness.Restatement
+            .Setup(r => r.ResolveAsync(It.IsAny<SecurityMasterRevisionPublishedEvent>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SecurityMasterRestatementDecision(RestatementRequired: true, Candidates: [candidate]));
+
+        var request = new PublishSecurityMasterRevisionRequest(
+            SecurityId: SecurityId,
+            RevisionId: revisionId,
+            Actor: "ops.analyst",
+            ApproverActor: "ops.reviewer");
+
+        var result = await harness.Service.PublishRevisionAsync(request);
+
+        result.RestatementRequired.Should().BeTrue();
+        result.RestatementCandidates.Should().ContainSingle().Which.Should().Be(candidate);
+        (await harness.Revisions.GetAsync(revisionId))!.State.Should().Be(SecurityMasterRevisionStateDto.Published);
+    }
+
+    [Fact]
     public async Task Publish_RevisionNotApproved_Throws_AndDoesNotFanOut()
     {
         var handler = new RecordingHandler(order: 10);
@@ -566,6 +594,7 @@ public sealed class SecurityMasterWorkbenchCommandServiceTests
         public Mock<ISecurityMasterConflictService> ConflictService { get; } = new(MockBehavior.Loose);
         public Mock<ISecurityMasterWorkbenchQueryService> QueryService { get; } = new(MockBehavior.Loose);
         public Mock<IOperationsContinuityWorkflowService> Workflow { get; } = new(MockBehavior.Loose);
+        public Mock<IPeriodAwareRestatementResolver> Restatement { get; } = new(MockBehavior.Loose);
         public ISecurityMasterRevisionStore Revisions { get; } = new InMemorySecurityMasterRevisionStore();
         public SecurityMasterWorkbenchCommandService Service { get; }
 
@@ -582,6 +611,11 @@ public sealed class SecurityMasterWorkbenchCommandServiceTests
                 .Setup(q => q.GetTrustSnapshotAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((SecurityMasterTrustSnapshotDto?)null);
 
+            // Default: no closed-period exposure. Individual tests override to assert restatement flow-through.
+            Restatement
+                .Setup(r => r.ResolveAsync(It.IsAny<SecurityMasterRevisionPublishedEvent>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new SecurityMasterRestatementDecision(RestatementRequired: false, Candidates: []));
+
             Service = new SecurityMasterWorkbenchCommandService(
                 EventStore,
                 Overrides.Object,
@@ -590,6 +624,7 @@ public sealed class SecurityMasterWorkbenchCommandServiceTests
                 QueryService.Object,
                 Workflow.Object,
                 Revisions,
+                Restatement.Object,
                 handlers ?? Array.Empty<ISecurityMasterRevisionPublishedHandler>(),
                 NullLogger<SecurityMasterWorkbenchCommandService>.Instance);
         }


### PR DESCRIPTION
<!-- phase:PR7 -->

> `<!-- phase:PR7 -->` above declares the roadmap scope tier (`src/**` + `tests/**` + `docs/**`) for the `scope-gate` check.

## Summary

First slice of **Phase 3 (period-aware propagation + restatement)** for the Security Master Passport Workbench, building on the Phase 2 governed-write surface now in `main`. A published revision whose edit lands in a **closed** accounting period becomes a governed **restatement proposal** rather than a silent mutation — routed by the authoritative ledger accounting-period status.

- **`ILedgerPeriodLockReader`** — the authoritative period-lock reader over `ILedgerJournalStore` (the same `LedgerAccountingPeriod.Status` authority `LedgerPeriodPostingGuard` enforces). **Default-deny:** a missing/unrecognized status or a store failure resolves to `HardClosed`, so an edit can never silently mutate a book whose lock state could not be confirmed.
- **`IPeriodAwareRestatementResolver` + `PeriodAwareRestatementResolver`** — for each `evt.AffectedLedgerBookIds`, route by the D3 matrix: `Open` → no restatement (lower-order handlers propagate); `SoftClosed` → restate only already-published packs; `HardClosed`/indeterminate → mandatory proposal with no posting. A hard-closed book with exposure but no locatable pack still reports `RestatementRequired` (a manual locate-affected-packs task) — never silent completion.
- **`IRestatementCandidateResolver`** seam + `NullRestatementCandidateResolver` (report-usage projection integration is a later slice).
- **`PublishRevisionAsync`** consults the resolver and flows `RestatementRequired` / `RestatementCandidates` into `SecurityMasterPublishResultDto`. The `void` published-handler seam remains for pure side effects.

The result-bearing decision lives in a resolver (not the `void` handler) because the handler fan-out cannot return candidates without overloading its contract; design-doc **D3** records the refinement.

## Reason

Implements the closed-period restatement-propagation invariant (W4-RPT-001 / Unknown #3 in the design doc): closed periods are never silently changed. Establishes the period-routing authority and wires it into the publish result.

**Scope honesty:** wired and fully unit-tested, but **end-to-end it is currently a no-op** — `PublishRevisionAsync` still emits `AffectedLedgerBookIds: []`, so the resolver has nothing to route until the next slice resolves affected books from the passport/downstream-impact read. The remaining Phase 3 slices (affected-book feed, `SecurityProjectionRebuild`/`CoverageInvalidation` handlers, governed adjustment poster, report-pack candidate resolver) and Phase 4 (endpoints/UI/options) follow.

## Testing performed

- [ ] `bash scripts/ci.sh` — not run locally (no .NET toolchain in this environment); CI is the authoritative compile/test
- [x] Relevant unit tests were added or updated — `LedgerPeriodLockReaderTests` (Open/SoftClosed/HardClosed + every default-deny path), `PeriodAwareRestatementResolverTests` (full D3 matrix, multi-book aggregation, no-candidate manual-locate), and a `PublishRevisionAsync` restatement flow-through test
- [ ] Relevant integration tests were added or updated — N/A (no endpoint surface in this slice)
- [ ] GitHub Actions `quality-gate` passed — runs on this PR as the authoritative gate

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019qm7pxZJDPsXViBkoHw7R2)_