### PR TITLE
fix(diagrams): log repo-relative paths instead of basenames

### DIFF
--- a/scripts/generate-diagrams.mjs
+++ b/scripts/generate-diagrams.mjs
@@ -12,9 +12,13 @@ async function main() {
   if (!trackerOnly) {
     const rendered = await generateUiDiagrams({ repoRoot, renderAll });
 
+    // Diagrams are emitted to both docs/diagrams/ and docs/diagrams/ui/, so log
+    // repo-relative paths — basenames alone render the two copies identically.
     for (const item of rendered) {
       const suffix = item.svgChanged ? 'svg updated' : 'svg unchanged';
-      console.log(`Rendered ${path.basename(item.dotPath)} -> ${path.basename(item.svgPath)} (${suffix})`);
+      const from = path.relative(repoRoot, item.dotPath).replaceAll(path.sep, '/');
+      const to = path.relative(repoRoot, item.svgPath).replaceAll(path.sep, '/');
+      console.log(`Rendered ${from} -> ${to} (${suffix})`);
     }
   }
 


### PR DESCRIPTION
Split out of #2300 (docs-automation audit) so that PR can stay at the narrowest phase scope.

## Problem

`generateUiDiagrams` writes each `.dot` to **both** `docs/diagrams/` and `docs/diagrams/ui/`, then renders both copies. The log printed `path.basename()`, which collapsed the two distinct files into identical lines:

```
Rendered ui-navigation-map.dot -> ui-navigation-map.svg (svg updated)
Rendered ui-navigation-map.dot -> ui-navigation-map.svg (svg updated)   <- different file, same text
```

Every diagram appeared twice with no way to tell which copy a line referred to. It reads like a bug in the generator; it was only the logging.

## Fix

Log repo-relative paths. The dual-write is intentional and unchanged — all 22 lines are now distinct:

```
Rendered docs/diagrams/ui-navigation-map.dot -> docs/diagrams/ui-navigation-map.svg (svg updated)
Rendered docs/diagrams/ui/ui-navigation-map.dot -> docs/diagrams/ui/ui-navigation-map.svg (svg updated)
```

## Validation

Ran `node scripts/generate-diagrams.mjs` and confirmed zero duplicate lines (`sort | uniq -d` is empty), where previously every entry was duplicated. Logging only — no rendered output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
