### PR TITLE
Web UI Concrete — W4: Accounting screens

### DIFF
--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.close-cockpit-panels.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.close-cockpit-panels.tsx
@@ -78,7 +78,7 @@ export function AccountingWorkflowLaunchPanel({ view }: { view: AccountingWorkfl
                 </div>
                 <div className="mt-3 flex items-center justify-between gap-2 border-t border-border/60 pt-2 text-xs">
                   <span className="text-muted-foreground">{step.metricLabel}</span>
-                  <span className="font-mono text-foreground">{step.metricValue}</span>
+                  <span className="font-mono tabular-nums text-foreground">{step.metricValue}</span>
                 </div>
               </Link>
             );
@@ -1297,7 +1297,7 @@ function CloseCommandCenterValue({ label, value }: { label: string; value: strin
   return (
     <div className="data-grid-surface flex items-center justify-between gap-4 px-3 py-2">
       <span className="text-muted-foreground">{label}</span>
-      <span className="font-mono text-foreground">{value}</span>
+      <span className="font-mono tabular-nums text-foreground">{value}</span>
     </div>
   );
 }

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.tsx
@@ -13,6 +13,7 @@ import { FormRow } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { StatusBanner } from "@/components/ui/status-banner";
 import { TabPanel, Tabs } from "@/components/ui/tabs";
+import { SeverityBadge } from "@/components/operations";
 import { LotsTrackerPanel, SecurityDetailsPanel } from "@/components/meridian/security-details-tracker";
 import { CoveragePassportDrillIn } from "@/components/meridian/coverage-passport-drill-in";
 import { AccountingTrialBalanceSelectedDetailPanel, trialBalanceColumns } from "@/components/accounting/TrialBalanceRowDetail";
@@ -205,8 +206,8 @@ const reconciliationQueueColumns: DenseDataTableColumn<ReconciliationQueueRunRow
   },
   { id: "mode", label: "Mode", render: (row) => <span className="font-mono uppercase text-muted-foreground">{row.modeLabel}</span> },
   { id: "status", label: "Status", render: (row) => row.runStatusLabel },
-  { id: "breaks", label: "Breaks", align: "right", render: (row) => <span className="font-mono">{row.breakCountLabel}</span> },
-  { id: "open", label: "Open", align: "right", render: (row) => <span className="font-mono">{row.openBreakLabel}</span> },
+  { id: "breaks", label: "Breaks", align: "right", render: (row) => <span className="font-mono tabular-nums">{row.breakCountLabel}</span> },
+  { id: "open", label: "Open", align: "right", render: (row) => <span className="font-mono tabular-nums">{row.openBreakLabel}</span> },
   {
     id: "reconciliation",
     label: "Reconciliation",
@@ -225,10 +226,10 @@ const reconciliationStatementRunColumns: DenseDataTableColumn<ReconciliationStat
   { id: "account", label: "Account", render: (row) => <span title={row.unavailableReason ?? undefined}>{row.accountLabel}</span> },
   { id: "period", label: "Period", render: (row) => <span className="font-mono text-muted-foreground" title={row.unavailableReason ?? undefined}>{row.periodLabel}</span> },
   { id: "status", label: "Status", render: (row) => <Badge variant={row.statusLabel === "Matched" || row.statusLabel === "Balanced" ? "success" : "warning"}>{row.statusLabel}</Badge> },
-  { id: "validation", label: "Validation issues", align: "right", render: (row) => <span className="font-mono">{row.validationIssueCountLabel}</span> },
-  { id: "matches", label: "Matches", align: "right", render: (row) => <span className="font-mono">{row.matchCountLabel}</span> },
-  { id: "breaks", label: "Breaks", align: "right", render: (row) => <span className="font-mono">{row.breakCountLabel}</span> },
-  { id: "cases", label: "Cases", align: "right", render: (row) => <span className="font-mono">{row.caseCountLabel}</span> },
+  { id: "validation", label: "Validation issues", align: "right", render: (row) => <span className="font-mono tabular-nums">{row.validationIssueCountLabel}</span> },
+  { id: "matches", label: "Matches", align: "right", render: (row) => <span className="font-mono tabular-nums">{row.matchCountLabel}</span> },
+  { id: "breaks", label: "Breaks", align: "right", render: (row) => <span className="font-mono tabular-nums">{row.breakCountLabel}</span> },
+  { id: "cases", label: "Cases", align: "right", render: (row) => <span className="font-mono tabular-nums">{row.caseCountLabel}</span> },
   { id: "imported", label: "Imported", render: (row) => <span className="font-mono text-muted-foreground">{row.importedAtLabel}</span> }
 ];
 
@@ -430,9 +431,9 @@ function ReconciliationComparisonPane({
       <div className="reconcile-pane-head">
         <span className="reconcile-pane-title">{heading}</span>
         <span className="reconcile-pane-chips">
-          <span className="reconcile-chip is-ok">{matched} matched</span>
-          {timing > 0 && <span className="reconcile-chip is-timing">{timing} timing</span>}
-          {breaks > 0 && <span className="reconcile-chip is-break">{`${breaks} break${breaks > 1 ? "s" : ""}`}</span>}
+          <SeverityBadge status="ready" dot={false} label={`${matched} matched`} />
+          {timing > 0 && <SeverityBadge status="action" dot={false} label={`${timing} timing`} />}
+          {breaks > 0 && <SeverityBadge status="blocked" dot={false} label={`${breaks} break${breaks > 1 ? "s" : ""}`} />}
         </span>
       </div>
       <div className="reconcile-pane-scroll" ref={scrollRef} onScroll={onScroll}>
@@ -3034,8 +3035,8 @@ export function AccountingScreen({ data, multiAssetCoverage }: AccountingScreenP
                           <Badge variant={row.varianceTone}>{row.varianceLabel}</Badge>
                         </div>
                         <div className="mt-2 grid grid-cols-2 gap-2 text-[11px] text-muted-foreground">
-                          <span className="font-mono">Primary {row.primaryBalanceLabel}</span>
-                          <span className="font-mono">{row.comparisonBalanceLabel}</span>
+                          <span className="font-mono tabular-nums">Primary {row.primaryBalanceLabel}</span>
+                          <span className="font-mono tabular-nums">{row.comparisonBalanceLabel}</span>
                         </div>
                       </div>
                     ))}
@@ -5582,9 +5583,9 @@ function ManualJournalPrivateCapitalActivityPanel({ activity }: { activity: Manu
                       <div className="mt-1 text-xs text-muted-foreground">{entry.issueLabel}</div>
                     </td>
                     <td className="px-3 py-2 font-mono text-xs">{entry.effectiveDateLabel}</td>
-                    <td className="px-3 py-2 font-mono text-xs">{entry.netActivityLabel}</td>
-                    <td className="px-3 py-2 font-mono text-xs">{entry.runningBalanceLabel}</td>
-                    <td className="px-3 py-2 font-mono text-xs">{entry.grossAmountLabel}</td>
+                    <td className="px-3 py-2 font-mono tabular-nums text-xs">{entry.netActivityLabel}</td>
+                    <td className="px-3 py-2 font-mono tabular-nums text-xs">{entry.runningBalanceLabel}</td>
+                    <td className="px-3 py-2 font-mono tabular-nums text-xs">{entry.grossAmountLabel}</td>
                     <td className="px-3 py-2 text-xs">{entry.evidenceLabel}</td>
                   </tr>
                 ))}
@@ -5619,9 +5620,9 @@ function ManualJournalPrivateCapitalActivityPanel({ activity }: { activity: Manu
                       <div className="mt-1 text-xs text-muted-foreground">{impact.issueLabel}</div>
                     </td>
                     <td className="px-3 py-2 font-mono text-xs">{impact.effectiveDateLabel}</td>
-                    <td className="px-3 py-2 font-mono text-xs">{impact.debitLabel}</td>
-                    <td className="px-3 py-2 font-mono text-xs">{impact.creditLabel}</td>
-                    <td className="px-3 py-2 font-mono text-xs">{impact.imbalanceLabel}</td>
+                    <td className="px-3 py-2 font-mono tabular-nums text-xs">{impact.debitLabel}</td>
+                    <td className="px-3 py-2 font-mono tabular-nums text-xs">{impact.creditLabel}</td>
+                    <td className="px-3 py-2 font-mono tabular-nums text-xs">{impact.imbalanceLabel}</td>
                     <td className="px-3 py-2 text-xs">
                       <div>{impact.evidenceLabel}</div>
                       <div className="mt-1 text-muted-foreground">{impact.lineLabel}</div>
@@ -5659,7 +5660,7 @@ function ManualJournalPrivateCapitalActivityPanel({ activity }: { activity: Manu
                       <div className="mt-1 text-xs text-muted-foreground">{output.issueLabel}</div>
                     </td>
                     <td className="px-3 py-2 font-mono text-xs">{output.effectiveDateLabel}</td>
-                    <td className="px-3 py-2 font-mono text-xs">{output.amountLabel}</td>
+                    <td className="px-3 py-2 font-mono tabular-nums text-xs">{output.amountLabel}</td>
                     <td className="px-3 py-2 text-xs">{output.evidenceLabel}</td>
                     <td className="px-3 py-2 text-xs">
                       <div className="break-all font-mono text-[11px] text-foreground">{output.workflowLabel}</div>
@@ -5687,8 +5688,8 @@ function ManualJournalPrivateCapitalActivityPanel({ activity }: { activity: Manu
                 </div>
                 <dl className="mt-2 grid gap-2 text-xs sm:grid-cols-2">
                   <div><dt className="text-muted-foreground">Effective</dt><dd className="font-mono">{event.effectiveDateLabel}</dd></div>
-                  <div><dt className="text-muted-foreground">Net</dt><dd className="font-mono">{event.amountLabel}</dd></div>
-                  <div><dt className="text-muted-foreground">Gross</dt><dd className="font-mono">{event.grossAmountLabel}</dd></div>
+                  <div><dt className="text-muted-foreground">Net</dt><dd className="font-mono tabular-nums">{event.amountLabel}</dd></div>
+                  <div><dt className="text-muted-foreground">Gross</dt><dd className="font-mono tabular-nums">{event.grossAmountLabel}</dd></div>
                   <div><dt className="text-muted-foreground">Evidence</dt><dd>{event.evidenceLabel}</dd></div>
                   <div><dt className="text-muted-foreground">Payment</dt><dd className="break-all">{event.paymentLabel}</dd></div>
                   <div><dt className="text-muted-foreground">Validation</dt><dd>{event.validationLabel}</dd></div>
@@ -5991,8 +5992,8 @@ function ManualJournalEntryWorkbenchPanel({ view }: { view: ManualJournalEntryWo
                           <div className="font-semibold text-foreground">{row.accountName}</div>
                           <div className="font-mono text-[11px] text-muted-foreground">{row.accountPath} / {row.accountType}</div>
                         </td>
-                        <td className="font-mono text-right">{row.debitLabel}</td>
-                        <td className="font-mono text-right">{row.creditLabel}</td>
+                        <td className="font-mono tabular-nums text-right">{row.debitLabel}</td>
+                        <td className="font-mono tabular-nums text-right">{row.creditLabel}</td>
                         <td>
                           <Badge variant={row.tone === "warning" ? "warning" : row.tone === "success" ? "success" : "outline"}>
                             {row.netEffectLabel}
@@ -7423,7 +7424,7 @@ function AccountingConfigurationPanel({ view }: { view: AccountingConfigurationV
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div>
                     <div className="font-semibold text-foreground">{view.preview.title}</div>
-                    <div className="mt-1 font-mono text-xs text-muted-foreground">{view.preview.balanceLabel}</div>
+                    <div className="mt-1 font-mono tabular-nums text-xs text-muted-foreground">{view.preview.balanceLabel}</div>
                   </div>
                   <Badge variant={view.preview.statusLabel.startsWith("Balanced") ? "success" : "warning"}>{view.preview.statusLabel}</Badge>
                 </div>
@@ -7432,7 +7433,7 @@ function AccountingConfigurationPanel({ view }: { view: AccountingConfigurationV
                     <div key={line.id} className="grid gap-2 rounded border border-border/60 px-2 py-2 text-xs sm:grid-cols-[1fr_auto_auto]">
                       <span className="min-w-0 break-words font-mono text-foreground">{line.account}</span>
                       <span className="font-mono text-muted-foreground">{line.side}</span>
-                      <span className="font-mono text-foreground">{line.amount}</span>
+                      <span className="font-mono tabular-nums text-foreground">{line.amount}</span>
                     </div>
                   ))}
                 </div>
@@ -7508,7 +7509,7 @@ function AccountingValue({ label, value, tone, ariaLabel }: { label: string; val
   return (
     <div aria-label={ariaLabel} className="data-grid-surface flex items-center justify-between gap-4 px-3 py-2">
       <span className="text-muted-foreground">{label}</span>
-      <span className={cn("font-mono text-foreground", tone)}>{value}</span>
+      <span className={cn("font-mono tabular-nums text-foreground", tone)}>{value}</span>
     </div>
   );
 }

--- a/src/Meridian.Ui/dashboard/src/screens/evidence-workbench-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/evidence-workbench-screen.tsx
@@ -522,7 +522,7 @@ function EvidenceMetric({ label, value, tone = "muted" }: { label: string; value
   return (
     <div className="rounded-md border border-border/70 bg-secondary/25 px-3 py-2">
       <div className="eyebrow-label">{label}</div>
-      <div className={cn("mt-1 font-mono text-lg font-semibold", metricToneClass[tone])}>{value}</div>
+      <div className={cn("mt-1 font-mono tabular-nums text-lg font-semibold", metricToneClass[tone])}>{value}</div>
     </div>
   );
 }

--- a/src/Meridian.Ui/dashboard/src/screens/operations-continuity-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/operations-continuity-screen.tsx
@@ -167,7 +167,7 @@ const operationalDashboardColumns: DenseDataTableColumn<OperationsContinuityDash
     render: (row) => (
       <span className="block text-xs leading-5">
         <Badge variant={toneBadge[row.statusTone]}>{row.statusLabel}</Badge>
-        <span className="mt-1 block font-mono text-foreground">{row.valueLabel}</span>
+        <span className="mt-1 block font-mono tabular-nums text-foreground">{row.valueLabel}</span>
       </span>
     )
   },

--- a/src/Meridian.Ui/dashboard/src/styles/accounting-screen.css
+++ b/src/Meridian.Ui/dashboard/src/styles/accounting-screen.css
@@ -1,16 +1,21 @@
-/* Accounting route-owned workstation styling. Keep imported from accounting-screen.tsx. */
+/* Accounting route-owned workstation styling — Concrete design language.
+   Flat #FFFFFF panels on the #DEE3EA canvas, hairline #CBD3DC borders, 2px radii,
+   one steel accent (#2F6F8F), mono tabular money, small-caps section labels. Every
+   value routes through the shared --ws-* / semantic tokens with a Concrete hex
+   fallback so the sheet tracks white-label + dark automatically.
+   Keep imported from accounting-screen.tsx. */
 
 .accounting-reference-panel,
 .accounting-draft-rail {
   display: grid;
   gap: 1rem;
   min-width: 0;
-  border: 1px solid #d8dde5;
-  border-radius: 8px;
-  background: #f3f5f8;
-  color: #20242a;
+  border: 1px solid var(--ws-border, #cbd3dc);
+  border-radius: var(--radius-card, 2px);
+  background: var(--ws-surface-raised, #f3f6f9);
+  color: var(--ws-text, #22272e);
   padding: 1rem;
-  box-shadow: 0 1px 2px rgba(21, 35, 48, 0.08);
+  box-shadow: var(--ws-shadow, none);
 }
 
 .accounting-journal-panel {
@@ -27,7 +32,7 @@
 
 .accounting-reference-kicker {
   margin: 0;
-  color: #65717f;
+  color: var(--ws-text-muted, #59636f);
   font-size: 0.75rem;
   font-weight: 760;
   line-height: 1.25;
@@ -37,7 +42,7 @@
 
 .accounting-reference-subtitle {
   margin: 0.25rem 0 0;
-  color: #65717f;
+  color: var(--ws-text-muted, #59636f);
   font-size: 0.875rem;
   line-height: 1.35;
 }
@@ -56,11 +61,11 @@
   align-items: center;
   justify-content: center;
   min-height: 1.5rem;
-  border: 1px solid #cbd4de;
-  border-radius: 5px;
-  background: #ffffff;
+  border: 1px solid var(--ws-border, #cbd3dc);
+  border-radius: var(--radius-chip, 2px);
+  background: var(--ws-surface, #ffffff);
   padding: 0.125rem 0.5rem;
-  color: #343a42;
+  color: var(--ws-text, #343a42);
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
   font-size: 0.6875rem;
   font-weight: 760;
@@ -71,15 +76,15 @@
 
 .accounting-reference-badge-success,
 .accounting-reference-balance-badge.is-balanced {
-  border-color: #2f8f79;
-  background: #e8f6f1;
-  color: #23715f;
+  border-color: var(--state-healthy-bd, rgba(22, 136, 95, 0.32));
+  background: var(--state-healthy-bg, rgba(22, 136, 95, 0.1));
+  color: var(--state-healthy-fg, #16885f);
 }
 
 .accounting-reference-badge-warning {
-  border-color: #b88939;
-  background: #fbf3df;
-  color: #8a6420;
+  border-color: var(--state-warn-bd, rgba(138, 82, 14, 0.38));
+  background: var(--state-warn-bg, rgba(138, 82, 14, 0.11));
+  color: var(--state-warn-fg, #8a520e);
 }
 
 .accounting-reference-balance-badge {
@@ -96,9 +101,9 @@
 }
 
 .accounting-reference-balance-badge.is-out {
-  border-color: #b25367;
-  background: #fae8ed;
-  color: #963c50;
+  border-color: var(--state-danger-bd, rgba(186, 63, 85, 0.35));
+  background: var(--state-danger-bg, rgba(186, 63, 85, 0.1));
+  color: var(--state-danger-fg, #ba3f55);
 }
 
 /* ── Split-pane reconciliation (statement vs. ledger) ──────────────────────
@@ -111,10 +116,10 @@
   grid-template-columns: repeat(2, minmax(0, 1fr));
   min-width: 0;
   overflow: hidden;
-  border: 1px solid var(--ws-border, #d7dce2);
-  border-radius: 8px;
+  border: 1px solid var(--ws-border, #cbd3dc);
+  border-radius: var(--radius-card, 2px);
   background: var(--ws-surface, #ffffff);
-  box-shadow: var(--ws-shadow, 0 1px 1px rgba(0, 0, 0, 0.08));
+  box-shadow: var(--ws-shadow, none);
 }
 
 .reconcile-pane {
@@ -125,7 +130,7 @@
 }
 
 .reconcile-pane + .reconcile-pane {
-  border-left: 1px solid var(--ws-border, #d7dce2);
+  border-left: 1px solid var(--ws-border, #cbd3dc);
 }
 
 .reconcile-pane-head {
@@ -134,8 +139,8 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
-  border-bottom: 1px solid var(--ws-border, #d7dce2);
-  background: var(--ws-surface-subtle, #f5f7fa);
+  border-bottom: 1px solid var(--ws-border, #cbd3dc);
+  background: var(--ws-surface-subtle, #ebeff4);
   padding: 0.5rem 0.8125rem;
 }
 
@@ -155,36 +160,6 @@
   gap: 0.3125rem;
 }
 
-.reconcile-chip {
-  border: 1px solid;
-  border-radius: var(--radius-chip, 4px);
-  padding: 0.0625rem 0.4375rem;
-  font-size: 0.625rem;
-  font-weight: 700;
-  line-height: 1.5;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-  white-space: nowrap;
-}
-
-.reconcile-chip.is-ok {
-  border-color: var(--state-healthy-bd);
-  background: var(--state-healthy-bg);
-  color: var(--state-healthy-fg);
-}
-
-.reconcile-chip.is-timing {
-  border-color: var(--state-warn-bd);
-  background: var(--state-warn-bg);
-  color: var(--state-warn-fg);
-}
-
-.reconcile-chip.is-break {
-  border-color: var(--state-danger-bd);
-  background: var(--state-danger-bg);
-  color: var(--state-danger-fg);
-}
-
 .reconcile-pane-scroll {
   flex: 1;
   min-height: 0;
@@ -201,7 +176,7 @@
   position: sticky;
   top: 0;
   z-index: 1;
-  border-bottom: 1px solid var(--ws-border, #d7dce2);
+  border-bottom: 1px solid var(--ws-border, #cbd3dc);
   background: var(--ws-surface, #ffffff);
   padding: 0.375rem 0.75rem;
   color: var(--ws-text-muted, #59636f);
@@ -224,7 +199,7 @@
 
 .reconcile-table td {
   position: relative;
-  border-top: 1px solid var(--ws-border, #d7dce2);
+  border-top: 1px solid var(--ws-border, #cbd3dc);
   padding: 0.5rem 0.75rem;
   vertical-align: middle;
 }
@@ -241,7 +216,7 @@
   bottom: 0;
   width: 3px;
   border-radius: 0 2px 2px 0;
-  background: var(--ws-border-strong, #b8c2cc);
+  background: var(--ws-border-strong, #99a5b2);
 }
 
 .reconcile-table tr.is-matched td:first-child::before {
@@ -265,7 +240,7 @@
 }
 
 .reconcile-table tbody tr:hover td {
-  background: var(--ws-row-hover, #f1f4f7);
+  background: var(--ws-row-hover, #eaeef3);
 }
 
 .reconcile-table tr.is-selected td {
@@ -312,6 +287,8 @@
 .reconcile-table td.num {
   color: var(--ws-text, #22272e);
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
   font-size: 0.8125rem;
   text-align: right;
   white-space: nowrap;
@@ -329,15 +306,15 @@
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) max-content;
   align-items: center;
   gap: 1rem;
-  border: 1px solid #d8dde5;
-  border-radius: 7px;
-  background: #f6f8fb;
+  border: 1px solid var(--ws-border, #cbd3dc);
+  border-radius: var(--radius-card, 2px);
+  background: var(--ws-surface-subtle, #ebeff4);
   padding: 0.875rem 1rem;
 }
 
 .accounting-balance-strip span {
   display: block;
-  color: #65717f;
+  color: var(--ws-text-muted, #59636f);
   font-size: 0.6875rem;
   font-weight: 760;
   letter-spacing: 0.08em;
@@ -347,17 +324,19 @@
 .accounting-balance-strip strong {
   display: block;
   margin-top: 0.4rem;
-  color: #20242a;
+  color: var(--ws-text, #22272e);
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
   font-size: 0.95rem;
   font-weight: 640;
 }
 
 .accounting-draft-button {
   width: 100%;
-  border: 1px solid #d8dde5;
-  border-radius: 6px;
-  background: #ffffff;
+  border: 1px solid var(--ws-border, #cbd3dc);
+  border-radius: var(--radius-card, 2px);
+  background: var(--ws-surface, #ffffff);
   padding: 0.75rem;
   text-align: left;
   transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
@@ -365,18 +344,18 @@
 
 .accounting-draft-button:hover,
 .accounting-draft-button.is-active {
-  border-color: #176fa3;
-  background: #f1f7fb;
-  box-shadow: inset 3px 0 0 #176fa3;
+  border-color: var(--ws-accent, #2f6f8f);
+  background: var(--state-paper-bg, rgba(47, 111, 143, 0.1));
+  box-shadow: inset 3px 0 0 var(--ws-accent, #2f6f8f);
 }
 
 .accounting-journal-header-grid {
   display: grid;
   grid-template-columns: minmax(9rem, 0.75fr) minmax(9rem, 0.75fr) minmax(16rem, 1.6fr);
   gap: 0.75rem 1rem;
-  border: 1px solid #d8dde5;
-  border-radius: 7px;
-  background: #f6f8fb;
+  border: 1px solid var(--ws-border, #cbd3dc);
+  border-radius: var(--radius-card, 2px);
+  background: var(--ws-surface-subtle, #ebeff4);
   padding: 0.875rem 1rem;
 }
 
@@ -388,7 +367,7 @@
 }
 
 .accounting-journal-header-grid span {
-  color: #65717f;
+  color: var(--ws-text-muted, #59636f);
   font-size: 0.6875rem;
   font-weight: 760;
   letter-spacing: 0.08em;
@@ -401,10 +380,10 @@
   min-width: 0;
   min-height: 2.25rem;
   width: 100%;
-  border: 1px solid #d8dde5;
-  border-radius: 6px;
-  background: #ffffff;
-  color: #20242a;
+  border: 1px solid var(--ws-border, #cbd3dc);
+  border-radius: var(--radius-button, 2px);
+  background: var(--ws-surface, #ffffff);
+  color: var(--ws-text, #22272e);
   padding: 0 0.65rem;
   font-size: 0.875rem;
   outline: none;
@@ -413,15 +392,15 @@
 .accounting-journal-header-grid input:focus,
 .accounting-journal-table input:focus,
 .accounting-journal-table select:focus {
-  border-color: #176fa3;
-  box-shadow: 0 0 0 2px rgba(23, 111, 163, 0.16);
+  border-color: var(--ws-accent, #2f6f8f);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ws-accent, #2f6f8f) 20%, transparent);
 }
 
 .accounting-journal-table-wrap {
   overflow: auto;
-  border: 1px solid #d8dde5;
-  border-radius: 7px;
-  background: #ffffff;
+  border: 1px solid var(--ws-border, #cbd3dc);
+  border-radius: var(--radius-card, 2px);
+  background: var(--ws-surface, #ffffff);
 }
 
 .accounting-journal-table {
@@ -429,15 +408,15 @@
   min-width: 58rem;
   border-collapse: separate;
   border-spacing: 0;
-  color: #20242a;
+  color: var(--ws-text, #22272e);
   font-size: 0.875rem;
 }
 
 .accounting-journal-table th {
-  border-bottom: 1px solid #d8dde5;
-  background: #ffffff;
+  border-bottom: 1px solid var(--ws-border, #cbd3dc);
+  background: var(--ws-surface, #ffffff);
   padding: 0.7rem 0.875rem;
-  color: #65717f;
+  color: var(--ws-text-muted, #59636f);
   font-size: 0.6875rem;
   font-weight: 760;
   letter-spacing: 0.08em;
@@ -446,7 +425,7 @@
 }
 
 .accounting-journal-table td {
-  border-bottom: 1px solid #d8dde5;
+  border-bottom: 1px solid var(--ws-border, #cbd3dc);
   padding: 0.55rem 0.875rem;
   vertical-align: top;
 }
@@ -460,34 +439,36 @@
 }
 
 .accounting-journal-table tr.is-selected td {
-  background: #f1f7fb;
+  background: var(--state-paper-bg, rgba(47, 111, 143, 0.1));
 }
 
 .accounting-journal-support-button {
   display: block;
   width: 100%;
-  border: 1px solid #d8dde5;
-  border-radius: 6px;
-  background: #ffffff;
+  border: 1px solid var(--ws-border, #cbd3dc);
+  border-radius: var(--radius-button, 2px);
+  background: var(--ws-surface, #ffffff);
   padding: 0.5rem 0.65rem;
   text-align: left;
 }
 
 .accounting-journal-support-button:hover {
-  border-color: #176fa3;
-  background: #f1f7fb;
+  border-color: var(--ws-accent, #2f6f8f);
+  background: var(--state-paper-bg, rgba(47, 111, 143, 0.1));
 }
 
 .accounting-journal-total-row td {
-  border-top: 2px solid #aab5c2;
-  background: #f6f8fb;
-  color: #20242a;
+  border-top: 2px solid var(--ws-border-strong, #99a5b2);
+  background: var(--ws-surface-subtle, #ebeff4);
+  color: var(--ws-text, #22272e);
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
   font-weight: 700;
 }
 
 .accounting-journal-total-row td:first-child {
-  color: #65717f;
+  color: var(--ws-text-muted, #59636f);
   font-family: "Segoe UI Variable Text", "Segoe UI", system-ui, sans-serif;
   font-size: 0.75rem;
   letter-spacing: 0.08em;
@@ -500,9 +481,9 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  border: 1px solid #d8dde5;
-  border-radius: 7px;
-  background: #ffffff;
+  border: 1px solid var(--ws-border, #cbd3dc);
+  border-radius: var(--radius-card, 2px);
+  background: var(--ws-surface, #ffffff);
   padding: 0.75rem 1rem;
 }
 
@@ -525,6 +506,6 @@
 
   .reconcile-pane + .reconcile-pane {
     border-left: 0;
-    border-top: 1px solid var(--ws-border, #d7dce2);
+    border-top: 1px solid var(--ws-border, #cbd3dc);
   }
 }


### PR DESCRIPTION
## Summary

Wave 2 (W4) reworks the **Accounting** area screens to the Concrete design system while preserving all existing behavior, view-models, and tests.

Owned screens restyled: `accounting-screen` (+ close-cockpit panels), `operations-continuity-screen`, `evidence-workbench-screen`, and the route-owned `styles/accounting-screen.css`.

## What changed

- **`accounting-screen.css` → Concrete tokens.** Routed every hardcoded color, radius, and shadow through the shared `--ws-*` and semantic state tokens (with Concrete hex fallbacks): flat `#FFFFFF` panels on the `#DEE3EA` canvas, hairline `#CBD3DC` borders, unified 2px radii, one steel accent (`#2F6F8F`), flat elevation, mono-tabular money, and small-caps section labels. Semantic reconciliation row status bars (matched / timing / break) now derive from the `--state-*` trios.
- **Adopted the new `@/components/operations` `SeverityBadge`** for the split-pane reconciliation status chips (`matched` / `timing` / `break`). Explicit `label` props keep the visible text byte-identical, and the ready/action/blocked tones preserve the prior green/orange/red mapping.
- **Concrete mono-tabular money** (`font-mono tabular-nums`) applied to amount, balance, debit/credit, imbalance, and right-aligned count cells across the accounting, close-cockpit, operations-continuity, and evidence-workbench screens.
- Removed the now-unused `.reconcile-chip*` CSS rules superseded by `SeverityBadge`.

## Behavior preservation

Presentation-only. No view-model logic, props, aria/focus, async/cancellation, or data-flow changes. All money is rendered from the same pre-formatted view-model strings (not re-parsed), so the DOM copy the tests assert on is unchanged. The `design-system-contract.test.ts` accounting assertions (`SecuritySchedulesPanel`, `<DenseDataTable`, `<ToolbarStrip`, `<EntitySummary`, view-model copy) and the evidence-status-tone contract remain satisfied.

## Validation

- `npm ci` clean (Node 24).
- `npm run build` — exit 0.
- `tsc --noEmit` — exit 0.
- Full dashboard vitest suite: **153 files / 1712 tests passing**, including `design-system-contract.test.ts`, `accounting-screen.test.tsx`, `accounting-screen.view-model.test.ts`, `operations-continuity-screen*.test`, and `evidence-workbench-screen.view-model.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)