### PR TITLE
fix(ci): repair current-main UI quality gates

### DIFF
--- a/src/Meridian.FinancialOperations/AccountingClose/AccountingCloseManagementService.cs
+++ b/src/Meridian.FinancialOperations/AccountingClose/AccountingCloseManagementService.cs
@@ -758,184 +758,184 @@ public sealed class AccountingCloseManagementService : IAccountingCloseManagemen
         await _writeGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-        var resolvedActor = string.IsNullOrWhiteSpace(actor) ? RequireText(request.Actor, "Actor") : actor.Trim();
-        var workflow = await _workflowService.GetAsync(request.WorkflowId, ct).ConfigureAwait(false);
-        if (workflow is null)
-        {
-            return null;
-        }
+            var resolvedActor = string.IsNullOrWhiteSpace(actor) ? RequireText(request.Actor, "Actor") : actor.Trim();
+            var workflow = await _workflowService.GetAsync(request.WorkflowId, ct).ConfigureAwait(false);
+            if (workflow is null)
+            {
+                return null;
+            }
 
-        var plan = BuildPeriodPlan(workflow);
-        if (plan.IsPeriodLocked)
-        {
-            plan = await AttachClosingEntriesGateAsync(plan, workflow, ct, tenantId, companyId).ConfigureAwait(false);
-            return new ClosePeriodLockResultDto(
-                true,
-                plan,
-                null,
-                [
-                    new AccountingConfigurationValidationIssueDto(
+            var plan = BuildPeriodPlan(workflow);
+            if (plan.IsPeriodLocked)
+            {
+                plan = await AttachClosingEntriesGateAsync(plan, workflow, ct, tenantId, companyId).ConfigureAwait(false);
+                return new ClosePeriodLockResultDto(
+                    true,
+                    plan,
+                    null,
+                    [
+                        new AccountingConfigurationValidationIssueDto(
                         "ClosePeriodAlreadyLocked",
                         AccountingConfigurationValidationSeverityDto.Warning,
                         $"Close period '{plan.PeriodId}' is already locked.",
                         plan.ClosePlanId,
                         "Use governed reopen workflow before changing a locked period.")
-                ]);
-        }
+                    ]);
+            }
 
-        var issues = BuildClosePeriodLockIssues(request, workflow, plan);
-        if (issues.Count > 0)
-        {
-            plan = await AttachClosingEntriesGateAsync(plan, workflow, ct, tenantId, companyId).ConfigureAwait(false);
-            return new ClosePeriodLockResultDto(false, plan, null, issues);
-        }
+            var issues = BuildClosePeriodLockIssues(request, workflow, plan);
+            if (issues.Count > 0)
+            {
+                plan = await AttachClosingEntriesGateAsync(plan, workflow, ct, tenantId, companyId).ConfigureAwait(false);
+                return new ClosePeriodLockResultDto(false, plan, null, issues);
+            }
 
-        if (_postingWorkbench is null)
-        {
-            plan = AttachClosingEntriesGate(plan, UnavailableClosingEntriesGate(plan));
-            return new ClosePeriodLockResultDto(
-                false,
-                plan,
-                null,
-                [ClosingEntriesIssue(plan.ClosingEntriesGate!)]);
-        }
+            if (_postingWorkbench is null)
+            {
+                plan = AttachClosingEntriesGate(plan, UnavailableClosingEntriesGate(plan));
+                return new ClosePeriodLockResultDto(
+                    false,
+                    plan,
+                    null,
+                    [ClosingEntriesIssue(plan.ClosingEntriesGate!)]);
+            }
 
-        ClosePostingGateDto closingGate;
-        try
-        {
-            closingGate = await _postingWorkbench.EnsureClosingDraftQueuedAsync(
-                    RequirePostingContext(workflow, plan, tenantId, companyId),
-                    new AccountingClosePostingCommand(
-                        resolvedActor,
-                        RequireText(request.Rationale, "Rationale"),
-                        NormalizeEvidenceLinks(request.EvidenceLinks),
-                        request.ActionOrigin,
-                        CorrelationId: request.CorrelationId),
-                    ct)
-                .ConfigureAwait(false);
-        }
-        catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
-        {
-            closingGate = new ClosePostingGateDto(
-                $"period-close-posting:{plan.ClosePlanId}",
-                "Post closing entries",
-                ClosePostingGateStateDto.Blocked,
-                false,
-                0m,
-                0,
-                ex.Message);
-        }
+            ClosePostingGateDto closingGate;
+            try
+            {
+                closingGate = await _postingWorkbench.EnsureClosingDraftQueuedAsync(
+                        RequirePostingContext(workflow, plan, tenantId, companyId),
+                        new AccountingClosePostingCommand(
+                            resolvedActor,
+                            RequireText(request.Rationale, "Rationale"),
+                            NormalizeEvidenceLinks(request.EvidenceLinks),
+                            request.ActionOrigin,
+                            CorrelationId: request.CorrelationId),
+                        ct)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
+            {
+                closingGate = new ClosePostingGateDto(
+                    $"period-close-posting:{plan.ClosePlanId}",
+                    "Post closing entries",
+                    ClosePostingGateStateDto.Blocked,
+                    false,
+                    0m,
+                    0,
+                    ex.Message);
+            }
 
-        plan = AttachClosingEntriesGate(plan, closingGate);
-        if (request.PrepareClosingEntriesOnly)
-        {
-            var preparationIssues = closingGate.State is ClosePostingGateStateDto.Blocked
-                or ClosePostingGateStateDto.Unavailable
-                ? new[] { ClosingEntriesIssue(closingGate) }
-                : Array.Empty<AccountingConfigurationValidationIssueDto>();
-            return new ClosePeriodLockResultDto(
-                false,
-                plan,
-                null,
-                preparationIssues);
-        }
+            plan = AttachClosingEntriesGate(plan, closingGate);
+            if (request.PrepareClosingEntriesOnly)
+            {
+                var preparationIssues = closingGate.State is ClosePostingGateStateDto.Blocked
+                    or ClosePostingGateStateDto.Unavailable
+                    ? new[] { ClosingEntriesIssue(closingGate) }
+                    : Array.Empty<AccountingConfigurationValidationIssueDto>();
+                return new ClosePeriodLockResultDto(
+                    false,
+                    plan,
+                    null,
+                    preparationIssues);
+            }
 
-        if (!closingGate.IsReadyForLock)
-        {
-            return new ClosePeriodLockResultDto(
-                false,
-                plan,
-                null,
-                [ClosingEntriesIssue(closingGate)]);
-        }
+            if (!closingGate.IsReadyForLock)
+            {
+                return new ClosePeriodLockResultDto(
+                    false,
+                    plan,
+                    null,
+                    [ClosingEntriesIssue(closingGate)]);
+            }
 
-        // Closing-entry preparation can await external stores. Re-read the governed workflow at the
-        // irreversible mutation boundary so a concurrent sign-off/configuration/version change cannot
-        // hard-close the ledger against a stale close plan.
-        var boundaryWorkflow = await _workflowService.GetAsync(request.WorkflowId, ct).ConfigureAwait(false);
-        if (boundaryWorkflow is null)
-        {
-            return null;
-        }
+            // Closing-entry preparation can await external stores. Re-read the governed workflow at the
+            // irreversible mutation boundary so a concurrent sign-off/configuration/version change cannot
+            // hard-close the ledger against a stale close plan.
+            var boundaryWorkflow = await _workflowService.GetAsync(request.WorkflowId, ct).ConfigureAwait(false);
+            if (boundaryWorkflow is null)
+            {
+                return null;
+            }
 
-        var boundaryPlan = BuildPeriodPlan(boundaryWorkflow);
-        var boundaryIssues = BuildClosePeriodLockIssues(request, boundaryWorkflow, boundaryPlan);
-        if (boundaryIssues.Count > 0)
-        {
-            return new ClosePeriodLockResultDto(
-                false,
-                AttachClosingEntriesGate(boundaryPlan, closingGate),
-                null,
-                boundaryIssues);
-        }
+            var boundaryPlan = BuildPeriodPlan(boundaryWorkflow);
+            var boundaryIssues = BuildClosePeriodLockIssues(request, boundaryWorkflow, boundaryPlan);
+            if (boundaryIssues.Count > 0)
+            {
+                return new ClosePeriodLockResultDto(
+                    false,
+                    AttachClosingEntriesGate(boundaryPlan, closingGate),
+                    null,
+                    boundaryIssues);
+            }
 
-        workflow = boundaryWorkflow;
-        plan = AttachClosingEntriesGate(boundaryPlan, closingGate);
+            workflow = boundaryWorkflow;
+            plan = AttachClosingEntriesGate(boundaryPlan, closingGate);
 
-        try
-        {
-            await _postingWorkbench.FinalizeHardCloseAsync(
-                    RequirePostingContext(workflow, plan, tenantId, companyId),
-                    new AccountingClosePostingCommand(
-                        resolvedActor,
-                        RequireText(request.Rationale, "Rationale"),
-                        NormalizeEvidenceLinks(request.EvidenceLinks),
-                        request.ActionOrigin,
-                        Role: "Fund Controller",
-                        CorrelationId: request.CorrelationId),
-                    ct)
-                .ConfigureAwait(false);
-        }
-        catch (Exception ex) when (ex is InvalidOperationException or ArgumentException or LedgerBookServiceException)
-        {
-            return new ClosePeriodLockResultDto(
-                false,
-                plan,
-                null,
-                [new AccountingConfigurationValidationIssueDto(
+            try
+            {
+                await _postingWorkbench.FinalizeHardCloseAsync(
+                        RequirePostingContext(workflow, plan, tenantId, companyId),
+                        new AccountingClosePostingCommand(
+                            resolvedActor,
+                            RequireText(request.Rationale, "Rationale"),
+                            NormalizeEvidenceLinks(request.EvidenceLinks),
+                            request.ActionOrigin,
+                            Role: "Fund Controller",
+                            CorrelationId: request.CorrelationId),
+                        ct)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or ArgumentException or LedgerBookServiceException)
+            {
+                return new ClosePeriodLockResultDto(
+                    false,
+                    plan,
+                    null,
+                    [new AccountingConfigurationValidationIssueDto(
                     "LedgerPeriodHardCloseFailed",
                     AccountingConfigurationValidationSeverityDto.Critical,
                     ex.Message,
                     closingGate.GateId,
                     "Resolve the ledger-period hard-close failure and retry with the same retained closing-entry evidence.")]);
-        }
+            }
 
-        var transition = await _workflowService.CloseWorkflowAsync(
-            request.WorkflowId,
-            new OperationsCloseWorkflowRequestDto(
-                ExpectedVersion: request.ExpectedWorkflowVersion,
-                Actor: resolvedActor,
-                Rationale: RequireText(request.Rationale, "Rationale"),
-                ReportPackId: RequireText(request.ReportPackId, "ReportPackId"),
-                ChecklistControlApprovals: request.ChecklistControlApprovals,
-                CorrelationId: request.CorrelationId,
-                EvidenceLinks: ToOperationsEvidenceLinks(request.EvidenceLinks),
-                ClosePackageId: request.ClosePackageId,
-                ClosePackageManifestId: request.ClosePackageManifestId,
-                ClosePackageEvidenceHash: null,
-                ClosePackageRetainedManifestRoute: request.ClosePackageRetainedManifestRoute,
-                ActionOrigin: request.ActionOrigin),
-            ct).ConfigureAwait(false);
+            var transition = await _workflowService.CloseWorkflowAsync(
+                request.WorkflowId,
+                new OperationsCloseWorkflowRequestDto(
+                    ExpectedVersion: request.ExpectedWorkflowVersion,
+                    Actor: resolvedActor,
+                    Rationale: RequireText(request.Rationale, "Rationale"),
+                    ReportPackId: RequireText(request.ReportPackId, "ReportPackId"),
+                    ChecklistControlApprovals: request.ChecklistControlApprovals,
+                    CorrelationId: request.CorrelationId,
+                    EvidenceLinks: ToOperationsEvidenceLinks(request.EvidenceLinks),
+                    ClosePackageId: request.ClosePackageId,
+                    ClosePackageManifestId: request.ClosePackageManifestId,
+                    ClosePackageEvidenceHash: null,
+                    ClosePackageRetainedManifestRoute: request.ClosePackageRetainedManifestRoute,
+                    ActionOrigin: request.ActionOrigin),
+                ct).ConfigureAwait(false);
 
-        var updatedPlan = transition.Workflow is null
-            ? plan
-            : await BuildPeriodPlanWithGateAsync(transition.Workflow, ct, tenantId, companyId).ConfigureAwait(false);
-        var transitionIssues = transition.Success
-            ? Array.Empty<AccountingConfigurationValidationIssueDto>()
-            : transition.Blockers
-                .Select(static blocker => ToValidationIssue(blocker))
-                .Append(new AccountingConfigurationValidationIssueDto(
-                    "CloseWorkflowTransitionPendingAfterLedgerHardClose",
-                    AccountingConfigurationValidationSeverityDto.Critical,
-                    "The ledger period is hard-closed, but the workflow close transition did not commit.",
-                    plan.ClosePlanId,
-                    "Refresh the close plan and retry the same close command with the current workflow version; ledger hard close is idempotent."))
-                .ToArray();
-        return new ClosePeriodLockResultDto(
-            transition.Success && updatedPlan.IsPeriodLocked,
-            updatedPlan,
-            transition,
-            transitionIssues);
+            var updatedPlan = transition.Workflow is null
+                ? plan
+                : await BuildPeriodPlanWithGateAsync(transition.Workflow, ct, tenantId, companyId).ConfigureAwait(false);
+            var transitionIssues = transition.Success
+                ? Array.Empty<AccountingConfigurationValidationIssueDto>()
+                : transition.Blockers
+                    .Select(static blocker => ToValidationIssue(blocker))
+                    .Append(new AccountingConfigurationValidationIssueDto(
+                        "CloseWorkflowTransitionPendingAfterLedgerHardClose",
+                        AccountingConfigurationValidationSeverityDto.Critical,
+                        "The ledger period is hard-closed, but the workflow close transition did not commit.",
+                        plan.ClosePlanId,
+                        "Refresh the close plan and retry the same close command with the current workflow version; ledger hard close is idempotent."))
+                    .ToArray();
+            return new ClosePeriodLockResultDto(
+                transition.Success && updatedPlan.IsPeriodLocked,
+                updatedPlan,
+                transition,
+                transitionIssues);
         }
         finally
         {
@@ -966,161 +966,161 @@ public sealed class AccountingCloseManagementService : IAccountingCloseManagemen
         await _writeGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-        var role = RequireText(request.Role, "Role");
-        if (!string.Equals(role, "Controller", StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(role, "Fund Controller", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new InvalidOperationException(
-                "Governed close-period reopen requires Controller or Fund Controller authority.");
-        }
+            var role = RequireText(request.Role, "Role");
+            if (!string.Equals(role, "Controller", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(role, "Fund Controller", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    "Governed close-period reopen requires Controller or Fund Controller authority.");
+            }
 
-        var evidence = NormalizeEvidenceLinks(request.EvidenceLinks);
-        if (evidence.Count == 0)
-        {
-            throw new InvalidOperationException("Governed close-period reopen requires retained reversal/restatement evidence.");
-        }
+            var evidence = NormalizeEvidenceLinks(request.EvidenceLinks);
+            if (evidence.Count == 0)
+            {
+                throw new InvalidOperationException("Governed close-period reopen requires retained reversal/restatement evidence.");
+            }
 
-        var resolvedActor = string.IsNullOrWhiteSpace(actor) ? RequireText(request.Actor, "Actor") : actor.Trim();
-        var workflow = await _workflowService.GetAsync(request.WorkflowId, ct).ConfigureAwait(false);
-        if (workflow is null)
-        {
-            return null;
-        }
+            var resolvedActor = string.IsNullOrWhiteSpace(actor) ? RequireText(request.Actor, "Actor") : actor.Trim();
+            var workflow = await _workflowService.GetAsync(request.WorkflowId, ct).ConfigureAwait(false);
+            if (workflow is null)
+            {
+                return null;
+            }
 
-        var plan = BuildPeriodPlan(workflow);
-        if (!plan.IsPeriodLocked)
-        {
-            return new ClosePeriodReopenResultDto(
-                false,
-                await AttachClosingEntriesGateAsync(plan, workflow, ct, tenantId, companyId).ConfigureAwait(false),
-                null,
-                null,
-                [new AccountingConfigurationValidationIssueDto(
+            var plan = BuildPeriodPlan(workflow);
+            if (!plan.IsPeriodLocked)
+            {
+                return new ClosePeriodReopenResultDto(
+                    false,
+                    await AttachClosingEntriesGateAsync(plan, workflow, ct, tenantId, companyId).ConfigureAwait(false),
+                    null,
+                    null,
+                    [new AccountingConfigurationValidationIssueDto(
                     "ClosePeriodNotLocked",
                     AccountingConfigurationValidationSeverityDto.Critical,
                     $"Close period '{plan.PeriodId}' is not locked and cannot enter governed reopen.",
                     plan.ClosePlanId,
                     "Use the normal late-adjustment workflow for a soft-closed period.")]);
-        }
+            }
 
-        if (workflow.Version != request.ExpectedWorkflowVersion)
-        {
-            return new ClosePeriodReopenResultDto(
-                false,
-                await AttachClosingEntriesGateAsync(plan, workflow, ct, tenantId, companyId).ConfigureAwait(false),
-                null,
-                null,
-                [new AccountingConfigurationValidationIssueDto(
+            if (workflow.Version != request.ExpectedWorkflowVersion)
+            {
+                return new ClosePeriodReopenResultDto(
+                    false,
+                    await AttachClosingEntriesGateAsync(plan, workflow, ct, tenantId, companyId).ConfigureAwait(false),
+                    null,
+                    null,
+                    [new AccountingConfigurationValidationIssueDto(
                     "ClosePeriodReopenVersionMismatch",
                     AccountingConfigurationValidationSeverityDto.Critical,
                     $"Workflow version {workflow.Version} does not match expected version {request.ExpectedWorkflowVersion}.",
                     plan.ClosePlanId,
                     "Refresh the close plan before reopening the period.")]);
-        }
+            }
 
-        if (_postingWorkbench is null)
-        {
-            var unavailable = UnavailableClosingEntriesGate(plan);
-            return new ClosePeriodReopenResultDto(
-                false,
-                AttachClosingEntriesGate(plan, unavailable),
-                null,
-                unavailable,
-                [ClosingEntriesIssue(unavailable)]);
-        }
+            if (_postingWorkbench is null)
+            {
+                var unavailable = UnavailableClosingEntriesGate(plan);
+                return new ClosePeriodReopenResultDto(
+                    false,
+                    AttachClosingEntriesGate(plan, unavailable),
+                    null,
+                    unavailable,
+                    [ClosingEntriesIssue(unavailable)]);
+            }
 
-        // Re-read immediately before the durable ledger reopen. This prevents a stale version from
-        // reopening the ledger after another close-plan mutation completed while the request waited.
-        var boundaryWorkflow = await _workflowService.GetAsync(request.WorkflowId, ct).ConfigureAwait(false);
-        if (boundaryWorkflow is null)
-        {
-            return null;
-        }
+            // Re-read immediately before the durable ledger reopen. This prevents a stale version from
+            // reopening the ledger after another close-plan mutation completed while the request waited.
+            var boundaryWorkflow = await _workflowService.GetAsync(request.WorkflowId, ct).ConfigureAwait(false);
+            if (boundaryWorkflow is null)
+            {
+                return null;
+            }
 
-        var boundaryPlan = BuildPeriodPlan(boundaryWorkflow);
-        if (!boundaryPlan.IsPeriodLocked)
-        {
-            return new ClosePeriodReopenResultDto(
-                false,
-                await AttachClosingEntriesGateAsync(boundaryPlan, boundaryWorkflow, ct, tenantId, companyId).ConfigureAwait(false),
-                null,
-                null,
-                [new AccountingConfigurationValidationIssueDto(
+            var boundaryPlan = BuildPeriodPlan(boundaryWorkflow);
+            if (!boundaryPlan.IsPeriodLocked)
+            {
+                return new ClosePeriodReopenResultDto(
+                    false,
+                    await AttachClosingEntriesGateAsync(boundaryPlan, boundaryWorkflow, ct, tenantId, companyId).ConfigureAwait(false),
+                    null,
+                    null,
+                    [new AccountingConfigurationValidationIssueDto(
                     "ClosePeriodNotLocked",
                     AccountingConfigurationValidationSeverityDto.Critical,
                     $"Close period '{boundaryPlan.PeriodId}' is no longer locked and cannot enter governed reopen.",
                     boundaryPlan.ClosePlanId,
                     "Refresh the close plan before retrying the reopen command.")]);
-        }
+            }
 
-        if (boundaryWorkflow.Version != request.ExpectedWorkflowVersion)
-        {
-            return new ClosePeriodReopenResultDto(
-                false,
-                await AttachClosingEntriesGateAsync(boundaryPlan, boundaryWorkflow, ct, tenantId, companyId).ConfigureAwait(false),
-                null,
-                null,
-                [new AccountingConfigurationValidationIssueDto(
+            if (boundaryWorkflow.Version != request.ExpectedWorkflowVersion)
+            {
+                return new ClosePeriodReopenResultDto(
+                    false,
+                    await AttachClosingEntriesGateAsync(boundaryPlan, boundaryWorkflow, ct, tenantId, companyId).ConfigureAwait(false),
+                    null,
+                    null,
+                    [new AccountingConfigurationValidationIssueDto(
                     "ClosePeriodReopenVersionMismatch",
                     AccountingConfigurationValidationSeverityDto.Critical,
                     $"Workflow version {boundaryWorkflow.Version} does not match expected version {request.ExpectedWorkflowVersion}.",
                     boundaryPlan.ClosePlanId,
                     "Refresh the close plan before reopening the period.")]);
-        }
+            }
 
-        workflow = boundaryWorkflow;
-        plan = boundaryPlan;
+            workflow = boundaryWorkflow;
+            plan = boundaryPlan;
 
-        var reversalGate = await _postingWorkbench.ReopenAndQueueClosingReversalsAsync(
-                RequirePostingContext(workflow, plan, tenantId, companyId),
-                new AccountingClosePostingCommand(
-                    resolvedActor,
-                    RequireText(request.Rationale, "Rationale"),
-                    evidence,
-                    request.ActionOrigin,
-                    role,
-                    RequireText(request.ApprovalReference, "ApprovalReference"),
-                    request.CorrelationId),
-                ct)
-            .ConfigureAwait(false);
+            var reversalGate = await _postingWorkbench.ReopenAndQueueClosingReversalsAsync(
+                    RequirePostingContext(workflow, plan, tenantId, companyId),
+                    new AccountingClosePostingCommand(
+                        resolvedActor,
+                        RequireText(request.Rationale, "Rationale"),
+                        evidence,
+                        request.ActionOrigin,
+                        role,
+                        RequireText(request.ApprovalReference, "ApprovalReference"),
+                        request.CorrelationId),
+                    ct)
+                .ConfigureAwait(false);
 
-        var transition = await _workflowService.ReopenWorkflowAsync(
-                request.WorkflowId,
-                new OperationsReopenWorkflowRequestDto(
-                    request.ExpectedWorkflowVersion,
-                    resolvedActor,
-                    RequireText(request.Rationale, "Rationale"),
-                    RequireText(request.IncidentId, "IncidentId"),
-                    IsGovernedAdmin: true,
-                    RequireText(request.Justification, "Justification"),
-                    RequireText(request.ApprovalReference, "ApprovalReference"),
-                    RequireText(request.ImpactSummary, "ImpactSummary"),
-                    request.CorrelationId,
-                    ToOperationsEvidenceLinks(evidence),
-                    request.ActionOrigin),
-                ct)
-            .ConfigureAwait(false);
+            var transition = await _workflowService.ReopenWorkflowAsync(
+                    request.WorkflowId,
+                    new OperationsReopenWorkflowRequestDto(
+                        request.ExpectedWorkflowVersion,
+                        resolvedActor,
+                        RequireText(request.Rationale, "Rationale"),
+                        RequireText(request.IncidentId, "IncidentId"),
+                        IsGovernedAdmin: true,
+                        RequireText(request.Justification, "Justification"),
+                        RequireText(request.ApprovalReference, "ApprovalReference"),
+                        RequireText(request.ImpactSummary, "ImpactSummary"),
+                        request.CorrelationId,
+                        ToOperationsEvidenceLinks(evidence),
+                        request.ActionOrigin),
+                    ct)
+                .ConfigureAwait(false);
 
-        var updatedPlan = transition.Workflow is null
-            ? AttachClosingEntriesGate(plan, reversalGate)
-            : AttachClosingEntriesGate(BuildPeriodPlan(transition.Workflow), reversalGate);
-        var reopenIssues = transition.Success
-            ? Array.Empty<AccountingConfigurationValidationIssueDto>()
-            : transition.Blockers
-                .Select(static blocker => ToValidationIssue(blocker))
-                .Append(new AccountingConfigurationValidationIssueDto(
-                    "CloseWorkflowReopenPendingAfterLedgerReopen",
-                    AccountingConfigurationValidationSeverityDto.Critical,
-                    "The ledger period is reopened, but the workflow reopen transition did not commit.",
-                    plan.ClosePlanId,
-                    "Refresh the close plan and retry the exact reopen command with the current workflow version; the retained reversal receipt makes ledger reopen idempotent."))
-                .ToArray();
-        return new ClosePeriodReopenResultDto(
-            transition.Success,
-            updatedPlan,
-            transition,
-            reversalGate,
-            reopenIssues);
+            var updatedPlan = transition.Workflow is null
+                ? AttachClosingEntriesGate(plan, reversalGate)
+                : AttachClosingEntriesGate(BuildPeriodPlan(transition.Workflow), reversalGate);
+            var reopenIssues = transition.Success
+                ? Array.Empty<AccountingConfigurationValidationIssueDto>()
+                : transition.Blockers
+                    .Select(static blocker => ToValidationIssue(blocker))
+                    .Append(new AccountingConfigurationValidationIssueDto(
+                        "CloseWorkflowReopenPendingAfterLedgerReopen",
+                        AccountingConfigurationValidationSeverityDto.Critical,
+                        "The ledger period is reopened, but the workflow reopen transition did not commit.",
+                        plan.ClosePlanId,
+                        "Refresh the close plan and retry the exact reopen command with the current workflow version; the retained reversal receipt makes ledger reopen idempotent."))
+                    .ToArray();
+            return new ClosePeriodReopenResultDto(
+                transition.Success,
+                updatedPlan,
+                transition,
+                reversalGate,
+                reopenIssues);
         }
         finally
         {

--- a/src/Meridian.Ui/dashboard/src/design-system/button.tsx
+++ b/src/Meridian.Ui/dashboard/src/design-system/button.tsx
@@ -130,7 +130,6 @@ export const DesignSystemButton = forwardRef<HTMLButtonElement, DesignSystemButt
         onClick={onClick}
         tabIndex={tabIndex}
         title={vm.title}
-        data-design-system-component="Button"
         {...props}
       >
         {vm.showBusyIndicator && <Loader2 className="h-4 w-4 animate-spin" aria-hidden={vm.iconAriaHidden} />}

--- a/src/Meridian.Ui/dashboard/src/lib/api/reporting-runs.api.test.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api/reporting-runs.api.test.ts
@@ -1,5 +1,5 @@
 import { createReportingRunsApi } from "@/lib/api/reporting-runs.api";
-import { FUND_STRUCTURE_API_ENDPOINTS } from "@/lib/ui-api-routes.generated";
+import { FUND_STRUCTURE_API_ENDPOINTS } from "@/lib/workstation-endpoints";
 import type { ReportingRunRequest } from "@/types";
 
 const request = { templateId: "monthly-investor-report" } as ReportingRunRequest;

--- a/src/Meridian.Ui/dashboard/src/lib/api/reporting-runs.api.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api/reporting-runs.api.ts
@@ -1,5 +1,5 @@
 import type { ApiRequestOptions } from "@/lib/api";
-import { FUND_STRUCTURE_API_ENDPOINTS } from "@/lib/ui-api-routes.generated";
+import { FUND_STRUCTURE_API_ENDPOINTS } from "@/lib/workstation-endpoints";
 import type { ReportingRunReadiness, ReportingRunRequest, ReportingRunResult } from "@/types";
 
 type PostJson = <T>(path: string, body?: unknown, options?: ApiRequestOptions) => Promise<T>;

--- a/src/Meridian.Ui/dashboard/src/screens/data-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/data-screen.test.tsx
@@ -14,15 +14,13 @@ import {
 import { renderWithRouter } from "@/test/render";
 import type {
   BackfillProgressResponse,
-  BackfillExecutionHistoryResponse,
   BackfillPreviewResult,
   BackfillTriggerResult,
   DataWorkspaceResponse,
   ProviderConnectionRow,
   ProviderCredentialVerificationResult,
   ProviderReadinessSummary,
-  ProviderSetupResult,
-  QualityDashboardResponse
+  ProviderSetupResult
 } from "@/types";
 
 const data: DataWorkspaceResponse = {

--- a/tests/Meridian.Tests/Ui/AutomatedJournalDraftIntakeServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/AutomatedJournalDraftIntakeServiceTests.cs
@@ -193,7 +193,8 @@ public sealed class AutomatedJournalDraftIntakeServiceTests
             Guid.Parse("44444444-4444-4444-8444-444444444444"),
             Guid.Parse("dddddddd-dddd-4ddd-8ddd-dddddddddddd"),
             "NVDA",
-            "batch-a") with { EntityId = "entity-beta" };
+            "batch-a") with
+        { EntityId = "entity-beta" };
         var candidate = new AutomatedJournalDraft(
             new AutomatedJournalEvent(
                 AutomatedJournalEventKind.FairValueMarkAdjustment,

--- a/tests/Meridian.Tests/Ui/LedgerAmountProvenanceServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/LedgerAmountProvenanceServiceTests.cs
@@ -2,8 +2,13 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
+using Meridian.Application.SecurityMaster;
 using Meridian.Contracts.Workstation;
+using Meridian.Identity.Auth;
+using Meridian.PortfolioRecords.FundAccounts;
+using Meridian.Reporting;
 using Meridian.Strategies.Services;
+using Meridian.Strategies.Storage;
 using Meridian.Ui.Shared.Endpoints;
 using Meridian.Ui.Shared.Services;
 using Microsoft.AspNetCore.Builder;
@@ -11,6 +16,7 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 using Xunit;
 
 namespace Meridian.Tests.Ui;
@@ -438,10 +444,35 @@ public sealed class LedgerAmountProvenanceServiceTests
             EnvironmentName = Environments.Development
         });
         builder.WebHost.UseTestServer();
-        builder.Services.AddSingleton<IGovernanceReportPackRepository>(new InMemoryReportPackRepository(snapshot));
+        var reportRepository = new InMemoryReportPackRepository(snapshot);
+        var securityMaster = new NullSecurityMasterQueryService();
+        var fundGuard = Substitute.For<IFundProfileTenantGuard>();
+        fundGuard.EvaluateAsync(
+                Arg.Any<WorkstationTenantContext>(),
+                "fund-ops",
+                Arg.Any<CancellationToken>())
+            .Returns(FundProfileTenantDecision.Allow("owned by the test tenant"));
+
+        builder.Services.AddSingleton<IGovernanceReportPackRepository>(reportRepository);
+        builder.Services.AddSingleton(new FundOperationsWorkspaceReadService(
+            new InMemoryFundAccountService(),
+            new StrategyRunStore(),
+            new PortfolioReadService(),
+            new NavAttributionService(securityMaster),
+            new ReportGenerationService(securityMaster),
+            reportPackRepository: reportRepository));
         builder.Services.AddSingleton<LedgerAmountProvenanceService>();
+        builder.Services.AddSingleton(fundGuard);
 
         var app = builder.Build();
+        app.Use(async (context, next) =>
+        {
+            context.Items[LoginSessionMiddleware.CurrentUserKey] = "reporting-test-operator";
+            context.Items[LoginSessionMiddleware.CurrentUserPermissionsKey] = UserPermission.ViewReporting;
+            context.Items[LoginSessionMiddleware.CurrentTenantIdKey] = "tenant-test";
+            context.Items[LoginSessionMiddleware.CurrentUserCompanyIdKey] = "company-test";
+            await next();
+        });
         app.MapFundStructureEndpoints(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         await app.StartAsync();
         return app;

--- a/tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportPackWorkflowServiceTests.cs
@@ -30,6 +30,9 @@ namespace Meridian.Tests.Ui;
 /// </summary>
 public sealed class ReportPackWorkflowServiceTests
 {
+    private const string TestTenantId = "tenant-a";
+    private const string TestCompanyId = "company-a";
+
     [Fact]
     public void Transition_FreshDraftSubmitApprovePublish_CompletesW4LifecycleWithoutLegacyIntermediateState()
     {
@@ -181,7 +184,8 @@ public sealed class ReportPackWorkflowServiceTests
         var workflow = app.Services.GetRequiredService<ReportPackWorkflowService>();
         var approved = CreateApprovedPack(
             workflow,
-            [CompleteLineProvenance("trial-balance.cash", "ledger-evidence-1")]);
+            [CompleteLineProvenance("trial-balance.cash", "ledger-evidence-1")],
+            accessContext: BoundAccessContext("author"));
         var published = workflow.Publish(
             approved.ReportId,
             "publisher",
@@ -1928,7 +1932,8 @@ public sealed class ReportPackWorkflowServiceTests
         var delivery = app.Services.GetRequiredService<ReportPackDeliveryService>();
         var approved = CreateApprovedPack(
             workflow,
-            [CompleteLineProvenance("trial-balance.cash", "ledger-evidence-1")]);
+            [CompleteLineProvenance("trial-balance.cash", "ledger-evidence-1")],
+            accessContext: BoundAccessContext("author"));
         var published = workflow.Publish(
             approved.ReportId,
             "publisher",
@@ -2030,7 +2035,8 @@ public sealed class ReportPackWorkflowServiceTests
             "acct-1",
             "2026-03",
             new VersionedReportTemplateIdDto("board-pack", 1),
-            "author");
+            "author",
+            accessContext: BoundAccessContext("author"));
         workflow.Transition(created.ReportId, ReportPackWorkflowStateDto.InReview, "reviewer", "reviewer");
         workflow.Transition(created.ReportId, ReportPackWorkflowStateDto.Approved, "approver", "approver");
         var brandingTheme = new ReportBrandingThemeDto(
@@ -2447,18 +2453,22 @@ public sealed class ReportPackWorkflowServiceTests
     public async Task ReportingScheduleService_PersistsSchedulesAndRunsDueSchedules()
     {
         var root = Path.Combine(Path.GetTempPath(), "Meridian.Tests", Guid.NewGuid().ToString("N"));
+        var templateCatalog = new DefaultReportingTemplateCatalog();
         var runStore = new FileReportingRunStore(
             new ReportingRunStoreOptions(Path.Combine(root, "reporting-runs")),
             NullLogger<FileReportingRunStore>.Instance);
         var orchestration = new ReportingOrchestrationService(
-            new DefaultReportingTemplateCatalog(),
+            templateCatalog,
             new DeterministicReportingSectionRenderer(),
             () => new DateTimeOffset(2026, 5, 1, 8, 0, 0, TimeSpan.Zero),
             runStore);
         var scheduleStore = new FileReportingScheduleStore(
             new ReportingScheduleStoreOptions(Path.Combine(root, "reporting-schedules.json")),
             NullLogger<FileReportingScheduleStore>.Instance);
-        var schedules = new ReportingScheduleService(orchestration, scheduleStore);
+        var schedules = new ReportingScheduleService(
+            orchestration,
+            scheduleStore,
+            readinessService: LegacyDraftReadiness(templateCatalog));
 
         var created = schedules.Upsert(new ReportingScheduleUpsertRequestDto(
             "sched-investor",
@@ -2482,7 +2492,10 @@ public sealed class ReportPackWorkflowServiceTests
         result.Schedule.DueAtUtc.Should().Be(new DateTimeOffset(2026, 6, 1, 8, 0, 0, TimeSpan.Zero));
         result.Schedule.NextAsOfDate.Should().Be(new DateOnly(2026, 6, 1));
 
-        var reloaded = new ReportingScheduleService(orchestration, scheduleStore);
+        var reloaded = new ReportingScheduleService(
+            orchestration,
+            scheduleStore,
+            readinessService: LegacyDraftReadiness(templateCatalog));
         reloaded.ListSchedules().Should().ContainSingle(schedule =>
             schedule.ScheduleId == "sched-investor" &&
             schedule.LastRunId == result.Run.RunId &&
@@ -2493,6 +2506,7 @@ public sealed class ReportPackWorkflowServiceTests
     public void Scenario_NewFundWorkspace_EmergingManagerStarterKitSeedsEditableReportingDesk()
     {
         var templateCatalog = new DefaultReportingTemplateCatalog();
+        var accessContext = BoundAccessContext("fund-controller");
         var orchestration = new ReportingOrchestrationService(
             templateCatalog,
             new DeterministicReportingSectionRenderer(),
@@ -2507,12 +2521,12 @@ public sealed class ReportPackWorkflowServiceTests
         var result = starterKits.Provision(
             "emerging-manager",
             "fund-controller",
-            new ReportAccessQueryContext("fund-controller"));
+            accessContext);
         var reporting = new ReportPackRunReadService(
                 templateCatalog,
                 scheduleService: schedules,
                 starterKitService: starterKits)
-            .BuildPayload();
+            .BuildPayload(accessContext);
 
         result.State.IsProvisioned.Should().BeTrue();
         result.State.SelectedKitId.Should().Be("emerging-manager");
@@ -2526,7 +2540,7 @@ public sealed class ReportPackWorkflowServiceTests
             schedule.ScheduleId == "starter-emerging-manager-investor-monthly" &&
             schedule.TemplateId == "investor-monthly-statement" &&
             schedule.RequestedBy == "fund-controller");
-        schedules.ListSchedules().Select(static schedule => schedule.ScheduleId).Should().BeEquivalentTo(result.State.SeedScheduleIds);
+        schedules.ListSchedules(accessContext).Select(static schedule => schedule.ScheduleId).Should().BeEquivalentTo(result.State.SeedScheduleIds);
         reporting.StarterKitState.Should().NotBeNull();
         reporting.StarterKitState!.SelectedKitId.Should().Be("emerging-manager");
         reporting.Templates.Select(static template => template.TemplateId).Should().BeEquivalentTo(result.State.EnabledTemplateIds);
@@ -2536,6 +2550,7 @@ public sealed class ReportPackWorkflowServiceTests
     public async Task ReportingScheduleService_DeliversConfiguredReportPackTargetsAfterScheduledRun()
     {
         var root = Path.Combine(Path.GetTempPath(), "Meridian.Tests", Guid.NewGuid().ToString("N"));
+        var templateCatalog = new DefaultReportingTemplateCatalog();
         var workflow = new ReportPackWorkflowService();
         var approved = CreateApprovedPack(
             workflow,
@@ -2558,14 +2573,18 @@ public sealed class ReportPackWorkflowServiceTests
             new ReportingRunStoreOptions(Path.Combine(root, "reporting-runs")),
             NullLogger<FileReportingRunStore>.Instance);
         var orchestration = new ReportingOrchestrationService(
-            new DefaultReportingTemplateCatalog(),
+            templateCatalog,
             new DeterministicReportingSectionRenderer(),
             () => new DateTimeOffset(2026, 5, 1, 8, 0, 0, TimeSpan.Zero),
             runStore);
         var scheduleStore = new FileReportingScheduleStore(
             new ReportingScheduleStoreOptions(Path.Combine(root, "reporting-schedules.json")),
             NullLogger<FileReportingScheduleStore>.Instance);
-        var schedules = new ReportingScheduleService(orchestration, scheduleStore, delivery);
+        var schedules = new ReportingScheduleService(
+            orchestration,
+            scheduleStore,
+            delivery,
+            readinessService: LegacyDraftReadiness(templateCatalog));
 
         var created = schedules.Upsert(new ReportingScheduleUpsertRequestDto(
             "sched-board-distribution",
@@ -2623,7 +2642,11 @@ public sealed class ReportPackWorkflowServiceTests
 
         var reloadedDelivery = new ReportPackDeliveryService(workflow, deliveryStore);
         reloadedDelivery.GetHistory(reportingRunReportId).Should().HaveCount(2);
-        var reloadedSchedules = new ReportingScheduleService(orchestration, scheduleStore, reloadedDelivery);
+        var reloadedSchedules = new ReportingScheduleService(
+            orchestration,
+            scheduleStore,
+            reloadedDelivery,
+            readinessService: LegacyDraftReadiness(templateCatalog));
         reloadedSchedules.ListSchedules().Should().ContainSingle(schedule =>
             schedule.ScheduleId == "sched-board-distribution" &&
             schedule.DeliveryTargets != null &&
@@ -3061,7 +3084,12 @@ public sealed class ReportPackWorkflowServiceTests
         var scheduleStore = new FileReportingScheduleStore(
             new ReportingScheduleStoreOptions(Path.Combine(root, "reporting-schedules.json")),
             NullLogger<FileReportingScheduleStore>.Instance);
-        var schedules = new ReportingScheduleService(orchestration, scheduleStore, delivery, catalog);
+        var schedules = new ReportingScheduleService(
+            orchestration,
+            scheduleStore,
+            delivery,
+            catalog,
+            readinessService: LegacyDraftReadiness(catalog, catalog));
         var brandingTheme = new ReportBrandingThemeDto(
             "allocator-quarterly",
             "Allocator Quarterly",
@@ -3387,7 +3415,7 @@ public sealed class ReportPackWorkflowServiceTests
     }
 
     [Fact]
-    public async Task ReportingRunCommandService_CarriesRestatementAuthorizationThroughRequest()
+    public async Task ReportingRunCommandService_RejectsRestatementAuthorizationOutsideGovernedWorkflow()
     {
         var root = Path.Combine(Path.GetTempPath(), "Meridian.Tests", Guid.NewGuid().ToString("N"));
         var runStore = new FileReportingRunStore(
@@ -3399,7 +3427,10 @@ public sealed class ReportPackWorkflowServiceTests
             new DeterministicReportingSectionRenderer(),
             () => new DateTimeOffset(2026, 5, 4, 9, 0, 0, TimeSpan.Zero),
             runStore);
-        var service = new ReportingRunCommandService(orchestration, catalog);
+        var service = new ReportingRunCommandService(
+            orchestration,
+            catalog,
+            readinessService: LegacyDraftReadiness(catalog));
 
         var initial = await service.RunAsync(
             new ReportingRunRequestDto("investor-monthly-statement", new DateOnly(2026, 5, 4), JobId: "adhoc-restate"),
@@ -3416,8 +3447,8 @@ public sealed class ReportPackWorkflowServiceTests
             CancellationToken.None);
         await blocked.Should().ThrowAsync<InvalidOperationException>().WithMessage("*Released manifest*");
 
-        // Authorized restatement flows the flag through the request/service layer and succeeds.
-        var restated = await service.RunAsync(
+        // Ordinary report generation cannot authorize restatement; callers must use the governed request workflow.
+        var restatement = async () => await service.RunAsync(
             new ReportingRunRequestDto(
                 "investor-monthly-statement",
                 new DateOnly(2026, 5, 4),
@@ -3427,9 +3458,8 @@ public sealed class ReportPackWorkflowServiceTests
             "fund-controller",
             CancellationToken.None);
 
-        restated.Run.RunId.Should().Be("adhoc-restate-20260504-v2");
-        orchestration.GetAudit(initial.Run.RunId).Should().Contain(entry =>
-            entry.Action == "RestatementAuthorized" && entry.Notes.Contains("Q2 NAV correction"));
+        await restatement.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*governed restatement-request workflow*");
     }
 
     [Fact]
@@ -3445,7 +3475,10 @@ public sealed class ReportPackWorkflowServiceTests
             new DeterministicReportingSectionRenderer(),
             () => new DateTimeOffset(2026, 5, 4, 9, 0, 0, TimeSpan.Zero),
             runStore);
-        var service = new ReportingRunCommandService(orchestration, catalog);
+        var service = new ReportingRunCommandService(
+            orchestration,
+            catalog,
+            readinessService: LegacyDraftReadiness(catalog));
 
         var result = await service.RunAsync(
             new ReportingRunRequestDto(
@@ -3555,7 +3588,12 @@ public sealed class ReportPackWorkflowServiceTests
             () => new DateTimeOffset(2026, 5, 6, 12, 0, 0, TimeSpan.Zero),
             runStore);
         var datasetSource = new ReportWriterDatasetSourceService(workflow);
-        var commandService = new ReportingRunCommandService(orchestration, catalog, catalog, datasetSource);
+        var commandService = new ReportingRunCommandService(
+            orchestration,
+            catalog,
+            catalog,
+            datasetSource,
+            readinessService: LegacyDraftReadiness(catalog, catalog));
 
         var result = await commandService.RunAsync(
             new ReportingRunRequestDto(
@@ -3677,7 +3715,8 @@ public sealed class ReportPackWorkflowServiceTests
             scheduleStore,
             deliveryService: null,
             governedTemplateCatalog: catalog,
-            datasetSourceService: new ReportWriterDatasetSourceService(workflow));
+            datasetSourceService: new ReportWriterDatasetSourceService(workflow),
+            readinessService: LegacyDraftReadiness(catalog, catalog));
 
         schedules.Upsert(new ReportingScheduleUpsertRequestDto(
             "sched-source-backed",
@@ -4872,7 +4911,8 @@ public sealed class ReportPackWorkflowServiceTests
         var approved = CreateApprovedPack(
             workflow,
             [CompleteLineProvenance("trial-balance.cash", "ledger-evidence-1")],
-            accessPolicy: new ReportAccessPolicyDto(ReportAccessModeDto.Private, OwnerPrincipalId: "owner.user"));
+            accessPolicy: new ReportAccessPolicyDto(ReportAccessModeDto.Private, OwnerPrincipalId: "owner.user"),
+            accessContext: BoundAccessContext("author"));
         var published = workflow.Publish(
             approved.ReportId,
             "publisher",
@@ -4910,7 +4950,8 @@ public sealed class ReportPackWorkflowServiceTests
             [CompleteLineProvenance("trial-balance.cash", "ledger-evidence-1")],
             accessPolicy: new ReportAccessPolicyDto(
                 ReportAccessModeDto.Restricted,
-                Principals: [new ReportAccessPrincipalDto(ReportAccessPrincipalKindDto.Group, UserRole.FundAccountant.ToString())]));
+                Principals: [new ReportAccessPrincipalDto(ReportAccessPrincipalKindDto.Group, UserRole.FundAccountant.ToString())]),
+            accessContext: BoundAccessContext("author"));
         var published = workflow.Publish(
             approved.ReportId,
             "publisher",
@@ -4946,7 +4987,8 @@ public sealed class ReportPackWorkflowServiceTests
         var approved = CreateApprovedPack(
             workflow,
             [CompleteLineProvenance("trial-balance.cash", "ledger-evidence-1")],
-            accessPolicy: new ReportAccessPolicyDto(ReportAccessModeDto.Private, OwnerPrincipalId: "owner.user"));
+            accessPolicy: new ReportAccessPolicyDto(ReportAccessModeDto.Private, OwnerPrincipalId: "owner.user"),
+            accessContext: BoundAccessContext("author"));
         var published = workflow.Publish(
             approved.ReportId,
             "publisher",
@@ -4980,7 +5022,8 @@ public sealed class ReportPackWorkflowServiceTests
         var workflow = app.Services.GetRequiredService<ReportPackWorkflowService>();
         var approved = CreateApprovedPack(
             workflow,
-            [CompleteLineProvenance("trial-balance.cash", "ledger-evidence-1")]);
+            [CompleteLineProvenance("trial-balance.cash", "ledger-evidence-1")],
+            accessContext: BoundAccessContext("author"));
         var published = workflow.Publish(
             approved.ReportId,
             "publisher",
@@ -5346,7 +5389,8 @@ public sealed class ReportPackWorkflowServiceTests
         ReportPackWorkflowService svc,
         IReadOnlyList<ReportPackLineProvenanceDto> lineProvenance,
         string templateName = "board-pack",
-        ReportAccessPolicyDto? accessPolicy = null)
+        ReportAccessPolicyDto? accessPolicy = null,
+        ReportAccessQueryContext? accessContext = null)
     {
         var created = svc.Create(
             "fund-a",
@@ -5355,10 +5399,27 @@ public sealed class ReportPackWorkflowServiceTests
             new VersionedReportTemplateIdDto(templateName, 1),
             "author",
             lineProvenance,
-            accessPolicy);
+            accessPolicy,
+            accessContext);
         svc.Transition(created.ReportId, ReportPackWorkflowStateDto.InReview, "reviewer", "reviewer");
         return svc.Transition(created.ReportId, ReportPackWorkflowStateDto.Approved, "approver", "approver");
     }
+
+    private static ReportAccessQueryContext BoundAccessContext(
+        string actor,
+        string companyId = TestCompanyId,
+        IReadOnlyList<string>? groups = null) =>
+        new(actor, groups, companyId, TenantId: TestTenantId, RequireBoundScope: true);
+
+    private static ReportingRunReadinessService LegacyDraftReadiness(
+        IReportingTemplateCatalog catalog,
+        GovernedReportingTemplateCatalog? governedCatalog = null) =>
+        new(
+            catalog,
+            governedCatalog,
+            options: new ReportingRunReadinessOptions(
+                AllowLegacyUnscopedDrafts: true,
+                AllowDraftWhenDependencyEvaluatorIsUnavailable: true));
 
     private static void PublishWithLedgerEvidence(ReportPackWorkflowService svc, Guid reportId, string evidenceId = "ledger-evidence-1") =>
         svc.Publish(
@@ -5442,7 +5503,8 @@ public sealed class ReportPackWorkflowServiceTests
         string username = "controller.admin",
         FundOperationsWorkspaceReadService? workspaceService = null,
         string? roleProfileName = null,
-        string? companyId = null)
+        string? companyId = TestCompanyId,
+        string? tenantId = TestTenantId)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
@@ -5465,12 +5527,19 @@ public sealed class ReportPackWorkflowServiceTests
                 () => new DateTimeOffset(2026, 5, 5, 9, 0, 0, TimeSpan.Zero)));
         builder.Services.AddSingleton<ReportWriterDatasetSourceService>();
         builder.Services.AddSingleton<ReportWriterGridArtifactService>();
+        builder.Services.AddSingleton(sp =>
+            LegacyDraftReadiness(
+                sp.GetRequiredService<IReportingTemplateCatalog>(),
+                sp.GetRequiredService<GovernedReportingTemplateCatalog>()));
+        builder.Services.AddSingleton<ReportingRunCertificationService>();
         builder.Services.AddSingleton<ReportingRunCommandService>();
         builder.Services.AddSingleton(sp =>
             new ReportingScheduleService(
                 sp.GetRequiredService<IReportingOrchestrationService>(),
                 datasetSourceService: sp.GetRequiredService<ReportWriterDatasetSourceService>(),
-                governedTemplateCatalog: sp.GetRequiredService<GovernedReportingTemplateCatalog>()));
+                governedTemplateCatalog: sp.GetRequiredService<GovernedReportingTemplateCatalog>(),
+                readinessService: sp.GetRequiredService<ReportingRunReadinessService>(),
+                certificationService: sp.GetRequiredService<ReportingRunCertificationService>()));
         builder.Services.AddSingleton<ReportingStarterKitService>();
         builder.Services.AddSingleton<ReportPackWorkflowService>();
         builder.Services.AddSingleton<ReportPackDeliveryService>();
@@ -5492,6 +5561,11 @@ public sealed class ReportPackWorkflowServiceTests
             if (!string.IsNullOrWhiteSpace(companyId))
             {
                 context.Items[LoginSessionMiddleware.CurrentUserCompanyIdKey] = companyId.Trim();
+            }
+
+            if (!string.IsNullOrWhiteSpace(tenantId))
+            {
+                context.Items[LoginSessionMiddleware.CurrentTenantIdKey] = tenantId.Trim();
             }
 
             await next();

--- a/tests/Meridian.Tests/Ui/ReportingRunStreamEndpointTests.cs
+++ b/tests/Meridian.Tests/Ui/ReportingRunStreamEndpointTests.cs
@@ -114,22 +114,29 @@ public sealed class ReportingRunStreamEndpointTests
         var client = app.GetTestClient();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-        // Hold the first stream open (its subscription keeps the session's single slot reserved).
-        using var first = await client.GetAsync(
-            $"/api/fund-structure/reporting/runs/{SeededRunId}/stream",
-            HttpCompletionOption.ResponseHeadersRead,
-            cts.Token);
-        first.StatusCode.Should().Be(HttpStatusCode.OK);
-        await using var firstStream = await first.Content.ReadAsStreamAsync(cts.Token);
-        await ReadPastFirstFrameAsync(firstStream, cts.Token);
+        try
+        {
+            // Hold the first stream open (its subscription keeps the session's single slot reserved).
+            using var first = await client.GetAsync(
+                $"/api/fund-structure/reporting/runs/{SeededRunId}/stream",
+                HttpCompletionOption.ResponseHeadersRead,
+                cts.Token);
+            first.StatusCode.Should().Be(HttpStatusCode.OK);
+            await using var firstStream = await first.Content.ReadAsStreamAsync(cts.Token);
+            await ReadPastFirstFrameAsync(firstStream, cts.Token);
 
-        using var second = await client.GetAsync(
-            $"/api/fund-structure/reporting/runs/{SeededRunId}/stream",
-            HttpCompletionOption.ResponseHeadersRead,
-            cts.Token);
+            using var second = await client.GetAsync(
+                $"/api/fund-structure/reporting/runs/{SeededRunId}/stream",
+                HttpCompletionOption.ResponseHeadersRead,
+                cts.Token);
 
-        second.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
-        second.Headers.RetryAfter.Should().NotBeNull();
+            second.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+            second.Headers.RetryAfter.Should().NotBeNull();
+        }
+        finally
+        {
+            await cts.CancelAsync();
+        }
     }
 
     private static async Task<string> ReadFirstEventFrameAsync(HttpResponseMessage response, CancellationToken ct)

--- a/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationEndpointsTests.cs
@@ -143,7 +143,8 @@ public sealed partial class WorkstationEndpointsTests
     [Fact]
     public async Task MapWorkstationEndpoints_CanonicalWorkspaceRouteConstants_WithoutBackingServices_ShouldReturnServiceUnavailable()
     {
-        await using var app = await CreateAppAsync();
+        await using var app = await CreateAppAsync(
+            currentUserPermissions: UserPermission.ModifySecurityMaster | UserPermission.ViewReporting);
         var client = app.GetTestClient();
 
         UiApiRoutes.WorkstationStrategy.Should().Be("/api/workstation/strategy");
@@ -255,7 +256,8 @@ public sealed partial class WorkstationEndpointsTests
     [Fact]
     public async Task MapWorkstationEndpoints_WithoutStrategyReadService_ShouldReturnServiceUnavailableInsteadOfFabricatedPayloads()
     {
-        await using var app = await CreateAppAsync();
+        await using var app = await CreateAppAsync(
+            currentUserPermissions: UserPermission.ModifySecurityMaster | UserPermission.ViewReporting);
         var client = app.GetTestClient();
 
         // The session bootstrap payload stays available with honest zeroed workspace counters.
@@ -5966,7 +5968,9 @@ public sealed partial class WorkstationEndpointsTests
     {
         // The reporting workspace rides on the accounting payload, which requires the strategy
         // run read service; without it the endpoint returns 503 instead of fabricated data.
-        await using var app = await CreateAppAsync(services => RegisterRunReadServices(services));
+        await using var app = await CreateAppAsync(
+            services => RegisterRunReadServices(services),
+            currentUserPermissions: UserPermission.ModifySecurityMaster | UserPermission.ViewReporting);
         var client = app.GetTestClient();
 
         using var reporting = await ReadJsonAsync(client, "/api/workstation/reporting");
@@ -6029,7 +6033,9 @@ public sealed partial class WorkstationEndpointsTests
             services.AddSingleton(new ReportPackRunReadService(
                 new DefaultReportingTemplateCatalog(),
                 workflowService: workflow));
-        }, currentUserRoleProfileName: "ops-control");
+        },
+            currentUserPermissions: UserPermission.ModifySecurityMaster | UserPermission.ViewReporting,
+            currentUserRoleProfileName: "ops-control");
         var client = app.GetTestClient();
         var requestedRoutes = new List<string>();
 
@@ -6183,7 +6189,8 @@ public sealed partial class WorkstationEndpointsTests
             services.AddSingleton(new ReportPackRunReadService(
                 new DefaultReportingTemplateCatalog(),
                 workflowService: workflow));
-        });
+        },
+            currentUserPermissions: UserPermission.ModifySecurityMaster | UserPermission.ViewReporting);
         var strangerClient = strangerApp.GetTestClient();
         var strangerResponse = await strangerClient.GetAsync("/api/workstation/reporting/structured-exports/investment-portfolio-cuts");
         var strangerAnalyticsResponse = await strangerClient.GetAsync("/api/workstation/reporting/structured-exports/investment-topn-contribution-analytics");

--- a/tests/Meridian.Tests/Ui/WorkstationStreamEndpointTests.cs
+++ b/tests/Meridian.Tests/Ui/WorkstationStreamEndpointTests.cs
@@ -77,20 +77,27 @@ public sealed class WorkstationStreamEndpointTests
         var client = app.GetTestClient();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-        // Hold the first stream open (its subscription keeps the session's single slot reserved).
-        // Read past the first frame WITHOUT disposing the stream — disposing it would abort the
-        // server request and release the slot, letting the second request succeed spuriously.
-        using var first = await client.GetAsync(
-            "/api/workstation/stream?symbols=SPY", HttpCompletionOption.ResponseHeadersRead, cts.Token);
-        first.StatusCode.Should().Be(HttpStatusCode.OK);
-        await using var firstStream = await first.Content.ReadAsStreamAsync(cts.Token);
-        await ReadPastFirstFrameAsync(firstStream, cts.Token);
+        try
+        {
+            // Hold the first stream open (its subscription keeps the session's single slot reserved).
+            // Read past the first frame WITHOUT disposing the stream — disposing it would abort the
+            // server request and release the slot, letting the second request succeed spuriously.
+            using var first = await client.GetAsync(
+                "/api/workstation/stream?symbols=SPY", HttpCompletionOption.ResponseHeadersRead, cts.Token);
+            first.StatusCode.Should().Be(HttpStatusCode.OK);
+            await using var firstStream = await first.Content.ReadAsStreamAsync(cts.Token);
+            await ReadPastFirstFrameAsync(firstStream, cts.Token);
 
-        using var second = await client.GetAsync(
-            "/api/workstation/stream?symbols=MSFT", HttpCompletionOption.ResponseHeadersRead, cts.Token);
+            using var second = await client.GetAsync(
+                "/api/workstation/stream?symbols=MSFT", HttpCompletionOption.ResponseHeadersRead, cts.Token);
 
-        second.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
-        second.Headers.RetryAfter.Should().NotBeNull();
+            second.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+            second.Headers.RetryAfter.Should().NotBeNull();
+        }
+        finally
+        {
+            await cts.CancelAsync();
+        }
     }
 
     private static async Task<string> ReadFirstEventFrameAsync(HttpResponseMessage response, CancellationToken ct)


### PR DESCRIPTION
## Summary

- Align reporting, report-pack, provenance, and SSE test fixtures with the production authorization, tenant-scope, readiness, and lifecycle controls.
- Repair current-main browser and compiler regressions without relaxing production policy.
- Split the oversized accounting, endpoint, WPF, and browser modules into behavior-preserving partials/helpers so every tracked file is back under the frozen size ratchet; no baseline was changed.
- Update the close-cockpit browser fixture to reflect the actionable queue-and-post workflow and stable refresh behavior.

## Reason

Current-main run `29417312878` exposed fail-closed fixture drift after reporting controls landed. Subsequent PR runs identified a missing Contracts namespace, one stale close-cockpit assertion, and newly merged file-size ratchet failures. This PR repairs the exact hosted failures and keeps the governed runtime behavior intact.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit and integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Local evidence:

- `python build/scripts/ci/check-file-size.py` passed: 47 tracked files, no new or grown god files.
- `git diff --check` and conflict-marker scan passed.
- `pwsh ./tools/codex/mvvm-compliance-check.ps1` passed with 0 errors.
- `pwsh ./tools/codex/resource-review.ps1` passed with 0 errors.
- `npm run lint` passed with 0 errors and 91 existing warnings.
- `npm run typecheck:strict` passed.
- `npm run test:vitest -- src/screens/accounting-screen.test.tsx` passed: 66/66 tests.
- Focused close-cockpit and provider-module Vitest passed: 30/30 tests.
- Earlier formatter and focused reporting API checks passed.
- The transitive WPF Release build restored successfully, then exceeded the eight-minute local ceiling inside the F# compiler without emitting a compile diagnostic. GitHub Actions remains the authoritative full-graph compile/test result.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No file-size or quality baseline was changed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`