### PR TITLE
Fix flaky run-bound terms cash-ladder test (deterministic clock)

### DIFF
--- a/tests/Meridian.Tests/AssetOperations/PortfolioCashLadderEngineTests.cs
+++ b/tests/Meridian.Tests/AssetOperations/PortfolioCashLadderEngineTests.cs
@@ -544,25 +544,33 @@ public sealed class PortfolioCashLadderEngineTests
             securityId, "Bond", "Superseded Terms Bond", $"CUSIP:{securityId:N}",
             ["Identity", "TermsHistory", "ProjectedCashFlows"]);
 
+        // Derive every timestamp from a single clock reading. The engine binds terms to a run by
+        // requiring terms.RecordedAt <= run.GeneratedAt, so the completed run's GeneratedAt and the
+        // run-bound terms' RecordedAt must be ordered deterministically. Two separate
+        // DateTimeOffset.UtcNow.AddDays(-2) readings are evaluated microseconds apart and would leave
+        // the terms recorded *after* the run, silently excluding them.
+        var now = DateTimeOffset.UtcNow;
+        var completedRunGeneratedAt = now.AddDays(-2);
+
         var completedRunId = Guid.NewGuid();
         var completedRun = new AssetCashFlowProjectionRunDto(
             completedRunId, securityId, AsOf.AddDays(-2), "asset-obligation-projection-v1", "Completed",
-            DateTimeOffset.UtcNow.AddDays(-2), "SecurityMaster", securityId.ToString("D"));
+            completedRunGeneratedAt, "SecurityMaster", securityId.ToString("D"));
         // Newer run failed and produced no flows; must not pull in its newer terms.
         var failedRun = new AssetCashFlowProjectionRunDto(
             Guid.NewGuid(), securityId, AsOf, "asset-obligation-projection-v1", "Failed",
-            DateTimeOffset.UtcNow, "SecurityMaster", securityId.ToString("D"));
+            now, "SecurityMaster", securityId.ToString("D"));
 
         // Terms tied to the completed run: effective and recorded on/before it, and carrying the call date.
         var runTerms = new AssetTermsVersionDto(
             Guid.NewGuid(), securityId, 1, $"security-master:{securityId:N}:1", AsOf.AddDays(-10),
-            DateTimeOffset.UtcNow.AddDays(-2), "SecurityMaster", securityId.ToString("D"),
+            completedRunGeneratedAt, "SecurityMaster", securityId.ToString("D"),
             "Superseded Terms Bond terms v1",
             JsonSerializer.SerializeToElement(new { callDate = callDate.ToString("yyyy-MM-dd") }));
         // Newer terms retained after the completed run, with no call date.
         var newerTerms = new AssetTermsVersionDto(
             Guid.NewGuid(), securityId, 2, $"security-master:{securityId:N}:2", AsOf.AddDays(-1),
-            DateTimeOffset.UtcNow, "SecurityMaster", securityId.ToString("D"),
+            now, "SecurityMaster", securityId.ToString("D"),
             "Superseded Terms Bond terms v2",
             JsonSerializer.SerializeToElement(new { note = "no call date" }));
 


### PR DESCRIPTION
## Summary

Fixes the one test that is currently red on `main`:
`Meridian.Tests.AssetOperations.PortfolioCashLadderEngineTests.Build_EarlyCallScenario_ReadsTermsBoundToSelectedRunNotNewestTerms`.

The test's `BuildCallablePositionWithSupersededTerms` helper stamped the completed run's `GeneratedAt` and the run-bound terms' `RecordedAt` with two **separate** `DateTimeOffset.UtcNow.AddDays(-2)` readings. Because the run object is constructed first, its `GeneratedAt` is a few microseconds earlier than the terms' `RecordedAt`. `PortfolioCashLadderEngine.SelectTermsForRun` binds terms to a run with `terms.RecordedAt <= run.GeneratedAt`, so the correct run-bound terms (which carry the call date) were excluded and the engine fell back to the newest terms (no call date) — yielding no `CallRedemption` flow and failing the assertion.

The change derives the run's `GeneratedAt` and the run-bound terms' `RecordedAt` from a **single** clock reading so the "recorded on/before the run" intent the test documents holds exactly and deterministically.

This is a **test-only** change — the engine's run/terms binding logic is unchanged and correct. Verified by tracing the selection: with a single `now`, `runTerms.RecordedAt == completedRun.GeneratedAt`, so the `<=` filter includes it, `newerTerms` is still excluded by its later `EffectiveDate`, and the call date resolves.

## Reason

The failure is deterministic (both timestamps use fixed offsets and `AsOf` is a fixed date), so it blocks CI on `main` and on every branch cut from it. It was introduced with the recently-merged run-bound-terms cash-ladder work, not by any product change.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — not run (no local .NET build in this environment); relying on GitHub `quality-gate`.
- [x] Root-caused against the engine's `SelectTermsForRun` binding rule and traced the corrected selection by hand.
- [ ] Relevant unit tests were added or updated — this **is** the affected unit test; behavior of the assertion is unchanged, only its fixture timing is made deterministic.
- [ ] GitHub Actions `quality-gate` passed — pending CI.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed


---
_Generated by [Claude Code](https://claude.ai/code/session_01Thw7hntsvhzzn2pCG4fQNM)_