### PR TITLE
fix(infrastructure): resolve CS0103 in WebSocket rate-limit snapshot

### DIFF
--- a/src/Meridian.Infrastructure/Adapters/Core/WebSocketProviderBase.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/WebSocketProviderBase.cs
@@ -122,8 +122,8 @@ public abstract class WebSocketProviderBase :
             RequestsInWindow: 0,
             // Capabilities expose these as nullable; this "diagnostics unavailable" snapshot marks
             // StateAvailable: false, so an unset limit collapses to a neutral zero placeholder.
-            MaxRequestsPerWindow: capabilities.MaxRequestsPerWindow ?? 0,
-            Window: capabilities.RateLimitWindow ?? TimeSpan.Zero,
+            MaxRequestsPerWindow: ProviderCapabilities.MaxRequestsPerWindow ?? 0,
+            Window: ProviderCapabilities.RateLimitWindow ?? TimeSpan.Zero,
             IsRateLimited: false,
             ResetAt: null,
             UsageRatio: 0,


### PR DESCRIPTION
## Summary

`WebSocketProviderBase.GetRateLimitDiagnosticsSnapshot()` now references the abstract `ProviderCapabilities` property directly instead of an undefined `capabilities` identifier. The "diagnostics unavailable" snapshot behavior is unchanged: nullable capability values collapse to a neutral zero placeholder (`MaxRequestsPerWindow: … ?? 0`, `Window: … ?? TimeSpan.Zero`) while `StateAvailable: false` still marks the snapshot as non-live.

## Reason

The desktop (WPF) publish job failed at build time with two compiler errors that halted the `Meridian.Infrastructure` compile — and therefore the entire publish:

```
src/Meridian.Infrastructure/Adapters/Core/WebSocketProviderBase.cs(125,35): error CS0103: The name 'capabilities' does not exist in the current context
src/Meridian.Infrastructure/Adapters/Core/WebSocketProviderBase.cs(126,21): error CS0103: The name 'capabilities' does not exist in the current context
```

An earlier edit removed the `var capabilities = ProviderCapabilities;` local, while a later change reintroduced nullable-coalesced references to `capabilities` without restoring that declaration — leaving two references to an undefined identifier. The fix points both references at the class's abstract `ProviderCapabilities` property (`ProviderCapabilities` type), which exposes `MaxRequestsPerWindow` (`int?`) and `RateLimitWindow` (`TimeSpan?`); the coalescing operators narrow those to the record's non-nullable `int` / `TimeSpan` parameters.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [ ] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

> No .NET SDK is available in this environment, so the fix could not be built locally. It is a two-line identifier correction verified against the `ProviderCapabilities` and `ProviderRateLimitDiagnosticSnapshot` type definitions; CI is the authoritative gate.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWUjvrUjtrEm5NzfvuqrXH)_