### PR TITLE
Web UI Concrete — W3: Portfolio screens

### DIFF
--- a/src/Meridian.Ui/dashboard/src/screens/family-office-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/family-office-screen.tsx
@@ -1,10 +1,15 @@
 import type { KeyboardEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 import { AlertTriangle, Boxes, GitBranch, Landmark, Network, TableProperties, WalletCards } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/card";
 import { DenseDataTable, type DenseDataTableColumn } from "@/components/meridian/ui-kit-primitives";
+import {
+  MetricCard,
+  type MetricCardTone,
+  KeyValueGrid
+} from "@/components/data/concrete";
+import { SeverityBadge, TrustStrip, type TrustStripItem } from "@/components/operations";
 import { cn } from "@/lib/utils";
 import {
   buildFamilyOfficeScreenViewModel,
@@ -23,13 +28,6 @@ const panelIconMap: Record<string, typeof Landmark> = {
   "unfunded-commitments": AlertTriangle,
   "unresolved-reconciliation-breaks": AlertTriangle,
   "stale-valuation-warnings": AlertTriangle
-};
-
-const toneBadgeVariant: Record<FamilyOfficeTone, "outline" | "success" | "warning" | "danger"> = {
-  default: "outline",
-  success: "success",
-  warning: "warning",
-  danger: "danger"
 };
 
 const graphNodeClassName: Record<FamilyOfficeTone, string> = {
@@ -139,16 +137,8 @@ export function FamilyOfficeScreen() {
               <p className="mt-2 text-sm text-warning">{vm.route.disabledReason}</p>
             ) : null}
           </div>
-          <div className="flex flex-wrap gap-2 lg:justify-end">
-            {vm.statusChips.map((chip) => (
-              <span
-                key={chip.label}
-                className="rounded-md border border-border bg-secondary/40 px-3 py-2 text-xs text-muted-foreground"
-                aria-label={`${chip.label}: ${chip.value}`}
-              >
-                {chip.label}<b className="ml-2 font-mono text-foreground">{chip.value}</b>
-              </span>
-            ))}
+          <div className="lg:justify-end">
+            <TrustStrip items={vm.statusChips.map((chip): TrustStripItem => ({ label: chip.label, value: chip.value }))} />
           </div>
         </div>
       </header>
@@ -259,17 +249,27 @@ export function FamilyOfficeScreen() {
             {vm.ownershipGraph.selectedNode ? (
               <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
                 <div>
-                  <div className="eyebrow-label">{vm.ownershipGraph.selectedNode.type}</div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <div className="eyebrow-label">{vm.ownershipGraph.selectedNode.type}</div>
+                    {vm.ownershipGraph.selectedNode.tone !== "default" ? (
+                      <SeverityBadge status={severityStatusFromTone(vm.ownershipGraph.selectedNode.tone)} />
+                    ) : null}
+                  </div>
                   <h2 className="mt-2 text-lg font-semibold text-foreground">{vm.ownershipGraph.selectedNode.label}</h2>
                   <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
                     {vm.ownershipGraph.selectedNode.detail}
                   </p>
                 </div>
-                <dl className="grid gap-2 sm:grid-cols-3 lg:min-w-[28rem]">
-                  <OwnershipDetail label="Value" value={vm.ownershipGraph.selectedNode.value} />
-                  <OwnershipDetail label="Ownership" value={vm.ownershipGraph.selectedNode.percentage} />
-                  <OwnershipDetail label="Parent" value={vm.ownershipGraph.selectedNode.parentId ?? "Root"} />
-                </dl>
+                <div className="lg:min-w-[28rem]">
+                  <KeyValueGrid
+                    columns={3}
+                    items={[
+                      { label: "Value", value: vm.ownershipGraph.selectedNode.value },
+                      { label: "Ownership", value: vm.ownershipGraph.selectedNode.percentage },
+                      { label: "Parent", value: vm.ownershipGraph.selectedNode.parentId ?? "Root" }
+                    ]}
+                  />
+                </div>
               </div>
             ) : (
               <p className="text-sm text-muted-foreground">{vm.ownershipGraph.selectedDetailEmptyTitle}</p>
@@ -281,25 +281,38 @@ export function FamilyOfficeScreen() {
   );
 }
 
+const panelMetricTone: Record<FamilyOfficeTone, MetricCardTone> = {
+  default: "neutral",
+  success: "success",
+  warning: "warning",
+  danger: "danger"
+};
+
+/** Map a family-office tone to a canonical severity string for {@link SeverityBadge}. */
+function severityStatusFromTone(tone: FamilyOfficeTone): string {
+  switch (tone) {
+    case "success":
+      return "Ready";
+    case "warning":
+      return "ReviewRequired";
+    case "danger":
+      return "Blocked";
+    default:
+      return "Info";
+  }
+}
+
 function FamilyOfficePanel({ panel }: { panel: FamilyOfficePanelViewModel }) {
   const Icon = panelIconMap[panel.id] ?? Landmark;
 
   return (
-    <Card className="panel-surface border-border/80" aria-label={panel.ariaLabel}>
-      <CardHeader className="space-y-3">
-        <div className="flex items-start justify-between gap-3">
-          <Icon className="mt-1 h-4 w-4 text-primary" aria-hidden="true" />
-          <Badge variant={toneBadgeVariant[panel.tone]}>{panel.tone === "default" ? "Tracked" : panel.tone}</Badge>
-        </div>
-        <div>
-          <CardTitle className="text-sm font-semibold text-foreground">{panel.label}</CardTitle>
-          <div className="mt-2 font-mono text-2xl font-semibold text-foreground">{panel.value}</div>
-        </div>
-      </CardHeader>
-      <CardContent>
-        <p className="text-sm leading-6 text-muted-foreground">{panel.detail}</p>
-      </CardContent>
-    </Card>
+    <div className="grid gap-2" aria-label={panel.ariaLabel} role="group">
+      <MetricCard label={panel.label} value={panel.value} tone={panelMetricTone[panel.tone]} />
+      <p className="flex items-start gap-2 px-1 text-xs leading-5 text-muted-foreground">
+        <Icon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+        <span>{panel.detail}</span>
+      </p>
+    </div>
   );
 }
 
@@ -319,7 +332,7 @@ function OwnershipNodeButton({
       ref={refCallback}
       type="button"
       className={cn(
-        "min-h-28 rounded-xl border px-4 py-3 text-left shadow-hard transition focus:outline-none focus:ring-2 focus:ring-primary/60",
+        "min-h-28 rounded-sm border px-4 py-3 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-primary/60",
         graphNodeClassName[node.tone],
         node.isSelected ? "ring-2 ring-primary/70" : "hover:border-primary/50"
       )}
@@ -331,21 +344,12 @@ function OwnershipNodeButton({
       onClick={() => onSelect(node.id)}
       onKeyDown={onKeyDown}
     >
-      <span className="block text-xs uppercase tracking-[0.2em] opacity-80">{node.type}</span>
+      <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] opacity-80">{node.type}</span>
       <span className="mt-2 block text-sm font-semibold text-foreground">{node.label}</span>
-      <span className="mt-3 flex items-center justify-between gap-3 font-mono text-xs">
+      <span className="mt-3 flex items-center justify-between gap-3 font-mono text-xs tabular-nums">
         <span>{node.value}</span>
         <span>{node.percentage}</span>
       </span>
     </button>
-  );
-}
-
-function OwnershipDetail({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-md border border-border/60 bg-secondary/20 px-3 py-2">
-      <dt className="text-xs text-muted-foreground">{label}</dt>
-      <dd className="mt-1 font-mono text-sm text-foreground">{value}</dd>
-    </div>
   );
 }

--- a/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.tsx
@@ -13,7 +13,9 @@ import {
   type FinancialRecordExplorerSummaryItem
 } from "@/components/meridian/financial-record-explorer";
 import { DenseDataTable, type DenseDataTableColumn } from "@/components/meridian/ui-kit-primitives";
-import { MetricCard } from "@/components/meridian/metric-card";
+import { MetricCard, type MetricCardTone, EmptyState } from "@/components/data/concrete";
+import { SeverityBadge, TrustStrip, type TrustStripItem } from "@/components/operations";
+import { EquityCurve, ChartCard } from "@/components/charts";
 import {
   getFinancialRecordExplorer,
   getRunAttribution,
@@ -38,7 +40,9 @@ import type {
   BrokerageHouseholdPortfolio,
   AccountingWorkspaceResponse,
   FinancialRecordExplorerDto,
+  EquityCurveSummary,
   FinancialRecordExplorerSavedViewSaveRequestDto,
+  MetricSnapshot,
   MultiAssetCoverageSummary,
   PortfolioWorkspaceResponse,
   StrategyWorkspaceResponse,
@@ -750,18 +754,17 @@ export function PortfolioScreen({
                 <div className="eyebrow-label">Sync trust</div>
                 <div className="mt-2 flex flex-wrap items-center gap-2">
                   <h3 className="text-base font-semibold text-foreground">{vm.brokerageTrustSnapshot.title}</h3>
-                  <Badge variant={workflowStatusVariant(vm.brokerageTrustSnapshot.statusTone)}>
-                    {vm.brokerageTrustSnapshot.statusLabel}
-                  </Badge>
+                  <SeverityBadge
+                    status={severityStatusFromTone(vm.brokerageTrustSnapshot.statusTone)}
+                    label={vm.brokerageTrustSnapshot.statusLabel}
+                  />
                 </div>
                 <p className="mt-2 max-w-4xl text-sm leading-6 text-muted-foreground">
                   {vm.brokerageTrustSnapshot.summary}
                 </p>
               </div>
-              <div className="flex flex-wrap items-center gap-2 lg:justify-end">
-                {vm.brokerageTrustSnapshot.chips.map((chip) => (
-                  <PortfolioChip key={chip.label} label={chip.label} value={chip.value} />
-                ))}
+              <div className="lg:justify-end">
+                <TrustStrip items={toTrustStripItems(vm.brokerageTrustSnapshot.chips, vm.brokerageTrustSnapshot.statusTone)} />
               </div>
             </div>
             <dl className="mt-3 grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
@@ -968,19 +971,14 @@ export function PortfolioScreen({
         </CardContent>
       </Card>
 
-      {vm.metricsFromTrading ? (
-        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          {vm.metricCards.map((metric) => (
-            <MetricCard key={metric.id} {...metric} />
-          ))}
-        </section>
-      ) : (
-        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          {vm.fallbackStats.map((stat) => (
-            <MetricCard key={stat.id} {...stat} />
-          ))}
-        </section>
-      )}
+      <section
+        className="grid gap-4 md:grid-cols-2 xl:grid-cols-4"
+        aria-label="Portfolio headline metrics"
+      >
+        {(vm.metricsFromTrading ? vm.metricCards : vm.fallbackStats).map((metric) => (
+          <PortfolioMetricCard key={metric.id} metric={metric} />
+        ))}
+      </section>
 
       <FinancialRecordExplorerShell
         explorerLabel="Financial Record Explorer"
@@ -1036,11 +1034,8 @@ export function PortfolioScreen({
                   caption="Select a position row to update the holding detail panel."
                 />
               ) : (
-                <div
-                  role="status"
-                  className="rounded-lg border border-warning/30 bg-warning/10 px-4 py-3 text-sm text-warning"
-                >
-                  {vm.positionEmptyText}
+                <div role="status" className="rounded-sm border border-border/70 bg-background/40">
+                  <EmptyState icon="table" title="No open holdings" detail={vm.positionEmptyText} compact />
                 </div>
               )}
             </CardContent>
@@ -1169,6 +1164,15 @@ export function PortfolioScreen({
                       </div>
                     ))}
                   </div>
+                  {selectedRunDrillIn?.runId === vm.selectedRun?.id &&
+                  (selectedRunDrillIn?.drawdownProfile?.points.length ?? 0) >= 2 ? (
+                    <div className="mt-3">
+                      <PortfolioDrillInChart
+                        profile={selectedRunDrillIn!.drawdownProfile!}
+                        runTitle={vm.selectedRun?.title ?? "selected run"}
+                      />
+                    </div>
+                  ) : null}
                   {vm.runDrillInSummary.bridgeRows.length > 0 ? (
                     <div className="mt-3 grid gap-2 lg:grid-cols-2" aria-label="Selected run realized unrealized bridge">
                       {vm.runDrillInSummary.bridgeRows.map((row) => (
@@ -1281,11 +1285,8 @@ export function PortfolioScreen({
                 </div>
               </div>
             ) : (
-              <div
-                role="status"
-                className="rounded-lg border border-warning/30 bg-warning/10 px-4 py-3 text-sm text-warning"
-              >
-                {vm.runEmptyText}
+              <div role="status" className="rounded-sm border border-border/70 bg-background/40">
+                <EmptyState icon="chart" title="No linked runs" detail={vm.runEmptyText} compact />
               </div>
             )}
           </CardContent>
@@ -1329,6 +1330,68 @@ function PortfolioChip({ label, value }: { label: string; value: string }) {
   );
 }
 
+/** Concrete KPI tile fed from a read-model `MetricSnapshot`. The snapshot's `"default"`
+ * tone maps to the Concrete `"neutral"` left-accent; other tones pass through 1:1. */
+const metricSnapshotToneClass: Record<MetricSnapshot["tone"], MetricCardTone> = {
+  default: "neutral",
+  success: "success",
+  warning: "warning",
+  danger: "danger"
+};
+
+/** Concrete equity + underwater drawdown view for a loaded run drill-in profile. Additive
+ * evidence only — rendered when the selected run has a fetched equity/drawdown series. */
+function PortfolioDrillInChart({
+  profile,
+  runTitle
+}: {
+  profile: EquityCurveSummary;
+  runTitle: string;
+}) {
+  const points = profile.points;
+  const equity = points.map((point) => point.totalEquity);
+  const drawdown = points.map((point) => -Math.abs(point.drawdownFromPeakPercent * 100));
+  const labels = points.map((point) => point.date);
+  const currency = (value: number) =>
+    `$${Math.round(value).toLocaleString("en-US")}`;
+
+  return (
+    <ChartCard
+      title="Run equity and drawdown"
+      subtitle={`Source-backed equity curve and underwater drawdown for ${runTitle}.`}
+      readout={[
+        { label: "Final equity", value: currency(profile.finalEquity) },
+        {
+          label: "Max drawdown",
+          value: `-${(profile.maxDrawdownPercent * 100).toFixed(2)}%`,
+          color: "var(--chart-drawdown, #BA3F55)"
+        },
+        { label: "Sharpe", value: profile.sharpeRatio.toFixed(2) }
+      ]}
+      height={280}
+      style={{ flexShrink: 0 }}
+    >
+      <EquityCurve
+        series={[{ label: "Equity", color: "var(--chart-equity, #2F6F8F)", points: equity }]}
+        drawdown={drawdown}
+        labels={labels}
+        valueFmt={currency}
+      />
+    </ChartCard>
+  );
+}
+
+function PortfolioMetricCard({ metric }: { metric: MetricSnapshot }) {
+  return (
+    <MetricCard
+      label={metric.label}
+      value={metric.value}
+      delta={metric.delta ?? undefined}
+      tone={metricSnapshotToneClass[metric.tone]}
+    />
+  );
+}
+
 function PortfolioWorkflowTaskActionIcon({ actionId }: { actionId: PortfolioWorkflowTaskAction["id"] }) {
   const Icon =
     actionId === "provider-setup"
@@ -1346,4 +1409,56 @@ function PortfolioWorkflowTaskActionIcon({ actionId }: { actionId: PortfolioWork
 
 function workflowStatusVariant(statusTone: "default" | "success" | "warning" | "danger") {
   return statusTone === "default" ? "outline" : statusTone;
+}
+
+type PortfolioTone = "default" | "success" | "warning" | "danger";
+
+/** Map a read-model status tone to a canonical severity string for {@link SeverityBadge}. */
+function severityStatusFromTone(tone: PortfolioTone): string {
+  switch (tone) {
+    case "success":
+      return "Ready";
+    case "warning":
+      return "ReviewRequired";
+    case "danger":
+      return "Blocked";
+    default:
+      return "Info";
+  }
+}
+
+/** Map a read-model status tone to a {@link TrustStrip} state token. */
+function trustStateFromTone(tone: PortfolioTone): string {
+  switch (tone) {
+    case "success":
+      return "ready";
+    case "warning":
+      return "review";
+    case "danger":
+      return "blocked";
+    default:
+      return "muted";
+  }
+}
+
+/** Render the brokerage sync-snapshot chip band as a Concrete {@link TrustStrip}. Each chip
+ * inherits the snapshot's overall tone, except the "Issues" chip which reads healthy only when
+ * its value shows zero issues. */
+function toTrustStripItems(
+  chips: { label: string; value: string }[],
+  statusTone: PortfolioTone
+): TrustStripItem[] {
+  return chips.map((chip) => {
+    const isIssueChip = /issue/i.test(chip.label);
+    const hasIssues = isIssueChip && !/^0\b/.test(chip.value.trim());
+    return {
+      label: chip.label,
+      value: chip.value,
+      state: isIssueChip
+        ? hasIssues
+          ? "review"
+          : "ready"
+        : trustStateFromTone(statusTone)
+    };
+  });
 }


### PR DESCRIPTION
## Summary

Wave 2 (W3) reworks the **Portfolio**-area screens to the Concrete design system and adopts the new shared component libraries, preserving all behavior, view-models, props, aria/focus wiring, and tests.

### `portfolio-screen.tsx`
- **MetricCard** (`@/components/data/concrete`) now renders the headline NAV/exposure metrics — the trading and fallback branches are unified under one labelled section, with a small presentational wrapper mapping the read-model `MetricSnapshot` tone (`default` → `neutral`).
- **TrustStrip** + **SeverityBadge** (`@/components/operations`) replace the ad-hoc chip band and status badge in the brokerage sync-snapshot; the per-field tone `dl` is retained.
- **EquityCurve** + **ChartCard** (`@/components/charts`) add an additive equity curve with an underwater drawdown subpane in the run drill-in section when a fetched equity/drawdown profile is present.
- **EmptyState** replaces the ad-hoc empty boxes for positions/runs (kept inside a `role="status"` live region; empty text preserved via `detail`).
- The aria-rich `ui-kit-primitives` `DenseDataTable` and the detail panels are **retained** for the selectable positions/runs/brokerage tables to preserve the tested contract (roles, `aria-controls`/`aria-expanded`/`aria-selected`, complementary panels, class hooks).

### `family-office-screen.tsx`
- **MetricCard** for the summary panels, **TrustStrip** for the header status chips, **KeyValueGrid** for the ownership detail facts, **SeverityBadge** for the selected-node status.
- Ownership node buttons flattened to Concrete language (2px radius, hairline border, no shadow, tabular numerics).

## Behavior preservation
Presentation-only rework. `*.view-model.ts` logic is unchanged; data flow, props, async/cancellation, and aria/focus are preserved. New shared components are consumed via barrels only — no edits to `components/**`, tokens, shell, routing, or other screens.

## Validation
- `vite build` — green (exit 0).
- `tsc --noEmit` (full project) — reported **0 errors** (the `npm run build` wrapper intermittently timed out under concurrent-agent CPU load; the type-check itself is clean).
- Test files pass per-file: portfolio (17), family-office (3, incl. jest-axe), portfolio view-model + family-office view-model (34). A combined 4-file run showed one flaky worker timeout that passed on isolated re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)