### PR TITLE
Add asset obligation projection engine

### DIFF
--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -884,7 +884,6 @@ Meridian-main
 │   ├── labeler.yml
 │   ├── labels.yml
 │   ├── markdown-link-check-config.json
-│   ├── PULL_REQUEST_TEMPLATE.md
 │   ├── pull_request_template.md
 │   ├── pull_request_template_desktop.md
 │   └── spellcheck-config.yml
@@ -4031,6 +4030,7 @@ Meridian-main
 │   │   └── README.md
 │   ├── Meridian.Instruments
 │   │   ├── AssetOperations
+│   │   │   ├── AssetObligationProjectionService.cs
 │   │   │   └── AssetOperationsReadService.cs
 │   │   ├── CertificatesOfDeposit
 │   │   │   ├── CertificateOfDepositProjectionService.cs
@@ -6689,7 +6689,8 @@ Meridian-main
 │   │   │   ├── OperationsContinuityPostgresRoundTripTests.cs
 │   │   │   ├── OperationsContinuityWorkflowServiceTests.cs
 │   │   │   ├── ReconciliationGovernanceServiceTests.cs
-│   │   │   └── ReconciliationRunServiceTests.cs
+│   │   │   ├── ReconciliationRunServiceTests.cs
+│   │   │   └── SecurityMasterCashFlowServiceTests.cs
 │   │   ├── Architecture
 │   │   │   ├── AccountingSemanticsBoundaryTests.cs
 │   │   │   └── LayerBoundaryTests.cs

--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -884,7 +884,6 @@ Meridian-main
 │   ├── labeler.yml
 │   ├── labels.yml
 │   ├── markdown-link-check-config.json
-│   ├── PULL_REQUEST_TEMPLATE.md
 │   ├── pull_request_template.md
 │   ├── pull_request_template_desktop.md
 │   └── spellcheck-config.yml
@@ -4029,6 +4028,7 @@ Meridian-main
 │   │   └── README.md
 │   ├── Meridian.Instruments
 │   │   ├── AssetOperations
+│   │   │   ├── AssetObligationProjectionService.cs
 │   │   │   └── AssetOperationsReadService.cs
 │   │   ├── CertificatesOfDeposit
 │   │   │   ├── CertificateOfDepositProjectionService.cs
@@ -6680,7 +6680,8 @@ Meridian-main
 │   │   │   ├── OperationsContinuityPostgresRoundTripTests.cs
 │   │   │   ├── OperationsContinuityWorkflowServiceTests.cs
 │   │   │   ├── ReconciliationGovernanceServiceTests.cs
-│   │   │   └── ReconciliationRunServiceTests.cs
+│   │   │   ├── ReconciliationRunServiceTests.cs
+│   │   │   └── SecurityMasterCashFlowServiceTests.cs
 │   │   ├── Architecture
 │   │   │   ├── AccountingSemanticsBoundaryTests.cs
 │   │   │   └── LayerBoundaryTests.cs

--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -884,6 +884,7 @@ Meridian-main
 │   ├── labeler.yml
 │   ├── labels.yml
 │   ├── markdown-link-check-config.json
+│   ├── PULL_REQUEST_TEMPLATE.md
 │   ├── pull_request_template.md
 │   ├── pull_request_template_desktop.md
 │   └── spellcheck-config.yml

--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -9,8 +9,8 @@
       "id": "SRC-APP",
       "path": "src/Meridian.Application",
       "readme": "src/Meridian.Application/README.md",
-      "readme_hash": "dc164eb556c8a2909642b6b2d77aaa858e08af4d6af5d3f0d3a2f948bd453c18",
-      "source_hash": "a1c906d4a1822fc6255923d974a36c9afd14f236e0142c6461275b9e863ca38b"
+      "readme_hash": "1d4da5a441f629475b24a38327489630ae138da5a3c1c1a51c642f4e4d698b5a",
+      "source_hash": "c018f793be944690236ca23dc72954dbe33108b730ea062b8552ca25dafd585e"
     },
     {
       "id": "SRC-BACKTESTING",
@@ -30,8 +30,8 @@
       "id": "SRC-CONTRACTS",
       "path": "src/Meridian.Contracts",
       "readme": "src/Meridian.Contracts/README.md",
-      "readme_hash": "60ff613e79568f059e32c82d55b326c1a6e2ca68aed50ab3a0d2602e1c428eeb",
-      "source_hash": "b9f964e05e48217232fcb315cbb5ba89c32ec33f294b284c92126d1962bdca18"
+      "readme_hash": "c8244d7a3e6e74fdb339c868f46f47899bc0491713d0e5bcfa84323487127a7c",
+      "source_hash": "f1bd2e89c9b777d9ec7825038d08f3a12055e34173be51b33f0250778c979c57"
     },
     {
       "id": "SRC-CORE",
@@ -86,8 +86,8 @@
       "id": "SRC-DESIGN-INSTRUMENTS",
       "path": "src/Meridian.Instruments",
       "readme": "src/Meridian.Instruments/README.md",
-      "readme_hash": "ff499f4abf1171607f39045dbdbc821135ed476721510002d43e8c8749cbcaec",
-      "source_hash": "3fd6b5c56203839d7267e047e7fae06e6e8c1522f91548b725b5a4ce5a9038f9"
+      "readme_hash": "ca50a8e4de342917fa1605de046e3dc19a9c86a30a978899e21d41fd9661823f",
+      "source_hash": "86e5882eb4cbf64806ba28bbff832215079874b0bcd369b22f6e0614e395c38c"
     },
     {
       "id": "SRC-DESIGN-PLATFORM",

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,7 +5,7 @@
 
 ## Overall Coverage
 
-**2642 / 7331** items documented (**36.0%**) &mdash; Grade: **F**
+**2643 / 7333** items documented (**36.0%**) &mdash; Grade: **F**
 
 ```text
 [=======-------------] 36.0%
@@ -15,7 +15,7 @@
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 2521 | 6835 | 36.9% | F |
+| Public Classes / Interfaces | 2522 | 6837 | 36.9% | F |
 | API Endpoints | 107 | 349 | 30.7% | F |
 | Configuration Options | 3 | 136 | 2.2% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |
@@ -23,7 +23,7 @@
 
 ## Undocumented Items
 
-### Public Classes / Interfaces (4314 undocumented)
+### Public Classes / Interfaces (4315 undocumented)
 
 | Item | Location |
 | ------ | ---------- |
@@ -77,7 +77,7 @@
 | `SecurityMasterActiveImportStatus` | `src/Meridian.Application/SecurityMaster/SecurityMasterIngestStatusService.cs:13` |
 | `SecurityMasterCompletedImportStatus` | `src/Meridian.Application/SecurityMaster/SecurityMasterIngestStatusService.cs:26` |
 | `ISecurityMasterIngestStatusService` | `src/Meridian.Application/SecurityMaster/SecurityMasterIngestStatusService.cs:41` |
-| ... and 4264 more | |
+| ... and 4265 more | |
 
 ### API Endpoints (242 undocumented)
 
@@ -193,7 +193,7 @@
 
 ## Recommendations
 
-1. **Public Classes / Interfaces**: 4314 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
+1. **Public Classes / Interfaces**: 4315 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
 2. **API Endpoints**: 242 endpoint(s) missing from `docs/reference/api-reference.md`. Run the endpoint audit and update the API reference table.
 3. **Configuration Options**: 133 config key(s) not found in `docs/generated/configuration-schema.md`. Re-run the configuration schema generator to synchronise.
 

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,7 +5,7 @@
 
 ## Overall Coverage
 
-**2634 / 7324** items documented (**36.0%**) &mdash; Grade: **F**
+**2635 / 7326** items documented (**36.0%**) &mdash; Grade: **F**
 
 ```text
 [=======-------------] 36.0%
@@ -15,7 +15,7 @@
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 2513 | 6828 | 36.8% | F |
+| Public Classes / Interfaces | 2514 | 6830 | 36.8% | F |
 | API Endpoints | 107 | 349 | 30.7% | F |
 | Configuration Options | 3 | 136 | 2.2% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |
@@ -23,7 +23,7 @@
 
 ## Undocumented Items
 
-### Public Classes / Interfaces (4315 undocumented)
+### Public Classes / Interfaces (4316 undocumented)
 
 | Item | Location |
 | ------ | ---------- |
@@ -77,7 +77,7 @@
 | `SecurityMasterActiveImportStatus` | `src/Meridian.Application/SecurityMaster/SecurityMasterIngestStatusService.cs:13` |
 | `SecurityMasterCompletedImportStatus` | `src/Meridian.Application/SecurityMaster/SecurityMasterIngestStatusService.cs:26` |
 | `ISecurityMasterIngestStatusService` | `src/Meridian.Application/SecurityMaster/SecurityMasterIngestStatusService.cs:41` |
-| ... and 4265 more | |
+| ... and 4266 more | |
 
 ### API Endpoints (242 undocumented)
 
@@ -193,7 +193,7 @@
 
 ## Recommendations
 
-1. **Public Classes / Interfaces**: 4315 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
+1. **Public Classes / Interfaces**: 4316 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
 2. **API Endpoints**: 242 endpoint(s) missing from `docs/reference/api-reference.md`. Run the endpoint audit and update the API reference table.
 3. **Configuration Options**: 133 config key(s) not found in `docs/generated/configuration-schema.md`. Re-run the configuration schema generator to synchronise.
 

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 539,
-  "total_lines": 89074,
+  "total_lines": 89089,
   "orphaned_count": 205,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2138,7 +2138,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7818,
+      "line_count": 7819,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -4098,7 +4098,7 @@
     },
     {
       "path": "src/Meridian.Application/README.md",
-      "line_count": 471,
+      "line_count": 475,
       "has_heading": true,
       "todo_count": 3,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -4130,7 +4130,7 @@
     },
     {
       "path": "src/Meridian.Contracts/README.md",
-      "line_count": 1338,
+      "line_count": 1344,
       "has_heading": true,
       "todo_count": 3,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -4258,7 +4258,7 @@
     },
     {
       "path": "src/Meridian.Instruments/README.md",
-      "line_count": 118,
+      "line_count": 122,
       "has_heading": true,
       "todo_count": 1,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 539,
-  "total_lines": 89089,
+  "total_lines": 89090,
   "orphaned_count": 205,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2138,7 +2138,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7819,
+      "line_count": 7820,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 538,
-  "total_lines": 88696,
+  "total_lines": 88711,
   "orphaned_count": 205,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -2138,7 +2138,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 7805,
+      "line_count": 7806,
       "has_heading": true,
       "todo_count": 9,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -4090,7 +4090,7 @@
     },
     {
       "path": "src/Meridian.Application/README.md",
-      "line_count": 471,
+      "line_count": 475,
       "has_heading": true,
       "todo_count": 3,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -4122,7 +4122,7 @@
     },
     {
       "path": "src/Meridian.Contracts/README.md",
-      "line_count": 1338,
+      "line_count": 1344,
       "has_heading": true,
       "todo_count": 3,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -4250,7 +4250,7 @@
     },
     {
       "path": "src/Meridian.Instruments/README.md",
-      "line_count": 118,
+      "line_count": 122,
       "has_heading": true,
       "todo_count": 1,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 539 |
-| Total lines | 89,074 |
+| Total lines | 89,089 |
 | Average file size (lines) | 165.3 |
 | Orphaned files | 205 |
 | Files without headings | 38 |

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 539 |
-| Total lines | 89,089 |
+| Total lines | 89,090 |
 | Average file size (lines) | 165.3 |
 | Orphaned files | 205 |
 | Files without headings | 38 |

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 538 |
-| Total lines | 88,696 |
+| Total lines | 88,711 |
 | Average file size (lines) | 164.9 |
 | Orphaned files | 205 |
 | Files without headings | 38 |

--- a/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
@@ -333,6 +333,7 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
         // Passport Workbench conflict-authority policy is storage-independent (pure precedence logic).
         services.TryAddSingleton<ISecurityMasterConflictAuthorityPolicy, SecurityMasterConflictAuthorityPolicy>();
         services.TryAddSingleton<IAssetOperationsProjectionStore, InMemoryAssetOperationsProjectionStore>();
+        services.TryAddSingleton<AssetObligationProjectionService>();
         services.TryAddSingleton<IAssetOperationsCommandService, AssetOperationsProjectionCommandService>();
         services.TryAddSingleton<IAssetOperationsQueryService, AssetOperationsReadService>();
 

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -6,7 +6,7 @@ module_id: SRC-APP
 path: src/Meridian.Application
 status: active
 owner_lane: Runtime Host
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-05
 ---
 
 # src/Meridian.Application
@@ -272,6 +272,10 @@ and UI presentation concerns in their owning layers.
   appends are routed through `SecurityMasterCorporateActionCommandService` so HTTP endpoints,
   imports, provider backfills, and future UI commands share the same validation, append, and
   structured audit path before the event store is touched.
+  `SecurityMasterCashFlowService` now generates deterministic calculated bullet and sinker
+  schedules from retained Security Master economic terms when provider-backed schedules are not
+  selected, so downstream Asset Operations views can present expected coupon/principal dates with
+  source-governed scenario posture instead of an empty calculated schedule.
   `SecurityMasterOperationalReadinessService` layers operational readiness on top of the shared
   asset-class catalog, validator registry, and governed profile catalog for equities, options,
   futures, FX, fixed income, direct loans, structured credit, private fund interests, private

--- a/src/Meridian.Application/SecurityMaster/SecurityMasterCashFlowService.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterCashFlowService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Storage.SecurityMaster;
 using Microsoft.Extensions.Logging;
@@ -91,20 +92,18 @@ public sealed class SecurityMasterCashFlowService : ISecurityMasterCashFlowServi
             return null;
         }
 
-        // Calculated types: return empty schedule — full math is handled by the ledger projector.
-        if (assignment.SourceKind is StructuredCashFlowSourceKind.CalculatedBullet
-            or StructuredCashFlowSourceKind.CalculatedSinker)
-        {
-            return new StructuredCashFlowProjectionDto(
-                securityId, assignment.SourceKind, scenario, DateTimeOffset.UtcNow, []);
-        }
-
         var security = await _queryService.GetByIdAsync(securityId, ct).ConfigureAwait(false);
         if (security is null)
         {
             _logger.LogWarning(
                 "Security {SecurityId} not found when retrieving cash flow projections.", securityId);
             return null;
+        }
+
+        if (assignment.SourceKind is StructuredCashFlowSourceKind.CalculatedBullet
+            or StructuredCashFlowSourceKind.CalculatedSinker)
+        {
+            return BuildCalculatedProjection(security, assignment.SourceKind, scenario);
         }
 
         var isin = security.Identifiers
@@ -125,10 +124,320 @@ public sealed class SecurityMasterCashFlowService : ISecurityMasterCashFlowServi
             securityId, isin, DateTimeOffset.UtcNow, scenario, ct).ConfigureAwait(false);
     }
 
+    private static StructuredCashFlowProjectionDto BuildCalculatedProjection(
+        SecurityDetailDto security,
+        StructuredCashFlowSourceKind sourceKind,
+        StructuredCashFlowScenario scenario)
+    {
+        var asOf = DateTimeOffset.UtcNow;
+        if (!TryReadDate(security, out var maturity, "maturityDate", "maturity", "legalFinalMaturity"))
+        {
+            return new StructuredCashFlowProjectionDto(security.SecurityId, sourceKind, scenario, asOf, []);
+        }
+
+        var issueDate = TryReadDate(security, out var issue, "issueDate", "originationDate", "effectiveDate")
+            ? issue
+            : DateOnly.FromDateTime(security.EffectiveFrom.UtcDateTime.Date);
+        var asOfDate = DateOnly.FromDateTime(asOf.UtcDateTime.Date);
+        if (issueDate > maturity)
+        {
+            return new StructuredCashFlowProjectionDto(security.SecurityId, sourceKind, scenario, asOf, []);
+        }
+
+        _ = TryReadDecimal(security, out var principalValue, "par", "originalFace", "notional", "principal", "principalAmount");
+        _ = TryReadDecimal(security, out var factorValue, "currentFactor", "factor");
+        _ = TryReadDecimal(security, out var couponValue, "fixedCouponRate", "couponRate", "coupon", "annualRate");
+        _ = TryReadString(security, out var frequencyValue, "paymentFrequency", "paymentFrequencyPerYear", "couponFrequency");
+        _ = TryReadString(security, out var dayCountValue, "dayCountConvention", "dayCount", "dayCountBasis");
+
+        var principalBasis = principalValue is > 0m ? principalValue.Value : 100m;
+        var factor = factorValue is > 0m ? factorValue.Value : 1m;
+        var outstanding = RoundCash(principalBasis * factor);
+        var annualRate = NormalizeAnnualRate(couponValue ?? 0m) + ScenarioRateShift(scenario);
+        if (annualRate < 0m)
+        {
+            annualRate = 0m;
+        }
+
+        var periodMonths = Math.Max(1, 12 / ResolvePaymentFrequencyPerYear(frequencyValue));
+        var dates = BuildPaymentDates(issueDate, maturity, periodMonths)
+            .Where(date => date >= asOfDate)
+            .ToArray();
+        if (dates.Length == 0)
+        {
+            return new StructuredCashFlowProjectionDto(security.SecurityId, sourceKind, scenario, asOf, []);
+        }
+
+        var entries = new List<StructuredCashFlowScheduleEntry>(dates.Length);
+        var accrualStart = issueDate;
+        var sinkerPrincipal = sourceKind == StructuredCashFlowSourceKind.CalculatedSinker
+            ? RoundCash(outstanding / dates.Length)
+            : 0m;
+        for (var i = 0; i < dates.Length; i++)
+        {
+            var date = dates[i];
+            while (accrualStart.AddMonths(periodMonths) < date)
+            {
+                accrualStart = accrualStart.AddMonths(periodMonths);
+            }
+
+            var interest = annualRate > 0m && outstanding > 0m
+                ? RoundCash(outstanding * annualRate * CalculateYearFraction(dayCountValue, accrualStart, date, periodMonths))
+                : 0m;
+            var principal = 0m;
+            var isLast = i == dates.Length - 1;
+            if (sourceKind == StructuredCashFlowSourceKind.CalculatedBullet && isLast)
+            {
+                principal = outstanding;
+            }
+            else if (sourceKind == StructuredCashFlowSourceKind.CalculatedSinker)
+            {
+                principal = isLast ? outstanding : decimal.Min(outstanding, sinkerPrincipal);
+            }
+
+            outstanding = RoundCash(outstanding - principal);
+            entries.Add(new StructuredCashFlowScheduleEntry(
+                ToUtcDateTimeOffset(date),
+                RoundCash(principal),
+                interest,
+                principalBasis == 0m ? 0m : RoundCash(outstanding / principalBasis)));
+            accrualStart = date;
+        }
+
+        return new StructuredCashFlowProjectionDto(security.SecurityId, sourceKind, scenario, asOf, entries);
+    }
+
     private static string MapSourceKindToProviderId(StructuredCashFlowSourceKind kind) => kind switch
     {
         StructuredCashFlowSourceKind.MIAC => "miac",
         StructuredCashFlowSourceKind.MoodysAnalytics => "moodys-analytics",
         _ => string.Empty
     };
+
+    private static IEnumerable<DateOnly> BuildPaymentDates(DateOnly issueDate, DateOnly maturity, int periodMonths)
+    {
+        var date = issueDate;
+        while (date < maturity)
+        {
+            date = date.AddMonths(periodMonths);
+            if (date > maturity)
+            {
+                date = maturity;
+            }
+
+            yield return date;
+        }
+    }
+
+    private static int ResolvePaymentFrequencyPerYear(string? paymentFrequency)
+    {
+        if (string.IsNullOrWhiteSpace(paymentFrequency))
+        {
+            return 1;
+        }
+
+        var normalized = paymentFrequency
+            .Replace("-", string.Empty, StringComparison.Ordinal)
+            .Replace("_", string.Empty, StringComparison.Ordinal)
+            .Replace(" ", string.Empty, StringComparison.Ordinal)
+            .Trim()
+            .ToUpperInvariant();
+        if (int.TryParse(normalized, out var parsed) && parsed > 0)
+        {
+            return Math.Clamp(parsed, 1, 12);
+        }
+
+        return normalized switch
+        {
+            "MONTHLY" => 12,
+            "QUARTERLY" => 4,
+            "SEMIANNUAL" or "SEMIANNUALLY" or "SEMIYEARLY" or "HALFYEARLY" => 2,
+            "ANNUAL" or "ANNUALLY" or "YEARLY" => 1,
+            _ => 1
+        };
+    }
+
+    private static decimal CalculateYearFraction(
+        string? dayCountConvention,
+        DateOnly accrualStart,
+        DateOnly accrualEnd,
+        int periodMonths)
+    {
+        if (accrualEnd <= accrualStart)
+        {
+            return 0m;
+        }
+
+        var normalized = dayCountConvention?.Replace(" ", string.Empty, StringComparison.Ordinal).ToUpperInvariant();
+        if (normalized is not null && normalized.Contains("30/360", StringComparison.OrdinalIgnoreCase))
+        {
+            return Days360(accrualStart, accrualEnd) / 360m;
+        }
+
+        var actualDays = accrualEnd.DayNumber - accrualStart.DayNumber;
+        if (normalized is not null && (normalized.Contains("ACT/360", StringComparison.OrdinalIgnoreCase) ||
+                                       normalized.Contains("ACTUAL/360", StringComparison.OrdinalIgnoreCase)))
+        {
+            return actualDays / 360m;
+        }
+
+        if (normalized is not null && (normalized.Contains("ACT/365", StringComparison.OrdinalIgnoreCase) ||
+                                       normalized.Contains("ACTUAL/365", StringComparison.OrdinalIgnoreCase)))
+        {
+            return actualDays / 365m;
+        }
+
+        return periodMonths / 12m;
+    }
+
+    private static decimal Days360(DateOnly start, DateOnly end)
+    {
+        var startDay = Math.Min(start.Day, 30);
+        var endDay = end.Day == 31 && startDay == 30 ? 30 : Math.Min(end.Day, 30);
+        return ((end.Year - start.Year) * 360m) + ((end.Month - start.Month) * 30m) + (endDay - startDay);
+    }
+
+    private static decimal NormalizeAnnualRate(decimal coupon)
+        => coupon > 1m ? coupon / 100m : coupon;
+
+    private static decimal ScenarioRateShift(StructuredCashFlowScenario scenario)
+        => scenario switch
+        {
+            StructuredCashFlowScenario.Up100 => 0.01m,
+            StructuredCashFlowScenario.Up200 => 0.02m,
+            StructuredCashFlowScenario.Up300 => 0.03m,
+            StructuredCashFlowScenario.Down100 => -0.01m,
+            StructuredCashFlowScenario.Down200 => -0.02m,
+            StructuredCashFlowScenario.Down300 => -0.03m,
+            StructuredCashFlowScenario.Stress => 0.03m,
+            _ => 0m
+        };
+
+    private static DateTimeOffset ToUtcDateTimeOffset(DateOnly date)
+        => new(date.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
+
+    private static decimal RoundCash(decimal amount)
+        => decimal.Round(amount, 4, MidpointRounding.AwayFromZero);
+
+    private static bool TryReadString(SecurityDetailDto security, out string? value, params string[] propertyNames)
+    {
+        foreach (var source in EnumerateTermSources(security))
+        {
+            foreach (var propertyName in propertyNames)
+            {
+                if (!TryGetProperty(source, propertyName, out var property))
+                {
+                    continue;
+                }
+
+                if (property.ValueKind == JsonValueKind.String)
+                {
+                    value = property.GetString();
+                    return !string.IsNullOrWhiteSpace(value);
+                }
+
+                if (property.ValueKind is JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False)
+                {
+                    value = property.ToString();
+                    return true;
+                }
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static bool TryReadDecimal(SecurityDetailDto security, out decimal? value, params string[] propertyNames)
+    {
+        foreach (var source in EnumerateTermSources(security))
+        {
+            foreach (var propertyName in propertyNames)
+            {
+                if (!TryGetProperty(source, propertyName, out var property))
+                {
+                    continue;
+                }
+
+                if (property.ValueKind == JsonValueKind.Number && property.TryGetDecimal(out var number))
+                {
+                    value = number;
+                    return true;
+                }
+
+                if (property.ValueKind == JsonValueKind.String &&
+                    decimal.TryParse(property.GetString(), out var parsed))
+                {
+                    value = parsed;
+                    return true;
+                }
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static bool TryReadDate(SecurityDetailDto security, out DateOnly value, params string[] propertyNames)
+    {
+        foreach (var source in EnumerateTermSources(security))
+        {
+            foreach (var propertyName in propertyNames)
+            {
+                if (!TryGetProperty(source, propertyName, out var property) ||
+                    property.ValueKind != JsonValueKind.String)
+                {
+                    continue;
+                }
+
+                var raw = property.GetString();
+                if (DateOnly.TryParse(raw, out value))
+                {
+                    return true;
+                }
+
+                if (DateTimeOffset.TryParse(raw, out var timestamp))
+                {
+                    value = DateOnly.FromDateTime(timestamp.UtcDateTime.Date);
+                    return true;
+                }
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static IEnumerable<JsonElement> EnumerateTermSources(SecurityDetailDto security)
+    {
+        yield return security.AssetSpecificTerms;
+        if (TryGetProperty(security.AssetSpecificTerms, "profileFields", out var profileFields) &&
+            profileFields.ValueKind == JsonValueKind.Object)
+        {
+            yield return profileFields;
+        }
+
+        yield return security.CommonTerms;
+    }
+
+    private static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement value)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            value = default;
+            return false;
+        }
+
+        foreach (var property in element.EnumerateObject())
+        {
+            if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                value = property.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
 }

--- a/src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs
+++ b/src/Meridian.Contracts/AssetOperations/AssetOperationsDtos.cs
@@ -143,7 +143,30 @@ public sealed record AssetTermsObligationTimelineEventDto(
     string? EvidenceLink,
     string? LedgerReferenceId,
     string Summary,
-    JsonElement? ExtensionPayload = null);
+    JsonElement? ExtensionPayload = null)
+{
+    public string? FormulaTrace { get; init; }
+
+    public string? LedgerReference { get; init; }
+
+    public string? NextAction { get; init; }
+}
+
+public sealed record AssetTimelineVarianceDto(
+    Guid VarianceId,
+    Guid SecurityId,
+    string EventKind,
+    DateOnly ExpectedDate,
+    DateOnly? ActualDate,
+    decimal? ExpectedAmount,
+    decimal? ActualAmount,
+    decimal? VarianceAmount,
+    string Currency,
+    string Status,
+    string SourceDomain,
+    string? SourceEntityId,
+    string Summary,
+    string? EvidenceLink = null);
 
 public sealed record AssetTermsObligationsTimelineDto(
     Guid SecurityId,
@@ -155,7 +178,12 @@ public sealed record AssetTermsObligationsTimelineDto(
     DateTimeOffset GeneratedAt,
     string SourceDomain,
     string? SourceEntityId,
-    JsonElement? ExtensionPayload = null);
+    JsonElement? ExtensionPayload = null)
+{
+    public string? AssetClass { get; init; }
+
+    public IReadOnlyList<AssetTimelineVarianceDto> Variances { get; init; } = [];
+}
 
 public sealed record AssetOperationsReadinessDto(
     Guid SecurityId,

--- a/src/Meridian.Contracts/README.md
+++ b/src/Meridian.Contracts/README.md
@@ -6,7 +6,7 @@ module_id: SRC-CONTRACTS
 path: src/Meridian.Contracts
 status: active
 owner_lane: Contract Compatibility
-last_reviewed: 2026-06-16
+last_reviewed: 2026-07-05
 ---
 
 # src/Meridian.Contracts
@@ -878,6 +878,12 @@ targets. `CustomAsset` rows remain available for profile-lineage, servicer/trust
 and obligation close-readiness compatibility coverage. Browser, WPF, and shared endpoint clients
 should render those rows as supplied instead of recalculating asset-class readiness, ledger
 coverage, reconciliation status, or close blockers locally.
+
+Asset Operations terms/obligations timeline contracts carry the shared projection view for
+expected cash flows, projected obligations, retained evidence posture, variances, ledger support,
+formula trace, and next action. Browser and WPF clients should render `AssetTermsObligationsTimelineDto`
+and its event/variance rows as supplied instead of rebuilding projection math or source-support
+rules in UI-specific DTOs.
 
 Brokerage sync activity payloads are fund-account scoped under `Workstation/BrokerageSyncDtos.cs`.
 Keep readiness and work-item decisions on `WorkstationBrokerageSyncStatusDto` and reserve

--- a/src/Meridian.Instruments/AssetOperations/AssetObligationProjectionService.cs
+++ b/src/Meridian.Instruments/AssetOperations/AssetObligationProjectionService.cs
@@ -1,0 +1,958 @@
+using System.Text.Json;
+using Meridian.Contracts.AssetOperations;
+using Meridian.Contracts.FixedIncome;
+using Meridian.Contracts.SecurityMaster;
+
+namespace Meridian.Instruments.AssetOperations;
+
+public sealed class AssetObligationProjectionService
+{
+    public const string EngineVersion = "asset-obligation-projection-v1";
+
+    private const string SecurityMasterSourceDomain = "SecurityMaster";
+
+    public AssetOperationsDetailDto ProjectFromSecurityMaster(SecurityDetailDto security)
+    {
+        ArgumentNullException.ThrowIfNull(security);
+
+        var generatedAt = DateTimeOffset.UtcNow;
+        var projectionAsOf = DateOnly.FromDateTime(generatedAt.UtcDateTime.Date);
+        var subject = BuildSubject(security);
+        var projectionRunId = Guid.NewGuid();
+        var terms = new[]
+        {
+            new AssetTermsVersionDto(
+                Guid.NewGuid(),
+                security.SecurityId,
+                checked((int)Math.Min(security.Version, int.MaxValue)),
+                $"security-master:{security.Version}",
+                DateOnly.FromDateTime(security.EffectiveFrom.UtcDateTime.Date),
+                generatedAt,
+                SecurityMasterSourceDomain,
+                security.SecurityId.ToString("D"),
+                $"{security.DisplayName} retained Security Master terms",
+                BuildSecurityMasterTermsPayload(security))
+        };
+        var lifecycle = new[]
+        {
+            new AssetLifecycleEventDto(
+                Guid.NewGuid(),
+                security.SecurityId,
+                "SecurityMasterStatus",
+                security.Status.ToString(),
+                DateOnly.FromDateTime(security.EffectiveFrom.UtcDateTime.Date),
+                generatedAt,
+                SecurityMasterSourceDomain,
+                security.SecurityId.ToString("D"),
+                $"Security Master subject is {security.Status}.",
+                JsonSerializer.SerializeToElement(new
+                {
+                    engineVersion = EngineVersion,
+                    security.Version,
+                    security.EffectiveFrom,
+                    security.EffectiveTo
+                }))
+        };
+        var run = new AssetCashFlowProjectionRunDto(
+            projectionRunId,
+            security.SecurityId,
+            projectionAsOf,
+            EngineVersion,
+            "Completed",
+            generatedAt,
+            SecurityMasterSourceDomain,
+            security.SecurityId.ToString("D"));
+        var flows = BuildProjectedCashFlowsFromSecurityTerms(security, projectionRunId).ToArray();
+        var ledger = BuildLedgerSupport(security, projectionAsOf, flows).ToArray();
+        var readyCapabilities = AssetOperationsProjectionBuilder.ReadyCapabilities(
+            subject.OperationalProfile,
+            terms,
+            lifecycle,
+            flows,
+            [],
+            [],
+            [],
+            ledger);
+        var readiness = AssetOperationsProjectionBuilder.BuildReadiness(
+            subject,
+            readyCapabilities,
+            SecurityMasterSourceDomain,
+            security.SecurityId.ToString("D"));
+
+        var detail = new AssetOperationsDetailDto(
+            subject,
+            terms,
+            lifecycle,
+            [run],
+            flows,
+            [],
+            [],
+            [],
+            ledger,
+            readiness,
+            lifecycle);
+        return AssetOperationsProjectionBuilder.WithTermsObligationsTimeline(detail);
+    }
+
+    public static IReadOnlyList<AssetTermsObligationTimelineEventDto> BuildProjectedObligationEvents(
+        AssetOperationSubjectDto subject,
+        IReadOnlyList<AssetTermsVersionDto> terms,
+        DateOnly projectionAsOf,
+        IReadOnlyList<AssetLedgerProjectionDto> ledgerProjections)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        ArgumentNullException.ThrowIfNull(terms);
+        ArgumentNullException.ThrowIfNull(ledgerProjections);
+
+        var term = terms
+            .OrderByDescending(static row => row.EffectiveDate)
+            .ThenByDescending(static row => row.RecordedAt)
+            .FirstOrDefault();
+        if (term?.ExtensionPayload is not { } payload || payload.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+        {
+            return [];
+        }
+
+        var events = new List<AssetTermsObligationTimelineEventDto>();
+        var currency = TryReadString(payload, out var currencyValue, "currency", "baseCurrency")
+            ? currencyValue!
+            : string.Empty;
+        var ledgerReference = ledgerProjections
+            .OrderBy(static row => row.AccountingDate)
+            .FirstOrDefault()?.LedgerReferenceId;
+
+        if (IsFixedIncome(subject.AssetClass))
+        {
+            AddFixedIncomeObligations(events, subject, term, payload, projectionAsOf, currency, ledgerReference);
+        }
+
+        if (IsDirectLoan(subject.AssetClass))
+        {
+            AddDirectLoanObligations(events, subject, term, payload, projectionAsOf, currency, ledgerReference);
+        }
+
+        if (IsPrivateFund(subject.AssetClass))
+        {
+            AddPrivateFundObligations(events, subject, term, payload, projectionAsOf, currency, ledgerReference);
+        }
+
+        if (IsStructuredOrCustom(subject.AssetClass))
+        {
+            AddStructuredOrCustomObligations(events, subject, term, payload, projectionAsOf, currency, ledgerReference);
+        }
+
+        return events
+            .OrderBy(static row => row.EffectiveDate)
+            .ThenBy(static row => row.EventLane)
+            .ThenBy(static row => row.EventKind)
+            .ToArray();
+    }
+
+    public static IReadOnlyList<AssetTimelineVarianceDto> BuildTimelineVariances(
+        AssetOperationSubjectDto subject,
+        IReadOnlyList<AssetProjectedCashFlowDto> projectedCashFlows,
+        IReadOnlyList<AssetActualActivityDto> actualActivity,
+        IReadOnlyList<AssetReconciliationResultDto> reconciliationResults,
+        DateOnly projectionAsOf)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        ArgumentNullException.ThrowIfNull(projectedCashFlows);
+        ArgumentNullException.ThrowIfNull(actualActivity);
+        ArgumentNullException.ThrowIfNull(reconciliationResults);
+
+        var variances = new List<AssetTimelineVarianceDto>();
+        foreach (var result in reconciliationResults.OrderBy(static row => row.ExpectedDate ?? row.ActualDate))
+        {
+            var expectedDate = result.ExpectedDate ?? result.ActualDate ?? projectionAsOf;
+            var dateMismatch = result.ExpectedDate.HasValue
+                && result.ActualDate.HasValue
+                && result.ExpectedDate.Value != result.ActualDate.Value;
+            var amountMismatch = result.VarianceAmount.HasValue && result.VarianceAmount.Value != 0m;
+            var reviewStatus = !string.Equals(result.MatchStatus, "Matched", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(result.MatchStatus, "Reconciled", StringComparison.OrdinalIgnoreCase);
+
+            if (!dateMismatch && !amountMismatch && !reviewStatus)
+            {
+                continue;
+            }
+
+            variances.Add(new AssetTimelineVarianceDto(
+                Guid.NewGuid(),
+                subject.SecurityId,
+                "CashFlowVariance",
+                expectedDate,
+                result.ActualDate,
+                result.ExpectedAmount,
+                result.ActualAmount,
+                result.VarianceAmount,
+                string.Empty,
+                result.MatchStatus,
+                result.SourceDomain,
+                result.SourceEntityId,
+                BuildVarianceSummary(result),
+                result.EvidenceLink));
+        }
+
+        foreach (var flow in projectedCashFlows.Where(flow => flow.DueDate < projectionAsOf))
+        {
+            var hasReconciliation = reconciliationResults.Any(result =>
+                result.ExpectedDate == flow.DueDate ||
+                (result.ExpectedAmount.HasValue && RoundCash(result.ExpectedAmount.Value) == RoundCash(flow.Amount)));
+            if (hasReconciliation)
+            {
+                continue;
+            }
+
+            var hasActual = actualActivity.Any(activity =>
+                activity.EffectiveDate == flow.DueDate &&
+                RoundCash(activity.Amount) == RoundCash(flow.Amount));
+            if (hasActual)
+            {
+                continue;
+            }
+
+            variances.Add(new AssetTimelineVarianceDto(
+                Guid.NewGuid(),
+                subject.SecurityId,
+                NormalizeVarianceEventKind(flow.FlowType),
+                flow.DueDate,
+                null,
+                flow.Amount,
+                null,
+                null,
+                flow.Currency,
+                "MissingEvidence",
+                flow.SourceDomain ?? "AssetOperations",
+                flow.SourceEntityId,
+                $"{flow.FlowType} expected on {flow.DueDate:yyyy-MM-dd} has no retained actual activity or reconciliation evidence."));
+        }
+
+        return variances
+            .OrderBy(static row => row.ExpectedDate)
+            .ThenBy(static row => row.EventKind)
+            .ToArray();
+    }
+
+    private static AssetOperationSubjectDto BuildSubject(SecurityDetailDto security)
+        => new(
+            security.SecurityId,
+            security.AssetClass,
+            security.DisplayName,
+            ResolvePrimaryIdentifier(security.Identifiers),
+            SecurityAssetClassCatalog.GetAssetOperationsCapabilities(security.AssetClass));
+
+    private static IEnumerable<AssetProjectedCashFlowDto> BuildProjectedCashFlowsFromSecurityTerms(
+        SecurityDetailDto security,
+        Guid projectionRunId)
+    {
+        if (!IsFixedIncome(security.AssetClass))
+        {
+            yield break;
+        }
+
+        var reference = BuildFixedIncomeReference(security);
+        if (reference is null)
+        {
+            yield break;
+        }
+
+        foreach (var flow in AssetOperationsProjectionBuilder.ProjectFixedIncomeCashFlows(reference, projectionRunId))
+        {
+            yield return flow;
+        }
+    }
+
+    private static IEnumerable<AssetLedgerProjectionDto> BuildLedgerSupport(
+        SecurityDetailDto security,
+        DateOnly projectionAsOf,
+        IReadOnlyList<AssetProjectedCashFlowDto> flows)
+    {
+        if (!SecurityAssetClassCatalog
+            .GetAssetOperationsCapabilities(security.AssetClass)
+            .Contains("LedgerProjection", StringComparer.OrdinalIgnoreCase))
+        {
+            yield break;
+        }
+
+        yield return new AssetLedgerProjectionDto(
+            Guid.NewGuid(),
+            security.SecurityId,
+            "AssetObligationLedgerSupport",
+            flows.OrderBy(static flow => flow.DueDate).FirstOrDefault()?.DueDate ?? projectionAsOf,
+            "Primary",
+            flows.Count == 0 ? "ManualReview" : "Draftable",
+            null,
+            null,
+            security.Currency,
+            EngineVersion,
+            security.SecurityId.ToString("D"),
+            $"security-master:{security.SecurityId:D}");
+    }
+
+    private static BondReferenceDto? BuildFixedIncomeReference(SecurityDetailDto security)
+    {
+        var payload = BuildSecurityMasterTermsPayload(security);
+        if (!TryReadDate(payload, out var maturity, "maturityDate", "maturity", "legalFinalMaturity"))
+        {
+            return null;
+        }
+
+        var issueDate = TryReadDate(payload, out var issueDateValue, "issueDate", "originationDate", "effectiveDate")
+            ? issueDateValue
+            : DateOnly.FromDateTime(security.EffectiveFrom.UtcDateTime.Date);
+        _ = TryReadDecimal(payload, out var par, "par", "originalFace", "notional", "principal", "principalAmount");
+        _ = TryReadString(payload, out var paymentFrequency, "paymentFrequency", "paymentFrequencyPerYear", "couponFrequency");
+        _ = TryReadDecimal(payload, out var couponRate, "fixedCouponRate", "couponRate", "coupon", "annualRate");
+        _ = TryReadString(payload, out var dayCount, "dayCountConvention", "dayCount", "dayCountBasis");
+        _ = TryReadDecimal(payload, out var factor, "currentFactor", "factor");
+        _ = TryReadString(payload, out var issuerName, "issuerName", "issuer", "gpSponsor");
+
+        return new BondReferenceDto(
+            security.SecurityId,
+            security.DisplayName,
+            security.Currency,
+            issuerName,
+            null,
+            ResolvePrimaryIdentifier(security.Identifiers) ?? security.SecurityId.ToString("D"),
+            new BondLifecycleDto(
+                security.SecurityId,
+                security.Status == SecurityStatusDto.Active ? BondLifecycleStat.Active : BondLifecycleStat.Retired,
+                issueDate,
+                TryReadDate(payload, out var callDate, "callDate") ? callDate : null,
+                maturity,
+                TryReadDate(payload, out _, "callDate"),
+                security.Version,
+                par,
+                PaymentFrequency: paymentFrequency),
+            couponRate is null
+                ? null
+                : new BondAccrualConventionDto(
+                    security.SecurityId,
+                    dayCount,
+                    null,
+                    null,
+                    "Fixed",
+                    couponRate,
+                    null,
+                    null,
+                    security.Version),
+            security.Version,
+            InflationLinked: factor is null
+                ? null
+                : new BondInflationLinkedDto(
+                    security.SecurityId,
+                    null,
+                    null,
+                    null,
+                    factor,
+                    TryReadDate(payload, out var factorDate, "factorDate", "currentFactorDate") ? factorDate : null,
+                    null,
+                    security.Version));
+    }
+
+    private static void AddFixedIncomeObligations(
+        List<AssetTermsObligationTimelineEventDto> events,
+        AssetOperationSubjectDto subject,
+        AssetTermsVersionDto term,
+        JsonElement payload,
+        DateOnly projectionAsOf,
+        string currency,
+        string? ledgerReference)
+    {
+        if (TryReadDate(payload, out var callDate, "callDate", "mandatoryPutDate", "preRefundDate") && callDate >= projectionAsOf)
+        {
+            events.Add(BuildObligationEvent(
+                subject,
+                term,
+                "CallPutReview",
+                "Obligations",
+                callDate,
+                currency,
+                "Review callable, put, or pre-refund terms before the contractual option date.",
+                "Security Master call/put date retained in economic terms.",
+                ledgerReference,
+                "Review option exercise and downstream ledger treatment."));
+        }
+
+        if (IsStructuredOrCustom(subject.AssetClass) ||
+            TryReadDecimal(payload, out _, "currentFactor", "factor") ||
+            TryReadString(payload, out _, "factorSchedule", "factorSource"))
+        {
+            events.Add(BuildObligationEvent(
+                subject,
+                term,
+                "FactorUpdate",
+                "Obligations",
+                NextMonthlyDate(projectionAsOf),
+                currency,
+                "Retain factor update evidence before principal/paydown support is treated as current.",
+                "Factor update cadence inferred from retained structured/factor terms.",
+                ledgerReference,
+                "Attach provider, trustee, or client-approved factor evidence."));
+        }
+
+        events.Add(BuildObligationEvent(
+            subject,
+            term,
+            "CorporateActionCheckpoint",
+            "Evidence",
+            NextMonthlyDate(projectionAsOf),
+            currency,
+            "Check provider corporate-action evidence before close and posting support.",
+            "Monthly corporate-action checkpoint generated for fixed-income schedule support.",
+            ledgerReference,
+            "Review corporate-action and lifecycle evidence."));
+    }
+
+    private static void AddDirectLoanObligations(
+        List<AssetTermsObligationTimelineEventDto> events,
+        AssetOperationSubjectDto subject,
+        AssetTermsVersionDto term,
+        JsonElement payload,
+        DateOnly projectionAsOf,
+        string currency,
+        string? ledgerReference)
+    {
+        var nextPayment = NextFrequencyDate(
+            projectionAsOf,
+            TryReadString(payload, out var frequency, "paymentFrequency") ? frequency : null);
+        if (TryReadString(payload, out _, "covenantsJson", "covenantSchedule", "covenants"))
+        {
+            events.Add(BuildObligationEvent(
+                subject,
+                term,
+                "CovenantTest",
+                "Obligations",
+                NextQuarterDate(projectionAsOf),
+                currency,
+                "Run covenant test and retain borrower support before treating loan support as current.",
+                "Covenant obligation inferred from retained direct-lending covenant terms.",
+                ledgerReference,
+                "Collect borrower covenant package and record test result."));
+        }
+
+        if (TryReadString(payload, out var rateType, "rateTypeKind", "rateType") &&
+            string.Equals(rateType, "Floating", StringComparison.OrdinalIgnoreCase))
+        {
+            events.Add(BuildObligationEvent(
+                subject,
+                term,
+                "RateReset",
+                "Obligations",
+                nextPayment,
+                currency,
+                "Reset floating-rate terms from retained index evidence.",
+                "Rate reset generated from floating-rate direct-lending terms.",
+                ledgerReference,
+                "Attach index observation and approve the reset."));
+        }
+
+        if (TryReadDecimal(payload, out var commitmentFeeRate, "commitmentFeeRate") && commitmentFeeRate > 0m)
+        {
+            events.Add(BuildObligationEvent(
+                subject,
+                term,
+                "CommitmentFee",
+                "CashFlow",
+                nextPayment,
+                currency,
+                "Project commitment-fee collection/review from retained unfunded commitment terms.",
+                $"commitment fee = unfunded commitment x {commitmentFeeRate:P4} x day-count fraction",
+                ledgerReference,
+                "Review fee accrual and cash evidence."));
+        }
+
+        if (TryReadDate(payload, out var maturity, "maturityDate") && maturity > projectionAsOf)
+        {
+            events.Add(BuildObligationEvent(
+                subject,
+                term,
+                "BorrowerNotice",
+                "Obligations",
+                maturity.AddDays(-10),
+                currency,
+                "Send or retain borrower maturity notice before the final principal date.",
+                "Notice date generated ten days before retained maturity.",
+                ledgerReference,
+                "Retain borrower notice evidence."));
+        }
+    }
+
+    private static void AddPrivateFundObligations(
+        List<AssetTermsObligationTimelineEventDto> events,
+        AssetOperationSubjectDto subject,
+        AssetTermsVersionDto term,
+        JsonElement payload,
+        DateOnly projectionAsOf,
+        string currency,
+        string? ledgerReference)
+    {
+        var navDate = TryReadDate(payload, out var retainedNavDate, "navDate", "valuationDate")
+            ? retainedNavDate
+            : projectionAsOf;
+        var nextStatementDate = AdvanceAfter(navDate, projectionAsOf, 3);
+        _ = TryReadDecimal(payload, out var unfundedCommitment, "unfundedAmount", "unfundedCommitment");
+
+        events.Add(BuildObligationEvent(
+            subject,
+            term,
+            "NavStatement",
+            "Evidence",
+            nextStatementDate,
+            currency,
+            "Expected NAV statement from administrator or GP.",
+            "Quarterly NAV statement cadence inferred from retained NAV date.",
+            ledgerReference,
+            "Attach administrator or GP NAV statement."));
+        events.Add(BuildObligationEvent(
+            subject,
+            term,
+            "CapitalAccountStatement",
+            "Evidence",
+            nextStatementDate,
+            currency,
+            "Expected capital-account statement support.",
+            "Quarterly capital-account statement cadence inferred from retained private-fund terms.",
+            ledgerReference,
+            "Attach capital-account statement and reconcile activity."));
+        events.Add(BuildObligationEvent(
+            subject,
+            term,
+            "UnfundedCommitmentReview",
+            "Obligations",
+            NextQuarterDate(projectionAsOf),
+            currency,
+            "Review unfunded commitment exposure and related close support.",
+            "Unfunded commitment review generated from retained commitment terms.",
+            ledgerReference,
+            "Confirm unfunded commitment and update close blockers.",
+            expectedAmount: unfundedCommitment));
+        events.Add(BuildObligationEvent(
+            subject,
+            term,
+            "CapitalCallEvidenceSlot",
+            "Evidence",
+            projectionAsOf.AddDays(30),
+            currency,
+            "Reserve evidence slot for capital-call notices.",
+            "Capital-call evidence slot generated because amount/date may be unknown until GP notice arrives.",
+            ledgerReference,
+            "Attach GP notice when received."));
+        events.Add(BuildObligationEvent(
+            subject,
+            term,
+            "DistributionEvidenceSlot",
+            "Evidence",
+            projectionAsOf.AddDays(30),
+            currency,
+            "Reserve evidence slot for distribution notices.",
+            "Distribution evidence slot generated because amount/date may be unknown until GP notice arrives.",
+            ledgerReference,
+            "Attach distribution notice when received."));
+    }
+
+    private static void AddStructuredOrCustomObligations(
+        List<AssetTermsObligationTimelineEventDto> events,
+        AssetOperationSubjectDto subject,
+        AssetTermsVersionDto term,
+        JsonElement payload,
+        DateOnly projectionAsOf,
+        string currency,
+        string? ledgerReference)
+    {
+        if (string.Equals(subject.AssetClass, "StructuredCredit", StringComparison.OrdinalIgnoreCase))
+        {
+            events.Add(BuildObligationEvent(
+                subject,
+                term,
+                "TrusteeReport",
+                "Evidence",
+                NextMonthlyDate(projectionAsOf),
+                currency,
+                "Expected trustee or servicer report for structured-credit support.",
+                "Monthly trustee-report cadence generated for structured-credit terms.",
+                ledgerReference,
+                "Attach trustee or servicer report."));
+            events.Add(BuildObligationEvent(
+                subject,
+                term,
+                "CollateralTape",
+                "Evidence",
+                NextMonthlyDate(projectionAsOf),
+                currency,
+                "Expected collateral tape before factor and valuation support is current.",
+                "Monthly collateral-tape cadence generated for structured-credit terms.",
+                ledgerReference,
+                "Attach collateral tape and resolve validation issues."));
+            events.Add(BuildObligationEvent(
+                subject,
+                term,
+                "FactorUpdate",
+                "Obligations",
+                NextMonthlyDate(projectionAsOf),
+                currency,
+                "Expected factor update for paydown, valuation, and ledger support.",
+                "Factor update generated from structured-credit factor terms.",
+                ledgerReference,
+                "Retain current factor evidence."));
+        }
+
+        events.Add(BuildObligationEvent(
+            subject,
+            term,
+            "ValuationReview",
+            "Obligations",
+            NextQuarterDate(projectionAsOf),
+            currency,
+            "Review valuation support before treating downstream close support as ready.",
+            "Quarterly valuation review generated from retained asset terms.",
+            ledgerReference,
+            "Attach valuation support or record review blocker."));
+
+        if (string.Equals(subject.AssetClass, "CustomAsset", StringComparison.OrdinalIgnoreCase) ||
+            TryReadString(payload, out _, "customProfileId"))
+        {
+            events.Add(BuildObligationEvent(
+                subject,
+                term,
+                "CustomProfileEvidenceReview",
+                "Obligations",
+                NextQuarterDate(projectionAsOf),
+                currency,
+                "Review custom-profile evidence and approved field lineage.",
+                "Custom profile review generated from retained profile-backed terms.",
+                ledgerReference,
+                "Confirm profile evidence and close blockers."));
+            events.Add(BuildObligationEvent(
+                subject,
+                term,
+                "ObligationCloseEvidence",
+                "Handoff",
+                NextQuarterDate(projectionAsOf),
+                currency,
+                "Confirm close evidence before downstream ledger or reporting support consumes the asset.",
+                "Close-evidence handoff generated from governed custom asset terms.",
+                ledgerReference,
+                "Resolve close blockers or mark manual review."));
+        }
+    }
+
+    private static AssetTermsObligationTimelineEventDto BuildObligationEvent(
+        AssetOperationSubjectDto subject,
+        AssetTermsVersionDto term,
+        string eventKind,
+        string lane,
+        DateOnly dueDate,
+        string currency,
+        string summary,
+        string formulaTrace,
+        string? ledgerReference,
+        string nextAction,
+        decimal? expectedAmount = null)
+    {
+        var status = dueDate < DateOnly.FromDateTime(DateTime.UtcNow.Date)
+            ? "MissingEvidence"
+            : "Projected";
+        return new AssetTermsObligationTimelineEventDto(
+            Guid.NewGuid(),
+            subject.SecurityId,
+            eventKind,
+            lane,
+            dueDate,
+            null,
+            null,
+            null,
+            expectedAmount,
+            null,
+            null,
+            currency,
+            status,
+            term.SourceDomain,
+            term.SourceEntityId,
+            null,
+            ledgerReference,
+            summary,
+            JsonSerializer.SerializeToElement(new
+            {
+                engineVersion = EngineVersion,
+                termsVersionId = term.TermsVersionId,
+                term.VersionNumber,
+                obligationKind = eventKind
+            }))
+        {
+            FormulaTrace = formulaTrace,
+            LedgerReference = ledgerReference,
+            NextAction = status == "MissingEvidence" ? $"Past due: {nextAction}" : nextAction
+        };
+    }
+
+    private static JsonElement BuildSecurityMasterTermsPayload(SecurityDetailDto security)
+        => JsonSerializer.SerializeToElement(new
+        {
+            engineVersion = EngineVersion,
+            security.AssetClass,
+            security.Currency,
+            security.Version,
+            security.EffectiveFrom,
+            security.EffectiveTo,
+            security.CommonTerms,
+            security.AssetSpecificTerms
+        });
+
+    private static bool IsFixedIncome(string? assetClass)
+        => assetClass is not null &&
+           (string.Equals(assetClass, "Bond", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(assetClass, "TreasuryBill", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(assetClass, "CommercialPaper", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(assetClass, "CertificateOfDeposit", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(assetClass, "StructuredCredit", StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsDirectLoan(string? assetClass)
+        => string.Equals(assetClass, "DirectLoan", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsPrivateFund(string? assetClass)
+        => string.Equals(assetClass, "PrivateFundInterest", StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(assetClass, "PrivateFund", StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(assetClass, "PartnershipInterest", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsStructuredOrCustom(string? assetClass)
+        => string.Equals(assetClass, "StructuredCredit", StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(assetClass, "CustomAsset", StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(assetClass, "RealEstateHolding", StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(assetClass, "CommitmentGuarantee", StringComparison.OrdinalIgnoreCase);
+
+    private static string? ResolvePrimaryIdentifier(IReadOnlyList<SecurityIdentifierDto> identifiers)
+    {
+        var primary = identifiers.FirstOrDefault(static identifier => identifier.IsPrimary)
+            ?? identifiers.FirstOrDefault();
+        return primary is null ? null : $"{primary.Kind}:{primary.Value}";
+    }
+
+    private static DateOnly NextMonthlyDate(DateOnly asOf)
+    {
+        var monthStart = new DateOnly(asOf.Year, asOf.Month, 1);
+        return monthStart.AddMonths(1);
+    }
+
+    private static DateOnly NextQuarterDate(DateOnly asOf)
+    {
+        var quarterStartMonth = (((asOf.Month - 1) / 3) * 3) + 1;
+        var next = new DateOnly(asOf.Year, quarterStartMonth, 1);
+        while (next <= asOf)
+        {
+            next = next.AddMonths(3);
+        }
+
+        return next;
+    }
+
+    private static DateOnly NextFrequencyDate(DateOnly asOf, string? paymentFrequency)
+    {
+        var months = NormalizeFrequencyMonths(paymentFrequency);
+        return asOf.AddMonths(months);
+    }
+
+    private static DateOnly AdvanceAfter(DateOnly anchor, DateOnly asOf, int months)
+    {
+        var next = anchor;
+        while (next <= asOf)
+        {
+            next = next.AddMonths(months);
+        }
+
+        return next;
+    }
+
+    private static int NormalizeFrequencyMonths(string? paymentFrequency)
+    {
+        if (string.IsNullOrWhiteSpace(paymentFrequency))
+        {
+            return 3;
+        }
+
+        var normalized = paymentFrequency
+            .Replace("-", string.Empty, StringComparison.Ordinal)
+            .Replace("_", string.Empty, StringComparison.Ordinal)
+            .Replace(" ", string.Empty, StringComparison.Ordinal)
+            .Trim()
+            .ToUpperInvariant();
+        if (int.TryParse(normalized, out var periodsPerYear) && periodsPerYear > 0)
+        {
+            return Math.Max(1, 12 / Math.Clamp(periodsPerYear, 1, 12));
+        }
+
+        return normalized switch
+        {
+            "MONTHLY" => 1,
+            "QUARTERLY" => 3,
+            "SEMIANNUAL" or "SEMIANNUALLY" or "SEMIYEARLY" => 6,
+            "ANNUAL" or "ANNUALLY" or "YEARLY" => 12,
+            "BULLET" => 12,
+            _ => 3
+        };
+    }
+
+    private static bool TryReadString(JsonElement payload, out string? value, params string[] propertyNames)
+    {
+        foreach (var candidate in EnumerateTermSources(payload))
+        {
+            foreach (var propertyName in propertyNames)
+            {
+                if (!TryGetProperty(candidate, propertyName, out var property))
+                {
+                    continue;
+                }
+
+                if (property.ValueKind == JsonValueKind.String)
+                {
+                    value = property.GetString();
+                    return !string.IsNullOrWhiteSpace(value);
+                }
+
+                if (property.ValueKind is JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False)
+                {
+                    value = property.ToString();
+                    return true;
+                }
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static bool TryReadDecimal(JsonElement payload, out decimal? value, params string[] propertyNames)
+    {
+        foreach (var candidate in EnumerateTermSources(payload))
+        {
+            foreach (var propertyName in propertyNames)
+            {
+                if (!TryGetProperty(candidate, propertyName, out var property))
+                {
+                    continue;
+                }
+
+                if (property.ValueKind == JsonValueKind.Number && property.TryGetDecimal(out var number))
+                {
+                    value = number;
+                    return true;
+                }
+
+                if (property.ValueKind == JsonValueKind.String &&
+                    decimal.TryParse(property.GetString(), out var parsed))
+                {
+                    value = parsed;
+                    return true;
+                }
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static bool TryReadDate(JsonElement payload, out DateOnly value, params string[] propertyNames)
+    {
+        foreach (var candidate in EnumerateTermSources(payload))
+        {
+            foreach (var propertyName in propertyNames)
+            {
+                if (!TryGetProperty(candidate, propertyName, out var property))
+                {
+                    continue;
+                }
+
+                if (property.ValueKind == JsonValueKind.String)
+                {
+                    var raw = property.GetString();
+                    if (DateOnly.TryParse(raw, out value))
+                    {
+                        return true;
+                    }
+
+                    if (DateTimeOffset.TryParse(raw, out var timestamp))
+                    {
+                        value = DateOnly.FromDateTime(timestamp.UtcDateTime.Date);
+                        return true;
+                    }
+                }
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static IEnumerable<JsonElement> EnumerateTermSources(JsonElement payload)
+    {
+        if (payload.ValueKind != JsonValueKind.Object)
+        {
+            yield break;
+        }
+
+        yield return payload;
+        if (TryGetProperty(payload, "assetSpecificTerms", out var assetSpecificTerms) &&
+            assetSpecificTerms.ValueKind == JsonValueKind.Object)
+        {
+            yield return assetSpecificTerms;
+            if (TryGetProperty(assetSpecificTerms, "profileFields", out var profileFields) &&
+                profileFields.ValueKind == JsonValueKind.Object)
+            {
+                yield return profileFields;
+            }
+        }
+
+        if (TryGetProperty(payload, "commonTerms", out var commonTerms) &&
+            commonTerms.ValueKind == JsonValueKind.Object)
+        {
+            yield return commonTerms;
+        }
+    }
+
+    private static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement value)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            value = default;
+            return false;
+        }
+
+        foreach (var property in element.EnumerateObject())
+        {
+            if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                value = property.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static string BuildVarianceSummary(AssetReconciliationResultDto result)
+    {
+        if (result.VarianceAmount.HasValue && result.VarianceAmount.Value != 0m)
+        {
+            return $"Expected {result.ExpectedAmount} but actual evidence retained {result.ActualAmount}; variance {result.VarianceAmount}.";
+        }
+
+        if (result.ExpectedDate.HasValue && result.ActualDate.HasValue && result.ExpectedDate.Value != result.ActualDate.Value)
+        {
+            return $"Expected date {result.ExpectedDate:yyyy-MM-dd} differs from actual date {result.ActualDate:yyyy-MM-dd}.";
+        }
+
+        return $"Reconciliation status is {result.MatchStatus}.";
+    }
+
+    private static string NormalizeVarianceEventKind(string flowType)
+        => flowType switch
+        {
+            "Maturity" => "PrincipalMaturityMissing",
+            "Principal" => "PrincipalRepaymentMissing",
+            _ => $"{flowType}Missing"
+        };
+
+    private static decimal RoundCash(decimal amount)
+        => decimal.Round(amount, 4, MidpointRounding.AwayFromZero);
+}

--- a/src/Meridian.Instruments/AssetOperations/AssetOperationsReadService.cs
+++ b/src/Meridian.Instruments/AssetOperations/AssetOperationsReadService.cs
@@ -13,15 +13,18 @@ public sealed class AssetOperationsReadService : IAssetOperationsQueryService
     private readonly IAssetOperationsProjectionStore? _projectionStore;
     private readonly ISecurityMasterQueryService? _securityMasterQueryService;
     private readonly IBondReferenceService? _bondReferenceService;
+    private readonly AssetObligationProjectionService _obligationProjectionService;
 
     public AssetOperationsReadService(
         IAssetOperationsProjectionStore? projectionStore = null,
         ISecurityMasterQueryService? securityMasterQueryService = null,
-        IBondReferenceService? bondReferenceService = null)
+        IBondReferenceService? bondReferenceService = null,
+        AssetObligationProjectionService? obligationProjectionService = null)
     {
         _projectionStore = projectionStore;
         _securityMasterQueryService = securityMasterQueryService;
         _bondReferenceService = bondReferenceService;
+        _obligationProjectionService = obligationProjectionService ?? new AssetObligationProjectionService();
     }
 
     public async Task<AssetOperationsDetailDto?> GetOperationsAsync(Guid securityId, CancellationToken ct = default)
@@ -46,7 +49,7 @@ public sealed class AssetOperationsReadService : IAssetOperationsQueryService
 
         return string.Equals(security.AssetClass, "Bond", StringComparison.OrdinalIgnoreCase)
             ? await BuildBondOperationsAsync(security, ct).ConfigureAwait(false)
-            : BuildIdentityOnlyOperations(security);
+            : _obligationProjectionService.ProjectFromSecurityMaster(security);
     }
 
     public async Task<AssetOperationsReadinessDto?> GetReadinessAsync(Guid securityId, CancellationToken ct = default)
@@ -62,7 +65,7 @@ public sealed class AssetOperationsReadService : IAssetOperationsQueryService
             : await _bondReferenceService.GetReferenceAsync(security.SecurityId, ct).ConfigureAwait(false);
         if (bond is null)
         {
-            return BuildIdentityOnlyOperations(security);
+            return _obligationProjectionService.ProjectFromSecurityMaster(security);
         }
 
         return AssetOperationsProjectionBuilder.FromBondReference(bond, BuildSubject(security));
@@ -168,7 +171,8 @@ public static class AssetOperationsProjectionBuilder
             version.RecordedAt,
             "DirectLending",
             contract.LoanId.ToString("D"),
-            $"{contract.FacilityName} terms version {version.VersionNumber}")).ToArray();
+            $"{contract.FacilityName} terms version {version.VersionNumber}",
+            BuildDirectLendingTermsPayload(contract, version.Terms))).ToArray();
         var lifecycle = new[]
         {
             new AssetLifecycleEventDto(
@@ -291,9 +295,10 @@ public static class AssetOperationsProjectionBuilder
                 $"bond-reference:{bond.Version}",
                 bond.Lifecycle?.IssueDate ?? DateOnly.FromDateTime(DateTime.UtcNow.Date),
                 DateTimeOffset.UtcNow,
-                "SecurityMaster",
-                subject.SecurityId.ToString("D"),
-                $"{bond.DisplayName} maturity/coupon reference terms")
+            "SecurityMaster",
+            subject.SecurityId.ToString("D"),
+            $"{bond.DisplayName} maturity/coupon reference terms",
+            BuildBondTermsPayload(bond))
         };
         IReadOnlyList<AssetLifecycleEventDto> lifecycle = bond.Lifecycle is null
             ? []
@@ -320,7 +325,7 @@ public static class AssetOperationsProjectionBuilder
             DateTimeOffset.UtcNow,
             "SecurityMaster",
             subject.SecurityId.ToString("D"));
-        var flows = BuildBondProjectedCashFlows(bond, projectionRunId).ToArray();
+        var flows = ProjectFixedIncomeCashFlows(bond, projectionRunId).ToArray();
         var ledger = new[]
         {
             new AssetLedgerProjectionDto(
@@ -354,6 +359,11 @@ public static class AssetOperationsProjectionBuilder
             lifecycle);
         return WithTermsObligationsTimeline(detail);
     }
+
+    internal static IReadOnlyList<AssetProjectedCashFlowDto> ProjectFixedIncomeCashFlows(
+        BondReferenceDto bond,
+        Guid projectionRunId)
+        => BuildBondProjectedCashFlows(bond, projectionRunId).ToArray();
 
     private static IEnumerable<AssetProjectedCashFlowDto> BuildBondProjectedCashFlows(BondReferenceDto bond, Guid projectionRunId)
     {
@@ -596,8 +606,19 @@ public static class AssetOperationsProjectionBuilder
                 reconciliation?.EvidenceLink ?? activity?.EvidenceLink,
                 ledgerProjection?.LedgerReferenceId,
                 BuildCashFlowTimelineSummary(flow, status),
-                BuildTimelineFlowPayload(flow, reconciliation, activity, ledgerProjection)));
+                BuildTimelineFlowPayload(flow, reconciliation, activity, ledgerProjection))
+            {
+                FormulaTrace = BuildCashFlowFormulaTrace(flow),
+                LedgerReference = ledgerProjection?.LedgerReferenceId,
+                NextAction = ResolveTimelineNextAction(status, ledgerProjection)
+            });
         }
+
+        events.AddRange(AssetObligationProjectionService.BuildProjectedObligationEvents(
+            subject,
+            terms,
+            projectionAsOf,
+            ledgerProjections));
 
         foreach (var lifecycle in lifecycleEvents.OrderBy(static row => row.EffectiveDate))
         {
@@ -620,7 +641,13 @@ public static class AssetOperationsProjectionBuilder
                 null,
                 null,
                 lifecycle.Summary,
-                lifecycle.ExtensionPayload));
+                lifecycle.ExtensionPayload)
+            {
+                FormulaTrace = "Lifecycle event retained from source domain.",
+                NextAction = lifecycle.LifecycleState.Contains("Inactive", StringComparison.OrdinalIgnoreCase)
+                    ? "Review inactive subject before downstream support consumes it."
+                    : "No action required unless source evidence changes."
+            });
         }
 
         var warnings = new List<string>();
@@ -634,6 +661,13 @@ public static class AssetOperationsProjectionBuilder
             warnings.Add("No projected cash-flow obligations are available for the timeline.");
         }
 
+        var variances = AssetObligationProjectionService.BuildTimelineVariances(
+            subject,
+            projectedCashFlows,
+            actualActivity,
+            reconciliationResults,
+            projectionAsOf);
+
         return new AssetTermsObligationsTimelineDto(
             subject.SecurityId,
             projectionAsOf,
@@ -643,7 +677,11 @@ public static class AssetOperationsProjectionBuilder
             warnings,
             generatedAt,
             latestRun?.SourceDomain ?? "AssetOperations",
-            latestRun?.SourceEntityId ?? subject.SecurityId.ToString("D"));
+            latestRun?.SourceEntityId ?? subject.SecurityId.ToString("D"))
+        {
+            AssetClass = subject.AssetClass,
+            Variances = variances
+        };
     }
 
     private static decimal ResolveBondPrincipalBasis(BondReferenceDto bond)
@@ -854,6 +892,68 @@ public static class AssetOperationsProjectionBuilder
     private static string BuildCashFlowTimelineSummary(AssetProjectedCashFlowDto flow, string status)
         => $"{flow.FlowType} obligation due {flow.DueDate:yyyy-MM-dd} for {flow.Amount} {flow.Currency}; status {status}.";
 
+    private static string BuildCashFlowFormulaTrace(AssetProjectedCashFlowDto flow)
+    {
+        if (flow.ExtensionPayload is { } payload && payload.ValueKind == JsonValueKind.Object)
+        {
+            if (TryReadPayloadString(payload, "formula", out var formula))
+            {
+                return formula;
+            }
+
+            if (TryReadPayloadString(payload, "type", out var type))
+            {
+                return $"{flow.FlowType}: {type}";
+            }
+        }
+
+        if (flow.PrincipalBasis.HasValue && flow.AnnualRate.HasValue && flow.AccrualStartDate.HasValue && flow.AccrualEndDate.HasValue)
+        {
+            return $"{flow.FlowType}: principal {flow.PrincipalBasis.Value} x rate {flow.AnnualRate.Value:P4} over {flow.AccrualStartDate:yyyy-MM-dd} to {flow.AccrualEndDate:yyyy-MM-dd}.";
+        }
+
+        return $"{flow.FlowType}: amount retained from {flow.SourceDomain ?? "AssetOperations"} projection.";
+    }
+
+    private static string ResolveTimelineNextAction(string status, AssetLedgerProjectionDto? ledgerProjection)
+    {
+        if (string.Equals(status, "Matched", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(status, "Reconciled", StringComparison.OrdinalIgnoreCase))
+        {
+            return ledgerProjection is null
+                ? "Review ledger support before close."
+                : "No action required unless evidence changes.";
+        }
+
+        if (string.Equals(status, "MissingEvidence", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Attach actual activity evidence or open a reconciliation case.";
+        }
+
+        return ledgerProjection is null
+            ? "Review ledger classification before posting support."
+            : "Monitor due date and retain actual evidence when it arrives.";
+    }
+
+    private static bool TryReadPayloadString(JsonElement payload, string propertyName, out string value)
+    {
+        foreach (var property in payload.EnumerateObject())
+        {
+            if (!string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            value = property.Value.ValueKind == JsonValueKind.String
+                ? property.Value.GetString() ?? string.Empty
+                : property.Value.ToString();
+            return !string.IsNullOrWhiteSpace(value);
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
     private static JsonElement BuildTimelineFlowPayload(
         AssetProjectedCashFlowDto flow,
         AssetReconciliationResultDto? reconciliation,
@@ -871,7 +971,75 @@ public static class AssetOperationsProjectionBuilder
             ledgerProjectionId = ledgerProjection?.LedgerProjectionId
         });
 
-    private static IReadOnlyList<string> ReadyCapabilities(
+    private static JsonElement BuildDirectLendingTermsPayload(LoanContractDetailDto contract, DirectLendingTermsDto terms)
+        => JsonSerializer.SerializeToElement(new
+        {
+            engineVersion = AssetObligationProjectionService.EngineVersion,
+            assetClass = "DirectLoan",
+            currency = terms.BaseCurrency.ToString(),
+            baseCurrency = terms.BaseCurrency.ToString(),
+            contract.LoanId,
+            contract.FacilityName,
+            borrowerName = contract.Borrower.BorrowerName,
+            terms.OriginationDate,
+            terms.MaturityDate,
+            terms.CommitmentAmount,
+            terms.RateTypeKind,
+            rateType = terms.RateTypeKind.ToString(),
+            terms.FixedAnnualRate,
+            terms.InterestIndexName,
+            terms.SpreadBps,
+            terms.FloorRate,
+            terms.CapRate,
+            terms.DayCountBasis,
+            dayCountBasis = terms.DayCountBasis.ToString(),
+            terms.PaymentFrequency,
+            paymentFrequency = terms.PaymentFrequency.ToString(),
+            terms.AmortizationType,
+            amortizationType = terms.AmortizationType.ToString(),
+            terms.CommitmentFeeRate,
+            terms.DefaultRateSpreadBps,
+            terms.PrepaymentAllowed,
+            terms.CovenantsJson,
+            terms.InterestOnlyMonths,
+            terms.GracePeriodDays,
+            terms.EffectiveRateFloor,
+            terms.EffectiveRateCap,
+            terms.PrepaymentPenaltyRate,
+            securityMasterReference = terms.SecurityMasterReference
+        });
+
+    private static JsonElement BuildBondTermsPayload(BondReferenceDto bond)
+        => JsonSerializer.SerializeToElement(new
+        {
+            engineVersion = AssetObligationProjectionService.EngineVersion,
+            assetClass = "Bond",
+            currency = bond.Currency,
+            bond.DisplayName,
+            bond.IssuerName,
+            bond.PrimaryIdentifier,
+            issueDate = bond.Lifecycle?.IssueDate,
+            callDate = bond.Lifecycle?.CallDate,
+            maturityDate = bond.Lifecycle?.MaturityDate,
+            legalFinalMaturity = bond.Lifecycle?.LegalFinalMaturity,
+            preRefundDate = bond.Lifecycle?.PreRefundDate,
+            mandatoryPutDate = bond.Lifecycle?.MandatoryPutDate,
+            par = bond.Lifecycle?.Par,
+            paymentFrequency = bond.Lifecycle?.PaymentFrequency,
+            dayCountConvention = bond.AccrualConvention?.DayCountConvention,
+            couponKind = bond.AccrualConvention?.CouponKind,
+            fixedCouponRate = bond.AccrualConvention?.FixedCouponRate,
+            floatingRateIndex = bond.AccrualConvention?.FloatingRateIndex,
+            floatingSpreadBps = bond.AccrualConvention?.FloatingSpreadBps,
+            sinkingFundSchedule = bond.SinkingFund?.Schedule,
+            factorSchedule = bond.SinkingFund is null ? null : "sinking-fund",
+            inflationIndex = bond.InflationLinked?.InflationIndex,
+            currentFactor = bond.InflationLinked?.CurrentFactor,
+            factorDate = bond.InflationLinked?.FactorDate,
+            cashFlowSource = bond.AccountingElections?.CashFlowSource
+        });
+
+    internal static IReadOnlyList<string> ReadyCapabilities(
         IReadOnlyList<string> capabilities,
         IReadOnlyList<AssetTermsVersionDto> terms,
         IReadOnlyList<AssetLifecycleEventDto> lifecycle,
@@ -915,7 +1083,7 @@ public static class AssetOperationsProjectionBuilder
             .ToArray();
     }
 
-    private static AssetOperationsReadinessDto BuildReadiness(
+    internal static AssetOperationsReadinessDto BuildReadiness(
         AssetOperationSubjectDto subject,
         IReadOnlyList<string> readyCapabilities,
         string sourceDomain,

--- a/src/Meridian.Instruments/README.md
+++ b/src/Meridian.Instruments/README.md
@@ -6,7 +6,7 @@ module_id: SRC-DESIGN-INSTRUMENTS
 path: src/Meridian.Instruments
 status: active
 owner_lane: Accounting and Ledger
-last_reviewed: 2026-06-06
+last_reviewed: 2026-07-05
 ---
 
 # src/Meridian.Instruments
@@ -42,6 +42,9 @@ This module belongs to the Design Module layer. Keep changes within that ownersh
   command, and projection builder for shared terms, lifecycle, cash-flow, activity,
   reconciliation, ledger, evidence, workflow-audit, terms/obligations timeline, and readiness
   views.
+- `AssetOperations/AssetObligationProjectionService.cs` - retained-term projection service for
+  Security Master-keyed assets that emits V1 expected cash flows, non-cash obligations, formula
+  traces, ledger-support references, and timeline variances without writing ledger facts.
 - `Indicators/TechnicalIndicatorService.cs` - live and historical technical indicator calculations
   over market trades, quotes, and OHLCV bars using Skender.Stock.Indicators.
 
@@ -54,8 +57,9 @@ terms, lifecycle, contract, expiry, maturity, accrual, sweep, liquidity, fund-fa
 chain-linkage details. Asset Operations projections also live here because they adapt instrument
 terms, obligation schedules, projected cash flows, ledger projections, and readiness evidence into
 the shared Security Master-keyed operational view. The terms/obligations timeline is derived here
-from projected cash-flow runs, actual activity, reconciliation results, lifecycle events, and ledger
-references so browser and WPF clients render a shared event rail without owning projection logic.
+from retained Security Master terms, projected cash-flow runs, generated non-cash obligations,
+actual activity, reconciliation results, lifecycle events, variances, and ledger references so
+browser and WPF clients render a shared event rail without owning projection logic.
 Application composition wires these services to Security Master, Asset Operations, and money-market
 projection stores, while UI Shared adapts them to shared browser/WPF routes without owning the
 instrument logic.

--- a/tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs
+++ b/tests/Meridian.QuantScript.Tests/ScriptRunnerTests.cs
@@ -46,6 +46,11 @@ public sealed class ScriptRunnerTests
     private static IReadOnlyDictionary<string, object?> NoParams =>
         new Dictionary<string, object?>();
 
+    private static TimeSpan RuntimeElapsed(ScriptRunResult result)
+        => result.Elapsed >= result.CompileTime
+            ? result.Elapsed - result.CompileTime
+            : TimeSpan.Zero;
+
     // ── Argument validation ───────────────────────────────────────────────────
 
     [Fact]
@@ -188,8 +193,8 @@ public sealed class ScriptRunnerTests
         result.Success.Should().BeFalse();
         result.RuntimeError.Should().Be("Script cancelled by user.");
         result.Checkpoint.Should().BeNull();
-        result.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3));
-        elapsed.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3));
+        RuntimeElapsed(result).Should().BeLessThan(TimeSpan.FromSeconds(3));
+        elapsed.Elapsed.Should().BeLessThan(result.CompileTime + TimeSpan.FromSeconds(3));
     }
 
     [Fact]
@@ -206,8 +211,8 @@ public sealed class ScriptRunnerTests
         result.Success.Should().BeFalse();
         result.RuntimeError.Should().Be("Script timed out.");
         result.Checkpoint.Should().BeNull();
-        result.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3));
-        elapsed.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3));
+        RuntimeElapsed(result).Should().BeLessThan(TimeSpan.FromSeconds(3));
+        elapsed.Elapsed.Should().BeLessThan(result.CompileTime + TimeSpan.FromSeconds(3));
     }
 
     [Fact]

--- a/tests/Meridian.Tests/Application/SecurityMasterCashFlowServiceTests.cs
+++ b/tests/Meridian.Tests/Application/SecurityMasterCashFlowServiceTests.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+using FluentAssertions;
+using Meridian.Application.SecurityMaster;
+using Meridian.Contracts.SecurityMaster;
+using Meridian.Storage.SecurityMaster;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using SecurityMasterQueryContract = Meridian.Application.SecurityMaster.ISecurityMasterQueryService;
+
+namespace Meridian.Tests.Application;
+
+public sealed class SecurityMasterCashFlowServiceTests
+{
+    [Fact]
+    public async Task GetProjectionAsync_CalculatedBullet_ShouldGenerateCouponAndMaturityScheduleFromRetainedTerms()
+    {
+        var securityId = Guid.Parse("11111111-aaaa-aaaa-aaaa-111111111111");
+        var asOf = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+        var store = Substitute.For<ISecurityMasterCashFlowStore>();
+        store.GetSourceAsync(securityId, Arg.Any<CancellationToken>())
+            .Returns(new SecurityCashFlowSourceDto(
+                securityId,
+                StructuredCashFlowSourceKind.CalculatedBullet,
+                DateTimeOffset.UtcNow,
+                false,
+                null,
+                null));
+        var query = Substitute.For<SecurityMasterQueryContract>();
+        query.GetByIdAsync(securityId, Arg.Any<CancellationToken>())
+            .Returns(BuildSecurity(
+                securityId,
+                JsonSerializer.SerializeToElement(new
+                {
+                    issueDate = asOf,
+                    maturityDate = asOf.AddYears(1),
+                    par = 100m,
+                    couponRate = 6m,
+                    paymentFrequency = "SemiAnnual",
+                    dayCountConvention = "30/360"
+                })));
+        var service = new SecurityMasterCashFlowService(
+            store,
+            Array.Empty<IStructuredCashFlowProvider>(),
+            query,
+            NullLogger<SecurityMasterCashFlowService>.Instance);
+
+        var projection = await service.GetProjectionAsync(securityId, StructuredCashFlowScenario.Base);
+
+        projection.Should().NotBeNull();
+        projection!.SourceKind.Should().Be(StructuredCashFlowSourceKind.CalculatedBullet);
+        projection.Schedule.Should().HaveCount(2);
+        projection.Schedule.Should().Contain(static row => row.InterestAmount == 3m && row.PrincipalAmount == 0m);
+        projection.Schedule.Last().Should().Match<StructuredCashFlowScheduleEntry>(row =>
+            row.InterestAmount == 3m &&
+            row.PrincipalAmount == 100m &&
+            row.Factor == 0m);
+    }
+
+    [Fact]
+    public async Task GetProjectionAsync_CalculatedSinker_ShouldAmortizePrincipalAcrossScheduleDates()
+    {
+        var securityId = Guid.Parse("22222222-bbbb-bbbb-bbbb-222222222222");
+        var asOf = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+        var store = Substitute.For<ISecurityMasterCashFlowStore>();
+        store.GetSourceAsync(securityId, Arg.Any<CancellationToken>())
+            .Returns(new SecurityCashFlowSourceDto(
+                securityId,
+                StructuredCashFlowSourceKind.CalculatedSinker,
+                DateTimeOffset.UtcNow,
+                false,
+                null,
+                null));
+        var query = Substitute.For<SecurityMasterQueryContract>();
+        query.GetByIdAsync(securityId, Arg.Any<CancellationToken>())
+            .Returns(BuildSecurity(
+                securityId,
+                JsonSerializer.SerializeToElement(new
+                {
+                    issueDate = asOf,
+                    maturityDate = asOf.AddYears(1),
+                    originalFace = 120m,
+                    couponRate = 0.12m,
+                    paymentFrequency = "Quarterly",
+                    dayCountConvention = "ACT/360"
+                })));
+        var service = new SecurityMasterCashFlowService(
+            store,
+            Array.Empty<IStructuredCashFlowProvider>(),
+            query,
+            NullLogger<SecurityMasterCashFlowService>.Instance);
+
+        var projection = await service.GetProjectionAsync(securityId, StructuredCashFlowScenario.Down100);
+
+        projection.Should().NotBeNull();
+        projection!.SourceKind.Should().Be(StructuredCashFlowSourceKind.CalculatedSinker);
+        projection.Schedule.Should().HaveCount(4);
+        projection.Schedule.Select(static row => row.PrincipalAmount).Should().OnlyContain(static amount => amount > 0m);
+        projection.Schedule.Sum(static row => row.PrincipalAmount).Should().Be(120m);
+        projection.Schedule.Last().Factor.Should().Be(0m);
+        projection.Schedule.First().InterestAmount.Should().BeGreaterThan(0m);
+    }
+
+    private static SecurityDetailDto BuildSecurity(Guid securityId, JsonElement assetSpecificTerms)
+        => new(
+            securityId,
+            "Bond",
+            SecurityStatusDto.Active,
+            "Calculated bond",
+            "USD",
+            JsonSerializer.SerializeToElement(new { displayName = "Calculated bond", currency = "USD" }),
+            assetSpecificTerms,
+            [new SecurityIdentifierDto(SecurityIdentifierKind.Cusip, "123456789", true, DateTimeOffset.UtcNow)],
+            [],
+            1,
+            DateTimeOffset.UtcNow,
+            null);
+}

--- a/tests/Meridian.Tests/AssetOperations/AssetOperationsReadServiceTests.cs
+++ b/tests/Meridian.Tests/AssetOperations/AssetOperationsReadServiceTests.cs
@@ -171,6 +171,15 @@ public sealed class AssetOperationsReadServiceTests
             timelineEvent.ActualAmount == 1_000m &&
             timelineEvent.VarianceAmount == 0m &&
             timelineEvent.EvidenceLink == cash.CashTransactionId.ToString("D"));
+        projection.TermsObligationsTimeline.Events.Should().Contain(timelineEvent =>
+            timelineEvent.EventKind == "CovenantTest" &&
+            timelineEvent.EventLane == "Obligations" &&
+            timelineEvent.FormulaTrace!.Contains("direct-lending covenant", StringComparison.OrdinalIgnoreCase) &&
+            timelineEvent.NextAction!.Contains("covenant", StringComparison.OrdinalIgnoreCase));
+        projection.TermsObligationsTimeline.Events.Should().Contain(timelineEvent =>
+            timelineEvent.EventKind == "CommitmentFee" &&
+            timelineEvent.EventLane == "CashFlow" &&
+            timelineEvent.LedgerReference == "ledger-map:direct-lending:NWTERM26");
         projection.Readiness.ReadyCapabilities.Should().Contain(["TermsHistory", "ProjectedCashFlows", "ActualActivity", "Reconciliation", "LedgerProjection"]);
     }
 
@@ -290,7 +299,142 @@ public sealed class AssetOperationsReadServiceTests
             f.Amount == 103m);
     }
 
-    private static SecurityDetailDto BuildSecurity(Guid securityId, string assetClass, string displayName)
+    [Fact]
+    public async Task GetOperationsAsync_ForPrivateFundInterest_ShouldGenerateNonCashObligationTimelineFromTerms()
+    {
+        var securityId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        var securityMaster = Substitute.For<ISecurityMasterQueryService>();
+        securityMaster.GetByIdAsync(securityId, Arg.Any<CancellationToken>())
+            .Returns(BuildSecurity(
+                securityId,
+                "PrivateFundInterest",
+                "Meridian Private Credit Fund I",
+                JsonSerializer.SerializeToElement(new
+                {
+                    customProfileId = "private-fund-interest",
+                    profileVersion = 1,
+                    profileFields = new
+                    {
+                        gpSponsor = "GP Capital",
+                        strategy = "Private Credit",
+                        commitment = 1_000_000m,
+                        fundedAmount = 250_000m,
+                        unfundedAmount = 750_000m,
+                        navDate = "2026-06-30"
+                    }
+                })));
+
+        var service = new AssetOperationsReadService(securityMasterQueryService: securityMaster);
+        var detail = await service.GetOperationsAsync(securityId);
+
+        detail.Should().NotBeNull();
+        detail!.Subject.AssetClass.Should().Be("PrivateFundInterest");
+        detail.ProjectedCashFlows.Should().BeEmpty();
+        detail.TermsObligationsTimeline.Should().NotBeNull();
+        detail.TermsObligationsTimeline!.AssetClass.Should().Be("PrivateFundInterest");
+        detail.TermsObligationsTimeline.Events.Should().Contain(timelineEvent =>
+            timelineEvent.EventKind == "NavStatement" &&
+            timelineEvent.EventLane == "Evidence" &&
+            timelineEvent.FormulaTrace!.Contains("Quarterly NAV", StringComparison.OrdinalIgnoreCase));
+        detail.TermsObligationsTimeline.Events.Should().Contain(timelineEvent =>
+            timelineEvent.EventKind == "CapitalAccountStatement" &&
+            timelineEvent.NextAction!.Contains("capital-account", StringComparison.OrdinalIgnoreCase));
+        detail.TermsObligationsTimeline.Events.Should().Contain(timelineEvent =>
+            timelineEvent.EventKind == "UnfundedCommitmentReview" &&
+            timelineEvent.ExpectedAmount == 750_000m);
+    }
+
+    [Fact]
+    public async Task GetOperationsAsync_ForStructuredCredit_ShouldGenerateFactorEvidenceAndProjectedPrincipalFromTerms()
+    {
+        var securityId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+        var asOf = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+        var maturity = asOf.AddYears(1);
+        var securityMaster = Substitute.For<ISecurityMasterQueryService>();
+        securityMaster.GetByIdAsync(securityId, Arg.Any<CancellationToken>())
+            .Returns(BuildSecurity(
+                securityId,
+                "StructuredCredit",
+                "Meridian CLO A-1",
+                JsonSerializer.SerializeToElement(new
+                {
+                    tranche = "A-1",
+                    poolId = "POOL-2026-1",
+                    collateralType = "CLO",
+                    originalFace = 1_000_000m,
+                    currentFactor = 0.9825m,
+                    couponRate = 6m,
+                    dayCountConvention = "30/360",
+                    paymentFrequency = "SemiAnnual",
+                    issueDate = asOf,
+                    maturityDate = maturity,
+                    factorSchedule = "monthly-trustee"
+                })));
+
+        var service = new AssetOperationsReadService(securityMasterQueryService: securityMaster);
+        var detail = await service.GetOperationsAsync(securityId);
+
+        detail.Should().NotBeNull();
+        detail!.ProjectedCashFlows.Should().Contain(static flow => flow.FlowType == "Coupon");
+        detail.ProjectedCashFlows.Single(static flow => flow.FlowType == "Maturity").Should().Match<AssetProjectedCashFlowDto>(flow =>
+            flow.Amount == 982_500m &&
+            flow.DueDate == maturity);
+        detail.TermsObligationsTimeline.Should().NotBeNull();
+        detail.TermsObligationsTimeline!.Events.Should().Contain(timelineEvent =>
+            timelineEvent.EventKind == "TrusteeReport" &&
+            timelineEvent.EventLane == "Evidence");
+        detail.TermsObligationsTimeline.Events.Should().Contain(timelineEvent =>
+            timelineEvent.EventKind == "CollateralTape" &&
+            timelineEvent.NextAction!.Contains("collateral tape", StringComparison.OrdinalIgnoreCase));
+        detail.TermsObligationsTimeline.Events.Should().Contain(timelineEvent =>
+            timelineEvent.EventKind == "FactorUpdate" &&
+            timelineEvent.LedgerReference == $"security-master:{securityId:D}");
+    }
+
+    [Fact]
+    public async Task GetOperationsAsync_ForCustomAsset_ShouldGenerateGovernedProfileAndCloseEvidenceObligations()
+    {
+        var securityId = Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+        var securityMaster = Substitute.For<ISecurityMasterQueryService>();
+        securityMaster.GetByIdAsync(securityId, Arg.Any<CancellationToken>())
+            .Returns(BuildSecurity(
+                securityId,
+                "CustomAsset",
+                "Specialized Holding",
+                JsonSerializer.SerializeToElement(new
+                {
+                    customProfileId = "specialized-holding",
+                    profileVersion = 2,
+                    profileFields = new
+                    {
+                        valuationDate = "2026-06-30",
+                        latestValuation = 725_000m,
+                        evidencePolicy = "controller-review"
+                    }
+                })));
+
+        var service = new AssetOperationsReadService(securityMasterQueryService: securityMaster);
+        var detail = await service.GetOperationsAsync(securityId);
+
+        detail.Should().NotBeNull();
+        detail!.TermsObligationsTimeline.Should().NotBeNull();
+        detail.TermsObligationsTimeline!.Events.Should().Contain(timelineEvent =>
+            timelineEvent.EventKind == "ValuationReview" &&
+            timelineEvent.EventLane == "Obligations");
+        detail.TermsObligationsTimeline.Events.Should().Contain(timelineEvent =>
+            timelineEvent.EventKind == "CustomProfileEvidenceReview" &&
+            timelineEvent.FormulaTrace!.Contains("Custom profile", StringComparison.OrdinalIgnoreCase));
+        detail.TermsObligationsTimeline.Events.Should().Contain(timelineEvent =>
+            timelineEvent.EventKind == "ObligationCloseEvidence" &&
+            timelineEvent.EventLane == "Handoff" &&
+            timelineEvent.NextAction!.Contains("close", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static SecurityDetailDto BuildSecurity(
+        Guid securityId,
+        string assetClass,
+        string displayName,
+        JsonElement? assetSpecificTerms = null)
         => new(
             securityId,
             assetClass,
@@ -298,7 +442,7 @@ public sealed class AssetOperationsReadServiceTests
             displayName,
             "USD",
             JsonSerializer.SerializeToElement(new { displayName, currency = "USD" }),
-            JsonSerializer.SerializeToElement(new { maturity = "2031-01-01", couponRate = 5.875m }),
+            assetSpecificTerms ?? JsonSerializer.SerializeToElement(new { maturity = "2031-01-01", couponRate = 5.875m }),
             [new SecurityIdentifierDto(SecurityIdentifierKind.Cusip, "123456789", true, DateTimeOffset.Parse("2026-01-01T00:00:00Z"))],
             [],
             3,
@@ -321,10 +465,10 @@ public sealed class AssetOperationsReadServiceTests
             DayCountBasis.Act360,
             PaymentFrequency.Monthly,
             AmortizationType.Bullet,
-            null,
+            0.01m,
             null,
             true,
-            null,
+            "{\"leverage\":\"tested quarterly\"}",
             SecurityMasterReference: new DirectLendingSecurityMasterReferenceDto(
                 securityId,
                 "NWTERM26",


### PR DESCRIPTION
<!-- phase:PR9 -->## Summary - Add an Instruments-layer asset obligation projection service that generates retained-term cash-flow and obligation timeline events for fixed income, direct loans, private funds, structured credit, and custom assets. - Extend Asset Operations timeline DTOs with variance, formula trace, ledger reference, next action, and asset-class metadata while preserving existing optional contract shape. - Fill calculated bullet/sinker cash-flow projection in Security Master from retained terms and scenario rate shifts. - Add focused .NET coverage for asset timelines, calculated Security Master cash-flow projections, and QuantScript runtime timeout behavior.  ## Local validation - PASS: `dotnet build src\Meridian.Instruments\Meridian.Instruments.csproj /p:EnableWindowsTargeting=true /p:NodeReuse=false` - PASS: `dotnet build tests\Meridian.Tests\Meridian.Tests.csproj -v:quiet -clp:ErrorsOnly /p:EnableWindowsTargeting=true /p:NodeReuse=false` - PASS: `dotnet test tests\Meridian.Tests\Meridian.Tests.csproj --no-build --filter "FullyQualifiedName~AssetOperationsReadServiceTests|FullyQualifiedName~SecurityMasterCashFlowServiceTests" --logger "console;verbosity=minimal" /p:EnableWindowsTargeting=true /p:NodeReuse=false -v:quiet` - PASS: `dotnet test tests\Meridian.QuantScript.Tests\Meridian.QuantScript.Tests.csproj -c Release --no-restore --no-build --filter "Category!=Integration&Category!=Performance" --logger "console;verbosity=minimal" /p:EnableWindowsTargeting=true` - PASS: `python .codex\skills\meridian-contract-governance\scripts\contract_impact.py --path src\Meridian.Contracts\AssetOperations\AssetOperationsDtos.cs --summary` - PASS: `python .codex\skills\meridian-contract-governance\scripts\contract_impact.py --path src\Meridian.Contracts\Workstation\SecurityMasterTrustWorkbenchDtos.cs --summary` - PASS: `python build\scripts\docs\validate-doc-hashes.py --write-module SRC-CONTRACTS --write-module SRC-DESIGN-INSTRUMENTS --write-module SRC-APP --summary` - PASS: `git diff --check` - FAIL: `bash scripts/ci.sh` completed the .NET matrix but failed in dashboard tests with exit 127 during Vitest batch 6; batch 6 passed when rerun directly. - FAIL: `bash scripts/ci.sh --lane verify-browser` later failed on an existing `accounting-screen.test.tsx` 15s timeout in batch 18; the exact timed-out test passed when rerun alone.  ## Notes - Opened as draft because local `bash scripts/ci.sh` did not complete successfully. GitHub Actions should be treated as the integration authority before this leaves draft.
## Hosted validation
- PASS: GitHub `quality-gate` on latest head `40e1c366f21e6ac1a88059f5cde0579a28f437ec`.
- PASS: GitHub `verify-dotnet`, `verify-browser`, `verify-fast`, `verify-desktop`, docs, scope/schema, route validation, secret scan, and CodeQL C#/JS-TS checks.
- PR remains draft because the Codex local `bash scripts/ci.sh` run failed earlier under local browser-test flakiness; hosted checks are the integration authority.