### PR TITLE
feat(ui): Security Master passport editor — browser write client + editor component (Phase 4 UI)

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -4624,7 +4624,9 @@ Meridian-main
 │   │   │   │   ├── lib
 │   │   │   │   │   ├── api
 │   │   │   │   │   │   ├── covered-call.api.test.ts
-│   │   │   │   │   │   └── covered-call.api.ts
+│   │   │   │   │   │   ├── covered-call.api.ts
+│   │   │   │   │   │   ├── security-master-workbench.api.test.ts
+│   │   │   │   │   │   └── security-master-workbench.api.ts
 │   │   │   │   │   ├── covered-call
 │   │   │   │   │   │   ├── index.ts
 │   │   │   │   │   │   ├── payoff.test.ts

--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -4560,6 +4560,10 @@ Meridian-main
 │   │   │   │   │   │   ├── security-details-tracker.tsx
 │   │   │   │   │   │   ├── security-details-tracker.view-model.test.ts
 │   │   │   │   │   │   ├── security-details-tracker.view-model.ts
+│   │   │   │   │   │   ├── security-passport-editor.test.tsx
+│   │   │   │   │   │   ├── security-passport-editor.tsx
+│   │   │   │   │   │   ├── security-passport-editor.view-model.test.ts
+│   │   │   │   │   │   ├── security-passport-editor.view-model.ts
 │   │   │   │   │   │   ├── strategy-formula-workbench.test.tsx
 │   │   │   │   │   │   ├── strategy-formula-workbench.tsx
 │   │   │   │   │   │   ├── ui-kit-primitives.test.tsx

--- a/docs/plans/security-master-passport-workbench.md
+++ b/docs/plans/security-master-passport-workbench.md
@@ -604,8 +604,13 @@ PR3 browser UI, PR4 WPF parity.
 - [x] `SecurityMasterWorkbenchOptions` bound from the `SecurityMasterWorkbench` configuration section
       (`AddOptions<…>().Configure<IConfiguration>(…)`), so the conflict-authority policy's
       `IOptionsMonitor` ranks the deployment's real source systems and hot-reloads.
-- [ ] Browser `security-passport-editor.tsx` extending `security-details-tracker.tsx`; entry point
-      from `buildMultiAssetCoveragePanel()` row. *(Follow-up slice — backend write surface lands first.)*
+- [~] Browser `security-passport-editor.tsx` extending `security-details-tracker.tsx`; entry point
+      from `buildMultiAssetCoveragePanel()` row. **Slice 1 (client foundation) landed:**
+      `lib/api/security-master-workbench.api.ts` typed client for the five governed-write routes
+      (server-derived identity omitted from request inputs; path `securityId` passed explicitly) plus
+      `classifyWorkbenchWriteError` mapping the 409 `version-conflict`/`revision-state-conflict`, 422
+      `workflow-required`/`unprocessable`, and 401/403 responses into a discriminated recovery hint for
+      the reload-banner / workflow-prompt UX. The editor component + coverage-panel entry are the next slice.
 - [ ] WPF `SecurityPassportEditorViewModel` + `SecurityPassportEditorPage.xaml`. *(Follow-up slice.)*
 
 ### Phase 5 — Tests

--- a/docs/plans/security-master-passport-workbench.md
+++ b/docs/plans/security-master-passport-workbench.md
@@ -616,9 +616,13 @@ PR3 browser UI, PR4 WPF parity.
       effective-from · justification) wired to Save Draft, a lifecycle action bar (Save Draft → Submit →
       Approve → Publish) whose enablement is driven by the pure view-model (Publish stays disabled until
       Approved), and a `role="alert"` banner that renders a non-destructive **Reload passport** action on a
-      stale-version 409. The client is injectable for testing. The coverage-panel entry point
-      (`buildMultiAssetCoveragePanel()` row → editor) and the richer tabs/source-conflicts grid are the
-      next slice.
+      stale-version 409. The client is injectable for testing. A **Source conflicts** section renders each
+      conflict (field · severity · policy winner · challenger) with **Accept** (resolve to the policy
+      winner) and **Override…** (inline form: winning source · reason · acknowledge-deviation) wired to
+      `resolveSourceConflict`; the override is gated client-side by `validateConflictOverride` (reason
+      required; acknowledgement required when deviating from the policy winner — mirroring the server's
+      422). The coverage-panel entry point (`buildMultiAssetCoveragePanel()` row → editor) and the
+      remaining read tabs (Economics/Venues/History) are the next slice.
 - [ ] WPF `SecurityPassportEditorViewModel` + `SecurityPassportEditorPage.xaml`. *(Follow-up slice.)*
 
 ### Phase 5 — Tests

--- a/docs/plans/security-master-passport-workbench.md
+++ b/docs/plans/security-master-passport-workbench.md
@@ -610,7 +610,15 @@ PR3 browser UI, PR4 WPF parity.
       (server-derived identity omitted from request inputs; path `securityId` passed explicitly) plus
       `classifyWorkbenchWriteError` mapping the 409 `version-conflict`/`revision-state-conflict`, 422
       `workflow-required`/`unprocessable`, and 401/403 responses into a discriminated recovery hint for
-      the reload-banner / workflow-prompt UX. The editor component + coverage-panel entry are the next slice.
+      the reload-banner / workflow-prompt UX. **Slice 2 (editor component) landed:**
+      `security-passport-editor.tsx` + `security-passport-editor.view-model.ts` — header (symbol · asset
+      class · trust-posture dot · state badge · version chip), a governed field-edit form (path · value ·
+      effective-from · justification) wired to Save Draft, a lifecycle action bar (Save Draft → Submit →
+      Approve → Publish) whose enablement is driven by the pure view-model (Publish stays disabled until
+      Approved), and a `role="alert"` banner that renders a non-destructive **Reload passport** action on a
+      stale-version 409. The client is injectable for testing. The coverage-panel entry point
+      (`buildMultiAssetCoveragePanel()` row → editor) and the richer tabs/source-conflicts grid are the
+      next slice.
 - [ ] WPF `SecurityPassportEditorViewModel` + `SecurityPassportEditorPage.xaml`. *(Follow-up slice.)*
 
 ### Phase 5 — Tests

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 534,
-  "total_lines": 86219,
+  "total_lines": 86226,
   "orphaned_count": 204,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2129,7 +2129,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7217,
+      "line_count": 7219,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -2785,7 +2785,7 @@
     },
     {
       "path": "docs/plans/security-master-passport-workbench.md",
-      "line_count": 658,
+      "line_count": 663,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 534,
-  "total_lines": 86226,
+  "total_lines": 86238,
   "orphaned_count": 204,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2129,7 +2129,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7219,
+      "line_count": 7223,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -2785,7 +2785,7 @@
     },
     {
       "path": "docs/plans/security-master-passport-workbench.md",
-      "line_count": 663,
+      "line_count": 671,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 534,
-  "total_lines": 86238,
+  "total_lines": 86242,
   "orphaned_count": 204,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2785,7 +2785,7 @@
     },
     {
       "path": "docs/plans/security-master-passport-workbench.md",
-      "line_count": 671,
+      "line_count": 675,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 534 |
-| Total lines | 86,219 |
+| Total lines | 86,226 |
 | Average file size (lines) | 161.5 |
 | Orphaned files | 204 |
 | Files without headings | 38 |

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 534 |
-| Total lines | 86,226 |
+| Total lines | 86,238 |
 | Average file size (lines) | 161.5 |
 | Orphaned files | 204 |
 | Files without headings | 38 |

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 534 |
-| Total lines | 86,238 |
+| Total lines | 86,242 |
 | Average file size (lines) | 161.5 |
 | Orphaned files | 204 |
 | Files without headings | 38 |

--- a/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.test.tsx
@@ -87,4 +87,65 @@ describe("SecurityPassportEditor", () => {
     renderEditor({});
     expect(screen.getByRole("button", { name: /publish/i })).toBeDisabled();
   });
+
+  it("accepts a source conflict with the policy winner and no deviation acknowledgement", async () => {
+    const user = userEvent.setup();
+    const resolveConflict = vi.fn().mockResolvedValue({
+      conflictId: "k1",
+      policyWinnerSource: "golden-copy",
+      chosenWinnerSource: "golden-copy",
+      isPolicyDeviation: false,
+      reason: "Accepted the recommended policy winner.",
+      newVersion: 8
+    });
+    render(
+      <SecurityPassportEditor
+        securityId={SECURITY_ID}
+        symbol="ACME"
+        version={7}
+        service={{ resolveConflict }}
+        conflicts={[{ conflictId: "k1", fieldLabel: "Coupon", policyWinnerSource: "golden-copy", challengerSource: "vendor-a", severity: "High" }]}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /^accept$/i }));
+
+    await waitFor(() => expect(resolveConflict).toHaveBeenCalledTimes(1));
+    const [, input] = resolveConflict.mock.calls[0];
+    expect(input).toMatchObject({ conflictId: "k1", chosenWinnerSource: "golden-copy", acknowledgePolicyDeviation: false, expectedVersion: 7 });
+  });
+
+  it("requires acknowledgement before an override deviation can resolve", async () => {
+    const user = userEvent.setup();
+    const resolveConflict = vi.fn().mockResolvedValue({
+      conflictId: "k1",
+      policyWinnerSource: "golden-copy",
+      chosenWinnerSource: "vendor-a",
+      isPolicyDeviation: true,
+      reason: "Vendor is correct.",
+      newVersion: 8
+    });
+    render(
+      <SecurityPassportEditor
+        securityId={SECURITY_ID}
+        symbol="ACME"
+        version={7}
+        service={{ resolveConflict }}
+        conflicts={[{ conflictId: "k1", fieldLabel: "Coupon", policyWinnerSource: "golden-copy", challengerSource: "vendor-a", severity: "High" }]}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /override/i }));
+    await user.type(screen.getByLabelText(/reason \(required\)/i), "Vendor is correct.");
+
+    // Deviation (challenger != policy winner) without acknowledgement keeps Resolve disabled.
+    expect(screen.getByRole("button", { name: /^resolve$/i })).toBeDisabled();
+
+    await user.click(screen.getByRole("checkbox", { name: /acknowledge deviation/i }));
+    expect(screen.getByRole("button", { name: /^resolve$/i })).toBeEnabled();
+
+    await user.click(screen.getByRole("button", { name: /^resolve$/i }));
+    await waitFor(() => expect(resolveConflict).toHaveBeenCalledTimes(1));
+    expect(resolveConflict.mock.calls[0][1]).toMatchObject({ chosenWinnerSource: "vendor-a", acknowledgePolicyDeviation: true });
+  });
 });

--- a/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SecurityPassportEditor, type SecurityPassportWorkbenchService } from "@/components/meridian/security-passport-editor";
+import { ApiError } from "@/lib/api-errors";
+import type { SecurityMasterEditResult } from "@/lib/api/security-master-workbench.api";
+
+const SECURITY_ID = "11111111-1111-1111-1111-111111111111";
+
+function editResult(overrides: Partial<SecurityMasterEditResult> = {}): SecurityMasterEditResult {
+  return {
+    securityId: SECURITY_ID,
+    revisionId: "rev-1",
+    newVersion: 8,
+    state: "Draft",
+    changeEntry: {
+      changeId: "c1",
+      streamVersion: 8,
+      eventType: "OperatorFieldAnnotation",
+      changedAtUtc: "2026-03-15T00:00:00Z",
+      effectiveAtUtc: "2026-03-15T00:00:00Z",
+      actor: "session.actor",
+      origin: "Operator",
+      sourceSystem: "operator",
+      sourceRecordId: null,
+      reason: "x",
+      summary: "x",
+      changedFields: ["EconomicDefinition.Coupon"],
+      changedFieldsSummary: "EconomicDefinition.Coupon"
+    },
+    ...overrides
+  };
+}
+
+function renderEditor(service: Partial<SecurityPassportWorkbenchService>) {
+  return render(
+    <SecurityPassportEditor securityId={SECURITY_ID} symbol="ACME" assetClass="Equity" version={7} trustPosture="Review" service={service} />
+  );
+}
+
+describe("SecurityPassportEditor", () => {
+  it("saves a draft through the workbench client with the loaded version and advances lifecycle state", async () => {
+    const user = userEvent.setup();
+    const updateField = vi.fn().mockResolvedValue(editResult());
+    renderEditor({ updateField });
+
+    await user.type(screen.getByPlaceholderText("EconomicDefinition.Coupon"), "EconomicDefinition.Coupon");
+    await user.type(screen.getByPlaceholderText("Vendor confirmation #…"), "Vendor confirmation 4821");
+    await user.click(screen.getByRole("button", { name: /save draft/i }));
+
+    await waitFor(() => expect(updateField).toHaveBeenCalledTimes(1));
+    const [calledSecurityId, input] = updateField.mock.calls[0];
+    expect(calledSecurityId).toBe(SECURITY_ID);
+    expect(input).toMatchObject({ expectedVersion: 7, fieldPath: "EconomicDefinition.Coupon", justification: "Vendor confirmation 4821" });
+
+    // Draft now exists → Submit becomes enabled.
+    await waitFor(() => expect(screen.getByRole("button", { name: /submit for approval/i })).toBeEnabled());
+  });
+
+  it("shows a non-destructive reload banner on a version conflict", async () => {
+    const user = userEvent.setup();
+    const updateField = vi.fn().mockRejectedValue(
+      new ApiError({ path: "/x", status: 409, responseBody: JSON.stringify({ error: "version-conflict", currentVersion: 9 }) })
+    );
+    const onReloadRequested = vi.fn();
+    render(
+      <SecurityPassportEditor
+        securityId={SECURITY_ID}
+        symbol="ACME"
+        version={7}
+        service={{ updateField }}
+        onReloadRequested={onReloadRequested}
+      />
+    );
+
+    await user.type(screen.getByPlaceholderText("EconomicDefinition.Coupon"), "EconomicDefinition.Coupon");
+    await user.type(screen.getByPlaceholderText("Vendor confirmation #…"), "reason");
+    await user.click(screen.getByRole("button", { name: /save draft/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/version 9/i);
+    await user.click(screen.getByRole("button", { name: /reload passport/i }));
+    expect(onReloadRequested).toHaveBeenCalledWith(9);
+  });
+
+  it("keeps publish disabled until the revision is approved", () => {
+    renderEditor({});
+    expect(screen.getByRole("button", { name: /publish/i })).toBeDisabled();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.tsx
@@ -1,0 +1,300 @@
+import { useCallback, useMemo, useState } from "react";
+import { AlertTriangle, RefreshCw, Save } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import {
+  approveSecurityMasterRevision as defaultApprove,
+  classifyWorkbenchWriteError,
+  publishSecurityMasterRevision as defaultPublish,
+  submitSecurityMasterRevision as defaultSubmit,
+  updateSecurityField as defaultUpdateField,
+  type SecurityMasterEditResult,
+  type SecurityMasterPublishResult,
+  type SecurityMasterRevisionState
+} from "@/lib/api/security-master-workbench.api";
+import {
+  buildPassportActions,
+  buildPassportStateBadge,
+  buildTrustPosture,
+  buildWorkbenchErrorBanner,
+  type PassportBannerViewModel,
+  type PassportLifecycleAction,
+  type PassportStateTone
+} from "./security-passport-editor.view-model";
+
+/** Injectable workbench client so the editor can be unit-tested without the network. */
+export interface SecurityPassportWorkbenchService {
+  updateField: typeof defaultUpdateField;
+  submit: typeof defaultSubmit;
+  approve: typeof defaultApprove;
+  publish: typeof defaultPublish;
+}
+
+const defaultService: SecurityPassportWorkbenchService = {
+  updateField: defaultUpdateField,
+  submit: defaultSubmit,
+  approve: defaultApprove,
+  publish: defaultPublish
+};
+
+export interface PassportApprovalContext {
+  workflowId: string;
+  expectedWorkflowVersion: number;
+  reviewer: string;
+  reportPackId: string;
+}
+
+export interface SecurityPassportEditorProps {
+  securityId: string;
+  symbol: string;
+  assetClass?: string | null;
+  /** The loaded passport version, captured as the optimistic-concurrency token. */
+  version: number;
+  trustPosture?: string | null;
+  fundProfileId?: string | null;
+  service?: Partial<SecurityPassportWorkbenchService>;
+  /** Invoked when the operator chooses to reload after a stale-version conflict. */
+  onReloadRequested?: (toVersion: number | null) => void;
+}
+
+interface WorkingRevision {
+  revisionId: string;
+  state: SecurityMasterRevisionState;
+  version: number;
+}
+
+const STATE_BADGE_VARIANT: Record<PassportStateTone, "default" | "outline" | "success" | "warning" | "danger"> = {
+  draft: "outline",
+  submitted: "warning",
+  approved: "default",
+  published: "success",
+  rejected: "danger"
+};
+
+const BANNER_CLASS: Record<PassportBannerViewModel["tone"], string> = {
+  error: "border-[var(--danger)] text-[var(--danger)]",
+  warning: "border-[var(--warning)] text-[var(--warning)]",
+  info: "border-border text-foreground"
+};
+
+export function SecurityPassportEditor({
+  securityId,
+  symbol,
+  assetClass,
+  version,
+  trustPosture,
+  fundProfileId,
+  service,
+  onReloadRequested
+}: SecurityPassportEditorProps) {
+  const client = useMemo<SecurityPassportWorkbenchService>(() => ({ ...defaultService, ...service }), [service]);
+
+  const [revision, setRevision] = useState<WorkingRevision | null>(null);
+  const [isBusy, setBusy] = useState(false);
+  const [banner, setBanner] = useState<PassportBannerViewModel | null>(null);
+
+  const [fieldPath, setFieldPath] = useState("");
+  const [newValue, setNewValue] = useState("");
+  const [effectiveFrom, setEffectiveFrom] = useState("");
+  const [justification, setJustification] = useState("");
+
+  const [approval, setApproval] = useState<PassportApprovalContext>({
+    workflowId: "",
+    expectedWorkflowVersion: 0,
+    reviewer: "",
+    reportPackId: ""
+  });
+
+  const hasPendingEdit = fieldPath.trim().length > 0 && justification.trim().length > 0;
+  const stateBadge = buildPassportStateBadge(revision?.state ?? null);
+  const trust = buildTrustPosture(trustPosture);
+  const expectedVersion = revision?.version ?? version;
+
+  const actions = useMemo(
+    () => buildPassportActions({ state: revision?.state ?? null, hasPendingEdit, isBusy }),
+    [revision?.state, hasPendingEdit, isBusy]
+  );
+
+  const run = useCallback(
+    async (work: () => Promise<void>) => {
+      setBusy(true);
+      setBanner(null);
+      try {
+        await work();
+      } catch (error) {
+        setBanner(buildWorkbenchErrorBanner(classifyWorkbenchWriteError(error)));
+      } finally {
+        setBusy(false);
+      }
+    },
+    []
+  );
+
+  const applyEditResult = useCallback((result: SecurityMasterEditResult) => {
+    setRevision({ revisionId: result.revisionId, state: result.state, version: result.newVersion });
+  }, []);
+
+  const handleSaveDraft = useCallback(() => {
+    void run(async () => {
+      const result = await client.updateField(securityId, {
+        expectedVersion,
+        fieldPath: fieldPath.trim(),
+        newValue: newValue.length > 0 ? newValue : null,
+        effectiveFrom: effectiveFrom.length > 0 ? effectiveFrom : new Date().toISOString(),
+        justification: justification.trim(),
+        fundProfileId: fundProfileId ?? null
+      });
+      applyEditResult(result);
+    });
+  }, [run, client, securityId, expectedVersion, fieldPath, newValue, effectiveFrom, justification, fundProfileId, applyEditResult]);
+
+  const handleSubmit = useCallback(() => {
+    if (!revision) return;
+    void run(async () => {
+      const result = await client.submit(securityId, {
+        revisionId: revision.revisionId,
+        workflowId: approval.workflowId.trim(),
+        expectedWorkflowVersion: approval.expectedWorkflowVersion,
+        reviewer: approval.reviewer.trim(),
+        reportPackId: approval.reportPackId.trim() || null,
+        fundProfileId: fundProfileId ?? null
+      });
+      applyEditResult(result);
+    });
+  }, [run, client, securityId, revision, approval, fundProfileId, applyEditResult]);
+
+  const handleApprove = useCallback(() => {
+    if (!revision) return;
+    void run(async () => {
+      const result = await client.approve(securityId, {
+        revisionId: revision.revisionId,
+        workflowId: approval.workflowId.trim(),
+        expectedWorkflowVersion: approval.expectedWorkflowVersion,
+        rationale: justification.trim() || "Approved via passport workbench.",
+        reportPackId: approval.reportPackId.trim()
+      });
+      applyEditResult(result);
+    });
+  }, [run, client, securityId, revision, approval, justification, applyEditResult]);
+
+  const handlePublish = useCallback(() => {
+    if (!revision) return;
+    void run(async () => {
+      const result: SecurityMasterPublishResult = await client.publish(securityId, {
+        revisionId: revision.revisionId
+      });
+      setRevision({ revisionId: result.revisionId, state: "Published", version: result.newVersion });
+    });
+  }, [run, client, securityId, revision]);
+
+  const actionHandlers: Record<PassportLifecycleAction, () => void> = {
+    "save-draft": handleSaveDraft,
+    submit: handleSubmit,
+    approve: handleApprove,
+    publish: handlePublish
+  };
+
+  return (
+    <Card data-testid="security-passport-editor">
+      <CardHeader>
+        <div className="flex flex-wrap items-center gap-2">
+          <CardTitle className="mr-2">{symbol}</CardTitle>
+          {assetClass ? <Badge variant="outline">{assetClass}</Badge> : null}
+          <Badge variant={trust.tone === "blocked" ? "danger" : trust.tone === "trusted" ? "success" : "warning"} dot>
+            {trust.label}
+          </Badge>
+          <Badge variant={STATE_BADGE_VARIANT[stateBadge.tone]}>{stateBadge.label}</Badge>
+          <Badge variant="outline">v{expectedVersion}</Badge>
+        </div>
+        <CardDescription>Governed passport edit — changes are staged as a draft and published through the approval gate.</CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        {banner ? (
+          <div
+            role="alert"
+            className={cn("flex items-start gap-2 rounded-md border px-3 py-2 text-sm", BANNER_CLASS[banner.tone])}
+          >
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+            <div className="space-y-1">
+              <p className="font-medium">{banner.title}</p>
+              <p>{banner.message}</p>
+              {banner.reloadToVersion !== undefined ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onReloadRequested?.(banner.reloadToVersion ?? null)}
+                >
+                  <RefreshCw className="mr-1 h-3.5 w-3.5" aria-hidden /> Reload passport
+                </Button>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+
+        <fieldset className="grid gap-3 sm:grid-cols-2" disabled={isBusy}>
+          <label className="space-y-1 text-sm">
+            <span className="text-muted-foreground">Field path</span>
+            <Input value={fieldPath} onChange={(e) => setFieldPath(e.target.value)} placeholder="EconomicDefinition.Coupon" />
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="text-muted-foreground">New value</span>
+            <Input value={newValue} onChange={(e) => setNewValue(e.target.value)} placeholder="5.125" />
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="text-muted-foreground">Effective from</span>
+            <Input type="date" value={effectiveFrom} onChange={(e) => setEffectiveFrom(e.target.value)} />
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="text-muted-foreground">Justification (required)</span>
+            <Input
+              value={justification}
+              onChange={(e) => setJustification(e.target.value)}
+              placeholder="Vendor confirmation #…"
+            />
+          </label>
+        </fieldset>
+
+        {(revision?.state ?? null) === "Draft" || (revision?.state ?? null) === "Submitted" ? (
+          <fieldset className="grid gap-3 sm:grid-cols-2" disabled={isBusy}>
+            <label className="space-y-1 text-sm">
+              <span className="text-muted-foreground">Approval workflow id</span>
+              <Input
+                value={approval.workflowId}
+                onChange={(e) => setApproval((a) => ({ ...a, workflowId: e.target.value }))}
+              />
+            </label>
+            <label className="space-y-1 text-sm">
+              <span className="text-muted-foreground">Independent reviewer</span>
+              <Input
+                value={approval.reviewer}
+                onChange={(e) => setApproval((a) => ({ ...a, reviewer: e.target.value }))}
+              />
+            </label>
+          </fieldset>
+        ) : null}
+
+        <div className="flex flex-wrap gap-2">
+          {actions.map((action) => (
+            <Button
+              key={action.action}
+              type="button"
+              variant={action.action === "save-draft" ? "secondary" : "default"}
+              disabled={!action.enabled}
+              title={action.disabledReason ?? undefined}
+              aria-label={action.disabledReason ? `${action.label} — ${action.disabledReason}` : action.label}
+              onClick={actionHandlers[action.action]}
+            >
+              {action.action === "save-draft" ? <Save className="mr-1 h-4 w-4" aria-hidden /> : null}
+              {action.label}
+            </Button>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { AlertTriangle, RefreshCw, Save } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -113,7 +113,18 @@ export function SecurityPassportEditor({
   service,
   onReloadRequested
 }: SecurityPassportEditorProps) {
-  const client = useMemo<SecurityPassportWorkbenchService>(() => ({ ...defaultService, ...service }), [service]);
+  // Depend on the individual methods rather than the `service` object so an inline `service={{…}}`
+  // literal (a fresh reference each render) does not invalidate every dependent useCallback.
+  const client = useMemo<SecurityPassportWorkbenchService>(
+    () => ({
+      updateField: service?.updateField ?? defaultUpdateField,
+      resolveConflict: service?.resolveConflict ?? defaultResolveConflict,
+      submit: service?.submit ?? defaultSubmit,
+      approve: service?.approve ?? defaultApprove,
+      publish: service?.publish ?? defaultPublish
+    }),
+    [service?.updateField, service?.resolveConflict, service?.submit, service?.approve, service?.publish]
+  );
 
   const [revision, setRevision] = useState<WorkingRevision | null>(null);
   const [isBusy, setBusy] = useState(false);
@@ -138,6 +149,21 @@ export function SecurityPassportEditor({
     reviewer: "",
     reportPackId: ""
   });
+
+  // Switching the active passport (or its loaded version) must not leak a draft, banner, or resolved
+  // conflicts from the previously-viewed security.
+  useEffect(() => {
+    setRevision(null);
+    setLiveVersion(version);
+    setBanner(null);
+    setResolvedConflictIds([]);
+    setOverrideConflictId(null);
+    setFieldPath("");
+    setNewValue("");
+    setEffectiveFrom("");
+    setJustification("");
+    setApproval({ workflowId: "", expectedWorkflowVersion: 0, reviewer: "", reportPackId: "" });
+  }, [securityId, version]);
 
   const hasPendingEdit = fieldPath.trim().length > 0 && justification.trim().length > 0;
   const stateBadge = buildPassportStateBadge(revision?.state ?? null);
@@ -183,7 +209,9 @@ export function SecurityPassportEditor({
         expectedVersion,
         fieldPath: fieldPath.trim(),
         newValue: newValue.length > 0 ? newValue : null,
-        effectiveFrom: effectiveFrom.length > 0 ? effectiveFrom : new Date().toISOString(),
+        // <input type="date"> yields a date-only YYYY-MM-DD; pin it to UTC midnight so the server's
+        // DateTimeOffset parse is unambiguous and never shifts a day across the operator's timezone.
+        effectiveFrom: effectiveFrom.length > 0 ? `${effectiveFrom}T00:00:00Z` : new Date().toISOString(),
         justification: justification.trim(),
         fundProfileId: fundProfileId ?? null
       });
@@ -339,10 +367,25 @@ export function SecurityPassportEditor({
               />
             </label>
             <label className="space-y-1 text-sm">
+              <span className="text-muted-foreground">Expected workflow version</span>
+              <Input
+                type="number"
+                value={approval.expectedWorkflowVersion || ""}
+                onChange={(e) => setApproval((a) => ({ ...a, expectedWorkflowVersion: Number.parseInt(e.target.value, 10) || 0 }))}
+              />
+            </label>
+            <label className="space-y-1 text-sm">
               <span className="text-muted-foreground">Independent reviewer</span>
               <Input
                 value={approval.reviewer}
                 onChange={(e) => setApproval((a) => ({ ...a, reviewer: e.target.value }))}
+              />
+            </label>
+            <label className="space-y-1 text-sm">
+              <span className="text-muted-foreground">Report pack id</span>
+              <Input
+                value={approval.reportPackId}
+                onChange={(e) => setApproval((a) => ({ ...a, reportPackId: e.target.value }))}
               />
             </label>
           </fieldset>

--- a/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.tsx
@@ -9,6 +9,7 @@ import {
   approveSecurityMasterRevision as defaultApprove,
   classifyWorkbenchWriteError,
   publishSecurityMasterRevision as defaultPublish,
+  resolveSourceConflict as defaultResolveConflict,
   submitSecurityMasterRevision as defaultSubmit,
   updateSecurityField as defaultUpdateField,
   type SecurityMasterEditResult,
@@ -16,18 +17,23 @@ import {
   type SecurityMasterRevisionState
 } from "@/lib/api/security-master-workbench.api";
 import {
+  buildConflictRows,
   buildPassportActions,
   buildPassportStateBadge,
   buildTrustPosture,
   buildWorkbenchErrorBanner,
+  validateConflictOverride,
   type PassportBannerViewModel,
+  type PassportConflictInput,
   type PassportLifecycleAction,
+  type PassportSeverityTone,
   type PassportStateTone
 } from "./security-passport-editor.view-model";
 
 /** Injectable workbench client so the editor can be unit-tested without the network. */
 export interface SecurityPassportWorkbenchService {
   updateField: typeof defaultUpdateField;
+  resolveConflict: typeof defaultResolveConflict;
   submit: typeof defaultSubmit;
   approve: typeof defaultApprove;
   publish: typeof defaultPublish;
@@ -35,6 +41,7 @@ export interface SecurityPassportWorkbenchService {
 
 const defaultService: SecurityPassportWorkbenchService = {
   updateField: defaultUpdateField,
+  resolveConflict: defaultResolveConflict,
   submit: defaultSubmit,
   approve: defaultApprove,
   publish: defaultPublish
@@ -55,9 +62,24 @@ export interface SecurityPassportEditorProps {
   version: number;
   trustPosture?: string | null;
   fundProfileId?: string | null;
+  /** Unresolved source conflicts for this passport, rendered in the Source conflicts section. */
+  conflicts?: PassportConflictInput[];
   service?: Partial<SecurityPassportWorkbenchService>;
   /** Invoked when the operator chooses to reload after a stale-version conflict. */
   onReloadRequested?: (toVersion: number | null) => void;
+}
+
+const SEVERITY_VARIANT: Record<PassportSeverityTone, "danger" | "warning" | "outline"> = {
+  high: "danger",
+  medium: "warning",
+  low: "outline",
+  none: "outline"
+};
+
+interface OverrideDraft {
+  chosenWinnerSource: string;
+  reason: string;
+  acknowledgeDeviation: boolean;
 }
 
 interface WorkingRevision {
@@ -87,6 +109,7 @@ export function SecurityPassportEditor({
   version,
   trustPosture,
   fundProfileId,
+  conflicts = [],
   service,
   onReloadRequested
 }: SecurityPassportEditorProps) {
@@ -95,6 +118,14 @@ export function SecurityPassportEditor({
   const [revision, setRevision] = useState<WorkingRevision | null>(null);
   const [isBusy, setBusy] = useState(false);
   const [banner, setBanner] = useState<PassportBannerViewModel | null>(null);
+  const [liveVersion, setLiveVersion] = useState(version);
+  const [resolvedConflictIds, setResolvedConflictIds] = useState<readonly string[]>([]);
+  const [overrideConflictId, setOverrideConflictId] = useState<string | null>(null);
+  const [overrideDraft, setOverrideDraft] = useState<OverrideDraft>({
+    chosenWinnerSource: "",
+    reason: "",
+    acknowledgeDeviation: false
+  });
 
   const [fieldPath, setFieldPath] = useState("");
   const [newValue, setNewValue] = useState("");
@@ -111,11 +142,20 @@ export function SecurityPassportEditor({
   const hasPendingEdit = fieldPath.trim().length > 0 && justification.trim().length > 0;
   const stateBadge = buildPassportStateBadge(revision?.state ?? null);
   const trust = buildTrustPosture(trustPosture);
-  const expectedVersion = revision?.version ?? version;
+  const expectedVersion = revision?.version ?? liveVersion;
 
   const actions = useMemo(
     () => buildPassportActions({ state: revision?.state ?? null, hasPendingEdit, isBusy }),
     [revision?.state, hasPendingEdit, isBusy]
+  );
+
+  const conflictRows = useMemo(
+    () =>
+      buildConflictRows(
+        conflicts.map((c) => ({ ...c, isResolved: c.isResolved || resolvedConflictIds.includes(c.conflictId) })),
+        { isBusy }
+      ),
+    [conflicts, resolvedConflictIds, isBusy]
   );
 
   const run = useCallback(
@@ -189,6 +229,36 @@ export function SecurityPassportEditor({
       setRevision({ revisionId: result.revisionId, state: "Published", version: result.newVersion });
     });
   }, [run, client, securityId, revision]);
+
+  const resolveConflict = useCallback(
+    (conflictId: string, chosenWinnerSource: string, reason: string, acknowledgeDeviation: boolean) => {
+      void run(async () => {
+        const result = await client.resolveConflict(securityId, {
+          conflictId,
+          expectedVersion,
+          chosenWinnerSource,
+          reason,
+          acknowledgePolicyDeviation: acknowledgeDeviation
+        });
+        setLiveVersion(result.newVersion);
+        setResolvedConflictIds((ids) => (ids.includes(conflictId) ? ids : [...ids, conflictId]));
+        setOverrideConflictId(null);
+      });
+    },
+    [run, client, securityId, expectedVersion]
+  );
+
+  const handleAcceptConflict = useCallback(
+    (conflict: PassportConflictInput) => {
+      resolveConflict(conflict.conflictId, conflict.policyWinnerSource, "Accepted the recommended policy winner.", false);
+    },
+    [resolveConflict]
+  );
+
+  const openOverride = useCallback((conflict: PassportConflictInput) => {
+    setOverrideConflictId(conflict.conflictId);
+    setOverrideDraft({ chosenWinnerSource: conflict.challengerSource, reason: "", acknowledgeDeviation: false });
+  }, []);
 
   const actionHandlers: Record<PassportLifecycleAction, () => void> = {
     "save-draft": handleSaveDraft,
@@ -276,6 +346,90 @@ export function SecurityPassportEditor({
               />
             </label>
           </fieldset>
+        ) : null}
+
+        {conflictRows.length > 0 ? (
+          <section className="space-y-2" aria-label="Source conflicts">
+            <h3 className="text-sm font-medium">Source conflicts</h3>
+            <ul className="space-y-2">
+              {conflictRows.map((row) => {
+                const overrideOpen = overrideConflictId === row.conflictId;
+                const validation = validateConflictOverride({
+                  chosenWinnerSource: overrideDraft.chosenWinnerSource,
+                  policyWinnerSource: row.policyWinnerSource,
+                  reason: overrideDraft.reason,
+                  acknowledgeDeviation: overrideDraft.acknowledgeDeviation
+                });
+                return (
+                  <li key={row.conflictId} className="rounded-md border px-3 py-2 text-sm">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-medium">{row.fieldLabel}</span>
+                      <Badge variant={SEVERITY_VARIANT[row.severityTone]}>{row.severityLabel}</Badge>
+                      <span className="text-muted-foreground">
+                        winner <code>{row.policyWinnerSource}</code> · challenger <code>{row.challengerSource}</code>
+                      </span>
+                      <div className="ml-auto flex gap-2">
+                        <Button type="button" size="sm" variant="secondary" disabled={!row.canAct} onClick={() => handleAcceptConflict(row)}>
+                          Accept
+                        </Button>
+                        <Button type="button" size="sm" variant="outline" disabled={!row.canAct} onClick={() => openOverride(row)}>
+                          Override…
+                        </Button>
+                      </div>
+                    </div>
+                    {overrideOpen ? (
+                      <div className="mt-2 space-y-2 border-t pt-2" aria-label={`Override ${row.fieldLabel}`}>
+                        <label className="space-y-1 text-sm block">
+                          <span className="text-muted-foreground">Winning source</span>
+                          <Input
+                            value={overrideDraft.chosenWinnerSource}
+                            onChange={(e) => setOverrideDraft((d) => ({ ...d, chosenWinnerSource: e.target.value }))}
+                          />
+                        </label>
+                        <label className="space-y-1 text-sm block">
+                          <span className="text-muted-foreground">Reason (required)</span>
+                          <Input
+                            value={overrideDraft.reason}
+                            onChange={(e) => setOverrideDraft((d) => ({ ...d, reason: e.target.value }))}
+                          />
+                        </label>
+                        <label className="flex items-center gap-2 text-sm">
+                          <input
+                            type="checkbox"
+                            checked={overrideDraft.acknowledgeDeviation}
+                            onChange={(e) => setOverrideDraft((d) => ({ ...d, acknowledgeDeviation: e.target.checked }))}
+                          />
+                          <span>Acknowledge deviation from the policy winner</span>
+                        </label>
+                        <div className="flex items-center gap-2">
+                          <Button
+                            type="button"
+                            size="sm"
+                            disabled={!validation.valid || isBusy}
+                            title={validation.reason ?? undefined}
+                            onClick={() =>
+                              resolveConflict(
+                                row.conflictId,
+                                overrideDraft.chosenWinnerSource.trim(),
+                                overrideDraft.reason.trim(),
+                                overrideDraft.acknowledgeDeviation
+                              )
+                            }
+                          >
+                            Resolve
+                          </Button>
+                          <Button type="button" size="sm" variant="ghost" onClick={() => setOverrideConflictId(null)}>
+                            Cancel
+                          </Button>
+                          {!validation.valid ? <span className="text-xs text-muted-foreground">{validation.reason}</span> : null}
+                        </div>
+                      </div>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
         ) : null}
 
         <div className="flex flex-wrap gap-2">

--- a/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.view-model.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPassportActions,
+  buildPassportStateBadge,
+  buildTrustPosture,
+  buildWorkbenchErrorBanner,
+  type PassportLifecycleAction
+} from "@/components/meridian/security-passport-editor.view-model";
+
+function actionMap(actions: ReturnType<typeof buildPassportActions>): Record<PassportLifecycleAction, boolean> {
+  return actions.reduce(
+    (acc, a) => {
+      acc[a.action] = a.enabled;
+      return acc;
+    },
+    {} as Record<PassportLifecycleAction, boolean>
+  );
+}
+
+describe("passport lifecycle actions", () => {
+  it("enables save-draft only when there is a pending edit", () => {
+    expect(actionMap(buildPassportActions({ state: null, hasPendingEdit: false, isBusy: false })))
+      .toMatchObject({ "save-draft": false });
+    expect(actionMap(buildPassportActions({ state: null, hasPendingEdit: true, isBusy: false })))
+      .toMatchObject({ "save-draft": true });
+  });
+
+  it("gates submit/approve/publish on the matching lifecycle state", () => {
+    expect(actionMap(buildPassportActions({ state: "Draft", hasPendingEdit: false, isBusy: false })))
+      .toMatchObject({ submit: true, approve: false, publish: false });
+    expect(actionMap(buildPassportActions({ state: "Submitted", hasPendingEdit: false, isBusy: false })))
+      .toMatchObject({ submit: false, approve: true, publish: false });
+    expect(actionMap(buildPassportActions({ state: "Approved", hasPendingEdit: false, isBusy: false })))
+      .toMatchObject({ submit: false, approve: false, publish: true });
+  });
+
+  it("disables everything while busy, with a reason", () => {
+    const actions = buildPassportActions({ state: "Approved", hasPendingEdit: true, isBusy: true });
+    expect(actions.every((a) => !a.enabled)).toBe(true);
+    expect(actions.every((a) => a.disabledReason && a.disabledReason.length > 0)).toBe(true);
+  });
+
+  it("explains why publish is disabled before approval", () => {
+    const publish = buildPassportActions({ state: "Draft", hasPendingEdit: false, isBusy: false })
+      .find((a) => a.action === "publish");
+    expect(publish?.enabled).toBe(false);
+    expect(publish?.disabledReason).toContain("approved");
+  });
+});
+
+describe("passport state badge", () => {
+  it("maps each lifecycle state to a distinct tone", () => {
+    expect(buildPassportStateBadge("Draft").tone).toBe("draft");
+    expect(buildPassportStateBadge("Submitted").tone).toBe("submitted");
+    expect(buildPassportStateBadge("Approved").tone).toBe("approved");
+    expect(buildPassportStateBadge("Published").tone).toBe("published");
+    expect(buildPassportStateBadge("Rejected").tone).toBe("rejected");
+    expect(buildPassportStateBadge(null).label).toBe("No draft");
+  });
+});
+
+describe("workbench error banner", () => {
+  it("offers a non-destructive reload on a version conflict", () => {
+    const banner = buildWorkbenchErrorBanner({ kind: "version-conflict", currentVersion: 7 });
+    expect(banner.tone).toBe("error");
+    expect(banner.reloadToVersion).toBe(7);
+    expect(banner.message).toContain("7");
+  });
+
+  it("prompts for a workflow on workflow-required", () => {
+    const banner = buildWorkbenchErrorBanner({ kind: "workflow-required" });
+    expect(banner.tone).toBe("warning");
+    expect(banner.title).toContain("workflow");
+  });
+
+  it("surfaces the server message for unprocessable edits", () => {
+    const banner = buildWorkbenchErrorBanner({ kind: "unprocessable", message: "Justification is required." });
+    expect(banner.message).toBe("Justification is required.");
+  });
+});
+
+describe("trust posture", () => {
+  it("classifies postures into blocked/review/trusted", () => {
+    expect(buildTrustPosture("Blocked").tone).toBe("blocked");
+    expect(buildTrustPosture("Trusted").tone).toBe("trusted");
+    expect(buildTrustPosture("anything-else").tone).toBe("review");
+    expect(buildTrustPosture(null).tone).toBe("review");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.view-model.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildConflictRows,
   buildPassportActions,
   buildPassportStateBadge,
   buildTrustPosture,
   buildWorkbenchErrorBanner,
+  validateConflictOverride,
   type PassportLifecycleAction
 } from "@/components/meridian/security-passport-editor.view-model";
 
@@ -76,6 +78,49 @@ describe("workbench error banner", () => {
   it("surfaces the server message for unprocessable edits", () => {
     const banner = buildWorkbenchErrorBanner({ kind: "unprocessable", message: "Justification is required." });
     expect(banner.message).toBe("Justification is required.");
+  });
+});
+
+describe("conflict rows", () => {
+  const conflicts = [
+    { conflictId: "c1", fieldLabel: "Coupon", policyWinnerSource: "golden-copy", challengerSource: "vendor-a", severity: "High" },
+    { conflictId: "c2", fieldLabel: "Maturity", policyWinnerSource: "golden-copy", challengerSource: "vendor-b", severity: "Low", isResolved: true }
+  ];
+
+  it("classifies severity and disables resolved rows", () => {
+    const rows = buildConflictRows(conflicts, { isBusy: false });
+    expect(rows[0].severityTone).toBe("high");
+    expect(rows[0].canAct).toBe(true);
+    expect(rows[1].canAct).toBe(false);
+  });
+
+  it("disables all rows while busy", () => {
+    const rows = buildConflictRows(conflicts, { isBusy: true });
+    expect(rows.every((r) => !r.canAct)).toBe(true);
+  });
+});
+
+describe("conflict override validation", () => {
+  it("requires a reason", () => {
+    const result = validateConflictOverride({ chosenWinnerSource: "golden-copy", policyWinnerSource: "golden-copy", reason: "", acknowledgeDeviation: false });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("reason");
+  });
+
+  it("requires acknowledgement when deviating from the policy winner", () => {
+    const result = validateConflictOverride({ chosenWinnerSource: "vendor-a", policyWinnerSource: "golden-copy", reason: "Vendor is correct.", acknowledgeDeviation: false });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("deviation");
+  });
+
+  it("accepts an acknowledged deviation with a reason", () => {
+    const result = validateConflictOverride({ chosenWinnerSource: "vendor-a", policyWinnerSource: "golden-copy", reason: "Vendor is correct.", acknowledgeDeviation: true });
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts the policy winner with a reason and no acknowledgement", () => {
+    const result = validateConflictOverride({ chosenWinnerSource: "golden-copy", policyWinnerSource: "golden-copy", reason: "Confirmed.", acknowledgeDeviation: false });
+    expect(result.valid).toBe(true);
   });
 });
 

--- a/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.view-model.ts
@@ -1,0 +1,157 @@
+/**
+ * Pure view-model logic for the Security Master passport editor (Phase 4 UI slice 2). Keeps the
+ * governed-write lifecycle rules — which action is enabled in which state, how a write failure becomes
+ * a recovery banner — out of the React component so they can be unit-tested directly.
+ *
+ * These are presentation rules only; the server re-validates every transition. The editor never decides
+ * readiness locally (no client-local governance rule), matching the design's "no client-local readiness".
+ */
+
+import type { SecurityMasterRevisionState, WorkbenchWriteError } from "@/lib/api/security-master-workbench.api";
+
+export type PassportLifecycleAction = "save-draft" | "submit" | "approve" | "publish";
+
+export interface PassportActionViewModel {
+  action: PassportLifecycleAction;
+  label: string;
+  enabled: boolean;
+  /** When disabled, a short reason suitable for a tooltip / aria-description. */
+  disabledReason: string | null;
+}
+
+export type PassportStateTone = "draft" | "submitted" | "approved" | "published" | "rejected";
+
+export interface PassportStateBadgeViewModel {
+  label: string;
+  tone: PassportStateTone;
+}
+
+export type PassportTrustTone = "blocked" | "review" | "trusted";
+
+export interface PassportTrustPostureViewModel {
+  label: string;
+  tone: PassportTrustTone;
+}
+
+export type PassportBannerTone = "error" | "warning" | "info";
+
+export interface PassportBannerViewModel {
+  tone: PassportBannerTone;
+  title: string;
+  message: string;
+  /** Present for a stale-version conflict: the editor offers a non-destructive reload to this version. */
+  reloadToVersion?: number | null;
+}
+
+const STATE_BADGES: Record<SecurityMasterRevisionState, PassportStateBadgeViewModel> = {
+  Draft: { label: "Draft", tone: "draft" },
+  Submitted: { label: "Submitted", tone: "submitted" },
+  Approved: { label: "Approved", tone: "approved" },
+  Published: { label: "Published", tone: "published" },
+  Rejected: { label: "Rejected", tone: "rejected" }
+};
+
+export function buildPassportStateBadge(state: SecurityMasterRevisionState | null): PassportStateBadgeViewModel {
+  return state ? STATE_BADGES[state] : { label: "No draft", tone: "draft" };
+}
+
+export interface PassportActionContext {
+  /** Lifecycle state of the working revision, or null when no draft has been opened yet. */
+  state: SecurityMasterRevisionState | null;
+  /** True when the form holds an unsaved field edit. */
+  hasPendingEdit: boolean;
+  /** True while a workbench request is in flight. */
+  isBusy: boolean;
+}
+
+export function buildPassportActions(context: PassportActionContext): PassportActionViewModel[] {
+  const { state, hasPendingEdit, isBusy } = context;
+  const busyReason = "A workbench action is already in progress.";
+
+  function build(
+    action: PassportLifecycleAction,
+    label: string,
+    allowed: boolean,
+    notAllowedReason: string
+  ): PassportActionViewModel {
+    if (isBusy) {
+      return { action, label, enabled: false, disabledReason: busyReason };
+    }
+    return {
+      action,
+      label,
+      enabled: allowed,
+      disabledReason: allowed ? null : notAllowedReason
+    };
+  }
+
+  return [
+    build("save-draft", "Save draft", hasPendingEdit, "Edit a field to save a draft."),
+    build("submit", "Submit for approval", state === "Draft", "Save a draft before submitting for approval."),
+    build("approve", "Approve", state === "Submitted", "Only a submitted revision can be approved."),
+    build("publish", "Publish", state === "Approved", "Publish is enabled once the revision is approved.")
+  ];
+}
+
+export function buildWorkbenchErrorBanner(error: WorkbenchWriteError): PassportBannerViewModel {
+  switch (error.kind) {
+    case "version-conflict":
+      return {
+        tone: "error",
+        title: "This passport changed",
+        message:
+          error.currentVersion != null
+            ? `Another operator published version ${error.currentVersion}. Reload to continue without losing your edit.`
+            : "Another operator changed this passport. Reload to continue without losing your edit.",
+        reloadToVersion: error.currentVersion
+      };
+    case "revision-state-conflict":
+      return {
+        tone: "error",
+        title: "Revision state changed",
+        message: error.message ?? "This revision is no longer in a state that allows the requested action. Reload the revision."
+      };
+    case "workflow-required":
+      return {
+        tone: "warning",
+        title: "Approval workflow required",
+        message: "Select an approval workflow and an independent reviewer before submitting for governed approval."
+      };
+    case "unprocessable":
+      return {
+        tone: "error",
+        title: "The edit was rejected",
+        message: error.message ?? "The request was understood but could not be processed. Check the required fields."
+      };
+    case "forbidden":
+      return {
+        tone: "error",
+        title: "Not permitted",
+        message: "You don't have permission to edit this security passport."
+      };
+    case "unauthorized":
+      return {
+        tone: "error",
+        title: "Session expired",
+        message: "Your session is no longer authenticated. Sign in again to continue editing."
+      };
+    case "unknown":
+    default:
+      return {
+        tone: "error",
+        title: "The request could not be completed",
+        message: error.kind === "unknown" ? error.message : "An unexpected error occurred."
+      };
+  }
+}
+
+export function buildTrustPosture(posture: string | null | undefined): PassportTrustPostureViewModel {
+  const normalized = (posture ?? "").trim().toLowerCase();
+  if (normalized === "blocked" || normalized === "critical") {
+    return { label: "Blocked", tone: "blocked" };
+  }
+  if (normalized === "trusted" || normalized === "ready" || normalized === "ok") {
+    return { label: "Trusted", tone: "trusted" };
+  }
+  return { label: "Review", tone: "review" };
+}

--- a/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/security-passport-editor.view-model.ts
@@ -145,6 +145,91 @@ export function buildWorkbenchErrorBanner(error: WorkbenchWriteError): PassportB
   }
 }
 
+export type PassportSeverityTone = "high" | "medium" | "low" | "none";
+
+export interface PassportConflictInput {
+  conflictId: string;
+  fieldLabel: string;
+  policyWinnerSource: string;
+  challengerSource: string;
+  severity?: string | null;
+  isResolved?: boolean;
+}
+
+export interface PassportConflictRowViewModel {
+  conflictId: string;
+  fieldLabel: string;
+  policyWinnerSource: string;
+  challengerSource: string;
+  severityTone: PassportSeverityTone;
+  severityLabel: string;
+  /** False when resolved or while a write is in flight. */
+  canAct: boolean;
+}
+
+function classifySeverity(severity: string | null | undefined): { tone: PassportSeverityTone; label: string } {
+  const normalized = (severity ?? "").trim().toLowerCase();
+  if (normalized === "critical" || normalized === "high") {
+    return { tone: "high", label: severity ?? "High" };
+  }
+  if (normalized === "medium") {
+    return { tone: "medium", label: severity ?? "Medium" };
+  }
+  if (normalized === "low") {
+    return { tone: "low", label: severity ?? "Low" };
+  }
+  return { tone: "none", label: severity ?? "None" };
+}
+
+export function buildConflictRows(
+  conflicts: readonly PassportConflictInput[],
+  context: { isBusy: boolean }
+): PassportConflictRowViewModel[] {
+  return conflicts.map((conflict) => {
+    const severity = classifySeverity(conflict.severity);
+    return {
+      conflictId: conflict.conflictId,
+      fieldLabel: conflict.fieldLabel,
+      policyWinnerSource: conflict.policyWinnerSource,
+      challengerSource: conflict.challengerSource,
+      severityTone: severity.tone,
+      severityLabel: severity.label,
+      canAct: !conflict.isResolved && !context.isBusy
+    };
+  });
+}
+
+export interface ConflictOverrideValidation {
+  valid: boolean;
+  /** When invalid, the single blocking reason; null when valid. */
+  reason: string | null;
+}
+
+/**
+ * Client-side guard for the override form (UX only — the server re-validates). A reason is always
+ * required, and choosing a winner other than the policy winner requires acknowledging the deviation,
+ * mirroring the server's policy-deviation-unacknowledged (422) rule.
+ */
+export function validateConflictOverride(input: {
+  chosenWinnerSource: string;
+  policyWinnerSource: string;
+  reason: string;
+  acknowledgeDeviation: boolean;
+}): ConflictOverrideValidation {
+  if (input.chosenWinnerSource.trim().length === 0) {
+    return { valid: false, reason: "Choose a winning source." };
+  }
+  if (input.reason.trim().length === 0) {
+    return { valid: false, reason: "A reason is required to resolve a source conflict." };
+  }
+  const isDeviation =
+    input.chosenWinnerSource.trim().toLowerCase() !== input.policyWinnerSource.trim().toLowerCase();
+  if (isDeviation && !input.acknowledgeDeviation) {
+    return { valid: false, reason: "Acknowledge the policy deviation to override the recommended winner." };
+  }
+  return { valid: true, reason: null };
+}
+
 export function buildTrustPosture(posture: string | null | undefined): PassportTrustPostureViewModel {
   const normalized = (posture ?? "").trim().toLowerCase();
   if (normalized === "blocked" || normalized === "critical") {

--- a/src/Meridian.Ui/dashboard/src/lib/api/security-master-workbench.api.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api/security-master-workbench.api.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "@/lib/api-errors";
+import {
+  approveSecurityMasterRevision,
+  classifyWorkbenchWriteError,
+  publishSecurityMasterRevision,
+  resolveSourceConflict,
+  submitSecurityMasterRevision,
+  updateSecurityField
+} from "@/lib/api/security-master-workbench.api";
+
+const SECURITY_ID = "11111111-1111-1111-1111-111111111111";
+
+describe("Security Master workbench API client", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}), text: async () => "{}" });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("routes each governed-write through the shared POST helper at the securityId-scoped path", async () => {
+    await updateSecurityField(SECURITY_ID, {
+      expectedVersion: 3,
+      fieldPath: "EconomicDefinition.Coupon",
+      newValue: "5.125",
+      effectiveFrom: "2026-03-15T00:00:00Z",
+      justification: "Vendor confirmation #4821."
+    });
+    await resolveSourceConflict(SECURITY_ID, {
+      conflictId: "c-1",
+      expectedVersion: 3,
+      chosenWinnerSource: "golden-copy",
+      reason: "Golden copy is authoritative."
+    });
+    await submitSecurityMasterRevision(SECURITY_ID, {
+      revisionId: "r-1",
+      workflowId: "w-1",
+      expectedWorkflowVersion: 1,
+      reviewer: "independent.reviewer"
+    });
+    await approveSecurityMasterRevision(SECURITY_ID, {
+      revisionId: "r-1",
+      workflowId: "w-1",
+      expectedWorkflowVersion: 2,
+      rationale: "Reviewed.",
+      reportPackId: "rp-1"
+    });
+    await publishSecurityMasterRevision(SECURITY_ID, { revisionId: "r-1" });
+
+    const base = `/api/security-master/${SECURITY_ID}/workbench`;
+    expect(fetchMock).toHaveBeenNthCalledWith(1, `${base}/field`, expect.objectContaining({ method: "POST" }));
+    expect(fetchMock).toHaveBeenNthCalledWith(2, `${base}/resolve-conflict`, expect.objectContaining({ method: "POST" }));
+    expect(fetchMock).toHaveBeenNthCalledWith(3, `${base}/submit`, expect.objectContaining({ method: "POST" }));
+    expect(fetchMock).toHaveBeenNthCalledWith(4, `${base}/approve`, expect.objectContaining({ method: "POST" }));
+    expect(fetchMock).toHaveBeenNthCalledWith(5, `${base}/publish`, expect.objectContaining({ method: "POST" }));
+  });
+
+  it("does not send the server-derived actor in the field-edit body", async () => {
+    await updateSecurityField(SECURITY_ID, {
+      expectedVersion: 3,
+      fieldPath: "EconomicDefinition.Coupon",
+      newValue: "5.125",
+      effectiveFrom: "2026-03-15T00:00:00Z",
+      justification: "Vendor confirmation #4821."
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body).not.toHaveProperty("actor");
+    expect(body.fieldPath).toBe("EconomicDefinition.Coupon");
+  });
+});
+
+describe("classifyWorkbenchWriteError", () => {
+  function apiError(status: number, body: Record<string, unknown>): ApiError {
+    return new ApiError({ path: "/x", status, responseBody: JSON.stringify(body) });
+  }
+
+  it("extracts the current version from a 409 version-conflict", () => {
+    const result = classifyWorkbenchWriteError(apiError(409, { error: "version-conflict", currentVersion: 7 }));
+    expect(result).toEqual({ kind: "version-conflict", currentVersion: 7 });
+  });
+
+  it("treats other 409s as a revision-state conflict", () => {
+    const result = classifyWorkbenchWriteError(apiError(409, { error: "revision-state-conflict", message: "not approved" }));
+    expect(result).toEqual({ kind: "revision-state-conflict", message: "not approved" });
+  });
+
+  it("recognizes the workflow-required 422", () => {
+    expect(classifyWorkbenchWriteError(apiError(422, { error: "workflow-required" }))).toEqual({ kind: "workflow-required" });
+  });
+
+  it("maps 403 and 401 to forbidden / unauthorized", () => {
+    expect(classifyWorkbenchWriteError(apiError(403, {})).kind).toBe("forbidden");
+    expect(classifyWorkbenchWriteError(apiError(401, {})).kind).toBe("unauthorized");
+  });
+
+  it("classifies non-API errors as unknown with a message", () => {
+    const result = classifyWorkbenchWriteError(new Error("network down"));
+    expect(result.kind).toBe("unknown");
+    expect((result as { message: string }).message).toBe("network down");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/lib/api/security-master-workbench.api.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api/security-master-workbench.api.ts
@@ -1,0 +1,231 @@
+/**
+ * Client functions for the Security Master Passport Workbench governed-write surface (Phase 4 UI slice 1).
+ *
+ * Thin wrappers over the shared dashboard fetch helpers so aborts, headers, and backend problem-detail
+ * handling stay aligned with the rest of the workstation. Identity is server-derived: the acting
+ * principal (and, on approve, the reviewer) is resolved from the session and overwrites the body, so
+ * these request inputs deliberately omit `actor`/`reviewer`-on-approve. The path `securityId` is
+ * authoritative, so it is passed as an argument rather than trusted from the body.
+ */
+
+import { apiPostJson } from "@/lib/api";
+import { isApiError } from "@/lib/api-errors";
+import {
+  securityMasterWorkbenchApproveEndpoint,
+  securityMasterWorkbenchFieldEndpoint,
+  securityMasterWorkbenchPublishEndpoint,
+  securityMasterWorkbenchResolveConflictEndpoint,
+  securityMasterWorkbenchSubmitEndpoint
+} from "@/lib/workstation-endpoints";
+
+export type SecurityMasterRevisionState = "Draft" | "Submitted" | "Approved" | "Published" | "Rejected";
+
+export interface SecurityMasterChangeHistoryItem {
+  changeId: string;
+  streamVersion: number;
+  eventType: string;
+  changedAtUtc: string;
+  effectiveAtUtc: string | null;
+  actor: string;
+  origin: string;
+  sourceSystem: string;
+  sourceRecordId: string | null;
+  reason: string | null;
+  summary: string;
+  changedFields: string[];
+  changedFieldsSummary: string;
+}
+
+export interface SecurityMasterEditResult {
+  securityId: string;
+  revisionId: string;
+  newVersion: number;
+  state: SecurityMasterRevisionState;
+  changeEntry: SecurityMasterChangeHistoryItem;
+}
+
+export interface SecurityMasterConflictResolution {
+  conflictId: string;
+  policyWinnerSource: string;
+  chosenWinnerSource: string;
+  isPolicyDeviation: boolean;
+  reason: string;
+  newVersion: number;
+}
+
+export interface RestatementCandidate {
+  reportId: string;
+  priorVersionReportId: string;
+  periodLabel: string;
+  summary: string;
+  changedLines: unknown[];
+}
+
+export interface SecurityMasterPublishResult {
+  securityId: string;
+  revisionId: string;
+  newVersion: number;
+  restatementRequired: boolean;
+  restatementCandidates: RestatementCandidate[];
+  invalidatedProjections: string[];
+}
+
+/** Effective-dated edit to a single passport field. `actor` is server-derived and not supplied here. */
+export interface UpdateSecurityFieldInput {
+  expectedVersion: number;
+  fieldPath: string;
+  newValue: string | null;
+  effectiveFrom: string;
+  justification: string;
+  sourceRecordId?: string | null;
+  fundProfileId?: string | null;
+  correlationId?: string | null;
+}
+
+/** Operator resolution of a source conflict. A deviation from the policy winner must be acknowledged. */
+export interface ResolveSourceConflictInput {
+  conflictId: string;
+  expectedVersion: number;
+  chosenWinnerSource: string;
+  reason: string;
+  acknowledgePolicyDeviation?: boolean;
+  correlationId?: string | null;
+}
+
+/** Submit a draft into the governed approval gate. `workflowId` is required by the endpoint. */
+export interface SubmitSecurityMasterRevisionInput {
+  revisionId: string;
+  note?: string | null;
+  fundProfileId?: string | null;
+  workflowId: string;
+  expectedWorkflowVersion: number;
+  reviewer: string;
+  reportPackId?: string | null;
+}
+
+/** Approve a submitted revision. `actor`/`reviewer` are server-derived (the caller is the reviewer). */
+export interface ApproveSecurityMasterRevisionInput {
+  revisionId: string;
+  workflowId: string;
+  expectedWorkflowVersion: number;
+  rationale: string;
+  reportPackId: string;
+  correlationId?: string | null;
+}
+
+/** Publish an approved revision. `actor` is server-derived. */
+export interface PublishSecurityMasterRevisionInput {
+  revisionId: string;
+  correlationId?: string | null;
+}
+
+export function updateSecurityField(
+  securityId: string,
+  input: UpdateSecurityFieldInput,
+  signal?: AbortSignal
+): Promise<SecurityMasterEditResult> {
+  return apiPostJson<SecurityMasterEditResult>(securityMasterWorkbenchFieldEndpoint(securityId), input, { signal });
+}
+
+export function resolveSourceConflict(
+  securityId: string,
+  input: ResolveSourceConflictInput,
+  signal?: AbortSignal
+): Promise<SecurityMasterConflictResolution> {
+  return apiPostJson<SecurityMasterConflictResolution>(
+    securityMasterWorkbenchResolveConflictEndpoint(securityId),
+    input,
+    { signal }
+  );
+}
+
+export function submitSecurityMasterRevision(
+  securityId: string,
+  input: SubmitSecurityMasterRevisionInput,
+  signal?: AbortSignal
+): Promise<SecurityMasterEditResult> {
+  return apiPostJson<SecurityMasterEditResult>(securityMasterWorkbenchSubmitEndpoint(securityId), input, { signal });
+}
+
+export function approveSecurityMasterRevision(
+  securityId: string,
+  input: ApproveSecurityMasterRevisionInput,
+  signal?: AbortSignal
+): Promise<SecurityMasterEditResult> {
+  return apiPostJson<SecurityMasterEditResult>(securityMasterWorkbenchApproveEndpoint(securityId), input, { signal });
+}
+
+export function publishSecurityMasterRevision(
+  securityId: string,
+  input: PublishSecurityMasterRevisionInput,
+  signal?: AbortSignal
+): Promise<SecurityMasterPublishResult> {
+  return apiPostJson<SecurityMasterPublishResult>(securityMasterWorkbenchPublishEndpoint(securityId), input, { signal });
+}
+
+/**
+ * A classified governed-write failure, so the editor can render the right recovery affordance:
+ * a stale-version reload banner, a workflow prompt, or a generic validation message.
+ */
+export type WorkbenchWriteError =
+  | { kind: "version-conflict"; currentVersion: number | null }
+  | { kind: "revision-state-conflict"; message: string | null }
+  | { kind: "workflow-required" }
+  | { kind: "unprocessable"; message: string | null }
+  | { kind: "forbidden" }
+  | { kind: "unauthorized" }
+  | { kind: "unknown"; message: string };
+
+interface WorkbenchErrorBody {
+  error?: unknown;
+  currentVersion?: unknown;
+  message?: unknown;
+}
+
+function parseErrorBody(responseBody: string | null): WorkbenchErrorBody {
+  if (!responseBody) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(responseBody) as unknown;
+    return typeof parsed === "object" && parsed !== null ? (parsed as WorkbenchErrorBody) : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Maps a thrown {@link ApiError} from a workbench write to a discriminated recovery hint. Non-API errors
+ * (network/abort) classify as `unknown` so callers always have a message to surface.
+ */
+export function classifyWorkbenchWriteError(error: unknown): WorkbenchWriteError {
+  if (!isApiError(error)) {
+    return { kind: "unknown", message: error instanceof Error ? error.message : "The request could not be completed." };
+  }
+
+  const body = parseErrorBody(error.responseBody);
+  const code = typeof body.error === "string" ? body.error : null;
+  const message = typeof body.message === "string" ? body.message : error.detail;
+
+  switch (error.status) {
+    case 401:
+      return { kind: "unauthorized" };
+    case 403:
+      return { kind: "forbidden" };
+    case 409:
+      if (code === "version-conflict") {
+        return {
+          kind: "version-conflict",
+          currentVersion: typeof body.currentVersion === "number" ? body.currentVersion : null
+        };
+      }
+      return { kind: "revision-state-conflict", message };
+    case 422:
+      if (code === "workflow-required") {
+        return { kind: "workflow-required" };
+      }
+      return { kind: "unprocessable", message };
+    default:
+      return { kind: "unknown", message: error.detail ?? `Request failed (${error.status}).` };
+  }
+}

--- a/src/Meridian.Ui/dashboard/src/lib/workstation-endpoints.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/workstation-endpoints.ts
@@ -211,6 +211,34 @@ export const SECURITY_MASTER_API_ENDPOINTS = {
   workstationConflictsBulkResolve: UI_API_ROUTES.WorkstationSecurityMasterBulkResolveConflicts
 } as const;
 
+/**
+ * Passport Workbench governed-write routes. Each carries a `{securityId:guid}` path segment that is
+ * authoritative server-side, so the helpers substitute it explicitly rather than relying on the body.
+ */
+function securityMasterWorkbenchPath(route: string, securityId: string): string {
+  return route.replace("{securityId:guid}", encodeURIComponent(securityId));
+}
+
+export function securityMasterWorkbenchFieldEndpoint(securityId: string): string {
+  return securityMasterWorkbenchPath(UI_API_ROUTES.SecurityMasterWorkbenchField, securityId);
+}
+
+export function securityMasterWorkbenchResolveConflictEndpoint(securityId: string): string {
+  return securityMasterWorkbenchPath(UI_API_ROUTES.SecurityMasterWorkbenchResolveConflict, securityId);
+}
+
+export function securityMasterWorkbenchSubmitEndpoint(securityId: string): string {
+  return securityMasterWorkbenchPath(UI_API_ROUTES.SecurityMasterWorkbenchSubmit, securityId);
+}
+
+export function securityMasterWorkbenchApproveEndpoint(securityId: string): string {
+  return securityMasterWorkbenchPath(UI_API_ROUTES.SecurityMasterWorkbenchApprove, securityId);
+}
+
+export function securityMasterWorkbenchPublishEndpoint(securityId: string): string {
+  return securityMasterWorkbenchPath(UI_API_ROUTES.SecurityMasterWorkbenchPublish, securityId);
+}
+
 export const REFERENCE_DATA_API_ENDPOINTS = {
   edgarFiler: UI_API_ROUTES.ReferenceDataEdgarFiler,
   edgarFacts: UI_API_ROUTES.ReferenceDataEdgarFacts,


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Adds the browser operator surface for the Security Master Passport Workbench governed-write endpoints merged in #2009. Three increments:

**1. Typed write client** (`lib/api/security-master-workbench.api.ts` + path builders in `workstation-endpoints.ts`)
- Thin wrappers over the shared dashboard POST helper for all five governed-write routes (field, resolve-conflict, submit, approve, publish), scoped by an explicit path `securityId`.
- Request inputs deliberately **omit the server-derived identity** (the acting principal everywhere, and the reviewer on approve), mirroring the endpoint's authority model.
- `classifyWorkbenchWriteError` maps a thrown `ApiError` into a discriminated recovery hint: 409 `version-conflict` (carrying `currentVersion`) vs `revision-state-conflict`, 422 `workflow-required` vs `unprocessable`, and 401/403.

**2. Editor component** (`security-passport-editor.tsx` + `security-passport-editor.view-model.ts`)
- Header (symbol · asset class · trust-posture dot · state badge · version chip), a governed field-edit form wired to Save Draft using the loaded version as the optimistic-concurrency token, and a lifecycle action bar (Save Draft → Submit → Approve → Publish).
- Action enablement comes from the pure view-model (Publish stays disabled until Approved; everything disabled while busy), and a `role="alert"` banner offers a **non-destructive Reload** action on a stale-version 409.
- The workbench client is injectable, so the component tests offline.

**3. Source-conflict resolution** (extends the editor)
- A Source conflicts section listing each conflict (field · severity · policy winner · challenger) with **Accept** (resolve to the policy winner) and **Override…** (inline form: winning source · reason · acknowledge-deviation), wired to `resolveSourceConflict`. The override is gated client-side by `validateConflictOverride` — reason required; acknowledgement required when deviating — the client mirror of the server's `policy-deviation-unacknowledged` 422.

The editor never decides readiness locally — every transition is server re-validated (no client-local governance rule), matching the design.

## Reason

Phase 4 of the workbench design (`docs/plans/security-master-passport-workbench.md`) calls for a browser passport editor over the governed-write endpoints. This PR lands the client foundation and the editor component (field edit + lifecycle + source-conflict resolution). The coverage-panel entry point, the remaining read tabs, and the WPF editor are deliberate follow-up slices.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully *(this slice is browser-only; the .NET gate is unaffected. Validated the dashboard directly — see below.)*
- [x] Relevant unit tests were added or updated
- [x] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed *(pending on this PR)*

Validated locally in `src/Meridian.Ui/dashboard`: `vitest` — **31 new tests pass** (7 API client + 4 endpoint additions covered by existing suite, 9 view-model, 3 editor, +8 conflict view-model/component); `tsc --noEmit` is **clean**. New coverage spans request routing, omission of the server-derived actor from the body, the full error-classification matrix, lifecycle action gating, the version-conflict reload banner, and the conflict Accept/Override (deviation-acknowledgement) flow.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019qm7pxZJDPsXViBkoHw7R2)_