### PR TITLE
ci(actions): bump setup-dotnet to v5.4.0 and setup-python to v6.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
 
@@ -234,7 +234,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.12"
 
@@ -269,7 +269,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Set up .NET SDK
         if: matrix.language == 'csharp'
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -34,7 +34,7 @@ jobs:
           node-version: "20"
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/desktop-installer-packaging.yml
+++ b/.github/workflows/desktop-installer-packaging.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
 
@@ -105,7 +105,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
 

--- a/.github/workflows/desktop-screenshot-capture.yml
+++ b/.github/workflows/desktop-screenshot-capture.yml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
 

--- a/.github/workflows/desktop-standalone-publish.yml
+++ b/.github/workflows/desktop-standalone-publish.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
 

--- a/.github/workflows/desktop-user-manual.yml
+++ b/.github/workflows/desktop-user-manual.yml
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
 

--- a/.github/workflows/desktop-workflow-runner.yml
+++ b/.github/workflows/desktop-workflow-runner.yml
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -56,7 +56,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.12"
 
@@ -98,7 +98,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/golden-path-validation.yml
+++ b/.github/workflows/golden-path-validation.yml
@@ -103,7 +103,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -138,12 +138,12 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ibapi-smoke.yml
+++ b/.github/workflows/ibapi-smoke.yml
@@ -52,7 +52,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
 

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/meridian-ci.yml
+++ b/.github/workflows/meridian-ci.yml
@@ -39,12 +39,12 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.12"
 
@@ -92,7 +92,7 @@ jobs:
           cache-dependency-path: src/Meridian.Ui/dashboard/package-lock.json
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.12"
 
@@ -123,7 +123,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.12"
 
@@ -156,7 +156,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/provider-validation.yml
+++ b/.github/workflows/provider-validation.yml
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
 

--- a/.github/workflows/publish-smoke.yml
+++ b/.github/workflows/publish-smoke.yml
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
 

--- a/.github/workflows/roadmap-source-docs.yml
+++ b/.github/workflows/roadmap-source-docs.yml
@@ -52,7 +52,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.12"
 
@@ -98,7 +98,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/roadmap-tools-manual.yml
+++ b/.github/workflows/roadmap-tools-manual.yml
@@ -55,7 +55,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/robinhood-options-smoke.yml
+++ b/.github/workflows/robinhood-options-smoke.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
 

--- a/.github/workflows/targeted-test.yml
+++ b/.github/workflows/targeted-test.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Set up .NET SDK
         if: inputs.mode == 'dotnet-filtered' || inputs.mode == 'wpf-dev-loop' || inputs.mode == 'wpf-route' || inputs.mode == 'desktop-smoke'
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
 
@@ -98,7 +98,7 @@ jobs:
 
       - name: Set up Python
         if: inputs.mode == 'docs-source'
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/windows-desktop-build.yml
+++ b/.github/workflows/windows-desktop-build.yml
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
 

--- a/.github/workflows/wpf-dev-validation.yml
+++ b/.github/workflows/wpf-dev-validation.yml
@@ -88,7 +88,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
 

--- a/.github/workflows/wpf-route-validation.yml
+++ b/.github/workflows/wpf-route-validation.yml
@@ -88,7 +88,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: global.json
 

--- a/build/scripts/ci/check-workflow-hygiene.py
+++ b/build/scripts/ci/check-workflow-hygiene.py
@@ -18,11 +18,11 @@ WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 
 CURRENT_ACTION_REFS = {
     "actions/checkout": "v6.0.2",
-    "actions/setup-dotnet": "v5.2.0",
+    "actions/setup-dotnet": "v5.4.0",
     "actions/cache": "v5.0.5",
     "actions/upload-artifact": "v7.0.1",
     "actions/setup-node": "v6.4.0",
-    "actions/setup-python": "v6.2.0",
+    "actions/setup-python": "v6.3.0",
 }
 
 ACTIVE_DOC_ROOTS = [


### PR DESCRIPTION
## Summary
Salvages the action version bumps recovered from the `codex/node24-actions-current` and `codex/node24-actions-hygiene` worktrees:

- `actions/setup-dotnet` v5.2.0 → v5.4.0 (20 uses across 22 workflow files)
- `actions/setup-python` v6.2.0 → v6.3.0 (14 uses)
- Matching pin updates in `build/scripts/ci/check-workflow-hygiene.py` so the hygiene gate accepts the bumped refs.

Supersedes dependabot PR #2011, which contains the same workflow bumps but cannot update the hygiene pin map — close #2011 once this merges.

## Validation
Not built locally; relying on quality-gate and verify-workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)