### PR TITLE
Persist durable instrument position projections (Slice 3)

### DIFF
--- a/docs/architecture/event-accounting-architecture.md
+++ b/docs/architecture/event-accounting-architecture.md
@@ -106,13 +106,19 @@ does not match server state blocks candidate creation. The compatibility Securit
 backtesting adjuster call the same calculator, but neither compatibility path establishes production
 posting authority.
 
-The Slice 1 semantic alignment is additive and transport-compatible. Slice 2 adds only the planned
+The Slice 1 semantic alignment is additive and transport-compatible. Slice 2 added only the planned
 Asset Operations role, book-position, and append-only economic-state projection tables needed for
-production candidate re-resolution. It does not migrate existing Security Master, direct-lending,
-portfolio, fund-account, or asset-family records and does not create a parallel balance store or a
-projection-event-to-journal link table. Shared read models query the immutable journal by ledger book
-plus indexed source event and expose the same lineage to the active browser and WPF workstation lanes
-without moving policy into either client.
+production candidate re-resolution. Slice 3 places a dedicated store contract over those tables:
+effective-dated security/book lookup, book-position lookup, transactional expected-version writes,
+append-only state history, and fail-closed role, overlap, cross-book, owner, and date validation.
+The shared Asset Operations read service composes durable typed history with the existing
+security-scoped projection and never treats it as a balance fact.
+
+These slices do not migrate existing Security Master, direct-lending, portfolio, fund-account, or
+asset-family records and do not create a parallel balance store or a projection-event-to-journal
+link table. Shared read models query the immutable journal by ledger book plus indexed source event
+and expose the same lineage to the active browser and WPF workstation lanes without moving policy
+into either client.
 
 ## Implementation Map
 
@@ -123,7 +129,7 @@ without moving policy into either client.
 | Instrument role, position, economic-event, and projection lineage contracts | `src/Meridian.Contracts/AssetOperations/InstrumentPositionDtos.cs` |
 | Instrument and Asset Operations projections | `src/Meridian.Instruments/AssetOperations` |
 | MBS factor-paydown calculator | `src/Meridian.Instruments/AssetOperations/FactorPaydownProjectionService.cs` |
-| Durable role, position, and economic-state payloads | `src/Meridian.Storage/AssetOperations/Migrations/002_instrument_position_projections.sql` |
+| Durable role, position, and economic-state projections | `src/Meridian.Storage/AssetOperations/IInstrumentPositionProjectionStore.cs`, `src/Meridian.Storage/AssetOperations/Migrations/002_instrument_position_projections.sql`, `003_instrument_position_projection_guards.sql` |
 | Journal evidence metadata | `src/Meridian.Ledger/JournalEvidenceReference.cs`, `JournalEntryMetadata.cs` |
 | Durable write validation | `src/Meridian.Storage/Ledger/AccountingPostingCommandValidator.cs`, `PostgresLedgerJournalStore.cs` |
 | Source-backed journal draft commands | `src/Meridian.FinancialOperations/Ledger/AccountingJournalDraftService.cs` |

--- a/docs/architecture/meridian-domain-model.md
+++ b/docs/architecture/meridian-domain-model.md
@@ -83,9 +83,11 @@ Reference Data / Security Master
 - Ledger and Storage own immutable `JournalEntry` append, balanced child `LedgerEntry` records,
   idempotency, period and basis guards, correction lineage, and durable accounting truth.
 
-These concepts are additive semantic contracts. Their introduction does not require an initial
-schema migration or immediate migration of existing Security Master, direct-lending, portfolio,
-fund-account, or position records.
+These concepts began as additive semantic contracts. Durable role, book-position, and economic-state
+projections now live in the separate Asset Operations schema with effective dating, retained source
+and approval provenance, optimistic concurrency, and append-only state history. Their adoption does
+not migrate or backfill existing Security Master, direct-lending, portfolio, fund-account, or
+asset-family records, and the projection schema never stores ledger balances.
 
 ## Expansion Notes
 

--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -4901,11 +4901,16 @@ Meridian-main
 │   │   ├── AssetOperations
 │   │   │   ├── Migrations
 │   │   │   │   ├── 001_asset_operations.sql
-│   │   │   │   └── 002_instrument_position_projections.sql
+│   │   │   │   ├── 002_instrument_position_projections.sql
+│   │   │   │   └── 003_instrument_position_projection_guards.sql
 │   │   │   ├── AssetOperationsMigrationRunner.cs
 │   │   │   ├── IAssetOperationsProjectionStore.cs
+│   │   │   ├── IInstrumentPositionProjectionStore.cs
 │   │   │   ├── InMemoryAssetOperationsProjectionStore.cs
-│   │   │   └── PostgresAssetOperationsProjectionStore.cs
+│   │   │   ├── InMemoryAssetOperationsProjectionStore.InstrumentPositions.cs
+│   │   │   ├── PostgresAssetOperationsProjectionStore.cs
+│   │   │   ├── PostgresAssetOperationsProjectionStore.InstrumentPositions.cs
+│   │   │   └── PostgresAssetOperationsProjectionStore.Locks.cs
 │   │   ├── Backfill
 │   │   │   ├── BackfillStatusStore.cs
 │   │   │   └── BackfillStatusStoreJsonContext.cs
@@ -7442,6 +7447,7 @@ Meridian-main
 │   │   │   ├── AssetOperationsMigrationRunnerTests.cs
 │   │   │   ├── AssetOperationsReadServiceTests.cs
 │   │   │   ├── FactorPaydownProjectionServiceTests.cs
+│   │   │   ├── InMemoryInstrumentPositionProjectionStoreSlice3Tests.cs
 │   │   │   ├── InstrumentPositionProjectionStoreTests.cs
 │   │   │   ├── PortfolioCashLadderEngineTests.cs
 │   │   │   └── PortfolioCashLadderReadServiceTests.cs

--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -86,8 +86,8 @@
       "id": "SRC-DESIGN-INSTRUMENTS",
       "path": "src/Meridian.Instruments",
       "readme": "src/Meridian.Instruments/README.md",
-      "readme_hash": "7105d44882fdb135b5b514b78f63d46acff67c25eecb96090483842afa660a4d",
-      "source_hash": "dac7e618b66c9dd79727550298e26fc48a2a9a241c263629921baf89e16d8663"
+      "readme_hash": "a1241bddbf38939bae660cd1adaaf3bbdcee4d051e771eb5a7cdc0c24b23861c",
+      "source_hash": "7ab2592dc08e88e458ec59aa307a6732a64158bb6d8d39b833ef0ef8c40f01fe"
     },
     {
       "id": "SRC-DESIGN-PLATFORM",
@@ -233,8 +233,8 @@
       "id": "SRC-STORAGE",
       "path": "src/Meridian.Storage",
       "readme": "src/Meridian.Storage/README.md",
-      "readme_hash": "f149dccb097bef6f458aaf8e3217aace1e8fba2129c62d995cc09de2ac1d9598",
-      "source_hash": "c759c23c100b172df891a7b1d43c739d9b32f7f3dddb0d668078f75142c3533b"
+      "readme_hash": "06e8ec6f103baec133c7a54017fe3e0570431a9836b7a2fecbae4647dd00e42e",
+      "source_hash": "57ba1f5e1f3136a3af5f6a30a7704066a27a6cc3a0e83a59b6230f9a0276baa3"
     },
     {
       "id": "SRC-STRATEGIES",

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,7 +5,7 @@
 
 ## Overall Coverage
 
-**2779 / 7449** items documented (**37.3%**) &mdash; Grade: **F**
+**2780 / 7451** items documented (**37.3%**) &mdash; Grade: **F**
 
 ```text
 [=======-------------] 37.3%
@@ -15,7 +15,7 @@
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 2659 | 7023 | 37.9% | F |
+| Public Classes / Interfaces | 2660 | 7025 | 37.9% | F |
 | API Endpoints | 106 | 279 | 38.0% | F |
 | Configuration Options | 3 | 136 | 2.2% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |
@@ -23,7 +23,7 @@
 
 ## Undocumented Items
 
-### Public Classes / Interfaces (4364 undocumented)
+### Public Classes / Interfaces (4365 undocumented)
 
 | Item | Location |
 | ------ | ---------- |
@@ -77,7 +77,7 @@
 | `CorporateActionSupersedeRestatementTrigger` | `src/Meridian.Application/SecurityMaster/CorporateActions/CorporateActionRestatementTrigger.cs:54` |
 | `PositionCorporateActionAdjustment` | `src/Meridian.Application/SecurityMaster/CorporateActions/ILivePositionCorporateActionAdjuster.cs:6` |
 | `RecordTickerChangeRequest` | `src/Meridian.Application/SecurityMaster/CorporateActions/SecurityMasterTickerChangeService.cs:10` |
-| ... and 4314 more | |
+| ... and 4315 more | |
 
 ### API Endpoints (173 undocumented)
 
@@ -193,7 +193,7 @@
 
 ## Recommendations
 
-1. **Public Classes / Interfaces**: 4364 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
+1. **Public Classes / Interfaces**: 4365 undocumented types. Consider generating API docs with DocFX (`docfx docfx.json`) to cover the long tail of public types automatically.
 2. **API Endpoints**: 173 endpoint(s) missing from `docs/reference/api-reference.md`. Run the endpoint audit and update the API reference table.
 3. **Configuration Options**: 133 config key(s) not found in `docs/generated/configuration-schema.md`. Re-run the configuration schema generator to synchronise.
 

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,11 +1,11 @@
 {
   "total_files": 578,
-  "total_lines": 96929,
+  "total_lines": 96962,
   "orphaned_count": 245,
   "no_heading_count": 148,
   "stale_count": 0,
   "todo_count": 204,
-  "average_lines": 167.7,
+  "average_lines": 167.8,
   "health_score": 78,
   "orphaned_files": [
     ".agents/skills/meridian-archive-organizer/SKILL.md",
@@ -1416,7 +1416,7 @@
     },
     {
       "path": "docs/architecture/event-accounting-architecture.md",
-      "line_count": 148,
+      "line_count": 154,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -1456,7 +1456,7 @@
     },
     {
       "path": "docs/architecture/meridian-domain-model.md",
-      "line_count": 92,
+      "line_count": 94,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -2200,7 +2200,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 8658,
+      "line_count": 8664,
       "has_heading": true,
       "todo_count": 8,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -4688,7 +4688,7 @@
     },
     {
       "path": "src/Meridian.Instruments/README.md",
-      "line_count": 161,
+      "line_count": 163,
       "has_heading": true,
       "todo_count": 1,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -4768,7 +4768,7 @@
     },
     {
       "path": "src/Meridian.Storage/README.md",
-      "line_count": 362,
+      "line_count": 379,
       "has_heading": true,
       "todo_count": 1,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,8 +20,8 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 578 |
-| Total lines | 96,929 |
-| Average file size (lines) | 167.7 |
+| Total lines | 96,962 |
+| Average file size (lines) | 167.8 |
 | Orphaned files | 245 |
 | Files without headings | 148 |
 | Stale files (>90 days) | 0 |

--- a/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
@@ -340,7 +340,11 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
         {
             services.AddSingleton(assetOperationsOptions);
             services.AddSingleton<AssetOperationsMigrationRunner>();
-            services.AddSingleton<IAssetOperationsProjectionStore, PostgresAssetOperationsProjectionStore>();
+            services.AddSingleton<PostgresAssetOperationsProjectionStore>();
+            services.AddSingleton<IAssetOperationsProjectionStore>(sp =>
+                sp.GetRequiredService<PostgresAssetOperationsProjectionStore>());
+            services.AddSingleton<IInstrumentPositionProjectionStore>(sp =>
+                sp.GetRequiredService<PostgresAssetOperationsProjectionStore>());
         }
 
         // Register null/stub implementations as fallbacks when Security Master is not configured.
@@ -378,7 +382,12 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
         services.TryAddSingleton<IUflProjectionRebuilder, NullUflProjectionRebuilder>();
         // Passport Workbench conflict-authority policy is storage-independent (pure precedence logic).
         services.TryAddSingleton<ISecurityMasterConflictAuthorityPolicy, SecurityMasterConflictAuthorityPolicy>();
-        services.TryAddSingleton<IAssetOperationsProjectionStore, InMemoryAssetOperationsProjectionStore>();
+        services.TryAddSingleton<InMemoryAssetOperationsProjectionStore>();
+        services.TryAddSingleton<IAssetOperationsProjectionStore>(sp =>
+            sp.GetRequiredService<InMemoryAssetOperationsProjectionStore>());
+        services.TryAddSingleton<IInstrumentPositionProjectionStore>(sp =>
+            sp.GetService<IAssetOperationsProjectionStore>() as IInstrumentPositionProjectionStore
+            ?? sp.GetRequiredService<InMemoryAssetOperationsProjectionStore>());
         services.TryAddSingleton<AssetObligationProjectionService>();
         services.TryAddSingleton<IAssetOperationsCommandService, AssetOperationsProjectionCommandService>();
         services.TryAddSingleton<IAssetOperationsQueryService, AssetOperationsReadService>();

--- a/src/Meridian.Instruments/AssetOperations/AssetOperationsReadService.cs
+++ b/src/Meridian.Instruments/AssetOperations/AssetOperationsReadService.cs
@@ -14,17 +14,20 @@ public sealed class AssetOperationsReadService : IAssetOperationsQueryService
     private readonly ISecurityMasterQueryService? _securityMasterQueryService;
     private readonly IBondReferenceService? _bondReferenceService;
     private readonly AssetObligationProjectionService _obligationProjectionService;
+    private readonly IInstrumentPositionProjectionStore? _positionProjectionStore;
 
     public AssetOperationsReadService(
         IAssetOperationsProjectionStore? projectionStore = null,
         ISecurityMasterQueryService? securityMasterQueryService = null,
         IBondReferenceService? bondReferenceService = null,
-        AssetObligationProjectionService? obligationProjectionService = null)
+        AssetObligationProjectionService? obligationProjectionService = null,
+        IInstrumentPositionProjectionStore? positionProjectionStore = null)
     {
         _projectionStore = projectionStore;
         _securityMasterQueryService = securityMasterQueryService;
         _bondReferenceService = bondReferenceService;
         _obligationProjectionService = obligationProjectionService ?? new AssetObligationProjectionService();
+        _positionProjectionStore = positionProjectionStore;
     }
 
     public async Task<AssetOperationsDetailDto?> GetOperationsAsync(Guid securityId, CancellationToken ct = default)
@@ -34,22 +37,49 @@ public sealed class AssetOperationsReadService : IAssetOperationsQueryService
         var published = _projectionStore is null
             ? null
             : await _projectionStore.GetAsync(securityId, ct).ConfigureAwait(false);
+        AssetOperationsDetailDto detail;
         if (published is not null)
         {
-            return AssetOperationsProjectionBuilder.WithTermsObligationsTimeline(published);
+            detail = AssetOperationsProjectionBuilder.WithTermsObligationsTimeline(published);
         }
-
-        var security = _securityMasterQueryService is null
-            ? null
-            : await _securityMasterQueryService.GetByIdAsync(securityId, ct).ConfigureAwait(false);
-        if (security is null)
+        else
         {
-            return null;
+            var security = _securityMasterQueryService is null
+                ? null
+                : await _securityMasterQueryService.GetByIdAsync(securityId, ct).ConfigureAwait(false);
+            if (security is null)
+            {
+                return null;
+            }
+
+            detail = string.Equals(security.AssetClass, "Bond", StringComparison.OrdinalIgnoreCase)
+                ? await BuildBondOperationsAsync(security, ct).ConfigureAwait(false)
+                : _obligationProjectionService.ProjectFromSecurityMaster(security);
         }
 
-        return string.Equals(security.AssetClass, "Bond", StringComparison.OrdinalIgnoreCase)
-            ? await BuildBondOperationsAsync(security, ct).ConfigureAwait(false)
-            : _obligationProjectionService.ProjectFromSecurityMaster(security);
+        if (_positionProjectionStore is null)
+        {
+            return detail;
+        }
+
+        var positions = await _positionProjectionStore
+            .GetSecurityAsync(securityId, ct)
+            .ConfigureAwait(false);
+        if (positions.InstrumentRoles.Count == 0 &&
+            positions.BookPositions.Count == 0 &&
+            positions.PositionEconomicStates.Count == 0 &&
+            positions.ProjectionLineages.Count == 0)
+        {
+            return detail;
+        }
+
+        return detail with
+        {
+            InstrumentRoles = positions.InstrumentRoles,
+            BookPositions = positions.BookPositions,
+            PositionEconomicStates = positions.PositionEconomicStates,
+            ProjectionLineages = positions.ProjectionLineages
+        };
     }
 
     public async Task<AssetOperationsReadinessDto?> GetReadinessAsync(Guid securityId, CancellationToken ct = default)

--- a/src/Meridian.Instruments/README.md
+++ b/src/Meridian.Instruments/README.md
@@ -6,7 +6,7 @@ module_id: SRC-DESIGN-INSTRUMENTS
 path: src/Meridian.Instruments
 status: active
 owner_lane: Accounting and Ledger
-last_reviewed: 2026-07-12
+last_reviewed: 2026-07-13
 ---
 
 # src/Meridian.Instruments
@@ -43,8 +43,8 @@ This module belongs to the Design Module layer. Keep changes within that ownersh
 - `AssetOperations/AssetOperationsReadService.cs` - Security Master-keyed asset operations query,
   command, and projection builder for shared terms, lifecycle, cash-flow, activity,
   reconciliation, ledger, evidence, workflow-audit, terms/obligations timeline, and readiness views,
-  plus contract-ready instrument-role, book-position, economic-state, and projection-lineage
-  collections.
+  plus durable instrument-role, book-position, economic-state, and projection-lineage collections
+  merged from the dedicated projection store without replacing existing security-scoped detail.
 - `AssetOperations/AssetObligationProjectionService.cs` - retained-term projection service for
   Security Master-keyed assets that emits V1 expected cash flows, non-cash obligations, formula
   traces, ledger-support references, and timeline variances without writing ledger facts.
@@ -146,9 +146,11 @@ services, and MMF liquidity projections are owned by `Meridian.Instruments`.
 
 The additive role, book-position, economic-state, event-reference, and projection-lineage contract
 alignment does not migrate existing Security Master, direct-lending, portfolio, fund-account, or
-asset-specific records. Slice 2 persists only the governed role, position, and append-only economic
-state needed to re-resolve typed posting candidates; it cannot create another ledger or balance
-authority.
+asset-specific records. Slice 3 adds effective-dated security/book and position lookup plus
+transactional optimistic concurrency over the Slice 2 projection tables. Asset Operations reads
+compose that durable typed history with the existing security-scoped projection instead of replacing
+terms, cash flows, reconciliation, readiness, or workflow state. These records remain rebuildable
+economic projections; they cannot create another ledger or balance authority.
 
 ## Change rules
 

--- a/src/Meridian.Storage/AssetOperations/AssetOperationsMigrationRunner.cs
+++ b/src/Meridian.Storage/AssetOperations/AssetOperationsMigrationRunner.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Meridian.Contracts.AssetOperations;
 using Npgsql;
 
@@ -16,16 +18,56 @@ public sealed class AssetOperationsMigrationRunner
     public async Task EnsureMigratedAsync(CancellationToken ct = default)
     {
         await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(ct).ConfigureAwait(false);
+
+        await using (var migrationLock = connection.CreateCommand())
+        {
+            migrationLock.Transaction = transaction;
+            migrationLock.CommandText =
+                "select pg_advisory_xact_lock(hashtextextended(@migration_scope, 0));";
+            migrationLock.Parameters.AddWithValue(
+                "migration_scope",
+                $"meridian.asset_operations.migrations.{_options.Schema}");
+            await migrationLock.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+
+        await EnsureMigrationLedgerAsync(connection, transaction, ct).ConfigureAwait(false);
 
         foreach (var scriptPath in GetMigrationScripts())
         {
             var sql = await File.ReadAllTextAsync(scriptPath, ct).ConfigureAwait(false);
+            var migrationId = Path.GetFileName(scriptPath);
+            var checksum = Convert.ToHexString(
+                    SHA256.HashData(Encoding.UTF8.GetBytes(sql)))
+                .ToLowerInvariant();
+            if (await IsMigrationAppliedAsync(
+                    connection,
+                    transaction,
+                    migrationId,
+                    checksum,
+                    ct)
+                .ConfigureAwait(false))
+            {
+                continue;
+            }
+
             var rendered = RenderSchema(sql, _options.Schema);
 
             await using var command = connection.CreateCommand();
+            command.Transaction = transaction;
             command.CommandText = rendered;
             await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+            await RecordMigrationAsync(
+                    connection,
+                    transaction,
+                    migrationId,
+                    checksum,
+                    ct)
+                .ConfigureAwait(false);
         }
+
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
     }
 
     public async Task ResetSchemaAsync(CancellationToken ct = default)
@@ -46,6 +88,68 @@ public sealed class AssetOperationsMigrationRunner
         var connection = new NpgsqlConnection(_options.ConnectionString);
         await connection.OpenAsync(ct).ConfigureAwait(false);
         return connection;
+    }
+
+    private async Task EnsureMigrationLedgerAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText =
+            $"""
+            create schema if not exists {QuoteIdentifier(_options.Schema)};
+            create table if not exists {QuoteIdentifier(_options.Schema)}.asset_operations_schema_migrations (
+                migration_id text primary key,
+                checksum text not null,
+                applied_at timestamptz not null default now()
+            );
+            """;
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    private async Task<bool> IsMigrationAppliedAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        string migrationId,
+        string checksum,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText =
+            $"select checksum from {QuoteIdentifier(_options.Schema)}.asset_operations_schema_migrations where migration_id = @migration_id;";
+        command.Parameters.AddWithValue("migration_id", migrationId);
+        var appliedChecksum = await command.ExecuteScalarAsync(ct).ConfigureAwait(false) as string;
+        if (appliedChecksum is null)
+        {
+            return false;
+        }
+
+        if (!string.Equals(appliedChecksum, checksum, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Asset Operations migration '{migrationId}' has changed since it was applied.");
+        }
+
+        return true;
+    }
+
+    private async Task RecordMigrationAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        string migrationId,
+        string checksum,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText =
+            $"insert into {QuoteIdentifier(_options.Schema)}.asset_operations_schema_migrations (migration_id, checksum) values (@migration_id, @checksum);";
+        command.Parameters.AddWithValue("migration_id", migrationId);
+        command.Parameters.AddWithValue("checksum", checksum);
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
     }
 
     private static IEnumerable<string> GetMigrationScripts()

--- a/src/Meridian.Storage/AssetOperations/IInstrumentPositionProjectionStore.cs
+++ b/src/Meridian.Storage/AssetOperations/IInstrumentPositionProjectionStore.cs
@@ -1,0 +1,336 @@
+using System.Text.Json;
+using Meridian.Contracts.AssetOperations;
+
+namespace Meridian.Storage.AssetOperations;
+
+/// <summary>
+/// Durable, rebuildable role and book-position projection state. This is not a ledger balance or
+/// an accounting source of truth.
+/// </summary>
+public sealed record InstrumentPositionProjectionSnapshot(
+    Guid SecurityId,
+    IReadOnlyList<InstrumentRoleDto> InstrumentRoles,
+    IReadOnlyList<BookPositionDto> BookPositions,
+    IReadOnlyList<PositionEconomicStateDto> PositionEconomicStates,
+    IReadOnlyList<ProjectionLineageDto> ProjectionLineages)
+{
+    public Guid? LedgerBookId { get; init; }
+
+    public DateOnly? AsOfDate { get; init; }
+}
+
+public interface IInstrumentPositionProjectionStore
+{
+    Task<InstrumentPositionProjectionSnapshot> GetSecurityAsync(
+        Guid securityId,
+        CancellationToken ct = default);
+
+    Task<InstrumentPositionProjectionSnapshot> GetAsOfAsync(
+        Guid securityId,
+        Guid ledgerBookId,
+        DateOnly asOfDate,
+        CancellationToken ct = default);
+
+    Task<BookPositionDto?> GetBookPositionAsync(
+        Guid positionId,
+        CancellationToken ct = default);
+
+    Task<BookPositionDto> UpsertAsync(
+        InstrumentRoleDto role,
+        BookPositionDto position,
+        PositionEconomicStateDto? economicState,
+        long expectedVersion,
+        AssetOperationsWriteApprovalDto approval,
+        CancellationToken ct = default);
+}
+
+internal static class InstrumentPositionProjectionRules
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public static (BookPositionDto Position, PositionEconomicStateDto? EconomicState) NormalizeWrite(
+        BookPositionDto position,
+        PositionEconomicStateDto? economicState)
+    {
+        var embeddedState = position.CurrentEconomicState;
+        if (embeddedState is not null && economicState is not null &&
+            !PayloadEquals(embeddedState, economicState))
+        {
+            throw new InvalidOperationException(
+                "The embedded and explicit economic states must describe the same approved projection.");
+        }
+
+        var state = economicState ?? embeddedState;
+        if (position.ProjectionLineage is not null && state?.ProjectionLineage is not null &&
+            !PayloadEquals(position.ProjectionLineage, state.ProjectionLineage))
+        {
+            throw new InvalidOperationException(
+                "The book-position and economic-state projection lineage must match.");
+        }
+
+        return (position with
+        {
+            CurrentEconomicState = state,
+            ProjectionLineage = state?.ProjectionLineage ?? position.ProjectionLineage
+        }, state);
+    }
+
+    public static void ValidateWrite(
+        InstrumentRoleDto role,
+        BookPositionDto position,
+        PositionEconomicStateDto? economicState,
+        long expectedVersion,
+        AssetOperationsWriteApprovalDto approval)
+    {
+        ArgumentNullException.ThrowIfNull(role);
+        ArgumentNullException.ThrowIfNull(position);
+        ArgumentNullException.ThrowIfNull(approval);
+
+        if (expectedVersion < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(expectedVersion), "Expected version cannot be negative.");
+        }
+
+        ValidateRole(role, approval);
+
+        if (position.EffectiveTo < position.EffectiveFrom)
+        {
+            throw new InvalidOperationException("Projection end dates cannot precede start dates.");
+        }
+
+        if (position.PositionId == Guid.Empty || position.SecurityId == Guid.Empty ||
+            position.RoleId == Guid.Empty || position.BookContext.LedgerBookId == Guid.Empty ||
+            position.BookContext.FundStructureNodeId == Guid.Empty || position.Version <= 0 ||
+            string.IsNullOrWhiteSpace(position.BookContext.FundProfileId) ||
+            string.IsNullOrWhiteSpace(position.PositionSide) ||
+            string.IsNullOrWhiteSpace(position.Status))
+        {
+            throw new InvalidOperationException("Book positions require position, security, role, book, side, and version values.");
+        }
+
+        var expectedOwnerKind = position.BookContext.FundStructureNodeKind.ToString();
+        if (role.RoleId != position.RoleId || role.SecurityId != position.SecurityId ||
+            !ExactTextEquals(role.OwnerScopeId, position.BookContext.FundProfileId) ||
+            !ExactTextEquals(role.OwnerScopeKind, expectedOwnerKind))
+        {
+            throw new InvalidOperationException("The instrument role and book position must have matching security and owner scope.");
+        }
+
+        ValidateRoleWindow(role, position);
+
+        ValidatePositionProvenance(position);
+        ValidateDimensions(position);
+        ValidateEconomicState(position, economicState);
+    }
+
+    public static void ValidateDedicatedProvenance(
+        InstrumentRoleDto role,
+        BookPositionDto position,
+        PositionEconomicStateDto? economicState)
+    {
+        if (role.OriginEvent is null || !HasEvidence(role.EvidenceLinks))
+        {
+            throw new InvalidOperationException(
+                "Dedicated instrument-role writes require a retained source event and evidence.");
+        }
+
+        if (position.OriginEvent is null && position.ProjectionLineage is null ||
+            !HasEvidence(position.EvidenceLinks))
+        {
+            throw new InvalidOperationException(
+                "Dedicated book-position writes require retained event lineage and evidence.");
+        }
+
+        if (economicState is not null &&
+            (economicState.SourceEvent is null && economicState.ProjectionLineage is null ||
+             !HasEvidence(economicState.EvidenceLinks)))
+        {
+            throw new InvalidOperationException(
+                "Dedicated economic-state writes require retained event lineage and evidence.");
+        }
+    }
+
+    public static void ValidateRole(
+        InstrumentRoleDto role,
+        AssetOperationsWriteApprovalDto approval)
+    {
+        ArgumentNullException.ThrowIfNull(role);
+        ArgumentNullException.ThrowIfNull(approval);
+        if (role.RoleId == Guid.Empty || role.SecurityId == Guid.Empty || role.Version <= 0 ||
+            string.IsNullOrWhiteSpace(role.OwnerScopeId) || string.IsNullOrWhiteSpace(role.OwnerScopeKind) ||
+            string.IsNullOrWhiteSpace(role.RoleKind) || string.IsNullOrWhiteSpace(role.AccountingSide) ||
+            string.IsNullOrWhiteSpace(role.EconomicSide) || role.EffectiveTo < role.EffectiveFrom)
+        {
+            throw new InvalidOperationException(
+                "Instrument role projections require identity, owner scope, role kind, valid dates, and a positive version.");
+        }
+
+        ValidateRoleProvenance(role);
+        if (string.IsNullOrWhiteSpace(approval.Actor) || string.IsNullOrWhiteSpace(approval.ApprovalReference) ||
+            string.IsNullOrWhiteSpace(approval.Rationale) || approval.ApprovedAt == default)
+        {
+            throw new InvalidOperationException("Instrument position writes require retained approval actor, reference, rationale, and timestamp.");
+        }
+    }
+
+    public static void ValidateDimensions(BookPositionDto position)
+    {
+        var dimensions = position.BookContext.Dimensions;
+        if (dimensions is null)
+        {
+            return;
+        }
+
+        if (dimensions.InstrumentId is Guid instrumentId && instrumentId != position.SecurityId ||
+            dimensions.PositionId is Guid positionId && positionId != position.PositionId ||
+            !string.IsNullOrWhiteSpace(dimensions.BookId) &&
+            !TextEquals(dimensions.BookId, position.BookContext.LedgerBookId.ToString("D")) ||
+            !string.IsNullOrWhiteSpace(dimensions.FundId) &&
+            !TextEquals(dimensions.FundId, position.BookContext.FundProfileId))
+        {
+            throw new InvalidOperationException("Book-position dimensions conflict with the position security, position, or ledger-book identity.");
+        }
+    }
+
+    public static void ValidateEconomicState(
+        BookPositionDto position,
+        PositionEconomicStateDto? state)
+    {
+        ValidatePositionProvenance(position);
+        if (state is null)
+        {
+            return;
+        }
+
+        if (state.EconomicStateId == Guid.Empty || state.PositionId != position.PositionId ||
+            state.Version <= 0 ||
+            string.IsNullOrWhiteSpace(state.Currency))
+        {
+            throw new InvalidOperationException(
+                "Economic states require identity, matching position, currency, and a positive version.");
+        }
+
+        if (state.AsOfDate < position.EffectiveFrom ||
+            position.EffectiveTo is DateOnly positionEnd && state.AsOfDate > positionEnd)
+        {
+            throw new InvalidOperationException("Economic-state dates must fall inside the book position effective window.");
+        }
+
+        var source = state.SourceEvent;
+        var lineage = state.ProjectionLineage;
+        var positionSource = position.OriginEvent;
+        var positionLineage = position.ProjectionLineage;
+        if (source?.EventId == Guid.Empty ||
+            positionSource?.SecurityId is Guid positionSourceSecurityId && positionSourceSecurityId != position.SecurityId ||
+            positionSource?.BookPositionId is Guid positionSourcePositionId && positionSourcePositionId != position.PositionId ||
+            positionLineage?.BookPositionId is Guid positionLineageId && positionLineageId != position.PositionId ||
+            positionLineage?.TriggerEvent.SecurityId is Guid positionTriggerSecurityId && positionTriggerSecurityId != position.SecurityId ||
+            positionLineage?.TriggerEvent.BookPositionId is Guid positionTriggerPositionId && positionTriggerPositionId != position.PositionId ||
+            source?.SecurityId is Guid sourceSecurityId && sourceSecurityId != position.SecurityId ||
+            source?.BookPositionId is Guid sourcePositionId && sourcePositionId != position.PositionId ||
+            lineage?.BookPositionId is Guid lineagePositionId && lineagePositionId != position.PositionId ||
+            lineage?.TriggerEvent.SecurityId is Guid triggerSecurityId && triggerSecurityId != position.SecurityId ||
+            lineage?.TriggerEvent.BookPositionId is Guid triggerPositionId && triggerPositionId != position.PositionId)
+        {
+            throw new InvalidOperationException("Economic-state event or projection lineage crosses the position security or book-position boundary.");
+        }
+
+        if (source is not null && lineage is not null && source.EventId != lineage.TriggerEvent.EventId)
+        {
+            throw new InvalidOperationException(
+                "Economic-state source event and projection trigger event must identify the same event.");
+        }
+    }
+
+    public static void ValidateStandaloneLineage(BookPositionDto position, ProjectionLineageDto lineage)
+    {
+        ArgumentNullException.ThrowIfNull(lineage);
+        ValidateLineageBoundary(position, lineage);
+    }
+
+    public static bool IsActive(DateOnly from, DateOnly? to, DateOnly asOf)
+        => from <= asOf && (to is null || to >= asOf);
+
+    public static void ValidateRoleWindow(InstrumentRoleDto role, BookPositionDto position)
+    {
+        if (role.EffectiveFrom > position.EffectiveFrom ||
+            role.EffectiveTo is DateOnly roleEnd &&
+            (position.EffectiveTo is null || position.EffectiveTo > roleEnd))
+        {
+            throw new InvalidOperationException(
+                "The instrument role effective window must cover the book position effective window.");
+        }
+    }
+
+    public static bool RangesOverlap(DateOnly leftFrom, DateOnly? leftTo, DateOnly rightFrom, DateOnly? rightTo)
+        => leftFrom <= (rightTo ?? DateOnly.MaxValue) && rightFrom <= (leftTo ?? DateOnly.MaxValue);
+
+    public static bool SameOverlapScope(BookPositionDto left, BookPositionDto right)
+        => left.SecurityId == right.SecurityId &&
+           left.RoleId == right.RoleId &&
+           left.BookContext.LedgerBookId == right.BookContext.LedgerBookId &&
+           TextEquals(left.BookContext.FundProfileId, right.BookContext.FundProfileId) &&
+           left.BookContext.FundStructureNodeKind == right.BookContext.FundStructureNodeKind &&
+           TextEquals(left.PositionSide, right.PositionSide);
+
+    public static bool ParticipatesInActiveOverlap(string? status)
+        => !TextEquals(status, "Closed") &&
+           !TextEquals(status, "Inactive") &&
+           !TextEquals(status, "Terminated") &&
+           !TextEquals(status, "Matured");
+
+    public static bool TextEquals(string? left, string? right)
+        => string.Equals(left?.Trim(), right?.Trim(), StringComparison.OrdinalIgnoreCase);
+
+    public static bool ExactTextEquals(string? left, string? right)
+        => string.Equals(left, right, StringComparison.Ordinal);
+
+    private static void ValidateRoleProvenance(InstrumentRoleDto role)
+    {
+        if (role.OriginEvent is not null &&
+            (role.OriginEvent.EventId == Guid.Empty ||
+             role.OriginEvent.SecurityId is Guid securityId && securityId != role.SecurityId))
+        {
+            throw new InvalidOperationException(
+                "Instrument-role provenance crosses the Security Master boundary.");
+        }
+    }
+
+    private static void ValidatePositionProvenance(BookPositionDto position)
+    {
+        if (position.OriginEvent is not null &&
+            (position.OriginEvent.EventId == Guid.Empty ||
+             position.OriginEvent.SecurityId is Guid securityId && securityId != position.SecurityId ||
+             position.OriginEvent.BookPositionId is Guid positionId && positionId != position.PositionId))
+        {
+            throw new InvalidOperationException(
+                "Book-position origin-event provenance crosses its security or position boundary.");
+        }
+
+        if (position.ProjectionLineage is not null)
+        {
+            ValidateLineageBoundary(position, position.ProjectionLineage);
+        }
+    }
+
+    private static void ValidateLineageBoundary(BookPositionDto position, ProjectionLineageDto lineage)
+    {
+        if (lineage.ProjectionRunId == Guid.Empty || lineage.TriggerEvent.EventId == Guid.Empty ||
+            (lineage.BookPositionId ?? lineage.TriggerEvent.BookPositionId) is not Guid ||
+            lineage.BookPositionId is Guid lineagePositionId && lineagePositionId != position.PositionId ||
+            lineage.TriggerEvent.SecurityId is Guid securityId && securityId != position.SecurityId ||
+            lineage.TriggerEvent.BookPositionId is Guid triggerPositionId && triggerPositionId != position.PositionId)
+        {
+            throw new InvalidOperationException(
+                "Projection lineage crosses the book-position security or position boundary.");
+        }
+    }
+
+    private static bool PayloadEquals<T>(T left, T right)
+        => JsonElement.DeepEquals(
+            JsonSerializer.SerializeToElement(left, JsonOptions),
+            JsonSerializer.SerializeToElement(right, JsonOptions));
+
+    private static bool HasEvidence(IReadOnlyList<string> evidenceLinks)
+        => evidenceLinks.Count > 0 && evidenceLinks.All(static link => !string.IsNullOrWhiteSpace(link));
+}

--- a/src/Meridian.Storage/AssetOperations/InMemoryAssetOperationsProjectionStore.InstrumentPositions.cs
+++ b/src/Meridian.Storage/AssetOperations/InMemoryAssetOperationsProjectionStore.InstrumentPositions.cs
@@ -1,0 +1,728 @@
+using System.Text.Json;
+using Meridian.Contracts.AssetOperations;
+
+namespace Meridian.Storage.AssetOperations;
+
+public sealed partial class InMemoryAssetOperationsProjectionStore
+{
+    private static readonly JsonSerializerOptions InstrumentPositionJsonOptions = new(JsonSerializerDefaults.Web);
+
+    private Dictionary<Guid, InstrumentRoleDto> _instrumentRoles = [];
+    private Dictionary<Guid, BookPositionDto> _bookPositions = [];
+    private Dictionary<Guid, PositionEconomicStateDto> _positionEconomicStates = [];
+    private Dictionary<Guid, ProjectionLineageDto> _projectionLineages = [];
+    private Dictionary<Guid, AssetOperationsWriteApprovalDto> _projectionApprovals = [];
+
+    public Task<InstrumentPositionProjectionSnapshot> GetSecurityAsync(
+        Guid securityId,
+        CancellationToken ct = default)
+    {
+        if (securityId == Guid.Empty)
+        {
+            throw new ArgumentException("A Security Master identity is required.", nameof(securityId));
+        }
+
+        ct.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            return Task.FromResult(ClonePayload(BuildSecuritySnapshot(securityId)));
+        }
+    }
+
+    public Task<InstrumentPositionProjectionSnapshot> GetAsOfAsync(
+        Guid securityId,
+        Guid ledgerBookId,
+        DateOnly asOfDate,
+        CancellationToken ct = default)
+    {
+        if (securityId == Guid.Empty)
+        {
+            throw new ArgumentException("A Security Master identity is required.", nameof(securityId));
+        }
+
+        if (ledgerBookId == Guid.Empty)
+        {
+            throw new ArgumentException("A ledger-book identity is required.", nameof(ledgerBookId));
+        }
+
+        ct.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            return Task.FromResult(ClonePayload(BuildSnapshot(securityId, ledgerBookId, asOfDate)));
+        }
+    }
+
+    public Task<BookPositionDto?> GetBookPositionAsync(
+        Guid positionId,
+        CancellationToken ct = default)
+    {
+        if (positionId == Guid.Empty)
+        {
+            throw new ArgumentException("A book-position identity is required.", nameof(positionId));
+        }
+
+        ct.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            if (!_bookPositions.TryGetValue(positionId, out var position))
+            {
+                return Task.FromResult<BookPositionDto?>(null);
+            }
+
+            var states = OrderedStates(PositionIdSet(positionId));
+            var lineages = OrderedLineages(PositionIdSet(positionId));
+            return Task.FromResult<BookPositionDto?>(ClonePayload(HydratePosition(position, states, lineages)));
+        }
+    }
+
+    public Task<BookPositionDto> UpsertAsync(
+        InstrumentRoleDto role,
+        BookPositionDto position,
+        PositionEconomicStateDto? economicState,
+        long expectedVersion,
+        AssetOperationsWriteApprovalDto approval,
+        CancellationToken ct = default)
+    {
+        var normalized = InstrumentPositionProjectionRules.NormalizeWrite(position, economicState);
+        var state = normalized.EconomicState;
+        var normalizedPosition = normalized.Position;
+        if (state is not null && state.Version != normalizedPosition.Version)
+        {
+            throw new InvalidOperationException(
+                "A dedicated economic-state write must use the same version as its book position.");
+        }
+
+        InstrumentPositionProjectionRules.ValidateWrite(
+            role,
+            normalizedPosition,
+            state,
+            expectedVersion,
+            approval);
+        InstrumentPositionProjectionRules.ValidateDedicatedProvenance(role, normalizedPosition, state);
+        EnsureRoleCoversPosition(role, normalizedPosition);
+        role = ClonePayload(role);
+        normalizedPosition = ClonePayload(normalizedPosition);
+        state = state is null ? null : ClonePayload(state);
+        approval = ClonePayload(approval);
+        ct.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            var roles = new Dictionary<Guid, InstrumentRoleDto>(_instrumentRoles);
+            var positions = new Dictionary<Guid, BookPositionDto>(_bookPositions);
+            var states = new Dictionary<Guid, PositionEconomicStateDto>(_positionEconomicStates);
+            var lineages = new Dictionary<Guid, ProjectionLineageDto>(_projectionLineages);
+            var approvals = new Dictionary<Guid, AssetOperationsWriteApprovalDto>(_projectionApprovals);
+
+            if (IsExactReplay(
+                    roles,
+                    positions,
+                    states,
+                    lineages,
+                    role,
+                    normalizedPosition,
+                    state,
+                    expectedVersion))
+            {
+                return Task.FromResult(ClonePayload(HydratePosition(
+                    positions[position.PositionId],
+                    OrderedStates(PositionIdSet(position.PositionId), states),
+                    OrderedLineages(PositionIdSet(position.PositionId), lineages))));
+            }
+
+            positions.TryGetValue(position.PositionId, out var persistedPosition);
+            roles.TryGetValue(role.RoleId, out var persistedRole);
+            ValidateDedicatedPositionVersion(persistedPosition, normalizedPosition, expectedVersion);
+            var roleChanged = persistedRole is null || !PayloadEquals(persistedRole, role);
+            var positionChanged = persistedPosition is null || !PayloadEquals(persistedPosition, normalizedPosition);
+            var stateChanged = state is not null && !states.ContainsKey(state.EconomicStateId);
+            ApplyRole(roles, role, requireConsecutiveVersion: true);
+            EnsurePositionOwnership(persistedPosition, normalizedPosition);
+            EnsureRoleCoversPositions(positions.Values, role, normalizedPosition);
+            EnsureStatesRemainWithinPosition(states.Values, normalizedPosition);
+            EnsureNoOverlap(positions.Values, normalizedPosition);
+            positions[normalizedPosition.PositionId] = normalizedPosition;
+            AppendEconomicState(states, lineages, positions, normalizedPosition, state);
+            AppendProjectionLineage(lineages, positions, normalizedPosition.ProjectionLineage);
+            RetainApproval(approvals, role.RoleId, approval, roleChanged);
+            RetainApproval(approvals, normalizedPosition.PositionId, approval, positionChanged);
+            if (state is not null)
+            {
+                RetainApproval(approvals, state.EconomicStateId, approval, stateChanged);
+            }
+
+            _instrumentRoles = roles;
+            _bookPositions = positions;
+            _positionEconomicStates = states;
+            _projectionLineages = lineages;
+            _projectionApprovals = approvals;
+            RefreshLegacyDetail(normalizedPosition.SecurityId);
+
+            return Task.FromResult(ClonePayload(HydratePosition(
+                normalizedPosition,
+                OrderedStates(PositionIdSet(normalizedPosition.PositionId)),
+                OrderedLineages(PositionIdSet(normalizedPosition.PositionId)))));
+        }
+    }
+
+    private void ApplyLegacyInstrumentPositionProjection(
+        AssetOperationsDetailDto detail,
+        AssetOperationsWriteApprovalDto approval)
+    {
+        var roles = new Dictionary<Guid, InstrumentRoleDto>(_instrumentRoles);
+        var positions = new Dictionary<Guid, BookPositionDto>(_bookPositions);
+        var states = new Dictionary<Guid, PositionEconomicStateDto>(_positionEconomicStates);
+        var lineages = new Dictionary<Guid, ProjectionLineageDto>(_projectionLineages);
+        var approvals = new Dictionary<Guid, AssetOperationsWriteApprovalDto>(_projectionApprovals);
+
+        foreach (var role in detail.InstrumentRoles)
+        {
+            if (role.SecurityId != detail.Subject.SecurityId)
+            {
+                throw new InvalidOperationException(
+                    "Instrument roles must match the Asset Operations subject Security Master identity.");
+            }
+
+            ValidateLegacyRole(role, approval);
+            roles.TryGetValue(role.RoleId, out var persistedRole);
+            var changed = persistedRole is null || !PayloadEquals(persistedRole, role);
+            ApplyRole(roles, role, requireConsecutiveVersion: false);
+            RetainApproval(approvals, role.RoleId, approval, changed);
+        }
+
+        foreach (var position in detail.BookPositions)
+        {
+            if (position.SecurityId != detail.Subject.SecurityId)
+            {
+                throw new InvalidOperationException(
+                    "Book positions must match the Asset Operations subject Security Master identity.");
+            }
+
+            if (!roles.TryGetValue(position.RoleId, out var role))
+            {
+                throw new InvalidOperationException(
+                    $"Book position '{position.PositionId:D}' requires a persisted instrument role.");
+            }
+
+            var explicitState = position.CurrentEconomicState is not null
+                ? detail.PositionEconomicStates.FirstOrDefault(candidate =>
+                    candidate.EconomicStateId == position.CurrentEconomicState.EconomicStateId)
+                : detail.PositionEconomicStates
+                    .Where(candidate => candidate.PositionId == position.PositionId)
+                    .OrderByDescending(static candidate => candidate.AsOfDate)
+                    .ThenByDescending(static candidate => candidate.Version)
+                    .ThenByDescending(static candidate => candidate.EconomicStateId)
+                    .FirstOrDefault();
+            var normalized = InstrumentPositionProjectionRules.NormalizeWrite(position, explicitState);
+            var state = normalized.EconomicState;
+            var normalizedPosition = normalized.Position;
+            InstrumentPositionProjectionRules.ValidateWrite(
+                role,
+                normalizedPosition,
+                state,
+                positions.GetValueOrDefault(position.PositionId)?.Version ?? 0,
+                approval);
+            EnsureRoleCoversPosition(role, normalizedPosition);
+            positions.TryGetValue(position.PositionId, out var persistedPosition);
+            EnsurePositionOwnership(persistedPosition, normalizedPosition);
+            if (persistedPosition is not null &&
+                !PayloadEquals(persistedPosition, normalizedPosition) &&
+                normalizedPosition.Version <= persistedPosition.Version)
+            {
+                throw new InvalidOperationException(
+                    $"Book position '{position.PositionId:D}' is stale or conflicts with the persisted version.");
+            }
+
+            var positionChanged = persistedPosition is null || !PayloadEquals(persistedPosition, normalizedPosition);
+            EnsureRoleCoversPositions(positions.Values, role, normalizedPosition);
+            EnsureStatesRemainWithinPosition(states.Values, normalizedPosition);
+            EnsureNoOverlap(positions.Values, normalizedPosition);
+            positions[normalizedPosition.PositionId] = normalizedPosition;
+            AppendEconomicState(states, lineages, positions, normalizedPosition, state);
+            AppendProjectionLineage(lineages, positions, normalizedPosition.ProjectionLineage);
+            RetainApproval(approvals, normalizedPosition.PositionId, approval, positionChanged);
+            if (state is not null)
+            {
+                RetainApproval(
+                    approvals,
+                    state.EconomicStateId,
+                    approval,
+                    !_positionEconomicStates.ContainsKey(state.EconomicStateId));
+            }
+        }
+
+        foreach (var role in detail.InstrumentRoles)
+        {
+            EnsureRoleCoversPositions(positions.Values, role, null);
+        }
+
+        foreach (var state in detail.PositionEconomicStates)
+        {
+            if (!positions.TryGetValue(state.PositionId, out var position))
+            {
+                throw new InvalidOperationException(
+                    $"Economic state '{state.EconomicStateId:D}' requires a persisted book position.");
+            }
+
+            if (position.SecurityId != detail.Subject.SecurityId)
+            {
+                throw new InvalidOperationException(
+                    "Economic states must match the Asset Operations subject Security Master identity.");
+            }
+
+            InstrumentPositionProjectionRules.ValidateEconomicState(position, state);
+            AppendEconomicState(states, lineages, positions, position, state);
+            RetainApproval(
+                approvals,
+                state.EconomicStateId,
+                approval,
+                !_positionEconomicStates.ContainsKey(state.EconomicStateId));
+        }
+
+        foreach (var lineage in detail.ProjectionLineages)
+        {
+            var positionId = lineage.BookPositionId ?? lineage.TriggerEvent.BookPositionId;
+            if (positionId is not Guid durablePositionId ||
+                !positions.TryGetValue(durablePositionId, out var position) ||
+                position.SecurityId != detail.Subject.SecurityId)
+            {
+                throw new InvalidOperationException(
+                    "Projection lineage must match a book position in the Asset Operations subject.");
+            }
+
+            InstrumentPositionProjectionRules.ValidateStandaloneLineage(position, lineage);
+            AppendProjectionLineage(lineages, positions, lineage);
+        }
+
+        _instrumentRoles = roles;
+        _bookPositions = positions;
+        _positionEconomicStates = states;
+        _projectionLineages = lineages;
+        _projectionApprovals = approvals;
+    }
+
+    private InstrumentPositionProjectionSnapshot BuildSecuritySnapshot(Guid securityId)
+        => BuildSnapshot(securityId, null, null);
+
+    private InstrumentPositionProjectionSnapshot BuildSnapshot(
+        Guid securityId,
+        Guid? ledgerBookId,
+        DateOnly? asOfDate)
+    {
+        var candidatePositions = _bookPositions.Values
+            .Where(position => position.SecurityId == securityId)
+            .Where(position => !ledgerBookId.HasValue || position.BookContext.LedgerBookId == ledgerBookId.Value)
+            .Where(position => !asOfDate.HasValue || InstrumentPositionProjectionRules.IsActive(
+                position.EffectiveFrom,
+                position.EffectiveTo,
+                asOfDate.Value))
+            .ToArray();
+        var candidateRoleIds = candidatePositions
+            .Select(static position => position.RoleId)
+            .ToHashSet();
+        var roles = _instrumentRoles.Values
+            .Where(role => role.SecurityId == securityId)
+            .Where(role => !ledgerBookId.HasValue || candidateRoleIds.Contains(role.RoleId))
+            .Where(role => !asOfDate.HasValue || InstrumentPositionProjectionRules.IsActive(
+                role.EffectiveFrom,
+                role.EffectiveTo,
+                asOfDate.Value))
+            .OrderBy(static role => role.EffectiveFrom)
+            .ThenBy(static role => role.Version)
+            .ThenBy(static role => role.RoleId)
+            .ToArray();
+        var activeRoleIds = roles.Select(static role => role.RoleId).ToHashSet();
+        var positions = candidatePositions
+            .Where(position => !asOfDate.HasValue || activeRoleIds.Contains(position.RoleId))
+            .OrderBy(static position => position.BookContext.LedgerBookId)
+            .ThenBy(static position => position.EffectiveFrom)
+            .ThenBy(static position => position.Version)
+            .ThenBy(static position => position.PositionId)
+            .ToArray();
+        var positionIds = positions.Select(static position => position.PositionId).ToHashSet();
+        var states = OrderedStates(positionIds)
+            .Where(state => !asOfDate.HasValue || state.AsOfDate <= asOfDate.Value)
+            .ToArray();
+        var lineages = OrderedLineages(positionIds)
+            .Where(lineage => !asOfDate.HasValue || lineage.ProjectionAsOfDate <= asOfDate.Value)
+            .ToArray();
+        var hydratedPositions = positions
+            .Select(position => HydratePosition(position, states, lineages))
+            .ToArray();
+
+        return new InstrumentPositionProjectionSnapshot(
+            securityId,
+            roles,
+            hydratedPositions,
+            states,
+            lineages)
+        {
+            LedgerBookId = ledgerBookId,
+            AsOfDate = asOfDate
+        };
+    }
+
+    private void RefreshLegacyDetail(Guid securityId)
+    {
+        if (!_details.TryGetValue(securityId, out var detail))
+        {
+            return;
+        }
+
+        var snapshot = BuildSecuritySnapshot(securityId);
+        _details[securityId] = detail with
+        {
+            InstrumentRoles = snapshot.InstrumentRoles,
+            BookPositions = snapshot.BookPositions,
+            PositionEconomicStates = snapshot.PositionEconomicStates,
+            ProjectionLineages = snapshot.ProjectionLineages
+        };
+    }
+
+    private IReadOnlyList<PositionEconomicStateDto> OrderedStates(
+        IReadOnlySet<Guid> positionIds,
+        IReadOnlyDictionary<Guid, PositionEconomicStateDto>? source = null)
+        => (source ?? _positionEconomicStates).Values
+            .Where(state => positionIds.Contains(state.PositionId))
+            .OrderBy(static state => state.AsOfDate)
+            .ThenBy(static state => state.Version)
+            .ThenBy(static state => state.EconomicStateId)
+            .ToArray();
+
+    private static HashSet<Guid> PositionIdSet(Guid positionId) => [positionId];
+
+    private IReadOnlyList<ProjectionLineageDto> OrderedLineages(
+        IReadOnlySet<Guid> positionIds,
+        IReadOnlyDictionary<Guid, ProjectionLineageDto>? source = null)
+        => (source ?? _projectionLineages).Values
+            .Where(lineage => lineage.BookPositionId is Guid positionId && positionIds.Contains(positionId) ||
+                lineage.TriggerEvent.BookPositionId is Guid triggerPositionId && positionIds.Contains(triggerPositionId))
+            .OrderBy(static lineage => lineage.ProjectionAsOfDate)
+            .ThenBy(static lineage => lineage.GeneratedAtUtc)
+            .ThenBy(static lineage => lineage.ProjectionRunId)
+            .ToArray();
+
+    private static BookPositionDto HydratePosition(
+        BookPositionDto position,
+        IReadOnlyList<PositionEconomicStateDto> states,
+        IReadOnlyList<ProjectionLineageDto> lineages)
+    {
+        var currentState = states
+            .Where(state => state.PositionId == position.PositionId)
+            .OrderByDescending(static state => state.AsOfDate)
+            .ThenByDescending(static state => state.Version)
+            .ThenByDescending(static state => state.EconomicStateId)
+            .FirstOrDefault();
+        var currentLineage = currentState?.ProjectionLineage ?? lineages
+            .Where(lineage => lineage.BookPositionId == position.PositionId ||
+                lineage.TriggerEvent.BookPositionId == position.PositionId)
+            .OrderByDescending(static lineage => lineage.ProjectionAsOfDate)
+            .ThenByDescending(static lineage => lineage.GeneratedAtUtc)
+            .ThenByDescending(static lineage => lineage.ProjectionRunId)
+            .FirstOrDefault();
+
+        return position with
+        {
+            CurrentEconomicState = currentState,
+            ProjectionLineage = currentLineage
+        };
+    }
+
+    private static void ValidateDedicatedPositionVersion(
+        BookPositionDto? persisted,
+        BookPositionDto incoming,
+        long expectedVersion)
+    {
+        if (persisted is null)
+        {
+            if (expectedVersion != 0 || incoming.Version != 1)
+            {
+                throw new InvalidOperationException(
+                    "New book positions require ExpectedVersion 0 and position Version 1.");
+            }
+
+            return;
+        }
+
+        if (expectedVersion != persisted.Version || incoming.Version != checked(persisted.Version + 1))
+        {
+            throw new InvalidOperationException(
+                $"Book position '{incoming.PositionId:D}' is stale; expected persisted version {persisted.Version} and next version {persisted.Version + 1}.");
+        }
+    }
+
+    private static bool IsExactReplay(
+        IReadOnlyDictionary<Guid, InstrumentRoleDto> roles,
+        IReadOnlyDictionary<Guid, BookPositionDto> positions,
+        IReadOnlyDictionary<Guid, PositionEconomicStateDto> states,
+        IReadOnlyDictionary<Guid, ProjectionLineageDto> lineages,
+        InstrumentRoleDto role,
+        BookPositionDto position,
+        PositionEconomicStateDto? state,
+        long expectedVersion)
+    {
+        if (expectedVersion != position.Version - 1 ||
+            !roles.TryGetValue(role.RoleId, out var persistedRole) ||
+            !positions.TryGetValue(position.PositionId, out var persistedPosition) ||
+            !PayloadEquals(persistedRole, role) ||
+            !PayloadEquals(persistedPosition, position))
+        {
+            return false;
+        }
+
+        if (state is not null &&
+            (!states.TryGetValue(state.EconomicStateId, out var persistedState) ||
+             !PayloadEquals(persistedState, state)))
+        {
+            return false;
+        }
+
+        var lineage = state?.ProjectionLineage ?? position.ProjectionLineage;
+        return lineage is null ||
+            lineages.TryGetValue(lineage.ProjectionRunId, out var persistedLineage) &&
+            PayloadEquals(persistedLineage, lineage);
+    }
+
+    private static void ApplyRole(
+        IDictionary<Guid, InstrumentRoleDto> roles,
+        InstrumentRoleDto role,
+        bool requireConsecutiveVersion)
+    {
+        if (!roles.TryGetValue(role.RoleId, out var persisted))
+        {
+            roles[role.RoleId] = role;
+            return;
+        }
+
+        if (!SameRoleIdentity(persisted, role))
+        {
+            throw new InvalidOperationException(
+                $"Instrument role '{role.RoleId:D}' cannot change security, owner scope, or role kind.");
+        }
+
+        if (!PayloadEquals(persisted, role) &&
+            (role.Version <= persisted.Version ||
+             requireConsecutiveVersion && role.Version != persisted.Version + 1))
+        {
+            throw new InvalidOperationException(
+                $"Instrument role '{role.RoleId:D}' is stale or conflicts with the persisted version.");
+        }
+
+        roles[role.RoleId] = PayloadEquals(persisted, role) ? persisted : role;
+    }
+
+    private static void ValidateLegacyRole(
+        InstrumentRoleDto role,
+        AssetOperationsWriteApprovalDto approval)
+        => InstrumentPositionProjectionRules.ValidateRole(role, approval);
+
+    private static void EnsurePositionOwnership(
+        BookPositionDto? persisted,
+        BookPositionDto incoming)
+    {
+        if (persisted is null)
+        {
+            return;
+        }
+
+        if (persisted.SecurityId != incoming.SecurityId ||
+            persisted.RoleId != incoming.RoleId ||
+            persisted.BookContext.LedgerBookId != incoming.BookContext.LedgerBookId ||
+            persisted.BookContext.FundStructureNodeId != incoming.BookContext.FundStructureNodeId ||
+            persisted.BookContext.FundStructureNodeKind != incoming.BookContext.FundStructureNodeKind ||
+            !InstrumentPositionProjectionRules.ExactTextEquals(
+                persisted.BookContext.FundProfileId,
+                incoming.BookContext.FundProfileId) ||
+            !InstrumentPositionProjectionRules.ExactTextEquals(persisted.PositionSide, incoming.PositionSide))
+        {
+            throw new InvalidOperationException(
+                $"Book position '{incoming.PositionId:D}' cannot cross its security, role, owner, side, or ledger-book boundary.");
+        }
+    }
+
+    private static void EnsureNoOverlap(
+        IEnumerable<BookPositionDto> positions,
+        BookPositionDto incoming)
+    {
+        if (!InstrumentPositionProjectionRules.ParticipatesInActiveOverlap(incoming.Status))
+        {
+            return;
+        }
+
+        var overlap = positions.FirstOrDefault(position =>
+            position.PositionId != incoming.PositionId &&
+            InstrumentPositionProjectionRules.ParticipatesInActiveOverlap(position.Status) &&
+            InstrumentPositionProjectionRules.SameOverlapScope(position, incoming) &&
+            InstrumentPositionProjectionRules.RangesOverlap(
+                position.EffectiveFrom,
+                position.EffectiveTo,
+                incoming.EffectiveFrom,
+                incoming.EffectiveTo));
+        if (overlap is not null)
+        {
+            throw new InvalidOperationException(
+                $"Book position '{incoming.PositionId:D}' overlaps active position '{overlap.PositionId:D}' in the same security, role, owner, side, and book scope.");
+        }
+    }
+
+    private static void EnsureRoleCoversPosition(
+        InstrumentRoleDto role,
+        BookPositionDto position)
+        => InstrumentPositionProjectionRules.ValidateRoleWindow(role, position);
+
+    private static void EnsureRoleCoversPositions(
+        IEnumerable<BookPositionDto> persistedPositions,
+        InstrumentRoleDto role,
+        BookPositionDto? replacement)
+    {
+        var positions = persistedPositions
+            .Where(position => replacement is null || position.PositionId != replacement.PositionId)
+            .Concat(replacement is null ? [] : [replacement]);
+        foreach (var position in positions.Where(position => position.RoleId == role.RoleId))
+        {
+            EnsureRoleCoversPosition(role, position);
+        }
+    }
+
+    private static void EnsureStatesRemainWithinPosition(
+        IEnumerable<PositionEconomicStateDto> states,
+        BookPositionDto position)
+    {
+        foreach (var state in states.Where(state => state.PositionId == position.PositionId))
+        {
+            InstrumentPositionProjectionRules.ValidateEconomicState(position, state);
+        }
+    }
+
+    private static void AppendEconomicState(
+        IDictionary<Guid, PositionEconomicStateDto> states,
+        IDictionary<Guid, ProjectionLineageDto> lineages,
+        IReadOnlyDictionary<Guid, BookPositionDto> positions,
+        BookPositionDto position,
+        PositionEconomicStateDto? state)
+    {
+        if (state is null)
+        {
+            return;
+        }
+
+        if (!positions.ContainsKey(state.PositionId))
+        {
+            throw new InvalidOperationException(
+                $"Economic state '{state.EconomicStateId:D}' requires a persisted book position.");
+        }
+
+        if (states.TryGetValue(state.EconomicStateId, out var persisted))
+        {
+            InstrumentPositionProjectionRules.ValidateEconomicState(position, state);
+            if (!PayloadEquals(persisted, state))
+            {
+                throw new InvalidOperationException(
+                    $"Economic state '{state.EconomicStateId:D}' is append-only and cannot be replaced.");
+            }
+
+            AppendProjectionLineage(lineages, positions, state.ProjectionLineage);
+            return;
+        }
+
+        InstrumentPositionProjectionRules.ValidateEconomicState(position, state);
+        ValidateCompatibilityStateVersion(position, state);
+
+        var conflictingVersion = states.Values.FirstOrDefault(candidate =>
+            candidate.PositionId == state.PositionId &&
+            candidate.Version == state.Version);
+        if (conflictingVersion is not null)
+        {
+            throw new InvalidOperationException(
+                $"Economic state version {state.Version} already exists for book position '{state.PositionId:D}'.");
+        }
+
+        states[state.EconomicStateId] = state;
+        AppendProjectionLineage(lineages, positions, state.ProjectionLineage);
+    }
+
+    private static void AppendProjectionLineage(
+        IDictionary<Guid, ProjectionLineageDto> lineages,
+        IReadOnlyDictionary<Guid, BookPositionDto> positions,
+        ProjectionLineageDto? lineage)
+    {
+        if (lineage is null)
+        {
+            return;
+        }
+
+        var positionId = lineage.BookPositionId ?? lineage.TriggerEvent.BookPositionId;
+        if (positionId is not Guid durablePositionId || !positions.TryGetValue(durablePositionId, out var position))
+        {
+            throw new InvalidOperationException(
+                $"Projection lineage '{lineage.ProjectionRunId:D}' requires a persisted book position.");
+        }
+
+        if (lineage.TriggerEvent.SecurityId is Guid securityId && securityId != position.SecurityId)
+        {
+            throw new InvalidOperationException(
+                $"Projection lineage '{lineage.ProjectionRunId:D}' crosses the position security boundary.");
+        }
+
+        InstrumentPositionProjectionRules.ValidateStandaloneLineage(position, lineage);
+
+        if (lineages.TryGetValue(lineage.ProjectionRunId, out var persisted) &&
+            !PayloadEquals(persisted, lineage))
+        {
+            throw new InvalidOperationException(
+                $"Projection lineage '{lineage.ProjectionRunId:D}' is append-only and cannot be replaced.");
+        }
+
+        lineages[lineage.ProjectionRunId] = persisted ?? lineage;
+    }
+
+    private static bool SameRoleIdentity(InstrumentRoleDto left, InstrumentRoleDto right)
+        => left.SecurityId == right.SecurityId &&
+           InstrumentPositionProjectionRules.ExactTextEquals(left.OwnerScopeId, right.OwnerScopeId) &&
+           InstrumentPositionProjectionRules.ExactTextEquals(left.OwnerScopeKind, right.OwnerScopeKind) &&
+           InstrumentPositionProjectionRules.ExactTextEquals(left.RoleKind, right.RoleKind);
+
+    private static void RetainApproval(
+        IDictionary<Guid, AssetOperationsWriteApprovalDto> approvals,
+        Guid projectionId,
+        AssetOperationsWriteApprovalDto approval,
+        bool changed)
+    {
+        if (changed || !approvals.ContainsKey(projectionId))
+        {
+            approvals[projectionId] = approval;
+        }
+    }
+
+    private static void ValidateCompatibilityStateVersion(
+        BookPositionDto position,
+        PositionEconomicStateDto state)
+    {
+        if (state.Version != position.Version && state.Version != checked(position.Version + 1))
+        {
+            throw new InvalidOperationException(
+                "Compatibility economic-state writes must match the position version or its immediate successor.");
+        }
+    }
+
+    internal AssetOperationsWriteApprovalDto? GetRetainedProjectionApproval(Guid projectionId)
+    {
+        lock (_gate)
+        {
+            var approval = _projectionApprovals.GetValueOrDefault(projectionId);
+            return approval is null ? null : ClonePayload(approval);
+        }
+    }
+
+    private static bool PayloadEquals<T>(T left, T right)
+        => string.Equals(
+            JsonSerializer.Serialize(left, InstrumentPositionJsonOptions),
+            JsonSerializer.Serialize(right, InstrumentPositionJsonOptions),
+            StringComparison.Ordinal);
+
+    private static T ClonePayload<T>(T value)
+        => JsonSerializer.Deserialize<T>(
+               JsonSerializer.Serialize(value, InstrumentPositionJsonOptions),
+               InstrumentPositionJsonOptions)
+           ?? throw new InvalidOperationException($"Could not clone {typeof(T).Name}.");
+}

--- a/src/Meridian.Storage/AssetOperations/InMemoryAssetOperationsProjectionStore.cs
+++ b/src/Meridian.Storage/AssetOperations/InMemoryAssetOperationsProjectionStore.cs
@@ -2,7 +2,9 @@ using Meridian.Contracts.AssetOperations;
 
 namespace Meridian.Storage.AssetOperations;
 
-public sealed class InMemoryAssetOperationsProjectionStore : IAssetOperationsProjectionStore
+public sealed partial class InMemoryAssetOperationsProjectionStore :
+    IAssetOperationsProjectionStore,
+    IInstrumentPositionProjectionStore
 {
     private readonly object _gate = new();
     private readonly Dictionary<Guid, AssetOperationsDetailDto> _details = new();
@@ -12,7 +14,8 @@ public sealed class InMemoryAssetOperationsProjectionStore : IAssetOperationsPro
         ct.ThrowIfCancellationRequested();
         lock (_gate)
         {
-            return Task.FromResult(_details.GetValueOrDefault(securityId));
+            var detail = _details.GetValueOrDefault(securityId);
+            return Task.FromResult(detail is null ? null : ClonePayload(detail));
         }
     }
 
@@ -24,6 +27,8 @@ public sealed class InMemoryAssetOperationsProjectionStore : IAssetOperationsPro
         ArgumentNullException.ThrowIfNull(projection);
         ArgumentNullException.ThrowIfNull(approval);
         ct.ThrowIfCancellationRequested();
+        projection = ClonePayload(projection);
+        approval = ClonePayload(approval);
 
         lock (_gate)
         {
@@ -68,6 +73,15 @@ public sealed class InMemoryAssetOperationsProjectionStore : IAssetOperationsPro
                     existing?.PositionEconomicStates,
                     economicStates),
                 ProjectionLineages = lineages
+            };
+            ApplyLegacyInstrumentPositionProjection(detail, approval);
+            var snapshot = BuildSecuritySnapshot(projection.Subject.SecurityId);
+            detail = detail with
+            {
+                InstrumentRoles = snapshot.InstrumentRoles,
+                BookPositions = snapshot.BookPositions,
+                PositionEconomicStates = snapshot.PositionEconomicStates,
+                ProjectionLineages = snapshot.ProjectionLineages
             };
             _details[projection.Subject.SecurityId] = detail;
         }

--- a/src/Meridian.Storage/AssetOperations/Migrations/003_instrument_position_projection_guards.sql
+++ b/src/Meridian.Storage/AssetOperations/Migrations/003_instrument_position_projection_guards.sql
@@ -1,0 +1,223 @@
+alter table __SCHEMA__.instrument_role_projections
+    add column if not exists approval_rationale text not null default '',
+    add column if not exists source_domain text null,
+    add column if not exists source_entity_id text null,
+    add column if not exists source_content_hash text null;
+
+alter table __SCHEMA__.book_position_projections
+    add column if not exists position_side text null,
+    add column if not exists position_status text null,
+    add column if not exists approval_rationale text not null default '',
+    add column if not exists source_domain text null,
+    add column if not exists source_entity_id text null,
+    add column if not exists source_content_hash text null,
+    add column if not exists projection_run_id uuid null,
+    add column if not exists projection_event_id uuid null;
+
+alter table __SCHEMA__.position_economic_state_projections
+    add column if not exists ledger_book_id uuid null,
+    add column if not exists owner_scope_id text null,
+    add column if not exists owner_scope_kind text null,
+    add column if not exists approval_rationale text not null default '',
+    add column if not exists source_domain text null,
+    add column if not exists source_entity_id text null,
+    add column if not exists source_content_hash text null,
+    add column if not exists projection_run_id uuid null,
+    add column if not exists projection_event_id uuid null;
+
+update __SCHEMA__.instrument_role_projections
+set source_event_id = coalesce(
+        source_event_id,
+        nullif(payload #>> '{originEvent,eventId}', '')::uuid),
+    approval_rationale = case
+        when btrim(approval_rationale) = '' then 'Migrated legacy approval; rationale was not captured.'
+        else approval_rationale
+    end,
+    source_domain = coalesce(source_domain, payload #>> '{originEvent,sourceDomain}'),
+    source_entity_id = coalesce(source_entity_id, payload #>> '{originEvent,sourceEntityId}'),
+    source_content_hash = coalesce(source_content_hash, payload #>> '{originEvent,sourceContentHash}');
+
+update __SCHEMA__.book_position_projections
+set position_side = coalesce(position_side, payload ->> 'positionSide'),
+    position_status = coalesce(position_status, payload ->> 'status'),
+    source_event_id = coalesce(
+        source_event_id,
+        nullif(payload #>> '{originEvent,eventId}', '')::uuid,
+        nullif(payload #>> '{projectionLineage,triggerEvent,eventId}', '')::uuid),
+    approval_rationale = case
+        when btrim(approval_rationale) = '' then 'Migrated legacy approval; rationale was not captured.'
+        else approval_rationale
+    end,
+    source_domain = coalesce(
+        source_domain,
+        payload #>> '{originEvent,sourceDomain}',
+        payload #>> '{projectionLineage,triggerEvent,sourceDomain}'),
+    source_entity_id = coalesce(
+        source_entity_id,
+        payload #>> '{originEvent,sourceEntityId}',
+        payload #>> '{projectionLineage,triggerEvent,sourceEntityId}'),
+    source_content_hash = coalesce(
+        source_content_hash,
+        payload #>> '{originEvent,sourceContentHash}',
+        payload #>> '{projectionLineage,triggerEvent,sourceContentHash}'),
+    projection_run_id = coalesce(
+        projection_run_id,
+        nullif(payload #>> '{projectionLineage,projectionRunId}', '')::uuid),
+    projection_event_id = coalesce(
+        projection_event_id,
+        nullif(payload #>> '{projectionLineage,projectionEventId}', '')::uuid);
+
+update __SCHEMA__.position_economic_state_projections as state
+set ledger_book_id = coalesce(state.ledger_book_id, position.ledger_book_id),
+    owner_scope_id = coalesce(state.owner_scope_id, position.owner_scope_id),
+    owner_scope_kind = coalesce(state.owner_scope_kind, position.owner_scope_kind),
+    source_event_id = coalesce(
+        state.source_event_id,
+        nullif(state.payload #>> '{sourceEvent,eventId}', '')::uuid,
+        nullif(state.payload #>> '{projectionLineage,triggerEvent,eventId}', '')::uuid),
+    approval_rationale = case
+        when btrim(state.approval_rationale) = '' then 'Migrated legacy approval; rationale was not captured.'
+        else state.approval_rationale
+    end,
+    source_domain = coalesce(
+        state.source_domain,
+        state.payload #>> '{sourceEvent,sourceDomain}',
+        state.payload #>> '{projectionLineage,triggerEvent,sourceDomain}'),
+    source_entity_id = coalesce(
+        state.source_entity_id,
+        state.payload #>> '{sourceEvent,sourceEntityId}',
+        state.payload #>> '{projectionLineage,triggerEvent,sourceEntityId}'),
+    source_content_hash = coalesce(
+        state.source_content_hash,
+        state.payload #>> '{sourceEvent,sourceContentHash}',
+        state.payload #>> '{projectionLineage,triggerEvent,sourceContentHash}'),
+    projection_run_id = coalesce(
+        state.projection_run_id,
+        nullif(state.payload #>> '{projectionLineage,projectionRunId}', '')::uuid),
+    projection_event_id = coalesce(
+        state.projection_event_id,
+        nullif(state.payload #>> '{projectionLineage,projectionEventId}', '')::uuid)
+from __SCHEMA__.book_position_projections as position
+where position.position_id = state.position_id;
+
+do $$
+declare
+    conflicting_run_id uuid;
+begin
+    select projection_run_id
+    into conflicting_run_id
+    from (
+        select projection_run_id, payload -> 'projectionLineage' as lineage
+        from __SCHEMA__.book_position_projections
+        where projection_run_id is not null
+          and payload -> 'projectionLineage' is not null
+        union all
+        select projection_run_id, payload -> 'projectionLineage' as lineage
+        from __SCHEMA__.position_economic_state_projections
+        where projection_run_id is not null
+          and payload -> 'projectionLineage' is not null
+    ) as retained_lineage
+    group by projection_run_id
+    having count(distinct lineage) > 1
+    order by projection_run_id
+    limit 1;
+
+    if conflicting_run_id is not null then
+        raise exception
+            'Migration 003 cannot continue: projection run % has conflicting retained lineage.',
+            conflicting_run_id
+            using errcode = '23514';
+    end if;
+end $$;
+
+alter table __SCHEMA__.book_position_projections
+    alter column position_side set not null,
+    alter column position_status set not null;
+
+alter table __SCHEMA__.position_economic_state_projections
+    alter column ledger_book_id set not null,
+    alter column owner_scope_id set not null,
+    alter column owner_scope_kind set not null;
+
+alter table __SCHEMA__.instrument_role_projections
+    alter column approval_rationale drop default;
+
+alter table __SCHEMA__.book_position_projections
+    alter column approval_rationale drop default;
+
+alter table __SCHEMA__.position_economic_state_projections
+    alter column approval_rationale drop default;
+
+create unique index if not exists ux_instrument_role_projection_scope
+    on __SCHEMA__.instrument_role_projections
+        (role_id, security_id, owner_scope_id, owner_scope_kind);
+
+create unique index if not exists ux_book_position_projection_scope
+    on __SCHEMA__.book_position_projections
+        (position_id, security_id, ledger_book_id, owner_scope_id, owner_scope_kind);
+
+create unique index if not exists ux_position_economic_state_position_version
+    on __SCHEMA__.position_economic_state_projections (position_id, version);
+
+alter table __SCHEMA__.book_position_projections
+    drop constraint if exists fk_book_position_projection_role;
+
+do $$
+begin
+    if not exists (
+        select 1
+        from pg_constraint
+        where conname = 'fk_book_position_projection_role_scope'
+          and conrelid = '__SCHEMA__.book_position_projections'::regclass
+    ) then
+        alter table __SCHEMA__.book_position_projections
+            add constraint fk_book_position_projection_role_scope
+                foreign key (role_id, security_id, owner_scope_id, owner_scope_kind)
+                references __SCHEMA__.instrument_role_projections
+                    (role_id, security_id, owner_scope_id, owner_scope_kind);
+    end if;
+exception
+    when duplicate_object then null;
+end $$;
+
+alter table __SCHEMA__.position_economic_state_projections
+    drop constraint if exists fk_position_economic_state_position;
+
+do $$
+begin
+    if not exists (
+        select 1
+        from pg_constraint
+        where conname = 'fk_position_economic_state_position_scope'
+          and conrelid = '__SCHEMA__.position_economic_state_projections'::regclass
+    ) then
+        alter table __SCHEMA__.position_economic_state_projections
+            add constraint fk_position_economic_state_position_scope
+                foreign key (position_id, security_id, ledger_book_id, owner_scope_id, owner_scope_kind)
+                references __SCHEMA__.book_position_projections
+                    (position_id, security_id, ledger_book_id, owner_scope_id, owner_scope_kind);
+    end if;
+exception
+    when duplicate_object then null;
+end $$;
+
+create index if not exists ix_instrument_role_projection_source_event
+    on __SCHEMA__.instrument_role_projections (source_event_id)
+    where source_event_id is not null;
+
+create index if not exists ix_book_position_projection_source_event
+    on __SCHEMA__.book_position_projections (source_event_id)
+    where source_event_id is not null;
+
+create index if not exists ix_position_economic_state_source_event
+    on __SCHEMA__.position_economic_state_projections (source_event_id)
+    where source_event_id is not null;
+
+create index if not exists ix_position_economic_state_security_book_as_of
+    on __SCHEMA__.position_economic_state_projections
+        (security_id, ledger_book_id, as_of_date desc, version desc);
+
+create index if not exists ix_book_position_projection_effective_scope
+    on __SCHEMA__.book_position_projections
+        (security_id, ledger_book_id, owner_scope_id, owner_scope_kind, role_id, position_side,
+         position_status, effective_from, effective_to);

--- a/src/Meridian.Storage/AssetOperations/PostgresAssetOperationsProjectionStore.InstrumentPositions.cs
+++ b/src/Meridian.Storage/AssetOperations/PostgresAssetOperationsProjectionStore.InstrumentPositions.cs
@@ -1,0 +1,736 @@
+using System.Data;
+using System.Text;
+using System.Text.Json;
+using Meridian.Contracts.AssetOperations;
+using Npgsql;
+
+namespace Meridian.Storage.AssetOperations;
+
+public sealed partial class PostgresAssetOperationsProjectionStore
+{
+    public async Task<InstrumentPositionProjectionSnapshot> GetSecurityAsync(
+        Guid securityId,
+        CancellationToken ct = default)
+    {
+        if (securityId == Guid.Empty)
+        {
+            throw new ArgumentException("Security identity cannot be empty.", nameof(securityId));
+        }
+
+        await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var transaction = await connection
+            .BeginTransactionAsync(IsolationLevel.RepeatableRead, ct)
+            .ConfigureAwait(false);
+        var snapshot = await ReadInstrumentSnapshotAsync(connection, transaction, securityId, null, null, ct)
+            .ConfigureAwait(false);
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
+        return snapshot;
+    }
+
+    public async Task<InstrumentPositionProjectionSnapshot> GetAsOfAsync(
+        Guid securityId,
+        Guid ledgerBookId,
+        DateOnly asOfDate,
+        CancellationToken ct = default)
+    {
+        if (securityId == Guid.Empty)
+        {
+            throw new ArgumentException("Security identity cannot be empty.", nameof(securityId));
+        }
+
+        if (ledgerBookId == Guid.Empty)
+        {
+            throw new ArgumentException("Ledger-book identity cannot be empty.", nameof(ledgerBookId));
+        }
+
+        await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var transaction = await connection
+            .BeginTransactionAsync(IsolationLevel.RepeatableRead, ct)
+            .ConfigureAwait(false);
+        var snapshot = await ReadInstrumentSnapshotAsync(
+                connection,
+                transaction,
+                securityId,
+                ledgerBookId,
+                asOfDate,
+                ct)
+            .ConfigureAwait(false);
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
+        return snapshot;
+    }
+
+    public async Task<BookPositionDto?> GetBookPositionAsync(
+        Guid positionId,
+        CancellationToken ct = default)
+    {
+        if (positionId == Guid.Empty)
+        {
+            throw new ArgumentException("Book-position identity cannot be empty.", nameof(positionId));
+        }
+
+        await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var transaction = await connection
+            .BeginTransactionAsync(IsolationLevel.RepeatableRead, ct)
+            .ConfigureAwait(false);
+        var position = await ReadBookPositionAsync(connection, transaction, positionId, false, ct)
+            .ConfigureAwait(false);
+        if (position is null)
+        {
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
+            return null;
+        }
+
+        var states = await ReadPositionStatesAsync(connection, transaction, positionId, null, ct)
+            .ConfigureAwait(false);
+        var hydrated = HydratePosition(position, states);
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
+        return hydrated;
+    }
+
+    public async Task<BookPositionDto> UpsertAsync(
+        InstrumentRoleDto role,
+        BookPositionDto position,
+        PositionEconomicStateDto? economicState,
+        long expectedVersion,
+        AssetOperationsWriteApprovalDto approval,
+        CancellationToken ct = default)
+    {
+        var normalized = InstrumentPositionProjectionRules.NormalizeWrite(position, economicState);
+        var normalizedPosition = normalized.Position;
+        var state = normalized.EconomicState;
+        if (state is not null && state.Version != normalizedPosition.Version)
+        {
+            throw new InvalidOperationException(
+                "A dedicated economic-state write must use the same version as its book position.");
+        }
+        InstrumentPositionProjectionRules.ValidateWrite(
+            role,
+            normalizedPosition,
+            state,
+            expectedVersion,
+            approval);
+        InstrumentPositionProjectionRules.ValidateDedicatedProvenance(role, normalizedPosition, state);
+
+        await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var transaction = await connection
+            .BeginTransactionAsync(IsolationLevel.Serializable, ct)
+            .ConfigureAwait(false);
+
+        await AcquirePositionScopeLockAsync(connection, transaction, normalizedPosition, ct).ConfigureAwait(false);
+        var lineage = state?.ProjectionLineage ?? normalizedPosition.ProjectionLineage;
+        if (lineage is not null)
+        {
+            await AcquireProjectionRunLockAsync(connection, transaction, lineage.ProjectionRunId, ct)
+                .ConfigureAwait(false);
+            await ValidateProjectionLineageAppendAsync(connection, transaction, lineage, ct)
+                .ConfigureAwait(false);
+        }
+
+        var persistedRole = await ReadInstrumentRoleAsync(connection, transaction, role.RoleId, true, ct)
+            .ConfigureAwait(false);
+        var persistedPosition = await ReadBookPositionAsync(
+                connection,
+                transaction,
+                normalizedPosition.PositionId,
+                true,
+                ct)
+            .ConfigureAwait(false);
+        var persistedState = state is null
+            ? null
+            : await ReadEconomicStateAsync(connection, transaction, state.EconomicStateId, true, ct)
+                .ConfigureAwait(false);
+
+        var roleReplay = persistedRole is not null && PayloadEquals(persistedRole, role);
+        var positionReplay = persistedPosition is not null && PayloadEquals(persistedPosition, normalizedPosition);
+        var stateReplay = state is null || persistedState is not null && PayloadEquals(persistedState, state);
+        if (expectedVersion == normalizedPosition.Version - 1 && roleReplay && positionReplay && stateReplay)
+        {
+            var replayStates = await ReadPositionStatesAsync(
+                    connection,
+                    transaction,
+                    normalizedPosition.PositionId,
+                    null,
+                    ct)
+                .ConfigureAwait(false);
+            var replay = HydratePosition(persistedPosition!, replayStates);
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
+            return replay;
+        }
+
+        ValidateRoleTransition(persistedRole, role);
+        ValidatePositionTransition(persistedPosition, normalizedPosition, expectedVersion);
+        ValidatePositionIdentity(persistedPosition, normalizedPosition);
+        await EnsureRoleCoversPositionsAsync(
+            connection,
+            transaction,
+            role,
+            normalizedPosition,
+            ct).ConfigureAwait(false);
+        await EnsureStatesRemainWithinPositionAsync(
+            connection,
+            transaction,
+            normalizedPosition,
+            ct).ConfigureAwait(false);
+        await EnsureNoOverlapAsync(connection, transaction, normalizedPosition, ct).ConfigureAwait(false);
+        await ValidateEconomicStateAppendAsync(
+            connection,
+            transaction,
+            normalizedPosition,
+            state,
+            persistedState,
+            ct).ConfigureAwait(false);
+
+        await UpsertInstrumentRoleAsync(connection, transaction, normalizedPosition.SecurityId, role, approval, ct)
+            .ConfigureAwait(false);
+        await UpsertBookPositionAsync(
+                connection,
+                transaction,
+                normalizedPosition.SecurityId,
+                normalizedPosition,
+                approval,
+                ct)
+            .ConfigureAwait(false);
+        if (state is not null && persistedState is null)
+        {
+            await AppendEconomicStateAsync(
+                    connection,
+                    transaction,
+                    normalizedPosition.SecurityId,
+                    normalizedPosition,
+                    state,
+                    approval,
+                    ct)
+                .ConfigureAwait(false);
+        }
+
+        var retainedStates = await ReadPositionStatesAsync(
+                connection,
+                transaction,
+                normalizedPosition.PositionId,
+                null,
+                ct)
+            .ConfigureAwait(false);
+        var result = HydratePosition(normalizedPosition, retainedStates);
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
+        return result;
+    }
+
+    private async Task<InstrumentPositionProjectionSnapshot> ReadInstrumentSnapshotAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        Guid securityId,
+        Guid? ledgerBookId,
+        DateOnly? asOfDate,
+        CancellationToken ct)
+    {
+        var roles = await ReadTypedListAsync<InstrumentRoleDto>(
+            connection,
+            transaction,
+            "instrument_role_projections",
+            "effective_from, version, role_id",
+            securityId,
+            ct).ConfigureAwait(false);
+        var candidatePositions = await ReadBookPositionsAsync(
+                connection,
+                transaction,
+                securityId,
+                ledgerBookId,
+                asOfDate,
+                ct)
+            .ConfigureAwait(false);
+
+        var effectiveRoles = asOfDate is null
+            ? roles
+            : roles.Where(role =>
+                    candidatePositions.Any(position => position.RoleId == role.RoleId) &&
+                    InstrumentPositionProjectionRules.IsActive(role.EffectiveFrom, role.EffectiveTo, asOfDate.Value))
+                .ToArray();
+        var effectiveRoleIds = effectiveRoles.Select(static role => role.RoleId).ToHashSet();
+        var positions = asOfDate is null
+            ? candidatePositions
+            : candidatePositions.Where(position => effectiveRoleIds.Contains(position.RoleId)).ToArray();
+        var positionIds = positions.Select(static position => position.PositionId).ToArray();
+        var states = await ReadSnapshotStatesAsync(
+                connection,
+                transaction,
+                securityId,
+                ledgerBookId,
+                positionIds,
+                asOfDate,
+                ct)
+            .ConfigureAwait(false);
+        var hydratedPositions = positions
+            .Select(position => HydratePosition(
+                position,
+                states.Where(state => state.PositionId == position.PositionId),
+                asOfDate))
+            .ToArray();
+        var lineages = BuildLineageHistory(hydratedPositions, states);
+
+        return new InstrumentPositionProjectionSnapshot(
+            securityId,
+            effectiveRoles,
+            hydratedPositions,
+            states,
+            lineages)
+        {
+            LedgerBookId = ledgerBookId,
+            AsOfDate = asOfDate
+        };
+    }
+
+    private async Task<IReadOnlyList<BookPositionDto>> ReadBookPositionsAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        Guid securityId,
+        Guid? ledgerBookId,
+        DateOnly? asOfDate,
+        CancellationToken ct)
+    {
+        var where = new StringBuilder("security_id = @security_id");
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.Parameters.AddWithValue("security_id", securityId);
+        if (ledgerBookId is Guid bookId)
+        {
+            where.Append(" and ledger_book_id = @ledger_book_id");
+            command.Parameters.AddWithValue("ledger_book_id", bookId);
+        }
+
+        if (asOfDate is DateOnly asOf)
+        {
+            where.Append(" and effective_from <= @as_of and (effective_to is null or effective_to >= @as_of)");
+            command.Parameters.AddWithValue("as_of", asOf);
+        }
+
+        command.CommandText =
+            $"select payload::text from {Qualified("book_position_projections")} where {where} " +
+            "order by effective_from, version, position_id;";
+        return await ReadPayloadsAsync<BookPositionDto>(command, ct).ConfigureAwait(false);
+    }
+
+    private async Task<InstrumentRoleDto?> ReadInstrumentRoleAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        Guid roleId,
+        bool forUpdate,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText =
+            $"select payload::text from {Qualified("instrument_role_projections")} where role_id = @id" +
+            (forUpdate ? " for update;" : ";");
+        command.Parameters.AddWithValue("id", roleId);
+        return await ReadPayloadAsync<InstrumentRoleDto>(command, ct).ConfigureAwait(false);
+    }
+
+    private async Task<BookPositionDto?> ReadBookPositionAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        Guid positionId,
+        bool forUpdate,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText =
+            $"select payload::text from {Qualified("book_position_projections")} where position_id = @id" +
+            (forUpdate ? " for update;" : ";");
+        command.Parameters.AddWithValue("id", positionId);
+        return await ReadPayloadAsync<BookPositionDto>(command, ct).ConfigureAwait(false);
+    }
+
+    private async Task<PositionEconomicStateDto?> ReadEconomicStateAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        Guid economicStateId,
+        bool forUpdate,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText =
+            $"select payload::text from {Qualified("position_economic_state_projections")} where economic_state_id = @id" +
+            (forUpdate ? " for update;" : ";");
+        command.Parameters.AddWithValue("id", economicStateId);
+        return await ReadPayloadAsync<PositionEconomicStateDto>(command, ct).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<PositionEconomicStateDto>> ReadPositionStatesAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        Guid positionId,
+        DateOnly? asOfDate,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText =
+            $"select payload::text from {Qualified("position_economic_state_projections")} " +
+            "where position_id = @position_id" +
+            (asOfDate is null ? string.Empty : " and as_of_date <= @as_of") +
+            " order by as_of_date, version, economic_state_id;";
+        command.Parameters.AddWithValue("position_id", positionId);
+        if (asOfDate is DateOnly asOf)
+        {
+            command.Parameters.AddWithValue("as_of", asOf);
+        }
+
+        return await ReadPayloadsAsync<PositionEconomicStateDto>(command, ct).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<PositionEconomicStateDto>> ReadSnapshotStatesAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        Guid securityId,
+        Guid? ledgerBookId,
+        IReadOnlyList<Guid> positionIds,
+        DateOnly? asOfDate,
+        CancellationToken ct)
+    {
+        if (positionIds.Count == 0)
+        {
+            return [];
+        }
+
+        var where = new StringBuilder("security_id = @security_id and position_id = any(@position_ids)");
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.Parameters.AddWithValue("security_id", securityId);
+        command.Parameters.AddWithValue("position_ids", positionIds.ToArray());
+        if (ledgerBookId is Guid bookId)
+        {
+            where.Append(" and ledger_book_id = @ledger_book_id");
+            command.Parameters.AddWithValue("ledger_book_id", bookId);
+        }
+
+        if (asOfDate is DateOnly asOf)
+        {
+            where.Append(" and as_of_date <= @as_of");
+            command.Parameters.AddWithValue("as_of", asOf);
+        }
+
+        command.CommandText =
+            $"select payload::text from {Qualified("position_economic_state_projections")} " +
+            $"where {where} order by as_of_date, version, economic_state_id;";
+        return await ReadPayloadsAsync<PositionEconomicStateDto>(command, ct).ConfigureAwait(false);
+    }
+
+    private async Task ValidateEconomicStateAppendAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        BookPositionDto position,
+        PositionEconomicStateDto? state,
+        PositionEconomicStateDto? persistedState,
+        CancellationToken ct)
+    {
+        if (state is null)
+        {
+            return;
+        }
+
+        if (persistedState is not null && !PayloadEquals(persistedState, state))
+        {
+            throw new InvalidOperationException(
+                $"Economic state '{state.EconomicStateId:D}' is append-only and cannot be replaced.");
+        }
+
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText =
+            $"select economic_state_id from {Qualified("position_economic_state_projections")} " +
+            "where position_id = @position_id and version = @version for update;";
+        command.Parameters.AddWithValue("position_id", position.PositionId);
+        command.Parameters.AddWithValue("version", state.Version);
+        var existingId = await command.ExecuteScalarAsync(ct).ConfigureAwait(false);
+        if (existingId is Guid existingStateId && existingStateId != state.EconomicStateId)
+        {
+            throw new InvalidOperationException(
+                $"Book position '{position.PositionId:D}' already has economic state version {state.Version}.");
+        }
+    }
+
+    private async Task EnsureRoleCoversPositionsAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        InstrumentRoleDto role,
+        BookPositionDto? replacement,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText =
+            $"select payload::text from {Qualified("book_position_projections")} " +
+            "where role_id = @role_id for update;";
+        command.Parameters.AddWithValue("role_id", role.RoleId);
+        var persisted = await ReadPayloadsAsync<BookPositionDto>(command, ct).ConfigureAwait(false);
+        var positions = persisted
+            .Where(position => replacement is null || position.PositionId != replacement.PositionId)
+            .Concat(replacement is null ? [] : [replacement]);
+        foreach (var position in positions)
+        {
+            InstrumentPositionProjectionRules.ValidateRoleWindow(role, position);
+        }
+    }
+
+    private async Task EnsureStatesRemainWithinPositionAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        BookPositionDto position,
+        CancellationToken ct)
+    {
+        var states = await ReadPositionStatesAsync(
+                connection,
+                transaction,
+                position.PositionId,
+                null,
+                ct)
+            .ConfigureAwait(false);
+        foreach (var state in states)
+        {
+            InstrumentPositionProjectionRules.ValidateEconomicState(position, state);
+        }
+    }
+
+    private async Task EnsureNoOverlapAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        BookPositionDto position,
+        CancellationToken ct)
+    {
+        if (!InstrumentPositionProjectionRules.ParticipatesInActiveOverlap(position.Status))
+        {
+            return;
+        }
+
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText =
+            $"""
+            select position_id
+            from {Qualified("book_position_projections")}
+            where position_id <> @position_id
+              and security_id = @security_id
+              and role_id = @role_id
+              and ledger_book_id = @ledger_book_id
+              and lower(owner_scope_id) = lower(@owner_scope_id)
+              and lower(owner_scope_kind) = lower(@owner_scope_kind)
+              and lower(position_side) = lower(@position_side)
+              and lower(position_status) not in ('closed', 'inactive', 'terminated', 'matured')
+              and effective_from <= @effective_to
+              and coalesce(effective_to, 'infinity'::date) >= @effective_from
+            limit 1
+            for update;
+            """;
+        command.Parameters.AddWithValue("position_id", position.PositionId);
+        command.Parameters.AddWithValue("security_id", position.SecurityId);
+        command.Parameters.AddWithValue("role_id", position.RoleId);
+        command.Parameters.AddWithValue("ledger_book_id", position.BookContext.LedgerBookId);
+        command.Parameters.AddWithValue("owner_scope_id", position.BookContext.FundProfileId);
+        command.Parameters.AddWithValue("owner_scope_kind", position.BookContext.FundStructureNodeKind.ToString());
+        command.Parameters.AddWithValue("position_side", position.PositionSide);
+        command.Parameters.AddWithValue("effective_from", position.EffectiveFrom);
+        command.Parameters.AddWithValue("effective_to", position.EffectiveTo ?? DateOnly.MaxValue);
+        if (await command.ExecuteScalarAsync(ct).ConfigureAwait(false) is Guid overlapId)
+        {
+            throw new InvalidOperationException(
+                $"Book position '{position.PositionId:D}' overlaps active position '{overlapId:D}' in the same security/book/owner/role scope.");
+        }
+    }
+
+    private static void ValidateRoleTransition(InstrumentRoleDto? persisted, InstrumentRoleDto incoming)
+    {
+        if (persisted is null)
+        {
+            return;
+        }
+
+        if (persisted.SecurityId != incoming.SecurityId ||
+            !InstrumentPositionProjectionRules.ExactTextEquals(persisted.OwnerScopeId, incoming.OwnerScopeId) ||
+            !InstrumentPositionProjectionRules.ExactTextEquals(persisted.OwnerScopeKind, incoming.OwnerScopeKind) ||
+            !InstrumentPositionProjectionRules.ExactTextEquals(persisted.RoleKind, incoming.RoleKind))
+        {
+            throw new InvalidOperationException("Instrument role identity and owner scope are immutable.");
+        }
+
+        if (!PayloadEquals(persisted, incoming) && incoming.Version != persisted.Version + 1)
+        {
+            throw new InvalidOperationException(
+                $"Instrument role '{incoming.RoleId:D}' expected next version {persisted.Version + 1}.");
+        }
+    }
+
+    private static void ValidateCompatibilityRoleTransition(
+        InstrumentRoleDto? persisted,
+        InstrumentRoleDto incoming)
+    {
+        if (persisted is null)
+        {
+            return;
+        }
+
+        if (persisted.SecurityId != incoming.SecurityId ||
+            !InstrumentPositionProjectionRules.ExactTextEquals(persisted.OwnerScopeId, incoming.OwnerScopeId) ||
+            !InstrumentPositionProjectionRules.ExactTextEquals(persisted.OwnerScopeKind, incoming.OwnerScopeKind) ||
+            !InstrumentPositionProjectionRules.ExactTextEquals(persisted.RoleKind, incoming.RoleKind))
+        {
+            throw new InvalidOperationException("Instrument role identity and owner scope are immutable.");
+        }
+
+        if (!PayloadEquals(persisted, incoming) && incoming.Version <= persisted.Version)
+        {
+            throw new InvalidOperationException(
+                $"Instrument role '{incoming.RoleId:D}' requires a strictly newer compatibility version.");
+        }
+    }
+
+    private static void ValidatePositionTransition(
+        BookPositionDto? persisted,
+        BookPositionDto incoming,
+        long expectedVersion)
+    {
+        if (persisted is null)
+        {
+            if (expectedVersion != 0 || incoming.Version != 1)
+            {
+                throw new InvalidOperationException("New book positions require ExpectedVersion 0 and Version 1.");
+            }
+
+            return;
+        }
+
+        if (persisted.Version != expectedVersion || incoming.Version != expectedVersion + 1)
+        {
+            throw new InvalidOperationException(
+                $"Book position '{incoming.PositionId:D}' is stale. Persisted version is {persisted.Version}; expected {expectedVersion}.");
+        }
+    }
+
+    private static void ValidateCompatibilityPositionTransition(
+        BookPositionDto? persisted,
+        BookPositionDto incoming)
+    {
+        if (persisted is null || PayloadEquals(persisted, incoming))
+        {
+            return;
+        }
+
+        if (incoming.Version <= persisted.Version)
+        {
+            throw new InvalidOperationException(
+                $"Book position '{incoming.PositionId:D}' is stale; expected next version {persisted.Version + 1}.");
+        }
+    }
+
+    private static void ValidateCompatibilityStateVersion(
+        BookPositionDto position,
+        PositionEconomicStateDto state)
+    {
+        if (state.Version != position.Version && state.Version != checked(position.Version + 1))
+        {
+            throw new InvalidOperationException(
+                "Compatibility economic-state writes must match the position version or its immediate successor.");
+        }
+    }
+
+    private static void ValidatePositionIdentity(BookPositionDto? persisted, BookPositionDto incoming)
+    {
+        if (persisted is null)
+        {
+            return;
+        }
+
+        if (persisted.SecurityId != incoming.SecurityId ||
+            persisted.RoleId != incoming.RoleId ||
+            persisted.BookContext.LedgerBookId != incoming.BookContext.LedgerBookId ||
+            persisted.BookContext.FundStructureNodeId != incoming.BookContext.FundStructureNodeId ||
+            !InstrumentPositionProjectionRules.ExactTextEquals(
+                persisted.BookContext.FundProfileId,
+                incoming.BookContext.FundProfileId) ||
+            persisted.BookContext.FundStructureNodeKind != incoming.BookContext.FundStructureNodeKind ||
+            !InstrumentPositionProjectionRules.ExactTextEquals(persisted.PositionSide, incoming.PositionSide))
+        {
+            throw new InvalidOperationException("Book-position security, role, book, owner scope, and side are immutable.");
+        }
+    }
+
+    private static BookPositionDto HydratePosition(
+        BookPositionDto position,
+        IEnumerable<PositionEconomicStateDto> states,
+        DateOnly? asOfDate = null)
+    {
+        var current = states
+            .OrderByDescending(static state => state.AsOfDate)
+            .ThenByDescending(static state => state.Version)
+            .ThenByDescending(static state => state.EconomicStateId)
+            .FirstOrDefault();
+        var positionLineage = position.ProjectionLineage;
+        if (asOfDate is DateOnly cutoff && positionLineage?.ProjectionAsOfDate > cutoff)
+        {
+            positionLineage = null;
+        }
+
+        return position with
+        {
+            CurrentEconomicState = current,
+            ProjectionLineage = current?.ProjectionLineage ?? positionLineage
+        };
+    }
+
+    private static IReadOnlyList<ProjectionLineageDto> BuildLineageHistory(
+        IReadOnlyList<BookPositionDto> positions,
+        IReadOnlyList<PositionEconomicStateDto> states)
+        => positions
+            .Select(static position => position.ProjectionLineage)
+            .Concat(states.Select(static state => state.ProjectionLineage))
+            .Where(static lineage => lineage is not null)
+            .Cast<ProjectionLineageDto>()
+            .DistinctBy(static lineage => lineage.ProjectionRunId)
+            .OrderBy(static lineage => lineage.ProjectionAsOfDate)
+            .ThenBy(static lineage => lineage.GeneratedAtUtc)
+            .ThenBy(static lineage => lineage.ProjectionRunId)
+            .ToArray();
+
+    private static bool PayloadEquals<T>(T left, T right)
+        => JsonElement.DeepEquals(
+            JsonSerializer.SerializeToElement(left, JsonOptions),
+            JsonSerializer.SerializeToElement(right, JsonOptions));
+
+    private static async Task<T?> ReadPayloadAsync<T>(NpgsqlCommand command, CancellationToken ct)
+    {
+        var payload = await command.ExecuteScalarAsync(ct).ConfigureAwait(false) as string;
+        return payload is null ? default : JsonSerializer.Deserialize<T>(payload, JsonOptions);
+    }
+
+    private static async Task<IReadOnlyList<T>> ReadPayloadsAsync<T>(
+        NpgsqlCommand command,
+        CancellationToken ct)
+    {
+        var rows = new List<T>();
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var row = JsonSerializer.Deserialize<T>(reader.GetString(0), JsonOptions);
+            if (row is not null)
+            {
+                rows.Add(row);
+            }
+        }
+
+        return rows;
+    }
+
+    private static void AddSourceEventParameters(NpgsqlCommand command, EconomicEventReferenceDto? source)
+    {
+        command.Parameters.AddWithValue("source_domain", (object?)source?.SourceDomain ?? DBNull.Value);
+        command.Parameters.AddWithValue("source_entity_id", (object?)source?.SourceEntityId ?? DBNull.Value);
+        command.Parameters.AddWithValue("source_content_hash", (object?)source?.SourceContentHash ?? DBNull.Value);
+    }
+
+    private static void AddProjectionParameters(NpgsqlCommand command, ProjectionLineageDto? lineage)
+    {
+        command.Parameters.AddWithValue("projection_run_id", (object?)lineage?.ProjectionRunId ?? DBNull.Value);
+        command.Parameters.AddWithValue("projection_event_id", (object?)lineage?.ProjectionEventId ?? DBNull.Value);
+    }
+}

--- a/src/Meridian.Storage/AssetOperations/PostgresAssetOperationsProjectionStore.Locks.cs
+++ b/src/Meridian.Storage/AssetOperations/PostgresAssetOperationsProjectionStore.Locks.cs
@@ -1,0 +1,99 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Meridian.Contracts.AssetOperations;
+using Npgsql;
+
+namespace Meridian.Storage.AssetOperations;
+
+public sealed partial class PostgresAssetOperationsProjectionStore
+{
+    private async Task AcquirePositionScopeLockAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        BookPositionDto position,
+        CancellationToken ct)
+    {
+        if (!InstrumentPositionProjectionRules.ParticipatesInActiveOverlap(position.Status))
+        {
+            return;
+        }
+
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "select pg_advisory_xact_lock(@lock_key);";
+        command.Parameters.AddWithValue("lock_key", ComputeScopeLockKey(position));
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    private async Task AcquireProjectionRunLockAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        Guid projectionRunId,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "select pg_advisory_xact_lock(@lock_key);";
+        command.Parameters.AddWithValue("lock_key", ComputeProjectionRunLockKey(projectionRunId));
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    private async Task ValidateProjectionLineageAppendAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        ProjectionLineageDto lineage,
+        CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText =
+            $"""
+            select (payload -> 'projectionLineage')::text
+            from {Qualified("book_position_projections")}
+            where projection_run_id = @projection_run_id
+            union all
+            select (payload -> 'projectionLineage')::text
+            from {Qualified("position_economic_state_projections")}
+            where projection_run_id = @projection_run_id;
+            """;
+        command.Parameters.AddWithValue("projection_run_id", lineage.ProjectionRunId);
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            if (reader.IsDBNull(0))
+            {
+                continue;
+            }
+
+            var persisted = JsonSerializer.Deserialize<ProjectionLineageDto>(reader.GetString(0), JsonOptions);
+            if (persisted is not null && !PayloadEquals(persisted, lineage))
+            {
+                throw new InvalidOperationException(
+                    $"Projection run '{lineage.ProjectionRunId:D}' cannot be reused with conflicting lineage.");
+            }
+        }
+    }
+
+    private static long ComputeScopeLockKey(BookPositionDto position)
+    {
+        var scope = string.Join(
+            '|',
+            position.SecurityId.ToString("D"),
+            position.RoleId.ToString("D"),
+            position.BookContext.LedgerBookId.ToString("D"),
+            position.BookContext.FundProfileId.Trim().ToUpperInvariant(),
+            position.BookContext.FundStructureNodeKind,
+            position.PositionSide.Trim().ToUpperInvariant());
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes($"position-scope|{scope}"));
+        return BinaryPrimitives.ReadInt64LittleEndian(hash);
+    }
+
+    private static long ComputeProjectionRunLockKey(Guid projectionRunId)
+    {
+        var hash = SHA256.HashData(
+            Encoding.UTF8.GetBytes($"projection-run|{projectionRunId:D}"));
+        return BinaryPrimitives.ReadInt64LittleEndian(hash);
+    }
+}

--- a/src/Meridian.Storage/AssetOperations/PostgresAssetOperationsProjectionStore.cs
+++ b/src/Meridian.Storage/AssetOperations/PostgresAssetOperationsProjectionStore.cs
@@ -1,10 +1,13 @@
 using System.Text.Json;
+using System.Data;
 using Meridian.Contracts.AssetOperations;
 using Npgsql;
 
 namespace Meridian.Storage.AssetOperations;
 
-public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsProjectionStore
+public sealed partial class PostgresAssetOperationsProjectionStore :
+    IAssetOperationsProjectionStore,
+    IInstrumentPositionProjectionStore
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
@@ -19,62 +22,46 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
     public async Task<AssetOperationsDetailDto?> GetAsync(Guid securityId, CancellationToken ct = default)
     {
         await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var transaction = await connection
+            .BeginTransactionAsync(IsolationLevel.RepeatableRead, ct)
+            .ConfigureAwait(false);
 
         var subject = await ReadSingleAsync<AssetOperationSubjectDto>(
             connection,
+            transaction,
             "asset_operation_subjects",
             securityId,
             ct).ConfigureAwait(false);
         if (subject is null)
         {
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
             return null;
         }
 
-        var instrumentRoles = await ReadTypedListAsync<InstrumentRoleDto>(
-            connection,
-            "instrument_role_projections",
-            "effective_from, version, role_id",
-            securityId,
-            ct).ConfigureAwait(false);
-        var bookPositions = await ReadTypedListAsync<BookPositionDto>(
-            connection,
-            "book_position_projections",
-            "effective_from, version, position_id",
-            securityId,
-            ct).ConfigureAwait(false);
-        var economicStates = await ReadTypedListAsync<PositionEconomicStateDto>(
-            connection,
-            "position_economic_state_projections",
-            "as_of_date, version, economic_state_id",
-            securityId,
-            ct).ConfigureAwait(false);
-        var projectionLineages = bookPositions
-            .Select(static position => position.ProjectionLineage)
-            .Concat(economicStates.Select(static state => state.ProjectionLineage))
-            .Where(static lineage => lineage is not null)
-            .Cast<ProjectionLineageDto>()
-            .DistinctBy(static lineage => lineage.ProjectionRunId)
-            .ToArray();
+        var typed = await ReadInstrumentSnapshotAsync(connection, transaction, securityId, null, null, ct)
+            .ConfigureAwait(false);
 
-        return new AssetOperationsDetailDto(
+        var detail = new AssetOperationsDetailDto(
             subject,
-            await ReadListAsync<AssetTermsVersionDto>(connection, "asset_terms_versions", securityId, ct).ConfigureAwait(false),
-            await ReadListAsync<AssetLifecycleEventDto>(connection, "asset_lifecycle_events", securityId, ct).ConfigureAwait(false),
-            await ReadListAsync<AssetCashFlowProjectionRunDto>(connection, "asset_cash_flow_projection_runs", securityId, ct).ConfigureAwait(false),
-            await ReadListAsync<AssetProjectedCashFlowDto>(connection, "asset_projected_cash_flows", securityId, ct).ConfigureAwait(false),
-            await ReadListAsync<AssetActualActivityDto>(connection, "asset_actual_activity", securityId, ct).ConfigureAwait(false),
-            await ReadListAsync<AssetReconciliationRunDto>(connection, "asset_reconciliation_runs", securityId, ct).ConfigureAwait(false),
-            await ReadListAsync<AssetReconciliationResultDto>(connection, "asset_reconciliation_results", securityId, ct).ConfigureAwait(false),
-            await ReadListAsync<AssetLedgerProjectionDto>(connection, "asset_ledger_projections", securityId, ct).ConfigureAwait(false),
-            await ReadSingleAsync<AssetOperationsReadinessDto>(connection, "asset_operations_readiness", securityId, ct).ConfigureAwait(false)
+            await ReadListAsync<AssetTermsVersionDto>(connection, transaction, "asset_terms_versions", securityId, ct).ConfigureAwait(false),
+            await ReadListAsync<AssetLifecycleEventDto>(connection, transaction, "asset_lifecycle_events", securityId, ct).ConfigureAwait(false),
+            await ReadListAsync<AssetCashFlowProjectionRunDto>(connection, transaction, "asset_cash_flow_projection_runs", securityId, ct).ConfigureAwait(false),
+            await ReadListAsync<AssetProjectedCashFlowDto>(connection, transaction, "asset_projected_cash_flows", securityId, ct).ConfigureAwait(false),
+            await ReadListAsync<AssetActualActivityDto>(connection, transaction, "asset_actual_activity", securityId, ct).ConfigureAwait(false),
+            await ReadListAsync<AssetReconciliationRunDto>(connection, transaction, "asset_reconciliation_runs", securityId, ct).ConfigureAwait(false),
+            await ReadListAsync<AssetReconciliationResultDto>(connection, transaction, "asset_reconciliation_results", securityId, ct).ConfigureAwait(false),
+            await ReadListAsync<AssetLedgerProjectionDto>(connection, transaction, "asset_ledger_projections", securityId, ct).ConfigureAwait(false),
+            await ReadSingleAsync<AssetOperationsReadinessDto>(connection, transaction, "asset_operations_readiness", securityId, ct).ConfigureAwait(false)
                 ?? BuildFallbackReadiness(subject),
-            await ReadListAsync<AssetLifecycleEventDto>(connection, "asset_workflow_audit", securityId, ct).ConfigureAwait(false))
+            await ReadListAsync<AssetLifecycleEventDto>(connection, transaction, "asset_workflow_audit", securityId, ct).ConfigureAwait(false))
         {
-            InstrumentRoles = instrumentRoles,
-            BookPositions = bookPositions,
-            PositionEconomicStates = economicStates,
-            ProjectionLineages = projectionLineages
+            InstrumentRoles = typed.InstrumentRoles,
+            BookPositions = typed.BookPositions,
+            PositionEconomicStates = typed.PositionEconomicStates,
+            ProjectionLineages = typed.ProjectionLineages
         };
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
+        return detail;
     }
 
     public async Task UpsertAsync(
@@ -91,7 +78,9 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
         }
 
         await using var connection = await OpenConnectionAsync(ct).ConfigureAwait(false);
-        await using var transaction = await connection.BeginTransactionAsync(ct).ConfigureAwait(false);
+        await using var transaction = await connection
+            .BeginTransactionAsync(IsolationLevel.Serializable, ct)
+            .ConfigureAwait(false);
 
         await DeleteExistingAsync(connection, transaction, projection.Subject.SecurityId, ct).ConfigureAwait(false);
         await InsertAsync(connection, transaction, "asset_operation_subjects", projection.Subject.SecurityId, "SecurityMaster", projection.Subject.SecurityId.ToString("D"), projection.Subject, ct).ConfigureAwait(false);
@@ -108,19 +97,128 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
 
         var normalizedPositions = NormalizeTypedProjections(projection);
         var normalizedStates = NormalizeEconomicStates(projection, normalizedPositions);
-        foreach (var role in projection.InstrumentRoles)
+        foreach (var position in normalizedPositions
+                     .Where(position => InstrumentPositionProjectionRules.ParticipatesInActiveOverlap(position.Status))
+                     .OrderBy(ComputeScopeLockKey))
         {
+            await AcquirePositionScopeLockAsync(connection, transaction, position, ct).ConfigureAwait(false);
+        }
+
+        var incomingLineages = projection.ProjectionLineages
+            .Concat(normalizedPositions
+                .Select(static position => position.ProjectionLineage)
+                .Where(static lineage => lineage is not null)!)
+            .Concat(normalizedStates
+                .Select(static state => state.ProjectionLineage)
+                .Where(static lineage => lineage is not null)!)
+            .Cast<ProjectionLineageDto>()
+            .ToArray();
+        var conflictingPersistedIdentity = incomingLineages
+            .GroupBy(static lineage => lineage.ProjectionRunId)
+            .FirstOrDefault(group => group.Skip(1).Any(lineage => !PayloadEquals(group.First(), lineage)));
+        if (conflictingPersistedIdentity is not null)
+        {
+            throw new InvalidOperationException(
+                $"Projection lineage '{conflictingPersistedIdentity.Key:D}' is append-only and cannot have conflicting payloads.");
+        }
+
+        foreach (var lineage in incomingLineages
+                     .DistinctBy(static lineage => lineage.ProjectionRunId)
+                     .OrderBy(static lineage => lineage.ProjectionRunId))
+        {
+            await AcquireProjectionRunLockAsync(connection, transaction, lineage.ProjectionRunId, ct)
+                .ConfigureAwait(false);
+            await ValidateProjectionLineageAppendAsync(connection, transaction, lineage, ct)
+                .ConfigureAwait(false);
+        }
+
+        foreach (var role in projection.InstrumentRoles.OrderBy(static role => role.RoleId))
+        {
+            InstrumentPositionProjectionRules.ValidateRole(role, approval);
+            var persistedRole = await ReadInstrumentRoleAsync(
+                    connection,
+                    transaction,
+                    role.RoleId,
+                    true,
+                    ct)
+                .ConfigureAwait(false);
+            ValidateCompatibilityRoleTransition(persistedRole, role);
             await UpsertInstrumentRoleAsync(connection, transaction, projection.Subject.SecurityId, role, approval, ct).ConfigureAwait(false);
         }
 
         foreach (var position in normalizedPositions)
         {
+            var role = projection.InstrumentRoles.FirstOrDefault(candidate => candidate.RoleId == position.RoleId)
+                ?? await ReadInstrumentRoleAsync(connection, transaction, position.RoleId, true, ct).ConfigureAwait(false)
+                ?? throw new InvalidOperationException($"Book position '{position.PositionId:D}' references a missing instrument role.");
+            var state = normalizedStates
+                .Where(candidate => candidate.PositionId == position.PositionId)
+                .OrderByDescending(static candidate => candidate.AsOfDate)
+                .ThenByDescending(static candidate => candidate.Version)
+                .FirstOrDefault();
+            InstrumentPositionProjectionRules.ValidateWrite(role, position, state, 0, approval);
+            var persistedPosition = await ReadBookPositionAsync(
+                    connection,
+                    transaction,
+                    position.PositionId,
+                    true,
+                    ct)
+                .ConfigureAwait(false);
+            ValidateCompatibilityPositionTransition(persistedPosition, position);
+            ValidatePositionIdentity(persistedPosition, position);
+            await EnsureRoleCoversPositionsAsync(
+                connection,
+                transaction,
+                role,
+                position,
+                ct).ConfigureAwait(false);
+            await EnsureStatesRemainWithinPositionAsync(
+                connection,
+                transaction,
+                position,
+                ct).ConfigureAwait(false);
+            await EnsureNoOverlapAsync(connection, transaction, position, ct).ConfigureAwait(false);
             await UpsertBookPositionAsync(connection, transaction, projection.Subject.SecurityId, position, approval, ct).ConfigureAwait(false);
+        }
+
+        foreach (var role in projection.InstrumentRoles.OrderBy(static role => role.RoleId))
+        {
+            await EnsureRoleCoversPositionsAsync(
+                connection,
+                transaction,
+                role,
+                null,
+                ct).ConfigureAwait(false);
         }
 
         foreach (var state in normalizedStates)
         {
-            await AppendEconomicStateAsync(connection, transaction, projection.Subject.SecurityId, state, approval, ct).ConfigureAwait(false);
+            var position = normalizedPositions.FirstOrDefault(candidate => candidate.PositionId == state.PositionId)
+                ?? await ReadBookPositionAsync(connection, transaction, state.PositionId, true, ct).ConfigureAwait(false)
+                ?? throw new InvalidOperationException($"Economic state '{state.EconomicStateId:D}' references a missing book position.");
+            if (position.SecurityId != projection.Subject.SecurityId)
+            {
+                throw new InvalidOperationException(
+                    "Economic states must match the Asset Operations subject Security Master identity.");
+            }
+
+            var persistedState = await ReadEconomicStateAsync(
+                    connection,
+                    transaction,
+                    state.EconomicStateId,
+                    true,
+                    ct)
+                .ConfigureAwait(false);
+            InstrumentPositionProjectionRules.ValidateEconomicState(position, state);
+            ValidateCompatibilityStateVersion(position, state);
+            await ValidateEconomicStateAppendAsync(
+                connection,
+                transaction,
+                position,
+                state,
+                persistedState,
+                ct).ConfigureAwait(false);
+            await AppendEconomicStateAsync(connection, transaction, projection.Subject.SecurityId, position, state, approval, ct).ConfigureAwait(false);
         }
 
         await transaction.CommitAsync(ct).ConfigureAwait(false);
@@ -197,21 +295,24 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
 
     private async Task<T?> ReadSingleAsync<T>(
         NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
         string table,
         Guid securityId,
         CancellationToken ct)
     {
-        var rows = await ReadListAsync<T>(connection, table, securityId, ct).ConfigureAwait(false);
+        var rows = await ReadListAsync<T>(connection, transaction, table, securityId, ct).ConfigureAwait(false);
         return rows.FirstOrDefault();
     }
 
     private async Task<IReadOnlyList<T>> ReadListAsync<T>(
         NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
         string table,
         Guid securityId,
         CancellationToken ct)
     {
         await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
         command.CommandText =
             $"""
             select payload::text
@@ -237,6 +338,7 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
 
     private async Task<IReadOnlyList<T>> ReadTypedListAsync<T>(
         NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
         string table,
         string orderBy,
         Guid securityId,
@@ -249,6 +351,7 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
         }
 
         await using var command = connection.CreateCommand();
+        command.Transaction = transaction;
         command.CommandText =
             $"select payload::text from {Qualified(table)} where security_id = @security_id order by {orderBy};";
         command.Parameters.AddWithValue("security_id", securityId);
@@ -305,7 +408,7 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
                 throw new InvalidOperationException($"Book position '{position.PositionId:D}' references a role that is not included in the projection write.");
             }
 
-            var state = position.CurrentEconomicState ?? projection.PositionEconomicStates
+            var state = projection.PositionEconomicStates
                 .Where(candidate => candidate.PositionId == position.PositionId)
                 .OrderByDescending(static candidate => candidate.AsOfDate)
                 .ThenByDescending(static candidate => candidate.Version)
@@ -313,10 +416,15 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
             var lineage = position.ProjectionLineage ?? projection.ProjectionLineages
                 .FirstOrDefault(candidate => candidate.BookPositionId == position.PositionId ||
                     candidate.TriggerEvent.BookPositionId == position.PositionId);
-            positions.Add(position with
+            var normalized = InstrumentPositionProjectionRules.NormalizeWrite(
+                position with
+                {
+                    ProjectionLineage = lineage
+                },
+                state);
+            positions.Add(normalized.Position with
             {
-                CurrentEconomicState = state,
-                ProjectionLineage = lineage
+                CurrentEconomicState = normalized.EconomicState
             });
         }
 
@@ -334,10 +442,26 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
         }
 
         if (projection.ProjectionLineages.Any(lineage =>
-                lineage.BookPositionId is not Guid positionId ||
-                projection.BookPositions.All(position => position.PositionId != positionId)))
+                (lineage.BookPositionId ?? lineage.TriggerEvent.BookPositionId) is not Guid positionId ||
+                positions.All(position => position.PositionId != positionId)))
         {
             throw new InvalidOperationException("Projection lineage must reference a book position included in the projection write.");
+        }
+
+        foreach (var lineage in projection.ProjectionLineages)
+        {
+            var positionId = lineage.BookPositionId ?? lineage.TriggerEvent.BookPositionId;
+            var position = positions.Single(candidate => candidate.PositionId == positionId);
+            InstrumentPositionProjectionRules.ValidateStandaloneLineage(position, lineage);
+        }
+
+        var conflictingLineage = projection.ProjectionLineages
+            .GroupBy(static lineage => lineage.ProjectionRunId)
+            .FirstOrDefault(group => group.Skip(1).Any(lineage => !PayloadEquals(group.First(), lineage)));
+        if (conflictingLineage is not null)
+        {
+            throw new InvalidOperationException(
+                $"Projection lineage '{conflictingLineage.Key:D}' is append-only and cannot have conflicting payloads.");
         }
 
         return positions;
@@ -354,7 +478,11 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
             .Cast<ProjectionLineageDto>()
             .ToArray();
 
-        return projection.PositionEconomicStates
+        var states = projection.PositionEconomicStates
+            .Concat(positions
+                .Select(static position => position.CurrentEconomicState)
+                .Where(static state => state is not null)!)
+            .Cast<PositionEconomicStateDto>()
             .Select(state => state.ProjectionLineage is not null
                 ? state
                 : state with
@@ -364,6 +492,16 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
                         lineage.TriggerEvent.EventId == state.SourceEvent?.EventId)
                 })
             .ToArray();
+        var conflictingState = states
+            .GroupBy(static state => state.EconomicStateId)
+            .FirstOrDefault(group => group.Skip(1).Any(state => !PayloadEquals(group.First(), state)));
+        if (conflictingState is not null)
+        {
+            throw new InvalidOperationException(
+                $"Economic state '{conflictingState.Key:D}' is append-only and cannot have conflicting payloads.");
+        }
+
+        return states.DistinctBy(static state => state.EconomicStateId).ToArray();
     }
 
     private async Task UpsertInstrumentRoleAsync(
@@ -381,16 +519,25 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
             insert into {Qualified("instrument_role_projections")} as persisted_role (
                 role_id, security_id, owner_scope_id, owner_scope_kind, role_kind,
                 effective_from, effective_to, version, source_event_id,
-                approval_actor, approval_reference, approved_at, evidence_links, payload)
+                approval_actor, approval_reference, approval_rationale, approved_at,
+                source_domain, source_entity_id, source_content_hash, evidence_links, payload)
             values (
                 @id, @security_id, @owner_scope_id, @owner_scope_kind, @role_kind,
                 @effective_from, @effective_to, @version, @source_event_id,
-                @approval_actor, @approval_reference, @approved_at, @evidence::jsonb, @payload::jsonb)
+                @approval_actor, @approval_reference, @approval_rationale, @approved_at,
+                @source_domain, @source_entity_id, @source_content_hash, @evidence::jsonb, @payload::jsonb)
             on conflict (role_id) do update set
                 effective_from = excluded.effective_from,
                 effective_to = excluded.effective_to,
                 version = excluded.version,
                 source_event_id = excluded.source_event_id,
+                source_domain = excluded.source_domain,
+                source_entity_id = excluded.source_entity_id,
+                source_content_hash = excluded.source_content_hash,
+                approval_actor = case when excluded.version > persisted_role.version then excluded.approval_actor else persisted_role.approval_actor end,
+                approval_reference = case when excluded.version > persisted_role.version then excluded.approval_reference else persisted_role.approval_reference end,
+                approval_rationale = case when excluded.version > persisted_role.version then excluded.approval_rationale else persisted_role.approval_rationale end,
+                approved_at = case when excluded.version > persisted_role.version then excluded.approved_at else persisted_role.approved_at end,
                 evidence_links = excluded.evidence_links,
                 payload = excluded.payload,
                 updated_at = case
@@ -411,6 +558,7 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
         command.Parameters.AddWithValue("role_kind", role.RoleKind);
         command.Parameters.AddWithValue("effective_from", role.EffectiveFrom);
         command.Parameters.AddWithValue("effective_to", (object?)role.EffectiveTo ?? DBNull.Value);
+        AddSourceEventParameters(command, role.OriginEvent);
         await EnsureTypedWriteAsync(command, "instrument role", role.RoleId, ct).ConfigureAwait(false);
     }
 
@@ -428,17 +576,32 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
             $"""
             insert into {Qualified("book_position_projections")} as persisted_position (
                 position_id, security_id, role_id, ledger_book_id, owner_scope_id, owner_scope_kind,
-                effective_from, effective_to, version, source_event_id,
-                approval_actor, approval_reference, approved_at, evidence_links, payload)
+                position_side, position_status, effective_from, effective_to, version, source_event_id,
+                approval_actor, approval_reference, approval_rationale, approved_at,
+                source_domain, source_entity_id, source_content_hash,
+                projection_run_id, projection_event_id, evidence_links, payload)
             values (
                 @id, @security_id, @role_id, @ledger_book_id, @owner_scope_id, @owner_scope_kind,
-                @effective_from, @effective_to, @version, @source_event_id,
-                @approval_actor, @approval_reference, @approved_at, @evidence::jsonb, @payload::jsonb)
+                @position_side, @position_status, @effective_from, @effective_to, @version, @source_event_id,
+                @approval_actor, @approval_reference, @approval_rationale, @approved_at,
+                @source_domain, @source_entity_id, @source_content_hash,
+                @projection_run_id, @projection_event_id, @evidence::jsonb, @payload::jsonb)
             on conflict (position_id) do update set
+                position_side = excluded.position_side,
+                position_status = excluded.position_status,
                 effective_from = excluded.effective_from,
                 effective_to = excluded.effective_to,
                 version = excluded.version,
                 source_event_id = excluded.source_event_id,
+                source_domain = excluded.source_domain,
+                source_entity_id = excluded.source_entity_id,
+                source_content_hash = excluded.source_content_hash,
+                projection_run_id = excluded.projection_run_id,
+                projection_event_id = excluded.projection_event_id,
+                approval_actor = case when excluded.version > persisted_position.version then excluded.approval_actor else persisted_position.approval_actor end,
+                approval_reference = case when excluded.version > persisted_position.version then excluded.approval_reference else persisted_position.approval_reference end,
+                approval_rationale = case when excluded.version > persisted_position.version then excluded.approval_rationale else persisted_position.approval_rationale end,
+                approved_at = case when excluded.version > persisted_position.version then excluded.approved_at else persisted_position.approved_at end,
                 evidence_links = excluded.evidence_links,
                 payload = excluded.payload,
                 updated_at = case
@@ -460,8 +623,12 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
         command.Parameters.AddWithValue("ledger_book_id", position.BookContext.LedgerBookId);
         command.Parameters.AddWithValue("owner_scope_id", position.BookContext.FundProfileId);
         command.Parameters.AddWithValue("owner_scope_kind", position.BookContext.FundStructureNodeKind.ToString());
+        command.Parameters.AddWithValue("position_side", position.PositionSide);
+        command.Parameters.AddWithValue("position_status", position.Status);
         command.Parameters.AddWithValue("effective_from", position.EffectiveFrom);
         command.Parameters.AddWithValue("effective_to", (object?)position.EffectiveTo ?? DBNull.Value);
+        AddSourceEventParameters(command, position.OriginEvent ?? position.ProjectionLineage?.TriggerEvent);
+        AddProjectionParameters(command, position.ProjectionLineage);
         await EnsureTypedWriteAsync(command, "book position", position.PositionId, ct).ConfigureAwait(false);
     }
 
@@ -469,6 +636,7 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
         NpgsqlConnection connection,
         NpgsqlTransaction transaction,
         Guid securityId,
+        BookPositionDto position,
         PositionEconomicStateDto state,
         AssetOperationsWriteApprovalDto approval,
         CancellationToken ct)
@@ -478,18 +646,30 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
         command.CommandText =
             $"""
             insert into {Qualified("position_economic_state_projections")} as persisted_state (
-                economic_state_id, position_id, security_id, as_of_date, version, source_event_id,
-                approval_actor, approval_reference, approved_at, evidence_links, payload)
+                economic_state_id, position_id, security_id, ledger_book_id, owner_scope_id,
+                owner_scope_kind, as_of_date, version, source_event_id,
+                approval_actor, approval_reference, approval_rationale, approved_at,
+                source_domain, source_entity_id, source_content_hash,
+                projection_run_id, projection_event_id, evidence_links, payload)
             values (
-                @id, @position_id, @security_id, @as_of_date, @version, @source_event_id,
-                @approval_actor, @approval_reference, @approved_at, @evidence::jsonb, @payload::jsonb)
+                @id, @position_id, @security_id, @ledger_book_id, @owner_scope_id,
+                @owner_scope_kind, @as_of_date, @version, @source_event_id,
+                @approval_actor, @approval_reference, @approval_rationale, @approved_at,
+                @source_domain, @source_entity_id, @source_content_hash,
+                @projection_run_id, @projection_event_id, @evidence::jsonb, @payload::jsonb)
             on conflict (economic_state_id) do update set
                 economic_state_id = persisted_state.economic_state_id
             where excluded.payload = persisted_state.payload;
             """;
-        AddTypedProjectionParameters(command, securityId, state.EconomicStateId, state.Version, state.SourceEvent?.EventId, state.EvidenceLinks, state, approval);
+        var sourceEvent = state.SourceEvent ?? state.ProjectionLineage?.TriggerEvent;
+        AddTypedProjectionParameters(command, securityId, state.EconomicStateId, state.Version, sourceEvent?.EventId, state.EvidenceLinks, state, approval);
         command.Parameters.AddWithValue("position_id", state.PositionId);
+        command.Parameters.AddWithValue("ledger_book_id", position.BookContext.LedgerBookId);
+        command.Parameters.AddWithValue("owner_scope_id", position.BookContext.FundProfileId);
+        command.Parameters.AddWithValue("owner_scope_kind", position.BookContext.FundStructureNodeKind.ToString());
         command.Parameters.AddWithValue("as_of_date", state.AsOfDate);
+        AddSourceEventParameters(command, sourceEvent);
+        AddProjectionParameters(command, state.ProjectionLineage);
         await EnsureTypedWriteAsync(command, "economic state", state.EconomicStateId, ct).ConfigureAwait(false);
     }
 
@@ -509,6 +689,7 @@ public sealed class PostgresAssetOperationsProjectionStore : IAssetOperationsPro
         command.Parameters.AddWithValue("source_event_id", (object?)sourceEventId ?? DBNull.Value);
         command.Parameters.AddWithValue("approval_actor", approval.Actor);
         command.Parameters.AddWithValue("approval_reference", approval.ApprovalReference);
+        command.Parameters.AddWithValue("approval_rationale", approval.Rationale);
         command.Parameters.AddWithValue("approved_at", approval.ApprovedAt);
         command.Parameters.AddWithValue("evidence", JsonSerializer.Serialize(evidenceLinks, JsonOptions));
         command.Parameters.AddWithValue("payload", JsonSerializer.Serialize(payload, JsonOptions));

--- a/src/Meridian.Storage/README.md
+++ b/src/Meridian.Storage/README.md
@@ -6,7 +6,7 @@ module_id: SRC-STORAGE
 path: src/Meridian.Storage
 status: active
 owner_lane: Accounting and Ledger
-last_reviewed: 2026-07-12
+last_reviewed: 2026-07-13
 ---
 
 # src/Meridian.Storage
@@ -230,13 +230,30 @@ Security Master continues to own canonical security identity; Asset Operations r
 identity, and Storage preserves each module's records without introducing a parent Instrument Master
 or reversing the dependency into Reference Data.
 `002_instrument_position_projections.sql` adds Security Master-keyed role and book-position payloads
-plus append-only position economic-state history. Existing aggregate writes preserve these typed
-collections when older callers send default-empty fields; the tables retain book/owner scope,
-effective dates, versions, source events, evidence, and approval metadata, but never ledger balances.
-Economic-state payloads retain their matching typed lineage, allowing every append-only factor event
-to survive a later current-position update. Role and position identities cannot move across Security
-Master, owner, role, or ledger-book boundaries, and idempotent replay preserves the original approval
-actor, reference, and timestamp.
+plus append-only position economic-state history. `IInstrumentPositionProjectionStore` exposes
+unfiltered security history, effective-dated security/book lookup, position lookup, and a
+transactional compare-and-swap write without exposing a ledger-balance API. Its PostgreSQL and
+in-memory implementations apply the same missing-role, date-window, overlap, cross-book, owner,
+dimension, provenance, and stale-version guards. The compatibility aggregate command derives the
+persisted version inside the same serializable write while preserving the legacy ability to import a
+strictly newer sparse version; exact `ExpectedVersion` compare-and-swap remains exclusive to the
+dedicated store. New dedicated writes require retained event provenance and evidence. PostgreSQL
+takes deterministic scope locks before row locks so concurrent writers cannot both establish
+overlapping active positions or lose a same-position update; multi-statement reads use a repeatable
+snapshot so position and economic-state versions cannot tear. The in-memory implementation retains
+the same approval evidence, defensively clones caller-owned payload graphs, and preserves the first
+approval on idempotent replay.
+
+`003_instrument_position_projection_guards.sql` normalizes approval rationale, source provenance,
+book/owner scope, and projection lineage identifiers used by those guarded queries. Existing
+aggregate writes preserve typed collections when older callers send default-empty fields; existing
+Security Master, direct-lending, portfolio, fund-account, and asset-family rows are not backfilled or
+migrated. Economic-state payloads retain their matching typed lineage, allowing every append-only
+factor event to survive a later current-position update. Role and position identities cannot move
+across Security Master, owner, role, or ledger-book boundaries, state versions cannot be replaced,
+and idempotent replay preserves the original approval actor, reference, rationale, and timestamp.
+Asset Operations migrations run under a schema-scoped advisory lock and a checksummed migration
+ledger, preventing concurrent first-start races and repeated DDL/history rewrites after restart.
 
 Fund-structure local-first persistence uses Storage-owned state stores. The JSON-backed store writes
 complete snapshots through `AtomicFileWriter`, and the in-memory store preserves the same snapshot

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -170,7 +170,12 @@ public static class WorkstationServiceCollectionExtensions
         services.TryAddSingleton<StrategyEngineValidationService>();
         services.TryAddSingleton<ISecurityReferenceLookup, SecurityMasterSecurityReferenceLookup>();
         services.TryAddSingleton<PortfolioReadService>();
-        services.TryAddSingleton<IAssetOperationsProjectionStore, InMemoryAssetOperationsProjectionStore>();
+        services.TryAddSingleton<InMemoryAssetOperationsProjectionStore>();
+        services.TryAddSingleton<IAssetOperationsProjectionStore>(sp =>
+            sp.GetRequiredService<InMemoryAssetOperationsProjectionStore>());
+        services.TryAddSingleton<IInstrumentPositionProjectionStore>(sp =>
+            sp.GetService<IAssetOperationsProjectionStore>() as IInstrumentPositionProjectionStore
+            ?? sp.GetRequiredService<InMemoryAssetOperationsProjectionStore>());
         services.TryAddSingleton<IAssetOperationsCommandService, AssetOperationsProjectionCommandService>();
         services.TryAddSingleton<IAssetOperationsQueryService, AssetOperationsReadService>();
         services.TryAddSingleton<IFactorPaydownProjectionService, FactorPaydownProjectionService>();

--- a/tests/Meridian.Tests/Application/Composition/StorageFeatureRegistrationTests.cs
+++ b/tests/Meridian.Tests/Application/Composition/StorageFeatureRegistrationTests.cs
@@ -18,6 +18,7 @@ using Meridian.Infrastructure.Adapters.Polygon;
 using Meridian.Infrastructure.Reconciliation;
 using Meridian.PortfolioRecords.FundAccounts;
 using Meridian.Storage.DirectLending;
+using Meridian.Storage.AssetOperations;
 using Meridian.Storage.FundAccounts;
 using Meridian.Storage.FundStructure;
 using Meridian.Storage.Interfaces;
@@ -37,6 +38,8 @@ public sealed class StorageFeatureRegistrationTests : IDisposable
     private readonly string? _originalSecurityMasterSchema;
     private readonly string? _originalDirectLendingConnectionString;
     private readonly string? _originalDirectLendingSchema;
+    private readonly string? _originalAssetOperationsConnectionString;
+    private readonly string? _originalAssetOperationsSchema;
     private readonly string? _originalLedgerConnectionString;
     private readonly string? _originalLedgerSchema;
     private readonly string? _originalFundAccountsConnectionString;
@@ -59,6 +62,8 @@ public sealed class StorageFeatureRegistrationTests : IDisposable
         _originalSecurityMasterSchema = Environment.GetEnvironmentVariable(SecurityMasterStartup.SchemaVariable);
         _originalDirectLendingConnectionString = Environment.GetEnvironmentVariable(DirectLendingStartup.ConnectionStringVariable);
         _originalDirectLendingSchema = Environment.GetEnvironmentVariable(DirectLendingStartup.SchemaVariable);
+        _originalAssetOperationsConnectionString = Environment.GetEnvironmentVariable(AssetOperationsStartup.ConnectionStringVariable);
+        _originalAssetOperationsSchema = Environment.GetEnvironmentVariable(AssetOperationsStartup.SchemaVariable);
         _originalLedgerConnectionString = Environment.GetEnvironmentVariable(LedgerStartup.ConnectionStringVariable);
         _originalLedgerSchema = Environment.GetEnvironmentVariable(LedgerStartup.SchemaVariable);
         _originalFundAccountsConnectionString = Environment.GetEnvironmentVariable(FundAccountsStartup.ConnectionStringVariable);
@@ -122,6 +127,43 @@ public sealed class StorageFeatureRegistrationTests : IDisposable
 
         services.Should().ContainSingle(sd => sd.ServiceType == typeof(StorageCatalogService));
         services.Should().ContainSingle(sd => sd.ServiceType == typeof(IStorageCatalogService));
+    }
+
+    [Fact]
+    public void Register_AliasesAssetOperationsInterfacesToSameInMemoryStore_WhenDatabaseIsNotConfigured()
+    {
+        ConfigureInMemoryGovernanceFixture();
+        ClearPostgresBackedStorageEnvironment();
+        var services = new ServiceCollection();
+
+        new StorageFeatureRegistration().Register(services, CompositionOptions.WebDashboard);
+
+        using var provider = services.BuildServiceProvider();
+        var legacyStore = provider.GetRequiredService<IAssetOperationsProjectionStore>();
+        legacyStore.Should().BeOfType<InMemoryAssetOperationsProjectionStore>();
+        provider.GetRequiredService<IInstrumentPositionProjectionStore>()
+            .Should()
+            .BeSameAs(legacyStore);
+    }
+
+    [Fact]
+    public void Register_AliasesAssetOperationsInterfacesToSamePostgresStore_WhenDatabaseIsConfigured()
+    {
+        ConfigureInMemoryGovernanceFixture();
+        ClearPostgresBackedStorageEnvironment();
+        Environment.SetEnvironmentVariable(
+            AssetOperationsStartup.ConnectionStringVariable,
+            "Host=asset-operations-db;Port=5432;Database=asset_operations;Username=postgres;Password=secret");
+        var services = new ServiceCollection();
+
+        new StorageFeatureRegistration().Register(services, CompositionOptions.WebDashboard);
+
+        using var provider = services.BuildServiceProvider();
+        var legacyStore = provider.GetRequiredService<IAssetOperationsProjectionStore>();
+        legacyStore.Should().BeOfType<PostgresAssetOperationsProjectionStore>();
+        provider.GetRequiredService<IInstrumentPositionProjectionStore>()
+            .Should()
+            .BeSameAs(legacyStore);
     }
 
     [Fact]
@@ -321,6 +363,8 @@ public sealed class StorageFeatureRegistrationTests : IDisposable
         Environment.SetEnvironmentVariable(SecurityMasterStartup.SchemaVariable, null);
         Environment.SetEnvironmentVariable(DirectLendingStartup.ConnectionStringVariable, null);
         Environment.SetEnvironmentVariable(DirectLendingStartup.SchemaVariable, null);
+        Environment.SetEnvironmentVariable(AssetOperationsStartup.ConnectionStringVariable, null);
+        Environment.SetEnvironmentVariable(AssetOperationsStartup.SchemaVariable, null);
         Environment.SetEnvironmentVariable(LedgerStartup.ConnectionStringVariable, null);
         Environment.SetEnvironmentVariable(LedgerStartup.SchemaVariable, null);
         ClearGovernancePersistenceEnvironment();
@@ -346,6 +390,8 @@ public sealed class StorageFeatureRegistrationTests : IDisposable
         Environment.SetEnvironmentVariable(SecurityMasterStartup.SchemaVariable, _originalSecurityMasterSchema);
         Environment.SetEnvironmentVariable(DirectLendingStartup.ConnectionStringVariable, _originalDirectLendingConnectionString);
         Environment.SetEnvironmentVariable(DirectLendingStartup.SchemaVariable, _originalDirectLendingSchema);
+        Environment.SetEnvironmentVariable(AssetOperationsStartup.ConnectionStringVariable, _originalAssetOperationsConnectionString);
+        Environment.SetEnvironmentVariable(AssetOperationsStartup.SchemaVariable, _originalAssetOperationsSchema);
         Environment.SetEnvironmentVariable(LedgerStartup.ConnectionStringVariable, _originalLedgerConnectionString);
         Environment.SetEnvironmentVariable(LedgerStartup.SchemaVariable, _originalLedgerSchema);
         Environment.SetEnvironmentVariable(FundAccountsStartup.ConnectionStringVariable, _originalFundAccountsConnectionString);

--- a/tests/Meridian.Tests/AssetOperations/AssetOperationsMigrationRunnerTests.cs
+++ b/tests/Meridian.Tests/AssetOperations/AssetOperationsMigrationRunnerTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Meridian.Contracts.AssetOperations;
+using Meridian.Contracts.FundStructure;
 using Meridian.Storage.AssetOperations;
 using Meridian.TestSupport;
 using Npgsql;
@@ -36,7 +37,8 @@ public sealed class AssetOperationsMigrationRunnerTests : IAsyncLifetime
     {
         var runner = new AssetOperationsMigrationRunner(_options);
 
-        await runner.EnsureMigratedAsync();
+        await Task.WhenAll(Enumerable.Range(0, 3)
+            .Select(_ => new AssetOperationsMigrationRunner(_options).EnsureMigratedAsync()));
         await runner.EnsureMigratedAsync();
 
         await using var connection = new NpgsqlConnection(_options.ConnectionString);
@@ -80,6 +82,198 @@ public sealed class AssetOperationsMigrationRunnerTests : IAsyncLifetime
         typedCommand.Parameters.AddWithValue("schema", _options.Schema);
         var typedTableCount = (long)(await typedCommand.ExecuteScalarAsync() ?? 0L);
         typedTableCount.Should().Be(3);
+
+        await using var migrationLedgerCommand = connection.CreateCommand();
+        migrationLedgerCommand.CommandText =
+            $"select count(*) from \"{_options.Schema}\".asset_operations_schema_migrations;";
+        ((long)(await migrationLedgerCommand.ExecuteScalarAsync() ?? 0L)).Should().Be(3);
+
+        await using var guardColumnCommand = connection.CreateCommand();
+        guardColumnCommand.CommandText =
+            """
+            select count(*)
+            from information_schema.columns
+            where table_schema = @schema
+              and (
+                (table_name = 'instrument_role_projections' and column_name in (
+                    'approval_rationale', 'source_domain', 'source_entity_id', 'source_content_hash'))
+                or
+                (table_name = 'book_position_projections' and column_name in (
+                    'position_side', 'position_status', 'approval_rationale', 'source_domain', 'source_entity_id',
+                    'source_content_hash', 'projection_run_id', 'projection_event_id'))
+                or
+                (table_name = 'position_economic_state_projections' and column_name in (
+                    'ledger_book_id', 'owner_scope_id', 'owner_scope_kind', 'approval_rationale',
+                    'source_domain', 'source_entity_id', 'source_content_hash',
+                    'projection_run_id', 'projection_event_id'))
+              );
+            """;
+        guardColumnCommand.Parameters.AddWithValue("schema", _options.Schema);
+        ((long)(await guardColumnCommand.ExecuteScalarAsync() ?? 0L)).Should().Be(21);
+
+        await using var constraintCommand = connection.CreateCommand();
+        constraintCommand.CommandText =
+            """
+            select count(*)
+            from information_schema.table_constraints
+            where constraint_schema = @schema
+              and constraint_name in (
+                'fk_book_position_projection_role_scope',
+                'fk_position_economic_state_position_scope');
+            """;
+        constraintCommand.Parameters.AddWithValue("schema", _options.Schema);
+        ((long)(await constraintCommand.ExecuteScalarAsync() ?? 0L)).Should().Be(2);
+
+        await using var noBalanceCommand = connection.CreateCommand();
+        noBalanceCommand.CommandText =
+            """
+            select count(*)
+            from information_schema.columns
+            where table_schema = @schema
+              and table_name in (
+                'instrument_role_projections',
+                'book_position_projections',
+                'position_economic_state_projections')
+              and column_name like '%balance%';
+            """;
+        noBalanceCommand.Parameters.AddWithValue("schema", _options.Schema);
+        ((long)(await noBalanceCommand.ExecuteScalarAsync() ?? 0L)).Should().Be(0);
+    }
+
+    [AssetOperationsDatabaseFact]
+    public async Task EnsureMigratedAsync_BackfillsSlice2TypedRowsWithoutReplacingTheirPayloads()
+    {
+        var runner = new AssetOperationsMigrationRunner(_options);
+        await runner.EnsureMigratedAsync();
+        var projection = InstrumentPositionProjectionFixture.Create();
+        var lineageOnlyState = projection.PositionEconomicStates.Single() with { SourceEvent = null };
+        projection = projection with
+        {
+            BookPositions =
+            [
+                projection.BookPositions.Single() with
+                {
+                    CurrentEconomicState = lineageOnlyState,
+                    ProjectionLineage = lineageOnlyState.ProjectionLineage
+                }
+            ],
+            PositionEconomicStates = [lineageOnlyState]
+        };
+        var store = new PostgresAssetOperationsProjectionStore(_options);
+        await store.UpsertAsync(projection, InstrumentPositionProjectionFixture.Approval);
+
+        await using (var connection = new NpgsqlConnection(_options.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var degrade = connection.CreateCommand();
+            degrade.CommandText =
+                $"""
+                alter table "{_options.Schema}"."book_position_projections"
+                    alter column position_side drop not null,
+                    alter column position_status drop not null;
+                alter table "{_options.Schema}"."position_economic_state_projections"
+                    alter column ledger_book_id drop not null,
+                    alter column owner_scope_id drop not null,
+                    alter column owner_scope_kind drop not null;
+                update "{_options.Schema}"."book_position_projections"
+                set position_side = null,
+                    position_status = null,
+                    approval_rationale = '',
+                    source_domain = null,
+                    source_entity_id = null,
+                    source_content_hash = null,
+                    projection_run_id = null,
+                    projection_event_id = null;
+                update "{_options.Schema}"."position_economic_state_projections"
+                set ledger_book_id = null,
+                    owner_scope_id = null,
+                    owner_scope_kind = null,
+                    source_event_id = null,
+                    approval_rationale = '',
+                    source_domain = null,
+                    source_entity_id = null,
+                    source_content_hash = null,
+                    projection_run_id = null,
+                    projection_event_id = null;
+                delete from "{_options.Schema}".asset_operations_schema_migrations
+                where migration_id = '003_instrument_position_projection_guards.sql';
+                """;
+            await degrade.ExecuteNonQueryAsync();
+        }
+
+        await runner.EnsureMigratedAsync();
+
+        await using var verifyConnection = new NpgsqlConnection(_options.ConnectionString);
+        await verifyConnection.OpenAsync();
+        await using var verify = verifyConnection.CreateCommand();
+        verify.CommandText =
+            $"""
+            select p.position_side,
+                   p.position_status,
+                   s.ledger_book_id,
+                   s.owner_scope_id,
+                   s.owner_scope_kind,
+                   s.source_event_id,
+                   p.payload::text,
+                   p.approval_rationale,
+                   s.approval_rationale
+            from "{_options.Schema}"."book_position_projections" p
+            join "{_options.Schema}"."position_economic_state_projections" s
+              on s.position_id = p.position_id
+            where p.position_id = @position_id;
+            """;
+        verify.Parameters.AddWithValue("position_id", InstrumentPositionProjectionFixture.PositionId);
+        await using var reader = await verify.ExecuteReaderAsync();
+        (await reader.ReadAsync()).Should().BeTrue();
+        reader.GetString(0).Should().Be(BookPositionSides.Long);
+        reader.GetString(1).Should().Be("Active");
+        reader.GetGuid(2).Should().Be(InstrumentPositionProjectionFixture.LedgerBookId);
+        reader.GetString(3).Should().Be("fund-alpha");
+        reader.GetString(4).Should().Be(FundStructureNodeKindDto.Fund.ToString());
+        reader.GetGuid(5).Should().Be(lineageOnlyState.ProjectionLineage!.TriggerEvent.EventId);
+        reader.GetString(6).Should().Contain(InstrumentPositionProjectionFixture.PositionId.ToString("D"));
+        reader.GetString(7).Should().Contain("rationale was not captured");
+        reader.GetString(8).Should().Contain("rationale was not captured");
+    }
+
+    [AssetOperationsDatabaseFact]
+    public async Task EnsureMigratedAsync_ShouldRejectConflictingLegacyProjectionRunLineage()
+    {
+        var runner = new AssetOperationsMigrationRunner(_options);
+        await runner.EnsureMigratedAsync();
+        var projection = InstrumentPositionProjectionFixture.Create();
+        var store = new PostgresAssetOperationsProjectionStore(_options);
+        await store.UpsertAsync(projection, InstrumentPositionProjectionFixture.Approval);
+
+        await using (var connection = new NpgsqlConnection(_options.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var seedConflict = connection.CreateCommand();
+            seedConflict.CommandText =
+                $"""
+                update "{_options.Schema}"."book_position_projections"
+                set projection_run_id = null,
+                    projection_event_id = null;
+                update "{_options.Schema}"."position_economic_state_projections"
+                set payload = jsonb_set(
+                        payload,
+                        array['projectionLineage', 'projectionEventId'],
+                        to_jsonb(@conflicting_event_id::text),
+                        false),
+                    projection_run_id = null,
+                    projection_event_id = null;
+                delete from "{_options.Schema}".asset_operations_schema_migrations
+                where migration_id = '003_instrument_position_projection_guards.sql';
+                """;
+            seedConflict.Parameters.AddWithValue("conflicting_event_id", Guid.NewGuid());
+            await seedConflict.ExecuteNonQueryAsync();
+        }
+
+        var act = () => runner.EnsureMigratedAsync();
+
+        var exception = await act.Should().ThrowAsync<PostgresException>();
+        exception.Which.SqlState.Should().Be(PostgresErrorCodes.CheckViolation);
+        exception.Which.MessageText.Should().Contain("conflicting retained lineage");
     }
 
 }

--- a/tests/Meridian.Tests/AssetOperations/AssetOperationsReadServiceTests.cs
+++ b/tests/Meridian.Tests/AssetOperations/AssetOperationsReadServiceTests.cs
@@ -6,6 +6,7 @@ using Meridian.Contracts.AssetOperations;
 using Meridian.Contracts.DirectLending;
 using Meridian.Contracts.FixedIncome;
 using Meridian.Contracts.SecurityMaster;
+using Meridian.Storage.AssetOperations;
 using NSubstitute;
 
 namespace Meridian.Tests.AssetOperations;
@@ -547,6 +548,150 @@ public sealed class AssetOperationsReadServiceTests
             timelineEvent.EventLane == "Handoff" &&
             timelineEvent.NextAction!.Contains("close", StringComparison.OrdinalIgnoreCase));
     }
+
+    [Fact]
+    public async Task GetOperationsAsync_ShouldMergeDurablePositionsWithoutChangingPublishedSecurityProjection()
+    {
+        var publishedProjection = InstrumentPositionProjectionFixture.Create();
+        var published = AssetOperationsProjectionBuilder.WithTermsObligationsTimeline(
+            BuildDetail(publishedProjection));
+        var expectedPublished = published;
+        var durableProjection = InstrumentPositionProjectionFixture.Advance(publishedProjection);
+        var snapshot = new InstrumentPositionProjectionSnapshot(
+            durableProjection.Subject.SecurityId,
+            durableProjection.InstrumentRoles,
+            durableProjection.BookPositions,
+            durableProjection.PositionEconomicStates,
+            durableProjection.ProjectionLineages);
+        var legacyStore = Substitute.For<IAssetOperationsProjectionStore>();
+        legacyStore.GetAsync(published.Subject.SecurityId, Arg.Any<CancellationToken>())
+            .Returns(published);
+        var positionStore = Substitute.For<IInstrumentPositionProjectionStore>();
+        positionStore.GetSecurityAsync(published.Subject.SecurityId, Arg.Any<CancellationToken>())
+            .Returns(snapshot);
+        var service = new AssetOperationsReadService(
+            projectionStore: legacyStore,
+            positionProjectionStore: positionStore);
+
+        var detail = await service.GetOperationsAsync(published.Subject.SecurityId);
+
+        detail.Should().NotBeNull();
+        detail!.Subject.Should().BeEquivalentTo(expectedPublished.Subject);
+        detail.TermsHistory.Should().BeEquivalentTo(expectedPublished.TermsHistory);
+        detail.LifecycleEvents.Should().BeEquivalentTo(expectedPublished.LifecycleEvents);
+        detail.CashFlowProjectionRuns.Should().BeEquivalentTo(expectedPublished.CashFlowProjectionRuns);
+        detail.ProjectedCashFlows.Should().BeEquivalentTo(expectedPublished.ProjectedCashFlows);
+        detail.ActualActivity.Should().BeEquivalentTo(expectedPublished.ActualActivity);
+        detail.ReconciliationRuns.Should().BeEquivalentTo(expectedPublished.ReconciliationRuns);
+        detail.ReconciliationResults.Should().BeEquivalentTo(expectedPublished.ReconciliationResults);
+        detail.LedgerProjections.Should().BeEquivalentTo(expectedPublished.LedgerProjections);
+        detail.Readiness.Should().BeEquivalentTo(expectedPublished.Readiness);
+        detail.WorkflowAudit.Should().BeEquivalentTo(expectedPublished.WorkflowAudit);
+        detail.TermsObligationsTimeline.Should().BeEquivalentTo(expectedPublished.TermsObligationsTimeline);
+        detail.InstrumentRoles.Should().BeEquivalentTo(snapshot.InstrumentRoles);
+        detail.BookPositions.Should().BeEquivalentTo(snapshot.BookPositions);
+        detail.PositionEconomicStates.Should().BeEquivalentTo(snapshot.PositionEconomicStates);
+        detail.ProjectionLineages.Should().BeEquivalentTo(snapshot.ProjectionLineages);
+    }
+
+    [Fact]
+    public async Task GetOperationsAsync_ShouldPreservePublishedTypedCollectionsWhenDedicatedStoreIsEmpty()
+    {
+        var published = BuildDetail(InstrumentPositionProjectionFixture.Create());
+        var legacyStore = Substitute.For<IAssetOperationsProjectionStore>();
+        legacyStore.GetAsync(published.Subject.SecurityId, Arg.Any<CancellationToken>())
+            .Returns(published);
+        var positionStore = Substitute.For<IInstrumentPositionProjectionStore>();
+        positionStore.GetSecurityAsync(published.Subject.SecurityId, Arg.Any<CancellationToken>())
+            .Returns(new InstrumentPositionProjectionSnapshot(published.Subject.SecurityId, [], [], [], []));
+        var service = new AssetOperationsReadService(
+            projectionStore: legacyStore,
+            positionProjectionStore: positionStore);
+
+        var detail = await service.GetOperationsAsync(published.Subject.SecurityId);
+
+        detail.Should().NotBeNull();
+        detail!.InstrumentRoles.Should().BeEquivalentTo(published.InstrumentRoles);
+        detail.BookPositions.Should().BeEquivalentTo(published.BookPositions);
+        detail.PositionEconomicStates.Should().BeEquivalentTo(published.PositionEconomicStates);
+        detail.ProjectionLineages.Should().BeEquivalentTo(published.ProjectionLineages);
+    }
+
+    [Fact]
+    public async Task GetOperationsAsync_ShouldTreatAnyDurableTypedStateAsAnAtomicProjectionReplacement()
+    {
+        var published = BuildDetail(InstrumentPositionProjectionFixture.Create());
+        var durableRole = published.InstrumentRoles.Single() with { Version = 9 };
+        var legacyStore = Substitute.For<IAssetOperationsProjectionStore>();
+        legacyStore.GetAsync(published.Subject.SecurityId, Arg.Any<CancellationToken>())
+            .Returns(published);
+        var positionStore = Substitute.For<IInstrumentPositionProjectionStore>();
+        positionStore.GetSecurityAsync(published.Subject.SecurityId, Arg.Any<CancellationToken>())
+            .Returns(new InstrumentPositionProjectionSnapshot(
+                published.Subject.SecurityId,
+                [durableRole],
+                [],
+                [],
+                []));
+        var service = new AssetOperationsReadService(
+            projectionStore: legacyStore,
+            positionProjectionStore: positionStore);
+
+        var detail = await service.GetOperationsAsync(published.Subject.SecurityId);
+
+        detail.Should().NotBeNull();
+        detail!.InstrumentRoles.Should().ContainSingle().Which.Should().BeEquivalentTo(durableRole);
+        detail.BookPositions.Should().BeEmpty();
+        detail.PositionEconomicStates.Should().BeEmpty();
+        detail.ProjectionLineages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetOperationsAsync_ShouldNotCreateDetailFromOrphanPositionProjection()
+    {
+        var projection = InstrumentPositionProjectionFixture.Create();
+        var securityMaster = Substitute.For<ISecurityMasterQueryService>();
+        securityMaster.GetByIdAsync(projection.Subject.SecurityId, Arg.Any<CancellationToken>())
+            .Returns((SecurityDetailDto?)null);
+        var positionStore = Substitute.For<IInstrumentPositionProjectionStore>();
+        positionStore.GetSecurityAsync(projection.Subject.SecurityId, Arg.Any<CancellationToken>())
+            .Returns(new InstrumentPositionProjectionSnapshot(
+                projection.Subject.SecurityId,
+                projection.InstrumentRoles,
+                projection.BookPositions,
+                projection.PositionEconomicStates,
+                projection.ProjectionLineages));
+        var service = new AssetOperationsReadService(
+            securityMasterQueryService: securityMaster,
+            positionProjectionStore: positionStore);
+
+        var detail = await service.GetOperationsAsync(projection.Subject.SecurityId);
+
+        detail.Should().BeNull();
+        await positionStore.DidNotReceive()
+            .GetSecurityAsync(projection.Subject.SecurityId, Arg.Any<CancellationToken>());
+    }
+
+    private static AssetOperationsDetailDto BuildDetail(AssetOperationsProjectionDto projection)
+        => new(
+            projection.Subject,
+            projection.TermsHistory,
+            projection.LifecycleEvents,
+            projection.CashFlowProjectionRuns,
+            projection.ProjectedCashFlows,
+            projection.ActualActivity,
+            projection.ReconciliationRuns,
+            projection.ReconciliationResults,
+            projection.LedgerProjections,
+            projection.Readiness,
+            projection.WorkflowAudit)
+        {
+            TermsObligationsTimeline = projection.TermsObligationsTimeline,
+            InstrumentRoles = projection.InstrumentRoles,
+            BookPositions = projection.BookPositions,
+            PositionEconomicStates = projection.PositionEconomicStates,
+            ProjectionLineages = projection.ProjectionLineages
+        };
 
     private static SecurityDetailDto BuildSecurity(
         Guid securityId,

--- a/tests/Meridian.Tests/AssetOperations/InMemoryInstrumentPositionProjectionStoreSlice3Tests.cs
+++ b/tests/Meridian.Tests/AssetOperations/InMemoryInstrumentPositionProjectionStoreSlice3Tests.cs
@@ -1,0 +1,701 @@
+using FluentAssertions;
+using Meridian.Contracts.AssetOperations;
+using Meridian.Contracts.FundStructure;
+using Meridian.Contracts.Ledger;
+using Meridian.Storage.AssetOperations;
+
+namespace Meridian.Tests.AssetOperations;
+
+public sealed class InMemoryInstrumentPositionProjectionStoreSlice3Tests
+{
+    private static readonly Guid SecurityId = Guid.Parse("b3000000-aaaa-4000-8000-000000000001");
+    private static readonly Guid RoleId = Guid.Parse("b3000000-aaaa-4000-8000-000000000002");
+    private static readonly Guid PositionId = Guid.Parse("b3000000-aaaa-4000-8000-000000000003");
+    private static readonly Guid LedgerBookId = Guid.Parse("b3000000-aaaa-4000-8000-000000000004");
+    private static readonly Guid OtherLedgerBookId = Guid.Parse("b3000000-aaaa-4000-8000-000000000005");
+    private static readonly DateOnly EffectiveFrom = new(2026, 1, 1);
+
+    private static AssetOperationsWriteApprovalDto Approval { get; } = new(
+        "controller@meridian.local",
+        "approval-mbs-position-2026",
+        "Approved retained MBS position projection.",
+        DateTimeOffset.Parse("2026-01-02T12:00:00Z"));
+
+    [Fact]
+    public async Task UpsertAsync_MonthlyMbsFactorSequence_EnforcesExactCasReplayAndHydratesLatestState()
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var store = new InMemoryAssetOperationsProjectionStore();
+        var role = CreateRole();
+        var firstState = CreateState(PositionId, 1, new DateOnly(2026, 1, 25), 0.9800m, 0.9625m);
+        var firstPosition = CreatePosition(role, PositionId, LedgerBookId, 1, firstState);
+
+        var invalidCreateState = CreateState(PositionId, 2, new DateOnly(2026, 1, 25), 0.9800m, 0.9625m);
+        var invalidCreate = CreatePosition(role, PositionId, LedgerBookId, 2, invalidCreateState);
+        var invalidCreateAct = () => store.UpsertAsync(
+            role,
+            invalidCreate,
+            invalidCreateState,
+            0,
+            Approval,
+            timeout.Token);
+        await invalidCreateAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*ExpectedVersion 0*Version 1*");
+
+        await store.UpsertAsync(role, firstPosition, firstState, 0, Approval, timeout.Token);
+        var secondState = CreateState(PositionId, 2, new DateOnly(2026, 2, 25), 0.9625m, 0.9500m);
+        var secondPosition = firstPosition with
+        {
+            Version = 2,
+            CurrentEconomicState = secondState,
+            ProjectionLineage = secondState.ProjectionLineage
+        };
+
+        await store.UpsertAsync(role, secondPosition, secondState, 1, Approval, timeout.Token);
+        var replay = await store.UpsertAsync(
+            role,
+            secondPosition,
+            secondState,
+            1,
+            Approval,
+            timeout.Token);
+
+        replay.Version.Should().Be(2);
+        replay.CurrentEconomicState.Should().BeEquivalentTo(secondState);
+        var staleState = CreateState(PositionId, 3, new DateOnly(2026, 3, 25), 0.9500m, 0.9400m);
+        var stalePosition = secondPosition with
+        {
+            Version = 3,
+            CurrentEconomicState = staleState,
+            ProjectionLineage = staleState.ProjectionLineage
+        };
+        var staleAct = () => store.UpsertAsync(
+            role,
+            stalePosition,
+            staleState,
+            1,
+            Approval,
+            timeout.Token);
+        await staleAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*stale*");
+
+        var persisted = await store.GetBookPositionAsync(PositionId, timeout.Token);
+        persisted.Should().NotBeNull();
+        persisted!.Version.Should().Be(2);
+        persisted.CurrentEconomicState.Should().BeEquivalentTo(secondState);
+        persisted.ProjectionLineage.Should().BeEquivalentTo(secondState.ProjectionLineage);
+        var snapshot = await store.GetSecurityAsync(SecurityId, timeout.Token);
+        snapshot.PositionEconomicStates.Should().HaveCount(2);
+        snapshot.ProjectionLineages.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetAsOfAsync_MultiBookFactorHistory_ReturnsOnlyEffectiveBookState()
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var store = new InMemoryAssetOperationsProjectionStore();
+        var role = CreateRole();
+        var firstState = CreateState(PositionId, 1, new DateOnly(2026, 1, 25), 0.9800m, 0.9625m);
+        var firstPosition = CreatePosition(
+            role,
+            PositionId,
+            LedgerBookId,
+            1,
+            firstState,
+            effectiveTo: new DateOnly(2026, 12, 31));
+        await store.UpsertAsync(role, firstPosition, firstState, 0, Approval, timeout.Token);
+
+        var futureState = CreateState(PositionId, 2, new DateOnly(2026, 10, 25), 0.9625m, 0.9400m);
+        var updatedPosition = firstPosition with
+        {
+            Version = 2,
+            CurrentEconomicState = futureState,
+            ProjectionLineage = futureState.ProjectionLineage
+        };
+        await store.UpsertAsync(role, updatedPosition, futureState, 1, Approval, timeout.Token);
+
+        var otherPositionId = Guid.Parse("b3000000-aaaa-4000-8000-000000000006");
+        var otherState = CreateState(otherPositionId, 1, new DateOnly(2026, 2, 25), 1.0000m, 0.9900m);
+        var otherPosition = CreatePosition(role, otherPositionId, OtherLedgerBookId, 1, otherState);
+        await store.UpsertAsync(role, otherPosition, otherState, 0, Approval, timeout.Token);
+
+        var asOfJune = await store.GetAsOfAsync(
+            SecurityId,
+            LedgerBookId,
+            new DateOnly(2026, 6, 30),
+            timeout.Token);
+
+        asOfJune.BookPositions.Should().ContainSingle()
+            .Which.PositionId.Should().Be(PositionId);
+        asOfJune.PositionEconomicStates.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(firstState);
+        asOfJune.BookPositions.Single().CurrentEconomicState.Should().BeEquivalentTo(firstState);
+        asOfJune.ProjectionLineages.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(firstState.ProjectionLineage);
+        asOfJune.LedgerBookId.Should().Be(LedgerBookId);
+        asOfJune.AsOfDate.Should().Be(new DateOnly(2026, 6, 30));
+
+        var afterExpiry = await store.GetAsOfAsync(
+            SecurityId,
+            LedgerBookId,
+            new DateOnly(2027, 1, 1),
+            timeout.Token);
+        afterExpiry.BookPositions.Should().BeEmpty();
+        afterExpiry.PositionEconomicStates.Should().BeEmpty();
+        afterExpiry.ProjectionLineages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task UpsertAsync_OverlappingActiveBookPosition_FailsAtomically()
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var store = new InMemoryAssetOperationsProjectionStore();
+        var role = CreateRole();
+        var firstState = CreateState(PositionId, 1, new DateOnly(2026, 1, 25), 0.9800m, 0.9625m);
+        var firstPosition = CreatePosition(role, PositionId, LedgerBookId, 1, firstState);
+        await store.UpsertAsync(role, firstPosition, firstState, 0, Approval, timeout.Token);
+
+        var overlappingPositionId = Guid.Parse("b3000000-aaaa-4000-8000-000000000007");
+        var overlappingState = CreateState(overlappingPositionId, 1, new DateOnly(2026, 2, 25), 0.9625m, 0.9500m);
+        var overlappingPosition = CreatePosition(
+            role,
+            overlappingPositionId,
+            LedgerBookId,
+            1,
+            overlappingState,
+            effectiveFrom: new DateOnly(2026, 2, 1));
+
+        var act = () => store.UpsertAsync(
+            role,
+            overlappingPosition,
+            overlappingState,
+            0,
+            Approval,
+            timeout.Token);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*overlaps active position*");
+        var snapshot = await store.GetSecurityAsync(SecurityId, timeout.Token);
+        snapshot.BookPositions.Should().ContainSingle()
+            .Which.PositionId.Should().Be(PositionId);
+        snapshot.PositionEconomicStates.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task UpsertAsync_InvalidRoleOwnerDatesDimensionsAndCrossBook_FailsClosed()
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var store = new InMemoryAssetOperationsProjectionStore();
+        var role = CreateRole();
+        var state = CreateState(PositionId, 1, new DateOnly(2026, 1, 25), 0.9800m, 0.9625m);
+        var position = CreatePosition(role, PositionId, LedgerBookId, 1, state);
+
+        var missingRolePosition = position with { RoleId = Guid.NewGuid() };
+        var missingRoleAct = () => store.UpsertAsync(
+            role,
+            missingRolePosition,
+            state,
+            0,
+            Approval,
+            timeout.Token);
+        await missingRoleAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*matching security and owner scope*");
+
+        var wrongOwnerRole = role with { OwnerScopeId = "fund-beta" };
+        var wrongOwnerAct = () => store.UpsertAsync(
+            wrongOwnerRole,
+            position,
+            state,
+            0,
+            Approval,
+            timeout.Token);
+        await wrongOwnerAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*matching security and owner scope*");
+
+        var missingProvenanceAct = () => store.UpsertAsync(
+            role with { OriginEvent = null },
+            position,
+            state,
+            0,
+            Approval,
+            timeout.Token);
+        await missingProvenanceAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*source event and evidence*");
+
+        var missingSideAct = () => store.UpsertAsync(
+            role with { AccountingSide = string.Empty },
+            position,
+            state,
+            0,
+            Approval,
+            timeout.Token);
+        await missingSideAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*role projections require*");
+
+        var invalidDates = position with { EffectiveTo = EffectiveFrom.AddDays(-1) };
+        var invalidDatesAct = () => store.UpsertAsync(
+            role,
+            invalidDates,
+            state,
+            0,
+            Approval,
+            timeout.Token);
+        await invalidDatesAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*end dates cannot precede start dates*");
+
+        var mismatchedDimensions = position with
+        {
+            BookContext = position.BookContext with
+            {
+                Dimensions = position.BookContext.Dimensions! with { InstrumentId = Guid.NewGuid() }
+            }
+        };
+        var dimensionsAct = () => store.UpsertAsync(
+            role,
+            mismatchedDimensions,
+            state,
+            0,
+            Approval,
+            timeout.Token);
+        await dimensionsAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*dimensions conflict*");
+
+        var mismatchedVersionState = state with { Version = 2 };
+        var stateVersionAct = () => store.UpsertAsync(
+            role,
+            position with { CurrentEconomicState = null },
+            mismatchedVersionState,
+            0,
+            Approval,
+            timeout.Token);
+        await stateVersionAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*same version*");
+
+        var invalidSourceState = state with
+        {
+            SourceEvent = state.SourceEvent! with { EventId = Guid.Empty }
+        };
+        var invalidSourceAct = () => store.UpsertAsync(
+            role,
+            position with { CurrentEconomicState = invalidSourceState },
+            invalidSourceState,
+            0,
+            Approval,
+            timeout.Token);
+        await invalidSourceAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*event or projection lineage crosses*");
+
+        await store.UpsertAsync(role, position, state, 0, Approval, timeout.Token);
+        var caseState = CreateState(PositionId, 2, new DateOnly(2026, 2, 25), 0.9625m, 0.9500m);
+        var caseRole = role with { OwnerScopeId = "FUND-ALPHA", Version = 2 };
+        var casePosition = CreatePosition(caseRole, PositionId, LedgerBookId, 2, caseState);
+        var caseChangeAct = () => store.UpsertAsync(
+            caseRole,
+            casePosition,
+            caseState,
+            1,
+            Approval,
+            timeout.Token);
+        await caseChangeAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*cannot change security, owner scope, or role kind*");
+
+        var otherBookState = CreateState(PositionId, 2, new DateOnly(2026, 2, 25), 0.9625m, 0.9500m);
+        var otherBookPosition = CreatePosition(role, PositionId, OtherLedgerBookId, 2, otherBookState);
+        var crossBookAct = () => store.UpsertAsync(
+            role,
+            otherBookPosition,
+            otherBookState,
+            1,
+            Approval,
+            timeout.Token);
+        await crossBookAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*ledger-book boundary*");
+
+        var persisted = await store.GetBookPositionAsync(PositionId, timeout.Token);
+        persisted!.BookContext.LedgerBookId.Should().Be(LedgerBookId);
+        persisted.Version.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task LegacyUpsert_DuplicateEconomicStateVersionWithNewIdentity_IsRejectedAtomically()
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var store = new InMemoryAssetOperationsProjectionStore();
+        var projection = InstrumentPositionProjectionFixture.Create();
+        await store.UpsertAsync(projection, InstrumentPositionProjectionFixture.Approval, timeout.Token);
+        var persistedPosition = projection.BookPositions.Single();
+        var persistedState = projection.PositionEconomicStates.Single();
+        var conflictingState = persistedState with
+        {
+            EconomicStateId = Guid.NewGuid(),
+            CurrentFactor = persistedState.CurrentFactor - 0.001m
+        };
+        var conflictingPosition = persistedPosition with
+        {
+            Version = persistedPosition.Version + 1,
+            CurrentEconomicState = conflictingState,
+            ProjectionLineage = conflictingState.ProjectionLineage
+        };
+        var conflictingProjection = projection with
+        {
+            BookPositions = [conflictingPosition],
+            PositionEconomicStates = [conflictingState]
+        };
+
+        var act = () => store.UpsertAsync(
+            conflictingProjection,
+            InstrumentPositionProjectionFixture.Approval,
+            timeout.Token);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*version*already exists*");
+        var persisted = await store.GetBookPositionAsync(InstrumentPositionProjectionFixture.PositionId, timeout.Token);
+        persisted!.Version.Should().Be(4);
+        var snapshot = await store.GetSecurityAsync(InstrumentPositionProjectionFixture.SecurityId, timeout.Token);
+        snapshot.PositionEconomicStates.Should().ContainSingle()
+            .Which.EconomicStateId.Should().Be(persistedState.EconomicStateId);
+    }
+
+    [Fact]
+    public async Task LegacyUpsert_ImportedVersionAndEmptyCompatibilityWrite_RemainVisibleToDedicatedQueries()
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var store = new InMemoryAssetOperationsProjectionStore();
+        var projection = InstrumentPositionProjectionFixture.Create();
+
+        await store.UpsertAsync(projection, InstrumentPositionProjectionFixture.Approval, timeout.Token);
+        await store.UpsertAsync(projection with
+        {
+            InstrumentRoles = [],
+            BookPositions = [],
+            PositionEconomicStates = [],
+            ProjectionLineages = []
+        }, InstrumentPositionProjectionFixture.Approval, timeout.Token);
+        var advanced = InstrumentPositionProjectionFixture.Advance(projection);
+        await store.UpsertAsync(advanced, InstrumentPositionProjectionFixture.Approval, timeout.Token);
+
+        var snapshot = await store.GetSecurityAsync(
+            InstrumentPositionProjectionFixture.SecurityId,
+            timeout.Token);
+        snapshot.InstrumentRoles.Should().ContainSingle();
+        snapshot.BookPositions.Should().ContainSingle()
+            .Which.Version.Should().Be(5);
+        snapshot.BookPositions.Single().CurrentEconomicState!.Version.Should().Be(6);
+        snapshot.PositionEconomicStates.Should().HaveCount(2);
+        snapshot.ProjectionLineages.Should().HaveCount(2);
+        var legacy = await store.GetAsync(InstrumentPositionProjectionFixture.SecurityId, timeout.Token);
+        legacy.Should().NotBeNull();
+        legacy!.BookPositions.Should().BeEquivalentTo(snapshot.BookPositions);
+        legacy.PositionEconomicStates.Should().BeEquivalentTo(snapshot.PositionEconomicStates);
+    }
+
+    [Fact]
+    public async Task DedicatedUpsert_ConflictingStateAndLineageInputs_FailClosedAndReplayKeepsApproval()
+    {
+        var store = new InMemoryAssetOperationsProjectionStore();
+        var role = CreateRole();
+        var state = CreateState(PositionId, 1, new DateOnly(2026, 1, 25), 0.9800m, 0.9625m);
+        var position = CreatePosition(role, PositionId, LedgerBookId, 1, state);
+        var conflictingState = state with { CurrentFactor = 0.9500m };
+
+        var conflictingWrite = () => store.UpsertAsync(
+            role,
+            position,
+            conflictingState,
+            expectedVersion: 0,
+            Approval);
+        await conflictingWrite.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*embedded and explicit economic states*");
+
+        var crossedLineage = state.ProjectionLineage! with { BookPositionId = Guid.NewGuid() };
+        var crossedPosition = position with
+        {
+            CurrentEconomicState = null,
+            ProjectionLineage = crossedLineage
+        };
+        var crossedWrite = () => store.UpsertAsync(
+            role,
+            crossedPosition,
+            null,
+            expectedVersion: 0,
+            Approval);
+        await crossedWrite.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*crosses the book-position*");
+
+        await store.UpsertAsync(role, position, state, expectedVersion: 0, Approval);
+        var replayApproval = Approval with
+        {
+            Actor = "replay-controller@meridian.local",
+            ApprovalReference = "replay-approval"
+        };
+        await store.UpsertAsync(role, position, state, expectedVersion: 0, replayApproval);
+
+        store.GetRetainedProjectionApproval(PositionId).Should().BeEquivalentTo(Approval);
+        store.GetRetainedProjectionApproval(state.EconomicStateId).Should().BeEquivalentTo(Approval);
+    }
+
+    [Fact]
+    public async Task LegacyUpsert_CrossSecurityIsRejectedWhileSparseImportedVersionsRemainCompatible()
+    {
+        var store = new InMemoryAssetOperationsProjectionStore();
+        var projection = InstrumentPositionProjectionFixture.Create();
+        var crossedRole = projection.InstrumentRoles.Single() with { SecurityId = Guid.NewGuid() };
+        var crossed = projection with
+        {
+            InstrumentRoles = [crossedRole],
+            BookPositions = [],
+            PositionEconomicStates = [],
+            ProjectionLineages = []
+        };
+
+        var crossedWrite = () => store.UpsertAsync(crossed, InstrumentPositionProjectionFixture.Approval);
+        await crossedWrite.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*subject Security Master identity*");
+        (await store.GetSecurityAsync(crossedRole.SecurityId)).BookPositions.Should().BeEmpty();
+
+        await store.UpsertAsync(projection, InstrumentPositionProjectionFixture.Approval);
+        var persistedPosition = projection.BookPositions.Single();
+        var jumpedState = projection.PositionEconomicStates.Single() with
+        {
+            EconomicStateId = Guid.NewGuid(),
+            Version = persistedPosition.Version + 3
+        };
+        var jumpedPosition = persistedPosition with
+        {
+            Version = persistedPosition.Version + 2,
+            CurrentEconomicState = jumpedState,
+            ProjectionLineage = jumpedState.ProjectionLineage
+        };
+        var jumped = projection with
+        {
+            InstrumentRoles = [projection.InstrumentRoles.Single() with { Version = 4 }],
+            BookPositions = [jumpedPosition],
+            PositionEconomicStates = [jumpedState]
+        };
+
+        await store.UpsertAsync(jumped, InstrumentPositionProjectionFixture.Approval);
+        var sparse = await store.GetBookPositionAsync(persistedPosition.PositionId);
+        sparse!.Version.Should().Be(jumpedPosition.Version);
+        sparse.CurrentEconomicState!.Version.Should().Be(jumpedState.Version);
+        (await store.GetSecurityAsync(projection.Subject.SecurityId)).InstrumentRoles.Single().Version
+            .Should().Be(4);
+    }
+
+    [Fact]
+    public async Task InMemoryStore_ShouldDefensivelyCloneRetainedEvidenceOnWriteAndRead()
+    {
+        var store = new InMemoryAssetOperationsProjectionStore();
+        var roleEvidence = new List<string> { "evidence://role/original" };
+        var stateEvidence = new List<string> { "evidence://state/original" };
+        var role = CreateRole() with { EvidenceLinks = roleEvidence };
+        var state = CreateState(PositionId, 1, new DateOnly(2026, 1, 25), 0.9800m, 0.9625m) with
+        {
+            EvidenceLinks = stateEvidence
+        };
+        var position = CreatePosition(role, PositionId, LedgerBookId, 1, state);
+
+        await store.UpsertAsync(role, position, state, expectedVersion: 0, Approval);
+        roleEvidence[0] = "evidence://role/tampered-after-write";
+        stateEvidence[0] = "evidence://state/tampered-after-write";
+
+        var firstRead = await store.GetSecurityAsync(SecurityId);
+        firstRead.InstrumentRoles.Single().EvidenceLinks.Should().Equal("evidence://role/original");
+        firstRead.PositionEconomicStates.Single().EvidenceLinks.Should().Equal("evidence://state/original");
+        var returnedEvidence = firstRead.InstrumentRoles.Single().EvidenceLinks.Should()
+            .BeAssignableTo<IList<string>>().Subject;
+        returnedEvidence[0] = "evidence://role/tampered-after-read";
+
+        var secondRead = await store.GetSecurityAsync(SecurityId);
+        secondRead.InstrumentRoles.Single().EvidenceLinks.Should().Equal("evidence://role/original");
+    }
+
+    [Fact]
+    public async Task DedicatedUpsert_UnknownActiveStatusAndWindowShrink_CannotBypassGuards()
+    {
+        var store = new InMemoryAssetOperationsProjectionStore();
+        var role = CreateRole();
+        var firstState = CreateState(PositionId, 1, new DateOnly(2026, 1, 25), 0.9800m, 0.9625m);
+        var first = CreatePosition(role, PositionId, LedgerBookId, 1, firstState);
+        await store.UpsertAsync(role, first, firstState, expectedVersion: 0, Approval);
+        var secondState = CreateState(PositionId, 2, new DateOnly(2026, 2, 25), 0.9625m, 0.9500m);
+        var second = first with
+        {
+            Version = 2,
+            CurrentEconomicState = secondState,
+            ProjectionLineage = secondState.ProjectionLineage
+        };
+        await store.UpsertAsync(role, second, secondState, expectedVersion: 1, Approval);
+
+        var shrink = second with
+        {
+            Version = 3,
+            EffectiveTo = new DateOnly(2026, 1, 31),
+            CurrentEconomicState = null,
+            ProjectionLineage = null
+        };
+        var shrinkWrite = () => store.UpsertAsync(role, shrink, null, expectedVersion: 2, Approval);
+        await shrinkWrite.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*inside the book position effective window*");
+
+        var typoPositionId = Guid.NewGuid();
+        var typoState = CreateState(typoPositionId, 1, new DateOnly(2026, 3, 25), 0.9500m, 0.9400m);
+        var typoPosition = CreatePosition(role, typoPositionId, LedgerBookId, 1, typoState) with
+        {
+            Status = "Actve"
+        };
+        var typoWrite = () => store.UpsertAsync(
+            role,
+            typoPosition,
+            typoState,
+            expectedVersion: 0,
+            Approval);
+        await typoWrite.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*overlaps active position*");
+
+        var closedPositionId = Guid.NewGuid();
+        var closedState = CreateState(closedPositionId, 1, new DateOnly(2026, 3, 25), 0.9500m, 0.9400m);
+        var closedPosition = CreatePosition(role, closedPositionId, LedgerBookId, 1, closedState) with
+        {
+            Status = "Closed"
+        };
+        await store.UpsertAsync(role, closedPosition, closedState, expectedVersion: 0, Approval);
+        (await store.GetSecurityAsync(SecurityId)).BookPositions.Should().HaveCount(2);
+    }
+
+    private static InstrumentRoleDto CreateRole(
+        DateOnly? effectiveFrom = null,
+        DateOnly? effectiveTo = null)
+    {
+        var start = effectiveFrom ?? EffectiveFrom;
+        var originEvent = new EconomicEventReferenceDto(
+            Guid.NewGuid(),
+            "PositionRoleEstablished",
+            1,
+            start,
+            new DateTimeOffset(start.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero),
+            "AssetOperations",
+            $"role-{RoleId:D}",
+            SourceContentHash: $"sha256:role-{RoleId:D}",
+            EvidenceLinks: ["evidence://position/holder"])
+        {
+            SecurityId = SecurityId
+        };
+        return new InstrumentRoleDto(
+            RoleId,
+            SecurityId,
+            "fund-alpha",
+            "Fund",
+            InstrumentRoleKinds.Holder,
+            InstrumentAccountingSides.Debit,
+            InstrumentEconomicSides.Asset,
+            start,
+            effectiveTo,
+            Version: 1,
+            OriginEvent: originEvent,
+            EvidenceLinks: ["evidence://position/holder"]);
+    }
+
+    private static BookPositionDto CreatePosition(
+        InstrumentRoleDto role,
+        Guid positionId,
+        Guid ledgerBookId,
+        long version,
+        PositionEconomicStateDto state,
+        DateOnly? effectiveFrom = null,
+        DateOnly? effectiveTo = null)
+    {
+        var dimensions = new LedgerDimensionSetDto(
+            role.OwnerScopeId,
+            "entity-alpha",
+            InstrumentId: role.SecurityId,
+            BookId: ledgerBookId.ToString("D"))
+        {
+            PositionId = positionId
+        };
+        var context = new AccountingBookContextDto(
+            ledgerBookId,
+            role.OwnerScopeId,
+            Guid.Parse("b3000000-aaaa-4000-8000-000000000008"),
+            FundStructureNodeKindDto.Fund,
+            "Fund Alpha GAAP",
+            "USD",
+            AccountingBasisKindDto.Gaap,
+            "gaap-mbs-v1",
+            "v1",
+            Dimensions: dimensions);
+
+        return new BookPositionDto(
+            positionId,
+            role.SecurityId,
+            role.RoleId,
+            context,
+            BookPositionSides.Long,
+            "Active",
+            effectiveFrom ?? EffectiveFrom,
+            effectiveTo,
+            version,
+            "Securities",
+            state,
+            OriginEvent: state.SourceEvent,
+            ProjectionLineage: state.ProjectionLineage,
+            EvidenceLinks: ["evidence://position/holder"]);
+    }
+
+    private static PositionEconomicStateDto CreateState(
+        Guid positionId,
+        long version,
+        DateOnly asOfDate,
+        decimal priorFactor,
+        decimal currentFactor)
+    {
+        var eventId = Guid.NewGuid();
+        var economicEvent = new EconomicEventReferenceDto(
+            eventId,
+            "MbsFactorPaydown",
+            version,
+            asOfDate,
+            new DateTimeOffset(asOfDate.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero),
+            "SecurityMaster",
+            $"factor-row-{asOfDate:yyyy-MM-dd}",
+            SourceContentHash: $"sha256:factor-{asOfDate:yyyy-MM-dd}",
+            EvidenceLinks: [$"evidence://factor/{asOfDate:yyyy-MM-dd}"])
+        {
+            SecurityId = SecurityId,
+            BookPositionId = positionId
+        };
+        var lineage = new ProjectionLineageDto(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "mbs-factor-paydown",
+            "1.0.0",
+            "factor-paydown-projection-v1",
+            "Base",
+            asOfDate,
+            economicEvent.OccurredAtUtc,
+            "SecurityMaster",
+            economicEvent.SourceEntityId,
+            economicEvent,
+            TermsHash: economicEvent.SourceContentHash,
+            EvidenceLinks: economicEvent.EvidenceLinks)
+        {
+            BookPositionId = positionId
+        };
+
+        return new PositionEconomicStateDto(
+            Guid.NewGuid(),
+            positionId,
+            asOfDate,
+            "USD",
+            version,
+            ParAmount: 100_000m,
+            OriginalFaceAmount: 100_000m,
+            CurrentFaceAmount: decimal.Round(100_000m * currentFactor, 2),
+            PriorFactor: priorFactor,
+            CurrentFactor: currentFactor,
+            SourceEvent: economicEvent,
+            EvidenceLinks: economicEvent.EvidenceLinks)
+        {
+            ProjectionLineage = lineage
+        };
+    }
+}

--- a/tests/Meridian.Tests/AssetOperations/InstrumentPositionProjectionStoreTests.cs
+++ b/tests/Meridian.Tests/AssetOperations/InstrumentPositionProjectionStoreTests.cs
@@ -26,6 +26,17 @@ public sealed class InMemoryInstrumentPositionProjectionStoreTests
             ProjectionLineages = []
         }, InstrumentPositionProjectionFixture.Approval);
         var advanced = InstrumentPositionProjectionFixture.Advance(projection);
+        var lineageOnlyState = advanced.PositionEconomicStates.Single() with { SourceEvent = null };
+        var lineageOnlyPosition = advanced.BookPositions.Single() with
+        {
+            CurrentEconomicState = lineageOnlyState,
+            ProjectionLineage = lineageOnlyState.ProjectionLineage
+        };
+        advanced = advanced with
+        {
+            BookPositions = [lineageOnlyPosition],
+            PositionEconomicStates = [lineageOnlyState]
+        };
         await store.UpsertAsync(advanced, InstrumentPositionProjectionFixture.Approval);
 
         var persisted = await store.GetAsync(InstrumentPositionProjectionFixture.SecurityId);
@@ -92,6 +103,17 @@ public sealed class PostgresInstrumentPositionProjectionStoreTests : IAsyncLifet
             ProjectionLineages = []
         }, InstrumentPositionProjectionFixture.Approval);
         var advanced = InstrumentPositionProjectionFixture.Advance(projection);
+        var lineageOnlyState = advanced.PositionEconomicStates.Single() with { SourceEvent = null };
+        var lineageOnlyPosition = advanced.BookPositions.Single() with
+        {
+            CurrentEconomicState = lineageOnlyState,
+            ProjectionLineage = lineageOnlyState.ProjectionLineage
+        };
+        advanced = advanced with
+        {
+            BookPositions = [lineageOnlyPosition],
+            PositionEconomicStates = [lineageOnlyState]
+        };
         await store.UpsertAsync(advanced, InstrumentPositionProjectionFixture.Approval);
 
         var persisted = await store.GetAsync(InstrumentPositionProjectionFixture.SecurityId);
@@ -101,10 +123,18 @@ public sealed class PostgresInstrumentPositionProjectionStoreTests : IAsyncLifet
         persisted.PositionEconomicStates.Should().HaveCount(2);
         persisted.ProjectionLineages.Should().HaveCount(2);
         persisted.PositionEconomicStates.Should().OnlyContain(state => state.ProjectionLineage != null);
+
+        await using var connection = new NpgsqlConnection(_options.ConnectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            $"select source_event_id from \"{_options.Schema}\".\"position_economic_state_projections\" where economic_state_id = @state_id;";
+        command.Parameters.AddWithValue("state_id", lineageOnlyState.EconomicStateId);
+        (await command.ExecuteScalarAsync()).Should().Be(lineageOnlyState.ProjectionLineage!.TriggerEvent.EventId);
     }
 
     [AssetOperationsDatabaseFact]
-    public async Task UpsertAsync_ShouldRejectPositionOwnershipChangesAndPreserveReplayApproval()
+    public async Task UpsertAsync_ShouldRejectPositionOwnershipChangesPreserveReplayApprovalAndAllowSparseImports()
     {
         await new AssetOperationsMigrationRunner(_options).EnsureMigratedAsync();
         var store = new PostgresAssetOperationsProjectionStore(_options);
@@ -146,7 +176,405 @@ public sealed class PostgresInstrumentPositionProjectionStoreTests : IAsyncLifet
         var act = () => store.UpsertAsync(conflicting, InstrumentPositionProjectionFixture.Approval);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*stale or conflicts*");
+            .WithMessage("*immutable*");
+
+        var jumpedPosition = originalPosition with
+        {
+            Version = originalPosition.Version + 2,
+            CurrentEconomicState = null,
+            ProjectionLineage = null
+        };
+        var jumped = projection with
+        {
+            InstrumentRoles = [projection.InstrumentRoles.Single() with { Version = 4 }],
+            BookPositions = [jumpedPosition],
+            PositionEconomicStates = [],
+            ProjectionLineages = []
+        };
+        await store.UpsertAsync(jumped, InstrumentPositionProjectionFixture.Approval);
+        var sparse = await store.GetBookPositionAsync(jumpedPosition.PositionId);
+        sparse!.Version.Should().Be(jumpedPosition.Version);
+        sparse.CurrentEconomicState!.EconomicStateId.Should()
+            .Be(projection.PositionEconomicStates.Single().EconomicStateId);
+        (await store.GetSecurityAsync(projection.Subject.SecurityId)).InstrumentRoles.Single().Version
+            .Should().Be(4);
+    }
+
+    [AssetOperationsDatabaseFact]
+    public async Task DedicatedStore_ShouldApplyExpectedVersionAndPreserveIdempotentReplay()
+    {
+        await new AssetOperationsMigrationRunner(_options).EnsureMigratedAsync();
+        var store = new PostgresAssetOperationsProjectionStore(_options);
+        var initial = InstrumentPositionProjectionFixture.CreateStrict();
+
+        var created = await store.UpsertAsync(
+            initial.Role,
+            initial.Position,
+            initial.State,
+            expectedVersion: 0,
+            InstrumentPositionProjectionFixture.Approval);
+        var replayed = await store.UpsertAsync(
+            initial.Role,
+            initial.Position,
+            initial.State,
+            expectedVersion: 0,
+            InstrumentPositionProjectionFixture.Approval with
+            {
+                Actor = "replay-controller@meridian.local",
+                ApprovalReference = "replay-approval"
+            });
+
+        await using (var replayConnection = new NpgsqlConnection(_options.ConnectionString))
+        {
+            await replayConnection.OpenAsync();
+            await using var replayApproval = replayConnection.CreateCommand();
+            replayApproval.CommandText =
+                $"""
+                select approval_actor = @actor
+                   and approval_reference = @reference
+                   and approval_rationale = @rationale
+                   and approved_at = @approved_at
+                from "{_options.Schema}"."book_position_projections"
+                where position_id = @position_id;
+                """;
+            replayApproval.Parameters.AddWithValue("actor", InstrumentPositionProjectionFixture.Approval.Actor);
+            replayApproval.Parameters.AddWithValue("reference", InstrumentPositionProjectionFixture.Approval.ApprovalReference);
+            replayApproval.Parameters.AddWithValue("rationale", InstrumentPositionProjectionFixture.Approval.Rationale);
+            replayApproval.Parameters.AddWithValue("approved_at", InstrumentPositionProjectionFixture.Approval.ApprovedAt);
+            replayApproval.Parameters.AddWithValue("position_id", InstrumentPositionProjectionFixture.PositionId);
+            (await replayApproval.ExecuteScalarAsync()).Should().Be(true);
+        }
+
+        var advanced = InstrumentPositionProjectionFixture.AdvanceStrict(initial);
+        var updated = await store.UpsertAsync(
+            advanced.Role,
+            advanced.Position,
+            advanced.State,
+            expectedVersion: 1,
+            InstrumentPositionProjectionFixture.Approval);
+
+        created.Version.Should().Be(1);
+        replayed.Should().BeEquivalentTo(created);
+        updated.Version.Should().Be(2);
+        updated.CurrentEconomicState.Should().BeEquivalentTo(advanced.State);
+
+        var replayWithStaleExpectedVersion = () => store.UpsertAsync(
+            advanced.Role,
+            advanced.Position,
+            advanced.State,
+            expectedVersion: 0,
+            InstrumentPositionProjectionFixture.Approval);
+        await replayWithStaleExpectedVersion.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*stale*");
+
+        var stale = () => store.UpsertAsync(
+            advanced.Role,
+            advanced.Position with { Version = 3 },
+            advanced.State with { Version = 3 },
+            expectedVersion: 1,
+            InstrumentPositionProjectionFixture.Approval);
+        await stale.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*stale*");
+
+        await using var connection = new NpgsqlConnection(_options.ConnectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            $"select approval_actor from \"{_options.Schema}\".\"book_position_projections\" where position_id = @position_id;";
+        command.Parameters.AddWithValue("position_id", InstrumentPositionProjectionFixture.PositionId);
+        (await command.ExecuteScalarAsync()).Should().Be(InstrumentPositionProjectionFixture.Approval.Actor);
+    }
+
+    [AssetOperationsDatabaseFact]
+    public async Task DedicatedStore_ShouldRejectProjectionRunReuseWithConflictingRetainedLineage()
+    {
+        await new AssetOperationsMigrationRunner(_options).EnsureMigratedAsync();
+        var store = new PostgresAssetOperationsProjectionStore(_options);
+        var initial = InstrumentPositionProjectionFixture.CreateStrict();
+        await store.UpsertAsync(
+            initial.Role,
+            initial.Position,
+            initial.State,
+            expectedVersion: 0,
+            InstrumentPositionProjectionFixture.Approval);
+        var advanced = InstrumentPositionProjectionFixture.AdvanceStrict(initial);
+        var conflictingLineage = advanced.State.ProjectionLineage! with
+        {
+            ProjectionRunId = initial.State.ProjectionLineage!.ProjectionRunId
+        };
+        var conflictingState = advanced.State with { ProjectionLineage = conflictingLineage };
+        var conflictingPosition = advanced.Position with
+        {
+            CurrentEconomicState = conflictingState,
+            ProjectionLineage = conflictingLineage
+        };
+
+        var act = () => store.UpsertAsync(
+            advanced.Role,
+            conflictingPosition,
+            conflictingState,
+            expectedVersion: 1,
+            InstrumentPositionProjectionFixture.Approval);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*cannot be reused with conflicting lineage*");
+        var persisted = await store.GetBookPositionAsync(initial.Position.PositionId);
+        persisted!.Version.Should().Be(1);
+        (await store.GetSecurityAsync(initial.Position.SecurityId))
+            .PositionEconomicStates.Should().ContainSingle();
+    }
+
+    [AssetOperationsDatabaseFact]
+    public async Task DedicatedStore_ShouldQueryEffectiveBookStateAfterRestartAndRejectOverlap()
+    {
+        await new AssetOperationsMigrationRunner(_options).EnsureMigratedAsync();
+        var writer = new PostgresAssetOperationsProjectionStore(_options);
+        var initial = InstrumentPositionProjectionFixture.CreateStrict();
+        await writer.UpsertAsync(
+            initial.Role,
+            initial.Position,
+            initial.State,
+            expectedVersion: 0,
+            InstrumentPositionProjectionFixture.Approval);
+        var advanced = InstrumentPositionProjectionFixture.AdvanceStrict(initial);
+        await writer.UpsertAsync(
+            advanced.Role,
+            advanced.Position,
+            advanced.State,
+            expectedVersion: 1,
+            InstrumentPositionProjectionFixture.Approval);
+
+        var restarted = new PostgresAssetOperationsProjectionStore(_options);
+        var asOf = await restarted.GetAsOfAsync(
+            InstrumentPositionProjectionFixture.SecurityId,
+            InstrumentPositionProjectionFixture.LedgerBookId,
+            new DateOnly(2026, 5, 31));
+        var beforeFirstProjection = await restarted.GetAsOfAsync(
+            InstrumentPositionProjectionFixture.SecurityId,
+            InstrumentPositionProjectionFixture.LedgerBookId,
+            new DateOnly(2026, 5, 1));
+        var byId = await restarted.GetBookPositionAsync(InstrumentPositionProjectionFixture.PositionId);
+        var history = await restarted.GetSecurityAsync(InstrumentPositionProjectionFixture.SecurityId);
+
+        asOf.BookPositions.Should().ContainSingle();
+        asOf.PositionEconomicStates.Should().ContainSingle()
+            .Which.EconomicStateId.Should().Be(initial.State.EconomicStateId);
+        asOf.BookPositions.Single().CurrentEconomicState.Should().BeEquivalentTo(initial.State);
+        beforeFirstProjection.BookPositions.Should().ContainSingle();
+        beforeFirstProjection.BookPositions.Single().CurrentEconomicState.Should().BeNull();
+        beforeFirstProjection.BookPositions.Single().ProjectionLineage.Should().BeNull();
+        beforeFirstProjection.PositionEconomicStates.Should().BeEmpty();
+        beforeFirstProjection.ProjectionLineages.Should().BeEmpty();
+        byId.Should().NotBeNull();
+        byId!.CurrentEconomicState.Should().BeEquivalentTo(advanced.State);
+        history.PositionEconomicStates.Should().HaveCount(2);
+        history.ProjectionLineages.Should().HaveCount(2);
+
+        var overlapping = initial.Position with
+        {
+            PositionId = Guid.Parse("a3000000-aaaa-4000-8000-000000000099"),
+            Version = 1,
+            CurrentEconomicState = null,
+            OriginEvent = initial.Position.OriginEvent! with
+            {
+                EventId = Guid.NewGuid(),
+                BookPositionId = Guid.Parse("a3000000-aaaa-4000-8000-000000000099")
+            },
+            ProjectionLineage = null,
+            BookContext = initial.Position.BookContext with
+            {
+                Dimensions = initial.Position.BookContext.Dimensions! with
+                {
+                    PositionId = Guid.Parse("a3000000-aaaa-4000-8000-000000000099")
+                }
+            }
+        };
+        var overlapWrite = () => restarted.UpsertAsync(
+            initial.Role,
+            overlapping,
+            null,
+            expectedVersion: 0,
+            InstrumentPositionProjectionFixture.Approval);
+        await overlapWrite.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*overlaps active position*");
+
+        var closedPosition = overlapping with
+        {
+            PositionId = Guid.Parse("a3000000-aaaa-4000-8000-000000000098"),
+            Status = "Closed",
+            OriginEvent = overlapping.OriginEvent! with
+            {
+                EventId = Guid.NewGuid(),
+                BookPositionId = Guid.Parse("a3000000-aaaa-4000-8000-000000000098")
+            },
+            BookContext = overlapping.BookContext with
+            {
+                Dimensions = overlapping.BookContext.Dimensions! with
+                {
+                    PositionId = Guid.Parse("a3000000-aaaa-4000-8000-000000000098")
+                }
+            }
+        };
+        await restarted.UpsertAsync(
+            initial.Role,
+            closedPosition,
+            null,
+            expectedVersion: 0,
+            InstrumentPositionProjectionFixture.Approval);
+        (await restarted.GetSecurityAsync(InstrumentPositionProjectionFixture.SecurityId))
+            .BookPositions.Should().HaveCount(2);
+    }
+
+    [AssetOperationsDatabaseFact]
+    public async Task GenericStore_DuplicateEconomicStateVersion_ShouldRollBackPositionAndApprovalChanges()
+    {
+        await new AssetOperationsMigrationRunner(_options).EnsureMigratedAsync();
+        var store = new PostgresAssetOperationsProjectionStore(_options);
+        var projection = InstrumentPositionProjectionFixture.Create();
+        await store.UpsertAsync(projection, InstrumentPositionProjectionFixture.Approval);
+        var persistedPosition = projection.BookPositions.Single();
+        var persistedState = projection.PositionEconomicStates.Single();
+        var conflictingState = persistedState with
+        {
+            EconomicStateId = Guid.NewGuid(),
+            CurrentFactor = persistedState.CurrentFactor - 0.001m
+        };
+        var conflictingPosition = persistedPosition with
+        {
+            Version = persistedPosition.Version + 1,
+            CurrentEconomicState = conflictingState,
+            ProjectionLineage = conflictingState.ProjectionLineage
+        };
+        var conflictingApproval = InstrumentPositionProjectionFixture.Approval with
+        {
+            Actor = "other-controller@meridian.local",
+            ApprovalReference = "approval-that-must-roll-back"
+        };
+
+        var act = () => store.UpsertAsync(
+            projection with
+            {
+                BookPositions = [conflictingPosition],
+                PositionEconomicStates = [conflictingState]
+            },
+            conflictingApproval);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*already has economic state version*");
+        var persisted = await store.GetBookPositionAsync(persistedPosition.PositionId);
+        persisted!.Version.Should().Be(persistedPosition.Version);
+        persisted.CurrentEconomicState!.EconomicStateId.Should().Be(persistedState.EconomicStateId);
+        var snapshot = await store.GetSecurityAsync(projection.Subject.SecurityId);
+        snapshot.PositionEconomicStates.Should().ContainSingle();
+
+        await using var connection = new NpgsqlConnection(_options.ConnectionString);
+        await connection.OpenAsync();
+        await using var approval = connection.CreateCommand();
+        approval.CommandText =
+            $"select approval_reference from \"{_options.Schema}\".\"book_position_projections\" where position_id = @position_id;";
+        approval.Parameters.AddWithValue("position_id", persistedPosition.PositionId);
+        (await approval.ExecuteScalarAsync()).Should().Be(InstrumentPositionProjectionFixture.Approval.ApprovalReference);
+    }
+
+    [AssetOperationsDatabaseFact]
+    public async Task DedicatedStore_ConcurrentOverlappingCreates_CommitAtMostOnePosition()
+    {
+        await new AssetOperationsMigrationRunner(_options).EnsureMigratedAsync();
+        var left = InstrumentPositionProjectionFixture.CreateStrict();
+        var right = InstrumentPositionProjectionFixture.ReidentifyStrict(left, Guid.NewGuid());
+        var leftStore = new PostgresAssetOperationsProjectionStore(_options);
+        var rightStore = new PostgresAssetOperationsProjectionStore(_options);
+
+        var writes = await Task.WhenAll(
+            Record.ExceptionAsync(() => leftStore.UpsertAsync(
+                left.Role,
+                left.Position,
+                left.State,
+                expectedVersion: 0,
+                InstrumentPositionProjectionFixture.Approval)),
+            Record.ExceptionAsync(() => rightStore.UpsertAsync(
+                right.Role,
+                right.Position,
+                right.State,
+                expectedVersion: 0,
+                InstrumentPositionProjectionFixture.Approval)));
+
+        writes.Count(error => error is null).Should().Be(1);
+        writes.Count(error => error is not null).Should().Be(1);
+        var snapshot = await leftStore.GetSecurityAsync(InstrumentPositionProjectionFixture.SecurityId);
+        snapshot.BookPositions.Should().ContainSingle();
+        snapshot.PositionEconomicStates.Should().ContainSingle();
+    }
+
+    [AssetOperationsDatabaseFact]
+    public async Task DedicatedStore_ConcurrentSamePositionUpdates_ShouldCommitExactlyOneVersion()
+    {
+        await new AssetOperationsMigrationRunner(_options).EnsureMigratedAsync();
+        var initial = InstrumentPositionProjectionFixture.CreateStrict();
+        var seedStore = new PostgresAssetOperationsProjectionStore(_options);
+        await seedStore.UpsertAsync(
+            initial.Role,
+            initial.Position,
+            initial.State,
+            expectedVersion: 0,
+            InstrumentPositionProjectionFixture.Approval);
+        var left = InstrumentPositionProjectionFixture.AdvanceStrict(initial);
+        var rightSource = left.State.SourceEvent! with
+        {
+            EventId = Guid.NewGuid(),
+            SourceEntityId = "factor-row-concurrent-right",
+            SourceContentHash = "sha256:factor-row-concurrent-right"
+        };
+        var rightLineage = left.State.ProjectionLineage! with
+        {
+            ProjectionRunId = Guid.NewGuid(),
+            ProjectionEventId = Guid.NewGuid(),
+            TriggerEvent = rightSource,
+            SourceEntityId = rightSource.SourceEntityId,
+            TermsHash = rightSource.SourceContentHash
+        };
+        var rightState = left.State with
+        {
+            EconomicStateId = Guid.NewGuid(),
+            CurrentFactor = left.State.CurrentFactor - 0.001m,
+            SourceEvent = rightSource,
+            ProjectionLineage = rightLineage
+        };
+        var right = left with
+        {
+            Position = left.Position with
+            {
+                CurrentEconomicState = rightState,
+                ProjectionLineage = rightLineage
+            },
+            State = rightState
+        };
+        var leftStore = new PostgresAssetOperationsProjectionStore(_options);
+        var rightStore = new PostgresAssetOperationsProjectionStore(_options);
+
+        var writes = await Task.WhenAll(
+            Record.ExceptionAsync(() => leftStore.UpsertAsync(
+                left.Role,
+                left.Position,
+                left.State,
+                expectedVersion: 1,
+                InstrumentPositionProjectionFixture.Approval)),
+            Record.ExceptionAsync(() => rightStore.UpsertAsync(
+                right.Role,
+                right.Position,
+                right.State,
+                expectedVersion: 1,
+                InstrumentPositionProjectionFixture.Approval)));
+
+        writes.Count(error => error is null).Should().Be(1);
+        writes.Count(error => error is not null).Should().Be(1);
+        var restarted = new PostgresAssetOperationsProjectionStore(_options);
+        var persisted = await restarted.GetBookPositionAsync(initial.Position.PositionId);
+        persisted!.Version.Should().Be(2);
+        new[] { left.State.EconomicStateId, right.State.EconomicStateId }
+            .Should().Contain(persisted.CurrentEconomicState!.EconomicStateId);
+        (await restarted.GetSecurityAsync(initial.Position.SecurityId))
+            .PositionEconomicStates.Should().HaveCount(2);
     }
 }
 
@@ -155,7 +583,7 @@ internal static class InstrumentPositionProjectionFixture
     internal static readonly Guid SecurityId = Guid.Parse("a3000000-aaaa-4000-8000-000000000001");
     private static readonly Guid RoleId = Guid.Parse("a3000000-aaaa-4000-8000-000000000002");
     internal static readonly Guid PositionId = Guid.Parse("a3000000-aaaa-4000-8000-000000000003");
-    private static readonly Guid LedgerBookId = Guid.Parse("a3000000-aaaa-4000-8000-000000000004");
+    internal static readonly Guid LedgerBookId = Guid.Parse("a3000000-aaaa-4000-8000-000000000004");
 
     internal static AssetOperationsWriteApprovalDto Approval { get; } = new(
         "controller@meridian.local",
@@ -205,6 +633,7 @@ internal static class InstrumentPositionProjectionFixture
             InstrumentEconomicSides.Asset,
             new DateOnly(2026, 1, 1),
             Version: 2,
+            OriginEvent: factor.EconomicState!.SourceEvent,
             EvidenceLinks: ["evidence://position/holder"]);
         var position = new BookPositionDto(
             PositionId,
@@ -217,6 +646,7 @@ internal static class InstrumentPositionProjectionFixture
             Version: 4,
             PrimaryAccountId: "Securities",
             CurrentEconomicState: factor.EconomicState,
+            OriginEvent: factor.EconomicState!.SourceEvent,
             ProjectionLineage: factor.Lineage,
             EvidenceLinks: ["evidence://position/holder"]);
         var subject = new AssetOperationSubjectDto(
@@ -276,4 +706,78 @@ internal static class InstrumentPositionProjectionFixture
             ProjectionLineages = [factor.Lineage!]
         };
     }
+
+    internal static StrictProjection CreateStrict()
+    {
+        var projection = Create();
+        var state = projection.PositionEconomicStates.Single() with { Version = 1 };
+        var role = projection.InstrumentRoles.Single() with { Version = 1 };
+        var position = projection.BookPositions.Single() with
+        {
+            Version = 1,
+            CurrentEconomicState = state,
+            ProjectionLineage = state.ProjectionLineage
+        };
+        return new StrictProjection(role, position, state);
+    }
+
+    internal static StrictProjection AdvanceStrict(StrictProjection current)
+    {
+        var projection = Create() with
+        {
+            InstrumentRoles = [current.Role],
+            BookPositions = [current.Position],
+            PositionEconomicStates = [current.State],
+            ProjectionLineages = current.State.ProjectionLineage is null ? [] : [current.State.ProjectionLineage!]
+        };
+        var advanced = Advance(projection);
+        var state = advanced.PositionEconomicStates.Single() with { Version = 2 };
+        var position = advanced.BookPositions.Single() with
+        {
+            Version = 2,
+            CurrentEconomicState = state,
+            ProjectionLineage = state.ProjectionLineage
+        };
+        return new StrictProjection(current.Role, position, state);
+    }
+
+    internal static StrictProjection ReidentifyStrict(StrictProjection source, Guid positionId)
+    {
+        var sourceEvent = source.State.SourceEvent! with
+        {
+            EventId = Guid.NewGuid(),
+            BookPositionId = positionId
+        };
+        var lineage = source.State.ProjectionLineage! with
+        {
+            ProjectionRunId = Guid.NewGuid(),
+            ProjectionEventId = Guid.NewGuid(),
+            TriggerEvent = sourceEvent,
+            BookPositionId = positionId
+        };
+        var state = source.State with
+        {
+            EconomicStateId = Guid.NewGuid(),
+            PositionId = positionId,
+            SourceEvent = sourceEvent,
+            ProjectionLineage = lineage
+        };
+        var position = source.Position with
+        {
+            PositionId = positionId,
+            BookContext = source.Position.BookContext with
+            {
+                Dimensions = source.Position.BookContext.Dimensions! with { PositionId = positionId }
+            },
+            CurrentEconomicState = state,
+            OriginEvent = sourceEvent,
+            ProjectionLineage = lineage
+        };
+        return new StrictProjection(source.Role, position, state);
+    }
+
+    internal sealed record StrictProjection(
+        InstrumentRoleDto Role,
+        BookPositionDto Position,
+        PositionEconomicStateDto State);
 }

--- a/tests/Meridian.Tests/Ui/WorkstationServiceCollectionExtensionsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationServiceCollectionExtensionsTests.cs
@@ -1,8 +1,10 @@
 using FluentAssertions;
 using Meridian.Execution.Services;
 using Meridian.Strategies.Storage;
+using Meridian.Storage.AssetOperations;
 using Meridian.Ui.Shared.Services;
 using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
 using CoreConfigStore = Meridian.Application.UI.ConfigStore;
 
 namespace Meridian.Tests.Ui;
@@ -63,6 +65,52 @@ public sealed class WorkstationServiceCollectionExtensionsTests
         provider.GetRequiredService<ITradingOperatorReadinessProvider>()
             .Should()
             .BeSameAs(provider.GetRequiredService<TradingOperatorReadinessService>());
+    }
+
+    [Fact]
+    public void AddWorkstationSharedServices_AliasesAssetOperationsInterfacesToSameInMemoryStore()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "Meridian.Tests", Guid.NewGuid().ToString("N"));
+        var configPath = Path.Combine(root, "appsettings.json");
+        Directory.CreateDirectory(root);
+        File.WriteAllText(configPath, "{}");
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(new CoreConfigStore(configPath));
+
+        services.AddWorkstationSharedServices();
+
+        using var provider = services.BuildServiceProvider();
+        var legacyStore = provider.GetRequiredService<IAssetOperationsProjectionStore>();
+        legacyStore.Should().BeOfType<InMemoryAssetOperationsProjectionStore>();
+        provider.GetRequiredService<IInstrumentPositionProjectionStore>()
+            .Should()
+            .BeSameAs(legacyStore);
+    }
+
+    [Fact]
+    public void AddWorkstationSharedServices_PreservesPreRegisteredDualAssetOperationsStore()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "Meridian.Tests", Guid.NewGuid().ToString("N"));
+        var configPath = Path.Combine(root, "appsettings.json");
+        Directory.CreateDirectory(root);
+        File.WriteAllText(configPath, "{}");
+        var customStore = Substitute.For<IAssetOperationsProjectionStore, IInstrumentPositionProjectionStore>();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(new CoreConfigStore(configPath));
+        services.AddSingleton<IAssetOperationsProjectionStore>(customStore);
+
+        services.AddWorkstationSharedServices();
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IAssetOperationsProjectionStore>()
+            .Should()
+            .BeSameAs(customStore);
+        provider.GetRequiredService<IInstrumentPositionProjectionStore>()
+            .Should()
+            .BeSameAs(customStore);
     }
 
     [Fact]


### PR DESCRIPTION
<!-- phase:PR7 -->

## Summary

Implements Slice 3 of the staged Instrument-to-Journal alignment program by making instrument roles, book positions, economic-state history, and projection lineage durable under the existing Asset Operations boundary.

- adds `IInstrumentPositionProjectionStore` with security/book as-of lookup, position lookup, transactional upsert with `ExpectedVersion`, and append-only economic-state history
- implements behaviorally aligned in-memory and PostgreSQL stores, including immutable identity/scope checks, effective dating, retained provenance/evidence, overlap rejection, stale-write protection, and idempotent replay
- uses serializable PostgreSQL writes plus deterministic advisory locks for position scopes and projection-run lineage
- adds migration 003 for normalized scope/provenance/approval fields, state-version uniqueness, composite ownership foreign keys, and fail-closed legacy lineage validation
- hardens migration execution with a schema-scoped lock and checksum-backed migration ledger
- merges durable typed projections into `AssetOperationsReadService` without creating orphan instrument identities or changing existing security-scoped projection behavior
- aliases the same concrete store instance behind legacy and dedicated interfaces in application and shared workstation composition
- updates architecture/source documentation and module source hashes

## Reason

Slice 2 established the governed MBS factor-paydown proof and minimal typed persistence. Slice 3 completes the durable role/position boundary needed for restart-safe, book-scoped Asset Operations projections without migrating Security Master, direct-lending, portfolio, or fund-account records.

## Accounting and architecture invariants

- `JournalEntry` remains the authoritative accounting aggregate.
- These tables retain projection identity, state, provenance, approval, and lineage only; they never store ledger balances.
- Security Master `SecurityId` remains canonical instrument identity.
- Existing instrument-family tables are not migrated or backfilled.
- Projection deletion/rebuild cannot alter immutable journal truth.
- The compatibility store accepts strictly newer sparse imported versions; the dedicated store retains exact consecutive CAS semantics.
- A projection-run ID cannot be reused with conflicting retained lineage, including legacy Slice 2 data encountered during migration.

## Testing performed

- [x] `bash scripts/ci.sh` completed successfully on commit `09be9a0a5` via Git Bash (`quality-gate` completed successfully)
- [x] Relevant unit tests were added or updated
- [x] Relevant integration tests were added or updated
- [x] GitHub Actions `quality-gate` passed

Additional local evidence:

- focused Slice 3 store/read-service/DI suite: 39 passed, 11 PostgreSQL-only tests skipped because local Docker is unavailable
- Slice 1-2 accounting compatibility suite: 71 passed
- Contracts, Instruments, Financial Operations, Ledger, Storage, and UI Shared dependency checks: 0 findings in each surface
- all 30 dashboard test batches and production bundle: passed through full CI
- formatting, file-size ratchet, staged diff hygiene, source README validation, lane manifest, and workflow hygiene: passed
- `SRC-STORAGE` and `SRC-DESIGN-INSTRUMENTS` source hashes refreshed

GitHub Actions remains the authoritative PostgreSQL/integration result.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`