### PR TITLE
fix(ci,ledger,accounting): clear pre-existing main test failures and unblock WPF doc-regen scope-gate

### DIFF
--- a/config/appsettings.schema.json
+++ b/config/appsettings.schema.json
@@ -420,10 +420,44 @@
         }
       }
     },
+    "AutoGapRemediationConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "DefaultProvider": {
+          "type": "string"
+        },
+        "MaxConcurrentRemediations": {
+          "type": "integer"
+        },
+        "MinimumGapDurationSeconds": {
+          "type": "integer"
+        },
+        "MinimumGapSize": {
+          "type": "integer"
+        },
+        "ProviderCooldownSeconds": {
+          "type": "integer"
+        },
+        "SymbolCooldownSeconds": {
+          "type": "integer"
+        }
+      }
+    },
     "BackfillConfig": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "AutoRemediation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AutoGapRemediationConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "EnableFallback": {
           "type": "boolean"
         },

--- a/src/Meridian.FinancialOperations/PrivateCapital/PrivateCapitalCloseCockpitService.cs
+++ b/src/Meridian.FinancialOperations/PrivateCapital/PrivateCapitalCloseCockpitService.cs
@@ -908,7 +908,7 @@ public sealed class PrivateCapitalCloseCockpitService : IPrivateCapitalCloseCock
             .Concat(draftEvidence)
             .DistinctBy(static link => $"{link.EvidenceId}|{link.Route}", StringComparer.OrdinalIgnoreCase)
             .ToArray();
-        var summary = allPosted
+        var summary = isReady && allPosted
             ? $"{scopedDrafts.Count} monthly fee/dividend draft(s) are posted with retained evidence."
             : $"{schedule.Summary} Configured={schedule.ConfiguredCount}, enabled={schedule.EnabledCount}, fee={schedule.FeeScheduleCount}, dividend={schedule.DividendScheduleCount}, ready={schedule.DraftReadyCount}, investigation={schedule.NeedsInvestigationCount}, blocked={schedule.BlockedCount}.";
         var requiredAction = schedule.State switch

--- a/src/Meridian.Ui.Shared/Services/AccountingClosePostingWorkbenchBridge.cs
+++ b/src/Meridian.Ui.Shared/Services/AccountingClosePostingWorkbenchBridge.cs
@@ -14,19 +14,27 @@ public sealed class AccountingClosePostingWorkbenchBridge : IAccountingClosePost
     private readonly AutomatedJournalIntakeRunner _runner;
     private readonly IManualJournalEntryWorkbenchService _workbench;
     private readonly IManualJournalEntryLifecycleService _lifecycle;
-    private readonly ILedgerBookService _ledgerBookService;
+    // Optional: the durable ledger book service is only registered when a persistence-backed
+    // ledger (Postgres) is configured. Without it the close-posting gate degrades to Blocked
+    // rather than failing composition, matching the workstation's "durable ledger optional" pattern.
+    private readonly ILedgerBookService? _ledgerBookService;
 
     public AccountingClosePostingWorkbenchBridge(
         AutomatedJournalIntakeRunner runner,
         IManualJournalEntryWorkbenchService workbench,
         IManualJournalEntryLifecycleService lifecycle,
-        ILedgerBookService ledgerBookService)
+        ILedgerBookService? ledgerBookService)
     {
         _runner = runner ?? throw new ArgumentNullException(nameof(runner));
         _workbench = workbench ?? throw new ArgumentNullException(nameof(workbench));
         _lifecycle = lifecycle ?? throw new ArgumentNullException(nameof(lifecycle));
-        _ledgerBookService = ledgerBookService ?? throw new ArgumentNullException(nameof(ledgerBookService));
+        _ledgerBookService = ledgerBookService;
     }
+
+    private ILedgerBookService RequireLedgerBookService()
+        => _ledgerBookService
+            ?? throw new InvalidOperationException(
+                "The durable ledger book service is not configured; period-close posting requires a persistence-backed ledger.");
 
     public async Task<ClosePostingGateDto> EvaluateAsync(
         AccountingClosePostingContext context,
@@ -107,7 +115,7 @@ public sealed class AccountingClosePostingWorkbenchBridge : IAccountingClosePost
                 $"Ledger period '{period.Label}' cannot be hard-closed while the closing-entry gate is {gate.State}: {gate.Detail}");
         }
 
-        var closed = await _ledgerBookService.ClosePeriodAsync(
+        var closed = await RequireLedgerBookService().ClosePeriodAsync(
                 period.PeriodId,
                 new CloseLedgerPeriodRequest(
                     LedgerPeriodCloseKindDto.HardClose,
@@ -212,7 +220,7 @@ public sealed class AccountingClosePostingWorkbenchBridge : IAccountingClosePost
         }
         else
         {
-            await _ledgerBookService.ReopenPeriodAsync(
+            await RequireLedgerBookService().ReopenPeriodAsync(
                     period.PeriodId,
                     new ReopenLedgerPeriodRequest(
                         command.Actor,
@@ -398,7 +406,7 @@ public sealed class AccountingClosePostingWorkbenchBridge : IAccountingClosePost
         AccountingClosePostingContext context,
         CancellationToken ct)
     {
-        var periods = await _ledgerBookService
+        var periods = await RequireLedgerBookService()
             .ListPeriodsAsync(new LedgerPeriodQuery(LedgerBookId: context.LedgerBookId), ct)
             .ConfigureAwait(false);
         var hasGuid = Guid.TryParse(context.PeriodId, out var requestedId);

--- a/src/Meridian.Ui.Shared/Services/AccountingClosePostingWorkbenchBridge.cs
+++ b/src/Meridian.Ui.Shared/Services/AccountingClosePostingWorkbenchBridge.cs
@@ -31,16 +31,24 @@ public sealed class AccountingClosePostingWorkbenchBridge : IAccountingClosePost
         _ledgerBookService = ledgerBookService;
     }
 
+    private const string LedgerUnavailableDetail =
+        "The durable ledger book service is not configured; period-close posting requires a persistence-backed ledger.";
+
     private ILedgerBookService RequireLedgerBookService()
-        => _ledgerBookService
-            ?? throw new InvalidOperationException(
-                "The durable ledger book service is not configured; period-close posting requires a persistence-backed ledger.");
+        => _ledgerBookService ?? throw new InvalidOperationException(LedgerUnavailableDetail);
 
     public async Task<ClosePostingGateDto> EvaluateAsync(
         AccountingClosePostingContext context,
         CancellationToken ct = default)
     {
         ValidateContext(context);
+        // Without a persistence-backed ledger the gate cannot resolve periods; degrade the read path
+        // to Blocked explicitly rather than surfacing an exception through the catch below.
+        if (_ledgerBookService is null)
+        {
+            return Blocked(context, LedgerUnavailableDetail);
+        }
+
         try
         {
             var period = await ResolvePeriodAsync(context, ct).ConfigureAwait(false);

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -527,7 +527,15 @@ public static class WorkstationServiceCollectionExtensions
                     ? null
                     : new DailyMarkToMarketService(new RegisteredHistoricalCloseMarkPriceSource(providerRegistry)));
         });
-        services.TryAddSingleton<IAccountingClosePostingWorkbench, AccountingClosePostingWorkbenchBridge>();
+        // The durable ledger book service is only registered when a persistence-backed ledger is
+        // configured (see StorageFeatureRegistration). Resolve it optionally so the workstation graph
+        // still composes without Postgres; the bridge degrades the close-posting gate to Blocked.
+        services.TryAddSingleton<IAccountingClosePostingWorkbench>(sp =>
+            new AccountingClosePostingWorkbenchBridge(
+                sp.GetRequiredService<AutomatedJournalIntakeRunner>(),
+                sp.GetRequiredService<IManualJournalEntryWorkbenchService>(),
+                sp.GetRequiredService<IManualJournalEntryLifecycleService>(),
+                sp.GetService<Meridian.Contracts.Ledger.ILedgerBookService>()));
         services.TryAddSingleton<DailyValuationScheduledWorker>();
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IHostedService, DailyValuationSchedulerHostedService>());

--- a/tests/Meridian.Tests/Application/Services/FundOperationsWorkspaceReadServiceTests.cs
+++ b/tests/Meridian.Tests/Application/Services/FundOperationsWorkspaceReadServiceTests.cs
@@ -969,7 +969,7 @@ public sealed class FundOperationsWorkspaceReadServiceTests
         workspace.RecordedRunCount.Should().Be(0);
         workspace.Ledger.Journal.Select(static row => row.Description)
             .Should()
-            .Equal("capital contribution", "administration accrual");
+            .Equal("administration accrual", "capital contribution");
         workspace.Ledger.TrialBalance.Should().ContainSingle(row =>
             row.AccountName == "Assets:Cash" && row.Balance == 1_000m);
         workspace.Ledger.TrialBalance.Should().ContainSingle(row =>

--- a/tests/Meridian.Tests/Storage/LedgerBookServiceTests.cs
+++ b/tests/Meridian.Tests/Storage/LedgerBookServiceTests.cs
@@ -361,7 +361,11 @@ public sealed class LedgerBookServiceTests
             "2026-P04",
             new DateOnly(2026, 4, 1),
             new DateOnly(2026, 4, 30)));
-        await store.AppendAsync(BuildBalancedEntry(period.PeriodId, revenue: 1_000m, expense: 250m));
+        await store.AppendAsync(BuildBalancedEntry(
+            period.PeriodId,
+            revenue: 1_000m,
+            expense: 250m,
+            timestamp: DateTimeOffset.Parse("2026-04-30T21:00:00Z")));
         await service.ClosePeriodAsync(
             period.PeriodId,
             new CloseLedgerPeriodRequest(LedgerPeriodCloseKindDto.SoftClose, "fund-controller"));

--- a/tests/Meridian.Tests/Storage/LedgerBookServiceTests.cs
+++ b/tests/Meridian.Tests/Storage/LedgerBookServiceTests.cs
@@ -365,7 +365,7 @@ public sealed class LedgerBookServiceTests
             period.PeriodId,
             revenue: 1_000m,
             expense: 250m,
-            timestamp: DateTimeOffset.Parse("2026-04-30T21:00:00Z")));
+            timestamp: new DateTimeOffset(2026, 4, 30, 21, 0, 0, TimeSpan.Zero)));
         await service.ClosePeriodAsync(
             period.PeriodId,
             new CloseLedgerPeriodRequest(LedgerPeriodCloseKindDto.SoftClose, "fund-controller"));

--- a/tests/Meridian.Tests/Ui/AccountingConfigurationServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/AccountingConfigurationServiceTests.cs
@@ -1306,7 +1306,10 @@ public sealed class AccountingConfigurationServiceTests
 
         var write = journalStore.Appended.Should().ContainSingle().Subject;
         postingTarget.PostCount.Should().Be(1);
-        postingTarget.LastWrite.Should().BeSameAs(write);
+        // The governed target captures the write as received; the store persists the normalized
+        // clone (normalize-on-append rebuilds the record), so compare by stable journal-entry identity.
+        postingTarget.LastWrite.Should().NotBeNull();
+        postingTarget.LastWrite!.Entry.JournalEntryId.Should().Be(write.Entry.JournalEntryId);
         write.AggregateId.Should().Be(ManualJournalLedgerBookId);
         write.LedgerBookId.Should().Be(ManualJournalLedgerBookId);
         write.PeriodId.Should().Be(ManualJournalPeriodId);
@@ -1401,7 +1404,8 @@ public sealed class AccountingConfigurationServiceTests
             MaximumMarkAgeDays: 3,
             MinimumConfidence: DailyPortfolioPriceConfidence.Medium,
             RequireCompleteCoverage: true,
-            ClosePeriodId: "2026-06"));
+            ClosePeriodId: "2026-06",
+            EntityId: "entity-master"));
         var scheduler = new DailyValuationScheduledWorker(
             scheduleSource,
             runner,

--- a/tools/roadmap/enforce_phase_scope.py
+++ b/tools/roadmap/enforce_phase_scope.py
@@ -43,6 +43,40 @@ PHASE_RULES: dict[str, list[str]] = {
 PHASE_LABEL = re.compile(r"\bphase:(PR[0-9])\b", re.IGNORECASE)
 PHASE_BODY = re.compile(r"<!--\s*phase\s*:\s*(PR[0-9])\s*-->", re.IGNORECASE)
 
+# The roadmap/source-doc authoring surface this gate protects. Mirrors the ``paths`` triggers of
+# .github/workflows/roadmap-source-docs.yml. A change is only subject to phase governance when it
+# edits one of these paths and is not a generated artifact (see GENERATED_ARTIFACT_PATTERNS).
+GOVERNED_SURFACE_PATTERNS: list[str] = [
+    "docs/roadmap/**",
+    "docs/source/**",
+    "docs/status/**",
+    "docs/architecture/**",
+    "src/**/README.md",
+    "build/scripts/docs/**",
+    ".github/workflows/roadmap-source-docs.yml",
+    ".github/instructions/source-documentation.instructions.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+]
+
+# Machine-generated artifacts that live inside the governed surface but change as a mechanical side
+# effect of source or roadmap-data edits: the WPF screen tracker, docs-automation summaries, the doc
+# health dashboard, and rendered diagram/doc trees. They are already drift-checked by their own
+# render/regenerate jobs, so the authoring phase-scope gate must never police them. Without this
+# exemption a PR that legitimately regenerates them (for example a src/Meridian.Wpf/** change that
+# refreshes the WPF screen tracker) is trapped between the documentation drift gate, which requires
+# them committed, and this gate, which would reject the same files as out of phase scope.
+GENERATED_ARTIFACT_PATTERNS: list[str] = [
+    "docs/status/wpf-screen-development-tracker.md",
+    "docs/status/wpf-screen-development-tracker.json",
+    "docs/status/docs-automation-summary.md",
+    "docs/status/docs-automation-summary.json",
+    "docs/status/doc-health-dashboard.json",
+    "docs/diagrams/**",
+    "docs/generated/**",
+    "docs/**/generated/**",
+]
+
 
 @dataclass(frozen=True)
 class PhaseResolution:
@@ -122,9 +156,28 @@ def parser() -> argparse.ArgumentParser:
 def main() -> int:
     args = parser().parse_args()
 
+    files = args.changed_file if args.changed_file else get_changed_files(args.base_ref, args.head_ref)
+
+    # Generated artifacts are exempt from phase scope: they are drift-checked by their own render
+    # jobs, so this gate only governs *authored* edits to the roadmap/source-doc surface.
+    generated = [f for f in files if matches(f, GENERATED_ARTIFACT_PATTERNS)]
+    governed_authored = [
+        f for f in files
+        if matches(f, GOVERNED_SURFACE_PATTERNS) and f not in generated
+    ]
+
     try:
         resolved = resolve_phase(args)
     except ValueError as ex:
+        # No phase declared. When the only governed-surface changes are generated artifacts there is
+        # no roadmap authoring to police, so the gate passes without requiring a phase marker. This
+        # unblocks PRs (for example src/Meridian.Wpf/** changes) that merely regenerate the WPF
+        # screen tracker or diagrams. Genuine authored roadmap/source-doc edits still require a marker.
+        if not governed_authored:
+            if args.json:
+                print(json.dumps({"phase": None, "source": "none", "changed": files, "generated_exempt": generated, "violations": []}, indent=2))
+            print("Phase scope gate passed: no authored roadmap/source-doc changes (generated artifacts and out-of-surface files are exempt).")
+            return 0
         print(f"::error::{ex}")
         return 2
 
@@ -132,12 +185,11 @@ def main() -> int:
         print(f"::error::Unsupported phase '{resolved.phase}'. Expected PR0..PR9.")
         return 2
 
-    files = args.changed_file if args.changed_file else get_changed_files(args.base_ref, args.head_ref)
     patterns = expand_patterns(resolved.phase)
-    violations = [f for f in files if not matches(f, patterns)]
+    violations = [f for f in files if not matches(f, patterns) and f not in generated]
 
     if args.json:
-        print(json.dumps({"phase": resolved.phase, "source": resolved.source, "changed": files, "patterns": patterns, "violations": violations}, indent=2))
+        print(json.dumps({"phase": resolved.phase, "source": resolved.source, "changed": files, "patterns": patterns, "generated_exempt": generated, "violations": violations}, indent=2))
 
     if violations:
         print(f"::error::Phase scope gate failed for {resolved.phase} (source: {resolved.source}).")


### PR DESCRIPTION
## Summary

Fixes the nine tests that were red on `main` (verified against the latest `Meridian CI` run on `ae341bd1`) and resolves the CI-governance catch-22 that kept `src/Meridian.Wpf/**` PRs from going green.

**Test / generated-artifact fixes**
- `config/appsettings.schema.json` — add the `AutoRemediation` property and the `AutoGapRemediationConfig` definition the generator now emits. The checked-in schema was regenerated incompletely alongside the `BackfillConfig` model change, so `ConfigSchemaIntegrationTests.CheckedInSchema_MatchesCurrentGeneratorOutput` drifted.
- `FundOperationsWorkspaceReadServiceTests` — expect the workspace journal in the read-model's established descending (recent-first) order (matches `LedgerReadService`/`StrategyRunReadService`).
- `LedgerBookServiceTests.ClosePeriodAsync_HardCloseWithTemporaryAccountResiduals_*` — date the seeded residual inside period `2026-P04` so the period-posting guard does not reject it before the hard-close path under test runs.
- `AccountingConfigurationServiceTests` — compare the posted durable write by stable journal-entry identity (normalize-on-append rebuilds the record, so `BeSameAs` can never hold), and supply the required `EntityId` dimension for the daily-valuation work item so submit-for-approval passes governed validation.

**Production fixes**
- `PrivateCapitalCloseCockpitService` — only show the "posted with retained evidence" scheduled-accruals summary when the lane is actually ready (`isReady && allPosted`), so a blocked needs-investigation lane surfaces the `fee=`/`dividend=` counts and required action instead of a misleading happy-path message.
- `AccountingClosePostingWorkbenchBridge` + `WorkstationServiceCollectionExtensions` — resolve `ILedgerBookService` optionally (it is only registered with a persistence-backed ledger, per `StorageFeatureRegistration`). The bridge now degrades the close-posting gate to `Blocked` rather than failing `UiServer` composition when Postgres is not configured — closing the `ILedgerBookService` DI gap that broke `BrokerageConnectionEndpointsTests.UiServer_*`.

**CI governance**
- `tools/roadmap/enforce_phase_scope.py` — exempt machine-generated artifacts (WPF screen tracker, docs-automation summaries, health dashboard, rendered diagram/doc trees) from the roadmap phase scope-gate, and require a `phase:PRx` marker only when *authored* roadmap/source-doc files change. WPF PRs can now commit the docs that `documentation.yml` forces them to regenerate without the scope-gate rejecting them; phase governance for genuine roadmap authoring is unchanged.

## Reason

`Meridian CI / quality-gate` was red repo-wide from nine pre-existing failures introduced by the `ae592b5b` "screen updates 2" durable-ledger refactor and its WIP follow-ups. Separately, any PR touching `src/Meridian.Wpf/**` regenerated docs under the scope-gated `docs/status/**` surface (notably `wpf-screen-development-tracker.*`), which the roadmap phase scope-gate then rejected — the team had been working around it by reverting the generated churn (`1e05a88a`).

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Notes: no .NET SDK is available in this environment, so `scripts/ci.sh` / `dotnet test` could not be run locally. Each failure was root-caused against the actual `verify-dotnet` failure logs from the latest `main` CI run and the source. The scope-gate change was verified locally with `python3 tools/roadmap/enforce_phase_scope.py` across four scenarios (WPF regen → pass; authored roadmap change with/without a phase marker; out-of-scope source with a marker). The authoritative `quality-gate` run on this PR is the final gate.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

Note: `tools/roadmap/enforce_phase_scope.py` (the roadmap phase scope-gate) is modified. It is not in the checklist's governance-file set, but the change is governance-adjacent and is described in full above for reviewer attention; the change only relaxes the gate for machine-generated artifacts and preserves enforcement for authored roadmap/source-doc edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KwCCB5aDn49KsCFuxwaqJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019KwCCB5aDn49KsCFuxwaqJ)_