### PR TITLE
Web UI: SSE live data spine for quote surfaces (Phase 4, step 1)

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -4979,6 +4979,8 @@ Meridian-main
 │   │   │   │   │       ├── entity-setup-wizard.test.tsx
 │   │   │   │   │       └── entity-setup-wizard.tsx
 │   │   │   │   ├── hooks
+│   │   │   │   │   ├── use-quotes-stream.test.ts
+│   │   │   │   │   ├── use-quotes-stream.ts
 │   │   │   │   │   ├── use-request-lifecycle.test.ts
 │   │   │   │   │   ├── use-request-lifecycle.ts
 │   │   │   │   │   ├── use-workstation-data.test.ts
@@ -5019,6 +5021,8 @@ Meridian-main
 │   │   │   │   │   ├── dev-fixtures.test.ts
 │   │   │   │   │   ├── dev-fixtures.ts
 │   │   │   │   │   ├── plaid-link.ts
+│   │   │   │   │   ├── quotes-stream.test.ts
+│   │   │   │   │   ├── quotes-stream.ts
 │   │   │   │   │   ├── report-writer-grid-diff.test.ts
 │   │   │   │   │   ├── report-writer-grid-diff.ts
 │   │   │   │   │   ├── report-writer-grid-format.test.ts
@@ -5500,6 +5504,7 @@ Meridian-main
 │   │   │   ├── WorkstationEndpoints.Reconciliation.cs
 │   │   │   ├── WorkstationEndpoints.SecurityMasterWorkbench.cs
 │   │   │   ├── WorkstationEndpoints.StatementConnectors.cs
+│   │   │   ├── WorkstationEndpoints.Stream.cs
 │   │   │   ├── WorkstationRiskEndpoints.cs
 │   │   │   └── WorkstationTenantContext.cs
 │   │   ├── Evidence
@@ -7312,6 +7317,7 @@ Meridian-main
 │   │   │   ├── WorkstationMultiAssetCoverageEndpointsTests.cs
 │   │   │   ├── WorkstationServiceCollectionExtensionsTests.cs
 │   │   │   ├── WorkstationStatementReconciliationEndpointTests.cs
+│   │   │   ├── WorkstationStreamEndpointTests.cs
 │   │   │   ├── WorkstationTenantContextTests.cs
 │   │   │   └── WorkstationWorkflowSummaryFinancialOperationsTests.cs
 │   │   ├── Workflow

--- a/docs/product/web-ui-improvements-implementation-plan-2026-07.md
+++ b/docs/product/web-ui-improvements-implementation-plan-2026-07.md
@@ -182,10 +182,16 @@ No feature work; confirm and document the rules each later phase must follow.
   `npm --prefix src/Meridian.Ui/dashboard run test`
 
 **Checklist**
-- [ ] `WorkstationEndpoints.Stream.cs` poll-bridge SSE endpoint + route constant + TS mirror.
-- [ ] `use-workstation-stream.ts` shared EventSource hook with fallback semantics.
-- [ ] Poller suspension wired on the four polling sites.
-- [ ] Step-2 fan-out seam (separate PR, hot-path review required).
+- [x] `WorkstationEndpoints.Stream.cs` poll-bridge SSE endpoint + route constant + TS mirror
+      (quotes topic; snapshot builder shared with the REST endpoint; coalesced frames + heartbeats).
+- [x] Shared EventSource client with fallback semantics (`lib/quotes-stream.ts` framework-agnostic
+      manager + `hooks/use-quotes-stream.ts` React binding; landed under these names rather than a
+      single `use-workstation-stream.ts`).
+- [x] Poller suspension wired on the three quote-driven polling sites (watchlist, live-quotes
+      matrix, price alerts); the `use-workstation-data` workspace poller is deferred to step 2 —
+      workspace topics need the event-driven fan-out seam, not a 30s poll-bridge.
+- [ ] Step-2 fan-out seam (separate PR, hot-path review required) + workspace topics + per-session
+      stream caps.
 
 ---
 

--- a/docs/status/TODO.md
+++ b/docs/status/TODO.md
@@ -43,11 +43,11 @@ Total items: **208**
 | `src/Meridian.Ui.Services/Services/ProviderHealthService.cs` | 530 | `NOTE` | ❌ | // NOTE: ProviderComparison is defined in AdvancedAnalyticsModels.cs for cross-provider comparison |
 | `src/Meridian.Ui.Shared/Endpoints/ArchiveMaintenanceEndpoints.cs` | 32 | `NOTE` | ❌ | // NOTE: GET /schedules, GET /schedules/{id}, POST /schedules, POST /schedules/{id}/enable, |
 | `src/Meridian.Ui.Shared/Endpoints/ArchiveMaintenanceEndpoints.cs` | 117 | `NOTE` | ❌ | // NOTE: POST /schedules/{id}/enable and POST /schedules/{id}/disable are registered |
-| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4333 | `NOTE` | ❌ | note: "Paper adapter routing is available.", |
-| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4345 | `NOTE` | ❌ | note: "Realtime subscriptions are steady.", |
-| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4357 | `NOTE` | ❌ | note: "Replay queue is elevated but within tolerance.", |
-| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4469 | `NOTE` | ❌ | Note: note, |
-| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4552 | `NOTE` | ❌ | Note: note, |
+| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4334 | `NOTE` | ❌ | note: "Paper adapter routing is available.", |
+| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4346 | `NOTE` | ❌ | note: "Realtime subscriptions are steady.", |
+| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4358 | `NOTE` | ❌ | note: "Replay queue is elevated but within tolerance.", |
+| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4470 | `NOTE` | ❌ | Note: note, |
+| `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` | 4553 | `NOTE` | ❌ | Note: note, |
 | `src/Meridian.Ui.Shared/Services/ProviderLedgerReconciliationService.cs` | 1974 | `NOTE` | ❌ | Note: "Provider-ledger reconciliation break signed off.", |
 | `src/Meridian.Ui.Shared/Services/ReportPackDeliveryService.cs` | 240 | `NOTE` | ❌ | Note: NormalizeNullable(target.Note) ?? $"Scheduled delivery for {normalizedTemplateId}.", |
 | `src/Meridian.Ui.Shared/Services/ReportPackRunReadService.cs` | 2047 | `NOTE` | ❌ | Note: NormalizeOptional(target.Note), |
@@ -81,8 +81,8 @@ Total items: **208**
 | `src/Meridian.Ui/dashboard/src/lib/dev-fixtures.ts` | 1400 | `NOTE` | ❌ | note: "Investor email-link delivery.", |
 | `src/Meridian.Ui/dashboard/src/lib/dev-fixtures.ts` | 1505 | `NOTE` | ❌ | note: "pricing-correction" |
 | `src/Meridian.Ui/dashboard/src/lib/dev-fixtures.ts` | 2191 | `NOTE` | ❌ | note: "Fixture handoff retained after identity review.", |
-| `src/Meridian.Ui/dashboard/src/lib/price-alerts/service.ts` | 145 | `NOTE` | ❌ | note: alert.note |
-| `src/Meridian.Ui/dashboard/src/lib/price-alerts/service.ts` | 227 | `NOTE` | ❌ | note: draft.note?.trim() ? draft.note.trim() : null, |
+| `src/Meridian.Ui/dashboard/src/lib/price-alerts/service.ts` | 146 | `NOTE` | ❌ | note: alert.note |
+| `src/Meridian.Ui/dashboard/src/lib/price-alerts/service.ts` | 248 | `NOTE` | ❌ | note: draft.note?.trim() ? draft.note.trim() : null, |
 | `src/Meridian.Ui/dashboard/src/lib/price-alerts/storage.test.ts` | 31 | `NOTE` | ❌ | note: null, |
 | `src/Meridian.Ui/dashboard/src/lib/price-alerts/storage.test.ts` | 50 | `NOTE` | ❌ | note: null |
 | `src/Meridian.Ui/dashboard/src/lib/price-alerts/storage.ts` | 119 | `NOTE` | ❌ | note: asString(raw.note) ?? null, |

--- a/docs/status/api-contract-coverage-dashboard.json
+++ b/docs/status/api-contract-coverage-dashboard.json
@@ -2165,31 +2165,31 @@
     {
       "method": "GET",
       "path": "/api/data/orderbook/{symbol}",
-      "source": "src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:188",
+      "source": "src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:127",
       "documented": true
     },
     {
       "method": "GET",
       "path": "/api/data/l3-orderbook/{symbol}",
-      "source": "src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:260",
+      "source": "src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:199",
       "documented": true
     },
     {
       "method": "GET",
       "path": "/api/data/bbo/{symbol}",
-      "source": "src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:330",
+      "source": "src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:269",
       "documented": true
     },
     {
       "method": "GET",
       "path": "/api/data/orderflow/{symbol}",
-      "source": "src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:370",
+      "source": "src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:309",
       "documented": true
     },
     {
       "method": "GET",
       "path": "/api/data/health",
-      "source": "src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:411",
+      "source": "src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:350",
       "documented": true
     },
     {
@@ -3533,13 +3533,13 @@
     {
       "method": "GET",
       "path": "/api/strategies/{strategyId}/runs",
-      "source": "src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs:2577",
+      "source": "src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs:2578",
       "documented": true
     },
     {
       "method": "GET",
       "path": "/api/strategies/runs/compare",
-      "source": "src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs:2698",
+      "source": "src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs:2699",
       "documented": true
     }
   ],

--- a/docs/status/api-contract-coverage-dashboard.md
+++ b/docs/status/api-contract-coverage-dashboard.md
@@ -153,11 +153,11 @@ Tracks whether mapped API routes and workstation DTO contracts are visible in th
 | `POST` | `/api/config/storage` | Documented | `src/Meridian.Ui.Shared/Endpoints/ConfigEndpoints.cs:151` |
 | `POST` | `/api/config/symbols` | Documented | `src/Meridian.Ui.Shared/Endpoints/ConfigEndpoints.cs:180` |
 | `GET` | `/api/connections` | Documented | `src/Meridian.Ui.Shared/Endpoints/StatusEndpoints.cs:144` |
-| `GET` | `/api/data/bbo/{symbol}` | Documented | `src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:330` |
-| `GET` | `/api/data/health` | Documented | `src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:411` |
-| `GET` | `/api/data/l3-orderbook/{symbol}` | Documented | `src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:260` |
-| `GET` | `/api/data/orderbook/{symbol}` | Documented | `src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:188` |
-| `GET` | `/api/data/orderflow/{symbol}` | Documented | `src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:370` |
+| `GET` | `/api/data/bbo/{symbol}` | Documented | `src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:269` |
+| `GET` | `/api/data/health` | Documented | `src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:350` |
+| `GET` | `/api/data/l3-orderbook/{symbol}` | Documented | `src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:199` |
+| `GET` | `/api/data/orderbook/{symbol}` | Documented | `src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:127` |
+| `GET` | `/api/data/orderflow/{symbol}` | Documented | `src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:309` |
 | `GET` | `/api/data/quotes-snapshot` | Documented | `src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:109` |
 | `GET` | `/api/data/quotes/{symbol}` | Documented | `src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:65` |
 | `GET` | `/api/data/trades/{symbol}` | Documented | `src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs:25` |
@@ -579,8 +579,8 @@ Tracks whether mapped API routes and workstation DTO contracts are visible in th
 | `POST` | `/api/strategies/covered-call/runs/{runId}/cancel` | Documented | `src/Meridian.Ui.Shared/Endpoints/CoveredCallEndpoints.cs:135` |
 | `GET` | `/api/strategies/covered-call/runs/{runId}/result` | Documented | `src/Meridian.Ui.Shared/Endpoints/CoveredCallEndpoints.cs:93` |
 | `GET` | `/api/strategies/covered-call/runs/{runId}/status` | Documented | `src/Meridian.Ui.Shared/Endpoints/CoveredCallEndpoints.cs:70` |
-| `GET` | `/api/strategies/runs/compare` | Documented | `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs:2698` |
-| `GET` | `/api/strategies/{strategyId}/runs` | Documented | `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs:2577` |
+| `GET` | `/api/strategies/runs/compare` | Documented | `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs:2699` |
+| `GET` | `/api/strategies/{strategyId}/runs` | Documented | `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs:2578` |
 | `GET` | `/api/subscriptions/active` | Documented | `src/Meridian.Ui.Shared/Endpoints/SubscriptionEndpoints.cs:21` |
 | `POST` | `/api/subscriptions/subscribe` | Documented | `src/Meridian.Ui.Shared/Endpoints/SubscriptionEndpoints.cs:43` |
 | `POST` | `/api/subscriptions/unsubscribe/{symbol}` | Documented | `src/Meridian.Ui.Shared/Endpoints/SubscriptionEndpoints.cs:72` |

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 538,
-  "total_lines": 88560,
+  "total_lines": 88572,
   "orphaned_count": 205,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2138,7 +2138,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7766,
+      "line_count": 7772,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -3106,7 +3106,7 @@
     },
     {
       "path": "docs/product/web-ui-improvements-implementation-plan-2026-07.md",
-      "line_count": 285,
+      "line_count": 291,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 538 |
-| Total lines | 88,560 |
+| Total lines | 88,572 |
 | Average file size (lines) | 164.6 |
 | Orphaned files | 205 |
 | Files without headings | 38 |

--- a/src/Meridian.Contracts/Api/UiApiRoutes.cs
+++ b/src/Meridian.Contracts/Api/UiApiRoutes.cs
@@ -599,6 +599,7 @@ public static class UiApiRoutes
 
     // Workstation root and compatibility workspace endpoints
     public const string WorkstationSession = "/api/workstation/session";
+    public const string WorkstationStream = "/api/workstation/stream";
     public const string WorkstationResearch = "/api/workstation/research";
     public const string WorkstationStrategy = "/api/workstation/strategy";
     public const string WorkstationResearchBriefing = "/api/workstation/research/briefing";

--- a/src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/LiveDataEndpoints.cs
@@ -108,75 +108,14 @@ public static class LiveDataEndpoints
         // in a single request. Optional ?symbols=AAPL,MSFT filters the result.
         group.MapGet(UiApiRoutes.DataQuotesSnapshot, (HttpContext ctx, string? symbols) =>
         {
-            var quoteCollector = ctx.RequestServices.GetService<QuoteCollector>();
-            if (quoteCollector is null)
+            var response = TryBuildQuotesSnapshotResponse(ctx.RequestServices, symbols);
+            if (response is null)
             {
                 return Results.Json(
                     new { error = "Quote collector not available" },
                     jsonOptions,
                     statusCode: StatusCodes.Status503ServiceUnavailable);
             }
-
-            var tradeCollector = ctx.RequestServices.GetService<TradeDataCollector>();
-            var sessionStats = ctx.RequestServices.GetService<SessionStatsCollector>();
-            var snapshot = quoteCollector.Snapshot();
-
-            HashSet<string>? filter = null;
-            if (!string.IsNullOrWhiteSpace(symbols))
-            {
-                filter = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                foreach (var part in symbols.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-                {
-                    if (part.Length > 0)
-                        filter.Add(part);
-                }
-            }
-
-            var items = new List<QuotesSnapshotItem>(snapshot.Count);
-            foreach (var (symbol, bbo) in snapshot)
-            {
-                if (filter is not null && !filter.Contains(symbol))
-                    continue;
-
-                decimal? lastPrice = null;
-                long? lastSize = null;
-                DateTimeOffset? lastTs = null;
-                if (tradeCollector is not null)
-                {
-                    var recent = tradeCollector.GetRecentTrades(symbol, limit: 1);
-                    if (recent.Count > 0)
-                    {
-                        var last = recent[0];
-                        lastPrice = last.Price;
-                        lastSize = last.Size;
-                        lastTs = last.Timestamp;
-                    }
-                }
-
-                items.Add(new QuotesSnapshotItem(
-                    Symbol: bbo.Symbol,
-                    Timestamp: bbo.Timestamp,
-                    BidPrice: bbo.BidPrice,
-                    BidSize: bbo.BidSize,
-                    AskPrice: bbo.AskPrice,
-                    AskSize: bbo.AskSize,
-                    MidPrice: bbo.MidPrice,
-                    Spread: bbo.Spread,
-                    LastPrice: lastPrice,
-                    LastSize: lastSize,
-                    LastTradeTimestamp: lastTs,
-                    SequenceNumber: bbo.SequenceNumber,
-                    StreamId: bbo.StreamId,
-                    Venue: bbo.Venue,
-                    Session: ToSessionDto(sessionStats?.TryGet(bbo.Symbol))));
-            }
-
-            items.Sort(static (a, b) => string.Compare(a.Symbol, b.Symbol, StringComparison.OrdinalIgnoreCase));
-
-            var response = new QuotesSnapshotResponse(
-                Timestamp: DateTimeOffset.UtcNow,
-                Count: items.Count,
-                Quotes: items);
 
             return Results.Json(response, jsonOptions);
         })
@@ -480,6 +419,80 @@ public static class LiveDataEndpoints
         })
         .WithName("GetDataHealth")
         .Produces(200);
+    }
+
+    /// <summary>
+    /// Builds the shared quotes snapshot payload used by the REST endpoint and the
+    /// workstation SSE stream. Returns null when the quote collector is unavailable.
+    /// </summary>
+    internal static QuotesSnapshotResponse? TryBuildQuotesSnapshotResponse(IServiceProvider services, string? symbols)
+    {
+        var quoteCollector = services.GetService<QuoteCollector>();
+        if (quoteCollector is null)
+        {
+            return null;
+        }
+
+        var tradeCollector = services.GetService<TradeDataCollector>();
+        var sessionStats = services.GetService<SessionStatsCollector>();
+        var snapshot = quoteCollector.Snapshot();
+
+        HashSet<string>? filter = null;
+        if (!string.IsNullOrWhiteSpace(symbols))
+        {
+            filter = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var part in symbols.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (part.Length > 0)
+                    filter.Add(part);
+            }
+        }
+
+        var items = new List<QuotesSnapshotItem>(snapshot.Count);
+        foreach (var (symbol, bbo) in snapshot)
+        {
+            if (filter is not null && !filter.Contains(symbol))
+                continue;
+
+            decimal? lastPrice = null;
+            long? lastSize = null;
+            DateTimeOffset? lastTs = null;
+            if (tradeCollector is not null)
+            {
+                var recent = tradeCollector.GetRecentTrades(symbol, limit: 1);
+                if (recent.Count > 0)
+                {
+                    var last = recent[0];
+                    lastPrice = last.Price;
+                    lastSize = last.Size;
+                    lastTs = last.Timestamp;
+                }
+            }
+
+            items.Add(new QuotesSnapshotItem(
+                Symbol: bbo.Symbol,
+                Timestamp: bbo.Timestamp,
+                BidPrice: bbo.BidPrice,
+                BidSize: bbo.BidSize,
+                AskPrice: bbo.AskPrice,
+                AskSize: bbo.AskSize,
+                MidPrice: bbo.MidPrice,
+                Spread: bbo.Spread,
+                LastPrice: lastPrice,
+                LastSize: lastSize,
+                LastTradeTimestamp: lastTs,
+                SequenceNumber: bbo.SequenceNumber,
+                StreamId: bbo.StreamId,
+                Venue: bbo.Venue,
+                Session: ToSessionDto(sessionStats?.TryGet(bbo.Symbol))));
+        }
+
+        items.Sort(static (a, b) => string.Compare(a.Symbol, b.Symbol, StringComparison.OrdinalIgnoreCase));
+
+        return new QuotesSnapshotResponse(
+            Timestamp: DateTimeOffset.UtcNow,
+            Count: items.Count,
+            Quotes: items);
     }
 
     private static SessionStatsDto? ToSessionDto(Meridian.Contracts.Domain.Models.SessionStats? stats)

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Stream.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Stream.cs
@@ -1,8 +1,10 @@
 using System.Text.Json;
 using Meridian.Contracts.Api;
+using Meridian.Domain.Collectors;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Meridian.Ui.Shared.Endpoints;
 
@@ -34,7 +36,7 @@ public static partial class WorkstationEndpoints
                     statusCode: StatusCodes.Status400BadRequest);
             }
 
-            if (LiveDataEndpoints.TryBuildQuotesSnapshotResponse(context.RequestServices, normalizedSymbols) is null)
+            if (context.RequestServices.GetService<QuoteCollector>() is null)
             {
                 return Results.Json(
                     new { error = "Quote collector not available" },
@@ -46,7 +48,7 @@ public static partial class WorkstationEndpoints
             context.Response.Headers.CacheControl = "no-cache";
             context.Response.Headers.Connection = "keep-alive";
 
-            string? lastQuotesSignature = null;
+            IReadOnlyList<QuotesSnapshotItem>? lastQuotes = null;
             var lastWriteUtc = DateTimeOffset.MinValue;
 
             try
@@ -57,12 +59,13 @@ public static partial class WorkstationEndpoints
                     var wrote = false;
                     if (snapshot is not null)
                     {
-                        // Coalesce on the quote rows only: the envelope timestamp moves
-                        // every tick even when no quote changed.
-                        var signature = JsonSerializer.Serialize(snapshot.Quotes, jsonOptions);
-                        if (!string.Equals(signature, lastQuotesSignature, StringComparison.Ordinal))
+                        // Coalesce on the quote rows only: the envelope timestamp moves every
+                        // tick even when no quote changed. QuotesSnapshotItem is a sealed record
+                        // of scalars, so value equality covers every serialized field without
+                        // allocating a serialization per idle tick.
+                        if (!QuoteRowsEqual(lastQuotes, snapshot.Quotes))
                         {
-                            lastQuotesSignature = signature;
+                            lastQuotes = snapshot.Quotes;
                             var payload = JsonSerializer.Serialize(snapshot, jsonOptions);
                             await context.Response.WriteAsync($"event: quotes\ndata: {payload}\n\n", ct).ConfigureAwait(false);
                             wrote = true;
@@ -96,6 +99,24 @@ public static partial class WorkstationEndpoints
         .Produces(200)
         .Produces(400)
         .Produces(503);
+    }
+
+    private static bool QuoteRowsEqual(IReadOnlyList<QuotesSnapshotItem>? previous, IReadOnlyList<QuotesSnapshotItem> current)
+    {
+        if (previous is null || previous.Count != current.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < current.Count; i++)
+        {
+            if (!current[i].Equals(previous[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Stream.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Stream.cs
@@ -1,0 +1,120 @@
+using System.Text.Json;
+using Meridian.Contracts.Api;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Meridian.Ui.Shared.Endpoints;
+
+/// <summary>
+/// Workstation Server-Sent Events stream. Step 1 of the live data spine: a
+/// poll-bridge that pushes the same read-model payloads the REST endpoints serve,
+/// coalescing unchanged snapshots so idle streams cost heartbeats only. True
+/// event-driven fan-out from the pipeline is a separate, hot-path-reviewed step.
+/// </summary>
+public static partial class WorkstationEndpoints
+{
+    private const int StreamPollIntervalMs = 2_000;
+    private const int StreamHeartbeatIntervalMs = 15_000;
+    private const int StreamMaxSymbols = 50;
+
+    private static void MapStreamEndpoints(RouteGroupBuilder group, JsonSerializerOptions jsonOptions)
+    {
+        // GET /api/workstation/stream?symbols=AAPL,MSFT — SSE channel emitting
+        // `event: quotes` frames with the quotes-snapshot payload for the requested
+        // symbols whenever it changes, plus `: heartbeat` comments while idle.
+        group.MapGet(WorkstationSubroute(UiApiRoutes.WorkstationStream), async (HttpContext context, string? symbols, CancellationToken ct) =>
+        {
+            var normalizedSymbols = NormalizeStreamSymbols(symbols);
+            if (normalizedSymbols is null)
+            {
+                return Results.Json(
+                    new { error = $"A maximum of {StreamMaxSymbols} symbols can be streamed per connection." },
+                    jsonOptions,
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            if (LiveDataEndpoints.TryBuildQuotesSnapshotResponse(context.RequestServices, normalizedSymbols) is null)
+            {
+                return Results.Json(
+                    new { error = "Quote collector not available" },
+                    jsonOptions,
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+
+            context.Response.ContentType = "text/event-stream";
+            context.Response.Headers.CacheControl = "no-cache";
+            context.Response.Headers.Connection = "keep-alive";
+
+            string? lastQuotesSignature = null;
+            var lastWriteUtc = DateTimeOffset.MinValue;
+
+            try
+            {
+                while (!ct.IsCancellationRequested)
+                {
+                    var snapshot = LiveDataEndpoints.TryBuildQuotesSnapshotResponse(context.RequestServices, normalizedSymbols);
+                    var wrote = false;
+                    if (snapshot is not null)
+                    {
+                        // Coalesce on the quote rows only: the envelope timestamp moves
+                        // every tick even when no quote changed.
+                        var signature = JsonSerializer.Serialize(snapshot.Quotes, jsonOptions);
+                        if (!string.Equals(signature, lastQuotesSignature, StringComparison.Ordinal))
+                        {
+                            lastQuotesSignature = signature;
+                            var payload = JsonSerializer.Serialize(snapshot, jsonOptions);
+                            await context.Response.WriteAsync($"event: quotes\ndata: {payload}\n\n", ct).ConfigureAwait(false);
+                            wrote = true;
+                        }
+                    }
+
+                    var nowUtc = DateTimeOffset.UtcNow;
+                    if (!wrote && (nowUtc - lastWriteUtc).TotalMilliseconds >= StreamHeartbeatIntervalMs)
+                    {
+                        await context.Response.WriteAsync(": heartbeat\n\n", ct).ConfigureAwait(false);
+                        wrote = true;
+                    }
+
+                    if (wrote)
+                    {
+                        lastWriteUtc = nowUtc;
+                        await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
+                    }
+
+                    await Task.Delay(StreamPollIntervalMs, ct).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // Client disconnected.
+            }
+
+            return Results.Empty;
+        })
+        .WithName("GetWorkstationStream")
+        .Produces(200)
+        .Produces(400)
+        .Produces(503);
+    }
+
+    /// <summary>
+    /// Trims and caps the symbol filter; returns null when the cap is exceeded and
+    /// an empty string when no filter was requested (stream all tracked symbols).
+    /// </summary>
+    private static string? NormalizeStreamSymbols(string? symbols)
+    {
+        if (string.IsNullOrWhiteSpace(symbols))
+        {
+            return string.Empty;
+        }
+
+        var parts = symbols.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length > StreamMaxSymbols)
+        {
+            return null;
+        }
+
+        return string.Join(',', parts);
+    }
+}

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -99,6 +99,7 @@ public static partial class WorkstationEndpoints
         // so it maps its own tenant-scoped group directly on the app.
         MapSecurityMasterWorkbenchEndpoints(app, jsonOptions);
 
+        MapStreamEndpoints(group, jsonOptions);
         MapStrategyDesignerEndpoints(group, jsonOptions);
         MapStrategyEngineEndpoints(group, jsonOptions);
         MapFeatureCapabilityEndpoints(group, jsonOptions);

--- a/src/Meridian.Ui/dashboard/src/hooks/use-quotes-stream.test.ts
+++ b/src/Meridian.Ui/dashboard/src/hooks/use-quotes-stream.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useQuotesStream } from "@/hooks/use-quotes-stream";
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  readonly listeners = new Map<string, Set<(event: MessageEvent<string> | Event) => void>>();
+  closed = false;
+
+  constructor(readonly url: string) {
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: (event: MessageEvent<string> | Event) => void) {
+    const set = this.listeners.get(type) ?? new Set();
+    set.add(listener);
+    this.listeners.set(type, set);
+  }
+
+  emit(type: string, data?: string) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(data === undefined ? new Event(type) : new MessageEvent(type, { data }));
+    }
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
+describe("useQuotesStream", () => {
+  beforeEach(() => {
+    FakeEventSource.instances = [];
+    vi.stubGlobal("EventSource", FakeEventSource);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("stays closed and unhealthy without symbols", () => {
+    const { result } = renderHook(() => useQuotesStream([]));
+    expect(result.current.healthy).toBe(false);
+    expect(FakeEventSource.instances).toHaveLength(0);
+  });
+
+  it("delivers pushed snapshots and closes the source on unmount", () => {
+    const { result, unmount } = renderHook(() => useQuotesStream(["SPY"]));
+
+    const payload = { timestamp: "2026-07-03T00:00:00Z", count: 0, quotes: [] };
+    act(() => {
+      FakeEventSource.instances[0]!.emit("quotes", JSON.stringify(payload));
+    });
+
+    expect(result.current.healthy).toBe(true);
+    expect(result.current.snapshot).toEqual(payload);
+
+    unmount();
+    expect(FakeEventSource.instances[0]!.closed).toBe(true);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/hooks/use-quotes-stream.test.ts
+++ b/src/Meridian.Ui/dashboard/src/hooks/use-quotes-stream.test.ts
@@ -30,11 +30,15 @@ class FakeEventSource {
 
 describe("useQuotesStream", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     FakeEventSource.instances = [];
     vi.stubGlobal("EventSource", FakeEventSource);
   });
 
   afterEach(() => {
+    // Drain any pending close-linger timers so connections never leak into the next test.
+    vi.runAllTimers();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -56,6 +60,9 @@ describe("useQuotesStream", () => {
     expect(result.current.snapshot).toEqual(payload);
 
     unmount();
+    act(() => {
+      vi.runAllTimers();
+    });
     expect(FakeEventSource.instances[0]!.closed).toBe(true);
   });
 });

--- a/src/Meridian.Ui/dashboard/src/hooks/use-quotes-stream.ts
+++ b/src/Meridian.Ui/dashboard/src/hooks/use-quotes-stream.ts
@@ -1,0 +1,41 @@
+import { useEffect, useMemo, useState } from "react";
+import { subscribeQuotesStream } from "@/lib/quotes-stream";
+import type { QuotesSnapshotResponse } from "@/types";
+
+export interface QuotesStreamState {
+  snapshot: QuotesSnapshotResponse | null;
+  /** True while the SSE channel is delivering; consumers suspend polling then. */
+  healthy: boolean;
+}
+
+/**
+ * React binding for the shared workstation quote stream. Pass the subscribed
+ * symbols; an empty list keeps the stream closed and `healthy` false so the
+ * caller's polling fallback stays in charge.
+ */
+export function useQuotesStream(symbols: readonly string[]): QuotesStreamState {
+  const symbolsKey = useMemo(
+    () => [...new Set(symbols.map((symbol) => symbol.trim().toUpperCase()).filter(Boolean))].sort().join(","),
+    [symbols]
+  );
+  const [state, setState] = useState<QuotesStreamState>({ snapshot: null, healthy: false });
+
+  useEffect(() => {
+    if (!symbolsKey) {
+      setState({ snapshot: null, healthy: false });
+      return;
+    }
+
+    const unsubscribe = subscribeQuotesStream(symbolsKey.split(","), {
+      onSnapshot: (snapshot) => setState((current) => ({ ...current, snapshot })),
+      onHealthChange: (healthy) => setState((current) => (current.healthy === healthy ? current : { ...current, healthy }))
+    });
+
+    return () => {
+      unsubscribe();
+      setState({ snapshot: null, healthy: false });
+    };
+  }, [symbolsKey]);
+
+  return state;
+}

--- a/src/Meridian.Ui/dashboard/src/lib/price-alerts/service.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/price-alerts/service.ts
@@ -1,4 +1,5 @@
 import { createContext, createElement, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useQuotesStream } from "@/hooks/use-quotes-stream";
 import { getLiveQuotesSnapshot } from "@/lib/api";
 import type { QuotesSnapshotItem, QuotesSnapshotResponse } from "@/types";
 import { describeCondition, shouldTrigger } from "./evaluator";
@@ -181,6 +182,18 @@ export function usePriceAlertsService(options: ServiceOptions = {}): PriceAlerts
     return Array.from(symbols).sort();
   }, [state.alerts]);
 
+  const quotesStream = useQuotesStream(watchedSymbols);
+
+  useEffect(() => {
+    if (!quotesStream.snapshot || watchedSymbols.length === 0) {
+      return;
+    }
+
+    evaluateSnapshot(quotesStream.snapshot);
+    setLastPollAt(now().toISOString());
+    setPollErrorMessage(null);
+  }, [evaluateSnapshot, now, quotesStream.snapshot, watchedSymbols.length]);
+
   useEffect(() => {
     if (watchedSymbols.length === 0) {
       setPollErrorMessage(null);
@@ -208,13 +221,21 @@ export function usePriceAlertsService(options: ServiceOptions = {}): PriceAlerts
     };
 
     void tick();
+    if (quotesStream.healthy) {
+      // Pushed snapshots drive alert evaluation; polling resumes if the stream degrades.
+      return () => {
+        cancelled = true;
+        controller.abort();
+      };
+    }
+
     const interval = window.setInterval(() => void tick(), pollIntervalMs);
     return () => {
       cancelled = true;
       controller.abort();
       window.clearInterval(interval);
     };
-  }, [evaluateSnapshot, fetchSnapshot, pollIntervalMs, watchedSymbols.join("|")]);
+  }, [evaluateSnapshot, fetchSnapshot, pollIntervalMs, quotesStream.healthy, watchedSymbols.join("|")]);
 
   const createAlert = useCallback((draft: PriceAlertDraft) => {
     const id = `alert-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;

--- a/src/Meridian.Ui/dashboard/src/lib/quotes-stream.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/quotes-stream.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildQuotesStreamUrl, isQuotesStreamSupported, subscribeQuotesStream } from "@/lib/quotes-stream";
+import type { QuotesSnapshotResponse } from "@/types";
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  readonly url: string;
+  readonly listeners = new Map<string, Set<(event: MessageEvent<string> | Event) => void>>();
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: (event: MessageEvent<string> | Event) => void) {
+    const set = this.listeners.get(type) ?? new Set();
+    set.add(listener);
+    this.listeners.set(type, set);
+  }
+
+  emit(type: string, data?: string) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(data === undefined ? new Event(type) : new MessageEvent(type, { data }));
+    }
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
+const snapshot: QuotesSnapshotResponse = {
+  timestamp: "2026-07-03T00:00:00Z",
+  count: 1,
+  quotes: [
+    {
+      symbol: "SPY",
+      timestamp: "2026-07-03T00:00:00Z",
+      bidPrice: 450,
+      bidSize: 100,
+      askPrice: 450.05,
+      askSize: 200,
+      midPrice: 450.025,
+      spread: 0.05,
+      lastPrice: null,
+      lastSize: null,
+      lastTradeTimestamp: null,
+      sequenceNumber: 1,
+      streamId: "TEST",
+      venue: "NYSE",
+      session: null
+    }
+  ]
+};
+
+describe("quotes stream client", () => {
+  beforeEach(() => {
+    FakeEventSource.instances = [];
+    vi.stubGlobal("EventSource", FakeEventSource);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("builds a normalized, deduplicated stream URL", () => {
+    expect(buildQuotesStreamUrl(["msft", "AAPL", "aapl "])).toBe(
+      "/api/workstation/stream?symbols=AAPL%2CMSFT"
+    );
+  });
+
+  it("shares one EventSource per symbol set and closes on last unsubscribe", () => {
+    const first = subscribeQuotesStream(["SPY"], { onSnapshot: vi.fn() });
+    const second = subscribeQuotesStream(["spy"], { onSnapshot: vi.fn() });
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+
+    first();
+    expect(FakeEventSource.instances[0]!.closed).toBe(false);
+    second();
+    expect(FakeEventSource.instances[0]!.closed).toBe(true);
+  });
+
+  it("dispatches parsed snapshots and health transitions", () => {
+    const onSnapshot = vi.fn();
+    const onHealthChange = vi.fn();
+    const unsubscribe = subscribeQuotesStream(["SPY"], { onSnapshot, onHealthChange });
+
+    expect(onHealthChange).toHaveBeenLastCalledWith(false);
+
+    const source = FakeEventSource.instances[0]!;
+    source.emit("quotes", JSON.stringify(snapshot));
+    expect(onSnapshot).toHaveBeenCalledWith(snapshot);
+    expect(onHealthChange).toHaveBeenLastCalledWith(true);
+
+    source.emit("error");
+    expect(onHealthChange).toHaveBeenLastCalledWith(false);
+
+    source.emit("quotes", "not json");
+    expect(onSnapshot).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+  });
+
+  it("replays the last snapshot to late subscribers", () => {
+    const early = subscribeQuotesStream(["SPY"], { onSnapshot: vi.fn() });
+    FakeEventSource.instances[0]!.emit("quotes", JSON.stringify(snapshot));
+
+    const onSnapshot = vi.fn();
+    const late = subscribeQuotesStream(["SPY"], { onSnapshot });
+    expect(onSnapshot).toHaveBeenCalledWith(snapshot);
+
+    early();
+    late();
+  });
+
+  it("reports unsupported environments as unhealthy without subscribing", () => {
+    vi.unstubAllGlobals();
+    expect(isQuotesStreamSupported()).toBe(false);
+
+    const onHealthChange = vi.fn();
+    const unsubscribe = subscribeQuotesStream(["SPY"], { onSnapshot: vi.fn(), onHealthChange });
+    expect(onHealthChange).toHaveBeenCalledWith(false);
+    unsubscribe();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/lib/quotes-stream.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/quotes-stream.test.ts
@@ -56,11 +56,15 @@ const snapshot: QuotesSnapshotResponse = {
 
 describe("quotes stream client", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     FakeEventSource.instances = [];
     vi.stubGlobal("EventSource", FakeEventSource);
   });
 
   afterEach(() => {
+    // Drain any pending close-linger timers so connections never leak into the next test.
+    vi.runAllTimers();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -70,15 +74,32 @@ describe("quotes stream client", () => {
     );
   });
 
-  it("shares one EventSource per symbol set and closes on last unsubscribe", () => {
+  it("shares one EventSource per symbol set and closes after the linger on last unsubscribe", () => {
     const first = subscribeQuotesStream(["SPY"], { onSnapshot: vi.fn() });
     const second = subscribeQuotesStream(["spy"], { onSnapshot: vi.fn() });
 
     expect(FakeEventSource.instances).toHaveLength(1);
 
     first();
-    expect(FakeEventSource.instances[0]!.closed).toBe(false);
     second();
+    expect(FakeEventSource.instances[0]!.closed).toBe(false);
+
+    vi.runAllTimers();
+    expect(FakeEventSource.instances[0]!.closed).toBe(true);
+  });
+
+  it("reuses a lingering connection when a subscriber returns before the close fires", () => {
+    const first = subscribeQuotesStream(["SPY"], { onSnapshot: vi.fn() });
+    first();
+
+    const second = subscribeQuotesStream(["SPY"], { onSnapshot: vi.fn() });
+    vi.runAllTimers();
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0]!.closed).toBe(false);
+
+    second();
+    vi.runAllTimers();
     expect(FakeEventSource.instances[0]!.closed).toBe(true);
   });
 

--- a/src/Meridian.Ui/dashboard/src/lib/quotes-stream.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/quotes-stream.ts
@@ -15,9 +15,14 @@ interface QuotesStreamConnection {
   handlers: Set<QuotesStreamHandlers>;
   healthy: boolean;
   lastSnapshot: QuotesSnapshotResponse | null;
+  closeTimer: ReturnType<typeof setTimeout> | null;
 }
 
 const connections = new Map<string, QuotesStreamConnection>();
+
+// Grace period before an unreferenced connection closes, so StrictMode
+// double-mounts and quick same-stream transitions reuse it instead of churning.
+const CLOSE_LINGER_MS = 1000;
 
 export function buildQuotesStreamUrl(symbols: readonly string[]): string {
   const normalized = [...new Set(symbols.map((symbol) => symbol.trim().toUpperCase()).filter(Boolean))].sort();
@@ -49,6 +54,9 @@ export function subscribeQuotesStream(
   if (!connection) {
     connection = openConnection(url);
     connections.set(url, connection);
+  } else if (connection.closeTimer !== null) {
+    clearTimeout(connection.closeTimer);
+    connection.closeTimer = null;
   }
 
   connection.handlers.add(handlers);
@@ -64,9 +72,13 @@ export function subscribeQuotesStream(
     }
 
     current.handlers.delete(handlers);
-    if (current.handlers.size === 0) {
-      current.source.close();
-      connections.delete(url);
+    if (current.handlers.size === 0 && current.closeTimer === null) {
+      current.closeTimer = setTimeout(() => {
+        if (current.handlers.size === 0) {
+          current.source.close();
+          connections.delete(url);
+        }
+      }, CLOSE_LINGER_MS);
     }
   };
 }
@@ -77,7 +89,8 @@ function openConnection(url: string): QuotesStreamConnection {
     source,
     handlers: new Set(),
     healthy: false,
-    lastSnapshot: null
+    lastSnapshot: null,
+    closeTimer: null
   };
 
   const setHealthy = (healthy: boolean) => {

--- a/src/Meridian.Ui/dashboard/src/lib/quotes-stream.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/quotes-stream.ts
@@ -1,0 +1,113 @@
+// Shared client for the workstation SSE quote stream (live data spine, step 1).
+// One EventSource per symbol set is shared across subscribers with refcounting;
+// consumers keep their polling paths and suspend them only while the stream is
+// healthy, so degraded environments fall back to polling automatically.
+import { UI_API_ROUTES } from "@/lib/ui-api-routes.generated";
+import type { QuotesSnapshotResponse } from "@/types";
+
+export interface QuotesStreamHandlers {
+  onSnapshot: (snapshot: QuotesSnapshotResponse) => void;
+  onHealthChange?: (healthy: boolean) => void;
+}
+
+interface QuotesStreamConnection {
+  source: EventSource;
+  handlers: Set<QuotesStreamHandlers>;
+  healthy: boolean;
+  lastSnapshot: QuotesSnapshotResponse | null;
+}
+
+const connections = new Map<string, QuotesStreamConnection>();
+
+export function buildQuotesStreamUrl(symbols: readonly string[]): string {
+  const normalized = [...new Set(symbols.map((symbol) => symbol.trim().toUpperCase()).filter(Boolean))].sort();
+  return normalized.length > 0
+    ? `${UI_API_ROUTES.WorkstationStream}?symbols=${encodeURIComponent(normalized.join(","))}`
+    : UI_API_ROUTES.WorkstationStream;
+}
+
+export function isQuotesStreamSupported(): boolean {
+  return typeof EventSource !== "undefined";
+}
+
+/**
+ * Subscribes to pushed quote snapshots for the given symbols. Returns an
+ * unsubscribe callback; the underlying EventSource closes when the last
+ * subscriber for the same symbol set leaves.
+ */
+export function subscribeQuotesStream(
+  symbols: readonly string[],
+  handlers: QuotesStreamHandlers
+): () => void {
+  if (!isQuotesStreamSupported() || symbols.length === 0) {
+    handlers.onHealthChange?.(false);
+    return () => undefined;
+  }
+
+  const url = buildQuotesStreamUrl(symbols);
+  let connection = connections.get(url);
+  if (!connection) {
+    connection = openConnection(url);
+    connections.set(url, connection);
+  }
+
+  connection.handlers.add(handlers);
+  handlers.onHealthChange?.(connection.healthy);
+  if (connection.lastSnapshot) {
+    handlers.onSnapshot(connection.lastSnapshot);
+  }
+
+  return () => {
+    const current = connections.get(url);
+    if (!current) {
+      return;
+    }
+
+    current.handlers.delete(handlers);
+    if (current.handlers.size === 0) {
+      current.source.close();
+      connections.delete(url);
+    }
+  };
+}
+
+function openConnection(url: string): QuotesStreamConnection {
+  const source = new EventSource(url);
+  const connection: QuotesStreamConnection = {
+    source,
+    handlers: new Set(),
+    healthy: false,
+    lastSnapshot: null
+  };
+
+  const setHealthy = (healthy: boolean) => {
+    if (connection.healthy === healthy) {
+      return;
+    }
+
+    connection.healthy = healthy;
+    for (const handler of connection.handlers) {
+      handler.onHealthChange?.(healthy);
+    }
+  };
+
+  source.addEventListener("quotes", (event) => {
+    let snapshot: QuotesSnapshotResponse;
+    try {
+      snapshot = JSON.parse((event as MessageEvent<string>).data) as QuotesSnapshotResponse;
+    } catch {
+      return;
+    }
+
+    connection.lastSnapshot = snapshot;
+    setHealthy(true);
+    for (const handler of connection.handlers) {
+      handler.onSnapshot(snapshot);
+    }
+  });
+
+  // EventSource reconnects automatically; consumers resume polling while unhealthy.
+  source.addEventListener("error", () => setHealthy(false));
+
+  return connection;
+}

--- a/src/Meridian.Ui/dashboard/src/lib/ui-api-routes.generated.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/ui-api-routes.generated.ts
@@ -481,6 +481,7 @@ export const UI_API_ROUTES = {
   PromotionReject: "/api/promotion/reject",
   PromotionHistory: "/api/promotion/history",
   WorkstationSession: "/api/workstation/session",
+  WorkstationStream: "/api/workstation/stream",
   WorkstationResearch: "/api/workstation/research",
   WorkstationStrategy: "/api/workstation/strategy",
   WorkstationResearchBriefing: "/api/workstation/research/briefing",

--- a/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.tsx
@@ -200,6 +200,7 @@ export function LiveQuotesScreen() {
             />
             <FreshnessChip
               {...freshnessInputFromLifecycle(vm.requestStatus.snapshot, LIVE_QUOTES_FRESHNESS_BUDGET_MS, "Quote matrix")}
+              live={vm.quoteStreamHealthy}
             />
             {activeSymbol ? <span>Selected {activeSymbol}; last update {marketVm.lastUpdateLabel}</span> : null}
           </div>

--- a/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.view-model.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { useQuotesStream } from "@/hooks/use-quotes-stream";
 import { useRequestLifecycle, type RequestLifecycleStatus } from "@/hooks/use-request-lifecycle";
 import type { ApiRequestOptions } from "@/lib/api";
 import { describeApiError } from "@/lib/api-errors";
@@ -483,6 +484,7 @@ export interface LiveQuotesScreenViewModel {
   submitLookup: (event: FormEvent<HTMLFormElement>) => void;
   refreshMarketData: () => Promise<void>;
   requestStatus: LiveQuotesRequestStatusModel;
+  quoteStreamHealthy: boolean;
 }
 
 export interface LiveQuoteRefreshCommandViewModel {
@@ -540,6 +542,8 @@ export function useLiveQuotesScreenViewModel(
   const [refreshing, setRefreshing] = useState(false);
   const [refreshingSnapshot, setRefreshingSnapshot] = useState(false);
   const [paused, setPaused] = useState(false);
+  const streamSymbols = useMemo(() => (paused ? [] : symbolSet), [paused, symbolSet]);
+  const quotesStream = useQuotesStream(streamSymbols);
   const marketLifecycle = useRequestLifecycle({
     operation: "live quote market panels",
     runningMessage: "Refreshing live quote, trade, and order-book panels.",
@@ -663,14 +667,28 @@ export function useLiveQuotesScreenViewModel(
   }, [activeSymbol, fetchMarketData, paused]);
 
   useEffect(() => {
+    if (!quotesStream.snapshot) {
+      return;
+    }
+
+    const pushed = quotesStream.snapshot;
+    setSnapshot((current) => mergeLiveQuotesLoadState({ status: "fulfilled", value: pushed }, current, "Failed to load quote matrix"));
+  }, [quotesStream.snapshot]);
+
+  useEffect(() => {
     if (symbolSet.length === 0 || paused) {
       return;
     }
 
     void fetchSnapshotData(symbolSet);
+    if (quotesStream.healthy) {
+      // The SSE stream feeds the matrix; polling stays suspended until it degrades.
+      return;
+    }
+
     const interval = window.setInterval(() => void fetchSnapshotData(symbolSet), LIVE_QUOTES_POLL_INTERVAL_MS);
     return () => window.clearInterval(interval);
-  }, [fetchSnapshotData, paused, symbolSet]);
+  }, [fetchSnapshotData, paused, quotesStream.healthy, symbolSet]);
 
   useEffect(() => {
     const nextSymbolSet = initialLiveMarketDataSymbolSet(route.routeSymbols, route.routeSymbol);
@@ -850,7 +868,8 @@ export function useLiveQuotesScreenViewModel(
       market: marketLifecycle.status,
       snapshot: snapshotLifecycle.status,
       orderSubmission: quickTrade.requestStatus
-    }
+    },
+    quoteStreamHealthy: quotesStream.healthy
   };
 }
 

--- a/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.tsx
@@ -260,6 +260,7 @@ export function WatchlistScreen() {
                     <FreshnessChip
                       errorMessage={vm.quoteFreshnessError}
                       label="Watchlist quotes"
+                      live={vm.quoteStreamHealthy}
                       staleBudgetMs={WATCHLIST_QUOTE_FRESHNESS_BUDGET_MS}
                       timestamp={vm.quoteFreshnessTimestamp}
                     />

--- a/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.view-model.ts
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ApiRequestOptions } from "@/lib/api";
 import { describeApiError, type ApiErrorDisplay } from "@/lib/api-errors";
+import { useQuotesStream } from "@/hooks/use-quotes-stream";
 import { formatRelativeAge as formatRelative } from "@/lib/time";
 import { WORKSTATION_ROUTE_CATALOG, workstationRouteWithQuery } from "@/lib/workspace";
-import type { MetricSnapshot, QuotesSnapshotItem, SymbolRecord, SymbolStatistics } from "@/types";
+import type { MetricSnapshot, QuotesSnapshotItem, QuotesSnapshotResponse, SymbolRecord, SymbolStatistics } from "@/types";
 
 export type WatchlistBadgeVariant = "default" | "outline" | "success" | "warning" | "danger" | "paper" | "live" | "research";
 export type WatchlistListState = "loading" | "error" | "empty" | "ready";
@@ -222,6 +223,7 @@ export interface WatchlistScreenViewModel {
   quoteStatusDetails: string[];
   quoteFreshnessTimestamp: string | null;
   quoteFreshnessError: string | null;
+  quoteStreamHealthy: boolean;
   quoteProviderSetupHandoff: WatchlistProviderSetupHandoff | null;
   quoteRefreshCommand: WatchlistQuoteRefreshCommandState;
   starterPackGroupLabel: string;
@@ -471,6 +473,33 @@ export function useWatchlistScreenViewModel(api: WatchlistApi): WatchlistScreenV
   }, [api.removeSymbol, pendingRemoveSymbol, refresh]);
 
   const subscribedSymbols = useMemo(() => symbols?.map((symbol) => symbol.symbol) ?? [], [symbols]);
+  const quotesStream = useQuotesStream(subscribedSymbols);
+
+  const applyQuotesSnapshot = useCallback((response: Pick<QuotesSnapshotResponse, "quotes">) => {
+    const next: Record<string, QuotesSnapshotItem> = {};
+    for (const quote of response.quotes) {
+      next[quote.symbol.toUpperCase()] = quote;
+    }
+
+    setQuotes((current) => {
+      const previous: Record<string, number> = {};
+      for (const [symbol, quote] of Object.entries(current)) {
+        if (quote.midPrice !== null && quote.midPrice !== undefined) {
+          previous[symbol] = quote.midPrice;
+        }
+      }
+      previousMidRef.current = previous;
+      return next;
+    });
+    setQuoteFetchedAt(Date.now());
+    setQuoteError(null);
+  }, []);
+
+  useEffect(() => {
+    if (quotesStream.snapshot) {
+      applyQuotesSnapshot(quotesStream.snapshot);
+    }
+  }, [applyQuotesSnapshot, quotesStream.snapshot]);
 
   const fetchQuotes = useCallback(async (currentSymbols: readonly string[]) => {
     if (currentSymbols.length === 0) {
@@ -494,23 +523,7 @@ export function useWatchlistScreenViewModel(api: WatchlistApi): WatchlistScreenV
         return;
       }
 
-      const next: Record<string, QuotesSnapshotItem> = {};
-      for (const quote of response.quotes) {
-        next[quote.symbol.toUpperCase()] = quote;
-      }
-
-      setQuotes((current) => {
-        const previous: Record<string, number> = {};
-        for (const [symbol, quote] of Object.entries(current)) {
-          if (quote.midPrice !== null && quote.midPrice !== undefined) {
-            previous[symbol] = quote.midPrice;
-          }
-        }
-        previousMidRef.current = previous;
-        return next;
-      });
-      setQuoteFetchedAt(Date.now());
-      setQuoteError(null);
+      applyQuotesSnapshot(response);
     } catch (error) {
       if (mountedRef.current && currentQuoteSymbolsKeyRef.current === requestKey) {
         if (!isAbortError(error)) {
@@ -528,7 +541,7 @@ export function useWatchlistScreenViewModel(api: WatchlistApi): WatchlistScreenV
         void fetchQuotes(pendingSymbols);
       }
     }
-  }, [api.getLiveQuotesSnapshot]);
+  }, [api.getLiveQuotesSnapshot, applyQuotesSnapshot]);
 
   useEffect(() => {
     currentQuoteSymbolsKeyRef.current = buildQuoteSymbolsKey(subscribedSymbols);
@@ -543,12 +556,19 @@ export function useWatchlistScreenViewModel(api: WatchlistApi): WatchlistScreenV
     }
 
     void fetchQuotes(subscribedSymbols);
+    if (quotesStream.healthy) {
+      // The SSE stream is delivering; polling stays suspended until it degrades.
+      return () => {
+        quoteAbortRef.current?.abort();
+      };
+    }
+
     const interval = window.setInterval(() => void fetchQuotes(subscribedSymbols), QUOTE_POLL_INTERVAL_MS);
     return () => {
       quoteAbortRef.current?.abort();
       window.clearInterval(interval);
     };
-  }, [fetchQuotes, subscribedSymbols]);
+  }, [fetchQuotes, quotesStream.healthy, subscribedSymbols]);
 
   const refreshQuotes = useCallback(async () => {
     if (subscribedSymbols.length === 0 || quoteRefreshing) {
@@ -669,6 +689,7 @@ export function useWatchlistScreenViewModel(api: WatchlistApi): WatchlistScreenV
     quoteStatusDetails: quoteStatus.details,
     quoteFreshnessTimestamp: quoteFetchedAt ? new Date(quoteFetchedAt).toISOString() : null,
     quoteFreshnessError: quoteError?.summary ?? null,
+    quoteStreamHealthy: quotesStream.healthy,
     quoteProviderSetupHandoff: quoteError ? buildProviderSetupHandoff("live-quotes") : null,
     quoteRefreshCommand: buildQuoteRefreshCommand(listState, rows.length, quoteRefreshing),
     starterPackGroupLabel: "Watchlist starter packs",

--- a/tests/Meridian.Tests/Ui/WorkstationStreamEndpointTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationStreamEndpointTests.cs
@@ -1,0 +1,139 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using Meridian.Contracts.Domain.Models;
+using Meridian.Domain.Collectors;
+using Meridian.Tests.TestHelpers;
+using Meridian.Ui.Shared.Endpoints;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Meridian.Tests.Ui;
+
+public sealed class WorkstationStreamEndpointTests
+{
+    private static readonly JsonSerializerOptions ServerJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    [Fact]
+    public async Task GetWorkstationStream_WithoutQuoteCollector_Returns503()
+    {
+        await using var app = await CreateStreamAppAsync(registerCollector: false);
+        var client = app.GetTestClient();
+
+        var response = await client.GetAsync("/api/workstation/stream");
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task GetWorkstationStream_WithTooManySymbols_Returns400()
+    {
+        await using var app = await CreateStreamAppAsync(registerCollector: true);
+        var client = app.GetTestClient();
+
+        var symbols = string.Join(',', Enumerable.Range(0, 51).Select(index => $"SYM{index}"));
+        var response = await client.GetAsync($"/api/workstation/stream?symbols={symbols}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task GetWorkstationStream_EmitsQuotesEventForFilteredSymbols()
+    {
+        await using var app = await CreateStreamAppAsync(registerCollector: true, seedSymbols: ["SPY", "MSFT"]);
+        var client = app.GetTestClient();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var response = await client.GetAsync(
+            "/api/workstation/stream?symbols=SPY",
+            HttpCompletionOption.ResponseHeadersRead,
+            cts.Token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("text/event-stream");
+
+        var frame = await ReadFirstEventFrameAsync(response, cts.Token);
+        frame.Should().StartWith("event: quotes");
+        frame.Should().Contain("\"symbol\":\"SPY\"");
+        frame.Should().NotContain("\"symbol\":\"MSFT\"");
+    }
+
+    private static async Task<string> ReadFirstEventFrameAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        var buffer = new byte[4096];
+        var builder = new StringBuilder();
+        while (!ct.IsCancellationRequested)
+        {
+            var read = await stream.ReadAsync(buffer, ct);
+            if (read <= 0)
+            {
+                break;
+            }
+
+            builder.Append(Encoding.UTF8.GetString(buffer, 0, read));
+            var text = builder.ToString();
+            var frameEnd = text.IndexOf("\n\n", StringComparison.Ordinal);
+            if (frameEnd >= 0)
+            {
+                return text[..frameEnd];
+            }
+        }
+
+        throw new TimeoutException("No SSE frame arrived before the read deadline.");
+    }
+
+    private static async Task<WebApplication> CreateStreamAppAsync(
+        bool registerCollector,
+        IReadOnlyList<string>? seedSymbols = null)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development
+        });
+        builder.WebHost.UseTestServer();
+
+        if (registerCollector)
+        {
+            var collector = new QuoteCollector(new TestMarketEventPublisher());
+            foreach (var symbol in seedSymbols ?? [])
+            {
+                collector.OnQuote(new MarketQuoteUpdate(
+                    Timestamp: DateTimeOffset.UtcNow,
+                    Symbol: symbol,
+                    BidPrice: 450.00m,
+                    BidSize: 100,
+                    AskPrice: 450.05m,
+                    AskSize: 200,
+                    StreamId: "TEST",
+                    Venue: "NYSE"));
+            }
+
+            builder.Services.AddSingleton(collector);
+        }
+
+        var app = builder.Build();
+        app.Use(AddTestTenantContext);
+        app.MapWorkstationEndpoints(ServerJsonOptions);
+        await app.StartAsync();
+        return app;
+    }
+
+    private static async Task AddTestTenantContext(HttpContext context, Func<Task> next)
+    {
+        context.Items[LoginSessionMiddleware.CurrentTenantIdKey] = "tenant-test";
+        context.Items[LoginSessionMiddleware.CurrentUserCompanyIdKey] = "company-test";
+        context.Items[LoginSessionMiddleware.CurrentUserKey] = "stream-test-operator";
+        await next();
+    }
+}


### PR DESCRIPTION
<!-- phase:PR7 -->
## Summary

Implements Phase 4 (step 1) of the [Web UI Improvements Implementation Plan](../blob/main/docs/product/web-ui-improvements-implementation-plan-2026-07.md): the SSE live data spine for quote-driven surfaces, landed behind a first-class polling fallback.

**Server**
- New `GET /api/workstation/stream?symbols=…` in `WorkstationEndpoints.Stream.cs`, modeled on the existing `/api/events/stream` poll-bridge precedent: 2s poll loop over the same read model the REST snapshot endpoint serves, emitting named `event: quotes` frames only when quote rows change (coalescing excludes the always-moving envelope timestamp), `: heartbeat` comments while idle, symbol filter capped at 50 (400 beyond), 503 when the quote collector isn't registered.
- The quotes-snapshot builder is extracted from `LiveDataEndpoints` into a shared `TryBuildQuotesSnapshotResponse` so REST and SSE serve one payload shape.
- Route constant `UiApiRoutes.WorkstationStream` + regenerated TS mirror.

**Client**
- `lib/quotes-stream.ts`: framework-agnostic manager sharing one `EventSource` per normalized symbol set (refcounted close, health tracking, last-snapshot replay for late subscribers, defensive JSON parse). `hooks/use-quotes-stream.ts` is the React binding.
- The three quote-driven pollers — watchlist, live-quotes matrix, price alerts — feed pushed snapshots through their **existing** success paths and suspend their `setInterval` loops only while the stream is healthy. Environments without `EventSource` (including jsdom) never report healthy, so polling behavior is byte-for-byte unchanged there.
- Freshness chips on stream-fed surfaces flip to the `live` state (the reserved flag from Phase 1).

**Explicitly deferred to step 2** (per plan, separately reviewed): event-driven fan-out from `EventPipeline` (which has no subscribe hook today), workspace topics for the `use-workstation-data` poller (a 30s poll-bridge adds nothing), and per-session stream caps. The plan doc's Phase 4 checklist records this split.

## Reason

Executes the next unit of the merged implementation plan after Phases 1–3 (#2087): the platform bet that makes quote surfaces push-fed and lights up the chips' live state, sequenced ahead of the notification center it will feed.

## Testing performed

- [x] `dotnet test tests/Meridian.Tests --filter FullyQualifiedName~WorkstationStreamEndpointTests` — 3/3 (503 without collector, 400 over-cap, real SSE frame read with content-type + symbol-filter assertions) plus the 12 preset endpoint tests still green
- [x] `dotnet test tests/Meridian.Ui.Tests` — 1223/1223
- [x] `dotnet build Meridian.sln -c Release /p:EnableWindowsTargeting=true` — 0 errors
- [x] `npm --prefix src/Meridian.Ui/dashboard run test` — full suite green (23/23 batches) including new stream-manager/hook tests with a stubbed EventSource and the affected watchlist/live-quotes/price-alerts suites
- [x] `npm --prefix src/Meridian.Ui/dashboard run build` — typecheck + bundle clean
- [x] Docs regenerated twice with the CI core profile — no drift
- [ ] Full `bash scripts/ci.sh` quality-gate — deferred to the GitHub-hosted authoritative check per CLAUDE.md

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ)_