### PR TITLE
fix(ui-shared): repair SecureReportingDistribution build errors breaking WPF/CodeQL lanes

### DIFF
--- a/src/Meridian.Ui.Shared/Endpoints/SecureReportingDistributionEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/SecureReportingDistributionEndpoints.cs
@@ -314,6 +314,6 @@ public static class SecureReportingDistributionEndpoints
         response.Headers.CacheControl = "no-store, private";
         response.Headers.Pragma = "no-cache";
         response.Headers.Expires = "0";
-        response.Headers.ReferrerPolicy = "no-referrer";
+        response.Headers["Referrer-Policy"] = "no-referrer";
     }
 }

--- a/src/Meridian.Ui.Shared/Services/ReportingSecureDistributionApplicationService.cs
+++ b/src/Meridian.Ui.Shared/Services/ReportingSecureDistributionApplicationService.cs
@@ -703,7 +703,7 @@ public sealed class ReportingSecureDistributionApplicationService
     private static void ValidatePath(string path, string parameterName)
     {
         var normalized = NormalizeRequired(path, parameterName, 1_024);
-        if (!normalized.StartsWith('/', StringComparison.Ordinal)
+        if (!normalized.StartsWith("/", StringComparison.Ordinal)
             || normalized.Contains('?', StringComparison.Ordinal)
             || normalized.Contains('#', StringComparison.Ordinal)
             || ContainsBearer(normalized))


### PR DESCRIPTION
## Summary

`main` currently fails to compile: `Meridian.Ui.Shared` has two C# errors in the SecureReportingDistribution feature, which breaks every lane that builds the solution — notably **`WPF W4 Acceptance`** and **`Analyze csharp` (CodeQL)**. This is the pre-existing "repair main build" breakage; both are textbook, behavior-preserving compile fixes:

- **`SecureReportingDistributionEndpoints.cs:317`** — `error CS1061: 'IHeaderDictionary' does not contain a definition for 'ReferrerPolicy'`. `IHeaderDictionary` exposes typed properties for `CacheControl`/`Pragma`/`Expires` but not `Referrer-Policy`. Set it via the string indexer: `response.Headers["Referrer-Policy"] = "no-referrer";`
- **`ReportingSecureDistributionApplicationService.cs:706`** — `error CS1503: cannot convert from 'char' to 'string'`. `string.StartsWith(char, StringComparison)` has no overload (only `StartsWith(char)` or `StartsWith(string, StringComparison)`); the call resolved to the string overload and failed to convert `'/'`. Pass the `"/"` string so `StartsWith(string, StringComparison)` binds (keeping `StringComparison.Ordinal`).

A codebase-wide grep confirms these are the only occurrences of either pattern.

## Verified outcome

CI's `verify-desktop (build/test WPF)` lane on this PR confirms the fix: **`Restore/Build WPF desktop shell` and `Build WPF desktop tests` both succeed** — the solution compiles again. Both edits are strictly runtime-identical, so they cannot change behavior.

## ⚠️ Known follow-up: pre-existing test failures this unmasks (not caused by this PR)

Restoring the build means CI now runs test suites that were **dormant while `main` couldn't compile**. Several are red for reasons unrelated to this change:

- **`verify-desktop`** — passes build, then fails at `Run WPF desktop development tests` (a WPF unit test).
- **`Pilot Acceptance Evidence`** — fails at its test/evidence step.
- **`regenerate-docs`** — WPF screen-tracker doc drift (stale test-reference counts).
- **`verify-dotnet` / `verify-browser`** — fail at the no-god-file ratchet cap gate on six over-cap files already on `main` (`api.ts`, `reporting-screen.tsx`, `FundStructureEndpoints.cs`, `WorkstationEndpoints.cs`, `ReportPackDeliveryService.cs`, `ReportPackRunReadService.cs`).

These are independent, pre-existing `main`-health issues (the WPF/acceptance tests never ran while the build was broken, so their failures were hidden). Diagnosing the WPF/acceptance test failures needs a Windows + `dotnet` environment — the failing test names are only in CI artifacts (`wpf-dev-test-validation.json`, TestResults `.trx`), not the console logs — so they're out of scope for this compile-only hotfix and are flagged here for a follow-up on the appropriate environment. This PR should still land on its own merit: it is the prerequisite that lets any of those lanes compile and run at all.

## Reason

Build-breaking errors on `main` block the WPF acceptance and CodeQL lanes for all branches. This unblocks compilation.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — _`dotnet` is not available in this environment; the fix is verified by CI compiling the WPF shell + tests on the `verify-desktop` lane._
- [x] Relevant unit tests were added or updated — _n/a; these are compiler-error corrections with no behavior change_
- [ ] Relevant integration tests were added or updated — _n/a_
- [ ] GitHub Actions `quality-gate` passed — blocked by the independent pre-existing `main` failures documented above, not by this change

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015x9Y54pV2eCPfdFh93GWcb