### PR TITLE
fix(wpf): contain page-load failures across all desktop workspace pages

### DIFF
--- a/src/Meridian.Wpf/Views/AccountingConfigurePage.xaml.cs
+++ b/src/Meridian.Wpf/Views/AccountingConfigurePage.xaml.cs
@@ -20,9 +20,19 @@ public partial class AccountingConfigurePage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        _loadCts?.Cancel();
-        _loadCts = new CancellationTokenSource();
-        await _viewModel.LoadAsync(_loadCts.Token);
+        try
+        {
+            _loadCts?.Cancel();
+            _loadCts = new CancellationTokenSource();
+            await _viewModel.LoadAsync(_loadCts.Token);
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Accounting Configure page failed to load.", ex);
+        }
     }
 
     private void OnPageUnloaded(object sender, RoutedEventArgs e)

--- a/src/Meridian.Wpf/Views/AccountingWorkspaceShellPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/AccountingWorkspaceShellPage.xaml.cs
@@ -58,16 +58,26 @@ public partial class AccountingWorkspaceShellPage : AccountingWorkspaceShellPage
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        _fundContextService.ActiveFundProfileChanged += OnSignalsChanged;
-        _shellContextService.SignalsChanged += OnSignalsChanged;
-        if (_operatingContextService is not null)
+        try
         {
-            _operatingContextService.ActiveContextChanged += OnOperatingContextChanged;
-            _operatingContextService.WindowModeChanged += OnSignalsChanged;
-        }
+            _fundContextService.ActiveFundProfileChanged += OnSignalsChanged;
+            _shellContextService.SignalsChanged += OnSignalsChanged;
+            if (_operatingContextService is not null)
+            {
+                _operatingContextService.ActiveContextChanged += OnOperatingContextChanged;
+                _operatingContextService.WindowModeChanged += OnSignalsChanged;
+            }
 
-        await RefreshAsync();
-        await RestoreShellDockLayoutAsync(AccountingDockManager);
+            await RefreshAsync();
+            await RestoreShellDockLayoutAsync(AccountingDockManager);
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Accounting Workspace Shell page failed to load.", ex);
+        }
     }
 
     private void OnPageUnloaded(object sender, RoutedEventArgs e)

--- a/src/Meridian.Wpf/Views/ActivityLogPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/ActivityLogPage.xaml.cs
@@ -37,8 +37,20 @@ public partial class ActivityLogPage : Page
         Unloaded += OnPageUnloaded;
     }
 
-    private async void OnPageLoaded(object sender, RoutedEventArgs e) =>
-        await _viewModel.StartAsync();
+    private async void OnPageLoaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await _viewModel.StartAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Activity Log page failed to load.", ex);
+        }
+    }
 
     private void OnPageUnloaded(object sender, RoutedEventArgs e) =>
         _viewModel.Stop();

--- a/src/Meridian.Wpf/Views/BackfillPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/BackfillPage.xaml.cs
@@ -32,16 +32,26 @@ public partial class BackfillPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        // Set default dates first; RestorePageFilterState will override with saved values
-        ToDatePicker.SelectedDate = DateTime.Today;
-        FromDatePicker.SelectedDate = DateTime.Today.AddDays(-30);
+        try
+        {
+            // Set default dates first; RestorePageFilterState will override with saved values
+            ToDatePicker.SelectedDate = DateTime.Today;
+            FromDatePicker.SelectedDate = DateTime.Today.AddDays(-30);
 
-        RestorePageFilterState();
-        UpdateProviderPrioritySummary();
-        UpdateGranularityHint();
-        RefreshStartSetupState();
+            RestorePageFilterState();
+            UpdateProviderPrioritySummary();
+            UpdateGranularityHint();
+            RefreshStartSetupState();
 
-        await _viewModel.ActivateAsync();
+            await _viewModel.ActivateAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Backfill page failed to load.", ex);
+        }
     }
 
     private void OnPageUnloaded(object sender, RoutedEventArgs e)

--- a/src/Meridian.Wpf/Views/BacktestPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/BacktestPage.xaml.cs
@@ -24,9 +24,19 @@ public partial class BacktestPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        _viewModel.EquityCurvePoints.CollectionChanged -= _equityCurvePointsChangedHandler;
-        _viewModel.EquityCurvePoints.CollectionChanged += _equityCurvePointsChangedHandler;
-        await _viewModel.ActivateAsync();
+        try
+        {
+            _viewModel.EquityCurvePoints.CollectionChanged -= _equityCurvePointsChangedHandler;
+            _viewModel.EquityCurvePoints.CollectionChanged += _equityCurvePointsChangedHandler;
+            await _viewModel.ActivateAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Backtest page failed to load.", ex);
+        }
     }
 
     private void OnPageUnloaded(object sender, RoutedEventArgs e)

--- a/src/Meridian.Wpf/Views/ChartingPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/ChartingPage.xaml.cs
@@ -15,5 +15,18 @@ public partial class ChartingPage : Page
         DataContext = _viewModel;
     }
 
-    private async void OnPageLoaded(object sender, RoutedEventArgs e) => await _viewModel.InitializeAsync();
+    private async void OnPageLoaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await _viewModel.InitializeAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Charting page failed to load.", ex);
+        }
+    }
 }

--- a/src/Meridian.Wpf/Views/CollectionSessionPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/CollectionSessionPage.xaml.cs
@@ -19,6 +19,16 @@ public partial class CollectionSessionPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        await _viewModel.LoadSessionsAsync();
+        try
+        {
+            await _viewModel.LoadSessionsAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Collection Session page failed to load.", ex);
+        }
     }
 }

--- a/src/Meridian.Wpf/Views/DataCalendarPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/DataCalendarPage.xaml.cs
@@ -29,8 +29,20 @@ public partial class DataCalendarPage : Page
         DataContext = _viewModel;
     }
 
-    private async void OnPageLoaded(object sender, RoutedEventArgs e) =>
-        await _viewModel.LoadAsync();
+    private async void OnPageLoaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await _viewModel.LoadAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Data Calendar page failed to load.", ex);
+        }
+    }
 
     private async void PreviousYear_Click(object sender, RoutedEventArgs e) =>
         await _viewModel.PreviousYearAsync();

--- a/src/Meridian.Wpf/Views/DataQualityPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/DataQualityPage.xaml.cs
@@ -35,10 +35,20 @@ public partial class DataQualityPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        await _viewModel.StartAsync();
-        CommandBar.CommandGroup = BuildCommandGroup();
-        RenderTrendChart(_viewModel.TrendPoints);
-        ApplyDrilldownHeatmap();
+        try
+        {
+            await _viewModel.StartAsync();
+            CommandBar.CommandGroup = BuildCommandGroup();
+            RenderTrendChart(_viewModel.TrendPoints);
+            ApplyDrilldownHeatmap();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Data Quality page failed to load.", ex);
+        }
     }
 
     private void OnPageUnloaded(object sender, RoutedEventArgs e) => _viewModel.Stop();

--- a/src/Meridian.Wpf/Views/DataSourcesPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/DataSourcesPage.xaml.cs
@@ -25,7 +25,17 @@ public partial class DataSourcesPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        await _viewModel.LoadAsync();
+        try
+        {
+            await _viewModel.LoadAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Data Sources page failed to load.", ex);
+        }
     }
 
     // ── Save – reads secret input before delegating ───────────────────────

--- a/src/Meridian.Wpf/Views/DirectLendingPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/DirectLendingPage.xaml.cs
@@ -17,7 +17,17 @@ public partial class DirectLendingPage : Page
 
     private async void OnPageLoaded(object sender, System.Windows.RoutedEventArgs e)
     {
-        Loaded -= OnPageLoaded;
-        await _viewModel.InitializeAsync();
+        try
+        {
+            Loaded -= OnPageLoaded;
+            await _viewModel.InitializeAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Direct Lending page failed to load.", ex);
+        }
     }
 }

--- a/src/Meridian.Wpf/Views/EnvironmentDesignerPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/EnvironmentDesignerPage.xaml.cs
@@ -82,13 +82,23 @@ public partial class EnvironmentDesignerPage : Page, INotifyPropertyChanged
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        if (_isLoaded)
+        try
         {
-            return;
-        }
+            if (_isLoaded)
+            {
+                return;
+            }
 
-        _isLoaded = true;
-        await RefreshAsync().ConfigureAwait(true);
+            _isLoaded = true;
+            await RefreshAsync().ConfigureAwait(true);
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Environment Designer page failed to load.", ex);
+        }
     }
 
     private async void OnRefreshClick(object sender, RoutedEventArgs e)

--- a/src/Meridian.Wpf/Views/ExportPresetsPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/ExportPresetsPage.xaml.cs
@@ -16,6 +16,16 @@ public partial class ExportPresetsPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        await _viewModel.InitializeAsync();
+        try
+        {
+            await _viewModel.InitializeAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Export Presets page failed to load.", ex);
+        }
     }
 }

--- a/src/Meridian.Wpf/Views/FundAccountsPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/FundAccountsPage.xaml.cs
@@ -16,5 +16,17 @@ public partial class FundAccountsPage : Page
     }
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
-        => await _viewModel.LoadFundAccountsAsync();
+    {
+        try
+        {
+            await _viewModel.LoadFundAccountsAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Fund Accounts page failed to load.", ex);
+        }
+    }
 }

--- a/src/Meridian.Wpf/Views/FundProfileSelectionPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/FundProfileSelectionPage.xaml.cs
@@ -17,6 +17,16 @@ public partial class FundProfileSelectionPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        await _viewModel.InitializeAsync();
+        try
+        {
+            await _viewModel.InitializeAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Fund Profile Selection page failed to load.", ex);
+        }
     }
 }

--- a/src/Meridian.Wpf/Views/HomeWorkspacePage.xaml.cs
+++ b/src/Meridian.Wpf/Views/HomeWorkspacePage.xaml.cs
@@ -18,6 +18,16 @@ public partial class HomeWorkspacePage : Page
 
     private async void OnLoaded(object sender, RoutedEventArgs e)
     {
-        await _viewModel.RefreshAsync();
+        try
+        {
+            await _viewModel.RefreshAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Home Workspace page failed to load.", ex);
+        }
     }
 }

--- a/src/Meridian.Wpf/Views/LiveDataViewerPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/LiveDataViewerPage.xaml.cs
@@ -48,8 +48,20 @@ public partial class LiveDataViewerPage : Page
         Unloaded += OnPageUnloaded;
     }
 
-    private async void OnPageLoaded(object sender, RoutedEventArgs e) =>
-        await _vm.ActivateAsync();
+    private async void OnPageLoaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await _vm.ActivateAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Live Data Viewer page failed to load.", ex);
+        }
+    }
 
     private void OnPageUnloaded(object sender, RoutedEventArgs e) =>
         _vm.Deactivate();

--- a/src/Meridian.Wpf/Views/OptionsPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/OptionsPage.xaml.cs
@@ -31,8 +31,20 @@ public partial class OptionsPage : Page
         DataContext = _viewModel;
     }
 
-    private async void OnPageLoaded(object sender, RoutedEventArgs e) =>
-        await _viewModel.LoadAllAsync();
+    private async void OnPageLoaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await _viewModel.LoadAllAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Options page failed to load.", ex);
+        }
+    }
 
     private async void LoadExpirations_Click(object sender, RoutedEventArgs e) =>
         await _viewModel.LoadExpirationsAsync();

--- a/src/Meridian.Wpf/Views/OrderBookPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/OrderBookPage.xaml.cs
@@ -32,8 +32,20 @@ public partial class OrderBookPage : Page
         Unloaded += OnPageUnloaded;
     }
 
-    private async void OnPageLoaded(object sender, RoutedEventArgs e) =>
-        await _viewModel.ActivateAsync();
+    private async void OnPageLoaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await _viewModel.ActivateAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Order Book page failed to load.", ex);
+        }
+    }
 
     private void OnPageUnloaded(object sender, RoutedEventArgs e)
     {

--- a/src/Meridian.Wpf/Views/PackageManagerPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/PackageManagerPage.xaml.cs
@@ -31,8 +31,20 @@ public partial class PackageManagerPage : Page
         PackageToInput.Text = today.ToString("yyyy-MM-dd");
     }
 
-    private async void OnPageLoaded(object sender, RoutedEventArgs e) =>
-        await _viewModel.LoadAsync();
+    private async void OnPageLoaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await _viewModel.LoadAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Package Manager page failed to load.", ex);
+        }
+    }
 
     private async void RefreshPackages_Click(object sender, RoutedEventArgs e) =>
         await _viewModel.RefreshPackagesCommand.ExecuteAsync(null);

--- a/src/Meridian.Wpf/Views/ProviderHealthPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/ProviderHealthPage.xaml.cs
@@ -30,8 +30,20 @@ public partial class ProviderHealthPage : Page
         Unloaded += OnPageUnloaded;
     }
 
-    private async void OnPageLoaded(object sender, RoutedEventArgs e) =>
-        await _viewModel.ActivateAsync();
+    private async void OnPageLoaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await _viewModel.ActivateAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Provider Health page failed to load.", ex);
+        }
+    }
 
     private void OnPageUnloaded(object sender, RoutedEventArgs e) =>
         _viewModel.Deactivate();

--- a/src/Meridian.Wpf/Views/ProviderPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/ProviderPage.xaml.cs
@@ -22,7 +22,17 @@ public partial class ProviderPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        await _viewModel.StartAsync(CancellationToken.None);
+        try
+        {
+            await _viewModel.StartAsync(CancellationToken.None);
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Provider page failed to load.", ex);
+        }
     }
 
     private void OnPageUnloaded(object sender, RoutedEventArgs e)

--- a/src/Meridian.Wpf/Views/RunMatPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/RunMatPage.xaml.cs
@@ -20,7 +20,17 @@ public partial class RunMatPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        await _viewModel.InitializeAsync();
+        try
+        {
+            await _viewModel.InitializeAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Run Mat page failed to load.", ex);
+        }
     }
 
     private void OnPageUnloaded(object sender, RoutedEventArgs e)

--- a/src/Meridian.Wpf/Views/ScheduleManagerPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/ScheduleManagerPage.xaml.cs
@@ -23,6 +23,16 @@ public partial class ScheduleManagerPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        await _viewModel.InitializeAsync();
+        try
+        {
+            await _viewModel.InitializeAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Schedule Manager page failed to load.", ex);
+        }
     }
 }

--- a/src/Meridian.Wpf/Views/ServiceManagerPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/ServiceManagerPage.xaml.cs
@@ -20,6 +20,16 @@ public partial class ServiceManagerPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        await _viewModel.InitializeAsync();
+        try
+        {
+            await _viewModel.InitializeAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Service Manager page failed to load.", ex);
+        }
     }
 }

--- a/src/Meridian.Wpf/Views/SetupWizardPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/SetupWizardPage.xaml.cs
@@ -13,9 +13,19 @@ public partial class SetupWizardPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        if (DataContext is SetupWizardViewModel viewModel)
+        try
         {
-            await viewModel.LoadAsync();
+            if (DataContext is SetupWizardViewModel viewModel)
+            {
+                await viewModel.LoadAsync();
+            }
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Setup Wizard page failed to load.", ex);
         }
     }
 }

--- a/src/Meridian.Wpf/Views/StorageOptimizationPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/StorageOptimizationPage.xaml.cs
@@ -33,6 +33,16 @@ public partial class StorageOptimizationPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        await _viewModel.LoadAsync();
+        try
+        {
+            await _viewModel.LoadAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Storage Optimization page failed to load.", ex);
+        }
     }
 }

--- a/src/Meridian.Wpf/Views/StoragePage.xaml.cs
+++ b/src/Meridian.Wpf/Views/StoragePage.xaml.cs
@@ -26,6 +26,16 @@ public partial class StoragePage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        await _viewModel.LoadAsync();
+        try
+        {
+            await _viewModel.LoadAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Storage page failed to load.", ex);
+        }
     }
 }

--- a/src/Meridian.Wpf/Views/StrategyRunsPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/StrategyRunsPage.xaml.cs
@@ -21,7 +21,17 @@ public partial class StrategyRunsPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        Loaded -= OnPageLoaded;
-        await _viewModel.InitializeAsync();
+        try
+        {
+            Loaded -= OnPageLoaded;
+            await _viewModel.InitializeAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Strategy Runs page failed to load.", ex);
+        }
     }
 }

--- a/src/Meridian.Wpf/Views/StrategyWorkspaceShellPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/StrategyWorkspaceShellPage.xaml.cs
@@ -29,11 +29,21 @@ public partial class StrategyWorkspaceShellPage : StrategyWorkspaceShellPageBase
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        AttachViewModelEvents();
-        ApplyToneBindings();
-        await ViewModel.StartAsync().ConfigureAwait(true);
-        ApplyToneBindings();
-        await RestoreShellDockLayoutAsync(StrategyDockManager).ConfigureAwait(true);
+        try
+        {
+            AttachViewModelEvents();
+            ApplyToneBindings();
+            await ViewModel.StartAsync().ConfigureAwait(true);
+            ApplyToneBindings();
+            await RestoreShellDockLayoutAsync(StrategyDockManager).ConfigureAwait(true);
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Strategy Workspace Shell page failed to load.", ex);
+        }
     }
 
     private void OnPageUnloaded(object sender, RoutedEventArgs e)

--- a/src/Meridian.Wpf/Views/SymbolMappingPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/SymbolMappingPage.xaml.cs
@@ -27,7 +27,17 @@ public partial class SymbolMappingPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        await _viewModel.LoadAsync();
+        try
+        {
+            await _viewModel.LoadAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Symbol Mapping page failed to load.", ex);
+        }
     }
 
     private async void ImportCsv_Click(object sender, RoutedEventArgs e)

--- a/src/Meridian.Wpf/Views/SymbolStoragePage.xaml.cs
+++ b/src/Meridian.Wpf/Views/SymbolStoragePage.xaml.cs
@@ -26,6 +26,16 @@ public partial class SymbolStoragePage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        await _viewModel.LoadAsync();
+        try
+        {
+            await _viewModel.LoadAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Symbol Storage page failed to load.", ex);
+        }
     }
 }

--- a/src/Meridian.Wpf/Views/SymbolsPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/SymbolsPage.xaml.cs
@@ -58,9 +58,19 @@ public partial class SymbolsPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        await _vm.ActivateAsync();
-        if (_vm.IsActive)
-            RestorePageFilterState();
+        try
+        {
+            await _vm.ActivateAsync();
+            if (_vm.IsActive)
+                RestorePageFilterState();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Symbols page failed to load.", ex);
+        }
     }
 
     private void SecurityType_Changed(object sender, SelectionChangedEventArgs e)

--- a/src/Meridian.Wpf/Views/SystemHealthPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/SystemHealthPage.xaml.cs
@@ -24,8 +24,20 @@ public partial class SystemHealthPage : Page
         DataContext = _viewModel;
     }
 
-    private async void OnPageLoaded(object sender, RoutedEventArgs e) =>
-        await _viewModel.StartAsync();
+    private async void OnPageLoaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await _viewModel.StartAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("System Health page failed to load.", ex);
+        }
+    }
 
     private void OnPageUnloaded(object sender, RoutedEventArgs e) =>
         _viewModel.Stop();

--- a/src/Meridian.Wpf/Views/TradingHoursPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/TradingHoursPage.xaml.cs
@@ -22,6 +22,18 @@ public partial class TradingHoursPage : Page
         DataContext = _viewModel;
     }
 
-    private async void OnPageLoaded(object sender, RoutedEventArgs e) =>
-        await _viewModel.LoadAsync();
+    private async void OnPageLoaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await _viewModel.LoadAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Trading Hours page failed to load.", ex);
+        }
+    }
 }

--- a/src/Meridian.Wpf/Views/WatchlistPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/WatchlistPage.xaml.cs
@@ -19,8 +19,20 @@ public partial class WatchlistPage : Page
         DataContext = _viewModel;
     }
 
-    private async void OnPageLoaded(object sender, RoutedEventArgs e) =>
-        await _viewModel.StartAsync();
+    private async void OnPageLoaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await _viewModel.StartAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Watchlist page failed to load.", ex);
+        }
+    }
 
     private void OnPageUnloaded(object sender, RoutedEventArgs e) =>
         _viewModel.Stop();

--- a/src/Meridian.Wpf/Views/WelcomePage.xaml.cs
+++ b/src/Meridian.Wpf/Views/WelcomePage.xaml.cs
@@ -30,8 +30,20 @@ public partial class WelcomePage : Page
         DataContext = _viewModel;
     }
 
-    private async void OnPageLoaded(object sender, RoutedEventArgs e) =>
-        await _viewModel.LoadAsync();
+    private async void OnPageLoaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await _viewModel.LoadAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Welcome page failed to load.", ex);
+        }
+    }
 
     // ── Step card click relays ─────────────────────────────────────────────────────────
     private void StepProvider_CardClick(object sender, MouseButtonEventArgs e) =>

--- a/src/Meridian.Wpf/Views/WorkspaceDeepPageHostPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/WorkspaceDeepPageHostPage.xaml.cs
@@ -53,20 +53,30 @@ public partial class WorkspaceDeepPageHostPage : Page
 
     private async void OnPageLoaded(object sender, RoutedEventArgs e)
     {
-        ApplyHostedChromeState();
-        ApplyPresentationMode();
-        CommandBar.CommandGroup = BuildCommandGroup();
-        _settingsConfigurationService.DesktopShellPreferencesChanged += OnDesktopShellPreferencesChanged;
-
-        if (!ReferenceEquals(HostedFrame.Content, _hostedPage))
+        try
         {
-            HostedFrame.Content = _hostedPage;
+            ApplyHostedChromeState();
+            ApplyPresentationMode();
+            CommandBar.CommandGroup = BuildCommandGroup();
+            _settingsConfigurationService.DesktopShellPreferencesChanged += OnDesktopShellPreferencesChanged;
+
+            if (!ReferenceEquals(HostedFrame.Content, _hostedPage))
+            {
+                HostedFrame.Content = _hostedPage;
+            }
+
+            if (_presentationMode == WorkspaceChromePresentationMode.Standalone && _shellContextService is not null)
+            {
+                _shellContextService.SignalsChanged += OnShellSignalsChanged;
+                await RefreshContextAsync();
+            }
         }
-
-        if (_presentationMode == WorkspaceChromePresentationMode.Standalone && _shellContextService is not null)
+        catch (System.OperationCanceledException)
         {
-            _shellContextService.SignalsChanged += OnShellSignalsChanged;
-            await RefreshContextAsync();
+        }
+        catch (System.Exception ex)
+        {
+            global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Workspace Deep Page Host page failed to load.", ex);
         }
     }
 


### PR DESCRIPTION
## Summary

Desktop workspace pages no longer crash the entire shell when a page's view-model load fails. The `async void` `Loaded` handlers on 38 pages awaited their view-model load (`LoadAsync`/`StartAsync`/`InitializeAsync`/`ActivateAsync`/`RefreshAsync`/etc.) with no `try`/`catch`. A non-recoverable exception thrown during load escaped the async-void state machine to the WPF dispatcher; `App.OnDispatcherUnhandledException` only marks a small recoverable set (`InvalidOperationException`, `HttpRequestException`, `TimeoutException`, `OperationCanceledException`, `IOException`) as handled, so any other type (e.g. `NullReferenceException`, `KeyNotFoundException`) tore the whole process down (exit `0xE0434352`).

Each handler's body is now wrapped so a load fault degrades to an empty/partial page and is logged via `LoggingService.LogError`, instead of exiting the desktop process. `OperationCanceledException` is swallowed (navigation away mid-load). Behavior is otherwise unchanged — synchronous setup and existing control flow inside each handler are preserved, just executed inside the guard.

## Reason

The desktop screenshot catalog (`scripts/dev/capture-desktop-screenshots.ps1`) runs a single long-lived desktop instance and steps through every page. A crash on one page killed the process, so every subsequent capture step failed (one faulting page → ~80 cascading step failures, plus noisy "property 'Width'" warnings from screenshotting the dead window). `FundLedgerPage` was contained in the prior change (PR #2023, merged); the catalog then progressed to step 87 and crashed on `ActivityLogPage` with the same defect. This change closes the entire bug class across the remaining unguarded page-load handlers so a single page fault can no longer take down the catalog (or, for operators, the whole workstation).

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [ ] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Note: the WPF desktop project targets `net10.0-windows` and is not buildable in this Linux agent; the authoritative checks are the `verify-desktop`, `WPF Dev Loop (DesktopWorkflowScriptTests)`, and `WPF W4 Acceptance` lanes on this PR. Change is a mechanical, uniform `try`/`catch` wrap (verified for balanced braces and that every touched handler is guarded); no behavior change beyond containing/logging load exceptions.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wqm3TYBfr7ujyh7ndZvvos)_