### PR TITLE
feat(security-master): report-pack-backed restatement candidate resolver

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -5133,6 +5133,7 @@ Meridian-main
 │   │   │   ├── ReportingScheduleService.cs
 │   │   │   ├── ReportingWorkflowService.cs
 │   │   │   ├── ReportPackDeliveryService.cs
+│   │   │   ├── ReportPackRestatementCandidateResolver.cs
 │   │   │   ├── ReportPackRunReadService.cs
 │   │   │   ├── ReportPackValidationService.cs
 │   │   │   ├── ReportWriterDatasetSourceService.cs
@@ -6570,6 +6571,7 @@ Meridian-main
 │   │   │   │   ├── LedgerPeriodLockReaderTests.cs
 │   │   │   │   ├── PeriodAwareRestatementResolverTests.cs
 │   │   │   │   ├── PublishedRevisionHandlerTests.cs
+│   │   │   │   ├── ReportPackRestatementCandidateResolverTests.cs
 │   │   │   │   ├── SecurityMasterConflictAuthorityPolicyTests.cs
 │   │   │   │   └── SecurityMasterWorkbenchCommandServiceTests.cs
 │   │   │   ├── CorporateActionCommandServiceTests.cs

--- a/docs/plans/security-master-passport-workbench.md
+++ b/docs/plans/security-master-passport-workbench.md
@@ -394,9 +394,10 @@ POST /api/security-master/{securityId:guid}/workbench/publish
   (fund-book granularity); the set is empty when the impact reports no ledger exposure, has no fund
   scope, or no durable ledger backend is registered (the store is an optional dependency). Still
   deferred to later slices: narrowing to the specific posting books that referenced the security (via
-  journal-line dimensions), cross-fund expansion for unscoped impacts, the soft-closed governed
-  adjustment poster (`IGovernedLedgerAdjustmentPoster`), and the report-pack `IRestatementCandidateResolver`
-  (defaults to a no-op → manual-locate).
+  journal-line dimensions), cross-fund expansion for unscoped impacts, and the soft-closed governed
+  adjustment poster (`IGovernedLedgerAdjustmentPoster`). The report-pack `IRestatementCandidateResolver`
+  is now implemented (`ReportPackRestatementCandidateResolver`, report-line-provenance backed); only
+  period-precise candidate narrowing and a durable security→report-line index remain as refinements.
 
 ### `SecurityProjectionRebuildHandler` (`Order = 10`) / `CoverageInvalidationHandler` (`Order = 20`)
 - Thin, idempotent. `SecurityProjectionRebuildHandler` rebuilds only the edited security via
@@ -572,10 +573,20 @@ PR3 browser UI, PR4 WPF parity.
       The result-bearing period-aware restatement decision is resolved by the command service via
       `IPeriodAwareRestatementResolver` (slice 1), not a void handler.
 - [x] `ILedgerPeriodLockReader` over `ILedgerJournalStore` (authoritative period status, default-deny — Q2).
-- [ ] `IGovernedLedgerAdjustmentPoster` (soft-closed adjustment) + `IRestatementCandidateResolver`
-      (surfaces candidates — Q3; `NullRestatementCandidateResolver` shipped as the no-op default, the
-      real report-pack resolver is deferred); add `ReportingWorkflowService.ProposeRestatement(...)` for
-      the operator-approved restatement step.
+- [~] `IRestatementCandidateResolver` (surfaces candidates — Q3) is now report-pack-backed:
+      `ReportPackRestatementCandidateResolver` (in `Meridian.Ui.Shared`) locates the published packs
+      that consumed the edited security from retained report-line provenance
+      (`SecurityMasterId`/`SecurityDefinitionId`, or a security-kind source) and surfaces them as
+      restatement candidates, and is the registered default; `NullRestatementCandidateResolver` is kept
+      as the no-op fallback for hosts without a report-pack backend. The resolver is scoped to the
+      impacted fund profile (threaded through `IRestatementCandidateResolver.ResolveAsync` from the
+      published event's downstream impact), matches precisely (an untieable pack is left to the
+      hard-closed default-deny manual-locate path, never a false candidate), and the period-aware
+      resolver deduplicates candidates by report across affected books. **Still deferred:**
+      `IGovernedLedgerAdjustmentPoster` (soft-closed adjustment posting), period-precise candidate
+      narrowing (the pack `Period` is a free-form label), and a durable security→report-line index to
+      replace the per-fund scan. `ReportingWorkflowService.Restate(...)` already exists as the
+      operator-approved restatement step the candidates feed.
 - [x] `SecurityMasterRevisionPublishedEvent.AffectedLedgerBookIds` resolved at publish time
       (`IAffectedLedgerBookResolver` / `LedgerBookAffectedResolver`: fund-book granularity from the
       impacted fund profile; empty when there is no ledger exposure or no durable ledger backend).

--- a/docs/plans/security-master-passport-workbench.md
+++ b/docs/plans/security-master-passport-workbench.md
@@ -582,11 +582,16 @@ PR3 browser UI, PR4 WPF parity.
       impacted fund profile (threaded through `IRestatementCandidateResolver.ResolveAsync` from the
       published event's downstream impact), matches precisely (an untieable pack is left to the
       hard-closed default-deny manual-locate path, never a false candidate), and the period-aware
-      resolver deduplicates candidates by report across affected books. **Still deferred:**
-      `IGovernedLedgerAdjustmentPoster` (soft-closed adjustment posting), period-precise candidate
-      narrowing (the pack `Period` is a free-form label), and a durable security→report-line index to
-      replace the per-fund scan. `ReportingWorkflowService.Restate(...)` already exists as the
-      operator-approved restatement step the candidates feed.
+      resolver deduplicates candidates by report across affected books. Only `Published` packs become
+      actionable candidates: an already-`Restated` pack that still references the security is logged for
+      manual attention rather than surfaced, because the workflow only allows `Restated -> Archived` so
+      `Restate(...)` would reject a repeat restatement (the hard-closed default-deny path still flags
+      such books for manual locate). **Still deferred:** repeated-restatement workflow support (so an
+      already-restated pack can be re-restated rather than only logged), `IGovernedLedgerAdjustmentPoster`
+      (soft-closed adjustment posting), period-precise candidate narrowing (the pack `Period` is a
+      free-form label), and a durable security→report-line index to replace the per-fund scan.
+      `ReportingWorkflowService.Restate(...)` already exists as the operator-approved restatement step the
+      candidates feed.
 - [x] `SecurityMasterRevisionPublishedEvent.AffectedLedgerBookIds` resolved at publish time
       (`IAffectedLedgerBookResolver` / `LedgerBookAffectedResolver`: fund-book granularity from the
       impacted fund profile; empty when there is no ledger exposure or no durable ledger backend).

--- a/docs/product/implementation-todo-list.md
+++ b/docs/product/implementation-todo-list.md
@@ -95,6 +95,7 @@ These are documented as implemented evidence, supported foundations, or design-l
 - [ ] Keep the work anchored to the current Security Master detail/passport route and shared read models; do not create a new route for this slice.
 - [ ] Extend the detail flow to cover multi-asset reference-data review, provider evidence, identifier confidence, terms/obligations, projected cash-flow readiness, ledger classification, and operations handoff from the retained Security Master context.
 - [ ] Add focused endpoint, browser, and WPF proof only where the existing Security Master detail flow exposes the new workbench state.
+- [x] Closed-period propagation: replace the no-op restatement candidate resolver with a report-pack-backed `ReportPackRestatementCandidateResolver` that locates the published packs which consumed the edited security (from retained report-line provenance) and surfaces them as governed restatement candidates, so a closed-period reference-data edit no longer always degrades to a manual locate-affected-packs task. Remaining: soft-closed governed-adjustment posting, period-precise candidate narrowing, and a durable security→report-line index.
 
 ## W5X-FINOPS-001 TODOs: Financial Operations Control Center
 

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,7 +5,7 @@
 
 ## Overall Coverage
 
-**2565 / 7186** items documented (**35.7%**) &mdash; Grade: **F**
+**2565 / 7187** items documented (**35.7%**) &mdash; Grade: **F**
 
 ```text
 [=======-------------] 35.7%
@@ -15,7 +15,7 @@
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 2444 | 6691 | 36.5% | F |
+| Public Classes / Interfaces | 2444 | 6692 | 36.5% | F |
 | API Endpoints | 107 | 348 | 30.7% | F |
 | Configuration Options | 3 | 136 | 2.2% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |
@@ -23,7 +23,7 @@
 
 ## Undocumented Items
 
-### Public Classes / Interfaces (4247 undocumented)
+### Public Classes / Interfaces (4248 undocumented)
 
 | Item | Location |
 | ------ | ---------- |
@@ -42,7 +42,8 @@
 | `NullSecurityValidationSnapshotStore` | `src/Meridian.Application/SecurityMaster/FileSecurityValidationSnapshotStore.cs:69` |
 | `PositionCorporateActionAdjustment` | `src/Meridian.Application/SecurityMaster/ILivePositionCorporateActionAdjuster.cs:6` |
 | `SecurityMasterRestatementDecision` | `src/Meridian.Application/SecurityMaster/IPeriodAwareRestatementResolver.cs:32` |
-| `SecurityMasterRevisionRecord` | `src/Meridian.Application/SecurityMaster/ISecurityMasterRevisionStore.cs:50` |
+| `RestatementCandidateResult` | `src/Meridian.Application/SecurityMaster/IPeriodAwareRestatementResolver.cs:44` |
+| `SecurityMasterRevisionRecord` | `src/Meridian.Application/SecurityMaster/ISecurityMasterRevisionStore.cs:52` |
 | `NullSecurityMasterPricingService` | `src/Meridian.Application/SecurityMaster/NullSecurityMasterClearwaterServices.cs:10` |
 | `NullSecurityMasterCashFlowService` | `src/Meridian.Application/SecurityMaster/NullSecurityMasterClearwaterServices.cs:37` |
 | `NullDataVendorEntitlementService` | `src/Meridian.Application/SecurityMaster/NullSecurityMasterClearwaterServices.cs:53` |
@@ -76,8 +77,7 @@
 | `FirstTimeConfigOptions` | `src/Meridian.Application/Services/AutoConfigurationService.cs:977` |
 | `SymbolPreset` | `src/Meridian.Application/Services/AutoConfigurationService.cs:1001` |
 | `WizardResult` | `src/Meridian.Application/Services/ConfigurationWizard.cs:314` |
-| `DataSourceSelection` | `src/Meridian.Application/Services/ConfigurationWizard.cs:323` |
-| ... and 4197 more | |
+| ... and 4198 more | |
 
 ### API Endpoints (241 undocumented)
 
@@ -193,7 +193,7 @@
 
 ## Recommendations
 
-1. **Public Classes / Interfaces**: 4247 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
+1. **Public Classes / Interfaces**: 4248 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
 2. **API Endpoints**: 241 endpoint(s) missing from `docs/reference/api-reference.md`. Run the endpoint audit and update the API reference table.
 3. **Configuration Options**: 133 config key(s) not found in `docs/generated/configuration-schema.md`. Re-run the configuration schema generator to synchronise.
 

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,7 +5,7 @@
 
 ## Overall Coverage
 
-**2564 / 7185** items documented (**35.7%**) &mdash; Grade: **F**
+**2565 / 7186** items documented (**35.7%**) &mdash; Grade: **F**
 
 ```text
 [=======-------------] 35.7%
@@ -15,7 +15,7 @@
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 2443 | 6690 | 36.5% | F |
+| Public Classes / Interfaces | 2444 | 6691 | 36.5% | F |
 | API Endpoints | 107 | 348 | 30.7% | F |
 | Configuration Options | 3 | 136 | 2.2% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 534,
-  "total_lines": 86291,
+  "total_lines": 86316,
   "orphaned_count": 204,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2129,7 +2129,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7235,
+      "line_count": 7237,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -2785,7 +2785,7 @@
     },
     {
       "path": "docs/plans/security-master-passport-workbench.md",
-      "line_count": 702,
+      "line_count": 713,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -3057,7 +3057,7 @@
     },
     {
       "path": "docs/product/implementation-todo-list.md",
-      "line_count": 185,
+      "line_count": 186,
       "has_heading": true,
       "todo_count": 2,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -4321,7 +4321,7 @@
     },
     {
       "path": "src/Meridian.Ui.Shared/README.md",
-      "line_count": 1814,
+      "line_count": 1825,
       "has_heading": true,
       "todo_count": 3,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 534,
-  "total_lines": 86316,
+  "total_lines": 86321,
   "orphaned_count": 204,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2785,7 +2785,7 @@
     },
     {
       "path": "docs/plans/security-master-passport-workbench.md",
-      "line_count": 713,
+      "line_count": 718,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 534 |
-| Total lines | 86,316 |
+| Total lines | 86,321 |
 | Average file size (lines) | 161.6 |
 | Orphaned files | 204 |
 | Files without headings | 38 |

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 534 |
-| Total lines | 86,291 |
+| Total lines | 86,316 |
 | Average file size (lines) | 161.6 |
 | Orphaned files | 204 |
 | Files without headings | 38 |

--- a/src/Meridian.Application/SecurityMaster/IPeriodAwareRestatementResolver.cs
+++ b/src/Meridian.Application/SecurityMaster/IPeriodAwareRestatementResolver.cs
@@ -128,17 +128,14 @@ public sealed class PeriodAwareRestatementResolver : IPeriodAwareRestatementReso
                     break;
 
                 case LedgerPeriodStatusDto.SoftClosed:
-                {
                     // The effect posts as a governed adjustment (later slice). Only already-published
-                    // report packs that consumed the line need restating.
-                    var result = await ResolveCandidatesAsync(publishedEvent, ledgerBookId, effectiveDate, ct).ConfigureAwait(false);
-                    candidates.AddRange(result.Candidates);
-
-                    // A pack that matched but is not an actionable candidate (e.g. already Restated, which
-                    // the workflow cannot re-restate) still needs manual follow-up. Unlike a hard-closed
-                    // book the soft-closed arm does not default-deny, so without this the decision would be
-                    // silently empty for a real match.
-                    if (result.HasNonActionableMatches)
+                    // report packs that consumed the line need restating. A pack that matched but is not
+                    // an actionable candidate (e.g. already Restated, which the workflow cannot re-restate)
+                    // still needs manual follow-up; unlike a hard-closed book the soft-closed arm does not
+                    // default-deny, so without this the decision would be silently empty for a real match.
+                    var softClosed = await ResolveCandidatesAsync(publishedEvent, ledgerBookId, effectiveDate, ct).ConfigureAwait(false);
+                    candidates.AddRange(softClosed.Candidates);
+                    if (softClosed.HasNonActionableMatches)
                     {
                         restatementRequired = true;
                         _logger.LogInformation(
@@ -146,20 +143,17 @@ public sealed class PeriodAwareRestatementResolver : IPeriodAwareRestatementReso
                             publishedEvent.RevisionId, ledgerBookId, effectiveDate);
                     }
                     break;
-                }
 
                 case LedgerPeriodStatusDto.HardClosed:
                 default:
-                {
                     // Hard-closed or any indeterminate/default-deny state: no posting, mandatory proposal.
                     restatementRequired = true;
-                    var result = await ResolveCandidatesAsync(publishedEvent, ledgerBookId, effectiveDate, ct).ConfigureAwait(false);
-                    candidates.AddRange(result.Candidates);
+                    var hardClosed = await ResolveCandidatesAsync(publishedEvent, ledgerBookId, effectiveDate, ct).ConfigureAwait(false);
+                    candidates.AddRange(hardClosed.Candidates);
                     _logger.LogInformation(
                         "Security Master revision {RevisionId} affects hard-closed ledger book {LedgerBookId} at {EffectiveDate}; proposing restatement (no posting).",
                         publishedEvent.RevisionId, ledgerBookId, effectiveDate);
                     break;
-                }
             }
         }
 

--- a/src/Meridian.Application/SecurityMaster/IPeriodAwareRestatementResolver.cs
+++ b/src/Meridian.Application/SecurityMaster/IPeriodAwareRestatementResolver.cs
@@ -34,6 +34,21 @@ public sealed record SecurityMasterRestatementDecision(
     IReadOnlyList<RestatementCandidateDto> Candidates);
 
 /// <summary>
+/// The outcome of locating report packs that consumed a changed line in a locked period: the actionable
+/// restatement <see cref="Candidates"/>, plus <see cref="HasNonActionableMatches"/> — true when at least
+/// one published pack referenced the security but could not be turned into an actionable candidate (for
+/// example an already-restated pack the workflow cannot re-restate). The caller uses the flag to require
+/// a manual follow-up for a soft-closed book even when no actionable candidate was produced, so a real
+/// match is never silently dropped.
+/// </summary>
+public sealed record RestatementCandidateResult(
+    IReadOnlyList<RestatementCandidateDto> Candidates,
+    bool HasNonActionableMatches)
+{
+    public static RestatementCandidateResult Empty { get; } = new([], false);
+}
+
+/// <summary>
 /// Resolves the report packs that consumed a changed line in a locked period covering an upstream
 /// edit, as restatement candidates. <paramref name="fundProfileId"/> scopes the search to the impacted
 /// fund's published packs. An empty result for a hard-closed book is treated by the caller as a manual
@@ -42,7 +57,7 @@ public sealed record SecurityMasterRestatementDecision(
 /// </summary>
 public interface IRestatementCandidateResolver
 {
-    Task<IReadOnlyList<RestatementCandidateDto>> ResolveAsync(
+    Task<RestatementCandidateResult> ResolveAsync(
         Guid securityId,
         Guid ledgerBookId,
         DateOnly effectiveDate,
@@ -59,16 +74,14 @@ public interface IRestatementCandidateResolver
 /// </summary>
 public sealed class NullRestatementCandidateResolver : IRestatementCandidateResolver
 {
-    private static readonly IReadOnlyList<RestatementCandidateDto> Empty = [];
-
-    public Task<IReadOnlyList<RestatementCandidateDto>> ResolveAsync(
+    public Task<RestatementCandidateResult> ResolveAsync(
         Guid securityId,
         Guid ledgerBookId,
         DateOnly effectiveDate,
         IReadOnlyList<string> changedFields,
         string? fundProfileId,
         CancellationToken ct = default)
-        => Task.FromResult(Empty);
+        => Task.FromResult(RestatementCandidateResult.Empty);
 }
 
 /// <summary>
@@ -115,20 +128,38 @@ public sealed class PeriodAwareRestatementResolver : IPeriodAwareRestatementReso
                     break;
 
                 case LedgerPeriodStatusDto.SoftClosed:
+                {
                     // The effect posts as a governed adjustment (later slice). Only already-published
                     // report packs that consumed the line need restating.
-                    candidates.AddRange(await ResolveCandidatesAsync(publishedEvent, ledgerBookId, effectiveDate, ct).ConfigureAwait(false));
+                    var result = await ResolveCandidatesAsync(publishedEvent, ledgerBookId, effectiveDate, ct).ConfigureAwait(false);
+                    candidates.AddRange(result.Candidates);
+
+                    // A pack that matched but is not an actionable candidate (e.g. already Restated, which
+                    // the workflow cannot re-restate) still needs manual follow-up. Unlike a hard-closed
+                    // book the soft-closed arm does not default-deny, so without this the decision would be
+                    // silently empty for a real match.
+                    if (result.HasNonActionableMatches)
+                    {
+                        restatementRequired = true;
+                        _logger.LogInformation(
+                            "Security Master revision {RevisionId} affects soft-closed ledger book {LedgerBookId} at {EffectiveDate} with a matching but non-actionable report pack; flagging manual restatement follow-up.",
+                            publishedEvent.RevisionId, ledgerBookId, effectiveDate);
+                    }
                     break;
+                }
 
                 case LedgerPeriodStatusDto.HardClosed:
                 default:
+                {
                     // Hard-closed or any indeterminate/default-deny state: no posting, mandatory proposal.
                     restatementRequired = true;
-                    candidates.AddRange(await ResolveCandidatesAsync(publishedEvent, ledgerBookId, effectiveDate, ct).ConfigureAwait(false));
+                    var result = await ResolveCandidatesAsync(publishedEvent, ledgerBookId, effectiveDate, ct).ConfigureAwait(false);
+                    candidates.AddRange(result.Candidates);
                     _logger.LogInformation(
                         "Security Master revision {RevisionId} affects hard-closed ledger book {LedgerBookId} at {EffectiveDate}; proposing restatement (no posting).",
                         publishedEvent.RevisionId, ledgerBookId, effectiveDate);
                     break;
+                }
             }
         }
 
@@ -145,7 +176,7 @@ public sealed class PeriodAwareRestatementResolver : IPeriodAwareRestatementReso
             restatementRequired || distinctCandidates.Length > 0, distinctCandidates);
     }
 
-    private Task<IReadOnlyList<RestatementCandidateDto>> ResolveCandidatesAsync(
+    private Task<RestatementCandidateResult> ResolveCandidatesAsync(
         SecurityMasterRevisionPublishedEvent publishedEvent, Guid ledgerBookId, DateOnly effectiveDate, CancellationToken ct)
         => _candidateResolver.ResolveAsync(
             publishedEvent.SecurityId, ledgerBookId, effectiveDate, publishedEvent.ChangedFields,

--- a/src/Meridian.Application/SecurityMaster/IPeriodAwareRestatementResolver.cs
+++ b/src/Meridian.Application/SecurityMaster/IPeriodAwareRestatementResolver.cs
@@ -35,9 +35,10 @@ public sealed record SecurityMasterRestatementDecision(
 
 /// <summary>
 /// Resolves the report packs that consumed a changed line in a locked period covering an upstream
-/// edit, as restatement candidates. The default implementation returns none (report-usage projection
-/// integration is a later slice); an empty result for a hard-closed book is treated as a manual
-/// locate-affected-packs task rather than "no restatement needed".
+/// edit, as restatement candidates. <paramref name="fundProfileId"/> scopes the search to the impacted
+/// fund's published packs. An empty result for a hard-closed book is treated by the caller as a manual
+/// locate-affected-packs task rather than "no restatement needed", so a precise resolver that cannot
+/// tie a published pack to the security never silently completes a closed period.
 /// </summary>
 public interface IRestatementCandidateResolver
 {
@@ -46,10 +47,16 @@ public interface IRestatementCandidateResolver
         Guid ledgerBookId,
         DateOnly effectiveDate,
         IReadOnlyList<string> changedFields,
+        string? fundProfileId,
         CancellationToken ct = default);
 }
 
-/// <summary>Default no-op candidate resolver — surfaces no packs until the report-usage projection is wired.</summary>
+/// <summary>
+/// No-op candidate resolver retained as the fallback for hosts without a report-pack backend. The
+/// report-pack-backed resolver (<c>ReportPackRestatementCandidateResolver</c> in the workstation layer)
+/// is the registered default; this surfaces no packs, leaving the caller's default-deny safety net to
+/// flag a hard-closed book for manual locate.
+/// </summary>
 public sealed class NullRestatementCandidateResolver : IRestatementCandidateResolver
 {
     private static readonly IReadOnlyList<RestatementCandidateDto> Empty = [];
@@ -59,6 +66,7 @@ public sealed class NullRestatementCandidateResolver : IRestatementCandidateReso
         Guid ledgerBookId,
         DateOnly effectiveDate,
         IReadOnlyList<string> changedFields,
+        string? fundProfileId,
         CancellationToken ct = default)
         => Task.FromResult(Empty);
 }
@@ -124,12 +132,22 @@ public sealed class PeriodAwareRestatementResolver : IPeriodAwareRestatementReso
             }
         }
 
-        // Any located candidate (even from a soft-closed book) is a published pack that must be restated.
-        return new SecurityMasterRestatementDecision(restatementRequired || candidates.Count > 0, candidates);
+        // The same fund-scoped published pack can surface from more than one affected ledger book;
+        // collapse to one proposal per report so the operator never sees a duplicate restatement
+        // candidate. Any located candidate (even from a soft-closed book) is a published pack that must
+        // be restated.
+        var distinctCandidates = candidates
+            .GroupBy(static candidate => candidate.ReportId)
+            .Select(static group => group.First())
+            .ToArray();
+
+        return new SecurityMasterRestatementDecision(
+            restatementRequired || distinctCandidates.Length > 0, distinctCandidates);
     }
 
     private Task<IReadOnlyList<RestatementCandidateDto>> ResolveCandidatesAsync(
         SecurityMasterRevisionPublishedEvent publishedEvent, Guid ledgerBookId, DateOnly effectiveDate, CancellationToken ct)
         => _candidateResolver.ResolveAsync(
-            publishedEvent.SecurityId, ledgerBookId, effectiveDate, publishedEvent.ChangedFields, ct);
+            publishedEvent.SecurityId, ledgerBookId, effectiveDate, publishedEvent.ChangedFields,
+            publishedEvent.DownstreamImpact.FundProfileId, ct);
 }

--- a/src/Meridian.Application/SecurityMaster/ISecurityMasterRevisionStore.cs
+++ b/src/Meridian.Application/SecurityMaster/ISecurityMasterRevisionStore.cs
@@ -15,9 +15,10 @@ public interface ISecurityMasterRevisionStore
     Task<SecurityMasterRevisionRecord> CreateDraftAsync(Guid securityId, string actor, CancellationToken ct = default);
 
     /// <summary>
-    /// Creates a Draft revision carrying the field-edit metadata (path, effective date, justification)
-    /// so a later publish can emit the correct effective-from and changed-field set for downstream
-    /// (period-aware / restatement) impact analysis instead of defaulting to publish time.
+    /// Creates a Draft revision carrying the field-edit metadata (path, effective date, justification,
+    /// and the optional fund-profile scope) so a later publish can emit the correct effective-from and
+    /// changed-field set, and resolve the scoped downstream impact, for period-aware / restatement
+    /// analysis instead of defaulting to publish time and an unscoped (empty) impact.
     /// </summary>
     Task<SecurityMasterRevisionRecord> CreateDraftAsync(
         Guid securityId,
@@ -25,6 +26,7 @@ public interface ISecurityMasterRevisionStore
         string fieldPath,
         DateTimeOffset fieldEffectiveFrom,
         string fieldJustification,
+        string? fundProfileId = null,
         CancellationToken ct = default);
 
     /// <summary>Returns the revision, or <c>null</c> when no revision with that id exists.</summary>
@@ -57,7 +59,8 @@ public sealed record SecurityMasterRevisionRecord(
     Guid? WorkflowId = null,
     string? FieldPath = null,
     DateTimeOffset? FieldEffectiveFrom = null,
-    string? FieldJustification = null);
+    string? FieldJustification = null,
+    string? FundProfileId = null);
 
 /// <summary>
 /// Raised when a revision lifecycle transition is attempted out of order — e.g. publishing a revision
@@ -84,7 +87,7 @@ public sealed class InMemorySecurityMasterRevisionStore : ISecurityMasterRevisio
     private readonly ConcurrentDictionary<Guid, SecurityMasterRevisionRecord> _revisions = new();
 
     public Task<SecurityMasterRevisionRecord> CreateDraftAsync(Guid securityId, string actor, CancellationToken ct = default)
-        => CreateDraftCore(securityId, actor, fieldPath: null, fieldEffectiveFrom: null, fieldJustification: null);
+        => CreateDraftCore(securityId, actor, fieldPath: null, fieldEffectiveFrom: null, fieldJustification: null, fundProfileId: null);
 
     public Task<SecurityMasterRevisionRecord> CreateDraftAsync(
         Guid securityId,
@@ -92,15 +95,17 @@ public sealed class InMemorySecurityMasterRevisionStore : ISecurityMasterRevisio
         string fieldPath,
         DateTimeOffset fieldEffectiveFrom,
         string fieldJustification,
+        string? fundProfileId = null,
         CancellationToken ct = default)
-        => CreateDraftCore(securityId, actor, fieldPath, fieldEffectiveFrom, fieldJustification);
+        => CreateDraftCore(securityId, actor, fieldPath, fieldEffectiveFrom, fieldJustification, fundProfileId);
 
     private Task<SecurityMasterRevisionRecord> CreateDraftCore(
         Guid securityId,
         string actor,
         string? fieldPath,
         DateTimeOffset? fieldEffectiveFrom,
-        string? fieldJustification)
+        string? fieldJustification,
+        string? fundProfileId)
     {
         var now = DateTimeOffset.UtcNow;
         var record = new SecurityMasterRevisionRecord(
@@ -113,7 +118,8 @@ public sealed class InMemorySecurityMasterRevisionStore : ISecurityMasterRevisio
             WorkflowId: null,
             FieldPath: fieldPath,
             FieldEffectiveFrom: fieldEffectiveFrom,
-            FieldJustification: fieldJustification);
+            FieldJustification: fieldJustification,
+            FundProfileId: string.IsNullOrWhiteSpace(fundProfileId) ? null : fundProfileId.Trim());
         _revisions[record.RevisionId] = record;
         return Task.FromResult(record);
     }

--- a/src/Meridian.Application/SecurityMaster/SecurityMasterWorkbenchCommandService.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterWorkbenchCommandService.cs
@@ -125,8 +125,13 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
         // (submit → approve → publish) is anchored to a real, server-issued revision id, and publish
         // can later emit the correct effective-date and changed-field set for downstream impact
         // analysis rather than defaulting to publish time.
+        // Persist the edit's optional fund-profile scope on the draft so publish can resolve a SCOPED
+        // downstream impact (and therefore real affected ledger books + restatement candidates). Without
+        // it, publish falls back to an unscoped impact whose empty affected-book set short-circuits the
+        // period-aware restatement path to "no restatement".
         var revision = await _revisions.CreateDraftAsync(
-            request.SecurityId, request.Actor, request.FieldPath, request.EffectiveFrom, request.Justification, ct)
+            request.SecurityId, request.Actor, request.FieldPath, request.EffectiveFrom, request.Justification,
+            request.FundProfileId, ct)
             .ConfigureAwait(false);
 
         _logger.LogInformation(
@@ -406,8 +411,13 @@ public sealed class SecurityMasterWorkbenchCommandService : ISecurityMasterWorkb
 
         var currentVersion = await GetCurrentVersionAsync(request.SecurityId, ct).ConfigureAwait(false);
 
+        // Scope the downstream-impact computation to the fund profile the edit was made under (carried
+        // on the draft revision), so affected ledger books and report-pack restatement candidates can be
+        // resolved. A null/blank scope (edit made without a fund context) yields an unscoped impact and
+        // the period-aware path reports no restatement — the cross-fund/multi-fund activation case is a
+        // later slice.
         var snapshot = await _queryService
-            .GetTrustSnapshotAsync(request.SecurityId, fundProfileId: null, ct)
+            .GetTrustSnapshotAsync(request.SecurityId, fundProfileId: revision.FundProfileId, ct)
             .ConfigureAwait(false);
 
         var downstreamImpact = snapshot?.DownstreamImpact ?? EmptyDownstreamImpact();

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -1254,6 +1254,17 @@ shared service instead of client code.
 The same normalization assigns each retained line a Financial Record Explorer id and
 `/api/workstation/financial-record-explorers/{explorerId}` href so browser and WPF clients can open
 the source-backed ledger, portfolio, or Security & Instrument Explorer without deriving routes.
+That retained report-line provenance also backs the Security Master Passport Workbench's
+closed-period restatement path: `ReportPackRestatementCandidateResolver` implements the
+application-layer `IRestatementCandidateResolver`, so when a governed reference-data edit publishes
+into a locked accounting period it locates the published packs that consumed the edited security
+(by retained `SecurityMasterId`/`SecurityDefinitionId` or a security-kind provenance source, scoped
+to the impacted fund profile) and surfaces them as governed restatement candidates the operator
+approves through `Restate(...)`. It is the registered default; `NullRestatementCandidateResolver`
+remains the no-op fallback for hosts without a report-pack backend. Matching is precise — an
+untieable published pack is left to the period-aware resolver's hard-closed default-deny
+manual-locate path rather than surfaced as a false candidate — and candidates are deduplicated by
+report across affected ledger books.
 Generated governed report packs enrich line-level provenance with display labels,
 source-system tags, related ledger and journal evidence IDs, line amounts, latest evidence
 timestamps, and API routes back to run continuity, ledger trial-balance, reconciliation, and

--- a/src/Meridian.Ui.Shared/Services/ReportPackRestatementCandidateResolver.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportPackRestatementCandidateResolver.cs
@@ -123,9 +123,8 @@ public sealed class ReportPackRestatementCandidateResolver : IRestatementCandida
             return [];
         }
 
-        var securityKey = securityId.ToString("D");
         return provenance
-            .Where(line => LineReferencesSecurity(line, securityKey))
+            .Where(line => LineReferencesSecurity(line, securityId))
             .Select(line => new ReportPackChangedLineDto(
                 LineKey: line.LineKey,
                 PreviousValue: line.ReportValue ?? string.Empty,
@@ -140,15 +139,15 @@ public sealed class ReportPackRestatementCandidateResolver : IRestatementCandida
             .ToArray();
     }
 
-    private static bool LineReferencesSecurity(ReportPackLineProvenanceDto line, string securityKey)
-        => MatchesSecurity(line.SecurityMasterId, securityKey)
-           || MatchesSecurity(line.SecurityDefinitionId, securityKey)
-           || (ContainsToken(line.SourceKind, "security") && MatchesSecurity(line.SourceId, securityKey));
+    private static bool LineReferencesSecurity(ReportPackLineProvenanceDto line, Guid securityId)
+        => MatchesSecurity(line.SecurityMasterId, securityId)
+           || MatchesSecurity(line.SecurityDefinitionId, securityId)
+           || (ContainsToken(line.SourceKind, "security") && MatchesSecurity(line.SourceId, securityId));
 
-    private static bool MatchesSecurity(string? value, string securityKey)
+    private static bool MatchesSecurity(string? value, Guid securityId)
         => !string.IsNullOrWhiteSpace(value)
            && Guid.TryParse(value, out var parsed)
-           && parsed.ToString("D").Equals(securityKey, StringComparison.OrdinalIgnoreCase);
+           && parsed == securityId;
 
     private static bool ContainsToken(string? value, string token)
         => !string.IsNullOrWhiteSpace(value)

--- a/src/Meridian.Ui.Shared/Services/ReportPackRestatementCandidateResolver.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportPackRestatementCandidateResolver.cs
@@ -16,19 +16,28 @@ namespace Meridian.Ui.Shared.Services;
 /// hard-closed book with report exposure no longer always degrades to a manual "locate affected packs"
 /// task.</para>
 ///
-/// <para><b>Matching.</b> A pack is a candidate when it is in a live published state
-/// (<see cref="ReportPackWorkflowStateDto.Published"/> or <see cref="ReportPackWorkflowStateDto.Restated"/>),
-/// is scoped to the impacted fund profile, and carries a retained report-line provenance entry tying a
-/// line to this security (by <c>SecurityMasterId</c>/<c>SecurityDefinitionId</c>, or a security-kind
-/// source whose id is the security). Matching is precise on purpose: a published pack that cannot be
-/// tied to the security is left to the caller's default-deny safety net (a hard-closed book still
-/// reports <see cref="SecurityMasterRestatementDecision.RestatementRequired"/> with a manual locate
-/// task), so a genuine miss is never silently completed.</para>
+/// <para><b>Matching.</b> A pack is an actionable candidate when it is in the live
+/// <see cref="ReportPackWorkflowStateDto.Published"/> state, is scoped to the impacted fund profile, and
+/// carries a retained report-line provenance entry tying a line to this security (by
+/// <c>SecurityMasterId</c>/<c>SecurityDefinitionId</c>, or a security-kind source whose id is the
+/// security). Matching is precise on purpose: a published pack that cannot be tied to the security is
+/// left to the caller's default-deny safety net (a hard-closed book still reports
+/// <see cref="SecurityMasterRestatementDecision.RestatementRequired"/> with a manual locate task), so a
+/// genuine miss is never silently completed.</para>
 ///
-/// <para><b>Deferred</b> to later slices: narrowing candidates to the specific reporting period
-/// covering the edit's effective date (the pack <c>Period</c> is a free-form label, so period-precise
-/// filtering is not yet safe and over-inclusion stays operator-reviewed); soft-closed governed-adjustment
-/// posting; and a durable security→report-line index that would replace this per-fund scan.</para>
+/// <para><b>Already-restated packs.</b> A pack already in <see cref="ReportPackWorkflowStateDto.Restated"/>
+/// that still references the security is deliberately NOT returned as a candidate: the workflow only
+/// permits <c>Restated -&gt; Archived</c>, so <see cref="ReportPackWorkflowService.Restate"/> (which
+/// transitions to <c>Restated</c>) would reject a repeat restatement as an invalid transition — a
+/// candidate the operator could not act on. Such a match is instead logged for manual attention rather
+/// than silently dropped. Supporting repeated restatement is a deferred report-pack workflow change.</para>
+///
+/// <para><b>Deferred</b> to later slices: repeated-restatement workflow support (so an already-restated
+/// pack can be re-restated instead of only logged); narrowing candidates to the specific reporting
+/// period covering the edit's effective date (the pack <c>Period</c> is a free-form label, so
+/// period-precise filtering is not yet safe and over-inclusion stays operator-reviewed); soft-closed
+/// governed-adjustment posting; and a durable security→report-line index that would replace this
+/// per-fund scan.</para>
 /// </summary>
 public sealed class ReportPackRestatementCandidateResolver : IRestatementCandidateResolver
 {
@@ -73,8 +82,11 @@ public sealed class ReportPackRestatementCandidateResolver : IRestatementCandida
             ct.ThrowIfCancellationRequested();
 
             // Only a live published output can require a restatement; drafts, in-review, approved, and
-            // archived/rejected packs are not published numbers consumers rely on.
-            if (record.State is not (ReportPackWorkflowStateDto.Published or ReportPackWorkflowStateDto.Restated))
+            // archived/rejected packs are not published numbers consumers rely on. An already-Restated
+            // pack is handled separately below — it is live but cannot be re-restated through the workflow.
+            var isPublished = record.State == ReportPackWorkflowStateDto.Published;
+            var isRestated = record.State == ReportPackWorkflowStateDto.Restated;
+            if (!isPublished && !isRestated)
             {
                 continue;
             }
@@ -82,6 +94,19 @@ public sealed class ReportPackRestatementCandidateResolver : IRestatementCandida
             var matchedLines = MatchSecurityLines(record, securityId);
             if (matchedLines.Count == 0)
             {
+                continue;
+            }
+
+            if (isRestated)
+            {
+                // The pack references the security but is already Restated; the workflow only allows
+                // Restated -> Archived, so Restate(...) would throw "invalid transition Restated ->
+                // Restated". Surfacing it as a candidate would hand the operator an unusable action, and
+                // dropping it silently would hide a genuinely affected published output. Log it for
+                // manual attention instead. (Repeated restatement is a deferred workflow change.)
+                _logger.LogWarning(
+                    "Report pack {ReportId} (period {Period}) consumed security {SecurityId} but is already in the Restated state; repeated restatement is not supported (Restated -> Archived only), so it is surfaced for manual review rather than as an actionable restatement candidate.",
+                    record.ReportId, record.Period, securityId);
                 continue;
             }
 
@@ -112,8 +137,11 @@ public sealed class ReportPackRestatementCandidateResolver : IRestatementCandida
     /// The retained report-line provenance entries on <paramref name="record"/> that tie a line to the
     /// edited security, projected into proposed changed lines. The proposal carries the line's retained
     /// report value (as both previous and current, since the restated value is the operator's to enter)
-    /// and forwards the provenance evidence id so the operator's later <see cref="ReportPackWorkflowService.Restate"/>
-    /// call can satisfy its evidence requirement.
+    /// and forwards the provenance evidence id <b>when the line has one</b>, giving the operator a head
+    /// start on <see cref="ReportPackWorkflowService.Restate"/>'s evidence requirement. These changed
+    /// lines are a proposal: the operator still supplies the final restated values and any missing
+    /// evidence links when invoking <c>Restate(...)</c>, which re-validates that every changed line
+    /// carries evidence.
     /// </summary>
     private static IReadOnlyList<ReportPackChangedLineDto> MatchSecurityLines(
         ReportPackWorkflowRecordDto record, Guid securityId)

--- a/src/Meridian.Ui.Shared/Services/ReportPackRestatementCandidateResolver.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportPackRestatementCandidateResolver.cs
@@ -1,0 +1,156 @@
+using Meridian.Application.SecurityMaster;
+using Meridian.Contracts.Workstation;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Ui.Shared.Services;
+
+/// <summary>
+/// Report-pack-backed <see cref="IRestatementCandidateResolver"/> for the Security Master Passport
+/// Workbench's closed-period restatement path (Phase 3). When a governed reference-data edit publishes
+/// into a locked accounting period, this resolver locates the published report packs that consumed the
+/// edited security and surfaces them as restatement <i>candidates</i>. The operator approves each via
+/// <see cref="ReportPackWorkflowService.Restate"/>; the workbench only proposes — it never mutates a
+/// published number.
+///
+/// <para>This replaces <see cref="NullRestatementCandidateResolver"/> as the registered default, so a
+/// hard-closed book with report exposure no longer always degrades to a manual "locate affected packs"
+/// task.</para>
+///
+/// <para><b>Matching.</b> A pack is a candidate when it is in a live published state
+/// (<see cref="ReportPackWorkflowStateDto.Published"/> or <see cref="ReportPackWorkflowStateDto.Restated"/>),
+/// is scoped to the impacted fund profile, and carries a retained report-line provenance entry tying a
+/// line to this security (by <c>SecurityMasterId</c>/<c>SecurityDefinitionId</c>, or a security-kind
+/// source whose id is the security). Matching is precise on purpose: a published pack that cannot be
+/// tied to the security is left to the caller's default-deny safety net (a hard-closed book still
+/// reports <see cref="SecurityMasterRestatementDecision.RestatementRequired"/> with a manual locate
+/// task), so a genuine miss is never silently completed.</para>
+///
+/// <para><b>Deferred</b> to later slices: narrowing candidates to the specific reporting period
+/// covering the edit's effective date (the pack <c>Period</c> is a free-form label, so period-precise
+/// filtering is not yet safe and over-inclusion stays operator-reviewed); soft-closed governed-adjustment
+/// posting; and a durable security→report-line index that would replace this per-fund scan.</para>
+/// </summary>
+public sealed class ReportPackRestatementCandidateResolver : IRestatementCandidateResolver
+{
+    private readonly ReportPackWorkflowService _reportPackWorkflow;
+    private readonly ILogger<ReportPackRestatementCandidateResolver> _logger;
+
+    public ReportPackRestatementCandidateResolver(
+        ReportPackWorkflowService reportPackWorkflow,
+        ILogger<ReportPackRestatementCandidateResolver> logger)
+    {
+        _reportPackWorkflow = reportPackWorkflow ?? throw new ArgumentNullException(nameof(reportPackWorkflow));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Task<IReadOnlyList<RestatementCandidateDto>> ResolveAsync(
+        Guid securityId,
+        Guid ledgerBookId,
+        DateOnly effectiveDate,
+        IReadOnlyList<string> changedFields,
+        string? fundProfileId,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(fundProfileId))
+        {
+            // Without a fund scope the published packs cannot be narrowed. The caller's default-deny
+            // path still flags a hard-closed book for manual locate, so this is not a silent miss.
+            _logger.LogWarning(
+                "Restatement candidates for security {SecurityId} could not be located: the published revision has no fund profile scope.",
+                securityId);
+            return Task.FromResult<IReadOnlyList<RestatementCandidateDto>>([]);
+        }
+
+        var changedFieldSummary = changedFields.Count == 0
+            ? "reference data"
+            : string.Join(", ", changedFields);
+
+        var candidates = new List<RestatementCandidateDto>();
+        foreach (var record in _reportPackWorkflow.ListRecordsForFundProfile(fundProfileId))
+        {
+            ct.ThrowIfCancellationRequested();
+
+            // Only a live published output can require a restatement; drafts, in-review, approved, and
+            // archived/rejected packs are not published numbers consumers rely on.
+            if (record.State is not (ReportPackWorkflowStateDto.Published or ReportPackWorkflowStateDto.Restated))
+            {
+                continue;
+            }
+
+            var matchedLines = MatchSecurityLines(record, securityId);
+            if (matchedLines.Count == 0)
+            {
+                continue;
+            }
+
+            candidates.Add(new RestatementCandidateDto(
+                ReportId: record.ReportId,
+                // A restatement publishes the next version of the same report, so the currently published
+                // record is the prior version the operator restates from.
+                PriorVersionReportId: record.ReportId,
+                PeriodLabel: record.Period,
+                Summary:
+                    $"Published report pack {record.ReportId:D} for period {record.Period} has " +
+                    $"{matchedLines.Count} line(s) sourced from security {securityId:D}; the governed edit to " +
+                    $"{changedFieldSummary} (effective {effectiveDate:yyyy-MM-dd}) may require a restatement.",
+                ChangedLines: matchedLines));
+        }
+
+        if (candidates.Count > 0)
+        {
+            _logger.LogInformation(
+                "Located {CandidateCount} report-pack restatement candidate(s) for security {SecurityId} in fund profile {FundProfileId}.",
+                candidates.Count, securityId, fundProfileId);
+        }
+
+        return Task.FromResult<IReadOnlyList<RestatementCandidateDto>>(candidates);
+    }
+
+    /// <summary>
+    /// The retained report-line provenance entries on <paramref name="record"/> that tie a line to the
+    /// edited security, projected into proposed changed lines. The proposal carries the line's retained
+    /// report value (as both previous and current, since the restated value is the operator's to enter)
+    /// and forwards the provenance evidence id so the operator's later <see cref="ReportPackWorkflowService.Restate"/>
+    /// call can satisfy its evidence requirement.
+    /// </summary>
+    private static IReadOnlyList<ReportPackChangedLineDto> MatchSecurityLines(
+        ReportPackWorkflowRecordDto record, Guid securityId)
+    {
+        if (record.LineProvenance is not { Count: > 0 } provenance)
+        {
+            return [];
+        }
+
+        var securityKey = securityId.ToString("D");
+        return provenance
+            .Where(line => LineReferencesSecurity(line, securityKey))
+            .Select(line => new ReportPackChangedLineDto(
+                LineKey: line.LineKey,
+                PreviousValue: line.ReportValue ?? string.Empty,
+                CurrentValue: line.ReportValue ?? string.Empty,
+                EvidenceLinks: string.IsNullOrWhiteSpace(line.EvidenceId)
+                    ? null
+                    : [new ReportPackEvidenceLinkDto(
+                        EvidenceId: line.EvidenceId,
+                        Label: $"Report-line provenance for {line.LineKey}",
+                        Route: line.FinancialRecordHref,
+                        Source: string.IsNullOrWhiteSpace(line.SourceKind) ? "report-line-provenance" : line.SourceKind)]))
+            .ToArray();
+    }
+
+    private static bool LineReferencesSecurity(ReportPackLineProvenanceDto line, string securityKey)
+        => MatchesSecurity(line.SecurityMasterId, securityKey)
+           || MatchesSecurity(line.SecurityDefinitionId, securityKey)
+           || (ContainsToken(line.SourceKind, "security") && MatchesSecurity(line.SourceId, securityKey));
+
+    private static bool MatchesSecurity(string? value, string securityKey)
+        => !string.IsNullOrWhiteSpace(value)
+           && Guid.TryParse(value, out var parsed)
+           && parsed.ToString("D").Equals(securityKey, StringComparison.OrdinalIgnoreCase);
+
+    private static bool ContainsToken(string? value, string token)
+        => !string.IsNullOrWhiteSpace(value)
+           && value.Contains(token, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Meridian.Ui.Shared/Services/ReportPackRestatementCandidateResolver.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportPackRestatementCandidateResolver.cs
@@ -52,7 +52,7 @@ public sealed class ReportPackRestatementCandidateResolver : IRestatementCandida
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public Task<IReadOnlyList<RestatementCandidateDto>> ResolveAsync(
+    public Task<RestatementCandidateResult> ResolveAsync(
         Guid securityId,
         Guid ledgerBookId,
         DateOnly effectiveDate,
@@ -69,7 +69,7 @@ public sealed class ReportPackRestatementCandidateResolver : IRestatementCandida
             _logger.LogWarning(
                 "Restatement candidates for security {SecurityId} could not be located: the published revision has no fund profile scope.",
                 securityId);
-            return Task.FromResult<IReadOnlyList<RestatementCandidateDto>>([]);
+            return Task.FromResult(RestatementCandidateResult.Empty);
         }
 
         var changedFieldSummary = changedFields.Count == 0
@@ -77,6 +77,7 @@ public sealed class ReportPackRestatementCandidateResolver : IRestatementCandida
             : string.Join(", ", changedFields);
 
         var candidates = new List<RestatementCandidateDto>();
+        var hasNonActionableMatches = false;
         foreach (var record in _reportPackWorkflow.ListRecordsForFundProfile(fundProfileId))
         {
             ct.ThrowIfCancellationRequested();
@@ -104,6 +105,7 @@ public sealed class ReportPackRestatementCandidateResolver : IRestatementCandida
                 // Restated". Surfacing it as a candidate would hand the operator an unusable action, and
                 // dropping it silently would hide a genuinely affected published output. Log it for
                 // manual attention instead. (Repeated restatement is a deferred workflow change.)
+                hasNonActionableMatches = true;
                 _logger.LogWarning(
                     "Report pack {ReportId} (period {Period}) consumed security {SecurityId} but is already in the Restated state; repeated restatement is not supported (Restated -> Archived only), so it is surfaced for manual review rather than as an actionable restatement candidate.",
                     record.ReportId, record.Period, securityId);
@@ -130,7 +132,7 @@ public sealed class ReportPackRestatementCandidateResolver : IRestatementCandida
                 candidates.Count, securityId, fundProfileId);
         }
 
-        return Task.FromResult<IReadOnlyList<RestatementCandidateDto>>(candidates);
+        return Task.FromResult(new RestatementCandidateResult(candidates, hasNonActionableMatches));
     }
 
     /// <summary>

--- a/src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs
@@ -1347,6 +1347,24 @@ public sealed class ReportPackWorkflowService
             .Take(Math.Clamp(limit, 1, 200))
             .ToArray();
 
+    /// <summary>
+    /// Every retained report-pack record scoped to a fund profile, newest period first. Unlike
+    /// <see cref="ListRecords"/> this is intentionally uncapped: callers that locate restatement
+    /// candidates for a closed-period reference-data edit must see the full set of the fund's published
+    /// packs, since a silently dropped pack would be a missed restatement.
+    /// </summary>
+    public IReadOnlyList<ReportPackWorkflowRecordDto> ListRecordsForFundProfile(string fundProfileId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fundProfileId);
+        var key = fundProfileId.Trim();
+        return _records.Values
+            .Where(record => string.Equals(record.FundProfileId, key, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(static record => record.Period, StringComparer.OrdinalIgnoreCase)
+            .ThenByDescending(static record => record.Version)
+            .ThenBy(static record => record.ReportId)
+            .ToArray();
+    }
+
     private void PersistRecords()
     {
         _store?.Save(_records.Values.ToArray());

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -240,13 +240,15 @@ public static class WorkstationServiceCollectionExtensions
         // Phase 3 period-aware propagation: the ledger accounting-period status is the lock
         // authority (default-deny → HardClosed when indeterminate). The restatement resolver routes a
         // closed-period edit into a governed restatement proposal rather than a silent mutation; the
-        // candidate resolver (report-pack locating) defaults to no-op until the report-usage projection lands.
+        // candidate resolver locates the published report packs that consumed the edited security from
+        // retained report-line provenance (ReportPackRestatementCandidateResolver), falling back to the
+        // no-op NullRestatementCandidateResolver only where no report-pack workflow backend is present.
         services.TryAddScoped<
             Meridian.Application.SecurityMaster.ILedgerPeriodLockReader,
             Meridian.Application.SecurityMaster.LedgerPeriodLockReader>();
         services.TryAddScoped<
             Meridian.Application.SecurityMaster.IRestatementCandidateResolver,
-            Meridian.Application.SecurityMaster.NullRestatementCandidateResolver>();
+            ReportPackRestatementCandidateResolver>();
         services.TryAddScoped<
             Meridian.Application.SecurityMaster.IPeriodAwareRestatementResolver,
             Meridian.Application.SecurityMaster.PeriodAwareRestatementResolver>();

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/PeriodAwareRestatementResolverTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/PeriodAwareRestatementResolverTests.cs
@@ -99,6 +99,20 @@ public sealed class PeriodAwareRestatementResolverTests
         decision.RestatementRequired.Should().BeTrue("any hard-closed affected book forces a restatement proposal");
     }
 
+    [Fact]
+    public async Task MultipleBooks_SameFundCandidate_IsDeduplicatedByReport()
+    {
+        // The candidate resolver locates fund-scoped published packs, so the same report surfaces from
+        // every affected book; the decision must collapse them to one proposal per report.
+        var candidate = Candidate();
+        var resolver = NewResolver(new FakeLockReader(_ => LedgerPeriodStatusDto.HardClosed), Candidates(candidate));
+
+        var decision = await resolver.ResolveAsync(Event(affectedBooks: [BookA, BookB]));
+
+        decision.RestatementRequired.Should().BeTrue();
+        decision.Candidates.Should().ContainSingle().Which.Should().Be(candidate);
+    }
+
     // ---- helpers ------------------------------------------------------------------------------
 
     private static PeriodAwareRestatementResolver NewResolver(
@@ -162,7 +176,8 @@ public sealed class PeriodAwareRestatementResolverTests
         public FakeCandidateResolver(IReadOnlyList<RestatementCandidateDto> candidates) => _candidates = candidates;
 
         public Task<IReadOnlyList<RestatementCandidateDto>> ResolveAsync(
-            Guid securityId, Guid ledgerBookId, DateOnly effectiveDate, IReadOnlyList<string> changedFields, CancellationToken ct = default)
+            Guid securityId, Guid ledgerBookId, DateOnly effectiveDate, IReadOnlyList<string> changedFields,
+            string? fundProfileId, CancellationToken ct = default)
             => Task.FromResult(_candidates);
     }
 }

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/PeriodAwareRestatementResolverTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/PeriodAwareRestatementResolverTests.cs
@@ -89,6 +89,23 @@ public sealed class PeriodAwareRestatementResolverTests
     }
 
     [Fact]
+    public async Task SoftClosedPeriod_NonActionableMatch_FlagsManualRestatement()
+    {
+        // A soft-closed book whose only match is non-actionable (e.g. already-restated, which the workflow
+        // cannot re-restate) must still be flagged for manual follow-up rather than reported as no
+        // restatement. The soft-closed arm does not default-deny, so this relies on the resolver's
+        // HasNonActionableMatches signal.
+        var resolver = NewResolver(
+            new FakeLockReader(_ => LedgerPeriodStatusDto.SoftClosed),
+            new FakeCandidateResolver([], hasNonActionableMatches: true));
+
+        var decision = await resolver.ResolveAsync(Event(affectedBooks: [BookA]));
+
+        decision.RestatementRequired.Should().BeTrue("a soft-closed non-actionable match still needs manual follow-up");
+        decision.Candidates.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task MultipleBooks_OneHardClosed_AggregatesToRestatementRequired()
     {
         var lockReader = new FakeLockReader(book => book == BookB ? LedgerPeriodStatusDto.HardClosed : LedgerPeriodStatusDto.Open);
@@ -173,11 +190,17 @@ public sealed class PeriodAwareRestatementResolverTests
     private sealed class FakeCandidateResolver : IRestatementCandidateResolver
     {
         private readonly IReadOnlyList<RestatementCandidateDto> _candidates;
-        public FakeCandidateResolver(IReadOnlyList<RestatementCandidateDto> candidates) => _candidates = candidates;
+        private readonly bool _hasNonActionableMatches;
 
-        public Task<IReadOnlyList<RestatementCandidateDto>> ResolveAsync(
+        public FakeCandidateResolver(IReadOnlyList<RestatementCandidateDto> candidates, bool hasNonActionableMatches = false)
+        {
+            _candidates = candidates;
+            _hasNonActionableMatches = hasNonActionableMatches;
+        }
+
+        public Task<RestatementCandidateResult> ResolveAsync(
             Guid securityId, Guid ledgerBookId, DateOnly effectiveDate, IReadOnlyList<string> changedFields,
             string? fundProfileId, CancellationToken ct = default)
-            => Task.FromResult(_candidates);
+            => Task.FromResult(new RestatementCandidateResult(_candidates, _hasNonActionableMatches));
     }
 }

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPackRestatementCandidateResolverTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPackRestatementCandidateResolverTests.cs
@@ -82,15 +82,18 @@ public sealed class ReportPackRestatementCandidateResolverTests
     }
 
     [Fact]
-    public async Task RestatedPackReferencingSecurity_IsACandidate()
+    public async Task RestatedPackReferencingSecurity_IsNotAnActionableCandidate()
     {
+        // An already-Restated pack cannot be re-restated (workflow allows Restated -> Archived only), so
+        // surfacing it as a candidate would hand the operator an action Restate() rejects. It is logged
+        // for manual attention instead of returned as a candidate.
         var resolver = NewResolver(
             PackInState(ReportPackWorkflowStateDto.Restated, FundProfileId, "2026-P02", SecurityLine("line-1", SecurityId)));
 
         var candidates = await resolver.ResolveAsync(
             SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
 
-        candidates.Should().ContainSingle("a restated pack is still the live published version");
+        candidates.Should().BeEmpty("a Restated pack is not actionable through Restate() and must not be a candidate");
     }
 
     [Fact]

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPackRestatementCandidateResolverTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPackRestatementCandidateResolverTests.cs
@@ -24,10 +24,11 @@ public sealed class ReportPackRestatementCandidateResolverTests
         var resolver = NewResolver(
             PublishedPack(FundProfileId, "2026-P03", SecurityLine("line-1", SecurityId)));
 
-        var candidates = await resolver.ResolveAsync(
+        var result = await resolver.ResolveAsync(
             SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], fundProfileId: null);
 
-        candidates.Should().BeEmpty("without a fund scope the published packs cannot be narrowed");
+        result.Candidates.Should().BeEmpty("without a fund scope the published packs cannot be narrowed");
+        result.HasNonActionableMatches.Should().BeFalse();
     }
 
     [Fact]
@@ -36,13 +37,14 @@ public sealed class ReportPackRestatementCandidateResolverTests
         var resolver = NewResolver(
             PublishedPack(FundProfileId, "2026-P03", SecurityLine("nav.line", SecurityId)));
 
-        var candidates = await resolver.ResolveAsync(
+        var result = await resolver.ResolveAsync(
             SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
 
-        candidates.Should().ContainSingle();
-        var candidate = candidates[0];
+        result.Candidates.Should().ContainSingle();
+        var candidate = result.Candidates[0];
         candidate.PeriodLabel.Should().Be("2026-P03");
         candidate.ChangedLines.Should().ContainSingle().Which.LineKey.Should().Be("nav.line");
+        result.HasNonActionableMatches.Should().BeFalse();
     }
 
     [Fact]
@@ -51,10 +53,10 @@ public sealed class ReportPackRestatementCandidateResolverTests
         var resolver = NewResolver(
             PublishedPack(FundProfileId, "2026-P03", SecurityLine("line-1", OtherSecurityId)));
 
-        var candidates = await resolver.ResolveAsync(
+        var result = await resolver.ResolveAsync(
             SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
 
-        candidates.Should().BeEmpty("the pack's provenance ties its line to a different security");
+        result.Candidates.Should().BeEmpty("the pack's provenance ties its line to a different security");
     }
 
     [Fact]
@@ -63,10 +65,10 @@ public sealed class ReportPackRestatementCandidateResolverTests
         var resolver = NewResolver(
             PublishedPack("fund-beta", "2026-P03", SecurityLine("line-1", SecurityId)));
 
-        var candidates = await resolver.ResolveAsync(
+        var result = await resolver.ResolveAsync(
             SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
 
-        candidates.Should().BeEmpty("only the impacted fund's packs are in scope");
+        result.Candidates.Should().BeEmpty("only the impacted fund's packs are in scope");
     }
 
     [Fact]
@@ -75,25 +77,28 @@ public sealed class ReportPackRestatementCandidateResolverTests
         var resolver = NewResolver(
             PackInState(ReportPackWorkflowStateDto.Approved, FundProfileId, "2026-P03", SecurityLine("line-1", SecurityId)));
 
-        var candidates = await resolver.ResolveAsync(
+        var result = await resolver.ResolveAsync(
             SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
 
-        candidates.Should().BeEmpty("only a live published output can require a restatement");
+        result.Candidates.Should().BeEmpty("only a live published output can require a restatement");
+        result.HasNonActionableMatches.Should().BeFalse("an approved (not yet published) pack is not a live output to flag");
     }
 
     [Fact]
     public async Task RestatedPackReferencingSecurity_IsNotAnActionableCandidate()
     {
         // An already-Restated pack cannot be re-restated (workflow allows Restated -> Archived only), so
-        // surfacing it as a candidate would hand the operator an action Restate() rejects. It is logged
-        // for manual attention instead of returned as a candidate.
+        // surfacing it as a candidate would hand the operator an action Restate() rejects. It is reported
+        // as a non-actionable match (logged, and a manual-follow-up signal to the caller) rather than a
+        // candidate or a silent drop.
         var resolver = NewResolver(
             PackInState(ReportPackWorkflowStateDto.Restated, FundProfileId, "2026-P02", SecurityLine("line-1", SecurityId)));
 
-        var candidates = await resolver.ResolveAsync(
+        var result = await resolver.ResolveAsync(
             SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
 
-        candidates.Should().BeEmpty("a Restated pack is not actionable through Restate() and must not be a candidate");
+        result.Candidates.Should().BeEmpty("a Restated pack is not actionable through Restate() and must not be a candidate");
+        result.HasNonActionableMatches.Should().BeTrue("the affected Restated pack must surface a manual-follow-up signal");
     }
 
     [Fact]
@@ -109,10 +114,11 @@ public sealed class ReportPackRestatementCandidateResolverTests
                     SourceId: "ledger-entry-9",
                     EvidenceId: "ev-9")));
 
-        var candidates = await resolver.ResolveAsync(
+        var result = await resolver.ResolveAsync(
             SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
 
-        candidates.Should().BeEmpty();
+        result.Candidates.Should().BeEmpty();
+        result.HasNonActionableMatches.Should().BeFalse();
     }
 
     [Fact]
@@ -126,10 +132,10 @@ public sealed class ReportPackRestatementCandidateResolverTests
                     SourceId: SecurityId.ToString("D"),
                     EvidenceId: "ev-1")));
 
-        var candidates = await resolver.ResolveAsync(
+        var result = await resolver.ResolveAsync(
             SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
 
-        candidates.Should().ContainSingle();
+        result.Candidates.Should().ContainSingle();
     }
 
     [Fact]
@@ -138,10 +144,10 @@ public sealed class ReportPackRestatementCandidateResolverTests
         var resolver = NewResolver(
             PublishedPack(FundProfileId, "2026-P03", SecurityLine("nav.line", SecurityId, evidenceId: "ev-42")));
 
-        var candidates = await resolver.ResolveAsync(
+        var result = await resolver.ResolveAsync(
             SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
 
-        var changedLine = candidates.Should().ContainSingle().Subject.ChangedLines.Should().ContainSingle().Subject;
+        var changedLine = result.Candidates.Should().ContainSingle().Subject.ChangedLines.Should().ContainSingle().Subject;
         changedLine.EvidenceLinks.Should().ContainSingle().Which.EvidenceId.Should().Be("ev-42");
     }
 

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPackRestatementCandidateResolverTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPackRestatementCandidateResolverTests.cs
@@ -1,0 +1,194 @@
+using FluentAssertions;
+using Meridian.Contracts.Workstation;
+using Meridian.Ui.Shared.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Meridian.Tests.SecurityMaster.Workbench;
+
+/// <summary>
+/// Report-pack-backed restatement candidate location: a closed-period reference-data edit surfaces the
+/// published packs that consumed the edited security (from retained report-line provenance) as governed
+/// restatement candidates, rather than degrading to a manual locate-affected-packs task.
+/// </summary>
+public sealed class ReportPackRestatementCandidateResolverTests
+{
+    private static readonly Guid SecurityId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid OtherSecurityId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid LedgerBookId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private const string FundProfileId = "fund-alpha";
+    private static readonly DateOnly EffectiveDate = new(2026, 03, 15);
+
+    [Fact]
+    public async Task NoFundScope_ReturnsNoCandidates()
+    {
+        var resolver = NewResolver(
+            PublishedPack(FundProfileId, "2026-P03", SecurityLine("line-1", SecurityId)));
+
+        var candidates = await resolver.ResolveAsync(
+            SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], fundProfileId: null);
+
+        candidates.Should().BeEmpty("without a fund scope the published packs cannot be narrowed");
+    }
+
+    [Fact]
+    public async Task PublishedPackReferencingSecurity_BecomesCandidate()
+    {
+        var resolver = NewResolver(
+            PublishedPack(FundProfileId, "2026-P03", SecurityLine("nav.line", SecurityId)));
+
+        var candidates = await resolver.ResolveAsync(
+            SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
+
+        candidates.Should().ContainSingle();
+        var candidate = candidates[0];
+        candidate.PeriodLabel.Should().Be("2026-P03");
+        candidate.ChangedLines.Should().ContainSingle().Which.LineKey.Should().Be("nav.line");
+    }
+
+    [Fact]
+    public async Task PackForOtherSecurity_IsNotACandidate()
+    {
+        var resolver = NewResolver(
+            PublishedPack(FundProfileId, "2026-P03", SecurityLine("line-1", OtherSecurityId)));
+
+        var candidates = await resolver.ResolveAsync(
+            SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
+
+        candidates.Should().BeEmpty("the pack's provenance ties its line to a different security");
+    }
+
+    [Fact]
+    public async Task PackForOtherFund_IsNotACandidate()
+    {
+        var resolver = NewResolver(
+            PublishedPack("fund-beta", "2026-P03", SecurityLine("line-1", SecurityId)));
+
+        var candidates = await resolver.ResolveAsync(
+            SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
+
+        candidates.Should().BeEmpty("only the impacted fund's packs are in scope");
+    }
+
+    [Fact]
+    public async Task UnpublishedPack_IsNotACandidate()
+    {
+        var resolver = NewResolver(
+            PackInState(ReportPackWorkflowStateDto.Approved, FundProfileId, "2026-P03", SecurityLine("line-1", SecurityId)));
+
+        var candidates = await resolver.ResolveAsync(
+            SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
+
+        candidates.Should().BeEmpty("only a live published output can require a restatement");
+    }
+
+    [Fact]
+    public async Task RestatedPackReferencingSecurity_IsACandidate()
+    {
+        var resolver = NewResolver(
+            PackInState(ReportPackWorkflowStateDto.Restated, FundProfileId, "2026-P02", SecurityLine("line-1", SecurityId)));
+
+        var candidates = await resolver.ResolveAsync(
+            SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
+
+        candidates.Should().ContainSingle("a restated pack is still the live published version");
+    }
+
+    [Fact]
+    public async Task PublishedPackWithoutMatchingProvenance_IsNotACandidate()
+    {
+        // Precise matching: a published pack with provenance that does not reference the security is
+        // left to the caller's default-deny safety net rather than surfaced as a false candidate.
+        var resolver = NewResolver(
+            PublishedPack(FundProfileId, "2026-P03",
+                new ReportPackLineProvenanceDto(
+                    LineKey: "cash.line",
+                    SourceKind: "ledger",
+                    SourceId: "ledger-entry-9",
+                    EvidenceId: "ev-9")));
+
+        var candidates = await resolver.ResolveAsync(
+            SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
+
+        candidates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SecurityKindSource_MatchesBySourceId()
+    {
+        var resolver = NewResolver(
+            PublishedPack(FundProfileId, "2026-P03",
+                new ReportPackLineProvenanceDto(
+                    LineKey: "holding.line",
+                    SourceKind: "security-master",
+                    SourceId: SecurityId.ToString("D"),
+                    EvidenceId: "ev-1")));
+
+        var candidates = await resolver.ResolveAsync(
+            SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
+
+        candidates.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task MatchedLine_CarriesProvenanceEvidenceForward()
+    {
+        var resolver = NewResolver(
+            PublishedPack(FundProfileId, "2026-P03", SecurityLine("nav.line", SecurityId, evidenceId: "ev-42")));
+
+        var candidates = await resolver.ResolveAsync(
+            SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
+
+        var changedLine = candidates.Should().ContainSingle().Subject.ChangedLines.Should().ContainSingle().Subject;
+        changedLine.EvidenceLinks.Should().ContainSingle().Which.EvidenceId.Should().Be("ev-42");
+    }
+
+    // ---- helpers ------------------------------------------------------------------------------
+
+    private static ReportPackRestatementCandidateResolver NewResolver(params ReportPackWorkflowRecordDto[] seedRecords)
+    {
+        var workflow = new ReportPackWorkflowService(new SeedStore(seedRecords));
+        return new ReportPackRestatementCandidateResolver(
+            workflow, NullLogger<ReportPackRestatementCandidateResolver>.Instance);
+    }
+
+    private static ReportPackLineProvenanceDto SecurityLine(string lineKey, Guid securityId, string evidenceId = "ev-1")
+        => new(
+            LineKey: lineKey,
+            SourceKind: "security-master",
+            SourceId: securityId.ToString("D"),
+            EvidenceId: evidenceId,
+            SecurityMasterId: securityId.ToString("D"));
+
+    private static ReportPackWorkflowRecordDto PublishedPack(
+        string fundProfileId, string period, params ReportPackLineProvenanceDto[] lineProvenance)
+        => PackInState(ReportPackWorkflowStateDto.Published, fundProfileId, period, lineProvenance);
+
+    private static ReportPackWorkflowRecordDto PackInState(
+        ReportPackWorkflowStateDto state, string fundProfileId, string period, params ReportPackLineProvenanceDto[] lineProvenance)
+    {
+        var now = new DateTimeOffset(2026, 03, 31, 0, 0, 0, TimeSpan.Zero);
+        return new ReportPackWorkflowRecordDto(
+            ReportId: Guid.NewGuid(),
+            FundProfileId: fundProfileId,
+            FundAccountId: $"{fundProfileId}-acct",
+            Period: period,
+            TemplateId: new VersionedReportTemplateIdDto("nav-pack", 1),
+            State: state,
+            Version: 1,
+            CreatedAt: now,
+            CreatedBy: "ops.analyst",
+            UpdatedAt: now,
+            AuditTrail: [new ReportPackAuditEventDto(now, "ops.analyst", "publish", ReportPackWorkflowStateDto.Approved, state)],
+            Restatement: null,
+            LineProvenance: lineProvenance);
+    }
+
+    private sealed class SeedStore : IReportPackWorkflowRecordStore
+    {
+        private readonly IReadOnlyList<ReportPackWorkflowRecordDto> _records;
+        public SeedStore(IReadOnlyList<ReportPackWorkflowRecordDto> records) => _records = records;
+
+        public IReadOnlyList<ReportPackWorkflowRecordDto> Load() => _records;
+        public void Save(IReadOnlyList<ReportPackWorkflowRecordDto> records) { }
+    }
+}


### PR DESCRIPTION
<!-- phase:PR7 -->
<!-- Phase PR7: this PR changes src/** (feature code), tests/**, and docs/** (incl. regenerated doc artifacts + README sync). PR7 is the minimal cumulative phase whose allowlist covers general src/**. -->

## Summary

Completes the closed-period restatement propagation slice of the Security Master Passport Workbench (named next slice for `W5-MASSET-001`). When a governed reference-data edit publishes into a **locked** accounting period, the workbench now surfaces the published report packs that consumed the edited security as governed restatement **candidates**, instead of always degrading to a manual "locate affected packs" task.

- New `ReportPackRestatementCandidateResolver` (`src/Meridian.Ui.Shared`) implements the application-layer `IRestatementCandidateResolver`. It locates candidates from retained **report-line provenance** (`SecurityMasterId`/`SecurityDefinitionId`, or a security-kind provenance source), scoped to the impacted fund profile and limited to **published** packs (only a live `Published` pack is re-restatable through the workflow), and is wired as the registered default.
- Matching is **precise**: an untieable published pack is left to the period-aware resolver's hard-closed default-deny manual-locate path rather than surfaced as a false candidate — a genuine miss is never silently completed. The operator approves each candidate via the existing `ReportPackWorkflowService.Restate(...)` path; the workbench only proposes.
- Threads the impacted fund profile through `IRestatementCandidateResolver.ResolveAsync` so the per-book lookup can scope to the fund.
- Adds `ReportPackWorkflowService.ListRecordsForFundProfile` — intentionally **uncapped** (unlike the 200-row `ListRecords`), so a silently dropped pack can never become a missed restatement.
- Deduplicates candidates by report across affected ledger books in `PeriodAwareRestatementResolver`.
- Keeps `NullRestatementCandidateResolver` as the documented no-op fallback for hosts without a report-pack backend.

Still deferred (documented): `IGovernedLedgerAdjustmentPoster` for soft-closed adjustment posting, period-precise candidate narrowing (the pack `Period` is a free-form label), repeated-restatement workflow support, and a durable security→report-line index to replace the per-fund scan.

## Reason

`W5-MASSET-001` and the Security Master Passport Workbench blueprint name the multi-asset reference-data workbench completion as the next slice, and its closed-period restatement guarantee had no teeth: the registered candidate resolver was a no-op, so every closed-period edit fell back to a manual locate task. This change makes the "a closed period is never silently changed" guarantee actually surface the affected published packs, strengthening governed-reporting evidence — squarely inside the operational-record-first scope gate.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — not run: `dotnet` is unavailable in the authoring environment, so the build/tests are validated here by `quality-gate`.
- [x] Relevant unit tests were added or updated — new `ReportPackRestatementCandidateResolverTests` (fund/security/state scoping, precise vs. untieable matching, evidence forwarding) and a cross-book dedup case in `PeriodAwareRestatementResolverTests`.
- [ ] Relevant integration tests were added or updated — the end-to-end `ClosedPeriodEdit` integration test remains a follow-up.
- [ ] GitHub Actions `quality-gate` passed — pending on this PR (the reason for opening it).

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)