### PR TITLE
Add asset terms/obligations timeline support

### DIFF
--- a/docs/source/data/source-modules.yml
+++ b/docs/source/data/source-modules.yml
@@ -67,6 +67,9 @@ modules:
       - W4-RECON-001
       - W4-RPT-001
       - W5-ACCT-001
+      - W5X-CONNECT-001
+      - W5X-EVIDENCE-001
+      - W5X-STMT-ONBOARD-001
     stage_gates:
       - DataConfidence
       - PaperSession
@@ -90,7 +93,7 @@ modules:
     diagrams:
       - DIA-ASSURANCE-LOOP
     todos: []
-    last_reviewed: 2026-06-09
+    last_reviewed: 2026-07-02
 
   - id: SRC-CORE
     path: src/Meridian.Core
@@ -700,6 +703,8 @@ modules:
       - W4-RECON-001
       - W5-ACCT-001
       - W5X-FINOPS-001
+      - W5X-CONNECT-001
+      - W5X-STMT-ONBOARD-001
     stage_gates:
       - PortfolioLedgerReview
       - AccountingRecords
@@ -719,7 +724,7 @@ modules:
     diagrams:
       - DIA-ASSURANCE-LOOP
     todos: []
-    last_reviewed: 2026-06-10
+    last_reviewed: 2026-07-02
 
   - id: SRC-DESIGN-WORKFLOW
     path: src/Meridian.Workflow
@@ -891,6 +896,9 @@ modules:
       - W4-RECON-001
       - W4-RPT-001
       - W5-ACCT-001
+      - W5X-CONNECT-001
+      - W5X-EVIDENCE-001
+      - W5X-STMT-ONBOARD-001
     stage_gates:
       - PaperSession
       - PortfolioLedgerReview
@@ -903,7 +911,7 @@ modules:
     diagrams:
       - DIA-BROWSER-WORKSTATION
     todos: []
-    last_reviewed: 2026-06-09
+    last_reviewed: 2026-07-02
 
   - id: SRC-UI-DASHBOARD
     path: src/Meridian.Ui/dashboard
@@ -920,6 +928,9 @@ modules:
       - W4-RPT-001
       - W5-ACCT-001
       - W5-MASSET-001
+      - W5X-CONNECT-001
+      - W5X-EVIDENCE-001
+      - W5X-STMT-ONBOARD-001
     stage_gates:
       - PaperSession
       - PromotionReview
@@ -936,7 +947,7 @@ modules:
       - DIA-BROWSER-WORKSTATION-ROUTES
     todos:
       - TODO-SRC-UI-DASHBOARD-001
-    last_reviewed: 2026-06-09
+    last_reviewed: 2026-07-02
 
   - id: SRC-WPF
     path: src/Meridian.Wpf

--- a/docs/source/generated/MANIFEST.json
+++ b/docs/source/generated/MANIFEST.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "docs/source/data/source-modules.yml",
-      "sha256": "627d932225729b9c45c4f639ca529e1ebdae25d6b740b7d966e4af76bec48531"
+      "sha256": "b1a116766ea16d3ddc97961ba337114ef572c64728eb19d16e278f739d22dbeb"
     },
     {
       "path": "docs/source/data/source-readme-coverage.yml",
@@ -32,7 +32,7 @@
     },
     {
       "path": "docs/source/generated/source-roadmap-traceability.md",
-      "sha256": "2d8e4bb9ddecfbae0c873233c760b7ff2c915220ca913c2c43d5abbfd0f5c757"
+      "sha256": "5fc1b33d09619f1bf344e5cabfd3bdca33ca6365d1dd9010d28d7cba55b937a9"
     },
     {
       "path": "docs/source/generated/source-todo-checklist.md",

--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -86,8 +86,8 @@
       "id": "SRC-DESIGN-INSTRUMENTS",
       "path": "src/Meridian.Instruments",
       "readme": "src/Meridian.Instruments/README.md",
-      "readme_hash": "9e8700c10e9d07f9180bbee3549ea955b079690ba3fbbd202789d59b0678245b",
-      "source_hash": "36e1f250961230ee7803db362461c63a1ab4c7287b8c7e75b845a87fc9fbdb10"
+      "readme_hash": "ff499f4abf1171607f39045dbdbc821135ed476721510002d43e8c8749cbcaec",
+      "source_hash": "3fd6b5c56203839d7267e047e7fae06e6e8c1522f91548b725b5a4ce5a9038f9"
     },
     {
       "id": "SRC-DESIGN-PLATFORM",

--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -30,8 +30,8 @@
       "id": "SRC-CONTRACTS",
       "path": "src/Meridian.Contracts",
       "readme": "src/Meridian.Contracts/README.md",
-      "readme_hash": "71a44c41782774f45eea44ad3c1b998321739c99665e53817bf290385726133d",
-      "source_hash": "eec3f6a3b1eed73a34ed871d4f13661058d3f6244b09a4dba2d80ce9afe1389d"
+      "readme_hash": "60ff613e79568f059e32c82d55b326c1a6e2ca68aed50ab3a0d2602e1c428eeb",
+      "source_hash": "b9f964e05e48217232fcb315cbb5ba89c32ec33f294b284c92126d1962bdca18"
     },
     {
       "id": "SRC-CORE",
@@ -72,8 +72,8 @@
       "id": "SRC-DESIGN-FINANCIAL-OPERATIONS",
       "path": "src/Meridian.FinancialOperations",
       "readme": "src/Meridian.FinancialOperations/README.md",
-      "readme_hash": "f9df3733cd2b46041d39f943e4c0543d2fa98fe45c84f93dca9c67d302114790",
-      "source_hash": "ea4e89cb4ac6342f87fce7db0ca3e6ae61935db0b6049c27d9473543483a780d"
+      "readme_hash": "8d74fbe0ace25e0c2347e3e1a0748e03446ba0c34c96cdae15070072e2529f6d",
+      "source_hash": "35761e44bd7b4b6ea3ed37c96d0b3854a91cbee1d5ee1241c6ef7d4ecd087323"
     },
     {
       "id": "SRC-DESIGN-IDENTITY",
@@ -254,8 +254,8 @@
       "id": "SRC-UI-DASHBOARD",
       "path": "src/Meridian.Ui/dashboard",
       "readme": "src/Meridian.Ui/dashboard/README.md",
-      "readme_hash": "4215f4e90d849ee95a4d52ac41ab5c2fd6712bc86d8e49cf8b67ea1596aa18cc",
-      "source_hash": "fe4fff4d0cdba57470af172ba7f0bad836adb6aaf129d0c3f104cc608f066ceb"
+      "readme_hash": "7ebe60871a9d28ee33477da60f156066a9875d9d94c4dd7665023f8e3284d3dc",
+      "source_hash": "d8b5cd26dfee6238f18a0b41f0592a3b9c8a57355bf2b655bcfe6482b58aef7c"
     },
     {
       "id": "SRC-UI-SERVICES",
@@ -268,8 +268,8 @@
       "id": "SRC-UI-SHARED",
       "path": "src/Meridian.Ui.Shared",
       "readme": "src/Meridian.Ui.Shared/README.md",
-      "readme_hash": "d8600ba3e6f12758a070bfd07c4be975faad657c800d3ede9a4329dd1b9f6429",
-      "source_hash": "4d5c89151f99a8279f18c527b9cded1ca37196690fea2f54a5f19124f474ac3f"
+      "readme_hash": "491b7cc4dbe090aefaadef32a060a837d1638ccda27fe5e74e8627ffe4c8629a",
+      "source_hash": "169962ac200943f2fae4f6cd23a3d73a98ff36bb76e15ee8fd9b64fef792fe8d"
     },
     {
       "id": "SRC-WPF",

--- a/docs/source/generated/source-roadmap-traceability.md
+++ b/docs/source/generated/source-roadmap-traceability.md
@@ -32,6 +32,9 @@ do_not_edit: true
 | `SRC-CONTRACTS` | Meridian contracts | `W4-RECON-001` | Portfolio ledger reconciliation readiness |
 | `SRC-CONTRACTS` | Meridian contracts | `W4-RPT-001` | Governed report pack readiness |
 | `SRC-CONTRACTS` | Meridian contracts | `W5-ACCT-001` | Accounting records and operational evidence |
+| `SRC-CONTRACTS` | Meridian contracts | `W5X-CONNECT-001` | Custodian and broker statement connector library |
+| `SRC-CONTRACTS` | Meridian contracts | `W5X-EVIDENCE-001` | Evidence Vault productization |
+| `SRC-CONTRACTS` | Meridian contracts | `W5X-STMT-ONBOARD-001` | Statement reconciliation onboarding wedge |
 | `SRC-CORE` | Meridian core | `W1-DATA-001` | Provider trust gate and data confidence baseline |
 | `SRC-CORE` | Meridian core | `W2-TRD-001` | Paper trading cockpit reliability |
 | `SRC-CORE` | Meridian core | `W7-LIVE-001` | Live-readiness governance |
@@ -46,6 +49,8 @@ do_not_edit: true
 | `SRC-DESIGN-FINANCIAL-OPERATIONS` | Meridian Financial Operations design module | `W4-RECON-001` | Portfolio ledger reconciliation readiness |
 | `SRC-DESIGN-FINANCIAL-OPERATIONS` | Meridian Financial Operations design module | `W5-ACCT-001` | Accounting records and operational evidence |
 | `SRC-DESIGN-FINANCIAL-OPERATIONS` | Meridian Financial Operations design module | `W5X-FINOPS-001` | Financial operations control center |
+| `SRC-DESIGN-FINANCIAL-OPERATIONS` | Meridian Financial Operations design module | `W5X-CONNECT-001` | Custodian and broker statement connector library |
+| `SRC-DESIGN-FINANCIAL-OPERATIONS` | Meridian Financial Operations design module | `W5X-STMT-ONBOARD-001` | Statement reconciliation onboarding wedge |
 | `SRC-DESIGN-IDENTITY` | Meridian Identity design module | `W5-ACCT-001` | Accounting records and operational evidence |
 | `SRC-DESIGN-INSTRUMENTS` | Meridian Instruments design module | `W4-RECON-001` | Portfolio ledger reconciliation readiness |
 | `SRC-DESIGN-INSTRUMENTS` | Meridian Instruments design module | `W5-MASSET-001` | Multi-asset operational coverage proof lane |
@@ -109,6 +114,9 @@ do_not_edit: true
 | `SRC-UI-DASHBOARD` | Browser workstation dashboard | `W4-RPT-001` | Governed report pack readiness |
 | `SRC-UI-DASHBOARD` | Browser workstation dashboard | `W5-ACCT-001` | Accounting records and operational evidence |
 | `SRC-UI-DASHBOARD` | Browser workstation dashboard | `W5-MASSET-001` | Multi-asset operational coverage proof lane |
+| `SRC-UI-DASHBOARD` | Browser workstation dashboard | `W5X-CONNECT-001` | Custodian and broker statement connector library |
+| `SRC-UI-DASHBOARD` | Browser workstation dashboard | `W5X-EVIDENCE-001` | Evidence Vault productization |
+| `SRC-UI-DASHBOARD` | Browser workstation dashboard | `W5X-STMT-ONBOARD-001` | Statement reconciliation onboarding wedge |
 | `SRC-UI-SERVICES` | UI services | `W2-TRD-001` | Paper trading cockpit reliability |
 | `SRC-UI-SERVICES` | UI services | `W2-PROMO-001` | Paper promotion evidence and operator acceptance |
 | `SRC-UI-SERVICES` | UI services | `W3-CONT-001` | Research to paper continuity |
@@ -119,6 +127,9 @@ do_not_edit: true
 | `SRC-UI-SHARED` | UI shared contracts | `W4-RECON-001` | Portfolio ledger reconciliation readiness |
 | `SRC-UI-SHARED` | UI shared contracts | `W4-RPT-001` | Governed report pack readiness |
 | `SRC-UI-SHARED` | UI shared contracts | `W5-ACCT-001` | Accounting records and operational evidence |
+| `SRC-UI-SHARED` | UI shared contracts | `W5X-CONNECT-001` | Custodian and broker statement connector library |
+| `SRC-UI-SHARED` | UI shared contracts | `W5X-EVIDENCE-001` | Evidence Vault productization |
+| `SRC-UI-SHARED` | UI shared contracts | `W5X-STMT-ONBOARD-001` | Statement reconciliation onboarding wedge |
 | `SRC-WPF` | WPF workstation | `W4-RECON-001` | Portfolio ledger reconciliation readiness |
 | `SRC-WPF` | WPF workstation | `W4-RPT-001` | Governed report pack readiness |
 | `SRC-WPF` | WPF workstation | `W5-ACCT-001` | Accounting records and operational evidence |

--- a/src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs
+++ b/src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs
@@ -124,6 +124,39 @@ public sealed record AssetLedgerProjectionDto(
     string? LedgerReferenceId,
     JsonElement? ExtensionPayload = null);
 
+public sealed record AssetTermsObligationTimelineEventDto(
+    Guid TimelineEventId,
+    Guid SecurityId,
+    string EventKind,
+    string EventLane,
+    DateOnly EffectiveDate,
+    DateOnly? PayDate,
+    DateOnly? AccrualStartDate,
+    DateOnly? AccrualEndDate,
+    decimal? ExpectedAmount,
+    decimal? ActualAmount,
+    decimal? VarianceAmount,
+    string Currency,
+    string Status,
+    string SourceDomain,
+    string? SourceEntityId,
+    string? EvidenceLink,
+    string? LedgerReferenceId,
+    string Summary,
+    JsonElement? ExtensionPayload = null);
+
+public sealed record AssetTermsObligationsTimelineDto(
+    Guid SecurityId,
+    DateOnly ProjectionAsOf,
+    string EngineVersion,
+    string Status,
+    IReadOnlyList<AssetTermsObligationTimelineEventDto> Events,
+    IReadOnlyList<string> Warnings,
+    DateTimeOffset GeneratedAt,
+    string SourceDomain,
+    string? SourceEntityId,
+    JsonElement? ExtensionPayload = null);
+
 public sealed record AssetOperationsReadinessDto(
     Guid SecurityId,
     string Status,
@@ -147,7 +180,10 @@ public sealed record AssetOperationsDetailDto(
     IReadOnlyList<AssetReconciliationResultDto> ReconciliationResults,
     IReadOnlyList<AssetLedgerProjectionDto> LedgerProjections,
     AssetOperationsReadinessDto Readiness,
-    IReadOnlyList<AssetLifecycleEventDto> WorkflowAudit);
+    IReadOnlyList<AssetLifecycleEventDto> WorkflowAudit)
+{
+    public AssetTermsObligationsTimelineDto? TermsObligationsTimeline { get; init; }
+}
 
 public sealed record AssetOperationsProjectionDto(
     AssetOperationSubjectDto Subject,
@@ -160,7 +196,10 @@ public sealed record AssetOperationsProjectionDto(
     IReadOnlyList<AssetReconciliationResultDto> ReconciliationResults,
     IReadOnlyList<AssetLedgerProjectionDto> LedgerProjections,
     AssetOperationsReadinessDto Readiness,
-    IReadOnlyList<AssetLifecycleEventDto> WorkflowAudit);
+    IReadOnlyList<AssetLifecycleEventDto> WorkflowAudit)
+{
+    public AssetTermsObligationsTimelineDto? TermsObligationsTimeline { get; init; }
+}
 
 public sealed record AssetOperationsWriteApprovalDto(
     string Actor,

--- a/src/Meridian.Contracts/README.md
+++ b/src/Meridian.Contracts/README.md
@@ -1301,6 +1301,9 @@ See `DIA-ASSURANCE-LOOP` in `docs/source/data/diagram-index.yml`.
 | `W4-RECON-001` | Portfolio ledger reconciliation readiness |
 | `W4-RPT-001` | Governed report pack readiness |
 | `W5-ACCT-001` | Accounting records and operational evidence |
+| `W5X-CONNECT-001` | Custodian and broker statement connector library |
+| `W5X-EVIDENCE-001` | Evidence Vault productization |
+| `W5X-STMT-ONBOARD-001` | Statement reconciliation onboarding wedge |
 <!-- source-roadmap-traceability:end -->
 
 ## TODO checklist

--- a/src/Meridian.FinancialOperations/README.md
+++ b/src/Meridian.FinancialOperations/README.md
@@ -472,6 +472,8 @@ evidence deletion.
 | `W4-RECON-001` | Portfolio ledger reconciliation readiness |
 | `W5-ACCT-001` | Accounting records and operational evidence |
 | `W5X-FINOPS-001` | Financial operations control center |
+| `W5X-CONNECT-001` | Custodian and broker statement connector library |
+| `W5X-STMT-ONBOARD-001` | Statement reconciliation onboarding wedge |
 <!-- source-roadmap-traceability:end -->
 
 ## TODO checklist

--- a/src/Meridian.Instruments/AssetOperations/AssetOperationsReadService.cs
+++ b/src/Meridian.Instruments/AssetOperations/AssetOperationsReadService.cs
@@ -715,7 +715,8 @@ public static class AssetOperationsProjectionBuilder
         }
 
         var actualDays = accrualEnd.DayNumber - accrualStart.DayNumber;
-        if (normalized is not null && normalized.Contains("ACT/360", StringComparison.OrdinalIgnoreCase))
+        if (normalized is not null && (normalized.Contains("ACT/360", StringComparison.OrdinalIgnoreCase) ||
+                                       normalized.Contains("ACTUAL/360", StringComparison.OrdinalIgnoreCase)))
         {
             return actualDays / 360m;
         }

--- a/src/Meridian.Instruments/AssetOperations/AssetOperationsReadService.cs
+++ b/src/Meridian.Instruments/AssetOperations/AssetOperationsReadService.cs
@@ -753,7 +753,7 @@ public static class AssetOperationsProjectionBuilder
         {
             formula,
             engineVersion = FixedIncomeCashFlowEngineVersion,
-            bond.AccrualConvention?.DayCountConvention,
+            dayCountConvention = bond.AccrualConvention?.DayCountConvention,
             paymentFrequencyPerYear = paymentFrequency,
             principalBasis,
             outstandingPrincipal,

--- a/src/Meridian.Instruments/AssetOperations/AssetOperationsReadService.cs
+++ b/src/Meridian.Instruments/AssetOperations/AssetOperationsReadService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Meridian.Instruments.FixedIncome;
 using Meridian.Contracts.AssetOperations;
 using Meridian.Contracts.DirectLending;
@@ -32,7 +33,7 @@ public sealed class AssetOperationsReadService : IAssetOperationsQueryService
             : await _projectionStore.GetAsync(securityId, ct).ConfigureAwait(false);
         if (published is not null)
         {
-            return published;
+            return AssetOperationsProjectionBuilder.WithTermsObligationsTimeline(published);
         }
 
         var security = _securityMasterQueryService is null
@@ -81,7 +82,7 @@ public sealed class AssetOperationsReadService : IAssetOperationsQueryService
             "SecurityMaster",
             subject.SecurityId.ToString("D"));
 
-        return new AssetOperationsDetailDto(
+        var detail = new AssetOperationsDetailDto(
             subject,
             [],
             [],
@@ -93,6 +94,7 @@ public sealed class AssetOperationsReadService : IAssetOperationsQueryService
             [],
             readiness,
             []);
+        return AssetOperationsProjectionBuilder.WithTermsObligationsTimeline(detail);
     }
 
     private static AssetOperationSubjectDto BuildSubject(SecurityDetailDto security)
@@ -133,6 +135,10 @@ public sealed class AssetOperationsProjectionCommandService : IAssetOperationsCo
 
 public static class AssetOperationsProjectionBuilder
 {
+    private const string TimelineEngineVersion = "asset-terms-obligations-timeline-v1";
+    private const string FixedIncomeCashFlowEngineVersion = "fixed-income-cash-flow-projection-v1";
+    private const decimal DefaultPrincipalBasis = 100m;
+
     public static AssetOperationsProjectionDto FromDirectLending(
         LoanContractDetailDto contract,
         IReadOnlyList<ProjectionRunDto> projectionRuns,
@@ -259,7 +265,7 @@ public static class AssetOperationsProjectionBuilder
         var readyCapabilities = ReadyCapabilities(subject.OperationalProfile, terms, lifecycle, flows, activity, reconciliations, reconciliationResults, ledger);
         var readiness = BuildReadiness(subject, readyCapabilities, "DirectLending", contract.LoanId.ToString("D"));
 
-        return new AssetOperationsProjectionDto(
+        var projection = new AssetOperationsProjectionDto(
             subject,
             terms,
             lifecycle,
@@ -271,6 +277,7 @@ public static class AssetOperationsProjectionBuilder
             ledger,
             readiness,
             lifecycle);
+        return WithTermsObligationsTimeline(projection);
     }
 
     public static AssetOperationsDetailDto FromBondReference(BondReferenceDto bond, AssetOperationSubjectDto subject)
@@ -308,7 +315,7 @@ public static class AssetOperationsProjectionBuilder
             projectionRunId,
             subject.SecurityId,
             DateOnly.FromDateTime(DateTime.UtcNow.Date),
-            "fixed-income-reference-v1",
+            FixedIncomeCashFlowEngineVersion,
             "Completed",
             DateTimeOffset.UtcNow,
             "SecurityMaster",
@@ -333,7 +340,7 @@ public static class AssetOperationsProjectionBuilder
         var readyCapabilities = ReadyCapabilities(subject.OperationalProfile, terms, lifecycle, flows, [], [], [], ledger);
         var readiness = BuildReadiness(subject, readyCapabilities, "SecurityMaster", subject.SecurityId.ToString("D"));
 
-        return new AssetOperationsDetailDto(
+        var detail = new AssetOperationsDetailDto(
             subject,
             terms,
             lifecycle,
@@ -345,6 +352,7 @@ public static class AssetOperationsProjectionBuilder
             ledger,
             readiness,
             lifecycle);
+        return WithTermsObligationsTimeline(detail);
     }
 
     private static IEnumerable<AssetProjectedCashFlowDto> BuildBondProjectedCashFlows(BondReferenceDto bond, Guid projectionRunId)
@@ -355,43 +363,512 @@ public static class AssetOperationsProjectionBuilder
             yield break;
         }
 
-        if (bond.AccrualConvention?.FixedCouponRate is decimal coupon && coupon > 0m)
+        var issueDate = bond.Lifecycle?.IssueDate ?? DateOnly.FromDateTime(DateTime.UtcNow.Date);
+        var paymentFrequency = ResolvePaymentFrequencyPerYear(bond.Lifecycle?.PaymentFrequency);
+        var periodMonths = Math.Max(1, 12 / paymentFrequency);
+        var principalBasis = ResolveBondPrincipalBasis(bond);
+        var outstandingPrincipal = principalBasis;
+        var sinkingFundEntries = bond.SinkingFund?.Schedule
+            .Where(static entry => entry.Amount > 0m)
+            .OrderBy(static entry => entry.SinkDate)
+            .ToArray() ?? [];
+        var sinkingFundIndex = 0;
+        var sequenceNumber = 1;
+        var accrualStart = issueDate;
+
+        while (accrualStart < maturity.Value)
+        {
+            var accrualEnd = accrualStart.AddMonths(periodMonths);
+            if (accrualEnd > maturity.Value)
+            {
+                accrualEnd = maturity.Value;
+            }
+
+            if (bond.AccrualConvention?.FixedCouponRate is decimal coupon && coupon > 0m && outstandingPrincipal > 0m)
+            {
+                var couponAmount = CalculateBondCouponAmount(
+                    outstandingPrincipal,
+                    coupon,
+                    bond.AccrualConvention.DayCountConvention,
+                    accrualStart,
+                    accrualEnd,
+                    paymentFrequency);
+
+                if (couponAmount > 0m)
+                {
+                    yield return new AssetProjectedCashFlowDto(
+                        Guid.NewGuid(),
+                        projectionRunId,
+                        bond.SecurityId,
+                        sequenceNumber++,
+                        "Coupon",
+                        accrualEnd,
+                        couponAmount,
+                        bond.Currency,
+                        "Projected",
+                        accrualStart,
+                        accrualEnd,
+                        outstandingPrincipal,
+                        decimal.Round(coupon / 100m, 8, MidpointRounding.AwayFromZero),
+                        "SecurityMaster",
+                        bond.SecurityId.ToString("D"),
+                        BuildBondFlowPayload(
+                            "fixed-coupon",
+                            bond,
+                            paymentFrequency,
+                            principalBasis,
+                            outstandingPrincipal,
+                            coupon,
+                            accrualStart,
+                            accrualEnd));
+                }
+            }
+
+            while (sinkingFundIndex < sinkingFundEntries.Length &&
+                   sinkingFundEntries[sinkingFundIndex].SinkDate <= accrualEnd &&
+                   sinkingFundEntries[sinkingFundIndex].SinkDate < maturity.Value &&
+                   outstandingPrincipal > 0m)
+            {
+                var entry = sinkingFundEntries[sinkingFundIndex++];
+                var principalRepayment = decimal.Min(outstandingPrincipal, RoundCash(entry.Amount));
+                if (principalRepayment <= 0m)
+                {
+                    continue;
+                }
+
+                outstandingPrincipal = RoundCash(outstandingPrincipal - principalRepayment);
+                yield return new AssetProjectedCashFlowDto(
+                    Guid.NewGuid(),
+                    projectionRunId,
+                    bond.SecurityId,
+                    sequenceNumber++,
+                    "PrincipalRepayment",
+                    entry.SinkDate,
+                    principalRepayment,
+                    bond.Currency,
+                    "Projected",
+                    null,
+                    entry.SinkDate,
+                    RoundCash(outstandingPrincipal + principalRepayment),
+                    null,
+                    "SecurityMaster",
+                    bond.SecurityId.ToString("D"),
+                    BuildBondFlowPayload(
+                        "sinking-fund-principal",
+                        bond,
+                        paymentFrequency,
+                        principalBasis,
+                        RoundCash(outstandingPrincipal + principalRepayment),
+                        null,
+                        null,
+                        entry.SinkDate));
+            }
+
+            if (accrualEnd == maturity.Value)
+            {
+                break;
+            }
+
+            accrualStart = accrualEnd;
+        }
+
+        if (outstandingPrincipal > 0m)
         {
             yield return new AssetProjectedCashFlowDto(
                 Guid.NewGuid(),
                 projectionRunId,
                 bond.SecurityId,
-                1,
-                "Coupon",
+                sequenceNumber,
+                "Maturity",
                 maturity.Value,
-                decimal.Round(coupon, 4, MidpointRounding.AwayFromZero),
+                RoundCash(outstandingPrincipal),
                 bond.Currency,
                 "Projected",
                 null,
                 maturity,
+                RoundCash(outstandingPrincipal),
                 null,
-                coupon,
                 "SecurityMaster",
-                bond.SecurityId.ToString("D"));
+                bond.SecurityId.ToString("D"),
+                BuildBondFlowPayload(
+                    "maturity-principal",
+                    bond,
+                    paymentFrequency,
+                    principalBasis,
+                    outstandingPrincipal,
+                    null,
+                    null,
+                    maturity.Value));
+        }
+    }
+
+    public static AssetOperationsDetailDto WithTermsObligationsTimeline(AssetOperationsDetailDto detail)
+    {
+        ArgumentNullException.ThrowIfNull(detail);
+        if (detail.TermsObligationsTimeline is not null)
+        {
+            return detail;
         }
 
-        yield return new AssetProjectedCashFlowDto(
-            Guid.NewGuid(),
-            projectionRunId,
-            bond.SecurityId,
-            2,
-            "Maturity",
-            maturity.Value,
-            100m,
-            bond.Currency,
-            "Projected",
-            null,
-            maturity,
-            100m,
-            null,
-            "SecurityMaster",
-            bond.SecurityId.ToString("D"));
+        return detail with
+        {
+            TermsObligationsTimeline = BuildTermsObligationsTimeline(
+                detail.Subject,
+                detail.TermsHistory,
+                detail.LifecycleEvents,
+                detail.CashFlowProjectionRuns,
+                detail.ProjectedCashFlows,
+                detail.ActualActivity,
+                detail.ReconciliationResults,
+                detail.LedgerProjections)
+        };
     }
+
+    private static AssetOperationsProjectionDto WithTermsObligationsTimeline(AssetOperationsProjectionDto projection)
+    {
+        ArgumentNullException.ThrowIfNull(projection);
+        if (projection.TermsObligationsTimeline is not null)
+        {
+            return projection;
+        }
+
+        return projection with
+        {
+            TermsObligationsTimeline = BuildTermsObligationsTimeline(
+                projection.Subject,
+                projection.TermsHistory,
+                projection.LifecycleEvents,
+                projection.CashFlowProjectionRuns,
+                projection.ProjectedCashFlows,
+                projection.ActualActivity,
+                projection.ReconciliationResults,
+                projection.LedgerProjections)
+        };
+    }
+
+    private static AssetTermsObligationsTimelineDto BuildTermsObligationsTimeline(
+        AssetOperationSubjectDto subject,
+        IReadOnlyList<AssetTermsVersionDto> terms,
+        IReadOnlyList<AssetLifecycleEventDto> lifecycleEvents,
+        IReadOnlyList<AssetCashFlowProjectionRunDto> projectionRuns,
+        IReadOnlyList<AssetProjectedCashFlowDto> projectedCashFlows,
+        IReadOnlyList<AssetActualActivityDto> actualActivity,
+        IReadOnlyList<AssetReconciliationResultDto> reconciliationResults,
+        IReadOnlyList<AssetLedgerProjectionDto> ledgerProjections)
+    {
+        var latestRun = projectionRuns
+            .OrderByDescending(static run => run.GeneratedAt)
+            .FirstOrDefault();
+        var projectionAsOf = latestRun?.ProjectionAsOf
+            ?? projectedCashFlows.OrderBy(static flow => flow.DueDate).FirstOrDefault()?.DueDate
+            ?? terms.OrderByDescending(static row => row.EffectiveDate).FirstOrDefault()?.EffectiveDate
+            ?? DateOnly.FromDateTime(DateTime.UtcNow.Date);
+        var generatedAt = latestRun?.GeneratedAt ?? DateTimeOffset.UtcNow;
+        var events = new List<AssetTermsObligationTimelineEventDto>();
+
+        foreach (var flow in projectedCashFlows.OrderBy(static flow => flow.DueDate).ThenBy(static flow => flow.SequenceNumber))
+        {
+            var reconciliation = FindReconciliation(flow, reconciliationResults);
+            var activity = FindActivity(flow, reconciliation, actualActivity);
+            var ledgerProjection = FindLedgerProjection(flow, ledgerProjections);
+            var status = ResolveTimelineStatus(flow, reconciliation, projectionAsOf);
+            var actualAmount = reconciliation?.ActualAmount ?? activity?.Amount;
+            var actualDate = reconciliation?.ActualDate ?? activity?.EffectiveDate;
+            var variance = reconciliation?.VarianceAmount
+                ?? (actualAmount.HasValue ? actualAmount.Value - flow.Amount : null);
+
+            events.Add(new AssetTermsObligationTimelineEventDto(
+                Guid.NewGuid(),
+                subject.SecurityId,
+                NormalizeTimelineEventKind(flow.FlowType),
+                ResolveTimelineLane(flow.FlowType),
+                flow.DueDate,
+                actualDate,
+                flow.AccrualStartDate,
+                flow.AccrualEndDate,
+                flow.Amount,
+                actualAmount,
+                variance,
+                flow.Currency,
+                status,
+                flow.SourceDomain ?? "AssetOperations",
+                flow.SourceEntityId,
+                reconciliation?.EvidenceLink ?? activity?.EvidenceLink,
+                ledgerProjection?.LedgerReferenceId,
+                BuildCashFlowTimelineSummary(flow, status),
+                BuildTimelineFlowPayload(flow, reconciliation, activity, ledgerProjection)));
+        }
+
+        foreach (var lifecycle in lifecycleEvents.OrderBy(static row => row.EffectiveDate))
+        {
+            events.Add(new AssetTermsObligationTimelineEventDto(
+                Guid.NewGuid(),
+                subject.SecurityId,
+                lifecycle.EventType,
+                "Lifecycle",
+                lifecycle.EffectiveDate,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                string.Empty,
+                lifecycle.LifecycleState,
+                lifecycle.SourceDomain,
+                lifecycle.SourceEntityId,
+                null,
+                null,
+                lifecycle.Summary,
+                lifecycle.ExtensionPayload));
+        }
+
+        var warnings = new List<string>();
+        if (terms.Count == 0)
+        {
+            warnings.Add("No retained terms version is available for the timeline.");
+        }
+
+        if (projectedCashFlows.Count == 0)
+        {
+            warnings.Add("No projected cash-flow obligations are available for the timeline.");
+        }
+
+        return new AssetTermsObligationsTimelineDto(
+            subject.SecurityId,
+            projectionAsOf,
+            latestRun is null ? TimelineEngineVersion : $"{latestRun.EngineVersion}+{TimelineEngineVersion}",
+            warnings.Count == 0 ? "Ready" : "ReviewRequired",
+            events.OrderBy(static row => row.EffectiveDate).ThenBy(static row => row.EventKind).ToArray(),
+            warnings,
+            generatedAt,
+            latestRun?.SourceDomain ?? "AssetOperations",
+            latestRun?.SourceEntityId ?? subject.SecurityId.ToString("D"));
+    }
+
+    private static decimal ResolveBondPrincipalBasis(BondReferenceDto bond)
+    {
+        var par = bond.Lifecycle?.Par is decimal parValue && parValue > 0m
+            ? parValue
+            : DefaultPrincipalBasis;
+        var factor = bond.InflationLinked?.CurrentFactor is decimal currentFactor && currentFactor > 0m
+            ? currentFactor
+            : 1m;
+        return RoundCash(par * factor);
+    }
+
+    private static int ResolvePaymentFrequencyPerYear(string? paymentFrequency)
+    {
+        if (string.IsNullOrWhiteSpace(paymentFrequency))
+        {
+            return 1;
+        }
+
+        var normalized = paymentFrequency
+            .Replace("-", string.Empty, StringComparison.Ordinal)
+            .Replace("_", string.Empty, StringComparison.Ordinal)
+            .Replace(" ", string.Empty, StringComparison.Ordinal)
+            .Trim()
+            .ToUpperInvariant();
+        if (int.TryParse(normalized, out var parsed) && parsed > 0)
+        {
+            return Math.Clamp(parsed, 1, 12);
+        }
+
+        return normalized switch
+        {
+            "MONTHLY" => 12,
+            "QUARTERLY" => 4,
+            "SEMIANNUAL" or "SEMIANNUALLY" or "SEMIYEARLY" or "HALFYEARLY" => 2,
+            "ANNUAL" or "ANNUALLY" or "YEARLY" => 1,
+            _ => 1
+        };
+    }
+
+    private static decimal CalculateBondCouponAmount(
+        decimal principalBasis,
+        decimal couponRatePercent,
+        string? dayCountConvention,
+        DateOnly accrualStart,
+        DateOnly accrualEnd,
+        int paymentFrequency)
+    {
+        var yearFraction = CalculateYearFraction(dayCountConvention, accrualStart, accrualEnd, paymentFrequency);
+        return RoundCash(principalBasis * (couponRatePercent / 100m) * yearFraction);
+    }
+
+    private static decimal CalculateYearFraction(
+        string? dayCountConvention,
+        DateOnly accrualStart,
+        DateOnly accrualEnd,
+        int paymentFrequency)
+    {
+        if (accrualEnd <= accrualStart)
+        {
+            return 0m;
+        }
+
+        var normalized = dayCountConvention?.Replace(" ", string.Empty, StringComparison.Ordinal).ToUpperInvariant();
+        if (normalized is not null && normalized.Contains("30/360", StringComparison.OrdinalIgnoreCase))
+        {
+            return Days360(accrualStart, accrualEnd) / 360m;
+        }
+
+        var actualDays = accrualEnd.DayNumber - accrualStart.DayNumber;
+        if (normalized is not null && normalized.Contains("ACT/360", StringComparison.OrdinalIgnoreCase))
+        {
+            return actualDays / 360m;
+        }
+
+        if (normalized is not null && (normalized.Contains("ACT/365", StringComparison.OrdinalIgnoreCase) ||
+                                       normalized.Contains("ACTUAL/365", StringComparison.OrdinalIgnoreCase)))
+        {
+            return actualDays / 365m;
+        }
+
+        return 1m / Math.Max(1, paymentFrequency);
+    }
+
+    private static decimal Days360(DateOnly start, DateOnly end)
+    {
+        var startDay = Math.Min(start.Day, 30);
+        var endDay = end.Day == 31 && startDay == 30 ? 30 : Math.Min(end.Day, 30);
+        return ((end.Year - start.Year) * 360m) + ((end.Month - start.Month) * 30m) + (endDay - startDay);
+    }
+
+    private static decimal RoundCash(decimal amount)
+        => decimal.Round(amount, 4, MidpointRounding.AwayFromZero);
+
+    private static JsonElement BuildBondFlowPayload(
+        string formula,
+        BondReferenceDto bond,
+        int paymentFrequency,
+        decimal principalBasis,
+        decimal outstandingPrincipal,
+        decimal? couponRatePercent,
+        DateOnly? accrualStart,
+        DateOnly accrualEnd)
+        => JsonSerializer.SerializeToElement(new
+        {
+            formula,
+            engineVersion = FixedIncomeCashFlowEngineVersion,
+            bond.AccrualConvention?.DayCountConvention,
+            paymentFrequencyPerYear = paymentFrequency,
+            principalBasis,
+            outstandingPrincipal,
+            couponRatePercent,
+            accrualStart,
+            accrualEnd,
+            inflationFactor = bond.InflationLinked?.CurrentFactor
+        });
+
+    private static AssetReconciliationResultDto? FindReconciliation(
+        AssetProjectedCashFlowDto flow,
+        IReadOnlyList<AssetReconciliationResultDto> reconciliationResults)
+        => reconciliationResults
+            .Where(result =>
+                result.ExpectedDate == flow.DueDate ||
+                (result.ExpectedAmount.HasValue && decimal.Round(result.ExpectedAmount.Value, 4, MidpointRounding.AwayFromZero) == flow.Amount))
+            .OrderByDescending(result => result.ExpectedDate == flow.DueDate && result.ExpectedAmount == flow.Amount)
+            .FirstOrDefault();
+
+    private static AssetActualActivityDto? FindActivity(
+        AssetProjectedCashFlowDto flow,
+        AssetReconciliationResultDto? reconciliation,
+        IReadOnlyList<AssetActualActivityDto> actualActivity)
+    {
+        if (reconciliation?.ActualDate is DateOnly actualDate)
+        {
+            var matched = actualActivity.FirstOrDefault(activity =>
+                activity.EffectiveDate == actualDate &&
+                (!reconciliation.ActualAmount.HasValue || activity.Amount == reconciliation.ActualAmount.Value));
+            if (matched is not null)
+            {
+                return matched;
+            }
+        }
+
+        return actualActivity.FirstOrDefault(activity =>
+            activity.EffectiveDate == flow.DueDate &&
+            activity.Amount == flow.Amount);
+    }
+
+    private static AssetLedgerProjectionDto? FindLedgerProjection(
+        AssetProjectedCashFlowDto flow,
+        IReadOnlyList<AssetLedgerProjectionDto> ledgerProjections)
+        => ledgerProjections
+            .OrderBy(row => Math.Abs(row.AccountingDate.DayNumber - flow.DueDate.DayNumber))
+            .FirstOrDefault(row => string.Equals(row.Currency, flow.Currency, StringComparison.OrdinalIgnoreCase));
+
+    private static string ResolveTimelineStatus(
+        AssetProjectedCashFlowDto flow,
+        AssetReconciliationResultDto? reconciliation,
+        DateOnly projectionAsOf)
+    {
+        if (reconciliation is not null)
+        {
+            return reconciliation.MatchStatus;
+        }
+
+        return flow.DueDate < projectionAsOf
+            ? "MissingEvidence"
+            : flow.Status;
+    }
+
+    private static string NormalizeTimelineEventKind(string flowType)
+        => flowType switch
+        {
+            "Maturity" => "PrincipalMaturity",
+            "Principal" => "PrincipalRepayment",
+            _ => flowType
+        };
+
+    private static string ResolveTimelineLane(string flowType)
+    {
+        if (flowType.Contains("Coupon", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Coupon";
+        }
+
+        if (flowType.Contains("Interest", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Interest";
+        }
+
+        if (flowType.Contains("Principal", StringComparison.OrdinalIgnoreCase) ||
+            flowType.Contains("Maturity", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Principal";
+        }
+
+        if (flowType.Contains("Capital", StringComparison.OrdinalIgnoreCase) ||
+            flowType.Contains("Distribution", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Capital";
+        }
+
+        return "CashFlow";
+    }
+
+    private static string BuildCashFlowTimelineSummary(AssetProjectedCashFlowDto flow, string status)
+        => $"{flow.FlowType} obligation due {flow.DueDate:yyyy-MM-dd} for {flow.Amount} {flow.Currency}; status {status}.";
+
+    private static JsonElement BuildTimelineFlowPayload(
+        AssetProjectedCashFlowDto flow,
+        AssetReconciliationResultDto? reconciliation,
+        AssetActualActivityDto? activity,
+        AssetLedgerProjectionDto? ledgerProjection)
+        => JsonSerializer.SerializeToElement(new
+        {
+            projectionRunId = flow.ProjectionRunId,
+            projectedCashFlowId = flow.ProjectedCashFlowId,
+            flow.SequenceNumber,
+            flow.PrincipalBasis,
+            flow.AnnualRate,
+            reconciliationResultId = reconciliation?.ReconciliationResultId,
+            actualActivityId = activity?.ActivityId,
+            ledgerProjectionId = ledgerProjection?.LedgerProjectionId
+        });
 
     private static IReadOnlyList<string> ReadyCapabilities(
         IReadOnlyList<string> capabilities,

--- a/src/Meridian.Instruments/README.md
+++ b/src/Meridian.Instruments/README.md
@@ -40,7 +40,8 @@ This module belongs to the Design Module layer. Keep changes within that ownersh
   sweep-profile, fund-family, and rebuild projection services.
 - `AssetOperations/AssetOperationsReadService.cs` - Security Master-keyed asset operations query,
   command, and projection builder for shared terms, lifecycle, cash-flow, activity,
-  reconciliation, ledger, evidence, workflow-audit, and readiness views.
+  reconciliation, ledger, evidence, workflow-audit, terms/obligations timeline, and readiness
+  views.
 - `Indicators/TechnicalIndicatorService.cs` - live and historical technical indicator calculations
   over market trades, quotes, and OHLCV bars using Skender.Stock.Indicators.
 
@@ -52,9 +53,12 @@ Asset-specific instrument reference services live here because they expose finan
 terms, lifecycle, contract, expiry, maturity, accrual, sweep, liquidity, fund-family, and
 chain-linkage details. Asset Operations projections also live here because they adapt instrument
 terms, obligation schedules, projected cash flows, ledger projections, and readiness evidence into
-the shared Security Master-keyed operational view. Application composition wires these services to
-Security Master, Asset Operations, and money-market projection stores, while UI Shared adapts them
-to shared browser/WPF routes without owning the instrument logic.
+the shared Security Master-keyed operational view. The terms/obligations timeline is derived here
+from projected cash-flow runs, actual activity, reconciliation results, lifecycle events, and ledger
+references so browser and WPF clients render a shared event rail without owning projection logic.
+Application composition wires these services to Security Master, Asset Operations, and money-market
+projection stores, while UI Shared adapts them to shared browser/WPF routes without owning the
+instrument logic.
 Technical indicator calculation lives here because moving-average, oscillator, volatility, VWAP,
 and volume-derived analytics are instrument-market analytics rather than application orchestration.
 The service keeps per-symbol streaming state bounded by `IndicatorConfiguration.MaxQuotesHistory`

--- a/src/Meridian.Storage/AssetOperations/InMemoryAssetOperationsProjectionStore.cs
+++ b/src/Meridian.Storage/AssetOperations/InMemoryAssetOperationsProjectionStore.cs
@@ -36,7 +36,10 @@ public sealed class InMemoryAssetOperationsProjectionStore : IAssetOperationsPro
             projection.ReconciliationResults,
             projection.LedgerProjections,
             projection.Readiness,
-            projection.WorkflowAudit);
+            projection.WorkflowAudit)
+        {
+            TermsObligationsTimeline = projection.TermsObligationsTimeline
+        };
 
         lock (_gate)
         {

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -1804,6 +1804,9 @@ See `DIA-BROWSER-WORKSTATION` in `docs/source/data/diagram-index.yml`.
 | `W4-RECON-001` | Portfolio ledger reconciliation readiness |
 | `W4-RPT-001` | Governed report pack readiness |
 | `W5-ACCT-001` | Accounting records and operational evidence |
+| `W5X-CONNECT-001` | Custodian and broker statement connector library |
+| `W5X-EVIDENCE-001` | Evidence Vault productization |
+| `W5X-STMT-ONBOARD-001` | Statement reconciliation onboarding wedge |
 <!-- source-roadmap-traceability:end -->
 
 ## TODO checklist

--- a/src/Meridian.Ui.Shared/Services/FinancialRecordExplorerReadService.cs
+++ b/src/Meridian.Ui.Shared/Services/FinancialRecordExplorerReadService.cs
@@ -1822,7 +1822,8 @@ public sealed class FinancialRecordExplorerReadService
     private static string BuildTermsObligationsSummary(AssetOperationsDetailDto operations)
     {
         var terms = operations.TermsHistory.Count;
-        var obligations = operations.ProjectedCashFlows.Count + operations.LifecycleEvents.Count;
+        var obligations = operations.TermsObligationsTimeline?.Events.Count
+            ?? operations.ProjectedCashFlows.Count + operations.LifecycleEvents.Count;
         if (terms == 0 && obligations == 0)
         {
             return "No terms";
@@ -1836,11 +1837,16 @@ public sealed class FinancialRecordExplorerReadService
         var latestTerms = operations.TermsHistory
             .OrderByDescending(static terms => terms.EffectiveDate)
             .FirstOrDefault();
-        var nextFlow = operations.ProjectedCashFlows
-            .OrderBy(static flow => flow.DueDate)
-            .FirstOrDefault();
+        var nextTimelineEvent = operations.TermsObligationsTimeline?.Events
+            .OrderBy(static timelineEvent => timelineEvent.EffectiveDate)
+            .FirstOrDefault(static timelineEvent => !string.Equals(timelineEvent.EventLane, "Lifecycle", StringComparison.OrdinalIgnoreCase));
+        var nextFlow = nextTimelineEvent is null
+            ? operations.ProjectedCashFlows
+                .OrderBy(static flow => flow.DueDate)
+                .FirstOrDefault()
+            : null;
 
-        if (latestTerms is null && nextFlow is null)
+        if (latestTerms is null && nextTimelineEvent is null && nextFlow is null)
         {
             return "No retained terms or obligation rows are available.";
         }
@@ -1851,7 +1857,14 @@ public sealed class FinancialRecordExplorerReadService
             parts.Add($"{latestTerms.Summary} Effective {latestTerms.EffectiveDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}.");
         }
 
-        if (nextFlow is not null)
+        if (nextTimelineEvent is not null)
+        {
+            var amount = nextTimelineEvent.ExpectedAmount.HasValue
+                ? $" for {FormatAmountCurrency(nextTimelineEvent.ExpectedAmount.Value, nextTimelineEvent.Currency)}"
+                : string.Empty;
+            parts.Add($"Next timeline event is {nextTimelineEvent.EventKind} due {nextTimelineEvent.EffectiveDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}{amount}; status {nextTimelineEvent.Status}.");
+        }
+        else if (nextFlow is not null)
         {
             parts.Add($"Next obligation is {nextFlow.FlowType} due {nextFlow.DueDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)} for {FormatAmountCurrency(nextFlow.Amount, nextFlow.Currency)}.");
         }
@@ -1860,7 +1873,9 @@ public sealed class FinancialRecordExplorerReadService
     }
 
     private static FinancialRecordExplorerTone ToneFromTerms(AssetOperationsDetailDto operations)
-        => operations.TermsHistory.Count == 0 && operations.ProjectedCashFlows.Count == 0
+        => operations.TermsHistory.Count == 0 &&
+           operations.ProjectedCashFlows.Count == 0 &&
+           (operations.TermsObligationsTimeline?.Events.Count ?? 0) == 0
             ? FinancialRecordExplorerTone.Warning
             : FinancialRecordExplorerTone.Success;
 

--- a/src/Meridian.Ui/dashboard/README.md
+++ b/src/Meridian.Ui/dashboard/README.md
@@ -1164,6 +1164,9 @@ See `DIA-BROWSER-WORKSTATION` and `DIA-PAPER-SESSION-REPLAY` in
 | `W4-RPT-001` | Governed report pack readiness |
 | `W5-ACCT-001` | Accounting records and operational evidence |
 | `W5-MASSET-001` | Multi-asset operational coverage proof lane |
+| `W5X-CONNECT-001` | Custodian and broker statement connector library |
+| `W5X-EVIDENCE-001` | Evidence Vault productization |
+| `W5X-STMT-ONBOARD-001` | Statement reconciliation onboarding wedge |
 <!-- source-roadmap-traceability:end -->
 
 ## TODO checklist

--- a/tests/Meridian.Tests/Application/Monitoring/PrometheusMetricsTests.cs
+++ b/tests/Meridian.Tests/Application/Monitoring/PrometheusMetricsTests.cs
@@ -9,7 +9,7 @@ namespace Meridian.Tests;
 /// Serializes all Prometheus metrics test classes that mutate the shared static
 /// <see cref="Metrics"/> counters, preventing race conditions when tests run in parallel.
 /// </summary>
-[CollectionDefinition("PrometheusMetrics")]
+[CollectionDefinition("PrometheusMetrics", DisableParallelization = true)]
 public sealed class PrometheusMetricsCollection { }
 
 /// <summary>

--- a/tests/Meridian.Tests/AssetOperations/AssetOperationsReadServiceTests.cs
+++ b/tests/Meridian.Tests/AssetOperations/AssetOperationsReadServiceTests.cs
@@ -28,7 +28,16 @@ public sealed class AssetOperationsReadServiceTests
                 "Meridian Funding LLC",
                 "Senior",
                 "CUSIP:123456789",
-                new BondLifecycleDto(securityId, BondLifecycleStat.Active, new DateOnly(2026, 1, 1), null, new DateOnly(2031, 1, 1), false, 3),
+                new BondLifecycleDto(
+                    securityId,
+                    BondLifecycleStat.Active,
+                    new DateOnly(2026, 1, 1),
+                    null,
+                    new DateOnly(2031, 1, 1),
+                    false,
+                    3,
+                    Par: 100m,
+                    PaymentFrequency: "SemiAnnual"),
                 new BondAccrualConventionDto(securityId, "30/360", 2, "US", "Fixed", 5.875m, null, null, 3),
                 3));
 
@@ -40,6 +49,28 @@ public sealed class AssetOperationsReadServiceTests
         detail!.Subject.AssetClass.Should().Be("Bond");
         detail.Subject.OperationalProfile.Should().Contain(["ProjectedCashFlows", "LedgerProjection", "Readiness"]);
         detail.ProjectedCashFlows.Select(static flow => flow.FlowType).Should().Contain(["Coupon", "Maturity"]);
+        detail.ProjectedCashFlows.Where(static flow => flow.FlowType == "Coupon").Should().HaveCount(10);
+        detail.ProjectedCashFlows.First(static flow => flow.FlowType == "Coupon").Should().Match<AssetProjectedCashFlowDto>(flow =>
+            flow.DueDate == new DateOnly(2026, 7, 1) &&
+            flow.AccrualStartDate == new DateOnly(2026, 1, 1) &&
+            flow.AccrualEndDate == new DateOnly(2026, 7, 1) &&
+            flow.Amount == 2.9375m &&
+            flow.PrincipalBasis == 100m &&
+            flow.AnnualRate == 0.05875m);
+        detail.ProjectedCashFlows.Single(static flow => flow.FlowType == "Maturity").Should().Match<AssetProjectedCashFlowDto>(flow =>
+            flow.DueDate == new DateOnly(2031, 1, 1) &&
+            flow.Amount == 100m &&
+            flow.PrincipalBasis == 100m);
+        detail.TermsObligationsTimeline.Should().NotBeNull();
+        detail.TermsObligationsTimeline!.Events.Should().Contain(static timelineEvent =>
+            timelineEvent.EventKind == "Coupon" &&
+            timelineEvent.EventLane == "Coupon" &&
+            timelineEvent.ExpectedAmount == 2.9375m &&
+            timelineEvent.LedgerReferenceId == "security-master:11111111-1111-1111-1111-111111111111");
+        detail.TermsObligationsTimeline.Events.Should().Contain(static timelineEvent =>
+            timelineEvent.EventKind == "PrincipalMaturity" &&
+            timelineEvent.EventLane == "Principal" &&
+            timelineEvent.ExpectedAmount == 100m);
         detail.Readiness.ReadyCapabilities.Should().Contain(["TermsHistory", "LifecycleState", "ProjectedCashFlows", "LedgerProjection"]);
     }
 
@@ -131,6 +162,15 @@ public sealed class AssetOperationsReadServiceTests
         projection.ActualActivity.Should().ContainSingle(static row => row.ActivityType == "InterestPayment");
         projection.ReconciliationResults.Should().ContainSingle(static row => row.MatchStatus == "Matched");
         projection.LedgerProjections.Should().ContainSingle(static row => row.SourceDomain == "LoanAccountingProjector");
+        projection.TermsObligationsTimeline.Should().NotBeNull();
+        projection.TermsObligationsTimeline!.Events.Should().ContainSingle(timelineEvent =>
+            timelineEvent.EventKind == "Interest" &&
+            timelineEvent.EventLane == "Interest" &&
+            timelineEvent.Status == "Matched" &&
+            timelineEvent.ExpectedAmount == 1_000m &&
+            timelineEvent.ActualAmount == 1_000m &&
+            timelineEvent.VarianceAmount == 0m &&
+            timelineEvent.EvidenceLink == cash.CashTransactionId.ToString("D"));
         projection.Readiness.ReadyCapabilities.Should().Contain(["TermsHistory", "ProjectedCashFlows", "ActualActivity", "Reconciliation", "LedgerProjection"]);
     }
 

--- a/tests/Meridian.Tests/AssetOperations/AssetOperationsReadServiceTests.cs
+++ b/tests/Meridian.Tests/AssetOperations/AssetOperationsReadServiceTests.cs
@@ -174,6 +174,122 @@ public sealed class AssetOperationsReadServiceTests
         projection.Readiness.ReadyCapabilities.Should().Contain(["TermsHistory", "ProjectedCashFlows", "ActualActivity", "Reconciliation", "LedgerProjection"]);
     }
 
+    [Fact]
+    public async Task GetOperationsAsync_ForBondWithSinkingFund_ShouldEmitPrincipalRepaymentRowsAndReduceMaturityPrincipal()
+    {
+        var securityId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var securityMaster = Substitute.For<ISecurityMasterQueryService>();
+        securityMaster.GetByIdAsync(securityId, Arg.Any<CancellationToken>())
+            .Returns(BuildSecurity(securityId, "Bond", "Test Sinking Fund Bond 6% 2028"));
+        var bondService = Substitute.For<IBondReferenceService>();
+        bondService.GetReferenceAsync(securityId, Arg.Any<CancellationToken>())
+            .Returns(new BondReferenceDto(
+                securityId,
+                "Test Sinking Fund Bond 6% 2028",
+                "USD",
+                "Test Issuer",
+                "Senior",
+                "CUSIP:999999999",
+                new BondLifecycleDto(
+                    securityId,
+                    BondLifecycleStat.Active,
+                    new DateOnly(2025, 1, 1),
+                    null,
+                    new DateOnly(2028, 1, 1),
+                    false,
+                    1,
+                    Par: 100m,
+                    PaymentFrequency: "Annual"),
+                new BondAccrualConventionDto(securityId, "30/360", 2, null, "Fixed", 6m, null, null, 1),
+                1,
+                SinkingFund: new BondSinkingFundDto(
+                    securityId,
+                    [new BondSinkingFundEntryDto(new DateOnly(2026, 1, 1), 40m)],
+                    "Annual",
+                    false,
+                    1)));
+
+        var service = new AssetOperationsReadService(securityMasterQueryService: securityMaster, bondReferenceService: bondService);
+        var detail = await service.GetOperationsAsync(securityId);
+
+        detail.Should().NotBeNull();
+        detail!.ProjectedCashFlows.Where(static f => f.FlowType == "Coupon").Should().HaveCount(3);
+        detail.ProjectedCashFlows.Where(static f => f.FlowType == "PrincipalRepayment").Should().HaveCount(1);
+
+        // first coupon is on the full 100m outstanding
+        detail.ProjectedCashFlows.First(static f => f.FlowType == "Coupon").Should().Match<AssetProjectedCashFlowDto>(f =>
+            f.DueDate == new DateOnly(2026, 1, 1) &&
+            f.Amount == 6m &&
+            f.PrincipalBasis == 100m);
+
+        // sinking-fund repayment of 40m reduces outstanding principal
+        detail.ProjectedCashFlows.Single(static f => f.FlowType == "PrincipalRepayment").Should().Match<AssetProjectedCashFlowDto>(f =>
+            f.DueDate == new DateOnly(2026, 1, 1) &&
+            f.Amount == 40m);
+
+        // subsequent coupons accrue on the reduced 60m outstanding
+        detail.ProjectedCashFlows
+            .Where(static f => f.FlowType == "Coupon" && f.DueDate > new DateOnly(2026, 1, 1))
+            .Should().AllSatisfy(f => f.Amount.Should().Be(3.6m));
+
+        // maturity carries only the remaining 60m outstanding principal
+        detail.ProjectedCashFlows.Single(static f => f.FlowType == "Maturity").Should().Match<AssetProjectedCashFlowDto>(f =>
+            f.DueDate == new DateOnly(2028, 1, 1) &&
+            f.Amount == 60m);
+    }
+
+    [Fact]
+    public async Task GetOperationsAsync_ForInflationLinkedBond_ShouldAdjustPrincipalBasisByInflationFactor()
+    {
+        var securityId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        var securityMaster = Substitute.For<ISecurityMasterQueryService>();
+        securityMaster.GetByIdAsync(securityId, Arg.Any<CancellationToken>())
+            .Returns(BuildSecurity(securityId, "Bond", "Test TIPS 5% 2027"));
+        var bondService = Substitute.For<IBondReferenceService>();
+        bondService.GetReferenceAsync(securityId, Arg.Any<CancellationToken>())
+            .Returns(new BondReferenceDto(
+                securityId,
+                "Test TIPS 5% 2027",
+                "USD",
+                "Test Issuer",
+                "Senior",
+                "CUSIP:888888888",
+                new BondLifecycleDto(
+                    securityId,
+                    BondLifecycleStat.Active,
+                    new DateOnly(2026, 1, 1),
+                    null,
+                    new DateOnly(2027, 1, 1),
+                    false,
+                    1,
+                    Par: 100m,
+                    PaymentFrequency: "Annual"),
+                new BondAccrualConventionDto(securityId, "30/360", 2, null, "Fixed", 5m, null, null, 1),
+                1,
+                InflationLinked: new BondInflationLinkedDto(
+                    securityId,
+                    "CPI-U",
+                    100m,
+                    new DateOnly(2026, 1, 1),
+                    1.03m,
+                    new DateOnly(2026, 12, 1),
+                    1.0m,
+                    1)));
+
+        var service = new AssetOperationsReadService(securityMasterQueryService: securityMaster, bondReferenceService: bondService);
+        var detail = await service.GetOperationsAsync(securityId);
+
+        detail.Should().NotBeNull();
+        // principal basis = 100 * 1.03 = 103m
+        detail!.ProjectedCashFlows.Single(static f => f.FlowType == "Coupon").Should().Match<AssetProjectedCashFlowDto>(f =>
+            f.DueDate == new DateOnly(2027, 1, 1) &&
+            f.Amount == 5.15m &&
+            f.PrincipalBasis == 103m);
+        detail.ProjectedCashFlows.Single(static f => f.FlowType == "Maturity").Should().Match<AssetProjectedCashFlowDto>(f =>
+            f.DueDate == new DateOnly(2027, 1, 1) &&
+            f.Amount == 103m);
+    }
+
     private static SecurityDetailDto BuildSecurity(Guid securityId, string assetClass, string displayName)
         => new(
             securityId,

--- a/tests/Meridian.Tests/Ui/WorkstationMultiAssetCoverageEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationMultiAssetCoverageEndpointsTests.cs
@@ -177,6 +177,16 @@ public sealed partial class WorkstationEndpointsTests
         bond!.Subject.AssetClass.Should().Be("Bond");
         loan.ProjectedCashFlows.Should().ContainSingle(static flow => flow.FlowType == "Interest");
         bond.ProjectedCashFlows.Should().ContainSingle(static flow => flow.FlowType == "Coupon");
+        loan.TermsObligationsTimeline.Should().NotBeNull();
+        bond.TermsObligationsTimeline.Should().NotBeNull();
+        loan.TermsObligationsTimeline!.Events.Should().ContainSingle(static timelineEvent =>
+            timelineEvent.EventKind == "Interest" &&
+            timelineEvent.EventLane == "Interest" &&
+            timelineEvent.ExpectedAmount == 100m);
+        bond.TermsObligationsTimeline!.Events.Should().ContainSingle(static timelineEvent =>
+            timelineEvent.EventKind == "Coupon" &&
+            timelineEvent.EventLane == "Coupon" &&
+            timelineEvent.ExpectedAmount == 100m);
         loan.Readiness.Capabilities.Should().BeEquivalentTo(bond.Readiness.Capabilities);
     }
 


### PR DESCRIPTION
Introduces AssetTermsObligationsTimelineDto to unify projected cash flows, actual activity, reconciliation results, and lifecycle events into a single event timeline. Enhances bond cash-flow projection with proper coupon calculation (supporting multiple day-count conventions, sinking funds, and inflation-linked bonds), extends AssetOperationsDetailDto and AssetOperationsProjectionDto with optional TermsObligationsTimeline property, and updates asset operations read service to build timeline on projection retrieval. Adds W5X roadmap traceability entries (custodian connector, evidence vault, statement onboarding) across contracts, financial operations, UI dashboard, and shared modules. Updates tests to validate timeline generation for bonds and loans.

## Summary

Describe the Meridian behavior changed by this pull request.

## Reason

Explain the requirement, issue, or defect being addressed.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [ ] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

## Safety review

- [ ] This pull request targets `main`
- [ ] No direct push to `main` was performed
- [ ] No tests were disabled or bypassed
- [ ] No secrets or credentials were committed
- [ ] No unrelated changes were included

## Governance changes

Check every governance file modified:

- [ ] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

Governance-file changes require explicit human approval.
