### PR TITLE
feat(ledger): fixed-asset depreciation engine

### DIFF
--- a/src/Meridian.Ledger/AutomatedJournalEventKind.cs
+++ b/src/Meridian.Ledger/AutomatedJournalEventKind.cs
@@ -37,4 +37,7 @@ public enum AutomatedJournalEventKind
 
     /// <summary>Period-close closing entries rolling net income into retained earnings.</summary>
     PeriodCloseClosingEntries,
+
+    /// <summary>Periodic fixed-asset depreciation charge (debit expense, credit accumulated depreciation).</summary>
+    DepreciationPosted,
 }

--- a/src/Meridian.Ledger/DepreciationInput.cs
+++ b/src/Meridian.Ledger/DepreciationInput.cs
@@ -1,0 +1,17 @@
+namespace Meridian.Ledger;
+
+/// <summary>
+/// Inputs for a single fixed-asset depreciation journal projection. Amounts are expressed in the
+/// ledger book currency for the asset's accounts.
+/// </summary>
+/// <param name="AssetId">Identity used to scope the depreciation expense and accumulated-depreciation accounts.</param>
+/// <param name="CostAccount">The asset's gross-cost account; validated to be an asset account.</param>
+/// <param name="DepreciationAmount">Depreciation charged for the period (must be positive).</param>
+/// <param name="FinancialAccountId">Optional fund/brokerage scope carried into posting metadata.</param>
+/// <param name="Description">Optional description override for the projected journal.</param>
+public sealed record DepreciationInput(
+    Guid AssetId,
+    LedgerAccount CostAccount,
+    decimal DepreciationAmount,
+    string? FinancialAccountId = null,
+    string? Description = null);

--- a/src/Meridian.Ledger/DepreciationMethod.cs
+++ b/src/Meridian.Ledger/DepreciationMethod.cs
@@ -1,0 +1,17 @@
+namespace Meridian.Ledger;
+
+/// <summary>Depreciation method applied to a capitalized fixed asset.</summary>
+public enum DepreciationMethod
+{
+    /// <summary>Equal depreciation charge each period across the useful life.</summary>
+    StraightLine,
+
+    /// <summary>
+    /// Accelerated charge on the declining net book value, auto-switching to straight-line over the
+    /// remaining life once straight-line yields the larger charge. Floored at salvage value.
+    /// </summary>
+    DecliningBalance,
+
+    /// <summary>Charge proportional to units produced or consumed in the period.</summary>
+    UnitsOfProduction,
+}

--- a/src/Meridian.Ledger/DepreciationPeriod.cs
+++ b/src/Meridian.Ledger/DepreciationPeriod.cs
@@ -1,0 +1,14 @@
+namespace Meridian.Ledger;
+
+/// <summary>One period row in a fixed-asset depreciation schedule.</summary>
+/// <param name="PeriodIndex">1-based period ordinal.</param>
+/// <param name="PeriodEnd">Last calendar day covered by the period.</param>
+/// <param name="OpeningNetBookValue">Net book value at the start of the period.</param>
+/// <param name="DepreciationAmount">Depreciation charged in the period.</param>
+/// <param name="ClosingNetBookValue">Net book value at the end of the period.</param>
+public sealed record DepreciationPeriod(
+    int PeriodIndex,
+    DateOnly PeriodEnd,
+    decimal OpeningNetBookValue,
+    decimal DepreciationAmount,
+    decimal ClosingNetBookValue);

--- a/src/Meridian.Ledger/DepreciationProjection.cs
+++ b/src/Meridian.Ledger/DepreciationProjection.cs
@@ -1,0 +1,17 @@
+namespace Meridian.Ledger;
+
+/// <summary>Balanced journal lines produced for a single fixed-asset depreciation event.</summary>
+public sealed record DepreciationProjection(
+    Guid AssetId,
+    string Description,
+    IReadOnlyList<(LedgerAccount account, decimal debit, decimal credit)> Lines)
+{
+    /// <summary>Total debits in the projected journal lines.</summary>
+    public decimal TotalDebits => Lines.Sum(static line => line.debit);
+
+    /// <summary>Total credits in the projected journal lines.</summary>
+    public decimal TotalCredits => Lines.Sum(static line => line.credit);
+
+    /// <summary>True when total projected debits equal projected credits.</summary>
+    public bool IsBalanced => TotalDebits == TotalCredits;
+}

--- a/src/Meridian.Ledger/DepreciationScheduleCalculator.cs
+++ b/src/Meridian.Ledger/DepreciationScheduleCalculator.cs
@@ -1,0 +1,153 @@
+namespace Meridian.Ledger;
+
+/// <summary>
+/// Pure fixed-asset depreciation schedule generator. Every method depreciates gross cost down to
+/// salvage value, rounds each period charge to two decimal places, and absorbs any rounding
+/// remainder in the final period so the closing net book value equals salvage value exactly.
+/// </summary>
+public sealed class DepreciationScheduleCalculator : IDepreciationScheduleCalculator
+{
+    private const int CurrencyScale = 2;
+
+    /// <inheritdoc/>
+    public IReadOnlyList<DepreciationPeriod> BuildSchedule(
+        FixedAssetRecord asset,
+        IReadOnlyList<long>? projectedUnitsPerPeriod = null)
+    {
+        ArgumentNullException.ThrowIfNull(asset);
+
+        if (asset.UsefulLifeMonths <= 0)
+            throw new ArgumentException("Useful life must be a positive number of months.", nameof(asset));
+        if (asset.Cost < 0m)
+            throw new ArgumentException("Asset cost cannot be negative.", nameof(asset));
+        if (asset.SalvageValue < 0m)
+            throw new ArgumentException("Salvage value cannot be negative.", nameof(asset));
+        if (asset.SalvageValue > asset.Cost)
+            throw new ArgumentException("Salvage value cannot exceed asset cost.", nameof(asset));
+
+        return asset.Method switch
+        {
+            DepreciationMethod.StraightLine => BuildStraightLine(asset),
+            DepreciationMethod.DecliningBalance => BuildDecliningBalance(asset),
+            DepreciationMethod.UnitsOfProduction => BuildUnitsOfProduction(asset, projectedUnitsPerPeriod),
+            _ => throw new ArgumentOutOfRangeException(nameof(asset), asset.Method, "Unsupported depreciation method."),
+        };
+    }
+
+    private static IReadOnlyList<DepreciationPeriod> BuildStraightLine(FixedAssetRecord asset)
+    {
+        var months = asset.UsefulLifeMonths;
+        var depreciable = asset.Cost - asset.SalvageValue;
+        var perPeriod = Round(depreciable / months);
+
+        var periods = new List<DepreciationPeriod>(months);
+        var opening = asset.Cost;
+        var accumulated = 0m;
+
+        for (var i = 1; i <= months; i++)
+        {
+            var isLast = i == months;
+            var charge = isLast ? depreciable - accumulated : perPeriod;
+            if (charge < 0m)
+                charge = 0m;
+            if (!isLast && accumulated + charge > depreciable)
+                charge = depreciable - accumulated;
+
+            accumulated += charge;
+            var closing = asset.Cost - accumulated;
+            periods.Add(new DepreciationPeriod(i, PeriodEnd(asset.InServiceDate, i), opening, charge, closing));
+            opening = closing;
+        }
+
+        return periods;
+    }
+
+    private static IReadOnlyList<DepreciationPeriod> BuildDecliningBalance(FixedAssetRecord asset)
+    {
+        if (asset.DecliningBalanceFactor <= 0m)
+            throw new ArgumentException("Declining-balance factor must be positive.", nameof(asset));
+
+        var months = asset.UsefulLifeMonths;
+        var rate = asset.DecliningBalanceFactor / months;
+
+        var periods = new List<DepreciationPeriod>(months);
+        var opening = asset.Cost;
+
+        for (var i = 1; i <= months; i++)
+        {
+            var remainingMonths = months - i + 1;
+            var decliningCharge = Round(opening * rate);
+            // Switch to straight-line over the remaining life once it yields the larger charge.
+            var straightLineCharge = Round((opening - asset.SalvageValue) / remainingMonths);
+            var charge = Math.Max(decliningCharge, straightLineCharge);
+
+            // Never depreciate below salvage; the final period lands exactly on salvage value.
+            if (i == months || opening - charge < asset.SalvageValue)
+                charge = opening - asset.SalvageValue;
+            if (charge < 0m)
+                charge = 0m;
+
+            var closing = opening - charge;
+            periods.Add(new DepreciationPeriod(i, PeriodEnd(asset.InServiceDate, i), opening, charge, closing));
+            opening = closing;
+        }
+
+        return periods;
+    }
+
+    private static IReadOnlyList<DepreciationPeriod> BuildUnitsOfProduction(
+        FixedAssetRecord asset,
+        IReadOnlyList<long>? projectedUnitsPerPeriod)
+    {
+        if (asset.TotalUnits is not { } totalUnits || totalUnits <= 0)
+            throw new ArgumentException("Units-of-production depreciation requires a positive TotalUnits.", nameof(asset));
+        if (projectedUnitsPerPeriod is null || projectedUnitsPerPeriod.Count == 0)
+        {
+            throw new ArgumentException(
+                "Units-of-production depreciation requires projected units for each period.",
+                nameof(projectedUnitsPerPeriod));
+        }
+
+        var depreciable = asset.Cost - asset.SalvageValue;
+        var periods = new List<DepreciationPeriod>(projectedUnitsPerPeriod.Count);
+        var opening = asset.Cost;
+        var accumulated = 0m;
+        long cumulativeUnits = 0;
+
+        for (var i = 0; i < projectedUnitsPerPeriod.Count; i++)
+        {
+            var periodUnits = projectedUnitsPerPeriod[i];
+            if (periodUnits < 0)
+                throw new ArgumentException("Projected units cannot be negative.", nameof(projectedUnitsPerPeriod));
+
+            cumulativeUnits = Math.Min(cumulativeUnits + periodUnits, totalUnits);
+            // Track cumulative depreciation against cumulative usage so per-period rounding never
+            // drifts and total depreciation is capped at the depreciable base.
+            var targetAccumulated = Round(depreciable * cumulativeUnits / totalUnits);
+            if (targetAccumulated > depreciable)
+                targetAccumulated = depreciable;
+
+            var charge = targetAccumulated - accumulated;
+            if (charge < 0m)
+                charge = 0m;
+
+            accumulated = targetAccumulated;
+            var closing = asset.Cost - accumulated;
+            periods.Add(new DepreciationPeriod(i + 1, PeriodEnd(asset.InServiceDate, i + 1), opening, charge, closing));
+            opening = closing;
+        }
+
+        return periods;
+    }
+
+    private static decimal Round(decimal value)
+        => decimal.Round(value, CurrencyScale, MidpointRounding.AwayFromZero);
+
+    /// <summary>Last calendar day of the month <paramref name="periodOrdinal"/> (1-based) into the life.</summary>
+    private static DateOnly PeriodEnd(DateOnly inServiceDate, int periodOrdinal)
+    {
+        var monthStart = inServiceDate.AddMonths(periodOrdinal - 1);
+        var daysInMonth = DateTime.DaysInMonth(monthStart.Year, monthStart.Month);
+        return new DateOnly(monthStart.Year, monthStart.Month, daysInMonth);
+    }
+}

--- a/src/Meridian.Ledger/FixedAssetDepreciationDraftBuilder.cs
+++ b/src/Meridian.Ledger/FixedAssetDepreciationDraftBuilder.cs
@@ -1,0 +1,89 @@
+using System.Globalization;
+
+namespace Meridian.Ledger;
+
+/// <summary>
+/// Batches per-asset depreciation projections for a period into a single governed
+/// <see cref="AutomatedJournalDraft"/> (kind <see cref="AutomatedJournalEventKind.DepreciationPosted"/>)
+/// so an accountant approves the whole period's depreciation run in one action — mirroring how
+/// <see cref="DailyPortfolioPricingDraftBuilder"/> batches daily fair-value marks.
+/// </summary>
+public static class FixedAssetDepreciationDraftBuilder
+{
+    /// <summary>
+    /// Builds one balanced depreciation draft covering every asset in <paramref name="assets"/> whose
+    /// charge is positive. Returns null when no asset has a charge to post.
+    /// </summary>
+    /// <param name="periodEnd">The accounting period the depreciation run belongs to.</param>
+    /// <param name="asOf">Timestamp used for the journal event and retained evidence.</param>
+    /// <param name="assets">Per-asset depreciation inputs for the period.</param>
+    /// <param name="bookLabel">Optional fund/book identifier used for scoping, idempotency, and metadata.</param>
+    /// <param name="description">Optional description override for the batched draft.</param>
+    public static AutomatedJournalDraft? BuildDraft(
+        DateOnly periodEnd,
+        DateTimeOffset asOf,
+        IReadOnlyList<DepreciationInput> assets,
+        string? bookLabel = null,
+        string? description = null)
+    {
+        ArgumentNullException.ThrowIfNull(assets);
+
+        var projected = assets
+            .Where(static asset => asset.DepreciationAmount > 0m)
+            .Select(FixedAssetDepreciationProjector.Project)
+            .ToArray();
+        if (projected.Length == 0)
+            return null;
+
+        var lines = projected
+            .SelectMany(static projection => projection.Lines)
+            .Select(static line => (line.account, line.debit, line.credit, (LedgerLineDimensionSet?)null))
+            .ToArray();
+
+        var totalDepreciation = projected.Sum(static projection => projection.TotalDebits);
+        var scope = string.IsNullOrWhiteSpace(bookLabel) ? "fixed-assets" : bookLabel.Trim();
+        var idempotencyKey = FormattableString.Invariant($"depreciation|{scope}|{periodEnd:yyyy-MM-dd}");
+        var resolvedDescription = string.IsNullOrWhiteSpace(description)
+            ? FormattableString.Invariant($"Fixed-asset depreciation for {scope} through {periodEnd:yyyy-MM-dd}")
+            : description.Trim();
+
+        var evidence = projected
+            .Select(projection => new JournalEvidenceReference(
+                EvidenceId: FormattableString.Invariant($"depreciation:{projection.AssetId:D}:{periodEnd:yyyy-MM-dd}"),
+                Uri: FormattableString.Invariant($"fixed-asset://{projection.AssetId:D}/depreciation/{periodEnd:yyyy-MM-dd}"),
+                Kind: "depreciation",
+                SourceSystem: "meridian.fixed-assets",
+                RetainedAtUtc: asOf,
+                RetainedBy: scope,
+                SubjectId: projection.AssetId.ToString("D"),
+                Description: projection.Description).Normalize())
+            .ToArray();
+
+        var journalEvent = new AutomatedJournalEvent(
+            AutomatedJournalEventKind.DepreciationPosted,
+            scope,
+            totalDepreciation,
+            asOf,
+            Description: resolvedDescription,
+            EffectiveDate: periodEnd,
+            IdempotencyKey: idempotencyKey,
+            EvidenceReferences: evidence);
+
+        var tags = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["depreciation.book"] = scope,
+            ["depreciation.periodEnd"] = periodEnd.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            ["depreciation.assetCount"] = projected.Length.ToString(CultureInfo.InvariantCulture),
+            ["depreciation.totalAmount"] = totalDepreciation.ToString(CultureInfo.InvariantCulture),
+        };
+
+        var metadata = new JournalEntryMetadata(
+            ActivityType: "depreciation",
+            EffectiveDate: periodEnd,
+            IdempotencyKey: idempotencyKey,
+            Tags: tags,
+            EvidenceReferences: evidence);
+
+        return new AutomatedJournalDraft(journalEvent, resolvedDescription, lines, metadata);
+    }
+}

--- a/src/Meridian.Ledger/FixedAssetDepreciationDraftBuilder.cs
+++ b/src/Meridian.Ledger/FixedAssetDepreciationDraftBuilder.cs
@@ -29,7 +29,7 @@ public static class FixedAssetDepreciationDraftBuilder
         ArgumentNullException.ThrowIfNull(assets);
 
         var projected = assets
-            .Where(static asset => asset.DepreciationAmount > 0m)
+            .Where(static asset => asset is not null && asset.DepreciationAmount > 0m)
             .Select(FixedAssetDepreciationProjector.Project)
             .ToArray();
         if (projected.Length == 0)
@@ -42,21 +42,26 @@ public static class FixedAssetDepreciationDraftBuilder
 
         var totalDepreciation = projected.Sum(static projection => projection.TotalDebits);
         var scope = string.IsNullOrWhiteSpace(bookLabel) ? "fixed-assets" : bookLabel.Trim();
-        var idempotencyKey = FormattableString.Invariant($"depreciation|{scope}|{periodEnd:yyyy-MM-dd}");
+        var periodEndText = periodEnd.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        var idempotencyKey = FormattableString.Invariant($"depreciation|{scope}|{periodEndText}");
         var resolvedDescription = string.IsNullOrWhiteSpace(description)
-            ? FormattableString.Invariant($"Fixed-asset depreciation for {scope} through {periodEnd:yyyy-MM-dd}")
+            ? FormattableString.Invariant($"Fixed-asset depreciation for {scope} through {periodEndText}")
             : description.Trim();
 
         var evidence = projected
-            .Select(projection => new JournalEvidenceReference(
-                EvidenceId: FormattableString.Invariant($"depreciation:{projection.AssetId:D}:{periodEnd:yyyy-MM-dd}"),
-                Uri: FormattableString.Invariant($"fixed-asset://{projection.AssetId:D}/depreciation/{periodEnd:yyyy-MM-dd}"),
-                Kind: "depreciation",
-                SourceSystem: "meridian.fixed-assets",
-                RetainedAtUtc: asOf,
-                RetainedBy: scope,
-                SubjectId: projection.AssetId.ToString("D"),
-                Description: projection.Description).Normalize())
+            .Select(projection =>
+            {
+                var assetId = projection.AssetId.ToString("D");
+                return new JournalEvidenceReference(
+                    EvidenceId: FormattableString.Invariant($"depreciation:{assetId}:{periodEndText}"),
+                    Uri: FormattableString.Invariant($"fixed-asset://{assetId}/depreciation/{periodEndText}"),
+                    Kind: "depreciation",
+                    SourceSystem: "meridian.fixed-assets",
+                    RetainedAtUtc: asOf,
+                    RetainedBy: scope,
+                    SubjectId: assetId,
+                    Description: projection.Description).Normalize();
+            })
             .ToArray();
 
         var journalEvent = new AutomatedJournalEvent(
@@ -72,7 +77,7 @@ public static class FixedAssetDepreciationDraftBuilder
         var tags = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             ["depreciation.book"] = scope,
-            ["depreciation.periodEnd"] = periodEnd.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            ["depreciation.periodEnd"] = periodEndText,
             ["depreciation.assetCount"] = projected.Length.ToString(CultureInfo.InvariantCulture),
             ["depreciation.totalAmount"] = totalDepreciation.ToString(CultureInfo.InvariantCulture),
         };

--- a/src/Meridian.Ledger/FixedAssetDepreciationProjector.cs
+++ b/src/Meridian.Ledger/FixedAssetDepreciationProjector.cs
@@ -1,0 +1,48 @@
+namespace Meridian.Ledger;
+
+/// <summary>
+/// Builds balanced fixed-asset depreciation journal lines: a debit to depreciation expense and a
+/// credit to the accumulated-depreciation contra-asset, scoped per asset. This is the depreciation
+/// analogue of <see cref="FixedIncomeAmortizationProjector"/>.
+/// </summary>
+public static class FixedAssetDepreciationProjector
+{
+    /// <summary>Projects balanced journal lines for one fixed-asset depreciation event.</summary>
+    public static DepreciationProjection Project(DepreciationInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(input.CostAccount);
+
+        if (input.AssetId == Guid.Empty)
+            throw new ArgumentException("Depreciation asset id is required.", nameof(input));
+
+        if (input.DepreciationAmount < 0m)
+            throw new ArgumentOutOfRangeException(nameof(input), "Depreciation amount cannot be negative.");
+
+        if (input.DepreciationAmount == 0m)
+            throw new ArgumentException("Depreciation amount must be non-zero.", nameof(input));
+
+        if (input.CostAccount.AccountType != LedgerAccountType.Asset)
+        {
+            throw new ArgumentException(
+                "Fixed-asset cost account must be an asset account for capitalized assets.",
+                nameof(input));
+        }
+
+        var scope = input.AssetId.ToString("D");
+        var depreciationExpense = LedgerAccounts.DepreciationExpenseFor(scope);
+        var accumulatedDepreciation = LedgerAccounts.AccumulatedDepreciationFor(scope);
+
+        var lines = new List<(LedgerAccount account, decimal debit, decimal credit)>
+        {
+            (depreciationExpense, input.DepreciationAmount, 0m),
+            (accumulatedDepreciation, 0m, input.DepreciationAmount),
+        };
+
+        var description = string.IsNullOrWhiteSpace(input.Description)
+            ? $"Depreciation for fixed asset {scope}"
+            : input.Description.Trim();
+
+        return new DepreciationProjection(input.AssetId, description, lines);
+    }
+}

--- a/src/Meridian.Ledger/FixedAssetRecord.cs
+++ b/src/Meridian.Ledger/FixedAssetRecord.cs
@@ -1,0 +1,34 @@
+namespace Meridian.Ledger;
+
+/// <summary>
+/// A capitalized fixed asset whose gross cost is depreciated to salvage value over its useful life.
+/// </summary>
+/// <param name="AssetId">Stable identity used to scope this asset's ledger accounts.</param>
+/// <param name="DisplayName">Human-readable asset name for evidence and descriptions.</param>
+/// <param name="Currency">ISO 4217 currency the cost and salvage amounts are expressed in.</param>
+/// <param name="Cost">Gross capitalized cost of the asset.</param>
+/// <param name="SalvageValue">Estimated residual value at the end of the useful life.</param>
+/// <param name="InServiceDate">Date the asset was placed in service; anchors the schedule.</param>
+/// <param name="UsefulLifeMonths">Depreciable life in whole months.</param>
+/// <param name="Method">Depreciation method to apply.</param>
+/// <param name="DecliningBalanceFactor">
+/// Multiplier applied to the straight-line rate for <see cref="DepreciationMethod.DecliningBalance"/>
+/// (e.g. 2.0 = double-declining). Ignored by other methods.
+/// </param>
+/// <param name="TotalUnits">
+/// Total expected lifetime units for <see cref="DepreciationMethod.UnitsOfProduction"/>. Ignored by
+/// other methods.
+/// </param>
+/// <param name="FinancialAccountId">Optional fund/brokerage scope carried into posting metadata.</param>
+public sealed record FixedAssetRecord(
+    Guid AssetId,
+    string DisplayName,
+    string Currency,
+    decimal Cost,
+    decimal SalvageValue,
+    DateOnly InServiceDate,
+    int UsefulLifeMonths,
+    DepreciationMethod Method,
+    decimal DecliningBalanceFactor = 2.0m,
+    long? TotalUnits = null,
+    string? FinancialAccountId = null);

--- a/src/Meridian.Ledger/IDepreciationScheduleCalculator.cs
+++ b/src/Meridian.Ledger/IDepreciationScheduleCalculator.cs
@@ -1,0 +1,17 @@
+namespace Meridian.Ledger;
+
+/// <summary>Generates a period-by-period depreciation schedule for a fixed asset.</summary>
+public interface IDepreciationScheduleCalculator
+{
+    /// <summary>
+    /// Builds the depreciation schedule for <paramref name="asset"/>.
+    /// <see cref="DepreciationMethod.StraightLine"/> and <see cref="DepreciationMethod.DecliningBalance"/>
+    /// produce a full forward schedule from the asset record alone.
+    /// <see cref="DepreciationMethod.UnitsOfProduction"/> is usage-driven and requires
+    /// <paramref name="projectedUnitsPerPeriod"/> (projected or actual units for each period); it
+    /// cannot be projected forward from the asset record alone.
+    /// </summary>
+    IReadOnlyList<DepreciationPeriod> BuildSchedule(
+        FixedAssetRecord asset,
+        IReadOnlyList<long>? projectedUnitsPerPeriod = null);
+}

--- a/src/Meridian.Ledger/LedgerAccounts.cs
+++ b/src/Meridian.Ledger/LedgerAccounts.cs
@@ -320,6 +320,25 @@ public static class LedgerAccounts
     public static readonly LedgerAccount AllocationControl =
         new("Allocation Control", LedgerAccountType.Asset);
 
+    // -------------------------------------------------------------------------
+    // Fixed-asset / depreciation accounts
+    // -------------------------------------------------------------------------
+
+    /// <summary>Gross capitalized cost of a fixed asset, scoped by asset identity.</summary>
+    public static LedgerAccount FixedAssetCostFor(string assetId) =>
+        CreateScoped("Fixed Asset Cost", LedgerAccountType.Asset, assetId);
+
+    /// <summary>
+    /// Accumulated depreciation for a fixed asset — a contra-asset that carries a credit balance and
+    /// nets against <see cref="FixedAssetCostFor"/> to yield net book value.
+    /// </summary>
+    public static LedgerAccount AccumulatedDepreciationFor(string assetId) =>
+        CreateScoped("Accumulated Depreciation", LedgerAccountType.Asset, assetId);
+
+    /// <summary>Periodic depreciation expense charged on a fixed asset.</summary>
+    public static LedgerAccount DepreciationExpenseFor(string assetId) =>
+        CreateScoped("Depreciation Expense", LedgerAccountType.Expense, assetId);
+
     private static LedgerAccount CreateScoped(string name, LedgerAccountType accountType, string financialAccountId)
         => new(name, accountType, FinancialAccountId: NormalizeAccountId(financialAccountId));
 

--- a/src/Meridian.Ledger/README.md
+++ b/src/Meridian.Ledger/README.md
@@ -47,6 +47,14 @@ fair-value adjustments flow through `AutomatedJournalApproval` before posting; t
 Application-layer `DailyMarkToMarketService` wires provider-chain close prices into this path.
 `FixedIncomeAmortizationProjector` produces balanced coupon accrual, discount accretion, and
 premium amortization lines for bond accounting workflows before persistence or approval posting.
+`FixedAssetDepreciationProjector` is the depreciation analogue: it projects balanced
+depreciation-expense/accumulated-depreciation (contra-asset) lines scoped per fixed asset.
+`DepreciationScheduleCalculator` builds the period-by-period schedule (straight-line,
+declining-balance with an auto-switch to straight-line and salvage floor, and usage-driven
+units-of-production), always depreciating to salvage value with the final period absorbing rounding.
+`FixedAssetDepreciationDraftBuilder` batches all of a period's per-asset projections into a single
+governed `AutomatedJournalDraft` (kind `DepreciationPosted`) so one approval covers the whole
+depreciation run, mirroring `DailyPortfolioPricingDraftBuilder`.
 `LedgerAccountTaxLotPolicyBook` resolves FIFO/LIFO/HIFO/SpecificId relief methods at the ledger
 account level so accounting statements can follow front-office lot-relief policy.
 `LedgerTaxLotReliefProjector` applies those account-level relief methods to open tax lots and

--- a/tests/Meridian.Tests/Ledger/DepreciationScheduleCalculatorTests.cs
+++ b/tests/Meridian.Tests/Ledger/DepreciationScheduleCalculatorTests.cs
@@ -1,0 +1,143 @@
+using FluentAssertions;
+using Meridian.Ledger;
+using Xunit;
+
+namespace Meridian.Tests.Ledger;
+
+/// <summary>
+/// Tests the depreciation schedule math: straight-line, declining-balance (with the auto-switch to
+/// straight-line and salvage floor), and usage-driven units-of-production. Every schedule must
+/// depreciate exactly to salvage value with no rounding drift.
+/// </summary>
+public sealed class DepreciationScheduleCalculatorTests
+{
+    private static readonly Guid AssetId = new("22222222-2222-2222-2222-222222222222");
+    private static readonly DateOnly InService = new(2026, 1, 15);
+
+    private readonly DepreciationScheduleCalculator _calculator = new();
+
+    private static FixedAssetRecord Asset(
+        decimal cost,
+        decimal salvage,
+        int months,
+        DepreciationMethod method,
+        decimal factor = 2.0m,
+        long? totalUnits = null)
+        => new(AssetId, "Test Asset", "USD", cost, salvage, InService, months, method, factor, totalUnits);
+
+    [Fact]
+    public void StraightLine_FullLife_SumsToCostMinusSalvageAndEndsAtSalvage()
+    {
+        var schedule = _calculator.BuildSchedule(Asset(12_000m, 2_000m, 10, DepreciationMethod.StraightLine));
+
+        schedule.Should().HaveCount(10);
+        schedule.Should().OnlyContain(period => period.DepreciationAmount == 1_000m);
+        schedule.Sum(period => period.DepreciationAmount).Should().Be(10_000m);
+        schedule[^1].ClosingNetBookValue.Should().Be(2_000m);
+    }
+
+    [Fact]
+    public void StraightLine_FinalPeriodAbsorbsRounding()
+    {
+        var schedule = _calculator.BuildSchedule(Asset(1_000m, 0m, 3, DepreciationMethod.StraightLine));
+
+        schedule[0].DepreciationAmount.Should().Be(333.33m);
+        schedule[1].DepreciationAmount.Should().Be(333.33m);
+        schedule[2].DepreciationAmount.Should().Be(333.34m);
+        schedule.Sum(period => period.DepreciationAmount).Should().Be(1_000m);
+        schedule[^1].ClosingNetBookValue.Should().Be(0m);
+    }
+
+    [Fact]
+    public void StraightLine_PeriodEndsAreMonthEndsFromInServiceDate()
+    {
+        var schedule = _calculator.BuildSchedule(Asset(300m, 0m, 3, DepreciationMethod.StraightLine));
+
+        schedule[0].PeriodEnd.Should().Be(new DateOnly(2026, 1, 31));
+        schedule[1].PeriodEnd.Should().Be(new DateOnly(2026, 2, 28));
+        schedule[2].PeriodEnd.Should().Be(new DateOnly(2026, 3, 31));
+    }
+
+    [Fact]
+    public void DecliningBalance_SwitchesToStraightLineAndEndsAtSalvage()
+    {
+        var schedule = _calculator.BuildSchedule(Asset(10_000m, 0m, 5, DepreciationMethod.DecliningBalance, factor: 2.0m));
+
+        // 40% declining rate: 4000, 2400, 1440, then straight-line takes over (1080 > 864), 1080.
+        schedule.Select(period => period.DepreciationAmount)
+            .Should().Equal(4_000m, 2_400m, 1_440m, 1_080m, 1_080m);
+        schedule.Sum(period => period.DepreciationAmount).Should().Be(10_000m);
+        schedule[^1].ClosingNetBookValue.Should().Be(0m);
+    }
+
+    [Fact]
+    public void DecliningBalance_NeverDepreciatesBelowSalvage()
+    {
+        var schedule = _calculator.BuildSchedule(Asset(1_000m, 100m, 4, DepreciationMethod.DecliningBalance, factor: 2.0m));
+
+        schedule.Should().OnlyContain(period => period.ClosingNetBookValue >= 100m);
+        schedule.Sum(period => period.DepreciationAmount).Should().Be(900m);
+        schedule[^1].ClosingNetBookValue.Should().Be(100m);
+    }
+
+    [Fact]
+    public void UnitsOfProduction_ProratesByUsageAndEndsAtSalvage()
+    {
+        var asset = Asset(11_000m, 1_000m, 4, DepreciationMethod.UnitsOfProduction, totalUnits: 1_000);
+
+        var schedule = _calculator.BuildSchedule(asset, new long[] { 100, 200, 300, 400 });
+
+        // $10 per unit over a 10,000 depreciable base.
+        schedule.Select(period => period.DepreciationAmount)
+            .Should().Equal(1_000m, 2_000m, 3_000m, 4_000m);
+        schedule[^1].ClosingNetBookValue.Should().Be(1_000m);
+    }
+
+    [Fact]
+    public void UnitsOfProduction_CapsAtTotalUnits()
+    {
+        var asset = Asset(11_000m, 1_000m, 2, DepreciationMethod.UnitsOfProduction, totalUnits: 1_000);
+
+        // Reported usage (1,200) exceeds the lifetime total (1,000); depreciation is capped.
+        var schedule = _calculator.BuildSchedule(asset, new long[] { 600, 600 });
+
+        schedule.Sum(period => period.DepreciationAmount).Should().Be(10_000m);
+        schedule[^1].ClosingNetBookValue.Should().Be(1_000m);
+    }
+
+    [Fact]
+    public void UnitsOfProduction_WithoutProjectedUnits_Throws()
+    {
+        var asset = Asset(11_000m, 1_000m, 4, DepreciationMethod.UnitsOfProduction, totalUnits: 1_000);
+
+        var act = () => _calculator.BuildSchedule(asset, projectedUnitsPerPeriod: null);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void UnitsOfProduction_WithoutTotalUnits_Throws()
+    {
+        var asset = Asset(11_000m, 1_000m, 4, DepreciationMethod.UnitsOfProduction, totalUnits: null);
+
+        var act = () => _calculator.BuildSchedule(asset, new long[] { 100 });
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void BuildSchedule_NonPositiveUsefulLife_Throws()
+    {
+        var act = () => _calculator.BuildSchedule(Asset(1_000m, 0m, 0, DepreciationMethod.StraightLine));
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void BuildSchedule_SalvageAboveCost_Throws()
+    {
+        var act = () => _calculator.BuildSchedule(Asset(1_000m, 2_000m, 12, DepreciationMethod.StraightLine));
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/Meridian.Tests/Ledger/FixedAssetDepreciationDraftBuilderTests.cs
+++ b/tests/Meridian.Tests/Ledger/FixedAssetDepreciationDraftBuilderTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using Meridian.Ledger;
+using Xunit;
+
+namespace Meridian.Tests.Ledger;
+
+/// <summary>
+/// Tests that the depreciation draft builder batches every asset's charge for a period into a
+/// single governed <see cref="AutomatedJournalDraft"/> that flows through
+/// <see cref="AutomatedJournalApproval"/>.
+/// </summary>
+public sealed class FixedAssetDepreciationDraftBuilderTests
+{
+    private static readonly Guid AssetA = new("33333333-3333-3333-3333-333333333333");
+    private static readonly Guid AssetB = new("44444444-4444-4444-4444-444444444444");
+    private static readonly DateOnly PeriodEnd = new(2026, 1, 31);
+    private static readonly DateTimeOffset AsOf = new(2026, 1, 31, 21, 0, 0, TimeSpan.Zero);
+
+    private static DepreciationInput Input(Guid assetId, decimal amount)
+        => new(assetId, LedgerAccounts.FixedAssetCostFor(assetId.ToString("D")), amount);
+
+    [Fact]
+    public void BuildDraft_BatchesAllAssetsIntoOneDraft()
+    {
+        var draft = FixedAssetDepreciationDraftBuilder.BuildDraft(
+            PeriodEnd,
+            AsOf,
+            [Input(AssetA, 100m), Input(AssetB, 200m)],
+            bookLabel: "fund-1");
+
+        draft.Should().NotBeNull();
+        draft!.Event.Kind.Should().Be(AutomatedJournalEventKind.DepreciationPosted);
+        draft.IsBalanced.Should().BeTrue();
+        draft.Lines.Should().HaveCount(4); // two lines per asset
+        draft.TotalDebits.Should().Be(300m);
+        draft.Event.Amount.Should().Be(300m);
+        draft.Event.EffectiveDate.Should().Be(PeriodEnd);
+        draft.Metadata.Tags.Should().ContainKey("depreciation.assetCount")
+            .WhoseValue.Should().Be("2");
+    }
+
+    [Fact]
+    public void BuildDraft_NoAssets_ReturnsNull()
+    {
+        var draft = FixedAssetDepreciationDraftBuilder.BuildDraft(PeriodEnd, AsOf, []);
+
+        draft.Should().BeNull();
+    }
+
+    [Fact]
+    public void BuildDraft_SkipsZeroAndNegativeCharges()
+    {
+        var draft = FixedAssetDepreciationDraftBuilder.BuildDraft(
+            PeriodEnd,
+            AsOf,
+            [Input(AssetA, 0m), Input(AssetB, 150m)]);
+
+        draft.Should().NotBeNull();
+        draft!.Lines.Should().HaveCount(2); // only AssetB projected
+        draft.TotalDebits.Should().Be(150m);
+    }
+
+    [Fact]
+    public void BuildDraft_AllZeroCharges_ReturnsNull()
+    {
+        var draft = FixedAssetDepreciationDraftBuilder.BuildDraft(
+            PeriodEnd,
+            AsOf,
+            [Input(AssetA, 0m)]);
+
+        draft.Should().BeNull();
+    }
+
+    [Fact]
+    public void BuildDraft_ProducesSubmittableApproval()
+    {
+        var draft = FixedAssetDepreciationDraftBuilder.BuildDraft(
+            PeriodEnd,
+            AsOf,
+            [Input(AssetA, 100m), Input(AssetB, 200m)]);
+
+        var approval = AutomatedJournalApproval.Submit(draft!, "controller", AsOf, "January depreciation run");
+
+        approval.Status.Should().Be(AutomatedJournalApprovalStatus.Submitted);
+        approval.Draft.Event.Kind.Should().Be(AutomatedJournalEventKind.DepreciationPosted);
+    }
+
+    [Fact]
+    public void BuildDraft_IdempotencyKeyIsStableForBookAndPeriod()
+    {
+        var first = FixedAssetDepreciationDraftBuilder.BuildDraft(PeriodEnd, AsOf, [Input(AssetA, 100m)], bookLabel: "fund-1");
+        var second = FixedAssetDepreciationDraftBuilder.BuildDraft(PeriodEnd, AsOf, [Input(AssetA, 100m)], bookLabel: "fund-1");
+
+        first!.Event.IdempotencyKey.Should().Be(second!.Event.IdempotencyKey);
+        first.Event.IdempotencyKey.Should().Be("depreciation|fund-1|2026-01-31");
+    }
+}

--- a/tests/Meridian.Tests/Ledger/FixedAssetDepreciationProjectorTests.cs
+++ b/tests/Meridian.Tests/Ledger/FixedAssetDepreciationProjectorTests.cs
@@ -1,0 +1,84 @@
+using FluentAssertions;
+using Meridian.Ledger;
+using Xunit;
+
+namespace Meridian.Tests.Ledger;
+
+/// <summary>
+/// Tests the fixed-asset depreciation projector: balanced expense/accumulated-depreciation lines
+/// scoped per asset, plus the account-type and amount guards it shares with the fixed-income
+/// amortization projector.
+/// </summary>
+public sealed class FixedAssetDepreciationProjectorTests
+{
+    private static readonly Guid AssetId = new("11111111-1111-1111-1111-111111111111");
+
+    private static LedgerAccount CostAccount => LedgerAccounts.FixedAssetCostFor(AssetId.ToString("D"));
+
+    [Fact]
+    public void Project_PostsDepreciationExpenseAndAccumulatedDepreciation()
+    {
+        var input = new DepreciationInput(AssetId, CostAccount, 500m);
+
+        var projection = FixedAssetDepreciationProjector.Project(input);
+
+        projection.IsBalanced.Should().BeTrue();
+        projection.TotalDebits.Should().Be(500m);
+        projection.Lines.Should().HaveCount(2);
+
+        var expenseLine = projection.Lines.Single(line => line.account.AccountType == LedgerAccountType.Expense);
+        expenseLine.account.Name.Should().Be("Depreciation Expense");
+        expenseLine.debit.Should().Be(500m);
+        expenseLine.credit.Should().Be(0m);
+
+        var accumulatedLine = projection.Lines.Single(line => line.account.Name == "Accumulated Depreciation");
+        accumulatedLine.account.AccountType.Should().Be(LedgerAccountType.Asset);
+        accumulatedLine.debit.Should().Be(0m);
+        accumulatedLine.credit.Should().Be(500m);
+    }
+
+    [Fact]
+    public void Project_ScopesAccountsByAssetId()
+    {
+        var projection = FixedAssetDepreciationProjector.Project(new DepreciationInput(AssetId, CostAccount, 42m));
+
+        projection.AssetId.Should().Be(AssetId);
+        projection.Lines.Should().Contain(line => line.account == LedgerAccounts.DepreciationExpenseFor(AssetId.ToString("D")));
+        projection.Lines.Should().Contain(line => line.account == LedgerAccounts.AccumulatedDepreciationFor(AssetId.ToString("D")));
+    }
+
+    [Fact]
+    public void Project_NonAssetCostAccount_Throws()
+    {
+        var expenseAccount = LedgerAccounts.DepreciationExpenseFor(AssetId.ToString("D"));
+        var input = new DepreciationInput(AssetId, expenseAccount, 100m);
+
+        var act = () => FixedAssetDepreciationProjector.Project(input);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Project_ZeroAmount_Throws()
+    {
+        var act = () => FixedAssetDepreciationProjector.Project(new DepreciationInput(AssetId, CostAccount, 0m));
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Project_NegativeAmount_Throws()
+    {
+        var act = () => FixedAssetDepreciationProjector.Project(new DepreciationInput(AssetId, CostAccount, -1m));
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Project_EmptyAssetId_Throws()
+    {
+        var act = () => FixedAssetDepreciationProjector.Project(new DepreciationInput(Guid.Empty, CostAccount, 100m));
+
+        act.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Implements the first engine from the [financing/liabilities/depreciation blueprint](docs/engineering/blueprints/financing-liabilities-depreciation-blueprint.md) (merged in #2165) — **fixed-asset depreciation** — kept entirely within `Meridian.Ledger` and plugged into the existing projector → ledger → approval pipeline. No changes to other layers or to any existing public signature; everything is additive.

**New ledger accounts** (`LedgerAccounts.cs`, per-asset scoped):
- `FixedAssetCostFor` (Asset), `AccumulatedDepreciationFor` (contra-asset, credit balance), `DepreciationExpenseFor` (Expense).

**New event kind** (`AutomatedJournalEventKind.cs`): `DepreciationPosted` — a builder-only kind, following the precedent of `FairValueMarkAdjustment` and `PeriodCloseClosingEntries` (not handled by the generic `AutomatedJournalDraftProjector`).

**New components** (`Meridian.Ledger`):
- `FixedAssetDepreciationProjector` — balanced `Dr DepreciationExpense / Cr AccumulatedDepreciation` lines, with the same account-type and non-zero-amount guards as `FixedIncomeAmortizationProjector`.
- `DepreciationScheduleCalculator` (+ `IDepreciationScheduleCalculator`) — straight-line, declining-balance (auto-switch to straight-line with a salvage floor), and usage-driven units-of-production. Every method depreciates exactly to salvage value, rounding to currency scale with the final period absorbing the remainder.
- `FixedAssetDepreciationDraftBuilder` — batches all of a period's per-asset projections into a **single** governed `AutomatedJournalDraft` so one approval covers the whole depreciation run, mirroring `DailyPortfolioPricingDraftBuilder`.
- Supporting records: `FixedAssetRecord`, `DepreciationMethod`, `DepreciationInput`, `DepreciationProjection`, `DepreciationPeriod`.

Out of scope for this PR (follow-ups, per the blueprint): the fixed-asset register store, application service, REST endpoints, and browser read-model, plus the repo and borrower-side-debt engines.

> Scope note: this PR touches `src/**` and `tests/**`, declared as `phase:PR7` for the roadmap source-docs scope gate (the `src/Meridian.Ledger/README.md` update brings it into that workflow's path filter).

## Reason

The blueprint identified fixed-asset depreciation as entirely greenfield and the most self-contained engine to build first (it lives wholly in `Meridian.Ledger`, structurally identical to bond premium/discount amortization). This lands the ledger-side accounting math and governed-draft path so the register/service/UI layers can build on a tested core.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [ ] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Unit tests were added (`tests/Meridian.Tests/Ledger/`): projector (balanced lines, account-type/amount/empty-id guards), schedule math (straight-line sum-to-salvage and rounding absorption, declining-balance auto-switch and salvage floor, units-of-production proration and over-production cap, and validation guards — all with hand-computed golden values), and the draft builder (batching, null/empty handling, submittable `AutomatedJournalApproval`, stable idempotency key). **Not run locally** — no .NET SDK is available in this environment; validation relies on CI.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdKzk1VAjiqtGfguxjBi6f