### PR TITLE
Strengthen case-insensitive metadata removal test

### DIFF
--- a/tests/Meridian.Tests/Execution/ExecutionOrderMetadataPolicyTests.cs
+++ b/tests/Meridian.Tests/Execution/ExecutionOrderMetadataPolicyTests.cs
@@ -99,7 +99,9 @@ public sealed class ExecutionOrderMetadataPolicyTests
     [Fact]
     public void RemoveClientRejectedServerOwnedKeys_RemovesKeysCaseInsensitively()
     {
-        var metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        // The input is deliberately case-sensitive: removal must be case-insensitive by
+        // the policy's own doing, not because of the caller's dictionary comparer.
+        var metadata = new Dictionary<string, string>
         {
             ["BROKER_ACCOUNT_ID"] = "acct-hijack"
         };


### PR DESCRIPTION
## Summary

Follow-up to #2122 (merged before this review fix landed). Changes one test in `tests/Meridian.Tests/Execution/ExecutionOrderMetadataPolicyTests.cs`: `RemoveClientRejectedServerOwnedKeys_RemovesKeysCaseInsensitively` now builds its input with a default case-sensitive dictionary instead of `StringComparer.OrdinalIgnoreCase`, so the assertion proves the policy's own removal comparer is case-insensitive rather than inheriting that behavior from the caller's dictionary.

## Reason

Addresses the review comment on #2122: with a case-insensitive input dictionary, the test could pass even if the policy stopped normalizing key casing itself, making the test's guarantee hollow.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully (targeted validation below; single-test-file change)
- [x] Relevant unit tests were added or updated (`dotnet test tests/Meridian.Tests -c Release` filtered to `ExecutionOrderMetadataPolicyTests`: 26 passed, 0 failed)
- [ ] Relevant integration tests were added or updated (not applicable)
- [ ] GitHub Actions `quality-gate` passed (pending on this PR)

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjEboE3NYRVbC9AYmzLSGV

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjEboE3NYRVbC9AYmzLSGV)_