### PR TITLE
Web UI: shell notification center (Phase 5)

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -4838,6 +4838,8 @@ Meridian-main
 │   │   │   │   │   │   ├── metric-card.tsx
 │   │   │   │   │   │   ├── metric-card.view-model.test.ts
 │   │   │   │   │   │   ├── metric-card.view-model.ts
+│   │   │   │   │   │   ├── notification-center.test.tsx
+│   │   │   │   │   │   ├── notification-center.tsx
 │   │   │   │   │   │   ├── number-passport.test.ts
 │   │   │   │   │   │   ├── number-passport.tsx
 │   │   │   │   │   │   ├── quant-notebook.test.tsx
@@ -4979,6 +4981,7 @@ Meridian-main
 │   │   │   │   │       ├── entity-setup-wizard.test.tsx
 │   │   │   │   │       └── entity-setup-wizard.tsx
 │   │   │   │   ├── hooks
+│   │   │   │   │   ├── use-notification-center.ts
 │   │   │   │   │   ├── use-quotes-stream.test.ts
 │   │   │   │   │   ├── use-quotes-stream.ts
 │   │   │   │   │   ├── use-request-lifecycle.test.ts
@@ -4995,6 +4998,12 @@ Meridian-main
 │   │   │   │   │   │   ├── index.ts
 │   │   │   │   │   │   ├── payoff.test.ts
 │   │   │   │   │   │   └── payoff.ts
+│   │   │   │   │   ├── notification-center
+│   │   │   │   │   │   ├── merge.test.ts
+│   │   │   │   │   │   ├── merge.ts
+│   │   │   │   │   │   ├── read-state.test.ts
+│   │   │   │   │   │   ├── read-state.ts
+│   │   │   │   │   │   └── types.ts
 │   │   │   │   │   ├── price-alerts
 │   │   │   │   │   │   ├── evaluator.test.ts
 │   │   │   │   │   │   ├── evaluator.ts

--- a/docs/product/web-ui-improvements-implementation-plan-2026-07.md
+++ b/docs/product/web-ui-improvements-implementation-plan-2026-07.md
@@ -211,20 +211,28 @@ No feature work; confirm and document the rules each later phase must follow.
   (`components/ui/sheet.tsx`) with severity grouping and per-item deep links. Every toast shown
   via `useToast` for these feeds is also written to the center — nothing is toast-only.
   Low-severity events default to inbox-silent (no toast).
-- **Read state:** net-new small file-backed store following the `FileWorkflowPresetStore`
-  template (snapshot record, `SemaphoreSlim`, `AtomicFileWriter`, STJ source-gen) — the only
-  mutable inbox store today (`InMemoryOperatorInboxService`) is `INonProductionOnlyService`.
-  Endpoints: `GET/POST /api/workstation/notifications/read-state` in a new partial.
-- **Delivery:** polls on the workspace cadence until Phase 4; then subscribes to the `inbox` topic.
-- **Tests:** merge/dedup/severity unit tests; read-state endpoint tests; bell + sheet interaction
-  tests.
-- **Validation:** `npm --prefix src/Meridian.Ui/dashboard run test` and
-  `dotnet test tests/Meridian.Tests -c Release /p:EnableWindowsTargeting=true --filter FullyQualifiedName~NotificationReadState`
+- **Read state:** *Amended at implementation — client-side (localStorage), not the server file
+  store the plan first sketched.* Exploration showed the feeds have mismatched persistence: price
+  alerts already carry durable read/acknowledged state client-side (`meridian.priceAlerts.v1`),
+  the operator inbox is server-*derived* but stateless (recomputed each request), and system
+  events are client-visible via the overview payload's `recentEvents`. So read/dismissed state for
+  the inbox + system feeds lives client-side under `meridian.workstation.notifications.v1`
+  (`lib/notification-center/read-state.ts`), matching the theme / SQL-workbench / price-alerts
+  convention — no net-new server persistence surface. Server-durable, cross-device read-state is a
+  possible later step (like the SSE fan-out was). Confirmed with the user before building.
+- **Delivery:** the center fetches the operator inbox on a 60s poll (degradable — a failed fetch
+  never blanks the other feeds), reads system events off the already-fetched overview payload, and
+  reads price-alert triggers off the price-alerts context.
+- **Tests:** merge/severity/read-state unit tests; bell + sheet interaction tests (open, mark-all,
+  deep link, inbox-failure resilience).
+- **Validation:** `npm --prefix src/Meridian.Ui/dashboard run test` (no server changes this phase).
 
 **Checklist**
-- [ ] Notification envelope + three-feed merge with dedup tests.
-- [ ] Bell + sheet UI; toasts mirrored into the center.
-- [ ] File-backed read-state store + endpoints + tests.
+- [x] Notification envelope + three-feed merge with unit tests (`lib/notification-center/merge.ts`).
+- [x] Bell + sheet UI (`components/meridian/notification-center.tsx`) replacing the price-alerts
+      bell; per-item deep links via `routeForOperatorWorkItem`; severity grouping.
+- [x] Client-side read-state store + tests (`lib/notification-center/read-state.ts`) — server
+      file store deferred (client-side chosen; see amendment above).
 
 ---
 

--- a/docs/status/TODO.md
+++ b/docs/status/TODO.md
@@ -1,6 +1,6 @@
 # TODO / FIXME / HACK / NOTE Scan
 
-Total items: **208**
+Total items: **209**
 
 | File | Line | Tag | Linked Issue | Text |
 | --- | ---: | --- | :---: | --- |
@@ -81,6 +81,7 @@ Total items: **208**
 | `src/Meridian.Ui/dashboard/src/lib/dev-fixtures.ts` | 1400 | `NOTE` | ❌ | note: "Investor email-link delivery.", |
 | `src/Meridian.Ui/dashboard/src/lib/dev-fixtures.ts` | 1505 | `NOTE` | ❌ | note: "pricing-correction" |
 | `src/Meridian.Ui/dashboard/src/lib/dev-fixtures.ts` | 2191 | `NOTE` | ❌ | note: "Fixture handoff retained after identity review.", |
+| `src/Meridian.Ui/dashboard/src/lib/notification-center/merge.test.ts` | 47 | `NOTE` | ❌ | note: null, |
 | `src/Meridian.Ui/dashboard/src/lib/price-alerts/service.ts` | 146 | `NOTE` | ❌ | note: alert.note |
 | `src/Meridian.Ui/dashboard/src/lib/price-alerts/service.ts` | 248 | `NOTE` | ❌ | note: draft.note?.trim() ? draft.note.trim() : null, |
 | `src/Meridian.Ui/dashboard/src/lib/price-alerts/storage.test.ts` | 31 | `NOTE` | ❌ | note: null, |

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,11 +1,11 @@
 {
   "total_files": 538,
-  "total_lines": 88572,
+  "total_lines": 88589,
   "orphaned_count": 205,
   "no_heading_count": 38,
   "stale_count": 0,
   "todo_count": 199,
-  "average_lines": 164.6,
+  "average_lines": 164.7,
   "health_score": 83,
   "orphaned_files": [
     ".agents/skills/meridian-archive-organizer/SKILL.md",
@@ -2138,7 +2138,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7772,
+      "line_count": 7781,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -3106,7 +3106,7 @@
     },
     {
       "path": "docs/product/web-ui-improvements-implementation-plan-2026-07.md",
-      "line_count": 291,
+      "line_count": 299,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,8 +20,8 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 538 |
-| Total lines | 88,572 |
-| Average file size (lines) | 164.6 |
+| Total lines | 88,589 |
+| Average file size (lines) | 164.7 |
 | Orphaned files | 205 |
 | Files without headings | 38 |
 | Stale files (>90 days) | 0 |

--- a/src/Meridian.Ui/dashboard/src/app.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.tsx
@@ -2,7 +2,6 @@ import { Component, lazy, memo, Suspense, useEffect, useMemo, useRef, useState, 
 import {
   ArrowRight,
   AlertTriangle,
-  Bell,
   LoaderCircle,
   Menu,
   Search
@@ -50,7 +49,8 @@ import {
 } from "@/components/meridian/command-palette.actions";
 import { CopyLinkButton } from "@/components/meridian/copy-link-button";
 import { SaveViewButton } from "@/components/meridian/save-view-dialog";
-import { PriceAlertsProvider, usePriceAlerts } from "@/lib/price-alerts/service";
+import { NotificationCenter } from "@/components/meridian/notification-center";
+import { PriceAlertsProvider } from "@/lib/price-alerts/service";
 import { cn } from "@/lib/utils";
 import { legacyWorkspaceRedirect, workspacePath } from "@/lib/workspace";
 import type { WorkspaceKey, WorkspaceSummary } from "@/types";
@@ -391,7 +391,7 @@ function AppShell() {
         <WorkstationTrustStrip viewModel={shell.trustStrip} />
 
         <div className="workstation-actions">
-          <PriceAlertsBell />
+          <NotificationCenter overview={overview} fundAccountId={operatingScopeInput.fundAccountId} />
           {session ? (
             <div
               className="workstation-session-card"
@@ -1017,33 +1017,6 @@ function WorkstationTrustStrip({
         );
       })}
     </section>
-  );
-}
-
-function PriceAlertsBell() {
-  const { unacknowledgedCount } = usePriceAlerts();
-  const hasUnread = unacknowledgedCount > 0;
-  if (!hasUnread) {
-    return null;
-  }
-
-  const label = `${unacknowledgedCount} unacknowledged price alert${unacknowledgedCount === 1 ? "" : "s"}`;
-
-  return (
-    <Link
-      to="/data/alerts"
-      aria-label={label}
-      title={label}
-      className="relative inline-flex h-9 w-9 items-center justify-center rounded-md border border-border/60 bg-transparent text-muted-foreground transition-colors hover:bg-secondary/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-    >
-      <Bell className="h-4 w-4" aria-hidden="true" />
-      <span
-        aria-hidden="true"
-        className="absolute -right-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full border border-background bg-warning px-1 font-mono text-[10px] font-semibold leading-none text-background"
-      >
-        {unacknowledgedCount > 99 ? "99+" : unacknowledgedCount}
-      </span>
-    </Link>
   );
 }
 

--- a/src/Meridian.Ui/dashboard/src/components/meridian/notification-center.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/notification-center.test.tsx
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { NotificationCenter } from "@/components/meridian/notification-center";
+import { PriceAlertsProvider } from "@/lib/price-alerts/service";
+import * as api from "@/lib/api";
+import type { OperatorInbox, SystemOverviewResponse } from "@/types";
+
+function memoryStorage() {
+  const map = new Map<string, string>();
+  return {
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => void map.set(key, value),
+    removeItem: (key) => void map.delete(key)
+  };
+}
+
+const inbox: OperatorInbox = {
+  asOf: "2026-07-03T12:00:00Z",
+  criticalCount: 1,
+  warningCount: 0,
+  reviewCount: 0,
+  summary: "1 critical",
+  items: [
+    {
+      workItemId: "reconciliation-break-run-1",
+      kind: "ReconciliationBreak",
+      label: "Reconciliation break",
+      detail: "Position break needs review.",
+      tone: "Critical",
+      createdAt: "2026-07-03T12:00:00Z",
+      runId: "run-1",
+      fundAccountId: null,
+      auditReference: null,
+      workspace: "accounting",
+      targetRoute: "/accounting/reconciliation",
+      targetPageTag: "FundReconciliation"
+    }
+  ]
+};
+
+const overview = {
+  recentEvents: [
+    { id: "evt-1", type: "warning", message: "Provider latency elevated.", source: "Alpaca", timestamp: "2026-07-03T11:59:00Z" }
+  ]
+} as unknown as SystemOverviewResponse;
+
+function renderCenter() {
+  return render(
+    <MemoryRouter>
+      <PriceAlertsProvider options={{ storage: memoryStorage() }}>
+        <NotificationCenter overview={overview} />
+      </PriceAlertsProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("NotificationCenter", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    // Read-state persists to jsdom localStorage; clear it so tests stay isolated.
+    window.localStorage.clear();
+  });
+
+  it("shows the unread count and opens a severity-grouped drawer with deep links", async () => {
+    vi.spyOn(api, "getOperatorInbox").mockResolvedValue(inbox);
+    const user = userEvent.setup();
+    renderCenter();
+
+    // Inbox item + system event = 2 unread once the inbox resolves.
+    await waitFor(() => expect(screen.getByRole("button", { name: "Notifications — 2 unread" })).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: "Notifications — 2 unread" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Notifications" });
+    expect(within(dialog).getByText("Reconciliation break")).toBeInTheDocument();
+    expect(within(dialog).getByText("Alpaca")).toBeInTheDocument();
+    expect(within(dialog).getByRole("link", { name: "Open Reconciliation break" })).toHaveAttribute(
+      "href",
+      "/accounting/reconciliation"
+    );
+  });
+
+  it("marks everything read from the drawer, clearing the badge", async () => {
+    vi.spyOn(api, "getOperatorInbox").mockResolvedValue(inbox);
+    const user = userEvent.setup();
+    renderCenter();
+
+    await user.click(await screen.findByRole("button", { name: "Notifications — 2 unread" }));
+    await user.click(screen.getByRole("button", { name: /Mark all read/ }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Notifications — none unread" })).toBeInTheDocument());
+  });
+
+  it("still renders when the operator inbox fetch fails", async () => {
+    vi.spyOn(api, "getOperatorInbox").mockRejectedValue(new Error("inbox offline"));
+    renderCenter();
+
+    // The system event feed still produces one unread notification.
+    await waitFor(() => expect(screen.getByRole("button", { name: "Notifications — 1 unread" })).toBeInTheDocument());
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/meridian/notification-center.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/notification-center.tsx
@@ -1,0 +1,193 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { Bell, Check, ExternalLink, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetBody,
+  SheetCloseButton,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle
+} from "@/components/ui/sheet";
+import { useNotificationCenter } from "@/hooks/use-notification-center";
+import { formatRelativeAge } from "@/lib/time";
+import { cn } from "@/lib/utils";
+import type { NotificationEnvelope, NotificationSeverity } from "@/lib/notification-center/types";
+import type { SystemOverviewResponse } from "@/types";
+
+const SEVERITY_ORDER: NotificationSeverity[] = ["critical", "warning", "info", "success"];
+const SEVERITY_LABELS: Record<NotificationSeverity, string> = {
+  critical: "Critical",
+  warning: "Warning",
+  info: "Info",
+  success: "Resolved"
+};
+const SEVERITY_DOT: Record<NotificationSeverity, string> = {
+  critical: "bg-danger",
+  warning: "bg-warning",
+  info: "bg-primary",
+  success: "bg-success"
+};
+const SOURCE_LABELS: Record<NotificationEnvelope["source"], string> = {
+  inbox: "Operator inbox",
+  system: "System",
+  "price-alert": "Price alert"
+};
+
+export interface NotificationCenterProps {
+  overview: SystemOverviewResponse | null;
+  fundAccountId?: string | null;
+}
+
+/**
+ * Masthead notification bell + drawer. Merges the operator inbox, system events,
+ * and price-alert triggers into one severity-grouped feed with per-item deep links
+ * and read/dismiss actions. Replaces the standalone price-alerts bell.
+ */
+export function NotificationCenter({ overview, fundAccountId }: NotificationCenterProps) {
+  const [open, setOpen] = useState(false);
+  const center = useNotificationCenter({ overview, fundAccountId });
+  const { notifications, unreadCount } = center;
+
+  const bellLabel = unreadCount > 0
+    ? `Notifications — ${unreadCount} unread`
+    : "Notifications — none unread";
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label={bellLabel}
+        title={bellLabel}
+        onClick={() => setOpen(true)}
+        className="relative inline-flex h-9 w-9 items-center justify-center rounded-md border border-border/60 bg-transparent text-muted-foreground transition-colors hover:bg-secondary/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+      >
+        <Bell className="h-4 w-4" aria-hidden="true" />
+        {unreadCount > 0 ? (
+          <span
+            aria-hidden="true"
+            className="absolute -right-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full border border-background bg-warning px-1 font-mono text-[10px] font-semibold leading-none text-background"
+          >
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        ) : null}
+      </button>
+
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent aria-labelledby="notification-center-title" aria-describedby="notification-center-summary" side="right">
+          <SheetHeader>
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <SheetTitle id="notification-center-title">Notifications</SheetTitle>
+                <SheetDescription id="notification-center-summary">
+                  {notifications.length === 0
+                    ? "You're all caught up."
+                    : `${unreadCount} unread of ${notifications.length}.`}
+                </SheetDescription>
+              </div>
+              <div className="flex flex-shrink-0 items-center gap-2">
+                {unreadCount > 0 ? (
+                  <Button size="sm" variant="outline" type="button" onClick={() => center.markAllRead()}>
+                    <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                    Mark all read
+                  </Button>
+                ) : null}
+                <SheetCloseButton onClick={() => setOpen(false)} />
+              </div>
+            </div>
+          </SheetHeader>
+          <SheetBody>
+            {notifications.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No operator, system, or price-alert notifications right now.</p>
+            ) : (
+              SEVERITY_ORDER.map((severity) => {
+                const rows = notifications.filter((entry) => entry.severity === severity);
+                if (rows.length === 0) {
+                  return null;
+                }
+                return (
+                  <section key={severity} aria-label={`${SEVERITY_LABELS[severity]} notifications`} className="space-y-2">
+                    <div className="eyebrow-label">{SEVERITY_LABELS[severity]}</div>
+                    <ul className="space-y-2">
+                      {rows.map((entry) => (
+                        <NotificationRow
+                          key={entry.id}
+                          entry={entry}
+                          onMarkRead={() => center.markRead(entry.id)}
+                          onDismiss={() => center.dismiss(entry.id)}
+                          onOpenRoute={() => {
+                            center.markRead(entry.id);
+                            setOpen(false);
+                          }}
+                        />
+                      ))}
+                    </ul>
+                  </section>
+                );
+              })
+            )}
+          </SheetBody>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}
+
+interface NotificationRowProps {
+  entry: NotificationEnvelope;
+  onMarkRead: () => void;
+  onDismiss: () => void;
+  onOpenRoute: () => void;
+}
+
+function NotificationRow({ entry, onMarkRead, onDismiss, onOpenRoute }: NotificationRowProps) {
+  return (
+    <li
+      className={cn(
+        "rounded-md border px-3 py-2.5 text-sm transition-colors",
+        entry.read ? "border-border/50 bg-transparent" : "border-primary/30 bg-primary/5"
+      )}
+    >
+      <div className="flex items-start gap-2.5">
+        <span
+          aria-hidden="true"
+          className={cn("mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full", entry.read ? "bg-muted-foreground/40" : SEVERITY_DOT[entry.severity])}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className={cn("truncate", entry.read ? "font-medium" : "font-semibold")}>{entry.title}</span>
+            {!entry.read ? <span className="sr-only">(unread)</span> : null}
+          </div>
+          <p className="mt-0.5 text-xs leading-5 text-muted-foreground">{entry.detail}</p>
+          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+            <span>{SOURCE_LABELS[entry.source]}</span>
+            <span aria-hidden="true">·</span>
+            <span>{formatRelativeAge(entry.timestamp)}</span>
+          </div>
+        </div>
+        <div className="flex flex-shrink-0 flex-col items-end gap-1.5">
+          {entry.route ? (
+            <Button asChild size="sm" variant="ghost">
+              <Link to={entry.route} onClick={onOpenRoute} aria-label={`Open ${entry.title}`}>
+                <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                <span className="ml-1">Open</span>
+              </Link>
+            </Button>
+          ) : null}
+          {!entry.read ? (
+            <Button size="sm" variant="ghost" type="button" onClick={onMarkRead} aria-label={`Mark ${entry.title} as read`}>
+              <Check className="h-3.5 w-3.5" aria-hidden="true" />
+            </Button>
+          ) : null}
+          {entry.dismissible ? (
+            <Button size="sm" variant="ghost" type="button" onClick={onDismiss} aria-label={`Dismiss ${entry.title}`}>
+              <X className="h-3.5 w-3.5" aria-hidden="true" />
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/hooks/use-notification-center.ts
+++ b/src/Meridian.Ui/dashboard/src/hooks/use-notification-center.ts
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { usePriceAlerts } from "@/lib/price-alerts/service";
+import { getOperatorInbox } from "@/lib/api";
+import {
+  buildNotificationCenterModel,
+  type NotificationCenterModel
+} from "@/lib/notification-center/merge";
+import {
+  dismissNotification,
+  loadNotificationReadState,
+  markNotificationRead,
+  markNotificationsRead,
+  saveNotificationReadState,
+  type NotificationReadState,
+  type StorageLike
+} from "@/lib/notification-center/read-state";
+import type { NotificationEnvelope } from "@/lib/notification-center/types";
+import type { OperatorInbox, SystemOverviewResponse } from "@/types";
+
+const DEFAULT_INBOX_POLL_INTERVAL_MS = 60_000;
+
+export interface UseNotificationCenterOptions {
+  overview: SystemOverviewResponse | null;
+  fundAccountId?: string | null;
+  fetchInbox?: (fundAccountId?: string) => Promise<OperatorInbox>;
+  storage?: StorageLike | null;
+  pollIntervalMs?: number;
+}
+
+export interface NotificationCenterApi extends NotificationCenterModel {
+  markRead: (id: string) => void;
+  markAllRead: () => void;
+  dismiss: (id: string) => void;
+}
+
+/**
+ * Shell-level notification center: fetches the operator inbox, reads system
+ * events off the overview payload and price-alert triggers off the price-alerts
+ * context, then merges them into one read-state-aware feed. Inbox fetch failures
+ * are non-blocking — the center still surfaces the other feeds.
+ */
+export function useNotificationCenter(options: UseNotificationCenterOptions): NotificationCenterApi {
+  const { overview, fundAccountId, fetchInbox = getOperatorInbox, storage, pollIntervalMs = DEFAULT_INBOX_POLL_INTERVAL_MS } = options;
+  const priceAlerts = usePriceAlerts();
+  const [inbox, setInbox] = useState<OperatorInbox | null>(null);
+  const [readState, setReadState] = useState<NotificationReadState>(() => loadNotificationReadState(storage));
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const normalizedFundAccountId = fundAccountId ?? undefined;
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const next = await fetchInbox(normalizedFundAccountId);
+        if (!cancelled && mountedRef.current) {
+          setInbox(next);
+        }
+      } catch {
+        // Inbox is one of three feeds — a failed fetch must not blank the center.
+      }
+    };
+
+    void load();
+    const interval = window.setInterval(() => void load(), pollIntervalMs);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [fetchInbox, normalizedFundAccountId, pollIntervalMs]);
+
+  const model = useMemo(
+    () =>
+      buildNotificationCenterModel({
+        inbox: inbox?.items ?? [],
+        systemEvents: overview?.recentEvents ?? [],
+        priceTriggers: priceAlerts.state.triggers,
+        readState
+      }),
+    [inbox, overview, priceAlerts.state.triggers, readState]
+  );
+
+  const findEnvelope = useCallback(
+    (id: string): NotificationEnvelope | undefined => model.notifications.find((entry) => entry.id === id),
+    [model.notifications]
+  );
+
+  const commitReadState = useCallback(
+    (next: NotificationReadState) => {
+      setReadState((current) => {
+        if (next === current) {
+          return current;
+        }
+        saveNotificationReadState(next, storage);
+        return next;
+      });
+    },
+    [storage]
+  );
+
+  const markRead = useCallback(
+    (id: string) => {
+      const envelope = findEnvelope(id);
+      if (!envelope) {
+        return;
+      }
+      if (envelope.source === "price-alert") {
+        priceAlerts.acknowledgeTrigger(envelope.sourceId);
+        return;
+      }
+      commitReadState(markNotificationRead(readState, id));
+    },
+    [commitReadState, findEnvelope, priceAlerts, readState]
+  );
+
+  const markAllRead = useCallback(() => {
+    priceAlerts.acknowledgeAllTriggers();
+    const ids = model.notifications
+      .filter((entry) => entry.source !== "price-alert" && !entry.read)
+      .map((entry) => entry.id);
+    if (ids.length > 0) {
+      commitReadState(markNotificationsRead(readState, ids));
+    }
+  }, [commitReadState, model.notifications, priceAlerts, readState]);
+
+  const dismiss = useCallback(
+    (id: string) => {
+      const envelope = findEnvelope(id);
+      if (!envelope || !envelope.dismissible) {
+        return;
+      }
+      commitReadState(dismissNotification(readState, id));
+    },
+    [commitReadState, findEnvelope, readState]
+  );
+
+  return { ...model, markRead, markAllRead, dismiss };
+}

--- a/src/Meridian.Ui/dashboard/src/hooks/use-notification-center.ts
+++ b/src/Meridian.Ui/dashboard/src/hooks/use-notification-center.ts
@@ -53,13 +53,18 @@ export function useNotificationCenter(options: UseNotificationCenterOptions): No
     };
   }, []);
 
+  // Hold fetchInbox in a ref so an inline (unstable) fetchInbox prop cannot re-run
+  // the poll effect every render — the effect only reacts to fund account + cadence.
+  const fetchInboxRef = useRef(fetchInbox);
+  fetchInboxRef.current = fetchInbox;
+
   const normalizedFundAccountId = fundAccountId ?? undefined;
   useEffect(() => {
     let cancelled = false;
 
     const load = async () => {
       try {
-        const next = await fetchInbox(normalizedFundAccountId);
+        const next = await fetchInboxRef.current(normalizedFundAccountId);
         if (!cancelled && mountedRef.current) {
           setInbox(next);
         }
@@ -74,7 +79,7 @@ export function useNotificationCenter(options: UseNotificationCenterOptions): No
       cancelled = true;
       window.clearInterval(interval);
     };
-  }, [fetchInbox, normalizedFundAccountId, pollIntervalMs]);
+  }, [normalizedFundAccountId, pollIntervalMs]);
 
   const model = useMemo(
     () =>

--- a/src/Meridian.Ui/dashboard/src/lib/notification-center/merge.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/notification-center/merge.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { buildNotificationCenterModel } from "@/lib/notification-center/merge";
+import { emptyNotificationReadState } from "@/lib/notification-center/read-state";
+import type { OperatorWorkItem, SystemEventRecord } from "@/types";
+import type { PriceAlertTrigger } from "@/lib/price-alerts/index";
+
+function inboxItem(overrides: Partial<OperatorWorkItem> = {}): OperatorWorkItem {
+  return {
+    workItemId: "reconciliation-break-run-1",
+    kind: "ReconciliationBreak",
+    label: "Reconciliation break",
+    detail: "Position break needs review.",
+    tone: "Critical",
+    createdAt: "2026-07-03T12:00:00Z",
+    runId: "run-1",
+    fundAccountId: null,
+    auditReference: null,
+    workspace: "accounting",
+    targetRoute: "/accounting/reconciliation",
+    targetPageTag: "FundReconciliation",
+    ...overrides
+  };
+}
+
+function systemEvent(overrides: Partial<SystemEventRecord> = {}): SystemEventRecord {
+  return {
+    id: "evt-1",
+    type: "warning",
+    message: "Provider latency elevated.",
+    source: "Alpaca",
+    timestamp: "2026-07-03T11:59:00Z",
+    ...overrides
+  };
+}
+
+function priceTrigger(overrides: Partial<PriceAlertTrigger> = {}): PriceAlertTrigger {
+  return {
+    id: "trigger-1",
+    alertId: "alert-1",
+    symbol: "AAPL",
+    condition: "above",
+    field: "last",
+    threshold: 200,
+    triggeredPrice: 201.5,
+    triggeredAt: "2026-07-03T11:58:00Z",
+    acknowledged: false,
+    note: null,
+    ...overrides
+  };
+}
+
+describe("buildNotificationCenterModel", () => {
+  it("merges the three feeds with mapped severities and a deep link for inbox items", () => {
+    const model = buildNotificationCenterModel({
+      inbox: [inboxItem()],
+      systemEvents: [systemEvent()],
+      priceTriggers: [priceTrigger()],
+      readState: emptyNotificationReadState()
+    });
+
+    expect(model.notifications).toHaveLength(3);
+    expect(model.unreadCount).toBe(3);
+
+    const inbox = model.notifications.find((entry) => entry.source === "inbox")!;
+    expect(inbox.severity).toBe("critical");
+    expect(inbox.route).toBe("/accounting/reconciliation");
+    expect(inbox.dismissible).toBe(true);
+
+    const system = model.notifications.find((entry) => entry.source === "system")!;
+    expect(system.severity).toBe("warning");
+    expect(system.route).toBeNull();
+
+    const price = model.notifications.find((entry) => entry.source === "price-alert")!;
+    expect(price.severity).toBe("warning");
+    expect(price.route).toBe("/data/alerts");
+    expect(price.dismissible).toBe(false);
+  });
+
+  it("orders unread first, then by severity, then newest", () => {
+    const model = buildNotificationCenterModel({
+      inbox: [
+        inboxItem({ workItemId: "w-info", tone: "Info", label: "Info item", createdAt: "2026-07-03T10:00:00Z" }),
+        inboxItem({ workItemId: "w-crit", tone: "Critical", label: "Critical item", createdAt: "2026-07-03T09:00:00Z" })
+      ],
+      systemEvents: [],
+      priceTriggers: [],
+      readState: { version: 1, readIds: ["inbox:w-crit"], dismissedIds: [] }
+    });
+
+    // The unread Info item sorts ahead of the read Critical item.
+    expect(model.notifications.map((entry) => entry.sourceId)).toEqual(["w-info", "w-crit"]);
+    expect(model.unreadCount).toBe(1);
+  });
+
+  it("applies read state from the store and the trigger's own acknowledged flag", () => {
+    const model = buildNotificationCenterModel({
+      inbox: [inboxItem()],
+      systemEvents: [],
+      priceTriggers: [priceTrigger({ acknowledged: true })],
+      readState: { version: 1, readIds: ["inbox:reconciliation-break-run-1"], dismissedIds: [] }
+    });
+
+    expect(model.unreadCount).toBe(0);
+    expect(model.notifications.every((entry) => entry.read)).toBe(true);
+  });
+
+  it("filters out dismissed inbox and system items", () => {
+    const model = buildNotificationCenterModel({
+      inbox: [inboxItem()],
+      systemEvents: [systemEvent()],
+      priceTriggers: [],
+      readState: { version: 1, readIds: [], dismissedIds: ["inbox:reconciliation-break-run-1", "system:evt-1"] }
+    });
+
+    expect(model.notifications).toHaveLength(0);
+  });
+
+  it("counts unread by severity", () => {
+    const model = buildNotificationCenterModel({
+      inbox: [
+        inboxItem({ workItemId: "c1", tone: "Critical" }),
+        inboxItem({ workItemId: "w1", tone: "Warning" })
+      ],
+      systemEvents: [systemEvent({ id: "e1", type: "error" })],
+      priceTriggers: [],
+      readState: emptyNotificationReadState()
+    });
+
+    expect(model.severityCounts).toEqual({ critical: 2, warning: 1, info: 0, success: 0 });
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/lib/notification-center/merge.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/notification-center/merge.ts
@@ -1,0 +1,173 @@
+import { routeForOperatorWorkItem } from "@/app-shell.workflow-routing";
+import type { OperatorWorkItem, OperatorWorkItemTone, SystemEventRecord } from "@/types";
+import type { PriceAlertTrigger } from "@/lib/price-alerts/index";
+import type { NotificationEnvelope, NotificationSeverity, NotificationSeverityCounts } from "@/lib/notification-center/types";
+import type { NotificationReadState } from "@/lib/notification-center/read-state";
+
+const SEVERITY_RANK: Record<NotificationSeverity, number> = {
+  critical: 3,
+  warning: 2,
+  info: 1,
+  success: 0
+};
+
+const PRICE_ALERTS_ROUTE = "/data/alerts";
+
+export interface NotificationFeeds {
+  inbox: readonly OperatorWorkItem[];
+  systemEvents: readonly SystemEventRecord[];
+  priceTriggers: readonly PriceAlertTrigger[];
+  readState: NotificationReadState;
+}
+
+export interface NotificationCenterModel {
+  notifications: NotificationEnvelope[];
+  unreadCount: number;
+  severityCounts: NotificationSeverityCounts;
+}
+
+/**
+ * Merges the operator inbox, system events, and price-alert triggers into one
+ * ordered feed. Inbox/system read state comes from `readState`; price-alert read
+ * state is the trigger's own `acknowledged` flag. Dismissed inbox/system items are
+ * filtered out entirely.
+ */
+export function buildNotificationCenterModel(feeds: NotificationFeeds): NotificationCenterModel {
+  const dismissed = new Set(feeds.readState.dismissedIds);
+  const read = new Set(feeds.readState.readIds);
+  const envelopes: NotificationEnvelope[] = [];
+
+  for (const item of feeds.inbox) {
+    const id = `inbox:${item.workItemId}`;
+    if (dismissed.has(id)) {
+      continue;
+    }
+    envelopes.push({
+      id,
+      source: "inbox",
+      sourceId: item.workItemId,
+      severity: severityFromInboxTone(item.tone),
+      title: item.label,
+      detail: item.detail,
+      timestamp: item.createdAt,
+      route: safeRoute(() => routeForOperatorWorkItem(item)),
+      read: read.has(id),
+      dismissible: true
+    });
+  }
+
+  for (const event of feeds.systemEvents) {
+    const id = `system:${event.id}`;
+    if (dismissed.has(id)) {
+      continue;
+    }
+    envelopes.push({
+      id,
+      source: "system",
+      sourceId: event.id,
+      severity: severityFromSystemType(event.type),
+      title: event.source,
+      detail: event.message,
+      timestamp: event.timestamp,
+      route: null,
+      read: read.has(id),
+      dismissible: true
+    });
+  }
+
+  for (const trigger of feeds.priceTriggers) {
+    const id = `price-alert:${trigger.id}`;
+    envelopes.push({
+      id,
+      source: "price-alert",
+      sourceId: trigger.id,
+      severity: "warning",
+      title: `${trigger.symbol} price alert`,
+      detail: describePriceTrigger(trigger),
+      timestamp: trigger.triggeredAt,
+      route: PRICE_ALERTS_ROUTE,
+      read: trigger.acknowledged,
+      dismissible: false
+    });
+  }
+
+  envelopes.sort(compareEnvelopes);
+
+  const severityCounts: NotificationSeverityCounts = { critical: 0, warning: 0, info: 0, success: 0 };
+  let unreadCount = 0;
+  for (const envelope of envelopes) {
+    if (!envelope.read) {
+      unreadCount += 1;
+      severityCounts[envelope.severity] += 1;
+    }
+  }
+
+  return { notifications: envelopes, unreadCount, severityCounts };
+}
+
+function compareEnvelopes(a: NotificationEnvelope, b: NotificationEnvelope): number {
+  // Unread first, then by severity, then newest.
+  if (a.read !== b.read) {
+    return a.read ? 1 : -1;
+  }
+  const severity = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
+  if (severity !== 0) {
+    return severity;
+  }
+  return compareTimestampsDesc(a.timestamp, b.timestamp);
+}
+
+function compareTimestampsDesc(a: string, b: string): number {
+  const left = Date.parse(a);
+  const right = Date.parse(b);
+  const leftValid = Number.isFinite(left);
+  const rightValid = Number.isFinite(right);
+  if (!leftValid && !rightValid) {
+    return 0;
+  }
+  if (!leftValid) {
+    return 1;
+  }
+  if (!rightValid) {
+    return -1;
+  }
+  return right - left;
+}
+
+function severityFromInboxTone(tone: OperatorWorkItemTone): NotificationSeverity {
+  switch (tone) {
+    case "Critical":
+      return "critical";
+    case "Warning":
+      return "warning";
+    case "Success":
+      return "success";
+    default:
+      return "info";
+  }
+}
+
+function severityFromSystemType(type: SystemEventRecord["type"]): NotificationSeverity {
+  switch (type) {
+    case "error":
+      return "critical";
+    case "warning":
+      return "warning";
+    default:
+      return "info";
+  }
+}
+
+function describePriceTrigger(trigger: PriceAlertTrigger): string {
+  const direction = trigger.condition.replace("-", " ");
+  return `${trigger.field} ${direction} ${trigger.threshold} — triggered at ${trigger.triggeredPrice}`;
+}
+
+function safeRoute(build: () => string): string | null {
+  try {
+    const route = build();
+    return route && route.trim() ? route : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/Meridian.Ui/dashboard/src/lib/notification-center/read-state.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/notification-center/read-state.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  dismissNotification,
+  emptyNotificationReadState,
+  loadNotificationReadState,
+  markNotificationRead,
+  markNotificationsRead,
+  NOTIFICATION_READ_STATE_KEY,
+  NOTIFICATION_READ_STATE_LIMIT,
+  saveNotificationReadState,
+  type StorageLike
+} from "@/lib/notification-center/read-state";
+
+function memoryStorage(seed: Record<string, string> = {}): StorageLike {
+  const map = new Map(Object.entries(seed));
+  return {
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => void map.set(key, value),
+    removeItem: (key) => void map.delete(key)
+  };
+}
+
+describe("notification read-state", () => {
+  it("returns empty state when nothing is stored or the blob is malformed", () => {
+    expect(loadNotificationReadState(memoryStorage())).toEqual(emptyNotificationReadState());
+    expect(loadNotificationReadState(memoryStorage({ [NOTIFICATION_READ_STATE_KEY]: "not json" }))).toEqual(
+      emptyNotificationReadState()
+    );
+  });
+
+  it("round-trips read and dismissed ids, dropping non-string entries", () => {
+    const storage = memoryStorage();
+    saveNotificationReadState(
+      { version: 1, readIds: ["inbox:a", "", "inbox:b"], dismissedIds: ["system:x"] } as never,
+      storage
+    );
+
+    const loaded = loadNotificationReadState(storage);
+    expect(loaded.readIds).toEqual(["inbox:a", "inbox:b"]);
+    expect(loaded.dismissedIds).toEqual(["system:x"]);
+  });
+
+  it("marks ids read idempotently without duplication or churn", () => {
+    let state = markNotificationRead(emptyNotificationReadState(), "inbox:a");
+    state = markNotificationRead(state, "inbox:b");
+    const beforeRepeat = state;
+    state = markNotificationRead(state, "inbox:a");
+    expect(state.readIds).toEqual(["inbox:a", "inbox:b"]);
+    // Re-marking an already-read id is a no-op (same reference, no re-render churn).
+    expect(state).toBe(beforeRepeat);
+  });
+
+  it("marks many ids read in one pass", () => {
+    const state = markNotificationsRead(emptyNotificationReadState(), ["inbox:a", "system:b"]);
+    expect(state.readIds).toEqual(["inbox:a", "system:b"]);
+  });
+
+  it("dismissing also marks the id read", () => {
+    const state = dismissNotification(emptyNotificationReadState(), "inbox:a");
+    expect(state.dismissedIds).toContain("inbox:a");
+    expect(state.readIds).toContain("inbox:a");
+  });
+
+  it("caps stored id lists to the FIFO limit", () => {
+    let state = emptyNotificationReadState();
+    for (let index = 0; index < NOTIFICATION_READ_STATE_LIMIT + 25; index += 1) {
+      state = markNotificationRead(state, `inbox:${index}`);
+    }
+    expect(state.readIds).toHaveLength(NOTIFICATION_READ_STATE_LIMIT);
+    // Oldest ids trimmed; newest retained.
+    expect(state.readIds[state.readIds.length - 1]).toBe(`inbox:${NOTIFICATION_READ_STATE_LIMIT + 24}`);
+    expect(state.readIds[0]).toBe("inbox:25");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/lib/notification-center/read-state.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/notification-center/read-state.test.ts
@@ -61,6 +61,17 @@ describe("notification read-state", () => {
     expect(state.readIds).toContain("inbox:a");
   });
 
+  it("returns the same reference when marking an already-read batch (no re-render churn)", () => {
+    const state = markNotificationsRead(emptyNotificationReadState(), ["inbox:a", "inbox:b"]);
+    const again = markNotificationsRead(state, ["inbox:a", "inbox:b"]);
+    expect(again).toBe(state);
+
+    // A batch with one new id still produces a new state.
+    const grown = markNotificationsRead(state, ["inbox:a", "inbox:c"]);
+    expect(grown).not.toBe(state);
+    expect(grown.readIds).toContain("inbox:c");
+  });
+
   it("caps stored id lists to the FIFO limit", () => {
     let state = emptyNotificationReadState();
     for (let index = 0; index < NOTIFICATION_READ_STATE_LIMIT + 25; index += 1) {

--- a/src/Meridian.Ui/dashboard/src/lib/notification-center/read-state.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/notification-center/read-state.ts
@@ -1,0 +1,136 @@
+// Client-side read/dismissed state for the notification center. Price-alert
+// acknowledgement is durable in its own store (meridian.priceAlerts.v1); this
+// tracks read/dismissed ids for the inbox and system-event feeds only, following
+// the meridian.workstation.<feature>.vN localStorage convention.
+export const NOTIFICATION_READ_STATE_KEY = "meridian.workstation.notifications.v1";
+export const NOTIFICATION_READ_STATE_LIMIT = 500;
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export interface NotificationReadState {
+  version: 1;
+  readIds: string[];
+  dismissedIds: string[];
+}
+
+export type NotificationReadStateWriteStatus = "saved" | "unavailable" | "failed";
+
+export function emptyNotificationReadState(): NotificationReadState {
+  return { version: 1, readIds: [], dismissedIds: [] };
+}
+
+function resolveStorage(storage?: StorageLike | null): StorageLike | null {
+  if (storage) {
+    return storage;
+  }
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeIdList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry === "string" && entry) {
+      seen.add(entry);
+    }
+  }
+  // Keep the most recent NOTIFICATION_READ_STATE_LIMIT ids (newest at the tail).
+  return [...seen].slice(-NOTIFICATION_READ_STATE_LIMIT);
+}
+
+function normalizeState(value: unknown): NotificationReadState {
+  if (typeof value !== "object" || value === null) {
+    return emptyNotificationReadState();
+  }
+  const source = value as Record<string, unknown>;
+  return {
+    version: 1,
+    readIds: normalizeIdList(source.readIds),
+    dismissedIds: normalizeIdList(source.dismissedIds)
+  };
+}
+
+export function loadNotificationReadState(storage?: StorageLike | null): NotificationReadState {
+  const target = resolveStorage(storage);
+  if (!target) {
+    return emptyNotificationReadState();
+  }
+
+  let raw: string | null;
+  try {
+    raw = target.getItem(NOTIFICATION_READ_STATE_KEY);
+  } catch {
+    return emptyNotificationReadState();
+  }
+
+  if (!raw) {
+    return emptyNotificationReadState();
+  }
+
+  try {
+    return normalizeState(JSON.parse(raw) as unknown);
+  } catch {
+    return emptyNotificationReadState();
+  }
+}
+
+export function saveNotificationReadState(
+  state: NotificationReadState,
+  storage?: StorageLike | null
+): NotificationReadStateWriteStatus {
+  const target = resolveStorage(storage);
+  if (!target) {
+    return "unavailable";
+  }
+
+  try {
+    target.setItem(NOTIFICATION_READ_STATE_KEY, JSON.stringify(normalizeState(state)));
+    return "saved";
+  } catch {
+    return "failed";
+  }
+}
+
+/** Appends an id to a bounded set, moving it to the newest position. */
+export function withId(ids: string[], id: string): string[] {
+  return [...ids.filter((entry) => entry !== id), id].slice(-NOTIFICATION_READ_STATE_LIMIT);
+}
+
+export function markNotificationRead(state: NotificationReadState, id: string): NotificationReadState {
+  if (state.readIds.includes(id)) {
+    return state;
+  }
+  return { ...state, readIds: withId(state.readIds, id) };
+}
+
+export function markNotificationsRead(state: NotificationReadState, ids: readonly string[]): NotificationReadState {
+  let readIds = state.readIds;
+  for (const id of ids) {
+    readIds = withId(readIds, id);
+  }
+  return readIds === state.readIds ? state : { ...state, readIds };
+}
+
+export function dismissNotification(state: NotificationReadState, id: string): NotificationReadState {
+  if (state.dismissedIds.includes(id)) {
+    return state;
+  }
+  return {
+    ...state,
+    readIds: withId(state.readIds, id),
+    dismissedIds: withId(state.dismissedIds, id)
+  };
+}

--- a/src/Meridian.Ui/dashboard/src/lib/notification-center/read-state.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/notification-center/read-state.ts
@@ -104,9 +104,16 @@ export function saveNotificationReadState(
   }
 }
 
-/** Appends an id to a bounded set, moving it to the newest position. */
+/** Appends an id to a bounded set, moving it to the newest position. Returns the
+ *  same array reference when the id is already present as the sole newest entry. */
 export function withId(ids: string[], id: string): string[] {
-  return [...ids.filter((entry) => entry !== id), id].slice(-NOTIFICATION_READ_STATE_LIMIT);
+  const filtered = ids.filter((entry) => entry !== id);
+  if (filtered.length === ids.length - 1 && ids[ids.length - 1] === id) {
+    // Already present exactly once and already newest — no change.
+    return ids;
+  }
+  const next = [...filtered, id];
+  return next.length > NOTIFICATION_READ_STATE_LIMIT ? next.slice(-NOTIFICATION_READ_STATE_LIMIT) : next;
 }
 
 export function markNotificationRead(state: NotificationReadState, id: string): NotificationReadState {
@@ -117,11 +124,16 @@ export function markNotificationRead(state: NotificationReadState, id: string): 
 }
 
 export function markNotificationsRead(state: NotificationReadState, ids: readonly string[]): NotificationReadState {
+  // Only touch ids that aren't already read, so an all-read batch is a no-op.
+  const missing = ids.filter((id) => !state.readIds.includes(id));
+  if (missing.length === 0) {
+    return state;
+  }
   let readIds = state.readIds;
-  for (const id of ids) {
+  for (const id of missing) {
     readIds = withId(readIds, id);
   }
-  return readIds === state.readIds ? state : { ...state, readIds };
+  return { ...state, readIds };
 }
 
 export function dismissNotification(state: NotificationReadState, id: string): NotificationReadState {

--- a/src/Meridian.Ui/dashboard/src/lib/notification-center/types.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/notification-center/types.ts
@@ -1,0 +1,29 @@
+// Notification center — shared envelope shape merging the operator inbox,
+// system events, and price-alert triggers into one client-side feed.
+export type NotificationSource = "inbox" | "system" | "price-alert";
+export type NotificationSeverity = "critical" | "warning" | "info" | "success";
+
+export interface NotificationEnvelope {
+  /** Stable id: `${source}:${sourceId}`. Read-state and actions key off this. */
+  id: string;
+  source: NotificationSource;
+  /** The originating feed's own id (WorkItemId, system event id, trigger id). */
+  sourceId: string;
+  severity: NotificationSeverity;
+  title: string;
+  detail: string;
+  /** ISO timestamp used for ordering and the relative-age label. */
+  timestamp: string;
+  /** Deep link into the owning surface, or null when the row isn't navigable. */
+  route: string | null;
+  read: boolean;
+  /** Inbox/system rows can be dismissed; price alerts are managed via acknowledge. */
+  dismissible: boolean;
+}
+
+export interface NotificationSeverityCounts {
+  critical: number;
+  warning: number;
+  info: number;
+  success: number;
+}


### PR DESCRIPTION
<!-- phase:PR7 -->
## Summary

Implements Phase 5 of the [Web UI Improvements Implementation Plan](../blob/main/docs/product/web-ui-improvements-implementation-plan-2026-07.md): a shell notification center folding three feeds into one masthead bell + drawer. **Fully client-side — no server changes.**

- **Merge core** (`lib/notification-center/merge.ts`, pure/unit-tested): combines the operator inbox (`getOperatorInbox`), system events (overview `recentEvents`), and price-alert triggers into one `NotificationEnvelope` feed. Each feed's tone maps to a shared severity; items order unread-first, then by severity, then recency; dismissed inbox/system items are filtered out.
- **Bell + drawer** (`components/meridian/notification-center.tsx`) replaces the standalone `PriceAlertsBell` in `app.tsx`'s masthead. Always-visible bell with an unread badge; a right-side `Sheet` grouped by severity (Critical / Warning / Info / Resolved) with per-item deep links via `routeForOperatorWorkItem`, plus mark-read, mark-all-read, and dismiss (inbox/system rows).
- **Read-state** (`lib/notification-center/read-state.ts`): client-side under `meridian.workstation.notifications.v1`, FIFO-capped, matching the theme / SQL-workbench / price-alerts convention.

**Design note — read-state is client-side, an intentional deviation from the plan's original server file-store sketch, confirmed with the repo owner before building.** The feeds have mismatched persistence: price alerts already carry durable acknowledgement client-side, the operator inbox is server-*derived* but stateless (recomputed per request), and system events arrive on the overview payload. So client-side read/dismissed state for the inbox + system feeds keeps all UI state in one place with no net-new server persistence. Server-durable, cross-device read-state can be a later step (as the SSE fan-out was in Phase 4). The plan doc's Phase 5 section is amended to record this.

Delivery: the inbox fetch polls at 60s and is **degradable** — a failed fetch never blanks the other feeds (covered by a test). Price alerts keep their own `acknowledged` mechanism; the center's "mark read" on a price row routes to `acknowledgeTrigger`.

## Reason

Executes the next unit of the merged plan after Phases 1–4: the durable, deep-linked inbox that gives an operator one glance-to-know-what-needs-attention surface, and the consumer of the Phase 1 freshness vocabulary and Phase 3 deep links.

## Testing performed

- [x] `npm --prefix src/Meridian.Ui/dashboard run test` — full suite green (23/23 batches), including 14 new notification tests: merge (severity mapping, ordering, read/dismiss filtering, counts), read-state (load/save/normalize, FIFO cap, idempotent mark-read), and component (unread badge, severity-grouped drawer, deep links, mark-all-read, inbox-failure resilience)
- [x] `npm --prefix src/Meridian.Ui/dashboard run build` — typecheck + bundle clean
- [x] `app.test.tsx` + `price-alerts-screen.test.tsx` pass after the masthead swap
- [x] Docs regenerated twice with the CI core profile — no drift (TODO-marker line shift committed)
- [ ] No C#/.NET changes in this phase — `dotnet` lanes are a no-op here; the GitHub `quality-gate` remains authoritative

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ)_