### PR TITLE
Fix dashboard TypeScript build errors and pre-existing browser-test failures

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/accounting/LedgerTable.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/LedgerTable.tsx
@@ -3,7 +3,7 @@
 // P&L color when the two sides disagree). Flat Concrete grid: white paper, small-caps muted
 // headers, hairline rows, mono tabular figures.
 import { useState } from "react";
-import type { KeyboardEvent } from "react";
+import type { AriaAttributes, KeyboardEvent } from "react";
 import { AmountCell } from "./AmountCell";
 import { toNumber } from "./money";
 
@@ -144,7 +144,11 @@ export function LedgerTable({
           onClick: () => handleSort(key),
           onKeyDown: handleSortKey(key),
           tabIndex: 0,
-          "aria-sort": sortKey === key ? (sortDir === 1 ? "ascending" : "descending") : "none",
+          "aria-sort": (sortKey === key
+            ? sortDir === 1
+              ? "ascending"
+              : "descending"
+            : "none") as AriaAttributes["aria-sort"],
           scope: "col",
         }
       : { scope: "col" };

--- a/src/Meridian.Ui/dashboard/src/components/accounting/ReconciliationPanel.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/accounting/ReconciliationPanel.tsx
@@ -143,8 +143,8 @@ function inject(): void {
 function compareItems(a: ReconciliationItem, b: ReconciliationItem, key: string): number {
   if (key === "amount") return (toNumber(a.amount) || 0) - (toNumber(b.amount) || 0);
   if (key === "status") return (a.matched ? 1 : 0) - (b.matched ? 1 : 0);
-  const an = toNumber(a[key]);
-  const bn = toNumber(b[key]);
+  const an = toNumber(a[key] as number | string | null | undefined);
+  const bn = toNumber(b[key] as number | string | null | undefined);
   if (Number.isFinite(an) || Number.isFinite(bn)) return (Number.isFinite(an) ? an : 0) - (Number.isFinite(bn) ? bn : 0);
   const av = String(a[key] ?? "");
   const bv = String(b[key] ?? "");

--- a/src/Meridian.Ui/dashboard/src/components/data/use-table-state.test.ts
+++ b/src/Meridian.Ui/dashboard/src/components/data/use-table-state.test.ts
@@ -104,7 +104,7 @@ describe("useTableState", () => {
 
   it("escapes quotes and newlines in CSV exports", async () => {
     vi.useFakeTimers();
-    const createObjectURL = vi.fn(() => "blob:csv");
+    const createObjectURL = vi.fn((_blob: Blob) => "blob:csv");
     const revokeObjectURL = vi.fn();
     Object.defineProperty(URL, "createObjectURL", { configurable: true, value: createObjectURL });
     Object.defineProperty(URL, "revokeObjectURL", { configurable: true, value: revokeObjectURL });

--- a/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.tsx
@@ -6,6 +6,7 @@ import {
   ArrowUp,
   BellPlus,
   CheckCircle2,
+  FileSpreadsheet,
   ListPlus,
   LineChart,
   Pause,


### PR DESCRIPTION
## Summary

Unblocks the dashboard for CI. Two related layers:

**1. Dashboard build (`tsc --noEmit && vite build`)** — fixed 8 pre-existing TypeScript
errors that failed the build on the `main`-based baseline (`FileSpreadsheet` import,
`aria-sort` typing, `unknown`→`toNumber`, an empty-tuple index). Type-level only.

**2. Browser test lane (`verify-browser` / `verify-fast (browser workstation)`)** — the
build fix alone left the browser lane red. CI's `verify-browser` runs the full vitest
suite (145 files, 19 batches) and **fails fast at batch 1**, which masked a broad,
pre-existing breakage from the recent Concrete UI restructure (`52447db91` / `2ad3e2ec1`):
**12 failing tests across 6 files, all failing on `main` too**. Fixed all of them.

### Source regressions (`52447db91` narrowed settings-screen section gating)
- **settings-screen.tsx**
  - `#alpaca-provider-setup` resolves to the `"brokerage"` task view, but
    `showBrokerageSection` was gated to `"providers"` only → the section (and its anchor
    target) never rendered. Restored the `"brokerage"` disjunct. *(fixes the app.test.tsx
    hash-focus timeout)*
  - The diagnostics + recent-events section was tab-gated to `"diagnostics"`, but the
    always-visible profile panel anchors to `#diagnostic-endpoints` → the anchor was broken
    on every other view. Made the section **persistent** (like the ungated profile section).
  - Restored scoped-access to the `"operations"` view (matches the pre-restructure
    `"access" || "operations"` gating).

### Design-system contract regression
- **index.css** — removed a duplicated, dead 217-line "Final cascade" workspace-surface
  block. It was overridden by `workspace-surface.css` (loads later, already carries these
  rules), so removal changes **nothing rendered** and satisfies the contract that these
  rules live outside the global token stylesheet.

### Stale tests (source changed intentionally; tests weren't updated)
- **workspace-nav.view-model.test.ts** — accounting nav relabeled `Overview`→`Today`,
  `Continuity`→`Close` (52447db91 "UI nav labels updated").
- **accounting-screen.view-model.test.ts** — reconciliation break title now uses the
  human-readable `financeBreakLabel` ("Cash variance needs review") from `2ad3e2ec1`.

### Test-only bugs (component behavior was already correct)
- **LedgerTable.test.tsx** — scoped the "not backfilled" assertion to the balance cell (the
  zero-credit cell also renders a dash).
- **ReconciliationPanel.test.tsx** — scoped the "$100.00 absent" assertion to the table
  (it legitimately appears in the summary bar).
- **use-table-state.test.ts** — jsdom's Blob exposes no reader and FileReader stalls under
  `vi.useFakeTimers()`; capture the CSV payload from the `Blob` constructor args instead.

## Reason

The TS errors block the dashboard build gate; the 12 test failures block `verify-browser`.
Both were pre-existing on `main` and would block any dashboard PR. None were caused by the
Concrete UI screen work in this branch.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Verified with the Node 24 toolchain (local Node 20.7.0 can't run the dashboard build/tests)
after `npm ci` in `src/Meridian.Ui/dashboard`:

- `tsc --noEmit` → **exit 0**; `vite build` → **exit 0** (`npm run build` passes)
- The 12 previously-failing tests all pass; targeted re-run of the 8 affected files → **187/187**
- Full 145-file suite → green apart from **2 pre-existing load-flaky files** (`reporting-screen`,
  `operator-readiness-console`) that time out only under heavy local load and **pass in isolation
  (66/66)** — they also passed before these changes and share no code path with them.

`scripts/ci.sh` and the hosted `quality-gate` were not run locally; leaving those for CI.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
