### PR TITLE
Extract the workstation session payload into a partial

### DIFF
--- a/build/config/file-size-baseline.json
+++ b/build/config/file-size-baseline.json
@@ -11,7 +11,7 @@
     "src/Meridian.FinancialOperations/PrivateCapital/PrivateCapitalCloseCockpitService.cs": 2052,
     "src/Meridian.Ui.Shared/Endpoints/FundStructureEndpoints.cs": 3028,
     "src/Meridian.Ui.Shared/Endpoints/LedgerEndpoints.cs": 3646,
-    "src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs": 5451,
+    "src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs": 5384,
     "src/Meridian.Ui.Shared/Evidence/EvidenceContributors.cs": 2954,
     "src/Meridian.Ui.Shared/Evidence/FileEvidenceArtifactStore.cs": 2633,
     "src/Meridian.Ui.Shared/Services/AccountingProductionReadinessService.cs": 3518,

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Session.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.Session.cs
@@ -1,0 +1,83 @@
+using Meridian.Contracts.Workstation;
+using Meridian.Strategies.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meridian.Ui.Shared.Endpoints;
+
+/// <summary>
+/// Workstation session bootstrap payload for the API surface: builds the typed session DTO
+/// (latest strategy-run digest, workspace summaries) and its display-name / role / environment /
+/// workspace mapping helpers. Split out of the WorkstationEndpoints core partial as a
+/// behavior-preserving relocation; the inline session route lambda and the shared BuildRunDigest
+/// helper remain in core (reached across the partial).
+/// </summary>
+public static partial class WorkstationEndpoints
+{
+    // PR-03: returns typed DTO instead of anonymous object
+    private static async Task<WorkstationSessionPayload> BuildSessionPayloadAsync(HttpContext context)
+    {
+        var readService = context.RequestServices.GetService<StrategyRunReadService>();
+        if (readService is null)
+        {
+            return new WorkstationSessionPayload(
+                DisplayName: "Meridian Operator",
+                Role: "Strategy Lead",
+                Environment: "paper",
+                ActiveWorkspace: "strategy",
+                CommandCount: 6,
+                LatestRun: null,
+                WorkspaceSummary: new WorkstationSessionWorkspaceSummary(0, 0, 0, 0, 0));
+        }
+
+        var runs = (await readService.GetRunsAsync(ct: context.RequestAborted).ConfigureAwait(false)).ToArray();
+        var latest = runs.FirstOrDefault();
+        var latestDetail = latest is null
+            ? null
+            : await readService.GetRunDetailAsync(latest.RunId, context.RequestAborted).ConfigureAwait(false);
+        var activeRuns = runs.Count(static run => run.Status is StrategyRunStatus.Running or StrategyRunStatus.Paused);
+        var reviewRuns = runs.Count(static run => run.Promotion?.RequiresReview == true || run.Status is StrategyRunStatus.Failed or StrategyRunStatus.Cancelled);
+
+        return new WorkstationSessionPayload(
+            DisplayName: BuildDisplayName(latest),
+            Role: BuildRole(latest),
+            Environment: MapEnvironment(latest),
+            ActiveWorkspace: MapWorkspace(latest),
+            CommandCount: Math.Max(6, runs.Length + activeRuns + reviewRuns),
+            LatestRun: latest is null ? null : BuildRunDigest(latest, latestDetail),
+            WorkspaceSummary: new WorkstationSessionWorkspaceSummary(
+                TotalRuns: runs.Length,
+                ActiveRuns: activeRuns,
+                ReviewRuns: reviewRuns,
+                LedgerCoverage: runs.Count(static run => !string.IsNullOrWhiteSpace(run.LedgerReference)),
+                PortfolioCoverage: runs.Count(static run => !string.IsNullOrWhiteSpace(run.PortfolioId))));
+    }
+
+    private static string BuildDisplayName(StrategyRunSummary? latest)
+        => latest is null ? "Meridian Operator" : $"{latest.StrategyName} Desk";
+
+    private static string BuildRole(StrategyRunSummary? latest)
+        => latest is null
+            ? "Strategy Lead"
+            : latest.Mode == StrategyRunMode.Live
+                ? "Live Operations"
+                : "Strategy Lead";
+
+    private static string MapEnvironment(StrategyRunSummary? latest)
+        => latest?.Mode switch
+        {
+            StrategyRunMode.Live => "live",
+            StrategyRunMode.Paper => "paper",
+            StrategyRunMode.Backtest => "research",
+            _ => "paper"
+        };
+
+    private static string MapWorkspace(StrategyRunSummary? latest)
+        => latest?.Promotion?.State switch
+        {
+            StrategyRunPromotionState.LiveManaged => "accounting",
+            StrategyRunPromotionState.CandidateForLive => "trading",
+            StrategyRunPromotionState.CandidateForPaper => "strategy",
+            _ => latest?.Mode == StrategyRunMode.Live ? "trading" : "strategy"
+        };
+}

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs
@@ -2862,45 +2862,6 @@ public static partial class WorkstationEndpoints
     }
 
     // PR-03: returns typed DTO instead of anonymous object
-    private static async Task<WorkstationSessionPayload> BuildSessionPayloadAsync(HttpContext context)
-    {
-        var readService = context.RequestServices.GetService<StrategyRunReadService>();
-        if (readService is null)
-        {
-            return new WorkstationSessionPayload(
-                DisplayName: "Meridian Operator",
-                Role: "Strategy Lead",
-                Environment: "paper",
-                ActiveWorkspace: "strategy",
-                CommandCount: 6,
-                LatestRun: null,
-                WorkspaceSummary: new WorkstationSessionWorkspaceSummary(0, 0, 0, 0, 0));
-        }
-
-        var runs = (await readService.GetRunsAsync(ct: context.RequestAborted).ConfigureAwait(false)).ToArray();
-        var latest = runs.FirstOrDefault();
-        var latestDetail = latest is null
-            ? null
-            : await readService.GetRunDetailAsync(latest.RunId, context.RequestAborted).ConfigureAwait(false);
-        var activeRuns = runs.Count(static run => run.Status is StrategyRunStatus.Running or StrategyRunStatus.Paused);
-        var reviewRuns = runs.Count(static run => run.Promotion?.RequiresReview == true || run.Status is StrategyRunStatus.Failed or StrategyRunStatus.Cancelled);
-
-        return new WorkstationSessionPayload(
-            DisplayName: BuildDisplayName(latest),
-            Role: BuildRole(latest),
-            Environment: MapEnvironment(latest),
-            ActiveWorkspace: MapWorkspace(latest),
-            CommandCount: Math.Max(6, runs.Length + activeRuns + reviewRuns),
-            LatestRun: latest is null ? null : BuildRunDigest(latest, latestDetail),
-            WorkspaceSummary: new WorkstationSessionWorkspaceSummary(
-                TotalRuns: runs.Length,
-                ActiveRuns: activeRuns,
-                ReviewRuns: reviewRuns,
-                LedgerCoverage: runs.Count(static run => !string.IsNullOrWhiteSpace(run.LedgerReference)),
-                PortfolioCoverage: runs.Count(static run => !string.IsNullOrWhiteSpace(run.PortfolioId))));
-    }
-
-    // PR-03: returns typed DTO instead of anonymous object
     private static async Task<WorkstationStrategyPayload> BuildStrategyPayloadAsync(HttpContext context)
     {
         var readService = context.RequestServices.GetService<StrategyRunReadService>();
@@ -4710,34 +4671,6 @@ public static partial class WorkstationEndpoints
             ],
             Alerts: alerts);
     }
-
-    private static string BuildDisplayName(StrategyRunSummary? latest)
-        => latest is null ? "Meridian Operator" : $"{latest.StrategyName} Desk";
-
-    private static string BuildRole(StrategyRunSummary? latest)
-        => latest is null
-            ? "Strategy Lead"
-            : latest.Mode == StrategyRunMode.Live
-                ? "Live Operations"
-                : "Strategy Lead";
-
-    private static string MapEnvironment(StrategyRunSummary? latest)
-        => latest?.Mode switch
-        {
-            StrategyRunMode.Live => "live",
-            StrategyRunMode.Paper => "paper",
-            StrategyRunMode.Backtest => "research",
-            _ => "paper"
-        };
-
-    private static string MapWorkspace(StrategyRunSummary? latest)
-        => latest?.Promotion?.State switch
-        {
-            StrategyRunPromotionState.LiveManaged => "accounting",
-            StrategyRunPromotionState.CandidateForLive => "trading",
-            StrategyRunPromotionState.CandidateForPaper => "strategy",
-            _ => latest?.Mode == StrategyRunMode.Live ? "trading" : "strategy"
-        };
 
     private static string BuildRunNotes(StrategyRunSummary run)
     {


### PR DESCRIPTION
## Summary

Behavior-preserving relocation. Increment 2l of the `WorkstationEndpoints.cs` decomposition: moves the **session bootstrap payload** builder (`BuildSessionPayloadAsync`) and its display-name/role/environment/workspace mapping helpers (`BuildDisplayName`, `BuildRole`, `MapEnvironment`, `MapWorkspace`) out of `src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.cs` into a new sibling partial `WorkstationEndpoints.Session.cs`.

Closed call graph: the 5 methods have zero references outside `WorkstationEndpoints.cs`; the only entry is the inline `GetWorkstationSession` route lambda (stays in core). The shared `BuildRunDigest` (in the StrategyBriefing partial) and `BuildRunNotes` (shared) remain in core and are reached across the `partial class`. No behavior, route, signature, or DI change.

Core `WorkstationEndpoints.cs` drops **5,451 → 5,385** lines; the no-new-god-file ratchet baseline is retightened.

## Reason

Continues the staged, behavior-preserving decomposition of the largest endpoint file toward the module-boundary goal in `docs/architecture/module-conventions.md` (following merged increments 2a–2k). Each increment stays small and independently CI-verifiable.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [ ] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Static verification (no local .NET SDK): each of the 5 methods defined exactly once in the new partial and 0 remaining in core; the shared `BuildRunNotes` and the route lambda retained in core; brace/paren balance preserved; closed call graph re-confirmed (0 references from other partials or any other `src` file); every referenced type's namespace verified; no trailing whitespace; final newline; single-blank seams at both removed blocks. `check-file-size.py` and `check-ai-inventory.py --summary` pass locally. Verbatim relocation — relying on CI `verify-fast`/`verify-dotnet`.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTfaY7p2TCSbenrQWgKtLT)_