### PR TITLE
Harden theme storage access and accounting view-model null guards

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/ui/theme-toggle.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/theme-toggle.test.tsx
@@ -4,9 +4,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { APPEARANCE_STORAGE_KEY } from "@/lib/theme";
 
+const localStorageDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+
 afterEach(() => {
+  if (localStorageDescriptor) {
+    Object.defineProperty(window, "localStorage", localStorageDescriptor);
+  }
   document.documentElement.removeAttribute("data-theme");
   localStorage.clear();
+  vi.restoreAllMocks();
 });
 
 describe("ThemeToggle", () => {
@@ -29,5 +35,23 @@ describe("ThemeToggle", () => {
   it("marks the active appearance via aria-checked", () => {
     render(<ThemeToggle value="light" apply={false} />);
     expect(screen.getByRole("radio", { name: "Light" })).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("keeps custom persistence best-effort when browser storage is blocked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new DOMException("Storage is blocked.", "SecurityError");
+      }
+    });
+
+    render(<ThemeToggle persist="meridian.test.appearance" onChange={onChange} />);
+
+    await user.click(screen.getByRole("radio", { name: "Dark" }));
+
+    expect(onChange).toHaveBeenCalledWith("dark");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
   });
 });

--- a/src/Meridian.Ui/dashboard/src/components/ui/theme-toggle.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/theme-toggle.tsx
@@ -1,6 +1,14 @@
 import { Monitor, Moon, Sun } from "lucide-react";
 import { useEffect, useState } from "react";
-import { applyAppearance, APPEARANCE_STORAGE_KEY, readStoredAppearance, writeStoredAppearance, type Appearance } from "@/lib/theme";
+import {
+  applyAppearance,
+  APPEARANCE_STORAGE_KEY,
+  getLocalStorage,
+  isAppearance,
+  readStoredAppearance,
+  writeStoredAppearance,
+  type Appearance
+} from "@/lib/theme";
 import { broadcastCompanionState } from "@/lib/companion-pane/opener-broadcast";
 import { cn } from "@/lib/utils";
 
@@ -45,11 +53,9 @@ export function ThemeToggle({
     if (persist === APPEARANCE_STORAGE_KEY) {
       return readStoredAppearance();
     }
-    if (persist && typeof localStorage !== "undefined") {
-      const saved = localStorage.getItem(persist);
-      if (saved === "system" || saved === "light" || saved === "dark") {
-        return saved;
-      }
+    const saved = persist ? readCustomStoredAppearance(persist) : null;
+    if (saved) {
+      return saved;
     }
     return defaultValue;
   });
@@ -69,8 +75,8 @@ export function ThemeToggle({
       writeStoredAppearance(next);
       // Push the appearance change to any open companion panes so they retheme live.
       broadcastCompanionState({ type: "appearance", appearance: next });
-    } else if (persist && typeof localStorage !== "undefined") {
-      localStorage.setItem(persist, next);
+    } else if (persist) {
+      writeCustomStoredAppearance(persist, next);
     }
     onChange?.(next);
   };
@@ -111,4 +117,21 @@ export function ThemeToggle({
       })}
     </div>
   );
+}
+
+function readCustomStoredAppearance(key: string): Appearance | null {
+  try {
+    const saved = getLocalStorage()?.getItem(key);
+    return isAppearance(saved) ? saved : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCustomStoredAppearance(key: string, appearance: Appearance) {
+  try {
+    getLocalStorage()?.setItem(key, appearance);
+  } catch {
+    // Custom appearance persistence is best-effort when browser storage is blocked.
+  }
 }

--- a/src/Meridian.Ui/dashboard/src/lib/theme.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/theme.ts
@@ -7,12 +7,20 @@ export function isAppearance(value: unknown): value is Appearance {
 }
 
 export function readStoredAppearance(storage: Storage | null = getLocalStorage()): Appearance {
-  const stored = storage?.getItem(APPEARANCE_STORAGE_KEY);
-  return isAppearance(stored) ? stored : "system";
+  try {
+    const stored = storage?.getItem(APPEARANCE_STORAGE_KEY);
+    return isAppearance(stored) ? stored : "system";
+  } catch {
+    return "system";
+  }
 }
 
 export function writeStoredAppearance(appearance: Appearance, storage: Storage | null = getLocalStorage()) {
-  storage?.setItem(APPEARANCE_STORAGE_KEY, appearance);
+  try {
+    storage?.setItem(APPEARANCE_STORAGE_KEY, appearance);
+  } catch {
+    // Appearance persistence is best-effort when browser storage is blocked.
+  }
 }
 
 export function applyAppearance(
@@ -31,7 +39,7 @@ export function applyAppearance(
   root.setAttribute("data-theme", appearance);
 }
 
-function getLocalStorage() {
+export function getLocalStorage() {
   try {
     return typeof localStorage === "undefined" ? null : localStorage;
   } catch {

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.capital-accounts.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.capital-accounts.view-model.test.ts
@@ -101,6 +101,69 @@ const fundEventLedgerRecord: PrivateCapitalFundEventLedgerRecord = {
   }
 };
 
+function createCapitalAccountWorkbench(
+  fundEventRecords: CapitalAccountWorkbench["investorAccounts"][number]["fundEventRecords"]
+): CapitalAccountWorkbench {
+  return {
+    fundProfileId: "fund-alpha",
+    ledgerBookId: "book-alpha",
+    projectedAtUtc: "2026-06-30T17:00:00Z",
+    capitalAccountId: "capital-account:fund-alpha:lp-1",
+    investorId: "investor:lp-1",
+    currency: "USD",
+    workbenchRoute: "/api/ledger/private-capital/capital-account-workbench?capitalAccountId=capital-account%3Afund-alpha%3Alp-1",
+    statusLabel: "Ready",
+    statusReason: "Capital account projection loaded.",
+    investorAccountCount: 1,
+    fundEventCount: fundEventRecords?.length ?? 0,
+    statementCount: 0,
+    restatementLineageCount: 0,
+    auditDrillThroughCount: 0,
+    netCapitalActivity: 125,
+    investorAccounts: [{
+      accountKey: "capital-account:fund-alpha:lp-1|investor:lp-1|USD",
+      capitalAccountId: "capital-account:fund-alpha:lp-1",
+      investorId: "investor:lp-1",
+      currency: "USD",
+      activityRoute: "/api/ledger/private-capital/capital-account-subledger?capitalAccountId=capital-account%3Afund-alpha%3Alp-1",
+      readiness: "Ready",
+      readinessLabel: "Ready",
+      readinessReason: "Retained evidence and statement support are available.",
+      nextAction: "Open statement",
+      nextActionRoute: "/api/ledger/private-capital/report-output?reportOutputId=report-output-1",
+      openingNetActivity: 0,
+      endingNetActivity: 125,
+      netCapitalActivity: 125,
+      contributions: 125,
+      distributions: 0,
+      subscriptions: 0,
+      redemptions: 0,
+      managementFees: 0,
+      fundEventCount: fundEventRecords?.length ?? 0,
+      postedFundEventCount: 0,
+      approvalQueueCount: 0,
+      publishedReportOutputCount: 0,
+      evidenceLinkCount: 0,
+      validationIssueCount: 0,
+      evidenceCategorySummary: "No evidence categories projected.",
+      evidenceLinks: [],
+      evidenceCategories: [],
+      fundEventRecords,
+      subledgerEntries: [],
+      ledgerImpacts: [],
+      reportOutputs: [],
+      validationIssues: [],
+      paymentIntentEvidence: null
+    }],
+    allocationRules: [],
+    statementLineage: [],
+    auditDrillThroughs: [],
+    validationIssues: [],
+    liveCapabilities: [],
+    plannedCapabilities: []
+  };
+}
+
 describe("accounting capital account view model", () => {
   it("loads the Capital Account Workbench with investor evidence, allocation rules, lineage, and audit drill-through rows", async () => {
     const workbench: CapitalAccountWorkbench = {
@@ -318,5 +381,22 @@ describe("accounting capital account view model", () => {
     });
     expect(result.current.liveCapabilities).toContain("Investor-level capital account evidence");
     expect(result.current.plannedCapabilities).toContain("Broad LP portal self-service");
+  });
+
+  it("renders investor accounts when fund-event records are absent from the projection", async () => {
+    const workbench = createCapitalAccountWorkbench(null as unknown as CapitalAccountWorkbench["investorAccounts"][number]["fundEventRecords"]);
+    const services: CapitalAccountWorkbenchServices = {
+      getWorkbench: vi.fn().mockResolvedValue(workbench)
+    };
+
+    const { result } = renderHook(() => useCapitalAccountWorkbenchViewModel(
+      true,
+      "?capitalAccountId=capital-account%3Afund-alpha%3Alp-1&investorId=investor%3Alp-1&currency=USD",
+      services
+    ));
+
+    await waitFor(() => expect(result.current.statusLabel).toBe("Ready"));
+    expect(result.current.investorAccounts).toHaveLength(1);
+    expect(result.current.fundEventCommandRows).toEqual([]);
   });
 });

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.capital-accounts.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.capital-accounts.view-model.ts
@@ -178,7 +178,7 @@ function buildCapitalAccountFundEventCommandRows(
   const rows: CapitalAccountWorkbenchFundEventCommandRowViewModel[] = [];
 
   for (const account of workbench.investorAccounts) {
-    for (const record of account.fundEventRecords) {
+    for (const record of account.fundEventRecords ?? []) {
       if (seen.has(record.fundEventId)) {
         continue;
       }
@@ -203,7 +203,7 @@ function buildCapitalAccountInvestorAccountRow(
     account.evidenceLinks,
     account.currency,
     account.netCapitalActivity,
-    account.fundEventRecords[0]?.effectiveDate ?? null
+    account.fundEventRecords?.[0]?.effectiveDate ?? null
   );
 
   return {

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.journal-entries.view-model.test.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.journal-entries.view-model.test.ts
@@ -1192,6 +1192,60 @@ describe("accounting-screen journal-entry view model", () => {
     ]));
   });
 
+  it("treats absent private-capital activity collections as empty rows", async () => {
+    const workbench: ManualJournalEntryWorkbench = {
+      ...manualJournalWorkbench,
+      privateCapitalActivity: {
+        ...manualJournalWorkbench.privateCapitalActivity!,
+        fundEvents: null,
+        capitalAccounts: null,
+        capitalAccountSubledgers: null,
+        capitalAccountSubledgerEntries: null,
+        ledgerImpacts: null,
+        reportOutputs: null,
+        fundEventRecords: null,
+        paymentIntents: null,
+        validationIssues: null
+      } as unknown as ManualJournalEntryWorkbench["privateCapitalActivity"]
+    };
+    const services: ManualJournalEntryWorkbenchServices = {
+      getWorkbench: vi.fn().mockResolvedValue(workbench),
+      searchSecurities: vi.fn().mockResolvedValue([]),
+      saveDraft: vi.fn().mockResolvedValue(manualJournalDraft),
+      validateDraft: vi.fn().mockResolvedValue(manualJournalDraft),
+      submitApproval: vi.fn().mockResolvedValue(manualJournalDraft),
+      attachEvidence: vi.fn().mockResolvedValue(manualJournalDraft),
+      applyLifecycleAction: vi.fn().mockResolvedValue({
+        journalEntry: manualJournalDraft,
+        transition: {
+          transitionId: "transition-approve",
+          fromStatus: "Submitted",
+          toStatus: "Approved",
+          action: "Approve",
+          actor: "browser-user",
+          recordedAtUtc: "2026-06-30T02:00:00Z",
+          notes: null,
+          correlationId: "manual-je-approve",
+          evidenceLinks: []
+        },
+        generatedJournalEntries: []
+      })
+    };
+
+    const { result } = renderHook(() => useManualJournalEntryWorkbenchViewModel(true, services));
+
+    await waitFor(() => expect(result.current.privateCapitalActivity.statusLabel).toBe("1 fund events / 1 capital accounts"));
+    expect(result.current.privateCapitalActivity.fundEvents).toEqual([]);
+    expect(result.current.privateCapitalActivity.capitalAccounts).toEqual([]);
+    expect(result.current.privateCapitalActivity.capitalAccountSubledgers).toEqual([]);
+    expect(result.current.privateCapitalActivity.capitalAccountSubledgerEntries).toEqual([]);
+    expect(result.current.privateCapitalActivity.ledgerImpacts).toEqual([]);
+    expect(result.current.privateCapitalActivity.reportOutputs).toEqual([]);
+    expect(result.current.privateCapitalActivity.fundEventLedgerRecords).toEqual([]);
+    expect(result.current.privateCapitalActivity.paymentIntents).toEqual([]);
+    expect(result.current.privateCapitalActivity.validationIssues).toEqual([]);
+  });
+
   it("loads manual journal entries with route ledger-book scope and preserves scope on mutations", async () => {
     const scopedWorkbench: ManualJournalEntryWorkbench = {
       ...manualJournalWorkbench,

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.journal-entries.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.journal-entries.view-model.ts
@@ -586,18 +586,20 @@ function buildManualJournalPrivateCapitalActivityView(
   }
 
   const currency = activity.currency || "USD";
+  const fundEvents = activity.fundEvents ?? [];
+  const capitalAccounts = activity.capitalAccounts ?? [];
   const capitalAccountSubledgers = activity.capitalAccountSubledgers ?? [];
-  const capitalAccountSubledgerEntries = activity.capitalAccountSubledgerEntries;
-  const ledgerImpacts = activity.ledgerImpacts;
-  const reportOutputs = activity.reportOutputs;
-  const fundEventLedgerRecords = activity.fundEventRecords;
+  const capitalAccountSubledgerEntries = activity.capitalAccountSubledgerEntries ?? [];
+  const ledgerImpacts = activity.ledgerImpacts ?? [];
+  const reportOutputs = activity.reportOutputs ?? [];
+  const fundEventLedgerRecords = activity.fundEventRecords ?? [];
   const paymentIntents = activity.paymentIntents ?? [];
   const fundEventLedgerRecordCount = fundEventLedgerRecords.length;
   const deferredPaymentIntentCount = paymentIntents.filter((item) => item.status === "ExecutionDeferred").length;
   const blockedPaymentIntentCount = paymentIntents.filter((item) => item.status === "Blocked" || item.status === "BankReturned").length;
   const postedFundEventCount = activity.postedFundEventCount ?? 0;
   const publishedReportOutputCount = activity.publishedReportOutputCount ?? 0;
-  const validationIssues = activity.validationIssues.map<AccountingConfigurationIssueViewModel>((issue, index) => ({
+  const validationIssues = (activity.validationIssues ?? []).map<AccountingConfigurationIssueViewModel>((issue, index) => ({
     id: `${issue.code}-${index}`,
     label: issue.code,
     message: issue.message,
@@ -689,8 +691,8 @@ function buildManualJournalPrivateCapitalActivityView(
         tone: validationIssues.length > 0 ? "warning" : "success"
       }
     ],
-    fundEvents: activity.fundEvents.map(buildManualJournalPrivateCapitalFundEventRow),
-    capitalAccounts: activity.capitalAccounts.map(buildManualJournalPrivateCapitalAccountRow),
+    fundEvents: fundEvents.map(buildManualJournalPrivateCapitalFundEventRow),
+    capitalAccounts: capitalAccounts.map(buildManualJournalPrivateCapitalAccountRow),
     capitalAccountSubledgers: capitalAccountSubledgers.map(buildManualJournalPrivateCapitalCapitalAccountSubledgerRow),
     capitalAccountSubledgerEntries: capitalAccountSubledgerEntries.map(buildManualJournalPrivateCapitalSubledgerEntryRow),
     ledgerImpacts: ledgerImpacts.map(buildManualJournalPrivateCapitalLedgerImpactRow),


### PR DESCRIPTION
## Summary
Salvages unlanded work recovered from the `codex/pr2083-review-fixes` worktree, rebased onto current main:

- **theme.ts**: storage read/write wrapped in try/catch so blocked browser storage (sandboxed iframes, privacy modes) falls back to defaults; `getLocalStorage` exported for reuse.
- **ThemeToggle**: custom persist keys go through safe storage helpers instead of raw `localStorage`; main's companion-pane broadcast retained.
- **Accounting view-models**: null guards for optional `fundEventRecords`, `fundEvents`, `capitalAccounts`, subledger/ledger-impact/report-output/validation-issue arrays in the capital-accounts and journal-entries builders, with regression tests for sparse workbench payloads.

The stash's regenerated `source-hash-manifest.json` was excluded (computed against stale sources); regenerate here if verify-docs asks for it.

## Validation
Not built locally (disk pressure); relying on quality-gate (verify-browser runs the new vitest suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)