### PR TITLE
Cancel activation token before load token in SymbolsPageViewModel

### DIFF
--- a/src/Meridian.Wpf/ViewModels/SymbolsPageViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/SymbolsPageViewModel.cs
@@ -424,8 +424,8 @@ public sealed class SymbolsPageViewModel : BindableBase, IPageActivationLifetime
 
     public void CancelActivation()
     {
-        CancelWithoutDisposing(Interlocked.Exchange(ref _loadCts, null));
         CancelWithoutDisposing(Interlocked.Exchange(ref _activationCts, null));
+        CancelWithoutDisposing(Interlocked.Exchange(ref _loadCts, null));
     }
 
     public void Deactivate()

--- a/tests/Meridian.Wpf.Tests/ViewModels/SymbolsPageViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/SymbolsPageViewModelTests.cs
@@ -24,8 +24,11 @@ public sealed class SymbolsPageViewModelTests
         viewModel.Should().Contain("public Task StartAsync(CancellationToken ct = default) => ActivateAsync(ct)");
         viewModel.Should().Contain("public void Stop() => Deactivate()");
         viewModel.Should().Contain("CancellationTokenSource.CreateLinkedTokenSource(ActivationToken, ct)");
-        viewModel.Should().Contain("CancelWithoutDisposing(Interlocked.Exchange(ref _loadCts, null))");
-        viewModel.Should().Contain("CancelWithoutDisposing(Interlocked.Exchange(ref _activationCts, null))");
+        var activationCancellation = viewModel.IndexOf("CancelWithoutDisposing(Interlocked.Exchange(ref _activationCts, null))", StringComparison.Ordinal);
+        var loadCancellation = viewModel.IndexOf("CancelWithoutDisposing(Interlocked.Exchange(ref _loadCts, null))", StringComparison.Ordinal);
+        activationCancellation.Should().BeGreaterThanOrEqualTo(0);
+        loadCancellation.Should().BeGreaterThanOrEqualTo(0);
+        activationCancellation.Should().BeLessThan(loadCancellation);
         viewModel.Should().Contain("_getConfiguredSymbolsAsync(loadCts.Token)");
         viewModel.Should().Contain("activationCts.Dispose();");
     }


### PR DESCRIPTION
## Summary
Salvages a small fix recovered from the `codex/wpf-symbols-cancel-fix` worktree. `CancelActivation` now cancels `_activationCts` before `_loadCts`, so an in-flight load observes the linked activation-scope cancellation rather than racing it. The source-inspection test now asserts the cancellation order instead of just the presence of both calls.

## Validation
Not built locally (disk pressure); relying on quality-gate (verify-dotnet / WPF test lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)