### PR TITLE
chore(ci): re-baseline types.ts file-size cap to current (11192)

### DIFF
--- a/build/config/file-size-baseline.json
+++ b/build/config/file-size-baseline.json
@@ -43,7 +43,7 @@
     "src/Meridian.Ui/dashboard/src/screens/strategy-screen.view-model.ts": 3492,
     "src/Meridian.Ui/dashboard/src/screens/trading-screen.tsx": 2605,
     "src/Meridian.Ui/dashboard/src/screens/trading-screen.view-model.ts": 5355,
-    "src/Meridian.Ui/dashboard/src/types.ts": 11184,
+    "src/Meridian.Ui/dashboard/src/types.ts": 11192,
     "src/Meridian.Wpf/ViewModels/Accounting/AccountingCloseViewModel.cs": 2653,
     "src/Meridian.Wpf/ViewModels/Accounting/AccountingConfigureViewModel.cs": 5545,
     "src/Meridian.Wpf/ViewModels/FundLedgerViewModel.cs": 3468,


### PR DESCRIPTION
## Summary

Bumps the file-size ratchet cap for `src/Meridian.Ui/dashboard/src/types.ts` from **11184 → 11192** in `build/config/file-size-baseline.json` (one-line change).

The recorded cap is 11184 but the file is currently **11192 lines** (8 over), so `build/scripts/ci/check-file-size.py` fails on `main` itself — and therefore on every PR whose CI merges with `main`:

```
File-size ratchet FAILED:
- GREW past cap: src/Meridian.Ui/dashboard/src/types.ts now 11192 lines (baseline cap 11184).
```

This is the **only** ratchet violation on `main` (verified locally: `File-size ratchet OK: 47 tracked file(s)` after the bump). The growth predates and is unrelated to any in-flight feature work — it slipped in after the last baseline refresh (#2167) without the cap being updated.

## Reason

The ratchet runs before the .NET build in `verify-fast`, so this stale cap aborts CI before any build/test executes, blocking unrelated PRs (e.g. the fixed-asset depreciation engine in #2171) from getting a real build+test run. Re-baselining to the current line count restores a green ratchet. Per the baseline's own convention, this is tracked debt surfaced in the diff; `types.ts` remains a refactor target and may still shrink freely.

## Testing performed

- [x] `python3 build/scripts/ci/check-file-size.py` passes after the change (`File-size ratchet OK`)
- [ ] `bash scripts/ci.sh` completed successfully
- [ ] GitHub Actions `quality-gate` passed

No code or behavior change — configuration baseline only.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdKzk1VAjiqtGfguxjBi6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdKzk1VAjiqtGfguxjBi6f)_