### PR TITLE
Add read-only Robinhood connect panel to Settings

### DIFF
--- a/src/Meridian.Ui/dashboard/src/app.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.test.tsx
@@ -56,6 +56,7 @@ function mockWorkstationData(overrides: Partial<WorkstationDataSnapshot>) {
     accounting: null,
     reporting: null,
     brokerageConnection: null,
+    robinhoodConnection: null,
     providerConnections: null,
     providerReadiness: null,
     providerRoutingConnections: null,

--- a/src/Meridian.Ui/dashboard/src/app.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.tsx
@@ -104,6 +104,7 @@ function AppShell() {
     accounting,
     reporting,
     brokerageConnection,
+    robinhoodConnection,
     providerConnections,
     providerReadiness,
     providerRoutingConnections,
@@ -422,6 +423,7 @@ function AppShell() {
                       accounting={accounting}
                       reporting={reporting}
                       brokerageConnection={brokerageConnection}
+                      robinhoodConnection={robinhoodConnection}
                       providerConnections={providerConnections}
                       providerRoutingConnections={providerRoutingConnections}
                       providerRoutingBindings={providerRoutingBindings}

--- a/src/Meridian.Ui/dashboard/src/hooks/use-workstation-data.test.ts
+++ b/src/Meridian.Ui/dashboard/src/hooks/use-workstation-data.test.ts
@@ -32,6 +32,7 @@ vi.mock("@/lib/api", () => ({
   getDataWorkspace: vi.fn(),
   getAccountingWorkspace: vi.fn(),
   getAlpacaConnectionStatus: vi.fn(),
+  getRobinhoodConnectionStatus: vi.fn(),
   getProviderConnections: vi.fn(),
   getProviderReadiness: vi.fn(),
   getProviderRoutingBindings: vi.fn(),
@@ -66,6 +67,7 @@ type Deferred<T> = {
 
 const requests: Record<string, Deferred<unknown>[]> = {
   brokerageConnection: [],
+  robinhoodConnection: [],
   brokeragePortfolio: [],
   data: [],
   accounting: [],
@@ -107,6 +109,7 @@ describe("useWorkstationData", () => {
     vi.mocked(api.getAccountingWorkspace).mockImplementation(() => track<AccountingWorkspaceResponse>("accounting"));
     vi.mocked(api.getReportingWorkspace).mockImplementation(() => track<ReportingWorkspaceResponse>("reporting"));
     vi.mocked(api.getAlpacaConnectionStatus).mockImplementation(() => track<BrokerageConnectionStatus>("brokerageConnection"));
+    vi.mocked(api.getRobinhoodConnectionStatus).mockImplementation(() => track<BrokerageConnectionStatus>("robinhoodConnection"));
     vi.mocked(api.getProviderConnections).mockImplementation(() => track<ProviderConnectionRow[]>("providerConnections"));
     vi.mocked(api.getProviderReadiness).mockImplementation(() => track<ProviderReadinessSummary>("providerReadiness"));
     vi.mocked(api.getProviderRoutingConnections).mockImplementation(() => track<ProviderRoutingConnection[]>("providerRoutingConnections"));
@@ -270,6 +273,7 @@ describe("useWorkstationData", () => {
         "<!DOCTYPE HTML><html><body><h1>404</h1><p>File not found</p></body></html>"
       ));
       resolveRequest<BrokerageConnectionStatus>("brokerageConnection", 0, { marker: "brokerage" } as unknown as BrokerageConnectionStatus);
+      resolveRequest<BrokerageConnectionStatus>("robinhoodConnection", 0, { marker: "robinhood" } as unknown as BrokerageConnectionStatus);
       resolveRequest<ProviderConnectionRow[]>("providerConnections", 0, []);
       resolveRequest<ProviderReadinessSummary>("providerReadiness", 0, buildProviderReadiness("reporting-html-404"));
       resolveRequest<ProviderRoutingConnection[]>("providerRoutingConnections", 0, []);
@@ -697,6 +701,7 @@ describe("useWorkstationData", () => {
       resolveRequest<AccountingWorkspaceResponse>("accounting", 0, { marker: "accounting" } as unknown as AccountingWorkspaceResponse);
       resolveRequest<ReportingWorkspaceResponse>("reporting", 0, { marker: "reporting" } as unknown as ReportingWorkspaceResponse);
       rejectRequest("brokerageConnection", 0, new Error("Alpaca connection status failed."));
+      resolveRequest<BrokerageConnectionStatus>("robinhoodConnection", 0, { marker: "robinhood" } as unknown as BrokerageConnectionStatus);
       resolveRequest<ProviderConnectionRow[]>("providerConnections", 0, []);
       resolveRequest<ProviderReadinessSummary>("providerReadiness", 0, buildProviderReadiness("partial-failure"));
       resolveRequest<ProviderRoutingConnection[]>("providerRoutingConnections", 0, []);
@@ -954,6 +959,7 @@ function resolveSecondaryRefreshBatch(index: number, marker: string) {
   resolveRequest<DataWorkspaceResponse>("data", index, { marker: `${marker} data` } as unknown as DataWorkspaceResponse);
   resolveRequest<ReportingWorkspaceResponse>("reporting", index, { marker: `${marker} reporting` } as unknown as ReportingWorkspaceResponse);
   resolveRequest<BrokerageConnectionStatus>("brokerageConnection", index, { marker: `${marker} connection` } as unknown as BrokerageConnectionStatus);
+  resolveRequest<BrokerageConnectionStatus>("robinhoodConnection", index, { marker: `${marker} robinhood` } as unknown as BrokerageConnectionStatus);
   resolveRequest<ProviderConnectionRow[]>("providerConnections", index, []);
   resolveRequest<ProviderReadinessSummary>("providerReadiness", index, buildProviderReadiness(marker));
   resolveRequest<ProviderRoutingConnection[]>("providerRoutingConnections", index, []);
@@ -991,6 +997,7 @@ function resolveRefreshBatchWithIndexes({
   resolveRequest<AccountingWorkspaceResponse>("accounting", defaultIndex, { marker: `${marker} accounting` } as unknown as AccountingWorkspaceResponse);
   resolveRequest<ReportingWorkspaceResponse>("reporting", defaultIndex, { marker: `${marker} reporting` } as unknown as ReportingWorkspaceResponse);
   resolveRequest<BrokerageConnectionStatus>("brokerageConnection", defaultIndex, { marker: `${marker} connection` } as unknown as BrokerageConnectionStatus);
+  resolveRequest<BrokerageConnectionStatus>("robinhoodConnection", defaultIndex, { marker: `${marker} robinhood` } as unknown as BrokerageConnectionStatus);
   resolveRequest<ProviderConnectionRow[]>("providerConnections", defaultIndex, []);
   resolveRequest<ProviderReadinessSummary>("providerReadiness", defaultIndex, buildProviderReadiness(marker));
   resolveRequest<ProviderRoutingConnection[]>("providerRoutingConnections", defaultIndex, []);

--- a/src/Meridian.Ui/dashboard/src/hooks/use-workstation-data.ts
+++ b/src/Meridian.Ui/dashboard/src/hooks/use-workstation-data.ts
@@ -5,6 +5,7 @@ import {
   getDataWorkspace,
   getAccountingWorkspace,
   getAlpacaConnectionStatus,
+  getRobinhoodConnectionStatus,
   getLedgerMappingWorkbench,
   getOperationsApprovalPolicyMatrix,
   getOperationsCloseCalendar,
@@ -74,6 +75,7 @@ type RefreshDataKey =
   | "accounting"
   | "reporting"
   | "brokerageConnection"
+  | "robinhoodConnection"
   | "providerConnections"
   | "providerReadiness"
   | "providerRoutingConnections"
@@ -124,6 +126,7 @@ interface WorkstationDataState {
   accounting: AccountingWorkspaceResponse | null;
   reporting: ReportingWorkspaceResponse | null;
   brokerageConnection: BrokerageConnectionStatus | null;
+  robinhoodConnection: BrokerageConnectionStatus | null;
   providerConnections: ProviderConnectionRow[] | null;
   providerReadiness: ProviderReadinessSummary | null;
   providerRoutingConnections: ProviderRoutingConnection[] | null;
@@ -162,6 +165,7 @@ const initialState: WorkstationDataState = {
   accounting: null,
   reporting: null,
   brokerageConnection: null,
+  robinhoodConnection: null,
   providerConnections: null,
   providerReadiness: null,
   providerRoutingConnections: null,
@@ -631,6 +635,12 @@ function createRefreshEntries(
     { key: "accounting", category: "workspace", workspaceKeys: ["accounting"], promise: getAccountingWorkspace(requestOptions) },
     { key: "reporting", category: "workspace", workspaceKeys: ["reporting"], promise: getReportingWorkspace(requestOptions) },
     { key: "brokerageConnection", category: "workspace", workspaceKeys: ["portfolio"], promise: getAlpacaConnectionStatus(requestOptions) },
+    {
+      key: "robinhoodConnection",
+      category: "workspace",
+      workspaceKeys: ["settings", "portfolio"],
+      promise: getRobinhoodConnectionStatus(requestOptions)
+    },
     { key: "providerConnections", category: "workspace", workspaceKeys: ["settings", "data"], promise: getProviderConnections(requestOptions) },
     { key: "providerReadiness", category: "workspace", workspaceKeys: ["settings", "data"], promise: getProviderReadiness(requestOptions) },
     { key: "providerRoutingConnections", category: "workspace", workspaceKeys: ["settings"], promise: getProviderRoutingConnections(requestOptions) },
@@ -786,6 +796,9 @@ function assignRefreshValue(state: WorkstationDataState, key: RefreshDataKey, va
       break;
     case "brokerageConnection":
       state.brokerageConnection = value as BrokerageConnectionStatus;
+      break;
+    case "robinhoodConnection":
+      state.robinhoodConnection = value as BrokerageConnectionStatus;
       break;
     case "providerConnections":
       state.providerConnections = value as ProviderConnectionRow[];

--- a/src/Meridian.Ui/dashboard/src/lib/api.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api.ts
@@ -3608,16 +3608,16 @@ export function getQualityCompleteness() {
   return getJson<Array<{ symbol: string; score: number; sampledAt: string }>>(QUALITY_API_ENDPOINTS.completeness);
 }
 
-export function getRobinhoodConnectionStatus() {
-  return getJson<BrokerageConnectionStatus>(brokerageConnectionStatusEndpoint("robinhood"));
+export function getRobinhoodConnectionStatus(options: ApiRequestOptions = {}) {
+  return getJson<BrokerageConnectionStatus>(brokerageConnectionStatusEndpoint("robinhood"), options);
 }
 
-export function startRobinhoodConnection() {
-  return postJson<BrokerageConnectionStatus>(brokerageConnectionConnectEndpoint("robinhood"));
+export function startRobinhoodConnection(options: ApiRequestOptions = {}) {
+  return postJson<BrokerageConnectionStatus>(brokerageConnectionConnectEndpoint("robinhood"), undefined, options);
 }
 
-export function revokeRobinhoodConnection() {
-  return deleteJson<BrokerageConnectionStatus>(brokerageConnectionEndpoint("robinhood"));
+export function revokeRobinhoodConnection(options: ApiRequestOptions = {}) {
+  return deleteJson<BrokerageConnectionStatus>(brokerageConnectionEndpoint("robinhood"), options);
 }
 
 export function getPortfolioWorkspace(options: ApiRequestOptions = {}) {

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.test.tsx
@@ -2313,6 +2313,20 @@ describe("SettingsScreen", () => {
     expect(authorizationLink).toHaveAttribute("rel", "noopener noreferrer");
   });
 
+  it("mounts the Robinhood card when deep-linked to the robinhood-provider-setup hash", () => {
+    renderWithRouter(
+      <SettingsScreen
+        session={session}
+        overview={overview}
+        robinhoodConnection={robinhoodConnection}
+      />,
+      { initialEntries: ["/settings#robinhood-provider-setup"] }
+    );
+
+    expect(document.querySelector("#robinhood-provider-setup")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Connect Robinhood" })).toBeInTheDocument();
+  });
+
   it("blocks live Alpaca credential testing until the live endpoint is acknowledged", async () => {
     const user = userEvent.setup();
     renderWithRouter(

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.test.tsx
@@ -162,6 +162,24 @@ const alpacaConnection: BrokerageConnectionStatus = {
   maskedKeyId: "********1234"
 };
 
+const robinhoodConnection: BrokerageConnectionStatus = {
+  providerId: "robinhood",
+  displayName: "Robinhood",
+  state: "Connected",
+  isConfigured: true,
+  isConnected: true,
+  authorizationUrl: null,
+  connectedAt: "2026-05-07T11:50:00Z",
+  expiresAt: "2026-06-07T11:50:00Z",
+  lastError: null,
+  warnings: [],
+  scopes: ["positions:read", "balances:read"],
+  environment: null,
+  externalAccountId: "RH-987",
+  verifiedAt: null,
+  maskedKeyId: null
+};
+
 const providerConnections: ProviderConnectionRow[] = [
   {
     providerId: "alpaca",
@@ -2231,6 +2249,68 @@ describe("SettingsScreen", () => {
       "title",
       "Enter an Alpaca key ID before testing the connection."
     );
+  });
+
+  it("renders the Robinhood read-only connection card with a connect button", () => {
+    renderWithRouter(
+      <SettingsScreen
+        session={session}
+        overview={overview}
+        brokerageConnection={alpacaConnection}
+        robinhoodConnection={robinhoodConnection}
+      />
+    );
+
+    expect(screen.getByText("Robinhood (read-only)").closest("#robinhood-provider-setup")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Connect Robinhood" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Disconnect" })).toBeInTheDocument();
+    expect(screen.getByText("RH-987")).toBeInTheDocument();
+    expect(screen.getByText("positions:read, balances:read")).toBeInTheDocument();
+  });
+
+  it("shows the OAuth environment hint and blocks connect when Robinhood is not configured", () => {
+    renderWithRouter(
+      <SettingsScreen
+        session={session}
+        overview={overview}
+        brokerageConnection={alpacaConnection}
+        robinhoodConnection={{
+          ...robinhoodConnection,
+          state: "NotConfigured",
+          isConfigured: false,
+          isConnected: false,
+          connectedAt: null,
+          expiresAt: null,
+          externalAccountId: null,
+          authorizationUrl: null,
+          scopes: []
+        }}
+      />
+    );
+
+    expect(screen.getByText(/Read-only Robinhood requires an authorized aggregation provider/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Connect Robinhood" })).toBeDisabled();
+  });
+
+  it("renders the Robinhood authorization link when authorization is pending", () => {
+    renderWithRouter(
+      <SettingsScreen
+        session={session}
+        overview={overview}
+        brokerageConnection={alpacaConnection}
+        robinhoodConnection={{
+          ...robinhoodConnection,
+          state: "AuthorizationPending",
+          isConnected: false,
+          authorizationUrl: "https://aggregator.example/oauth/authorize?token=abc"
+        }}
+      />
+    );
+
+    const authorizationLink = screen.getByRole("link", { name: /Open authorization page/ });
+    expect(authorizationLink).toHaveAttribute("href", "https://aggregator.example/oauth/authorize?token=abc");
+    expect(authorizationLink).toHaveAttribute("target", "_blank");
+    expect(authorizationLink).toHaveAttribute("rel", "noopener noreferrer");
   });
 
   it("blocks live Alpaca credential testing until the live endpoint is acknowledged", async () => {

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx
@@ -564,6 +564,9 @@ function resolveSettingsTaskViewId(hash: string): SettingsTaskViewId {
   if (normalizedHash === "backend-capability-coverage") {
     return "diagnostics";
   }
+  if (normalizedHash === "robinhood-provider-setup") {
+    return "brokerage";
+  }
   return settingsTaskViews.find((view) => view.sectionId === normalizedHash)?.id ?? "overview";
 }
 

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx
@@ -55,6 +55,7 @@ import { cn } from "@/lib/utils";
 import {
   buildSettingsScreenViewModel,
   useAlpacaConnectionFormViewModel,
+  useRobinhoodConnectionViewModel,
   useSettingsRecentEventsSelectionViewModel,
   type SettingsAlpacaCredentialFieldState,
   type SettingsProfileAuthenticationStep,
@@ -131,6 +132,7 @@ interface SettingsScreenProps {
   accounting?: AccountingWorkspaceResponse | null;
   reporting?: ReportingWorkspaceResponse | null;
   brokerageConnection?: BrokerageConnectionStatus | null;
+  robinhoodConnection?: BrokerageConnectionStatus | null;
   providerConnections?: ProviderConnectionRow[] | null;
   providerRoutingConnections?: ProviderRoutingConnection[] | null;
   providerRoutingBindings?: ProviderRoutingBinding[] | null;
@@ -656,6 +658,7 @@ export function SettingsScreen({
   accounting = null,
   reporting = null,
   brokerageConnection = null,
+  robinhoodConnection = null,
   providerConnections = null,
   providerRoutingConnections = null,
   providerRoutingBindings = null,
@@ -685,6 +688,7 @@ export function SettingsScreen({
     accounting,
     reporting,
     brokerageConnection,
+    robinhoodConnection,
     providerConnections,
     providerRoutingConnections,
     providerRoutingBindings,
@@ -703,6 +707,11 @@ export function SettingsScreen({
   const alpacaForm = useAlpacaConnectionFormViewModel({
     onRefresh,
     canClear: vm.alpacaConnectionPanel.canClear
+  });
+  const robinhoodForm = useRobinhoodConnectionViewModel({
+    onRefresh,
+    canConnect: vm.robinhoodConnectionPanel.canConnect && vm.robinhoodConnectionPanel.isConfigured,
+    canDisconnect: vm.robinhoodConnectionPanel.canDisconnect
   });
   const recentEventsVm = useSettingsRecentEventsSelectionViewModel(vm.recentEventsSection);
   const inferredTaskView = useMemo(() => inferSettingsTaskView({
@@ -4394,6 +4403,119 @@ export function SettingsScreen({
                 </div>
               ))}
             </div>
+          </div>
+        </CardContent>
+      </Card>
+      ) : null}
+
+      {showBrokerageSection ? (
+      <Card
+        id="robinhood-provider-setup"
+        className={cn("panel-surface scroll-mt-6 border", diagnosticToneClass[vm.robinhoodConnectionPanel.statusTone])}
+      >
+        <CardHeader>
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <div className="eyebrow-label">Brokerage connection</div>
+              <CardTitle className="mt-2 flex items-center gap-2 text-base">
+                <ShieldCheck className="h-4 w-4 text-primary" />
+                Robinhood (read-only)
+              </CardTitle>
+              <CardDescription className="mt-2">{vm.robinhoodConnectionPanel.statusDetail}</CardDescription>
+            </div>
+            <Badge variant={vm.robinhoodConnectionPanel.badgeVariant} dot={vm.robinhoodConnectionPanel.statusTone === "success"}>
+              {vm.robinhoodConnectionPanel.stateLabel}
+            </Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(280px,0.8fr)]">
+          <div className="grid gap-3">
+            {!vm.robinhoodConnectionPanel.isConfigured ? (
+              <div className="rounded-md border border-warning/35 bg-warning/10 px-3 py-2 text-xs leading-5 text-warning">
+                Read-only Robinhood requires an authorized aggregation provider. Set the ROBINHOOD_BROKERAGE_* OAuth
+                environment variables.
+              </div>
+            ) : null}
+            {vm.robinhoodConnectionPanel.warnings.length > 0 ? (
+              <div className="rounded-md border border-warning/35 bg-warning/10 px-3 py-2 text-xs leading-5 text-warning">
+                {vm.robinhoodConnectionPanel.warnings[0]}
+              </div>
+            ) : null}
+            {vm.robinhoodConnectionPanel.authorizationUrl ? (
+              <div className="rounded-md border border-primary/35 bg-primary/10 px-3 py-2 text-xs leading-5">
+                <p className="leading-5">Complete authorization in the opened tab to finish connecting Robinhood.</p>
+                <a
+                  href={vm.robinhoodConnectionPanel.authorizationUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-2 inline-flex items-center gap-1 font-medium text-primary underline"
+                >
+                  Open authorization page
+                  <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                </a>
+              </div>
+            ) : null}
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                size="sm"
+                onClick={robinhoodForm.connect}
+                disabled={
+                  robinhoodForm.busy
+                  || !vm.robinhoodConnectionPanel.canConnect
+                  || !vm.robinhoodConnectionPanel.isConfigured
+                }
+                busy={robinhoodForm.busyAction === "connect"}
+                busyLabel="Connecting Robinhood"
+              >
+                <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+                Connect Robinhood
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={robinhoodForm.disconnect}
+                disabled={robinhoodForm.busy || !vm.robinhoodConnectionPanel.canDisconnect}
+                busy={robinhoodForm.busyAction === "disconnect"}
+                busyLabel="Disconnecting Robinhood"
+              >
+                <Trash2 className="h-4 w-4" aria-hidden="true" />
+                Disconnect
+              </Button>
+              {robinhoodForm.actionMessage ? (
+                <div
+                  role={robinhoodForm.statusRole}
+                  aria-live={robinhoodForm.statusRole === "alert" ? "assertive" : "polite"}
+                  className={robinhoodForm.statusClassName}
+                >
+                  <div>{robinhoodForm.actionMessage}</div>
+                  {robinhoodForm.actionDetails.length > 0 ? (
+                    <ul className="mt-2 list-disc space-y-1 pl-5 text-xs leading-5">
+                      {robinhoodForm.actionDetails.map((detail) => (
+                        <li key={detail}>{detail}</li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <div className="flex flex-wrap gap-2">
+              <SettingsChip label="Provider" value={vm.robinhoodConnectionPanel.providerLabel} />
+            </div>
+            <dl className="grid gap-2">
+              <SettingsFieldRow
+                label="Account"
+                value={vm.robinhoodConnectionPanel.accountLabel}
+                tone={vm.robinhoodConnectionPanel.statusTone === "success" ? "success" : "muted"}
+              />
+              <SettingsFieldRow label="Connected" value={vm.robinhoodConnectionPanel.connectedAtLabel} tone="muted" />
+              <SettingsFieldRow label="Expires" value={vm.robinhoodConnectionPanel.expiresAtLabel} tone="muted" />
+              <SettingsFieldRow label="Scopes" value={vm.robinhoodConnectionPanel.scopesLabel} tone="muted" />
+            </dl>
           </div>
         </CardContent>
       </Card>

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx
@@ -716,6 +716,9 @@ export function SettingsScreen({
     canConnect: vm.robinhoodConnectionPanel.canConnect && vm.robinhoodConnectionPanel.isConfigured,
     canDisconnect: vm.robinhoodConnectionPanel.canDisconnect
   });
+  // The status endpoint returns authorizationUrl only on the connect response, so prefer the
+  // URL the form retained over the (post-refresh null) panel value for the manual fallback link.
+  const robinhoodAuthorizationUrl = robinhoodForm.authorizationUrl ?? vm.robinhoodConnectionPanel.authorizationUrl;
   const recentEventsVm = useSettingsRecentEventsSelectionViewModel(vm.recentEventsSection);
   const inferredTaskView = useMemo(() => inferSettingsTaskView({
     overview,
@@ -4444,11 +4447,11 @@ export function SettingsScreen({
                 {vm.robinhoodConnectionPanel.warnings[0]}
               </div>
             ) : null}
-            {vm.robinhoodConnectionPanel.authorizationUrl ? (
+            {robinhoodAuthorizationUrl && vm.robinhoodConnectionPanel.canConnect ? (
               <div className="rounded-md border border-primary/35 bg-primary/10 px-3 py-2 text-xs leading-5">
                 <p className="leading-5">Complete authorization in the opened tab to finish connecting Robinhood.</p>
                 <a
-                  href={vm.robinhoodConnectionPanel.authorizationUrl}
+                  href={robinhoodAuthorizationUrl}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="mt-2 inline-flex items-center gap-1 font-medium text-primary underline"

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.view-model.test.ts
@@ -1629,6 +1629,40 @@ describe("buildSettingsScreenViewModel", () => {
     expect(result.current.actionMessage).toContain("opened tab");
   });
 
+  it("retains the authorization URL across the post-connect refresh and clears it on disconnect", async () => {
+    const startConnection = vi.fn().mockResolvedValue({
+      ...robinhoodConnection,
+      state: "AuthorizationPending",
+      isConnected: false,
+      authorizationUrl: "https://aggregator.example/oauth/authorize?token=abc"
+    });
+    const revokeConnection = vi.fn().mockResolvedValue({
+      ...robinhoodConnection,
+      state: "Disconnected",
+      isConnected: false
+    });
+    // The status endpoint returns authorizationUrl: null, so onRefresh must not erase the link.
+    const onRefresh = vi.fn();
+    const { result } = renderHook(() => useRobinhoodConnectionViewModel({
+      canConnect: true,
+      canDisconnect: true,
+      startConnection,
+      revokeConnection,
+      openAuthorizationUrl: vi.fn(),
+      onRefresh
+    }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+    expect(result.current.authorizationUrl).toBe("https://aggregator.example/oauth/authorize?token=abc");
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(result.current.authorizationUrl).toBeNull();
+  });
+
   it("ignores Robinhood connect when connect is not permitted", async () => {
     const startConnection = vi.fn();
     const { result } = renderHook(() => useRobinhoodConnectionViewModel({

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.view-model.test.ts
@@ -5,7 +5,8 @@ import {
   buildAlpacaConnectionCommandState,
   buildSettingsRecentEventsSelectionViewModel,
   buildSettingsScreenViewModel,
-  useAlpacaConnectionFormViewModel
+  useAlpacaConnectionFormViewModel,
+  useRobinhoodConnectionViewModel
 } from "@/screens/settings-screen.view-model";
 import type {
   BrokerageConnectionStatus,
@@ -62,6 +63,24 @@ const alpacaConnection: BrokerageConnectionStatus = {
   externalAccountId: "PA123",
   verifiedAt: "2026-05-07T11:50:00Z",
   maskedKeyId: "********1234"
+};
+
+const robinhoodConnection: BrokerageConnectionStatus = {
+  providerId: "robinhood",
+  displayName: "Robinhood",
+  state: "Connected",
+  isConfigured: true,
+  isConnected: true,
+  authorizationUrl: null,
+  connectedAt: "2026-05-07T11:50:00Z",
+  expiresAt: "2026-06-07T11:50:00Z",
+  lastError: null,
+  warnings: [],
+  scopes: ["positions:read", "balances:read"],
+  environment: null,
+  externalAccountId: "RH-987",
+  verifiedAt: null,
+  maskedKeyId: null
 };
 
 const providerConnections: ProviderConnectionRow[] = [
@@ -719,6 +738,98 @@ describe("buildSettingsScreenViewModel", () => {
       actionHref: "/trading/readiness",
       actionAriaLabel: "Open Trading readiness after Alpaca account verification"
     });
+  });
+
+  it("derives a connected Robinhood OAuth panel", () => {
+    const vm = buildSettingsScreenViewModel({
+      session,
+      overview,
+      robinhoodConnection
+    });
+
+    expect(vm.robinhoodConnectionPanel).toMatchObject({
+      providerLabel: "Robinhood",
+      stateLabel: "Connected",
+      statusTone: "success",
+      accountLabel: "RH-987",
+      scopesLabel: "positions:read, balances:read",
+      authorizationUrl: null,
+      isConfigured: true,
+      canConnect: false,
+      canDisconnect: true
+    });
+    expect(vm.robinhoodConnectionPanel.connectedAtLabel).toBe("2026-05-07T11:50:00Z");
+    expect(vm.robinhoodConnectionPanel.expiresAtLabel).toBe("2026-06-07T11:50:00Z");
+    expect(vm.robinhoodConnectionPanel.statusDetail).toContain("Robinhood account RH-987");
+    expect(vm.robinhoodConnectionPanel.statusDetail).not.toContain("Alpaca");
+    expect(vm.robinhoodConnectionPanel.statusDetail).not.toContain("/v2/account");
+  });
+
+  it("flags a degraded Robinhood panel with a danger tone", () => {
+    const vm = buildSettingsScreenViewModel({
+      session,
+      overview,
+      robinhoodConnection: {
+        ...robinhoodConnection,
+        state: "Degraded",
+        isConnected: false,
+        lastError: "Aggregation provider rejected the refresh token."
+      }
+    });
+
+    expect(vm.robinhoodConnectionPanel.statusTone).toBe("danger");
+    expect(vm.robinhoodConnectionPanel.badgeVariant).toBe("danger");
+    expect(vm.robinhoodConnectionPanel.statusDetail).toBe("Aggregation provider rejected the refresh token.");
+  });
+
+  it("derives an unconfigured Robinhood panel that blocks connect and disconnect", () => {
+    const vm = buildSettingsScreenViewModel({
+      session,
+      overview,
+      robinhoodConnection: {
+        ...robinhoodConnection,
+        state: "NotConfigured",
+        isConfigured: false,
+        isConnected: false,
+        connectedAt: null,
+        expiresAt: null,
+        externalAccountId: null,
+        scopes: []
+      }
+    });
+
+    expect(vm.robinhoodConnectionPanel).toMatchObject({
+      stateLabel: "Not configured",
+      statusTone: "default",
+      accountLabel: "Not linked",
+      connectedAtLabel: "Not connected",
+      expiresAtLabel: "No expiry recorded",
+      scopesLabel: "No scopes granted",
+      isConfigured: false,
+      canConnect: true,
+      canDisconnect: false
+    });
+    expect(vm.robinhoodConnectionPanel.statusDetail).toContain("ROBINHOOD_BROKERAGE_");
+    expect(vm.robinhoodConnectionPanel.statusDetail).not.toContain("Alpaca");
+  });
+
+  it("surfaces a pending Robinhood authorization URL", () => {
+    const vm = buildSettingsScreenViewModel({
+      session,
+      overview,
+      robinhoodConnection: {
+        ...robinhoodConnection,
+        state: "AuthorizationPending",
+        isConnected: false,
+        authorizationUrl: "https://aggregator.example/oauth/authorize?token=abc"
+      }
+    });
+
+    expect(vm.robinhoodConnectionPanel.authorizationUrl).toBe(
+      "https://aggregator.example/oauth/authorize?token=abc"
+    );
+    expect(vm.robinhoodConnectionPanel.statusTone).toBe("warning");
+    expect(vm.robinhoodConnectionPanel.canConnect).toBe(true);
   });
 
   it("builds profile authentication posture from session and brokerage authority", () => {
@@ -1472,6 +1583,117 @@ describe("buildSettingsScreenViewModel", () => {
       "secretKey: Secret key must include the paper account scope."
     ]);
     expect(result.current.statusRole).toBe("alert");
+  });
+
+  it("opens the Robinhood authorization URL and refreshes on connect", async () => {
+    const startConnection = vi.fn().mockResolvedValue({
+      ...robinhoodConnection,
+      state: "AuthorizationPending",
+      isConnected: false,
+      authorizationUrl: "https://aggregator.example/oauth/authorize?token=abc"
+    });
+    const openAuthorizationUrl = vi.fn();
+    const onRefresh = vi.fn();
+    const { result } = renderHook(() => useRobinhoodConnectionViewModel({
+      canConnect: true,
+      canDisconnect: false,
+      startConnection,
+      openAuthorizationUrl,
+      onRefresh
+    }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(startConnection).toHaveBeenCalledTimes(1);
+    expect(openAuthorizationUrl).toHaveBeenCalledWith("https://aggregator.example/oauth/authorize?token=abc");
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(result.current.busy).toBe(false);
+    expect(result.current.actionTone).toBe("success");
+    expect(result.current.actionMessage).toContain("opened tab");
+  });
+
+  it("ignores Robinhood connect when connect is not permitted", async () => {
+    const startConnection = vi.fn();
+    const { result } = renderHook(() => useRobinhoodConnectionViewModel({
+      canConnect: false,
+      canDisconnect: true,
+      startConnection
+    }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(startConnection).not.toHaveBeenCalled();
+  });
+
+  it("revokes the Robinhood connection and refreshes on disconnect", async () => {
+    const revokeConnection = vi.fn().mockResolvedValue({
+      ...robinhoodConnection,
+      state: "Disconnected",
+      isConnected: false
+    });
+    const onRefresh = vi.fn();
+    const { result } = renderHook(() => useRobinhoodConnectionViewModel({
+      canConnect: false,
+      canDisconnect: true,
+      revokeConnection,
+      onRefresh
+    }));
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(revokeConnection).toHaveBeenCalledTimes(1);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(result.current.actionTone).toBe("success");
+    expect(result.current.actionMessage).toBe("Robinhood connection revoked.");
+  });
+
+  it("ignores Robinhood disconnect when disconnect is not permitted", async () => {
+    const revokeConnection = vi.fn();
+    const onRefresh = vi.fn();
+    const { result } = renderHook(() => useRobinhoodConnectionViewModel({
+      canConnect: true,
+      canDisconnect: false,
+      revokeConnection,
+      onRefresh
+    }));
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(revokeConnection).not.toHaveBeenCalled();
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(result.current.busy).toBe(false);
+  });
+
+  it("reports Robinhood connect failures without throwing", async () => {
+    const startConnection = vi.fn().mockRejectedValue(
+      new ApiError({
+        path: "/api/brokerage-connections/robinhood/connect",
+        status: 502,
+        detail: "Robinhood connect failed.",
+        validationIssues: []
+      })
+    );
+    const { result } = renderHook(() => useRobinhoodConnectionViewModel({
+      canConnect: true,
+      canDisconnect: false,
+      startConnection
+    }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(result.current.actionTone).toBe("danger");
+    expect(result.current.statusRole).toBe("alert");
+    expect(result.current.busy).toBe(false);
   });
 });
 

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.view-model.test.ts
@@ -782,6 +782,21 @@ describe("buildSettingsScreenViewModel", () => {
     expect(vm.robinhoodConnectionPanel.statusDetail).toBe("Aggregation provider rejected the refresh token.");
   });
 
+  it("blocks disconnect when the Robinhood connection is already disconnected", () => {
+    const vm = buildSettingsScreenViewModel({
+      session,
+      overview,
+      robinhoodConnection: {
+        ...robinhoodConnection,
+        state: "Disconnected",
+        isConnected: false
+      }
+    });
+
+    expect(vm.robinhoodConnectionPanel.canDisconnect).toBe(false);
+    expect(vm.robinhoodConnectionPanel.canConnect).toBe(true);
+  });
+
   it("derives an unconfigured Robinhood panel that blocks connect and disconnect", () => {
     const vm = buildSettingsScreenViewModel({
       session,

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.view-model.ts
@@ -701,7 +701,7 @@ export function useRobinhoodConnectionViewModel({
       setBusyAction(null);
       setActionMessage(
         authorizationUrl
-          ? "Complete Robinhood authorization in the opened tab, then refresh."
+          ? "Complete Robinhood authorization in the opened tab (or the link below if a popup was blocked), then refresh."
           : status.isConnected
             ? "Robinhood connection is active."
             : status.lastError ?? status.warnings[0] ?? "Robinhood connection updated."
@@ -1682,7 +1682,6 @@ function buildRobinhoodConnectionPanel(connection: BrokerageConnectionStatus | n
         : "default";
   const scopes = connection?.scopes ?? [];
   const isConfigured = connection?.isConfigured === true;
-  const isConnected = connection?.isConnected === true;
 
   return {
     providerLabel: connection?.displayName ?? "Robinhood",
@@ -1698,7 +1697,7 @@ function buildRobinhoodConnectionPanel(connection: BrokerageConnectionStatus | n
     warnings: connection?.warnings ?? [],
     isConfigured,
     canConnect: state !== "Connected",
-    canDisconnect: isConfigured || isConnected
+    canDisconnect: state !== "NotConfigured" && state !== "Disconnected"
   };
 }
 

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.view-model.ts
@@ -636,6 +636,7 @@ export interface SettingsRobinhoodConnectionFormViewModel {
   actionTone: "default" | "success" | "warning" | "danger";
   statusRole: "status" | "alert";
   statusClassName: string;
+  authorizationUrl: string | null;
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
 }
@@ -662,6 +663,10 @@ export function useRobinhoodConnectionViewModel({
   const [actionMessage, setActionMessage] = useState<string | null>(null);
   const [actionDetails, setActionDetails] = useState<string[]>([]);
   const [actionTone, setActionTone] = useState<"default" | "success" | "warning" | "danger">("default");
+  // The Robinhood status endpoint only ever returns authorizationUrl on the connect
+  // response (status refreshes return null), so retain it here to keep the manual
+  // fallback link available after the post-connect refresh and across status polls.
+  const [authorizationUrl, setAuthorizationUrl] = useState<string | null>(null);
   const mountedRef = useRef(true);
   const actionRevisionRef = useRef(0);
 
@@ -688,9 +693,10 @@ export function useRobinhoodConnectionViewModel({
         return;
       }
 
-      const authorizationUrl = status.authorizationUrl?.trim();
-      if (authorizationUrl) {
-        openAuthorizationUrl(authorizationUrl);
+      const nextAuthorizationUrl = status.authorizationUrl?.trim() || null;
+      if (nextAuthorizationUrl) {
+        setAuthorizationUrl(nextAuthorizationUrl);
+        openAuthorizationUrl(nextAuthorizationUrl);
       }
 
       await onRefresh?.();
@@ -700,14 +706,14 @@ export function useRobinhoodConnectionViewModel({
 
       setBusyAction(null);
       setActionMessage(
-        authorizationUrl
+        nextAuthorizationUrl
           ? "Complete Robinhood authorization in the opened tab (or the link below if a popup was blocked), then refresh."
           : status.isConnected
             ? "Robinhood connection is active."
             : status.lastError ?? status.warnings[0] ?? "Robinhood connection updated."
       );
       setActionDetails([]);
-      setActionTone(authorizationUrl || status.isConnected ? "success" : "warning");
+      setActionTone(nextAuthorizationUrl || status.isConnected ? "success" : "warning");
     } catch (err) {
       if (!isActiveAction(mountedRef, actionRevisionRef, revision)) {
         return;
@@ -744,6 +750,7 @@ export function useRobinhoodConnectionViewModel({
         return;
       }
 
+      setAuthorizationUrl(null);
       setBusyAction(null);
       setActionMessage("Robinhood connection revoked.");
       setActionDetails([]);
@@ -769,6 +776,7 @@ export function useRobinhoodConnectionViewModel({
     actionTone,
     statusRole: actionTone === "danger" ? "alert" : "status",
     statusClassName: actionTone === "danger" ? "text-sm text-danger" : "text-sm text-muted-foreground",
+    authorizationUrl,
     connect,
     disconnect
   };

--- a/src/Meridian.Ui/dashboard/src/screens/settings-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/settings-screen.view-model.ts
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState, type FormEvent } from "react";
-import { connectAlpacaConnection, revokeAlpacaConnection } from "@/lib/api";
+import {
+  connectAlpacaConnection,
+  revokeAlpacaConnection,
+  startRobinhoodConnection,
+  revokeRobinhoodConnection
+} from "@/lib/api";
 import type { ApiRequestOptions } from "@/lib/api";
 import { describeApiError } from "@/lib/api-errors";
 import { settingsProviderConnectionRoute, WORKSTATION_ROUTE_CATALOG } from "@/lib/workspace";
@@ -617,6 +622,158 @@ function isActiveAction(
   return mountedRef.current && actionRevisionRef.current === revision;
 }
 
+interface SettingsRobinhoodConnectionDependencies {
+  startConnection?: () => Promise<BrokerageConnectionStatus>;
+  revokeConnection?: () => Promise<BrokerageConnectionStatus>;
+  openAuthorizationUrl?: (url: string) => void;
+}
+
+export interface SettingsRobinhoodConnectionFormViewModel {
+  busy: boolean;
+  busyAction: "connect" | "disconnect" | null;
+  actionMessage: string | null;
+  actionDetails: string[];
+  actionTone: "default" | "success" | "warning" | "danger";
+  statusRole: "status" | "alert";
+  statusClassName: string;
+  connect: () => Promise<void>;
+  disconnect: () => Promise<void>;
+}
+
+function defaultOpenAuthorizationUrl(url: string): void {
+  if (typeof window !== "undefined" && typeof window.open === "function") {
+    window.open(url, "_blank", "noopener");
+  }
+}
+
+export function useRobinhoodConnectionViewModel({
+  onRefresh,
+  canConnect,
+  canDisconnect,
+  startConnection = startRobinhoodConnection,
+  revokeConnection = revokeRobinhoodConnection,
+  openAuthorizationUrl = defaultOpenAuthorizationUrl
+}: {
+  onRefresh?: () => Promise<void> | void;
+  canConnect: boolean;
+  canDisconnect: boolean;
+} & SettingsRobinhoodConnectionDependencies): SettingsRobinhoodConnectionFormViewModel {
+  const [busyAction, setBusyAction] = useState<"connect" | "disconnect" | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [actionDetails, setActionDetails] = useState<string[]>([]);
+  const [actionTone, setActionTone] = useState<"default" | "success" | "warning" | "danger">("default");
+  const mountedRef = useRef(true);
+  const actionRevisionRef = useRef(0);
+
+  useEffect(() => () => {
+    mountedRef.current = false;
+    actionRevisionRef.current += 1;
+  }, []);
+
+  const connect = async () => {
+    if (!canConnect || busyAction !== null) {
+      return;
+    }
+
+    const revision = actionRevisionRef.current + 1;
+    actionRevisionRef.current = revision;
+    setBusyAction("connect");
+    setActionMessage(null);
+    setActionDetails([]);
+    setActionTone("default");
+
+    try {
+      const status = await startConnection();
+      if (!isActiveAction(mountedRef, actionRevisionRef, revision)) {
+        return;
+      }
+
+      const authorizationUrl = status.authorizationUrl?.trim();
+      if (authorizationUrl) {
+        openAuthorizationUrl(authorizationUrl);
+      }
+
+      await onRefresh?.();
+      if (!isActiveAction(mountedRef, actionRevisionRef, revision)) {
+        return;
+      }
+
+      setBusyAction(null);
+      setActionMessage(
+        authorizationUrl
+          ? "Complete Robinhood authorization in the opened tab, then refresh."
+          : status.isConnected
+            ? "Robinhood connection is active."
+            : status.lastError ?? status.warnings[0] ?? "Robinhood connection updated."
+      );
+      setActionDetails([]);
+      setActionTone(authorizationUrl || status.isConnected ? "success" : "warning");
+    } catch (err) {
+      if (!isActiveAction(mountedRef, actionRevisionRef, revision)) {
+        return;
+      }
+
+      const display = describeApiError(err, "Robinhood connection request failed.");
+      setBusyAction(null);
+      setActionMessage(display.summary);
+      setActionDetails(display.details);
+      setActionTone("danger");
+    }
+  };
+
+  const disconnect = async () => {
+    if (!canDisconnect || busyAction !== null) {
+      return;
+    }
+
+    const revision = actionRevisionRef.current + 1;
+    actionRevisionRef.current = revision;
+    setBusyAction("disconnect");
+    setActionMessage(null);
+    setActionDetails([]);
+    setActionTone("default");
+
+    try {
+      await revokeConnection();
+      if (!isActiveAction(mountedRef, actionRevisionRef, revision)) {
+        return;
+      }
+
+      await onRefresh?.();
+      if (!isActiveAction(mountedRef, actionRevisionRef, revision)) {
+        return;
+      }
+
+      setBusyAction(null);
+      setActionMessage("Robinhood connection revoked.");
+      setActionDetails([]);
+      setActionTone("success");
+    } catch (err) {
+      if (!isActiveAction(mountedRef, actionRevisionRef, revision)) {
+        return;
+      }
+
+      const display = describeApiError(err, "Robinhood disconnect request failed.");
+      setBusyAction(null);
+      setActionMessage(display.summary);
+      setActionDetails(display.details);
+      setActionTone("danger");
+    }
+  };
+
+  return {
+    busy: busyAction !== null,
+    busyAction,
+    actionMessage,
+    actionDetails,
+    actionTone,
+    statusRole: actionTone === "danger" ? "alert" : "status",
+    statusClassName: actionTone === "danger" ? "text-sm text-danger" : "text-sm text-muted-foreground",
+    connect,
+    disconnect
+  };
+}
+
 export interface SettingsSessionItem {
   label: string;
   value: string;
@@ -794,6 +951,23 @@ export interface SettingsAlpacaConnectionPanel {
   setupChecklist: SettingsAlpacaSetupStep[];
 }
 
+export interface SettingsRobinhoodConnectionPanel {
+  providerLabel: string;
+  stateLabel: string;
+  statusDetail: string;
+  statusTone: "default" | "success" | "warning" | "danger";
+  badgeVariant: "outline" | "success" | "warning" | "danger";
+  accountLabel: string;
+  connectedAtLabel: string;
+  expiresAtLabel: string;
+  scopesLabel: string;
+  authorizationUrl: string | null;
+  warnings: string[];
+  isConfigured: boolean;
+  canConnect: boolean;
+  canDisconnect: boolean;
+}
+
 export interface SettingsProviderConnectionRow {
   providerId: string;
   integrationConnectionId: string;
@@ -962,6 +1136,7 @@ export interface SettingsScreenViewModel {
   recentEventsSection: SettingsRecentEventsSection;
   providerConnectionCenter: SettingsProviderConnectionCenter;
   alpacaConnectionPanel: SettingsAlpacaConnectionPanel;
+  robinhoodConnectionPanel: SettingsRobinhoodConnectionPanel;
   diagnosticLinks: SettingsDiagnosticLink[];
   diagnosticCounts: SettingsDiagnosticCounts;
   diagnosticSummary: string;
@@ -988,6 +1163,7 @@ export interface SettingsScreenPayload {
   accounting?: AccountingWorkspaceResponse | null;
   reporting?: ReportingWorkspaceResponse | null;
   brokerageConnection?: BrokerageConnectionStatus | null;
+  robinhoodConnection?: BrokerageConnectionStatus | null;
   providerConnections?: ProviderConnectionRow[] | null;
   providerRoutingConnections?: ProviderRoutingConnection[] | null;
   providerRoutingBindings?: ProviderRoutingBinding[] | null;
@@ -1495,6 +1671,37 @@ function buildAlpacaConnectionPanel(connection: BrokerageConnectionStatus | null
   };
 }
 
+function buildRobinhoodConnectionPanel(connection: BrokerageConnectionStatus | null): SettingsRobinhoodConnectionPanel {
+  const state = connection?.state ?? "NotConfigured";
+  const tone: SettingsRobinhoodConnectionPanel["statusTone"] = state === "Connected"
+    ? "success"
+    : state === "Degraded" || state === "ReauthorizationRequired"
+      ? "danger"
+      : state === "Disconnected" || state === "AuthorizationPending"
+        ? "warning"
+        : "default";
+  const scopes = connection?.scopes ?? [];
+  const isConfigured = connection?.isConfigured === true;
+  const isConnected = connection?.isConnected === true;
+
+  return {
+    providerLabel: connection?.displayName ?? "Robinhood",
+    stateLabel: connectionStateLabel(state),
+    statusDetail: robinhoodConnectionStatusDetail(connection),
+    statusTone: tone,
+    badgeVariant: tone === "default" ? "outline" : tone,
+    accountLabel: connection?.externalAccountId?.trim() || "Not linked",
+    connectedAtLabel: connection?.connectedAt?.trim() || "Not connected",
+    expiresAtLabel: connection?.expiresAt?.trim() || "No expiry recorded",
+    scopesLabel: scopes.length > 0 ? scopes.join(", ") : "No scopes granted",
+    authorizationUrl: connection?.authorizationUrl?.trim() || null,
+    warnings: connection?.warnings ?? [],
+    isConfigured,
+    canConnect: state !== "Connected",
+    canDisconnect: isConfigured || isConnected
+  };
+}
+
 function buildAlpacaSetupChecklist(
   connection: BrokerageConnectionStatus | null,
   isLive: boolean
@@ -1601,6 +1808,29 @@ function connectionStatusDetail(connection: BrokerageConnectionStatus | null): s
   }
 
   return "No Alpaca API-key connection is stored.";
+}
+
+function robinhoodConnectionStatusDetail(connection: BrokerageConnectionStatus | null): string {
+  if (connection?.isConnected) {
+    const account = connection.externalAccountId?.trim();
+    return account
+      ? `Read-only Robinhood account ${account} is linked via OAuth.`
+      : "Read-only Robinhood account is linked via OAuth.";
+  }
+
+  if (connection?.lastError) {
+    return connection.lastError;
+  }
+
+  if (connection?.state === "AuthorizationPending" || connection?.authorizationUrl?.trim()) {
+    return "Robinhood authorization is pending. Complete the OAuth consent to finish linking.";
+  }
+
+  if (connection?.isConfigured) {
+    return "Robinhood OAuth is configured but no account is connected yet.";
+  }
+
+  return "No read-only Robinhood connection is configured. Set the ROBINHOOD_BROKERAGE_* OAuth environment variables.";
 }
 
 function buildProfileAuthenticationPanel(
@@ -2364,6 +2594,7 @@ export function buildSettingsScreenViewModel(
     payload.providerRoutingRefreshing === true
   );
   const alpacaConnectionPanel = buildAlpacaConnectionPanel(payload.brokerageConnection ?? null);
+  const robinhoodConnectionPanel = buildRobinhoodConnectionPanel(payload.robinhoodConnection ?? null);
 
   return {
     headerChips: buildSettingsHeaderChips(session, overview, diagnosticSection.diagnosticStatusLabel),
@@ -2383,6 +2614,7 @@ export function buildSettingsScreenViewModel(
     recentEventsSection: buildRecentEventsSection(overview),
     providerConnectionCenter,
     alpacaConnectionPanel,
+    robinhoodConnectionPanel,
     runtimeCapabilitySection,
     operationsControlCenter,
     assetProfileGovernancePanel,


### PR DESCRIPTION
## Summary

Adds the browser workstation surface for linking a Robinhood account via the read-only OAuth (aggregator) path. The backend OAuth service, `/api/brokerage-connections/robinhood/*` endpoints, sync adapters, and client API functions already existed; this wires Robinhood's connection status through the dashboard data layer and adds the missing **Settings → Brokerage Setup** panel, mirroring the existing Alpaca panel.

- **Data layer** (`use-workstation-data.ts`): fetch `robinhoodConnection` status on refresh, threaded through the refresh `AbortSignal` like every sibling request.
- **View-model** (`settings-screen.view-model.ts`): `buildRobinhoodConnectionPanel` + `useRobinhoodConnectionViewModel` (connect/disconnect), with Robinhood-specific OAuth status copy rather than the Alpaca/API-key wording.
- **Screen** (`settings-screen.tsx`): a "Connect Robinhood" card (anchor `robinhood-provider-setup`) with connect/disconnect actions, an authorization-URL link, and a not-configured hint pointing at the `ROBINHOOD_BROKERAGE_*` OAuth environment variables.
- **API** (`api.ts`): thread `ApiRequestOptions` through the Robinhood connection calls.

The change is additive and backward-compatible (`robinhoodConnection` defaults to `null`). The connection is **read-only** (balances/positions/activity), not order execution. Runtime aggregator OAuth configuration (`ROBINHOOD_BROKERAGE_*` endpoints/client credentials) is operator-supplied; the panel surfaces guidance when it is unset.

## Reason

There was no UI to connect a Robinhood account — the read-only OAuth backend existed but only Alpaca had a Settings panel and only Alpaca's status was wired into the dashboard data layer. This completes the operator-facing path so a Robinhood account can be linked once an authorized aggregation provider is configured.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Validation run locally: `npm --prefix src/Meridian.Ui/dashboard run build` (green) and `npm --prefix src/Meridian.Ui/dashboard run test` (full suite green, all batches). Added tests cover panel derivation (connected / unconfigured / pending / degraded), the connect & disconnect hook guards and failure handling, and screen rendering of the not-configured hint and the authorization link. `scripts/ci.sh` and the `quality-gate` check were not run locally and will execute via GitHub Actions on this PR.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdEZmHyy9xyt4CcfUYgc2f

---
_Generated by [Claude Code](https://claude.ai/code/session_01QdEZmHyy9xyt4CcfUYgc2f)_