### PR TITLE
[salvage/product] Add WPF data confidence indicator

### DIFF
--- a/src/Meridian.Wpf/Controls/DataConfidenceIndicator.xaml
+++ b/src/Meridian.Wpf/Controls/DataConfidenceIndicator.xaml
@@ -1,0 +1,93 @@
+<UserControl x:Class="Meridian.Wpf.Controls.DataConfidenceIndicator"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             x:Name="Root"
+             mc:Ignorable="d"
+             MinHeight="34"
+             d:DesignHeight="52" d:DesignWidth="320"
+             AutomationProperties.AutomationId="{Binding ElementName=Root, Path=IndicatorAutomationId}"
+             AutomationProperties.Name="{Binding ElementName=Root, Path=Model.AccessibleExplanation}">
+    <Button x:Name="ExplanationButton"
+            DataContext="{Binding ElementName=Root}"
+            Command="{Binding ExplanationCommand}"
+            CommandParameter="{Binding ExplanationCommandParameter}"
+            ToolTip="{Binding Model.Explanation}"
+            Padding="0"
+            BorderThickness="0"
+            Background="Transparent"
+            HorizontalContentAlignment="Stretch"
+            VerticalContentAlignment="Stretch"
+            AutomationProperties.AutomationId="{Binding IndicatorAutomationId}"
+            AutomationProperties.Name="{Binding Model.AccessibleExplanation}">
+        <Button.Style>
+            <Style TargetType="Button">
+                <Setter Property="Cursor" Value="Hand" />
+                <Setter Property="Focusable" Value="True" />
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding IsClickThroughEnabled}" Value="False">
+                        <Setter Property="Cursor" Value="Arrow" />
+                        <Setter Property="Focusable" Value="False" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+        </Button.Style>
+        <Border Style="{StaticResource WorkspaceToneBadgeStyle}"
+                Padding="8,5">
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                <TextBlock Text="{Binding Model.IconGlyph}"
+                           FontFamily="{StaticResource SymbolThemeFontFamily}"
+                           Margin="0,0,7,0"
+                           VerticalAlignment="Center"
+                           Style="{StaticResource WorkspaceToneBadgeTextStyle}"
+                           AutomationProperties.AutomationId="{Binding IconAutomationId}" />
+                <StackPanel>
+                    <WrapPanel>
+                        <TextBlock Text="{Binding Model.ConfidenceLabel}"
+                                   FontSize="11"
+                                   FontWeight="SemiBold"
+                                   Style="{StaticResource WorkspaceToneBadgeTextStyle}"
+                                   AutomationProperties.AutomationId="{Binding ConfidenceAutomationId}" />
+                        <TextBlock Text=" · " FontSize="11" Foreground="{StaticResource ConsoleTextMutedBrush}" />
+                        <TextBlock Text="{Binding Model.ReconciliationLabel}"
+                                   FontSize="11"
+                                   FontWeight="SemiBold"
+                                   Style="{StaticResource WorkspaceToneBadgeTextStyle}"
+                                   AutomationProperties.AutomationId="{Binding ReconciliationAutomationId}" />
+                    </WrapPanel>
+                    <TextBlock Text="{Binding Model.ProviderLabel, StringFormat=Source: {0}}"
+                               Margin="0,2,0,0"
+                               FontSize="10"
+                               Foreground="{StaticResource ConsoleTextMutedBrush}"
+                               TextTrimming="CharacterEllipsis"
+                               AutomationProperties.AutomationId="{Binding SourceAutomationId}" />
+                    <TextBlock Text="{Binding Model.FreshnessLabel}"
+                               Margin="0,1,0,0"
+                               FontSize="10"
+                               Foreground="{StaticResource ConsoleTextMutedBrush}"
+                               AutomationProperties.AutomationId="{Binding FreshnessAutomationId}" />
+                    <TextBlock Text="{Binding Model.Notes}"
+                               Margin="0,1,0,0"
+                               FontSize="10"
+                               Foreground="{StaticResource ConsoleTextMutedBrush}"
+                               TextWrapping="Wrap"
+                               AutomationProperties.AutomationId="{Binding NotesAutomationId}">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Model.Notes}" Value="{x:Null}">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Model.Notes}" Value="">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </StackPanel>
+            </StackPanel>
+        </Border>
+    </Button>
+</UserControl>

--- a/src/Meridian.Wpf/Controls/DataConfidenceIndicator.xaml.cs
+++ b/src/Meridian.Wpf/Controls/DataConfidenceIndicator.xaml.cs
@@ -1,0 +1,155 @@
+using System.Windows;
+using System.Windows.Automation;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Meridian.Wpf.Models;
+
+namespace Meridian.Wpf.Controls;
+
+public partial class DataConfidenceIndicator : UserControl
+{
+    public static readonly DependencyProperty ModelProperty =
+        DependencyProperty.Register(
+            nameof(Model),
+            typeof(DataConfidenceIndicatorModel),
+            typeof(DataConfidenceIndicator),
+            new PropertyMetadata(DataConfidenceIndicatorModel.Unknown(), OnModelChanged));
+
+    public static readonly DependencyProperty ToneProperty =
+        DependencyProperty.Register(nameof(Tone), typeof(string), typeof(DataConfidenceIndicator), new PropertyMetadata(WorkspaceTone.Neutral));
+
+    public static readonly DependencyProperty ExplanationCommandProperty =
+        DependencyProperty.Register(nameof(ExplanationCommand), typeof(ICommand), typeof(DataConfidenceIndicator), new PropertyMetadata(null));
+
+    public static readonly DependencyProperty ExplanationCommandParameterProperty =
+        DependencyProperty.Register(nameof(ExplanationCommandParameter), typeof(object), typeof(DataConfidenceIndicator), new PropertyMetadata(null));
+
+    public static readonly DependencyProperty IsClickThroughEnabledProperty =
+        DependencyProperty.Register(nameof(IsClickThroughEnabled), typeof(bool), typeof(DataConfidenceIndicator), new PropertyMetadata(true));
+
+    public static readonly DependencyProperty IndicatorAutomationIdProperty =
+        DependencyProperty.Register(
+            nameof(IndicatorAutomationId),
+            typeof(string),
+            typeof(DataConfidenceIndicator),
+            new PropertyMetadata("DataConfidenceIndicator", OnIndicatorAutomationIdChanged));
+
+    public static readonly DependencyProperty IconAutomationIdProperty =
+        DependencyProperty.Register(nameof(IconAutomationId), typeof(string), typeof(DataConfidenceIndicator), new PropertyMetadata("DataConfidenceIndicatorIcon"));
+
+    public static readonly DependencyProperty ConfidenceAutomationIdProperty =
+        DependencyProperty.Register(nameof(ConfidenceAutomationId), typeof(string), typeof(DataConfidenceIndicator), new PropertyMetadata("DataConfidenceIndicatorConfidence"));
+
+    public static readonly DependencyProperty ReconciliationAutomationIdProperty =
+        DependencyProperty.Register(nameof(ReconciliationAutomationId), typeof(string), typeof(DataConfidenceIndicator), new PropertyMetadata("DataConfidenceIndicatorReconciliation"));
+
+    public static readonly DependencyProperty SourceAutomationIdProperty =
+        DependencyProperty.Register(nameof(SourceAutomationId), typeof(string), typeof(DataConfidenceIndicator), new PropertyMetadata("DataConfidenceIndicatorSource"));
+
+    public static readonly DependencyProperty FreshnessAutomationIdProperty =
+        DependencyProperty.Register(nameof(FreshnessAutomationId), typeof(string), typeof(DataConfidenceIndicator), new PropertyMetadata("DataConfidenceIndicatorFreshness"));
+
+    public static readonly DependencyProperty NotesAutomationIdProperty =
+        DependencyProperty.Register(nameof(NotesAutomationId), typeof(string), typeof(DataConfidenceIndicator), new PropertyMetadata("DataConfidenceIndicatorNotes"));
+
+    public DataConfidenceIndicator()
+    {
+        InitializeComponent();
+        AutomationProperties.SetAutomationId(this, IndicatorAutomationId);
+        UpdateAutomationName();
+    }
+
+    public DataConfidenceIndicatorModel Model
+    {
+        get => (DataConfidenceIndicatorModel)GetValue(ModelProperty);
+        set => SetValue(ModelProperty, value);
+    }
+
+    public string Tone
+    {
+        get => (string)GetValue(ToneProperty);
+        private set => SetValue(ToneProperty, value);
+    }
+
+    public ICommand? ExplanationCommand
+    {
+        get => (ICommand?)GetValue(ExplanationCommandProperty);
+        set => SetValue(ExplanationCommandProperty, value);
+    }
+
+    public object? ExplanationCommandParameter
+    {
+        get => GetValue(ExplanationCommandParameterProperty);
+        set => SetValue(ExplanationCommandParameterProperty, value);
+    }
+
+    public bool IsClickThroughEnabled
+    {
+        get => (bool)GetValue(IsClickThroughEnabledProperty);
+        set => SetValue(IsClickThroughEnabledProperty, value);
+    }
+
+    public string IndicatorAutomationId
+    {
+        get => (string)GetValue(IndicatorAutomationIdProperty);
+        set => SetValue(IndicatorAutomationIdProperty, value);
+    }
+
+    public string IconAutomationId
+    {
+        get => (string)GetValue(IconAutomationIdProperty);
+        set => SetValue(IconAutomationIdProperty, value);
+    }
+
+    public string ConfidenceAutomationId
+    {
+        get => (string)GetValue(ConfidenceAutomationIdProperty);
+        set => SetValue(ConfidenceAutomationIdProperty, value);
+    }
+
+    public string ReconciliationAutomationId
+    {
+        get => (string)GetValue(ReconciliationAutomationIdProperty);
+        set => SetValue(ReconciliationAutomationIdProperty, value);
+    }
+
+    public string SourceAutomationId
+    {
+        get => (string)GetValue(SourceAutomationIdProperty);
+        set => SetValue(SourceAutomationIdProperty, value);
+    }
+
+    public string FreshnessAutomationId
+    {
+        get => (string)GetValue(FreshnessAutomationIdProperty);
+        set => SetValue(FreshnessAutomationIdProperty, value);
+    }
+
+    public string NotesAutomationId
+    {
+        get => (string)GetValue(NotesAutomationIdProperty);
+        set => SetValue(NotesAutomationIdProperty, value);
+    }
+
+    private static void OnModelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is DataConfidenceIndicator control)
+        {
+            control.Tone = control.Model.Tone;
+            control.UpdateAutomationName();
+        }
+    }
+
+    private static void OnIndicatorAutomationIdChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is DataConfidenceIndicator control && e.NewValue is string automationId)
+        {
+            AutomationProperties.SetAutomationId(control, automationId);
+        }
+    }
+
+    private void UpdateAutomationName()
+    {
+        AutomationProperties.SetName(this, Model.AccessibleExplanation);
+    }
+}

--- a/src/Meridian.Wpf/Models/DataConfidenceIndicatorModel.cs
+++ b/src/Meridian.Wpf/Models/DataConfidenceIndicatorModel.cs
@@ -1,0 +1,213 @@
+using Meridian.Contracts.Workstation;
+using Meridian.Ui.Services.Services;
+
+namespace Meridian.Wpf.Models;
+
+public enum DataConfidenceLevel
+{
+    Unknown = 0,
+    Current,
+    Stale,
+    Partial,
+    Estimated,
+    ProviderDegraded,
+    Missing
+}
+
+public enum DataConfidenceReconciliationStatus
+{
+    Unknown = 0,
+    Reconciled,
+    Unreconciled,
+    Estimated
+}
+
+public static class DataConfidenceLabels
+{
+    public const string Current = "Current";
+    public const string Stale = "Stale";
+    public const string Partial = "Partial";
+    public const string Reconciled = "Reconciled";
+    public const string Unreconciled = "Unreconciled";
+    public const string Estimated = "Estimated";
+    public const string ProviderDegraded = "Provider Degraded";
+    public const string Missing = "Missing";
+    public const string Unknown = "Unknown";
+}
+
+public sealed record DataConfidenceIndicatorModel(
+    DataConfidenceLevel ConfidenceLevel,
+    DateTimeOffset? FreshnessTimestamp,
+    string SourceName,
+    DataConfidenceReconciliationStatus ReconciliationStatus,
+    string? Notes,
+    string Explanation,
+    string? ExplanationRoute = null,
+    string? ProviderStatus = null)
+{
+    public static DataConfidenceIndicatorModel Unknown(string sourceName = "Not reported", string? notes = null)
+        => new(
+            DataConfidenceLevel.Unknown,
+            FreshnessTimestamp: null,
+            Normalize(sourceName, "Not reported"),
+            DataConfidenceReconciliationStatus.Unknown,
+            notes,
+            "Source confidence has not been reported for this value.");
+
+    public static DataConfidenceIndicatorModel FromEvidence(
+        EvidenceStatusDto status,
+        EvidenceFreshnessDto freshness,
+        string? sourceSystem,
+        string? notes = null,
+        string? explanationRoute = null)
+    {
+        var confidence = status switch
+        {
+            EvidenceStatusDto.Ready when !freshness.IsStale => DataConfidenceLevel.Current,
+            EvidenceStatusDto.Stale => DataConfidenceLevel.Stale,
+            EvidenceStatusDto.Missing => DataConfidenceLevel.Missing,
+            EvidenceStatusDto.Blocked => DataConfidenceLevel.Partial,
+            EvidenceStatusDto.ReviewRequired => DataConfidenceLevel.Partial,
+            _ when freshness.IsStale => DataConfidenceLevel.Stale,
+            _ => DataConfidenceLevel.Unknown
+        };
+
+        var reconciliation = status switch
+        {
+            EvidenceStatusDto.Ready => DataConfidenceReconciliationStatus.Reconciled,
+            EvidenceStatusDto.Missing or EvidenceStatusDto.Blocked or EvidenceStatusDto.ReviewRequired or EvidenceStatusDto.Stale => DataConfidenceReconciliationStatus.Unreconciled,
+            _ => DataConfidenceReconciliationStatus.Unknown
+        };
+
+        return new DataConfidenceIndicatorModel(
+            confidence,
+            freshness.AsOf,
+            Normalize(sourceSystem, "Evidence"),
+            reconciliation,
+            FirstNonBlank(notes, freshness.Reason),
+            BuildExplanation(confidence, reconciliation, sourceSystem, freshness.AsOf, FirstNonBlank(notes, freshness.Reason)),
+            explanationRoute);
+    }
+
+    public static DataConfidenceIndicatorModel FromProviderStatus(
+        ProviderStatusInfo provider,
+        DataConfidenceReconciliationStatus reconciliationStatus = DataConfidenceReconciliationStatus.Unknown,
+        string? notes = null,
+        string? explanationRoute = null)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+
+        var status = Normalize(provider.Status, provider.IsConnected ? "Connected" : "Disconnected");
+        var degraded = !provider.IsConnected
+            || !provider.IsEnabled
+            || ContainsAny(status, "degraded", "unhealthy", "error", "failed", "blocked", "disconnected")
+            || !string.IsNullOrWhiteSpace(provider.LastError)
+            || !string.IsNullOrWhiteSpace(provider.LastFailureKind);
+        var asOf = provider.LastMessageReceivedAt
+            ?? provider.LastHeartbeatReceivedAt
+            ?? (provider.LastConnectedAt.HasValue ? new DateTimeOffset(DateTime.SpecifyKind(provider.LastConnectedAt.Value, DateTimeKind.Utc)) : null);
+        var confidence = degraded ? DataConfidenceLevel.ProviderDegraded : DataConfidenceLevel.Current;
+        var providerNotes = FirstNonBlank(notes, provider.LastError, provider.LastFailureKind, provider.LifecycleState, provider.WebSocketState);
+
+        return new DataConfidenceIndicatorModel(
+            confidence,
+            asOf,
+            Normalize(provider.DisplayName, provider.Name, "Provider"),
+            reconciliationStatus,
+            providerNotes,
+            BuildExplanation(confidence, reconciliationStatus, provider.DisplayName, asOf, providerNotes),
+            explanationRoute,
+            status);
+    }
+
+    public string ConfidenceLabel => ConfidenceLevel switch
+    {
+        DataConfidenceLevel.Current => DataConfidenceLabels.Current,
+        DataConfidenceLevel.Stale => DataConfidenceLabels.Stale,
+        DataConfidenceLevel.Partial => DataConfidenceLabels.Partial,
+        DataConfidenceLevel.Estimated => DataConfidenceLabels.Estimated,
+        DataConfidenceLevel.ProviderDegraded => DataConfidenceLabels.ProviderDegraded,
+        DataConfidenceLevel.Missing => DataConfidenceLabels.Missing,
+        _ => DataConfidenceLabels.Unknown
+    };
+
+    public string ReconciliationLabel => ReconciliationStatus switch
+    {
+        DataConfidenceReconciliationStatus.Reconciled => DataConfidenceLabels.Reconciled,
+        DataConfidenceReconciliationStatus.Unreconciled => DataConfidenceLabels.Unreconciled,
+        DataConfidenceReconciliationStatus.Estimated => DataConfidenceLabels.Estimated,
+        _ => DataConfidenceLabels.Unknown
+    };
+
+    public string FreshnessLabel => FreshnessTimestamp?.ToString("yyyy-MM-dd HH:mm 'UTC'") ?? "As of unavailable";
+
+    public string ProviderLabel => string.IsNullOrWhiteSpace(ProviderStatus)
+        ? SourceName
+        : $"{SourceName} · {ProviderStatus}";
+
+    public string SummaryLabel => $"{ConfidenceLabel} · {ReconciliationLabel}";
+
+    public string Tone => ConfidenceLevel switch
+    {
+        DataConfidenceLevel.Current when ReconciliationStatus is DataConfidenceReconciliationStatus.Reconciled => WorkspaceTone.Success,
+        DataConfidenceLevel.ProviderDegraded or DataConfidenceLevel.Stale or DataConfidenceLevel.Partial => WorkspaceTone.Warning,
+        DataConfidenceLevel.Missing => WorkspaceTone.Danger,
+        DataConfidenceLevel.Estimated => WorkspaceTone.Info,
+        _ => WorkspaceTone.Neutral
+    };
+
+    public string IconGlyph => ConfidenceLevel switch
+    {
+        DataConfidenceLevel.Current => "\uE73E",
+        DataConfidenceLevel.ProviderDegraded => "\uE7BA",
+        DataConfidenceLevel.Stale => "\uE823",
+        DataConfidenceLevel.Partial => "\uE9D5",
+        DataConfidenceLevel.Estimated => "\uE9D2",
+        DataConfidenceLevel.Missing => "\uE783",
+        _ => "\uE946"
+    };
+
+    public string AccessibleExplanation
+        => $"Data confidence {SummaryLabel}; source {ProviderLabel}; freshness {FreshnessLabel}. {Explanation}";
+
+    private static string BuildExplanation(
+        DataConfidenceLevel confidence,
+        DataConfidenceReconciliationStatus reconciliation,
+        string? sourceName,
+        DateTimeOffset? freshnessTimestamp,
+        string? notes)
+    {
+        var source = Normalize(sourceName, "source not reported");
+        var freshness = freshnessTimestamp?.ToString("yyyy-MM-dd HH:mm 'UTC'") ?? "freshness unavailable";
+        var noteText = string.IsNullOrWhiteSpace(notes) ? string.Empty : $" Notes: {notes}";
+        return $"{LabelFor(confidence)} value from {source}; {LabelFor(reconciliation)}; {freshness}.{noteText}";
+    }
+
+    private static string LabelFor(DataConfidenceLevel level) => level switch
+    {
+        DataConfidenceLevel.Current => DataConfidenceLabels.Current,
+        DataConfidenceLevel.Stale => DataConfidenceLabels.Stale,
+        DataConfidenceLevel.Partial => DataConfidenceLabels.Partial,
+        DataConfidenceLevel.Estimated => DataConfidenceLabels.Estimated,
+        DataConfidenceLevel.ProviderDegraded => DataConfidenceLabels.ProviderDegraded,
+        DataConfidenceLevel.Missing => DataConfidenceLabels.Missing,
+        _ => DataConfidenceLabels.Unknown
+    };
+
+    private static string LabelFor(DataConfidenceReconciliationStatus status) => status switch
+    {
+        DataConfidenceReconciliationStatus.Reconciled => DataConfidenceLabels.Reconciled,
+        DataConfidenceReconciliationStatus.Unreconciled => DataConfidenceLabels.Unreconciled,
+        DataConfidenceReconciliationStatus.Estimated => DataConfidenceLabels.Estimated,
+        _ => DataConfidenceLabels.Unknown
+    };
+
+    private static string Normalize(params string?[] candidates)
+        => candidates.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value))?.Trim() ?? string.Empty;
+
+    private static string FirstNonBlank(params string?[] candidates)
+        => Normalize(candidates);
+
+    private static bool ContainsAny(string value, params string[] needles)
+        => needles.Any(needle => value.Contains(needle, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/Meridian.Wpf/README.md
+++ b/src/Meridian.Wpf/README.md
@@ -46,6 +46,8 @@ Manual desktop secret entry uses `SecretInputControl`, which keeps values hidden
 an explicit reveal toggle with non-secret automation names, and clears masked and revealed values
 together when a flow resets the input.
 
+Reusable value-adjacent confidence badges use `DataConfidenceIndicator` and `DataConfidenceIndicatorModel` so Portfolio, Accounting, Reporting, and Data screens can display the same Current, Stale, Partial, Reconciled, Unreconciled, Estimated, and Provider Degraded labels with source/provider metadata, freshness, reconciliation status, fallback notes, and click-through explanations sourced from shared evidence or provider read models where available.
+
 The Accounting workspace includes a dedicated `FundStructureSetupPage` and `FundStructureSetupViewModel` for operator entity setup. It uses the shared `FundStructureSetupWorkflowService` so desktop setup validation, graph preview, review-and-create, and account handoff behavior match `/api/fund-structure`.
 `FundAccountingConfigure` now routes to `AccountingConfigurePage` and `AccountingConfigureViewModel`
 instead of a generic ledger page. The page opens on compact action chrome instead of a duplicate

--- a/tests/Meridian.Wpf.Tests/Models/DataConfidenceIndicatorModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/Models/DataConfidenceIndicatorModelTests.cs
@@ -1,0 +1,73 @@
+#if WINDOWS
+using Meridian.Contracts.Workstation;
+using Meridian.Ui.Services.Services;
+using Meridian.Wpf.Models;
+
+namespace Meridian.Wpf.Tests.Models;
+
+public sealed class DataConfidenceIndicatorModelTests
+{
+    [Fact]
+    public void FromEvidence_WithReadyFreshEvidence_UsesCurrentReconciledLabels()
+    {
+        var asOf = new DateTimeOffset(2026, 6, 15, 12, 30, 0, TimeSpan.Zero);
+
+        var model = DataConfidenceIndicatorModel.FromEvidence(
+            EvidenceStatusDto.Ready,
+            new EvidenceFreshnessDto(asOf, IsStale: false, Reason: null),
+            "Portfolio ledger");
+
+        model.ConfidenceLabel.Should().Be(DataConfidenceLabels.Current);
+        model.ReconciliationLabel.Should().Be(DataConfidenceLabels.Reconciled);
+        model.FreshnessLabel.Should().Be("2026-06-15 12:30 UTC");
+        model.ProviderLabel.Should().Be("Portfolio ledger");
+        model.Tone.Should().Be(WorkspaceTone.Success);
+        model.AccessibleExplanation.Should().Contain("Current · Reconciled");
+    }
+
+    [Fact]
+    public void FromEvidence_WithReviewRequiredStaleEvidence_SurfacesPartialUnreconciledNotes()
+    {
+        var model = DataConfidenceIndicatorModel.FromEvidence(
+            EvidenceStatusDto.ReviewRequired,
+            new EvidenceFreshnessDto(new DateTimeOffset(2026, 6, 14, 9, 0, 0, TimeSpan.Zero), IsStale: true, Reason: "Source file is older than policy."),
+            "Accounting import");
+
+        model.ConfidenceLabel.Should().Be(DataConfidenceLabels.Partial);
+        model.ReconciliationLabel.Should().Be(DataConfidenceLabels.Unreconciled);
+        model.Notes.Should().Be("Source file is older than policy.");
+        model.Tone.Should().Be(WorkspaceTone.Warning);
+    }
+
+    [Fact]
+    public void FromProviderStatus_WithDegradedProvider_UsesProviderDegradedLabelAndStatus()
+    {
+        var model = DataConfidenceIndicatorModel.FromProviderStatus(new ProviderStatusInfo
+        {
+            Name = "ibkr",
+            DisplayName = "Interactive Brokers",
+            IsEnabled = true,
+            IsConnected = true,
+            Status = "Degraded",
+            LastMessageReceivedAt = new DateTimeOffset(2026, 6, 15, 10, 5, 0, TimeSpan.Zero),
+            LastFailureKind = "Heartbeat timeout"
+        });
+
+        model.ConfidenceLabel.Should().Be(DataConfidenceLabels.ProviderDegraded);
+        model.ProviderLabel.Should().Be("Interactive Brokers · Degraded");
+        model.Notes.Should().Be("Heartbeat timeout");
+        model.Tone.Should().Be(WorkspaceTone.Warning);
+    }
+
+    [Fact]
+    public void Unknown_UsesExplicitUnavailableState()
+    {
+        var model = DataConfidenceIndicatorModel.Unknown();
+
+        model.ConfidenceLabel.Should().Be(DataConfidenceLabels.Unknown);
+        model.ReconciliationLabel.Should().Be(DataConfidenceLabels.Unknown);
+        model.FreshnessLabel.Should().Be("As of unavailable");
+        model.Tone.Should().Be(WorkspaceTone.Neutral);
+    }
+}
+#endif


### PR DESCRIPTION
## Salvage provenance

Recreated stale product salvage work on top of current origin/main.

- Source branch: $sourceBranch
- Source commit: $sourceSha
- Original merge base: $base
- Current origin/main: $mainSha

## Validation

- git diff --cached --check passed before commit.
- Full ash scripts/ci.sh has not been run for this draft salvage PR.

## Changed paths

- src/Meridian.Wpf/Controls/DataConfidenceIndicator.xaml
- src/Meridian.Wpf/Controls/DataConfidenceIndicator.xaml.cs
- src/Meridian.Wpf/Models/DataConfidenceIndicatorModel.cs
- src/Meridian.Wpf/README.md
- tests/Meridian.Wpf.Tests/Models/DataConfidenceIndicatorModelTests.cs