### PR TITLE
Fix main build: remove duplicate operator-override decision shim from #2217/#2272 merge collision

### DIFF
--- a/src/Meridian.Storage/SecurityMaster/PostgresOperatorOverridesStore.cs
+++ b/src/Meridian.Storage/SecurityMaster/PostgresOperatorOverridesStore.cs
@@ -240,23 +240,6 @@ public sealed class PostgresOperatorOverridesStore : IOperatorOverridesStore
         };
     }
 
-    public async Task<OperatorOverridesDto> RecordApprovalDecisionAsync(
-        Guid securityId,
-        OperatorOverrideDecisionRequest request,
-        CancellationToken ct = default)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-        var result = await RecordApprovalDecisionAsync(
-                securityId,
-                new OperatorOverrideApprovalDecisionRequest(request.Decision, Comment: request.Comment),
-                request.Reviewer,
-                ct)
-            .ConfigureAwait(false);
-
-        return result ?? throw new InvalidOperationException(
-            $"No operator overrides exist for security '{securityId:D}'.");
-    }
-
     private async Task<(Dictionary<string, string> Values, IReadOnlyList<SecurityOverrideAuditEntryDto> AuditTrail)> LoadForUpdateAsync(
         NpgsqlConnection connection,
         NpgsqlTransaction transaction,


### PR DESCRIPTION
## Summary

Removes a duplicate, broken `RecordApprovalDecisionAsync` shim from `PostgresOperatorOverridesStore` so `main` compiles again.

Two PRs independently performed the *same* operator-override decision migration and merged into `main` close together:
- **#2272** completed the migration by **replacing** `OperatorOverrideApprovalDecisionRequest` with `OperatorOverrideDecisionRequest` (reviewer folded into the request).
- **#2217** (`passport-workbench-wrapup`) did its own version that **kept** the old record and added a shim overload delegating to it.

The 3-way merge combined both, leaving `PostgresOperatorOverridesStore` with a **duplicate** `RecordApprovalDecisionAsync(Guid, OperatorOverrideDecisionRequest, CancellationToken)` (`CS0111`) whose shim body constructed the now-deleted `OperatorOverrideApprovalDecisionRequest` (`CS0246`) and called a 4-arg overload that no longer exists — so `main`'s `verify-dotnet` fails to compile.

This deletes the redundant shim. The canonical implementation (reviewer taken from the request, throws on a missing row or non-`Pending` overlay) is the single decision method; every other consumer already targets the new signature.

## Reason

`main` (`ce711e17`) does not compile: the #2217 + #2272 merge left a duplicate method that references a deleted type. Every downstream PR inherits the failure because CI builds against `main`.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — **not run: no .NET SDK in this environment; relying on `quality-gate`**
- [x] Relevant unit tests were added or updated — no test change needed; the removed shim was unreachable dead code that never compiled
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed — pending on this PR

Verified statically: after removal there are zero references to the deleted `OperatorOverrideApprovalDecisionRequest` anywhere, exactly one `RecordApprovalDecisionAsync` remains in the store, and no conflict markers exist. Only 17 lines deleted, one file.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rr15LMeT5DWy1w6YDgqctQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rr15LMeT5DWy1w6YDgqctQ)_