### PR TITLE
Web UI: editable sticky operating-scope picker (Phase 6a)

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -4855,6 +4855,8 @@ Meridian-main
 │   │   │   │   │   │   ├── reporting-hub.tsx
 │   │   │   │   │   │   ├── reporting-period-switcher.tsx
 │   │   │   │   │   │   ├── save-view-dialog.tsx
+│   │   │   │   │   │   ├── scope-picker.test.tsx
+│   │   │   │   │   │   ├── scope-picker.tsx
 │   │   │   │   │   │   ├── security-details-tracker.test.tsx
 │   │   │   │   │   │   ├── security-details-tracker.tsx
 │   │   │   │   │   │   ├── security-details-tracker.view-model.test.ts
@@ -5004,6 +5006,9 @@ Meridian-main
 │   │   │   │   │   │   ├── read-state.test.ts
 │   │   │   │   │   │   ├── read-state.ts
 │   │   │   │   │   │   └── types.ts
+│   │   │   │   │   ├── operating-scope
+│   │   │   │   │   │   ├── fund-accounts.test.ts
+│   │   │   │   │   │   └── fund-accounts.ts
 │   │   │   │   │   ├── price-alerts
 │   │   │   │   │   │   ├── evaluator.test.ts
 │   │   │   │   │   │   ├── evaluator.ts
@@ -5240,6 +5245,7 @@ Meridian-main
 │   │   │   │   ├── app-shell.development-fixture-notice.ts
 │   │   │   │   ├── app-shell.evidence-timeline.ts
 │   │   │   │   ├── app-shell.linked-context.ts
+│   │   │   │   ├── app-shell.operating-scope.test.ts
 │   │   │   │   ├── app-shell.operating-scope.ts
 │   │   │   │   ├── app-shell.operator-focus.ts
 │   │   │   │   ├── app-shell.route-focus.ts

--- a/docs/product/web-ui-improvements-implementation-plan-2026-07.md
+++ b/docs/product/web-ui-improvements-implementation-plan-2026-07.md
@@ -248,6 +248,16 @@ No feature work; confirm and document the rules each later phase must follow.
   explicit "not filtered by fund" hint. Migrate workspace-by-workspace: Portfolio → Accounting →
   Reporting → Trading.
 
+  **Landed:** the sticky persistence, route-change merge, and per-route dimension application
+  already existed in `app.tsx` (persisted under the existing `meridian.workstation.operatingContext.v1`
+  store, so no new `operatingScope.v1` key was introduced). This unit added the missing write path:
+  an editable `ScopePicker` dialog (`components/meridian/scope-picker.tsx`, symbol live-search + fund-account
+  suggestions from the brokerage payload + free-text provider), reachable from a `WorkflowContinuityDock`
+  "Change scope" control and an `operating-scope-edit` palette action, plus dimmed/dashed scope chips with a
+  "carried, but not applied on this workspace" hint driven by the new `operatingScopeDimensionsForRoute`
+  export. Because every workspace already consumes the shared scope engine per-route, the per-workspace
+  migration is covered by that single wiring rather than screen-by-screen edits.
+
 ### 6b. Virtualized dense grids (#7)
 - `DenseDataTable` (`components/meridian/ui-kit-primitives.tsx`) soft-caps via
   `maxVisibleRows`/`rows.slice` + "show all" — not windowing. Add real row virtualization inside
@@ -280,7 +290,7 @@ additionally re-runs the a11y suites (`*-screen.a11y.test.tsx`,
 `dense-row-detail-accessibility.test.tsx`).
 
 **Checklist**
-- [ ] 6a scope picker + persistence + Portfolio migration.
+- [x] 6a scope picker + persistence + Portfolio migration.
 - [ ] 6b virtualization inside `DenseDataTable` with a11y contract tests green.
 - [ ] 6c chart callback props + `ChartSyncContext` + one evidence-drill screen.
 - [ ] 6d chrome-less pane branch + BroadcastChannel bridge + popup fallback link.

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 538,
-  "total_lines": 88589,
+  "total_lines": 88605,
   "orphaned_count": 205,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2138,7 +2138,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7781,
+      "line_count": 7787,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -3106,7 +3106,7 @@
     },
     {
       "path": "docs/product/web-ui-improvements-implementation-plan-2026-07.md",
-      "line_count": 299,
+      "line_count": 309,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 538 |
-| Total lines | 88,589 |
+| Total lines | 88,605 |
 | Average file size (lines) | 164.7 |
 | Orphaned files | 205 |
 | Files without headings | 38 |

--- a/src/Meridian.Ui/dashboard/src/app-shell.operating-scope.test.ts
+++ b/src/Meridian.Ui/dashboard/src/app-shell.operating-scope.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { operatingScopeDimensionsForRoute } from "@/app-shell.operating-scope";
+
+describe("operatingScopeDimensionsForRoute", () => {
+  it("returns the dimensions each workspace actually filters on", () => {
+    expect(operatingScopeDimensionsForRoute("/data/quotes")).toEqual(["symbol", "provider", "window"]);
+    expect(operatingScopeDimensionsForRoute("/accounting/ledger")).toEqual([
+      "symbol",
+      "fundAccountId",
+      "runId",
+      "provider",
+      "window"
+    ]);
+    expect(operatingScopeDimensionsForRoute("/settings")).toEqual(["fundAccountId", "provider"]);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/app-shell.operating-scope.ts
+++ b/src/Meridian.Ui/dashboard/src/app-shell.operating-scope.ts
@@ -141,6 +141,16 @@ export function appendOperatingScopeToRoute(route: string, operatingScope: AppSh
     .reduce((current, item) => appendSearchValue(current, item.key, item.value, true), route);
 }
 
+/**
+ * The scope dimensions that actually filter data on the given route's workspace.
+ * A set dimension not in this list is carried (sticky) but not applied here — the
+ * basis for the "not filtered on this workspace" hint in the scope display.
+ */
+export function operatingScopeDimensionsForRoute(route: string): AppShellOperatingScopeQueryKey[] {
+  const keys = operatingScopeKeysForRoute(route);
+  return keys ? [...keys] : [];
+}
+
 export function summarizeOperatingScopeForRoute(
   route: string,
   operatingScope: AppShellOperatingScopeState

--- a/src/Meridian.Ui/dashboard/src/app.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.tsx
@@ -17,11 +17,16 @@ import {
   type ShellStatusPanel
 } from "@/app-shell.view-model";
 import {
+  appendOperatingScopeToRoute,
+  buildOperatingScopeFromSearch,
+  operatingScopeDimensionsForRoute,
   readOperatingScopeFromSearch,
   removeOperatingScopeFromSearch,
   type AppShellOperatingScopeInput
 } from "@/app-shell.operating-scope";
 import { CommandPalette } from "@/components/meridian/command-palette";
+import { ScopePicker } from "@/components/meridian/scope-picker";
+import { collectScopeFundAccounts } from "@/lib/operating-scope/fund-accounts";
 import { WorkflowContinuityDock } from "@/components/meridian/workflow-continuity-dock";
 import { WorkspaceHeader } from "@/components/meridian/workspace-header";
 import { WorkspaceNav } from "@/components/meridian/workspace-nav";
@@ -104,6 +109,7 @@ export function App() {
 function AppShell() {
   const [commandOpen, setCommandOpen] = useState(false);
   const [navOpen, setNavOpen] = useState(false);
+  const [scopePickerOpen, setScopePickerOpen] = useState(false);
   const [routeAnnouncement, setRouteAnnouncement] = useState("");
   const [storedOperatingScope, setStoredOperatingScope] = useState(readStoredOperatingScope);
   const workbenchRef = useRef<HTMLElement | null>(null);
@@ -189,9 +195,21 @@ function AppShell() {
     })),
     [upsertWorkflowPreset, workflowPresets]
   );
+  const scopeActionItem = useMemo<CommandPaletteActionItem>(
+    () => ({
+      id: "operating-scope-edit",
+      verbLabel: "Set operating scope…",
+      description: "Set the subject, fund account, and provider carried across the workstation.",
+      keywords: ["scope", "fund account", "subject", "filter"],
+      run: async () => {
+        setScopePickerOpen(true);
+      }
+    }),
+    []
+  );
   const paletteActionItems = useMemo(
-    () => [...presetPinActionItems, ...screenActionItems],
-    [presetPinActionItems, screenActionItems]
+    () => [scopeActionItem, ...presetPinActionItems, ...screenActionItems],
+    [scopeActionItem, presetPinActionItems, screenActionItems]
   );
 
   useEffect(() => {
@@ -223,6 +241,22 @@ function AppShell() {
     setStoredOperatingScope(emptyScope);
     navigate(`${pathname}${removeOperatingScopeFromSearch(search)}${hash}`, { replace: true });
   };
+
+  // Replace the operating scope from the picker: persist it and reflect the
+  // applicable dimensions into the current route so URL-reading screens filter,
+  // preserving any non-scope query params already on the route.
+  const handleSetOperatingScope = (next: AppShellOperatingScopeInput) => {
+    const compacted = compactOperatingScope(next);
+    suppressScopePersistRef.current = false;
+    writeStoredOperatingScope(compacted);
+    setStoredOperatingScope(compacted);
+    const baseRoute = `${pathname}${removeOperatingScopeFromSearch(search)}`;
+    const scopeState = buildOperatingScopeFromSearch("", compacted);
+    navigate(`${appendOperatingScopeToRoute(baseRoute, scopeState)}${hash}`, { replace: true });
+  };
+
+  const scopeFundAccountOptions = useMemo(() => collectScopeFundAccounts(brokeragePortfolio), [brokeragePortfolio]);
+  const scopeDimensionsInEffect = useMemo(() => operatingScopeDimensionsForRoute(pathname), [pathname]);
 
   useEffect(() => {
     const handleCommandShortcut = (event: KeyboardEvent) => {
@@ -443,6 +477,8 @@ function AppShell() {
           <WorkflowContinuityDock
             viewModel={shell.workflowContinuity}
             onClearOperatingContext={handleClearOperatingContext}
+            onEditOperatingContext={() => setScopePickerOpen(true)}
+            scopeDimensionsInEffect={scopeDimensionsInEffect}
           />
 
           <div className="workbench-scroll px-4 py-4 lg:px-6 lg:py-5">
@@ -591,6 +627,13 @@ function AppShell() {
         operatingContextSymbol={operatingContextSymbol}
         operatingScope={operatingScopeInput}
         onPresetUsed={handleWorkflowPresetUsed}
+      />
+      <ScopePicker
+        open={scopePickerOpen}
+        onOpenChange={setScopePickerOpen}
+        scope={operatingScopeInput}
+        fundAccounts={scopeFundAccountOptions}
+        onApply={handleSetOperatingScope}
       />
       <Sheet open={navOpen} onOpenChange={setNavOpen} side="left">
         <SheetContent

--- a/src/Meridian.Ui/dashboard/src/components/meridian/scope-picker.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/scope-picker.test.tsx
@@ -1,0 +1,95 @@
+import type { ComponentProps } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { ScopePicker } from "@/components/meridian/scope-picker";
+import type { AppShellOperatingScopeInput } from "@/app-shell.operating-scope";
+import type { ScopeFundAccountOption } from "@/lib/operating-scope/fund-accounts";
+import type { SymbolRecord } from "@/types";
+
+const FUND_ACCOUNTS: ScopeFundAccountOption[] = [
+  { id: "fund-a", label: "Alpha Fund" },
+  { id: "fund-b", label: "Beta Fund" }
+];
+
+function symbolRecord(symbol: string, provider: string): SymbolRecord {
+  return { symbol, provider } as unknown as SymbolRecord;
+}
+
+function renderPicker(overrides: Partial<ComponentProps<typeof ScopePicker>> = {}) {
+  const onApply = vi.fn();
+  const onOpenChange = vi.fn();
+  const scope: AppShellOperatingScopeInput = overrides.scope ?? {};
+  const searchSymbols = overrides.searchSymbols ?? vi.fn().mockResolvedValue([]);
+  render(
+    <ScopePicker
+      open
+      onOpenChange={onOpenChange}
+      scope={scope}
+      fundAccounts={FUND_ACCOUNTS}
+      onApply={onApply}
+      searchSymbols={searchSymbols}
+      {...overrides}
+    />
+  );
+  return { onApply, onOpenChange, searchSymbols };
+}
+
+describe("ScopePicker", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("seeds the fields from the active scope when opened", () => {
+    renderPicker({ scope: { symbol: "AAPL", fundAccountId: "fund-a", provider: "alpaca" } });
+
+    expect(screen.getByLabelText("Subject symbol")).toHaveValue("AAPL");
+    expect(screen.getByLabelText("Fund account")).toHaveValue("fund-a");
+    expect(screen.getByLabelText("Provider")).toHaveValue("alpaca");
+  });
+
+  it("shows live symbol suggestions and applies the clicked one", async () => {
+    const searchSymbols = vi.fn().mockResolvedValue([symbolRecord("MSFT", "alpaca"), symbolRecord("MSTR", "alpaca")]);
+    const { onApply } = renderPicker({ searchSymbols });
+
+    fireEvent.change(screen.getByLabelText("Subject symbol"), { target: { value: "ms" } });
+
+    const suggestion = await screen.findByRole("button", { name: /MSFT/ });
+    fireEvent.click(suggestion);
+
+    expect(searchSymbols).toHaveBeenCalledWith("ms", expect.objectContaining({ signal: expect.any(AbortSignal) }));
+    expect(screen.getByLabelText("Subject symbol")).toHaveValue("MSFT");
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply scope" }));
+    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ symbol: "MSFT" }));
+  });
+
+  it("emits the complete next scope on apply, carrying untouched dimensions", () => {
+    const { onApply, onOpenChange } = renderPicker({
+      scope: { symbol: "AAPL", fundAccountId: "fund-a", provider: "alpaca", runId: "run-9", from: "2026-01-01" }
+    });
+
+    fireEvent.change(screen.getByLabelText("Provider"), { target: { value: "polygon" } });
+    fireEvent.click(screen.getByRole("button", { name: "Apply scope" }));
+
+    expect(onApply).toHaveBeenCalledWith({
+      symbol: "AAPL",
+      fundAccountId: "fund-a",
+      provider: "polygon",
+      runId: "run-9",
+      from: "2026-01-01",
+      to: null,
+      date: null,
+      asOf: null
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("clears the entire scope from the clear action", () => {
+    const { onApply } = renderPicker({ scope: { symbol: "AAPL", provider: "alpaca" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear scope" }));
+
+    expect(onApply).toHaveBeenCalledWith({});
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/meridian/scope-picker.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/scope-picker.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useId, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { searchSymbolsQuery } from "@/lib/api";
+import { normalizeOperatingContextSymbol, type AppShellOperatingScopeInput } from "@/app-shell.operating-scope";
+import type { ScopeFundAccountOption } from "@/lib/operating-scope/fund-accounts";
+import type { SymbolRecord } from "@/types";
+
+const SYMBOL_SEARCH_DEBOUNCE_MS = 250;
+const SYMBOL_SEARCH_MIN_LENGTH = 2;
+const SYMBOL_SUGGESTION_LIMIT = 8;
+
+export interface ScopePickerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  scope: AppShellOperatingScopeInput;
+  fundAccounts: ScopeFundAccountOption[];
+  onApply: (next: AppShellOperatingScopeInput) => void;
+  /** Overridable for tests. */
+  searchSymbols?: typeof searchSymbolsQuery;
+}
+
+/**
+ * Editable operating-scope picker. Sets the sticky scope dimensions an operator
+ * carries across the workstation: subject symbol (live search), fund account
+ * (typed, with discovered suggestions), and provider. Apply persists + reflects
+ * into the URL via the caller; the picker itself only collects the values.
+ */
+export function ScopePicker({ open, onOpenChange, scope, fundAccounts, onApply, searchSymbols = searchSymbolsQuery }: ScopePickerProps) {
+  const [symbol, setSymbol] = useState("");
+  const [fundAccountId, setFundAccountId] = useState("");
+  const [provider, setProvider] = useState("");
+  const [symbolSuggestions, setSymbolSuggestions] = useState<SymbolRecord[]>([]);
+  const fundAccountListId = useId();
+
+  // Seed the fields from the active scope each time the dialog opens.
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setSymbol(scope.symbol ?? "");
+    setFundAccountId(scope.fundAccountId ?? "");
+    setProvider(scope.provider ?? "");
+    setSymbolSuggestions([]);
+  }, [open, scope.symbol, scope.fundAccountId, scope.provider]);
+
+  const symbolQuery = symbol.trim();
+  const suggestionsRef = useRef(setSymbolSuggestions);
+  suggestionsRef.current = setSymbolSuggestions;
+  useEffect(() => {
+    if (!open || symbolQuery.length < SYMBOL_SEARCH_MIN_LENGTH) {
+      suggestionsRef.current([]);
+      return;
+    }
+
+    const controller = new AbortController();
+    const timer = window.setTimeout(() => {
+      void searchSymbols(symbolQuery, { signal: controller.signal })
+        .then((records) => suggestionsRef.current(records.slice(0, SYMBOL_SUGGESTION_LIMIT)))
+        .catch(() => undefined);
+    }, SYMBOL_SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      controller.abort();
+      window.clearTimeout(timer);
+    };
+  }, [open, searchSymbols, symbolQuery]);
+
+  const apply = () => {
+    // Emit the complete next scope: this dialog's fields plus the dimensions it
+    // doesn't edit, so the caller can treat it as a replace.
+    onApply({
+      symbol: normalizeOperatingContextSymbol(symbol),
+      fundAccountId: fundAccountId.trim() || null,
+      provider: provider.trim() || null,
+      runId: scope.runId ?? null,
+      from: scope.from ?? null,
+      to: scope.to ?? null,
+      date: scope.date ?? null,
+      asOf: scope.asOf ?? null
+    });
+    onOpenChange(false);
+  };
+
+  const clearAll = () => {
+    onApply({});
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent aria-labelledby="scope-picker-title" aria-describedby="scope-picker-description">
+        <DialogHeader>
+          <DialogTitle id="scope-picker-title">Operating scope</DialogTitle>
+          <DialogDescription id="scope-picker-description">
+            Set the subject, fund account, and provider carried across the workstation. Each screen
+            applies the dimensions it supports.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3 pt-2">
+          <div>
+            <label className="text-sm font-medium text-foreground" htmlFor="scope-picker-symbol">
+              Subject symbol
+            </label>
+            <Input
+              id="scope-picker-symbol"
+              autoComplete="off"
+              placeholder="e.g. AAPL"
+              value={symbol}
+              onChange={(event) => setSymbol(event.target.value)}
+            />
+            {symbolSuggestions.length > 0 ? (
+              <ul className="mt-1 max-h-40 overflow-y-auto rounded-md border border-border/70 bg-background" aria-label="Symbol suggestions">
+                {symbolSuggestions.map((record) => (
+                  <li key={record.symbol}>
+                    <button
+                      type="button"
+                      className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-sm hover:bg-secondary/60 focus-visible:outline-none focus-visible:bg-secondary/60"
+                      onClick={() => {
+                        setSymbol(record.symbol);
+                        setSymbolSuggestions([]);
+                      }}
+                    >
+                      <span className="font-mono">{record.symbol}</span>
+                      {record.provider ? <span className="text-xs text-muted-foreground">{record.provider}</span> : null}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+
+          <div>
+            <label className="text-sm font-medium text-foreground" htmlFor="scope-picker-fund-account">
+              Fund account
+            </label>
+            <Input
+              id="scope-picker-fund-account"
+              autoComplete="off"
+              list={fundAccounts.length > 0 ? fundAccountListId : undefined}
+              placeholder="Fund account id"
+              value={fundAccountId}
+              onChange={(event) => setFundAccountId(event.target.value)}
+            />
+            {fundAccounts.length > 0 ? (
+              <datalist id={fundAccountListId}>
+                {fundAccounts.map((account) => (
+                  <option key={account.id} value={account.id}>
+                    {account.label}
+                  </option>
+                ))}
+              </datalist>
+            ) : null}
+          </div>
+
+          <div>
+            <label className="text-sm font-medium text-foreground" htmlFor="scope-picker-provider">
+              Provider
+            </label>
+            <Input
+              id="scope-picker-provider"
+              autoComplete="off"
+              placeholder="e.g. alpaca"
+              value={provider}
+              onChange={(event) => setProvider(event.target.value)}
+            />
+          </div>
+
+          <div className="flex items-center justify-between gap-3 pt-2">
+            <Button type="button" size="sm" variant="ghost" onClick={clearAll}>
+              Clear scope
+            </Button>
+            <div className="flex items-center gap-2">
+              <Button type="button" size="sm" variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button type="button" size="sm" onClick={apply}>
+                Apply scope
+              </Button>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/meridian/scope-picker.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/scope-picker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -52,22 +52,26 @@ export function ScopePicker({ open, onOpenChange, scope, fundAccounts, onApply, 
   }, [open, scope.symbol, scope.fundAccountId, scope.provider]);
 
   const symbolQuery = symbol.trim();
-  const suggestionsRef = useRef(setSymbolSuggestions);
-  suggestionsRef.current = setSymbolSuggestions;
   useEffect(() => {
     if (!open || symbolQuery.length < SYMBOL_SEARCH_MIN_LENGTH) {
-      suggestionsRef.current([]);
+      setSymbolSuggestions([]);
       return;
     }
 
+    let active = true;
     const controller = new AbortController();
     const timer = window.setTimeout(() => {
       void searchSymbols(symbolQuery, { signal: controller.signal })
-        .then((records) => suggestionsRef.current(records.slice(0, SYMBOL_SUGGESTION_LIMIT)))
+        .then((records) => {
+          if (active) {
+            setSymbolSuggestions(records.slice(0, SYMBOL_SUGGESTION_LIMIT));
+          }
+        })
         .catch(() => undefined);
     }, SYMBOL_SEARCH_DEBOUNCE_MS);
 
     return () => {
+      active = false;
       controller.abort();
       window.clearTimeout(timer);
     };
@@ -119,7 +123,7 @@ export function ScopePicker({ open, onOpenChange, scope, fundAccounts, onApply, 
             {symbolSuggestions.length > 0 ? (
               <ul className="mt-1 max-h-40 overflow-y-auto rounded-md border border-border/70 bg-background" aria-label="Symbol suggestions">
                 {symbolSuggestions.map((record) => (
-                  <li key={record.symbol}>
+                  <li key={`${record.symbol}-${record.provider ?? ""}`}>
                     <button
                       type="button"
                       className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-sm hover:bg-secondary/60 focus-visible:outline-none focus-visible:bg-secondary/60"

--- a/src/Meridian.Ui/dashboard/src/components/meridian/workflow-continuity-dock.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/workflow-continuity-dock.tsx
@@ -1,20 +1,27 @@
 import { useState } from "react";
-import { ArrowRight, ChevronDown, GitBranch, X } from "lucide-react";
+import { ArrowRight, ChevronDown, GitBranch, SlidersHorizontal, X } from "lucide-react";
 import { Link } from "react-router-dom";
 import "@/styles/workflow-continuity-dock.css";
 import type { AppShellWorkflowContinuityViewModel } from "@/app-shell.view-model";
+import type { AppShellOperatingScopeQueryKey } from "@/app-shell.operating-scope";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 export function WorkflowContinuityDock({
   viewModel,
-  onClearOperatingContext
+  onClearOperatingContext,
+  onEditOperatingContext,
+  scopeDimensionsInEffect
 }: {
   viewModel: AppShellWorkflowContinuityViewModel;
   onClearOperatingContext?: () => void;
+  onEditOperatingContext?: () => void;
+  scopeDimensionsInEffect?: AppShellOperatingScopeQueryKey[];
 }) {
   const decision = viewModel.decisionBrief;
   const scopeSummary = viewModel.operatingScope.items.map((item) => `${item.label} ${item.value}`).join(", ");
+  const isDimensionInEffect = (id: string) =>
+    !scopeDimensionsInEffect || scopeDimensionsInEffect.includes(id as AppShellOperatingScopeQueryKey);
   const [operatorFlowOpen, setOperatorFlowOpen] = useState(false);
   const toggleOperatorFlow = () => setOperatorFlowOpen((isOpen) => !isOpen);
 
@@ -39,6 +46,17 @@ export function WorkflowContinuityDock({
         <div className="workflow-continuity-meta" aria-label={`Current route ${viewModel.routeLabel}`}>
           <span>{viewModel.contextValue}</span>
           <span>{viewModel.routeLabel}</span>
+          {onEditOperatingContext ? (
+            <button
+              type="button"
+              className="workflow-continuity-clear focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+              onClick={onEditOperatingContext}
+              aria-label={viewModel.operatingScope.hasScope ? "Change operating scope" : "Set operating scope"}
+              title={viewModel.operatingScope.hasScope ? "Change operating scope" : "Set operating scope"}
+            >
+              <SlidersHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
+            </button>
+          ) : null}
           {viewModel.operatingScope.hasScope && viewModel.clearSubjectAriaLabel && onClearOperatingContext ? (
             <button
               type="button"
@@ -54,12 +72,20 @@ export function WorkflowContinuityDock({
         {scopeSummary ? <p className="sr-only">Operating scope: {scopeSummary}.</p> : null}
         {viewModel.operatingScope.items.length > 0 ? (
           <dl className="workflow-continuity-scope" aria-label={viewModel.operatingScope.label}>
-            {viewModel.operatingScope.items.map((item) => (
-              <div key={item.id} className="workflow-continuity-scope-chip" aria-label={item.ariaLabel}>
-                <dt>{item.label}</dt>
-                <dd>{item.value}</dd>
-              </div>
-            ))}
+            {viewModel.operatingScope.items.map((item) => {
+              const inEffect = isDimensionInEffect(item.id);
+              return (
+                <div
+                  key={item.id}
+                  className={cn("workflow-continuity-scope-chip", !inEffect && "workflow-continuity-scope-chip-inactive")}
+                  aria-label={inEffect ? item.ariaLabel : `${item.ariaLabel}. Not applied on this workspace.`}
+                  title={inEffect ? undefined : "Carried, but not applied on this workspace"}
+                >
+                  <dt>{item.label}</dt>
+                  <dd>{item.value}</dd>
+                </div>
+              );
+            })}
           </dl>
         ) : null}
       </div>

--- a/src/Meridian.Ui/dashboard/src/lib/operating-scope/fund-accounts.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/operating-scope/fund-accounts.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { collectScopeFundAccounts } from "@/lib/operating-scope/fund-accounts";
+import type { BrokerageHouseholdPortfolio } from "@/types";
+
+function portfolio(accounts: unknown): BrokerageHouseholdPortfolio {
+  return { accounts } as unknown as BrokerageHouseholdPortfolio;
+}
+
+describe("collectScopeFundAccounts", () => {
+  it("returns an empty list for missing or malformed payloads", () => {
+    expect(collectScopeFundAccounts(null)).toEqual([]);
+    expect(collectScopeFundAccounts(undefined)).toEqual([]);
+    expect(collectScopeFundAccounts(portfolio("nope"))).toEqual([]);
+  });
+
+  it("derives distinct id/label options sorted by label", () => {
+    const result = collectScopeFundAccounts(
+      portfolio([
+        { fundAccountId: "fund-b", displayName: "Beta Fund" },
+        { fundAccountId: "fund-a", displayName: "Alpha Fund" },
+        { fundAccountId: "fund-b", displayName: "Beta Fund (dup)" }
+      ])
+    );
+
+    expect(result).toEqual([
+      { id: "fund-a", label: "Alpha Fund" },
+      { id: "fund-b", label: "Beta Fund" }
+    ]);
+  });
+
+  it("falls back to the id when the display name is missing and skips invalid rows", () => {
+    const result = collectScopeFundAccounts(
+      portfolio([
+        { fundAccountId: "fund-x", displayName: "  " },
+        { fundAccountId: "  ", displayName: "ignored" },
+        { displayName: "no id" },
+        { fundAccountId: "fund-y" }
+      ])
+    );
+
+    expect(result).toEqual([
+      { id: "fund-x", label: "fund-x" },
+      { id: "fund-y", label: "fund-y" }
+    ]);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/lib/operating-scope/fund-accounts.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/operating-scope/fund-accounts.ts
@@ -1,0 +1,37 @@
+// Fund-account options for the operating-scope picker. There is no fund-account
+// list endpoint; the household brokerage payload is the cleanest available source
+// (id + display name), so we derive suggestions from it defensively.
+import type { BrokerageHouseholdPortfolio } from "@/types";
+
+export interface ScopeFundAccountOption {
+  id: string;
+  label: string;
+}
+
+/**
+ * Distinct fund accounts discovered from the loaded brokerage household payload,
+ * sorted by label. Returns an empty list when nothing is available — the picker's
+ * fund-account field still accepts a typed id in that case.
+ */
+export function collectScopeFundAccounts(
+  brokeragePortfolio: BrokerageHouseholdPortfolio | null | undefined
+): ScopeFundAccountOption[] {
+  const accounts = brokeragePortfolio?.accounts;
+  if (!Array.isArray(accounts)) {
+    return [];
+  }
+
+  const byId = new Map<string, ScopeFundAccountOption>();
+  for (const account of accounts) {
+    const id = typeof account?.fundAccountId === "string" ? account.fundAccountId.trim() : "";
+    if (!id || byId.has(id)) {
+      continue;
+    }
+    const label = typeof account?.displayName === "string" && account.displayName.trim()
+      ? account.displayName.trim()
+      : id;
+    byId.set(id, { id, label });
+  }
+
+  return [...byId.values()].sort((a, b) => a.label.localeCompare(b.label));
+}

--- a/src/Meridian.Ui/dashboard/src/styles/workflow-continuity-dock.css
+++ b/src/Meridian.Ui/dashboard/src/styles/workflow-continuity-dock.css
@@ -85,6 +85,11 @@
   padding: 0.0625rem 0.3125rem;
 }
 
+.workflow-continuity-scope-chip-inactive {
+  opacity: 0.55;
+  border-style: dashed;
+}
+
 .workflow-continuity-scope-chip dt {
   color: var(--ws-text-muted, #59636F);
   font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Adds the missing **write path** for the browser workstation's sticky operating scope (Phase 6a of the web-UI improvement plan). The scope engine already persisted operator context (`meridian.workstation.operatingContext.v1`), merged it on every route change, and applied the dimensions each workspace supports — but there was no in-app way to *edit* the scope. This PR supplies the editor and the "not applied here" affordance.

- **`ScopePicker` dialog** (`components/meridian/scope-picker.tsx`): subject-symbol **live search** (debounced, abortable), fund-account suggestions sourced from the brokerage household payload, and a free-text provider field. Apply emits the *complete* next scope (carrying dimensions it doesn't edit) so the caller treats it as a replace; "Clear scope" resets to empty.
- **Entry points**: a "Change scope" control on the `WorkflowContinuityDock` and an `operating-scope-edit` command-palette action.
- **Dimmed inactive dimensions**: scope chips for dimensions a workspace does not filter on render dimmed/dashed with a "carried, but not applied on this workspace" hint, driven by the new `operatingScopeDimensionsForRoute` export.
- **`collectScopeFundAccounts`**: derives distinct, label-sorted fund-account options from the brokerage portfolio, falling back to the account id when a display name is missing.

Because every workspace already consumes the shared scope engine per-route, the per-workspace "migration" (Portfolio → Accounting → Reporting → Trading) is covered by this single wiring rather than screen-by-screen edits. No new `operatingScope.v1` storage key was introduced — the existing `operatingContext.v1` store is reused.

## Reason

Phase 6a of `docs/product/web-ui-improvements-implementation-plan-2026-07.md` ("Editable, sticky operating scope", idea #6). Operators could carry scope across the workstation but had no UI to set or change it, and screens that ignore a dimension gave no signal that the carried value wasn't applied.

## Testing performed

- [x] `npm run test` (full dashboard suite) — all green
- [x] `npm run build` (tsc `--noEmit` + vite) — clean
- [x] Relevant unit tests were added or updated (`fund-accounts.test.ts`, `app-shell.operating-scope.test.ts`, `scope-picker.test.tsx`)
- [ ] Relevant integration tests were added or updated (n/a — client-only change)
- [ ] GitHub Actions `quality-gate` passed (pending CI)

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ)_