### PR TITLE
Web UI: pop-out companion panes (Phase 6d)

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -4822,6 +4822,8 @@ Meridian-main
 │   │   │   │   │   │   ├── command-palette.tsx
 │   │   │   │   │   │   ├── command-palette.view-model.test.ts
 │   │   │   │   │   │   ├── command-palette.view-model.ts
+│   │   │   │   │   │   ├── companion-pane-window.test.tsx
+│   │   │   │   │   │   ├── companion-pane-window.tsx
 │   │   │   │   │   │   ├── copy-link-button.test.tsx
 │   │   │   │   │   │   ├── copy-link-button.tsx
 │   │   │   │   │   │   ├── coverage-passport-drill-in.test.tsx
@@ -4846,6 +4848,8 @@ Meridian-main
 │   │   │   │   │   │   ├── notification-center.tsx
 │   │   │   │   │   │   ├── number-passport.test.ts
 │   │   │   │   │   │   ├── number-passport.tsx
+│   │   │   │   │   │   ├── pop-out-pane-button.test.tsx
+│   │   │   │   │   │   ├── pop-out-pane-button.tsx
 │   │   │   │   │   │   ├── quant-notebook.test.tsx
 │   │   │   │   │   │   ├── quant-notebook.tsx
 │   │   │   │   │   │   ├── quant-notebook.view-model.test.ts
@@ -5001,6 +5005,12 @@ Meridian-main
 │   │   │   │   │   │   ├── covered-call.api.ts
 │   │   │   │   │   │   ├── security-master-workbench.api.test.ts
 │   │   │   │   │   │   └── security-master-workbench.api.ts
+│   │   │   │   │   ├── companion-pane
+│   │   │   │   │   │   ├── chrome-bridge.test.ts
+│   │   │   │   │   │   ├── chrome-bridge.ts
+│   │   │   │   │   │   ├── opener-broadcast.ts
+│   │   │   │   │   │   ├── pane-window.test.ts
+│   │   │   │   │   │   └── pane-window.ts
 │   │   │   │   │   ├── covered-call
 │   │   │   │   │   │   ├── index.ts
 │   │   │   │   │   │   ├── payoff.test.ts
@@ -5235,6 +5245,7 @@ Meridian-main
 │   │   │   │   │   ├── accounting-screen.css
 │   │   │   │   │   ├── app-shell.css
 │   │   │   │   │   ├── command-palette.css
+│   │   │   │   │   ├── companion-pane.css
 │   │   │   │   │   ├── dense-row-detail-accessibility.css
 │   │   │   │   │   ├── index.css
 │   │   │   │   │   ├── ui-kit-primitives.css

--- a/docs/product/web-ui-improvements-implementation-plan-2026-07.md
+++ b/docs/product/web-ui-improvements-implementation-plan-2026-07.md
@@ -312,6 +312,21 @@ No feature work; confirm and document the rules each later phase must follow.
   visible fallback link (`target="_blank" rel="noopener noreferrer"`). Pane components must be
   shell-independent; session expiry propagates over the channel.
 
+  **Landed:** `app.tsx` now branches at the top (`AppRoot`) — `/panes/*` renders `CompanionPaneWindow`
+  instead of `AppShell`, so a pane carries no masthead, navigation, or workstation data loading.
+  `lib/companion-pane/pane-window.ts` holds the pure pane registry/route helpers and
+  `openCompanionPane` (opens with `noopener,noreferrer` and never inspects the return value).
+  `lib/companion-pane/chrome-bridge.ts` is the same-origin `BroadcastChannel` bridge with a validated
+  message contract (`appearance` | `scope` | `session-expired`) and an injectable channel for tests;
+  `opener-broadcast.ts` is the main-window side (lazy shared channel, no-op when unavailable). The
+  main window broadcasts appearance changes (from the theme toggle) and a `session-expired` signal on
+  `pagehide`; `CompanionPaneWindow` applies the persisted appearance on load, retheme's live, and
+  shows a "main window no longer available" alert on session end. `PopOutPaneButton` renders a
+  `window.open` button **plus** an always-visible fallback link. Exemplar adopter: the watchlist
+  workspace header (pop-out hidden when already inside a pane). `scope` is carried in the bridge
+  contract (validated + tested) and reserved for scope-aware panes; fanned-out stream data over the
+  channel remains the documented Phase 4 follow-up (the exemplar panes still open their own feeds).
+
 **Validation for all of Phase 6:** `npm --prefix src/Meridian.Ui/dashboard run test`; grid work
 additionally re-runs the a11y suites (`*-screen.a11y.test.tsx`,
 `dense-row-detail-accessibility.test.tsx`).
@@ -320,7 +335,7 @@ additionally re-runs the a11y suites (`*-screen.a11y.test.tsx`,
 - [x] 6a scope picker + persistence + Portfolio migration.
 - [x] 6b virtualization inside `DenseDataTable` with a11y contract tests green.
 - [x] 6c chart callback props + `ChartSyncContext` + one evidence-drill screen.
-- [ ] 6d chrome-less pane branch + BroadcastChannel bridge + popup fallback link.
+- [x] 6d chrome-less pane branch + BroadcastChannel bridge + popup fallback link.
 
 ---
 

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,11 +1,11 @@
 {
   "total_files": 538,
-  "total_lines": 88670,
+  "total_lines": 88696,
   "orphaned_count": 205,
   "no_heading_count": 38,
   "stale_count": 0,
   "todo_count": 200,
-  "average_lines": 164.8,
+  "average_lines": 164.9,
   "health_score": 83,
   "orphaned_files": [
     ".agents/skills/meridian-archive-organizer/SKILL.md",
@@ -2138,7 +2138,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7794,
+      "line_count": 7805,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -3106,7 +3106,7 @@
     },
     {
       "path": "docs/product/web-ui-improvements-implementation-plan-2026-07.md",
-      "line_count": 336,
+      "line_count": 351,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,8 +20,8 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 538 |
-| Total lines | 88,670 |
-| Average file size (lines) | 164.8 |
+| Total lines | 88,696 |
+| Average file size (lines) | 164.9 |
 | Orphaned files | 205 |
 | Files without headings | 38 |
 | Stale files (>90 days) | 0 |

--- a/src/Meridian.Ui/dashboard/src/app.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.tsx
@@ -29,6 +29,9 @@ import { ScopePicker } from "@/components/meridian/scope-picker";
 import { collectScopeFundAccounts } from "@/lib/operating-scope/fund-accounts";
 import { WorkflowContinuityDock } from "@/components/meridian/workflow-continuity-dock";
 import { WorkspaceHeader } from "@/components/meridian/workspace-header";
+import { CompanionPaneWindow } from "@/components/meridian/companion-pane-window";
+import { isCompanionPaneRoute } from "@/lib/companion-pane/pane-window";
+import { broadcastCompanionState } from "@/lib/companion-pane/opener-broadcast";
 import { WorkspaceNav } from "@/components/meridian/workspace-nav";
 import { Skeleton } from "@/components/data/skeleton";
 import { Badge } from "@/components/ui/badge";
@@ -100,10 +103,23 @@ export function App() {
   return (
     <PriceAlertsProvider>
       <ToastProvider>
-        <AppShell />
+        <AppRoot />
       </ToastProvider>
     </PriceAlertsProvider>
   );
+}
+
+/**
+ * Chrome-less companion panes (`/panes/*`) render before — and instead of — the
+ * full workstation shell, so a pop-out window carries no masthead, navigation, or
+ * workstation data loading. Everything else renders the shell.
+ */
+function AppRoot() {
+  const { pathname } = useLocation();
+  if (isCompanionPaneRoute(pathname)) {
+    return <CompanionPaneWindow />;
+  }
+  return <AppShell />;
 }
 
 function AppShell() {
@@ -280,6 +296,14 @@ function AppShell() {
     window.addEventListener("keydown", handleCommandShortcut);
     return () => window.removeEventListener("keydown", handleCommandShortcut);
   }, [commandOpen, setCommandOpen]);
+
+  // Tell any open companion panes when the main workstation window goes away, so
+  // they can surface that their source is gone rather than silently going stale.
+  useEffect(() => {
+    const handlePageHide = () => broadcastCompanionState({ type: "session-expired" });
+    window.addEventListener("pagehide", handlePageHide);
+    return () => window.removeEventListener("pagehide", handlePageHide);
+  }, []);
 
   const shell = useMemo(() => buildAppShellViewState({
     pathname,

--- a/src/Meridian.Ui/dashboard/src/components/meridian/companion-pane-window.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/companion-pane-window.test.tsx
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { APPEARANCE_STORAGE_KEY } from "@/lib/theme";
+import type { BroadcastChannelLike } from "@/lib/companion-pane/chrome-bridge";
+import { CompanionPaneWindow } from "@/components/meridian/companion-pane-window";
+
+vi.mock("@/screens/watchlist-screen", () => ({
+  WatchlistScreen: () => <div data-testid="watchlist-screen">watchlist</div>
+}));
+vi.mock("@/screens/live-quotes-screen", () => ({
+  LiveQuotesScreen: () => <div data-testid="live-quotes-screen">live quotes</div>
+}));
+
+class FakeChannel implements BroadcastChannelLike {
+  private listeners = new Set<(event: MessageEvent) => void>();
+  postMessage() {}
+  addEventListener(_type: "message", listener: (event: MessageEvent) => void) {
+    this.listeners.add(listener);
+  }
+  removeEventListener(_type: "message", listener: (event: MessageEvent) => void) {
+    this.listeners.delete(listener);
+  }
+  close() {}
+  emit(data: unknown) {
+    this.listeners.forEach((listener) => listener({ data } as MessageEvent));
+  }
+}
+
+function renderPane(path: string, channel: FakeChannel) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <CompanionPaneWindow openChannel={() => channel} />
+    </MemoryRouter>
+  );
+}
+
+describe("CompanionPaneWindow", () => {
+  afterEach(() => {
+    cleanup();
+    window.localStorage.clear();
+  });
+
+  it("renders the resolved pane surface chrome-less", async () => {
+    renderPane("/panes/watchlist", new FakeChannel());
+    expect(screen.getByRole("main", { name: "Watchlist companion pane" })).toBeInTheDocument();
+    expect(await screen.findByTestId("watchlist-screen")).toBeInTheDocument();
+    // chrome-less: none of the shell's workspace navigation is rendered
+    expect(screen.queryByRole("navigation")).toBeNull();
+  });
+
+  it("shows a message for an unknown pane", () => {
+    renderPane("/panes/does-not-exist", new FakeChannel());
+    expect(screen.getByText(/not available/i)).toBeInTheDocument();
+  });
+
+  it("applies a live appearance change broadcast from the main window", () => {
+    const channel = new FakeChannel();
+    renderPane("/panes/watchlist", channel);
+
+    channel.emit({ type: "appearance", appearance: "dark" });
+    expect(window.localStorage.getItem(APPEARANCE_STORAGE_KEY)).toBe("dark");
+  });
+
+  it("surfaces a session-ended alert when the main window goes away", async () => {
+    const channel = new FakeChannel();
+    renderPane("/panes/watchlist", channel);
+    expect(screen.queryByRole("alert")).toBeNull();
+
+    channel.emit({ type: "session-expired" });
+    expect(await screen.findByRole("alert")).toHaveTextContent(/no longer available/i);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/meridian/companion-pane-window.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/companion-pane-window.tsx
@@ -66,7 +66,10 @@ export function CompanionPaneWindow({ openChannel = openCompanionChannel }: Comp
     };
   }, [openChannel]);
 
-  if (!pane) {
+  // Unknown route, or a pane registered without a mapped component — fail gracefully
+  // rather than rendering an undefined component (which would crash React).
+  const PaneComponent = pane ? PANE_COMPONENTS[pane.id] : undefined;
+  if (!pane || !PaneComponent) {
     return (
       <div className="companion-pane" role="main" aria-label="Unknown companion pane">
         <div className="companion-pane-empty">
@@ -75,8 +78,6 @@ export function CompanionPaneWindow({ openChannel = openCompanionChannel }: Comp
       </div>
     );
   }
-
-  const PaneComponent = PANE_COMPONENTS[pane.id];
 
   return (
     <div className="companion-pane" role="main" aria-label={pane.description}>

--- a/src/Meridian.Ui/dashboard/src/components/meridian/companion-pane-window.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/companion-pane-window.tsx
@@ -1,0 +1,99 @@
+import { Suspense, lazy, useEffect, useState, type ComponentType } from "react";
+import { useLocation } from "react-router-dom";
+import { applyAppearance, readStoredAppearance, writeStoredAppearance } from "@/lib/theme";
+import {
+  createCompanionBridge,
+  openCompanionChannel,
+  type BroadcastChannelLike
+} from "@/lib/companion-pane/chrome-bridge";
+import { resolveCompanionPane } from "@/lib/companion-pane/pane-window";
+import "@/styles/companion-pane.css";
+
+const WatchlistScreen = lazy(() =>
+  import("@/screens/watchlist-screen").then((module) => ({ default: module.WatchlistScreen }))
+);
+const LiveQuotesScreen = lazy(() =>
+  import("@/screens/live-quotes-screen").then((module) => ({ default: module.LiveQuotesScreen }))
+);
+
+const PANE_COMPONENTS: Record<string, ComponentType> = {
+  watchlist: WatchlistScreen,
+  "live-quotes": LiveQuotesScreen
+};
+
+export interface CompanionPaneWindowProps {
+  /** Injectable channel opener for tests. */
+  openChannel?: (name?: string) => BroadcastChannelLike | null;
+}
+
+/**
+ * Chrome-less host for a companion pane. Rendered instead of the full app shell
+ * for `/panes/*` routes: no masthead, no navigation, no workstation data
+ * loading — just the pane surface. Applies the persisted appearance on load and
+ * subscribes to the companion bridge so a theme change or session end in the main
+ * window propagates here live.
+ */
+export function CompanionPaneWindow({ openChannel = openCompanionChannel }: CompanionPaneWindowProps = {}) {
+  const { pathname } = useLocation();
+  const pane = resolveCompanionPane(pathname);
+  const [sessionEnded, setSessionEnded] = useState(false);
+
+  // Same-origin localStorage already holds the chosen appearance; apply it so the
+  // pane opens in the same theme as the main window.
+  useEffect(() => {
+    applyAppearance(readStoredAppearance());
+  }, []);
+
+  useEffect(() => {
+    const channel = openChannel();
+    if (!channel) {
+      return;
+    }
+    const bridge = createCompanionBridge(channel);
+    const unsubscribe = bridge.subscribe((message) => {
+      if (message.type === "appearance") {
+        writeStoredAppearance(message.appearance);
+        applyAppearance(message.appearance);
+      } else if (message.type === "session-expired") {
+        setSessionEnded(true);
+      }
+      // `scope` messages are reserved for scope-aware panes; the exemplar panes
+      // (watchlist, live quotes) do not filter by operating scope.
+    });
+    return () => {
+      unsubscribe();
+      bridge.close();
+    };
+  }, [openChannel]);
+
+  if (!pane) {
+    return (
+      <div className="companion-pane" role="main" aria-label="Unknown companion pane">
+        <div className="companion-pane-empty">
+          This companion pane is not available. Open it from the main workstation window.
+        </div>
+      </div>
+    );
+  }
+
+  const PaneComponent = PANE_COMPONENTS[pane.id];
+
+  return (
+    <div className="companion-pane" role="main" aria-label={pane.description}>
+      <header className="companion-pane-header">
+        <span className="companion-pane-title">{pane.title}</span>
+        <span className="companion-pane-badge">Companion pane</span>
+      </header>
+      {sessionEnded ? (
+        <div role="alert" className="companion-pane-session-ended">
+          The main workstation window is no longer available. Reopen this pane from the workstation.
+        </div>
+      ) : null}
+      <div className="companion-pane-body">
+        <Suspense fallback={<div className="companion-pane-loading">Loading {pane.title}…</div>}>
+          <PaneComponent />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/meridian/pop-out-pane-button.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/pop-out-pane-button.test.tsx
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { PopOutPaneButton } from "@/components/meridian/pop-out-pane-button";
+
+describe("PopOutPaneButton", () => {
+  afterEach(() => cleanup());
+
+  it("opens the pane via the injected opener with noopener", () => {
+    const open = vi.fn().mockReturnValue(null);
+    render(<PopOutPaneButton paneId="watchlist" opener={{ open: open as unknown as Window["open"] }} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Pop out in a companion window" }));
+    expect(open).toHaveBeenCalledWith("/panes/watchlist", "_blank", "noopener,noreferrer");
+  });
+
+  it("always renders a persistent fallback link that opens a new tab safely", () => {
+    render(<PopOutPaneButton paneId="live-quotes" />);
+    const link = screen.getByRole("link", { name: "Open in new tab" });
+    expect(link).toHaveAttribute("href", "/panes/live-quotes");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/meridian/pop-out-pane-button.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/pop-out-pane-button.test.tsx
@@ -15,7 +15,7 @@ describe("PopOutPaneButton", () => {
 
   it("always renders a persistent fallback link that opens a new tab safely", () => {
     render(<PopOutPaneButton paneId="live-quotes" />);
-    const link = screen.getByRole("link", { name: "Open in new tab" });
+    const link = screen.getByRole("link", { name: "Open Live quotes in a new tab" });
     expect(link).toHaveAttribute("href", "/panes/live-quotes");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");

--- a/src/Meridian.Ui/dashboard/src/components/meridian/pop-out-pane-button.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/pop-out-pane-button.tsx
@@ -1,6 +1,6 @@
 import { ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { companionPaneHref, openCompanionPane, type PaneOpener } from "@/lib/companion-pane/pane-window";
+import { COMPANION_PANES, companionPaneHref, openCompanionPane, type PaneOpener } from "@/lib/companion-pane/pane-window";
 
 export interface PopOutPaneButtonProps {
   paneId: string;
@@ -16,6 +16,7 @@ export interface PopOutPaneButtonProps {
  * detect a blocked popup — the fallback link is the reliable path in.
  */
 export function PopOutPaneButton({ paneId, label = "Pop out", opener = window }: PopOutPaneButtonProps) {
+  const paneTitle = COMPANION_PANES[paneId]?.title ?? paneId;
   return (
     <span className="pop-out-pane">
       <Button
@@ -33,6 +34,7 @@ export function PopOutPaneButton({ paneId, label = "Pop out", opener = window }:
         href={companionPaneHref(paneId)}
         target="_blank"
         rel="noopener noreferrer"
+        aria-label={`Open ${paneTitle} in a new tab`}
       >
         Open in new tab
       </a>

--- a/src/Meridian.Ui/dashboard/src/components/meridian/pop-out-pane-button.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/pop-out-pane-button.tsx
@@ -1,0 +1,41 @@
+import { ExternalLink } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { companionPaneHref, openCompanionPane, type PaneOpener } from "@/lib/companion-pane/pane-window";
+
+export interface PopOutPaneButtonProps {
+  paneId: string;
+  label?: string;
+  /** Injectable opener for tests. */
+  opener?: PaneOpener;
+}
+
+/**
+ * Open a workspace surface in a companion window. Renders a button that calls
+ * `window.open` (with `noopener`) plus a persistent, always-visible fallback
+ * link. Because a `noopener` open returns null even on success, we never try to
+ * detect a blocked popup — the fallback link is the reliable path in.
+ */
+export function PopOutPaneButton({ paneId, label = "Pop out", opener = window }: PopOutPaneButtonProps) {
+  return (
+    <span className="pop-out-pane">
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        onClick={() => openCompanionPane(paneId, opener)}
+        aria-label={`${label} in a companion window`}
+      >
+        <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+        <span>{label}</span>
+      </Button>
+      <a
+        className="pop-out-pane-fallback"
+        href={companionPaneHref(paneId)}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Open in new tab
+      </a>
+    </span>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/theme-toggle.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/theme-toggle.tsx
@@ -1,6 +1,7 @@
 import { Monitor, Moon, Sun } from "lucide-react";
 import { useEffect, useState } from "react";
 import { applyAppearance, APPEARANCE_STORAGE_KEY, readStoredAppearance, writeStoredAppearance, type Appearance } from "@/lib/theme";
+import { broadcastCompanionState } from "@/lib/companion-pane/opener-broadcast";
 import { cn } from "@/lib/utils";
 
 export interface ThemeToggleProps {
@@ -66,6 +67,8 @@ export function ThemeToggle({
     }
     if (persist === APPEARANCE_STORAGE_KEY) {
       writeStoredAppearance(next);
+      // Push the appearance change to any open companion panes so they retheme live.
+      broadcastCompanionState({ type: "appearance", appearance: next });
     } else if (persist && typeof localStorage !== "undefined") {
       localStorage.setItem(persist, next);
     }

--- a/src/Meridian.Ui/dashboard/src/lib/companion-pane/chrome-bridge.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/companion-pane/chrome-bridge.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createCompanionBridge,
+  normalizeCompanionBridgeMessage,
+  type BroadcastChannelLike,
+  type CompanionBridgeMessage
+} from "@/lib/companion-pane/chrome-bridge";
+
+class FakeChannel implements BroadcastChannelLike {
+  posted: unknown[] = [];
+  closed = false;
+  private listeners = new Set<(event: MessageEvent) => void>();
+
+  postMessage(message: unknown) {
+    this.posted.push(message);
+  }
+  addEventListener(_type: "message", listener: (event: MessageEvent) => void) {
+    this.listeners.add(listener);
+  }
+  removeEventListener(_type: "message", listener: (event: MessageEvent) => void) {
+    this.listeners.delete(listener);
+  }
+  close() {
+    this.closed = true;
+  }
+  emit(data: unknown) {
+    this.listeners.forEach((listener) => listener({ data } as MessageEvent));
+  }
+}
+
+describe("normalizeCompanionBridgeMessage", () => {
+  it("accepts well-formed messages", () => {
+    expect(normalizeCompanionBridgeMessage({ type: "appearance", appearance: "dark" })).toEqual({
+      type: "appearance",
+      appearance: "dark"
+    });
+    expect(normalizeCompanionBridgeMessage({ type: "scope", scope: { symbol: "AAPL" } })).toEqual({
+      type: "scope",
+      scope: { symbol: "AAPL" }
+    });
+    expect(normalizeCompanionBridgeMessage({ type: "session-expired" })).toEqual({ type: "session-expired" });
+  });
+
+  it("rejects malformed or unknown payloads", () => {
+    expect(normalizeCompanionBridgeMessage(null)).toBeNull();
+    expect(normalizeCompanionBridgeMessage("nope")).toBeNull();
+    expect(normalizeCompanionBridgeMessage({ type: "appearance", appearance: "neon" })).toBeNull();
+    expect(normalizeCompanionBridgeMessage({ type: "scope", scope: "x" })).toBeNull();
+    expect(normalizeCompanionBridgeMessage({ type: "other" })).toBeNull();
+  });
+});
+
+describe("createCompanionBridge", () => {
+  it("posts to the channel and delivers normalized inbound messages", () => {
+    const channel = new FakeChannel();
+    const bridge = createCompanionBridge(channel);
+    const handler = vi.fn();
+    const unsubscribe = bridge.subscribe(handler);
+
+    const message: CompanionBridgeMessage = { type: "appearance", appearance: "light" };
+    bridge.post(message);
+    expect(channel.posted).toEqual([message]);
+
+    channel.emit({ type: "session-expired" });
+    expect(handler).toHaveBeenCalledWith({ type: "session-expired" });
+
+    channel.emit({ type: "garbage" }); // ignored
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    channel.emit({ type: "session-expired" });
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    bridge.close();
+    expect(channel.closed).toBe(true);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/lib/companion-pane/chrome-bridge.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/companion-pane/chrome-bridge.ts
@@ -1,0 +1,84 @@
+// Same-origin cross-window bridge between the main workstation and its companion
+// panes. Built on BroadcastChannel: the main window posts appearance, operating
+// scope, and session-lifecycle updates; panes subscribe and apply them live.
+// Persisted state (theme, scope) is already shared through same-origin
+// localStorage on load — this channel carries the LIVE push so panes update
+// without waiting on a storage round-trip.
+import { isAppearance, type Appearance } from "@/lib/theme";
+import type { AppShellOperatingScopeInput } from "@/app-shell.operating-scope";
+
+export const COMPANION_CHANNEL_NAME = "meridian.workstation.companion.v1";
+
+export type CompanionBridgeMessage =
+  | { type: "appearance"; appearance: Appearance }
+  | { type: "scope"; scope: AppShellOperatingScopeInput }
+  | { type: "session-expired" };
+
+/** Minimal BroadcastChannel surface, injectable for tests. */
+export interface BroadcastChannelLike {
+  postMessage(message: unknown): void;
+  addEventListener(type: "message", listener: (event: MessageEvent) => void): void;
+  removeEventListener(type: "message", listener: (event: MessageEvent) => void): void;
+  close(): void;
+}
+
+/** Validate an inbound payload (cross-window data is untrusted). */
+export function normalizeCompanionBridgeMessage(data: unknown): CompanionBridgeMessage | null {
+  if (!data || typeof data !== "object") {
+    return null;
+  }
+  const type = (data as { type?: unknown }).type;
+  if (type === "appearance") {
+    const appearance = (data as { appearance?: unknown }).appearance;
+    return isAppearance(appearance) ? { type: "appearance", appearance } : null;
+  }
+  if (type === "scope") {
+    const scope = (data as { scope?: unknown }).scope;
+    return scope && typeof scope === "object"
+      ? { type: "scope", scope: scope as AppShellOperatingScopeInput }
+      : null;
+  }
+  if (type === "session-expired") {
+    return { type: "session-expired" };
+  }
+  return null;
+}
+
+export interface CompanionBridge {
+  post(message: CompanionBridgeMessage): void;
+  subscribe(handler: (message: CompanionBridgeMessage) => void): () => void;
+  close(): void;
+}
+
+export function createCompanionBridge(channel: BroadcastChannelLike): CompanionBridge {
+  const handlers = new Set<(message: CompanionBridgeMessage) => void>();
+  const onMessage = (event: MessageEvent) => {
+    const message = normalizeCompanionBridgeMessage(event.data);
+    if (message) {
+      handlers.forEach((handler) => handler(message));
+    }
+  };
+  channel.addEventListener("message", onMessage);
+  return {
+    post: (message) => channel.postMessage(message),
+    subscribe: (handler) => {
+      handlers.add(handler);
+      return () => {
+        handlers.delete(handler);
+      };
+    },
+    close: () => {
+      handlers.clear();
+      channel.removeEventListener("message", onMessage);
+      channel.close();
+    }
+  };
+}
+
+/** Open the shared channel, or null when BroadcastChannel is unavailable. */
+export function openCompanionChannel(name: string = COMPANION_CHANNEL_NAME): BroadcastChannelLike | null {
+  if (typeof BroadcastChannel === "undefined") {
+    return null;
+  }
+  return new BroadcastChannel(name);
+}

--- a/src/Meridian.Ui/dashboard/src/lib/companion-pane/opener-broadcast.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/companion-pane/opener-broadcast.ts
@@ -1,0 +1,31 @@
+// Main-window side of the companion bridge. Lazily opens a single shared channel
+// and posts updates to any open panes. A no-op when BroadcastChannel is
+// unavailable (e.g. SSR or older environments), so callers can broadcast
+// unconditionally.
+import {
+  createCompanionBridge,
+  openCompanionChannel,
+  type CompanionBridge,
+  type CompanionBridgeMessage
+} from "./chrome-bridge";
+
+let cachedBridge: CompanionBridge | null | undefined;
+
+function getOpenerBridge(): CompanionBridge | null {
+  if (cachedBridge === undefined) {
+    const channel = openCompanionChannel();
+    cachedBridge = channel ? createCompanionBridge(channel) : null;
+  }
+  return cachedBridge;
+}
+
+/** Broadcast a companion-bridge message from the main workstation window. */
+export function broadcastCompanionState(message: CompanionBridgeMessage): void {
+  getOpenerBridge()?.post(message);
+}
+
+/** Test seam: reset the cached opener bridge. */
+export function resetOpenerBridgeForTests(): void {
+  cachedBridge?.close();
+  cachedBridge = undefined;
+}

--- a/src/Meridian.Ui/dashboard/src/lib/companion-pane/pane-window.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/companion-pane/pane-window.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  companionPaneHref,
+  isCompanionPaneRoute,
+  openCompanionPane,
+  resolveCompanionPane
+} from "@/lib/companion-pane/pane-window";
+
+describe("companion pane routing", () => {
+  it("builds hrefs and recognizes pane routes", () => {
+    expect(companionPaneHref("watchlist")).toBe("/panes/watchlist");
+    expect(isCompanionPaneRoute("/panes/watchlist")).toBe(true);
+    expect(isCompanionPaneRoute("/data/watchlist")).toBe(false);
+  });
+
+  it("resolves known panes and rejects unknown or non-pane paths", () => {
+    expect(resolveCompanionPane("/panes/watchlist")?.title).toBe("Watchlist");
+    expect(resolveCompanionPane("/panes/live-quotes/")?.id).toBe("live-quotes");
+    expect(resolveCompanionPane("/panes/nope")).toBeNull();
+    expect(resolveCompanionPane("/data/quotes")).toBeNull();
+  });
+
+  it("opens a pane window with noopener and never inspects the return value", () => {
+    // window.open with noopener returns null even on success — the helper must not
+    // depend on the return value.
+    const open = vi.fn().mockReturnValue(null);
+    openCompanionPane("live-quotes", { open: open as unknown as Window["open"] });
+    expect(open).toHaveBeenCalledWith("/panes/live-quotes", "_blank", "noopener,noreferrer");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/lib/companion-pane/pane-window.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/companion-pane/pane-window.ts
@@ -1,0 +1,50 @@
+// Companion panes: chrome-less pop-out windows that render a single workspace
+// surface (e.g. the watchlist or live quotes) in their own browser window,
+// synchronized with the main workstation over a same-origin channel.
+
+export const COMPANION_PANE_ROUTE_PREFIX = "/panes/";
+
+export interface CompanionPaneDefinition {
+  id: string;
+  title: string;
+  /** Accessible label for the chrome-less window region. */
+  description: string;
+}
+
+export const COMPANION_PANES: Record<string, CompanionPaneDefinition> = {
+  watchlist: { id: "watchlist", title: "Watchlist", description: "Watchlist companion pane" },
+  "live-quotes": { id: "live-quotes", title: "Live quotes", description: "Live quotes companion pane" }
+};
+
+export function companionPaneHref(paneId: string): string {
+  return `${COMPANION_PANE_ROUTE_PREFIX}${paneId}`;
+}
+
+/** True when the path targets a companion pane (used for the chrome-less app branch). */
+export function isCompanionPaneRoute(pathname: string): boolean {
+  return pathname.startsWith(COMPANION_PANE_ROUTE_PREFIX);
+}
+
+/** Resolve the pane definition for a path, or null when it is not a known pane. */
+export function resolveCompanionPane(pathname: string): CompanionPaneDefinition | null {
+  if (!isCompanionPaneRoute(pathname)) {
+    return null;
+  }
+  const id = pathname.slice(COMPANION_PANE_ROUTE_PREFIX.length).replace(/\/+$/, "").split("/")[0];
+  return COMPANION_PANES[id] ?? null;
+}
+
+export interface PaneOpener {
+  open: Window["open"];
+}
+
+/**
+ * Open a companion pane in a new window. Uses `noopener,noreferrer` so the child
+ * cannot reach back into the opener. Because `window.open` with `noopener` returns
+ * `null` even on success, callers must NOT infer popup-blocker state from the
+ * return value — always keep a visible fallback link so the user has a reliable
+ * way in.
+ */
+export function openCompanionPane(paneId: string, opener: PaneOpener = window): void {
+  opener.open(companionPaneHref(paneId), "_blank", "noopener,noreferrer");
+}

--- a/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.tsx
@@ -1,11 +1,13 @@
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { Activity, AlertCircle, CheckCircle2, EyeOff, Eye, LineChart, Plus, RefreshCw, Settings, Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { MetricSnapshotCard } from "@/components/meridian/metric-card";
+import { PopOutPaneButton } from "@/components/meridian/pop-out-pane-button";
 import { DenseDataTable, type DenseDataTableColumn, ToolbarStrip } from "@/components/meridian/ui-kit-primitives";
+import { isCompanionPaneRoute } from "@/lib/companion-pane/pane-window";
 import {
   addSymbol as addSymbolApi,
   bulkAddSymbols,
@@ -35,19 +37,25 @@ export function WatchlistScreen() {
     removeSymbol: removeSymbolApi
   });
   const FeedbackIcon = vm.submitFeedback?.tone === "success" ? CheckCircle2 : AlertCircle;
+  const inCompanionPane = isCompanionPaneRoute(useLocation().pathname);
 
   return (
     <div className="space-y-6">
       <Card>
         <CardHeader>
-          <div className="eyebrow-label">Data Lane</div>
-          <CardTitle className="flex items-center gap-2">
-            <Activity className="h-5 w-5 text-primary" />
-            Symbol watchlist
-          </CardTitle>
-          <CardDescription>
-            Add, remove, and monitor symbols subscribed to the live data pipeline. Open a symbol to view live quotes.
-          </CardDescription>
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="eyebrow-label">Data Lane</div>
+              <CardTitle className="flex items-center gap-2">
+                <Activity className="h-5 w-5 text-primary" />
+                Symbol watchlist
+              </CardTitle>
+              <CardDescription>
+                Add, remove, and monitor symbols subscribed to the live data pipeline. Open a symbol to view live quotes.
+              </CardDescription>
+            </div>
+            {inCompanionPane ? null : <PopOutPaneButton paneId="watchlist" />}
+          </div>
         </CardHeader>
         <CardContent>
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">

--- a/src/Meridian.Ui/dashboard/src/styles/companion-pane.css
+++ b/src/Meridian.Ui/dashboard/src/styles/companion-pane.css
@@ -1,0 +1,77 @@
+/* Chrome-less companion pane window. Fills the viewport with a slim header and
+   the pane surface — no masthead or navigation. */
+.companion-pane {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--ws-surface, #ffffff);
+  color: var(--ws-text, #16202c);
+}
+
+.companion-pane-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.875rem;
+  border-bottom: 1px solid var(--ws-border, #99a5b2);
+  background: var(--ws-surface-raised, #f0f3f6);
+}
+
+.companion-pane-title {
+  font-weight: 600;
+  font-size: 0.8125rem;
+}
+
+.companion-pane-badge {
+  font-family: "Cascadia Mono", "JetBrains Mono", Consolas, ui-monospace, monospace;
+  font-size: 0.625rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ws-text-muted, #59636f);
+  border: 1px solid var(--ws-border, #99a5b2);
+  border-radius: 2px;
+  padding: 0.0625rem 0.375rem;
+}
+
+.companion-pane-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 0.875rem;
+}
+
+.companion-pane-loading,
+.companion-pane-empty {
+  padding: 1.5rem;
+  color: var(--ws-text-muted, #59636f);
+  font-size: 0.8125rem;
+}
+
+.companion-pane-session-ended {
+  padding: 0.5rem 0.875rem;
+  border-bottom: 1px solid var(--chart-drawdown, #ba3f55);
+  background: rgba(186, 63, 85, 0.12);
+  color: var(--ws-text, #16202c);
+  font-size: 0.75rem;
+}
+
+/* Pop-out control: a button plus an always-visible fallback link, so the pane is
+   reachable even when window.open is blocked (its noopener return value can't be
+   trusted to detect that). */
+.pop-out-pane {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.pop-out-pane-fallback {
+  font-size: 0.6875rem;
+  color: var(--cyan-primary, #2f6f8f);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.pop-out-pane-fallback:focus-visible {
+  outline: 2px solid var(--cyan-primary, #2f6f8f);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Adds **chrome-less pop-out companion windows** for individual workspace surfaces (Phase 6d of the web-UI improvement plan), synchronized with the main workstation over a same-origin `BroadcastChannel`.

- **Chrome-less pane route:** `app.tsx` now branches at the top (`AppRoot`) — `/panes/*` renders `CompanionPaneWindow` instead of `AppShell`, so a pane carries **no masthead, navigation, or workstation data loading**, just the pane surface.
- **`lib/companion-pane/pane-window.ts`** — pure pane registry + route helpers and `openCompanionPane`, which opens with `noopener,noreferrer` and **never inspects the return value** (it's `null` even on success).
- **`lib/companion-pane/chrome-bridge.ts`** — same-origin `BroadcastChannel` bridge with a **validated** message contract (`appearance` | `scope` | `session-expired`) and an injectable channel for tests; `opener-broadcast.ts` is the lazy main-window sender (no-op when `BroadcastChannel` is unavailable).
- **Live sync:** the main window broadcasts appearance changes (theme toggle) and a `session-expired` signal on `pagehide`. `CompanionPaneWindow` applies the persisted appearance on load, retheme's live, and surfaces a "main window no longer available" alert on session end.
- **`PopOutPaneButton`** renders a `window.open` button **plus** an always-visible fallback link (`target="_blank" rel="noopener noreferrer"`) — the reliable path in when a popup is blocked, since the `noopener` return value can't reveal that. Adopted on the **watchlist** header (hidden when already inside a pane).

`scope` is carried in the bridge contract (validated + tested) and reserved for scope-aware panes; the exemplar panes (watchlist, live quotes) don't filter by operating scope. Fanned-out **stream data** over the channel remains the documented Phase 4 follow-up (panes still open their own feeds for now).

## Reason

Phase 6d of `docs/product/web-ui-improvements-implementation-plan-2026-07.md` ("Pop-out companion panes", idea #9). Every route previously rendered inside the masthead + shell chrome, so an operator couldn't detach a surface (e.g. the watchlist) into its own window alongside the main workstation.

## Testing performed

- [x] `npm run test` (full dashboard suite) — 1862 tests green
- [x] `npm run lint` — clean (no new issues)
- [x] `npm run build` (tsc `--noEmit` + vite) — clean
- [x] Relevant unit/component tests added: `pane-window.test.ts` (route/opener helpers), `chrome-bridge.test.ts` (message normalization + pub/sub), `pop-out-pane-button.test.tsx` (opener call + fallback link), `companion-pane-window.test.tsx` (chrome-less render, unknown pane, live appearance, session-ended)
- [ ] Relevant integration tests were added or updated (n/a — client-only change)
- [ ] GitHub Actions `quality-gate` passed (pending CI)

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ)_