### PR TITLE
Stream fan-out B: SSE endpoint switches to event-driven broadcaster

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Stream.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Stream.cs
@@ -65,17 +65,16 @@ public static partial class WorkstationEndpoints
                 {
                     while (!ct.IsCancellationRequested)
                     {
-                        // Single writer: race the next snapshot against the heartbeat interval so a
-                        // heartbeat never writes to Response.Body concurrently with a snapshot.
+                        // Single writer: wait for the next snapshot with a heartbeat-interval timeout.
+                        // When the timeout cancels the token, WaitToReadAsync throws and we write a
+                        // heartbeat instead — Response.Body is never written from two paths at once, and
+                        // there is no per-iteration Task.WhenAny/Task.Delay/.AsTask() allocation churn.
                         using var iteration = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                        var readTask = subscription.Reader.WaitToReadAsync(iteration.Token).AsTask();
-                        var delayTask = Task.Delay(StreamHeartbeatIntervalMs, iteration.Token);
-                        var completed = await Task.WhenAny(readTask, delayTask).ConfigureAwait(false);
-                        iteration.Cancel();
+                        iteration.CancelAfter(StreamHeartbeatIntervalMs);
 
-                        if (completed == readTask)
+                        try
                         {
-                            if (!await readTask.ConfigureAwait(false))
+                            if (!await subscription.Reader.WaitToReadAsync(iteration.Token).ConfigureAwait(false))
                             {
                                 break; // broadcaster completed the channel — the stream is done.
                             }
@@ -94,8 +93,9 @@ public static partial class WorkstationEndpoints
                                 await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
                             }
                         }
-                        else
+                        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
                         {
+                            // Heartbeat interval elapsed with no snapshot — keep the connection warm.
                             await context.Response.WriteAsync(": heartbeat\n\n", ct).ConfigureAwait(false);
                             await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
                         }

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Stream.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Stream.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
 using Meridian.Contracts.Api;
-using Meridian.Domain.Collectors;
+using Meridian.Ui.Shared.Streaming;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -9,22 +9,21 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Meridian.Ui.Shared.Endpoints;
 
 /// <summary>
-/// Workstation Server-Sent Events stream. Step 1 of the live data spine: a
-/// poll-bridge that pushes the same read-model payloads the REST endpoints serve,
-/// coalescing unchanged snapshots so idle streams cost heartbeats only. True
-/// event-driven fan-out from the pipeline is a separate, hot-path-reviewed step.
+/// Workstation Server-Sent Events stream. Event-driven fan-out: connections subscribe to a topic on
+/// the <see cref="IQuoteStreamBroadcaster"/>, which rebuilds and coalesces each topic's snapshot once
+/// per change and pushes it to every subscriber. One snapshot build is shared across all subscribers
+/// of a topic, and the market-data ingestion hot path is untouched.
 /// </summary>
 public static partial class WorkstationEndpoints
 {
-    private const int StreamPollIntervalMs = 2_000;
     private const int StreamHeartbeatIntervalMs = 15_000;
     private const int StreamMaxSymbols = 50;
 
     private static void MapStreamEndpoints(RouteGroupBuilder group, JsonSerializerOptions jsonOptions)
     {
-        // GET /api/workstation/stream?symbols=AAPL,MSFT — SSE channel emitting
-        // `event: quotes` frames with the quotes-snapshot payload for the requested
-        // symbols whenever it changes, plus `: heartbeat` comments while idle.
+        // GET /api/workstation/stream?symbols=AAPL,MSFT — SSE channel emitting `event: quotes`
+        // frames with the quotes-snapshot payload for the requested symbols whenever it changes, plus
+        // `: heartbeat` comments while idle.
         group.MapGet(WorkstationSubroute(UiApiRoutes.WorkstationStream), async (HttpContext context, string? symbols, CancellationToken ct) =>
         {
             var normalizedSymbols = NormalizeStreamSymbols(symbols);
@@ -36,56 +35,71 @@ public static partial class WorkstationEndpoints
                     statusCode: StatusCodes.Status400BadRequest);
             }
 
-            if (context.RequestServices.GetService<QuoteCollector>() is null)
+            var broadcaster = context.RequestServices.GetService<IQuoteStreamBroadcaster>();
+            if (broadcaster is null)
             {
                 return Results.Json(
-                    new { error = "Quote collector not available" },
+                    new { error = "Quote stream not available" },
                     jsonOptions,
                     statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+
+            var topic = StreamTopic.Quotes(normalizedSymbols);
+            var subscription = broadcaster.TrySubscribe(topic, ResolveStreamSessionId(context));
+            if (subscription is null)
+            {
+                context.Response.Headers["Retry-After"] = "5";
+                return Results.Json(
+                    new { error = "Too many concurrent streams for this session." },
+                    jsonOptions,
+                    statusCode: StatusCodes.Status429TooManyRequests);
             }
 
             context.Response.ContentType = "text/event-stream";
             context.Response.Headers.CacheControl = "no-cache";
             context.Response.Headers.Connection = "keep-alive";
 
-            IReadOnlyList<QuotesSnapshotItem>? lastQuotes = null;
-            var lastWriteUtc = DateTimeOffset.MinValue;
-
             try
             {
-                while (!ct.IsCancellationRequested)
+                await using (subscription)
                 {
-                    var snapshot = LiveDataEndpoints.TryBuildQuotesSnapshotResponse(context.RequestServices, normalizedSymbols);
-                    var wrote = false;
-                    if (snapshot is not null)
+                    while (!ct.IsCancellationRequested)
                     {
-                        // Coalesce on the quote rows only: the envelope timestamp moves every
-                        // tick even when no quote changed. QuotesSnapshotItem is a sealed record
-                        // of scalars, so value equality covers every serialized field without
-                        // allocating a serialization per idle tick.
-                        if (!QuoteRowsEqual(lastQuotes, snapshot.Quotes))
+                        // Single writer: race the next snapshot against the heartbeat interval so a
+                        // heartbeat never writes to Response.Body concurrently with a snapshot.
+                        using var iteration = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                        var readTask = subscription.Reader.WaitToReadAsync(iteration.Token).AsTask();
+                        var delayTask = Task.Delay(StreamHeartbeatIntervalMs, iteration.Token);
+                        var completed = await Task.WhenAny(readTask, delayTask).ConfigureAwait(false);
+                        iteration.Cancel();
+
+                        if (completed == readTask)
                         {
-                            lastQuotes = snapshot.Quotes;
-                            var payload = JsonSerializer.Serialize(snapshot, jsonOptions);
-                            await context.Response.WriteAsync($"event: quotes\ndata: {payload}\n\n", ct).ConfigureAwait(false);
-                            wrote = true;
+                            if (!await readTask.ConfigureAwait(false))
+                            {
+                                break; // broadcaster completed the channel — the stream is done.
+                            }
+
+                            // Coalesce anything queued to the newest snapshot before writing.
+                            QuotesSnapshotResponse? latest = null;
+                            while (subscription.Reader.TryRead(out var snapshot))
+                            {
+                                latest = snapshot;
+                            }
+
+                            if (latest is not null)
+                            {
+                                var payload = JsonSerializer.Serialize(latest, jsonOptions);
+                                await context.Response.WriteAsync($"event: quotes\ndata: {payload}\n\n", ct).ConfigureAwait(false);
+                                await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
+                            }
+                        }
+                        else
+                        {
+                            await context.Response.WriteAsync(": heartbeat\n\n", ct).ConfigureAwait(false);
+                            await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
                         }
                     }
-
-                    var nowUtc = DateTimeOffset.UtcNow;
-                    if (!wrote && (nowUtc - lastWriteUtc).TotalMilliseconds >= StreamHeartbeatIntervalMs)
-                    {
-                        await context.Response.WriteAsync(": heartbeat\n\n", ct).ConfigureAwait(false);
-                        wrote = true;
-                    }
-
-                    if (wrote)
-                    {
-                        lastWriteUtc = nowUtc;
-                        await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
-                    }
-
-                    await Task.Delay(StreamPollIntervalMs, ct).ConfigureAwait(false);
                 }
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -98,30 +112,26 @@ public static partial class WorkstationEndpoints
         .WithName("GetWorkstationStream")
         .Produces(200)
         .Produces(400)
+        .Produces(429)
         .Produces(503);
     }
 
-    private static bool QuoteRowsEqual(IReadOnlyList<QuotesSnapshotItem>? previous, IReadOnlyList<QuotesSnapshotItem> current)
+    /// <summary>
+    /// Resolve the per-session identity used for the concurrent-stream cap. Falls back to an empty id
+    /// (treated as unscoped / uncapped) when no logged-in operator is on the request.
+    /// </summary>
+    private static string ResolveStreamSessionId(HttpContext context)
     {
-        if (previous is null || previous.Count != current.Count)
-        {
-            return false;
-        }
-
-        for (var i = 0; i < current.Count; i++)
-        {
-            if (!current[i].Equals(previous[i]))
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return context.Items.TryGetValue(LoginSessionMiddleware.CurrentUserKey, out var user)
+            && user is string userId
+            && !string.IsNullOrWhiteSpace(userId)
+                ? userId
+                : string.Empty;
     }
 
     /// <summary>
-    /// Trims and caps the symbol filter; returns null when the cap is exceeded and
-    /// an empty string when no filter was requested (stream all tracked symbols).
+    /// Trims and caps the symbol filter; returns null when the cap is exceeded and an empty string
+    /// when no filter was requested (stream all tracked symbols).
     /// </summary>
     private static string? NormalizeStreamSymbols(string? symbols)
     {

--- a/tests/Meridian.Tests/Ui/WorkstationStreamEndpointTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationStreamEndpointTests.cs
@@ -7,6 +7,7 @@ using Meridian.Contracts.Domain.Models;
 using Meridian.Domain.Collectors;
 using Meridian.Tests.TestHelpers;
 using Meridian.Ui.Shared.Endpoints;
+using Meridian.Ui.Shared.Streaming;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -25,9 +26,9 @@ public sealed class WorkstationStreamEndpointTests
     };
 
     [Fact]
-    public async Task GetWorkstationStream_WithoutQuoteCollector_Returns503()
+    public async Task GetWorkstationStream_WithoutBroadcaster_Returns503()
     {
-        await using var app = await CreateStreamAppAsync(registerCollector: false);
+        await using var app = await CreateStreamAppAsync(registerStream: false);
         var client = app.GetTestClient();
 
         var response = await client.GetAsync("/api/workstation/stream");
@@ -38,7 +39,7 @@ public sealed class WorkstationStreamEndpointTests
     [Fact]
     public async Task GetWorkstationStream_WithTooManySymbols_Returns400()
     {
-        await using var app = await CreateStreamAppAsync(registerCollector: true);
+        await using var app = await CreateStreamAppAsync(registerStream: true);
         var client = app.GetTestClient();
 
         var symbols = string.Join(',', Enumerable.Range(0, 51).Select(index => $"SYM{index}"));
@@ -50,7 +51,7 @@ public sealed class WorkstationStreamEndpointTests
     [Fact]
     public async Task GetWorkstationStream_EmitsQuotesEventForFilteredSymbols()
     {
-        await using var app = await CreateStreamAppAsync(registerCollector: true, seedSymbols: ["SPY", "MSFT"]);
+        await using var app = await CreateStreamAppAsync(registerStream: true, seedSymbols: ["SPY", "MSFT"]);
         var client = app.GetTestClient();
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
@@ -66,6 +67,27 @@ public sealed class WorkstationStreamEndpointTests
         frame.Should().StartWith("event: quotes");
         frame.Should().Contain("\"symbol\":\"SPY\"");
         frame.Should().NotContain("\"symbol\":\"MSFT\"");
+    }
+
+    [Fact]
+    public async Task GetWorkstationStream_BeyondSessionCap_Returns429()
+    {
+        await using var app = await CreateStreamAppAsync(
+            registerStream: true, seedSymbols: ["SPY"], maxConcurrentStreams: 1);
+        var client = app.GetTestClient();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        // Hold the first stream open (its subscription keeps the session's single slot reserved).
+        using var first = await client.GetAsync(
+            "/api/workstation/stream?symbols=SPY", HttpCompletionOption.ResponseHeadersRead, cts.Token);
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        await ReadFirstEventFrameAsync(first, cts.Token);
+
+        using var second = await client.GetAsync(
+            "/api/workstation/stream?symbols=MSFT", HttpCompletionOption.ResponseHeadersRead, cts.Token);
+
+        second.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+        second.Headers.RetryAfter.Should().NotBeNull();
     }
 
     private static async Task<string> ReadFirstEventFrameAsync(HttpResponseMessage response, CancellationToken ct)
@@ -94,8 +116,9 @@ public sealed class WorkstationStreamEndpointTests
     }
 
     private static async Task<WebApplication> CreateStreamAppAsync(
-        bool registerCollector,
-        IReadOnlyList<string>? seedSymbols = null)
+        bool registerStream,
+        IReadOnlyList<string>? seedSymbols = null,
+        int maxConcurrentStreams = 8)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
@@ -103,7 +126,7 @@ public sealed class WorkstationStreamEndpointTests
         });
         builder.WebHost.UseTestServer();
 
-        if (registerCollector)
+        if (registerStream)
         {
             var collector = new QuoteCollector(new TestMarketEventPublisher());
             foreach (var symbol in seedSymbols ?? [])
@@ -120,6 +143,19 @@ public sealed class WorkstationStreamEndpointTests
             }
 
             builder.Services.AddSingleton(collector);
+            builder.Services.AddSingleton(new QuoteStreamOptions
+            {
+                CoalesceIntervalMs = 0,
+                MaxConcurrentStreamsPerSession = maxConcurrentStreams,
+                SubscriberChannelCapacity = 1
+            });
+            builder.Services.AddSingleton(sp => new StreamConnectionRegistry(
+                sp.GetRequiredService<QuoteStreamOptions>().MaxConcurrentStreamsPerSession));
+            builder.Services.AddSingleton(sp => new QuoteStreamBroadcaster(
+                sp,
+                sp.GetRequiredService<StreamConnectionRegistry>(),
+                sp.GetRequiredService<QuoteStreamOptions>()));
+            builder.Services.AddSingleton<IQuoteStreamBroadcaster>(sp => sp.GetRequiredService<QuoteStreamBroadcaster>());
         }
 
         var app = builder.Build();

--- a/tests/Meridian.Tests/Ui/WorkstationStreamEndpointTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationStreamEndpointTests.cs
@@ -78,10 +78,13 @@ public sealed class WorkstationStreamEndpointTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
         // Hold the first stream open (its subscription keeps the session's single slot reserved).
+        // Read past the first frame WITHOUT disposing the stream — disposing it would abort the
+        // server request and release the slot, letting the second request succeed spuriously.
         using var first = await client.GetAsync(
             "/api/workstation/stream?symbols=SPY", HttpCompletionOption.ResponseHeadersRead, cts.Token);
         first.StatusCode.Should().Be(HttpStatusCode.OK);
-        await ReadFirstEventFrameAsync(first, cts.Token);
+        await using var firstStream = await first.Content.ReadAsStreamAsync(cts.Token);
+        await ReadPastFirstFrameAsync(firstStream, cts.Token);
 
         using var second = await client.GetAsync(
             "/api/workstation/stream?symbols=MSFT", HttpCompletionOption.ResponseHeadersRead, cts.Token);
@@ -113,6 +116,26 @@ public sealed class WorkstationStreamEndpointTests
         }
 
         throw new TimeoutException("No SSE frame arrived before the read deadline.");
+    }
+
+    // Reads until the first `\n\n` frame boundary but leaves the stream open so the caller keeps the
+    // server request (and its reserved session slot) alive.
+    private static async Task ReadPastFirstFrameAsync(Stream stream, CancellationToken ct)
+    {
+        var buffer = new byte[1024];
+        while (!ct.IsCancellationRequested)
+        {
+            var read = await stream.ReadAsync(buffer, ct);
+            if (read <= 0)
+            {
+                break;
+            }
+
+            if (Encoding.UTF8.GetString(buffer, 0, read).Contains("\n\n", StringComparison.Ordinal))
+            {
+                return;
+            }
+        }
     }
 
     private static async Task<WebApplication> CreateStreamAppAsync(


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

The behavior-flipping increment of the quote-stream fan-out blueprint. With the A1 seam, A2a primitives, and A2b broadcaster + DI all merged, this switches the workstation quote SSE endpoint from a **per-connection 2-second poll** to an **event-driven subscription** on the `QuoteStreamBroadcaster`.

- Subscribe to `StreamTopic.Quotes(symbols)` via `IQuoteStreamBroadcaster` and drain its coalesced snapshot channel, instead of rebuilding a snapshot per connection per tick. **One snapshot build per topic is now shared across all subscribers.**
- **Single writer:** the heartbeat races the next snapshot via a linked-token `Task.WhenAny`, so a heartbeat never writes to `Response.Body` concurrently with a snapshot frame (the concurrency hazard flagged in the blueprint review).
- **503** when the broadcaster is unavailable; **429 + `Retry-After`** when the session's concurrent-stream cap is exceeded; session id resolved from the login session's current user (empty ⇒ unscoped/uncapped). The 400 symbol cap is unchanged.
- Retire the per-connection poll interval and the endpoint-local `QuoteRowsEqual` (coalescing now lives in the broadcaster).

**Wire format is unchanged** — `event: quotes` frames of `QuotesSnapshotResponse`, `: heartbeat` comments — so `lib/quotes-stream.ts` needs no change. Endpoint tests register the broadcaster and add a **429 cap** test alongside the existing 503 / 400 / emits-quotes cases.

This completes the **server-side** fan-out (blueprint increments A + B). The remaining blueprint work is **C** (client companion-pane stream sharing over the `BroadcastChannel`), which is independent.

## Reason

Final server step of the deferred stream fan-out: turns N independent poll loops into one event-woken push per topic, with per-session caps — while leaving the market-data ingestion/storage hot path untouched.

## Testing performed

- [x] xUnit endpoint tests updated + added (`WorkstationStreamEndpointTests`: 503, 400, emits-quotes, 429 cap)
- [x] Broadcaster unit tests already cover fan-out/coalescing/cap/dispose (merged)
- [ ] Relevant integration tests were added or updated — endpoint tests use the TestServer harness
- [ ] GitHub Actions `quality-gate` passed (pending CI — authoritative compile/test; no local .NET toolchain in the authoring environment)

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ)_