### PR TITLE
refactor: quality hardening of provider factory, gap remediation, and pipeline config

### DIFF
--- a/config/appsettings.schema.json
+++ b/config/appsettings.schema.json
@@ -139,6 +139,16 @@
     "OfflineFirstMode": {
       "type": "boolean"
     },
+    "Pipeline": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/PipelineRuntimeConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "PluginsPath": {
       "anyOf": [
         {
@@ -1383,6 +1393,46 @@
               ]
             }
           }
+        }
+      }
+    },
+    "PipelineRuntimeConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "FinalFlushTimeoutSeconds": {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "SinkFlushTimeoutSeconds": {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },

--- a/src/Meridian.Application/Backfill/AutoGapRemediationService.cs
+++ b/src/Meridian.Application/Backfill/AutoGapRemediationService.cs
@@ -288,11 +288,14 @@ public sealed class AutoGapRemediationService : IDisposable
     private readonly DataQualityMonitoringService? _qualityMonitoringService;
 
     // Graceful-shutdown tracking for background (event-driven) remediation tasks. New work observes
-    // _shutdownCts, and Dispose drains in-flight tasks before releasing resources.
+    // _shutdownCts, and Dispose drains in-flight tasks before releasing resources. _lifecycleLock
+    // serializes the _disposed transition against background-task spawning so a task can never be
+    // registered (and left undrained, or touch a disposed _shutdownCts) after Dispose has begun.
+    private readonly object _lifecycleLock = new();
     private readonly CancellationTokenSource _shutdownCts = new();
     private readonly ConcurrentDictionary<Task, byte> _inFlight = new();
     private static readonly TimeSpan ShutdownDrainTimeout = TimeSpan.FromSeconds(10);
-    private volatile bool _disposed;
+    private bool _disposed;
 
     public AutoGapRemediationService(
         IBackfillExecutionGateway backfillGateway,
@@ -320,11 +323,16 @@ public sealed class AutoGapRemediationService : IDisposable
 
     public void Dispose()
     {
-        if (_disposed)
-            return;
+        // Flip _disposed under the lifecycle lock so any concurrent OnQualityGapDetected either
+        // registered its task before this point (and is therefore in _inFlight for draining) or
+        // observes _disposed and bails out — no task can slip in after this transition.
+        lock (_lifecycleLock)
+        {
+            if (_disposed)
+                return;
 
-        // Stop new event-driven work first, then signal cancellation to in-flight tasks.
-        _disposed = true;
+            _disposed = true;
+        }
 
         if (_qualityMonitoringService is not null)
         {
@@ -455,14 +463,19 @@ public sealed class AutoGapRemediationService : IDisposable
 
     private void OnQualityGapDetected(QualityDataGap gap)
     {
-        if (_disposed)
-        {
-            return;
-        }
-
         // Event-driven remediation runs in the background: attach it to the shutdown cancellation
-        // token and track the task so Dispose can drain in-flight work instead of losing it.
-        TrackBackgroundRemediation(HandleDataQualityGapAsync(gap, ct: _shutdownCts.Token));
+        // token and track the task so Dispose can drain in-flight work instead of losing it. The
+        // lifecycle lock guarantees registration is atomic with the _disposed check, so a task is
+        // never spawned (nor _shutdownCts touched) once Dispose has started.
+        lock (_lifecycleLock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            TrackBackgroundRemediation(HandleDataQualityGapAsync(gap, ct: _shutdownCts.Token));
+        }
     }
 
     private void TrackBackgroundRemediation(Task task)

--- a/src/Meridian.Application/Backfill/AutoGapRemediationService.cs
+++ b/src/Meridian.Application/Backfill/AutoGapRemediationService.cs
@@ -341,24 +341,45 @@ public sealed class AutoGapRemediationService : IDisposable
 
         _shutdownCts.Cancel();
 
-        // Best-effort graceful drain: give background remediation tasks a bounded window to
-        // observe cancellation and unwind so we do not tear down the semaphore beneath them.
+        // Graceful drain: give background remediation tasks a bounded window to observe cancellation
+        // and unwind. Track whether the drain actually completed so we only tear down the shutdown
+        // token and concurrency gate once no task can still touch them.
+        var drained = true;
         var pending = _inFlight.Keys.ToArray();
         if (pending.Length > 0)
         {
             try
             {
-                Task.WhenAll(pending).Wait(ShutdownDrainTimeout);
+                // Wait returns false on timeout (tasks still running); true when all completed.
+                drained = Task.WhenAll(pending).Wait(ShutdownDrainTimeout);
             }
             catch (Exception ex)
             {
-                // Faulted/cancelled background tasks are expected during shutdown; log and continue.
+                // An AggregateException here means the tasks finished (faulting) within the window,
+                // so the drain is complete — the tasks are no longer running.
                 _log.Debug(ex, "In-flight auto-remediation tasks completed with errors during shutdown drain");
+                drained = true;
             }
         }
 
-        _shutdownCts.Dispose();
-        _concurrencyGate.Dispose();
+        if (drained)
+        {
+            _shutdownCts.Dispose();
+            _concurrencyGate.Dispose();
+        }
+        else
+        {
+            // Drain timed out: at least one remediation is still running and will release the
+            // semaphore / observe the token as it unwinds (e.g. in its finally block). Disposing
+            // now would turn that valid in-flight work into an ObjectDisposedException, so we defer
+            // teardown to finalization instead. Neither type holds an unmanaged handle here (we
+            // never allocated a wait handle), so skipping explicit Dispose does not leak resources.
+            _log.Warning(
+                "Auto-remediation shutdown drain timed out after {TimeoutSeconds}s with up to {Count} task(s) " +
+                "still running; deferring disposal of shutdown resources to finalization to avoid tearing them " +
+                "down under active use",
+                ShutdownDrainTimeout.TotalSeconds, pending.Length);
+        }
     }
 
     public Task HandleDataQualityGapAsync(QualityDataGap gap, string? provider = null, CancellationToken ct = default)

--- a/src/Meridian.Application/Backfill/AutoGapRemediationService.cs
+++ b/src/Meridian.Application/Backfill/AutoGapRemediationService.cs
@@ -27,6 +27,31 @@ public enum AutoRemediationTriggerSource
     QualityAlert
 }
 
+/// <summary>
+/// Guardrail policy for automatic gap remediation.
+/// </summary>
+/// <param name="MinimumGapDuration">
+/// Minimum observed gap duration before a data-quality gap is worth remediating.
+/// Applies per data-quality gap signal.
+/// </param>
+/// <param name="MinimumGapSize">
+/// Minimum number of missing observations before a remediation is enqueued.
+/// Applies per remediation request (a single symbol or a batched symbol group).
+/// </param>
+/// <param name="SymbolCooldown">
+/// Per-symbol quiet window. After a symbol is remediated it is skipped until this window
+/// elapses, preventing repeated backfills of the same symbol. Scope: individual symbol.
+/// </param>
+/// <param name="ProviderCooldown">
+/// Per-provider quiet window. After any remediation runs against a provider, further
+/// remediations for that provider are skipped until this window elapses, protecting the
+/// upstream provider from bursts. Scope: individual provider (not global, not per-symbol).
+/// </param>
+/// <param name="MaxConcurrentRemediations">
+/// Global ceiling on the number of remediation executions running at once across all symbols
+/// and providers. Enforced by a semaphore, independent of the cooldown windows.
+/// </param>
+/// <param name="DefaultProvider">Provider used when a signal does not specify one.</param>
 public sealed record AutoGapRemediationPolicy(
     TimeSpan MinimumGapDuration,
     int MinimumGapSize,
@@ -42,6 +67,26 @@ public sealed record AutoGapRemediationPolicy(
         ProviderCooldown: TimeSpan.FromMinutes(1),
         MaxConcurrentRemediations: 2,
         DefaultProvider: "stooq");
+
+    /// <summary>
+    /// Policy builder: constructs a policy from optional overrides, falling back to
+    /// <see cref="Default"/> per field. Lets hosts tune individual windows/limits (e.g. from
+    /// operator configuration) without re-declaring every value or hardcoding the defaults.
+    /// </summary>
+    public static AutoGapRemediationPolicy Create(
+        TimeSpan? minimumGapDuration = null,
+        int? minimumGapSize = null,
+        TimeSpan? symbolCooldown = null,
+        TimeSpan? providerCooldown = null,
+        int? maxConcurrentRemediations = null,
+        string? defaultProvider = null)
+        => new(
+            minimumGapDuration ?? Default.MinimumGapDuration,
+            minimumGapSize ?? Default.MinimumGapSize,
+            symbolCooldown ?? Default.SymbolCooldown,
+            providerCooldown ?? Default.ProviderCooldown,
+            maxConcurrentRemediations ?? Default.MaxConcurrentRemediations,
+            defaultProvider ?? Default.DefaultProvider);
 }
 
 public enum BackfillRemediationSlaTier
@@ -104,6 +149,16 @@ public sealed record BackfillRemediationSlaSnapshot(
     int RequiresOwnerAssignmentCount,
     IReadOnlyList<BackfillRemediationSlaStatusItem> Items);
 
+/// <summary>
+/// SLA classification policy for remediation executions.
+/// </summary>
+/// <param name="StandardWindow">
+/// Time allowed to resolve a standard-tier gap, measured from when the gap was observed.
+/// </param>
+/// <param name="SameBusinessDayWindow">
+/// Tighter window applied to escalated (same-business-day) gaps that feed critical downstream
+/// workflows, carry a critical severity, or arrive as quality alerts.
+/// </param>
 public sealed record BackfillRemediationSlaPolicy(
     TimeSpan StandardWindow,
     TimeSpan SameBusinessDayWindow)
@@ -122,6 +177,17 @@ public sealed record BackfillRemediationSlaPolicy(
         StandardWindow: TimeSpan.FromHours(48),
         SameBusinessDayWindow: TimeSpan.FromHours(8));
 
+    /// <summary>
+    /// Policy builder: constructs a policy from optional window overrides, falling back to
+    /// <see cref="Default"/> per field so hosts can tune SLA windows without hardcoding defaults.
+    /// </summary>
+    public static BackfillRemediationSlaPolicy Create(
+        TimeSpan? standardWindow = null,
+        TimeSpan? sameBusinessDayWindow = null)
+        => new(
+            standardWindow ?? Default.StandardWindow,
+            sameBusinessDayWindow ?? Default.SameBusinessDayWindow);
+
     public BackfillRemediationSlaDecision Classify(
         AutoRemediationTriggerSource source,
         string? severity,
@@ -129,21 +195,15 @@ public sealed record BackfillRemediationSlaPolicy(
         DateTimeOffset observedAtUtc)
     {
         var normalizedWorkflow = NormalizeWorkflow(downstreamWorkflow);
-        var criticalWorkflow = CriticalDownstreamWorkflows.Any(workflow =>
-            normalizedWorkflow.Contains(workflow, StringComparison.OrdinalIgnoreCase));
+        var criticalWorkflow = IsCriticalWorkflow(normalizedWorkflow);
         var criticalSeverity = IsCriticalSeverity(severity);
-        var alertDriven = source == AutoRemediationTriggerSource.QualityAlert;
+        var alertDriven = IsAlertDriven(source);
         var sameBusinessDay = criticalWorkflow || criticalSeverity || alertDriven;
+
         var tier = sameBusinessDay
             ? BackfillRemediationSlaTier.SameBusinessDay
             : BackfillRemediationSlaTier.Standard;
-        var reasonCode = criticalWorkflow
-            ? "CriticalWorkflow"
-            : criticalSeverity
-                ? "CriticalSeverity"
-                : alertDriven
-                    ? "QualityAlert"
-                    : "StandardGap";
+        var reasonCode = ResolveReasonCode(criticalWorkflow, criticalSeverity, alertDriven);
 
         return new BackfillRemediationSlaDecision(
             tier,
@@ -153,9 +213,28 @@ public sealed record BackfillRemediationSlaPolicy(
             reasonCode);
     }
 
+    private static bool IsCriticalWorkflow(string normalizedWorkflow)
+        => CriticalDownstreamWorkflows.Any(workflow =>
+            normalizedWorkflow.Contains(workflow, StringComparison.OrdinalIgnoreCase));
+
     private static bool IsCriticalSeverity(string? severity)
         => string.Equals(severity, "Major", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(severity, "Critical", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsAlertDriven(AutoRemediationTriggerSource source)
+        => source == AutoRemediationTriggerSource.QualityAlert;
+
+    // First matching escalation reason wins; order mirrors the precedence in Classify.
+    private static string ResolveReasonCode(bool criticalWorkflow, bool criticalSeverity, bool alertDriven)
+    {
+        if (criticalWorkflow)
+            return "CriticalWorkflow";
+        if (criticalSeverity)
+            return "CriticalSeverity";
+        if (alertDriven)
+            return "QualityAlert";
+        return "StandardGap";
+    }
 
     private static string NormalizeWorkflow(string? downstreamWorkflow)
         => string.IsNullOrWhiteSpace(downstreamWorkflow)
@@ -187,17 +266,33 @@ internal sealed class AutoRemediationState
 /// </summary>
 public sealed class AutoGapRemediationService : IDisposable
 {
+    // Synchronization model (see issue: mixed lock + SemaphoreSlim on shared state):
+    //   * _idempotency + the per-entry lock(state): guard the read-modify-write of a single
+    //     AutoRemediationState (attempt count / last outcome) for one idempotency key. The lock is
+    //     held only for that in-memory bookkeeping and is NEVER held across an await or while
+    //     acquiring _concurrencyGate.
+    //   * _concurrencyGate (SemaphoreSlim): throttles how many remediation executions run at once
+    //     (MaxConcurrentRemediations). It bounds execution; it does not protect any shared field.
+    //   * _cooldowns: lock-free (ConcurrentDictionary-backed) last-attempt timestamps.
+    // Because the per-state lock is never held while waiting on the semaphore (and vice versa),
+    // there is no lock-ordering cycle and no deadlock path between the two primitives.
     private readonly IBackfillExecutionGateway _backfillGateway;
     private readonly BackfillExecutionHistory _history;
     private readonly AutoGapRemediationPolicy _policy;
     private readonly BackfillRemediationSlaPolicy _slaPolicy;
     private readonly ILogger _log;
     private readonly ConcurrentDictionary<string, AutoRemediationState> _idempotency = new(StringComparer.OrdinalIgnoreCase);
-    private readonly ConcurrentDictionary<string, DateTimeOffset> _symbolCooldown = new(StringComparer.OrdinalIgnoreCase);
-    private readonly ConcurrentDictionary<string, DateTimeOffset> _providerCooldown = new(StringComparer.OrdinalIgnoreCase);
+    private readonly RemediationCooldownTracker _cooldowns;
+    private readonly BackfillRemediationSlaEvaluator _slaEvaluator;
     private readonly SemaphoreSlim _concurrencyGate;
     private readonly DataQualityMonitoringService? _qualityMonitoringService;
-    private bool _disposed;
+
+    // Graceful-shutdown tracking for background (event-driven) remediation tasks. New work observes
+    // _shutdownCts, and Dispose drains in-flight tasks before releasing resources.
+    private readonly CancellationTokenSource _shutdownCts = new();
+    private readonly ConcurrentDictionary<Task, byte> _inFlight = new();
+    private static readonly TimeSpan ShutdownDrainTimeout = TimeSpan.FromSeconds(10);
+    private volatile bool _disposed;
 
     public AutoGapRemediationService(
         IBackfillExecutionGateway backfillGateway,
@@ -213,6 +308,8 @@ public sealed class AutoGapRemediationService : IDisposable
         _policy = policy ?? AutoGapRemediationPolicy.Default;
         _slaPolicy = slaPolicy ?? BackfillRemediationSlaPolicy.Default;
         _log = log ?? LoggingSetup.ForContext<AutoGapRemediationService>();
+        _cooldowns = new RemediationCooldownTracker(_policy.SymbolCooldown, _policy.ProviderCooldown);
+        _slaEvaluator = new BackfillRemediationSlaEvaluator(_history);
         _concurrencyGate = new SemaphoreSlim(Math.Max(1, _policy.MaxConcurrentRemediations));
 
         if (_qualityMonitoringService is not null)
@@ -226,13 +323,34 @@ public sealed class AutoGapRemediationService : IDisposable
         if (_disposed)
             return;
 
+        // Stop new event-driven work first, then signal cancellation to in-flight tasks.
+        _disposed = true;
+
         if (_qualityMonitoringService is not null)
         {
             _qualityMonitoringService.OnGapDetected -= OnQualityGapDetected;
         }
 
+        _shutdownCts.Cancel();
+
+        // Best-effort graceful drain: give background remediation tasks a bounded window to
+        // observe cancellation and unwind so we do not tear down the semaphore beneath them.
+        var pending = _inFlight.Keys.ToArray();
+        if (pending.Length > 0)
+        {
+            try
+            {
+                Task.WhenAll(pending).Wait(ShutdownDrainTimeout);
+            }
+            catch (Exception ex)
+            {
+                // Faulted/cancelled background tasks are expected during shutdown; log and continue.
+                _log.Debug(ex, "In-flight auto-remediation tasks completed with errors during shutdown drain");
+            }
+        }
+
+        _shutdownCts.Dispose();
         _concurrencyGate.Dispose();
-        _disposed = true;
     }
 
     public Task HandleDataQualityGapAsync(QualityDataGap gap, string? provider = null, CancellationToken ct = default)
@@ -333,50 +451,42 @@ public sealed class AutoGapRemediationService : IDisposable
         DateTimeOffset? nowUtc = null,
         int maxExecutions = 100,
         TimeSpan? dueSoonWindow = null)
-    {
-        var evaluatedAt = (nowUtc ?? DateTimeOffset.UtcNow).ToUniversalTime();
-
-        if (maxExecutions <= 0)
-        {
-            return new BackfillRemediationSlaSnapshot(
-                evaluatedAt,
-                Total: 0,
-                OverdueCount: 0,
-                DueSoonCount: 0,
-                RequiresOwnerAssignmentCount: 0,
-                Items: Array.Empty<BackfillRemediationSlaStatusItem>());
-        }
-
-        var dueSoonThreshold = dueSoonWindow ?? TimeSpan.FromHours(1);
-        if (dueSoonThreshold < TimeSpan.Zero)
-        {
-            dueSoonThreshold = TimeSpan.Zero;
-        }
-
-        var items = _history.GetRecentExecutions(maxExecutions)
-            .Where(static execution => execution.Trigger == ExecutionTrigger.AutoRemediation)
-            .Select(execution => TryBuildSlaStatusItem(execution, evaluatedAt, dueSoonThreshold))
-            .Where(static item => item is not null)
-            .Select(static item => item!)
-            .OrderBy(static item => SlaStatusPriority(item.Status))
-            .ThenBy(static item => item.DueAtUtc)
-            .ThenBy(static item => item.Provider, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(static item => string.Join(",", item.Symbols), StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        return new BackfillRemediationSlaSnapshot(
-            evaluatedAt,
-            items.Count,
-            items.Count(static item => item.Status == BackfillRemediationSlaStatus.Overdue),
-            items.Count(static item => item.Status == BackfillRemediationSlaStatus.DueSoon),
-            items.Count(static item =>
-                item.RequiresOwnerAssignment && item.Status != BackfillRemediationSlaStatus.Completed),
-            items);
-    }
+        => _slaEvaluator.Evaluate(nowUtc, maxExecutions, dueSoonWindow);
 
     private void OnQualityGapDetected(QualityDataGap gap)
     {
-        _ = HandleDataQualityGapAsync(gap);
+        if (_disposed)
+        {
+            return;
+        }
+
+        // Event-driven remediation runs in the background: attach it to the shutdown cancellation
+        // token and track the task so Dispose can drain in-flight work instead of losing it.
+        TrackBackgroundRemediation(HandleDataQualityGapAsync(gap, ct: _shutdownCts.Token));
+    }
+
+    private void TrackBackgroundRemediation(Task task)
+    {
+        _inFlight[task] = 0;
+
+        // Remove on completion and observe faults so a background failure never becomes an
+        // unobserved-task exception. Runs synchronously on completion; no extra scheduling.
+        task.ContinueWith(
+            static (completed, state) =>
+            {
+                var self = (AutoGapRemediationService)state!;
+                self._inFlight.TryRemove(completed, out _);
+                if (completed.IsFaulted)
+                {
+                    self._log.Warning(
+                        completed.Exception?.GetBaseException(),
+                        "Background auto-remediation task faulted");
+                }
+            },
+            this,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     private async Task EnqueueRemediationAsync(
@@ -412,14 +522,14 @@ public sealed class AutoGapRemediationService : IDisposable
         var now = DateTimeOffset.UtcNow;
         var slaDecision = _slaPolicy.Classify(source, severity, downstreamWorkflow, now);
 
-        if (IsCoolingDown(_providerCooldown, normalizedProvider, _policy.ProviderCooldown, now))
+        if (_cooldowns.IsProviderCoolingDown(normalizedProvider, now))
         {
             _log.Debug("Auto-remediation provider cooldown active for {Provider}", normalizedProvider);
             return;
         }
 
         var eligibleSymbols = normalizedSymbols
-            .Where(symbol => !IsCoolingDown(_symbolCooldown, symbol, _policy.SymbolCooldown, now))
+            .Where(symbol => !_cooldowns.IsSymbolCoolingDown(symbol, now))
             .ToArray();
 
         if (eligibleSymbols.Length == 0)
@@ -430,6 +540,12 @@ public sealed class AutoGapRemediationService : IDisposable
 
         var idempotencyKey = BuildIdempotencyKey(eligibleSymbols, normalizedProvider, from, to);
 
+        // Idempotency gate: the key identifies one (symbols|provider|date-range) remediation. We hold
+        // a per-key lock only long enough to read-and-update the shared AutoRemediationState so two
+        // concurrent triggers for the same key cannot both pass the gate. A recently Completed or
+        // Skipped attempt within the symbol-cooldown window short-circuits (deduplicates); otherwise
+        // we claim this attempt (increment count, reset outcome) and proceed to execute outside the
+        // lock. The lock is never held across the await on _concurrencyGate or the gateway call.
         var state = _idempotency.GetOrAdd(idempotencyKey, _ => new AutoRemediationState());
         lock (state)
         {
@@ -480,7 +596,7 @@ public sealed class AutoGapRemediationService : IDisposable
                     ? AutoRemediationOutcome.Completed.ToString()
                     : AutoRemediationOutcome.FailedPermanent.ToString();
 
-                UpdateCooldowns(eligibleSymbols, normalizedProvider, now);
+                _cooldowns.Record(eligibleSymbols, normalizedProvider, now);
                 UpdateOutcome(state, result.Success ? AutoRemediationOutcome.Completed : AutoRemediationOutcome.FailedPermanent);
             }
             catch (Exception ex)
@@ -524,7 +640,7 @@ public sealed class AutoGapRemediationService : IDisposable
             : normalized.ToLowerInvariant();
     }
 
-    private static string BuildIdempotencyKey(IReadOnlyList<string> symbols, string provider, DateOnly from, DateOnly to)
+    internal static string BuildIdempotencyKey(IReadOnlyList<string> symbols, string provider, DateOnly from, DateOnly to)
         => $"{string.Join(",", symbols)}|{provider.ToLowerInvariant()}|{from:yyyy-MM-dd}|{to:yyyy-MM-dd}";
 
     private static string BuildBatchedReason(IEnumerable<string> reasons)
@@ -543,11 +659,174 @@ public sealed class AutoGapRemediationService : IDisposable
         };
     }
 
-    private static bool IsCoolingDown(ConcurrentDictionary<string, DateTimeOffset> state, string key, TimeSpan cooldown, DateTimeOffset now)
-        => state.TryGetValue(key, out var lastAttempt) && (now - lastAttempt) < cooldown;
-
     private static bool IsTransientFailure(Exception ex)
         => ex is HttpRequestException or TimeoutException or OperationCanceledException;
+
+    private static void UpdateOutcome(AutoRemediationState state, AutoRemediationOutcome outcome)
+    {
+        lock (state)
+        {
+            state.LastOutcome = outcome;
+        }
+    }
+
+    private static BackfillExecutionLog CreateExecutionLog(
+        IReadOnlyList<string> symbols,
+        string provider,
+        DateOnly from,
+        DateOnly to,
+        AutoRemediationTriggerSource source,
+        string reason,
+        string idempotencyKey,
+        int attempt,
+        BackfillRemediationSlaDecision slaDecision)
+    {
+        return new BackfillExecutionLog
+        {
+            ScheduleId = "auto-gap-remediation",
+            ScheduleName = "Auto Gap Remediation",
+            Trigger = ExecutionTrigger.AutoRemediation,
+            ScheduledAt = DateTimeOffset.UtcNow,
+            StartedAt = DateTimeOffset.UtcNow,
+            FromDate = from,
+            ToDate = to,
+            Symbols = symbols.ToList(),
+            Status = ExecutionStatus.Running,
+            AutoRemediationTriggerReason = reason,
+            AutoRemediationAttemptCount = attempt,
+            AutoRemediationLastOutcome = AutoRemediationOutcome.None.ToString(),
+            AutoRemediationIdempotencyKey = idempotencyKey,
+            AutoRemediationSla = new BackfillRemediationSlaMetadata(
+                slaDecision.Tier,
+                slaDecision.DueAtUtc,
+                slaDecision.RequiresOwnerAssignment,
+                slaDecision.DownstreamWorkflow,
+                slaDecision.ReasonCode,
+                provider,
+                source)
+        };
+    }
+
+    private sealed record AutoGapRemediationCandidate(
+        string Symbol,
+        DateOnly From,
+        DateOnly To,
+        string Provider,
+        AutoRemediationTriggerSource Source,
+        string Reason,
+        int GapSize);
+
+    private sealed record AutoRemediationBatchKey(
+        string Provider,
+        DateOnly From,
+        DateOnly To,
+        AutoRemediationTriggerSource Source);
+}
+
+/// <summary>
+/// Tracks per-symbol and per-provider cooldown windows for auto-remediation. Split out of
+/// <see cref="AutoGapRemediationService"/> so cooldown state and its quiet-window rules live in one
+/// place. Backed by concurrent dictionaries; safe for concurrent readers and writers.
+/// </summary>
+internal sealed class RemediationCooldownTracker
+{
+    private readonly ConcurrentDictionary<string, DateTimeOffset> _symbolCooldowns = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, DateTimeOffset> _providerCooldowns = new(StringComparer.OrdinalIgnoreCase);
+    private readonly TimeSpan _symbolCooldown;
+    private readonly TimeSpan _providerCooldown;
+
+    public RemediationCooldownTracker(TimeSpan symbolCooldown, TimeSpan providerCooldown)
+    {
+        _symbolCooldown = symbolCooldown;
+        _providerCooldown = providerCooldown;
+    }
+
+    /// <summary>True when the provider was remediated within its cooldown window as of <paramref name="now"/>.</summary>
+    public bool IsProviderCoolingDown(string provider, DateTimeOffset now)
+        => IsCoolingDown(_providerCooldowns, provider, _providerCooldown, now);
+
+    /// <summary>True when the symbol was remediated within its cooldown window as of <paramref name="now"/>.</summary>
+    public bool IsSymbolCoolingDown(string symbol, DateTimeOffset now)
+        => IsCoolingDown(_symbolCooldowns, symbol, _symbolCooldown, now);
+
+    /// <summary>Records the last-attempt timestamp for the given symbols and provider.</summary>
+    public void Record(IReadOnlyList<string> symbols, string provider, DateTimeOffset timestamp)
+    {
+        foreach (var symbol in symbols)
+        {
+            _symbolCooldowns[symbol] = timestamp;
+        }
+
+        _providerCooldowns[provider] = timestamp;
+    }
+
+    private static bool IsCoolingDown(
+        ConcurrentDictionary<string, DateTimeOffset> state,
+        string key,
+        TimeSpan cooldown,
+        DateTimeOffset now)
+        => state.TryGetValue(key, out var lastAttempt) && (now - lastAttempt) < cooldown;
+}
+
+/// <summary>
+/// Evaluates SLA status for recorded auto-remediation executions and builds a snapshot. Split out of
+/// <see cref="AutoGapRemediationService"/> so SLA classification/status projection is isolated from
+/// remediation execution and cooldown concerns. Reads from <see cref="BackfillExecutionHistory"/>;
+/// performs no mutation.
+/// </summary>
+internal sealed class BackfillRemediationSlaEvaluator
+{
+    private readonly BackfillExecutionHistory _history;
+
+    public BackfillRemediationSlaEvaluator(BackfillExecutionHistory history)
+    {
+        _history = history;
+    }
+
+    public BackfillRemediationSlaSnapshot Evaluate(
+        DateTimeOffset? nowUtc,
+        int maxExecutions,
+        TimeSpan? dueSoonWindow)
+    {
+        var evaluatedAt = (nowUtc ?? DateTimeOffset.UtcNow).ToUniversalTime();
+
+        if (maxExecutions <= 0)
+        {
+            return new BackfillRemediationSlaSnapshot(
+                evaluatedAt,
+                Total: 0,
+                OverdueCount: 0,
+                DueSoonCount: 0,
+                RequiresOwnerAssignmentCount: 0,
+                Items: Array.Empty<BackfillRemediationSlaStatusItem>());
+        }
+
+        var dueSoonThreshold = dueSoonWindow ?? TimeSpan.FromHours(1);
+        if (dueSoonThreshold < TimeSpan.Zero)
+        {
+            dueSoonThreshold = TimeSpan.Zero;
+        }
+
+        var items = _history.GetRecentExecutions(maxExecutions)
+            .Where(static execution => execution.Trigger == ExecutionTrigger.AutoRemediation)
+            .Select(execution => TryBuildSlaStatusItem(execution, evaluatedAt, dueSoonThreshold))
+            .Where(static item => item is not null)
+            .Select(static item => item!)
+            .OrderBy(static item => SlaStatusPriority(item.Status))
+            .ThenBy(static item => item.DueAtUtc)
+            .ThenBy(static item => item.Provider, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static item => string.Join(",", item.Symbols), StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return new BackfillRemediationSlaSnapshot(
+            evaluatedAt,
+            items.Count,
+            items.Count(static item => item.Status == BackfillRemediationSlaStatus.Overdue),
+            items.Count(static item => item.Status == BackfillRemediationSlaStatus.DueSoon),
+            items.Count(static item =>
+                item.RequiresOwnerAssignment && item.Status != BackfillRemediationSlaStatus.Completed),
+            items);
+    }
 
     private static BackfillRemediationSlaStatusItem? TryBuildSlaStatusItem(
         BackfillExecutionLog execution,
@@ -624,7 +903,7 @@ public sealed class AutoGapRemediationService : IDisposable
         TimeSpan dueSoonThreshold)
     {
         var idempotencyKey = execution.AutoRemediationIdempotencyKey ??
-            BuildIdempotencyKey(execution.Symbols, provider, execution.FromDate, execution.ToDate);
+            AutoGapRemediationService.BuildIdempotencyKey(execution.Symbols, provider, execution.FromDate, execution.ToDate);
         var status = ResolveSlaStatus(execution, dueAt, evaluatedAt, dueSoonThreshold);
 
         return new BackfillRemediationSlaStatusItem(
@@ -708,74 +987,4 @@ public sealed class AutoGapRemediationService : IDisposable
             BackfillRemediationSlaStatus.Completed => 4,
             _ => 5
         };
-
-    private static void UpdateOutcome(AutoRemediationState state, AutoRemediationOutcome outcome)
-    {
-        lock (state)
-        {
-            state.LastOutcome = outcome;
-        }
-    }
-
-    private void UpdateCooldowns(IReadOnlyList<string> symbols, string provider, DateTimeOffset timestamp)
-    {
-        foreach (var symbol in symbols)
-        {
-            _symbolCooldown[symbol] = timestamp;
-        }
-
-        _providerCooldown[provider] = timestamp;
-    }
-
-    private static BackfillExecutionLog CreateExecutionLog(
-        IReadOnlyList<string> symbols,
-        string provider,
-        DateOnly from,
-        DateOnly to,
-        AutoRemediationTriggerSource source,
-        string reason,
-        string idempotencyKey,
-        int attempt,
-        BackfillRemediationSlaDecision slaDecision)
-    {
-        return new BackfillExecutionLog
-        {
-            ScheduleId = "auto-gap-remediation",
-            ScheduleName = "Auto Gap Remediation",
-            Trigger = ExecutionTrigger.AutoRemediation,
-            ScheduledAt = DateTimeOffset.UtcNow,
-            StartedAt = DateTimeOffset.UtcNow,
-            FromDate = from,
-            ToDate = to,
-            Symbols = symbols.ToList(),
-            Status = ExecutionStatus.Running,
-            AutoRemediationTriggerReason = reason,
-            AutoRemediationAttemptCount = attempt,
-            AutoRemediationLastOutcome = AutoRemediationOutcome.None.ToString(),
-            AutoRemediationIdempotencyKey = idempotencyKey,
-            AutoRemediationSla = new BackfillRemediationSlaMetadata(
-                slaDecision.Tier,
-                slaDecision.DueAtUtc,
-                slaDecision.RequiresOwnerAssignment,
-                slaDecision.DownstreamWorkflow,
-                slaDecision.ReasonCode,
-                provider,
-                source)
-        };
-    }
-
-    private sealed record AutoGapRemediationCandidate(
-        string Symbol,
-        DateOnly From,
-        DateOnly To,
-        string Provider,
-        AutoRemediationTriggerSource Source,
-        string Reason,
-        int GapSize);
-
-    private sealed record AutoRemediationBatchKey(
-        string Provider,
-        DateOnly From,
-        DateOnly To,
-        AutoRemediationTriggerSource Source);
 }

--- a/src/Meridian.Application/Composition/Features/PipelineFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/PipelineFeatureRegistration.cs
@@ -196,12 +196,19 @@ internal sealed class PipelineFeatureRegistration : IServiceFeatureRegistration
                     config.Validation.UseRealTimeMode);
             }
 
+            // Flush timeouts are operator-tunable via the Pipeline config section; unset or
+            // non-positive values fall back to the pipeline's built-in defaults (30s / 60s).
+            var finalFlushTimeout = ToPositiveTimeout(config.Pipeline?.FinalFlushTimeoutSeconds);
+            var sinkFlushTimeout = ToPositiveTimeout(config.Pipeline?.SinkFlushTimeoutSeconds);
+
             return new EventPipeline(
                 sink,
                 EventPipelinePolicy.DurableStreaming,
                 metrics: metrics,
                 wal: wal,
                 auditTrail: auditTrail,
+                finalFlushTimeout: finalFlushTimeout,
+                sinkFlushTimeout: sinkFlushTimeout,
                 validator: validator,
                 deadLetterSink: deadLetterSink,
                 dedupLedger: dedupLedger,
@@ -275,6 +282,13 @@ internal sealed class PipelineFeatureRegistration : IServiceFeatureRegistration
 
         return services;
     }
+
+    /// <summary>
+    /// Converts an optional configured timeout (in seconds) to a <see cref="TimeSpan"/>, treating
+    /// null or non-positive values as unset so the pipeline applies its built-in default.
+    /// </summary>
+    private static TimeSpan? ToPositiveTimeout(int? seconds)
+        => seconds is > 0 ? TimeSpan.FromSeconds(seconds.Value) : null;
 
     /// <summary>
     /// Resolves each sink ID from the <paramref name="activeIds"/> list using the

--- a/src/Meridian.Application/DirectLending/DirectLendingServicerStatementService.cs
+++ b/src/Meridian.Application/DirectLending/DirectLendingServicerStatementService.cs
@@ -10,6 +10,16 @@ public sealed class DirectLendingServicerStatementService : IDirectLendingServic
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private readonly IDirectLendingService _directLendingService;
+
+    // Lock-ordering invariant for _gate:
+    //   * _gate is the single monitor guarding the two in-memory stores below (_batches and
+    //     _importedRowHashes). Because there is exactly one lock, no lock-acquisition order exists
+    //     to violate — deadlock would require a second lock or lock reentrancy across threads.
+    //   * Critical sections under _gate must stay purely in-memory and synchronous: never await,
+    //     and never call _directLendingService or any other collaborator while holding _gate.
+    //     All such I/O (portfolio/loan loads, batch creation, payment application) is performed
+    //     BEFORE or AFTER the lock, never inside it. Honouring this keeps the lock uncontended and
+    //     free of any deadlock/reentrancy risk.
     private readonly object _gate = new();
     private readonly Dictionary<Guid, ServicerStatementPreviewDto> _batches = new();
     private readonly HashSet<string> _importedRowHashes = new(StringComparer.Ordinal);

--- a/src/Meridian.Core/Config/AppConfig.cs
+++ b/src/Meridian.Core/Config/AppConfig.cs
@@ -67,7 +67,8 @@ public sealed record AppConfig(
     ProviderConnectionsConfig? ProviderConnections = null,
     FeatureCapabilityOptions? FeatureCapabilities = null,
     FundOperationsPersistenceConfig? FundOperationsPersistence = null,
-    ProviderModulesConfig? ProviderModules = null
+    ProviderModulesConfig? ProviderModules = null,
+    PipelineRuntimeConfig? Pipeline = null
 )
 {
     /// <summary>
@@ -79,6 +80,24 @@ public sealed record AppConfig(
     [JsonExtensionData]
     public Dictionary<string, System.Text.Json.JsonElement>? AdditionalSections { get; set; }
 }
+
+/// <summary>
+/// Runtime tuning for the event pipeline's flush behaviour. All fields are optional; unset values
+/// fall back to the pipeline's built-in defaults (final flush 30s, periodic sink flush 60s), so
+/// existing configurations keep their current behaviour. Non-positive values are ignored (treated
+/// as unset) by the pipeline registration.
+/// </summary>
+/// <param name="FinalFlushTimeoutSeconds">
+/// Timeout, in seconds, for the final flush during pipeline shutdown before giving up.
+/// </param>
+/// <param name="SinkFlushTimeoutSeconds">
+/// Per-call timeout, in seconds, for periodic sink flushes, preventing a hung sink from stalling
+/// the pipeline indefinitely.
+/// </param>
+public sealed record PipelineRuntimeConfig(
+    int? FinalFlushTimeoutSeconds = null,
+    int? SinkFlushTimeoutSeconds = null
+);
 
 /// <summary>
 /// Configuration for the unified provider registry (Phase 1.2).

--- a/src/Meridian.Core/Serialization/MarketDataJsonContext.cs
+++ b/src/Meridian.Core/Serialization/MarketDataJsonContext.cs
@@ -75,6 +75,7 @@ namespace Meridian.Core.Serialization;
 // Configuration types
 [JsonSerializable(typeof(List<string>))]
 [JsonSerializable(typeof(AppConfig))]
+[JsonSerializable(typeof(PipelineRuntimeConfig))]
 [JsonSerializable(typeof(FeatureCapabilityOptions))]
 [JsonSerializable(typeof(Dictionary<string, bool>))]
 [JsonSerializable(typeof(StorageConfig))]

--- a/src/Meridian.Infrastructure/Adapters/Core/ProviderFactory.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/ProviderFactory.cs
@@ -511,7 +511,8 @@ public sealed class ProviderFactory
         if (!enabled)
             return null;
 
-        var credential = CreateCredentialContext<TCredentialSource>((credentialName, configuredValue)).Get(credentialName);
+        // Null-conditional guards against a custom/test-double resolver returning a null context.
+        var credential = CreateCredentialContext<TCredentialSource>((credentialName, configuredValue))?.Get(credentialName);
         return string.IsNullOrWhiteSpace(credential) ? null : factory(credential);
     }
 

--- a/src/Meridian.Infrastructure/Adapters/Core/ProviderFactory.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/ProviderFactory.cs
@@ -110,43 +110,43 @@ public sealed class ProviderFactory
         var providersCfg = backfillCfg?.Providers;
 
         // Synthetic offline dataset
-        TryAddBackfillProvider(providers, () => CreateSyntheticBackfillProvider(providersCfg?.Synthetic));
+        TryAddBackfillProvider(providers, "synthetic", () => CreateSyntheticBackfillProvider(providersCfg?.Synthetic));
 
         // Interactive Brokers native historical path (or guidance-only stub in non-IBAPI builds)
-        TryAddBackfillProvider(providers, () => CreateIbBackfillProvider(_config.IB));
+        TryAddBackfillProvider(providers, "interactive-brokers", () => CreateIbBackfillProvider(_config.IB));
 
         // Alpaca Markets (highest priority when configured)
-        TryAddBackfillProvider(providers, () => CreateAlpacaBackfillProvider(providersCfg?.Alpaca));
+        TryAddBackfillProvider(providers, "alpaca", () => CreateAlpacaBackfillProvider(providersCfg?.Alpaca));
 
         // Yahoo Finance (broad free coverage)
-        TryAddBackfillProvider(providers, () => CreateYahooBackfillProvider(providersCfg?.Yahoo));
+        TryAddBackfillProvider(providers, "yahoo", () => CreateYahooBackfillProvider(providersCfg?.Yahoo));
 
         // Polygon.io
-        TryAddBackfillProvider(providers, () => CreatePolygonBackfillProvider(providersCfg?.Polygon));
+        TryAddBackfillProvider(providers, "polygon", () => CreatePolygonBackfillProvider(providersCfg?.Polygon));
 
         // Tiingo
-        TryAddBackfillProvider(providers, () => CreateTiingoBackfillProvider(providersCfg?.Tiingo));
+        TryAddBackfillProvider(providers, "tiingo", () => CreateTiingoBackfillProvider(providersCfg?.Tiingo));
 
         // Twelve Data
-        TryAddBackfillProvider(providers, CreateTwelveDataBackfillProvider);
+        TryAddBackfillProvider(providers, "twelvedata", CreateTwelveDataBackfillProvider);
 
         // Finnhub
-        TryAddBackfillProvider(providers, () => CreateFinnhubBackfillProvider(providersCfg?.Finnhub));
+        TryAddBackfillProvider(providers, "finnhub", () => CreateFinnhubBackfillProvider(providersCfg?.Finnhub));
 
         // Stooq
-        TryAddBackfillProvider(providers, () => CreateStooqBackfillProvider(providersCfg?.Stooq));
+        TryAddBackfillProvider(providers, "stooq", () => CreateStooqBackfillProvider(providersCfg?.Stooq));
 
         // Alpha Vantage
-        TryAddBackfillProvider(providers, () => CreateAlphaVantageBackfillProvider(providersCfg?.AlphaVantage));
+        TryAddBackfillProvider(providers, "alphavantage", () => CreateAlphaVantageBackfillProvider(providersCfg?.AlphaVantage));
 
         // FRED economic data
-        TryAddBackfillProvider(providers, () => CreateFredBackfillProvider(providersCfg?.Fred));
+        TryAddBackfillProvider(providers, "fred", () => CreateFredBackfillProvider(providersCfg?.Fred));
 
         // Nasdaq Data Link
-        TryAddBackfillProvider(providers, () => CreateNasdaqBackfillProvider(providersCfg?.Nasdaq));
+        TryAddBackfillProvider(providers, "nasdaq", () => CreateNasdaqBackfillProvider(providersCfg?.Nasdaq));
 
         // Robinhood historical bars (unofficial API, explicitly enabled)
-        TryAddBackfillProvider(providers, () => CreateRobinhoodBackfillProvider(providersCfg?.Robinhood));
+        TryAddBackfillProvider(providers, "robinhood", () => CreateRobinhoodBackfillProvider(providersCfg?.Robinhood));
 
         return providers
             .OrderBy(p => p.Priority)
@@ -155,6 +155,7 @@ public sealed class ProviderFactory
 
     private void TryAddBackfillProvider(
         List<IHistoricalDataProvider> providers,
+        string providerLabel,
         Func<IHistoricalDataProvider?> factory)
     {
         try
@@ -167,14 +168,16 @@ public sealed class ProviderFactory
         }
         catch (Exception ex)
         {
-            _log.Warning(ex, "Failed to create backfill provider");
+            // Isolate one provider's construction failure so the rest still register, but name the
+            // provider and surface the exception so configuration/credential errors are not silent.
+            _log.Warning(ex, "Failed to create backfill provider {Provider}; skipping it for this run", providerLabel);
         }
     }
 
 
     private IHistoricalDataProvider? CreateSyntheticBackfillProvider(SyntheticMarketDataConfig? cfg)
     {
-        if (cfg?.Enabled != true)
+        if (!EnabledWhenOptedIn(cfg?.Enabled))
             return null;
 
         return new SyntheticHistoricalDataProvider(cfg);
@@ -201,7 +204,7 @@ public sealed class ProviderFactory
 
     private IHistoricalDataProvider? CreateAlpacaBackfillProvider(AlpacaBackfillConfig? cfg)
     {
-        if (!(cfg?.Enabled ?? true))
+        if (!EnabledByDefault(cfg?.Enabled))
             return null;
 
         var configuredOptions = new AlpacaOptions(
@@ -216,7 +219,7 @@ public sealed class ProviderFactory
         var aliasAwareCredentials = AlpacaCredentialEnvironment.Resolve(configuredOptions);
         var keyId = FirstNonBlank(credentials.Get("ALPACA_KEY_ID"), aliasAwareCredentials.KeyId);
         var secretKey = FirstNonBlank(credentials.Get("ALPACA_SECRET_KEY"), aliasAwareCredentials.SecretKey);
-        if (string.IsNullOrEmpty(keyId) || string.IsNullOrEmpty(secretKey))
+        if (string.IsNullOrWhiteSpace(keyId) || string.IsNullOrWhiteSpace(secretKey))
             return null;
 
         return new AlpacaHistoricalDataProvider(
@@ -231,105 +234,68 @@ public sealed class ProviderFactory
 
     private IHistoricalDataProvider? CreateYahooBackfillProvider(YahooBackfillConfig? cfg)
     {
-        if (!(cfg?.Enabled ?? true))
+        if (!EnabledByDefault(cfg?.Enabled))
             return null;
         return new YahooFinanceHistoricalDataProvider(log: _log);
     }
 
     private IHistoricalDataProvider? CreatePolygonBackfillProvider(PolygonBackfillConfig? cfg)
-    {
-        if (!(cfg?.Enabled ?? true))
-            return null;
-
-        var credentials = CreateCredentialContext<PolygonHistoricalDataProvider>(
-            ("POLYGON_API_KEY", cfg?.ApiKey));
-        var apiKey = credentials.Get("POLYGON_API_KEY");
-        if (string.IsNullOrEmpty(apiKey))
-            return null;
-
-        return new PolygonHistoricalDataProvider(apiKey: apiKey, log: _log);
-    }
+        => CreateCredentialGatedBackfillProvider<PolygonHistoricalDataProvider>(
+            EnabledByDefault(cfg?.Enabled),
+            "POLYGON_API_KEY",
+            cfg?.ApiKey,
+            apiKey => new PolygonHistoricalDataProvider(apiKey: apiKey, log: _log));
 
     private IHistoricalDataProvider? CreateTiingoBackfillProvider(TiingoBackfillConfig? cfg)
-    {
-        if (!(cfg?.Enabled ?? true))
-            return null;
-
-        var credentials = CreateCredentialContext<TiingoHistoricalDataProvider>(
-            ("TIINGO_API_TOKEN", cfg?.ApiToken));
-        var token = credentials.Get("TIINGO_API_TOKEN");
-        if (string.IsNullOrEmpty(token))
-            return null;
-
-        return new TiingoHistoricalDataProvider(apiToken: token, log: _log);
-    }
+        => CreateCredentialGatedBackfillProvider<TiingoHistoricalDataProvider>(
+            EnabledByDefault(cfg?.Enabled),
+            "TIINGO_API_TOKEN",
+            cfg?.ApiToken,
+            token => new TiingoHistoricalDataProvider(apiToken: token, log: _log));
 
     private IHistoricalDataProvider? CreateTwelveDataBackfillProvider()
-    {
-        var credentials = CreateCredentialContext<TwelveDataHistoricalDataProvider>(
-            ("TWELVEDATA_API_KEY", null));
-        var apiKey = credentials.Get("TWELVEDATA_API_KEY");
-        if (string.IsNullOrEmpty(apiKey))
-            return null;
-
-        return new TwelveDataHistoricalDataProvider(apiKey: apiKey, log: _log);
-    }
+        => CreateCredentialGatedBackfillProvider<TwelveDataHistoricalDataProvider>(
+            enabled: true,
+            "TWELVEDATA_API_KEY",
+            configuredValue: null,
+            apiKey => new TwelveDataHistoricalDataProvider(apiKey: apiKey, log: _log));
 
     private IHistoricalDataProvider? CreateFinnhubBackfillProvider(FinnhubBackfillConfig? cfg)
-    {
-        if (!(cfg?.Enabled ?? true))
-            return null;
-
-        var credentials = CreateCredentialContext<FinnhubHistoricalDataProvider>(
-            ("FINNHUB_API_KEY", cfg?.ApiKey));
-        var apiKey = credentials.Get("FINNHUB_API_KEY");
-        if (string.IsNullOrEmpty(apiKey))
-            return null;
-
-        return new FinnhubHistoricalDataProvider(apiKey: apiKey, log: _log);
-    }
+        => CreateCredentialGatedBackfillProvider<FinnhubHistoricalDataProvider>(
+            EnabledByDefault(cfg?.Enabled),
+            "FINNHUB_API_KEY",
+            cfg?.ApiKey,
+            apiKey => new FinnhubHistoricalDataProvider(apiKey: apiKey, log: _log));
 
     private IHistoricalDataProvider? CreateStooqBackfillProvider(StooqBackfillConfig? cfg)
     {
-        if (!(cfg?.Enabled ?? true))
+        if (!EnabledByDefault(cfg?.Enabled))
             return null;
         return new StooqHistoricalDataProvider(log: _log);
     }
 
     private IHistoricalDataProvider? CreateAlphaVantageBackfillProvider(AlphaVantageBackfillConfig? cfg)
-    {
-        // Disabled by default due to very limited free tier
-        if (!(cfg?.Enabled ?? false))
-            return null;
-
-        var credentials = CreateCredentialContext<AlphaVantageHistoricalDataProvider>(
-            ("ALPHA_VANTAGE_API_KEY", cfg?.ApiKey));
-        var apiKey = credentials.Get("ALPHA_VANTAGE_API_KEY");
-        if (string.IsNullOrEmpty(apiKey))
-            return null;
-
-        return new AlphaVantageHistoricalDataProvider(apiKey: apiKey, log: _log);
-    }
+        // Opt-in only: the free tier is severely rate-limited, so absent config leaves it disabled.
+        => CreateCredentialGatedBackfillProvider<AlphaVantageHistoricalDataProvider>(
+            EnabledWhenOptedIn(cfg?.Enabled),
+            "ALPHA_VANTAGE_API_KEY",
+            cfg?.ApiKey,
+            apiKey => new AlphaVantageHistoricalDataProvider(apiKey: apiKey, log: _log));
 
     private IHistoricalDataProvider? CreateFredBackfillProvider(FredBackfillConfig? cfg)
-    {
-        if (!(cfg?.Enabled ?? false))
-            return null;
-
-        var credentials = CreateCredentialContext<FredHistoricalDataProvider>(
-            ("FRED_API_KEY", cfg?.ApiKey));
-        var apiKey = credentials.Get("FRED_API_KEY");
-        if (string.IsNullOrEmpty(apiKey))
-            return null;
-
-        return new FredHistoricalDataProvider(apiKey: apiKey, log: _log);
-    }
+        => CreateCredentialGatedBackfillProvider<FredHistoricalDataProvider>(
+            EnabledWhenOptedIn(cfg?.Enabled),
+            "FRED_API_KEY",
+            cfg?.ApiKey,
+            apiKey => new FredHistoricalDataProvider(apiKey: apiKey, log: _log));
 
     private IHistoricalDataProvider? CreateNasdaqBackfillProvider(NasdaqBackfillConfig? cfg)
     {
-        if (!(cfg?.Enabled ?? true))
+        if (!EnabledByDefault(cfg?.Enabled))
             return null;
 
+        // Nasdaq Data Link serves a limited free universe without a key, so an absent
+        // credential is not disqualifying — the key only raises rate limits.
         var credentials = CreateCredentialContext<NasdaqDataLinkHistoricalDataProvider>(
             ("NASDAQ_DATA_LINK_API_KEY", cfg?.ApiKey));
         var apiKey = credentials.Get("NASDAQ_DATA_LINK_API_KEY");
@@ -340,21 +306,15 @@ public sealed class ProviderFactory
     }
 
     private IHistoricalDataProvider? CreateRobinhoodBackfillProvider(RobinhoodConfig? cfg)
-    {
-        if (cfg?.Enabled != true)
-            return null;
-
-        var credentials = CreateCredentialContext<RobinhoodHistoricalDataProvider>(
-            ("ROBINHOOD_ACCESS_TOKEN", null));
-        var accessToken = credentials.Get("ROBINHOOD_ACCESS_TOKEN");
-        if (string.IsNullOrEmpty(accessToken))
-            return null;
-
-        return new RobinhoodHistoricalDataProvider(
-            accessToken: accessToken,
-            priority: cfg.Priority,
-            log: _log);
-    }
+        // Opt-in only: unofficial API that requires an explicitly supplied access token.
+        => CreateCredentialGatedBackfillProvider<RobinhoodHistoricalDataProvider>(
+            EnabledWhenOptedIn(cfg?.Enabled),
+            "ROBINHOOD_ACCESS_TOKEN",
+            configuredValue: null,
+            accessToken => new RobinhoodHistoricalDataProvider(
+                accessToken: accessToken,
+                priority: cfg!.Priority,
+                log: _log));
 
     /// <summary>
     /// Creates all configured symbol search providers.
@@ -366,31 +326,31 @@ public sealed class ProviderFactory
         var backfillProviders = _config.Backfill?.Providers;
 
         // Synthetic reference universe search
-        TryAddSearchProvider(providers, () => CreateSyntheticSearchProvider(backfillProviders?.Synthetic));
+        TryAddSearchProvider(providers, "synthetic", () => CreateSyntheticSearchProvider(backfillProviders?.Synthetic));
 
         // Alpaca Symbol Search (uses same credentials as Alpaca backfill)
-        TryAddSearchProvider(providers, () => CreateAlpacaSearchProvider(backfillProviders?.Alpaca));
+        TryAddSearchProvider(providers, "alpaca", () => CreateAlpacaSearchProvider(backfillProviders?.Alpaca));
 
         // Finnhub Symbol Search (uses same credentials as Finnhub backfill)
-        TryAddSearchProvider(providers, () => CreateFinnhubSearchProvider(backfillProviders?.Finnhub));
+        TryAddSearchProvider(providers, "finnhub", () => CreateFinnhubSearchProvider(backfillProviders?.Finnhub));
 
         // Tiingo Symbol Search (uses same credentials as Tiingo backfill)
-        TryAddSearchProvider(providers, () => CreateTiingoSearchProvider(backfillProviders?.Tiingo));
+        TryAddSearchProvider(providers, "tiingo", () => CreateTiingoSearchProvider(backfillProviders?.Tiingo));
 
         // Alpha Vantage Symbol Search (uses same credentials as Alpha Vantage backfill)
-        TryAddSearchProvider(providers, () => CreateAlphaVantageSearchProvider(backfillProviders?.AlphaVantage));
+        TryAddSearchProvider(providers, "alphavantage", () => CreateAlphaVantageSearchProvider(backfillProviders?.AlphaVantage));
 
         // Twelve Data Symbol Search (uses same credentials as Twelve Data backfill)
-        TryAddSearchProvider(providers, CreateTwelveDataSearchProvider);
+        TryAddSearchProvider(providers, "twelvedata", CreateTwelveDataSearchProvider);
 
         // FRED Symbol Search (uses same credentials as FRED backfill)
-        TryAddSearchProvider(providers, () => CreateFredSearchProvider(backfillProviders?.Fred));
+        TryAddSearchProvider(providers, "fred", () => CreateFredSearchProvider(backfillProviders?.Fred));
 
         // Nasdaq Data Link Symbol Search (uses same credentials as Nasdaq Data Link backfill)
-        TryAddSearchProvider(providers, () => CreateNasdaqSearchProvider(backfillProviders?.Nasdaq));
+        TryAddSearchProvider(providers, "nasdaq", () => CreateNasdaqSearchProvider(backfillProviders?.Nasdaq));
 
         // Polygon Symbol Search (uses same credentials as Polygon backfill)
-        TryAddSearchProvider(providers, () => CreatePolygonSearchProvider(backfillProviders?.Polygon));
+        TryAddSearchProvider(providers, "polygon", () => CreatePolygonSearchProvider(backfillProviders?.Polygon));
 
         return providers
             .OrderBy(p => p.Priority)
@@ -399,6 +359,7 @@ public sealed class ProviderFactory
 
     private void TryAddSearchProvider(
         List<ISymbolSearchProvider> providers,
+        string providerLabel,
         Func<ISymbolSearchProvider?> factory)
     {
         try
@@ -411,14 +372,16 @@ public sealed class ProviderFactory
         }
         catch (Exception ex)
         {
-            _log.Warning(ex, "Failed to create symbol search provider");
+            // Isolate one provider's construction failure so the rest still register, but name the
+            // provider and surface the exception so configuration/credential errors are not silent.
+            _log.Warning(ex, "Failed to create symbol search provider {Provider}; skipping it for this run", providerLabel);
         }
     }
 
 
     private ISymbolSearchProvider? CreateSyntheticSearchProvider(SyntheticMarketDataConfig? cfg)
     {
-        if (cfg?.Enabled != true)
+        if (!EnabledWhenOptedIn(cfg?.Enabled))
             return null;
 
         return new SyntheticMarketDataClient(new NullMarketEventPublisher(), cfg);
@@ -426,8 +389,8 @@ public sealed class ProviderFactory
 
     private ISymbolSearchProvider? CreateAlpacaSearchProvider(AlpacaBackfillConfig? cfg)
     {
-        // Enabled by default if config is null (credential-based activation)
-        if (cfg != null && !cfg.Enabled)
+        // Enabled by default unless config explicitly disables it (credential-based activation).
+        if (!EnabledByDefault(cfg?.Enabled))
             return null;
 
         var credentials = CreateCredentialContext<AlpacaHistoricalDataProvider>(
@@ -435,110 +398,62 @@ public sealed class ProviderFactory
             ("ALPACA_SECRET_KEY", cfg?.SecretKey));
         var keyId = credentials.Get("ALPACA_KEY_ID");
         var secretKey = credentials.Get("ALPACA_SECRET_KEY");
-        if (string.IsNullOrEmpty(keyId) || string.IsNullOrEmpty(secretKey))
+        if (string.IsNullOrWhiteSpace(keyId) || string.IsNullOrWhiteSpace(secretKey))
             return null;
 
         return new AlpacaSymbolSearchProviderRefactored(keyId, secretKey, httpClient: null, log: _log);
     }
 
     private ISymbolSearchProvider? CreateFinnhubSearchProvider(FinnhubBackfillConfig? cfg)
-    {
-        // Enabled by default if config is null (credential-based activation)
-        if (cfg != null && !cfg.Enabled)
-            return null;
-
-        var credentials = CreateCredentialContext<FinnhubHistoricalDataProvider>(
-            ("FINNHUB_API_KEY", cfg?.ApiKey));
-        var apiKey = credentials.Get("FINNHUB_API_KEY");
-        if (string.IsNullOrEmpty(apiKey))
-            return null;
-
-        return new FinnhubSymbolSearchProviderRefactored(apiKey, httpClient: null, log: _log);
-    }
+        => CreateCredentialGatedSearchProvider<FinnhubHistoricalDataProvider>(
+            EnabledByDefault(cfg?.Enabled),
+            "FINNHUB_API_KEY",
+            cfg?.ApiKey,
+            apiKey => new FinnhubSymbolSearchProviderRefactored(apiKey, httpClient: null, log: _log));
 
     private ISymbolSearchProvider? CreateTiingoSearchProvider(TiingoBackfillConfig? cfg)
-    {
-        // Enabled by default if config is null (credential-based activation)
-        if (cfg != null && !cfg.Enabled)
-            return null;
-
-        var credentials = CreateCredentialContext<TiingoHistoricalDataProvider>(
-            ("TIINGO_API_TOKEN", cfg?.ApiToken));
-        var token = credentials.Get("TIINGO_API_TOKEN");
-        if (string.IsNullOrEmpty(token))
-            return null;
-
-        return new TiingoSymbolSearchProvider(token, httpClient: null, log: _log);
-    }
+        => CreateCredentialGatedSearchProvider<TiingoHistoricalDataProvider>(
+            EnabledByDefault(cfg?.Enabled),
+            "TIINGO_API_TOKEN",
+            cfg?.ApiToken,
+            token => new TiingoSymbolSearchProvider(token, httpClient: null, log: _log));
 
     private ISymbolSearchProvider? CreateAlphaVantageSearchProvider(AlphaVantageBackfillConfig? cfg)
-    {
         // Keep Alpha Vantage opt-in to avoid consuming the constrained free-tier quota implicitly.
-        if (!(cfg?.Enabled ?? false))
-            return null;
-
-        var credentials = CreateCredentialContext<AlphaVantageHistoricalDataProvider>(
-            ("ALPHA_VANTAGE_API_KEY", cfg?.ApiKey));
-        var apiKey = credentials.Get("ALPHA_VANTAGE_API_KEY");
-        if (string.IsNullOrEmpty(apiKey))
-            return null;
-
-        return new AlphaVantageSymbolSearchProvider(apiKey, httpClient: null, log: _log);
-    }
+        => CreateCredentialGatedSearchProvider<AlphaVantageHistoricalDataProvider>(
+            EnabledWhenOptedIn(cfg?.Enabled),
+            "ALPHA_VANTAGE_API_KEY",
+            cfg?.ApiKey,
+            apiKey => new AlphaVantageSymbolSearchProvider(apiKey, httpClient: null, log: _log));
 
     private ISymbolSearchProvider? CreateTwelveDataSearchProvider()
-    {
-        var credentials = CreateCredentialContext<TwelveDataHistoricalDataProvider>(
-            ("TWELVEDATA_API_KEY", null));
-        var apiKey = credentials.Get("TWELVEDATA_API_KEY");
-        if (string.IsNullOrEmpty(apiKey))
-            return null;
-
-        return new TwelveDataSymbolSearchProvider(apiKey, httpClient: null, log: _log);
-    }
+        => CreateCredentialGatedSearchProvider<TwelveDataHistoricalDataProvider>(
+            enabled: true,
+            "TWELVEDATA_API_KEY",
+            configuredValue: null,
+            apiKey => new TwelveDataSymbolSearchProvider(apiKey, httpClient: null, log: _log));
 
     private ISymbolSearchProvider? CreateFredSearchProvider(FredBackfillConfig? cfg)
-    {
-        if (cfg != null && !cfg.Enabled)
-            return null;
-
-        var credentials = CreateCredentialContext<FredHistoricalDataProvider>(
-            ("FRED_API_KEY", cfg?.ApiKey));
-        var apiKey = credentials.Get("FRED_API_KEY");
-        if (string.IsNullOrEmpty(apiKey))
-            return null;
-
-        return new FredSymbolSearchProvider(apiKey, httpClient: null, log: _log);
-    }
+        => CreateCredentialGatedSearchProvider<FredHistoricalDataProvider>(
+            EnabledByDefault(cfg?.Enabled),
+            "FRED_API_KEY",
+            cfg?.ApiKey,
+            apiKey => new FredSymbolSearchProvider(apiKey, httpClient: null, log: _log));
 
     private ISymbolSearchProvider? CreateNasdaqSearchProvider(NasdaqBackfillConfig? cfg)
-    {
-        if (cfg != null && !cfg.Enabled)
-            return null;
-
-        var credentials = CreateCredentialContext<NasdaqDataLinkHistoricalDataProvider>(
-            ("NASDAQ_DATA_LINK_API_KEY", cfg?.ApiKey));
-        var apiKey = credentials.Get("NASDAQ_DATA_LINK_API_KEY");
-        if (string.IsNullOrEmpty(apiKey))
-            return null;
-
-        return new NasdaqDataLinkSymbolSearchProvider(apiKey, httpClient: null, log: _log);
-    }
+        => CreateCredentialGatedSearchProvider<NasdaqDataLinkHistoricalDataProvider>(
+            EnabledByDefault(cfg?.Enabled),
+            "NASDAQ_DATA_LINK_API_KEY",
+            cfg?.ApiKey,
+            apiKey => new NasdaqDataLinkSymbolSearchProvider(apiKey, httpClient: null, log: _log));
 
     private ISymbolSearchProvider? CreatePolygonSearchProvider(PolygonBackfillConfig? cfg)
-    {
-        // Enabled by default if config is null (credential-based activation)
-        if (cfg != null && !cfg.Enabled)
-            return null;
-
-        var credentials = CreateCredentialContext<PolygonHistoricalDataProvider>(
-            ("POLYGON_API_KEY", cfg?.ApiKey));
-        var apiKey = credentials.Get("POLYGON_API_KEY");
-        if (string.IsNullOrEmpty(apiKey))
-            return null;
-
-        return new PolygonSymbolSearchProvider(apiKey, httpClient: null, log: _log);
-    }
+        // Enabled by default unless config explicitly disables it (credential-based activation).
+        => CreateCredentialGatedSearchProvider<PolygonHistoricalDataProvider>(
+            EnabledByDefault(cfg?.Enabled),
+            "POLYGON_API_KEY",
+            cfg?.ApiKey,
+            apiKey => new PolygonSymbolSearchProvider(apiKey, httpClient: null, log: _log));
 
     /// <summary>
     /// Creates a composite backfill provider with automatic failover.
@@ -561,6 +476,60 @@ public sealed class ProviderFactory
             enableCrossValidation: false,
             log: _log);
     }
+
+    /// <summary>
+    /// A provider participates unless its configuration explicitly disables it.
+    /// Absent configuration (<see langword="null"/>) is treated as enabled.
+    /// </summary>
+    private static bool EnabledByDefault(bool? configuredEnabled) => configuredEnabled != false;
+
+    /// <summary>
+    /// A provider participates only when its configuration explicitly enables it.
+    /// Absent configuration (<see langword="null"/>) is treated as disabled (opt-in).
+    /// </summary>
+    private static bool EnabledWhenOptedIn(bool? configuredEnabled) => configuredEnabled == true;
+
+    /// <summary>
+    /// Shared template for the single-credential, credential-gated providers. Resolves one
+    /// credential through the attribute-based <typeparamref name="TCredentialSource"/> context
+    /// and invokes <paramref name="factory"/> only when the provider is <paramref name="enabled"/>
+    /// and the credential resolves to a non-blank value. Returns <see langword="null"/> (provider
+    /// omitted) when disabled or the credential is absent.
+    /// </summary>
+    /// <typeparam name="TCredentialSource">
+    /// The provider type whose <c>[RequiresCredential]</c> attributes drive credential resolution.
+    /// Symbol-search providers reuse their historical-provider counterpart's credential metadata.
+    /// </typeparam>
+    /// <typeparam name="TResult">The provider interface returned by <paramref name="factory"/>.</typeparam>
+    private TResult? CreateCredentialGatedProvider<TCredentialSource, TResult>(
+        bool enabled,
+        string credentialName,
+        string? configuredValue,
+        Func<string, TResult> factory)
+        where TResult : class
+    {
+        if (!enabled)
+            return null;
+
+        var credential = CreateCredentialContext<TCredentialSource>((credentialName, configuredValue)).Get(credentialName);
+        return string.IsNullOrWhiteSpace(credential) ? null : factory(credential);
+    }
+
+    private IHistoricalDataProvider? CreateCredentialGatedBackfillProvider<TCredentialSource>(
+        bool enabled,
+        string credentialName,
+        string? configuredValue,
+        Func<string, IHistoricalDataProvider> factory)
+        => CreateCredentialGatedProvider<TCredentialSource, IHistoricalDataProvider>(
+            enabled, credentialName, configuredValue, factory);
+
+    private ISymbolSearchProvider? CreateCredentialGatedSearchProvider<TCredentialSource>(
+        bool enabled,
+        string credentialName,
+        string? configuredValue,
+        Func<string, ISymbolSearchProvider> factory)
+        => CreateCredentialGatedProvider<TCredentialSource, ISymbolSearchProvider>(
+            enabled, credentialName, configuredValue, factory);
 
     private ICredentialContext CreateCredentialContext<TProvider>(params (string Name, string? Value)[] configuredValues)
     {


### PR DESCRIPTION
## Summary

Behavior-preserving quality refactor across four subsystems, addressing 15 reported issues:

**`ProviderFactory` (issues 1, 2, 10, 11, 12)**
- Extracted a single-credential `CreateCredentialGatedProvider<TCredentialSource, TResult>` template (plus thin backfill/search wrappers) that collapses the eight near-identical `Create*BackfillProvider` methods and the mirror `Create*SearchProvider` methods into one-line factories.
- Added `EnabledByDefault` / `EnabledWhenOptedIn` helpers so the previously inconsistent `?? true` / `?? false` / `!= true` idioms are uniform and self-documenting, while preserving each provider's existing default.
- Credentials are now treated as missing when whitespace-only (`IsNullOrWhiteSpace`), and the isolate-and-log catch names the provider so configuration/credential errors are no longer swallowed anonymously.

**`AutoGapRemediationService` (issues 3, 4, 5, 6, 7, 13, 14, 15)**
- Split the god class: cooldown state moved to `RemediationCooldownTracker`, SLA status projection moved to `BackfillRemediationSlaEvaluator`.
- Documented the synchronization model (per-idempotency-key `lock` vs. the concurrency `SemaphoreSlim` vs. lock-free cooldowns) and the idempotency-gate locking, establishing there is no lock-ordering cycle.
- Event-driven remediation is now tracked under a shutdown `CancellationTokenSource`, drained in `Dispose`, with background faults observed instead of fire-and-forget.
- Extracted named boolean helpers from the nested-ternary SLA classification; added `Create` policy builders and scope docs for the `TimeSpan` policy fields.

**`EventPipeline` / config (issue 8)**
- Added optional `PipelineRuntimeConfig` (final/sink flush timeouts) to `AppConfig`, registered it for source-generated serialization, and wired it through the pipeline DI registration so the flush timeouts are operator-tunable. Defaults (30s / 60s) are unchanged when unset.

**`DirectLendingServicerStatementService` (issue 9)**
- Documented the `_gate` lock-ordering invariant (single monitor; no I/O or `await` under the lock), removing the ambiguous deadlock-risk concern.

## Reason

Addresses a reported list of maintainability/robustness findings (duplication, mixed synchronization, undocumented locking, fire-and-forget without cancellation, hardcoded config, and silent error swallowing) across the provider factory, gap-remediation, pipeline, and direct-lending code paths.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [ ] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

> Note: the change is intended to be behavior-preserving and is covered by the existing `AutoGapRemediationServiceTests` and `ProviderFactoryCredentialContextTests` suites. The authoring environment has no .NET SDK, so no local build/test was run — CI `quality-gate` is the authoritative gate and must pass before merge.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BR6cMTZVurpxusMKuFvguJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BR6cMTZVurpxusMKuFvguJ)_