### PR TITLE
Web UI Concrete — W7: Data screens

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/data/backfill-validation-dashboard.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/backfill-validation-dashboard.tsx
@@ -1,9 +1,10 @@
-import { AlertCircle, CheckCircle2, AlertTriangle, RefreshCw } from "lucide-react";
-import { useState, useEffect } from "react";
+import { RefreshCw } from "lucide-react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
-import { Badge } from "@/components/ui/badge";
+import { EmptyState, MetricCard } from "@/components/data/concrete";
+import { SeverityBadge } from "@/components/operations";
 import { cn } from "@/lib/utils";
 
 interface BackfillValidation {
@@ -32,17 +33,21 @@ interface BackfillValidationDashboardProps {
   isLoading?: boolean;
 }
 
-function getStatusColor(completeness: number): string {
-  if (completeness >= 0.95) return "bg-green-500";
-  if (completeness >= 0.8) return "bg-yellow-500";
-  return "bg-red-500";
+// Concrete severity mapping: Complete reads Ready (spruce-green), Good reads Action
+// (ochre — attention, not blocked), Incomplete reads Blocked (brick-red). The original
+// human label is preserved via SeverityBadge's `label` prop.
+function getStatusSeverity(status: string): string {
+  if (status === "Complete") return "Ready";
+  if (status === "Good") return "Action";
+  if (status === "Incomplete") return "Blocked";
+  return "Info";
 }
 
-function getStatusBadgeVariant(status: string): "success" | "warning" | "danger" | "default" {
-  if (status === "Complete") return "success";
-  if (status === "Good") return "warning";
-  if (status === "Incomplete") return "danger";
-  return "default";
+// Completeness-driven tone for the value readout: alpha layer only, semantic tokens.
+function getCompletenessToneClass(completeness: number): string {
+  if (completeness >= 0.95) return "text-success";
+  if (completeness >= 0.8) return "text-warning";
+  return "text-danger";
 }
 
 export function BackfillValidationDashboard({
@@ -87,22 +92,10 @@ export function BackfillValidationDashboard({
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-              <div className="p-4 rounded-lg border bg-card">
-                <div className="text-sm text-muted-foreground">Complete (≥95%)</div>
-                <div className="text-3xl font-bold text-green-600 mt-1">{summary.complete}</div>
-              </div>
-              <div className="p-4 rounded-lg border bg-card">
-                <div className="text-sm text-muted-foreground">Good (80-95%)</div>
-                <div className="text-3xl font-bold text-yellow-600 mt-1">{summary.good}</div>
-              </div>
-              <div className="p-4 rounded-lg border bg-card">
-                <div className="text-sm text-muted-foreground">Poor (&lt;80%)</div>
-                <div className="text-3xl font-bold text-red-600 mt-1">{summary.poor}</div>
-              </div>
-              <div className="p-4 rounded-lg border bg-card">
-                <div className="text-sm text-muted-foreground">Average Completeness</div>
-                <div className="text-3xl font-bold mt-1">{Math.round(summary.average * 100)}%</div>
-              </div>
+              <MetricCard label="Complete (≥95%)" value={summary.complete} tone="success" />
+              <MetricCard label="Good (80-95%)" value={summary.good} tone="warning" />
+              <MetricCard label="Poor (<80%)" value={summary.poor} tone="danger" />
+              <MetricCard label="Average Completeness" value={`${Math.round(summary.average * 100)}%`} tone="neutral" />
             </div>
           </CardContent>
         </Card>
@@ -120,28 +113,27 @@ export function BackfillValidationDashboard({
         </CardHeader>
         <CardContent>
           {validations.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-8 text-center">
-              <AlertCircle className="h-8 w-8 text-muted-foreground mb-2" />
-              <p className="text-sm text-muted-foreground">
-                No symbols configured yet. Add symbols to monitor backfill completeness.
-              </p>
-            </div>
+            <EmptyState
+              icon="table"
+              title="No symbols configured yet"
+              detail="Add symbols to monitor backfill completeness."
+            />
           ) : (
             <div className="space-y-3">
               {validations.map((validation) => (
                 <div
                   key={validation.symbol}
-                  className="p-4 rounded-lg border hover:bg-muted/50 transition-colors"
+                  className="rounded-[var(--radius-card,2px)] border border-border/70 bg-background/35 p-4 transition-colors hover:border-border hover:bg-secondary/40"
                 >
                   <div className="flex items-center justify-between mb-3">
                     <div className="flex items-center gap-3">
-                      <span className="font-semibold text-base">{validation.symbol}</span>
-                      <Badge variant={getStatusBadgeVariant(validation.status)} className="text-xs">
-                        {validation.status}
-                      </Badge>
+                      <span className="font-semibold text-base text-foreground">{validation.symbol}</span>
+                      <SeverityBadge status={getStatusSeverity(validation.status)} label={validation.status} />
                     </div>
                     <div className="text-right">
-                      <div className="text-2xl font-bold">{Math.round(validation.completeness * 100)}%</div>
+                      <div className={cn("font-mono text-2xl font-semibold tabular-nums", getCompletenessToneClass(validation.completeness))}>
+                        {Math.round(validation.completeness * 100)}%
+                      </div>
                       <div className="text-xs text-muted-foreground">
                         {validation.coveredDays} of {validation.totalDays} days
                       </div>
@@ -158,7 +150,7 @@ export function BackfillValidationDashboard({
 
                   {/* Date range */}
                   {validation.firstDataPoint && validation.lastDataPoint && (
-                    <div className="text-xs text-muted-foreground mb-2">
+                    <div className="font-mono text-xs text-muted-foreground mb-2">
                       {validation.firstDataPoint} to {validation.lastDataPoint}
                     </div>
                   )}
@@ -166,10 +158,10 @@ export function BackfillValidationDashboard({
                   {/* Gaps */}
                   {validation.gaps && validation.gaps.length > 0 && (
                     <details className="cursor-pointer">
-                      <summary className="text-xs font-semibold text-yellow-700 hover:text-yellow-900">
+                      <summary className="text-xs font-semibold text-warning hover:text-warning/80">
                         {validation.gaps.length} gap{validation.gaps.length > 1 ? "s" : ""} detected
                       </summary>
-                      <ul className="mt-2 space-y-1 text-xs text-muted-foreground list-disc list-inside">
+                      <ul className="mt-2 space-y-1 font-mono text-xs text-muted-foreground list-disc list-inside">
                         {validation.gaps.slice(0, 3).map((gap, idx) => (
                           <li key={idx}>{gap}</li>
                         ))}

--- a/src/Meridian.Ui/dashboard/src/components/data/provider-capability-badges.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/provider-capability-badges.tsx
@@ -1,11 +1,16 @@
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
+// Concrete language: capabilities read as desaturated semantic trios — a solid hairline
+// border over an alpha-10 wash, never a solid fill. Streaming rides the one steel accent;
+// backfill purple, symbol-search spruce-green, brokerage ochre. Colors resolve from tokens
+// (purple is dark-mode aware via --purple) so no raw palette hexes leak into components.
 const CAPABILITY_COLORS: Record<string, string> = {
-  Streaming: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
-  Backfill: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
-  SymbolSearch: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-  Brokerage: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+  Streaming: "border-primary/40 bg-primary/[0.10] text-primary",
+  Backfill:
+    "border-[color:color-mix(in_srgb,var(--purple)_40%,transparent)] bg-[color:color-mix(in_srgb,var(--purple)_10%,transparent)] text-[color:var(--purple)]",
+  SymbolSearch: "border-success/40 bg-success/[0.10] text-success",
+  Brokerage: "border-warning/45 bg-warning/[0.11] text-warning",
 };
 
 interface Props {

--- a/src/Meridian.Ui/dashboard/src/components/data/symbol-universe-manager.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/data/symbol-universe-manager.tsx
@@ -1,4 +1,4 @@
-import { Plus, Trash2, Edit2, CheckCircle2, AlertCircle } from "lucide-react";
+import { Plus, Trash2, Edit2, CheckCircle2 } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -6,7 +6,7 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
-import { cn } from "@/lib/utils";
+import { EmptyState } from "@/components/data/concrete";
 
 interface Symbol {
   symbol: string;
@@ -94,27 +94,27 @@ export function SymbolUniverseManager({ symbols, onAdd, onUpdate, onDelete, isLo
         </CardHeader>
         <CardContent>
           {symbols.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-8 text-center">
-              <AlertCircle className="h-8 w-8 text-muted-foreground mb-2" />
-              <p className="text-sm text-muted-foreground">No symbols configured yet.</p>
-              <p className="text-xs text-muted-foreground mt-1">Add your first symbol to get started.</p>
-            </div>
+            <EmptyState
+              icon="table"
+              title="No symbols configured yet."
+              detail="Add your first symbol to get started."
+            />
           ) : (
             <div className="grid gap-2">
               {symbols.map((sym) => (
                 <div
                   key={sym.symbol}
-                  className="flex items-center justify-between p-3 rounded-lg border hover:bg-muted/50 transition-colors"
+                  className="flex items-center justify-between p-3 rounded-[var(--radius-card,2px)] border border-border/70 bg-background/35 transition-colors hover:border-border hover:bg-secondary/40"
                 >
                   <div className="flex items-center gap-3 flex-1">
                     <div>
                       <div className="flex items-center gap-2">
-                        <span className="font-semibold">{sym.symbol}</span>
+                        <span className="font-semibold text-foreground">{sym.symbol}</span>
                         <Badge variant="outline" className="text-xs">
                           {sym.exchange}
                         </Badge>
                         {sym.status === "configured" && (
-                          <CheckCircle2 className="h-4 w-4 text-green-600" aria-label="Configured" />
+                          <CheckCircle2 className="h-4 w-4 text-success" aria-label="Configured" />
                         )}
                       </div>
                       <div className="text-xs text-muted-foreground mt-1">
@@ -144,7 +144,7 @@ export function SymbolUniverseManager({ symbols, onAdd, onUpdate, onDelete, isLo
                       disabled={isLoading}
                       aria-label={`Delete ${sym.symbol}`}
                     >
-                      <Trash2 className="h-4 w-4 text-red-500" />
+                      <Trash2 className="h-4 w-4 text-danger" />
                     </Button>
                   </div>
                 </div>

--- a/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.tsx
@@ -23,6 +23,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { FieldSupportText, joinDescribedByIds } from "@/components/ui/field-support";
 import { HistoricalChartCard } from "@/components/meridian/historical-chart";
+import { DepthChart } from "@/components/charts";
 import { DenseDataTable, EntitySummary, type DenseDataTableColumn } from "@/components/meridian/ui-kit-primitives";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
@@ -313,6 +314,19 @@ export function LiveQuotesScreen() {
               ) : (
                 <div className="space-y-3">
                   <PanelStateMessage state={marketVm.orderbookState} />
+                  {marketVm.orderbook.bids.length > 0 || marketVm.orderbook.asks.length > 0 ? (
+                    <div
+                      className="overflow-hidden rounded-[var(--radius-card,2px)] border border-border/70 bg-background/40"
+                      role="img"
+                      aria-label={`Order-book depth profile for ${activeSymbol}: cumulative bid and ask size around the mid price.`}
+                    >
+                      <DepthChart
+                        bids={marketVm.orderbook.bids.map((level) => ({ price: level.price, size: level.size }))}
+                        asks={marketVm.orderbook.asks.map((level) => ({ price: level.price, size: level.size }))}
+                        mid={marketVm.orderbook.midPrice ?? null}
+                      />
+                    </div>
+                  ) : null}
                   <DepthLadder
                     ladder={marketVm.depthLadder}
                     onSeedBuy={(price) => quickTrade.seedTicket("Buy", price)}


### PR DESCRIPTION
## Summary

Wave 2 (W7 · Data) rework of the Data-area presentation to the Concrete design system. Restyles and adopts the new shared component libraries while **preserving all existing behavior, view-models, and tests**.

## Changes (owned files only)

- **`components/data/provider-capability-badges.tsx`** — replace raw Tailwind palette colors (`bg-blue-100`, `bg-purple-100`, …) with desaturated semantic trios (steel / purple / spruce-green / ochre): a solid hairline border over an alpha-10 wash, never a solid fill. Purple resolves from the dark-mode-aware `--purple` token, so no raw palette hexes leak into components.
- **`components/data/backfill-validation-dashboard.tsx`** — adopt the shared Concrete `MetricCard` (3px left-accent KPI tiles), `EmptyState`, and `SeverityBadge`. `Complete`/`Good`/`Incomplete` map to `Ready`/`Action`/`Blocked` severities while preserving the original human labels. Numerics moved to mono tabular; 2px card radii; semantic tone tokens throughout.
- **`components/data/symbol-universe-manager.tsx`** — adopt the shared Concrete `EmptyState`; swap raw green/red marks for semantic `success`/`danger` tokens; 2px radii and hairline borders.
- **`screens/live-quotes-screen.tsx`** — add the shared Concrete `DepthChart` order-book depth profile above the existing L2 ladder (additive; driven from the live order book via the existing view model), wrapped in a labeled `role="img"` container. Mirrors the charting-workstation depth-profile pattern.

No view-model logic, props, ARIA/focus wiring, async/cancellation, or live-data polling changed. Shared Wave-1 data-furniture, `index.css`, `tailwind.config.ts`, shell files, `app.tsx`, and other screens are untouched.

## Verification

- `npm ci` ✓
- `npm run build` — exit 0 ✓
- Data-area tests green: `data-screen`, `live-quotes-screen` (45), `watchlist-screen`, `price-alerts-screen`, `symbol-universe-manager`, `provider-setup-panel`.
- Full `npx vitest run` — **1711 passed / 1712**; the single failure is an unrelated, pre-existing timeout in `reporting-screen.test.tsx` (out of scope, imports none of these files) that **passes in isolation**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)