### PR TITLE
[salvage/product] Refactor desktop feature module registry

### DIFF
--- a/src/Meridian.Wpf/Features/DesktopFeatureModuleRegistry.cs
+++ b/src/Meridian.Wpf/Features/DesktopFeatureModuleRegistry.cs
@@ -7,16 +7,16 @@ namespace Meridian.Wpf.Features;
 
 public static class DesktopFeatureModuleRegistry
 {
-    private static readonly IDesktopFeatureModule[] Modules =
+    private static readonly Func<IDesktopFeatureModule>[] ModuleFactories =
     [
-        new Home.HomeFeatureModule(),
-        new Trading.TradingFeatureModule(),
-        new Portfolio.PortfolioFeatureModule(),
-        new Accounting.AccountingFeatureModule(),
-        new Reporting.ReportingFeatureModule(),
-        new Strategy.StrategyFeatureModule(),
-        new Data.DataFeatureModule(),
-        new Settings.SettingsFeatureModule()
+        DesktopFeature.Module<Home.HomeFeatureModule>(),
+        DesktopFeature.Module<Trading.TradingFeatureModule>(),
+        DesktopFeature.Module<Portfolio.PortfolioFeatureModule>(),
+        DesktopFeature.Module<Accounting.AccountingFeatureModule>(),
+        DesktopFeature.Module<Reporting.ReportingFeatureModule>(),
+        DesktopFeature.Module<Strategy.StrategyFeatureModule>(),
+        DesktopFeature.Module<Data.DataFeatureModule>(),
+        DesktopFeature.Module<Settings.SettingsFeatureModule>()
     ];
 
     public static IServiceCollection AddMeridianWpfFeatureModules(this IServiceCollection services)
@@ -25,7 +25,7 @@ public static class DesktopFeatureModuleRegistry
 
         services.AddSingleton(ShellPageRegistryBuilder.BuildDefault());
 
-        foreach (var module in Modules)
+        foreach (var module in GetModules())
         {
             module.Register(services);
         }
@@ -48,13 +48,21 @@ public static class DesktopFeatureModuleRegistry
         return services.AddMeridianWpfFeatureModules();
     }
 
-    public static IReadOnlyList<IDesktopFeatureModule> GetModules() => Modules;
+    public static IReadOnlyList<IDesktopFeatureModule> GetModules()
+        => ModuleFactories.Select(static createModule => createModule()).ToArray();
 
     public static IReadOnlyList<FeatureCapabilityDescriptor> GetCapabilities()
-        => Modules
+        => GetModules()
             .SelectMany(static module => module.DeclareCapabilities())
             .GroupBy(static capability => capability.CapabilityKey, StringComparer.OrdinalIgnoreCase)
             .Select(static group => group.First())
             .OrderBy(static capability => capability.DisplayName, StringComparer.OrdinalIgnoreCase)
             .ToArray();
+}
+
+public static class DesktopFeature
+{
+    public static Func<IDesktopFeatureModule> Module<T>()
+        where T : IDesktopFeatureModule, new()
+        => static () => new T();
 }

--- a/tests/Meridian.Wpf.Tests/Features/DesktopFeatureModuleRegistryTests.cs
+++ b/tests/Meridian.Wpf.Tests/Features/DesktopFeatureModuleRegistryTests.cs
@@ -1,0 +1,47 @@
+using Meridian.Wpf.Features;
+
+namespace Meridian.Wpf.Tests.Features;
+
+public sealed class DesktopFeatureModuleRegistryTests
+{
+    [Fact]
+    public void GetModules_ShouldReturnAllExpectedModulesInStableStartupOrder()
+    {
+        DesktopFeatureModuleRegistry.GetModules()
+            .Select(static module => module.GetType())
+            .Should()
+            .Equal(
+                typeof(Meridian.Wpf.Features.Home.HomeFeatureModule),
+                typeof(Meridian.Wpf.Features.Trading.TradingFeatureModule),
+                typeof(Meridian.Wpf.Features.Portfolio.PortfolioFeatureModule),
+                typeof(Meridian.Wpf.Features.Accounting.AccountingFeatureModule),
+                typeof(Meridian.Wpf.Features.Reporting.ReportingFeatureModule),
+                typeof(Meridian.Wpf.Features.Strategy.StrategyFeatureModule),
+                typeof(Meridian.Wpf.Features.Data.DataFeatureModule),
+                typeof(Meridian.Wpf.Features.Settings.SettingsFeatureModule));
+    }
+
+    [Fact]
+    public void GetModules_ShouldReturnFreshModulesFromDeclarativeFactories()
+    {
+        var first = DesktopFeatureModuleRegistry.GetModules();
+        var second = DesktopFeatureModuleRegistry.GetModules();
+
+        first.Select(static module => module.GetType()).Should().Equal(second.Select(static module => module.GetType()));
+        first.Zip(second, static (left, right) => ReferenceEquals(left, right))
+            .Should()
+            .OnlyContain(static sameInstance => sameInstance is false);
+    }
+
+    [Fact]
+    public void GetCapabilities_ShouldKeepCapabilityKeysUniqueAfterAggregation()
+    {
+        var duplicateKeys = DesktopFeatureModuleRegistry.GetCapabilities()
+            .GroupBy(static capability => capability.CapabilityKey, StringComparer.OrdinalIgnoreCase)
+            .Where(static group => group.Count() > 1)
+            .Select(static group => group.Key)
+            .ToArray();
+
+        duplicateKeys.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Salvage provenance

Recreated stale product salvage work on top of current origin/main.

- Source branch: $sourceBranch
- Source commit: $sourceSha
- Original merge base: $base
- Current origin/main: $mainSha

## Validation

- git diff --cached --check passed before commit.
- Full ash scripts/ci.sh has not been run for this draft salvage PR.

## Changed paths

- src/Meridian.Wpf/Features/DesktopFeatureModuleRegistry.cs
- tests/Meridian.Wpf.Tests/Features/DesktopFeatureModuleRegistryTests.cs