### PR TITLE
Add skeleton loaders and honest streaming states to the workstation

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/ui/async-region.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/async-region.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AsyncRegion } from "@/components/ui/async-region";
+
+const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+afterEach(() => {
+  consoleError.mockClear();
+});
+
+const skeleton = <div data-testid="skeleton">shimmer</div>;
+
+describe("AsyncRegion", () => {
+  it("shows the skeleton on first load and announces it", () => {
+    render(
+      <AsyncRegion loading hasData={false} label="reconciliation table" skeleton={skeleton}>
+        <div>resolved</div>
+      </AsyncRegion>
+    );
+
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument();
+    expect(screen.queryByText("resolved")).toBeNull();
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-busy", "true");
+    expect(status).toHaveTextContent("Loading reconciliation table…");
+  });
+
+  it("keeps data on screen during a background refresh instead of blanking it", () => {
+    render(
+      <AsyncRegion loading hasData label="table" skeleton={skeleton}>
+        <div>resolved</div>
+      </AsyncRegion>
+    );
+
+    expect(screen.queryByTestId("skeleton")).toBeNull();
+    expect(screen.getByText("resolved")).toBeInTheDocument();
+  });
+
+  it("renders resolved content once settled", () => {
+    render(
+      <AsyncRegion loading={false} hasData skeleton={skeleton}>
+        <div>resolved</div>
+      </AsyncRegion>
+    );
+
+    expect(screen.getByText("resolved")).toBeInTheDocument();
+  });
+
+  it("shows the error state with retry when first load fails", async () => {
+    const onRetry = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AsyncRegion
+        loading={false}
+        error="Close package could not be loaded."
+        hasData={false}
+        onRetry={onRetry}
+        skeleton={skeleton}
+      >
+        <div>resolved</div>
+      </AsyncRegion>
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Close package could not be loaded.");
+    expect(screen.queryByText("resolved")).toBeNull();
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps stale data visible when a refresh errors but data already exists", () => {
+    render(
+      <AsyncRegion loading={false} error="refresh failed" hasData skeleton={skeleton}>
+        <div>resolved</div>
+      </AsyncRegion>
+    );
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByText("resolved")).toBeInTheDocument();
+  });
+
+  it("reads a request-lifecycle phase directly", () => {
+    render(
+      <AsyncRegion phase="running" hasData={false} label="feed" skeleton={skeleton}>
+        <div>resolved</div>
+      </AsyncRegion>
+    );
+
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument();
+  });
+
+  it("renders the empty node when settled with no data", () => {
+    render(
+      <AsyncRegion loading={false} hasData={false} empty={<div>nothing here</div>} skeleton={skeleton}>
+        <div>resolved</div>
+      </AsyncRegion>
+    );
+
+    expect(screen.getByText("nothing here")).toBeInTheDocument();
+    expect(screen.queryByText("resolved")).toBeNull();
+  });
+
+  it("contains a render-time throw from resolved children to this region", () => {
+    function Boom(): JSX.Element {
+      throw new Error("child exploded");
+    }
+
+    render(
+      <AsyncRegion loading={false} hasData label="detail panel" skeleton={skeleton}>
+        <Boom />
+      </AsyncRegion>
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Detail panel hit an unexpected error.");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/async-region.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/async-region.tsx
@@ -1,0 +1,127 @@
+import type { ReactNode } from "react";
+import { RegionErrorBoundary, RegionErrorState } from "@/components/ui/error-boundary";
+import type { RequestLifecyclePhase } from "@/hooks/use-request-lifecycle";
+import { cn } from "@/lib/utils";
+
+/**
+ * Wraps a data region so it resolves honestly and independently: a shaped
+ * skeleton on first load, the resolved content once a view-model settles, and a
+ * contained error state (plus a per-region {@link RegionErrorBoundary}) when it
+ * fails — so one bad panel degrades gracefully instead of blanking the screen.
+ *
+ * Reads the flags screens already expose. Pass either a `useRequestLifecycle`
+ * `phase` or the plain `loading` boolean many view-models surface, plus an
+ * `error` string. `hasData` is what keeps streaming honest: skeletons only stand
+ * in on *first* load (no data yet). A background refresh over existing data keeps
+ * the data on screen — the freshness chip, not a blanked pane, tells the operator
+ * a refresh is in flight.
+ *
+ * @example
+ * <AsyncRegion
+ *   loading={view.loading}
+ *   error={view.errorText}
+ *   hasData={view.rows.length > 0}
+ *   label="reconciliation table"
+ *   onRetry={() => void view.refresh()}
+ *   skeleton={<SkeletonGrid rows={6} columns={5} />}
+ * >
+ *   <ReconciliationTable rows={view.rows} />
+ * </AsyncRegion>
+ */
+export interface AsyncRegionProps {
+  /** Shaped placeholder shown during first load. Use a `Skeleton*` preset. */
+  skeleton: ReactNode;
+  /** Resolved content, rendered once data is available. */
+  children: ReactNode;
+  /** Lifecycle phase from `useRequestLifecycle`, when the region is driven by it. */
+  phase?: RequestLifecyclePhase;
+  /** Plain loading flag for view-models that expose `loading` directly. */
+  loading?: boolean;
+  /** Error text/flag. Replaces content only while there is no data to fall back to. */
+  error?: string | null;
+  /**
+   * Whether resolved data already exists. Gates first-load skeletons and
+   * error-state takeover: while true, background refreshes and transient errors
+   * never blank the region.
+   */
+  hasData?: boolean;
+  /** Optional node for the resolved-but-empty case (settled, no data, no error). */
+  empty?: ReactNode;
+  /** Retry handler surfaced in the error state and forwarded to the boundary. */
+  onRetry?: () => void;
+  /** Accessible region label, e.g. "close package detail". Announced while busy. */
+  label?: string;
+  className?: string;
+}
+
+function isLoadingState(phase: RequestLifecyclePhase | undefined, loading: boolean | undefined): boolean {
+  return loading === true || phase === "running";
+}
+
+function isErrorState(phase: RequestLifecyclePhase | undefined, error: string | null | undefined): boolean {
+  return Boolean(error) || phase === "failed";
+}
+
+export function AsyncRegion({
+  skeleton,
+  children,
+  phase,
+  loading,
+  error,
+  hasData = false,
+  empty,
+  onRetry,
+  label = "content",
+  className
+}: AsyncRegionProps) {
+  const busy = isLoadingState(phase, loading);
+  const failed = isErrorState(phase, error);
+
+  // First load: no data yet and a request is running — stand in with the shape.
+  if (busy && !hasData) {
+    return (
+      <div className={className} role="status" aria-busy="true" aria-live="polite">
+        <span className="sr-only">Loading {label}…</span>
+        {skeleton}
+      </div>
+    );
+  }
+
+  // Failed with nothing to show. With data present we keep it on screen and let
+  // the surface's own freshness/status affordances report the stale attempt.
+  if (failed && !hasData) {
+    return (
+      <div className={className}>
+        <RegionErrorState
+          message={typeof error === "string" && error ? error : `${capitalize(label)} could not be loaded.`}
+          onRetry={onRetry}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <RegionErrorBoundary
+      regionLabel={label}
+      resetKeys={[hasData, busy]}
+      fallback={({ error: caught, reset }) => (
+        <div className={className}>
+          <RegionErrorState
+            message={`${capitalize(label)} hit an unexpected error.`}
+            detail={caught.message || undefined}
+            onRetry={onRetry ? () => { reset(); onRetry(); } : reset}
+            retryLabel={onRetry ? "Retry" : "Reload section"}
+          />
+        </div>
+      )}
+    >
+      <div className={cn(className)} aria-busy={busy || undefined}>
+        {!hasData && empty ? empty : children}
+      </div>
+    </RegionErrorBoundary>
+  );
+}
+
+function capitalize(value: string): string {
+  return value.length > 0 ? value.charAt(0).toUpperCase() + value.slice(1) : value;
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/error-boundary.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/error-boundary.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RegionErrorBoundary, RegionErrorState } from "@/components/ui/error-boundary";
+
+const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+afterEach(() => {
+  consoleError.mockClear();
+});
+
+function Boom({ shouldThrow }: { shouldThrow: boolean }): JSX.Element {
+  if (shouldThrow) {
+    throw new Error("panel exploded");
+  }
+
+  return <div>panel content</div>;
+}
+
+describe("RegionErrorState", () => {
+  it("renders as an alert with an optional retry", async () => {
+    const onRetry = vi.fn();
+    const user = userEvent.setup();
+    render(<RegionErrorState message="Table could not be loaded." onRetry={onRetry} />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Table could not be loaded.");
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the retry button when no handler is given", () => {
+    render(<RegionErrorState message="No retry here." />);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});
+
+describe("RegionErrorBoundary", () => {
+  it("contains a render-time throw to its own region", () => {
+    render(
+      <RegionErrorBoundary regionLabel="reconciliation table">
+        <Boom shouldThrow />
+      </RegionErrorBoundary>
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("reconciliation table hit an unexpected error.");
+    expect(screen.queryByText("panel content")).toBeNull();
+  });
+
+  it("supports a custom fallback with reset", async () => {
+    const user = userEvent.setup();
+
+    function Harness(): JSX.Element {
+      const [broken, setBroken] = useState(true);
+      return (
+        <RegionErrorBoundary
+          resetKeys={[broken]}
+          fallback={({ reset }) => (
+            <button
+              type="button"
+              onClick={() => {
+                setBroken(false);
+                reset();
+              }}
+            >
+              recover
+            </button>
+          )}
+        >
+          <Boom shouldThrow={broken} />
+        </RegionErrorBoundary>
+      );
+    }
+
+    render(<Harness />);
+    await user.click(screen.getByRole("button", { name: "recover" }));
+    expect(screen.getByText("panel content")).toBeInTheDocument();
+  });
+
+  it("reports errors to the onError hook", () => {
+    const onError = vi.fn();
+    render(
+      <RegionErrorBoundary onError={onError}>
+        <Boom shouldThrow />
+      </RegionErrorBoundary>
+    );
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/error-boundary.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/error-boundary.tsx
@@ -1,0 +1,133 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { RefreshCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/**
+ * Inline error surface for a single region. Deliberately compact — one failed
+ * panel should degrade to a legible, recoverable message without blanking the
+ * screen around it. Pair with {@link RegionErrorBoundary} (render-time throws)
+ * or drive it directly from a view-model error flag.
+ */
+export interface RegionErrorStateProps {
+  message: string;
+  detail?: string | null;
+  onRetry?: () => void;
+  retryLabel?: string;
+  className?: string;
+}
+
+export function RegionErrorState({
+  message,
+  detail,
+  onRetry,
+  retryLabel = "Retry",
+  className
+}: RegionErrorStateProps) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex flex-col gap-2 rounded-[2px] border border-danger/30 bg-danger/10 px-3.5 py-3 text-sm text-danger",
+        className
+      )}
+    >
+      <div className="font-semibold">{message}</div>
+      {detail ? <div className="font-mono text-xs leading-5 text-danger/80">{detail}</div> : null}
+      {onRetry ? (
+        <div>
+          <Button type="button" size="sm" variant="outline" onClick={onRetry}>
+            <RefreshCcw className="h-3.5 w-3.5" aria-hidden="true" />
+            {retryLabel}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export interface RegionErrorBoundaryProps {
+  children: ReactNode;
+  /**
+   * Custom fallback. Receives the caught error and a `reset` callback that clears
+   * the boundary so the region can re-mount its children. Defaults to
+   * {@link RegionErrorState}.
+   */
+  fallback?: (context: { error: Error; reset: () => void }) => ReactNode;
+  /** Label woven into the default message, e.g. "reconciliation table". */
+  regionLabel?: string;
+  /** Reported to telemetry/logging hooks; the boundary never swallows silently. */
+  onError?: (error: Error, info: ErrorInfo) => void;
+  /**
+   * Changing any value here after an error clears the boundary. Feed it a retry
+   * counter or the request version so a successful refresh re-mounts the region.
+   */
+  resetKeys?: readonly unknown[];
+}
+
+interface RegionErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Catches render-time errors thrown by a region's children and contains them to
+ * that region. Without this, a single throwing panel takes down the whole screen
+ * — the opposite of the honest, independently-resolving layout we want.
+ */
+export class RegionErrorBoundary extends Component<RegionErrorBoundaryProps, RegionErrorBoundaryState> {
+  state: RegionErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): RegionErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    this.props.onError?.(error, info);
+  }
+
+  componentDidUpdate(previous: RegionErrorBoundaryProps): void {
+    if (this.state.error && !areResetKeysEqual(previous.resetKeys, this.props.resetKeys)) {
+      this.reset();
+    }
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (!error) {
+      return this.props.children;
+    }
+
+    if (this.props.fallback) {
+      return this.props.fallback({ error, reset: this.reset });
+    }
+
+    const label = this.props.regionLabel ?? "This section";
+    return (
+      <RegionErrorState
+        message={`${label} hit an unexpected error.`}
+        detail={error.message || undefined}
+        onRetry={this.reset}
+        retryLabel="Reload section"
+      />
+    );
+  }
+}
+
+function areResetKeysEqual(
+  previous: readonly unknown[] | undefined,
+  next: readonly unknown[] | undefined
+): boolean {
+  if (previous === next) {
+    return true;
+  }
+
+  if (!previous || !next || previous.length !== next.length) {
+    return false;
+  }
+
+  return previous.every((value, index) => Object.is(value, next[index]));
+}

--- a/src/Meridian.Ui/dashboard/src/components/ui/skeleton.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/skeleton.test.tsx
@@ -1,0 +1,69 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  Skeleton,
+  SkeletonCardRow,
+  SkeletonForm,
+  SkeletonGrid,
+  SkeletonText,
+  SkeletonTimeline
+} from "@/components/ui/skeleton";
+
+describe("Skeleton", () => {
+  it("renders a decorative, animated block", () => {
+    const { container } = render(<Skeleton className="h-4 w-10" />);
+    const block = container.firstElementChild as HTMLElement;
+
+    expect(block).toHaveAttribute("aria-hidden", "true");
+    expect(block.className).toContain("animate-pulse");
+    expect(block.className).toContain("motion-reduce:animate-none");
+    expect(block.className).toContain("h-4");
+  });
+
+  it("stays out of the accessibility tree so regions own the loading announcement", () => {
+    const { container } = render(<SkeletonCardRow />);
+    expect(container.querySelector("[aria-hidden='true']")).not.toBeNull();
+  });
+});
+
+describe("Skeleton presets", () => {
+  it("renders the requested number of text lines", () => {
+    const { container } = render(<SkeletonText lines={4} />);
+    expect(container.querySelectorAll("[aria-hidden='true'] > div")).toHaveLength(4);
+  });
+
+  it("renders one card per requested metric", () => {
+    const { container } = render(<SkeletonCardRow cards={3} />);
+    // Each card is a bordered wrapper containing skeleton blocks.
+    expect(container.querySelectorAll(".border.bg-card")).toHaveLength(3);
+  });
+
+  it("renders header plus body rows for a grid", () => {
+    const { container } = render(<SkeletonGrid rows={5} columns={3} showHeader />);
+    const grids = container.querySelectorAll("[style*='grid-template-columns']");
+    // One header row + five body rows.
+    expect(grids).toHaveLength(6);
+  });
+
+  it("omits the header when asked", () => {
+    const { container } = render(<SkeletonGrid rows={2} columns={2} showHeader={false} />);
+    expect(container.querySelectorAll("[style*='grid-template-columns']")).toHaveLength(2);
+  });
+
+  it("renders a timeline item per event", () => {
+    const { container } = render(<SkeletonTimeline items={4} />);
+    expect(container.querySelectorAll("li")).toHaveLength(4);
+  });
+
+  it("renders a field per form row plus an action", () => {
+    const { container } = render(<SkeletonForm fields={3} />);
+    const root = container.firstElementChild as HTMLElement;
+    // Three field groups + one action block.
+    expect(root.children).toHaveLength(4);
+  });
+
+  it("guards against zero or negative counts", () => {
+    const { container } = render(<SkeletonText lines={0} />);
+    expect(container.querySelectorAll("[aria-hidden='true'] > div")).toHaveLength(1);
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/skeleton.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/skeleton.tsx
@@ -1,0 +1,177 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Placeholder block that occupies the same footprint as content that has not
+ * loaded yet. On a data-dense operator screen this is what preserves spatial
+ * memory across navigations — the reconciliation table, the metric row, and the
+ * evidence timeline keep their positions instead of collapsing behind a spinner.
+ *
+ * The pulse is the whole point, so it animates; `motion-reduce:animate-none`
+ * holds it static for operators who opt out of motion (the global
+ * `prefers-reduced-motion` rule in `styles/index.css` also neutralizes it).
+ *
+ * Skeletons are decorative — they carry `aria-hidden` so assistive tech is not
+ * flooded with empty nodes. The accessible "loading" announcement belongs to the
+ * wrapping region (see {@link AsyncRegion}), not to each block.
+ */
+export type SkeletonProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "animate-pulse rounded-[2px] bg-muted/70 motion-reduce:animate-none",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * Stacked text lines. The last line is short by default so the block reads as a
+ * paragraph rather than a solid rectangle.
+ */
+export interface SkeletonTextProps {
+  lines?: number;
+  className?: string;
+  lastLineWidth?: string;
+}
+
+export function SkeletonText({ lines = 3, className, lastLineWidth = "w-2/3" }: SkeletonTextProps) {
+  return (
+    <div className={cn("space-y-2", className)} aria-hidden="true">
+      {Array.from({ length: Math.max(1, lines) }).map((_, index) => (
+        <Skeleton
+          key={index}
+          className={cn("h-3.5", index === lines - 1 ? lastLineWidth : "w-full")}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * A row of metric/summary cards — the shape at the top of most cockpit screens.
+ * Mirrors the `grid gap-2 md:grid-cols-2 xl:grid-cols-4` layout the real metric
+ * rows use so nothing jumps when values resolve.
+ */
+export interface SkeletonCardRowProps {
+  cards?: number;
+  className?: string;
+}
+
+export function SkeletonCardRow({ cards = 4, className }: SkeletonCardRowProps) {
+  return (
+    <div className={cn("grid gap-2 md:grid-cols-2 xl:grid-cols-4", className)} aria-hidden="true">
+      {Array.from({ length: Math.max(1, cards) }).map((_, index) => (
+        <div
+          key={index}
+          className="space-y-3 rounded-[2px] border border-border bg-card p-4"
+        >
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="h-6 w-16" />
+          <Skeleton className="h-3 w-20" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * A tabular grid — header strip plus body rows. Use for reconciliation tables,
+ * journal-entry grids, package histories, and any dense row/column surface.
+ */
+export interface SkeletonGridProps {
+  rows?: number;
+  columns?: number;
+  className?: string;
+  showHeader?: boolean;
+}
+
+export function SkeletonGrid({ rows = 5, columns = 4, className, showHeader = true }: SkeletonGridProps) {
+  const columnCount = Math.max(1, columns);
+  const template = { gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))` } as const;
+
+  return (
+    <div
+      className={cn("overflow-hidden rounded-[2px] border border-border", className)}
+      aria-hidden="true"
+    >
+      {showHeader ? (
+        <div className="grid gap-3 border-b border-border/70 bg-secondary/20 px-3 py-2.5" style={template}>
+          {Array.from({ length: columnCount }).map((_, index) => (
+            <Skeleton key={index} className="h-3 w-16" />
+          ))}
+        </div>
+      ) : null}
+      <div className="divide-y divide-border/60">
+        {Array.from({ length: Math.max(1, rows) }).map((_, rowIndex) => (
+          <div key={rowIndex} className="grid gap-3 px-3 py-3" style={template}>
+            {Array.from({ length: columnCount }).map((_, columnIndex) => (
+              <Skeleton
+                key={columnIndex}
+                className={cn("h-3.5", columnIndex === 0 ? "w-3/4" : "w-1/2")}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A vertical timeline — dot + connector rail + event content. Use for evidence
+ * timelines, audit trails, and workflow-history rails.
+ */
+export interface SkeletonTimelineProps {
+  items?: number;
+  className?: string;
+}
+
+export function SkeletonTimeline({ items = 4, className }: SkeletonTimelineProps) {
+  const count = Math.max(1, items);
+
+  return (
+    <ol className={cn("space-y-4", className)} aria-hidden="true">
+      {Array.from({ length: count }).map((_, index) => (
+        <li key={index} className="flex gap-3">
+          <div className="flex flex-col items-center">
+            <Skeleton className="h-2.5 w-2.5 rounded-full" />
+            {index < count - 1 ? <Skeleton className="mt-1 w-px flex-1" /> : null}
+          </div>
+          <div className="min-w-0 flex-1 space-y-2 pb-1">
+            <Skeleton className="h-3.5 w-1/3" />
+            <Skeleton className="h-3 w-2/3" />
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+/**
+ * A stacked form — label + control pairs plus a trailing action. Use for setup,
+ * sign-off, and adjustment drafts while their initial values settle.
+ */
+export interface SkeletonFormProps {
+  fields?: number;
+  className?: string;
+  showAction?: boolean;
+}
+
+export function SkeletonForm({ fields = 4, className, showAction = true }: SkeletonFormProps) {
+  return (
+    <div className={cn("space-y-4", className)} aria-hidden="true">
+      {Array.from({ length: Math.max(1, fields) }).map((_, index) => (
+        <div key={index} className="space-y-1.5">
+          <Skeleton className="h-3 w-28" />
+          <Skeleton className="h-9 w-full rounded-[2px]" />
+        </div>
+      ))}
+      {showAction ? <Skeleton className="h-9 w-32 rounded-[2px]" /> : null}
+    </div>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/screens/accounting-screen.close-cockpit-panels.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/accounting-screen.close-cockpit-panels.tsx
@@ -1,11 +1,13 @@
 import { AlertCircle, BookCheck, CheckCircle2, Landmark, LockKeyhole, Network, Paperclip, RefreshCcw, ShieldCheck, Table2, UserCheck, WalletCards, X } from "lucide-react";
 import { Link } from "react-router-dom";
+import { AsyncRegion } from "@/components/ui/async-region";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { FreshnessChip } from "@/components/ui/freshness-chip";
 import { Input } from "@/components/ui/input";
+import { SkeletonCardRow, SkeletonGrid, SkeletonTimeline } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { accountingToolingBadgeVariant, accountingToolingBorderClass } from "@/screens/accounting-screen.styles";
 import { AccountingChip } from "@/screens/accounting-screen.workbench-context";
@@ -241,6 +243,35 @@ export function CloseCommandCenterPanel({
   );
 }
 
+/**
+ * First-load placeholder for the close cockpit body. The grey shape matches the
+ * real layout — metric row, journal/package grid, then the evidence timeline —
+ * so the pane keeps its spatial hierarchy while each region's view-model settles
+ * instead of erasing it behind a spinner.
+ */
+function CloseCockpitSkeleton() {
+  return (
+    <div className="space-y-4">
+      <SkeletonCardRow cards={4} />
+      <SkeletonGrid rows={6} columns={4} />
+      <SkeletonTimeline items={4} />
+    </div>
+  );
+}
+
+/**
+ * True once any part of the close plan has resolved. Keeps a background refresh
+ * from blanking a pane that already has data to show.
+ */
+function closeCockpitHasData(view: AccountingCloseReportPackageViewModel): boolean {
+  return (
+    view.tasks.length > 0 ||
+    view.closeCalendar.length > 0 ||
+    view.packageRows.length > 0 ||
+    view.selectedPackage !== null
+  );
+}
+
 export function AccountingCloseReportPackagePanel({ view }: { view: AccountingCloseReportPackageViewModel }) {
   const runCloseWorkflowAction = (actionId: AccountingCloseWorkflowActionId | null) => {
     if (!actionId) {
@@ -391,6 +422,14 @@ export function AccountingCloseReportPackagePanel({ view }: { view: AccountingCl
           </div>
         </CardHeader>
         <CardContent className="space-y-4">
+          <AsyncRegion
+            loading={view.loading}
+            hasData={closeCockpitHasData(view)}
+            label="close package detail"
+            className="space-y-4"
+            onRetry={() => void view.refresh()}
+            skeleton={<CloseCockpitSkeleton />}
+          >
           {view.loadingText ? <p role="status" className="text-sm text-muted-foreground">{view.loadingText}</p> : null}
           {view.errorText ? (
             <div role="status" className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-sm text-warning">
@@ -1295,6 +1334,7 @@ export function AccountingCloseReportPackagePanel({ view }: { view: AccountingCl
               )}
             </div>
           </div>
+          </AsyncRegion>
         </CardContent>
       </Card>
     </section>


### PR DESCRIPTION
## Summary

Adds skeleton loading to the browser workstation so data-dense operator screens keep their spatial hierarchy while view-models settle, instead of erasing the layout behind a spinner.

New shared primitives in `src/components/ui/`:

- **`skeleton.tsx`** — a `Skeleton` base block (decorative/`aria-hidden`, pulses, honors reduced motion) plus reusable layout presets that cover most screens: `SkeletonText`, `SkeletonCardRow` (metric rows), `SkeletonGrid` (tables/journal grids), `SkeletonTimeline` (evidence/audit rails), and `SkeletonForm` (setup/sign-off drafts).
- **`error-boundary.tsx`** — `RegionErrorBoundary` (contains a render-time throw to one region with a `reset`/`resetKeys` recovery path) and a compact `RegionErrorState` inline error surface.
- **`async-region.tsx`** — `AsyncRegion`, a wrapper that reads the flags view-models already expose (a `useRequestLifecycle` `phase` **or** the plain `loading` boolean) and resolves a region honestly:
  - shaped skeleton on **first** load,
  - resolved content once settled,
  - `hasData` gating so a **background refresh keeps existing data on screen** (the freshness chip, not a blanked pane, signals a refresh is in flight),
  - an optional inline error state, and a wrapping `RegionErrorBoundary` so one failed panel degrades gracefully instead of blanking the screen.

Flagship integration: the Accounting close cockpit report-package panel body (`accounting-screen.close-cockpit-panels.tsx`) now renders a layout-shaped placeholder — metric row, package grid, evidence timeline — on first load, resolving in place. Its existing inline error banner and `FreshnessChip` are preserved, so the panel keeps its honest error/freshness affordances.

Screens follow the `.view-model.ts` pattern and expose these flags centrally, so the same `AsyncRegion` can be reused across the remaining screens without per-screen bespoke loading code.

## Reason

The kit had `spinner.tsx` and `toast.tsx` but no skeleton component. A spinner over a blank pane erases the information hierarchy on every navigation, costing operators their spatial memory of where the reconciliation table, metric cards, and evidence timeline live. This adds skeletons, honest streaming states, and per-region error isolation as reusable primitives.

## Testing performed

- [x] Relevant unit tests were added or updated — new `skeleton.test.tsx`, `error-boundary.test.tsx`, `async-region.test.tsx` (22 cases covering presets, first-load vs. background-refresh, error/empty states, lifecycle-phase input, and render-throw isolation)
- [x] `tsc --noEmit` clean; `eslint` clean on changed files
- [x] Full dashboard vitest suite green: **1975 tests / 202 files passing** (includes the touched `accounting-screen.test.tsx`, 47/47)
- [ ] `bash scripts/ci.sh` completed successfully
- [ ] GitHub Actions `quality-gate` passed

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2WRwrhLErM4JRC3CrgR7v)_