### PR TITLE
feat(security-master): durable security→report-line index for restatement lookup (S4)

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -5135,6 +5135,8 @@ Meridian-main
 │   │   │   ├── ReportPackDeliveryService.cs
 │   │   │   ├── ReportPackRestatementCandidateResolver.cs
 │   │   │   ├── ReportPackRunReadService.cs
+│   │   │   ├── ReportPackSecurityLineIndex.cs
+│   │   │   ├── ReportPackSecurityLineMatcher.cs
 │   │   │   ├── ReportPackValidationService.cs
 │   │   │   ├── ReportWriterDatasetSourceService.cs
 │   │   │   ├── ReportWriterGridArtifactService.cs
@@ -6572,6 +6574,7 @@ Meridian-main
 │   │   │   │   ├── PeriodAwareRestatementResolverTests.cs
 │   │   │   │   ├── PublishedRevisionHandlerTests.cs
 │   │   │   │   ├── ReportPackRestatementCandidateResolverTests.cs
+│   │   │   │   ├── ReportPackSecurityLineIndexTests.cs
 │   │   │   │   ├── SecurityMasterConflictAuthorityPolicyTests.cs
 │   │   │   │   └── SecurityMasterWorkbenchCommandServiceTests.cs
 │   │   │   ├── CorporateActionCommandServiceTests.cs

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,7 +5,7 @@
 
 ## Overall Coverage
 
-**2565 / 7187** items documented (**35.7%**) &mdash; Grade: **F**
+**2566 / 7191** items documented (**35.7%**) &mdash; Grade: **F**
 
 ```text
 [=======-------------] 35.7%
@@ -15,7 +15,7 @@
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 2444 | 6692 | 36.5% | F |
+| Public Classes / Interfaces | 2445 | 6696 | 36.5% | F |
 | API Endpoints | 107 | 348 | 30.7% | F |
 | Configuration Options | 3 | 136 | 2.2% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |
@@ -23,7 +23,7 @@
 
 ## Undocumented Items
 
-### Public Classes / Interfaces (4248 undocumented)
+### Public Classes / Interfaces (4251 undocumented)
 
 | Item | Location |
 | ------ | ---------- |
@@ -77,7 +77,7 @@
 | `FirstTimeConfigOptions` | `src/Meridian.Application/Services/AutoConfigurationService.cs:977` |
 | `SymbolPreset` | `src/Meridian.Application/Services/AutoConfigurationService.cs:1001` |
 | `WizardResult` | `src/Meridian.Application/Services/ConfigurationWizard.cs:314` |
-| ... and 4198 more | |
+| ... and 4201 more | |
 
 ### API Endpoints (241 undocumented)
 
@@ -193,7 +193,7 @@
 
 ## Recommendations
 
-1. **Public Classes / Interfaces**: 4248 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
+1. **Public Classes / Interfaces**: 4251 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
 2. **API Endpoints**: 241 endpoint(s) missing from `docs/reference/api-reference.md`. Run the endpoint audit and update the API reference table.
 3. **Configuration Options**: 133 config key(s) not found in `docs/generated/configuration-schema.md`. Re-run the configuration schema generator to synchronise.
 

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,11 +1,11 @@
 {
   "total_files": 534,
-  "total_lines": 86321,
+  "total_lines": 86324,
   "orphaned_count": 204,
   "no_heading_count": 38,
   "stale_count": 0,
   "todo_count": 199,
-  "average_lines": 161.6,
+  "average_lines": 161.7,
   "health_score": 83,
   "orphaned_files": [
     ".agents/skills/meridian-archive-organizer/SKILL.md",
@@ -2129,7 +2129,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7237,
+      "line_count": 7240,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,8 +20,8 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 534 |
-| Total lines | 86,321 |
-| Average file size (lines) | 161.6 |
+| Total lines | 86,324 |
+| Average file size (lines) | 161.7 |
 | Orphaned files | 204 |
 | Files without headings | 38 |
 | Stale files (>90 days) | 0 |

--- a/src/Meridian.Ui.Shared/Services/ReportPackRestatementCandidateResolver.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportPackRestatementCandidateResolver.cs
@@ -32,12 +32,18 @@ namespace Meridian.Ui.Shared.Services;
 /// candidate the operator could not act on. Such a match is instead logged for manual attention rather
 /// than silently dropped. Supporting repeated restatement is a deferred report-pack workflow change.</para>
 ///
+/// <para><b>Lookup.</b> Candidate records are located through
+/// <see cref="ReportPackWorkflowService.ListRecordsForSecurityInFund"/>, which uses the durable
+/// security→report-line index (<see cref="IReportPackSecurityLineIndex"/>) for an O(matches) lookup and
+/// falls back to a full fund scan when no index is wired. The membership rule is the shared
+/// <see cref="ReportPackSecurityLineMatcher"/>, so the index and this resolver agree on exactly which
+/// lines reference the security.</para>
+///
 /// <para><b>Deferred</b> to later slices: repeated-restatement workflow support (so an already-restated
 /// pack can be re-restated instead of only logged); narrowing candidates to the specific reporting
 /// period covering the edit's effective date (the pack <c>Period</c> is a free-form label, so
 /// period-precise filtering is not yet safe and over-inclusion stays operator-reviewed); soft-closed
-/// governed-adjustment posting; and a durable security→report-line index that would replace this
-/// per-fund scan.</para>
+/// governed-adjustment posting; and exposing the index's cross-fund lookup on a public surface.</para>
 /// </summary>
 public sealed class ReportPackRestatementCandidateResolver : IRestatementCandidateResolver
 {
@@ -78,7 +84,7 @@ public sealed class ReportPackRestatementCandidateResolver : IRestatementCandida
 
         var candidates = new List<RestatementCandidateDto>();
         var hasNonActionableMatches = false;
-        foreach (var record in _reportPackWorkflow.ListRecordsForFundProfile(fundProfileId))
+        foreach (var record in _reportPackWorkflow.ListRecordsForSecurityInFund(securityId, fundProfileId))
         {
             ct.ThrowIfCancellationRequested();
 
@@ -154,7 +160,7 @@ public sealed class ReportPackRestatementCandidateResolver : IRestatementCandida
         }
 
         return provenance
-            .Where(line => LineReferencesSecurity(line, securityId))
+            .Where(line => ReportPackSecurityLineMatcher.LineReferencesSecurity(line, securityId))
             .Select(line => new ReportPackChangedLineDto(
                 LineKey: line.LineKey,
                 PreviousValue: line.ReportValue ?? string.Empty,
@@ -168,18 +174,4 @@ public sealed class ReportPackRestatementCandidateResolver : IRestatementCandida
                         Source: string.IsNullOrWhiteSpace(line.SourceKind) ? "report-line-provenance" : line.SourceKind)]))
             .ToArray();
     }
-
-    private static bool LineReferencesSecurity(ReportPackLineProvenanceDto line, Guid securityId)
-        => MatchesSecurity(line.SecurityMasterId, securityId)
-           || MatchesSecurity(line.SecurityDefinitionId, securityId)
-           || (ContainsToken(line.SourceKind, "security") && MatchesSecurity(line.SourceId, securityId));
-
-    private static bool MatchesSecurity(string? value, Guid securityId)
-        => !string.IsNullOrWhiteSpace(value)
-           && Guid.TryParse(value, out var parsed)
-           && parsed == securityId;
-
-    private static bool ContainsToken(string? value, string token)
-        => !string.IsNullOrWhiteSpace(value)
-           && value.Contains(token, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Meridian.Ui.Shared/Services/ReportPackSecurityLineIndex.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportPackSecurityLineIndex.cs
@@ -1,0 +1,185 @@
+using Meridian.Contracts.Workstation;
+
+namespace Meridian.Ui.Shared.Services;
+
+/// <summary>
+/// One report pack's contribution to a security in the security→report-line index: which report (and the
+/// fund/state it is in) references <see cref="SecurityId"/>, and on which report lines.
+/// </summary>
+public sealed record ReportPackSecurityLineIndexEntry(
+    Guid SecurityId,
+    Guid ReportId,
+    string FundProfileId,
+    ReportPackWorkflowStateDto State,
+    IReadOnlyList<string> LineKeys);
+
+/// <summary>
+/// Durable-by-derivation index from a security id to the report packs whose retained report-line
+/// provenance references it. It replaces the per-fund linear scan in
+/// <see cref="ReportPackRestatementCandidateResolver"/> with an O(matches) lookup, and exposes a
+/// cross-fund <see cref="Lookup"/> seam (consumed internally for now; a public cross-fund surface is a
+/// later slice). The index is a derived cache: it is always rebuildable from the report-pack workflow
+/// records (the source of truth), so it carries no independent persistence.
+/// </summary>
+public interface IReportPackSecurityLineIndex
+{
+    /// <summary>Recomputes <paramref name="record"/>'s contributions, replacing any prior entries for it.</summary>
+    void Upsert(ReportPackWorkflowRecordDto record);
+
+    /// <summary>Removes all index entries contributed by <paramref name="reportId"/>.</summary>
+    void RemoveReport(Guid reportId);
+
+    /// <summary>Clears and rebuilds the index from <paramref name="records"/> (startup backfill / self-heal).</summary>
+    void Rebuild(IEnumerable<ReportPackWorkflowRecordDto> records);
+
+    /// <summary>Entries for a security scoped to a single fund profile.</summary>
+    IReadOnlyList<ReportPackSecurityLineIndexEntry> LookupByFund(Guid securityId, string fundProfileId);
+
+    /// <summary>All entries for a security across every fund (cross-fund seam).</summary>
+    IReadOnlyList<ReportPackSecurityLineIndexEntry> Lookup(Guid securityId);
+}
+
+/// <summary>
+/// In-memory <see cref="IReportPackSecurityLineIndex"/>. Kept current by routing every report-pack
+/// mutation through a single chokepoint in <see cref="ReportPackWorkflowService"/>, and rebuilt from the
+/// persisted workflow records on construction. A single lock guards both maps so an <see cref="Upsert"/>
+/// (remove-then-add) is atomic against concurrent lookups.
+/// </summary>
+public sealed class InMemoryReportPackSecurityLineIndex : IReportPackSecurityLineIndex
+{
+    private readonly object _gate = new();
+
+    // securityId -> (reportId -> entry). Nested by report so a re-upsert replaces a report's entry in place.
+    private readonly Dictionary<Guid, Dictionary<Guid, ReportPackSecurityLineIndexEntry>> _bySecurity = new();
+
+    // reportId -> the security ids it currently contributes, so a re-upsert can remove stale contributions.
+    private readonly Dictionary<Guid, IReadOnlyList<Guid>> _reportSecurities = new();
+
+    public void Upsert(ReportPackWorkflowRecordDto record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        var perSecurityLineKeys = new Dictionary<Guid, List<string>>();
+        foreach (var line in record.LineProvenance ?? [])
+        {
+            foreach (var securityId in ReportPackSecurityLineMatcher.ReferencedSecurityIds(line))
+            {
+                if (!perSecurityLineKeys.TryGetValue(securityId, out var keys))
+                {
+                    keys = [];
+                    perSecurityLineKeys[securityId] = keys;
+                }
+
+                keys.Add(line.LineKey);
+            }
+        }
+
+        lock (_gate)
+        {
+            RemoveReportInternal(record.ReportId);
+
+            if (perSecurityLineKeys.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var (securityId, lineKeys) in perSecurityLineKeys)
+            {
+                var entry = new ReportPackSecurityLineIndexEntry(
+                    securityId,
+                    record.ReportId,
+                    record.FundProfileId,
+                    record.State,
+                    lineKeys.Distinct(StringComparer.Ordinal).ToArray());
+
+                if (!_bySecurity.TryGetValue(securityId, out var byReport))
+                {
+                    byReport = [];
+                    _bySecurity[securityId] = byReport;
+                }
+
+                byReport[record.ReportId] = entry;
+            }
+
+            _reportSecurities[record.ReportId] = perSecurityLineKeys.Keys.ToArray();
+        }
+    }
+
+    public void RemoveReport(Guid reportId)
+    {
+        lock (_gate)
+        {
+            RemoveReportInternal(reportId);
+        }
+    }
+
+    public void Rebuild(IEnumerable<ReportPackWorkflowRecordDto> records)
+    {
+        ArgumentNullException.ThrowIfNull(records);
+
+        lock (_gate)
+        {
+            _bySecurity.Clear();
+            _reportSecurities.Clear();
+        }
+
+        foreach (var record in records)
+        {
+            Upsert(record);
+        }
+    }
+
+    public IReadOnlyList<ReportPackSecurityLineIndexEntry> Lookup(Guid securityId)
+    {
+        lock (_gate)
+        {
+            return _bySecurity.TryGetValue(securityId, out var byReport)
+                ? byReport.Values.ToArray()
+                : [];
+        }
+    }
+
+    public IReadOnlyList<ReportPackSecurityLineIndexEntry> LookupByFund(Guid securityId, string fundProfileId)
+    {
+        var fund = fundProfileId?.Trim();
+        if (string.IsNullOrEmpty(fund))
+        {
+            return [];
+        }
+
+        lock (_gate)
+        {
+            if (!_bySecurity.TryGetValue(securityId, out var byReport))
+            {
+                return [];
+            }
+
+            return byReport.Values
+                .Where(entry => string.Equals(entry.FundProfileId, fund, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+        }
+    }
+
+    // Must be called under _gate.
+    private void RemoveReportInternal(Guid reportId)
+    {
+        if (!_reportSecurities.TryGetValue(reportId, out var securityIds))
+        {
+            return;
+        }
+
+        foreach (var securityId in securityIds)
+        {
+            if (_bySecurity.TryGetValue(securityId, out var byReport))
+            {
+                byReport.Remove(reportId);
+                if (byReport.Count == 0)
+                {
+                    _bySecurity.Remove(securityId);
+                }
+            }
+        }
+
+        _reportSecurities.Remove(reportId);
+    }
+}

--- a/src/Meridian.Ui.Shared/Services/ReportPackSecurityLineIndex.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportPackSecurityLineIndex.cs
@@ -58,7 +58,16 @@ public sealed class InMemoryReportPackSecurityLineIndex : IReportPackSecurityLin
     public void Upsert(ReportPackWorkflowRecordDto record)
     {
         ArgumentNullException.ThrowIfNull(record);
+        lock (_gate)
+        {
+            UpsertLocked(record);
+        }
+    }
 
+    // Recomputes a record's contributions. The caller MUST hold _gate, so a Rebuild can apply many
+    // upserts atomically (the index is never observed half-rebuilt by a concurrent lookup).
+    private void UpsertLocked(ReportPackWorkflowRecordDto record)
+    {
         var perSecurityLineKeys = new Dictionary<Guid, List<string>>();
         foreach (var line in record.LineProvenance ?? [])
         {
@@ -70,39 +79,41 @@ public sealed class InMemoryReportPackSecurityLineIndex : IReportPackSecurityLin
                     perSecurityLineKeys[securityId] = keys;
                 }
 
-                keys.Add(line.LineKey);
-            }
-        }
-
-        lock (_gate)
-        {
-            RemoveReportInternal(record.ReportId);
-
-            if (perSecurityLineKeys.Count == 0)
-            {
-                return;
-            }
-
-            foreach (var (securityId, lineKeys) in perSecurityLineKeys)
-            {
-                var entry = new ReportPackSecurityLineIndexEntry(
-                    securityId,
-                    record.ReportId,
-                    record.FundProfileId,
-                    record.State,
-                    lineKeys.Distinct(StringComparer.Ordinal).ToArray());
-
-                if (!_bySecurity.TryGetValue(securityId, out var byReport))
+                // Register the security even when the contributing line has no key; only collect
+                // non-empty keys so the Ordinal Distinct below never hashes a null line key.
+                if (!string.IsNullOrEmpty(line.LineKey))
                 {
-                    byReport = [];
-                    _bySecurity[securityId] = byReport;
+                    keys.Add(line.LineKey);
                 }
+            }
+        }
 
-                byReport[record.ReportId] = entry;
+        RemoveReportInternal(record.ReportId);
+
+        if (perSecurityLineKeys.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var (securityId, lineKeys) in perSecurityLineKeys)
+        {
+            var entry = new ReportPackSecurityLineIndexEntry(
+                securityId,
+                record.ReportId,
+                record.FundProfileId,
+                record.State,
+                lineKeys.Distinct(StringComparer.Ordinal).ToArray());
+
+            if (!_bySecurity.TryGetValue(securityId, out var byReport))
+            {
+                byReport = [];
+                _bySecurity[securityId] = byReport;
             }
 
-            _reportSecurities[record.ReportId] = perSecurityLineKeys.Keys.ToArray();
+            byReport[record.ReportId] = entry;
         }
+
+        _reportSecurities[record.ReportId] = perSecurityLineKeys.Keys.ToArray();
     }
 
     public void RemoveReport(Guid reportId)
@@ -117,15 +128,17 @@ public sealed class InMemoryReportPackSecurityLineIndex : IReportPackSecurityLin
     {
         ArgumentNullException.ThrowIfNull(records);
 
+        // Clear and re-apply under a single lock so a concurrent lookup never observes a partially
+        // rebuilt (or momentarily empty) index.
         lock (_gate)
         {
             _bySecurity.Clear();
             _reportSecurities.Clear();
-        }
-
-        foreach (var record in records)
-        {
-            Upsert(record);
+            foreach (var record in records)
+            {
+                ArgumentNullException.ThrowIfNull(record);
+                UpsertLocked(record);
+            }
         }
     }
 

--- a/src/Meridian.Ui.Shared/Services/ReportPackSecurityLineMatcher.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportPackSecurityLineMatcher.cs
@@ -1,0 +1,80 @@
+using Meridian.Contracts.Workstation;
+
+namespace Meridian.Ui.Shared.Services;
+
+/// <summary>
+/// Shared "does this report line reference a security" matcher for the report-pack restatement path.
+/// Extracted so the candidate resolver (<see cref="ReportPackRestatementCandidateResolver"/>) and the
+/// durable security→report-line index (<see cref="IReportPackSecurityLineIndex"/>) agree on exactly one
+/// membership rule: a report-line provenance entry references a security when its
+/// <c>SecurityMasterId</c> or <c>SecurityDefinitionId</c> parses to the security id, or when it carries a
+/// security-kind source whose <c>SourceId</c> parses to the security id.
+/// </summary>
+public static class ReportPackSecurityLineMatcher
+{
+    /// <summary>True when <paramref name="line"/> ties a report line to <paramref name="securityId"/>.</summary>
+    public static bool LineReferencesSecurity(ReportPackLineProvenanceDto line, Guid securityId)
+    {
+        ArgumentNullException.ThrowIfNull(line);
+        return MatchesSecurity(line.SecurityMasterId, securityId)
+            || MatchesSecurity(line.SecurityDefinitionId, securityId)
+            || (ContainsToken(line.SourceKind, "security") && MatchesSecurity(line.SourceId, securityId));
+    }
+
+    /// <summary>True when <paramref name="record"/> has any retained provenance line referencing the security.</summary>
+    public static bool RecordReferencesSecurity(ReportPackWorkflowRecordDto record, Guid securityId)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+        return record.LineProvenance is { Count: > 0 } provenance
+            && provenance.Any(line => LineReferencesSecurity(line, securityId));
+    }
+
+    /// <summary>
+    /// The distinct security ids a single provenance line contributes — the reverse of
+    /// <see cref="LineReferencesSecurity"/>: for any returned id <c>s</c>, <c>LineReferencesSecurity(line, s)</c>
+    /// is true, and vice versa. Used to build the security→report-line index.
+    /// </summary>
+    public static IEnumerable<Guid> ReferencedSecurityIds(ReportPackLineProvenanceDto line)
+    {
+        ArgumentNullException.ThrowIfNull(line);
+
+        if (TryParseSecurity(line.SecurityMasterId, out var fromMaster))
+        {
+            yield return fromMaster;
+        }
+
+        if (TryParseSecurity(line.SecurityDefinitionId, out var fromDefinition) && fromDefinition != fromMaster)
+        {
+            yield return fromDefinition;
+        }
+
+        if (ContainsToken(line.SourceKind, "security")
+            && TryParseSecurity(line.SourceId, out var fromSource)
+            && fromSource != fromMaster
+            && fromSource != fromDefinition)
+        {
+            yield return fromSource;
+        }
+    }
+
+    private static bool MatchesSecurity(string? value, Guid securityId)
+        => TryParseSecurity(value, out var parsed) && parsed == securityId;
+
+    private static bool TryParseSecurity(string? value, out Guid securityId)
+    {
+        // Behaviour-preserving with the original resolver matcher: non-blank and parseable. Guid.Empty is
+        // not special-cased, so the extracted predicate matches the merged resolver exactly (the parity
+        // test guards this), and the index's ReferencedSecurityIds stays the exact reverse of it.
+        if (!string.IsNullOrWhiteSpace(value) && Guid.TryParse(value, out securityId))
+        {
+            return true;
+        }
+
+        securityId = Guid.Empty;
+        return false;
+    }
+
+    private static bool ContainsToken(string? value, string token)
+        => !string.IsNullOrWhiteSpace(value)
+           && value.Contains(token, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Meridian.Ui.Shared/Services/ReportPackSecurityLineMatcher.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportPackSecurityLineMatcher.cs
@@ -38,20 +38,25 @@ public static class ReportPackSecurityLineMatcher
     {
         ArgumentNullException.ThrowIfNull(line);
 
-        if (TryParseSecurity(line.SecurityMasterId, out var fromMaster))
+        // Dedupe on successfully-parsed ids only. Comparing against the out-variables would wrongly
+        // suppress a legitimate all-zeros (Guid.Empty) definition id whenever an earlier source failed
+        // to parse (its out-variable also defaults to Guid.Empty) — which would make this the inexact
+        // reverse of LineReferencesSecurity and silently drop that record from the index.
+        var seen = new HashSet<Guid>();
+
+        if (TryParseSecurity(line.SecurityMasterId, out var fromMaster) && seen.Add(fromMaster))
         {
             yield return fromMaster;
         }
 
-        if (TryParseSecurity(line.SecurityDefinitionId, out var fromDefinition) && fromDefinition != fromMaster)
+        if (TryParseSecurity(line.SecurityDefinitionId, out var fromDefinition) && seen.Add(fromDefinition))
         {
             yield return fromDefinition;
         }
 
         if (ContainsToken(line.SourceKind, "security")
             && TryParseSecurity(line.SourceId, out var fromSource)
-            && fromSource != fromMaster
-            && fromSource != fromDefinition)
+            && seen.Add(fromSource))
         {
             yield return fromSource;
         }

--- a/src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs
@@ -1106,14 +1106,22 @@ public sealed class ReportPackWorkflowService
 
     private readonly ConcurrentDictionary<Guid, ReportPackWorkflowRecordDto> _records = new();
     private readonly IReportPackWorkflowRecordStore? _store;
+    private readonly IReportPackSecurityLineIndex? _securityLineIndex;
 
-    public ReportPackWorkflowService(IReportPackWorkflowRecordStore? store = null)
+    public ReportPackWorkflowService(
+        IReportPackWorkflowRecordStore? store = null,
+        IReportPackSecurityLineIndex? securityLineIndex = null)
     {
         _store = store;
+        _securityLineIndex = securityLineIndex;
         foreach (var record in _store?.Load() ?? [])
         {
             _records[record.ReportId] = record;
         }
+
+        // Backfill the derived security→report-line index from the loaded records (the workflow records
+        // are the source of truth), so the index is current on first use after a process start/upgrade.
+        _securityLineIndex?.Rebuild(_records.Values);
     }
 
     public ReportPackWorkflowRecordDto Create(
@@ -1139,8 +1147,7 @@ public sealed class ReportPackWorkflowService
             , null,
             NormalizeLineProvenance(lineProvenance),
             AccessPolicy: normalizedAccessPolicy);
-        _records[id] = record;
-        PersistRecords();
+        SaveAndIndex(record);
         return record;
     }
 
@@ -1178,8 +1185,7 @@ public sealed class ReportPackWorkflowService
             UpdatedAt = now,
             AuditTrail = record.AuditTrail.Append(new ReportPackAuditEventDto(now, actor, target.ToString().ToLowerInvariant(), record.State, target, note)).ToArray()
         };
-        _records[reportId] = next;
-        PersistRecords();
+        SaveAndIndex(next);
         return next;
     }
 
@@ -1200,8 +1206,7 @@ public sealed class ReportPackWorkflowService
                 rejectedAt,
                 evidenceLinks is null ? null : NormalizeEvidenceLinks(evidenceLinks))
         };
-        _records[reportId] = next;
-        PersistRecords();
+        SaveAndIndex(next);
         return next;
     }
 
@@ -1246,8 +1251,7 @@ public sealed class ReportPackWorkflowService
             Version = transitioned.Version + 1,
             Restatement = new ReportPackRestatementMetadataDto(reasonCode, approver, priorVersionReportId, changedLines, evidenceLinks)
         };
-        _records[reportId] = next;
-        PersistRecords();
+        SaveAndIndex(next);
         return next;
     }
 
@@ -1301,8 +1305,7 @@ public sealed class ReportPackWorkflowService
                 SignOffContext: NormalizeWorkflowOptional(signOffContext) ?? BuildPublicationSignOffContext(actor, role, actionOrigin),
                 ActionOrigin: actionOrigin)
         };
-        _records[reportId] = next;
-        PersistRecords();
+        SaveAndIndex(next);
         return next;
     }
 
@@ -1357,12 +1360,56 @@ public sealed class ReportPackWorkflowService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(fundProfileId);
         var key = fundProfileId.Trim();
-        return _records.Values
-            .Where(record => string.Equals(record.FundProfileId, key, StringComparison.OrdinalIgnoreCase))
+        return OrderFundRecords(
+            _records.Values.Where(record => string.Equals(record.FundProfileId, key, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    /// <summary>
+    /// The report packs in a fund profile whose retained report-line provenance references
+    /// <paramref name="securityId"/>. When a security→report-line index is wired this is an O(matches)
+    /// lookup; otherwise it falls back to the full fund scan filtered by the shared matcher, preserving
+    /// behaviour. Callers apply their own state gating (e.g. only Published/Restated packs).
+    /// </summary>
+    public IReadOnlyList<ReportPackWorkflowRecordDto> ListRecordsForSecurityInFund(Guid securityId, string fundProfileId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fundProfileId);
+        var key = fundProfileId.Trim();
+
+        if (_securityLineIndex is not null)
+        {
+            var matches = new List<ReportPackWorkflowRecordDto>();
+            foreach (var entry in _securityLineIndex.LookupByFund(securityId, key))
+            {
+                if (_records.TryGetValue(entry.ReportId, out var record))
+                {
+                    matches.Add(record);
+                }
+            }
+
+            return OrderFundRecords(matches);
+        }
+
+        return OrderFundRecords(
+            _records.Values.Where(record =>
+                string.Equals(record.FundProfileId, key, StringComparison.OrdinalIgnoreCase)
+                && ReportPackSecurityLineMatcher.RecordReferencesSecurity(record, securityId)));
+    }
+
+    private static IReadOnlyList<ReportPackWorkflowRecordDto> OrderFundRecords(IEnumerable<ReportPackWorkflowRecordDto> records) =>
+        records
             .OrderByDescending(static record => record.Period, StringComparer.OrdinalIgnoreCase)
             .ThenByDescending(static record => record.Version)
             .ThenBy(static record => record.ReportId)
             .ToArray();
+
+    private void SaveAndIndex(ReportPackWorkflowRecordDto record)
+    {
+        // Single chokepoint for every report-pack mutation: update the authoritative record map, persist,
+        // then update the derived security→report-line index. Routing all writes through here keeps the
+        // index from drifting out of sync with _records.
+        _records[record.ReportId] = record;
+        PersistRecords();
+        _securityLineIndex?.Upsert(record);
     }
 
     private void PersistRecords()

--- a/src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs
@@ -1404,12 +1404,15 @@ public sealed class ReportPackWorkflowService
 
     private void SaveAndIndex(ReportPackWorkflowRecordDto record)
     {
-        // Single chokepoint for every report-pack mutation: update the authoritative record map, persist,
-        // then update the derived security→report-line index. Routing all writes through here keeps the
-        // index from drifting out of sync with _records.
+        // Single chokepoint for every report-pack mutation. Update the authoritative record map and the
+        // derived security→report-line index together BEFORE persisting, so the two in-memory views stay
+        // consistent even if PersistRecords throws. (Persisting between them would, on a write failure,
+        // leave the index permanently missing a record _records already has — a silent restatement
+        // candidate miss, since the index-backed lookup no longer scans _records.) PersistRecords runs
+        // last because it serializes the current _records snapshot.
         _records[record.ReportId] = record;
-        PersistRecords();
         _securityLineIndex?.Upsert(record);
+        PersistRecords();
     }
 
     private void PersistRecords()

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -306,6 +306,10 @@ public static class WorkstationServiceCollectionExtensions
                 sp.GetRequiredService<ReportTemplateRegistryService>()));
         services.TryAddSingleton<IReportingTemplateCatalog>(sp =>
             sp.GetRequiredService<GovernedReportingTemplateCatalog>());
+        // Derived security→report-line index backing the report-pack restatement candidate lookup. A
+        // singleton so it shares the lifetime of the (singleton) workflow service that keeps it current;
+        // it is rebuilt from the persisted workflow records on construction.
+        services.TryAddSingleton<IReportPackSecurityLineIndex, InMemoryReportPackSecurityLineIndex>();
         services.TryAddSingleton<ReportPackWorkflowService>();
         services.TryAddSingleton<ReportPackDeliveryService>();
         services.TryAddSingleton<ReportWriterDatasetSourceService>();

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPackRestatementCandidateResolverTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPackRestatementCandidateResolverTests.cs
@@ -151,11 +151,38 @@ public sealed class ReportPackRestatementCandidateResolverTests
         changedLine.EvidenceLinks.Should().ContainSingle().Which.EvidenceId.Should().Be("ev-42");
     }
 
+    [Fact]
+    public async Task IndexBackedAndScan_ProduceIdenticalResults()
+    {
+        // The index-backed lookup must be a behaviour-preserving optimization of the full fund scan.
+        var seed = new[]
+        {
+            PublishedPack(FundProfileId, "2026-P03", SecurityLine("nav.line", SecurityId), SecurityLine("alt.line", OtherSecurityId)),
+            PackInState(ReportPackWorkflowStateDto.Restated, FundProfileId, "2026-P02", SecurityLine("old.line", SecurityId)),
+            PublishedPack("fund-beta", "2026-P03", SecurityLine("other-fund.line", SecurityId)),
+            PackInState(ReportPackWorkflowStateDto.Approved, FundProfileId, "2026-P03", SecurityLine("draft.line", SecurityId)),
+        };
+
+        var indexed = await NewResolver(useIndex: true, seed)
+            .ResolveAsync(SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
+        var scanned = await NewResolver(useIndex: false, seed)
+            .ResolveAsync(SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
+
+        indexed.Candidates.Select(c => c.ReportId).Should().BeEquivalentTo(scanned.Candidates.Select(c => c.ReportId));
+        indexed.HasNonActionableMatches.Should().Be(scanned.HasNonActionableMatches);
+        indexed.Candidates.Should().ContainSingle("only the Published same-fund pack is actionable");
+        indexed.HasNonActionableMatches.Should().BeTrue("the Restated same-fund pack is a non-actionable match");
+    }
+
     // ---- helpers ------------------------------------------------------------------------------
 
     private static ReportPackRestatementCandidateResolver NewResolver(params ReportPackWorkflowRecordDto[] seedRecords)
+        => NewResolver(useIndex: true, seedRecords);
+
+    private static ReportPackRestatementCandidateResolver NewResolver(bool useIndex, params ReportPackWorkflowRecordDto[] seedRecords)
     {
-        var workflow = new ReportPackWorkflowService(new SeedStore(seedRecords));
+        IReportPackSecurityLineIndex? index = useIndex ? new InMemoryReportPackSecurityLineIndex() : null;
+        var workflow = new ReportPackWorkflowService(new SeedStore(seedRecords), index);
         return new ReportPackRestatementCandidateResolver(
             workflow, NullLogger<ReportPackRestatementCandidateResolver>.Instance);
     }

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPackSecurityLineIndexTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPackSecurityLineIndexTests.cs
@@ -1,0 +1,192 @@
+using FluentAssertions;
+using Meridian.Contracts.Workstation;
+using Meridian.Ui.Shared.Services;
+
+namespace Meridian.Tests.SecurityMaster.Workbench;
+
+/// <summary>
+/// Unit coverage for the derived security→report-line index and the shared matcher it relies on. The
+/// index must stay an exact reverse of the matcher (so it agrees with the candidate resolver) and must
+/// stay consistent under re-upsert, removal, and rebuild.
+/// </summary>
+public sealed class ReportPackSecurityLineIndexTests
+{
+    private static readonly Guid SecurityA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid SecurityB = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private const string FundA = "fund-alpha";
+    private const string FundB = "fund-beta";
+
+    [Fact]
+    public void Upsert_ThenLookupByFund_ReturnsEntryWithLineKeys()
+    {
+        var index = new InMemoryReportPackSecurityLineIndex();
+        var record = Pack(FundA, ReportPackWorkflowStateDto.Published,
+            SecurityLine("nav.line", SecurityA), SecurityLine("income.line", SecurityA));
+
+        index.Upsert(record);
+
+        var entry = index.LookupByFund(SecurityA, FundA).Should().ContainSingle().Subject;
+        entry.ReportId.Should().Be(record.ReportId);
+        entry.FundProfileId.Should().Be(FundA);
+        entry.State.Should().Be(ReportPackWorkflowStateDto.Published);
+        entry.LineKeys.Should().BeEquivalentTo(["nav.line", "income.line"]);
+    }
+
+    [Fact]
+    public void LookupByFund_WrongFund_ReturnsEmpty()
+    {
+        var index = new InMemoryReportPackSecurityLineIndex();
+        index.Upsert(Pack(FundA, ReportPackWorkflowStateDto.Published, SecurityLine("nav.line", SecurityA)));
+
+        index.LookupByFund(SecurityA, FundB).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Lookup_ReturnsEntriesAcrossFunds()
+    {
+        var index = new InMemoryReportPackSecurityLineIndex();
+        index.Upsert(Pack(FundA, ReportPackWorkflowStateDto.Published, SecurityLine("a.line", SecurityA)));
+        index.Upsert(Pack(FundB, ReportPackWorkflowStateDto.Published, SecurityLine("b.line", SecurityA)));
+
+        index.Lookup(SecurityA).Should().HaveCount(2);
+        index.Lookup(SecurityA).Select(e => e.FundProfileId).Should().BeEquivalentTo([FundA, FundB]);
+    }
+
+    [Fact]
+    public void Upsert_SameReport_RefreshesStateInPlace()
+    {
+        var index = new InMemoryReportPackSecurityLineIndex();
+        var published = Pack(FundA, ReportPackWorkflowStateDto.Published, SecurityLine("nav.line", SecurityA));
+        index.Upsert(published);
+
+        var restated = published with { State = ReportPackWorkflowStateDto.Restated };
+        index.Upsert(restated);
+
+        var entry = index.LookupByFund(SecurityA, FundA).Should().ContainSingle().Subject;
+        entry.State.Should().Be(ReportPackWorkflowStateDto.Restated);
+    }
+
+    [Fact]
+    public void Upsert_WhenSecurityNoLongerReferenced_RemovesStaleEntry()
+    {
+        var index = new InMemoryReportPackSecurityLineIndex();
+        var withSecurity = Pack(FundA, ReportPackWorkflowStateDto.Published, SecurityLine("nav.line", SecurityA));
+        index.Upsert(withSecurity);
+
+        // Re-upsert the same report with provenance that no longer references SecurityA.
+        var withoutSecurity = withSecurity with
+        {
+            LineProvenance = [new ReportPackLineProvenanceDto(LineKey: "cash.line", SourceKind: "ledger", SourceId: "ledger-1", EvidenceId: "ev-1")]
+        };
+        index.Upsert(withoutSecurity);
+
+        index.Lookup(SecurityA).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RemoveReport_RemovesAllItsEntries()
+    {
+        var index = new InMemoryReportPackSecurityLineIndex();
+        var record = Pack(FundA, ReportPackWorkflowStateDto.Published,
+            SecurityLine("a.line", SecurityA), SecurityLine("b.line", SecurityB));
+        index.Upsert(record);
+
+        index.RemoveReport(record.ReportId);
+
+        index.Lookup(SecurityA).Should().BeEmpty();
+        index.Lookup(SecurityB).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Rebuild_ReplacesEntireIndex()
+    {
+        var index = new InMemoryReportPackSecurityLineIndex();
+        index.Upsert(Pack(FundA, ReportPackWorkflowStateDto.Published, SecurityLine("stale.line", SecurityA)));
+
+        var fresh = Pack(FundB, ReportPackWorkflowStateDto.Published, SecurityLine("fresh.line", SecurityB));
+        index.Rebuild([fresh]);
+
+        index.Lookup(SecurityA).Should().BeEmpty("the prior contents are cleared on rebuild");
+        index.LookupByFund(SecurityB, FundB).Should().ContainSingle().Which.ReportId.Should().Be(fresh.ReportId);
+    }
+
+    [Fact]
+    public void Upsert_LineReferencingTwoSecurities_IndexesUnderBoth()
+    {
+        var index = new InMemoryReportPackSecurityLineIndex();
+        var line = new ReportPackLineProvenanceDto(
+            LineKey: "blended.line",
+            SourceKind: "security-master",
+            SourceId: SecurityA.ToString("D"),
+            EvidenceId: "ev-1",
+            SecurityMasterId: SecurityA.ToString("D"),
+            SecurityDefinitionId: SecurityB.ToString("D"));
+        index.Upsert(Pack(FundA, ReportPackWorkflowStateDto.Published, line));
+
+        index.Lookup(SecurityA).Should().ContainSingle();
+        index.Lookup(SecurityB).Should().ContainSingle();
+    }
+
+    [Fact]
+    public void ReferencedSecurityIds_IsExactReverseOf_LineReferencesSecurity()
+    {
+        var line = new ReportPackLineProvenanceDto(
+            LineKey: "nav.line",
+            SourceKind: "security-master",
+            SourceId: SecurityA.ToString("D"),
+            EvidenceId: "ev-1",
+            SecurityMasterId: SecurityA.ToString("D"),
+            SecurityDefinitionId: SecurityB.ToString("D"));
+
+        var referenced = ReportPackSecurityLineMatcher.ReferencedSecurityIds(line).ToArray();
+
+        referenced.Should().BeEquivalentTo([SecurityA, SecurityB]);
+        foreach (var securityId in referenced)
+        {
+            ReportPackSecurityLineMatcher.LineReferencesSecurity(line, securityId).Should().BeTrue();
+        }
+        ReportPackSecurityLineMatcher.LineReferencesSecurity(line, Guid.NewGuid()).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NonSecurityKindSource_DoesNotReferenceSecurityBySourceId()
+    {
+        // A ledger-kind source whose id happens to be a guid must NOT be treated as a security reference.
+        var line = new ReportPackLineProvenanceDto(
+            LineKey: "ledger.line",
+            SourceKind: "ledger",
+            SourceId: SecurityA.ToString("D"),
+            EvidenceId: "ev-1");
+
+        ReportPackSecurityLineMatcher.ReferencedSecurityIds(line).Should().BeEmpty();
+        ReportPackSecurityLineMatcher.LineReferencesSecurity(line, SecurityA).Should().BeFalse();
+    }
+
+    private static ReportPackLineProvenanceDto SecurityLine(string lineKey, Guid securityId)
+        => new(
+            LineKey: lineKey,
+            SourceKind: "security-master",
+            SourceId: securityId.ToString("D"),
+            EvidenceId: "ev-1",
+            SecurityMasterId: securityId.ToString("D"));
+
+    private static ReportPackWorkflowRecordDto Pack(
+        string fundProfileId, ReportPackWorkflowStateDto state, params ReportPackLineProvenanceDto[] lineProvenance)
+    {
+        var now = new DateTimeOffset(2026, 03, 31, 0, 0, 0, TimeSpan.Zero);
+        return new ReportPackWorkflowRecordDto(
+            ReportId: Guid.NewGuid(),
+            FundProfileId: fundProfileId,
+            FundAccountId: $"{fundProfileId}-acct",
+            Period: "2026-P03",
+            TemplateId: new VersionedReportTemplateIdDto("nav-pack", 1),
+            State: state,
+            Version: 1,
+            CreatedAt: now,
+            CreatedBy: "ops.analyst",
+            UpdatedAt: now,
+            AuditTrail: [new ReportPackAuditEventDto(now, "ops.analyst", "publish", ReportPackWorkflowStateDto.Approved, state)],
+            Restatement: null,
+            LineProvenance: lineProvenance);
+    }
+}

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPackSecurityLineIndexTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPackSecurityLineIndexTests.cs
@@ -149,6 +149,27 @@ public sealed class ReportPackSecurityLineIndexTests
     }
 
     [Fact]
+    public void Upsert_LineWithNullKey_StillIndexesSecurityWithoutThrowing()
+    {
+        // A null line key must not crash the Ordinal Distinct, and — unlike skipping the whole line —
+        // must not drop the security reference (that would be a silent miss, which this feature exists
+        // to avoid). The security is indexed; the null key is simply omitted from LineKeys.
+        var index = new InMemoryReportPackSecurityLineIndex();
+        var line = new ReportPackLineProvenanceDto(
+            LineKey: null!,
+            SourceKind: "security-master",
+            SourceId: SecurityA.ToString("D"),
+            EvidenceId: "ev-1",
+            SecurityMasterId: SecurityA.ToString("D"));
+
+        var act = () => index.Upsert(Pack(FundA, ReportPackWorkflowStateDto.Published, line));
+
+        act.Should().NotThrow();
+        index.LookupByFund(SecurityA, FundA).Should().ContainSingle()
+            .Which.LineKeys.Should().BeEmpty();
+    }
+
+    [Fact]
     public void NonSecurityKindSource_DoesNotReferenceSecurityBySourceId()
     {
         // A ledger-kind source whose id happens to be a guid must NOT be treated as a security reference.

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPackSecurityLineIndexTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPackSecurityLineIndexTests.cs
@@ -170,6 +170,39 @@ public sealed class ReportPackSecurityLineIndexTests
     }
 
     [Fact]
+    public void ReferencedSecurityIds_KeepsAllZeroDefinitionId_WhenMasterMissing()
+    {
+        // Regression: a failed SecurityMasterId parse must not suppress an all-zeros (Guid.Empty)
+        // SecurityDefinitionId. Otherwise ReferencedSecurityIds stops being the exact reverse of
+        // LineReferencesSecurity and the index silently misses a record the full scan still matches.
+        var line = new ReportPackLineProvenanceDto(
+            LineKey: "nav.line",
+            SourceKind: "report",
+            SourceId: "n/a",
+            EvidenceId: "ev-1",
+            SecurityMasterId: null,
+            SecurityDefinitionId: Guid.Empty.ToString("D"));
+
+        ReportPackSecurityLineMatcher.ReferencedSecurityIds(line).Should().Contain(Guid.Empty);
+        ReportPackSecurityLineMatcher.LineReferencesSecurity(line, Guid.Empty).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReferencedSecurityIds_DedupesRepeatedSecurityId()
+    {
+        // Master, definition, and security-kind source all the same id → yielded once.
+        var line = new ReportPackLineProvenanceDto(
+            LineKey: "nav.line",
+            SourceKind: "security-master",
+            SourceId: SecurityA.ToString("D"),
+            EvidenceId: "ev-1",
+            SecurityMasterId: SecurityA.ToString("D"),
+            SecurityDefinitionId: SecurityA.ToString("D"));
+
+        ReportPackSecurityLineMatcher.ReferencedSecurityIds(line).Should().ContainSingle().Which.Should().Be(SecurityA);
+    }
+
+    [Fact]
     public void NonSecurityKindSource_DoesNotReferenceSecurityBySourceId()
     {
         // A ledger-kind source whose id happens to be a guid must NOT be treated as a security reference.


### PR DESCRIPTION
<!-- phase:PR7 -->
<!-- Phase PR7: changes src/** (feature code), tests/**, and docs/** (regenerated artifacts). PR7 is the minimal cumulative phase whose allowlist covers general src/**. -->

## Summary

First of the deferred Security Master restatement follow-up slices (**S4** of the scoped sequence S4→S3→S5→S1→S2). Replaces the per-fund linear scan in `ReportPackRestatementCandidateResolver` with an **O(matches)** lookup against a derived **security→report-line index**, and extracts the shared "references this security" matcher so the resolver and the index agree on exactly one membership rule.

- **`ReportPackSecurityLineMatcher`** — behaviour-preserving extraction of the resolver's match predicate, plus `ReferencedSecurityIds` (its exact reverse) used to build the index.
- **`IReportPackSecurityLineIndex` + `InMemoryReportPackSecurityLineIndex`** — maps a security id to the report packs whose retained report-line provenance references it, with per-fund and cross-fund lookup. It is a **derived cache**, fully rebuildable from the report-pack workflow records (the source of truth), so it carries **no separate persistence** (this trims the originally-planned file store to avoid a dual-persistence consistency risk).
- **`ReportPackWorkflowService`** — routes every mutation (create / transition / reject / restate / publish) through a single `SaveAndIndex` chokepoint, backfills the index from persisted records on construction, and exposes `ListRecordsForSecurityInFund` (index-backed, with a full-scan fallback when no index is wired).
- The resolver uses the index-backed lookup; behaviour is unchanged — a **parity test** asserts index-backed results equal the full-scan results.
- DI registers the index as a singleton sharing the (singleton) workflow service lifetime.

The index's cross-fund `Lookup` ships but is consumed only internally; exposing it on a public surface is left to the cross-fund activation slice (S1).

## Reason

The merged restatement candidate resolver (PR #2022) scanned every report-pack record in a fund on each closed-period publish. This slice makes that lookup O(matches) and lays the cross-fund lookup seam S1 needs, while extracting the shared matcher that the period-narrowing (S3) and repeated-restatement (S5) slices also build on. It is the lowest-risk, independent first step in the deferred sequence and improves the just-shipped resolver directly.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — not run: `dotnet` is unavailable in the authoring environment, so the build/tests are validated here by `quality-gate`.
- [x] Relevant unit tests were added or updated — `ReportPackSecurityLineIndexTests` (upsert/lookup/cross-fund/state-refresh/stale-removal/rebuild/multi-security + matcher reverse-consistency) and a resolver index-vs-scan **parity** test in `ReportPackRestatementCandidateResolverTests`.
- [ ] Relevant integration tests were added or updated — n/a (behaviour-preserving refactor; covered by unit + parity tests).
- [ ] GitHub Actions `quality-gate` passed — pending on this PR (the reason for opening it).

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017nYikCeRK7n6GdRSEJmUGB)_