### PR TITLE
fix(wpf): reset EnvironmentDesigner load guard on swallowed failure

### DIFF
--- a/src/Meridian.Wpf/Views/EnvironmentDesignerPage.xaml.cs
+++ b/src/Meridian.Wpf/Views/EnvironmentDesignerPage.xaml.cs
@@ -94,9 +94,14 @@ public partial class EnvironmentDesignerPage : Page, INotifyPropertyChanged
         }
         catch (System.OperationCanceledException)
         {
+            // Allow a later navigation to retry the load instead of latching empty.
+            _isLoaded = false;
         }
         catch (System.Exception ex)
         {
+            // Reset the re-entry guard so a transient load failure can recover on
+            // the next navigation rather than leaving the page permanently empty.
+            _isLoaded = false;
             global::Meridian.Wpf.Services.LoggingService.Instance.LogError("Environment Designer page failed to load.", ex);
         }
     }


### PR DESCRIPTION
## Summary

`EnvironmentDesignerPage` can recover from a failed initial load again. The page gates its load with a one-way `_isLoaded` latch:

```csharp
if (_isLoaded) return;
_isLoaded = true;
await RefreshAsync().ConfigureAwait(true);
```

After the load handler was wrapped in `try`/`catch` (PR #2025, to stop page-load faults from crashing the shell), a thrown-and-swallowed `RefreshAsync()` left `_isLoaded == true` with no reset anywhere in the file. Navigating away and back then hit `if (_isLoaded) return;` and never retried, leaving the page permanently empty. This resets `_isLoaded = false` in both catch blocks so a transient load failure can recover on the next navigation.

## Reason

Follow-up to PR #2025. A high-priority review comment flagged that swallowing the load exception strands the re-entry latch. Audited all 38 handlers wrapped in that PR: `EnvironmentDesignerPage` is the only one with a stranded load latch — the others either have no load guard or clean their state up on unload, and the pre-await event subscriptions in three pages are unaffected (the change only swapped crash-for-swallow; their subscribe/unsubscribe lifetime is unchanged).

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [ ] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Note: the WPF desktop project targets `net10.0-windows` and is not buildable in this Linux agent; the authoritative checks are the `verify-desktop`, `WPF Dev Loop (DesktopWorkflowScriptTests)`, and `WPF W4 Acceptance` lanes on this PR. The change is a two-line guard reset inside existing catch blocks.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wqm3TYBfr7ujyh7ndZvvos)_