### PR TITLE
Make LedgerAccount.FinancialAccountId equality case-insensitive

### DIFF
--- a/src/Meridian.Ledger/LedgerAccount.cs
+++ b/src/Meridian.Ledger/LedgerAccount.cs
@@ -6,12 +6,35 @@ namespace Meridian.Ledger;
 /// For multi-bank / multi-broker ledgers, <see cref="FinancialAccountId"/> scopes the account to a
 /// specific user-owned account.
 /// </summary>
+/// <remarks>
+/// <see cref="FinancialAccountId"/> participates in equality case-insensitively: read-side account
+/// scoping (see <c>Ledger.MatchesFinancialAccount</c>) matches account ids with
+/// <see cref="StringComparison.OrdinalIgnoreCase"/>, so posting-side account identity must agree.
+/// Otherwise postings whose account ids differ only by casing accumulate in separate balance
+/// buckets that every read-side filter then reports as a single account.
+/// </remarks>
 public sealed record LedgerAccount(
     string Name,
     LedgerAccountType AccountType,
     string? Symbol = null,
     string? FinancialAccountId = null)
 {
+    /// <inheritdoc/>
+    public bool Equals(LedgerAccount? other)
+        => other is not null
+            && Name == other.Name
+            && AccountType == other.AccountType
+            && Symbol == other.Symbol
+            && string.Equals(FinancialAccountId, other.FinancialAccountId, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+        => HashCode.Combine(
+            Name,
+            AccountType,
+            Symbol,
+            FinancialAccountId is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(FinancialAccountId));
+
     /// <inheritdoc/>
     public override string ToString()
     {

--- a/tests/Meridian.Tests/Ledger/LedgerAccountIdentityTests.cs
+++ b/tests/Meridian.Tests/Ledger/LedgerAccountIdentityTests.cs
@@ -1,0 +1,110 @@
+using FluentAssertions;
+using Meridian.Ledger;
+using Xunit;
+
+namespace Meridian.Tests.Ledger;
+
+/// <summary>
+/// Locks in the account-identity contract: <see cref="LedgerAccount.FinancialAccountId"/> is
+/// case-insensitive so posting-side dictionary keying agrees with read-side
+/// <c>Ledger.MatchesFinancialAccount</c> scoping, while <c>Name</c> and <c>Symbol</c> remain
+/// case-sensitive.
+/// </summary>
+public sealed class LedgerAccountIdentityTests
+{
+    [Fact]
+    public void Equals_FinancialAccountIdDiffersOnlyByCase_AreEqual()
+    {
+        var upper = new LedgerAccount("Cash", LedgerAccountType.Asset, FinancialAccountId: "ACC-1");
+        var lower = new LedgerAccount("Cash", LedgerAccountType.Asset, FinancialAccountId: "acc-1");
+
+        upper.Should().Be(lower);
+        upper.GetHashCode().Should().Be(lower.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_NameOrSymbolDiffersByCase_AreNotEqual()
+    {
+        var account = new LedgerAccount("Cash", LedgerAccountType.Asset, Symbol: "AAPL");
+
+        account.Should().NotBe(account with { Name = "cash" });
+        account.Should().NotBe(account with { Symbol = "aapl" });
+    }
+
+    [Fact]
+    public void TrialBalance_MixedCaseFinancialAccountId_AccumulatesInOneAccount()
+    {
+        var ledger = new Meridian.Ledger.Ledger();
+        var timestamp = DateTimeOffset.UtcNow;
+        var cashUpper = new LedgerAccount("Cash", LedgerAccountType.Asset, FinancialAccountId: "ACC-1");
+        var revenueUpper = new LedgerAccount("Revenue", LedgerAccountType.Revenue, FinancialAccountId: "ACC-1");
+        var cashLower = new LedgerAccount("Cash", LedgerAccountType.Asset, FinancialAccountId: "acc-1");
+        var revenueLower = new LedgerAccount("Revenue", LedgerAccountType.Revenue, FinancialAccountId: "acc-1");
+
+        ledger.PostLines(timestamp, "sale-1", new[]
+        {
+            (cashUpper, 100m, 0m),
+            (revenueUpper, 0m, 100m),
+        });
+        ledger.PostLines(timestamp, "sale-2", new[]
+        {
+            (cashLower, 40m, 0m),
+            (revenueLower, 0m, 40m),
+        });
+
+        var trialBalance = ledger.TrialBalance();
+
+        trialBalance.Should().HaveCount(2);
+        trialBalance[cashUpper].Should().Be(140m);
+        trialBalance[revenueUpper].Should().Be(140m);
+    }
+
+    [Fact]
+    public void TrialBalance_ScopedByAnyCasing_ReturnsSameMergedAccounts()
+    {
+        var ledger = new Meridian.Ledger.Ledger();
+        var timestamp = DateTimeOffset.UtcNow;
+
+        ledger.PostLines(timestamp, "sale-1", new[]
+        {
+            (new LedgerAccount("Cash", LedgerAccountType.Asset, FinancialAccountId: "ACC-1"), 100m, 0m),
+            (new LedgerAccount("Revenue", LedgerAccountType.Revenue, FinancialAccountId: "ACC-1"), 0m, 100m),
+        });
+        ledger.PostLines(timestamp, "sale-2", new[]
+        {
+            (new LedgerAccount("Cash", LedgerAccountType.Asset, FinancialAccountId: "acc-1"), 40m, 0m),
+            (new LedgerAccount("Revenue", LedgerAccountType.Revenue, FinancialAccountId: "acc-1"), 0m, 40m),
+        });
+
+        var scopedUpper = ledger.TrialBalance(financialAccountId: "ACC-1");
+        var scopedLower = ledger.TrialBalance(financialAccountId: "acc-1");
+
+        scopedUpper.Should().HaveCount(2);
+        scopedUpper.Should().BeEquivalentTo(scopedLower);
+        scopedUpper.Values.Sum(Math.Abs).Should().Be(280m);
+    }
+
+    [Fact]
+    public void SummarizeAccounts_MixedCaseFinancialAccountId_ReportsSingleAccountPerName()
+    {
+        var ledger = new Meridian.Ledger.Ledger();
+        var timestamp = DateTimeOffset.UtcNow;
+
+        ledger.PostLines(timestamp, "sale-1", new[]
+        {
+            (new LedgerAccount("Cash", LedgerAccountType.Asset, FinancialAccountId: "ACC-1"), 100m, 0m),
+            (new LedgerAccount("Revenue", LedgerAccountType.Revenue, FinancialAccountId: "acc-1"), 0m, 100m),
+        });
+        ledger.PostLines(timestamp, "sale-2", new[]
+        {
+            (new LedgerAccount("Cash", LedgerAccountType.Asset, FinancialAccountId: "acc-1"), 40m, 0m),
+            (new LedgerAccount("Revenue", LedgerAccountType.Revenue, FinancialAccountId: "ACC-1"), 0m, 40m),
+        });
+
+        var summaries = ledger.SummarizeAccounts(financialAccountId: "Acc-1");
+
+        summaries.Should().HaveCount(2);
+        summaries.Select(summary => summary.Account.Name)
+            .Should().BeEquivalentTo(["Cash", "Revenue"]);
+    }
+}


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Fixes a trial-balance correctness defect found by the codebase audit: posting-side account identity used `LedgerAccount`'s default case-sensitive record equality, while read-side scoping (`Ledger.MatchesFinancialAccount`) compares `FinancialAccountId` with `OrdinalIgnoreCase`. Postings whose account ids differed only by casing (e.g. `ACC-1` vs `acc-1`) accumulated in **separate** `Dictionary<LedgerAccount, ...>` balance buckets that every read-side filter then reported as a **single** account — silently corrupting trial balances, account summaries, and balance snapshots.

## Change

- `src/Meridian.Ledger/LedgerAccount.cs`: override `Equals`/`GetHashCode` to compare `FinancialAccountId` case-insensitively. `Name`, `Symbol`, and `AccountType` keep their existing case-sensitive semantics. Display casing is preserved (first-posted casing wins for a merged bucket key) — no operator-visible ID rewriting.
- `tests/Meridian.Tests/Ledger/LedgerAccountIdentityTests.cs`: five regression tests locking in the identity contract (equality + hash agreement, trial-balance merging, scoped queries under any casing, account summaries, and Name/Symbol remaining case-sensitive).

Fixing equality on the record was chosen over normalizing at construction because `LedgerAccount` is constructed directly at 11+ sites across six projects (not just via the `LedgerAccounts` factory), and record-level equality covers every dictionary/group-by consumer (trial balances, shadow-NAV comparison, paper-session persistence, workspace read models) in one place without altering displayed IDs.

## Validation

- `Meridian.Tests.Ledger` namespace: 145 passed, 0 failed.
- Broader consumer sweep (`FinancialOperations.Ledger`, `PaperSession`, `FundOperationsWorkspace`, `ShadowNav`, `AccountingSemanticBoundary`, `LedgerCliCommand`): 130 passed, 0 failed.
- No existing tests assert case-sensitive account-id distinctness; no JSON serialization keys dictionaries by `LedgerAccount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)