### PR TITLE
Stream fan-out C: companion-pane stream sharing (owner/follower)

### DIFF
--- a/docs/product/web-ui-stream-fan-out-blueprint-2026-07.md
+++ b/docs/product/web-ui-stream-fan-out-blueprint-2026-07.md
@@ -326,14 +326,15 @@ npm --prefix src/Meridian.Ui/dashboard run build
 
 ## 9. Phasing (each a separate PR, hot-path review gated)
 
-1. **PR A — Notifier seam + broadcaster (server), behind a flag.** `IQuoteUpdateNotifier`,
-   `QuoteStreamBroadcaster`, `StreamTopic`, options, DI, `QuoteCollector` optional param. Endpoint
-   still polls; broadcaster runs in shadow with unit tests. No behavior change. **Requires hot-path
-   review** of the notifier call site.
-2. **PR B — Endpoint switch + registry/caps.** Rewrite the SSE loop to subscribe; add
-   `StreamConnectionRegistry`, 429, session-expiry close. Flip the flag. Endpoint tests updated.
-3. **PR C — Client companion fan-out.** Bridge `quotes` messages, owner/follower roles, follower
-   degradation. Adopt on the watchlist + live-quotes panes.
+1. **PR A — Notifier seam + broadcaster (server).** ✅ Shipped. `IQuoteUpdateNotifier`,
+   `QuoteStreamBroadcaster`, `StreamTopic`, options, DI, `QuoteCollector` optional param. Broadcaster
+   ran in shadow with unit tests; the notifier call site was hot-path reviewed.
+2. **PR B — Endpoint switch + registry/caps.** ✅ Shipped. SSE loop subscribes to a topic instead of
+   polling; `StreamConnectionRegistry`, 429 + `Retry-After`, per-session cap. Endpoint tests updated.
+3. **PR C — Client companion fan-out.** ✅ Shipped. Bridge `quotes`/`quotes-request` messages,
+   owner/follower roles in `quotes-stream.ts`, follower degradation on `session-expired` / stale
+   watchdog. Role is decided by route (`isCompanionPaneRoute`), so the watchlist + live-quotes panes
+   follow automatically with no screen change.
 4. **PR D (optional, future) — Additional topics** (`workspace:<key>`, `inbox`, `report-run:<id>`)
    reusing `StreamTopic`; wire the `use-workstation-data` workspace poller suspension deferred in
    Phase 4 step 1.

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 539,
-  "total_lines": 89090,
+  "total_lines": 89091,
   "orphaned_count": 205,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -3114,7 +3114,7 @@
     },
     {
       "path": "docs/product/web-ui-stream-fan-out-blueprint-2026-07.md",
-      "line_count": 362,
+      "line_count": 363,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 539 |
-| Total lines | 89,090 |
+| Total lines | 89,091 |
 | Average file size (lines) | 165.3 |
 | Orphaned files | 205 |
 | Files without headings | 38 |

--- a/src/Meridian.Ui/dashboard/src/lib/companion-pane/chrome-bridge.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/companion-pane/chrome-bridge.test.ts
@@ -41,12 +41,37 @@ describe("normalizeCompanionBridgeMessage", () => {
     expect(normalizeCompanionBridgeMessage({ type: "session-expired" })).toEqual({ type: "session-expired" });
   });
 
+  it("accepts well-formed quotes and quotes-request messages", () => {
+    const snapshot = { timestamp: "2026-07-05T00:00:00Z", count: 0, quotes: [] };
+    expect(
+      normalizeCompanionBridgeMessage({ type: "quotes", symbolsKey: "AAPL,MSFT", snapshot })
+    ).toEqual({ type: "quotes", symbolsKey: "AAPL,MSFT", snapshot });
+    expect(normalizeCompanionBridgeMessage({ type: "quotes-request", symbolsKey: "SPY" })).toEqual({
+      type: "quotes-request",
+      symbolsKey: "SPY"
+    });
+  });
+
   it("rejects malformed or unknown payloads", () => {
     expect(normalizeCompanionBridgeMessage(null)).toBeNull();
     expect(normalizeCompanionBridgeMessage("nope")).toBeNull();
     expect(normalizeCompanionBridgeMessage({ type: "appearance", appearance: "neon" })).toBeNull();
     expect(normalizeCompanionBridgeMessage({ type: "scope", scope: "x" })).toBeNull();
     expect(normalizeCompanionBridgeMessage({ type: "other" })).toBeNull();
+    // quotes with a missing/invalid snapshot or empty key is rejected.
+    expect(normalizeCompanionBridgeMessage({ type: "quotes", symbolsKey: "SPY" })).toBeNull();
+    expect(
+      normalizeCompanionBridgeMessage({ type: "quotes", symbolsKey: "SPY", snapshot: { count: 1 } })
+    ).toBeNull();
+    expect(
+      normalizeCompanionBridgeMessage({
+        type: "quotes",
+        symbolsKey: "",
+        snapshot: { timestamp: "t", count: 0, quotes: [] }
+      })
+    ).toBeNull();
+    expect(normalizeCompanionBridgeMessage({ type: "quotes-request" })).toBeNull();
+    expect(normalizeCompanionBridgeMessage({ type: "quotes-request", symbolsKey: "" })).toBeNull();
   });
 });
 

--- a/src/Meridian.Ui/dashboard/src/lib/companion-pane/chrome-bridge.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/companion-pane/chrome-bridge.ts
@@ -6,13 +6,33 @@
 // without waiting on a storage round-trip.
 import { isAppearance, type Appearance } from "@/lib/theme";
 import type { AppShellOperatingScopeInput } from "@/app-shell.operating-scope";
+import type { QuotesSnapshotResponse } from "@/types";
 
 export const COMPANION_CHANNEL_NAME = "meridian.workstation.companion.v1";
 
 export type CompanionBridgeMessage =
   | { type: "appearance"; appearance: Appearance }
   | { type: "scope"; scope: AppShellOperatingScopeInput }
-  | { type: "session-expired" };
+  | { type: "session-expired" }
+  // Owner window re-broadcasts a quote snapshot for a symbol set so follower panes
+  // consume the opener's feed instead of opening their own EventSource.
+  | { type: "quotes"; symbolsKey: string; snapshot: QuotesSnapshotResponse }
+  // Follower pane asks the owner to re-send the latest snapshot for a symbol set
+  // (fast warm-up when a pane opens after the owner is already streaming).
+  | { type: "quotes-request"; symbolsKey: string };
+
+/** Structural check for a cross-window snapshot payload (untrusted data). */
+function isQuotesSnapshot(value: unknown): value is QuotesSnapshotResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as { timestamp?: unknown; count?: unknown; quotes?: unknown };
+  return (
+    typeof record.timestamp === "string" &&
+    typeof record.count === "number" &&
+    Array.isArray(record.quotes)
+  );
+}
 
 /** Minimal BroadcastChannel surface, injectable for tests. */
 export interface BroadcastChannelLike {
@@ -40,6 +60,19 @@ export function normalizeCompanionBridgeMessage(data: unknown): CompanionBridgeM
   }
   if (type === "session-expired") {
     return { type: "session-expired" };
+  }
+  if (type === "quotes") {
+    const record = data as { symbolsKey?: unknown; snapshot?: unknown };
+    const snapshot = record.snapshot;
+    return typeof record.symbolsKey === "string" && record.symbolsKey.length > 0 && isQuotesSnapshot(snapshot)
+      ? { type: "quotes", symbolsKey: record.symbolsKey, snapshot }
+      : null;
+  }
+  if (type === "quotes-request") {
+    const symbolsKey = (data as { symbolsKey?: unknown }).symbolsKey;
+    return typeof symbolsKey === "string" && symbolsKey.length > 0
+      ? { type: "quotes-request", symbolsKey }
+      : null;
   }
   return null;
 }

--- a/src/Meridian.Ui/dashboard/src/lib/quotes-stream.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/quotes-stream.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { buildQuotesStreamUrl, isQuotesStreamSupported, subscribeQuotesStream } from "@/lib/quotes-stream";
+import {
+  buildQuotesStreamUrl,
+  isQuotesStreamSupported,
+  resetQuotesStreamForTests,
+  setQuotesStreamChannelForTests,
+  setQuotesStreamRoleForTests,
+  subscribeQuotesStream
+} from "@/lib/quotes-stream";
+import type { BroadcastChannelLike } from "@/lib/companion-pane/chrome-bridge";
 import type { QuotesSnapshotResponse } from "@/types";
 
 class FakeEventSource {
@@ -30,6 +38,31 @@ class FakeEventSource {
   }
 }
 
+// Same-origin channel double: postMessage records (a real BroadcastChannel never
+// echoes to its own instance); emit() simulates an inbound message from the other
+// window and is delivered to subscribers.
+class FakeChannel implements BroadcastChannelLike {
+  posted: unknown[] = [];
+  closed = false;
+  private listeners = new Set<(event: MessageEvent) => void>();
+
+  postMessage(message: unknown) {
+    this.posted.push(message);
+  }
+  addEventListener(_type: "message", listener: (event: MessageEvent) => void) {
+    this.listeners.add(listener);
+  }
+  removeEventListener(_type: "message", listener: (event: MessageEvent) => void) {
+    this.listeners.delete(listener);
+  }
+  close() {
+    this.closed = true;
+  }
+  emit(data: unknown) {
+    this.listeners.forEach((listener) => listener({ data } as MessageEvent));
+  }
+}
+
 const snapshot: QuotesSnapshotResponse = {
   timestamp: "2026-07-03T00:00:00Z",
   count: 1,
@@ -54,16 +87,24 @@ const snapshot: QuotesSnapshotResponse = {
   ]
 };
 
+let fakeChannel: FakeChannel;
+
 describe("quotes stream client", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     FakeEventSource.instances = [];
     vi.stubGlobal("EventSource", FakeEventSource);
+    fakeChannel = new FakeChannel();
+    setQuotesStreamChannelForTests(() => fakeChannel);
+    setQuotesStreamRoleForTests("owner");
   });
 
   afterEach(() => {
-    // Drain any pending close-linger timers so connections never leak into the next test.
+    // Drain any pending timers so connections never leak into the next test.
     vi.runAllTimers();
+    resetQuotesStreamForTests();
+    setQuotesStreamRoleForTests(null);
+    setQuotesStreamChannelForTests(null);
     vi.useRealTimers();
     vi.unstubAllGlobals();
   });
@@ -136,6 +177,21 @@ describe("quotes stream client", () => {
     late();
   });
 
+  it("owner re-broadcasts each snapshot and answers follower warm-up requests", () => {
+    const unsubscribe = subscribeQuotesStream(["SPY"], { onSnapshot: vi.fn() });
+    FakeEventSource.instances[0]!.emit("quotes", JSON.stringify(snapshot));
+
+    // The snapshot is pushed to any companion panes following this symbol set.
+    expect(fakeChannel.posted).toContainEqual({ type: "quotes", symbolsKey: "SPY", snapshot });
+
+    // A follower requests the current snapshot; the owner replies with the last one.
+    fakeChannel.posted = [];
+    fakeChannel.emit({ type: "quotes-request", symbolsKey: "SPY" });
+    expect(fakeChannel.posted).toContainEqual({ type: "quotes", symbolsKey: "SPY", snapshot });
+
+    unsubscribe();
+  });
+
   it("reports unsupported environments as unhealthy without subscribing", () => {
     vi.unstubAllGlobals();
     expect(isQuotesStreamSupported()).toBe(false);
@@ -144,5 +200,46 @@ describe("quotes stream client", () => {
     const unsubscribe = subscribeQuotesStream(["SPY"], { onSnapshot: vi.fn(), onHealthChange });
     expect(onHealthChange).toHaveBeenCalledWith(false);
     unsubscribe();
+  });
+
+  describe("follower role", () => {
+    beforeEach(() => {
+      setQuotesStreamRoleForTests("follower");
+    });
+
+    it("follows the opener's feed without opening its own EventSource", () => {
+      const onSnapshot = vi.fn();
+      const onHealthChange = vi.fn();
+      const unsubscribe = subscribeQuotesStream(["SPY"], { onSnapshot, onHealthChange });
+
+      // A pane opens no EventSource and asks the opener to warm it up.
+      expect(FakeEventSource.instances).toHaveLength(0);
+      expect(fakeChannel.posted).toContainEqual({ type: "quotes-request", symbolsKey: "SPY" });
+      expect(onHealthChange).toHaveBeenLastCalledWith(false);
+
+      // An inbound snapshot from the opener drives the follower healthy.
+      fakeChannel.emit({ type: "quotes", symbolsKey: "SPY", snapshot });
+      expect(onSnapshot).toHaveBeenCalledWith(snapshot);
+      expect(onHealthChange).toHaveBeenLastCalledWith(true);
+
+      // Opener gone (session-expired) → unhealthy → polling resumes.
+      fakeChannel.emit({ type: "session-expired" });
+      expect(onHealthChange).toHaveBeenLastCalledWith(false);
+
+      unsubscribe();
+    });
+
+    it("degrades to unhealthy after the stale watchdog when snapshots stop", () => {
+      const onHealthChange = vi.fn();
+      const unsubscribe = subscribeQuotesStream(["SPY"], { onSnapshot: vi.fn(), onHealthChange });
+
+      fakeChannel.emit({ type: "quotes", symbolsKey: "SPY", snapshot });
+      expect(onHealthChange).toHaveBeenLastCalledWith(true);
+
+      vi.advanceTimersByTime(6000);
+      expect(onHealthChange).toHaveBeenLastCalledWith(false);
+
+      unsubscribe();
+    });
   });
 });

--- a/src/Meridian.Ui/dashboard/src/lib/quotes-stream.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/quotes-stream.test.ts
@@ -229,6 +229,19 @@ describe("quotes stream client", () => {
       unsubscribe();
     });
 
+    it("warms up once per symbol set, not once per subscriber", () => {
+      const first = subscribeQuotesStream(["SPY"], { onSnapshot: vi.fn() });
+      const second = subscribeQuotesStream(["SPY"], { onSnapshot: vi.fn() });
+
+      const requests = fakeChannel.posted.filter(
+        (message) => (message as { type?: string }).type === "quotes-request"
+      );
+      expect(requests).toHaveLength(1);
+
+      first();
+      second();
+    });
+
     it("degrades to unhealthy after the stale watchdog when snapshots stop", () => {
       const onHealthChange = vi.fn();
       const unsubscribe = subscribeQuotesStream(["SPY"], { onSnapshot: vi.fn(), onHealthChange });

--- a/src/Meridian.Ui/dashboard/src/lib/quotes-stream.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/quotes-stream.ts
@@ -247,6 +247,7 @@ function subscribeAsFollower(symbolsKey: string, handlers: QuotesStreamHandlers)
   ensureFollowerListener(bridge);
 
   let connection = followerConnections.get(symbolsKey);
+  const isNewConnection = !connection;
   if (!connection) {
     connection = {
       symbolsKey,
@@ -259,14 +260,17 @@ function subscribeAsFollower(symbolsKey: string, handlers: QuotesStreamHandlers)
   }
 
   connection.handlers.add(handlers);
-  armFollowerStaleTimer(connection);
   handlers.onHealthChange?.(connection.healthy);
   if (connection.lastSnapshot) {
     handlers.onSnapshot(connection.lastSnapshot);
   }
 
-  // Ask the opener to send the current snapshot immediately (fast warm-up).
-  bridge.post({ type: "quotes-request", symbolsKey });
+  // Warm up the opener once, when this symbol set is first followed. Re-mounts of
+  // additional subscribers reuse the connection and must not re-request or reset
+  // the stale watchdog — the watchdog is (re)armed only on real snapshot receipt.
+  if (isNewConnection) {
+    bridge.post({ type: "quotes-request", symbolsKey });
+  }
 
   return () => {
     const current = followerConnections.get(symbolsKey);
@@ -332,6 +336,12 @@ function setFollowerHealthy(connection: FollowerConnection, healthy: boolean): v
     return;
   }
   connection.healthy = healthy;
+  // Once unhealthy, the watchdog has nothing left to do — drop it so it cannot
+  // fire redundantly. A later snapshot re-arms it via armFollowerStaleTimer.
+  if (!healthy && connection.staleTimer !== null) {
+    clearTimeout(connection.staleTimer);
+    connection.staleTimer = null;
+  }
   for (const handler of connection.handlers) {
     handler.onHealthChange?.(healthy);
   }

--- a/src/Meridian.Ui/dashboard/src/lib/quotes-stream.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/quotes-stream.ts
@@ -1,33 +1,97 @@
-// Shared client for the workstation SSE quote stream (live data spine, step 1).
-// One EventSource per symbol set is shared across subscribers with refcounting;
-// consumers keep their polling paths and suspend them only while the stream is
-// healthy, so degraded environments fall back to polling automatically.
+// Shared client for the workstation SSE quote stream (live data spine).
+//
+// Owner window (the main workstation): one EventSource per symbol set, shared
+// across subscribers with refcounting, exactly as before — and it re-broadcasts
+// each snapshot over the same-origin companion BroadcastChannel.
+//
+// Follower window (a `/panes/*` companion pane): opens NO EventSource. It follows
+// the opener's feed over the companion channel, so a pane beside a live main
+// window costs one server connection, not two.
+//
+// Any failure — opener gone (`session-expired`), no snapshot within the stale
+// window, or an unsupported environment — flips the consumer unhealthy so its
+// polling fallback resumes. Fallback stays first-class everywhere.
 import { UI_API_ROUTES } from "@/lib/ui-api-routes.generated";
 import type { QuotesSnapshotResponse } from "@/types";
+import {
+  createCompanionBridge,
+  openCompanionChannel,
+  type BroadcastChannelLike,
+  type CompanionBridge
+} from "@/lib/companion-pane/chrome-bridge";
+import { isCompanionPaneRoute } from "@/lib/companion-pane/pane-window";
 
 export interface QuotesStreamHandlers {
   onSnapshot: (snapshot: QuotesSnapshotResponse) => void;
   onHealthChange?: (healthy: boolean) => void;
 }
 
-interface QuotesStreamConnection {
+export type QuotesStreamRole = "owner" | "follower";
+
+interface OwnerConnection {
   source: EventSource;
+  symbolsKey: string;
   handlers: Set<QuotesStreamHandlers>;
   healthy: boolean;
   lastSnapshot: QuotesSnapshotResponse | null;
   closeTimer: ReturnType<typeof setTimeout> | null;
 }
 
-const connections = new Map<string, QuotesStreamConnection>();
+interface FollowerConnection {
+  symbolsKey: string;
+  handlers: Set<QuotesStreamHandlers>;
+  healthy: boolean;
+  lastSnapshot: QuotesSnapshotResponse | null;
+  staleTimer: ReturnType<typeof setTimeout> | null;
+}
 
-// Grace period before an unreferenced connection closes, so StrictMode
+const connections = new Map<string, OwnerConnection>(); // owner, keyed by URL
+const followerConnections = new Map<string, FollowerConnection>(); // follower, keyed by symbolsKey
+
+// Grace period before an unreferenced owner connection closes, so StrictMode
 // double-mounts and quick same-stream transitions reuse it instead of churning.
 const CLOSE_LINGER_MS = 1000;
 
+// A follower is healthy only while snapshots keep arriving from the opener. If the
+// opener dies without firing `pagehide` (crash/kill), this watchdog flips the
+// follower unhealthy so polling resumes.
+const FOLLOWER_STALE_MS = 6000;
+
+let roleOverride: QuotesStreamRole | null = null;
+let channelOpener: () => BroadcastChannelLike | null = openCompanionChannel;
+let streamBridge: CompanionBridge | null | undefined;
+let ownerRequestUnsub: (() => void) | null = null;
+let followerBridgeUnsub: (() => void) | null = null;
+
+/** Role for this window: companion-pane routes follow, everything else owns. */
+export function resolveQuotesStreamRole(): QuotesStreamRole {
+  if (roleOverride !== null) {
+    return roleOverride;
+  }
+  if (typeof window === "undefined") {
+    return "owner";
+  }
+  return isCompanionPaneRoute(window.location.pathname) ? "follower" : "owner";
+}
+
+/** Lazily open the single shared companion bridge, or null when unavailable. */
+function getStreamBridge(): CompanionBridge | null {
+  if (streamBridge === undefined) {
+    const channel = channelOpener();
+    streamBridge = channel ? createCompanionBridge(channel) : null;
+  }
+  return streamBridge;
+}
+
+/** Normalized, deduplicated, sorted symbol-set key shared by URL and topic. */
+export function normalizeQuotesSymbolKey(symbols: readonly string[]): string {
+  return [...new Set(symbols.map((symbol) => symbol.trim().toUpperCase()).filter(Boolean))].sort().join(",");
+}
+
 export function buildQuotesStreamUrl(symbols: readonly string[]): string {
-  const normalized = [...new Set(symbols.map((symbol) => symbol.trim().toUpperCase()).filter(Boolean))].sort();
-  return normalized.length > 0
-    ? `${UI_API_ROUTES.WorkstationStream}?symbols=${encodeURIComponent(normalized.join(","))}`
+  const key = normalizeQuotesSymbolKey(symbols);
+  return key.length > 0
+    ? `${UI_API_ROUTES.WorkstationStream}?symbols=${encodeURIComponent(key)}`
     : UI_API_ROUTES.WorkstationStream;
 }
 
@@ -37,27 +101,44 @@ export function isQuotesStreamSupported(): boolean {
 
 /**
  * Subscribes to pushed quote snapshots for the given symbols. Returns an
- * unsubscribe callback; the underlying EventSource closes when the last
- * subscriber for the same symbol set leaves.
+ * unsubscribe callback. In the owner window the underlying EventSource closes
+ * when the last subscriber for the same symbol set leaves; in a follower pane no
+ * EventSource is opened at all.
  */
 export function subscribeQuotesStream(
   symbols: readonly string[],
   handlers: QuotesStreamHandlers
 ): () => void {
-  if (!isQuotesStreamSupported() || symbols.length === 0) {
+  if (symbols.length === 0) {
     handlers.onHealthChange?.(false);
     return () => undefined;
   }
 
+  if (resolveQuotesStreamRole() === "follower") {
+    return subscribeAsFollower(normalizeQuotesSymbolKey(symbols), handlers);
+  }
+
+  if (!isQuotesStreamSupported()) {
+    handlers.onHealthChange?.(false);
+    return () => undefined;
+  }
+
+  return subscribeAsOwner(symbols, handlers);
+}
+
+function subscribeAsOwner(symbols: readonly string[], handlers: QuotesStreamHandlers): () => void {
   const url = buildQuotesStreamUrl(symbols);
+  const symbolsKey = normalizeQuotesSymbolKey(symbols);
   let connection = connections.get(url);
   if (!connection) {
-    connection = openConnection(url);
+    connection = openConnection(url, symbolsKey);
     connections.set(url, connection);
   } else if (connection.closeTimer !== null) {
     clearTimeout(connection.closeTimer);
     connection.closeTimer = null;
   }
+
+  ensureOwnerRequestListener();
 
   connection.handlers.add(handlers);
   handlers.onHealthChange?.(connection.healthy);
@@ -83,10 +164,11 @@ export function subscribeQuotesStream(
   };
 }
 
-function openConnection(url: string): QuotesStreamConnection {
+function openConnection(url: string, symbolsKey: string): OwnerConnection {
   const source = new EventSource(url);
-  const connection: QuotesStreamConnection = {
+  const connection: OwnerConnection = {
     source,
+    symbolsKey,
     handlers: new Set(),
     healthy: false,
     lastSnapshot: null,
@@ -117,10 +199,173 @@ function openConnection(url: string): QuotesStreamConnection {
     for (const handler of connection.handlers) {
       handler.onSnapshot(snapshot);
     }
+    // Re-broadcast to any companion panes following this symbol set.
+    getStreamBridge()?.post({ type: "quotes", symbolsKey, snapshot });
   });
 
   // EventSource reconnects automatically; consumers resume polling while unhealthy.
   source.addEventListener("error", () => setHealthy(false));
 
   return connection;
+}
+
+/** Owner answers a follower's warm-up request with the latest snapshot it holds. */
+function ensureOwnerRequestListener(): void {
+  if (ownerRequestUnsub) {
+    return;
+  }
+  const bridge = getStreamBridge();
+  if (!bridge) {
+    return;
+  }
+  ownerRequestUnsub = bridge.subscribe((message) => {
+    if (message.type !== "quotes-request") {
+      return;
+    }
+    for (const connection of connections.values()) {
+      if (connection.symbolsKey === message.symbolsKey && connection.lastSnapshot) {
+        bridge.post({ type: "quotes", symbolsKey: connection.symbolsKey, snapshot: connection.lastSnapshot });
+        return;
+      }
+    }
+  });
+}
+
+function subscribeAsFollower(symbolsKey: string, handlers: QuotesStreamHandlers): () => void {
+  if (!symbolsKey) {
+    handlers.onHealthChange?.(false);
+    return () => undefined;
+  }
+
+  const bridge = getStreamBridge();
+  if (!bridge) {
+    // No cross-window channel — cannot follow; stay unhealthy so polling drives.
+    handlers.onHealthChange?.(false);
+    return () => undefined;
+  }
+
+  ensureFollowerListener(bridge);
+
+  let connection = followerConnections.get(symbolsKey);
+  if (!connection) {
+    connection = {
+      symbolsKey,
+      handlers: new Set(),
+      healthy: false,
+      lastSnapshot: null,
+      staleTimer: null
+    };
+    followerConnections.set(symbolsKey, connection);
+  }
+
+  connection.handlers.add(handlers);
+  armFollowerStaleTimer(connection);
+  handlers.onHealthChange?.(connection.healthy);
+  if (connection.lastSnapshot) {
+    handlers.onSnapshot(connection.lastSnapshot);
+  }
+
+  // Ask the opener to send the current snapshot immediately (fast warm-up).
+  bridge.post({ type: "quotes-request", symbolsKey });
+
+  return () => {
+    const current = followerConnections.get(symbolsKey);
+    if (!current) {
+      return;
+    }
+
+    current.handlers.delete(handlers);
+    if (current.handlers.size === 0) {
+      if (current.staleTimer !== null) {
+        clearTimeout(current.staleTimer);
+      }
+      followerConnections.delete(symbolsKey);
+      if (followerConnections.size === 0) {
+        detachFollowerListener();
+      }
+    }
+  };
+}
+
+/** Follower delivers snapshots from inbound `quotes` messages and degrades on loss. */
+function ensureFollowerListener(bridge: CompanionBridge): void {
+  if (followerBridgeUnsub) {
+    return;
+  }
+  followerBridgeUnsub = bridge.subscribe((message) => {
+    if (message.type === "quotes") {
+      const connection = followerConnections.get(message.symbolsKey);
+      if (!connection) {
+        return;
+      }
+      connection.lastSnapshot = message.snapshot;
+      armFollowerStaleTimer(connection);
+      setFollowerHealthy(connection, true);
+      for (const handler of connection.handlers) {
+        handler.onSnapshot(message.snapshot);
+      }
+    } else if (message.type === "session-expired") {
+      // Opener is gone — flip every follower unhealthy so polling resumes.
+      for (const connection of followerConnections.values()) {
+        setFollowerHealthy(connection, false);
+      }
+    }
+  });
+}
+
+function detachFollowerListener(): void {
+  followerBridgeUnsub?.();
+  followerBridgeUnsub = null;
+}
+
+function armFollowerStaleTimer(connection: FollowerConnection): void {
+  if (connection.staleTimer !== null) {
+    clearTimeout(connection.staleTimer);
+  }
+  connection.staleTimer = setTimeout(() => {
+    setFollowerHealthy(connection, false);
+  }, FOLLOWER_STALE_MS);
+}
+
+function setFollowerHealthy(connection: FollowerConnection, healthy: boolean): void {
+  if (connection.healthy === healthy) {
+    return;
+  }
+  connection.healthy = healthy;
+  for (const handler of connection.handlers) {
+    handler.onHealthChange?.(healthy);
+  }
+}
+
+/** Test seam: force a role, or pass null to restore route-based detection. */
+export function setQuotesStreamRoleForTests(role: QuotesStreamRole | null): void {
+  roleOverride = role;
+}
+
+/** Test seam: inject the companion channel opener (null restores the default). */
+export function setQuotesStreamChannelForTests(opener: (() => BroadcastChannelLike | null) | null): void {
+  resetQuotesStreamForTests();
+  channelOpener = opener ?? openCompanionChannel;
+}
+
+/** Test seam: tear down all connections, bridge listeners, and cached bridge. */
+export function resetQuotesStreamForTests(): void {
+  ownerRequestUnsub?.();
+  ownerRequestUnsub = null;
+  detachFollowerListener();
+  for (const connection of connections.values()) {
+    if (connection.closeTimer !== null) {
+      clearTimeout(connection.closeTimer);
+    }
+    connection.source.close();
+  }
+  connections.clear();
+  for (const connection of followerConnections.values()) {
+    if (connection.staleTimer !== null) {
+      clearTimeout(connection.staleTimer);
+    }
+  }
+  followerConnections.clear();
+  streamBridge?.close();
+  streamBridge = undefined;
 }


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Final increment (PR C) of the quote-stream fan-out blueprint (`docs/product/web-ui-stream-fan-out-blueprint-2026-07.md`). Companion panes now **follow** the main workstation window's quote feed over the existing same-origin companion `BroadcastChannel` instead of each opening their own `EventSource`. A pane open beside a live workstation window drops from **2 server SSE connections to 1**; the worst case (a stranded pane) is unchanged from today — it polls.

- **`lib/companion-pane/chrome-bridge.ts`** — two new `CompanionBridgeMessage` variants: `quotes` (owner → follower snapshot re-broadcast) and `quotes-request` (follower → owner warm-up). `normalizeCompanionBridgeMessage` structurally validates the symbol key and snapshot shape — cross-window data stays untrusted.
- **`lib/quotes-stream.ts`** — role is decided by route (`isCompanionPaneRoute`): companion-pane windows **follow**, every other window **owns**.
  - *Owner*: unchanged EventSource + refcount, and now re-broadcasts every snapshot to panes and answers `quotes-request` with its last snapshot.
  - *Follower*: opens **no** EventSource; emits a one-shot `quotes-request`, delivers snapshots from inbound `quotes` messages, and degrades to `healthy=false` on `session-expired` (opener closed via `pagehide`) or a stale-snapshot watchdog — so the consumer's polling fallback resumes. Fallback stays first-class; there is no owner-election in v1.
- Watchlist and live-quotes panes adopt **automatically** through `useQuotesStream` — no screen change (the role switch lives entirely inside the stream client).

## Reason

Phase 6d gave each browser window its own refcounted `EventSource`; a pop-out pane showing the same symbols opened a duplicate server connection because the refcount map is per-document. Composed with the server-side fan-out already merged (PRs A/B), this turns N windows into one owner feed re-broadcast to followers, without touching the market-data ingestion hot path.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully (CI is authoritative here)
- [x] Relevant unit tests were added or updated — extended `chrome-bridge.test.ts` (new-message validation) and `quotes-stream.test.ts` (owner re-broadcast + warm-up reply; follower opens no EventSource, warms up, delivers snapshots, degrades on `session-expired` and stale watchdog)
- [x] Not applicable — no server/integration surface in this increment (client-only)
- [ ] GitHub Actions `quality-gate` passed

Local: `npx vitest run` on the affected suites (15 + 7 tests) passed; `npm run build` (typecheck + bundle) and `eslint` on the changed files are clean.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vcv5Q6U9XF9hUrEJxYNerJ)_