### PR TITLE
Consumer installer and browser-first concierge

### DIFF
--- a/.github/workflows/desktop-installer-packaging.yml
+++ b/.github/workflows/desktop-installer-packaging.yml
@@ -202,9 +202,81 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  build-consumer-setup:
+    name: package-consumer-setup
+    needs: release-preflight
+    runs-on: windows-latest
+    timeout-minutes: 120
+    environment:
+      name: desktop-release-signing
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v5.4.0
+        with:
+          global-json-file: global.json
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.0.0
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: src/Meridian.Ui/dashboard/package-lock.json
+
+      - name: Prepare signing certificate for a tag release
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: signing
+        shell: pwsh
+        env:
+          MDC_SIGNING_CERT_PFX_BASE64: ${{ secrets.MDC_SIGNING_CERT_PFX_BASE64 }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:MDC_SIGNING_CERT_PFX_BASE64)) {
+            throw "Tag release builds require MDC_SIGNING_CERT_PFX_BASE64 in the protected desktop-release-signing environment."
+          }
+          $certPath = Join-Path $env:RUNNER_TEMP "meridian-release-signing.pfx"
+          [IO.File]::WriteAllBytes($certPath, [Convert]::FromBase64String($env:MDC_SIGNING_CERT_PFX_BASE64))
+          "cert_path=$certPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Build the x64 and ARM64 consumer package
+        shell: pwsh
+        env:
+          MDC_SIGNING_CERT_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.MDC_SIGNING_CERT_PASSWORD || '' }}
+        run: |
+          pwsh ./build/scripts/install/build-consumer-setup.ps1 `
+            -SigningCertificate '${{ steps.signing.outputs.cert_path }}' `
+            -SigningCertificatePassword $env:MDC_SIGNING_CERT_PASSWORD
+
+      - name: Generate consumer release evidence
+        shell: pwsh
+        run: |
+          python build/scripts/ci/generate-release-evidence-manifest.py `
+            --project consumer-setup `
+            --runtime windows `
+            --artifact-root artifacts/consumer-setup `
+            --output artifacts/consumer-setup/release-evidence.json `
+            --workflow-run-id '${{ github.run_id }}' `
+            --validation-lane verify-desktop-release-preflight `
+            --validation-lane package-consumer-setup
+
+      - name: Upload consumer setup artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: meridian-consumer-setup-${{ github.run_id }}
+          path: |
+            artifacts/consumer-setup/Meridian-Setup.exe
+            artifacts/consumer-setup/release-evidence.json
+          if-no-files-found: error
+          retention-days: 14
+
   release:
     name: publish-desktop-installer-release
-    needs: build-msix
+    needs: [build-msix, build-consumer-setup]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -219,6 +291,12 @@ jobs:
           merge-multiple: true
           path: artifacts/release
 
+      - name: Download consumer setup artifact
+        uses: actions/download-artifact@v5.0.0
+        with:
+          name: meridian-consumer-setup-${{ github.run_id }}
+          path: artifacts/release/consumer
+
       - name: Publish GitHub release assets
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v2
         with:
@@ -226,6 +304,7 @@ jobs:
             artifacts/release/**/*.msix
             artifacts/release/**/*.msixbundle
             artifacts/release/**/*.appinstaller
+            artifacts/release/**/Meridian-Setup.exe
             artifacts/release/**/release-evidence.json
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/build/scripts/install/build-consumer-setup.ps1
+++ b/build/scripts/install/build-consumer-setup.ps1
@@ -1,0 +1,52 @@
+[CmdletBinding()]
+param(
+    [string]$Configuration = "Release",
+    [string]$OutputDirectory = "artifacts/consumer-setup",
+    [string]$SigningCertificate,
+    [string]$SigningCertificatePassword
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "../../..")).Path
+$outputRoot = Join-Path $repoRoot $OutputDirectory
+$payloadRoot = Join-Path $outputRoot "payload"
+if (-not $outputRoot.StartsWith($repoRoot + [IO.Path]::DirectorySeparatorChar, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "OutputDirectory must resolve inside the repository."
+}
+Remove-Item -LiteralPath $outputRoot -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $payloadRoot -Force | Out-Null
+
+Push-Location (Join-Path $repoRoot "src/Meridian.Ui/dashboard")
+try {
+    npm ci --prefer-offline --no-audit --no-fund
+    npm run build
+} finally { Pop-Location }
+
+foreach ($runtime in @("win-x64", "win-arm64")) {
+    $runtimeRoot = Join-Path $payloadRoot $runtime
+    $hostRoot = Join-Path $runtimeRoot "host"
+    $desktopRoot = Join-Path $runtimeRoot "desktop"
+    New-Item -ItemType Directory -Path $hostRoot, $desktopRoot -Force | Out-Null
+
+    dotnet publish (Join-Path $repoRoot "src/Meridian/Meridian.csproj") -c $Configuration -r $runtime --self-contained true -o $hostRoot
+    dotnet publish (Join-Path $repoRoot "src/Meridian.Wpf/Meridian.Wpf.csproj") -c $Configuration -r $runtime --self-contained true -o $desktopRoot /p:EnableWindowsTargeting=true /p:EnableFullWpfBuild=true /p:WindowsPackageType=None
+    dotnet publish (Join-Path $repoRoot "src/Meridian.Launcher/Meridian.Launcher.csproj") -c $Configuration -r $runtime --self-contained true -o $runtimeRoot
+
+    $workstationAssets = Join-Path $repoRoot "src/Meridian.Ui/wwwroot/workstation"
+    if (-not (Test-Path $workstationAssets)) { throw "Browser workstation assets were not produced at $workstationAssets" }
+    Copy-Item -Path $workstationAssets -Destination (Join-Path $hostRoot "wwwroot") -Recurse -Force
+}
+
+$setupPublish = Join-Path $outputRoot "publish"
+dotnet publish (Join-Path $repoRoot "src/Meridian.Setup/Meridian.Setup.csproj") -c $Configuration -r win-x64 --self-contained true -o $setupPublish /p:MeridianPayloadDir=$payloadRoot
+$setup = Join-Path $setupPublish "Meridian-Setup.exe"
+if (-not (Test-Path $setup)) { throw "Meridian-Setup.exe was not produced." }
+
+if (-not [string]::IsNullOrWhiteSpace($SigningCertificate)) {
+    $signTool = (Get-Command signtool.exe -ErrorAction Stop).Source
+    & $signTool sign /fd SHA256 /td SHA256 /tr http://timestamp.digicert.com /f $SigningCertificate /p $SigningCertificatePassword $setup
+    if ($LASTEXITCODE -ne 0) { throw "Authenticode signing failed." }
+}
+
+Copy-Item $setup (Join-Path $outputRoot "Meridian-Setup.exe") -Force
+Get-FileHash (Join-Path $outputRoot "Meridian-Setup.exe") -Algorithm SHA256 | Format-List

--- a/docs/operators/browser-workstation-installer.md
+++ b/docs/operators/browser-workstation-installer.md
@@ -2,7 +2,7 @@
 
 **Status:** active
 **Owner:** core-team
-**Reviewed:** 2026-05-31
+**Reviewed:** 2026-07-13
 
 This is the canonical operator entry for browser workstation installation and validation.
 
@@ -14,15 +14,32 @@ This is the canonical operator entry for browser workstation installation and va
 
 ## Deployment Sequence
 
-1. Build workstation artifacts from the supported command surface.
-2. Install or refresh local workstation package path.
-3. Validate launch path and API endpoint connectivity.
-4. Confirm asset hash/manifest sanity for the installed package.
-5. Capture evidence snapshot for operator handoff.
+For end users, the supported release artifact is the production-signed
+`Meridian-Setup.exe`. It detects x64 or ARM64, installs the self-contained local host,
+browser assets, desktop workstation, and launcher, creates one Start Menu entry, and
+launches browser-first setup. It requires no PowerShell, SDK, Node, Git, certificate
+installation, or user-selected port.
+
+The launcher creates a random loopback port and a one-use account-bootstrap token. The
+token remains in the URL fragment until the setup page posts it to the loopback-only
+bootstrap endpoint and is invalidated when the first local administrator is created.
+Application data and credentials remain outside the installation directory.
+
+Developer and operator scripts under `build/scripts/install/` are release-pipeline
+machinery, not end-user instructions. Release packaging uses:
+
+```powershell
+pwsh ./build/scripts/install/build-consumer-setup.ps1
+```
+
+Tag builds sign and publish `Meridian-Setup.exe` through the protected Desktop Installer
+Release workflow. Workflow changes require explicit human governance review.
 
 ## Canonical Validation
 
 - Start command and launch posture remain defined in this section's parent operator documentation.
+- Validate clean install, repair, uninstall, first-account creation, offline sample mode,
+  x64, and ARM64 in clean Windows virtual machines before publishing a production tag.
 - For support artifacts, include API readiness and operator inbox verification before handoff:
   - `GET /api/workstation/operator/inbox`
   - `GET /api/workstation/trading/readiness`

--- a/docs/source/generated/stale-docs.json
+++ b/docs/source/generated/stale-docs.json
@@ -11,19 +11,17 @@
     "version": "1.0.0"
   },
   "source_hash_manifest": "docs/source/generated/source-hash-manifest.json",
-  "stale_count": 20,
+  "stale_count": 29,
   "stale_modules": [
     {
       "module_id": "SRC-APP",
       "path": "src/Meridian.Application",
       "readme": "src/Meridian.Application/README.md",
       "reasons": [
-        "source_hash_drift",
-        "readme_hash_drift"
+        "source_hash_drift"
       ],
       "recommended_actions": [
         "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
-        "review README changes and rerender generated blocks if needed",
         "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
       ]
     },
@@ -40,9 +38,9 @@
       ]
     },
     {
-      "module_id": "SRC-BACKTESTING-SDK",
-      "path": "src/Meridian.Backtesting.Sdk",
-      "readme": "src/Meridian.Backtesting.Sdk/README.md",
+      "module_id": "SRC-CONTRACTS",
+      "path": "src/Meridian.Contracts",
+      "readme": "src/Meridian.Contracts/README.md",
       "reasons": [
         "source_hash_drift"
       ],
@@ -60,6 +58,20 @@
       ],
       "recommended_actions": [
         "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-DESIGN-AUDIT",
+      "path": "src/Meridian.Audit",
+      "readme": "src/Meridian.Audit/README.md",
+      "reasons": [
+        "source_hash_drift",
+        "readme_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
         "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
       ]
     },
@@ -88,6 +100,18 @@
       ]
     },
     {
+      "module_id": "SRC-DESIGN-INSTRUMENTS",
+      "path": "src/Meridian.Instruments",
+      "readme": "src/Meridian.Instruments/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
       "module_id": "SRC-DESIGN-PLATFORM",
       "path": "src/Meridian.Platform",
       "readme": "src/Meridian.Platform/README.md",
@@ -100,9 +124,57 @@
       ]
     },
     {
+      "module_id": "SRC-DESIGN-PORTFOLIO-RECORDS",
+      "path": "src/Meridian.PortfolioRecords",
+      "readme": "src/Meridian.PortfolioRecords/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-DESIGN-REFERENCE-DATA",
+      "path": "src/Meridian.ReferenceData",
+      "readme": "src/Meridian.ReferenceData/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
       "module_id": "SRC-DOMAIN",
       "path": "src/Meridian.Domain",
       "readme": "src/Meridian.Domain/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-EXECUTION",
+      "path": "src/Meridian.Execution",
+      "readme": "src/Meridian.Execution/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-EXECUTION-SDK",
+      "path": "src/Meridian.Execution.Sdk",
+      "readme": "src/Meridian.Execution.Sdk/README.md",
       "reasons": [
         "source_hash_drift"
       ],
@@ -148,26 +220,16 @@
       ]
     },
     {
-      "module_id": "SRC-FSHARP-TRADING",
-      "path": "src/Meridian.FSharp.Trading",
-      "readme": "src/Meridian.FSharp.Trading/README.md",
+      "module_id": "SRC-HOST",
+      "path": "src/Meridian",
+      "readme": "src/Meridian/README.md",
       "reasons": [
-        "source_hash_drift"
+        "source_hash_drift",
+        "readme_hash_drift"
       ],
       "recommended_actions": [
         "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
-        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
-      ]
-    },
-    {
-      "module_id": "SRC-IBAPI-SMOKESTUB",
-      "path": "src/Meridian.IbApi.SmokeStub",
-      "readme": "src/Meridian.IbApi.SmokeStub/README.md",
-      "reasons": [
-        "source_hash_drift"
-      ],
-      "recommended_actions": [
-        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
         "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
       ]
     },
@@ -184,9 +246,21 @@
       ]
     },
     {
-      "module_id": "SRC-PROVIDER-SDK",
-      "path": "src/Meridian.ProviderSdk",
-      "readme": "src/Meridian.ProviderSdk/README.md",
+      "module_id": "SRC-LEDGER",
+      "path": "src/Meridian.Ledger",
+      "readme": "src/Meridian.Ledger/README.md",
+      "reasons": [
+        "source_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-MCP",
+      "path": "src/Meridian.Mcp",
+      "readme": "src/Meridian.Mcp/README.md",
       "reasons": [
         "source_hash_drift"
       ],
@@ -200,6 +274,20 @@
       "path": "src/Meridian.QuantScript",
       "readme": "src/Meridian.QuantScript/README.md",
       "reasons": [
+        "source_hash_drift",
+        "readme_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-RISK",
+      "path": "src/Meridian.Risk",
+      "readme": "src/Meridian.Risk/README.md",
+      "reasons": [
         "source_hash_drift"
       ],
       "recommended_actions": [
@@ -208,9 +296,9 @@
       ]
     },
     {
-      "module_id": "SRC-STRATEGIES",
-      "path": "src/Meridian.Strategies",
-      "readme": "src/Meridian.Strategies/README.md",
+      "module_id": "SRC-STORAGE",
+      "path": "src/Meridian.Storage",
+      "readme": "src/Meridian.Storage/README.md",
       "reasons": [
         "source_hash_drift"
       ],
@@ -234,6 +322,20 @@
       ]
     },
     {
+      "module_id": "SRC-UI-DASHBOARD",
+      "path": "src/Meridian.Ui/dashboard",
+      "readme": "src/Meridian.Ui/dashboard/README.md",
+      "reasons": [
+        "source_hash_drift",
+        "readme_hash_drift"
+      ],
+      "recommended_actions": [
+        "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
       "module_id": "SRC-UI-SERVICES",
       "path": "src/Meridian.Ui.Services",
       "readme": "src/Meridian.Ui.Services/README.md",
@@ -246,15 +348,27 @@
       ]
     },
     {
-      "module_id": "SRC-WPF",
-      "path": "src/Meridian.Wpf",
-      "readme": "src/Meridian.Wpf/README.md",
+      "module_id": "SRC-UI-SHARED",
+      "path": "src/Meridian.Ui.Shared",
+      "readme": "src/Meridian.Ui.Shared/README.md",
       "reasons": [
         "source_hash_drift",
         "readme_hash_drift"
       ],
       "recommended_actions": [
         "review source changes and update the nearest README, TODOs, diagrams, or registry if behavior changed",
+        "review README changes and rerender generated blocks if needed",
+        "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
+      ]
+    },
+    {
+      "module_id": "SRC-WPF",
+      "path": "src/Meridian.Wpf",
+      "readme": "src/Meridian.Wpf/README.md",
+      "reasons": [
+        "readme_hash_drift"
+      ],
+      "recommended_actions": [
         "review README changes and rerender generated blocks if needed",
         "run validate-doc-hashes.py --write-module <MODULE_ID> only after the docs/code alignment review is complete"
       ]

--- a/docs/source/generated/stale-docs.md
+++ b/docs/source/generated/stale-docs.md
@@ -8,28 +8,37 @@ do_not_edit: true
 
 This report marks registered source modules whose code or README hashes differ from the reviewed baseline.
 
-- Stale modules: 20
+- Stale modules: 29
 - Removed module hash entries: 0
 
 | Module | Path | README | Reason |
 | --- | --- | --- | --- |
-| `SRC-APP` | `src/Meridian.Application` | `src/Meridian.Application/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-APP` | `src/Meridian.Application` | `src/Meridian.Application/README.md` | `source_hash_drift` |
 | `SRC-BACKTESTING` | `src/Meridian.Backtesting` | `src/Meridian.Backtesting/README.md` | `source_hash_drift` |
-| `SRC-BACKTESTING-SDK` | `src/Meridian.Backtesting.Sdk` | `src/Meridian.Backtesting.Sdk/README.md` | `source_hash_drift` |
+| `SRC-CONTRACTS` | `src/Meridian.Contracts` | `src/Meridian.Contracts/README.md` | `source_hash_drift` |
 | `SRC-CORE` | `src/Meridian.Core` | `src/Meridian.Core/README.md` | `source_hash_drift` |
+| `SRC-DESIGN-AUDIT` | `src/Meridian.Audit` | `src/Meridian.Audit/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-DESIGN-DATA-INTEGRATION` | `src/Meridian.DataIntegration` | `src/Meridian.DataIntegration/README.md` | `source_hash_drift` |
 | `SRC-DESIGN-IDENTITY` | `src/Meridian.Identity` | `src/Meridian.Identity/README.md` | `source_hash_drift` |
+| `SRC-DESIGN-INSTRUMENTS` | `src/Meridian.Instruments` | `src/Meridian.Instruments/README.md` | `source_hash_drift` |
 | `SRC-DESIGN-PLATFORM` | `src/Meridian.Platform` | `src/Meridian.Platform/README.md` | `source_hash_drift` |
+| `SRC-DESIGN-PORTFOLIO-RECORDS` | `src/Meridian.PortfolioRecords` | `src/Meridian.PortfolioRecords/README.md` | `source_hash_drift` |
+| `SRC-DESIGN-REFERENCE-DATA` | `src/Meridian.ReferenceData` | `src/Meridian.ReferenceData/README.md` | `source_hash_drift` |
 | `SRC-DOMAIN` | `src/Meridian.Domain` | `src/Meridian.Domain/README.md` | `source_hash_drift` |
+| `SRC-EXECUTION` | `src/Meridian.Execution` | `src/Meridian.Execution/README.md` | `source_hash_drift` |
+| `SRC-EXECUTION-SDK` | `src/Meridian.Execution.Sdk` | `src/Meridian.Execution.Sdk/README.md` | `source_hash_drift` |
 | `SRC-FSHARP` | `src/Meridian.FSharp` | `src/Meridian.FSharp/README.md` | `source_hash_drift` |
 | `SRC-FSHARP-DIRECTLENDING` | `src/Meridian.FSharp.DirectLending.Aggregates` | `src/Meridian.FSharp.DirectLending.Aggregates/README.md` | `source_hash_drift` |
 | `SRC-FSHARP-LEDGER` | `src/Meridian.FSharp.Ledger` | `src/Meridian.FSharp.Ledger/README.md` | `source_hash_drift` |
-| `SRC-FSHARP-TRADING` | `src/Meridian.FSharp.Trading` | `src/Meridian.FSharp.Trading/README.md` | `source_hash_drift` |
-| `SRC-IBAPI-SMOKESTUB` | `src/Meridian.IbApi.SmokeStub` | `src/Meridian.IbApi.SmokeStub/README.md` | `source_hash_drift` |
+| `SRC-HOST` | `src/Meridian` | `src/Meridian/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-INFRASTRUCTURE` | `src/Meridian.Infrastructure` | `src/Meridian.Infrastructure/README.md` | `source_hash_drift` |
-| `SRC-PROVIDER-SDK` | `src/Meridian.ProviderSdk` | `src/Meridian.ProviderSdk/README.md` | `source_hash_drift` |
-| `SRC-QUANTSCRIPT` | `src/Meridian.QuantScript` | `src/Meridian.QuantScript/README.md` | `source_hash_drift` |
-| `SRC-STRATEGIES` | `src/Meridian.Strategies` | `src/Meridian.Strategies/README.md` | `source_hash_drift` |
+| `SRC-LEDGER` | `src/Meridian.Ledger` | `src/Meridian.Ledger/README.md` | `source_hash_drift` |
+| `SRC-MCP` | `src/Meridian.Mcp` | `src/Meridian.Mcp/README.md` | `source_hash_drift` |
+| `SRC-QUANTSCRIPT` | `src/Meridian.QuantScript` | `src/Meridian.QuantScript/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-RISK` | `src/Meridian.Risk` | `src/Meridian.Risk/README.md` | `source_hash_drift` |
+| `SRC-STORAGE` | `src/Meridian.Storage` | `src/Meridian.Storage/README.md` | `source_hash_drift` |
 | `SRC-UI` | `src/Meridian.Ui` | `src/Meridian.Ui/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-UI-DASHBOARD` | `src/Meridian.Ui/dashboard` | `src/Meridian.Ui/dashboard/README.md` | `source_hash_drift`, `readme_hash_drift` |
 | `SRC-UI-SERVICES` | `src/Meridian.Ui.Services` | `src/Meridian.Ui.Services/README.md` | `source_hash_drift` |
-| `SRC-WPF` | `src/Meridian.Wpf` | `src/Meridian.Wpf/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-UI-SHARED` | `src/Meridian.Ui.Shared` | `src/Meridian.Ui.Shared/README.md` | `source_hash_drift`, `readme_hash_drift` |
+| `SRC-WPF` | `src/Meridian.Wpf` | `src/Meridian.Wpf/README.md` | `readme_hash_drift` |

--- a/src/Meridian.Contracts/Workstation/FirstRunDtos.cs
+++ b/src/Meridian.Contracts/Workstation/FirstRunDtos.cs
@@ -1,0 +1,44 @@
+namespace Meridian.Contracts.Workstation;
+
+public sealed record FirstRunStatusDto(
+    bool IsComplete,
+    string? Goal,
+    string? StarterKitId,
+    string? DataChoice,
+    WorkspaceModeDto Workspace,
+    IReadOnlyList<StarterWorkspaceDto> StarterKits,
+    IReadOnlyList<ActivationOutcomeDto> Outcomes,
+    IReadOnlyList<RecommendedActionDto> RecommendedActions);
+
+public sealed record WorkspaceModeDto(
+    string Id,
+    string Name,
+    bool IsSample,
+    string Badge,
+    string SafetyMessage,
+    string SamplePackVersion);
+
+public sealed record StarterWorkspaceDto(
+    string Id,
+    string Name,
+    string Goal,
+    string Description,
+    string DefaultRoute);
+
+public sealed record ActivationOutcomeDto(
+    string Key,
+    string Label,
+    string ActionLabel,
+    string Route,
+    bool IsComplete,
+    DateTimeOffset? CompletedAtUtc);
+
+public sealed record RecommendedActionDto(string Label, string Route, string Description);
+
+public sealed record CompleteFirstRunRequestDto(
+    string Goal,
+    string StarterKitId,
+    string DataChoice,
+    bool UseSampleData);
+
+public sealed record CompleteActivationOutcomeRequestDto(string Key);

--- a/src/Meridian.Launcher/Meridian.Launcher.csproj
+++ b/src/Meridian.Launcher/Meridian.Launcher.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>Meridian</AssemblyName>
+    <RootNamespace>Meridian.Launcher</RootNamespace>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+</Project>

--- a/src/Meridian.Launcher/Program.cs
+++ b/src/Meridian.Launcher/Program.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+
+namespace Meridian.Launcher;
+
+internal static class Program
+{
+    [STAThread]
+    private static async Task<int> Main(string[] args)
+    {
+        var installRoot = AppContext.BaseDirectory;
+        var hostPath = Path.Combine(installRoot, "host", "Meridian.exe");
+        if (!File.Exists(hostPath))
+        {
+            MessageBox("Meridian needs repair because the local host is missing.", "Meridian");
+            return 2;
+        }
+
+        var port = ReserveLoopbackPort();
+        var bootstrapToken = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+        var url = $"http://127.0.0.1:{port}";
+        var start = new ProcessStartInfo(hostPath)
+        {
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(hostPath)!
+        };
+        start.Environment["ASPNETCORE_URLS"] = url;
+        start.Environment["MDC_BOOTSTRAP_TOKEN"] = bootstrapToken;
+        start.Environment["MDC_AUTH_MODE"] = "required";
+        start.Environment["MERIDIAN_INSTALL_ROOT"] = installRoot;
+        start.Environment["MDC_DATA_ROOT"] = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Meridian", "Data");
+        using var process = Process.Start(start);
+        if (process is null) return 3;
+
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+        for (var attempt = 0; attempt < 80 && !process.HasExited; attempt++)
+        {
+            try
+            {
+                var response = await client.GetAsync($"{url}/healthz").ConfigureAwait(false);
+                if (response.IsSuccessStatusCode) break;
+            }
+            catch (HttpRequestException) { }
+            catch (TaskCanceledException) { }
+            await Task.Delay(250).ConfigureAwait(false);
+        }
+
+        var accountStore = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Meridian", "Data", "governance", "user-accounts.json");
+        var destination = File.Exists(accountStore)
+            ? $"{url}/workstation/"
+            : $"{url}/setup/account#token={Uri.EscapeDataString(bootstrapToken)}";
+        Process.Start(new ProcessStartInfo(destination) { UseShellExecute = true });
+        await process.WaitForExitAsync().ConfigureAwait(false);
+        return process.ExitCode;
+    }
+
+    private static int ReserveLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static void MessageBox(string message, string title) =>
+        Process.Start(new ProcessStartInfo("mshta.exe", $"javascript:alert('{message.Replace("'", "") }');close()") { UseShellExecute = true });
+}

--- a/src/Meridian.Launcher/README.md
+++ b/src/Meridian.Launcher/README.md
@@ -1,0 +1,5 @@
+# Meridian Launcher
+
+Windows consumer entry point. It selects an available loopback port, starts the bundled
+self-contained host, waits for readiness, and opens either first-account setup or the
+browser workstation. The installer creates the single Start Menu entry for this binary.

--- a/src/Meridian.Setup/Meridian.Setup.csproj
+++ b/src/Meridian.Setup/Meridian.Setup.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>Meridian-Setup</AssemblyName>
+    <RootNamespace>Meridian.Setup</RootNamespace>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(MeridianPayloadDir)' != ''">
+    <EmbeddedResource Include="$(MeridianPayloadDir)\**\*" LogicalName="payload/%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+</Project>

--- a/src/Meridian.Setup/Program.cs
+++ b/src/Meridian.Setup/Program.cs
@@ -1,0 +1,95 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Microsoft.Win32;
+
+namespace Meridian.Setup;
+
+internal static class Program
+{
+    private const string ProductVersion = "1.0.0";
+
+    [STAThread]
+    private static int Main(string[] args)
+    {
+        var installRoot = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Programs", "Meridian");
+        if (args.Contains("--uninstall", StringComparer.OrdinalIgnoreCase)) return Uninstall(installRoot);
+        try
+        {
+            Directory.CreateDirectory(installRoot);
+            ExtractPayload(installRoot);
+            var installedSetup = Path.Combine(installRoot, "Meridian-Setup.exe");
+            if (!string.Equals(Environment.ProcessPath, installedSetup, StringComparison.OrdinalIgnoreCase))
+                File.Copy(Environment.ProcessPath!, installedSetup, true);
+            RegisterProduct(installRoot);
+            CreateStartMenuShortcut(installRoot);
+            Process.Start(new ProcessStartInfo(Path.Combine(installRoot, "Meridian.exe")) { UseShellExecute = true });
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Show($"Meridian setup could not finish.\n\n{ex.Message}");
+            return 1;
+        }
+    }
+
+    private static void ExtractPayload(string installRoot)
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var resources = assembly.GetManifestResourceNames().Where(name => name.StartsWith("payload/", StringComparison.Ordinal)).ToArray();
+        if (resources.Length == 0) throw new InvalidOperationException("The signed installer does not contain a Meridian product payload.");
+        var runtime = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "win-arm64" : "win-x64";
+        var prefix = $"payload/{runtime}/";
+        foreach (var resource in resources.Where(name => name.StartsWith(prefix, StringComparison.Ordinal)))
+        {
+            var relative = resource[prefix.Length..].Replace('/', Path.DirectorySeparatorChar);
+            var target = Path.GetFullPath(Path.Combine(installRoot, relative));
+            if (!target.StartsWith(Path.GetFullPath(installRoot) + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)) throw new InvalidDataException("Invalid package path.");
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+            using var source = assembly.GetManifestResourceStream(resource) ?? throw new InvalidDataException($"Missing package resource {resource}.");
+            using var destination = File.Create(target);
+            source.CopyTo(destination);
+        }
+    }
+
+    private static void RegisterProduct(string installRoot)
+    {
+        using var key = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\Windows\CurrentVersion\Uninstall\Meridian");
+        key.SetValue("DisplayName", "Meridian");
+        key.SetValue("DisplayVersion", ProductVersion);
+        key.SetValue("Publisher", "Meridian");
+        key.SetValue("InstallLocation", installRoot);
+        key.SetValue("DisplayIcon", Path.Combine(installRoot, "Meridian.exe"));
+        var installedSetup = Path.Combine(installRoot, "Meridian-Setup.exe");
+        key.SetValue("UninstallString", $"\"{installedSetup}\" --uninstall");
+        key.SetValue("ModifyPath", $"\"{installedSetup}\" --repair");
+        key.SetValue("NoModify", 0, RegistryValueKind.DWord);
+        key.SetValue("NoRepair", 0, RegistryValueKind.DWord);
+    }
+
+    private static void CreateStartMenuShortcut(string installRoot)
+    {
+        var startMenu = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.StartMenu), "Programs");
+        Directory.CreateDirectory(startMenu);
+        var shortcut = Path.Combine(startMenu, "Meridian.url");
+        File.WriteAllText(shortcut, $"[InternetShortcut]{Environment.NewLine}URL=file:///{Path.Combine(installRoot, "Meridian.exe").Replace('\\', '/')}{Environment.NewLine}IconFile={Path.Combine(installRoot, "Meridian.exe")}{Environment.NewLine}IconIndex=0");
+    }
+
+    private static int Uninstall(string installRoot)
+    {
+        try
+        {
+            var shortcut = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.StartMenu), "Programs", "Meridian.url");
+            if (File.Exists(shortcut)) File.Delete(shortcut);
+            Registry.CurrentUser.DeleteSubKeyTree(@"Software\Microsoft\Windows\CurrentVersion\Uninstall\Meridian", false);
+            var cleanup = Path.Combine(Path.GetTempPath(), $"meridian-uninstall-{Guid.NewGuid():N}.cmd");
+            File.WriteAllText(cleanup, $"@echo off\r\nping 127.0.0.1 -n 3 > nul\r\nrmdir /s /q \"{installRoot}\"\r\ndel /q \"%~f0\"\r\n");
+            Process.Start(new ProcessStartInfo("cmd.exe", $"/c \"{cleanup}\"") { CreateNoWindow = true, UseShellExecute = false });
+            return 0;
+        }
+        catch (Exception ex) { Show($"Meridian could not be removed. Your data was not changed.\n\n{ex.Message}"); return 1; }
+    }
+
+    private static void Show(string message) =>
+        Process.Start(new ProcessStartInfo("mshta.exe", $"javascript:alert('{message.Replace("'", "").Replace("\n", "\\n")}');close()") { UseShellExecute = true });
+}

--- a/src/Meridian.Setup/README.md
+++ b/src/Meridian.Setup/README.md
@@ -1,0 +1,6 @@
+# Meridian Setup
+
+Build-time bootstrapper for the public `Meridian-Setup.exe` artifact. The release build
+embeds x64 and ARM64 payloads, selects the current architecture, installs under the
+current user's local Programs directory, registers repair/uninstall, and preserves
+application data during uninstall. Production artifacts must be Authenticode-signed.

--- a/src/Meridian.Ui.Shared/Endpoints/FirstRunEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/FirstRunEndpoints.cs
@@ -1,0 +1,40 @@
+using Meridian.Contracts.Workstation;
+using Meridian.Ui.Shared.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace Meridian.Ui.Shared.Endpoints;
+
+public static class FirstRunEndpoints
+{
+    public static void MapFirstRunEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/workstation/first-run").WithTags("First run");
+        group.MapGet("/", async (HttpContext context, FirstRunExperienceService service, CancellationToken ct) =>
+            Results.Ok(await service.GetAsync(CurrentUser(context), ct).ConfigureAwait(false)));
+        group.MapPost("/complete", async (HttpContext context, CompleteFirstRunRequestDto request, FirstRunExperienceService service, CancellationToken ct) =>
+        {
+            try { return Results.Ok(await service.CompleteAsync(CurrentUser(context), request, ct).ConfigureAwait(false)); }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+        group.MapPost("/outcomes/complete", async (HttpContext context, CompleteActivationOutcomeRequestDto request, FirstRunExperienceService service, CancellationToken ct) =>
+        {
+            try { return Results.Ok(await service.CompleteOutcomeAsync(CurrentUser(context), request.Key, ct).ConfigureAwait(false)); }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+        app.MapPost("/api/workstation/desktop/launch", (HttpContext context, DesktopLaunchRequest request, DesktopWorkstationLaunchService service) =>
+        {
+            var remote = context.Connection.RemoteIpAddress;
+            if (remote is not null && !System.Net.IPAddress.IsLoopback(remote)) return Results.NotFound();
+            return service.TryLaunch(request.Page, out var message)
+                ? Results.Ok(new { message })
+                : Results.Json(new { error = message }, statusCode: StatusCodes.Status409Conflict);
+        }).WithTags("Workstation");
+    }
+
+    private static string CurrentUser(HttpContext context) =>
+        context.Items[LoginSessionMiddleware.CurrentUserKey] as string
+        ?? throw new InvalidOperationException("An authenticated user is required.");
+
+    private sealed record DesktopLaunchRequest(string? Page);
+}

--- a/src/Meridian.Ui.Shared/Endpoints/InitialAccountBootstrapEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/InitialAccountBootstrapEndpoints.cs
@@ -1,0 +1,45 @@
+using Meridian.Ui.Shared.Services;
+using Meridian.Identity;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace Meridian.Ui.Shared.Endpoints;
+
+public static class InitialAccountBootstrapEndpoints
+{
+    public static void MapInitialAccountBootstrapEndpoints(this WebApplication app)
+    {
+        app.MapGet("/setup/account", (InitialAccountBootstrapService bootstrap) =>
+            bootstrap.IsAvailable
+                ? Results.Content(AccountPage, "text/html; charset=utf-8")
+                : Results.Redirect("/login"))
+            .ExcludeFromDescription();
+
+        app.MapPost("/api/auth/bootstrap", async (HttpContext context, BootstrapAccountRequest request, InitialAccountBootstrapService bootstrap, CancellationToken ct) =>
+        {
+            var session = await bootstrap.CreateAsync(context.Connection.RemoteIpAddress, request.Token, request.Username, request.Password, ct).ConfigureAwait(false);
+            if (session is null)
+            {
+                return Results.Json(new { error = "The setup link is invalid, expired, or an account already exists. Passwords must contain at least 12 characters." }, statusCode: StatusCodes.Status403Forbidden);
+            }
+
+            var secure = CookieCsrfProtection.ShouldUseSecureCookies(context);
+            context.Response.Cookies.Append(LoginSessionMiddleware.SessionCookieName, session, new CookieOptions
+            {
+                HttpOnly = true, SameSite = SameSiteMode.Strict, Secure = secure, Path = "/",
+                Expires = DateTimeOffset.UtcNow + LoginSessionService.SessionDuration
+            });
+            CookieCsrfProtection.IssueCsrfCookie(context, secure, LoginSessionService.SessionDuration);
+            return Results.Ok(new { redirect = "/workstation/setup" });
+        }).ExcludeFromDescription();
+    }
+
+    private sealed record BootstrapAccountRequest(string Token, string Username, string Password);
+
+    private const string AccountPage = """
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Create your Meridian login</title>
+<style>body{margin:0;background:#07111f;color:#e7eef8;font:16px system-ui;display:grid;min-height:100vh;place-items:center}.card{width:min(30rem,calc(100% - 3rem));padding:2.5rem;border:1px solid #26374d;border-radius:24px;background:#0e1a2b;box-shadow:0 20px 60px #0008}h1{font-size:2rem;margin:.5rem 0}p{color:#a9b8ca;line-height:1.55}label{display:block;margin:1.25rem 0 .4rem}input{box-sizing:border-box;width:100%;padding:.8rem;border:1px solid #42546d;border-radius:10px;background:#07111f;color:white}button{width:100%;margin-top:1.5rem;padding:.9rem;border:0;border-radius:10px;background:#37c8dc;color:#04232b;font-weight:700}#error{color:#ffb4b4}</style></head><body><main class="card"><small>MERIDIAN · LOCAL SETUP</small><h1>Create your Meridian login</h1><p>This administrator stays on this computer. The one-use setup token is kept in the URL fragment and is never sent in a page request.</p><form id="form"><label for="username">Username</label><input id="username" autocomplete="username" required maxlength="80"><label for="password">Password</label><input id="password" type="password" autocomplete="new-password" minlength="12" required><p>Use at least 12 characters.</p><button>Create login and continue</button><p id="error" role="alert"></p></form></main><script>
+const token=new URLSearchParams(location.hash.slice(1)).get('token')||''; history.replaceState(null,'',location.pathname); document.getElementById('form').addEventListener('submit',async e=>{e.preventDefault();const error=document.getElementById('error');error.textContent='';const response=await fetch('/api/auth/bootstrap',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({token,username:document.getElementById('username').value,password:document.getElementById('password').value})});const body=await response.json();if(response.ok)location.assign(body.redirect);else error.textContent=body.error||'Setup could not continue.'});
+</script></body></html>
+""";
+}

--- a/src/Meridian.Ui.Shared/Endpoints/LoginSessionMiddleware.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/LoginSessionMiddleware.cs
@@ -106,6 +106,7 @@ public sealed class LoginSessionMiddleware
 
         // Exempt the login page and all auth API endpoints
         if (trimmedPath.Equals("/login", StringComparison.OrdinalIgnoreCase) ||
+            trimmedPath.Equals("/setup/account", StringComparison.OrdinalIgnoreCase) ||
             trimmedPath.StartsWith("/api/auth", StringComparison.OrdinalIgnoreCase))
         {
             await _next(context);

--- a/src/Meridian.Ui.Shared/Endpoints/UiEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/UiEndpoints.cs
@@ -237,9 +237,11 @@ public static class UiEndpoints
 
         // Authentication endpoints (login page, login API, logout API)
         app.MapAuthEndpoints();
+        app.MapInitialAccountBootstrapEndpoints();
 
         // React workstation shell and bootstrap data
         app.MapWorkstationEndpoints(jsonOptions);
+        app.MapFirstRunEndpoints();
         app.MapEvidenceEndpoints(jsonOptions);
 
         // Paper trading cockpit endpoints

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -11,6 +11,12 @@ last_reviewed: 2026-07-12
 
 # src/Meridian.Ui.Shared
 
+The shared workstation graph owns first-run state, the curated starter catalog,
+versioned sample provisioning, and outcome-based activation evidence. Browser and WPF
+clients consume these endpoints instead of defining client-only setup policy. Initial
+local-account creation reuses the governed identity store through a loopback-only,
+one-use bootstrap token.
+
 ## Purpose
 
 UI shared contains shared UI read models, endpoint adapters, and compatibility shims for browser

--- a/src/Meridian.Ui.Shared/Services/DesktopWorkstationLaunchService.cs
+++ b/src/Meridian.Ui.Shared/Services/DesktopWorkstationLaunchService.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics;
+
+namespace Meridian.Ui.Shared.Services;
+
+public sealed class DesktopWorkstationLaunchService
+{
+    private static readonly HashSet<string> AllowedPages = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Trading", "Portfolio", "Accounting", "Reporting", "Strategy", "Data", "Settings"
+    };
+
+    public bool TryLaunch(string? requestedPage, out string message)
+    {
+        var page = string.IsNullOrWhiteSpace(requestedPage) ? "Portfolio" : requestedPage.Trim();
+        if (!AllowedPages.Contains(page))
+        {
+            message = "Choose a supported Meridian workspace.";
+            return false;
+        }
+
+        var installRoot = Environment.GetEnvironmentVariable("MERIDIAN_INSTALL_ROOT") ?? AppContext.BaseDirectory;
+        var executable = Path.Combine(installRoot, "desktop", "Meridian.Desktop.exe");
+        if (!File.Exists(executable))
+        {
+            message = "The desktop workstation is not installed. Repair Meridian to restore it.";
+            return false;
+        }
+
+        Process.Start(new ProcessStartInfo(executable, $"--page={page}") { UseShellExecute = true, WorkingDirectory = Path.GetDirectoryName(executable)! });
+        message = "Desktop workstation opened.";
+        return true;
+    }
+}

--- a/src/Meridian.Ui.Shared/Services/FirstRunExperienceService.cs
+++ b/src/Meridian.Ui.Shared/Services/FirstRunExperienceService.cs
@@ -1,0 +1,183 @@
+using System.Text.Json;
+using Meridian.Contracts.Workstation;
+using Meridian.Storage.Archival;
+
+namespace Meridian.Ui.Shared.Services;
+
+/// <summary>
+/// Owns durable first-run, starter-workspace, sample-pack, and activation evidence.
+/// UI clients consume this governed state instead of defining onboarding policy locally.
+/// </summary>
+public sealed class FirstRunExperienceService(ConfigStore configStore)
+{
+    public const string SamplePackVersion = "2026.1";
+    private readonly SemaphoreSlim _writeGate = new(1, 1);
+    private readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+
+    private static readonly StarterWorkspaceDto[] StarterKits =
+    [
+        new("personal-portfolio", "Personal Portfolio Desk", "monitor-investments", "Track holdings, watchlists, and portfolio changes.", "/portfolio"),
+        new("fund-operations", "Fund Operations Desk", "operate-fund", "Run daily controls, approvals, and operational evidence.", "/accounting/operations-continuity"),
+        new("accounting-reconciliation", "Accounting and Reconciliation Desk", "reconcile-accounts", "Import statements, investigate breaks, and close with evidence.", "/accounting/statement-import"),
+        new("strategy-research", "Strategy Research Desk", "research-strategies", "Research, backtest, and paper-trade governed strategies.", "/strategy"),
+        new("market-data", "Market Data Desk", "collect-market-data", "Connect, validate, and monitor trusted market data.", "/data")
+    ];
+
+    private static readonly (string Key, string Label, string Action, string Route)[] OutcomeCatalog =
+    [
+        ("workspace-opened", "Open or create a workspace", "Open workspace", "/portfolio"),
+        ("data-imported", "Import sample or real data", "Import data", "/accounting/statement-import"),
+        ("validation-resolved", "Resolve one validation issue", "Review breaks", "/accounting/reconciliation/match"),
+        ("report-run", "Run one report", "Run report", "/reporting/run"),
+        ("result-saved", "Save or export one useful result", "Review results", "/reporting/library")
+    ];
+
+    public async Task<FirstRunStatusDto> GetAsync(string username, CancellationToken ct = default)
+    {
+        var state = await ReadAsync(username, ct).ConfigureAwait(false);
+        return ToDto(state);
+    }
+
+    public async Task<FirstRunStatusDto> CompleteAsync(
+        string username,
+        CompleteFirstRunRequestDto request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var kit = StarterKits.FirstOrDefault(item => item.Id.Equals(request.StarterKitId, StringComparison.OrdinalIgnoreCase))
+            ?? throw new ArgumentException("Choose a supported starter workspace.", nameof(request));
+
+        var dataChoice = NormalizeDataChoice(request.DataChoice);
+        var useSample = request.UseSampleData || dataChoice == "sample";
+        var now = DateTimeOffset.UtcNow;
+        var state = new FirstRunState(
+            true,
+            string.IsNullOrWhiteSpace(request.Goal) ? kit.Goal : request.Goal.Trim(),
+            kit.Id,
+            dataChoice,
+            useSample,
+            useSample ? "sample" : "primary",
+            new Dictionary<string, DateTimeOffset>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["workspace-opened"] = now,
+                ["data-imported"] = useSample ? now : default
+            }.Where(pair => pair.Value != default).ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.OrdinalIgnoreCase),
+            now);
+
+        await WriteAsync(username, state, ct).ConfigureAwait(false);
+        if (useSample)
+        {
+            await ProvisionSamplePackAsync(username, ct).ConfigureAwait(false);
+        }
+
+        return ToDto(state);
+    }
+
+    public async Task<FirstRunStatusDto> CompleteOutcomeAsync(string username, string key, CancellationToken ct = default)
+    {
+        if (!OutcomeCatalog.Any(item => item.Key.Equals(key, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new ArgumentException("Unknown activation outcome.", nameof(key));
+        }
+
+        var state = await ReadAsync(username, ct).ConfigureAwait(false);
+        var outcomes = new Dictionary<string, DateTimeOffset>(state.CompletedOutcomes, StringComparer.OrdinalIgnoreCase)
+        {
+            [key.Trim()] = DateTimeOffset.UtcNow
+        };
+        state = state with { CompletedOutcomes = outcomes };
+        await WriteAsync(username, state, ct).ConfigureAwait(false);
+        return ToDto(state);
+    }
+
+    private FirstRunStatusDto ToDto(FirstRunState state)
+    {
+        var sample = state.IsSample;
+        var workspace = new WorkspaceModeDto(
+            state.WorkspaceId,
+            sample ? "Meridian Sample Workspace" : "Meridian Workspace",
+            sample,
+            sample ? "SAMPLE · PAPER" : "LOCAL",
+            sample ? "Sample data only. No live trading or production accounting." : "Local workspace data.",
+            sample ? SamplePackVersion : string.Empty);
+        var outcomes = OutcomeCatalog.Select(item =>
+        {
+            state.CompletedOutcomes.TryGetValue(item.Key, out var completedAt);
+            return new ActivationOutcomeDto(item.Key, item.Label, item.Action, item.Route, completedAt != default, completedAt == default ? null : completedAt);
+        }).ToArray();
+        var kit = StarterKits.FirstOrDefault(item => item.Id == state.StarterKitId);
+        var recommendations = new[]
+        {
+            new RecommendedActionDto("Open your desk", kit?.DefaultRoute ?? "/portfolio", "See the workspace configured for your goal."),
+            new RecommendedActionDto(sample ? "Review the sample statement" : "Add starting data", "/accounting/statement-import", "Import and validate a statement or holdings file."),
+            new RecommendedActionDto("Run a report", "/reporting/run", "Produce a useful result and keep the evidence.")
+        };
+        return new FirstRunStatusDto(state.IsComplete, state.Goal, state.StarterKitId, state.DataChoice, workspace, StarterKits, outcomes, recommendations);
+    }
+
+    private async Task<FirstRunState> ReadAsync(string username, CancellationToken ct)
+    {
+        var path = StatePath(username);
+        if (!File.Exists(path)) return FirstRunState.Empty;
+        try
+        {
+            await using var stream = File.OpenRead(path);
+            return await JsonSerializer.DeserializeAsync<FirstRunState>(stream, _json, ct).ConfigureAwait(false) ?? FirstRunState.Empty;
+        }
+        catch (JsonException)
+        {
+            return FirstRunState.Empty;
+        }
+    }
+
+    private async Task WriteAsync(string username, FirstRunState state, CancellationToken ct)
+    {
+        await _writeGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await AtomicFileWriter.WriteAsync(StatePath(username), JsonSerializer.Serialize(state, _json), ct).ConfigureAwait(false);
+        }
+        finally { _writeGate.Release(); }
+    }
+
+    private Task ProvisionSamplePackAsync(string username, CancellationToken ct)
+    {
+        var pack = new
+        {
+            version = SamplePackVersion,
+            label = "Sample · Paper",
+            generatedAtUtc = DateTimeOffset.UtcNow,
+            portfolio = new { name = "Northstar Sample Portfolio", cash = 125000m, holdings = new[] { new { symbol = "SPY", quantity = 120 }, new { symbol = "MSFT", quantity = 80 } } },
+            watchlist = new[] { "AAPL", "NVDA", "TLT", "EURUSD" },
+            marketHistory = new { symbols = new[] { "SPY", "MSFT", "TLT" }, sessions = 90 },
+            statement = new { fileName = "sample-custodian-statement.csv", status = "Awaiting import" },
+            reconciliationBreaks = new[] { new { id = "SAMPLE-BRK-001", summary = "Cash variance", amount = 1250m }, new { id = "SAMPLE-BRK-002", summary = "Unmatched fee", amount = 42.50m } },
+            report = new { name = "Sample portfolio review", status = "Ready to run" },
+            strategy = new { name = "Sample covered call", environment = "Paper", status = "Ready" }
+        };
+        return AtomicFileWriter.WriteAsync(SamplePath(username), JsonSerializer.Serialize(pack, _json), ct);
+    }
+
+    private string StatePath(string username) => Path.Combine(Root(username), "first-run.json");
+    private string SamplePath(string username) => Path.Combine(Root(username), "sample-pack.json");
+    private string Root(string username) => Path.Combine(configStore.GetDataRoot(), "workspaces", SafeSegment(username));
+    private static string SafeSegment(string value) => string.Concat(value.Trim().ToLowerInvariant().Select(ch => char.IsLetterOrDigit(ch) || ch is '-' or '_' ? ch : '-'));
+    private static string NormalizeDataChoice(string value) => value?.Trim().ToLowerInvariant() switch
+    {
+        "upload" => "upload", "provider" => "provider", "sample" => "sample", "skip" => "skip",
+        _ => throw new ArgumentException("Choose upload, provider, sample, or skip.", nameof(value))
+    };
+
+    private sealed record FirstRunState(
+        bool IsComplete,
+        string? Goal,
+        string? StarterKitId,
+        string? DataChoice,
+        bool IsSample,
+        string WorkspaceId,
+        IReadOnlyDictionary<string, DateTimeOffset> CompletedOutcomes,
+        DateTimeOffset? CompletedAtUtc)
+    {
+        public static FirstRunState Empty { get; } = new(false, null, null, null, false, "primary", new Dictionary<string, DateTimeOffset>(), null);
+    }
+}

--- a/src/Meridian.Ui.Shared/Services/InitialAccountBootstrapService.cs
+++ b/src/Meridian.Ui.Shared/Services/InitialAccountBootstrapService.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using Meridian.Identity;
+using Meridian.Identity.Auth;
+
+namespace Meridian.Ui.Shared.Services;
+
+/// <summary>Creates the first local administrator through a loopback-only, one-use launcher token.</summary>
+public sealed class InitialAccountBootstrapService(IUserAccountStore accountStore, LoginSessionService sessions)
+{
+    public const string TokenEnvironmentVariable = "MDC_BOOTSTRAP_TOKEN";
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public bool IsAvailable => !accountStore.HasAccounts && !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(TokenEnvironmentVariable));
+
+    public async Task<string?> CreateAsync(IPAddress? remoteAddress, string? suppliedToken, string username, string password, CancellationToken ct)
+    {
+        if (remoteAddress is not null && !IPAddress.IsLoopback(remoteAddress)) return null;
+        if (string.IsNullOrWhiteSpace(username) || username.Length > 80 || password.Length < 12) return null;
+
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (accountStore.HasAccounts) return null;
+            var expected = Environment.GetEnvironmentVariable(TokenEnvironmentVariable);
+            if (!TokenEquals(expected, suppliedToken)) return null;
+
+            await accountStore.UpsertAsync(
+                new UserAccountUpsertRequestDto(
+                    username.Trim(), UserRole.Admin.ToString(), null, null, password, null, false, false,
+                    "local-installer", "Create the first local Meridian administrator.", "initial-account-bootstrap", "local"),
+                "local-installer", ct).ConfigureAwait(false);
+
+            Environment.SetEnvironmentVariable(TokenEnvironmentVariable, null);
+            return sessions.CreateSession(username.Trim(), password);
+        }
+        finally { _gate.Release(); }
+    }
+
+    private static bool TokenEquals(string? expected, string? supplied)
+    {
+        if (string.IsNullOrWhiteSpace(expected) || string.IsNullOrWhiteSpace(supplied)) return false;
+        var left = Encoding.UTF8.GetBytes(expected);
+        var right = Encoding.UTF8.GetBytes(supplied);
+        return left.Length == right.Length && CryptographicOperations.FixedTimeEquals(left, right);
+    }
+}

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -144,6 +144,9 @@ public static class WorkstationServiceCollectionExtensions
         services.TryAddSingleton<IScopedAuthorizationService>(sp => sp.GetRequiredService<ScopedAccessService>());
         services.TryAddSingleton<UserProfileRegistry>();
         services.TryAddSingleton<LoginSessionService>();
+        services.TryAddSingleton<InitialAccountBootstrapService>();
+        services.TryAddSingleton<FirstRunExperienceService>();
+        services.TryAddSingleton<DesktopWorkstationLaunchService>();
         services.TryAddSingleton<IOperatorInboxService, InMemoryOperatorInboxService>();
         services.TryAddSingleton<FeatureCapabilitySettingsService>();
         services.TryAddSingleton<SensitiveActionPolicyEngine>();

--- a/src/Meridian.Ui/dashboard/README.md
+++ b/src/Meridian.Ui/dashboard/README.md
@@ -11,6 +11,11 @@ last_reviewed: 2026-07-10
 
 # src/Meridian.Ui/dashboard
 
+First launch is browser-primary. `/setup` renders the first-run concierge while the
+shared first-run API remains the source of truth for starter kits, sample safety labels,
+recommendations, and completed activation outcomes. Sample mode stays offline-capable
+and visibly labelled `SAMPLE · PAPER` throughout the shell.
+
 ## Purpose
 
 Browser workstation dashboard is the active browser operator workstation.

--- a/src/Meridian.Ui/dashboard/src/app.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.tsx
@@ -76,9 +76,9 @@ import {
 import { ActivityLogProvider } from "@/lib/activity-log/store";
 import {
   OnboardingCoachMark,
-  OnboardingHeaderProgress,
   useOnboardingTour
 } from "@/components/meridian/onboarding-tour";
+import { ActivationHeaderProgress } from "@/features/first-run/activation-progress";
 import { PriceAlertsProvider } from "@/lib/price-alerts/service";
 import {
   reportWorkstationRouteError,
@@ -87,6 +87,9 @@ import {
 import { cn } from "@/lib/utils";
 import { legacyWorkspaceRedirect, resolveWorkstationRouteBreadcrumbLabel, workspacePath } from "@/lib/workspace";
 import type { WorkspaceKey, WorkspaceSummary } from "@/types";
+import { FirstRunScreen } from "@/features/first-run/first-run-screen";
+import type { FirstRunStatus } from "@/features/first-run/types";
+import { apiGetJson } from "@/lib/api";
 
 // Lazy route modules and data-backed panels often mount hash targets after the
 // shell route change. Wait briefly before falling back to the workbench landmark,
@@ -150,8 +153,24 @@ export function App() {
  */
 function AppRoot() {
   const { pathname } = useLocation();
+  const [firstRun, setFirstRun] = useState<FirstRunStatus | null>(null);
+  const [firstRunChecked, setFirstRunChecked] = useState(false);
+  useEffect(() => {
+    let active = true;
+    apiGetJson<FirstRunStatus>("/api/workstation/first-run/")
+      .then((value) => { if (active) { setFirstRun(value); setFirstRunChecked(true); } })
+      .catch(() => { if (active) setFirstRunChecked(true); });
+    return () => { active = false; };
+  }, []);
+
   if (isCompanionPaneRoute(pathname)) {
     return <CompanionPaneWindow />;
+  }
+  if (firstRunChecked && firstRun && !firstRun.isComplete && pathname !== "/setup") {
+    return <Navigate to="/setup" replace />;
+  }
+  if (pathname === "/setup") {
+    return <FirstRunScreen initialStatus={firstRun} />;
   }
   return <AppShell />;
 }
@@ -482,7 +501,7 @@ function AppShell() {
         actions={(
           <>
             <DecisionBriefPill brief={shell.workflowContinuity.decisionBrief} />
-            <OnboardingHeaderProgress controller={onboardingTour} />
+            <ActivationHeaderProgress />
             <ActivityCenter />
             <NotificationCenter overview={overview} fundAccountId={operatingScopeInput.fundAccountId} />
           </>

--- a/src/Meridian.Ui/dashboard/src/features/first-run/activation-progress.tsx
+++ b/src/Meridian.Ui/dashboard/src/features/first-run/activation-progress.tsx
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+import { FlaskConical } from "lucide-react";
+import { apiGetJson, apiPostJson } from "@/lib/api";
+import type { FirstRunStatus } from "./types";
+
+export function ActivationHeaderProgress() {
+  const [status, setStatus] = useState<FirstRunStatus | null>(null);
+  useEffect(() => { void apiGetJson<FirstRunStatus>("/api/workstation/first-run/").then(setStatus).catch(() => undefined); }, []);
+  if (!status?.isComplete) return null;
+  const completed = status.outcomes.filter((outcome) => outcome.isComplete).length;
+  return <div className="flex items-center gap-2">
+    {status.workspace.isSample ? <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-400/15 px-2.5 py-1 text-xs font-semibold text-amber-200" title={status.workspace.safetyMessage}><FlaskConical size={13} />{status.workspace.badge}</span> : null}
+    <span className="rounded-full bg-slate-800 px-2.5 py-1 text-xs text-slate-300" title="Activation is based on completed outcomes, not page visits">Getting started {completed}/{status.outcomes.length}</span>
+    <button className="rounded-full border border-slate-700 px-2.5 py-1 text-xs text-slate-300 hover:border-cyan-400 hover:text-cyan-200" onClick={() => void apiPostJson("/api/workstation/desktop/launch", { page: "Portfolio" })}>Open desktop workstation</button>
+  </div>;
+}

--- a/src/Meridian.Ui/dashboard/src/features/first-run/first-run-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/features/first-run/first-run-screen.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useMemo, useState } from "react";
+import { ArrowLeft, ArrowRight, Check, Database, ShieldCheck } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { apiGetJson, apiPostJson } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import type { FirstRunStatus } from "./types";
+
+const goals = [
+  ["monitor-investments", "Monitor investments"],
+  ["operate-fund", "Operate a fund"],
+  ["reconcile-accounts", "Reconcile accounts and statements"],
+  ["research-strategies", "Research and test strategies"],
+  ["collect-market-data", "Collect trusted market data"]
+] as const;
+
+const dataChoices = [
+  ["upload", "Upload a statement or holdings file"],
+  ["provider", "Connect a provider"],
+  ["sample", "Use sample data"],
+  ["skip", "Skip for now"]
+] as const;
+
+export function FirstRunScreen({ initialStatus }: { initialStatus?: FirstRunStatus | null }) {
+  const navigate = useNavigate();
+  const [status, setStatus] = useState<FirstRunStatus | null>(initialStatus ?? null);
+  const [step, setStep] = useState(0);
+  const [goal, setGoal] = useState("monitor-investments");
+  const [starterKitId, setStarterKitId] = useState("personal-portfolio");
+  const [dataChoice, setDataChoice] = useState("sample");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!status) apiGetJson<FirstRunStatus>("/api/workstation/first-run/").then(setStatus).catch((reason) => setError(String(reason)));
+  }, [status]);
+
+  useEffect(() => {
+    const recommended = status?.starterKits.find((kit) => kit.goal === goal);
+    if (recommended) setStarterKitId(recommended.id);
+  }, [goal, status]);
+
+  const starter = useMemo(() => status?.starterKits.find((kit) => kit.id === starterKitId), [starterKitId, status]);
+  const steps = ["Welcome", "Your goal", "Starting data", "Review", "Ready"];
+
+  async function finish() {
+    setBusy(true);
+    setError(null);
+    try {
+      const next = await apiPostJson<FirstRunStatus>("/api/workstation/first-run/complete", {
+        goal,
+        starterKitId,
+        dataChoice,
+        useSampleData: dataChoice === "sample"
+      });
+      setStatus(next);
+      setStep(4);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "Meridian could not save this workspace setup.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!status) return <div className="min-h-screen bg-slate-950 p-8 text-slate-100">Preparing Meridian…</div>;
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-5 py-8 text-slate-100" aria-labelledby="first-run-title">
+      <div className="mx-auto flex min-h-[calc(100vh-4rem)] max-w-5xl flex-col rounded-3xl border border-slate-800 bg-slate-900/80 shadow-2xl">
+        <header className="border-b border-slate-800 px-7 py-6">
+          <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-[0.22em] text-cyan-300"><ShieldCheck size={18} /> Meridian</div>
+          <ol className="mt-5 grid grid-cols-5 gap-2" aria-label="Setup progress">
+            {steps.map((label, index) => <li key={label} className={`rounded-full px-3 py-2 text-center text-xs ${index <= step ? "bg-cyan-400/15 text-cyan-200" : "bg-slate-800 text-slate-500"}`}>{index < step ? <Check className="mr-1 inline" size={13} /> : null}{label}</li>)}
+          </ol>
+        </header>
+
+        <section className="flex flex-1 flex-col justify-center px-7 py-10 md:px-16">
+          {step === 0 ? <>
+            <p className="text-sm font-medium text-cyan-300">A calm start, with no infrastructure to configure</p>
+            <h1 id="first-run-title" className="mt-3 text-4xl font-semibold tracking-tight">Welcome to Meridian</h1>
+            <p className="mt-4 max-w-2xl text-lg text-slate-300">Set up a focused desk, or explore a believable paper workspace that works without credentials or network access.</p>
+            <div className="mt-8 grid gap-4 md:grid-cols-2">
+              <Choice selected onClick={() => { setDataChoice("sample"); setStep(1); }} title="Explore with sample data" description="Recommended. See a portfolio, statement, breaks, report, and paper strategy immediately." />
+              <Choice selected={false} onClick={() => setStep(1)} title="Set up my workspace" description="Choose your goal and add your own data now or later." />
+            </div>
+          </> : null}
+
+          {step === 1 ? <>
+            <h1 id="first-run-title" className="text-3xl font-semibold">What do you want Meridian to help with?</h1>
+            <div className="mt-7 grid gap-3 md:grid-cols-2">{goals.map(([id, label]) => <Choice key={id} selected={goal === id} onClick={() => setGoal(id)} title={label} description={status.starterKits.find((kit) => kit.goal === id)?.description ?? "Configure a focused Meridian desk."} />)}</div>
+          </> : null}
+
+          {step === 2 ? <>
+            <h1 id="first-run-title" className="text-3xl font-semibold">Choose your starting data</h1>
+            <p className="mt-3 text-slate-300">Sample mode is clearly labelled and can never place live trades or post production accounting.</p>
+            <div className="mt-7 grid gap-3 md:grid-cols-2">{dataChoices.map(([id, label]) => <Choice key={id} selected={dataChoice === id} onClick={() => setDataChoice(id)} title={label} description={id === "sample" ? "Works offline and needs no provider credentials." : id === "skip" ? "You can add data later from your desk." : "Meridian will guide the next step after setup."} />)}</div>
+          </> : null}
+
+          {step === 3 ? <>
+            <h1 id="first-run-title" className="text-3xl font-semibold">Review your setup</h1>
+            <div className="mt-7 divide-y divide-slate-800 rounded-2xl border border-slate-700 bg-slate-950/40">
+              <Review label="Starter workspace" value={starter?.name ?? starterKitId} />
+              <Review label="Storage" value="Meridian application data (outside the installation directory)" />
+              <Review label="Starting data" value={dataChoices.find(([id]) => id === dataChoice)?.[1] ?? dataChoice} />
+              <Review label="Trading and accounting" value={dataChoice === "sample" ? "Paper and sample only" : "No live action until explicitly connected and approved"} />
+              <Review label="Credentials" value="Encrypted credential store; never included in sample data" />
+            </div>
+          </> : null}
+
+          {step === 4 ? <>
+            <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-emerald-400/15 text-emerald-300"><Check size={32} /></div>
+            <h1 id="first-run-title" className="mt-6 text-4xl font-semibold">Your workspace is ready</h1>
+            {status.workspace.isSample ? <p className="mt-3 inline-flex w-fit items-center gap-2 rounded-full bg-amber-400/15 px-3 py-1.5 text-sm font-semibold text-amber-200"><Database size={15} /> {status.workspace.badge}</p> : null}
+            <div className="mt-8 grid gap-4 md:grid-cols-3">{status.recommendedActions.map((action) => <button key={action.route} className="rounded-2xl border border-slate-700 bg-slate-950/40 p-5 text-left transition hover:border-cyan-400" onClick={() => navigate(action.route)}><strong className="block text-slate-100">{action.label}</strong><span className="mt-2 block text-sm text-slate-400">{action.description}</span></button>)}</div>
+          </> : null}
+
+          {error ? <p className="mt-6 rounded-xl border border-red-500/40 bg-red-500/10 p-4 text-red-200" role="alert">What failed: setup could not be saved. What it affects: this workspace is not ready yet. Meridian can try again. Details: {error}</p> : null}
+        </section>
+
+        {step > 0 && step < 4 ? <footer className="flex items-center justify-between border-t border-slate-800 px-7 py-5">
+          <Button variant="ghost" onClick={() => setStep((value) => Math.max(0, value - 1))}><ArrowLeft size={16} /> Back</Button>
+          <Button disabled={busy} onClick={() => step === 3 ? void finish() : setStep((value) => value + 1)}>{busy ? "Creating workspace…" : step === 3 ? "Create workspace" : "Continue"} <ArrowRight size={16} /></Button>
+        </footer> : null}
+      </div>
+    </main>
+  );
+}
+
+function Choice({ selected, onClick, title, description }: { selected: boolean; onClick: () => void; title: string; description: string }) {
+  return <button type="button" aria-pressed={selected} onClick={onClick} className={`rounded-2xl border p-5 text-left transition ${selected ? "border-cyan-400 bg-cyan-400/10" : "border-slate-700 bg-slate-950/30 hover:border-slate-500"}`}><strong className="block text-base text-slate-100">{title}</strong><span className="mt-2 block text-sm leading-6 text-slate-400">{description}</span></button>;
+}
+
+function Review({ label, value }: { label: string; value: string }) {
+  return <div className="grid gap-1 px-5 py-4 md:grid-cols-[13rem_1fr]"><span className="text-sm text-slate-400">{label}</span><strong className="font-medium text-slate-100">{value}</strong></div>;
+}

--- a/src/Meridian.Ui/dashboard/src/features/first-run/types.ts
+++ b/src/Meridian.Ui/dashboard/src/features/first-run/types.ts
@@ -1,0 +1,34 @@
+export interface StarterWorkspace {
+  id: string;
+  name: string;
+  goal: string;
+  description: string;
+  defaultRoute: string;
+}
+
+export interface ActivationOutcome {
+  key: string;
+  label: string;
+  actionLabel: string;
+  route: string;
+  isComplete: boolean;
+  completedAtUtc: string | null;
+}
+
+export interface FirstRunStatus {
+  isComplete: boolean;
+  goal: string | null;
+  starterKitId: string | null;
+  dataChoice: string | null;
+  workspace: {
+    id: string;
+    name: string;
+    isSample: boolean;
+    badge: string;
+    safetyMessage: string;
+    samplePackVersion: string;
+  };
+  starterKits: StarterWorkspace[];
+  outcomes: ActivationOutcome[];
+  recommendedActions: Array<{ label: string; route: string; description: string }>;
+}

--- a/src/Meridian.Wpf/README.md
+++ b/src/Meridian.Wpf/README.md
@@ -11,6 +11,10 @@ last_reviewed: 2026-07-12
 
 # src/Meridian.Wpf
 
+The desktop workstation is installed as part of the single Meridian product and opened
+on demand from the browser workstation. It is not a separate end-user package or Start
+Menu product.
+
 ## Purpose
 
 WPF workstation is an active Windows desktop operator workstation and a co-equal UI lane alongside

--- a/src/Meridian/README.md
+++ b/src/Meridian/README.md
@@ -11,6 +11,11 @@ last_reviewed: 2026-06-02
 
 # src/Meridian
 
+Consumer releases start this host through the installed Meridian launcher. The launcher
+owns dynamic loopback-port selection, first-account bootstrap, data-root separation,
+readiness polling, and browser launch. Direct host commands remain developer/operator
+surfaces, not end-user installation instructions.
+
 ## Purpose
 
 Meridian host is the application host, CLI entrypoint, and runtime composition root.

--- a/tests/Meridian.Tests/Identity/InitialAccountBootstrapServiceTests.cs
+++ b/tests/Meridian.Tests/Identity/InitialAccountBootstrapServiceTests.cs
@@ -1,0 +1,47 @@
+using System.Net;
+using FluentAssertions;
+using Meridian.Identity;
+using Meridian.Storage;
+using Meridian.Testing;
+using Meridian.Ui.Shared.Services;
+using Xunit;
+
+namespace Meridian.Tests.Identity;
+
+[Collection("IdentityEnvironment")]
+public sealed class InitialAccountBootstrapServiceTests
+{
+    [Fact]
+    public async Task CreateAsync_WithLoopbackOneUseToken_CreatesAuditedAccountAndSession()
+    {
+        using var artifacts = TestArtifactDirectory.Create(nameof(CreateAsync_WithLoopbackOneUseToken_CreatesAuditedAccountAndSession));
+        using var environment = new EnvironmentVariableScope().Set(InitialAccountBootstrapService.TokenEnvironmentVariable, "one-use-token");
+        var store = new FileUserAccountStore(new StorageOptions { RootPath = artifacts.RootPath });
+        var registry = new UserProfileRegistry(null, store);
+        var sessions = new LoginSessionService(new FakeHostEnvironment("Production"), registry);
+        var service = new InitialAccountBootstrapService(store, sessions);
+
+        var token = await service.CreateAsync(IPAddress.Loopback, "one-use-token", "owner", "twelve-characters", CancellationToken.None);
+
+        token.Should().NotBeNull();
+        sessions.ValidateSession(token!).Should().BeTrue();
+        store.LoadAccounts().Should().ContainSingle(account => account.Username == "owner");
+        Environment.GetEnvironmentVariable(InitialAccountBootstrapService.TokenEnvironmentVariable).Should().BeNull();
+        (await service.CreateAsync(IPAddress.Loopback, "one-use-token", "other", "twelve-characters", CancellationToken.None)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateAsync_FromNonLoopback_DoesNotCreateAccount()
+    {
+        using var artifacts = TestArtifactDirectory.Create(nameof(CreateAsync_FromNonLoopback_DoesNotCreateAccount));
+        using var environment = new EnvironmentVariableScope().Set(InitialAccountBootstrapService.TokenEnvironmentVariable, "token");
+        var store = new FileUserAccountStore(new StorageOptions { RootPath = artifacts.RootPath });
+        var sessions = new LoginSessionService(new FakeHostEnvironment("Production"), new UserProfileRegistry(null, store));
+        var service = new InitialAccountBootstrapService(store, sessions);
+
+        var result = await service.CreateAsync(IPAddress.Parse("192.0.2.1"), "token", "owner", "twelve-characters", CancellationToken.None);
+
+        result.Should().BeNull();
+        store.HasAccounts.Should().BeFalse();
+    }
+}

--- a/tests/Meridian.Tests/Ui/FirstRunExperienceServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/FirstRunExperienceServiceTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using Meridian.Contracts.Workstation;
+using Meridian.Core.Config;
+using Meridian.Ui.Shared.Services;
+using Meridian.Testing;
+using Xunit;
+
+namespace Meridian.Tests.Ui;
+
+public sealed class FirstRunExperienceServiceTests
+{
+    [Fact]
+    public async Task CompleteAsync_SampleMode_ProvisionsGovernedPackAndOutcomeEvidence()
+    {
+        using var artifacts = TestArtifactDirectory.Create(nameof(CompleteAsync_SampleMode_ProvisionsGovernedPackAndOutcomeEvidence));
+        var configPath = Path.Combine(artifacts.RootPath, "appsettings.json");
+        var config = new ConfigStore(configPath);
+        await config.SaveAsync(new AppConfig(DataRoot: artifacts.RootPath));
+        var service = new FirstRunExperienceService(config);
+
+        var result = await service.CompleteAsync("local-admin", new CompleteFirstRunRequestDto(
+            "monitor-investments", "personal-portfolio", "sample", true));
+
+        result.IsComplete.Should().BeTrue();
+        result.Workspace.IsSample.Should().BeTrue();
+        result.Workspace.Badge.Should().Contain("SAMPLE");
+        result.Outcomes.Single(item => item.Key == "workspace-opened").IsComplete.Should().BeTrue();
+        result.Outcomes.Single(item => item.Key == "data-imported").IsComplete.Should().BeTrue();
+        File.Exists(Path.Combine(artifacts.RootPath, "workspaces", "local-admin", "sample-pack.json")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CompleteOutcomeAsync_RejectsUnknownOutcome()
+    {
+        using var artifacts = TestArtifactDirectory.Create(nameof(CompleteOutcomeAsync_RejectsUnknownOutcome));
+        var config = new ConfigStore(Path.Combine(artifacts.RootPath, "appsettings.json"));
+        await config.SaveAsync(new AppConfig(DataRoot: artifacts.RootPath));
+        var service = new FirstRunExperienceService(config);
+
+        var act = () => service.CompleteOutcomeAsync("operator", "visited-a-page");
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*Unknown activation outcome*");
+    }
+}


### PR DESCRIPTION
## Summary
- add one consumer Setup.exe pipeline containing x64 and ARM64 host, browser, desktop, and launcher payloads
- add loopback-only one-use first-account bootstrap plus server-owned starter kits, sample pack, and activation evidence
- add browser-first concierge, persistent SAMPLE / PAPER safety badge, and desktop workstation command

## Validation
- dotnet build src/Meridian.Launcher/Meridian.Launcher.csproj (pass)
- dotnet build src/Meridian.Setup/Meridian.Setup.csproj (pass)
- dotnet build src/Meridian.Ui.Shared/Meridian.Ui.Shared.csproj --no-restore (pass; existing Microsoft.OpenApi NU1903 warning)
- dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter FullyQualifiedName~FirstRunExperienceServiceTests|FullyQualifiedName~InitialAccountBootstrapServiceTests --no-build --no-restore (4 passed)
- workflow YAML parsed with PyYAML (pass)
- npm run build reached Vite asset bundling but exceeded the local command window
- bash scripts/ci.sh could not start because this Windows host requires a WSL update; GitHub Actions is required for authoritative integration proof

## Governance
This changes .github/workflows/desktop-installer-packaging.yml and therefore requires explicit human governance review. Production tag signing also requires the protected desktop-release-signing environment.