### PR TITLE
feat(security-master): period-precise restatement candidate narrowing (S3)

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -5138,6 +5138,7 @@ Meridian-main
 │   │   │   ├── ReportPackSecurityLineIndex.cs
 │   │   │   ├── ReportPackSecurityLineMatcher.cs
 │   │   │   ├── ReportPackValidationService.cs
+│   │   │   ├── ReportPeriodRange.cs
 │   │   │   ├── ReportWriterDatasetSourceService.cs
 │   │   │   ├── ReportWriterGridArtifactService.cs
 │   │   │   ├── RiskRuleRuntimeService.cs
@@ -6575,6 +6576,7 @@ Meridian-main
 │   │   │   │   ├── PublishedRevisionHandlerTests.cs
 │   │   │   │   ├── ReportPackRestatementCandidateResolverTests.cs
 │   │   │   │   ├── ReportPackSecurityLineIndexTests.cs
+│   │   │   │   ├── ReportPeriodRangeTests.cs
 │   │   │   │   ├── SecurityMasterConflictAuthorityPolicyTests.cs
 │   │   │   │   └── SecurityMasterWorkbenchCommandServiceTests.cs
 │   │   │   ├── CorporateActionCommandServiceTests.cs

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,7 +5,7 @@
 
 ## Overall Coverage
 
-**2566 / 7191** items documented (**35.7%**) &mdash; Grade: **F**
+**2567 / 7192** items documented (**35.7%**) &mdash; Grade: **F**
 
 ```text
 [=======-------------] 35.7%
@@ -15,7 +15,7 @@
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 2445 | 6696 | 36.5% | F |
+| Public Classes / Interfaces | 2446 | 6697 | 36.5% | F |
 | API Endpoints | 107 | 348 | 30.7% | F |
 | Configuration Options | 3 | 136 | 2.2% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 534,
-  "total_lines": 86324,
+  "total_lines": 86326,
   "orphaned_count": 204,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2129,7 +2129,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7240,
+      "line_count": 7242,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 534 |
-| Total lines | 86,324 |
+| Total lines | 86,326 |
 | Average file size (lines) | 161.7 |
 | Orphaned files | 204 |
 | Files without headings | 38 |

--- a/src/Meridian.Ui.Shared/Services/ReportPackRestatementCandidateResolver.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportPackRestatementCandidateResolver.cs
@@ -39,11 +39,16 @@ namespace Meridian.Ui.Shared.Services;
 /// <see cref="ReportPackSecurityLineMatcher"/>, so the index and this resolver agree on exactly which
 /// lines reference the security.</para>
 ///
+/// <para><b>Period narrowing.</b> A pack whose reporting period falls entirely before the edit's
+/// effective date cannot be affected by it and is dropped (via <see cref="ReportPeriodRange"/>). This is
+/// fail-open: only unambiguous ISO period labels (year, year-month, year-month-day) are parsed; fiscal
+/// P/Q labels and free text are kept, so narrowing reduces over-inclusion without ever causing a silent
+/// miss.</para>
+///
 /// <para><b>Deferred</b> to later slices: repeated-restatement workflow support (so an already-restated
-/// pack can be re-restated instead of only logged); narrowing candidates to the specific reporting
-/// period covering the edit's effective date (the pack <c>Period</c> is a free-form label, so
-/// period-precise filtering is not yet safe and over-inclusion stays operator-reviewed); soft-closed
-/// governed-adjustment posting; and exposing the index's cross-fund lookup on a public surface.</para>
+/// pack can be re-restated instead of only logged); soft-closed governed-adjustment posting; exposing
+/// the index's cross-fund lookup on a public surface; and a canonical period identifier that would let
+/// the narrowing parse fiscal period/quarter labels exactly.</para>
 /// </summary>
 public sealed class ReportPackRestatementCandidateResolver : IRestatementCandidateResolver
 {
@@ -94,6 +99,15 @@ public sealed class ReportPackRestatementCandidateResolver : IRestatementCandida
             var isPublished = record.State == ReportPackWorkflowStateDto.Published;
             var isRestated = record.State == ReportPackWorkflowStateDto.Restated;
             if (!isPublished && !isRestated)
+            {
+                continue;
+            }
+
+            // Period narrowing (fail-open): a pack whose reporting period falls entirely before the
+            // edit's effective date cannot be affected by it, so it is neither an actionable candidate
+            // nor a manual-follow-up signal. A period label this layer cannot confidently parse (fiscal
+            // P/Q numbers, free text) is kept, so the narrowing never introduces a silent miss.
+            if (ReportPeriodRange.IsEntirelyBefore(record.Period, effectiveDate))
             {
                 continue;
             }

--- a/src/Meridian.Ui.Shared/Services/ReportPeriodRange.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportPeriodRange.cs
@@ -1,0 +1,72 @@
+namespace Meridian.Ui.Shared.Services;
+
+/// <summary>
+/// Confidently resolves a report pack's free-form <c>Period</c> label into the calendar date range it
+/// covers — but <b>only</b> for unambiguous ISO-style labels: a bare year (<c>2026</c>), a year-month
+/// (<c>2026-05</c>), or a full date (<c>2026-05-31</c>). Fiscal period/quarter labels (<c>2026-P03</c>,
+/// <c>2026-Q1</c>) and any other free text return <c>null</c>, because mapping them to calendar dates
+/// requires a fund-specific fiscal calendar this layer does not have.
+///
+/// <para>Callers MUST treat <c>null</c> as "unknown range" and <b>fail open</b> (keep the candidate):
+/// the restatement narrowing may only <i>exclude</i> a pack it is certain falls entirely before an
+/// edit's effective date, never one whose period it cannot parse — otherwise it would risk a silent
+/// restatement miss.</para>
+/// </summary>
+public static class ReportPeriodRange
+{
+    /// <summary>
+    /// The inclusive <c>[Start, End]</c> calendar range a period label covers, or <c>null</c> when the
+    /// label is not an unambiguous ISO year / year-month / year-month-day.
+    /// </summary>
+    public static (DateOnly Start, DateOnly End)? TryParse(string? period)
+    {
+        if (string.IsNullOrWhiteSpace(period))
+        {
+            return null;
+        }
+
+        var parts = period.Trim().Split('-');
+        if (parts.Length is < 1 or > 3)
+        {
+            return null;
+        }
+
+        // The year must be a 4-digit calendar year; this is what excludes "P03"/"Q1"-style first tokens.
+        if (parts[0].Length != 4 || !int.TryParse(parts[0], out var year) || year is < 1900 or > 9999)
+        {
+            return null;
+        }
+
+        if (parts.Length == 1)
+        {
+            return (new DateOnly(year, 1, 1), new DateOnly(year, 12, 31));
+        }
+
+        // A non-numeric or out-of-range month (e.g. "P03", "Q1", "13") fails open to null.
+        if (!int.TryParse(parts[1], out var month) || month is < 1 or > 12)
+        {
+            return null;
+        }
+
+        if (parts.Length == 2)
+        {
+            return (new DateOnly(year, month, 1), new DateOnly(year, month, DateTime.DaysInMonth(year, month)));
+        }
+
+        if (!int.TryParse(parts[2], out var day) || day < 1 || day > DateTime.DaysInMonth(year, month))
+        {
+            return null;
+        }
+
+        var date = new DateOnly(year, month, day);
+        return (date, date);
+    }
+
+    /// <summary>
+    /// True only when <paramref name="period"/> parses to a confident range that ends strictly before
+    /// <paramref name="effectiveDate"/> — i.e. the period is entirely earlier than an edit effective on
+    /// that date and so cannot be affected by it. Unparseable labels return <c>false</c> (fail open).
+    /// </summary>
+    public static bool IsEntirelyBefore(string? period, DateOnly effectiveDate)
+        => TryParse(period) is { End: var end } && end < effectiveDate;
+}

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPackRestatementCandidateResolverTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPackRestatementCandidateResolverTests.cs
@@ -174,6 +174,70 @@ public sealed class ReportPackRestatementCandidateResolverTests
         indexed.HasNonActionableMatches.Should().BeTrue("the Restated same-fund pack is a non-actionable match");
     }
 
+    [Fact]
+    public async Task PackForPeriodBeforeEffectiveDate_IsExcluded()
+    {
+        var resolver = NewResolver(
+            PublishedPack(FundProfileId, "2025-12", SecurityLine("nav.line", SecurityId)));
+
+        var result = await resolver.ResolveAsync(
+            SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
+
+        result.Candidates.Should().BeEmpty("a period entirely before the edit's effective date is unaffected");
+        result.HasNonActionableMatches.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task PackForCoveringPeriod_IsCandidate()
+    {
+        var resolver = NewResolver(
+            PublishedPack(FundProfileId, "2026-03", SecurityLine("nav.line", SecurityId)));
+
+        var result = await resolver.ResolveAsync(
+            SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
+
+        result.Candidates.Should().ContainSingle("the period covers the effective date");
+    }
+
+    [Fact]
+    public async Task PackForPeriodAfterEffectiveDate_IsCandidate()
+    {
+        var resolver = NewResolver(
+            PublishedPack(FundProfileId, "2026-06", SecurityLine("nav.line", SecurityId)));
+
+        var result = await resolver.ResolveAsync(
+            SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
+
+        result.Candidates.Should().ContainSingle("a corrected value flows forward into later published periods");
+    }
+
+    [Fact]
+    public async Task PackForUnparseablePeriod_IsKept()
+    {
+        // Fail-open: a fiscal/free-form period the narrowing cannot interpret must stay a candidate.
+        var resolver = NewResolver(
+            PublishedPack(FundProfileId, "2026-P03", SecurityLine("nav.line", SecurityId)));
+
+        var result = await resolver.ResolveAsync(
+            SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
+
+        result.Candidates.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task RestatedPackForPeriodBeforeEffectiveDate_IsNotEvenFlagged()
+    {
+        // An out-of-range pack is dropped before the already-Restated handling, so it raises no manual signal.
+        var resolver = NewResolver(
+            PackInState(ReportPackWorkflowStateDto.Restated, FundProfileId, "2025-12", SecurityLine("old.line", SecurityId)));
+
+        var result = await resolver.ResolveAsync(
+            SecurityId, LedgerBookId, EffectiveDate, ["EconomicDefinition.Coupon"], FundProfileId);
+
+        result.Candidates.Should().BeEmpty();
+        result.HasNonActionableMatches.Should().BeFalse("a period before the edit is unaffected, so no manual follow-up");
+    }
+
     // ---- helpers ------------------------------------------------------------------------------
 
     private static ReportPackRestatementCandidateResolver NewResolver(params ReportPackWorkflowRecordDto[] seedRecords)

--- a/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPeriodRangeTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/Workbench/ReportPeriodRangeTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using Meridian.Ui.Shared.Services;
+
+namespace Meridian.Tests.SecurityMaster.Workbench;
+
+/// <summary>
+/// The period parser is the fail-open core of the restatement period narrowing: it must resolve
+/// unambiguous ISO labels exactly and return null (so the caller keeps the candidate) for anything it
+/// cannot confidently interpret.
+/// </summary>
+public sealed class ReportPeriodRangeTests
+{
+    [Fact]
+    public void BareYear_CoversWholeYear()
+        => ReportPeriodRange.TryParse("2026").Should().Be((new DateOnly(2026, 1, 1), new DateOnly(2026, 12, 31)));
+
+    [Fact]
+    public void YearMonth_CoversWholeMonth()
+        => ReportPeriodRange.TryParse("2026-05").Should().Be((new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 31)));
+
+    [Fact]
+    public void YearMonth_UsesActualMonthLength()
+        => ReportPeriodRange.TryParse("2026-02").Should().Be((new DateOnly(2026, 2, 1), new DateOnly(2026, 2, 28)));
+
+    [Fact]
+    public void SingleDigitMonth_IsAccepted()
+        => ReportPeriodRange.TryParse("2026-5").Should().Be((new DateOnly(2026, 5, 1), new DateOnly(2026, 5, 31)));
+
+    [Fact]
+    public void FullDate_IsASingleDay()
+        => ReportPeriodRange.TryParse("2026-05-31").Should().Be((new DateOnly(2026, 5, 31), new DateOnly(2026, 5, 31)));
+
+    [Theory]
+    [InlineData("2026-P03")]
+    [InlineData("2026-Q1")]
+    [InlineData("FY2026")]
+    [InlineData("2026-13")]      // invalid month
+    [InlineData("2026-02-30")]   // invalid day
+    [InlineData("Q1-2026")]      // year not first
+    [InlineData("")]
+    [InlineData(null)]
+    public void AmbiguousOrInvalidLabels_ReturnNull(string? period)
+        => ReportPeriodRange.TryParse(period).Should().BeNull();
+
+    [Theory]
+    [InlineData("2025-12", true)]      // entirely before
+    [InlineData("2026-02", true)]      // month before
+    [InlineData("2026-03-14", true)]   // day before
+    [InlineData("2026-03", false)]     // covers the effective date
+    [InlineData("2026-03-15", false)]  // exactly the effective date
+    [InlineData("2026-06", false)]     // after
+    [InlineData("2026-P03", false)]    // unparseable → fail open (kept)
+    [InlineData("not-a-period", false)]
+    public void IsEntirelyBefore_OnlyExcludesConfidentlyEarlierPeriods(string period, bool expected)
+        => ReportPeriodRange.IsEntirelyBefore(period, new DateOnly(2026, 3, 15)).Should().Be(expected);
+}


### PR DESCRIPTION
<!-- phase:PR7 -->
<!-- Phase PR7: changes src/** (feature code), tests/**, and docs/** (regenerated artifacts). PR7 is the minimal cumulative phase whose allowlist covers general src/**. -->

## Summary

Second deferred restatement follow-up slice (**S3** of the sequence S4→S3→S5→S1→S2; S4 merged in #2024). The candidate resolver surfaced **every** fund pack referencing the edited security regardless of reporting period; it now drops packs whose period falls **entirely before** the edit's effective date — those cannot be affected by a forward-effective correction.

- **`ReportPeriodRange`** — a **fail-open** period parser. It resolves a confident `[start, end]` range only for unambiguous ISO labels (`2026`, `2026-05`, `2026-05-31`); fiscal `P`/`Q` labels (`2026-P03`, `2026-Q1`) and free text return `null`, because mapping them needs a fund-specific fiscal calendar this layer doesn't have. `IsEntirelyBefore` excludes a period **only** when it parses **and** ends strictly before the effective date.
- The resolver applies the narrowing **before** state handling, so an out-of-range pack is neither an actionable candidate nor a manual-follow-up signal. Any pack whose period covers/follows the date, or whose label is unparseable, is kept — so the narrowing reduces over-inclusion **without ever causing a silent miss**.
- Index-vs-scan parity (from S4) is preserved: the filter runs after the lookup, equally on both paths.

## Reason

Over-inclusion: a reference-data edit effective on date *D* only affects reports for periods covering or following *D*; reports whose period entirely predates *D* used data that was correct as-of-then. Dropping those reduces false restatement candidates the operator would otherwise review. The fail-open design guarantees the filter can only remove packs it is **certain** are out of range, never one whose period it cannot parse.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — not run: `dotnet` is unavailable in the authoring environment, so the build/tests are validated here by `quality-gate`.
- [x] Relevant unit tests were added or updated — `ReportPeriodRangeTests` (ISO parse, fail-open for fiscal/invalid labels, `IsEntirelyBefore` boundaries) and resolver tests for before/covering/after/unparseable periods plus restated-before suppression.
- [ ] Relevant integration tests were added or updated — n/a (behaviour scoped to the resolver; covered by unit tests).
- [ ] GitHub Actions `quality-gate` passed — pending on this PR (the reason for opening it).

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017nYikCeRK7n6GdRSEJmUGB)_