### PR TITLE
fix(execution): close two live-trading safety gaps

### DIFF
--- a/src/Meridian.Execution/Adapters/BrokerageGatewayAdapter.cs
+++ b/src/Meridian.Execution/Adapters/BrokerageGatewayAdapter.cs
@@ -12,12 +12,21 @@ namespace Meridian.Execution.Adapters;
 
 /// <summary>
 /// Bridges an <see cref="IBrokerageGateway"/> (from Execution.Sdk) to the
-/// <see cref="IOrderGateway"/> contract used by <see cref="Interfaces.IExecutionContext"/>.
-/// This allows any brokerage provider to plug into the existing execution framework
-/// without modifying the strategy-facing interfaces.
+/// <see cref="IOrderGateway"/> contract, mapping broker capabilities, order state, and execution
+/// reports between the two shapes.
 /// </summary>
+/// <remarks>
+/// This adapter is an <b>internal implementation detail</b> of the execution layer. It is never
+/// registered as a directly resolvable order-submission service: live order submission and
+/// cancellation are owned exclusively by <see cref="OrderManagementSystem"/> (the OMS), which runs
+/// the pre-trade gate stack (placement gate, live-order readiness, operator controls, security
+/// master, and risk validation) before any order reaches a broker. The live <see cref="IOrderGateway"/>
+/// exposed through dependency injection is a read-only view over this adapter
+/// (<see cref="OmsGovernedBrokerageOrderGateway"/>) whose submission and cancellation members are
+/// blocked, so no caller can bypass the OMS gates by resolving <see cref="IOrderGateway"/> directly.
+/// </remarks>
 [ImplementsAdr("ADR-015", "Adapts live brokerage gateways to the IOrderGateway contract")]
-public sealed class BrokerageGatewayAdapter : IOrderGateway
+internal sealed class BrokerageGatewayAdapter : IOrderGateway
 {
     private readonly IBrokerageGateway _inner;
     private readonly ILogger<BrokerageGatewayAdapter> _logger;

--- a/src/Meridian.Execution/Adapters/OmsGovernedBrokerageOrderGateway.cs
+++ b/src/Meridian.Execution/Adapters/OmsGovernedBrokerageOrderGateway.cs
@@ -1,0 +1,82 @@
+using Meridian.Execution.Interfaces;
+using Meridian.Execution.Models;
+
+namespace Meridian.Execution.Adapters;
+
+/// <summary>
+/// The read-only <see cref="IOrderGateway"/> surface exposed for a <b>live</b> brokerage gateway.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Live order submission and cancellation are owned exclusively by
+/// <see cref="OrderManagementSystem"/> (the OMS), which enforces the pre-trade gate stack —
+/// placement gate, live-order readiness, operator-control circuit breaker, security-master gate,
+/// and risk validation — before any order reaches a broker. To make that ownership structural
+/// rather than conventional, the live <see cref="IOrderGateway"/> resolved from dependency injection
+/// is <em>this</em> view rather than the raw <see cref="BrokerageGatewayAdapter"/>: read-only broker
+/// metadata and the execution-report stream are delegated to the adapter (so health, capability, and
+/// blotter surfaces keep working), while <see cref="SubmitAsync"/> and <see cref="CancelAsync"/> are
+/// blocked. A caller that resolves <see cref="IOrderGateway"/> and attempts to place or cancel a live
+/// order therefore fails fast instead of silently bypassing the OMS gates.
+/// </para>
+/// <para>
+/// The paper-trading gateway is unaffected: paper sessions have no live broker and no gate stack to
+/// bypass, so their <see cref="IOrderGateway"/> remains fully functional.
+/// </para>
+/// </remarks>
+internal sealed class OmsGovernedBrokerageOrderGateway : IOrderGateway
+{
+    private const string SubmissionBlockedMessage =
+        "Live order submission must go through the Order Management System (IOrderManager.PlaceOrderAsync). " +
+        "The live IOrderGateway is a read-only view; direct submission would bypass the pre-trade risk and " +
+        "compliance gate stack.";
+
+    private const string CancellationBlockedMessage =
+        "Live order cancellation must go through the Order Management System (IOrderManager.CancelOrderAsync). " +
+        "The live IOrderGateway is a read-only view; direct cancellation would bypass OMS order tracking.";
+
+    private readonly BrokerageGatewayAdapter _inner;
+
+    internal OmsGovernedBrokerageOrderGateway(BrokerageGatewayAdapter inner)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+    }
+
+    /// <inheritdoc />
+    public string BrokerName => _inner.BrokerName;
+
+    /// <inheritdoc />
+    public ExecutionMode Mode => _inner.Mode;
+
+    /// <inheritdoc />
+    public OrderGatewayCapabilities Capabilities => _inner.Capabilities;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Validation is side-effect free and remains available so operator surfaces can pre-flight an
+    /// order, but a successful validation does not grant a submission path outside the OMS.
+    /// </remarks>
+    public Task<OrderValidationResult> ValidateOrderAsync(Meridian.Execution.Sdk.OrderRequest request, CancellationToken ct = default)
+        => _inner.ValidateOrderAsync(request, ct);
+
+    /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">
+    /// Always thrown. Live orders must be placed through <see cref="OrderManagementSystem"/>.
+    /// </exception>
+    public Task<OrderAcknowledgement> SubmitAsync(Meridian.Execution.Sdk.OrderRequest request, CancellationToken ct = default)
+        => throw new InvalidOperationException(SubmissionBlockedMessage);
+
+    /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">
+    /// Always thrown. Live orders must be cancelled through <see cref="OrderManagementSystem"/>.
+    /// </exception>
+    public Task<bool> CancelAsync(string orderId, CancellationToken ct = default)
+        => throw new InvalidOperationException(CancellationBlockedMessage);
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<OrderStatusUpdate> StreamOrderUpdatesAsync(CancellationToken ct = default)
+        => _inner.StreamOrderUpdatesAsync(ct);
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync() => _inner.DisposeAsync();
+}

--- a/src/Meridian.Execution/BrokerageServiceRegistration.cs
+++ b/src/Meridian.Execution/BrokerageServiceRegistration.cs
@@ -46,7 +46,11 @@ public static class BrokerageServiceRegistration
             return ResolveBrokerageGateway(sp, brokerageConfig.Gateway);
         });
 
-        // Register the BrokerageGatewayAdapter that bridges IBrokerageGateway → IOrderGateway
+        // Register the DI-resolvable IOrderGateway. In paper mode this is the fully functional
+        // PaperTradingGateway (paper sessions have no live broker and no gate stack to bypass).
+        // In live mode the raw BrokerageGatewayAdapter is an internal detail owned by the OMS;
+        // the resolvable gateway is a read-only view whose submit/cancel members are blocked, so
+        // live order placement cannot bypass the OMS pre-trade gate stack via IOrderGateway.
         services.TryAddSingleton<IOrderGateway>(sp =>
         {
             var brokerageConfig = sp.GetRequiredService<BrokerageConfiguration>();
@@ -59,10 +63,12 @@ public static class BrokerageServiceRegistration
                 return new Adapters.PaperTradingGateway(paperLogger, secMaster, sp.GetService<Adapters.PaperTradingGatewayOptions>());
             }
 
-            // Resolve the named brokerage gateway via keyed registration
+            // Resolve the named brokerage gateway via keyed registration, then expose it as an
+            // OMS-governed read-only view rather than a directly submittable gateway.
             var gateway = ResolveBrokerageGateway(sp, brokerageConfig.Gateway);
             var adapterLogger = sp.GetRequiredService<ILogger<BrokerageGatewayAdapter>>();
-            return new BrokerageGatewayAdapter(gateway, adapterLogger, brokerageConfig);
+            var adapter = new BrokerageGatewayAdapter(gateway, adapterLogger, brokerageConfig);
+            return new OmsGovernedBrokerageOrderGateway(adapter);
         });
 
         // Register the OMS with the resolved gateway

--- a/src/Meridian.Execution/Services/PortfolioStatePositionTracker.cs
+++ b/src/Meridian.Execution/Services/PortfolioStatePositionTracker.cs
@@ -1,0 +1,107 @@
+using Meridian.Execution.Models;
+using Meridian.Execution.Sdk;
+
+namespace Meridian.Execution.Services;
+
+/// <summary>
+/// Production <see cref="IPositionTracker"/> that projects a live
+/// <see cref="IPortfolioState"/> (for example <see cref="PaperTradingPortfolio"/>, or any
+/// broker-backed portfolio implementation) into the real-time position and P&amp;L view that
+/// risk rules consume.
+/// </summary>
+/// <remarks>
+/// Before this adapter existed, <c>IPositionTracker</c> had no production implementation, so the
+/// two most safety-critical risk rules — <c>PositionLimitRule</c> (per-symbol position caps) and
+/// <c>DrawdownCircuitBreaker</c> (portfolio drawdown kill-switch) — could only be exercised against
+/// test doubles and could not function in a real deployment. This type bridges those rules to the
+/// portfolio state that the execution layer already maintains, without duplicating position
+/// accounting: it is a thin, read-only projection over the single source of truth.
+/// </remarks>
+public sealed class PortfolioStatePositionTracker : IPositionTracker
+{
+    private readonly IPortfolioState _portfolio;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>
+    /// Creates a position tracker backed by the supplied portfolio state.
+    /// </summary>
+    /// <param name="portfolio">The authoritative portfolio state to project. Required.</param>
+    /// <param name="timeProvider">
+    /// Clock used to stamp <see cref="PositionState.LastUpdated"/>. Defaults to
+    /// <see cref="TimeProvider.System"/> when not supplied.
+    /// </param>
+    public PortfolioStatePositionTracker(IPortfolioState portfolio, TimeProvider? timeProvider = null)
+    {
+        _portfolio = portfolio ?? throw new ArgumentNullException(nameof(portfolio));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <inheritdoc />
+    public PositionState GetPosition(string symbol)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(symbol);
+
+        return _portfolio.Positions.TryGetValue(symbol, out var position)
+            ? ToPositionState(position, _timeProvider.GetUtcNow())
+            : EmptyPosition(symbol, _timeProvider.GetUtcNow());
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, PositionState> GetAllPositions()
+    {
+        var asOf = _timeProvider.GetUtcNow();
+        var snapshot = new Dictionary<string, PositionState>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (symbol, position) in _portfolio.Positions)
+        {
+            snapshot[symbol] = ToPositionState(position, asOf);
+        }
+
+        return snapshot;
+    }
+
+    /// <inheritdoc />
+    public decimal GetPortfolioValue() => _portfolio.PortfolioValue;
+
+    /// <inheritdoc />
+    public decimal GetCash() => _portfolio.Cash;
+
+    /// <inheritdoc />
+    public decimal GetUnrealizedPnl() => _portfolio.UnrealisedPnl;
+
+    /// <inheritdoc />
+    public decimal GetRealizedPnl() => _portfolio.RealisedPnl;
+
+    private static PositionState ToPositionState(IPosition position, DateTimeOffset asOf)
+    {
+        var quantity = (decimal)position.Quantity;
+
+        // IPosition exposes unrealised P&L but not the current mark directly. Recover the mark from
+        // the identity UnrealizedPnl = (MarketPrice - AverageCostBasis) * Quantity so that the
+        // projected PositionState (whose MarketValue and UnrealizedPnl are derived from MarketPrice)
+        // stays internally consistent with the source portfolio. A flat position has no meaningful
+        // mark, so fall back to the average cost basis.
+        var marketPrice = quantity == 0m
+            ? position.AverageCostBasis
+            : position.AverageCostBasis + (position.UnrealizedPnl / quantity);
+
+        return new PositionState
+        {
+            Symbol = position.Symbol,
+            Quantity = quantity,
+            AverageCostBasis = position.AverageCostBasis,
+            MarketPrice = marketPrice,
+            RealizedPnl = position.RealizedPnl,
+            LastUpdated = asOf
+        };
+    }
+
+    private static PositionState EmptyPosition(string symbol, DateTimeOffset asOf) => new()
+    {
+        Symbol = symbol,
+        Quantity = 0m,
+        AverageCostBasis = 0m,
+        MarketPrice = 0m,
+        RealizedPnl = 0m,
+        LastUpdated = asOf
+    };
+}

--- a/src/Meridian/UiServer.cs
+++ b/src/Meridian/UiServer.cs
@@ -189,6 +189,11 @@ public sealed class UiServer : IAsyncDisposable
                 options: sp.GetRequiredService<Meridian.Execution.Adapters.PaperTradingGatewayOptions>()));
         builder.Services.AddSingleton<PaperTradingPortfolio>(_ => new PaperTradingPortfolio(100_000m));
         builder.Services.AddSingleton<IPortfolioState>(sp => sp.GetRequiredService<PaperTradingPortfolio>());
+        // Production IPositionTracker projection over the live portfolio state. Gives the
+        // safety-critical risk rules (PositionLimitRule, DrawdownCircuitBreaker) a real backing
+        // instead of leaving IPositionTracker without any non-test implementation.
+        builder.Services.AddSingleton<IPositionTracker>(sp =>
+            new PortfolioStatePositionTracker(sp.GetRequiredService<IPortfolioState>()));
         builder.Services.AddSingleton<IOrderManager>(sp =>
         {
             var gateway = sp.GetRequiredService<IExecutionGateway>();

--- a/tests/Meridian.Tests/Execution/OmsGovernedBrokerageOrderGatewayTests.cs
+++ b/tests/Meridian.Tests/Execution/OmsGovernedBrokerageOrderGatewayTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using Meridian.Execution.Adapters;
+using Meridian.Execution.Sdk;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using GatewayExecutionMode = Meridian.Execution.Models.ExecutionMode;
+
+namespace Meridian.Tests.Execution;
+
+/// <summary>
+/// Verifies that the live <c>IOrderGateway</c> surface exposed to DI consumers cannot be used to
+/// submit or cancel live orders directly — those lifecycle operations are owned by the OMS gate
+/// stack (<c>IOrderManager</c>). Read-only broker metadata is still delegated so health, capability,
+/// and blotter surfaces keep working.
+/// </summary>
+public sealed class OmsGovernedBrokerageOrderGatewayTests
+{
+    [Fact]
+    public void Constructor_WithNullAdapter_Throws()
+    {
+        var act = () => new OmsGovernedBrokerageOrderGateway(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task SubmitAsync_IsBlocked_AndNeverReachesTheBroker()
+    {
+        var gateway = CreateMockGateway();
+        await using var sut = CreateSut(gateway);
+
+        Func<Task> act = async () => await sut.SubmitAsync(MarketBuy());
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Order Management System*");
+        await gateway.DidNotReceive().SubmitOrderAsync(Arg.Any<OrderRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CancelAsync_IsBlocked_AndNeverReachesTheBroker()
+    {
+        var gateway = CreateMockGateway();
+        await using var sut = CreateSut(gateway);
+
+        Func<Task> act = async () => await sut.CancelAsync("order-1");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Order Management System*");
+        await gateway.DidNotReceive().CancelOrderAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReadOnlyMetadata_DelegatesToUnderlyingBroker()
+    {
+        await using var sut = CreateSut();
+
+        sut.BrokerName.Should().Be("Test Broker");
+        sut.Mode.Should().Be(GatewayExecutionMode.Live);
+        sut.Capabilities.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ValidateOrderAsync_RemainsAvailableForPreflight()
+    {
+        await using var sut = CreateSut();
+
+        var result = await sut.ValidateOrderAsync(MarketBuy());
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private static OmsGovernedBrokerageOrderGateway CreateSut(IBrokerageGateway? gateway = null)
+    {
+        var adapter = new BrokerageGatewayAdapter(
+            gateway ?? CreateMockGateway(),
+            NullLogger<BrokerageGatewayAdapter>.Instance);
+        return new OmsGovernedBrokerageOrderGateway(adapter);
+    }
+
+    private static IBrokerageGateway CreateMockGateway()
+    {
+        var gateway = Substitute.For<IBrokerageGateway>();
+        gateway.BrokerDisplayName.Returns("Test Broker");
+        gateway.GatewayId.Returns("test");
+        gateway.IsConnected.Returns(true);
+        gateway.BrokerageCapabilities.Returns(BrokerageCapabilities.UsEquity());
+        return gateway;
+    }
+
+    private static OrderRequest MarketBuy(string symbol = "AAPL", decimal qty = 10m) => new()
+    {
+        Symbol = symbol,
+        Side = OrderSide.Buy,
+        Type = OrderType.Market,
+        Quantity = qty,
+    };
+}

--- a/tests/Meridian.Tests/Execution/PortfolioStatePositionTrackerTests.cs
+++ b/tests/Meridian.Tests/Execution/PortfolioStatePositionTrackerTests.cs
@@ -1,0 +1,183 @@
+using FluentAssertions;
+using Meridian.Execution.Models;
+using Meridian.Execution.Sdk;
+using Meridian.Execution.Services;
+using Meridian.Risk.Rules;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Meridian.Tests.Execution;
+
+/// <summary>
+/// Tests for <see cref="PortfolioStatePositionTracker"/>, the production
+/// <see cref="IPositionTracker"/> that projects a live <see cref="IPortfolioState"/> into the
+/// position/P&amp;L view consumed by risk rules. The rule-integration tests deliberately wire the
+/// real <see cref="PositionLimitRule"/> and <see cref="DrawdownCircuitBreaker"/> against a real
+/// <see cref="PaperTradingPortfolio"/> — with no test doubles — to prove those safety-critical
+/// rules can now function in a real deployment.
+/// </summary>
+public sealed class PortfolioStatePositionTrackerTests
+{
+    // ─── Construction / argument validation ──────────────────────────────────
+
+    [Fact]
+    public void Constructor_WithNullPortfolio_ThrowsArgumentNullException()
+    {
+        var act = () => new PortfolioStatePositionTracker(null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("portfolio");
+    }
+
+    [Fact]
+    public void GetPosition_WithNullOrWhitespaceSymbol_Throws()
+    {
+        var tracker = new PortfolioStatePositionTracker(new PaperTradingPortfolio(100_000m));
+
+        var actNull = () => tracker.GetPosition(null!);
+        var actBlank = () => tracker.GetPosition("   ");
+
+        actNull.Should().Throw<ArgumentException>();
+        actBlank.Should().Throw<ArgumentException>();
+    }
+
+    // ─── Projection of held positions ────────────────────────────────────────
+
+    [Fact]
+    public void GetPosition_HeldSymbol_ProjectsQuantityAndCostBasis()
+    {
+        var portfolio = new PaperTradingPortfolio(100_000m);
+        portfolio.ApplyFill(BuildFill("AAPL", OrderSide.Buy, qty: 40m, price: 150m));
+        var tracker = new PortfolioStatePositionTracker(portfolio);
+
+        var position = tracker.GetPosition("AAPL");
+
+        position.Symbol.Should().Be("AAPL");
+        position.Quantity.Should().Be(40m);
+        position.AverageCostBasis.Should().Be(150m);
+    }
+
+    [Fact]
+    public void GetPosition_HeldSymbol_ReconstructsMarkConsistentWithUnrealizedPnl()
+    {
+        var portfolio = new PaperTradingPortfolio(100_000m);
+        portfolio.ApplyFill(BuildFill("AAPL", OrderSide.Buy, qty: 100m, price: 150m));
+        // Mark the position up so there is a non-zero unrealised P&L to reconstruct.
+        portfolio.UpdateMarketPrice("AAPL", 170m);
+        var tracker = new PortfolioStatePositionTracker(portfolio);
+
+        var position = tracker.GetPosition("AAPL");
+
+        // The derived market price must reproduce the source portfolio's unrealised P&L exactly,
+        // i.e. UnrealizedPnl = (MarketPrice - AverageCostBasis) * Quantity.
+        position.MarketPrice.Should().Be(170m);
+        position.UnrealizedPnl.Should().Be(portfolio.Positions["AAPL"].UnrealizedPnl);
+        position.UnrealizedPnl.Should().Be(2_000m); // (170 - 150) * 100
+    }
+
+    [Fact]
+    public void GetPosition_UnknownSymbol_ReturnsFlatPosition()
+    {
+        var tracker = new PortfolioStatePositionTracker(new PaperTradingPortfolio(100_000m));
+
+        var position = tracker.GetPosition("NVDA");
+
+        position.Symbol.Should().Be("NVDA");
+        position.Quantity.Should().Be(0m);
+        position.MarketValue.Should().Be(0m);
+    }
+
+    [Fact]
+    public void GetAllPositions_ReturnsEveryHeldSymbol()
+    {
+        var portfolio = new PaperTradingPortfolio(500_000m);
+        portfolio.ApplyFill(BuildFill("AAPL", OrderSide.Buy, qty: 10m, price: 150m));
+        portfolio.ApplyFill(BuildFill("MSFT", OrderSide.Buy, qty: 5m, price: 300m));
+        var tracker = new PortfolioStatePositionTracker(portfolio);
+
+        var positions = tracker.GetAllPositions();
+
+        positions.Should().ContainKeys("AAPL", "MSFT");
+        positions["AAPL"].Quantity.Should().Be(10m);
+        positions["MSFT"].Quantity.Should().Be(5m);
+    }
+
+    // ─── Portfolio-level projections ─────────────────────────────────────────
+
+    [Fact]
+    public void PortfolioAggregates_DelegateToSourcePortfolio()
+    {
+        var portfolio = new PaperTradingPortfolio(100_000m);
+        portfolio.ApplyFill(BuildFill("AAPL", OrderSide.Buy, qty: 100m, price: 150m));
+        portfolio.UpdateMarketPrice("AAPL", 140m); // 10-per-share unrealised loss on 100 shares
+        var tracker = new PortfolioStatePositionTracker(portfolio);
+
+        tracker.GetCash().Should().Be(portfolio.Cash);
+        tracker.GetPortfolioValue().Should().Be(portfolio.PortfolioValue);
+        tracker.GetUnrealizedPnl().Should().Be(portfolio.UnrealisedPnl);
+        tracker.GetRealizedPnl().Should().Be(portfolio.RealisedPnl);
+        tracker.GetUnrealizedPnl().Should().Be(-1_000m);
+    }
+
+    // ─── Rule integration — no test doubles ──────────────────────────────────
+
+    [Fact]
+    public async Task PositionLimitRule_WithRealTracker_ApprovesWithinCapAndRejectsBeyond()
+    {
+        var portfolio = new PaperTradingPortfolio(1_000_000m);
+        portfolio.ApplyFill(BuildFill("AAPL", OrderSide.Buy, qty: 80m, price: 150m));
+        var tracker = new PortfolioStatePositionTracker(portfolio);
+        var rule = new PositionLimitRule(tracker, maxPositionSize: 100m, NullLogger<PositionLimitRule>.Instance);
+
+        // Current 80 long, buy 15 → projected 95 ≤ 100 → approve.
+        var approved = await rule.EvaluateAsync(BuildOrder("AAPL", OrderSide.Buy, 15m));
+        // Current 80 long, buy 40 → projected 120 > 100 → reject.
+        var rejected = await rule.EvaluateAsync(BuildOrder("AAPL", OrderSide.Buy, 40m));
+
+        approved.IsApproved.Should().BeTrue();
+        rejected.IsApproved.Should().BeFalse();
+        rejected.RejectReason.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task DrawdownCircuitBreaker_WithRealTracker_TripsWhenPortfolioValueFalls()
+    {
+        var portfolio = new PaperTradingPortfolio(100_000m);
+        portfolio.ApplyFill(BuildFill("AAPL", OrderSide.Buy, qty: 100m, price: 150m));
+        // Mark down to 50 → portfolio value = 85_000 cash + 5_000 mark = 90_000 → 10% drawdown.
+        portfolio.UpdateMarketPrice("AAPL", 50m);
+        var tracker = new PortfolioStatePositionTracker(portfolio);
+
+        var tightBreaker = new DrawdownCircuitBreaker(
+            tracker, initialCapital: 100_000m, maxDrawdownPercent: 5m, NullLogger<DrawdownCircuitBreaker>.Instance);
+        var looseBreaker = new DrawdownCircuitBreaker(
+            tracker, initialCapital: 100_000m, maxDrawdownPercent: 20m, NullLogger<DrawdownCircuitBreaker>.Instance);
+
+        var tripped = await tightBreaker.EvaluateAsync(BuildOrder("MSFT", OrderSide.Buy, 1m));
+        var allowed = await looseBreaker.EvaluateAsync(BuildOrder("MSFT", OrderSide.Buy, 1m));
+
+        tripped.IsApproved.Should().BeFalse("a 10% drawdown breaches the 5% kill-switch");
+        allowed.IsApproved.Should().BeTrue("a 10% drawdown is within the 20% threshold");
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private static OrderRequest BuildOrder(string symbol, OrderSide side, decimal quantity) => new()
+    {
+        Symbol = symbol,
+        Side = side,
+        Type = OrderType.Market,
+        Quantity = quantity,
+    };
+
+    private static ExecutionReport BuildFill(string symbol, OrderSide side, decimal qty, decimal price) => new()
+    {
+        OrderId = Guid.NewGuid().ToString("N"),
+        Symbol = symbol,
+        Side = side,
+        ReportType = ExecutionReportType.Fill,
+        FilledQuantity = qty,
+        FillPrice = price,
+        Commission = 0m,
+        Timestamp = DateTimeOffset.UtcNow,
+        OrderStatus = Meridian.Execution.Sdk.OrderStatus.Filled,
+    };
+}


### PR DESCRIPTION
## Summary

Two live-trading safety gaps in the execution layer are closed with the safest, behavior-preserving changes.

**1. Production `IPositionTracker`.** `IPositionTracker` had no production implementation, so the two most safety-critical risk rules — `PositionLimitRule` (per-symbol caps) and `DrawdownCircuitBreaker` (drawdown kill-switch) — could only run against Moq test doubles and could not function in a real deployment.
- Added `PortfolioStatePositionTracker` (`src/Meridian.Execution/Services/`): a thin, read-only projection over the existing `IPortfolioState` (the single source of truth for positions/cash/P&L), so no position accounting is duplicated.
- Registered `IPositionTracker` in the `UiServer` composition root over the already-registered `IPortfolioState`.

**2. Fold live `IOrderGateway` submission behind the OMS.** `BrokerageGatewayAdapter` (the live `IOrderGateway`) exposed a public `SubmitAsync` that reached the broker without the `OrderManagementSystem` six-stage gate stack (placement gate, live-order readiness, operator-control circuit breaker, security-master gate, risk validator). Whether an order was gated depended on which interface a caller resolved (`IExecutionGateway` vs `IOrderGateway`).
- Made `BrokerageGatewayAdapter` `internal` (an implementation detail; the test assembly already has `InternalsVisibleTo`).
- The live `IOrderGateway` resolved from DI is now `OmsGovernedBrokerageOrderGateway`, a read-only view that delegates broker metadata and the execution-report stream (so `/health`, `/capabilities`, and blotter surfaces keep working) but blocks direct `SubmitAsync`/`CancelAsync`, directing callers to `IOrderManager` (the OMS gate stack).
- The paper `IOrderGateway` is unchanged — paper sessions have no live broker and no gate stack to bypass.

> Note on the reported merge-conflict markers: they were already resolved on this branch. `HEAD` matches `origin/main` and there are no `<<<<<<<`/`=======`/`>>>>>>>` markers anywhere in `src/`; the 10 named ETL files are valid C#. No changes were needed for that part.

## Reason

Addresses an execution-layer safety audit: (a) the two most safety-critical risk rules were unwireable in production, and (b) a live order could bypass the entire risk/compliance gate stack via the `IOrderGateway` seam. Order placement already routes through the OMS everywhere in production (HTTP endpoints, reconciliation), so this makes that ownership structural rather than conventional.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — the .NET SDK is not available in this remote environment; validation is delegated to GitHub Actions `quality-gate`.
- [x] Relevant unit tests were added or updated — `PortfolioStatePositionTrackerTests` (projection + no-Moq integration of `PositionLimitRule` and `DrawdownCircuitBreaker` against a real `PaperTradingPortfolio`); `OmsGovernedBrokerageOrderGatewayTests` (submit/cancel blocked and never reach the broker; read-only metadata still delegated).
- [ ] Relevant integration tests were added or updated — existing `ExecutionGovernanceEndpointsTests` (which submit via the OMS HTTP endpoint) continue to cover the live path unchanged.
- [ ] GitHub Actions `quality-gate` passed — pending on this PR.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxZKGnmv4Rt7GAhZxSNiin

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxZKGnmv4Rt7GAhZxSNiin)_