### PR TITLE
fix(reconciliation): preserve source trade codes during typed import

### DIFF
--- a/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/StatementReconciliationService.cs
@@ -181,7 +181,7 @@ public sealed class StatementReconciliationService
                 securities.Add(p.Security);
             }
 
-            switch (ToStatementRowKind(p.TransactionType))
+            switch (p.RowKind)
             {
                 case StatementRowKind.Position:
                     positions.Add(new StatementPosition(
@@ -250,7 +250,11 @@ public sealed class StatementReconciliationService
 
             var mapped = new StatementMappedCsvRow(profile, BuildColumnMap(header, parts));
             var account = mapped.GetRequired(StatementCanonicalField.Account, currentRowNumber);
-            var activityType = profile.MapActivityType(mapped.GetRequired(StatementCanonicalField.ActivityType, currentRowNumber));
+            // Classify the row kind from the mapped (canonical) activity, but keep the original source
+            // activity code for the transaction so direction-bearing codes (e.g. BUY/SELL, which a
+            // profile may both map to "trade") are not lost for downstream matching/classification.
+            var sourceActivityType = mapped.GetRequired(StatementCanonicalField.ActivityType, currentRowNumber);
+            var activityType = profile.MapActivityType(sourceActivityType);
             var rowKind = ToStatementRowKind(activityType);
             // Position rows must carry a security identifier (MatchRows auto-matches positions
             // without re-checking the symbol, so a blank one would become a false high-confidence
@@ -304,7 +308,8 @@ public sealed class StatementReconciliationService
                 settlementDate,
                 amount,
                 feesCommission,
-                activityType,
+                rowKind,
+                sourceActivityType,
                 externalReference);
         }
     }
@@ -696,6 +701,7 @@ public sealed class StatementReconciliationService
         DateOnly? SettlementDate,
         decimal Amount,
         decimal FeesCommission,
+        StatementRowKind RowKind,
         string TransactionType,
         string? ExternalReference);
 }

--- a/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/StatementReconciliationServiceTests.cs
@@ -43,6 +43,36 @@ public sealed class StatementReconciliationServiceTests
     }
 
     [Fact]
+    public async Task ImportAsync_SampleBrokerProfile_PreservesSourceTradeCodes()
+    {
+        var svc = new StatementReconciliationService();
+        var filePath = Path.GetTempFileName();
+        try
+        {
+            // The sample-broker profile maps both BUY and SELL to the canonical "trade" activity.
+            // Typed import must classify the row kind from the mapped value but retain the original
+            // source code on the transaction, so buys and sells remain distinguishable downstream.
+            await File.WriteAllLinesAsync(filePath,
+            [
+                "BrokerAccount,Ticker,Units,ExecutionPrice,NetCash,TxnCode,TradeDate",
+                "BRK-1,MSFT,5,400,0,BUY,2026-05-27",
+                "BRK-1,MSFT,3,410,0,SELL,2026-05-28"
+            ]);
+
+            var result = await svc.ImportAsync(
+                "broker", filePath, StatementMappingProfileRegistry.SampleBrokerCsvV1ProfileId, CancellationToken.None);
+
+            Assert.Equal(2, result.Transactions.Count);
+            Assert.Contains(result.Transactions, t => t.TransactionType == "BUY");
+            Assert.Contains(result.Transactions, t => t.TransactionType == "SELL");
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Fact]
     public async Task ImportAsync_Returns_Typed_Normalized_Broker_Collections_With_Source_Trace()
     {
         var svc = new StatementReconciliationService();


### PR DESCRIPTION
## Summary

Typed statement import stored the **mapped** (canonical) activity value as `StatementTransaction.TransactionType`. Mapping profiles that collapse codes — the built-in sample-broker profile maps both `BUY` and `SELL` to the canonical `trade` — therefore produced indistinguishable transactions, dropping trade direction that downstream matching logic compares against exactly (e.g. `BUY`/`SELL`).

Fix: classify the row kind from the mapped activity value (threaded through `ParsedStatementLine.RowKind`), but keep the **original source activity code** on the transaction's `TransactionType`, so buys and sells remain distinguishable for downstream clients of `ImportAsync`.

## Reason

Follow-up to the merged reconciliation-intake PR (#2032). When that PR unified import onto the mapping-profile-driven parser, it began applying `MapActivityType` to the value stored on the transaction. A final Codex review point flagged that this loses the source trade direction; it landed as #2032 was merging, so it's addressed here on a fresh branch.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — *not run: no .NET SDK in the authoring environment; relying on `quality-gate`.*
- [x] Relevant unit tests were added or updated — `StatementReconciliationServiceTests.ImportAsync_SampleBrokerProfile_PreservesSourceTradeCodes` asserts a sample-broker import retains `BUY` and `SELL` on the transactions. The existing broker typed-import test continues to guard canonical-activity behavior.
- [ ] Relevant integration tests were added or updated — N/A (service-level coverage)
- [x] GitHub Actions `quality-gate` — pending on this PR.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmipP72wokem2RQAryCEsK)_