### PR TITLE
refactor(providers): split god-classes into focused collaborators

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/Core/CompositeHistoricalDataProvider.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/CompositeHistoricalDataProvider.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Threading;
 using Meridian.Core.Exceptions;
 using Meridian.Core.Logging;
@@ -27,13 +26,10 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
 {
     private readonly List<IHistoricalDataProvider> _providers;
     private readonly ISymbolResolver? _symbolResolver;
-    private readonly ProviderRateLimitTracker _rateLimitTracker;
-    private readonly ConcurrentDictionary<string, ProviderHealthStatus> _healthStatus = new();
-    private readonly ConcurrentDictionary<string, DateTimeOffset> _providerFailures = new();
-    private readonly TimeSpan _failureBackoffDuration;
+    private readonly ProviderRotationStrategy _rotation;
+    private readonly ProviderHealthTracker _health;
+    private readonly CrossProviderValidator _validator;
     private readonly bool _enableCrossValidation;
-    private readonly bool _enableRateLimitRotation;
-    private readonly double _rateLimitRotationThreshold;
     private readonly TimeSpan _maxRateLimitRetryBudget;
     private readonly ILogger _log;
     private bool _disposed;
@@ -41,14 +37,6 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
     // Maximum number of times the whole provider chain is retried after every candidate has
     // been rate limited. Kept small so a persistent rate limit cannot wedge a single request.
     private const int MaxRateLimitRetries = 3;
-
-    // A single rate-limit reset longer than this is treated as "not worth waiting for"; the
-    // request fails fast rather than blocking on it.
-    private static readonly TimeSpan MaxSingleRateLimitWait = TimeSpan.FromMinutes(5);
-
-    // Upper bound on the random jitter added to each rate-limit wait so that many concurrent
-    // requests do not resume in lock-step and hammer the provider at the same instant.
-    private static readonly TimeSpan RateLimitRetryJitter = TimeSpan.FromSeconds(1);
 
     /// <summary>
     /// Event raised as a request progresses through the provider chain: when a provider
@@ -88,12 +76,12 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
     /// <summary>
     /// Get current health status of all providers.
     /// </summary>
-    public IReadOnlyDictionary<string, ProviderHealthStatus> ProviderHealth => _healthStatus;
+    public IReadOnlyDictionary<string, ProviderHealthStatus> ProviderHealth => _health.Health;
 
     /// <summary>
     /// Get current rate limit status for all providers.
     /// </summary>
-    public IReadOnlyDictionary<string, RateLimitStatus> RateLimitStatus => _rateLimitTracker.GetAllStatus();
+    public IReadOnlyDictionary<string, RateLimitStatus> RateLimitStatus => _rotation.GetAllStatus();
 
     public IReadOnlyList<DataGranularity> SupportedGranularities =>
         _providers
@@ -121,27 +109,27 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
             throw new ArgumentException("At least one provider is required", nameof(providers));
 
         _symbolResolver = symbolResolver;
-        _failureBackoffDuration = failureBackoffDuration ?? TimeSpan.FromMinutes(5);
         _enableCrossValidation = enableCrossValidation;
-        _enableRateLimitRotation = enableRateLimitRotation;
-        _rateLimitRotationThreshold = rateLimitRotationThreshold;
         // Overall wall-clock budget for waiting out rate limits across all retry attempts.
         // Bounds the worst case (previously ~15 min: 3 retries x 5 min) to a single knob.
         _maxRateLimitRetryBudget = maxRateLimitRetryBudget ?? TimeSpan.FromMinutes(5);
         _log = log ?? LoggingSetup.ForContext<CompositeHistoricalDataProvider>();
 
-        // Initialize rate limit tracker
-        _rateLimitTracker = new ProviderRateLimitTracker(_log);
+        // Rate-limit aware rotation policy, backed by a per-provider rate-limit state tracker.
+        var rateLimitTracker = new ProviderRateLimitTracker(_log);
         foreach (var provider in _providers)
         {
-            _rateLimitTracker.RegisterProvider(provider);
+            rateLimitTracker.RegisterProvider(provider);
         }
+        _rotation = new ProviderRotationStrategy(rateLimitTracker, enableRateLimitRotation, rateLimitRotationThreshold);
 
-        // Initialize health status
-        foreach (var provider in _providers)
-        {
-            _healthStatus[provider.Name] = new ProviderHealthStatus(provider.Name, true, "Not checked");
-        }
+        // Per-provider health status and failure backoff bookkeeping.
+        _health = new ProviderHealthTracker(
+            _providers.Select(p => p.Name),
+            failureBackoffDuration ?? TimeSpan.FromMinutes(5));
+
+        // Best-effort cross-provider validation (only invoked when enabled).
+        _validator = new CrossProviderValidator(_providers, ResolveSymbolForProviderAsync, _log);
     }
 
     public async Task<bool> IsAvailableAsync(CancellationToken ct = default)
@@ -168,7 +156,7 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
             candidateSelector: GetOrderedProviders,
             fetchAsync: (provider, resolved, token) => provider.GetDailyBarsAsync(resolved, from, to, token),
             onSuccessAsync: _enableCrossValidation
-                ? (bars, provider, token) => ValidateBarsAsync(bars, symbol, from, to, provider.Name, token)
+                ? (bars, provider, token) => _validator.ValidateAsync(bars, symbol, from, to, provider.Name, token)
                 : null,
             allFailedMessageFactory: summary => $"All providers failed for {symbol}: {summary}",
             ct).ConfigureAwait(false);
@@ -230,16 +218,16 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
             foreach (var provider in candidateSelector())
             {
                 // Skip providers in backoff period
-                if (IsInBackoffPeriod(provider.Name))
+                if (_health.IsInBackoffPeriod(provider.Name))
                 {
                     _log.Debug("Skipping {Provider} - in backoff period", provider.Name);
                     continue;
                 }
 
                 // Skip rate-limited providers if rotation is enabled
-                if (_enableRateLimitRotation && _rateLimitTracker.IsRateLimited(provider.Name))
+                if (_rotation.Enabled && _rotation.IsRateLimited(provider.Name))
                 {
-                    var resetTime = _rateLimitTracker.GetTimeUntilReset(provider.Name);
+                    var resetTime = _rotation.GetTimeUntilReset(provider.Name);
                     _log.Debug("Skipping {Provider} - rate limited, resets in {ResetTime}", provider.Name, resetTime);
                     continue;
                 }
@@ -256,7 +244,7 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
                     var startTime = DateTimeOffset.UtcNow;
 
                     // Record the request attempt
-                    _rateLimitTracker.RecordRequest(provider.Name);
+                    _rotation.RecordRequest(provider.Name);
 
                     var results = await fetchAsync(provider, resolvedSymbol, ct).ConfigureAwait(false);
                     var elapsed = DateTimeOffset.UtcNow - startTime;
@@ -264,9 +252,9 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
                     if (results is { Count: > 0 })
                     {
                         // Update health status and clear any rate limit state
-                        UpdateHealthStatus(provider.Name, true, $"Retrieved {results.Count} {operationLabel}", elapsed);
-                        ClearFailure(provider.Name);
-                        _rateLimitTracker.ClearRateLimitState(provider.Name);
+                        _health.UpdateHealth(provider.Name, true, $"Retrieved {results.Count} {operationLabel}", elapsed);
+                        _health.ClearFailure(provider.Name);
+                        _rotation.ClearRateLimitState(provider.Name);
 
                         _log.Information("Successfully retrieved {Count} {Operation} from {Provider} for {Symbol}",
                             results.Count, operationLabel, provider.Name, symbol);
@@ -293,7 +281,7 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
                     if (IsRateLimitException(ex))
                     {
                         var retryAfter = ExtractRetryAfter(ex);
-                        _rateLimitTracker.RecordRateLimitHit(provider.Name, retryAfter);
+                        _rotation.RecordRateLimitHit(provider.Name, retryAfter);
                         _log.Warning("Provider {Provider} hit rate limit for {Symbol} {Operation}, rotating to next provider",
                             provider.Name, symbol, operationLabel);
                         RaiseProgress(symbol, provider.Name, requestStartedAt, status: "rate-limited", error: ex.Message);
@@ -301,7 +289,7 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
                     else
                     {
                         _log.Warning(ex, "Provider {Provider} failed for {Symbol} {Operation}", provider.Name, symbol, operationLabel);
-                        RecordFailure(provider.Name, ex.Message);
+                        _health.RecordFailure(provider.Name, ex.Message);
                         RaiseProgress(symbol, provider.Name, requestStartedAt, status: "failed", error: ex.Message);
                     }
                     errors.Add((provider.Name, ex));
@@ -310,12 +298,12 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
 
             // All providers failed - if they were all just rate limited and we still have retry
             // attempts and time budget left, wait for the earliest reset (with jitter) and retry.
-            if (_enableRateLimitRotation
+            if (_rotation.Enabled
                 && errors.Count > 0
                 && errors.All(e => IsRateLimitException(e.Error))
                 && attempt < MaxRateLimitRetries)
             {
-                var wait = ComputeRateLimitWait(retryDeadline);
+                var wait = _rotation.ComputeRateLimitWait(_providers, retryDeadline);
                 if (wait.HasValue)
                 {
                     _log.Information(
@@ -338,30 +326,6 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
             RaiseProgress(symbol, Name, requestStartedAt, status: "no-data");
             return Array.Empty<TResult>();
         }
-    }
-
-    /// <summary>
-    /// Determine how long to wait for the earliest provider rate-limit reset before the next
-    /// retry, honoring the overall <paramref name="retryDeadline"/> budget and adding jitter.
-    /// Returns <see langword="null"/> when waiting is not worthwhile (no reset known, the reset
-    /// is too far out, or the remaining budget is exhausted), signalling the caller to fail fast.
-    /// </summary>
-    private TimeSpan? ComputeRateLimitWait(DateTimeOffset retryDeadline)
-    {
-        var shortestWait = GetShortestRateLimitWait();
-        if (!shortestWait.HasValue || shortestWait.Value >= MaxSingleRateLimitWait)
-            return null;
-
-        var remaining = retryDeadline - DateTimeOffset.UtcNow;
-        if (remaining <= TimeSpan.Zero || shortestWait.Value > remaining)
-            return null;
-
-        // Add bounded random jitter so concurrent requests don't resume in lock-step.
-        var jitterMs = Random.Shared.Next(0, (int)RateLimitRetryJitter.TotalMilliseconds + 1);
-        var wait = shortestWait.Value + TimeSpan.FromMilliseconds(jitterMs);
-
-        // Never let jitter push the wait past the remaining budget.
-        return wait > remaining ? remaining : wait;
     }
 
     /// <summary>
@@ -402,30 +366,7 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
     /// Get all providers ordered by rate limit capacity when rotation is enabled.
     /// </summary>
     private IEnumerable<IHistoricalDataProvider> GetOrderedProviders()
-        => OrderByRateLimitAvailability(_providers);
-
-    /// <summary>
-    /// Order an arbitrary provider set by rate-limit capacity when rotation is enabled:
-    /// providers with capacity first, then those approaching their limit, then rate-limited ones
-    /// last. When rotation is disabled the input order (priority order) is preserved.
-    /// </summary>
-    private IEnumerable<IHistoricalDataProvider> OrderByRateLimitAvailability(IEnumerable<IHistoricalDataProvider> providers)
-    {
-        if (!_enableRateLimitRotation)
-            return providers;
-
-        // Order by: not rate limited first, then by usage ratio (lowest first), then by priority
-        return providers.OrderBy(p =>
-        {
-            if (_rateLimitTracker.IsRateLimited(p.Name))
-                return 1000; // Put rate-limited providers last
-
-            if (_rateLimitTracker.IsApproachingLimit(p.Name, _rateLimitRotationThreshold))
-                return 100 + (int)(_rateLimitTracker.GetStatus(p.Name)?.UsagePercent ?? 0);
-
-            return p.Priority;
-        });
-    }
+        => _rotation.OrderByAvailability(_providers);
 
     /// <summary>
     /// Check if an exception indicates a rate limit error (HTTP 429).
@@ -469,30 +410,21 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
         return null;
     }
 
-    /// <summary>
-    /// Get the shortest wait time until any provider's rate limit resets.
-    /// </summary>
-    private TimeSpan? GetShortestRateLimitWait() =>
-        _providers
-            .Select(p => _rateLimitTracker.GetTimeUntilReset(p.Name))
-            .Where(w => w.HasValue)
-            .Min();
-
     public async Task<IReadOnlyList<AdjustedHistoricalBar>> GetAdjustedDailyBarsAsync(string symbol, DateOnly? from, DateOnly? to, CancellationToken ct = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
         // Get providers that support adjusted prices, ordered by rate limit availability
-        var adjustedProviders = OrderByRateLimitAvailability(
+        var adjustedProviders = _rotation.OrderByAvailability(
             _providers.Where(p => p.Capabilities.AdjustedPrices));
 
         foreach (var provider in adjustedProviders)
         {
-            if (IsInBackoffPeriod(provider.Name))
+            if (_health.IsInBackoffPeriod(provider.Name))
                 continue;
 
             // Skip rate-limited providers if rotation is enabled
-            if (_enableRateLimitRotation && _rateLimitTracker.IsRateLimited(provider.Name))
+            if (_rotation.Enabled && _rotation.IsRateLimited(provider.Name))
             {
                 _log.Debug("Skipping {Provider} for adjusted bars - rate limited", provider.Name);
                 continue;
@@ -503,14 +435,14 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
                 var resolvedSymbol = await ResolveSymbolForProviderAsync(symbol, provider.Name, ct).ConfigureAwait(false);
 
                 // Record the request attempt
-                _rateLimitTracker.RecordRequest(provider.Name);
+                _rotation.RecordRequest(provider.Name);
 
                 var bars = await provider.GetAdjustedDailyBarsAsync(resolvedSymbol, from, to, ct).ConfigureAwait(false);
 
                 if (bars is { Count: > 0 })
                 {
-                    ClearFailure(provider.Name);
-                    _rateLimitTracker.ClearRateLimitState(provider.Name);
+                    _health.ClearFailure(provider.Name);
+                    _rotation.ClearRateLimitState(provider.Name);
                     return bars;
                 }
             }
@@ -523,14 +455,14 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
                 if (IsRateLimitException(ex))
                 {
                     var retryAfter = ExtractRetryAfter(ex);
-                    _rateLimitTracker.RecordRateLimitHit(provider.Name, retryAfter);
+                    _rotation.RecordRateLimitHit(provider.Name, retryAfter);
                     _log.Warning("Provider {Provider} hit rate limit for adjusted bars, rotating to next",
                         provider.Name);
                 }
                 else
                 {
                     _log.Warning(ex, "Provider {Provider} failed for adjusted bars", provider.Name);
-                    RecordFailure(provider.Name, ex.Message);
+                    _health.RecordFailure(provider.Name, ex.Message);
                 }
             }
         }
@@ -554,16 +486,16 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
             {
                 var available = await p.IsAvailableAsync(ct).ConfigureAwait(false);
                 var elapsed = DateTimeOffset.UtcNow - startTime;
-                UpdateHealthStatus(p.Name, available, available ? "Healthy" : "Unavailable", elapsed);
+                _health.UpdateHealth(p.Name, available, available ? "Healthy" : "Unavailable", elapsed);
             }
             catch (Exception ex)
             {
-                UpdateHealthStatus(p.Name, false, ex.Message);
+                _health.UpdateHealth(p.Name, false, ex.Message);
             }
         });
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
-        return _healthStatus;
+        return _health.Health;
     }
 
     private async Task<string> ResolveSymbolForProviderAsync(string symbol, string providerName, CancellationToken ct)
@@ -583,90 +515,13 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
         }
     }
 
-    private async Task ValidateBarsAsync(IReadOnlyList<HistoricalBar> bars, string symbol, DateOnly? from, DateOnly? to, string sourceProvider, CancellationToken ct)
-    {
-        // Try to validate with a different provider
-        var validationProvider = _providers.FirstOrDefault(p => p.Name != sourceProvider);
-        if (validationProvider is null)
-            return;
-
-        try
-        {
-            // Resolve the symbol for the validation provider too — providers can use
-            // different symbol formats (e.g. "AAPL" vs "aapl.us"), and validating with
-            // the unresolved symbol silently compares against the wrong (or no) data.
-            var resolvedSymbol = await ResolveSymbolForProviderAsync(symbol, validationProvider.Name, ct).ConfigureAwait(false);
-            var validationBars = await validationProvider.GetDailyBarsAsync(resolvedSymbol, from, to, ct).ConfigureAwait(false);
-
-            if (validationBars.Count > 0)
-            {
-                var discrepancies = 0;
-                foreach (var bar in bars.Take(5)) // Check first 5 bars
-                {
-                    var matchingBar = validationBars.FirstOrDefault(b => b.SessionDate == bar.SessionDate);
-                    if (matchingBar is not null)
-                    {
-                        var closeDiff = Math.Abs(bar.Close - matchingBar.Close) / bar.Close;
-                        if (closeDiff > 0.01m) // More than 1% difference
-                        {
-                            discrepancies++;
-                            _log.Debug("Price discrepancy on {Date}: {Provider1}={Price1}, {Provider2}={Price2}",
-                                bar.SessionDate, sourceProvider, bar.Close, validationProvider.Name, matchingBar.Close);
-                        }
-                    }
-                }
-
-                if (discrepancies > 0)
-                {
-                    _log.Warning("Found {Count} price discrepancies between {Provider1} and {Provider2} for {Symbol}",
-                        discrepancies, sourceProvider, validationProvider.Name, symbol);
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            _log.Debug(ex, "Cross-validation failed for {Symbol}", symbol);
-        }
-    }
-
-    private bool IsInBackoffPeriod(string providerName)
-    {
-        if (_providerFailures.TryGetValue(providerName, out var failedAt))
-        {
-            return DateTimeOffset.UtcNow - failedAt < _failureBackoffDuration;
-        }
-        return false;
-    }
-
-    private void RecordFailure(string providerName, string message)
-    {
-        _providerFailures[providerName] = DateTimeOffset.UtcNow;
-        UpdateHealthStatus(providerName, false, message);
-    }
-
-    private void ClearFailure(string providerName)
-    {
-        _providerFailures.TryRemove(providerName, out _);
-    }
-
-    private void UpdateHealthStatus(string providerName, bool isAvailable, string? message = null, TimeSpan? responseTime = null)
-    {
-        _healthStatus[providerName] = new ProviderHealthStatus(
-            providerName,
-            isAvailable,
-            message,
-            DateTimeOffset.UtcNow,
-            responseTime
-        );
-    }
-
     public void Dispose()
     {
         if (_disposed)
             return;
         _disposed = true;
 
-        _rateLimitTracker.Dispose();
+        _rotation.Dispose();
 
         foreach (var provider in _providers.OfType<IDisposable>())
         {

--- a/src/Meridian.Infrastructure/Adapters/Core/CrossProviderValidator.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/CrossProviderValidator.cs
@@ -1,0 +1,84 @@
+using Meridian.Contracts.Domain.Models;
+using Serilog;
+
+namespace Meridian.Infrastructure.Adapters.Core;
+
+/// <summary>
+/// Cross-validates bars returned by one provider against a second provider for the
+/// <see cref="CompositeHistoricalDataProvider"/>, logging any material price discrepancies.
+/// Extracted so the composite provider does not own validation logic directly
+/// (single-responsibility collaborator). Validation is best-effort: failures are logged and
+/// never propagate to the data path.
+/// </summary>
+internal sealed class CrossProviderValidator
+{
+    private readonly IReadOnlyList<IHistoricalDataProvider> _providers;
+    private readonly Func<string, string, CancellationToken, Task<string>> _resolveSymbolForProvider;
+    private readonly ILogger _log;
+
+    public CrossProviderValidator(
+        IReadOnlyList<IHistoricalDataProvider> providers,
+        Func<string, string, CancellationToken, Task<string>> resolveSymbolForProvider,
+        ILogger log)
+    {
+        _providers = providers;
+        _resolveSymbolForProvider = resolveSymbolForProvider;
+        _log = log;
+    }
+
+    /// <summary>
+    /// Validate <paramref name="bars"/> (from <paramref name="sourceProvider"/>) against the first
+    /// other available provider, logging close-price discrepancies over 1% on the first few bars.
+    /// </summary>
+    public async Task ValidateAsync(
+        IReadOnlyList<HistoricalBar> bars,
+        string symbol,
+        DateOnly? from,
+        DateOnly? to,
+        string sourceProvider,
+        CancellationToken ct)
+    {
+        // Try to validate with a different provider
+        var validationProvider = _providers.FirstOrDefault(p => p.Name != sourceProvider);
+        if (validationProvider is null)
+            return;
+
+        try
+        {
+            // Resolve the symbol for the validation provider too — providers can use
+            // different symbol formats (e.g. "AAPL" vs "aapl.us"), and validating with
+            // the unresolved symbol silently compares against the wrong (or no) data.
+            var resolvedSymbol = await _resolveSymbolForProvider(symbol, validationProvider.Name, ct).ConfigureAwait(false);
+            var validationBars = await validationProvider.GetDailyBarsAsync(resolvedSymbol, from, to, ct).ConfigureAwait(false);
+
+            if (validationBars.Count > 0)
+            {
+                var discrepancies = 0;
+                foreach (var bar in bars.Take(5)) // Check first 5 bars
+                {
+                    var matchingBar = validationBars.FirstOrDefault(b => b.SessionDate == bar.SessionDate);
+                    if (matchingBar is not null)
+                    {
+                        var closeDiff = Math.Abs(bar.Close - matchingBar.Close) / bar.Close;
+                        if (closeDiff > 0.01m) // More than 1% difference
+                        {
+                            discrepancies++;
+                            _log.Debug("Price discrepancy on {Date}: {Provider1}={Price1}, {Provider2}={Price2}",
+                                bar.SessionDate, sourceProvider, bar.Close, validationProvider.Name, matchingBar.Close);
+                        }
+                    }
+                }
+
+                if (discrepancies > 0)
+                {
+                    _log.Warning("Found {Count} price discrepancies between {Provider1} and {Provider2} for {Symbol}",
+                        discrepancies, sourceProvider, validationProvider.Name, symbol);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Debug(ex, "Cross-validation failed for {Symbol}", symbol);
+        }
+    }
+}

--- a/src/Meridian.Infrastructure/Adapters/Core/PollingProviderBase.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/PollingProviderBase.cs
@@ -1,0 +1,288 @@
+using Meridian.Core.Exceptions;
+using Meridian.Infrastructure.Contracts;
+using Meridian.Infrastructure.Resilience;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Infrastructure.Adapters.Core;
+
+/// <summary>
+/// Abstract base class for polling-based market data providers (REST providers that do not
+/// expose a streaming WebSocket API). Consolidates the connection lifecycle, honest
+/// connection diagnostics, and degraded-state backoff that would otherwise be hand-rolled per
+/// provider — the polling counterpart to <see cref="WebSocketProviderBase"/>.
+///
+/// <para>
+/// Derived classes implement the provider-specific poll via <see cref="PollOnceAsync"/> and
+/// report their subscription count via <see cref="ActiveSubscriptionCount"/>. They may record
+/// poll activity through the protected <c>Record*</c> helpers so the shared diagnostics stay
+/// accurate.
+/// </para>
+/// </summary>
+[ImplementsAdr("ADR-001", "Unified polling provider base class for REST-polling market data providers")]
+[ImplementsAdr("ADR-004", "All async methods support CancellationToken")]
+public abstract class PollingProviderBase
+{
+    private readonly string _providerName;
+    private readonly SemaphoreSlim _lifecycleLock = new(1, 1);
+
+    private CancellationTokenSource? _pollCts;
+    private Task? _pollTask;
+    private volatile bool _connected;
+    private volatile bool _disposed;
+    private volatile ProviderConnectionLifecycleState _lifecycleState = ProviderConnectionLifecycleState.Configured;
+    private DateTimeOffset? _connectedAt;
+    private DateTimeOffset? _disconnectedAt;
+    private DateTimeOffset? _lastPollAttemptAt;
+    private DateTimeOffset? _lastSuccessfulApiCallAt;
+    private DateTimeOffset? _lastMessageReceivedAt;
+    private string? _lastError;
+    private int _consecutivePollFailures;
+
+    /// <summary>Logger for the derived provider.</summary>
+    protected readonly ILogger Log;
+
+    /// <summary>Interval between poll cycles.</summary>
+    protected TimeSpan PollInterval { get; }
+
+    protected PollingProviderBase(string providerName, ILogger logger, TimeSpan pollInterval)
+    {
+        _providerName = providerName;
+        Log = logger ?? throw new ArgumentNullException(nameof(logger));
+        PollInterval = pollInterval;
+    }
+
+    /// <summary>Raised whenever the connection diagnostics change (e.g. a lifecycle transition).</summary>
+    public event Action<WebSocketConnectionDiagnostics>? ConnectionDiagnosticsChanged;
+
+    /// <summary>Whether the provider is configured/enabled and may be connected.</summary>
+    public abstract bool IsEnabled { get; }
+
+    // ── Protected state accessors (for provider-specific diagnostics snapshots) ──
+
+    protected bool Disposed => _disposed;
+    protected bool Connected => _connected;
+    protected ProviderConnectionLifecycleState LifecycleState => _lifecycleState;
+    protected DateTimeOffset? ConnectedAt => _connectedAt;
+    protected DateTimeOffset? DisconnectedAt => _disconnectedAt;
+    protected DateTimeOffset? LastPollAttemptAt => _lastPollAttemptAt;
+    protected DateTimeOffset? LastSuccessfulApiCallAt => _lastSuccessfulApiCallAt;
+    protected DateTimeOffset? LastMessageReceivedAt => _lastMessageReceivedAt;
+    protected string? LastError => _lastError;
+    protected int ConsecutivePollFailures => _consecutivePollFailures;
+
+    /// <summary>Message recorded to <see cref="LastError"/> when a connect is attempted while not enabled.</summary>
+    protected virtual string NotEnabledError => $"{_providerName} is not configured.";
+
+    /// <summary>Exception thrown by <see cref="ConnectAsync"/> when the provider is not enabled.</summary>
+    protected virtual Exception CreateNotEnabledException() => new ConnectionException(NotEnabledError);
+
+    // ── Lifecycle ──────────────────────────────────────────────────────────
+
+    /// <summary>Starts the polling loop after validating that the provider is enabled.</summary>
+    public async Task ConnectAsync(CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (!IsEnabled)
+        {
+            SetLifecycleState(ProviderConnectionLifecycleState.NotConfigured);
+            _lastError = NotEnabledError;
+            throw CreateNotEnabledException();
+        }
+
+        await _lifecycleLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_connected)
+                return;
+
+            SetLifecycleState(ProviderConnectionLifecycleState.Connecting);
+            _pollCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            _connected = true;
+            _connectedAt = DateTimeOffset.UtcNow;
+            _lastError = null;
+            _consecutivePollFailures = 0;
+            SetLifecycleState(ProviderConnectionLifecycleState.Connected);
+            _pollTask = RunPollLoopAsync(_pollCts.Token);
+            Log.LogInformation("{Provider} connected (polling interval {Interval})", _providerName, PollInterval);
+        }
+        finally
+        {
+            _lifecycleLock.Release();
+        }
+    }
+
+    /// <summary>Stops the polling loop and marks the provider disconnected.</summary>
+    public async Task DisconnectAsync(CancellationToken ct = default)
+    {
+        await _lifecycleLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (!_connected)
+            {
+                if (_lifecycleState is not ProviderConnectionLifecycleState.NotConfigured)
+                    SetLifecycleState(ProviderConnectionLifecycleState.Disconnected);
+                return;
+            }
+
+            SetLifecycleState(ProviderConnectionLifecycleState.Disconnecting);
+            _connected = false;
+
+            if (_pollCts is not null)
+            {
+                await _pollCts.CancelAsync().ConfigureAwait(false);
+                if (_pollTask is not null)
+                {
+                    try
+                    { await _pollTask.WaitAsync(ct).ConfigureAwait(false); }
+                    catch (OperationCanceledException) { }
+                }
+                _pollCts.Dispose();
+                _pollCts = null;
+            }
+
+            _pollTask = null;
+            _disconnectedAt = DateTimeOffset.UtcNow;
+            SetLifecycleState(ProviderConnectionLifecycleState.Disconnected);
+            Log.LogInformation("{Provider} disconnected", _providerName);
+        }
+        finally
+        {
+            _lifecycleLock.Release();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        await DisconnectAsync().ConfigureAwait(false);
+        _lifecycleLock.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    // ── Diagnostics ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Honest connection diagnostics for a polling provider. REST polling holds no WebSocket, so
+    /// <see cref="WebSocketConnectionDiagnostics.WebSocketState"/> is reported as
+    /// <see cref="System.Net.WebSockets.WebSocketState.None"/>; poll activity maps onto the
+    /// heartbeat/message fields and consecutive poll failures onto reconnect attempts.
+    /// </summary>
+    public WebSocketConnectionDiagnostics GetConnectionDiagnosticsSnapshot()
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new WebSocketConnectionDiagnostics(
+            ProviderName: _providerName,
+            LifecycleState: _lifecycleState,
+            WebSocketState: System.Net.WebSockets.WebSocketState.None,
+            IsConnected: _connected,
+            IsReconnecting: _connected && _consecutivePollFailures > 0,
+            ReconnectAttempts: _consecutivePollFailures,
+            LastConnectedAt: _connectedAt,
+            LastDisconnectedAt: _disconnectedAt,
+            LastHeartbeatReceivedAt: _lastSuccessfulApiCallAt,
+            LastMessageReceivedAt: _lastMessageReceivedAt,
+            LastReconnectAttemptAt: _lastPollAttemptAt,
+            LastError: _lastError,
+            LastFailureKind: null,
+            ConnectionAge: _connected && _connectedAt is { } connectedAt ? now - connectedAt : null,
+            IdleDuration: _lastMessageReceivedAt is { } lastMessageAt ? now - lastMessageAt : null,
+            ActiveSubscriptions: ActiveSubscriptionCount);
+    }
+
+    // ── Hooks for derived providers ─────────────────────────────────────────
+
+    /// <summary>
+    /// Performs a single poll cycle across the provider's subscriptions, returning
+    /// <see langword="true"/> when the cycle succeeded and <see langword="false"/> when it failed
+    /// (which drives the shared degraded-state backoff). Implementations should update poll
+    /// diagnostics via the protected <c>Record*</c> helpers.
+    /// </summary>
+    protected abstract Task<bool> PollOnceAsync(CancellationToken ct);
+
+    /// <summary>Current number of active subscriptions, surfaced in diagnostics.</summary>
+    protected abstract int ActiveSubscriptionCount { get; }
+
+    // ── Diagnostics mutators for derived providers ──────────────────────────
+
+    protected void RecordPollAttempt() => _lastPollAttemptAt = DateTimeOffset.UtcNow;
+    protected void RecordSuccessfulApiCall() => _lastSuccessfulApiCallAt = DateTimeOffset.UtcNow;
+    protected void RecordMessageReceived() => _lastMessageReceivedAt = DateTimeOffset.UtcNow;
+    protected void RecordError(string message) => _lastError = message;
+    protected void ClearError() => _lastError = null;
+    protected void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
+
+    /// <summary>Transitions the lifecycle state and raises <see cref="ConnectionDiagnosticsChanged"/>.</summary>
+    protected void SetLifecycleState(ProviderConnectionLifecycleState state)
+    {
+        if (_lifecycleState == state)
+            return;
+
+        _lifecycleState = state;
+        Log.LogInformation("{Provider} lifecycle state changed to {LifecycleState}", _providerName, state);
+
+        try
+        {
+            ConnectionDiagnosticsChanged?.Invoke(GetConnectionDiagnosticsSnapshot());
+        }
+        catch (Exception ex)
+        {
+            Log.LogWarning(ex, "{Provider} connection diagnostics subscriber threw", _providerName);
+        }
+    }
+
+    // ── Polling loop ────────────────────────────────────────────────────────
+
+    private async Task RunPollLoopAsync(CancellationToken ct)
+    {
+        Log.LogInformation("{Provider} poll loop started", _providerName);
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(PollInterval, ct).ConfigureAwait(false);
+
+                var pollSucceeded = await PollOnceAsync(ct).ConfigureAwait(false);
+
+                if (pollSucceeded)
+                {
+                    _consecutivePollFailures = 0;
+                    if (_lifecycleState is ProviderConnectionLifecycleState.Degraded)
+                        SetLifecycleState(ProviderConnectionLifecycleState.Connected);
+                }
+                else
+                {
+                    _consecutivePollFailures++;
+                    if (_lifecycleState is not ProviderConnectionLifecycleState.Failed)
+                        SetLifecycleState(ProviderConnectionLifecycleState.Degraded);
+                    var backoff = CalculatePollBackoff(_consecutivePollFailures);
+                    Log.LogWarning(
+                        "{Provider} polling degraded after {Failures} consecutive failed poll cycles; backing off for {Delay}",
+                        _providerName,
+                        _consecutivePollFailures,
+                        backoff);
+                    await Task.Delay(backoff, ct).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
+        {
+            Log.LogError(ex, "{Provider} poll loop failed unexpectedly", _providerName);
+        }
+        finally
+        {
+            Log.LogInformation("{Provider} poll loop stopped", _providerName);
+        }
+    }
+
+    /// <summary>Exponential backoff (capped at 30s) applied after consecutive failed poll cycles.</summary>
+    private static TimeSpan CalculatePollBackoff(int consecutiveFailures)
+    {
+        var attempt = Math.Clamp(consecutiveFailures, 1, 5);
+        var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt - 1));
+        return delay > TimeSpan.FromSeconds(30) ? TimeSpan.FromSeconds(30) : delay;
+    }
+}

--- a/src/Meridian.Infrastructure/Adapters/Core/ProviderHealthTracker.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/ProviderHealthTracker.cs
@@ -1,0 +1,56 @@
+using System.Collections.Concurrent;
+
+namespace Meridian.Infrastructure.Adapters.Core;
+
+/// <summary>
+/// Tracks per-provider health status and short-lived failure backoff for the
+/// <see cref="CompositeHistoricalDataProvider"/>. Extracted so the composite provider does not
+/// own health/backoff bookkeeping directly (single-responsibility collaborator).
+/// </summary>
+internal sealed class ProviderHealthTracker
+{
+    private readonly ConcurrentDictionary<string, ProviderHealthStatus> _healthStatus = new();
+    private readonly ConcurrentDictionary<string, DateTimeOffset> _providerFailures = new();
+    private readonly TimeSpan _failureBackoffDuration;
+
+    public ProviderHealthTracker(IEnumerable<string> providerNames, TimeSpan failureBackoffDuration)
+    {
+        _failureBackoffDuration = failureBackoffDuration;
+        foreach (var name in providerNames)
+        {
+            _healthStatus[name] = new ProviderHealthStatus(name, true, "Not checked");
+        }
+    }
+
+    /// <summary>Current health status of all tracked providers.</summary>
+    public IReadOnlyDictionary<string, ProviderHealthStatus> Health => _healthStatus;
+
+    /// <summary>
+    /// Whether the provider is currently within its post-failure backoff window and should be skipped.
+    /// </summary>
+    public bool IsInBackoffPeriod(string providerName)
+        => _providerFailures.TryGetValue(providerName, out var failedAt)
+           && DateTimeOffset.UtcNow - failedAt < _failureBackoffDuration;
+
+    /// <summary>Record a provider failure, starting its backoff window and marking it unhealthy.</summary>
+    public void RecordFailure(string providerName, string message)
+    {
+        _providerFailures[providerName] = DateTimeOffset.UtcNow;
+        UpdateHealth(providerName, isAvailable: false, message);
+    }
+
+    /// <summary>Clear a provider's failure state after a successful call.</summary>
+    public void ClearFailure(string providerName)
+        => _providerFailures.TryRemove(providerName, out _);
+
+    /// <summary>Update the recorded health status for a provider.</summary>
+    public void UpdateHealth(string providerName, bool isAvailable, string? message = null, TimeSpan? responseTime = null)
+    {
+        _healthStatus[providerName] = new ProviderHealthStatus(
+            providerName,
+            isAvailable,
+            message,
+            DateTimeOffset.UtcNow,
+            responseTime);
+    }
+}

--- a/src/Meridian.Infrastructure/Adapters/Core/ProviderRotationStrategy.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/ProviderRotationStrategy.cs
@@ -1,0 +1,102 @@
+namespace Meridian.Infrastructure.Adapters.Core;
+
+/// <summary>
+/// Rate-limit-aware rotation policy for the <see cref="CompositeHistoricalDataProvider"/>.
+/// Decides the order in which providers are attempted and how long to wait for a rate-limit
+/// reset before retrying. Rate-limit <em>state</em> lives in the injected
+/// <see cref="ProviderRateLimitTracker"/>; this collaborator owns only the ordering and
+/// wait <em>policy</em>.
+/// </summary>
+internal sealed class ProviderRotationStrategy
+{
+    // A single rate-limit reset longer than this is treated as "not worth waiting for"; the
+    // request fails fast rather than blocking on it.
+    private static readonly TimeSpan MaxSingleRateLimitWait = TimeSpan.FromMinutes(5);
+
+    // Upper bound on the random jitter added to each rate-limit wait so that many concurrent
+    // requests do not resume in lock-step and hammer the provider at the same instant.
+    private static readonly TimeSpan RateLimitRetryJitter = TimeSpan.FromSeconds(1);
+
+    private readonly ProviderRateLimitTracker _rateLimitTracker;
+    private readonly double _approachingThreshold;
+
+    public ProviderRotationStrategy(
+        ProviderRateLimitTracker rateLimitTracker,
+        bool enabled,
+        double approachingThreshold)
+    {
+        _rateLimitTracker = rateLimitTracker;
+        Enabled = enabled;
+        _approachingThreshold = approachingThreshold;
+    }
+
+    /// <summary>Whether rate-limit aware rotation is enabled.</summary>
+    public bool Enabled { get; }
+
+    /// <summary>
+    /// Order a provider set by rate-limit capacity when rotation is enabled: providers with
+    /// capacity first, then those approaching their limit, then rate-limited ones last. When
+    /// rotation is disabled the input order (priority order) is preserved.
+    /// </summary>
+    public IEnumerable<IHistoricalDataProvider> OrderByAvailability(IEnumerable<IHistoricalDataProvider> providers)
+    {
+        if (!Enabled)
+            return providers;
+
+        return providers.OrderBy(p =>
+        {
+            if (_rateLimitTracker.IsRateLimited(p.Name))
+                return 1000; // Put rate-limited providers last
+
+            if (_rateLimitTracker.IsApproachingLimit(p.Name, _approachingThreshold))
+                return 100 + (int)(_rateLimitTracker.GetStatus(p.Name)?.UsagePercent ?? 0);
+
+            return p.Priority;
+        });
+    }
+
+    /// <summary>
+    /// Determine how long to wait for the earliest provider rate-limit reset before the next
+    /// retry, honoring the overall <paramref name="retryDeadline"/> budget and adding jitter.
+    /// Returns <see langword="null"/> when waiting is not worthwhile (no reset known, the reset
+    /// is too far out, or the remaining budget is exhausted), signalling the caller to fail fast.
+    /// </summary>
+    public TimeSpan? ComputeRateLimitWait(IEnumerable<IHistoricalDataProvider> providers, DateTimeOffset retryDeadline)
+    {
+        var shortestWait = providers
+            .Select(p => _rateLimitTracker.GetTimeUntilReset(p.Name))
+            .Where(w => w.HasValue)
+            .Min();
+
+        if (!shortestWait.HasValue || shortestWait.Value >= MaxSingleRateLimitWait)
+            return null;
+
+        var remaining = retryDeadline - DateTimeOffset.UtcNow;
+        if (remaining <= TimeSpan.Zero || shortestWait.Value > remaining)
+            return null;
+
+        // Add bounded random jitter so concurrent requests don't resume in lock-step.
+        var jitterMs = Random.Shared.Next(0, (int)RateLimitRetryJitter.TotalMilliseconds + 1);
+        var wait = shortestWait.Value + TimeSpan.FromMilliseconds(jitterMs);
+
+        // Never let jitter push the wait past the remaining budget.
+        return wait > remaining ? remaining : wait;
+    }
+
+    // --- Rate-limit state operations (delegated to the tracker) ---
+
+    public bool IsRateLimited(string providerName) => _rateLimitTracker.IsRateLimited(providerName);
+
+    public TimeSpan? GetTimeUntilReset(string providerName) => _rateLimitTracker.GetTimeUntilReset(providerName);
+
+    public void RecordRequest(string providerName) => _rateLimitTracker.RecordRequest(providerName);
+
+    public void RecordRateLimitHit(string providerName, TimeSpan? retryAfter)
+        => _rateLimitTracker.RecordRateLimitHit(providerName, retryAfter);
+
+    public void ClearRateLimitState(string providerName) => _rateLimitTracker.ClearRateLimitState(providerName);
+
+    public IReadOnlyDictionary<string, RateLimitStatus> GetAllStatus() => _rateLimitTracker.GetAllStatus();
+
+    public void Dispose() => _rateLimitTracker.Dispose();
+}

--- a/src/Meridian.Infrastructure/Adapters/NYSE/NYSEDataSource.cs
+++ b/src/Meridian.Infrastructure/Adapters/NYSE/NYSEDataSource.cs
@@ -51,7 +51,12 @@ public sealed class NYSEDataSource : DataSourceBase, IRealtimeDataSource, IHisto
 {
 
     private readonly NYSEOptions _options;
-    private readonly IHttpClientFactory _httpClientFactory;
+
+    // Shared OAuth token acquisition/caching and authenticated REST client creation.
+    private readonly NyseAccessTokenProvider _auth;
+
+    // Historical / corporate-action fetch + parse logic (wrapped here by the resilience policies).
+    private readonly NyseHistoricalDataProvider _historical;
 
     // WebSocket lifecycle managed by WebSocketConnectionManager (replaces _webSocket, _connectionCts, _receiveTask)
     private readonly WebSocketConnectionManager _wsManager;
@@ -66,10 +71,6 @@ public sealed class NYSEDataSource : DataSourceBase, IRealtimeDataSource, IHisto
     private readonly ConcurrentDictionary<int, SubscriptionInfo> _subscriptions = new();
     private readonly ConcurrentDictionary<string, int> _symbolToSubId = new();
     private int _nextSubscriptionId = 1;
-
-    private string? _accessToken;
-    private DateTimeOffset _tokenExpiry = DateTimeOffset.MinValue;
-    private readonly SemaphoreSlim _authLock = new(1, 1);
 
     private static readonly HashSet<string> SupportedMarketsSet = new(StringComparer.OrdinalIgnoreCase) { "US" };
     private static readonly HashSet<AssetClass> SupportedAssetClassesSet = new()
@@ -142,7 +143,17 @@ public sealed class NYSEDataSource : DataSourceBase, IRealtimeDataSource, IHisto
         : base(sourceOptions ?? DataSourceOptions.Default, logger)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
-        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+
+        _auth = new NyseAccessTokenProvider(
+            _options,
+            httpClientFactory,
+            logger ?? LoggingSetup.ForContext<NYSEDataSource>());
+
+        _historical = new NyseHistoricalDataProvider(
+            _auth,
+            sourceId: "nyse",
+            logger ?? LoggingSetup.ForContext<NYSEDataSource>());
 
         _wsManager = new WebSocketConnectionManager(
             providerName: "NYSE",
@@ -168,8 +179,8 @@ public sealed class NYSEDataSource : DataSourceBase, IRealtimeDataSource, IHisto
         try
         {
             // Try to obtain an access token to validate credentials
-            await EnsureAuthenticatedAsync(ct).ConfigureAwait(false);
-            return !string.IsNullOrEmpty(_accessToken);
+            await _auth.EnsureAuthenticatedAsync(ct).ConfigureAwait(false);
+            return !string.IsNullOrEmpty(_auth.AccessToken);
         }
         catch (Exception ex)
         {
@@ -182,13 +193,13 @@ public sealed class NYSEDataSource : DataSourceBase, IRealtimeDataSource, IHisto
     {
         try
         {
-            await EnsureAuthenticatedAsync(ct).ConfigureAwait(false);
+            await _auth.EnsureAuthenticatedAsync(ct).ConfigureAwait(false);
 
             // Test REST API connectivity
             using var request = new HttpRequestMessage(HttpMethod.Get, "/markets/status");
-            AddAuthHeader(request);
+            _auth.AddAuthHeader(request);
 
-            using var httpClient = CreateNyseHttpClient();
+            using var httpClient = _auth.CreateHttpClient();
             using var response = await httpClient.SendAsync(request, ct).ConfigureAwait(false);
             return response.IsSuccessStatusCode;
         }
@@ -213,7 +224,7 @@ public sealed class NYSEDataSource : DataSourceBase, IRealtimeDataSource, IHisto
         _depthUpdates.OnCompleted();
         _depthUpdates.Dispose();
 
-        _authLock.Dispose();
+        _auth.Dispose();
         _reconnectCts.Dispose();
     }
 
@@ -244,7 +255,7 @@ public sealed class NYSEDataSource : DataSourceBase, IRealtimeDataSource, IHisto
             return;
         }
 
-        await EnsureAuthenticatedAsync(ct).ConfigureAwait(false);
+        await _auth.EnsureAuthenticatedAsync(ct).ConfigureAwait(false);
 
         if (_reconnectCts.IsCancellationRequested)
         {
@@ -258,7 +269,7 @@ public sealed class NYSEDataSource : DataSourceBase, IRealtimeDataSource, IHisto
         {
             await _wsManager.ConnectAsync(
                 new Uri(_options.EffectiveWebSocketUrl),
-                ws => ws.Options.SetRequestHeader("Authorization", $"Bearer {_accessToken}"),
+                ws => ws.Options.SetRequestHeader("Authorization", $"Bearer {_auth.AccessToken}"),
                 ct).ConfigureAwait(false);
 
             Status = DataSourceStatus.Connected;
@@ -443,322 +454,46 @@ public sealed class NYSEDataSource : DataSourceBase, IRealtimeDataSource, IHisto
         return adjusted.Select(b => b.ToHistoricalBar(preferAdjusted: false)).ToList();
     }
 
-    public async Task<IReadOnlyList<AdjustedHistoricalBar>> GetAdjustedDailyBarsAsync(
+    public Task<IReadOnlyList<AdjustedHistoricalBar>> GetAdjustedDailyBarsAsync(
         string symbol,
         DateOnly? from = null,
         DateOnly? to = null,
         CancellationToken ct = default)
-    {
-        return await ExecuteWithPoliciesAsync(async token =>
-        {
-            await EnsureAuthenticatedAsync(token).ConfigureAwait(false);
+        => ExecuteWithPoliciesAsync(
+            token => _historical.FetchAdjustedDailyBarsAsync(symbol, from, to, token),
+            "GetAdjustedDailyBars",
+            ct);
 
-            var fromDate = from ?? DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1));
-            var toDate = to ?? DateOnly.FromDateTime(DateTime.UtcNow);
-
-            var url = $"/historical/bars/{symbol}?from={fromDate:yyyy-MM-dd}&to={toDate:yyyy-MM-dd}&adjusted=true";
-
-            using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            AddAuthHeader(request);
-
-            using var httpClient = CreateNyseHttpClient();
-            using var response = await httpClient.SendAsync(request, token).ConfigureAwait(false);
-            response.EnsureSuccessStatusCode();
-
-            var json = await response.Content.ReadAsStringAsync(token).ConfigureAwait(false);
-            var data = JsonSerializer.Deserialize<NYSEHistoricalBarsResponse>(json);
-
-            if (data?.Bars == null || data.Bars.Count == 0)
-            {
-                Log.Information("No historical bars returned from NYSE for {Symbol}", symbol);
-                return Array.Empty<AdjustedHistoricalBar>();
-            }
-
-            var bars = new List<AdjustedHistoricalBar>();
-
-            foreach (var bar in data.Bars)
-            {
-                if (!ProviderDateParsing.TryParseProviderDate(bar.Date, out var sessionDate))
-                {
-                    Log.Warning("Skipping NYSE bar for {Symbol} with unparseable date {Date}", symbol, bar.Date);
-                    continue;
-                }
-
-                try
-                {
-                    bars.Add(new AdjustedHistoricalBar(
-                        Symbol: symbol.ToUpperInvariant(),
-                        SessionDate: sessionDate,
-                        Open: bar.Open,
-                        High: bar.High,
-                        Low: bar.Low,
-                        Close: bar.Close,
-                        Volume: bar.Volume,
-                        Source: Id,
-                        SequenceNumber: bar.SequenceNumber ?? 0,
-                        AdjustedOpen: bar.AdjustedOpen,
-                        AdjustedHigh: bar.AdjustedHigh,
-                        AdjustedLow: bar.AdjustedLow,
-                        AdjustedClose: bar.AdjustedClose,
-                        AdjustedVolume: bar.AdjustedVolume,
-                        SplitFactor: bar.SplitFactor,
-                        DividendAmount: bar.DividendAmount
-                    ));
-                }
-                catch (Exception ex)
-                {
-                    Log.Warning(ex, "Failed to parse NYSE bar for {Symbol} on {Date}", symbol, bar.Date);
-                }
-            }
-
-            Log.Information("Fetched {Count} historical bars from NYSE for {Symbol}", bars.Count, symbol);
-            return bars.OrderBy(b => b.SessionDate).ToArray();
-        }, "GetAdjustedDailyBars", ct).ConfigureAwait(false);
-    }
-
-    public async Task<IReadOnlyList<IntradayBar>> GetIntradayBarsAsync(
+    public Task<IReadOnlyList<IntradayBar>> GetIntradayBarsAsync(
         string symbol,
         string interval,
         DateTimeOffset? from = null,
         DateTimeOffset? to = null,
         CancellationToken ct = default)
-    {
-        return await ExecuteWithPoliciesAsync(async token =>
-        {
-            await EnsureAuthenticatedAsync(token).ConfigureAwait(false);
+        => ExecuteWithPoliciesAsync(
+            token => _historical.FetchIntradayBarsAsync(symbol, interval, from, to, token),
+            "GetIntradayBars",
+            ct);
 
-            var fromTime = from ?? DateTimeOffset.UtcNow.AddDays(-5);
-            var toTime = to ?? DateTimeOffset.UtcNow;
-
-            var url = $"/historical/intraday/{symbol}?from={fromTime:O}&to={toTime:O}&interval={interval}";
-
-            using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            AddAuthHeader(request);
-
-            using var httpClient = CreateNyseHttpClient();
-            using var response = await httpClient.SendAsync(request, token).ConfigureAwait(false);
-            response.EnsureSuccessStatusCode();
-
-            var json = await response.Content.ReadAsStringAsync(token).ConfigureAwait(false);
-            var data = JsonSerializer.Deserialize<NYSEIntradayBarsResponse>(json);
-
-            if (data?.Bars == null || data.Bars.Count == 0)
-            {
-                return Array.Empty<IntradayBar>();
-            }
-
-            return data.Bars.Select(bar => new IntradayBar(
-                Symbol: symbol.ToUpperInvariant(),
-                Timestamp: DateTimeOffset.Parse(bar.Timestamp),
-                Interval: interval,
-                Open: bar.Open,
-                High: bar.High,
-                Low: bar.Low,
-                Close: bar.Close,
-                Volume: bar.Volume,
-                Source: Id,
-                TradeCount: bar.TradeCount,
-                VWAP: bar.Vwap
-            )).OrderBy(b => b.Timestamp).ToArray();
-        }, "GetIntradayBars", ct).ConfigureAwait(false);
-    }
-
-    public async Task<IReadOnlyList<DividendInfo>> GetDividendsAsync(
+    public Task<IReadOnlyList<DividendInfo>> GetDividendsAsync(
         string symbol,
         DateOnly? from = null,
         DateOnly? to = null,
         CancellationToken ct = default)
-    {
-        return await ExecuteWithPoliciesAsync(async token =>
-        {
-            await EnsureAuthenticatedAsync(token).ConfigureAwait(false);
+        => ExecuteWithPoliciesAsync(
+            token => _historical.FetchDividendsAsync(symbol, from, to, token),
+            "GetDividends",
+            ct);
 
-            var fromDate = from ?? DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-5));
-            var toDate = to ?? DateOnly.FromDateTime(DateTime.UtcNow);
-
-            var url = $"/corporate-actions/dividends/{symbol}?from={fromDate:yyyy-MM-dd}&to={toDate:yyyy-MM-dd}";
-
-            using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            AddAuthHeader(request);
-
-            using var httpClient = CreateNyseHttpClient();
-            using var response = await httpClient.SendAsync(request, token).ConfigureAwait(false);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                Log.Warning("NYSE returned {Status} for dividends request for {Symbol}", response.StatusCode, symbol);
-                return Array.Empty<DividendInfo>();
-            }
-
-            var json = await response.Content.ReadAsStringAsync(token).ConfigureAwait(false);
-            var data = JsonSerializer.Deserialize<NYSEDividendsResponse>(json);
-
-            if (data?.Dividends == null || data.Dividends.Count == 0)
-            {
-                return Array.Empty<DividendInfo>();
-            }
-
-            var dividends = new List<DividendInfo>();
-            foreach (var div in data.Dividends)
-            {
-                if (!ProviderDateParsing.TryParseProviderDate(div.ExDate, out var exDate))
-                {
-                    Log.Warning("Skipping NYSE dividend for {Symbol} with unparseable ex-date {ExDate}", symbol, div.ExDate);
-                    continue;
-                }
-
-                dividends.Add(new DividendInfo(
-                    Symbol: symbol.ToUpperInvariant(),
-                    ExDate: exDate,
-                    PaymentDate: ProviderDateParsing.ParseProviderDateOrNull(div.PaymentDate),
-                    RecordDate: ProviderDateParsing.ParseProviderDateOrNull(div.RecordDate),
-                    Amount: div.Amount,
-                    Currency: div.Currency ?? "USD",
-                    Type: ParseDividendType(div.Type),
-                    Source: Id
-                ));
-            }
-
-            return dividends.OrderBy(d => d.ExDate).ToArray();
-        }, "GetDividends", ct).ConfigureAwait(false);
-    }
-
-    public async Task<IReadOnlyList<SplitInfo>> GetSplitsAsync(
+    public Task<IReadOnlyList<SplitInfo>> GetSplitsAsync(
         string symbol,
         DateOnly? from = null,
         DateOnly? to = null,
         CancellationToken ct = default)
-    {
-        return await ExecuteWithPoliciesAsync(async token =>
-        {
-            await EnsureAuthenticatedAsync(token).ConfigureAwait(false);
-
-            var fromDate = from ?? DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-10));
-            var toDate = to ?? DateOnly.FromDateTime(DateTime.UtcNow);
-
-            var url = $"/corporate-actions/splits/{symbol}?from={fromDate:yyyy-MM-dd}&to={toDate:yyyy-MM-dd}";
-
-            using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            AddAuthHeader(request);
-
-            using var httpClient = CreateNyseHttpClient();
-            using var response = await httpClient.SendAsync(request, token).ConfigureAwait(false);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                Log.Warning("NYSE returned {Status} for splits request for {Symbol}", response.StatusCode, symbol);
-                return Array.Empty<SplitInfo>();
-            }
-
-            var json = await response.Content.ReadAsStringAsync(token).ConfigureAwait(false);
-            var data = JsonSerializer.Deserialize<NYSESplitsResponse>(json);
-
-            if (data?.Splits == null || data.Splits.Count == 0)
-            {
-                return Array.Empty<SplitInfo>();
-            }
-
-            var splits = new List<SplitInfo>();
-            foreach (var split in data.Splits)
-            {
-                if (!ProviderDateParsing.TryParseProviderDate(split.ExDate, out var exDate))
-                {
-                    Log.Warning("Skipping NYSE split for {Symbol} with unparseable ex-date {ExDate}", symbol, split.ExDate);
-                    continue;
-                }
-
-                splits.Add(new SplitInfo(
-                    Symbol: symbol.ToUpperInvariant(),
-                    ExDate: exDate,
-                    SplitFrom: split.SplitFrom,
-                    SplitTo: split.SplitTo,
-                    Source: Id
-                ));
-            }
-
-            return splits.OrderBy(s => s.ExDate).ToArray();
-        }, "GetSplits", ct).ConfigureAwait(false);
-    }
-
-
-
-    private async Task EnsureAuthenticatedAsync(CancellationToken ct)
-    {
-        if (!string.IsNullOrEmpty(_accessToken) && DateTimeOffset.UtcNow < _tokenExpiry.AddMinutes(-5))
-        {
-            return;
-        }
-
-        await _authLock.WaitAsync(ct).ConfigureAwait(false);
-        try
-        {
-            if (!string.IsNullOrEmpty(_accessToken) && DateTimeOffset.UtcNow < _tokenExpiry.AddMinutes(-5))
-            {
-                return;
-            }
-
-            var apiKey = _options.ResolveApiKey();
-            var apiSecret = _options.ResolveApiSecret();
-
-            if (string.IsNullOrEmpty(apiKey) || string.IsNullOrEmpty(apiSecret))
-            {
-                throw new InvalidOperationException("NYSE API credentials not configured");
-            }
-
-            // OAuth2 client credentials flow
-            var authContent = new FormUrlEncodedContent(new Dictionary<string, string>
-            {
-                ["grant_type"] = "client_credentials",
-                ["client_id"] = _options.ResolveClientId() ?? apiKey,
-                ["client_secret"] = apiSecret
-            });
-
-            using var authRequest = new HttpRequestMessage(HttpMethod.Post, "/oauth/token")
-            {
-                Content = authContent
-            };
-
-            using var httpClient = CreateNyseHttpClient();
-            using var response = await httpClient.SendAsync(authRequest, ct).ConfigureAwait(false);
-            response.EnsureSuccessStatusCode();
-
-            var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-            var tokenResponse = JsonSerializer.Deserialize<NYSETokenResponse>(json);
-
-            _accessToken = tokenResponse?.AccessToken
-                ?? throw new InvalidOperationException("Failed to obtain NYSE access token");
-            _tokenExpiry = DateTimeOffset.UtcNow.AddSeconds(tokenResponse.ExpiresIn);
-
-            Log.Debug("Obtained NYSE access token, expires at {Expiry}", _tokenExpiry);
-        }
-        finally
-        {
-            _authLock.Release();
-        }
-    }
-
-    private void AddAuthHeader(HttpRequestMessage request)
-    {
-        if (!string.IsNullOrEmpty(_accessToken))
-        {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
-        }
-    }
-
-    /// <summary>
-    /// Creates a named <see cref="HttpClient"/> via <see cref="IHttpClientFactory"/>, setting the
-    /// dynamic <see cref="NYSEOptions.EffectiveBaseUrl"/> as the base address.  The shared handler
-    /// pool (connection lifetime, retry pipeline) is managed entirely by the factory.
-    /// </summary>
-    private HttpClient CreateNyseHttpClient()
-    {
-        var client = _httpClientFactory.CreateClient(HttpClientNames.NYSE);
-        // BaseAddress is dynamic per NYSEOptions; it must be applied to the lightweight
-        // HttpClient wrapper.  The underlying HttpMessageHandler/connection pool is
-        // owned by IHttpClientFactory and survives beyond any single HttpClient instance.
-        client.BaseAddress = new Uri(_options.EffectiveBaseUrl);
-        return client;
-    }
+        => ExecuteWithPoliciesAsync(
+            token => _historical.FetchSplitsAsync(symbol, from, to, token),
+            "GetSplits",
+            ct);
 
 
 
@@ -1008,16 +743,6 @@ public sealed class NYSEDataSource : DataSourceBase, IRealtimeDataSource, IHisto
         "delete" or "remove" => DepthOperation.Delete,
         _ => DepthOperation.Insert // Default to Insert for unrecognized operations
     };
-
-    private static DividendType ParseDividendType(string? type) => type?.ToLowerInvariant() switch
-    {
-        "special" => DividendType.Special,
-        "return" => DividendType.Return,
-        "liquidation" => DividendType.Liquidation,
-        _ => DividendType.Regular
-    };
-
-
 
     private enum SubscriptionType { Trades, Quotes, Depth }
 

--- a/src/Meridian.Infrastructure/Adapters/NYSE/NyseAccessTokenProvider.cs
+++ b/src/Meridian.Infrastructure/Adapters/NYSE/NyseAccessTokenProvider.cs
@@ -1,0 +1,118 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Meridian.Infrastructure.Http;
+using Serilog;
+
+namespace Meridian.Infrastructure.Adapters.NYSE;
+
+/// <summary>
+/// Shared OAuth2 access-token provider for the NYSE Direct adapter. Owns token acquisition,
+/// caching, and expiry, and produces authenticated REST clients/requests. Extracted from
+/// <see cref="NYSEDataSource"/> so the streaming and historical concerns share a single token
+/// cache instead of each re-implementing authentication.
+/// </summary>
+internal sealed class NyseAccessTokenProvider : IDisposable
+{
+    private readonly NYSEOptions _options;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger _log;
+    private readonly SemaphoreSlim _authLock = new(1, 1);
+
+    private string? _accessToken;
+    private DateTimeOffset _tokenExpiry = DateTimeOffset.MinValue;
+
+    public NyseAccessTokenProvider(NYSEOptions options, IHttpClientFactory httpClientFactory, ILogger log)
+    {
+        _options = options;
+        _httpClientFactory = httpClientFactory;
+        _log = log;
+    }
+
+    /// <summary>The currently cached bearer token, if any (used for the WebSocket handshake header).</summary>
+    public string? AccessToken => _accessToken;
+
+    /// <summary>
+    /// Ensures a valid (non-expired) access token is cached, obtaining a fresh one via the
+    /// OAuth2 client-credentials flow when needed. Refreshes 5 minutes before expiry.
+    /// </summary>
+    public async Task EnsureAuthenticatedAsync(CancellationToken ct)
+    {
+        if (!string.IsNullOrEmpty(_accessToken) && DateTimeOffset.UtcNow < _tokenExpiry.AddMinutes(-5))
+        {
+            return;
+        }
+
+        await _authLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (!string.IsNullOrEmpty(_accessToken) && DateTimeOffset.UtcNow < _tokenExpiry.AddMinutes(-5))
+            {
+                return;
+            }
+
+            var apiKey = _options.ResolveApiKey();
+            var apiSecret = _options.ResolveApiSecret();
+
+            if (string.IsNullOrEmpty(apiKey) || string.IsNullOrEmpty(apiSecret))
+            {
+                throw new InvalidOperationException("NYSE API credentials not configured");
+            }
+
+            // OAuth2 client credentials flow
+            var authContent = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["grant_type"] = "client_credentials",
+                ["client_id"] = _options.ResolveClientId() ?? apiKey,
+                ["client_secret"] = apiSecret
+            });
+
+            using var authRequest = new HttpRequestMessage(HttpMethod.Post, "/oauth/token")
+            {
+                Content = authContent
+            };
+
+            using var httpClient = CreateHttpClient();
+            using var response = await httpClient.SendAsync(authRequest, ct).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            var tokenResponse = JsonSerializer.Deserialize<NYSETokenResponse>(json);
+
+            _accessToken = tokenResponse?.AccessToken
+                ?? throw new InvalidOperationException("Failed to obtain NYSE access token");
+            _tokenExpiry = DateTimeOffset.UtcNow.AddSeconds(tokenResponse.ExpiresIn);
+
+            _log.Debug("Obtained NYSE access token, expires at {Expiry}", _tokenExpiry);
+        }
+        finally
+        {
+            _authLock.Release();
+        }
+    }
+
+    /// <summary>Applies the cached bearer token to the given request, if a token is available.</summary>
+    public void AddAuthHeader(HttpRequestMessage request)
+    {
+        if (!string.IsNullOrEmpty(_accessToken))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
+        }
+    }
+
+    /// <summary>
+    /// Creates a named <see cref="HttpClient"/> via <see cref="IHttpClientFactory"/>, setting the
+    /// dynamic <see cref="NYSEOptions.EffectiveBaseUrl"/> as the base address. The shared handler
+    /// pool (connection lifetime, retry pipeline) is managed entirely by the factory.
+    /// </summary>
+    public HttpClient CreateHttpClient()
+    {
+        var client = _httpClientFactory.CreateClient(HttpClientNames.NYSE);
+        // BaseAddress is dynamic per NYSEOptions; it must be applied to the lightweight
+        // HttpClient wrapper. The underlying HttpMessageHandler/connection pool is
+        // owned by IHttpClientFactory and survives beyond any single HttpClient instance.
+        client.BaseAddress = new Uri(_options.EffectiveBaseUrl);
+        return client;
+    }
+
+    public void Dispose() => _authLock.Dispose();
+}

--- a/src/Meridian.Infrastructure/Adapters/NYSE/NyseHistoricalDataProvider.cs
+++ b/src/Meridian.Infrastructure/Adapters/NYSE/NyseHistoricalDataProvider.cs
@@ -1,0 +1,262 @@
+using System.Text.Json;
+using Meridian.Contracts.Domain.Models;
+using Meridian.Domain.Models;
+using Meridian.Infrastructure.DataSources;
+using Meridian.Infrastructure.Utilities;
+using Serilog;
+
+namespace Meridian.Infrastructure.Adapters.NYSE;
+
+/// <summary>
+/// Historical and corporate-action data access for the NYSE Direct adapter (daily/adjusted bars,
+/// intraday bars, dividends, splits). Extracted from <see cref="NYSEDataSource"/> so historical
+/// fetch/parse logic is separated from the streaming lifecycle; it shares the same
+/// <see cref="NyseAccessTokenProvider"/> for authentication. The owning <see cref="NYSEDataSource"/>
+/// wraps each call in its resilience policies.
+/// </summary>
+internal sealed class NyseHistoricalDataProvider
+{
+    private readonly NyseAccessTokenProvider _auth;
+    private readonly string _sourceId;
+    private readonly ILogger _log;
+
+    public NyseHistoricalDataProvider(NyseAccessTokenProvider auth, string sourceId, ILogger log)
+    {
+        _auth = auth;
+        _sourceId = sourceId;
+        _log = log;
+    }
+
+    public async Task<IReadOnlyList<AdjustedHistoricalBar>> FetchAdjustedDailyBarsAsync(
+        string symbol,
+        DateOnly? from,
+        DateOnly? to,
+        CancellationToken token)
+    {
+        await _auth.EnsureAuthenticatedAsync(token).ConfigureAwait(false);
+
+        var fromDate = from ?? DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1));
+        var toDate = to ?? DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var url = $"/historical/bars/{symbol}?from={fromDate:yyyy-MM-dd}&to={toDate:yyyy-MM-dd}&adjusted=true";
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        _auth.AddAuthHeader(request);
+
+        using var httpClient = _auth.CreateHttpClient();
+        using var response = await httpClient.SendAsync(request, token).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync(token).ConfigureAwait(false);
+        var data = JsonSerializer.Deserialize<NYSEHistoricalBarsResponse>(json);
+
+        if (data?.Bars == null || data.Bars.Count == 0)
+        {
+            _log.Information("No historical bars returned from NYSE for {Symbol}", symbol);
+            return Array.Empty<AdjustedHistoricalBar>();
+        }
+
+        var bars = new List<AdjustedHistoricalBar>();
+
+        foreach (var bar in data.Bars)
+        {
+            if (!ProviderDateParsing.TryParseProviderDate(bar.Date, out var sessionDate))
+            {
+                _log.Warning("Skipping NYSE bar for {Symbol} with unparseable date {Date}", symbol, bar.Date);
+                continue;
+            }
+
+            try
+            {
+                bars.Add(new AdjustedHistoricalBar(
+                    Symbol: symbol.ToUpperInvariant(),
+                    SessionDate: sessionDate,
+                    Open: bar.Open,
+                    High: bar.High,
+                    Low: bar.Low,
+                    Close: bar.Close,
+                    Volume: bar.Volume,
+                    Source: _sourceId,
+                    SequenceNumber: bar.SequenceNumber ?? 0,
+                    AdjustedOpen: bar.AdjustedOpen,
+                    AdjustedHigh: bar.AdjustedHigh,
+                    AdjustedLow: bar.AdjustedLow,
+                    AdjustedClose: bar.AdjustedClose,
+                    AdjustedVolume: bar.AdjustedVolume,
+                    SplitFactor: bar.SplitFactor,
+                    DividendAmount: bar.DividendAmount
+                ));
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(ex, "Failed to parse NYSE bar for {Symbol} on {Date}", symbol, bar.Date);
+            }
+        }
+
+        _log.Information("Fetched {Count} historical bars from NYSE for {Symbol}", bars.Count, symbol);
+        return bars.OrderBy(b => b.SessionDate).ToArray();
+    }
+
+    public async Task<IReadOnlyList<IntradayBar>> FetchIntradayBarsAsync(
+        string symbol,
+        string interval,
+        DateTimeOffset? from,
+        DateTimeOffset? to,
+        CancellationToken token)
+    {
+        await _auth.EnsureAuthenticatedAsync(token).ConfigureAwait(false);
+
+        var fromTime = from ?? DateTimeOffset.UtcNow.AddDays(-5);
+        var toTime = to ?? DateTimeOffset.UtcNow;
+
+        var url = $"/historical/intraday/{symbol}?from={fromTime:O}&to={toTime:O}&interval={interval}";
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        _auth.AddAuthHeader(request);
+
+        using var httpClient = _auth.CreateHttpClient();
+        using var response = await httpClient.SendAsync(request, token).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync(token).ConfigureAwait(false);
+        var data = JsonSerializer.Deserialize<NYSEIntradayBarsResponse>(json);
+
+        if (data?.Bars == null || data.Bars.Count == 0)
+        {
+            return Array.Empty<IntradayBar>();
+        }
+
+        return data.Bars.Select(bar => new IntradayBar(
+            Symbol: symbol.ToUpperInvariant(),
+            Timestamp: DateTimeOffset.Parse(bar.Timestamp),
+            Interval: interval,
+            Open: bar.Open,
+            High: bar.High,
+            Low: bar.Low,
+            Close: bar.Close,
+            Volume: bar.Volume,
+            Source: _sourceId,
+            TradeCount: bar.TradeCount,
+            VWAP: bar.Vwap
+        )).OrderBy(b => b.Timestamp).ToArray();
+    }
+
+    public async Task<IReadOnlyList<DividendInfo>> FetchDividendsAsync(
+        string symbol,
+        DateOnly? from,
+        DateOnly? to,
+        CancellationToken token)
+    {
+        await _auth.EnsureAuthenticatedAsync(token).ConfigureAwait(false);
+
+        var fromDate = from ?? DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-5));
+        var toDate = to ?? DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var url = $"/corporate-actions/dividends/{symbol}?from={fromDate:yyyy-MM-dd}&to={toDate:yyyy-MM-dd}";
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        _auth.AddAuthHeader(request);
+
+        using var httpClient = _auth.CreateHttpClient();
+        using var response = await httpClient.SendAsync(request, token).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _log.Warning("NYSE returned {Status} for dividends request for {Symbol}", response.StatusCode, symbol);
+            return Array.Empty<DividendInfo>();
+        }
+
+        var json = await response.Content.ReadAsStringAsync(token).ConfigureAwait(false);
+        var data = JsonSerializer.Deserialize<NYSEDividendsResponse>(json);
+
+        if (data?.Dividends == null || data.Dividends.Count == 0)
+        {
+            return Array.Empty<DividendInfo>();
+        }
+
+        var dividends = new List<DividendInfo>();
+        foreach (var div in data.Dividends)
+        {
+            if (!ProviderDateParsing.TryParseProviderDate(div.ExDate, out var exDate))
+            {
+                _log.Warning("Skipping NYSE dividend for {Symbol} with unparseable ex-date {ExDate}", symbol, div.ExDate);
+                continue;
+            }
+
+            dividends.Add(new DividendInfo(
+                Symbol: symbol.ToUpperInvariant(),
+                ExDate: exDate,
+                PaymentDate: ProviderDateParsing.ParseProviderDateOrNull(div.PaymentDate),
+                RecordDate: ProviderDateParsing.ParseProviderDateOrNull(div.RecordDate),
+                Amount: div.Amount,
+                Currency: div.Currency ?? "USD",
+                Type: ParseDividendType(div.Type),
+                Source: _sourceId
+            ));
+        }
+
+        return dividends.OrderBy(d => d.ExDate).ToArray();
+    }
+
+    public async Task<IReadOnlyList<SplitInfo>> FetchSplitsAsync(
+        string symbol,
+        DateOnly? from,
+        DateOnly? to,
+        CancellationToken token)
+    {
+        await _auth.EnsureAuthenticatedAsync(token).ConfigureAwait(false);
+
+        var fromDate = from ?? DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-10));
+        var toDate = to ?? DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var url = $"/corporate-actions/splits/{symbol}?from={fromDate:yyyy-MM-dd}&to={toDate:yyyy-MM-dd}";
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        _auth.AddAuthHeader(request);
+
+        using var httpClient = _auth.CreateHttpClient();
+        using var response = await httpClient.SendAsync(request, token).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _log.Warning("NYSE returned {Status} for splits request for {Symbol}", response.StatusCode, symbol);
+            return Array.Empty<SplitInfo>();
+        }
+
+        var json = await response.Content.ReadAsStringAsync(token).ConfigureAwait(false);
+        var data = JsonSerializer.Deserialize<NYSESplitsResponse>(json);
+
+        if (data?.Splits == null || data.Splits.Count == 0)
+        {
+            return Array.Empty<SplitInfo>();
+        }
+
+        var splits = new List<SplitInfo>();
+        foreach (var split in data.Splits)
+        {
+            if (!ProviderDateParsing.TryParseProviderDate(split.ExDate, out var exDate))
+            {
+                _log.Warning("Skipping NYSE split for {Symbol} with unparseable ex-date {ExDate}", symbol, split.ExDate);
+                continue;
+            }
+
+            splits.Add(new SplitInfo(
+                Symbol: symbol.ToUpperInvariant(),
+                ExDate: exDate,
+                SplitFrom: split.SplitFrom,
+                SplitTo: split.SplitTo,
+                Source: _sourceId
+            ));
+        }
+
+        return splits.OrderBy(s => s.ExDate).ToArray();
+    }
+
+    private static DividendType ParseDividendType(string? type) => type?.ToLowerInvariant() switch
+    {
+        "special" => DividendType.Special,
+        "return" => DividendType.Return,
+        "liquidation" => DividendType.Liquidation,
+        _ => DividendType.Regular
+    };
+}

--- a/src/Meridian.Infrastructure/Adapters/Robinhood/RobinhoodMarketDataClient.cs
+++ b/src/Meridian.Infrastructure/Adapters/Robinhood/RobinhoodMarketDataClient.cs
@@ -40,7 +40,7 @@ namespace Meridian.Infrastructure.Adapters.Robinhood;
 [ImplementsAdr("ADR-004", "All async methods support CancellationToken")]
 [ImplementsAdr("ADR-005", "Attribute-based provider discovery")]
 [ImplementsAdr("ADR-010", "Uses IHttpClientFactory for HTTP connections")]
-public sealed class RobinhoodMarketDataClient : IMarketDataClient, IProviderConnectionDiagnosticsSource
+public sealed class RobinhoodMarketDataClient : PollingProviderBase, IMarketDataClient, IProviderConnectionDiagnosticsSource
 {
     private const string QuotesEndpoint = "https://api.robinhood.com/marketdata/quotes/";
     private const string EnvAccessToken = "ROBINHOOD_ACCESS_TOKEN";
@@ -51,22 +51,9 @@ public sealed class RobinhoodMarketDataClient : IMarketDataClient, IProviderConn
     private readonly QuoteCollector _quoteCollector;
     private readonly ILogger<RobinhoodMarketDataClient> _logger;
     private readonly string? _accessToken;
-    private readonly SemaphoreSlim _lifecycleLock = new(1, 1);
 
     private readonly ConcurrentDictionary<int, string> _subscriptions = new();
     private int _nextSubId;
-    private CancellationTokenSource? _pollCts;
-    private Task? _pollTask;
-    private volatile bool _connected;
-    private bool _disposed;
-    private volatile ProviderConnectionLifecycleState _lifecycleState = ProviderConnectionLifecycleState.Configured;
-    private DateTimeOffset? _connectedAt;
-    private DateTimeOffset? _disconnectedAt;
-    private DateTimeOffset? _lastPollAttemptAt;
-    private DateTimeOffset? _lastSuccessfulApiCallAt;
-    private DateTimeOffset? _lastMessageReceivedAt;
-    private string? _lastError;
-    private int _consecutivePollFailures;
     private long _dataQualityRejections;
 
     public RobinhoodMarketDataClient(
@@ -74,10 +61,11 @@ public sealed class RobinhoodMarketDataClient : IMarketDataClient, IProviderConn
         QuoteCollector quoteCollector,
         ILogger<RobinhoodMarketDataClient> logger,
         string? accessToken = null)
+        : base("Robinhood Live Quotes", logger, DefaultPollInterval)
     {
         _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
         _quoteCollector = quoteCollector ?? throw new ArgumentNullException(nameof(quoteCollector));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _logger = logger;
         _accessToken = accessToken ?? Environment.GetEnvironmentVariable(EnvAccessToken);
     }
 
@@ -105,118 +93,22 @@ public sealed class RobinhoodMarketDataClient : IMarketDataClient, IProviderConn
         "Trade tick data and market depth are not available."
     ];
 
-    // ── IProviderConnectionDiagnosticsSource ─────────────────────────────
-
-    /// <inheritdoc />
-    public event Action<WebSocketConnectionDiagnostics>? ConnectionDiagnosticsChanged;
-
-    /// <inheritdoc />
-    /// <remarks>
-    /// Robinhood polls REST rather than holding a WebSocket, so <see cref="WebSocketState"/>
-    /// is reported as <see cref="WebSocketState.None"/>; poll activity maps onto the
-    /// heartbeat/message fields and consecutive poll failures onto reconnect attempts.
-    /// </remarks>
-    public WebSocketConnectionDiagnostics GetConnectionDiagnosticsSnapshot()
-    {
-        var now = DateTimeOffset.UtcNow;
-        return new WebSocketConnectionDiagnostics(
-            ProviderName: "Robinhood Live Quotes",
-            LifecycleState: _lifecycleState,
-            WebSocketState: System.Net.WebSockets.WebSocketState.None,
-            IsConnected: _connected,
-            IsReconnecting: _connected && _consecutivePollFailures > 0,
-            ReconnectAttempts: _consecutivePollFailures,
-            LastConnectedAt: _connectedAt,
-            LastDisconnectedAt: _disconnectedAt,
-            LastHeartbeatReceivedAt: _lastSuccessfulApiCallAt,
-            LastMessageReceivedAt: _lastMessageReceivedAt,
-            LastReconnectAttemptAt: _lastPollAttemptAt,
-            LastError: _lastError,
-            LastFailureKind: null,
-            ConnectionAge: _connected && _connectedAt is { } connectedAt ? now - connectedAt : null,
-            IdleDuration: _lastMessageReceivedAt is { } lastMessageAt ? now - lastMessageAt : null,
-            ActiveSubscriptions: _subscriptions.Count);
-    }
-
     // ── IMarketDataClient ─────────────────────────────────────────────────
 
-    public bool IsEnabled => !string.IsNullOrWhiteSpace(_accessToken);
-
     /// <inheritdoc />
-    public async Task ConnectAsync(CancellationToken ct = default)
-    {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+    public override bool IsEnabled => !string.IsNullOrWhiteSpace(_accessToken);
 
-        if (string.IsNullOrWhiteSpace(_accessToken))
-        {
-            SetLifecycleState(ProviderConnectionLifecycleState.NotConfigured);
-            _lastError = "Robinhood access token is missing.";
-            throw new ConnectionException(
-                $"ROBINHOOD_ACCESS_TOKEN environment variable is not set. " +
-                "Set it to your Robinhood personal access token before connecting.");
-        }
+    /// <summary>Error recorded when a connect is attempted without a token (see base class).</summary>
+    protected override string NotEnabledError => "Robinhood access token is missing.";
 
-        await _lifecycleLock.WaitAsync(ct).ConfigureAwait(false);
-        try
-        {
-            if (_connected)
-                return;
+    /// <summary>Exception thrown by the base <c>ConnectAsync</c> when no token is configured.</summary>
+    protected override Exception CreateNotEnabledException()
+        => new ConnectionException(
+            "ROBINHOOD_ACCESS_TOKEN environment variable is not set. " +
+            "Set it to your Robinhood personal access token before connecting.");
 
-            SetLifecycleState(ProviderConnectionLifecycleState.Connecting);
-            _pollCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            _connected = true;
-            _connectedAt = DateTimeOffset.UtcNow;
-            _lastError = null;
-            _consecutivePollFailures = 0;
-            SetLifecycleState(ProviderConnectionLifecycleState.Connected);
-            _pollTask = RunPollLoopAsync(_pollCts.Token);
-            _logger.LogInformation("Robinhood market data client connected (polling interval {Interval})", DefaultPollInterval);
-        }
-        finally
-        {
-            _lifecycleLock.Release();
-        }
-    }
-
-    /// <inheritdoc />
-    public async Task DisconnectAsync(CancellationToken ct = default)
-    {
-        await _lifecycleLock.WaitAsync(ct).ConfigureAwait(false);
-        try
-        {
-            if (!_connected)
-            {
-                if (_lifecycleState is not ProviderConnectionLifecycleState.NotConfigured)
-                    SetLifecycleState(ProviderConnectionLifecycleState.Disconnected);
-                return;
-            }
-
-            SetLifecycleState(ProviderConnectionLifecycleState.Disconnecting);
-            _connected = false;
-
-            if (_pollCts is not null)
-            {
-                await _pollCts.CancelAsync().ConfigureAwait(false);
-                if (_pollTask is not null)
-                {
-                    try
-                    { await _pollTask.WaitAsync(ct).ConfigureAwait(false); }
-                    catch (OperationCanceledException) { }
-                }
-                _pollCts.Dispose();
-                _pollCts = null;
-            }
-
-            _pollTask = null;
-            _disconnectedAt = DateTimeOffset.UtcNow;
-            SetLifecycleState(ProviderConnectionLifecycleState.Disconnected);
-            _logger.LogInformation("Robinhood market data client disconnected");
-        }
-        finally
-        {
-            _lifecycleLock.Release();
-        }
-    }
+    /// <summary>Number of active quote subscriptions, surfaced in shared diagnostics.</summary>
+    protected override int ActiveSubscriptionCount => _subscriptions.Count;
 
     /// <inheritdoc />
     public int SubscribeTrades(SymbolConfig cfg)
@@ -245,7 +137,7 @@ public sealed class RobinhoodMarketDataClient : IMarketDataClient, IProviderConn
     /// <summary>Subscribe a symbol to receive polling-based BBO quote updates.</summary>
     public int SubscribeQuotes(SymbolConfig cfg)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+        ThrowIfDisposed();
         var id = Interlocked.Increment(ref _nextSubId);
         _subscriptions.TryAdd(id, cfg.Symbol.ToUpperInvariant());
         _logger.LogDebug("Robinhood subscribed quotes for {Symbol} (subId={SubId})", cfg.Symbol, id);
@@ -265,101 +157,71 @@ public sealed class RobinhoodMarketDataClient : IMarketDataClient, IProviderConn
     public RobinhoodMarketDataDiagnostics GetDiagnosticsSnapshot()
     {
         var now = DateTimeOffset.UtcNow;
-        var lastActivity = _lastMessageReceivedAt ?? _lastSuccessfulApiCallAt ?? _connectedAt;
+        var lastActivity = LastMessageReceivedAt ?? LastSuccessfulApiCallAt ?? ConnectedAt;
 
         return new RobinhoodMarketDataDiagnostics(
             ProviderId: "robinhood-live",
-            LifecycleState: _lifecycleState,
-            IsConnected: _connected,
+            LifecycleState: LifecycleState,
+            IsConnected: Connected,
             ActiveSubscriptionCount: _subscriptions.Count,
-            LastConnectedAt: _connectedAt,
-            LastDisconnectedAt: _disconnectedAt,
-            LastPollAttemptAt: _lastPollAttemptAt,
-            LastSuccessfulApiCallAt: _lastSuccessfulApiCallAt,
-            LastMessageReceivedAt: _lastMessageReceivedAt,
-            LastError: _lastError,
-            ConsecutivePollFailures: _consecutivePollFailures,
+            LastConnectedAt: ConnectedAt,
+            LastDisconnectedAt: DisconnectedAt,
+            LastPollAttemptAt: LastPollAttemptAt,
+            LastSuccessfulApiCallAt: LastSuccessfulApiCallAt,
+            LastMessageReceivedAt: LastMessageReceivedAt,
+            LastError: LastError,
+            ConsecutivePollFailures: ConsecutivePollFailures,
             DataQualityRejections: Interlocked.Read(ref _dataQualityRejections),
-            ConnectionAge: _connected && _connectedAt is not null ? now - _connectedAt.Value : null,
-            IdleDuration: lastActivity is not null ? now - lastActivity.Value : null);
+            ConnectionAge: Connected && ConnectedAt is { } connectedAt ? now - connectedAt : null,
+            IdleDuration: lastActivity is { } activityAt ? now - activityAt : null);
     }
 
-    // ── Polling loop ──────────────────────────────────────────────────────
+    // ── Polling ────────────────────────────────────────────────────────────
 
-    private async Task RunPollLoopAsync(CancellationToken ct)
+    /// <summary>
+    /// Runs one poll cycle: batches the subscribed symbols (deduplicated) and polls the
+    /// Robinhood quotes endpoint per batch. Returns <see langword="true"/> only if every batch
+    /// succeeded, so the base class can drive degraded-state backoff.
+    /// </summary>
+    protected override async Task<bool> PollOnceAsync(CancellationToken ct)
     {
-        _logger.LogInformation("Robinhood quote polling loop started");
-        try
+        var seenSymbols = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var batch = new List<string>(MaxSymbolsPerBatch);
+        var pollSucceeded = true;
+
+        foreach (var symbol in _subscriptions.Values)
         {
-            while (!ct.IsCancellationRequested)
+            ct.ThrowIfCancellationRequested();
+
+            if (!seenSymbols.Add(symbol))
             {
-                await Task.Delay(DefaultPollInterval, ct).ConfigureAwait(false);
-
-                var seenSymbols = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                var batch = new List<string>(MaxSymbolsPerBatch);
-                var pollSucceeded = true;
-
-                foreach (var symbol in _subscriptions.Values)
-                {
-                    ct.ThrowIfCancellationRequested();
-
-                    if (!seenSymbols.Add(symbol))
-                    {
-                        continue;
-                    }
-
-                    batch.Add(symbol);
-                    if (batch.Count < MaxSymbolsPerBatch)
-                    {
-                        continue;
-                    }
-
-                    pollSucceeded &= await PollBatchAsync(batch, ct).ConfigureAwait(false);
-                    batch.Clear();
-                }
-
-                if (batch.Count > 0)
-                {
-                    ct.ThrowIfCancellationRequested();
-                    pollSucceeded &= await PollBatchAsync(batch, ct).ConfigureAwait(false);
-                }
-
-                if (pollSucceeded)
-                {
-                    _consecutivePollFailures = 0;
-                    if (_lifecycleState is ProviderConnectionLifecycleState.Degraded)
-                        SetLifecycleState(ProviderConnectionLifecycleState.Connected);
-                }
-                else
-                {
-                    _consecutivePollFailures++;
-                    if (_lifecycleState is not ProviderConnectionLifecycleState.Failed)
-                        SetLifecycleState(ProviderConnectionLifecycleState.Degraded);
-                    var backoff = CalculatePollBackoff(_consecutivePollFailures);
-                    _logger.LogWarning(
-                        "Robinhood quote polling degraded after {Failures} consecutive failed poll cycles; backing off for {Delay}",
-                        _consecutivePollFailures,
-                        backoff);
-                    await Task.Delay(backoff, ct).ConfigureAwait(false);
-                }
+                continue;
             }
+
+            batch.Add(symbol);
+            if (batch.Count < MaxSymbolsPerBatch)
+            {
+                continue;
+            }
+
+            pollSucceeded &= await PollBatchAsync(batch, ct).ConfigureAwait(false);
+            batch.Clear();
         }
-        catch (OperationCanceledException) { }
-        catch (Exception ex)
+
+        if (batch.Count > 0)
         {
-            _logger.LogError(ex, "Robinhood quote polling loop failed unexpectedly");
+            ct.ThrowIfCancellationRequested();
+            pollSucceeded &= await PollBatchAsync(batch, ct).ConfigureAwait(false);
         }
-        finally
-        {
-            _logger.LogInformation("Robinhood quote polling loop stopped");
-        }
+
+        return pollSucceeded;
     }
 
     private async Task<bool> PollBatchAsync(IReadOnlyList<string> symbols, CancellationToken ct)
     {
         try
         {
-            _lastPollAttemptAt = DateTimeOffset.UtcNow;
+            RecordPollAttempt();
             using var client = CreateHttpClient();
             var symbolList = string.Join(",", symbols);
             var url = $"{QuotesEndpoint}?symbols={Uri.EscapeDataString(symbolList)}";
@@ -371,7 +233,7 @@ public sealed class RobinhoodMarketDataClient : IMarketDataClient, IProviderConn
 
             if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
             {
-                _lastError = "Provider returned Unauthorized while polling Robinhood quotes. Refresh or replace the stored access token.";
+                RecordError("Provider returned Unauthorized while polling Robinhood quotes. Refresh or replace the stored access token.");
                 SetLifecycleState(ProviderConnectionLifecycleState.Failed);
                 _logger.LogWarning("Robinhood quote polling: 401 Unauthorized — access token may have expired");
                 return false;
@@ -379,7 +241,7 @@ public sealed class RobinhoodMarketDataClient : IMarketDataClient, IProviderConn
 
             if (!response.IsSuccessStatusCode)
             {
-                _lastError = $"Provider returned HTTP {(int)response.StatusCode} while polling Robinhood quotes.";
+                RecordError($"Provider returned HTTP {(int)response.StatusCode} while polling Robinhood quotes.");
                 _logger.LogWarning(
                     "Robinhood quote polling: HTTP {StatusCode} for batch {Symbols}",
                     response.StatusCode, string.Join(",", symbols));
@@ -393,8 +255,8 @@ public sealed class RobinhoodMarketDataClient : IMarketDataClient, IProviderConn
 
             if (result?.Results is null)
             {
-                _lastSuccessfulApiCallAt = DateTimeOffset.UtcNow;
-                _lastError = null;
+                RecordSuccessfulApiCall();
+                ClearError();
                 return true;
             }
 
@@ -436,10 +298,10 @@ public sealed class RobinhoodMarketDataClient : IMarketDataClient, IProviderConn
                 publishedAny = true;
             }
 
-            _lastSuccessfulApiCallAt = DateTimeOffset.UtcNow;
+            RecordSuccessfulApiCall();
             if (publishedAny)
-                _lastMessageReceivedAt = _lastSuccessfulApiCallAt;
-            _lastError = null;
+                RecordMessageReceived();
+            ClearError();
             return true;
         }
         catch (OperationCanceledException)
@@ -448,7 +310,7 @@ public sealed class RobinhoodMarketDataClient : IMarketDataClient, IProviderConn
         }
         catch (Exception ex)
         {
-            _lastError = ex.Message;
+            RecordError(ex.Message);
             _logger.LogError(ex, "Robinhood quote poll error for batch {Symbols}", string.Join(",", symbols));
             return false;
         }
@@ -469,40 +331,6 @@ public sealed class RobinhoodMarketDataClient : IMarketDataClient, IProviderConn
         if (!string.IsNullOrEmpty(_accessToken))
         {
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
-        }
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (_disposed)
-            return;
-        _disposed = true;
-        await DisconnectAsync().ConfigureAwait(false);
-        _lifecycleLock.Dispose();
-    }
-
-    private static TimeSpan CalculatePollBackoff(int consecutiveFailures)
-    {
-        var attempt = Math.Clamp(consecutiveFailures, 1, 5);
-        var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt - 1));
-        return delay > TimeSpan.FromSeconds(30) ? TimeSpan.FromSeconds(30) : delay;
-    }
-
-    private void SetLifecycleState(ProviderConnectionLifecycleState state)
-    {
-        if (_lifecycleState == state)
-            return;
-
-        _lifecycleState = state;
-        _logger.LogInformation("Robinhood market data lifecycle state changed to {LifecycleState}", state);
-
-        try
-        {
-            ConnectionDiagnosticsChanged?.Invoke(GetConnectionDiagnosticsSnapshot());
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Robinhood connection diagnostics subscriber threw");
         }
     }
 


### PR DESCRIPTION
## Summary

Extracts three cohesive concerns out of large provider classes, preserving behavior. Part of a provider-adapter code-review remediation pass (the earlier items — dead-code removal, a shared `ProviderDateParsing` utility, Composite failover + time budget/jitter, Polygon-on-base, `*Constants.cs` standardization, builder retirement, Robinhood per-request auth — already landed on `main` via #2169). This PR carries the remaining three structural splits.

### Changes
- **Composite provider (#6):** split `CompositeHistoricalDataProvider` into
  - `ProviderHealthTracker` — per-provider health status + failure backoff
  - `ProviderRotationStrategy` — rate-limit-aware ordering + wait/jitter policy over `ProviderRateLimitTracker`
  - `CrossProviderValidator` — best-effort cross-provider price validation
- **NYSE (#11):** `NYSEDataSource` (1138 → 894 lines) now delegates to
  - `NyseAccessTokenProvider` — shared OAuth token lifecycle, `AddAuthHeader`, authenticated `HttpClient`
  - `NyseHistoricalDataProvider` — bars / intraday / dividends / splits fetch + parse

  The data source stays the streaming coordinator and keeps its `IRealtimeDataSource`/`IHistoricalDataSource` contract and DI registration unchanged.
- **Robinhood (#12):** new `PollingProviderBase` (the polling counterpart to `WebSocketProviderBase`) owns connect/disconnect lifecycle, honest diagnostics, and degraded-state backoff. `RobinhoodMarketDataClient` (566 → 393 lines) now implements only `PollOnceAsync` plus provider specifics; the reflection-tested `PollBatchAsync` seam is preserved.

### Validation
- `Meridian.Infrastructure` builds clean against `main`.
- Behavior preserved — existing suites pass: `CompositeHistoricalDataProviderTests` (23), NYSE (112), Robinhood (62), `MarketDataClientFactoryTests` (12).
- No public contract, `[DataSource]` discovery, or DI-registration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)