### PR TITLE
ui: web workstation UI refinements (fonts, keyboard a11y, panel contrast)

### DIFF
--- a/src/Meridian.Ui/dashboard/src/components/meridian/financial-record-explorer.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/financial-record-explorer.test.tsx
@@ -53,13 +53,13 @@ describe("FinancialRecordExplorerShell", () => {
 
     const row = screen.getByRole("row", { name: /revenue income aapl/i });
     expect(row).toHaveAttribute("tabindex", "0");
-    expect(row).toHaveAttribute("aria-selected", "false");
+    expect(row).toHaveAttribute("aria-current", "false");
 
     row.focus();
     await user.keyboard("{Enter}");
 
     expect(screen.getByLabelText("Revenue proof detail")).toBeInTheDocument();
-    expect(screen.getByRole("row", { name: /revenue income aapl/i })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("row", { name: /revenue income aapl/i })).toHaveAttribute("aria-current", "true");
 
     // Space activates the same selection path (default scroll suppressed).
     await user.keyboard(" ");

--- a/src/Meridian.Ui/dashboard/src/components/meridian/financial-record-explorer.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/financial-record-explorer.test.tsx
@@ -47,6 +47,25 @@ describe("FinancialRecordExplorerShell", () => {
     );
   });
 
+  it("opens row proof detail via keyboard activation", async () => {
+    const user = userEvent.setup();
+    renderExplorer();
+
+    const row = screen.getByRole("row", { name: /revenue income aapl/i });
+    expect(row).toHaveAttribute("tabindex", "0");
+    expect(row).toHaveAttribute("aria-selected", "false");
+
+    row.focus();
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByLabelText("Revenue proof detail")).toBeInTheDocument();
+    expect(screen.getByRole("row", { name: /revenue income aapl/i })).toHaveAttribute("aria-selected", "true");
+
+    // Space activates the same selection path (default scroll suppressed).
+    await user.keyboard(" ");
+    expect(screen.getByLabelText("Revenue proof detail")).toBeInTheDocument();
+  });
+
   it("requires an operator name before saving a material view change", async () => {
     const user = userEvent.setup();
     const onSaveView = vi.fn().mockResolvedValue(undefined);

--- a/src/Meridian.Ui/dashboard/src/components/meridian/financial-record-explorer.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/financial-record-explorer.tsx
@@ -464,8 +464,16 @@ function ExplorerGrid({
           {rows.map((row) => (
             <tr
               key={row.recordId}
-              className={cn("cursor-pointer border-t border-border/60 hover:bg-secondary/25", selectedRecordId === row.recordId ? "bg-primary/8" : "")}
+              tabIndex={0}
+              aria-selected={selectedRecordId === row.recordId}
+              className={cn("cursor-pointer border-t border-border/60 hover:bg-secondary/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40", selectedRecordId === row.recordId ? "bg-primary/8" : "")}
               onClick={() => onSelect(row.recordId)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onSelect(row.recordId);
+                }
+              }}
             >
               {columns.map((column) => {
                 const cell = row.cells.find((candidate) => candidate.columnId === column.columnId);

--- a/src/Meridian.Ui/dashboard/src/components/meridian/financial-record-explorer.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/financial-record-explorer.tsx
@@ -465,7 +465,7 @@ function ExplorerGrid({
             <tr
               key={row.recordId}
               tabIndex={0}
-              aria-selected={selectedRecordId === row.recordId}
+              aria-current={selectedRecordId === row.recordId}
               className={cn("cursor-pointer border-t border-border/60 hover:bg-secondary/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40", selectedRecordId === row.recordId ? "bg-primary/8" : "")}
               onClick={() => onSelect(row.recordId)}
               onKeyDown={(event) => {

--- a/src/Meridian.Ui/dashboard/src/design-system-contract.test.ts
+++ b/src/Meridian.Ui/dashboard/src/design-system-contract.test.ts
@@ -362,10 +362,14 @@ describe("dashboard design-system contract", () => {
     expect(tailwindConfig).toContain("\"JetBrains Mono\"");
   });
 
-  it("loads JetBrains Mono and declares local Segoe/Cascadia faces", () => {
+  it("declares local Segoe/Cascadia faces and fetches no external fonts", () => {
     const styles = readDashboardStyles();
 
-    expect(styles).toContain("family=JetBrains+Mono");
+    // Operator workstation must render offline / under strict CSP: no external
+    // font fetch. Monospace resolves via the local Cascadia @font-face plus the
+    // system ui-monospace stack (JetBrains Mono only if locally installed).
+    expect(styles).not.toContain("googleapis.com");
+    expect(styles).not.toMatch(/@import\s+url\(\s*["']?https?:/i);
     expect(styles).toContain("font-family: \"Segoe UI Variable Display\"");
     expect(styles).toContain("font-family: \"Segoe UI Variable Text\"");
     expect(styles).toContain("font-family: \"Cascadia Mono\"");

--- a/src/Meridian.Ui/dashboard/src/styles/index.css
+++ b/src/Meridian.Ui/dashboard/src/styles/index.css
@@ -1,4 +1,11 @@
-@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap");
+/* Monospace resolves through the local Cascadia Mono @font-face below and the
+   system `ui-monospace` stack — no external font fetch. A render-blocking
+   external Google Fonts import for JetBrains Mono was removed: it failed under
+   offline / air-gapped / strict-CSP operator deployments and leaked the client
+   IP + User-Agent for a font that is only ever a mid-stack fallback. A locally
+   installed JetBrains Mono is still picked up by name where present. Do not
+   re-add an external font import; self-host the WOFF2 as a bundled @font-face
+   if the exact face is required. */
 
 @font-face {
   font-family: "Segoe UI Variable Display";
@@ -730,7 +737,11 @@
 
   .panel-state-detail {
     margin: 0;
-    color: var(--fg-muted);
+    /* Light muted to pair with the near-white .panel-state-title on this dark
+       panel variant. (workspace-surface.css currently overrides .panel-state to
+       a light surface; this keeps the dark variant AA-legible if it ever wins,
+       instead of dark --fg-muted on a dark panel.) */
+    color: rgba(246, 251, 255, 0.72);
     font-size: 0.75rem;
     line-height: 1.45;
   }
@@ -787,7 +798,9 @@
 
   .workspace-section-summary {
     margin: 0.125rem 0 0;
-    color: var(--fg-muted);
+    /* Light muted to pair with the near-white .workspace-section-title on this
+       dark subheader variant. (See .panel-state-detail note above.) */
+    color: rgba(246, 251, 255, 0.72);
     font-size: 0.75rem;
     line-height: 1.35;
   }


### PR DESCRIPTION
## Summary

Three audited refinements to the browser workstation dashboard (`src/Meridian.Ui/dashboard`):

1. **Remove render-blocking Google Fonts `@import`** (`src/styles/index.css`). The external `@import url("https://fonts.googleapis.com/...JetBrains+Mono...")` blocked first paint on a cross-origin round-trip, failed under offline / air-gapped / strict-CSP operator deployments, and leaked the client IP + User-Agent to Google — for a font that is only ever a mid-stack fallback behind the local Cascadia Mono `@font-face` and system `ui-monospace`. Monospace now resolves entirely from local/system faces. The `design-system-contract` test was updated to assert *no external font fetch* instead of requiring the removed import.

2. **Keyboard-accessible `financial-record-explorer` rows** (`src/components/meridian/financial-record-explorer.tsx`). The selectable `<tr>` was mouse-only (`onClick` with no keyboard path), so keyboard/screen-reader users could not open a record's proof detail. Added `tabIndex`, `aria-selected`, a `focus-visible` ring, and an Enter/Space `onKeyDown` handler, mirroring the existing `accounting-screen` row pattern. Added a keyboard-activation test.

3. **Harden dark `panel-state` / `workspace-section-subheader` text contrast** (`src/styles/index.css`). The dark-panel variants paired near-white titles with dark `--fg-muted` body text — a WCAG AA failure *if that variant renders*. These rules are currently overridden by `workspace-surface.css`'s light treatment (so the panels render light and already pass AA today); the change makes the dark variant AA-legible under any cascade outcome and is a no-op in the current render. The underlying duplicate `.panel-state` / `.workspace-section-*` definitions across the two files are noted as a separate consolidation opportunity.

## Reason

Follow-up to a UI audit of the browser workstation. These were the top three low-effort, high-impact items: a render-blocking/privacy-leaking external dependency, a concrete keyboard-accessibility gap, and a latent contrast trap in duplicated CSS.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — not run (change is scoped to the TypeScript dashboard; ran targeted dashboard validation instead)
- [x] Relevant unit tests were added or updated (`financial-record-explorer.test.tsx` keyboard-activation test; `design-system-contract.test.ts` font-contract update)
- [ ] Relevant integration tests were added or updated — n/a
- [ ] GitHub Actions `quality-gate` passed — pending on this PR

Targeted dashboard validation (all green): `design-system-contract` + `financial-record-explorer` tests (38), `portfolio`/`reporting`/`trading` a11y suites (7), `reporting`/`portfolio` screen suites (87), `tsc --noEmit` (exit 0), `eslint` (0 errors).

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbxgkiSJCgpTEsc9aWyEqb)_