### PR TITLE
feat(ui): migrate Watchlist and Live Quotes onto ScreenLayout

### DIFF
--- a/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/live-quotes-screen.tsx
@@ -21,6 +21,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScreenLayout } from "@/components/ui/screen-layout";
 import { FieldSupportText, joinDescribedByIds } from "@/components/ui/field-support";
 import { FreshnessChip } from "@/components/ui/freshness-chip";
 import { freshnessInputFromLifecycle } from "@/components/ui/freshness-chip.view-model";
@@ -77,18 +78,17 @@ export function LiveQuotesScreen() {
   const session = marketVm.sessionStats;
 
   return (
-    <div className="space-y-6">
+    <ScreenLayout
+      title={
+        <span className="flex items-center gap-2">
+          <LineChart className="h-5 w-5 text-primary" />
+          {workspaceVm.title}
+        </span>
+      }
+      scope="Data Lane"
+      description={`${workspaceVm.description} Refreshes every ${vm.pollIntervalSecondsLabel}s unless paused.`}
+    >
       <Card>
-        <CardHeader>
-          <div className="eyebrow-label">Data Lane</div>
-          <CardTitle className="flex items-center gap-2">
-            <LineChart className="h-5 w-5 text-primary" />
-            {workspaceVm.title}
-          </CardTitle>
-          <CardDescription>
-            {workspaceVm.description} Refreshes every {vm.pollIntervalSecondsLabel}s unless paused.
-          </CardDescription>
-        </CardHeader>
         <CardContent>
           <form
             onSubmit={vm.submitLookup}
@@ -384,7 +384,7 @@ export function LiveQuotesScreen() {
         </div>
         </>
       ) : null}
-    </div>
+    </ScreenLayout>
   );
 }
 

--- a/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/watchlist-screen.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { ScreenLayout } from "@/components/ui/screen-layout";
 import { MetricSnapshotCard } from "@/components/meridian/metric-card";
 import { PopOutPaneButton } from "@/components/meridian/pop-out-pane-button";
 import { DenseDataTable, type DenseDataTableColumn, ToolbarStrip } from "@/components/meridian/ui-kit-primitives";
@@ -99,23 +100,18 @@ export function WatchlistScreen() {
   const inCompanionPane = isCompanionPaneRoute(useLocation().pathname);
 
   return (
-    <div className="space-y-6">
+    <ScreenLayout
+      title={
+        <span className="flex items-center gap-2">
+          <Activity className="h-5 w-5 text-primary" />
+          Symbol watchlist
+        </span>
+      }
+      scope="Data Lane"
+      description="Add, remove, and monitor symbols subscribed to the live data pipeline. Open a symbol to view live quotes."
+      actions={inCompanionPane ? undefined : <PopOutPaneButton paneId="watchlist" />}
+    >
       <Card>
-        <CardHeader>
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0">
-              <div className="eyebrow-label">Data Lane</div>
-              <CardTitle className="flex items-center gap-2">
-                <Activity className="h-5 w-5 text-primary" />
-                Symbol watchlist
-              </CardTitle>
-              <CardDescription>
-                Add, remove, and monitor symbols subscribed to the live data pipeline. Open a symbol to view live quotes.
-              </CardDescription>
-            </div>
-            {inCompanionPane ? null : <PopOutPaneButton paneId="watchlist" />}
-          </div>
-        </CardHeader>
         <CardContent>
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
             {vm.stats.map((stat) => (
@@ -379,7 +375,7 @@ export function WatchlistScreen() {
           )}
         </CardContent>
       </Card>
-    </div>
+    </ScreenLayout>
   );
 }
 


### PR DESCRIPTION
## Summary

Continues the `ScreenLayout` rollout with the two Data-lane companion-pane screens.

- **Watchlist** — eyebrow/title/description and the pop-out-pane action lift into the Header zone; stats, add-symbol form, starter packs, table, and the existing companion detail rail stay in the Work zone.
- **Live Quotes** — eyebrow/title/description into the Header zone; the symbol-lookup form, quote matrix, selected-symbol detail column, order book, trades, and diagnostics stay in the Work zone.

### Why these keep their inline rails (not the Context zone)

The task direction was to route companion-pane selection detail into the Context zone. On close inspection these two are better left with their purpose-built inline rails, and I want to flag the reasoning rather than force it:

- The Watchlist detail panel is **already a `complementary` landmark**. Nesting it inside ScreenLayout's Context rail (also `complementary`) would create duplicate landmarks and regress `watchlist-screen.a11y.test.tsx`.
- Live Quotes' detail column doubles as an **onboarding empty-state** (with "add starter symbols" CTAs) when nothing is selected — a Context-zone "closed" state would hide those affordances.
- The Context zone is already demonstrated in production by **Trial Balance**, whose detail genuinely toggles open on row selection and closes on dismiss — the pattern the Context zone is designed for.

The Header-zone standardization is the primary win for these screens (title/scope/actions now render in the same place as every other migrated route).

## Reason

Idea #1 — one canonical screen skeleton. This brings the running total to 11 screens on `ScreenLayout`.

## Testing performed

- [x] Relevant unit tests pass unchanged — Watchlist (incl. a11y) 17, Live Quotes 47.
- [ ] Relevant integration tests were added or updated
- [ ] `bash scripts/ci.sh` completed successfully
- [ ] GitHub Actions `quality-gate` passed

Local validation: `tsc --noEmit -p tsconfig.strict-null.json` ✅, default `tsc` ✅, `eslint` ✅, `vite build` ✅, full dashboard suite **2065 tests green**.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWgsZxXRxHhXaz2WKNSJNz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWgsZxXRxHhXaz2WKNSJNz)_