### PR TITLE
ci: fix desktop/web screenshot capture workflows to match refresh contract

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,8 +41,8 @@ scope.
 | Publish Smoke | `publish-smoke.yml` | Manual only | Runs `build/scripts/publish/publish.ps1` for a selected Windows runtime and uploads the generated standalone output. | Publish output |
 | Desktop Standalone Publish | `desktop-standalone-publish.yml` | Manual only | Publishes a desktop standalone `win-x64` executable and uploads the output. | Desktop standalone output |
 | Desktop Installer Packaging | `desktop-installer-packaging.yml` | Tag pushes (`v*`), manual | Runs a WPF release preflight build/test gate, builds signed MSIX installer packages for `win-x64` and `win-arm64`, uploads workflow artifacts, and attaches package assets to GitHub releases for tag runs. | Desktop installer packages (`.msix`, `.msixbundle`, `.appinstaller`) |
-| Windows Desktop Build Support | `desktop-workflow-runner.yml`, `desktop-screenshot-capture.yml`, `desktop-user-manual.yml` | Manual only | Runs selected desktop workflows, captures desktop screenshots, or generates the desktop user manual. Screenshot/manual workflows are read-only and upload artifacts; they do not commit back to the repository. | Desktop workflow, screenshot, or manual artifacts |
-| Web Screenshot Capture | `web-screenshot-capture.yml` | Manual only | Captures browser workstation screenshots from the configured route list using lockfile-strict `npm ci`. The workflow is read-only and uploads artifacts; it does not open PRs or push commits. | Web screenshot artifacts |
+| Windows Desktop Build Support | `desktop-workflow-runner.yml`, `desktop-screenshot-capture.yml`, `desktop-user-manual.yml` | Manual only | Runs selected desktop workflows, captures desktop screenshots, or generates the desktop user manual. These workflows always upload artifacts; `desktop-screenshot-capture.yml` can additionally open a `peter-evans/create-pull-request` PR with the refreshed catalog when dispatched with `commit: true`. They never push commits directly. | Desktop workflow, screenshot, or manual artifacts; optional screenshot refresh PR |
+| Web Screenshot Capture | `web-screenshot-capture.yml` | Manual only | Captures browser workstation screenshots from the configured route list with `npm install --include=optional`, uploads artifacts, and opens a `peter-evans/create-pull-request` PR (`automation/web-screenshot-capture`) with the refreshed catalog. It never pushes commits directly. | Web screenshot artifacts; screenshot refresh PR |
 | Provider Smoke Checks | `ibapi-smoke.yml`, `robinhood-options-smoke.yml` | Path-filtered or manual | Runs provider smoke checks that are too specialized for the normal PR fast path. | Smoke evidence artifacts |
 | Copilot Setup Steps | `copilot-setup-steps.yml` | Copilot setup, relevant pushes/PRs, manual | Validates the GitHub Copilot hosted setup path for repository dependencies. | None |
 
@@ -162,8 +162,9 @@ python3 build/scripts/docs/generate-workflow-manifest.py
 
 - All workflows use repository-relative paths.
 - Default token permissions are read-only.
-- Manual screenshot and manual-generation workflows are artifact-only; repository writes should be
-  made from a reviewed local or PR workflow, not from those capture jobs.
+- Manual screenshot-capture workflows never push commits directly; any repository write is proposed
+  through a reviewed `peter-evans/create-pull-request` PR (always for the web capture, and for the
+  desktop capture only when dispatched with `commit: true`).
 - PR and branch workflows cancel superseded runs.
 - Build/test workflows use explicit restore, build, and test phases; the CI .NET lane aggregates per-project test results before failing so each run reports all broken configured test slices.
 - Test lanes that enable hang diagnostics upload uniquely named evidence artifacts for reruns so passing and failing runs both leave inspectable logs.

--- a/.github/workflows/desktop-screenshot-capture.yml
+++ b/.github/workflows/desktop-screenshot-capture.yml
@@ -7,9 +7,15 @@ on:
         description: Output directory for captured screenshots.
         required: false
         default: "docs/screenshots/desktop"
+      commit:
+        description: Open a pull request with the refreshed desktop screenshots.
+        type: boolean
+        required: false
+        default: false
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 concurrency:
   group: desktop-screenshot-capture-${{ github.ref }}
@@ -186,3 +192,18 @@ jobs:
           path: artifacts/desktop-screenshot-capture/all-screenshots/
           if-no-files-found: ignore
           retention-days: 14
+
+      - name: Open screenshot refresh pull request
+        if: ${{ success() && inputs.commit == true }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: automation/desktop-screenshot-capture
+          base: ${{ github.event.repository.default_branch }}
+          title: "chore: refresh desktop workstation screenshot catalog"
+          commit-message: "chore: refresh desktop workstation screenshot catalog"
+          body: |
+            Automated refresh of the desktop WPF screenshot catalog captured by the
+            Desktop Screenshot Capture workflow. Review the rendered screens before merging.
+          add-paths: |
+            ${{ steps.validate_output_dir.outputs.safe_output_dir }}/*.png
+          delete-branch: true

--- a/.github/workflows/desktop-screenshot-capture.yml
+++ b/.github/workflows/desktop-screenshot-capture.yml
@@ -39,6 +39,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
         with:
+          # Always capture and propose the refresh from the canonical default branch so a
+          # dispatch from a feature branch cannot publish that branch's commits into the
+          # automation/desktop-screenshot-capture PR alongside the screenshots.
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           fetch-depth: 1
 

--- a/.github/workflows/web-screenshot-capture.yml
+++ b/.github/workflows/web-screenshot-capture.yml
@@ -34,6 +34,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
         with:
+          # Always capture and propose the refresh from the canonical default branch so a
+          # dispatch from a feature branch cannot publish that branch's commits into the
+          # automation/web-screenshot-capture PR alongside the screenshots.
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           fetch-depth: 1
 

--- a/.github/workflows/web-screenshot-capture.yml
+++ b/.github/workflows/web-screenshot-capture.yml
@@ -13,7 +13,8 @@ on:
         default: "scripts/dev/web-screenshot-routes.json"
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 concurrency:
   group: web-screenshot-capture-${{ github.ref }}
@@ -44,7 +45,7 @@ jobs:
           cache-dependency-path: src/Meridian.Ui/dashboard/package-lock.json
 
       - name: Install dashboard dependencies
-        run: npm ci --prefix src/Meridian.Ui/dashboard --include=optional
+        run: npm install --prefix src/Meridian.Ui/dashboard --include=optional
 
       - name: Install Playwright browser
         run: |
@@ -166,3 +167,19 @@ jobs:
           path: ${{ steps.validate_output_dir.outputs.safe_output_dir }}/*.png
           if-no-files-found: ignore
           retention-days: 14
+
+      - name: Open screenshot refresh pull request
+        if: ${{ steps.capture_web.outcome == 'success' }}
+        continue-on-error: true
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: automation/web-screenshot-capture
+          base: ${{ github.event.repository.default_branch }}
+          title: "chore: refresh web workstation screenshot catalog"
+          commit-message: "chore: refresh web workstation screenshot catalog"
+          body: |
+            Automated refresh of the web workstation screenshot catalog captured by the
+            Web Screenshot Capture workflow. Review the rendered routes before merging.
+          add-paths: |
+            ${{ steps.validate_output_dir.outputs.safe_output_dir }}/*.png
+          delete-branch: true


### PR DESCRIPTION
## Summary

Fixes the desktop application (and web) screenshot-capture GitHub Actions workflows so they match the refresh contract asserted by `tests/scripts/test_refresh_screenshots_workflow.py`. Both workflows can now propose a refreshed screenshot catalog through a reviewed pull request (never a direct push):

- **`desktop-screenshot-capture.yml`** — adds a boolean `commit` workflow input and a `peter-evans/create-pull-request@v7` step gated on `if: ${{ success() && inputs.commit == true }}` (branch `automation/desktop-screenshot-capture`, base = repository default branch). Permissions raised to `contents: write` + `pull-requests: write` solely to open the PR.
- **`web-screenshot-capture.yml`** — switches the dependency install from lockfile-strict `npm ci` to `npm install --include=optional`, and adds a `peter-evans/create-pull-request@v7` step (branch `automation/web-screenshot-capture`) that opens a PR with the refreshed catalog. Permissions raised to `contents: write` + `pull-requests: write`.
- **`.github/workflows/README.md`** — updated the workflow table and Standards section, which previously claimed these jobs were read-only and "do not open PRs / commit back," to describe the new PR-based refresh behavior.

## Reason

The two capture workflows had drifted out of sync with the `test_refresh_screenshots_workflow` contract, leaving two failing tests:

- The desktop workflow had no opt-in commit/PR path (`if: ${{ success() && inputs.commit == true }}` was missing).
- The web workflow used `npm ci` and never opened a refresh PR (expected `npm install --include=optional` plus a `peter-evans/create-pull-request@v7` step).

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were validated — `python3 -m pytest tests/scripts/test_refresh_screenshots_workflow.py` and the full screenshot suite pass (23 passed); both YAML files parse cleanly
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] `.github/workflows/**`

Governance-file changes require explicit human approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0135DY2VUivC9RyA7H7BKpfb)_