### PR TITLE
Replace hardcoded XAML hex colors with theme brush tokens

### DIFF
--- a/src/Meridian.Wpf/MainWindow.xaml
+++ b/src/Meridian.Wpf/MainWindow.xaml
@@ -310,8 +310,8 @@
               Visibility="Collapsed"
               IsHitTestVisible="False"
               Panel.ZIndex="100">
-            <Rectangle Fill="#AA1A3A5C" />
-            <Border BorderBrush="#4499CC" BorderThickness="3" Margin="24" CornerRadius="8">
+            <Rectangle Fill="{StaticResource DropOverlayFillBrush}" />
+            <Border BorderBrush="{StaticResource DropOverlayBorderBrush}" BorderThickness="3" Margin="24" CornerRadius="8">
                 <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
                     <TextBlock x:Name="DropOverlayIcon"
                                Text="&#xE896;"
@@ -324,7 +324,7 @@
                                HorizontalAlignment="Center" Margin="0,12,0,4" />
                     <TextBlock x:Name="DropOverlaySubtitle"
                                Text="CSV · JSON · JSONL · Parquet"
-                               FontSize="14" Foreground="#AACCFF"
+                               FontSize="14" Foreground="{StaticResource DropOverlaySubtitleBrush}"
                                HorizontalAlignment="Center" />
                 </StackPanel>
             </Border>

--- a/src/Meridian.Wpf/Styles/Animations.xaml
+++ b/src/Meridian.Wpf/Styles/Animations.xaml
@@ -286,8 +286,8 @@
     <Storyboard x:Key="FlashHighlightStoryboard">
         <ColorAnimationUsingKeyFrames
             Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Color)">
-            <LinearColorKeyFrame KeyTime="0:0:0" Value="#333fb950" />
-            <LinearColorKeyFrame KeyTime="0:0:0.3" Value="#333fb950" />
+            <LinearColorKeyFrame KeyTime="0:0:0" Value="{StaticResource FlashHighlightColor}" />
+            <LinearColorKeyFrame KeyTime="0:0:0.3" Value="{StaticResource FlashHighlightColor}" />
             <SplineColorKeyFrame KeyTime="0:0:0.8" Value="Transparent" KeySpline="0.4,0,0.2,1" />
         </ColorAnimationUsingKeyFrames>
     </Storyboard>

--- a/src/Meridian.Wpf/Styles/AppStyles.xaml
+++ b/src/Meridian.Wpf/Styles/AppStyles.xaml
@@ -27,7 +27,7 @@
         <Setter Property="Padding" Value="20" />
         <Setter Property="Effect">
             <Setter.Value>
-                <DropShadowEffect Color="#000000" BlurRadius="18" ShadowDepth="2" Direction="270" Opacity="0.30" />
+                <DropShadowEffect Color="{StaticResource ShadowColor}" BlurRadius="18" ShadowDepth="2" Direction="270" Opacity="0.30" />
             </Setter.Value>
         </Setter>
     </Style>
@@ -214,19 +214,19 @@
 
     <Style x:Key="TagIBStyle" TargetType="Border" BasedOn="{StaticResource TagStyle}">
         <Setter Property="Background" Value="{StaticResource ConsoleAccentBlueAlpha10Brush}" />
-        <Setter Property="BorderBrush" Value="#4D42C6D6" />
+        <Setter Property="BorderBrush" Value="{StaticResource TagIbBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
     </Style>
 
     <Style x:Key="TagAlpacaStyle" TargetType="Border" BasedOn="{StaticResource TagStyle}">
         <Setter Property="Background" Value="{StaticResource ConsoleAccentOrangeAlpha10Brush}" />
-        <Setter Property="BorderBrush" Value="#4DE4A84B" />
+        <Setter Property="BorderBrush" Value="{StaticResource TagAlpacaBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
     </Style>
 
     <Style x:Key="TagPolygonStyle" TargetType="Border" BasedOn="{StaticResource TagStyle}">
         <Setter Property="Background" Value="{StaticResource ConsoleAccentPurpleAlpha10Brush}" />
-        <Setter Property="BorderBrush" Value="#4D7AB3FF" />
+        <Setter Property="BorderBrush" Value="{StaticResource TagPolygonBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
     </Style>
 
@@ -517,15 +517,15 @@
     <!-- ========================================== -->
 
     <Style x:Key="DarkTooltipStyle" TargetType="ToolTip">
-        <Setter Property="Background" Value="#0F1B28" />
-        <Setter Property="Foreground" Value="#DCE8F4" />
-        <Setter Property="BorderBrush" Value="#1A2F42" />
+        <Setter Property="Background" Value="{StaticResource DarkTooltipSurfaceBrush}" />
+        <Setter Property="Foreground" Value="{StaticResource DarkTooltipTextBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource DarkTooltipBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Padding" Value="10,7" />
         <Setter Property="FontSize" Value="12" />
         <Setter Property="Effect">
             <Setter.Value>
-                <DropShadowEffect Color="#000000" BlurRadius="14" ShadowDepth="3" Direction="270" Opacity="0.32" />
+                <DropShadowEffect Color="{StaticResource ShadowColor}" BlurRadius="14" ShadowDepth="3" Direction="270" Opacity="0.32" />
             </Setter.Value>
         </Setter>
         <Setter Property="Template">
@@ -549,7 +549,7 @@
     <!-- ========================================== -->
 
     <Style x:Key="LoadingOverlayStyle" TargetType="Grid">
-        <Setter Property="Background" Value="#80000000" />
+        <Setter Property="Background" Value="{StaticResource ModalScrimBrush}" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
     </Style>

--- a/src/Meridian.Wpf/Styles/BrandResources.xaml
+++ b/src/Meridian.Wpf/Styles/BrandResources.xaml
@@ -2,21 +2,32 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
+    <!-- Brand palette tokens: a rebrand changes these values in one place. -->
+    <Color x:Key="MeridianBrandGradientStartColor">#1A6BB5</Color>
+    <Color x:Key="MeridianBrandGradientMidColor">#0EA5E9</Color>
+    <Color x:Key="MeridianBrandGradientEndColor">#16A34A</Color>
+    <Color x:Key="MeridianBrandBeamStartColor">#60A5FA</Color>
+    <Color x:Key="MeridianBrandBeamMidColor">#67E8F9</Color>
+    <Color x:Key="MeridianBrandBeamEndColor">#86EFAC</Color>
+    <Color x:Key="MeridianBrandStarColor">#84F3B6</Color>
+    <Color x:Key="MeridianBrandHaloColor">#355B81</Color>
+    <Color x:Key="MeridianBrandHorizonColor">#3F78C2</Color>
+
     <LinearGradientBrush x:Key="MeridianBrandGradientBrush" StartPoint="0,1" EndPoint="1,0">
-        <GradientStop Color="#1A6BB5" Offset="0" />
-        <GradientStop Color="#0EA5E9" Offset="0.55" />
-        <GradientStop Color="#16A34A" Offset="1" />
+        <GradientStop Color="{StaticResource MeridianBrandGradientStartColor}" Offset="0" />
+        <GradientStop Color="{StaticResource MeridianBrandGradientMidColor}" Offset="0.55" />
+        <GradientStop Color="{StaticResource MeridianBrandGradientEndColor}" Offset="1" />
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="MeridianBrandBeamBrush" StartPoint="0.5,0" EndPoint="0.5,1">
-        <GradientStop Color="#60A5FA" Offset="0" />
-        <GradientStop Color="#67E8F9" Offset="0.55" />
-        <GradientStop Color="#86EFAC" Offset="1" />
+        <GradientStop Color="{StaticResource MeridianBrandBeamStartColor}" Offset="0" />
+        <GradientStop Color="{StaticResource MeridianBrandBeamMidColor}" Offset="0.55" />
+        <GradientStop Color="{StaticResource MeridianBrandBeamEndColor}" Offset="1" />
     </LinearGradientBrush>
 
-    <SolidColorBrush x:Key="MeridianBrandStarBrush" Color="#84F3B6" />
-    <SolidColorBrush x:Key="MeridianBrandHaloBrush" Color="#355B81" />
-    <SolidColorBrush x:Key="MeridianBrandHorizonBrush" Color="#3F78C2" />
+    <SolidColorBrush x:Key="MeridianBrandStarBrush" Color="{StaticResource MeridianBrandStarColor}" />
+    <SolidColorBrush x:Key="MeridianBrandHaloBrush" Color="{StaticResource MeridianBrandHaloColor}" />
+    <SolidColorBrush x:Key="MeridianBrandHorizonBrush" Color="{StaticResource MeridianBrandHorizonColor}" />
 
     <Geometry x:Key="MeridianBrandChartGeometry">M 6.5,17 L 10.1,11.4 L 12.9,14.2 L 17.9,8.1</Geometry>
     <Geometry x:Key="MeridianBrandMeridianGeometry">M 12,4.3 L 12,18.9</Geometry>

--- a/src/Meridian.Wpf/Styles/ThemeControls.xaml
+++ b/src/Meridian.Wpf/Styles/ThemeControls.xaml
@@ -138,7 +138,7 @@
         <Setter Property="Template" Value="{StaticResource PrimaryButtonTemplate}" />
         <Setter Property="BorderBrush" Value="{StaticResource ConsoleAccentBlueBrush}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="Foreground" Value="#FFFFFF" />
+        <Setter Property="Foreground" Value="{StaticResource OnAccentTextBrush}" />
         <Setter Property="Padding" Value="16,9" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="FontWeight" Value="SemiBold" />

--- a/src/Meridian.Wpf/Styles/ThemeSurfaces.xaml
+++ b/src/Meridian.Wpf/Styles/ThemeSurfaces.xaml
@@ -12,7 +12,7 @@
         <Setter Property="Padding" Value="20" />
         <Setter Property="Effect">
             <Setter.Value>
-                <DropShadowEffect Color="#000000" BlurRadius="1" ShadowDepth="0" Direction="270" Opacity="0.08" />
+                <DropShadowEffect Color="{StaticResource ShadowColor}" BlurRadius="1" ShadowDepth="0" Direction="270" Opacity="0.08" />
             </Setter.Value>
         </Setter>
     </Style>
@@ -24,7 +24,7 @@
         <Setter Property="Padding" Value="16" />
         <Setter Property="Effect">
             <Setter.Value>
-                <DropShadowEffect Color="#000000"
+                <DropShadowEffect Color="{StaticResource ShadowColor}"
                                   BlurRadius="1"
                                   ShadowDepth="0"
                                   Direction="270"
@@ -158,7 +158,7 @@
         <Setter Property="Padding" Value="20" />
         <Setter Property="Effect">
             <Setter.Value>
-                <DropShadowEffect Color="#000000" BlurRadius="2" ShadowDepth="0" Direction="270" Opacity="0.10" />
+                <DropShadowEffect Color="{StaticResource ShadowColor}" BlurRadius="2" ShadowDepth="0" Direction="270" Opacity="0.10" />
             </Setter.Value>
         </Setter>
     </Style>

--- a/src/Meridian.Wpf/Styles/ThemeTokens.xaml
+++ b/src/Meridian.Wpf/Styles/ThemeTokens.xaml
@@ -314,4 +314,163 @@
     <SolidColorBrush x:Key="BadgeDangerForegroundBrush" Color="{StaticResource ConsoleAccentRedDim}" />
     <SolidColorBrush x:Key="DangerColorBrush"           Color="{StaticResource ConsoleAccentRedDim}" />
 
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <!-- Tokens hoisted from inline page/control markup.                      -->
+    <!-- Exact legacy values are preserved; these centralize colors that      -->
+    <!-- were previously hardcoded in View XAML so future theming, dark-mode,  -->
+    <!-- and rebrand work has a single source of truth.                       -->
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+
+    <!-- Bright status/metric signal palette (health, diagnostics, analytics) -->
+    <Color x:Key="SignalPositiveColor">#48BB78</Color>
+    <Color x:Key="SignalPositiveVividColor">#3AD16A</Color>
+    <Color x:Key="SignalWarningColor">#ED8936</Color>
+    <Color x:Key="SignalNegativeColor">#F56565</Color>
+    <Color x:Key="SignalNegativeVividColor">#F85149</Color>
+    <SolidColorBrush x:Key="SignalPositiveBrush"      Color="{StaticResource SignalPositiveColor}" />
+    <SolidColorBrush x:Key="SignalPositiveVividBrush" Color="{StaticResource SignalPositiveVividColor}" />
+    <SolidColorBrush x:Key="SignalWarningBrush"       Color="{StaticResource SignalWarningColor}" />
+    <SolidColorBrush x:Key="SignalNegativeBrush"      Color="{StaticResource SignalNegativeColor}" />
+    <SolidColorBrush x:Key="SignalNegativeVividBrush" Color="{StaticResource SignalNegativeVividColor}" />
+
+    <!-- Notification severity badges -->
+    <Color x:Key="SeverityCriticalColor">#F44336</Color>
+    <Color x:Key="SeverityErrorColor">#FF5722</Color>
+    <Color x:Key="SeverityWarningColor">#FFC107</Color>
+    <Color x:Key="NotificationDangerSurfaceColor">#2D1B1B</Color>
+    <SolidColorBrush x:Key="SeverityCriticalBrush" Color="{StaticResource SeverityCriticalColor}" />
+    <SolidColorBrush x:Key="SeverityErrorBrush"    Color="{StaticResource SeverityErrorColor}" />
+    <SolidColorBrush x:Key="SeverityWarningBrush"  Color="{StaticResource SeverityWarningColor}" />
+    <SolidColorBrush x:Key="NotificationDangerSurfaceBrush" Color="{StaticResource NotificationDangerSurfaceColor}" />
+
+    <!-- Dark neutral ink for text on light/amber badges -->
+    <Color x:Key="BadgeDarkTextColor">#333333</Color>
+    <SolidColorBrush x:Key="BadgeDarkTextBrush" Color="{StaticResource BadgeDarkTextColor}" />
+
+    <!-- On-accent text (white text over solid accent fills) -->
+    <Color x:Key="OnAccentTextColor">#FFFFFF</Color>
+    <SolidColorBrush x:Key="OnAccentTextBrush" Color="{StaticResource OnAccentTextColor}" />
+
+    <!-- Muted text on dark chrome surfaces (float windows, metric tiles) -->
+    <Color x:Key="DarkSurfaceMutedTextColor">#888888</Color>
+    <SolidColorBrush x:Key="DarkSurfaceMutedTextBrush" Color="{StaticResource DarkSurfaceMutedTextColor}" />
+
+    <!-- Top bar / masthead text and accents (over the near-black brand bar) -->
+    <Color x:Key="TopBarTextSecondaryColor">#9CA3AF</Color>
+    <Color x:Key="TopBarTextMutedColor">#6B7280</Color>
+    <Color x:Key="TopBarAccentBlueColor">#60A5FA</Color>
+    <Color x:Key="TopBarAlertAmberColor">#F59E0B</Color>
+    <SolidColorBrush x:Key="TopBarTextSecondaryBrush" Color="{StaticResource TopBarTextSecondaryColor}" />
+    <SolidColorBrush x:Key="TopBarTextMutedBrush"     Color="{StaticResource TopBarTextMutedColor}" />
+    <SolidColorBrush x:Key="TopBarAccentBlueBrush"    Color="{StaticResource TopBarAccentBlueColor}" />
+    <SolidColorBrush x:Key="TopBarAlertAmberBrush"    Color="{StaticResource TopBarAlertAmberColor}" />
+
+    <!-- Startup window text (over the dark brand panel) -->
+    <Color x:Key="StartupSubtitleTextColor">#C9D1D9</Color>
+    <Color x:Key="StartupBodyTextColor">#AAB4BF</Color>
+    <Color x:Key="StartupFootnoteTextColor">#7E8792</Color>
+    <SolidColorBrush x:Key="StartupSubtitleTextBrush" Color="{StaticResource StartupSubtitleTextColor}" />
+    <SolidColorBrush x:Key="StartupBodyTextBrush"     Color="{StaticResource StartupBodyTextColor}" />
+    <SolidColorBrush x:Key="StartupFootnoteTextBrush" Color="{StaticResource StartupFootnoteTextColor}" />
+
+    <!-- Floating quote / page windows (dark detached surfaces) -->
+    <Color x:Key="FloatWindowBackgroundColor">#0A0A12</Color>
+    <Color x:Key="FloatWindowChromeColor">#1A2A4A</Color>
+    <Color x:Key="QuoteBidColor">#44CC44</Color>
+    <Color x:Key="QuoteAskColor">#CC4444</Color>
+    <SolidColorBrush x:Key="FloatWindowBackgroundBrush" Color="{StaticResource FloatWindowBackgroundColor}" />
+    <SolidColorBrush x:Key="FloatWindowChromeBrush"     Color="{StaticResource FloatWindowChromeColor}" />
+    <SolidColorBrush x:Key="QuoteBidBrush" Color="{StaticResource QuoteBidColor}" />
+    <SolidColorBrush x:Key="QuoteAskBrush" Color="{StaticResource QuoteAskColor}" />
+
+    <!-- Ticker strip (transparent overlay bar; alpha variants of the float navy) -->
+    <Color x:Key="TickerStripBackgroundColor">#EE0A0A0F</Color>
+    <Color x:Key="TickerStripBorderColor">#FF1A2A4A</Color>
+    <Color x:Key="TickerItemBackgroundColor">#0A0A1A</Color>
+    <Color x:Key="TickerFlashOverlayColor">#1AFFFFFF</Color>
+    <Color x:Key="TickerUpColor">#44AA44</Color>
+    <Color x:Key="TickerDownColor">#AA4444</Color>
+    <Color x:Key="TickerMutedGlyphColor">#44667799</Color>
+    <Color x:Key="TickerHairlineColor">#661A2A4A</Color>
+    <SolidColorBrush x:Key="TickerStripBackgroundBrush" Color="{StaticResource TickerStripBackgroundColor}" />
+    <SolidColorBrush x:Key="TickerStripBorderBrush"     Color="{StaticResource TickerStripBorderColor}" />
+    <SolidColorBrush x:Key="TickerItemBackgroundBrush"  Color="{StaticResource TickerItemBackgroundColor}" />
+    <SolidColorBrush x:Key="TickerFlashOverlayBrush"    Color="{StaticResource TickerFlashOverlayColor}" />
+    <SolidColorBrush x:Key="TickerUpBrush"    Color="{StaticResource TickerUpColor}" />
+    <SolidColorBrush x:Key="TickerDownBrush"  Color="{StaticResource TickerDownColor}" />
+    <SolidColorBrush x:Key="TickerMutedGlyphBrush" Color="{StaticResource TickerMutedGlyphColor}" />
+    <SolidColorBrush x:Key="TickerHairlineBrush"   Color="{StaticResource TickerHairlineColor}" />
+
+    <!-- Latency metric tiles and co-location badge (diagnostics) -->
+    <Color x:Key="MetricTileSurfaceColor">#1A3A5C</Color>
+    <Color x:Key="CoLocationBadgeSurfaceColor">#1A5C3A</Color>
+    <SolidColorBrush x:Key="MetricTileSurfaceBrush"      Color="{StaticResource MetricTileSurfaceColor}" />
+    <SolidColorBrush x:Key="CoLocationBadgeSurfaceBrush" Color="{StaticResource CoLocationBadgeSurfaceColor}" />
+
+    <!-- File-drop overlays (window drag-import and dock/split drop targets) -->
+    <Color x:Key="DropOverlayFillColor">#AA1A3A5C</Color>
+    <Color x:Key="DropOverlayBorderColor">#4499CC</Color>
+    <Color x:Key="DropOverlaySubtitleColor">#AACCFF</Color>
+    <Color x:Key="DropTargetFillColor">#22007ACC</Color>
+    <Color x:Key="DropTargetBorderColor">#66007ACC</Color>
+    <SolidColorBrush x:Key="DropOverlayFillBrush"     Color="{StaticResource DropOverlayFillColor}" />
+    <SolidColorBrush x:Key="DropOverlayBorderBrush"   Color="{StaticResource DropOverlayBorderColor}" />
+    <SolidColorBrush x:Key="DropOverlaySubtitleBrush" Color="{StaticResource DropOverlaySubtitleColor}" />
+    <SolidColorBrush x:Key="DropTargetFillBrush"      Color="{StaticResource DropTargetFillColor}" />
+    <SolidColorBrush x:Key="DropTargetBorderBrush"    Color="{StaticResource DropTargetBorderColor}" />
+
+    <!-- Modal scrim (busy/overlay dim layer) -->
+    <Color x:Key="ModalScrimColor">#80000000</Color>
+    <SolidColorBrush x:Key="ModalScrimBrush" Color="{StaticResource ModalScrimColor}" />
+
+    <!-- Strategy workspace hero card (blue-tinted dark) -->
+    <Color x:Key="StrategyHeroSurfaceColor">#12253A</Color>
+    <Color x:Key="StrategyHeroBorderColor">#22486B</Color>
+    <Color x:Key="StrategyHeroLabelColor">#7EA3C5</Color>
+    <Color x:Key="StrategyHeroMetaColor">#A8BED7</Color>
+    <SolidColorBrush x:Key="StrategyHeroSurfaceBrush" Color="{StaticResource StrategyHeroSurfaceColor}" />
+    <SolidColorBrush x:Key="StrategyHeroBorderBrush"  Color="{StaticResource StrategyHeroBorderColor}" />
+    <SolidColorBrush x:Key="StrategyHeroLabelBrush"   Color="{StaticResource StrategyHeroLabelColor}" />
+    <SolidColorBrush x:Key="StrategyHeroMetaBrush"    Color="{StaticResource StrategyHeroMetaColor}" />
+
+    <!-- Accounting workspace hero card (gold-tinted dark) -->
+    <Color x:Key="AccountingHeroSurfaceColor">#2D200F</Color>
+    <Color x:Key="AccountingHeroBorderColor">#875A24</Color>
+    <Color x:Key="AccountingHeroLabelColor">#E1B980</Color>
+    <Color x:Key="AccountingHeroSummaryColor">#F2DEC0</Color>
+    <Color x:Key="AccountingHeroDetailColor">#D7C2A4</Color>
+    <SolidColorBrush x:Key="AccountingHeroSurfaceBrush" Color="{StaticResource AccountingHeroSurfaceColor}" />
+    <SolidColorBrush x:Key="AccountingHeroBorderBrush"  Color="{StaticResource AccountingHeroBorderColor}" />
+    <SolidColorBrush x:Key="AccountingHeroLabelBrush"   Color="{StaticResource AccountingHeroLabelColor}" />
+    <SolidColorBrush x:Key="AccountingHeroSummaryBrush" Color="{StaticResource AccountingHeroSummaryColor}" />
+    <SolidColorBrush x:Key="AccountingHeroDetailBrush"  Color="{StaticResource AccountingHeroDetailColor}" />
+
+    <!-- Assorted banners / tints -->
+    <Color x:Key="InfoBannerTintColor">#0D58A6FA</Color>
+    <Color x:Key="WarningTintSubtleColor">#1EFFCA28</Color>
+    <Color x:Key="RecoveryBannerBorderColor">#C0392B</Color>
+    <SolidColorBrush x:Key="InfoBannerTintBrush"       Color="{StaticResource InfoBannerTintColor}" />
+    <SolidColorBrush x:Key="WarningTintSubtleBrush"    Color="{StaticResource WarningTintSubtleColor}" />
+    <SolidColorBrush x:Key="RecoveryBannerBorderBrush" Color="{StaticResource RecoveryBannerBorderColor}" />
+
+    <!-- Provider tag borders (IB cyan / Alpaca amber / Polygon blue) -->
+    <Color x:Key="TagIbBorderColor">#4D42C6D6</Color>
+    <Color x:Key="TagAlpacaBorderColor">#4DE4A84B</Color>
+    <Color x:Key="TagPolygonBorderColor">#4D7AB3FF</Color>
+    <SolidColorBrush x:Key="TagIbBorderBrush"      Color="{StaticResource TagIbBorderColor}" />
+    <SolidColorBrush x:Key="TagAlpacaBorderBrush"  Color="{StaticResource TagAlpacaBorderColor}" />
+    <SolidColorBrush x:Key="TagPolygonBorderBrush" Color="{StaticResource TagPolygonBorderColor}" />
+
+    <!-- Dark tooltip surface -->
+    <Color x:Key="DarkTooltipSurfaceColor">#0F1B28</Color>
+    <Color x:Key="DarkTooltipTextColor">#DCE8F4</Color>
+    <Color x:Key="DarkTooltipBorderColor">#1A2F42</Color>
+    <SolidColorBrush x:Key="DarkTooltipSurfaceBrush" Color="{StaticResource DarkTooltipSurfaceColor}" />
+    <SolidColorBrush x:Key="DarkTooltipTextBrush"    Color="{StaticResource DarkTooltipTextColor}" />
+    <SolidColorBrush x:Key="DarkTooltipBorderBrush"  Color="{StaticResource DarkTooltipBorderColor}" />
+
+    <!-- Effect colors (consumed as Color, not Brush) -->
+    <Color x:Key="ShadowColor">#000000</Color>
+    <Color x:Key="FlashHighlightColor">#333FB950</Color>
+
 </ResourceDictionary>

--- a/src/Meridian.Wpf/Views/AccountingWorkspaceShellPage.xaml
+++ b/src/Meridian.Wpf/Views/AccountingWorkspaceShellPage.xaml
@@ -116,14 +116,14 @@
                         <Border Margin="0,18,0,0"
                                 Padding="14,12"
                                 CornerRadius="12"
-                                Background="#2D200F"
-                                BorderBrush="#875A24"
+                                Background="{StaticResource AccountingHeroSurfaceBrush}"
+                                BorderBrush="{StaticResource AccountingHeroBorderBrush}"
                                 BorderThickness="1">
                             <StackPanel>
                                 <TextBlock Text="Selected Lane"
                                            FontSize="11"
                                            FontWeight="SemiBold"
-                                           Foreground="#E1B980" />
+                                           Foreground="{StaticResource AccountingHeroLabelBrush}" />
                                 <TextBlock x:Name="AccountingHeroLaneText"
                                            Margin="0,6,0,0"
                                            FontSize="18"
@@ -133,13 +133,13 @@
                                 <TextBlock x:Name="AccountingHeroSummaryText"
                                            Margin="0,4,0,0"
                                            FontSize="12"
-                                           Foreground="#F2DEC0"
+                                           Foreground="{StaticResource AccountingHeroSummaryBrush}"
                                            TextWrapping="Wrap"
                                            Text="Fund operations posture is ready for review." />
                                 <TextBlock x:Name="AccountingHeroDetailText"
                                            Margin="0,8,0,0"
                                            FontSize="12"
-                                           Foreground="#D7C2A4"
+                                           Foreground="{StaticResource AccountingHeroDetailBrush}"
                                            TextWrapping="Wrap"
                                            Text="Keep the selected Accounting lane visible before moving into the queue wall." />
                             </StackPanel>

--- a/src/Meridian.Wpf/Views/AdvancedAnalyticsPage.xaml
+++ b/src/Meridian.Wpf/Views/AdvancedAnalyticsPage.xaml
@@ -88,7 +88,7 @@
                 <Border Grid.Column="2" Style="{StaticResource CardStyle}">
                     <StackPanel HorizontalAlignment="Center">
                         <TextBlock Text="{Binding CompletenessText}" FontSize="32" FontWeight="Bold"
-                                   Foreground="#48BB78" HorizontalAlignment="Center" />
+                                   Foreground="{StaticResource SignalPositiveBrush}" HorizontalAlignment="Center" />
                         <TextBlock Text="Completeness" Foreground="{StaticResource ConsoleTextMutedBrush}" HorizontalAlignment="Center" />
                     </StackPanel>
                 </Border>
@@ -96,7 +96,7 @@
                 <Border Grid.Column="4" Style="{StaticResource CardStyle}">
                     <StackPanel HorizontalAlignment="Center">
                         <TextBlock Text="{Binding TotalGapsText}" FontSize="32" FontWeight="Bold"
-                                   Foreground="#ED8936" HorizontalAlignment="Center" />
+                                   Foreground="{StaticResource SignalWarningBrush}" HorizontalAlignment="Center" />
                         <TextBlock Text="Data Gaps" Foreground="{StaticResource ConsoleTextMutedBrush}" HorizontalAlignment="Center" />
                     </StackPanel>
                 </Border>
@@ -104,7 +104,7 @@
                 <Border Grid.Column="6" Style="{StaticResource CardStyle}">
                     <StackPanel HorizontalAlignment="Center">
                         <TextBlock Text="--" FontSize="32" FontWeight="Bold"
-                                   Foreground="#F56565" HorizontalAlignment="Center" />
+                                   Foreground="{StaticResource SignalNegativeBrush}" HorizontalAlignment="Center" />
                         <TextBlock Text="Anomalies" Foreground="{StaticResource ConsoleTextMutedBrush}" HorizontalAlignment="Center" />
                     </StackPanel>
                 </Border>
@@ -367,8 +367,8 @@
                                         <TextBlock Text="{Binding Provider}" FontWeight="SemiBold" Foreground="{StaticResource ConsoleTextBrush}" VerticalAlignment="Center" />
                                         <ProgressBar Grid.Column="1" Value="{Binding LatencyPercent}" Maximum="100" Height="8" VerticalAlignment="Center" />
                                         <TextBlock Grid.Column="2" Text="{Binding P50Text}" Foreground="{StaticResource ConsoleTextBrush}" HorizontalAlignment="Right" VerticalAlignment="Center" />
-                                        <TextBlock Grid.Column="3" Text="{Binding P95Text}" Foreground="#ED8936" HorizontalAlignment="Right" VerticalAlignment="Center" />
-                                        <TextBlock Grid.Column="4" Text="{Binding P99Text}" Foreground="#F56565" HorizontalAlignment="Right" VerticalAlignment="Center" />
+                                        <TextBlock Grid.Column="3" Text="{Binding P95Text}" Foreground="{StaticResource SignalWarningBrush}" HorizontalAlignment="Right" VerticalAlignment="Center" />
+                                        <TextBlock Grid.Column="4" Text="{Binding P99Text}" Foreground="{StaticResource SignalNegativeBrush}" HorizontalAlignment="Right" VerticalAlignment="Center" />
                                     </Grid>
                                 </Border>
                             </DataTemplate>
@@ -479,7 +479,7 @@
                                         <ProgressBar Grid.Column="2" Value="{Binding OverallScore}" Maximum="100" Height="6" Margin="12,0" VerticalAlignment="Center" />
                                         <TextBlock Grid.Column="3" Text="{Binding CompletenessText}" Foreground="{StaticResource ConsoleTextBrush}" HorizontalAlignment="Right" VerticalAlignment="Center" />
                                         <TextBlock Grid.Column="4" Text="{Binding IntegrityText}" Foreground="{StaticResource ConsoleTextBrush}" HorizontalAlignment="Right" VerticalAlignment="Center" />
-                                        <TextBlock Grid.Column="5" Text="{Binding IssueCount}" Foreground="#F56565" HorizontalAlignment="Right" VerticalAlignment="Center" />
+                                        <TextBlock Grid.Column="5" Text="{Binding IssueCount}" Foreground="{StaticResource SignalNegativeBrush}" HorizontalAlignment="Right" VerticalAlignment="Center" />
                                     </Grid>
                                 </Border>
                             </DataTemplate>
@@ -511,7 +511,7 @@
                 <StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
                         <TextBlock Text="&#xE946;" FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                   Foreground="#ED8936" FontSize="20" VerticalAlignment="Center" />
+                                   Foreground="{StaticResource SignalWarningBrush}" FontSize="20" VerticalAlignment="Center" />
                         <TextBlock Text="Recommendations" Style="{StaticResource CardHeaderStyle}" Margin="8,0,0,0" VerticalAlignment="Center" />
                     </StackPanel>
 
@@ -531,7 +531,7 @@
                                         <ColumnDefinition Width="*" />
                                     </Grid.ColumnDefinitions>
                                     <TextBlock Text="&#xE946;" FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                               FontSize="14" Foreground="#ED8936" Margin="0,0,12,0" VerticalAlignment="Top" />
+                                               FontSize="14" Foreground="{StaticResource SignalWarningBrush}" Margin="0,0,12,0" VerticalAlignment="Top" />
                                     <TextBlock Grid.Column="1" Text="{Binding}" TextWrapping="Wrap" Foreground="{StaticResource ConsoleTextBrush}" />
                                 </Grid>
                             </DataTemplate>

--- a/src/Meridian.Wpf/Views/ArchiveHealthPage.xaml
+++ b/src/Meridian.Wpf/Views/ArchiveHealthPage.xaml
@@ -21,7 +21,7 @@
                                    FontSize="24" Foreground="{StaticResource InfoColorBrush}" VerticalAlignment="Center" HorizontalAlignment="Center" />
                     </Border>
                     <TextBlock Text="Archive Health" Style="{StaticResource PageTitleStyle}" Margin="12,0,0,0" VerticalAlignment="Center" />
-                    <Border x:Name="HealthStatusBadge" Background="#48BB78" CornerRadius="999" Padding="8,4" VerticalAlignment="Center" Margin="12,0,0,0">
+                    <Border x:Name="HealthStatusBadge" Background="{StaticResource SignalPositiveBrush}" CornerRadius="999" Padding="8,4" VerticalAlignment="Center" Margin="12,0,0,0">
                         <TextBlock x:Name="HealthStatusText" Text="Healthy" FontSize="12" Foreground="White" />
                     </Border>
                 </StackPanel>
@@ -107,17 +107,17 @@
                             </StackPanel>
 
                             <StackPanel Grid.Column="1">
-                                <TextBlock x:Name="VerifiedFilesText" Text="0" Style="{StaticResource MetricValueStyle}" Foreground="#48BB78" />
+                                <TextBlock x:Name="VerifiedFilesText" Text="0" Style="{StaticResource MetricValueStyle}" Foreground="{StaticResource SignalPositiveBrush}" />
                                 <TextBlock Text="Verified" Style="{StaticResource ConsoleTextMutedStyle}" />
                             </StackPanel>
 
                             <StackPanel Grid.Column="2">
-                                <TextBlock x:Name="PendingFilesText" Text="0" Style="{StaticResource MetricValueStyle}" Foreground="#ED8936" />
+                                <TextBlock x:Name="PendingFilesText" Text="0" Style="{StaticResource MetricValueStyle}" Foreground="{StaticResource SignalWarningBrush}" />
                                 <TextBlock Text="Pending" Style="{StaticResource ConsoleTextMutedStyle}" />
                             </StackPanel>
 
                             <StackPanel Grid.Column="3">
-                                <TextBlock x:Name="FailedFilesText" Text="0" Style="{StaticResource MetricValueStyle}" Foreground="#F56565" />
+                                <TextBlock x:Name="FailedFilesText" Text="0" Style="{StaticResource MetricValueStyle}" Foreground="{StaticResource SignalNegativeBrush}" />
                                 <TextBlock Text="Failed" Style="{StaticResource ConsoleTextMutedStyle}" />
                             </StackPanel>
                         </Grid>
@@ -213,9 +213,9 @@
                     <StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
                             <TextBlock Text="&#xE7BA;" FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                       FontSize="16" Foreground="#F56565" Margin="0,0,8,0" />
+                                       FontSize="16" Foreground="{StaticResource SignalNegativeBrush}" Margin="0,0,8,0" />
                             <TextBlock Text="Active Issues" Style="{StaticResource CardHeaderStyle}" />
-                            <Border x:Name="IssueCountBadge" Background="#F56565" CornerRadius="999" Padding="8,3"
+                            <Border x:Name="IssueCountBadge" Background="{StaticResource SignalNegativeBrush}" CornerRadius="999" Padding="8,3"
                                     Visibility="Collapsed" Margin="8,0,0,0">
                                 <TextBlock x:Name="IssueCountText" Text="0" FontSize="12" Foreground="White" />
                             </Border>
@@ -252,7 +252,7 @@
 
                         <TextBlock x:Name="NoIssuesText" Text="No issues detected. Archive is healthy!"
                                    Visibility="Visible" Style="{StaticResource ConsoleTextMutedStyle}"
-                                   Foreground="#48BB78" HorizontalAlignment="Center" />
+                                   Foreground="{StaticResource SignalPositiveBrush}" HorizontalAlignment="Center" />
                     </StackPanel>
                 </Border>
 

--- a/src/Meridian.Wpf/Views/BackfillPage.xaml
+++ b/src/Meridian.Wpf/Views/BackfillPage.xaml
@@ -908,7 +908,7 @@
                                   MaxHeight="200">
                             <ListView.ItemTemplate>
                                 <DataTemplate>
-                                    <Border Background="#1EFFCA28" CornerRadius="4" Padding="12,8" Margin="0,2">
+                                    <Border Background="{StaticResource WarningTintSubtleBrush}" CornerRadius="4" Padding="12,8" Margin="0,2">
                                         <Grid>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="*" />

--- a/src/Meridian.Wpf/Views/CredentialManagementPage.xaml
+++ b/src/Meridian.Wpf/Views/CredentialManagementPage.xaml
@@ -360,7 +360,7 @@
 
                     <!-- Test result banner -->
                     <Border Margin="0,0,0,12" Padding="14,10" CornerRadius="6"
-                            Background="#0D58A6FA"
+                            Background="{StaticResource InfoBannerTintBrush}"
                             Visibility="{Binding IsTestResultVisible, Converter={StaticResource BoolToVisibilityConverter}}">
                         <TextBlock Text="{Binding TestResultText}"
                                    FontSize="12" TextWrapping="Wrap"
@@ -434,7 +434,7 @@
             </ScrollViewer>
 
             <!-- Busy overlay -->
-            <Border Background="#80000000"
+            <Border Background="{StaticResource ModalScrimBrush}"
                     Visibility="{Binding IsBusy, Converter={StaticResource BoolToVisibilityConverter}}">
                 <TextBlock Text="Working…" Foreground="White" FontSize="14"
                            HorizontalAlignment="Center" VerticalAlignment="Center" />

--- a/src/Meridian.Wpf/Views/DiagnosticsPage.xaml
+++ b/src/Meridian.Wpf/Views/DiagnosticsPage.xaml
@@ -218,26 +218,26 @@
                     <!-- Latency Percentiles -->
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
                         <!-- p50 Card -->
-                        <Border Width="100" Height="80" CornerRadius="8" Background="#1A3A5C" Margin="0,0,12,0">
+                        <Border Width="100" Height="80" CornerRadius="8" Background="{StaticResource MetricTileSurfaceBrush}" Margin="0,0,12,0">
                             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <TextBlock Text="{Binding P50Ms}" FontSize="22" FontWeight="Bold" Foreground="White" HorizontalAlignment="Center" />
-                                <TextBlock Text="p50 ms" Foreground="#888" FontSize="11" HorizontalAlignment="Center" />
+                                <TextBlock Text="p50 ms" Foreground="{StaticResource DarkSurfaceMutedTextBrush}" FontSize="11" HorizontalAlignment="Center" />
                             </StackPanel>
                         </Border>
 
                         <!-- p95 Card -->
-                        <Border Width="100" Height="80" CornerRadius="8" Background="#1A3A5C" Margin="0,0,12,0">
+                        <Border Width="100" Height="80" CornerRadius="8" Background="{StaticResource MetricTileSurfaceBrush}" Margin="0,0,12,0">
                             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <TextBlock Text="{Binding P95Ms}" FontSize="22" FontWeight="Bold" Foreground="White" HorizontalAlignment="Center" />
-                                <TextBlock Text="p95 ms" Foreground="#888" FontSize="11" HorizontalAlignment="Center" />
+                                <TextBlock Text="p95 ms" Foreground="{StaticResource DarkSurfaceMutedTextBrush}" FontSize="11" HorizontalAlignment="Center" />
                             </StackPanel>
                         </Border>
 
                         <!-- p99 Card -->
-                        <Border Width="100" Height="80" CornerRadius="8" Background="#1A3A5C">
+                        <Border Width="100" Height="80" CornerRadius="8" Background="{StaticResource MetricTileSurfaceBrush}">
                             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <TextBlock Text="{Binding P99Ms}" FontSize="22" FontWeight="Bold" Foreground="White" HorizontalAlignment="Center" />
-                                <TextBlock Text="p99 ms" Foreground="#888" FontSize="11" HorizontalAlignment="Center" />
+                                <TextBlock Text="p99 ms" Foreground="{StaticResource DarkSurfaceMutedTextBrush}" FontSize="11" HorizontalAlignment="Center" />
                             </StackPanel>
                         </Border>
                     </StackPanel>
@@ -245,10 +245,10 @@
                     <!-- CoLocation Badge -->
                     <Border x:Name="CoLocationBadge" 
                             Visibility="{Binding CoLocationActive, Converter={StaticResource BoolToVisibilityConverter}}"
-                            Background="#1A5C3A" CornerRadius="6" Padding="12,6" Margin="0,8,0,0" Width="Auto" HorizontalAlignment="Left">
+                            Background="{StaticResource CoLocationBadgeSurfaceBrush}" CornerRadius="6" Padding="12,6" Margin="0,8,0,0" Width="Auto" HorizontalAlignment="Left">
                         <StackPanel Orientation="Horizontal">
                             <TextBlock Text="⚡" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center" />
-                            <TextBlock Text="CoLocation Profile Active" Foreground="#3AD16A" FontSize="12" VerticalAlignment="Center" />
+                            <TextBlock Text="CoLocation Profile Active" Foreground="{StaticResource SignalPositiveVividBrush}" FontSize="12" VerticalAlignment="Center" />
                         </StackPanel>
                     </Border>
 

--- a/src/Meridian.Wpf/Views/FloatingPageWindow.xaml
+++ b/src/Meridian.Wpf/Views/FloatingPageWindow.xaml
@@ -6,15 +6,15 @@
         MinWidth="640" MinHeight="480"
         Width="1024" Height="700"
         ShowInTaskbar="True"
-        Background="#0A0A12">
-    <Grid Background="#0A0A12">
+        Background="{StaticResource FloatWindowBackgroundBrush}">
+    <Grid Background="{StaticResource FloatWindowBackgroundBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
         <!-- Title bar: drag to move, shows page title and close button -->
-        <Border Grid.Row="0" Background="#1A2A4A" Padding="12,6"
+        <Border Grid.Row="0" Background="{StaticResource FloatWindowChromeBrush}" Padding="12,6"
                 MouseLeftButtonDown="TitleBar_MouseLeftButtonDown"
                 Cursor="SizeAll">
             <Grid>
@@ -29,7 +29,7 @@
                            VerticalAlignment="Center"/>
                 <Button Grid.Column="1"
                         Content="✕"
-                        Foreground="#888888" Background="Transparent"
+                        Foreground="{StaticResource DarkSurfaceMutedTextBrush}" Background="Transparent"
                         BorderThickness="0" Padding="8,2"
                         Cursor="Arrow"
                         FontSize="12"

--- a/src/Meridian.Wpf/Views/InstitutionalCommandPaletteControl.xaml
+++ b/src/Meridian.Wpf/Views/InstitutionalCommandPaletteControl.xaml
@@ -85,7 +85,7 @@
     <Grid x:Name="CommandPaletteOverlay"
           Visibility="{Binding CommandPaletteVisibility}"
           Panel.ZIndex="100"
-          Background="#80000000"
+          Background="{StaticResource ModalScrimBrush}"
           AutomationProperties.AutomationId="CommandPaletteOverlay"
           AutomationProperties.Name="Command Palette Overlay"
           MouseDown="CommandPaletteOverlay_MouseDown">

--- a/src/Meridian.Wpf/Views/MeridianDockingManager.xaml
+++ b/src/Meridian.Wpf/Views/MeridianDockingManager.xaml
@@ -31,8 +31,8 @@
 
         <!-- ── Drag-and-drop drop-target overlay (preserves existing page-tag protocol) ── -->
         <Border x:Name="DropOverlay"
-                Background="#22007ACC"
-                BorderBrush="#66007ACC"
+                Background="{StaticResource DropTargetFillBrush}"
+                BorderBrush="{StaticResource DropTargetBorderBrush}"
                 BorderThickness="2"
                 Visibility="Collapsed">
             <TextBlock HorizontalAlignment="Center"

--- a/src/Meridian.Wpf/Views/NotificationCenterPage.xaml
+++ b/src/Meridian.Wpf/Views/NotificationCenterPage.xaml
@@ -118,7 +118,7 @@
 
                     <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="24,0,0,0">
                         <Border x:Name="CriticalBadge"
-                                Background="#F44336"
+                                Background="{StaticResource SeverityCriticalBrush}"
                                 CornerRadius="999"
                                 Padding="10,3"
                                 Margin="0,0,8,0"
@@ -127,7 +127,7 @@
                             <TextBlock x:Name="CriticalCountText" Text="{Binding CriticalAlertCountText}" FontSize="11" Foreground="White" FontWeight="SemiBold" />
                         </Border>
                         <Border x:Name="ErrorBadge"
-                                Background="#FF5722"
+                                Background="{StaticResource SeverityErrorBrush}"
                                 CornerRadius="999"
                                 Padding="10,3"
                                 Margin="0,0,8,0"
@@ -136,13 +136,13 @@
                             <TextBlock x:Name="ErrorCountText" Text="{Binding ErrorAlertCountText}" FontSize="11" Foreground="White" FontWeight="SemiBold" />
                         </Border>
                         <Border x:Name="WarningBadge"
-                                Background="#FFC107"
+                                Background="{StaticResource SeverityWarningBrush}"
                                 CornerRadius="999"
                                 Padding="10,3"
                                 Margin="0,0,8,0"
                                 Visibility="{Binding IsWarningAlertBadgeVisible, Converter={StaticResource BoolToVisibilityConverter}}"
                                 AutomationProperties.Name="{Binding WarningAlertCountText}">
-                            <TextBlock x:Name="WarningCountText" Text="{Binding WarningAlertCountText}" FontSize="11" Foreground="#333" FontWeight="SemiBold" />
+                            <TextBlock x:Name="WarningCountText" Text="{Binding WarningAlertCountText}" FontSize="11" Foreground="{StaticResource BadgeDarkTextBrush}" FontWeight="SemiBold" />
                         </Border>
                         <TextBlock x:Name="SnoozedCountText"
                                    Text="{Binding SnoozedAlertCountText}"
@@ -234,7 +234,7 @@
                     <StackPanel x:Name="PlaybookStepsPanel" Margin="0,0,0,16" />
 
                     <!-- What happens if ignored -->
-                    <Border Background="#2D1B1B" CornerRadius="6" Padding="12,8" Margin="0,0,0,4">
+                    <Border Background="{StaticResource NotificationDangerSurfaceBrush}" CornerRadius="6" Padding="12,8" Margin="0,0,0,4">
                         <StackPanel Orientation="Horizontal">
                             <TextBlock Text="&#xE7BA;"
                                        FontFamily="{StaticResource SymbolThemeFontFamily}"

--- a/src/Meridian.Wpf/Views/QuoteFloatWindow.xaml
+++ b/src/Meridian.Wpf/Views/QuoteFloatWindow.xaml
@@ -7,16 +7,16 @@
         Width="320" Height="210"
         Title="{Binding Symbol}"
         ShowInTaskbar="False"
-        Background="#0A0A12"
+        Background="{StaticResource FloatWindowBackgroundBrush}"
         Topmost="True">
-    <Grid Background="#0A0A12">
+    <Grid Background="{StaticResource FloatWindowBackgroundBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
         <!-- Title bar: drag to move, shows symbol name and close button -->
-        <Border Grid.Row="0" Background="#1A2A4A" Padding="8,5"
+        <Border Grid.Row="0" Background="{StaticResource FloatWindowChromeBrush}" Padding="8,5"
                 MouseLeftButtonDown="TitleBar_MouseLeftButtonDown"
                 Cursor="SizeAll">
             <Grid>
@@ -31,7 +31,7 @@
                            VerticalAlignment="Center"/>
                 <Button Grid.Column="1"
                         Content="✕"
-                        Foreground="#888888" Background="Transparent"
+                        Foreground="{StaticResource DarkSurfaceMutedTextBrush}" Background="Transparent"
                         BorderThickness="0" Padding="6,2"
                         Cursor="Arrow"
                         FontSize="12"
@@ -60,20 +60,20 @@
 
             <!-- Bid -->
             <TextBlock Grid.Row="1" Grid.Column="0"
-                       Text="Bid:" Foreground="#888888" FontSize="12"
+                       Text="Bid:" Foreground="{StaticResource DarkSurfaceMutedTextBrush}" FontSize="12"
                        VerticalAlignment="Center" Margin="0,6,0,0"/>
             <TextBlock Grid.Row="1" Grid.Column="1"
                        Text="{Binding BidPrice, StringFormat=N4}"
-                       Foreground="#44CC44" FontFamily="Consolas" FontSize="12"
+                       Foreground="{StaticResource QuoteBidBrush}" FontFamily="Consolas" FontSize="12"
                        VerticalAlignment="Center" Margin="0,6,0,0"/>
 
             <!-- Ask -->
             <TextBlock Grid.Row="2" Grid.Column="0"
-                       Text="Ask:" Foreground="#888888" FontSize="12"
+                       Text="Ask:" Foreground="{StaticResource DarkSurfaceMutedTextBrush}" FontSize="12"
                        VerticalAlignment="Center" Margin="0,4,0,0"/>
             <TextBlock Grid.Row="2" Grid.Column="1"
                        Text="{Binding AskPrice, StringFormat=N4}"
-                       Foreground="#CC4444" FontFamily="Consolas" FontSize="12"
+                       Foreground="{StaticResource QuoteAskBrush}" FontFamily="Consolas" FontSize="12"
                        VerticalAlignment="Center" Margin="0,4,0,0"/>
         </Grid>
     </Grid>

--- a/src/Meridian.Wpf/Views/SecurityMasterPage.xaml
+++ b/src/Meridian.Wpf/Views/SecurityMasterPage.xaml
@@ -69,17 +69,17 @@
                             </Border.InputBindings>
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="⚠ "
-                                           Foreground="#333"
+                                           Foreground="{StaticResource BadgeDarkTextBrush}"
                                            FontWeight="Bold"
                                            FontSize="12"
                                            VerticalAlignment="Center" />
                                 <TextBlock Text="{Binding OpenConflictCount}"
-                                           Foreground="#333"
+                                           Foreground="{StaticResource BadgeDarkTextBrush}"
                                            FontWeight="Bold"
                                            FontSize="12"
                                            VerticalAlignment="Center" />
                                 <TextBlock Text=" conflicts"
-                                           Foreground="#333"
+                                           Foreground="{StaticResource BadgeDarkTextBrush}"
                                            FontSize="12"
                                            VerticalAlignment="Center" />
                             </StackPanel>

--- a/src/Meridian.Wpf/Views/SecurityPassportEditorView.xaml
+++ b/src/Meridian.Wpf/Views/SecurityPassportEditorView.xaml
@@ -24,7 +24,7 @@
 
             <!-- Recovery banner -->
             <Border Margin="0,8,0,0" Padding="10,8" BorderThickness="1"
-                    BorderBrush="#C0392B"
+                    BorderBrush="{StaticResource RecoveryBannerBorderBrush}"
                     Visibility="{Binding HasBanner, Converter={StaticResource BooleanToVisibility}}"
                     AutomationProperties.Name="Passport edit banner">
                 <TextBlock Text="{Binding BannerText}" TextWrapping="Wrap" />

--- a/src/Meridian.Wpf/Views/ShellMastheadControl.xaml
+++ b/src/Meridian.Wpf/Views/ShellMastheadControl.xaml
@@ -23,7 +23,7 @@
                 <TextBlock Text="Operator Workstation"
                            FontFamily="{StaticResource MeridianBodyFontFamily}"
                            FontSize="12"
-                           Foreground="#6B7280"
+                           Foreground="{StaticResource TopBarTextMutedBrush}"
                            VerticalAlignment="Center"
                            Margin="12,0,0,0" />
             </StackPanel>
@@ -42,7 +42,7 @@
                         <TextBlock Text="&#xE8B7;"
                                    FontFamily="{StaticResource SymbolThemeFontFamily}"
                                    FontSize="11"
-                                   Foreground="#F59E0B"
+                                   Foreground="{StaticResource TopBarAlertAmberBrush}"
                                    VerticalAlignment="Center" />
                         <TextBlock Text="{Binding ActiveFundName}"
                                    Margin="6,0,0,0"
@@ -52,7 +52,7 @@
                         <TextBlock Text="{Binding ActiveFundSubtitle}"
                                    Margin="6,0,0,0"
                                    FontSize="11"
-                                   Foreground="#9CA3AF" />
+                                   Foreground="{StaticResource TopBarTextSecondaryBrush}" />
                     </StackPanel>
                 </Border>
                 <ComboBox Width="220"
@@ -78,7 +78,7 @@
                     <TextBlock Text="&#xE777;"
                                FontFamily="{StaticResource SymbolThemeFontFamily}"
                                FontSize="14"
-                               Foreground="#9CA3AF" />
+                               Foreground="{StaticResource TopBarTextSecondaryBrush}" />
                 </Button>
                 <ComboBox Width="132"
                           Margin="0,0,8,0"
@@ -97,7 +97,7 @@
                     <TextBlock Text="{Binding CurrentModeName}"
                                FontSize="11"
                                FontWeight="SemiBold"
-                               Foreground="#60A5FA" />
+                               Foreground="{StaticResource TopBarAccentBlueBrush}" />
                 </Border>
                 <Button Style="{StaticResource IconButtonStyle}"
                         Command="{Binding ShowCommandPaletteCommand}"
@@ -110,7 +110,7 @@
                     <TextBlock Text="{StaticResource IconSearch}"
                                FontFamily="{StaticResource SymbolThemeFontFamily}"
                                FontSize="14"
-                               Foreground="#9CA3AF" />
+                               Foreground="{StaticResource TopBarTextSecondaryBrush}" />
                 </Button>
             </StackPanel>
         </DockPanel>

--- a/src/Meridian.Wpf/Views/SplitPaneHostControl.xaml
+++ b/src/Meridian.Wpf/Views/SplitPaneHostControl.xaml
@@ -13,8 +13,8 @@
     <Grid>
         <Grid x:Name="ContentGrid"/>
         <Border x:Name="DropOverlay"
-                Background="#22007ACC"
-                BorderBrush="#66007ACC"
+                Background="{StaticResource DropTargetFillBrush}"
+                BorderBrush="{StaticResource DropTargetBorderBrush}"
                 BorderThickness="2"
                 Visibility="Collapsed">
             <TextBlock HorizontalAlignment="Center"

--- a/src/Meridian.Wpf/Views/StartupWindow.xaml
+++ b/src/Meridian.Wpf/Views/StartupWindow.xaml
@@ -50,7 +50,7 @@
                     <TextBlock Text="Desktop workstation startup"
                                Margin="0,8,0,0"
                                FontSize="15"
-                               Foreground="#C9D1D9"
+                               Foreground="{StaticResource StartupSubtitleTextBrush}"
                                TextWrapping="Wrap" />
                 </StackPanel>
 
@@ -74,7 +74,7 @@
                                            FontWeight="SemiBold" />
                                 <TextBlock Text="Dependency injection, routes, and workstation services are prepared before the shell opens."
                                            Margin="0,4,0,0"
-                                           Foreground="#AAB4BF"
+                                           Foreground="{StaticResource StartupBodyTextBrush}"
                                            TextWrapping="Wrap" />
                             </StackPanel>
                         </Grid>
@@ -99,7 +99,7 @@
                                            FontWeight="SemiBold" />
                                 <TextBlock Text="{Binding AuthenticationDetailText}"
                                            Margin="0,4,0,0"
-                                           Foreground="#AAB4BF"
+                                           Foreground="{StaticResource StartupBodyTextBrush}"
                                            TextWrapping="Wrap" />
                             </StackPanel>
                         </Grid>
@@ -123,7 +123,7 @@
                                        FontWeight="SemiBold" />
                             <TextBlock Text="{Binding OperatingModeText}"
                                        Margin="0,4,0,0"
-                                       Foreground="#AAB4BF"
+                                       Foreground="{StaticResource StartupBodyTextBrush}"
                                        TextWrapping="Wrap" />
                         </StackPanel>
                     </Grid>
@@ -131,7 +131,7 @@
 
                 <TextBlock Grid.Row="2"
                            Text="{Binding CredentialSourceText}"
-                           Foreground="#7E8792"
+                           Foreground="{StaticResource StartupFootnoteTextBrush}"
                            FontSize="12"
                            TextWrapping="Wrap" />
             </Grid>

--- a/src/Meridian.Wpf/Views/StrategyWorkspaceShellPage.xaml
+++ b/src/Meridian.Wpf/Views/StrategyWorkspaceShellPage.xaml
@@ -72,14 +72,14 @@
                             <Border Margin="0,18,0,0"
                                     Padding="14,12"
                                     CornerRadius="12"
-                                    Background="#12253A"
-                                    BorderBrush="#22486B"
+                                    Background="{StaticResource StrategyHeroSurfaceBrush}"
+                                    BorderBrush="{StaticResource StrategyHeroBorderBrush}"
                                     BorderThickness="1">
                                 <StackPanel>
                                     <TextBlock Text="Selected Run"
                                                FontSize="11"
                                                FontWeight="SemiBold"
-                                               Foreground="#7EA3C5" />
+                                               Foreground="{StaticResource StrategyHeroLabelBrush}" />
                                     <TextBlock x:Name="ActiveRunNameText"
                                                Margin="0,6,0,0"
                                                FontSize="18"
@@ -89,7 +89,7 @@
                                     <TextBlock x:Name="ActiveRunMetaText"
                                                Margin="0,4,0,0"
                                                FontSize="12"
-                                               Foreground="#A8BED7"
+                                               Foreground="{StaticResource StrategyHeroMetaBrush}"
                                                Text="{Binding ActiveRunMetaText}" />
                                 </StackPanel>
                             </Border>

--- a/src/Meridian.Wpf/Views/TickerStripWindow.xaml
+++ b/src/Meridian.Wpf/Views/TickerStripWindow.xaml
@@ -21,8 +21,8 @@
         <Border x:Name="FullStrip"
                 Height="28"
                 VerticalAlignment="Bottom"
-                Background="#EE0A0A0F"
-                BorderBrush="#FF1A2A4A"
+                Background="{StaticResource TickerStripBackgroundBrush}"
+                BorderBrush="{StaticResource TickerStripBorderBrush}"
                 BorderThickness="0,1,0,0">
             <Grid>
                 <Grid.ColumnDefinitions>
@@ -44,14 +44,14 @@
                         <DataTemplate>
                             <Border Padding="8,0"
                                     Margin="0,0,1,0"
-                                    Background="#0A0A1A"
+                                    Background="{StaticResource TickerItemBackgroundBrush}"
                                     VerticalAlignment="Stretch">
                                 <!-- Flash highlight: semi-transparent white overlay appears on IsFlashing -->
                                 <Border.Style>
                                     <Style TargetType="Border">
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsFlashing}" Value="True">
-                                                <Setter Property="Background" Value="#1AFFFFFF" />
+                                                <Setter Property="Background" Value="{StaticResource TickerFlashOverlayBrush}" />
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
@@ -76,7 +76,7 @@
                                     <TextBlock Text="{Binding BidText}"
                                                FontFamily="Consolas"
                                                FontSize="10"
-                                               Foreground="#44AA44"
+                                               Foreground="{StaticResource TickerUpBrush}"
                                                VerticalAlignment="Center" />
                                     <TextBlock Text="/"
                                                FontFamily="Consolas"
@@ -86,7 +86,7 @@
                                     <TextBlock Text="{Binding AskText}"
                                                FontFamily="Consolas"
                                                FontSize="10"
-                                               Foreground="#AA4444"
+                                               Foreground="{StaticResource TickerDownBrush}"
                                                VerticalAlignment="Center" />
                                 </StackPanel>
                             </Border>
@@ -97,13 +97,13 @@
                 <!-- Right-side controls: context menu hint -->
                 <Border Grid.Column="1"
                         Padding="8,0"
-                        Background="#0A0A1A"
+                        Background="{StaticResource TickerItemBackgroundBrush}"
                         Cursor="Hand"
                         MouseRightButtonUp="OnRightClick"
                         ToolTip="Right-click for options">
                     <TextBlock Text="⋮"
                                FontSize="14"
-                               Foreground="#44667799"
+                               Foreground="{StaticResource TickerMutedGlyphBrush}"
                                VerticalAlignment="Center"
                                HorizontalAlignment="Center" />
                 </Border>
@@ -114,7 +114,7 @@
         <Border x:Name="HairlineStrip"
                 Height="4"
                 VerticalAlignment="Bottom"
-                Background="#661A2A4A"
+                Background="{StaticResource TickerHairlineBrush}"
                 Visibility="Collapsed" />
     </Grid>
 </Window>

--- a/src/Meridian.Wpf/Views/WorkspacePage.xaml
+++ b/src/Meridian.Wpf/Views/WorkspacePage.xaml
@@ -118,7 +118,7 @@
                             <TextBox Style="{StaticResource FormTextBoxStyle}"
                                      Text="{Binding NewName, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBlock Text="{Binding NewNameError}"
-                                       Foreground="#F85149"
+                                       Foreground="{StaticResource SignalNegativeVividBrush}"
                                        FontSize="11"
                                        Margin="0,4,0,0"
                                        Visibility="{Binding HasNewNameError, Converter={StaticResource BoolToVisibilityConverter}}" />


### PR DESCRIPTION
## Summary

Moves ~100 hardcoded hex color literals out of WPF View, control, and style markup and into centrally-defined theme resources. No rendered colors change — every literal is replaced by a `{StaticResource ...}` token that resolves to the same value.

- **`Styles/ThemeTokens.xaml`** — added a new "hoisted from inline markup" section defining `Color` + `SolidColorBrush` pairs for every distinct value that was previously inlined, grouped semantically: bright signal/metric palette, notification severity badges, top-bar/masthead text & accents, startup-panel text, floating quote/page windows, ticker strip, diagnostics metric tiles, file-drop overlays, modal scrim, strategy/accounting workspace hero cards, provider tag borders, dark tooltip, plus `ShadowColor` and `FlashHighlightColor` (consumed as `Color` by `DropShadowEffect` / `LinearColorKeyFrame`).
- **24 View/control/style files** — replaced each inline `"#hex"` with the matching brush token (or `Color` resource where the consumer requires a `Color` rather than a `Brush`).
- **`Styles/BrandResources.xaml`** — hoisted the brand gradient/star/halo/horizon hex into named `Color` resources within that file so the brand palette is token-driven (relevant to rebrands).

26 files changed. `ThemeTokens.xaml` is merged globally in `App.xaml`, so every new token resolves in all Views and Windows.

## Reason

78+ hardcoded hex color literals were scattered directly through XAML markup instead of referencing theme resources. Any future theming, dark-mode, or rebrand effort would have required hunting down each literal across the tree. Centralizing them gives a single source of truth in the token dictionaries.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [ ] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

No .NET SDK is available in this environment, so the build was not run locally; `quality-gate` remains the authoritative gate. The change is a mechanical, behavior-preserving markup refactor and was validated statically:

- All 26 changed files parse as well-formed XML.
- No duplicate `x:Key` introduced; no new dangling `StaticResource` references (every referenced key resolves to a defined token).
- Each of the 100 replaced literals was cross-checked against `HEAD` — the token now referenced at each site resolves to the **exact** original hex value (0 mismatches). Brand color set in `BrandResources.xaml` is identical before/after.
- No remaining hardcoded hex literals in markup outside the token-definition files.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ew1yv3eY7AuGdWSSDcYQim)_