### PR TITLE
fix(security-master): repair main build after #2271 merge collision (duplicate store method)

### DIFF
--- a/src/Meridian.Storage/SecurityMaster/PostgresOperatorOverridesStore.cs
+++ b/src/Meridian.Storage/SecurityMaster/PostgresOperatorOverridesStore.cs
@@ -241,23 +241,6 @@ public sealed class PostgresOperatorOverridesStore : IOperatorOverridesStore
         };
     }
 
-    public async Task<OperatorOverridesDto> RecordApprovalDecisionAsync(
-        Guid securityId,
-        OperatorOverrideDecisionRequest request,
-        CancellationToken ct = default)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-        var result = await RecordApprovalDecisionAsync(
-                securityId,
-                new OperatorOverrideApprovalDecisionRequest(request.Decision, Comment: request.Comment),
-                request.Reviewer,
-                ct)
-            .ConfigureAwait(false);
-
-        return result ?? throw new InvalidOperationException(
-            $"No operator overrides exist for security '{securityId:D}'.");
-    }
-
     private async Task<(Dictionary<string, string> Values, IReadOnlyList<SecurityOverrideAuditEntryDto> AuditTrail)> LoadForUpdateAsync(
         NpgsqlConnection connection,
         NpgsqlTransaction transaction,

--- a/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/SecurityMasterEndpoints.cs
@@ -953,10 +953,18 @@ public static class SecurityMasterEndpoints
             {
                 return Results.BadRequest(new { error = exception.Message });
             }
-            catch (InvalidOperationException)
+            catch (InvalidOperationException exception) when (exception.Message.Contains("No operator overrides exist", StringComparison.Ordinal))
             {
+                // Expected domain condition: no overlay exists to decide on.
                 return Results.NotFound();
             }
+            catch (InvalidOperationException exception) when (exception.Message.Contains("not Pending", StringComparison.Ordinal))
+            {
+                // Expected domain condition: the overlay exists but is not in a reviewable (Pending) state.
+                return Results.Conflict(new { error = exception.Message });
+            }
+            // Any other InvalidOperationException (e.g. Security Master not configured) is an operational
+            // failure and is intentionally left to surface as a 500 rather than be masked as a 404.
         })
         .WithName("RecordSecurityMasterOperatorOverrideDecision")
         .Accepts<OperatorOverrideDecisionRequest>("application/json")
@@ -964,6 +972,7 @@ public static class SecurityMasterEndpoints
         .Produces(StatusCodes.Status400BadRequest)
         .Produces(StatusCodes.Status403Forbidden)
         .Produces(StatusCodes.Status404NotFound)
+        .Produces(StatusCodes.Status409Conflict)
         .Produces(StatusCodes.Status429TooManyRequests)
         .RequireRateLimiting(UiEndpoints.MutationRateLimitPolicy)
         .AddEndpointFilter(RequireModifySecurityMasterPermission);

--- a/tests/Meridian.Tests/Ui/SecurityMasterExceptionCaseworkServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/SecurityMasterExceptionCaseworkServiceTests.cs
@@ -753,9 +753,25 @@ public sealed class SecurityMasterExceptionCaseworkServiceTests
             OperatorOverrideDecisionRequest request,
             CancellationToken ct = default)
         {
+            ArgumentNullException.ThrowIfNull(request);
+            if (string.IsNullOrWhiteSpace(request.Reviewer))
+            {
+                throw new ArgumentException("reviewer must be provided.", nameof(request));
+            }
+
+            if (request.Decision is not (SecurityOverrideApprovalStatusDto.Approved or SecurityOverrideApprovalStatusDto.Rejected))
+            {
+                throw new ArgumentOutOfRangeException(nameof(request), request.Decision, "Approval decision must be Approved or Rejected.");
+            }
+
             if (!_overrides.TryGetValue(securityId, out var existing))
             {
                 throw new InvalidOperationException($"No operator overrides exist for security '{securityId}'.");
+            }
+
+            if (existing.ApprovalStatus != SecurityOverrideApprovalStatusDto.Pending)
+            {
+                throw new InvalidOperationException($"Operator overrides for security '{securityId}' are '{existing.ApprovalStatus}', not Pending.");
             }
 
             var reviewedAt = DateTimeOffset.UtcNow;


### PR DESCRIPTION
## Summary

Merging #2271 combined the forward operator-override refactor with a concurrent "keep both"
state in `PostgresOperatorOverridesStore`, leaving **`main` uncompilable**: the store carried a
**duplicate** `RecordApprovalDecisionAsync` adapter that referenced the now-deleted
`OperatorOverrideApprovalDecisionRequest` type and called a removed 4-arg overload (undefined type
+ duplicate method + no-matching-overload).

This restores a compiling `main` and folds in the two review fixes that did not make it into #2271:

- **Remove the dead duplicate adapter** in `PostgresOperatorOverridesStore` — the primary
  `RecordApprovalDecisionAsync` already implements the new `OperatorOverrideDecisionRequest`
  contract (Pending guard, non-null return).
- **Endpoint exception mapping** (flagged by two reviewers on #2271): the decision route no longer
  maps *every* `InvalidOperationException` to `404`. It translates only the expected **missing →
  404** and **non-Pending → 409** domain conditions; a configuration/unexpected failure (e.g.
  "Security Master is not configured" from `NullOperatorOverridesStore`) now surfaces as **500**
  instead of being masked as a missing override. Adds `409` to the produced responses.
- **Test-fake parity**: the casework test fake mirrors the production store's reviewer / decision /
  Pending validation.

3 files changed.

## Reason

`main` does not build after the #2271 merge; this unblocks every branch and PR in the repo again,
and lands the review feedback from #2271 that the merge outran.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [ ] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

No .NET SDK is available in this environment, so local build/test could not be run; CI is the
validation gate. Verified there are zero remaining references to the deleted type, zero conflict
markers, and a single `RecordApprovalDecisionAsync` definition in the store. The endpoint message
filters match both the production store and the in-memory test fakes ("No operator overrides
exist"); no tests were disabled.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018UbVPhzJ9S2QoQiwNGRBrt)_