### PR TITLE
Link tax-lot cost-basis relief to Security Master reference data

### DIFF
--- a/src/Meridian.Application/SecurityMaster/SecurityMasterAmortizationLedgerBridge.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterAmortizationLedgerBridge.cs
@@ -97,13 +97,10 @@ public sealed class SecurityMasterAmortizationLedgerBridge : ISecurityMasterAmor
             return 0;
 
         // Straight-line premium/discount over the posted periods; positive = premium (write-down),
-        // negative = discount (write-up). Distributed evenly with the remainder on the last period.
+        // negative = discount (write-up).
         var premiumDiscountTotal = postingContext.PositionFace > 0m
             ? RoundCash(postingContext.PositionFace * (postingContext.PurchasePricePercentOfPar - 100m) / 100m)
             : 0m;
-        var perPeriodPremiumDiscount = premiumDiscountTotal == 0m
-            ? 0m
-            : RoundCash(premiumDiscountTotal / schedule.Count);
 
         var allocatedPremiumDiscount = 0m;
         var posted = 0;
@@ -114,11 +111,12 @@ public sealed class SecurityMasterAmortizationLedgerBridge : ISecurityMasterAmor
             var effectiveDate = DateOnly.FromDateTime(entry.PeriodDate.UtcDateTime.Date);
             var timestamp = ToUtcStartOfDay(effectiveDate);
 
-            var isLast = i == schedule.Count - 1;
-            var premiumDiscountShare = isLast
-                ? premiumDiscountTotal - allocatedPremiumDiscount
-                : perPeriodPremiumDiscount;
-            allocatedPremiumDiscount += premiumDiscountShare;
+            // Cumulative-target distribution: each period's share is the rounded cumulative total
+            // to date minus what has already been allocated. This keeps shares monotonic toward the
+            // target so accumulated per-period rounding can never flip the final period's sign.
+            var cumulativeTarget = RoundCash(premiumDiscountTotal * (i + 1) / schedule.Count);
+            var premiumDiscountShare = cumulativeTarget - allocatedPremiumDiscount;
+            allocatedPremiumDiscount = cumulativeTarget;
 
             var couponAccrual = Math.Max(0m, RoundCash(entry.InterestAmount));
             var premiumAmortization = premiumDiscountShare > 0m ? premiumDiscountShare : 0m;

--- a/src/Meridian.Application/SecurityMaster/SecurityMasterAmortizationLedgerBridge.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterAmortizationLedgerBridge.cs
@@ -1,0 +1,246 @@
+using System.Security.Cryptography;
+using System.Text;
+using Meridian.Contracts.SecurityMaster;
+using Meridian.Ledger;
+using Microsoft.Extensions.Logging;
+using DomainLedger = Meridian.Ledger.Ledger;
+
+namespace Meridian.Application.SecurityMaster;
+
+/// <summary>
+/// Posts structured cash flow / accrual / amortization projections from
+/// <see cref="ISecurityMasterCashFlowService"/> into a <see cref="Ledger"/> using
+/// <see cref="LedgerViewKind.SecurityMaster"/>, so projected coupon accrual, premium
+/// amortization / discount accretion, and principal paydowns become balanced journal entries
+/// instead of remaining display-only. Idempotent: entries whose deterministic journal id already
+/// appears in the ledger are skipped.
+/// </summary>
+public interface ISecurityMasterAmortizationLedgerBridge
+{
+    /// <summary>
+    /// Projects <paramref name="securityId"/>'s cash flow schedule and posts one balanced
+    /// accrual/amortization entry per schedule period (coupon accrual plus straight-line
+    /// premium/discount amortization when a position is supplied), and a separate principal-paydown
+    /// entry per period with a principal amount. Returns the number of journal entries posted.
+    /// </summary>
+    Task<int> PostProjectedCashFlowsAsync(
+        Guid securityId,
+        string ticker,
+        DomainLedger ledger,
+        AmortizationLedgerPostingContext? context = null,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Position-level context for posting projected cash flows. Coupon and principal amounts are
+/// taken from the projection as-is (in the projection's own par basis); the premium/discount is
+/// derived here from the position because the schedule does not carry it.
+/// </summary>
+/// <param name="PositionFace">Held face/par of the position; drives premium/discount amortization. Zero disables it.</param>
+/// <param name="PurchasePricePercentOfPar">Purchase price as a percent of par (e.g. 102 = 2% premium; 98 = 2% discount).</param>
+/// <param name="FinancialAccountId">Optional account scope for the ledger accounts.</param>
+/// <param name="Scenario">Rate scenario used to request the projection.</param>
+/// <param name="MaxPeriods">Optional cap on how many schedule periods to post (null = all).</param>
+public sealed record AmortizationLedgerPostingContext(
+    decimal PositionFace = 0m,
+    decimal PurchasePricePercentOfPar = 100m,
+    string? FinancialAccountId = null,
+    StructuredCashFlowScenario Scenario = StructuredCashFlowScenario.Base,
+    int? MaxPeriods = null);
+
+/// <inheritdoc />
+public sealed class SecurityMasterAmortizationLedgerBridge : ISecurityMasterAmortizationLedgerBridge
+{
+    private readonly ISecurityMasterCashFlowService _cashFlowService;
+    private readonly ILogger<SecurityMasterAmortizationLedgerBridge> _logger;
+
+    public SecurityMasterAmortizationLedgerBridge(
+        ISecurityMasterCashFlowService cashFlowService,
+        ILogger<SecurityMasterAmortizationLedgerBridge> logger)
+    {
+        _cashFlowService = cashFlowService;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<int> PostProjectedCashFlowsAsync(
+        Guid securityId,
+        string ticker,
+        DomainLedger ledger,
+        AmortizationLedgerPostingContext? context = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(ledger);
+        ArgumentException.ThrowIfNullOrWhiteSpace(ticker);
+
+        var postingContext = context ?? new AmortizationLedgerPostingContext();
+        var projection = await _cashFlowService.GetProjectionAsync(securityId, postingContext.Scenario, ct).ConfigureAwait(false);
+        if (projection is null || projection.Schedule.Count == 0)
+        {
+            _logger.LogDebug(
+                "SecurityMasterAmortizationLedgerBridge: no cash flow projection for {SecurityId} under scenario {Scenario}.",
+                securityId, postingContext.Scenario);
+            return 0;
+        }
+
+        var normalizedTicker = ticker.Trim().ToUpperInvariant();
+        var financialAccountId = string.IsNullOrWhiteSpace(postingContext.FinancialAccountId)
+            ? null
+            : postingContext.FinancialAccountId.Trim();
+        var carrying = LedgerAccounts.Securities(normalizedTicker, financialAccountId);
+        var existingIds = ledger.Journal.Select(static j => j.JournalEntryId).ToHashSet();
+
+        var schedule = projection.Schedule.OrderBy(static entry => entry.PeriodDate).ToList();
+        if (postingContext.MaxPeriods is { } max && max >= 0 && schedule.Count > max)
+            schedule = schedule.Take(max).ToList();
+        if (schedule.Count == 0)
+            return 0;
+
+        // Straight-line premium/discount over the posted periods; positive = premium (write-down),
+        // negative = discount (write-up). Distributed evenly with the remainder on the last period.
+        var premiumDiscountTotal = postingContext.PositionFace > 0m
+            ? RoundCash(postingContext.PositionFace * (postingContext.PurchasePricePercentOfPar - 100m) / 100m)
+            : 0m;
+        var perPeriodPremiumDiscount = premiumDiscountTotal == 0m
+            ? 0m
+            : RoundCash(premiumDiscountTotal / schedule.Count);
+
+        var allocatedPremiumDiscount = 0m;
+        var posted = 0;
+
+        for (var i = 0; i < schedule.Count; i++)
+        {
+            var entry = schedule[i];
+            var effectiveDate = DateOnly.FromDateTime(entry.PeriodDate.UtcDateTime.Date);
+            var timestamp = ToUtcStartOfDay(effectiveDate);
+
+            var isLast = i == schedule.Count - 1;
+            var premiumDiscountShare = isLast
+                ? premiumDiscountTotal - allocatedPremiumDiscount
+                : perPeriodPremiumDiscount;
+            allocatedPremiumDiscount += premiumDiscountShare;
+
+            var couponAccrual = Math.Max(0m, RoundCash(entry.InterestAmount));
+            var premiumAmortization = premiumDiscountShare > 0m ? premiumDiscountShare : 0m;
+            var discountAccretion = premiumDiscountShare < 0m ? -premiumDiscountShare : 0m;
+
+            if (couponAccrual > 0m || premiumAmortization > 0m || discountAccretion > 0m)
+            {
+                if (PostAmortizationEntry(
+                        ledger, existingIds, securityId, normalizedTicker, carrying, financialAccountId,
+                        effectiveDate, timestamp, couponAccrual, discountAccretion, premiumAmortization))
+                {
+                    posted++;
+                }
+            }
+
+            var principalPaydown = Math.Max(0m, RoundCash(entry.PrincipalAmount));
+            if (principalPaydown > 0m &&
+                PostPrincipalPaydown(
+                    ledger, existingIds, securityId, normalizedTicker, carrying, financialAccountId,
+                    effectiveDate, timestamp, principalPaydown))
+            {
+                posted++;
+            }
+        }
+
+        if (posted > 0)
+        {
+            _logger.LogInformation(
+                "SecurityMasterAmortizationLedgerBridge posted {Count} accrual/amortization entries for {Ticker}.",
+                posted, normalizedTicker);
+        }
+
+        return posted;
+    }
+
+    private static bool PostAmortizationEntry(
+        DomainLedger ledger,
+        HashSet<Guid> existingIds,
+        Guid securityId,
+        string ticker,
+        LedgerAccount carrying,
+        string? financialAccountId,
+        DateOnly effectiveDate,
+        DateTimeOffset timestamp,
+        decimal couponAccrual,
+        decimal discountAccretion,
+        decimal premiumAmortization)
+    {
+        var journalId = DeriveJournalId(securityId, effectiveDate, "amort");
+        if (!existingIds.Add(journalId))
+            return false;
+
+        var description = $"Fixed-income accrual/amortization {ticker} {effectiveDate:yyyy-MM-dd}";
+        var projection = FixedIncomeAmortizationProjector.Project(new FixedIncomeAmortizationInput(
+            ticker,
+            carrying,
+            couponAccrual,
+            discountAccretion,
+            premiumAmortization,
+            financialAccountId,
+            description));
+
+        var lines = projection.Lines
+            .Select(line => new LedgerEntry(Guid.NewGuid(), journalId, timestamp, line.account, line.debit, line.credit, description))
+            .ToList();
+
+        ledger.Post(new JournalEntry(journalId, timestamp, description, lines, BuildMetadata(
+            "FixedIncomeAmortization", ticker, securityId, financialAccountId, effectiveDate)));
+        return true;
+    }
+
+    private static bool PostPrincipalPaydown(
+        DomainLedger ledger,
+        HashSet<Guid> existingIds,
+        Guid securityId,
+        string ticker,
+        LedgerAccount carrying,
+        string? financialAccountId,
+        DateOnly effectiveDate,
+        DateTimeOffset timestamp,
+        decimal principalPaydown)
+    {
+        var journalId = DeriveJournalId(securityId, effectiveDate, "principal");
+        if (!existingIds.Add(journalId))
+            return false;
+
+        var cash = string.IsNullOrWhiteSpace(financialAccountId)
+            ? LedgerAccounts.Cash
+            : LedgerAccounts.CashAccount(financialAccountId);
+        var description = $"Principal paydown {ticker} {effectiveDate:yyyy-MM-dd}";
+
+        var lines = new List<LedgerEntry>
+        {
+            new(Guid.NewGuid(), journalId, timestamp, cash, principalPaydown, 0m, description),
+            new(Guid.NewGuid(), journalId, timestamp, carrying, 0m, principalPaydown, description),
+        };
+
+        ledger.Post(new JournalEntry(journalId, timestamp, description, lines, BuildMetadata(
+            "PrincipalPaydown", ticker, securityId, financialAccountId, effectiveDate)));
+        return true;
+    }
+
+    private static JournalEntryMetadata BuildMetadata(
+        string activityType,
+        string ticker,
+        Guid securityId,
+        string? financialAccountId,
+        DateOnly effectiveDate)
+        => new(
+            ActivityType: activityType,
+            Symbol: ticker,
+            SecurityId: securityId,
+            LedgerView: LedgerViewKind.SecurityMaster,
+            FinancialAccountId: financialAccountId,
+            EffectiveDate: effectiveDate);
+
+    private static DateTimeOffset ToUtcStartOfDay(DateOnly date)
+        => new(date.Year, date.Month, date.Day, 0, 0, 0, TimeSpan.Zero);
+
+    private static decimal RoundCash(decimal amount)
+        => decimal.Round(amount, 2, MidpointRounding.AwayFromZero);
+
+    private static Guid DeriveJournalId(Guid securityId, DateOnly effectiveDate, string suffix)
+        => new(MD5.HashData(Encoding.UTF8.GetBytes($"{securityId:D}:{effectiveDate:yyyy-MM-dd}:{suffix}")));
+}

--- a/src/Meridian.Application/SecurityMaster/SecurityMasterCostBasisAdjustmentService.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterCostBasisAdjustmentService.cs
@@ -187,6 +187,7 @@ public sealed class SecurityMasterCostBasisAdjustmentService : ISecurityMasterCo
             return;
 
         _ = TryReadString(security, out var dayCount, "dayCountConvention", "dayCount", "dayCountBasis");
+        var normalizedDayCount = NormalizeDayCount(dayCount);
 
         // Fixed-income lots are recorded as a price per 100 of par (bond quotation convention);
         // premium/discount amortizes straight-line toward par, weighted by the day-count year
@@ -196,7 +197,9 @@ public sealed class SecurityMasterCostBasisAdjustmentService : ISecurityMasterCo
 
         foreach (var lot in openLots)
         {
-            if (lot.SecurityId is { } lotSecurityId && lotSecurityId != securityId)
+            // Reference-data amortization only applies to lots explicitly linked to this security;
+            // unlinked lots (no SecurityId) relieve at their recorded basis.
+            if (lot.SecurityId != securityId)
                 continue;
             if (lot.AcquiredDate >= amortizeTo || lot.AcquiredDate >= maturity)
                 continue;
@@ -205,8 +208,8 @@ public sealed class SecurityMasterCostBasisAdjustmentService : ISecurityMasterCo
             if (premiumOrDiscount == 0m)
                 continue;
 
-            var elapsed = YearFraction(dayCount, lot.AcquiredDate, amortizeTo);
-            var life = YearFraction(dayCount, lot.AcquiredDate, maturity);
+            var elapsed = YearFraction(normalizedDayCount, lot.AcquiredDate, amortizeTo);
+            var life = YearFraction(normalizedDayCount, lot.AcquiredDate, maturity);
             if (life <= 0m)
                 continue;
 
@@ -247,17 +250,19 @@ public sealed class SecurityMasterCostBasisAdjustmentService : ISecurityMasterCo
 
     // ── Day-count year fraction (mirrors SecurityMasterCashFlowService tokens) ─────────────────
 
-    private static decimal YearFraction(string? dayCountConvention, DateOnly start, DateOnly end)
+    private static string? NormalizeDayCount(string? dayCountConvention)
+        => dayCountConvention?.Replace(" ", string.Empty, StringComparison.Ordinal).ToUpperInvariant();
+
+    private static decimal YearFraction(string? normalizedDayCount, DateOnly start, DateOnly end)
     {
         if (end <= start)
             return 0m;
 
-        var normalized = dayCountConvention?.Replace(" ", string.Empty, StringComparison.Ordinal).ToUpperInvariant();
-        if (normalized is not null && normalized.Contains("30/360", StringComparison.Ordinal))
+        if (normalizedDayCount is not null && normalizedDayCount.Contains("30/360", StringComparison.Ordinal))
             return Days360(start, end) / 360m;
 
         var actualDays = end.DayNumber - start.DayNumber;
-        if (normalized is not null && (normalized.Contains("ACT/360", StringComparison.Ordinal) || normalized.Contains("ACTUAL/360", StringComparison.Ordinal)))
+        if (normalizedDayCount is not null && (normalizedDayCount.Contains("ACT/360", StringComparison.Ordinal) || normalizedDayCount.Contains("ACTUAL/360", StringComparison.Ordinal)))
             return actualDays / 360m;
 
         // Default (including ACT/365 and unrecognized conventions): actual days over 365.
@@ -266,8 +271,9 @@ public sealed class SecurityMasterCostBasisAdjustmentService : ISecurityMasterCo
 
     private static decimal Days360(DateOnly start, DateOnly end)
     {
+        // US 30/360 (NASD): D1 of 31 becomes 30; D2 of 31 becomes 30 only when D1 is 30 or 31.
         var startDay = Math.Min(start.Day, 30);
-        var endDay = end.Day == 31 && startDay == 30 ? 30 : Math.Min(end.Day, 30);
+        var endDay = end.Day == 31 && start.Day >= 30 ? 30 : end.Day;
         return ((end.Year - start.Year) * 360m) + ((end.Month - start.Month) * 30m) + (endDay - startDay);
     }
 

--- a/src/Meridian.Application/SecurityMaster/SecurityMasterCostBasisAdjustmentService.cs
+++ b/src/Meridian.Application/SecurityMaster/SecurityMasterCostBasisAdjustmentService.cs
@@ -1,0 +1,381 @@
+using System.Text.Json;
+using Meridian.Contracts.SecurityMaster;
+using Meridian.Ledger;
+using Microsoft.Extensions.Logging;
+
+namespace Meridian.Application.SecurityMaster;
+
+/// <summary>
+/// Reads day-count, factor, and corporate-action reference data from the Security Master and
+/// projects it into <see cref="LedgerTaxLotBasisAdjustment"/>s that the ledger relief engine
+/// consumes. This is the linkage between tax-lot / cost-basis accounting and Security Master
+/// reference data: cost basis is relieved against factor- and corporate-action-restated,
+/// day-count-amortized lots instead of their raw recorded quantity and unit cost.
+/// </summary>
+public interface ISecurityMasterCostBasisAdjustmentService
+{
+    /// <summary>
+    /// Builds the reference-data basis adjustments for <paramref name="securityId"/> effective as
+    /// of <paramref name="asOf"/>: forward/reverse splits and return-of-capital from corporate
+    /// actions, current pool-factor paydown, and per-lot straight-line premium/discount
+    /// amortization derived from the master's day-count convention.
+    /// </summary>
+    /// <param name="priorFactor">
+    /// The pool factor already reflected in the lots' recorded face (default <c>1</c> — lots
+    /// recorded at original face). A current factor below this produces a paydown adjustment.
+    /// </param>
+    Task<IReadOnlyList<LedgerTaxLotBasisAdjustment>> BuildAdjustmentsAsync(
+        Guid securityId,
+        IReadOnlyList<LedgerTaxLot> openLots,
+        DateOnly asOf,
+        decimal priorFactor = 1m,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Enriches <paramref name="baseInput"/> with the Security Master basis adjustments for
+    /// <paramref name="securityId"/> and projects realized-gain relief. Equivalent to calling
+    /// <see cref="BuildAdjustmentsAsync"/> and re-running
+    /// <see cref="LedgerTaxLotReliefProjector.Project"/> with the adjustments applied.
+    /// </summary>
+    Task<LedgerTaxLotReliefProjection> ProjectReliefAsync(
+        LedgerTaxLotReliefInput baseInput,
+        Guid securityId,
+        decimal priorFactor = 1m,
+        CancellationToken ct = default);
+}
+
+/// <inheritdoc />
+public sealed class SecurityMasterCostBasisAdjustmentService : ISecurityMasterCostBasisAdjustmentService
+{
+    private readonly ISecurityMasterQueryService _queryService;
+    private readonly ILogger<SecurityMasterCostBasisAdjustmentService> _logger;
+
+    public SecurityMasterCostBasisAdjustmentService(
+        ISecurityMasterQueryService queryService,
+        ILogger<SecurityMasterCostBasisAdjustmentService> logger)
+    {
+        _queryService = queryService;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<LedgerTaxLotBasisAdjustment>> BuildAdjustmentsAsync(
+        Guid securityId,
+        IReadOnlyList<LedgerTaxLot> openLots,
+        DateOnly asOf,
+        decimal priorFactor = 1m,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(openLots);
+
+        var adjustments = new List<LedgerTaxLotBasisAdjustment>();
+        AddCorporateActionAdjustments(adjustments, await GetEffectiveActionsAsync(securityId, asOf, ct).ConfigureAwait(false), securityId, asOf);
+
+        var security = await _queryService.GetByIdAsync(securityId, ct).ConfigureAwait(false);
+        if (security is not null)
+        {
+            AddFactorAdjustment(adjustments, security, securityId, asOf, priorFactor);
+            AddAmortizationAdjustments(adjustments, security, openLots, securityId, asOf);
+        }
+
+        return adjustments;
+    }
+
+    /// <inheritdoc />
+    public async Task<LedgerTaxLotReliefProjection> ProjectReliefAsync(
+        LedgerTaxLotReliefInput baseInput,
+        Guid securityId,
+        decimal priorFactor = 1m,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(baseInput);
+
+        var adjustments = await BuildAdjustmentsAsync(securityId, baseInput.OpenLots, baseInput.SaleDate, priorFactor, ct)
+            .ConfigureAwait(false);
+
+        // Preserve any adjustments already carried on the base input (explicit caller overrides)
+        // ahead of the ones sourced from the Security Master.
+        var combined = baseInput.BasisAdjustments.Concat(adjustments).ToArray();
+
+        var enrichedInput = new LedgerTaxLotReliefInput(
+            baseInput.Account,
+            baseInput.SaleDate,
+            baseInput.QuantitySold,
+            baseInput.SalePrice,
+            baseInput.ReliefMethod,
+            baseInput.OpenLots,
+            baseInput.FinancialAccountId,
+            baseInput.SpecificLotIds,
+            combined);
+
+        return LedgerTaxLotReliefProjector.Project(enrichedInput);
+    }
+
+    private async Task<IReadOnlyList<CorporateActionDto>> GetEffectiveActionsAsync(
+        Guid securityId, DateOnly asOf, CancellationToken ct)
+    {
+        var actions = await _queryService.GetCorporateActionsAsync(securityId, ct).ConfigureAwait(false);
+        if (actions is null || actions.Count == 0)
+            return [];
+
+        return CorporateActionEffectiveStateProjector.ProjectEffectiveActions(actions, EndOfDay(asOf));
+    }
+
+    private void AddCorporateActionAdjustments(
+        List<LedgerTaxLotBasisAdjustment> adjustments,
+        IReadOnlyList<CorporateActionDto> effectiveActions,
+        Guid securityId,
+        DateOnly asOf)
+    {
+        foreach (var action in effectiveActions)
+        {
+            if (action.ExDate > asOf)
+                continue;
+
+            var canonical = CorporateActionEventTypes.Normalize(action.EventType);
+            var reference = $"corp-action:{action.CorpActId:D}";
+
+            if (canonical is CorporateActionEventTypes.StockSplit or CorporateActionEventTypes.ReverseStockSplit
+                && action.SplitRatio is { } ratio && ratio > 0m)
+            {
+                adjustments.Add(new LedgerTaxLotBasisAdjustment(
+                    LedgerTaxLotBasisAdjustmentKind.Split, ratio, action.ExDate, securityId, LotId: null, reference).EnsureValid());
+            }
+            else if (canonical == CorporateActionEventTypes.ReturnOfCapital
+                && action.DividendPerShare is { } perShare && perShare > 0m)
+            {
+                adjustments.Add(new LedgerTaxLotBasisAdjustment(
+                    LedgerTaxLotBasisAdjustmentKind.ReturnOfCapital, perShare, action.ExDate, securityId, LotId: null, reference).EnsureValid());
+            }
+        }
+    }
+
+    private void AddFactorAdjustment(
+        List<LedgerTaxLotBasisAdjustment> adjustments,
+        SecurityDetailDto security,
+        Guid securityId,
+        DateOnly asOf,
+        decimal priorFactor)
+    {
+        if (priorFactor <= 0m)
+        {
+            _logger.LogDebug("Skipping factor adjustment for {SecurityId}: prior factor {PriorFactor} is not positive.", securityId, priorFactor);
+            return;
+        }
+
+        if (!TryReadDecimal(security, out var currentFactor, "currentFactor", "factor") || currentFactor is not > 0m)
+            return;
+
+        var ratio = currentFactor.Value / priorFactor;
+        if (ratio >= 1m)
+            return; // No paydown (factor unchanged or increased): nothing to relieve from basis.
+
+        adjustments.Add(new LedgerTaxLotBasisAdjustment(
+            LedgerTaxLotBasisAdjustmentKind.Factor, ratio, asOf, securityId, LotId: null, "current-factor").EnsureValid());
+    }
+
+    private void AddAmortizationAdjustments(
+        List<LedgerTaxLotBasisAdjustment> adjustments,
+        SecurityDetailDto security,
+        IReadOnlyList<LedgerTaxLot> openLots,
+        Guid securityId,
+        DateOnly asOf)
+    {
+        if (!IsFixedIncome(security.AssetClass))
+            return;
+        if (!TryReadDate(security, out var maturity, "maturityDate", "maturity", "legalFinalMaturity"))
+            return;
+
+        _ = TryReadString(security, out var dayCount, "dayCountConvention", "dayCount", "dayCountBasis");
+
+        // Fixed-income lots are recorded as a price per 100 of par (bond quotation convention);
+        // premium/discount amortizes straight-line toward par, weighted by the day-count year
+        // fraction from acquisition to the sale/as-of date.
+        const decimal parPrice = 100m;
+        var amortizeTo = asOf < maturity ? asOf : maturity;
+
+        foreach (var lot in openLots)
+        {
+            if (lot.SecurityId is { } lotSecurityId && lotSecurityId != securityId)
+                continue;
+            if (lot.AcquiredDate >= amortizeTo || lot.AcquiredDate >= maturity)
+                continue;
+
+            var premiumOrDiscount = lot.UnitCost - parPrice;
+            if (premiumOrDiscount == 0m)
+                continue;
+
+            var elapsed = YearFraction(dayCount, lot.AcquiredDate, amortizeTo);
+            var life = YearFraction(dayCount, lot.AcquiredDate, maturity);
+            if (life <= 0m)
+                continue;
+
+            var fraction = elapsed / life;
+            if (fraction <= 0m)
+                continue;
+            if (fraction > 1m)
+                fraction = 1m;
+
+            // Signed per-unit delta that moves basis toward par: premium (unit cost > par) yields a
+            // negative delta (write-down); discount (unit cost < par) yields a positive delta.
+            var delta = decimal.Round((parPrice - lot.UnitCost) * fraction, 10, MidpointRounding.AwayFromZero);
+            if (delta == 0m)
+                continue;
+
+            adjustments.Add(new LedgerTaxLotBasisAdjustment(
+                LedgerTaxLotBasisAdjustmentKind.Amortization, delta, asOf, securityId, lot.LotId, "straight-line-amortization").EnsureValid());
+        }
+    }
+
+    private static bool IsFixedIncome(string? assetClass)
+    {
+        if (string.IsNullOrWhiteSpace(assetClass))
+            return false;
+
+        return assetClass.Trim().ToUpperInvariant() switch
+        {
+            "BOND" or "TREASURYBILL" or "CERTIFICATEOFDEPOSIT" or "COMMERCIALPAPER"
+                or "MORTGAGEBACKED" or "MORTGAGEBACKEDSECURITY" or "MBS"
+                or "ASSETBACKED" or "ASSETBACKEDSECURITY" or "ABS"
+                or "STRUCTUREDCREDIT" or "LOAN" or "DIRECTLOAN" or "AMORTIZINGLOAN" => true,
+            _ => false,
+        };
+    }
+
+    private static DateTimeOffset EndOfDay(DateOnly date)
+        => new(date.ToDateTime(new TimeOnly(23, 59, 59)), TimeSpan.Zero);
+
+    // ── Day-count year fraction (mirrors SecurityMasterCashFlowService tokens) ─────────────────
+
+    private static decimal YearFraction(string? dayCountConvention, DateOnly start, DateOnly end)
+    {
+        if (end <= start)
+            return 0m;
+
+        var normalized = dayCountConvention?.Replace(" ", string.Empty, StringComparison.Ordinal).ToUpperInvariant();
+        if (normalized is not null && normalized.Contains("30/360", StringComparison.Ordinal))
+            return Days360(start, end) / 360m;
+
+        var actualDays = end.DayNumber - start.DayNumber;
+        if (normalized is not null && (normalized.Contains("ACT/360", StringComparison.Ordinal) || normalized.Contains("ACTUAL/360", StringComparison.Ordinal)))
+            return actualDays / 360m;
+
+        // Default (including ACT/365 and unrecognized conventions): actual days over 365.
+        return actualDays / 365m;
+    }
+
+    private static decimal Days360(DateOnly start, DateOnly end)
+    {
+        var startDay = Math.Min(start.Day, 30);
+        var endDay = end.Day == 31 && startDay == 30 ? 30 : Math.Min(end.Day, 30);
+        return ((end.Year - start.Year) * 360m) + ((end.Month - start.Month) * 30m) + (endDay - startDay);
+    }
+
+    // ── Security-term JSON readers (mirror SecurityMasterCashFlowService) ──────────────────────
+
+    private static bool TryReadString(SecurityDetailDto security, out string? value, params string[] propertyNames)
+    {
+        foreach (var source in EnumerateTermSources(security))
+        {
+            foreach (var propertyName in propertyNames)
+            {
+                if (!TryGetProperty(source, propertyName, out var property))
+                    continue;
+
+                if (property.ValueKind == JsonValueKind.String)
+                {
+                    value = property.GetString();
+                    return !string.IsNullOrWhiteSpace(value);
+                }
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static bool TryReadDecimal(SecurityDetailDto security, out decimal? value, params string[] propertyNames)
+    {
+        foreach (var source in EnumerateTermSources(security))
+        {
+            foreach (var propertyName in propertyNames)
+            {
+                if (!TryGetProperty(source, propertyName, out var property))
+                    continue;
+
+                if (property.ValueKind == JsonValueKind.Number && property.TryGetDecimal(out var number))
+                {
+                    value = number;
+                    return true;
+                }
+
+                if (property.ValueKind == JsonValueKind.String && decimal.TryParse(property.GetString(), out var parsed))
+                {
+                    value = parsed;
+                    return true;
+                }
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static bool TryReadDate(SecurityDetailDto security, out DateOnly value, params string[] propertyNames)
+    {
+        foreach (var source in EnumerateTermSources(security))
+        {
+            foreach (var propertyName in propertyNames)
+            {
+                if (!TryGetProperty(source, propertyName, out var property) || property.ValueKind != JsonValueKind.String)
+                    continue;
+
+                var raw = property.GetString();
+                if (DateOnly.TryParse(raw, out value))
+                    return true;
+
+                if (DateTimeOffset.TryParse(raw, out var timestamp))
+                {
+                    value = DateOnly.FromDateTime(timestamp.UtcDateTime.Date);
+                    return true;
+                }
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static IEnumerable<JsonElement> EnumerateTermSources(SecurityDetailDto security)
+    {
+        yield return security.AssetSpecificTerms;
+        if (TryGetProperty(security.AssetSpecificTerms, "profileFields", out var profileFields) &&
+            profileFields.ValueKind == JsonValueKind.Object)
+        {
+            yield return profileFields;
+        }
+
+        yield return security.CommonTerms;
+    }
+
+    private static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement value)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            value = default;
+            return false;
+        }
+
+        foreach (var property in element.EnumerateObject())
+        {
+            if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                value = property.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+}

--- a/src/Meridian.Ledger/LedgerTaxLot.cs
+++ b/src/Meridian.Ledger/LedgerTaxLot.cs
@@ -9,7 +9,8 @@ public sealed record LedgerTaxLot
         string lotId,
         DateOnly acquiredDate,
         decimal quantity,
-        decimal unitCost)
+        decimal unitCost,
+        Guid? securityId = null)
     {
         if (string.IsNullOrWhiteSpace(lotId))
             throw new ArgumentException("Tax lot identifier must not be null or whitespace.", nameof(lotId));
@@ -22,6 +23,7 @@ public sealed record LedgerTaxLot
         AcquiredDate = acquiredDate;
         Quantity = quantity;
         UnitCost = unitCost;
+        SecurityId = securityId;
     }
 
     public string LotId { get; }
@@ -31,4 +33,12 @@ public sealed record LedgerTaxLot
     public decimal Quantity { get; }
 
     public decimal UnitCost { get; }
+
+    /// <summary>
+    /// Optional Security Master identity for this lot. When present, the relief engine can be
+    /// fed day-count, factor, and corporate-action basis adjustments sourced from the master
+    /// (see <see cref="LedgerTaxLotBasisAdjustment"/>), linking cost-basis accounting to
+    /// authoritative reference data instead of relying on quantity/unit-cost alone.
+    /// </summary>
+    public Guid? SecurityId { get; }
 }

--- a/src/Meridian.Ledger/LedgerTaxLotBasisAdjuster.cs
+++ b/src/Meridian.Ledger/LedgerTaxLotBasisAdjuster.cs
@@ -1,0 +1,91 @@
+namespace Meridian.Ledger;
+
+/// <summary>
+/// Applies reference-data-derived <see cref="LedgerTaxLotBasisAdjustment"/>s to open tax lots,
+/// producing the effective lots the relief engine relieves against. This is the seam that lets
+/// day-count (amortized cost), factor (pool paydown), and corporate-action (split, return of
+/// capital) economics from the Security Master flow into cost-basis accounting.
+/// </summary>
+public static class LedgerTaxLotBasisAdjuster
+{
+    /// <summary>
+    /// Returns <paramref name="openLots"/> restated by <paramref name="adjustments"/>. Adjustments
+    /// are applied per lot in <see cref="LedgerTaxLotBasisAdjustment.EffectiveDate"/> order; a lot
+    /// whose quantity is reduced to zero or below (a full factor paydown or reverse split) is
+    /// dropped from the effective set. When <paramref name="adjustments"/> is empty the original
+    /// lots are returned unchanged.
+    /// </summary>
+    public static IReadOnlyList<LedgerTaxLot> Apply(
+        IReadOnlyList<LedgerTaxLot> openLots,
+        IReadOnlyList<LedgerTaxLotBasisAdjustment> adjustments)
+    {
+        ArgumentNullException.ThrowIfNull(openLots);
+        ArgumentNullException.ThrowIfNull(adjustments);
+
+        if (adjustments.Count == 0)
+            return openLots;
+
+        var ordered = adjustments
+            .Select(static adjustment => adjustment.EnsureValid())
+            .OrderBy(static adjustment => adjustment.EffectiveDate)
+            .ThenBy(static adjustment => adjustment.Kind)
+            .ThenBy(static adjustment => adjustment.Reference, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var effective = new List<LedgerTaxLot>(openLots.Count);
+        foreach (var lot in openLots)
+        {
+            var quantity = lot.Quantity;
+            var unitCost = lot.UnitCost;
+
+            foreach (var adjustment in ordered)
+            {
+                if (!adjustment.AppliesTo(lot))
+                    continue;
+
+                (quantity, unitCost) = ApplyOne(adjustment, quantity, unitCost);
+            }
+
+            quantity = RoundQuantity(quantity);
+            if (quantity <= 0m)
+                continue; // Fully paid down / reverse-split to nothing; no basis remains to relieve.
+
+            effective.Add(new LedgerTaxLot(
+                lot.LotId,
+                lot.AcquiredDate,
+                quantity,
+                RoundUnitCost(Math.Max(0m, unitCost)),
+                lot.SecurityId));
+        }
+
+        return effective;
+    }
+
+    private static (decimal quantity, decimal unitCost) ApplyOne(
+        LedgerTaxLotBasisAdjustment adjustment,
+        decimal quantity,
+        decimal unitCost)
+        => adjustment.Kind switch
+        {
+            // Split: total basis is preserved (quantity × unit cost is invariant).
+            LedgerTaxLotBasisAdjustmentKind.Split => (quantity * adjustment.Value, unitCost / adjustment.Value),
+
+            // Return of capital reduces per-unit basis, floored at zero.
+            LedgerTaxLotBasisAdjustmentKind.ReturnOfCapital => (quantity, Math.Max(0m, unitCost - adjustment.Value)),
+
+            // Factor paydown scales remaining face; per-unit basis is unchanged, so the paid-down
+            // principal is relieved from basis in proportion to the factor reduction.
+            LedgerTaxLotBasisAdjustmentKind.Factor => (quantity * adjustment.Value, unitCost),
+
+            // Premium amortization (negative) / discount accretion (positive) moves basis toward par.
+            LedgerTaxLotBasisAdjustmentKind.Amortization => (quantity, Math.Max(0m, unitCost + adjustment.Value)),
+
+            _ => throw new ArgumentOutOfRangeException(nameof(adjustment), adjustment.Kind, "Unsupported basis-adjustment kind."),
+        };
+
+    private static decimal RoundQuantity(decimal quantity)
+        => decimal.Round(quantity, 10, MidpointRounding.AwayFromZero);
+
+    private static decimal RoundUnitCost(decimal unitCost)
+        => decimal.Round(unitCost, 10, MidpointRounding.AwayFromZero);
+}

--- a/src/Meridian.Ledger/LedgerTaxLotBasisAdjustment.cs
+++ b/src/Meridian.Ledger/LedgerTaxLotBasisAdjustment.cs
@@ -1,0 +1,68 @@
+namespace Meridian.Ledger;
+
+/// <summary>
+/// A single reference-data-derived cost-basis adjustment applied to open tax lots before
+/// realized-gain relief. The adjustment is intentionally numeric and Security-Master-agnostic:
+/// the application layer reads day-count, factor, and corporate-action data from the master and
+/// projects it into these primitives, keeping the ledger relief engine free of reference-data
+/// dependencies.
+/// </summary>
+/// <param name="Kind">Which transform to apply; fixes the meaning of <paramref name="Value"/>.</param>
+/// <param name="Value">
+/// Kind-specific magnitude: a split/factor ratio for <see cref="LedgerTaxLotBasisAdjustmentKind.Split"/>
+/// and <see cref="LedgerTaxLotBasisAdjustmentKind.Factor"/>, a per-unit amount for
+/// <see cref="LedgerTaxLotBasisAdjustmentKind.ReturnOfCapital"/>, and a signed per-unit delta for
+/// <see cref="LedgerTaxLotBasisAdjustmentKind.Amortization"/>.
+/// </param>
+/// <param name="EffectiveDate">
+/// The date the adjustment takes economic effect (corporate-action ex-date, or the as-of date for
+/// factor/amortization). Only lots acquired strictly before this date are adjusted.
+/// </param>
+/// <param name="SecurityId">
+/// When set, the adjustment applies only to lots carrying the same
+/// <see cref="LedgerTaxLot.SecurityId"/>; a null scope applies to every candidate lot.
+/// </param>
+/// <param name="LotId">
+/// When set, the adjustment targets a single lot by identifier (used for per-lot amortization);
+/// a null value applies to every lot matched by <paramref name="SecurityId"/>.
+/// </param>
+/// <param name="Reference">Optional provenance reference (e.g. corporate-action id or source tag).</param>
+public sealed record LedgerTaxLotBasisAdjustment(
+    LedgerTaxLotBasisAdjustmentKind Kind,
+    decimal Value,
+    DateOnly EffectiveDate,
+    Guid? SecurityId = null,
+    string? LotId = null,
+    string? Reference = null)
+{
+    /// <summary>Validates the <see cref="Value"/> magnitude against the <see cref="Kind"/>.</summary>
+    public LedgerTaxLotBasisAdjustment EnsureValid()
+    {
+        switch (Kind)
+        {
+            case LedgerTaxLotBasisAdjustmentKind.Split when Value <= 0m:
+                throw new ArgumentOutOfRangeException(nameof(Value), Value, "Split ratio must be positive.");
+            case LedgerTaxLotBasisAdjustmentKind.Factor when Value <= 0m:
+                throw new ArgumentOutOfRangeException(nameof(Value), Value, "Factor ratio must be positive.");
+            case LedgerTaxLotBasisAdjustmentKind.ReturnOfCapital when Value < 0m:
+                throw new ArgumentOutOfRangeException(nameof(Value), Value, "Return-of-capital amount cannot be negative.");
+        }
+
+        return this;
+    }
+
+    /// <summary>Returns true when this adjustment applies to <paramref name="lot"/>.</summary>
+    public bool AppliesTo(LedgerTaxLot lot)
+    {
+        ArgumentNullException.ThrowIfNull(lot);
+
+        if (SecurityId is { } securityScope && lot.SecurityId != securityScope)
+            return false;
+        if (!string.IsNullOrWhiteSpace(LotId) && !string.Equals(LotId, lot.LotId, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        // Only lots that existed before the adjustment's economic effect are restated; a lot
+        // acquired on or after the ex-date already reflects the post-event terms.
+        return EffectiveDate > lot.AcquiredDate;
+    }
+}

--- a/src/Meridian.Ledger/LedgerTaxLotBasisAdjustmentKind.cs
+++ b/src/Meridian.Ledger/LedgerTaxLotBasisAdjustmentKind.cs
@@ -1,0 +1,42 @@
+namespace Meridian.Ledger;
+
+/// <summary>
+/// The kind of cost-basis adjustment applied to an open <see cref="LedgerTaxLot"/> before
+/// realized-gain relief. Each kind fixes the meaning of
+/// <see cref="LedgerTaxLotBasisAdjustment.Value"/> so the relief engine can consume
+/// reference-data-derived adjustments without depending on Security Master contracts.
+/// </summary>
+public enum LedgerTaxLotBasisAdjustmentKind
+{
+    /// <summary>
+    /// Share-count restatement from a forward or reverse split.
+    /// <see cref="LedgerTaxLotBasisAdjustment.Value"/> is the split ratio R (new shares per old
+    /// share; forward split R&gt;1, reverse split 0&lt;R&lt;1). Quantity is multiplied by R and unit
+    /// cost is divided by R, preserving total basis.
+    /// </summary>
+    Split,
+
+    /// <summary>
+    /// Return-of-capital distribution that reduces cost basis rather than recognizing income.
+    /// <see cref="LedgerTaxLotBasisAdjustment.Value"/> is the per-unit capital returned; unit
+    /// cost is reduced by that amount (floored at zero).
+    /// </summary>
+    ReturnOfCapital,
+
+    /// <summary>
+    /// Pool-factor restatement for amortizing debt (MBS/ABS/loans).
+    /// <see cref="LedgerTaxLotBasisAdjustment.Value"/> is the factor ratio applied to the lot's
+    /// outstanding face (current factor ÷ prior factor, 0&lt;ratio≤1). Quantity (face) is scaled
+    /// by the ratio while unit cost is unchanged, so basis is relieved in proportion to the
+    /// principal paid down. Lots are assumed to be recorded at their prior-factor face.
+    /// </summary>
+    Factor,
+
+    /// <summary>
+    /// Premium amortization / discount accretion of a fixed-income lot toward par.
+    /// <see cref="LedgerTaxLotBasisAdjustment.Value"/> is the signed per-unit change applied to
+    /// unit cost: negative amortizes a premium down toward par, positive accretes a discount up
+    /// toward par (floored at zero).
+    /// </summary>
+    Amortization,
+}

--- a/src/Meridian.Ledger/LedgerTaxLotReliefInput.cs
+++ b/src/Meridian.Ledger/LedgerTaxLotReliefInput.cs
@@ -13,7 +13,8 @@ public sealed record LedgerTaxLotReliefInput
         LedgerTaxLotReliefMethod reliefMethod,
         IReadOnlyList<LedgerTaxLot> openLots,
         string? financialAccountId = null,
-        IReadOnlyList<string>? specificLotIds = null)
+        IReadOnlyList<string>? specificLotIds = null,
+        IReadOnlyList<LedgerTaxLotBasisAdjustment>? basisAdjustments = null)
     {
         ArgumentNullException.ThrowIfNull(account);
         ArgumentNullException.ThrowIfNull(openLots);
@@ -39,6 +40,9 @@ public sealed record LedgerTaxLotReliefInput
                 .Select(static lotId => lotId.Trim())
                 .Where(static lotId => lotId.Length > 0)
                 .ToArray();
+        BasisAdjustments = basisAdjustments is null
+            ? []
+            : basisAdjustments.ToArray();
     }
 
     public LedgerAccount Account { get; }
@@ -56,4 +60,11 @@ public sealed record LedgerTaxLotReliefInput
     public string? FinancialAccountId { get; }
 
     public IReadOnlyList<string> SpecificLotIds { get; }
+
+    /// <summary>
+    /// Reference-data-derived cost-basis adjustments (day-count amortization, pool factor, and
+    /// corporate-action restatements) applied to <see cref="OpenLots"/> before relief. Empty when
+    /// the sale relieves lots at their recorded quantity and unit cost.
+    /// </summary>
+    public IReadOnlyList<LedgerTaxLotBasisAdjustment> BasisAdjustments { get; }
 }

--- a/src/Meridian.Ledger/LedgerTaxLotReliefProjection.cs
+++ b/src/Meridian.Ledger/LedgerTaxLotReliefProjection.cs
@@ -16,4 +16,13 @@ public sealed record LedgerTaxLotReliefProjection(
     public decimal TotalCredits => Lines.Sum(static line => line.credit);
 
     public bool IsBalanced => TotalDebits == TotalCredits;
+
+    /// <summary>
+    /// The reference-data basis adjustments that were applied to the open lots before relief.
+    /// Empty when the sale relieved lots at their recorded quantity and unit cost.
+    /// </summary>
+    public IReadOnlyList<LedgerTaxLotBasisAdjustment> AppliedAdjustments { get; init; } = [];
+
+    /// <summary>The effective open lots after applying <see cref="AppliedAdjustments"/>.</summary>
+    public IReadOnlyList<LedgerTaxLot> EffectiveLots { get; init; } = [];
 }

--- a/src/Meridian.Ledger/LedgerTaxLotReliefProjector.cs
+++ b/src/Meridian.Ledger/LedgerTaxLotReliefProjector.cs
@@ -9,41 +9,52 @@ public static class LedgerTaxLotReliefProjector
     {
         ArgumentNullException.ThrowIfNull(input);
 
-        var orderedLots = OrderLots(input).ToList();
+        // Feed reference-data (day-count amortization, factor, corporate-action) basis
+        // adjustments into the relief engine before ordering, so cost-basis relief reflects the
+        // effective lots rather than their raw recorded quantity and unit cost.
+        var effectiveLots = input.BasisAdjustments.Count == 0
+            ? input.OpenLots
+            : LedgerTaxLotBasisAdjuster.Apply(input.OpenLots, input.BasisAdjustments);
+
+        var orderedLots = OrderLots(input, effectiveLots).ToList();
         var selections = SelectLots(input.QuantitySold, orderedLots);
         var proceeds = RoundCurrency(input.QuantitySold * input.SalePrice);
         var costBasis = selections.Sum(static selection => selection.CostBasis);
         var realizedGainOrLoss = proceeds - costBasis;
         var lines = BuildLines(input, proceeds, costBasis, realizedGainOrLoss);
 
-        return new LedgerTaxLotReliefProjection(input, selections, proceeds, costBasis, realizedGainOrLoss, lines);
+        return new LedgerTaxLotReliefProjection(input, selections, proceeds, costBasis, realizedGainOrLoss, lines)
+        {
+            AppliedAdjustments = input.BasisAdjustments,
+            EffectiveLots = effectiveLots,
+        };
     }
 
-    private static IEnumerable<LedgerTaxLot> OrderLots(LedgerTaxLotReliefInput input)
+    private static IEnumerable<LedgerTaxLot> OrderLots(LedgerTaxLotReliefInput input, IReadOnlyList<LedgerTaxLot> effectiveLots)
     {
         return input.ReliefMethod switch
         {
-            LedgerTaxLotReliefMethod.Fifo => input.OpenLots
+            LedgerTaxLotReliefMethod.Fifo => effectiveLots
                 .OrderBy(static lot => lot.AcquiredDate)
                 .ThenBy(static lot => lot.LotId, StringComparer.OrdinalIgnoreCase),
-            LedgerTaxLotReliefMethod.Lifo => input.OpenLots
+            LedgerTaxLotReliefMethod.Lifo => effectiveLots
                 .OrderByDescending(static lot => lot.AcquiredDate)
                 .ThenBy(static lot => lot.LotId, StringComparer.OrdinalIgnoreCase),
-            LedgerTaxLotReliefMethod.Hifo => input.OpenLots
+            LedgerTaxLotReliefMethod.Hifo => effectiveLots
                 .OrderByDescending(static lot => lot.UnitCost)
                 .ThenBy(static lot => lot.AcquiredDate)
                 .ThenBy(static lot => lot.LotId, StringComparer.OrdinalIgnoreCase),
-            LedgerTaxLotReliefMethod.SpecificId => OrderSpecificLots(input),
+            LedgerTaxLotReliefMethod.SpecificId => OrderSpecificLots(input, effectiveLots),
             _ => throw new ArgumentOutOfRangeException(nameof(input), input.ReliefMethod, "Unsupported tax-lot relief method."),
         };
     }
 
-    private static IEnumerable<LedgerTaxLot> OrderSpecificLots(LedgerTaxLotReliefInput input)
+    private static IEnumerable<LedgerTaxLot> OrderSpecificLots(LedgerTaxLotReliefInput input, IReadOnlyList<LedgerTaxLot> effectiveLots)
     {
         if (input.SpecificLotIds.Count == 0)
             throw new ArgumentException("SpecificId relief requires at least one selected lot identifier.", nameof(input));
 
-        var openLots = input.OpenLots.ToDictionary(static lot => lot.LotId, StringComparer.OrdinalIgnoreCase);
+        var openLots = effectiveLots.ToDictionary(static lot => lot.LotId, StringComparer.OrdinalIgnoreCase);
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var lotId in input.SpecificLotIds)
         {

--- a/src/Meridian.Ledger/README.md
+++ b/src/Meridian.Ledger/README.md
@@ -59,6 +59,15 @@ depreciation run, mirroring `DailyPortfolioPricingDraftBuilder`.
 account level so accounting statements can follow front-office lot-relief policy.
 `LedgerTaxLotReliefProjector` applies those account-level relief methods to open tax lots and
 prepares balanced cash, security cost-basis, and realized gain/loss lines before durable posting.
+`LedgerTaxLot` carries an optional `SecurityId` so cost-basis lots link to Security Master
+reference data. `LedgerTaxLotBasisAdjuster` (fed via `LedgerTaxLotReliefInput.BasisAdjustments`)
+restates open lots by reference-data-derived `LedgerTaxLotBasisAdjustment`s — corporate-action
+splits and return of capital, pool-factor paydowns, and day-count premium/discount amortization —
+before relief, keeping the ledger engine free of Security Master contracts while relieving basis
+against the effective lots. The Application-layer `SecurityMasterCostBasisAdjustmentService` reads
+the master and produces those adjustments; `SecurityMasterAmortizationLedgerBridge` posts the
+matching coupon-accrual, premium-amortization/discount-accretion, and principal-paydown journal
+entries so cash flow projections are booked instead of remaining display-only.
 `AutomatedJournalDraftProjector` produces balanced drafts for dividend declarations, dividend
 receipts, cash-interest credits, corporate-action cash events, and recurring accrual obligations
 such as management fees, performance fees, commissions, and withholding taxes before workflow

--- a/tests/Meridian.Tests/Ledger/LedgerTaxLotBasisAdjusterTests.cs
+++ b/tests/Meridian.Tests/Ledger/LedgerTaxLotBasisAdjusterTests.cs
@@ -1,0 +1,256 @@
+using FluentAssertions;
+using Meridian.Ledger;
+using Xunit;
+
+namespace Meridian.Tests.Ledger;
+
+/// <summary>
+/// Unit tests for <see cref="LedgerTaxLotBasisAdjuster"/> and its integration into
+/// <see cref="LedgerTaxLotReliefProjector"/> — the seam that feeds Security Master day-count,
+/// factor, and corporate-action basis adjustments into cost-basis relief.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class LedgerTaxLotBasisAdjusterTests
+{
+    private static readonly Guid SecurityId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000010");
+    private static readonly Guid OtherSecurityId = Guid.Parse("bbbbbbbb-0000-0000-0000-000000000020");
+
+    [Fact]
+    public void Apply_WithNoAdjustments_ReturnsSameInstance()
+    {
+        IReadOnlyList<LedgerTaxLot> lots = [new("lot-a", new DateOnly(2026, 1, 1), 10m, 90m, SecurityId)];
+
+        var result = LedgerTaxLotBasisAdjuster.Apply(lots, []);
+
+        result.Should().BeSameAs(lots);
+    }
+
+    [Fact]
+    public void Apply_ForwardSplit_ScalesQuantityUpAndUnitCostDown_PreservingTotalBasis()
+    {
+        IReadOnlyList<LedgerTaxLot> lots = [new("lot-a", new DateOnly(2026, 1, 1), 10m, 90m, SecurityId)];
+        var split = new LedgerTaxLotBasisAdjustment(
+            LedgerTaxLotBasisAdjustmentKind.Split, 2m, new DateOnly(2026, 2, 1), SecurityId);
+
+        var result = LedgerTaxLotBasisAdjuster.Apply(lots, [split]);
+
+        result.Should().ContainSingle();
+        result[0].Quantity.Should().Be(20m);
+        result[0].UnitCost.Should().Be(45m);
+        (result[0].Quantity * result[0].UnitCost).Should().Be(900m);
+    }
+
+    [Fact]
+    public void Apply_ReverseSplit_ScalesQuantityDownAndUnitCostUp()
+    {
+        IReadOnlyList<LedgerTaxLot> lots = [new("lot-a", new DateOnly(2026, 1, 1), 10m, 9m, SecurityId)];
+        var reverse = new LedgerTaxLotBasisAdjustment(
+            LedgerTaxLotBasisAdjustmentKind.Split, 0.1m, new DateOnly(2026, 2, 1), SecurityId);
+
+        var result = LedgerTaxLotBasisAdjuster.Apply(lots, [reverse]);
+
+        result[0].Quantity.Should().Be(1m);
+        result[0].UnitCost.Should().Be(90m);
+    }
+
+    [Fact]
+    public void Apply_DoesNotAdjustLotsAcquiredOnOrAfterEffectiveDate()
+    {
+        // A lot acquired on the ex-date already reflects the post-split terms.
+        IReadOnlyList<LedgerTaxLot> lots = [new("lot-a", new DateOnly(2026, 2, 1), 10m, 90m, SecurityId)];
+        var split = new LedgerTaxLotBasisAdjustment(
+            LedgerTaxLotBasisAdjustmentKind.Split, 2m, new DateOnly(2026, 2, 1), SecurityId);
+
+        var result = LedgerTaxLotBasisAdjuster.Apply(lots, [split]);
+
+        result[0].Quantity.Should().Be(10m);
+        result[0].UnitCost.Should().Be(90m);
+    }
+
+    [Fact]
+    public void Apply_ReturnOfCapital_ReducesUnitCostAndFloorsAtZero()
+    {
+        IReadOnlyList<LedgerTaxLot> lots =
+        [
+            new("lot-a", new DateOnly(2026, 1, 1), 10m, 50m, SecurityId),
+            new("lot-b", new DateOnly(2026, 1, 1), 10m, 3m, SecurityId),
+        ];
+        var roc = new LedgerTaxLotBasisAdjustment(
+            LedgerTaxLotBasisAdjustmentKind.ReturnOfCapital, 5m, new DateOnly(2026, 2, 1), SecurityId);
+
+        var result = LedgerTaxLotBasisAdjuster.Apply(lots, [roc]);
+
+        result[0].UnitCost.Should().Be(45m);
+        result[1].UnitCost.Should().Be(0m); // floored, cannot go negative
+    }
+
+    [Fact]
+    public void Apply_FactorPaydown_ScalesFaceWhileKeepingUnitCost()
+    {
+        IReadOnlyList<LedgerTaxLot> lots = [new("lot-a", new DateOnly(2026, 1, 1), 100m, 99m, SecurityId)];
+        var factor = new LedgerTaxLotBasisAdjustment(
+            LedgerTaxLotBasisAdjustmentKind.Factor, 0.8m, new DateOnly(2026, 6, 1), SecurityId);
+
+        var result = LedgerTaxLotBasisAdjuster.Apply(lots, [factor]);
+
+        result[0].Quantity.Should().Be(80m);
+        result[0].UnitCost.Should().Be(99m);
+        (result[0].Quantity * result[0].UnitCost).Should().Be(7920m); // paid-down basis is relieved
+    }
+
+    [Fact]
+    public void Apply_FactorPaydownToNearZero_DropsLot()
+    {
+        IReadOnlyList<LedgerTaxLot> lots = [new("lot-a", new DateOnly(2026, 1, 1), 1m, 100m, SecurityId)];
+        var factor = new LedgerTaxLotBasisAdjustment(
+            LedgerTaxLotBasisAdjustmentKind.Factor, 0.00000000001m, new DateOnly(2026, 6, 1), SecurityId);
+
+        var result = LedgerTaxLotBasisAdjuster.Apply(lots, [factor]);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Apply_PremiumAmortization_MovesUnitCostTowardParDown()
+    {
+        IReadOnlyList<LedgerTaxLot> lots = [new("lot-a", new DateOnly(2026, 1, 1), 100m, 102m, SecurityId)];
+        var amortization = new LedgerTaxLotBasisAdjustment(
+            LedgerTaxLotBasisAdjustmentKind.Amortization, -1m, new DateOnly(2026, 6, 1), SecurityId);
+
+        var result = LedgerTaxLotBasisAdjuster.Apply(lots, [amortization]);
+
+        result[0].UnitCost.Should().Be(101m);
+    }
+
+    [Fact]
+    public void Apply_DiscountAccretion_MovesUnitCostTowardParUp()
+    {
+        IReadOnlyList<LedgerTaxLot> lots = [new("lot-a", new DateOnly(2026, 1, 1), 100m, 98m, SecurityId)];
+        var accretion = new LedgerTaxLotBasisAdjustment(
+            LedgerTaxLotBasisAdjustmentKind.Amortization, 1m, new DateOnly(2026, 6, 1), SecurityId);
+
+        var result = LedgerTaxLotBasisAdjuster.Apply(lots, [accretion]);
+
+        result[0].UnitCost.Should().Be(99m);
+    }
+
+    [Fact]
+    public void Apply_SecurityScopedAdjustment_OnlyTouchesMatchingLots()
+    {
+        IReadOnlyList<LedgerTaxLot> lots =
+        [
+            new("lot-match", new DateOnly(2026, 1, 1), 10m, 90m, SecurityId),
+            new("lot-other", new DateOnly(2026, 1, 1), 10m, 90m, OtherSecurityId),
+        ];
+        var split = new LedgerTaxLotBasisAdjustment(
+            LedgerTaxLotBasisAdjustmentKind.Split, 2m, new DateOnly(2026, 2, 1), SecurityId);
+
+        var result = LedgerTaxLotBasisAdjuster.Apply(lots, [split]);
+
+        result.Single(l => l.LotId == "lot-match").Quantity.Should().Be(20m);
+        result.Single(l => l.LotId == "lot-other").Quantity.Should().Be(10m);
+    }
+
+    [Fact]
+    public void Apply_LotTargetedAdjustment_OnlyTouchesNamedLot()
+    {
+        IReadOnlyList<LedgerTaxLot> lots =
+        [
+            new("lot-a", new DateOnly(2026, 1, 1), 100m, 102m, SecurityId),
+            new("lot-b", new DateOnly(2026, 1, 1), 100m, 102m, SecurityId),
+        ];
+        var amortization = new LedgerTaxLotBasisAdjustment(
+            LedgerTaxLotBasisAdjustmentKind.Amortization, -2m, new DateOnly(2026, 6, 1), SecurityId, LotId: "lot-a");
+
+        var result = LedgerTaxLotBasisAdjuster.Apply(lots, [amortization]);
+
+        result.Single(l => l.LotId == "lot-a").UnitCost.Should().Be(100m);
+        result.Single(l => l.LotId == "lot-b").UnitCost.Should().Be(102m);
+    }
+
+    [Fact]
+    public void Apply_InvalidSplitRatio_Throws()
+    {
+        IReadOnlyList<LedgerTaxLot> lots = [new("lot-a", new DateOnly(2026, 1, 1), 10m, 90m, SecurityId)];
+        var invalid = new LedgerTaxLotBasisAdjustment(
+            LedgerTaxLotBasisAdjustmentKind.Split, 0m, new DateOnly(2026, 2, 1), SecurityId);
+
+        var act = () => LedgerTaxLotBasisAdjuster.Apply(lots, [invalid]);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Project_WithSplitAdjustment_RelievesAgainstSplitAdjustedLots()
+    {
+        var account = LedgerAccounts.Securities("AAPL", "broker-1");
+        var input = new LedgerTaxLotReliefInput(
+            account,
+            new DateOnly(2026, 3, 1),
+            quantitySold: 12m,
+            salePrice: 50m,
+            LedgerTaxLotReliefMethod.Fifo,
+            [new LedgerTaxLot("lot-a", new DateOnly(2026, 1, 1), 10m, 90m, SecurityId)],
+            basisAdjustments:
+            [
+                new LedgerTaxLotBasisAdjustment(LedgerTaxLotBasisAdjustmentKind.Split, 2m, new DateOnly(2026, 2, 1), SecurityId),
+            ]);
+
+        var projection = LedgerTaxLotReliefProjector.Project(input);
+
+        projection.IsBalanced.Should().BeTrue();
+        projection.EffectiveLots.Should().ContainSingle();
+        projection.EffectiveLots[0].Quantity.Should().Be(20m);
+        projection.EffectiveLots[0].UnitCost.Should().Be(45m);
+        projection.AppliedAdjustments.Should().ContainSingle();
+        projection.Selections[0].QuantityRelieved.Should().Be(12m);
+        projection.CostBasis.Should().Be(540m); // 12 shares @ 45 post-split
+        projection.Proceeds.Should().Be(600m);
+        projection.RealizedGainOrLoss.Should().Be(60m);
+    }
+
+    [Fact]
+    public void Project_WithFactorPaydown_ReducesRelievableBasis()
+    {
+        var account = LedgerAccounts.Securities("MBS1", "broker-2");
+        var input = new LedgerTaxLotReliefInput(
+            account,
+            new DateOnly(2026, 6, 30),
+            quantitySold: 40m,
+            salePrice: 101m,
+            LedgerTaxLotReliefMethod.Fifo,
+            [new LedgerTaxLot("lot-a", new DateOnly(2026, 1, 1), 100m, 100m, SecurityId)],
+            basisAdjustments:
+            [
+                new LedgerTaxLotBasisAdjustment(LedgerTaxLotBasisAdjustmentKind.Factor, 0.5m, new DateOnly(2026, 6, 30), SecurityId),
+            ]);
+
+        var projection = LedgerTaxLotReliefProjector.Project(input);
+
+        projection.EffectiveLots[0].Quantity.Should().Be(50m); // 100 face paid down to 50
+        projection.CostBasis.Should().Be(4000m);
+        projection.RealizedGainOrLoss.Should().Be(40m);
+    }
+
+    [Fact]
+    public void Project_WhenAdjustedQuantityIsInsufficient_Throws()
+    {
+        var account = LedgerAccounts.Securities("MBS1", "broker-2");
+        var input = new LedgerTaxLotReliefInput(
+            account,
+            new DateOnly(2026, 6, 30),
+            quantitySold: 60m,
+            salePrice: 101m,
+            LedgerTaxLotReliefMethod.Fifo,
+            [new LedgerTaxLot("lot-a", new DateOnly(2026, 1, 1), 100m, 100m, SecurityId)],
+            basisAdjustments:
+            [
+                new LedgerTaxLotBasisAdjustment(LedgerTaxLotBasisAdjustmentKind.Factor, 0.5m, new DateOnly(2026, 6, 30), SecurityId),
+            ]);
+
+        var act = () => LedgerTaxLotReliefProjector.Project(input);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Insufficient open tax-lot quantity*");
+    }
+}

--- a/tests/Meridian.Tests/SecurityMaster/SecurityMasterAmortizationLedgerBridgeTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityMasterAmortizationLedgerBridgeTests.cs
@@ -1,0 +1,176 @@
+using FluentAssertions;
+using Meridian.Application.SecurityMaster;
+using Meridian.Contracts.SecurityMaster;
+using Meridian.Ledger;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+using DomainLedger = Meridian.Ledger.Ledger;
+
+namespace Meridian.Tests.SecurityMaster;
+
+/// <summary>
+/// Unit tests for <see cref="SecurityMasterAmortizationLedgerBridge"/> — posting structured cash
+/// flow / accrual / amortization projections into the ledger instead of leaving them display-only.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class SecurityMasterAmortizationLedgerBridgeTests
+{
+    private static readonly Guid SecurityId = Guid.Parse("dddddddd-0000-0000-0000-000000000001");
+    private const string Ticker = "CORP2030";
+
+    private static SecurityMasterAmortizationLedgerBridge BuildBridge(ISecurityMasterCashFlowService cashFlowService)
+        => new(cashFlowService, NullLogger<SecurityMasterAmortizationLedgerBridge>.Instance);
+
+    private static ISecurityMasterCashFlowService CashFlowServiceWith(
+        StructuredCashFlowProjectionDto? projection,
+        StructuredCashFlowScenario scenario = StructuredCashFlowScenario.Base)
+    {
+        var service = Substitute.For<ISecurityMasterCashFlowService>();
+        service.GetProjectionAsync(SecurityId, scenario, Arg.Any<CancellationToken>()).Returns(projection);
+        return service;
+    }
+
+    private static StructuredCashFlowProjectionDto Projection(params StructuredCashFlowScheduleEntry[] schedule)
+        => new(SecurityId, StructuredCashFlowSourceKind.CalculatedBullet, StructuredCashFlowScenario.Base, DateTimeOffset.UtcNow, schedule);
+
+    private static StructuredCashFlowScheduleEntry Period(int year, int month, int day, decimal interest, decimal principal = 0m)
+        => new(new DateTimeOffset(year, month, day, 0, 0, 0, TimeSpan.Zero), principal, interest, 1m);
+
+    [Fact]
+    public async Task PostProjectedCashFlowsAsync_PostsCouponAccrualPerPeriod()
+    {
+        var projection = Projection(
+            Period(2026, 6, 30, interest: 30m),
+            Period(2026, 12, 31, interest: 30m));
+        var bridge = BuildBridge(CashFlowServiceWith(projection));
+        var ledger = new DomainLedger();
+
+        var posted = await bridge.PostProjectedCashFlowsAsync(SecurityId, Ticker, ledger);
+
+        posted.Should().Be(2);
+        ledger.Journal.Should().HaveCount(2);
+        ledger.Journal.Should().OnlyContain(entry => entry.IsBalanced);
+        ledger.GetBalance(LedgerAccounts.AccruedInterestReceivable(Ticker)).Should().Be(60m);
+        ledger.GetBalance(LedgerAccounts.CouponIncome).Should().Be(60m);
+
+        var first = ledger.Journal[0];
+        first.Metadata.SecurityId.Should().Be(SecurityId);
+        first.Metadata.Symbol.Should().Be(Ticker);
+        first.Metadata.LedgerView.Should().Be(LedgerViewKind.SecurityMaster);
+        first.Metadata.ActivityType.Should().Be("FixedIncomeAmortization");
+    }
+
+    [Fact]
+    public async Task PostProjectedCashFlowsAsync_AmortizesPremiumTowardPar()
+    {
+        var projection = Projection(Period(2026, 6, 30, interest: 20m));
+        var bridge = BuildBridge(CashFlowServiceWith(projection));
+        var ledger = new DomainLedger();
+
+        // 1,000 face bought at 102% -> 20 of premium amortized over the single posted period.
+        var context = new AmortizationLedgerPostingContext(PositionFace: 1000m, PurchasePricePercentOfPar: 102m);
+        var posted = await bridge.PostProjectedCashFlowsAsync(SecurityId, Ticker, ledger, context);
+
+        posted.Should().Be(1);
+        ledger.Journal[0].IsBalanced.Should().BeTrue();
+        ledger.GetBalance(LedgerAccounts.AccruedInterestReceivable(Ticker)).Should().Be(20m);
+        ledger.GetBalance(LedgerAccounts.Securities(Ticker)).Should().Be(-20m); // carrying value written down
+        ledger.GetBalance(LedgerAccounts.CouponIncome).Should().Be(0m); // coupon 20 offset by premium 20
+    }
+
+    [Fact]
+    public async Task PostProjectedCashFlowsAsync_AccretesDiscountTowardPar()
+    {
+        var projection = Projection(Period(2026, 6, 30, interest: 0m));
+        var bridge = BuildBridge(CashFlowServiceWith(projection));
+        var ledger = new DomainLedger();
+
+        var context = new AmortizationLedgerPostingContext(PositionFace: 1000m, PurchasePricePercentOfPar: 98m);
+        var posted = await bridge.PostProjectedCashFlowsAsync(SecurityId, Ticker, ledger, context);
+
+        posted.Should().Be(1);
+        ledger.Journal[0].IsBalanced.Should().BeTrue();
+        ledger.GetBalance(LedgerAccounts.Securities(Ticker)).Should().Be(20m); // carrying value written up
+        ledger.GetBalance(LedgerAccounts.CouponIncome).Should().Be(20m);
+    }
+
+    [Fact]
+    public async Task PostProjectedCashFlowsAsync_PostsPrincipalPaydownSeparately()
+    {
+        var projection = Projection(Period(2026, 6, 30, interest: 30m, principal: 500m));
+        var bridge = BuildBridge(CashFlowServiceWith(projection));
+        var ledger = new DomainLedger();
+
+        var posted = await bridge.PostProjectedCashFlowsAsync(SecurityId, Ticker, ledger);
+
+        posted.Should().Be(2); // coupon accrual + principal paydown
+        ledger.Journal.Should().HaveCount(2);
+        ledger.Journal.Should().OnlyContain(entry => entry.IsBalanced);
+        ledger.GetBalance(LedgerAccounts.Cash).Should().Be(500m);
+        ledger.GetBalance(LedgerAccounts.Securities(Ticker)).Should().Be(-500m);
+
+        var paydown = ledger.Journal.Single(entry => entry.Metadata.ActivityType == "PrincipalPaydown");
+        paydown.Metadata.SecurityId.Should().Be(SecurityId);
+        paydown.Metadata.LedgerView.Should().Be(LedgerViewKind.SecurityMaster);
+    }
+
+    [Fact]
+    public async Task PostProjectedCashFlowsAsync_IsIdempotent()
+    {
+        var projection = Projection(Period(2026, 6, 30, interest: 30m, principal: 500m));
+        var bridge = BuildBridge(CashFlowServiceWith(projection));
+        var ledger = new DomainLedger();
+
+        var firstPass = await bridge.PostProjectedCashFlowsAsync(SecurityId, Ticker, ledger);
+        var secondPass = await bridge.PostProjectedCashFlowsAsync(SecurityId, Ticker, ledger);
+
+        firstPass.Should().Be(2);
+        secondPass.Should().Be(0);
+        ledger.Journal.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task PostProjectedCashFlowsAsync_RespectsMaxPeriods()
+    {
+        var projection = Projection(
+            Period(2026, 3, 31, interest: 10m),
+            Period(2026, 6, 30, interest: 10m),
+            Period(2026, 9, 30, interest: 10m));
+        var bridge = BuildBridge(CashFlowServiceWith(projection));
+        var ledger = new DomainLedger();
+
+        var posted = await bridge.PostProjectedCashFlowsAsync(
+            SecurityId, Ticker, ledger, new AmortizationLedgerPostingContext(MaxPeriods: 2));
+
+        posted.Should().Be(2);
+        ledger.Journal.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task PostProjectedCashFlowsAsync_WithNoProjection_PostsNothing()
+    {
+        var bridge = BuildBridge(CashFlowServiceWith(projection: null));
+        var ledger = new DomainLedger();
+
+        var posted = await bridge.PostProjectedCashFlowsAsync(SecurityId, Ticker, ledger);
+
+        posted.Should().Be(0);
+        ledger.Journal.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task PostProjectedCashFlowsAsync_ScopesAccountsToFinancialAccount()
+    {
+        var projection = Projection(Period(2026, 6, 30, interest: 40m));
+        var bridge = BuildBridge(CashFlowServiceWith(projection));
+        var ledger = new DomainLedger();
+
+        var context = new AmortizationLedgerPostingContext(FinancialAccountId: "broker-9");
+        await bridge.PostProjectedCashFlowsAsync(SecurityId, Ticker, ledger, context);
+
+        ledger.GetBalance(LedgerAccounts.AccruedInterestReceivable(Ticker, "broker-9")).Should().Be(40m);
+        ledger.GetBalance(LedgerAccounts.CouponIncomeFor("broker-9")).Should().Be(40m);
+        ledger.Journal[0].Metadata.FinancialAccountId.Should().Be("broker-9");
+    }
+}

--- a/tests/Meridian.Tests/SecurityMaster/SecurityMasterAmortizationLedgerBridgeTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityMasterAmortizationLedgerBridgeTests.cs
@@ -131,6 +131,35 @@ public sealed class SecurityMasterAmortizationLedgerBridgeTests
     }
 
     [Fact]
+    public async Task PostProjectedCashFlowsAsync_SmallPremiumOverManyPeriods_NeverBooksReversedSign()
+    {
+        // 1 face at 102% -> 0.02 total premium spread over 4 periods. Naive per-period rounding
+        // would over-allocate the first periods and flip the last period into a discount accretion;
+        // the cumulative-target distribution keeps every share a premium write-down.
+        var projection = Projection(
+            Period(2026, 3, 31, interest: 5m),
+            Period(2026, 6, 30, interest: 5m),
+            Period(2026, 9, 30, interest: 5m),
+            Period(2026, 12, 31, interest: 5m));
+        var bridge = BuildBridge(CashFlowServiceWith(projection));
+        var ledger = new DomainLedger();
+
+        var context = new AmortizationLedgerPostingContext(PositionFace: 1m, PurchasePricePercentOfPar: 102m);
+        var posted = await bridge.PostProjectedCashFlowsAsync(SecurityId, Ticker, ledger, context);
+
+        posted.Should().Be(4);
+        ledger.Journal.Should().OnlyContain(entry => entry.IsBalanced);
+
+        // A premium position must only ever credit (write down) the carrying account; a debit would
+        // mean an erroneous discount accretion on a premium bond.
+        var securities = LedgerAccounts.Securities(Ticker);
+        ledger.Journal.SelectMany(entry => entry.Lines)
+            .Where(line => line.Account == securities)
+            .Should().OnlyContain(line => line.Debit == 0m);
+        ledger.GetBalance(securities).Should().Be(-0.02m);
+    }
+
+    [Fact]
     public async Task PostProjectedCashFlowsAsync_RespectsMaxPeriods()
     {
         var projection = Projection(

--- a/tests/Meridian.Tests/SecurityMaster/SecurityMasterCostBasisAdjustmentServiceTests.cs
+++ b/tests/Meridian.Tests/SecurityMaster/SecurityMasterCostBasisAdjustmentServiceTests.cs
@@ -1,0 +1,241 @@
+using System.Text.Json;
+using FluentAssertions;
+using Meridian.Application.SecurityMaster;
+using Meridian.Contracts.SecurityMaster;
+using Meridian.Ledger;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+using ISecurityMasterQueryService = Meridian.Application.SecurityMaster.ISecurityMasterQueryService;
+
+namespace Meridian.Tests.SecurityMaster;
+
+/// <summary>
+/// Unit tests for <see cref="SecurityMasterCostBasisAdjustmentService"/> — the enricher that reads
+/// Security Master corporate actions, factor, and day-count terms and projects them into ledger
+/// tax-lot basis adjustments.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class SecurityMasterCostBasisAdjustmentServiceTests
+{
+    private static readonly Guid SecurityId = Guid.Parse("cccccccc-0000-0000-0000-000000000001");
+    private const string Ticker = "ACME";
+
+    private static SecurityMasterCostBasisAdjustmentService BuildService(ISecurityMasterQueryService queryService)
+        => new(queryService, NullLogger<SecurityMasterCostBasisAdjustmentService>.Instance);
+
+    private static ISecurityMasterQueryService QueryServiceWith(
+        IReadOnlyList<CorporateActionDto>? actions = null,
+        SecurityDetailDto? security = null)
+    {
+        var queryService = Substitute.For<ISecurityMasterQueryService>();
+        queryService.GetCorporateActionsAsync(SecurityId, Arg.Any<CancellationToken>())
+            .Returns(actions ?? []);
+        queryService.GetByIdAsync(SecurityId, Arg.Any<CancellationToken>())
+            .Returns(security);
+        return queryService;
+    }
+
+    private static CorporateActionDto Action(
+        string eventType,
+        DateOnly exDate,
+        decimal? splitRatio = null,
+        decimal? dividendPerShare = null,
+        string? lifecycleState = null)
+        => new(
+            CorpActId: Guid.NewGuid(),
+            SecurityId: SecurityId,
+            EventType: eventType,
+            ExDate: exDate,
+            PayDate: exDate.AddDays(10),
+            DividendPerShare: dividendPerShare,
+            Currency: dividendPerShare is null ? null : "USD",
+            SplitRatio: splitRatio,
+            NewSecurityId: null,
+            DistributionRatio: null,
+            AcquirerSecurityId: null,
+            ExchangeRatio: null,
+            SubscriptionPricePerShare: null,
+            RightsPerShare: null,
+            RecordDate: exDate.AddDays(1),
+            LifecycleState: lifecycleState);
+
+    private static SecurityDetailDto Security(string assetClass, object assetSpecificTerms)
+        => new(
+            SecurityId,
+            assetClass,
+            SecurityStatusDto.Active,
+            "ACME Corp",
+            "USD",
+            JsonSerializer.SerializeToElement(new { displayName = "ACME Corp", currency = "USD" }),
+            JsonSerializer.SerializeToElement(assetSpecificTerms),
+            [new SecurityIdentifierDto(SecurityIdentifierKind.Ticker, Ticker, true, DateTimeOffset.UtcNow)],
+            [],
+            1,
+            DateTimeOffset.UtcNow,
+            null);
+
+    private static IReadOnlyList<LedgerTaxLot> Lots(params LedgerTaxLot[] lots) => lots;
+
+    [Fact]
+    public async Task BuildAdjustmentsAsync_ForwardSplit_ProducesSplitAdjustment()
+    {
+        var queryService = QueryServiceWith(actions: [Action("StockSplit", new DateOnly(2024, 6, 1), splitRatio: 2m)]);
+        var service = BuildService(queryService);
+
+        var adjustments = await service.BuildAdjustmentsAsync(
+            SecurityId, Lots(new LedgerTaxLot("lot-a", new DateOnly(2024, 1, 1), 10m, 90m, SecurityId)), new DateOnly(2025, 1, 1));
+
+        adjustments.Should().ContainSingle();
+        adjustments[0].Kind.Should().Be(LedgerTaxLotBasisAdjustmentKind.Split);
+        adjustments[0].Value.Should().Be(2m);
+        adjustments[0].EffectiveDate.Should().Be(new DateOnly(2024, 6, 1));
+        adjustments[0].SecurityId.Should().Be(SecurityId);
+    }
+
+    [Fact]
+    public async Task BuildAdjustmentsAsync_ReturnOfCapital_ProducesBasisReduction()
+    {
+        var queryService = QueryServiceWith(actions: [Action("ReturnOfCapital", new DateOnly(2024, 3, 1), dividendPerShare: 1.5m)]);
+        var service = BuildService(queryService);
+
+        var adjustments = await service.BuildAdjustmentsAsync(
+            SecurityId, Lots(new LedgerTaxLot("lot-a", new DateOnly(2024, 1, 1), 10m, 50m, SecurityId)), new DateOnly(2025, 1, 1));
+
+        adjustments.Should().ContainSingle();
+        adjustments[0].Kind.Should().Be(LedgerTaxLotBasisAdjustmentKind.ReturnOfCapital);
+        adjustments[0].Value.Should().Be(1.5m);
+    }
+
+    [Fact]
+    public async Task BuildAdjustmentsAsync_CancelledCorporateAction_IsExcluded()
+    {
+        var queryService = QueryServiceWith(actions:
+        [
+            Action("StockSplit", new DateOnly(2024, 6, 1), splitRatio: 2m, lifecycleState: CorporateActionLifecycleStates.Cancelled),
+        ]);
+        var service = BuildService(queryService);
+
+        var adjustments = await service.BuildAdjustmentsAsync(
+            SecurityId, Lots(new LedgerTaxLot("lot-a", new DateOnly(2024, 1, 1), 10m, 90m, SecurityId)), new DateOnly(2025, 1, 1));
+
+        adjustments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task BuildAdjustmentsAsync_CorporateActionAfterAsOf_IsExcluded()
+    {
+        var queryService = QueryServiceWith(actions: [Action("StockSplit", new DateOnly(2026, 6, 1), splitRatio: 2m)]);
+        var service = BuildService(queryService);
+
+        var adjustments = await service.BuildAdjustmentsAsync(
+            SecurityId, Lots(new LedgerTaxLot("lot-a", new DateOnly(2024, 1, 1), 10m, 90m, SecurityId)), new DateOnly(2025, 1, 1));
+
+        adjustments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task BuildAdjustmentsAsync_CurrentFactorBelowPrior_ProducesFactorPaydown()
+    {
+        var queryService = QueryServiceWith(security: Security("MortgageBacked", new { currentFactor = 0.75m }));
+        var service = BuildService(queryService);
+
+        var adjustments = await service.BuildAdjustmentsAsync(
+            SecurityId, Lots(new LedgerTaxLot("lot-a", new DateOnly(2024, 1, 1), 100m, 100m, SecurityId)), new DateOnly(2025, 1, 1));
+
+        adjustments.Should().ContainSingle();
+        adjustments[0].Kind.Should().Be(LedgerTaxLotBasisAdjustmentKind.Factor);
+        adjustments[0].Value.Should().Be(0.75m);
+    }
+
+    [Fact]
+    public async Task BuildAdjustmentsAsync_FactorAtOne_ProducesNoFactorAdjustment()
+    {
+        var queryService = QueryServiceWith(security: Security("MortgageBacked", new { currentFactor = 1m }));
+        var service = BuildService(queryService);
+
+        var adjustments = await service.BuildAdjustmentsAsync(
+            SecurityId, Lots(new LedgerTaxLot("lot-a", new DateOnly(2024, 1, 1), 100m, 100m, SecurityId)), new DateOnly(2025, 1, 1));
+
+        adjustments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task BuildAdjustmentsAsync_BondPremium_ProducesStraightLineAmortization()
+    {
+        var queryService = QueryServiceWith(security: Security("Bond", new
+        {
+            maturityDate = "2030-01-01",
+            dayCountConvention = "30/360",
+            par = 100m,
+        }));
+        var service = BuildService(queryService);
+
+        // Lot bought at 110 (10-point premium), 5 of 10 years elapsed -> half the premium amortized.
+        var adjustments = await service.BuildAdjustmentsAsync(
+            SecurityId, Lots(new LedgerTaxLot("lot-a", new DateOnly(2020, 1, 1), 100m, 110m, SecurityId)), new DateOnly(2025, 1, 1));
+
+        adjustments.Should().ContainSingle();
+        adjustments[0].Kind.Should().Be(LedgerTaxLotBasisAdjustmentKind.Amortization);
+        adjustments[0].Value.Should().Be(-5m); // premium written down toward par
+        adjustments[0].LotId.Should().Be("lot-a");
+    }
+
+    [Fact]
+    public async Task BuildAdjustmentsAsync_NonFixedIncome_ProducesNoAmortization()
+    {
+        var queryService = QueryServiceWith(security: Security("Equity", new { maturityDate = "2030-01-01", dayCountConvention = "30/360" }));
+        var service = BuildService(queryService);
+
+        var adjustments = await service.BuildAdjustmentsAsync(
+            SecurityId, Lots(new LedgerTaxLot("lot-a", new DateOnly(2020, 1, 1), 100m, 110m, SecurityId)), new DateOnly(2025, 1, 1));
+
+        adjustments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ProjectReliefAsync_AppliesSplitToReduceCostBasis()
+    {
+        var queryService = QueryServiceWith(actions: [Action("StockSplit", new DateOnly(2024, 6, 1), splitRatio: 2m)]);
+        var service = BuildService(queryService);
+
+        var account = LedgerAccounts.Securities(Ticker, "broker-1");
+        var baseInput = new LedgerTaxLotReliefInput(
+            account,
+            new DateOnly(2025, 1, 1),
+            quantitySold: 12m,
+            salePrice: 50m,
+            LedgerTaxLotReliefMethod.Fifo,
+            [new LedgerTaxLot("lot-a", new DateOnly(2024, 1, 1), 10m, 90m, SecurityId)]);
+
+        var projection = await service.ProjectReliefAsync(baseInput, SecurityId);
+
+        projection.IsBalanced.Should().BeTrue();
+        projection.AppliedAdjustments.Should().ContainSingle();
+        projection.EffectiveLots[0].Quantity.Should().Be(20m);
+        projection.CostBasis.Should().Be(540m); // 12 @ 45 post-split
+        projection.RealizedGainOrLoss.Should().Be(60m);
+    }
+
+    [Fact]
+    public async Task ProjectReliefAsync_WithNoReferenceData_MatchesUnadjustedProjection()
+    {
+        var queryService = QueryServiceWith();
+        var service = BuildService(queryService);
+
+        var account = LedgerAccounts.Securities(Ticker, "broker-1");
+        var baseInput = new LedgerTaxLotReliefInput(
+            account,
+            new DateOnly(2025, 1, 1),
+            quantitySold: 5m,
+            salePrice: 120m,
+            LedgerTaxLotReliefMethod.Fifo,
+            [new LedgerTaxLot("lot-a", new DateOnly(2024, 1, 1), 10m, 100m, SecurityId)]);
+
+        var projection = await service.ProjectReliefAsync(baseInput, SecurityId);
+
+        projection.AppliedAdjustments.Should().BeEmpty();
+        projection.CostBasis.Should().Be(500m);
+        projection.RealizedGainOrLoss.Should().Be(100m);
+    }
+}


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Links tax-lot / cost-basis accounting to Security Master reference data, closing the largest remaining gap to institutional NAV / cost-basis integrity:

- **`SecurityId` on lots.** `LedgerTaxLot` gains an optional `SecurityId` so cost-basis lots link to authoritative reference data.
- **Basis adjustments feed the relief engine.** New pure, contracts-light `Meridian.Ledger` primitives — `LedgerTaxLotBasisAdjustment` / `LedgerTaxLotBasisAdjustmentKind` and `LedgerTaxLotBasisAdjuster` — restate open lots for corporate-action splits and return of capital, pool-factor paydowns, and day-count premium/discount amortization. `LedgerTaxLotReliefInput` / `LedgerTaxLotReliefProjector` / `LedgerTaxLotReliefProjection` thread and surface those adjustments, so relief runs against the *effective* lots. Behaviour is unchanged when no adjustments are supplied.
- **Security-Master-aware composition.** `SecurityMasterCostBasisAdjustmentService` reads corporate actions (via the effective-state projector), current factor, and day-count terms from the master and projects them into those adjustments (and can run enriched relief end-to-end). The ledger engine stays free of Security Master contracts; the reference-data reads live in `Meridian.Application`.
- **Projections wired into the ledger.** `SecurityMasterAmortizationLedgerBridge` posts projected coupon accrual, premium amortization / discount accretion, and principal paydowns as balanced, idempotent journal entries under `LedgerViewKind.SecurityMaster` — turning previously display-only cash flow projections into booked accounting, mirroring the existing `SecurityMasterLedgerBridge` corporate-action path.

The design is additive: layer boundaries are respected (`Meridian.Ledger` still references only `Meridian.Core` + `Meridian.FSharp.Ledger`), all existing constructors keep compiling via trailing optional parameters, and the existing `FixedIncomeAmortizationProjector` (previously uncalled) is now the amortization sink.

> Phase marker `PR7` declared for the roadmap scope gate: this change touches `src/**` (including a `src/**/README.md` doc-alignment edit) and `tests/**`, which `PR7` is the narrowest phase to cover.

## Reason

Tax-lot relief previously operated purely on recorded quantity/unit cost with no link to Security Master reference data: splits, return of capital, pool factors, and premium/discount amortization never adjusted cost basis, and cash flow / accrual / amortization projections were computed but never posted to the ledger. This closes that gap so realized-gain relief and NAV reflect factor-, corporate-action-, and day-count-restated basis.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Ran targeted validation locally (.NET 10 SDK): 33 new unit tests pass, and the existing `Meridian.Tests.Ledger` + `Meridian.Tests.SecurityMaster` suites stay green (618 passed, 0 failed). The full `scripts/ci.sh` gate was not run locally; the GitHub-hosted `quality-gate` remains authoritative.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed