### PR TITLE
feat(reconciliation): make local statements reconcilable via mapping profile

### DIFF
--- a/src/Meridian.FinancialOperations/Reconciliation/StatementMappingProfiles.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementMappingProfiles.cs
@@ -14,7 +14,14 @@ public enum StatementCanonicalField
     SettlementDate,
     Currency,
     FeesCommission,
-    ExternalTransactionId
+    ExternalTransactionId,
+    AccountId,
+    ExternalAccountId,
+    SecurityId,
+    UnresolvedIdentifier,
+    MarketValue,
+    Amount,
+    ExternalReference
 }
 
 public sealed record StatementFieldMapping(
@@ -101,7 +108,14 @@ public sealed class StatementMappingProfileRegistry
                 new(StatementCanonicalField.SettlementDate, "settlementDate", Required: false),
                 new(StatementCanonicalField.Currency, "currency", Required: false),
                 new(StatementCanonicalField.FeesCommission, "feesCommission", Required: false),
-                new(StatementCanonicalField.ExternalTransactionId, "externalTransactionId", Required: false)
+                new(StatementCanonicalField.ExternalTransactionId, "externalTransactionId", Required: false),
+                new(StatementCanonicalField.AccountId, "accountId", Required: false),
+                new(StatementCanonicalField.ExternalAccountId, "externalAccountId", Required: false),
+                new(StatementCanonicalField.SecurityId, "securityId", Required: false),
+                new(StatementCanonicalField.UnresolvedIdentifier, "unresolvedIdentifier", Required: false),
+                new(StatementCanonicalField.MarketValue, "marketValue", Required: false),
+                new(StatementCanonicalField.Amount, "amount", Required: false),
+                new(StatementCanonicalField.ExternalReference, "externalReference", Required: false)
             ],
             [
                 new("position", "position"),
@@ -178,6 +192,16 @@ internal sealed class StatementMappedCsvRow
 
     public DateOnly GetRequiredDate(StatementCanonicalField field, int rowNumber) =>
         DateOnly.Parse(GetRequired(field, rowNumber), CultureInfo.InvariantCulture);
+
+    public decimal? GetOptionalDecimal(StatementCanonicalField field) =>
+        GetOptional(field) is { } value && !string.IsNullOrWhiteSpace(value)
+            ? decimal.Parse(value, NumberStyles.Number, CultureInfo.InvariantCulture)
+            : null;
+
+    public DateOnly? GetOptionalDate(StatementCanonicalField field) =>
+        GetOptional(field) is { } value && !string.IsNullOrWhiteSpace(value)
+            ? DateOnly.Parse(value, CultureInfo.InvariantCulture)
+            : null;
 
     public Dictionary<string, string> ToCanonicalSnapshot()
     {

--- a/src/Meridian.FinancialOperations/Reconciliation/StatementMappingProfiles.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementMappingProfiles.cs
@@ -184,7 +184,10 @@ internal sealed class StatementMappedCsvRow
             return null;
         }
 
-        return value;
+        // Treat a blank/whitespace mapped value the same as a missing one so callers' default
+        // fallbacks (e.g. currency -> "USD", accountId -> account) apply to blank or omitted
+        // optional columns, matching the prior positional importer.
+        return string.IsNullOrWhiteSpace(value) ? null : value;
     }
 
     public decimal GetRequiredDecimal(StatementCanonicalField field, int rowNumber) =>

--- a/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationContextAdapter.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationContextAdapter.cs
@@ -20,7 +20,7 @@ public sealed class StatementReconciliationContextAdapter(StatementReconciliatio
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
-        var import = await service.ImportAsync(request.SourceKind, request.SourcePath, cancellationToken).ConfigureAwait(false);
+        var import = await service.ImportAsync(request.SourceKind, request.SourcePath, request.MappingProfileId, cancellationToken).ConfigureAwait(false);
         return new DataIntegrationIngestionResult(import.ImportId, import.SourceKind, import.SourcePath, import.RowCount);
     }
 

--- a/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
@@ -32,7 +32,7 @@ public sealed class StatementReconciliationService
         ct.ThrowIfCancellationRequested();
         var normalizedSourceKind = ValidateSourceAccess(sourceKind, sourcePath);
         var profileId = mappingProfileId;
-        if (RequiresCanonicalStatementSchema(normalizedSourceKind))
+        if (UsesCanonicalSchema(normalizedSourceKind, profileId))
         {
             var profile = ValidateStatementHeader(normalizedSourceKind, sourcePath, profileId);
             profileId = profile.ProfileId;
@@ -120,9 +120,17 @@ public sealed class StatementReconciliationService
         || string.Equals(normalizedSourceKind, "custodian", StringComparison.Ordinal)
         || string.Equals(normalizedSourceKind, "sample-broker", StringComparison.Ordinal);
 
+    // A source is parsed through the canonical, mapping-profile-driven path when its kind always
+    // requires the canonical schema, OR when the caller explicitly selects a mapping profile.
+    // The latter makes operator-supplied ('local') statements reconcilable via a chosen profile,
+    // while a 'local' source with no profile keeps its lenient raw-passthrough behavior.
+    private static bool UsesCanonicalSchema(string normalizedSourceKind, string? mappingProfileId) =>
+        RequiresCanonicalStatementSchema(normalizedSourceKind)
+        || !string.IsNullOrWhiteSpace(mappingProfileId);
+
     private ExternalStatementCaseIntakeResult CreateExternalStatementCases(string normalizedSourceKind, string sourcePath, string? mappingProfileId = null)
     {
-        if (!RequiresCanonicalStatementSchema(normalizedSourceKind))
+        if (!UsesCanonicalSchema(normalizedSourceKind, mappingProfileId))
         {
             var content = File.ReadAllText(sourcePath);
             var importId = DeterministicFingerprint.Compute($"{normalizedSourceKind}|{sourcePath}|{content}");

--- a/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
@@ -246,9 +246,10 @@ public sealed class StatementReconciliationService
             var account = mapped.GetRequired(StatementCanonicalField.Account, currentRowNumber);
             var activityType = profile.MapActivityType(mapped.GetRequired(StatementCanonicalField.ActivityType, currentRowNumber));
             var rowKind = ToStatementRowKind(activityType);
-            var symbol = rowKind == StatementRowKind.CashBalance
-                ? mapped.GetOptional(StatementCanonicalField.SecurityIdentifier) ?? string.Empty
-                : mapped.GetRequired(StatementCanonicalField.SecurityIdentifier, currentRowNumber);
+            // Symbol is optional for import: account-level cash, fee, and dividend rows legitimately
+            // omit it, matching the prior positional importer (the numeric/date canonical fields below
+            // remain required).
+            var symbol = mapped.GetOptional(StatementCanonicalField.SecurityIdentifier) ?? string.Empty;
             var quantity = mapped.GetRequiredDecimal(StatementCanonicalField.Quantity, currentRowNumber);
             var price = mapped.GetRequiredDecimal(StatementCanonicalField.Price, currentRowNumber);
             var cashAmount = mapped.GetRequiredDecimal(StatementCanonicalField.CashAmount, currentRowNumber);

--- a/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
@@ -7,16 +7,6 @@ namespace Meridian.FinancialOperations.Reconciliation;
 public sealed class StatementReconciliationService
 {
     private readonly StatementBreakClassifier _breakClassifier = new();
-    private static readonly string[] CanonicalStatementColumns =
-    [
-        "account",
-        "symbol",
-        "quantity",
-        "price",
-        "cashAmount",
-        "activityType",
-        "tradeDate"
-    ];
     private readonly StatementMappingProfileRegistry _mappingProfiles;
 
     public StatementReconciliationService(StatementMappingProfileRegistry? mappingProfiles = null)
@@ -42,13 +32,16 @@ public sealed class StatementReconciliationService
         return Task.FromResult($"Statement source '{normalizedSourceKind}:{sourcePath}' passed local file accessibility checks{profileSuffix}.");
     }
 
-    public async Task<NormalizedStatementImportResult> ImportAsync(string sourceKind, string sourcePath, CancellationToken ct)
+    public Task<NormalizedStatementImportResult> ImportAsync(string sourceKind, string sourcePath, CancellationToken ct) =>
+        ImportAsync(sourceKind, sourcePath, mappingProfileId: null, ct: ct);
+
+    public async Task<NormalizedStatementImportResult> ImportAsync(string sourceKind, string sourcePath, string? mappingProfileId, CancellationToken ct)
     {
         var normalizedSourceKind = ValidateSourceAccess(sourceKind, sourcePath);
         ct.ThrowIfCancellationRequested();
-        if (RequiresCanonicalStatementSchema(normalizedSourceKind))
+        if (UsesCanonicalSchema(normalizedSourceKind, mappingProfileId))
         {
-            return await ReadNormalizedStatementImportAsync(normalizedSourceKind, sourcePath, ct).ConfigureAwait(false);
+            return await ReadNormalizedStatementImportAsync(normalizedSourceKind, sourcePath, mappingProfileId, ct).ConfigureAwait(false);
         }
 
         var content = await File.ReadAllTextAsync(sourcePath, ct).ConfigureAwait(false);
@@ -148,15 +141,17 @@ public sealed class StatementReconciliationService
             cases);
     }
 
-    private static async Task<NormalizedStatementImportResult> ReadNormalizedStatementImportAsync(
+    private async Task<NormalizedStatementImportResult> ReadNormalizedStatementImportAsync(
         string normalizedSourceKind,
         string sourcePath,
+        string? mappingProfileId,
         CancellationToken ct)
     {
-        ValidateCanonicalStatementHeader(sourcePath);
+        var profile = ValidateStatementHeader(normalizedSourceKind, sourcePath, mappingProfileId);
+        var header = File.ReadLines(sourcePath).First().Split(',', StringSplitOptions.TrimEntries);
 
         var content = await File.ReadAllTextAsync(sourcePath, ct).ConfigureAwait(false);
-        var importId = DeterministicFingerprint.Compute($"{normalizedSourceKind}|{sourcePath}|{content}");
+        var importId = DeterministicFingerprint.Compute($"{normalizedSourceKind}|{profile.ProfileId}|{sourcePath}|{content}");
         var positions = new List<StatementPosition>();
         var cashBalances = new List<StatementCashBalance>();
         var transactions = new List<StatementTransaction>();
@@ -241,30 +236,47 @@ public sealed class StatementReconciliationService
         ParsedStatementLine ParseCanonicalStatementLine(string line, int currentRowNumber)
         {
             var parts = line.Split(',', StringSplitOptions.TrimEntries);
-            if (parts.Length < CanonicalStatementColumns.Length)
+            if (parts.Length < header.Length)
             {
-                throw new InvalidDataException($"Statement row {currentRowNumber} has {parts.Length} columns; expected at least {CanonicalStatementColumns.Length}.");
+                throw new InvalidDataException($"Statement row {currentRowNumber} has {parts.Length} columns; expected at least {header.Length} for mapping profile '{profile.ProfileId}'.");
             }
 
-            var account = parts[0];
-            var symbol = parts[1];
-            var quantity = decimal.Parse(parts[2], CultureInfo.InvariantCulture);
-            var price = decimal.Parse(parts[3], CultureInfo.InvariantCulture);
-            var cashAmount = decimal.Parse(parts[4], CultureInfo.InvariantCulture);
-            var activityType = parts[5];
-            var tradeDate = DateOnly.Parse(parts[6], CultureInfo.InvariantCulture);
-            var sourceRow = CreateSourceRowReference(importId, currentRowNumber, line, CreateRawSnapshot(importId, normalizedSourceKind, sourcePath, currentRowNumber, line, parts));
-            var snapshot = sourceRow.RawSnapshot;
-            var securityId = GetOptional(parts, 9);
-            var unresolvedIdentifier = GetOptional(parts, 10) ?? (string.IsNullOrWhiteSpace(symbol) ? null : symbol);
-            var currency = GetOptional(parts, 11) ?? "USD";
-            var marketValue = GetOptionalDecimal(parts, 12) ?? price * quantity;
-            var settlementDate = GetOptionalDate(parts, 13);
-            var amount = GetOptionalDecimal(parts, 14) ?? (cashAmount == 0m ? marketValue : cashAmount);
-            var feesCommission = GetOptionalDecimal(parts, 15) ?? 0m;
-            var externalReference = GetOptional(parts, 16);
-            var externalAccountId = GetOptional(parts, 8) ?? account;
-            var accountId = GetOptional(parts, 7) ?? account;
+            var mapped = new StatementMappedCsvRow(profile, BuildColumnMap(header, parts));
+            var account = mapped.GetRequired(StatementCanonicalField.Account, currentRowNumber);
+            var activityType = profile.MapActivityType(mapped.GetRequired(StatementCanonicalField.ActivityType, currentRowNumber));
+            var rowKind = ToStatementRowKind(activityType);
+            var symbol = rowKind == StatementRowKind.CashBalance
+                ? mapped.GetOptional(StatementCanonicalField.SecurityIdentifier) ?? string.Empty
+                : mapped.GetRequired(StatementCanonicalField.SecurityIdentifier, currentRowNumber);
+            var quantity = mapped.GetRequiredDecimal(StatementCanonicalField.Quantity, currentRowNumber);
+            var price = mapped.GetRequiredDecimal(StatementCanonicalField.Price, currentRowNumber);
+            var cashAmount = mapped.GetRequiredDecimal(StatementCanonicalField.CashAmount, currentRowNumber);
+            var tradeDate = mapped.GetRequiredDate(StatementCanonicalField.TradeDate, currentRowNumber);
+            var settlementDate = mapped.GetOptionalDate(StatementCanonicalField.SettlementDate);
+            var currency = mapped.GetOptional(StatementCanonicalField.Currency) ?? "USD";
+            var marketValue = mapped.GetOptionalDecimal(StatementCanonicalField.MarketValue) ?? price * quantity;
+            var amount = mapped.GetOptionalDecimal(StatementCanonicalField.Amount) ?? (cashAmount == 0m ? marketValue : cashAmount);
+            var feesCommission = mapped.GetOptionalDecimal(StatementCanonicalField.FeesCommission) ?? 0m;
+            var externalReference = mapped.GetOptional(StatementCanonicalField.ExternalReference)
+                ?? mapped.GetOptional(StatementCanonicalField.ExternalTransactionId);
+            var securityId = mapped.GetOptional(StatementCanonicalField.SecurityId);
+            var unresolvedIdentifier = mapped.GetOptional(StatementCanonicalField.UnresolvedIdentifier)
+                ?? (string.IsNullOrWhiteSpace(symbol) ? null : symbol);
+            var accountId = mapped.GetOptional(StatementCanonicalField.AccountId) ?? account;
+            var externalAccountId = mapped.GetOptional(StatementCanonicalField.ExternalAccountId) ?? account;
+
+            var snapshot = mapped.ToCanonicalSnapshot();
+            snapshot["importId"] = importId;
+            snapshot["sourceKind"] = normalizedSourceKind;
+            snapshot["sourcePath"] = sourcePath;
+            snapshot["mappingProfileId"] = profile.ProfileId;
+            snapshot["account"] = account;
+            snapshot["symbol"] = symbol;
+            snapshot["activityType"] = activityType;
+            snapshot["tradeDate"] = tradeDate.ToString("O");
+            snapshot["rowNumber"] = currentRowNumber.ToString(CultureInfo.InvariantCulture);
+            snapshot["rawLine"] = line;
+            var sourceRow = CreateSourceRowReference(importId, currentRowNumber, line, snapshot);
             var security = new StatementSecurityReference(importId, currentRowNumber, sourceRow.SourceRowHash, snapshot, securityId, unresolvedIdentifier, currency);
 
             return new ParsedStatementLine(
@@ -362,22 +374,6 @@ public sealed class StatementReconciliationService
     }
 
 
-    private static void ValidateCanonicalStatementHeader(string sourcePath)
-    {
-        var header = File.ReadLines(sourcePath).FirstOrDefault();
-        if (string.IsNullOrWhiteSpace(header))
-        {
-            throw new InvalidDataException("Statement source file is empty.");
-        }
-
-        var actual = header.Split(',', StringSplitOptions.TrimEntries);
-        EnsureUniqueStatementHeaderColumns(actual, StatementMappingProfileRegistry.CanonicalCsvV1ProfileId);
-        if (!CanonicalCsvHeaderPrefixMatches(actual))
-        {
-            throw new InvalidDataException("Statement source must use the canonical external statement header: account,symbol,quantity,price,cashAmount,activityType,tradeDate.");
-        }
-    }
-
     private StatementMappingProfile ValidateStatementHeader(string normalizedSourceKind, string sourcePath, string? mappingProfileId = null)
     {
         var profile = _mappingProfiles.ResolveForSourceKind(normalizedSourceKind, mappingProfileId);
@@ -458,68 +454,6 @@ public sealed class StatementReconciliationService
         string line,
         IReadOnlyDictionary<string, string> rawSnapshot)
         => new(importId, rowNumber, DeterministicFingerprint.Compute($"{importId}|{rowNumber}|{line}"), rawSnapshot);
-
-    private static IReadOnlyDictionary<string, string> CreateRawSnapshot(
-        string importId,
-        string normalizedSourceKind,
-        string sourcePath,
-        int rowNumber,
-        string line,
-        string[] parts)
-    {
-        var snapshot = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["importId"] = importId,
-            ["sourceKind"] = normalizedSourceKind,
-            ["sourcePath"] = sourcePath,
-            ["account"] = parts[0],
-            ["symbol"] = parts[1],
-            ["quantity"] = parts[2],
-            ["price"] = parts[3],
-            ["cashAmount"] = parts[4],
-            ["activityType"] = parts[5],
-            ["tradeDate"] = parts[6],
-            ["rowNumber"] = rowNumber.ToString(),
-            ["rawLine"] = line
-        };
-
-        AddOptional(snapshot, "accountId", parts, 7);
-        AddOptional(snapshot, "externalAccountId", parts, 8);
-        AddOptional(snapshot, "securityId", parts, 9);
-        AddOptional(snapshot, "unresolvedIdentifier", parts, 10);
-        AddOptional(snapshot, "currency", parts, 11);
-        AddOptional(snapshot, "marketValue", parts, 12);
-        AddOptional(snapshot, "settlementDate", parts, 13);
-        AddOptional(snapshot, "amount", parts, 14);
-        AddOptional(snapshot, "feesCommission", parts, 15);
-        AddOptional(snapshot, "externalReference", parts, 16);
-        return snapshot;
-    }
-
-    private static void AddOptional(Dictionary<string, string> snapshot, string key, string[] parts, int index)
-    {
-        var value = GetOptional(parts, index);
-        if (value is not null)
-        {
-            snapshot[key] = value;
-        }
-    }
-
-    private static string? GetOptional(string[] parts, int index)
-    {
-        if (parts.Length <= index || string.IsNullOrWhiteSpace(parts[index]))
-        {
-            return null;
-        }
-
-        return parts[index];
-    }
-
-    private static decimal? GetOptionalDecimal(string[] parts, int index) =>
-        GetOptional(parts, index) is { } value ? decimal.Parse(value, CultureInfo.InvariantCulture) : null;
-
-    private static DateOnly? GetOptionalDate(string[] parts, int index) =>
-        GetOptional(parts, index) is { } value ? DateOnly.Parse(value, CultureInfo.InvariantCulture) : null;
 
     private static StatementRowKind ToStatementRowKind(string activityType)
     {

--- a/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
@@ -345,6 +345,13 @@ public sealed class StatementReconciliationService
             var currency = mapped.GetOptional(StatementCanonicalField.Currency) ?? "USD";
             var feesCommission = mapped.GetOptional(StatementCanonicalField.FeesCommission);
             var externalTransactionId = mapped.GetOptional(StatementCanonicalField.ExternalTransactionId);
+            // Economic amount, derived consistently with the import path: prefer an explicit mapped
+            // amount, then a non-zero cash amount, then market value (or price * quantity), so a row
+            // carrying its value in the optional amount column is not classified as zero on intake.
+            var amount = mapped.GetOptionalDecimal(StatementCanonicalField.Amount)
+                ?? (cashAmount == 0m
+                    ? mapped.GetOptionalDecimal(StatementCanonicalField.MarketValue) ?? price * quantity
+                    : cashAmount);
             var rowFingerprint = DeterministicFingerprint.Compute($"{importId}|{rowNumber}|{line}");
             var rawSnapshot = mapped.ToCanonicalSnapshot();
             rawSnapshot["importId"] = importId;
@@ -371,7 +378,7 @@ public sealed class StatementReconciliationService
                 rowKind,
                 symbol,
                 quantity,
-                cashAmount == 0m ? price * quantity : cashAmount,
+                amount,
                 new DateTimeOffset(tradeDate.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero),
                 currency,
                 rowFingerprint,

--- a/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
@@ -246,10 +246,13 @@ public sealed class StatementReconciliationService
             var account = mapped.GetRequired(StatementCanonicalField.Account, currentRowNumber);
             var activityType = profile.MapActivityType(mapped.GetRequired(StatementCanonicalField.ActivityType, currentRowNumber));
             var rowKind = ToStatementRowKind(activityType);
-            // Symbol is optional for import: account-level cash, fee, and dividend rows legitimately
-            // omit it, matching the prior positional importer (the numeric/date canonical fields below
-            // remain required).
-            var symbol = mapped.GetOptional(StatementCanonicalField.SecurityIdentifier) ?? string.Empty;
+            // Position rows must carry a security identifier (MatchRows auto-matches positions
+            // without re-checking the symbol, so a blank one would become a false high-confidence
+            // match instead of a security-mapping break). Account-level cash/fee/dividend and other
+            // activity rows may omit it, matching the prior positional importer.
+            var symbol = rowKind == StatementRowKind.Position
+                ? mapped.GetRequired(StatementCanonicalField.SecurityIdentifier, currentRowNumber)
+                : mapped.GetOptional(StatementCanonicalField.SecurityIdentifier) ?? string.Empty;
             var quantity = mapped.GetRequiredDecimal(StatementCanonicalField.Quantity, currentRowNumber);
             var price = mapped.GetRequiredDecimal(StatementCanonicalField.Price, currentRowNumber);
             var cashAmount = mapped.GetRequiredDecimal(StatementCanonicalField.CashAmount, currentRowNumber);
@@ -329,9 +332,11 @@ public sealed class StatementReconciliationService
             var account = mapped.GetRequired(StatementCanonicalField.Account, rowNumber);
             var activityType = profile.MapActivityType(mapped.GetRequired(StatementCanonicalField.ActivityType, rowNumber));
             var rowKind = ToStatementRowKind(activityType);
-            // Symbol is optional (account-level cash/fee/dividend rows omit it), consistent with the
-            // import path; required numeric/date fields are still enforced below.
-            var symbol = mapped.GetOptional(StatementCanonicalField.SecurityIdentifier) ?? string.Empty;
+            // Position rows must carry a security identifier (see import path); account-level
+            // cash/fee/dividend and other activity rows may omit it. Kept consistent across both paths.
+            var symbol = rowKind == StatementRowKind.Position
+                ? mapped.GetRequired(StatementCanonicalField.SecurityIdentifier, rowNumber)
+                : mapped.GetOptional(StatementCanonicalField.SecurityIdentifier) ?? string.Empty;
             var quantity = mapped.GetRequiredDecimal(StatementCanonicalField.Quantity, rowNumber);
             var price = mapped.GetRequiredDecimal(StatementCanonicalField.Price, rowNumber);
             var cashAmount = mapped.GetRequiredDecimal(StatementCanonicalField.CashAmount, rowNumber);

--- a/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
@@ -329,9 +329,9 @@ public sealed class StatementReconciliationService
             var account = mapped.GetRequired(StatementCanonicalField.Account, rowNumber);
             var activityType = profile.MapActivityType(mapped.GetRequired(StatementCanonicalField.ActivityType, rowNumber));
             var rowKind = ToStatementRowKind(activityType);
-            var symbol = rowKind == StatementRowKind.CashBalance
-                ? mapped.GetOptional(StatementCanonicalField.SecurityIdentifier) ?? string.Empty
-                : mapped.GetRequired(StatementCanonicalField.SecurityIdentifier, rowNumber);
+            // Symbol is optional (account-level cash/fee/dividend rows omit it), consistent with the
+            // import path; required numeric/date fields are still enforced below.
+            var symbol = mapped.GetOptional(StatementCanonicalField.SecurityIdentifier) ?? string.Empty;
             var quantity = mapped.GetRequiredDecimal(StatementCanonicalField.Quantity, rowNumber);
             var price = mapped.GetRequiredDecimal(StatementCanonicalField.Price, rowNumber);
             var cashAmount = mapped.GetRequiredDecimal(StatementCanonicalField.CashAmount, rowNumber);

--- a/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
@@ -132,8 +132,14 @@ public sealed class StatementReconciliationService
 
         var rows = ReadCanonicalStatementRows(normalizedSourceKind, sourcePath, mappingProfileId);
         var (matches, cases) = MatchRows(rows);
+        // Compute the import id from the resolved profile and file content, identical to the import
+        // path (and to ReadCanonicalStatementRows for non-empty files), so import and reconcile/intake
+        // refer to the same run even for a valid but empty (header-only) statement.
+        var profile = _mappingProfiles.ResolveForSourceKind(normalizedSourceKind, mappingProfileId);
+        var canonicalContent = File.ReadAllText(sourcePath);
+        var canonicalImportId = DeterministicFingerprint.Compute($"{normalizedSourceKind}|{profile.ProfileId}|{sourcePath}|{canonicalContent}");
         return new ExternalStatementCaseIntakeResult(
-            rows.Count == 0 ? DeterministicFingerprint.Compute($"{normalizedSourceKind}|{mappingProfileId}|{sourcePath}") : rows[0].RawSnapshot["importId"],
+            canonicalImportId,
             normalizedSourceKind,
             sourcePath,
             rows.Count,

--- a/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
@@ -236,9 +236,10 @@ public sealed class StatementReconciliationService
         ParsedStatementLine ParseCanonicalStatementLine(string line, int currentRowNumber)
         {
             var parts = line.Split(',', StringSplitOptions.TrimEntries);
-            if (parts.Length < header.Length)
+            var requiredColumnCount = RequiredColumnCount(profile, header);
+            if (parts.Length < requiredColumnCount)
             {
-                throw new InvalidDataException($"Statement row {currentRowNumber} has {parts.Length} columns; expected at least {header.Length} for mapping profile '{profile.ProfileId}'.");
+                throw new InvalidDataException($"Statement row {currentRowNumber} has {parts.Length} columns; expected at least {requiredColumnCount} required columns for mapping profile '{profile.ProfileId}'.");
             }
 
             var mapped = new StatementMappedCsvRow(profile, BuildColumnMap(header, parts));
@@ -317,9 +318,10 @@ public sealed class StatementReconciliationService
             }
 
             var parts = line.Split(',', StringSplitOptions.TrimEntries);
-            if (parts.Length < header.Length)
+            var requiredColumnCount = RequiredColumnCount(profile, header);
+            if (parts.Length < requiredColumnCount)
             {
-                throw new InvalidDataException($"Statement row {rowNumber} has {parts.Length} columns; expected at least {header.Length} for mapping profile '{profile.ProfileId}'.");
+                throw new InvalidDataException($"Statement row {rowNumber} has {parts.Length} columns; expected at least {requiredColumnCount} required columns for mapping profile '{profile.ProfileId}'.");
             }
 
             var mapped = new StatementMappedCsvRow(profile, BuildColumnMap(header, parts));
@@ -446,6 +448,29 @@ public sealed class StatementReconciliationService
         }
 
         return map;
+    }
+
+    // The number of leading columns a data row must contain to cover every required mapped field.
+    // Optional trailing columns may be omitted by an individual row (BuildColumnMap pads them empty);
+    // such rows default their optional values rather than being rejected for being shorter than the
+    // full header.
+    private static int RequiredColumnCount(StatementMappingProfile profile, string[] header)
+    {
+        var requiredColumns = profile.FieldMappings
+            .Where(mapping => mapping.Required)
+            .Select(mapping => mapping.SourceColumn)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var lastRequiredIndex = -1;
+        for (var i = 0; i < header.Length; i++)
+        {
+            if (requiredColumns.Contains(header[i]))
+            {
+                lastRequiredIndex = i;
+            }
+        }
+
+        return lastRequiredIndex + 1;
     }
 
     private static StatementSourceRowReference CreateSourceRowReference(

--- a/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
@@ -514,4 +514,31 @@ public sealed class StatementReconciliationServiceTests
         }
     }
 
+    [Fact]
+    public async Task ImportAsync_BlankOptionalColumns_ApplyDefaults()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            // Optional columns present but blank must fall back to their defaults (currency -> USD,
+            // accountId -> account), not become empty strings.
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "account,symbol,quantity,price,cashAmount,activityType,tradeDate,accountId,currency",
+                "EXT-1,SPY,10,500,0,position,2026-05-29,,"
+            ]);
+
+            var result = await svc.ImportAsync("broker", filePath, CancellationToken.None);
+
+            var position = Assert.Single(result.Positions);
+            Assert.Equal("USD", position.Currency);
+            Assert.Equal("EXT-1", position.AccountId);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
 }

--- a/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
@@ -355,4 +355,57 @@ public sealed class StatementReconciliationServiceTests
         }
     }
 
+    [Fact]
+    public async Task ImportAsync_LocalStatement_WithProfile_ProducesTypedCollections()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "account,symbol,quantity,price,cashAmount,activityType,tradeDate",
+                "LOC-1,SPY,10,500,0,position,2026-05-29",
+                "LOC-1,,0,0,125.25,cash,2026-05-29"
+            ]);
+
+            var result = await svc.ImportAsync(
+                "local", filePath, StatementMappingProfileRegistry.CanonicalCsvV1ProfileId, CancellationToken.None);
+
+            // With a profile, a 'local' source is normalized into typed collections rather than
+            // returned as raw rows.
+            Assert.Equal(2, result.RowCount);
+            Assert.Single(result.Positions);
+            Assert.Single(result.CashBalances);
+            Assert.Equal(10m, result.Positions[0].Quantity);
+            Assert.Equal(125.25m, result.CashBalances[0].Amount);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public async Task ImportAsync_LocalStatement_WithoutProfile_RemainsRawRowCount()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            // Backward compatibility: no profile means the lenient raw passthrough is preserved.
+            await File.WriteAllLinesAsync(filePath, ["header", "row1", "row2"]);
+
+            var result = await svc.ImportAsync("local", filePath, CancellationToken.None);
+
+            Assert.Equal(2, result.RowCount);
+            Assert.Empty(result.Positions);
+            Assert.Empty(result.CashBalances);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
 }

--- a/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
@@ -490,4 +490,28 @@ public sealed class StatementReconciliationServiceTests
         }
     }
 
+    [Fact]
+    public async Task ImportAsync_SymbolLessPositionRow_Throws()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            // A position row must carry a security identifier; a blank one is a mapping error and must
+            // be rejected rather than auto-matched as a high-confidence position.
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "account,symbol,quantity,price,cashAmount,activityType,tradeDate",
+                "EXT-1,,10,500,0,position,2026-05-29"
+            ]);
+
+            await Assert.ThrowsAsync<InvalidDataException>(() =>
+                svc.ImportAsync("broker", filePath, CancellationToken.None));
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
 }

--- a/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
@@ -464,4 +464,30 @@ public sealed class StatementReconciliationServiceTests
         }
     }
 
+    [Fact]
+    public async Task CreateExternalStatementCasesAsync_SymbolLessFeeRow_ParsesWithoutError()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            // Case intake must accept symbol-less fee rows just like the import path, so a local+profile
+            // file does not import successfully but then throw during reconciliation.
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "account,symbol,quantity,price,cashAmount,activityType,tradeDate",
+                "EXT-1,,0,0,-9.99,fee,2026-05-29"
+            ]);
+
+            var intake = await svc.CreateExternalStatementCasesAsync(
+                "local", filePath, StatementMappingProfileRegistry.CanonicalCsvV1ProfileId, CancellationToken.None);
+
+            Assert.Equal(1, intake.RowCount);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
 }

--- a/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
@@ -568,4 +568,32 @@ public sealed class StatementReconciliationServiceTests
         }
     }
 
+    [Fact]
+    public async Task ImportAndCaseIntake_EmptyProfiledStatement_ShareImportId()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            // Valid header, no data rows: import and intake must still refer to the same run id.
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "account,symbol,quantity,price,cashAmount,activityType,tradeDate"
+            ]);
+
+            var import = await svc.ImportAsync(
+                "local", filePath, StatementMappingProfileRegistry.CanonicalCsvV1ProfileId, CancellationToken.None);
+            var intake = await svc.CreateExternalStatementCasesAsync(
+                "local", filePath, StatementMappingProfileRegistry.CanonicalCsvV1ProfileId, CancellationToken.None);
+
+            Assert.Equal(0, import.RowCount);
+            Assert.Equal(0, intake.RowCount);
+            Assert.Equal(import.ImportId, intake.ImportId);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
 }

--- a/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
@@ -214,4 +214,145 @@ public sealed class StatementReconciliationServiceTests
         }
     }
 
+    [Fact]
+    public async Task ReconcileAsync_LocalStatement_WithMappingProfile_ProducesMatchesAndCases()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "account,symbol,quantity,price,cashAmount,activityType,tradeDate",
+                "LOC-1,SPY,10,500,0,position,2026-05-29",
+                "LOC-1,,0,0,125.25,cash,2026-05-29"
+            ]);
+
+            var result = await svc.ReconcileAsync(
+                "local", filePath, StatementMappingProfileRegistry.CanonicalCsvV1ProfileId, CancellationToken.None);
+
+            // Previously a 'local' source returned zero matches and zero cases; with a mapping
+            // profile selected it is now parsed canonically and reconciled.
+            Assert.Equal(1, result.MatchCount);
+            Assert.Equal(1, result.UnresolvedCount);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public async Task CreateExternalStatementCasesAsync_LocalStatement_WithProfile_ProducesCases()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "account,symbol,quantity,price,cashAmount,activityType,tradeDate",
+                "LOC-1,,0,0,125.25,cash,2026-05-29"
+            ]);
+
+            var intake = await svc.CreateExternalStatementCasesAsync(
+                "local", filePath, StatementMappingProfileRegistry.CanonicalCsvV1ProfileId, CancellationToken.None);
+
+            Assert.Equal(1, intake.RowCount);
+            Assert.Single(intake.Cases);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_LocalStatement_WithoutProfile_RemainsRawWithZeroCases()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            // A non-canonical local file with no mapping profile keeps the lenient raw passthrough:
+            // it is accepted but produces no canonical rows, matches, or cases.
+            await File.WriteAllLinesAsync(filePath, ["header", "row1", "row2"]);
+
+            var result = await svc.ReconcileAsync("local", filePath, CancellationToken.None);
+
+            Assert.Equal(0, result.MatchCount);
+            Assert.Equal(0, result.UnresolvedCount);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_LocalStatement_WithCustomProfile_MapsArbitraryColumns()
+    {
+        var customProfile = new StatementMappingProfile(
+            "custom-local-v1",
+            "Custom Local v1",
+            [
+                new(StatementCanonicalField.Account, "acct"),
+                new(StatementCanonicalField.SecurityIdentifier, "ticker"),
+                new(StatementCanonicalField.Quantity, "qty"),
+                new(StatementCanonicalField.Price, "px"),
+                new(StatementCanonicalField.CashAmount, "cash"),
+                new(StatementCanonicalField.ActivityType, "type"),
+                new(StatementCanonicalField.TradeDate, "td")
+            ],
+            [
+                new("position", "position"),
+                new("cash", "cash")
+            ]);
+        var registry = new StatementMappingProfileRegistry([customProfile]);
+        var svc = new StatementReconciliationService(registry);
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "acct,ticker,qty,px,cash,type,td",
+                "LOC-1,SPY,10,500,0,position,2026-05-29",
+                "LOC-1,,0,0,125.25,cash,2026-05-29"
+            ]);
+
+            var result = await svc.ReconcileAsync("local", filePath, "custom-local-v1", CancellationToken.None);
+
+            Assert.Equal(1, result.MatchCount);
+            Assert.Equal(1, result.UnresolvedCount);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_LocalStatement_WithProfile_ValidatesHeaderAndThrowsOnMismatch()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            // With a profile selected, a 'local' source is now header-validated; a non-canonical
+            // header against the canonical profile must be rejected rather than silently accepted.
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "account,symbol",
+                "LOC-1,SPY"
+            ]);
+
+            await Assert.ThrowsAsync<InvalidDataException>(() =>
+                svc.ValidateAsync("local", filePath, StatementMappingProfileRegistry.CanonicalCsvV1ProfileId, CancellationToken.None));
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
 }

--- a/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
@@ -408,4 +408,33 @@ public sealed class StatementReconciliationServiceTests
         }
     }
 
+    [Fact]
+    public async Task ImportAsync_RowOmittingOptionalTrailingColumns_DefaultsOptionalValues()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            // The header advertises optional trailing columns, but the data row stops after the
+            // required tradeDate. Such rows must import with defaulted optional values rather than
+            // being rejected for being shorter than the full header.
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "account,symbol,quantity,price,cashAmount,activityType,tradeDate,currency,marketValue,settlementDate",
+                "EXT-1,SPY,10,500,0,position,2026-05-29"
+            ]);
+
+            var result = await svc.ImportAsync("broker", filePath, CancellationToken.None);
+
+            Assert.Equal(1, result.RowCount);
+            var position = Assert.Single(result.Positions);
+            Assert.Equal("USD", position.Currency);
+            Assert.Equal(5000m, position.MarketValue);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
 }

--- a/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
@@ -437,4 +437,31 @@ public sealed class StatementReconciliationServiceTests
         }
     }
 
+    [Fact]
+    public async Task ImportAsync_SymbolLessFeeRow_ImportsAsTransaction()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            // Account-level fee rows legitimately omit the symbol; import must accept them
+            // (as transactions) rather than rejecting them for a missing SecurityIdentifier.
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "account,symbol,quantity,price,cashAmount,activityType,tradeDate",
+                "EXT-1,,0,0,-9.99,fee,2026-05-29"
+            ]);
+
+            var result = await svc.ImportAsync("broker", filePath, CancellationToken.None);
+
+            Assert.Equal(1, result.RowCount);
+            var transaction = Assert.Single(result.Transactions);
+            Assert.Equal("fee", transaction.TransactionType);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
 }

--- a/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
@@ -541,4 +541,31 @@ public sealed class StatementReconciliationServiceTests
         }
     }
 
+    [Fact]
+    public async Task ReconcileAsync_FeeRow_WithAmountColumn_SurfacesMaterialCase()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            // The fee carries its value in the amount column with cashAmount=0. Case intake must use
+            // the mapped amount so the material break is surfaced; if it derived a zero amount the
+            // break would be classified as immaterial and no case would be created.
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "account,symbol,quantity,price,cashAmount,activityType,tradeDate,amount",
+                "EXT-1,,0,0,0,fee,2026-05-29,-50"
+            ]);
+
+            var result = await svc.ReconcileAsync(
+                "local", filePath, StatementMappingProfileRegistry.CanonicalCsvV1ProfileId, CancellationToken.None);
+
+            Assert.Equal(1, result.UnresolvedCount);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary

Makes operator-supplied (`local`) reconciliation statements **first-class** — both reconcilable and importable into typed collections — when a mapping profile is selected, while preserving the existing lenient raw-passthrough behavior for `local` with no profile.

Previously `local` was an intake dead-end: `ImportAsync` returned only raw row references and `ReconcileAsync`/`CreateExternalStatementCases` produced zero matches and cases, so a fund's own statement file could never be reconciled. The canonical, mapping-profile-driven path was reserved for `broker`/`custodian`/`sample-broker`.

Changes:
- New `UsesCanonicalSchema` gate: a source is parsed through the canonical, profile-driven path when its kind requires the canonical schema **or when the caller explicitly selects a mapping profile**. So `ReconcileAsync`/`CreateExternalStatementCasesAsync`/`ValidateAsync` work for `local` + a profile.
- `ImportAsync` gains a `mappingProfileId` overload and uses the same gate, so `local` + a profile normalizes into typed positions/cash/transactions (addresses review feedback that `ImportAsync` was inconsistent with the reconciliation workflow).
- Importer unified on the mapping-profile-driven parser: `StatementCanonicalField` gains `AccountId`, `ExternalAccountId`, `SecurityId`, `UnresolvedIdentifier`, `MarketValue`, `Amount`, `ExternalReference` (mapped in the canonical profile), and the import path now extracts via profile column mappings instead of fixed positional indices. The dead positional parser/validator/snapshot helpers are removed (net −117 lines in the service).
- `local` with **no** profile is unchanged (raw passthrough), so existing callers and behavior are preserved.

## Reason

First slices of the reconciliation-intake hardening from the accounting/ingestion review: reconciliation is a Tier‑1 product pillar and half the "Verified Coverage" north-star, but customer-owned statements could not be reconciled at all. These changes close that gap, backward-compatibly, reusing (and unifying on) the already-tested profile-driven parser.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — *not run: no .NET SDK in the authoring environment; relying on `quality-gate`.*
- [x] Relevant unit tests were added or updated — `StatementReconciliationServiceTests`: local+canonical-profile reconciliation produces matches/cases; local+custom-profile arbitrary-column mapping; local+profile header validation throws on mismatch; local+profile typed import; backward-compat guards that local without a profile yields zero cases and raw row counts. The existing broker typed-import test guards the unified parser.
- [ ] Relevant integration tests were added or updated — N/A (service-level coverage)
- [x] GitHub Actions `quality-gate` — pending on this PR.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)