### PR TITLE
Web UI Concrete — W2: Trading screens

### DIFF
--- a/src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.tsx
@@ -1,10 +1,10 @@
 import { Activity, ArrowRight, ClipboardList, FileCheck2, RadioTower, RefreshCcw, ShieldCheck, TrendingUp } from "lucide-react";
 import { Link } from "react-router-dom";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { DenseDataTable, type DenseDataTableColumn } from "@/components/meridian/ui-kit-primitives";
-import { MetricCard } from "@/components/meridian/metric-card";
+import { GateRail, SeverityBadge } from "@/components/operations";
+import { MetricCard, type MetricCardTone } from "@/components/data/concrete";
 import { cn } from "@/lib/utils";
 import {
   useOperatorReadinessConsoleViewModel,
@@ -20,6 +20,7 @@ import {
 import type {
   DataWorkspaceResponse,
   AccountingWorkspaceResponse,
+  MetricSnapshot,
   ReportingWorkspaceResponse,
   StrategyWorkspaceResponse,
   TradingWorkspaceResponse
@@ -33,18 +34,32 @@ interface OperatorReadinessConsoleProps {
   reporting: ReportingWorkspaceResponse | null;
 }
 
-const levelBadge: Record<ReadinessConsoleLevel, "success" | "warning" | "danger" | "outline"> = {
-  ready: "success",
-  review: "warning",
-  blocked: "danger",
-  neutral: "outline"
+// Concrete severity vocabulary. The console's readiness levels collapse onto the design
+// system's canonical operator severities: ready · review · action · blocked · info.
+// `SeverityBadge`/`GateRail` normalize the string, and "neutral" resolves to the muted
+// "info" tone. Passing the level as the status keeps one source of truth.
+const levelStatus: Record<ReadinessConsoleLevel, string> = {
+  ready: "ready",
+  review: "review",
+  blocked: "blocked",
+  neutral: "neutral"
 };
 
+// Severity-tinted panel shell: an alpha-10 wash + solid semantic border, never a solid
+// fill, matching the Concrete readiness surfaces.
 const levelPanel: Record<ReadinessConsoleLevel, string> = {
-  ready: "border-success/35 bg-success/10",
-  review: "border-warning/35 bg-warning/10",
-  blocked: "border-danger/35 bg-danger/10",
-  neutral: "border-border/70 bg-secondary/25"
+  ready: "border-[var(--severity-ready-bd)] bg-[var(--severity-ready-bg)]",
+  review: "border-[var(--severity-review-bd)] bg-[var(--severity-review-bg)]",
+  blocked: "border-[var(--severity-blocked-bd)] bg-[var(--severity-blocked-bg)]",
+  neutral: "border-[var(--severity-info-bd)] bg-[var(--severity-info-bg)]"
+};
+
+// `MetricSnapshot` tone → Concrete MetricCard left-accent tone.
+const metricTone: Record<MetricSnapshot["tone"], MetricCardTone> = {
+  default: "neutral",
+  success: "success",
+  warning: "warning",
+  danger: "danger"
 };
 
 const panelIcons: Record<ReadinessConsolePanel["id"], typeof ShieldCheck> = {
@@ -70,7 +85,7 @@ const workItemColumns: DenseDataTableColumn<ReadinessConsoleRow>[] = [
   {
     id: "status",
     label: "Status",
-    render: (row) => <Badge variant={levelBadge[row.level]} aria-label={row.statusAriaLabel}>{row.value}</Badge>
+    render: (row) => <SeverityBadge status={levelStatus[row.level]} label={row.value} aria-label={row.statusAriaLabel} />
   },
   {
     id: "target",
@@ -100,7 +115,7 @@ const evidencePanelColumns: DenseDataTableColumn<ReadinessConsoleRow>[] = [
   {
     id: "status",
     label: "Status",
-    render: (row) => <Badge variant={levelBadge[row.level]} aria-label={row.statusAriaLabel}>{row.value}</Badge>
+    render: (row) => <SeverityBadge status={levelStatus[row.level]} label={row.value} aria-label={row.statusAriaLabel} />
   },
   {
     id: "detail",
@@ -148,10 +163,24 @@ export function OperatorReadinessConsole({
         <div className="flex flex-wrap items-center justify-end gap-2">
           <ConsoleChip label="As of" value={vm.asOf} />
           <ConsoleChip label="Inbox" value={vm.inboxSummary} />
-          <span className={cn("rounded-sm border px-2.5 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em]", levelPanel[vm.overallLevel])}>
-            {vm.overallLabel}
-          </span>
+          <SeverityBadge status={levelStatus[vm.overallLevel]} label={vm.overallLabel} />
         </div>
+      </section>
+
+      <section
+        className="panel-surface px-4 py-4"
+        role="group"
+        aria-label="Readiness gate pipeline"
+      >
+        <div className="eyebrow-label mb-3">Readiness pipeline</div>
+        <GateRail
+          gates={vm.checkpointGates.map((gate) => ({
+            key: gate.id,
+            label: gate.label,
+            status: levelStatus[gate.level],
+            statusLabel: gate.value
+          }))}
+        />
       </section>
 
       <section className="grid gap-4 xl:grid-cols-[1.25fr_0.75fr]">
@@ -166,7 +195,7 @@ export function OperatorReadinessConsole({
                 </CardTitle>
                 <CardDescription className="mt-2">{vm.subtitle}</CardDescription>
               </div>
-              <Badge variant={levelBadge[vm.overallLevel]}>{vm.overallLabel}</Badge>
+              <SeverityBadge status={levelStatus[vm.overallLevel]} label={vm.overallLabel} />
             </div>
           </CardHeader>
           <CardContent className="space-y-3">
@@ -237,7 +266,7 @@ export function OperatorReadinessConsole({
               >
                 <div className="flex items-center justify-between gap-3">
                   <span className="text-sm font-semibold">{source.label}</span>
-                  <Badge variant={levelBadge[source.level]} aria-label={source.statusAriaLabel}>{source.status}</Badge>
+                  <SeverityBadge status={levelStatus[source.level]} label={source.status} aria-label={source.statusAriaLabel} />
                 </div>
                 <p className="mt-1 break-all font-mono text-[11px] text-muted-foreground">{source.endpoint}</p>
               </div>
@@ -267,7 +296,12 @@ export function OperatorReadinessConsole({
             aria-describedby={metric.detailId}
             className="grid gap-2"
           >
-            <MetricCard {...metric} />
+            <MetricCard
+              label={metric.label}
+              value={metric.value}
+              delta={metric.delta}
+              tone={metricTone[metric.tone]}
+            />
             <p
               id={metric.detailId}
               className={cn("rounded-md border px-2.5 py-2 text-xs leading-5 text-foreground/75", levelPanel[metric.level])}
@@ -355,7 +389,7 @@ function SelectedWorkItemDetail({
     >
       <div className="head flex items-center justify-between gap-3">
         <span>Selected work item</span>
-        <Badge variant={levelBadge[detail.level]} aria-label={detail.statusAriaLabel}>{detail.statusLabel}</Badge>
+        <SeverityBadge status={levelStatus[detail.level]} label={detail.statusLabel} aria-label={detail.statusAriaLabel} />
       </div>
       <div className="body">
         <div className="min-w-0">
@@ -504,7 +538,7 @@ function SelectedEvidenceDetail({
     >
       <div className="head flex items-center justify-between gap-3">
         <span>Selected evidence</span>
-        <Badge variant={levelBadge[detail.level]} aria-label={detail.statusAriaLabel}>{detail.statusLabel}</Badge>
+        <SeverityBadge status={levelStatus[detail.level]} label={detail.statusLabel} aria-label={detail.statusAriaLabel} />
       </div>
       <div className="body">
         <div className="min-w-0">
@@ -544,14 +578,17 @@ function ReadinessRow({ row }: { row: ReadinessConsoleRow }) {
       role="group"
       aria-label={row.ariaLabel}
       aria-describedby={row.detailId}
-      className={cn("rounded-lg border bg-card px-3 py-3 shadow-[var(--shadow-panel)]", levelPanel[row.level])}
+      className={cn(
+        "rounded-[var(--radius-card)] border border-l-[3px] px-3 py-3",
+        levelPanel[row.level]
+      )}
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="text-sm font-semibold text-foreground">{row.label}</div>
           <div className="mt-1 break-words font-mono text-xs text-muted-foreground">{row.meta}</div>
         </div>
-        <Badge variant={levelBadge[row.level]} aria-label={row.statusAriaLabel}>{row.value}</Badge>
+        <SeverityBadge status={levelStatus[row.level]} label={row.value} aria-label={row.statusAriaLabel} />
       </div>
       <p id={row.detailId} className="mt-2 text-xs leading-5 text-foreground/80">{row.detail}</p>
       {row.action ? (

--- a/src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx
@@ -23,10 +23,11 @@ import {
   SheetHeader,
   SheetTitle
 } from "@/components/ui/sheet";
-import { MetricCard } from "@/components/meridian/metric-card";
 import { DenseRowDetailPanel } from "@/components/meridian/dense-row-detail-accessibility";
 import { DenseDataTable, type DenseDataTableColumn } from "@/components/meridian/ui-kit-primitives";
 import { WorkspaceFilterBar, WorkspaceTabStrip } from "@/components/meridian/workspace-primitives";
+import { MetricCard, type MetricCardTone } from "@/components/data/concrete";
+import { SeverityBadge } from "@/components/operations";
 import { cn } from "@/lib/utils";
 import {
   formatReadinessStatusValue,
@@ -120,6 +121,23 @@ const acceptanceLabel: Record<AcceptanceLevel, string> = {
   ready: "Ready",
   review: "Review",
   atRisk: "At risk"
+};
+
+// Concrete severity vocabulary: acceptance levels collapse onto the design system's
+// canonical operator severities (ready · review · action · blocked · info). `atRisk`
+// maps to the brick-red "blocked" severity used by SeverityBadge.
+const acceptanceStatus: Record<AcceptanceLevel, string> = {
+  ready: "ready",
+  review: "review",
+  atRisk: "blocked"
+};
+
+// `MetricSnapshot` tone → Concrete MetricCard left-accent tone.
+const metricCardTone: Record<TradingWorkspaceResponse["metrics"][number]["tone"], MetricCardTone> = {
+  default: "neutral",
+  success: "success",
+  warning: "warning",
+  danger: "danger"
 };
 
 const workItemTone: Record<string, string> = {
@@ -526,7 +544,13 @@ export function TradingScreen({ data }: TradingScreenProps) {
     <div className="space-y-8">
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         {data.metrics.map((metric) => (
-          <MetricCard key={metric.id} {...metric} />
+          <MetricCard
+            key={metric.id}
+            label={metric.label}
+            value={metric.value}
+            delta={metric.delta}
+            tone={metricCardTone[metric.tone]}
+          />
         ))}
       </section>
 
@@ -2028,9 +2052,7 @@ function AcceptanceStatusCard({
               <RotateCcw className={cn("h-4 w-4", readinessVm.refreshing && "animate-spin")} />
               {readinessVm.refreshButtonLabel}
             </Button>
-            <span className={cn("rounded-sm border px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em]", acceptanceTone[overallLevel])}>
-              {readyCount}/{totalCount} ready
-            </span>
+            <SeverityBadge status={acceptanceStatus[overallLevel]} label={`${readyCount}/${totalCount} ready`} />
           </div>
         </div>
       </CardHeader>
@@ -2071,7 +2093,7 @@ function AcceptanceStatusCard({
 
 function ReadinessSummaryPill({ row }: { row: TradingReadinessSummaryRow }) {
   return (
-    <div className={cn("data-grid-surface border px-3 py-2", acceptanceTone[row.level])} aria-label={row.ariaLabel}>
+    <div className={cn("data-grid-surface border border-l-[3px] px-3 py-2", acceptanceTone[row.level])} aria-label={row.ariaLabel}>
       <p className="text-xs font-semibold uppercase tracking-[0.14em] opacity-80">{row.label}</p>
       <p className="mt-1 break-words font-mono text-xs font-semibold text-foreground">{row.label}: {row.value}</p>
     </div>
@@ -2080,15 +2102,13 @@ function ReadinessSummaryPill({ row }: { row: TradingReadinessSummaryRow }) {
 
 function AcceptanceRow({ item }: { item: CockpitAcceptanceItem }) {
   return (
-    <div className={cn("data-grid-surface border px-4 py-3", acceptanceTone[item.level])}>
+    <div className={cn("data-grid-surface border border-l-[3px] px-4 py-3", acceptanceTone[item.level])}>
       <div className="flex items-start justify-between gap-3">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.14em] opacity-80">{item.label}</p>
           <p className="mt-1 font-mono text-sm font-semibold">{item.value}</p>
         </div>
-        <span className="rounded-sm border border-border/70 bg-background/70 px-2 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-foreground">
-          {acceptanceLabel[item.level]}
-        </span>
+        <SeverityBadge status={acceptanceStatus[item.level]} label={acceptanceLabel[item.level]} />
       </div>
       <p className="mt-2 text-xs leading-5 text-foreground/80">{item.detail}</p>
     </div>
@@ -2138,7 +2158,7 @@ function OperatorWorkItemList({
             >
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <span className="font-semibold text-foreground">{item.label}</span>
-                <span className="font-mono text-[11px] uppercase tracking-[0.12em]">{item.tone}</span>
+                <SeverityBadge status={item.tone} label={item.tone} />
               </div>
               <p className="mt-1 text-xs leading-5 text-foreground/80">{item.detail}</p>
               {item.metadataText && (


### PR DESCRIPTION
## Summary

Wave 2 rework of the **Trading** area to the Concrete design system, adopting the new shared component libraries while preserving all existing behavior, view-models, tests, and accessibility contracts.

Owned files:
- `src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx`
- `src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.tsx`

## What changed

- **Concrete `MetricCard`** (`@/components/data/concrete`) for headline stats on both screens — the raised paper tile with a 3px left-accent border, mono tabular value, and signed delta. `MetricSnapshot` tone is mapped onto the design-system tone.
- **`SeverityBadge`** (`@/components/operations`) replaces every status chip: readiness levels, acceptance gates, evidence rows, work-item tones, and API-source health. Readiness levels collapse onto the canonical `ready · review · action · blocked · info` severities (alpha-10 wash + solid semantic border, never a solid fill). Existing `aria-label` overrides are passed through, so accessible names are unchanged.
- **`GateRail`** adds a "readiness pipeline" horizontal stepper to the operator readiness console, driven by the existing checkpoint gates, under a distinct accessible name.
- Readiness surfaces flattened to Concrete: dropped the panel shadow, added the 3px severity left-accent, and moved panel washes onto the `--severity-*` tokens.

## Deliberate scope decision

The pre-existing accessible `DenseDataTable` (from `@/components/meridian/ui-kit-primitives`) is **retained** for the blotter/orders/readiness tables. It carries keyboard navigation, row-detail announcements, sort buttons, and `aria-controls`/`aria-expanded` wiring that the view-models drive and the tests assert. Wave 1 already restyled it to the flat Concrete look (hairline borders, 2px radius, steel-blue selected-row rail, zebra rows). Swapping it for the simpler presentational concrete `DenseDataTable` would strip that behavior and break tests, so it was intentionally kept.

## Validation

- `trading-screen.test.tsx`, `trading-screen.view-model.test.ts`, `operator-readiness-console.test.tsx`, `operator-readiness-console.view-model.test.ts`: **122/122 pass**.
- Scoped `tsc` typecheck of the owned files is clean.
- Full `vitest run` (1674 tests): no failure touches the owned files.

## Notes for reviewers

`npm run build` currently fails on this baseline due to **pre-existing** TypeScript errors in files outside this PR's scope (`components/accounting/LedgerTable.tsx`, `components/accounting/ReconciliationPanel.tsx`, `components/data/use-table-state.test.ts`, `screens/live-quotes-screen.tsx`), introduced by earlier commits (`52447db91`, `2ad3e2ec1`). These are unrelated to the Trading rework and are flagged for a separate fix. No view-model, token, shared-component (`components/**`), routing (`app.tsx`), or shell files were changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)