### PR TITLE
Web UI Concrete — U2: UI primitives aligned + gap-fill

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/ui/accordion.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/accordion.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { Accordion } from "@/components/ui/accordion";
+
+const items = [
+  { title: "Section A", content: "Body A" },
+  { title: "Section B", content: "Body B" },
+  { title: "Section C", content: "Body C" }
+];
+
+describe("Accordion", () => {
+  it("opens a section on click and collapses others in single mode", async () => {
+    const user = userEvent.setup();
+    render(<Accordion items={items} />);
+
+    await user.click(screen.getByRole("button", { name: /Section A/ }));
+    expect(screen.getByText("Body A")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Section B/ }));
+    expect(screen.queryByText("Body A")).not.toBeInTheDocument();
+    expect(screen.getByText("Body B")).toBeInTheDocument();
+  });
+
+  it("keeps multiple sections open in multi mode", async () => {
+    const user = userEvent.setup();
+    render(<Accordion items={items} multi />);
+
+    await user.click(screen.getByRole("button", { name: /Section A/ }));
+    await user.click(screen.getByRole("button", { name: /Section B/ }));
+
+    expect(screen.getByText("Body A")).toBeInTheDocument();
+    expect(screen.getByText("Body B")).toBeInTheDocument();
+  });
+
+  it("moves header focus with arrow keys", async () => {
+    const user = userEvent.setup();
+    render(<Accordion items={items} />);
+
+    screen.getByRole("button", { name: /Section A/ }).focus();
+    await user.keyboard("{ArrowDown}");
+    expect(screen.getByRole("button", { name: /Section B/ })).toHaveFocus();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/accordion.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/accordion.tsx
@@ -1,0 +1,118 @@
+import { type KeyboardEvent, type ReactNode, useRef, useState } from "react";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface AccordionItem {
+  id?: string;
+  title: ReactNode;
+  content: ReactNode;
+  badge?: ReactNode;
+  disabled?: boolean;
+}
+
+export interface AccordionProps {
+  items: AccordionItem[];
+  multi?: boolean;
+  defaultOpen?: number[];
+  className?: string;
+}
+
+/**
+ * Collapsible sections (single or multi-open). Concrete: flat, hairline-bordered container
+ * with divider rules between items; caret rotates on open. Keyboard nav per the Concrete
+ * matrix — Arrow keys move between headers, Enter/Space toggles.
+ */
+export function Accordion({ items, multi = false, defaultOpen = [], className }: AccordionProps) {
+  const [open, setOpen] = useState<Set<number>>(() => new Set(defaultOpen));
+  const headerRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const toggle = (index: number) => {
+    setOpen((previous) => {
+      const next = multi ? new Set(previous) : new Set<number>();
+      if (previous.has(index)) {
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
+      return next;
+    });
+  };
+
+  const focusHeader = (index: number) => {
+    const enabledIndices = items.map((item, i) => (item.disabled ? -1 : i)).filter((i) => i >= 0);
+    if (enabledIndices.length === 0) {
+      return;
+    }
+    const position = enabledIndices.indexOf(index);
+    const target = position < 0 ? enabledIndices[0]! : index;
+    headerRefs.current[target]?.focus();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    const enabledIndices = items.map((item, i) => (item.disabled ? -1 : i)).filter((i) => i >= 0);
+    const position = enabledIndices.indexOf(index);
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        focusHeader(enabledIndices[(position + 1) % enabledIndices.length]!);
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        focusHeader(enabledIndices[(position - 1 + enabledIndices.length) % enabledIndices.length]!);
+        break;
+      case "Home":
+        event.preventDefault();
+        focusHeader(enabledIndices[0]!);
+        break;
+      case "End":
+        event.preventDefault();
+        focusHeader(enabledIndices[enabledIndices.length - 1]!);
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div className={cn("rounded-[2px] border border-border bg-card", className)}>
+      {items.map((item, index) => {
+        const isOpen = open.has(index);
+        const panelId = `${item.id ?? "accordion"}-panel-${index}`;
+        return (
+          <div key={item.id ?? index} className={cn(index > 0 && "border-t border-border")}>
+            <button
+              ref={(node) => {
+                headerRefs.current[index] = node;
+              }}
+              type="button"
+              aria-expanded={isOpen}
+              aria-controls={panelId}
+              disabled={item.disabled}
+              onClick={() => !item.disabled && toggle(index)}
+              onKeyDown={(event) => handleKeyDown(event, index)}
+              className={cn(
+                "flex w-full items-center gap-2.5 px-3.5 py-3 text-left text-sm font-semibold text-foreground transition-colors [outline-offset:-2px]",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+                item.disabled ? "cursor-not-allowed opacity-55" : "hover:bg-[#EAEEF3]"
+              )}
+            >
+              <ChevronRight
+                aria-hidden="true"
+                className={cn("h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform duration-150", isOpen && "rotate-90")}
+              />
+              <span className="flex-1">{item.title}</span>
+              {item.badge != null ? (
+                <span className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground">{item.badge}</span>
+              ) : null}
+            </button>
+            {isOpen ? (
+              <div id={panelId} className="px-3.5 pb-3.5 pl-[2.125rem] text-sm leading-5 text-muted-foreground">
+                {item.content}
+              </div>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/badge.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/badge.tsx
@@ -42,7 +42,7 @@ export function Badge({ children, className, dot = false, variant = "default", .
   return (
     <span
       className={cn(
-        "inline-flex min-h-6 items-center gap-1.5 rounded-[var(--radius-chip,0.25rem)] border px-2.5 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] shadow-[var(--shadow-panel)]",
+        "inline-flex min-h-6 items-center gap-1.5 rounded-[2px] border px-2.5 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.14em]",
         variantClasses[variant],
         className
       )}

--- a/src/Meridian.Ui/dashboard/src/components/ui/button.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/button.tsx
@@ -45,10 +45,10 @@ type ButtonChildProps = React.HTMLAttributes<HTMLElement> & {
 };
 
 const variantClasses: Record<NonNullable<ButtonProps["variant"]>, string> = {
-  default: "border-primary bg-primary text-primary-foreground shadow-flat hover:bg-primary/85",
-  secondary: "border-border bg-secondary text-secondary-foreground hover:bg-secondary/80",
-  outline: "border-border bg-background/40 text-foreground hover:bg-secondary/60",
-  ghost: "border-transparent bg-transparent text-muted-foreground hover:border-border/60 hover:bg-secondary/55 hover:text-foreground",
+  default: "border-primary bg-primary text-primary-foreground hover:bg-primary/85 active:bg-[#255B75]",
+  secondary: "border-border bg-secondary text-secondary-foreground hover:border-[#ADB8C4] hover:bg-[#EAEEF3] active:bg-[#D7E5F1]",
+  outline: "border-border bg-transparent text-foreground hover:border-[#ADB8C4] hover:bg-[#EAEEF3] active:bg-[#D7E5F1]",
+  ghost: "border-transparent bg-transparent text-muted-foreground hover:bg-[#EAEEF3] hover:text-foreground active:bg-[#D7E5F1]",
   destructive: "border-danger/60 bg-danger/10 text-danger hover:bg-danger/15"
 };
 
@@ -77,7 +77,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   }, ref) => {
     const vm = buildButtonCommandViewModel({ disabled, busy, busyLabel, disabledReason, title });
     const classes = cn(
-      "inline-flex items-center justify-center gap-2 rounded-[var(--radius-button,0.375rem)] border font-semibold transition-[background-color,border-color,box-shadow] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50 disabled:shadow-none",
+      "inline-flex items-center justify-center gap-2 rounded-[2px] border font-semibold transition-[background-color,border-color,color] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50",
       variantClasses[variant],
       sizeClasses[size],
       vm.disabled && asChild && "pointer-events-none opacity-50",

--- a/src/Meridian.Ui/dashboard/src/components/ui/callout.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/callout.tsx
@@ -1,0 +1,58 @@
+import { type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export type CalloutTone = "info" | "success" | "warning" | "danger";
+
+export interface CalloutProps {
+  tone?: CalloutTone;
+  title?: ReactNode;
+  icon?: ReactNode;
+  children?: ReactNode;
+  className?: string;
+}
+
+const toneClasses: Record<CalloutTone, string> = {
+  info: "border-l-primary bg-primary/10",
+  success: "border-l-success bg-success/10",
+  warning: "border-l-warning bg-warning/10",
+  danger: "border-l-danger bg-danger/10"
+};
+
+const iconToneClasses: Record<CalloutTone, string> = {
+  info: "text-primary",
+  success: "text-success",
+  warning: "text-warning",
+  danger: "text-danger"
+};
+
+const defaultIcons: Record<CalloutTone, string> = {
+  info: "ℹ",
+  success: "✓",
+  warning: "▲",
+  danger: "✕"
+};
+
+/**
+ * Inline prose guidance inside content — distinct from `StatusBanner` (run results). Concrete:
+ * desaturated alpha-10 wash, solid 3px left rule, hairline border, 2px corners, no fill.
+ */
+export function Callout({ tone = "info", title, icon, children, className }: CalloutProps) {
+  return (
+    <div
+      role="note"
+      className={cn(
+        "flex gap-2.5 rounded-[2px] border border-border border-l-[3px] px-3.5 py-3 text-sm",
+        toneClasses[tone],
+        className
+      )}
+    >
+      <span aria-hidden="true" className={cn("shrink-0 leading-5", iconToneClasses[tone])}>
+        {icon ?? defaultIcons[tone]}
+      </span>
+      <div className="min-w-0 flex-1">
+        {title ? <p className="font-semibold leading-5 text-foreground">{title}</p> : null}
+        {children ? <p className="leading-5 text-muted-foreground">{children}</p> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/card.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/card.tsx
@@ -37,7 +37,7 @@ interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 const cardVariants: Record<NonNullable<CardProps["variant"]>, string> = {
   default: "",
   interactive:
-    "cursor-pointer transition-[background-color,border-color,box-shadow] hover:border-border hover:bg-muted/45 hover:shadow-[var(--shadow-float)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+    "cursor-pointer transition-[background-color,border-color] hover:border-[#ADB8C4] hover:bg-[#F3F6F9] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
 };
 
 export const Card = forwardRef<HTMLDivElement, CardProps>(
@@ -45,7 +45,7 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(
     <div
       ref={ref}
       className={cn(
-        "rounded-[var(--radius-card,0.5rem)] border border-border bg-card text-card-foreground shadow-panel",
+        "rounded-[2px] border border-border bg-card text-card-foreground",
         cardVariants[variant],
         className
       )}

--- a/src/Meridian.Ui/dashboard/src/components/ui/checkbox.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/checkbox.tsx
@@ -41,10 +41,10 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           <span
             aria-hidden="true"
             className={cn(
-              "flex h-4 w-4 items-center justify-center rounded-[var(--radius-checkbox,0.1875rem)] border bg-background shadow-[var(--shadow-panel)]",
-              "transition-[background-color,border-color,box-shadow] duration-150",
+              "flex h-4 w-4 items-center justify-center rounded-[2px] border bg-[#F3F6F9]",
+              "transition-[background-color,border-color] duration-150",
               "peer-focus-visible:ring-2 peer-focus-visible:ring-primary/40",
-              checkedState ? "border-primary bg-primary" : "border-border",
+              checkedState ? "border-primary bg-primary" : "border-border peer-hover:border-[#ADB8C4]",
               error ? "border-danger" : ""
             )}
           >
@@ -111,13 +111,13 @@ export const Toggle = forwardRef<HTMLButtonElement, ToggleProps>(
         <span
           aria-hidden="true"
           className={cn(
-            "relative h-5 w-9 rounded-full border shadow-[var(--shadow-panel)] transition-colors duration-150",
-            checkedState ? "border-primary bg-primary" : "border-border bg-secondary"
+            "relative h-5 w-9 rounded-full border transition-colors duration-150",
+            checkedState ? "border-primary bg-primary" : "border-border bg-[#F3F6F9]"
           )}
         >
           <span
             className={cn(
-              "absolute top-0.5 h-4 w-4 rounded-full bg-background shadow-[var(--shadow-panel)] transition-transform duration-150",
+              "absolute top-0.5 h-4 w-4 rounded-full bg-background transition-transform duration-150",
               checkedState ? "translate-x-[1.0625rem]" : "translate-x-0.5"
             )}
           />

--- a/src/Meridian.Ui/dashboard/src/components/ui/combobox.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/combobox.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Combobox } from "@/components/ui/combobox";
+
+const options = [
+  { value: "AAPL", label: "Apple Inc." },
+  { value: "MSFT", label: "Microsoft Corp." },
+  { value: "GOOG", label: "Alphabet Inc." }
+];
+
+describe("Combobox", () => {
+  it("filters options by query and commits selection with Enter", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<Combobox options={options} onChange={onChange} />);
+
+    const input = screen.getByRole("combobox");
+    await user.click(input);
+    await user.type(input, "micro");
+
+    expect(screen.getByRole("option", { name: /Microsoft/ })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Apple/ })).not.toBeInTheDocument();
+
+    await user.keyboard("{Enter}");
+    expect(onChange).toHaveBeenCalledWith("MSFT");
+  });
+
+  it("navigates options with arrow keys", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<Combobox options={options} onChange={onChange} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(onChange).toHaveBeenCalledWith("MSFT");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/combobox.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/combobox.tsx
@@ -1,0 +1,192 @@
+import { Fragment, type KeyboardEvent, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ComboboxOption {
+  value: string;
+  label: string;
+}
+
+export interface ComboboxProps {
+  options: Array<ComboboxOption | string>;
+  value?: string;
+  onChange?: (value: string) => void;
+  label?: ReactNode;
+  placeholder?: string;
+  disabled?: boolean;
+  emptyText?: string;
+  className?: string;
+  id?: string;
+}
+
+function normalize(options: Array<ComboboxOption | string>): ComboboxOption[] {
+  return options.map((option) => (typeof option === "string" ? { value: option, label: option } : option));
+}
+
+function highlight(label: string, query: string): ReactNode {
+  if (!query) {
+    return label;
+  }
+  const index = label.toLowerCase().indexOf(query.toLowerCase());
+  if (index === -1) {
+    return label;
+  }
+  return (
+    <Fragment>
+      {label.slice(0, index)}
+      <span className="bg-primary/15 text-primary">{label.slice(index, index + query.length)}</span>
+      {label.slice(index + query.length)}
+    </Fragment>
+  );
+}
+
+/**
+ * Searchable single-select. Type to filter, Arrow keys to navigate, Enter to confirm,
+ * Escape to close (keeping the current selection). Concrete: flat field, hairline border,
+ * menu carries the only shadow.
+ */
+export function Combobox({
+  options,
+  value,
+  onChange,
+  label,
+  placeholder = "Search…",
+  disabled = false,
+  emptyText = "No matches",
+  className,
+  id
+}: ComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [highlighted, setHighlighted] = useState(0);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const items = useMemo(() => normalize(options), [options]);
+  const selected = items.find((option) => option.value === value);
+  const filtered = useMemo(
+    () => (query ? items.filter((option) => option.label.toLowerCase().includes(query.toLowerCase())) : items),
+    [items, query]
+  );
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return undefined;
+    }
+    const handler = (event: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
+        setOpen(false);
+        setQuery("");
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  useEffect(() => {
+    setHighlighted(0);
+  }, [query]);
+
+  const commit = (option: ComboboxOption) => {
+    onChange?.(option.value);
+    setOpen(false);
+    setQuery("");
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        setOpen(true);
+        setHighlighted((current) => Math.min(current + 1, filtered.length - 1));
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        setHighlighted((current) => Math.max(current - 1, 0));
+        break;
+      case "Enter":
+        event.preventDefault();
+        if (filtered[highlighted]) {
+          commit(filtered[highlighted]!);
+        }
+        break;
+      case "Escape":
+        setOpen(false);
+        setQuery("");
+        break;
+      default:
+        break;
+    }
+  };
+
+  const listboxId = id ? `${id}-listbox` : undefined;
+
+  return (
+    <div ref={rootRef} className={cn("relative w-full", className)}>
+      {label ? (
+        <span className="mb-1.5 block font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          {label}
+        </span>
+      ) : null}
+      <div
+        className={cn(
+          "flex h-9 items-center rounded-[2px] border border-border bg-[#F3F6F9]",
+          "focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/40",
+          disabled && "cursor-not-allowed opacity-55"
+        )}
+      >
+        <input
+          id={id}
+          type="text"
+          role="combobox"
+          aria-expanded={open}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          disabled={disabled}
+          placeholder={selected && !open ? selected.label : placeholder}
+          value={open ? query : selected ? selected.label : ""}
+          onFocus={() => setOpen(true)}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setOpen(true);
+          }}
+          onKeyDown={handleKeyDown}
+          className="min-w-0 flex-1 bg-transparent px-2.5 font-mono text-sm text-foreground placeholder:text-muted-foreground/70 focus:outline-none"
+        />
+        <span aria-hidden="true" className="px-2.5 text-xs text-muted-foreground">
+          ▾
+        </span>
+      </div>
+      {open ? (
+        <div
+          role="listbox"
+          id={listboxId}
+          className="absolute left-0 right-0 top-[calc(100%+4px)] z-[100] max-h-60 overflow-y-auto rounded-[2px] border border-border bg-popover shadow-[0_2px_6px_rgba(0,0,0,0.18)]"
+        >
+          {filtered.length === 0 ? (
+            <div className="px-3 py-2.5 text-xs text-muted-foreground">{emptyText}</div>
+          ) : (
+            filtered.map((option, index) => {
+              const isSelected = option.value === value;
+              return (
+                <div
+                  key={option.value}
+                  role="option"
+                  aria-selected={isSelected}
+                  onMouseEnter={() => setHighlighted(index)}
+                  onClick={() => commit(option)}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-2 px-3 py-2 font-mono text-xs text-foreground",
+                    index === highlighted && "bg-[#EAEEF3]",
+                    isSelected && "font-semibold text-primary"
+                  )}
+                >
+                  {highlight(option.label, query)}
+                  {isSelected ? <span className="ml-auto text-[11px]">✓</span> : null}
+                </div>
+              );
+            })
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/context-menu.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/context-menu.tsx
@@ -87,7 +87,7 @@ export function ContextMenu({ className, items, label = "Context menu", onClose,
         role="menu"
         aria-label={label}
         className={cn(
-          "fixed z-[60] min-w-44 overflow-hidden rounded-[var(--radius-button,0.375rem)] border border-border bg-popover py-1 text-sm text-popover-foreground shadow-[var(--shadow-float)]",
+          "fixed z-[60] min-w-44 overflow-hidden rounded-[2px] border border-border bg-popover py-1 text-sm text-popover-foreground shadow-[0_2px_6px_rgba(0,0,0,0.18)]",
           className
         )}
         onKeyDown={handleMenuKeyDown}
@@ -102,9 +102,9 @@ export function ContextMenu({ className, items, label = "Context menu", onClose,
             role="menuitem"
             disabled={item.disabled}
             className={cn(
-              "flex w-full items-center gap-2 px-3 py-2 text-left transition-colors",
+              "flex w-full items-center gap-2 px-3 py-2 text-left transition-colors [outline-offset:-2px]",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-              item.danger ? "text-danger hover:bg-danger/10" : "hover:bg-secondary/70",
+              item.danger ? "text-danger hover:bg-danger/10" : "hover:bg-[#EAEEF3]",
               item.disabled && "cursor-not-allowed opacity-50"
             )}
             onClick={() => {

--- a/src/Meridian.Ui/dashboard/src/components/ui/date-picker.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/date-picker.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { DatePicker, monthGrid, toIsoDate } from "@/components/ui/date-picker";
+import { DateRangePicker } from "@/components/ui/date-range-picker";
+
+describe("date helpers", () => {
+  it("formats a date as ISO YYYY-MM-DD in local time", () => {
+    expect(toIsoDate(new Date(2026, 5, 9))).toBe("2026-06-09");
+  });
+
+  it("returns a full 6-week grid", () => {
+    expect(monthGrid(new Date(2026, 5, 1))).toHaveLength(42);
+  });
+});
+
+describe("DatePicker", () => {
+  it("opens the calendar and emits an ISO date on selection", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<DatePicker label="Trade date" value="2026-06-15" onChange={onChange} />);
+
+    await user.click(screen.getByRole("textbox"));
+    await user.click(screen.getByRole("button", { name: "20" }));
+
+    expect(onChange).toHaveBeenCalledWith("2026-06-20");
+  });
+});
+
+describe("DateRangePicker", () => {
+  it("sets the start then the end date", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    const { rerender } = render(<DateRangePicker label="Window" start={null} end={null} onChange={onChange} />);
+
+    await user.click(screen.getByRole("textbox"));
+    await user.click(screen.getAllByRole("button", { name: "10" })[0]!);
+    expect(onChange).toHaveBeenLastCalledWith({ start: expect.stringMatching(/-10$/), end: null });
+
+    const start = onChange.mock.calls.at(-1)![0].start as string;
+    rerender(<DateRangePicker label="Window" start={start} end={null} onChange={onChange} />);
+    await user.click(screen.getAllByRole("button", { name: "20" })[0]!);
+    expect(onChange).toHaveBeenLastCalledWith({ start, end: expect.stringMatching(/-20$/) });
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/date-picker.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/date-picker.tsx
@@ -1,0 +1,143 @@
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+export interface DatePickerProps {
+  value?: string | null;
+  onChange?: (value: string) => void;
+  label?: ReactNode;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+}
+
+const DOW = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+
+export function toIsoDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function monthGrid(month: Date): Date[] {
+  const first = new Date(month.getFullYear(), month.getMonth(), 1);
+  const start = new Date(first);
+  start.setDate(start.getDate() - first.getDay());
+  const days: Date[] = [];
+  for (let i = 0; i < 42; i += 1) {
+    const day = new Date(start);
+    day.setDate(day.getDate() + i);
+    days.push(day);
+  }
+  return days;
+}
+
+const dayButtonClass =
+  "flex h-8 w-8 items-center justify-center rounded-[2px] border border-transparent font-mono text-xs text-foreground transition-colors hover:bg-[#EAEEF3] focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 [outline-offset:-2px]";
+
+/**
+ * Single-date input with a flat calendar popover. Concrete: hairline field, menu shadow on the
+ * calendar, 2px cells, one accent for the selected day. Emits ISO `YYYY-MM-DD` via `onChange`.
+ */
+export function DatePicker({ value, onChange, label, placeholder = "Select date…", disabled = false, className, id }: DatePickerProps) {
+  const [open, setOpen] = useState(false);
+  const [month, setMonth] = useState<Date>(value ? new Date(value) : new Date());
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return undefined;
+    }
+    const handler = (event: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  const days = monthGrid(month);
+  const display = value
+    ? new Date(value).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })
+    : placeholder;
+  const today = toIsoDate(new Date());
+
+  return (
+    <div ref={rootRef} className={cn("relative w-full", className)}>
+      {label ? (
+        <label htmlFor={id} className="mb-1.5 block font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          {label}
+        </label>
+      ) : null}
+      <input
+        id={id}
+        type="text"
+        readOnly
+        disabled={disabled}
+        value={display}
+        onClick={() => !disabled && setOpen((current) => !current)}
+        className={cn(
+          "h-9 w-full cursor-pointer rounded-[2px] border border-border bg-[#F3F6F9] px-2.5 font-mono text-sm text-foreground",
+          "hover:border-[#ADB8C4] focus-visible:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+          disabled && "cursor-not-allowed opacity-55"
+        )}
+      />
+      {open ? (
+        <div className="absolute left-0 top-[calc(100%+4px)] z-[100] rounded-[2px] border border-border bg-popover p-3 shadow-[0_2px_6px_rgba(0,0,0,0.18)]">
+          <div className="mb-3 flex items-center justify-between text-xs font-semibold text-foreground">
+            <button
+              type="button"
+              aria-label="Previous month"
+              onClick={() => setMonth(new Date(month.getFullYear(), month.getMonth() - 1))}
+              className="rounded-[2px] border border-border bg-card px-2 py-1 transition-colors hover:bg-[#EAEEF3]"
+            >
+              ←
+            </button>
+            <span>{month.toLocaleDateString("en-US", { year: "numeric", month: "long" })}</span>
+            <button
+              type="button"
+              aria-label="Next month"
+              onClick={() => setMonth(new Date(month.getFullYear(), month.getMonth() + 1))}
+              className="rounded-[2px] border border-border bg-card px-2 py-1 transition-colors hover:bg-[#EAEEF3]"
+            >
+              →
+            </button>
+          </div>
+          <div className="grid grid-cols-7 gap-0.5">
+            {DOW.map((day) => (
+              <div key={day} className="text-center font-mono text-[10px] font-semibold text-muted-foreground">
+                {day}
+              </div>
+            ))}
+            {days.map((day, index) => {
+              const iso = toIsoDate(day);
+              const other = day.getMonth() !== month.getMonth();
+              const selected = value === iso;
+              const isToday = iso === today;
+              return (
+                <button
+                  key={index}
+                  type="button"
+                  onClick={() => {
+                    onChange?.(iso);
+                    setOpen(false);
+                  }}
+                  className={cn(
+                    dayButtonClass,
+                    other && "text-muted-foreground",
+                    isToday && !selected && "border-primary",
+                    selected && "border-primary bg-primary text-primary-foreground hover:bg-primary"
+                  )}
+                >
+                  {day.getDate()}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/date-range-picker.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/date-range-picker.tsx
@@ -1,0 +1,158 @@
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import { monthGrid, toIsoDate } from "@/components/ui/date-picker";
+import { cn } from "@/lib/utils";
+
+export interface DateRange {
+  start: string | null;
+  end: string | null;
+}
+
+export interface DateRangePickerProps {
+  start?: string | null;
+  end?: string | null;
+  onChange?: (range: DateRange) => void;
+  label?: ReactNode;
+  disabled?: boolean;
+  className?: string;
+}
+
+const DOW = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+
+const dayButtonClass =
+  "flex h-8 w-8 items-center justify-center border border-transparent font-mono text-xs text-foreground transition-colors hover:bg-[#EAEEF3] focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 [outline-offset:-2px]";
+
+function shortLabel(value: string | null | undefined, fallback: string): string {
+  return value ? new Date(value).toLocaleDateString("en-US", { month: "short", day: "numeric" }) : fallback;
+}
+
+/**
+ * Start/end date range selection across two months. Concrete: hairline field, menu-shadowed
+ * dual calendar, accent endpoints with an alpha-10 in-range wash. Emits `{ start, end }` ISO
+ * dates via `onChange`.
+ */
+export function DateRangePicker({ start, end, onChange, label, disabled = false, className }: DateRangePickerProps) {
+  const [open, setOpen] = useState(false);
+  const [month, setMonth] = useState<Date>(start ? new Date(start) : new Date());
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return undefined;
+    }
+    const handler = (event: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  const handleDayClick = (day: Date) => {
+    const iso = toIsoDate(day);
+    if (!start || (start && end)) {
+      onChange?.({ start: iso, end: null });
+    } else if (iso < start) {
+      onChange?.({ start: iso, end: start });
+    } else {
+      onChange?.({ start, end: iso });
+      setOpen(false);
+    }
+  };
+
+  const inRange = (day: Date) => {
+    const iso = toIsoDate(day);
+    return Boolean(start && end && iso >= start && iso <= end);
+  };
+
+  const renderMonth = (base: Date, offset: number) => {
+    const monthDate = new Date(base.getFullYear(), base.getMonth() + offset, 1);
+    return (
+      <div className="w-[16rem]">
+        <div className="mb-3 flex items-center justify-between text-xs font-semibold text-foreground">
+          {offset === 0 ? (
+            <button
+              type="button"
+              aria-label="Previous month"
+              onClick={() => setMonth(new Date(base.getFullYear(), base.getMonth() - 1))}
+              className="rounded-[2px] border border-border bg-card px-2 py-1 transition-colors hover:bg-[#EAEEF3]"
+            >
+              ←
+            </button>
+          ) : (
+            <span />
+          )}
+          <span>{monthDate.toLocaleDateString("en-US", { year: "numeric", month: "long" })}</span>
+          {offset === 1 ? (
+            <button
+              type="button"
+              aria-label="Next month"
+              onClick={() => setMonth(new Date(base.getFullYear(), base.getMonth() + 1))}
+              className="rounded-[2px] border border-border bg-card px-2 py-1 transition-colors hover:bg-[#EAEEF3]"
+            >
+              →
+            </button>
+          ) : (
+            <span />
+          )}
+        </div>
+        <div className="grid grid-cols-7 gap-0.5">
+          {DOW.map((day) => (
+            <div key={day} className="text-center font-mono text-[10px] font-semibold text-muted-foreground">
+              {day}
+            </div>
+          ))}
+          {monthGrid(monthDate).map((day, index) => {
+            const iso = toIsoDate(day);
+            const isStart = start === iso;
+            const isEnd = end === iso;
+            const within = inRange(day);
+            return (
+              <button
+                key={index}
+                type="button"
+                onClick={() => handleDayClick(day)}
+                className={cn(
+                  dayButtonClass,
+                  "rounded-[2px]",
+                  within && "bg-primary/10",
+                  (isStart || isEnd) && "border-primary bg-primary text-primary-foreground hover:bg-primary"
+                )}
+              >
+                {day.getDate()}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div ref={rootRef} className={cn("relative w-full", className)}>
+      {label ? (
+        <span className="mb-1.5 block font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          {label}
+        </span>
+      ) : null}
+      <input
+        type="text"
+        readOnly
+        disabled={disabled}
+        value={`${shortLabel(start, "Start")} — ${shortLabel(end, "End")}`}
+        onClick={() => !disabled && setOpen((current) => !current)}
+        className={cn(
+          "h-9 w-full cursor-pointer rounded-[2px] border border-border bg-[#F3F6F9] px-2.5 font-mono text-sm text-foreground",
+          "hover:border-[#ADB8C4] focus-visible:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+          disabled && "cursor-not-allowed opacity-55"
+        )}
+      />
+      {open ? (
+        <div className="absolute left-0 top-[calc(100%+4px)] z-[100] flex gap-4 rounded-[2px] border border-border bg-popover p-3 shadow-[0_2px_6px_rgba(0,0,0,0.18)]">
+          {renderMonth(month, 0)}
+          {renderMonth(month, 1)}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/density-toggle.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/density-toggle.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DensityToggle } from "@/components/ui/density-toggle";
+
+afterEach(() => {
+  document.body.removeAttribute("data-theme-density");
+});
+
+describe("DensityToggle", () => {
+  it("writes the density attribute to the body and reports changes", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<DensityToggle onChange={onChange} />);
+
+    await user.click(screen.getByRole("radio", { name: "Compact" }));
+    expect(onChange).toHaveBeenCalledWith("compact");
+    expect(document.body.getAttribute("data-theme-density")).toBe("compact");
+
+    await user.click(screen.getByRole("radio", { name: "Default" }));
+    expect(document.body.hasAttribute("data-theme-density")).toBe(false);
+  });
+
+  it("marks the active level via aria-checked", () => {
+    render(<DensityToggle value="spacious" apply={false} />);
+    expect(screen.getByRole("radio", { name: "Spacious" })).toHaveAttribute("aria-checked", "true");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/density-toggle.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/density-toggle.tsx
@@ -1,0 +1,150 @@
+import { type RefObject, useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+export type Density = "compact" | "default" | "spacious";
+
+export interface DensityToggleProps {
+  value?: Density;
+  defaultValue?: Density;
+  onChange?: (value: Density) => void;
+  target?: "body" | "root" | "html" | string | RefObject<HTMLElement> | HTMLElement | null;
+  apply?: boolean;
+  persist?: string | null;
+  showLabels?: boolean;
+  size?: "sm" | "md";
+  fullWidth?: boolean;
+  className?: string;
+}
+
+const LEVELS: Array<{ value: Density; label: string; gap: number }> = [
+  { value: "compact", label: "Compact", gap: 1 },
+  { value: "default", label: "Default", gap: 2 },
+  { value: "spacious", label: "Spacious", gap: 4 }
+];
+
+function resolveTarget(target: DensityToggleProps["target"]): HTMLElement | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  if (!target || target === "body") {
+    return document.body;
+  }
+  if (target === "root" || target === "html") {
+    return document.documentElement;
+  }
+  if (typeof target === "string") {
+    return document.querySelector<HTMLElement>(target);
+  }
+  if (typeof target === "object" && "current" in target) {
+    return target.current;
+  }
+  return target;
+}
+
+function applyDensity(el: HTMLElement | null, value: Density) {
+  if (!el) {
+    return;
+  }
+  if (value === "default") {
+    el.removeAttribute("data-theme-density");
+  } else {
+    el.setAttribute("data-theme-density", value);
+  }
+}
+
+function Glyph({ gap }: { gap: number }) {
+  return (
+    <span aria-hidden="true" className="inline-flex w-[11px] flex-col" style={{ gap }}>
+      <i className="block h-[1.5px] rounded-[1px] bg-current" />
+      <i className="block h-[1.5px] rounded-[1px] bg-current" />
+      <i className="block h-[1.5px] rounded-[1px] bg-current" />
+    </span>
+  );
+}
+
+/**
+ * Operator control for the density token scopes (`data-theme-density="compact"|"spacious"`).
+ * Writes the attribute to a target element (`document.body` by default) and can `persist` the
+ * choice. Concrete segmented look — flat, hairline, 2px corners.
+ */
+export function DensityToggle({
+  value: controlled,
+  defaultValue = "default",
+  onChange,
+  target = "body",
+  apply = true,
+  persist = null,
+  showLabels = true,
+  size = "md",
+  fullWidth = false,
+  className
+}: DensityToggleProps) {
+  const isControlled = controlled != null;
+  const [internal, setInternal] = useState<Density>(() => {
+    if (isControlled) {
+      return controlled;
+    }
+    if (persist && typeof localStorage !== "undefined") {
+      const saved = localStorage.getItem(persist);
+      if (saved === "compact" || saved === "default" || saved === "spacious") {
+        return saved;
+      }
+    }
+    return defaultValue;
+  });
+  const value = isControlled ? controlled : internal;
+
+  useEffect(() => {
+    if (!apply) {
+      return;
+    }
+    applyDensity(resolveTarget(target), value);
+  }, [value, apply, target]);
+
+  const select = (next: Density) => {
+    if (!isControlled) {
+      setInternal(next);
+    }
+    if (persist && typeof localStorage !== "undefined") {
+      localStorage.setItem(persist, next);
+    }
+    onChange?.(next);
+  };
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Display density"
+      className={cn(
+        "inline-flex items-stretch gap-0.5 rounded-[2px] border border-border bg-[#F3F6F9] p-0.5",
+        fullWidth && "flex w-full",
+        className
+      )}
+    >
+      {LEVELS.map((level) => {
+        const active = level.value === value;
+        return (
+          <button
+            key={level.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            title={level.label}
+            onClick={() => select(level.value)}
+            className={cn(
+              "inline-flex flex-1 items-center justify-center gap-1.5 rounded-[2px] font-medium leading-none transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+              size === "sm" ? "px-2.5 py-1 text-[11px]" : "px-3 py-1.5 text-xs",
+              active
+                ? "bg-card font-semibold text-foreground shadow-[inset_0_0_0_1px_hsl(var(--border))]"
+                : "bg-transparent text-muted-foreground hover:bg-[#EAEEF3] hover:text-foreground"
+            )}
+          >
+            <Glyph gap={level.gap} />
+            {showLabels ? <span>{level.label}</span> : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/dialog.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/dialog.test.tsx
@@ -128,7 +128,7 @@ describe("Dialog", () => {
       "max-h-[calc(100dvh-2rem)]",
       "overflow-y-auto",
       "overscroll-contain",
-      "rounded-[var(--radius-card,0.5rem)]"
+      "rounded-[2px]"
     );
   });
 

--- a/src/Meridian.Ui/dashboard/src/components/ui/dialog.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/components/ui/dialog.view-model.test.ts
@@ -18,7 +18,7 @@ describe("dialog interaction view model", () => {
     expect(viewModel.className).toContain("max-h-[calc(100dvh-2rem)]");
     expect(viewModel.className).toContain("overflow-y-auto");
     expect(viewModel.className).toContain("overscroll-contain");
-    expect(viewModel.className).toContain("rounded-[var(--radius-card,0.5rem)]");
+    expect(viewModel.className).toContain("rounded-[2px]");
   });
 
   it("preserves caller-provided tab target while deriving the dialog surface", () => {

--- a/src/Meridian.Ui/dashboard/src/components/ui/dialog.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/components/ui/dialog.view-model.ts
@@ -121,7 +121,7 @@ export function buildDialogContentViewModel(tabIndex = -1): DialogContentViewMod
     className: [
       "w-full max-w-lg",
       "max-h-[calc(100dvh-2rem)] overflow-y-auto overscroll-contain",
-      "rounded-[var(--radius-card,0.5rem)] border border-border bg-card p-5 text-card-foreground shadow-float backdrop-blur-sm",
+      "rounded-[2px] border border-border bg-card p-5 text-card-foreground shadow-[0_2px_6px_rgba(0,0,0,0.18)]",
       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
     ].join(" ")
   };
@@ -141,9 +141,9 @@ export function buildDialogCloseButtonViewModel({
     disabled,
     iconAriaHidden: true,
     className: [
-      "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-button,0.375rem)] border",
-      "border-border/70 bg-transparent text-muted-foreground transition-colors duration-200",
-      "hover:bg-secondary/55 hover:text-foreground",
+      "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[2px] border [outline-offset:-2px]",
+      "border-border bg-transparent text-muted-foreground transition-colors duration-150",
+      "hover:border-[#ADB8C4] hover:bg-[#EAEEF3] hover:text-foreground",
       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
       "disabled:cursor-not-allowed disabled:opacity-50"
     ].join(" ")

--- a/src/Meridian.Ui/dashboard/src/components/ui/drawer.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/drawer.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Drawer, DrawerBody, DrawerFooter, DrawerHeader } from "@/components/ui/drawer";
+
+describe("Drawer", () => {
+  it("renders nothing when closed", () => {
+    render(
+      <Drawer open={false} onClose={vi.fn()} title="Inspector">
+        <DrawerBody>content</DrawerBody>
+      </Drawer>
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders header/body/footer and closes via the close button", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <Drawer open onClose={onClose}>
+        <DrawerHeader title="Account 4000" onClose={onClose} />
+        <DrawerBody>Revenue detail</DrawerBody>
+        <DrawerFooter>
+          <button type="button">Save</button>
+        </DrawerFooter>
+      </Drawer>
+    );
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Revenue detail")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Close drawer" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <Drawer open onClose={onClose} title="Filters">
+        <DrawerBody>content</DrawerBody>
+      </Drawer>
+    );
+
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/drawer.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/drawer.tsx
@@ -1,0 +1,166 @@
+import { type HTMLAttributes, type ReactNode, useCallback, useEffect, useRef } from "react";
+import { X } from "lucide-react";
+import { resolveDialogTabTarget, resolveInitialDialogFocus } from "@/components/ui/dialog.view-model";
+import { cn } from "@/lib/utils";
+
+type DrawerSide = "left" | "right";
+
+export interface DrawerProps {
+  open: boolean;
+  onClose?: () => void;
+  side?: DrawerSide;
+  title?: ReactNode;
+  closeOnEsc?: boolean;
+  closeOnBackdrop?: boolean;
+  children?: ReactNode;
+  className?: string;
+}
+
+function getActiveElement(): HTMLElement | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  return document.activeElement instanceof HTMLElement ? document.activeElement : null;
+}
+
+/**
+ * Side panel for inspection/filters without leaving context. Slides from an edge,
+ * traps focus, and dismisses via Escape or backdrop. Concrete: flat panel, hairline
+ * border, the detached overlay carries the only shadow.
+ *
+ * Compose the body with `DrawerHeader` / `DrawerBody` / `DrawerFooter`, or pass a `title`
+ * for the default header + close button.
+ */
+export function Drawer({
+  open,
+  onClose,
+  side = "right",
+  title,
+  closeOnEsc = true,
+  closeOnBackdrop = true,
+  children,
+  className
+}: DrawerProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+
+  const requestClose = useCallback(() => onClose?.(), [onClose]);
+
+  useEffect(() => {
+    if (!open || typeof window === "undefined") {
+      return undefined;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (closeOnEsc && event.key === "Escape") {
+        event.preventDefault();
+        requestClose();
+        return;
+      }
+      if (event.key !== "Tab") {
+        return;
+      }
+      const nextFocus = resolveDialogTabTarget(panelRef.current, getActiveElement(), event.shiftKey);
+      if (nextFocus) {
+        event.preventDefault();
+        nextFocus.focus();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [open, closeOnEsc, requestClose]);
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+    restoreFocusRef.current = getActiveElement();
+    const frame = window.requestAnimationFrame(() => {
+      resolveInitialDialogFocus(panelRef.current, getActiveElement())?.focus();
+    });
+    return () => {
+      window.cancelAnimationFrame(frame);
+      const restore = restoreFocusRef.current;
+      restoreFocusRef.current = null;
+      if (restore?.isConnected) {
+        restore.focus();
+      }
+    };
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={overlayRef}
+      className={cn("fixed inset-0 z-50 flex bg-background/70", side === "left" ? "justify-start" : "justify-end")}
+      onMouseDown={(event) => {
+        if (closeOnBackdrop && event.target === overlayRef.current) {
+          requestClose();
+        }
+      }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        tabIndex={-1}
+        className={cn(
+          "flex h-full w-full max-w-[360px] flex-col bg-card shadow-[0_2px_6px_rgba(0,0,0,0.18)] focus:outline-none",
+          side === "left" ? "border-r border-border sheet-slide-left" : "border-l border-border sheet-slide-right",
+          className
+        )}
+      >
+        {title ? <DrawerHeader title={title} onClose={onClose} /> : null}
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export interface DrawerHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  title?: ReactNode;
+  onClose?: () => void;
+}
+
+export function DrawerHeader({ title, onClose, className, children, ...props }: DrawerHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-2 border-b border-border bg-[#F3F6F9] px-4 py-3",
+        className
+      )}
+      {...props}
+    >
+      {title ? <h2 className="text-sm font-semibold text-foreground">{title}</h2> : null}
+      {children}
+      {onClose ? (
+        <button
+          type="button"
+          aria-label="Close drawer"
+          onClick={onClose}
+          className="ml-auto inline-flex h-8 w-8 items-center justify-center rounded-[2px] text-muted-foreground transition-colors [outline-offset:-2px] hover:bg-[#EAEEF3] hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        >
+          <X className="h-4 w-4" aria-hidden="true" />
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+export function DrawerBody({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex-1 space-y-4 overflow-y-auto p-4 text-sm text-foreground", className)} {...props} />;
+}
+
+export function DrawerFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("flex flex-wrap items-center justify-end gap-2 border-t border-border px-4 py-3", className)}
+      {...props}
+    />
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/feedback-primitives.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/feedback-primitives.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Callout } from "@/components/ui/callout";
+import { Kbd } from "@/components/ui/kbd";
+import { Spinner } from "@/components/ui/spinner";
+
+describe("Callout", () => {
+  it("renders a titled note with tone-driven left rule", () => {
+    render(
+      <Callout tone="warning" title="Live environment">
+        Orders execute against real capital.
+      </Callout>
+    );
+    const note = screen.getByRole("note");
+    expect(note).toHaveClass("border-l-warning");
+    expect(screen.getByText("Live environment")).toBeInTheDocument();
+    expect(screen.getByText("Orders execute against real capital.")).toBeInTheDocument();
+  });
+});
+
+describe("Kbd", () => {
+  it("splits a combo string into separate key caps", () => {
+    render(<Kbd keys="Ctrl+Enter" />);
+    expect(screen.getByText("Ctrl")).toBeInTheDocument();
+    expect(screen.getByText("Enter")).toBeInTheDocument();
+  });
+
+  it("renders children when no keys are provided", () => {
+    render(<Kbd>Esc</Kbd>);
+    expect(screen.getByText("Esc")).toBeInTheDocument();
+  });
+});
+
+describe("Spinner", () => {
+  it("exposes a status role with the accessible label", () => {
+    render(<Spinner label="Loading positions" />);
+    expect(screen.getByRole("status", { name: "Loading positions" })).toBeInTheDocument();
+    expect(screen.getByText("Loading positions")).toBeInTheDocument();
+  });
+
+  it("defaults the accessible label to Loading", () => {
+    render(<Spinner />);
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/file-upload.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/file-upload.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { FileUpload } from "@/components/ui/file-upload";
+
+describe("FileUpload", () => {
+  it("selects files through the input and lists them", async () => {
+    const user = userEvent.setup();
+    const onFilesSelected = vi.fn();
+    const { container } = render(<FileUpload label="Evidence" onFilesSelected={onFilesSelected} />);
+
+    const input = container.querySelector("input[type='file']") as HTMLInputElement;
+    const file = new File(["x"], "trades.csv", { type: "text/csv" });
+    await user.upload(input, file);
+
+    expect(onFilesSelected).toHaveBeenCalledWith([file]);
+    expect(screen.getByText("trades.csv")).toBeInTheDocument();
+  });
+
+  it("removes a selected file", async () => {
+    const user = userEvent.setup();
+    const onFilesSelected = vi.fn();
+    const { container } = render(<FileUpload onFilesSelected={onFilesSelected} />);
+
+    const input = container.querySelector("input[type='file']") as HTMLInputElement;
+    const file = new File(["x"], "ledger.json", { type: "application/json" });
+    await user.upload(input, file);
+
+    await user.click(screen.getByRole("button", { name: "Remove ledger.json" }));
+    expect(onFilesSelected).toHaveBeenLastCalledWith([]);
+    expect(screen.queryByText("ledger.json")).not.toBeInTheDocument();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/file-upload.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/file-upload.tsx
@@ -1,0 +1,117 @@
+import { type ReactNode, useRef, useState } from "react";
+import { Upload, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface FileUploadProps {
+  label?: ReactNode;
+  onFilesSelected?: (files: File[]) => void;
+  multiple?: boolean;
+  accept?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * Drag-and-drop file input (also click-to-browse). Concrete: flat dashed hairline drop zone
+ * that shifts to the accent on drag, 2px corners; selected files list as hairline-bordered
+ * rows with a dim-red remove control.
+ */
+export function FileUpload({
+  label,
+  onFilesSelected,
+  multiple = true,
+  accept = "*",
+  disabled = false,
+  className
+}: FileUploadProps) {
+  const [files, setFiles] = useState<File[]>([]);
+  const [dragging, setDragging] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const emit = (next: File[]) => {
+    setFiles(next);
+    onFilesSelected?.(next);
+  };
+
+  const addFiles = (list: FileList | null) => {
+    if (!list) {
+      return;
+    }
+    const incoming = Array.from(list);
+    emit(multiple ? [...files, ...incoming] : incoming);
+  };
+
+  const removeFile = (index: number) => {
+    emit(files.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className={cn("w-full", className)}>
+      {label ? (
+        <span className="mb-1.5 block font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          {label}
+        </span>
+      ) : null}
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => inputRef.current?.click()}
+        onDrop={(event) => {
+          event.preventDefault();
+          setDragging(false);
+          if (!disabled) {
+            addFiles(event.dataTransfer.files);
+          }
+        }}
+        onDragOver={(event) => {
+          event.preventDefault();
+          if (!disabled) {
+            setDragging(true);
+          }
+        }}
+        onDragLeave={() => setDragging(false)}
+        className={cn(
+          "flex w-full flex-col items-center gap-2 rounded-[2px] border-2 border-dashed px-5 py-5 text-center transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+          dragging ? "border-primary bg-primary/10" : "border-border bg-[#F3F6F9] hover:border-[#ADB8C4]",
+          disabled && "cursor-not-allowed opacity-55"
+        )}
+      >
+        <Upload className="h-6 w-6 text-muted-foreground" aria-hidden="true" />
+        <span className="text-xs text-muted-foreground">Drag files here or click to browse</span>
+        <span className="font-mono text-[10px] text-muted-foreground">
+          {accept !== "*" ? `Accepts: ${accept}` : "Any file type"}
+        </span>
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        multiple={multiple}
+        accept={accept}
+        disabled={disabled}
+        className="hidden"
+        onChange={(event) => addFiles(event.target.files)}
+      />
+      {files.length > 0 ? (
+        <ul className="mt-2 space-y-1">
+          {files.map((file, index) => (
+            <li
+              key={`${file.name}-${index}`}
+              className="flex items-center gap-2 rounded-[2px] border border-border bg-card px-2 py-1.5 text-xs"
+            >
+              <span className="min-w-0 flex-1 truncate font-mono text-foreground">{file.name}</span>
+              <button
+                type="button"
+                aria-label={`Remove ${file.name}`}
+                onClick={() => removeFile(index)}
+                className="text-danger transition-colors hover:text-danger/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+              >
+                <X className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/gauge.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/gauge.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Gauge, LinearGauge } from "@/components/ui/gauge";
+
+describe("Gauge", () => {
+  it("renders the rounded percentage of value/max", () => {
+    render(<Gauge value={30} max={120} label="Fill rate" />);
+    expect(screen.getByText("25%")).toBeInTheDocument();
+    expect(screen.getByText("Fill rate")).toBeInTheDocument();
+  });
+
+  it("clamps values above the maximum", () => {
+    render(<Gauge value={200} max={100} />);
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+});
+
+describe("LinearGauge", () => {
+  it("exposes a progressbar with the computed percentage", () => {
+    render(<LinearGauge value={65} label="Memory" />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "65");
+    expect(screen.getByText("65%")).toBeInTheDocument();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/gauge.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/gauge.tsx
@@ -1,0 +1,127 @@
+import { type CSSProperties, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export interface GaugeProps {
+  value?: number;
+  max?: number;
+  label?: ReactNode;
+  size?: number;
+  thickness?: number;
+  color?: string;
+  showValue?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+
+/**
+ * Circular progress indicator for a single headline metric. Concrete: flat plot, hairline
+ * track, one accent arc; the number renders as a mono metric, the label as a small-caps
+ * eyebrow.
+ */
+export function Gauge({
+  value = 0,
+  max = 100,
+  label,
+  size = 120,
+  thickness = 8,
+  color = "hsl(var(--primary))",
+  showValue = true,
+  className,
+  style
+}: GaugeProps) {
+  const percent = Math.min(Math.max(max > 0 ? value / max : 0, 0), 1);
+  const radius = (size - thickness) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference * (1 - percent);
+  const center = size / 2;
+
+  return (
+    <div className={cn("flex flex-col items-center gap-3", className)} style={style}>
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} style={{ transform: "rotate(-90deg)" }} role="img" aria-label={typeof label === "string" ? label : "gauge"}>
+        <circle cx={center} cy={center} r={radius} fill="none" stroke="hsl(var(--border))" strokeWidth={thickness} />
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke={color}
+          strokeWidth={thickness}
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          strokeLinecap="butt"
+          style={{ transition: "stroke-dashoffset 300ms ease-out" }}
+        />
+      </svg>
+      {label || showValue ? (
+        <div className="text-center">
+          {showValue ? (
+            <div className="font-mono text-[28px] font-bold leading-none tabular-nums text-foreground">
+              {Math.round(percent * 100)}%
+            </div>
+          ) : null}
+          {label ? (
+            <div className="mt-1 font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              {label}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export interface LinearGaugeProps {
+  value?: number;
+  max?: number;
+  label?: ReactNode;
+  showValue?: boolean;
+  color?: string;
+  height?: number;
+  className?: string;
+  style?: CSSProperties;
+}
+
+/**
+ * Horizontal progress indicator with a small-caps label and mono value readout. Concrete:
+ * flat hairline-bordered track, one accent fill, 2px corners.
+ */
+export function LinearGauge({
+  value = 0,
+  max = 100,
+  label,
+  showValue = true,
+  color = "hsl(var(--primary))",
+  height = 8,
+  className,
+  style
+}: LinearGaugeProps) {
+  const percent = Math.min(Math.max(max > 0 ? value / max : 0, 0), 1) * 100;
+
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)} style={style}>
+      {label || showValue ? (
+        <div className="flex items-baseline justify-between">
+          {label ? (
+            <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">{label}</span>
+          ) : null}
+          {showValue ? (
+            <span className="font-mono text-sm font-semibold tabular-nums text-foreground">{Math.round(percent)}%</span>
+          ) : null}
+        </div>
+      ) : null}
+      <div
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(percent)}
+        className="relative w-full overflow-hidden rounded-[2px] border border-border bg-[#F3F6F9]"
+        style={{ height }}
+      >
+        <div
+          className="absolute left-0 top-0 h-full"
+          style={{ width: `${percent}%`, backgroundColor: color, transition: "width 300ms ease-out" }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/input.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/input.tsx
@@ -46,14 +46,14 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           ref={ref}
           type={type}
           className={cn(
-            "w-full rounded-[var(--radius-button,0.375rem)] border bg-background/55 text-sm text-foreground shadow-[var(--shadow-panel)] placeholder:text-muted-foreground/60",
+            "w-full rounded-[2px] border bg-[#F3F6F9] text-sm text-foreground placeholder:text-muted-foreground/60",
             "min-h-9 px-3 py-2",
-            "transition-[background-color,border-color,box-shadow] duration-150",
+            "transition-[background-color,border-color] duration-150",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
             "disabled:cursor-not-allowed disabled:opacity-50",
             error
               ? "border-danger/60 focus-visible:ring-danger/40"
-              : "border-border/80 hover:border-border focus-visible:border-primary/60",
+              : "border-border hover:border-[#ADB8C4] focus-visible:border-primary",
             hasLeading && "pl-9",
             hasTrailing && "pr-9",
             className

--- a/src/Meridian.Ui/dashboard/src/components/ui/kbd.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/kbd.tsx
@@ -1,0 +1,55 @@
+import { Fragment, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export interface KbdProps {
+  /** A combo string (`"Ctrl+Enter"`, `"⌘ K"`) or an explicit list of key caps. */
+  keys?: string | string[];
+  variant?: "default" | "solid";
+  className?: string;
+  children?: ReactNode;
+}
+
+function parseKeys(keys?: string | string[], children?: ReactNode): string[] | null {
+  if (Array.isArray(keys)) {
+    return keys;
+  }
+  if (typeof keys === "string") {
+    return keys.split(/\s*\+\s*|\s+/).filter(Boolean);
+  }
+  if (typeof children === "string") {
+    return children.split(/\s*\+\s*|\s+/).filter(Boolean);
+  }
+  return null;
+}
+
+/**
+ * Keyboard shortcut hint. Operator workstations are keyboard-driven; this renders crisp mono
+ * key caps and combos (⌘K, Ctrl+Enter). Concrete: hairline border with a 2px "keycap" bottom
+ * edge, mono type, 2px corners.
+ */
+export function Kbd({ keys, variant = "default", className, children }: KbdProps) {
+  const parts = parseKeys(keys, children);
+  const keyClass = cn(
+    "inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-[2px] border border-b-2 border-border px-1.5 font-mono text-[11px] font-semibold leading-none",
+    variant === "solid" ? "bg-card text-foreground" : "bg-[#F3F6F9] text-muted-foreground"
+  );
+
+  return (
+    <span className={cn("inline-flex items-center gap-0.5 align-middle", className)}>
+      {parts ? (
+        parts.map((key, index) => (
+          <Fragment key={index}>
+            {index > 0 ? (
+              <span aria-hidden="true" className="px-px text-[10px] font-medium text-muted-foreground">
+                +
+              </span>
+            ) : null}
+            <kbd className={keyClass}>{key}</kbd>
+          </Fragment>
+        ))
+      ) : (
+        <kbd className={keyClass}>{children}</kbd>
+      )}
+    </span>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/layout.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/layout.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Flex, Grid, Stack } from "@/components/ui/layout";
+
+describe("layout primitives", () => {
+  it("renders a vertical Stack with tokenized spacing", () => {
+    render(
+      <Stack spacing="lg" aria-label="stack">
+        <span>a</span>
+        <span>b</span>
+      </Stack>
+    );
+
+    const stack = screen.getByLabelText("stack");
+    expect(stack).toHaveClass("flex", "flex-col", "gap-4");
+  });
+
+  it("renders a horizontal Flex with alignment and wrap", () => {
+    render(
+      <Flex gap="sm" align="center" justify="between" wrap aria-label="flex">
+        <span>a</span>
+      </Flex>
+    );
+
+    const flex = screen.getByLabelText("flex");
+    expect(flex).toHaveClass("flex-row", "gap-1.5", "items-center", "justify-between", "flex-wrap");
+  });
+
+  it("renders an equal-column Grid", () => {
+    render(
+      <Grid cols={3} gap="xl" aria-label="grid">
+        <span>a</span>
+      </Grid>
+    );
+
+    const grid = screen.getByLabelText("grid");
+    expect(grid).toHaveClass("grid", "grid-cols-3", "gap-6");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/layout.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/layout.tsx
@@ -1,0 +1,121 @@
+import { forwardRef, type HTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Concrete layout primitives — `Stack`, `Flex`, and `Grid`.
+ *
+ * Prefer these over hand-rolled flex/grid so spacing tracks the Meridian spacing
+ * scale (`xs sm md lg xl 2xl`). Each maps to a fixed Tailwind gap utility so the
+ * rhythm stays consistent (6 tight · 12 standard · 16 generous · 24 section · 32 major).
+ */
+export type SpacingScale = "none" | "xs" | "sm" | "md" | "lg" | "xl" | "2xl";
+
+const gapClasses: Record<SpacingScale, string> = {
+  none: "gap-0",
+  xs: "gap-1", // ~3px micro / 4px
+  sm: "gap-1.5", // ~6px tight
+  md: "gap-3", // 12px standard
+  lg: "gap-4", // 16px generous
+  xl: "gap-6", // 24px section
+  "2xl": "gap-8" // 32px major
+};
+
+type FlexAlign = "start" | "center" | "end" | "stretch" | "baseline";
+type FlexJustify = "start" | "center" | "end" | "between" | "around" | "evenly";
+
+const alignClasses: Record<FlexAlign, string> = {
+  start: "items-start",
+  center: "items-center",
+  end: "items-end",
+  stretch: "items-stretch",
+  baseline: "items-baseline"
+};
+
+const justifyClasses: Record<FlexJustify, string> = {
+  start: "justify-start",
+  center: "justify-center",
+  end: "justify-end",
+  between: "justify-between",
+  around: "justify-around",
+  evenly: "justify-evenly"
+};
+
+export interface StackProps extends HTMLAttributes<HTMLDivElement> {
+  direction?: "vertical" | "horizontal";
+  spacing?: SpacingScale;
+  align?: FlexAlign;
+  justify?: FlexJustify;
+}
+
+/** Semantic directional flex — reach for it when direction is the point. */
+export const Stack = forwardRef<HTMLDivElement, StackProps>(
+  ({ className, direction = "vertical", spacing = "md", align = "stretch", justify = "start", ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "flex",
+        direction === "vertical" ? "flex-col" : "flex-row",
+        gapClasses[spacing],
+        alignClasses[align],
+        justifyClasses[justify],
+        className
+      )}
+      {...props}
+    />
+  )
+);
+
+Stack.displayName = "Stack";
+
+export interface FlexProps extends HTMLAttributes<HTMLDivElement> {
+  vertical?: boolean;
+  gap?: SpacingScale;
+  align?: FlexAlign;
+  justify?: FlexJustify;
+  wrap?: boolean;
+}
+
+/** A row (or `vertical` column) with `align` / `justify` / `gap`. */
+export const Flex = forwardRef<HTMLDivElement, FlexProps>(
+  ({ className, vertical = false, gap = "md", align = "stretch", justify = "start", wrap = false, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "flex",
+        vertical ? "flex-col" : "flex-row",
+        wrap && "flex-wrap",
+        gapClasses[gap],
+        alignClasses[align],
+        justifyClasses[justify],
+        className
+      )}
+      {...props}
+    />
+  )
+);
+
+Flex.displayName = "Flex";
+
+export interface GridProps extends HTMLAttributes<HTMLDivElement> {
+  cols?: 1 | 2 | 3 | 4 | 5 | 6 | 12;
+  gap?: SpacingScale;
+}
+
+const colClasses: Record<NonNullable<GridProps["cols"]>, string> = {
+  1: "grid-cols-1",
+  2: "grid-cols-2",
+  3: "grid-cols-3",
+  4: "grid-cols-4",
+  5: "grid-cols-5",
+  6: "grid-cols-6",
+  12: "grid-cols-12"
+};
+
+/** Equal-column CSS grid: `<Grid cols={3} gap="lg">`. */
+export const Grid = forwardRef<HTMLDivElement, GridProps>(
+  ({ className, cols = 2, gap = "md", ...props }, ref) => (
+    <div ref={ref} className={cn("grid", colClasses[cols], gapClasses[gap], className)} {...props} />
+  )
+);
+
+Grid.displayName = "Grid";

--- a/src/Meridian.Ui/dashboard/src/components/ui/number-input.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/number-input.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { NumberInput } from "@/components/ui/number-input";
+import { TextArea } from "@/components/ui/text-area";
+
+describe("NumberInput", () => {
+  it("increments and decrements by step, emitting the value", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<NumberInput aria-label="Qty" defaultValue={5} step={2} onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Increment" }));
+    expect(onChange).toHaveBeenLastCalledWith(7);
+
+    await user.click(screen.getByRole("button", { name: "Decrement" }));
+    expect(onChange).toHaveBeenLastCalledWith(5);
+  });
+
+  it("clamps to min and disables the decrement button at the floor", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<NumberInput aria-label="Qty" value={0} min={0} onChange={onChange} />);
+
+    expect(screen.getByRole("button", { name: "Decrement" })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Increment" }));
+    expect(onChange).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("TextArea", () => {
+  it("renders a labelled control and surfaces error state", () => {
+    render(<TextArea label="Notes" error="Required" defaultValue="draft" />);
+    const control = screen.getByRole("textbox");
+    expect(control).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByText("Notes")).toBeInTheDocument();
+    expect(screen.getByText("Required")).toBeInTheDocument();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/number-input.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/number-input.tsx
@@ -1,0 +1,109 @@
+import { type ReactNode, useState } from "react";
+import { cn } from "@/lib/utils";
+
+export interface NumberInputProps {
+  value?: number;
+  defaultValue?: number;
+  onChange?: (value: number) => void;
+  label?: ReactNode;
+  min?: number;
+  max?: number;
+  step?: number;
+  disabled?: boolean;
+  placeholder?: string;
+  error?: boolean;
+  className?: string;
+  id?: string;
+  "aria-label"?: string;
+}
+
+/**
+ * Numeric input with +/- steppers. Concrete: flat field, hairline border, mono value, 2px
+ * corners; buttons clamp to `min`/`max`. Controlled via `value`, or uncontrolled via
+ * `defaultValue`.
+ */
+export function NumberInput({
+  value,
+  defaultValue = 0,
+  onChange,
+  label,
+  min,
+  max,
+  step = 1,
+  disabled = false,
+  placeholder,
+  error = false,
+  className,
+  id,
+  "aria-label": ariaLabel
+}: NumberInputProps) {
+  const controlled = value !== undefined;
+  const [internal, setInternal] = useState(defaultValue);
+  const current = controlled ? value! : internal;
+
+  const clamp = (next: number) => {
+    let result = next;
+    if (min !== undefined && result < min) result = min;
+    if (max !== undefined && result > max) result = max;
+    return result;
+  };
+
+  const commit = (next: number) => {
+    const clamped = clamp(next);
+    if (!controlled) {
+      setInternal(clamped);
+    }
+    onChange?.(clamped);
+  };
+
+  return (
+    <div className={className}>
+      {label ? (
+        <label htmlFor={id} className="mb-1.5 block font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          {label}
+        </label>
+      ) : null}
+      <div
+        className={cn(
+          "flex h-9 items-center rounded-[2px] border bg-[#F3F6F9]",
+          "focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/40",
+          error ? "border-danger/60" : "border-border",
+          disabled && "cursor-not-allowed opacity-55"
+        )}
+      >
+        <button
+          type="button"
+          aria-label="Decrement"
+          disabled={disabled || (min !== undefined && current <= min)}
+          onClick={() => commit(current - step)}
+          className="flex h-full w-8 items-center justify-center border-r border-border text-base font-semibold text-foreground transition-colors hover:bg-[#EAEEF3] focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50 [outline-offset:-2px]"
+        >
+          −
+        </button>
+        <input
+          id={id}
+          type="number"
+          inputMode="decimal"
+          aria-label={ariaLabel}
+          value={current}
+          min={min}
+          max={max}
+          step={step}
+          disabled={disabled}
+          placeholder={placeholder}
+          onChange={(event) => commit(Number.parseFloat(event.target.value) || 0)}
+          className="min-w-0 flex-1 bg-transparent px-2 text-center font-mono text-sm text-foreground focus:outline-none"
+        />
+        <button
+          type="button"
+          aria-label="Increment"
+          disabled={disabled || (max !== undefined && current >= max)}
+          onClick={() => commit(current + step)}
+          className="flex h-full w-8 items-center justify-center border-l border-border text-base font-semibold text-foreground transition-colors hover:bg-[#EAEEF3] focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50 [outline-offset:-2px]"
+        >
+          +
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/panel-surface.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/panel-surface.tsx
@@ -12,9 +12,9 @@ export const PanelSurface = forwardRef<HTMLDivElement, PanelSurfaceProps>(
     <div
       ref={ref}
       className={cn(
-        "rounded-[var(--radius-card,0.5rem)] border border-border bg-card text-card-foreground shadow-[var(--shadow-panel)]",
-        raised && "bg-muted/35",
-        elevated && "shadow-[var(--shadow-float)]",
+        "rounded-[2px] border border-border bg-card text-card-foreground",
+        raised && "bg-[#F3F6F9]",
+        elevated && "shadow-[0_2px_6px_rgba(0,0,0,0.18)]",
         flat && "shadow-none",
         className
       )}

--- a/src/Meridian.Ui/dashboard/src/components/ui/popover.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/popover.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Popover } from "@/components/ui/popover";
+
+describe("Popover", () => {
+  it("renders nothing when closed", () => {
+    render(<Popover open={false}>panel</Popover>);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders content and closes on Escape", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <Popover open onClose={onClose}>
+        Anchored content
+      </Popover>
+    );
+
+    expect(screen.getByText("Anchored content")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/popover.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/popover.tsx
@@ -1,0 +1,117 @@
+import { type CSSProperties, type ReactNode, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+type PopoverPosition = "top" | "bottom" | "left" | "right";
+
+export interface PopoverProps {
+  open: boolean;
+  onClose?: () => void;
+  anchorEl?: HTMLElement | null;
+  position?: PopoverPosition;
+  offset?: number;
+  closeOnEsc?: boolean;
+  closeOnBackdrop?: boolean;
+  children?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Lightweight floating panel anchored to a control — no backdrop weight, positioned to the
+ * anchor. Concrete: flat panel with a hairline border; the detached overlay carries the only
+ * shadow (`0 2px 6px rgba(0,0,0,.18)`).
+ */
+export function Popover({
+  open,
+  onClose,
+  anchorEl,
+  position = "bottom",
+  offset = 8,
+  closeOnEsc = true,
+  closeOnBackdrop = true,
+  children,
+  className
+}: PopoverProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [style, setStyle] = useState<CSSProperties>({});
+
+  useLayoutEffect(() => {
+    if (!open || !anchorEl || !panelRef.current || typeof window === "undefined") {
+      return undefined;
+    }
+
+    const update = () => {
+      const anchor = anchorEl.getBoundingClientRect();
+      const panel = panelRef.current!.getBoundingClientRect();
+      let top = 0;
+      let left = 0;
+
+      switch (position) {
+        case "top":
+          top = anchor.top - panel.height - offset;
+          left = anchor.left + anchor.width / 2 - panel.width / 2;
+          break;
+        case "bottom":
+          top = anchor.bottom + offset;
+          left = anchor.left + anchor.width / 2 - panel.width / 2;
+          break;
+        case "left":
+          top = anchor.top + anchor.height / 2 - panel.height / 2;
+          left = anchor.left - panel.width - offset;
+          break;
+        case "right":
+          top = anchor.top + anchor.height / 2 - panel.height / 2;
+          left = anchor.right + offset;
+          break;
+        default:
+          break;
+      }
+
+      const margin = 8;
+      left = Math.max(margin, Math.min(left, window.innerWidth - panel.width - margin));
+      top = Math.max(margin, Math.min(top, window.innerHeight - panel.height - margin));
+      setStyle({ top: `${top}px`, left: `${left}px` });
+    };
+
+    update();
+    window.addEventListener("scroll", update, true);
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update, true);
+      window.removeEventListener("resize", update);
+    };
+  }, [open, anchorEl, position, offset]);
+
+  useEffect(() => {
+    if (!open || typeof document === "undefined") {
+      return undefined;
+    }
+    const handleKey = (event: KeyboardEvent) => {
+      if (closeOnEsc && event.key === "Escape") {
+        onClose?.();
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, closeOnEsc, onClose]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <>
+      {closeOnBackdrop ? <div className="fixed inset-0 z-[1000]" aria-hidden="true" onMouseDown={onClose} /> : null}
+      <div
+        ref={panelRef}
+        role="dialog"
+        style={style}
+        className={cn(
+          "fixed z-[1001] max-w-[280px] rounded-[2px] border border-border bg-popover p-3 text-sm text-popover-foreground shadow-[0_2px_6px_rgba(0,0,0,0.18)]",
+          className
+        )}
+      >
+        {children}
+      </div>
+    </>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/primitives.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/primitives.test.tsx
@@ -19,7 +19,7 @@ describe("design-system UI primitives", () => {
       </PanelSurface>
     );
 
-    expect(screen.getByLabelText("Security panel")).toHaveClass("rounded-[var(--radius-card,0.5rem)]");
+    expect(screen.getByLabelText("Security panel")).toHaveClass("rounded-[2px]");
     expect(screen.getByText("Security Master")).toHaveAttribute("aria-current", "page");
   });
 

--- a/src/Meridian.Ui/dashboard/src/components/ui/progress.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/progress.tsx
@@ -19,11 +19,11 @@ export const Progress = forwardRef<HTMLDivElement, ProgressProps>(
         aria-valuemin={0}
         aria-valuemax={safeMax}
         aria-valuenow={safeValue}
-        className={cn("h-2 overflow-hidden rounded-[var(--radius-chip,0.25rem)] bg-secondary", className)}
+        className={cn("h-2 overflow-hidden rounded-[2px] border border-border bg-[#F3F6F9]", className)}
         {...props}
       >
         <div
-          className="h-full rounded-[var(--radius-chip,0.25rem)] bg-primary transition-all duration-300"
+          className="h-full rounded-[2px] bg-primary transition-all duration-300"
           style={{ width: `${percent}%` }}
         />
       </div>

--- a/src/Meridian.Ui/dashboard/src/components/ui/radio-group.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/radio-group.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { RadioGroup } from "@/components/ui/radio-group";
+
+const options = [
+  { value: "live", label: "Live" },
+  { value: "paper", label: "Paper" },
+  { value: "fixture", label: "Fixture" }
+];
+
+describe("RadioGroup", () => {
+  it("selects an option on click and emits the value", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<RadioGroup aria-label="Environment" options={options} value="live" onChange={onChange} />);
+
+    await user.click(screen.getByRole("radio", { name: "Paper" }));
+    expect(onChange).toHaveBeenCalledWith("paper");
+    expect(screen.getByRole("radio", { name: "Live" })).toBeChecked();
+  });
+
+  it("moves selection with arrow keys and wraps", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<RadioGroup aria-label="Environment" options={options} value="fixture" onChange={onChange} />);
+
+    screen.getByRole("radio", { name: "Fixture" }).focus();
+    await user.keyboard("{ArrowDown}");
+    expect(onChange).toHaveBeenCalledWith("live");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/radio-group.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/radio-group.tsx
@@ -1,0 +1,122 @@
+import { type KeyboardEvent, type ReactNode, useId } from "react";
+import { cn } from "@/lib/utils";
+
+export interface RadioOption {
+  value: string;
+  label: ReactNode;
+  hint?: ReactNode;
+  disabled?: boolean;
+}
+
+export interface RadioGroupProps {
+  options: Array<RadioOption | string>;
+  value?: string;
+  onChange?: (value: string) => void;
+  name?: string;
+  orientation?: "vertical" | "horizontal";
+  disabled?: boolean;
+  className?: string;
+  "aria-label"?: string;
+}
+
+function normalize(options: Array<RadioOption | string>): RadioOption[] {
+  return options.map((option) => (typeof option === "string" ? { value: option, label: option } : option));
+}
+
+/**
+ * Single-select form primitive: round ring with a filled center dot. Roving-focus keyboard
+ * nav per the Concrete keyboard matrix (Arrow keys move within the group, Space selects).
+ */
+export function RadioGroup({
+  options,
+  value,
+  onChange,
+  name,
+  orientation = "vertical",
+  disabled = false,
+  className,
+  "aria-label": ariaLabel
+}: RadioGroupProps) {
+  const generatedName = useId();
+  const groupName = name ?? generatedName;
+  const items = normalize(options);
+  const enabled = items.filter((option) => !(disabled || option.disabled));
+
+  const move = (currentValue: string, delta: number) => {
+    if (enabled.length === 0) {
+      return;
+    }
+    const index = enabled.findIndex((option) => option.value === currentValue);
+    const nextIndex = index < 0 ? 0 : (index + delta + enabled.length) % enabled.length;
+    onChange?.(enabled[nextIndex]!.value);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLLabelElement>, optionValue: string) => {
+    switch (event.key) {
+      case "ArrowDown":
+      case "ArrowRight":
+        event.preventDefault();
+        move(optionValue, 1);
+        break;
+      case "ArrowUp":
+      case "ArrowLeft":
+        event.preventDefault();
+        move(optionValue, -1);
+        break;
+      case " ":
+      case "Enter":
+        event.preventDefault();
+        onChange?.(optionValue);
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className={cn("flex", orientation === "horizontal" ? "flex-row flex-wrap gap-4" : "flex-col gap-2.5", className)}
+    >
+      {items.map((option) => {
+        const checked = option.value === value;
+        const itemDisabled = disabled || option.disabled;
+        return (
+          <label
+            key={option.value}
+            className={cn(
+              "inline-flex items-start gap-2 text-sm",
+              itemDisabled ? "cursor-not-allowed opacity-55" : "cursor-pointer"
+            )}
+            onKeyDown={(event) => !itemDisabled && handleKeyDown(event, option.value)}
+          >
+            <span
+              aria-hidden="true"
+              className={cn(
+                "mt-px flex h-4 w-4 shrink-0 items-center justify-center rounded-full border bg-[#F3F6F9] transition-colors",
+                checked ? "border-primary" : "border-border"
+              )}
+            >
+              {checked ? <span className="h-2 w-2 rounded-full bg-primary" /> : null}
+            </span>
+            <input
+              type="radio"
+              name={groupName}
+              value={option.value}
+              checked={checked}
+              disabled={itemDisabled}
+              onChange={() => onChange?.(option.value)}
+              className="sr-only"
+              tabIndex={checked || (!value && option.value === enabled[0]?.value) ? 0 : -1}
+            />
+            <span className="grid gap-0.5">
+              <span className="leading-[18px] text-foreground">{option.label}</span>
+              {option.hint ? <span className="text-xs leading-5 text-muted-foreground">{option.hint}</span> : null}
+            </span>
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/risk-control-panel.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/risk-control-panel.tsx
@@ -47,7 +47,7 @@ export function RiskControlPanel() {
       <CardContent className="space-y-4">
         <span id="risk-control-status" className="sr-only" aria-live="polite">{vm.statusAnnouncement}</span>
         {vm.error ? (
-          <div role="alert" className="rounded-[var(--radius-button,0.375rem)] border border-danger/35 bg-danger/10 px-3 py-2.5 text-sm text-danger">
+          <div role="alert" className="rounded-[2px] border border-danger/35 bg-danger/10 px-3 py-2.5 text-sm text-danger">
             <p>{vm.error.summary}</p>
             {vm.error.details.length > 0 ? (
               <ul className="mt-2 list-disc space-y-1 pl-5 text-xs leading-5 text-danger/90">
@@ -62,7 +62,7 @@ export function RiskControlPanel() {
           <div
             role={vm.statusRole}
             className={cn(
-              "rounded-[var(--radius-button,0.375rem)] border px-3 py-2.5 text-sm",
+              "rounded-[2px] border px-3 py-2.5 text-sm",
               vm.statusTone === "success"
                 ? "border-success/35 bg-success/10 text-success"
                 : vm.statusTone === "danger"
@@ -76,7 +76,7 @@ export function RiskControlPanel() {
         <div className="space-y-2">
           <h4 className="text-xs font-semibold uppercase text-muted-foreground">{vm.rowsLabel}</h4>
           {vm.rows.map((row) => (
-            <article key={row.ruleName} className="rounded-[var(--radius-card,0.5rem)] border border-border/70 bg-background/35 p-3">
+            <article key={row.ruleName} className="rounded-[2px] border border-border/70 bg-background/35 p-3">
               <div className="flex items-center justify-between gap-3">
                 <h4 className="font-semibold">{row.ruleName}</h4>
                 <span className={cn("text-xs font-semibold uppercase tracking-wide", toneClass[row.tone])}>
@@ -90,13 +90,13 @@ export function RiskControlPanel() {
             </article>
           ))}
           {vm.rows.length === 0 && (
-            <p role={vm.loading ? "status" : undefined} className="rounded-[var(--radius-card,0.5rem)] border border-border/70 bg-secondary/25 px-3 py-3 text-sm text-muted-foreground">
+            <p role={vm.loading ? "status" : undefined} className="rounded-[2px] border border-border/70 bg-secondary/25 px-3 py-3 text-sm text-muted-foreground">
               {vm.emptyRowsText}
             </p>
           )}
         </div>
 
-        <div className="rounded-[var(--radius-card,0.5rem)] border border-border/70 bg-background/35 p-3">
+        <div className="rounded-[2px] border border-border/70 bg-background/35 p-3">
           <label htmlFor={vm.drawdownField.id} className="text-sm font-semibold">
             {vm.drawdownField.label}
           </label>
@@ -135,7 +135,7 @@ export function RiskControlPanel() {
           </div>
         </div>
 
-        <div className="rounded-[var(--radius-card,0.5rem)] border border-border/70 bg-background/35 p-3">
+        <div className="rounded-[2px] border border-border/70 bg-background/35 p-3">
           <h4 className="font-semibold">{vm.timelineLabel}</h4>
           <ul className="mt-2 space-y-1 text-sm text-muted-foreground">
             {vm.violationTimeline.slice(0, 10).map((item) => (

--- a/src/Meridian.Ui/dashboard/src/components/ui/segmented-control.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/segmented-control.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+
+describe("SegmentedControl", () => {
+  it("marks the active option and emits the raw value on change", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <SegmentedControl
+        aria-label="View"
+        value="table"
+        onChange={onChange}
+        options={[
+          { value: "table", label: "Table" },
+          { value: "chart", label: "Chart" }
+        ]}
+      />
+    );
+
+    expect(screen.getByRole("tab", { name: "Table" })).toHaveAttribute("aria-selected", "true");
+
+    await user.click(screen.getByRole("tab", { name: "Chart" }));
+    expect(onChange).toHaveBeenCalledWith("chart");
+  });
+
+  it("does not emit for disabled options and accepts string options", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <SegmentedControl
+        value="day"
+        onChange={onChange}
+        options={["day", { value: "week", label: "Week", disabled: true }]}
+      />
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Week" }));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("tab", { name: "day" })).toBeInTheDocument();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/segmented-control.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/segmented-control.tsx
@@ -1,0 +1,84 @@
+import { type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export interface SegmentedOption {
+  value: string;
+  label: ReactNode;
+  icon?: ReactNode;
+  count?: ReactNode;
+  disabled?: boolean;
+}
+
+export interface SegmentedControlProps {
+  options: Array<SegmentedOption | string>;
+  value?: string;
+  onChange?: (value: string) => void;
+  size?: "sm" | "md";
+  fullWidth?: boolean;
+  className?: string;
+  "aria-label"?: string;
+}
+
+function normalize(options: Array<SegmentedOption | string>): SegmentedOption[] {
+  return options.map((option) => (typeof option === "string" ? { value: option, label: option } : option));
+}
+
+/**
+ * Compact mutually-exclusive view switch (table/chart, day/week/month). Denser than
+ * `RadioGroup`; lives in toolbars. Concrete: inset track, flat active segment carried by a
+ * hairline inset border, 2px corners.
+ */
+export function SegmentedControl({
+  options,
+  value,
+  onChange,
+  size = "md",
+  fullWidth = false,
+  className,
+  "aria-label": ariaLabel
+}: SegmentedControlProps) {
+  const items = normalize(options);
+
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className={cn(
+        "inline-flex items-stretch gap-0.5 rounded-[2px] border border-border bg-[#F3F6F9] p-0.5",
+        fullWidth && "flex w-full",
+        className
+      )}
+    >
+      {items.map((option) => {
+        const active = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            disabled={option.disabled}
+            onClick={() => !option.disabled && onChange?.(option.value)}
+            className={cn(
+              "inline-flex flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-[2px] font-medium leading-none transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+              size === "sm" ? "px-2.5 py-1 text-[11px]" : "px-3 py-1.5 text-xs",
+              active
+                ? "bg-card font-semibold text-foreground shadow-[inset_0_0_0_1px_hsl(var(--border))]"
+                : "bg-transparent text-muted-foreground hover:bg-[#EAEEF3] hover:text-foreground",
+              option.disabled && "cursor-not-allowed opacity-45"
+            )}
+          >
+            {option.icon ? <span aria-hidden="true" className="inline-flex">{option.icon}</span> : null}
+            <span>{option.label}</span>
+            {option.count != null ? (
+              <span className={cn("font-mono text-[11px] font-semibold", active ? "text-primary" : "text-muted-foreground")}>
+                {option.count}
+              </span>
+            ) : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/select.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/select.tsx
@@ -30,14 +30,14 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
       <select
         ref={ref}
         className={cn(
-          "w-full appearance-none rounded-[var(--radius-button,0.375rem)] border bg-secondary/40 text-sm text-foreground shadow-[var(--shadow-panel)]",
+          "w-full appearance-none rounded-[2px] border bg-[#F3F6F9] text-sm text-foreground",
           "min-h-9 py-2 pl-3 pr-8",
           "transition-colors duration-150",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
           "disabled:cursor-not-allowed disabled:opacity-50",
           error
             ? "border-danger/60 focus-visible:ring-danger/40"
-            : "border-border/80 hover:border-border focus-visible:border-primary/60",
+            : "border-border hover:border-[#ADB8C4] focus-visible:border-primary",
           className
         )}
         aria-invalid={error || undefined}

--- a/src/Meridian.Ui/dashboard/src/components/ui/sheet.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/sheet.tsx
@@ -151,7 +151,7 @@ export function SheetContent({ className, side = "right", ...props }: SheetConte
       aria-modal="true"
       tabIndex={-1}
       className={cn(
-        "relative flex h-full w-full max-w-2xl flex-col overflow-y-auto border-border bg-card shadow-float focus:outline-none",
+        "relative flex h-full w-full max-w-2xl flex-col overflow-y-auto border-border bg-card shadow-[0_2px_6px_rgba(0,0,0,0.18)] focus:outline-none",
         side === "left" ? "border-r sheet-slide-left" : "border-l sheet-slide-right",
         className
       )}
@@ -199,7 +199,7 @@ export function SheetCloseButton({ label = "Close panel", className, onClick, ..
       aria-label={label}
       title={label}
       className={cn(
-        "absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-[var(--radius-button,0.375rem)] text-muted-foreground transition-colors hover:bg-secondary/50 hover:text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40",
+        "absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-[2px] text-muted-foreground transition-colors [outline-offset:-2px] hover:bg-[#EAEEF3] hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
         className
       )}
       onClick={onClick}

--- a/src/Meridian.Ui/dashboard/src/components/ui/spinner.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/spinner.tsx
@@ -1,0 +1,50 @@
+import { cn } from "@/lib/utils";
+
+export interface SpinnerProps {
+  size?: "sm" | "md" | "lg";
+  variant?: "accent" | "muted" | "onDark";
+  label?: string;
+  className?: string;
+}
+
+const sizeClasses: Record<NonNullable<SpinnerProps["size"]>, string> = {
+  sm: "h-3.5 w-3.5 border-2",
+  md: "h-5 w-5 border-2",
+  lg: "h-8 w-8 border-[3px]"
+};
+
+const variantClasses: Record<NonNullable<SpinnerProps["variant"]>, string> = {
+  accent: "border-border border-t-primary",
+  muted: "border-border border-t-muted-foreground",
+  onDark: "border-white/25 border-t-white"
+};
+
+/**
+ * Async loading indicator — a minimal ring with a semantic stroke. Motion is the whole
+ * function here, so it animates (respecting `prefers-reduced-motion` via `motion-reduce`).
+ */
+export function Spinner({ size = "md", variant = "accent", label, className }: SpinnerProps) {
+  const ring = (
+    <span
+      role="status"
+      aria-label={label ?? "Loading"}
+      className={cn(
+        "inline-block shrink-0 animate-spin rounded-full motion-reduce:[animation-duration:1.6s]",
+        sizeClasses[size],
+        variantClasses[variant],
+        className
+      )}
+    />
+  );
+
+  if (!label) {
+    return ring;
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+      {ring}
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/status-banner.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/status-banner.tsx
@@ -20,7 +20,7 @@ export function StatusBanner({ className, detail, title, tone = "info", ...props
   return (
     <div
       className={cn(
-        "rounded-[var(--radius-button,0.375rem)] border border-border border-l-4 px-3.5 py-3 text-sm shadow-[var(--shadow-panel)]",
+        "rounded-[2px] border border-border border-l-[3px] px-3.5 py-3 text-sm",
         toneClasses[tone],
         className
       )}

--- a/src/Meridian.Ui/dashboard/src/components/ui/stepper.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/stepper.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Stepper } from "@/components/ui/stepper";
+
+const steps = [{ label: "Ingest" }, { label: "Mapping" }, { label: "Review" }];
+
+describe("Stepper", () => {
+  it("marks the active step and reports jumps", async () => {
+    const user = userEvent.setup();
+    const onStepChange = vi.fn();
+
+    render(<Stepper steps={steps} activeStep={1} onStepChange={onStepChange} />);
+
+    expect(screen.getByRole("tab", { name: /Mapping/ })).toHaveAttribute("aria-selected", "true");
+
+    await user.click(screen.getByRole("tab", { name: /Review/ }));
+    expect(onStepChange).toHaveBeenCalledWith(2);
+  });
+
+  it("renders completed steps with a check mark", () => {
+    render(<Stepper steps={steps} activeStep={2} />);
+    // Ingest (index 0) and Mapping (index 1) are complete.
+    expect(screen.getAllByText("✓")).toHaveLength(2);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/stepper.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/stepper.tsx
@@ -1,0 +1,69 @@
+import { type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export interface Step {
+  label: ReactNode;
+  badge?: ReactNode;
+}
+
+export interface StepperProps {
+  steps: Step[];
+  activeStep?: number;
+  onStepChange?: (index: number) => void;
+  showStepNumber?: boolean;
+  className?: string;
+}
+
+/**
+ * Tab-like multi-step form navigation — jump to any step. Concrete: flat, hairline divider
+ * between steps, active step marked by a teal-blue bottom rule and an accent number chip;
+ * completed steps show a check.
+ */
+export function Stepper({ steps, activeStep = 0, onStepChange, showStepNumber = true, className }: StepperProps) {
+  return (
+    <div role="tablist" className={cn("flex gap-px border-b border-border bg-border", className)}>
+      {steps.map((step, index) => {
+        const active = index === activeStep;
+        const complete = index < activeStep;
+        return (
+          <button
+            key={index}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onStepChange?.(index)}
+            className={cn(
+              "flex flex-1 items-center gap-2 truncate px-4 py-2.5 text-left text-xs transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 [outline-offset:-2px]",
+              active
+                ? "border-b-2 border-primary bg-background pb-[9px] font-semibold text-foreground"
+                : "bg-card text-muted-foreground hover:bg-[#EAEEF3] hover:text-foreground"
+            )}
+          >
+            {showStepNumber ? (
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full font-mono text-[10px] font-semibold",
+                  active
+                    ? "bg-primary text-primary-foreground"
+                    : complete
+                      ? "bg-success text-primary-foreground"
+                      : "bg-[#F3F6F9] text-muted-foreground"
+                )}
+              >
+                {complete ? "✓" : index + 1}
+              </span>
+            ) : null}
+            <span className="truncate">{step.label}</span>
+            {step.badge != null ? (
+              <span className="ml-auto shrink-0 rounded-[2px] bg-[#F3F6F9] px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                {step.badge}
+              </span>
+            ) : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/tabs.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/tabs.tsx
@@ -77,7 +77,7 @@ export function Tabs({ children, className, defaultValue, onValueChange, tabs, v
               data-tab-id={tab.id}
             >
               <span>{tab.label}</span>
-              {tab.count ? <span className="rounded-[var(--radius-chip,0.25rem)] border border-border px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">{tab.count}</span> : null}
+              {tab.count ? <span className="rounded-[2px] border border-border px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">{tab.count}</span> : null}
             </button>
           );
         })}

--- a/src/Meridian.Ui/dashboard/src/components/ui/text-area.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/text-area.tsx
@@ -1,0 +1,51 @@
+import { forwardRef, type ReactNode, type TextareaHTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+export interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  label?: ReactNode;
+  error?: ReactNode;
+}
+
+/**
+ * Multi-line text input. Concrete: flat field, hairline border with a hover-darkened rule and
+ * teal focus ring, 2px corners; small-caps label and dim-red error line.
+ */
+export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  ({ label, error, rows = 4, className, id, ...props }, ref) => {
+    const control = (
+      <textarea
+        ref={ref}
+        id={id}
+        rows={rows}
+        aria-invalid={error ? true : undefined}
+        className={cn(
+          "w-full rounded-[2px] border bg-[#F3F6F9] px-2.5 py-2 text-sm leading-relaxed text-foreground placeholder:text-muted-foreground/70",
+          "transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+          "disabled:cursor-not-allowed disabled:opacity-55",
+          "resize-y",
+          error ? "border-danger/60 focus-visible:ring-danger/40" : "border-border hover:border-[#ADB8C4] focus-visible:border-primary",
+          className
+        )}
+        {...props}
+      />
+    );
+
+    if (!label && !error) {
+      return control;
+    }
+
+    return (
+      <label className="block">
+        {label ? (
+          <span className="mb-1.5 block font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+            {label}
+          </span>
+        ) : null}
+        {control}
+        {error ? <span className="mt-1.5 block text-xs leading-5 text-danger">{error}</span> : null}
+      </label>
+    );
+  }
+);
+
+TextArea.displayName = "TextArea";

--- a/src/Meridian.Ui/dashboard/src/components/ui/toast.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/toast.tsx
@@ -85,7 +85,7 @@ export function Toast({ className, onDismiss, toast }: { className?: string; onD
   return (
     <div
       className={cn(
-        "flex min-w-72 max-w-md items-start gap-3 rounded-[var(--radius-card,0.5rem)] border border-l-4 border-border bg-popover px-3.5 py-3 text-popover-foreground shadow-[var(--shadow-float)]",
+        "flex min-w-72 max-w-md items-start gap-3 rounded-[2px] border border-l-[3px] border-border bg-popover px-3.5 py-3 text-popover-foreground shadow-[0_2px_6px_rgba(0,0,0,0.18)]",
         toneClasses[toast.tone],
         className
       )}

--- a/src/Meridian.Ui/dashboard/src/components/ui/tooltip.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/tooltip.tsx
@@ -54,8 +54,8 @@ export function Tooltip({ children, className, content, side = "top" }: TooltipP
         role="tooltip"
         className={cn(
           "pointer-events-none absolute z-50 whitespace-nowrap",
-          "rounded-[var(--radius-button,0.375rem)] border border-border bg-popover px-2.5 py-1.5",
-          "font-mono text-[11px] text-popover-foreground shadow-float",
+          "rounded-[2px] border border-border bg-popover px-2.5 py-1.5",
+          "font-mono text-[11px] text-popover-foreground shadow-[0_2px_6px_rgba(0,0,0,0.18)]",
           "opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100",
           sideClasses[side],
           className

--- a/src/Meridian.Ui/dashboard/src/styles/ui-kit-primitives.css
+++ b/src/Meridian.Ui/dashboard/src/styles/ui-kit-primitives.css
@@ -307,7 +307,7 @@
 
 .dense-data-table-wrap {
   border-color: var(--ws-border);
-  border-radius: 6px;
+  border-radius: 2px;
   background: var(--ws-surface);
   box-shadow: none;
 }
@@ -354,4 +354,20 @@
 .dense-data-table-empty {
   color: var(--ws-text-muted);
   padding: 2rem 0.75rem;
+}
+
+/* ── Concrete radius normalization ──────────────────────────────────────────
+   Concrete unifies control/card/panel corners to a single tight 2px radius;
+   structure is carried by hairline borders, not rounding. Override the legacy
+   scalable-radius values so these hand-authored primitives read as Concrete
+   regardless of the base --radius-* token resolution.
+──────────────────────────────────────────────────────────────────────────*/
+.meridian-toolbar-strip,
+.entity-summary,
+.entity-summary-field {
+  border-radius: 2px;
+}
+
+.meridian-toolbar-chip {
+  border-radius: 2px;
 }


### PR DESCRIPTION
Foundation wave (U2 of 5) of the Meridian web UI "Concrete" design-system rework.

Aligns the shared UI primitive layer (`src/components/ui/*`, `styles/ui-kit-primitives.css`) to Concrete — 2px radii, flat/no-shadow surfaces, hairline load-bearing borders, one steel-blue accent, small-caps labels, mono tabular data — and adds the missing primitives from the design system (SegmentedControl, Combobox, RadioGroup, Toggle, Drawer, Popover, Stepper, Accordion, DensityToggle, Gauge/LinearGauge, Callout, Kbd, Spinner, NumberInput, TextArea, DatePicker/DateRangePicker, FileUpload, Stack/Grid/Flex). Existing component APIs preserved; tokens referenced with hex fallbacks so it compiles ahead of the token PR (U1).

Part of a two-wave batch: foundation (U1–U5) → screens (W1–W8). Merge order within the wave is independent.

**Validation:** finalized by the coordinator after the worker stopped early; local build was blocked by machine contention from sibling agents, so **GitHub `quality-gate` CI is the authoritative validator here** — please confirm CI green before merge.