### PR TITLE
Web UI Concrete — mainfix: restore green build + tests on main

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/data/column-chooser.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/column-chooser.tsx
@@ -75,7 +75,9 @@ export function ColumnChooser({ columns = [], visible, onChange }: ColumnChooser
   const toggle = (key: string) => {
     const next = new Set(visSet);
     if (next.has(key)) {
-      if (next.size > 1) next.delete(key);
+      // Never hide the last remaining column — a table always needs one.
+      if (next.size <= 1) return;
+      next.delete(key);
     } else {
       next.add(key);
     }

--- a/src/Meridian.Ui/dashboard/src/components/ui/combobox.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/combobox.tsx
@@ -170,6 +170,7 @@ export function Combobox({
                 <div
                   key={option.value}
                   role="option"
+                  aria-label={option.label}
                   aria-selected={isSelected}
                   onMouseEnter={() => setHighlighted(index)}
                   onClick={() => commit(option)}

--- a/src/Meridian.Ui/dashboard/src/components/ui/drawer.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/drawer.tsx
@@ -122,7 +122,7 @@ export function Drawer({
   );
 }
 
-export interface DrawerHeaderProps extends HTMLAttributes<HTMLDivElement> {
+export interface DrawerHeaderProps extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
   title?: ReactNode;
   onClose?: () => void;
 }

--- a/src/Meridian.Ui/dashboard/src/components/ui/file-upload.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/file-upload.tsx
@@ -86,10 +86,11 @@ export function FileUpload({
       <input
         ref={inputRef}
         type="file"
+        tabIndex={-1}
         multiple={multiple}
-        accept={accept}
+        accept={accept === "*" ? undefined : accept}
         disabled={disabled}
-        className="hidden"
+        className="sr-only"
         onChange={(event) => addFiles(event.target.files)}
       />
       {files.length > 0 ? (

--- a/src/Meridian.Ui/dashboard/src/design-system-contract.test.ts
+++ b/src/Meridian.Ui/dashboard/src/design-system-contract.test.ts
@@ -331,15 +331,17 @@ describe("dashboard design-system contract", () => {
     expect(readDashboardPrimitive("toast.tsx")).toContain("export function ToastProvider");
   });
 
-  it("keeps UI primitives on tokenized radii and shallow light-system shadows", () => {
+  it("keeps UI primitives on Concrete 2px radii and shallow light-system shadows", () => {
     const primitiveSource = readdirSync(resolve(process.cwd(), "src/components/ui"))
       .filter((entry) => entry.endsWith(".tsx") && !entry.endsWith(".test.tsx"))
       .map((entry) => readDashboardPrimitive(entry))
       .join("\n");
 
-    expect(primitiveSource).toContain("--radius-button");
-    expect(primitiveSource).toContain("--radius-card");
-    expect(primitiveSource).toContain("--shadow-panel");
+    // Concrete unifies primitives on a single tight 2px corner, and the only
+    // elevation is the detached-overlay menu shadow — surfaces are otherwise flat.
+    // (The --radius-*/--shadow-* tokens themselves are asserted separately above.)
+    expect(primitiveSource).toContain("rounded-[2px]");
+    expect(primitiveSource).toContain("shadow-[0_2px_6px_rgba(0,0,0,0.18)]");
     expect(primitiveSource).not.toContain("1px_1px_0");
     expect(primitiveSource).not.toContain("2px_2px_0");
     expect(primitiveSource).not.toContain("border-slate");


### PR DESCRIPTION
**Restores `main` to a green build + test state** after the 5 foundation PRs (U1–U5) merged with some checks red (PR #2049 merged before its follow-up fixes, and #2051/#2052 merged with `verify-browser` failing).

Fixes on current `main`:
- **U2 `drawer.tsx`** — `DrawerHeaderProps` clashed with `HTMLAttributes.title` (TS2430) → `Omit<…, "title">`. **This broke `tsc`/the whole build on main.**
- **U2 `combobox.tsx`** — highlighted option had a broken accessible name (`"Micro soft Corp."`) → stable `aria-label`.
- **U2 `file-upload.tsx`** — invalid `accept="*"` blocked file selection → omit for any-file; `sr-only` input.
- **U4 `column-chooser.tsx`** — never fire a no-op `onChange` / never drop the last column (adopts the agent's own code-review fix that missed the merge).
- **Contract test** — reconciled `keeps UI primitives on … radii/shadows` to U2's Concrete convention (`rounded-[2px]` + flat overlay shadow) instead of the old CSS-var-in-TSX strings; negative guardrails kept.

**Validation (Node 24):** `npm run build` exit 0; full `vitest` was 2 failed / 1647 passed before → both failures fixed and re-verified (21/21 on the two files). Merge this to make `main` green before Wave 2 (screens).