### PR TITLE
Web UI Concrete — U5: charts + accounting components

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/accounting/AccountTree.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/AccountTree.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { AccountTree, type AccountNode } from "./AccountTree";
+
+const nodes: AccountNode[] = [
+  {
+    code: "1000",
+    name: "Assets",
+    children: [
+      { code: "1010", name: "Cash", balance: 4000 },
+      { code: "1020", name: "Receivables", balance: 1500 }
+    ]
+  }
+];
+
+describe("AccountTree", () => {
+  it("rolls up child balances onto a parent with no explicit balance", () => {
+    render(<AccountTree nodes={nodes} currency="USD" defaultExpandedDepth={1} />);
+    // 4000 + 1500 = 5500 rolled up to Assets
+    expect(screen.getByText("$5,500.00")).toBeInTheDocument();
+  });
+
+  it("renders leaf balances", () => {
+    render(<AccountTree nodes={nodes} currency="USD" defaultExpandedDepth={1} />);
+    expect(screen.getByText("$4,000.00")).toBeInTheDocument();
+    expect(screen.getByText("$1,500.00")).toBeInTheDocument();
+  });
+
+  it("exposes a tree role", () => {
+    render(<AccountTree nodes={nodes} />);
+    expect(screen.getByRole("tree", { name: "Chart of accounts" })).toBeInTheDocument();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/accounting/AccountTree.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/AccountTree.tsx
@@ -1,0 +1,174 @@
+// Meridian chart-of-accounts tree — an expandable account hierarchy with roll-up balances. A
+// parent with no explicit `balance` sums its descendants; parents render bold, leaves muted.
+// Disclosure triangles toggle branches; depth indents the name column; balances are mono and
+// right-aligned. Flat Concrete theme.
+import { useState } from "react";
+import type { ReactNode } from "react";
+import { AmountCell } from "./AmountCell";
+import { toNumber } from "./money";
+
+export interface AccountNode {
+  /** Account code/number (mono prefix). Also the expand/select key — must be unique. */
+  code: string;
+  name: string;
+  /** Explicit balance. Omit on a parent to roll up its children. */
+  balance?: number | string;
+  /** Optional classification tag (asset/liability/equity/revenue/expense) — for your own use. */
+  type?: string;
+  children?: AccountNode[];
+}
+
+export interface AccountTreeProps {
+  nodes: AccountNode[];
+  /** @default "USD" */
+  currency?: string;
+  /** Branches at or above this depth start expanded (root = 0). @default 1 */
+  defaultExpandedDepth?: number;
+  /** Code of the row to highlight with the accent rail. */
+  selectedCode?: string;
+  /** Row click handler — makes rows selectable. */
+  onSelect?: (node: AccountNode) => void;
+  /** Header label over the balance column. @default "Balance" */
+  valueLabel?: string;
+}
+
+let injected = false;
+function inject(): void {
+  if (injected || typeof document === "undefined") return;
+  injected = true;
+  const css = `
+.act{border:1px solid var(--border,#CBD3DC);border-radius:var(--radius-chip,2px);
+  overflow:hidden;background:var(--bg-light,#FFFFFF);}
+.act__head{display:grid;grid-template-columns:1fr auto;gap:12px;padding:8px 12px;
+  background:var(--bg-medium,#EBEFF4);border-bottom:1px solid var(--border,#CBD3DC);
+  font-family:var(--font-body,inherit);font-size:10px;font-weight:600;font-variant:all-small-caps;
+  letter-spacing:.03em;color:var(--text-muted,#59636F);}
+.act__head .act--r{text-align:right;}
+.act__row{display:grid;grid-template-columns:1fr auto;gap:12px;align-items:center;
+  padding:6px 12px;border-top:1px solid var(--border,#CBD3DC);}
+.act__row:hover{background:var(--bg-hover,#F3F6F9);}
+.act__row--sel{cursor:pointer;}
+.act__row--on{background:var(--bg-active,#E6EEF5);box-shadow:inset 3px 0 0 var(--accent,#2F6F8F);}
+.act__name{display:flex;align-items:center;gap:8px;min-width:0;
+  font-family:var(--font-body,inherit);font-size:12px;color:var(--text-primary,#22272E);}
+.act__name--group{font-weight:600;}
+.act__tw{width:14px;height:14px;flex:0 0 auto;display:inline-flex;align-items:center;
+  justify-content:center;font-size:9px;color:var(--text-muted,#59636F);
+  cursor:pointer;border-radius:var(--radius-chip,2px);user-select:none;}
+.act__tw:hover{background:var(--bg-active,#E6EEF5);color:var(--text-secondary,#4D5967);}
+.act__tw--leaf{cursor:default;opacity:0;}
+.act__code{font-family:var(--font-data,monospace);font-size:11px;color:var(--text-muted,#59636F);
+  flex:0 0 auto;}
+.act__label{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+`;
+  const el = document.createElement("style");
+  el.setAttribute("data-mds", "accounttree");
+  el.textContent = css;
+  document.head.appendChild(el);
+}
+
+function rollup(node: AccountNode): number {
+  if (node.children && node.children.length) {
+    const explicit = toNumber(node.balance);
+    if (node.balance != null && Number.isFinite(explicit)) return explicit;
+    return node.children.reduce((a, c) => a + rollup(c), 0);
+  }
+  const own = toNumber(node.balance);
+  return Number.isFinite(own) ? own : 0;
+}
+
+// Seed the expanded set with every node code down to defaultExpandedDepth (0-based root=0).
+function seedExpanded(nodes: AccountNode[], depth: number, maxDepth: number, set: Set<string>): void {
+  for (const n of nodes) {
+    if (n.children && n.children.length) {
+      if (depth < maxDepth) set.add(n.code);
+      seedExpanded(n.children, depth + 1, maxDepth, set);
+    }
+  }
+}
+
+export function AccountTree({
+  nodes,
+  currency = "USD",
+  defaultExpandedDepth = 1,
+  selectedCode,
+  onSelect,
+  valueLabel = "Balance"
+}: AccountTreeProps) {
+  inject();
+  const [expanded, setExpanded] = useState<Set<string>>(() => {
+    const s = new Set<string>();
+    seedExpanded(nodes, 0, defaultExpandedDepth, s);
+    return s;
+  });
+
+  const toggle = (code: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(code)) next.delete(code);
+      else next.add(code);
+      return next;
+    });
+
+  const out: ReactNode[] = [];
+  const walk = (list: AccountNode[], depth: number) => {
+    for (const node of list) {
+      const hasKids = !!(node.children && node.children.length);
+      const open = expanded.has(node.code);
+      const isGroup = hasKids;
+      const selectable = !!onSelect;
+      const on = selectedCode != null && selectedCode === node.code;
+      out.push(
+        <div
+          key={node.code}
+          className={`act__row${selectable ? " act__row--sel" : ""}${on ? " act__row--on" : ""}`}
+          onClick={onSelect ? () => onSelect(node) : undefined}
+          role={onSelect ? "button" : "treeitem"}
+          aria-expanded={hasKids ? open : undefined}
+          aria-selected={on || undefined}
+          tabIndex={onSelect ? 0 : undefined}
+        >
+          <div className={`act__name${isGroup ? " act__name--group" : ""}`} style={{ paddingLeft: depth * 18 }}>
+            <span
+              className={`act__tw${hasKids ? "" : " act__tw--leaf"}`}
+              onClick={
+                hasKids
+                  ? (e) => {
+                      e.stopPropagation();
+                      toggle(node.code);
+                    }
+                  : undefined
+              }
+              aria-hidden={!hasKids}
+            >
+              {hasKids ? (open ? "▾" : "▸") : "•"}
+            </span>
+            {node.code && <span className="act__code">{node.code}</span>}
+            <span className="act__label">{node.name}</span>
+          </div>
+          <AmountCell
+            value={rollup(node)}
+            currency={currency}
+            parens
+            strong={isGroup}
+            style={isGroup ? undefined : { color: "var(--text-secondary, #4D5967)" }}
+          />
+        </div>
+      );
+      if (hasKids && open) walk(node.children!, depth + 1);
+    }
+  };
+  walk(nodes, 0);
+
+  return (
+    <div className="act" role="tree" aria-label="Chart of accounts">
+      <div className="act__head">
+        <div>Account</div>
+        <div className="act--r">{valueLabel}</div>
+      </div>
+      {out}
+    </div>
+  );
+}
+
+AccountTree.displayName = "AccountTree";

--- a/src/Meridian.Ui/dashboard/src/components/accounting/AmountCell.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/AmountCell.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { AmountCell } from "./AmountCell";
+
+describe("AmountCell", () => {
+  it("renders a plain positive amount", () => {
+    render(<AmountCell value={1234.5} currency="USD" />);
+    expect(screen.getByText("$1,234.50")).toBeInTheDocument();
+  });
+
+  it("renders negatives in accounting parentheses when parens is set", () => {
+    render(<AmountCell value={-1234} currency="USD" parens />);
+    expect(screen.getByText("($1,234.00)")).toBeInTheDocument();
+  });
+
+  it("renders exact zero as an em dash when zeroDash is set", () => {
+    render(<AmountCell value={0} zeroDash />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("colors P&L mode: negative red, positive green", () => {
+    const { rerender } = render(<AmountCell value={-5} mode="pnl" />);
+    expect(screen.getByText("−5.00")).toHaveStyle({ color: "var(--red-dim, #8C2F40)" });
+
+    rerender(<AmountCell value={5} mode="pnl" signed />);
+    expect(screen.getByText("+5.00")).toHaveStyle({ color: "var(--green-dim, #10663F)" });
+  });
+
+  it("renders through an alternate element tag", () => {
+    render(<AmountCell as="td" value={10} data-testid="amt" />);
+    const cell = screen.getByTestId("amt");
+    expect(cell.tagName).toBe("TD");
+    expect(cell).toHaveTextContent("10.00");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/accounting/AmountCell.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/AmountCell.tsx
@@ -1,0 +1,84 @@
+// Meridian money primitive — a single right-aligned mono amount. Encodes sign, currency, fixed
+// decimals, accounting parentheses for negatives, zero-as-dash, and an optional P&L color tone
+// (negative red / positive green). The atom every accounting table is built from.
+import type { CSSProperties } from "react";
+import { createElement } from "react";
+import { formatMoney, toNumber } from "./money";
+
+export interface AmountCellProps {
+  /** Number, or a money-ish string ("(1,234.00)", "-921.00"). */
+  value: number | string;
+  /** Currency code (USD, EUR, GBP, JPY, CHF…). Omit for a bare number. */
+  currency?: string;
+  /** Decimal places. @default 2 */
+  decimals?: number;
+  /**
+   * Color tone:
+   *  - "plain"  primary text (balances, neutral amounts) — default
+   *  - "pnl"    negative red / positive green / zero muted (deltas, realized gains)
+   *  - "muted"  muted text (secondary / opening rows)
+   * @default "plain"
+   */
+  mode?: "plain" | "pnl" | "muted";
+  /** Render negatives as (1,234.00) instead of −1,234.00 (statement convention). @default false */
+  parens?: boolean;
+  /** Exact zero renders as an em dash. @default false */
+  zeroDash?: boolean;
+  /** Positives get an explicit leading +. @default false */
+  signed?: boolean;
+  /** 600 weight for subtotal / total rows. @default false */
+  strong?: boolean;
+  /** Element tag to render. @default "span" */
+  as?: keyof JSX.IntrinsicElements;
+  style?: CSSProperties;
+  /** Extra attributes (className, title, aria-*) forwarded to the element. */
+  [key: string]: unknown;
+}
+
+export function AmountCell({
+  value,
+  currency,
+  decimals = 2,
+  mode = "plain",
+  parens = false,
+  zeroDash = false,
+  signed = false,
+  strong = false,
+  as = "span",
+  style = {},
+  ...rest
+}: AmountCellProps) {
+  const num = toNumber(value);
+  const text = formatMoney(value, { currency, decimals, parens, zeroDash, signed });
+
+  let color = "var(--text-primary, #22272E)";
+  if (mode === "muted") {
+    color = "var(--text-muted, #59636F)";
+  } else if (mode === "pnl") {
+    color =
+      !Number.isFinite(num) || num === 0
+        ? "var(--text-muted, #59636F)"
+        : num < 0
+          ? "var(--red-dim, #8C2F40)"
+          : "var(--green-dim, #10663F)";
+  }
+
+  return createElement(
+    as,
+    {
+      style: {
+        fontFamily: "var(--font-data, monospace)",
+        fontVariantNumeric: "tabular-nums",
+        fontFeatureSettings: '"tnum" 1',
+        fontWeight: strong ? 600 : 400,
+        whiteSpace: "nowrap",
+        color,
+        ...style
+      },
+      ...rest
+    },
+    text
+  );
+}
+
+AmountCell.displayName = "AmountCell";

--- a/src/Meridian.Ui/dashboard/src/components/accounting/JournalEntryForm.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/JournalEntryForm.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import { JournalEntryForm, type JournalLine } from "./JournalEntryForm";
+
+const balanced: JournalLine[] = [
+  { account: "Cash", debit: 500, credit: "" },
+  { account: "Revenue", debit: "", credit: 500 }
+];
+
+const unbalanced: JournalLine[] = [
+  { account: "Cash", debit: 500, credit: "" },
+  { account: "Revenue", debit: "", credit: 400 }
+];
+
+describe("JournalEntryForm", () => {
+  it("gates the Post button on a balanced entry", () => {
+    render(<JournalEntryForm initialLines={balanced} onPost={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Post entry" })).toBeEnabled();
+    expect(screen.getByText("Balanced")).toBeInTheDocument();
+  });
+
+  it("disables Post and shows the shortfall when out of balance", () => {
+    render(<JournalEntryForm initialLines={unbalanced} onPost={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Post entry" })).toBeDisabled();
+    expect(screen.getByText(/Out by/)).toBeInTheDocument();
+  });
+
+  it("fires onPost with the current entry when balanced", () => {
+    const onPost = vi.fn();
+    render(<JournalEntryForm initialLines={balanced} onPost={onPost} />);
+    fireEvent.click(screen.getByRole("button", { name: "Post entry" }));
+    expect(onPost).toHaveBeenCalledTimes(1);
+    expect(onPost.mock.calls[0][0].lines).toHaveLength(2);
+  });
+
+  it("emits onChange when a line edits", () => {
+    const onChange = vi.fn();
+    render(<JournalEntryForm initialLines={balanced} onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText("Line 1 debit"), { target: { value: "600" } });
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/accounting/JournalEntryForm.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/JournalEntryForm.tsx
@@ -1,0 +1,268 @@
+// Meridian journal-entry form — balanced double-entry input. A header (date / reference / memo)
+// sits over a line grid of Account · Debit · Credit with live column totals and a balance gauge
+// that stays red ("Out by …") until Σdebit = Σcredit, then turns green ("Balanced"). Add/remove
+// lines; an optional account list drives autocomplete; the Post button is gated on a balanced
+// entry. Self-contained (native inputs styled with Concrete tokens) so it has no cross-unit deps.
+import { useState } from "react";
+import { AmountCell } from "./AmountCell";
+import { toNumber } from "./money";
+
+export interface JournalLine {
+  account?: string;
+  debit?: number | string;
+  credit?: number | string;
+}
+
+export interface JournalHeader {
+  date?: string;
+  ref?: string;
+  memo?: string;
+}
+
+export interface JournalEntry {
+  header: JournalHeader;
+  lines: JournalLine[];
+}
+
+export interface JournalEntryFormProps {
+  /** Seed lines. @default two blank lines */
+  initialLines?: JournalLine[];
+  /** Seed header fields. */
+  initialHeader?: JournalHeader;
+  /** Account names for the input datalist (autocomplete). */
+  accounts?: string[];
+  /** @default "USD" */
+  currency?: string;
+  /** Absolute debit−credit difference treated as balanced. @default 0.005 */
+  tolerance?: number;
+  /** Fires on every edit with the full { header, lines } state. */
+  onChange?: (entry: JournalEntry) => void;
+  /** When set, renders a Post button (enabled only when balanced). */
+  onPost?: (entry: JournalEntry) => void;
+}
+
+let injected = false;
+function inject(): void {
+  if (injected || typeof document === "undefined") return;
+  injected = true;
+  const css = `
+.jnl{border:1px solid var(--border,#CBD3DC);border-radius:var(--radius-card,2px);
+  background:var(--bg-light,#FFFFFF);overflow:hidden;}
+.jnl__hd{display:grid;grid-template-columns:140px 160px 1fr;gap:12px;padding:14px;
+  border-bottom:1px solid var(--border,#CBD3DC);background:var(--bg-medium,#EBEFF4);}
+.jnl__field{display:flex;flex-direction:column;gap:4px;min-width:0;}
+.jnl__lbl{font-family:var(--font-body,inherit);font-size:10px;font-weight:600;font-variant:all-small-caps;
+  letter-spacing:.03em;color:var(--text-muted,#59636F);}
+.jnl__inp{font-family:var(--font-body,inherit);font-size:12px;color:var(--text-primary,#22272E);
+  background:var(--bg-light,#FFFFFF);border:1px solid var(--border,#CBD3DC);border-radius:var(--radius-button,2px);
+  padding:5px 8px;line-height:1.4;width:100%;box-sizing:border-box;}
+.jnl__inp:focus{outline:2px solid var(--accent,#2F6F8F);outline-offset:-1px;border-color:var(--accent,#2F6F8F);}
+.jnl__inp--num{font-family:var(--font-data,monospace);text-align:right;font-variant-numeric:tabular-nums;}
+.jnl__grid{width:100%;border-collapse:separate;border-spacing:0;font-family:var(--font-data,monospace);font-size:12px;}
+.jnl__grid th{padding:8px 12px;text-align:left;font-family:var(--font-body,inherit);font-size:10px;
+  font-weight:600;font-variant:all-small-caps;letter-spacing:.03em;color:var(--text-muted,#59636F);
+  border-bottom:1px solid var(--border,#CBD3DC);}
+.jnl__grid th.jnl--r{text-align:right;}
+.jnl__grid th.jnl--x{width:36px;}
+.jnl__grid td{padding:5px 12px;border-top:1px solid var(--border,#CBD3DC);vertical-align:middle;}
+.jnl__grid tbody tr:first-child td{border-top:none;}
+.jnl__grid td.jnl--r{text-align:right;}
+.jnl__del{width:24px;height:24px;display:inline-flex;align-items:center;justify-content:center;
+  border:1px solid transparent;border-radius:var(--radius-button,2px);background:transparent;cursor:pointer;
+  color:var(--text-muted,#59636F);font-size:14px;line-height:1;transition:all .12s ease;}
+.jnl__del:hover{background:var(--red-a10,rgba(186,63,85,.10));border-color:var(--red,#BA3F55);color:var(--red-dim,#8C2F40);}
+.jnl__grid tfoot td{padding:8px 12px;border-top:2px solid var(--border-strong,#99A5B2);
+  background:var(--bg-medium,#EBEFF4);font-weight:600;}
+.jnl__grid tfoot td.jnl--r{text-align:right;}
+.jnl__foot-lbl{font-family:var(--font-body,inherit);font-size:11px;font-variant:all-small-caps;letter-spacing:.03em;color:var(--text-secondary,#4D5967);}
+.jnl__bar{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 14px;border-top:1px solid var(--border,#CBD3DC);}
+.jnl__actions{display:flex;gap:8px;}
+.jnl__btn{font-family:var(--font-body,inherit);font-size:12px;font-weight:600;cursor:pointer;
+  border-radius:var(--radius-button,2px);padding:6px 12px;line-height:1.3;border:1px solid;transition:all .12s ease;}
+.jnl__btn--ghost{background:transparent;border-color:var(--border,#CBD3DC);color:var(--text-secondary,#4D5967);}
+.jnl__btn--ghost:hover{background:var(--bg-hover,#F3F6F9);border-color:var(--border-strong,#99A5B2);}
+.jnl__btn--primary{background:var(--accent,#2F6F8F);border-color:var(--accent,#2F6F8F);color:#fff;}
+.jnl__btn--primary:hover:not(:disabled){background:var(--accent-pressed,#255B75);border-color:var(--accent-pressed,#255B75);}
+.jnl__btn:disabled{cursor:not-allowed;opacity:.5;}
+.jnl__status{display:inline-flex;align-items:center;gap:7px;
+  font-family:var(--font-body,inherit);font-size:11px;font-weight:600;font-variant:all-small-caps;letter-spacing:.03em;
+  border:1px solid;border-radius:var(--radius-chip,2px);padding:5px 10px;}
+.jnl__status--bal{background:var(--green-a10,rgba(22,136,95,.10));border-color:var(--green,#16885F);color:var(--green-dim,#10663F);}
+.jnl__status--out{background:var(--red-a10,rgba(186,63,85,.10));border-color:var(--red,#BA3F55);color:var(--red-dim,#8C2F40);}
+.jnl__dot{height:6px;width:6px;border-radius:50%;background:currentColor;}
+`;
+  const el = document.createElement("style");
+  el.setAttribute("data-mds", "journal");
+  el.textContent = css;
+  document.head.appendChild(el);
+}
+
+const blankLine = (): JournalLine => ({ account: "", debit: "", credit: "" });
+
+export function JournalEntryForm({
+  initialLines,
+  initialHeader,
+  accounts,
+  currency = "USD",
+  tolerance = 0.005,
+  onChange,
+  onPost
+}: JournalEntryFormProps) {
+  inject();
+  const [header, setHeader] = useState<JournalHeader>(() => ({ date: "", ref: "", memo: "", ...initialHeader }));
+  const [lines, setLines] = useState<JournalLine[]>(() =>
+    initialLines && initialLines.length ? initialLines.map((l) => ({ ...blankLine(), ...l })) : [blankLine(), blankLine()]
+  );
+
+  const emit = (h: JournalHeader, l: JournalLine[]) => onChange?.({ header: h, lines: l });
+  const setH = (k: keyof JournalHeader, v: string) => {
+    const h = { ...header, [k]: v };
+    setHeader(h);
+    emit(h, lines);
+  };
+  const setL = (i: number, k: keyof JournalLine, v: string) => {
+    const l = lines.map((row, idx) => (idx === i ? { ...row, [k]: v } : row));
+    setLines(l);
+    emit(header, l);
+  };
+  const addLine = () => {
+    const l = [...lines, blankLine()];
+    setLines(l);
+    emit(header, l);
+  };
+  const delLine = (i: number) => {
+    const l = lines.length > 1 ? lines.filter((_, idx) => idx !== i) : [blankLine()];
+    setLines(l);
+    emit(header, l);
+  };
+
+  const totalD = lines.reduce((a, r) => a + (toNumber(r.debit) || 0), 0);
+  const totalC = lines.reduce((a, r) => a + (toNumber(r.credit) || 0), 0);
+  const diff = totalD - totalC;
+  const balanced = Math.abs(diff) <= tolerance && (totalD > 0 || totalC > 0);
+  const dlId = accounts && accounts.length ? "jnl-accts" : undefined;
+
+  return (
+    <div className="jnl" role="group" aria-label="Journal entry">
+      <div className="jnl__hd">
+        <div className="jnl__field">
+          <label className="jnl__lbl" htmlFor="jnl-date">
+            Date
+          </label>
+          <input id="jnl-date" className="jnl__inp" type="date" value={header.date} onChange={(e) => setH("date", e.target.value)} />
+        </div>
+        <div className="jnl__field">
+          <label className="jnl__lbl" htmlFor="jnl-ref">
+            Reference
+          </label>
+          <input id="jnl-ref" className="jnl__inp" placeholder="JE-0001" value={header.ref} onChange={(e) => setH("ref", e.target.value)} />
+        </div>
+        <div className="jnl__field">
+          <label className="jnl__lbl" htmlFor="jnl-memo">
+            Memo
+          </label>
+          <input id="jnl-memo" className="jnl__inp" placeholder="Description" value={header.memo} onChange={(e) => setH("memo", e.target.value)} />
+        </div>
+      </div>
+
+      {dlId && (
+        <datalist id={dlId}>
+          {accounts!.map((a) => (
+            <option key={a} value={a} />
+          ))}
+        </datalist>
+      )}
+
+      <table className="jnl__grid">
+        <thead>
+          <tr>
+            <th>Account</th>
+            <th className="jnl--r">Debit</th>
+            <th className="jnl--r">Credit</th>
+            <th className="jnl--x" aria-label="Remove" />
+          </tr>
+        </thead>
+        <tbody>
+          {lines.map((row, i) => (
+            <tr key={i}>
+              <td>
+                <input
+                  className="jnl__inp"
+                  placeholder="Account"
+                  value={row.account}
+                  onChange={(e) => setL(i, "account", e.target.value)}
+                  list={dlId}
+                  aria-label={`Line ${i + 1} account`}
+                />
+              </td>
+              <td className="jnl--r">
+                <input
+                  className="jnl__inp jnl__inp--num"
+                  type="number"
+                  placeholder="0.00"
+                  value={row.debit as string | number}
+                  onChange={(e) => setL(i, "debit", e.target.value)}
+                  aria-label={`Line ${i + 1} debit`}
+                />
+              </td>
+              <td className="jnl--r">
+                <input
+                  className="jnl__inp jnl__inp--num"
+                  type="number"
+                  placeholder="0.00"
+                  value={row.credit as string | number}
+                  onChange={(e) => setL(i, "credit", e.target.value)}
+                  aria-label={`Line ${i + 1} credit`}
+                />
+              </td>
+              <td className="jnl--r">
+                <button type="button" className="jnl__del" aria-label={`Remove line ${i + 1}`} onClick={() => delLine(i)}>
+                  ×
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          <tr>
+            <td className="jnl__foot-lbl">Totals</td>
+            <td className="jnl--r">
+              <AmountCell value={totalD} currency={currency} strong />
+            </td>
+            <td className="jnl--r">
+              <AmountCell value={totalC} currency={currency} strong />
+            </td>
+            <td />
+          </tr>
+        </tfoot>
+      </table>
+
+      <div className="jnl__bar">
+        <div className="jnl__actions">
+          <button type="button" className="jnl__btn jnl__btn--ghost" onClick={addLine}>
+            + Add line
+          </button>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <span className={`jnl__status ${balanced ? "jnl__status--bal" : "jnl__status--out"}`} role="status">
+            <span className="jnl__dot" aria-hidden="true" />
+            {balanced ? (
+              "Balanced"
+            ) : (
+              <>
+                Out by <AmountCell value={Math.abs(diff)} currency={currency} strong style={{ color: "inherit" }} />
+              </>
+            )}
+          </span>
+          {onPost && (
+            <button type="button" className="jnl__btn jnl__btn--primary" disabled={!balanced} onClick={() => onPost({ header, lines })}>
+              Post entry
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+JournalEntryForm.displayName = "JournalEntryForm";

--- a/src/Meridian.Ui/dashboard/src/components/accounting/LedgerTable.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/LedgerTable.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, within } from "@testing-library/react";
+import { LedgerTable, type LedgerRow } from "./LedgerTable";
+
+const rows: LedgerRow[] = [
+  { date: "2026-01-02", ref: "JE-1", memo: "Opening buy", debit: 1000, credit: 0 },
+  { date: "2026-01-03", ref: "JE-2", memo: "Fee", debit: 0, credit: 250 }
+];
+
+describe("LedgerTable", () => {
+  it("renders debit/credit totals in the footer", () => {
+    render(<LedgerTable rows={rows} currency="USD" opening={0} />);
+    const footer = screen.getByText("Totals").closest("tr")!;
+    expect(within(footer).getByText("$1,000.00")).toBeInTheDocument();
+    expect(within(footer).getByText("$250.00")).toBeInTheDocument();
+  });
+
+  it("computes a running balance from the opening value", () => {
+    render(<LedgerTable rows={rows} currency="USD" opening={0} />);
+    // opening 0 → +1000 → +1000 running, then -250 → 750 running balance in the last data row.
+    const bodyRows = screen.getAllByRole("row").filter((r) => r.closest("tbody"));
+    const lastRow = bodyRows[bodyRows.length - 1];
+    expect(within(lastRow).getByText("$750.00")).toBeInTheDocument();
+  });
+
+  it("flags an imbalance in the footer when debits and credits disagree", () => {
+    render(<LedgerTable rows={[{ date: "2026-01-04", debit: 100, credit: 0 }]} currency="USD" />);
+    expect(screen.getByLabelText("Ledger imbalance")).toBeInTheDocument();
+  });
+
+  it("marks a balanced ledger", () => {
+    render(<LedgerTable rows={[{ date: "2026-01-05", debit: 100, credit: 100 }]} currency="USD" />);
+    expect(screen.getByLabelText("Ledger balanced")).toBeInTheDocument();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/accounting/LedgerTable.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/LedgerTable.tsx
@@ -1,0 +1,226 @@
+// Meridian general-ledger / journal table — double-entry rows with Debit / Credit columns and a
+// running Balance, plus a totals footer that proves Σdebit = Σcredit (the footer balance turns to
+// P&L color when the two sides disagree). Flat Concrete grid: white paper, small-caps muted
+// headers, hairline rows, mono tabular figures.
+import { useState } from "react";
+import { AmountCell } from "./AmountCell";
+import { toNumber } from "./money";
+
+export interface LedgerRow {
+  date: string;
+  /** Document / journal reference (rendered in accent). */
+  ref?: string;
+  /** Posting description. */
+  memo?: string;
+  /** Account name/code — shown only when `showAccount` is set. */
+  account?: string;
+  /** Debit amount (number or money-ish string). Blank side renders as a dash. */
+  debit?: number | string;
+  /** Credit amount. */
+  credit?: number | string;
+  /** Explicit running balance. Omit to auto-compute from `opening` + normal-side deltas. */
+  balance?: number | string;
+}
+
+export interface LedgerTableProps {
+  rows: LedgerRow[];
+  /** @default "USD" */
+  currency?: string;
+  /** Opening balance — renders a leading muted row and seeds the running balance. */
+  opening?: number | string;
+  /** Show an Account column (journal spanning multiple accounts). @default false */
+  showAccount?: boolean;
+  /** Which side increases the running balance. @default "debit" */
+  normalSide?: "debit" | "credit";
+  /** Accessible caption / region label. */
+  caption?: string;
+  /** Fires when a sortable header is clicked. */
+  onSort?: (key: string, dir: number) => void;
+}
+
+type SortKey = "date" | "ref" | "account" | "memo" | "debit" | "credit" | "balance";
+
+let injected = false;
+function inject(): void {
+  if (injected || typeof document === "undefined") return;
+  injected = true;
+  const css = `
+.ldg-wrap{overflow-x:auto;border:1px solid var(--border,#CBD3DC);
+  border-radius:var(--radius-chip,2px);background:var(--bg-light,#FFFFFF);}
+.ldg{width:100%;min-width:100%;border-collapse:separate;border-spacing:0;
+  font-family:var(--font-data,monospace);font-size:12px;}
+.ldg thead th{padding:9px 12px;text-align:left;white-space:nowrap;position:sticky;top:0;
+  background:var(--bg-medium,#EBEFF4);z-index:1;
+  font-family:var(--font-body,inherit);font-size:10px;font-weight:600;font-variant:all-small-caps;
+  letter-spacing:.03em;color:var(--text-muted,#59636F);
+  border-bottom:1px solid var(--border-strong,#99A5B2);border-right:1px solid var(--border-divider,#CBD3DC);}
+.ldg thead th:last-child{border-right:none;}
+.ldg th.ldg--r{text-align:right;}
+.ldg td{padding:11px 12px;white-space:nowrap;color:var(--text-primary,#22272E);
+  border-top:1px solid var(--border,#CBD3DC);border-right:1px solid var(--border-divider,#CBD3DC);
+  vertical-align:baseline;height:40px;}
+.ldg td:last-child{border-right:none;}
+.ldg tbody tr:first-child td{border-top:none;}
+.ldg td.ldg--r{text-align:right;}
+.ldg tbody tr:hover{background:var(--bg-hover,#F3F6F9);}
+.ldg__date{color:var(--text-secondary,#4D5967);}
+.ldg__ref{color:var(--accent,#2F6F8F);}
+.ldg__memo{font-family:var(--font-body,inherit);color:var(--text-secondary,#4D5967);
+  white-space:normal;min-width:160px;}
+.ldg__acct{color:var(--text-primary,#22272E);}
+.ldg__open td{background:var(--bg-medium,#EBEFF4);color:var(--text-muted,#59636F);}
+.ldg__open .ldg__memo{font-style:italic;}
+.ldg tfoot td{padding:9px 12px;background:var(--bg-medium,#EBEFF4);font-weight:600;
+  border-top:2px solid var(--border-strong,#99A5B2);color:var(--text-primary,#22272E);}
+.ldg tfoot td.ldg--r{text-align:right;}
+.ldg__foot-label{font-family:var(--font-body,inherit);font-variant:all-small-caps;letter-spacing:.03em;
+  font-size:11px;color:var(--text-secondary,#4D5967);}
+.ldg__sort{cursor:pointer;user-select:none;}
+`;
+  const el = document.createElement("style");
+  el.setAttribute("data-mds", "ledger");
+  el.textContent = css;
+  document.head.appendChild(el);
+}
+
+export function LedgerTable({
+  rows,
+  currency = "USD",
+  opening,
+  showAccount = false,
+  normalSide = "debit",
+  caption,
+  onSort
+}: LedgerTableProps) {
+  inject();
+  const [sortKey, setSortKey] = useState<SortKey | null>(null);
+  const [sortDir, setSortDir] = useState(1);
+
+  const handleSort = (key: SortKey) => {
+    const nextDir = sortKey === key ? (sortDir === 1 ? -1 : 1) : 1;
+    setSortKey(key);
+    setSortDir(nextDir);
+    onSort?.(key, nextDir);
+  };
+
+  const openingNum = toNumber(opening);
+  const hasOpening = Number.isFinite(openingNum);
+
+  // Compute running balances when a row omits `balance`.
+  let bal = hasOpening ? openingNum : 0;
+  let hasRunning = hasOpening;
+  const computed = rows.map((r) => {
+    const d = toNumber(r.debit) || 0;
+    const c = toNumber(r.credit) || 0;
+    const delta = normalSide === "credit" ? c - d : d - c;
+    const explicit = toNumber(r.balance);
+    if (r.balance != null && Number.isFinite(explicit)) {
+      bal = explicit;
+      hasRunning = true;
+    } else {
+      bal += delta;
+    }
+    return { ...r, _bal: bal };
+  });
+
+  const totalD = rows.reduce((a, r) => a + (toNumber(r.debit) || 0), 0);
+  const totalC = rows.reduce((a, r) => a + (toNumber(r.credit) || 0), 0);
+  const imbalance = totalD - totalC;
+
+  const caret = (key: SortKey) => (sortKey === key ? (sortDir === 1 ? " ↑" : " ↓") : "");
+
+  return (
+    <div className="ldg-wrap" role="region" aria-label={caption || "General ledger"}>
+      <table className="ldg">
+        <thead>
+          <tr>
+            <th className="ldg__sort" onClick={() => handleSort("date")}>
+              Date{caret("date")}
+            </th>
+            <th className="ldg__sort" onClick={() => handleSort("ref")}>
+              Ref{caret("ref")}
+            </th>
+            {showAccount && (
+              <th className="ldg__sort" onClick={() => handleSort("account")}>
+                Account{caret("account")}
+              </th>
+            )}
+            <th className="ldg__sort" onClick={() => handleSort("memo")}>
+              Description{caret("memo")}
+            </th>
+            <th className="ldg--r ldg__sort" onClick={() => handleSort("debit")}>
+              Debit{caret("debit")}
+            </th>
+            <th className="ldg--r ldg__sort" onClick={() => handleSort("credit")}>
+              Credit{caret("credit")}
+            </th>
+            <th className="ldg--r ldg__sort" onClick={() => handleSort("balance")}>
+              Balance{caret("balance")}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {hasOpening && (
+            <tr className="ldg__open">
+              <td className="ldg__date" />
+              <td />
+              {showAccount && <td />}
+              <td className="ldg__memo">Opening balance</td>
+              <td className="ldg--r" />
+              <td className="ldg--r" />
+              <td className="ldg--r">
+                <AmountCell value={openingNum} currency={currency} mode="muted" />
+              </td>
+            </tr>
+          )}
+          {computed.map((r, i) => (
+            <tr key={i}>
+              <td className="ldg__date">{r.date}</td>
+              <td className="ldg__ref">{r.ref}</td>
+              {showAccount && <td className="ldg__acct">{r.account}</td>}
+              <td className="ldg__memo">{r.memo}</td>
+              <td className="ldg--r">
+                <AmountCell value={r.debit ?? ""} currency={currency} zeroDash />
+              </td>
+              <td className="ldg--r">
+                <AmountCell value={r.credit ?? ""} currency={currency} zeroDash />
+              </td>
+              <td className="ldg--r">
+                {hasRunning ? (
+                  <AmountCell value={r._bal} currency={currency} parens />
+                ) : (
+                  <span style={{ color: "var(--text-disabled, #889099)" }}>—</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          <tr>
+            <td className="ldg__foot-label" colSpan={showAccount ? 4 : 3}>
+              Totals
+            </td>
+            <td className="ldg--r">
+              <AmountCell value={totalD} currency={currency} strong />
+            </td>
+            <td className="ldg--r">
+              <AmountCell value={totalC} currency={currency} strong />
+            </td>
+            <td className="ldg--r">
+              <AmountCell
+                value={imbalance}
+                currency={currency}
+                mode={Math.abs(imbalance) < 0.005 ? "muted" : "pnl"}
+                parens
+                strong
+                aria-label={Math.abs(imbalance) < 0.005 ? "Ledger balanced" : "Ledger imbalance"}
+              />
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  );
+}
+
+LedgerTable.displayName = "LedgerTable";

--- a/src/Meridian.Ui/dashboard/src/components/accounting/ReconciliationPanel.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/ReconciliationPanel.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { vi } from "vitest";
+import { ReconciliationPanel, type ReconciliationSide } from "./ReconciliationPanel";
+
+const statement: ReconciliationSide = {
+  title: "Statement",
+  items: [
+    { id: "s1", date: "2026-06-01", ref: "TXN-1", memo: "Wire in", amount: 1000, matched: true },
+    { id: "s2", date: "2026-06-02", ref: "TXN-2", memo: "Fee", amount: -50, matched: false }
+  ]
+};
+
+const ledger: ReconciliationSide = {
+  title: "Ledger",
+  items: [{ id: "l1", date: "2026-06-01", ref: "JE-1", memo: "Deposit", amount: 1000, matched: true }]
+};
+
+describe("ReconciliationPanel", () => {
+  it("flags 'Out by …' when the two sides disagree", () => {
+    render(<ReconciliationPanel left={statement} right={ledger} currency="USD" />);
+    // statement 950 vs ledger 1000 → out by 50
+    expect(screen.getByText(/Out by/)).toBeInTheDocument();
+  });
+
+  it("marks reconciled when balances match within tolerance", () => {
+    const balanced: ReconciliationSide = { title: "Ledger", items: [{ id: "l1", amount: 950, matched: true }] };
+    render(<ReconciliationPanel left={statement} right={balanced} currency="USD" />);
+    expect(screen.getByText("Reconciled")).toBeInTheDocument();
+  });
+
+  it("fires onToggleItem when a match checkbox changes", () => {
+    const onToggleItem = vi.fn();
+    render(<ReconciliationPanel left={statement} right={ledger} currency="USD" onToggleItem={onToggleItem} />);
+    const box = screen.getByLabelText("Match Statement item TXN-2");
+    fireEvent.click(box);
+    expect(onToggleItem).toHaveBeenCalledWith("s2", true);
+  });
+
+  it("filters to open items", () => {
+    render(<ReconciliationPanel left={statement} right={ledger} currency="USD" />);
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    // the statement side should still show its open Fee row
+    expect(screen.getByText("Fee")).toBeInTheDocument();
+    // the ledger side (all matched) should now be empty
+    expect(screen.getAllByText("No matching items").length).toBeGreaterThan(0);
+  });
+
+  it("totals each side over the full data set", () => {
+    render(<ReconciliationPanel left={statement} right={ledger} currency="USD" />);
+    const summary = screen.getByText("Statement balance").closest(".rec__sumcell") as HTMLElement;
+    expect(within(summary).getByText("$950.00")).toBeInTheDocument();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/accounting/ReconciliationPanel.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/ReconciliationPanel.tsx
@@ -1,0 +1,389 @@
+// Meridian reconciliation panel — a two-sided statement vs. ledger comparison rendered as proper
+// multi-column data tables (Date · Reference · Memo · [Category] · Amount). A shared toolbar
+// filters by match status (All / Matched / Open) and free-text searches across the visible
+// columns; every column header is click-to-sort (asc → desc → unsorted). Matched rows carry a
+// green wash, unmatched an amber wash. A summary bar totals each side over the FULL data set (not
+// the filtered view) and flags the difference: "Reconciled" (green) within tolerance, "Out by …"
+// (red) otherwise. Self-contained (native checkbox + search) so it has no cross-unit deps.
+import { useState } from "react";
+import { AmountCell } from "./AmountCell";
+import { toNumber } from "./money";
+
+export interface ReconciliationItem {
+  id?: string | number;
+  date?: string;
+  /** Document / transaction reference. */
+  ref?: string;
+  memo?: string;
+  /** Optional classification — surfaces a "Category" column when any item sets it. */
+  category?: string;
+  amount: number | string;
+  /** Whether this line has a counterpart on the other side. */
+  matched?: boolean;
+  [key: string]: unknown;
+}
+
+export interface ReconciliationSide {
+  /** Side label (e.g. "Statement", "Ledger"). Also used in the summary bar. */
+  title: string;
+  items: ReconciliationItem[];
+}
+
+export interface ReconciliationColumn {
+  /** Item field this column reads. */
+  key: string;
+  /** Column header label. */
+  label: string;
+  /** Render in the tabular mono/data font (dates, refs). */
+  mono?: boolean;
+  /** Right-align the header + cells (numeric columns). */
+  num?: boolean;
+  /** Render the cell through `AmountCell` with accounting formatting. */
+  amount?: boolean;
+}
+
+export interface ReconciliationPanelProps {
+  left: ReconciliationSide;
+  right: ReconciliationSide;
+  /**
+   * Column definitions, applied to both sides. Defaults to Date · Reference · Memo · Amount,
+   * with a Category column inserted automatically when any item carries `category`.
+   */
+  columns?: ReconciliationColumn[];
+  /** @default "USD" */
+  currency?: string;
+  /** Explicit statement-side balance. Defaults to the sum of `left.items`. */
+  statementBalance?: number | string;
+  /** Explicit book-side balance. Defaults to the sum of `right.items`. */
+  bookBalance?: number | string;
+  /** Absolute difference treated as reconciled. @default 0.005 */
+  tolerance?: number;
+  /** Show the free-text search box. @default true */
+  searchable?: boolean;
+  /** Show the All / Matched / Open status filter. @default true */
+  filterable?: boolean;
+  /** Fires when a single item's match checkbox toggles. */
+  onToggleItem?: (id: ReconciliationItem["id"], matched: boolean) => void;
+  /** Fires when a side's header checkbox toggles all visible items. */
+  onToggleAll?: (side: ReconciliationSide, matched: boolean) => void;
+}
+
+type Sort = { key: string | null; dir: number };
+type StatusFilter = "all" | "matched" | "open";
+
+let injected = false;
+function inject(): void {
+  if (injected || typeof document === "undefined") return;
+  injected = true;
+  const css = `
+.rec{border:1px solid var(--border,#CBD3DC);border-radius:var(--radius-card,2px);
+  background:var(--bg-light,#FFFFFF);overflow:hidden;}
+.rec__toolbar{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;
+  padding:8px 12px;background:var(--bg-medium,#EBEFF4);border-bottom:1px solid var(--border,#CBD3DC);}
+.rec__seg{display:inline-flex;border:1px solid var(--border,#CBD3DC);border-radius:var(--radius-chip,2px);overflow:hidden;background:var(--bg-light,#FFFFFF);}
+.rec__seg button{appearance:none;border:none;background:transparent;cursor:pointer;
+  font-family:var(--font-body,inherit);font-size:10px;font-weight:600;font-variant:all-small-caps;letter-spacing:.03em;
+  color:var(--text-muted,#59636F);padding:4px 10px;line-height:1.4;border-left:1px solid var(--border,#CBD3DC);}
+.rec__seg button:first-child{border-left:none;}
+.rec__seg button[aria-pressed="true"]{background:var(--bg-medium,#EBEFF4);color:var(--text-primary,#22272E);box-shadow:inset 0 -2px 0 var(--accent,#2F6F8F);}
+.rec__search{font-family:var(--font-body,inherit);font-size:12px;color:var(--text-primary,#22272E);
+  background:var(--bg-light,#FFFFFF);border:1px solid var(--border,#CBD3DC);border-radius:var(--radius-button,2px);padding:4px 9px;line-height:1.4;min-width:180px;}
+.rec__search:focus{outline:2px solid var(--accent,#2F6F8F);outline-offset:-1px;border-color:var(--accent,#2F6F8F);}
+.rec__cols{display:grid;grid-template-columns:1fr 1fr;}
+.rec__side{min-width:0;display:flex;flex-direction:column;}
+.rec__side + .rec__side{border-left:1px solid var(--border,#CBD3DC);}
+.rec__head{display:flex;align-items:center;justify-content:space-between;gap:8px;
+  padding:9px 12px;background:var(--bg-medium,#EBEFF4);border-bottom:1px solid var(--border,#CBD3DC);}
+.rec__title{font-family:var(--font-body,inherit);font-size:10px;font-weight:600;font-variant:all-small-caps;
+  letter-spacing:.03em;color:var(--text-muted,#59636F);}
+.rec__counts{display:flex;gap:6px;}
+.rec__chip{font-family:var(--font-body,inherit);font-size:10px;font-weight:600;font-variant:all-small-caps;
+  letter-spacing:.02em;border:1px solid;border-radius:var(--radius-chip,2px);padding:1px 6px;line-height:1.4;white-space:nowrap;}
+.rec__chip--ok{background:var(--green-a10,rgba(22,136,95,.10));border-color:var(--green,#16885F);color:var(--green-dim,#10663F);}
+.rec__chip--open{background:var(--orange-a10,rgba(138,82,14,.10));border-color:var(--orange,#8A520E);color:var(--orange-dim,#683E0B);}
+.rec__tablewrap{overflow-x:auto;}
+.rec__table{width:100%;border-collapse:collapse;table-layout:auto;}
+.rec__table th{position:sticky;top:0;background:var(--bg-light,#FFFFFF);text-align:left;
+  font-family:var(--font-body,inherit);font-size:9px;font-weight:600;font-variant:all-small-caps;letter-spacing:.04em;
+  color:var(--text-muted,#59636F);padding:6px 10px;border-bottom:1px solid var(--border,#CBD3DC);
+  white-space:nowrap;cursor:pointer;user-select:none;}
+.rec__table th:hover{color:var(--text-primary,#22272E);}
+.rec__table th.is-sorted{color:var(--accent,#2F6F8F);}
+.rec__table th.num{text-align:right;}
+.rec__caret{display:inline-block;width:0;height:0;margin-left:4px;vertical-align:middle;}
+.rec__caret--asc{border-left:3px solid transparent;border-right:3px solid transparent;border-bottom:4px solid currentColor;}
+.rec__caret--desc{border-left:3px solid transparent;border-right:3px solid transparent;border-top:4px solid currentColor;}
+.rec__table td{font-family:var(--font-body,inherit);font-size:12px;color:var(--text-primary,#22272E);
+  padding:6px 10px;border-top:1px solid var(--border,#CBD3DC);vertical-align:baseline;white-space:nowrap;}
+.rec__table td.mono{font-family:var(--font-data,monospace);font-size:11px;font-variant-numeric:tabular-nums;color:var(--text-muted,#59636F);}
+.rec__table td.memo{white-space:normal;max-width:0;width:99%;}
+.rec__table td.num{text-align:right;}
+.rec__table tr.matched td{background:var(--green-a10,rgba(22,136,95,.06));}
+.rec__table tr.open td{background:var(--orange-a10,rgba(138,82,14,.06));}
+.rec__empty{padding:16px 12px;font-family:var(--font-body,inherit);font-size:12px;color:var(--text-muted,#59636F);text-align:center;}
+.rec__summary{display:grid;grid-template-columns:1fr 1fr auto;gap:12px;align-items:center;
+  padding:10px 14px;border-top:2px solid var(--border-strong,#99A5B2);background:var(--bg-medium,#EBEFF4);}
+.rec__sumcell{display:flex;flex-direction:column;gap:2px;min-width:0;}
+.rec__sumlabel{font-family:var(--font-body,inherit);font-size:10px;font-weight:600;font-variant:all-small-caps;
+  letter-spacing:.03em;color:var(--text-muted,#59636F);}
+.rec__statusbox{display:flex;align-items:center;gap:7px;justify-self:end;
+  font-family:var(--font-body,inherit);font-size:11px;font-weight:600;font-variant:all-small-caps;
+  letter-spacing:.03em;border:1px solid;border-radius:var(--radius-chip,2px);padding:4px 10px;}
+.rec__statusbox--bal{background:var(--green-a10,rgba(22,136,95,.10));border-color:var(--green,#16885F);color:var(--green-dim,#10663F);}
+.rec__statusbox--out{background:var(--red-a10,rgba(186,63,85,.10));border-color:var(--red,#BA3F55);color:var(--red-dim,#8C2F40);}
+.rec__dot{height:6px;width:6px;border-radius:50%;background:currentColor;}
+`;
+  const el = document.createElement("style");
+  el.setAttribute("data-mds", "reconcile");
+  el.textContent = css;
+  document.head.appendChild(el);
+}
+
+function compareItems(a: ReconciliationItem, b: ReconciliationItem, key: string): number {
+  if (key === "amount") return (toNumber(a.amount) || 0) - (toNumber(b.amount) || 0);
+  if (key === "status") return (a.matched ? 1 : 0) - (b.matched ? 1 : 0);
+  const av = String(a[key] ?? "");
+  const bv = String(b[key] ?? "");
+  return av.localeCompare(bv, undefined, { numeric: true });
+}
+
+interface SortHeadProps {
+  col: ReconciliationColumn;
+  sort: Sort;
+  onSort: (key: string) => void;
+}
+function SortHead({ col, sort, onSort }: SortHeadProps) {
+  const active = sort.key === col.key;
+  return (
+    <th
+      className={`${col.num ? "num" : ""} ${active ? "is-sorted" : ""}`.trim()}
+      onClick={() => onSort(col.key)}
+      aria-sort={active ? (sort.dir > 0 ? "ascending" : "descending") : "none"}
+      scope="col"
+    >
+      {col.label}
+      {active && <span className={`rec__caret rec__caret--${sort.dir > 0 ? "asc" : "desc"}`} aria-hidden="true" />}
+    </th>
+  );
+}
+
+interface SideProps {
+  side: ReconciliationSide;
+  columns: ReconciliationColumn[];
+  currency: string;
+  status: StatusFilter;
+  query: string;
+  sort: Sort;
+  onSort: (key: string) => void;
+  onToggleItem?: ReconciliationPanelProps["onToggleItem"];
+  onToggleAll?: ReconciliationPanelProps["onToggleAll"];
+}
+function Side({ side, columns, currency, status, query, sort, onSort, onToggleItem, onToggleAll }: SideProps) {
+  const items = side.items || [];
+  const matched = items.filter((i) => i.matched).length;
+  const open = items.length - matched;
+
+  let rows = items;
+  if (status === "matched") rows = rows.filter((i) => i.matched);
+  else if (status === "open") rows = rows.filter((i) => !i.matched);
+
+  const q = query.trim().toLowerCase();
+  if (q) {
+    rows = rows.filter((i) => columns.some((c) => String(i[c.key] ?? "").toLowerCase().includes(q)));
+  }
+
+  if (sort.key) {
+    const key = sort.key;
+    rows = [...rows].sort((a, b) => sort.dir * compareItems(a, b, key));
+  }
+
+  const allMatched = rows.length > 0 && rows.every((i) => i.matched);
+
+  return (
+    <div className="rec__side">
+      <div className="rec__head">
+        <span className="rec__title">{side.title}</span>
+        <span className="rec__counts">
+          <span className="rec__chip rec__chip--ok">{matched} matched</span>
+          {open > 0 && <span className="rec__chip rec__chip--open">{open} open</span>}
+        </span>
+      </div>
+      <div className="rec__tablewrap">
+        <table className="rec__table">
+          <thead>
+            <tr>
+              <th style={{ width: 28, textAlign: "center" }}>
+                <input
+                  type="checkbox"
+                  checked={allMatched}
+                  aria-label={`Match all ${side.title} items`}
+                  onChange={(e) => onToggleAll?.(side, e.target.checked)}
+                />
+              </th>
+              {columns.map((c) => (
+                <SortHead key={c.key} col={c} sort={sort} onSort={onSort} />
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 && (
+              <tr>
+                <td className="rec__empty" colSpan={columns.length + 1}>
+                  No matching items
+                </td>
+              </tr>
+            )}
+            {rows.map((it, i) => (
+              <tr key={it.id ?? i} className={it.matched ? "matched" : "open"}>
+                <td style={{ textAlign: "center", paddingLeft: 6, paddingRight: 6 }}>
+                  <input
+                    type="checkbox"
+                    checked={it.matched || false}
+                    aria-label={`Match ${side.title} item ${it.ref ?? i + 1}`}
+                    onChange={(e) => onToggleItem?.(it.id, e.target.checked)}
+                  />
+                </td>
+                {columns.map((c) =>
+                  c.amount ? (
+                    <td key={c.key} className="num">
+                      <AmountCell value={it.amount} currency={currency} parens />
+                    </td>
+                  ) : (
+                    <td key={c.key} className={`${c.mono ? "mono" : ""} ${c.key === "memo" ? "memo" : ""}`.trim()}>
+                      {String(it[c.key] ?? "")}
+                    </td>
+                  )
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+const STATUS_TABS: Array<{ key: StatusFilter; label: string }> = [
+  { key: "all", label: "All" },
+  { key: "matched", label: "Matched" },
+  { key: "open", label: "Open" }
+];
+
+export function ReconciliationPanel({
+  left,
+  right,
+  columns,
+  currency = "USD",
+  statementBalance,
+  bookBalance,
+  tolerance = 0.005,
+  searchable = true,
+  filterable = true,
+  onToggleItem,
+  onToggleAll
+}: ReconciliationPanelProps) {
+  inject();
+  const [status, setStatus] = useState<StatusFilter>("all");
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<Sort>({ key: null, dir: 1 });
+
+  const onSort = (key: string) =>
+    setSort((s) => (s.key !== key ? { key, dir: 1 } : s.dir > 0 ? { key, dir: -1 } : { key: null, dir: 1 }));
+
+  // Resolve columns: explicit prop, else default set + Category only if present in the data.
+  const allItems = [...(left.items || []), ...(right.items || [])];
+  const hasCategory = allItems.some((i) => i.category != null && i.category !== "");
+  const cols: ReconciliationColumn[] =
+    columns || [
+      { key: "date", label: "Date", mono: true },
+      { key: "ref", label: "Reference", mono: true },
+      { key: "memo", label: "Memo" },
+      ...(hasCategory ? [{ key: "category", label: "Category" }] : []),
+      { key: "amount", label: "Amount", num: true, amount: true }
+    ];
+
+  const sb =
+    statementBalance != null
+      ? toNumber(statementBalance)
+      : (left.items || []).reduce((a, i) => a + (toNumber(i.amount) || 0), 0);
+  const bb =
+    bookBalance != null ? toNumber(bookBalance) : (right.items || []).reduce((a, i) => a + (toNumber(i.amount) || 0), 0);
+  const diff = sb - bb;
+  const balanced = Math.abs(diff) <= tolerance;
+
+  return (
+    <div className="rec" role="group" aria-label="Reconciliation">
+      {(filterable || searchable) && (
+        <div className="rec__toolbar">
+          {filterable ? (
+            <div className="rec__seg" role="group" aria-label="Filter by status">
+              {STATUS_TABS.map((t) => (
+                <button key={t.key} type="button" aria-pressed={status === t.key} onClick={() => setStatus(t.key)}>
+                  {t.label}
+                </button>
+              ))}
+            </div>
+          ) : (
+            <span />
+          )}
+          {searchable && (
+            <input
+              className="rec__search"
+              type="search"
+              placeholder="Filter memo, ref…"
+              aria-label="Filter reconciliation items"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+          )}
+        </div>
+      )}
+      <div className="rec__cols">
+        <Side
+          side={left}
+          columns={cols}
+          currency={currency}
+          status={status}
+          query={query}
+          sort={sort}
+          onSort={onSort}
+          onToggleItem={onToggleItem}
+          onToggleAll={onToggleAll}
+        />
+        <Side
+          side={right}
+          columns={cols}
+          currency={currency}
+          status={status}
+          query={query}
+          sort={sort}
+          onSort={onSort}
+          onToggleItem={onToggleItem}
+          onToggleAll={onToggleAll}
+        />
+      </div>
+      <div className="rec__summary">
+        <div className="rec__sumcell">
+          <span className="rec__sumlabel">{left.title} balance</span>
+          <AmountCell value={sb} currency={currency} parens strong />
+        </div>
+        <div className="rec__sumcell">
+          <span className="rec__sumlabel">{right.title} balance</span>
+          <AmountCell value={bb} currency={currency} parens strong />
+        </div>
+        <div className={`rec__statusbox ${balanced ? "rec__statusbox--bal" : "rec__statusbox--out"}`} role="status">
+          <span className="rec__dot" aria-hidden="true" />
+          {balanced ? (
+            "Reconciled"
+          ) : (
+            <>
+              Out by <AmountCell value={Math.abs(diff)} currency={currency} strong style={{ color: "inherit" }} />
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ReconciliationPanel.displayName = "ReconciliationPanel";

--- a/src/Meridian.Ui/dashboard/src/components/accounting/StatementTable.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/StatementTable.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { StatementTable, type StatementSection } from "./StatementTable";
+
+const sections: StatementSection[] = [
+  {
+    label: "Revenue",
+    rows: [{ label: "Trading fees", value: 12000 }],
+    subtotal: { label: "Total revenue", value: 12000 }
+  },
+  {
+    label: "Operating expenses",
+    rows: [{ label: "Data providers", value: -4000 }],
+    subtotal: { label: "Total expenses", value: -4000 }
+  }
+];
+
+describe("StatementTable", () => {
+  it("renders sections, line items, and a grand total", () => {
+    render(<StatementTable sections={sections} total={{ label: "Net income", value: 8000 }} currency="USD" />);
+    expect(screen.getByText("Revenue")).toBeInTheDocument();
+    expect(screen.getByText("Net income")).toBeInTheDocument();
+    expect(screen.getByText("$8,000.00")).toBeInTheDocument();
+  });
+
+  it("renders negatives in accounting parentheses", () => {
+    render(<StatementTable sections={sections} currency="USD" />);
+    expect(screen.getAllByText("($4,000.00)").length).toBeGreaterThan(0);
+  });
+
+  it("supports comparison columns via values maps", () => {
+    render(
+      <StatementTable
+        columns={[
+          { key: "cur", label: "2026" },
+          { key: "prv", label: "2025" }
+        ]}
+        sections={[{ rows: [{ label: "Cash", values: { cur: 100, prv: 80 } }] }]}
+        currency="USD"
+      />
+    );
+    expect(screen.getByText("$100.00")).toBeInTheDocument();
+    expect(screen.getByText("$80.00")).toBeInTheDocument();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/accounting/StatementTable.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/StatementTable.tsx
@@ -1,0 +1,160 @@
+// Meridian financial-statement table — P&L, balance sheet, or cash-flow layout: grouped sections
+// with indented line items, per-section subtotals, and a strong double-ruled grand total. Supports
+// one or two amount columns for period comparison. Negatives render in accounting parentheses.
+import { Fragment } from "react";
+import { AmountCell } from "./AmountCell";
+
+export interface StatementValue {
+  label: string;
+  /** Single amount (when there's one column). */
+  value?: number | string;
+  /** Per-column amounts, keyed by `columns[].key` (comparison statements). */
+  values?: Record<string, number | string>;
+  /** Indent level for nested line items. @default 0 */
+  indent?: number;
+  /** Render the label muted (informational sub-lines). */
+  muted?: boolean;
+}
+
+export interface StatementSection {
+  /** Small-caps section header (e.g. "Revenue", "Operating expenses"). Optional. */
+  label?: string;
+  rows: StatementValue[];
+  /** Section subtotal row (top border, bold). */
+  subtotal?: StatementValue;
+}
+
+export interface StatementColumn {
+  key: string;
+  label: string;
+}
+
+export interface StatementTableProps {
+  sections: StatementSection[];
+  /** Grand-total row — double-ruled, bold. */
+  total?: StatementValue;
+  /** Amount columns. Omit for a single unlabeled column. */
+  columns?: StatementColumn[];
+  /** @default "USD" */
+  currency?: string;
+  /** Negatives in parentheses. @default true */
+  parens?: boolean;
+  /** Color amounts as gains/losses (negative red / positive green). @default false */
+  pnl?: boolean;
+}
+
+let injected = false;
+function inject(): void {
+  if (injected || typeof document === "undefined") return;
+  injected = true;
+  const css = `
+.stm-wrap{overflow-x:auto;border:1px solid var(--border,#CBD3DC);
+  border-radius:var(--radius-chip,2px);background:var(--bg-light,#FFFFFF);}
+.stm{width:100%;border-collapse:separate;border-spacing:0;font-family:var(--font-data,monospace);font-size:12px;}
+.stm thead th{padding:9px 14px;white-space:nowrap;background:var(--bg-medium,#EBEFF4);
+  font-family:var(--font-body,inherit);font-size:10px;font-weight:600;font-variant:all-small-caps;
+  letter-spacing:.03em;color:var(--text-muted,#59636F);
+  border-bottom:1px solid var(--border,#CBD3DC);text-align:right;}
+.stm thead th.stm--l{text-align:left;}
+.stm__section td{padding:10px 14px 5px;font-family:var(--font-body,inherit);font-size:10px;font-weight:600;
+  font-variant:all-small-caps;letter-spacing:.05em;color:var(--text-secondary,#4D5967);
+  border-top:1px solid var(--border,#CBD3DC);}
+.stm__section--first td{border-top:none;}
+.stm__item td{padding:9px 14px;color:var(--text-primary,#22272E);height:40px;}
+.stm__item td.stm--l{color:var(--text-secondary,#4D5967);}
+.stm__item td.stm--num{text-align:right;}
+.stm__item--muted td.stm--l{color:var(--text-muted,#59636F);}
+.stm__sub td{padding:10px 14px;font-weight:600;border-top:1px solid var(--border,#CBD3DC);
+  background:var(--card-surface-raised,#F3F6F9);}
+.stm__sub td.stm--l{font-family:var(--font-body,inherit);font-variant:all-small-caps;letter-spacing:.03em;
+  font-size:11px;color:var(--text-primary,#22272E);}
+.stm__sub td.stm--num{text-align:right;}
+.stm__total td{padding:10px 14px;font-weight:600;background:var(--bg-medium,#EBEFF4);
+  border-top:2px solid var(--border-strong,#99A5B2);
+  border-bottom:3px double var(--border-strong,#99A5B2);}
+.stm__total td.stm--l{font-family:var(--font-body,inherit);font-variant:all-small-caps;letter-spacing:.04em;
+  font-size:12px;color:var(--text-primary,#22272E);}
+.stm__total td.stm--num{text-align:right;}
+`;
+  const el = document.createElement("style");
+  el.setAttribute("data-mds", "statement");
+  el.textContent = css;
+  document.head.appendChild(el);
+}
+
+export function StatementTable({ sections, total, columns, currency = "USD", parens = true, pnl = false }: StatementTableProps) {
+  inject();
+  const cols: StatementColumn[] = columns && columns.length ? columns : [{ key: "value", label: "" }];
+
+  const valuesOf = (obj: StatementValue | undefined | null): Array<number | string | undefined> => {
+    if (obj == null) return cols.map(() => undefined);
+    if (obj.values) return cols.map((c) => obj.values![c.key]);
+    return cols.map(() => obj.value); // single value broadcast (1-col case)
+  };
+
+  return (
+    <div className="stm-wrap" role="table" aria-label="Financial statement">
+      <table className="stm">
+        <thead>
+          <tr>
+            <th className="stm--l">&nbsp;</th>
+            {cols.map((c) => (
+              <th key={c.key}>{c.label}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sections.map((sec, si) => (
+            <Fragment key={si}>
+              {sec.label && (
+                <tr className={`stm__section${si === 0 ? " stm__section--first" : ""}`}>
+                  <td colSpan={cols.length + 1}>{sec.label}</td>
+                </tr>
+              )}
+              {(sec.rows || []).map((row, ri) => (
+                <tr key={ri} className={`stm__item${row.muted ? " stm__item--muted" : ""}`}>
+                  <td className="stm--l" style={{ paddingLeft: 14 + (row.indent || 0) * 16 }}>
+                    {row.label}
+                  </td>
+                  {valuesOf(row).map((v, vi) => (
+                    <td key={vi} className="stm--num">
+                      {v == null || v === "" ? (
+                        <span style={{ color: "var(--text-disabled, #889099)" }}>—</span>
+                      ) : (
+                        <AmountCell value={v} currency={currency} parens={parens} mode={pnl ? "pnl" : "plain"} />
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+              {sec.subtotal && (
+                <tr className="stm__sub">
+                  <td className="stm--l">{sec.subtotal.label}</td>
+                  {valuesOf(sec.subtotal).map((v, vi) => (
+                    <td key={vi} className="stm--num">
+                      <AmountCell value={v ?? ""} currency={currency} parens={parens} strong mode={pnl ? "pnl" : "plain"} />
+                    </td>
+                  ))}
+                </tr>
+              )}
+            </Fragment>
+          ))}
+        </tbody>
+        {total && (
+          <tfoot>
+            <tr className="stm__total">
+              <td className="stm--l">{total.label}</td>
+              {valuesOf(total).map((v, vi) => (
+                <td key={vi} className="stm--num">
+                  <AmountCell value={v ?? ""} currency={currency} parens={parens} strong mode={pnl ? "pnl" : "plain"} />
+                </td>
+              ))}
+            </tr>
+          </tfoot>
+        )}
+      </table>
+    </div>
+  );
+}
+
+StatementTable.displayName = "StatementTable";

--- a/src/Meridian.Ui/dashboard/src/components/accounting/TaxLotTable.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/TaxLotTable.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, within } from "@testing-library/react";
+import { TaxLotTable, type TaxLot } from "./TaxLotTable";
+
+const lots: TaxLot[] = [
+  // acquired long ago → long-term, gain
+  { id: "a", acquired: "2020-01-01", quantity: 10, costBasis: 1000, marketValue: 1500 },
+  // recently acquired → short-term, loss
+  { id: "b", acquired: "2026-06-01", quantity: 5, costBasis: 800, marketValue: 700 }
+];
+
+describe("TaxLotTable", () => {
+  it("classifies holding period by days held vs. the long-term threshold", () => {
+    render(<TaxLotTable lots={lots} currency="USD" asOf="2026-06-30" />);
+    expect(screen.getByText("Long-term")).toBeInTheDocument();
+    expect(screen.getByText("Short-term")).toBeInTheDocument();
+  });
+
+  it("computes unrealized gain per lot with a percent", () => {
+    render(<TaxLotTable lots={lots} currency="USD" asOf="2026-06-30" />);
+    // +500 on 1000 basis = +50.00%
+    expect(screen.getByText("+50.00%")).toBeInTheDocument();
+  });
+
+  it("rolls up basis, value, and total gain in the footer", () => {
+    render(<TaxLotTable lots={lots} currency="USD" asOf="2026-06-30" />);
+    const footer = screen.getByText("2 lots").closest("tr")!;
+    // total basis 1800, value 2200, gain +400
+    expect(within(footer).getByText("$1,800.00")).toBeInTheDocument();
+    expect(within(footer).getByText("$2,200.00")).toBeInTheDocument();
+    expect(within(footer).getByText("+$400.00")).toBeInTheDocument();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/accounting/TaxLotTable.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/TaxLotTable.tsx
@@ -1,0 +1,212 @@
+// Meridian tax-lot table — cost-basis lots with holding-period classification and unrealized (or
+// realized) P&L. Each lot: acquisition date + days held, quantity, cost basis, market value (or
+// proceeds), and gain/loss with a percent, plus a short/long-term badge derived from days held vs.
+// `longTermDays` (amber short-term / steel-blue long-term). The footer rolls up basis, value, and
+// total gain. All figures mono and tabular; P&L is red/green. Flat Concrete grid.
+import { AmountCell } from "./AmountCell";
+import { toNumber } from "./money";
+
+export interface TaxLot {
+  id?: string | number;
+  /** Acquisition date (ISO "2025-02-14"). Drives days-held and the holding-period badge. */
+  acquired: string;
+  /** Instrument symbol — shown only when `showSymbol` is set. */
+  symbol?: string;
+  quantity: number | string;
+  costBasis: number | string;
+  /** Current market value — used when mode = "unrealized". */
+  marketValue?: number | string;
+  /** Sale proceeds — used when mode = "realized". */
+  proceeds?: number | string;
+  /** Override computed holding days (e.g. server-supplied). */
+  daysHeld?: number;
+  /** Force the holding-period classification instead of deriving it. */
+  term?: "short" | "long";
+}
+
+export interface TaxLotTableProps {
+  lots: TaxLot[];
+  /** @default "USD" */
+  currency?: string;
+  /** ISO date the holding period and market value are measured at. @default now */
+  asOf?: string;
+  /** Days held at or above which a lot is long-term. @default 365 */
+  longTermDays?: number;
+  /** "unrealized" uses marketValue; "realized" uses proceeds. @default "unrealized" */
+  mode?: "unrealized" | "realized";
+  /** Include a Symbol column (cross-instrument lot list). @default false */
+  showSymbol?: boolean;
+  /** Accessible caption / region label. */
+  caption?: string;
+}
+
+let injected = false;
+function inject(): void {
+  if (injected || typeof document === "undefined") return;
+  injected = true;
+  const css = `
+.tlt-wrap{overflow-x:auto;border:1px solid var(--border,#CBD3DC);
+  border-radius:var(--radius-chip,2px);background:var(--bg-light,#FFFFFF);}
+.tlt{width:100%;min-width:100%;border-collapse:separate;border-spacing:0;
+  font-family:var(--font-data,monospace);font-size:12px;}
+.tlt thead th{padding:9px 12px;text-align:left;white-space:nowrap;position:sticky;top:0;z-index:1;
+  background:var(--bg-medium,#EBEFF4);
+  font-family:var(--font-body,inherit);font-size:10px;font-weight:600;font-variant:all-small-caps;
+  letter-spacing:.03em;color:var(--text-muted,#59636F);
+  border-bottom:1px solid var(--border-strong,#99A5B2);border-right:1px solid var(--border-divider,#CBD3DC);}
+.tlt thead th:last-child{border-right:none;}
+.tlt th.tlt--r{text-align:right;}
+.tlt td{padding:7px 12px;white-space:nowrap;color:var(--text-primary,#22272E);
+  border-top:1px solid var(--border,#CBD3DC);border-right:1px solid var(--border-divider,#CBD3DC);
+  vertical-align:middle;font-variant-numeric:tabular-nums;}
+.tlt td:last-child{border-right:none;}
+.tlt tbody tr:first-child td{border-top:none;}
+.tlt td.tlt--r{text-align:right;}
+.tlt tbody tr:hover{background:var(--bg-hover,#F3F6F9);}
+.tlt__date{color:var(--text-secondary,#4D5967);}
+.tlt__sym{font-weight:600;color:var(--text-primary,#22272E);}
+.tlt__days{color:var(--text-muted,#59636F);font-size:11px;}
+.tlt__hp{display:inline-flex;align-items:center;gap:5px;border:1px solid;border-radius:var(--radius-chip,2px);
+  padding:2px 7px;font-family:var(--font-body,inherit);font-size:10px;font-weight:600;font-variant:all-small-caps;
+  letter-spacing:.03em;white-space:nowrap;line-height:1.3;}
+.tlt__hp--short{background:var(--orange-a10,rgba(138,82,14,.10));border-color:var(--orange,#8A520E);color:var(--orange-dim,#683E0B);}
+.tlt__hp--long{background:var(--blue-a10,rgba(47,111,143,.10));border-color:var(--accent,#2F6F8F);color:var(--accent,#2F6F8F);}
+.tlt__hp__dot{height:5px;width:5px;border-radius:50%;background:currentColor;flex:0 0 auto;}
+.tlt__pct{font-family:var(--font-data,monospace);font-size:10.5px;margin-left:7px;}
+.tlt tfoot td{padding:9px 12px;background:var(--bg-medium,#EBEFF4);font-weight:600;
+  border-top:2px solid var(--border-strong,#99A5B2);color:var(--text-primary,#22272E);}
+.tlt tfoot td.tlt--r{text-align:right;}
+.tlt__foot-lbl{font-family:var(--font-body,inherit);font-size:11px;font-variant:all-small-caps;letter-spacing:.03em;color:var(--text-secondary,#4D5967);}
+`;
+  const el = document.createElement("style");
+  el.setAttribute("data-mds", "taxlot");
+  el.textContent = css;
+  document.head.appendChild(el);
+}
+
+const DAY = 86400000;
+function daysHeld(acquired: string, asOf?: string): number | null {
+  const a = Date.parse(acquired);
+  const b = asOf ? Date.parse(asOf) : Date.now();
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return null;
+  return Math.max(0, Math.floor((b - a) / DAY));
+}
+function fmtDays(d: number | null): string {
+  if (d == null) return "";
+  if (d < 365) return `${d}d`;
+  const y = Math.floor(d / 365);
+  const r = d % 365;
+  return r >= 30 ? `${y}y ${Math.floor(r / 30)}m` : `${y}y`;
+}
+function fmtQty(q: number | string): string {
+  const n = toNumber(q);
+  if (!Number.isFinite(n)) return String(q);
+  return n.toLocaleString("en-US", { maximumFractionDigits: 4 });
+}
+
+export function TaxLotTable({
+  lots,
+  currency = "USD",
+  asOf,
+  longTermDays = 365,
+  mode = "unrealized",
+  showSymbol = false,
+  caption
+}: TaxLotTableProps) {
+  inject();
+  const valueHead = mode === "realized" ? "Proceeds" : "Market value";
+  const gainHead = mode === "realized" ? "Realized P&L" : "Unrealized P&L";
+
+  const computed = lots.map((l) => {
+    const basis = toNumber(l.costBasis);
+    const value = toNumber(mode === "realized" ? l.proceeds : l.marketValue);
+    const gain = Number.isFinite(basis) && Number.isFinite(value) ? value - basis : NaN;
+    const pct = Number.isFinite(gain) && basis !== 0 ? (gain / Math.abs(basis)) * 100 : NaN;
+    const held = l.daysHeld != null ? l.daysHeld : daysHeld(l.acquired, asOf);
+    const long = l.term ? l.term === "long" : held != null && held >= longTermDays;
+    return { ...l, basis, value, gain, pct, held, long };
+  });
+
+  const tBasis = computed.reduce((a, r) => a + (Number.isFinite(r.basis) ? r.basis : 0), 0);
+  const tValue = computed.reduce((a, r) => a + (Number.isFinite(r.value) ? r.value : 0), 0);
+  const tGain = tValue - tBasis;
+
+  return (
+    <div className="tlt-wrap" role="region" aria-label={caption || "Tax lots"}>
+      <table className="tlt">
+        <thead>
+          <tr>
+            <th>Acquired</th>
+            {showSymbol && <th>Symbol</th>}
+            <th>Holding period</th>
+            <th className="tlt--r">Quantity</th>
+            <th className="tlt--r">Cost basis</th>
+            <th className="tlt--r">{valueHead}</th>
+            <th className="tlt--r">{gainHead}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {computed.map((r, i) => (
+            <tr key={r.id ?? i}>
+              <td className="tlt__date">
+                {r.acquired}
+                {r.held != null && <span className="tlt__days">{"  ·  "}{fmtDays(r.held)}</span>}
+              </td>
+              {showSymbol && <td className="tlt__sym">{r.symbol}</td>}
+              <td>
+                <span className={`tlt__hp ${r.long ? "tlt__hp--long" : "tlt__hp--short"}`}>
+                  <span className="tlt__hp__dot" aria-hidden="true" />
+                  {r.long ? "Long-term" : "Short-term"}
+                </span>
+              </td>
+              <td className="tlt--r">{fmtQty(r.quantity)}</td>
+              <td className="tlt--r">
+                <AmountCell value={r.basis} currency={currency} />
+              </td>
+              <td className="tlt--r">
+                <AmountCell value={r.value} currency={currency} />
+              </td>
+              <td className="tlt--r">
+                <AmountCell value={r.gain} currency={currency} mode="pnl" signed zeroDash />
+                {Number.isFinite(r.pct) && (
+                  <span
+                    className="tlt__pct"
+                    style={{
+                      color:
+                        r.gain < 0
+                          ? "var(--red-dim, #8C2F40)"
+                          : r.gain > 0
+                            ? "var(--green-dim, #10663F)"
+                            : "var(--text-muted, #59636F)"
+                    }}
+                  >
+                    {r.gain >= 0 ? "+" : "−"}
+                    {Math.abs(r.pct).toFixed(2)}%
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          <tr>
+            <td className="tlt__foot-lbl" colSpan={showSymbol ? 4 : 3}>
+              {computed.length} {computed.length === 1 ? "lot" : "lots"}
+            </td>
+            <td className="tlt--r">
+              <AmountCell value={tBasis} currency={currency} strong />
+            </td>
+            <td className="tlt--r">
+              <AmountCell value={tValue} currency={currency} strong />
+            </td>
+            <td className="tlt--r">
+              <AmountCell value={tGain} currency={currency} mode="pnl" signed strong />
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  );
+}
+
+TaxLotTable.displayName = "TaxLotTable";

--- a/src/Meridian.Ui/dashboard/src/components/accounting/index.ts
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/index.ts
@@ -1,0 +1,26 @@
+// Meridian "Concrete" accounting primitives — books-aware components that prove their own
+// arithmetic (LedgerTable flags imbalance, ReconciliationPanel flags "Out by …", JournalEntryForm
+// gates Post on balance, StatementTable double-rules totals, AccountTree rolls child balances,
+// TaxLotTable classifies long/short + basis/unrealized). All money flows through AmountCell.
+export * from "./money";
+
+export { AmountCell } from "./AmountCell";
+export type { AmountCellProps } from "./AmountCell";
+
+export { LedgerTable } from "./LedgerTable";
+export type { LedgerTableProps, LedgerRow } from "./LedgerTable";
+
+export { AccountTree } from "./AccountTree";
+export type { AccountTreeProps, AccountNode } from "./AccountTree";
+
+export { StatementTable } from "./StatementTable";
+export type { StatementTableProps, StatementSection, StatementValue, StatementColumn } from "./StatementTable";
+
+export { JournalEntryForm } from "./JournalEntryForm";
+export type { JournalEntryFormProps, JournalLine, JournalHeader, JournalEntry } from "./JournalEntryForm";
+
+export { TaxLotTable } from "./TaxLotTable";
+export type { TaxLotTableProps, TaxLot } from "./TaxLotTable";
+
+export { ReconciliationPanel } from "./ReconciliationPanel";
+export type { ReconciliationPanelProps, ReconciliationSide, ReconciliationItem, ReconciliationColumn } from "./ReconciliationPanel";

--- a/src/Meridian.Ui/dashboard/src/components/accounting/money.test.ts
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/money.test.ts
@@ -1,0 +1,74 @@
+import { currencySymbol, formatMoney, sumAmounts, toNumber } from "./money";
+
+// Currency codes without a mapped glyph render as "CODE" + a narrow no-break space (U+202F),
+// matching the Concrete thin-separator number convention.
+const NNBSP = " ";
+
+describe("money.toNumber", () => {
+  it("passes through finite numbers", () => {
+    expect(toNumber(1234.5)).toBe(1234.5);
+    expect(toNumber(0)).toBe(0);
+  });
+
+  it("reads accounting parentheses as negative", () => {
+    expect(toNumber("(1,234.00)")).toBe(-1234);
+    expect(toNumber("($921.00)")).toBe(-921);
+  });
+
+  it("parses signed and separated strings", () => {
+    expect(toNumber("-921.00")).toBe(-921);
+    expect(toNumber("12,000.25")).toBe(12000.25);
+    expect(toNumber("−45.5")).toBe(-45.5); // unicode minus
+  });
+
+  it("returns NaN for blank / unparseable input", () => {
+    expect(Number.isNaN(toNumber(""))).toBe(true);
+    expect(Number.isNaN(toNumber(null))).toBe(true);
+    expect(Number.isNaN(toNumber(undefined))).toBe(true);
+  });
+});
+
+describe("money.formatMoney", () => {
+  it("renders negatives with parentheses when parens is set", () => {
+    expect(formatMoney(-1234, { parens: true })).toBe("(1,234.00)");
+    expect(formatMoney(-1234, { currency: "USD", parens: true })).toBe("($1,234.00)");
+  });
+
+  it("renders negatives with a unicode minus by default", () => {
+    expect(formatMoney(-42.5)).toBe("−42.50");
+  });
+
+  it("renders exact zero as an em dash when zeroDash is set", () => {
+    expect(formatMoney(0, { zeroDash: true })).toBe("—");
+    expect(formatMoney(0)).toBe("0.00");
+  });
+
+  it("adds an explicit plus on positive deltas when signed", () => {
+    expect(formatMoney(18.4, { signed: true })).toBe("+18.40");
+    expect(formatMoney(-18.4, { signed: true })).toBe("−18.40");
+  });
+
+  it("honours the decimals option (prices use 4dp)", () => {
+    expect(formatMoney(101.2, { decimals: 4 })).toBe("101.2000");
+  });
+
+  it("prefixes the currency symbol (unknown codes use a narrow no-break space)", () => {
+    expect(formatMoney(5, { currency: "EUR" })).toBe("€5.00");
+    expect(formatMoney(5, { currency: "ZZZ" })).toBe(`ZZZ${NNBSP}5.00`);
+  });
+});
+
+describe("money.sumAmounts", () => {
+  it("sums money-ish values and ignores blanks/NaN", () => {
+    expect(sumAmounts([100, "(50.00)", "", null, "25.50"])).toBeCloseTo(75.5, 6);
+  });
+});
+
+describe("money.currencySymbol", () => {
+  it("maps known codes and falls back to a spaced prefix", () => {
+    expect(currencySymbol("USD")).toBe("$");
+    expect(currencySymbol("GBP")).toBe("£");
+    expect(currencySymbol()).toBe("");
+    expect(currencySymbol("XYZ")).toBe(`XYZ${NNBSP}`);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/accounting/money.ts
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/money.ts
@@ -1,0 +1,82 @@
+// Meridian accounting — shared money helpers. No React, no DOM. Used by AmountCell and the
+// ledger/statement primitives so every amount formats identically: mono tabular, fixed decimals,
+// accounting parentheses for negatives, zero-as-dash, explicit signs on deltas.
+
+/** Options accepted by {@link formatMoney}. */
+export interface FormatMoneyOptions {
+  /** Currency code (USD, EUR, GBP, JPY, CHF…). Omit for a bare number. */
+  currency?: string;
+  /** Decimal places. @default 2 */
+  decimals?: number;
+  /** Render negatives as `(1,234.00)` instead of `−1,234.00` (statement convention). @default false */
+  parens?: boolean;
+  /** Exact zero renders as an em dash. @default false */
+  zeroDash?: boolean;
+  /** Positives get an explicit leading `+`. @default false */
+  signed?: boolean;
+}
+
+const SYMBOLS: Record<string, string> = {
+  USD: "$",
+  EUR: "€",
+  GBP: "£",
+  JPY: "¥",
+  CNY: "¥",
+  CHF: "CHF ",
+  CAD: "$",
+  AUD: "$"
+};
+
+/** Currency code → leading symbol. Unknown codes render as a `"CODE "` prefix. */
+export function currencySymbol(code?: string | null): string {
+  if (!code) return "";
+  return SYMBOLS[code] ?? code + " ";
+}
+
+/**
+ * Coerce a value (number or money-ish string like `"(1,234.00)"`) to a Number.
+ * Returns `NaN` when the input is blank or unparseable. Accounting parentheses are read as
+ * negative so a round-tripped statement string parses back to its signed value.
+ */
+export function toNumber(value: number | string | null | undefined): number {
+  if (value == null || value === "") return NaN;
+  if (typeof value === "number") return value;
+  const s = String(value).trim();
+  const neg = /^\(.*\)$/.test(s); // accounting parentheses = negative
+  const cleaned = s.replace(/[(),\s]/g, "").replace(/[^0-9.−-]/g, "").replace(/−/g, "-");
+  const n = parseFloat(cleaned);
+  if (Number.isNaN(n)) return NaN;
+  return neg ? -Math.abs(n) : n;
+}
+
+/**
+ * Format a money value the Meridian way — tabular, fixed decimals, optional currency symbol.
+ *  - `parens`   → negatives as `(1,234.00)` instead of `−1,234.00` (statement convention)
+ *  - `zeroDash` → exact zero renders as an em dash
+ *  - `signed`   → positives get an explicit leading `+`
+ *
+ * Non-finite input passes through: `null`/`undefined` → `""`, everything else → its string form.
+ */
+export function formatMoney(value: number | string | null | undefined, opts: FormatMoneyOptions = {}): string {
+  const { currency, decimals = 2, parens = false, zeroDash = false, signed = false } = opts;
+  const num = toNumber(value);
+  if (!Number.isFinite(num)) return value == null ? "" : String(value);
+  if (zeroDash && num === 0) return "—";
+  const sym = currencySymbol(currency);
+  const mag = Math.abs(num).toLocaleString("en-US", {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals
+  });
+  const neg = num < 0;
+  if (neg && parens) return `(${sym}${mag})`;
+  const sign = neg ? "−" : signed && num > 0 ? "+" : "";
+  return `${sign}${sym}${mag}`;
+}
+
+/** Sum a list of money-ish values, ignoring blanks / NaN. */
+export function sumAmounts(values: Array<number | string | null | undefined>): number {
+  return values.reduce<number>((acc, v) => {
+    const n = toNumber(v);
+    return acc + (Number.isFinite(n) ? n : 0);
+  }, 0);
+}

--- a/src/Meridian.Ui/dashboard/src/components/charts/CandleChart.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/charts/CandleChart.tsx
@@ -1,0 +1,216 @@
+// Meridian candlestick chart — price/time axes with labels, gridlines, MA overlays, a crosshair
+// readout with a right-axis price chip, and an optional volume histogram subpane. Up candles use
+// --chart-equity (green, hollow body); down use --chart-drawdown (red, filled). SVG, flex-fills
+// its container — give the wrapper a definite height (see ChartCard).
+import { niceTicks } from "./ticks";
+
+export interface Candle {
+  /** X-axis time label, e.g. "10:48". */
+  t: string;
+  o: number;
+  h: number;
+  l: number;
+  c: number;
+  /** Volume (drives the histogram subpane). */
+  v?: number;
+}
+
+export interface CandleOverlay {
+  label: string;
+  /** CSS color (token var), e.g. "var(--accent, #2F6F8F)". */
+  color: string;
+  /** Moving-average window in bars. */
+  win: number;
+}
+
+export interface CandleChartProps {
+  bars: Candle[];
+  /** MA overlays. @default MA20 (accent) + MA50 (warning) */
+  overlays?: CandleOverlay[];
+  /** Bar index to mark with the crosshair + price chip. */
+  crosshairIndex?: number | null;
+  /** Show the volume histogram subpane. @default true */
+  showVolume?: boolean;
+  /** Approx. number of price gridlines. @default 6 */
+  priceTicks?: number;
+  /** Approx. number of time labels. @default 7 */
+  timeTicks?: number;
+}
+
+const DEFAULT_OVERLAYS: CandleOverlay[] = [
+  { label: "MA20", color: "var(--accent, #2F6F8F)", win: 20 },
+  { label: "MA50", color: "var(--chart-warning, #8A520E)", win: 50 }
+];
+
+const UP = "var(--chart-equity, #16885F)";
+const DOWN = "var(--chart-drawdown, #BA3F55)";
+const PLOT = "var(--chart-plot, #FFFFFF)";
+const GRID = "var(--chart-grid, #CBD3DC)";
+const AXIS = "var(--chart-axis, #59636F)";
+const BORDER = "var(--chart-border, #99A5B2)";
+const CROSSHAIR = "var(--chart-crosshair, #2F6F8F)";
+
+export function CandleChart({
+  bars,
+  overlays = DEFAULT_OVERLAYS,
+  crosshairIndex = null,
+  showVolume = true,
+  priceTicks = 6,
+  timeTicks = 7
+}: CandleChartProps) {
+  const W = 960;
+  const H = 540;
+  const padL = 48;
+  const padT = 14;
+  const axisR = 64;
+  const axisB = 28;
+  const volH = showVolume ? 80 : 0;
+  const volGap = showVolume ? 12 : 0;
+  const plotL = padL;
+  const plotR = W - axisR;
+  const priceT = padT;
+  const priceB = H - axisB - volH - volGap;
+  const volB = H - axisB;
+  const volT = priceB + volGap;
+
+  const denom = bars.length > 1 ? bars.length - 1 : 1;
+  const his = bars.map((b) => b.h);
+  const los = bars.map((b) => b.l);
+  let max = his.length ? Math.max(...his) : 1;
+  let min = los.length ? Math.min(...los) : 0;
+  const padv = (max - min) * 0.08 || 1;
+  max += padv;
+  min -= padv;
+  const maxVol = Math.max(...bars.map((b) => b.v || 0), 0) || 1;
+
+  const x = (i: number) => plotL + i * ((plotR - plotL) / denom);
+  const yP = (v: number) => priceT + (max - v) * ((priceB - priceT) / (max - min || 1));
+  const yV = (v: number) => volB - (v / maxVol) * (volB - volT);
+  const bw = Math.max(2.2, ((plotR - plotL) / (bars.length || 1)) * 0.68);
+
+  const ma = (win: number): Array<number | null> =>
+    bars.map((_, i) => {
+      if (i < win - 1) return null;
+      const slice = bars.slice(i - win + 1, i + 1);
+      return slice.reduce((acc, b) => acc + b.c, 0) / slice.length;
+    });
+  const maPath = (win: number) => {
+    let d = "";
+    let started = false;
+    ma(win).forEach((v, i) => {
+      if (v == null) return;
+      d += `${started ? "L" : "M"}${x(i).toFixed(1)},${yP(v).toFixed(1)} `;
+      started = true;
+    });
+    return d.trim();
+  };
+
+  const pTicks = niceTicks(min, max, priceTicks);
+  const tStep = Math.max(1, Math.round((bars.length || 1) / timeTicks));
+  const ch = crosshairIndex != null && bars[crosshairIndex] ? bars[crosshairIndex] : null;
+
+  const axFont = { fontFamily: "var(--font-data, monospace)", fontSize: 11 };
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      style={{ width: "100%", height: "100%", display: "block" }}
+      role="img"
+      aria-label="Candlestick price chart"
+    >
+      <rect x="0" y="0" width={W} height={H} fill={PLOT} />
+      {/* price gridlines + right-axis labels */}
+      {pTicks.map((v, k) => (
+        <g key={k}>
+          <line x1={plotL} x2={plotR} y1={yP(v)} y2={yP(v)} stroke={GRID} strokeWidth="1" />
+          <text x={plotR + 7} y={yP(v) + 4} fill={AXIS} style={axFont}>
+            {v.toFixed(2)}
+          </text>
+        </g>
+      ))}
+      {/* time gridlines + bottom labels */}
+      {bars.map((b, i) =>
+        i % tStep === 0 || i === bars.length - 1 ? (
+          <g key={"t" + i}>
+            <line x1={x(i)} x2={x(i)} y1={priceT} y2={priceB} stroke={GRID} strokeWidth="1" opacity="0.6" />
+            <text x={x(i)} y={H - 7} fill={AXIS} textAnchor="middle" style={axFont}>
+              {b.t}
+            </text>
+          </g>
+        ) : null
+      )}
+      {/* axis frame */}
+      <line x1={plotL} x2={plotR} y1={priceB} y2={priceB} stroke={BORDER} strokeWidth="1" />
+      <line x1={plotR} x2={plotR} y1={priceT} y2={volB} stroke={BORDER} strokeWidth="1" />
+
+      {/* volume histogram */}
+      {showVolume &&
+        bars.map((b, i) => {
+          const up = b.c >= b.o;
+          const top = yV(b.v || 0);
+          return (
+            <rect
+              key={"v" + i}
+              x={x(i) - bw / 2}
+              y={top}
+              width={bw}
+              height={Math.max(0, volB - top)}
+              fill={up ? UP : DOWN}
+              opacity="0.28"
+            />
+          );
+        })}
+      {showVolume && <line x1={plotL - 1} x2={plotR} y1={volB} y2={volB} stroke={BORDER} strokeWidth="1.2" />}
+
+      {/* candles */}
+      {bars.map((b, i) => {
+        const up = b.c >= b.o;
+        const col = up ? UP : DOWN;
+        const bodyY = yP(Math.max(b.o, b.c));
+        const bodyH = Math.max(1, Math.abs(yP(b.o) - yP(b.c)));
+        return (
+          <g key={i}>
+            <line x1={x(i)} x2={x(i)} y1={yP(b.h)} y2={yP(b.l)} stroke={col} strokeWidth="1" />
+            <rect x={x(i) - bw / 2} y={bodyY} width={bw} height={bodyH} fill={up ? PLOT : col} stroke={col} strokeWidth="1" />
+          </g>
+        );
+      })}
+
+      {/* MA overlays */}
+      {overlays.map((o, k) => (
+        <path key={k} d={maPath(o.win)} fill="none" stroke={o.color} strokeWidth="1.5" />
+      ))}
+
+      {/* crosshair */}
+      {ch && crosshairIndex != null && (
+        <g>
+          <line
+            x1={x(crosshairIndex)}
+            x2={x(crosshairIndex)}
+            y1={priceT}
+            y2={volB}
+            stroke={CROSSHAIR}
+            strokeWidth="1.2"
+            strokeDasharray="4 2"
+            opacity="0.8"
+          />
+          <line x1={plotL} x2={plotR} y1={yP(ch.c)} y2={yP(ch.c)} stroke={CROSSHAIR} strokeWidth="1.2" strokeDasharray="4 2" opacity="0.8" />
+          <circle cx={x(crosshairIndex)} cy={yP(ch.c)} r="4" fill={CROSSHAIR} opacity="0.9" />
+          <rect x={plotR + 2} y={yP(ch.c) - 10} width={axisR - 4} height="20" fill={CROSSHAIR} rx="2" opacity="0.95" />
+          <text
+            x={plotR + axisR / 2}
+            y={yP(ch.c) + 5}
+            fill="#fff"
+            textAnchor="middle"
+            style={{ ...axFont, fontWeight: 600, fontSize: 13 }}
+          >
+            {ch.c.toFixed(2)}
+          </text>
+        </g>
+      )}
+    </svg>
+  );
+}
+
+CandleChart.displayName = "CandleChart";

--- a/src/Meridian.Ui/dashboard/src/components/charts/ChartCard.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/charts/ChartCard.tsx
@@ -1,0 +1,111 @@
+// Meridian chart card — the ChartCardStyle wrapper: header row (title + optional small-caps
+// OHLC/stat readout + actions) over a framed plot area. Hosts CandleChart / EquityCurve panes.
+// Flat Concrete surface: white panel, hairline border, no shadow.
+import type { CSSProperties, ReactNode } from "react";
+
+export interface ChartReadoutItem {
+  label: string;
+  value: ReactNode;
+  /** Override the value color (e.g. green / red). */
+  color?: string;
+}
+
+export interface ChartCardProps {
+  title: string;
+  subtitle?: string;
+  /** Inline OHLC / stat readout shown beside the title. */
+  readout?: ChartReadoutItem[];
+  /** Right-aligned controls (timeframe buttons, etc.). */
+  actions?: ReactNode;
+  /**
+   * Plot-area height in px. Pass `null` to let the plot flex-fill a definite-height parent.
+   * @default 320
+   */
+  height?: number | null;
+  children?: ReactNode;
+  style?: CSSProperties;
+}
+
+export function ChartCard({ title, subtitle, readout, actions, height = 320, children, style = {} }: ChartCardProps) {
+  return (
+    <div
+      style={{
+        background: "var(--card-surface, var(--panel, #FFFFFF))",
+        border: "1px solid var(--border, #CBD3DC)",
+        borderRadius: "var(--radius-card, 2px)",
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+        ...style
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          padding: "12px 14px",
+          borderBottom: "1px solid var(--border, #CBD3DC)"
+        }}
+      >
+        <div style={{ minWidth: 0 }}>
+          <div
+            style={{
+              fontFamily: "var(--font-display, inherit)",
+              fontSize: 14,
+              fontWeight: 600,
+              color: "var(--text-primary, #22272E)"
+            }}
+          >
+            {title}
+          </div>
+          {subtitle && <div style={{ fontSize: 11, color: "var(--text-muted, #59636F)", marginTop: 1 }}>{subtitle}</div>}
+        </div>
+        {readout && (
+          <div style={{ display: "flex", gap: 16, marginLeft: 8, flexWrap: "wrap" }}>
+            {readout.map((r, i) => (
+              <div key={i} style={{ display: "flex", flexDirection: "column" }}>
+                <span
+                  style={{
+                    fontFamily: "var(--font-body, inherit)",
+                    fontSize: 9,
+                    fontVariant: "all-small-caps",
+                    letterSpacing: ".03em",
+                    color: "var(--text-muted, #59636F)"
+                  }}
+                >
+                  {r.label}
+                </span>
+                <span
+                  style={{
+                    fontFamily: "var(--font-data, monospace)",
+                    fontSize: 12,
+                    fontVariantNumeric: "tabular-nums",
+                    color: r.color || "var(--text-primary, #22272E)"
+                  }}
+                >
+                  {r.value}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+        <div style={{ flex: 1 }} />
+        {actions}
+      </div>
+      <div
+        style={{
+          height: height ?? undefined,
+          flex: height == null ? 1 : undefined,
+          minHeight: 0,
+          padding: 8,
+          background: "var(--chart-plot, #FFFFFF)"
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+ChartCard.displayName = "ChartCard";

--- a/src/Meridian.Ui/dashboard/src/components/charts/CorrelationHeatmap.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/charts/CorrelationHeatmap.tsx
@@ -1,0 +1,100 @@
+// Meridian CorrelationHeatmap — a square matrix of pairwise correlations (-1..1). Positive
+// correlation washes green, negative red, intensity by magnitude; the diagonal reads 1.00. A
+// token-driven grid (not SVG) so values stay legible and cells stay square at any size.
+import { Fragment } from "react";
+
+export interface CorrelationHeatmapProps {
+  /** Axis labels (tickers/series), length N. Used for both rows and columns. */
+  labels: string[];
+  /** N×N correlation values in -1..1; `matrix[r][c]`. */
+  matrix: Array<Array<number | null>>;
+  /** Cell value formatter. @default v => v.toFixed(2) */
+  valueFmt?: (v: number) => string;
+  /** Square cell edge in px. @default 46 */
+  cellSize?: number;
+  /** Row-header column width in px. @default 56 */
+  headerSize?: number;
+  /** Print the numeric value inside each cell. @default true */
+  showValues?: boolean;
+  /** Hover callback with { row, col, value }. */
+  onCellHover?: ((cell: { row: number; col: number; value: number | null }) => void) | null;
+}
+
+let injected = false;
+function inject(): void {
+  if (injected || typeof document === "undefined") return;
+  injected = true;
+  const css = `
+.mds-corr{display:inline-grid;gap:1px;background:var(--border,#CBD3DC);
+  border:1px solid var(--border-strong,#99A5B2);font-family:var(--font-data,monospace);}
+.mds-corr__h{background:var(--bg-medium,#EBEFF4);color:var(--text-secondary,#4D5967);
+  font-size:11px;font-weight:600;display:flex;align-items:center;justify-content:center;
+  padding:4px 6px;white-space:nowrap;}
+.mds-corr__rh{justify-content:flex-end;padding-right:8px;}
+.mds-corr__cell{display:flex;align-items:center;justify-content:center;font-size:11px;
+  color:var(--text-primary,#22272E);font-variant-numeric:tabular-nums;cursor:default;}
+.mds-corr__cell--diag{color:var(--text-muted,#59636F);background:var(--bg-active,#E6EEF5)!important;}
+.mds-corr__corner{background:var(--bg-medium,#EBEFF4);}
+`;
+  const el = document.createElement("style");
+  el.setAttribute("data-mds", "corr-heatmap");
+  el.textContent = css;
+  document.head.appendChild(el);
+}
+
+function cellColor(v: number | null): string {
+  if (v == null || Number.isNaN(v)) return "var(--bg-light,#FFFFFF)";
+  const mag = Math.min(1, Math.abs(v));
+  const pct = (mag * 62).toFixed(0);
+  const base = v >= 0 ? "var(--green,#16885F)" : "var(--red,#BA3F55)";
+  return `color-mix(in srgb, ${base} ${pct}%, var(--bg-light,#FFFFFF))`;
+}
+
+export function CorrelationHeatmap({
+  labels = [],
+  matrix = [],
+  valueFmt = (v) => v.toFixed(2),
+  cellSize = 46,
+  headerSize = 56,
+  showValues = true,
+  onCellHover = null
+}: CorrelationHeatmapProps) {
+  inject();
+  const n = labels.length;
+  const cols = `${headerSize}px repeat(${n}, ${cellSize}px)`;
+
+  return (
+    <div className="mds-corr" style={{ gridTemplateColumns: cols }} role="grid" aria-label="Correlation matrix">
+      <div className="mds-corr__corner" />
+      {labels.map((l) => (
+        <div key={"ch" + l} className="mds-corr__h" role="columnheader">
+          {l}
+        </div>
+      ))}
+      {matrix.map((row, r) => (
+        <Fragment key={"r" + r}>
+          <div className="mds-corr__h mds-corr__rh" role="rowheader">
+            {labels[r]}
+          </div>
+          {row.map((v, c) => {
+            const diag = r === c;
+            return (
+              <div
+                key={"c" + r + "-" + c}
+                role="gridcell"
+                className={`mds-corr__cell${diag ? " mds-corr__cell--diag" : ""}`}
+                style={{ background: cellColor(v), height: cellSize }}
+                title={`${labels[r]} · ${labels[c]} = ${v == null ? "—" : valueFmt(v)}`}
+                onMouseEnter={onCellHover ? () => onCellHover({ row: r, col: c, value: v }) : undefined}
+              >
+                {showValues && v != null && !Number.isNaN(v) ? valueFmt(v) : ""}
+              </div>
+            );
+          })}
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+
+CorrelationHeatmap.displayName = "CorrelationHeatmap";

--- a/src/Meridian.Ui/dashboard/src/components/charts/DepthChart.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/charts/DepthChart.tsx
@@ -1,0 +1,145 @@
+// Meridian DepthChart — order-book market depth (volume profile). Cumulative bid size rises as a
+// green step area toward the mid from the left; cumulative ask size rises red to the right. The
+// mid price marks the spread. Reads a live order book at a glance. Explicit-height svg.
+
+export interface DepthLevel {
+  price: number;
+  size: number;
+}
+
+export interface DepthChartProps {
+  /** Bid levels — any order; cumulated outward from the mid. */
+  bids: DepthLevel[];
+  /** Ask levels — any order; cumulated outward from the mid. */
+  asks: DepthLevel[];
+  /** Mid price. @default midpoint of best bid / best ask */
+  mid?: number | null;
+  /** Format for price-axis values. @default p => p.toFixed(2) */
+  priceFmt?: (p: number) => string;
+  /** Format for cumulative-size axis. @default 1.2k-style */
+  sizeFmt?: (s: number) => string;
+  /** @default 4 */
+  sizeTicks?: number;
+  /** @default 7 */
+  priceTicks?: number;
+}
+
+const PLOT = "var(--chart-plot, #FFFFFF)";
+const GRID = "var(--chart-grid, #CBD3DC)";
+const AXIS = "var(--chart-axis, #59636F)";
+const BORDER = "var(--chart-border, #99A5B2)";
+const CROSSHAIR = "var(--chart-crosshair, #2F6F8F)";
+const UP = "var(--chart-equity, #16885F)";
+const DOWN = "var(--chart-drawdown, #BA3F55)";
+
+export function DepthChart({
+  bids = [],
+  asks = [],
+  mid = null,
+  priceFmt = (p) => p.toFixed(2),
+  sizeFmt = (s) => (s >= 1000 ? `${(s / 1000).toFixed(1)}k` : String(s)),
+  sizeTicks = 4,
+  priceTicks = 7
+}: DepthChartProps) {
+  const W = 960;
+  const H = 360;
+  const padT = 16;
+  const axisB = 26;
+  const axisL = 8;
+  const axisR = 52;
+  const plotL = axisL;
+  const plotR = W - axisR;
+  const plotT = padT;
+  const plotB = H - axisB;
+
+  // sort outward from the mid
+  const bidsS = [...bids].sort((a, b) => b.price - a.price); // best (highest) first
+  const asksS = [...asks].sort((a, b) => a.price - b.price); // best (lowest) first
+  const bestBid = bidsS.length ? bidsS[0].price : null;
+  const bestAsk = asksS.length ? asksS[0].price : null;
+  const midPrice =
+    mid != null ? mid : bestBid != null && bestAsk != null ? (bestBid + bestAsk) / 2 : bestBid ?? bestAsk ?? 0;
+
+  // cumulative depth outward from mid
+  let cum = 0;
+  const bidPts = bidsS.map((b) => {
+    cum += b.size;
+    return { price: b.price, depth: cum };
+  });
+  cum = 0;
+  const askPts = asksS.map((a) => {
+    cum += a.size;
+    return { price: a.price, depth: cum };
+  });
+
+  const allP = [...bids, ...asks].map((d) => d.price);
+  const pLo = allP.length ? Math.min(...allP) : midPrice - 1;
+  const pHi = allP.length ? Math.max(...allP) : midPrice + 1;
+  const pSpan = pHi - pLo || 1;
+  const maxDepth = Math.max(1, ...bidPts.map((p) => p.depth), ...askPts.map((p) => p.depth));
+
+  const x = (p: number) => plotL + ((p - pLo) / pSpan) * (plotR - plotL);
+  const y = (d: number) => plotB - (d / maxDepth) * (plotB - plotT);
+
+  const step = (pts: Array<{ price: number; depth: number }>) => {
+    if (!pts.length) return "";
+    let d = `M${x(midPrice).toFixed(1)},${y(0).toFixed(1)}`;
+    let prevDepth = 0;
+    for (const p of pts) {
+      d += ` L${x(p.price).toFixed(1)},${y(prevDepth).toFixed(1)} L${x(p.price).toFixed(1)},${y(p.depth).toFixed(1)}`;
+      prevDepth = p.depth;
+    }
+    const last = pts[pts.length - 1];
+    d += ` L${x(last.price).toFixed(1)},${y(0).toFixed(1)} Z`;
+    return d;
+  };
+
+  const bidPath = step(bidPts);
+  const askPath = step(askPts);
+
+  const labelFont = { fontFamily: "var(--font-data, monospace)", fontSize: 11 };
+  const sTicks = Array.from({ length: sizeTicks + 1 }, (_, i) => Math.round((i / sizeTicks) * maxDepth));
+  const pStep = Math.max(1, Math.round(priceTicks));
+  const priceLabels = Array.from({ length: pStep + 1 }, (_, i) => pLo + (i / pStep) * pSpan);
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      style={{ width: "100%", height: "100%", display: "block" }}
+      role="img"
+      aria-label="Order-book depth chart"
+    >
+      <rect x="0" y="0" width={W} height={H} fill={PLOT} />
+      {[...new Set(sTicks)].map((s, k) => (
+        <g key={k}>
+          <line x1={plotL} x2={plotR} y1={y(s)} y2={y(s)} stroke={GRID} strokeWidth="0.8" opacity="0.55" />
+          <text x={plotR + 8} y={y(s) + 4} fill={AXIS} textAnchor="start" style={labelFont}>
+            {sizeFmt(s)}
+          </text>
+        </g>
+      ))}
+
+      {bidPath && <path d={bidPath} fill={UP} opacity="0.18" />}
+      {bidPath && <path d={bidPath} fill="none" stroke={UP} strokeWidth="1.6" />}
+      {askPath && <path d={askPath} fill={DOWN} opacity="0.18" />}
+      {askPath && <path d={askPath} fill="none" stroke={DOWN} strokeWidth="1.6" />}
+
+      {/* mid / spread */}
+      <line x1={x(midPrice)} x2={x(midPrice)} y1={plotT} y2={plotB} stroke={CROSSHAIR} strokeWidth="1.2" strokeDasharray="4 3" />
+      <rect x={x(midPrice) - 38} y={plotT - 2} width="76" height="17" fill={CROSSHAIR} opacity="0.95" />
+      <text x={x(midPrice)} y={plotT + 11} fill="#fff" textAnchor="middle" style={{ ...labelFont, fontWeight: 600 }}>
+        mid {priceFmt(midPrice)}
+      </text>
+
+      {priceLabels.map((p, i) => (
+        <text key={"p" + i} x={x(p)} y={H - 8} fill={AXIS} textAnchor="middle" style={labelFont}>
+          {priceFmt(p)}
+        </text>
+      ))}
+      <line x1={plotL} x2={plotR} y1={plotB} y2={plotB} stroke={BORDER} strokeWidth="1.2" />
+    </svg>
+  );
+}
+
+DepthChart.displayName = "DepthChart";

--- a/src/Meridian.Ui/dashboard/src/components/charts/DrawdownChart.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/charts/DrawdownChart.tsx
@@ -1,0 +1,125 @@
+// Meridian DrawdownChart — the underwater plot. Drawdown (peak-to-trough decline, always ≤ 0)
+// hangs below a 0% waterline as a filled curve, with an optional dashed limit rule and a marker
+// on the maximum drawdown. Pairs beside an EquityCurve in backtest / strategy reporting.
+import { niceTicks } from "./ticks";
+
+export interface DrawdownChartProps {
+  /** Drawdown series in percent — 0 or negative values (e.g. -12.4). */
+  series: number[];
+  /** Time-axis labels, parallel to `series`. */
+  labels?: string[];
+  /** Optional limit line in percent (e.g. -10) — dashed warning rule. */
+  threshold?: number | null;
+  /** Format for axis + marker values. @default v => `${v.toFixed(0)}%` */
+  valueFmt?: (v: number) => string;
+  /** Mark the maximum drawdown point. @default true */
+  markMax?: boolean;
+  /** @default 5 */
+  valueTicks?: number;
+  /** @default 7 */
+  timeTicks?: number;
+}
+
+const PLOT = "var(--chart-plot, #FFFFFF)";
+const GRID = "var(--chart-grid, #CBD3DC)";
+const AXIS = "var(--chart-axis, #59636F)";
+const BORDER = "var(--chart-border, #99A5B2)";
+const DRAWDOWN = "var(--chart-drawdown, #BA3F55)";
+const WARNING = "var(--chart-warning, #8A520E)";
+
+export function DrawdownChart({
+  series,
+  labels = [],
+  threshold = null,
+  valueFmt = (v) => `${v.toFixed(0)}%`,
+  markMax = true,
+  valueTicks = 5,
+  timeTicks = 7
+}: DrawdownChartProps) {
+  const W = 960;
+  const H = 360;
+  const padT = 14;
+  const axisR = 56;
+  const axisB = 26;
+  const plotL = 8;
+  const plotR = W - axisR;
+  const plotT = padT;
+  const plotB = H - axisB;
+
+  const n = series.length;
+  const denom = n > 1 ? n - 1 : 1;
+  const dd = series.map((v) => Math.min(0, v));
+  const min = Math.min(...dd, threshold != null ? threshold : 0, 0) * 1.08 || -1;
+  const max = 0;
+
+  const x = (i: number) => plotL + i * ((plotR - plotL) / denom);
+  const y = (v: number) => plotT + (max - v) * ((plotB - plotT) / (max - min || 1));
+  const path = dd.map((v, i) => `${i === 0 ? "M" : "L"}${x(i).toFixed(1)},${y(v).toFixed(1)}`).join(" ");
+  const areaPath = n ? `M${x(0).toFixed(1)},${y(0).toFixed(1)} ${path.slice(1)} L${x(n - 1).toFixed(1)},${y(0).toFixed(1)} Z` : "";
+
+  const vTicks = niceTicks(min, max, valueTicks).filter((v) => v <= 0);
+  const tStep = Math.max(1, Math.round((n || 1) / timeTicks));
+  const labelFont = { fontFamily: "var(--font-data, monospace)", fontSize: 11 };
+
+  let maxIdx = 0;
+  for (let i = 1; i < n; i++) if (dd[i] < dd[maxIdx]) maxIdx = i;
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      style={{ width: "100%", height: "100%", display: "block" }}
+      role="img"
+      aria-label="Drawdown underwater chart"
+    >
+      <rect x="0" y="0" width={W} height={H} fill={PLOT} />
+      {vTicks.map((v, k) => (
+        <g key={k}>
+          <line x1={plotL} x2={plotR} y1={y(v)} y2={y(v)} stroke={GRID} strokeWidth="0.8" opacity="0.6" />
+          <text x={plotR + 8} y={y(v) + 4} fill={AXIS} textAnchor="start" style={labelFont}>
+            {valueFmt(v)}
+          </text>
+        </g>
+      ))}
+      {labels.map((lab, i) =>
+        i % tStep === 0 || i === n - 1 ? (
+          <text key={"t" + i} x={x(i)} y={H - 8} fill={AXIS} textAnchor="middle" style={labelFont}>
+            {lab}
+          </text>
+        ) : null
+      )}
+
+      {/* underwater fill + curve */}
+      {areaPath && <path d={areaPath} fill={DRAWDOWN} opacity="0.18" />}
+      {path && <path d={path} fill="none" stroke={DRAWDOWN} strokeWidth="1.6" />}
+
+      {/* 0% waterline */}
+      <line x1={plotL} x2={plotR} y1={y(0)} y2={y(0)} stroke={BORDER} strokeWidth="1.2" />
+
+      {/* threshold rule */}
+      {threshold != null && (
+        <g>
+          <line x1={plotL} x2={plotR} y1={y(threshold)} y2={y(threshold)} stroke={WARNING} strokeWidth="1.2" strokeDasharray="5 4" opacity="0.85" />
+          <text x={plotL + 4} y={y(threshold) - 5} fill={WARNING} style={{ ...labelFont, fontWeight: 600 }}>
+            {valueFmt(threshold)} limit
+          </text>
+        </g>
+      )}
+
+      {/* max drawdown marker */}
+      {markMax && n > 0 && (
+        <g>
+          <line x1={x(maxIdx)} x2={x(maxIdx)} y1={y(0)} y2={y(dd[maxIdx])} stroke={DRAWDOWN} strokeWidth="1" strokeDasharray="3 3" opacity="0.7" />
+          <circle cx={x(maxIdx)} cy={y(dd[maxIdx])} r="3.5" fill={DRAWDOWN} />
+          <rect x={Math.min(x(maxIdx) + 6, plotR - 70)} y={y(dd[maxIdx]) - 9} width="66" height="18" fill={DRAWDOWN} opacity="0.95" />
+          <text x={Math.min(x(maxIdx) + 6, plotR - 70) + 33} y={y(dd[maxIdx]) + 4} fill="#fff" textAnchor="middle" style={{ ...labelFont, fontWeight: 600 }}>
+            max {valueFmt(dd[maxIdx])}
+          </text>
+        </g>
+      )}
+      <line x1={plotR} x2={plotR} y1={plotT} y2={plotB} stroke={BORDER} strokeWidth="1.2" />
+    </svg>
+  );
+}
+
+DrawdownChart.displayName = "DrawdownChart";

--- a/src/Meridian.Ui/dashboard/src/components/charts/EquityCurve.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/charts/EquityCurve.tsx
@@ -1,0 +1,221 @@
+// Meridian equity curve — line (with area fill) + benchmark overlay, value-axis labels,
+// gridlines, legend, crosshair readout, and an optional drawdown subpane. Mirrors the
+// performance charts in analytics / backtest reporting. Flex-fills its container.
+import { niceTicks } from "./ticks";
+
+export interface EquitySeries {
+  label: string;
+  /** CSS color (token var). */
+  color: string;
+  points: number[];
+  /** Render dashed (benchmarks). @default false */
+  dashed?: boolean;
+  /** Set false to skip the area fill on the primary series. */
+  area?: boolean;
+}
+
+export interface EquityCurveProps {
+  /** First series is primary (gets the area fill + crosshair price chip). */
+  series: EquitySeries[];
+  /** X-axis time labels, aligned to the point index. */
+  labels?: string[];
+  /** Drawdown values (≤ 0) for the bottom subpane. */
+  drawdown?: number[] | null;
+  /** Format value-axis + crosshair labels. @default v => v.toFixed(0) */
+  valueFmt?: (v: number) => string;
+  /** Point index to mark with the crosshair. */
+  crosshairIndex?: number | null;
+  /** Approx. number of value gridlines. @default 6 */
+  valueTicks?: number;
+  /** Approx. number of time labels. @default 7 */
+  timeTicks?: number;
+  /** Show the legend row. @default true */
+  showLegend?: boolean;
+  /** Area fill under the primary series. @default true */
+  fill?: boolean;
+}
+
+const PLOT = "var(--chart-plot, #FFFFFF)";
+const GRID = "var(--chart-grid, #CBD3DC)";
+const AXIS = "var(--chart-axis, #59636F)";
+const BORDER = "var(--chart-border, #99A5B2)";
+const CROSSHAIR = "var(--chart-crosshair, #2F6F8F)";
+const DRAWDOWN = "var(--chart-drawdown, #BA3F55)";
+
+export function EquityCurve({
+  series,
+  labels = [],
+  drawdown = null,
+  valueFmt = (v) => v.toFixed(0),
+  crosshairIndex = null,
+  valueTicks = 6,
+  timeTicks = 7,
+  showLegend = true,
+  fill = true
+}: EquityCurveProps) {
+  const W = 960;
+  const H = 460;
+  const padL = 48;
+  const padT = 14;
+  const axisR = 62;
+  const axisB = 28;
+  const ddH = drawdown ? 88 : 0;
+  const ddGap = drawdown ? 12 : 0;
+  const plotL = padL;
+  const plotR = W - axisR;
+  const eqT = padT;
+  const eqB = H - axisB - ddH - ddGap;
+  const ddT = eqB + ddGap;
+  const ddB = H - axisB;
+
+  const primary = series[0];
+  const n = primary ? primary.points.length : 0;
+  const denom = n > 1 ? n - 1 : 1;
+  const allV = series.flatMap((s) => s.points);
+  let max = allV.length ? Math.max(...allV) : 1;
+  let min = allV.length ? Math.min(...allV) : 0;
+  const pv = (max - min) * 0.08 || 1;
+  max += pv;
+  min -= pv;
+
+  const x = (i: number) => plotL + i * ((plotR - plotL) / denom);
+  const y = (v: number) => eqT + (max - v) * ((eqB - eqT) / (max - min || 1));
+  const line = (pts: number[]) => pts.map((v, i) => `${i === 0 ? "M" : "L"}${x(i).toFixed(1)},${y(v).toFixed(1)}`).join(" ");
+  const area = (pts: number[]) => `${line(pts)} L${x(n - 1).toFixed(1)},${eqB} L${x(0).toFixed(1)},${eqB} Z`;
+
+  const vTicks = niceTicks(min, max, valueTicks);
+  const tStep = Math.max(1, Math.round((n || 1) / timeTicks));
+  const axFont = { fontFamily: "var(--font-data, monospace)", fontSize: 12, fontWeight: 500 };
+  const labelFont = { fontFamily: "var(--font-data, monospace)", fontSize: 11 };
+
+  // drawdown subpane scale (drawdown values are <= 0)
+  const ddMin = drawdown ? Math.min(...drawdown, 0) : 0;
+  const yD = (v: number) => ddT + (0 - v) * ((ddB - ddT) / (ddMin || -1));
+  const ddArea = drawdown
+    ? `M${x(0).toFixed(1)},${yD(0).toFixed(1)} ${drawdown
+        .map((v, i) => `L${x(i).toFixed(1)},${yD(v).toFixed(1)}`)
+        .join(" ")} L${x(n - 1).toFixed(1)},${yD(0).toFixed(1)} Z`
+    : "";
+
+  const legendText = { fontFamily: "var(--font-data, monospace)", fontSize: 11, color: "var(--text-secondary, #4D5967)" };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      {showLegend && (
+        <div style={{ display: "flex", gap: 16, padding: "0 8px 8px", flexWrap: "wrap" }}>
+          {series.map((s, k) => (
+            <span key={k} style={{ display: "inline-flex", alignItems: "center", gap: 6, ...legendText }}>
+              <span style={{ width: 14, height: 0, borderTop: `2px ${s.dashed ? "dashed" : "solid"} ${s.color}` }} />
+              {s.label}
+            </span>
+          ))}
+          {drawdown && (
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 6, ...legendText }}>
+              <span style={{ width: 14, height: 8, background: DRAWDOWN, opacity: 0.25 }} />
+              drawdown
+            </span>
+          )}
+        </div>
+      )}
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        preserveAspectRatio="none"
+        style={{ width: "100%", flex: 1, display: "block" }}
+        role="img"
+        aria-label="Equity performance curve"
+      >
+        <rect x="0" y="0" width={W} height={H} fill={PLOT} />
+        {/* value gridlines + labels */}
+        {vTicks.map((v, k) => (
+          <g key={k}>
+            <line x1={plotL} x2={plotR} y1={y(v)} y2={y(v)} stroke={GRID} strokeWidth="0.8" opacity="0.65" />
+            <text x={plotR + 8} y={y(v) + 5} fill={AXIS} textAnchor="start" style={labelFont}>
+              {valueFmt(v)}
+            </text>
+          </g>
+        ))}
+        {/* time labels */}
+        {labels.map((lab, i) =>
+          i % tStep === 0 || i === n - 1 ? (
+            <g key={"t" + i}>
+              <line x1={x(i)} x2={x(i)} y1={eqT} y2={eqB} stroke={GRID} strokeWidth="0.8" opacity="0.55" />
+              <text x={x(i)} y={H - 8} fill={AXIS} textAnchor="middle" style={labelFont}>
+                {lab}
+              </text>
+            </g>
+          ) : null
+        )}
+        <line x1={plotR} x2={plotR} y1={eqT} y2={ddB} stroke={BORDER} strokeWidth="1.2" />
+        <line x1={plotL - 1} x2={plotR} y1={eqB} y2={eqB} stroke={BORDER} strokeWidth="1.2" />
+        <line x1={plotL - 1} x2={plotL - 1} y1={eqT} y2={eqB} stroke={BORDER} strokeWidth="1" opacity="0.4" />
+
+        {/* area fill for the primary series */}
+        {fill && primary && primary.area !== false && <path d={area(primary.points)} fill={primary.color} opacity="0.10" />}
+        {/* series lines */}
+        {series.map((s, k) => (
+          <path
+            key={k}
+            d={line(s.points)}
+            fill="none"
+            stroke={s.color}
+            strokeWidth={k === 0 ? 2 : 1.5}
+            strokeDasharray={s.dashed ? "5 4" : undefined}
+          />
+        ))}
+
+        {/* drawdown subpane */}
+        {drawdown && (
+          <g>
+            <path d={ddArea} fill={DRAWDOWN} opacity="0.20" />
+            <path
+              d={`M${x(0).toFixed(1)},${yD(drawdown[0]).toFixed(1)} ${drawdown
+                .map((v, i) => `L${x(i).toFixed(1)},${yD(v).toFixed(1)}`)
+                .join(" ")}`}
+              fill="none"
+              stroke={DRAWDOWN}
+              strokeWidth="1.4"
+            />
+            <line x1={plotL - 1} x2={plotR} y1={yD(0)} y2={yD(0)} stroke={BORDER} strokeWidth="1" opacity="0.6" />
+            <text x={plotR + 8} y={yD(0) + 5} fill={AXIS} textAnchor="start" style={labelFont}>
+              0%
+            </text>
+            <text x={plotR + 8} y={ddB} fill={AXIS} textAnchor="start" style={labelFont}>
+              {ddMin.toFixed(0)}%
+            </text>
+          </g>
+        )}
+
+        {/* crosshair */}
+        {crosshairIndex != null && primary && primary.points[crosshairIndex] != null && (
+          <g>
+            <line
+              x1={x(crosshairIndex)}
+              x2={x(crosshairIndex)}
+              y1={eqT}
+              y2={ddB}
+              stroke={CROSSHAIR}
+              strokeWidth="1.2"
+              strokeDasharray="4 2"
+              opacity="0.8"
+            />
+            {series.map((s, k) => (
+              <circle key={k} cx={x(crosshairIndex)} cy={y(s.points[crosshairIndex])} r="4" fill={s.color} opacity="0.9" />
+            ))}
+            <rect x={plotR + 2} y={y(primary.points[crosshairIndex]) - 10} width={axisR - 4} height="20" fill={CROSSHAIR} rx="2" opacity="0.95" />
+            <text
+              x={plotR + axisR / 2}
+              y={y(primary.points[crosshairIndex]) + 5}
+              fill="#fff"
+              textAnchor="middle"
+              style={{ ...axFont, fontWeight: 600, fontSize: 13 }}
+            >
+              {valueFmt(primary.points[crosshairIndex])}
+            </text>
+          </g>
+        )}
+      </svg>
+    </div>
+  );
+}
+
+EquityCurve.displayName = "EquityCurve";

--- a/src/Meridian.Ui/dashboard/src/components/charts/Histogram.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/charts/Histogram.tsx
@@ -1,0 +1,161 @@
+// Meridian Histogram — distribution of a sample (daily returns, slippage, fill latency). Pass
+// raw `values` (auto-binned) or precomputed `bins`. When `signed`, bars left of zero tint red and
+// right of zero green so a returns distribution reads instantly; an optional dashed mean rule
+// overlays. Flat, token-driven, explicit-height svg.
+
+export interface HistogramBin {
+  x0: number;
+  x1: number;
+  count: number;
+}
+
+export interface HistogramProps {
+  /** Raw sample — auto-binned. Provide this OR `bins`. */
+  values?: number[] | null;
+  /** Precomputed bins. Provide this OR `values`. */
+  bins?: HistogramBin[] | null;
+  /** Bin count when auto-binning `values`. @default 24 */
+  binCount?: number;
+  /** Tint bars red/green by the sign of their center (returns view). @default true */
+  signed?: boolean;
+  /** Draw the dashed mean rule. @default true */
+  showMean?: boolean;
+  /** Override the computed mean. */
+  mean?: number | null;
+  /** Format for x-axis bin-edge values. @default v => v.toFixed(1) */
+  valueFmt?: (v: number) => string;
+  /** Format for y-axis counts. @default String */
+  countFmt?: (c: number) => string;
+  /** @default 7 */
+  xTicks?: number;
+}
+
+const PLOT = "var(--chart-plot, #FFFFFF)";
+const GRID = "var(--chart-grid, #CBD3DC)";
+const AXIS = "var(--chart-axis, #59636F)";
+const BORDER = "var(--chart-border, #99A5B2)";
+const CROSSHAIR = "var(--chart-crosshair, #2F6F8F)";
+const UP = "var(--chart-equity, #16885F)";
+const DOWN = "var(--chart-drawdown, #BA3F55)";
+const PRIMARY = "var(--chart-primary, #2F6F8F)";
+
+function buildBins(values: number[], binCount: number): HistogramBin[] {
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min || 1;
+  const w = span / binCount;
+  const bins: HistogramBin[] = Array.from({ length: binCount }, (_, i) => ({
+    x0: min + i * w,
+    x1: min + (i + 1) * w,
+    count: 0
+  }));
+  for (const v of values) {
+    let i = Math.floor((v - min) / w);
+    if (i >= binCount) i = binCount - 1;
+    if (i < 0) i = 0;
+    bins[i].count += 1;
+  }
+  return bins;
+}
+
+export function Histogram({
+  values = null,
+  bins: presetBins = null,
+  binCount = 24,
+  signed = true,
+  showMean = true,
+  mean: meanProp = null,
+  valueFmt = (v) => v.toFixed(1),
+  countFmt = (c) => String(c),
+  xTicks = 7
+}: HistogramProps) {
+  const bins = presetBins || (values && values.length ? buildBins(values, binCount) : []);
+  const W = 960;
+  const H = 340;
+  const padT = 14;
+  const axisB = 28;
+  const axisL = 40;
+  const axisR = 10;
+  const plotL = axisL;
+  const plotR = W - axisR;
+  const plotT = padT;
+  const plotB = H - axisB;
+  const n = bins.length;
+  const maxCount = Math.max(1, ...bins.map((b) => b.count));
+  const lo = n ? bins[0].x0 : 0;
+  const hi = n ? bins[n - 1].x1 : 1;
+  const span = hi - lo || 1;
+
+  const bx = (v: number) => plotL + ((v - lo) / span) * (plotR - plotL);
+  const by = (c: number) => plotB - (c / maxCount) * (plotB - plotT);
+  const gap = 1.5;
+
+  const mean =
+    meanProp != null ? meanProp : values && values.length ? values.reduce((a, b) => a + b, 0) / values.length : null;
+
+  const cTicks = [0, 0.25, 0.5, 0.75, 1].map((f) => Math.round(f * maxCount));
+  const labelFont = { fontFamily: "var(--font-data, monospace)", fontSize: 11 };
+  const tStep = Math.max(1, Math.round((n || 1) / xTicks));
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      style={{ width: "100%", height: "100%", display: "block" }}
+      role="img"
+      aria-label="Distribution histogram"
+    >
+      <rect x="0" y="0" width={W} height={H} fill={PLOT} />
+      {[...new Set(cTicks)].map((c, k) => (
+        <g key={k}>
+          <line x1={plotL} x2={plotR} y1={by(c)} y2={by(c)} stroke={GRID} strokeWidth="0.8" opacity="0.55" />
+          <text x={plotL - 6} y={by(c) + 4} fill={AXIS} textAnchor="end" style={labelFont}>
+            {countFmt(c)}
+          </text>
+        </g>
+      ))}
+
+      {bins.map((b, i) => {
+        const center = (b.x0 + b.x1) / 2;
+        const color = !signed ? PRIMARY : center < 0 ? DOWN : UP;
+        const x0 = bx(b.x0) + gap;
+        const x1 = bx(b.x1) - gap;
+        const top = by(b.count);
+        return <rect key={i} x={x0} y={top} width={Math.max(0.5, x1 - x0)} height={plotB - top} fill={color} opacity="0.75" />;
+      })}
+
+      {/* x labels at bin edges */}
+      {bins.map((b, i) =>
+        i % tStep === 0 ? (
+          <text key={"x" + i} x={bx(b.x0)} y={H - 9} fill={AXIS} textAnchor="middle" style={labelFont}>
+            {valueFmt(b.x0)}
+          </text>
+        ) : null
+      )}
+      {n > 0 && (
+        <text x={bx(bins[n - 1].x1)} y={H - 9} fill={AXIS} textAnchor="middle" style={labelFont}>
+          {valueFmt(bins[n - 1].x1)}
+        </text>
+      )}
+
+      {/* zero reference */}
+      {signed && lo < 0 && hi > 0 && <line x1={bx(0)} x2={bx(0)} y1={plotT} y2={plotB} stroke={BORDER} strokeWidth="1" opacity="0.5" />}
+
+      {/* mean rule */}
+      {showMean && mean != null && mean >= lo && mean <= hi && (
+        <g>
+          <line x1={bx(mean)} x2={bx(mean)} y1={plotT} y2={plotB} stroke={CROSSHAIR} strokeWidth="1.2" strokeDasharray="5 3" />
+          <rect x={Math.min(bx(mean) + 5, plotR - 78)} y={plotT} width="74" height="17" fill={CROSSHAIR} opacity="0.95" />
+          <text x={Math.min(bx(mean) + 5, plotR - 78) + 37} y={plotT + 12} fill="#fff" textAnchor="middle" style={{ ...labelFont, fontWeight: 600 }}>
+            μ {valueFmt(mean)}
+          </text>
+        </g>
+      )}
+
+      <line x1={plotL} x2={plotR} y1={plotB} y2={plotB} stroke={BORDER} strokeWidth="1.2" />
+      <line x1={plotL} x2={plotL} y1={plotT} y2={plotB} stroke={BORDER} strokeWidth="1" opacity="0.5" />
+    </svg>
+  );
+}
+
+Histogram.displayName = "Histogram";

--- a/src/Meridian.Ui/dashboard/src/components/charts/Sparkline.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/charts/Sparkline.tsx
@@ -1,0 +1,102 @@
+// Meridian Sparkline — inline mini chart for MetricCard and table cells.
+// Line, area, and bar variants. SVG-based, zero deps. Concrete tokens with hex fallbacks.
+
+export interface SparklineProps {
+  /** The data series. An empty array renders nothing. */
+  points?: number[];
+  /** @default 80 */
+  width?: number;
+  /** @default 28 */
+  height?: number;
+  /** @default "line" */
+  variant?: "line" | "area" | "bar";
+  /** Series color. @default var(--chart-equity, #16885F) */
+  color?: string;
+  /** Line stroke width. @default 1.5 */
+  strokeWidth?: number;
+  /** Reference line / bar-sign pivot (e.g. 0 for P&L). Values below it draw red. */
+  baseline?: number | null;
+}
+
+const DOWN = "var(--chart-drawdown, #BA3F55)";
+
+export function Sparkline({
+  points = [],
+  width = 80,
+  height = 28,
+  variant = "line",
+  color = "var(--chart-equity, #16885F)",
+  strokeWidth = 1.5,
+  baseline = null
+}: SparklineProps) {
+  if (!points.length) return null;
+
+  const n = points.length;
+  const min = Math.min(...points);
+  const max = Math.max(...points);
+  const range = max - min || 1;
+  const padV = 2;
+
+  const xScale = (i: number) => (n === 1 ? width / 2 : (i / (n - 1)) * width);
+  const yScale = (v: number) => height - padV - ((v - min) / range) * (height - padV * 2);
+
+  if (variant === "bar") {
+    const barW = Math.max(1, (width / n) * 0.72);
+    return (
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        style={{ display: "block", overflow: "visible" }}
+        aria-hidden="true"
+      >
+        {points.map((v, i) => {
+          const barH = Math.max(1, ((v - min) / range) * (height - padV));
+          const isPos = baseline == null || v >= baseline;
+          return (
+            <rect
+              key={i}
+              x={xScale(i) - barW / 2}
+              y={height - barH}
+              width={barW}
+              height={barH}
+              fill={isPos ? color : DOWN}
+              opacity="0.85"
+            />
+          );
+        })}
+      </svg>
+    );
+  }
+
+  const pathD = points.map((v, i) => `${i === 0 ? "M" : "L"}${xScale(i).toFixed(1)},${yScale(v).toFixed(1)}`).join(" ");
+  const areaD = `${pathD} L${xScale(n - 1).toFixed(1)},${height} L${xScale(0).toFixed(1)},${height} Z`;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      style={{ display: "block", overflow: "visible" }}
+      aria-hidden="true"
+    >
+      {variant === "area" && <path d={areaD} fill={color} opacity="0.15" />}
+      {baseline != null && (
+        <line
+          x1={0}
+          x2={width}
+          y1={yScale(baseline)}
+          y2={yScale(baseline)}
+          stroke={color}
+          strokeWidth="0.5"
+          opacity="0.4"
+          strokeDasharray="2 2"
+        />
+      )}
+      <path d={pathD} fill="none" stroke={color} strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" />
+      <circle cx={xScale(n - 1)} cy={yScale(points[n - 1])} r="2.5" fill={color} />
+    </svg>
+  );
+}
+
+Sparkline.displayName = "Sparkline";

--- a/src/Meridian.Ui/dashboard/src/components/charts/charts.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/charts/charts.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from "@testing-library/react";
+import { CandleChart, type Candle } from "./CandleChart";
+import { EquityCurve } from "./EquityCurve";
+import { DrawdownChart } from "./DrawdownChart";
+import { Histogram } from "./Histogram";
+import { DepthChart } from "./DepthChart";
+import { CorrelationHeatmap } from "./CorrelationHeatmap";
+import { Sparkline } from "./Sparkline";
+import { ChartCard } from "./ChartCard";
+
+const bars: Candle[] = [
+  { t: "10:00", o: 100, h: 105, l: 99, c: 104, v: 1200 },
+  { t: "10:01", o: 104, h: 106, l: 102, c: 103, v: 900 },
+  { t: "10:02", o: 103, h: 108, l: 103, c: 107, v: 1500 }
+];
+
+describe("CandleChart", () => {
+  it("renders an accessible svg with a candle per bar", () => {
+    const { container } = render(<CandleChart bars={bars} showVolume />);
+    expect(screen.getByRole("img", { name: "Candlestick price chart" })).toBeInTheDocument();
+    // wick line + body rect per bar exist
+    expect(container.querySelectorAll("rect").length).toBeGreaterThanOrEqual(bars.length);
+  });
+
+  it("draws a crosshair price chip at the given index", () => {
+    const { container } = render(<CandleChart bars={bars} crosshairIndex={2} />);
+    // The close price (107.00) shows as the white-filled crosshair chip label (distinct from the
+    // axis tick that may share the value).
+    const chip = Array.from(container.querySelectorAll("text")).find(
+      (t) => t.getAttribute("fill") === "#fff" && t.textContent === "107.00"
+    );
+    expect(chip).toBeTruthy();
+  });
+});
+
+describe("EquityCurve", () => {
+  it("renders a legend and a series path", () => {
+    const { container } = render(
+      <EquityCurve
+        series={[{ label: "Strategy", color: "var(--chart-equity, #16885F)", points: [100, 110, 105, 120] }]}
+        labels={["Jan", "Feb", "Mar", "Apr"]}
+      />
+    );
+    expect(screen.getByText("Strategy")).toBeInTheDocument();
+    expect(container.querySelectorAll("path").length).toBeGreaterThan(0);
+  });
+
+  it("renders a drawdown subpane when drawdown is supplied", () => {
+    render(
+      <EquityCurve
+        series={[{ label: "S", color: "#16885F", points: [100, 90, 95] }]}
+        drawdown={[0, -10, -5]}
+      />
+    );
+    expect(screen.getByText("drawdown")).toBeInTheDocument();
+  });
+});
+
+describe("DrawdownChart", () => {
+  it("marks the maximum drawdown", () => {
+    render(<DrawdownChart series={[0, -5, -12, -8]} labels={["a", "b", "c", "d"]} />);
+    expect(screen.getByText(/max/)).toBeInTheDocument();
+  });
+
+  it("labels a threshold rule", () => {
+    render(<DrawdownChart series={[0, -5, -12]} threshold={-10} />);
+    expect(screen.getByText(/limit/)).toBeInTheDocument();
+  });
+});
+
+describe("Histogram", () => {
+  it("auto-bins raw values into an svg", () => {
+    const { container } = render(<Histogram values={[-2, -1, 0, 1, 2, 1, 0, -1]} binCount={6} />);
+    expect(screen.getByRole("img", { name: "Distribution histogram" })).toBeInTheDocument();
+    expect(container.querySelectorAll("rect").length).toBeGreaterThan(1);
+  });
+
+  it("renders precomputed bins", () => {
+    const { container } = render(
+      <Histogram
+        bins={[
+          { x0: -1, x1: 0, count: 3 },
+          { x0: 0, x1: 1, count: 5 }
+        ]}
+      />
+    );
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+});
+
+describe("DepthChart", () => {
+  it("renders bid/ask step areas and the mid label", () => {
+    render(
+      <DepthChart
+        bids={[
+          { price: 99, size: 100 },
+          { price: 98, size: 200 }
+        ]}
+        asks={[
+          { price: 101, size: 150 },
+          { price: 102, size: 120 }
+        ]}
+      />
+    );
+    expect(screen.getByText(/mid/)).toBeInTheDocument();
+  });
+});
+
+describe("CorrelationHeatmap", () => {
+  it("renders a grid with the diagonal reading 1.00", () => {
+    render(
+      <CorrelationHeatmap
+        labels={["AAPL", "MSFT"]}
+        matrix={[
+          [1, 0.4],
+          [0.4, 1]
+        ]}
+      />
+    );
+    expect(screen.getByRole("grid", { name: "Correlation matrix" })).toBeInTheDocument();
+    expect(screen.getAllByText("1.00").length).toBe(2);
+  });
+});
+
+describe("Sparkline", () => {
+  it("renders nothing for an empty series", () => {
+    const { container } = render(<Sparkline points={[]} />);
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("renders a line variant path", () => {
+    const { container } = render(<Sparkline points={[1, 3, 2, 5]} />);
+    expect(container.querySelector("path")).toBeInTheDocument();
+  });
+
+  it("renders a bar variant with one rect per point", () => {
+    const { container } = render(<Sparkline points={[1, -2, 3]} variant="bar" baseline={0} />);
+    expect(container.querySelectorAll("rect").length).toBe(3);
+  });
+});
+
+describe("ChartCard", () => {
+  it("renders title, readout, and children", () => {
+    render(
+      <ChartCard title="AAPL" subtitle="1m" readout={[{ label: "Last", value: "104.00" }]}>
+        <div data-testid="plot">plot</div>
+      </ChartCard>
+    );
+    expect(screen.getByText("AAPL")).toBeInTheDocument();
+    expect(screen.getByText("Last")).toBeInTheDocument();
+    expect(screen.getByTestId("plot")).toBeInTheDocument();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/charts/index.ts
+++ b/src/Meridian.Ui/dashboard/src/components/charts/index.ts
@@ -1,0 +1,25 @@
+// Meridian "Concrete" chart primitives — SVG-based, responsive, token-driven (with hex fallbacks).
+// Charts flex-fill their container: give the wrapper a definite height (see ChartCard).
+export { ChartCard } from "./ChartCard";
+export type { ChartCardProps, ChartReadoutItem } from "./ChartCard";
+
+export { CandleChart } from "./CandleChart";
+export type { CandleChartProps, Candle, CandleOverlay } from "./CandleChart";
+
+export { EquityCurve } from "./EquityCurve";
+export type { EquityCurveProps, EquitySeries } from "./EquityCurve";
+
+export { DrawdownChart } from "./DrawdownChart";
+export type { DrawdownChartProps } from "./DrawdownChart";
+
+export { Histogram } from "./Histogram";
+export type { HistogramProps, HistogramBin } from "./Histogram";
+
+export { DepthChart } from "./DepthChart";
+export type { DepthChartProps, DepthLevel } from "./DepthChart";
+
+export { CorrelationHeatmap } from "./CorrelationHeatmap";
+export type { CorrelationHeatmapProps } from "./CorrelationHeatmap";
+
+export { Sparkline } from "./Sparkline";
+export type { SparklineProps } from "./Sparkline";

--- a/src/Meridian.Ui/dashboard/src/components/charts/ticks.ts
+++ b/src/Meridian.Ui/dashboard/src/components/charts/ticks.ts
@@ -1,0 +1,14 @@
+// Shared axis-tick helper for the SVG chart primitives. Produces "nice" round tick values
+// (1/2/5 × 10ⁿ steps) spanning [min, max] with roughly `count` divisions.
+
+export function niceTicks(min: number, max: number, count: number): number[] {
+  const span = max - min || 1;
+  const raw = span / Math.max(1, count);
+  const mag = Math.pow(10, Math.floor(Math.log10(raw)));
+  const norm = raw / mag;
+  const step = (norm >= 5 ? 5 : norm >= 2 ? 2 : 1) * mag;
+  const start = Math.ceil(min / step) * step;
+  const out: number[] = [];
+  for (let v = start; v <= max + 1e-9; v += step) out.push(+v.toFixed(6));
+  return out;
+}


### PR DESCRIPTION
## Web UI Concrete — U5: charts + accounting components (Wave 1 foundation)

Foundation unit **U5 of 5**. Adds two NEW shared component libraries for the Meridian "Concrete"
design system that Wave 2 screens will adopt. No existing files changed; both directories are new
and self-contained (no cross-unit imports), so this is independently mergeable.

### New: `src/components/charts/` (SVG-based, responsive, definite-height wrappers)
- `CandleChart` — OHLC candles (hollow-up/filled-down), price/time axes, gridlines, MA overlays,
  optional volume subpane, crosshair price chip.
- `EquityCurve` — line + area, benchmark overlay, legend, value axis, optional drawdown subpane,
  crosshair readout.
- `DrawdownChart` — underwater plot with 0% waterline, optional limit rule, max-drawdown marker.
- `Histogram` — auto-binned or precomputed bins; red/green sign tint; mean rule.
- `DepthChart` — cumulative bid/ask step areas around a mid/spread marker.
- `CorrelationHeatmap` — token-driven grid, green/red magnitude wash, diagonal = 1.00.
- `Sparkline` — inline line/area/bar mini-chart.
- `ChartCard` — titled, readout/actions frame hosting a plot (flat, hairline, no shadow).

### New: `src/components/accounting/` (books-aware; tables prove their own arithmetic)
- `money` util (`formatMoney`, `sumAmounts`, `toNumber`, `currencySymbol`) — mono tabular, fixed
  decimals, accounting parentheses for negatives, zero-as-dash, explicit delta signs.
- `AmountCell` — the money atom (plain / pnl / muted tones).
- `LedgerTable` — debit/credit + running balance; footer flags imbalance.
- `AccountTree` — chart-of-accounts hierarchy; parents roll up child balances.
- `StatementTable` — grouped sections, subtotals, double-ruled grand total; 1–2 columns.
- `JournalEntryForm` — double-entry input; Post gated on balance; "Out by …" until balanced.
- `TaxLotTable` — long/short classification + basis/unrealized (or realized) P&L rollup.
- `ReconciliationPanel` — two-sided compare, status filter + search + sortable headers; summary
  flags "Reconciled" / "Out by …".

### Design fidelity ("Concrete")
Re-implemented natively in React 18 + TypeScript + Tailwind 3 to match the handoff's visual output
(not its structure). 2px radii, flat hairline surfaces, white panels. Tokens are consumed with hex
fallbacks (e.g. `var(--chart-equity, #16885F)`) so components render correctly before sibling U1's
token layer merges. Charts flex-fill their container per PATTERNS.md.

### Validation
- `npm ci` — clean, 0 vulnerabilities.
- `npm run build` (`tsc --noEmit`) — new files type-check clean.
- Co-located tests: **48 passing** across 8 files (charts smoke/render + accounting arithmetic;
  money/AmountCell negatives→parentheses, zero→dash, sign/currency formatting).
- `/code-review` pass applied (test-scoping + assertion fixes; no component bugs found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
