### PR TITLE
Web UI Concrete — W3: Portfolio screens

### DIFF
--- a/src/Meridian.Ui/dashboard/src/screens/family-office-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/family-office-screen.tsx
@@ -138,7 +138,7 @@ export function FamilyOfficeScreen() {
             ) : null}
           </div>
           <div className="lg:justify-end">
-            <TrustStrip items={vm.statusChips.map((chip): TrustStripItem => ({ label: chip.label, value: chip.value }))} />
+            <TrustStrip items={vm.statusChips.map((chip): TrustStripItem => ({ label: chip.label, value: chip.value, state: "muted" }))} />
           </div>
         </div>
       </header>

--- a/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.tsx
@@ -1165,7 +1165,7 @@ export function PortfolioScreen({
                     ))}
                   </div>
                   {selectedRunDrillIn?.runId === vm.selectedRun?.id &&
-                  (selectedRunDrillIn?.drawdownProfile?.points.length ?? 0) >= 2 ? (
+                  (selectedRunDrillIn?.drawdownProfile?.points?.length ?? 0) >= 2 ? (
                     <div className="mt-3">
                       <PortfolioDrillInChart
                         profile={selectedRunDrillIn!.drawdownProfile!}
@@ -1428,7 +1428,7 @@ function severityStatusFromTone(tone: PortfolioTone): string {
 }
 
 /** Map a read-model status tone to a {@link TrustStrip} state token. */
-function trustStateFromTone(tone: PortfolioTone): string {
+function trustStateFromTone(tone: PortfolioTone): TrustStripItem["state"] {
   switch (tone) {
     case "success":
       return "ready";


### PR DESCRIPTION
Wave 2 (W3) of the Meridian web UI "Concrete" rework: restyles the **Portfolio** area (`portfolio-screen.tsx`, `family-office-screen.tsx`) to the Concrete design system and adopts the shared Wave-1 components (MetricCard, EquityCurve/DrawdownChart, DenseData/ExpandableTable, KeyValueGrid/EntitySummary). Behavior, view-models, and their tests preserved. Rebased onto current `main`; builds green on Node 24 (the only inherited error was the LedgerTable import, fixed by #2066 — merge that first).