### PR TITLE
Web UI Concrete — W5: Reporting screens

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/meridian/report-writer-grid-diff-view.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/report-writer-grid-diff-view.tsx
@@ -1,5 +1,5 @@
 import { ArrowDown, ArrowUp } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
+import { SeverityBadge } from "@/components/operations";
 import { cn } from "@/lib/utils";
 import type { ReportWriterDiffRowState, ReportWriterGridDiff } from "@/types";
 
@@ -9,11 +9,12 @@ export interface ReportWriterGridDiffViewProps {
   className?: string;
 }
 
-const STATE_BADGE: Record<ReportWriterDiffRowState, "success" | "warning" | "danger" | "outline"> = {
-  Added: "success",
-  Removed: "danger",
-  Changed: "warning",
-  Unchanged: "outline"
+// Concrete severity layer: diff row state → operator-readiness status string.
+const STATE_STATUS: Record<ReportWriterDiffRowState, string> = {
+  Added: "Ready",
+  Removed: "Blocked",
+  Changed: "ReviewRequired",
+  Unchanged: "Info"
 };
 
 const STATE_LABEL: Record<ReportWriterDiffRowState, string> = {
@@ -52,7 +53,7 @@ export function ReportWriterGridDiffView({ diff, maxRows = 6, className }: Repor
             {rows.map((row) => (
               <tr key={`${row.state}:${row.rowKey}`} className="border-t border-border/50">
                 <td className="px-2 py-1.5">
-                  <Badge variant={STATE_BADGE[row.state]}>{STATE_LABEL[row.state]}</Badge>
+                  <SeverityBadge status={STATE_STATUS[row.state]} label={STATE_LABEL[row.state]} />
                 </td>
                 {row.cells.map((cell) => {
                   const display = cell.currentValue ?? cell.priorValue ?? "";

--- a/src/Meridian.Ui/dashboard/src/components/meridian/reporting-hub.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/reporting-hub.tsx
@@ -2,8 +2,9 @@ import { AlertTriangle, ArrowUpRight, FileText } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { SeverityBadge } from "@/components/operations";
 import { cn } from "@/lib/utils";
-import type { ReportingHubModel, ReportingHubTone } from "@/lib/reporting-hub";
+import type { ReportingHubBadgeVariant, ReportingHubModel, ReportingHubTone } from "@/lib/reporting-hub";
 
 export interface ReportingHubProps {
   model: ReportingHubModel;
@@ -15,6 +16,14 @@ const toneClasses: Record<ReportingHubTone, string> = {
   warning: "text-warning",
   danger: "text-danger",
   muted: "text-muted-foreground"
+};
+
+// Concrete severity layer: hub badge variant → operator-readiness status string.
+const badgeVariantStatus: Record<ReportingHubBadgeVariant, string> = {
+  success: "Ready",
+  warning: "ReviewRequired",
+  danger: "Blocked",
+  outline: "Info"
 };
 
 /**
@@ -62,7 +71,7 @@ export function ReportingHub({ model, className }: ReportingHubProps) {
                       </div>
                       <div className="mt-1 break-words text-sm font-semibold text-foreground">{item.title}</div>
                     </div>
-                    <Badge variant={item.badgeVariant}>{item.statusLabel}</Badge>
+                    <SeverityBadge status={badgeVariantStatus[item.badgeVariant]} label={item.statusLabel} />
                   </div>
                   <p className="text-xs leading-5 text-muted-foreground">{item.detail}</p>
                   <dl className="grid gap-2 text-xs sm:grid-cols-2" aria-label={`${item.title} decision facts`}>
@@ -130,7 +139,7 @@ export function ReportingHub({ model, className }: ReportingHubProps) {
                   >
                     <div className="flex items-start justify-between gap-2">
                       <span className="min-w-0 break-words font-semibold text-foreground">{card.family}</span>
-                      <Badge variant={card.badgeVariant}>{card.statusLabel}</Badge>
+                      <SeverityBadge status={badgeVariantStatus[card.badgeVariant]} label={card.statusLabel} />
                     </div>
                     <p className={cn("text-xs leading-5", toneClasses[card.statusTone])}>{card.approvedAsOfLabel}</p>
                     <p className="text-[11px] leading-4 text-muted-foreground">

--- a/src/Meridian.Ui/dashboard/src/screens/operations-record-release-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/operations-record-release-screen.tsx
@@ -1,9 +1,10 @@
 import { ArrowRight, DatabaseZap, FileCheck2, Landmark, Network } from "lucide-react";
 import { Link } from "react-router-dom";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import { GateRail, ReadinessPanel, SeverityBadge } from "@/components/operations";
+import { MetricCard } from "@/components/data/concrete";
 import { WORKSTATION_ROUTE_CATALOG } from "@/lib/workspace";
 import { useOperationsContinuityScreenViewModel } from "@/screens/operations-continuity-screen.view-model";
 import { useReportingScreenViewModel } from "@/screens/reporting-screen.view-model";
@@ -26,6 +27,31 @@ const tonePanel: Record<OperationsRecordReleaseTone, string> = {
   review: "border-warning/35 bg-warning/10",
   blocked: "border-danger/35 bg-danger/10",
   neutral: "border-border/70 bg-secondary/25"
+};
+
+// Concrete severity layer: collapse the release tone onto the operator-readiness status
+// strings that the operations components normalize (Ready · Review · Action · Blocked · Info).
+const toneStatus: Record<OperationsRecordReleaseTone, string> = {
+  ready: "Ready",
+  review: "ReviewRequired",
+  blocked: "Blocked",
+  neutral: "Info"
+};
+
+const toneMetric: Record<OperationsRecordReleaseTone, "success" | "warning" | "danger" | "neutral"> = {
+  ready: "success",
+  review: "warning",
+  blocked: "danger",
+  neutral: "neutral"
+};
+
+// Reporting read-model badge variants → readiness status strings for SeverityBadge.
+const badgeVariantStatus: Record<"default" | "outline" | "success" | "warning" | "danger", string> = {
+  success: "Ready",
+  warning: "ReviewRequired",
+  danger: "Blocked",
+  outline: "Info",
+  default: "Info"
 };
 
 export function OperationsRecordReleaseScreen({ data, reporting }: OperationsRecordReleaseScreenProps) {
@@ -58,7 +84,7 @@ export function OperationsRecordReleaseScreen({ data, reporting }: OperationsRec
             <p className="mt-2 max-w-4xl text-xs leading-5 text-muted-foreground">{vm.rootAreaSummary}</p>
           </div>
           <div className="flex flex-col items-start gap-2 sm:items-end">
-            <Badge variant={vm.badgeVariant} dot>{vm.statusLabel}</Badge>
+            <SeverityBadge status={toneStatus[vm.tone]} label={vm.statusLabel} />
             <span className="font-mono text-[11px] text-muted-foreground">{vm.routePathLabel}</span>
           </div>
         </div>
@@ -90,6 +116,15 @@ export function OperationsRecordReleaseScreen({ data, reporting }: OperationsRec
             </Link>
           </Button>
         </div>
+        <GateRail
+          className="px-1 py-2"
+          gates={vm.steps.map((step) => ({
+            key: step.id,
+            label: step.label,
+            status: toneStatus[step.tone],
+            statusLabel: step.statusLabel
+          }))}
+        />
         <ol className="grid gap-3 md:grid-cols-2 xl:grid-cols-6">
           {vm.steps.map((step) => (
             <li key={step.id}>
@@ -104,7 +139,7 @@ export function OperationsRecordReleaseScreen({ data, reporting }: OperationsRec
                 <span className="min-w-0">
                   <span className="flex items-center justify-between gap-2">
                     <span className="font-semibold text-foreground">{step.label}</span>
-                    <Badge variant={step.badgeVariant}>{step.statusLabel}</Badge>
+                    <SeverityBadge status={toneStatus[step.tone]} label={step.statusLabel} />
                   </span>
                   <span className="mt-2 block text-xs leading-5 text-muted-foreground">{step.detail}</span>
                 </span>
@@ -142,9 +177,10 @@ export function OperationsRecordReleaseScreen({ data, reporting }: OperationsRec
                   >
                     <div className="flex flex-wrap items-center justify-between gap-2">
                       <span className="font-semibold text-foreground">{distribution.label}</span>
-                      <Badge variant={distribution.pendingItemsLabel === "0 pending" ? "outline" : "warning"}>
-                        {distribution.pendingItemsLabel}
-                      </Badge>
+                      <SeverityBadge
+                        status={distribution.pendingItemsLabel === "0 pending" ? "Ready" : "ReviewRequired"}
+                        label={distribution.pendingItemsLabel}
+                      />
                     </div>
                     <p className="mt-1 text-xs leading-5 text-muted-foreground">
                       {distribution.channel} - {distribution.ownerLabel} - {distribution.pendingSummary}
@@ -171,7 +207,7 @@ export function OperationsRecordReleaseScreen({ data, reporting }: OperationsRec
                 <div key={`${template.id}-${template.version}`} className="rounded-md border border-border/70 bg-secondary/25 px-3 py-2">
                   <div className="flex flex-wrap items-center justify-between gap-2">
                     <span className="font-semibold text-foreground">{template.name}</span>
-                    <Badge variant={template.statusVariant}>{template.statusLabel}</Badge>
+                    <SeverityBadge status={badgeVariantStatus[template.statusVariant]} label={template.statusLabel} />
                   </div>
                   <p className="mt-1 text-xs leading-5 text-muted-foreground">
                     {template.family} - {template.version} - {template.sectionSummary}
@@ -195,7 +231,7 @@ export function OperationsRecordReleaseScreen({ data, reporting }: OperationsRec
                 <div key={run.id} className="rounded-md border border-border/70 bg-secondary/25 px-3 py-2">
                   <div className="flex flex-wrap items-center justify-between gap-2">
                     <span className="break-all font-mono text-xs font-semibold text-foreground">{run.id}</span>
-                    <Badge variant={run.status === "Failed" ? "warning" : "outline"}>{run.status}</Badge>
+                    <SeverityBadge status={run.status} label={run.status} />
                   </div>
                   <p className="mt-1 text-xs leading-5 text-muted-foreground">
                     {run.family} - {run.lineageSummary} - {run.auditSummary}
@@ -216,15 +252,13 @@ export function OperationsRecordReleaseScreen({ data, reporting }: OperationsRec
 
 function ReleaseMetric({ metric }: { metric: OperationsRecordReleaseMetric }) {
   return (
-    <div className={cn("rounded-md border px-3 py-3", tonePanel[metric.tone])}>
-      <div className="flex items-start justify-between gap-2">
-        <span className="text-xs text-muted-foreground">{metric.label}</span>
-        <Badge variant={metric.tone === "ready" ? "success" : metric.tone === "blocked" ? "danger" : metric.tone === "review" ? "warning" : "outline"}>
-          {metric.value}
-        </Badge>
-      </div>
-      <p className="mt-3 text-xs leading-5 text-muted-foreground">{metric.detail}</p>
-    </div>
+    <MetricCard
+      label={metric.label}
+      value={metric.value}
+      delta={metric.detail}
+      tone={toneMetric[metric.tone]}
+      trend="flat"
+    />
   );
 }
 
@@ -238,39 +272,37 @@ function ReleasePanel({
   const Icon = icon === "source" ? DatabaseZap : icon === "accounting" ? Landmark : Network;
 
   return (
-    <Card className={cn("border", tonePanel[panel.tone])}>
-      <CardHeader>
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div className="min-w-0">
-            <CardTitle className="flex items-center gap-2">
-              <Icon className="h-4 w-4 text-primary" aria-hidden="true" />
-              {panel.title}
-            </CardTitle>
-            <CardDescription className="mt-2">{panel.description}</CardDescription>
-          </div>
-          <Badge variant={panel.badgeVariant}>{panel.statusLabel}</Badge>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-3">
+    <ReadinessPanel
+      state={toneStatus[panel.tone]}
+      statusLabel={panel.statusLabel}
+      title={
+        <span className="flex items-center gap-2">
+          <Icon className="h-4 w-4 text-primary" aria-hidden="true" />
+          {panel.title}
+        </span>
+      }
+      detail={panel.description}
+      actions={
         <Button asChild variant="outline" size="sm">
           <Link to={panel.primaryHref} aria-label={panel.primaryAriaLabel}>
             {panel.primaryLabel}
             <ArrowRight className="h-4 w-4" aria-hidden="true" />
           </Link>
         </Button>
-        {panel.rows.length > 0 ? (
-          <div role="list" aria-label={`${panel.title} release evidence`} className="grid gap-2">
-            {panel.rows.map((row) => (
-              <ReleaseEvidenceRow key={row.id} row={row} />
-            ))}
-          </div>
-        ) : (
-          <p role="status" className="rounded-md border border-warning/35 bg-warning/10 px-3 py-2 text-sm leading-6 text-warning">
-            {panel.emptyText}
-          </p>
-        )}
-      </CardContent>
-    </Card>
+      }
+    >
+      {panel.rows.length > 0 ? (
+        <div role="list" aria-label={`${panel.title} release evidence`} className="grid gap-2">
+          {panel.rows.map((row) => (
+            <ReleaseEvidenceRow key={row.id} row={row} />
+          ))}
+        </div>
+      ) : (
+        <p role="status" className="rounded-md border border-warning/35 bg-warning/10 px-3 py-2 text-sm leading-6 text-warning">
+          {panel.emptyText}
+        </p>
+      )}
+    </ReadinessPanel>
   );
 }
 
@@ -282,7 +314,7 @@ function ReleaseEvidenceRow({ row }: { row: OperationsRecordReleaseEvidenceRow }
           <span className="block font-semibold text-foreground">{row.label}</span>
           <span className="mt-1 block text-xs leading-5 text-muted-foreground">{row.detail}</span>
         </span>
-        <Badge variant={row.badgeVariant}>{row.value}</Badge>
+        <SeverityBadge status={toneStatus[row.tone]} label={row.value} />
       </span>
       <span className="mt-2 inline-flex items-center gap-1.5 font-mono text-[11px] text-primary">
         {row.routeLabel}

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.delivery-history.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.delivery-history.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { SeverityBadge } from "@/components/operations";
 import { evidenceWorkbenchPath } from "@/lib/workspace";
 import { reportingRunReportWriterGridEndpoint } from "@/lib/workstation-endpoints";
 import {
@@ -53,7 +54,7 @@ export function ReportingDeliveryHistoryPanel({
                     <span className="block font-semibold text-foreground">{attempt.recipient}</span>
                     <span className="mt-1 block text-xs text-muted-foreground">{attempt.recipientRole} · {attempt.channel}</span>
                   </span>
-                  <Badge variant={attempt.state === "Failed" ? "warning" : "success"}>{attempt.state}</Badge>
+                  <SeverityBadge status={attempt.state} label={attempt.state} />
                 </div>
                 <p className="mt-2 break-all font-mono text-[11px] text-muted-foreground">{attempt.deliveryReference}</p>
                 <p className="mt-1 text-xs leading-5 text-muted-foreground">

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.private-capital-readiness.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.private-capital-readiness.tsx
@@ -1,9 +1,9 @@
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { SeverityBadge } from "@/components/operations";
 import { WORKSTATION_API_ENDPOINTS } from "@/lib/workstation-endpoints";
 import type {
   AccountingWorkspaceResponse,
-  ManualJournalEntryStatus,
   PrivateCapitalActivityProjection,
   PrivateCapitalCapitalAccountSubledger,
   PrivateCapitalEvidenceCategory,
@@ -31,9 +31,10 @@ export function ReportingPrivateCapitalReadinessPanel({ data }: { data: Accounti
                 Read-only report readiness from Accounting private-capital activity data.
               </CardDescription>
             </div>
-            <Badge variant={activity ? fundEventRecords.length > 0 ? "success" : "outline" : "warning"} dot>
-              {activity ? "Source data" : "Not loaded"}
-            </Badge>
+            <SeverityBadge
+              status={activity ? (fundEventRecords.length > 0 ? "Ready" : "Info") : "ReviewRequired"}
+              label={activity ? "Source data" : "Not loaded"}
+            />
           </div>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -166,17 +167,27 @@ function ReportingPrivateCapitalFundEventRecordRow({
       </td>
       <td className="px-3 py-2">
         <div className="flex flex-wrap gap-1.5">
-          <Badge variant={privateCapitalApprovalVariant(record.approvalState)} dot>{record.approvalState}</Badge>
-          <Badge variant={privateCapitalReadinessVariant(record.readiness)} dot>{record.readinessLabel || record.readiness}</Badge>
-          {record.isPosted ? <Badge variant="success">Posted</Badge> : <Badge variant="outline">Unposted</Badge>}
+          <SeverityBadge status={record.approvalState} label={record.approvalState} />
+          <SeverityBadge status={record.readiness ?? "Info"} label={record.readinessLabel || record.readiness} />
+          {record.isPosted ? (
+            <SeverityBadge status="Ready" label="Posted" />
+          ) : (
+            <SeverityBadge status="Info" label="Unposted" />
+          )}
         </div>
         <p className="mt-2 text-xs leading-5 text-muted-foreground">{record.readinessReason || "No readiness reason retained."}</p>
         <p className="mt-1 text-xs text-muted-foreground">{record.nextAction || "No next action retained."}</p>
       </td>
       <td className="px-3 py-2">
         <div className="flex flex-wrap gap-1.5">
-          <Badge variant={record.isReportReady ? "success" : "warning"}>{record.isReportReady ? "Report-ready" : "Not report-ready"}</Badge>
-          <Badge variant={record.isPublished ? "success" : "outline"}>{record.isPublished ? "Published" : "Not published"}</Badge>
+          <SeverityBadge
+            status={record.isReportReady ? "Ready" : "ReviewRequired"}
+            label={record.isReportReady ? "Report-ready" : "Not report-ready"}
+          />
+          <SeverityBadge
+            status={record.isPublished ? "Ready" : "Info"}
+            label={record.isPublished ? "Published" : "Not published"}
+          />
         </div>
         <p className="mt-2 text-xs text-muted-foreground">
           {record.reportOutputCount.toLocaleString()} output{record.reportOutputCount === 1 ? "" : "s"} / {record.reportLineProvenanceCount.toLocaleString()} provenance line{record.reportLineProvenanceCount === 1 ? "" : "s"}
@@ -254,9 +265,10 @@ function ReportingPrivateCapitalSubledgerRow({ subledger }: { subledger: Private
         <div className="mt-1">{subledger.publishedReportOutputCount.toLocaleString()} published report output{subledger.publishedReportOutputCount === 1 ? "" : "s"}</div>
       </td>
       <td className="px-3 py-2 text-xs">
-        <Badge variant={privateCapitalReadinessVariant(subledger.readiness ?? "EvidenceMissing")} dot>
-          {subledger.readinessLabel || subledger.readiness || "Evidence missing"}
-        </Badge>
+        <SeverityBadge
+          status={subledger.readiness ?? "EvidenceMissing"}
+          label={subledger.readinessLabel || subledger.readiness || "Evidence missing"}
+        />
         <div className="mt-1 text-[11px] text-muted-foreground">{subledger.readinessReason || "No subledger readiness reason"}</div>
         <ReportingPrivateCapitalRouteLink label={subledger.nextAction || "Next action"} href={subledger.nextActionRoute ?? subledger.activityRoute} />
         <div>{subledger.evidenceLinkCount.toLocaleString()} retained evidence link{subledger.evidenceLinkCount === 1 ? "" : "s"}</div>
@@ -283,9 +295,10 @@ function ReportingPrivateCapitalLedgerImpactList({ impacts }: { impacts: Private
                   <span className="block font-semibold text-foreground">{impact.fundEventType || impact.fundEventId}</span>
                   <span className="mt-1 block break-all font-mono text-[11px] text-muted-foreground">{impact.journalEntryId}</span>
                 </span>
-                <Badge variant={impact.isPostingReady ? "success" : impact.isBalanced ? "warning" : "danger"} dot>
-                  {impact.isPostingReady ? "Posting-ready" : impact.isBalanced ? "Balanced review" : "Unbalanced"}
-                </Badge>
+                <SeverityBadge
+                  status={impact.isPostingReady ? "Ready" : impact.isBalanced ? "ReviewRequired" : "Blocked"}
+                  label={impact.isPostingReady ? "Posting-ready" : impact.isBalanced ? "Balanced review" : "Unbalanced"}
+                />
               </div>
               <div className="mt-2 grid grid-cols-2 gap-2 font-mono text-[11px] text-muted-foreground">
                 <span>Debits {formatReportingMoney(impact.totalDebits, impact.currency)}</span>
@@ -320,8 +333,14 @@ function ReportingPrivateCapitalReportOutputList({ outputs }: { outputs: Private
                   <span className="mt-1 block break-all font-mono text-[11px] text-muted-foreground">{output.reportOutputId}</span>
                 </span>
                 <span className="flex flex-wrap justify-end gap-1.5">
-                  <Badge variant={output.isReportReady ? "success" : "warning"}>{output.readinessLabel || (output.isReportReady ? "Report-ready" : "Review")}</Badge>
-                  <Badge variant={output.isPublished ? "success" : "outline"}>{output.isPublished ? "Published" : "Unpublished"}</Badge>
+                  <SeverityBadge
+                    status={output.isReportReady ? "Ready" : "ReviewRequired"}
+                    label={output.readinessLabel || (output.isReportReady ? "Report-ready" : "Review")}
+                  />
+                  <SeverityBadge
+                    status={output.isPublished ? "Ready" : "Info"}
+                    label={output.isPublished ? "Published" : "Unpublished"}
+                  />
                 </span>
               </div>
               <p className="mt-2 text-[11px] text-muted-foreground">{output.readinessReason || "No report-output readiness reason"}</p>
@@ -352,7 +371,10 @@ function ReportingPrivateCapitalEvidenceCategories({ categories }: { categories:
       {categories.map((category) => (
         <div key={category.categoryId} className="rounded-sm border border-border/60 bg-secondary/20 px-2 py-1">
           <div className="flex flex-wrap items-center gap-1.5">
-            <Badge variant={category.isReady ? "success" : "warning"} dot>{category.label || category.categoryId}</Badge>
+            <SeverityBadge
+              status={category.isReady ? "Ready" : "ReviewRequired"}
+              label={category.label || category.categoryId}
+            />
             <span className="font-mono text-[11px] text-muted-foreground">{category.evidenceLinkCount.toLocaleString()} evidence</span>
           </div>
           <p className="mt-1 text-[11px] leading-5 text-muted-foreground">{category.summary || "No evidence summary retained."}</p>
@@ -387,34 +409,6 @@ function ReportingPrivateCapitalRouteLink({ label, href }: { label: string; href
       {label}: {href}
     </a>
   );
-}
-
-function privateCapitalApprovalVariant(status: ManualJournalEntryStatus): "outline" | "success" | "warning" | "danger" {
-  if (status === "Approved") {
-    return "success";
-  }
-
-  if (status === "Submitted") {
-    return "warning";
-  }
-
-  if (status === "NeedsFix" || status === "Rejected") {
-    return "danger";
-  }
-
-  return "outline";
-}
-
-function privateCapitalReadinessVariant(readiness: PrivateCapitalFundEventLedgerRecord["readiness"]): "outline" | "success" | "warning" | "danger" {
-  if (readiness === "Published" || readiness === "Ready") {
-    return "success";
-  }
-
-  if (readiness === "Blocked") {
-    return "danger";
-  }
-
-  return readiness ? "warning" : "outline";
 }
 
 function formatReportingMoney(value: number, currency: string): string {

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Select } from "@/components/ui/select";
+import { SeverityBadge } from "@/components/operations";
 import { FinancialRecordExplorerShell } from "@/components/meridian/financial-record-explorer";
 import { MetricCard } from "@/components/meridian/metric-card";
 import { ReportingPeriodSwitcher } from "@/components/meridian/reporting-period-switcher";
@@ -134,6 +135,23 @@ const structuredExportDownloadFormats = [
   { format: "xls", label: "XLS" },
   { format: "xlsx", label: "XLSX" }
 ] as const;
+
+// Concrete severity layer: reporting read-model badge variant → operator-readiness status
+// string (Ready · Review · Action · Blocked · Info) consumed by SeverityBadge. Used for the
+// run/approval/delivery STATUS chips; informational count/outline badges keep their neutral look.
+const reportingStatusFromVariant: Record<
+  "default" | "outline" | "success" | "warning" | "danger" | "paper" | "live" | "research",
+  string
+> = {
+  success: "Ready",
+  warning: "ReviewRequired",
+  danger: "Blocked",
+  outline: "Info",
+  default: "Info",
+  paper: "ReviewRequired",
+  live: "Blocked",
+  research: "Info"
+};
 const livePortfolioAutoRefreshIntervalMs = 60_000;
 const defaultExportsReportRunRequester = "browser-workstation";
 const reportingProfileColumns: DenseDataTableColumn<ReportingProfileRow>[] = [
@@ -1645,7 +1663,7 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <span className="font-semibold text-foreground">{template.name}</span>
                   <span className="flex flex-wrap items-center gap-1.5">
-                    <Badge variant={template.statusVariant}>{template.statusLabel}</Badge>
+                    <SeverityBadge status={reportingStatusFromVariant[template.statusVariant]} label={template.statusLabel} />
                     <Badge variant="outline">{template.sourceLabel}</Badge>
                     <Badge variant="outline">{template.family}</Badge>
                     <Badge variant="outline">{template.accessMode}</Badge>
@@ -1777,7 +1795,7 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
               <div key={run.id} className="rounded-md border border-border/70 bg-secondary/20 px-3 py-2">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <span className="font-mono text-sm text-foreground">{run.id}</span>
-                  <Badge variant={run.status === "Failed" ? "warning" : "outline"}>{run.status}</Badge>
+                  <SeverityBadge status={run.status} label={run.status} />
                 </div>
                 <p className="mt-1 text-xs leading-5 text-muted-foreground">
                   {run.family} · {run.trigger} · {run.lineageSummary} · {run.auditSummary}
@@ -1940,9 +1958,10 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
                   {vm.workflowTaskPanel.description}
                 </p>
               </div>
-              <Badge variant={vm.workflowTaskPanel.statusVariant}>
-                {vm.workflowTaskPanel.statusLabel}
-              </Badge>
+              <SeverityBadge
+                status={reportingStatusFromVariant[vm.workflowTaskPanel.statusVariant]}
+                label={vm.workflowTaskPanel.statusLabel}
+              />
             </div>
             <div className="flex flex-wrap gap-2">
               {vm.workflowTaskPanel.chips.map((chip) => (
@@ -1969,9 +1988,10 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
                     {vm.workflowTaskPanel.publicationReview.description}
                   </p>
                 </div>
-                <Badge variant={vm.workflowTaskPanel.publicationReview.statusVariant}>
-                  {vm.workflowTaskPanel.publicationReview.statusLabel}
-                </Badge>
+                <SeverityBadge
+                  status={reportingStatusFromVariant[vm.workflowTaskPanel.publicationReview.statusVariant]}
+                  label={vm.workflowTaskPanel.publicationReview.statusLabel}
+                />
               </div>
               <p className="mt-3 rounded-md border border-border/70 bg-background/40 px-3 py-2 text-sm leading-6 text-foreground">
                 {vm.workflowTaskPanel.publicationReview.summaryText}
@@ -2090,9 +2110,10 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
                     {vm.workflowTaskPanel.restatementReview.description}
                   </p>
                 </div>
-                <Badge variant={vm.workflowTaskPanel.restatementReview.statusVariant}>
-                  {vm.workflowTaskPanel.restatementReview.statusLabel}
-                </Badge>
+                <SeverityBadge
+                  status={reportingStatusFromVariant[vm.workflowTaskPanel.restatementReview.statusVariant]}
+                  label={vm.workflowTaskPanel.restatementReview.statusLabel}
+                />
               </div>
               <p className="mt-3 rounded-md border border-border/70 bg-background/40 px-3 py-2 text-sm leading-6 text-foreground">
                 {vm.workflowTaskPanel.restatementReview.summaryText}


### PR DESCRIPTION
Wave 2 (W5): restyles the **Reporting** area (`reporting-screen` + modules, `operations-record-release-screen`, reporting-exclusive meridian components) to the Concrete design system and adopts shared Wave-1 components (SeverityBadge/ReadinessPanel/GateRail for run/delivery status, DenseData/FilteredData tables, MetricCard). Behavior + view-models preserved. Built green on Node 24; reporting suites 64/64 pass. (Inherited LedgerTable build error is fixed by #2066 — merge that first.)