### PR TITLE
Complete statement connector scheduled fetch workflow

### DIFF
--- a/database/manifest/contracts.json
+++ b/database/manifest/contracts.json
@@ -3355,7 +3355,7 @@
       ]
     }
   ],
-  "fingerprint": "bbfbb43200775b0f3c673b4454ec8c6258ea81c540218c05dbdb1052a5a5e707",
+  "fingerprint": "b30383a659bb3e6d75d5b392b5e7437d6aca35451185b7122ea9d65f7b2e45ac",
   "mapping_policy": {
     "level": "module",
     "note": "Schema associations are module-level only; no DTO-to-table or member-to-column structural equivalence is claimed.",
@@ -5392,7 +5392,7 @@
       "contract_sets": [
         "all-contracts"
       ],
-      "fingerprint": "e098327131b50ba22e6bf6c8e7f0eb31c9ae03a904bb2b97c8938824e351ea9a",
+      "fingerprint": "1c74f4f8c687870486c311e25ff0a9f2a65d79c3b0befccaccb75d311eb5c423",
       "mapped_schemas": [],
       "namespace": "Meridian.Contracts.Workstation",
       "object_ids": [
@@ -309256,7 +309256,7 @@
       "diagram": false,
       "diagram_contract_sets": [],
       "enum_members": [],
-      "fingerprint": "e3d7e55f3c9e556f05e0421ec266d5222b9fb3347665bcaed38990ee5b6b6f6c",
+      "fingerprint": "4aa19a0410368e6c8077f1f6707c083f917aed8b2ce9f10ee2a31f086a42e7da",
       "full_name": "Meridian.Contracts.Workstation.StatementFetchScheduleDto",
       "id": "Meridian.Contracts.Workstation.StatementFetchScheduleDto",
       "kind": "record",
@@ -309423,6 +309423,20 @@
           "json_ignored": false,
           "json_name": null,
           "key_type": null,
+          "name": "SourceKind",
+          "nullable": false,
+          "origin": "positional_parameter",
+          "raw_type": "string",
+          "source_line": 167,
+          "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
           "name": "ToleranceProfileId",
           "nullable": false,
           "origin": "positional_parameter",
@@ -309458,7 +309472,7 @@
       "diagram": false,
       "diagram_contract_sets": [],
       "enum_members": [],
-      "fingerprint": "ebb5d6b952e92fd4cf50431f7b105b0e922d084d57b4a5804949bc904091a00d",
+      "fingerprint": "f5f54bce33b818f13527ff64b887848b2c2ac59018e3a56f25c524e8865d892b",
       "full_name": "Meridian.Contracts.Workstation.StatementFetchScheduleUpsertRequestDto",
       "id": "Meridian.Contracts.Workstation.StatementFetchScheduleUpsertRequestDto",
       "kind": "record",
@@ -309475,7 +309489,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "int",
-          "source_line": 176,
+          "source_line": 177,
           "type": "int"
         },
         {
@@ -309489,7 +309503,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 170,
+          "source_line": 171,
           "type": "string"
         },
         {
@@ -309503,7 +309517,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "bool",
-          "source_line": 177,
+          "source_line": 178,
           "type": "bool"
         },
         {
@@ -309517,7 +309531,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 171,
+          "source_line": 172,
           "type": "string"
         },
         {
@@ -309531,7 +309545,7 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 172,
+          "source_line": 173,
           "type": "string"
         },
         {
@@ -309545,7 +309559,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 174,
+          "source_line": 175,
           "type": "string?"
         },
         {
@@ -309559,7 +309573,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 169,
+          "source_line": 170,
           "type": "string?"
         },
         {
@@ -309573,8 +309587,23 @@
           "nullable": false,
           "origin": "positional_parameter",
           "raw_type": "string",
-          "source_line": 173,
+          "source_line": 174,
           "type": "string"
+        },
+        {
+          "collection": false,
+          "collection_kind": null,
+          "default": "null",
+          "element_type": null,
+          "json_ignored": false,
+          "json_name": null,
+          "key_type": null,
+          "name": "SourceKind",
+          "nullable": true,
+          "origin": "positional_parameter",
+          "raw_type": "string?",
+          "source_line": 179,
+          "type": "string?"
         },
         {
           "collection": false,
@@ -309587,7 +309616,7 @@
           "nullable": true,
           "origin": "positional_parameter",
           "raw_type": "string?",
-          "source_line": 175,
+          "source_line": 176,
           "type": "string?"
         }
       ],
@@ -309597,12 +309626,12 @@
       "qualified_name": "Meridian.Contracts.Workstation.StatementFetchScheduleUpsertRequestDto",
       "references": [],
       "source": {
-        "line": 168,
+        "line": 169,
         "path": "src/Meridian.Contracts/Workstation/StatementConnectorDtos.cs"
       },
       "sources": [
         {
-          "line": 168,
+          "line": 169,
           "path": "src/Meridian.Contracts/Workstation/StatementConnectorDtos.cs"
         }
       ],

--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -1045,6 +1045,8 @@ Meridian-main
 │   │   └── __init__.py
 │   ├── rules
 │   │   └── doc-rules.yaml
+│   ├── schema-control
+│   │   └── migrations.json
 │   └── scripts
 │       ├── ai
 │       │   ├── tests
@@ -6165,10 +6167,14 @@ Meridian-main
 │   │   │   │   │   ├── settings-screen.view-model.ts
 │   │   │   │   │   ├── settings-screen.workflow-continuity.ts
 │   │   │   │   │   ├── settings-task-chooser.tsx
+│   │   │   │   │   ├── statement-fetch-panel.test.tsx
+│   │   │   │   │   ├── statement-fetch-panel.tsx
+│   │   │   │   │   ├── statement-fetch-panel.view-model.ts
 │   │   │   │   │   ├── statement-import-panel.test.tsx
 │   │   │   │   │   ├── statement-import-panel.tsx
 │   │   │   │   │   ├── statement-import-panel.view-model.test.ts
 │   │   │   │   │   ├── statement-import-panel.view-model.ts
+│   │   │   │   │   ├── statement-import-preview.tsx
 │   │   │   │   │   ├── statement-import-screen.tsx
 │   │   │   │   │   ├── strategy-designer-screen.test.tsx
 │   │   │   │   │   ├── strategy-designer-screen.tsx

--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -1045,8 +1045,6 @@ Meridian-main
 │   │   └── __init__.py
 │   ├── rules
 │   │   └── doc-rules.yaml
-│   ├── schema-control
-│   │   └── migrations.json
 │   └── scripts
 │       ├── ai
 │       │   ├── tests

--- a/docs/operators/reconciliation-operations.md
+++ b/docs/operators/reconciliation-operations.md
@@ -2,7 +2,7 @@
 
 **Status:** active
 **Owner:** core-team
-**Reviewed:** 2026-05-31
+**Reviewed:** 2026-07-18
 
 This lane is the canonical operator procedure page for reconciliation exception response, recovery prioritization, and evidence capture.
 
@@ -31,6 +31,29 @@ This lane is the canonical operator procedure page for reconciliation exception 
    - command history and operator actions.
 5. Escalate for approval/reopen only when automated recovery would alter authoritative records.
 
+## Import Broker Or Custodian Statements
+
+1. Open `Accounting` -> `Import statement`.
+2. Choose the source path:
+   - `File upload` for CSV, OFX/QFX, IB Flex XML, or connector JSON; or
+   - `Scheduled fetch` for a fetch-capable provider connection such as Alpaca.
+3. Review the detected canonical columns, per-column confidence, position/transaction/cash/fee/
+   dividend record counts, sample rows, mapping-profile suggestion, and format-drift warnings.
+4. For a new CSV or OFX layout, clone or create a declarative mapping profile, edit its field aliases
+   and activity codes, save it, and confirm that live preview is ready before commit. This does not
+   require a Meridian release.
+5. For file import, enter the institution, Meridian fund account, external account, and statement
+   period, then commit. For remote import, enter the same account scope, classify the statement as
+   `Broker` or `Custodian`, preview the provider data, then save a cadence or select `Run now` on an
+   existing schedule. Legacy schedules without this field remain classified as broker imports.
+6. Open the returned Evidence Vault route to inspect retained source/canonical proof and open the
+   returned reconciliation route for break or case review.
+
+Scheduled-fetch credentials remain in the existing provider credential vault. The statement screen
+never asks for, displays, or persists API keys. A transient fetch failure leaves the last successful
+watermark unchanged so the schedule remains retryable; the schedule row shows a stable failure type
+without exposing upstream exception text.
+
 ## Mandatory Checks
 
 - Confirm provider/provider-connection state is current.
@@ -46,6 +69,8 @@ This lane is the canonical operator procedure page for reconciliation exception 
 dotnet run --project src/Meridian/Meridian.csproj -- --mode workstation --http-port 8080
 curl http://localhost:8080/api/workstation/operator/inbox
 curl http://localhost:8080/api/workstation/reconciliation/queue
+curl http://localhost:8080/api/workstation/reconciliation/statement-connectors
+curl http://localhost:8080/api/workstation/reconciliation/statement-fetch-schedules
 ```
 
 - Support recovery commands follow per-provider policy in

--- a/docs/roadmap/data/roadmap-items.yml
+++ b/docs/roadmap/data/roadmap-items.yml
@@ -428,7 +428,7 @@ items:
     health: green
     priority: high
     evidence_posture: complete
-    current_summary: Delivered 2026-07-02. Statement connectors ship as data, not code - declarative versioned CSV/OFX mapping-profile documents (operator-editable, atomic-write persisted, drift-detected), an IB Flex Report XML connector, an OFX 1.x/2.x bank and investment connector, and a fetch-capable Alpaca activity plus portfolio connector reusing the existing brokerage gateway and credential vault. Every connector classifies transactional, position, cash-balance, fee, and dividend data into canonical records, previews per-column mapping confidence and per-kind record breakdowns, and commits deterministically rendered canonical-CSV artifacts through the existing statement-run workflow into the reconciliation queue. Scheduled fetches run through persisted schedules with duplicate-key idempotency; the Accounting workspace gains an Import Statement surface with a live mapping-profile editor.
+    current_summary: Delivered 2026-07-02 and completed operator scheduled-fetch coverage 2026-07-18. Statement connectors ship as data, not code - declarative versioned CSV/OFX mapping-profile documents (operator-editable, atomic-write persisted, drift-detected), an IB Flex Report XML connector, an OFX 1.x/2.x bank and investment connector, and a fetch-capable Alpaca activity plus portfolio connector reusing the existing brokerage gateway and credential vault. Every connector classifies transactional, position, cash-balance, fee, and dividend data into canonical records, previews per-column mapping confidence and per-kind record breakdowns, and commits deterministically rendered canonical-CSV artifacts through the existing statement-run workflow into the reconciliation queue. The Accounting Import Statement surface now accepts file upload or remote provider preview, provides a live mapping-profile editor, and lets operators create, edit, pause, delete, refresh, and run persisted broker- or custodian-classified fetch schedules. Duplicate-key idempotency is preserved; transient scheduled-fetch failures do not advance the successful watermark or expose exception messages.
     exit_criteria:
       - Operators onboard a new custodian CSV or OFX layout by authoring a mapping profile document without a release.
       - Statement imports preview detected columns with per-column mapping confidence and per-kind (position, transaction, cash, fee, dividend) record breakdowns before commit.
@@ -465,7 +465,11 @@ items:
         path: tests/Meridian.Tests/Reconciliation/Connectors/OfxStatementConnectorTests.cs
       - type: test
         path: tests/Meridian.Tests/Reconciliation/Connectors/AlpacaActivityStatementConnectorTests.cs
-    last_reviewed: 2026-07-02
+      - type: source
+        path: src/Meridian.Ui/dashboard/src/screens/statement-fetch-panel.tsx
+      - type: test
+        path: src/Meridian.Ui/dashboard/src/screens/statement-fetch-panel.test.tsx
+    last_reviewed: 2026-07-18
 
   - id: W5X-EVIDENCE-001
     title: Evidence Vault productization

--- a/docs/roadmap/generated/MANIFEST.json
+++ b/docs/roadmap/generated/MANIFEST.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "docs/roadmap/data/roadmap-items.yml",
-      "sha256": "f8b2dd38bf5c80a6bff728be69923f29b6befef19bec579b4d52ccbd65bccb9b"
+      "sha256": "d72f600eea3ae8fd8562e035f8fc106796f8485f925b109a81596ffa74a94232"
     },
     {
       "path": "docs/roadmap/data/stage-gates.yml",
@@ -36,7 +36,7 @@
     },
     {
       "path": "docs/roadmap/generated/roadmap-register.md",
-      "sha256": "884ccc6d366eeb268f39aacde1d303e05e8a0160693a140bcd60ae2443d21ed7"
+      "sha256": "c990c39a54f26c093989126c9e130611557e70e26b9ecc448346f11d3ba0e4fd"
     },
     {
       "path": "docs/status/ROADMAP_SUMMARY.md",

--- a/docs/roadmap/generated/roadmap-register.md
+++ b/docs/roadmap/generated/roadmap-register.md
@@ -259,11 +259,11 @@ Completed the shared multi-asset operations proof lane by exposing Security Mast
 | Priority | high |
 | Owner lane | Accounting and Ledger |
 | Evidence posture | complete |
-| Last reviewed | 2026-07-02 |
+| Last reviewed | 2026-07-18 |
 
 ### Current Summary
 
-Delivered 2026-07-02. Statement connectors ship as data, not code - declarative versioned CSV/OFX mapping-profile documents (operator-editable, atomic-write persisted, drift-detected), an IB Flex Report XML connector, an OFX 1.x/2.x bank and investment connector, and a fetch-capable Alpaca activity plus portfolio connector reusing the existing brokerage gateway and credential vault. Every connector classifies transactional, position, cash-balance, fee, and dividend data into canonical records, previews per-column mapping confidence and per-kind record breakdowns, and commits deterministically rendered canonical-CSV artifacts through the existing statement-run workflow into the reconciliation queue. Scheduled fetches run through persisted schedules with duplicate-key idempotency; the Accounting workspace gains an Import Statement surface with a live mapping-profile editor.
+Delivered 2026-07-02 and completed operator scheduled-fetch coverage 2026-07-18. Statement connectors ship as data, not code - declarative versioned CSV/OFX mapping-profile documents (operator-editable, atomic-write persisted, drift-detected), an IB Flex Report XML connector, an OFX 1.x/2.x bank and investment connector, and a fetch-capable Alpaca activity plus portfolio connector reusing the existing brokerage gateway and credential vault. Every connector classifies transactional, position, cash-balance, fee, and dividend data into canonical records, previews per-column mapping confidence and per-kind record breakdowns, and commits deterministically rendered canonical-CSV artifacts through the existing statement-run workflow into the reconciliation queue. The Accounting Import Statement surface now accepts file upload or remote provider preview, provides a live mapping-profile editor, and lets operators create, edit, pause, delete, refresh, and run persisted broker- or custodian-classified fetch schedules. Duplicate-key idempotency is preserved; transient scheduled-fetch failures do not advance the successful watermark or expose exception messages.
 
 ### Exit Criteria
 

--- a/docs/source/data/source-modules.yml
+++ b/docs/source/data/source-modules.yml
@@ -109,7 +109,7 @@ modules:
     diagrams:
       - DIA-ASSURANCE-LOOP
     todos: []
-    last_reviewed: 2026-07-15
+    last_reviewed: 2026-07-18
 
   - id: SRC-CORE
     path: src/Meridian.Core
@@ -742,7 +742,7 @@ modules:
     diagrams:
       - DIA-ASSURANCE-LOOP
     todos: []
-    last_reviewed: 2026-07-02
+    last_reviewed: 2026-07-18
 
   - id: SRC-DESIGN-WORKFLOW
     path: src/Meridian.Workflow
@@ -870,7 +870,7 @@ modules:
     diagrams:
       - DIA-BROWSER-WORKSTATION
     todos: []
-    last_reviewed: 2026-06-09
+    last_reviewed: 2026-07-18
 
   - id: SRC-UI-SERVICES
     path: src/Meridian.Ui.Services
@@ -929,7 +929,7 @@ modules:
     diagrams:
       - DIA-BROWSER-WORKSTATION
     todos: []
-    last_reviewed: 2026-07-15
+    last_reviewed: 2026-07-18
 
   - id: SRC-UI-DASHBOARD
     path: src/Meridian.Ui/dashboard
@@ -965,7 +965,7 @@ modules:
       - DIA-BROWSER-WORKSTATION-ROUTES
     todos:
       - TODO-SRC-UI-DASHBOARD-001
-    last_reviewed: 2026-07-15
+    last_reviewed: 2026-07-18
 
   - id: SRC-WPF
     path: src/Meridian.Wpf

--- a/docs/source/generated/MANIFEST.json
+++ b/docs/source/generated/MANIFEST.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "docs/source/data/source-modules.yml",
-      "sha256": "a5292c9f09626b8699246aeb47a07e4485748836eef6cd93b29982a56caa710b"
+      "sha256": "330b82e94ac9cdcc763751fe9f9e892e1239c12fdd44a4e690e5e11f5aa59d0a"
     },
     {
       "path": "docs/source/data/source-readme-coverage.yml",

--- a/docs/source/generated/source-hash-manifest.json
+++ b/docs/source/generated/source-hash-manifest.json
@@ -30,8 +30,8 @@
       "id": "SRC-CONTRACTS",
       "path": "src/Meridian.Contracts",
       "readme": "src/Meridian.Contracts/README.md",
-      "readme_hash": "6afbf81bb265e9345e935eb22fdbd748cae2d72d1b39055f4e68d8dc9610cfb7",
-      "source_hash": "9f3958c86e47dc77414fd946688898d91f63c477eb813c6ddaa2f551a425f706"
+      "readme_hash": "74f4bddbc53eea8aa3dfc9354fb1da53c8f2650699e4023986a30cb9c3cdea08",
+      "source_hash": "255ddf8987df786f00bbd7523c6d59486b314d758438445031fce06e12057d83"
     },
     {
       "id": "SRC-CORE",
@@ -72,8 +72,8 @@
       "id": "SRC-DESIGN-FINANCIAL-OPERATIONS",
       "path": "src/Meridian.FinancialOperations",
       "readme": "src/Meridian.FinancialOperations/README.md",
-      "readme_hash": "9f23fd7c50b3f24bfdfde28d1036e1284da77894b15b5cba933ddb16e15fb5be",
-      "source_hash": "804583afeeb84c60bdec9b61c7b6dbd06072c3c541f9b6c45d2a383618f70fa9"
+      "readme_hash": "2214e1ea4c223b95fc028f378a42951abc91a11da4e2fd9cab84ecfda2c4fe2a",
+      "source_hash": "602185a393aa8da9c82308cc7e0c3818e15d8cab68267670ecc1f9618ea4d7aa"
     },
     {
       "id": "SRC-DESIGN-IDENTITY",
@@ -254,15 +254,15 @@
       "id": "SRC-UI",
       "path": "src/Meridian.Ui",
       "readme": "src/Meridian.Ui/README.md",
-      "readme_hash": "4b0a1b5f08e83ae83e98a33da71bcc83d054de1bf238d2fe4ca022fe8707344b",
-      "source_hash": "ad55885b246b40ce2a6e9161880f14513637220605b65c6338af5adb7246ae6d"
+      "readme_hash": "722e4dd3f90bb6f460426bec4698fe1b7f810afce6dc87743eefe40279581e6c",
+      "source_hash": "1bca99c8a38c99c80fd3e4929271dbfa8550bf306229fe687f642b2a06f231cf"
     },
     {
       "id": "SRC-UI-DASHBOARD",
       "path": "src/Meridian.Ui/dashboard",
       "readme": "src/Meridian.Ui/dashboard/README.md",
-      "readme_hash": "74ec07759234a76e226fc8594a8101ad2ae9317c4d21c556a408a84cebab9d92",
-      "source_hash": "ad55885b246b40ce2a6e9161880f14513637220605b65c6338af5adb7246ae6d"
+      "readme_hash": "2915ff7af2787175d21f3d4685524bfcfa628b4987911616f035180dcca57c5d",
+      "source_hash": "1bca99c8a38c99c80fd3e4929271dbfa8550bf306229fe687f642b2a06f231cf"
     },
     {
       "id": "SRC-UI-SERVICES",
@@ -275,8 +275,8 @@
       "id": "SRC-UI-SHARED",
       "path": "src/Meridian.Ui.Shared",
       "readme": "src/Meridian.Ui.Shared/README.md",
-      "readme_hash": "ead9364f02f1221fa33aa80e1067034cfad119c7a4ff464f729ce3801921a06c",
-      "source_hash": "92b5e3cfc435eae72165eccff09b79b96e02d3b47f017c10f2ac3cbc33d6df90"
+      "readme_hash": "cc1a3a92c0986cb355761aaf3cd6c4a87091bdb6dbeafec481a540f9835f253c",
+      "source_hash": "fd12b21df7113e39bb331801a7c4049df200911b048227c9a3404f305e4aa7a9"
     },
     {
       "id": "SRC-WPF",

--- a/docs/status/TODO.md
+++ b/docs/status/TODO.md
@@ -189,10 +189,10 @@ Total items: **217**
 | `src/Meridian.Ui/dashboard/src/screens/w4-acceptance-parity.test.ts` | 437 | `NOTE` | ❌ | note: "Published to investor portal." |
 | `src/Meridian.Ui/dashboard/src/types/reporting-governance.ts` | 124 | `NOTE` | ❌ | note: string \| null; |
 | `src/Meridian.Ui/dashboard/src/types/workstation-3.ts` | 1055 | `NOTE` | ❌ | note: string; |
-| `src/Meridian.Ui/dashboard/src/types/workstation-4.ts` | 650 | `NOTE` | ❌ | note: string \| null; |
-| `src/Meridian.Ui/dashboard/src/types/workstation-4.ts` | 1006 | `NOTE` | ❌ | note: string \| null; |
-| `src/Meridian.Ui/dashboard/src/types/workstation-4.ts` | 1057 | `NOTE` | ❌ | note: string \| null; |
-| `src/Meridian.Ui/dashboard/src/types/workstation-4.ts` | 1398 | `NOTE` | ❌ | note: string \| null; |
+| `src/Meridian.Ui/dashboard/src/types/workstation-4.ts` | 652 | `NOTE` | ❌ | note: string \| null; |
+| `src/Meridian.Ui/dashboard/src/types/workstation-4.ts` | 1008 | `NOTE` | ❌ | note: string \| null; |
+| `src/Meridian.Ui/dashboard/src/types/workstation-4.ts` | 1059 | `NOTE` | ❌ | note: string \| null; |
+| `src/Meridian.Ui/dashboard/src/types/workstation-4.ts` | 1400 | `NOTE` | ❌ | note: string \| null; |
 | `src/Meridian.Wpf/GlobalUsings.cs` | 7 | `NOTE` | ❌ | // NOTE: Type aliases and Contracts namespaces are NOT re-defined here because |
 | `src/Meridian.Wpf/ViewModels/SecurityPassportEditorViewModel.cs` | 262 | `NOTE` | ❌ | Note: null, |
 | `tests/Meridian.Tests/Application/Backfill/BackfillWorkerServiceTests.cs` | 28 | `NOTE` | ❌ | // NOTE: Using null! because validation throws before dependencies are accessed |

--- a/docs/status/api-contract-coverage-dashboard.json
+++ b/docs/status/api-contract-coverage-dashboard.json
@@ -6891,7 +6891,7 @@
     },
     {
       "name": "StatementFetchScheduleUpsertRequestDto",
-      "source": "src/Meridian.Contracts/Workstation/StatementConnectorDtos.cs:167",
+      "source": "src/Meridian.Contracts/Workstation/StatementConnectorDtos.cs:168",
       "documented": false
     },
     {

--- a/docs/status/api-contract-coverage-dashboard.md
+++ b/docs/status/api-contract-coverage-dashboard.md
@@ -1270,7 +1270,7 @@ Tracks whether mapped API routes and workstation DTO contracts are visible in th
 | `StatementColumnMappingDto` | Gap | `src/Meridian.Contracts/Workstation/StatementConnectorDtos.cs:57` |
 | `StatementConnectorDescriptorDto` | Gap | `src/Meridian.Contracts/Workstation/StatementConnectorDtos.cs:9` |
 | `StatementFetchScheduleDto` | Gap | `src/Meridian.Contracts/Workstation/StatementConnectorDtos.cs:154` |
-| `StatementFetchScheduleUpsertRequestDto` | Gap | `src/Meridian.Contracts/Workstation/StatementConnectorDtos.cs:167` |
+| `StatementFetchScheduleUpsertRequestDto` | Gap | `src/Meridian.Contracts/Workstation/StatementConnectorDtos.cs:168` |
 | `StatementImportCommitResultDto` | Gap | `src/Meridian.Contracts/Workstation/StatementConnectorDtos.cs:116` |
 | `StatementImportIssueDto` | Gap | `src/Meridian.Contracts/Workstation/StatementConnectorDtos.cs:64` |
 | `StatementImportPreviewDto` | Gap | `src/Meridian.Contracts/Workstation/StatementConnectorDtos.cs:101` |

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,12 +1,12 @@
 {
-  "total_files": 624,
-  "total_lines": 112212,
-  "orphaned_count": 244,
+  "total_files": 659,
+  "total_lines": 122012,
+  "orphaned_count": 246,
   "no_heading_count": 148,
   "stale_count": 0,
   "todo_count": 205,
-  "average_lines": 179.8,
-  "health_score": 80,
+  "average_lines": 185.1,
+  "health_score": 81,
   "orphaned_files": [
     ".agents/skills/meridian-archive-organizer/SKILL.md",
     ".agents/skills/meridian-blueprint/SKILL.md",
@@ -236,6 +236,8 @@
     "docs/source/source-readme-template.md",
     "docs/source/source-todo-standard.md",
     "docs/testing/wave2-cockpit-reliability-evidence-runbook.md",
+    "output/schema-control-29654725912/candidate/reports/schema-diff.md",
+    "output/schema-control-29654725912/candidate/reports/summary.md",
     "plugins/frontend-web-dev/agents/electron-angular-native.md",
     "plugins/frontend-web-dev/agents/expert-react-frontend-engineer.md",
     "plugins/frontend-web-dev/skills/playwright-explore-website/SKILL.md",
@@ -2511,7 +2513,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 9158,
+      "line_count": 9164,
       "has_heading": true,
       "todo_count": 8,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -2719,7 +2721,7 @@
     },
     {
       "path": "docs/operators/reconciliation-operations.md",
-      "line_count": 65,
+      "line_count": 90,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -4710,6 +4712,286 @@
       "stale": false
     },
     {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/asset-operations-contracts.md",
+      "line_count": 432,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/banking-contracts.md",
+      "line_count": 82,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/direct-lending-contracts-page-01.md",
+      "line_count": 675,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/direct-lending-contracts-page-02.md",
+      "line_count": 176,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/direct-lending-contracts.md",
+      "line_count": 13,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/fund-governance-contracts-page-01.md",
+      "line_count": 747,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/fund-governance-contracts-page-02.md",
+      "line_count": 617,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/fund-governance-contracts.md",
+      "line_count": 13,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/identity-access-contracts.md",
+      "line_count": 316,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/ledger-contracts-page-01.md",
+      "line_count": 800,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/ledger-contracts-page-02.md",
+      "line_count": 764,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/ledger-contracts-page-03.md",
+      "line_count": 763,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/ledger-contracts-page-04.md",
+      "line_count": 490,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/ledger-contracts.md",
+      "line_count": 15,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/money-market-contracts.md",
+      "line_count": 24,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/reporting-contracts.md",
+      "line_count": 186,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/security-master-contracts-page-01.md",
+      "line_count": 533,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/security-master-contracts-page-02.md",
+      "line_count": 616,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/security-master-contracts-page-03.md",
+      "line_count": 84,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/contracts/security-master-contracts.md",
+      "line_count": 14,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/data-object-catalog.md",
+      "line_count": 39,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/modules/asset_operations.md",
+      "line_count": 199,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/modules/banking.md",
+      "line_count": 52,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/modules/fund_accounts.md",
+      "line_count": 214,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/modules/fund_structure.md",
+      "line_count": 179,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/modules/identity_access.md",
+      "line_count": 50,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/modules/ledger.md",
+      "line_count": 310,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/modules/money_market.md",
+      "line_count": 50,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/modules/public.md",
+      "line_count": 17,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/modules/reporting.md",
+      "line_count": 201,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/modules/security_master.md",
+      "line_count": 1007,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/README.md",
+      "line_count": 8,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/docs/schema-catalog.md",
+      "line_count": 22,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/reports/schema-diff.md",
+      "line_count": 25,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
+      "path": "output/schema-control-29654725912/candidate/reports/summary.md",
+      "line_count": 18,
+      "has_heading": true,
+      "todo_count": 0,
+      "last_modified_utc": "1970-01-01T00:00:00+00:00",
+      "stale": false
+    },
+    {
       "path": "plugins/frontend-web-dev/agents/electron-angular-native.md",
       "line_count": 286,
       "has_heading": true,
@@ -4895,7 +5177,7 @@
     },
     {
       "path": "src/Meridian.Contracts/README.md",
-      "line_count": 1396,
+      "line_count": 1400,
       "has_heading": true,
       "todo_count": 3,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -4959,7 +5241,7 @@
     },
     {
       "path": "src/Meridian.FinancialOperations/README.md",
-      "line_count": 566,
+      "line_count": 568,
       "has_heading": true,
       "todo_count": 1,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -5151,7 +5433,7 @@
     },
     {
       "path": "src/Meridian.Ui.Shared/README.md",
-      "line_count": 1955,
+      "line_count": 1958,
       "has_heading": true,
       "todo_count": 3,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -5159,7 +5441,7 @@
     },
     {
       "path": "src/Meridian.Ui/dashboard/README.md",
-      "line_count": 1305,
+      "line_count": 1311,
       "has_heading": true,
       "todo_count": 4,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -5183,7 +5465,7 @@
     },
     {
       "path": "src/Meridian.Ui/README.md",
-      "line_count": 99,
+      "line_count": 102,
       "has_heading": true,
       "todo_count": 1,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,12 +1,12 @@
 {
-  "total_files": 659,
-  "total_lines": 122012,
-  "orphaned_count": 246,
+  "total_files": 624,
+  "total_lines": 112259,
+  "orphaned_count": 244,
   "no_heading_count": 148,
   "stale_count": 0,
   "todo_count": 205,
-  "average_lines": 185.1,
-  "health_score": 81,
+  "average_lines": 179.9,
+  "health_score": 80,
   "orphaned_files": [
     ".agents/skills/meridian-archive-organizer/SKILL.md",
     ".agents/skills/meridian-blueprint/SKILL.md",
@@ -236,8 +236,6 @@
     "docs/source/source-readme-template.md",
     "docs/source/source-todo-standard.md",
     "docs/testing/wave2-cockpit-reliability-evidence-runbook.md",
-    "output/schema-control-29654725912/candidate/reports/schema-diff.md",
-    "output/schema-control-29654725912/candidate/reports/summary.md",
     "plugins/frontend-web-dev/agents/electron-angular-native.md",
     "plugins/frontend-web-dev/agents/expert-react-frontend-engineer.md",
     "plugins/frontend-web-dev/skills/playwright-explore-website/SKILL.md",
@@ -2513,7 +2511,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 9164,
+      "line_count": 9162,
       "has_heading": true,
       "todo_count": 8,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",
@@ -4706,286 +4704,6 @@
     {
       "path": "Meridian Design System/VISUAL_FOUNDATIONS.md",
       "line_count": 74,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/asset-operations-contracts.md",
-      "line_count": 432,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/banking-contracts.md",
-      "line_count": 82,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/direct-lending-contracts-page-01.md",
-      "line_count": 675,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/direct-lending-contracts-page-02.md",
-      "line_count": 176,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/direct-lending-contracts.md",
-      "line_count": 13,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/fund-governance-contracts-page-01.md",
-      "line_count": 747,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/fund-governance-contracts-page-02.md",
-      "line_count": 617,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/fund-governance-contracts.md",
-      "line_count": 13,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/identity-access-contracts.md",
-      "line_count": 316,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/ledger-contracts-page-01.md",
-      "line_count": 800,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/ledger-contracts-page-02.md",
-      "line_count": 764,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/ledger-contracts-page-03.md",
-      "line_count": 763,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/ledger-contracts-page-04.md",
-      "line_count": 490,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/ledger-contracts.md",
-      "line_count": 15,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/money-market-contracts.md",
-      "line_count": 24,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/reporting-contracts.md",
-      "line_count": 186,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/security-master-contracts-page-01.md",
-      "line_count": 533,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/security-master-contracts-page-02.md",
-      "line_count": 616,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/security-master-contracts-page-03.md",
-      "line_count": 84,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/contracts/security-master-contracts.md",
-      "line_count": 14,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/data-object-catalog.md",
-      "line_count": 39,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/modules/asset_operations.md",
-      "line_count": 199,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/modules/banking.md",
-      "line_count": 52,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/modules/fund_accounts.md",
-      "line_count": 214,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/modules/fund_structure.md",
-      "line_count": 179,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/modules/identity_access.md",
-      "line_count": 50,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/modules/ledger.md",
-      "line_count": 310,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/modules/money_market.md",
-      "line_count": 50,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/modules/public.md",
-      "line_count": 17,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/modules/reporting.md",
-      "line_count": 201,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/modules/security_master.md",
-      "line_count": 1007,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/README.md",
-      "line_count": 8,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/docs/schema-catalog.md",
-      "line_count": 22,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/reports/schema-diff.md",
-      "line_count": 25,
-      "has_heading": true,
-      "todo_count": 0,
-      "last_modified_utc": "1970-01-01T00:00:00+00:00",
-      "stale": false
-    },
-    {
-      "path": "output/schema-control-29654725912/candidate/reports/summary.md",
-      "line_count": 18,
       "has_heading": true,
       "todo_count": 0,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -11,7 +11,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 ## Overall Health Score
 
 ```text
-  [########################------] 81/100
+  [########################------] 80/100
   Rating: Good
 ```
 
@@ -19,14 +19,14 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 
 | Metric | Value |
 | -------- | ------- |
-| Total documentation files | 659 |
-| Total lines | 122,012 |
-| Average file size (lines) | 185.1 |
-| Orphaned files | 246 |
+| Total documentation files | 624 |
+| Total lines | 112,259 |
+| Average file size (lines) | 179.9 |
+| Orphaned files | 244 |
 | Files without headings | 148 |
 | Stale files (>90 days) | 0 |
 | TODO/FIXME markers | 205 |
-| **Health score** | **81/100** |
+| **Health score** | **80/100** |
 
 ### Score Breakdown
 
@@ -85,7 +85,7 @@ These files are not linked from any other Markdown file in the repository:
 - `Meridian Design System/SKILL.md`
 - `Meridian Design System/VISUAL_FOUNDATIONS.md`
 - `Meridian Design System/components/accounting/AccountTree.prompt.md`
-- ... and 226 more
+- ... and 224 more
 
 ## Trend
 
@@ -93,7 +93,7 @@ These files are not linked from any other Markdown file in the repository:
 
 | Date | Score | Files | Orphans | Stale |
 | ------ | ------- | ------- | --------- | ------- |
-| 1970-01-01 | 81 | 659 | 246 | 0 |
+| 1970-01-01 | 80 | 624 | 244 | 0 |
 
 ---
 

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -11,7 +11,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 ## Overall Health Score
 
 ```text
-  [########################------] 80/100
+  [########################------] 81/100
   Rating: Good
 ```
 
@@ -19,14 +19,14 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 
 | Metric | Value |
 | -------- | ------- |
-| Total documentation files | 624 |
-| Total lines | 112,212 |
-| Average file size (lines) | 179.8 |
-| Orphaned files | 244 |
+| Total documentation files | 659 |
+| Total lines | 122,012 |
+| Average file size (lines) | 185.1 |
+| Orphaned files | 246 |
 | Files without headings | 148 |
 | Stale files (>90 days) | 0 |
 | TODO/FIXME markers | 205 |
-| **Health score** | **80/100** |
+| **Health score** | **81/100** |
 
 ### Score Breakdown
 
@@ -85,7 +85,7 @@ These files are not linked from any other Markdown file in the repository:
 - `Meridian Design System/SKILL.md`
 - `Meridian Design System/VISUAL_FOUNDATIONS.md`
 - `Meridian Design System/components/accounting/AccountTree.prompt.md`
-- ... and 224 more
+- ... and 226 more
 
 ## Trend
 
@@ -93,7 +93,7 @@ These files are not linked from any other Markdown file in the repository:
 
 | Date | Score | Files | Orphans | Stale |
 | ------ | ------- | ------- | --------- | ------- |
-| 1970-01-01 | 80 | 624 | 244 | 0 |
+| 1970-01-01 | 81 | 659 | 246 | 0 |
 
 ---
 

--- a/src/Meridian.Contracts/README.md
+++ b/src/Meridian.Contracts/README.md
@@ -872,6 +872,10 @@ links with break id, route, status, priority, reason, and suggested next action 
 Vault identity, Evidence Workbench route, reconciliation route, and operator next actions so browser
 and WPF clients can deep-link into the exact casework opened by the statement run without relying on
 parallel arrays.
+The same additive contract family carries persisted statement-fetch schedule and upsert payloads.
+Schedules expose an explicit `SourceKind` (`broker` or `custodian`) so background imports preserve
+the same reconciliation classification as file imports; omitted values on older upsert clients and
+persisted snapshots default to `broker` for compatibility.
 Direct Lending servicer statement intake contracts live under
 `DirectLending/DirectLendingWorkflowDtos.cs`. They publish shared preview/import/apply request and
 result payloads, row-level validation issues, statement kind/status/apply-mode enums, and retained

--- a/src/Meridian.Contracts/Workstation/StatementConnectorDtos.cs
+++ b/src/Meridian.Contracts/Workstation/StatementConnectorDtos.cs
@@ -163,7 +163,8 @@ public sealed record StatementFetchScheduleDto(
     bool Enabled,
     DateTimeOffset? LastRunAtUtc,
     string? LastRunStatus,
-    DateTimeOffset? NextDueAtUtc);
+    DateTimeOffset? NextDueAtUtc,
+    string SourceKind);
 
 public sealed record StatementFetchScheduleUpsertRequestDto(
     string? ScheduleId,
@@ -174,4 +175,5 @@ public sealed record StatementFetchScheduleUpsertRequestDto(
     string? MappingProfileId,
     string? ToleranceProfileId,
     int CadenceHours,
-    bool Enabled);
+    bool Enabled,
+    string? SourceKind = null);

--- a/src/Meridian.FinancialOperations/README.md
+++ b/src/Meridian.FinancialOperations/README.md
@@ -79,7 +79,9 @@ This module belongs to the Design Module layer. Keep changes within that ownersh
   statement-run workflow (positions, transactions, cash balances, fees, and dividends all
   classify per kind), returning retained break ids plus structured reconciliation case links for
   the opened reconciliation work while retaining legacy case id/route arrays for compatibility; and
-  persisted fetch schedules with an idempotent schedule runner.
+  persisted broker/custodian-classified fetch schedules with an idempotent schedule runner whose
+  transient failures retain a stable non-sensitive status without advancing the last-successful-fetch
+  watermark.
 - `Banking/` - payment initiation, approval/rejection workflow, bank-side transaction records,
   deterministic transaction seeding, and PostgreSQL-backed banking persistence adapter.
 
@@ -89,7 +91,7 @@ Use this README to understand the module before editing source files. Update the
 
 Statement reconciliation also lives here. Broker/custodian statement intake, mapping profiles, validation, duplicate detection, matching, break classification, reconciliation decision journals, statement-run persistence, and durable case materialization are Financial Operations behavior. Application commands and shared UI services invoke the module workflow, but they do not own reconciliation state, matching rules, or statement-run persistence.
 
-The statement connector library (`Reconciliation/Connectors/`, ADR-018) extends that intake seam: connectors parse CSV, OFX, IB Flex XML, and Alpaca snapshot sources into canonical records classified per kind (position, transaction, cash balance, fee, dividend), driven by declarative, operator-editable mapping-profile documents rather than code. Commit renders a deterministic canonical-CSV artifact and hands it to `IStatementRunWorkflowService`, so the downstream matching, break, and case pipeline is unchanged and duplicate-key idempotency is preserved. Profiles record the last accepted column layout for format-drift warnings, and fetch-capable connectors reuse the existing brokerage gateways and provider credential store — never a new secret store.
+The statement connector library (`Reconciliation/Connectors/`, ADR-018) extends that intake seam: connectors parse CSV, OFX, IB Flex XML, and Alpaca snapshot sources into canonical records classified per kind (position, transaction, cash balance, fee, dividend), driven by declarative, operator-editable mapping-profile documents rather than code. Commit renders a deterministic canonical-CSV artifact and hands it to `IStatementRunWorkflowService`, so the downstream matching, break, and case pipeline is unchanged and duplicate-key idempotency is preserved. Profiles record the last accepted column layout for format-drift warnings, and fetch-capable connectors reuse the existing brokerage gateways and provider credential store — never a new secret store. Persisted schedules retain an explicit broker/custodian source classification, support operator run-now and background cadence, and default legacy snapshots to broker; a failed fetch records only the exception type, preserves the prior success watermark, and remains due for safe retry.
 The commit result also carries the specific break ids and structured reconciliation case links
 created by the Financial Operations workflow, including each case route, status, priority, reason,
 and suggested next action, allowing Evidence Vault and browser clients to point operators directly

--- a/src/Meridian.FinancialOperations/Reconciliation/Connectors/StatementFetchScheduleRunner.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/Connectors/StatementFetchScheduleRunner.cs
@@ -64,7 +64,7 @@ public sealed class StatementFetchScheduleRunner(
                     new StatementImportCommitRequest(
                         document,
                         schedule.ConnectorId,
-                        SourceKind: "broker",
+                        SourceKind: schedule.SourceKind,
                         SourceInstitution: schedule.SourceInstitution,
                         FundAccountId: schedule.FundAccountId,
                         ExternalAccountId: schedule.ExternalAccountId,
@@ -89,7 +89,11 @@ public sealed class StatementFetchScheduleRunner(
                 schedule.ScheduleId,
                 schedule.ConnectorId,
                 schedule.ExternalAccountId);
-            await scheduleStore.RecordRunAsync(schedule.ScheduleId, nowUtc, $"Failed: {ex.Message}", ct).ConfigureAwait(false);
+            await scheduleStore.RecordFailureAsync(
+                    schedule.ScheduleId,
+                    $"Failed: {ex.GetType().Name}",
+                    ct)
+                .ConfigureAwait(false);
             return null;
         }
     }

--- a/src/Meridian.FinancialOperations/Reconciliation/Connectors/StatementFetchScheduleStore.cs
+++ b/src/Meridian.FinancialOperations/Reconciliation/Connectors/StatementFetchScheduleStore.cs
@@ -17,7 +17,8 @@ public sealed record StatementFetchSchedule(
     int CadenceHours,
     bool Enabled,
     DateTimeOffset? LastRunAtUtc = null,
-    string? LastRunStatus = null)
+    string? LastRunStatus = null,
+    string SourceKind = "broker")
 {
     public DateTimeOffset? NextDueAtUtc =>
         !Enabled ? null : LastRunAtUtc?.AddHours(Math.Max(1, CadenceHours));
@@ -40,6 +41,7 @@ public interface IStatementFetchScheduleStore
     Task<StatementFetchSchedule> UpsertAsync(StatementFetchSchedule schedule, CancellationToken ct = default);
     Task<bool> DeleteAsync(string scheduleId, CancellationToken ct = default);
     Task RecordRunAsync(string scheduleId, DateTimeOffset ranAtUtc, string status, CancellationToken ct = default);
+    Task RecordFailureAsync(string scheduleId, string status, CancellationToken ct = default);
 }
 
 /// <summary>
@@ -72,7 +74,8 @@ public sealed class FileStatementFetchScheduleStore
         {
             ScheduleId = string.IsNullOrWhiteSpace(schedule.ScheduleId)
                 ? Guid.NewGuid().ToString("N")
-                : schedule.ScheduleId.Trim()
+                : schedule.ScheduleId.Trim(),
+            SourceKind = schedule.SourceKind.Trim().ToLowerInvariant()
         };
 
         return await UpdateSnapshotAsync(snapshot =>
@@ -135,6 +138,28 @@ public sealed class FileStatementFetchScheduleStore
         }, ct).ConfigureAwait(false);
     }
 
+    public async Task RecordFailureAsync(string scheduleId, string status, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scheduleId);
+        await UpdateSnapshotAsync(snapshot =>
+        {
+            var existing = snapshot.Schedules.FirstOrDefault(candidate =>
+                string.Equals(candidate.ScheduleId, scheduleId.Trim(), StringComparison.OrdinalIgnoreCase));
+            if (existing is null)
+            {
+                return snapshot;
+            }
+
+            var updated = existing with { LastRunStatus = status };
+            var retained = snapshot.Schedules
+                .Select(candidate => string.Equals(candidate.ScheduleId, updated.ScheduleId, StringComparison.OrdinalIgnoreCase)
+                    ? updated
+                    : candidate)
+                .ToArray();
+            return new StatementFetchScheduleSnapshot(SnapshotVersion, retained);
+        }, ct).ConfigureAwait(false);
+    }
+
     protected override StatementFetchScheduleSnapshot CreateEmptySnapshot() => new(SnapshotVersion, []);
 
     protected override StatementFetchScheduleSnapshot OnSnapshotLoaded(StatementFetchScheduleSnapshot snapshot)
@@ -167,6 +192,12 @@ public sealed class FileStatementFetchScheduleStore
         if (schedule.CadenceHours < 1)
         {
             throw new InvalidDataException("Fetch schedule cadence must be at least one hour.");
+        }
+
+        if (!string.Equals(schedule.SourceKind, "broker", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(schedule.SourceKind, "custodian", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException("Fetch schedule source kind must be broker or custodian.");
         }
     }
 

--- a/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.StatementConnectors.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/WorkstationEndpoints.StatementConnectors.cs
@@ -352,7 +352,10 @@ public static partial class WorkstationEndpoints
                                 ? "statement-default"
                                 : request.ToleranceProfileId,
                             request.CadenceHours,
-                            request.Enabled),
+                            request.Enabled,
+                            SourceKind: string.IsNullOrWhiteSpace(request.SourceKind)
+                                ? "broker"
+                                : request.SourceKind),
                         context.RequestAborted)
                     .ConfigureAwait(false);
                 return Results.Json(ToScheduleDto(saved), jsonOptions);
@@ -561,5 +564,6 @@ public static partial class WorkstationEndpoints
             schedule.Enabled,
             schedule.LastRunAtUtc,
             schedule.LastRunStatus,
-            schedule.NextDueAtUtc);
+            schedule.NextDueAtUtc,
+            schedule.SourceKind);
 }

--- a/src/Meridian.Ui.Shared/README.md
+++ b/src/Meridian.Ui.Shared/README.md
@@ -69,7 +69,10 @@ supported local-workstation HTTP binding omits that flag only when both ends of 
 loopback, allowing the packaged browser login to return its `SameSite=Strict` cookies on localhost.
 
 Preserve cross-surface compatibility when evolving shared read models. Keep ledger/reconciliation
-source-of-truth services authoritative. `SecurityMasterWorkbenchQueryService` is published under
+source-of-truth services authoritative. Statement connector endpoints expose file and remote
+preview plus persisted fetch-schedule CRUD/run operations over shared DTOs; schedule upserts default
+an omitted source kind to `broker`, while explicit `custodian` values pass unchanged into Financial
+Operations. `SecurityMasterWorkbenchQueryService` is published under
 `Meridian.Ui.Shared.Services` and composes Application Security Master services into the shared
 workstation drill-in projection. `FamilyOfficeReadService` composes the family-office
 workstation overview from fund-structure, fund-account, reconciliation, and strategy-run read

--- a/src/Meridian.Ui/README.md
+++ b/src/Meridian.Ui/README.md
@@ -36,6 +36,9 @@ state so host-served workstation assets retain the same financial-operations flo
 The dashboard Accounting Closeout trail also mirrors the design-document Financial Operations flow:
 `Receive Activity`, `Match Records`, `Resolve Exceptions`, `Approve Results`, and `Produce Evidence`.
 The browser Accounting screen renders that same lane above its detailed closeout panels.
+The Accounting `Import statement` route supports file upload and provider-backed scheduled fetches,
+including canonical confidence preview, broker/custodian classification, and direct Evidence Vault
+and reconciliation-queue handoff; persistence and import policy remain server-owned.
 The dashboard Reporting workspace owns schedule draft/save, pause/resume, and single-schedule run
 controls. Persistence and release-gated delivery remain server-owned, and due schedules are leased
 only by the hosted reporting worker; the browser has no public batch due-run control.

--- a/src/Meridian.Ui/dashboard/README.md
+++ b/src/Meridian.Ui/dashboard/README.md
@@ -111,11 +111,17 @@ browser renders retained documents with classification, source hash, typed chann
 tenant/scope, extraction status, reviewer state, linked operational objects, open support-request
 count, support-only authority posture, and manifest links, while keeping intake and readiness policy
 in shared contracts/endpoints.
-Statement import commit results render the shared Evidence Vault identity, Evidence Workbench route,
-reconciliation route, and structured reconciliation case links directly from the commit response,
-including status, priority, reason, and suggested next action. The browser blocks commit while
-preview errors remain, so operators can move from imported custodian/broker source to retained
-proof and exact casework without browser-local routing rules or avoidable server rejections.
+Statement import accepts either a bounded file upload or a remote fetch through a fetch-capable
+provider connection. The scheduled-fetch tab previews remote activity with the same canonical
+column-confidence and per-kind breakdown as file import, then lets operators create, edit, pause,
+delete, refresh, or run persisted schedules with an explicit broker/custodian classification without
+collecting credentials in the browser. Run-now
+results render the shared Evidence Vault and reconciliation routes. File-import commit results also
+render Evidence Vault identity, the Evidence Workbench route, reconciliation route, and structured
+reconciliation case links directly from the commit response, including status, priority, reason,
+and suggested next action. The browser blocks file commit while preview errors remain, so operators
+can move from imported custodian/broker source to retained proof and exact casework without
+browser-local routing rules or avoidable server rejections.
 The request-list queue renders typed close, audit, tax, report-package, and operational-event family
 badges beside each frozen support list so operators can distinguish close binder blockers from audit
 or report-support package gaps without parsing manifest JSON.

--- a/src/Meridian.Ui/dashboard/src/screens/statement-fetch-panel.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/statement-fetch-panel.test.tsx
@@ -1,0 +1,237 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "jest-axe";
+import { describe, expect, it, vi } from "vitest";
+import { StatementFetchPanel } from "@/screens/statement-fetch-panel";
+import {
+  validateStatementFetchDraft,
+  type StatementFetchDraft,
+  type StatementFetchPanelServices
+} from "@/screens/statement-fetch-panel.view-model";
+import { renderWithRouter } from "@/test/render";
+import type {
+  StatementConnectorDescriptor,
+  StatementFetchSchedule,
+  StatementImportCommitResult,
+  StatementImportPreview,
+  StatementMappingProfile
+} from "@/types";
+
+const connectors: StatementConnectorDescriptor[] = [
+  {
+    connectorId: "alpaca-activity",
+    displayName: "Alpaca account activity",
+    fileExtensions: [".json"],
+    supportsFileImport: true,
+    supportsRemoteFetch: true,
+    requiresMappingProfile: false,
+    defaultProfileId: "alpaca-activity-v1"
+  },
+  {
+    connectorId: "csv-mapped",
+    displayName: "Mapped CSV",
+    fileExtensions: [".csv"],
+    supportsFileImport: true,
+    supportsRemoteFetch: false,
+    requiresMappingProfile: true,
+    defaultProfileId: "canonical-csv-v1"
+  }
+];
+
+const profiles: StatementMappingProfile[] = [
+  {
+    schemaVersion: 1,
+    profileId: "alpaca-activity-v1",
+    displayName: "Alpaca activity",
+    format: "json",
+    csv: null,
+    culture: null,
+    dateFormats: null,
+    fields: [],
+    activityCodes: [],
+    lastAcceptedFingerprint: null,
+    isBuiltIn: true,
+    notes: null
+  }
+];
+
+const preview: StatementImportPreview = {
+  connectorId: "alpaca-activity",
+  connectorDisplayName: "Alpaca account activity",
+  profileId: "alpaca-activity-v1",
+  fileName: "alpaca-PA3ALPACA01-20260718.json",
+  fileSizeBytes: 512,
+  detectedColumns: ["activity_type", "symbol", "qty"],
+  columnMappings: [
+    { sourceColumn: "activity_type", canonicalField: "ActivityType", confidence: "Alias", score: 0.95, rationale: "Known Alpaca alias." },
+    { sourceColumn: "symbol", canonicalField: "SecurityIdentifier", confidence: "Exact", score: 1, rationale: "Exact field." },
+    { sourceColumn: "qty", canonicalField: "Quantity", confidence: "Alias", score: 0.9, rationale: "Known Alpaca alias." }
+  ],
+  recordCount: 2,
+  kindSummaries: [
+    {
+      kind: "Transaction",
+      recordCount: 2,
+      sampleRecords: [
+        {
+          kind: "Transaction",
+          account: "PA3ALPACA01",
+          symbol: "AAPL",
+          quantity: 2,
+          price: 190,
+          cashAmount: -380,
+          activityType: "Buy",
+          tradeDate: "2026-07-17",
+          settlementDate: null,
+          currency: "USD",
+          feesCommission: 0,
+          externalTransactionId: "alpaca-activity-1"
+        }
+      ]
+    }
+  ],
+  issues: [],
+  profileSuggestions: [],
+  status: "ReadyToImport",
+  nextAction: "Save or run the schedule to import these records."
+};
+
+const schedule: StatementFetchSchedule = {
+  scheduleId: "alpaca-daily",
+  connectorId: "alpaca-activity",
+  externalAccountId: "PA3ALPACA01",
+  fundAccountId: "FUND-ALPHA-BROKERAGE",
+  sourceInstitution: "Alpaca",
+  mappingProfileId: "alpaca-activity-v1",
+  toleranceProfileId: "statement-default",
+  cadenceHours: 24,
+  enabled: true,
+  lastRunAtUtc: "2026-07-17T06:00:00Z",
+  lastRunStatus: "Imported run stmt-run-88: 2 record(s), 1 case(s).",
+  nextDueAtUtc: "2026-07-18T06:00:00Z",
+  sourceKind: "broker"
+};
+
+const runResult: StatementImportCommitResult = {
+  runId: "stmt-run-99",
+  duplicate: false,
+  recordCount: 2,
+  kindSummaries: preview.kindSummaries,
+  breakCount: 1,
+  caseCount: 1,
+  retainedSourcePath: "reconciliation/statement-connector-imports/stmt-run-99/alpaca.json",
+  retainedCanonicalPath: "reconciliation/statement-connector-imports/stmt-run-99/canonical.csv",
+  status: "Imported",
+  nextAction: "Review the reconciliation queue.",
+  evidenceWorkbenchRoute: "/accounting/evidence?subjectId=stmt-run-99",
+  reconciliationRoute: "/accounting/reconciliation/match?runId=stmt-run-99"
+};
+
+function makeServices(): StatementFetchPanelServices {
+  return {
+    deleteSchedule: vi.fn(async () => undefined),
+    fetchPreview: vi.fn(async () => preview),
+    listSchedules: vi.fn(async () => [schedule]),
+    runSchedule: vi.fn(async () => runResult),
+    upsertSchedule: vi.fn(async (request) => ({
+      ...schedule,
+      ...request,
+      scheduleId: request.scheduleId ?? "generated-schedule"
+    }))
+  };
+}
+
+const validDraft: StatementFetchDraft = {
+  cadenceHours: "24",
+  connectorId: "alpaca-activity",
+  datasets: "all",
+  enabled: true,
+  externalAccountId: "PA3ALPACA01",
+  fundAccountId: "FUND-ALPHA-BROKERAGE",
+  mappingProfileId: "alpaca-activity-v1",
+  scheduleId: "alpaca-daily",
+  sinceDate: "2026-07-17",
+  sourceInstitution: "Alpaca",
+  sourceKind: "broker",
+  toleranceProfileId: "statement-default"
+};
+
+describe("validateStatementFetchDraft", () => {
+  it("requires a remote connector and reconciliation scope before scheduling", () => {
+    expect(validateStatementFetchDraft(validDraft, connectors, "schedule")).toEqual({});
+    expect(validateStatementFetchDraft({
+      ...validDraft,
+      cadenceHours: "0",
+      connectorId: "csv-mapped",
+      externalAccountId: "",
+      fundAccountId: "",
+      sourceInstitution: ""
+    }, connectors, "schedule")).toMatchObject({
+      cadenceHours: expect.any(String),
+      connectorId: expect.any(String),
+      externalAccountId: expect.any(String),
+      fundAccountId: expect.any(String),
+      sourceInstitution: expect.any(String)
+    });
+  });
+});
+
+describe("StatementFetchPanel", () => {
+  it("previews provider activity with canonical mapping confidence and stays accessible", async () => {
+    const user = userEvent.setup();
+    const services = makeServices();
+    const { container } = renderWithRouter(
+      <StatementFetchPanel connectors={connectors} profiles={profiles} services={services} />,
+      { initialEntries: ["/accounting/statement-import"] }
+    );
+
+    await waitFor(() => expect(screen.getByRole("table", { name: "Statement fetch schedules" })).toBeInTheDocument());
+    await user.type(screen.getByLabelText("External account"), "PA3ALPACA01");
+    await user.click(screen.getByRole("button", { name: "Preview remote statement" }));
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: `Preview: ${preview.fileName}` })).toBeInTheDocument());
+    expect(screen.getByRole("table", { name: "Statement column mappings" })).toHaveTextContent("Alias");
+    expect(services.fetchPreview).toHaveBeenCalledWith(expect.objectContaining({
+      connectorId: "alpaca-activity",
+      externalAccountId: "PA3ALPACA01",
+      datasets: "all"
+    }));
+
+    const results = await axe(container);
+    expect(results.violations).toHaveLength(0);
+  });
+
+  it("edits, saves, runs, and deletes persisted schedules", async () => {
+    const user = userEvent.setup();
+    const services = makeServices();
+    renderWithRouter(
+      <StatementFetchPanel connectors={connectors} profiles={profiles} services={services} />,
+      { initialEntries: ["/accounting/statement-import"] }
+    );
+
+    await waitFor(() => expect(screen.getByRole("table", { name: "Statement fetch schedules" })).toBeInTheDocument());
+    await user.click(screen.getByRole("button", { name: "Edit schedule alpaca-daily" }));
+    expect(screen.getByLabelText("Fund account")).toHaveValue("FUND-ALPHA-BROKERAGE");
+    await user.selectOptions(screen.getByLabelText("Statement source"), "custodian");
+    await user.click(screen.getByRole("button", { name: "Save fetch schedule" }));
+    await waitFor(() => expect(screen.getByText("Statement fetch schedule saved")).toBeInTheDocument());
+    expect(services.upsertSchedule).toHaveBeenCalledWith(expect.objectContaining({
+      scheduleId: "alpaca-daily",
+      connectorId: "alpaca-activity",
+      cadenceHours: 24,
+      enabled: true,
+      sourceKind: "custodian"
+    }));
+
+    await user.click(screen.getByRole("button", { name: "Run schedule alpaca-daily" }));
+    await waitFor(() => expect(screen.getByText("Scheduled statement imported")).toBeInTheDocument());
+    expect(screen.getByRole("link", { name: /Open reconciliation queue/ })).toHaveAttribute(
+      "href",
+      "/accounting/reconciliation/match?runId=stmt-run-99"
+    );
+
+    await user.click(screen.getByRole("button", { name: "Delete schedule alpaca-daily" }));
+    await waitFor(() => expect(screen.queryByRole("table", { name: "Statement fetch schedules" })).not.toBeInTheDocument());
+    expect(services.deleteSchedule).toHaveBeenCalledWith("alpaca-daily");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/screens/statement-fetch-panel.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/statement-fetch-panel.tsx
@@ -1,0 +1,434 @@
+import { ArrowRight, Play, Plus, RefreshCw, Trash2 } from "lucide-react";
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
+import { StatusBanner } from "@/components/ui/status-banner";
+import type { ApiErrorDisplay } from "@/lib/api-errors";
+import { WORKSTATION_ROUTE_CATALOG } from "@/lib/workspace";
+import {
+  useStatementFetchPanelViewModel,
+  type StatementFetchDraftField,
+  type StatementFetchPanelServices
+} from "@/screens/statement-fetch-panel.view-model";
+import { StatementImportPreviewDetails } from "@/screens/statement-import-preview";
+import type { StatementConnectorDescriptor, StatementMappingProfile } from "@/types";
+
+export interface StatementFetchPanelProps {
+  connectors: StatementConnectorDescriptor[];
+  profiles: StatementMappingProfile[];
+  services?: Partial<StatementFetchPanelServices>;
+}
+
+export function StatementFetchPanel({ connectors, profiles, services }: StatementFetchPanelProps) {
+  const viewModel = useStatementFetchPanelViewModel({ connectors, profiles, services });
+
+  if (viewModel.remoteConnectors.length === 0) {
+    return (
+      <StatusBanner
+        tone="warning"
+        title="No remote statement connector is available"
+        detail="Configure a fetch-capable broker connection, such as Alpaca, or use the file upload path. Credentials stay in the existing provider vault."
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Remote statement preview and schedule</CardTitle>
+          <CardDescription>
+            Fetch broker or custodian activity through the existing provider connection, inspect the canonical mapping, then save a recurring schedule or run it now. No credentials are stored in this workflow.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-5">
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <FetchField label="Fetch connector" field="connectorId" error={viewModel.draftErrors.connectorId}>
+              <Select
+                id="statement-fetch-connector-id"
+                value={viewModel.draft.connectorId}
+                aria-invalid={Boolean(viewModel.draftErrors.connectorId)}
+                aria-describedby={viewModel.draftErrors.connectorId ? "statement-fetch-connector-id-error" : undefined}
+                onChange={(event) => viewModel.updateDraft("connectorId", event.target.value)}
+              >
+                {viewModel.remoteConnectors.map((connector) => (
+                  <option key={connector.connectorId} value={connector.connectorId}>{connector.displayName}</option>
+                ))}
+              </Select>
+            </FetchField>
+            <FetchField label="External account" field="externalAccountId" error={viewModel.draftErrors.externalAccountId}>
+              <Input
+                id="statement-fetch-external-account-id"
+                value={viewModel.draft.externalAccountId}
+                aria-invalid={Boolean(viewModel.draftErrors.externalAccountId)}
+                aria-describedby={viewModel.draftErrors.externalAccountId ? "statement-fetch-external-account-id-error" : undefined}
+                onChange={(event) => viewModel.updateDraft("externalAccountId", event.target.value)}
+                placeholder="PA3ALPACA01"
+              />
+            </FetchField>
+            <FetchField label="Mapping profile" field="mappingProfileId">
+              <Select
+                id="statement-fetch-mapping-profile-id"
+                value={viewModel.draft.mappingProfileId}
+                onChange={(event) => viewModel.updateDraft("mappingProfileId", event.target.value)}
+              >
+                <option value="">Connector default</option>
+                {viewModel.profiles.map((profile) => (
+                  <option key={profile.profileId} value={profile.profileId}>
+                    {profile.displayName}{profile.isBuiltIn ? " (built-in)" : ""}
+                  </option>
+                ))}
+              </Select>
+            </FetchField>
+            <FetchField label="Fetch from" field="sinceDate" error={viewModel.draftErrors.sinceDate}>
+              <Input
+                id="statement-fetch-since-date"
+                type="date"
+                value={viewModel.draft.sinceDate}
+                aria-invalid={Boolean(viewModel.draftErrors.sinceDate)}
+                aria-describedby={viewModel.draftErrors.sinceDate ? "statement-fetch-since-date-error" : undefined}
+                onChange={(event) => viewModel.updateDraft("sinceDate", event.target.value)}
+              />
+            </FetchField>
+            <FetchField label="Preview datasets" field="datasets">
+              <Select
+                id="statement-fetch-datasets"
+                value={viewModel.draft.datasets}
+                onChange={(event) => viewModel.updateDraft("datasets", event.target.value as "activity" | "positions" | "all")}
+              >
+                <option value="all">Activity and positions</option>
+                <option value="activity">Account activity</option>
+                <option value="positions">Current positions</option>
+              </Select>
+            </FetchField>
+          </div>
+
+          {viewModel.previewError ? <FetchError title="Remote statement preview failed" error={viewModel.previewError} /> : null}
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              busy={viewModel.previewBusy}
+              busyLabel="Fetching preview…"
+              disabled={!viewModel.canPreview}
+              disabledReason={viewModel.previewDisabledReason ?? undefined}
+              onClick={() => void viewModel.previewFetch()}
+            >
+              Preview remote statement
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              Preview is read-only. Only a saved schedule run commits records into reconciliation.
+            </span>
+          </div>
+
+          <div className="border-t border-border pt-5">
+            <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h3 className="text-sm font-semibold">Schedule configuration</h3>
+                <p className="text-xs text-muted-foreground">Leave schedule id blank to create a new schedule.</p>
+              </div>
+              <Button type="button" size="sm" variant="outline" onClick={viewModel.newSchedule}>
+                <Plus className="size-3.5" aria-hidden="true" />
+                New schedule
+              </Button>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              <FetchField label="Schedule id" field="scheduleId">
+                <Input
+                  id="statement-fetch-schedule-id"
+                  value={viewModel.draft.scheduleId}
+                  onChange={(event) => viewModel.updateDraft("scheduleId", event.target.value)}
+                  placeholder="Generated when blank"
+                />
+              </FetchField>
+              <FetchField label="Fund account" field="fundAccountId" error={viewModel.draftErrors.fundAccountId}>
+                <Input
+                  id="statement-fetch-fund-account-id"
+                  value={viewModel.draft.fundAccountId}
+                  aria-invalid={Boolean(viewModel.draftErrors.fundAccountId)}
+                  aria-describedby={viewModel.draftErrors.fundAccountId ? "statement-fetch-fund-account-id-error" : undefined}
+                  onChange={(event) => viewModel.updateDraft("fundAccountId", event.target.value)}
+                  placeholder="FUND-ALPHA-BROKERAGE"
+                />
+              </FetchField>
+              <FetchField label="Source institution" field="sourceInstitution" error={viewModel.draftErrors.sourceInstitution}>
+                <Input
+                  id="statement-fetch-source-institution"
+                  value={viewModel.draft.sourceInstitution}
+                  aria-invalid={Boolean(viewModel.draftErrors.sourceInstitution)}
+                  aria-describedby={viewModel.draftErrors.sourceInstitution ? "statement-fetch-source-institution-error" : undefined}
+                  onChange={(event) => viewModel.updateDraft("sourceInstitution", event.target.value)}
+                  placeholder="Alpaca"
+                />
+              </FetchField>
+              <FetchField label="Statement source" field="sourceKind">
+                <Select
+                  id="statement-fetch-source-kind"
+                  value={viewModel.draft.sourceKind}
+                  onChange={(event) => viewModel.updateDraft("sourceKind", event.target.value as "broker" | "custodian")}
+                >
+                  <option value="broker">Broker</option>
+                  <option value="custodian">Custodian</option>
+                </Select>
+              </FetchField>
+              <FetchField label="Tolerance profile" field="toleranceProfileId">
+                <Input
+                  id="statement-fetch-tolerance-profile-id"
+                  value={viewModel.draft.toleranceProfileId}
+                  onChange={(event) => viewModel.updateDraft("toleranceProfileId", event.target.value)}
+                />
+              </FetchField>
+              <FetchField label="Cadence (hours)" field="cadenceHours" error={viewModel.draftErrors.cadenceHours}>
+                <Input
+                  id="statement-fetch-cadence-hours"
+                  type="number"
+                  min="1"
+                  step="1"
+                  value={viewModel.draft.cadenceHours}
+                  aria-invalid={Boolean(viewModel.draftErrors.cadenceHours)}
+                  aria-describedby={viewModel.draftErrors.cadenceHours ? "statement-fetch-cadence-hours-error" : undefined}
+                  onChange={(event) => viewModel.updateDraft("cadenceHours", event.target.value)}
+                />
+              </FetchField>
+              <div className="flex items-end pb-2">
+                <Checkbox
+                  id="statement-fetch-enabled"
+                  checked={viewModel.draft.enabled}
+                  onCheckedChange={(checked) => viewModel.updateDraft("enabled", checked)}
+                  label="Enable automatic fetches"
+                />
+              </div>
+            </div>
+          </div>
+
+          {viewModel.saveError ? <FetchError title="Schedule save failed" error={viewModel.saveError} /> : null}
+          {viewModel.saveMessage ? <StatusBanner tone="success" title="Statement fetch schedule saved" detail={viewModel.saveMessage} /> : null}
+          <div>
+            <Button
+              type="button"
+              busy={viewModel.saveBusy}
+              busyLabel="Saving schedule…"
+              disabled={!viewModel.canSave}
+              disabledReason={viewModel.saveDisabledReason ?? undefined}
+              onClick={() => void viewModel.saveSchedule()}
+            >
+              Save fetch schedule
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {viewModel.preview ? (
+        <StatementImportPreviewDetails
+          preview={viewModel.preview}
+          selectedKind={viewModel.selectedKind}
+          onSelectKind={viewModel.selectKind}
+        />
+      ) : null}
+
+      <StatementFetchSchedulesTable viewModel={viewModel} />
+      <StatementFetchRunResult viewModel={viewModel} />
+    </div>
+  );
+}
+
+function FetchField({
+  children,
+  error,
+  field,
+  label
+}: {
+  children: ReactNode;
+  error?: string;
+  field: StatementFetchDraftField;
+  label: string;
+}) {
+  const id = `statement-fetch-${toKebabCase(field)}`;
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      {children}
+      {error ? <p id={`${id}-error`} className="text-xs text-danger" role="alert">{error}</p> : null}
+    </div>
+  );
+}
+
+function StatementFetchSchedulesTable({
+  viewModel
+}: {
+  viewModel: ReturnType<typeof useStatementFetchPanelViewModel>;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle>Saved statement fetch schedules</CardTitle>
+            <CardDescription>Run a schedule now, edit its configuration, or remove it.</CardDescription>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            busy={viewModel.loading}
+            busyLabel="Refreshing…"
+            onClick={() => void viewModel.refreshSchedules()}
+          >
+            <RefreshCw className="size-3.5" aria-hidden="true" />
+            Refresh
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {viewModel.loadError ? <FetchError title="Schedule list failed" error={viewModel.loadError} /> : null}
+        {viewModel.runError ? <FetchError title="Scheduled statement run failed" error={viewModel.runError} /> : null}
+        {viewModel.deleteError ? <FetchError title="Schedule delete failed" error={viewModel.deleteError} /> : null}
+        {!viewModel.loading && viewModel.schedules.length === 0 ? (
+          <StatusBanner
+            tone="info"
+            title="No schedules configured"
+            detail="Complete the fetch and reconciliation fields above, then save the first statement schedule."
+          />
+        ) : null}
+        {viewModel.schedules.length > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse text-xs" aria-label="Statement fetch schedules">
+              <caption className="sr-only">Persisted remote statement fetch schedules and run posture</caption>
+              <thead>
+                <tr className="border-b border-border text-left font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                  <th scope="col" className="px-2 py-2">Schedule</th>
+                  <th scope="col" className="px-2 py-2">Account</th>
+                  <th scope="col" className="px-2 py-2">Cadence</th>
+                  <th scope="col" className="px-2 py-2">Last result</th>
+                  <th scope="col" className="px-2 py-2">Next due</th>
+                  <th scope="col" className="px-2 py-2 text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {viewModel.schedules.map((schedule) => (
+                  <tr key={schedule.scheduleId} className="border-b border-border/60 align-top">
+                    <td className="px-2 py-2">
+                      <div className="font-mono font-semibold">{schedule.scheduleId}</div>
+                      <div className="mt-1 flex flex-wrap gap-1.5">
+                        <Badge variant={schedule.enabled ? "success" : "outline"}>{schedule.enabled ? "Enabled" : "Paused"}</Badge>
+                        <Badge variant="paper">{schedule.connectorId}</Badge>
+                        <Badge variant="outline" className="capitalize">{schedule.sourceKind}</Badge>
+                      </div>
+                    </td>
+                    <td className="px-2 py-2">
+                      <div>{schedule.sourceInstitution}</div>
+                      <div className="font-mono text-muted-foreground">{schedule.externalAccountId}</div>
+                      <div className="font-mono text-muted-foreground">{schedule.fundAccountId}</div>
+                    </td>
+                    <td className="px-2 py-2 font-mono">Every {schedule.cadenceHours}h</td>
+                    <td className="max-w-64 px-2 py-2">
+                      <div>{schedule.lastRunStatus ?? "Not run"}</div>
+                      <div className="font-mono text-[10px] text-muted-foreground">{formatTimestamp(schedule.lastRunAtUtc)}</div>
+                    </td>
+                    <td className="px-2 py-2 font-mono">{formatTimestamp(schedule.nextDueAtUtc)}</td>
+                    <td className="px-2 py-2">
+                      <div className="flex flex-wrap justify-end gap-1.5">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          aria-label={`Edit schedule ${schedule.scheduleId}`}
+                          onClick={() => viewModel.editSchedule(schedule)}
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          aria-label={`Run schedule ${schedule.scheduleId}`}
+                          busy={viewModel.runBusyId === schedule.scheduleId}
+                          busyLabel="Running…"
+                          onClick={() => void viewModel.runSchedule(schedule.scheduleId)}
+                        >
+                          <Play className="size-3.5" aria-hidden="true" />
+                          Run now
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          aria-label={`Delete schedule ${schedule.scheduleId}`}
+                          busy={viewModel.deleteBusyId === schedule.scheduleId}
+                          busyLabel="Deleting…"
+                          onClick={() => void viewModel.deleteSchedule(schedule.scheduleId)}
+                        >
+                          <Trash2 className="size-3.5" aria-hidden="true" />
+                          Delete
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function StatementFetchRunResult({
+  viewModel
+}: {
+  viewModel: ReturnType<typeof useStatementFetchPanelViewModel>;
+}) {
+  const result = viewModel.runResult;
+  if (!result) {
+    return null;
+  }
+
+  const reconciliationRoute = result.reconciliationRoute ?? WORKSTATION_ROUTE_CATALOG.accountingReconciliationMatch;
+  const evidenceRoute = result.evidenceWorkbenchRoute ?? WORKSTATION_ROUTE_CATALOG.accountingEvidence;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{result.duplicate ? "Statement already imported" : "Scheduled statement imported"}</CardTitle>
+        <CardDescription>
+          Run {result.runId} {result.duplicate ? "matched retained evidence" : `committed ${result.recordCount} records`} with {result.breakCount} breaks and {result.caseCount} cases. {result.nextAction}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-wrap gap-2">
+        <Button asChild size="sm" variant="outline">
+          <Link to={evidenceRoute}>
+            Open Evidence Vault
+            <ArrowRight className="size-3.5" aria-hidden="true" />
+          </Link>
+        </Button>
+        <Button asChild size="sm">
+          <Link to={reconciliationRoute}>
+            Open reconciliation queue
+            <ArrowRight className="size-3.5" aria-hidden="true" />
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function FetchError({ error, title }: { error: ApiErrorDisplay; title: string }) {
+  const detail = [error.summary, ...error.details].filter(Boolean).join(" ");
+  return <StatusBanner tone="danger" title={title} detail={detail} />;
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) {
+    return "—";
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+function toKebabCase(value: string): string {
+  return value.replace(/[A-Z]/g, (character) => `-${character.toLowerCase()}`);
+}

--- a/src/Meridian.Ui/dashboard/src/screens/statement-fetch-panel.view-model.ts
+++ b/src/Meridian.Ui/dashboard/src/screens/statement-fetch-panel.view-model.ts
@@ -1,0 +1,418 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  deleteStatementFetchSchedule,
+  fetchStatementPreview,
+  listStatementFetchSchedules,
+  runStatementFetchSchedule,
+  upsertStatementFetchSchedule
+} from "@/lib/api";
+import { describeApiError, type ApiErrorDisplay } from "@/lib/api-errors";
+import type {
+  StatementConnectorDescriptor,
+  StatementFetchDatasets,
+  StatementFetchSchedule,
+  StatementFetchScheduleUpsertRequest,
+  StatementImportCommitResult,
+  StatementImportPreview,
+  StatementMappingProfile
+} from "@/types";
+
+export interface StatementFetchPanelServices {
+  deleteSchedule: typeof deleteStatementFetchSchedule;
+  fetchPreview: typeof fetchStatementPreview;
+  listSchedules: typeof listStatementFetchSchedules;
+  runSchedule: typeof runStatementFetchSchedule;
+  upsertSchedule: typeof upsertStatementFetchSchedule;
+}
+
+const DEFAULT_SERVICES: StatementFetchPanelServices = {
+  deleteSchedule: deleteStatementFetchSchedule,
+  fetchPreview: fetchStatementPreview,
+  listSchedules: listStatementFetchSchedules,
+  runSchedule: runStatementFetchSchedule,
+  upsertSchedule: upsertStatementFetchSchedule
+};
+
+export interface StatementFetchDraft {
+  cadenceHours: string;
+  connectorId: string;
+  datasets: StatementFetchDatasets;
+  enabled: boolean;
+  externalAccountId: string;
+  fundAccountId: string;
+  mappingProfileId: string;
+  scheduleId: string;
+  sinceDate: string;
+  sourceInstitution: string;
+  sourceKind: "broker" | "custodian";
+  toleranceProfileId: string;
+}
+
+export type StatementFetchDraftField = keyof StatementFetchDraft;
+export type StatementFetchDraftErrors = Partial<Record<StatementFetchDraftField, string>>;
+
+export interface StatementFetchPanelViewModel {
+  canPreview: boolean;
+  canSave: boolean;
+  deleteBusyId: string | null;
+  deleteError: ApiErrorDisplay | null;
+  draft: StatementFetchDraft;
+  draftErrors: StatementFetchDraftErrors;
+  editSchedule: (schedule: StatementFetchSchedule) => void;
+  loadError: ApiErrorDisplay | null;
+  loading: boolean;
+  newSchedule: () => void;
+  preview: StatementImportPreview | null;
+  previewBusy: boolean;
+  previewDisabledReason: string | null;
+  previewError: ApiErrorDisplay | null;
+  previewFetch: () => Promise<void>;
+  profiles: StatementMappingProfile[];
+  refreshSchedules: () => Promise<void>;
+  remoteConnectors: StatementConnectorDescriptor[];
+  runBusyId: string | null;
+  runError: ApiErrorDisplay | null;
+  runResult: StatementImportCommitResult | null;
+  runSchedule: (scheduleId: string) => Promise<void>;
+  saveBusy: boolean;
+  saveDisabledReason: string | null;
+  saveError: ApiErrorDisplay | null;
+  saveMessage: string | null;
+  saveSchedule: () => Promise<void>;
+  schedules: StatementFetchSchedule[];
+  selectedKind: string | null;
+  selectKind: (kind: string) => void;
+  deleteSchedule: (scheduleId: string) => Promise<void>;
+  updateDraft: <Field extends StatementFetchDraftField>(field: Field, value: StatementFetchDraft[Field]) => void;
+}
+
+export interface UseStatementFetchPanelOptions {
+  connectors: StatementConnectorDescriptor[];
+  profiles: StatementMappingProfile[];
+  services?: Partial<StatementFetchPanelServices>;
+}
+
+export function validateStatementFetchDraft(
+  draft: StatementFetchDraft,
+  connectors: StatementConnectorDescriptor[],
+  mode: "preview" | "schedule"
+): StatementFetchDraftErrors {
+  const errors: StatementFetchDraftErrors = {};
+  const connector = connectors.find((candidate) => candidate.connectorId === draft.connectorId);
+  if (!draft.connectorId.trim()) {
+    errors.connectorId = "Select a fetch-capable connector.";
+  } else if (!connector?.supportsRemoteFetch) {
+    errors.connectorId = "The selected connector does not support remote statement fetches.";
+  }
+
+  if (!draft.externalAccountId.trim()) {
+    errors.externalAccountId = "Enter the external broker or custodian account id.";
+  }
+
+  if (draft.sinceDate && !/^\d{4}-\d{2}-\d{2}$/.test(draft.sinceDate)) {
+    errors.sinceDate = "Fetch start must use YYYY-MM-DD format.";
+  }
+
+  if (mode === "schedule") {
+    if (!draft.fundAccountId.trim()) {
+      errors.fundAccountId = "Enter the Meridian fund account id.";
+    }
+    if (!draft.sourceInstitution.trim()) {
+      errors.sourceInstitution = "Enter the broker or custodian name.";
+    }
+
+    const cadence = Number(draft.cadenceHours);
+    if (!Number.isInteger(cadence) || cadence < 1) {
+      errors.cadenceHours = "Cadence must be a whole number of hours greater than zero.";
+    }
+  }
+
+  return errors;
+}
+
+export function useStatementFetchPanelViewModel({
+  connectors,
+  profiles,
+  services: serviceOverrides
+}: UseStatementFetchPanelOptions): StatementFetchPanelViewModel {
+  const services = useMemo(
+    () => ({ ...DEFAULT_SERVICES, ...serviceOverrides }),
+    [serviceOverrides]
+  );
+  const remoteConnectors = useMemo(
+    () => connectors.filter((connector) => connector.supportsRemoteFetch),
+    [connectors]
+  );
+  const [draft, setDraft] = useState<StatementFetchDraft>(() => createStatementFetchDraft([]));
+  const [draftErrors, setDraftErrors] = useState<StatementFetchDraftErrors>({});
+  const [schedules, setSchedules] = useState<StatementFetchSchedule[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<ApiErrorDisplay | null>(null);
+  const [preview, setPreview] = useState<StatementImportPreview | null>(null);
+  const [previewBusy, setPreviewBusy] = useState(false);
+  const [previewError, setPreviewError] = useState<ApiErrorDisplay | null>(null);
+  const [selectedKind, setSelectedKind] = useState<string | null>(null);
+  const [saveBusy, setSaveBusy] = useState(false);
+  const [saveError, setSaveError] = useState<ApiErrorDisplay | null>(null);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [runBusyId, setRunBusyId] = useState<string | null>(null);
+  const [runError, setRunError] = useState<ApiErrorDisplay | null>(null);
+  const [runResult, setRunResult] = useState<StatementImportCommitResult | null>(null);
+  const [deleteBusyId, setDeleteBusyId] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<ApiErrorDisplay | null>(null);
+
+  const refreshSchedules = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const next = await services.listSchedules();
+      setSchedules(sortSchedules(next));
+    } catch (error) {
+      setLoadError(describeApiError(error, "Statement fetch schedules failed to load."));
+    } finally {
+      setLoading(false);
+    }
+  }, [services]);
+
+  useEffect(() => {
+    void refreshSchedules();
+  }, [refreshSchedules]);
+
+  useEffect(() => {
+    if (draft.connectorId || remoteConnectors.length === 0) {
+      return;
+    }
+
+    setDraft((current) => createStatementFetchDraft(remoteConnectors, current));
+  }, [draft.connectorId, remoteConnectors]);
+
+  const updateDraft = useCallback(<Field extends StatementFetchDraftField>(
+    field: Field,
+    value: StatementFetchDraft[Field]
+  ) => {
+    setDraft((current) => {
+      const next = { ...current, [field]: value };
+      if (field === "connectorId") {
+        const connector = remoteConnectors.find((candidate) => candidate.connectorId === value);
+        next.mappingProfileId = connector?.defaultProfileId ?? "";
+        if (!next.sourceInstitution.trim() || current.sourceInstitution === currentConnectorName(current, remoteConnectors)) {
+          next.sourceInstitution = connector?.displayName ?? "";
+        }
+      }
+      return next;
+    });
+    setDraftErrors((current) => ({ ...current, [field]: undefined }));
+    setSaveMessage(null);
+    setSaveError(null);
+    if (["connectorId", "externalAccountId", "mappingProfileId", "sinceDate", "datasets"].includes(field)) {
+      setPreview(null);
+      setPreviewError(null);
+      setSelectedKind(null);
+    }
+  }, [remoteConnectors]);
+
+  const previewFetch = useCallback(async () => {
+    const errors = validateStatementFetchDraft(draft, remoteConnectors, "preview");
+    setDraftErrors(errors);
+    if (Object.keys(errors).length > 0) {
+      return;
+    }
+
+    setPreviewBusy(true);
+    setPreviewError(null);
+    setRunResult(null);
+    try {
+      const next = await services.fetchPreview({
+        connectorId: draft.connectorId.trim(),
+        externalAccountId: draft.externalAccountId.trim(),
+        mappingProfileId: draft.mappingProfileId.trim() || null,
+        since: draft.sinceDate ? `${draft.sinceDate}T00:00:00Z` : null,
+        datasets: draft.datasets
+      });
+      setPreview(next);
+      setSelectedKind(next.kindSummaries[0]?.kind ?? null);
+    } catch (error) {
+      setPreview(null);
+      setSelectedKind(null);
+      setPreviewError(describeApiError(error, "Remote statement preview failed."));
+    } finally {
+      setPreviewBusy(false);
+    }
+  }, [draft, remoteConnectors, services]);
+
+  const saveSchedule = useCallback(async () => {
+    const errors = validateStatementFetchDraft(draft, remoteConnectors, "schedule");
+    setDraftErrors(errors);
+    if (Object.keys(errors).length > 0) {
+      return;
+    }
+
+    setSaveBusy(true);
+    setSaveError(null);
+    setSaveMessage(null);
+    try {
+      const saved = await services.upsertSchedule(toScheduleRequest(draft));
+      setSchedules((current) => sortSchedules([
+        ...current.filter((schedule) => schedule.scheduleId !== saved.scheduleId),
+        saved
+      ]));
+      setDraft((current) => createStatementFetchDraft(remoteConnectors, current, saved));
+      setSaveMessage(`Schedule ${saved.scheduleId} saved. ${saved.enabled ? "Automatic fetches are enabled." : "The schedule is paused."}`);
+    } catch (error) {
+      setSaveError(describeApiError(error, "Statement fetch schedule could not be saved."));
+    } finally {
+      setSaveBusy(false);
+    }
+  }, [draft, remoteConnectors, services]);
+
+  const editSchedule = useCallback((schedule: StatementFetchSchedule) => {
+    setDraft((current) => createStatementFetchDraft(remoteConnectors, current, schedule));
+    setDraftErrors({});
+    setSaveError(null);
+    setSaveMessage(null);
+    setPreview(null);
+    setPreviewError(null);
+    setRunResult(null);
+  }, [remoteConnectors]);
+
+  const newSchedule = useCallback(() => {
+    setDraft(createStatementFetchDraft(remoteConnectors));
+    setDraftErrors({});
+    setSaveError(null);
+    setSaveMessage(null);
+    setPreview(null);
+    setPreviewError(null);
+    setRunResult(null);
+  }, [remoteConnectors]);
+
+  const runSchedule = useCallback(async (scheduleId: string) => {
+    setRunBusyId(scheduleId);
+    setRunError(null);
+    setRunResult(null);
+    try {
+      const result = await services.runSchedule(scheduleId);
+      setRunResult(result);
+    } catch (error) {
+      setRunError(describeApiError(error, `Statement fetch schedule ${scheduleId} failed.`));
+    } finally {
+      setRunBusyId(null);
+      try {
+        const next = await services.listSchedules();
+        setSchedules(sortSchedules(next));
+      } catch {
+        // The run result is authoritative; a subsequent explicit refresh can recover list state.
+      }
+    }
+  }, [services]);
+
+  const deleteSchedule = useCallback(async (scheduleId: string) => {
+    setDeleteBusyId(scheduleId);
+    setDeleteError(null);
+    try {
+      await services.deleteSchedule(scheduleId);
+      setSchedules((current) => current.filter((schedule) => schedule.scheduleId !== scheduleId));
+      if (draft.scheduleId === scheduleId) {
+        setDraft(createStatementFetchDraft(remoteConnectors));
+      }
+    } catch (error) {
+      setDeleteError(describeApiError(error, `Statement fetch schedule ${scheduleId} could not be deleted.`));
+    } finally {
+      setDeleteBusyId(null);
+    }
+  }, [draft.scheduleId, remoteConnectors, services]);
+
+  const previewErrors = validateStatementFetchDraft(draft, remoteConnectors, "preview");
+  const scheduleErrors = validateStatementFetchDraft(draft, remoteConnectors, "schedule");
+  const previewDisabledReason = firstError(previewErrors);
+  const saveDisabledReason = firstError(scheduleErrors);
+
+  return {
+    canPreview: previewDisabledReason === null,
+    canSave: saveDisabledReason === null,
+    deleteBusyId,
+    deleteError,
+    deleteSchedule,
+    draft,
+    draftErrors,
+    editSchedule,
+    loadError,
+    loading,
+    newSchedule,
+    preview,
+    previewBusy,
+    previewDisabledReason,
+    previewError,
+    previewFetch,
+    profiles,
+    refreshSchedules,
+    remoteConnectors,
+    runBusyId,
+    runError,
+    runResult,
+    runSchedule,
+    saveBusy,
+    saveDisabledReason,
+    saveError,
+    saveMessage,
+    saveSchedule,
+    schedules,
+    selectedKind,
+    selectKind: setSelectedKind,
+    updateDraft
+  };
+}
+
+function createStatementFetchDraft(
+  connectors: StatementConnectorDescriptor[],
+  current?: StatementFetchDraft,
+  schedule?: StatementFetchSchedule
+): StatementFetchDraft {
+  const connector = schedule
+    ? connectors.find((candidate) => candidate.connectorId === schedule.connectorId)
+    : connectors[0];
+  const defaultSinceDate = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  return {
+    cadenceHours: schedule ? String(schedule.cadenceHours) : "24",
+    connectorId: schedule?.connectorId ?? connector?.connectorId ?? "",
+    datasets: current?.datasets ?? "all",
+    enabled: schedule?.enabled ?? true,
+    externalAccountId: schedule?.externalAccountId ?? current?.externalAccountId ?? "",
+    fundAccountId: schedule?.fundAccountId ?? current?.fundAccountId ?? "",
+    mappingProfileId: schedule ? schedule.mappingProfileId ?? "" : connector?.defaultProfileId ?? "",
+    scheduleId: schedule?.scheduleId ?? "",
+    sinceDate: schedule?.lastRunAtUtc?.slice(0, 10) ?? current?.sinceDate ?? defaultSinceDate,
+    sourceInstitution: schedule?.sourceInstitution ?? connector?.displayName ?? current?.sourceInstitution ?? "",
+    sourceKind: schedule?.sourceKind ?? current?.sourceKind ?? "broker",
+    toleranceProfileId: schedule?.toleranceProfileId ?? current?.toleranceProfileId ?? "statement-default"
+  };
+}
+
+function currentConnectorName(
+  draft: StatementFetchDraft,
+  connectors: StatementConnectorDescriptor[]
+): string {
+  return connectors.find((candidate) => candidate.connectorId === draft.connectorId)?.displayName ?? "";
+}
+
+function toScheduleRequest(draft: StatementFetchDraft): StatementFetchScheduleUpsertRequest {
+  return {
+    scheduleId: draft.scheduleId.trim() || null,
+    connectorId: draft.connectorId.trim(),
+    externalAccountId: draft.externalAccountId.trim(),
+    fundAccountId: draft.fundAccountId.trim(),
+    sourceInstitution: draft.sourceInstitution.trim(),
+    mappingProfileId: draft.mappingProfileId.trim() || null,
+    toleranceProfileId: draft.toleranceProfileId.trim() || null,
+    cadenceHours: Number(draft.cadenceHours),
+    enabled: draft.enabled,
+    sourceKind: draft.sourceKind
+  };
+}
+
+function sortSchedules(schedules: StatementFetchSchedule[]): StatementFetchSchedule[] {
+  return [...schedules].sort((left, right) => left.scheduleId.localeCompare(right.scheduleId));
+}
+
+function firstError(errors: StatementFetchDraftErrors): string | null {
+  return Object.values(errors).find((value): value is string => Boolean(value)) ?? null;
+}

--- a/src/Meridian.Ui/dashboard/src/screens/statement-import-panel.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/statement-import-panel.test.tsx
@@ -4,11 +4,13 @@ import { axe } from "jest-axe";
 import { describe, expect, it, vi } from "vitest";
 import { StatementImportPanel } from "@/screens/statement-import-panel";
 import type { StatementImportPanelServices } from "@/screens/statement-import-panel.view-model";
+import type { StatementFetchPanelServices } from "@/screens/statement-fetch-panel.view-model";
 import { renderWithRouter } from "@/test/render";
 import type {
   StatementConnectorDescriptor,
   StatementImportCommitResult,
   StatementImportPreview,
+  StatementFetchSchedule,
   StatementMappingProfile
 } from "@/types";
 
@@ -129,6 +131,32 @@ const commitResult: StatementImportCommitResult = {
   nextActions: ["Open retained statement evidence in Evidence Vault.", "Review reconciliation cases and linked statement evidence."]
 };
 
+const remoteConnector: StatementConnectorDescriptor = {
+  connectorId: "alpaca-activity",
+  displayName: "Alpaca account activity",
+  fileExtensions: [".json"],
+  supportsFileImport: true,
+  supportsRemoteFetch: true,
+  requiresMappingProfile: false,
+  defaultProfileId: "builtin-generic"
+};
+
+const fetchSchedule: StatementFetchSchedule = {
+  scheduleId: "alpaca-daily",
+  connectorId: "alpaca-activity",
+  externalAccountId: "PA3ALPACA01",
+  fundAccountId: "FUND-A",
+  sourceInstitution: "Alpaca",
+  mappingProfileId: "builtin-generic",
+  toleranceProfileId: "statement-default",
+  cadenceHours: 24,
+  enabled: true,
+  lastRunAtUtc: null,
+  lastRunStatus: null,
+  nextDueAtUtc: null,
+  sourceKind: "broker"
+};
+
 function makeServices(): StatementImportPanelServices {
   return {
     getConnectors: vi.fn(async () => connectors),
@@ -136,6 +164,16 @@ function makeServices(): StatementImportPanelServices {
     upsertMappingProfile: vi.fn(async (profile: StatementMappingProfile) => profile),
     previewImport: vi.fn(async () => preview),
     commitImport: vi.fn(async () => commitResult)
+  };
+}
+
+function makeFetchServices(): StatementFetchPanelServices {
+  return {
+    deleteSchedule: vi.fn(async () => undefined),
+    fetchPreview: vi.fn(async () => preview),
+    listSchedules: vi.fn(async () => [fetchSchedule]),
+    runSchedule: vi.fn(async () => commitResult),
+    upsertSchedule: vi.fn(async () => fetchSchedule)
   };
 }
 
@@ -204,5 +242,21 @@ describe("StatementImportPanel", () => {
       "href",
       "/accounting/reconciliation/match?runId=stmt-run-77&caseId=case%3Abreak-cash-1&breakId=break-cash-1"
     );
+  });
+
+  it("opens the scheduled-fetch operator path from the Import statement route", async () => {
+    const user = userEvent.setup();
+    const services = makeServices();
+    services.getConnectors = vi.fn(async () => [...connectors, remoteConnector]);
+    renderWithRouter(
+      <StatementImportPanel services={services} fetchServices={makeFetchServices()} />,
+      { initialEntries: ["/accounting/statement-import"] }
+    );
+
+    await waitFor(() => expect(screen.getByRole("tab", { name: "Scheduled fetch" })).toBeEnabled());
+    await user.click(screen.getByRole("tab", { name: "Scheduled fetch" }));
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Remote statement preview and schedule" })).toBeInTheDocument());
+    expect(screen.getByRole("table", { name: "Statement fetch schedules" })).toHaveTextContent("alpaca-daily");
   });
 });

--- a/src/Meridian.Ui/dashboard/src/screens/statement-import-panel.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/statement-import-panel.tsx
@@ -1,4 +1,5 @@
 import { ArrowRight, Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -10,44 +11,84 @@ import { Label } from "@/components/ui/label";
 import { PanelSurface } from "@/components/ui/panel-surface";
 import { Select } from "@/components/ui/select";
 import { StatusBanner } from "@/components/ui/status-banner";
+import { TabPanel, Tabs } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { WORKSTATION_ROUTE_CATALOG } from "@/lib/workspace";
 import {
-  STATEMENT_FORMAT_DRIFT_ISSUE_CODE,
-  statementColumnConfidenceBadgeVariant,
-  statementIssueBadgeVariant,
   useStatementImportPanelViewModel,
   type StatementImportPanelViewModel,
   type UseStatementImportPanelOptions
 } from "@/screens/statement-import-panel.view-model";
+import { StatementFetchPanel } from "@/screens/statement-fetch-panel";
+import type { StatementFetchPanelServices } from "@/screens/statement-fetch-panel.view-model";
+import { StatementImportPreviewDetails } from "@/screens/statement-import-preview";
 import type { ApiErrorDisplay } from "@/lib/api-errors";
 
-export function StatementImportPanel(options: UseStatementImportPanelOptions = {}) {
+export interface StatementImportPanelProps extends UseStatementImportPanelOptions {
+  fetchServices?: Partial<StatementFetchPanelServices>;
+}
+
+export function StatementImportPanel(options: StatementImportPanelProps = {}) {
   const viewModel = useStatementImportPanelViewModel(options);
+  const [sourceMode, setSourceMode] = useState("file");
 
   return (
     <section className="flex flex-col gap-4" aria-label="Import statement">
       <PanelSurface className="p-4">
         <h1 className="text-base font-semibold text-foreground">Import statement</h1>
         <p className="mt-1 text-xs text-muted-foreground">
-          Upload a broker or custodian statement, review the detected column mappings and record kinds, then commit
-          the import into the reconciliation queue.
+          Upload a broker or custodian statement, or fetch it through a configured provider. Review the canonical
+          mapping and confidence before records enter the reconciliation queue.
         </p>
       </PanelSurface>
 
       <h2 className="sr-only">Statement import workflow</h2>
-
       {viewModel.loadError ? (
         <ErrorBanner title="Statement connector library failed to load" error={viewModel.loadError} />
       ) : null}
-
-      <SourceSection viewModel={viewModel} />
-      {viewModel.previewError ? (
-        <ErrorBanner title="Statement preview failed" error={viewModel.previewError} />
-      ) : null}
-      {viewModel.preview ? <PreviewSection viewModel={viewModel} /> : null}
-      <ProfileEditorSection viewModel={viewModel} />
-      <CommitSection viewModel={viewModel} />
+      <Tabs
+        aria-label="Statement import source"
+        value={sourceMode}
+        onValueChange={setSourceMode}
+        tabs={[
+          { id: "file", label: "File upload" },
+          { id: "scheduled", label: "Scheduled fetch" }
+        ]}
+      >
+        <TabPanel>
+          <div className="flex flex-col gap-4">
+            <SourceSection viewModel={viewModel} />
+            {viewModel.previewError ? (
+              <ErrorBanner title="Statement preview failed" error={viewModel.previewError} />
+            ) : null}
+            {viewModel.preview ? (
+              <StatementImportPreviewDetails
+                preview={viewModel.preview}
+                selectedKind={viewModel.selectedKind}
+                onSelectKind={viewModel.selectKind}
+              />
+            ) : null}
+            <ProfileEditorSection viewModel={viewModel} />
+            <CommitSection viewModel={viewModel} />
+          </div>
+        </TabPanel>
+        <TabPanel>
+          {sourceMode === "scheduled" && viewModel.loading ? (
+            <StatusBanner
+              tone="info"
+              title="Loading statement connectors"
+              detail="Checking the connector catalog for remote-fetch support."
+            />
+          ) : null}
+          {sourceMode === "scheduled" && !viewModel.loading ? (
+            <StatementFetchPanel
+              connectors={viewModel.connectors}
+              profiles={viewModel.profiles}
+              services={options.fetchServices}
+            />
+          ) : null}
+        </TabPanel>
+      </Tabs>
     </section>
   );
 }
@@ -158,168 +199,6 @@ function SourceSection({ viewModel }: { viewModel: StatementImportPanelViewModel
         ) : null}
       </CardContent>
     </Card>
-  );
-}
-
-function PreviewSection({ viewModel }: { viewModel: StatementImportPanelViewModel }) {
-  const preview = viewModel.preview;
-  if (!preview) {
-    return null;
-  }
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Preview: {preview.fileName}</CardTitle>
-        <CardDescription>
-          {preview.connectorDisplayName} parsed {preview.recordCount} records.{" "}
-          {preview.nextAction}
-        </CardDescription>
-        <div className="mt-1">
-          <Badge variant={preview.status === "ReadyToImport" ? "success" : "warning"}>
-            {preview.status}
-          </Badge>
-        </div>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-5">
-        <ColumnMappingTable viewModel={viewModel} />
-        <KindSummarySection viewModel={viewModel} />
-        <IssueList viewModel={viewModel} />
-      </CardContent>
-    </Card>
-  );
-}
-
-function ColumnMappingTable({ viewModel }: { viewModel: StatementImportPanelViewModel }) {
-  const mappings = viewModel.preview?.columnMappings ?? [];
-  if (mappings.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className="overflow-x-auto">
-      <table className="w-full border-collapse text-xs" aria-label="Statement column mappings">
-        <caption className="sr-only">Detected statement columns mapped onto canonical Meridian fields</caption>
-        <thead>
-          <tr className="border-b border-border text-left font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-            <th scope="col" className="px-2 py-1.5">Source column</th>
-            <th scope="col" className="px-2 py-1.5">Canonical field</th>
-            <th scope="col" className="px-2 py-1.5">Confidence</th>
-          </tr>
-        </thead>
-        <tbody>
-          {mappings.map((mapping) => (
-            <tr key={mapping.sourceColumn} className="border-b border-border/60">
-              <td className="px-2 py-1.5 font-mono">{mapping.sourceColumn}</td>
-              <td className="px-2 py-1.5 font-mono">{mapping.canonicalField ?? "—"}</td>
-              <td className="px-2 py-1.5">
-                <Badge
-                  variant={statementColumnConfidenceBadgeVariant(mapping.confidence)}
-                  title={`${mapping.rationale} (score ${mapping.score.toFixed(2)})`}
-                >
-                  {mapping.confidence}
-                </Badge>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-
-function KindSummarySection({ viewModel }: { viewModel: StatementImportPanelViewModel }) {
-  if (viewModel.kindSummaries.length === 0) {
-    return null;
-  }
-
-  const selected = viewModel.selectedKindSummary;
-
-  return (
-    <div className="flex flex-col gap-3">
-      <div className="flex flex-wrap gap-2" role="group" aria-label="Record kinds">
-        {viewModel.kindSummaries.map((summary) => (
-          <button
-            key={summary.kind}
-            type="button"
-            aria-pressed={summary.kind === viewModel.selectedKind}
-            className={cn(
-              "inline-flex items-center gap-1.5 rounded-[2px] border px-2.5 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.14em]",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-              summary.kind === viewModel.selectedKind
-                ? "border-primary bg-primary/15 text-primary"
-                : "border-border bg-secondary/35 text-muted-foreground hover:border-[#ADB8C4]"
-            )}
-            onClick={() => viewModel.selectKind(summary.kind)}
-          >
-            {summary.kind}
-            <span aria-hidden="true">{summary.recordCount}</span>
-            <span className="sr-only">{summary.recordCount} records</span>
-          </button>
-        ))}
-      </div>
-      {selected && selected.sampleRecords.length > 0 ? (
-        <div className="overflow-x-auto">
-          <table className="w-full border-collapse text-xs" aria-label={`Sample ${selected.kind} records`}>
-            <caption className="sr-only">Sample records parsed for the {selected.kind} kind</caption>
-            <thead>
-              <tr className="border-b border-border text-left font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-                <th scope="col" className="px-2 py-1.5">Account</th>
-                <th scope="col" className="px-2 py-1.5">Symbol</th>
-                <th scope="col" className="px-2 py-1.5">Activity</th>
-                <th scope="col" className="px-2 py-1.5">Trade date</th>
-                <th scope="col" className="px-2 py-1.5 text-right">Quantity</th>
-                <th scope="col" className="px-2 py-1.5 text-right">Price</th>
-                <th scope="col" className="px-2 py-1.5 text-right">Cash</th>
-              </tr>
-            </thead>
-            <tbody>
-              {selected.sampleRecords.map((record, index) => (
-                <tr key={`${record.externalTransactionId ?? record.symbol}-${index}`} className="border-b border-border/60">
-                  <td className="px-2 py-1.5 font-mono">{record.account}</td>
-                  <td className="px-2 py-1.5 font-mono">{record.symbol}</td>
-                  <td className="px-2 py-1.5">{record.activityType}</td>
-                  <td className="px-2 py-1.5 font-mono">{record.tradeDate}</td>
-                  <td className="px-2 py-1.5 text-right font-mono">{record.quantity}</td>
-                  <td className="px-2 py-1.5 text-right font-mono">{record.price}</td>
-                  <td className="px-2 py-1.5 text-right font-mono">{record.cashAmount}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function IssueList({ viewModel }: { viewModel: StatementImportPanelViewModel }) {
-  if (viewModel.issues.length === 0) {
-    return null;
-  }
-
-  return (
-    <ul className="flex flex-col gap-1.5" aria-label="Statement import issues">
-      {viewModel.issues.map((issue, index) => (
-        <li
-          key={`${issue.code}-${issue.rowNumber ?? "file"}-${index}`}
-          className="flex flex-wrap items-center gap-2 rounded-[2px] border border-border/60 bg-card px-2 py-1.5 text-xs"
-        >
-          <Badge variant={statementIssueBadgeVariant(issue.severity)}>{issue.severity}</Badge>
-          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-            {issue.code}
-            {issue.rowNumber !== null ? ` · row ${issue.rowNumber}` : ""}
-            {issue.field ? ` · ${issue.field}` : ""}
-          </span>
-          <span className="min-w-0 flex-1">
-            {issue.message}
-            {issue.code === STATEMENT_FORMAT_DRIFT_ISSUE_CODE
-              ? " Review the mapping profile before committing — the statement layout drifted from the accepted fingerprint."
-              : ""}
-          </span>
-        </li>
-      ))}
-    </ul>
   );
 }
 

--- a/src/Meridian.Ui/dashboard/src/screens/statement-import-preview.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/statement-import-preview.tsx
@@ -1,0 +1,188 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import {
+  STATEMENT_FORMAT_DRIFT_ISSUE_CODE,
+  statementColumnConfidenceBadgeVariant,
+  statementIssueBadgeVariant
+} from "@/screens/statement-import-panel.view-model";
+import type { StatementImportPreview } from "@/types";
+
+export interface StatementImportPreviewDetailsProps {
+  onSelectKind: (kind: string) => void;
+  preview: StatementImportPreview;
+  selectedKind: string | null;
+}
+
+export function StatementImportPreviewDetails({
+  onSelectKind,
+  preview,
+  selectedKind
+}: StatementImportPreviewDetailsProps) {
+  const selectedKindSummary = preview.kindSummaries.find((summary) => summary.kind === selectedKind)
+    ?? preview.kindSummaries[0]
+    ?? null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Preview: {preview.fileName}</CardTitle>
+        <CardDescription>
+          {preview.connectorDisplayName} parsed {preview.recordCount} records. {preview.nextAction}
+        </CardDescription>
+        <div className="mt-1">
+          <Badge variant={preview.status === "ReadyToImport" ? "success" : "warning"}>
+            {preview.status}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-5">
+        <StatementColumnMappingTable preview={preview} />
+        <StatementKindSummarySection
+          preview={preview}
+          selectedKind={selectedKindSummary?.kind ?? null}
+          onSelectKind={onSelectKind}
+        />
+        <StatementIssueList preview={preview} />
+      </CardContent>
+    </Card>
+  );
+}
+
+function StatementColumnMappingTable({ preview }: { preview: StatementImportPreview }) {
+  if (preview.columnMappings.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse text-xs" aria-label="Statement column mappings">
+        <caption className="sr-only">Detected statement columns mapped onto canonical Meridian fields</caption>
+        <thead>
+          <tr className="border-b border-border text-left font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+            <th scope="col" className="px-2 py-1.5">Source column</th>
+            <th scope="col" className="px-2 py-1.5">Canonical field</th>
+            <th scope="col" className="px-2 py-1.5">Confidence</th>
+          </tr>
+        </thead>
+        <tbody>
+          {preview.columnMappings.map((mapping) => (
+            <tr key={mapping.sourceColumn} className="border-b border-border/60">
+              <td className="px-2 py-1.5 font-mono">{mapping.sourceColumn}</td>
+              <td className="px-2 py-1.5 font-mono">{mapping.canonicalField ?? "—"}</td>
+              <td className="px-2 py-1.5">
+                <Badge
+                  variant={statementColumnConfidenceBadgeVariant(mapping.confidence)}
+                  title={`${mapping.rationale} (score ${mapping.score.toFixed(2)})`}
+                >
+                  {mapping.confidence}
+                </Badge>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function StatementKindSummarySection({
+  onSelectKind,
+  preview,
+  selectedKind
+}: StatementImportPreviewDetailsProps) {
+  if (preview.kindSummaries.length === 0) {
+    return null;
+  }
+
+  const selected = preview.kindSummaries.find((summary) => summary.kind === selectedKind)
+    ?? preview.kindSummaries[0]
+    ?? null;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap gap-2" role="group" aria-label="Record kinds">
+        {preview.kindSummaries.map((summary) => (
+          <button
+            key={summary.kind}
+            type="button"
+            aria-pressed={summary.kind === selected?.kind}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-[2px] border px-2.5 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.14em]",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+              summary.kind === selected?.kind
+                ? "border-primary bg-primary/15 text-primary"
+                : "border-border bg-secondary/35 text-muted-foreground hover:border-[#ADB8C4]"
+            )}
+            onClick={() => onSelectKind(summary.kind)}
+          >
+            {summary.kind}
+            <span aria-hidden="true">{summary.recordCount}</span>
+            <span className="sr-only">{summary.recordCount} records</span>
+          </button>
+        ))}
+      </div>
+      {selected && selected.sampleRecords.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse text-xs" aria-label={`Sample ${selected.kind} records`}>
+            <caption className="sr-only">Sample records parsed for the {selected.kind} kind</caption>
+            <thead>
+              <tr className="border-b border-border text-left font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                <th scope="col" className="px-2 py-1.5">Account</th>
+                <th scope="col" className="px-2 py-1.5">Symbol</th>
+                <th scope="col" className="px-2 py-1.5">Activity</th>
+                <th scope="col" className="px-2 py-1.5">Trade date</th>
+                <th scope="col" className="px-2 py-1.5 text-right">Quantity</th>
+                <th scope="col" className="px-2 py-1.5 text-right">Price</th>
+                <th scope="col" className="px-2 py-1.5 text-right">Cash</th>
+              </tr>
+            </thead>
+            <tbody>
+              {selected.sampleRecords.map((record, index) => (
+                <tr key={`${record.externalTransactionId ?? record.symbol}-${index}`} className="border-b border-border/60">
+                  <td className="px-2 py-1.5 font-mono">{record.account}</td>
+                  <td className="px-2 py-1.5 font-mono">{record.symbol}</td>
+                  <td className="px-2 py-1.5">{record.activityType}</td>
+                  <td className="px-2 py-1.5 font-mono">{record.tradeDate}</td>
+                  <td className="px-2 py-1.5 text-right font-mono">{record.quantity}</td>
+                  <td className="px-2 py-1.5 text-right font-mono">{record.price}</td>
+                  <td className="px-2 py-1.5 text-right font-mono">{record.cashAmount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function StatementIssueList({ preview }: { preview: StatementImportPreview }) {
+  if (preview.issues.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul className="flex flex-col gap-1.5" aria-label="Statement import issues">
+      {preview.issues.map((issue, index) => (
+        <li
+          key={`${issue.code}-${issue.rowNumber ?? "file"}-${index}`}
+          className="flex flex-wrap items-center gap-2 rounded-[2px] border border-border/60 bg-card px-2 py-1.5 text-xs"
+        >
+          <Badge variant={statementIssueBadgeVariant(issue.severity)}>{issue.severity}</Badge>
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            {issue.code}
+            {issue.rowNumber !== null ? ` · row ${issue.rowNumber}` : ""}
+            {issue.field ? ` · ${issue.field}` : ""}
+          </span>
+          <span className="min-w-0 flex-1">
+            {issue.message}
+            {issue.code === STATEMENT_FORMAT_DRIFT_ISSUE_CODE
+              ? " Review the mapping profile before committing — the statement layout drifted from the accepted fingerprint."
+              : ""}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/types/workstation-4.ts
+++ b/src/Meridian.Ui/dashboard/src/types/workstation-4.ts
@@ -83,6 +83,7 @@ export interface StatementFetchSchedule {
   lastRunAtUtc: string | null;
   lastRunStatus: string | null;
   nextDueAtUtc: string | null;
+  sourceKind: StatementImportSourceKind;
 }
 
 export type StatementImportSourceKind = "broker" | "custodian";
@@ -106,6 +107,7 @@ export interface StatementFetchScheduleUpsertRequest {
   toleranceProfileId?: string | null;
   cadenceHours: number;
   enabled: boolean;
+  sourceKind?: StatementImportSourceKind | null;
 }
 
 export interface AccountingReconciliationRecord {

--- a/tests/Meridian.Tests/Reconciliation/Connectors/StatementImportServiceTests.cs
+++ b/tests/Meridian.Tests/Reconciliation/Connectors/StatementImportServiceTests.cs
@@ -233,6 +233,39 @@ public sealed class StatementImportServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task ScheduleStore_LegacySnapshot_DefaultsSourceKindToBroker()
+    {
+        var schedulePath = Path.Combine(_root, "reconciliation", "statement-fetch-schedules.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(schedulePath)!);
+        await File.WriteAllTextAsync(
+            schedulePath,
+            """
+            {
+              "version": 1,
+              "schedules": [
+                {
+                  "scheduleId": "legacy-schedule",
+                  "connectorId": "fake-fetch",
+                  "externalAccountId": "EXT-LEGACY",
+                  "fundAccountId": "FUND-LEGACY",
+                  "sourceInstitution": "Legacy Broker",
+                  "mappingProfileId": null,
+                  "toleranceProfileId": "statement-default",
+                  "cadenceHours": 24,
+                  "enabled": true,
+                  "lastRunAtUtc": null,
+                  "lastRunStatus": null
+                }
+              ]
+            }
+            """);
+
+        var schedule = (await new FileStatementFetchScheduleStore(_root).ListAsync()).Single();
+
+        schedule.SourceKind.Should().Be("broker");
+    }
+
+    [Fact]
     public async Task ScheduleRunner_RunsDueSchedules_AndRecordsOutcome()
     {
         var scheduleStore = new FileStatementFetchScheduleStore(_root);
@@ -246,7 +279,8 @@ public sealed class StatementImportServiceTests : IDisposable
             MappingProfileId: null,
             ToleranceProfileId: "statement-default",
             CadenceHours: 24,
-            Enabled: true));
+            Enabled: true,
+            SourceKind: "custodian"));
 
         var now = new DateTimeOffset(2026, 7, 1, 6, 0, 0, TimeSpan.Zero);
         var ran = await runner.RunDueSchedulesAsync(now);
@@ -255,6 +289,7 @@ public sealed class StatementImportServiceTests : IDisposable
         var updated = (await scheduleStore.ListAsync()).Single();
         updated.LastRunAtUtc.Should().Be(now);
         updated.LastRunStatus.Should().StartWith("Imported");
+        (await _workflow.ListImportsAsync()).Single().Broker.Should().Be("custodian");
 
         // Just ran: not due again until the cadence elapses.
         (await runner.RunDueSchedulesAsync(now.AddHours(1))).Should().Be(0);
@@ -276,12 +311,17 @@ public sealed class StatementImportServiceTests : IDisposable
             ToleranceProfileId: "statement-default",
             CadenceHours: 24,
             Enabled: true));
+        var lastSuccessfulRun = new DateTimeOffset(2026, 7, 17, 6, 0, 0, TimeSpan.Zero);
+        await scheduleStore.RecordRunAsync("sched-bad", lastSuccessfulRun, "Imported prior run");
 
-        var ran = await runner.RunDueSchedulesAsync(DateTimeOffset.UtcNow);
+        var ran = await runner.RunDueSchedulesAsync(lastSuccessfulRun.AddHours(25));
 
         ran.Should().Be(1);
         var updated = (await scheduleStore.ListAsync()).Single();
-        updated.LastRunStatus.Should().StartWith("Failed:");
+        updated.LastRunAtUtc.Should().Be(
+            lastSuccessfulRun,
+            "a transient fetch failure must preserve the last successful schedule watermark");
+        updated.LastRunStatus.Should().Be("Failed: NotSupportedException");
     }
 
     /// <summary>A fetch-capable connector returning a canonical CSV document, for scheduler tests.</summary>


### PR DESCRIPTION
## Summary

- completes the Accounting **Import statement** workflow with File upload and Scheduled fetch paths
- adds remote connector preview, mapping-confidence review, schedule create/edit/pause/run/delete controls, and direct Evidence Vault/reconciliation handoff
- carries broker/custodian source classification through browser types, shared DTOs/endpoints, persisted schedules, and scheduled imports
- hardens transient scheduler failures so stable failure status is recorded without advancing the last-successful watermark
- updates operator, source-module, contract, dashboard, and roadmap documentation

## Reason

The connector library already supports IB Flex XML, Alpaca activity, OFX, and declarative CSV/OFX profiles. The missing adoption surface was an operator-accessible scheduled-fetch workflow in Accounting. This change exposes the existing fetch/scheduler seam without collecting credentials and preserves the canonical preview and reconciliation controls used by file imports.

## Testing performed

- [x] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [x] Relevant integration tests were added or updated
- [x] GitHub Actions `quality-gate` passed

Additional focused evidence:

- `npm run test:vitest -- src/screens/statement-import-panel.view-model.test.ts src/screens/statement-import-panel.test.tsx src/screens/statement-fetch-panel.test.tsx` — 24/24 passed, including axe accessibility coverage
- `dotnet test tests/Meridian.Tests/Meridian.Tests.csproj --filter "FullyQualifiedName~Meridian.Tests.Reconciliation.Connectors.StatementImportServiceTests" ...` — 14/14 passed
- `npm run build` — production dashboard TypeScript/Vite build passed
- contract-impact, roadmap registry, source README, generated-doc drift, and documentation-hash validation passed
- rendered Accounting scheduled-fetch workflow inspected with connector preview, source-kind selection, schedule editing, and dense schedule table

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`


<!-- phase:PR9 -->


