### PR TITLE
Web UI: row virtualization for DenseDataTable (Phase 6b)

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -4871,6 +4871,7 @@ Meridian-main
 │   │   │   │   │   │   ├── strategy-formula-workbench.tsx
 │   │   │   │   │   │   ├── ui-kit-primitives.test.tsx
 │   │   │   │   │   │   ├── ui-kit-primitives.tsx
+│   │   │   │   │   │   ├── ui-kit-primitives.virtualization.test.tsx
 │   │   │   │   │   │   ├── workflow-continuity-dock.test.tsx
 │   │   │   │   │   │   ├── workflow-continuity-dock.tsx
 │   │   │   │   │   │   ├── workspace-header.test.tsx
@@ -5032,6 +5033,8 @@ Meridian-main
 │   │   │   │   │   ├── csv.ts
 │   │   │   │   │   ├── daily-control-tower.test.ts
 │   │   │   │   │   ├── daily-control-tower.ts
+│   │   │   │   │   ├── dense-virtualization.test.ts
+│   │   │   │   │   ├── dense-virtualization.ts
 │   │   │   │   │   ├── dev-fixtures.test.ts
 │   │   │   │   │   ├── dev-fixtures.ts
 │   │   │   │   │   ├── plaid-link.ts

--- a/docs/product/web-ui-improvements-implementation-plan-2026-07.md
+++ b/docs/product/web-ui-improvements-implementation-plan-2026-07.md
@@ -267,6 +267,19 @@ No feature work; confirm and document the rules each later phase must follow.
   `DenseRowDetailPanel` (contract already prescribes this; avoids variable-height rows).
   First adopters: trial balance, journal entries, reconciliation breaks, financial record explorer.
 
+  **Landed:** an opt-in `virtualization={{ rowHeight, viewportRowCount?, overscan? }}` prop on
+  `DenseDataTable`. Windowing is expressed with top/bottom spacer rows so the element stays a
+  semantic `<table>`; `aria-rowcount`/`aria-rowindex` report positions across the full set. The
+  offset/reveal/type-ahead math is a pure module (`lib/dense-virtualization.ts`, unit-tested).
+  Keyboard traversal (Arrow/Home/End/type-ahead) addresses the full data set: targeting a
+  windowed-out row scrolls it into view and defers focus until it mounts (focus survives unmount).
+  Escape-back-to-row is coordinated through a reveal-handler registry in
+  `dense-row-detail-accessibility.tsx` so the panel can return focus to a selected row that
+  windowing unmounted, instead of grabbing an unrelated in-window row. The prop is absent for the
+  17 existing consumers (behaviour byte-identical); adopted first in **trial balance**, gated above
+  a row-count threshold so small sets render normally. Journal entries, reconciliation breaks, and
+  the financial record explorer are follow-up adopters that reuse the same prop.
+
 ### 6c. Linked chart crosshair + evidence drill (#8)
 - Charts (`components/charts/`) are stateless SVG: `crosshairIndex` prop flows IN, no events flow
   OUT. Add optional `onCrosshairChange(index)` / `onPointActivate(index)` props to `CandleChart`
@@ -291,7 +304,7 @@ additionally re-runs the a11y suites (`*-screen.a11y.test.tsx`,
 
 **Checklist**
 - [x] 6a scope picker + persistence + Portfolio migration.
-- [ ] 6b virtualization inside `DenseDataTable` with a11y contract tests green.
+- [x] 6b virtualization inside `DenseDataTable` with a11y contract tests green.
 - [ ] 6c chart callback props + `ChartSyncContext` + one evidence-drill screen.
 - [ ] 6d chrome-less pane branch + BroadcastChannel bridge + popup fallback link.
 

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 538,
-  "total_lines": 88610,
+  "total_lines": 88626,
   "orphaned_count": 205,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2138,7 +2138,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7787,
+      "line_count": 7790,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -3106,7 +3106,7 @@
     },
     {
       "path": "docs/product/web-ui-improvements-implementation-plan-2026-07.md",
-      "line_count": 309,
+      "line_count": 322,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 538 |
-| Total lines | 88,610 |
+| Total lines | 88,626 |
 | Average file size (lines) | 164.7 |
 | Orphaned files | 205 |
 | Files without headings | 38 |

--- a/src/Meridian.Ui/dashboard/src/components/meridian/dense-row-detail-accessibility.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/dense-row-detail-accessibility.tsx
@@ -72,6 +72,30 @@ export function buildDenseRowDetailAnnouncement(label: string): string {
   return `${label} selected. Detail panel updated.`;
 }
 
+/**
+ * Returns true when it has taken over focus handling (scrolled the controlling
+ * row back into view and focused it). Registered by virtualized dense tables so
+ * Escape can return focus to a selected row that has been unmounted by windowing.
+ */
+export type DenseRowRevealHandler = () => boolean;
+
+const denseRowRevealHandlers = new Map<string, DenseRowRevealHandler>();
+
+/**
+ * Register a reveal handler for a detail panel id. A virtualized dense table
+ * uses this so that pressing Escape from the detail panel can bring a
+ * scrolled-out selected row back into the window before focusing it. Returns an
+ * unregister function; safe to call when the same panel id is re-registered.
+ */
+export function registerDenseRowRevealHandler(panelId: string, handler: DenseRowRevealHandler): () => void {
+  denseRowRevealHandlers.set(panelId, handler);
+  return () => {
+    if (denseRowRevealHandlers.get(panelId) === handler) {
+      denseRowRevealHandlers.delete(panelId);
+    }
+  };
+}
+
 export function focusDenseRowDetailPanel(panelId: string | undefined): void {
   if (!panelId || typeof document === "undefined") return;
   window.requestAnimationFrame(() => {
@@ -85,18 +109,35 @@ function handleDenseRowDetailPanelKeyDown(event: KeyboardEvent<HTMLElement>) {
   const panelId = event.currentTarget.id;
   if (!panelId) return;
 
+  // The selected controlling row, if it is currently mounted.
   const selectedController = document.querySelector<HTMLElement>(
     `[aria-controls="${escapeAttributeSelectorValue(panelId)}"][aria-selected="true"]`
   );
+  if (selectedController) {
+    event.preventDefault();
+    selectedController.focus();
+    return;
+  }
+
+  // The selected row is not mounted — a virtualized table has scrolled it out of
+  // the window. A registered reveal handler owns the panel's reveal semantics
+  // (it knows the selected row's index); prefer it over the generic fallback,
+  // which would otherwise grab an unrelated windowed row that controls the same
+  // panel.
+  const revealer = denseRowRevealHandlers.get(panelId);
+  if (revealer?.()) {
+    event.preventDefault();
+    return;
+  }
+
+  // Non-virtualized fallback: focus the first controlling row.
   const fallbackController = document.querySelector<HTMLElement>(
     `[aria-controls="${escapeAttributeSelectorValue(panelId)}"][data-selectable="true"]`
   );
-  const controller = selectedController ?? fallbackController;
-
-  if (!controller) return;
-
-  event.preventDefault();
-  controller.focus();
+  if (fallbackController) {
+    event.preventDefault();
+    fallbackController.focus();
+  }
 }
 
 function escapeAttributeSelectorValue(value: string): string {

--- a/src/Meridian.Ui/dashboard/src/components/meridian/ui-kit-primitives.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/ui-kit-primitives.tsx
@@ -1,11 +1,31 @@
-import { memo, useId, useState, type KeyboardEvent, type ReactNode } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type ReactNode
+} from "react";
 import {
   DENSE_ROW_DETAIL_KEYBOARD_INSTRUCTIONS,
   buildDenseRowDetailAnnouncement,
-  focusDenseRowDetailPanel
+  focusDenseRowDetailPanel,
+  registerDenseRowRevealHandler
 } from "@/components/meridian/dense-row-detail-accessibility";
+import {
+  computeRevealScrollTop,
+  computeRowWindow,
+  resolveTypeaheadIndex
+} from "@/lib/dense-virtualization";
 import { cn } from "@/lib/utils";
 import "@/styles/ui-kit-primitives.css";
+
+const DEFAULT_VIRTUALIZATION_OVERSCAN = 6;
+const DEFAULT_VIRTUALIZATION_VIEWPORT_ROWS = 12;
+const TYPEAHEAD_RESET_MS = 500;
 
 export interface ToolbarStripItem {
   id: string;
@@ -58,6 +78,15 @@ export interface DenseDataTableSortState {
   direction: "asc" | "desc";
 }
 
+export interface DenseDataTableVirtualization {
+  /** Fixed pixel height of every row. Stable heights keep the offset math exact. */
+  rowHeight: number;
+  /** Number of rows the scroll viewport shows at once. Default 12. */
+  viewportRowCount?: number;
+  /** Rows rendered beyond the viewport on each side to smooth fast scrolls. Default 6. */
+  overscan?: number;
+}
+
 export interface DenseDataTableProps<T> {
   columns: DenseDataTableColumn<T>[];
   rows: T[];
@@ -76,6 +105,14 @@ export interface DenseDataTableProps<T> {
   sort?: DenseDataTableSortState | null;
   onToggleSort?: (columnId: string) => void;
   maxVisibleRows?: number | null;
+  /**
+   * Enable row windowing for large data sets. When set, only a window of rows is
+   * mounted and the table exposes `aria-rowcount`/`aria-rowindex` so assistive
+   * tech reports positions across the full set. Requires stable row heights.
+   */
+  virtualization?: DenseDataTableVirtualization | null;
+  /** Per-row text used for keyboard type-ahead; defaults to `getRowAriaLabel`. */
+  getRowTypeaheadText?: (row: T) => string | undefined;
 }
 
 function DenseDataTableComponent<T>({
@@ -95,21 +132,323 @@ function DenseDataTableComponent<T>({
   caption,
   sort = null,
   onToggleSort,
-  maxVisibleRows = null
+  maxVisibleRows = null,
+  virtualization = null,
+  getRowTypeaheadText
 }: DenseDataTableProps<T>) {
   const generatedKeyboardInstructionsId = useId();
   const [showAllRows, setShowAllRows] = useState(false);
+  const [selectionAnnouncement, setSelectionAnnouncement] = useState("");
+  const [scrollTop, setScrollTop] = useState(0);
+  const [pendingFocusRowId, setPendingFocusRowId] = useState<string | null>(null);
+
+  // The wrap is itself the scroll viewport (max-height + overflow), so windowing
+  // reads and drives its scrollTop directly rather than nesting a second scroller.
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const scrollRafRef = useRef<number | null>(null);
+  const typeaheadRef = useRef<{ buffer: string; at: number }>({ buffer: "", at: 0 });
+
+  const rowHeight = virtualization?.rowHeight ?? 0;
+  const isVirtual = virtualization != null && rowHeight > 0 && rows.length > 0;
+  const overscan = virtualization?.overscan ?? DEFAULT_VIRTUALIZATION_OVERSCAN;
+  const viewportRowCount = virtualization?.viewportRowCount ?? DEFAULT_VIRTUALIZATION_VIEWPORT_ROWS;
+  const viewportHeight = rowHeight * viewportRowCount;
+
   const visibleRowLimit = typeof maxVisibleRows === "number" && maxVisibleRows > 0 ? maxVisibleRows : null;
-  const cappedRows = visibleRowLimit && !showAllRows ? rows.slice(0, visibleRowLimit) : rows;
+  // Windowing supersedes the "show all" soft cap: a virtualized table renders the
+  // full set through spacer rows, so the cap only applies when not virtualizing.
+  const cappedRows = !isVirtual && visibleRowLimit && !showAllRows ? rows.slice(0, visibleRowLimit) : rows;
   const hiddenRowCount = Math.max(0, rows.length - cappedRows.length);
+  // navRows is the addressable set for keyboard traversal — the full data set when
+  // virtualizing, the rendered slice otherwise (cappedRows === rows when virtual).
+  const navRows = cappedRows;
+
+  const rowWindow = isVirtual
+    ? computeRowWindow({ scrollTop, rowHeight, rowCount: rows.length, viewportHeight, overscan })
+    : null;
+  const renderRows = rowWindow ? rows.slice(rowWindow.startIndex, rowWindow.endIndex) : cappedRows;
+  const renderBaseIndex = rowWindow ? rowWindow.startIndex : 0;
+
   const selectableRows = onRowSelect !== undefined && cappedRows.length > 0;
   const exposesExpandedRows = getRowAriaExpanded !== undefined;
   const keyboardInstructionsId = `${tableId ?? generatedKeyboardInstructionsId}-keyboard-instructions`;
-  const focusableRowId = resolveFocusableDenseRowId(cappedRows, getRowId, selectedRowId);
-  const [selectionAnnouncement, setSelectionAnnouncement] = useState("");
+  const focusableRowId = resolveFocusableDenseRowId(renderRows, getRowId, selectedRowId);
+
+  const getAnnouncementLabel = (row: T) => getRowSelectAriaLabel?.(row) ?? getRowAriaLabel?.(row);
+  const getTypeaheadLabel = (row: T) => getRowTypeaheadText?.(row) ?? getRowAriaLabel?.(row) ?? "";
+
+  // `scrollTop` state is the source of truth for the window math (it is what the
+  // current render used); we also push it onto the DOM node so the real browser
+  // actually scrolls. Reading el.scrollTop here would be wrong under jsdom, which
+  // has no layout.
+  const revealRowIndex = (index: number) => {
+    if (rowHeight <= 0) return;
+    const next = computeRevealScrollTop({ index, rowHeight, scrollTop, viewportHeight });
+    if (next !== scrollTop) {
+      if (wrapRef.current) {
+        wrapRef.current.scrollTop = next;
+      }
+      setScrollTop(next);
+    }
+  };
+
+  const focusRowById = useCallback((rowId: string) => {
+    const el = wrapRef.current?.querySelector<HTMLTableRowElement>(
+      `tr[data-dense-row-id="${escapeAttributeSelectorValue(rowId)}"]`
+    );
+    if (el) {
+      el.focus();
+      return true;
+    }
+    return false;
+  }, []);
+
+  const moveToRow = (targetIndex: number) => {
+    if (!onRowSelect) return;
+    const targetRow = navRows[targetIndex];
+    if (!targetRow) return;
+    const targetId = getRowId(targetRow);
+    if (isVirtual) {
+      // Bring the target into the window; if it is not mounted yet, defer focus
+      // until the reveal-driven re-render mounts it.
+      if (focusRowById(targetId)) {
+        revealRowIndex(targetIndex);
+      } else {
+        revealRowIndex(targetIndex);
+        setPendingFocusRowId(targetId);
+      }
+    } else {
+      focusRowById(targetId);
+    }
+    selectDenseRow(
+      targetRow,
+      getAnnouncementLabel(targetRow),
+      getRowAriaControls?.(targetRow),
+      false,
+      onRowSelect,
+      setSelectionAnnouncement
+    );
+  };
+
+  const handleRowKeyDown = (event: KeyboardEvent<HTMLTableRowElement>, currentIndex: number) => {
+    if (!onRowSelect) return;
+    if (event.target !== event.currentTarget && isInteractiveTableTarget(event.target)) return;
+
+    const currentRow = navRows[currentIndex];
+
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      if (currentRow) {
+        selectDenseRow(
+          currentRow,
+          getAnnouncementLabel(currentRow),
+          getRowAriaControls?.(currentRow),
+          true,
+          onRowSelect,
+          setSelectionAnnouncement
+        );
+      }
+      return;
+    }
+
+    const targetIndex = resolveKeyboardTargetRowIndex(event.key, currentIndex, navRows.length);
+    if (targetIndex !== null) {
+      event.preventDefault();
+      moveToRow(targetIndex);
+      return;
+    }
+
+    // Type-ahead: a printable character jumps to the next matching row across the
+    // full addressable set (so windowed rows remain reachable without scrolling).
+    if (event.key.length === 1 && event.key !== " " && !event.ctrlKey && !event.metaKey && !event.altKey) {
+      const now = Date.now();
+      const store = typeaheadRef.current;
+      const continued = now - store.at < TYPEAHEAD_RESET_MS && store.buffer.length > 0;
+      const buffer = continued ? store.buffer + event.key : event.key;
+      store.buffer = buffer;
+      store.at = now;
+      const matchIndex = resolveTypeaheadIndex({
+        labels: navRows.map(getTypeaheadLabel),
+        buffer,
+        fromIndex: currentIndex,
+        inclusive: continued
+      });
+      if (matchIndex !== null) {
+        event.preventDefault();
+        moveToRow(matchIndex);
+      }
+    }
+  };
+
+  const handleScroll = useCallback(() => {
+    if (scrollRafRef.current != null) return;
+    scrollRafRef.current = window.requestAnimationFrame(() => {
+      scrollRafRef.current = null;
+      const current = wrapRef.current;
+      if (current) {
+        setScrollTop(current.scrollTop);
+      }
+    });
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (scrollRafRef.current != null) {
+        cancelAnimationFrame(scrollRafRef.current);
+      }
+    },
+    []
+  );
+
+  // Focus a row that was not mounted when navigation targeted it, once the
+  // reveal-driven scroll has mounted it into the window.
+  useEffect(() => {
+    if (!pendingFocusRowId) return;
+    const el = wrapRef.current?.querySelector<HTMLTableRowElement>(
+      `tr[data-dense-row-id="${escapeAttributeSelectorValue(pendingFocusRowId)}"]`
+    );
+    if (el) {
+      el.focus();
+      setPendingFocusRowId(null);
+    }
+  }, [pendingFocusRowId, scrollTop]);
+
+  // Let Escape from the detail panel return focus to a selected row that windowing
+  // has scrolled out of view.
+  const selectedRow = selectedRowId != null ? rows.find((row) => getRowId(row) === selectedRowId) : undefined;
+  const selectedPanelId = selectedRow ? getRowAriaControls?.(selectedRow) : undefined;
+  const revealSelectedRef = useRef<() => boolean>(() => false);
+  revealSelectedRef.current = () => {
+    if (!isVirtual || selectedRowId == null) return false;
+    const index = rows.findIndex((row) => getRowId(row) === selectedRowId);
+    if (index < 0) return false;
+    revealRowIndex(index);
+    setPendingFocusRowId(selectedRowId);
+    return true;
+  };
+  useEffect(() => {
+    if (!isVirtual || !selectedPanelId) return;
+    return registerDenseRowRevealHandler(selectedPanelId, () => revealSelectedRef.current());
+  }, [isVirtual, selectedPanelId]);
+
+  const tableElement = (
+    <table
+      id={tableId}
+      role={exposesExpandedRows ? "treegrid" : undefined}
+      className="dense-data-table"
+      aria-label={ariaLabel}
+      aria-describedby={selectableRows ? keyboardInstructionsId : undefined}
+      aria-rowcount={isVirtual ? rows.length + 1 : undefined}
+    >
+      {caption ? <caption className="sr-only">{caption}</caption> : null}
+      <thead>
+        <tr aria-rowindex={isVirtual ? 1 : undefined}>
+          {columns.map((column) => {
+            const sortable = Boolean(column.sortable && onToggleSort);
+            const sorted = sortable && sort?.columnId === column.id;
+            return (
+              <th
+                key={column.id}
+                scope="col"
+                aria-sort={sortable ? sorted ? sort.direction === "asc" ? "ascending" : "descending" : "none" : undefined}
+                className={cn(
+                  column.align === "right" ? "text-right" : "text-left",
+                  sortable ? "dense-data-table-sortable" : undefined,
+                  sorted ? "dense-data-table-sorted" : undefined,
+                  column.className
+                )}
+              >
+                {sortable ? (
+                  <button
+                    type="button"
+                    className="dense-data-table-sort-button"
+                    onClick={() => onToggleSort?.(column.id)}
+                    aria-label={buildSortButtonAriaLabel(column, sorted ? sort : null)}
+                  >
+                    <span>{column.label}</span>
+                    <span className="dense-data-table-sort-indicator" aria-hidden="true">
+                      {sorted ? sort.direction === "asc" ? "↑" : "↓" : "↕"}
+                    </span>
+                  </button>
+                ) : column.label || (column.srLabel ? <span className="sr-only">{column.srLabel}</span> : null)}
+              </th>
+            );
+          })}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.length === 0 ? (
+          <tr>
+            <td colSpan={columns.length} className="dense-data-table-empty">
+              {emptyText}
+            </td>
+          </tr>
+        ) : (
+          <>
+            {rowWindow && rowWindow.topPad > 0 ? (
+              <tr aria-hidden="true" className="dense-data-table-spacer">
+                <td colSpan={columns.length} style={{ height: rowWindow.topPad, padding: 0 }} />
+              </tr>
+            ) : null}
+            {renderRows.map((row, index) => {
+              const absoluteIndex = renderBaseIndex + index;
+              const rowId = getRowId(row);
+              const selected = selectedRowId === rowId;
+              const selectable = onRowSelect !== undefined;
+              const rowAriaLabel = selectable
+                ? getRowSelectAriaLabel?.(row) ?? getRowAriaLabel?.(row)
+                : getRowAriaLabel?.(row);
+              const rowAriaExpanded = selectable ? getRowAriaExpanded?.(row) : undefined;
+              const rowStyle: CSSProperties | undefined = isVirtual ? { height: rowHeight } : undefined;
+              return (
+                <tr
+                  key={rowId}
+                  aria-label={rowAriaLabel}
+                  aria-controls={selectable ? getRowAriaControls?.(row) : undefined}
+                  aria-expanded={rowAriaExpanded}
+                  aria-selected={selected || undefined}
+                  aria-rowindex={isVirtual ? absoluteIndex + 2 : undefined}
+                  tabIndex={selectable ? rowId === focusableRowId ? 0 : -1 : undefined}
+                  data-selectable={selectable ? "true" : undefined}
+                  data-dense-row-id={selectable ? rowId : undefined}
+                  style={rowStyle}
+                  className={cn(selectable ? "selectable" : undefined, selected ? "selected" : undefined, getRowClassName?.(row))}
+                  onClick={selectable ? (event) => {
+                    if (isInteractiveTableTarget(event.target)) return;
+                    selectDenseRow(row, rowAriaLabel, getRowAriaControls?.(row), false, onRowSelect, setSelectionAnnouncement);
+                  } : undefined}
+                  onKeyDown={selectable ? (event) => handleRowKeyDown(event, absoluteIndex) : undefined}
+                >
+                  {columns.map((column) => (
+                    <td
+                      key={column.id}
+                      className={cn(column.align === "right" ? "text-right" : "text-left", column.className)}
+                    >
+                      {column.render(row)}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+            {rowWindow && rowWindow.bottomPad > 0 ? (
+              <tr aria-hidden="true" className="dense-data-table-spacer">
+                <td colSpan={columns.length} style={{ height: rowWindow.bottomPad, padding: 0 }} />
+              </tr>
+            ) : null}
+          </>
+        )}
+      </tbody>
+    </table>
+  );
 
   return (
-    <div className="dense-data-table-wrap" data-empty={rows.length === 0 ? "true" : undefined}>
+    <div
+      className={cn("dense-data-table-wrap", isVirtual ? "dense-data-table-wrap-virtual" : undefined)}
+      data-empty={rows.length === 0 ? "true" : undefined}
+      ref={wrapRef}
+      style={isVirtual ? { maxHeight: viewportHeight } : undefined}
+      onScroll={isVirtual ? handleScroll : undefined}
+    >
       {selectableRows ? (
         <p id={keyboardInstructionsId} className="sr-only">
           {DENSE_ROW_DETAIL_KEYBOARD_INSTRUCTIONS}
@@ -120,105 +459,7 @@ function DenseDataTableComponent<T>({
           {selectionAnnouncement}
         </div>
       ) : null}
-      <table
-        id={tableId}
-        role={exposesExpandedRows ? "treegrid" : undefined}
-        className="dense-data-table"
-        aria-label={ariaLabel}
-        aria-describedby={selectableRows ? keyboardInstructionsId : undefined}
-      >
-        {caption ? <caption className="sr-only">{caption}</caption> : null}
-        <thead>
-          <tr>
-            {columns.map((column) => {
-              const sortable = Boolean(column.sortable && onToggleSort);
-              const sorted = sortable && sort?.columnId === column.id;
-              return (
-                <th
-                  key={column.id}
-                  scope="col"
-                  aria-sort={sortable ? sorted ? sort.direction === "asc" ? "ascending" : "descending" : "none" : undefined}
-                  className={cn(
-                    column.align === "right" ? "text-right" : "text-left",
-                    sortable ? "dense-data-table-sortable" : undefined,
-                    sorted ? "dense-data-table-sorted" : undefined,
-                    column.className
-                  )}
-                >
-                  {sortable ? (
-                    <button
-                      type="button"
-                      className="dense-data-table-sort-button"
-                      onClick={() => onToggleSort?.(column.id)}
-                      aria-label={buildSortButtonAriaLabel(column, sorted ? sort : null)}
-                    >
-                      <span>{column.label}</span>
-                      <span className="dense-data-table-sort-indicator" aria-hidden="true">
-                        {sorted ? sort.direction === "asc" ? "↑" : "↓" : "↕"}
-                      </span>
-                    </button>
-                  ) : column.label || (column.srLabel ? <span className="sr-only">{column.srLabel}</span> : null)}
-                </th>
-              );
-            })}
-          </tr>
-        </thead>
-        <tbody>
-          {rows.length > 0 ? cappedRows.map((row, rowIndex) => {
-            const rowId = getRowId(row);
-            const selected = selectedRowId === rowId;
-            const selectable = onRowSelect !== undefined;
-            const rowAriaLabel = selectable
-              ? getRowSelectAriaLabel?.(row) ?? getRowAriaLabel?.(row)
-              : getRowAriaLabel?.(row);
-            const rowAriaExpanded = selectable ? getRowAriaExpanded?.(row) : undefined;
-            return (
-              <tr
-                key={rowId}
-                aria-label={rowAriaLabel}
-                aria-controls={selectable ? getRowAriaControls?.(row) : undefined}
-                aria-expanded={rowAriaExpanded}
-                aria-selected={selected || undefined}
-                tabIndex={selectable ? rowId === focusableRowId ? 0 : -1 : undefined}
-                data-selectable={selectable ? "true" : undefined}
-                data-dense-row-id={selectable ? rowId : undefined}
-                className={cn(selectable ? "selectable" : undefined, selected ? "selected" : undefined, getRowClassName?.(row))}
-                onClick={selectable ? (event) => {
-                  if (isInteractiveTableTarget(event.target)) return;
-                  selectDenseRow(row, rowAriaLabel, getRowAriaControls?.(row), false, onRowSelect, setSelectionAnnouncement);
-                } : undefined}
-                onKeyDown={selectable ? (event) => {
-                  handleSelectableRowKeyDown(event, {
-                    row,
-                    rowIndex,
-                    rows: cappedRows,
-                    getRowId,
-                    getRowAriaControls,
-                    getRowAnnouncementLabel: (item) => getRowSelectAriaLabel?.(item) ?? getRowAriaLabel?.(item),
-                    onRowSelect,
-                    setSelectionAnnouncement
-                  });
-                } : undefined}
-              >
-                {columns.map((column) => (
-                  <td
-                    key={column.id}
-                    className={cn(column.align === "right" ? "text-right" : "text-left", column.className)}
-                  >
-                    {column.render(row)}
-                  </td>
-                ))}
-              </tr>
-            );
-          }) : (
-            <tr>
-              <td colSpan={columns.length} className="dense-data-table-empty">
-                {emptyText}
-              </td>
-            </tr>
-          )}
-        </tbody>
-      </table>
+      {tableElement}
       {hiddenRowCount > 0 ? (
         <div className="dense-data-table-row-cap">
           <button type="button" onClick={() => setShowAllRows(true)}>
@@ -257,60 +498,6 @@ function buildSortButtonAriaLabel<T>(
   }
 
   return `${column.label} sorted ${sort.direction === "asc" ? "ascending" : "descending"}. Activate to change sort.`;
-}
-
-function handleSelectableRowKeyDown<T>(
-  event: KeyboardEvent<HTMLTableRowElement>,
-  options: {
-    row: T;
-    rowIndex: number;
-    rows: T[];
-    getRowId: (row: T) => string;
-    getRowAriaControls?: (row: T) => string | undefined;
-    getRowAnnouncementLabel?: (row: T) => string | undefined;
-    onRowSelect: (row: T) => void;
-    setSelectionAnnouncement: (announcement: string) => void;
-  }
-) {
-  if (event.target !== event.currentTarget && isInteractiveTableTarget(event.target)) return;
-
-  if (event.key === "Enter" || event.key === " ") {
-    event.preventDefault();
-    selectDenseRow(
-      options.row,
-      options.getRowAnnouncementLabel?.(options.row),
-      options.getRowAriaControls?.(options.row),
-      true,
-      options.onRowSelect,
-      options.setSelectionAnnouncement
-    );
-    return;
-  }
-
-  const targetIndex = resolveKeyboardTargetRowIndex(event.key, options.rowIndex, options.rows.length);
-  if (targetIndex === null) {
-    return;
-  }
-
-  event.preventDefault();
-  const targetRow = options.rows[targetIndex];
-  if (!targetRow) {
-    return;
-  }
-
-  const targetRowId = options.getRowId(targetRow);
-  const targetElement = event.currentTarget
-    .closest("tbody")
-    ?.querySelector<HTMLTableRowElement>(`tr[data-dense-row-id="${escapeAttributeSelectorValue(targetRowId)}"]`);
-  targetElement?.focus();
-  selectDenseRow(
-    targetRow,
-    options.getRowAnnouncementLabel?.(targetRow),
-    options.getRowAriaControls?.(targetRow),
-    false,
-    options.onRowSelect,
-    options.setSelectionAnnouncement
-  );
 }
 
 function selectDenseRow<T>(

--- a/src/Meridian.Ui/dashboard/src/components/meridian/ui-kit-primitives.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/ui-kit-primitives.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useId,
+  useMemo,
   useRef,
   useState,
   type CSSProperties,
@@ -175,7 +176,12 @@ function DenseDataTableComponent<T>({
   const focusableRowId = resolveFocusableDenseRowId(renderRows, getRowId, selectedRowId);
 
   const getAnnouncementLabel = (row: T) => getRowSelectAriaLabel?.(row) ?? getRowAriaLabel?.(row);
-  const getTypeaheadLabel = (row: T) => getRowTypeaheadText?.(row) ?? getRowAriaLabel?.(row) ?? "";
+  // Precompute type-ahead labels once per row-set change rather than on every
+  // keystroke (the map is O(N) and allocates a fresh array each call).
+  const typeaheadLabels = useMemo(
+    () => navRows.map((row) => getRowTypeaheadText?.(row) ?? getRowAriaLabel?.(row) ?? ""),
+    [navRows, getRowTypeaheadText, getRowAriaLabel]
+  );
 
   // `scrollTop` state is the source of truth for the window math (it is what the
   // current render used); we also push it onto the DOM node so the real browser
@@ -268,7 +274,7 @@ function DenseDataTableComponent<T>({
       store.buffer = buffer;
       store.at = now;
       const matchIndex = resolveTypeaheadIndex({
-        labels: navRows.map(getTypeaheadLabel),
+        labels: typeaheadLabels,
         buffer,
         fromIndex: currentIndex,
         inclusive: continued
@@ -315,7 +321,12 @@ function DenseDataTableComponent<T>({
 
   // Let Escape from the detail panel return focus to a selected row that windowing
   // has scrolled out of view.
-  const selectedRow = selectedRowId != null ? rows.find((row) => getRowId(row) === selectedRowId) : undefined;
+  // Memoized so scroll-driven re-renders don't repeat the O(N) lookup; the deps
+  // are stable across scroll (only scrollTop state changes then).
+  const selectedRow = useMemo(
+    () => (selectedRowId != null ? rows.find((row) => getRowId(row) === selectedRowId) : undefined),
+    [rows, selectedRowId, getRowId]
+  );
   const selectedPanelId = selectedRow ? getRowAriaControls?.(selectedRow) : undefined;
   const revealSelectedRef = useRef<() => boolean>(() => false);
   revealSelectedRef.current = () => {

--- a/src/Meridian.Ui/dashboard/src/components/meridian/ui-kit-primitives.virtualization.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/ui-kit-primitives.virtualization.test.tsx
@@ -1,0 +1,137 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import { DenseRowDetailPanel } from "@/components/meridian/dense-row-detail-accessibility";
+import { DenseDataTable, type DenseDataTableColumn } from "@/components/meridian/ui-kit-primitives";
+
+interface Row {
+  id: string;
+  index: number;
+  name: string;
+}
+
+const DETAIL_PANEL_ID = "virtual-grid-detail";
+const ROW_HEIGHT = 20;
+const VIEWPORT_ROWS = 10;
+
+function buildRows(count: number): Row[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `row-${index}`,
+    index,
+    name: index === 45 ? "Zebra account" : `Item ${index}`
+  }));
+}
+
+const columns: DenseDataTableColumn<Row>[] = [
+  { id: "name", label: "Name", render: (row) => row.name },
+  { id: "index", label: "Index", render: (row) => String(row.index) }
+];
+
+function Harness({ rows, selectedRowId = "row-0" }: { rows: Row[]; selectedRowId?: string }) {
+  return (
+    <div>
+      <DenseDataTable
+        columns={columns}
+        rows={rows}
+        getRowId={(row) => row.id}
+        getRowAriaLabel={(row) => `${row.name} row`}
+        getRowSelectAriaLabel={(row) => `Select ${row.name}`}
+        getRowAriaControls={() => DETAIL_PANEL_ID}
+        getRowAriaExpanded={(row) => row.id === selectedRowId}
+        getRowTypeaheadText={(row) => row.name}
+        selectedRowId={selectedRowId}
+        onRowSelect={() => undefined}
+        emptyText="No rows"
+        ariaLabel="Virtualized grid"
+        virtualization={{ rowHeight: ROW_HEIGHT, viewportRowCount: VIEWPORT_ROWS, overscan: 4 }}
+      />
+      <DenseRowDetailPanel id={DETAIL_PANEL_ID} ariaLabel="Virtual grid detail">
+        <p>Detail</p>
+      </DenseRowDetailPanel>
+    </div>
+  );
+}
+
+function renderedRowIds(): string[] {
+  return Array.from(document.querySelectorAll<HTMLElement>("tr[data-dense-row-id]")).map(
+    (el) => el.getAttribute("data-dense-row-id") ?? ""
+  );
+}
+
+describe("DenseDataTable virtualization", () => {
+  afterEach(() => cleanup());
+
+  it("mounts only a window of rows and exposes full-set row positions", () => {
+    render(<Harness rows={buildRows(60)} />);
+
+    const table = screen.getByRole("treegrid", { name: "Virtualized grid" });
+    // aria-rowcount covers the full data set plus the header row.
+    expect(table).toHaveAttribute("aria-rowcount", "61");
+
+    const ids = renderedRowIds();
+    expect(ids.length).toBeLessThan(60); // windowed, not all mounted
+    expect(ids).toContain("row-0");
+    expect(ids).not.toContain("row-59");
+
+    // Header is row 1; the first data row is absolute index 0 => aria-rowindex 2.
+    const firstRow = screen.getByRole("row", { name: "Select Item 0" });
+    expect(firstRow).toHaveAttribute("aria-rowindex", "2");
+  });
+
+  it("navigates to a windowed-out row with End, revealing and focusing it", async () => {
+    const user = userEvent.setup();
+    render(<Harness rows={buildRows(60)} />);
+
+    expect(renderedRowIds()).not.toContain("row-59");
+
+    const firstRow = screen.getByRole("row", { name: "Select Item 0" });
+    firstRow.focus();
+    await user.keyboard("{End}");
+
+    await waitFor(() => {
+      const lastRow = screen.queryByRole("row", { name: "Select Item 59" });
+      expect(lastRow).not.toBeNull();
+      expect(lastRow).toHaveFocus();
+    });
+    expect(screen.getByRole("status")).toHaveTextContent("Select Item 59 selected. Detail panel updated.");
+  });
+
+  it("type-ahead jumps to a matching row outside the current window", async () => {
+    const user = userEvent.setup();
+    render(<Harness rows={buildRows(60)} />);
+
+    expect(renderedRowIds()).not.toContain("row-45");
+
+    const firstRow = screen.getByRole("row", { name: "Select Item 0" });
+    firstRow.focus();
+    await user.keyboard("z");
+
+    await waitFor(() => {
+      const zebra = screen.queryByRole("row", { name: "Select Zebra account" });
+      expect(zebra).not.toBeNull();
+      expect(zebra).toHaveFocus();
+    });
+  });
+
+  it("Escape from the detail panel reveals a selected row that windowing unmounted", async () => {
+    const user = userEvent.setup();
+    // selectedRowId stays row-0 (controlled); navigating scrolls it out of the window.
+    render(<Harness rows={buildRows(60)} selectedRowId="row-0" />);
+
+    const firstRow = screen.getByRole("row", { name: "Select Item 0" });
+    firstRow.focus();
+    await user.keyboard("{End}");
+
+    await waitFor(() => expect(renderedRowIds()).not.toContain("row-0"));
+
+    const panel = screen.getByRole("region", { name: "Virtual grid detail" });
+    panel.focus();
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      const revealed = screen.queryByRole("row", { name: "Select Item 0" });
+      expect(revealed).not.toBeNull();
+      expect(revealed).toHaveFocus();
+    });
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/lib/dense-virtualization.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/dense-virtualization.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { computeRevealScrollTop, computeRowWindow, resolveTypeaheadIndex } from "@/lib/dense-virtualization";
+
+describe("computeRowWindow", () => {
+  it("returns an empty window for an empty or zero-height data set", () => {
+    expect(computeRowWindow({ scrollTop: 0, rowHeight: 32, rowCount: 0, viewportHeight: 320, overscan: 6 })).toEqual({
+      startIndex: 0,
+      endIndex: 0,
+      topPad: 0,
+      bottomPad: 0
+    });
+    expect(computeRowWindow({ scrollTop: 100, rowHeight: 0, rowCount: 50, viewportHeight: 320, overscan: 6 })).toEqual({
+      startIndex: 0,
+      endIndex: 0,
+      topPad: 0,
+      bottomPad: 0
+    });
+  });
+
+  it("windows around the scroll offset with overscan and exact spacer padding", () => {
+    // 1000 rows * 20px = 20000px total. Scrolled to 4000px => firstVisible = 200.
+    const window = computeRowWindow({ scrollTop: 4000, rowHeight: 20, rowCount: 1000, viewportHeight: 200, overscan: 5 });
+    expect(window.startIndex).toBe(195); // 200 - 5 overscan
+    // firstVisible(200) + ceil(200/20)=10 visible + 5 overscan = 215
+    expect(window.endIndex).toBe(215);
+    expect(window.topPad).toBe(195 * 20);
+    expect(window.bottomPad).toBe((1000 - 215) * 20);
+    // Spacers + rendered rows always sum to the full virtual height.
+    const renderedHeight = (window.endIndex - window.startIndex) * 20;
+    expect(window.topPad + renderedHeight + window.bottomPad).toBe(1000 * 20);
+  });
+
+  it("clamps at the top and bottom edges", () => {
+    const top = computeRowWindow({ scrollTop: -50, rowHeight: 32, rowCount: 40, viewportHeight: 320, overscan: 4 });
+    expect(top.startIndex).toBe(0);
+    expect(top.topPad).toBe(0);
+
+    const bottom = computeRowWindow({ scrollTop: 100000, rowHeight: 32, rowCount: 40, viewportHeight: 320, overscan: 4 });
+    expect(bottom.endIndex).toBe(40);
+    expect(bottom.bottomPad).toBe(0);
+  });
+});
+
+describe("computeRevealScrollTop", () => {
+  const base = { rowHeight: 20, viewportHeight: 200 };
+
+  it("aligns a row above the window to the top", () => {
+    expect(computeRevealScrollTop({ ...base, index: 10, scrollTop: 400 })).toBe(200);
+  });
+
+  it("aligns a row below the window to the bottom", () => {
+    // index 50 => rowBottom 1020; viewport 200 => 1020 - 200 = 820.
+    expect(computeRevealScrollTop({ ...base, index: 50, scrollTop: 100 })).toBe(820);
+  });
+
+  it("leaves the offset untouched when the row is already visible", () => {
+    expect(computeRevealScrollTop({ ...base, index: 12, scrollTop: 200 })).toBe(200);
+  });
+});
+
+describe("resolveTypeaheadIndex", () => {
+  const labels = ["Alpha", "Bravo", "Charlie", "Bravado", "Delta"];
+
+  it("finds the next matching row after the current one for a fresh keystroke", () => {
+    expect(resolveTypeaheadIndex({ labels, buffer: "b", fromIndex: 0, inclusive: false })).toBe(1);
+  });
+
+  it("cycles through matches when the same key repeats", () => {
+    expect(resolveTypeaheadIndex({ labels, buffer: "b", fromIndex: 1, inclusive: false })).toBe(3);
+    // wraps back around to the first match past the end
+    expect(resolveTypeaheadIndex({ labels, buffer: "b", fromIndex: 3, inclusive: false })).toBe(1);
+  });
+
+  it("keeps the current row when a continuation buffer still matches it", () => {
+    expect(resolveTypeaheadIndex({ labels, buffer: "brav", fromIndex: 1, inclusive: true })).toBe(1);
+  });
+
+  it("returns null when nothing matches or the buffer is blank", () => {
+    expect(resolveTypeaheadIndex({ labels, buffer: "z", fromIndex: 0, inclusive: false })).toBeNull();
+    expect(resolveTypeaheadIndex({ labels, buffer: "   ", fromIndex: 0, inclusive: false })).toBeNull();
+    expect(resolveTypeaheadIndex({ labels: [], buffer: "a", fromIndex: 0, inclusive: false })).toBeNull();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/lib/dense-virtualization.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/dense-virtualization.test.ts
@@ -38,6 +38,11 @@ describe("computeRowWindow", () => {
     const bottom = computeRowWindow({ scrollTop: 100000, rowHeight: 32, rowCount: 40, viewportHeight: 320, overscan: 4 });
     expect(bottom.endIndex).toBe(40);
     expect(bottom.bottomPad).toBe(0);
+    // Overscroll past the bottom clamps startIndex to endIndex (never beyond it),
+    // so the slice stays valid and topPad never exceeds the full virtual height.
+    expect(bottom.startIndex).toBeLessThanOrEqual(bottom.endIndex);
+    expect(bottom.startIndex).toBe(40);
+    expect(bottom.topPad).toBe(40 * 32);
   });
 });
 

--- a/src/Meridian.Ui/dashboard/src/lib/dense-virtualization.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/dense-virtualization.ts
@@ -47,8 +47,12 @@ export function computeRowWindow(input: RowWindowInput): RowWindow {
   const firstVisible = Math.floor(safeScroll / rowHeight);
   const visibleCount = Math.max(1, Math.ceil(Math.max(0, viewportHeight) / rowHeight));
 
-  const startIndex = Math.max(0, firstVisible - safeOverscan);
+  // Compute endIndex first, then clamp startIndex to it. Overscrolling past the
+  // bottom (elastic scroll, resize) can push firstVisible beyond rowCount; without
+  // the clamp startIndex would exceed endIndex, yielding an empty slice with an
+  // oversized topPad and an unstable scrollbar.
   const endIndex = Math.min(rowCount, firstVisible + visibleCount + safeOverscan);
+  const startIndex = Math.max(0, Math.min(endIndex, firstVisible - safeOverscan));
 
   return {
     startIndex,

--- a/src/Meridian.Ui/dashboard/src/lib/dense-virtualization.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/dense-virtualization.ts
@@ -1,0 +1,134 @@
+/**
+ * Pure windowing helpers for {@link DenseDataTable}'s optional row virtualization.
+ *
+ * The table stays a semantic `<table>`: windowing is expressed with spacer rows
+ * (top/bottom padding) rather than absolutely-positioned children, so row
+ * addressing (`aria-rowindex`) and keyboard traversal keep working across the
+ * full data set even though only a window of rows is mounted. Row heights are
+ * fixed (`rowHeight`) which is what makes the offset math exact.
+ */
+
+export interface RowWindowInput {
+  /** Current scroll offset of the viewport, in pixels. */
+  scrollTop: number;
+  /** Fixed height of every row, in pixels. */
+  rowHeight: number;
+  /** Total number of rows in the full data set. */
+  rowCount: number;
+  /** Height of the scroll viewport, in pixels. */
+  viewportHeight: number;
+  /** Extra rows rendered above and below the viewport to smooth fast scrolls. */
+  overscan: number;
+}
+
+export interface RowWindow {
+  /** Absolute index of the first mounted row (inclusive). */
+  startIndex: number;
+  /** Absolute index one past the last mounted row (exclusive). */
+  endIndex: number;
+  /** Height of the leading spacer row, in pixels. */
+  topPad: number;
+  /** Height of the trailing spacer row, in pixels. */
+  bottomPad: number;
+}
+
+/**
+ * Resolve the slice of rows to mount for a given scroll offset, plus the
+ * spacer heights that keep the scrollbar sized to the full data set.
+ */
+export function computeRowWindow(input: RowWindowInput): RowWindow {
+  const { scrollTop, rowHeight, rowCount, viewportHeight, overscan } = input;
+  if (rowCount <= 0 || rowHeight <= 0) {
+    return { startIndex: 0, endIndex: 0, topPad: 0, bottomPad: 0 };
+  }
+
+  const safeScroll = Math.max(0, scrollTop);
+  const safeOverscan = Math.max(0, Math.floor(overscan));
+  const firstVisible = Math.floor(safeScroll / rowHeight);
+  const visibleCount = Math.max(1, Math.ceil(Math.max(0, viewportHeight) / rowHeight));
+
+  const startIndex = Math.max(0, firstVisible - safeOverscan);
+  const endIndex = Math.min(rowCount, firstVisible + visibleCount + safeOverscan);
+
+  return {
+    startIndex,
+    endIndex,
+    topPad: startIndex * rowHeight,
+    bottomPad: Math.max(0, (rowCount - endIndex) * rowHeight)
+  };
+}
+
+export interface RevealScrollInput {
+  /** Absolute index of the row to bring into view. */
+  index: number;
+  /** Fixed height of every row, in pixels. */
+  rowHeight: number;
+  /** Current scroll offset of the viewport, in pixels. */
+  scrollTop: number;
+  /** Height of the scroll viewport, in pixels. */
+  viewportHeight: number;
+}
+
+/**
+ * The scroll offset that brings `index` fully into the viewport. Rows above the
+ * window align to the top; rows below align to the bottom; already-visible rows
+ * leave the offset unchanged (no scroll jitter on in-window navigation).
+ */
+export function computeRevealScrollTop(input: RevealScrollInput): number {
+  const { index, rowHeight, scrollTop, viewportHeight } = input;
+  if (rowHeight <= 0 || index < 0) {
+    return Math.max(0, scrollTop);
+  }
+
+  const rowTop = index * rowHeight;
+  const rowBottom = rowTop + rowHeight;
+  const safeScroll = Math.max(0, scrollTop);
+
+  if (rowTop < safeScroll) {
+    return rowTop;
+  }
+  if (rowBottom > safeScroll + viewportHeight) {
+    return Math.max(0, rowBottom - viewportHeight);
+  }
+  return safeScroll;
+}
+
+export interface TypeaheadInput {
+  /** Per-row match text, aligned to the full data set by absolute index. */
+  labels: string[];
+  /** Accumulated type-ahead buffer. */
+  buffer: string;
+  /** Index the search starts from (the currently focused row). */
+  fromIndex: number;
+  /**
+   * When true (a continuation of an existing buffer) the current row is a valid
+   * match; when false (a fresh keystroke) the search starts at the next row so
+   * repeated keys cycle through matches.
+   */
+  inclusive: boolean;
+}
+
+/**
+ * Resolve the absolute index of the next row whose label starts with the
+ * type-ahead buffer, wrapping around the full data set. Returns null when
+ * nothing matches.
+ */
+export function resolveTypeaheadIndex(input: TypeaheadInput): number | null {
+  const needle = input.buffer.trim().toLowerCase();
+  const count = input.labels.length;
+  if (!needle || count === 0) {
+    return null;
+  }
+
+  const from = ((Math.trunc(input.fromIndex) % count) + count) % count;
+  const start = input.inclusive ? 0 : 1;
+  const end = input.inclusive ? count - 1 : count;
+
+  for (let step = start; step <= end; step++) {
+    const index = (from + step) % count;
+    if ((input.labels[index] ?? "").toLowerCase().startsWith(needle)) {
+      return index;
+    }
+  }
+  return null;
+}

--- a/src/Meridian.Ui/dashboard/src/screens/trial-balance-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/trial-balance-screen.tsx
@@ -27,6 +27,9 @@ interface TrialBalanceScreenProps {
 
 type TrialBalanceViewMode = "table" | "hierarchy";
 
+/** Above this row count the trial-balance grid windows rows instead of rendering all of them. */
+const TRIAL_BALANCE_VIRTUALIZATION_THRESHOLD = 40;
+
 export function TrialBalanceScreen({ data }: TrialBalanceScreenProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const [viewMode, setViewMode] = useState<TrialBalanceViewMode>("table");
@@ -285,10 +288,16 @@ export function TrialBalanceScreen({ data }: TrialBalanceScreenProps) {
                   getRowSelectAriaLabel={(line) => line.selectAriaLabel}
                   getRowAriaControls={(line) => line.detailPanelId}
                   getRowAriaExpanded={(line) => line.isExpanded}
+                  getRowTypeaheadText={(line) => line.accountLabel}
                   selectedRowId={reconciliation.trialBalanceView.selectedRowId}
                   onRowSelect={(line) => reconciliation.selectTrialBalanceRow(line.rowId)}
                   emptyText={reconciliation.trialBalanceView.emptyDetail}
                   ariaLabel={reconciliation.trialBalanceView.tableLabel}
+                  virtualization={
+                    reconciliation.trialBalanceView.rows.length > TRIAL_BALANCE_VIRTUALIZATION_THRESHOLD
+                      ? { rowHeight: 36, viewportRowCount: 15 }
+                      : null
+                  }
                 />
                 {reconciliation.trialBalanceView.selectedDetail ? (
                   <AccountingTrialBalanceSelectedDetailPanel

--- a/src/Meridian.Ui/dashboard/src/styles/ui-kit-primitives.css
+++ b/src/Meridian.Ui/dashboard/src/styles/ui-kit-primitives.css
@@ -382,6 +382,40 @@
   padding: 2rem 0.75rem;
 }
 
+/* ── Virtualized dense tables ────────────────────────────────────────────────
+   When DenseDataTable windows rows it mounts only a slice plus top/bottom spacer
+   rows. Keep row heights exact, neutralize the spacers, and disable zebra
+   striping (nth-child parity is meaningless once the mounted slice shifts).
+──────────────────────────────────────────────────────────────────────────*/
+.dense-data-table-wrap-virtual {
+  overflow-y: auto;
+}
+
+.dense-data-table-spacer,
+.dense-data-table-spacer:hover {
+  background: transparent;
+}
+
+.dense-data-table-spacer td {
+  padding: 0;
+  border: 0;
+}
+
+.dense-data-table-wrap-virtual .dense-data-table tbody tr:nth-child(even) {
+  background: var(--ws-surface);
+}
+
+.dense-data-table-wrap-virtual .dense-data-table tbody tr.selectable td,
+.dense-data-table-wrap-virtual .dense-data-table tbody tr td {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.dense-data-table-wrap-virtual .dense-data-table tbody tr.selected {
+  background: var(--ws-row-selected);
+}
+
 /* ── Concrete radius normalization ──────────────────────────────────────────
    Concrete unifies control/card/panel corners to a single tight 2px radius;
    structure is carried by hairline borders, not rounding. Override the legacy


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Adds opt-in **row virtualization** to the shared `DenseDataTable` (Phase 6b of the web-UI improvement plan) so large dense grids render only a window of rows instead of all of them — while preserving the `dense-row-detail-accessibility` contract.

- **`lib/dense-virtualization.ts`** — pure, unit-tested window/reveal/type-ahead math. Fixed row heights make the spacer-offset arithmetic exact.
- **`DenseDataTable` gains `virtualization={{ rowHeight, viewportRowCount?, overscan? }}`.** Windowing is expressed with top/bottom **spacer rows**, so the element stays a semantic `<table>`. It exposes `aria-rowcount`/`aria-rowindex` so assistive tech reports positions across the **full** set even though only a slice is mounted.
- **Keyboard traversal addresses the full data set.** Arrow/Home/End and **type-ahead** can target a windowed-out row: the grid scrolls it into view and **defers focus until it mounts**, so focus survives unmount.
- **Escape-back-to-row across the window.** A reveal-handler registry in `dense-row-detail-accessibility.tsx` lets Escape from the detail panel return focus to a selected row that windowing unmounted, instead of grabbing an unrelated in-window row that controls the same panel.
- **Adopted in the trial-balance grid** above a row-count threshold (small sets render normally). CSS keeps row heights exact, neutralizes spacer rows, and disables zebra striping under windowing.

The `virtualization` prop is **absent** for the 17 other `DenseDataTable` consumers, so their behaviour is byte-identical. Journal entries, reconciliation breaks, and the financial record explorer are follow-up adopters that reuse the same prop.

## Reason

Phase 6b of `docs/product/web-ui-improvements-implementation-plan-2026-07.md` ("Virtualized dense grids", idea #7). `DenseDataTable` previously soft-capped large sets with `maxVisibleRows`/`rows.slice` + a "show all" button — not real windowing — so very large grids paid full render/DOM cost once expanded.

## Testing performed

- [x] `npm run test` (full dashboard suite) — all green
- [x] `npm run lint` — clean
- [x] `npm run build` (tsc `--noEmit` + vite) — clean
- [x] Relevant unit tests added (`dense-virtualization.test.ts`) and component tests added (`ui-kit-primitives.virtualization.test.tsx`: windowing, End reveal, type-ahead reveal, Escape-back-to-row); the `dense-row-detail-accessibility` contract suite stays green
- [ ] Relevant integration tests were added or updated (n/a — client-only change)
- [ ] GitHub Actions `quality-gate` passed (pending CI)

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ)_