### PR TITLE
fix(docs-automation): repair broken command, stop CRLF churn, and end the API coverage feedback loop

### DIFF
--- a/build/scripts/docs/generate-api-contract-coverage-dashboard.py
+++ b/build/scripts/docs/generate-api-contract-coverage-dashboard.py
@@ -44,8 +44,15 @@ DATA_SOURCES = [
     "src/**/*.cs endpoint mappings",
     "src/Meridian.Contracts/Api/UiApiRoutes.cs",
     "src/Meridian.Contracts/Workstation/*.cs",
-    "docs/**/*.md",
+    "docs/**/*.md (excluding generated report roots)",
 ]
+
+# Generated reports live under these roots and echo route paths and contract names verbatim —
+# including this dashboard's own markdown, which lists every endpoint it scans. Treating them as
+# documentation creates a feedback loop: an endpoint counts as documented purely because a prior
+# run wrote it into a report. That inflates coverage toward 100% and leaves the artifact unable to
+# converge, since each run's output changes the next run's input.
+GENERATED_DOC_ROOTS = ("docs/status", "docs/generated")
 
 
 def _should_skip(path: Path) -> bool:
@@ -161,6 +168,14 @@ def _scan_workstation_contracts(root: Path) -> list[dict[str, object]]:
     return contracts
 
 
+def _is_generated_doc(root: Path, path: Path) -> bool:
+    relative = _rel(root, path)
+    return any(
+        relative == generated_root or relative.startswith(generated_root + "/")
+        for generated_root in GENERATED_DOC_ROOTS
+    )
+
+
 def _load_docs_text(root: Path) -> str:
     docs_dir = root / "docs"
     if not docs_dir.is_dir():
@@ -168,6 +183,8 @@ def _load_docs_text(root: Path) -> str:
 
     chunks: list[str] = []
     for path in _iter_files(docs_dir, ".md"):
+        if _is_generated_doc(root, path):
+            continue
         chunks.append(_read_text(path))
     normalized = "\n".join(chunks)
     return ROUTE_CONSTRAINT_RE.sub(r"{\1}", normalized).casefold()

--- a/build/scripts/docs/generate-structure-docs.py
+++ b/build/scripts/docs/generate-structure-docs.py
@@ -44,6 +44,13 @@ EXCLUDED_ROOT_DIR_NAMES = {
     "data",
 }
 
+# Git-ignored directories that the filesystem merge in `_git_visible_files` would otherwise
+# pick up. These hold checkouts of the repository itself, so walking them injects thousands of
+# duplicate entries and makes the generated tree depend on local scratch state.
+EXCLUDED_RELATIVE_DIR_PATHS = {
+    ".claude/worktrees",
+}
+
 EXCLUDED_FILE_SUFFIXES = {
     ".bak",
     ".log",
@@ -73,6 +80,22 @@ def utc_now() -> str:
     return STABLE_GENERATED_AT
 
 
+def write_text_lf(path: Path, content: str) -> None:
+    """Write UTF-8 text with LF endings so generated docs match the repo on every platform."""
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(content)
+
+
+def _is_excluded_relative_dir(relative_parts: tuple[str, ...]) -> bool:
+    if not relative_parts:
+        return False
+    candidate = "/".join(relative_parts)
+    return any(
+        candidate == excluded or candidate.startswith(excluded + "/")
+        for excluded in EXCLUDED_RELATIVE_DIR_PATHS
+    )
+
+
 def is_excluded(path: Path, root: Path | None = None) -> bool:
     if path.is_symlink():
         return True
@@ -87,6 +110,8 @@ def is_excluded(path: Path, root: Path | None = None) -> bool:
         except ValueError:
             relative_parts = parts
         if relative_parts and relative_parts[0] in EXCLUDED_ROOT_DIR_NAMES:
+            return True
+        if _is_excluded_relative_dir(relative_parts):
             return True
         if len(relative_parts) == 1 and relative_parts[0] in EXCLUDED_ROOT_FILE_NAMES:
             return True
@@ -111,6 +136,8 @@ def _is_excluded_relative_file(path: PurePosixPath) -> bool:
     if not parts or any(part in EXCLUDED_DIR_NAMES for part in parts):
         return True
     if parts[0] in EXCLUDED_ROOT_DIR_NAMES:
+        return True
+    if _is_excluded_relative_dir(parts):
         return True
     if len(parts) == 1 and parts[0] in EXCLUDED_ROOT_FILE_NAMES:
         return True
@@ -377,9 +404,22 @@ def generate_provider_registry(root: Path) -> str:
     return "\n".join(lines)
 
 
+DEFAULT_OUTPUTS = {
+    "workflows": "docs/generated/workflows-overview.md",
+    "providers": "docs/generated/provider-registry.md",
+    "structure": "docs/generated/repository-structure.md",
+}
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate documentation artifacts for repo structure and workflows.")
-    parser.add_argument("--output", required=True, help="Path to output markdown file")
+    parser.add_argument(
+        "--output",
+        help=(
+            "Path to output markdown file. Defaults to the canonical path for the "
+            f"selected mode ({', '.join(f'{k}: {v}' for k, v in DEFAULT_OUTPUTS.items())})."
+        ),
+    )
     parser.add_argument("--format", default="markdown", help="Output format (currently markdown only)")
     parser.add_argument("--workflows-only", action="store_true", help="Generate workflows overview")
     parser.add_argument("--providers-only", action="store_true", help="Generate provider registry")
@@ -392,21 +432,21 @@ def main() -> int:
     if args.format.lower() != "markdown":
         raise SystemExit("Only markdown format is supported")
 
-    root = Path.cwd()
-    output_path = Path(args.output)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-
     if args.workflows_only and args.providers_only:
         raise SystemExit("--workflows-only and --providers-only are mutually exclusive")
 
-    if args.workflows_only:
-        content = generate_workflows_overview(root)
-    elif args.providers_only:
-        content = generate_provider_registry(root)
-    else:
-        content = generate_repository_structure(root)
+    root = Path.cwd()
 
-    output_path.write_text(content, encoding="utf-8")
+    if args.workflows_only:
+        mode, content = "workflows", generate_workflows_overview(root)
+    elif args.providers_only:
+        mode, content = "providers", generate_provider_registry(root)
+    else:
+        mode, content = "structure", generate_repository_structure(root)
+
+    output_path = Path(args.output or DEFAULT_OUTPUTS[mode])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    write_text_lf(output_path, content)
     return 0
 
 

--- a/build/scripts/docs/generate-workflow-manifest.py
+++ b/build/scripts/docs/generate-workflow-manifest.py
@@ -23,6 +23,12 @@ class WorkflowRef:
     command: str
 
 
+def write_text_lf(path: Path, content: str) -> None:
+    """Write UTF-8 text with LF endings so generated docs match the repo on every platform."""
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(content)
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate workflow docs/validation artifacts from manifest.")
     parser.add_argument(
@@ -339,7 +345,7 @@ def write_commands_reference(path: Path, workflows: list[dict[str, Any]]) -> Non
             lines.append(f"  - `{command}`")
         lines.append("")
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+    write_text_lf(path, "\n".join(lines).rstrip() + "\n")
 
 
 def main() -> int:
@@ -355,11 +361,11 @@ def main() -> int:
 
     help_doc = help_doc_path.read_text(encoding="utf-8")
     help_doc = replace_block(help_doc, HELP_BLOCK_START, HELP_BLOCK_END, build_help_snippet(workflows))
-    help_doc_path.write_text(help_doc, encoding="utf-8")
+    write_text_lf(help_doc_path, help_doc)
 
     dev_doc = dev_doc_path.read_text(encoding="utf-8")
     dev_doc = replace_block(dev_doc, DEV_BLOCK_START, DEV_BLOCK_END, build_dev_snippet(workflows))
-    dev_doc_path.write_text(dev_doc, encoding="utf-8")
+    write_text_lf(dev_doc_path, dev_doc)
 
     write_commands_reference(repo_root / args.commands_output, workflows)
 
@@ -402,7 +408,7 @@ def main() -> int:
 
     summary_path = repo_root / args.summary_output
     summary_path.parent.mkdir(parents=True, exist_ok=True)
-    summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    write_text_lf(summary_path, json.dumps(summary, indent=2) + "\n")
 
     drift_lines = [
         "# Workflow Drift Report",
@@ -457,7 +463,7 @@ def main() -> int:
 
     drift_path = repo_root / args.drift_output
     drift_path.parent.mkdir(parents=True, exist_ok=True)
-    drift_path.write_text("\n".join(drift_lines).rstrip() + "\n", encoding="utf-8")
+    write_text_lf(drift_path, "\n".join(drift_lines).rstrip() + "\n")
 
     print(f"Generated workflow artifacts for {len(workflows)} workflows.")
     print(f"Status: {drift_status}")

--- a/build/scripts/docs/run-docs-automation.py
+++ b/build/scripts/docs/run-docs-automation.py
@@ -26,6 +26,23 @@ from typing import Dict, Iterable, List, Sequence
 TODO_SCAN_JSON_PATH = "docs/status/todo-scan-results.json"
 TODO_ISSUE_SUMMARY_PATH = "docs/status/todo-issue-creation-summary.json"
 
+# Recorded commands use this token so summary artifacts stay identical across
+# machines; execution substitutes the running interpreter (see execution_command).
+PYTHON_DISPLAY = "python3"
+
+
+def execution_command(command: Sequence[str]) -> List[str]:
+    """Swap the recorded interpreter token for the interpreter running this script."""
+    if command and command[0] == PYTHON_DISPLAY:
+        return [sys.executable, *command[1:]]
+    return list(command)
+
+
+def write_text_lf(path: Path, content: str) -> None:
+    """Write UTF-8 text with LF endings so generated summaries match the repo on every platform."""
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(content)
+
 
 @dataclass
 class ScriptResult:
@@ -397,12 +414,12 @@ def resolve_selected_scripts(args: argparse.Namespace) -> List[str]:
 def run_script_with_args(name: str, root: Path, extra_args: Sequence[str] | None = None) -> ScriptResult:
     config = SCRIPT_CONFIG[name]
     script_path = root / "build" / "scripts" / "docs" / str(config["script"])
-    command = ["python3", str(script_path), *[str(arg) for arg in config.get("args", [])]]
+    command = [PYTHON_DISPLAY, str(script_path), *[str(arg) for arg in config.get("args", [])]]
     if extra_args:
         command.extend(str(arg) for arg in extra_args)
 
     started = time.perf_counter()
-    proc = subprocess.run(command, cwd=root, capture_output=True, text=True)
+    proc = subprocess.run(execution_command(command), cwd=root, capture_output=True, text=True)
     duration = time.perf_counter() - started
 
     if proc.returncode == 0:
@@ -478,7 +495,7 @@ def write_markdown_summary(path: Path, results: Iterable[ScriptResult], dry_run:
             lines.append(f"- `{failed.name}`: {failed.error or 'Unknown error'}")
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    write_text_lf(path, "\n".join(lines) + "\n")
 
 
 def main() -> int:  # noqa: C901
@@ -499,7 +516,7 @@ def main() -> int:  # noqa: C901
         for name in selected:
             config = SCRIPT_CONFIG[name]
             script_path = root / "build" / "scripts" / "docs" / str(config["script"])
-            command = ["python3", str(script_path), *[str(arg) for arg in config.get("args", [])]]
+            command = [PYTHON_DISPLAY, str(script_path), *[str(arg) for arg in config.get("args", [])]]
             # For scan-todos, add JSON output if --auto-create-todos is set
             if name == "scan-todos" and args.auto_create_todos:
                 command.extend(["--json-output", TODO_SCAN_JSON_PATH])
@@ -517,7 +534,7 @@ def main() -> int:  # noqa: C901
 
         if args.auto_create_todos and "scan-todos" in selected:
             issue_cmd = [
-                "python3",
+                PYTHON_DISPLAY,
                 str(root / "build" / "scripts" / "docs" / "create-todo-issues.py"),
                 "--scan-json",
                 TODO_SCAN_JSON_PATH,
@@ -596,7 +613,7 @@ def main() -> int:  # noqa: C901
         }
         out = Path(args.json_output)
         out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        write_text_lf(out, json.dumps(payload, indent=2) + "\n")
         print(f"Wrote JSON summary: {args.json_output}")
 
     failed = [r for r in results if r.status == "failed"]

--- a/build/scripts/docs/tests/test_generate_api_contract_coverage_dashboard.py
+++ b/build/scripts/docs/tests/test_generate_api_contract_coverage_dashboard.py
@@ -104,5 +104,74 @@ class GenerateApiContractCoverageDashboardTests(unittest.TestCase):
             )
 
 
+    def _build_repo_with_endpoint(self, root: Path) -> None:
+        endpoints = root / "src" / "Meridian.Ui.Shared" / "Endpoints"
+        endpoints.mkdir(parents=True)
+        (endpoints / "FirstRunEndpoints.cs").write_text(
+            'app.MapGet("/api/auth/desktop-launch/{ticket}", Handler);\n',
+            encoding="utf-8",
+        )
+        (root / "docs").mkdir()
+
+    def test_generated_reports_do_not_count_as_documentation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._build_repo_with_endpoint(root)
+            # A prior dashboard run lists every scanned route in its own report.
+            (root / "docs" / "status").mkdir()
+            (root / "docs" / "status" / "api-contract-coverage-dashboard.md").write_text(
+                "| GET | `/api/auth/desktop-launch/{ticket}` | gap |\n",
+                encoding="utf-8",
+            )
+
+            payload = api_contract_coverage.build_dashboard(root)
+
+            self.assertEqual(0, payload["summary"]["documented_endpoint_count"])
+            self.assertEqual(1, payload["summary"]["undocumented_endpoint_count"])
+
+    def test_hand_written_docs_still_count_as_documentation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._build_repo_with_endpoint(root)
+            (root / "docs" / "development").mkdir()
+            (root / "docs" / "development" / "first-run.md").write_text(
+                "The desktop launch handshake calls `/api/auth/desktop-launch/{ticket}`.\n",
+                encoding="utf-8",
+            )
+
+            payload = api_contract_coverage.build_dashboard(root)
+
+            self.assertEqual(1, payload["summary"]["documented_endpoint_count"])
+            self.assertEqual(0, payload["summary"]["undocumented_endpoint_count"])
+
+    def test_coverage_is_stable_when_a_prior_report_is_present(self) -> None:
+        """The score must not depend on whether a previous run left a report behind."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._build_repo_with_endpoint(root)
+            (root / "docs" / "development").mkdir()
+            (root / "docs" / "development" / "first-run.md").write_text(
+                "Calls `/api/auth/desktop-launch/{ticket}`.\n",
+                encoding="utf-8",
+            )
+
+            first = api_contract_coverage.build_dashboard(root)
+
+            (root / "docs" / "status").mkdir()
+            (root / "docs" / "status" / "api-contract-coverage-dashboard.md").write_text(
+                "| GET | `/api/auth/desktop-launch/{ticket}` | documented |\n",
+                encoding="utf-8",
+            )
+            (root / "docs" / "generated" / "workflow-command-reference.md").parent.mkdir()
+            (root / "docs" / "generated" / "workflow-command-reference.md").write_text(
+                "`/api/auth/desktop-launch/{ticket}`\n",
+                encoding="utf-8",
+            )
+
+            second = api_contract_coverage.build_dashboard(root)
+
+            self.assertEqual(first["score_percent"], second["score_percent"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/build/scripts/docs/tests/test_generate_structure_docs.py
+++ b/build/scripts/docs/tests/test_generate_structure_docs.py
@@ -117,6 +117,51 @@ class GenerateStructureDocsTests(unittest.TestCase):
             self.assertNotIn(".nuget", rendered)
             self.assertNotIn("artifacts", rendered)
 
+    def test_render_tree_skips_nested_worktree_checkouts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "src").mkdir()
+            (root / "src" / "Meridian.cs").write_text("namespace Meridian;\n", encoding="utf-8")
+            (root / ".claude" / "settings.json").parent.mkdir(parents=True)
+            (root / ".claude" / "settings.json").write_text("{}\n", encoding="utf-8")
+            # A git-ignored worktree holds a second checkout of the repository.
+            worktree_src = root / ".claude" / "worktrees" / "task-branch" / "src"
+            worktree_src.mkdir(parents=True)
+            (worktree_src / "WorktreeCopy.cs").write_text("namespace Meridian;\n", encoding="utf-8")
+
+            rendered = generate_structure_docs.render_tree(root)
+
+            self.assertIn("Meridian.cs", rendered)
+            self.assertIn("settings.json", rendered)
+            self.assertNotIn("worktrees", rendered)
+            self.assertNotIn("WorktreeCopy.cs", rendered)
+
+    def test_parse_args_defaults_output_to_canonical_path_per_mode(self) -> None:
+        cases = [
+            ([], "docs/generated/repository-structure.md"),
+            (["--workflows-only"], "docs/generated/workflows-overview.md"),
+            (["--providers-only"], "docs/generated/provider-registry.md"),
+        ]
+        for argv, expected in cases:
+            with self.subTest(argv=argv):
+                with patch.object(sys, "argv", ["generate-structure-docs.py", *argv]):
+                    args = generate_structure_docs.parse_args()
+                self.assertIsNone(args.output)
+
+                mode = "structure"
+                if args.workflows_only:
+                    mode = "workflows"
+                elif args.providers_only:
+                    mode = "providers"
+                self.assertEqual(expected, generate_structure_docs.DEFAULT_OUTPUTS[mode])
+
+    def test_parse_args_honors_explicit_output_override(self) -> None:
+        with patch.object(
+            sys, "argv", ["generate-structure-docs.py", "--workflows-only", "--output", "custom.md"]
+        ):
+            args = generate_structure_docs.parse_args()
+        self.assertEqual("custom.md", args.output)
+
     def test_render_tree_skips_symlinked_entries(self) -> None:
         with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as external:
             root = Path(tmp)


### PR DESCRIPTION
<!-- phase:PR6 -->

Audit of the four docs-automation entrypoints:

```
python3 build/scripts/docs/run-docs-automation.py --profile core
python3 build/scripts/docs/generate-structure-docs.py --workflows-only
python3 build/scripts/docs/generate-workflow-manifest.py
node scripts/generate-diagrams.mjs
```

Two of the four were broken or actively harmful. This PR is **script fixes only** — no regenerated artifacts (see *Follow-up*).

> **Scope:** `build/scripts/docs/**` only, declared `phase:PR6` (the narrowest phase covering `build/**`). The `generate-diagrams.mjs` logging fix from this audit is split into its own PR — it sits outside the governed surface, so bundling it here would have forced a widen to `phase:PR9` for a six-line change.

## What was wrong

| Issue | Impact |
|---|---|
| `--workflows-only` required `--output` with no default | The documented command exited 2 — it never ran |
| `write_text()` uses the platform newline | Every Windows run rewrote LF-stored docs as CRLF, dirtying 5 tracked files with a **zero-content diff** |
| `"python3"` hardcoded for subprocesses | Locally `python3` is 3.9.13 but `python` is 3.11.5 — the orchestrator ran children under a *different* interpreter |
| `_git_visible_files` walked `.claude/worktrees/` | A git-ignored dir holding full repo checkouts injected **17,660 lines** into the generated tree |

## The API coverage dashboard measured its own output

`generate-api-contract-coverage-dashboard.py` scans `docs/**/*.md` for route paths to decide what is documented — and its own report lives in `docs/status/`, listing every endpoint it scans. An endpoint counted as documented purely because a **previous run wrote it there**.

That made the artifact non-convergent — a 2-cycle where each run's output became the next run's input:

| Branch | Committed | Corpus (= committed `.md`) | CI regen → | Observed diff |
|---|---|---|---|---|
| `main` | 100.0 (610 listed) | lacks `desktop-launch` | 99.8 | `-100.0 +99.8` |
| `claude/docs-regen-hygiene` | 99.8 (611 listed) | *has* it | 100.0 | `-99.8 +100.0` |

This is why **Documentation Automation has stayed red** even after that regeneration attempt, which got the failing diff down to exactly these two files and still failed.

Excluding generated report roots (`docs/status`, `docs/generated`) makes it reach a fixed point — three consecutive runs now produce byte-identical output.

### ⚠️ Reported coverage drops 100.0% → 29.3%

That is the true value (250/611 endpoints, 103/875 contracts). The self-reference was manufacturing **351 of the 610** "documented" endpoints — including `/api/auth/desktop-launch/{ticket}`, which no documentation mentions at all.

- Hand-written docs still count: `/api/system/shutdown` remains documented via `docs/development/process-lifecycle-diagnostics.md`.
- Nothing gates on the score; no other dashboard aggregates it.
- `generate-coverage.py` was checked for the same defect and converges cleanly.
- The ~361 now-visible undocumented endpoints are a real backlog this metric was hiding — not in scope here.

## Validation

- **99 tests pass, 3 new**, each verified non-vacuous (they fail with the fix neutralized).
- One pre-existing failure, `test_check_ai_inventory`, reproduces on a clean checkout of `main` and is unrelated to this branch.
- `--workflows-only` and the manifest generator both exit 0 and leave the tree clean, where previously one failed outright and the other dirtied five files.
- CI output is unchanged by the CRLF and worktree fixes (CI is Linux and has no worktrees); `docs-automation-summary.json` stays byte-stable because the recorded `python3` token is preserved.

## Expected check status

`regenerate-docs` will **fail on this PR**, as it already does on `main`. This PR does not turn that gate green — it removes the blocker that prevented it from ever going green. The dashboard fix legitimately enlarges that diff (committed `100.0` vs regenerated `29.3`), which the follow-up regeneration commit resolves.

## Follow-up (not in this PR)

1. **Regeneration commit** — now unblocked, but must run from a clean checkout.
2. `docs/generated/provider-registry.md` is **orphaned** — only `make/docs.mk --providers-only` builds it, not in any profile or CI, stale since 2026-06-06. Adopt into `core` or archive.
3. `enforceFreshness` on `docs-automation-core` uses file **mtime** — it can never fire in CI (fresh clones stamp checkout time) and false-positives locally on wall-clock. Suggest disabling; keep `enforceMissing`/`enforceCanonicalPaths`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
