### PR TITLE
feat(ui/data): contextual actions on coverage-gap and anomaly cells

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/ui/context-menu.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/context-menu.tsx
@@ -133,6 +133,8 @@ export function useContextMenu() {
     setPosition({ x: event.clientX, y: event.clientY });
   }, []);
 
+  const openAt = useCallback((next: ContextMenuPosition) => setPosition(next), []);
+
   const onKeyDown = useCallback((event: React.KeyboardEvent<HTMLElement>) => {
     if (event.key !== "ContextMenu" && !(event.shiftKey && event.key === "F10")) {
       return;
@@ -149,6 +151,7 @@ export function useContextMenu() {
     closeMenu,
     onContextMenu,
     onKeyDown,
+    openAt,
     open: position !== null,
     position
   };

--- a/src/Meridian.Ui/dashboard/src/screens/data-screen.cell-actions.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/data-screen.cell-actions.test.tsx
@@ -1,0 +1,199 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildCellActions,
+  useCellActions,
+  CellActionConfirmDialog,
+  CellActionTrigger,
+  ContextMenu,
+  type AnomalyCellContext,
+  type CellActionApi,
+  type CellActionId,
+  type CoverageGapCellContext
+} from "./data-screen.cell-actions";
+import type { ToastApi } from "@/components/ui/toast";
+
+const coverageContext: CoverageGapCellContext = {
+  kind: "coverage-gap",
+  symbol: "GME",
+  sourcesLabel: "configured-streaming"
+};
+
+const anomalyContext: AnomalyCellContext = {
+  kind: "anomaly",
+  symbol: "AMC",
+  anomalyId: "anomaly-1",
+  anomalyType: "PriceSpike"
+};
+
+function actionIds(context: CoverageGapCellContext | AnomalyCellContext) {
+  return buildCellActions(context, () => undefined)
+    .filter((entry) => entry.type !== "divider")
+    .map((entry) => entry.id);
+}
+
+describe("buildCellActions", () => {
+  it("projects coverage-gap actions with a destructive exclude", () => {
+    expect(actionIds(coverageContext)).toEqual([
+      "backfill",
+      "master",
+      "open-capability-matrix",
+      "exclude"
+    ]);
+    const exclude = buildCellActions(coverageContext, () => undefined).find((entry) => entry.id === "exclude");
+    expect(exclude?.type !== "divider" && exclude?.danger).toBe(true);
+  });
+
+  it("projects anomaly actions without a destructive item", () => {
+    expect(actionIds(anomalyContext)).toEqual([
+      "acknowledge",
+      "backfill",
+      "compare-providers",
+      "open-capability-matrix"
+    ]);
+    const dangerous = buildCellActions(anomalyContext, () => undefined).some(
+      (entry) => entry.type !== "divider" && entry.danger
+    );
+    expect(dangerous).toBe(false);
+  });
+
+  it("routes every actionable item through the dispatcher", () => {
+    const dispatch = vi.fn();
+    for (const entry of buildCellActions(coverageContext, dispatch)) {
+      if (entry.type !== "divider") {
+        entry.onSelect?.();
+      }
+    }
+    expect(dispatch).toHaveBeenCalledWith<[CellActionId]>("backfill");
+    expect(dispatch).toHaveBeenCalledWith<[CellActionId]>("exclude");
+  });
+
+  it("disables mutating actions while busy but keeps navigation live", () => {
+    const entries = buildCellActions(coverageContext, () => undefined, { busy: true });
+    const disabledFor = (id: CellActionId) => {
+      const entry = entries.find((candidate) => candidate.id === id);
+      return entry && entry.type !== "divider" ? entry.disabled : undefined;
+    };
+    expect(disabledFor("backfill")).toBe(true);
+    expect(disabledFor("open-capability-matrix")).toBeFalsy();
+  });
+});
+
+function stubToast(): ToastApi {
+  return {
+    dismiss: vi.fn(),
+    show: vi.fn(() => ""),
+    success: vi.fn(() => ""),
+    warning: vi.fn(() => ""),
+    danger: vi.fn(() => ""),
+    info: vi.fn(() => "")
+  };
+}
+
+function Harness({
+  context,
+  toast,
+  api,
+  onOpenCapabilityMatrix
+}: {
+  context: CoverageGapCellContext | AnomalyCellContext;
+  toast: ToastApi;
+  api?: Partial<CellActionApi>;
+  onOpenCapabilityMatrix?: (symbol: string) => void;
+}) {
+  const cellActions = useCellActions({ toast, api, onOpenCapabilityMatrix });
+  return (
+    <div>
+      <CellActionTrigger label="Open actions" onOpen={(event) => cellActions.openFor(event, context)} />
+      <ContextMenu
+        open={cellActions.menu.open}
+        position={cellActions.menu.position}
+        items={cellActions.menu.items}
+        onClose={cellActions.menu.close}
+        label={cellActions.menu.label}
+      />
+      <CellActionConfirmDialog
+        confirm={cellActions.confirm}
+        running={cellActions.running}
+        onResolve={cellActions.resolveConfirm}
+      />
+    </div>
+  );
+}
+
+describe("useCellActions", () => {
+  it("triggers a backfill through the endpoint layer and reports success", async () => {
+    const user = userEvent.setup();
+    const toast = stubToast();
+    const triggerBackfill = vi.fn().mockResolvedValue({ success: true });
+
+    render(<Harness context={coverageContext} toast={toast} api={{ triggerBackfill }} />);
+
+    await user.click(screen.getByRole("button", { name: "Open actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: /Backfill this range/ }));
+
+    await waitFor(() =>
+      expect(triggerBackfill).toHaveBeenCalledWith({ provider: null, symbols: ["GME"], from: null, to: null })
+    );
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it("gates exclude behind a confirmation dialog before archiving", async () => {
+    const user = userEvent.setup();
+    const toast = stubToast();
+    const archiveSymbol = vi.fn().mockResolvedValue({ success: true, symbol: "GME" });
+
+    render(<Harness context={coverageContext} toast={toast} api={{ archiveSymbol }} />);
+
+    await user.click(screen.getByRole("button", { name: "Open actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: /Exclude symbol/ }));
+
+    // The archive must not fire until the operator confirms.
+    expect(archiveSymbol).not.toHaveBeenCalled();
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveTextContent("Exclude GME?");
+
+    await user.click(screen.getByRole("button", { name: "Exclude symbol" }));
+    await waitFor(() => expect(archiveSymbol).toHaveBeenCalledWith("GME"));
+  });
+
+  it("cancels exclude without archiving", async () => {
+    const user = userEvent.setup();
+    const archiveSymbol = vi.fn();
+
+    render(<Harness context={coverageContext} toast={stubToast()} api={{ archiveSymbol }} />);
+
+    await user.click(screen.getByRole("button", { name: "Open actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: /Exclude symbol/ }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(archiveSymbol).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges an anomaly through the endpoint layer", async () => {
+    const user = userEvent.setup();
+    const acknowledgeAnomaly = vi.fn().mockResolvedValue(undefined);
+
+    render(<Harness context={anomalyContext} toast={stubToast()} api={{ acknowledgeAnomaly }} />);
+
+    await user.click(screen.getByRole("button", { name: "Open actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: /Flag as acknowledged/ }));
+
+    await waitFor(() => expect(acknowledgeAnomaly).toHaveBeenCalledWith("anomaly-1"));
+  });
+
+  it("delegates compare-across-providers to the capability-matrix navigator", async () => {
+    const user = userEvent.setup();
+    const onOpenCapabilityMatrix = vi.fn();
+
+    render(
+      <Harness context={anomalyContext} toast={stubToast()} onOpenCapabilityMatrix={onOpenCapabilityMatrix} />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: /Compare across providers/ }));
+
+    expect(onOpenCapabilityMatrix).toHaveBeenCalledWith("AMC");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/screens/data-screen.cell-actions.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/data-screen.cell-actions.test.tsx
@@ -171,6 +171,31 @@ describe("useCellActions", () => {
     expect(archiveSymbol).not.toHaveBeenCalled();
   });
 
+  it("keeps the confirm dialog open and undismissable while the action is in flight", async () => {
+    const user = userEvent.setup();
+    let resolveArchive: (() => void) | undefined;
+    const archiveSymbol = vi.fn(
+      () =>
+        new Promise<{ success: boolean; symbol: string }>((resolve) => {
+          resolveArchive = () => resolve({ success: true, symbol: "GME" });
+        })
+    );
+
+    render(<Harness context={coverageContext} toast={stubToast()} api={{ archiveSymbol }} />);
+
+    await user.click(screen.getByRole("button", { name: "Open actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: /Exclude symbol/ }));
+    await user.click(screen.getByRole("button", { name: "Exclude symbol" }));
+
+    // In flight: the confirm control is disabled and Escape must not dismiss the dialog.
+    await waitFor(() => expect(screen.getByRole("button", { name: "Working…" })).toBeDisabled());
+    await user.keyboard("{Escape}");
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    resolveArchive?.();
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+  });
+
   it("acknowledges an anomaly through the endpoint layer", async () => {
     const user = userEvent.setup();
     const acknowledgeAnomaly = vi.fn().mockResolvedValue(undefined);

--- a/src/Meridian.Ui/dashboard/src/screens/data-screen.cell-actions.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/data-screen.cell-actions.tsx
@@ -1,0 +1,368 @@
+import {
+  CheckCircle2,
+  DatabaseZap,
+  MoreHorizontal,
+  ShieldCheck,
+  Table2,
+  Trash2
+} from "lucide-react";
+import {
+  useCallback,
+  useMemo,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode
+} from "react";
+import {
+  ContextMenu,
+  useContextMenu,
+  type ContextMenuEntry,
+  type ContextMenuPosition
+} from "@/components/ui/context-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { acknowledgeAnomaly, archiveSymbol, triggerBackfill } from "@/lib/api";
+import { describeApiError } from "@/lib/api-errors";
+import type { ToastApi } from "@/components/ui/toast";
+import { cn } from "@/lib/utils";
+
+/**
+ * Contextual actions on the data itself: right-click (or the hover-revealed "⋯" affordance) on a
+ * coverage-gap row or an anomaly surfaces the operations that live on that datum — backfill,
+ * exclude, master, acknowledge, compare — routed through the workstation endpoint layer rather
+ * than a separate jobs screen three clicks away.
+ */
+
+/** A red coverage-gap cell: an active symbol with no security-master record. */
+export interface CoverageGapCellContext {
+  kind: "coverage-gap";
+  symbol: string;
+  sourcesLabel: string;
+}
+
+/** An anomalous tick flagged by the quality monitor. */
+export interface AnomalyCellContext {
+  kind: "anomaly";
+  symbol: string;
+  anomalyId: string;
+  anomalyType: string;
+}
+
+export type CellActionContext = CoverageGapCellContext | AnomalyCellContext;
+
+/** Stable identifiers for every contextual action, shared by the builder, hook, and tests. */
+export type CellActionId =
+  | "backfill"
+  | "master"
+  | "exclude"
+  | "acknowledge"
+  | "compare-providers"
+  | "open-capability-matrix";
+
+export interface BuildCellActionsOptions {
+  /** Disable mutating actions while another action for the same context is in flight. */
+  busy?: boolean;
+}
+
+/**
+ * Pure projection of a cell context onto its context-menu entries. Every actionable item routes
+ * back through {@link onAction}; the hook decides what each id does (direct call vs confirm gate).
+ */
+export function buildCellActions(
+  context: CellActionContext,
+  onAction: (actionId: CellActionId) => void,
+  options: BuildCellActionsOptions = {}
+): ContextMenuEntry[] {
+  const busy = options.busy ?? false;
+  const item = (
+    id: CellActionId,
+    label: string,
+    icon: ReactNode,
+    extra: { danger?: boolean; disabled?: boolean } = {}
+  ): ContextMenuEntry => ({
+    id,
+    type: "item",
+    label,
+    icon,
+    danger: extra.danger,
+    disabled: extra.disabled,
+    onSelect: () => onAction(id)
+  });
+
+  if (context.kind === "coverage-gap") {
+    return [
+      item("backfill", "Backfill this range", <DatabaseZap className="h-4 w-4" aria-hidden="true" />, { disabled: busy }),
+      item("master", "Master this symbol", <ShieldCheck className="h-4 w-4" aria-hidden="true" />, { disabled: busy }),
+      { id: "coverage-divider", type: "divider" },
+      item("open-capability-matrix", "Open provider capability matrix", <Table2 className="h-4 w-4" aria-hidden="true" />),
+      { id: "coverage-danger-divider", type: "divider" },
+      item("exclude", "Exclude symbol", <Trash2 className="h-4 w-4" aria-hidden="true" />, { danger: true, disabled: busy })
+    ];
+  }
+
+  return [
+    item("acknowledge", "Flag as acknowledged", <CheckCircle2 className="h-4 w-4" aria-hidden="true" />, { disabled: busy }),
+    item("backfill", "Backfill symbol", <DatabaseZap className="h-4 w-4" aria-hidden="true" />, { disabled: busy }),
+    item("compare-providers", "Compare across providers", <Table2 className="h-4 w-4" aria-hidden="true" />),
+    { id: "anomaly-divider", type: "divider" },
+    item("open-capability-matrix", "Open provider capability matrix", <Table2 className="h-4 w-4" aria-hidden="true" />)
+  ];
+}
+
+/** A pending destructive action awaiting operator confirmation. */
+interface CellActionConfirmState {
+  title: string;
+  description: string;
+  confirmLabel: string;
+  run: () => Promise<void>;
+}
+
+export interface CellActionApi {
+  triggerBackfill: typeof triggerBackfill;
+  archiveSymbol: typeof archiveSymbol;
+  acknowledgeAnomaly: typeof acknowledgeAnomaly;
+}
+
+const defaultCellActionApi: CellActionApi = {
+  triggerBackfill,
+  archiveSymbol,
+  acknowledgeAnomaly
+};
+
+export interface UseCellActionsOptions {
+  toast: ToastApi;
+  /** Reuse the coverage-gaps draft flow for "Master this symbol". */
+  onMasterSymbol?: (symbol: string) => void;
+  /** Navigate/scroll to the provider capability matrix, optionally focused on a symbol. */
+  onOpenCapabilityMatrix?: (symbol: string) => void;
+  /** Re-fetch the owning panel after a successful mutation. */
+  onAfterMutation?: () => void;
+  /** Injectable endpoint surface for tests. */
+  api?: Partial<CellActionApi>;
+}
+
+export interface UseCellActionsResult {
+  /** Open the context menu for a cell from a right-click or the hover-revealed trigger. */
+  openFor: (
+    event: ReactMouseEvent<HTMLElement> | ReactKeyboardEvent<HTMLElement>,
+    context: CellActionContext
+  ) => void;
+  /** Menu wiring to spread onto {@link ContextMenu}. */
+  menu: {
+    open: boolean;
+    position: ContextMenuPosition | null;
+    items: ContextMenuEntry[];
+    close: () => void;
+    label: string;
+  };
+  /** Pending destructive confirmation, or null. */
+  confirm: CellActionConfirmState | null;
+  resolveConfirm: (accept: boolean) => void;
+  /** True while a mutating action is in flight. */
+  running: boolean;
+}
+
+/**
+ * Shared contextual-action hook for the Data screen. Owns a single context menu whose entries are
+ * derived from the currently targeted cell, executes mutating actions through the workstation
+ * endpoint layer, gates destructive actions behind a confirm dialog, and reports outcomes on toast.
+ */
+export function useCellActions(options: UseCellActionsOptions): UseCellActionsResult {
+  const { toast, onMasterSymbol, onOpenCapabilityMatrix, onAfterMutation } = options;
+  const optionsApi = options.api;
+  const api = useMemo<CellActionApi>(() => ({ ...defaultCellActionApi, ...optionsApi }), [optionsApi]);
+  const menu = useContextMenu();
+  const [context, setContext] = useState<CellActionContext | null>(null);
+  const [running, setRunning] = useState(false);
+  const [confirm, setConfirm] = useState<CellActionConfirmState | null>(null);
+
+  const openFor = useCallback(
+    (
+      event: ReactMouseEvent<HTMLElement> | ReactKeyboardEvent<HTMLElement>,
+      target: CellActionContext
+    ) => {
+      setContext(target);
+      if ("clientX" in event && (event.clientX !== 0 || event.clientY !== 0)) {
+        menu.onContextMenu(event as ReactMouseEvent<HTMLElement>);
+        return;
+      }
+      // Keyboard / synthetic activation: anchor to the triggering element instead of (0,0).
+      event.preventDefault();
+      const rect = event.currentTarget.getBoundingClientRect();
+      menu.openAt({ x: rect.left, y: rect.bottom + 4 });
+    },
+    [menu]
+  );
+
+  const runAction = useCallback(
+    async (successTitle: string, fallback: string, effect: () => Promise<unknown>) => {
+      setRunning(true);
+      try {
+        await effect();
+        toast.success(successTitle);
+        onAfterMutation?.();
+      } catch (error) {
+        toast.danger(fallback, describeApiError(error, fallback).summary);
+      } finally {
+        setRunning(false);
+      }
+    },
+    [toast, onAfterMutation]
+  );
+
+  const dispatch = useCallback(
+    (actionId: CellActionId) => {
+      if (!context) {
+        return;
+      }
+      const { symbol } = context;
+      switch (actionId) {
+        case "backfill":
+          void runAction(
+            `Backfill queued for ${symbol}`,
+            `Could not queue a backfill for ${symbol}.`,
+            () => api.triggerBackfill({ provider: null, symbols: [symbol], from: null, to: null })
+          );
+          return;
+        case "master":
+          onMasterSymbol?.(symbol);
+          return;
+        case "acknowledge":
+          if (context.kind === "anomaly") {
+            const anomalyId = context.anomalyId;
+            void runAction(
+              `Acknowledged anomaly for ${symbol}`,
+              `Could not acknowledge the anomaly for ${symbol}.`,
+              () => api.acknowledgeAnomaly(anomalyId)
+            );
+          }
+          return;
+        case "compare-providers":
+        case "open-capability-matrix":
+          onOpenCapabilityMatrix?.(symbol);
+          return;
+        case "exclude":
+          setConfirm({
+            title: `Exclude ${symbol}?`,
+            description: `${symbol} will be archived and dropped from coverage tracking. You can re-add it from the symbol registry.`,
+            confirmLabel: "Exclude symbol",
+            run: () =>
+              runAction(
+                `${symbol} excluded from coverage`,
+                `Could not exclude ${symbol}.`,
+                () => api.archiveSymbol(symbol)
+              )
+          });
+          return;
+        default:
+          return;
+      }
+    },
+    [context, api, runAction, onMasterSymbol, onOpenCapabilityMatrix]
+  );
+
+  const resolveConfirm = useCallback(
+    (accept: boolean) => {
+      const pending = confirm;
+      setConfirm(null);
+      if (accept && pending) {
+        void pending.run();
+      }
+    },
+    [confirm]
+  );
+
+  const items = context ? buildCellActions(context, dispatch, { busy: running }) : [];
+
+  return {
+    openFor,
+    menu: {
+      open: menu.open,
+      position: menu.position,
+      items,
+      close: menu.closeMenu,
+      label: "Cell actions"
+    },
+    confirm,
+    resolveConfirm,
+    running
+  };
+}
+
+/**
+ * The hover/focus-revealed "⋯" affordance that pairs with the invisible right-click gesture. Lives
+ * inside a `group` row; stays out of the way until the row is hovered or the trigger is focused.
+ */
+export function CellActionTrigger({
+  onOpen,
+  label,
+  className
+}: {
+  onOpen: (event: ReactMouseEvent<HTMLElement> | ReactKeyboardEvent<HTMLElement>) => void;
+  label: string;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-haspopup="menu"
+      onClick={onOpen}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          onOpen(event);
+        }
+      }}
+      className={cn(
+        "inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-[2px] text-muted-foreground transition-opacity",
+        "opacity-0 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+        "group-hover:opacity-100 group-focus-within:opacity-100 hover:text-foreground",
+        className
+      )}
+    >
+      <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
+    </button>
+  );
+}
+
+/** Confirmation gate for destructive contextual actions (e.g. excluding a symbol). */
+export function CellActionConfirmDialog({
+  confirm,
+  running,
+  onResolve
+}: {
+  confirm: CellActionConfirmState | null;
+  running: boolean;
+  onResolve: (accept: boolean) => void;
+}) {
+  return (
+    <Dialog open={confirm !== null} onOpenChange={(open) => (open ? undefined : onResolve(false))}>
+      {confirm ? (
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>{confirm.title}</DialogTitle>
+            <DialogDescription>{confirm.description}</DialogDescription>
+          </DialogHeader>
+          <div className="mt-4 flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => onResolve(false)} disabled={running}>
+              Cancel
+            </Button>
+            <Button type="button" variant="destructive" onClick={() => onResolve(true)} disabled={running}>
+              {running ? "Working…" : confirm.confirmLabel}
+            </Button>
+          </div>
+        </DialogContent>
+      ) : null}
+    </Dialog>
+  );
+}
+
+/** Re-export for consumers rendering the menu inline. */
+export { ContextMenu };

--- a/src/Meridian.Ui/dashboard/src/screens/data-screen.cell-actions.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/data-screen.cell-actions.tsx
@@ -270,11 +270,15 @@ export function useCellActions(options: UseCellActionsOptions): UseCellActionsRe
 
   const resolveConfirm = useCallback(
     (accept: boolean) => {
-      const pending = confirm;
-      setConfirm(null);
-      if (accept && pending) {
-        void pending.run();
+      if (!confirm) {
+        return;
       }
+      if (!accept) {
+        setConfirm(null);
+        return;
+      }
+      // Keep the dialog mounted (showing its in-flight state) until the action settles.
+      void confirm.run().finally(() => setConfirm(null));
     },
     [confirm]
   );
@@ -315,11 +319,6 @@ export function CellActionTrigger({
       aria-label={label}
       aria-haspopup="menu"
       onClick={onOpen}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          onOpen(event);
-        }
-      }}
       className={cn(
         "inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-[2px] text-muted-foreground transition-opacity",
         "opacity-0 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
@@ -343,7 +342,15 @@ export function CellActionConfirmDialog({
   onResolve: (accept: boolean) => void;
 }) {
   return (
-    <Dialog open={confirm !== null} onOpenChange={(open) => (open ? undefined : onResolve(false))}>
+    <Dialog
+      open={confirm !== null}
+      onOpenChange={(open) => {
+        // Ignore backdrop/Escape dismissal while the action is still running.
+        if (!open && !running) {
+          onResolve(false);
+        }
+      }}
+    >
       {confirm ? (
         <DialogContent className="max-w-md">
           <DialogHeader>

--- a/src/Meridian.Ui/dashboard/src/screens/data-screen.data-regions.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/data-screen.data-regions.tsx
@@ -1,0 +1,280 @@
+import { RefreshCcw } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { StatusBanner } from "@/components/ui/status-banner";
+import { useToast, type ToastApi } from "@/components/ui/toast";
+import { cn } from "@/lib/utils";
+import {
+  CellActionConfirmDialog,
+  CellActionTrigger,
+  ContextMenu,
+  useCellActions
+} from "@/screens/data-screen.cell-actions";
+import type { CoverageGapsViewModel } from "@/screens/data-screen.coverage-gaps.view-model";
+import type { DataQualityPanelViewModel } from "@/screens/data-screen.data-quality.view-model";
+import { qualityToneBadgeVariant, resultToneClass } from "@/screens/data-screen.tone-styles";
+
+/** Reveal the provider capability matrix region in response to a contextual "compare" action. */
+function revealCapabilityMatrix(toast: ToastApi, symbol?: string) {
+  const target = typeof document !== "undefined" ? document.getElementById("capability-matrix-title") : null;
+  if (!target) {
+    toast.warning("Provider capability matrix is not on this view.");
+    return;
+  }
+  target.scrollIntoView({ behavior: "smooth", block: "start" });
+  toast.info(
+    "Provider capability matrix",
+    symbol ? `Comparing provider coverage relevant to ${symbol}.` : undefined
+  );
+}
+
+export function CoverageGapsRegion({ panel }: { panel: CoverageGapsViewModel }) {
+  const toast = useToast();
+  const cellActions = useCellActions({
+    toast,
+    onMasterSymbol: (symbol) => void panel.requestDraft(symbol),
+    onOpenCapabilityMatrix: (symbol) => revealCapabilityMatrix(toast, symbol),
+    onAfterMutation: () => void panel.refresh()
+  });
+  return (
+    <section aria-labelledby="coverage-gaps-title" className="workspace-region coverage-gaps-region">
+      <Card>
+        <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle id="coverage-gaps-title">Security master coverage</CardTitle>
+            <CardDescription>
+              Active symbols without a validated security-master record (rule RC001).
+              {panel.model ? ` ${panel.model.summary} Last quality run: ${panel.model.runAtLabel}.` : null}
+            </CardDescription>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void panel.refresh()}
+            disabled={panel.loading}
+            aria-label="Refresh security master coverage"
+          >
+            <RefreshCcw className="h-4 w-4" aria-hidden="true" />
+            <span className="ml-1.5">{panel.loading ? "Refreshing…" : "Refresh"}</span>
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {panel.error ? (
+            <StatusBanner tone="danger" title="Coverage report unavailable" detail={panel.error} />
+          ) : !panel.model ? (
+            <p className="text-sm text-muted-foreground" role="status">Loading coverage report…</p>
+          ) : panel.model.rows.length === 0 ? (
+            <p className="text-sm text-muted-foreground" role="status">{panel.model.summary}</p>
+          ) : (
+            <ul className="grid gap-2" aria-label="Unmastered active symbols">
+              {panel.model.rows.map((row) => {
+                const draft = panel.drafts[row.symbol];
+                const context = {
+                  kind: "coverage-gap" as const,
+                  symbol: row.symbol,
+                  sourcesLabel: row.sourcesLabel
+                };
+                return (
+                  <li
+                    key={row.symbol}
+                    className="group grid gap-1.5 rounded-[2px] text-sm transition-colors hover:bg-muted/40"
+                    onContextMenu={(event) => cellActions.openFor(event, context)}
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-mono font-semibold">{row.symbol}</span>
+                      <span className="text-muted-foreground">active in {row.sourcesLabel}</span>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => void panel.requestDraft(row.symbol)}
+                        disabled={panel.draftingSymbol !== null}
+                        aria-label={`Build a security-master draft for ${row.symbol}`}
+                      >
+                        {panel.draftingSymbol === row.symbol ? "Drafting…" : "Master this"}
+                      </Button>
+                      <CellActionTrigger
+                        label={`Actions for ${row.symbol}`}
+                        onOpen={(event) => cellActions.openFor(event, context)}
+                        className="ml-auto"
+                      />
+                      {panel.draftErrors[row.symbol] ? (
+                        <span className="text-sm text-destructive" role="alert">{panel.draftErrors[row.symbol]}</span>
+                      ) : null}
+                    </div>
+                    {draft ? (
+                      <div className="rounded-md border p-2 text-sm">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge variant={draft.resolved ? "success" : "warning"}>
+                            {draft.resolved ? "Resolved" : "Manual completion required"}
+                          </Badge>
+                          <span className="font-semibold">{draft.displayName ?? draft.symbol}</span>
+                          <span className="text-muted-foreground">
+                            {draft.assetClass}
+                            {draft.exchange ? ` · ${draft.exchange}` : ""}
+                            {draft.currency ? ` · ${draft.currency}` : ""}
+                            {" · "}{draft.provenance}
+                          </span>
+                        </div>
+                        <ul className="mt-1.5 grid gap-0.5" aria-label={`Draft identifiers for ${row.symbol}`}>
+                          {draft.identifiers.map((identifier) => (
+                            <li key={`${identifier.kind}:${identifier.value}`} className="font-mono text-xs text-muted-foreground">
+                              {identifier.kind}: {identifier.value}
+                              {identifier.isPrimary ? " (primary)" : ""}
+                            </li>
+                          ))}
+                        </ul>
+                        {draft.notes ? (
+                          <p className="mt-1.5 text-xs text-muted-foreground">{draft.notes}</p>
+                        ) : null}
+                      </div>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+      <ContextMenu
+        open={cellActions.menu.open}
+        position={cellActions.menu.position}
+        items={cellActions.menu.items}
+        onClose={cellActions.menu.close}
+        label={cellActions.menu.label}
+      />
+      <CellActionConfirmDialog
+        confirm={cellActions.confirm}
+        running={cellActions.running}
+        onResolve={cellActions.resolveConfirm}
+      />
+    </section>
+  );
+}
+
+export function DataQualityRegion({ panel }: { panel: DataQualityPanelViewModel }) {
+  const toast = useToast();
+  const cellActions = useCellActions({
+    toast,
+    onOpenCapabilityMatrix: (symbol) => revealCapabilityMatrix(toast, symbol),
+    onAfterMutation: () => void panel.refresh()
+  });
+  return (
+    <section aria-labelledby="data-quality-title" className="workspace-region data-quality-region">
+      <Card>
+        <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle id="data-quality-title">Data quality</CardTitle>
+            <CardDescription>
+              Unified completeness, freshness, gap, and anomaly posture across tracked symbols.
+              {panel.model ? ` ${panel.model.summary}` : null}
+            </CardDescription>
+          </div>
+          <div className="flex items-center gap-2">
+            {panel.model && (
+              <Badge variant={qualityToneBadgeVariant[panel.model.overallTone]} dot={panel.model.overallTone === "success"}>
+                {panel.model.overallLabel}
+              </Badge>
+            )}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void panel.refresh()}
+              disabled={panel.loading}
+              aria-label="Refresh data quality dashboard"
+            >
+              <RefreshCcw className="h-4 w-4" aria-hidden="true" />
+              <span className="ml-1.5">{panel.loading ? "Refreshing…" : "Refresh"}</span>
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {panel.error ? (
+            <StatusBanner tone="danger" title="Data quality unavailable" detail={panel.error} />
+          ) : !panel.model ? (
+            <p className="text-sm text-muted-foreground" role="status">Loading data quality…</p>
+          ) : (
+            <div className="grid gap-4">
+              <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4" role="list" aria-label="Data quality scores">
+                {panel.model.scoreCards.map((card) => (
+                  <div
+                    key={card.id}
+                    role="listitem"
+                    className={cn("rounded-md border p-3 text-sm", resultToneClass[card.tone])}
+                  >
+                    <div className="text-xs uppercase tracking-wide">{card.label}</div>
+                    <div className="mt-1 font-mono text-lg font-semibold">{card.value}</div>
+                  </div>
+                ))}
+              </div>
+              {panel.model.attentionSymbols.length > 0 && (
+                <div>
+                  <h3 className="text-sm font-semibold">Symbols needing attention</h3>
+                  <ul className="mt-2 grid gap-1.5">
+                    {panel.model.attentionSymbols.map((row) => (
+                      <li key={row.symbol} className="flex flex-wrap items-center gap-2 text-sm">
+                        <Badge variant={qualityToneBadgeVariant[row.tone]}>{row.health}</Badge>
+                        <span className="font-mono font-semibold">{row.symbol}</span>
+                        <span className="text-muted-foreground">
+                          completeness {row.completenessLabel} · freshness {row.freshnessLabel} ·{" "}
+                          {row.gapCount} gap{row.gapCount === 1 ? "" : "s"} · {row.anomalyCount} anomal
+                          {row.anomalyCount === 1 ? "y" : "ies"}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {panel.model.unacknowledgedAnomalies.length > 0 && (
+                <div>
+                  <h3 className="text-sm font-semibold">Unacknowledged anomalies</h3>
+                  <ul className="mt-2 grid gap-1.5">
+                    {panel.model.unacknowledgedAnomalies.map((anomaly) => {
+                      const context = {
+                        kind: "anomaly" as const,
+                        symbol: anomaly.symbol,
+                        anomalyId: anomaly.anomalyId,
+                        anomalyType: anomaly.anomalyType
+                      };
+                      return (
+                        <li
+                          key={anomaly.anomalyId}
+                          className="group flex items-center gap-2 rounded-[2px] text-sm text-muted-foreground transition-colors hover:bg-muted/40"
+                          onContextMenu={(event) => cellActions.openFor(event, context)}
+                        >
+                          <span className="min-w-0 flex-1 truncate">
+                            <span className="font-mono font-semibold text-foreground">{anomaly.symbol}</span>{" "}
+                            {anomaly.anomalyType}: {anomaly.message}
+                          </span>
+                          <CellActionTrigger
+                            label={`Actions for the ${anomaly.symbol} anomaly`}
+                            onOpen={(event) => cellActions.openFor(event, context)}
+                          />
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+      <ContextMenu
+        open={cellActions.menu.open}
+        position={cellActions.menu.position}
+        items={cellActions.menu.items}
+        onClose={cellActions.menu.close}
+        label={cellActions.menu.label}
+      />
+      <CellActionConfirmDialog
+        confirm={cellActions.confirm}
+        running={cellActions.running}
+        onResolve={cellActions.resolveConfirm}
+      />
+    </section>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/screens/data-screen.tone-styles.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/data-screen.tone-styles.ts
@@ -1,0 +1,15 @@
+import type { BackfillResultCardState } from "@/screens/data-screen.view-model";
+
+/** Tonal border/background/text classes shared by the backfill result card and quality scorecards. */
+export const resultToneClass: Record<BackfillResultCardState["tone"], string> = {
+  warning: "border-warning/35 bg-warning/10 text-warning",
+  success: "border-success/35 bg-success/10 text-success",
+  danger: "border-danger/35 bg-danger/10 text-danger"
+};
+
+/** Maps a data-quality tone onto the corresponding Badge variant. */
+export const qualityToneBadgeVariant = {
+  success: "success",
+  warning: "warning",
+  danger: "danger"
+} as const;

--- a/src/Meridian.Ui/dashboard/src/screens/data-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/data-screen.tsx
@@ -57,6 +57,13 @@ import {
   type CoverageGapsViewModel
 } from "@/screens/data-screen.coverage-gaps.view-model";
 import {
+  CellActionConfirmDialog,
+  CellActionTrigger,
+  ContextMenu,
+  useCellActions
+} from "@/screens/data-screen.cell-actions";
+import { useToast, type ToastApi } from "@/components/ui/toast";
+import {
   DATA_BACKFILL_DETAIL_PANEL_ID,
   DATA_EXPORT_DETAIL_PANEL_ID,
   DATA_PROVIDER_DETAIL_PANEL_ID,
@@ -2426,7 +2433,28 @@ function CorporateActionInboxRegion({ panel }: { panel: CorporateActionInboxView
   );
 }
 
+/** Reveal the provider capability matrix region in response to a contextual "compare" action. */
+function revealCapabilityMatrix(toast: ToastApi, symbol?: string) {
+  const target = typeof document !== "undefined" ? document.getElementById("capability-matrix-title") : null;
+  if (!target) {
+    toast.warning("Provider capability matrix is not on this view.");
+    return;
+  }
+  target.scrollIntoView({ behavior: "smooth", block: "start" });
+  toast.info(
+    "Provider capability matrix",
+    symbol ? `Comparing provider coverage relevant to ${symbol}.` : undefined
+  );
+}
+
 function CoverageGapsRegion({ panel }: { panel: CoverageGapsViewModel }) {
+  const toast = useToast();
+  const cellActions = useCellActions({
+    toast,
+    onMasterSymbol: (symbol) => void panel.requestDraft(symbol),
+    onOpenCapabilityMatrix: (symbol) => revealCapabilityMatrix(toast, symbol),
+    onAfterMutation: () => void panel.refresh()
+  });
   return (
     <section aria-labelledby="coverage-gaps-title" className="workspace-region coverage-gaps-region">
       <Card>
@@ -2461,8 +2489,17 @@ function CoverageGapsRegion({ panel }: { panel: CoverageGapsViewModel }) {
             <ul className="grid gap-2" aria-label="Unmastered active symbols">
               {panel.model.rows.map((row) => {
                 const draft = panel.drafts[row.symbol];
+                const context = {
+                  kind: "coverage-gap" as const,
+                  symbol: row.symbol,
+                  sourcesLabel: row.sourcesLabel
+                };
                 return (
-                  <li key={row.symbol} className="grid gap-1.5 text-sm">
+                  <li
+                    key={row.symbol}
+                    className="group grid gap-1.5 rounded-[2px] text-sm transition-colors hover:bg-muted/40"
+                    onContextMenu={(event) => cellActions.openFor(event, context)}
+                  >
                     <div className="flex flex-wrap items-center gap-2">
                       <span className="font-mono font-semibold">{row.symbol}</span>
                       <span className="text-muted-foreground">active in {row.sourcesLabel}</span>
@@ -2476,6 +2513,11 @@ function CoverageGapsRegion({ panel }: { panel: CoverageGapsViewModel }) {
                       >
                         {panel.draftingSymbol === row.symbol ? "Drafting…" : "Master this"}
                       </Button>
+                      <CellActionTrigger
+                        label={`Actions for ${row.symbol}`}
+                        onOpen={(event) => cellActions.openFor(event, context)}
+                        className="ml-auto"
+                      />
                       {panel.draftErrors[row.symbol] ? (
                         <span className="text-sm text-destructive" role="alert">{panel.draftErrors[row.symbol]}</span>
                       ) : null}
@@ -2514,11 +2556,29 @@ function CoverageGapsRegion({ panel }: { panel: CoverageGapsViewModel }) {
           )}
         </CardContent>
       </Card>
+      <ContextMenu
+        open={cellActions.menu.open}
+        position={cellActions.menu.position}
+        items={cellActions.menu.items}
+        onClose={cellActions.menu.close}
+        label={cellActions.menu.label}
+      />
+      <CellActionConfirmDialog
+        confirm={cellActions.confirm}
+        running={cellActions.running}
+        onResolve={cellActions.resolveConfirm}
+      />
     </section>
   );
 }
 
 function DataQualityRegion({ panel }: { panel: DataQualityPanelViewModel }) {
+  const toast = useToast();
+  const cellActions = useCellActions({
+    toast,
+    onOpenCapabilityMatrix: (symbol) => revealCapabilityMatrix(toast, symbol),
+    onAfterMutation: () => void panel.refresh()
+  });
   return (
     <section aria-labelledby="data-quality-title" className="workspace-region data-quality-region">
       <Card>
@@ -2590,12 +2650,30 @@ function DataQualityRegion({ panel }: { panel: DataQualityPanelViewModel }) {
                 <div>
                   <h3 className="text-sm font-semibold">Unacknowledged anomalies</h3>
                   <ul className="mt-2 grid gap-1.5">
-                    {panel.model.unacknowledgedAnomalies.map((anomaly) => (
-                      <li key={anomaly.anomalyId} className="text-sm text-muted-foreground">
-                        <span className="font-mono font-semibold text-foreground">{anomaly.symbol}</span>{" "}
-                        {anomaly.anomalyType}: {anomaly.message}
-                      </li>
-                    ))}
+                    {panel.model.unacknowledgedAnomalies.map((anomaly) => {
+                      const context = {
+                        kind: "anomaly" as const,
+                        symbol: anomaly.symbol,
+                        anomalyId: anomaly.anomalyId,
+                        anomalyType: anomaly.anomalyType
+                      };
+                      return (
+                        <li
+                          key={anomaly.anomalyId}
+                          className="group flex items-center gap-2 rounded-[2px] text-sm text-muted-foreground transition-colors hover:bg-muted/40"
+                          onContextMenu={(event) => cellActions.openFor(event, context)}
+                        >
+                          <span className="min-w-0 flex-1 truncate">
+                            <span className="font-mono font-semibold text-foreground">{anomaly.symbol}</span>{" "}
+                            {anomaly.anomalyType}: {anomaly.message}
+                          </span>
+                          <CellActionTrigger
+                            label={`Actions for the ${anomaly.symbol} anomaly`}
+                            onOpen={(event) => cellActions.openFor(event, context)}
+                          />
+                        </li>
+                      );
+                    })}
                   </ul>
                 </div>
               )}
@@ -2603,6 +2681,18 @@ function DataQualityRegion({ panel }: { panel: DataQualityPanelViewModel }) {
           )}
         </CardContent>
       </Card>
+      <ContextMenu
+        open={cellActions.menu.open}
+        position={cellActions.menu.position}
+        items={cellActions.menu.items}
+        onClose={cellActions.menu.close}
+        label={cellActions.menu.label}
+      />
+      <CellActionConfirmDialog
+        confirm={cellActions.confirm}
+        running={cellActions.running}
+        onResolve={cellActions.resolveConfirm}
+      />
     </section>
   );
 }

--- a/src/Meridian.Ui/dashboard/src/screens/data-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/data-screen.tsx
@@ -39,10 +39,7 @@ import { TabPanel, Tabs } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { workspaceForPath } from "@/lib/workspace";
 import { useDataQueryPanel } from "@/screens/data-screen.query-panel.view-model";
-import {
-  useDataQualityPanel,
-  type DataQualityPanelViewModel
-} from "@/screens/data-screen.data-quality.view-model";
+import { useDataQualityPanel } from "@/screens/data-screen.data-quality.view-model";
 import {
   CAPABILITY_LEGEND,
   useCapabilityMatrixPanel,
@@ -52,17 +49,9 @@ import {
   useCorporateActionInboxPanel,
   type CorporateActionInboxViewModel
 } from "@/screens/data-screen.corporate-action-inbox.view-model";
-import {
-  useCoverageGapsPanel,
-  type CoverageGapsViewModel
-} from "@/screens/data-screen.coverage-gaps.view-model";
-import {
-  CellActionConfirmDialog,
-  CellActionTrigger,
-  ContextMenu,
-  useCellActions
-} from "@/screens/data-screen.cell-actions";
-import { useToast, type ToastApi } from "@/components/ui/toast";
+import { useCoverageGapsPanel } from "@/screens/data-screen.coverage-gaps.view-model";
+import { CoverageGapsRegion, DataQualityRegion } from "@/screens/data-screen.data-regions";
+import { resultToneClass } from "@/screens/data-screen.tone-styles";
 import {
   DATA_BACKFILL_DETAIL_PANEL_ID,
   DATA_EXPORT_DETAIL_PANEL_ID,
@@ -2229,12 +2218,6 @@ function FieldTile({ field }: { field: { id: string; label: string; value: strin
   );
 }
 
-const resultToneClass: Record<BackfillResultCardState["tone"], string> = {
-  warning: "border-warning/35 bg-warning/10 text-warning",
-  success: "border-success/35 bg-success/10 text-success",
-  danger: "border-danger/35 bg-danger/10 text-danger"
-};
-
 function BackfillResultCard({ state }: { state: BackfillResultCardState }) {
   return (
     <div
@@ -2255,12 +2238,6 @@ function BackfillResultCard({ state }: { state: BackfillResultCardState }) {
     </div>
   );
 }
-
-const qualityToneBadgeVariant = {
-  success: "success",
-  warning: "warning",
-  danger: "danger"
-} as const;
 
 function CapabilityMatrixRegion({ panel }: { panel: CapabilityMatrixViewModel }) {
   return (
@@ -2429,270 +2406,6 @@ function CorporateActionInboxRegion({ panel }: { panel: CorporateActionInboxView
           )}
         </CardContent>
       </Card>
-    </section>
-  );
-}
-
-/** Reveal the provider capability matrix region in response to a contextual "compare" action. */
-function revealCapabilityMatrix(toast: ToastApi, symbol?: string) {
-  const target = typeof document !== "undefined" ? document.getElementById("capability-matrix-title") : null;
-  if (!target) {
-    toast.warning("Provider capability matrix is not on this view.");
-    return;
-  }
-  target.scrollIntoView({ behavior: "smooth", block: "start" });
-  toast.info(
-    "Provider capability matrix",
-    symbol ? `Comparing provider coverage relevant to ${symbol}.` : undefined
-  );
-}
-
-function CoverageGapsRegion({ panel }: { panel: CoverageGapsViewModel }) {
-  const toast = useToast();
-  const cellActions = useCellActions({
-    toast,
-    onMasterSymbol: (symbol) => void panel.requestDraft(symbol),
-    onOpenCapabilityMatrix: (symbol) => revealCapabilityMatrix(toast, symbol),
-    onAfterMutation: () => void panel.refresh()
-  });
-  return (
-    <section aria-labelledby="coverage-gaps-title" className="workspace-region coverage-gaps-region">
-      <Card>
-        <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-3">
-          <div>
-            <CardTitle id="coverage-gaps-title">Security master coverage</CardTitle>
-            <CardDescription>
-              Active symbols without a validated security-master record (rule RC001).
-              {panel.model ? ` ${panel.model.summary} Last quality run: ${panel.model.runAtLabel}.` : null}
-            </CardDescription>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => void panel.refresh()}
-            disabled={panel.loading}
-            aria-label="Refresh security master coverage"
-          >
-            <RefreshCcw className="h-4 w-4" aria-hidden="true" />
-            <span className="ml-1.5">{panel.loading ? "Refreshing…" : "Refresh"}</span>
-          </Button>
-        </CardHeader>
-        <CardContent>
-          {panel.error ? (
-            <StatusBanner tone="danger" title="Coverage report unavailable" detail={panel.error} />
-          ) : !panel.model ? (
-            <p className="text-sm text-muted-foreground" role="status">Loading coverage report…</p>
-          ) : panel.model.rows.length === 0 ? (
-            <p className="text-sm text-muted-foreground" role="status">{panel.model.summary}</p>
-          ) : (
-            <ul className="grid gap-2" aria-label="Unmastered active symbols">
-              {panel.model.rows.map((row) => {
-                const draft = panel.drafts[row.symbol];
-                const context = {
-                  kind: "coverage-gap" as const,
-                  symbol: row.symbol,
-                  sourcesLabel: row.sourcesLabel
-                };
-                return (
-                  <li
-                    key={row.symbol}
-                    className="group grid gap-1.5 rounded-[2px] text-sm transition-colors hover:bg-muted/40"
-                    onContextMenu={(event) => cellActions.openFor(event, context)}
-                  >
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="font-mono font-semibold">{row.symbol}</span>
-                      <span className="text-muted-foreground">active in {row.sourcesLabel}</span>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={() => void panel.requestDraft(row.symbol)}
-                        disabled={panel.draftingSymbol !== null}
-                        aria-label={`Build a security-master draft for ${row.symbol}`}
-                      >
-                        {panel.draftingSymbol === row.symbol ? "Drafting…" : "Master this"}
-                      </Button>
-                      <CellActionTrigger
-                        label={`Actions for ${row.symbol}`}
-                        onOpen={(event) => cellActions.openFor(event, context)}
-                        className="ml-auto"
-                      />
-                      {panel.draftErrors[row.symbol] ? (
-                        <span className="text-sm text-destructive" role="alert">{panel.draftErrors[row.symbol]}</span>
-                      ) : null}
-                    </div>
-                    {draft ? (
-                      <div className="rounded-md border p-2 text-sm">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <Badge variant={draft.resolved ? "success" : "warning"}>
-                            {draft.resolved ? "Resolved" : "Manual completion required"}
-                          </Badge>
-                          <span className="font-semibold">{draft.displayName ?? draft.symbol}</span>
-                          <span className="text-muted-foreground">
-                            {draft.assetClass}
-                            {draft.exchange ? ` · ${draft.exchange}` : ""}
-                            {draft.currency ? ` · ${draft.currency}` : ""}
-                            {" · "}{draft.provenance}
-                          </span>
-                        </div>
-                        <ul className="mt-1.5 grid gap-0.5" aria-label={`Draft identifiers for ${row.symbol}`}>
-                          {draft.identifiers.map((identifier) => (
-                            <li key={`${identifier.kind}:${identifier.value}`} className="font-mono text-xs text-muted-foreground">
-                              {identifier.kind}: {identifier.value}
-                              {identifier.isPrimary ? " (primary)" : ""}
-                            </li>
-                          ))}
-                        </ul>
-                        {draft.notes ? (
-                          <p className="mt-1.5 text-xs text-muted-foreground">{draft.notes}</p>
-                        ) : null}
-                      </div>
-                    ) : null}
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </CardContent>
-      </Card>
-      <ContextMenu
-        open={cellActions.menu.open}
-        position={cellActions.menu.position}
-        items={cellActions.menu.items}
-        onClose={cellActions.menu.close}
-        label={cellActions.menu.label}
-      />
-      <CellActionConfirmDialog
-        confirm={cellActions.confirm}
-        running={cellActions.running}
-        onResolve={cellActions.resolveConfirm}
-      />
-    </section>
-  );
-}
-
-function DataQualityRegion({ panel }: { panel: DataQualityPanelViewModel }) {
-  const toast = useToast();
-  const cellActions = useCellActions({
-    toast,
-    onOpenCapabilityMatrix: (symbol) => revealCapabilityMatrix(toast, symbol),
-    onAfterMutation: () => void panel.refresh()
-  });
-  return (
-    <section aria-labelledby="data-quality-title" className="workspace-region data-quality-region">
-      <Card>
-        <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-3">
-          <div>
-            <CardTitle id="data-quality-title">Data quality</CardTitle>
-            <CardDescription>
-              Unified completeness, freshness, gap, and anomaly posture across tracked symbols.
-              {panel.model ? ` ${panel.model.summary}` : null}
-            </CardDescription>
-          </div>
-          <div className="flex items-center gap-2">
-            {panel.model && (
-              <Badge variant={qualityToneBadgeVariant[panel.model.overallTone]} dot={panel.model.overallTone === "success"}>
-                {panel.model.overallLabel}
-              </Badge>
-            )}
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => void panel.refresh()}
-              disabled={panel.loading}
-              aria-label="Refresh data quality dashboard"
-            >
-              <RefreshCcw className="h-4 w-4" aria-hidden="true" />
-              <span className="ml-1.5">{panel.loading ? "Refreshing…" : "Refresh"}</span>
-            </Button>
-          </div>
-        </CardHeader>
-        <CardContent>
-          {panel.error ? (
-            <StatusBanner tone="danger" title="Data quality unavailable" detail={panel.error} />
-          ) : !panel.model ? (
-            <p className="text-sm text-muted-foreground" role="status">Loading data quality…</p>
-          ) : (
-            <div className="grid gap-4">
-              <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4" role="list" aria-label="Data quality scores">
-                {panel.model.scoreCards.map((card) => (
-                  <div
-                    key={card.id}
-                    role="listitem"
-                    className={cn("rounded-md border p-3 text-sm", resultToneClass[card.tone])}
-                  >
-                    <div className="text-xs uppercase tracking-wide">{card.label}</div>
-                    <div className="mt-1 font-mono text-lg font-semibold">{card.value}</div>
-                  </div>
-                ))}
-              </div>
-              {panel.model.attentionSymbols.length > 0 && (
-                <div>
-                  <h3 className="text-sm font-semibold">Symbols needing attention</h3>
-                  <ul className="mt-2 grid gap-1.5">
-                    {panel.model.attentionSymbols.map((row) => (
-                      <li key={row.symbol} className="flex flex-wrap items-center gap-2 text-sm">
-                        <Badge variant={qualityToneBadgeVariant[row.tone]}>{row.health}</Badge>
-                        <span className="font-mono font-semibold">{row.symbol}</span>
-                        <span className="text-muted-foreground">
-                          completeness {row.completenessLabel} · freshness {row.freshnessLabel} ·{" "}
-                          {row.gapCount} gap{row.gapCount === 1 ? "" : "s"} · {row.anomalyCount} anomal
-                          {row.anomalyCount === 1 ? "y" : "ies"}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              {panel.model.unacknowledgedAnomalies.length > 0 && (
-                <div>
-                  <h3 className="text-sm font-semibold">Unacknowledged anomalies</h3>
-                  <ul className="mt-2 grid gap-1.5">
-                    {panel.model.unacknowledgedAnomalies.map((anomaly) => {
-                      const context = {
-                        kind: "anomaly" as const,
-                        symbol: anomaly.symbol,
-                        anomalyId: anomaly.anomalyId,
-                        anomalyType: anomaly.anomalyType
-                      };
-                      return (
-                        <li
-                          key={anomaly.anomalyId}
-                          className="group flex items-center gap-2 rounded-[2px] text-sm text-muted-foreground transition-colors hover:bg-muted/40"
-                          onContextMenu={(event) => cellActions.openFor(event, context)}
-                        >
-                          <span className="min-w-0 flex-1 truncate">
-                            <span className="font-mono font-semibold text-foreground">{anomaly.symbol}</span>{" "}
-                            {anomaly.anomalyType}: {anomaly.message}
-                          </span>
-                          <CellActionTrigger
-                            label={`Actions for the ${anomaly.symbol} anomaly`}
-                            onOpen={(event) => cellActions.openFor(event, context)}
-                          />
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </div>
-              )}
-            </div>
-          )}
-        </CardContent>
-      </Card>
-      <ContextMenu
-        open={cellActions.menu.open}
-        position={cellActions.menu.position}
-        items={cellActions.menu.items}
-        onClose={cellActions.menu.close}
-        label={cellActions.menu.label}
-      />
-      <CellActionConfirmDialog
-        confirm={cellActions.confirm}
-        running={cellActions.running}
-        onResolve={cellActions.resolveConfirm}
-      />
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Brings operations to the data itself on the Data screen: right-clicking (or using the new hover/focus-revealed "⋯" affordance) a red coverage-gap row or an anomaly now surfaces the operations that live on that datum, instead of navigating three clicks away to a separate jobs screen.

- **New shared hook** `useCellActions(context)` in `screens/data-screen.cell-actions.tsx` feeds `components/ui/context-menu.tsx`, with all mutating actions routed through the existing workstation endpoint layer (`triggerBackfill`, `archiveSymbol`, `acknowledgeAnomaly`).
- **Coverage-gap cells** (from `data-screen.coverage-gaps.view-model.ts`): *Backfill this range*, *Master this symbol* (reuses the existing draft flow), *Open provider capability matrix*, and a confirm-gated destructive *Exclude symbol*.
- **Anomaly cells** (from `data-screen.data-quality.view-model.ts`): *Flag as acknowledged*, *Backfill symbol*, *Compare across providers*, *Open provider capability matrix*.
- **Discoverability:** the invisible right-click gesture is paired with a per-row `⋯` trigger that appears on hover/focus and anchors the menu on keyboard activation (new `openAt()` on `useContextMenu`).
- **Safety:** destructive actions are held behind a confirmation dialog; in-flight actions disable mutating menu items and report outcomes on toast. Navigation actions (capability matrix) remain live while busy.

## Reason

Implements the "Contextual actions on the data itself" idea: when showing data, show what the user can do with it right there. The action lives on the gap/anomaly, not in a separate screen.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated — `data-screen.cell-actions.test.tsx` (9 tests: pure builder projection for both contexts, dispatcher routing, busy-state disabling, backfill/acknowledge endpoint wiring, confirm-gated exclude, cancel path, capability-matrix delegation). `npx vitest run` green; adjacent coverage-gaps / data-quality / primitives suites still pass.
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Also verified locally: `tsc --noEmit` clean and `eslint src` clean for the touched files.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01722GFBJ8j8571va43GLnrr)_