### PR TITLE
Add tests for compliance policy engine and brokerage go-live gates

### DIFF
--- a/tests/Meridian.Tests/Compliance/AccessReviewServiceTests.cs
+++ b/tests/Meridian.Tests/Compliance/AccessReviewServiceTests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using Meridian.Audit.Compliance;
+using Xunit;
+
+namespace Meridian.Tests.Compliance;
+
+/// <summary>
+/// Guards the dormant-permission access review. The failure mode under guard: a
+/// privileged role left on an actor who has not used it in over 90 days survives the
+/// periodic review, widening the standing-privilege surface.
+/// </summary>
+public sealed class AccessReviewServiceTests
+{
+    [Fact]
+    public void ReviewDormantPermissions_LastUsedOver90DaysAgo_RemovesAllRoles()
+    {
+        var service = new AccessReviewService();
+        string[] roles = ["TreasuryOperator", "OverrideApprover"];
+
+        var review = service.ReviewDormantPermissions(
+            actorId: "treasury-ops-1",
+            reviewedBy: "compliance-lead",
+            currentRoles: roles,
+            lastUsedAtUtc: DateTimeOffset.UtcNow.AddDays(-120));
+
+        review.RemovedRoles.Should().BeEquivalentTo(roles,
+            "dormant privileged roles must be stripped by the periodic review");
+        review.Reason.Should().Be("Dormant permissions cleanup.");
+        review.ActorId.Should().Be("treasury-ops-1");
+        review.ReviewedBy.Should().Be("compliance-lead");
+    }
+
+    [Fact]
+    public void ReviewDormantPermissions_RecentlyUsed_RemovesNothing()
+    {
+        var service = new AccessReviewService();
+
+        var review = service.ReviewDormantPermissions(
+            actorId: "treasury-ops-1",
+            reviewedBy: "compliance-lead",
+            currentRoles: ["TreasuryOperator"],
+            lastUsedAtUtc: DateTimeOffset.UtcNow.AddDays(-30));
+
+        review.RemovedRoles.Should().BeEmpty(
+            "actively used roles must survive the review untouched");
+        review.Reason.Should().Be("No dormant permissions.");
+    }
+
+    [Fact]
+    public void GetReviews_AccumulatesEveryReviewRecord()
+    {
+        var service = new AccessReviewService();
+
+        var dormant = service.ReviewDormantPermissions(
+            "actor-a", "compliance-lead", ["RulesAdmin"], DateTimeOffset.UtcNow.AddDays(-365));
+        var active = service.ReviewDormantPermissions(
+            "actor-b", "compliance-lead", ["ReconciliationOfficer"], DateTimeOffset.UtcNow.AddDays(-1));
+
+        service.GetReviews().Should().HaveCount(2,
+            "the review trail is compliance evidence and must retain every outcome")
+            .And.ContainInOrder(dormant, active);
+    }
+}

--- a/tests/Meridian.Tests/Compliance/CompliancePolicyEngineTests.cs
+++ b/tests/Meridian.Tests/Compliance/CompliancePolicyEngineTests.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using Meridian.Audit.Compliance;
 
 namespace Meridian.Tests.Compliance;
@@ -56,4 +57,154 @@ public sealed class CompliancePolicyEngineTests
         Assert.True(audit.VerifyIntegrity());
         Assert.Equal(2, audit.GetAll().Count);
     }
+
+    [Theory]
+    [InlineData(SensitiveAction.RuleEdit)]
+    [InlineData(SensitiveAction.BreakClosure)]
+    [InlineData(SensitiveAction.PaymentRelease)]
+    [InlineData(SensitiveAction.OverrideApproval)]
+    public void Evaluate_ActorLacksRequiredRole_Rejects(SensitiveAction action)
+    {
+        var policy = new CompliancePolicyEngine();
+        var actor = new ActorContext(
+            "analyst-1", ["ReadOnlyAnalyst"], "Research", "10.0.0.5", "desk-3", MfaSatisfied: true);
+        var request = CreateRequest(
+            action,
+            requestedBy: "requester-1",
+            approvers: ["approver-2", "approver-3"]);
+
+        var result = policy.Evaluate(actor, request);
+
+        result.Allowed.Should().BeFalse(
+            "every sensitive action requires its dedicated privileged role");
+        result.Reason.Should().Be("Missing required privileged role.");
+    }
+
+    [Fact]
+    public void Evaluate_UnknownAction_Rejects()
+    {
+        var policy = new CompliancePolicyEngine();
+        var actor = new ActorContext(
+            "ops-1", ["RulesAdmin", "TreasuryOperator"], "Ops", "10.0.0.1", "laptop", MfaSatisfied: true);
+        var request = CreateRequest((SensitiveAction)999, requestedBy: "requester-1");
+
+        var result = policy.Evaluate(actor, request);
+
+        result.Allowed.Should().BeFalse("actions outside the policy catalog must default to deny");
+        result.Reason.Should().Be("Unknown action.");
+    }
+
+    [Theory]
+    [InlineData(SensitiveAction.RuleEdit, "RulesAdmin")]
+    [InlineData(SensitiveAction.BreakClosure, "ReconciliationOfficer")]
+    public void Evaluate_NonStepUpActionWithoutMfa_Allows(SensitiveAction action, string role)
+    {
+        // Rule edits and break closures require the privileged role but no MFA step-up
+        // or dual approval; this pins the boundary so step-up rules do not silently
+        // expand or contract.
+        var policy = new CompliancePolicyEngine();
+        var actor = new ActorContext(
+            "ops-1", [role], "Ops", "10.0.0.1", "laptop", MfaSatisfied: false);
+        var request = CreateRequest(action, requestedBy: "requester-1", approvers: null);
+
+        var result = policy.Evaluate(actor, request);
+
+        result.Allowed.Should().BeTrue();
+        result.Reason.Should().Be("Allowed");
+    }
+
+    [Theory]
+    [InlineData(SensitiveAction.PaymentRelease, "TreasuryOperator")]
+    [InlineData(SensitiveAction.OverrideApproval, "OverrideApprover")]
+    public void Evaluate_StepUpActionWithoutMfa_Rejects(SensitiveAction action, string role)
+    {
+        var policy = new CompliancePolicyEngine();
+        var actor = new ActorContext(
+            "approver-1", [role], "Treasury", "10.0.0.1", "laptop", MfaSatisfied: false);
+        var request = CreateRequest(
+            action,
+            requestedBy: "requester-1",
+            approvers: ["approver-2", "approver-3"]);
+
+        var result = policy.Evaluate(actor, request);
+
+        result.Allowed.Should().BeFalse("payment release and override approval require MFA step-up");
+        result.Reason.Should().Be("Step-up requirement failed: MFA required.");
+    }
+
+    public static TheoryData<string[]?> InsufficientApprovers => new()
+    {
+        null,
+        Array.Empty<string>(),
+        new[] { "approver-2" }
+    };
+
+    [Theory]
+    [MemberData(nameof(InsufficientApprovers))]
+    public void Evaluate_StepUpActionWithoutTwoApprovers_Rejects(string[]? approvers)
+    {
+        var policy = new CompliancePolicyEngine();
+        var actor = new ActorContext(
+            "approver-1", ["TreasuryOperator"], "Treasury", "10.0.0.1", "laptop", MfaSatisfied: true);
+        var request = CreateRequest(
+            SensitiveAction.PaymentRelease,
+            requestedBy: "requester-1",
+            approvers: approvers);
+
+        var result = policy.Evaluate(actor, request);
+
+        result.Allowed.Should().BeFalse();
+        result.Reason.Should().Be("Step-up requirement failed: dual approval required.");
+    }
+
+    [Fact]
+    public void Evaluate_DuplicateApproversDifferingOnlyByCase_RejectsDualApproval()
+    {
+        // One person approving twice under case variants of the same id must not
+        // satisfy dual approval.
+        var policy = new CompliancePolicyEngine();
+        var actor = new ActorContext(
+            "approver-1", ["TreasuryOperator"], "Treasury", "10.0.0.1", "laptop", MfaSatisfied: true);
+        var request = CreateRequest(
+            SensitiveAction.PaymentRelease,
+            requestedBy: "requester-1",
+            approvers: ["approver-2", "APPROVER-2"]);
+
+        var result = policy.Evaluate(actor, request);
+
+        result.Allowed.Should().BeFalse();
+        result.Reason.Should().Be("Step-up requirement failed: dual approval required.");
+    }
+
+    [Fact]
+    public void Evaluate_SelfApprovalWithCaseInsensitiveActorIdMatch_Rejects()
+    {
+        var policy = new CompliancePolicyEngine();
+        var actor = new ActorContext(
+            "Approver-1", ["OverrideApprover"], "Risk", "10.0.0.1", "laptop", MfaSatisfied: true);
+        var request = CreateRequest(
+            SensitiveAction.OverrideApproval,
+            requestedBy: "approver-1",
+            approvers: ["approver-2", "approver-3"]);
+
+        var result = policy.Evaluate(actor, request);
+
+        result.Allowed.Should().BeFalse(
+            "segregation of duties must not be bypassable via actor-id casing");
+        result.Reason.Should().Contain("Segregation of duties violation");
+    }
+
+    private static ComplianceActionRequest CreateRequest(
+        SensitiveAction action,
+        string? requestedBy = null,
+        string[]? approvers = null) => new(
+        action,
+        ObjectType: "Payment",
+        ObjectId: "payment-1",
+        BeforeStateJson: "{\"status\":\"pending\"}",
+        AfterStateJson: "{\"status\":\"released\"}",
+        CorrelationId: "corr-1",
+        EntityId: "fund-1",
+        RequestedByActorId: requestedBy,
+        AdditionalApproverIds: approvers);
 }

--- a/tests/Meridian.Tests/Compliance/ImmutableAuditLogServiceTests.cs
+++ b/tests/Meridian.Tests/Compliance/ImmutableAuditLogServiceTests.cs
@@ -1,0 +1,123 @@
+using FluentAssertions;
+using Meridian.Audit.Compliance;
+using Xunit;
+
+namespace Meridian.Tests.Compliance;
+
+/// <summary>
+/// Guards the tamper-evident audit trail behind privileged compliance actions. The
+/// failure mode under guard: an audit event whose hash chain no longer proves ordering
+/// and content, letting a payment release or override approval be altered or reordered
+/// without detection.
+/// </summary>
+public sealed class ImmutableAuditLogServiceTests
+{
+    [Fact]
+    public void VerifyIntegrity_EmptyLog_ReturnsTrue()
+    {
+        var audit = new ImmutableAuditLogService();
+
+        audit.VerifyIntegrity().Should().BeTrue();
+        audit.GetAll().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Append_FirstEvent_HasNoPreviousHash()
+    {
+        var audit = new ImmutableAuditLogService();
+
+        var evt = audit.Append(CreateActor(), CreateRequest("payment-1"));
+
+        evt.PreviousHash.Should().BeNull();
+        evt.Hash.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void Append_ChainsEachEventToThePreviousHash()
+    {
+        var audit = new ImmutableAuditLogService();
+        var actor = CreateActor();
+
+        var first = audit.Append(actor, CreateRequest("payment-1"));
+        var second = audit.Append(actor, CreateRequest("payment-2"));
+        var third = audit.Append(actor, CreateRequest("payment-3"));
+
+        second.PreviousHash.Should().Be(first.Hash,
+            "each event must chain to its predecessor so reordering is detectable");
+        third.PreviousHash.Should().Be(second.Hash);
+        audit.GetAll().Should().HaveCount(3).And.ContainInOrder(first, second, third);
+    }
+
+    [Fact]
+    public void Append_ProducesIndependentlyVerifiableHash()
+    {
+        var audit = new ImmutableAuditLogService();
+
+        var evt = audit.Append(CreateActor(), CreateRequest("payment-1"));
+
+        AuditHash.Compute(evt with { Hash = string.Empty }).Should().Be(evt.Hash,
+            "an external verifier must be able to recompute the stored hash from the event payload");
+    }
+
+    [Fact]
+    public void Append_RecordsActorAndRequestProvenance()
+    {
+        var audit = new ImmutableAuditLogService();
+        var actor = CreateActor();
+        var request = CreateRequest("payment-1");
+
+        var evt = audit.Append(actor, request);
+
+        evt.ActorId.Should().Be(actor.ActorId);
+        evt.SourceIp.Should().Be(actor.SourceIp);
+        evt.DeviceId.Should().Be(actor.DeviceId);
+        evt.Action.Should().Be(request.Action);
+        evt.ObjectId.Should().Be(request.ObjectId);
+        evt.CorrelationId.Should().Be(request.CorrelationId);
+        evt.BeforeStateJson.Should().Be(request.BeforeStateJson);
+        evt.AfterStateJson.Should().Be(request.AfterStateJson);
+    }
+
+    [Fact]
+    public void AuditHash_TamperedPayload_ProducesDifferentHash()
+    {
+        var audit = new ImmutableAuditLogService();
+
+        var evt = audit.Append(CreateActor(), CreateRequest("payment-1"));
+        var tampered = evt with { AfterStateJson = "{\"status\":\"released\",\"amount\":9999999}" };
+
+        AuditHash.Compute(tampered with { Hash = string.Empty }).Should().NotBe(evt.Hash,
+            "any change to the recorded state must invalidate the stored hash");
+    }
+
+    [Fact]
+    public void VerifyIntegrity_UntamperedChain_ReturnsTrue()
+    {
+        var audit = new ImmutableAuditLogService();
+        var actor = CreateActor();
+
+        audit.Append(actor, CreateRequest("payment-1"));
+        audit.Append(actor, CreateRequest("payment-2"));
+
+        audit.VerifyIntegrity().Should().BeTrue();
+    }
+
+    private static ActorContext CreateActor() => new(
+        ActorId: "treasury-ops-1",
+        Roles: ["TreasuryOperator"],
+        Team: "Treasury",
+        SourceIp: "10.20.30.40",
+        DeviceId: "workstation-7",
+        MfaSatisfied: true);
+
+    private static ComplianceActionRequest CreateRequest(string objectId) => new(
+        Action: SensitiveAction.PaymentRelease,
+        ObjectType: "Payment",
+        ObjectId: objectId,
+        BeforeStateJson: "{\"status\":\"pending\"}",
+        AfterStateJson: "{\"status\":\"released\"}",
+        CorrelationId: $"corr-{objectId}",
+        EntityId: "fund-1",
+        RequestedByActorId: "requester-1",
+        AdditionalApproverIds: ["approver-2", "approver-3"]);
+}

--- a/tests/Meridian.Tests/Execution/BrokerageOrderPlacementGateTests.cs
+++ b/tests/Meridian.Tests/Execution/BrokerageOrderPlacementGateTests.cs
@@ -1,0 +1,246 @@
+using FluentAssertions;
+using Meridian.Execution.Sdk;
+using Xunit;
+
+namespace Meridian.Tests.Execution;
+
+/// <summary>
+/// Guards the central order-placement gate shared by HTTP endpoints and the OMS.
+/// The failure mode under guard: a permissive regression that lets an order route to a
+/// live broker before every go-live phase, evidence gate, and signoff artifact has passed.
+/// Every rejection branch is pinned so a removed check surfaces as a failing test.
+/// </summary>
+public sealed class BrokerageOrderPlacementGateTests : IDisposable
+{
+    private readonly string _tempRoot = Path.Combine(
+        Path.GetTempPath(), "meridian-tests", $"placement-gate-{Guid.NewGuid():N}");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("paper")]
+    [InlineData("PAPER")]
+    public void Evaluate_NoConfigurationWithPaperGateway_Allows(string? selectedGatewayId)
+    {
+        var decision = BrokerageOrderPlacementGate.Evaluate(configuration: null, selectedGatewayId);
+
+        decision.IsAllowed.Should().BeTrue(
+            "paper trading must stay available before any brokerage configuration exists");
+        decision.RejectReason.Should().BeNull();
+    }
+
+    [Fact]
+    public void Evaluate_NoConfigurationWithLiveGateway_Rejects()
+    {
+        var decision = BrokerageOrderPlacementGate.Evaluate(configuration: null, selectedGatewayId: "alpaca");
+
+        decision.IsAllowed.Should().BeFalse(
+            "a live broker must never receive orders without an explicit brokerage configuration");
+        decision.RejectReason.Should().Contain("alpaca").And.Contain("configuration is required");
+    }
+
+    [Fact]
+    public void Evaluate_DefaultConfiguration_RejectsBecausePaperFlowIsNotEnabled()
+    {
+        // A freshly-constructed configuration (Gateway = "paper", no broker flows) must be
+        // deny-by-default: even paper order flow requires an explicit flag.
+        var decision = BrokerageOrderPlacementGate.Evaluate(new BrokerageConfiguration());
+
+        decision.IsAllowed.Should().BeFalse();
+        decision.RejectReason.Should().Contain("Paper order flow is disabled");
+    }
+
+    [Fact]
+    public void Evaluate_PaperGatewayWithPaperFlowEnabled_Allows()
+    {
+        var configuration = new BrokerageConfiguration
+        {
+            Gateway = "paper",
+            BrokerFlows = { ["paper"] = new BrokerFlowFlags { PaperOrderFlowEnabled = true } }
+        };
+
+        var decision = BrokerageOrderPlacementGate.Evaluate(configuration, "paper");
+
+        decision.IsAllowed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_SelectedGatewayDiffersFromConfiguredGateway_Rejects()
+    {
+        var configuration = CreateLiveReadyConfiguration(gateway: "alpaca");
+
+        var decision = BrokerageOrderPlacementGate.Evaluate(configuration, selectedGatewayId: "ib");
+
+        decision.IsAllowed.Should().BeFalse(
+            "orders must not route through a broker other than the configured one");
+        decision.RejectReason.Should().Contain("'alpaca'").And.Contain("'ib'");
+    }
+
+    [Fact]
+    public void Evaluate_SelectedGatewayMatchesAfterNormalization_Allows()
+    {
+        var configuration = CreateLiveReadyConfiguration(gateway: "alpaca");
+
+        var decision = BrokerageOrderPlacementGate.Evaluate(configuration, selectedGatewayId: "  ALPACA  ");
+
+        decision.IsAllowed.Should().BeTrue("gateway ids are compared case-insensitively after trimming");
+    }
+
+    [Fact]
+    public void Evaluate_BlankConfiguredGatewayFallsBackToSelectedGateway_UsesSelectedBrokerFlow()
+    {
+        var configuration = CreateLiveReadyConfiguration(gateway: "alpaca");
+        configuration.Gateway = "   ";
+
+        var decision = BrokerageOrderPlacementGate.Evaluate(configuration, selectedGatewayId: "alpaca");
+
+        decision.IsAllowed.Should().BeTrue(
+            "when the configuration has no gateway the active broker selection drives the flow lookup");
+    }
+
+    [Fact]
+    public void Evaluate_LiveGatewayWithoutBrokerFlowEntry_RejectsProductionRouting()
+    {
+        var configuration = CreateLiveReadyConfiguration(gateway: "alpaca");
+        configuration.BrokerFlows.Clear();
+
+        var decision = BrokerageOrderPlacementGate.Evaluate(configuration, "alpaca");
+
+        decision.IsAllowed.Should().BeFalse("a broker with no flow flags must default to deny");
+        decision.RejectReason.Should().Contain("Production order routing is disabled");
+    }
+
+    [Fact]
+    public void Evaluate_LiveExecutionNotEnabled_Rejects()
+    {
+        var configuration = CreateLiveReadyConfiguration(gateway: "alpaca");
+        configuration.LiveExecutionEnabled = false;
+
+        var decision = BrokerageOrderPlacementGate.Evaluate(configuration, "alpaca");
+
+        decision.IsAllowed.Should().BeFalse("the live-execution safety switch is the final manual guard");
+        decision.RejectReason.Should().Contain("Live execution must be explicitly enabled");
+    }
+
+    [Theory]
+    [InlineData(nameof(BrokerageConfiguration.ReadOnlyPhaseEnabled), "read-only phase is disabled")]
+    [InlineData(nameof(BrokerageConfiguration.PaperTradingPhaseEnabled), "paper-trading phase is disabled")]
+    [InlineData(nameof(BrokerageConfiguration.ProductionRoutingPhaseEnabled), "production routing is disabled")]
+    public void Evaluate_AnyRolloutPhaseDisabled_Rejects(string phaseProperty, string expectedReasonFragment)
+    {
+        var configuration = CreateLiveReadyConfiguration(gateway: "alpaca");
+        typeof(BrokerageConfiguration).GetProperty(phaseProperty)!.SetValue(configuration, false);
+
+        var decision = BrokerageOrderPlacementGate.Evaluate(configuration, "alpaca");
+
+        decision.IsAllowed.Should().BeFalse(
+            "production routing requires every rollout phase to be explicitly enabled");
+        decision.RejectReason.Should().Contain(expectedReasonFragment);
+    }
+
+    [Theory]
+    [InlineData(nameof(BrokerageConfiguration.ReadOnlyVerificationPassed), "read-only verification must pass")]
+    [InlineData(nameof(BrokerageConfiguration.PaperLifecycleTestsPassed), "paper-trading lifecycle tests must pass")]
+    [InlineData(nameof(BrokerageConfiguration.ReplayEvidencePassed), "replay evidence must pass")]
+    public void Evaluate_AnyEvidenceGateFailing_Rejects(string evidenceProperty, string expectedReasonFragment)
+    {
+        var configuration = CreateLiveReadyConfiguration(gateway: "alpaca");
+        typeof(BrokerageConfiguration).GetProperty(evidenceProperty)!.SetValue(configuration, false);
+
+        var decision = BrokerageOrderPlacementGate.Evaluate(configuration, "alpaca");
+
+        decision.IsAllowed.Should().BeFalse("go-live evidence gates must all pass before live routing");
+        decision.RejectReason.Should().Contain(expectedReasonFragment);
+    }
+
+    [Fact]
+    public void Evaluate_ValidationArtifactMissing_Rejects()
+    {
+        var configuration = CreateLiveReadyConfiguration(gateway: "alpaca");
+        configuration.ValidationGates = new BrokerValidationGateOptions
+        {
+            RequireValidationArtifactsForOrderPlacement = true,
+            ValidationArtifactPath = Path.Combine(_tempRoot, "missing-validation.json"),
+            SignoffArtifactPath = Path.Combine(_tempRoot, "missing-signoff.json")
+        };
+
+        var decision = BrokerageOrderPlacementGate.Evaluate(configuration, "alpaca");
+
+        decision.IsAllowed.Should().BeFalse();
+        decision.RejectReason.Should().Contain("validation artifact is present");
+    }
+
+    [Fact]
+    public void Evaluate_SignoffArtifactMissing_Rejects()
+    {
+        var configuration = CreateLiveReadyConfiguration(gateway: "alpaca");
+        configuration.ValidationGates = new BrokerValidationGateOptions
+        {
+            RequireValidationArtifactsForOrderPlacement = true,
+            ValidationArtifactPath = WriteArtifact("validation.json"),
+            SignoffArtifactPath = Path.Combine(_tempRoot, "missing-signoff.json")
+        };
+
+        var decision = BrokerageOrderPlacementGate.Evaluate(configuration, "alpaca");
+
+        decision.IsAllowed.Should().BeFalse(
+            "an operator signoff is required even when validation evidence exists");
+        decision.RejectReason.Should().Contain("signoff artifact is present");
+    }
+
+    [Fact]
+    public void Evaluate_AllPhasesEvidenceAndArtifactsPresent_Allows()
+    {
+        var configuration = CreateLiveReadyConfiguration(gateway: "alpaca");
+        configuration.ValidationGates = new BrokerValidationGateOptions
+        {
+            RequireValidationArtifactsForOrderPlacement = true,
+            ValidationArtifactPath = WriteArtifact("validation.json"),
+            SignoffArtifactPath = WriteArtifact("signoff.json")
+        };
+
+        var decision = BrokerageOrderPlacementGate.Evaluate(configuration, "alpaca");
+
+        decision.IsAllowed.Should().BeTrue();
+        decision.RejectReason.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Builds a configuration that passes every live-routing gate except the artifact
+    /// checks, which are disabled so individual tests can flip exactly one gate off.
+    /// </summary>
+    private static BrokerageConfiguration CreateLiveReadyConfiguration(string gateway) => new()
+    {
+        Gateway = gateway,
+        LiveExecutionEnabled = true,
+        ProductionRoutingPhaseEnabled = true,
+        ReadOnlyVerificationPassed = true,
+        PaperLifecycleTestsPassed = true,
+        ReplayEvidencePassed = true,
+        BrokerFlows =
+        {
+            [gateway] = new BrokerFlowFlags { ProductionOrderRoutingEnabled = true }
+        },
+        ValidationGates = new BrokerValidationGateOptions
+        {
+            RequireValidationArtifactsForOrderPlacement = false
+        }
+    };
+
+    private string WriteArtifact(string fileName)
+    {
+        Directory.CreateDirectory(_tempRoot);
+        var path = Path.Combine(_tempRoot, fileName);
+        File.WriteAllText(path, "{}");
+        return path;
+    }
+}

--- a/tests/Meridian.Tests/Execution/BrokerageValidationEvaluatorTests.cs
+++ b/tests/Meridian.Tests/Execution/BrokerageValidationEvaluatorTests.cs
@@ -1,0 +1,146 @@
+using FluentAssertions;
+using Meridian.Execution.Sdk;
+using Xunit;
+
+namespace Meridian.Tests.Execution;
+
+/// <summary>
+/// Guards the live-readiness review evaluator. The failure mode under guard: a lane is
+/// declared live-ready while the brokerage configuration still points at paper trading,
+/// has live execution disabled, or carries no pre-trade guardrails — letting a go-live
+/// claim pass review against a broker that cannot actually route production orders.
+/// </summary>
+public sealed class BrokerageValidationEvaluatorTests
+{
+    [Fact]
+    public void Evaluate_NullConfiguration_ReportsRequiredWithUnconfiguredGateway()
+    {
+        var report = BrokerageValidationEvaluator.Evaluate(configuration: null);
+
+        report.State.Should().Be(BrokerageValidationState.Required);
+        report.HasBlockingGap.Should().BeFalse();
+        report.GatewayId.Should().BeEmpty();
+        report.GatewayDisplayName.Should().Be("Unconfigured");
+        report.Findings.Should().BeEmpty();
+        report.Summary.Should().Contain("not projected into this workflow");
+    }
+
+    [Fact]
+    public void Evaluate_LiveExecutionDisabled_ReportsBlockingGap()
+    {
+        var configuration = CreateLiveConfiguration("alpaca");
+        configuration.LiveExecutionEnabled = false;
+
+        var report = BrokerageValidationEvaluator.Evaluate(configuration);
+
+        report.State.Should().Be(BrokerageValidationState.Gap);
+        report.HasBlockingGap.Should().BeTrue();
+        report.Findings.Should().ContainSingle()
+            .Which.Should().Contain("does not enable live execution");
+        report.Summary.Should().Contain("Resolve the Alpaca broker configuration");
+    }
+
+    [Fact]
+    public void Evaluate_BlankGateway_ReportsGapAskingForLiveBroker()
+    {
+        var configuration = CreateLiveConfiguration(gateway: "   ");
+
+        var report = BrokerageValidationEvaluator.Evaluate(configuration);
+
+        report.State.Should().Be(BrokerageValidationState.Gap);
+        report.GatewayId.Should().BeEmpty();
+        report.GatewayDisplayName.Should().Be("Unconfigured");
+        report.Findings.Should().ContainSingle()
+            .Which.Should().Contain("No live brokerage gateway is configured");
+        report.Summary.Should().Contain("Configure a live broker");
+    }
+
+    [Fact]
+    public void Evaluate_GatewayStillPaper_ReportsGap()
+    {
+        var configuration = CreateLiveConfiguration("paper");
+
+        var report = BrokerageValidationEvaluator.Evaluate(configuration);
+
+        report.State.Should().Be(BrokerageValidationState.Gap);
+        report.GatewayDisplayName.Should().Be("Paper trading");
+        report.Findings.Should().ContainSingle()
+            .Which.Should().Contain("still points to paper trading");
+    }
+
+    [Fact]
+    public void Evaluate_LiveDisabledAndPaperGateway_AccumulatesBothFindings()
+    {
+        var configuration = new BrokerageConfiguration
+        {
+            Gateway = "paper",
+            LiveExecutionEnabled = false
+        };
+
+        var report = BrokerageValidationEvaluator.Evaluate(configuration);
+
+        report.State.Should().Be(BrokerageValidationState.Gap);
+        report.Findings.Should().HaveCount(2,
+            "a reviewer must see every blocking gap at once, not one per review round");
+        report.Summary.Should()
+            .Contain("does not enable live execution").And
+            .Contain("still points to paper trading");
+    }
+
+    [Fact]
+    public void Evaluate_LiveGatewayWithoutGuardrails_WarnsAboutMissingLimits()
+    {
+        var configuration = CreateLiveConfiguration("alpaca");
+
+        var report = BrokerageValidationEvaluator.Evaluate(configuration);
+
+        report.State.Should().Be(BrokerageValidationState.Required);
+        report.HasBlockingGap.Should().BeFalse();
+        report.Findings.Should().ContainSingle()
+            .Which.Should().Contain("MaxPositionSize, MaxOrderNotional, or MaxOpenOrders");
+        report.Summary.Should().Contain("No explicit MaxPositionSize");
+    }
+
+    [Theory]
+    [InlineData(5_000, 0, 0)]
+    [InlineData(0, 250_000, 0)]
+    [InlineData(0, 0, 25)]
+    public void Evaluate_AnyExplicitGuardrail_ReportsCleanRequiredReview(
+        decimal maxPositionSize, decimal maxOrderNotional, int maxOpenOrders)
+    {
+        var configuration = CreateLiveConfiguration("alpaca");
+        configuration.MaxPositionSize = maxPositionSize;
+        configuration.MaxOrderNotional = maxOrderNotional;
+        configuration.MaxOpenOrders = maxOpenOrders;
+
+        var report = BrokerageValidationEvaluator.Evaluate(configuration);
+
+        report.State.Should().Be(BrokerageValidationState.Required);
+        report.Findings.Should().BeEmpty();
+        report.Summary.Should().Contain("Validate connectivity, credentials, account permissions");
+    }
+
+    [Theory]
+    [InlineData("alpaca", "alpaca", "Alpaca")]
+    [InlineData("  ALPACA  ", "alpaca", "Alpaca")]
+    [InlineData("robinhood", "robinhood", "Robinhood")]
+    [InlineData("ib", "ib", "Interactive Brokers")]
+    [InlineData("interactivebrokers", "interactivebrokers", "Interactive Brokers")]
+    [InlineData("tradier", "tradier", "tradier")]
+    public void Evaluate_NormalizesGatewayIdAndResolvesDisplayName(
+        string configuredGateway, string expectedGatewayId, string expectedDisplayName)
+    {
+        var configuration = CreateLiveConfiguration(configuredGateway);
+
+        var report = BrokerageValidationEvaluator.Evaluate(configuration);
+
+        report.GatewayId.Should().Be(expectedGatewayId);
+        report.GatewayDisplayName.Should().Be(expectedDisplayName);
+    }
+
+    private static BrokerageConfiguration CreateLiveConfiguration(string gateway) => new()
+    {
+        Gateway = gateway,
+        LiveExecutionEnabled = true
+    };
+}

--- a/tests/Meridian.Tests/Execution/ExecutionOrderMetadataPolicyTests.cs
+++ b/tests/Meridian.Tests/Execution/ExecutionOrderMetadataPolicyTests.cs
@@ -1,0 +1,176 @@
+using FluentAssertions;
+using Meridian.Execution.Sdk;
+using Xunit;
+
+namespace Meridian.Tests.Execution;
+
+/// <summary>
+/// Guards the server-owned order-metadata boundary. The failure mode under guard: a
+/// client smuggles broker-account, asset-class, or execution-control override keys into
+/// order metadata and steers routing decisions that only the server may make.
+/// </summary>
+public sealed class ExecutionOrderMetadataPolicyTests
+{
+    public static TheoryData<string> ClientRejectedKeys => new(
+        "broker_account_id",
+        "brokerAccountId",
+        "account_id",
+        "accountId",
+        "alpaca:broker_account_id",
+        "asset_class",
+        "assetClass",
+        "alpaca:asset_class",
+        "manualOverrideId",
+        "manual_override_id",
+        "executionControlOverrideId",
+        "execution_control_override_id",
+        "liveReadinessEvidenceReference",
+        "live_readiness_evidence_reference",
+        "livePromotionAuditReference",
+        "live_promotion_audit_reference");
+
+    [Fact]
+    public void ContainsClientRejectedServerOwnedKey_NullMetadata_ReturnsFalse()
+    {
+        ExecutionOrderMetadataPolicy.ContainsClientRejectedServerOwnedKey(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ContainsClientRejectedServerOwnedKey_BenignMetadata_ReturnsFalse()
+    {
+        var metadata = new Dictionary<string, string>
+        {
+            ["strategy_run_id"] = "run-2026-07-06-01",
+            ["desk"] = "options-income"
+        };
+
+        ExecutionOrderMetadataPolicy.ContainsClientRejectedServerOwnedKey(metadata).Should().BeFalse();
+    }
+
+    [Theory]
+    [MemberData(nameof(ClientRejectedKeys))]
+    public void ContainsClientRejectedServerOwnedKey_EachServerOwnedKey_IsDetected(string rejectedKey)
+    {
+        var metadata = new Dictionary<string, string>
+        {
+            ["strategy_run_id"] = "run-2026-07-06-01",
+            [rejectedKey] = "client-supplied-value"
+        };
+
+        ExecutionOrderMetadataPolicy.ContainsClientRejectedServerOwnedKey(metadata)
+            .Should().BeTrue($"'{rejectedKey}' is server-owned and must be rejected when a client supplies it");
+    }
+
+    [Fact]
+    public void RemoveClientRejectedServerOwnedKeys_NullMetadata_ReturnsNull()
+    {
+        ExecutionOrderMetadataPolicy.RemoveClientRejectedServerOwnedKeys(null).Should().BeNull();
+    }
+
+    [Fact]
+    public void RemoveClientRejectedServerOwnedKeys_NoServerOwnedKeys_ReturnsSameInstance()
+    {
+        var metadata = new Dictionary<string, string> { ["desk"] = "options-income" };
+
+        var sanitized = ExecutionOrderMetadataPolicy.RemoveClientRejectedServerOwnedKeys(metadata);
+
+        sanitized.Should().BeSameAs(metadata, "clean metadata must not be copied");
+    }
+
+    [Fact]
+    public void RemoveClientRejectedServerOwnedKeys_StripsServerOwnedKeysAndKeepsTheRest()
+    {
+        var metadata = new Dictionary<string, string>
+        {
+            ["broker_account_id"] = "acct-hijack",
+            ["assetClass"] = "us_option",
+            ["strategy_run_id"] = "run-2026-07-06-01"
+        };
+
+        var sanitized = ExecutionOrderMetadataPolicy.RemoveClientRejectedServerOwnedKeys(metadata);
+
+        sanitized.Should().NotBeSameAs(metadata);
+        sanitized.Should().ContainKey("strategy_run_id");
+        sanitized.Should().NotContainKey("broker_account_id");
+        sanitized.Should().NotContainKey("assetClass");
+        metadata.Should().ContainKey("broker_account_id", "the caller's dictionary must not be mutated");
+    }
+
+    [Fact]
+    public void RemoveClientRejectedServerOwnedKeys_RemovesKeysCaseInsensitively()
+    {
+        var metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["BROKER_ACCOUNT_ID"] = "acct-hijack"
+        };
+
+        var sanitized = ExecutionOrderMetadataPolicy.RemoveClientRejectedServerOwnedKeys(metadata);
+
+        sanitized.Should().BeEmpty("removal compares keys case-insensitively");
+    }
+
+    [Fact]
+    public void RemoveBrokerAccountAndOverrideKeys_NullRequest_Throws()
+    {
+        var act = () => ExecutionOrderMetadataPolicy.RemoveBrokerAccountAndOverrideKeys(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void RemoveBrokerAccountAndOverrideKeys_NoMetadata_ReturnsSameRequest()
+    {
+        var request = CreateOrderRequest(metadata: null);
+
+        var sanitized = ExecutionOrderMetadataPolicy.RemoveBrokerAccountAndOverrideKeys(request);
+
+        sanitized.Should().BeSameAs(request);
+    }
+
+    [Fact]
+    public void RemoveBrokerAccountAndOverrideKeys_StripsAccountAndOverrideKeys()
+    {
+        var request = CreateOrderRequest(new Dictionary<string, string>
+        {
+            ["broker_account_id"] = "acct-hijack",
+            ["executionControlOverrideId"] = "override-42",
+            ["live_promotion_audit_reference"] = "audit-99",
+            ["strategy_run_id"] = "run-2026-07-06-01"
+        });
+
+        var sanitized = ExecutionOrderMetadataPolicy.RemoveBrokerAccountAndOverrideKeys(request);
+
+        sanitized.Should().NotBeSameAs(request);
+        sanitized.Metadata.Should().ContainKey("strategy_run_id");
+        sanitized.Metadata.Should().NotContainKeys(
+            "broker_account_id", "executionControlOverrideId", "live_promotion_audit_reference");
+        sanitized.Symbol.Should().Be(request.Symbol, "sanitizing metadata must not alter order economics");
+        sanitized.Quantity.Should().Be(request.Quantity);
+    }
+
+    [Fact]
+    public void RemoveBrokerAccountAndOverrideKeys_PreservesAssetClassKeys()
+    {
+        // Asset-class keys are rejected at the client boundary but tolerated on the
+        // server-internal sanitization path; this pins that deliberate difference.
+        var request = CreateOrderRequest(new Dictionary<string, string>
+        {
+            ["asset_class"] = "us_option"
+        });
+
+        var sanitized = ExecutionOrderMetadataPolicy.RemoveBrokerAccountAndOverrideKeys(request);
+
+        sanitized.Should().BeSameAs(request);
+        sanitized.Metadata.Should().ContainKey("asset_class");
+    }
+
+    private static OrderRequest CreateOrderRequest(IReadOnlyDictionary<string, string>? metadata) => new()
+    {
+        Symbol = "SPY",
+        Side = OrderSide.Buy,
+        Type = OrderType.Limit,
+        Quantity = 100m,
+        LimitPrice = 512.35m,
+        Metadata = metadata
+    };
+}


### PR DESCRIPTION
## Summary

Adds 87 xUnit tests for the highest-risk untested classes identified by a repository-wide test coverage analysis. No production code changes — test-only additions:

- **`BrokerageOrderPlacementGate`** (`tests/Meridian.Tests/Execution/BrokerageOrderPlacementGateTests.cs`): pins every rejection branch of the central live order-routing gate — missing configuration, gateway mismatch, deny-by-default broker flows, the live-execution safety switch, all three rollout phases, all three evidence gates, and the validation/signoff artifact requirements — plus the paper-trading and fully-gated allow paths.
- **`BrokerageValidationEvaluator`** (`.../BrokerageValidationEvaluatorTests.cs`): null/paper/blank-gateway blocking gaps, multi-finding accumulation, missing-guardrail warnings, and gateway id normalization/display-name resolution.
- **`ExecutionOrderMetadataPolicy`** (`.../ExecutionOrderMetadataPolicyTests.cs`): detection and stripping of all 16 server-owned metadata keys, reference-preserving no-op paths, caller-dictionary immutability, and the deliberate asset-class difference between the client-reject and server-sanitize key sets.
- **`CompliancePolicyEngine`** (`tests/Meridian.Tests/Compliance/CompliancePolicyEngineTests.cs`, extended): per-action role requirements, unknown-action deny, MFA step-up and dual-approval boundaries (including case-insensitive duplicate approvers), and case-insensitive self-approval blocking.
- **`ImmutableAuditLogService` / `AuditHash`** (new `ImmutableAuditLogServiceTests.cs`): hash chaining across events, independent hash recomputation, provenance capture, and tamper sensitivity of the hash.
- **`AccessReviewService`** (new `AccessReviewServiceTests.cs`): dormant-role removal past the 90-day threshold and review-trail retention.

Observation surfaced while writing these (not changed here, worth a follow-up look): `ExecutionOrderMetadataPolicy` detects rejected keys with the caller dictionary's own comparer but removes them case-insensitively, so a case-variant key (e.g. `Broker_Account_Id`) in a case-sensitive dictionary passes `ContainsClientRejectedServerOwnedKey` yet would be stripped by the removal path.

## Reason

A coverage analysis found these compliance and execution go-live controls had zero (or happy-path-only) behavioral tests despite being security/compliance boundaries: the order-placement gate decides whether live production orders may route, the metadata policy blocks client-side broker-account hijacking, and the compliance engine enforces segregation-of-duties, MFA step-up, and dual approval for payment release and override approval.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully (not run locally — container lacks the full toolchain; targeted validation below)
- [x] Relevant unit tests were added or updated (`dotnet test tests/Meridian.Tests -c Release` filtered to the six touched test classes: 90 passed, 0 failed)
- [ ] Relevant integration tests were added or updated (unit-level scope only)
- [ ] GitHub Actions `quality-gate` passed (pending on this PR)

`dotnet format whitespace --verify-no-changes` passes for the touched files.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjEboE3NYRVbC9AYmzLSGV

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjEboE3NYRVbC9AYmzLSGV)_