### PR TITLE
Group SecurityMaster into rebuild/corporate-actions/validation sub-namespaces

### DIFF
--- a/src/Meridian.Application/Composition/Startup/CommandServiceRegistration.cs
+++ b/src/Meridian.Application/Composition/Startup/CommandServiceRegistration.cs
@@ -118,7 +118,7 @@ internal static class CommandServiceRegistration
         services.AddSingleton<ICliCommand>(sp => new SecurityMasterCommands(
             importService: null,
             sp.GetRequiredService<ILogger>(),
-            corporateActionIngestOrchestrator: sp.GetService<Meridian.Application.SecurityMaster.CorporateActionIngestOrchestrator>(),
+            corporateActionIngestOrchestrator: sp.GetService<Meridian.Application.SecurityMaster.CorporateActions.CorporateActionIngestOrchestrator>(),
             securityMasterEventStore: sp.GetService<Meridian.Storage.SecurityMaster.ISecurityMasterEventStore>()));
         services.TryAddSingleton(sp => new CommandDispatcher(sp.GetServices<ICliCommand>().ToArray()));
         return services;

--- a/src/Meridian.Application/GlobalUsings.SecurityMasterConcerns.cs
+++ b/src/Meridian.Application/GlobalUsings.SecurityMasterConcerns.cs
@@ -1,0 +1,6 @@
+// Re-exports the SecurityMaster concern sub-namespaces so existing consumers that reference
+// Meridian.Application.SecurityMaster keep resolving the rebuild, corporate-action, and
+// validation types that were regrouped into these sub-namespaces, without per-file using churn.
+global using Meridian.Application.SecurityMaster.CorporateActions;
+global using Meridian.Application.SecurityMaster.Rebuild;
+global using Meridian.Application.SecurityMaster.Validation;

--- a/src/Meridian.Application/SecurityMaster/CorporateActions/CorporateActionCommandService.cs
+++ b/src/Meridian.Application/SecurityMaster/CorporateActions/CorporateActionCommandService.cs
@@ -2,7 +2,7 @@ using Meridian.Contracts.SecurityMaster;
 using Meridian.Storage.SecurityMaster;
 using Microsoft.Extensions.Logging;
 
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.CorporateActions;
 
 public interface ICorporateActionCommandService
 {

--- a/src/Meridian.Application/SecurityMaster/CorporateActions/CorporateActionInboxState.cs
+++ b/src/Meridian.Application/SecurityMaster/CorporateActions/CorporateActionInboxState.cs
@@ -1,6 +1,6 @@
 using Meridian.Contracts.SecurityMaster;
 
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.CorporateActions;
 
 /// <summary>Operator request to apply one staged inbox proposal.</summary>
 public sealed record CorporateActionInboxApplyRequest(

--- a/src/Meridian.Application/SecurityMaster/CorporateActions/CorporateActionIngestOrchestrator.cs
+++ b/src/Meridian.Application/SecurityMaster/CorporateActions/CorporateActionIngestOrchestrator.cs
@@ -3,7 +3,7 @@ using Meridian.Infrastructure.Adapters.Core;
 using Meridian.Storage.SecurityMaster;
 using Microsoft.Extensions.Logging;
 
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.CorporateActions;
 
 /// <summary>
 /// Request for a corporate-action ingest sweep. When <see cref="Symbols"/> is null or empty

--- a/src/Meridian.Application/SecurityMaster/CorporateActions/CorporateActionRestatementTrigger.cs
+++ b/src/Meridian.Application/SecurityMaster/CorporateActions/CorporateActionRestatementTrigger.cs
@@ -3,7 +3,7 @@ using Meridian.Contracts.Workstation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.CorporateActions;
 
 /// <summary>
 /// Maps an accepted superseding corporate action (amendment or cancellation) to the

--- a/src/Meridian.Application/SecurityMaster/CorporateActions/CorporateActionValidation.cs
+++ b/src/Meridian.Application/SecurityMaster/CorporateActions/CorporateActionValidation.cs
@@ -1,6 +1,6 @@
 using Meridian.Contracts.SecurityMaster;
 
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.CorporateActions;
 
 internal static class CorporateActionValidation
 {

--- a/src/Meridian.Application/SecurityMaster/CorporateActions/ILivePositionCorporateActionAdjuster.cs
+++ b/src/Meridian.Application/SecurityMaster/CorporateActions/ILivePositionCorporateActionAdjuster.cs
@@ -1,4 +1,4 @@
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.CorporateActions;
 
 /// <summary>
 /// Result of applying corporate-action adjustments to a live open position.

--- a/src/Meridian.Application/SecurityMaster/CorporateActions/SecurityMasterCorporateActionCommandService.cs
+++ b/src/Meridian.Application/SecurityMaster/CorporateActions/SecurityMasterCorporateActionCommandService.cs
@@ -2,7 +2,7 @@ using Meridian.Contracts.SecurityMaster;
 using Meridian.Storage.SecurityMaster;
 using Microsoft.Extensions.Logging;
 
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.CorporateActions;
 
 public sealed class SecurityMasterCorporateActionCommandService : ISecurityMasterCorporateActionCommandService
 {

--- a/src/Meridian.Application/SecurityMaster/CorporateActions/SecurityMasterTickerChangeService.cs
+++ b/src/Meridian.Application/SecurityMaster/CorporateActions/SecurityMasterTickerChangeService.cs
@@ -2,7 +2,7 @@ using Meridian.Contracts.SecurityMaster;
 using Microsoft.Extensions.Logging;
 using ContractSecurityMasterQueryService = Meridian.Contracts.SecurityMaster.ISecurityMasterQueryService;
 
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.CorporateActions;
 
 /// <summary>
 /// Request to record a ticker change (e.g. FB→META) as a first-class security-master event.

--- a/src/Meridian.Application/SecurityMaster/Rebuild/IUflProjectionRebuilder.cs
+++ b/src/Meridian.Application/SecurityMaster/Rebuild/IUflProjectionRebuilder.cs
@@ -1,4 +1,4 @@
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.Rebuild;
 
 /// <summary>
 /// Rebuilds UFL projections for a requested asset class.

--- a/src/Meridian.Application/SecurityMaster/Rebuild/SecurityMasterAggregateRebuilder.cs
+++ b/src/Meridian.Application/SecurityMaster/Rebuild/SecurityMasterAggregateRebuilder.cs
@@ -1,7 +1,7 @@
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Storage.SecurityMaster;
 
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.Rebuild;
 
 public sealed class SecurityMasterAggregateRebuilder
 {

--- a/src/Meridian.Application/SecurityMaster/Rebuild/SecurityMasterRebuildOrchestrator.cs
+++ b/src/Meridian.Application/SecurityMaster/Rebuild/SecurityMasterRebuildOrchestrator.cs
@@ -2,7 +2,7 @@ using Meridian.Contracts.SecurityMaster;
 using Meridian.Storage.SecurityMaster;
 using Microsoft.Extensions.Logging;
 
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.Rebuild;
 
 public sealed class SecurityMasterRebuildOrchestrator
 {

--- a/src/Meridian.Application/SecurityMaster/Rebuild/SecurityProjectionRebuildHandler.cs
+++ b/src/Meridian.Application/SecurityMaster/Rebuild/SecurityProjectionRebuildHandler.cs
@@ -2,7 +2,7 @@ using Meridian.Contracts.Workstation;
 using Meridian.Storage.SecurityMaster;
 using Microsoft.Extensions.Logging;
 
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.Rebuild;
 
 /// <summary>
 /// Published-revision side effect (<c>Order = 10</c>, runs first): refreshes the edited security's

--- a/src/Meridian.Application/SecurityMaster/Rebuild/UflProjectionRebuilder.cs
+++ b/src/Meridian.Application/SecurityMaster/Rebuild/UflProjectionRebuilder.cs
@@ -2,7 +2,7 @@ using Meridian.Core.Exceptions;
 using Meridian.ReferenceData.SecurityMaster;
 using Microsoft.Extensions.Logging;
 
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.Rebuild;
 
 /// <summary>
 /// Routes UFL projection rebuild requests through the shared Security Master rebuild pipeline.

--- a/src/Meridian.Application/SecurityMaster/Validation/AssetClassValidatorRegistry.cs
+++ b/src/Meridian.Application/SecurityMaster/Validation/AssetClassValidatorRegistry.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.ReferenceData.SecurityMaster;
 
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.Validation;
 
 public sealed record SecurityValidationContext(
     SecurityProjectionRecord Record,

--- a/src/Meridian.Application/SecurityMaster/Validation/FileSecurityValidationSnapshotStore.cs
+++ b/src/Meridian.Application/SecurityMaster/Validation/FileSecurityValidationSnapshotStore.cs
@@ -6,7 +6,7 @@ using Meridian.Core.Serialization;
 using Meridian.Storage;
 using Meridian.Storage.Archival;
 
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.Validation;
 
 public interface ISecurityValidationSnapshotStore
 {

--- a/src/Meridian.Application/SecurityMaster/Validation/SecurityMasterOptionsValidator.cs
+++ b/src/Meridian.Application/SecurityMaster/Validation/SecurityMasterOptionsValidator.cs
@@ -1,7 +1,7 @@
 using Meridian.Contracts.SecurityMaster;
 using Microsoft.Extensions.Options;
 
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.Validation;
 
 /// <summary>
 /// Validates <see cref="SecurityMasterOptions"/> at startup so misconfigured

--- a/src/Meridian.Application/SecurityMaster/Validation/SecurityValidationGateService.cs
+++ b/src/Meridian.Application/SecurityMaster/Validation/SecurityValidationGateService.cs
@@ -1,7 +1,7 @@
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Contracts.Services;
 
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.Validation;
 
 public sealed class SecurityValidationGateService : ISecurityValidationGateService
 {

--- a/src/Meridian.Application/SecurityMaster/Validation/SecurityValidationService.cs
+++ b/src/Meridian.Application/SecurityMaster/Validation/SecurityValidationService.cs
@@ -4,7 +4,7 @@ using Meridian.Contracts.Api;
 using Meridian.Contracts.SecurityMaster;
 using Meridian.Storage.SecurityMaster;
 
-namespace Meridian.Application.SecurityMaster;
+namespace Meridian.Application.SecurityMaster.Validation;
 
 public interface ISecurityValidationService
 {

--- a/src/Meridian.Backtesting/GlobalUsings.SecurityMasterConcerns.cs
+++ b/src/Meridian.Backtesting/GlobalUsings.SecurityMasterConcerns.cs
@@ -1,0 +1,6 @@
+// Re-exports the SecurityMaster concern sub-namespaces so existing consumers that reference
+// Meridian.Application.SecurityMaster keep resolving the rebuild, corporate-action, and
+// validation types that were regrouped into these sub-namespaces, without per-file using churn.
+global using Meridian.Application.SecurityMaster.CorporateActions;
+global using Meridian.Application.SecurityMaster.Rebuild;
+global using Meridian.Application.SecurityMaster.Validation;

--- a/src/Meridian.Execution/GlobalUsings.SecurityMasterConcerns.cs
+++ b/src/Meridian.Execution/GlobalUsings.SecurityMasterConcerns.cs
@@ -1,0 +1,6 @@
+// Re-exports the SecurityMaster concern sub-namespaces so existing consumers that reference
+// Meridian.Application.SecurityMaster keep resolving the rebuild, corporate-action, and
+// validation types that were regrouped into these sub-namespaces, without per-file using churn.
+global using Meridian.Application.SecurityMaster.CorporateActions;
+global using Meridian.Application.SecurityMaster.Rebuild;
+global using Meridian.Application.SecurityMaster.Validation;

--- a/src/Meridian.QuantScript/GlobalUsings.SecurityMasterConcerns.cs
+++ b/src/Meridian.QuantScript/GlobalUsings.SecurityMasterConcerns.cs
@@ -1,0 +1,6 @@
+// Re-exports the SecurityMaster concern sub-namespaces so existing consumers that reference
+// Meridian.Application.SecurityMaster keep resolving the rebuild, corporate-action, and
+// validation types that were regrouped into these sub-namespaces, without per-file using churn.
+global using Meridian.Application.SecurityMaster.CorporateActions;
+global using Meridian.Application.SecurityMaster.Rebuild;
+global using Meridian.Application.SecurityMaster.Validation;

--- a/src/Meridian.Strategies/GlobalUsings.SecurityMasterConcerns.cs
+++ b/src/Meridian.Strategies/GlobalUsings.SecurityMasterConcerns.cs
@@ -1,0 +1,6 @@
+// Re-exports the SecurityMaster concern sub-namespaces so existing consumers that reference
+// Meridian.Application.SecurityMaster keep resolving the rebuild, corporate-action, and
+// validation types that were regrouped into these sub-namespaces, without per-file using churn.
+global using Meridian.Application.SecurityMaster.CorporateActions;
+global using Meridian.Application.SecurityMaster.Rebuild;
+global using Meridian.Application.SecurityMaster.Validation;

--- a/src/Meridian.Ui.Shared/GlobalUsings.SecurityMasterConcerns.cs
+++ b/src/Meridian.Ui.Shared/GlobalUsings.SecurityMasterConcerns.cs
@@ -1,0 +1,6 @@
+// Re-exports the SecurityMaster concern sub-namespaces so existing consumers that reference
+// Meridian.Application.SecurityMaster keep resolving the rebuild, corporate-action, and
+// validation types that were regrouped into these sub-namespaces, without per-file using churn.
+global using Meridian.Application.SecurityMaster.CorporateActions;
+global using Meridian.Application.SecurityMaster.Rebuild;
+global using Meridian.Application.SecurityMaster.Validation;

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -302,7 +302,7 @@ public static class WorkstationServiceCollectionExtensions
             Meridian.Application.SecurityMaster.NullMultiAssetCoverageInvalidator>();
         services.TryAddEnumerable(ServiceDescriptor.Scoped<
             Meridian.Application.SecurityMaster.ISecurityMasterRevisionPublishedHandler,
-            Meridian.Application.SecurityMaster.SecurityProjectionRebuildHandler>());
+            Meridian.Application.SecurityMaster.Rebuild.SecurityProjectionRebuildHandler>());
         services.TryAddEnumerable(ServiceDescriptor.Scoped<
             Meridian.Application.SecurityMaster.ISecurityMasterRevisionPublishedHandler,
             Meridian.Application.SecurityMaster.CoverageInvalidationHandler>());

--- a/src/Meridian.Wpf/Features/Strategy/StrategyFeatureModule.cs
+++ b/src/Meridian.Wpf/Features/Strategy/StrategyFeatureModule.cs
@@ -134,7 +134,7 @@ public sealed class StrategyFeatureModule : IDesktopFeatureModule
             services.AddSingleton<Meridian.Backtesting.CorporateActionAdjustmentService>();
             services.AddSingleton<Meridian.Backtesting.ICorporateActionAdjustmentService>(
                 sp => sp.GetRequiredService<Meridian.Backtesting.CorporateActionAdjustmentService>());
-            services.AddSingleton<Meridian.Application.SecurityMaster.ILivePositionCorporateActionAdjuster>(
+            services.AddSingleton<Meridian.Application.SecurityMaster.CorporateActions.ILivePositionCorporateActionAdjuster>(
                 sp => sp.GetRequiredService<Meridian.Backtesting.CorporateActionAdjustmentService>());
             services.AddSingleton<ITradingParametersBackfillService, TradingParametersBackfillService>();
         }

--- a/src/Meridian.Wpf/GlobalUsings.SecurityMasterConcerns.cs
+++ b/src/Meridian.Wpf/GlobalUsings.SecurityMasterConcerns.cs
@@ -1,0 +1,6 @@
+// Re-exports the SecurityMaster concern sub-namespaces so existing consumers that reference
+// Meridian.Application.SecurityMaster keep resolving the rebuild, corporate-action, and
+// validation types that were regrouped into these sub-namespaces, without per-file using churn.
+global using Meridian.Application.SecurityMaster.CorporateActions;
+global using Meridian.Application.SecurityMaster.Rebuild;
+global using Meridian.Application.SecurityMaster.Validation;

--- a/tests/Meridian.Backtesting.Tests/GlobalUsings.SecurityMasterConcerns.cs
+++ b/tests/Meridian.Backtesting.Tests/GlobalUsings.SecurityMasterConcerns.cs
@@ -1,0 +1,6 @@
+// Re-exports the SecurityMaster concern sub-namespaces so existing consumers that reference
+// Meridian.Application.SecurityMaster keep resolving the rebuild, corporate-action, and
+// validation types that were regrouped into these sub-namespaces, without per-file using churn.
+global using Meridian.Application.SecurityMaster.CorporateActions;
+global using Meridian.Application.SecurityMaster.Rebuild;
+global using Meridian.Application.SecurityMaster.Validation;

--- a/tests/Meridian.FundStructure.Tests/GlobalUsings.SecurityMasterConcerns.cs
+++ b/tests/Meridian.FundStructure.Tests/GlobalUsings.SecurityMasterConcerns.cs
@@ -1,0 +1,6 @@
+// Re-exports the SecurityMaster concern sub-namespaces so existing consumers that reference
+// Meridian.Application.SecurityMaster keep resolving the rebuild, corporate-action, and
+// validation types that were regrouped into these sub-namespaces, without per-file using churn.
+global using Meridian.Application.SecurityMaster.CorporateActions;
+global using Meridian.Application.SecurityMaster.Rebuild;
+global using Meridian.Application.SecurityMaster.Validation;

--- a/tests/Meridian.Tests/Execution/PaperTradingPortfolioTests.cs
+++ b/tests/Meridian.Tests/Execution/PaperTradingPortfolioTests.cs
@@ -329,20 +329,20 @@ public sealed class PaperTradingPortfolioCorporateActionTests
             Timestamp = DateTimeOffset.UtcNow,
         };
 
-    private sealed class StubCorporateActionAdjuster : Meridian.Application.SecurityMaster.ILivePositionCorporateActionAdjuster
+    private sealed class StubCorporateActionAdjuster : Meridian.Application.SecurityMaster.CorporateActions.ILivePositionCorporateActionAdjuster
     {
         private readonly decimal _splitRatio;
         public int CallCount { get; private set; }
 
         public StubCorporateActionAdjuster(decimal splitRatio) => _splitRatio = splitRatio;
 
-        public Task<Meridian.Application.SecurityMaster.PositionCorporateActionAdjustment> AdjustPositionAsync(
+        public Task<Meridian.Application.SecurityMaster.CorporateActions.PositionCorporateActionAdjustment> AdjustPositionAsync(
             string ticker, decimal quantity, decimal costBasis, DateTimeOffset positionOpenedAt, CancellationToken ct = default)
         {
             CallCount++;
             var adjustedQty = quantity * _splitRatio;
             var adjustedCb = _splitRatio != 0 ? costBasis / _splitRatio : costBasis;
-            return Task.FromResult(new Meridian.Application.SecurityMaster.PositionCorporateActionAdjustment(
+            return Task.FromResult(new Meridian.Application.SecurityMaster.CorporateActions.PositionCorporateActionAdjustment(
                 ticker, quantity, adjustedQty, costBasis, adjustedCb, ActionCount: 1));
         }
     }

--- a/tests/Meridian.Tests/GlobalUsings.SecurityMasterConcerns.cs
+++ b/tests/Meridian.Tests/GlobalUsings.SecurityMasterConcerns.cs
@@ -1,0 +1,6 @@
+// Re-exports the SecurityMaster concern sub-namespaces so existing consumers that reference
+// Meridian.Application.SecurityMaster keep resolving the rebuild, corporate-action, and
+// validation types that were regrouped into these sub-namespaces, without per-file using churn.
+global using Meridian.Application.SecurityMaster.CorporateActions;
+global using Meridian.Application.SecurityMaster.Rebuild;
+global using Meridian.Application.SecurityMaster.Validation;

--- a/tests/Meridian.Wpf.Tests/GlobalUsings.SecurityMasterConcerns.cs
+++ b/tests/Meridian.Wpf.Tests/GlobalUsings.SecurityMasterConcerns.cs
@@ -1,0 +1,6 @@
+// Re-exports the SecurityMaster concern sub-namespaces so existing consumers that reference
+// Meridian.Application.SecurityMaster keep resolving the rebuild, corporate-action, and
+// validation types that were regrouped into these sub-namespaces, without per-file using churn.
+global using Meridian.Application.SecurityMaster.CorporateActions;
+global using Meridian.Application.SecurityMaster.Rebuild;
+global using Meridian.Application.SecurityMaster.Validation;


### PR DESCRIPTION
## Summary

Addresses the last of the five requested issues: `src/Meridian.Application/SecurityMaster/` was ~60 flat files with no sub-grouping despite clearly separable concerns. This regroups three of those concerns into sub-namespaces and matching subfolders:

- **`…SecurityMaster.Rebuild`** — `SecurityMasterAggregateRebuilder`, `SecurityMasterRebuildOrchestrator`, `SecurityProjectionRebuildHandler`, `UflProjectionRebuilder` (+ `IUflProjectionRebuilder`).
- **`…SecurityMaster.CorporateActions`** — `CorporateActionCommandService`, `CorporateActionInboxState`, `CorporateActionIngestOrchestrator`, `CorporateActionRestatementTrigger`, `CorporateActionValidation`, `SecurityMasterCorporateActionCommandService`, `ILivePositionCorporateActionAdjuster` (+ `PositionCorporateActionAdjustment`), `SecurityMasterTickerChangeService`.
- **`…SecurityMaster.Validation`** — `AssetClassValidatorRegistry`, `SecurityValidationService`, `SecurityValidationGateService`, `SecurityMasterOptionsValidator`, `FileSecurityValidationSnapshotStore`.

Core services (query/import/pricing/cash-flow), the ledger bridge, conflict/governance/workbench surfaces, resolvers, DTOs, exceptions, and the shared mapping/readiness types intentionally **stay in the root** `Meridian.Application.SecurityMaster` namespace — including the heavily fully-qualified query and restatement/ledger interfaces, so the public API and DI wiring stay stable.

### How consumers keep compiling

Rather than churn ~160 call sites with per-file `using` edits, each of the **11 projects** that reference these types gets a small `GlobalUsings.SecurityMasterConcerns.cs` that re-exports the three sub-namespaces. The **6 fully-qualified references** to moved types are updated to their new namespaces directly (global usings can't resolve fully-qualified names). A collision scan confirmed none of the moved type names are defined elsewhere, so the re-exports introduce no ambiguity.

This is a **pure namespace/folder reorganization — no behavior changes.**

## Reason

`SecurityMaster/` mixed rebuild, corporate-action, and validation concerns in one flat namespace, making ownership and navigation harder. Sub-namespacing them mirrors the separation the code already has in practice.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — not run (no local .NET build in this environment); this is a namespace move whose correctness is a compile concern, so `quality-gate` is the authoritative validation.
- [x] Static verification: every reference path audited (11 referencing projects covered by re-exports; all 6 fully-qualified references rewritten; `benchmarks/` and other trees confirmed to have no references; moved-type-name collision scan clean).
- [ ] Relevant unit/integration tests — none needed; no behavior change.
- [ ] GitHub Actions `quality-gate` passed — pending CI.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed


---
_Generated by [Claude Code](https://claude.ai/code/session_01Thw7hntsvhzzn2pCG4fQNM)_