### PR TITLE
feat(security-master): Phase 4 — workbench write endpoints + options config-binding

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -5026,6 +5026,7 @@ Meridian-main
 │   │   │   ├── WorkstationEndpoints.PlotTool.cs
 │   │   │   ├── WorkstationEndpoints.ProviderIntegrations.cs
 │   │   │   ├── WorkstationEndpoints.Reconciliation.cs
+│   │   │   ├── WorkstationEndpoints.SecurityMasterWorkbench.cs
 │   │   │   ├── WorkstationRiskEndpoints.cs
 │   │   │   └── WorkstationTenantContext.cs
 │   │   ├── Evidence
@@ -6741,6 +6742,8 @@ Meridian-main
 │   │   │   ├── SecurityMasterInstrumentPassportTests.cs
 │   │   │   ├── SecurityMasterPreferredEquityEndpointsTests.cs
 │   │   │   ├── SecurityMasterValidationEndpointsTests.cs
+│   │   │   ├── SecurityMasterWorkbenchEndpointsTests.cs
+│   │   │   ├── SecurityMasterWorkbenchOptionsBindingTests.cs
 │   │   │   ├── StrategyDesignerWorkstationEndpointsTests.cs
 │   │   │   ├── TradingOperatorReadinessServiceTests.cs
 │   │   │   ├── Wave2OperatorInboxAcceptanceTests.cs

--- a/docs/plans/security-master-passport-workbench.md
+++ b/docs/plans/security-master-passport-workbench.md
@@ -314,10 +314,16 @@ POST /api/security-master/{securityId:guid}/workbench/resolve-conflict
 
 POST /api/security-master/{securityId:guid}/workbench/submit
   Body: SubmitSecurityMasterRevisionRequest → 200: SecurityMasterEditResultDto
+  409: { "error": "revision-state-conflict", ... } | { "error": "version-conflict", currentVersion }
+
+POST /api/security-master/{securityId:guid}/workbench/approve
+  Body: ApproveSecurityMasterRevisionRequest → 200: SecurityMasterEditResultDto
+  409: { "error": "revision-state-conflict", ... }
 
 POST /api/security-master/{securityId:guid}/workbench/publish
   Body: PublishSecurityMasterRevisionRequest → 200: SecurityMasterPublishResultDto
-  403: { "error": "approval-required" }
+  409: { "error": "revision-state-conflict", ... }   # publish-before-approved / unknown revision
+  500: { "error": "publish-side-effect-failed", ... } # durable append; handlers idempotent; retry-safe
 ```
 
 ## Component Design
@@ -574,10 +580,25 @@ PR3 browser UI, PR4 WPF parity.
 - [ ] DI registration (ordered handler collection).
 
 ### Phase 4 — Endpoints + UI
-- [ ] New partial `WorkstationEndpoints.SecurityMasterWorkbench.cs` mapping the 4 routes.
+- [x] New partial `WorkstationEndpoints.SecurityMasterWorkbench.cs` mapping the routes (field,
+      resolve-conflict, submit, **approve**, publish — approve added so the UI can drive the full
+      field→submit→approve→publish lifecycle through one cohesive surface). Each route requires
+      `ModifySecurityMaster`, is tenant-scoped, and the path `securityId` overrides the request body so a
+      mismatched body can never target another security. Domain failures map via a shared
+      `ExecuteWorkbenchAsync` helper: stale version → **409** `{ version-conflict, currentVersion }`;
+      invalid lifecycle transition (incl. publish-before-approved / unknown revision) → **409**
+      `{ revision-state-conflict }`; rejected invariant (justification / policy-deviation / non-candidate
+      winner) → **422**; publish side-effect failure → **500** (durable append, idempotent handlers,
+      retry-safe). *Mapping note:* the original sketch listed publish-before-approved as `403`; it now
+      surfaces as `409`, because the same approval precondition (`EnsureRevisionInStateAsync`) also covers
+      unknown/foreign revisions, and a 409 "refetch the revision and retry" is the coherent client
+      behaviour for all three. The conflict-resolution `422` covers the unacknowledged-policy-deviation case.
+- [x] `SecurityMasterWorkbenchOptions` bound from the `SecurityMasterWorkbench` configuration section
+      (`AddOptions<…>().Configure<IConfiguration>(…)`), so the conflict-authority policy's
+      `IOptionsMonitor` ranks the deployment's real source systems and hot-reloads.
 - [ ] Browser `security-passport-editor.tsx` extending `security-details-tracker.tsx`; entry point
-      from `buildMultiAssetCoveragePanel()` row.
-- [ ] WPF `SecurityPassportEditorViewModel` + `SecurityPassportEditorPage.xaml`.
+      from `buildMultiAssetCoveragePanel()` row. *(Follow-up slice — backend write surface lands first.)*
+- [ ] WPF `SecurityPassportEditorViewModel` + `SecurityPassportEditorPage.xaml`. *(Follow-up slice.)*
 
 ### Phase 5 — Tests
 - [ ] All unit tests above (~22) green; ≥80% on new code.

--- a/docs/plans/security-master-passport-workbench.md
+++ b/docs/plans/security-master-passport-workbench.md
@@ -584,7 +584,13 @@ PR3 browser UI, PR4 WPF parity.
       resolve-conflict, submit, **approve**, publish — approve added so the UI can drive the full
       field→submit→approve→publish lifecycle through one cohesive surface). Each route requires
       `ModifySecurityMaster`, is tenant-scoped, and the path `securityId` overrides the request body so a
-      mismatched body can never target another security. Domain failures map via a shared
+      mismatched body can never target another security. The **acting principal is server-derived** from
+      the session (`EndpointAuthorization.TryResolveActor`, 401 if unresolved) and overwrites the body
+      `Actor` on every route; on approve it also overwrites `Reviewer` (the caller *is* the reviewer), so a
+      caller cannot post the assigned reviewer's name to record/bypass approval as that person — the
+      approval gate's reviewer-match and the submit-time reviewer-independence check run against trusted
+      identity (`Reviewer` on submit stays body-supplied: it is the assignment of who must approve). Domain
+      failures map via a shared
       `ExecuteWorkbenchAsync` helper: stale version → **409** `{ version-conflict, currentVersion }`;
       invalid lifecycle transition (incl. publish-before-approved / unknown revision) → **409**
       `{ revision-state-conflict }`; rejected invariant (justification / policy-deviation / non-candidate

--- a/docs/plans/security-master-passport-workbench.md
+++ b/docs/plans/security-master-passport-workbench.md
@@ -314,6 +314,8 @@ POST /api/security-master/{securityId:guid}/workbench/resolve-conflict
 
 POST /api/security-master/{securityId:guid}/workbench/submit
   Body: SubmitSecurityMasterRevisionRequest → 200: SecurityMasterEditResultDto
+  422: { "error": "workflow-required" }   # governed submit must name an approval workflow (a
+                                          # workflow-less submit would strand the revision in Submitted)
   409: { "error": "revision-state-conflict", ... } | { "error": "version-conflict", currentVersion }
 
 POST /api/security-master/{securityId:guid}/workbench/approve

--- a/docs/status/TODO.md
+++ b/docs/status/TODO.md
@@ -1,6 +1,6 @@
 # TODO / FIXME / HACK / NOTE Scan
 
-Total items: **196**
+Total items: **197**
 
 | File | Line | Tag | Linked Issue | Text |
 | --- | ---: | --- | :---: | --- |
@@ -193,6 +193,7 @@ Total items: **196**
 | `tests/Meridian.Tests/Ui/FundOpsCloseLaneScenarioTests.cs` | 418 | `NOTE` | ❌ | // Note: Status derives as ApprovalPending once all four gates are clean, which is expected |
 | `tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs` | 112 | `NOTE` | ❌ | Note: "Approved by controller.", |
 | `tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs` | 1757 | `NOTE` | ❌ | Note: "Delivered after restatement.", |
+| `tests/Meridian.Tests/Ui/SecurityMasterWorkbenchEndpointsTests.cs` | 111 | `NOTE` | ❌ | Note: "ready", |
 | `tests/Meridian.Tests/Ui/WorkstationFinancialRecordExplorerEndpointTests.cs` | 179 | `NOTE` | ❌ | Note: "Board pack delivered with retained evidence graph.", |
 | `tests/Meridian.Ui.Tests/Services/DiagnosticsServiceTests.cs` | 9 | `NOTE` | ❌ | /// Note: The service methods require a running backend (ApiClientService), |
 | `tests/Meridian.Ui.Tests/Services/ScheduledMaintenanceServiceTests.cs` | 85 | `NOTE` | ❌ | // NOTE: since this is a singleton shared across tests, if StartScheduler was |

--- a/docs/status/TODO.md
+++ b/docs/status/TODO.md
@@ -43,11 +43,11 @@ Total items: **196**
 | `src/Meridian.Ui.Services/Services/ProviderHealthService.cs` | 530 | `NOTE` | ❌ | // NOTE: ProviderComparison is defined in AdvancedAnalyticsModels.cs for cross-provider comparison |
 | `src/Meridian.Ui.Shared/Endpoints/ArchiveMaintenanceEndpoints.cs` | 32 | `NOTE` | ❌ | // NOTE: GET /schedules, GET /schedules/{id}, POST /schedules, POST /schedules/{id}/enable, |
 | `src/Meridian.Ui.Shared/Endpoints/ArchiveMaintenanceEndpoints.cs` | 117 | `NOTE` | ❌ | // NOTE: POST /schedules/{id}/enable and POST /schedules/{id}/disable are registered |
-| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4231 | `NOTE` | ❌ | note: "Paper adapter routing is available.", |
-| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4243 | `NOTE` | ❌ | note: "Realtime subscriptions are steady.", |
-| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4255 | `NOTE` | ❌ | note: "Replay queue is elevated but within tolerance.", |
-| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4367 | `NOTE` | ❌ | Note: note, |
-| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4450 | `NOTE` | ❌ | Note: note, |
+| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4235 | `NOTE` | ❌ | note: "Paper adapter routing is available.", |
+| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4247 | `NOTE` | ❌ | note: "Realtime subscriptions are steady.", |
+| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4259 | `NOTE` | ❌ | note: "Replay queue is elevated but within tolerance.", |
+| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4371 | `NOTE` | ❌ | Note: note, |
+| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4454 | `NOTE` | ❌ | Note: note, |
 | `src/Meridian.Ui.Shared/Services/ProviderLedgerReconciliationService.cs` | 1974 | `NOTE` | ❌ | Note: "Provider-ledger reconciliation break signed off.", |
 | `src/Meridian.Ui.Shared/Services/ReportPackDeliveryService.cs` | 240 | `NOTE` | ❌ | Note: NormalizeNullable(target.Note) ?? $"Scheduled delivery for {normalizedTemplateId}.", |
 | `src/Meridian.Ui.Shared/Services/ReportPackRunReadService.cs` | 2047 | `NOTE` | ❌ | Note: NormalizeOptional(target.Note), |

--- a/docs/status/api-contract-coverage-dashboard.json
+++ b/docs/status/api-contract-coverage-dashboard.json
@@ -3533,13 +3533,13 @@
     {
       "method": "GET",
       "path": "/api/strategies/{strategyId}/runs",
-      "source": "src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs:2514",
+      "source": "src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs:2518",
       "documented": true
     },
     {
       "method": "GET",
       "path": "/api/strategies/runs/compare",
-      "source": "src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs:2635",
+      "source": "src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs:2639",
       "documented": true
     }
   ],

--- a/docs/status/api-contract-coverage-dashboard.md
+++ b/docs/status/api-contract-coverage-dashboard.md
@@ -579,8 +579,8 @@ Tracks whether mapped API routes and workstation DTO contracts are visible in th
 | `POST` | `/api/strategies/covered-call/runs/{runId}/cancel` | Documented | `src/Meridian.Ui.Shared/Endpoints/CoveredCallEndpoints.cs:135` |
 | `GET` | `/api/strategies/covered-call/runs/{runId}/result` | Documented | `src/Meridian.Ui.Shared/Endpoints/CoveredCallEndpoints.cs:93` |
 | `GET` | `/api/strategies/covered-call/runs/{runId}/status` | Documented | `src/Meridian.Ui.Shared/Endpoints/CoveredCallEndpoints.cs:70` |
-| `GET` | `/api/strategies/runs/compare` | Documented | `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs:2635` |
-| `GET` | `/api/strategies/{strategyId}/runs` | Documented | `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs:2514` |
+| `GET` | `/api/strategies/runs/compare` | Documented | `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs:2639` |
+| `GET` | `/api/strategies/{strategyId}/runs` | Documented | `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs:2518` |
 | `GET` | `/api/subscriptions/active` | Documented | `src/Meridian.Ui.Shared/Endpoints/SubscriptionEndpoints.cs:21` |
 | `POST` | `/api/subscriptions/subscribe` | Documented | `src/Meridian.Ui.Shared/Endpoints/SubscriptionEndpoints.cs:43` |
 | `POST` | `/api/subscriptions/unsubscribe/{symbol}` | Documented | `src/Meridian.Ui.Shared/Endpoints/SubscriptionEndpoints.cs:72` |

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,7 +5,7 @@
 
 ## Overall Coverage
 
-**2557 / 7181** items documented (**35.6%**) &mdash; Grade: **F**
+**2558 / 7181** items documented (**35.6%**) &mdash; Grade: **F**
 
 ```text
 [=======-------------] 35.6%
@@ -15,7 +15,7 @@
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 2436 | 6686 | 36.4% | F |
+| Public Classes / Interfaces | 2437 | 6686 | 36.4% | F |
 | API Endpoints | 107 | 348 | 30.7% | F |
 | Configuration Options | 3 | 136 | 2.2% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |
@@ -23,7 +23,7 @@
 
 ## Undocumented Items
 
-### Public Classes / Interfaces (4250 undocumented)
+### Public Classes / Interfaces (4249 undocumented)
 
 | Item | Location |
 | ------ | ---------- |
@@ -77,7 +77,7 @@
 | `ExecutionStatistics` | `src/Meridian.Application/Scheduling/BackfillExecutionLog.cs:185` |
 | `ProviderUsageStats` | `src/Meridian.Application/Scheduling/BackfillExecutionLog.cs:218` |
 | `SymbolExecutionResult` | `src/Meridian.Application/Scheduling/BackfillExecutionLog.cs:234` |
-| ... and 4200 more | |
+| ... and 4199 more | |
 
 ### API Endpoints (241 undocumented)
 
@@ -193,7 +193,7 @@
 
 ## Recommendations
 
-1. **Public Classes / Interfaces**: 4250 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
+1. **Public Classes / Interfaces**: 4249 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
 2. **API Endpoints**: 241 endpoint(s) missing from `docs/reference/api-reference.md`. Run the endpoint audit and update the API reference table.
 3. **Configuration Options**: 133 config key(s) not found in `docs/generated/configuration-schema.md`. Re-run the configuration schema generator to synchronise.
 

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 534,
-  "total_lines": 86187,
+  "total_lines": 86211,
   "orphaned_count": 204,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2129,7 +2129,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7214,
+      "line_count": 7217,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -2785,7 +2785,7 @@
     },
     {
       "path": "docs/plans/security-master-passport-workbench.md",
-      "line_count": 629,
+      "line_count": 650,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,11 +1,11 @@
 {
   "total_files": 534,
-  "total_lines": 86211,
+  "total_lines": 86217,
   "orphaned_count": 204,
   "no_heading_count": 38,
   "stale_count": 0,
   "todo_count": 199,
-  "average_lines": 161.4,
+  "average_lines": 161.5,
   "health_score": 83,
   "orphaned_files": [
     ".agents/skills/meridian-archive-organizer/SKILL.md",
@@ -2785,7 +2785,7 @@
     },
     {
       "path": "docs/plans/security-master-passport-workbench.md",
-      "line_count": 650,
+      "line_count": 656,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 534,
-  "total_lines": 86217,
+  "total_lines": 86219,
   "orphaned_count": 204,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2785,7 +2785,7 @@
     },
     {
       "path": "docs/plans/security-master-passport-workbench.md",
-      "line_count": 656,
+      "line_count": 658,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 534 |
-| Total lines | 86,217 |
+| Total lines | 86,219 |
 | Average file size (lines) | 161.5 |
 | Orphaned files | 204 |
 | Files without headings | 38 |

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,8 +20,8 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 534 |
-| Total lines | 86,211 |
-| Average file size (lines) | 161.4 |
+| Total lines | 86,217 |
+| Average file size (lines) | 161.5 |
 | Orphaned files | 204 |
 | Files without headings | 38 |
 | Stale files (>90 days) | 0 |

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 534 |
-| Total lines | 86,187 |
+| Total lines | 86,211 |
 | Average file size (lines) | 161.4 |
 | Orphaned files | 204 |
 | Files without headings | 38 |

--- a/src/Meridian.Contracts/Api/UiApiRoutes.cs
+++ b/src/Meridian.Contracts/Api/UiApiRoutes.cs
@@ -356,6 +356,7 @@ public static class UiApiRoutes
     public const string SecurityMasterWorkbenchField = "/api/security-master/{securityId:guid}/workbench/field";
     public const string SecurityMasterWorkbenchResolveConflict = "/api/security-master/{securityId:guid}/workbench/resolve-conflict";
     public const string SecurityMasterWorkbenchSubmit = "/api/security-master/{securityId:guid}/workbench/submit";
+    public const string SecurityMasterWorkbenchApprove = "/api/security-master/{securityId:guid}/workbench/approve";
     public const string SecurityMasterWorkbenchPublish = "/api/security-master/{securityId:guid}/workbench/publish";
     public const string SecurityMasterImport = "/api/security-master/import";
     public const string SecurityMasterIngestStatus = "/api/security-master/ingest/status";

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.SecurityMasterWorkbench.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.SecurityMasterWorkbench.cs
@@ -132,6 +132,16 @@ public static partial class WorkstationEndpoints
                 return Results.Unauthorized();
             }
 
+            // The governed surface must submit through the approval workflow: a workflow-less submit
+            // advances the revision to Submitted without binding a workflow, but the only approval path
+            // requires one, leaving the revision stuck and unpublishable. Require the workflow context here.
+            if (request.WorkflowId is not { } workflowId || workflowId == Guid.Empty)
+            {
+                return WorkbenchUnprocessable(
+                    "workflow-required",
+                    "A workflowId is required to submit a Security Master revision through the governed approval gate.");
+            }
+
             // Actor is the server-derived submitter; Reviewer stays as the body-supplied assignment (who
             // must later approve) — the command service enforces that the two differ.
             var bound = request with { SecurityId = securityId, Actor = actor };
@@ -288,6 +298,9 @@ public static partial class WorkstationEndpoints
 
     private static IResult WorkbenchMissingPayload(string detail)
         => Results.ValidationProblem(new Dictionary<string, string[]> { ["request"] = [detail] });
+
+    private static IResult WorkbenchUnprocessable(string error, string message)
+        => Results.Json(new { error, message }, statusCode: StatusCodes.Status422UnprocessableEntity);
 
     private static string SecurityMasterSubroute(string route)
     {

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.SecurityMasterWorkbench.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.SecurityMasterWorkbench.cs
@@ -54,7 +54,13 @@ public static partial class WorkstationEndpoints
                 return WorkbenchMissingPayload("An UpdateSecurityFieldRequest body is required.");
             }
 
-            var bound = request with { SecurityId = securityId };
+            if (!EndpointAuthorization.TryResolveActor(context, out var actor))
+            {
+                return Results.Unauthorized();
+            }
+
+            // The acting principal is server-derived from the session, never trusted from the body.
+            var bound = request with { SecurityId = securityId, Actor = actor };
             return await ExecuteWorkbenchAsync(
                 () => service.UpdateSecurityFieldAsync(bound, context.RequestAborted), jsonOptions).ConfigureAwait(false);
         })
@@ -85,7 +91,12 @@ public static partial class WorkstationEndpoints
                 return WorkbenchMissingPayload("A ResolveSourceConflictRequest body is required.");
             }
 
-            var bound = request with { SecurityId = securityId };
+            if (!EndpointAuthorization.TryResolveActor(context, out var actor))
+            {
+                return Results.Unauthorized();
+            }
+
+            var bound = request with { SecurityId = securityId, Actor = actor };
             return await ExecuteWorkbenchAsync(
                 () => service.ResolveSourceConflictAsync(bound, context.RequestAborted), jsonOptions).ConfigureAwait(false);
         })
@@ -116,7 +127,14 @@ public static partial class WorkstationEndpoints
                 return WorkbenchMissingPayload("A SubmitSecurityMasterRevisionRequest body is required.");
             }
 
-            var bound = request with { SecurityId = securityId };
+            if (!EndpointAuthorization.TryResolveActor(context, out var actor))
+            {
+                return Results.Unauthorized();
+            }
+
+            // Actor is the server-derived submitter; Reviewer stays as the body-supplied assignment (who
+            // must later approve) — the command service enforces that the two differ.
+            var bound = request with { SecurityId = securityId, Actor = actor };
             return await ExecuteWorkbenchAsync(
                 () => service.SubmitForApprovalAsync(bound, context.RequestAborted), jsonOptions).ConfigureAwait(false);
         })
@@ -147,7 +165,14 @@ public static partial class WorkstationEndpoints
                 return WorkbenchMissingPayload("An ApproveSecurityMasterRevisionRequest body is required.");
             }
 
-            var bound = request with { SecurityId = securityId };
+            if (!EndpointAuthorization.TryResolveActor(context, out var actor))
+            {
+                return Results.Unauthorized();
+            }
+
+            // The caller IS the reviewer: both Actor and Reviewer are server-derived from the session, so a
+            // caller cannot post the assigned reviewer's name and record/bypass approval as that person.
+            var bound = request with { SecurityId = securityId, Actor = actor, Reviewer = actor };
             return await ExecuteWorkbenchAsync(
                 () => service.ApproveRevisionAsync(bound, context.RequestAborted), jsonOptions).ConfigureAwait(false);
         })
@@ -178,7 +203,12 @@ public static partial class WorkstationEndpoints
                 return WorkbenchMissingPayload("A PublishSecurityMasterRevisionRequest body is required.");
             }
 
-            var bound = request with { SecurityId = securityId };
+            if (!EndpointAuthorization.TryResolveActor(context, out var actor))
+            {
+                return Results.Unauthorized();
+            }
+
+            var bound = request with { SecurityId = securityId, Actor = actor };
             return await ExecuteWorkbenchAsync(
                 () => service.PublishRevisionAsync(bound, context.RequestAborted), jsonOptions).ConfigureAwait(false);
         })

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.SecurityMasterWorkbench.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.SecurityMasterWorkbench.cs
@@ -262,7 +262,15 @@ public static partial class WorkstationEndpoints
     private static string SecurityMasterSubroute(string route)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(route);
-        return route.StartsWith(SecurityMasterApiRoutePrefix, StringComparison.Ordinal)
+
+        // Only strip the prefix when the route is exactly the prefix or the prefix is followed by a path
+        // separator, so a similarly-named sibling (e.g. "/api/security-master-templates") is never mangled.
+        if (route.Equals(SecurityMasterApiRoutePrefix, StringComparison.Ordinal))
+        {
+            return string.Empty;
+        }
+
+        return route.StartsWith(SecurityMasterApiRoutePrefix + "/", StringComparison.Ordinal)
             ? route[SecurityMasterApiRoutePrefix.Length..]
             : route;
     }

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.SecurityMasterWorkbench.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.SecurityMasterWorkbench.cs
@@ -1,0 +1,269 @@
+using System.Text.Json;
+using Meridian.Application.SecurityMaster;
+using Meridian.Contracts.Api;
+using Meridian.Contracts.Workstation;
+using Meridian.Identity.Auth;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Meridian.Ui.Shared.Endpoints;
+
+public static partial class WorkstationEndpoints
+{
+    private const string SecurityMasterApiRoutePrefix = "/api/security-master";
+
+    /// <summary>
+    /// Maps the Security Master Passport Workbench governed-write surface (Phase 4). Each route requires
+    /// <see cref="UserPermission.ModifySecurityMaster"/>, is tenant-scoped, and routes the request through
+    /// <see cref="ISecurityMasterWorkbenchCommandService"/>. The path <c>securityId</c> is authoritative —
+    /// the request body's id is overwritten so a mismatched body can never target another security.
+    ///
+    /// <para>Domain failures map to stable status codes via <see cref="ExecuteWorkbenchAsync{T}"/>:
+    /// stale expected version → <b>409</b> with the current version; an invalid lifecycle transition
+    /// (e.g. publishing a revision that is not Approved, or an unknown revision) → <b>409</b>; a rejected
+    /// invariant (missing justification, unacknowledged policy deviation, non-candidate winner) → <b>422</b>;
+    /// a publish whose side-effect fan-out failed → <b>500</b> (the append is durable and handlers are
+    /// idempotent, so the caller may retry).</para>
+    /// </summary>
+    internal static void MapSecurityMasterWorkbenchEndpoints(this WebApplication app, JsonSerializerOptions jsonOptions)
+    {
+        var group = app.MapGroup(SecurityMasterApiRoutePrefix)
+            .WithTags("SecurityMasterWorkbench")
+            .RequireWorkstationTenantScope();
+
+        group.MapPost(SecurityMasterSubroute(UiApiRoutes.SecurityMasterWorkbenchField), async (
+            Guid securityId,
+            UpdateSecurityFieldRequest? request,
+            HttpContext context,
+            [FromServices] ISecurityMasterWorkbenchCommandService? service) =>
+        {
+            if (!EndpointAuthorization.HasPermission(context, UserPermission.ModifySecurityMaster))
+            {
+                return EndpointHelpers.Forbidden();
+            }
+
+            if (service is null)
+            {
+                return WorkbenchServiceUnavailable();
+            }
+
+            if (request is null)
+            {
+                return WorkbenchMissingPayload("An UpdateSecurityFieldRequest body is required.");
+            }
+
+            var bound = request with { SecurityId = securityId };
+            return await ExecuteWorkbenchAsync(
+                () => service.UpdateSecurityFieldAsync(bound, context.RequestAborted), jsonOptions).ConfigureAwait(false);
+        })
+        .WithName("SecurityMasterWorkbenchField")
+        .Produces<SecurityMasterEditResultDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status409Conflict)
+        .Produces(StatusCodes.Status422UnprocessableEntity);
+
+        group.MapPost(SecurityMasterSubroute(UiApiRoutes.SecurityMasterWorkbenchResolveConflict), async (
+            Guid securityId,
+            ResolveSourceConflictRequest? request,
+            HttpContext context,
+            [FromServices] ISecurityMasterWorkbenchCommandService? service) =>
+        {
+            if (!EndpointAuthorization.HasPermission(context, UserPermission.ModifySecurityMaster))
+            {
+                return EndpointHelpers.Forbidden();
+            }
+
+            if (service is null)
+            {
+                return WorkbenchServiceUnavailable();
+            }
+
+            if (request is null)
+            {
+                return WorkbenchMissingPayload("A ResolveSourceConflictRequest body is required.");
+            }
+
+            var bound = request with { SecurityId = securityId };
+            return await ExecuteWorkbenchAsync(
+                () => service.ResolveSourceConflictAsync(bound, context.RequestAborted), jsonOptions).ConfigureAwait(false);
+        })
+        .WithName("SecurityMasterWorkbenchResolveConflict")
+        .Produces<SecurityMasterConflictResolutionDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status409Conflict)
+        .Produces(StatusCodes.Status422UnprocessableEntity);
+
+        group.MapPost(SecurityMasterSubroute(UiApiRoutes.SecurityMasterWorkbenchSubmit), async (
+            Guid securityId,
+            SubmitSecurityMasterRevisionRequest? request,
+            HttpContext context,
+            [FromServices] ISecurityMasterWorkbenchCommandService? service) =>
+        {
+            if (!EndpointAuthorization.HasPermission(context, UserPermission.ModifySecurityMaster))
+            {
+                return EndpointHelpers.Forbidden();
+            }
+
+            if (service is null)
+            {
+                return WorkbenchServiceUnavailable();
+            }
+
+            if (request is null)
+            {
+                return WorkbenchMissingPayload("A SubmitSecurityMasterRevisionRequest body is required.");
+            }
+
+            var bound = request with { SecurityId = securityId };
+            return await ExecuteWorkbenchAsync(
+                () => service.SubmitForApprovalAsync(bound, context.RequestAborted), jsonOptions).ConfigureAwait(false);
+        })
+        .WithName("SecurityMasterWorkbenchSubmit")
+        .Produces<SecurityMasterEditResultDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status409Conflict)
+        .Produces(StatusCodes.Status422UnprocessableEntity);
+
+        group.MapPost(SecurityMasterSubroute(UiApiRoutes.SecurityMasterWorkbenchApprove), async (
+            Guid securityId,
+            ApproveSecurityMasterRevisionRequest? request,
+            HttpContext context,
+            [FromServices] ISecurityMasterWorkbenchCommandService? service) =>
+        {
+            if (!EndpointAuthorization.HasPermission(context, UserPermission.ModifySecurityMaster))
+            {
+                return EndpointHelpers.Forbidden();
+            }
+
+            if (service is null)
+            {
+                return WorkbenchServiceUnavailable();
+            }
+
+            if (request is null)
+            {
+                return WorkbenchMissingPayload("An ApproveSecurityMasterRevisionRequest body is required.");
+            }
+
+            var bound = request with { SecurityId = securityId };
+            return await ExecuteWorkbenchAsync(
+                () => service.ApproveRevisionAsync(bound, context.RequestAborted), jsonOptions).ConfigureAwait(false);
+        })
+        .WithName("SecurityMasterWorkbenchApprove")
+        .Produces<SecurityMasterEditResultDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status409Conflict)
+        .Produces(StatusCodes.Status422UnprocessableEntity);
+
+        group.MapPost(SecurityMasterSubroute(UiApiRoutes.SecurityMasterWorkbenchPublish), async (
+            Guid securityId,
+            PublishSecurityMasterRevisionRequest? request,
+            HttpContext context,
+            [FromServices] ISecurityMasterWorkbenchCommandService? service) =>
+        {
+            if (!EndpointAuthorization.HasPermission(context, UserPermission.ModifySecurityMaster))
+            {
+                return EndpointHelpers.Forbidden();
+            }
+
+            if (service is null)
+            {
+                return WorkbenchServiceUnavailable();
+            }
+
+            if (request is null)
+            {
+                return WorkbenchMissingPayload("A PublishSecurityMasterRevisionRequest body is required.");
+            }
+
+            var bound = request with { SecurityId = securityId };
+            return await ExecuteWorkbenchAsync(
+                () => service.PublishRevisionAsync(bound, context.RequestAborted), jsonOptions).ConfigureAwait(false);
+        })
+        .WithName("SecurityMasterWorkbenchPublish")
+        .Produces<SecurityMasterPublishResultDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status409Conflict)
+        .Produces(StatusCodes.Status422UnprocessableEntity)
+        .Produces(StatusCodes.Status500InternalServerError);
+    }
+
+    /// <summary>
+    /// Executes a governed-write command and maps its domain failures to stable status codes. Unmapped
+    /// exceptions are allowed to propagate to the framework's 500 handler rather than being masked.
+    /// </summary>
+    private static async Task<IResult> ExecuteWorkbenchAsync<T>(
+        Func<Task<T>> action, JsonSerializerOptions jsonOptions)
+    {
+        try
+        {
+            var result = await action().ConfigureAwait(false);
+            return Results.Json(result, jsonOptions, statusCode: StatusCodes.Status200OK);
+        }
+        catch (SecurityMasterConcurrencyException ex)
+        {
+            // Stale expected version: the passport advanced since load. Surface the current version so
+            // the client can refetch and replay without losing the operator's edit.
+            return Results.Json(
+                new { error = "version-conflict", currentVersion = ex.CurrentVersion },
+                jsonOptions,
+                statusCode: StatusCodes.Status409Conflict);
+        }
+        catch (SecurityMasterPublishFailedException ex)
+        {
+            // The durable append already happened but a side-effect handler failed. Handlers are
+            // idempotent and the revision stays Approved, so the caller may retry the publish.
+            return Results.Json(
+                new { error = "publish-side-effect-failed", message = ex.Message },
+                jsonOptions,
+                statusCode: StatusCodes.Status500InternalServerError);
+        }
+        catch (SecurityMasterRevisionStateException ex)
+        {
+            // The revision is not in a state that permits this transition (e.g. publishing one that was
+            // never approved, or an unknown/foreign revision) — a lifecycle conflict the client resolves
+            // by refetching the revision.
+            return Results.Json(
+                new { error = "revision-state-conflict", message = ex.Message },
+                jsonOptions,
+                statusCode: StatusCodes.Status409Conflict);
+        }
+        catch (ArgumentException ex)
+        {
+            // A rejected governed invariant: missing justification, unacknowledged policy deviation, or a
+            // chosen winner that is not a conflict candidate. The request was understood but cannot be
+            // processed as-is.
+            return Results.Json(
+                new { error = "unprocessable", message = ex.Message },
+                jsonOptions,
+                statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // A domain-state precondition failed (security not found for edit, missing trust snapshot, or
+            // an approval gate that blocked the transition).
+            return Results.Json(
+                new { error = "conflict", message = ex.Message },
+                jsonOptions,
+                statusCode: StatusCodes.Status409Conflict);
+        }
+    }
+
+    private static IResult WorkbenchServiceUnavailable()
+        => Results.Problem(
+            "The Security Master workbench command service is not registered.",
+            statusCode: StatusCodes.Status501NotImplemented);
+
+    private static IResult WorkbenchMissingPayload(string detail)
+        => Results.ValidationProblem(new Dictionary<string, string[]> { ["request"] = [detail] });
+
+    private static string SecurityMasterSubroute(string route)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(route);
+        return route.StartsWith(SecurityMasterApiRoutePrefix, StringComparison.Ordinal)
+            ? route[SecurityMasterApiRoutePrefix.Length..]
+            : route;
+    }
+}

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -91,6 +91,10 @@ public static partial class WorkstationEndpoints
         .WithName("GetWorkstationStrategyBriefing")
         .Produces<StrategyBriefingDto>(200);
 
+        // Governed Security Master write surface lives under /api/security-master (not /api/workstation),
+        // so it maps its own tenant-scoped group directly on the app.
+        MapSecurityMasterWorkbenchEndpoints(app, jsonOptions);
+
         MapStrategyDesignerEndpoints(group, jsonOptions);
         MapStrategyEngineEndpoints(group, jsonOptions);
         MapFeatureCapabilityEndpoints(group, jsonOptions);

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -232,13 +232,11 @@ public static class WorkstationServiceCollectionExtensions
             Meridian.Application.SecurityMaster.ISecurityMasterWorkbenchCommandService,
             Meridian.Application.SecurityMaster.SecurityMasterWorkbenchCommandService>();
         // Bind the source-precedence ladder (and the rest of the workbench options) from configuration so
-        // the conflict-authority policy ranks real deployment source systems. IConfiguration is resolved
-        // at build time (the extension takes no config arg), and IOptionsMonitor lets the ladder hot-reload.
+        // the conflict-authority policy ranks real deployment source systems. BindConfiguration registers a
+        // reload-token source, so IOptionsMonitor reflects ladder changes without a restart.
         services
             .AddOptions<Meridian.Application.SecurityMaster.SecurityMasterWorkbenchOptions>()
-            .Configure<IConfiguration>((options, configuration) => configuration
-                .GetSection(Meridian.Application.SecurityMaster.SecurityMasterWorkbenchOptions.SectionName)
-                .Bind(options));
+            .BindConfiguration(Meridian.Application.SecurityMaster.SecurityMasterWorkbenchOptions.SectionName);
         // Phase 3 period-aware propagation: the ledger accounting-period status is the lock
         // authority (default-deny → HardClosed when indeterminate). The restatement resolver routes a
         // closed-period edit into a governed restatement proposal rather than a silent mutation; the

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -231,6 +231,14 @@ public static class WorkstationServiceCollectionExtensions
         services.TryAddScoped<
             Meridian.Application.SecurityMaster.ISecurityMasterWorkbenchCommandService,
             Meridian.Application.SecurityMaster.SecurityMasterWorkbenchCommandService>();
+        // Bind the source-precedence ladder (and the rest of the workbench options) from configuration so
+        // the conflict-authority policy ranks real deployment source systems. IConfiguration is resolved
+        // at build time (the extension takes no config arg), and IOptionsMonitor lets the ladder hot-reload.
+        services
+            .AddOptions<Meridian.Application.SecurityMaster.SecurityMasterWorkbenchOptions>()
+            .Configure<IConfiguration>((options, configuration) => configuration
+                .GetSection(Meridian.Application.SecurityMaster.SecurityMasterWorkbenchOptions.SectionName)
+                .Bind(options));
         // Phase 3 period-aware propagation: the ledger accounting-period status is the lock
         // authority (default-deny → HardClosed when indeterminate). The restatement resolver routes a
         // closed-period edit into a governed restatement proposal rather than a silent mutation; the

--- a/src/Meridian.Ui/dashboard/src/lib/ui-api-routes.generated.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/ui-api-routes.generated.ts
@@ -293,6 +293,7 @@ export const UI_API_ROUTES = {
   SecurityMasterWorkbenchField: "/api/security-master/{securityId:guid}/workbench/field",
   SecurityMasterWorkbenchResolveConflict: "/api/security-master/{securityId:guid}/workbench/resolve-conflict",
   SecurityMasterWorkbenchSubmit: "/api/security-master/{securityId:guid}/workbench/submit",
+  SecurityMasterWorkbenchApprove: "/api/security-master/{securityId:guid}/workbench/approve",
   SecurityMasterWorkbenchPublish: "/api/security-master/{securityId:guid}/workbench/publish",
   SecurityMasterImport: "/api/security-master/import",
   SecurityMasterIngestStatus: "/api/security-master/ingest/status",

--- a/tests/Meridian.Tests/Ui/SecurityMasterWorkbenchEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/SecurityMasterWorkbenchEndpointsTests.cs
@@ -24,6 +24,7 @@ namespace Meridian.Tests.Ui;
 public sealed class SecurityMasterWorkbenchEndpointsTests
 {
     private static readonly JsonSerializerOptions Json = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+    private const string SessionActor = "session.actor";
 
     [Fact]
     public async Task Field_WithoutModifyPermission_Returns403()
@@ -40,7 +41,7 @@ public sealed class SecurityMasterWorkbenchEndpointsTests
     }
 
     [Fact]
-    public async Task Field_WithPermission_Returns200_AndPathSecurityIdOverridesBody()
+    public async Task Field_WithPermission_Returns200_AndServerOverridesPathIdAndActor()
     {
         var pathId = Guid.NewGuid();
         var service = Substitute.For<ISecurityMasterWorkbenchCommandService>();
@@ -50,13 +51,63 @@ public sealed class SecurityMasterWorkbenchEndpointsTests
         await using var app = await CreateAppAsync(service, UserPermission.ModifySecurityMaster);
         var client = app.GetTestClient();
 
-        // Body carries a DIFFERENT security id than the path; the path must win.
+        // Body carries a DIFFERENT security id than the path AND a spoofed actor; both must be overridden.
+        var spoofed = FieldRequest(Guid.NewGuid()) with { Actor = "spoofed.actor" };
         using var response = await client.PostAsJsonAsync(
-            $"/api/security-master/{pathId:D}/workbench/field", FieldRequest(Guid.NewGuid()), Json);
+            $"/api/security-master/{pathId:D}/workbench/field", spoofed, Json);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         captured.Should().NotBeNull();
         captured!.SecurityId.Should().Be(pathId, "the route id is authoritative over the request body");
+        captured.Actor.Should().Be(SessionActor, "the acting principal is derived from the session, not the body");
+    }
+
+    [Fact]
+    public async Task Approve_DerivesActorAndReviewerFromSession_IgnoringBody()
+    {
+        // The impersonation vector: a caller posts the assigned reviewer's name to approve as that
+        // person. The endpoint must override both Actor and Reviewer with the authenticated session id.
+        var securityId = Guid.NewGuid();
+        var service = Substitute.For<ISecurityMasterWorkbenchCommandService>();
+        ApproveSecurityMasterRevisionRequest? captured = null;
+        service.ApproveRevisionAsync(Arg.Do<ApproveSecurityMasterRevisionRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(ci => EditResult(((ApproveSecurityMasterRevisionRequest)ci[0]).SecurityId));
+        await using var app = await CreateAppAsync(service, UserPermission.ModifySecurityMaster);
+        var client = app.GetTestClient();
+
+        var body = new ApproveSecurityMasterRevisionRequest(
+            SecurityId: securityId,
+            RevisionId: Guid.NewGuid(),
+            WorkflowId: Guid.NewGuid(),
+            ExpectedWorkflowVersion: 1,
+            Actor: "attacker",
+            Reviewer: "victim.assigned.reviewer",
+            Rationale: "looks good",
+            ReportPackId: "rp-1");
+
+        using var response = await client.PostAsJsonAsync(
+            $"/api/security-master/{securityId:D}/workbench/approve", body, Json);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        captured.Should().NotBeNull();
+        captured!.Actor.Should().Be(SessionActor);
+        captured.Reviewer.Should().Be(SessionActor, "the caller is the reviewer; a body-supplied reviewer name must not impersonate");
+    }
+
+    [Fact]
+    public async Task UnauthenticatedActor_Returns401_WithoutTouchingService()
+    {
+        var service = Substitute.For<ISecurityMasterWorkbenchCommandService>();
+        // Permission present but no resolvable session actor.
+        await using var app = await CreateAppAsync(service, UserPermission.ModifySecurityMaster, sessionActor: null);
+        var client = app.GetTestClient();
+
+        var securityId = Guid.NewGuid();
+        using var response = await client.PostAsJsonAsync(
+            $"/api/security-master/{securityId:D}/workbench/field", FieldRequest(securityId), Json);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        await service.DidNotReceive().UpdateSecurityFieldAsync(Arg.Any<UpdateSecurityFieldRequest>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -183,7 +234,9 @@ public sealed class SecurityMasterWorkbenchEndpointsTests
                 ChangedFieldsSummary: "EconomicDefinition.Coupon"));
 
     private static async Task<WebApplication> CreateAppAsync(
-        ISecurityMasterWorkbenchCommandService service, UserPermission permissions)
+        ISecurityMasterWorkbenchCommandService service,
+        UserPermission permissions,
+        string? sessionActor = SessionActor)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Development });
         builder.WebHost.UseTestServer();
@@ -194,6 +247,10 @@ public sealed class SecurityMasterWorkbenchEndpointsTests
         {
             context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] = permissions;
             context.Items[LoginSessionMiddleware.CurrentTenantIdKey] = "tenant-test";
+            if (sessionActor is not null)
+            {
+                context.Items[LoginSessionMiddleware.CurrentUserKey] = sessionActor;
+            }
             await next();
         });
         app.MapSecurityMasterWorkbenchEndpoints(Json);

--- a/tests/Meridian.Tests/Ui/SecurityMasterWorkbenchEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/SecurityMasterWorkbenchEndpointsTests.cs
@@ -1,0 +1,204 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Meridian.Application.SecurityMaster;
+using Meridian.Contracts.Workstation;
+using Meridian.Identity.Auth;
+using Meridian.Ui.Shared.Endpoints;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace Meridian.Tests.Ui;
+
+/// <summary>
+/// Phase 4 governed-write surface: the workbench endpoints route through
+/// <see cref="ISecurityMasterWorkbenchCommandService"/> behind <see cref="UserPermission.ModifySecurityMaster"/>
+/// and a tenant scope, and map domain failures to stable status codes (409 stale version / lifecycle
+/// conflict, 422 rejected invariant, 500 publish side-effect failure).
+/// </summary>
+public sealed class SecurityMasterWorkbenchEndpointsTests
+{
+    private static readonly JsonSerializerOptions Json = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    [Fact]
+    public async Task Field_WithoutModifyPermission_Returns403()
+    {
+        var service = Substitute.For<ISecurityMasterWorkbenchCommandService>();
+        await using var app = await CreateAppAsync(service, UserPermission.ViewSecurityMaster);
+        var client = app.GetTestClient();
+
+        using var response = await client.PostAsJsonAsync(
+            $"/api/security-master/{Guid.NewGuid():D}/workbench/field", FieldRequest(Guid.NewGuid()), Json);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        await service.DidNotReceive().UpdateSecurityFieldAsync(Arg.Any<UpdateSecurityFieldRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Field_WithPermission_Returns200_AndPathSecurityIdOverridesBody()
+    {
+        var pathId = Guid.NewGuid();
+        var service = Substitute.For<ISecurityMasterWorkbenchCommandService>();
+        UpdateSecurityFieldRequest? captured = null;
+        service.UpdateSecurityFieldAsync(Arg.Do<UpdateSecurityFieldRequest>(r => captured = r), Arg.Any<CancellationToken>())
+            .Returns(ci => EditResult(((UpdateSecurityFieldRequest)ci[0]).SecurityId));
+        await using var app = await CreateAppAsync(service, UserPermission.ModifySecurityMaster);
+        var client = app.GetTestClient();
+
+        // Body carries a DIFFERENT security id than the path; the path must win.
+        using var response = await client.PostAsJsonAsync(
+            $"/api/security-master/{pathId:D}/workbench/field", FieldRequest(Guid.NewGuid()), Json);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        captured.Should().NotBeNull();
+        captured!.SecurityId.Should().Be(pathId, "the route id is authoritative over the request body");
+    }
+
+    [Fact]
+    public async Task Field_StaleExpectedVersion_Returns409_WithCurrentVersion()
+    {
+        var securityId = Guid.NewGuid();
+        var service = Substitute.For<ISecurityMasterWorkbenchCommandService>();
+        service.UpdateSecurityFieldAsync(Arg.Any<UpdateSecurityFieldRequest>(), Arg.Any<CancellationToken>())
+            .Throws(new SecurityMasterConcurrencyException(securityId, expectedVersion: 3, currentVersion: 7));
+        await using var app = await CreateAppAsync(service, UserPermission.ModifySecurityMaster);
+        var client = app.GetTestClient();
+
+        using var response = await client.PostAsJsonAsync(
+            $"/api/security-master/{securityId:D}/workbench/field", FieldRequest(securityId), Json);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("error").GetString().Should().Be("version-conflict");
+        body.GetProperty("currentVersion").GetInt64().Should().Be(7);
+    }
+
+    [Fact]
+    public async Task Field_RejectedInvariant_Returns422()
+    {
+        var securityId = Guid.NewGuid();
+        var service = Substitute.For<ISecurityMasterWorkbenchCommandService>();
+        service.UpdateSecurityFieldAsync(Arg.Any<UpdateSecurityFieldRequest>(), Arg.Any<CancellationToken>())
+            .Throws(new ArgumentException("An operator-origin edit requires a non-empty justification."));
+        await using var app = await CreateAppAsync(service, UserPermission.ModifySecurityMaster);
+        var client = app.GetTestClient();
+
+        using var response = await client.PostAsJsonAsync(
+            $"/api/security-master/{securityId:D}/workbench/field", FieldRequest(securityId), Json);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task Publish_NotApproved_Returns409_RevisionStateConflict()
+    {
+        var securityId = Guid.NewGuid();
+        var revisionId = Guid.NewGuid();
+        var service = Substitute.For<ISecurityMasterWorkbenchCommandService>();
+        service.PublishRevisionAsync(Arg.Any<PublishSecurityMasterRevisionRequest>(), Arg.Any<CancellationToken>())
+            .Throws(new SecurityMasterRevisionStateException(revisionId, "expected state Approved but the revision is Submitted."));
+        await using var app = await CreateAppAsync(service, UserPermission.ModifySecurityMaster);
+        var client = app.GetTestClient();
+
+        using var response = await client.PostAsJsonAsync(
+            $"/api/security-master/{securityId:D}/workbench/publish",
+            new PublishSecurityMasterRevisionRequest(securityId, revisionId, "ops.analyst", "ops.approver"), Json);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("error").GetString().Should().Be("revision-state-conflict");
+    }
+
+    [Fact]
+    public async Task Publish_SideEffectFailure_Returns500()
+    {
+        var securityId = Guid.NewGuid();
+        var revisionId = Guid.NewGuid();
+        var service = Substitute.For<ISecurityMasterWorkbenchCommandService>();
+        service.PublishRevisionAsync(Arg.Any<PublishSecurityMasterRevisionRequest>(), Arg.Any<CancellationToken>())
+            .Throws(new SecurityMasterPublishFailedException(securityId, revisionId, ["SecurityProjectionRebuildHandler"]));
+        await using var app = await CreateAppAsync(service, UserPermission.ModifySecurityMaster);
+        var client = app.GetTestClient();
+
+        using var response = await client.PostAsJsonAsync(
+            $"/api/security-master/{securityId:D}/workbench/publish",
+            new PublishSecurityMasterRevisionRequest(securityId, revisionId, "ops.analyst", "ops.approver"), Json);
+
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("error").GetString().Should().Be("publish-side-effect-failed");
+    }
+
+    [Fact]
+    public async Task MissingBody_RejectsWithClientError_WithoutTouchingService()
+    {
+        var service = Substitute.For<ISecurityMasterWorkbenchCommandService>();
+        await using var app = await CreateAppAsync(service, UserPermission.ModifySecurityMaster);
+        var client = app.GetTestClient();
+
+        // No JSON body → the endpoint rejects (4xx) before touching the command service.
+        using var response = await client.PostAsync(
+            $"/api/security-master/{Guid.NewGuid():D}/workbench/field", content: null);
+
+        ((int)response.StatusCode).Should().BeInRange(400, 499);
+        await service.DidNotReceive().UpdateSecurityFieldAsync(Arg.Any<UpdateSecurityFieldRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    // ---- helpers ------------------------------------------------------------------------------
+
+    private static UpdateSecurityFieldRequest FieldRequest(Guid securityId)
+        => new(
+            SecurityId: securityId,
+            ExpectedVersion: 3,
+            FieldPath: "EconomicDefinition.Coupon",
+            NewValue: "5.125",
+            EffectiveFrom: new DateTimeOffset(2026, 03, 15, 0, 0, 0, TimeSpan.Zero),
+            Actor: "ops.analyst",
+            Justification: "Vendor confirmation #4821 corrects the coupon.");
+
+    private static SecurityMasterEditResultDto EditResult(Guid securityId)
+        => new(
+            SecurityId: securityId,
+            RevisionId: Guid.NewGuid(),
+            NewVersion: 4,
+            State: SecurityMasterRevisionStateDto.Draft,
+            ChangeEntry: new SecurityMasterChangeHistoryItemDto(
+                ChangeId: Guid.NewGuid().ToString("N"),
+                StreamVersion: 4,
+                EventType: "OperatorFieldAnnotation",
+                ChangedAtUtc: new DateTimeOffset(2026, 03, 15, 0, 0, 0, TimeSpan.Zero),
+                EffectiveAtUtc: new DateTimeOffset(2026, 03, 15, 0, 0, 0, TimeSpan.Zero),
+                Actor: "ops.analyst",
+                Origin: "Operator",
+                SourceSystem: "operator",
+                SourceRecordId: null,
+                Reason: "Vendor confirmation #4821 corrects the coupon.",
+                Summary: "Coupon corrected to 5.125.",
+                ChangedFields: ["EconomicDefinition.Coupon"],
+                ChangedFieldsSummary: "EconomicDefinition.Coupon"));
+
+    private static async Task<WebApplication> CreateAppAsync(
+        ISecurityMasterWorkbenchCommandService service, UserPermission permissions)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Development });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton(service);
+
+        var app = builder.Build();
+        app.Use(async (context, next) =>
+        {
+            context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] = permissions;
+            context.Items[LoginSessionMiddleware.CurrentTenantIdKey] = "tenant-test";
+            await next();
+        });
+        app.MapSecurityMasterWorkbenchEndpoints(Json);
+
+        await app.StartAsync();
+        return app;
+    }
+}

--- a/tests/Meridian.Tests/Ui/SecurityMasterWorkbenchEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/SecurityMasterWorkbenchEndpointsTests.cs
@@ -95,6 +95,32 @@ public sealed class SecurityMasterWorkbenchEndpointsTests
     }
 
     [Fact]
+    public async Task Submit_WithoutWorkflowId_Returns422_WithoutAdvancingRevision()
+    {
+        // A workflow-less submit would advance the revision to Submitted with no bound workflow, which the
+        // approve route can never satisfy — so the governed endpoint must reject it up front.
+        var securityId = Guid.NewGuid();
+        var service = Substitute.For<ISecurityMasterWorkbenchCommandService>();
+        await using var app = await CreateAppAsync(service, UserPermission.ModifySecurityMaster);
+        var client = app.GetTestClient();
+
+        var body = new SubmitSecurityMasterRevisionRequest(
+            SecurityId: securityId,
+            RevisionId: Guid.NewGuid(),
+            Actor: "ops.analyst",
+            Note: "ready",
+            WorkflowId: null);
+
+        using var response = await client.PostAsJsonAsync(
+            $"/api/security-master/{securityId:D}/workbench/submit", body, Json);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>();
+        payload.GetProperty("error").GetString().Should().Be("workflow-required");
+        await service.DidNotReceive().SubmitForApprovalAsync(Arg.Any<SubmitSecurityMasterRevisionRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task UnauthenticatedActor_Returns401_WithoutTouchingService()
     {
         var service = Substitute.For<ISecurityMasterWorkbenchCommandService>();

--- a/tests/Meridian.Tests/Ui/SecurityMasterWorkbenchOptionsBindingTests.cs
+++ b/tests/Meridian.Tests/Ui/SecurityMasterWorkbenchOptionsBindingTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using Meridian.Application.SecurityMaster;
+using Meridian.Ui.Shared.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Meridian.Tests.Ui;
+
+/// <summary>
+/// Phase 4 configuration binding: the workbench source-precedence ladder (and the rest of the options)
+/// must bind from the <c>SecurityMasterWorkbench</c> configuration section so the conflict-authority
+/// policy ranks the deployment's real source systems rather than the empty default.
+/// </summary>
+public sealed class SecurityMasterWorkbenchOptionsBindingTests
+{
+    [Fact]
+    public void AddWorkstationSharedServices_BindsWorkbenchOptionsFromConfiguration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["SecurityMasterWorkbench:SourcePrecedence:0"] = "golden-copy",
+                ["SecurityMasterWorkbench:SourcePrecedence:1"] = "vendor-a",
+                ["SecurityMasterWorkbench:SourcePrecedence:2"] = "vendor-b",
+                ["SecurityMasterWorkbench:GoldenCopySource"] = "golden-copy",
+                ["SecurityMasterWorkbench:MaxBulkResolveBatch"] = "50",
+                ["SecurityMasterWorkbench:RequireIndependentReviewer"] = "false",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddWorkstationSharedServices();
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptionsMonitor<SecurityMasterWorkbenchOptions>>().CurrentValue;
+
+        options.SourcePrecedence.Should().Equal("golden-copy", "vendor-a", "vendor-b");
+        options.GoldenCopySource.Should().Be("golden-copy");
+        options.MaxBulkResolveBatch.Should().Be(50);
+        options.RequireIndependentReviewer.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AddWorkstationSharedServices_WithNoSection_LeavesSourcePrecedenceEmpty()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddWorkstationSharedServices();
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptionsMonitor<SecurityMasterWorkbenchOptions>>().CurrentValue;
+
+        // No configured ladder ⇒ the policy applies no presumptive ranking (falls through to freshness
+        // then confidence) rather than ranking against a placeholder.
+        options.SourcePrecedence.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Exposes the Security Master Passport Workbench **governed-write REST surface** and binds its runtime options from configuration (Phase 4 backend slice). Builds on the merged Phase 1–3 command service, lifecycle store, and propagation handlers.

**Endpoints** — new partial `WorkstationEndpoints.SecurityMasterWorkbench.cs`, each requiring `ModifySecurityMaster` and a workstation tenant scope, routed through `ISecurityMasterWorkbenchCommandService`:

| Route | Command |
| --- | --- |
| `POST /api/security-master/{securityId}/workbench/field` | `UpdateSecurityFieldAsync` |
| `POST /api/security-master/{securityId}/workbench/resolve-conflict` | `ResolveSourceConflictAsync` |
| `POST /api/security-master/{securityId}/workbench/submit` | `SubmitForApprovalAsync` |
| `POST /api/security-master/{securityId}/workbench/approve` | `ApproveRevisionAsync` |
| `POST /api/security-master/{securityId}/workbench/publish` | `PublishRevisionAsync` |

- The `approve` route was added beyond the original 4-route sketch so the UI can drive the full `field → submit → approve → publish` lifecycle through one cohesive surface.
- The path `securityId` is **authoritative** — it overwrites the request body's id so a mismatched body can never target another security.
- Domain failures map to stable status codes via a shared `ExecuteWorkbenchAsync` helper: stale expected version → **409** `{ version-conflict, currentVersion }`; invalid lifecycle transition (incl. publish-before-approved / unknown revision) → **409** `{ revision-state-conflict }`; rejected governed invariant (missing justification / unacknowledged policy deviation / non-candidate winner) → **422**; publish side-effect failure → **500** (the durable append already happened and handlers are idempotent, so the caller may retry). Unmapped exceptions propagate to the framework's 500.

**Options binding** — `SecurityMasterWorkbenchOptions` now binds from the `SecurityMasterWorkbench` configuration section via `AddOptions<…>().Configure<IConfiguration>(…)`, so the conflict-authority policy's `IOptionsMonitor` ranks the deployment's real source systems and hot-reloads. An absent section leaves the precedence ladder empty (no presumptive ranking — falls through to freshness then confidence).

## Reason

Phase 4 of the workbench design (`docs/plans/security-master-passport-workbench.md`) requires the governed-write HTTP surface and configuration-bound source precedence. The route constants and command service already existed; this PR maps the routes with consistent status semantics and wires the options binding. The browser/WPF passport editors are a deliberate follow-up slice — the backend write surface lands first.

**Mapping note:** the original sketch listed publish-before-approved as `403 approval-required`; it now surfaces as `409 revision-state-conflict`, because the same approval precondition (`EnsureRevisionInStateAsync`) also covers unknown/foreign revisions and a 409 "refetch the revision and retry" is the coherent client behaviour for all three. Documented in the design doc.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully *(no local .NET toolchain in this environment; relying on the hosted `quality-gate`)*
- [x] Relevant unit tests were added or updated
- [x] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed *(pending on this PR)*

New coverage: `SecurityMasterWorkbenchEndpointsTests` (TestHost integration — permission gating returns 403, path-id authority over the body, and the 409 / 422 / 500 mappings) and `SecurityMasterWorkbenchOptionsBindingTests` (source-precedence ladder binds from configuration; empty section stays empty).

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019qm7pxZJDPsXViBkoHw7R2)_