### PR TITLE
fix: harden live order control metadata

### DIFF
--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -135,8 +135,8 @@
       "id": "SRC-EXECUTION",
       "path": "src/Meridian.Execution",
       "readme": "src/Meridian.Execution/README.md",
-      "readme_hash": "3f884b82dea5a3df12e6d5256392e3b304fc6ea38b82f9f6b560be2de119277b",
-      "source_hash": "33e0df1ae9648348dc691f22a1bb72b80f4558c92ca2f47505b88632166cade3"
+      "readme_hash": "d578005338d6cc2bd7901f9797d0116063b3c76b0d9b380d8b586c5107f90a6a",
+      "source_hash": "40079f33afe7884099c0963929dc7e8b011434af1a9bc528c0df78a043e87f79"
     },
     {
       "id": "SRC-EXECUTION-SDK",

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 540,
-  "total_lines": 90057,
+  "total_lines": 90060,
   "orphaned_count": 206,
   "no_heading_count": 38,
   "stale_count": 0,
@@ -4195,7 +4195,7 @@
     },
     {
       "path": "src/Meridian.Execution/README.md",
-      "line_count": 93,
+      "line_count": 96,
       "has_heading": true,
       "todo_count": 1,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 540 |
-| Total lines | 90,057 |
+| Total lines | 90,060 |
 | Average file size (lines) | 166.8 |
 | Orphaned files | 206 |
 | Files without headings | 38 |

--- a/src/Meridian.Execution/OrderManagementSystem.cs
+++ b/src/Meridian.Execution/OrderManagementSystem.cs
@@ -118,8 +118,9 @@ public sealed class OrderManagementSystem : IOrderManager, IDisposable
             };
         }
 
+        var requiresLiveOrderReadinessGate = RequiresLiveOrderReadinessGate(brokerName);
         LiveOrderReadinessDecision? liveOrderReadinessDecision = null;
-        if (RequiresLiveOrderReadinessGate(brokerName))
+        if (requiresLiveOrderReadinessGate)
         {
             liveOrderReadinessDecision = await EvaluateLiveOrderReadinessAsync(
                 safeRequest,
@@ -162,7 +163,9 @@ public sealed class OrderManagementSystem : IOrderManager, IDisposable
         ExecutionControlDecision? operatorControlDecision = null;
         if (_operatorControls is not null)
         {
-            var controlDecision = _operatorControls.EvaluateOrder(request, _portfolioState, runId);
+            // Live orders must not let client-owned override metadata bypass operator controls.
+            var controlRequest = requiresLiveOrderReadinessGate ? safeRequest : request;
+            var controlDecision = _operatorControls.EvaluateOrder(controlRequest, _portfolioState, runId);
             operatorControlDecision = controlDecision;
             if (!controlDecision.IsApproved)
             {

--- a/src/Meridian.Execution/README.md
+++ b/src/Meridian.Execution/README.md
@@ -45,11 +45,14 @@ validation gate, resolved Security Master identity, non-blocked validation, and 
 that preserves the Security Master ID, fill ID, symbol, and gate evidence for provenance.
 Live execution controls include persisted circuit-breaker state, position limits, and manual
 overrides. Run-scoped manual overrides are matched against order `runId` metadata, and submitted
-orders that use an override carry the applied override ID, run/strategy/symbol scope, and control
-decision metadata in the execution audit trail. Orders rejected by operator controls carry stable
-reject codes such as `CIRCUIT_BREAKER_OPEN`, `POSITION_LIMIT_EXCEEDED`, or `MANUAL_FORCE_BLOCK`
-plus the same run/strategy/symbol audit scope so operations can distinguish policy failures from
-broker failures during review. The OMS also records durable audit outcomes for
+paper orders that use an override carry the applied override ID, run/strategy/symbol scope, and
+control decision metadata in the execution audit trail. Live broker orders evaluate operator
+controls with broker-account, override, and live-readiness metadata stripped from the client
+request, so client-supplied override IDs cannot bypass kill-switch or position controls before
+broker routing. Orders rejected by operator controls carry stable reject codes such as
+`CIRCUIT_BREAKER_OPEN`, `POSITION_LIMIT_EXCEEDED`, or `MANUAL_FORCE_BLOCK` plus the same
+run/strategy/symbol audit scope so operations can distinguish policy failures from broker failures
+during review. The OMS also records durable audit outcomes for
 submitted, rejected, cancelled, cancel-rejected, modified, and modify-rejected order lifecycle
 events with broker, order, symbol, scope, reject reason, and operation metadata for operations
 review. Shared `/api/execution/controls/*` endpoints expose the snapshot plus secured mutations for

--- a/tests/Meridian.Tests/Execution/OrderManagementSystemTests.cs
+++ b/tests/Meridian.Tests/Execution/OrderManagementSystemTests.cs
@@ -635,6 +635,73 @@ public sealed class OrderManagementSystemTests : IDisposable
     }
 
     [Fact]
+    public async Task PlaceOrderAsync_WithLiveBrokerAndClientOverrideMetadata_DoesNotBypassOperatorControls()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "Meridian.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+        await using var auditTrail = new ExecutionAuditTrailService(
+            new ExecutionAuditTrailOptions(Path.Combine(tempRoot, "audit")),
+            NullLogger<ExecutionAuditTrailService>.Instance);
+        var controls = new ExecutionOperatorControlService(
+            new ExecutionOperatorControlOptions(Path.Combine(tempRoot, "controls")),
+            NullLogger<ExecutionOperatorControlService>.Instance,
+            auditTrail);
+        var bypassOverride = await controls.CreateManualOverrideAsync(new ManualOverrideRequest(
+            Kind: ExecutionManualOverrideKinds.BypassOrderControls,
+            Reason: "Operator approved emergency closeout.",
+            CreatedBy: "ops",
+            Symbol: "AAPL",
+            StrategyId: "strategy-live",
+            RunId: "run-live-001"));
+        await controls.SetCircuitBreakerAsync(
+            isOpen: true,
+            reason: "Operator halt",
+            changedBy: "ops");
+
+        var gateway = Substitute.For<IExecutionGateway>();
+        gateway.GatewayId.Returns("alpaca");
+        var liveReadinessGate = new RecordingLiveOrderReadinessGate(
+            LiveOrderReadinessDecision.Approved("audit://live/run-live-001"));
+        using var oms = new OrderManagementSystem(
+            gateway,
+            NullLogger<OrderManagementSystem>.Instance,
+            operatorControls: controls,
+            auditTrail: auditTrail,
+            brokerageConfiguration: CreateEnabledBrokerageConfiguration("alpaca"),
+            liveOrderReadinessGate: liveReadinessGate);
+
+        var result = await oms.PlaceOrderAsync(new OrderRequest
+        {
+            Symbol = "AAPL",
+            Side = OrderSide.Sell,
+            Type = OrderType.Market,
+            Quantity = 1m,
+            StrategyId = "strategy-live",
+            FundAccountId = LiveFundAccountId,
+            Metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["actor"] = "ops",
+                ["correlationId"] = "act-live-forged-override",
+                ["manualOverrideId"] = bypassOverride.OverrideId,
+                ["runId"] = "run-live-001"
+            }
+        });
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Operator halt");
+        liveReadinessGate.Request.Should().NotBeNull();
+        await gateway.DidNotReceive().SubmitOrderAsync(Arg.Any<OrderRequest>(), Arg.Any<CancellationToken>());
+
+        var auditEntries = await auditTrail.GetRecentAsync(10);
+        auditEntries.Should().Contain(entry =>
+            entry.Action == "OrderRejected" &&
+            entry.Reason == "CIRCUIT_BREAKER_OPEN" &&
+            entry.CorrelationId == "act-live-forged-override" &&
+            entry.Metadata != null &&
+            entry.Metadata["rejectCode"] == "CIRCUIT_BREAKER_OPEN");
+    }
+
+    [Fact]
     public async Task PlaceOrderAsync_WithClientBrokerAccountMetadata_StripsRoutingKeysBeforeGatewaySubmit()
     {
         OrderRequest? submittedRequest = null;


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary
- Hardens the live broker order path so operator controls evaluate live orders against the sanitized request, after broker-account, manual override, and live-readiness metadata are stripped from client-supplied order metadata.
- Adds a regression test proving a live broker order cannot use client-supplied `manualOverrideId` metadata to bypass an open circuit breaker, even when W7 live-readiness evidence is approved.
- Updates the execution source README, refreshes the reviewed `SRC-EXECUTION` source hash manifest entry, merges current `origin/main`, and regenerates the doc-health dashboard delta required by CI.

## Validation
- `dotnet test tests\Meridian.Tests\Meridian.Tests.csproj --filter "FullyQualifiedName~OrderManagementSystemTests" /p:EnableWindowsTargeting=true` -> pass before base merge (20 tests; existing warnings include NU1903 for Microsoft.OpenApi and existing analyzer/XML/nullability warnings)
- `dotnet test tests\Meridian.Tests\Meridian.Tests.csproj --filter "FullyQualifiedName~OrderManagementSystemTests" /p:EnableWindowsTargeting=true /p:UseSharedCompilation=false -m:1` -> pass after base merge (20 tests; same existing warnings)
- `dotnet test tests\Meridian.Tests\Meridian.Tests.csproj --no-build --filter "FullyQualifiedName~OrderManagementSystemGovernanceTests" /p:EnableWindowsTargeting=true /p:UseSharedCompilation=false -m:1` -> pass after base merge (5 tests)
- `python build\scripts\docs\generate-health-dashboard.py --output docs/status/doc-health-dashboard.md --json-output docs/status/doc-health-dashboard.json --summary` -> pass from clean detached worktree; copied only `docs/status/doc-health-dashboard.*` back to this branch
- `python build\scripts\docs\validate-source-readmes.py --summary` -> pass
- `python build\scripts\docs\render-source-docs.py --summary` -> pass, 0 files changed
- `git diff --check` -> pass
- `bash scripts/ci.sh` via `C:\Program Files\Git\bin\bash.exe` from a clean detached PR-head worktree with `TEMP`/`TMP`/`TMPDIR` and npm cache redirected to `D:\Meridian-ci-temp` -> pass (`Meridian CI lane 'quality-gate' completed successfully`)
- GitHub Actions on PR head `b0cd9ac` -> all checks pass; expected skips: `verify-full (coverage + scenario tests)` and aggregate `CodeQL`

## Notes
- `python build\scripts\docs\validate-doc-hashes.py --summary` still reports 19 pre-existing source-hash drifts outside this branch. `SRC-EXECUTION` was reviewed and refreshed with `--write-module SRC-EXECUTION`; it is absent from the residual drift list.
- A first full local `bash scripts/ci.sh` attempt in the primary checkout failed because `C:`/default temp had about 0.05 GB free; failures were disk-capacity writes under `AppData\Local\Temp\Meridian.Tests`, not branch logic. The clean-worktree retry passed with temp redirected to `D:`.