### PR TITLE
Web UI: linked chart crosshair + evidence drill (Phase 6c)

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -4776,6 +4776,10 @@ Meridian-main
 │   │   │   │   │   │   └── TrialBalanceRowDetail.tsx
 │   │   │   │   │   ├── charts
 │   │   │   │   │   │   ├── CandleChart.tsx
+│   │   │   │   │   │   ├── chart-interaction.test.ts
+│   │   │   │   │   │   ├── chart-interaction.tsx
+│   │   │   │   │   │   ├── chart-sync.test.tsx
+│   │   │   │   │   │   ├── chart-sync.tsx
 │   │   │   │   │   │   ├── ChartCard.tsx
 │   │   │   │   │   │   ├── charts.test.tsx
 │   │   │   │   │   │   ├── CorrelationHeatmap.tsx

--- a/docs/product/web-ui-improvements-implementation-plan-2026-07.md
+++ b/docs/product/web-ui-improvements-implementation-plan-2026-07.md
@@ -288,6 +288,20 @@ No feature work; confirm and document the rules each later phase must follow.
   existing `*.linked-context.ts` / `*.evidence-timeline.ts` modules. Scope the context per screen
   — never global.
 
+  **Landed:** `CandleChart` and `EquityCurve` gained optional `onCrosshairChange`/`onPointActivate`
+  props. When either is set they render a transparent, focusable `ChartInteractionOverlay`
+  (`components/charts/chart-interaction.tsx`, pure index-from-pointer + keyboard-step helpers,
+  unit-tested) with slider semantics over the plot area — pointer move/leave, click, and
+  Arrow/Home/End/Enter/Space drive crosshair + activation. `ChartSyncContext`
+  (`components/charts/chart-sync.tsx`) holds hovered/selected state normalized on the **timestamp**,
+  so linked charts with different x-domains stay aligned; `useChartCrosshairSync(timestamps)` maps a
+  chart's indices to/from the shared timestamp (via the pure, tested `nearestTimestampIndex`) and
+  fires `onActivate` for the drill. Scoped per screen via `ChartSyncProvider`. Exemplar wiring: the
+  Portfolio run drill-in equity curve now emits crosshair/activation and renders a per-point
+  evidence readout (date, equity, drawdown) driven by the shared selected timestamp — ready for a
+  second linked chart in the same provider. The props are absent for every other chart usage, so
+  existing charts are unchanged (overlay only renders when a callback is supplied).
+
 ### 6d. Pop-out companion panes (#9)
 - Every route currently renders inside masthead + shell chrome in `app.tsx` — add an early
   chrome-less branch (`/panes/watchlist`, `/panes/live-quotes`) returning a blank layout before
@@ -305,7 +319,7 @@ additionally re-runs the a11y suites (`*-screen.a11y.test.tsx`,
 **Checklist**
 - [x] 6a scope picker + persistence + Portfolio migration.
 - [x] 6b virtualization inside `DenseDataTable` with a11y contract tests green.
-- [ ] 6c chart callback props + `ChartSyncContext` + one evidence-drill screen.
+- [x] 6c chart callback props + `ChartSyncContext` + one evidence-drill screen.
 - [ ] 6d chrome-less pane branch + BroadcastChannel bridge + popup fallback link.
 
 ---

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,7 +5,7 @@
 
 ## Overall Coverage
 
-**2634 / 7322** items documented (**36.0%**) &mdash; Grade: **F**
+**2634 / 7324** items documented (**36.0%**) &mdash; Grade: **F**
 
 ```text
 [=======-------------] 36.0%
@@ -15,7 +15,7 @@
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 2513 | 6826 | 36.8% | F |
+| Public Classes / Interfaces | 2513 | 6828 | 36.8% | F |
 | API Endpoints | 107 | 349 | 30.7% | F |
 | Configuration Options | 3 | 136 | 2.2% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |
@@ -23,7 +23,7 @@
 
 ## Undocumented Items
 
-### Public Classes / Interfaces (4313 undocumented)
+### Public Classes / Interfaces (4315 undocumented)
 
 | Item | Location |
 | ------ | ---------- |
@@ -77,7 +77,7 @@
 | `SecurityMasterActiveImportStatus` | `src/Meridian.Application/SecurityMaster/SecurityMasterIngestStatusService.cs:13` |
 | `SecurityMasterCompletedImportStatus` | `src/Meridian.Application/SecurityMaster/SecurityMasterIngestStatusService.cs:26` |
 | `ISecurityMasterIngestStatusService` | `src/Meridian.Application/SecurityMaster/SecurityMasterIngestStatusService.cs:41` |
-| ... and 4263 more | |
+| ... and 4265 more | |
 
 ### API Endpoints (242 undocumented)
 
@@ -193,7 +193,7 @@
 
 ## Recommendations
 
-1. **Public Classes / Interfaces**: 4313 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
+1. **Public Classes / Interfaces**: 4315 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
 2. **API Endpoints**: 242 endpoint(s) missing from `docs/reference/api-reference.md`. Run the endpoint audit and update the API reference table.
 3. **Configuration Options**: 133 config key(s) not found in `docs/generated/configuration-schema.md`. Re-run the configuration schema generator to synchronise.
 

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,11 +1,11 @@
 {
   "total_files": 538,
-  "total_lines": 88626,
+  "total_lines": 88670,
   "orphaned_count": 205,
   "no_heading_count": 38,
   "stale_count": 0,
   "todo_count": 200,
-  "average_lines": 164.7,
+  "average_lines": 164.8,
   "health_score": 83,
   "orphaned_files": [
     ".agents/skills/meridian-archive-organizer/SKILL.md",
@@ -2138,7 +2138,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7790,
+      "line_count": 7794,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -3106,7 +3106,7 @@
     },
     {
       "path": "docs/product/web-ui-improvements-implementation-plan-2026-07.md",
-      "line_count": 322,
+      "line_count": 336,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -3602,7 +3602,7 @@
     },
     {
       "path": "docs/source/generated/source-roadmap-traceability.md",
-      "line_count": 125,
+      "line_count": 136,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -4122,7 +4122,7 @@
     },
     {
       "path": "src/Meridian.Contracts/README.md",
-      "line_count": 1335,
+      "line_count": 1338,
       "has_heading": true,
       "todo_count": 3,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -4186,7 +4186,7 @@
     },
     {
       "path": "src/Meridian.FinancialOperations/README.md",
-      "line_count": 524,
+      "line_count": 526,
       "has_heading": true,
       "todo_count": 1,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -4250,7 +4250,7 @@
     },
     {
       "path": "src/Meridian.Instruments/README.md",
-      "line_count": 114,
+      "line_count": 118,
       "has_heading": true,
       "todo_count": 1,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -4354,7 +4354,7 @@
     },
     {
       "path": "src/Meridian.Ui.Shared/README.md",
-      "line_count": 1832,
+      "line_count": 1835,
       "has_heading": true,
       "todo_count": 3,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -4362,7 +4362,7 @@
     },
     {
       "path": "src/Meridian.Ui/dashboard/README.md",
-      "line_count": 1213,
+      "line_count": 1216,
       "has_heading": true,
       "todo_count": 4,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,8 +20,8 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 538 |
-| Total lines | 88,626 |
-| Average file size (lines) | 164.7 |
+| Total lines | 88,670 |
+| Average file size (lines) | 164.8 |
 | Orphaned files | 205 |
 | Files without headings | 38 |
 | Stale files (>90 days) | 0 |

--- a/src/Meridian.Ui/dashboard/src/components/charts/CandleChart.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/charts/CandleChart.tsx
@@ -2,6 +2,7 @@
 // readout with a right-axis price chip, and an optional volume histogram subpane. Up candles use
 // --chart-equity (green, hollow body); down use --chart-drawdown (red, filled). SVG, flex-fills
 // its container — give the wrapper a definite height (see ChartCard).
+import { ChartInteractionOverlay } from "./chart-interaction";
 import { niceTicks } from "./ticks";
 
 export interface Candle {
@@ -29,6 +30,13 @@ export interface CandleChartProps {
   overlays?: CandleOverlay[];
   /** Bar index to mark with the crosshair + price chip. */
   crosshairIndex?: number | null;
+  /**
+   * Emit the hovered/keyboard-focused bar index (null on leave). Providing this
+   * (or `onPointActivate`) enables an interactive overlay over the plot area.
+   */
+  onCrosshairChange?: (index: number | null) => void;
+  /** Emit the activated bar index (click, Enter, or Space). */
+  onPointActivate?: (index: number) => void;
   /** Show the volume histogram subpane. @default true */
   showVolume?: boolean;
   /** Approx. number of price gridlines. @default 6 */
@@ -54,6 +62,8 @@ export function CandleChart({
   bars,
   overlays = DEFAULT_OVERLAYS,
   crosshairIndex = null,
+  onCrosshairChange,
+  onPointActivate,
   showVolume = true,
   priceTicks = 6,
   timeTicks = 7
@@ -209,6 +219,19 @@ export function CandleChart({
           </text>
         </g>
       )}
+
+      {/* interaction overlay (crosshair + activation) */}
+      <ChartInteractionOverlay
+        x={plotL}
+        y={priceT}
+        width={plotR - plotL}
+        height={volB - priceT}
+        count={bars.length}
+        crosshairIndex={crosshairIndex}
+        onCrosshairChange={onCrosshairChange}
+        onPointActivate={onPointActivate}
+        ariaLabel="Move crosshair across price bars; activate to drill into the selected bar"
+      />
     </svg>
   );
 }

--- a/src/Meridian.Ui/dashboard/src/components/charts/EquityCurve.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/charts/EquityCurve.tsx
@@ -1,6 +1,7 @@
 // Meridian equity curve — line (with area fill) + benchmark overlay, value-axis labels,
 // gridlines, legend, crosshair readout, and an optional drawdown subpane. Mirrors the
 // performance charts in analytics / backtest reporting. Flex-fills its container.
+import { ChartInteractionOverlay } from "./chart-interaction";
 import { niceTicks } from "./ticks";
 
 export interface EquitySeries {
@@ -25,6 +26,13 @@ export interface EquityCurveProps {
   valueFmt?: (v: number) => string;
   /** Point index to mark with the crosshair. */
   crosshairIndex?: number | null;
+  /**
+   * Emit the hovered/keyboard-focused point index (null on leave). Providing this
+   * (or `onPointActivate`) enables an interactive overlay over the plot area.
+   */
+  onCrosshairChange?: (index: number | null) => void;
+  /** Emit the activated point index (click, Enter, or Space). */
+  onPointActivate?: (index: number) => void;
   /** Approx. number of value gridlines. @default 6 */
   valueTicks?: number;
   /** Approx. number of time labels. @default 7 */
@@ -48,6 +56,8 @@ export function EquityCurve({
   drawdown = null,
   valueFmt = (v) => v.toFixed(0),
   crosshairIndex = null,
+  onCrosshairChange,
+  onPointActivate,
   valueTicks = 6,
   timeTicks = 7,
   showLegend = true,
@@ -215,6 +225,19 @@ export function EquityCurve({
             </text>
           </g>
         )}
+
+        {/* interaction overlay (crosshair + activation) */}
+        <ChartInteractionOverlay
+          x={plotL}
+          y={eqT}
+          width={plotR - plotL}
+          height={ddB - eqT}
+          count={n}
+          crosshairIndex={crosshairIndex}
+          onCrosshairChange={onCrosshairChange}
+          onPointActivate={onPointActivate}
+          ariaLabel="Move crosshair across equity points; activate to drill into the selected point"
+        />
       </svg>
     </div>
   );

--- a/src/Meridian.Ui/dashboard/src/components/charts/chart-interaction.test.ts
+++ b/src/Meridian.Ui/dashboard/src/components/charts/chart-interaction.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { indexFromPointerX, stepCrosshairIndex } from "@/components/charts/chart-interaction";
+
+describe("indexFromPointerX", () => {
+  it("returns null for empty data or zero-width overlays", () => {
+    expect(indexFromPointerX(10, 0, 100, 0)).toBeNull();
+    expect(indexFromPointerX(10, 0, 0, 5)).toBeNull();
+  });
+
+  it("maps the left and right edges to the first and last index", () => {
+    expect(indexFromPointerX(0, 0, 100, 5)).toBe(0);
+    expect(indexFromPointerX(100, 0, 100, 5)).toBe(4);
+  });
+
+  it("maps the midpoint to the middle index and clamps beyond the edges", () => {
+    expect(indexFromPointerX(50, 0, 100, 5)).toBe(2);
+    expect(indexFromPointerX(-40, 0, 100, 5)).toBe(0);
+    expect(indexFromPointerX(400, 0, 100, 5)).toBe(4);
+  });
+
+  it("accounts for the overlay's left offset", () => {
+    expect(indexFromPointerX(120, 20, 200, 5)).toBe(2); // (120-20)/200 = 0.5 -> index 2
+  });
+});
+
+describe("stepCrosshairIndex", () => {
+  it("starts at the near edge for the pressed direction when no index is set", () => {
+    expect(stepCrosshairIndex(null, "ArrowRight", 5)).toBe(0);
+    expect(stepCrosshairIndex(null, "ArrowLeft", 5)).toBe(4);
+  });
+
+  it("steps and clamps within bounds", () => {
+    expect(stepCrosshairIndex(2, "ArrowRight", 5)).toBe(3);
+    expect(stepCrosshairIndex(4, "ArrowRight", 5)).toBe(4);
+    expect(stepCrosshairIndex(2, "ArrowLeft", 5)).toBe(1);
+    expect(stepCrosshairIndex(0, "ArrowLeft", 5)).toBe(0);
+  });
+
+  it("jumps to the ends and ignores non-navigation keys", () => {
+    expect(stepCrosshairIndex(2, "Home", 5)).toBe(0);
+    expect(stepCrosshairIndex(2, "End", 5)).toBe(4);
+    expect(stepCrosshairIndex(2, "a", 5)).toBeNull();
+    expect(stepCrosshairIndex(2, "ArrowRight", 0)).toBeNull();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/charts/chart-interaction.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/charts/chart-interaction.tsx
@@ -1,0 +1,132 @@
+// Shared interaction layer for Meridian's stateless SVG charts. The charts render
+// under `preserveAspectRatio="none"`, so horizontal screen space maps linearly to
+// the point index — a transparent overlay rect can translate pointer/keyboard
+// input into a bar/point index and emit crosshair + activation events, without the
+// chart itself owning any state.
+import type { KeyboardEvent, PointerEvent as ReactPointerEvent, MouseEvent as ReactMouseEvent } from "react";
+
+/**
+ * Map a pointer's client X to the nearest point index. Linear because the charts
+ * stretch to fill their container (`preserveAspectRatio="none"`), so the overlay's
+ * client width covers exactly the plotted index range.
+ */
+export function indexFromPointerX(clientX: number, rectLeft: number, rectWidth: number, count: number): number | null {
+  if (count <= 0 || rectWidth <= 0) return null;
+  const fraction = (clientX - rectLeft) / rectWidth;
+  const clamped = Math.min(1, Math.max(0, fraction));
+  return Math.round(clamped * (count - 1));
+}
+
+/**
+ * Resolve the next crosshair index for a keyboard event, or null when the key is
+ * not a navigation key. A null current index starts at the near edge for the
+ * pressed direction.
+ */
+export function stepCrosshairIndex(current: number | null, key: string, count: number): number | null {
+  if (count <= 0) return null;
+  switch (key) {
+    case "ArrowRight":
+      return current == null ? 0 : Math.min(count - 1, current + 1);
+    case "ArrowLeft":
+      return current == null ? count - 1 : Math.max(0, current - 1);
+    case "Home":
+      return 0;
+    case "End":
+      return count - 1;
+    default:
+      return null;
+  }
+}
+
+export interface ChartInteractionOverlayProps {
+  /** Plot-area geometry in SVG user units. */
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  /** Number of plotted points/bars. */
+  count: number;
+  /** Current crosshair index (for keyboard stepping + slider value). */
+  crosshairIndex: number | null;
+  onCrosshairChange?: (index: number | null) => void;
+  onPointActivate?: (index: number) => void;
+  ariaLabel: string;
+}
+
+/**
+ * Transparent, focusable overlay that turns pointer and keyboard input over a
+ * chart's plot area into crosshair-move and point-activate events. Rendered last
+ * (on top) so it captures events; its fill is transparent so chart visuals show
+ * through. Exposes slider semantics keyed to the point index.
+ */
+export function ChartInteractionOverlay({
+  x,
+  y,
+  width,
+  height,
+  count,
+  crosshairIndex,
+  onCrosshairChange,
+  onPointActivate,
+  ariaLabel
+}: ChartInteractionOverlayProps) {
+  if (count <= 0 || (!onCrosshairChange && !onPointActivate)) {
+    return null;
+  }
+
+  const indexFromEvent = (event: ReactPointerEvent<SVGRectElement> | ReactMouseEvent<SVGRectElement>): number | null => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    return indexFromPointerX(event.clientX, rect.left, rect.width, count);
+  };
+
+  const handlePointerMove = (event: ReactPointerEvent<SVGRectElement>) => {
+    if (!onCrosshairChange) return;
+    const index = indexFromEvent(event);
+    if (index != null) {
+      onCrosshairChange(index);
+    }
+  };
+
+  const handleClick = (event: ReactMouseEvent<SVGRectElement>) => {
+    const index = indexFromEvent(event);
+    if (index == null) return;
+    onCrosshairChange?.(index);
+    onPointActivate?.(index);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<SVGRectElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      if (crosshairIndex != null) {
+        event.preventDefault();
+        onPointActivate?.(crosshairIndex);
+      }
+      return;
+    }
+    const next = stepCrosshairIndex(crosshairIndex, event.key, count);
+    if (next != null) {
+      event.preventDefault();
+      onCrosshairChange?.(next);
+    }
+  };
+
+  return (
+    <rect
+      x={x}
+      y={y}
+      width={width}
+      height={height}
+      fill="transparent"
+      style={{ cursor: "crosshair", outline: "none" }}
+      tabIndex={0}
+      role="slider"
+      aria-label={ariaLabel}
+      aria-valuemin={0}
+      aria-valuemax={Math.max(0, count - 1)}
+      aria-valuenow={crosshairIndex ?? undefined}
+      onPointerMove={handlePointerMove}
+      onPointerLeave={() => onCrosshairChange?.(null)}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+    />
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/charts/chart-sync.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/charts/chart-sync.test.tsx
@@ -1,0 +1,97 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import { EquityCurve } from "@/components/charts/EquityCurve";
+import {
+  ChartSyncProvider,
+  nearestTimestampIndex,
+  useChartCrosshairSync,
+  useChartSync
+} from "@/components/charts/chart-sync";
+
+describe("nearestTimestampIndex", () => {
+  it("returns null when there is no target or no timestamps", () => {
+    expect(nearestTimestampIndex([0, 1, 2], null)).toBeNull();
+    expect(nearestTimestampIndex([], 5)).toBeNull();
+  });
+
+  it("returns the index of the closest timestamp, preferring the earlier one on ties", () => {
+    expect(nearestTimestampIndex([0, 100, 200, 300], 190)).toBe(2);
+    expect(nearestTimestampIndex([50, 150, 250], 200)).toBe(1); // 150 and 250 both 50 away -> first
+  });
+});
+
+function BoundEquityCurve({ timestamps, points }: { timestamps: number[]; points: number[] }) {
+  const sync = useChartCrosshairSync(timestamps);
+  return (
+    <EquityCurve
+      series={[{ label: "Equity", color: "var(--chart-equity)", points }]}
+      crosshairIndex={sync.crosshairIndex}
+      onCrosshairChange={sync.onCrosshairChange}
+      onPointActivate={sync.onPointActivate}
+      showLegend={false}
+    />
+  );
+}
+
+function SelectedReadout() {
+  const { selectedTimestamp } = useChartSync();
+  return <div data-testid="selected">{selectedTimestamp ?? "none"}</div>;
+}
+
+describe("chart crosshair synchronization", () => {
+  afterEach(() => cleanup());
+
+  it("mirrors a crosshair across linked charts with different x-domains", async () => {
+    const user = userEvent.setup();
+    render(
+      <ChartSyncProvider>
+        <BoundEquityCurve timestamps={[0, 100, 200, 300]} points={[1, 2, 3, 4]} />
+        <BoundEquityCurve timestamps={[50, 150, 250]} points={[9, 8, 7]} />
+      </ChartSyncProvider>
+    );
+
+    const [chartA, chartB] = screen.getAllByRole("slider");
+    chartA.focus();
+    await user.keyboard("{ArrowRight}{ArrowRight}{ArrowRight}"); // move chart A to index 2 (ts 200)
+
+    // Chart A sits on its own index 2; chart B resolves the shared ts 200 to its nearest point (150 -> index 1).
+    expect(chartA).toHaveAttribute("aria-valuenow", "2");
+    expect(chartB).toHaveAttribute("aria-valuenow", "1");
+  });
+
+  it("activating a point publishes the selected timestamp for the evidence drill", async () => {
+    const user = userEvent.setup();
+    render(
+      <ChartSyncProvider>
+        <BoundEquityCurve timestamps={[0, 100, 200, 300]} points={[1, 2, 3, 4]} />
+        <SelectedReadout />
+      </ChartSyncProvider>
+    );
+
+    expect(screen.getByTestId("selected")).toHaveTextContent("none");
+
+    const slider = screen.getByRole("slider");
+    slider.focus();
+    await user.keyboard("{ArrowRight}{Enter}"); // crosshair to index 0 (ts 0), then activate
+
+    expect(screen.getByTestId("selected")).toHaveTextContent("0");
+  });
+
+  it("activates the point under a pointer click", () => {
+    render(
+      <ChartSyncProvider>
+        <BoundEquityCurve timestamps={[0, 100, 200, 300]} points={[1, 2, 3, 4]} />
+        <SelectedReadout />
+      </ChartSyncProvider>
+    );
+
+    const slider = screen.getByRole("slider");
+    slider.getBoundingClientRect = () =>
+      ({ left: 0, width: 300, top: 0, height: 100, right: 300, bottom: 100, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect;
+
+    fireEvent.click(slider, { clientX: 300 }); // right edge -> last index (3) -> ts 300
+
+    expect(screen.getByTestId("selected")).toHaveTextContent("300");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/charts/chart-sync.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/charts/chart-sync.test.tsx
@@ -19,6 +19,13 @@ describe("nearestTimestampIndex", () => {
     expect(nearestTimestampIndex([0, 100, 200, 300], 190)).toBe(2);
     expect(nearestTimestampIndex([50, 150, 250], 200)).toBe(1); // 150 and 250 both 50 away -> first
   });
+
+  it("clamps to the ends and hits exact matches", () => {
+    expect(nearestTimestampIndex([10, 20, 30], 5)).toBe(0); // before first
+    expect(nearestTimestampIndex([10, 20, 30], 100)).toBe(2); // after last
+    expect(nearestTimestampIndex([10, 20, 30], 20)).toBe(1); // exact
+    expect(nearestTimestampIndex([10, 20, 30, 40, 50], 34)).toBe(2); // closer to 30 than 40
+  });
 });
 
 function BoundEquityCurve({ timestamps, points }: { timestamps: number[]; points: number[] }) {

--- a/src/Meridian.Ui/dashboard/src/components/charts/chart-sync.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/charts/chart-sync.tsx
@@ -1,0 +1,99 @@
+// Per-screen chart synchronization. Charts stay stateless and emit crosshair /
+// activation events; a screen wraps its linked charts in a ChartSyncProvider so a
+// crosshair or selection on one chart is reflected on the others. State is
+// normalized on the TIMESTAMP, not the point index, so charts with different
+// x-domains (e.g. a candle series and an equity curve sampled at different rates)
+// stay aligned. Scope this per screen — never globally.
+import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
+
+export interface ChartSyncState {
+  /** Timestamp (epoch ms) currently hovered across the synced charts, or null. */
+  hoveredTimestamp: number | null;
+  /** Timestamp (epoch ms) of the activated/selected point, or null. */
+  selectedTimestamp: number | null;
+}
+
+export interface ChartSyncApi extends ChartSyncState {
+  setHoveredTimestamp: (timestamp: number | null) => void;
+  setSelectedTimestamp: (timestamp: number | null) => void;
+}
+
+const ChartSyncContext = createContext<ChartSyncApi | null>(null);
+
+export function ChartSyncProvider({ children }: { children: ReactNode }) {
+  const [hoveredTimestamp, setHoveredTimestamp] = useState<number | null>(null);
+  const [selectedTimestamp, setSelectedTimestamp] = useState<number | null>(null);
+  const value = useMemo<ChartSyncApi>(
+    () => ({ hoveredTimestamp, selectedTimestamp, setHoveredTimestamp, setSelectedTimestamp }),
+    [hoveredTimestamp, selectedTimestamp]
+  );
+  return <ChartSyncContext.Provider value={value}>{children}</ChartSyncContext.Provider>;
+}
+
+export function useChartSync(): ChartSyncApi {
+  const context = useContext(ChartSyncContext);
+  if (!context) {
+    throw new Error("useChartSync must be used within a ChartSyncProvider");
+  }
+  return context;
+}
+
+/**
+ * Index of the timestamp closest to `target`, or null when there is no target or
+ * no timestamps. Used to translate the shared (timestamp-based) sync state back
+ * into a per-chart point index.
+ */
+export function nearestTimestampIndex(timestamps: number[], target: number | null): number | null {
+  if (target == null || timestamps.length === 0) {
+    return null;
+  }
+  let bestIndex = 0;
+  let bestDistance = Infinity;
+  for (let index = 0; index < timestamps.length; index++) {
+    const distance = Math.abs(timestamps[index] - target);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestIndex = index;
+    }
+  }
+  return bestIndex;
+}
+
+export interface ChartCrosshairSync {
+  /** Crosshair index for this chart, resolved from the shared hovered timestamp. */
+  crosshairIndex: number | null;
+  onCrosshairChange: (index: number | null) => void;
+  onPointActivate: (index: number) => void;
+}
+
+/**
+ * Bind one chart to the shared sync state. `timestamps` maps this chart's point
+ * indices to epoch-ms timestamps; the returned handlers translate index events
+ * into shared-timestamp updates and back, so linked charts track each other even
+ * with mismatched x-domains. `onActivate` fires on point activation for the
+ * screen's evidence drill.
+ */
+export function useChartCrosshairSync(
+  timestamps: number[],
+  options?: { onActivate?: (index: number, timestamp: number) => void }
+): ChartCrosshairSync {
+  const sync = useChartSync();
+  const crosshairIndex = useMemo(
+    () => nearestTimestampIndex(timestamps, sync.hoveredTimestamp),
+    [timestamps, sync.hoveredTimestamp]
+  );
+
+  const onCrosshairChange = (index: number | null) => {
+    sync.setHoveredTimestamp(index == null ? null : timestamps[index] ?? null);
+  };
+
+  const onPointActivate = (index: number) => {
+    const timestamp = timestamps[index] ?? null;
+    sync.setSelectedTimestamp(timestamp);
+    if (timestamp != null) {
+      options?.onActivate?.(index, timestamp);
+    }
+  };
+
+  return { crosshairIndex, onCrosshairChange, onPointActivate };
+}

--- a/src/Meridian.Ui/dashboard/src/components/charts/chart-sync.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/charts/chart-sync.tsx
@@ -4,7 +4,7 @@
 // normalized on the TIMESTAMP, not the point index, so charts with different
 // x-domains (e.g. a candle series and an equity curve sampled at different rates)
 // stay aligned. Scope this per screen — never globally.
-import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
 
 export interface ChartSyncState {
   /** Timestamp (epoch ms) currently hovered across the synced charts, or null. */
@@ -41,22 +41,34 @@ export function useChartSync(): ChartSyncApi {
 /**
  * Index of the timestamp closest to `target`, or null when there is no target or
  * no timestamps. Used to translate the shared (timestamp-based) sync state back
- * into a per-chart point index.
+ * into a per-chart point index. Ties resolve to the earlier index.
+ *
+ * `timestamps` is assumed ascending (chart x-axes are chronological), which lets
+ * this run in O(log N) — it is called per pointer-move frame per synced chart.
  */
 export function nearestTimestampIndex(timestamps: number[], target: number | null): number | null {
   if (target == null || timestamps.length === 0) {
     return null;
   }
-  let bestIndex = 0;
-  let bestDistance = Infinity;
-  for (let index = 0; index < timestamps.length; index++) {
-    const distance = Math.abs(timestamps[index] - target);
-    if (distance < bestDistance) {
-      bestDistance = distance;
-      bestIndex = index;
+  let low = 0;
+  let high = timestamps.length - 1;
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    if (timestamps[mid] === target) {
+      return mid;
+    }
+    if (timestamps[mid] < target) {
+      low = mid + 1;
+    } else {
+      high = mid;
     }
   }
-  return bestIndex;
+  // `low` is the first candidate at or after the target; the earlier neighbour can
+  // be closer (and wins ties).
+  if (low > 0 && Math.abs(timestamps[low - 1] - target) <= Math.abs(timestamps[low] - target)) {
+    return low - 1;
+  }
+  return low;
 }
 
 export interface ChartCrosshairSync {
@@ -77,23 +89,31 @@ export function useChartCrosshairSync(
   timestamps: number[],
   options?: { onActivate?: (index: number, timestamp: number) => void }
 ): ChartCrosshairSync {
-  const sync = useChartSync();
+  const { hoveredTimestamp, setHoveredTimestamp, setSelectedTimestamp } = useChartSync();
+  const onActivate = options?.onActivate;
   const crosshairIndex = useMemo(
-    () => nearestTimestampIndex(timestamps, sync.hoveredTimestamp),
-    [timestamps, sync.hoveredTimestamp]
+    () => nearestTimestampIndex(timestamps, hoveredTimestamp),
+    [timestamps, hoveredTimestamp]
   );
 
-  const onCrosshairChange = (index: number | null) => {
-    sync.setHoveredTimestamp(index == null ? null : timestamps[index] ?? null);
-  };
+  // Stable identities so downstream charts don't re-render on every sync update.
+  const onCrosshairChange = useCallback(
+    (index: number | null) => {
+      setHoveredTimestamp(index == null ? null : timestamps[index] ?? null);
+    },
+    [setHoveredTimestamp, timestamps]
+  );
 
-  const onPointActivate = (index: number) => {
-    const timestamp = timestamps[index] ?? null;
-    sync.setSelectedTimestamp(timestamp);
-    if (timestamp != null) {
-      options?.onActivate?.(index, timestamp);
-    }
-  };
+  const onPointActivate = useCallback(
+    (index: number) => {
+      const timestamp = timestamps[index] ?? null;
+      setSelectedTimestamp(timestamp);
+      if (timestamp != null) {
+        onActivate?.(index, timestamp);
+      }
+    },
+    [setSelectedTimestamp, timestamps, onActivate]
+  );
 
   return { crosshairIndex, onCrosshairChange, onPointActivate };
 }

--- a/src/Meridian.Ui/dashboard/src/components/charts/charts.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/charts/charts.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { CandleChart, type Candle } from "./CandleChart";
 import { EquityCurve } from "./EquityCurve";
 import { DrawdownChart } from "./DrawdownChart";
@@ -31,6 +31,28 @@ describe("CandleChart", () => {
       (t) => t.getAttribute("fill") === "#fff" && t.textContent === "107.00"
     );
     expect(chip).toBeTruthy();
+  });
+
+  it("adds no interaction overlay unless a callback is provided", () => {
+    render(<CandleChart bars={bars} />);
+    expect(screen.queryByRole("slider")).toBeNull();
+  });
+
+  it("emits crosshair and activation events from the interaction overlay", () => {
+    const onCrosshairChange = vi.fn();
+    const onPointActivate = vi.fn();
+    render(
+      <CandleChart bars={bars} crosshairIndex={1} onCrosshairChange={onCrosshairChange} onPointActivate={onPointActivate} />
+    );
+
+    const slider = screen.getByRole("slider");
+    expect(slider).toHaveAttribute("aria-valuemax", String(bars.length - 1));
+
+    fireEvent.keyDown(slider, { key: "ArrowRight" });
+    expect(onCrosshairChange).toHaveBeenCalledWith(2);
+
+    fireEvent.keyDown(slider, { key: "Enter" });
+    expect(onPointActivate).toHaveBeenCalledWith(1);
   });
 });
 

--- a/src/Meridian.Ui/dashboard/src/components/charts/index.ts
+++ b/src/Meridian.Ui/dashboard/src/components/charts/index.ts
@@ -23,3 +23,11 @@ export type { CorrelationHeatmapProps } from "./CorrelationHeatmap";
 
 export { Sparkline } from "./Sparkline";
 export type { SparklineProps } from "./Sparkline";
+
+export {
+  ChartSyncProvider,
+  useChartSync,
+  useChartCrosshairSync,
+  nearestTimestampIndex
+} from "./chart-sync";
+export type { ChartSyncState, ChartSyncApi, ChartCrosshairSync } from "./chart-sync";

--- a/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.tsx
@@ -1,5 +1,5 @@
 import type { KeyboardEvent } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { BriefcaseBusiness, FileCheck2, LineChart, Network, Settings, ShieldCheck, Wallet } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
@@ -18,7 +18,14 @@ import {
 import { DenseDataTable, type DenseDataTableColumn } from "@/components/meridian/ui-kit-primitives";
 import { MetricCard, type MetricCardTone, EmptyState } from "@/components/data/concrete";
 import { SeverityBadge, TrustStrip, type TrustStripItem } from "@/components/operations";
-import { EquityCurve, ChartCard } from "@/components/charts";
+import {
+  EquityCurve,
+  ChartCard,
+  ChartSyncProvider,
+  useChartSync,
+  useChartCrosshairSync,
+  nearestTimestampIndex
+} from "@/components/charts";
 import {
   getFinancialRecordExplorer,
   getRunAttribution,
@@ -1365,9 +1372,21 @@ const metricSnapshotToneClass: Record<MetricSnapshot["tone"], MetricCardTone> = 
   danger: "danger"
 };
 
+const drillInCurrency = (value: number) => `$${Math.round(value).toLocaleString("en-US")}`;
+
 /** Concrete equity + underwater drawdown view for a loaded run drill-in profile. Additive
- * evidence only — rendered when the selected run has a fetched equity/drawdown series. */
-function PortfolioDrillInChart({
+ * evidence only — rendered when the selected run has a fetched equity/drawdown series. The
+ * chart is scoped in its own ChartSyncProvider so crosshair and point activation stay local to
+ * this drill-in (never global) and can drive a per-point evidence readout. */
+function PortfolioDrillInChart(props: { profile: EquityCurveSummary; runTitle: string }) {
+  return (
+    <ChartSyncProvider>
+      <PortfolioDrillInChartInner {...props} />
+    </ChartSyncProvider>
+  );
+}
+
+function PortfolioDrillInChartInner({
   profile,
   runTitle
 }: {
@@ -1378,15 +1397,15 @@ function PortfolioDrillInChart({
   const equity = points.map((point) => point.totalEquity);
   const drawdown = points.map((point) => -Math.abs(point.drawdownFromPeakPercent * 100));
   const labels = points.map((point) => point.date);
-  const currency = (value: number) =>
-    `$${Math.round(value).toLocaleString("en-US")}`;
+  const timestamps = useMemo(() => points.map((point) => Date.parse(point.date)), [points]);
+  const sync = useChartCrosshairSync(timestamps);
 
   return (
     <ChartCard
       title="Run equity and drawdown"
       subtitle={`Source-backed equity curve and underwater drawdown for ${runTitle}.`}
       readout={[
-        { label: "Final equity", value: currency(profile.finalEquity) },
+        { label: "Final equity", value: drillInCurrency(profile.finalEquity) },
         {
           label: "Max drawdown",
           value: `-${(profile.maxDrawdownPercent * 100).toFixed(2)}%`,
@@ -1401,9 +1420,48 @@ function PortfolioDrillInChart({
         series={[{ label: "Equity", color: "var(--chart-equity, #2F6F8F)", points: equity }]}
         drawdown={drawdown}
         labels={labels}
-        valueFmt={currency}
+        valueFmt={drillInCurrency}
+        crosshairIndex={sync.crosshairIndex}
+        onCrosshairChange={sync.onCrosshairChange}
+        onPointActivate={sync.onPointActivate}
       />
+      <PortfolioDrillInPointEvidence profile={profile} timestamps={timestamps} />
     </ChartCard>
+  );
+}
+
+/** Evidence drill: when a chart point is activated, surface that point's source-backed
+ * detail. Reads the selected timestamp from the shared chart-sync context so it stays in
+ * step with the equity curve (and any future linked chart in the same provider). */
+function PortfolioDrillInPointEvidence({
+  profile,
+  timestamps
+}: {
+  profile: EquityCurveSummary;
+  timestamps: number[];
+}) {
+  const { selectedTimestamp } = useChartSync();
+  const selectedIndex = nearestTimestampIndex(timestamps, selectedTimestamp);
+  if (selectedIndex == null) {
+    return null;
+  }
+  const point = profile.points[selectedIndex];
+  if (!point) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="mt-2 rounded-md border border-border/70 bg-secondary/20 px-3 py-2 text-xs"
+    >
+      <span className="font-semibold text-foreground">Selected point — {point.date}</span>
+      <span className="ml-2 text-muted-foreground">
+        Equity {drillInCurrency(point.totalEquity)} · drawdown{" "}
+        {(-Math.abs(point.drawdownFromPeakPercent * 100)).toFixed(2)}%
+      </span>
+    </div>
   );
 }
 


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Makes Meridian's stateless SVG charts emit interaction events and lets a screen **link** them (Phase 6c of the web-UI improvement plan): a crosshair or point activation on one chart flows to the others and into an evidence drill.

- **`CandleChart` & `EquityCurve` gain optional `onCrosshairChange`/`onPointActivate`.** When either is set they render a transparent, focusable `ChartInteractionOverlay` over the plot area with **slider semantics** — pointer move/leave, click, and `Arrow`/`Home`/`End`/`Enter`/`Space` drive crosshair + activation. The overlay renders **only when a callback is supplied**, so every existing chart usage is byte-identical.
- **`components/charts/chart-interaction.tsx`** — pure, unit-tested index-from-pointer and keyboard-step helpers plus the overlay component.
- **`components/charts/chart-sync.tsx`** — a per-screen `ChartSyncProvider`/`useChartSync` and a `useChartCrosshairSync(timestamps)` hook. State is normalized on the **timestamp** (not the point index) via the pure `nearestTimestampIndex`, so linked charts with **different x-domains** stay aligned. Scoped per screen — never global.
- **Exemplar wiring:** the Portfolio run drill-in equity curve now emits crosshair/activation and renders a per-point **evidence readout** (date, equity, drawdown) driven by the shared selected timestamp — ready for a second linked chart in the same provider.

## Reason

Phase 6c of `docs/product/web-ui-improvements-implementation-plan-2026-07.md` ("Linked chart crosshair + evidence drill", idea #8). The charts were previously one-way (`crosshairIndex` flowed in, nothing flowed out), so hovering/activating a chart point couldn't sync across charts or surface point-level evidence.

## Testing performed

- [x] `npm run test` (full dashboard suite) — all green
- [x] `npm run lint` — clean (no new issues)
- [x] `npm run build` (tsc `--noEmit` + vite) — clean
- [x] Relevant unit/component tests added: `chart-interaction.test.ts` (pointer/keyboard helpers), `chart-sync.test.tsx` (`nearestTimestampIndex`, cross-domain crosshair linking, activation→selected drill, pointer-click activation), and a `CandleChart` overlay test in `charts.test.tsx`
- [ ] Relevant integration tests were added or updated (n/a — client-only change)
- [ ] GitHub Actions `quality-gate` passed (pending CI)

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ)_