### PR TITLE
feat(ui): add canonical ScreenLayout four-zone skeleton

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/ui/screen-layout.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/screen-layout.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { FOCUS_SIGNAL_LIMIT, ScreenLayout, type FocusSignal } from "@/components/ui/screen-layout";
+
+describe("ScreenLayout", () => {
+  it("renders the header zone with title, scope, and top-right actions", () => {
+    render(
+      <ScreenLayout
+        title="Trial Balance"
+        scope="All entities · Primary GL"
+        actions={<button type="button">Export</button>}
+      >
+        <div>work</div>
+      </ScreenLayout>
+    );
+
+    const heading = screen.getByRole("heading", { level: 1, name: "Trial Balance" });
+    expect(heading).toBeInTheDocument();
+    expect(screen.getByText("All entities · Primary GL")).toBeInTheDocument();
+
+    // Primary actions live in the header's banner, always top-right.
+    const header = screen.getByRole("banner");
+    expect(within(header).getByRole("button", { name: "Export" })).toBeInTheDocument();
+  });
+
+  it("renders focus signals as an opinionated row and caps them at the limit", () => {
+    const signals: FocusSignal[] = Array.from({ length: FOCUS_SIGNAL_LIMIT + 2 }, (_, index) => ({
+      id: `s${index}`,
+      label: `Label ${index}`,
+      value: `Value ${index}`
+    }));
+
+    render(
+      <ScreenLayout title="Screen" focus={signals}>
+        <div>work</div>
+      </ScreenLayout>
+    );
+
+    expect(screen.getByText(`Value ${FOCUS_SIGNAL_LIMIT - 1}`)).toBeInTheDocument();
+    // Signals beyond the limit are dropped rather than becoming a metric wall.
+    expect(screen.queryByText(`Value ${FOCUS_SIGNAL_LIMIT}`)).not.toBeInTheDocument();
+  });
+
+  it("collapses and expands the focus zone", async () => {
+    const user = userEvent.setup();
+    render(
+      <ScreenLayout title="Screen" focus={<div>focus body</div>}>
+        <div>work</div>
+      </ScreenLayout>
+    );
+
+    const toggle = screen.getByRole("button", { name: /hide/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(toggle);
+
+    const collapsedToggle = screen.getByRole("button", { name: /show/i });
+    expect(collapsedToggle).toHaveAttribute("aria-expanded", "false");
+    const region = document.getElementById(collapsedToggle.getAttribute("aria-controls") ?? "");
+    expect(region).not.toBeNull();
+    expect(region).toHaveAttribute("hidden");
+  });
+
+  it("starts collapsed when requested and hides the toggle when not collapsible", () => {
+    const { rerender } = render(
+      <ScreenLayout title="Screen" focus={<div>focus body</div>} focusDefaultCollapsed>
+        <div>work</div>
+      </ScreenLayout>
+    );
+    expect(screen.getByRole("button", { name: /show/i })).toHaveAttribute("aria-expanded", "false");
+
+    rerender(
+      <ScreenLayout title="Screen" focus={<div>focus body</div>} focusCollapsible={false}>
+        <div>work</div>
+      </ScreenLayout>
+    );
+    expect(screen.queryByRole("button", { name: /show|hide/i })).not.toBeInTheDocument();
+  });
+
+  it("omits the focus zone entirely when there are no signals", () => {
+    render(
+      <ScreenLayout title="Screen" focus={[]}>
+        <div>work</div>
+      </ScreenLayout>
+    );
+    expect(screen.queryByRole("region", { name: "Focus" })).not.toBeInTheDocument();
+  });
+
+  it("renders the work zone children", () => {
+    render(
+      <ScreenLayout title="Screen">
+        <table aria-label="ledger" />
+      </ScreenLayout>
+    );
+    expect(screen.getByRole("table", { name: "ledger" })).toBeInTheDocument();
+  });
+
+  it("shows the context rail only when open, and closes on request", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    const { rerender } = render(
+      <ScreenLayout
+        title="Screen"
+        context={<div>evidence</div>}
+        contextOpen={false}
+        contextLabel="Account detail"
+        onContextClose={onClose}
+      >
+        <div>work</div>
+      </ScreenLayout>
+    );
+    expect(screen.queryByRole("complementary", { name: "Account detail" })).not.toBeInTheDocument();
+
+    rerender(
+      <ScreenLayout
+        title="Screen"
+        context={<div>evidence</div>}
+        contextOpen
+        contextLabel="Account detail"
+        onContextClose={onClose}
+      >
+        <div>work</div>
+      </ScreenLayout>
+    );
+
+    const rail = screen.getByRole("complementary", { name: "Account detail" });
+    expect(within(rail).getByText("evidence")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Close Account detail" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the close control when no handler is provided", () => {
+    render(
+      <ScreenLayout title="Screen" context={<div>evidence</div>} contextOpen contextLabel="Detail">
+        <div>work</div>
+      </ScreenLayout>
+    );
+    expect(screen.queryByRole("button", { name: /close detail/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/ui/screen-layout.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/screen-layout.test.tsx
@@ -87,6 +87,20 @@ describe("ScreenLayout", () => {
     expect(screen.queryByRole("region", { name: "Focus" })).not.toBeInTheDocument();
   });
 
+  it.each([
+    ["false", false],
+    ["empty string", ""]
+  ])("does not render empty focus/context chrome when a zone resolves to %s", (_label, value) => {
+    // `focus`/`context` are ReactNode, so `cond && <X/>` can pass `false`.
+    render(
+      <ScreenLayout title="Screen" focus={value} context={value} contextOpen contextLabel="Detail">
+        <div>work</div>
+      </ScreenLayout>
+    );
+    expect(screen.queryByRole("region", { name: "Focus" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("complementary", { name: "Detail" })).not.toBeInTheDocument();
+  });
+
   it("renders the work zone children", () => {
     render(
       <ScreenLayout title="Screen">

--- a/src/Meridian.Ui/dashboard/src/components/ui/screen-layout.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/screen-layout.tsx
@@ -1,0 +1,274 @@
+import { ChevronDown, X } from "lucide-react";
+import {
+  forwardRef,
+  useId,
+  useState,
+  type HTMLAttributes,
+  type ReactNode
+} from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * `ScreenLayout` — the one canonical screen skeleton every operator route inherits.
+ *
+ * The problem it solves: before this, every screen invented its own layout, so an
+ * operator's eyes had to re-learn where things were on every route. `ScreenLayout`
+ * fixes a four-zone skeleton so the same kind of thing is always in the same place:
+ *
+ *  1. **Header zone** — screen title, ambient scope, and the 1–3 primary actions
+ *     (always top-right, always the same place).
+ *  2. **Focus zone** — a compact, opinionated summary of "what needs my attention
+ *     here right now" (≤4 signals, not a metric wall). Collapsible.
+ *  3. **Work zone** — the main table/chart/form, taking the majority of the space.
+ *  4. **Context zone** — a right rail for evidence/detail/provenance that slides in
+ *     on selection. This standardizes the home for companion panes and passports.
+ *
+ * Zones are named slots. The work zone is `children`; the rest are props so the
+ * skeleton stays deterministic and every screen renders each zone in the same
+ * structural position regardless of what a screen chooses to put in it.
+ *
+ * @example
+ * <ScreenLayout
+ *   title="Trial Balance"
+ *   scope="All entities · Primary GL · Current period"
+ *   actions={<Button>Export</Button>}
+ *   focus={[
+ *     { id: "breaks", label: "Open breaks", value: "3", tone: "caution" },
+ *     { id: "basis", label: "Basis", value: "IFRS" }
+ *   ]}
+ *   context={selected ? <RowDetail row={selected} /> : null}
+ *   contextOpen={Boolean(selected)}
+ *   contextLabel="Account detail"
+ *   onContextClose={clearSelection}
+ * >
+ *   <DenseDataTable … />
+ * </ScreenLayout>
+ */
+
+/** Tone maps a focus signal to a semantic accent without a wall of raw metrics. */
+export type FocusSignalTone = "neutral" | "positive" | "caution" | "critical";
+
+export interface FocusSignal {
+  /** Stable key for the signal. */
+  id: string;
+  /** Short label describing what the signal measures. */
+  label: ReactNode;
+  /** The headline value operators scan for. */
+  value: ReactNode;
+  /** Optional one-line qualifier shown under the value. */
+  hint?: ReactNode;
+  /** Semantic accent. Defaults to `"neutral"`. */
+  tone?: FocusSignalTone;
+}
+
+/** How many focus signals the zone will render before the rest are dropped. */
+export const FOCUS_SIGNAL_LIMIT = 4;
+
+const focusToneClasses: Record<FocusSignalTone, string> = {
+  neutral: "text-foreground",
+  positive: "text-success",
+  caution: "text-warning",
+  critical: "text-danger"
+};
+
+export interface ScreenLayoutProps extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
+  // ── Header zone ─────────────────────────────────────────────────────────
+  /** Screen title. Rendered as the labelled heading for the whole layout. */
+  title: ReactNode;
+  /**
+   * Ambient scope for this screen (entity, book, period, environment…). Rendered
+   * just under the title so operators always see what they are looking at.
+   */
+  scope?: ReactNode;
+  /** Optional secondary description under the title. */
+  description?: ReactNode;
+  /**
+   * The 1–3 primary actions for this screen. Always rendered top-right. Keep this
+   * to the screen's primary verbs — secondary controls belong in the work zone.
+   */
+  actions?: ReactNode;
+
+  // ── Focus zone ──────────────────────────────────────────────────────────
+  /**
+   * "What needs my attention here right now." Pass a `FocusSignal[]` for the
+   * opinionated signal row (capped at {@link FOCUS_SIGNAL_LIMIT}), or arbitrary
+   * content. Omit to hide the zone entirely.
+   */
+  focus?: FocusSignal[] | ReactNode;
+  /** Accessible label / eyebrow for the focus zone. Defaults to "Focus". */
+  focusLabel?: string;
+  /** When `false`, the focus zone cannot be collapsed. Defaults to `true`. */
+  focusCollapsible?: boolean;
+  /** Start the focus zone collapsed. Defaults to `false`. */
+  focusDefaultCollapsed?: boolean;
+
+  // ── Work zone ───────────────────────────────────────────────────────────
+  /** The main table / chart / form. Takes the majority of the space. */
+  children: ReactNode;
+
+  // ── Context zone ────────────────────────────────────────────────────────
+  /** Evidence / detail / provenance for the current selection. */
+  context?: ReactNode;
+  /** Whether the context rail is open. When `false`, the work zone fills the width. */
+  contextOpen?: boolean;
+  /** Accessible label for the context rail. Defaults to "Context". */
+  contextLabel?: string;
+  /** Called when the operator dismisses the context rail. Omit to hide the close control. */
+  onContextClose?: () => void;
+}
+
+function isFocusSignalArray(value: unknown): value is FocusSignal[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (item) => item != null && typeof item === "object" && "id" in item && "value" in item
+    )
+  );
+}
+
+function FocusSignalRow({ signals }: { signals: FocusSignal[] }) {
+  const visible = signals.slice(0, FOCUS_SIGNAL_LIMIT);
+  return (
+    <dl className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      {visible.map((signal) => (
+        <div key={signal.id} className="min-w-0">
+          <dt className="truncate text-xs font-medium text-muted-foreground">{signal.label}</dt>
+          <dd className={cn("mt-0.5 truncate text-lg font-semibold leading-tight", focusToneClasses[signal.tone ?? "neutral"])}>
+            {signal.value}
+          </dd>
+          {signal.hint ? <p className="mt-0.5 truncate text-xs text-muted-foreground">{signal.hint}</p> : null}
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+/**
+ * The canonical four-zone screen skeleton. See {@link ScreenLayoutProps} for the
+ * named slots. Migrate screens onto this so every route reads the same way.
+ */
+export const ScreenLayout = forwardRef<HTMLDivElement, ScreenLayoutProps>(function ScreenLayout(
+  {
+    className,
+    title,
+    scope,
+    description,
+    actions,
+    focus,
+    focusLabel = "Focus",
+    focusCollapsible = true,
+    focusDefaultCollapsed = false,
+    children,
+    context,
+    contextOpen = false,
+    contextLabel = "Context",
+    onContextClose,
+    ...props
+  },
+  ref
+) {
+  const reactId = useId();
+  const titleId = `${reactId}-title`;
+  const focusRegionId = `${reactId}-focus`;
+  const [focusCollapsed, setFocusCollapsed] = useState(focusDefaultCollapsed);
+
+  const hasFocus = focus != null && (!Array.isArray(focus) || focus.length > 0);
+  const focusBody = hasFocus
+    ? isFocusSignalArray(focus)
+      ? <FocusSignalRow signals={focus} />
+      : focus
+    : null;
+
+  const showContext = contextOpen && context != null;
+
+  return (
+    <div
+      ref={ref}
+      className={cn("flex min-h-0 flex-col gap-4", className)}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {/* 1. Header zone — title, scope, primary actions (always top-right). */}
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h1 id={titleId} className="truncate text-base font-semibold leading-snug tracking-normal text-foreground">
+            {title}
+          </h1>
+          {scope ? <div className="mt-0.5 text-xs text-muted-foreground">{scope}</div> : null}
+          {description ? <p className="mt-1 max-w-prose text-xs leading-5 text-muted-foreground">{description}</p> : null}
+        </div>
+        {actions ? (
+          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">{actions}</div>
+        ) : null}
+      </header>
+
+      {/* Body — focus + work stack in the main column; context is the right rail. */}
+      <div className="flex min-h-0 flex-1 flex-col gap-4 xl:flex-row">
+        <div className="flex min-w-0 flex-1 flex-col gap-4">
+          {/* 2. Focus zone — ≤4 signals of "what needs my attention". Collapsible. */}
+          {hasFocus ? (
+            <section
+              aria-label={focusLabel}
+              className="rounded-[2px] border border-border bg-card text-card-foreground"
+            >
+              <div className="flex items-center justify-between gap-2 px-4 py-2">
+                <span className="eyebrow-label text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  {focusLabel}
+                </span>
+                {focusCollapsible ? (
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1 rounded-[2px] px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                    aria-expanded={!focusCollapsed}
+                    aria-controls={focusRegionId}
+                    onClick={() => setFocusCollapsed((collapsed) => !collapsed)}
+                  >
+                    <span>{focusCollapsed ? "Show" : "Hide"}</span>
+                    <ChevronDown
+                      className={cn("h-3.5 w-3.5 transition-transform", focusCollapsed && "-rotate-90")}
+                      aria-hidden="true"
+                    />
+                  </button>
+                ) : null}
+              </div>
+              <div id={focusRegionId} hidden={focusCollapsed} className="border-t border-border/70 px-4 py-3">
+                {focusBody}
+              </div>
+            </section>
+          ) : null}
+
+          {/* 3. Work zone — the main table / chart / form. */}
+          <div className="min-h-0 flex-1">{children}</div>
+        </div>
+
+        {/* 4. Context zone — right rail that slides in on selection. */}
+        {showContext ? (
+          <aside
+            role="complementary"
+            aria-label={contextLabel}
+            className="flex w-full shrink-0 flex-col rounded-[2px] border border-border bg-card text-card-foreground xl:w-[360px]"
+          >
+            <div className="flex items-center justify-between gap-2 border-b border-border/70 px-4 py-2">
+              <span className="eyebrow-label text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                {contextLabel}
+              </span>
+              {onContextClose ? (
+                <button
+                  type="button"
+                  className="inline-flex h-6 w-6 items-center justify-center rounded-[2px] text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                  aria-label={`Close ${contextLabel}`}
+                  onClick={onContextClose}
+                >
+                  <X className="h-4 w-4" aria-hidden="true" />
+                </button>
+              ) : null}
+            </div>
+            <div className="min-h-0 flex-1 overflow-auto p-4">{context}</div>
+          </aside>
+        ) : null}
+      </div>
+    </div>
+  );
+});
+
+ScreenLayout.displayName = "ScreenLayout";

--- a/src/Meridian.Ui/dashboard/src/components/ui/screen-layout.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/screen-layout.tsx
@@ -117,6 +117,15 @@ export interface ScreenLayoutProps extends Omit<HTMLAttributes<HTMLDivElement>, 
   onContextClose?: () => void;
 }
 
+/**
+ * True when a node would actually render something. `ReactNode` admits `false`,
+ * `null`, `undefined`, and `""` — all of which render nothing — so zones use this
+ * to avoid drawing their chrome (border, header, toggle) around empty content.
+ */
+function isRenderableNode(node: unknown): boolean {
+  return node != null && node !== false && node !== "";
+}
+
 function isFocusSignalArray(value: unknown): value is FocusSignal[] {
   return (
     Array.isArray(value) &&
@@ -172,14 +181,17 @@ export const ScreenLayout = forwardRef<HTMLDivElement, ScreenLayoutProps>(functi
   const focusRegionId = `${reactId}-focus`;
   const [focusCollapsed, setFocusCollapsed] = useState(focusDefaultCollapsed);
 
-  const hasFocus = focus != null && (!Array.isArray(focus) || focus.length > 0);
+  // `focus`/`context` are `ReactNode`, so a caller writing `focus={cond && <X/>}`
+  // can pass `false` (or `""`). Those are `!= null`, so guard them explicitly or
+  // the zone chrome (border, header, toggle) renders around empty content.
+  const hasFocus = isRenderableNode(focus) && (!Array.isArray(focus) || focus.length > 0);
   const focusBody = hasFocus
     ? isFocusSignalArray(focus)
       ? <FocusSignalRow signals={focus} />
       : focus
     : null;
 
-  const showContext = contextOpen && context != null;
+  const showContext = contextOpen && isRenderableNode(context);
 
   return (
     <div

--- a/src/Meridian.Ui/dashboard/src/screens/trial-balance-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/trial-balance-screen.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { FormRow } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { ScreenLayout, type FocusSignal } from "@/components/ui/screen-layout";
 import { Select } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import { WORKSTATION_ROUTE_CATALOG, workstationRouteWithQuery } from "@/lib/workspace";
@@ -153,30 +154,61 @@ export function TrialBalanceScreen({ data }: TrialBalanceScreenProps) {
     );
   }
 
-  return (
-    <div className="space-y-4">
-      <Card className="panel-surface">
-        <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-3">
-          <div className="min-w-0">
-            <CardTitle>Trial Balance</CardTitle>
-            <CardDescription>Pick a ledger run to review basis-aware account balances.</CardDescription>
-          </div>
-          <FormRow label="Run" labelFor="trial-balance-run-select" className="w-full max-w-xs sm:w-64">
-            <Select
-              id="trial-balance-run-select"
-              value={selectedReconciliation?.runId ?? ""}
-              onChange={(event) => selectRun(event.target.value)}
-            >
-              {reconciliationQueue.map((item) => (
-                <option key={item.runId} value={item.runId}>
-                  {item.strategyName} ({item.runId})
-                </option>
-              ))}
-            </Select>
-          </FormRow>
-        </CardHeader>
-      </Card>
+  const selectedBasisLabel =
+    reconciliation.trialBalanceView.basisOptions.find((option) => option.isSelected)?.label ?? "—";
 
+  // Focus zone — ≤4 signals of "what needs my attention on this run right now".
+  const focusSignals: FocusSignal[] = [
+    {
+      id: "run",
+      label: "Selected run",
+      value: selectedReconciliation?.strategyName ?? "—",
+      hint: selectedReconciliation?.runId
+    },
+    { id: "basis", label: "Accounting basis", value: selectedBasisLabel },
+    { id: "accounts", label: "Accounts in view", value: reconciliation.trialBalanceView.filteredRowCountLabel },
+    {
+      id: "journal",
+      label: "Journal entries",
+      value: journalLoading ? "…" : String(journalEvidence.rows.length)
+    }
+  ];
+
+  const trialBalanceScope = `${entityScope} · ${ledgerBook} · ${period}`;
+
+  return (
+    <ScreenLayout
+      title="Trial Balance"
+      scope={trialBalanceScope}
+      description="Pick a ledger run to review basis-aware account balances."
+      actions={
+        <FormRow label="Run" labelFor="trial-balance-run-select" className="w-full max-w-xs sm:w-64">
+          <Select
+            id="trial-balance-run-select"
+            value={selectedReconciliation?.runId ?? ""}
+            onChange={(event) => selectRun(event.target.value)}
+          >
+            {reconciliationQueue.map((item) => (
+              <option key={item.runId} value={item.runId}>
+                {item.strategyName} ({item.runId})
+              </option>
+            ))}
+          </Select>
+        </FormRow>
+      }
+      focus={focusSignals}
+      context={
+        reconciliation.trialBalanceView.selectedDetail ? (
+          <AccountingTrialBalanceSelectedDetailPanel
+            panelId={reconciliation.trialBalanceView.detailPanelId}
+            detail={reconciliation.trialBalanceView.selectedDetail}
+          />
+        ) : null
+      }
+      contextOpen={Boolean(reconciliation.trialBalanceView.selectedDetail)}
+      contextLabel="Trial-balance detail"
+      onContextClose={() => reconciliation.selectTrialBalanceRow(null)}
+    >
       <Card className="panel-surface">
         <CardHeader>
           <CardTitle>Trial balance scope</CardTitle>
@@ -279,44 +311,25 @@ export function TrialBalanceScreen({ data }: TrialBalanceScreenProps) {
           </div>
           {reconciliation.trialBalanceView.hasRows ? (
             viewMode === "table" ? (
-              <div className="grid gap-3 xl:grid-cols-[minmax(0,1.25fr)_minmax(260px,0.75fr)]">
-                <DenseDataTable
-                  columns={trialBalanceColumns}
-                  rows={reconciliation.trialBalanceView.rows}
-                  getRowId={(line) => line.rowId}
-                  getRowAriaLabel={(line) => line.ariaLabel}
-                  getRowSelectAriaLabel={(line) => line.selectAriaLabel}
-                  getRowAriaControls={(line) => line.detailPanelId}
-                  getRowAriaExpanded={(line) => line.isExpanded}
-                  getRowTypeaheadText={(line) => line.accountLabel}
-                  selectedRowId={reconciliation.trialBalanceView.selectedRowId}
-                  onRowSelect={(line) => reconciliation.selectTrialBalanceRow(line.rowId)}
-                  emptyText={reconciliation.trialBalanceView.emptyDetail}
-                  ariaLabel={reconciliation.trialBalanceView.tableLabel}
-                  virtualization={
-                    reconciliation.trialBalanceView.rows.length > TRIAL_BALANCE_VIRTUALIZATION_THRESHOLD
-                      ? { rowHeight: 36, viewportRowCount: 15 }
-                      : null
-                  }
-                />
-                {reconciliation.trialBalanceView.selectedDetail ? (
-                  <AccountingTrialBalanceSelectedDetailPanel
-                    panelId={reconciliation.trialBalanceView.detailPanelId}
-                    detail={reconciliation.trialBalanceView.selectedDetail}
-                  />
-                ) : (
-                  <aside
-                    id={reconciliation.trialBalanceView.detailPanelId}
-                    role="region"
-                    aria-label={reconciliation.trialBalanceView.detailEmptyAriaLabel}
-                    className="row-detail-panel h-fit min-w-0"
-                  >
-                    <div className="eyebrow-label">Trial-balance detail</div>
-                    <h3 className="mt-1 text-sm font-semibold text-foreground">{reconciliation.trialBalanceView.detailEmptyTitle}</h3>
-                    <p className="mt-2 text-sm leading-6 text-muted-foreground">{reconciliation.trialBalanceView.detailEmptyText}</p>
-                  </aside>
-                )}
-              </div>
+              <DenseDataTable
+                columns={trialBalanceColumns}
+                rows={reconciliation.trialBalanceView.rows}
+                getRowId={(line) => line.rowId}
+                getRowAriaLabel={(line) => line.ariaLabel}
+                getRowSelectAriaLabel={(line) => line.selectAriaLabel}
+                getRowAriaControls={(line) => line.detailPanelId}
+                getRowAriaExpanded={(line) => line.isExpanded}
+                getRowTypeaheadText={(line) => line.accountLabel}
+                selectedRowId={reconciliation.trialBalanceView.selectedRowId}
+                onRowSelect={(line) => reconciliation.selectTrialBalanceRow(line.rowId)}
+                emptyText={reconciliation.trialBalanceView.emptyDetail}
+                ariaLabel={reconciliation.trialBalanceView.tableLabel}
+                virtualization={
+                  reconciliation.trialBalanceView.rows.length > TRIAL_BALANCE_VIRTUALIZATION_THRESHOLD
+                    ? { rowHeight: 36, viewportRowCount: 15 }
+                    : null
+                }
+              />
             ) : (
               <AccountTree
                 nodes={treeNodes}
@@ -409,6 +422,6 @@ export function TrialBalanceScreen({ data }: TrialBalanceScreenProps) {
       <p className="text-xs text-muted-foreground">
         Looking for the full ledger explorer? <Link className="text-primary underline-offset-2 hover:underline" to={WORKSTATION_ROUTE_CATALOG.accountingLedger}>Open Ledger Explorer</Link>.
       </p>
-    </div>
+    </ScreenLayout>
   );
 }


### PR DESCRIPTION
## Summary

Introduces a single canonical `<ScreenLayout>` component in `components/ui` that every operator screen can inherit, and migrates the Trial Balance screen onto it as the first proof of the pattern.

Previously every screen invented its own layout — some opened with "workbench context", some with a task navigator, some with a metric row, some straight into a table — so an operator's eyes had to re-learn where things live on each route. `ScreenLayout` fixes a four-zone skeleton so the same kind of thing is always in the same place:

- **Header zone** — screen title, ambient scope, and the 1–3 primary actions (always top-right).
- **Focus zone** — a compact, opinionated "what needs my attention here right now" summary (≤4 signals via the `FocusSignal` type, not a metric wall). Collapsible.
- **Work zone** — the main table/chart/form (`children`), taking the majority of the space.
- **Context zone** — a right rail for evidence/detail/provenance that slides in on selection, standardizing the home already used ad hoc by companion panes and passports.

Zones are named slots: the work zone is `children`, the rest are props, so the skeleton stays deterministic and every screen renders each zone in the same structural position.

**Trial Balance migration** (mechanical proof of the pattern):
- The run selector becomes a header action; run/basis/account/journal signals move into the Focus zone.
- The selected-row detail moves out of the inline two-column grid into the standardized Context rail — it opens on row selection and closes on dismiss.
- All existing screen content (scope card, ledger table, journal evidence, related securities) is preserved in the Work zone.

Remaining screens can be migrated one at a time; the heaviest screens can follow.

## Reason

Implements idea #1 — "One canonical screen skeleton." Inconsistent per-screen layouts are the single biggest "I can't find the feature" tax for operators. A shared, opinionated skeleton is the platform bet that makes later navigation/consistency improvements cheap and uniform.

## Testing performed

- [x] Relevant unit tests were added or updated — new `screen-layout.test.tsx` (8 cases covering all four zones, collapsible focus, and context open/close/accessibility); existing `trial-balance-screen.test.tsx` continues to pass unchanged
- [ ] Relevant integration tests were added or updated
- [ ] `bash scripts/ci.sh` completed successfully
- [ ] GitHub Actions `quality-gate` passed

Local validation on the browser dashboard: `tsc --noEmit` clean, `eslint` clean on changed files, `vite build` succeeds, and the `components/ui` + design-system-contract + trial-balance suites pass (127 tests green).

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWgsZxXRxHhXaz2WKNSJNz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWgsZxXRxHhXaz2WKNSJNz)_