### PR TITLE
Web UI: freshness chips, palette action verbs, deep links + saved views (Phases 1–3)

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -4809,12 +4809,16 @@ Meridian-main
 │   │   │   │   │   │   ├── use-table-state.test.ts
 │   │   │   │   │   │   └── use-table-state.ts
 │   │   │   │   │   ├── meridian
+│   │   │   │   │   │   ├── command-palette.actions.test.ts
+│   │   │   │   │   │   ├── command-palette.actions.ts
 │   │   │   │   │   │   ├── command-palette.entity-search.test.ts
 │   │   │   │   │   │   ├── command-palette.entity-search.ts
 │   │   │   │   │   │   ├── command-palette.test.tsx
 │   │   │   │   │   │   ├── command-palette.tsx
 │   │   │   │   │   │   ├── command-palette.view-model.test.ts
 │   │   │   │   │   │   ├── command-palette.view-model.ts
+│   │   │   │   │   │   ├── copy-link-button.test.tsx
+│   │   │   │   │   │   ├── copy-link-button.tsx
 │   │   │   │   │   │   ├── coverage-passport-drill-in.test.tsx
 │   │   │   │   │   │   ├── coverage-passport-drill-in.tsx
 │   │   │   │   │   │   ├── coverage-passport-drill-in.view-model.test.ts
@@ -4847,6 +4851,7 @@ Meridian-main
 │   │   │   │   │   │   ├── reporting-hub.test.tsx
 │   │   │   │   │   │   ├── reporting-hub.tsx
 │   │   │   │   │   │   ├── reporting-period-switcher.tsx
+│   │   │   │   │   │   ├── save-view-dialog.tsx
 │   │   │   │   │   │   ├── security-details-tracker.test.tsx
 │   │   │   │   │   │   ├── security-details-tracker.tsx
 │   │   │   │   │   │   ├── security-details-tracker.view-model.test.ts
@@ -4925,6 +4930,10 @@ Meridian-main
 │   │   │   │   │       ├── file-upload.test.tsx
 │   │   │   │   │       ├── file-upload.tsx
 │   │   │   │   │       ├── form.tsx
+│   │   │   │   │       ├── freshness-chip.test.tsx
+│   │   │   │   │       ├── freshness-chip.tsx
+│   │   │   │   │       ├── freshness-chip.view-model.test.ts
+│   │   │   │   │       ├── freshness-chip.view-model.ts
 │   │   │   │   │       ├── gauge.test.tsx
 │   │   │   │   │       ├── gauge.tsx
 │   │   │   │   │       ├── input.tsx
@@ -5022,8 +5031,14 @@ Meridian-main
 │   │   │   │   │   ├── sql-workbench-storage.ts
 │   │   │   │   │   ├── theme.test.ts
 │   │   │   │   │   ├── theme.ts
+│   │   │   │   │   ├── time.test.ts
+│   │   │   │   │   ├── time.ts
 │   │   │   │   │   ├── ui-api-routes.generated.ts
 │   │   │   │   │   ├── utils.ts
+│   │   │   │   │   ├── view-state-envelope.test.ts
+│   │   │   │   │   ├── view-state-envelope.ts
+│   │   │   │   │   ├── workflow-route-match.test.ts
+│   │   │   │   │   ├── workflow-route-match.ts
 │   │   │   │   │   ├── workspace-catalog.generated.ts
 │   │   │   │   │   ├── workspace.test.ts
 │   │   │   │   │   ├── workspace.ts

--- a/docs/product/web-ui-improvements-implementation-plan-2026-07.md
+++ b/docs/product/web-ui-improvements-implementation-plan-2026-07.md
@@ -92,9 +92,13 @@ No feature work; confirm and document the rules each later phase must follow.
   into the existing `COMMAND_KIND_ORDER` flow. Items with `confirmLabel` render an inline
   confirm row (no modal) before `run()` fires; results surface via the existing `useToast` API.
 - **First providers (delegating to existing surfaces, no new business logic):**
-  - workflow preset pin / mark-used (`POST /api/workstation/workflows/presets/{id}/pin`, `/used`);
-  - reporting export run (`screens/reporting-screen.exports-runner.tsx` command path);
-  - close-calendar item creation (`OperationsContinuityCloseCalendarItems` POST).
+  - workflow preset pin / unpin (`POST /api/workstation/workflows/presets/{id}/pin`), built at shell
+    level from the preset library;
+  - reporting export run (`screens/reporting-screen.exports-runner.tsx` command path), registered by
+    the reporting screen while mounted with confirm required.
+  - *Amended at implementation:* close-calendar item creation was dropped as a palette verb — it
+    requires a six-field form, which is a navigation target rather than a verb; it remains reachable
+    through existing workflow route items.
 - **Governance rule (enforced by convention + review):** approval-gated or destructive mutations
   are never palette-registered; providers must delegate to existing view-model commands.
 - **Tests:** extend `command-palette.view-model.test.ts` (action merge, ordering, confirm flow)
@@ -102,9 +106,10 @@ No feature work; confirm and document the rules each later phase must follow.
 - **Validation:** `npm --prefix src/Meridian.Ui/dashboard run test`
 
 **Checklist**
-- [ ] `action` kind + provider registry + inline confirm.
-- [ ] Three launch providers wired to existing POST surfaces.
-- [ ] Palette keyboard tests cover the action path.
+- [x] `action` kind + provider registry + inline confirm.
+- [x] Launch providers wired to existing POST surfaces (preset pin/unpin + reporting export run;
+      close-calendar dropped as form-shaped).
+- [x] Palette keyboard tests cover the action path.
 
 ---
 

--- a/docs/product/web-ui-improvements-implementation-plan-2026-07.md
+++ b/docs/product/web-ui-improvements-implementation-plan-2026-07.md
@@ -45,7 +45,7 @@ No feature work; confirm and document the rules each later phase must follow.
   `buildMutationHeaders()` (`mdc-csrf` cookie → `X-CSRF-Token`).
 
 **Checklist**
-- [ ] Conventions above linked from the first implementation PR description.
+- [x] Conventions above linked from the first implementation PR description.
 
 ---
 
@@ -73,9 +73,9 @@ No feature work; confirm and document the rules each later phase must follow.
 - **Validation:** `npm --prefix src/Meridian.Ui/dashboard run test`
 
 **Checklist**
-- [ ] `lastSucceededAt` added to `use-request-lifecycle.ts` with tests.
-- [ ] `FreshnessChip` primitive + view-model + tests.
-- [ ] Adopted on the five surfaces above.
+- [x] `lastSucceededAt` added to `use-request-lifecycle.ts` with tests.
+- [x] `FreshnessChip` primitive + view-model + tests.
+- [x] Adopted on the five surfaces above.
 
 ---
 

--- a/docs/product/web-ui-improvements-implementation-plan-2026-07.md
+++ b/docs/product/web-ui-improvements-implementation-plan-2026-07.md
@@ -132,16 +132,19 @@ No feature work; confirm and document the rules each later phase must follow.
   `FileWorkflowPresetStore` (`{dataRoot}/workstation/workflows/workflow-presets.json`, atomic
   writes via `AtomicFileWriter`, versioned `WorkflowPresetSnapshot`) with an optional
   `viewStateEnvelope` field — no new store. Saved views then surface through the existing preset
-  items in the palette and workflow continuity dock.
+  items in the palette and workflow continuity dock. *Implementation note:* the field landed as an
+  additive nullable property on snapshot v1 (no v2 bump — additive nullable is bidirectionally
+  compatible under System.Text.Json Web defaults), capped at 4096 chars server-side.
 - **Tests:** envelope round-trip + version-tolerance unit tests; `WorkflowPresetService` payload
   extension tests in `tests/Meridian.Tests/Ui/WorkflowLibraryEndpointTests.cs` style.
 - **Validation:** `npm --prefix src/Meridian.Ui/dashboard run test` and
   `dotnet test tests/Meridian.Tests -c Release /p:EnableWindowsTargeting=true --filter FullyQualifiedName~WorkflowLibraryEndpointTests`
 
 **Checklist**
-- [ ] `view-state-envelope.ts` with round-trip tests.
-- [ ] `workspace-header.tsx` `actions` slot + Copy-link button.
-- [ ] Preset payload extension + server tests.
+- [x] `view-state-envelope.ts` with round-trip tests (table-state helpers shipped as the Phases 5–6
+      contract; no screen consumer yet since `useTableState` is currently unconsumed).
+- [x] `workspace-header.tsx` `actions` slot + Copy-link button (+ Save-view dialog).
+- [x] Preset payload extension + server tests.
 
 ---
 

--- a/docs/status/TODO.md
+++ b/docs/status/TODO.md
@@ -159,11 +159,11 @@ Total items: **208**
 | `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4955 | `NOTE` | ❌ | note: "Board package." |
 | `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4998 | `NOTE` | ❌ | note: "Board package.", |
 | `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 5151 | `NOTE` | ❌ | note: "pricing-correction" |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 2940 | `NOTE` | ❌ | note: note \|\| null |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 2951 | `NOTE` | ❌ | note: draft.deliveryNote, |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 3706 | `NOTE` | ❌ | note: "Delivered from browser Reporting workspace.", |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 3729 | `NOTE` | ❌ | note: "Published from browser Reporting workspace." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 3828 | `NOTE` | ❌ | note: `Delivery failure recorded from Reporting workspace for ${attempt.recipient}.`, |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 2943 | `NOTE` | ❌ | note: note \|\| null |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 2954 | `NOTE` | ❌ | note: draft.deliveryNote, |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 3709 | `NOTE` | ❌ | note: "Delivered from browser Reporting workspace.", |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 3732 | `NOTE` | ❌ | note: "Published from browser Reporting workspace." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 3831 | `NOTE` | ❌ | note: `Delivery failure recorded from Reporting workspace for ${attempt.recipient}.`, |
 | `src/Meridian.Ui/dashboard/src/screens/reporting-screen.view-model.test.ts` | 195 | `NOTE` | ❌ | note: "pricing-correction" |
 | `src/Meridian.Ui/dashboard/src/screens/reporting-screen.view-model.test.ts` | 528 | `NOTE` | ❌ | note: "Board package." |
 | `src/Meridian.Ui/dashboard/src/screens/reporting-screen.view-model.ts` | 384 | `NOTE` | ❌ | note: string \| null; |

--- a/docs/status/TODO.md
+++ b/docs/status/TODO.md
@@ -1,6 +1,6 @@
 # TODO / FIXME / HACK / NOTE Scan
 
-Total items: **207**
+Total items: **208**
 
 | File | Line | Tag | Linked Issue | Text |
 | --- | ---: | --- | :---: | --- |
@@ -56,9 +56,9 @@ Total items: **207**
 | `src/Meridian.Ui/dashboard/src/app-shell.view-model.test.ts` | 718 | `NOTE` | ❌ | note: "Streaming quote path is healthy." |
 | `src/Meridian.Ui/dashboard/src/app-shell.view-model.test.ts` | 793 | `NOTE` | ❌ | note: "Streaming quote path is healthy." |
 | `src/Meridian.Ui/dashboard/src/app-shell.view-model.test.ts` | 1250 | `NOTE` | ❌ | note: "Paper endpoint returned intermittent quote gaps.", |
-| `src/Meridian.Ui/dashboard/src/app.test.tsx` | 220 | `NOTE` | ❌ | note: "Paper endpoint returned intermittent quote gaps.", |
-| `src/Meridian.Ui/dashboard/src/app.test.tsx` | 378 | `NOTE` | ❌ | note: "Credential check failed" |
-| `src/Meridian.Ui/dashboard/src/app.test.tsx` | 628 | `NOTE` | ❌ | note: "Paper endpoint returned intermittent quote gaps.", |
+| `src/Meridian.Ui/dashboard/src/app.test.tsx` | 221 | `NOTE` | ❌ | note: "Paper endpoint returned intermittent quote gaps.", |
+| `src/Meridian.Ui/dashboard/src/app.test.tsx` | 379 | `NOTE` | ❌ | note: "Credential check failed" |
+| `src/Meridian.Ui/dashboard/src/app.test.tsx` | 629 | `NOTE` | ❌ | note: "Paper endpoint returned intermittent quote gaps.", |
 | `src/Meridian.Ui/dashboard/src/components/meridian/security-details-tracker.test.tsx` | 17 | `NOTE` | ❌ | note: "Opening sleeve" |
 | `src/Meridian.Ui/dashboard/src/components/meridian/security-details-tracker.tsx` | 568 | `NOTE` | ❌ | note: draftNote |
 | `src/Meridian.Ui/dashboard/src/components/meridian/security-details-tracker.tsx` | 585 | `NOTE` | ❌ | note: draftNote.trim() |
@@ -89,16 +89,17 @@ Total items: **207**
 | `src/Meridian.Ui/dashboard/src/lib/price-alerts/storage.ts` | 154 | `NOTE` | ❌ | note: asString(raw.note) ?? null |
 | `src/Meridian.Ui/dashboard/src/lib/price-alerts/types.ts` | 11 | `NOTE` | ❌ | note: string \| null; |
 | `src/Meridian.Ui/dashboard/src/lib/price-alerts/types.ts` | 30 | `NOTE` | ❌ | note: string \| null; |
+| `src/Meridian.Ui/dashboard/src/lib/view-state-envelope.test.ts` | 21 | `NOTE` | ❌ | note: "Fónd Δ — ünïcode" |
 | `src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.test.ts` | 467 | `NOTE` | ❌ | note: "Coupon posted." |
 | `src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.test.ts` | 487 | `NOTE` | ❌ | note: "Expected-versus-actual variance." |
 | `src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.test.ts` | 1970 | `NOTE` | ❌ | note: "Expected-versus-actual variance." |
 | `src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts` | 906 | `NOTE` | ❌ | note: string \| null; |
-| `src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts` | 2921 | `NOTE` | ❌ | note: "Semi-annual fixed coupon projected from the reference coupon schedule." |
-| `src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts` | 2941 | `NOTE` | ❌ | note: "Principal paydown carries a small expected-versus-actual variance for operator review." |
-| `src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts` | 2961 | `NOTE` | ❌ | note: "Final coupon and principal repayment remain pending until trustee schedule confirmation." |
-| `src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts` | 2983 | `NOTE` | ❌ | note: "Validation coupon row used by browser workbench checks." |
-| `src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts` | 3003 | `NOTE` | ❌ | note: "Validation amortization row keeps schedule selection consistent." |
-| `src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts` | 6069 | `NOTE` | ❌ | note: event.sourceReason ?? (event.isCurrentProjection ? "Current schedule projection." : null) |
+| `src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts` | 2922 | `NOTE` | ❌ | note: "Semi-annual fixed coupon projected from the reference coupon schedule." |
+| `src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts` | 2942 | `NOTE` | ❌ | note: "Principal paydown carries a small expected-versus-actual variance for operator review." |
+| `src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts` | 2962 | `NOTE` | ❌ | note: "Final coupon and principal repayment remain pending until trustee schedule confirmation." |
+| `src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts` | 2984 | `NOTE` | ❌ | note: "Validation coupon row used by browser workbench checks." |
+| `src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts` | 3004 | `NOTE` | ❌ | note: "Validation amortization row keeps schedule selection consistent." |
+| `src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts` | 6070 | `NOTE` | ❌ | note: event.sourceReason ?? (event.isCurrentProjection ? "Current schedule projection." : null) |
 | `src/Meridian.Ui/dashboard/src/screens/covered-call-screen.view-model.ts` | 287 | `NOTE` | ❌ | note: string; |
 | `src/Meridian.Ui/dashboard/src/screens/covered-call-screen.view-model.ts` | 990 | `NOTE` | ❌ | note: "Covered-call net curve requires the underlying cost basis which is not yet threaded through the API. The chart shows the short-call leg only." |
 | `src/Meridian.Ui/dashboard/src/screens/data-screen.security-master.ts` | 80 | `NOTE` | ❌ | note: string; |
@@ -114,7 +115,7 @@ Total items: **207**
 | `src/Meridian.Ui/dashboard/src/screens/data-screen.view-model.test.ts` | 1095 | `NOTE` | ❌ | note: "Backfill pressure is elevated.", |
 | `src/Meridian.Ui/dashboard/src/screens/data-screen.view-model.test.ts` | 1605 | `NOTE` | ❌ | note: "Checkpoint delay exceeded the review threshold.", |
 | `src/Meridian.Ui/dashboard/src/screens/data-screen.view-model.ts` | 263 | `NOTE` | ❌ | note: string; |
-| `src/Meridian.Ui/dashboard/src/screens/data-screen.view-model.ts` | 2364 | `NOTE` | ❌ | note: recommendedActionText ?? providerRecord?.note ?? "No operator action reported", |
+| `src/Meridian.Ui/dashboard/src/screens/data-screen.view-model.ts` | 2366 | `NOTE` | ❌ | note: recommendedActionText ?? providerRecord?.note ?? "No operator action reported", |
 | `src/Meridian.Ui/dashboard/src/screens/operations-record-release-screen.view-model.test.ts` | 123 | `NOTE` | ❌ | note: "Ready" |
 | `src/Meridian.Ui/dashboard/src/screens/operator-readiness-console.view-model.test.ts` | 187 | `NOTE` | ❌ | note: "Ready", |
 | `src/Meridian.Ui/dashboard/src/screens/price-alerts-screen.test.tsx` | 41 | `NOTE` | ❌ | note: null, |
@@ -130,39 +131,39 @@ Total items: **207**
 | `src/Meridian.Ui/dashboard/src/screens/price-alerts-screen.view-model.ts` | 511 | `NOTE` | ❌ | note: buildPriceAlertStaticFormField(PRICE_ALERT_STATIC_FIELD_CONFIG.note) |
 | `src/Meridian.Ui/dashboard/src/screens/price-alerts-screen.view-model.ts` | 529 | `NOTE` | ❌ | note: form.note.trim() \|\| null |
 | `src/Meridian.Ui/dashboard/src/screens/price-alerts-screen.view-model.ts` | 601 | `NOTE` | ❌ | note: { |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 686 | `NOTE` | ❌ | note: "Built-in template catalog" |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 694 | `NOTE` | ❌ | note: "Controller approved investor statement baseline." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 1267 | `NOTE` | ❌ | note: "Board package." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 2234 | `NOTE` | ❌ | note: "Added exposure columns." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3400 | `NOTE` | ❌ | note: "Approved custom exposure report-writer pack." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3683 | `NOTE` | ❌ | note: "Email link pack." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3764 | `NOTE` | ❌ | note: "Email link pack." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3803 | `NOTE` | ❌ | note: "Board portal pack." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3809 | `NOTE` | ❌ | note: "Email link archive." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3854 | `NOTE` | ❌ | note: "Board portal pack." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3860 | `NOTE` | ❌ | note: "Email link archive." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3896 | `NOTE` | ❌ | note: "Board package." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3902 | `NOTE` | ❌ | note: "Investor package." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3924 | `NOTE` | ❌ | note: "Board package.", |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4001 | `NOTE` | ❌ | note: "Investor package.", |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4025 | `NOTE` | ❌ | note: "Delivered after approval.", |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4270 | `NOTE` | ❌ | note: "Board portal package cleared." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4584 | `NOTE` | ❌ | note: "Board package." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4624 | `NOTE` | ❌ | note: "Board package.", |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4666 | `NOTE` | ❌ | note: "Delivered after approval.", |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4705 | `NOTE` | ❌ | note: "Delivery failure recorded from Reporting workspace for Board reporting committee.", |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4724 | `NOTE` | ❌ | note: "Delivery failure recorded from Reporting workspace for Board reporting committee.", |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4772 | `NOTE` | ❌ | note: "Board package." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4794 | `NOTE` | ❌ | note: "Board package.", |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4840 | `NOTE` | ❌ | note: "Board package.", |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4896 | `NOTE` | ❌ | note: "Board package." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4939 | `NOTE` | ❌ | note: "Board package.", |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 5092 | `NOTE` | ❌ | note: "pricing-correction" |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 2830 | `NOTE` | ❌ | note: note \|\| null |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 2841 | `NOTE` | ❌ | note: draft.deliveryNote, |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 3596 | `NOTE` | ❌ | note: "Delivered from browser Reporting workspace.", |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 3619 | `NOTE` | ❌ | note: "Published from browser Reporting workspace." |
-| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 3718 | `NOTE` | ❌ | note: `Delivery failure recorded from Reporting workspace for ${attempt.recipient}.`, |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 688 | `NOTE` | ❌ | note: "Built-in template catalog" |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 696 | `NOTE` | ❌ | note: "Controller approved investor statement baseline." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 1269 | `NOTE` | ❌ | note: "Board package." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 2293 | `NOTE` | ❌ | note: "Added exposure columns." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3459 | `NOTE` | ❌ | note: "Approved custom exposure report-writer pack." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3742 | `NOTE` | ❌ | note: "Email link pack." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3823 | `NOTE` | ❌ | note: "Email link pack." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3862 | `NOTE` | ❌ | note: "Board portal pack." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3868 | `NOTE` | ❌ | note: "Email link archive." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3913 | `NOTE` | ❌ | note: "Board portal pack." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3919 | `NOTE` | ❌ | note: "Email link archive." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3955 | `NOTE` | ❌ | note: "Board package." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3961 | `NOTE` | ❌ | note: "Investor package." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 3983 | `NOTE` | ❌ | note: "Board package.", |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4060 | `NOTE` | ❌ | note: "Investor package.", |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4084 | `NOTE` | ❌ | note: "Delivered after approval.", |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4329 | `NOTE` | ❌ | note: "Board portal package cleared." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4643 | `NOTE` | ❌ | note: "Board package." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4683 | `NOTE` | ❌ | note: "Board package.", |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4725 | `NOTE` | ❌ | note: "Delivered after approval.", |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4764 | `NOTE` | ❌ | note: "Delivery failure recorded from Reporting workspace for Board reporting committee.", |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4783 | `NOTE` | ❌ | note: "Delivery failure recorded from Reporting workspace for Board reporting committee.", |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4831 | `NOTE` | ❌ | note: "Board package." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4853 | `NOTE` | ❌ | note: "Board package.", |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4899 | `NOTE` | ❌ | note: "Board package.", |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4955 | `NOTE` | ❌ | note: "Board package." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 4998 | `NOTE` | ❌ | note: "Board package.", |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx` | 5151 | `NOTE` | ❌ | note: "pricing-correction" |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 2940 | `NOTE` | ❌ | note: note \|\| null |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 2951 | `NOTE` | ❌ | note: draft.deliveryNote, |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 3706 | `NOTE` | ❌ | note: "Delivered from browser Reporting workspace.", |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 3729 | `NOTE` | ❌ | note: "Published from browser Reporting workspace." |
+| `src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx` | 3828 | `NOTE` | ❌ | note: `Delivery failure recorded from Reporting workspace for ${attempt.recipient}.`, |
 | `src/Meridian.Ui/dashboard/src/screens/reporting-screen.view-model.test.ts` | 195 | `NOTE` | ❌ | note: "pricing-correction" |
 | `src/Meridian.Ui/dashboard/src/screens/reporting-screen.view-model.test.ts` | 528 | `NOTE` | ❌ | note: "Board package." |
 | `src/Meridian.Ui/dashboard/src/screens/reporting-screen.view-model.ts` | 384 | `NOTE` | ❌ | note: string \| null; |
@@ -180,11 +181,11 @@ Total items: **207**
 | `src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx` | 1640 | `NOTE` | ❌ | note: providerRuntimeQuarantineActionNote(action) |
 | `src/Meridian.Ui/dashboard/src/screens/w4-acceptance-parity.test.ts` | 429 | `NOTE` | ❌ | note: "Close evidence reviewed." |
 | `src/Meridian.Ui/dashboard/src/screens/w4-acceptance-parity.test.ts` | 437 | `NOTE` | ❌ | note: "Published to investor portal." |
-| `src/Meridian.Ui/dashboard/src/types.ts` | 3924 | `NOTE` | ❌ | note: string; |
-| `src/Meridian.Ui/dashboard/src/types.ts` | 5065 | `NOTE` | ❌ | note: string \| null; |
-| `src/Meridian.Ui/dashboard/src/types.ts` | 5418 | `NOTE` | ❌ | note: string \| null; |
-| `src/Meridian.Ui/dashboard/src/types.ts` | 5467 | `NOTE` | ❌ | note: string \| null; |
-| `src/Meridian.Ui/dashboard/src/types.ts` | 5664 | `NOTE` | ❌ | note: string \| null; |
+| `src/Meridian.Ui/dashboard/src/types.ts` | 3926 | `NOTE` | ❌ | note: string; |
+| `src/Meridian.Ui/dashboard/src/types.ts` | 5067 | `NOTE` | ❌ | note: string \| null; |
+| `src/Meridian.Ui/dashboard/src/types.ts` | 5420 | `NOTE` | ❌ | note: string \| null; |
+| `src/Meridian.Ui/dashboard/src/types.ts` | 5469 | `NOTE` | ❌ | note: string \| null; |
+| `src/Meridian.Ui/dashboard/src/types.ts` | 5666 | `NOTE` | ❌ | note: string \| null; |
 | `src/Meridian.Wpf/GlobalUsings.cs` | 7 | `NOTE` | ❌ | // NOTE: Type aliases and Contracts namespaces are NOT re-defined here because |
 | `src/Meridian.Wpf/ViewModels/SecurityPassportEditorViewModel.cs` | 262 | `NOTE` | ❌ | Note: null, |
 | `tests/Meridian.Tests/Application/Backfill/BackfillWorkerServiceTests.cs` | 28 | `NOTE` | ❌ | // NOTE: Using null! because validation throws before dependencies are accessed |

--- a/docs/status/api-contract-coverage-dashboard.json
+++ b/docs/status/api-contract-coverage-dashboard.json
@@ -7106,17 +7106,17 @@
     },
     {
       "name": "WorkflowPresetLibraryDto",
-      "source": "src/Meridian.Contracts/Workstation/WorkflowLibraryDtos.cs:63",
+      "source": "src/Meridian.Contracts/Workstation/WorkflowLibraryDtos.cs:64",
       "documented": true
     },
     {
       "name": "WorkflowPresetSaveRequest",
-      "source": "src/Meridian.Contracts/Workstation/WorkflowLibraryDtos.cs:70",
+      "source": "src/Meridian.Contracts/Workstation/WorkflowLibraryDtos.cs:71",
       "documented": true
     },
     {
       "name": "WorkflowPresetPinRequest",
-      "source": "src/Meridian.Contracts/Workstation/WorkflowLibraryDtos.cs:82",
+      "source": "src/Meridian.Contracts/Workstation/WorkflowLibraryDtos.cs:84",
       "documented": true
     },
     {

--- a/docs/status/api-contract-coverage-dashboard.md
+++ b/docs/status/api-contract-coverage-dashboard.md
@@ -1328,9 +1328,9 @@ Tracks whether mapped API routes and workstation DTO contracts are visible in th
 | `WorkflowLibraryDto` | Documented | `src/Meridian.Contracts/Workstation/WorkflowLibraryDtos.cs:6` |
 | `WorkflowNextAction` | Documented | `src/Meridian.Contracts/Workstation/WorkflowSummaryDtos.cs:33` |
 | `WorkflowPresetDto` | Documented | `src/Meridian.Contracts/Workstation/WorkflowLibraryDtos.cs:43` |
-| `WorkflowPresetLibraryDto` | Documented | `src/Meridian.Contracts/Workstation/WorkflowLibraryDtos.cs:63` |
-| `WorkflowPresetPinRequest` | Documented | `src/Meridian.Contracts/Workstation/WorkflowLibraryDtos.cs:82` |
-| `WorkflowPresetSaveRequest` | Documented | `src/Meridian.Contracts/Workstation/WorkflowLibraryDtos.cs:70` |
+| `WorkflowPresetLibraryDto` | Documented | `src/Meridian.Contracts/Workstation/WorkflowLibraryDtos.cs:64` |
+| `WorkflowPresetPinRequest` | Documented | `src/Meridian.Contracts/Workstation/WorkflowLibraryDtos.cs:84` |
+| `WorkflowPresetSaveRequest` | Documented | `src/Meridian.Contracts/Workstation/WorkflowLibraryDtos.cs:71` |
 | `WorkspaceWorkflowSummary` | Documented | `src/Meridian.Contracts/Workstation/WorkflowSummaryDtos.cs:20` |
 | `WorkstationAccountingAgingBucketPayload` | Documented | `src/Meridian.Contracts/Workstation/WorkstationBootstrapDtos.cs:739` |
 | `WorkstationAccountingAlertPayload` | Documented | `src/Meridian.Contracts/Workstation/WorkstationBootstrapDtos.cs:756` |

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 538,
-  "total_lines": 88434,
+  "total_lines": 88457,
   "orphaned_count": 205,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2138,7 +2138,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7748,
+      "line_count": 7763,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -3106,7 +3106,7 @@
     },
     {
       "path": "docs/product/web-ui-improvements-implementation-plan-2026-07.md",
-      "line_count": 277,
+      "line_count": 285,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 538 |
-| Total lines | 88,434 |
+| Total lines | 88,457 |
 | Average file size (lines) | 164.4 |
 | Orphaned files | 205 |
 | Files without headings | 38 |

--- a/src/Meridian.Contracts/Workstation/WorkflowLibraryDtos.cs
+++ b/src/Meridian.Contracts/Workstation/WorkflowLibraryDtos.cs
@@ -55,7 +55,8 @@ public sealed record WorkflowPresetDto(
     bool IsPinned,
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt,
-    DateTimeOffset? LastUsedAt);
+    DateTimeOffset? LastUsedAt,
+    string? ViewStateEnvelope = null);
 
 /// <summary>
 /// Shared preset catalog projection for the workstation workflow library.
@@ -74,7 +75,8 @@ public sealed record WorkflowPresetSaveRequest(
     string WorkflowId,
     string? ActionId,
     IReadOnlyList<string>? Tags,
-    bool IsPinned);
+    bool IsPinned,
+    string? ViewStateEnvelope = null);
 
 /// <summary>
 /// Request to update a workflow preset's pinned state.

--- a/src/Meridian.Ui.Shared/Workflows/FileWorkflowPresetStore.cs
+++ b/src/Meridian.Ui.Shared/Workflows/FileWorkflowPresetStore.cs
@@ -11,6 +11,10 @@ namespace Meridian.Ui.Shared.Workflows;
 /// </summary>
 public sealed class FileWorkflowPresetStore : IWorkflowPresetStore
 {
+    // Additive nullable DTO properties (e.g. ViewStateEnvelope) stay on version 1: older
+    // snapshots deserialize them as null and older binaries ignore them. Bump the version
+    // only for breaking shape changes, and add a v(n-1)->v(n) migration in LoadAsync
+    // instead of relying on the unsupported-version throw below.
     private const int SnapshotVersion = 1;
 
     private readonly string _snapshotPath;

--- a/src/Meridian.Ui.Shared/Workflows/WorkflowPresetService.cs
+++ b/src/Meridian.Ui.Shared/Workflows/WorkflowPresetService.cs
@@ -12,6 +12,7 @@ public sealed class WorkflowPresetService
     private const int MaxNameLength = 120;
     private const int MaxDescriptionLength = 1024;
     private const int MaxTagLength = 64;
+    private const int MaxViewStateEnvelopeLength = 4096;
 
     private readonly IWorkflowActionCatalog _catalog;
     private readonly IWorkflowPresetStore _store;
@@ -190,6 +191,11 @@ public sealed class WorkflowPresetService
             return $"Preset tags cannot exceed {MaxTagLength} characters.";
         }
 
+        if (!string.IsNullOrWhiteSpace(request.ViewStateEnvelope) && request.ViewStateEnvelope.Trim().Length > MaxViewStateEnvelopeLength)
+        {
+            return $"Preset view state cannot exceed {MaxViewStateEnvelopeLength} characters.";
+        }
+
         var workflow = FindWorkflow(request.WorkflowId);
         if (workflow is null)
         {
@@ -229,7 +235,8 @@ public sealed class WorkflowPresetService
             IsPinned: request.IsPinned,
             CreatedAt: existing?.CreatedAt ?? now,
             UpdatedAt: now,
-            LastUsedAt: existing?.LastUsedAt);
+            LastUsedAt: existing?.LastUsedAt,
+            ViewStateEnvelope: NormalizeOptional(request.ViewStateEnvelope));
     }
 
     private WorkflowDefinitionDto? FindWorkflow(string workflowId)

--- a/src/Meridian.Ui/dashboard/src/app.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.test.tsx
@@ -38,6 +38,7 @@ function idleRequestStatus(operation: string) {
     error: null,
     startedAt: null,
     settledAt: null,
+    lastSucceededAt: null,
     staleDiscardCount: 0,
     backoff: { attempt: 0, retryCount: 0, nextRetryDelayMs: null, maxRetries: 0 }
   };

--- a/src/Meridian.Ui/dashboard/src/app.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.tsx
@@ -48,6 +48,8 @@ import {
   useCommandPaletteActions,
   type CommandPaletteActionItem
 } from "@/components/meridian/command-palette.actions";
+import { CopyLinkButton } from "@/components/meridian/copy-link-button";
+import { SaveViewButton } from "@/components/meridian/save-view-dialog";
 import { PriceAlertsProvider, usePriceAlerts } from "@/lib/price-alerts/service";
 import { cn } from "@/lib/utils";
 import { legacyWorkspaceRedirect, workspacePath } from "@/lib/workspace";
@@ -422,6 +424,16 @@ function AppShell() {
           tabIndex={-1}
         >
           <WorkspaceHeader
+            actions={(
+              <>
+                <CopyLinkButton />
+                <SaveViewButton
+                  workflowLibrary={workflowLibrary}
+                  workflowError={workflowError}
+                  onPresetSaved={upsertWorkflowPreset}
+                />
+              </>
+            )}
             breadcrumbItems={breadcrumbItems}
             workspace={headerWorkspace}
             session={session}

--- a/src/Meridian.Ui/dashboard/src/app.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.tsx
@@ -43,7 +43,11 @@ import {
 import { StatusBanner } from "@/components/ui/status-banner";
 import { ToastProvider } from "@/components/ui/toast";
 import { useWorkstationData } from "@/hooks/use-workstation-data";
-import { markWorkflowPresetUsed } from "@/lib/api";
+import { markWorkflowPresetUsed, pinWorkflowPreset } from "@/lib/api";
+import {
+  useCommandPaletteActions,
+  type CommandPaletteActionItem
+} from "@/components/meridian/command-palette.actions";
 import { PriceAlertsProvider, usePriceAlerts } from "@/lib/price-alerts/service";
 import { cn } from "@/lib/utils";
 import { legacyWorkspaceRedirect, workspacePath } from "@/lib/workspace";
@@ -163,6 +167,30 @@ function AppShell() {
     markWorkflowPresetUsed(presetId).then((preset) => {
       upsertWorkflowPreset(preset);
     });
+
+  const screenActionItems = useCommandPaletteActions();
+  const presetPinActionItems = useMemo<CommandPaletteActionItem[]>(
+    () => (workflowPresets?.presets ?? []).map((preset) => ({
+      id: `preset-pin:${preset.presetId}`,
+      verbLabel: preset.isPinned ? `Unpin preset ${preset.name}` : `Pin preset ${preset.name}`,
+      description: preset.isPinned
+        ? `Remove ${preset.name} from the pinned presets shown first in the palette.`
+        : `Keep ${preset.name} at the top of the palette preset list.`,
+      keywords: ["preset", "pin", preset.workflowTitle],
+      run: () => pinWorkflowPreset(preset.presetId, !preset.isPinned).then((updated) => {
+        upsertWorkflowPreset(updated);
+        return {
+          title: updated.isPinned ? `Pinned ${updated.name}.` : `Unpinned ${updated.name}.`,
+          tone: "success" as const
+        };
+      })
+    })),
+    [upsertWorkflowPreset, workflowPresets]
+  );
+  const paletteActionItems = useMemo(
+    () => [...presetPinActionItems, ...screenActionItems],
+    [presetPinActionItems, screenActionItems]
+  );
 
   useEffect(() => {
     if (suppressScopePersistRef.current) {
@@ -547,6 +575,7 @@ function AppShell() {
         workflowPresets={workflowPresets}
         workflowError={workflowError}
         operatorFocusItems={shell.workflowContinuity.operatorFocusCommandItems}
+        actionItems={paletteActionItems}
         operatingContextSymbol={operatingContextSymbol}
         operatingScope={operatingScopeInput}
         onPresetUsed={handleWorkflowPresetUsed}

--- a/src/Meridian.Ui/dashboard/src/app.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.tsx
@@ -146,6 +146,7 @@ function AppShell() {
     error,
     workspaceErrors,
     refreshStatus,
+    portfolioRefreshStatus,
     refresh,
     refreshPortfolio,
     refreshProviderRouting,
@@ -437,6 +438,7 @@ function AppShell() {
                       brokerageConnection={brokerageConnection}
                       brokeragePortfolio={brokeragePortfolio}
                       multiAssetCoverage={portfolioMultiAssetCoverage}
+                      refreshStatus={portfolioRefreshStatus}
                     />
                   )} />
                   <Route path="/accounting/operations-continuity" element={<OperationsContinuityScreen />} />

--- a/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.actions.test.ts
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.actions.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  getCommandPaletteActionsSnapshot,
+  registerCommandPaletteActions,
+  type CommandPaletteActionItem
+} from "@/components/meridian/command-palette.actions";
+
+function action(id: string): CommandPaletteActionItem {
+  return {
+    id,
+    verbLabel: `Run ${id}`,
+    description: `Test action ${id}`,
+    run: async () => undefined
+  };
+}
+
+describe("command palette action registry", () => {
+  it("registers, replaces, and unregisters actions per source", () => {
+    const first = [action("one")];
+    const unregisterA = registerCommandPaletteActions("test:source-a", first);
+    const unregisterB = registerCommandPaletteActions("test:source-b", [action("two")]);
+
+    expect(getCommandPaletteActionsSnapshot().map((item) => item.id)).toEqual(["one", "two"]);
+
+    const replacement = [action("one-replaced")];
+    const unregisterA2 = registerCommandPaletteActions("test:source-a", replacement);
+    expect(getCommandPaletteActionsSnapshot().map((item) => item.id)).toEqual(["one-replaced", "two"]);
+
+    unregisterA();
+    expect(getCommandPaletteActionsSnapshot().map((item) => item.id)).toEqual(
+      ["one-replaced", "two"]
+    );
+
+    unregisterA2();
+    unregisterB();
+    expect(getCommandPaletteActionsSnapshot()).toEqual([]);
+  });
+
+  it("returns a stable snapshot between registrations", () => {
+    const unregister = registerCommandPaletteActions("test:stable", [action("stable")]);
+    const first = getCommandPaletteActionsSnapshot();
+    const second = getCommandPaletteActionsSnapshot();
+    expect(second).toBe(first);
+    unregister();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.actions.ts
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.actions.ts
@@ -1,0 +1,71 @@
+// Command palette action registry. Screens register context-scoped verbs while
+// mounted (and unregister on unmount); the app shell composes these with its own
+// shell-level actions and feeds one array into the palette view model.
+//
+// Governance: approval-gated or destructive mutations are never registered here.
+// A `run` handler must delegate to an existing screen command or lib/api wrapper —
+// the palette is a dispatch surface, not a home for business logic.
+import { useSyncExternalStore } from "react";
+
+export interface CommandPaletteActionResult {
+  title: string;
+  detail?: string;
+  tone?: "success" | "warning" | "danger" | "info";
+}
+
+export interface CommandPaletteActionItem {
+  id: string;
+  /** Imperative label, e.g. "Pin preset Morning close". */
+  verbLabel: string;
+  description: string;
+  keywords?: string[];
+  /** Require the inline two-step arm/confirm flow before running. */
+  confirm?: boolean;
+  disabled?: boolean;
+  disabledReason?: string | null;
+  run: () => Promise<CommandPaletteActionResult | void>;
+}
+
+type Listener = () => void;
+
+const actionSources = new Map<string, CommandPaletteActionItem[]>();
+const listeners = new Set<Listener>();
+let snapshot: CommandPaletteActionItem[] = [];
+
+function rebuildSnapshot() {
+  snapshot = [...actionSources.values()].flat();
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/**
+ * Registers a source's action items, replacing any prior registration under the
+ * same sourceId. Returns an unregister callback for effect cleanup.
+ */
+export function registerCommandPaletteActions(
+  sourceId: string,
+  items: CommandPaletteActionItem[]
+): () => void {
+  actionSources.set(sourceId, items);
+  rebuildSnapshot();
+  return () => {
+    if (actionSources.get(sourceId) === items) {
+      actionSources.delete(sourceId);
+      rebuildSnapshot();
+    }
+  };
+}
+
+export function getCommandPaletteActionsSnapshot(): CommandPaletteActionItem[] {
+  return snapshot;
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function useCommandPaletteActions(): CommandPaletteActionItem[] {
+  return useSyncExternalStore(subscribe, getCommandPaletteActionsSnapshot, getCommandPaletteActionsSnapshot);
+}

--- a/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 import { axe } from "jest-axe";
 import { CommandPalette } from "@/components/meridian/command-palette";
+import { ToastProvider } from "@/components/ui/toast";
 import { renderWithRouter } from "@/test/render";
 import type { WorkflowLibrary, WorkflowPresetLibrary } from "@/types";
 import type { CommandPaletteEntitySearchServices } from "@/components/meridian/command-palette.entity-search";
@@ -381,5 +382,102 @@ describe("CommandPalette", () => {
 
     expect(onPresetUsed).toHaveBeenCalledWith("preset-1");
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("runs a non-confirm action immediately and reports the result as a toast", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const run = vi.fn().mockResolvedValue({ title: "Pinned Morning close.", tone: "success" as const });
+
+    renderWithRouter(
+      <ToastProvider>
+        <CommandPalette
+          open
+          onOpenChange={onOpenChange}
+          actionItems={[
+            {
+              id: "preset-pin:morning",
+              verbLabel: "Pin preset Morning close",
+              description: "Keep Morning close at the top of the palette preset list.",
+              run
+            }
+          ]}
+        />
+      </ToastProvider>,
+      { initialEntries: ["/trading"] }
+    );
+
+    await user.click(screen.getByRole("button", { name: /Pin preset Morning close/ }));
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(await screen.findByText("Pinned Morning close.")).toBeInTheDocument();
+  });
+
+  it("requires a second activation for confirm actions and disarms on Escape without closing", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const run = vi.fn().mockResolvedValue(undefined);
+
+    renderWithRouter(
+      <ToastProvider>
+        <CommandPalette
+          open
+          onOpenChange={onOpenChange}
+          actionItems={[
+            {
+              id: "reporting-run-exports",
+              verbLabel: "Run exports report: Monthly NAV pack",
+              description: "Start the selected on-demand exports report run.",
+              confirm: true,
+              run
+            }
+          ]}
+        />
+      </ToastProvider>,
+      { initialEntries: ["/reporting"] }
+    );
+
+    const actionButton = screen.getByRole("button", { name: /Run exports report/ });
+    await user.click(actionButton);
+
+    expect(run).not.toHaveBeenCalled();
+    expect(screen.getByText(/Press Enter again to confirm/)).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    expect(screen.queryByText(/Press Enter again to confirm/)).not.toBeInTheDocument();
+
+    await user.click(actionButton);
+    await user.click(actionButton);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("surfaces action failures as danger toasts", async () => {
+    const user = userEvent.setup();
+    const run = vi.fn().mockRejectedValue(new Error("preset service offline"));
+
+    renderWithRouter(
+      <ToastProvider>
+        <CommandPalette
+          open
+          onOpenChange={vi.fn()}
+          actionItems={[
+            {
+              id: "preset-pin:morning",
+              verbLabel: "Pin preset Morning close",
+              description: "Keep Morning close at the top of the palette preset list.",
+              run
+            }
+          ]}
+        />
+      </ToastProvider>,
+      { initialEntries: ["/trading"] }
+    );
+
+    await user.click(screen.getByRole("button", { name: /Pin preset Morning close/ }));
+
+    expect(await screen.findByText("preset service offline")).toBeInTheDocument();
   });
 });

--- a/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.tsx
@@ -2,17 +2,24 @@ import { useEffect, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/toast";
 import { useCommandPaletteEntitySearch } from "@/components/meridian/command-palette.entity-search";
 import type { CommandPaletteEntitySearchServices } from "@/components/meridian/command-palette.entity-search";
+import type {
+  CommandPaletteActionItem,
+  CommandPaletteActionResult
+} from "@/components/meridian/command-palette.actions";
 import {
   buildCommandPaletteViewModel,
   resolveCommandPaletteKeyCommand,
   type CommandPaletteFocusAction,
   type CommandPaletteFocusBoundary,
-  type CommandPaletteFocusTarget
+  type CommandPaletteFocusTarget,
+  type CommandPaletteItem
 } from "@/components/meridian/command-palette.view-model";
 import { COMMAND_PALETTE_DIALOG_ID } from "@/app-shell.view-model";
 import type { AppShellOperatingScopeInput } from "@/app-shell.operating-scope";
+import { describeApiError } from "@/lib/api-errors";
 import { cn } from "@/lib/utils";
 import type { WorkflowLibrary, WorkflowPresetLibrary } from "@/types";
 
@@ -42,6 +49,7 @@ interface CommandPaletteProps {
   workflowPresets?: WorkflowPresetLibrary | null;
   workflowError?: string | null;
   operatorFocusItems?: CommandPaletteFocusAction[] | null;
+  actionItems?: CommandPaletteActionItem[] | null;
   operatingContextSymbol?: string | null;
   operatingScope?: AppShellOperatingScopeInput | null;
   onPresetUsed?: (presetId: string) => void | Promise<void>;
@@ -55,6 +63,7 @@ export function CommandPalette({
   workflowPresets,
   workflowError,
   operatorFocusItems,
+  actionItems,
   operatingContextSymbol,
   operatingScope,
   onPresetUsed,
@@ -62,15 +71,20 @@ export function CommandPalette({
 }: CommandPaletteProps) {
   const { pathname, search, hash } = useLocation();
   const [query, setQuery] = useState("");
+  const [armedActionId, setArmedActionId] = useState<string | null>(null);
+  const armedActionIdRef = useRef<string | null>(null);
+  armedActionIdRef.current = armedActionId;
   const dialogRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const initialCommandRef = useRef<HTMLAnchorElement | null>(null);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
+  const toast = useToast();
   const entitySearch = useCommandPaletteEntitySearch({ open, query, services: entitySearchServices });
 
   useEffect(() => {
     if (!open) {
       setQuery("");
+      setArmedActionId(null);
     }
   }, [open]);
 
@@ -87,8 +101,15 @@ export function CommandPalette({
         key: event.key,
         shiftKey: event.shiftKey,
         focusBoundary: getCommandPaletteFocusBoundary(dialogRef.current, document.activeElement),
-        focusTarget: getCommandPaletteFocusTarget(searchInputRef.current, document.activeElement)
+        focusTarget: getCommandPaletteFocusTarget(searchInputRef.current, document.activeElement),
+        actionArmed: armedActionIdRef.current !== null
       });
+
+      if (command === "disarm-action") {
+        event.preventDefault();
+        setArmedActionId(null);
+        return;
+      }
 
       if (command === "close") {
         event.preventDefault();
@@ -121,7 +142,42 @@ export function CommandPalette({
   const closePalette = () => {
     onOpenChange(false);
     setQuery("");
+    setArmedActionId(null);
     restoreFocusRef.current?.focus();
+  };
+
+  const runActionItem = (item: CommandPaletteItem) => {
+    const meta = item.action;
+    if (!meta) {
+      return;
+    }
+
+    const handler = (actionItems ?? []).find((candidate) => candidate.id === meta.actionId);
+    if (!handler || handler.disabled) {
+      return;
+    }
+
+    if (meta.confirm && armedActionId !== item.id) {
+      setArmedActionId(item.id);
+      return;
+    }
+
+    setArmedActionId(null);
+    closePalette();
+    void handler
+      .run()
+      .then((result) => {
+        const outcome = (result ?? undefined) as CommandPaletteActionResult | undefined;
+        toast.show({
+          title: outcome?.title ?? `${handler.verbLabel} complete.`,
+          detail: outcome?.detail,
+          tone: outcome?.tone ?? "success"
+        });
+      })
+      .catch((error) => {
+        const display = describeApiError(error, `${handler.verbLabel} failed.`);
+        toast.danger(display.summary, display.details.join(" ") || undefined);
+      });
   };
 
   if (!open) {
@@ -137,6 +193,7 @@ export function CommandPalette({
       workflowPresets,
       workflowError,
       operatorFocusItems,
+      actionItems,
       entityItems: entitySearch.items,
       entitySearchStatus: entitySearch.status,
       entitySearchError: entitySearch.error
@@ -312,7 +369,54 @@ export function CommandPalette({
                 <span className="font-mono text-[10px] text-muted-foreground">{group.countLabel}</span>
               </div>
               <div className="grid gap-1">
-                {group.items.map((item) => (
+                {group.items.map((item) => item.action ? (
+                  <button
+                    key={item.id}
+                    type="button"
+                    data-command-id={item.id}
+                    data-command-list-item="true"
+                    disabled={item.statusTone === "blocked"}
+                    aria-label={item.ariaLabel}
+                    className={cn(
+                      "command-palette-command rounded-md border px-3 py-2.5 text-left text-sm transition-colors",
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+                      "disabled:cursor-not-allowed disabled:opacity-60",
+                      armedActionId === item.id
+                        ? "border-warning/50 bg-warning/10 text-foreground"
+                        : "border-transparent hover:border-border/70 hover:bg-secondary/70"
+                    )}
+                    onClick={() => runActionItem(item)}
+                    onBlur={() => {
+                      if (armedActionId === item.id) {
+                        setArmedActionId(null);
+                      }
+                    }}
+                  >
+                    <span className="flex items-start justify-between gap-3">
+                      <span className="min-w-0">
+                        <span aria-live="polite" className="block font-semibold leading-snug">
+                          {armedActionId === item.id
+                            ? `Press Enter again to confirm — ${item.commandLabel}`
+                            : item.commandLabel}
+                        </span>
+                        <span className="mt-0.5 block text-xs text-muted-foreground">{item.description}</span>
+                      </span>
+                      <span className="flex shrink-0 flex-col items-end gap-1.5">
+                        <span className="command-palette-route">{item.routeLabel}</span>
+                        {item.statusVisible && (
+                          <span
+                            className={cn(
+                              "command-palette-status",
+                              `command-palette-status-${item.statusTone}`
+                            )}
+                          >
+                            {item.statusLabel}
+                          </span>
+                        )}
+                      </span>
+                    </span>
+                  </button>
+                ) : (
                   <Link
                     key={item.id}
                     ref={item.id === viewModel.initialFocusItemId ? initialCommandRef : undefined}
@@ -387,12 +491,12 @@ function getCommandPaletteFocusableElements(dialog: HTMLDivElement | null): HTML
   );
 }
 
-function getCommandPaletteCommandElements(dialog: HTMLDivElement | null): HTMLAnchorElement[] {
+function getCommandPaletteCommandElements(dialog: HTMLDivElement | null): HTMLElement[] {
   if (!dialog) {
     return [];
   }
 
-  return Array.from(dialog.querySelectorAll<HTMLAnchorElement>("[data-command-list-item='true']"));
+  return Array.from(dialog.querySelectorAll<HTMLElement>("[data-command-list-item='true']"));
 }
 
 function getCommandPaletteFocusTarget(

--- a/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.view-model.test.ts
@@ -1063,8 +1063,68 @@ describe("command palette view model", () => {
     );
   });
 
+  it("builds runnable action items ordered after focus actions", () => {
+    const model = buildCommandPaletteViewModel("/reporting", undefined, {
+      actionItems: [
+        {
+          id: "reporting-run-exports",
+          verbLabel: "Run exports report: Monthly NAV pack",
+          description: "Start the selected on-demand exports report run.",
+          keywords: ["report", "run"],
+          confirm: true,
+          run: async () => undefined
+        },
+        {
+          id: "preset-pin:morning",
+          verbLabel: "Pin preset Morning close",
+          description: "Keep Morning close at the top of the palette preset list.",
+          disabled: true,
+          disabledReason: "Preset library unavailable.",
+          run: async () => undefined
+        }
+      ]
+    });
+
+    const actionItems = model.items.filter((item) => item.kind === "action");
+    expect(actionItems.map((item) => item.id)).toEqual([
+      "action:reporting-run-exports",
+      "action:preset-pin:morning"
+    ]);
+    expect(actionItems[0]).toMatchObject({
+      commandLabel: "Run exports report: Monthly NAV pack",
+      statusLabel: "Confirm to run",
+      statusTone: "ready",
+      action: { actionId: "reporting-run-exports", confirm: true }
+    });
+    expect(actionItems[1]).toMatchObject({
+      statusLabel: "Preset library unavailable.",
+      statusTone: "blocked",
+      action: { actionId: "preset-pin:morning", confirm: false }
+    });
+
+    const groupKinds = model.commandGroups.map((group) => group.kind);
+    expect(groupKinds.indexOf("action")).toBeLessThan(groupKinds.indexOf("workspace"));
+    expect(model.itemCountLabel).toContain("2 actions");
+
+    const filtered = buildCommandPaletteViewModel("/reporting", undefined, {
+      actionItems: [
+        {
+          id: "reporting-run-exports",
+          verbLabel: "Run exports report: Monthly NAV pack",
+          description: "Start the selected on-demand exports report run.",
+          keywords: ["report", "run"],
+          run: async () => undefined
+        }
+      ]
+    }, "run exports");
+    expect(filtered.filteredItems.some((item) => item.id === "action:reporting-run-exports")).toBe(true);
+  });
+
   it("keeps command palette keyboard commands in the view model", () => {
     expect(resolveCommandPaletteKeyCommand({ key: "Escape", focusBoundary: "middle" })).toBe("close");
+    expect(resolveCommandPaletteKeyCommand({ key: "Escape", focusBoundary: "middle", actionArmed: true })).toBe(
+      "disarm-action"
+    );
     expect(resolveCommandPaletteKeyCommand({ key: "Tab", focusBoundary: "last" })).toBe("focus-first");
     expect(resolveCommandPaletteKeyCommand({ key: "Tab", shiftKey: true, focusBoundary: "first" })).toBe("focus-last");
     expect(resolveCommandPaletteKeyCommand({ key: "Tab", focusBoundary: "outside" })).toBe("focus-first");

--- a/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.view-model.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { encodeViewStateEnvelope } from "@/lib/view-state-envelope";
 import {
   buildCommandPaletteViewModel,
   resolveCommandPaletteKeyCommand
@@ -1118,6 +1119,64 @@ describe("command palette view model", () => {
       ]
     }, "run exports");
     expect(filtered.filteredItems.some((item) => item.id === "action:reporting-run-exports")).toBe(true);
+  });
+
+  it("appends a saved view's state token to the preset route", () => {
+    const viewStateEnvelope = encodeViewStateEnvelope({
+      v: 1,
+      screen: "reporting-exports",
+      state: { selectedExportsTemplateId: "investor-monthly-statement" }
+    })!;
+
+    const model = buildCommandPaletteViewModel("/trading", undefined, {
+      workflowPresets: {
+        generatedAt: "2026-07-01T00:00:00Z",
+        presets: [
+          {
+            presetId: "saved-view-1",
+            name: "Month-end exports",
+            description: "Saved exports view",
+            workflowId: "reporting-delivery",
+            workflowTitle: "Reporting Delivery",
+            actionId: "reporting.exports",
+            actionLabel: "Open exports",
+            workspaceId: "reporting",
+            workspaceTitle: "Reporting",
+            targetPageTag: "ReportingExports",
+            tags: [],
+            isPinned: false,
+            createdAt: "2026-07-01T00:00:00Z",
+            updatedAt: "2026-07-01T00:00:00Z",
+            lastUsedAt: null,
+            viewStateEnvelope
+          },
+          {
+            presetId: "tampered-view",
+            name: "Tampered view",
+            description: "Bad token stays off the route",
+            workflowId: "reporting-delivery",
+            workflowTitle: "Reporting Delivery",
+            actionId: "reporting.exports",
+            actionLabel: "Open exports",
+            workspaceId: "reporting",
+            workspaceTitle: "Reporting",
+            targetPageTag: "ReportingExports",
+            tags: [],
+            isPinned: false,
+            createdAt: "2026-07-01T00:00:00Z",
+            updatedAt: "2026-07-01T00:00:00Z",
+            lastUsedAt: null,
+            viewStateEnvelope: "!!not-a-valid-token!!"
+          }
+        ]
+      }
+    });
+
+    const presets = model.items.filter((item) => item.kind === "preset");
+    const saved = presets.find((item) => item.presetId === "saved-view-1");
+    const tampered = presets.find((item) => item.presetId === "tampered-view");
+    expect(saved?.route).toContain(`view=${viewStateEnvelope}`);
+    expect(tampered?.route ?? "").not.toContain("view=");
   });
 
   it("keeps command palette keyboard commands in the view model", () => {

--- a/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.view-model.ts
@@ -13,6 +13,7 @@ import {
   type AppShellOperatingScopeInput,
   type AppShellOperatingScopeState
 } from "@/app-shell.operating-scope";
+import type { CommandPaletteActionItem } from "@/components/meridian/command-palette.actions";
 import type {
   WorkflowAction,
   WorkflowDefinition,
@@ -23,12 +24,13 @@ import type {
   WorkspaceSummary
 } from "@/types";
 
-export type CommandPaletteItemKind = "focus" | "entity" | "workspace" | "route" | "workflow" | "preset";
+export type CommandPaletteItemKind = "focus" | "action" | "entity" | "workspace" | "route" | "workflow" | "preset";
 export type CommandPaletteItemStatusTone = "blocked" | "review" | "ready" | "current" | "neutral";
 export type CommandPaletteFocusBoundary = "first" | "last" | "middle" | "outside" | "none";
 export type CommandPaletteFocusTarget = "search" | "command" | "other";
 export type CommandPaletteKeyCommand =
   | "close"
+  | "disarm-action"
   | "activate-first-command"
   | "focus-first"
   | "focus-last"
@@ -49,6 +51,8 @@ export interface CommandPaletteItem {
   commandLabel: string;
   ariaLabel: string;
   presetId: string | null;
+  /** Set for runnable action items; the component resolves the handler by item id. */
+  action?: { actionId: string; confirm: boolean } | null;
   active: boolean;
 }
 
@@ -79,6 +83,7 @@ export interface CommandPaletteWorkflowData {
   workflowError?: string | null;
   operatorFocusItems?: CommandPaletteFocusAction[] | null;
   entityItems?: CommandPaletteEntityItem[] | null;
+  actionItems?: CommandPaletteActionItem[] | null;
   entitySearchStatus?: "idle" | "searching" | "ready" | "degraded" | "error" | null;
   entitySearchError?: string | null;
 }
@@ -141,6 +146,7 @@ export interface CommandPaletteViewModel {
 
 const COMMAND_KIND_LABELS: Record<CommandPaletteItemKind, string> = {
   focus: "Focus actions",
+  action: "Actions",
   entity: "Entities",
   workspace: "Workspaces",
   route: "Quick routes",
@@ -150,6 +156,7 @@ const COMMAND_KIND_LABELS: Record<CommandPaletteItemKind, string> = {
 
 const COMMAND_KIND_SINGULAR_LABELS: Record<CommandPaletteItemKind, string> = {
   focus: "focus action",
+  action: "action",
   entity: "entity",
   workspace: "workspace",
   route: "quick route",
@@ -159,6 +166,7 @@ const COMMAND_KIND_SINGULAR_LABELS: Record<CommandPaletteItemKind, string> = {
 
 const COMMAND_KIND_PLURAL_LABELS: Record<CommandPaletteItemKind, string> = {
   focus: "focus actions",
+  action: "actions",
   entity: "entities",
   workspace: "workspaces",
   route: "quick routes",
@@ -166,7 +174,7 @@ const COMMAND_KIND_PLURAL_LABELS: Record<CommandPaletteItemKind, string> = {
   workflow: "workflows"
 };
 
-const COMMAND_KIND_ORDER: CommandPaletteItemKind[] = ["focus", "entity", "workspace", "route", "preset", "workflow"];
+const COMMAND_KIND_ORDER: CommandPaletteItemKind[] = ["focus", "action", "entity", "workspace", "route", "preset", "workflow"];
 const COMMAND_PALETTE_FILTER_COUNT_ID = "command-palette-filter-count";
 const COMMAND_PALETTE_EMPTY_STATE_ID = "command-palette-empty-state";
 const COMMAND_PALETTE_EMPTY_STATE_TITLE_ID = "command-palette-empty-state-title";
@@ -289,6 +297,8 @@ export interface CommandPaletteKeyboardState {
   shiftKey?: boolean;
   focusBoundary: CommandPaletteFocusBoundary;
   focusTarget?: CommandPaletteFocusTarget;
+  /** True while a confirm-required action item is armed awaiting its second activation. */
+  actionArmed?: boolean;
 }
 
 export function buildCommandPaletteViewModel(
@@ -307,12 +317,13 @@ export function buildCommandPaletteViewModel(
     symbol: operatingContextScope?.symbol ?? operatingContextSymbol
   });
   const focusItems = buildFocusItems(workflowData.operatorFocusItems ?? [], pathname, operatingScope);
+  const actionItems = buildActionItems(workflowData.actionItems ?? []);
   const entityItems = buildEntityItems(workflowData.entityItems ?? [], pathname);
   const workspaceItems = buildWorkspaceItems(visibleWorkspaces, activeKey, operatingScope);
   const routeItems = buildRouteItems(pathname, operatingScope);
   const presetItems = buildPresetItems(workflowData.workflowPresets?.presets ?? [], pathname, operatingScope);
   const workflowItems = buildWorkflowItems(workflowData.workflowLibrary?.workflows ?? [], pathname, operatingScope);
-  const items = [...focusItems, ...entityItems, ...workspaceItems, ...routeItems, ...presetItems, ...workflowItems];
+  const items = [...focusItems, ...actionItems, ...entityItems, ...workspaceItems, ...routeItems, ...presetItems, ...workflowItems];
   const normalizedQuery = query.trim();
   const filteredItems = filterCommandItems(items, normalizedQuery);
   const commandGroups = buildCommandPaletteGroups(filteredItems);
@@ -368,9 +379,10 @@ export function buildCommandPaletteViewModel(
           presetItems.length,
           workflowItems.length,
           focusItems.length,
-          entityItems.length
+          entityItems.length,
+          actionItems.length
         )
-      : buildLocalItemCountLabel(workspaceItems.length, routeItems.length, focusItems.length, entityItems.length),
+      : buildLocalItemCountLabel(workspaceItems.length, routeItems.length, focusItems.length, entityItems.length, actionItems.length),
     activeWorkspaceLabel,
     initialFocusItemId:
       filteredItems.find((item) => item.kind === "focus")?.id
@@ -523,10 +535,11 @@ export function resolveCommandPaletteKeyCommand({
   key,
   shiftKey = false,
   focusBoundary,
-  focusTarget = "other"
+  focusTarget = "other",
+  actionArmed = false
 }: CommandPaletteKeyboardState): CommandPaletteKeyCommand {
   if (key === "Escape") {
-    return "close";
+    return actionArmed ? "disarm-action" : "close";
   }
 
   if (key === "Enter" && focusTarget === "search") {
@@ -585,6 +598,27 @@ function buildWorkspaceItems(
       active
     };
   });
+}
+
+function buildActionItems(actions: CommandPaletteActionItem[]): CommandPaletteItem[] {
+  return actions.map<CommandPaletteItem>((action) => ({
+    id: `action:${action.id}`,
+    kind: "action",
+    label: action.verbLabel,
+    description: [action.description, ...(action.keywords ?? [])].join(" ").trim(),
+    route: "",
+    routeLabel: "Action",
+    statusLabel: action.disabled ? action.disabledReason ?? "Unavailable" : action.confirm ? "Confirm to run" : "Runs now",
+    statusTone: action.disabled ? "blocked" : "ready",
+    statusVisible: Boolean(action.disabled || action.confirm),
+    commandLabel: action.verbLabel,
+    ariaLabel: action.disabled
+      ? `${action.verbLabel}. Unavailable: ${action.disabledReason ?? "not available right now"}`
+      : `${action.verbLabel}. ${action.description}`,
+    presetId: null,
+    action: { actionId: action.id, confirm: Boolean(action.confirm) },
+    active: false
+  }));
 }
 
 function buildFocusItems(
@@ -829,9 +863,10 @@ function buildBackendStatusLabel(
   return `${workflowActionCount} workflow action${workflowActionCount === 1 ? "" : "s"} - ${presetCount} preset${presetCount === 1 ? "" : "s"}`;
 }
 
-function buildLocalItemCountLabel(workspaceCount: number, routeCount: number, focusCount = 0, entityCount = 0) {
+function buildLocalItemCountLabel(workspaceCount: number, routeCount: number, focusCount = 0, entityCount = 0, actionCount = 0) {
   return joinCommandPaletteCounts([
     focusCount > 0 ? `${focusCount} focus action${focusCount === 1 ? "" : "s"}` : null,
+    actionCount > 0 ? `${actionCount} action${actionCount === 1 ? "" : "s"}` : null,
     entityCount > 0 ? `${entityCount} entity result${entityCount === 1 ? "" : "s"}` : null,
     `${workspaceCount} workspace${workspaceCount === 1 ? "" : "s"}`,
     `${routeCount} quick route${routeCount === 1 ? "" : "s"}`
@@ -844,10 +879,12 @@ function buildItemCountLabel(
   presetCount: number,
   workflowActionCount: number,
   focusCount = 0,
-  entityCount = 0
+  entityCount = 0,
+  actionCount = 0
 ) {
   return joinCommandPaletteCounts([
     focusCount > 0 ? `${focusCount} focus action${focusCount === 1 ? "" : "s"}` : null,
+    actionCount > 0 ? `${actionCount} action${actionCount === 1 ? "" : "s"}` : null,
     entityCount > 0 ? `${entityCount} entity result${entityCount === 1 ? "" : "s"}` : null,
     `${workspaceCount} workspace${workspaceCount === 1 ? "" : "s"}`,
     `${routeCount} quick route${routeCount === 1 ? "" : "s"}`,

--- a/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/command-palette.view-model.ts
@@ -1,4 +1,5 @@
 import {
+  appendRouteQuery,
   canonicalizeWorkspaceSummaries,
   normalizeWorkspacePath,
   WORKSPACES,
@@ -6,6 +7,7 @@ import {
   workflowTargetPath,
   workspacePath
 } from "@/lib/workspace";
+import { decodeViewStateEnvelope, VIEW_STATE_QUERY_KEY } from "@/lib/view-state-envelope";
 import {
   appendOperatingScopeToRoute,
   buildOperatingScopeFromSearch,
@@ -740,7 +742,8 @@ function buildPresetItems(
   return [...presets]
     .sort(comparePresets)
     .map<CommandPaletteItem>((preset) => {
-      const route = materializeCommandRoute(workflowTargetPath(preset.targetPageTag, preset.workspaceId), operatingScope);
+      const baseRoute = materializeCommandRoute(workflowTargetPath(preset.targetPageTag, preset.workspaceId), operatingScope);
+      const route = appendPresetViewState(baseRoute, preset.viewStateEnvelope ?? null);
       const current = isExactActivePath(pathname, route);
 
       return {
@@ -759,6 +762,14 @@ function buildPresetItems(
         active: false
       };
     });
+}
+
+function appendPresetViewState(route: string, viewStateEnvelope: string | null): string {
+  if (!viewStateEnvelope || !decodeViewStateEnvelope(viewStateEnvelope)) {
+    return route;
+  }
+
+  return appendRouteQuery(route, { [VIEW_STATE_QUERY_KEY]: viewStateEnvelope });
 }
 
 function buildWorkflowItems(

--- a/src/Meridian.Ui/dashboard/src/components/meridian/copy-link-button.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/copy-link-button.test.tsx
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { CopyLinkButton } from "@/components/meridian/copy-link-button";
+import { ToastProvider } from "@/components/ui/toast";
+
+describe("CopyLinkButton", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("copies the current URL and confirms with a toast", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
+
+    render(
+      <ToastProvider>
+        <CopyLinkButton />
+      </ToastProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy link to this view" }));
+
+    expect(await screen.findByText("Link copied")).toBeInTheDocument();
+    expect(writeText).toHaveBeenCalledWith(window.location.href);
+  });
+
+  it("falls back to a danger toast when the clipboard is unavailable", async () => {
+    vi.stubGlobal("navigator", { ...navigator, clipboard: undefined });
+
+    render(
+      <ToastProvider>
+        <CopyLinkButton />
+      </ToastProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy link to this view" }));
+
+    expect(await screen.findByText("Copy failed")).toBeInTheDocument();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/meridian/copy-link-button.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/copy-link-button.tsx
@@ -1,0 +1,35 @@
+import { Link2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/toast";
+import { copyTextToClipboard } from "@/lib/csv";
+
+/**
+ * Copies the current browser URL so an operator can hand a teammate this exact
+ * view. Scope, symbol, task mode, and any `view` state param are already
+ * URL-borne, so the address itself is the shareable artifact.
+ */
+export function CopyLinkButton() {
+  const toast = useToast();
+
+  const handleCopy = async () => {
+    const copied = await copyTextToClipboard(window.location.href);
+    if (copied) {
+      toast.success("Link copied", "Paste it to share this exact view.");
+    } else {
+      toast.danger("Copy failed", "Copy the address from the browser bar instead.");
+    }
+  };
+
+  return (
+    <Button
+      aria-label="Copy link to this view"
+      onClick={() => void handleCopy()}
+      size="sm"
+      title="Copy link to this view"
+      type="button"
+      variant="ghost"
+    >
+      <Link2 aria-hidden="true" className="size-4" />
+    </Button>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/meridian/save-view-dialog.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/save-view-dialog.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import { useLocation } from "react-router-dom";
+import { BookmarkPlus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/components/ui/toast";
+import { saveWorkflowPreset } from "@/lib/api";
+import { describeApiError } from "@/lib/api-errors";
+import { findWorkflowActionForRoute } from "@/lib/workflow-route-match";
+import { VIEW_STATE_QUERY_KEY } from "@/lib/view-state-envelope";
+import type { WorkflowLibrary, WorkflowPreset } from "@/types";
+
+const MAX_SAVE_VIEW_NAME_LENGTH = 120;
+
+interface SaveViewButtonProps {
+  workflowLibrary: WorkflowLibrary | null;
+  workflowError?: string | null;
+  onPresetSaved: (preset: WorkflowPreset) => void;
+}
+
+/**
+ * Saves the current view as a workflow preset. The preset carries the current
+ * `view` state token (when present) so reopening it restores the exact view;
+ * scope-only views are still valid saves. Enabled only when a workflow action
+ * owns the current route — presets must attach to catalog workflows.
+ */
+export function SaveViewButton({ workflowLibrary, workflowError, onPresetSaved }: SaveViewButtonProps) {
+  const { pathname, search } = useLocation();
+  const toast = useToast();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const routeMatch = findWorkflowActionForRoute(workflowLibrary, pathname);
+  const disabledReason = workflowError
+    ? "Workflow library is unavailable."
+    : !routeMatch
+      ? "No workflow action owns this route yet."
+      : null;
+
+  const handleSave = async () => {
+    if (!routeMatch || saving) {
+      return;
+    }
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const viewStateEnvelope = new URLSearchParams(search).get(VIEW_STATE_QUERY_KEY);
+      const preset = await saveWorkflowPreset({
+        name: trimmedName,
+        description: description.trim() || null,
+        workflowId: routeMatch.workflow.workflowId,
+        actionId: routeMatch.action.actionId,
+        tags: [],
+        isPinned: false,
+        viewStateEnvelope
+      });
+      onPresetSaved(preset);
+      toast.success(`Saved view ${preset.name}.`, "Find it in the command palette presets.");
+      setOpen(false);
+      setName("");
+      setDescription("");
+    } catch (error) {
+      const display = describeApiError(error, "Saving the view failed.");
+      toast.danger(display.summary, display.details.join(" ") || undefined);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        aria-label="Save this view as a preset"
+        disabled={Boolean(disabledReason)}
+        disabledReason={disabledReason ?? undefined}
+        onClick={() => setOpen(true)}
+        size="sm"
+        title="Save this view as a preset"
+        type="button"
+        variant="ghost"
+      >
+        <BookmarkPlus aria-hidden="true" className="size-4" />
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent aria-labelledby="save-view-title" aria-describedby="save-view-description">
+          <DialogHeader>
+            <DialogTitle id="save-view-title">Save this view</DialogTitle>
+            <DialogDescription id="save-view-description">
+              Stores the current route{routeMatch ? ` under ${routeMatch.workflow.title}` : ""} as a
+              team-visible preset, including any captured view state.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 pt-2">
+            <div>
+              <label className="text-sm font-medium text-foreground" htmlFor="save-view-name">
+                View name
+              </label>
+              <Input
+                id="save-view-name"
+                maxLength={MAX_SAVE_VIEW_NAME_LENGTH}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="Month-end breaks — Fund A"
+                value={name}
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium text-foreground" htmlFor="save-view-description-input">
+                Description (optional)
+              </label>
+              <Input
+                id="save-view-description-input"
+                onChange={(event) => setDescription(event.target.value)}
+                placeholder="What a teammate lands on when opening this view"
+                value={description}
+              />
+            </div>
+            <div className="flex justify-end gap-3 pt-2">
+              <Button onClick={() => setOpen(false)} size="sm" type="button" variant="outline">
+                Cancel
+              </Button>
+              <Button
+                busy={saving}
+                busyLabel="Saving view"
+                disabled={!name.trim() || saving}
+                onClick={() => void handleSave()}
+                size="sm"
+                type="button"
+              >
+                Save view
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/meridian/workspace-header.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/workspace-header.test.tsx
@@ -38,4 +38,19 @@ describe("WorkspaceHeader", () => {
     expect(screen.queryByLabelText("8 commands available in the command palette")).not.toBeInTheDocument();
     expect(screen.getByText("Refreshing Trading workspace data.")).toHaveClass("sr-only");
   });
+
+  it("renders shell-provided actions before the refresh button", () => {
+    render(
+      <WorkspaceHeader
+        workspace={workspaceForKey("trading")}
+        session={session}
+        onRefresh={vi.fn()}
+        actions={<button type="button">Copy link to this view</button>}
+      />
+    );
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons[0]).toHaveTextContent("Copy link to this view");
+    expect(screen.getByRole("button", { name: /Refresh Trading workspace data/ })).toBeInTheDocument();
+  });
 });

--- a/src/Meridian.Ui/dashboard/src/components/meridian/workspace-header.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/workspace-header.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { AlertTriangle, RefreshCcw } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumb, type BreadcrumbItem } from "@/components/ui/breadcrumb";
@@ -35,6 +36,8 @@ interface WorkspaceHeaderProps {
   session: SessionInfo | null;
   onRefresh?: () => void;
   refreshing?: boolean;
+  /** Shell-provided header actions (e.g. copy link, save view), rendered before refresh. */
+  actions?: ReactNode;
 }
 
 export function WorkspaceHeader({
@@ -42,7 +45,8 @@ export function WorkspaceHeader({
   workspace,
   session,
   onRefresh,
-  refreshing = false
+  refreshing = false,
+  actions
 }: WorkspaceHeaderProps) {
   const viewModel = buildWorkspaceHeaderViewModel({
     workspace,
@@ -90,6 +94,7 @@ export function WorkspaceHeader({
             </div>
 
             <div className="flex flex-shrink-0 flex-wrap items-center gap-2">
+              {actions}
               {viewModel.refreshAction && onRefresh ? (
                 <Button
                   variant="ghost"

--- a/src/Meridian.Ui/dashboard/src/components/ui/freshness-chip.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/freshness-chip.test.tsx
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { FreshnessChip } from "@/components/ui/freshness-chip";
+
+describe("FreshnessChip", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-02T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("renders the fresh state for a recent timestamp", () => {
+    render(
+      <FreshnessChip label="Quotes" staleBudgetMs={10_000} timestamp="2026-07-02T11:59:58.000Z" />
+    );
+    const chip = screen.getByLabelText("Quotes updated 2s ago.");
+    expect(chip.getAttribute("data-freshness-state")).toBe("fresh");
+  });
+
+  it("transitions to aging as time passes without new data", () => {
+    render(
+      <FreshnessChip label="Quotes" staleBudgetMs={5_000} timestamp="2026-07-02T11:59:58.000Z" />
+    );
+    expect(screen.getByText("2s ago").getAttribute("data-freshness-state")).toBe("fresh");
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(screen.getByLabelText(/Quotes is stale/).getAttribute("data-freshness-state")).toBe("aging");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/freshness-chip.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/freshness-chip.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import {
+  buildFreshnessChipViewModel,
+  type FreshnessChipInput
+} from "@/components/ui/freshness-chip.view-model";
+
+/**
+ * Compact "how current is this number" indicator built on Badge. Feed it the last
+ * successful update timestamp (lifecycle `lastSucceededAt` or a server as-of field)
+ * plus a per-surface staleness budget; it re-evaluates its age on an internal tick
+ * so a surface whose polling stops visibly ages. Intentionally not `aria-live` —
+ * high-frequency surfaces update every couple of seconds.
+ */
+export interface FreshnessChipProps extends Omit<FreshnessChipInput, "now"> {
+  className?: string;
+}
+
+const MAX_TICK_MS = 30_000;
+
+export function FreshnessChip({ className, ...input }: FreshnessChipProps) {
+  const now = useNowTick(Math.max(1000, Math.min(input.staleBudgetMs, MAX_TICK_MS)), input.timestamp);
+  const vm = buildFreshnessChipViewModel({ ...input, now });
+
+  return (
+    <Badge
+      aria-label={vm.ariaLabel}
+      className={className}
+      data-freshness-state={vm.state}
+      dot={vm.dot}
+      title={vm.title ?? undefined}
+      variant={vm.badgeVariant}
+    >
+      {vm.text}
+    </Badge>
+  );
+}
+
+function useNowTick(intervalMs: number, resetKey: string | null): number {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    setNow(Date.now());
+    const id = window.setInterval(() => setNow(Date.now()), intervalMs);
+    return () => window.clearInterval(id);
+  }, [intervalMs, resetKey]);
+
+  return now;
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/freshness-chip.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/components/ui/freshness-chip.view-model.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFreshnessChipViewModel,
+  freshnessInputFromLifecycle
+} from "@/components/ui/freshness-chip.view-model";
+import type { RequestLifecycleStatus } from "@/hooks/use-request-lifecycle";
+
+const NOW = Date.parse("2026-07-02T12:00:00.000Z");
+
+function baseInput(overrides: Partial<Parameters<typeof buildFreshnessChipViewModel>[0]> = {}) {
+  return {
+    timestamp: "2026-07-02T11:59:55.000Z",
+    staleBudgetMs: 10_000,
+    now: NOW,
+    label: "Quotes",
+    ...overrides
+  };
+}
+
+function lifecycleStatus(overrides: Partial<RequestLifecycleStatus> = {}): RequestLifecycleStatus {
+  return {
+    operation: "test refresh",
+    phase: "succeeded",
+    inFlight: false,
+    version: 1,
+    message: "Refresh complete.",
+    error: null,
+    startedAt: "2026-07-02T11:59:54.000Z",
+    settledAt: "2026-07-02T11:59:55.000Z",
+    lastSucceededAt: "2026-07-02T11:59:55.000Z",
+    staleDiscardCount: 0,
+    backoff: { attempt: 1, retryCount: 0, nextRetryDelayMs: null, maxRetries: 0 },
+    ...overrides
+  };
+}
+
+describe("buildFreshnessChipViewModel", () => {
+  it("reports fresh within the staleness budget", () => {
+    const vm = buildFreshnessChipViewModel(baseInput());
+    expect(vm.state).toBe("fresh");
+    expect(vm.badgeVariant).toBe("outline");
+    expect(vm.text).toBe("5s ago");
+    expect(vm.ariaLabel).toBe("Quotes updated 5s ago.");
+  });
+
+  it("reports aging past the staleness budget", () => {
+    const vm = buildFreshnessChipViewModel(baseInput({ timestamp: "2026-07-02T11:58:00.000Z" }));
+    expect(vm.state).toBe("aging");
+    expect(vm.badgeVariant).toBe("warning");
+    expect(vm.text).toBe("Stale · 2m ago");
+  });
+
+  it("suppresses the aging tone while a refresh is in flight", () => {
+    const vm = buildFreshnessChipViewModel(
+      baseInput({ timestamp: "2026-07-02T11:58:00.000Z", inFlight: true })
+    );
+    expect(vm.state).toBe("fresh");
+  });
+
+  it("reports failing when an error is present, keeping the last success age", () => {
+    const vm = buildFreshnessChipViewModel(
+      baseInput({ timestamp: "2026-07-02T11:58:00.000Z", errorMessage: "HTTP 503" })
+    );
+    expect(vm.state).toBe("failing");
+    expect(vm.badgeVariant).toBe("danger");
+    expect(vm.text).toBe("Failing · 2m ago");
+    expect(vm.ariaLabel).toContain("HTTP 503");
+    expect(vm.ariaLabel).toContain("Last success 2m ago.");
+  });
+
+  it("reports unknown when no timestamp exists", () => {
+    const vm = buildFreshnessChipViewModel(baseInput({ timestamp: null }));
+    expect(vm.state).toBe("unknown");
+    expect(vm.text).toBe("No data");
+    expect(vm.ariaLabel).toBe("Quotes has not been updated yet.");
+  });
+
+  it("gives live precedence over everything else", () => {
+    const vm = buildFreshnessChipViewModel(
+      baseInput({ live: true, errorMessage: "ignored", timestamp: null })
+    );
+    expect(vm.state).toBe("live");
+    expect(vm.dot).toBe(true);
+    expect(vm.badgeVariant).toBe("success");
+  });
+});
+
+describe("freshnessInputFromLifecycle", () => {
+  it("maps lastSucceededAt and reports no error on success", () => {
+    const input = freshnessInputFromLifecycle(lifecycleStatus(), 10_000, "Quotes");
+    expect(input.timestamp).toBe("2026-07-02T11:59:55.000Z");
+    expect(input.errorMessage).toBeNull();
+  });
+
+  it("surfaces the error and retry detail on failure", () => {
+    const input = freshnessInputFromLifecycle(
+      lifecycleStatus({
+        phase: "failed",
+        error: "HTTP 503",
+        backoff: { attempt: 2, retryCount: 1, nextRetryDelayMs: 2000, maxRetries: 3 }
+      }),
+      10_000,
+      "Quotes"
+    );
+    expect(input.errorMessage).toBe("HTTP 503");
+    expect(input.detail).toBe("Retrying in 2s");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/freshness-chip.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/components/ui/freshness-chip.view-model.ts
@@ -1,0 +1,112 @@
+import { formatRelativeAge } from "@/lib/time";
+import type { RequestLifecycleStatus } from "@/hooks/use-request-lifecycle";
+
+export type FreshnessState = "fresh" | "aging" | "failing" | "live" | "unknown";
+
+export interface FreshnessChipInput {
+  /** ISO timestamp of the last successful update — lifecycle `lastSucceededAt` or a server as-of field. */
+  timestamp: string | null;
+  /** Age beyond which the data is presented as aging/stale. */
+  staleBudgetMs: number;
+  now: number;
+  /** Subject used in the accessible label, e.g. "Quotes". */
+  label?: string;
+  /** Marks the surface as failing regardless of age. */
+  errorMessage?: string | null;
+  /** Suppresses the aging tone while a refresh is running. */
+  inFlight?: boolean;
+  /** Push-fed surface indicator (reserved for the live data spine). */
+  live?: boolean;
+  /** Extra hover detail such as retry metadata. */
+  detail?: string | null;
+}
+
+export interface FreshnessChipViewModel {
+  state: FreshnessState;
+  badgeVariant: "outline" | "warning" | "danger" | "success";
+  dot: boolean;
+  text: string;
+  ariaLabel: string;
+  title: string | null;
+}
+
+export function buildFreshnessChipViewModel(input: FreshnessChipInput): FreshnessChipViewModel {
+  const subject = input.label?.trim() || "Data";
+  const age = formatRelativeAge(input.timestamp, input.now);
+
+  if (input.live) {
+    return {
+      state: "live",
+      badgeVariant: "success",
+      dot: true,
+      text: "Live",
+      ariaLabel: `${subject} is streaming live.`,
+      title: input.detail ?? null
+    };
+  }
+
+  if (input.errorMessage) {
+    return {
+      state: "failing",
+      badgeVariant: "danger",
+      dot: false,
+      text: input.timestamp ? `Failing · ${age}` : "Failing",
+      ariaLabel: `${subject} refresh is failing: ${input.errorMessage}${input.timestamp ? ` Last success ${age}.` : ""}`,
+      title: joinDetail(input.errorMessage, input.detail)
+    };
+  }
+
+  if (!input.timestamp) {
+    return {
+      state: "unknown",
+      badgeVariant: "outline",
+      dot: false,
+      text: "No data",
+      ariaLabel: `${subject} has not been updated yet.`,
+      title: input.detail ?? null
+    };
+  }
+
+  const ageMs = input.now - new Date(input.timestamp).getTime();
+  const aging = Number.isFinite(ageMs) && ageMs > input.staleBudgetMs && !input.inFlight;
+  if (aging) {
+    return {
+      state: "aging",
+      badgeVariant: "warning",
+      dot: false,
+      text: `Stale · ${age}`,
+      ariaLabel: `${subject} is stale: last success ${age}.`,
+      title: input.detail ?? null
+    };
+  }
+
+  return {
+    state: "fresh",
+    badgeVariant: "outline",
+    dot: false,
+    text: age,
+    ariaLabel: `${subject} updated ${age}.`,
+    title: input.detail ?? null
+  };
+}
+
+/** Maps a request lifecycle status onto chip input so screens share one derivation. */
+export function freshnessInputFromLifecycle(
+  status: RequestLifecycleStatus,
+  staleBudgetMs: number,
+  label?: string
+): Omit<FreshnessChipInput, "now"> {
+  const retry = status.backoff.nextRetryDelayMs;
+  return {
+    timestamp: status.lastSucceededAt,
+    staleBudgetMs,
+    label,
+    errorMessage: status.phase === "failed" ? status.error : null,
+    inFlight: status.inFlight,
+    detail: retry != null ? `Retrying in ${Math.round(retry / 1000)}s` : null
+  };
+}
+
+function joinDetail(errorMessage: string, detail: string | null | undefined): string {
+  return detail ? `${errorMessage} — ${detail}` : errorMessage;
+}

--- a/src/Meridian.Ui/dashboard/src/hooks/use-request-lifecycle.test.ts
+++ b/src/Meridian.Ui/dashboard/src/hooks/use-request-lifecycle.test.ts
@@ -145,4 +145,49 @@ describe("useRequestLifecycle", () => {
       maxRetries: 2
     });
   });
+
+  it("Scenario_PollingFailsAfterSuccess_LastSucceededAtSurvivesTheFailure", () => {
+    const { result } = renderHook(() => useRequestLifecycle({ operation: "quote refresh" }));
+
+    expect(result.current.status.lastSucceededAt).toBeNull();
+
+    let token: ReturnType<typeof result.current.start>;
+    act(() => {
+      token = result.current.start();
+    });
+    act(() => {
+      result.current.succeed(token!);
+    });
+
+    const lastSucceededAt = result.current.status.lastSucceededAt;
+    expect(lastSucceededAt).not.toBeNull();
+    expect(result.current.status.settledAt).toBe(lastSucceededAt);
+
+    act(() => {
+      token = result.current.start();
+    });
+    act(() => {
+      result.current.fail(token!, new Error("provider outage"));
+    });
+
+    expect(result.current.status.phase).toBe("failed");
+    expect(result.current.status.lastSucceededAt).toBe(lastSucceededAt);
+    expect(result.current.status.settledAt).not.toBeNull();
+  });
+
+  it("Scenario_StaleSucceedDiscarded_DoesNotAdvanceLastSucceededAt", () => {
+    const { result } = renderHook(() => useRequestLifecycle({ operation: "quote refresh" }));
+
+    let older: ReturnType<typeof result.current.start>;
+    act(() => {
+      older = result.current.start();
+      result.current.start();
+    });
+    act(() => {
+      result.current.succeed(older!);
+    });
+
+    expect(result.current.status.lastSucceededAt).toBeNull();
+    expect(result.current.status.staleDiscardCount).toBe(1);
+  });
 });

--- a/src/Meridian.Ui/dashboard/src/hooks/use-request-lifecycle.ts
+++ b/src/Meridian.Ui/dashboard/src/hooks/use-request-lifecycle.ts
@@ -19,6 +19,8 @@ export interface RequestLifecycleStatus {
   error: string | null;
   startedAt: string | null;
   settledAt: string | null;
+  /** Timestamp of the most recent successful settle; survives later failures. */
+  lastSucceededAt: string | null;
   staleDiscardCount: number;
   backoff: RequestBackoffMetadata;
 }
@@ -87,6 +89,7 @@ export function useRequestLifecycle({
     error: null,
     startedAt: null,
     settledAt: null,
+    lastSucceededAt: null,
     staleDiscardCount: 0,
     backoff: {
       attempt: 0,
@@ -218,6 +221,7 @@ export function useRequestLifecycle({
       controllerRef.current = null;
     }
     inFlightRef.current = false;
+    const settledAt = new Date().toISOString();
     setStatus((current) => ({
       ...current,
       phase: "succeeded",
@@ -225,7 +229,8 @@ export function useRequestLifecycle({
       version: token.version,
       message: options.message ?? successMessage,
       error: null,
-      settledAt: new Date().toISOString(),
+      settledAt,
+      lastSucceededAt: settledAt,
       backoff: {
         ...current.backoff,
         nextRetryDelayMs: null

--- a/src/Meridian.Ui/dashboard/src/lib/time.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/time.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { formatRelativeAge } from "@/lib/time";
+
+describe("formatRelativeAge", () => {
+  it("returns Never for missing or invalid timestamps", () => {
+    expect(formatRelativeAge(null)).toBe("Never");
+    expect(formatRelativeAge("bad")).toBe("Never");
+  });
+
+  it("formats second and minute ages", () => {
+    const now = Date.parse("2026-05-09T01:00:00.000Z");
+    expect(formatRelativeAge("2026-05-09T00:59:30.000Z", now)).toBe("30s ago");
+    expect(formatRelativeAge("2026-05-09T00:40:00.000Z", now)).toBe("20m ago");
+  });
+
+  it("formats hour and day ages", () => {
+    const now = Date.parse("2026-05-09T12:00:00.000Z");
+    expect(formatRelativeAge("2026-05-09T07:00:00.000Z", now)).toBe("5h ago");
+    expect(formatRelativeAge("2026-05-06T12:00:00.000Z", now)).toBe("3d ago");
+  });
+
+  it("falls back to an absolute label for future timestamps", () => {
+    const now = Date.parse("2026-05-09T01:00:00.000Z");
+    const future = "2026-05-09T02:00:00.000Z";
+    expect(formatRelativeAge(future, now)).toBe(new Date(future).toLocaleString());
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/lib/time.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/time.ts
@@ -1,0 +1,36 @@
+// Meridian shared time formatting. Relative-age text for freshness indicators and
+// "last updated" labels; promoted from the watchlist view model so chips, screens,
+// and view models share one age vocabulary.
+export function formatRelativeAge(iso: string | null, now = Date.now()): string {
+  if (!iso) {
+    return "Never";
+  }
+
+  const timestamp = new Date(iso).getTime();
+  if (Number.isNaN(timestamp)) {
+    return "Never";
+  }
+
+  const diff = now - timestamp;
+  if (diff < 0) {
+    return new Date(iso).toLocaleString();
+  }
+
+  const seconds = Math.round(diff / 1000);
+  if (seconds < 60) {
+    return `${seconds}s ago`;
+  }
+
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h ago`;
+  }
+
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}

--- a/src/Meridian.Ui/dashboard/src/lib/view-state-envelope.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/view-state-envelope.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendViewStateToRoute,
+  buildTableViewState,
+  decodeViewStateEnvelope,
+  encodeViewStateEnvelope,
+  MAX_VIEW_STATE_TOKEN_LENGTH,
+  normalizeTableViewState,
+  readViewStateFromSearch,
+  stripViewStateFromSearch,
+  VIEW_STATE_QUERY_KEY,
+  type ViewStateEnvelope
+} from "@/lib/view-state-envelope";
+
+const envelope: ViewStateEnvelope = {
+  v: 1,
+  screen: "reporting-exports",
+  state: {
+    selectedExportsTemplateId: "investor-monthly-statement",
+    asOfDate: "2026-06-30",
+    note: "Fónd Δ — ünïcode"
+  }
+};
+
+describe("view state envelope", () => {
+  it("round-trips unicode payloads and nested filters", () => {
+    const nested: ViewStateEnvelope = {
+      v: 1,
+      screen: "trial-balance",
+      state: buildTableViewState({
+        query: "cash",
+        sortBy: { column: "balance", direction: "desc" },
+        filters: { entity: ["Fund Δ", "Fund B"], status: ["open"] }
+      })
+    };
+
+    const token = encodeViewStateEnvelope(nested);
+    expect(token).not.toBeNull();
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(decodeViewStateEnvelope(token)).toEqual(nested);
+
+    const unicodeToken = encodeViewStateEnvelope(envelope);
+    expect(decodeViewStateEnvelope(unicodeToken)).toEqual(envelope);
+  });
+
+  it("rejects tampered tokens, wrong versions, and malformed shapes", () => {
+    const token = encodeViewStateEnvelope(envelope)!;
+    expect(decodeViewStateEnvelope(`${token}garbage!!`)).toBeNull();
+    expect(decodeViewStateEnvelope("not-base64-json")).toBeNull();
+
+    const wrongVersion = { ...envelope, v: 2 } as unknown as ViewStateEnvelope;
+    expect(decodeViewStateEnvelope(encodeViewStateEnvelope(wrongVersion))).toBeNull();
+
+    const arrayState = { v: 1, screen: "x", state: [] } as unknown as ViewStateEnvelope;
+    expect(decodeViewStateEnvelope(encodeViewStateEnvelope(arrayState))).toBeNull();
+  });
+
+  it("returns null when the payload exceeds the token budget", () => {
+    const oversized: ViewStateEnvelope = {
+      v: 1,
+      screen: "reporting-exports",
+      state: { blob: "x".repeat(MAX_VIEW_STATE_TOKEN_LENGTH * 2) }
+    };
+    expect(encodeViewStateEnvelope(oversized)).toBeNull();
+    expect(appendViewStateToRoute("/reporting/exports", oversized)).toBe("/reporting/exports");
+  });
+
+  it("reads only the matching screen from a search string", () => {
+    const route = appendViewStateToRoute("/reporting/exports?fundAccountId=fund-a", envelope);
+    const search = route.slice(route.indexOf("?"));
+
+    expect(readViewStateFromSearch(search, "reporting-exports")).toEqual(envelope);
+    expect(readViewStateFromSearch(search, "trial-balance")).toBeNull();
+  });
+
+  it("strips only the view param, preserving scope keys", () => {
+    const route = appendViewStateToRoute(
+      "/reporting/exports?symbol=AAPL&fundAccountId=f-1&runId=r-1&provider=p&from=a&to=b&date=d&asOf=e",
+      envelope
+    );
+    const search = route.slice(route.indexOf("?"));
+    const stripped = stripViewStateFromSearch(search);
+
+    const params = new URLSearchParams(stripped);
+    expect(params.get(VIEW_STATE_QUERY_KEY)).toBeNull();
+    for (const key of ["symbol", "fundAccountId", "runId", "provider", "from", "to", "date", "asOf"]) {
+      expect(params.get(key)).not.toBeNull();
+    }
+  });
+
+  it("normalizes table view state defensively", () => {
+    expect(normalizeTableViewState(null)).toEqual({ query: "", sortBy: null, filters: {} });
+    expect(
+      normalizeTableViewState({ query: 42, sortBy: { column: "x", direction: "sideways" }, filters: { a: [1] } })
+    ).toEqual({ query: "", sortBy: null, filters: {} });
+    expect(
+      normalizeTableViewState({ query: "q", sortBy: { column: "x", direction: "asc" }, filters: { a: ["1"] } })
+    ).toEqual({ query: "q", sortBy: { column: "x", direction: "asc" }, filters: { a: ["1"] } });
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/lib/view-state-envelope.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/view-state-envelope.ts
@@ -1,0 +1,140 @@
+// Versioned, URL-safe envelope for screen-local view state. Serialized as a single
+// `view=<base64url(JSON)>` query param so operating-scope keys stay untouched and
+// the token can be stored opaquely (e.g. on a workflow preset as a saved view).
+import { appendRouteQuery } from "@/lib/workspace";
+import type { TableFilters, TableSort } from "@/components/data/use-table-state";
+
+export const VIEW_STATE_QUERY_KEY = "view";
+export const VIEW_STATE_ENVELOPE_VERSION = 1 as const;
+export const MAX_VIEW_STATE_TOKEN_LENGTH = 2000;
+
+export interface ViewStateEnvelope {
+  v: typeof VIEW_STATE_ENVELOPE_VERSION;
+  /** Screen discriminator, e.g. "reporting-exports"; hydration ignores foreign screens. */
+  screen: string;
+  state: Record<string, unknown>;
+}
+
+/** Returns the encoded token, or null when the payload exceeds the URL budget. */
+export function encodeViewStateEnvelope(envelope: ViewStateEnvelope): string | null {
+  const token = toBase64Url(JSON.stringify(envelope));
+  return token.length > MAX_VIEW_STATE_TOKEN_LENGTH ? null : token;
+}
+
+/** Defensive decode: bad base64, bad JSON, wrong version, or wrong shape all yield null. */
+export function decodeViewStateEnvelope(raw: string | null | undefined): ViewStateEnvelope | null {
+  if (!raw || raw.length > MAX_VIEW_STATE_TOKEN_LENGTH) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(fromBase64Url(raw));
+    if (
+      typeof parsed !== "object"
+      || parsed === null
+      || (parsed as { v?: unknown }).v !== VIEW_STATE_ENVELOPE_VERSION
+      || typeof (parsed as { screen?: unknown }).screen !== "string"
+      || typeof (parsed as { state?: unknown }).state !== "object"
+      || (parsed as { state?: unknown }).state === null
+      || Array.isArray((parsed as { state?: unknown }).state)
+    ) {
+      return null;
+    }
+
+    return parsed as ViewStateEnvelope;
+  } catch {
+    return null;
+  }
+}
+
+export function appendViewStateToRoute(route: string, envelope: ViewStateEnvelope): string {
+  const token = encodeViewStateEnvelope(envelope);
+  return token ? appendRouteQuery(route, { [VIEW_STATE_QUERY_KEY]: token }) : route;
+}
+
+export function readViewStateFromSearch(search: string, screen: string): ViewStateEnvelope | null {
+  let raw: string | null;
+  try {
+    raw = new URLSearchParams(search).get(VIEW_STATE_QUERY_KEY);
+  } catch {
+    return null;
+  }
+
+  const envelope = decodeViewStateEnvelope(raw);
+  return envelope && envelope.screen === screen ? envelope : null;
+}
+
+export function stripViewStateFromSearch(search: string): string {
+  try {
+    const params = new URLSearchParams(search);
+    params.delete(VIEW_STATE_QUERY_KEY);
+    const next = params.toString();
+    return next ? `?${next}` : "";
+  } catch {
+    return search;
+  }
+}
+
+// Table-state bridge: the serializable slice of useTableState, normalized defensively
+// on the way back in. Contract for later phases; no screen consumer yet.
+export function buildTableViewState(
+  table: { query: string; sortBy: TableSort | null; filters: TableFilters }
+): Record<string, unknown> {
+  return {
+    query: table.query,
+    sortBy: table.sortBy,
+    filters: table.filters
+  };
+}
+
+export function normalizeTableViewState(state: unknown): {
+  query: string;
+  sortBy: TableSort | null;
+  filters: TableFilters;
+} {
+  const source = typeof state === "object" && state !== null ? state as Record<string, unknown> : {};
+  const sortBy = source.sortBy;
+  const filters = source.filters;
+
+  return {
+    query: typeof source.query === "string" ? source.query : "",
+    sortBy: isTableSort(sortBy) ? sortBy : null,
+    filters: isTableFilters(filters) ? filters : {}
+  };
+}
+
+function isTableSort(value: unknown): value is TableSort {
+  return (
+    typeof value === "object"
+    && value !== null
+    && typeof (value as TableSort).column === "string"
+    && ((value as TableSort).direction === "asc" || (value as TableSort).direction === "desc")
+  );
+}
+
+function isTableFilters(value: unknown): value is TableFilters {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  return Object.values(value).every(
+    (entry) => entry === undefined
+      || (Array.isArray(entry) && entry.every((item) => typeof item === "string"))
+  );
+}
+
+function toBase64Url(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function fromBase64Url(token: string): string {
+  const padded = token.replaceAll("-", "+").replaceAll("_", "/").padEnd(Math.ceil(token.length / 4) * 4, "=");
+  const binary = atob(padded);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}

--- a/src/Meridian.Ui/dashboard/src/lib/workflow-route-match.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/workflow-route-match.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { findWorkflowActionForRoute } from "@/lib/workflow-route-match";
+import type { WorkflowAction, WorkflowLibrary } from "@/types";
+
+function action(actionId: string, routePrefixes: string[], routeContains: string[] = []): WorkflowAction {
+  return {
+    actionId,
+    label: actionId,
+    detail: `Detail for ${actionId}`,
+    targetPageTag: "Tag",
+    tone: "ready",
+    workItemKind: null,
+    routePrefixes,
+    routeContains,
+    aliases: []
+  };
+}
+
+const library: WorkflowLibrary = {
+  generatedAt: "2026-07-01T00:00:00Z",
+  workflows: [
+    {
+      workflowId: "reporting-delivery",
+      title: "Reporting Delivery",
+      summary: "Reporting workflows",
+      workspaceId: "reporting",
+      workspaceTitle: "Reporting",
+      entryPageTag: "Reporting",
+      tone: "ready",
+      actions: [
+        action("reporting.open", ["/reporting"]),
+        action("reporting.exports", ["/reporting/report-builder", "/reporting/exports"])
+      ],
+      evidenceTags: [],
+      marketPatternTags: []
+    },
+    {
+      workflowId: "accounting-close",
+      title: "Accounting Close",
+      summary: "Close workflows",
+      workspaceId: "accounting",
+      workspaceTitle: "Accounting",
+      entryPageTag: "Accounting",
+      tone: "ready",
+      actions: [action("accounting.recon", [], ["reconciliation"])],
+      evidenceTags: [],
+      marketPatternTags: []
+    }
+  ]
+} as WorkflowLibrary;
+
+describe("findWorkflowActionForRoute", () => {
+  it("picks the longest matching route prefix", () => {
+    const match = findWorkflowActionForRoute(library, "/reporting/report-builder");
+    expect(match?.action.actionId).toBe("reporting.exports");
+    expect(match?.workflow.workflowId).toBe("reporting-delivery");
+  });
+
+  it("falls back to shorter prefixes and contains matches", () => {
+    expect(findWorkflowActionForRoute(library, "/reporting/evidence")?.action.actionId).toBe("reporting.open");
+    expect(findWorkflowActionForRoute(library, "/accounting/reconciliation/match")?.action.actionId).toBe(
+      "accounting.recon"
+    );
+  });
+
+  it("returns null without a library or a match", () => {
+    expect(findWorkflowActionForRoute(null, "/reporting")).toBeNull();
+    expect(findWorkflowActionForRoute(library, "/settings")).toBeNull();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/lib/workflow-route-match.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/workflow-route-match.test.ts
@@ -63,6 +63,13 @@ describe("findWorkflowActionForRoute", () => {
     );
   });
 
+  it("does not match sibling routes that merely share a string prefix", () => {
+    expect(findWorkflowActionForRoute(library, "/reporting-sibling")).toBeNull();
+    expect(findWorkflowActionForRoute(library, "/reporting/report-builder-archive")?.action.actionId).not.toBe(
+      "reporting.exports"
+    );
+  });
+
   it("returns null without a library or a match", () => {
     expect(findWorkflowActionForRoute(null, "/reporting")).toBeNull();
     expect(findWorkflowActionForRoute(library, "/settings")).toBeNull();

--- a/src/Meridian.Ui/dashboard/src/lib/workflow-route-match.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/workflow-route-match.ts
@@ -1,0 +1,56 @@
+// Resolves which workflow action owns a workstation route, so saved views can
+// attach to the existing workflow preset system. Longest route-prefix match wins.
+import type { WorkflowAction, WorkflowDefinition, WorkflowLibrary } from "@/types";
+
+export interface WorkflowRouteMatch {
+  workflow: WorkflowDefinition;
+  action: WorkflowAction;
+}
+
+export function findWorkflowActionForRoute(
+  workflowLibrary: WorkflowLibrary | null | undefined,
+  pathname: string
+): WorkflowRouteMatch | null {
+  if (!workflowLibrary || !pathname) {
+    return null;
+  }
+
+  let best: { match: WorkflowRouteMatch; specificity: number } | null = null;
+  for (const workflow of workflowLibrary.workflows) {
+    for (const action of workflow.actions) {
+      const specificity = routeMatchSpecificity(action, pathname);
+      if (specificity > (best?.specificity ?? 0)) {
+        best = { match: { workflow, action }, specificity };
+      }
+    }
+  }
+
+  return best?.match ?? null;
+}
+
+function routeMatchSpecificity(action: WorkflowAction, pathname: string): number {
+  const prefixes = action.routePrefixes ?? [];
+  let specificity = 0;
+  for (const prefix of prefixes) {
+    const normalized = prefix.trim();
+    if (!normalized) {
+      continue;
+    }
+
+    if (pathname === normalized || pathname.startsWith(`${normalized.replace(/\/$/, "")}/`)) {
+      specificity = Math.max(specificity, normalized.length);
+    } else if (pathname.startsWith(normalized)) {
+      specificity = Math.max(specificity, normalized.length);
+    }
+  }
+
+  for (const fragment of action.routeContains ?? []) {
+    const contains = fragment.trim();
+    if (contains && pathname.includes(contains)) {
+      // Substring matches are weaker than any prefix match of the same length.
+      specificity = Math.max(specificity, Math.max(1, contains.length - 1));
+    }
+  }
+
+  return specificity;
+}

--- a/src/Meridian.Ui/dashboard/src/lib/workflow-route-match.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/workflow-route-match.ts
@@ -32,14 +32,13 @@ function routeMatchSpecificity(action: WorkflowAction, pathname: string): number
   const prefixes = action.routePrefixes ?? [];
   let specificity = 0;
   for (const prefix of prefixes) {
-    const normalized = prefix.trim();
+    const normalized = prefix.trim().replace(/\/$/, "");
     if (!normalized) {
       continue;
     }
 
-    if (pathname === normalized || pathname.startsWith(`${normalized.replace(/\/$/, "")}/`)) {
-      specificity = Math.max(specificity, normalized.length);
-    } else if (pathname.startsWith(normalized)) {
+    // Segment-boundary match only: "/reporting/report" must not claim "/reporting/report-builder".
+    if (pathname === normalized || pathname.startsWith(`${normalized}/`)) {
       specificity = Math.max(specificity, normalized.length);
     }
   }

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.close-cockpit-panels.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.close-cockpit-panels.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
+import { FreshnessChip } from "@/components/ui/freshness-chip";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { accountingToolingBadgeVariant, accountingToolingBorderClass } from "@/screens/accounting-screen.styles";
@@ -14,6 +15,8 @@ import type {
   AccountingWorkflowLaunchViewState,
   CloseCommandCenterViewState
 } from "@/screens/accounting-screen.view-model";
+
+export const CLOSE_COCKPIT_FRESHNESS_BUDGET_MS = 15 * 60_000;
 
 const accountingWorkflowStepIcons: Record<AccountingWorkflowLaunchViewState["steps"][number]["id"], typeof ShieldCheck> = {
   ledger: Table2,
@@ -151,6 +154,12 @@ export function CloseCommandCenterPanel({
             <div className="grid gap-2 text-sm">
               <CloseCommandCenterValue label="Fund account" value={view.fundAccountLabel} />
               <CloseCommandCenterValue label="Updated" value={view.updatedLabel} />
+              <FreshnessChip
+                className="w-fit"
+                label="Close command center"
+                staleBudgetMs={CLOSE_COCKPIT_FRESHNESS_BUDGET_MS}
+                timestamp={view.updatedAtUtc}
+              />
             </div>
           </div>
         </CardHeader>

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.close-cockpit.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.close-cockpit.view-model.test.ts
@@ -2262,6 +2262,7 @@ describe("accounting-screen close-cockpit view model", () => {
       "/accounting/approvals",
       "/reporting/evidence"
     ]);
+    expect(state.updatedAtUtc).toBe(closeWorkflow.updatedAtUtc);
   });
 
   it("marks the controller close command center ready only when all close signals clear", () => {

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.close-cockpit.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.close-cockpit.view-model.ts
@@ -3174,6 +3174,7 @@ export function buildCloseCommandCenterViewState({
     fundAccountLabel: workflow?.fundAccountId ?? multiAssetCoverage?.fundAccountId ?? "All accounts",
     summary: buildCloseCommandCenterSummary(status, metricRows, workflowError),
     updatedLabel,
+    updatedAtUtc: workflow?.updatedAtUtc ?? accountingSystemReconciliation?.generatedAtUtc ?? multiAssetCoverage?.asOfUtc ?? null,
     metricRows,
     blockerRows,
     actionRows: [
@@ -3343,6 +3344,7 @@ function buildSharedFinancialOperationsCommandCenterViewState(
     fundAccountLabel: commandCenter.fundAccountId ?? commandCenter.fundProfileId ?? "All accounts",
     summary: errorText ? `${closeSupportDecision?.summary ?? commandCenter.summary} ${errorText}` : closeSupportDecision?.summary ?? commandCenter.summary,
     updatedLabel: commandCenter.generatedAtUtc,
+    updatedAtUtc: commandCenter.generatedAtUtc ?? null,
     metricRows,
     blockerRows,
     actionRows,

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.view-model.ts
@@ -2451,6 +2451,7 @@ export interface CloseCommandCenterViewState {
   fundAccountLabel: string;
   summary: string;
   updatedLabel: string;
+  updatedAtUtc: string | null;
   metricRows: CloseCommandCenterMetricViewModel[];
   blockerRows: CloseCommandCenterBlockerViewModel[];
   actionRows: CloseCommandCenterActionViewModel[];

--- a/src/Meridian.Ui/dashboard/src/screens/data-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/data-screen.view-model.ts
@@ -1009,6 +1009,7 @@ const idleBackfillRequestStatus: RequestLifecycleStatus = {
   error: null,
   startedAt: null,
   settledAt: null,
+  lastSucceededAt: null,
   staleDiscardCount: 0,
   backoff: { attempt: 0, retryCount: 0, nextRetryDelayMs: null, maxRetries: 0 }
 };
@@ -1022,6 +1023,7 @@ const idleDataUploadRequestStatus: RequestLifecycleStatus = {
   error: null,
   startedAt: null,
   settledAt: null,
+  lastSucceededAt: null,
   staleDiscardCount: 0,
   backoff: { attempt: 0, retryCount: 0, nextRetryDelayMs: null, maxRetries: 0 }
 };

--- a/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.test.tsx
@@ -1144,6 +1144,15 @@ describe("LiveQuotesScreen quick trade", () => {
     vi.restoreAllMocks();
   });
 
+  it("shows freshness chips for the market panels and quote matrix after data loads", async () => {
+    renderWithRouter(<LiveQuotesScreen />, { initialEntries: ["/data/quotes?symbol=AAPL"] });
+
+    await waitForAsyncEffects();
+
+    expect(screen.getByLabelText(/Market panels updated/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Quote matrix updated/)).toBeInTheDocument();
+  });
+
   it("seeds a buy ticket at the ask price when ask is clicked and submits", async () => {
     const submitSpy = vi.spyOn(api, "submitOrder").mockResolvedValue({
       success: true,

--- a/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.tsx
@@ -22,6 +22,8 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { FieldSupportText, joinDescribedByIds } from "@/components/ui/field-support";
+import { FreshnessChip } from "@/components/ui/freshness-chip";
+import { freshnessInputFromLifecycle } from "@/components/ui/freshness-chip.view-model";
 import { EmptyState } from "@/components/data/empty-state";
 import { HistoricalChartCard } from "@/components/meridian/historical-chart";
 import { DepthChart } from "@/components/charts";
@@ -32,6 +34,7 @@ import { getLiveOrderbook, getLiveQuote, getLiveQuotesSnapshot, getLiveTrades, s
 import { cn } from "@/lib/utils";
 import {
   computeIntradayMetrics,
+  LIVE_QUOTES_FRESHNESS_BUDGET_MS,
   useLiveQuotesScreenViewModel,
   type LiveMarketDataCommandId,
   type LiveMarketDataWorkspaceViewModel,
@@ -192,6 +195,12 @@ export function LiveQuotesScreen() {
             <span className="font-semibold text-foreground">{workspaceVm.symbolSetLabel}</span>
             {marketVm.venueLabel ? <Badge variant="outline">{marketVm.venueLabel}</Badge> : null}
             {marketVm.stale ? <Badge variant="warning">Stale</Badge> : null}
+            <FreshnessChip
+              {...freshnessInputFromLifecycle(vm.requestStatus.market, LIVE_QUOTES_FRESHNESS_BUDGET_MS, "Market panels")}
+            />
+            <FreshnessChip
+              {...freshnessInputFromLifecycle(vm.requestStatus.snapshot, LIVE_QUOTES_FRESHNESS_BUDGET_MS, "Quote matrix")}
+            />
             {activeSymbol ? <span>Selected {activeSymbol}; last update {marketVm.lastUpdateLabel}</span> : null}
           </div>
         </CardContent>

--- a/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.view-model.ts
@@ -17,6 +17,7 @@ import type {
 } from "@/types";
 
 export const LIVE_QUOTES_POLL_INTERVAL_MS = 2000;
+export const LIVE_QUOTES_FRESHNESS_BUDGET_MS = 2 * LIVE_QUOTES_POLL_INTERVAL_MS;
 export const LIVE_QUOTES_TRADE_HISTORY_LIMIT = 200;
 export const LIVE_QUOTES_TRADE_TABLE_LIMIT = 25;
 export const LIVE_QUOTES_EMPTY_VALUE = "—";
@@ -502,6 +503,7 @@ const idleOrderSubmissionStatus: RequestLifecycleStatus = {
   error: null,
   startedAt: null,
   settledAt: null,
+  lastSucceededAt: null,
   staleDiscardCount: 0,
   backoff: { attempt: 0, retryCount: 0, nextRetryDelayMs: null, maxRetries: 0 }
 };

--- a/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.test.tsx
@@ -380,6 +380,31 @@ describe("PortfolioScreen", () => {
     expect(screen.getByText(/\$18,900 exposure with \+\$90 unrealized p&l/i)).toBeDefined();
   });
 
+  it("shows a workspace freshness chip when a refresh status is provided", async () => {
+    await renderPortfolioScreen(
+      <PortfolioScreen
+        trading={trading}
+        strategy={strategy}
+        accounting={accounting}
+        refreshStatus={{
+          operation: "portfolio refresh",
+          phase: "succeeded",
+          inFlight: false,
+          version: 1,
+          message: "Refresh complete.",
+          error: null,
+          startedAt: new Date().toISOString(),
+          settledAt: new Date().toISOString(),
+          lastSucceededAt: new Date().toISOString(),
+          staleDiscardCount: 0,
+          backoff: { attempt: 1, retryCount: 0, nextRetryDelayMs: null, maxRetries: 0 }
+        }}
+      />
+    );
+
+    expect(screen.getByLabelText(/Portfolio workspace updated/)).toBeInTheDocument();
+  });
+
   it("renders positions and runs from the Portfolio workspace payload when available", async () => {
     await renderPortfolioScreen(
       <PortfolioScreen portfolio={portfolio} trading={trading} strategy={strategy} accounting={accounting} />

--- a/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.tsx
@@ -5,6 +5,9 @@ import { Link, useLocation } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { FreshnessChip } from "@/components/ui/freshness-chip";
+import { freshnessInputFromLifecycle } from "@/components/ui/freshness-chip.view-model";
+import type { RequestLifecycleStatus } from "@/hooks/use-request-lifecycle";
 import {
   FinancialRecordExplorerShell,
   type FinancialRecordExplorerAction,
@@ -58,7 +61,10 @@ interface PortfolioScreenProps {
   brokerageConnection?: BrokerageConnectionStatus | null;
   brokeragePortfolio?: BrokerageHouseholdPortfolio | null;
   multiAssetCoverage?: MultiAssetCoverageSummary | null;
+  refreshStatus?: RequestLifecycleStatus | null;
 }
+
+export const PORTFOLIO_FRESHNESS_BUDGET_MS = 5 * 60_000;
 
 const pnlToneClass = {
   success: "text-success",
@@ -274,7 +280,8 @@ export function PortfolioScreen({
   accounting,
   brokerageConnection,
   brokeragePortfolio,
-  multiAssetCoverage
+  multiAssetCoverage,
+  refreshStatus
 }: PortfolioScreenProps) {
   const location = useLocation();
   const brokerageAccountButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
@@ -497,6 +504,11 @@ export function PortfolioScreen({
           </p>
         </div>
         <div className="flex flex-wrap items-center justify-end gap-2">
+          {refreshStatus ? (
+            <FreshnessChip
+              {...freshnessInputFromLifecycle(refreshStatus, PORTFOLIO_FRESHNESS_BUDGET_MS, "Portfolio workspace")}
+            />
+          ) : null}
           {vm.headerChips.map((chip) => (
             <PortfolioChip key={chip.label} label={chip.label} value={chip.value} />
           ))}

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx
@@ -1540,6 +1540,7 @@ describe("ReportingScreen", () => {
     expect(fundView).toHaveTextContent("Shadow NAV");
     expect(fundView).toHaveTextContent("$3,650");
     expect(fundView).toHaveTextContent("Freshness: LiveLinked · cut=2026-04-11T16:00:00Z · source=2026-04-11T15:58:00Z");
+    expect(within(fundView).getByLabelText(/Consolidated fund source data/)).toBeInTheDocument();
     expect(fundView).toHaveTextContent("Market tick: linked · provider=portfolio-summary-live · age=120s · seq=1775923080000 · tick=2026-04-11T15:58:00Z");
     expect(fundView).toHaveTextContent("Policy: LivePortfolioView · evaluated=2026-04-11T16:00:00Z · sourceAge=120s · liveWindow=300s · staleWindow=86400s");
     expect(fundView).toHaveTextContent("Source age is 120 second(s), inside the 5-minute live-link window.");

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event";
 import { ReportingScreen } from "@/screens/reporting-screen";
 import { getCommandPaletteActionsSnapshot } from "@/components/meridian/command-palette.actions";
+import { encodeViewStateEnvelope } from "@/lib/view-state-envelope";
 import { renderWithRouter } from "@/test/render";
 import type { AccountingWorkspaceResponse, FinancialRecordExplorerDto, ReportingTemplateMetadata } from "@/types";
 
@@ -1674,6 +1675,46 @@ describe("ReportingScreen", () => {
 
     const fundRow = screen.getByRole("listitem", { name: "fund-alpha Fund cross-fund consolidation" });
     expect(fundRow).toHaveTextContent("cross-fund:20260411160000:funds-1:entities-1:sources-3");
+  });
+
+  it("hydrates the exports draft from a valid view-state link", () => {
+    const token = encodeViewStateEnvelope({
+      v: 1,
+      screen: "reporting-exports",
+      state: { selectedExportsTemplateId: "investor-monthly-statement:1.0.0", asOfDate: "2026-06-30" }
+    })!;
+
+    renderWithRouter(<ReportingScreen data={accounting} />, {
+      initialEntries: [`/reporting/report-builder?view=${token}`]
+    });
+
+    expect(screen.getByLabelText("Exports report as-of date")).toHaveValue("2026-06-30");
+    expect(screen.getByLabelText("Exports report template")).toHaveValue("investor-monthly-statement:1.0.0");
+  });
+
+  it("ignores view-state links for unknown templates or foreign screens", () => {
+    const unknownTemplate = encodeViewStateEnvelope({
+      v: 1,
+      screen: "reporting-exports",
+      state: { selectedExportsTemplateId: "not-a-real-template:9.9.9", asOfDate: "2026-06-30" }
+    })!;
+
+    const { unmount } = renderWithRouter(<ReportingScreen data={accounting} />, {
+      initialEntries: [`/reporting/report-builder?view=${unknownTemplate}`]
+    });
+    expect(screen.getByLabelText("Exports report as-of date")).not.toHaveValue("2026-06-30");
+    unmount();
+
+    const foreignScreen = encodeViewStateEnvelope({
+      v: 1,
+      screen: "trial-balance",
+      state: { selectedExportsTemplateId: "investor-monthly-statement:1.0.0", asOfDate: "2026-06-30" }
+    })!;
+
+    renderWithRouter(<ReportingScreen data={accounting} />, {
+      initialEntries: [`/reporting/report-builder?view=${foreignScreen}`]
+    });
+    expect(screen.getByLabelText("Exports report as-of date")).not.toHaveValue("2026-06-30");
   });
 
   it("registers the exports-run palette action while mounted and unregisters on unmount", () => {

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ReportingScreen } from "@/screens/reporting-screen";
+import { getCommandPaletteActionsSnapshot } from "@/components/meridian/command-palette.actions";
 import { renderWithRouter } from "@/test/render";
 import type { AccountingWorkspaceResponse, FinancialRecordExplorerDto, ReportingTemplateMetadata } from "@/types";
 
@@ -1673,6 +1674,22 @@ describe("ReportingScreen", () => {
 
     const fundRow = screen.getByRole("listitem", { name: "fund-alpha Fund cross-fund consolidation" });
     expect(fundRow).toHaveTextContent("cross-fund:20260411160000:funds-1:entities-1:sources-3");
+  });
+
+  it("registers the exports-run palette action while mounted and unregisters on unmount", () => {
+    const { unmount } = renderWithRouter(<ReportingScreen data={accounting} />, {
+      initialEntries: ["/reporting/report-builder"]
+    });
+
+    const registered = getCommandPaletteActionsSnapshot().find((item) => item.id === "reporting-run-exports");
+    expect(registered).toBeDefined();
+    expect(registered?.confirm).toBe(true);
+    expect(registered?.verbLabel).toMatch(/^Run exports report: /);
+
+    unmount();
+    expect(
+      getCommandPaletteActionsSnapshot().some((item) => item.id === "reporting-run-exports")
+    ).toBe(false);
   });
 
   it("renders structured exports from the shared reporting payload", () => {

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
@@ -1,6 +1,6 @@
 import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
 import { FileText, Landmark, Network, PencilLine, RotateCcw, XCircle } from "lucide-react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -8,6 +8,12 @@ import { FreshnessChip } from "@/components/ui/freshness-chip";
 import { Select } from "@/components/ui/select";
 import { SeverityBadge } from "@/components/operations";
 import { registerCommandPaletteActions } from "@/components/meridian/command-palette.actions";
+import {
+  encodeViewStateEnvelope,
+  readViewStateFromSearch,
+  stripViewStateFromSearch,
+  VIEW_STATE_QUERY_KEY
+} from "@/lib/view-state-envelope";
 import { FinancialRecordExplorerShell } from "@/components/meridian/financial-record-explorer";
 import { MetricSnapshotCard } from "@/components/meridian/metric-card";
 import { ReportingPeriodSwitcher } from "@/components/meridian/reporting-period-switcher";
@@ -150,6 +156,8 @@ const reportingStatusFromVariant: Record<
 const livePortfolioAutoRefreshIntervalMs = 60_000;
 const LIVE_PORTFOLIO_FRESHNESS_BUDGET_MS = 2 * livePortfolioAutoRefreshIntervalMs;
 const defaultExportsReportRunRequester = "browser-workstation";
+const EXPORTS_VIEW_STATE_SCREEN = "reporting-exports";
+const exportsViewReflectDebounceMs = 300;
 const reportingProfileColumns: DenseDataTableColumn<ReportingProfileRow>[] = [
   {
     id: "profile",
@@ -194,7 +202,8 @@ const reportingProfileColumns: DenseDataTableColumn<ReportingProfileRow>[] = [
 ];
 
 export function ReportingScreen({ data, onRefreshLivePortfolioViews }: ReportingScreenProps) {
-  const { pathname } = useLocation();
+  const { pathname, search } = useLocation();
+  const navigate = useNavigate();
   const vm = useReportingScreenViewModel(data?.reporting ?? null, undefined, pathname);
   const hubModel = useMemo(
     () => buildReportingHubModel(vm.runStatusRows, vm.templateRows, data?.reporting?.dailyWork ?? []),
@@ -315,6 +324,66 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
     });
   }, [data?.reporting, templateRowsKey]);
 
+  const exportsViewHydratedRef = useRef(false);
+  useEffect(() => {
+    if (exportsViewHydratedRef.current || vm.templateRows.length === 0) {
+      return;
+    }
+
+    exportsViewHydratedRef.current = true;
+    const envelope = readViewStateFromSearch(search, EXPORTS_VIEW_STATE_SCREEN);
+    if (!envelope) {
+      return;
+    }
+
+    const templateRowId = typeof envelope.state.selectedExportsTemplateId === "string"
+      ? envelope.state.selectedExportsTemplateId
+      : null;
+    const asOfDate = typeof envelope.state.asOfDate === "string" ? envelope.state.asOfDate : null;
+    const template = templateRowId ? vm.templateRows.find((row) => row.id === templateRowId) : null;
+    if (!template || !template.canRunOnDemand) {
+      return;
+    }
+
+    setExportsRunDraft((current) => ({
+      ...current,
+      templateRowId: template.id,
+      asOfDate: asOfDate ?? current.asOfDate
+    }));
+  }, [search, templateRowsKey, vm.templateRows]);
+
+  const reflectExportsViewTimer = useRef<number | null>(null);
+  useEffect(() => () => {
+    if (reflectExportsViewTimer.current !== null) {
+      window.clearTimeout(reflectExportsViewTimer.current);
+    }
+  }, []);
+
+  function reflectExportsViewState(nextDraft: ExportsReportRunDraftState) {
+    if (reflectExportsViewTimer.current !== null) {
+      window.clearTimeout(reflectExportsViewTimer.current);
+    }
+
+    reflectExportsViewTimer.current = window.setTimeout(() => {
+      reflectExportsViewTimer.current = null;
+      const template = resolveSelectedExportsTemplate(vm.templateRows, nextDraft);
+      const token = template
+        ? encodeViewStateEnvelope({
+            v: 1,
+            screen: EXPORTS_VIEW_STATE_SCREEN,
+            state: { selectedExportsTemplateId: template.id, asOfDate: nextDraft.asOfDate }
+          })
+        : null;
+      if (!token) {
+        return;
+      }
+
+      const params = new URLSearchParams(stripViewStateFromSearch(search));
+      params.set(VIEW_STATE_QUERY_KEY, token);
+      navigate(`${pathname}?${params.toString()}`, { replace: true });
+    }, exportsViewReflectDebounceMs);
+  }
+
   function handleReportPackProfileKeyDown(event: KeyboardEvent<HTMLDivElement>) {
     const command = resolveReportPackProfileKeyCommand(event.key);
     if (!command) {
@@ -385,10 +454,11 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
   }
 
   function updateExportsReportRunDraft(field: ExportsReportRunDraftField, value: string) {
-    setExportsRunDraft((current) => ({
-      ...current,
-      [field]: value
-    }));
+    setExportsRunDraft((current) => {
+      const next = { ...current, [field]: value };
+      reflectExportsViewState(next);
+      return next;
+    });
   }
 
   async function handleExportsReportRun() {

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { FreshnessChip } from "@/components/ui/freshness-chip";
 import { Select } from "@/components/ui/select";
 import { SeverityBadge } from "@/components/operations";
+import { registerCommandPaletteActions } from "@/components/meridian/command-palette.actions";
 import { FinancialRecordExplorerShell } from "@/components/meridian/financial-record-explorer";
 import { MetricSnapshotCard } from "@/components/meridian/metric-card";
 import { ReportingPeriodSwitcher } from "@/components/meridian/reporting-period-switcher";
@@ -401,6 +402,38 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
       "Exports report run"
     );
   }
+
+  const handleExportsReportRunRef = useRef(handleExportsReportRun);
+  handleExportsReportRunRef.current = handleExportsReportRun;
+
+  useEffect(() => {
+    if (!selectedExportsTemplate) {
+      return;
+    }
+
+    const disabled = !selectedExportsTemplate.canRunOnDemand || Boolean(runningTemplateRunId);
+    return registerCommandPaletteActions("reporting-screen", [
+      {
+        id: "reporting-run-exports",
+        verbLabel: `Run exports report: ${selectedExportsTemplate.name}`,
+        description: "Start the selected on-demand exports report run with the drafted as-of date.",
+        keywords: ["report", "export", "run"],
+        confirm: true,
+        disabled,
+        disabledReason: runningTemplateRunId
+          ? "A template run is already in progress."
+          : selectedExportsTemplate.runDisabledReason,
+        run: async () => {
+          await handleExportsReportRunRef.current();
+          return {
+            title: `${selectedExportsTemplate.name} run requested.`,
+            detail: "Track progress under Reporting exports run status.",
+            tone: "success" as const
+          };
+        }
+      }
+    ]);
+  }, [runningTemplateRunId, selectedExportsTemplate]);
 
   async function executeTemplateRun(
     template: ReportingTemplateRow,

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
@@ -374,13 +374,16 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
             state: { selectedExportsTemplateId: template.id, asOfDate: nextDraft.asOfDate }
           })
         : null;
-      if (!token) {
-        return;
+
+      // When the state cannot encode, strip any carried token so a stale view
+      // param never lingers in the shareable URL.
+      const params = new URLSearchParams(stripViewStateFromSearch(search));
+      if (token) {
+        params.set(VIEW_STATE_QUERY_KEY, token);
       }
 
-      const params = new URLSearchParams(stripViewStateFromSearch(search));
-      params.set(VIEW_STATE_QUERY_KEY, token);
-      navigate(`${pathname}?${params.toString()}`, { replace: true });
+      const nextSearch = params.toString();
+      navigate(nextSearch ? `${pathname}?${nextSearch}` : pathname, { replace: true });
     }, exportsViewReflectDebounceMs);
   }
 

--- a/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx
@@ -4,6 +4,7 @@ import { useLocation } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { FreshnessChip } from "@/components/ui/freshness-chip";
 import { Select } from "@/components/ui/select";
 import { SeverityBadge } from "@/components/operations";
 import { FinancialRecordExplorerShell } from "@/components/meridian/financial-record-explorer";
@@ -146,6 +147,7 @@ const reportingStatusFromVariant: Record<
   research: "Info"
 };
 const livePortfolioAutoRefreshIntervalMs = 60_000;
+const LIVE_PORTFOLIO_FRESHNESS_BUDGET_MS = 2 * livePortfolioAutoRefreshIntervalMs;
 const defaultExportsReportRunRequester = "browser-workstation";
 const reportingProfileColumns: DenseDataTableColumn<ReportingProfileRow>[] = [
   {
@@ -1193,8 +1195,13 @@ export function ReportingScreen({ data, onRefreshLivePortfolioViews }: Reporting
                     <p className="mt-2 break-all font-mono text-[11px] text-muted-foreground">
                       {view.sourceCount} source{view.sourceCount === 1 ? "" : "s"} · {view.sourceAsOfUtc ?? view.asOf}
                     </p>
-                    <p className="mt-1 break-all font-mono text-[11px] text-muted-foreground">
-                      Freshness: {view.state} · cut={view.asOf} · source={view.sourceAsOfUtc ?? "unavailable"}
+                    <p className="mt-1 flex flex-wrap items-center gap-2 break-all font-mono text-[11px] text-muted-foreground">
+                      <span>Freshness: {view.state} · cut={view.asOf} · source={view.sourceAsOfUtc ?? "unavailable"}</span>
+                      <FreshnessChip
+                        label={`${view.label} source data`}
+                        staleBudgetMs={LIVE_PORTFOLIO_FRESHNESS_BUDGET_MS}
+                        timestamp={view.sourceAsOfUtc ?? null}
+                      />
                     </p>
                     <p className="mt-1 break-all font-mono text-[11px] text-muted-foreground">
                       Market tick: {view.isMarketTickLinked ? "linked" : "snapshot"} · provider={view.marketDataProvider ?? "unavailable"} · age={view.marketTickAgeSeconds ?? "n/a"}s · seq={view.marketTickSequence ?? "n/a"} · tick={view.marketTickAsOfUtc ?? view.sourceAsOfUtc ?? "unavailable"}

--- a/src/Meridian.Ui/dashboard/src/screens/trading-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/trading-screen.view-model.ts
@@ -508,6 +508,7 @@ const idleTradingReadinessStatus: RequestLifecycleStatus = {
   error: null,
   startedAt: null,
   settledAt: null,
+  lastSucceededAt: null,
   staleDiscardCount: 0,
   backoff: { attempt: 0, retryCount: 0, nextRetryDelayMs: null, maxRetries: 0 }
 };
@@ -521,6 +522,7 @@ const idleExecutionEvidenceStatus: RequestLifecycleStatus = {
   error: null,
   startedAt: null,
   settledAt: null,
+  lastSucceededAt: null,
   staleDiscardCount: 0,
   backoff: { attempt: 0, retryCount: 0, nextRetryDelayMs: null, maxRetries: 0 }
 };

--- a/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.test.tsx
@@ -159,6 +159,14 @@ describe("WatchlistScreen", () => {
     expect(vi.mocked(api.getLiveQuotesSnapshot).mock.calls[0]?.[0]).toEqual(["MSFT", "AAPL"]);
   });
 
+  it("shows a freshness chip once live quotes have loaded", async () => {
+    renderWithRouter(<WatchlistScreen />, { initialEntries: ["/data/watchlist"] });
+
+    await screen.findByText(/Live prices for 2 symbols/i, undefined, fullSuiteTimeout);
+
+    expect(screen.getByLabelText(/Watchlist quotes updated/)).toBeInTheDocument();
+  });
+
   it("lets operators manually refresh live quotes", async () => {
     const user = userEvent.setup();
     renderWithRouter(<WatchlistScreen />, { initialEntries: ["/data/watchlist"] });

--- a/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.tsx
@@ -15,8 +15,10 @@ import {
   removeSymbol as removeSymbolApi
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
+import { FreshnessChip } from "@/components/ui/freshness-chip";
 import {
   useWatchlistScreenViewModel,
+  WATCHLIST_QUOTE_FRESHNESS_BUDGET_MS,
   type WatchlistDetailFieldTone,
   type WatchlistRowViewModel,
   type WatchlistSelectedDetail,
@@ -253,7 +255,15 @@ export function WatchlistScreen() {
                 className={`flex flex-col gap-3 rounded-md border px-4 py-3 text-sm sm:flex-row sm:items-center sm:justify-between ${quoteStatusClass[vm.quoteStatusTone]}`}
               >
                 <div className="min-w-0">
-                  <div>{vm.quoteStatusLabel}</div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span>{vm.quoteStatusLabel}</span>
+                    <FreshnessChip
+                      errorMessage={vm.quoteFreshnessError}
+                      label="Watchlist quotes"
+                      staleBudgetMs={WATCHLIST_QUOTE_FRESHNESS_BUDGET_MS}
+                      timestamp={vm.quoteFreshnessTimestamp}
+                    />
+                  </div>
                   {vm.quoteStatusDetails.length > 0 ? (
                     <ul className="mt-2 list-disc space-y-1 pl-5 text-xs leading-5">
                       {vm.quoteStatusDetails.map((detail) => (

--- a/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.view-model.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ApiRequestOptions } from "@/lib/api";
 import { describeApiError, type ApiErrorDisplay } from "@/lib/api-errors";
+import { formatRelativeAge as formatRelative } from "@/lib/time";
 import { WORKSTATION_ROUTE_CATALOG, workstationRouteWithQuery } from "@/lib/workspace";
 import type { MetricSnapshot, QuotesSnapshotItem, SymbolRecord, SymbolStatistics } from "@/types";
 
@@ -32,6 +33,7 @@ const STATUS_RANK: Record<SymbolRecord["status"], number> = {
 };
 
 const QUOTE_POLL_INTERVAL_MS = 2000;
+export const WATCHLIST_QUOTE_FRESHNESS_BUDGET_MS = 2 * QUOTE_POLL_INTERVAL_MS;
 const QUOTE_STALE_THRESHOLD_MS = 15_000;
 export const WATCHLIST_EMPTY_VALUE = "—";
 export const WATCHLIST_NO_QUOTE_LABEL = "No quote";
@@ -218,6 +220,8 @@ export interface WatchlistScreenViewModel {
   quoteStatusLabel: string;
   quoteStatusTone: WatchlistQuoteStatusTone;
   quoteStatusDetails: string[];
+  quoteFreshnessTimestamp: string | null;
+  quoteFreshnessError: string | null;
   quoteProviderSetupHandoff: WatchlistProviderSetupHandoff | null;
   quoteRefreshCommand: WatchlistQuoteRefreshCommandState;
   starterPackGroupLabel: string;
@@ -663,6 +667,8 @@ export function useWatchlistScreenViewModel(api: WatchlistApi): WatchlistScreenV
     quoteStatusLabel: quoteStatus.label,
     quoteStatusTone: quoteStatus.tone,
     quoteStatusDetails: quoteStatus.details,
+    quoteFreshnessTimestamp: quoteFetchedAt ? new Date(quoteFetchedAt).toISOString() : null,
+    quoteFreshnessError: quoteError?.summary ?? null,
     quoteProviderSetupHandoff: quoteError ? buildProviderSetupHandoff("live-quotes") : null,
     quoteRefreshCommand: buildQuoteRefreshCommand(listState, rows.length, quoteRefreshing),
     starterPackGroupLabel: "Watchlist starter packs",
@@ -917,39 +923,7 @@ export function buildWatchlistStats(stats: SymbolStatistics | null): MetricSnaps
   ];
 }
 
-export function formatRelative(iso: string | null, now = Date.now()): string {
-  if (!iso) {
-    return "Never";
-  }
-
-  const timestamp = new Date(iso).getTime();
-  if (Number.isNaN(timestamp)) {
-    return "Never";
-  }
-
-  const diff = now - timestamp;
-  if (diff < 0) {
-    return new Date(iso).toLocaleString();
-  }
-
-  const seconds = Math.round(diff / 1000);
-  if (seconds < 60) {
-    return `${seconds}s ago`;
-  }
-
-  const minutes = Math.round(seconds / 60);
-  if (minutes < 60) {
-    return `${minutes}m ago`;
-  }
-
-  const hours = Math.round(minutes / 60);
-  if (hours < 24) {
-    return `${hours}h ago`;
-  }
-
-  const days = Math.round(hours / 24);
-  return `${days}d ago`;
-}
+export { formatRelativeAge as formatRelative } from "@/lib/time";
 
 export function validatePendingSymbol(value: string): string | null {
   return parseWatchlistSymbols(value).length === 0 ? "Enter at least one symbol before adding it." : null;

--- a/src/Meridian.Ui/dashboard/src/types.ts
+++ b/src/Meridian.Ui/dashboard/src/types.ts
@@ -1058,6 +1058,7 @@ export interface WorkflowPreset {
   createdAt: string;
   updatedAt: string;
   lastUsedAt: string | null;
+  viewStateEnvelope?: string | null;
 }
 
 export interface WorkflowPresetLibrary {
@@ -1114,6 +1115,7 @@ export interface WorkflowPresetSaveRequest {
   actionId?: string | null;
   tags?: string[] | null;
   isPinned: boolean;
+  viewStateEnvelope?: string | null;
 }
 
 export type OperationsWorkflowStatus =

--- a/tests/Meridian.Tests/Ui/WorkflowLibraryEndpointTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkflowLibraryEndpointTests.cs
@@ -238,6 +238,138 @@ public sealed class WorkflowLibraryEndpointTests
     }
 
     [Fact]
+    public async Task MapWorkstationEndpoints_WorkflowPresets_ShouldRoundTripViewStateEnvelope()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "meridian-tests", "workflow-presets", Guid.NewGuid().ToString("N"));
+        await using var app = await CreateWorkflowPresetAppAsync(root);
+        var client = app.GetTestClient();
+
+        const string envelope = "eyJ2IjoxLCJzY3JlZW4iOiJyZXBvcnRpbmctZXhwb3J0cyIsInN0YXRlIjp7fX0";
+        var saveResponse = await client.PostAsJsonAsync(
+            "/api/workstation/workflows/presets",
+            new WorkflowPresetSaveRequest(
+                PresetId: "saved-view",
+                Name: "Saved view",
+                Description: null,
+                WorkflowId: "data-provider-recovery",
+                ActionId: null,
+                Tags: [],
+                IsPinned: false,
+                ViewStateEnvelope: envelope),
+            ServerJsonOptions);
+
+        saveResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var saved = await saveResponse.Content.ReadFromJsonAsync<WorkflowPresetDto>(ServerJsonOptions);
+        saved!.ViewStateEnvelope.Should().Be(envelope);
+
+        var pinResponse = await client.PostAsJsonAsync(
+            "/api/workstation/workflows/presets/saved-view/pin",
+            new WorkflowPresetPinRequest(true),
+            ServerJsonOptions);
+        var pinned = await pinResponse.Content.ReadFromJsonAsync<WorkflowPresetDto>(ServerJsonOptions);
+        pinned!.ViewStateEnvelope.Should().Be(envelope);
+
+        var usedResponse = await client.PostAsync("/api/workstation/workflows/presets/saved-view/used", content: null);
+        var used = await usedResponse.Content.ReadFromJsonAsync<WorkflowPresetDto>(ServerJsonOptions);
+        used!.ViewStateEnvelope.Should().Be(envelope);
+
+        var libraryResponse = await client.GetAsync("/api/workstation/workflows/presets");
+        var library = await libraryResponse.Content.ReadFromJsonAsync<WorkflowPresetLibraryDto>(ServerJsonOptions);
+        library!.Presets.Should().ContainSingle(preset =>
+            preset.PresetId == "saved-view" && preset.ViewStateEnvelope == envelope);
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_WorkflowPresets_ShouldDefaultViewStateEnvelopeToNull()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "meridian-tests", "workflow-presets", Guid.NewGuid().ToString("N"));
+        await using var app = await CreateWorkflowPresetAppAsync(root);
+        var client = app.GetTestClient();
+
+        var saveResponse = await client.PostAsJsonAsync(
+            "/api/workstation/workflows/presets",
+            new WorkflowPresetSaveRequest(
+                PresetId: "plain-preset",
+                Name: "Plain preset",
+                Description: null,
+                WorkflowId: "data-provider-recovery",
+                ActionId: null,
+                Tags: [],
+                IsPinned: false),
+            ServerJsonOptions);
+
+        saveResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var saved = await saveResponse.Content.ReadFromJsonAsync<WorkflowPresetDto>(ServerJsonOptions);
+        saved!.ViewStateEnvelope.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_WorkflowPresets_ShouldRejectOversizedViewStateEnvelope()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "meridian-tests", "workflow-presets", Guid.NewGuid().ToString("N"));
+        await using var app = await CreateWorkflowPresetAppAsync(root);
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/api/workstation/workflows/presets",
+            new WorkflowPresetSaveRequest(
+                PresetId: "oversized-view",
+                Name: "Oversized view",
+                Description: null,
+                WorkflowId: "data-provider-recovery",
+                ActionId: null,
+                Tags: [],
+                IsPinned: false,
+                ViewStateEnvelope: new string('v', 4097)),
+            ServerJsonOptions);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("cannot exceed 4096");
+    }
+
+    [Fact]
+    public async Task MapWorkstationEndpoints_WorkflowPresets_ShouldLoadLegacySnapshotsWithoutViewState()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "meridian-tests", "workflow-presets", Guid.NewGuid().ToString("N"));
+        var snapshotPath = Path.Combine(root, "workstation", "workflows", "workflow-presets.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(snapshotPath)!);
+        await File.WriteAllTextAsync(snapshotPath, """
+        {
+          "version": 1,
+          "presets": [
+            {
+              "presetId": "legacy-preset",
+              "name": "Legacy preset",
+              "description": null,
+              "workflowId": "data-provider-recovery",
+              "workflowTitle": "Data Provider Recovery",
+              "actionId": null,
+              "actionLabel": "Open workflow",
+              "workspaceId": "data",
+              "workspaceTitle": "Data",
+              "targetPageTag": "ProviderHealth",
+              "tags": [],
+              "isPinned": false,
+              "createdAt": "2026-06-01T00:00:00+00:00",
+              "updatedAt": "2026-06-01T00:00:00+00:00",
+              "lastUsedAt": null
+            }
+          ]
+        }
+        """);
+
+        await using var app = await CreateWorkflowPresetAppAsync(root);
+        var client = app.GetTestClient();
+
+        var libraryResponse = await client.GetAsync("/api/workstation/workflows/presets");
+        libraryResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var library = await libraryResponse.Content.ReadFromJsonAsync<WorkflowPresetLibraryDto>(ServerJsonOptions);
+        library!.Presets.Should().ContainSingle(preset =>
+            preset.PresetId == "legacy-preset" && preset.ViewStateEnvelope == null);
+    }
+
+    [Fact]
     public async Task MapWorkstationEndpoints_WorkflowPresets_ShouldRejectUnknownWorkflow()
     {
         var root = Path.Combine(Path.GetTempPath(), "meridian-tests", "workflow-presets", Guid.NewGuid().ToString("N"));


### PR DESCRIPTION
<!-- phase:PR7 -->
## Summary

Implements Phases 1–3 of the merged [Web UI Improvements Implementation Plan](../blob/main/docs/product/web-ui-improvements-implementation-plan-2026-07.md), one commit per phase:

**Phase 1 — Freshness chips** (`7f96d1c2`)
- Adds a success-only `lastSucceededAt` to `use-request-lifecycle.ts` (`settledAt` moves on any settle, including failures, so it can't answer "when did this data last load").
- New `FreshnessChip` primitive on `Badge` with fresh/aging/failing/live/unknown states, internal age tick, full-sentence `aria-label` (deliberately no `aria-live` — 2s-updating chips would spam screen readers). Shared relative-age formatter promoted from the watchlist VM to `lib/time.ts`.
- Adopted on five surfaces: live quotes market/matrix panels, watchlist quotes, portfolio workspace header, close command center (server `generatedAtUtc` path), reporting live-portfolio views.
- **Reviewer sign-off requested:** staleness budgets are 2× each surface's refresh cadence; the 5-minute portfolio and 15-minute close-cockpit budgets are judgment calls.

**Phase 2 — Command palette action verbs** (`ce933b2e`)
- New `action` item kind: a registry module (`command-palette.actions.ts`) lets screens contribute context-scoped verbs while mounted; the shell composes them with shell-level actions. Run handlers stay out of the view-model (resolved by id in the component).
- Inline two-step arm/confirm for consequential actions (Escape disarms without closing via a new `disarm-action` key command) — no nested Dialog inside the palette's focus containment. Results surface as toasts (`describeApiError` for failures); the palette is the first `ToastProvider` consumer by design and toast use stays scoped to shell chrome.
- Launch verbs: preset pin/unpin per preset, and the reporting screen's gated "Run exports report" (confirm required). Close-calendar creation was dropped as a verb — six required fields make it a form, not a verb — recorded in the plan doc.

**Phase 3 — Copy-link deep links + saved views** (`0e38060b`)
- Versioned view-state envelope serialized as one `view=<base64url(JSON)>` query param (`lib/view-state-envelope.ts`; unicode-safe, defensive decode, 2000-char cap); operating-scope query keys untouched. Table-state bridge helpers ship as the contract for later phases (no screen consumer yet — `useTableState` is currently unconsumed).
- `WorkspaceHeader` gains an `actions` slot with Copy-link and Save-view buttons. Copy-link copies `window.location.href` — every screen is shareable at scope granularity day one.
- Saved views ride the existing preset system: additive nullable `ViewStateEnvelope` on `WorkflowPresetDto`/`WorkflowPresetSaveRequest` (snapshot stays v1 — additive nullable is bidirectionally compatible under STJ Web defaults, documented beside `SnapshotVersion`), 4096-char server validation, token appended to preset routes in the palette when it decodes.
- Exemplar reflection/hydration on reporting exports: draft template + as-of date reflect into the URL on user edits (debounced, `replace` navigation); hydration re-validates template existence and `canRunOnDemand` — links are never trusted.

Phase 0 conventions (per the plan doc): localStorage keys `meridian.workstation.<feature>.vN`; route constants in `UiApiRoutes.cs` mirrored via `generate-ui-api-routes-ts.py` (no new routes were needed — presets reuse existing endpoints); endpoint tests on the in-proc `UseTestServer` harness.

## Reason

Executes the approved next slice of the browser-workstation improvement plan delivered by #2086: the three quick-win phases (brainstorm ideas #2, #3, #4), sequenced ahead of the SSE live-data spine.

## Testing performed

- [x] `npm --prefix src/Meridian.Ui/dashboard run test` — full suite green (22/22 batches), including new unit/component/keyboard/hydration tests per phase
- [x] `npm --prefix src/Meridian.Ui/dashboard run build` — typecheck + bundle clean
- [x] `dotnet test tests/Meridian.Tests --filter FullyQualifiedName~WorkflowLibraryEndpointTests` — 12/12 (envelope round-trip, null default, >4096 → 400, legacy v1 snapshot load, pin/used preservation)
- [x] `dotnet test tests/Meridian.Ui.Tests` — 1223/1223
- [x] `dotnet build Meridian.sln -c Release /p:EnableWindowsTargeting=true` — 0 errors
- [x] `bash scripts/ci.sh --lane verify-docs` and `--lane verify-workflows` — pass; docs regenerated twice to prove no drift
- [ ] Full `bash scripts/ci.sh` quality-gate — deferred to the GitHub-hosted `quality-gate` check (full .NET suite exceeds this container's practical budget; per CLAUDE.md the hosted gate is authoritative)

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ)_