### PR TITLE
Harden Identity authentication paths: coverage, data-integrity logging, least-privilege, dedup

### DIFF
--- a/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
@@ -63,6 +63,7 @@ using Meridian.Workflow.EnvironmentDesign;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Meridian.Application.Composition.Features;
@@ -139,7 +140,9 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
             {
                 var storageOptions = sp.GetRequiredService<StorageOptions>();
                 var persistencePath = Path.Combine(storageOptions.RootPath, "governance", "user-access-assignments.json");
-                return new FileScopedAccessAssignmentStore(persistencePath);
+                return new FileScopedAccessAssignmentStore(
+                    persistencePath,
+                    sp.GetService<ILogger<FileScopedAccessAssignmentStore>>());
             });
         }
         services.TryAddSingleton<IAccessScopeLineageProvider, FundStructureAccessScopeLineageProvider>();

--- a/src/Meridian.Identity/Application/FundStructureAccessScopeLineageProvider.cs
+++ b/src/Meridian.Identity/Application/FundStructureAccessScopeLineageProvider.cs
@@ -27,9 +27,17 @@ public sealed class FundStructureAccessScopeLineageProvider : IAccessScopeLineag
         var graph = await _fundStructureService.GetOrganizationStructureAsync(
             new OrganizationStructureQuery(ActiveOnly: false, AsOf: asOf),
             ct).ConfigureAwait(false);
-        var nodeKinds = graph.Nodes.ToDictionary(
-            static node => node.NodeId,
-            static node => ToAccessScopeKind(node.Kind));
+        // Only nodes whose kind maps to a known access scope contribute an authorizing scope.
+        // An unmapped node kind is deliberately excluded (least privilege): it never widens
+        // authority, while ancestor traversal still continues through it via the ownership links.
+        var nodeKinds = new Dictionary<Guid, AccessScopeKindDto>();
+        foreach (var node in graph.Nodes)
+        {
+            if (TryMapAccessScopeKind(node.Kind, out var mappedKind))
+            {
+                nodeKinds[node.NodeId] = mappedKind;
+            }
+        }
         var parentByChild = graph.OwnershipLinks
             .Where(link => link.EffectiveTo is null || link.EffectiveTo > asOf)
             .GroupBy(static link => link.ChildNodeId)
@@ -66,18 +74,46 @@ public sealed class FundStructureAccessScopeLineageProvider : IAccessScopeLineag
         return scopes;
     }
 
-    private static AccessScopeKindDto ToAccessScopeKind(FundStructureNodeKindDto kind)
-        => kind switch
+    /// <summary>
+    /// Maps a fund-structure node kind to its authorizing access scope. Returns
+    /// <see langword="false"/> for any unmapped kind so callers can omit it from the scope
+    /// lineage rather than defaulting to the highest-privilege <see cref="AccessScopeKindDto.Global"/>
+    /// scope (which would widen authority).
+    /// </summary>
+    private static bool TryMapAccessScopeKind(FundStructureNodeKindDto kind, out AccessScopeKindDto scopeKind)
+    {
+        switch (kind)
         {
-            FundStructureNodeKindDto.Organization => AccessScopeKindDto.Organization,
-            FundStructureNodeKindDto.Business => AccessScopeKindDto.Business,
-            FundStructureNodeKindDto.Client => AccessScopeKindDto.Client,
-            FundStructureNodeKindDto.Fund => AccessScopeKindDto.Fund,
-            FundStructureNodeKindDto.Sleeve => AccessScopeKindDto.Sleeve,
-            FundStructureNodeKindDto.Vehicle => AccessScopeKindDto.Vehicle,
-            FundStructureNodeKindDto.InvestmentPortfolio => AccessScopeKindDto.InvestmentPortfolio,
-            FundStructureNodeKindDto.Entity => AccessScopeKindDto.LegalEntity,
-            FundStructureNodeKindDto.Account => AccessScopeKindDto.Account,
-            _ => AccessScopeKindDto.Global
-        };
+            case FundStructureNodeKindDto.Organization:
+                scopeKind = AccessScopeKindDto.Organization;
+                return true;
+            case FundStructureNodeKindDto.Business:
+                scopeKind = AccessScopeKindDto.Business;
+                return true;
+            case FundStructureNodeKindDto.Client:
+                scopeKind = AccessScopeKindDto.Client;
+                return true;
+            case FundStructureNodeKindDto.Fund:
+                scopeKind = AccessScopeKindDto.Fund;
+                return true;
+            case FundStructureNodeKindDto.Sleeve:
+                scopeKind = AccessScopeKindDto.Sleeve;
+                return true;
+            case FundStructureNodeKindDto.Vehicle:
+                scopeKind = AccessScopeKindDto.Vehicle;
+                return true;
+            case FundStructureNodeKindDto.InvestmentPortfolio:
+                scopeKind = AccessScopeKindDto.InvestmentPortfolio;
+                return true;
+            case FundStructureNodeKindDto.Entity:
+                scopeKind = AccessScopeKindDto.LegalEntity;
+                return true;
+            case FundStructureNodeKindDto.Account:
+                scopeKind = AccessScopeKindDto.Account;
+                return true;
+            default:
+                scopeKind = default;
+                return false;
+        }
+    }
 }

--- a/src/Meridian.Identity/Application/IdentityGovernanceNormalization.cs
+++ b/src/Meridian.Identity/Application/IdentityGovernanceNormalization.cs
@@ -1,0 +1,62 @@
+namespace Meridian.Identity;
+
+/// <summary>
+/// Shared normalization helpers for Identity governance stores and services.
+/// Centralizes actor resolution, required-value normalization, correlation-id defaulting,
+/// and audit-id generation that were previously duplicated across
+/// <see cref="FileUserAccountStore"/>, <see cref="ScopedAccessService"/>, and
+/// <see cref="FileRolePermissionProfileStore"/>.
+/// </summary>
+internal static class IdentityGovernanceNormalization
+{
+    /// <summary>Length of the <c>yyyyMMddHHmmssfff</c> timestamp component used in audit ids.</summary>
+    private const string AuditTimestampFormat = "yyyyMMddHHmmssfff";
+
+    /// <summary>
+    /// Trims <paramref name="value"/> and throws when it is null, empty, or whitespace.
+    /// </summary>
+    public static string NormalizeRequired(string? value, string parameterName)
+    {
+        var trimmed = value?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+        {
+            throw new ArgumentException($"{parameterName} is required.", parameterName);
+        }
+
+        return trimmed;
+    }
+
+    /// <summary>
+    /// Resolves the effective actor for a governed mutation: an explicit authenticated
+    /// <paramref name="actor"/> wins, otherwise the request-supplied
+    /// <paramref name="requestedBy"/> is required.
+    /// </summary>
+    public static string ResolveActor(string? actor, string? requestedBy)
+    {
+        if (!string.IsNullOrWhiteSpace(actor))
+        {
+            return actor.Trim();
+        }
+
+        return NormalizeRequired(requestedBy, "RequestedBy");
+    }
+
+    /// <summary>
+    /// Returns the trimmed <paramref name="correlationId"/>, or a deterministic
+    /// <paramref name="prefix"/>-scoped value when none is supplied.
+    /// </summary>
+    public static string NormalizeCorrelationId(string? correlationId, string prefix)
+        => string.IsNullOrWhiteSpace(correlationId)
+            ? $"{prefix}-{Guid.NewGuid():N}"
+            : correlationId.Trim();
+
+    /// <summary>
+    /// Builds a governance audit id of the form <c>{prefix}-{timestamp}-{guid}</c>, truncated to
+    /// <paramref name="maxLength"/> characters.
+    /// </summary>
+    public static string NewAuditId(string prefix, DateTimeOffset timestamp, int maxLength = 64)
+    {
+        var value = $"{prefix}-{timestamp.ToString(AuditTimestampFormat, System.Globalization.CultureInfo.InvariantCulture)}-{Guid.NewGuid():N}";
+        return value[..Math.Min(maxLength, value.Length)];
+    }
+}

--- a/src/Meridian.Identity/Application/ScopedAccessServices.cs
+++ b/src/Meridian.Identity/Application/ScopedAccessServices.cs
@@ -84,7 +84,7 @@ public sealed class ScopedAccessService : IScopedAccessAssignmentService, IScope
         EnsureHumanOrigin(request.ActionOrigin, "grant scoped access assignments");
         var normalized = ValidateCreate(request, actor);
         var now = DateTimeOffset.UtcNow;
-        var auditId = BuildAuditId("access-grant", now);
+        var auditId = IdentityGovernanceNormalization.NewAuditId("access-grant", now, maxLength: 46);
         var correlationId = string.IsNullOrWhiteSpace(request.CorrelationId)
             ? $"access-grant-{Guid.NewGuid():N}"
             : request.CorrelationId.Trim();
@@ -125,8 +125,8 @@ public sealed class ScopedAccessService : IScopedAccessAssignmentService, IScope
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureHumanOrigin(request.ActionOrigin, "revoke scoped access assignments");
-        var resolvedActor = NormalizeRequired(actor, nameof(actor));
-        var rationale = NormalizeRequired(request.Rationale, nameof(request.Rationale));
+        var resolvedActor = IdentityGovernanceNormalization.NormalizeRequired(actor, nameof(actor));
+        var rationale = IdentityGovernanceNormalization.NormalizeRequired(request.Rationale, nameof(request.Rationale));
         var existing = await _store.GetAsync(request.AssignmentId, ct).ConfigureAwait(false)
             ?? throw new KeyNotFoundException($"Access assignment '{request.AssignmentId}' was not found.");
 
@@ -136,7 +136,7 @@ public sealed class ScopedAccessService : IScopedAccessAssignmentService, IScope
         }
 
         var now = DateTimeOffset.UtcNow;
-        var auditId = BuildAuditId("access-revoke", now);
+        var auditId = IdentityGovernanceNormalization.NewAuditId("access-revoke", now, maxLength: 46);
         var correlationId = string.IsNullOrWhiteSpace(request.CorrelationId)
             ? $"access-revoke-{Guid.NewGuid():N}"
             : request.CorrelationId.Trim();
@@ -239,12 +239,10 @@ public sealed class ScopedAccessService : IScopedAccessAssignmentService, IScope
 
     private static ValidatedCreateRequest ValidateCreate(UserAccessAssignmentCreateRequestDto request, string actor)
     {
-        var principalId = NormalizeRequired(request.PrincipalId, nameof(request.PrincipalId));
-        var resolvedActor = string.IsNullOrWhiteSpace(actor)
-            ? NormalizeRequired(request.RequestedBy, nameof(request.RequestedBy))
-            : actor.Trim();
-        var rationale = NormalizeRequired(request.Rationale, nameof(request.Rationale));
-        var roleName = NormalizeRequired(request.Role, nameof(request.Role));
+        var principalId = IdentityGovernanceNormalization.NormalizeRequired(request.PrincipalId, nameof(request.PrincipalId));
+        var resolvedActor = IdentityGovernanceNormalization.ResolveActor(actor, request.RequestedBy);
+        var rationale = IdentityGovernanceNormalization.NormalizeRequired(request.Rationale, nameof(request.Rationale));
+        var roleName = IdentityGovernanceNormalization.NormalizeRequired(request.Role, nameof(request.Role));
         if (!Enum.TryParse<UserRole>(roleName, ignoreCase: true, out var role))
         {
             throw new ArgumentException($"Unknown role '{request.Role}'.", nameof(request));
@@ -323,17 +321,6 @@ public sealed class ScopedAccessService : IScopedAccessAssignmentService, IScope
         return scopeId;
     }
 
-    private static string NormalizeRequired(string? value, string parameterName)
-    {
-        var normalized = value?.Trim();
-        if (string.IsNullOrWhiteSpace(normalized))
-        {
-            throw new ArgumentException($"{parameterName} is required.", parameterName);
-        }
-
-        return normalized;
-    }
-
     private static void EnsureHumanOrigin(OperationsActionOriginDto actionOrigin, string action)
     {
         if (actionOrigin != OperationsActionOriginDto.HumanOperator)
@@ -369,12 +356,6 @@ public sealed class ScopedAccessService : IScopedAccessAssignmentService, IScope
         Guid? scopeId,
         string reason)
         => new(false, actor, permission, scopeKind, scopeId, reason);
-
-    private static string BuildAuditId(string prefix, DateTimeOffset now)
-    {
-        var value = $"{prefix}-{now:yyyyMMddHHmmssfff}-{Guid.NewGuid():N}";
-        return value[..Math.Min(46, value.Length)];
-    }
 
     private static UserAccessAssignmentAuditEventDto BuildAuditEvent(
         string eventType,

--- a/src/Meridian.Identity/Infrastructure/RolePermissionProfileStore.cs
+++ b/src/Meridian.Identity/Infrastructure/RolePermissionProfileStore.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 using Meridian.Identity.Auth;
 using Meridian.Storage;
 using Meridian.Storage.Archival;
+using Microsoft.Extensions.Logging;
 
 namespace Meridian.Identity;
 
@@ -29,11 +30,13 @@ public sealed class FileRolePermissionProfileStore : IRolePermissionProfileStore
     private readonly object _gate = new();
     private readonly SemaphoreSlim _writeGate = new(1, 1);
     private readonly string _path;
+    private readonly ILogger<FileRolePermissionProfileStore>? _logger;
 
-    public FileRolePermissionProfileStore(StorageOptions storageOptions)
+    public FileRolePermissionProfileStore(StorageOptions storageOptions, ILogger<FileRolePermissionProfileStore>? logger = null)
     {
         ArgumentNullException.ThrowIfNull(storageOptions);
         _path = Path.Combine(storageOptions.RootPath, "governance", "role-permission-profiles.json");
+        _logger = logger;
     }
 
     public Task<RolePermissionCatalogDto> GetCatalogAsync(CancellationToken ct = default)
@@ -65,10 +68,8 @@ public sealed class FileRolePermissionProfileStore : IRolePermissionProfileStore
         ArgumentNullException.ThrowIfNull(request);
         var validated = Validate(request, actor);
         var now = DateTimeOffset.UtcNow;
-        var auditId = $"role-profile-{now:yyyyMMddHHmmssfff}-{Guid.NewGuid():N}"[..46];
-        var correlationId = string.IsNullOrWhiteSpace(request.CorrelationId)
-            ? $"settings-role-profile-{Guid.NewGuid():N}"
-            : request.CorrelationId.Trim();
+        var auditId = IdentityGovernanceNormalization.NewAuditId("role-profile", now, maxLength: 46);
+        var correlationId = IdentityGovernanceNormalization.NormalizeCorrelationId(request.CorrelationId, "settings-role-profile");
 
         await _writeGate.WaitAsync(ct).ConfigureAwait(false);
         try
@@ -142,8 +143,14 @@ public sealed class FileRolePermissionProfileStore : IRolePermissionProfileStore
                     JsonOptions);
                 return snapshot ?? new RolePermissionProfileSnapshot([]);
             }
-            catch (JsonException)
+            catch (JsonException ex)
             {
+                // Fail safe (no custom profiles) so built-in roles still resolve, but surface the
+                // data-integrity problem instead of silently masking a corrupt governance file.
+                _logger?.LogError(
+                    ex,
+                    "Corrupt role-permission-profile governance file at {Path}; treating as no custom profiles. Manual data-integrity review required.",
+                    _path);
                 return new RolePermissionProfileSnapshot([]);
             }
         }
@@ -177,7 +184,7 @@ public sealed class FileRolePermissionProfileStore : IRolePermissionProfileStore
         RolePermissionProfileUpsertRequestDto request,
         string actor)
     {
-        var profileName = NormalizeDisplayValue(request.ProfileName, nameof(request.ProfileName));
+        var profileName = IdentityGovernanceNormalization.NormalizeRequired(request.ProfileName, nameof(request.ProfileName));
         var profileKey = ProfileKey(profileName);
         if (profileKey.Length == 0)
         {
@@ -189,7 +196,7 @@ public sealed class FileRolePermissionProfileStore : IRolePermissionProfileStore
             throw new ArgumentException("Custom role profile names cannot replace a built-in role.", nameof(request));
         }
 
-        var displayName = NormalizeDisplayValue(request.DisplayName, nameof(request.DisplayName));
+        var displayName = IdentityGovernanceNormalization.NormalizeRequired(request.DisplayName, nameof(request.DisplayName));
         var description = string.IsNullOrWhiteSpace(request.Description)
             ? $"Custom authority profile based on {request.BaseRole}."
             : request.Description.Trim();
@@ -209,10 +216,8 @@ public sealed class FileRolePermissionProfileStore : IRolePermissionProfileStore
             throw new ArgumentException("At least one permission is required.", nameof(request));
         }
 
-        var rationale = NormalizeDisplayValue(request.Rationale, nameof(request.Rationale));
-        var resolvedActor = string.IsNullOrWhiteSpace(actor)
-            ? NormalizeDisplayValue(request.RequestedBy, nameof(request.RequestedBy))
-            : actor.Trim();
+        var rationale = IdentityGovernanceNormalization.NormalizeRequired(request.Rationale, nameof(request.Rationale));
+        var resolvedActor = IdentityGovernanceNormalization.ResolveActor(actor, request.RequestedBy);
 
         return new ValidatedRolePermissionProfile(
             ProfileName: profileName,
@@ -224,17 +229,6 @@ public sealed class FileRolePermissionProfileStore : IRolePermissionProfileStore
             Permissions: permissions,
             Actor: resolvedActor,
             Rationale: rationale);
-    }
-
-    private static string NormalizeDisplayValue(string? value, string parameterName)
-    {
-        var normalized = value?.Trim();
-        if (string.IsNullOrWhiteSpace(normalized))
-        {
-            throw new ArgumentException($"{parameterName} is required.", parameterName);
-        }
-
-        return normalized;
     }
 
     private static string NormalizeProfileName(string? value) => ProfileKey(value ?? string.Empty);

--- a/src/Meridian.Identity/Infrastructure/ScopedAccessAssignmentStore.cs
+++ b/src/Meridian.Identity/Infrastructure/ScopedAccessAssignmentStore.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Meridian.Identity.Auth;
 using Meridian.Storage.Archival;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 
 namespace Meridian.Identity;
@@ -36,10 +37,12 @@ public sealed class FileScopedAccessAssignmentStore : IScopedAccessAssignmentSto
 
     private readonly string _path;
     private readonly object _gate = new();
+    private readonly ILogger<FileScopedAccessAssignmentStore>? _logger;
 
-    public FileScopedAccessAssignmentStore(string path)
+    public FileScopedAccessAssignmentStore(string path, ILogger<FileScopedAccessAssignmentStore>? logger = null)
     {
         _path = path ?? throw new ArgumentNullException(nameof(path));
+        _logger = logger;
     }
 
     public Task<IReadOnlyList<UserAccessAssignmentDto>> ListAsync(CancellationToken ct = default)
@@ -132,8 +135,15 @@ public sealed class FileScopedAccessAssignmentStore : IScopedAccessAssignmentSto
             return JsonSerializer.Deserialize<ScopedAccessAssignmentSnapshot>(json, JsonOptions)
                 ?? new ScopedAccessAssignmentSnapshot([]);
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
+            // Fail safe (no assignments) so authorization keeps evaluating, but surface the
+            // data-integrity problem instead of silently masking a corrupt governance file as
+            // "no scoped access assignments exist".
+            _logger?.LogError(
+                ex,
+                "Corrupt scoped-access-assignment governance file at {Path}; treating as no assignments. Manual data-integrity review required.",
+                _path);
             return new ScopedAccessAssignmentSnapshot([]);
         }
     }

--- a/src/Meridian.Identity/Infrastructure/UserAccountStore.cs
+++ b/src/Meridian.Identity/Infrastructure/UserAccountStore.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 using Meridian.Identity.Auth;
 using Meridian.Storage;
 using Meridian.Storage.Archival;
+using Microsoft.Extensions.Logging;
 
 namespace Meridian.Identity;
 
@@ -57,12 +58,14 @@ public sealed class FileUserAccountStore : IUserAccountStore
     private readonly SemaphoreSlim _writeGate = new(1, 1);
     private readonly string _path;
     private readonly string _auditPath;
+    private readonly ILogger<FileUserAccountStore>? _logger;
 
-    public FileUserAccountStore(StorageOptions storageOptions)
+    public FileUserAccountStore(StorageOptions storageOptions, ILogger<FileUserAccountStore>? logger = null)
     {
         ArgumentNullException.ThrowIfNull(storageOptions);
         _path = Path.Combine(storageOptions.RootPath, "governance", "user-accounts.json");
         _auditPath = Path.Combine(storageOptions.RootPath, "governance", "user-account-audit.jsonl");
+        _logger = logger;
     }
 
     public bool HasAccounts => ReadSnapshot().Accounts.Count > 0;
@@ -119,13 +122,15 @@ public sealed class FileUserAccountStore : IUserAccountStore
                     events.Add(auditEvent);
                 }
             }
-            catch (JsonException)
+            catch (JsonException ex)
             {
                 // Keep the account surface available even if one historical audit line is corrupt.
+                _logger?.LogWarning(ex, "Skipping corrupt user-account audit line in {Path}.", _auditPath);
             }
-            catch (NotSupportedException)
+            catch (NotSupportedException ex)
             {
                 // Keep the account surface available even if one historical audit line is corrupt.
+                _logger?.LogWarning(ex, "Skipping unreadable user-account audit line in {Path}.", _auditPath);
             }
         }
 
@@ -165,8 +170,8 @@ public sealed class FileUserAccountStore : IUserAccountStore
                 throw new ArgumentException("A new account requires NewPassword or PasswordHash.", nameof(request));
             }
 
-            var auditId = NewAuditId("user-account");
-            var correlationId = NormalizeCorrelationId(request.CorrelationId, "user-account-upsert");
+            var auditId = IdentityGovernanceNormalization.NewAuditId("user-account", now);
+            var correlationId = IdentityGovernanceNormalization.NormalizeCorrelationId(request.CorrelationId, "user-account-upsert");
             var persisted = new PersistedUserAccount(
                 Username: validated.Username,
                 PasswordHash: passwordHash,
@@ -230,10 +235,10 @@ public sealed class FileUserAccountStore : IUserAccountStore
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
-        var username = NormalizeRequired(request.Username, nameof(request.Username));
+        var username = IdentityGovernanceNormalization.NormalizeRequired(request.Username, nameof(request.Username));
         var accountKey = AccountKey(username);
-        var resolvedActor = ResolveActor(actor, request.RequestedBy);
-        var rationale = NormalizeRequired(request.Rationale, nameof(request.Rationale));
+        var resolvedActor = IdentityGovernanceNormalization.ResolveActor(actor, request.RequestedBy);
+        var rationale = IdentityGovernanceNormalization.NormalizeRequired(request.Rationale, nameof(request.Rationale));
         var passwordHash = ResolvePasswordHash(request.NewPassword, request.PasswordHash, existingHash: null)
             ?? throw new ArgumentException("Password reset requires NewPassword or PasswordHash.", nameof(request));
         var now = DateTimeOffset.UtcNow;
@@ -250,7 +255,7 @@ public sealed class FileUserAccountStore : IUserAccountStore
             }
 
             var existing = accounts[index];
-            var auditId = NewAuditId("user-password-reset");
+            var auditId = IdentityGovernanceNormalization.NewAuditId("user-password-reset", now);
             var updated = existing with
             {
                 PasswordHash = passwordHash,
@@ -271,7 +276,7 @@ public sealed class FileUserAccountStore : IUserAccountStore
                 resolvedActor,
                 dto,
                 rationale,
-                NormalizeCorrelationId(request.CorrelationId, "user-password-reset"),
+                IdentityGovernanceNormalization.NormalizeCorrelationId(request.CorrelationId, "user-password-reset"),
                 revokedSessionCount);
             await AppendAuditAsync(auditEvent, ct).ConfigureAwait(false);
             return new UserAccountMutationResultDto(dto, auditEvent, revokedSessionCount);
@@ -289,10 +294,10 @@ public sealed class FileUserAccountStore : IUserAccountStore
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
-        var username = NormalizeRequired(request.Username, nameof(request.Username));
+        var username = IdentityGovernanceNormalization.NormalizeRequired(request.Username, nameof(request.Username));
         var accountKey = AccountKey(username);
-        var resolvedActor = ResolveActor(actor, request.RequestedBy);
-        var rationale = NormalizeRequired(request.Rationale, nameof(request.Rationale));
+        var resolvedActor = IdentityGovernanceNormalization.ResolveActor(actor, request.RequestedBy);
+        var rationale = IdentityGovernanceNormalization.NormalizeRequired(request.Rationale, nameof(request.Rationale));
         var now = DateTimeOffset.UtcNow;
 
         await _writeGate.WaitAsync(ct).ConfigureAwait(false);
@@ -307,7 +312,7 @@ public sealed class FileUserAccountStore : IUserAccountStore
             }
 
             var existing = accounts[index];
-            var auditId = NewAuditId(request.IsDisabled ? "user-account-disabled" : "user-account-enabled");
+            var auditId = IdentityGovernanceNormalization.NewAuditId(request.IsDisabled ? "user-account-disabled" : "user-account-enabled", now);
             var updated = existing with
             {
                 IsDisabled = request.IsDisabled,
@@ -328,7 +333,7 @@ public sealed class FileUserAccountStore : IUserAccountStore
                 resolvedActor,
                 dto,
                 rationale,
-                NormalizeCorrelationId(request.CorrelationId, request.IsDisabled ? "user-account-disabled" : "user-account-enabled"),
+                IdentityGovernanceNormalization.NormalizeCorrelationId(request.CorrelationId, request.IsDisabled ? "user-account-disabled" : "user-account-enabled"),
                 revokedSessionCount);
             await AppendAuditAsync(auditEvent, ct).ConfigureAwait(false);
             return new UserAccountMutationResultDto(dto, auditEvent, revokedSessionCount);
@@ -346,11 +351,11 @@ public sealed class FileUserAccountStore : IUserAccountStore
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
-        var resolvedActor = ResolveActor(actor, request.RequestedBy);
-        var rationale = NormalizeRequired(request.Rationale, nameof(request.Rationale));
+        var resolvedActor = IdentityGovernanceNormalization.ResolveActor(actor, request.RequestedBy);
+        var rationale = IdentityGovernanceNormalization.NormalizeRequired(request.Rationale, nameof(request.Rationale));
         var now = DateTimeOffset.UtcNow;
-        var auditId = NewAuditId("user-session-revoked");
-        var correlationId = NormalizeCorrelationId(request.CorrelationId, "user-session-revoke");
+        var auditId = IdentityGovernanceNormalization.NewAuditId("user-session-revoked", now);
+        var correlationId = IdentityGovernanceNormalization.NormalizeCorrelationId(request.CorrelationId, "user-session-revoke");
         var username = string.IsNullOrWhiteSpace(request.Username) ? "*" : request.Username.Trim();
 
         var auditEvent = new UserAccountAuditEventDto(
@@ -396,8 +401,15 @@ public sealed class FileUserAccountStore : IUserAccountStore
                     JsonOptions);
                 return snapshot ?? new UserAccountSnapshot([]);
             }
-            catch (JsonException)
+            catch (JsonException ex)
             {
+                // Fail safe (no accounts) so the surface stays available, but surface the
+                // data-integrity problem instead of silently masking a corrupt governance file
+                // as "no accounts exist".
+                _logger?.LogError(
+                    ex,
+                    "Corrupt user-account governance file at {Path}; treating as no accounts. Manual data-integrity review required.",
+                    _path);
                 return new UserAccountSnapshot([]);
             }
         }
@@ -431,7 +443,7 @@ public sealed class FileUserAccountStore : IUserAccountStore
         string rationale,
         string actor)
     {
-        var normalizedUsername = NormalizeRequired(username, nameof(username));
+        var normalizedUsername = IdentityGovernanceNormalization.NormalizeRequired(username, nameof(username));
         if (!Enum.TryParse<UserRole>(role?.Trim(), ignoreCase: true, out var parsedRole))
         {
             throw new ArgumentException($"Unknown role '{role}'.", nameof(role));
@@ -462,8 +474,8 @@ public sealed class FileUserAccountStore : IUserAccountStore
             string.IsNullOrWhiteSpace(companyId) ? null : companyId.Trim(),
             resolvedPermissionNames,
             permissions,
-            ResolveActor(actor, requestedBy),
-            NormalizeRequired(rationale, nameof(rationale)));
+            IdentityGovernanceNormalization.ResolveActor(actor, requestedBy),
+            IdentityGovernanceNormalization.NormalizeRequired(rationale, nameof(rationale)));
     }
 
     private static string? ResolvePasswordHash(string? newPassword, string? passwordHash, string? existingHash)
@@ -540,35 +552,6 @@ public sealed class FileUserAccountStore : IUserAccountStore
 
     private static UserRole ParseRole(string role)
         => Enum.TryParse<UserRole>(role, ignoreCase: true, out var parsed) ? parsed : UserRole.ReadOnly;
-
-    private static string NormalizeRequired(string? value, string parameterName)
-    {
-        var trimmed = value?.Trim();
-        if (string.IsNullOrWhiteSpace(trimmed))
-        {
-            throw new ArgumentException($"{parameterName} is required.", parameterName);
-        }
-
-        return trimmed;
-    }
-
-    private static string ResolveActor(string? actor, string? requestedBy)
-    {
-        if (!string.IsNullOrWhiteSpace(actor))
-        {
-            return actor.Trim();
-        }
-
-        return NormalizeRequired(requestedBy, nameof(requestedBy));
-    }
-
-    private static string NormalizeCorrelationId(string? correlationId, string prefix)
-        => string.IsNullOrWhiteSpace(correlationId)
-            ? $"{prefix}-{Guid.NewGuid():N}"
-            : correlationId.Trim();
-
-    private static string NewAuditId(string prefix)
-        => $"{prefix}-{DateTimeOffset.UtcNow:yyyyMMddHHmmssfff}-{Guid.NewGuid():N}"[..Math.Min(64, prefix.Length + 1 + 17 + 1 + 32)];
 
     private static string AccountKey(string username)
         => username.Trim().ToLowerInvariant();

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -134,7 +134,9 @@ public static class WorkstationServiceCollectionExtensions
             {
                 var storageOptions = sp.GetRequiredService<StorageOptions>();
                 var persistencePath = Path.Combine(storageOptions.RootPath, "governance", "user-access-assignments.json");
-                return new FileScopedAccessAssignmentStore(persistencePath);
+                return new FileScopedAccessAssignmentStore(
+                    persistencePath,
+                    sp.GetService<ILogger<FileScopedAccessAssignmentStore>>());
             });
         }
         services.TryAddSingleton<ScopedAccessService>();

--- a/src/Meridian.Wpf/Services/DesktopAuthenticationSession.cs
+++ b/src/Meridian.Wpf/Services/DesktopAuthenticationSession.cs
@@ -38,6 +38,19 @@ public sealed class DesktopAuthenticationSession(LoginSessionService loginSessio
 
     public UserPermission? CurrentPermissions => CurrentUser?.Permissions;
 
+    /// <summary>
+    /// Client-side defense-in-depth permission check for the desktop shell. When a resolved
+    /// operator profile is present, the check enforces that profile's granted
+    /// <see cref="UserProfile.Permissions"/>. Anonymous development sessions and unauthenticated
+    /// sessions have no resolved permission set, so gating defers to the authentication gates and
+    /// returns <see langword="true"/>. Server-side authorization remains authoritative in all cases.
+    /// </summary>
+    public bool HasPermission(UserPermission permission)
+    {
+        var current = CurrentPermissions;
+        return current is null || (current.Value & permission) == permission;
+    }
+
     public DesktopSignInResult SignIn(string username, string password)
     {
         if (!IsConfigured)

--- a/src/Meridian.Wpf/Services/DesktopAuthenticationSession.cs
+++ b/src/Meridian.Wpf/Services/DesktopAuthenticationSession.cs
@@ -39,16 +39,23 @@ public sealed class DesktopAuthenticationSession(LoginSessionService loginSessio
     public UserPermission? CurrentPermissions => CurrentUser?.Permissions;
 
     /// <summary>
-    /// Client-side defense-in-depth permission check for the desktop shell. When a resolved
-    /// operator profile is present, the check enforces that profile's granted
-    /// <see cref="UserProfile.Permissions"/>. Anonymous development sessions and unauthenticated
-    /// sessions have no resolved permission set, so gating defers to the authentication gates and
-    /// returns <see langword="true"/>. Server-side authorization remains authoritative in all cases.
+    /// Client-side defense-in-depth permission check for the desktop shell. Fails closed: unless
+    /// the environment explicitly permits continuing without credentials (unconfigured local
+    /// development), a resolved operator profile that grants <paramref name="permission"/> is
+    /// required. This prevents an unauthenticated Production session from being treated as fully
+    /// privileged. Server-side authorization remains authoritative in all cases.
     /// </summary>
     public bool HasPermission(UserPermission permission)
     {
+        if (CanContinueWithoutCredentials)
+        {
+            // Unconfigured local development: gating defers to the authentication gates so the
+            // local shell is not blocked.
+            return true;
+        }
+
         var current = CurrentPermissions;
-        return current is null || (current.Value & permission) == permission;
+        return current is not null && (current.Value & permission) == permission;
     }
 
     public DesktopSignInResult SignIn(string username, string password)

--- a/src/Meridian.Wpf/ViewModels/MainWindowViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/MainWindowViewModel.cs
@@ -659,9 +659,10 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
 
     private void NotifyCollectorPermissionDenied(string action)
     {
+        var gerund = action == "stop" ? "stopping" : "starting";
         _notificationService.ShowNotification(
             "Permission required",
-            $"Your role does not permit {action}ing data collection. Provider control requires the ManageProviders permission.",
+            $"Your role does not permit {gerund} data collection. Provider control requires the ManageProviders permission.",
             NotificationType.Warning,
             5000);
     }

--- a/src/Meridian.Wpf/ViewModels/MainWindowViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/MainWindowViewModel.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Windows.Media;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.Input;
+using Meridian.Identity.Auth;
 using Meridian.Ui.Services;
 using Meridian.Ui.Services.Services;
 using Meridian.Wpf.Contracts;
@@ -75,8 +76,8 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
         StatusBar = new StatusBarViewModel(statusService, notificationService);
 
         NavigateCommand = new RelayCommand<string>(Navigate);
-        StartCollectorCommand = new AsyncRelayCommand(StartCollectorAsync);
-        StopCollectorCommand = new AsyncRelayCommand(StopCollectorAsync);
+        StartCollectorCommand = new AsyncRelayCommand(StartCollectorAsync, CanControlCollector);
+        StopCollectorCommand = new AsyncRelayCommand(StopCollectorAsync, CanControlCollector);
         RefreshCommand = new RelayCommand(() => _messagingService.Send("RefreshStatus"));
         LogoutCommand = new RelayCommand(Logout, CanLogout);
         AddClipboardSymbolsCommand = new AsyncRelayCommand(AddPendingSymbolsToWatchlistAsync, () => _pendingClipboardSymbols.Count > 0);
@@ -239,7 +240,19 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
         AuthenticatedRoleText = ResolveAuthenticatedRoleText();
         AuthenticatedSessionDetail = ResolveAuthenticatedSessionDetail();
         LogoutCommand.NotifyCanExecuteChanged();
+        StartCollectorCommand.NotifyCanExecuteChanged();
+        StopCollectorCommand.NotifyCanExecuteChanged();
     }
+
+    /// <summary>
+    /// Client-side defense-in-depth gate for collector control. Starting or stopping data
+    /// collection reconfigures a provider connection, so it requires
+    /// <see cref="UserPermission.ManageProviders"/> when a signed-in operator profile is
+    /// resolved. Anonymous development and unauthenticated sessions are not gated here (they are
+    /// governed by the authentication gates); server-side authorization stays authoritative.
+    /// </summary>
+    private bool CanControlCollector()
+        => _authenticationSession.HasPermission(UserPermission.ManageProviders);
 
     public void ShowStartupExperience()
     {
@@ -584,6 +597,12 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
 
     private async Task StartCollectorAsync()
     {
+        if (!CanControlCollector())
+        {
+            NotifyCollectorPermissionDenied("start");
+            return;
+        }
+
         try
         {
             var provider = _connectionService.CurrentProvider;
@@ -613,6 +632,12 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
 
     private async Task StopCollectorAsync()
     {
+        if (!CanControlCollector())
+        {
+            NotifyCollectorPermissionDenied("stop");
+            return;
+        }
+
         try
         {
             await _connectionService.DisconnectAsync();
@@ -630,6 +655,15 @@ public sealed class MainWindowViewModel : BindableBase, IDisposable
                 NotificationType.Error,
                 0);
         }
+    }
+
+    private void NotifyCollectorPermissionDenied(string action)
+    {
+        _notificationService.ShowNotification(
+            "Permission required",
+            $"Your role does not permit {action}ing data collection. Provider control requires the ManageProviders permission.",
+            NotificationType.Warning,
+            5000);
     }
 
     private async Task TestConnectionAsync()

--- a/tests/Meridian.Tests/Identity/FileUserAccountStoreTests.cs
+++ b/tests/Meridian.Tests/Identity/FileUserAccountStoreTests.cs
@@ -1,0 +1,110 @@
+using FluentAssertions;
+using Meridian.Identity;
+using Meridian.Identity.Auth;
+using Meridian.Storage;
+using Meridian.Testing;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Meridian.Tests.Identity;
+
+/// <summary>
+/// Operator scenario: the governed user-account file is the authentication source of record. A
+/// corrupt file must fail safe (no accounts) yet surface a data-integrity signal through the
+/// injected logger, so a truncated or hand-edited governance file is not silently indistinguishable
+/// from "no accounts exist". These tests also cover the create/audit round-trip.
+/// </summary>
+public sealed class FileUserAccountStoreTests
+{
+    [Fact]
+    public void LoadAccounts_WithCorruptFile_ReturnsEmptyAndLogsDataIntegrityError()
+    {
+        using var artifacts = TestArtifactDirectory.Create(nameof(LoadAccounts_WithCorruptFile_ReturnsEmptyAndLogsDataIntegrityError));
+        WriteGovernanceFile(artifacts.RootPath, "user-accounts.json", "{ not valid json ]");
+        var logger = new CapturingLogger<FileUserAccountStore>();
+        var store = new FileUserAccountStore(new StorageOptions { RootPath = artifacts.RootPath }, logger);
+
+        var accounts = store.LoadAccounts();
+
+        accounts.Should().BeEmpty();
+        store.HasAccounts.Should().BeFalse();
+        logger.Entries.Should().Contain(entry =>
+            entry.Level == LogLevel.Error && entry.Message.Contains("Corrupt user-account", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void LoadAccounts_WithNoFile_ReturnsEmptyWithoutLoggingError()
+    {
+        using var artifacts = TestArtifactDirectory.Create(nameof(LoadAccounts_WithNoFile_ReturnsEmptyWithoutLoggingError));
+        var logger = new CapturingLogger<FileUserAccountStore>();
+        var store = new FileUserAccountStore(new StorageOptions { RootPath = artifacts.RootPath }, logger);
+
+        store.LoadAccounts().Should().BeEmpty();
+
+        logger.Entries.Should().NotContain(entry => entry.Level == LogLevel.Error);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_PersistsAccountAndAppendsAuditEvent()
+    {
+        using var artifacts = TestArtifactDirectory.Create(nameof(UpsertAsync_PersistsAccountAndAppendsAuditEvent));
+        var store = new FileUserAccountStore(new StorageOptions { RootPath = artifacts.RootPath });
+
+        var result = await store.UpsertAsync(
+            new UserAccountUpsertRequestDto(
+                Username: "fund-admin",
+                Role: nameof(UserRole.Admin),
+                RoleProfileName: null,
+                PermissionNames: null,
+                NewPassword: "initial-pw",
+                PasswordHash: null,
+                IsDisabled: null,
+                PasswordResetRequired: false,
+                RequestedBy: "provisioner",
+                Rationale: "Provision initial fund administrator."),
+            actor: "provisioner");
+
+        result.Account.Username.Should().Be("fund-admin");
+        result.AuditEvent.EventType.Should().Be("user-account-created");
+        result.AuditEvent.Actor.Should().Be("provisioner");
+        result.AuditEvent.AuditId.Should().NotBeNullOrWhiteSpace();
+
+        var reloaded = new FileUserAccountStore(new StorageOptions { RootPath = artifacts.RootPath });
+        var loaded = reloaded.LoadAccounts();
+        loaded.Should().ContainSingle().Which.Username.Should().Be("fund-admin");
+        PasswordHashing.VerifyPassword("initial-pw", loaded[0].PasswordHash).Should().BeTrue();
+
+        var audit = await reloaded.GetAuditEventsAsync();
+        audit.Should().ContainSingle(item => item.AuditId == result.AuditEvent.AuditId);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_WithoutPasswordMaterial_Throws()
+    {
+        using var artifacts = TestArtifactDirectory.Create(nameof(UpsertAsync_WithoutPasswordMaterial_Throws));
+        var store = new FileUserAccountStore(new StorageOptions { RootPath = artifacts.RootPath });
+
+        var act = () => store.UpsertAsync(
+            new UserAccountUpsertRequestDto(
+                Username: "no-secret",
+                Role: nameof(UserRole.ReadOnly),
+                RoleProfileName: null,
+                PermissionNames: null,
+                NewPassword: null,
+                PasswordHash: null,
+                IsDisabled: null,
+                PasswordResetRequired: false,
+                RequestedBy: "provisioner",
+                Rationale: "Missing password material."),
+            actor: "provisioner");
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    private static void WriteGovernanceFile(string rootPath, string fileName, string content)
+    {
+        var directory = Path.Combine(rootPath, "governance");
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(Path.Combine(directory, fileName), content);
+    }
+}

--- a/tests/Meridian.Tests/Identity/FundStructureAccessScopeLineageProviderTests.cs
+++ b/tests/Meridian.Tests/Identity/FundStructureAccessScopeLineageProviderTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using Meridian.Application.FundStructure;
+using Meridian.Contracts.FundStructure;
+using Meridian.Identity;
+using Meridian.Identity.Auth;
+using Meridian.PortfolioRecords.FundAccounts;
+using Xunit;
+
+namespace Meridian.Tests.Identity;
+
+/// <summary>
+/// Operator scenario: scoped authorization walks a fund's ownership lineage so a grant at a parent
+/// scope authorizes a child. Each ancestor must be attributed its own least-privilege scope kind;
+/// an ancestor must never be surfaced as the highest-privilege <see cref="AccessScopeKindDto.Global"/>
+/// scope, which would widen authority on the lineage path.
+/// </summary>
+public sealed class FundStructureAccessScopeLineageProviderTests
+{
+    [Fact]
+    public async Task ResolveLineageAsync_MapsEachAncestorToItsOwnScopeKindNeverGlobal()
+    {
+        var fundStructure = new InMemoryFundStructureService(new InMemoryFundAccountService());
+        var now = DateTimeOffset.UtcNow.AddMinutes(-10);
+        var orgId = Guid.NewGuid();
+        var businessId = Guid.NewGuid();
+        var fundId = Guid.NewGuid();
+
+        await fundStructure.CreateOrganizationAsync(new CreateOrganizationRequest(orgId, "ORG", "Organization", "USD", now, "test"));
+        await fundStructure.CreateBusinessAsync(new CreateBusinessRequest(businessId, orgId, BusinessKindDto.FundManager, "BUS", "Business", "USD", now, "test"));
+        await fundStructure.CreateFundAsync(new CreateFundRequest(fundId, "FUND-A", "Fund A", "USD", now, "test", BusinessId: businessId));
+
+        var provider = new FundStructureAccessScopeLineageProvider(fundStructure);
+
+        var lineage = await provider.ResolveLineageAsync(AccessScopeKindDto.Fund, fundId);
+
+        lineage.Should().Contain(new AccessScopeRef(AccessScopeKindDto.Business, businessId));
+        lineage.Should().Contain(new AccessScopeRef(AccessScopeKindDto.Organization, orgId));
+        lineage.Should().NotContain(scope => scope.ScopeKind == AccessScopeKindDto.Global,
+            "an ancestor node must never be surfaced as the highest-privilege Global scope");
+    }
+
+    [Fact]
+    public async Task ResolveLineageAsync_ForGlobalScope_ReturnsEmpty()
+    {
+        var fundStructure = new InMemoryFundStructureService(new InMemoryFundAccountService());
+        var provider = new FundStructureAccessScopeLineageProvider(fundStructure);
+
+        var lineage = await provider.ResolveLineageAsync(AccessScopeKindDto.Global, Guid.NewGuid());
+
+        lineage.Should().BeEmpty();
+    }
+}

--- a/tests/Meridian.Tests/Identity/GovernanceStoreDataIntegrityTests.cs
+++ b/tests/Meridian.Tests/Identity/GovernanceStoreDataIntegrityTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using Meridian.Identity;
+using Meridian.Storage;
+using Meridian.Testing;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Meridian.Tests.Identity;
+
+/// <summary>
+/// Operator scenario: every file-backed Identity governance store must fail safe on a corrupt file
+/// while surfacing the data-integrity problem through its injected logger, rather than silently
+/// masking corruption as an empty (unconfigured) surface.
+/// </summary>
+public sealed class GovernanceStoreDataIntegrityTests
+{
+    [Fact]
+    public async Task RolePermissionProfileStore_WithCorruptFile_LogsDataIntegrityError()
+    {
+        using var artifacts = TestArtifactDirectory.Create(nameof(RolePermissionProfileStore_WithCorruptFile_LogsDataIntegrityError));
+        WriteGovernanceFile(artifacts.RootPath, "role-permission-profiles.json", "not-json");
+        var logger = new CapturingLogger<FileRolePermissionProfileStore>();
+        var store = new FileRolePermissionProfileStore(new StorageOptions { RootPath = artifacts.RootPath }, logger);
+
+        var catalog = await store.GetCatalogAsync();
+
+        // Built-in roles still resolve; only custom profiles are suppressed.
+        catalog.Roles.Should().OnlyContain(role => role.IsBuiltIn);
+        logger.Entries.Should().Contain(entry =>
+            entry.Level == LogLevel.Error && entry.Message.Contains("Corrupt role-permission-profile", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ScopedAccessAssignmentStore_WithCorruptFile_LogsDataIntegrityError()
+    {
+        using var artifacts = TestArtifactDirectory.Create(nameof(ScopedAccessAssignmentStore_WithCorruptFile_LogsDataIntegrityError));
+        var path = Path.Combine(artifacts.RootPath, "user-access-assignments.json");
+        File.WriteAllText(path, "{ broken json");
+        var logger = new CapturingLogger<FileScopedAccessAssignmentStore>();
+        var store = new FileScopedAccessAssignmentStore(path, logger);
+
+        var assignments = await store.ListAsync();
+
+        assignments.Should().BeEmpty();
+        logger.Entries.Should().Contain(entry =>
+            entry.Level == LogLevel.Error && entry.Message.Contains("Corrupt scoped-access-assignment", StringComparison.Ordinal));
+    }
+
+    private static void WriteGovernanceFile(string rootPath, string fileName, string content)
+    {
+        var directory = Path.Combine(rootPath, "governance");
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(Path.Combine(directory, fileName), content);
+    }
+}

--- a/tests/Meridian.Tests/Identity/IdentityTestSupport.cs
+++ b/tests/Meridian.Tests/Identity/IdentityTestSupport.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Meridian.Tests.Identity;
+
+/// <summary>
+/// Serializes tests that mutate process-wide authentication environment variables
+/// (<c>MDC_USERS</c>, <c>MDC_AUTH_MODE</c>, ...) so parallel xUnit collections do not race on them.
+/// </summary>
+[CollectionDefinition("IdentityEnvironment", DisableParallelization = true)]
+public sealed class IdentityEnvironmentCollection;
+
+/// <summary>Restores mutated environment variables when disposed.</summary>
+internal sealed class EnvironmentVariableScope : IDisposable
+{
+    private readonly Dictionary<string, string?> _originalValues = new(StringComparer.Ordinal);
+
+    public EnvironmentVariableScope Set(string name, string? value)
+    {
+        if (!_originalValues.ContainsKey(name))
+        {
+            _originalValues[name] = Environment.GetEnvironmentVariable(name);
+        }
+
+        Environment.SetEnvironmentVariable(name, value);
+        return this;
+    }
+
+    public void Dispose()
+    {
+        foreach (var entry in _originalValues)
+        {
+            Environment.SetEnvironmentVariable(entry.Key, entry.Value);
+        }
+    }
+}
+
+internal sealed class FakeHostEnvironment(string environmentName) : IHostEnvironment
+{
+    public string EnvironmentName { get; set; } = environmentName;
+
+    public string ApplicationName { get; set; } = "Meridian.Tests";
+
+    public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+
+    public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+}
+
+/// <summary>Minimal capturing <see cref="ILogger{T}"/> for asserting store data-integrity logging.</summary>
+internal sealed class CapturingLogger<T> : ILogger<T>
+{
+    private readonly List<(LogLevel Level, string Message)> _entries = [];
+
+    public IReadOnlyList<(LogLevel Level, string Message)> Entries => _entries;
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+        => _entries.Add((logLevel, formatter(state, exception)));
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/Meridian.Tests/Identity/LoginSessionServiceTests.cs
+++ b/tests/Meridian.Tests/Identity/LoginSessionServiceTests.cs
@@ -1,0 +1,140 @@
+using FluentAssertions;
+using Meridian.Identity;
+using Meridian.Identity.Auth;
+using Xunit;
+
+namespace Meridian.Tests.Identity;
+
+/// <summary>
+/// Operator scenario: the desktop and web shells trade credentials for an in-memory session token
+/// and then re-validate that token on every request. These tests exercise the token lifecycle —
+/// creation, validation, profile resolution, logout, and revocation — plus the environment-driven
+/// authentication mode that governs anonymous access.
+/// </summary>
+[Collection("IdentityEnvironment")]
+public sealed class LoginSessionServiceTests
+{
+    [Fact]
+    public void CreateSession_WithValidCredentials_IssuesValidatableToken()
+    {
+        using var env = ConfigureUsers(("operator", "pw-operator", UserRole.Accounting));
+        var service = CreateService("Production");
+
+        var token = service.CreateSession("operator", "pw-operator");
+
+        token.Should().NotBeNullOrWhiteSpace();
+        service.ValidateSession(token!).Should().BeTrue();
+        var profile = service.GetSessionProfile(token!);
+        profile.Should().NotBeNull();
+        profile!.Username.Should().Be("operator");
+        profile.Role.Should().Be(UserRole.Accounting);
+    }
+
+    [Fact]
+    public void CreateSession_WithInvalidCredentials_ReturnsNull()
+    {
+        using var env = ConfigureUsers(("operator", "pw-operator", UserRole.Accounting));
+        var service = CreateService("Production");
+
+        service.CreateSession("operator", "wrong").Should().BeNull();
+        service.CreateSession("nobody", "pw-operator").Should().BeNull();
+    }
+
+    [Fact]
+    public void ValidateSession_UnknownToken_ReturnsFalse()
+    {
+        using var env = ConfigureUsers(("operator", "pw-operator", UserRole.Accounting));
+        var service = CreateService("Production");
+
+        service.ValidateSession("deadbeef").Should().BeFalse();
+        service.GetSessionProfile("deadbeef").Should().BeNull();
+    }
+
+    [Fact]
+    public void RemoveSession_InvalidatesToken()
+    {
+        using var env = ConfigureUsers(("operator", "pw-operator", UserRole.Accounting));
+        var service = CreateService("Production");
+        var token = service.CreateSession("operator", "pw-operator")!;
+
+        service.RemoveSession(token);
+
+        service.ValidateSession(token).Should().BeFalse();
+        service.GetSessionProfile(token).Should().BeNull();
+    }
+
+    [Fact]
+    public void RevokeSessionsForUser_RemovesOnlyThatUsersSessions()
+    {
+        using var env = ConfigureUsers(
+            ("alice", "pw-alice", UserRole.Accounting),
+            ("bob", "pw-bob", UserRole.Analysis));
+        var service = CreateService("Production");
+        var aliceOne = service.CreateSession("alice", "pw-alice")!;
+        var aliceTwo = service.CreateSession("alice", "pw-alice")!;
+        var bob = service.CreateSession("bob", "pw-bob")!;
+
+        var revoked = service.RevokeSessionsForUser("alice");
+
+        revoked.Should().Be(2);
+        service.ValidateSession(aliceOne).Should().BeFalse();
+        service.ValidateSession(aliceTwo).Should().BeFalse();
+        service.ValidateSession(bob).Should().BeTrue();
+    }
+
+    [Fact]
+    public void RevokeAllSessions_ClearsEveryToken()
+    {
+        using var env = ConfigureUsers(("operator", "pw-operator", UserRole.Accounting));
+        var service = CreateService("Production");
+        var token = service.CreateSession("operator", "pw-operator")!;
+
+        service.RevokeAllSessions().Should().Be(1);
+
+        service.ValidateSession(token).Should().BeFalse();
+    }
+
+    [Fact]
+    public void AuthenticationMode_ProductionUnconfigured_RequiresCredentials()
+    {
+        using var env = new EnvironmentVariableScope()
+            .Set("MDC_USERS", null)
+            .Set("MDC_USERNAME", null)
+            .Set("MDC_PASSWORD_HASH", null)
+            .Set("MDC_AUTH_MODE", null);
+        var service = CreateService("Production");
+
+        service.IsConfigured.Should().BeFalse();
+        service.AllowAnonymousWhenUnconfigured.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AuthenticationMode_DevelopmentDefault_AllowsAnonymous()
+    {
+        using var env = new EnvironmentVariableScope()
+            .Set("MDC_USERS", null)
+            .Set("MDC_USERNAME", null)
+            .Set("MDC_PASSWORD_HASH", null)
+            .Set("MDC_AUTH_MODE", null)
+            .Set("MDC_PACKAGED_BUILD", null)
+            .Set("MERIDIAN_CUSTOMER_BUILD", null);
+        var service = CreateService("Development");
+
+        service.AllowAnonymousWhenUnconfigured.Should().BeTrue();
+    }
+
+    private static LoginSessionService CreateService(string environmentName)
+        => new(new FakeHostEnvironment(environmentName), new UserProfileRegistry());
+
+    private static EnvironmentVariableScope ConfigureUsers(params (string Username, string Password, UserRole Role)[] users)
+    {
+        var entries = users.Select(user =>
+            $$"""{"username":"{{user.Username}}","passwordHash":"{{PasswordHashing.HashPassword(user.Password)}}","role":"{{user.Role}}"}""");
+        return new EnvironmentVariableScope()
+            .Set("MDC_USERS", $"[{string.Join(",", entries)}]")
+            .Set("MDC_DEMO_USERS", null)
+            .Set("MDC_USERNAME", null)
+            .Set("MDC_PASSWORD_HASH", null)
+            .Set("MDC_AUTH_MODE", null);
+    }
+}

--- a/tests/Meridian.Tests/Identity/PasswordHashingTests.cs
+++ b/tests/Meridian.Tests/Identity/PasswordHashingTests.cs
@@ -1,0 +1,81 @@
+using FluentAssertions;
+using Meridian.Identity;
+using Xunit;
+
+namespace Meridian.Tests.Identity;
+
+/// <summary>
+/// Operator scenario: local Meridian accounts are hash-backed, so the password hashing helper
+/// must round-trip correct credentials, reject wrong ones in constant time, and refuse malformed
+/// or unsupported hash material rather than silently accepting it.
+/// </summary>
+public sealed class PasswordHashingTests
+{
+    [Fact]
+    public void HashPassword_ProducesSupportedPbkdf2Format()
+    {
+        var hash = PasswordHashing.HashPassword("correct horse battery staple");
+
+        hash.Should().StartWith($"{PasswordHashing.Algorithm}$");
+        PasswordHashing.IsSupportedHash(hash).Should().BeTrue();
+        hash.Split('$').Should().HaveCount(4);
+    }
+
+    [Fact]
+    public void HashPassword_UsesRandomSaltSoTwoHashesDiffer()
+    {
+        var first = PasswordHashing.HashPassword("same-password");
+        var second = PasswordHashing.HashPassword("same-password");
+
+        first.Should().NotBe(second, "each hash must use a fresh random salt");
+        PasswordHashing.VerifyPassword("same-password", first).Should().BeTrue();
+        PasswordHashing.VerifyPassword("same-password", second).Should().BeTrue();
+    }
+
+    [Fact]
+    public void VerifyPassword_WithCorrectPassword_ReturnsTrue()
+    {
+        var hash = PasswordHashing.HashPassword("s3cret-value");
+
+        PasswordHashing.VerifyPassword("s3cret-value", hash).Should().BeTrue();
+    }
+
+    [Fact]
+    public void VerifyPassword_WithWrongPassword_ReturnsFalse()
+    {
+        var hash = PasswordHashing.HashPassword("s3cret-value");
+
+        PasswordHashing.VerifyPassword("s3cret-valuE", hash).Should().BeFalse();
+        PasswordHashing.VerifyPassword("totally-different", hash).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-hash")]
+    [InlineData("pbkdf2-sha256$0$c2FsdA==$aGFzaA==")]      // non-positive iterations
+    [InlineData("bcrypt$210000$c2FsdA==$aGFzaA==")]         // unsupported algorithm
+    [InlineData("pbkdf2-sha256$210000$not-base64$aGFzaA==")] // malformed salt
+    public void VerifyPassword_WithMalformedHash_ReturnsFalse(string malformedHash)
+    {
+        PasswordHashing.VerifyPassword("any-password", malformedHash).Should().BeFalse();
+    }
+
+    [Fact]
+    public void VerifyPassword_WithEmptyPassword_ReturnsFalse()
+    {
+        var hash = PasswordHashing.HashPassword("s3cret-value");
+
+        PasswordHashing.VerifyPassword(string.Empty, hash).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("bcrypt$210000$c2FsdA==$aGFzaA==")]
+    [InlineData("pbkdf2-sha256$abc$c2FsdA==$aGFzaA==")] // non-numeric iterations
+    public void IsSupportedHash_RejectsUnsupportedOrMalformedMaterial(string? candidate)
+    {
+        PasswordHashing.IsSupportedHash(candidate).Should().BeFalse();
+    }
+}

--- a/tests/Meridian.Tests/Identity/UserProfileRegistryTests.cs
+++ b/tests/Meridian.Tests/Identity/UserProfileRegistryTests.cs
@@ -1,0 +1,168 @@
+using FluentAssertions;
+using Meridian.Identity;
+using Meridian.Identity.Auth;
+using Xunit;
+
+namespace Meridian.Tests.Identity;
+
+/// <summary>
+/// Operator scenario: Meridian resolves who may sign in from either a governed account store or
+/// hashed environment bootstrap records. These tests exercise the authentication decision itself
+/// — credential matching, disabled accounts, store precedence, and permission resolution — rather
+/// than the downstream authorization surfaces.
+/// </summary>
+[Collection("IdentityEnvironment")]
+public sealed class UserProfileRegistryTests
+{
+    [Fact]
+    public void Authenticate_WithCorrectCredentials_ReturnsProfile()
+    {
+        using var env = ClearAuthEnvironment()
+            .Set("MDC_USERS", UsersJson(("trader", "pw-trader", UserRole.TradeDesk)));
+        var registry = new UserProfileRegistry();
+
+        var profile = registry.Authenticate("trader", "pw-trader");
+
+        profile.Should().NotBeNull();
+        profile!.Username.Should().Be("trader");
+        profile.Role.Should().Be(UserRole.TradeDesk);
+        profile.Permissions.Should().Be(RolePermissions.For(UserRole.TradeDesk));
+    }
+
+    [Fact]
+    public void Authenticate_WithWrongPassword_ReturnsNull()
+    {
+        using var env = ClearAuthEnvironment()
+            .Set("MDC_USERS", UsersJson(("trader", "pw-trader", UserRole.TradeDesk)));
+        var registry = new UserProfileRegistry();
+
+        registry.Authenticate("trader", "wrong-password").Should().BeNull();
+    }
+
+    [Fact]
+    public void Authenticate_WithUnknownUser_ReturnsNull()
+    {
+        using var env = ClearAuthEnvironment()
+            .Set("MDC_USERS", UsersJson(("trader", "pw-trader", UserRole.TradeDesk)));
+        var registry = new UserProfileRegistry();
+
+        registry.Authenticate("ghost", "pw-trader").Should().BeNull();
+    }
+
+    [Fact]
+    public void Authenticate_UsernameComparisonIsCaseSensitive()
+    {
+        using var env = ClearAuthEnvironment()
+            .Set("MDC_USERS", UsersJson(("Trader", "pw", UserRole.TradeDesk)));
+        var registry = new UserProfileRegistry();
+
+        registry.Authenticate("trader", "pw").Should().BeNull();
+        registry.Authenticate("Trader", "pw").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Authenticate_DisabledAccount_ReturnsNull()
+    {
+        var hash = PasswordHashing.HashPassword("pw");
+        using var env = ClearAuthEnvironment()
+            .Set("MDC_USERS", $$"""[{"username":"suspended","passwordHash":"{{hash}}","role":"Admin","disabled":true}]""");
+        var registry = new UserProfileRegistry();
+
+        registry.Authenticate("suspended", "pw").Should().BeNull();
+        registry.GetProfile("suspended").Should().BeNull();
+    }
+
+    [Fact]
+    public void IsConfigured_ReflectsWhetherUsableAccountsExist()
+    {
+        using (var empty = ClearAuthEnvironment())
+        {
+            new UserProfileRegistry().IsConfigured.Should().BeFalse();
+        }
+
+        using var env = ClearAuthEnvironment()
+            .Set("MDC_USERS", UsersJson(("admin", "pw", UserRole.Admin)));
+        new UserProfileRegistry().IsConfigured.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Authenticate_PrefersGovernedAccountStoreOverEnvironment()
+    {
+        // Environment provides a would-be admin, but the governed store is authoritative and
+        // does not contain that account, so environment records must be ignored entirely.
+        using var env = ClearAuthEnvironment()
+            .Set("MDC_USERS", UsersJson(("env-admin", "pw", UserRole.Admin)));
+        var store = new StubAccountStore(
+            new UserAccountConfig("store-user", PasswordHashing.HashPassword("store-pw"), UserRole.Analysis));
+        var registry = new UserProfileRegistry(roleProfileStore: null, accountStore: store);
+
+        registry.Authenticate("env-admin", "pw").Should().BeNull("the governed store suppresses environment records");
+        var stored = registry.Authenticate("store-user", "store-pw");
+        stored.Should().NotBeNull();
+        stored!.Role.Should().Be(UserRole.Analysis);
+    }
+
+    [Fact]
+    public void Authenticate_WithPermissionOverride_UsesExplicitPermissions()
+    {
+        var hash = PasswordHashing.HashPassword("pw");
+        using var env = ClearAuthEnvironment()
+            .Set("MDC_USERS", $$"""[{"username":"scoped","passwordHash":"{{hash}}","role":"ReadOnly","permissions":["ViewTrades","ExportData"]}]""");
+        var registry = new UserProfileRegistry();
+
+        var profile = registry.Authenticate("scoped", "pw");
+
+        profile.Should().NotBeNull();
+        profile!.Permissions.Should().Be(UserPermission.ViewTrades | UserPermission.ExportData);
+    }
+
+    [Fact]
+    public void Authenticate_MalformedMultiUserJson_ReturnsNullWithoutThrowing()
+    {
+        using var env = ClearAuthEnvironment()
+            .Set("MDC_USERS", "{ this is not valid json");
+        var registry = new UserProfileRegistry();
+
+        registry.IsConfigured.Should().BeFalse();
+        registry.Authenticate("anyone", "pw").Should().BeNull();
+    }
+
+    private static EnvironmentVariableScope ClearAuthEnvironment()
+        => new EnvironmentVariableScope()
+            .Set("MDC_USERS", null)
+            .Set("MDC_DEMO_USERS", null)
+            .Set("MDC_USERNAME", null)
+            .Set("MDC_PASSWORD_HASH", null);
+
+    private static string UsersJson(params (string Username, string Password, UserRole Role)[] users)
+    {
+        var entries = users.Select(user =>
+            $$"""{"username":"{{user.Username}}","passwordHash":"{{PasswordHashing.HashPassword(user.Password)}}","role":"{{user.Role}}"}""");
+        return $"[{string.Join(",", entries)}]";
+    }
+
+    private sealed class StubAccountStore(params UserAccountConfig[] accounts) : IUserAccountStore
+    {
+        public bool HasAccounts => accounts.Length > 0;
+
+        public IReadOnlyList<UserAccountConfig> LoadAccounts() => accounts;
+
+        public Task<IReadOnlyList<UserAccountDto>> GetAccountsAsync(CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<UserAccountAuditEventDto>> GetAuditEventsAsync(int? limit = null, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task<UserAccountMutationResultDto> UpsertAsync(UserAccountUpsertRequestDto request, string actor, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task<UserAccountMutationResultDto> ResetPasswordAsync(UserPasswordResetRequestDto request, string actor, int revokedSessionCount = 0, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task<UserAccountMutationResultDto> SetDisabledAsync(UserAccountDisableRequestDto request, string actor, int revokedSessionCount = 0, CancellationToken ct = default)
+            => throw new NotSupportedException();
+
+        public Task<UserSessionRevokeResultDto> RecordSessionRevocationAsync(UserSessionRevokeRequestDto request, string actor, int revokedSessionCount, CancellationToken ct = default)
+            => throw new NotSupportedException();
+    }
+}

--- a/tests/Meridian.Wpf.Tests/Services/DesktopAuthenticationSessionTests.cs
+++ b/tests/Meridian.Wpf.Tests/Services/DesktopAuthenticationSessionTests.cs
@@ -86,6 +86,22 @@ public sealed class DesktopAuthenticationSessionTests
     }
 
     [Fact]
+    public void HasPermission_WhenProductionUnauthenticated_FailsClosed()
+    {
+        using var env = new EnvironmentVariableScope()
+            .Set("MDC_USERS", null)
+            .Set("MDC_USERNAME", null)
+            .Set("MDC_PASSWORD_HASH", null)
+            .Set("MDC_AUTH_MODE", "required");
+
+        var session = CreateSession("Production");
+
+        // No signed-in profile and credentials are required: gating must fail closed.
+        session.HasPermission(UserPermission.ManageProviders).Should().BeFalse();
+        session.HasPermission(UserPermission.ViewMarketData).Should().BeFalse();
+    }
+
+    [Fact]
     public void HasPermission_WhenNoResolvedProfile_DefersToAuthenticationGates()
     {
         using var env = new EnvironmentVariableScope()

--- a/tests/Meridian.Wpf.Tests/Services/DesktopAuthenticationSessionTests.cs
+++ b/tests/Meridian.Wpf.Tests/Services/DesktopAuthenticationSessionTests.cs
@@ -54,6 +54,53 @@ public sealed class DesktopAuthenticationSessionTests
     }
 
     [Fact]
+    public void HasPermission_WhenAdminSignedIn_EnforcesGrantedPermissions()
+    {
+        using var env = new EnvironmentVariableScope()
+            .Set("MDC_USERS", HashedDesktopAdminUsersJson())
+            .Set("MDC_USERNAME", null)
+            .Set("MDC_PASSWORD_HASH", null)
+            .Set("MDC_AUTH_MODE", null);
+
+        var session = CreateSession("Production");
+        session.SignIn("desktop-admin", "pw").Succeeded.Should().BeTrue();
+
+        session.HasPermission(UserPermission.ManageProviders).Should().BeTrue();
+        session.HasPermission(UserPermission.ManageUsers).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasPermission_WhenReadOnlySignedIn_DeniesPrivilegedPermission()
+    {
+        using var env = new EnvironmentVariableScope()
+            .Set("MDC_USERS", HashedDesktopReadOnlyUsersJson())
+            .Set("MDC_USERNAME", null)
+            .Set("MDC_PASSWORD_HASH", null)
+            .Set("MDC_AUTH_MODE", null);
+
+        var session = CreateSession("Production");
+        session.SignIn("desktop-viewer", "pw").Succeeded.Should().BeTrue();
+
+        session.HasPermission(UserPermission.ManageProviders).Should().BeFalse();
+        session.HasPermission(UserPermission.ViewMarketData).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasPermission_WhenNoResolvedProfile_DefersToAuthenticationGates()
+    {
+        using var env = new EnvironmentVariableScope()
+            .Set("MDC_USERS", null)
+            .Set("MDC_USERNAME", null)
+            .Set("MDC_PASSWORD_HASH", null)
+            .Set("MDC_AUTH_MODE", "optional");
+
+        var session = CreateSession("Development");
+
+        // No signed-in operator profile: gating defers (returns true) so local development is not blocked.
+        session.HasPermission(UserPermission.ManageProviders).Should().BeTrue();
+    }
+
+    [Fact]
     public void ContinueWithoutCredentials_WhenDevelopmentAndUnconfigured_ShouldCreateAnonymousDevelopmentSession()
     {
         using var env = new EnvironmentVariableScope()
@@ -99,6 +146,9 @@ public sealed class DesktopAuthenticationSessionTests
 
     internal static string HashedDesktopAdminUsersJson()
         => $$"""[{"username":"desktop-admin","passwordHash":"{{PasswordHashing.HashPassword("pw")}}","role":"Admin"}]""";
+
+    internal static string HashedDesktopReadOnlyUsersJson()
+        => $$"""[{"username":"desktop-viewer","passwordHash":"{{PasswordHashing.HashPassword("pw")}}","role":"ReadOnly"}]""";
 
     internal sealed class EnvironmentVariableScope : IDisposable
     {

--- a/tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/MainShellViewModelTests.cs
@@ -599,6 +599,61 @@ public sealed class MainShellViewModelTests
     }
 
     [Fact]
+    public void CollectorCommands_WhenAdminSignedIn_AreEnabled()
+    {
+        using var env = new DesktopAuthenticationSessionTests.EnvironmentVariableScope()
+            .Set("MDC_USERS", DesktopAuthenticationSessionTests.HashedDesktopAdminUsersJson())
+            .Set("MDC_USERNAME", null)
+            .Set("MDC_PASSWORD_HASH", null)
+            .Set("MDC_AUTH_MODE", null);
+
+        var session = DesktopAuthenticationSessionTests.CreateSession("Production");
+        session.SignIn("desktop-admin", "pw").Succeeded.Should().BeTrue();
+
+        WpfTestThread.Run(() =>
+        {
+            using var vm = CreateMainWindowViewModel(session);
+
+            vm.StartCollectorCommand.CanExecute(null).Should().BeTrue();
+            vm.StopCollectorCommand.CanExecute(null).Should().BeTrue();
+        });
+    }
+
+    [Fact]
+    public void CollectorCommands_WhenSignedInWithoutManageProviders_AreDisabled()
+    {
+        using var env = new DesktopAuthenticationSessionTests.EnvironmentVariableScope()
+            .Set("MDC_USERS", DesktopAuthenticationSessionTests.HashedDesktopReadOnlyUsersJson())
+            .Set("MDC_USERNAME", null)
+            .Set("MDC_PASSWORD_HASH", null)
+            .Set("MDC_AUTH_MODE", null);
+
+        var session = DesktopAuthenticationSessionTests.CreateSession("Production");
+        session.SignIn("desktop-viewer", "pw").Succeeded.Should().BeTrue();
+
+        WpfTestThread.Run(() =>
+        {
+            using var vm = CreateMainWindowViewModel(session);
+
+            vm.StartCollectorCommand.CanExecute(null).Should().BeFalse();
+            vm.StopCollectorCommand.CanExecute(null).Should().BeFalse();
+        });
+    }
+
+    [Fact]
+    public void CollectorCommands_WhenUnauthenticatedDevelopmentSession_RemainEnabled()
+    {
+        WpfTestThread.Run(() =>
+        {
+            using var vm = CreateMainWindowViewModel();
+
+            // No resolved operator profile: client-side gating defers so local development is not blocked.
+            vm.StartCollectorCommand.CanExecute(null).Should().BeTrue();
+            vm.StopCollectorCommand.CanExecute(null).Should().BeTrue();
+        });
+    }
+
+    [Fact]
     public void LogoutCommand_WhenSignedIn_ShouldClearSessionAndRaiseLogoutRequest()
     {
         using var env = new DesktopAuthenticationSessionTests.EnvironmentVariableScope()


### PR DESCRIPTION
## Summary

Hardens the Meridian Identity subsystem across five findings:

- **Test coverage for the authentication paths.** Adds focused unit tests for `PasswordHashing`, `UserProfileRegistry`, and `LoginSessionService` (credential round-trip, disabled accounts, store precedence, token lifecycle, revocation, environment-driven auth mode), plus the file-backed governance stores and the fund-structure scope-lineage provider.
- **Data-integrity logging in the file-backed stores.** `FileUserAccountStore`, `FileScopedAccessAssignmentStore`, and `FileRolePermissionProfileStore` now take an optional injected logger and emit a data-integrity error when a governance file fails to deserialize, so a corrupt file no longer reads as an indistinguishable "no records exist". Behavior stays fail-safe (empty snapshot); only the observability changes.
- **Client-side permission enforcement in the WPF shell (defense-in-depth).** `DesktopAuthenticationSession.HasPermission` reads the resolved operator profile's permissions and gates the collector start/stop commands on `ManageProviders`. Anonymous development and unauthenticated sessions defer to the existing authentication gates; server-side authorization remains authoritative.
- **Least-privilege scope-lineage default.** `FundStructureAccessScopeLineageProvider` no longer defaults an unmapped node kind to the highest-privilege `Global` scope. Unmapped kinds are omitted from the scope lineage (no authority widening) while ancestor traversal continues through them.
- **De-duplicated governance helpers.** The triplicated actor / rationale / correlation-id / audit-id normalization logic is centralized in a single `IdentityGovernanceNormalization` helper consumed by the three stores/services.

## Reason

Identity had thin coverage on the actual authentication paths, three governance stores silently swallowed `JsonException` with no way to surface corruption, the WPF shell had role display but zero client-side permission enforcement, the scope-lineage mapping defaulted unmapped kinds to the highest-privilege scope, and the normalization helpers were duplicated near-identically across three files.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Note: no local .NET SDK is available in this environment, so validation is deferred to the GitHub Actions `quality-gate`. New tests cover each finding: `PasswordHashingTests`, `UserProfileRegistryTests`, `LoginSessionServiceTests`, `FileUserAccountStoreTests`, `GovernanceStoreDataIntegrityTests`, `FundStructureAccessScopeLineageProviderTests`, plus WPF `DesktopAuthenticationSession`/collector-gating tests.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed


---
_Generated by [Claude Code](https://claude.ai/code/session_01WNW3GbzPNU2ZpSYpq5RyVZ)_