### PR TITLE
Repair main build: finish operator-override decision migration + re-land valuation scheduler fix

### DIFF
--- a/src/Meridian.Application/SecurityMaster/NullSecurityMasterServices.cs
+++ b/src/Meridian.Application/SecurityMaster/NullSecurityMasterServices.cs
@@ -261,20 +261,11 @@ internal sealed class NullOperatorOverridesStore : IOperatorOverridesStore
             "Security Master is not configured. " +
             "Set the MERIDIAN_SECURITY_MASTER_CONNECTION_STRING environment variable to enable operator overrides."));
 
-<<<<<<< Updated upstream
-    public Task<OperatorOverridesDto?> RecordApprovalDecisionAsync(
-        Guid securityId,
-        OperatorOverrideApprovalDecisionRequest request,
-        string reviewer,
-        CancellationToken ct = default)
-        => Task.FromException<OperatorOverridesDto?>(new InvalidOperationException(
-=======
     public Task<OperatorOverridesDto> RecordApprovalDecisionAsync(
         Guid securityId,
         OperatorOverrideDecisionRequest request,
         CancellationToken ct = default)
         => Task.FromException<OperatorOverridesDto>(new InvalidOperationException(
->>>>>>> Stashed changes
             "Security Master is not configured. " +
             "Set the MERIDIAN_SECURITY_MASTER_CONNECTION_STRING environment variable to enable operator overrides."));
 }

--- a/src/Meridian.Contracts/SecurityMaster/OperatorOverrides.cs
+++ b/src/Meridian.Contracts/SecurityMaster/OperatorOverrides.cs
@@ -58,23 +58,13 @@ public sealed record OperatorOverridesPatchRequest(
 }
 
 /// <summary>
-<<<<<<< Updated upstream
-/// Records a reviewer's approval decision for a security's pending operator overrides. The
-/// <see cref="Decision"/> must be either <see cref="SecurityOverrideApprovalStatusDto.Approved"/> or
-/// <see cref="SecurityOverrideApprovalStatusDto.Rejected"/>; the acting reviewer is server-derived
-/// from the authenticated principal, not supplied by the caller.
-/// </summary>
-public sealed record OperatorOverrideApprovalDecisionRequest(
-    SecurityOverrideApprovalStatusDto Decision,
-    string? ReasonCode = null,
-=======
 /// A reviewer's decision on a pending operator-override overlay. <see cref="Decision"/> must be
 /// <see cref="SecurityOverrideApprovalStatusDto.Approved"/> or
 /// <see cref="SecurityOverrideApprovalStatusDto.Rejected"/>; the reviewer identity and an optional
-/// comment are stamped onto the durable audit trail.
+/// comment are stamped onto the durable audit trail. <see cref="Reviewer"/> is server-derived from
+/// the authenticated principal, not supplied by the caller.
 /// </summary>
 public sealed record OperatorOverrideDecisionRequest(
     SecurityOverrideApprovalStatusDto Decision,
     string Reviewer,
->>>>>>> Stashed changes
     string? Comment = null);

--- a/src/Meridian.Core/Serialization/SecurityMasterJsonContext.cs
+++ b/src/Meridian.Core/Serialization/SecurityMasterJsonContext.cs
@@ -137,11 +137,7 @@ namespace Meridian.Core.Serialization;
 [JsonSerializable(typeof(UpsertSecurityAliasRequest))]
 [JsonSerializable(typeof(OperatorOverridesDto))]
 [JsonSerializable(typeof(OperatorOverridesPatchRequest))]
-<<<<<<< Updated upstream
-[JsonSerializable(typeof(OperatorOverrideApprovalDecisionRequest))]
-=======
 [JsonSerializable(typeof(OperatorOverrideDecisionRequest))]
->>>>>>> Stashed changes
 [JsonSerializable(typeof(SecurityOverrideAuditEntryDto))]
 [JsonSerializable(typeof(SecurityOverrideAuditEntryDto[]))]
 [JsonSerializable(typeof(List<SecurityOverrideAuditEntryDto>))]

--- a/src/Meridian.Storage/SecurityMaster/IOperatorOverridesStore.cs
+++ b/src/Meridian.Storage/SecurityMaster/IOperatorOverridesStore.cs
@@ -18,18 +18,6 @@ public interface IOperatorOverridesStore
         CancellationToken ct = default);
 
     /// <summary>
-<<<<<<< Updated upstream
-    /// Records a reviewer's approve/reject decision for a security's pending operator overrides,
-    /// transitioning the persisted approval status and appending to the audit trail. Returns
-    /// <see langword="null"/> when no override record exists for <paramref name="securityId"/> (there
-    /// is nothing to review). Implementations must persist the decision so a subsequent
-    /// <see cref="GetAsync"/> reflects it.
-    /// </summary>
-    Task<OperatorOverridesDto?> RecordApprovalDecisionAsync(
-        Guid securityId,
-        OperatorOverrideApprovalDecisionRequest request,
-        string reviewer,
-=======
     /// Records a reviewer's Approved/Rejected decision on the current override overlay, stamping the
     /// reviewer identity and time and appending a durable audit entry. Throws
     /// <see cref="InvalidOperationException"/> when no override row exists or it is not Pending, and
@@ -38,6 +26,5 @@ public interface IOperatorOverridesStore
     Task<OperatorOverridesDto> RecordApprovalDecisionAsync(
         Guid securityId,
         OperatorOverrideDecisionRequest request,
->>>>>>> Stashed changes
         CancellationToken ct = default);
 }

--- a/src/Meridian.Storage/SecurityMaster/PostgresOperatorOverridesStore.cs
+++ b/src/Meridian.Storage/SecurityMaster/PostgresOperatorOverridesStore.cs
@@ -149,16 +149,16 @@ public sealed class PostgresOperatorOverridesStore : IOperatorOverridesStore
         };
     }
 
-    public async Task<OperatorOverridesDto?> RecordApprovalDecisionAsync(
+    public async Task<OperatorOverridesDto> RecordApprovalDecisionAsync(
         Guid securityId,
-        OperatorOverrideApprovalDecisionRequest request,
-        string reviewer,
+        OperatorOverrideDecisionRequest request,
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
+        var reviewer = request.Reviewer;
         if (string.IsNullOrWhiteSpace(reviewer))
         {
-            throw new ArgumentException("reviewer must be provided.", nameof(reviewer));
+            throw new ArgumentException("Reviewer must be provided.", nameof(request));
         }
 
         if (request.Decision is not (SecurityOverrideApprovalStatusDto.Approved or SecurityOverrideApprovalStatusDto.Rejected))
@@ -178,11 +178,21 @@ public sealed class PostgresOperatorOverridesStore : IOperatorOverridesStore
         if (existing is null)
         {
             // Nothing to review — a reviewer cannot decide on overrides that were never recorded.
-            return null;
+            throw new InvalidOperationException(
+                $"No operator overrides exist for security {securityId}; there is nothing to review.");
+        }
+
+        if (existing.ApprovalStatus != SecurityOverrideApprovalStatusDto.Pending)
+        {
+            // Only a pending overlay can be decided; an already-decided overlay must be re-patched first.
+            throw new InvalidOperationException(
+                $"Operator overrides for security {securityId} are {existing.ApprovalStatus}, not Pending; there is no pending decision to record.");
         }
 
         var reviewedAt = DateTimeOffset.UtcNow;
-        var reasonCode = string.IsNullOrWhiteSpace(request.ReasonCode) ? existing.ReasonCode : request.ReasonCode.Trim();
+        // The decision request no longer carries a reason code; the reason travels with the patch that
+        // opened the overlay, so the decision preserves the existing value.
+        var reasonCode = existing.ReasonCode;
         var comment = string.IsNullOrWhiteSpace(request.Comment) ? null : request.Comment.Trim();
         var auditTrail = Append(
             existing.AuditTrail,

--- a/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
@@ -934,26 +934,33 @@ public static class SecurityMasterEndpoints
         /// </remarks>
         group.MapPost(UiApiRoutes.SecurityMasterOperatorOverrideDecision, async (
             Guid securityId,
-            OperatorOverrideApprovalDecisionRequest request,
+            OperatorOverrideDecisionRequest request,
             HttpContext context,
             [FromServices] IOperatorOverridesStore store,
             CancellationToken ct) =>
         {
-            var reviewer = ResolveActor(context);
+            // The reviewer identity is server-derived from the authenticated principal and overrides
+            // any caller-supplied value, so a decision can never be attributed to someone else.
+            var decision = request with { Reviewer = ResolveActor(context) };
             try
             {
                 var updated = await store
-                    .RecordApprovalDecisionAsync(securityId, request, reviewer, ct)
+                    .RecordApprovalDecisionAsync(securityId, decision, ct)
                     .ConfigureAwait(false);
-                return updated is null ? Results.NotFound() : Results.Json(updated, jsonOptions);
+                return Results.Json(updated, jsonOptions);
             }
-            catch (ArgumentOutOfRangeException exception)
+            catch (ArgumentException exception)
             {
                 return Results.BadRequest(new { error = exception.Message });
             }
+            catch (InvalidOperationException exception)
+            {
+                // No pending overlay to decide (missing row or already decided).
+                return Results.NotFound(new { error = exception.Message });
+            }
         })
         .WithName("RecordSecurityMasterOperatorOverrideDecision")
-        .Accepts<OperatorOverrideApprovalDecisionRequest>("application/json")
+        .Accepts<OperatorOverrideDecisionRequest>("application/json")
         .Produces<OperatorOverridesDto>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status400BadRequest)
         .Produces(StatusCodes.Status403Forbidden)

--- a/src/Meridian.Ui.Shared/Services/DailyValuationScheduler.cs
+++ b/src/Meridian.Ui.Shared/Services/DailyValuationScheduler.cs
@@ -327,6 +327,8 @@ public sealed class DailyValuationScheduledWorker
             var evidenceLinks = BuildEvidenceLinks(item, run, nowUtc);
             var blockers = run.Valuation.UnpricedSymbols
                 .Select(static symbol => $"{symbol}: no trusted closing mark available")
+                .Concat(run.Valuation.StalePricedSymbols
+                    .Select(static symbol => $"{symbol}: closing mark rejected — exceeds maximum mark-age policy"))
                 .ToArray();
 
             if (run.Valuation.Projection is null && blockers.Length > 0)

--- a/src/Meridian.Ui/dashboard/src/components/ui/badge.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/ui/badge.tsx
@@ -13,8 +13,5 @@ import { DesignSystemBadge, type DesignSystemBadgeProps } from "@/design-system/
  * <Badge variant="live" dot>LIVE</Badge>
  */
 export type BadgeProps = DesignSystemBadgeProps;
-<<<<<<< Updated upstream
 
-=======
->>>>>>> Stashed changes
 export const Badge = DesignSystemBadge;

--- a/src/Meridian.Wpf/Services/WorkstationSecurityMasterApiClient.cs
+++ b/src/Meridian.Wpf/Services/WorkstationSecurityMasterApiClient.cs
@@ -12,7 +12,7 @@ public interface IWorkstationSecurityMasterApiClient
         Guid securityId, CancellationToken ct = default);
 
     Task<ApiResponse<OperatorOverridesDto>> RecordOperatorOverrideDecisionAsync(
-        Guid securityId, OperatorOverrideApprovalDecisionRequest request, CancellationToken ct = default);
+        Guid securityId, OperatorOverrideDecisionRequest request, CancellationToken ct = default);
 
     Task<SecurityMasterTrustSnapshotDto?> GetTrustSnapshotAsync(
         Guid securityId,
@@ -63,7 +63,7 @@ public sealed class WorkstationSecurityMasterApiClient : IWorkstationSecurityMas
             SecurityIdRoute(UiApiRoutes.SecurityMasterOperatorOverrides, securityId), ct);
 
     public Task<ApiResponse<OperatorOverridesDto>> RecordOperatorOverrideDecisionAsync(
-        Guid securityId, OperatorOverrideApprovalDecisionRequest request, CancellationToken ct = default)
+        Guid securityId, OperatorOverrideDecisionRequest request, CancellationToken ct = default)
         => _apiClient.PostWithResponseAsync<OperatorOverridesDto>(
             SecurityIdRoute(UiApiRoutes.SecurityMasterOperatorOverrideDecision, securityId), request, ct);
 

--- a/tests/Meridian.Tests/Ui/ProviderLedgerReconciliationServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/ProviderLedgerReconciliationServiceTests.cs
@@ -3120,10 +3120,9 @@ public sealed class ProviderLedgerReconciliationServiceTests
             CancellationToken ct = default) =>
             throw new NotSupportedException();
 
-        public Task<OperatorOverridesDto?> RecordApprovalDecisionAsync(
+        public Task<OperatorOverridesDto> RecordApprovalDecisionAsync(
             Guid requestedSecurityId,
-            OperatorOverrideApprovalDecisionRequest request,
-            string reviewer,
+            OperatorOverrideDecisionRequest request,
             CancellationToken ct = default) =>
             throw new NotSupportedException();
     }

--- a/tests/Meridian.Tests/Ui/SecurityMasterExceptionCaseworkServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/SecurityMasterExceptionCaseworkServiceTests.cs
@@ -748,27 +748,26 @@ public sealed class SecurityMasterExceptionCaseworkServiceTests
             return Task.FromResult(updated);
         }
 
-        public Task<OperatorOverridesDto?> RecordApprovalDecisionAsync(
+        public Task<OperatorOverridesDto> RecordApprovalDecisionAsync(
             Guid securityId,
-            OperatorOverrideApprovalDecisionRequest request,
-            string reviewer,
+            OperatorOverrideDecisionRequest request,
             CancellationToken ct = default)
         {
             if (!_overrides.TryGetValue(securityId, out var existing))
             {
-                return Task.FromResult<OperatorOverridesDto?>(null);
+                throw new InvalidOperationException(
+                    $"No operator overrides exist for security {securityId}.");
             }
 
             var reviewedAt = DateTimeOffset.UtcNow;
             var updated = existing with
             {
                 ApprovalStatus = request.Decision,
-                ReasonCode = string.IsNullOrWhiteSpace(request.ReasonCode) ? existing.ReasonCode : request.ReasonCode,
-                ReviewedBy = reviewer,
+                ReviewedBy = request.Reviewer,
                 ReviewedAt = reviewedAt
             };
             _overrides[securityId] = updated;
-            return Task.FromResult<OperatorOverridesDto?>(updated);
+            return Task.FromResult(updated);
         }
     }
 

--- a/tests/Meridian.Tests/Ui/SecurityMasterOperatorOverrideDecisionEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/SecurityMasterOperatorOverrideDecisionEndpointsTests.cs
@@ -120,7 +120,10 @@ public sealed class SecurityMasterOperatorOverrideDecisionEndpointsTests
                 "security-steward",
                 DateTimeOffset.UtcNow)
             {
-                ApprovalStatus = SecurityOverrideApprovalStatusDto.Pending
+                ApprovalStatus = SecurityOverrideApprovalStatusDto.Pending,
+                // The reason code travels with the overlay (the patch that opened it); the decision
+                // preserves it rather than re-supplying it.
+                ReasonCode = "provider-symbol-confirmed"
             };
         }
 
@@ -134,10 +137,9 @@ public sealed class SecurityMasterOperatorOverrideDecisionEndpointsTests
             CancellationToken ct = default)
             => throw new NotSupportedException();
 
-        public Task<OperatorOverridesDto?> RecordApprovalDecisionAsync(
+        public Task<OperatorOverridesDto> RecordApprovalDecisionAsync(
             Guid securityId,
-            OperatorOverrideApprovalDecisionRequest request,
-            string reviewer,
+            OperatorOverrideDecisionRequest request,
             CancellationToken ct = default)
         {
             if (request.Decision is not (SecurityOverrideApprovalStatusDto.Approved or SecurityOverrideApprovalStatusDto.Rejected))
@@ -147,19 +149,19 @@ public sealed class SecurityMasterOperatorOverrideDecisionEndpointsTests
 
             if (!_overrides.TryGetValue(securityId, out var existing))
             {
-                return Task.FromResult<OperatorOverridesDto?>(null);
+                throw new InvalidOperationException(
+                    $"No operator overrides exist for security {securityId}.");
             }
 
             var reviewedAt = DateTimeOffset.UtcNow;
             var updated = existing with
             {
                 ApprovalStatus = request.Decision,
-                ReasonCode = string.IsNullOrWhiteSpace(request.ReasonCode) ? existing.ReasonCode : request.ReasonCode,
-                ReviewedBy = reviewer,
+                ReviewedBy = request.Reviewer,
                 ReviewedAt = reviewedAt
             };
             _overrides[securityId] = updated;
-            return Task.FromResult<OperatorOverridesDto?>(updated);
+            return Task.FromResult(updated);
         }
     }
 }

--- a/tests/Meridian.Wpf.Tests/ViewModels/SecurityMasterViewModelTests.cs
+++ b/tests/Meridian.Wpf.Tests/ViewModels/SecurityMasterViewModelTests.cs
@@ -1856,7 +1856,7 @@ public sealed class SecurityMasterViewModelTests
         public Task<OperatorOverridesDto?> GetOperatorOverridesAsync(Guid securityId, CancellationToken ct = default)
             => Task.FromResult<OperatorOverridesDto?>(null);
 
-        public Task<ApiResponse<OperatorOverridesDto>> RecordOperatorOverrideDecisionAsync(Guid securityId, OperatorOverrideApprovalDecisionRequest request, CancellationToken ct = default)
+        public Task<ApiResponse<OperatorOverridesDto>> RecordOperatorOverrideDecisionAsync(Guid securityId, OperatorOverrideDecisionRequest request, CancellationToken ct = default)
             => Task.FromResult(ApiResponse<OperatorOverridesDto>.Fail("not supported in stub", 501));
 
         // Passport Workbench governed-write methods are not exercised by these tests.


### PR DESCRIPTION
## Summary

Two fixes bundled per request:

**1. Repair `main`'s broken build (`f176d65e`).** Commit `f176d65e` ("various") committed an unresolved `git stash pop`, leaving `<<<<<<< Updated upstream / >>>>>>> Stashed changes` markers in the operator-override files, so `main` no longer compiled (`CS8300`). It also added the audit-trail migration and the "executable spec" tests for a new decision contract but never migrated the production consumers. This **completes** that intended migration rather than reverting it:

- `OperatorOverrideDecisionRequest(Decision, Reviewer, Comment)` replaces `OperatorOverrideApprovalDecisionRequest`. The reviewer now travels inside the request; the reason code travels with the patch that opened the overlay.
- `IOperatorOverridesStore.RecordApprovalDecisionAsync` returns a non-nullable snapshot and throws `InvalidOperationException` on a missing row or non-`Pending` overlay, `ArgumentException` on a blank reviewer / non-decision status.
- `PostgresOperatorOverridesStore` and `NullOperatorOverridesStore` implement the new signature; the store preserves the existing reason code and enforces the `Pending` precondition.
- The decision endpoint binds the new record and stamps the **server-derived** reviewer (`request with { Reviewer = ResolveActor(context) }`) so the acting reviewer can never be caller-supplied; maps `ArgumentException` → 400 and `InvalidOperationException` → 404.
- WPF API client and all store/client test doubles updated to the new signature; the whitespace-only `badge.tsx` stash conflict resolved.

**2. Re-land the daily-valuation scheduler blocker fix** (Codex P2) that missed the merge cut of #2264: an all-stale valuation run lands its symbols in `StalePricedSymbols` (not `UnpricedSymbols`), so it was mis-recorded as `NoAdjustment` with no blockers instead of `Blocked`. `StalePricedSymbols` is now folded into the blocker list.

## Reason

`main` does not compile on its own because of the committed stash-conflict markers in `f176d65e`; every PR's CI inherits that failure because CI builds the PR merged with `main`. The scheduler fix is a genuine correctness fix that was authored against #2264 but did not make the merge.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — **not run: no .NET SDK in this environment; relying on `quality-gate`**
- [x] Relevant unit tests were added or updated — decision endpoint/store test doubles reconciled to the new contract
- [ ] Relevant integration tests were added or updated — the DB-gated `PostgresOperatorOverridesStoreTests` (the spec for the new shape) now match the implementation
- [ ] GitHub Actions `quality-gate` passed — pending on this PR

Verified statically (no local compiler): zero references to the old type/signature remain, all six `IOperatorOverridesStore` implementers and both `IWorkstationSecurityMasterApiClient` implementers match the new signature, no conflict markers remain, and the three CI-running endpoint tests trace to their expected 200/404/403 outcomes.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [ ] No unrelated changes were included — **intentionally bundles the two explicitly-requested fixes** (the `f176d65e` compile repair and the accounting scheduler blocker fix)

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rr15LMeT5DWy1w6YDgqctQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rr15LMeT5DWy1w6YDgqctQ)_