### PR TITLE
Stream fan-out A2: topic registry + per-session caps (broadcaster next)

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -5656,6 +5656,10 @@ Meridian-main
 │   │   │   ├── TradingOperatorReadinessService.cs
 │   │   │   ├── WorkstationServiceCollectionExtensions.cs
 │   │   │   └── WorkstationWorkflowSummaryService.cs
+│   │   ├── Streaming
+│   │   │   ├── QuoteStreamOptions.cs
+│   │   │   ├── StreamConnectionRegistry.cs
+│   │   │   └── StreamTopic.cs
 │   │   ├── Workflows
 │   │   │   ├── BuiltInWorkflowDefinitionProvider.cs
 │   │   │   ├── FileWorkflowPresetStore.cs
@@ -7269,6 +7273,9 @@ Meridian-main
 │   │   │   ├── MmfRebuildTests.cs
 │   │   │   └── MoneyMarketFundServiceTests.cs
 │   │   ├── Ui
+│   │   │   ├── Streaming
+│   │   │   │   ├── StreamConnectionRegistryTests.cs
+│   │   │   │   └── StreamTopicTests.cs
 │   │   │   ├── AccountingConfigurationServiceTests.cs
 │   │   │   ├── AccountingMigrationRunExecutionServiceTests.cs
 │   │   │   ├── AccountingProductionReadinessOperationalHardeningTests.cs

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,7 +5,7 @@
 
 ## Overall Coverage
 
-**2637 / 7326** items documented (**36.0%**) &mdash; Grade: **F**
+**2639 / 7328** items documented (**36.0%**) &mdash; Grade: **F**
 
 ```text
 [=======-------------] 36.0%
@@ -15,7 +15,7 @@
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 2516 | 6830 | 36.8% | F |
+| Public Classes / Interfaces | 2518 | 6832 | 36.9% | F |
 | API Endpoints | 107 | 349 | 30.7% | F |
 | Configuration Options | 3 | 136 | 2.2% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,11 +1,11 @@
 {
   "total_files": 539,
-  "total_lines": 89063,
+  "total_lines": 89070,
   "orphaned_count": 205,
   "no_heading_count": 38,
   "stale_count": 0,
   "todo_count": 200,
-  "average_lines": 165.2,
+  "average_lines": 165.3,
   "health_score": 83,
   "orphaned_files": [
     ".agents/skills/meridian-archive-organizer/SKILL.md",
@@ -2138,7 +2138,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7807,
+      "line_count": 7814,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,8 +20,8 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 539 |
-| Total lines | 89,063 |
-| Average file size (lines) | 165.2 |
+| Total lines | 89,070 |
+| Average file size (lines) | 165.3 |
 | Orphaned files | 205 |
 | Files without headings | 38 |
 | Stale files (>90 days) | 0 |

--- a/src/Meridian.Ui.Shared/Streaming/QuoteStreamOptions.cs
+++ b/src/Meridian.Ui.Shared/Streaming/QuoteStreamOptions.cs
@@ -1,0 +1,26 @@
+namespace Meridian.Ui.Shared.Streaming;
+
+/// <summary>
+/// Tuning knobs for the workstation quote-stream fan-out. Bindable from configuration
+/// under <see cref="SectionName"/>.
+/// </summary>
+public sealed class QuoteStreamOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "Workstation:QuoteStream";
+
+    /// <summary>
+    /// Maximum push cadence: dirty topics are rebuilt and fanned out at most this often.
+    /// Also the floor for how quickly a change reaches subscribers.
+    /// </summary>
+    public int CoalesceIntervalMs { get; set; } = 250;
+
+    /// <summary>Maximum concurrent stream connections per session.</summary>
+    public int MaxConcurrentStreamsPerSession { get; set; } = 4;
+
+    /// <summary>
+    /// Per-subscriber channel capacity. 1 means latest-snapshot-wins (drop-oldest), so a
+    /// slow client can never block the broadcaster — it only drops intermediate snapshots.
+    /// </summary>
+    public int SubscriberChannelCapacity { get; set; } = 1;
+}

--- a/src/Meridian.Ui.Shared/Streaming/StreamConnectionRegistry.cs
+++ b/src/Meridian.Ui.Shared/Streaming/StreamConnectionRegistry.cs
@@ -31,7 +31,18 @@ public sealed class StreamConnectionRegistry
 
         while (true)
         {
-            var current = _counts.GetOrAdd(sessionId, 0);
+            if (!_counts.TryGetValue(sessionId, out var current))
+            {
+                // First reservation for this session — add directly (never inserts a 0).
+                if (_counts.TryAdd(sessionId, 1))
+                {
+                    return true;
+                }
+
+                // Another thread added it first — re-read and retry.
+                continue;
+            }
+
             if (current >= _maxPerSession)
             {
                 return false;

--- a/src/Meridian.Ui.Shared/Streaming/StreamConnectionRegistry.cs
+++ b/src/Meridian.Ui.Shared/Streaming/StreamConnectionRegistry.cs
@@ -1,0 +1,87 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Meridian.Ui.Shared.Streaming;
+
+/// <summary>
+/// Tracks the number of concurrent quote-stream connections per session and enforces a
+/// per-session cap. A singleton hit concurrently by many request threads, so all counter
+/// mutations are atomic (compare-and-swap on a <see cref="ConcurrentDictionary{TKey,TValue}"/>).
+/// </summary>
+public sealed class StreamConnectionRegistry
+{
+    private readonly int _maxPerSession;
+    private readonly ConcurrentDictionary<string, int> _counts = new(System.StringComparer.Ordinal);
+
+    public StreamConnectionRegistry(int maxConcurrentStreamsPerSession)
+    {
+        _maxPerSession = maxConcurrentStreamsPerSession > 0 ? maxConcurrentStreamsPerSession : 1;
+    }
+
+    /// <summary>
+    /// Atomically reserves a stream slot for the session. Returns false when the session
+    /// is already at its cap. An empty session id is treated as unscoped and never capped.
+    /// </summary>
+    public bool TryReserve(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId))
+        {
+            return true;
+        }
+
+        while (true)
+        {
+            var current = _counts.GetOrAdd(sessionId, 0);
+            if (current >= _maxPerSession)
+            {
+                return false;
+            }
+
+            if (_counts.TryUpdate(sessionId, current + 1, current))
+            {
+                return true;
+            }
+
+            // Lost the race with another thread — re-read and retry.
+        }
+    }
+
+    /// <summary>Releases a previously reserved slot for the session.</summary>
+    public void Release(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId))
+        {
+            return;
+        }
+
+        while (true)
+        {
+            if (!_counts.TryGetValue(sessionId, out var current) || current <= 0)
+            {
+                return;
+            }
+
+            if (current == 1)
+            {
+                // Conditionally remove only if the value is still 1 (atomic).
+                if (((ICollection<KeyValuePair<string, int>>)_counts).Remove(new KeyValuePair<string, int>(sessionId, 1)))
+                {
+                    return;
+                }
+            }
+            else if (_counts.TryUpdate(sessionId, current - 1, current))
+            {
+                return;
+            }
+
+            // Lost the race — retry.
+        }
+    }
+
+    /// <summary>Current number of active streams for the session.</summary>
+    public int ActiveCount(string sessionId)
+        => _counts.TryGetValue(sessionId, out var count) ? count : 0;
+
+    /// <summary>Drops all accounting for a session (e.g. on logout / session expiry).</summary>
+    public void CloseSession(string sessionId) => _counts.TryRemove(sessionId, out _);
+}

--- a/src/Meridian.Ui.Shared/Streaming/StreamTopic.cs
+++ b/src/Meridian.Ui.Shared/Streaming/StreamTopic.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Linq;
+
+namespace Meridian.Ui.Shared.Streaming;
+
+/// <summary>
+/// Identifies a quote-stream fan-out topic: the canonical, order- and case-independent
+/// set of symbols a subscriber wants, or the "all tracked symbols" sentinel. Topic
+/// equality is by <see cref="Key"/>, so subscribers requesting the same symbols — in any
+/// order or case — share one topic (and therefore one snapshot build per fan-out tick).
+/// </summary>
+public readonly struct StreamTopic : IEquatable<StreamTopic>
+{
+    /// <summary>Topic key for "all tracked symbols".</summary>
+    public const string AllQuotesKey = "quotes:*";
+
+    private StreamTopic(string key, string symbolFilter)
+    {
+        Key = key;
+        SymbolFilter = symbolFilter;
+    }
+
+    /// <summary>Canonical, stable identifier for this topic.</summary>
+    public string Key { get; }
+
+    /// <summary>
+    /// The comma-joined symbol filter to pass to the snapshot builder, or empty string
+    /// for "all tracked symbols".
+    /// </summary>
+    public string SymbolFilter { get; }
+
+    /// <summary>Topic covering every tracked symbol.</summary>
+    public static StreamTopic AllQuotes { get; } = new(AllQuotesKey, string.Empty);
+
+    /// <summary>
+    /// Build a quotes topic from a raw or normalized symbol filter (comma-separated).
+    /// Symbols are trimmed, upper-cased, de-duplicated, and sorted so equivalent
+    /// requests collapse to the same topic. An empty/whitespace filter yields
+    /// <see cref="AllQuotes"/>.
+    /// </summary>
+    public static StreamTopic Quotes(string? symbolFilter)
+    {
+        if (string.IsNullOrWhiteSpace(symbolFilter))
+        {
+            return AllQuotes;
+        }
+
+        var symbols = symbolFilter
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(static symbol => symbol.ToUpperInvariant())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static symbol => symbol, StringComparer.Ordinal)
+            .ToArray();
+
+        if (symbols.Length == 0)
+        {
+            return AllQuotes;
+        }
+
+        var canonical = string.Join(',', symbols);
+        return new StreamTopic($"quotes:{canonical}", canonical);
+    }
+
+    public bool Equals(StreamTopic other) => string.Equals(Key, other.Key, StringComparison.Ordinal);
+
+    public override bool Equals(object? obj) => obj is StreamTopic other && Equals(other);
+
+    public override int GetHashCode() => Key is null ? 0 : StringComparer.Ordinal.GetHashCode(Key);
+
+    public override string ToString() => Key ?? AllQuotesKey;
+}

--- a/src/Meridian.Ui.Shared/Streaming/StreamTopic.cs
+++ b/src/Meridian.Ui.Shared/Streaming/StreamTopic.cs
@@ -14,20 +14,26 @@ public readonly struct StreamTopic : IEquatable<StreamTopic>
     /// <summary>Topic key for "all tracked symbols".</summary>
     public const string AllQuotesKey = "quotes:*";
 
+    private readonly string? _key;
+    private readonly string? _symbolFilter;
+
     private StreamTopic(string key, string symbolFilter)
     {
-        Key = key;
-        SymbolFilter = symbolFilter;
+        _key = key;
+        _symbolFilter = symbolFilter;
     }
 
-    /// <summary>Canonical, stable identifier for this topic.</summary>
-    public string Key { get; }
+    /// <summary>
+    /// Canonical, stable identifier for this topic. <c>default(StreamTopic)</c> resolves to
+    /// <see cref="AllQuotesKey"/> so the default value behaves as <see cref="AllQuotes"/>.
+    /// </summary>
+    public string Key => _key ?? AllQuotesKey;
 
     /// <summary>
     /// The comma-joined symbol filter to pass to the snapshot builder, or empty string
     /// for "all tracked symbols".
     /// </summary>
-    public string SymbolFilter { get; }
+    public string SymbolFilter => _symbolFilter ?? string.Empty;
 
     /// <summary>Topic covering every tracked symbol.</summary>
     public static StreamTopic AllQuotes { get; } = new(AllQuotesKey, string.Empty);
@@ -65,7 +71,11 @@ public readonly struct StreamTopic : IEquatable<StreamTopic>
 
     public override bool Equals(object? obj) => obj is StreamTopic other && Equals(other);
 
-    public override int GetHashCode() => Key is null ? 0 : StringComparer.Ordinal.GetHashCode(Key);
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Key);
 
-    public override string ToString() => Key ?? AllQuotesKey;
+    public override string ToString() => Key;
+
+    public static bool operator ==(StreamTopic left, StreamTopic right) => left.Equals(right);
+
+    public static bool operator !=(StreamTopic left, StreamTopic right) => !left.Equals(right);
 }

--- a/tests/Meridian.Tests/Ui/Streaming/StreamConnectionRegistryTests.cs
+++ b/tests/Meridian.Tests/Ui/Streaming/StreamConnectionRegistryTests.cs
@@ -1,0 +1,70 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Meridian.Ui.Shared.Streaming;
+using Xunit;
+
+namespace Meridian.Tests.Ui;
+
+public sealed class StreamConnectionRegistryTests
+{
+    [Fact]
+    public void TryReserve_EnforcesPerSessionCap()
+    {
+        var registry = new StreamConnectionRegistry(maxConcurrentStreamsPerSession: 2);
+
+        registry.TryReserve("s1").Should().BeTrue();
+        registry.TryReserve("s1").Should().BeTrue();
+        registry.TryReserve("s1").Should().BeFalse();
+        registry.ActiveCount("s1").Should().Be(2);
+
+        // A different session has its own budget.
+        registry.TryReserve("s2").Should().BeTrue();
+    }
+
+    [Fact]
+    public void Release_FreesASlot()
+    {
+        var registry = new StreamConnectionRegistry(1);
+        registry.TryReserve("s1").Should().BeTrue();
+        registry.TryReserve("s1").Should().BeFalse();
+
+        registry.Release("s1");
+
+        registry.ActiveCount("s1").Should().Be(0);
+        registry.TryReserve("s1").Should().BeTrue();
+    }
+
+    [Fact]
+    public void CloseSession_ResetsCount()
+    {
+        var registry = new StreamConnectionRegistry(4);
+        registry.TryReserve("s1");
+        registry.TryReserve("s1");
+
+        registry.CloseSession("s1");
+
+        registry.ActiveCount("s1").Should().Be(0);
+    }
+
+    [Fact]
+    public void UnscopedSession_IsNeverCapped()
+    {
+        var registry = new StreamConnectionRegistry(1);
+
+        registry.TryReserve("").Should().BeTrue();
+        registry.TryReserve("").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TryReserve_IsThreadSafeUnderConcurrency()
+    {
+        var registry = new StreamConnectionRegistry(maxConcurrentStreamsPerSession: 10);
+
+        var grants = await Task.WhenAll(
+            Enumerable.Range(0, 100).Select(_ => Task.Run(() => registry.TryReserve("s1"))));
+
+        grants.Count(granted => granted).Should().Be(10);
+        registry.ActiveCount("s1").Should().Be(10);
+    }
+}

--- a/tests/Meridian.Tests/Ui/Streaming/StreamTopicTests.cs
+++ b/tests/Meridian.Tests/Ui/Streaming/StreamTopicTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using Meridian.Ui.Shared.Streaming;
+using Xunit;
+
+namespace Meridian.Tests.Ui;
+
+public sealed class StreamTopicTests
+{
+    [Fact]
+    public void Quotes_CanonicalizesOrderAndCase()
+    {
+        var a = StreamTopic.Quotes("msft,aapl");
+        var b = StreamTopic.Quotes("AAPL, MSFT");
+
+        a.Key.Should().Be("quotes:AAPL,MSFT");
+        a.SymbolFilter.Should().Be("AAPL,MSFT");
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Quotes_DeduplicatesSymbols()
+    {
+        StreamTopic.Quotes("AAPL,aapl,AAPL").Key.Should().Be("quotes:AAPL");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(",")]
+    public void Quotes_EmptyFilter_IsAllQuotes(string? filter)
+    {
+        var topic = StreamTopic.Quotes(filter);
+
+        topic.Should().Be(StreamTopic.AllQuotes);
+        topic.Key.Should().Be(StreamTopic.AllQuotesKey);
+        topic.SymbolFilter.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DistinctTopics_AreNotEqual()
+    {
+        StreamTopic.Quotes("AAPL").Should().NotBe(StreamTopic.Quotes("MSFT"));
+        StreamTopic.Quotes("AAPL").Should().NotBe(StreamTopic.AllQuotes);
+    }
+}

--- a/tests/Meridian.Tests/Ui/Streaming/StreamTopicTests.cs
+++ b/tests/Meridian.Tests/Ui/Streaming/StreamTopicTests.cs
@@ -43,5 +43,15 @@ public sealed class StreamTopicTests
     {
         StreamTopic.Quotes("AAPL").Should().NotBe(StreamTopic.Quotes("MSFT"));
         StreamTopic.Quotes("AAPL").Should().NotBe(StreamTopic.AllQuotes);
+        (StreamTopic.Quotes("AAPL") != StreamTopic.Quotes("MSFT")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Default_BehavesAsAllQuotes()
+    {
+        default(StreamTopic).Should().Be(StreamTopic.AllQuotes);
+        (default(StreamTopic) == StreamTopic.AllQuotes).Should().BeTrue();
+        default(StreamTopic).Key.Should().Be(StreamTopic.AllQuotesKey);
+        default(StreamTopic).SymbolFilter.Should().BeEmpty();
     }
 }


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Second implementation increment of the quote-stream fan-out blueprint (`docs/product/web-ui-stream-fan-out-blueprint-2026-07.md`), building on the A1 notifier seam already merged. This PR lands the **self-contained fan-out primitives** with **zero behavior change** — no endpoint or DI wiring yet, so nothing is on the hot path.

**A2a (this commit):**
- **`StreamTopic`** — canonical, order/case-independent quotes topic key (trim → upper → dedupe → sort), or the `quotes:*` all-symbols sentinel, so equivalent symbol requests collapse to one topic (one snapshot build per fan-out tick).
- **`QuoteStreamOptions`** — coalesce cadence, per-session stream cap (default 4), subscriber channel capacity (default 1 = latest-wins).
- **`StreamConnectionRegistry`** — thread-safe (atomic compare-and-swap) per-session concurrent-stream counter with reserve/release/close; empty session id is treated as unscoped.

Tests cover topic canonicalization/dedup/all-sentinel and the registry's cap, release, close, unscoped, and **concurrent-reserve thread safety**.

**Next in this PR (A2b):** the `QuoteStreamBroadcaster` (implements `IQuoteUpdateNotifier`) with per-topic coalesced fan-out over bounded per-subscriber channels, plus DI wiring. The endpoint keeps polling until increment B, so this whole PR remains zero-behavior-change and hot-path-review-friendly.

## Reason

Continues the blueprint's phased, hot-path-review-gated implementation of the deferred stream fan-out. Landing the primitives separately keeps each reviewable slice small.

## Testing performed

- [x] Docs regenerate cleanly (structure + doc-health + coverage) — idempotent
- [x] xUnit tests added (`StreamTopicTests`, `StreamConnectionRegistryTests`)
- [ ] Relevant integration tests were added or updated (n/a — no endpoint wiring yet)
- [ ] GitHub Actions `quality-gate` passed (pending CI — authoritative compile/test; no local .NET toolchain in the authoring environment)

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ)_