### PR TITLE
ci: fix file-size ratchet by bumping settings-screen.tsx cap 7514 -> 7522

### DIFF
--- a/build/config/file-size-baseline.json
+++ b/build/config/file-size-baseline.json
@@ -37,7 +37,7 @@
     "src/Meridian.Ui/dashboard/src/screens/portfolio-screen.view-model.ts": 2542,
     "src/Meridian.Ui/dashboard/src/screens/reporting-screen.tsx": 3575,
     "src/Meridian.Ui/dashboard/src/screens/reporting-screen.view-model.ts": 2852,
-    "src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx": 7514,
+    "src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx": 7522,
     "src/Meridian.Ui/dashboard/src/screens/settings-screen.view-model.ts": 3227,
     "src/Meridian.Ui/dashboard/src/screens/strategy-designer-screen.view-model.ts": 2385,
     "src/Meridian.Ui/dashboard/src/screens/strategy-screen.view-model.ts": 3492,


### PR DESCRIPTION
## Problem

The Meridian CI **file-size ratchet** gate (`verify-fast (restore/build/test)` → "Enforce no-new-god-file ratchet", running `build/scripts/ci/check-file-size.py`) is failing on `main` and therefore on **every open PR**:

```
File-size ratchet FAILED: GREW past cap: src/Meridian.Ui/dashboard/src/screens/settings-screen.tsx now 7522 lines (baseline cap 7514). Reduce it, or update the baseline with justification.
```

**Root cause:** PR #2224 (commit `c8b4cda69` "wip: preserve uncommitted settings-screen metric tone refactor") grew `settings-screen.tsx` from 7505 → 7522 lines on `main` without updating the ratchet baseline (`build/config/file-size-baseline.json`, frozen cap 7514), so `main` and all downstream PRs are red on this gate.

## Fix

Bump the recorded `settings-screen.tsx` cap to the file's actual current line count on `main` (**7522**), matching what `check-file-size.py --update-baseline` would record. Per the check's own guidance, growing a baselined file past its cap requires an explicit, justified baseline update — this records the growth as tracked debt rather than silently allowing it.

This is a **minimal, behavior-preserving CI unblock only** — no product source changes. A genuine extraction of `settings-screen.tsx` into composed sub-components (ADR-017 / ADR-018) remains the healthier long-term fix and should be tracked separately.

## Verification

Ran the exact CI command locally on this branch:

```
$ python3 build/scripts/ci/check-file-size.py
File-size ratchet OK: 46 tracked file(s), no new or grown god files (threshold 2000 lines).
```

(The "Notice" that `data-screen.tsx` is now under threshold is a pre-existing stale entry unrelated to this change; left untouched to keep the diff surgical.)

Independent of the P0-correctness-fixes PR #2226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)