### PR TITLE
Consolidate Security Master validation and surface the data-driven schema

### DIFF
--- a/src/Meridian.Application/SecurityMaster/SecurityMasterQueryService.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterQueryService.cs
@@ -255,8 +255,9 @@ public sealed class SecurityMasterQueryService : ISecurityMasterQueryService, Me
         // as-of term rebuild still governs which economic terms are returned, so this only
         // restores identity resolution — it never hands back today's terms under yesterday's
         // identity.
+        var identifierKindText = identifierKind.ToString();
         return universe.FirstOrDefault(candidate =>
-            MatchesIdentifierIgnoringWindow(candidate, identifierKind, normalizedValue, normalizedProvider));
+            MatchesIdentifierIgnoringWindow(candidate, identifierKind, identifierKindText, normalizedValue, normalizedProvider));
     }
 
     private static IReadOnlyList<string?> BuildLookupCandidates(string? value, Func<string?, string> normalize)
@@ -325,6 +326,7 @@ public sealed class SecurityMasterQueryService : ISecurityMasterQueryService, Me
     private static bool MatchesIdentifierIgnoringWindow(
         SecurityProjectionRecord candidate,
         SecurityIdentifierKind identifierKind,
+        string identifierKindText,
         string normalizedValue,
         string normalizedProvider)
     {
@@ -337,7 +339,7 @@ public sealed class SecurityMasterQueryService : ISecurityMasterQueryService, Me
         }
 
         if (candidate.Aliases.Any(alias =>
-                string.Equals(alias.AliasKind, identifierKind.ToString(), StringComparison.OrdinalIgnoreCase)
+                string.Equals(alias.AliasKind, identifierKindText, StringComparison.OrdinalIgnoreCase)
                 && alias.IsEnabled
                 && SecurityIdentifierNormalizer.NormalizeValue(identifierKind, alias.AliasValue).Equals(normalizedValue, StringComparison.Ordinal)
                 && ProviderMatches(alias.Provider, normalizedProvider)))
@@ -345,7 +347,7 @@ public sealed class SecurityMasterQueryService : ISecurityMasterQueryService, Me
             return true;
         }
 
-        return string.Equals(candidate.PrimaryIdentifierKind, identifierKind.ToString(), StringComparison.OrdinalIgnoreCase)
+        return string.Equals(candidate.PrimaryIdentifierKind, identifierKindText, StringComparison.OrdinalIgnoreCase)
                && SecurityIdentifierNormalizer.NormalizeValue(identifierKind, candidate.PrimaryIdentifierValue).Equals(normalizedValue, StringComparison.Ordinal);
     }
 

--- a/src/Meridian.Application/SecurityMaster/SecurityMasterQueryService.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterQueryService.cs
@@ -32,7 +32,13 @@ public sealed class SecurityMasterQueryService : ISecurityMasterQueryService, Me
     public async Task<SecurityDetailDto?> GetByIdentifierAsync(SecurityIdentifierKind identifierKind, string identifierValue, string? provider, CancellationToken ct = default, DateTimeOffset? asOfUtc = null)
     {
         var asOf = asOfUtc ?? DateTimeOffset.UtcNow;
-        var projection = await TryGetProjectionByIdentifierAsync(identifierKind, identifierValue, provider, asOf, ct)
+        var projection = await TryGetProjectionByIdentifierAsync(
+                identifierKind,
+                identifierValue,
+                provider,
+                asOf,
+                allowIdentityFallback: asOfUtc is not null,
+                ct)
             .ConfigureAwait(false);
         if (projection is null)
         {
@@ -203,6 +209,7 @@ public sealed class SecurityMasterQueryService : ISecurityMasterQueryService, Me
         string identifierValue,
         string? provider,
         DateTimeOffset asOf,
+        bool allowIdentityFallback,
         CancellationToken ct)
     {
         var providerCandidates = BuildLookupCandidates(provider, SecurityIdentifierNormalizer.NormalizeProvider);
@@ -234,7 +241,22 @@ public sealed class SecurityMasterQueryService : ISecurityMasterQueryService, Me
 
         var normalizedProvider = SecurityIdentifierNormalizer.NormalizeProvider(provider);
         var universe = await _store.LoadAllAsync(ct).ConfigureAwait(false);
-        return universe.FirstOrDefault(candidate => MatchesIdentifier(candidate, identifierKind, normalizedValue, normalizedProvider, asOf));
+        var asOfMatch = universe.FirstOrDefault(candidate =>
+            MatchesIdentifier(candidate, identifierKind, normalizedValue, normalizedProvider, asOf));
+        if (asOfMatch is not null || !allowIdentityFallback)
+        {
+            return asOfMatch;
+        }
+
+        // As-of fallback: an identifier row's recorded validity window is frequently its
+        // data-entry time rather than the real-world assignment time, so a point-in-time lookup
+        // can miss a security whose identity is genuinely stable. When nothing is active at the
+        // requested as-of, resolve by identity while ignoring the temporal window. The caller's
+        // as-of term rebuild still governs which economic terms are returned, so this only
+        // restores identity resolution — it never hands back today's terms under yesterday's
+        // identity.
+        return universe.FirstOrDefault(candidate =>
+            MatchesIdentifierIgnoringWindow(candidate, identifierKind, normalizedValue, normalizedProvider));
     }
 
     private static IReadOnlyList<string?> BuildLookupCandidates(string? value, Func<string?, string> normalize)
@@ -289,6 +311,33 @@ public sealed class SecurityMasterQueryService : ISecurityMasterQueryService, Me
                 string.Equals(alias.AliasKind, identifierKind.ToString(), StringComparison.OrdinalIgnoreCase)
                 && alias.ValidFrom <= asOf
                 && (!alias.ValidTo.HasValue || alias.ValidTo.Value > asOf)
+                && alias.IsEnabled
+                && SecurityIdentifierNormalizer.NormalizeValue(identifierKind, alias.AliasValue).Equals(normalizedValue, StringComparison.Ordinal)
+                && ProviderMatches(alias.Provider, normalizedProvider)))
+        {
+            return true;
+        }
+
+        return string.Equals(candidate.PrimaryIdentifierKind, identifierKind.ToString(), StringComparison.OrdinalIgnoreCase)
+               && SecurityIdentifierNormalizer.NormalizeValue(identifierKind, candidate.PrimaryIdentifierValue).Equals(normalizedValue, StringComparison.Ordinal);
+    }
+
+    private static bool MatchesIdentifierIgnoringWindow(
+        SecurityProjectionRecord candidate,
+        SecurityIdentifierKind identifierKind,
+        string normalizedValue,
+        string normalizedProvider)
+    {
+        if (candidate.Identifiers.Any(identifier =>
+                identifier.Kind == identifierKind
+                && SecurityIdentifierNormalizer.GetOrComputeNormalizedValue(identifier).Equals(normalizedValue, StringComparison.Ordinal)
+                && ProviderMatches(identifier.Provider, identifier.NormalizedProvider, normalizedProvider)))
+        {
+            return true;
+        }
+
+        if (candidate.Aliases.Any(alias =>
+                string.Equals(alias.AliasKind, identifierKind.ToString(), StringComparison.OrdinalIgnoreCase)
                 && alias.IsEnabled
                 && SecurityIdentifierNormalizer.NormalizeValue(identifierKind, alias.AliasValue).Equals(normalizedValue, StringComparison.Ordinal)
                 && ProviderMatches(alias.Provider, normalizedProvider)))

--- a/src/Meridian.Application/SecurityMaster/Validation/SecurityValidationService.cs
+++ b/src/Meridian.Application/SecurityMaster/Validation/SecurityValidationService.cs
@@ -300,8 +300,16 @@ public sealed class SecurityValidationService : ISecurityValidationService
 
         issues.AddRange(ValidatePrimaryIdentifierProjection(record, activePrimaryIdentifiers));
 
+        // Provider only distinguishes ProviderSymbol identities; canonical identifiers (ISIN,
+        // FIGI, RIC, ...) are provider-independent, so a repeated canonical value must collide
+        // even when the duplicate rows carry different provider annotations. Keep this consistent
+        // with cross-record duplicate detection below.
         var duplicateInRecord = activeIdentifiers
-            .GroupBy(static identifier => IdentifierKey(identifier, includeProvider: true), StringComparer.OrdinalIgnoreCase)
+            .GroupBy(
+                static identifier => IdentifierKey(
+                    identifier,
+                    includeProvider: identifier.Kind == SecurityIdentifierKind.ProviderSymbol),
+                StringComparer.OrdinalIgnoreCase)
             .FirstOrDefault(static group => group.Count() > 1);
         if (duplicateInRecord is not null)
         {

--- a/src/Meridian.Contracts/SecurityMaster/SecurityIdentifierNormalizer.cs
+++ b/src/Meridian.Contracts/SecurityMaster/SecurityIdentifierNormalizer.cs
@@ -73,7 +73,9 @@ public static class SecurityIdentifierNormalizer
             SecurityIdentifierKind.Cusip => ValidateCusip(normalized),
             SecurityIdentifierKind.Sedol => ValidateSedol(normalized),
             SecurityIdentifierKind.OccOptionSymbol => ValidateOccOptionSymbol(normalized),
-            SecurityIdentifierKind.Lei => normalized.Length == 20 && IsAlphaNumeric(normalized),
+            SecurityIdentifierKind.Lei => ValidateLei(normalized),
+            SecurityIdentifierKind.Figi => ValidateFigi(normalized),
+            SecurityIdentifierKind.Ric => ValidateRic(normalized),
             SecurityIdentifierKind.Wkn => normalized.Length == 6 && IsAlphaNumeric(normalized),
             SecurityIdentifierKind.Valoren => normalized.Length is >= 6 and <= 9 && IsDigitsOnly(normalized),
             SecurityIdentifierKind.Cik => normalized.Length is >= 1 and <= 10 && IsDigitsOnly(normalized),
@@ -86,7 +88,9 @@ public static class SecurityIdentifierNormalizer
             SecurityIdentifierKind.Cusip => "CUSIP must be a 9-character code with a valid check digit.",
             SecurityIdentifierKind.Sedol => "SEDOL must be a 7-character alphanumeric code with a valid check digit.",
             SecurityIdentifierKind.OccOptionSymbol => "OCC option symbols must match the compact OSI format: root(1-6) + yymmdd + C/P + 8-digit strike.",
-            SecurityIdentifierKind.Lei => "LEI must be a 20-character alphanumeric code.",
+            SecurityIdentifierKind.Lei => "LEI must be a 20-character alphanumeric code with a valid ISO 17442 (mod 97-10) check digit.",
+            SecurityIdentifierKind.Figi => "FIGI must be a 12-character code of consonants and digits with 'G' in position 3 and a valid check digit.",
+            SecurityIdentifierKind.Ric => "RIC must be 1-40 characters using letters, digits, and RIC punctuation (. = # / ^ : _ -).",
             SecurityIdentifierKind.Wkn => "WKN must be a 6-character alphanumeric code.",
             SecurityIdentifierKind.Valoren => "Valoren must be a 6- to 9-digit Swiss security number.",
             SecurityIdentifierKind.Cik => "CIK must be a 1- to 10-digit SEC issuer code.",
@@ -304,5 +308,112 @@ public static class SecurityIdentifierNormalizer
 
         var strike = normalized[(rootLength + 7)..];
         return strike.Length == 8 && strike.All(static character => character is >= '0' and <= '9');
+    }
+
+    private static bool ValidateLei(string normalized)
+    {
+        if (normalized.Length != 20 || !IsAlphaNumeric(normalized))
+        {
+            return false;
+        }
+
+        // ISO 17442 carries an ISO 7064 MOD 97-10 checksum in the last two digits. Expanding
+        // letters to two-digit values (A=10 .. Z=35) and taking the whole 20-character code
+        // modulo 97 yields 1 for a valid LEI. See also the reference algorithm in
+        // src/Meridian.FSharp/Domain/SecurityIdentifiers.fs.
+        return Mod97(normalized) == 1;
+    }
+
+    private static bool ValidateFigi(string normalized)
+    {
+        if (normalized.Length != 12)
+        {
+            return false;
+        }
+
+        // FIGI values use upper-case consonants (vowels are never used, to avoid ISIN/ticker
+        // collisions) and digits; the third character is always 'G' and the last is a MOD-10
+        // check digit.
+        for (var index = 0; index < 12; index++)
+        {
+            var character = normalized[index];
+            var isDigit = character is >= '0' and <= '9';
+            var isConsonant = character is >= 'A' and <= 'Z' && !IsVowel(character);
+            if (!isDigit && !isConsonant)
+            {
+                return false;
+            }
+        }
+
+        if (normalized[2] != 'G' || !char.IsDigit(normalized[11]))
+        {
+            return false;
+        }
+
+        return FigiCheckDigit(normalized) == normalized[11] - '0';
+    }
+
+    private static bool ValidateRic(string normalized)
+    {
+        // Reuters Instrument Codes are a root plus optional exchange/chain suffix and may include
+        // '.', '=', '#', '/', '^', ':', '_' and '-'. There is no published check digit, so this
+        // stays a lightweight structural guard: RIC characters only, at least one alphanumeric,
+        // and no embedded whitespace (already removed by trimming during normalization).
+        if (normalized.Length is < 1 or > 40)
+        {
+            return false;
+        }
+
+        var hasAlphaNumeric = false;
+        foreach (var character in normalized)
+        {
+            if (char.IsLetterOrDigit(character))
+            {
+                hasAlphaNumeric = true;
+            }
+            else if (character is not ('.' or '=' or '#' or '/' or '^' or ':' or '_' or '-'))
+            {
+                return false;
+            }
+        }
+
+        return hasAlphaNumeric;
+    }
+
+    private static bool IsVowel(char character)
+        => character is 'A' or 'E' or 'I' or 'O' or 'U';
+
+    private static int Mod97(string value)
+    {
+        var remainder = 0;
+        foreach (var character in value)
+        {
+            remainder = char.IsDigit(character)
+                ? (remainder * 10 + (character - '0')) % 97
+                : (remainder * 100 + (character - 'A' + 10)) % 97;
+        }
+
+        return remainder;
+    }
+
+    private static int FigiCheckDigit(string figi)
+    {
+        // Luhn-style MOD 10 over the first 11 characters (digits keep face value; letters map
+        // A=10 .. Z=35); values in odd (0-based) positions are doubled and their decimal digits
+        // summed. The check digit makes the running total a multiple of 10.
+        var sum = 0;
+        for (var index = 0; index < 11; index++)
+        {
+            var character = figi[index];
+            var value = char.IsDigit(character) ? character - '0' : character - 'A' + 10;
+            if (index % 2 == 1)
+            {
+                value *= 2;
+            }
+
+            sum += (value / 10) + (value % 10);
+        }
+
+        return (10 - (sum % 10)) % 10;
     }
 }

--- a/src/Meridian.Contracts/SecurityMaster/SecurityIdentifierNormalizer.cs
+++ b/src/Meridian.Contracts/SecurityMaster/SecurityIdentifierNormalizer.cs
@@ -364,10 +364,13 @@ public static class SecurityIdentifierNormalizer
             return false;
         }
 
+        // RICs are strictly ASCII; use an explicit ASCII test rather than the Unicode-aware
+        // char.IsLetterOrDigit so accented/non-Latin letters cannot bypass the guard. Values are
+        // already upper-cased during normalization.
         var hasAlphaNumeric = false;
         foreach (var character in normalized)
         {
-            if (char.IsLetterOrDigit(character))
+            if (character is (>= 'A' and <= 'Z') or (>= '0' and <= '9'))
             {
                 hasAlphaNumeric = true;
             }

--- a/tests/Meridian.Tests/SecurityMaster/SecurityIdentifierNormalizerTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityIdentifierNormalizerTests.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+using Meridian.Contracts.SecurityMaster;
+
+namespace Meridian.Tests.SecurityMaster;
+
+/// <summary>
+/// Format-validation and normalization coverage for the identifier kinds that previously had no
+/// (or check-digit-free) validation: LEI (ISO 17442 mod 97-10), FIGI (structure + mod-10 check
+/// digit), and RIC (lightweight structural guard).
+/// </summary>
+public sealed class SecurityIdentifierNormalizerTests
+{
+    [Theory]
+    [InlineData("HWUPKR0MPOU8FGXBT394")] // Apple Inc. LEI (valid ISO 7064 mod 97-10 checksum).
+    [InlineData("hwupkr0mpou8fgxbt394")] // Case-insensitive: normalized to upper before validation.
+    public void TryValidateFormat_ValidLei_Succeeds(string value)
+    {
+        var isValid = SecurityIdentifierNormalizer.TryValidateFormat(SecurityIdentifierKind.Lei, value, out var message);
+
+        isValid.Should().BeTrue();
+        message.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("HWUPKR0MPOU8FGXBT395")] // Wrong check digits (mod-97 != 1).
+    [InlineData("HWUPKR0MPOU8FGXBT39")]  // Too short.
+    [InlineData("HWUPKR0MPOU8FGXBT3940")] // Too long.
+    public void TryValidateFormat_InvalidLei_FailsWithCheckDigitMessage(string value)
+    {
+        var isValid = SecurityIdentifierNormalizer.TryValidateFormat(SecurityIdentifierKind.Lei, value, out var message);
+
+        isValid.Should().BeFalse();
+        message.Should().Contain("LEI");
+    }
+
+    [Theory]
+    [InlineData("BBG000B9XRY4")] // Apple Inc. FIGI.
+    [InlineData("BBG000B9Y5X2")] // Apple composite FIGI.
+    [InlineData("BBG001S5N8V8")] // Apple share-class FIGI.
+    public void TryValidateFormat_ValidFigi_Succeeds(string value)
+    {
+        var isValid = SecurityIdentifierNormalizer.TryValidateFormat(SecurityIdentifierKind.Figi, value, out var message);
+
+        isValid.Should().BeTrue();
+        message.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("BBG000B9XRY5")] // Wrong check digit.
+    [InlineData("BBB000B9XRY4")] // No 'G' in position 3.
+    [InlineData("BBG0A0B9XRY4")] // Contains a vowel.
+    [InlineData("BBG000B9XRY")]  // Too short.
+    public void TryValidateFormat_InvalidFigi_FailsWithFigiMessage(string value)
+    {
+        var isValid = SecurityIdentifierNormalizer.TryValidateFormat(SecurityIdentifierKind.Figi, value, out var message);
+
+        isValid.Should().BeFalse();
+        message.Should().Contain("FIGI");
+    }
+
+    [Theory]
+    [InlineData("AAPL.O")]
+    [InlineData("EUR=")]
+    [InlineData("GBP=D2")]
+    [InlineData("0#.FTSE")]
+    public void TryValidateFormat_ValidRic_Succeeds(string value)
+    {
+        var isValid = SecurityIdentifierNormalizer.TryValidateFormat(SecurityIdentifierKind.Ric, value, out var message);
+
+        isValid.Should().BeTrue();
+        message.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("AAPL O")]   // Embedded whitespace.
+    [InlineData("AAPL$O")]   // Illegal character.
+    [InlineData("....")]     // No alphanumeric content.
+    public void TryValidateFormat_InvalidRic_Fails(string value)
+    {
+        var isValid = SecurityIdentifierNormalizer.TryValidateFormat(SecurityIdentifierKind.Ric, value, out var message);
+
+        isValid.Should().BeFalse();
+        message.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void NormalizeValue_Figi_StripsPunctuationAndUppercases()
+        => SecurityIdentifierNormalizer.NormalizeValue(SecurityIdentifierKind.Figi, " bbg-000-b9xry4 ")
+            .Should().Be("BBG000B9XRY4");
+
+    [Fact]
+    public void NormalizeValue_Ric_PreservesPunctuationAndUppercases()
+        => SecurityIdentifierNormalizer.NormalizeValue(SecurityIdentifierKind.Ric, " aapl.o ")
+            .Should().Be("AAPL.O");
+}

--- a/tests/Meridian.Tests/SecurityMaster/SecurityMasterQueryServiceAsOfTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityMasterQueryServiceAsOfTests.cs
@@ -103,6 +103,45 @@ public sealed class SecurityMasterQueryServiceAsOfTests
         currentDetail!.DisplayName.Should().Be("Acme Corporation");
     }
 
+    [Fact]
+    public async Task GetByIdentifierAsync_WithAsOf_FallsBackToStableIdentity_WhenIdentifierRowPostdatesAsOf()
+    {
+        // The CUSIP identity was backfilled after the security already existed, so its recorded
+        // ValidFrom postdates the requested as-of even though the security was live then. The
+        // point-in-time lookup should still resolve the (stable) identity and return the terms as
+        // recorded at that time, instead of returning null.
+        var securityId = Guid.NewGuid();
+        var eventStore = Substitute.For<ISecurityMasterEventStore>();
+        eventStore.LoadAsync(securityId, Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            MakeEnvelope(securityId, version: 1, timestamp: T0, displayName: "Acme Corp")
+        });
+
+        var record = MakeProjection(securityId, "Acme Corporation") with
+        {
+            Identifiers = new[]
+            {
+                new SecurityIdentifierDto(SecurityIdentifierKind.Ticker, "ACME", true, T0.AddDays(-10), null, null),
+                new SecurityIdentifierDto(SecurityIdentifierKind.Cusip, "037833100", false, T0.AddDays(10), null, null)
+            }
+        };
+        var store = Substitute.For<ISecurityMasterStore>();
+        store.LoadAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<SecurityProjectionRecord>>(new[] { record }));
+        // Leaving store.GetByIdentifierAsync unconfigured makes the exact-match passes return null,
+        // forcing the in-memory universe scan and then the as-of identity fallback.
+        var snapshotStore = Substitute.For<ISecurityMasterSnapshotStore>();
+        var service = new SecurityMasterQueryService(
+            eventStore, store, new SecurityMasterAggregateRebuilder(eventStore, snapshotStore));
+
+        var historical = await service.GetByIdentifierAsync(
+            SecurityIdentifierKind.Cusip, "037833100", null, asOfUtc: T0.AddDays(2));
+
+        historical.Should().NotBeNull();
+        historical!.SecurityId.Should().Be(securityId);
+        historical.DisplayName.Should().Be("Acme Corp");
+    }
+
     private static SecurityMasterQueryService CreateService(
         ISecurityMasterEventStore eventStore,
         SecurityProjectionRecord? currentProjection)

--- a/tests/Meridian.Tests/SecurityMaster/SecurityValidationServiceTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityValidationServiceTests.cs
@@ -59,6 +59,82 @@ public sealed class SecurityValidationServiceTests
     }
 
     [Fact]
+    public void Scenario_DuplicateFigiAcrossRecords_ProducesCriticalCollisionIssue()
+    {
+        var securityA = Guid.NewGuid();
+        var securityB = Guid.NewGuid();
+        const string duplicateFigi = "BBG000B9XRY4"; // Valid FIGI check digit shared by two securities.
+
+        var first = CreateProjection(
+            securityA,
+            "Equity",
+            [CreateIdentifier(SecurityIdentifierKind.Figi, duplicateFigi, isPrimary: true)]);
+        var second = CreateProjection(
+            securityB,
+            "Equity",
+            [CreateIdentifier(SecurityIdentifierKind.Figi, duplicateFigi, isPrimary: true)]);
+
+        var service = new SecurityValidationService(
+            Substitute.For<ISecurityMasterStore>(),
+            AssetClassValidatorRegistry.CreateDefault());
+
+        var report = service.ValidateRecord(first, [first, second], Now);
+
+        var issue = report.Issues.Should()
+            .ContainSingle(static item => item.Code == "SM_DUPLICATE_CANONICAL_IDENTIFIER")
+            .Which;
+        issue.Severity.Should().Be(SecurityValidationSeverityDto.Critical);
+        issue.AffectedFields.Should().Contain("identifiers.Figi");
+        issue.EvidenceLinks.Should().Contain(link => link.EvidenceId == securityB.ToString());
+    }
+
+    [Fact]
+    public void Scenario_SameCanonicalValueWithDifferentProvidersOnOneRecord_IsFlaggedAsDuplicate()
+    {
+        // A canonical identifier (ISIN) is provider-independent, so repeating the same value with
+        // a different provider annotation on one record must still trip in-record duplicate
+        // detection — provider only distinguishes ProviderSymbol identities.
+        var record = CreateProjection(
+            Guid.NewGuid(),
+            "Equity",
+            [
+                CreateIdentifier(SecurityIdentifierKind.Isin, "US0378331005", isPrimary: true),
+                CreateIdentifier(SecurityIdentifierKind.Isin, "US0378331005", isPrimary: false, provider: "Bloomberg")
+            ]);
+        var service = new SecurityValidationService(
+            Substitute.For<ISecurityMasterStore>(),
+            AssetClassValidatorRegistry.CreateDefault());
+
+        var report = service.ValidateRecord(record, [record], Now);
+
+        report.Issues.Should().Contain(issue =>
+            issue.Code == "SM_IDENTIFIER_DUPLICATE_ACTIVE"
+            && issue.Severity == SecurityValidationSeverityDto.Error);
+    }
+
+    [Fact]
+    public void Scenario_InvalidLeiCheckDigit_ProducesStructuredIdentifierFormatIssue()
+    {
+        var record = CreateProjection(
+            Guid.NewGuid(),
+            "Equity",
+            [
+                CreateIdentifier(SecurityIdentifierKind.Isin, "US0378331005", isPrimary: true),
+                CreateIdentifier(SecurityIdentifierKind.Lei, "HWUPKR0MPOU8FGXBT395", isPrimary: false)
+            ]);
+        var service = new SecurityValidationService(
+            Substitute.For<ISecurityMasterStore>(),
+            AssetClassValidatorRegistry.CreateDefault());
+
+        var report = service.ValidateRecord(record, [record], Now);
+
+        report.Issues.Should().Contain(issue =>
+            issue.Code == "SM_IDENTIFIER_FORMAT_INVALID"
+            && issue.Severity == SecurityValidationSeverityDto.Error
+            && issue.Message.Contains("Lei", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void Scenario_InvalidOptionTerms_ProducesStructuredAssetClassIssues()
     {
         var securityId = Guid.NewGuid();


### PR DESCRIPTION
## Summary

Consolidates Security Master validation and closes several validation gaps. Landing in phases on this branch:

- **Identifier validation gaps (landed).** `SecurityIdentifierNormalizer` now validates the identifier kinds that previously had weak or no format checks:
  - **LEI** — full ISO 17442 (ISO 7064 mod 97-10) check-digit validation instead of length + alphanumeric only.
  - **FIGI** — structural validation (consonant/digit alphabet, `G` in position 3) plus the mod-10 check digit; previously no validation at all.
  - **RIC** — lightweight structural guard (RIC punctuation only, at least one alphanumeric, no embedded whitespace); previously no validation at all.
- **Identifier collision detection (landed).** In-record duplicate detection keyed on provider for every identifier kind, so a canonical (provider-independent) identifier repeated with a different provider annotation slipped through. It now keys on provider only for `ProviderSymbol`, consistent with cross-record duplicate detection.
- **As-of fallback (landed).** Point-in-time identifier resolution returned `null` when an identifier row's recorded `ValidFrom` postdated the requested as-of (common when an identity is backfilled after the security already existed). It now falls back to resolving the stable identity while the caller's as-of term rebuild still governs which terms are returned — so a historical lookup never hands back today's terms under yesterday's identity.

Further phases (data-driven reference taxonomies shared across both validation engines, and WPF typed guided-form parity for `SecurityAssetProfileFieldDefinitionDto`) will be added as follow-up commits on this branch.

## Reason

The two Security Master validation engines used divergent vocabularies and left concrete gaps: several exchange/regulatory identifiers (LEI, FIGI, RIC) were accepted without meaningful format validation, canonical-identifier collisions could evade in-record detection, and historical identifier resolution could return nothing for identities that were simply backfilled after creation.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Added `SecurityIdentifierNormalizerTests` (LEI/FIGI/RIC valid + invalid cases and normalization), FIGI cross-record + in-record provider collision scenarios in `SecurityValidationServiceTests`, and an as-of identity fallback scenario in `SecurityMasterQueryServiceAsOfTests`. The local environment has no .NET SDK; validation is via GitHub Actions (`quality-gate` and a targeted `Meridian.Tests` run).

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014dBvq9XnDBbgtEPMLmD9Hr)_