### PR TITLE
chore(ci): refresh file-size baseline for types.ts drift

### DIFF
--- a/build/config/file-size-baseline.json
+++ b/build/config/file-size-baseline.json
@@ -43,7 +43,7 @@
     "src/Meridian.Ui/dashboard/src/screens/strategy-screen.view-model.ts": 3492,
     "src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx": 2605,
     "src/Meridian.Ui/dashboard/src/screens/trading-screen.view-model.ts": 5355,
-    "src/Meridian.Ui/dashboard/src/types.ts": 11184,
+    "src/Meridian.Ui/dashboard/src/types.ts": 11192,
     "src/Meridian.Wpf/ViewModels/Accounting/AccountingCloseViewModel.cs": 2653,
     "src/Meridian.Wpf/ViewModels/Accounting/AccountingConfigureViewModel.cs": 5545,
     "src/Meridian.Wpf/ViewModels/FundLedgerViewModel.cs": 3468,


### PR DESCRIPTION
## Summary

One-line follow-up to #2167. A merge landed on `main` after that baseline refresh and grew `src/Meridian.Ui/dashboard/src/types.ts` from **11184 → 11192** lines, tripping the file-size ratchet again on `main` (and every branch cut from it). This refreshes the single affected cap. Only the baseline data file changes.

## Reason

Unblock CI. `main`'s ratchet baseline keeps drifting behind ongoing merges that grow tracked files without running `--update-baseline`.

**Process note for maintainers:** this is the second baseline drift in a short window (#2167 fixed 7 files; this fixes 1 more that grew minutes later). Chasing it with maintenance PRs is a losing race — consider having contributors run `python3 build/scripts/ci/check-file-size.py --update-baseline` as part of any PR that grows a tracked file, or making the ratchet auto-refresh/advisory, so it stops blocking unrelated PRs.

## Testing performed

- [x] `python3 build/scripts/ci/check-file-size.py` passes locally after the refresh (was failing on `types.ts`).
- [ ] `bash scripts/ci.sh` completed successfully
- [ ] GitHub Actions `quality-gate` passed

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included — only the baseline data file changes

## Governance changes

- [x] No governance files changed (baseline data only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWgsZxXRxHhXaz2WKNSJNz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWgsZxXRxHhXaz2WKNSJNz)_