### PR TITLE
Web UI Concrete — U4: operations + data-furniture components

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/data/column-chooser.concrete.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/column-chooser.concrete.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ColumnChooser } from "./column-chooser";
+
+const columns = [
+  { key: "symbol", label: "Symbol" },
+  { key: "qty", label: "Qty" },
+  { key: "pnl", label: "P&L" },
+];
+
+// The checked "✓" glyph lives inside each menu item and contributes to its accessible
+// name, so column items are matched by substring rather than an exact name.
+
+describe("ColumnChooser (Concrete)", () => {
+  it("opens the menu and lists all columns", async () => {
+    render(<ColumnChooser columns={columns} onChange={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /columns/i }));
+    expect(screen.getByText("Show / hide columns")).toBeInTheDocument();
+    expect(screen.getByRole("menuitemcheckbox", { name: /Symbol/ })).toBeInTheDocument();
+  });
+
+  it("emits the remaining visible keys when a column is hidden", async () => {
+    const onChange = vi.fn();
+    render(<ColumnChooser columns={columns} onChange={onChange} />);
+    await userEvent.click(screen.getByRole("button", { name: /columns/i }));
+    await userEvent.click(screen.getByRole("menuitemcheckbox", { name: /Qty/ }));
+    expect(onChange).toHaveBeenCalledWith(["symbol", "pnl"]);
+  });
+
+  it("never hides the last remaining column", async () => {
+    const onChange = vi.fn();
+    render(<ColumnChooser columns={columns} visible={["symbol"]} onChange={onChange} />);
+    await userEvent.click(screen.getByRole("button", { name: /columns/i }));
+    await userEvent.click(screen.getByRole("menuitemcheckbox", { name: /Symbol/ }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/data/column-chooser.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/column-chooser.tsx
@@ -1,0 +1,128 @@
+// Meridian ColumnChooser (Concrete) — a dropdown to toggle column visibility in a
+// DenseDataTable / FilteredDataTable. Flat hairline-bordered trigger and menu; the menu
+// carries the one tight hard-edged popover shadow. At least one column always stays
+// visible.
+import { useEffect, useMemo, useRef, useState } from "react";
+import { injectStyle } from "../operations/inject-style";
+
+const CSS = `
+.mds-colchz{position:relative;display:inline-block;}
+.mds-colchz__btn{display:inline-flex;align-items:center;gap:6px;padding:6px 11px;
+  border:1px solid var(--border,#CBD3DC);border-radius:var(--radius-button,2px);
+  background:var(--bg-panel,var(--bg-light,#fff));color:var(--text-secondary,#4D5967);
+  font-family:var(--font-body);font-size:12px;cursor:pointer;
+  transition:background .1s ease,border-color .1s ease;}
+.mds-colchz__btn:hover{background:var(--bg-active,#E6EEF5);border-color:var(--accent,#2F6F8F);}
+.mds-colchz__btn:focus-visible{outline:var(--focus-ring,2px solid #2F6F8F);outline-offset:2px;}
+.mds-colchz__btn--active{border-color:var(--accent,#2F6F8F);color:var(--accent,#2F6F8F);}
+.mds-colchz__menu{position:absolute;top:calc(100% + 4px);right:0;z-index:200;min-width:180px;
+  background:var(--bg-panel,var(--bg-light,#fff));border:1px solid var(--border,#CBD3DC);
+  border-radius:var(--radius-button,2px);
+  box-shadow:var(--shadow-menu,0 2px 6px rgba(0,0,0,.18));overflow:hidden;}
+.mds-colchz__head{padding:8px 12px 6px;font-family:var(--font-body);font-size:10px;font-weight:600;
+  font-variant:all-small-caps;letter-spacing:.04em;color:var(--text-muted,#59636F);
+  border-bottom:1px solid var(--border,#CBD3DC);}
+.mds-colchz__item{display:flex;align-items:center;gap:9px;padding:8px 12px;cursor:pointer;width:100%;
+  font-family:var(--font-body);font-size:12px;color:var(--text-primary,#22272E);text-align:left;
+  background:transparent;border:none;transition:background .08s ease;}
+.mds-colchz__item:hover{background:var(--bg-active,#E6EEF5);}
+.mds-colchz__ck{width:14px;height:14px;border:1.5px solid var(--border,#CBD3DC);border-radius:2px;
+  flex-shrink:0;display:flex;align-items:center;justify-content:center;font-size:9px;}
+.mds-colchz__ck--on{background:var(--accent,#2F6F8F);border-color:var(--accent,#2F6F8F);color:white;}
+.mds-colchz__foot{padding:8px 12px;border-top:1px solid var(--border,#CBD3DC);}
+.mds-colchz__reset{appearance:none;border:none;background:transparent;
+  font-family:var(--font-body);font-size:11px;color:var(--accent,#2F6F8F);cursor:pointer;padding:0;}
+.mds-colchz__reset:hover{opacity:.75;}
+`;
+
+export interface ColumnChooserColumn {
+  key: string;
+  label: string;
+}
+
+export interface ColumnChooserProps {
+  columns?: ColumnChooserColumn[];
+  /** Visible column keys. Defaults to all columns visible. */
+  visible?: string[];
+  onChange?: (visibleKeys: string[]) => void;
+}
+
+/**
+ * ColumnChooser — toggle which table columns are visible. The last visible column can't
+ * be hidden, so a table is never left with zero columns.
+ *
+ * @example
+ * <ColumnChooser columns={cols} visible={visible} onChange={setVisible} />
+ */
+export function ColumnChooser({ columns = [], visible, onChange }: ColumnChooserProps) {
+  injectStyle("colchooser", CSS);
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const visSet = useMemo(
+    () => new Set(visible ?? columns.map((c) => c.key)),
+    [visible, columns],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const toggle = (key: string) => {
+    const next = new Set(visSet);
+    if (next.has(key)) {
+      if (next.size > 1) next.delete(key);
+    } else {
+      next.add(key);
+    }
+    onChange?.([...next]);
+  };
+
+  const reset = () => onChange?.(columns.map((c) => c.key));
+  const hiddenCount = columns.length - visSet.size;
+
+  return (
+    <div ref={ref} className="mds-colchz">
+      <button
+        type="button"
+        className={`mds-colchz__btn${hiddenCount > 0 ? " mds-colchz__btn--active" : ""}`}
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="true"
+        aria-expanded={open}
+      >
+        Columns {hiddenCount > 0 && `· ${hiddenCount} hidden`}
+      </button>
+      {open && (
+        <div className="mds-colchz__menu" role="menu">
+          <div className="mds-colchz__head">Show / hide columns</div>
+          {columns.map((col) => (
+            <button
+              type="button"
+              key={col.key}
+              className="mds-colchz__item"
+              onClick={() => toggle(col.key)}
+              role="menuitemcheckbox"
+              aria-checked={visSet.has(col.key)}
+            >
+              <span className={`mds-colchz__ck${visSet.has(col.key) ? " mds-colchz__ck--on" : ""}`}>
+                {visSet.has(col.key) && "✓"}
+              </span>
+              {col.label}
+            </button>
+          ))}
+          {hiddenCount > 0 && (
+            <div className="mds-colchz__foot">
+              <button type="button" className="mds-colchz__reset" onClick={reset}>
+                Reset to default
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/data/concrete.ts
+++ b/src/Meridian.Ui/dashboard/src/components/data/concrete.ts
@@ -1,0 +1,53 @@
+// Meridian "Concrete" data-furniture library — NEW shared table + surface components.
+//
+// Natively re-implemented from the Meridian Design System handoff (React 18 + TypeScript
+// + Tailwind 3) for the browser workstation. These live alongside the pre-existing
+// domain-specific `data/*` files but form an independent design-system surface that
+// Wave 2 screens adopt. Design tokens are owned by sibling U1; every consumer reads them
+// with a hex fallback so this library is independently mergeable.
+//
+// This barrel intentionally does NOT re-export the older domain components in this
+// directory (provider drawers, symbol-universe manager, …) — those are separate surfaces.
+
+export {
+  DenseDataTable,
+  type DenseDataTableProps,
+  type DataTableColumn,
+} from "./dense-data-table";
+export {
+  ExpandableDataTable,
+  type ExpandableDataTableProps,
+  type ExpandableDataTableColumn,
+} from "./expandable-data-table";
+export {
+  FilteredDataTable,
+  type FilteredDataTableProps,
+  type FilteredDataTableColumn,
+} from "./filtered-data-table";
+export {
+  ColumnChooser,
+  type ColumnChooserProps,
+  type ColumnChooserColumn,
+} from "./column-chooser";
+export { Pagination, type PaginationProps } from "./pagination";
+export { EmptyState, type EmptyStateProps, type EmptyStateIcon } from "./empty-state";
+export {
+  Skeleton,
+  SkeletonTable,
+  type SkeletonProps,
+  type SkeletonTableProps,
+} from "./skeleton";
+export { KeyValueGrid, type KeyValueGridProps, type KeyValueGridItem } from "./key-value-grid";
+export {
+  EntitySummary,
+  type EntitySummaryProps,
+  type EntitySummaryItem,
+} from "./entity-summary";
+export { MetricCard, type MetricCardProps, type MetricCardTone } from "./metric-card";
+export {
+  useTableState,
+  type TableState,
+  type TableSort,
+  type TableFilters,
+  type SortDirection,
+} from "./use-table-state";

--- a/src/Meridian.Ui/dashboard/src/components/data/dense-data-table.concrete.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/dense-data-table.concrete.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { DenseDataTable, type DataTableColumn } from "./dense-data-table";
+
+interface Position extends Record<string, unknown> {
+  symbol: string;
+  qty: number;
+  pnl: string;
+}
+
+const columns: DataTableColumn<Position>[] = [
+  { key: "symbol", label: "Symbol" },
+  { key: "qty", label: "Qty", align: "right" },
+  { key: "pnl", label: "P&L", align: "right", render: (r) => <span data-testid="pnl">{r.pnl}</span> },
+];
+
+const rows: Position[] = [
+  { symbol: "AAPL", qty: 100, pnl: "+1,204.00" },
+  { symbol: "MSFT", qty: 50, pnl: "-318.22" },
+];
+
+describe("DenseDataTable (Concrete)", () => {
+  it("renders headers, rows, and custom cell renderers", () => {
+    render(<DenseDataTable columns={columns} rows={rows} />);
+    expect(screen.getByText("Symbol")).toBeInTheDocument();
+    expect(screen.getByText("AAPL")).toBeInTheDocument();
+    expect(screen.getAllByTestId("pnl")).toHaveLength(2);
+  });
+
+  it("fires onRowClick with the row and index", async () => {
+    const onRowClick = vi.fn();
+    render(<DenseDataTable columns={columns} rows={rows} onRowClick={onRowClick} />);
+    await userEvent.click(screen.getByText("MSFT"));
+    expect(onRowClick).toHaveBeenCalledWith(rows[1], 1);
+  });
+
+  it("fires onSort when a sortable header is clicked", async () => {
+    const onSort = vi.fn();
+    render(<DenseDataTable columns={columns} rows={rows} onSort={onSort} sortKey="qty" sortDir="desc" />);
+    await userEvent.click(screen.getByText("Qty"));
+    expect(onSort).toHaveBeenCalledWith("qty");
+  });
+
+  it("renders a checkbox column and drives selection when selectable", async () => {
+    const onSelectRow = vi.fn();
+    render(
+      <DenseDataTable
+        columns={columns}
+        rows={rows}
+        selectable
+        selectedRows={[0]}
+        onSelectRow={onSelectRow}
+      />,
+    );
+    const checkboxes = screen.getAllByRole("checkbox");
+    // 1 select-all + 2 rows.
+    expect(checkboxes).toHaveLength(3);
+    await userEvent.click(screen.getByLabelText("Select row 2"));
+    expect(onSelectRow).toHaveBeenCalledWith(rows[1], 1, true);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/data/dense-data-table.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/dense-data-table.tsx
@@ -1,0 +1,180 @@
+// Meridian dense data grid (Concrete) — the flat institutional table. White paper panel,
+// small-caps muted headers, hairline row borders, off-white raised zebra rows, and a
+// steel-blue left rail + wash on the hovered/selected row. ~34px rows, mono tabular
+// numerics. Optional checkbox column for multi-select workflows and header sort arrows.
+import type { ReactNode } from "react";
+import { injectStyle } from "../operations/inject-style";
+
+const CSS = `
+.dds-wrap{overflow-x:auto;border:1px solid var(--border,#CBD3DC);background:var(--bg-panel,var(--bg-light,#fff));}
+.dds{width:100%;min-width:100%;border-collapse:separate;border-spacing:0;
+  font-family:var(--font-data,monospace);font-size:12px;}
+.dds thead{position:sticky;top:0;z-index:1;background:var(--bg-medium,#F3F6F9);}
+.dds th{padding:9px 12px;text-align:left;white-space:nowrap;
+  font-family:var(--font-body);font-size:10px;font-weight:600;font-variant:all-small-caps;
+  letter-spacing:.03em;color:var(--text-muted,#59636F);
+  border-bottom:1px solid var(--border-strong,#99A5B2);border-right:1px solid var(--border-divider,#DDE3EA);}
+.dds th:last-child{border-right:none;}
+.dds th.dds--r{text-align:right;}
+.dds th.dds--checkbox{padding:9px 10px;width:34px;text-align:center;}
+.dds td{padding:8px 12px;white-space:nowrap;color:var(--text-primary,#22272E);
+  border-top:1px solid var(--border,#CBD3DC);border-right:1px solid var(--border-divider,#DDE3EA);
+  font-variant-numeric:tabular-nums;height:34px;}
+.dds td:last-child{border-right:none;}
+.dds td.dds--checkbox{padding:6px 10px;text-align:center;}
+.dds tbody tr:first-child td{border-top:none;}
+.dds td.dds--r{text-align:right;}
+.dds tbody tr{background:var(--bg-panel,var(--bg-light,#fff));}
+.dds tbody tr:nth-child(even){background:var(--card-surface-raised,#F3F6F9);}
+.dds tbody tr.dds--sel{cursor:pointer;}
+.dds tbody tr:hover,.dds tbody tr.dds--on{background:var(--bg-active,#E6EEF5);box-shadow:inset 3px 0 0 var(--accent,#2F6F8F);}
+.dds tbody tr.dds--sel:focus-visible{outline:var(--focus-ring,2px solid #2F6F8F);outline-offset:-2px;}
+.dds__ckbox{width:16px;height:16px;cursor:pointer;border:1px solid var(--border,#CBD3DC);
+  border-radius:var(--radius-chip,2px);appearance:none;background:var(--bg-panel,var(--bg-light,#fff));}
+.dds__ckbox:hover{border-color:var(--accent,#2F6F8F);}
+.dds__ckbox:checked{background:var(--accent,#2F6F8F);border-color:var(--accent,#2F6F8F);
+  background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M13.3 4.3L6 11.6 2.7 8.3" stroke="white" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+  background-size:12px;background-position:center;background-repeat:no-repeat;}
+.dds__sort{margin-left:6px;font-size:9px;opacity:.4;}
+.dds th.dds--sorted{color:var(--text-secondary,#4D5967);}
+.dds th.dds--sorted .dds__sort{opacity:1;color:var(--accent,#2F6F8F);}
+`;
+
+export interface DataTableColumn<Row = Record<string, unknown>> {
+  key: string;
+  label: ReactNode;
+  align?: "left" | "right";
+  /** Show a sort affordance for this column. @default true when onSort is set */
+  sortable?: boolean;
+  /** Custom cell renderer; receives the row object. */
+  render?: (row: Row) => ReactNode;
+}
+
+export interface DenseDataTableProps<Row = Record<string, unknown>> {
+  columns: DataTableColumn<Row>[];
+  rows: Row[];
+  /** Row index highlighted with the steel-blue rail. @default -1 */
+  selectedIndex?: number;
+  /** Active sort column key. */
+  sortKey?: string;
+  /** @default "asc" */
+  sortDir?: "asc" | "desc";
+  onRowClick?: (row: Row, index: number) => void;
+  onSort?: (key: string) => void;
+  /** Enable the checkbox column for multi-select. @default false */
+  selectable?: boolean;
+  /** Row indices currently selected. */
+  selectedRows?: number[];
+  /** Fired when a row checkbox is toggled. Receives (row, index, isSelected). */
+  onSelectRow?: (row: Row, index: number, isSelected: boolean) => void;
+  /** Fired when the "select all" checkbox is toggled. Receives isSelected. */
+  onSelectAll?: (isSelected: boolean) => void;
+}
+
+/**
+ * Dense mono data grid — the workhorse of every Meridian screen.
+ *
+ * @example
+ * <DenseDataTable
+ *   selectedIndex={2}
+ *   sortKey="pnl" sortDir="desc" onSort={setSort}
+ *   onRowClick={(row, i) => select(i)}
+ *   columns={[
+ *     { key: "symbol", label: "Symbol" },
+ *     { key: "qty", label: "Qty", align: "right" },
+ *   ]}
+ *   rows={positions}
+ * />
+ */
+export function DenseDataTable<Row extends Record<string, unknown> = Record<string, unknown>>({
+  columns,
+  rows,
+  selectedIndex = -1,
+  sortKey,
+  sortDir = "asc",
+  onRowClick,
+  onSort,
+  selectable = false,
+  selectedRows = [],
+  onSelectRow,
+  onSelectAll,
+}: DenseDataTableProps<Row>) {
+  injectStyle("dds", CSS);
+  const allSelected = selectable && selectedRows.length === rows.length && rows.length > 0;
+  const someSelected = selectable && selectedRows.length > 0 && selectedRows.length < rows.length;
+
+  return (
+    <div className="dds-wrap">
+      <table className="dds">
+        <thead>
+          <tr>
+            {selectable && (
+              <th className="dds--checkbox">
+                <input
+                  type="checkbox"
+                  className="dds__ckbox"
+                  checked={allSelected}
+                  ref={(el) => {
+                    if (el) el.indeterminate = someSelected;
+                  }}
+                  onChange={() => onSelectAll?.(!allSelected)}
+                  aria-label="Select all rows"
+                />
+              </th>
+            )}
+            {columns.map((c) => {
+              const sorted = sortKey === c.key;
+              const sortable = Boolean(onSort) && c.sortable !== false;
+              const cls = `${c.align === "right" ? "dds--r " : ""}${sorted ? "dds--sorted" : ""}`.trim();
+              return (
+                <th
+                  key={c.key}
+                  className={cls}
+                  onClick={sortable ? () => onSort?.(c.key) : undefined}
+                  style={{ cursor: sortable ? "pointer" : "default" }}
+                >
+                  {c.label}
+                  {sortable && (
+                    <span className="dds__sort">{sorted ? (sortDir === "asc" ? "▲" : "▼") : "↕"}</span>
+                  )}
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => {
+            const isSelected = selectedRows.includes(i);
+            const on = i === selectedIndex || isSelected;
+            return (
+              <tr
+                key={i}
+                className={`${onRowClick ? "dds--sel " : ""}${on ? "dds--on" : ""}`.trim()}
+                tabIndex={onRowClick ? 0 : undefined}
+                onClick={onRowClick ? () => onRowClick(row, i) : undefined}
+              >
+                {selectable && (
+                  <td className="dds--checkbox">
+                    <input
+                      type="checkbox"
+                      className="dds__ckbox"
+                      checked={isSelected}
+                      onChange={() => onSelectRow?.(row, i, !isSelected)}
+                      onClick={(e) => e.stopPropagation()}
+                      aria-label={`Select row ${i + 1}`}
+                    />
+                  </td>
+                )}
+                {columns.map((c) => (
+                  <td key={c.key} className={c.align === "right" ? "dds--r" : ""}>
+                    {c.render ? c.render(row) : (row[c.key] as ReactNode)}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/data/empty-state.concrete.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/empty-state.concrete.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { EmptyState } from "./empty-state";
+
+describe("EmptyState (Concrete)", () => {
+  it("renders the title and detail", () => {
+    render(<EmptyState title="No matching rows" detail="Adjust the filters and try again." />);
+    expect(screen.getByText("No matching rows")).toBeInTheDocument();
+    expect(screen.getByText("Adjust the filters and try again.")).toBeInTheDocument();
+  });
+
+  it("renders an action button only when both action and onAction are set", async () => {
+    const onAction = vi.fn();
+    const { rerender } = render(<EmptyState title="Empty" action="Add row" />);
+    expect(screen.queryByRole("button")).toBeNull();
+
+    rerender(<EmptyState title="Empty" action="Add row" onAction={onAction} />);
+    await userEvent.click(screen.getByRole("button", { name: "Add row" }));
+    expect(onAction).toHaveBeenCalledOnce();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/data/empty-state.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/empty-state.tsx
@@ -1,0 +1,106 @@
+// Meridian EmptyState (Concrete) — a consistent zero-data placeholder for tables and
+// panels. A muted line-icon, a title, an optional detail line, and an optional primary
+// action (steel accent). Flat, no decoration.
+import { injectStyle } from "../operations/inject-style";
+
+const CSS = `
+.mds-empty{display:flex;flex-direction:column;align-items:center;justify-content:center;
+  text-align:center;font-family:var(--font-body);padding:48px 24px;gap:12px;}
+.mds-empty--compact{padding:24px 16px;gap:8px;}
+.mds-empty__icon{color:var(--text-disabled,#889099);display:inline-flex;}
+.mds-empty__title{font-size:14px;font-weight:600;color:var(--text-secondary,#4D5967);}
+.mds-empty--compact .mds-empty__title{font-size:13px;}
+.mds-empty__detail{font-size:12px;color:var(--text-muted,#59636F);max-width:280px;line-height:1.5;}
+.mds-empty__action{margin-top:4px;padding:7px 16px;border:1px solid var(--accent,#2F6F8F);
+  background:var(--accent,#2F6F8F);color:#fff;border-radius:var(--radius-button,2px);
+  font-family:var(--font-body);font-size:12px;font-weight:600;cursor:pointer;transition:background .12s ease;}
+.mds-empty__action:hover{background:var(--accent-pressed,#255B75);border-color:var(--accent-pressed,#255B75);}
+.mds-empty__action:focus-visible{outline:var(--focus-ring,2px solid #2F6F8F);outline-offset:2px;}
+`;
+
+export type EmptyStateIcon = "table" | "search" | "chart" | "docs" | "inbox";
+
+const ICONS: Record<EmptyStateIcon, JSX.Element> = {
+  table: (
+    <>
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <line x1="3" y1="9" x2="21" y2="9" />
+      <line x1="3" y1="15" x2="21" y2="15" />
+      <line x1="9" y1="9" x2="9" y2="21" />
+    </>
+  ),
+  search: (
+    <>
+      <circle cx="11" cy="11" r="7" />
+      <line x1="16.5" y1="16.5" x2="21" y2="21" />
+    </>
+  ),
+  chart: <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />,
+  docs: (
+    <>
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <polyline points="14 2 14 8 20 8" />
+    </>
+  ),
+  inbox: (
+    <>
+      <polyline points="22 13 16 13 14 16 10 16 8 13 2 13" />
+      <path d="M5.45 5.11L2 13v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-7.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" />
+    </>
+  ),
+};
+
+export interface EmptyStateProps {
+  /** @default "table" */
+  icon?: EmptyStateIcon;
+  /** @default "No data" */
+  title?: string;
+  detail?: string;
+  /** Action label. Renders a button only when both `action` and `onAction` are set. */
+  action?: string;
+  onAction?: () => void;
+  /** Tighter padding for inline use. @default false */
+  compact?: boolean;
+}
+
+/**
+ * EmptyState — a zero-data placeholder for tables and panels.
+ *
+ * @example
+ * <EmptyState icon="search" title="No matching rows" detail="Adjust the filters and try again." />
+ */
+export function EmptyState({
+  icon = "table",
+  title = "No data",
+  detail,
+  action,
+  onAction,
+  compact = false,
+}: EmptyStateProps) {
+  injectStyle("empty-state", CSS);
+  return (
+    <div className={`mds-empty${compact ? " mds-empty--compact" : ""}`}>
+      <span className="mds-empty__icon" aria-hidden="true">
+        <svg
+          width={32}
+          height={32}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          {ICONS[icon] ?? ICONS.table}
+        </svg>
+      </span>
+      <div className="mds-empty__title">{title}</div>
+      {detail && <div className="mds-empty__detail">{detail}</div>}
+      {action && onAction && (
+        <button type="button" className="mds-empty__action" onClick={onAction}>
+          {action}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/data/entity-summary.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/entity-summary.tsx
@@ -1,0 +1,70 @@
+// Meridian entity summary (Concrete) — an identity fact band: a small-caps muted label
+// over a value, with per-item mono/color control (e.g. tint a value green for healthy).
+// Values ellipsis-truncate; laid out in N responsive columns.
+import type { CSSProperties, ReactNode } from "react";
+
+export interface EntitySummaryItem {
+  label: ReactNode;
+  value: ReactNode;
+  /** Set false for prose values (names, descriptions). @default true */
+  mono?: boolean;
+  /** Override value color, e.g. "var(--severity-ready-fg)" for healthy. */
+  color?: string;
+}
+
+export interface EntitySummaryProps {
+  items: EntitySummaryItem[];
+  /** @default 3 */
+  columns?: number;
+}
+
+const labelStyle: CSSProperties = {
+  fontFamily: "var(--font-body)",
+  fontSize: 10,
+  fontWeight: 600,
+  fontVariant: "all-small-caps",
+  letterSpacing: "0.03em",
+  color: "var(--text-muted, #59636F)",
+  marginBottom: 3,
+};
+
+/**
+ * EntitySummary — an identity fact band with per-item mono/color control.
+ *
+ * @example
+ * <EntitySummary items={[
+ *   { label: "Symbol", value: "AAPL" },
+ *   { label: "Name", value: "Apple Inc.", mono: false },
+ *   { label: "Status", value: "Active", color: "var(--severity-ready-fg)" },
+ * ]} />
+ */
+export function EntitySummary({ items, columns = 3 }: EntitySummaryProps) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+        gap: "14px 20px",
+      }}
+    >
+      {items.map((it, i) => (
+        <div key={i} style={{ minWidth: 0 }}>
+          <div style={labelStyle}>{it.label}</div>
+          <div
+            style={{
+              fontSize: 13,
+              fontFamily: it.mono === false ? "var(--font-body)" : "var(--font-data, monospace)",
+              fontVariantNumeric: "tabular-nums",
+              color: it.color || "var(--text-primary, #22272E)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {it.value}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/data/expandable-data-table.concrete.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/expandable-data-table.concrete.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { ExpandableDataTable } from "./expandable-data-table";
+
+interface Txn extends Record<string, unknown> {
+  date: string;
+  amount: string;
+  account: string;
+}
+
+const columns = [
+  { key: "date", label: "Date" },
+  { key: "amount", label: "Amount", align: "right" as const },
+];
+
+const rows: Txn[] = [
+  { date: "2026-06-01", amount: "1,000.00", account: "4000" },
+  { date: "2026-06-02", amount: "250.00", account: "5100" },
+];
+
+describe("ExpandableDataTable (Concrete)", () => {
+  it("renders rows without an expand column when expandable is omitted", () => {
+    const { container } = render(<ExpandableDataTable columns={columns} rows={rows} />);
+    expect(container.querySelector(".edt--expand")).toBeNull();
+    expect(screen.getByText("2026-06-01")).toBeInTheDocument();
+  });
+
+  it("toggles a detail panel via the expand chevron", async () => {
+    render(
+      <ExpandableDataTable
+        columns={columns}
+        rows={rows}
+        expandable={(row) => <div data-testid="detail">Account {row.account}</div>}
+      />,
+    );
+    expect(screen.queryByTestId("detail")).toBeNull();
+
+    // First cell in the first row is the expand chevron.
+    const chevrons = document.querySelectorAll(".edt--expand");
+    await userEvent.click(chevrons[1] as Element); // [0] is the header cell
+    expect(screen.getByTestId("detail")).toHaveTextContent("Account 4000");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/data/expandable-data-table.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/expandable-data-table.tsx
@@ -1,0 +1,210 @@
+// Meridian expandable data table (Concrete) — a DenseDataTable with collapsible detail
+// rows. Each row can expand to a full-width detail panel (audit trail, allocations,
+// related records, …) rendered via the `expandable` slot. Flat institutional styling,
+// steel-blue hover rail, and a light slide on expand/collapse.
+import { Fragment, useState, type ReactNode } from "react";
+import { injectStyle } from "../operations/inject-style";
+import type { DataTableColumn } from "./dense-data-table";
+
+const CSS = `
+.edt-wrap{overflow-x:auto;border:1px solid var(--border,#CBD3DC);
+  border-radius:var(--radius-card,2px);background:var(--bg-panel,var(--bg-light,#fff));}
+.edt{width:100%;border-collapse:separate;border-spacing:0;
+  font-family:var(--font-data,monospace);font-size:12px;}
+.edt thead{position:sticky;top:0;z-index:1;background:var(--bg-medium,#F3F6F9);}
+.edt th{padding:9px 12px;text-align:left;white-space:nowrap;
+  font-family:var(--font-body);font-size:10px;font-weight:600;font-variant:all-small-caps;
+  letter-spacing:.03em;color:var(--text-muted,#59636F);
+  border-bottom:1px solid var(--border-strong,#99A5B2);}
+.edt th.edt--r{text-align:right;}
+.edt th.edt--expand{width:34px;padding:9px 10px;text-align:center;}
+.edt th.edt--checkbox{padding:9px 10px;width:34px;text-align:center;}
+.edt td{padding:8px 12px;white-space:nowrap;color:var(--text-primary,#22272E);
+  border-top:1px solid var(--border,#CBD3DC);font-variant-numeric:tabular-nums;height:34px;}
+.edt td.edt--expand{padding:6px 10px;text-align:center;cursor:pointer;}
+.edt td.edt--checkbox{padding:6px 10px;text-align:center;}
+.edt tbody tr:first-child td{border-top:none;}
+.edt td.edt--r{text-align:right;}
+.edt tbody tr.edt-main{background:var(--bg-panel,var(--bg-light,#fff));}
+.edt tbody tr.edt-main:nth-child(4n+1){background:var(--card-surface-raised,#F3F6F9);}
+.edt tbody tr.edt-main:hover{background:var(--bg-active,#E6EEF5);box-shadow:inset 3px 0 0 var(--accent,#2F6F8F);}
+.edt tbody tr.edt-main.edt--sel{cursor:pointer;}
+.edt tbody tr.edt-expand{background:var(--blue-a10,rgba(47,111,143,.10));}
+.edt tbody tr.edt-expand td{padding:0;border:none;}
+.edt__detail{padding:16px 12px;}
+.edt__chevron{display:inline-block;transition:transform 150ms ease;font-size:12px;}
+.edt__chevron.edt--open{transform:rotate(90deg);}
+.edt__ckbox{width:16px;height:16px;cursor:pointer;border:1px solid var(--border,#CBD3DC);
+  border-radius:var(--radius-chip,2px);appearance:none;background:var(--bg-panel,var(--bg-light,#fff));}
+.edt__ckbox:hover{border-color:var(--accent,#2F6F8F);}
+.edt__ckbox:checked{background:var(--accent,#2F6F8F);border-color:var(--accent,#2F6F8F);
+  background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M13.3 4.3L6 11.6 2.7 8.3" stroke="white" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+  background-size:12px;background-position:center;background-repeat:no-repeat;}
+.edt__sort{margin-left:6px;font-size:9px;opacity:.4;}
+.edt th.edt--sorted{color:var(--text-secondary,#4D5967);}
+.edt th.edt--sorted .edt__sort{opacity:1;color:var(--accent,#2F6F8F);}
+`;
+
+export type ExpandableDataTableColumn<Row = Record<string, unknown>> = DataTableColumn<Row>;
+
+export interface ExpandableDataTableProps<Row = Record<string, unknown>> {
+  columns: ExpandableDataTableColumn<Row>[];
+  rows: Row[];
+  /**
+   * Render function for expanded detail content. Receives (row, index).
+   * If omitted, no expand column is shown.
+   */
+  expandable?: (row: Row, index: number) => ReactNode;
+  /** Row index highlighted with the accent rail. @default -1 */
+  selectedIndex?: number;
+  /** Active sort column key. */
+  sortKey?: string;
+  /** @default "asc" */
+  sortDir?: "asc" | "desc";
+  /** Fired when a row is clicked (main row only, not the expand chevron). */
+  onRowClick?: (row: Row, index: number) => void;
+  onSort?: (key: string) => void;
+  /** Enable the checkbox column for multi-select. @default false */
+  selectable?: boolean;
+  selectedRows?: number[];
+  onSelectRow?: (row: Row, index: number, isSelected: boolean) => void;
+  onSelectAll?: (isSelected: boolean) => void;
+}
+
+/**
+ * ExpandableDataTable — DenseDataTable with collapsible per-row detail panels.
+ *
+ * @example
+ * <ExpandableDataTable
+ *   columns={[{ key: "date", label: "Date" }, { key: "amount", label: "Amount", align: "right" }]}
+ *   rows={transactions}
+ *   expandable={(row) => <p>Account: {row.account}</p>}
+ * />
+ */
+export function ExpandableDataTable<Row extends Record<string, unknown> = Record<string, unknown>>({
+  columns,
+  rows,
+  expandable,
+  selectedIndex = -1,
+  sortKey,
+  sortDir = "asc",
+  onRowClick,
+  onSort,
+  selectable = false,
+  selectedRows = [],
+  onSelectRow,
+  onSelectAll,
+}: ExpandableDataTableProps<Row>) {
+  injectStyle("edt", CSS);
+  const [expandedIndices, setExpandedIndices] = useState<Set<number>>(new Set());
+
+  const toggleExpand = (index: number) => {
+    setExpandedIndices((current) => {
+      const next = new Set(current);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+  };
+
+  const allSelected = selectable && selectedRows.length === rows.length && rows.length > 0;
+  const someSelected = selectable && selectedRows.length > 0 && selectedRows.length < rows.length;
+  const colSpan = (expandable ? 1 : 0) + (selectable ? 1 : 0) + columns.length;
+
+  return (
+    <div className="edt-wrap">
+      <table className="edt">
+        <thead>
+          <tr>
+            {expandable && <th className="edt--expand" />}
+            {selectable && (
+              <th className="edt--checkbox">
+                <input
+                  type="checkbox"
+                  className="edt__ckbox"
+                  checked={allSelected}
+                  ref={(el) => {
+                    if (el) el.indeterminate = someSelected;
+                  }}
+                  onChange={() => onSelectAll?.(!allSelected)}
+                  aria-label="Select all rows"
+                />
+              </th>
+            )}
+            {columns.map((c) => {
+              const sorted = sortKey === c.key;
+              const sortable = Boolean(onSort) && c.sortable !== false;
+              const cls = `${c.align === "right" ? "edt--r " : ""}${sorted ? "edt--sorted" : ""}`.trim();
+              return (
+                <th
+                  key={c.key}
+                  className={cls}
+                  onClick={sortable ? () => onSort?.(c.key) : undefined}
+                  style={{ cursor: sortable ? "pointer" : "default" }}
+                >
+                  {c.label}
+                  {sortable && (
+                    <span className="edt__sort">{sorted ? (sortDir === "asc" ? "▲" : "▼") : "↕"}</span>
+                  )}
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => {
+            const isSelected = selectedRows.includes(i);
+            const isExpanded = expandedIndices.has(i);
+            const on = onRowClick || i === selectedIndex || isSelected;
+            return (
+              <Fragment key={i}>
+                <tr
+                  className={`edt-main${on ? " edt--sel" : ""}`}
+                  tabIndex={onRowClick ? 0 : undefined}
+                  onClick={onRowClick ? () => onRowClick(row, i) : undefined}
+                >
+                  {expandable && (
+                    <td
+                      className="edt--expand"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        toggleExpand(i);
+                      }}
+                    >
+                      <span className={`edt__chevron${isExpanded ? " edt--open" : ""}`}>›</span>
+                    </td>
+                  )}
+                  {selectable && (
+                    <td className="edt--checkbox">
+                      <input
+                        type="checkbox"
+                        className="edt__ckbox"
+                        checked={isSelected}
+                        onChange={() => onSelectRow?.(row, i, !isSelected)}
+                        onClick={(e) => e.stopPropagation()}
+                        aria-label={`Select row ${i + 1}`}
+                      />
+                    </td>
+                  )}
+                  {columns.map((c) => (
+                    <td key={c.key} className={c.align === "right" ? "edt--r" : ""}>
+                      {c.render ? c.render(row) : (row[c.key] as ReactNode)}
+                    </td>
+                  ))}
+                </tr>
+
+                {expandable && isExpanded && (
+                  <tr className="edt-expand">
+                    <td colSpan={colSpan}>
+                      <div className="edt__detail">{expandable(row, i)}</div>
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/data/filtered-data-table.concrete.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/filtered-data-table.concrete.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { FilteredDataTable } from "./filtered-data-table";
+
+interface Row extends Record<string, unknown> {
+  symbol: string;
+  sector: string;
+}
+
+const columns = [
+  { key: "symbol", label: "Symbol" },
+  { key: "sector", label: "Sector" },
+];
+
+const data: Row[] = [
+  { symbol: "AAPL", sector: "Tech" },
+  { symbol: "XOM", sector: "Energy" },
+  { symbol: "MSFT", sector: "Tech" },
+];
+
+describe("FilteredDataTable (Concrete)", () => {
+  it("renders a title, the result count, and all rows", () => {
+    render(<FilteredDataTable title="Universe" data={data} columns={columns} />);
+    expect(screen.getByText("Universe")).toBeInTheDocument();
+    expect(screen.getByText("3 of 3")).toBeInTheDocument();
+    expect(screen.getByText("AAPL")).toBeInTheDocument();
+  });
+
+  it("filters rows via the search box and updates the count", async () => {
+    render(<FilteredDataTable data={data} columns={columns} />);
+    await userEvent.type(screen.getByLabelText("Search all fields"), "energy");
+    expect(screen.getByText("XOM")).toBeInTheDocument();
+    expect(screen.queryByText("AAPL")).toBeNull();
+    expect(screen.getByText("1 of 3")).toBeInTheDocument();
+  });
+
+  it("shows a no-results message when the search matches nothing", async () => {
+    render(<FilteredDataTable data={data} columns={columns} />);
+    await userEvent.type(screen.getByLabelText("Search all fields"), "zzz");
+    expect(screen.getByText("No results match your search")).toBeInTheDocument();
+  });
+
+  it("sorts by a column header click", async () => {
+    render(<FilteredDataTable data={data} columns={columns} />);
+    await userEvent.click(screen.getByText("Symbol"));
+    const cells = screen.getAllByRole("cell").map((c) => c.textContent);
+    // Ascending: AAPL first.
+    expect(cells[0]).toBe("AAPL");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/data/filtered-data-table.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/filtered-data-table.tsx
@@ -1,0 +1,179 @@
+// Meridian FilteredDataTable (Concrete) — a self-contained data surface unifying a search
+// toolbar + result count + CSV export over a dense table, driven by `useTableState`.
+// Flat institutional styling matching DenseDataTable. Re-implemented natively (no core/*
+// dependency) so Wave 2 screens can adopt it without waiting on sibling units.
+import type { ReactNode } from "react";
+import { injectStyle } from "../operations/inject-style";
+import { useTableState, type TableState } from "./use-table-state";
+
+const CSS = `
+.fdt-wrap{display:flex;flex-direction:column;gap:12px;}
+.fdt-toolbar{display:flex;align-items:center;gap:12px;padding:12px;flex-wrap:wrap;
+  background:var(--bg-medium,#F3F6F9);border-radius:var(--radius-chip,2px);
+  border:1px solid var(--border,#CBD3DC);}
+.fdt-search{flex:1;min-width:200px;}
+.fdt-search input{width:100%;box-sizing:border-box;height:30px;padding:4px 10px;
+  border:1px solid var(--border,#CBD3DC);border-radius:var(--radius-button,2px);
+  background:var(--bg-panel,var(--bg-light,#fff));color:var(--text-primary,#22272E);
+  font-family:var(--font-body);font-size:12px;transition:border-color .1s ease;}
+.fdt-search input:focus{outline:none;border-color:var(--accent,#2F6F8F);}
+.fdt-count{font-family:var(--font-data,monospace);font-size:12px;color:var(--text-muted,#59636F);}
+.fdt-badge{display:inline-block;margin-left:8px;padding:2px 7px;background:var(--blue-a10,rgba(47,111,143,.10));
+  border:1px solid var(--accent,#2F6F8F);color:var(--accent,#2F6F8F);border-radius:var(--radius-chip,2px);
+  font-family:var(--font-body);font-size:11px;font-weight:600;}
+.fdt-actions{display:flex;gap:8px;margin-left:auto;}
+.fdt-btn{appearance:none;height:30px;padding:4px 12px;border-radius:var(--radius-button,2px);
+  font-family:var(--font-body);font-size:12px;font-weight:600;cursor:pointer;
+  transition:background .1s ease,border-color .1s ease;}
+.fdt-btn--ghost{border:1px solid var(--border,#CBD3DC);background:var(--bg-panel,var(--bg-light,#fff));color:var(--text-secondary,#4D5967);}
+.fdt-btn--ghost:hover{border-color:var(--accent,#2F6F8F);background:var(--bg-active,#E6EEF5);}
+.fdt-btn--primary{border:1px solid var(--accent,#2F6F8F);background:var(--accent,#2F6F8F);color:#fff;}
+.fdt-btn--primary:hover{background:var(--accent-pressed,#255B75);border-color:var(--accent-pressed,#255B75);}
+.fdt-btn:focus-visible{outline:var(--focus-ring,2px solid #2F6F8F);outline-offset:2px;}
+.fdt-title{margin:0;font-family:var(--font-body);font-size:15px;font-weight:600;color:var(--text-primary,#22272E);}
+.fdt-table{border:1px solid var(--border,#CBD3DC);border-radius:var(--radius-chip,2px);overflow:hidden;}
+.fdt-table table{width:100%;border-collapse:separate;border-spacing:0;font-family:var(--font-data,monospace);font-size:12px;}
+.fdt-table thead{position:sticky;top:0;z-index:1;background:var(--bg-medium,#F3F6F9);}
+.fdt-table th{padding:9px 12px;text-align:left;white-space:nowrap;user-select:none;
+  font-family:var(--font-body);font-size:10px;font-weight:600;font-variant:all-small-caps;letter-spacing:.03em;
+  color:var(--text-muted,#59636F);border-bottom:1px solid var(--border-strong,#99A5B2);}
+.fdt-table th.fdt--sortable{cursor:pointer;transition:background .1s ease;}
+.fdt-table th.fdt--sortable:hover{background:var(--bg-panel,var(--bg-light,#fff));}
+.fdt-table th.fdt--sorted{background:var(--bg-panel,var(--bg-light,#fff));color:var(--accent,#2F6F8F);}
+.fdt-table th.fdt--r{text-align:right;}
+.fdt-table td{padding:8px 12px;height:34px;border-top:1px solid var(--border,#CBD3DC);
+  color:var(--text-primary,#22272E);font-variant-numeric:tabular-nums;}
+.fdt-table tbody tr{background:var(--bg-panel,var(--bg-light,#fff));}
+.fdt-table tbody tr:nth-child(even){background:var(--card-surface-raised,#F3F6F9);}
+.fdt-table tbody tr:hover{background:var(--bg-active,#E6EEF5);box-shadow:inset 3px 0 0 var(--accent,#2F6F8F);}
+.fdt-table td.fdt--r{text-align:right;}
+.fdt-empty{padding:48px 24px;text-align:center;color:var(--text-muted,#59636F);
+  font-family:var(--font-body);font-size:13px;}
+`;
+
+export interface FilteredDataTableColumn {
+  key: string;
+  label: ReactNode;
+  align?: "left" | "right";
+  sortable?: boolean;
+  filterable?: boolean;
+}
+
+export interface FilteredDataTableProps<Row extends Record<string, unknown> = Record<string, unknown>> {
+  data?: Row[];
+  columns?: FilteredDataTableColumn[];
+  title?: string;
+  /** Called instead of the default CSV export; receives the live table state. */
+  onExport?: (state: TableState<Row>) => void;
+  /** Persist query/sort/filters under this localStorage key. */
+  localStorageKey?: string | null;
+}
+
+/**
+ * FilteredDataTable — search + sort + export over a dense table in one surface.
+ *
+ * @example
+ * <FilteredDataTable title="Positions" data={rows} columns={cols} />
+ */
+export function FilteredDataTable<Row extends Record<string, unknown> = Record<string, unknown>>({
+  data = [],
+  columns = [],
+  title = "",
+  onExport,
+  localStorageKey = null,
+}: FilteredDataTableProps<Row>) {
+  injectStyle("filtered-data-table", CSS);
+  const state = useTableState<Row>(data, localStorageKey);
+
+  const handleSort = (colKey: string) => {
+    const col = columns.find((c) => c.key === colKey);
+    if (col?.sortable !== false) state.toggleSort(colKey);
+  };
+
+  return (
+    <div className="fdt-wrap">
+      {title && <h3 className="fdt-title">{title}</h3>}
+
+      <div className="fdt-toolbar">
+        <div className="fdt-search">
+          <input
+            type="text"
+            placeholder="Search all fields…"
+            value={state.query}
+            onChange={(e) => state.setQuery(e.target.value)}
+            aria-label="Search all fields"
+          />
+        </div>
+        <div className="fdt-count">
+          {state.resultCount} of {state.rawData.length}
+          {state.filterCount > 0 && (
+            <span className="fdt-badge">
+              {state.filterCount} filter{state.filterCount !== 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+        <div className="fdt-actions">
+          {state.filterCount > 0 && (
+            <button type="button" className="fdt-btn fdt-btn--ghost" onClick={state.clearAllFilters}>
+              Clear filters
+            </button>
+          )}
+          <button
+            type="button"
+            className="fdt-btn fdt-btn--primary"
+            onClick={() => (onExport ? onExport(state) : state.exportCSV())}
+          >
+            {onExport ? "Export" : "Export CSV"}
+          </button>
+        </div>
+      </div>
+
+      <div className="fdt-table">
+        {state.data.length === 0 ? (
+          <div className="fdt-empty">
+            {state.resultCount === 0 && data.length > 0
+              ? "No results match your search"
+              : "No data"}
+          </div>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                {columns.map((col) => {
+                  const sortable = col.sortable !== false;
+                  const sorted = state.sortBy?.column === col.key;
+                  const cls = `${sortable ? "fdt--sortable " : ""}${sorted ? "fdt--sorted " : ""}${col.align === "right" ? "fdt--r" : ""}`.trim();
+                  return (
+                    <th
+                      key={col.key}
+                      className={cls}
+                      onClick={sortable ? () => handleSort(col.key) : undefined}
+                    >
+                      {col.label}
+                      {sortable && sorted && (
+                        <span style={{ marginLeft: 4 }}>
+                          {state.sortBy?.direction === "asc" ? "↑" : "↓"}
+                        </span>
+                      )}
+                    </th>
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {state.data.map((row, idx) => (
+                <tr key={idx}>
+                  {columns.map((col) => (
+                    <td key={col.key} className={col.align === "right" ? "fdt--r" : ""}>
+                      {row[col.key] as ReactNode}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/data/key-value-grid.concrete.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/key-value-grid.concrete.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { KeyValueGrid } from "./key-value-grid";
+import { EntitySummary } from "./entity-summary";
+
+describe("KeyValueGrid (Concrete)", () => {
+  it("renders each label/value fact", () => {
+    render(
+      <KeyValueGrid
+        columns={3}
+        items={[
+          { label: "CUSIP", value: "037833100" },
+          { label: "Exchange", value: "NASDAQ" },
+        ]}
+      />,
+    );
+    expect(screen.getByText("CUSIP")).toBeInTheDocument();
+    expect(screen.getByText("037833100")).toBeInTheDocument();
+    expect(screen.getByText("NASDAQ")).toBeInTheDocument();
+  });
+});
+
+describe("EntitySummary (Concrete)", () => {
+  it("renders facts and applies per-item color overrides", () => {
+    const { container } = render(
+      <EntitySummary
+        items={[
+          { label: "Symbol", value: "AAPL" },
+          { label: "Name", value: "Apple Inc.", mono: false },
+          { label: "Status", value: "Active", color: "var(--severity-ready-fg)" },
+        ]}
+      />,
+    );
+    expect(screen.getByText("Apple Inc.")).toBeInTheDocument();
+    const colored = Array.from(container.querySelectorAll<HTMLElement>("div")).find(
+      (el) => el.textContent === "Active" && el.style.color !== "",
+    );
+    expect(colored?.style.color).toContain("severity-ready-fg");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/data/key-value-grid.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/key-value-grid.tsx
@@ -1,0 +1,55 @@
+// Meridian key/value fact grid (Concrete) — a small-caps muted label over a mono tabular
+// value, laid out in N responsive columns. Used in entity summaries and detail panes.
+import type { CSSProperties, ReactNode } from "react";
+
+export interface KeyValueGridItem {
+  label: ReactNode;
+  value: ReactNode;
+}
+
+export interface KeyValueGridProps {
+  items: KeyValueGridItem[];
+  /** @default 2 */
+  columns?: number;
+}
+
+const labelStyle: CSSProperties = {
+  fontFamily: "var(--font-body)",
+  fontSize: 10,
+  fontWeight: 600,
+  fontVariant: "all-small-caps",
+  letterSpacing: "0.03em",
+  color: "var(--text-muted, #59636F)",
+};
+
+const valueStyle: CSSProperties = {
+  fontFamily: "var(--font-data, monospace)",
+  fontSize: 13,
+  fontVariantNumeric: "tabular-nums",
+  color: "var(--text-primary, #22272E)",
+};
+
+/**
+ * KeyValueGrid — a label-over-value fact grid.
+ *
+ * @example
+ * <KeyValueGrid columns={3} items={[{ label: "CUSIP", value: "037833100" }]} />
+ */
+export function KeyValueGrid({ items, columns = 2 }: KeyValueGridProps) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+        gap: "12px 24px",
+      }}
+    >
+      {items.map((it, i) => (
+        <div key={i} style={{ display: "flex", flexDirection: "column", gap: 3, minWidth: 0 }}>
+          <div style={labelStyle}>{it.label}</div>
+          <div style={valueStyle}>{it.value}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/data/metric-card.concrete.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/metric-card.concrete.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MetricCard } from "./metric-card";
+
+describe("MetricCard (Concrete)", () => {
+  it("renders the label, value, and delta", () => {
+    render(<MetricCard label="Net liquidation" value="$1,284,002.18" delta="+1.84% today" tone="success" />);
+    expect(screen.getByText("Net liquidation")).toBeInTheDocument();
+    expect(screen.getByText("$1,284,002.18")).toBeInTheDocument();
+    expect(screen.getByText("+1.84% today")).toBeInTheDocument();
+  });
+
+  it("applies the tone class for the left-accent border", () => {
+    const { container } = render(<MetricCard label="Day P&L" value="-$4,118.22" tone="danger" />);
+    expect(container.querySelector(".mds-metric--danger")).not.toBeNull();
+  });
+
+  it("infers delta trend from its leading sign", () => {
+    const { container, rerender } = render(<MetricCard label="X" value="1" delta="+2%" />);
+    expect(container.querySelector(".mds-delta--up")).not.toBeNull();
+    rerender(<MetricCard label="X" value="1" delta="-2%" />);
+    expect(container.querySelector(".mds-delta--down")).not.toBeNull();
+  });
+
+  it("honours an explicit trend override", () => {
+    const { container } = render(<MetricCard label="X" value="1" delta="2%" trend="flat" />);
+    expect(container.querySelector(".mds-delta--flat")).not.toBeNull();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/data/metric-card.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/metric-card.tsx
@@ -1,0 +1,67 @@
+// Meridian KPI tile (Concrete) — mirrors the desktop MetricCardStyle + its
+// success/danger/warning/info variants: a raised paper surface with a 3px LEFT-accent
+// border in the tone color, a small-caps label, a 24px mono value, and a signed delta
+// (green up / red down). This is the design-system MetricCard; the pre-existing
+// read-model tile lives at `components/meridian/metric-card.tsx` and is left untouched.
+import type { ReactNode } from "react";
+import { injectStyle } from "../operations/inject-style";
+
+const CSS = `
+.mds-metric{background:var(--card-surface-raised,#F3F6F9);
+  border:1px solid var(--border,#CBD3DC);border-left-width:3px;
+  border-radius:var(--radius-card,2px);padding:18px;}
+.mds-metric--neutral{border-left-color:var(--border-strong,#99A5B2);}
+.mds-metric--info{border-left-color:var(--accent,#2F6F8F);}
+.mds-metric--success{border-left-color:var(--severity-ready-fg,#16885F);}
+.mds-metric--warning{border-left-color:var(--severity-action-fg,#8A520E);}
+.mds-metric--danger{border-left-color:var(--severity-blocked-fg,#BA3F55);}
+.mds-metric__label{font-family:var(--font-body);font-size:10px;font-weight:600;
+  font-variant:all-small-caps;letter-spacing:.03em;color:var(--text-muted,#59636F);margin:0;}
+.mds-metric__value{margin:8px 0 0;font-family:var(--font-data,monospace);font-size:24px;font-weight:600;
+  line-height:1;font-variant-numeric:tabular-nums;color:var(--text-primary,#22272E);}
+.mds-metric__delta{font-family:var(--font-data,monospace);font-size:11px;margin-top:6px;
+  font-variant-numeric:tabular-nums;}
+.mds-delta--up{color:var(--severity-ready-fg,#16885F);}
+.mds-delta--down{color:var(--severity-blocked-fg,#BA3F55);}
+.mds-delta--flat{color:var(--text-muted,#59636F);}
+`;
+
+export type MetricCardTone = "neutral" | "info" | "success" | "warning" | "danger";
+
+export interface MetricCardProps {
+  /** Small-caps label, e.g. "Net liquidation". */
+  label: ReactNode;
+  /** Mono tabular value, e.g. "$1,284,002.18". */
+  value: ReactNode;
+  /** Signed delta/context line, e.g. "+1.84% today". */
+  delta?: string;
+  /** Left-accent color. @default "neutral" */
+  tone?: MetricCardTone;
+  /** Force delta color; otherwise inferred from a leading +/− sign. */
+  trend?: "up" | "down" | "flat";
+}
+
+/**
+ * MetricCard — the KPI tile with a 3px left-accent border. Lay out 4–5 in a row.
+ *
+ * @example
+ * <MetricCard label="Net liquidation" value="$1,284,002.18" delta="+1.84% today" tone="success" />
+ * <MetricCard label="Day P&L" value="-$4,118.22" delta="-0.32%" tone="danger" />
+ */
+export function MetricCard({ label, value, delta, tone = "neutral", trend }: MetricCardProps) {
+  injectStyle("metric", CSS);
+  const t =
+    trend ??
+    (delta?.trim().startsWith("-") ? "down" : delta?.trim().startsWith("+") ? "up" : "flat");
+  return (
+    <div
+      className={`mds-metric mds-metric--${tone}`}
+      role="group"
+      aria-label={`${typeof label === "string" ? label : ""}: ${typeof value === "string" ? value : ""}`.trim()}
+    >
+      <p className="mds-metric__label">{label}</p>
+      <p className="mds-metric__value">{value}</p>
+      {delta && <div className={`mds-metric__delta mds-delta--${t}`}>{delta}</div>}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/data/pagination.concrete.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/pagination.concrete.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Pagination } from "./pagination";
+
+describe("Pagination (Concrete)", () => {
+  it("renders an item range summary when totalItems is provided", () => {
+    render(<Pagination currentPage={2} totalPages={5} totalItems={230} itemsPerPage={50} />);
+    expect(screen.getByText("51–100 of 230")).toBeInTheDocument();
+  });
+
+  it("disables prev on the first page and next on the last", () => {
+    const { rerender } = render(<Pagination currentPage={1} totalPages={3} />);
+    expect(screen.getByLabelText("Previous page")).toBeDisabled();
+    rerender(<Pagination currentPage={3} totalPages={3} />);
+    expect(screen.getByLabelText("Next page")).toBeDisabled();
+  });
+
+  it("emits the next page when the next control is clicked", async () => {
+    const onPageChange = vi.fn();
+    render(<Pagination currentPage={2} totalPages={5} onPageChange={onPageChange} />);
+    await userEvent.click(screen.getByLabelText("Next page"));
+    expect(onPageChange).toHaveBeenCalledWith(3);
+  });
+
+  it("marks the current page control as current", () => {
+    render(<Pagination currentPage={2} totalPages={5} />);
+    expect(screen.getByLabelText("Page 2")).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/data/pagination.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/pagination.tsx
@@ -1,0 +1,147 @@
+// Meridian Pagination (Concrete) — prev/next controls, windowed page numbers with
+// ellipses, and a jump-to-page input. Flat hairline buttons; the active page carries the
+// steel accent. No external deps.
+import { useState } from "react";
+import { injectStyle } from "../operations/inject-style";
+
+const CSS = `
+.pgn-wrap{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;
+  padding:12px;background:var(--bg-medium,#F3F6F9);border-radius:var(--radius-chip,2px);
+  border:1px solid var(--border,#CBD3DC);}
+.pgn-info{font-family:var(--font-data,monospace);font-size:12px;color:var(--text-muted,#59636F);
+  font-variant-numeric:tabular-nums;}
+.pgn-controls{display:flex;align-items:center;gap:4px;}
+.pgn-btn{appearance:none;border:1px solid var(--border,#CBD3DC);background:var(--bg-panel,var(--bg-light,#fff));
+  color:var(--text-primary,#22272E);min-width:28px;height:28px;padding:0 6px;border-radius:var(--radius-button,2px);
+  cursor:pointer;font-family:var(--font-data,monospace);font-size:12px;font-weight:500;
+  display:flex;align-items:center;justify-content:center;
+  transition:background .1s ease,border-color .1s ease;}
+.pgn-btn:hover:not(:disabled){background:var(--bg-active,#E6EEF5);border-color:var(--accent,#2F6F8F);}
+.pgn-btn:focus-visible{outline:var(--focus-ring,2px solid #2F6F8F);outline-offset:1px;}
+.pgn-btn:disabled{opacity:.4;cursor:not-allowed;}
+.pgn-btn--active{background:var(--accent,#2F6F8F);color:#fff;border-color:var(--accent,#2F6F8F);}
+.pgn-ellipsis{padding:0 4px;color:var(--text-muted,#59636F);}
+.pgn-jump{height:28px;padding:4px 8px;width:52px;text-align:center;
+  border:1px solid var(--border,#CBD3DC);border-radius:var(--radius-button,2px);
+  background:var(--bg-panel,var(--bg-light,#fff));color:var(--text-primary,#22272E);
+  font-family:var(--font-data,monospace);font-size:12px;transition:border-color .1s ease;}
+.pgn-jump:focus{outline:none;border-color:var(--accent,#2F6F8F);}
+`;
+
+export interface PaginationProps {
+  currentPage?: number;
+  totalPages?: number;
+  onPageChange?: (page: number) => void;
+  totalItems?: number;
+  itemsPerPage?: number;
+  siblingCount?: number;
+}
+
+/**
+ * Pagination — page controls with a windowed number range and jump-to input.
+ *
+ * @example
+ * <Pagination currentPage={page} totalPages={20} totalItems={987} itemsPerPage={50} onPageChange={setPage} />
+ */
+export function Pagination({
+  currentPage = 1,
+  totalPages = 1,
+  onPageChange = () => {},
+  totalItems = 0,
+  itemsPerPage = 50,
+  siblingCount = 1,
+}: PaginationProps) {
+  injectStyle("pagination", CSS);
+  const [jumpValue, setJumpValue] = useState(String(currentPage));
+
+  const goTo = (page: number) => {
+    const clamped = Math.max(1, Math.min(totalPages, page));
+    onPageChange(clamped);
+  };
+
+  const handleJump = () => {
+    const page = Math.max(1, Math.min(totalPages, parseInt(jumpValue, 10) || 1));
+    setJumpValue(String(page));
+    onPageChange(page);
+  };
+
+  const getPageRange = (): Array<number | "..."> => {
+    const range: Array<number | "..."> = [];
+    const leftSibling = Math.max(2, currentPage - siblingCount);
+    const rightSibling = Math.min(totalPages - 1, currentPage + siblingCount);
+
+    range.push(1);
+    if (leftSibling > 2) range.push("...");
+    for (let i = leftSibling; i <= rightSibling; i++) range.push(i);
+    if (rightSibling < totalPages - 1) range.push("...");
+    if (totalPages > 1) range.push(totalPages);
+    return range;
+  };
+
+  const pageRange = getPageRange();
+  const startItem = (currentPage - 1) * itemsPerPage + 1;
+  const endItem = Math.min(currentPage * itemsPerPage, totalItems || 0);
+
+  return (
+    <div className="pgn-wrap">
+      <div className="pgn-info">
+        {totalItems > 0
+          ? `${startItem}–${endItem} of ${totalItems}`
+          : `Page ${currentPage} of ${totalPages}`}
+      </div>
+
+      <div className="pgn-controls">
+        <button
+          type="button"
+          className="pgn-btn"
+          onClick={() => goTo(currentPage - 1)}
+          disabled={currentPage === 1}
+          aria-label="Previous page"
+        >
+          ‹
+        </button>
+
+        {pageRange.map((page, idx) =>
+          page === "..." ? (
+            <span key={`e${idx}`} className="pgn-ellipsis">
+              …
+            </span>
+          ) : (
+            <button
+              type="button"
+              key={page}
+              className={`pgn-btn${page === currentPage ? " pgn-btn--active" : ""}`}
+              onClick={() => goTo(page)}
+              aria-label={`Page ${page}`}
+              aria-current={page === currentPage ? "page" : undefined}
+            >
+              {page}
+            </button>
+          ),
+        )}
+
+        <button
+          type="button"
+          className="pgn-btn"
+          onClick={() => goTo(currentPage + 1)}
+          disabled={currentPage === totalPages}
+          aria-label="Next page"
+        >
+          ›
+        </button>
+
+        <input
+          type="number"
+          className="pgn-jump"
+          value={jumpValue}
+          onChange={(e) => setJumpValue(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleJump()}
+          onBlur={handleJump}
+          min={1}
+          max={totalPages}
+          aria-label="Jump to page"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/data/skeleton.concrete.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/skeleton.concrete.test.tsx
@@ -1,0 +1,33 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Skeleton, SkeletonTable } from "./skeleton";
+
+describe("Skeleton (Concrete)", () => {
+  it("renders a single block placeholder by default", () => {
+    const { container } = render(<Skeleton width={120} height={16} />);
+    const el = container.querySelector(".mds-skel") as HTMLElement;
+    expect(el).not.toBeNull();
+    expect(el.style.width).toBe("120px");
+    expect(el.style.height).toBe("16px");
+  });
+
+  it("renders one line per `lines` for the text variant", () => {
+    const { container } = render(<Skeleton variant="text" lines={4} />);
+    expect(container.querySelectorAll(".mds-skel--text")).toHaveLength(4);
+  });
+
+  it("defaults circle height to its width", () => {
+    const { container } = render(<Skeleton variant="circle" width={40} />);
+    const el = container.querySelector(".mds-skel--circle") as HTMLElement;
+    expect(el.style.width).toBe("40px");
+    expect(el.style.height).toBe("40px");
+  });
+});
+
+describe("SkeletonTable (Concrete)", () => {
+  it("lays out rows × columns placeholder cells", () => {
+    const { container } = render(<SkeletonTable rows={3} columns={5} />);
+    expect(container.querySelectorAll("tr")).toHaveLength(3);
+    expect(container.querySelectorAll("td")).toHaveLength(15);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/data/skeleton.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/skeleton.tsx
@@ -1,0 +1,113 @@
+// Meridian Skeleton (Concrete) — a loading placeholder with a subtle shimmer that is
+// reduced-motion safe. Compose `text` lines / `block` cards / `circle` avatars, or use
+// SkeletonTable for a dense placeholder grid while a table is still fetching.
+import type { CSSProperties, HTMLAttributes } from "react";
+import { injectStyle } from "../operations/inject-style";
+
+const CSS = `
+.mds-skel{display:block;background:var(--bg-active,#E1EAF2);border-radius:var(--radius-chip,2px);
+  position:relative;overflow:hidden;}
+.mds-skel::after{content:"";position:absolute;inset:0;transform:translateX(-100%);
+  background:linear-gradient(90deg,transparent,var(--bg-hover,#F1F4F7),transparent);
+  animation:mds-skel-sweep 1.3s ease-in-out infinite;}
+.mds-skel--text{height:12px;margin:3px 0;}
+.mds-skel--circle{border-radius:50%;}
+.mds-skel-lines{display:flex;flex-direction:column;gap:8px;}
+.mds-skel-table{width:100%;border-collapse:collapse;font-family:var(--font-body);}
+.mds-skel-table td{padding:9px 12px;border-bottom:1px solid var(--border-divider,#DDE3EA);}
+@keyframes mds-skel-sweep{100%{transform:translateX(100%);}}
+@media (prefers-reduced-motion:reduce){.mds-skel::after{animation:none;}}
+`;
+
+export interface SkeletonProps extends HTMLAttributes<HTMLSpanElement> {
+  /** Shape. @default "block" */
+  variant?: "block" | "text" | "circle";
+  /** CSS width (number → px). */
+  width?: number | string;
+  /** CSS height (number → px). For `circle`, defaults to `width`. */
+  height?: number | string;
+  /** Line count when `variant="text"` (last line is shortened). @default 3 */
+  lines?: number;
+}
+
+function toDim(value?: number | string): string | undefined {
+  if (value == null) return undefined;
+  return typeof value === "number" ? `${value}px` : value;
+}
+
+/**
+ * Skeleton — a shimmer loading placeholder.
+ *
+ * @example
+ * <Skeleton variant="text" lines={4} />
+ * <Skeleton variant="circle" width={40} />
+ */
+export function Skeleton({
+  variant = "block",
+  width,
+  height,
+  lines = 3,
+  className,
+  style,
+  ...rest
+}: SkeletonProps) {
+  injectStyle("skeleton", CSS);
+
+  if (variant === "text" && lines > 1) {
+    return (
+      <div className={`mds-skel-lines${className ? " " + className : ""}`} {...rest}>
+        {Array.from({ length: lines }).map((_, i) => (
+          <span
+            key={i}
+            className="mds-skel mds-skel--text"
+            style={{ width: i === lines - 1 ? "60%" : toDim(width) ?? "100%" }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  const modifier =
+    variant === "text" ? " mds-skel--text" : variant === "circle" ? " mds-skel--circle" : "";
+  const dims: CSSProperties = { ...style };
+  if (width != null) dims.width = toDim(width);
+  if (height != null) dims.height = toDim(height);
+  if (variant === "circle" && width != null && height == null) dims.height = toDim(width);
+
+  return (
+    <span className={`mds-skel${modifier}${className ? " " + className : ""}`} style={dims} {...rest} />
+  );
+}
+
+export interface SkeletonTableProps extends HTMLAttributes<HTMLTableElement> {
+  /** Placeholder row count. @default 5 */
+  rows?: number;
+  /** Placeholder column count. @default 4 */
+  columns?: number;
+}
+
+/**
+ * SkeletonTable — a dense placeholder grid for tables that are still fetching.
+ *
+ * @example
+ * <SkeletonTable rows={8} columns={5} />
+ */
+export function SkeletonTable({ rows = 5, columns = 4, className, ...rest }: SkeletonTableProps) {
+  injectStyle("skeleton", CSS);
+  const widths = ["70%", "45%", "55%", "40%", "60%", "50%"];
+  return (
+    <table className={`mds-skel-table${className ? " " + className : ""}`} {...rest}>
+      <tbody>
+        {Array.from({ length: rows }).map((_, r) => (
+          <tr key={r}>
+            {Array.from({ length: columns }).map((_, c) => (
+              <td key={c}>
+                <span className="mds-skel mds-skel--text" style={{ width: widths[(r + c) % widths.length] }} />
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/data/use-table-state.test.ts
+++ b/src/Meridian.Ui/dashboard/src/components/data/use-table-state.test.ts
@@ -1,0 +1,56 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useTableState } from "./use-table-state";
+
+interface Row extends Record<string, unknown> {
+  symbol: string;
+  sector: string;
+  qty: number;
+}
+
+const data: Row[] = [
+  { symbol: "AAPL", sector: "Tech", qty: 100 },
+  { symbol: "XOM", sector: "Energy", qty: 40 },
+  { symbol: "MSFT", sector: "Tech", qty: 75 },
+];
+
+describe("useTableState", () => {
+  it("searches across all fields", () => {
+    const { result } = renderHook(() => useTableState<Row>(data));
+    act(() => result.current.setQuery("energy"));
+    expect(result.current.data.map((r) => r.symbol)).toEqual(["XOM"]);
+    expect(result.current.resultCount).toBe(1);
+  });
+
+  it("toggles sort direction on repeated column toggles", () => {
+    const { result } = renderHook(() => useTableState<Row>(data));
+    act(() => result.current.toggleSort("qty"));
+    expect(result.current.data.map((r) => r.qty)).toEqual([40, 75, 100]);
+    act(() => result.current.toggleSort("qty"));
+    expect(result.current.data.map((r) => r.qty)).toEqual([100, 75, 40]);
+  });
+
+  it("applies multi-select column filters and counts them", () => {
+    const { result } = renderHook(() => useTableState<Row>(data));
+    act(() => result.current.toggleFilter("sector", "Tech"));
+    expect(result.current.data.map((r) => r.symbol)).toEqual(["AAPL", "MSFT"]);
+    expect(result.current.filterCount).toBe(1);
+    act(() => result.current.toggleFilter("sector", "Tech"));
+    expect(result.current.resultCount).toBe(3);
+    expect(result.current.filterCount).toBe(0);
+  });
+
+  it("clears query, sort, and filters together", () => {
+    const { result } = renderHook(() => useTableState<Row>(data));
+    act(() => {
+      result.current.setQuery("tech");
+      result.current.toggleSort("qty");
+      result.current.toggleFilter("sector", "Tech");
+    });
+    act(() => result.current.clearAllFilters());
+    expect(result.current.query).toBe("");
+    expect(result.current.sortBy).toBeNull();
+    expect(result.current.filterCount).toBe(0);
+    expect(result.current.resultCount).toBe(3);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/data/use-table-state.ts
+++ b/src/Meridian.Ui/dashboard/src/components/data/use-table-state.ts
@@ -1,0 +1,175 @@
+// Meridian useTableState (Concrete) — lightweight query / sort / filter state for data
+// tables. One hook manages the search query, per-column multi-select filters, and sort;
+// its derived `data` feeds FilteredDataTable (and any DenseDataTable). Optionally persists
+// query/sort/filters to localStorage under a caller-supplied key.
+import { useEffect, useMemo, useState } from "react";
+
+export type SortDirection = "asc" | "desc";
+
+export interface TableSort {
+  column: string;
+  direction: SortDirection;
+}
+
+export type TableFilters = Record<string, string[] | undefined>;
+
+export interface TableState<Row = Record<string, unknown>> {
+  /** Rows after filter → search → sort. */
+  data: Row[];
+  /** The unfiltered source rows. */
+  rawData: Row[];
+  setData: (rows: Row[]) => void;
+  query: string;
+  setQuery: (q: string) => void;
+  sortBy: TableSort | null;
+  toggleSort: (column: string) => void;
+  filters: TableFilters;
+  toggleFilter: (column: string, value: string) => void;
+  clearAllFilters: () => void;
+  exportCSV: (filename?: string) => void;
+  /** Number of columns with at least one active filter value. */
+  filterCount: number;
+  /** Number of rows after all narrowing. */
+  resultCount: number;
+}
+
+function readValue(row: Record<string, unknown>, column: string): unknown {
+  return row[column];
+}
+
+/**
+ * Manage query / sort / filter state for a data table.
+ *
+ * @param initialData source rows.
+ * @param localStorageKey when provided, query/sort/filters persist under this key.
+ */
+export function useTableState<Row extends Record<string, unknown> = Record<string, unknown>>(
+  initialData: Row[] = [],
+  localStorageKey: string | null = null,
+): TableState<Row> {
+  const [data, setData] = useState<Row[]>(initialData);
+  const [query, setQuery] = useState("");
+  const [sortBy, setSortBy] = useState<TableSort | null>(null);
+  const [filters, setFilters] = useState<TableFilters>({});
+
+  // Restore persisted state on mount / key change.
+  useEffect(() => {
+    if (!localStorageKey || typeof localStorage === "undefined") return;
+    const saved = localStorage.getItem(localStorageKey);
+    if (!saved) return;
+    try {
+      const parsed = JSON.parse(saved) as {
+        query?: string;
+        sortBy?: TableSort | null;
+        filters?: TableFilters;
+      };
+      setQuery(parsed.query ?? "");
+      setSortBy(parsed.sortBy ?? null);
+      setFilters(parsed.filters ?? {});
+    } catch {
+      // Ignore malformed persisted state.
+    }
+  }, [localStorageKey]);
+
+  // Persist state when it changes.
+  useEffect(() => {
+    if (!localStorageKey || typeof localStorage === "undefined") return;
+    localStorage.setItem(localStorageKey, JSON.stringify({ query, sortBy, filters }));
+  }, [query, sortBy, filters, localStorageKey]);
+
+  const filtered = useMemo(() => {
+    let result = data;
+    for (const [column, values] of Object.entries(filters)) {
+      if (!values || values.length === 0) continue;
+      result = result.filter((row) => values.includes(String(readValue(row, column))));
+    }
+    return result;
+  }, [data, filters]);
+
+  const searched = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return filtered;
+    return filtered.filter((row) =>
+      Object.values(row).some((value) => String(value).toLowerCase().includes(q)),
+    );
+  }, [filtered, query]);
+
+  const sorted = useMemo(() => {
+    if (!sortBy) return searched;
+    const { column, direction } = sortBy;
+    const result = [...searched];
+    result.sort((a, b) => {
+      const aVal = readValue(a, column);
+      const bVal = readValue(b, column);
+      if (aVal === bVal) return 0;
+      const cmp = (aVal as never) < (bVal as never) ? -1 : 1;
+      return direction === "asc" ? cmp : -cmp;
+    });
+    return result;
+  }, [searched, sortBy]);
+
+  const toggleSort = (column: string) => {
+    setSortBy((current) =>
+      current?.column === column
+        ? { column, direction: current.direction === "asc" ? "desc" : "asc" }
+        : { column, direction: "asc" },
+    );
+  };
+
+  const toggleFilter = (column: string, value: string) => {
+    setFilters((current) => {
+      const existing = current[column] ?? [];
+      const updated = existing.includes(value)
+        ? existing.filter((v) => v !== value)
+        : [...existing, value];
+      return { ...current, [column]: updated.length > 0 ? updated : undefined };
+    });
+  };
+
+  const clearAllFilters = () => {
+    setQuery("");
+    setSortBy(null);
+    setFilters({});
+  };
+
+  const exportCSV = (filename = "data.csv") => {
+    if (sorted.length === 0 || typeof document === "undefined") return;
+    const headers = Object.keys(sorted[0]);
+    const csv = [
+      headers.join(","),
+      ...sorted.map((row) =>
+        headers
+          .map((h) => {
+            const value = readValue(row, h);
+            if (value === null || value === undefined) return "";
+            const str = String(value);
+            return str.includes(",") ? `"${str.replace(/"/g, '""')}"` : str;
+          })
+          .join(","),
+      ),
+    ].join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return {
+    data: sorted,
+    rawData: data,
+    setData,
+    query,
+    setQuery,
+    sortBy,
+    toggleSort,
+    filters,
+    toggleFilter,
+    clearAllFilters,
+    exportCSV,
+    filterCount: Object.values(filters).filter((v) => v && v.length > 0).length,
+    resultCount: sorted.length,
+  };
+}

--- a/src/Meridian.Ui/dashboard/src/components/operations/evidence-link.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/operations/evidence-link.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { EvidenceLink } from "./evidence-link";
+
+describe("EvidenceLink", () => {
+  it("renders as an anchor when href is set", () => {
+    render(<EvidenceLink label="Recon pack" status="Ready" route="evidence://recon/2026-06" href="#recon" />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "#recon");
+    expect(screen.getByText("Recon pack")).toBeInTheDocument();
+    expect(screen.getByText("evidence://recon/2026-06")).toBeInTheDocument();
+  });
+
+  it("renders as a button and fires onOpen when clicked", async () => {
+    const onOpen = vi.fn();
+    render(<EvidenceLink label="Approval" status="Missing" onOpen={onOpen} />);
+    const button = screen.getByRole("button");
+    await userEvent.click(button);
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it("tints the status dot by the resolved severity", () => {
+    const { container } = render(<EvidenceLink label="Break" status="Blocked" />);
+    expect(container.querySelector(".mds-evidence--blocked")).not.toBeNull();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/operations/evidence-link.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/operations/evidence-link.tsx
@@ -1,0 +1,90 @@
+// Meridian evidence link (Concrete) — a reference to an evidence artifact (the "evidence"
+// concept is central: readiness, reconciliation, provider, and report-pack evidence).
+// Mirrors the EvidenceStatus model (Unknown | Ready | ReviewRequired | Blocked | Stale |
+// Missing). Renders as a clickable chip: status dot, label, mono route, open arrow.
+// Renders as an <a> when `href` is set, otherwise a <button>.
+import type { AnchorHTMLAttributes, ButtonHTMLAttributes, ReactNode } from "react";
+import { injectStyle } from "./inject-style";
+import { normalizeSeverity } from "./status";
+
+const CSS = `
+.mds-evidence{display:inline-flex;align-items:center;gap:8px;max-width:100%;
+  border:1px solid var(--border,#D7DCE2);border-radius:var(--radius-chip,2px);
+  background:var(--bg-medium,#F5F7FA);padding:5px 9px;font-family:var(--font-body);font-size:12px;
+  color:var(--text-primary,#22272E);text-decoration:none;cursor:pointer;
+  transition:border-color 120ms ease,background-color 120ms ease;}
+.mds-evidence:hover{border-color:var(--border-hover,#ADB8C4);background:var(--bg-hover,#F1F4F7);}
+.mds-evidence:focus-visible{outline:var(--focus-ring,2px solid #2F6F8F);outline-offset:var(--focus-ring-offset,2px);}
+.mds-evidence__dot{width:7px;height:7px;border-radius:50%;flex:0 0 auto;background:var(--state-muted-fg,#6E7781);}
+.mds-evidence--ready .mds-evidence__dot{background:var(--state-healthy-fg,#16885F);}
+.mds-evidence--review .mds-evidence__dot{background:var(--state-paper-fg,#2F6F8F);}
+.mds-evidence--action .mds-evidence__dot{background:var(--state-warn-fg,#8A520E);}
+.mds-evidence--blocked .mds-evidence__dot{background:var(--state-danger-fg,#BA3F55);}
+.mds-evidence__label{font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.mds-evidence__route{font-family:var(--font-data,monospace);font-size:10px;color:var(--text-muted,#59636F);
+  overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0;}
+.mds-evidence__arrow{margin-left:auto;color:var(--text-muted,#59636F);flex:0 0 auto;font-size:11px;}
+`;
+
+type EvidenceLinkOwnProps = {
+  /** Evidence label. */
+  label?: ReactNode;
+  /** Evidence status (Ready, ReviewRequired, Blocked, Stale, Missing, …). @default "info" */
+  status?: string;
+  /** Mono route / identifier (e.g. an evidence:// URI). */
+  route?: ReactNode;
+  /** If set, renders an anchor to this href. */
+  href?: string;
+  /** Click handler (when used as a button). */
+  onOpen?: () => void;
+};
+
+export type EvidenceLinkProps = EvidenceLinkOwnProps &
+  Omit<
+    AnchorHTMLAttributes<HTMLAnchorElement> & ButtonHTMLAttributes<HTMLButtonElement>,
+    keyof EvidenceLinkOwnProps
+  >;
+
+/**
+ * Evidence link — a clickable reference to an evidence artifact.
+ *
+ * @example
+ * <EvidenceLink label="Recon pack" status="Ready" route="evidence://recon/2026-06" href="#" />
+ * <EvidenceLink label="Approval"   status="Missing" route="evidence://approval/pending" onOpen={open} />
+ */
+export function EvidenceLink({
+  label,
+  status = "info",
+  route,
+  href,
+  onOpen,
+  className,
+  ...rest
+}: EvidenceLinkProps) {
+  injectStyle("evidence-link", CSS);
+  const sev = normalizeSeverity(status);
+  const cls = `mds-evidence mds-evidence--${sev}${className ? " " + className : ""}`;
+  const body = (
+    <>
+      <span className="mds-evidence__dot" aria-hidden="true" />
+      {label && <span className="mds-evidence__label">{label}</span>}
+      {route && <span className="mds-evidence__route">{route}</span>}
+      <span className="mds-evidence__arrow" aria-hidden="true">
+        ↗
+      </span>
+    </>
+  );
+
+  if (href) {
+    return (
+      <a className={cls} href={href} onClick={onOpen} {...rest}>
+        {body}
+      </a>
+    );
+  }
+  return (
+    <button type="button" className={cls} onClick={onOpen} {...rest}>
+      {body}
+    </button>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/operations/gate-rail.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/operations/gate-rail.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { GateRail } from "./gate-rail";
+
+const gates = [
+  { key: "BrokerIngest", label: "Broker ingest", status: "Passed" },
+  { key: "SecurityMaster", label: "Security master", status: "Passed" },
+  { key: "LedgerPosting", label: "Ledger posting", status: "InProgress" },
+  { key: "Reconciliation", label: "Reconciliation", status: "ReviewRequired" },
+  { key: "Approval", label: "Approval", status: "NotStarted" },
+];
+
+describe("GateRail", () => {
+  it("renders one node per gate with its label", () => {
+    const { container } = render(<GateRail gates={gates} />);
+    expect(container.querySelectorAll(".mds-gate")).toHaveLength(gates.length);
+    expect(screen.getByText("Broker ingest")).toBeInTheDocument();
+    expect(screen.getByText("Approval")).toBeInTheDocument();
+  });
+
+  it("tints nodes by status and marks passed gates with a check glyph", () => {
+    const { container } = render(<GateRail gates={gates} />);
+    expect(container.querySelectorAll(".mds-gate--ready")).toHaveLength(2);
+    expect(container.querySelector(".mds-gate--review")).not.toBeNull();
+    expect(container.querySelector(".mds-gate--info")).not.toBeNull();
+    expect(screen.getAllByText("✓").length).toBeGreaterThan(0);
+  });
+
+  it("exposes an accessible label combining gate and humanized status", () => {
+    render(<GateRail gates={gates} />);
+    expect(screen.getByLabelText("Ledger posting: In Progress")).toBeInTheDocument();
+  });
+
+  it("renders nothing catastrophic for an empty gate list", () => {
+    const { container } = render(<GateRail gates={[]} />);
+    expect(container.querySelectorAll(".mds-gate")).toHaveLength(0);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/operations/gate-rail.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/operations/gate-rail.tsx
@@ -1,0 +1,83 @@
+// Meridian gate rail (Concrete) — the operations pipeline as a connected horizontal
+// stepper. Renders the operator workflow: BrokerIngest → SecurityMaster → LedgerPosting
+// → Reconciliation → Approval (or any gate list). Each node is tinted by its status
+// (Passed / InProgress / ReviewRequired / Blocked / NotStarted) and the connector into a
+// node turns green once the preceding gate has Passed.
+import type { CSSProperties, ReactNode } from "react";
+import { injectStyle } from "./inject-style";
+import { normalizeSeverity, humanizeStatus, type SeverityKey } from "./status";
+
+const CSS = `
+.mds-gates{display:flex;list-style:none;margin:0;padding:0;gap:0;min-width:0;}
+.mds-gate{position:relative;flex:1 1 0;display:flex;flex-direction:column;align-items:center;
+  gap:6px;text-align:center;padding:0 4px;min-width:0;}
+.mds-gate:not(:first-child)::before{content:"";position:absolute;top:13px;left:calc(-50% + 14px);
+  width:calc(100% - 28px);height:2px;background:var(--mds-gate-line,var(--border,#D7DCE2));z-index:0;}
+.mds-gate__node{position:relative;z-index:1;display:inline-flex;align-items:center;justify-content:center;
+  width:28px;height:28px;border-radius:50%;border:1.5px solid var(--severity-info-bd,#D7DCE2);
+  background:var(--bg-panel,var(--bg-light,#fff));color:var(--severity-info-fg,#6E7781);
+  font-family:var(--font-data,monospace);font-size:11px;font-weight:700;}
+.mds-gate--ready .mds-gate__node{border-color:var(--severity-ready-fg,#16885F);background:var(--severity-ready-bg,rgba(22,136,95,.10));color:var(--severity-ready-fg,#16885F);}
+.mds-gate--review .mds-gate__node{border-color:var(--severity-review-fg,#2F6F8F);background:var(--severity-review-bg,rgba(47,111,143,.10));color:var(--severity-review-fg,#2F6F8F);}
+.mds-gate--action .mds-gate__node{border-color:var(--severity-action-fg,#8A520E);background:var(--severity-action-bg,rgba(138,82,14,.11));color:var(--severity-action-fg,#8A520E);}
+.mds-gate--blocked .mds-gate__node{border-color:var(--severity-blocked-fg,#BA3F55);background:var(--severity-blocked-bg,rgba(186,63,85,.10));color:var(--severity-blocked-fg,#BA3F55);}
+.mds-gate__label{font-family:var(--font-body);font-size:11px;font-weight:600;color:var(--text-primary,#22272E);line-height:1.2;}
+.mds-gate__status{font-family:var(--font-data,monospace);font-size:9px;font-weight:700;letter-spacing:.04em;
+  text-transform:uppercase;color:var(--text-muted,#59636F);}
+`;
+
+const GLYPH: Partial<Record<SeverityKey, string>> = { ready: "✓", blocked: "!" };
+
+export interface GateRailGate {
+  /** Stable key (e.g. an OperationsGateKey). */
+  key?: string;
+  /** Gate label shown under the node. */
+  label: ReactNode;
+  /** Gate status string — normalized to ready · review · action · blocked · info. */
+  status: string;
+  /** Override the auto-humanized status caption. */
+  statusLabel?: ReactNode;
+}
+
+export interface GateRailProps {
+  gates: GateRailGate[];
+  className?: string;
+}
+
+/**
+ * Gate rail — the operations pipeline as a connected horizontal stepper.
+ *
+ * @example
+ * <GateRail gates={[
+ *   { key: "BrokerIngest",   label: "Broker ingest",   status: "Passed" },
+ *   { key: "SecurityMaster", label: "Security master", status: "Passed" },
+ *   { key: "LedgerPosting",  label: "Ledger posting",  status: "InProgress" },
+ *   { key: "Reconciliation", label: "Reconciliation",  status: "ReviewRequired" },
+ *   { key: "Approval",       label: "Approval",        status: "NotStarted" },
+ * ]} />
+ */
+export function GateRail({ gates = [], className }: GateRailProps) {
+  injectStyle("gate-rail", CSS);
+  return (
+    <ol className={`mds-gates${className ? " " + className : ""}`}>
+      {gates.map((g, i) => {
+        const sev = normalizeSeverity(g.status);
+        const prevReady = i > 0 && normalizeSeverity(gates[i - 1].status) === "ready";
+        const line = prevReady ? "var(--severity-ready-fg,#16885F)" : "var(--border,#D7DCE2)";
+        const style = { "--mds-gate-line": line } as CSSProperties;
+        return (
+          <li
+            key={g.key || i}
+            className={`mds-gate mds-gate--${sev}`}
+            style={style}
+            aria-label={`${g.label}: ${humanizeStatus(g.status)}`}
+          >
+            <span className="mds-gate__node">{GLYPH[sev] ?? i + 1}</span>
+            <span className="mds-gate__label">{g.label}</span>
+            <span className="mds-gate__status">{g.statusLabel || humanizeStatus(g.status)}</span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/operations/index.ts
+++ b/src/Meridian.Ui/dashboard/src/components/operations/index.ts
@@ -1,0 +1,26 @@
+// Meridian "Concrete" operations component library — the operator-readiness layer.
+//
+// NEW shared components for the browser workstation, natively re-implemented from the
+// Meridian Design System handoff (React 18 + TypeScript + Tailwind 3). Wave 2 screens
+// adopt these; nothing imports them yet. Design tokens (`--severity-*`, `--state-*`,
+// `--border`, `--accent`, `--bg-*`, `--text-*`) are owned by sibling U1; every consumer
+// here reads them with a hex fallback so this library is independently mergeable.
+
+export {
+  normalizeSeverity,
+  humanizeStatus,
+  severityKeys,
+  severityLabels,
+  type SeverityKey,
+} from "./status";
+export { SeverityBadge, type SeverityBadgeProps } from "./severity-badge";
+export { ReadinessPanel, type ReadinessPanelProps } from "./readiness-panel";
+export { GateRail, type GateRailProps, type GateRailGate } from "./gate-rail";
+export {
+  ValidationIssueList,
+  type ValidationIssueListProps,
+  type ValidationIssue,
+} from "./validation-issue-list";
+export { EvidenceLink, type EvidenceLinkProps } from "./evidence-link";
+export { TrustStrip, type TrustStripProps, type TrustStripItem } from "./trust-strip";
+export { WorkspaceSection, type WorkspaceSectionProps } from "./workspace-section";

--- a/src/Meridian.Ui/dashboard/src/components/operations/inject-style.ts
+++ b/src/Meridian.Ui/dashboard/src/components/operations/inject-style.ts
@@ -1,0 +1,23 @@
+// Scoped-stylesheet injection helper for the Concrete design-system components.
+//
+// Each native component injects its own stylesheet once (keyed by a `data-mds`
+// attribute), mirroring the handoff bundle's per-component CSS injection. This helper
+// centralises the idempotency guard so every component doesn't re-implement the
+// `injected` boolean + document-guard boilerplate. Safe to call on every render and
+// in non-DOM (SSR / unit-test import) environments.
+
+const injectedKeys = new Set<string>();
+
+/**
+ * Inject `css` into `<head>` exactly once per `key`. No-op when there is no `document`
+ * (e.g. server render) or when the key has already been injected.
+ */
+export function injectStyle(key: string, css: string): void {
+  if (injectedKeys.has(key)) return;
+  injectedKeys.add(key);
+  if (typeof document === "undefined") return;
+  const el = document.createElement("style");
+  el.setAttribute("data-mds", key);
+  el.textContent = css;
+  document.head.appendChild(el);
+}

--- a/src/Meridian.Ui/dashboard/src/components/operations/readiness-panel.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/operations/readiness-panel.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ReadinessPanel } from "./readiness-panel";
+
+describe("ReadinessPanel", () => {
+  it("renders title, detail, score, and the state badge", () => {
+    render(
+      <ReadinessPanel
+        state="ReviewRequired"
+        score="86 / 100"
+        title="Reconciliation"
+        detail="3 open exceptions above tolerance."
+      />,
+    );
+    expect(screen.getByText("Reconciliation")).toBeInTheDocument();
+    expect(screen.getByText("3 open exceptions above tolerance.")).toBeInTheDocument();
+    expect(screen.getByText("86 / 100")).toBeInTheDocument();
+    expect(screen.getByText("Review")).toBeInTheDocument();
+  });
+
+  it("tints the panel by the resolved severity", () => {
+    const { container } = render(<ReadinessPanel state="Blocked" title="Ledger" />);
+    expect(container.querySelector(".mds-rpanel--blocked")).not.toBeNull();
+  });
+
+  it("renders footer actions and body children", () => {
+    render(
+      <ReadinessPanel state="Ready" title="Approval" actions={<button>Approve</button>}>
+        <span>lane body</span>
+      </ReadinessPanel>,
+    );
+    expect(screen.getByRole("button", { name: "Approve" })).toBeInTheDocument();
+    expect(screen.getByText("lane body")).toBeInTheDocument();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/operations/readiness-panel.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/operations/readiness-panel.tsx
@@ -1,0 +1,82 @@
+// Meridian readiness panel (Concrete) — mirrors the desktop `.panel-state`.
+//
+// A gate / readiness summary block: a SeverityBadge state label + optional score, a
+// title, a detail line, optional body content, and a right-aligned action footer. The
+// left rail and border tint track `state`. The workhorse for "this lane is
+// ReviewRequired because…" panels across Operations, Accounting, and Data.
+import type { ReactNode } from "react";
+import { injectStyle } from "./inject-style";
+import { SeverityBadge } from "./severity-badge";
+import { normalizeSeverity } from "./status";
+
+const CSS = `
+.mds-rpanel{display:grid;gap:8px;min-width:0;border:1px solid var(--severity-info-bd,#D7DCE2);
+  border-left:3px solid var(--severity-info-fg,#6E7781);border-radius:var(--radius-card,2px);
+  background:var(--bg-panel,var(--bg-light,#fff));padding:12px 14px;}
+.mds-rpanel--ready{border-color:var(--severity-ready-bd,rgba(22,136,95,.36));border-left-color:var(--severity-ready-fg,#16885F);}
+.mds-rpanel--review{border-color:var(--severity-review-bd,rgba(47,111,143,.36));border-left-color:var(--severity-review-fg,#2F6F8F);}
+.mds-rpanel--action{border-color:var(--severity-action-bd,rgba(138,82,14,.42));border-left-color:var(--severity-action-fg,#8A520E);}
+.mds-rpanel--blocked{border-color:var(--severity-blocked-bd,rgba(186,63,85,.40));border-left-color:var(--severity-blocked-fg,#BA3F55);}
+.mds-rpanel__head{display:flex;align-items:center;justify-content:space-between;gap:10px;min-width:0;}
+.mds-rpanel__score{font-family:var(--font-data,monospace);font-size:11px;font-weight:700;
+  color:var(--text-secondary,#4D5967);font-variant-numeric:tabular-nums;white-space:nowrap;}
+.mds-rpanel__title{margin:0;color:var(--text-primary,#22272E);font-size:13px;font-weight:700;line-height:1.25;
+  overflow:hidden;text-overflow:ellipsis;}
+.mds-rpanel__detail{margin:0;color:var(--text-muted,#59636F);font-size:12px;line-height:1.45;}
+.mds-rpanel__foot{display:flex;flex-wrap:wrap;gap:8px;align-items:center;justify-content:flex-end;
+  border-top:1px solid var(--border,#D7DCE2);padding-top:10px;margin-top:2px;}
+`;
+
+export interface ReadinessPanelProps {
+  /** Readiness status string (Ready, ReviewRequired, Blocked, …). @default "info" */
+  state?: string;
+  /** Override the badge label (defaults to the canonical severity name). */
+  statusLabel?: ReactNode;
+  /** Bold panel title. */
+  title?: ReactNode;
+  /** Muted supporting detail line. */
+  detail?: ReactNode;
+  /** Optional mono score / metric shown top-right (e.g. "86 / 100"). */
+  score?: ReactNode;
+  /** Right-aligned action footer (buttons). */
+  actions?: ReactNode;
+  /** Extra body content between the detail line and the footer. */
+  children?: ReactNode;
+}
+
+/**
+ * Readiness panel — a gate / readiness summary block led by a {@link SeverityBadge}.
+ *
+ * @example
+ * <ReadinessPanel
+ *   state="ReviewRequired"
+ *   score="86 / 100"
+ *   title="Reconciliation"
+ *   detail="3 open exceptions above tolerance in the custody cash lane."
+ *   actions={<><Button variant="ghost">Investigate</Button><Button variant="primary">Approve</Button></>}
+ * />
+ */
+export function ReadinessPanel({
+  state = "info",
+  statusLabel,
+  title,
+  detail,
+  score,
+  actions,
+  children,
+}: ReadinessPanelProps) {
+  injectStyle("readiness-panel", CSS);
+  const sev = normalizeSeverity(state);
+  return (
+    <div className={`mds-rpanel mds-rpanel--${sev}`}>
+      <div className="mds-rpanel__head">
+        <SeverityBadge status={state} label={statusLabel} />
+        {score != null && <span className="mds-rpanel__score">{score}</span>}
+      </div>
+      {title && <p className="mds-rpanel__title">{title}</p>}
+      {detail && <p className="mds-rpanel__detail">{detail}</p>}
+      {children}
+      {actions && <div className="mds-rpanel__foot">{actions}</div>}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/operations/severity-badge.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/operations/severity-badge.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SeverityBadge } from "./severity-badge";
+
+describe("SeverityBadge", () => {
+  it("renders the canonical label for a normalized status", () => {
+    render(<SeverityBadge status="ReviewRequired" />);
+    expect(screen.getByText("Review")).toBeInTheDocument();
+  });
+
+  it("applies the severity class for the resolved severity", () => {
+    const { container } = render(<SeverityBadge status="Blocked" />);
+    expect(container.querySelector(".mds-sev--blocked")).not.toBeNull();
+  });
+
+  it("honours a custom label and defaults to info", () => {
+    render(<SeverityBadge label="3 breaks" />);
+    expect(screen.getByText("3 breaks")).toBeInTheDocument();
+  });
+
+  it("omits the status dot when dot is false", () => {
+    const { container } = render(<SeverityBadge status="Ready" dot={false} />);
+    expect(container.querySelector(".mds-sev__dot")).toBeNull();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/operations/severity-badge.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/operations/severity-badge.tsx
@@ -1,0 +1,60 @@
+// Meridian severity badge (Concrete) — mirrors the desktop `.severity-badge`.
+//
+// The operator status chip: mono, 9px, uppercase, alpha-10 wash + solid semantic border
+// (never a solid fill). Accepts any of the platform's readiness / severity strings
+// (Ready, ReviewRequired, Blocked, Critical, Stale, …) and collapses them onto the five
+// canonical severities via `normalizeSeverity`.
+import type { HTMLAttributes, ReactNode } from "react";
+import { injectStyle } from "./inject-style";
+import { normalizeSeverity, severityLabels } from "./status";
+
+const CSS = `
+.mds-sev{display:inline-flex;align-items:center;gap:5px;width:fit-content;max-width:100%;
+  min-height:20px;border:1px solid var(--severity-info-bd,#D7DCE2);border-radius:var(--radius-chip,2px);
+  background:var(--severity-info-bg,#F5F7FA);color:var(--severity-info-fg,#6E7781);
+  font-family:var(--font-data,"Cascadia Mono","JetBrains Mono",monospace);font-size:9px;font-weight:700;line-height:1;
+  letter-spacing:.04em;padding:0 7px;text-transform:uppercase;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.mds-sev__dot{height:5px;width:5px;border-radius:50%;background:currentColor;flex:0 0 auto;}
+.mds-sev--ready{border-color:var(--severity-ready-bd,rgba(22,136,95,.36));background:var(--severity-ready-bg,rgba(22,136,95,.10));color:var(--severity-ready-fg,#16885F);}
+.mds-sev--review{border-color:var(--severity-review-bd,rgba(47,111,143,.36));background:var(--severity-review-bg,rgba(47,111,143,.10));color:var(--severity-review-fg,#2F6F8F);}
+.mds-sev--action{border-color:var(--severity-action-bd,rgba(138,82,14,.42));background:var(--severity-action-bg,rgba(138,82,14,.11));color:var(--severity-action-fg,#8A520E);}
+.mds-sev--blocked{border-color:var(--severity-blocked-bd,rgba(186,63,85,.40));background:var(--severity-blocked-bg,rgba(186,63,85,.10));color:var(--severity-blocked-fg,#BA3F55);}
+.mds-sev--info{border-color:var(--severity-info-bd,#D7DCE2);background:var(--severity-info-bg,#F5F7FA);color:var(--severity-info-fg,#6E7781);}
+`;
+
+export interface SeverityBadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  /**
+   * Any Meridian readiness / severity string. Normalized to
+   * ready · review · action · blocked · info.
+   * @default "info"
+   */
+  status?: string;
+  /** Override the auto label (defaults to the canonical severity name). */
+  label?: ReactNode;
+  /** Prepend a filled status dot. @default true */
+  dot?: boolean;
+}
+
+/**
+ * Operator status chip — the single most-used status encoding in Meridian.
+ *
+ * @example
+ * <SeverityBadge status="ReviewRequired" />          // → "Review" (steel-blue)
+ * <SeverityBadge status="Blocked" label="3 breaks" /> // custom label, brick-red
+ */
+export function SeverityBadge({
+  status = "info",
+  label,
+  dot = true,
+  className,
+  ...rest
+}: SeverityBadgeProps) {
+  injectStyle("severity-badge", CSS);
+  const sev = normalizeSeverity(status);
+  return (
+    <span className={`mds-sev mds-sev--${sev}${className ? " " + className : ""}`} {...rest}>
+      {dot && <span className="mds-sev__dot" aria-hidden="true" />}
+      {label != null ? label : severityLabels[sev]}
+    </span>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/operations/status.test.ts
+++ b/src/Meridian.Ui/dashboard/src/components/operations/status.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSeverity, humanizeStatus, severityKeys, severityLabels } from "./status";
+
+describe("normalizeSeverity", () => {
+  it("collapses platform status strings onto the five canonical severities", () => {
+    expect(normalizeSeverity("Ready")).toBe("ready");
+    expect(normalizeSeverity("Passed")).toBe("ready");
+    expect(normalizeSeverity("ReviewRequired")).toBe("review");
+    expect(normalizeSeverity("InProgress")).toBe("review");
+    expect(normalizeSeverity("Stale")).toBe("action");
+    expect(normalizeSeverity("Warning")).toBe("action");
+    expect(normalizeSeverity("Blocked")).toBe("blocked");
+    expect(normalizeSeverity("Critical")).toBe("blocked");
+  });
+
+  it("is punctuation- and case-insensitive", () => {
+    expect(normalizeSeverity("review-required")).toBe("review");
+    expect(normalizeSeverity("Review_Required")).toBe("review");
+    expect(normalizeSeverity("LIVE / LINKED")).toBe("ready");
+  });
+
+  it("falls back to info for unknown, empty, or nullish input", () => {
+    expect(normalizeSeverity("NotStarted")).toBe("info");
+    expect(normalizeSeverity("gibberish")).toBe("info");
+    expect(normalizeSeverity("")).toBe("info");
+    expect(normalizeSeverity(undefined)).toBe("info");
+    expect(normalizeSeverity(null)).toBe("info");
+  });
+
+  it("only ever returns a known severity key with a label", () => {
+    for (const s of ["Ready", "x", "", "Blocked", "Weird-99"]) {
+      const sev = normalizeSeverity(s);
+      expect(severityKeys).toContain(sev);
+      expect(severityLabels[sev]).toBeTruthy();
+    }
+  });
+});
+
+describe("humanizeStatus", () => {
+  it("splits camelCase and separators into words", () => {
+    expect(humanizeStatus("ReviewRequired")).toBe("Review Required");
+    expect(humanizeStatus("NotStarted")).toBe("Not Started");
+    expect(humanizeStatus("in_progress")).toBe("In progress");
+    expect(humanizeStatus("")).toBe("");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/operations/status.ts
+++ b/src/Meridian.Ui/dashboard/src/components/operations/status.ts
@@ -1,0 +1,68 @@
+// Meridian operator status vocabulary (Concrete design system).
+//
+// The platform classifies nearly everything as a readiness state. Across the type
+// model the recurring status strings are: Ready · ReviewRequired · Blocked · Unknown ·
+// Missing · Stale · NotStarted · InProgress · Passed, plus validation severities
+// Info · Warning · Critical. This helper collapses all of them onto the five canonical
+// operator severities the visual system encodes: ready · review · action · blocked ·
+// info — mirroring the `.severity-badge` classes in the desktop stylesheet.
+//
+// Re-implemented natively in TypeScript for the browser workstation; sibling U1 owns the
+// `--severity-*` / `--state-*` design tokens, so every consumer here reads tokens with a
+// hex fallback that matches the handoff output.
+
+/** The five canonical operator severities the Concrete visual system encodes. */
+export type SeverityKey = "ready" | "review" | "action" | "blocked" | "info";
+
+export const severityKeys: readonly SeverityKey[] = [
+  "ready",
+  "review",
+  "action",
+  "blocked",
+  "info",
+];
+
+export const severityLabels: Record<SeverityKey, string> = {
+  ready: "Ready",
+  review: "Review",
+  action: "Action",
+  blocked: "Blocked",
+  info: "Info",
+};
+
+const SEVERITY_MAP: Record<string, SeverityKey> = {
+  // ready / green
+  ready: "ready", passed: "ready", healthy: "ready", complete: "ready", completed: "ready",
+  cleared: "ready", certified: "ready", approved: "ready", posted: "ready", live: "ready",
+  linked: "ready", livelinked: "ready", verified: "ready", success: "ready", ok: "ready",
+  // review / steel-blue
+  review: "review", reviewrequired: "review", inreview: "review", inprogress: "review",
+  reviewerassigned: "review", submitted: "review", awaitingoperatordecision: "review",
+  readyforreview: "review", running: "review", queued: "review", sourcebacked: "review",
+  // action / ochre — needs operator attention but not hard-blocked
+  action: "action", needsattention: "action", needsfix: "action", warning: "action",
+  degraded: "action", attention: "action", exceptionsopen: "action", stale: "action",
+  reviewrequiredsoon: "action", drafted: "action", deferred: "action",
+  // blocked / brick-red
+  blocked: "blocked", critical: "blocked", failed: "blocked", rejected: "blocked",
+  error: "blocked", blocker: "blocked",
+  // info / muted — unknown, not yet started, absent
+  info: "info", unknown: "info", notstarted: "info", missing: "info", pending: "info",
+  draft: "info", neutral: "info", notrequired: "info", default: "info", "": "info",
+};
+
+/** Collapse any Meridian status / severity string onto one of the 5 canonical severities. */
+export function normalizeSeverity(status?: string | null): SeverityKey {
+  if (!status) return "info";
+  const key = String(status).toLowerCase().replace(/[^a-z]/g, "");
+  return SEVERITY_MAP[key] ?? "info";
+}
+
+/** `"ReviewRequired"` → `"Review Required"`; `"NotStarted"` → `"Not Started"`. */
+export function humanizeStatus(status?: string | null): string {
+  if (!status) return "";
+  return String(status)
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .replace(/^./, (c) => c.toUpperCase());
+}

--- a/src/Meridian.Ui/dashboard/src/components/operations/trust-strip.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/operations/trust-strip.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TrustStrip } from "./trust-strip";
+
+const items = [
+  { label: "Readiness", value: "86 / 100", state: "review" },
+  { label: "Recon", value: "3 breaks", state: "blocked" },
+  { label: "Providers", value: "4 live", state: "ready" },
+  { label: "Approval", value: "Pending", state: "pending" },
+];
+
+describe("TrustStrip", () => {
+  it("renders a label/value item per entry", () => {
+    const { container } = render(<TrustStrip items={items} />);
+    expect(container.querySelectorAll(".mds-trust__item")).toHaveLength(4);
+    expect(screen.getByText("Readiness")).toBeInTheDocument();
+    expect(screen.getByText("86 / 100")).toBeInTheDocument();
+  });
+
+  it("maps trust states to their tint classes (review reads as attention/ochre)", () => {
+    const { container } = render(<TrustStrip items={items} />);
+    expect(container.querySelector(".mds-trust__item--review")).not.toBeNull();
+    expect(container.querySelector(".mds-trust__item--blocked")).not.toBeNull();
+    expect(container.querySelector(".mds-trust__item--ready")).not.toBeNull();
+    expect(container.querySelector(".mds-trust__item--pending")).not.toBeNull();
+  });
+
+  it("falls back to a muted item for an unknown state", () => {
+    const { container } = render(<TrustStrip items={[{ label: "X", value: "y" }]} />);
+    expect(container.querySelector(".mds-trust__item--muted")).not.toBeNull();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/operations/trust-strip.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/operations/trust-strip.tsx
@@ -1,0 +1,78 @@
+// Meridian trust strip (Concrete) — mirrors the desktop `.workstation-trust-strip`.
+//
+// The masthead readiness band: a row of label/value items tinted by state
+// (ready · review · blocked · pending), surfacing the operator's evidence posture at a
+// glance. Note: per the app, "review" reads ochre here (attention) rather than the
+// steel-blue used by SeverityBadge, and "pending" carries a distinct purple tint.
+import type { ReactNode } from "react";
+import { injectStyle } from "./inject-style";
+
+const CSS = `
+.mds-trust{display:flex;flex-wrap:wrap;align-items:stretch;gap:8px;min-width:0;}
+.mds-trust__item{display:flex;flex-direction:column;gap:2px;min-width:0;
+  border:1px solid var(--state-muted-bd,#D7DCE2);border-left-width:3px;border-radius:var(--radius-chip,2px);
+  background:var(--state-muted-bg,#F5F7FA);padding:5px 10px;}
+.mds-trust__item--ready{border-color:var(--state-healthy-bd,rgba(22,136,95,.32));border-left-color:var(--state-healthy-fg,#16885F);background:var(--state-healthy-bg,rgba(22,136,95,.10));}
+.mds-trust__item--review{border-color:var(--state-warn-bd,rgba(138,82,14,.38));border-left-color:var(--state-warn-fg,#8A520E);background:var(--state-warn-bg,rgba(138,82,14,.11));}
+.mds-trust__item--blocked{border-color:var(--state-danger-bd,rgba(186,63,85,.35));border-left-color:var(--state-danger-fg,#BA3F55);background:var(--state-danger-bg,rgba(186,63,85,.10));}
+.mds-trust__item--pending{border-color:var(--state-pending-bd,rgba(111,91,167,.34));border-left-color:var(--state-pending-fg,#6F5BA7);background:var(--state-pending-bg,rgba(111,91,167,.10));}
+.mds-trust__label{font-family:var(--font-data,monospace);font-size:9px;font-weight:700;text-transform:uppercase;
+  letter-spacing:.05em;color:var(--text-muted,#59636F);white-space:nowrap;}
+.mds-trust__value{font-family:var(--font-body);font-size:12px;font-weight:600;color:var(--text-primary,#22272E);white-space:nowrap;}
+`;
+
+type TrustState = "ready" | "review" | "blocked" | "pending" | "muted";
+
+const STATE: Record<string, TrustState> = {
+  ready: "ready", passed: "ready", healthy: "ready", live: "ready", certified: "ready", approved: "ready",
+  review: "review", reviewrequired: "review", inreview: "review", warning: "review", attention: "review",
+  needsattention: "review", inprogress: "review",
+  blocked: "blocked", critical: "blocked", failed: "blocked", degraded: "blocked",
+  pending: "pending", submitted: "pending", queued: "pending", strategy: "pending", paper: "pending",
+};
+
+function trustState(s?: string): TrustState {
+  if (!s) return "muted";
+  return STATE[String(s).toLowerCase().replace(/[^a-z]/g, "")] ?? "muted";
+}
+
+export interface TrustStripItem {
+  /** Small-caps label. */
+  label: ReactNode;
+  /** Mono/short value. */
+  value: ReactNode;
+  /** State tint — Ready | ReviewRequired | Blocked | Pending (and aliases). */
+  state?: string;
+}
+
+export interface TrustStripProps {
+  items: TrustStripItem[];
+  className?: string;
+}
+
+/**
+ * Trust strip — the masthead readiness band giving operators an at-a-glance evidence
+ * posture. Per the app, `review` reads ochre (attention) here rather than the steel-blue
+ * used by {@link SeverityBadge}.
+ *
+ * @example
+ * <TrustStrip items={[
+ *   { label: "Readiness", value: "86 / 100", state: "review" },
+ *   { label: "Recon",     value: "3 breaks", state: "blocked" },
+ *   { label: "Providers", value: "4 live",   state: "ready" },
+ *   { label: "Approval",  value: "Pending",  state: "pending" },
+ * ]} />
+ */
+export function TrustStrip({ items = [], className }: TrustStripProps) {
+  injectStyle("trust-strip", CSS);
+  return (
+    <div className={`mds-trust${className ? " " + className : ""}`}>
+      {items.map((it, i) => (
+        <div key={i} className={`mds-trust__item mds-trust__item--${trustState(it.state)}`}>
+          <span className="mds-trust__label">{it.label}</span>
+          <span className="mds-trust__value">{it.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/operations/validation-issue-list.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/operations/validation-issue-list.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ValidationIssueList } from "./validation-issue-list";
+
+const issues = [
+  { code: "RECON-204", severity: "Critical", message: "Custody cash break exceeds tolerance.", gate: "Reconciliation" },
+  { code: "MAP-118", severity: "Warning", message: "Provider field 'cusip' unmapped for 12 rows.", gate: "SecurityMaster" },
+  { code: "EVID-007", severity: "Info", message: "Approval evidence pack not yet generated." },
+];
+
+describe("ValidationIssueList", () => {
+  it("renders one row per issue with code, message, and gate", () => {
+    const { container } = render(<ValidationIssueList issues={issues} />);
+    expect(container.querySelectorAll(".mds-issue")).toHaveLength(3);
+    expect(screen.getByText("RECON-204")).toBeInTheDocument();
+    expect(screen.getByText("Custody cash break exceeds tolerance.")).toBeInTheDocument();
+    expect(screen.getByText("Reconciliation")).toBeInTheDocument();
+  });
+
+  it("maps validation severities onto issue tone classes", () => {
+    const { container } = render(<ValidationIssueList issues={issues} />);
+    expect(container.querySelector(".mds-issue--blocked")).not.toBeNull();
+    expect(container.querySelector(".mds-issue--action")).not.toBeNull();
+    expect(container.querySelector(".mds-issue--info")).not.toBeNull();
+  });
+
+  it("renders the empty label when there are no issues", () => {
+    render(<ValidationIssueList issues={[]} emptyLabel="All clear" />);
+    expect(screen.getByText("All clear")).toBeInTheDocument();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/operations/validation-issue-list.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/operations/validation-issue-list.tsx
@@ -1,0 +1,94 @@
+// Meridian validation issue list (Concrete) — the recurring `{ code, severity, message }`
+// validation pattern (ExtensibilityValidationIssue, EvidenceValidationIssue,
+// AccountingConfigurationValidationIssue, ProviderIntegrationValidationIssue, …).
+// Renders issues as compact rows: a severity dot, mono code, message, optional gate tag.
+// Validation severities Info / Warning / Critical collapse onto info / action / blocked.
+import type { ReactNode } from "react";
+import { injectStyle } from "./inject-style";
+import { normalizeSeverity } from "./status";
+
+const CSS = `
+.mds-issues{display:flex;flex-direction:column;border:1px solid var(--border,#D7DCE2);
+  border-radius:var(--radius-card,2px);overflow:hidden;background:var(--bg-panel,var(--bg-light,#fff));}
+.mds-issues__empty{padding:14px;text-align:center;color:var(--text-muted,#59636F);
+  font-family:var(--font-body);font-size:12px;}
+.mds-issue{display:grid;grid-template-columns:auto auto 1fr auto;gap:10px;align-items:baseline;
+  padding:9px 12px;border-top:1px solid var(--border,#D7DCE2);}
+.mds-issue:first-child{border-top:0;}
+.mds-issue--dense{padding:6px 10px;}
+.mds-issue__dot{align-self:center;width:7px;height:7px;border-radius:50%;flex:0 0 auto;
+  background:var(--severity-info-fg,#6E7781);}
+.mds-issue--blocked .mds-issue__dot{background:var(--severity-blocked-fg,#BA3F55);}
+.mds-issue--action .mds-issue__dot{background:var(--severity-action-fg,#8A520E);}
+.mds-issue--review .mds-issue__dot{background:var(--severity-review-fg,#2F6F8F);}
+.mds-issue--ready .mds-issue__dot{background:var(--severity-ready-fg,#16885F);}
+.mds-issue__code{font-family:var(--font-data,monospace);font-size:11px;font-weight:700;
+  color:var(--text-secondary,#4D5967);white-space:nowrap;}
+.mds-issue__msg{font-family:var(--font-body);font-size:12px;color:var(--text-primary,#22272E);line-height:1.4;min-width:0;}
+.mds-issue__gate{font-family:var(--font-data,monospace);font-size:9px;font-weight:700;text-transform:uppercase;
+  letter-spacing:.04em;color:var(--text-muted,#59636F);white-space:nowrap;}
+`;
+
+export interface ValidationIssue {
+  /** Stable issue code (mono). */
+  code?: string;
+  /** Severity string — Info | Warning | Critical (or any readiness status). */
+  severity: string;
+  /** Human-readable issue message. */
+  message: ReactNode;
+  /** Optional gate / scope tag shown at the row end. */
+  gate?: ReactNode;
+}
+
+export interface ValidationIssueListProps {
+  issues: ValidationIssue[];
+  /** Tighter row padding. @default false */
+  dense?: boolean;
+  /** Shown when `issues` is empty. @default "No issues" */
+  emptyLabel?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Validation issue list — the recurring Meridian `{ code, severity, message }` shape.
+ *
+ * @example
+ * <ValidationIssueList issues={[
+ *   { code: "RECON-204", severity: "Critical", message: "Custody cash break exceeds tolerance.", gate: "Reconciliation" },
+ *   { code: "MAP-118",   severity: "Warning",  message: "Provider field 'cusip' unmapped for 12 rows.", gate: "SecurityMaster" },
+ *   { code: "EVID-007",  severity: "Info",     message: "Approval evidence pack not yet generated." },
+ * ]} />
+ */
+export function ValidationIssueList({
+  issues = [],
+  dense = false,
+  emptyLabel = "No issues",
+  className,
+}: ValidationIssueListProps) {
+  injectStyle("validation-issues", CSS);
+  if (!issues.length) {
+    return (
+      <div className={`mds-issues${className ? " " + className : ""}`}>
+        <div className="mds-issues__empty">{emptyLabel}</div>
+      </div>
+    );
+  }
+  return (
+    <div className={`mds-issues${className ? " " + className : ""}`}>
+      {issues.map((it, i) => {
+        const sev = normalizeSeverity(it.severity);
+        return (
+          <div
+            key={it.code || i}
+            className={`mds-issue mds-issue--${sev}${dense ? " mds-issue--dense" : ""}`}
+          >
+            <span className="mds-issue__dot" aria-hidden="true" />
+            {it.code && <span className="mds-issue__code">{it.code}</span>}
+            <span className="mds-issue__msg">{it.message}</span>
+            {it.gate && <span className="mds-issue__gate">{it.gate}</span>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/operations/workspace-section.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/operations/workspace-section.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { WorkspaceSection } from "./workspace-section";
+
+describe("WorkspaceSection", () => {
+  it("renders title, summary, and body content", () => {
+    render(
+      <WorkspaceSection id="recon" title="Reconciliation" summary="3 open exceptions">
+        <p>lane content</p>
+      </WorkspaceSection>,
+    );
+    expect(screen.getByRole("heading", { name: "Reconciliation" })).toBeInTheDocument();
+    expect(screen.getByText("3 open exceptions")).toBeInTheDocument();
+    expect(screen.getByText("lane content")).toBeInTheDocument();
+  });
+
+  it("renders the jump affordance as an anchor when jumpHref is set", () => {
+    render(<WorkspaceSection title="R" jump="Open lane" jumpHref="#recon" />);
+    expect(screen.getByRole("link", { name: "Open lane" })).toHaveAttribute("href", "#recon");
+  });
+
+  it("renders the jump affordance as a button and fires onJump", async () => {
+    const onJump = vi.fn();
+    render(<WorkspaceSection title="R" jump="Open lane" onJump={onJump} />);
+    await userEvent.click(screen.getByRole("button", { name: "Open lane" }));
+    expect(onJump).toHaveBeenCalledOnce();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/operations/workspace-section.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/operations/workspace-section.tsx
@@ -1,0 +1,91 @@
+// Meridian workspace section (Concrete) — mirrors the desktop `.workspace-section-band`.
+//
+// A sticky section header (title + summary on the left, optional jump affordance on the
+// right) over a content body. Used to band an operator workspace into labelled,
+// jump-to-able regions that keep their heading pinned while the region scrolls.
+import type { ReactNode } from "react";
+import { injectStyle } from "./inject-style";
+
+const CSS = `
+.mds-wsection{display:grid;gap:12px;scroll-margin-top:12px;min-width:0;}
+.mds-wsection__head{position:sticky;top:0;z-index:15;display:flex;flex-wrap:wrap;align-items:center;
+  justify-content:space-between;gap:10px;min-width:0;
+  border:1px solid var(--border,#D7DCE2);border-radius:var(--radius-card,2px);background:var(--bg-medium,#F5F7FA);
+  padding:9px 12px;}
+.mds-wsection__heading{min-width:0;}
+.mds-wsection__title{margin:0;color:var(--text-primary,#22272E);font-size:13px;font-weight:700;line-height:1.2;}
+.mds-wsection__summary{margin:1px 0 0;color:var(--text-muted,#59636F);font-size:12px;line-height:1.35;}
+.mds-wsection__jump{display:inline-flex;align-items:center;gap:6px;min-height:30px;
+  border:1px solid var(--accent,#2F6F8F);border-radius:var(--radius-chip,2px);
+  background:var(--blue-a10,rgba(47,111,143,.10));color:var(--accent,#2F6F8F);
+  padding:4px 10px;font-family:var(--font-body);font-size:11px;font-weight:700;cursor:pointer;text-decoration:none;
+  white-space:nowrap;}
+.mds-wsection__jump:hover{background:var(--bg-active,#E6EEF5);}
+.mds-wsection__jump:focus-visible{outline:var(--focus-ring,2px solid #2F6F8F);outline-offset:2px;}
+.mds-wsection__body{display:grid;gap:12px;min-width:0;}
+`;
+
+export interface WorkspaceSectionProps {
+  /** Anchor id (for jump links / scroll-margin). */
+  id?: string;
+  /** Section title. */
+  title?: ReactNode;
+  /** Muted one-line summary under the title. */
+  summary?: ReactNode;
+  /** Jump affordance label (omit to hide). */
+  jump?: ReactNode;
+  /** Jump click handler (button mode). */
+  onJump?: () => void;
+  /** Jump href (anchor mode — takes precedence over onJump). */
+  jumpHref?: string;
+  children?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Workspace section — a sticky section header over a content body. Bands an operator
+ * workspace into labelled regions whose heading stays pinned while the region scrolls.
+ *
+ * @example
+ * <WorkspaceSection
+ *   id="reconciliation"
+ *   title="Reconciliation"
+ *   summary="3 open exceptions above tolerance · custody cash lane"
+ *   jump="Open lane" jumpHref="#recon"
+ * >
+ *   <ValidationIssueList issues={issues} />
+ * </WorkspaceSection>
+ */
+export function WorkspaceSection({
+  id,
+  title,
+  summary,
+  jump,
+  onJump,
+  jumpHref,
+  children,
+  className,
+}: WorkspaceSectionProps) {
+  injectStyle("workspace-section", CSS);
+  return (
+    <section id={id} className={`mds-wsection${className ? " " + className : ""}`}>
+      <div className="mds-wsection__head">
+        <div className="mds-wsection__heading">
+          {title && <h3 className="mds-wsection__title">{title}</h3>}
+          {summary && <p className="mds-wsection__summary">{summary}</p>}
+        </div>
+        {jump &&
+          (jumpHref ? (
+            <a className="mds-wsection__jump" href={jumpHref}>
+              {jump}
+            </a>
+          ) : (
+            <button type="button" className="mds-wsection__jump" onClick={onJump}>
+              {jump}
+            </button>
+          ))}
+      </div>
+      <div className="mds-wsection__body">{children}</div>
+    </section>
+  );
+}


### PR DESCRIPTION
Foundation wave (U4 of 5) of the Meridian web UI "Concrete" rework. New shared components: src/components/operations/* (SeverityBadge, ReadinessPanel, GateRail, ValidationIssueList, EvidenceLink, TrustStrip, WorkspaceSection) and src/components/data/* (DenseDataTable, FilteredDataTable, ExpandableDataTable, Pagination, ColumnChooser, EmptyState, Skeleton, KeyValueGrid, EntitySummary, MetricCard + useTableState), each with a TS props interface + co-located smoke test; tokens use hex fallbacks. Wave 2 screens adopt these. Finalized by coordinator after the worker stopped early — GitHub quality-gate CI is the authoritative validator; confirm CI green before merge.