### PR TITLE
feat(dashboard): control-tower triage, dense-table row guard, strictNullChecks gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,9 @@ jobs:
       - name: Lint dashboard source
         run: npm --prefix src/Meridian.Ui/dashboard run lint
 
+      - name: Enforce strictNullChecks on dashboard source
+        run: npm --prefix src/Meridian.Ui/dashboard run typecheck:strict
+
       - name: Run dashboard tests
         run: npm --prefix src/Meridian.Ui/dashboard run test
 

--- a/src/Meridian.Ui/dashboard/eslint.config.mjs
+++ b/src/Meridian.Ui/dashboard/eslint.config.mjs
@@ -39,7 +39,7 @@ export default tseslint.config(
       "no-useless-assignment": "error",
       "no-useless-escape": "error",
       "preserve-caught-error": "error",
-      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-unused-vars": [
         "error",
         {

--- a/src/Meridian.Ui/dashboard/package.json
+++ b/src/Meridian.Ui/dashboard/package.json
@@ -10,6 +10,7 @@
     "screenshots": "node ../../../scripts/dev/capture-web-screenshots.mjs",
     "smoke:workstation": "node scripts/smoke-workstation.mjs",
     "lint": "eslint src",
+    "typecheck:strict": "tsc --noEmit -p tsconfig.strict-null.json",
     "test": "node --max-old-space-size=4096 ./scripts/run-vitest-stable.mjs",
     "test:vitest": "vitest run",
     "test:watch": "vitest",

--- a/src/Meridian.Ui/dashboard/src/app-shell.workflow-routing.ts
+++ b/src/Meridian.Ui/dashboard/src/app-shell.workflow-routing.ts
@@ -36,6 +36,8 @@ export function actionLabelForOperatorWorkItem(item: OperatorWorkItem): string {
       return "Open provider trust";
     case "ExecutionControl":
       return "Open execution controls";
+    case "BrokerExecutionReconciliation":
+      return "Review broker orders";
   }
 }
 
@@ -56,6 +58,7 @@ function fallbackRouteForOperatorWorkItemKind(kind: OperatorWorkItem["kind"]): s
     case "PaperReplay":
     case "PromotionReview":
     case "ExecutionControl":
+    case "BrokerExecutionReconciliation":
       return WORKSTATION_ROUTE_CATALOG.tradingReadiness;
     case "BrokerageSync":
       return WORKSTATION_ROUTE_CATALOG.settingsAlpacaProviderSetup;

--- a/src/Meridian.Ui/dashboard/src/components/meridian/security-details-tracker.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/security-details-tracker.tsx
@@ -476,7 +476,7 @@ function loadLots(securityId: string): SecurityLot[] {
       && typeof l.tradeDate === "string"
       && typeof l.quantity === "number"
       && typeof l.price === "number"
-    ).map((l) => ({ fees: 0, note: "", ...l }));
+    ).map((l) => ({ ...l, fees: l.fees ?? 0, note: l.note ?? "" }));
   } catch {
     return [];
   }

--- a/src/Meridian.Ui/dashboard/src/components/meridian/ui-kit-primitives.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/ui-kit-primitives.test.tsx
@@ -279,6 +279,58 @@ describe("DenseDataTable", () => {
 
     expect(screen.getByRole("row", { name: "NVDA Watched" })).toBeInTheDocument();
   });
+
+  it("guards the DOM with a default row cap when no explicit limit is given", async () => {
+    const user = userEvent.setup();
+    const manyRows = Array.from({ length: 150 }, (_, index) => ({
+      id: `row-${index}`,
+      symbol: `SYM${index}`,
+      status: "Watched"
+    }));
+
+    render(
+      <DenseDataTable
+        columns={columns}
+        rows={manyRows}
+        getRowId={(row) => row.id}
+        getRowAriaLabel={(row) => `${row.symbol} ${row.status}`}
+        emptyText="No rows"
+        ariaLabel="Unbounded table"
+      />
+    );
+
+    // Only the first 100 rows are mounted by default; the rest stay behind the
+    // progressive-disclosure control so a large set never floods the DOM.
+    expect(screen.getByRole("row", { name: "SYM0 Watched" })).toBeInTheDocument();
+    expect(screen.getByRole("row", { name: "SYM99 Watched" })).toBeInTheDocument();
+    expect(screen.queryByRole("row", { name: "SYM100 Watched" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Show all 150 rows" }));
+    expect(screen.getByRole("row", { name: "SYM149 Watched" })).toBeInTheDocument();
+  });
+
+  it("renders every row when the cap is explicitly disabled with null", () => {
+    const manyRows = Array.from({ length: 130 }, (_, index) => ({
+      id: `row-${index}`,
+      symbol: `SYM${index}`,
+      status: "Watched"
+    }));
+
+    render(
+      <DenseDataTable
+        columns={columns}
+        rows={manyRows}
+        getRowId={(row) => row.id}
+        getRowAriaLabel={(row) => `${row.symbol} ${row.status}`}
+        emptyText="No rows"
+        ariaLabel="Uncapped table"
+        maxVisibleRows={null}
+      />
+    );
+
+    expect(screen.getByRole("row", { name: "SYM129 Watched" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Show all/ })).not.toBeInTheDocument();
+  });
 });
 
 function getTestRowId(row: TestRow) {

--- a/src/Meridian.Ui/dashboard/src/components/meridian/ui-kit-primitives.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/ui-kit-primitives.tsx
@@ -28,6 +28,13 @@ const DEFAULT_VIRTUALIZATION_OVERSCAN = 6;
 const DEFAULT_VIRTUALIZATION_VIEWPORT_ROWS = 12;
 const TYPEAHEAD_RESET_MS = 500;
 
+// Default DOM-row guard for non-virtualized tables. Fixed-height tables should
+// pass `virtualization` for true windowing; everything else renders at most this
+// many rows and surfaces a "Show all N rows" control, so a large data set can
+// never dump thousands of nodes into the DOM by omission. Pass `maxVisibleRows={null}`
+// to opt a table out of the cap explicitly.
+export const DEFAULT_DENSE_TABLE_ROW_CAP = 100;
+
 export interface ToolbarStripItem {
   id: string;
   label: string;
@@ -105,6 +112,13 @@ export interface DenseDataTableProps<T> {
   caption?: string | null;
   sort?: DenseDataTableSortState | null;
   onToggleSort?: (columnId: string) => void;
+  /**
+   * Soft cap on rows mounted into the DOM for non-virtualized tables; excess
+   * rows collapse behind a "Show all N rows" control. Defaults to
+   * {@link DEFAULT_DENSE_TABLE_ROW_CAP}. Pass an explicit number to tune it, or
+   * `null` to render every row (only safe for bounded data sets). Ignored while
+   * `virtualization` is active, which windows the full set instead.
+   */
   maxVisibleRows?: number | null;
   /**
    * Enable row windowing for large data sets. When set, only a window of rows is
@@ -133,7 +147,7 @@ function DenseDataTableComponent<T>({
   caption,
   sort = null,
   onToggleSort,
-  maxVisibleRows = null,
+  maxVisibleRows = DEFAULT_DENSE_TABLE_ROW_CAP,
   virtualization = null,
   getRowTypeaheadText
 }: DenseDataTableProps<T>) {

--- a/src/Meridian.Ui/dashboard/src/lib/reporting-hub.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/reporting-hub.ts
@@ -270,7 +270,7 @@ function buildDailyWorkItem(item: ReportingHubDailyWorkInput): ReportingHubDaily
   const nextActionLabel = item.primaryActionLabel.trim() || "Review";
   const proofLabel = buildProofLabel(evidenceGaps, item.secondaryActionLabel);
   const detailParts = [item.detail, dueLabel, evidenceGaps.length > 0 ? `${countUnit(evidenceGaps.length, "evidence gap")}` : ""]
-    .filter((part) => part.trim().length > 0);
+    .filter((part): part is string => part != null && part.trim().length > 0);
 
   return {
     workItemId: item.workItemId,

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.governance.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.governance.view-model.ts
@@ -2355,7 +2355,7 @@ export function useAccountingConfigurationViewModel(
         }
       : null;
     const selectedDryRunRuleVersion = dryRunPreview
-      ? workspace.postingRules.find((rule) => rule.ruleId === dryRunPreview.selectedRuleId)?.ruleVersion ?? "v1"
+      ? (workspace?.postingRules ?? []).find((rule) => rule.ruleId === dryRunPreview.selectedRuleId)?.ruleVersion ?? "v1"
       : null;
 
     return {

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.tsx
@@ -2340,10 +2340,7 @@ export function AccountingScreen({ data, multiAssetCoverage }: AccountingScreenP
             <summary className="cursor-pointer text-sm font-semibold text-foreground">System details</summary>
             <div className="mt-4 space-y-4">
               {workflowLaunch ? <AccountingWorkflowLaunchPanel view={workflowLaunch} /> : null}
-              <CloseCommandCenterPanel
-                view={closeCommandCenter}
-                onRefresh={() => void refreshCloseWorkflow()}
-              />
+              {closeCommandCenter ? <CloseCommandCenterPanel view={closeCommandCenter} onRefresh={() => void refreshCloseWorkflow()} /> : null}
               <AccountingCloseReportPackagePanel view={closeReportPackage} />
               <AccountingTaskModeLauncher />
             </div>
@@ -2353,11 +2350,8 @@ export function AccountingScreen({ data, multiAssetCoverage }: AccountingScreenP
         <>
       {sectionVisibility.showWorkflowDetails && workflowLaunch ? <AccountingWorkflowLaunchPanel view={workflowLaunch} /> : null}
 
-      {sectionVisibility.showWorkflowDetails ? (
-      <CloseCommandCenterPanel
-        view={closeCommandCenter}
-        onRefresh={() => void refreshCloseWorkflow()}
-      />
+      {sectionVisibility.showWorkflowDetails && closeCommandCenter ? (
+        <CloseCommandCenterPanel view={closeCommandCenter} onRefresh={() => void refreshCloseWorkflow()} />
       ) : null}
 
       {sectionVisibility.showWorkflowDetails ? <AccountingCloseReportPackagePanel view={closeReportPackage} /> : null}

--- a/src/Meridian.Ui/dashboard/src/screens/daily-control-tower-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/daily-control-tower-screen.test.tsx
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "jest-axe";
+import { buildAppShellViewState, type AppShellWorkspacePayload } from "@/app-shell.view-model";
+import { DailyControlTowerScreen } from "@/screens/daily-control-tower-screen";
+import { renderWithRouter } from "@/test/render";
+import type { DataWorkspaceResponse, TradingWorkspaceResponse } from "@/types";
+
+// A payload that produces a multi-row finance queue so row selection is
+// observable: two trading work items plus one data-provider warning.
+const payload: AppShellWorkspacePayload = {
+  session: {
+    displayName: "Ops Desk",
+    role: "Operator",
+    environment: "paper",
+    activeWorkspace: "trading",
+    commandCount: 7
+  },
+  overview: null,
+  strategy: null,
+  trading: {
+    readiness: {
+      asOf: "2026-05-14T21:30:00Z",
+      overallStatus: "Blocked",
+      readyForPaperOperation: false,
+      acceptanceGates: [],
+      activeSession: null,
+      sessions: [],
+      replay: null,
+      controls: { circuitBreakerOpen: false },
+      promotion: null,
+      trustGate: null,
+      brokerageSync: null,
+      workItems: [
+        {
+          workItemId: "brokerage-sync",
+          kind: "BrokerageSync",
+          label: "Brokerage sync failed",
+          detail: "Account sync failed after the last provider heartbeat.",
+          tone: "Critical",
+          createdAt: "2026-05-14T20:00:00Z",
+          runId: null,
+          fundAccountId: "fund-1",
+          auditReference: "audit-1",
+          workspace: "portfolio",
+          targetRoute: "/portfolio/brokerage-sync",
+          targetPageTag: "BrokerageSync"
+        },
+        {
+          workItemId: "report-pack",
+          kind: "ReportPackApproval",
+          label: "Report pack approval waiting",
+          detail: "Monthly board pack still needs an operator sign-off.",
+          tone: "Warning",
+          createdAt: "2026-05-14T21:00:00Z",
+          runId: "run-1",
+          fundAccountId: null,
+          auditReference: "audit-2",
+          workspace: "reporting",
+          targetRoute: "/reporting/report-packs",
+          targetPageTag: "ReportPackApproval"
+        }
+      ],
+      warnings: []
+    }
+  } as unknown as TradingWorkspaceResponse,
+  portfolio: null,
+  data: {
+    providers: [
+      {
+        provider: "Alpaca",
+        status: "Warning",
+        capability: "paper",
+        latency: "120ms",
+        note: "Paper endpoint returned intermittent quote gaps.",
+        recommendedAction: "Review paper provider posture."
+      }
+    ],
+    backfills: [],
+    exports: []
+  } as unknown as DataWorkspaceResponse,
+  accounting: null,
+  reporting: null,
+  workflowSummary: null
+};
+
+function renderScreen() {
+  const shell = buildAppShellViewState({
+    pathname: "/",
+    loading: false,
+    error: null,
+    workspaceErrors: {},
+    payload
+  });
+  return renderWithRouter(
+    <DailyControlTowerScreen viewModel={shell.workflowContinuity} trustStrip={shell.trustStrip} />
+  );
+}
+
+describe("DailyControlTowerScreen", () => {
+  it("renders the ranked finance queue and defaults the evidence pane to the top row", () => {
+    renderScreen();
+
+    expect(
+      screen.getByRole("heading", { name: "What needs an operator decision now" })
+    ).toBeInTheDocument();
+
+    // Each queue row exposes a selection control; the top-ranked row's evidence
+    // shows without any interaction.
+    expect(
+      screen.getByRole("button", { name: "Show evidence for Report pack approval waiting" })
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.getByRole("region", { name: /Report pack approval waiting Evidence summary/ })
+    ).toBeInTheDocument();
+  });
+
+  it("updates the evidence pane in place when another queue row is selected", async () => {
+    const user = userEvent.setup();
+    renderScreen();
+
+    const brokerageButton = screen.getByRole("button", {
+      name: "Show evidence for Brokerage sync failed"
+    });
+    expect(brokerageButton).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(brokerageButton);
+
+    // Selection moved without navigating away: the evidence region now reflects
+    // the clicked row, and the pressed state follows it.
+    expect(brokerageButton).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.getByRole("region", { name: /Brokerage sync failed Evidence summary/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Show evidence for Report pack approval waiting" })
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = renderScreen();
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/screens/daily-control-tower-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/daily-control-tower-screen.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { ArrowRight } from "lucide-react";
 import { Link } from "react-router-dom";
 import type { AppShellTrustStripState, AppShellWorkflowContinuityViewModel } from "@/app-shell.view-model";
@@ -33,7 +34,12 @@ const badgeVariantToStatus: Record<"outline" | "success" | "warning" | "danger",
 
 export function DailyControlTowerScreen({ viewModel, trustStrip }: DailyControlTowerScreenProps) {
   const model = buildDailyControlTowerModel(viewModel, trustStrip);
-  const selectedQueueRow = model.queueRows[0] ?? null;
+  // Triage-in-place: the operator can inspect any queue row's evidence without
+  // leaving the tower. Falls back to the top-ranked row until one is chosen
+  // (or when the chosen row leaves the queue on refresh).
+  const [selectedQueueItemId, setSelectedQueueItemId] = useState<string | null>(null);
+  const selectedQueueRow =
+    model.queueRows.find((row) => row.item.id === selectedQueueItemId) ?? model.queueRows[0] ?? null;
 
   return (
     <section
@@ -140,16 +146,26 @@ export function DailyControlTowerScreen({ viewModel, trustStrip }: DailyControlT
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-border">
-                  {model.queueRows.map((row, index) => (
+                  {model.queueRows.map((row) => {
+                    const isSelected = row.item.id === selectedQueueRow?.item.id;
+                    return (
                     <tr
                       key={row.item.id}
-                      className={index === 0 ? "align-top bg-primary/5" : "align-top"}
-                      aria-current={index === 0 ? "true" : undefined}
+                      className={isSelected ? "align-top bg-primary/5" : "align-top"}
+                      aria-current={isSelected ? "true" : undefined}
                     >
                       <td className="max-w-sm px-4 py-4">
                         <div className="space-y-2">
                           <div className="flex flex-wrap items-center gap-2">
-                            <span className="font-medium text-foreground">{row.item.label}</span>
+                            <button
+                              type="button"
+                              onClick={() => setSelectedQueueItemId(row.item.id)}
+                              aria-pressed={isSelected}
+                              aria-label={`Show evidence for ${row.item.label}`}
+                              className="text-left font-medium text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                            >
+                              {row.item.label}
+                            </button>
                             <SeverityBadge
                               status={badgeVariantToStatus[row.badgeVariant]}
                               label={row.statusLabel}
@@ -174,7 +190,8 @@ export function DailyControlTowerScreen({ viewModel, trustStrip }: DailyControlT
                         {row.proof?.label ?? row.proofPassportItems.find((item) => item.id === "freshness")?.value ?? "No evidence linked"}
                       </td>
                     </tr>
-                  ))}
+                    );
+                  })}
                 </tbody>
               </table>
             </div>

--- a/src/Meridian.Ui/dashboard/src/screens/evidence-workbench-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/evidence-workbench-screen.view-model.ts
@@ -1759,13 +1759,13 @@ export function buildEvidencePacketActions(input: {
 
     return {
       id: action.actionId,
-      label: action.label,
       detail: action.detail,
       targetLabel: formatPageTag(action.targetPageTag),
       tone: mapWorkflowActionTone(action.tone),
       href,
       control,
-      ...command
+      ...command,
+      label: action.label // row title; keep it from being clobbered by the command's button-verb label
     };
   });
 }

--- a/src/Meridian.Ui/dashboard/src/screens/operations-continuity-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/operations-continuity-screen.tsx
@@ -1383,7 +1383,7 @@ export function OperationsContinuityScreen() {
             actor: "browser-operator",
             reviewer: row.reviewer,
             rationale: `Approved workflow approval ${row.id} from Operations Continuity approval history.`,
-            reportPackId: row.approveWorkflowReportPackId,
+            reportPackId: row.approveWorkflowReportPackId!, // guarded above: approve returns early when absent
             correlationId: `browser-approval-decision:approve:${row.id}`,
             evidenceLinks: row.approveWorkflowEvidenceLinks,
             checklistControlApprovals: row.approveWorkflowChecklistControlApprovals,

--- a/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.view-model.ts
@@ -1719,7 +1719,7 @@ function buildSelectedBrokeragePositionDetail(
       { label: "Unrealized P&L", value: pnl, tone: pnlStatusTone },
       { label: "Security coverage", value: coverageLabel, tone: coverageTone },
       { label: "Position ID", value: position.positionId ?? "Unavailable", tone: position.positionId ? "muted" : "warning" },
-      { label: "Currency", value: position.currency, tone: "muted" }
+      { label: "Currency", value: position.currency ?? "Unavailable", tone: "muted" }
     ]
   };
 }

--- a/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.ts
@@ -1319,10 +1319,10 @@ function validateCellKindParameters(cell: StrategyBuilderCell, cellIds: Readonly
     const parsedMinSize = minSize ? Number(minSize) : null;
     const parsedMaxSize = maxSize ? Number(maxSize) : null;
 
-    if (minSize && (!Number.isFinite(parsedMinSize) || parsedMinSize < 0)) {
+    if (minSize && (!Number.isFinite(parsedMinSize) || (parsedMinSize !== null && parsedMinSize < 0))) {
       messages.push({ code: "UniverseBuilderMinSizeInvalid", severity: "error", targetId: cell.cellId, message: `${label} (universe-builder) minSize must be a non-negative number.` });
     }
-    if (maxSize && (!Number.isFinite(parsedMaxSize) || parsedMaxSize < 0)) {
+    if (maxSize && (!Number.isFinite(parsedMaxSize) || (parsedMaxSize !== null && parsedMaxSize < 0))) {
       messages.push({ code: "UniverseBuilderMaxSizeInvalid", severity: "error", targetId: cell.cellId, message: `${label} (universe-builder) maxSize must be a non-negative number.` });
     }
     if (

--- a/src/Meridian.Ui/dashboard/src/screens/strategy-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/strategy-screen.tsx
@@ -551,7 +551,11 @@ export function StrategyScreen({ data }: StrategyScreenProps) {
                   <Button
                     size="sm"
                     aria-label={vm.promotionPanel.sessionCreated.actionAriaLabel}
-                    onClick={() => { navigate(vm.promotionPanel.sessionCreated.actionHref); }}
+                    onClick={() => {
+                      if (vm.promotionPanel.sessionCreated) {
+                        navigate(vm.promotionPanel.sessionCreated.actionHref);
+                      }
+                    }}
                   >
                     {vm.promotionPanel.sessionCreated.actionLabel}
                   </Button>

--- a/src/Meridian.Ui/dashboard/src/screens/trading-screen.evidence-timeline.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/trading-screen.evidence-timeline.ts
@@ -111,6 +111,8 @@ function toneFromReadinessStatus(status: TradingAcceptanceGate["status"]): Opera
       return "review";
     case "Ready":
       return "ready";
+    case "Unknown":
+      return "pending";
   }
 }
 

--- a/src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx
@@ -954,7 +954,7 @@ export function TradingScreen({ data, fundAccountId: operatingFundAccountId }: T
                         min={0}
                         step={0.01}
                         value={orderTicket.controls.limitPrice.value}
-                        onChange={(e) => orderTicket.updateField(orderTicket.controls.limitPrice.field, e.target.value)}
+                        onChange={(e) => orderTicket.controls.limitPrice && orderTicket.updateField(orderTicket.controls.limitPrice.field, e.target.value)}
                         aria-label={orderTicket.controls.limitPrice.ariaLabel}
                         aria-describedby={orderTicket.controls.limitPrice.describedBy}
                         error={orderTicket.controls.limitPrice.invalid}

--- a/src/Meridian.Ui/dashboard/tsconfig.strict-null.json
+++ b/src/Meridian.Ui/dashboard/tsconfig.strict-null.json
@@ -1,0 +1,12 @@
+{
+  // Incremental strictNullChecks gate. Production source under src/ is null-safe
+  // today and this config enforces it going forward (see `npm run typecheck:strict`,
+  // wired into CI). Test files stay excluded until their fixtures are migrated off
+  // the base config's looser typing; tighten the exclude list as they are cleaned.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strictNullChecks": true
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
## Summary

Three ranked value improvements from the web-UI audit, following the merged retry/stream work (#2124, #2148):

- **#7 Daily Control Tower is now a triage surface.** The default landing screen pinned its evidence pane to the top queue row (`queueRows[0]`); other rows could only be actioned by navigating away. Each blocked-item label is now a selection button that updates the evidence pane in place (`aria-pressed` reflects selection; the highlight and `aria-current` follow it). Adds the screen's first tests — it was the only major screen with none: render + default selection, in-place selection change, and a jest-axe pass.
- **#6 DenseDataTable defaults to a DOM row-count guard.** The table rendered every row unless a caller opted into virtualization (only trial balance did) — the other ~20 call sites could dump unbounded rows into the DOM. True windowing needs fixed row heights most tables don't have, so instead of forcing virtualization this defaults `maxVisibleRows` to a 100-row cap: excess rows collapse behind the existing "Show all N rows" control. Callers keep full control (explicit number tunes it, `null` opts out, `virtualization` still windows the full set; `data-screen` already passed `100`, so it's unchanged).
- **#5 strictNullChecks enforced on production source, `no-explicit-any` re-armed.** Tightening to strictNullChecks flagged 16 production sites; several were genuine latent defects `strict:false` had masked — a missing `BrokerExecutionReconciliation` work-item case returning `undefined`, an omitted `Unknown` readiness-tone case, and an evidence packet-action row rendering the button verb as its title because a spread clobbered the action label. The rest are behavior-preserving guards. A new `tsconfig.strict-null.json` + `typecheck:strict` script covers `src/` (excluding tests, whose fixtures still rely on looser typing) and is wired into CI so any prod null-safety regression fails the build. `@typescript-eslint/no-explicit-any` is re-enabled as `warn` (source has zero `any` today).

## Reason

Next-highest-value items from the browser-workstation audit after the resilience fixes: the default landing screen wasn't usable for triage, a shared table primitive could flood the DOM, and the codebase's null-safety floor was off despite the code being nearly null-safe in practice.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated (new `daily-control-tower-screen.test.tsx`; DenseDataTable default-cap and null-opt-out cases; existing suites cover the null-safety edits)
- [ ] Relevant integration tests were added or updated (not applicable — UI/view-model behavior)
- [ ] GitHub Actions `quality-gate` passed (pending on this PR)

Local validation: full dashboard suite green (`npm run test`), base `tsc --noEmit` and the new `typecheck:strict` both clean, eslint clean (0 errors; pre-existing `exhaustive-deps` warnings only), file-size ratchet and generated-route drift gates green.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [ ] No governance files changed
- [x] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

`.github/workflows/ci.yml` gains one step in the existing `browser-workstation` job: `npm run typecheck:strict` (the strictNullChecks gate). No other workflow behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VT2GaUkx6zAmCywRKJaTk

---
_Generated by [Claude Code](https://claude.ai/code/session_012VT2GaUkx6zAmCywRKJaTk)_