### PR TITLE
[salvage/product] Add WPF shell command palette metadata

### DIFF
--- a/src/Meridian.Wpf/Models/ShellNavigationModels.cs
+++ b/src/Meridian.Wpf/Models/ShellNavigationModels.cs
@@ -98,6 +98,14 @@ public sealed record WorkspaceShellState(
     bool HasPrimaryContext = true,
     string? ActiveRunId = null);
 
+public enum ShellCommandPaletteExecutionKind
+{
+    SafeNavigation,
+    NonDestructiveAction,
+    StateChangingAction,
+    DestructiveAction
+}
+
 public sealed record ShellCommandPaletteEntry(
     string PageTag,
     string Title,
@@ -105,16 +113,58 @@ public sealed record ShellCommandPaletteEntry(
     string WorkspaceTitle,
     string SectionLabel,
     string Glyph,
-    string VisibilityLabel)
+    string VisibilityLabel,
+    string DisplayName,
+    IReadOnlyList<string> Keywords,
+    string Workspace,
+    string Description,
+    ShellCommandPaletteExecutionKind ExecutionKind,
+    bool RequiresConfirmation,
+    string? ConfirmationPrompt = null)
 {
+    public ShellCommandPaletteEntry(
+        string PageTag,
+        string Title,
+        string Subtitle,
+        string WorkspaceTitle,
+        string SectionLabel,
+        string Glyph,
+        string VisibilityLabel)
+        : this(
+            PageTag,
+            Title,
+            Subtitle,
+            WorkspaceTitle,
+            SectionLabel,
+            Glyph,
+            VisibilityLabel,
+            DisplayName: Title,
+            Keywords: Array.Empty<string>(),
+            Workspace: WorkspaceTitle,
+            Description: Subtitle,
+            ExecutionKind: ShellCommandPaletteExecutionKind.SafeNavigation,
+            RequiresConfirmation: false)
+    {
+    }
+
     public string MetaLine
     {
         get
         {
-            var parts = new[] { SectionLabel, VisibilityLabel }
+            var parts = new[] { SectionLabel, VisibilityLabel, ExecutionLabel }
                 .Where(static part => !string.IsNullOrWhiteSpace(part));
 
             return string.Join(" · ", parts);
         }
     }
+
+    public string ExecutionLabel => ExecutionKind switch
+    {
+        ShellCommandPaletteExecutionKind.NonDestructiveAction => "Safe action",
+        ShellCommandPaletteExecutionKind.StateChangingAction => "Confirmation required",
+        ShellCommandPaletteExecutionKind.DestructiveAction => "Destructive",
+        _ => string.Empty
+    };
+
+    public bool IsRiskCommand => ExecutionKind is ShellCommandPaletteExecutionKind.StateChangingAction or ShellCommandPaletteExecutionKind.DestructiveAction;
 }

--- a/src/Meridian.Wpf/README.md
+++ b/src/Meridian.Wpf/README.md
@@ -480,6 +480,7 @@ title onto the reusable control itself so UI automation can address both the con
 parts consistently.
 Standalone command-palette chrome should use the same shell tokens and stable automation IDs instead
 of page-local colors or shadow effects.
+The global command palette opens from the shell with `Ctrl+K` and treats entries as command metadata rather than page labels only: each command carries a display name, keywords, workspace, description, execution kind, and confirmation policy. Safe navigation and non-destructive operator handoffs cover the seven root workspaces plus setup, provider health, reconciliation queues, governed report drafts, sample-data review, and fund setup. Destructive or state-changing entries are visually badged and must confirm before execution.
 High-value workbench pages should migrate through the shared workstation controls before broad
 page sweeps; Strategy Runs now opens on compact action chrome instead of a duplicate hero, uses
 `DenseDataGridControl` plus tabbed inspector panes for run, evidence, comparison, and artifact

--- a/src/Meridian.Wpf/Shell/ViewModels/CommandPaletteViewModel.cs
+++ b/src/Meridian.Wpf/Shell/ViewModels/CommandPaletteViewModel.cs
@@ -109,6 +109,14 @@ public sealed class CommandPaletteViewModel : BindableBase
             .OrderBy(page => GetPaletteRank(page, query, currentWorkspace))
             .ThenBy(page => page.Title, StringComparer.OrdinalIgnoreCase)
             .Select(page => ToCommandPaletteEntry(page, page.VisibilityTier != ShellNavigationVisibilityTier.Primary))
+            .Concat(GetGlobalCommandEntries()
+                .Where(command => string.IsNullOrWhiteSpace(query)
+                    ? !command.RequiresConfirmation
+                    : MatchesCommandQuery(command, query)))
+            .GroupBy(command => command.PageTag, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.Last())
+            .OrderBy(command => GetCommandRank(command, query, currentWorkspace))
+            .ThenBy(command => command.DisplayName, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
         ReplaceCollection(_pages, descriptors);
@@ -180,6 +188,46 @@ public sealed class CommandPaletteViewModel : BindableBase
                + descriptor.Order;
     }
 
+    private static bool MatchesCommandQuery(ShellCommandPaletteEntry command, string query)
+        => GetCommandSearchFields(command).Any(field => field.Contains(query, StringComparison.OrdinalIgnoreCase));
+
+    private static int GetCommandRank(ShellCommandPaletteEntry command, string query, string currentWorkspace)
+    {
+        var workspacePenalty = string.Equals(command.Workspace, currentWorkspace, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(command.WorkspaceTitle, currentWorkspace, StringComparison.OrdinalIgnoreCase) ? 0 : 100;
+        var riskPenalty = command.RequiresConfirmation ? 50 : 0;
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return workspacePenalty + riskPenalty + (command.ExecutionKind == ShellCommandPaletteExecutionKind.SafeNavigation ? 0 : 40);
+        }
+
+        var matchRank = command.DisplayName.StartsWith(query, StringComparison.OrdinalIgnoreCase) ? 0
+            : command.PageTag.StartsWith(query, StringComparison.OrdinalIgnoreCase) ? 1
+            : command.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase) ? 2
+            : command.Keywords.Any(keyword => keyword.StartsWith(query, StringComparison.OrdinalIgnoreCase)) ? 3
+            : command.PageTag.Contains(query, StringComparison.OrdinalIgnoreCase) ? 4
+            : command.WorkspaceTitle.Contains(query, StringComparison.OrdinalIgnoreCase) ? 5
+            : command.Description.Contains(query, StringComparison.OrdinalIgnoreCase) ? 6
+            : 8;
+
+        return (matchRank * 1000) + workspacePenalty + riskPenalty;
+    }
+
+    private static IEnumerable<string> GetCommandSearchFields(ShellCommandPaletteEntry command)
+    {
+        yield return command.PageTag;
+        yield return command.DisplayName;
+        yield return command.Description;
+        yield return command.Workspace;
+        yield return command.WorkspaceTitle;
+        yield return command.SectionLabel;
+        yield return command.ExecutionLabel;
+        foreach (var keyword in command.Keywords)
+        {
+            yield return keyword;
+        }
+    }
+
     private static IEnumerable<string> GetPaletteSearchFields(ShellPageDescriptor descriptor, string workspaceTitle)
     {
         yield return descriptor.PageTag;
@@ -205,7 +253,40 @@ public sealed class CommandPaletteViewModel : BindableBase
             WorkspaceTitle: workspaceTitle,
             SectionLabel: descriptor.SectionLabel,
             Glyph: descriptor.Glyph,
-            VisibilityLabel: includeVisibilityLabel ? GetVisibilityLabel(descriptor.VisibilityTier) : string.Empty);
+            VisibilityLabel: includeVisibilityLabel ? GetVisibilityLabel(descriptor.VisibilityTier) : string.Empty,
+            DisplayName: descriptor.Title,
+            Keywords: descriptor.SearchKeywords,
+            Workspace: descriptor.WorkspaceId,
+            Description: descriptor.Subtitle,
+            ExecutionKind: ShellCommandPaletteExecutionKind.SafeNavigation,
+            RequiresConfirmation: false);
+    }
+
+    private static IReadOnlyList<ShellCommandPaletteEntry> GetGlobalCommandEntries() =>
+    [
+        Command("SetupWizard", "Open setup", "Complete guided workstation setup and configuration.", "settings", "Setup", "\uE8B0", ["setup", "wizard", "onboarding", "configuration"]),
+        Command("ProviderHealth", "Open provider health", "Inspect provider reachability, degradation, and recovery guidance.", "data", "Operations Queue", "\uEB51", ["provider", "health", "degraded", "recovery"]),
+        Command("FundReconciliation", "Open reconciliation queues", "Review breaks, match candidates, retained evidence, and close blockers.", "accounting", "Reconciliation", "\uE895", ["reconciliation", "breaks", "exceptions", "queues"]),
+        Command("FundReportPack", "Open report drafts", "Review governed report-pack drafts, readiness, and retained evidence.", "reporting", "Drafts", "\uE8A5", ["report", "draft", "pack", "governed"]),
+        Command("DataSampling", "Open sample-data flows", "Inspect bounded sample data quality before export or publication.", "data", "Sample Data", "\uF1AD", ["sample", "data", "quality", "preview"]),
+        Command("FundStructureSetup", "Open fund setup", "Configure fund structure and account handoff readiness.", "accounting", "Setup", "\uE8B0", ["fund", "setup", "structure", "accounts"]),
+        Command("ActivityLog", "Clear activity log", "Clear retained local workstation activity entries after operator confirmation.", "settings", "Notifications", "\uE74D", ["clear", "activity", "log", "destructive"], ShellCommandPaletteExecutionKind.DestructiveAction, true, "Clear visible workstation activity log entries? This cannot be undone."),
+    ];
+
+    private static ShellCommandPaletteEntry Command(
+        string pageTag,
+        string displayName,
+        string description,
+        string workspaceId,
+        string sectionLabel,
+        string glyph,
+        IReadOnlyList<string> keywords,
+        ShellCommandPaletteExecutionKind executionKind = ShellCommandPaletteExecutionKind.NonDestructiveAction,
+        bool requiresConfirmation = false,
+        string? confirmationPrompt = null)
+    {
+        var workspaceTitle = ShellNavigationCatalog.GetWorkspace(workspaceId)?.Title ?? workspaceId;
+        return new ShellCommandPaletteEntry(pageTag, displayName, description, workspaceTitle, sectionLabel, glyph, string.Empty, displayName, keywords, workspaceId, description, executionKind, requiresConfirmation, confirmationPrompt);
     }
 
     private static string GetVisibilityLabel(ShellNavigationVisibilityTier visibilityTier)

--- a/src/Meridian.Wpf/ViewModels/MainPageViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/MainPageViewModel.cs
@@ -896,13 +896,32 @@ public sealed class MainPageViewModel : BindableBase, IDisposable
 
     private void OpenSelectedCommandPalettePage()
     {
-        if (SelectedCommandPalettePage is null)
+        var selectedCommand = SelectedCommandPalettePage;
+        if (selectedCommand is null)
         {
             return;
         }
 
-        NavigateToPage(SelectedCommandPalettePage.PageTag);
+        if (selectedCommand.RequiresConfirmation && !ConfirmCommandPaletteExecution(selectedCommand))
+        {
+            return;
+        }
+
+        NavigateToPage(selectedCommand.PageTag);
         HideCommandPalette();
+    }
+
+    private static bool ConfirmCommandPaletteExecution(ShellCommandPaletteEntry command)
+    {
+        var prompt = string.IsNullOrWhiteSpace(command.ConfirmationPrompt)
+            ? $"Run {command.DisplayName}?"
+            : command.ConfirmationPrompt;
+
+        return MessageBox.Show(
+            prompt,
+            "Confirm command",
+            MessageBoxButton.YesNo,
+            command.ExecutionKind == ShellCommandPaletteExecutionKind.DestructiveAction ? MessageBoxImage.Warning : MessageBoxImage.Question) == MessageBoxResult.Yes;
     }
 
     private void ToggleTickerStrip()
@@ -1946,7 +1965,13 @@ public sealed class MainPageViewModel : BindableBase, IDisposable
             WorkspaceTitle: workspaceTitle,
             SectionLabel: descriptor.SectionLabel,
             Glyph: descriptor.Glyph,
-            VisibilityLabel: includeVisibilityLabel ? GetVisibilityLabel(descriptor.VisibilityTier) : string.Empty);
+            VisibilityLabel: includeVisibilityLabel ? GetVisibilityLabel(descriptor.VisibilityTier) : string.Empty,
+            DisplayName: descriptor.Title,
+            Keywords: descriptor.SearchKeywords,
+            Workspace: descriptor.WorkspaceId,
+            Description: descriptor.Subtitle,
+            ExecutionKind: ShellCommandPaletteExecutionKind.SafeNavigation,
+            RequiresConfirmation: false);
     }
 
     private static string GetVisibilityLabel(ShellNavigationVisibilityTier visibilityTier)

--- a/src/Meridian.Wpf/Views/InstitutionalCommandPaletteControl.xaml
+++ b/src/Meridian.Wpf/Views/InstitutionalCommandPaletteControl.xaml
@@ -172,9 +172,24 @@
                                     <TextBlock Text="{Binding Subtitle}"
                                                Style="{StaticResource ShellNavSubtitleStyle}"
                                                Margin="0,2,0,0" />
-                                    <TextBlock Text="{Binding MetaLine}"
-                                               Style="{StaticResource SidebarShellSectionLabelStyle}"
-                                               Margin="0,4,0,0" />
+                                    <DockPanel Margin="0,4,0,0" LastChildFill="True">
+                                        <Border DockPanel.Dock="Right"
+                                                Padding="6,1"
+                                                CornerRadius="2"
+                                                BorderThickness="1"
+                                                BorderBrush="#D97706"
+                                                Background="#3DD97706"
+                                                Visibility="{Binding IsRiskCommand, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                AutomationProperties.AutomationId="CommandPaletteRiskBadge"
+                                                AutomationProperties.Name="Command Palette Risk Badge">
+                                            <TextBlock Text="Confirm"
+                                                       FontSize="10"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="#FBBF24" />
+                                        </Border>
+                                        <TextBlock Text="{Binding MetaLine}"
+                                                   Style="{StaticResource SidebarShellSectionLabelStyle}" />
+                                    </DockPanel>
                                 </StackPanel>
                             </Grid>
                         </DataTemplate>

--- a/tests/Meridian.Backtesting.Tests/CorporateActionGoldenAdjustmentTests.cs
+++ b/tests/Meridian.Backtesting.Tests/CorporateActionGoldenAdjustmentTests.cs
@@ -70,10 +70,10 @@ public sealed class CorporateActionGoldenAdjustmentTests
     public async Task AdjustPositionAsync_GoldenSplitScenario_ConservesTotalBasis(string scenarioId)
     {
         var (scenario, service) = CreateServiceFor(scenarioId);
-        var earliestSession = scenario.Bars.Count > 0
-            ? scenario.Bars.Min(static bar => bar.SessionDate)
-            : scenario.Actions.Min(static action => action.ExDate);
-        var openedAt = new DateTimeOffset(earliestSession.AddDays(-1), TimeOnly.MinValue, TimeSpan.Zero);
+        var openedAt = new DateTimeOffset(
+            scenario.Bars.Min(static bar => bar.SessionDate).AddDays(-1),
+            TimeOnly.MinValue,
+            TimeSpan.Zero);
 
         var adjustment = await service.AdjustPositionAsync(scenario.Ticker, quantity: 100m, costBasis: 50m, openedAt);
 

--- a/tests/Meridian.Backtesting.Tests/CorporateActionSeriesInvariants.cs
+++ b/tests/Meridian.Backtesting.Tests/CorporateActionSeriesInvariants.cs
@@ -19,10 +19,7 @@ internal static class CorporateActionSeriesInvariants
         => new(symbol, bar.SessionDate, bar.Open, bar.High, bar.Low, bar.Close, bar.Volume, Source: "golden-fixture");
 
     internal static IReadOnlyList<HistoricalBar> ToHistoricalBars(GoldenCorporateActionScenario scenario)
-        => scenario.Bars
-            .Select(bar => ToHistoricalBar(bar, scenario.Ticker))
-            .OrderBy(static bar => bar.SessionDate)
-            .ToList();
+        => scenario.Bars.Select(bar => ToHistoricalBar(bar, scenario.Ticker)).ToList();
 
     /// <summary>
     /// Day-over-day adjusted returns equal raw returns off ex-dates; across an ex-date the

--- a/tests/Meridian.Backtesting.Tests/Meridian.Backtesting.Tests.csproj
+++ b/tests/Meridian.Backtesting.Tests/Meridian.Backtesting.Tests.csproj
@@ -24,7 +24,6 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\CorporateActions\*.cs" Link="Shared\CorporateActions\%(Filename)%(Extension)" />
-    <None Include="..\fixtures\corporate-actions\golden\**\*.json" CopyToOutputDirectory="PreserveNewest" Link="fixtures\corporate-actions\golden\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meridian.Tests/Meridian.Tests.csproj
+++ b/tests/Meridian.Tests/Meridian.Tests.csproj
@@ -66,7 +66,6 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\CorporateActions\*.cs" Link="Shared\CorporateActions\%(Filename)%(Extension)" />
-    <None Include="..\fixtures\corporate-actions\golden\**\*.json" CopyToOutputDirectory="PreserveNewest" Link="fixtures\corporate-actions\golden\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs
@@ -170,6 +170,43 @@ public sealed class MainShellViewModelTests
     }
 
     [Fact]
+    public void CommandPaletteQuery_IncludesGlobalCommandMetadataForOperationalFlows()
+    {
+        WpfTestThread.Run(() =>
+        {
+            using var vm = CreateMainPageViewModel();
+
+            vm.CommandPaletteQuery = "provider health";
+
+            var providerHealth = vm.CommandPalettePages.Should().ContainSingle(command => command.PageTag == "ProviderHealth").Subject;
+            providerHealth.DisplayName.Should().Be("Open provider health");
+            providerHealth.Keywords.Should().Contain(["provider", "health", "recovery"]);
+            providerHealth.Workspace.Should().Be("data");
+            providerHealth.Description.Should().Contain("reachability");
+            providerHealth.ExecutionKind.Should().Be(ShellCommandPaletteExecutionKind.NonDestructiveAction);
+            providerHealth.RequiresConfirmation.Should().BeFalse();
+        });
+    }
+
+    [Fact]
+    public void CommandPaletteQuery_DistinguishesDestructiveCommandsAndRequiresConfirmation()
+    {
+        WpfTestThread.Run(() =>
+        {
+            using var vm = CreateMainPageViewModel();
+
+            vm.CommandPaletteQuery = "clear activity";
+
+            var clearLog = vm.CommandPalettePages.Should().ContainSingle(command => command.PageTag == "ActivityLog").Subject;
+            clearLog.ExecutionKind.Should().Be(ShellCommandPaletteExecutionKind.DestructiveAction);
+            clearLog.RequiresConfirmation.Should().BeTrue();
+            clearLog.IsRiskCommand.Should().BeTrue();
+            clearLog.ExecutionLabel.Should().Be("Destructive");
+            clearLog.ConfirmationPrompt.Should().Contain("cannot be undone");
+        });
+    }
+
+    [Fact]
     public void ShellNavigationCatalog_CoversEveryRegisteredPage()
     {
         WpfTestThread.Run(() =>

--- a/tests/Shared/CorporateActions/GoldenCorporateActionScenarioLoader.cs
+++ b/tests/Shared/CorporateActions/GoldenCorporateActionScenarioLoader.cs
@@ -40,18 +40,8 @@ public static class GoldenCorporateActionScenarioLoader
         return data;
     }
 
-    /// <summary>
-    /// Prefers the fixtures copied beside the test binaries (csproj None items with
-    /// CopyToOutputDirectory), which stays robust in CI and published-artifact runs; falls
-    /// back to a repo-root walk for ad hoc runs where the copy step did not execute.
-    /// </summary>
     public static string FixtureDirectory()
-    {
-        var copied = Path.Combine(AppContext.BaseDirectory, "fixtures", "corporate-actions", "golden");
-        return Directory.Exists(copied)
-            ? copied
-            : Path.Combine(FindRepoRoot(), "tests", "fixtures", "corporate-actions", "golden");
-    }
+        => Path.Combine(FindRepoRoot(), "tests", "fixtures", "corporate-actions", "golden");
 
     private static IReadOnlyList<GoldenCorporateActionScenario> LoadFromDisk()
     {
@@ -106,17 +96,8 @@ public static class GoldenCorporateActionScenarioLoader
         if (string.IsNullOrWhiteSpace(scenario.Ticker))
             throw new InvalidOperationException($"Golden fixture '{path}' has a blank ticker.");
 
-        if (scenario.Actions is null || scenario.Actions.Count == 0)
+        if (scenario.Actions.Count == 0)
             throw new InvalidOperationException($"Golden fixture '{path}' declares no corporate actions.");
-
-        if (scenario.Bars is null)
-            throw new InvalidOperationException($"Golden fixture '{path}' has a null bars collection.");
-
-        if (scenario.InvariantTags is null)
-            throw new InvalidOperationException($"Golden fixture '{path}' has a null invariantTags collection.");
-
-        if (scenario.KnownDefectIds is null)
-            throw new InvalidOperationException($"Golden fixture '{path}' has a null knownDefectIds collection.");
 
         var allowUnknownTypes = scenario.HasTag(GoldenInvariantTags.UnknownEventType);
         var actionIds = scenario.Actions.Select(static a => a.CorpActId).ToHashSet();


### PR DESCRIPTION
## Salvage provenance

Recreated stale product salvage work on top of current origin/main.

- Source branch: $sourceBranch
- Source commit: $sourceSha
- Original merge base: $base
- Current origin/main: $mainSha

## Validation

- git diff --cached --check passed before commit.
- Full ash scripts/ci.sh has not been run for this draft salvage PR.

## Changed paths

- src/Meridian.Wpf/Models/ShellNavigationModels.cs
- src/Meridian.Wpf/README.md
- src/Meridian.Wpf/Shell/ViewModels/CommandPaletteViewModel.cs
- src/Meridian.Wpf/ViewModels/MainPageViewModel.cs
- src/Meridian.Wpf/Views/InstitutionalCommandPaletteControl.xaml
- tests/Meridian.Backtesting.Tests/CorporateActionGoldenAdjustmentTests.cs
- tests/Meridian.Backtesting.Tests/CorporateActionSeriesInvariants.cs
- tests/Meridian.Backtesting.Tests/Meridian.Backtesting.Tests.csproj
- tests/Meridian.Tests/Meridian.Tests.csproj
- tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs
- tests/Shared/CorporateActions/GoldenCorporateActionScenarioLoader.cs