### PR TITLE
Handle exceptions in FundLedgerPage load to prevent crashes

### DIFF
--- a/src/Meridian.Wpf/Views/FundLedgerPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/FundLedgerPage.xaml.cs
@@ -35,7 +35,7 @@ public partial class FundLedgerPage : Page
         }
         catch (Exception ex)
         {
-            Services.LoggingService.Instance.LogError(
+            Meridian.Wpf.Services.LoggingService.Instance.LogError(
                 "Fund operations page failed to load.", ex);
         }
     }

--- a/src/Meridian.Wpf/Views/FundLedgerPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/FundLedgerPage.xaml.cs
@@ -20,7 +20,24 @@ public partial class FundLedgerPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        await _viewModel.LoadAsync();
+        // OnPageLoaded is an 'async void' handler, so any exception that escapes
+        // LoadAsync is posted to the dispatcher. Non-recoverable exception types are
+        // not marked Handled by the global dispatcher hook and tear the whole process
+        // down, which previously crashed the desktop shell (and the screenshot catalog)
+        // when fund data was empty/minimal. Contain load failures here so navigation to
+        // the fund operations page degrades to an empty/partial state instead of exiting.
+        try
+        {
+            await _viewModel.LoadAsync();
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            Services.LoggingService.Instance.LogError(
+                "Fund operations page failed to load.", ex);
+        }
     }
 
     private void OnPageUnloaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary

Added exception handling to the `FundLedgerPage.OnPageLoaded` method to gracefully handle failures during fund data loading. When `LoadAsync()` throws an unhandled exception in this async void event handler, it is posted to the dispatcher and can crash the entire application. The change wraps the load operation in a try-catch block to contain failures and allow the page to degrade to an empty/partial state instead of terminating the process.

## Reason

The `OnPageLoaded` async void event handler previously allowed exceptions from `LoadAsync()` to escape uncaught. In async void handlers, unhandled exceptions are posted to the synchronization context dispatcher. Non-recoverable exception types are not marked as handled by the global dispatcher hook and cause the entire process to terminate, which previously crashed the desktop shell and screenshot catalog when fund data was empty or minimal.

This change ensures that load failures are contained and logged, allowing graceful degradation rather than application termination.

## Testing performed

- [x] `bash scripts/ci.sh` completed successfully
- [x] No unit tests needed—this is defensive exception handling in an event handler
- [x] No integration tests needed—the change preserves existing behavior on success and adds safe fallback on failure
- [x] GitHub Actions `quality-gate` passed

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

https://claude.ai/code/session_01Wqm3TYBfr7ujyh7ndZvvos