### PR TITLE
feat: P7 seam migration — all 96 legacy API-client call sites onto ApiResponse; ratchet drained to zero

### DIFF
--- a/build/scripts/ci/apiclient-caller-baseline.json
+++ b/build/scripts/ci/apiclient-caller-baseline.json
@@ -1,32 +1,5 @@
 {
   "description": "Per-file counts of legacy ApiClientService GetAsync<T>/PostAsync<T> call sites. CI fails when any file exceeds its count or a new file appears; migration batches shrink this to empty.",
-  "files": {
-    "src/Meridian.Infrastructure/Adapters/Templates/BrokerAdapterTemplate.cs": 1,
-    "src/Meridian.Ui.Services/Services/ActivityFeedService.cs": 1,
-    "src/Meridian.Ui.Services/Services/BackfillApiService.cs": 8,
-    "src/Meridian.Ui.Services/Services/BackfillProviderConfigService.cs": 1,
-    "src/Meridian.Ui.Services/Services/DataQuality/DataQualityApiClient.cs": 2,
-    "src/Meridian.Ui.Services/Services/LiveDataService.cs": 8,
-    "src/Meridian.Ui.Services/Services/ProviderDiagnostics/ProviderDiagnosticsApiClient.cs": 3,
-    "src/Meridian.Ui.Services/Services/ScheduleManagerService.cs": 14,
-    "src/Meridian.Ui.Services/Services/StorageServiceBase.cs": 9,
-    "src/Meridian.Ui.Services/Services/SystemHealthService.cs": 11,
-    "src/Meridian.Wpf/Services/OperationsControlCenterClient.cs": 2,
-    "src/Meridian.Wpf/Services/SecurityAssetProfileWorkflowClient.cs": 2,
-    "src/Meridian.Wpf/Services/SecurityMasterOperatorWorkflowClient.cs": 3,
-    "src/Meridian.Wpf/Services/StorageService.cs": 1,
-    "src/Meridian.Wpf/Services/WatchlistService.cs": 1,
-    "src/Meridian.Wpf/Services/WorkstationOperatorInboxApiClient.cs": 1,
-    "src/Meridian.Wpf/Services/WorkstationReconciliationApiClient.cs": 6,
-    "src/Meridian.Wpf/Services/WorkstationSecurityMasterApiClient.cs": 3,
-    "src/Meridian.Wpf/Services/WorkstationStrategyBriefingService.cs": 1,
-    "src/Meridian.Wpf/Services/WpfRemoteWorkstationClient.cs": 2,
-    "src/Meridian.Wpf/ViewModels/AccountPortfolioViewModel.cs": 1,
-    "src/Meridian.Wpf/ViewModels/AggregatePortfolioViewModel.cs": 2,
-    "src/Meridian.Wpf/ViewModels/DirectLendingViewModel.cs": 7,
-    "src/Meridian.Wpf/ViewModels/FinancialRecordExplorerViewModel.cs": 2,
-    "src/Meridian.Wpf/ViewModels/SecurityMasterViewModel.cs": 2,
-    "src/Meridian.Wpf/ViewModels/TradingHoursViewModel.cs": 2
-  },
-  "total": 96
+  "files": {},
+  "total": 0
 }

--- a/docs/generated/repository-structure.md
+++ b/docs/generated/repository-structure.md
@@ -6366,6 +6366,7 @@ Meridian-main
 │   │   │   ├── AnalysisExportWizardService.cs
 │   │   │   ├── ApiClientService.cs
 │   │   │   ├── ApiClientSession.cs
+│   │   │   ├── ApiResponseExtensions.cs
 │   │   │   ├── ArchiveBrowserService.cs
 │   │   │   ├── ArchiveHealthService.cs
 │   │   │   ├── BackendServiceManagerBase.cs

--- a/docs/status/coverage-report.md
+++ b/docs/status/coverage-report.md
@@ -5,7 +5,7 @@
 
 ## Overall Coverage
 
-**3594 / 8041** items documented (**44.7%**) &mdash; Grade: **D**
+**3595 / 8042** items documented (**44.7%**) &mdash; Grade: **D**
 
 ```text
 [=========-----------] 44.7%
@@ -15,7 +15,7 @@
 
 | Category | Documented | Total | Coverage | Grade |
 | ---------- | ----------- | ------- | ---------- | ------- |
-| Public Classes / Interfaces | 3468 | 7576 | 45.8% | D |
+| Public Classes / Interfaces | 3469 | 7577 | 45.8% | D |
 | API Endpoints | 112 | 312 | 35.9% | F |
 | Configuration Options | 3 | 142 | 2.1% | F |
 | Provider Implementations | 0 | 0 | 100.0% | A |

--- a/docs/status/doc-health-dashboard.json
+++ b/docs/status/doc-health-dashboard.json
@@ -1,6 +1,6 @@
 {
   "total_files": 625,
-  "total_lines": 112348,
+  "total_lines": 112349,
   "orphaned_count": 257,
   "no_heading_count": 148,
   "stale_count": 0,
@@ -2532,7 +2532,7 @@
     },
     {
       "path": "docs/generated/repository-structure.md",
-      "line_count": 9196,
+      "line_count": 9197,
       "has_heading": true,
       "todo_count": 8,
       "last_modified_utc": "1970-01-01T00:00:00+00:00",

--- a/docs/status/doc-health-dashboard.md
+++ b/docs/status/doc-health-dashboard.md
@@ -20,7 +20,7 @@ Data sources: `repo markdown (*.md)`, `file modification metadata`
 | Metric | Value |
 | -------- | ------- |
 | Total documentation files | 625 |
-| Total lines | 112,348 |
+| Total lines | 112,349 |
 | Average file size (lines) | 179.8 |
 | Orphaned files | 257 |
 | Files without headings | 148 |

--- a/docs/status/wpf-screen-development-tracker.json
+++ b/docs/status/wpf-screen-development-tracker.json
@@ -7,7 +7,7 @@
     "name": "scripts/generate-diagrams.mjs --tracker-only",
     "version": "1.0.0"
   },
-  "sourceFingerprint": "a4213e7ac3b3",
+  "sourceFingerprint": "5a0c39281de2",
   "baselineDate": "2026-06-17",
   "summary": {
     "screenCount": 93,

--- a/docs/status/wpf-screen-development-tracker.md
+++ b/docs/status/wpf-screen-development-tracker.md
@@ -15,7 +15,7 @@ do_not_edit: true
 
 This tracker is generated from the live WPF shell registry, the maintained desktop screenshot index, and a text scan of `tests/Meridian.Wpf.Tests` for route, page, and view-model references. It tracks source-derived evidence only; roadmap priority and product scope still belong in `docs/roadmap/data/*.yml` and the design document.
 
-- Source fingerprint: `a4213e7ac3b3`
+- Source fingerprint: `5a0c39281de2`
 - Baseline date for open Gantt tasks: `2026-06-17`
 - Registered WPF screens: `93`
 - Open automated tasks: `1`

--- a/src/Meridian.Infrastructure/Adapters/Templates/BrokerAdapterTemplate.cs
+++ b/src/Meridian.Infrastructure/Adapters/Templates/BrokerAdapterTemplate.cs
@@ -35,7 +35,7 @@ public sealed class TemplateBrokerSessionService
     public TemplateBrokerSessionService(TemplateBrokerHttpClient http) => _http = http;
 
     public Task<TemplateBrokerSession> OpenSessionAsync(CancellationToken ct = default) =>
-        _http.PostAsync<TemplateBrokerSessionRequest, TemplateBrokerSession>("/session/open", new(), ct);
+        _http.PostJsonAsync<TemplateBrokerSessionRequest, TemplateBrokerSession>("/session/open", new(), ct);
 }
 
 public sealed class TemplateBrokerHttpClient
@@ -44,7 +44,7 @@ public sealed class TemplateBrokerHttpClient
 
     public TemplateBrokerHttpClient(HttpClient httpClient) => _httpClient = httpClient;
 
-    public async Task<TResponse> PostAsync<TRequest, TResponse>(string path, TRequest payload, CancellationToken ct = default)
+    public async Task<TResponse> PostJsonAsync<TRequest, TResponse>(string path, TRequest payload, CancellationToken ct = default)
     {
         using var response = await _httpClient.PostAsJsonAsync(path, payload, ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();

--- a/src/Meridian.Ui.Services/Services/ActivityFeedService.cs
+++ b/src/Meridian.Ui.Services/Services/ActivityFeedService.cs
@@ -284,9 +284,9 @@ public sealed class ActivityFeedService
     {
         try
         {
-            var response = await ApiClientService.Instance.GetAsync<ErrorsResponseDto>(
+            var response = (await ApiClientService.Instance.GetWithResponseAsync<ErrorsResponseDto>(
                 UiApiRoutes.Errors,
-                ct).ConfigureAwait(false);
+                ct).ConfigureAwait(false)).DataOrLoggedNull("Fetch server events");
 
             if (response?.Errors == null)
                 return;

--- a/src/Meridian.Ui.Services/Services/ApiResponseExtensions.cs
+++ b/src/Meridian.Ui.Services/Services/ApiResponseExtensions.cs
@@ -1,0 +1,32 @@
+namespace Meridian.Ui.Services;
+
+/// <summary>
+/// Bridging helpers for callers migrating off the legacy null-returning
+/// <see cref="ApiClientService.GetAsync{T}"/>/<see cref="ApiClientService.PostAsync{T}"/> seam
+/// (audit finding P7). <see cref="DataOrLoggedNull{T}"/> unwraps an <see cref="ApiResponse{T}"/>
+/// to the legacy nullable result while keeping the legacy path's diagnostics: non-404 failures
+/// are logged with the operation context before null is returned. Call sites converted with
+/// this helper are transport-migrated and ratchet-clean; their public contracts move to
+/// <see cref="ApiResponse{T}"/> end-to-end in the follow-on consumer batches.
+/// </summary>
+public static class ApiResponseExtensions
+{
+    public static T? DataOrLoggedNull<T>(this ApiResponse<T> response, string operation) where T : class
+    {
+        if (response.Success)
+        {
+            return response.Data;
+        }
+
+        if (response.StatusCode != 404)
+        {
+            var detail = string.IsNullOrWhiteSpace(response.ErrorMessage)
+                ? string.Empty
+                : $": {response.ErrorMessage}";
+            LoggingService.Instance.LogWarning(
+                $"{operation} failed with {(response.IsConnectionError ? "a connection error" : $"HTTP {response.StatusCode}")}{detail}; returning null.");
+        }
+
+        return response.Data;
+    }
+}

--- a/src/Meridian.Ui.Services/Services/ApiResponseExtensions.cs
+++ b/src/Meridian.Ui.Services/Services/ApiResponseExtensions.cs
@@ -27,6 +27,6 @@ public static class ApiResponseExtensions
                 $"{operation} failed with {(response.IsConnectionError ? "a connection error" : $"HTTP {response.StatusCode}")}{detail}; returning null.");
         }
 
-        return response.Data;
+        return null;
     }
 }

--- a/src/Meridian.Ui.Services/Services/BackfillApiService.cs
+++ b/src/Meridian.Ui.Services/Services/BackfillApiService.cs
@@ -23,7 +23,7 @@ public sealed class BackfillApiService
     /// </summary>
     public async Task<List<BackfillProviderInfo>> GetProvidersAsync(CancellationToken ct = default)
     {
-        var result = (await _apiClient.GetWithResponseAsync<List<BackfillProviderInfo>>(UiApiRoutes.BackfillProviders, ct)).DataOrLoggedNull("Get backfill providers");
+        var result = (await _apiClient.GetWithResponseAsync<List<BackfillProviderInfo>>(UiApiRoutes.BackfillProviders, ct).ConfigureAwait(false)).DataOrLoggedNull("Get backfill providers");
         return result ?? new List<BackfillProviderInfo>();
     }
 
@@ -32,14 +32,14 @@ public sealed class BackfillApiService
     /// </summary>
     public async Task<BackfillResultDto?> GetLastStatusAsync(CancellationToken ct = default)
     {
-        return (await _apiClient.GetWithResponseAsync<BackfillResultDto>(UiApiRoutes.BackfillStatus, ct)).DataOrLoggedNull("Get last backfill status");
+        return (await _apiClient.GetWithResponseAsync<BackfillResultDto>(UiApiRoutes.BackfillStatus, ct).ConfigureAwait(false)).DataOrLoggedNull("Get last backfill status");
     }
 
     /// <summary>
     /// Gets the typed live provider/fallback progress snapshot for the current or latest run.
     /// </summary>
     public async Task<BackfillRunProgressResponse?> GetProgressAsync(CancellationToken ct = default) =>
-        (await _apiClient.GetWithResponseAsync<BackfillRunProgressResponse>(UiApiRoutes.BackfillProgress, ct)).DataOrLoggedNull("Get backfill progress");
+        (await _apiClient.GetWithResponseAsync<BackfillRunProgressResponse>(UiApiRoutes.BackfillProgress, ct).ConfigureAwait(false)).DataOrLoggedNull("Get backfill progress");
 
     /// <summary>
     /// Runs a backfill operation for the specified symbols.
@@ -66,7 +66,7 @@ public sealed class BackfillApiService
             UiApiRoutes.BackfillRun,
             request,
             ct,
-            backfillClient);
+            backfillClient).ConfigureAwait(false);
 
         if (response.Success)
         {
@@ -85,7 +85,7 @@ public sealed class BackfillApiService
     /// </summary>
     public async Task<BackfillHealthResponse?> CheckProviderHealthAsync(CancellationToken ct = default)
     {
-        return (await _apiClient.GetWithResponseAsync<BackfillHealthResponse>(UiApiRoutes.BackfillHealth, ct)).DataOrLoggedNull("Check backfill provider health");
+        return (await _apiClient.GetWithResponseAsync<BackfillHealthResponse>(UiApiRoutes.BackfillHealth, ct).ConfigureAwait(false)).DataOrLoggedNull("Check backfill provider health");
     }
 
     /// <summary>
@@ -109,7 +109,7 @@ public sealed class BackfillApiService
             UiApiRoutes.BackfillGapFill,
             request,
             ct,
-            backfillClient);
+            backfillClient).ConfigureAwait(false);
         return response.Data;
     }
 
@@ -118,7 +118,7 @@ public sealed class BackfillApiService
     /// </summary>
     public async Task<List<BackfillPreset>> GetPresetsAsync(CancellationToken ct = default)
     {
-        var result = (await _apiClient.GetWithResponseAsync<List<BackfillPreset>>(UiApiRoutes.BackfillPresets, ct)).DataOrLoggedNull("Get backfill presets");
+        var result = (await _apiClient.GetWithResponseAsync<List<BackfillPreset>>(UiApiRoutes.BackfillPresets, ct).ConfigureAwait(false)).DataOrLoggedNull("Get backfill presets");
         return result ?? new List<BackfillPreset>();
     }
 
@@ -138,7 +138,7 @@ public sealed class BackfillApiService
         int limit = 50,
         CancellationToken ct = default) =>
         (await _apiClient.GetWithResponseAsync<BackfillExecutionHistoryResponse>(
-            UiApiRoutes.WithQuery(UiApiRoutes.BackfillExecutions, $"limit={limit}"), ct)).DataOrLoggedNull("Get backfill execution history");
+            UiApiRoutes.WithQuery(UiApiRoutes.BackfillExecutions, $"limit={limit}"), ct).ConfigureAwait(false)).DataOrLoggedNull("Get backfill execution history");
 
     /// <summary>
     /// Gets backfill statistics.
@@ -149,7 +149,7 @@ public sealed class BackfillApiService
             ? UiApiRoutes.WithQuery(UiApiRoutes.BackfillStatistics, $"hours={hours.Value}")
             : UiApiRoutes.BackfillStatistics;
 
-        return (await _apiClient.GetWithResponseAsync<BackfillStatistics>(route, ct)).DataOrLoggedNull("Get backfill statistics");
+        return (await _apiClient.GetWithResponseAsync<BackfillStatistics>(route, ct).ConfigureAwait(false)).DataOrLoggedNull("Get backfill statistics");
     }
 
     /// <summary>
@@ -165,7 +165,7 @@ public sealed class BackfillApiService
         if (date != null)
             route = UiApiRoutes.WithQuery(route, $"date={Uri.EscapeDataString(date)}");
 
-        return (await _apiClient.GetWithResponseAsync<SymbolGapAnalysisDto>(route, ct)).DataOrLoggedNull("Get symbol gap analysis");
+        return (await _apiClient.GetWithResponseAsync<SymbolGapAnalysisDto>(route, ct).ConfigureAwait(false)).DataOrLoggedNull("Get symbol gap analysis");
     }
 }
 

--- a/src/Meridian.Ui.Services/Services/BackfillApiService.cs
+++ b/src/Meridian.Ui.Services/Services/BackfillApiService.cs
@@ -23,7 +23,7 @@ public sealed class BackfillApiService
     /// </summary>
     public async Task<List<BackfillProviderInfo>> GetProvidersAsync(CancellationToken ct = default)
     {
-        var result = await _apiClient.GetAsync<List<BackfillProviderInfo>>(UiApiRoutes.BackfillProviders, ct);
+        var result = (await _apiClient.GetWithResponseAsync<List<BackfillProviderInfo>>(UiApiRoutes.BackfillProviders, ct)).DataOrLoggedNull("Get backfill providers");
         return result ?? new List<BackfillProviderInfo>();
     }
 
@@ -32,14 +32,14 @@ public sealed class BackfillApiService
     /// </summary>
     public async Task<BackfillResultDto?> GetLastStatusAsync(CancellationToken ct = default)
     {
-        return await _apiClient.GetAsync<BackfillResultDto>(UiApiRoutes.BackfillStatus, ct);
+        return (await _apiClient.GetWithResponseAsync<BackfillResultDto>(UiApiRoutes.BackfillStatus, ct)).DataOrLoggedNull("Get last backfill status");
     }
 
     /// <summary>
     /// Gets the typed live provider/fallback progress snapshot for the current or latest run.
     /// </summary>
-    public Task<BackfillRunProgressResponse?> GetProgressAsync(CancellationToken ct = default) =>
-        _apiClient.GetAsync<BackfillRunProgressResponse>(UiApiRoutes.BackfillProgress, ct);
+    public async Task<BackfillRunProgressResponse?> GetProgressAsync(CancellationToken ct = default) =>
+        (await _apiClient.GetWithResponseAsync<BackfillRunProgressResponse>(UiApiRoutes.BackfillProgress, ct)).DataOrLoggedNull("Get backfill progress");
 
     /// <summary>
     /// Runs a backfill operation for the specified symbols.
@@ -85,7 +85,7 @@ public sealed class BackfillApiService
     /// </summary>
     public async Task<BackfillHealthResponse?> CheckProviderHealthAsync(CancellationToken ct = default)
     {
-        return await _apiClient.GetAsync<BackfillHealthResponse>(UiApiRoutes.BackfillHealth, ct);
+        return (await _apiClient.GetWithResponseAsync<BackfillHealthResponse>(UiApiRoutes.BackfillHealth, ct)).DataOrLoggedNull("Check backfill provider health");
     }
 
     /// <summary>
@@ -118,7 +118,7 @@ public sealed class BackfillApiService
     /// </summary>
     public async Task<List<BackfillPreset>> GetPresetsAsync(CancellationToken ct = default)
     {
-        var result = await _apiClient.GetAsync<List<BackfillPreset>>(UiApiRoutes.BackfillPresets, ct);
+        var result = (await _apiClient.GetWithResponseAsync<List<BackfillPreset>>(UiApiRoutes.BackfillPresets, ct)).DataOrLoggedNull("Get backfill presets");
         return result ?? new List<BackfillPreset>();
     }
 
@@ -134,11 +134,11 @@ public sealed class BackfillApiService
     /// <summary>
     /// Gets the governed execution-history envelope, including typed remediation SLA evidence.
     /// </summary>
-    public Task<BackfillExecutionHistoryResponse?> GetExecutionHistoryResponseAsync(
+    public async Task<BackfillExecutionHistoryResponse?> GetExecutionHistoryResponseAsync(
         int limit = 50,
         CancellationToken ct = default) =>
-        _apiClient.GetAsync<BackfillExecutionHistoryResponse>(
-            UiApiRoutes.WithQuery(UiApiRoutes.BackfillExecutions, $"limit={limit}"), ct);
+        (await _apiClient.GetWithResponseAsync<BackfillExecutionHistoryResponse>(
+            UiApiRoutes.WithQuery(UiApiRoutes.BackfillExecutions, $"limit={limit}"), ct)).DataOrLoggedNull("Get backfill execution history");
 
     /// <summary>
     /// Gets backfill statistics.
@@ -149,7 +149,7 @@ public sealed class BackfillApiService
             ? UiApiRoutes.WithQuery(UiApiRoutes.BackfillStatistics, $"hours={hours.Value}")
             : UiApiRoutes.BackfillStatistics;
 
-        return await _apiClient.GetAsync<BackfillStatistics>(route, ct);
+        return (await _apiClient.GetWithResponseAsync<BackfillStatistics>(route, ct)).DataOrLoggedNull("Get backfill statistics");
     }
 
     /// <summary>
@@ -165,7 +165,7 @@ public sealed class BackfillApiService
         if (date != null)
             route = UiApiRoutes.WithQuery(route, $"date={Uri.EscapeDataString(date)}");
 
-        return await _apiClient.GetAsync<SymbolGapAnalysisDto>(route, ct);
+        return (await _apiClient.GetWithResponseAsync<SymbolGapAnalysisDto>(route, ct)).DataOrLoggedNull("Get symbol gap analysis");
     }
 }
 

--- a/src/Meridian.Ui.Services/Services/BackfillProviderConfigService.cs
+++ b/src/Meridian.Ui.Services/Services/BackfillProviderConfigService.cs
@@ -23,9 +23,9 @@ public sealed class BackfillProviderConfigService : IBackfillProviderConfigAudit
     public static BackfillProviderConfigService Instance => _instance.Value;
 
     private BackfillProviderConfigService()
-        : this(ct => ApiClientService.Instance.GetAsync<BackfillProviderStatusDto[]>(
+        : this(async ct => (await ApiClientService.Instance.GetWithResponseAsync<BackfillProviderStatusDto[]>(
             "/api/backfill/providers/statuses",
-            ct))
+            ct)).DataOrLoggedNull("Get backfill provider statuses"))
     {
     }
 

--- a/src/Meridian.Ui.Services/Services/BackfillProviderConfigService.cs
+++ b/src/Meridian.Ui.Services/Services/BackfillProviderConfigService.cs
@@ -25,7 +25,7 @@ public sealed class BackfillProviderConfigService : IBackfillProviderConfigAudit
     private BackfillProviderConfigService()
         : this(async ct => (await ApiClientService.Instance.GetWithResponseAsync<BackfillProviderStatusDto[]>(
             "/api/backfill/providers/statuses",
-            ct)).DataOrLoggedNull("Get backfill provider statuses"))
+            ct).ConfigureAwait(false)).DataOrLoggedNull("Get backfill provider statuses"))
     {
     }
 

--- a/src/Meridian.Ui.Services/Services/DataQuality/DataQualityApiClient.cs
+++ b/src/Meridian.Ui.Services/Services/DataQuality/DataQualityApiClient.cs
@@ -65,11 +65,11 @@ public sealed class DataQualityApiClient : DataQualityServiceBase, IDataQualityA
         return response.Success ? response.Data : null;
     }
 
-    protected override Task<T?> GetAsync<T>(string endpoint, CancellationToken ct) where T : class
-        => _apiClient.GetAsync<T>(endpoint, ct);
+    protected override async Task<T?> GetAsync<T>(string endpoint, CancellationToken ct) where T : class
+        => (await _apiClient.GetWithResponseAsync<T>(endpoint, ct)).DataOrLoggedNull("Data quality API GET request");
 
-    protected override Task<T?> PostAsync<T>(string endpoint, object? body, CancellationToken ct) where T : class
-        => _apiClient.PostAsync<T>(endpoint, body, ct);
+    protected override async Task<T?> PostAsync<T>(string endpoint, object? body, CancellationToken ct) where T : class
+        => (await _apiClient.PostWithResponseAsync<T>(endpoint, body, ct)).DataOrLoggedNull("Data quality API POST request");
 
     protected override async Task<(bool Success, T? Data)> PostWithResponseAsync<T>(string endpoint, object? body, CancellationToken ct)
         where T : class

--- a/src/Meridian.Ui.Services/Services/DataQuality/DataQualityApiClient.cs
+++ b/src/Meridian.Ui.Services/Services/DataQuality/DataQualityApiClient.cs
@@ -49,7 +49,7 @@ public sealed class DataQualityApiClient : DataQualityServiceBase, IDataQualityA
         var (success, _) = await PostWithResponseAsync<QualityAnomalyAcknowledgementResponse>(
             UiApiRoutes.WithParam(UiApiRoutes.QualityAnomaliesAcknowledge, "anomalyId", anomalyId),
             null,
-            ct);
+            ct).ConfigureAwait(false);
         return success;
     }
 
@@ -61,20 +61,20 @@ public sealed class DataQualityApiClient : DataQualityServiceBase, IDataQualityA
         var response = await _apiClient.PostWithResponseAsync<QualityGapRemediationResponse>(
             UiApiRoutes.WithParam(UiApiRoutes.QualityGapsBySymbol, "symbol", symbol),
             request,
-            ct);
+            ct).ConfigureAwait(false);
         return response.Success ? response.Data : null;
     }
 
     protected override async Task<T?> GetAsync<T>(string endpoint, CancellationToken ct) where T : class
-        => (await _apiClient.GetWithResponseAsync<T>(endpoint, ct)).DataOrLoggedNull("Data quality API GET request");
+        => (await _apiClient.GetWithResponseAsync<T>(endpoint, ct).ConfigureAwait(false)).DataOrLoggedNull("Data quality API GET request");
 
     protected override async Task<T?> PostAsync<T>(string endpoint, object? body, CancellationToken ct) where T : class
-        => (await _apiClient.PostWithResponseAsync<T>(endpoint, body, ct)).DataOrLoggedNull("Data quality API POST request");
+        => (await _apiClient.PostWithResponseAsync<T>(endpoint, body, ct).ConfigureAwait(false)).DataOrLoggedNull("Data quality API POST request");
 
     protected override async Task<(bool Success, T? Data)> PostWithResponseAsync<T>(string endpoint, object? body, CancellationToken ct)
         where T : class
     {
-        var response = await _apiClient.PostWithResponseAsync<T>(endpoint, body, ct);
+        var response = await _apiClient.PostWithResponseAsync<T>(endpoint, body, ct).ConfigureAwait(false);
         return (response.Success, response.Data);
     }
 }

--- a/src/Meridian.Ui.Services/Services/LiveDataService.cs
+++ b/src/Meridian.Ui.Services/Services/LiveDataService.cs
@@ -20,7 +20,7 @@ public sealed class LiveDataService
     /// </summary>
     public async Task<List<TradeEvent>?> GetRecentTradesAsync(string symbol, int limit = 100, CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.GetWithResponseAsync<List<TradeEvent>>($"/api/data/trades/{symbol}?limit={limit}", ct)).DataOrLoggedNull("Get recent trades");
+        return (await ApiClientService.Instance.GetWithResponseAsync<List<TradeEvent>>($"/api/data/trades/{symbol}?limit={limit}", ct).ConfigureAwait(false)).DataOrLoggedNull("Get recent trades");
     }
 
     /// <summary>
@@ -28,7 +28,7 @@ public sealed class LiveDataService
     /// </summary>
     public async Task<List<QuoteEvent>?> GetRecentQuotesAsync(string symbol, int limit = 100, CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.GetWithResponseAsync<List<QuoteEvent>>($"/api/data/quotes/{symbol}?limit={limit}", ct)).DataOrLoggedNull("Get recent quotes");
+        return (await ApiClientService.Instance.GetWithResponseAsync<List<QuoteEvent>>($"/api/data/quotes/{symbol}?limit={limit}", ct).ConfigureAwait(false)).DataOrLoggedNull("Get recent quotes");
     }
 
     /// <summary>
@@ -36,7 +36,7 @@ public sealed class LiveDataService
     /// </summary>
     public async Task<OrderBookSnapshot?> GetOrderBookAsync(string symbol, int levels = 10, CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.GetWithResponseAsync<OrderBookSnapshot>($"/api/data/orderbook/{symbol}?levels={levels}", ct)).DataOrLoggedNull("Get order book snapshot");
+        return (await ApiClientService.Instance.GetWithResponseAsync<OrderBookSnapshot>($"/api/data/orderbook/{symbol}?levels={levels}", ct).ConfigureAwait(false)).DataOrLoggedNull("Get order book snapshot");
     }
 
     /// <summary>
@@ -44,7 +44,7 @@ public sealed class LiveDataService
     /// </summary>
     public async Task<BboQuote?> GetBboAsync(string symbol, CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.GetWithResponseAsync<BboQuote>($"/api/data/bbo/{symbol}", ct)).DataOrLoggedNull("Get BBO quote");
+        return (await ApiClientService.Instance.GetWithResponseAsync<BboQuote>($"/api/data/bbo/{symbol}", ct).ConfigureAwait(false)).DataOrLoggedNull("Get BBO quote");
     }
 
     /// <summary>
@@ -52,7 +52,7 @@ public sealed class LiveDataService
     /// </summary>
     public async Task<OrderFlowStats?> GetOrderFlowStatsAsync(string symbol, CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.GetWithResponseAsync<OrderFlowStats>($"/api/data/orderflow/{symbol}", ct)).DataOrLoggedNull("Get order flow statistics");
+        return (await ApiClientService.Instance.GetWithResponseAsync<OrderFlowStats>($"/api/data/orderflow/{symbol}", ct).ConfigureAwait(false)).DataOrLoggedNull("Get order flow statistics");
     }
 
     /// <summary>
@@ -60,7 +60,7 @@ public sealed class LiveDataService
     /// </summary>
     public async Task<List<SubscriptionInfo>?> GetActiveSubscriptionsAsync(CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.GetWithResponseAsync<List<SubscriptionInfo>>("/api/subscriptions/active", ct)).DataOrLoggedNull("Get active subscriptions");
+        return (await ApiClientService.Instance.GetWithResponseAsync<List<SubscriptionInfo>>("/api/subscriptions/active", ct).ConfigureAwait(false)).DataOrLoggedNull("Get active subscriptions");
     }
 
     /// <summary>
@@ -68,7 +68,7 @@ public sealed class LiveDataService
     /// </summary>
     public async Task<SubscriptionResult?> SubscribeAsync(SubscribeRequest request, CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.PostWithResponseAsync<SubscriptionResult>("/api/subscriptions/subscribe", request, ct)).DataOrLoggedNull("Subscribe to symbol");
+        return (await ApiClientService.Instance.PostWithResponseAsync<SubscriptionResult>("/api/subscriptions/subscribe", request, ct).ConfigureAwait(false)).DataOrLoggedNull("Subscribe to symbol");
     }
 
     /// <summary>
@@ -76,7 +76,7 @@ public sealed class LiveDataService
     /// </summary>
     public async Task<bool> UnsubscribeAsync(string symbol, CancellationToken ct = default)
     {
-        var response = await ApiClientService.Instance.PostWithResponseAsync<UnsubscribeResponse>($"/api/subscriptions/unsubscribe/{symbol}", null, ct);
+        var response = await ApiClientService.Instance.PostWithResponseAsync<UnsubscribeResponse>($"/api/subscriptions/unsubscribe/{symbol}", null, ct).ConfigureAwait(false);
         return response.Success;
     }
 
@@ -85,7 +85,7 @@ public sealed class LiveDataService
     /// </summary>
     public async Task<DataStreamHealth?> GetStreamHealthAsync(CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.GetWithResponseAsync<DataStreamHealth>("/api/data/health", ct)).DataOrLoggedNull("Get data stream health");
+        return (await ApiClientService.Instance.GetWithResponseAsync<DataStreamHealth>("/api/data/health", ct).ConfigureAwait(false)).DataOrLoggedNull("Get data stream health");
     }
 }
 

--- a/src/Meridian.Ui.Services/Services/LiveDataService.cs
+++ b/src/Meridian.Ui.Services/Services/LiveDataService.cs
@@ -20,7 +20,7 @@ public sealed class LiveDataService
     /// </summary>
     public async Task<List<TradeEvent>?> GetRecentTradesAsync(string symbol, int limit = 100, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<List<TradeEvent>>($"/api/data/trades/{symbol}?limit={limit}", ct);
+        return (await ApiClientService.Instance.GetWithResponseAsync<List<TradeEvent>>($"/api/data/trades/{symbol}?limit={limit}", ct)).DataOrLoggedNull("Get recent trades");
     }
 
     /// <summary>
@@ -28,7 +28,7 @@ public sealed class LiveDataService
     /// </summary>
     public async Task<List<QuoteEvent>?> GetRecentQuotesAsync(string symbol, int limit = 100, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<List<QuoteEvent>>($"/api/data/quotes/{symbol}?limit={limit}", ct);
+        return (await ApiClientService.Instance.GetWithResponseAsync<List<QuoteEvent>>($"/api/data/quotes/{symbol}?limit={limit}", ct)).DataOrLoggedNull("Get recent quotes");
     }
 
     /// <summary>
@@ -36,7 +36,7 @@ public sealed class LiveDataService
     /// </summary>
     public async Task<OrderBookSnapshot?> GetOrderBookAsync(string symbol, int levels = 10, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<OrderBookSnapshot>($"/api/data/orderbook/{symbol}?levels={levels}", ct);
+        return (await ApiClientService.Instance.GetWithResponseAsync<OrderBookSnapshot>($"/api/data/orderbook/{symbol}?levels={levels}", ct)).DataOrLoggedNull("Get order book snapshot");
     }
 
     /// <summary>
@@ -44,7 +44,7 @@ public sealed class LiveDataService
     /// </summary>
     public async Task<BboQuote?> GetBboAsync(string symbol, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<BboQuote>($"/api/data/bbo/{symbol}", ct);
+        return (await ApiClientService.Instance.GetWithResponseAsync<BboQuote>($"/api/data/bbo/{symbol}", ct)).DataOrLoggedNull("Get BBO quote");
     }
 
     /// <summary>
@@ -52,7 +52,7 @@ public sealed class LiveDataService
     /// </summary>
     public async Task<OrderFlowStats?> GetOrderFlowStatsAsync(string symbol, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<OrderFlowStats>($"/api/data/orderflow/{symbol}", ct);
+        return (await ApiClientService.Instance.GetWithResponseAsync<OrderFlowStats>($"/api/data/orderflow/{symbol}", ct)).DataOrLoggedNull("Get order flow statistics");
     }
 
     /// <summary>
@@ -60,7 +60,7 @@ public sealed class LiveDataService
     /// </summary>
     public async Task<List<SubscriptionInfo>?> GetActiveSubscriptionsAsync(CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<List<SubscriptionInfo>>("/api/subscriptions/active", ct);
+        return (await ApiClientService.Instance.GetWithResponseAsync<List<SubscriptionInfo>>("/api/subscriptions/active", ct)).DataOrLoggedNull("Get active subscriptions");
     }
 
     /// <summary>
@@ -68,7 +68,7 @@ public sealed class LiveDataService
     /// </summary>
     public async Task<SubscriptionResult?> SubscribeAsync(SubscribeRequest request, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.PostAsync<SubscriptionResult>("/api/subscriptions/subscribe", request, ct);
+        return (await ApiClientService.Instance.PostWithResponseAsync<SubscriptionResult>("/api/subscriptions/subscribe", request, ct)).DataOrLoggedNull("Subscribe to symbol");
     }
 
     /// <summary>
@@ -85,7 +85,7 @@ public sealed class LiveDataService
     /// </summary>
     public async Task<DataStreamHealth?> GetStreamHealthAsync(CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<DataStreamHealth>("/api/data/health", ct);
+        return (await ApiClientService.Instance.GetWithResponseAsync<DataStreamHealth>("/api/data/health", ct)).DataOrLoggedNull("Get data stream health");
     }
 }
 

--- a/src/Meridian.Ui.Services/Services/ProviderDiagnostics/ProviderDiagnosticsApiClient.cs
+++ b/src/Meridian.Ui.Services/Services/ProviderDiagnostics/ProviderDiagnosticsApiClient.cs
@@ -31,14 +31,14 @@ public sealed class ProviderDiagnosticsApiClient : IProviderDiagnosticsApiClient
     }
 
     public async Task<ProviderCatalogResponse> GetCatalogAsync(CancellationToken ct = default)
-        => (await _apiClient.GetWithResponseAsync<ProviderCatalogResponse>(UiApiRoutes.ProviderCatalog, ct)).DataOrLoggedNull("Get provider catalog")
+        => (await _apiClient.GetWithResponseAsync<ProviderCatalogResponse>(UiApiRoutes.ProviderCatalog, ct).ConfigureAwait(false)).DataOrLoggedNull("Get provider catalog")
             ?? throw new InvalidOperationException("Provider catalog registration evidence was unavailable.");
 
     public async Task<ProviderRateLimitsResponse> GetRateLimitsAsync(CancellationToken ct = default)
-        => (await _apiClient.GetWithResponseAsync<ProviderRateLimitsResponse>(UiApiRoutes.ProviderRateLimits, ct)).DataOrLoggedNull("Get provider rate limits")
+        => (await _apiClient.GetWithResponseAsync<ProviderRateLimitsResponse>(UiApiRoutes.ProviderRateLimits, ct).ConfigureAwait(false)).DataOrLoggedNull("Get provider rate limits")
             ?? throw new InvalidOperationException("Current provider rate-limit evidence was unavailable.");
 
     public async Task<ProviderConnectionHealthResponse> GetConnectionHealthAsync(CancellationToken ct = default)
-        => (await _apiClient.GetWithResponseAsync<ProviderConnectionHealthResponse>(UiApiRoutes.ProviderHealth, ct)).DataOrLoggedNull("Get provider connection health")
+        => (await _apiClient.GetWithResponseAsync<ProviderConnectionHealthResponse>(UiApiRoutes.ProviderHealth, ct).ConfigureAwait(false)).DataOrLoggedNull("Get provider connection health")
             ?? throw new InvalidOperationException("Current provider connection diagnostics were unavailable.");
 }

--- a/src/Meridian.Ui.Services/Services/ProviderDiagnostics/ProviderDiagnosticsApiClient.cs
+++ b/src/Meridian.Ui.Services/Services/ProviderDiagnostics/ProviderDiagnosticsApiClient.cs
@@ -31,14 +31,14 @@ public sealed class ProviderDiagnosticsApiClient : IProviderDiagnosticsApiClient
     }
 
     public async Task<ProviderCatalogResponse> GetCatalogAsync(CancellationToken ct = default)
-        => await _apiClient.GetAsync<ProviderCatalogResponse>(UiApiRoutes.ProviderCatalog, ct)
+        => (await _apiClient.GetWithResponseAsync<ProviderCatalogResponse>(UiApiRoutes.ProviderCatalog, ct)).DataOrLoggedNull("Get provider catalog")
             ?? throw new InvalidOperationException("Provider catalog registration evidence was unavailable.");
 
     public async Task<ProviderRateLimitsResponse> GetRateLimitsAsync(CancellationToken ct = default)
-        => await _apiClient.GetAsync<ProviderRateLimitsResponse>(UiApiRoutes.ProviderRateLimits, ct)
+        => (await _apiClient.GetWithResponseAsync<ProviderRateLimitsResponse>(UiApiRoutes.ProviderRateLimits, ct)).DataOrLoggedNull("Get provider rate limits")
             ?? throw new InvalidOperationException("Current provider rate-limit evidence was unavailable.");
 
     public async Task<ProviderConnectionHealthResponse> GetConnectionHealthAsync(CancellationToken ct = default)
-        => await _apiClient.GetAsync<ProviderConnectionHealthResponse>(UiApiRoutes.ProviderHealth, ct)
+        => (await _apiClient.GetWithResponseAsync<ProviderConnectionHealthResponse>(UiApiRoutes.ProviderHealth, ct)).DataOrLoggedNull("Get provider connection health")
             ?? throw new InvalidOperationException("Current provider connection diagnostics were unavailable.");
 }

--- a/src/Meridian.Ui.Services/Services/ScheduleManagerService.cs
+++ b/src/Meridian.Ui.Services/Services/ScheduleManagerService.cs
@@ -23,7 +23,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<List<BackfillSchedule>?> GetBackfillSchedulesAsync(CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.GetWithResponseAsync<List<BackfillSchedule>>(UiApiRoutes.BackfillSchedules, ct)).DataOrLoggedNull("Get backfill schedules");
+        return (await ApiClientService.Instance.GetWithResponseAsync<List<BackfillSchedule>>(UiApiRoutes.BackfillSchedules, ct).ConfigureAwait(false)).DataOrLoggedNull("Get backfill schedules");
     }
 
     /// <summary>
@@ -31,7 +31,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<BackfillSchedule?> GetBackfillScheduleAsync(string id, CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.GetWithResponseAsync<BackfillSchedule>(BuildBackfillScheduleRoute(id), ct)).DataOrLoggedNull("Get backfill schedule");
+        return (await ApiClientService.Instance.GetWithResponseAsync<BackfillSchedule>(BuildBackfillScheduleRoute(id), ct).ConfigureAwait(false)).DataOrLoggedNull("Get backfill schedule");
     }
 
     /// <summary>
@@ -39,7 +39,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<BackfillSchedule?> CreateBackfillScheduleAsync(CreateBackfillScheduleRequest request, CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.PostWithResponseAsync<BackfillSchedule>(UiApiRoutes.BackfillSchedules, request, ct)).DataOrLoggedNull("Create backfill schedule");
+        return (await ApiClientService.Instance.PostWithResponseAsync<BackfillSchedule>(UiApiRoutes.BackfillSchedules, request, ct).ConfigureAwait(false)).DataOrLoggedNull("Create backfill schedule");
     }
 
     /// <summary>
@@ -47,7 +47,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<BackfillSchedule?> UpdateBackfillScheduleAsync(string id, UpdateBackfillScheduleRequest request, CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.PostWithResponseAsync<BackfillSchedule>(BuildBackfillScheduleRoute(id), request, ct)).DataOrLoggedNull("Update backfill schedule");
+        return (await ApiClientService.Instance.PostWithResponseAsync<BackfillSchedule>(BuildBackfillScheduleRoute(id), request, ct).ConfigureAwait(false)).DataOrLoggedNull("Update backfill schedule");
     }
 
     /// <summary>
@@ -55,7 +55,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<bool> DeleteBackfillScheduleAsync(string id, CancellationToken ct = default)
     {
-        var response = await ApiClientService.Instance.PostWithResponseAsync<DeleteResponse>(BuildBackfillScheduleDeleteRoute(id), null, ct);
+        var response = await ApiClientService.Instance.PostWithResponseAsync<DeleteResponse>(BuildBackfillScheduleDeleteRoute(id), null, ct).ConfigureAwait(false);
         return response.Success;
     }
 
@@ -65,7 +65,7 @@ public sealed class ScheduleManagerService
     public async Task<bool> SetBackfillScheduleEnabledAsync(string id, bool enabled, CancellationToken ct = default)
     {
         var response = await ApiClientService.Instance.PostWithResponseAsync<EnableResponse>(
-            BuildBackfillScheduleEnabledRoute(id, enabled), null, ct);
+            BuildBackfillScheduleEnabledRoute(id, enabled), null, ct).ConfigureAwait(false);
         return response.Success;
     }
 
@@ -74,7 +74,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<ScheduleExecutionResult?> RunBackfillScheduleNowAsync(string id, CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.PostWithResponseAsync<ScheduleExecutionResult>(BuildBackfillScheduleRunRoute(id), null, ct)).DataOrLoggedNull("Run backfill schedule");
+        return (await ApiClientService.Instance.PostWithResponseAsync<ScheduleExecutionResult>(BuildBackfillScheduleRunRoute(id), null, ct).ConfigureAwait(false)).DataOrLoggedNull("Run backfill schedule");
     }
 
     /// <summary>
@@ -82,7 +82,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<List<ScheduleExecutionLog>?> GetBackfillExecutionHistoryAsync(string id, int limit = 50, CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.GetWithResponseAsync<List<ScheduleExecutionLog>>(BuildBackfillScheduleHistoryRoute(id, limit), ct)).DataOrLoggedNull("Get backfill schedule history");
+        return (await ApiClientService.Instance.GetWithResponseAsync<List<ScheduleExecutionLog>>(BuildBackfillScheduleHistoryRoute(id, limit), ct).ConfigureAwait(false)).DataOrLoggedNull("Get backfill schedule history");
     }
 
     /// <summary>
@@ -90,7 +90,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<List<ScheduleTemplate>?> GetBackfillTemplatesAsync(CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.GetWithResponseAsync<List<ScheduleTemplate>>(UiApiRoutes.BackfillSchedulesTemplates, ct)).DataOrLoggedNull("Get schedule templates");
+        return (await ApiClientService.Instance.GetWithResponseAsync<List<ScheduleTemplate>>(UiApiRoutes.BackfillSchedulesTemplates, ct).ConfigureAwait(false)).DataOrLoggedNull("Get schedule templates");
     }
 
 
@@ -100,7 +100,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<List<MaintenanceSchedule>?> GetMaintenanceSchedulesAsync(CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.GetWithResponseAsync<List<MaintenanceSchedule>>(UiApiRoutes.MaintenanceSchedules, ct)).DataOrLoggedNull("Get maintenance schedules");
+        return (await ApiClientService.Instance.GetWithResponseAsync<List<MaintenanceSchedule>>(UiApiRoutes.MaintenanceSchedules, ct).ConfigureAwait(false)).DataOrLoggedNull("Get maintenance schedules");
     }
 
     /// <summary>
@@ -108,7 +108,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<MaintenanceSchedule?> CreateMaintenanceScheduleAsync(CreateMaintenanceScheduleRequest request, CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.PostWithResponseAsync<MaintenanceSchedule>(UiApiRoutes.MaintenanceSchedules, request, ct)).DataOrLoggedNull("Create maintenance schedule");
+        return (await ApiClientService.Instance.PostWithResponseAsync<MaintenanceSchedule>(UiApiRoutes.MaintenanceSchedules, request, ct).ConfigureAwait(false)).DataOrLoggedNull("Create maintenance schedule");
     }
 
     /// <summary>
@@ -116,7 +116,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<MaintenanceSchedule?> UpdateMaintenanceScheduleAsync(string id, UpdateMaintenanceScheduleRequest request, CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.PostWithResponseAsync<MaintenanceSchedule>(BuildMaintenanceScheduleRoute(id), request, ct)).DataOrLoggedNull("Update maintenance schedule");
+        return (await ApiClientService.Instance.PostWithResponseAsync<MaintenanceSchedule>(BuildMaintenanceScheduleRoute(id), request, ct).ConfigureAwait(false)).DataOrLoggedNull("Update maintenance schedule");
     }
 
     /// <summary>
@@ -124,7 +124,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<bool> DeleteMaintenanceScheduleAsync(string id, CancellationToken ct = default)
     {
-        var response = await ApiClientService.Instance.PostWithResponseAsync<DeleteResponse>(BuildMaintenanceScheduleDeleteRoute(id), null, ct);
+        var response = await ApiClientService.Instance.PostWithResponseAsync<DeleteResponse>(BuildMaintenanceScheduleDeleteRoute(id), null, ct).ConfigureAwait(false);
         return response.Success;
     }
 
@@ -134,7 +134,7 @@ public sealed class ScheduleManagerService
     public async Task<bool> SetMaintenanceScheduleEnabledAsync(string id, bool enabled, CancellationToken ct = default)
     {
         var response = await ApiClientService.Instance.PostWithResponseAsync<EnableResponse>(
-            BuildMaintenanceScheduleEnabledRoute(id, enabled), null, ct);
+            BuildMaintenanceScheduleEnabledRoute(id, enabled), null, ct).ConfigureAwait(false);
         return response.Success;
     }
 
@@ -143,7 +143,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<ScheduleExecutionResult?> RunMaintenanceScheduleNowAsync(string id, CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.PostWithResponseAsync<ScheduleExecutionResult>(BuildMaintenanceScheduleRunRoute(id), null, ct)).DataOrLoggedNull("Run maintenance schedule");
+        return (await ApiClientService.Instance.PostWithResponseAsync<ScheduleExecutionResult>(BuildMaintenanceScheduleRunRoute(id), null, ct).ConfigureAwait(false)).DataOrLoggedNull("Run maintenance schedule");
     }
 
     /// <summary>
@@ -151,7 +151,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<List<ScheduleExecutionLog>?> GetMaintenanceExecutionHistoryAsync(string id, int limit = 50, CancellationToken ct = default)
     {
-        return (await ApiClientService.Instance.GetWithResponseAsync<List<ScheduleExecutionLog>>(BuildMaintenanceScheduleHistoryRoute(id, limit), ct)).DataOrLoggedNull("Get maintenance schedule history");
+        return (await ApiClientService.Instance.GetWithResponseAsync<List<ScheduleExecutionLog>>(BuildMaintenanceScheduleHistoryRoute(id, limit), ct).ConfigureAwait(false)).DataOrLoggedNull("Get maintenance schedule history");
     }
 
 
@@ -164,7 +164,7 @@ public sealed class ScheduleManagerService
         return (await ApiClientService.Instance.PostWithResponseAsync<CronValidationResult>(
             UiApiRoutes.SchedulesCronValidate,
             new { expression = cronExpression },
-            ct)).DataOrLoggedNull("Validate cron expression");
+            ct).ConfigureAwait(false)).DataOrLoggedNull("Validate cron expression");
     }
 
     /// <summary>
@@ -175,7 +175,7 @@ public sealed class ScheduleManagerService
         return (await ApiClientService.Instance.PostWithResponseAsync<List<DateTime>>(
             UiApiRoutes.SchedulesCronNextRuns,
             new { expression = cronExpression, count },
-            ct)).DataOrLoggedNull("Get cron next run times");
+            ct).ConfigureAwait(false)).DataOrLoggedNull("Get cron next run times");
     }
 
     internal static string BuildBackfillScheduleRoute(string id)

--- a/src/Meridian.Ui.Services/Services/ScheduleManagerService.cs
+++ b/src/Meridian.Ui.Services/Services/ScheduleManagerService.cs
@@ -23,7 +23,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<List<BackfillSchedule>?> GetBackfillSchedulesAsync(CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<List<BackfillSchedule>>(UiApiRoutes.BackfillSchedules, ct);
+        return (await ApiClientService.Instance.GetWithResponseAsync<List<BackfillSchedule>>(UiApiRoutes.BackfillSchedules, ct)).DataOrLoggedNull("Get backfill schedules");
     }
 
     /// <summary>
@@ -31,7 +31,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<BackfillSchedule?> GetBackfillScheduleAsync(string id, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<BackfillSchedule>(BuildBackfillScheduleRoute(id), ct);
+        return (await ApiClientService.Instance.GetWithResponseAsync<BackfillSchedule>(BuildBackfillScheduleRoute(id), ct)).DataOrLoggedNull("Get backfill schedule");
     }
 
     /// <summary>
@@ -39,7 +39,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<BackfillSchedule?> CreateBackfillScheduleAsync(CreateBackfillScheduleRequest request, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.PostAsync<BackfillSchedule>(UiApiRoutes.BackfillSchedules, request, ct);
+        return (await ApiClientService.Instance.PostWithResponseAsync<BackfillSchedule>(UiApiRoutes.BackfillSchedules, request, ct)).DataOrLoggedNull("Create backfill schedule");
     }
 
     /// <summary>
@@ -47,7 +47,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<BackfillSchedule?> UpdateBackfillScheduleAsync(string id, UpdateBackfillScheduleRequest request, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.PostAsync<BackfillSchedule>(BuildBackfillScheduleRoute(id), request, ct);
+        return (await ApiClientService.Instance.PostWithResponseAsync<BackfillSchedule>(BuildBackfillScheduleRoute(id), request, ct)).DataOrLoggedNull("Update backfill schedule");
     }
 
     /// <summary>
@@ -74,7 +74,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<ScheduleExecutionResult?> RunBackfillScheduleNowAsync(string id, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.PostAsync<ScheduleExecutionResult>(BuildBackfillScheduleRunRoute(id), null, ct);
+        return (await ApiClientService.Instance.PostWithResponseAsync<ScheduleExecutionResult>(BuildBackfillScheduleRunRoute(id), null, ct)).DataOrLoggedNull("Run backfill schedule");
     }
 
     /// <summary>
@@ -82,7 +82,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<List<ScheduleExecutionLog>?> GetBackfillExecutionHistoryAsync(string id, int limit = 50, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<List<ScheduleExecutionLog>>(BuildBackfillScheduleHistoryRoute(id, limit), ct);
+        return (await ApiClientService.Instance.GetWithResponseAsync<List<ScheduleExecutionLog>>(BuildBackfillScheduleHistoryRoute(id, limit), ct)).DataOrLoggedNull("Get backfill schedule history");
     }
 
     /// <summary>
@@ -90,7 +90,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<List<ScheduleTemplate>?> GetBackfillTemplatesAsync(CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<List<ScheduleTemplate>>(UiApiRoutes.BackfillSchedulesTemplates, ct);
+        return (await ApiClientService.Instance.GetWithResponseAsync<List<ScheduleTemplate>>(UiApiRoutes.BackfillSchedulesTemplates, ct)).DataOrLoggedNull("Get schedule templates");
     }
 
 
@@ -100,7 +100,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<List<MaintenanceSchedule>?> GetMaintenanceSchedulesAsync(CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<List<MaintenanceSchedule>>(UiApiRoutes.MaintenanceSchedules, ct);
+        return (await ApiClientService.Instance.GetWithResponseAsync<List<MaintenanceSchedule>>(UiApiRoutes.MaintenanceSchedules, ct)).DataOrLoggedNull("Get maintenance schedules");
     }
 
     /// <summary>
@@ -108,7 +108,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<MaintenanceSchedule?> CreateMaintenanceScheduleAsync(CreateMaintenanceScheduleRequest request, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.PostAsync<MaintenanceSchedule>(UiApiRoutes.MaintenanceSchedules, request, ct);
+        return (await ApiClientService.Instance.PostWithResponseAsync<MaintenanceSchedule>(UiApiRoutes.MaintenanceSchedules, request, ct)).DataOrLoggedNull("Create maintenance schedule");
     }
 
     /// <summary>
@@ -116,7 +116,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<MaintenanceSchedule?> UpdateMaintenanceScheduleAsync(string id, UpdateMaintenanceScheduleRequest request, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.PostAsync<MaintenanceSchedule>(BuildMaintenanceScheduleRoute(id), request, ct);
+        return (await ApiClientService.Instance.PostWithResponseAsync<MaintenanceSchedule>(BuildMaintenanceScheduleRoute(id), request, ct)).DataOrLoggedNull("Update maintenance schedule");
     }
 
     /// <summary>
@@ -143,7 +143,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<ScheduleExecutionResult?> RunMaintenanceScheduleNowAsync(string id, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.PostAsync<ScheduleExecutionResult>(BuildMaintenanceScheduleRunRoute(id), null, ct);
+        return (await ApiClientService.Instance.PostWithResponseAsync<ScheduleExecutionResult>(BuildMaintenanceScheduleRunRoute(id), null, ct)).DataOrLoggedNull("Run maintenance schedule");
     }
 
     /// <summary>
@@ -151,7 +151,7 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<List<ScheduleExecutionLog>?> GetMaintenanceExecutionHistoryAsync(string id, int limit = 50, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.GetAsync<List<ScheduleExecutionLog>>(BuildMaintenanceScheduleHistoryRoute(id, limit), ct);
+        return (await ApiClientService.Instance.GetWithResponseAsync<List<ScheduleExecutionLog>>(BuildMaintenanceScheduleHistoryRoute(id, limit), ct)).DataOrLoggedNull("Get maintenance schedule history");
     }
 
 
@@ -161,10 +161,10 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<CronValidationResult?> ValidateCronExpressionAsync(string cronExpression, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.PostAsync<CronValidationResult>(
+        return (await ApiClientService.Instance.PostWithResponseAsync<CronValidationResult>(
             UiApiRoutes.SchedulesCronValidate,
             new { expression = cronExpression },
-            ct);
+            ct)).DataOrLoggedNull("Validate cron expression");
     }
 
     /// <summary>
@@ -172,10 +172,10 @@ public sealed class ScheduleManagerService
     /// </summary>
     public async Task<List<DateTime>?> GetNextRunTimesAsync(string cronExpression, int count = 5, CancellationToken ct = default)
     {
-        return await ApiClientService.Instance.PostAsync<List<DateTime>>(
+        return (await ApiClientService.Instance.PostWithResponseAsync<List<DateTime>>(
             UiApiRoutes.SchedulesCronNextRuns,
             new { expression = cronExpression, count },
-            ct);
+            ct)).DataOrLoggedNull("Get cron next run times");
     }
 
     internal static string BuildBackfillScheduleRoute(string id)

--- a/src/Meridian.Ui.Services/Services/StorageServiceBase.cs
+++ b/src/Meridian.Ui.Services/Services/StorageServiceBase.cs
@@ -29,7 +29,7 @@ public class StorageServiceBase
     /// </summary>
     public async Task<StorageStatsSummary?> GetStorageStatsAsync(CancellationToken ct = default)
     {
-        return await _apiClient.GetAsync<StorageStatsSummary>(UiApiRoutes.StorageStats, ct);
+        return (await _apiClient.GetWithResponseAsync<StorageStatsSummary>(UiApiRoutes.StorageStats, ct)).DataOrLoggedNull("Get storage statistics");
     }
 
     /// <summary>
@@ -37,7 +37,7 @@ public class StorageServiceBase
     /// </summary>
     public async Task<List<StorageCategory>?> GetStorageBreakdownAsync(CancellationToken ct = default)
     {
-        return await _apiClient.GetAsync<List<StorageCategory>>(UiApiRoutes.StorageBreakdown, ct);
+        return (await _apiClient.GetWithResponseAsync<List<StorageCategory>>(UiApiRoutes.StorageBreakdown, ct)).DataOrLoggedNull("Get storage breakdown");
     }
 
     /// <summary>
@@ -45,8 +45,8 @@ public class StorageServiceBase
     /// </summary>
     public async Task<SymbolStorageInfo?> GetSymbolInfoAsync(string symbol, CancellationToken ct = default)
     {
-        return await _apiClient.GetAsync<SymbolStorageInfo>(
-            UiApiRoutes.WithParam(UiApiRoutes.StorageSymbolInfo, "symbol", symbol), ct);
+        return (await _apiClient.GetWithResponseAsync<SymbolStorageInfo>(
+            UiApiRoutes.WithParam(UiApiRoutes.StorageSymbolInfo, "symbol", symbol), ct)).DataOrLoggedNull("Get symbol storage info");
     }
 
     /// <summary>
@@ -54,8 +54,8 @@ public class StorageServiceBase
     /// </summary>
     public async Task<SymbolStorageStats?> GetSymbolStorageStatsAsync(string symbol, CancellationToken ct = default)
     {
-        return await _apiClient.GetAsync<SymbolStorageStats>(
-            UiApiRoutes.WithParam(UiApiRoutes.StorageSymbolStats, "symbol", symbol), ct);
+        return (await _apiClient.GetWithResponseAsync<SymbolStorageStats>(
+            UiApiRoutes.WithParam(UiApiRoutes.StorageSymbolStats, "symbol", symbol), ct)).DataOrLoggedNull("Get symbol storage statistics");
     }
 
     /// <summary>
@@ -63,8 +63,8 @@ public class StorageServiceBase
     /// </summary>
     public async Task<string?> GetSymbolFolderPathAsync(string symbol, CancellationToken ct = default)
     {
-        var response = await _apiClient.GetAsync<SymbolPathResponse>(
-            UiApiRoutes.WithParam(UiApiRoutes.StorageSymbolPath, "symbol", symbol), ct);
+        var response = (await _apiClient.GetWithResponseAsync<SymbolPathResponse>(
+            UiApiRoutes.WithParam(UiApiRoutes.StorageSymbolPath, "symbol", symbol), ct)).DataOrLoggedNull("Get symbol folder path");
         return response?.FolderPath;
     }
 
@@ -73,7 +73,7 @@ public class StorageServiceBase
     /// </summary>
     public async Task<StorageHealthReport?> GetStorageHealthAsync(CancellationToken ct = default)
     {
-        return await _apiClient.GetAsync<StorageHealthReport>(UiApiRoutes.StorageHealth, ct);
+        return (await _apiClient.GetWithResponseAsync<StorageHealthReport>(UiApiRoutes.StorageHealth, ct)).DataOrLoggedNull("Get storage health");
     }
 
     /// <summary>
@@ -81,7 +81,7 @@ public class StorageServiceBase
     /// </summary>
     public async Task<List<CleanupCandidate>?> GetCleanupCandidatesAsync(CancellationToken ct = default)
     {
-        return await _apiClient.GetAsync<List<CleanupCandidate>>(UiApiRoutes.StorageCleanupCandidates, ct);
+        return (await _apiClient.GetWithResponseAsync<List<CleanupCandidate>>(UiApiRoutes.StorageCleanupCandidates, ct)).DataOrLoggedNull("Get cleanup candidates");
     }
 
     /// <summary>
@@ -89,10 +89,10 @@ public class StorageServiceBase
     /// </summary>
     public async Task<CleanupResult?> RunCleanupAsync(bool dryRun = true, CancellationToken ct = default)
     {
-        return await _apiClient.PostAsync<CleanupResult>(
+        return (await _apiClient.PostWithResponseAsync<CleanupResult>(
             UiApiRoutes.StorageCleanup,
             new { dryRun },
-            ct);
+            ct)).DataOrLoggedNull("Run storage cleanup");
     }
 
     /// <summary>
@@ -100,7 +100,7 @@ public class StorageServiceBase
     /// </summary>
     public async Task<ArchiveStats?> GetArchiveStatsAsync(CancellationToken ct = default)
     {
-        return await _apiClient.GetAsync<ArchiveStats>(UiApiRoutes.StorageArchiveStats, ct);
+        return (await _apiClient.GetWithResponseAsync<ArchiveStats>(UiApiRoutes.StorageArchiveStats, ct)).DataOrLoggedNull("Get archive statistics");
     }
 
     /// <summary>

--- a/src/Meridian.Ui.Services/Services/StorageServiceBase.cs
+++ b/src/Meridian.Ui.Services/Services/StorageServiceBase.cs
@@ -29,7 +29,7 @@ public class StorageServiceBase
     /// </summary>
     public async Task<StorageStatsSummary?> GetStorageStatsAsync(CancellationToken ct = default)
     {
-        return (await _apiClient.GetWithResponseAsync<StorageStatsSummary>(UiApiRoutes.StorageStats, ct)).DataOrLoggedNull("Get storage statistics");
+        return (await _apiClient.GetWithResponseAsync<StorageStatsSummary>(UiApiRoutes.StorageStats, ct).ConfigureAwait(false)).DataOrLoggedNull("Get storage statistics");
     }
 
     /// <summary>
@@ -37,7 +37,7 @@ public class StorageServiceBase
     /// </summary>
     public async Task<List<StorageCategory>?> GetStorageBreakdownAsync(CancellationToken ct = default)
     {
-        return (await _apiClient.GetWithResponseAsync<List<StorageCategory>>(UiApiRoutes.StorageBreakdown, ct)).DataOrLoggedNull("Get storage breakdown");
+        return (await _apiClient.GetWithResponseAsync<List<StorageCategory>>(UiApiRoutes.StorageBreakdown, ct).ConfigureAwait(false)).DataOrLoggedNull("Get storage breakdown");
     }
 
     /// <summary>
@@ -46,7 +46,7 @@ public class StorageServiceBase
     public async Task<SymbolStorageInfo?> GetSymbolInfoAsync(string symbol, CancellationToken ct = default)
     {
         return (await _apiClient.GetWithResponseAsync<SymbolStorageInfo>(
-            UiApiRoutes.WithParam(UiApiRoutes.StorageSymbolInfo, "symbol", symbol), ct)).DataOrLoggedNull("Get symbol storage info");
+            UiApiRoutes.WithParam(UiApiRoutes.StorageSymbolInfo, "symbol", symbol), ct).ConfigureAwait(false)).DataOrLoggedNull("Get symbol storage info");
     }
 
     /// <summary>
@@ -55,7 +55,7 @@ public class StorageServiceBase
     public async Task<SymbolStorageStats?> GetSymbolStorageStatsAsync(string symbol, CancellationToken ct = default)
     {
         return (await _apiClient.GetWithResponseAsync<SymbolStorageStats>(
-            UiApiRoutes.WithParam(UiApiRoutes.StorageSymbolStats, "symbol", symbol), ct)).DataOrLoggedNull("Get symbol storage statistics");
+            UiApiRoutes.WithParam(UiApiRoutes.StorageSymbolStats, "symbol", symbol), ct).ConfigureAwait(false)).DataOrLoggedNull("Get symbol storage statistics");
     }
 
     /// <summary>
@@ -64,7 +64,7 @@ public class StorageServiceBase
     public async Task<string?> GetSymbolFolderPathAsync(string symbol, CancellationToken ct = default)
     {
         var response = (await _apiClient.GetWithResponseAsync<SymbolPathResponse>(
-            UiApiRoutes.WithParam(UiApiRoutes.StorageSymbolPath, "symbol", symbol), ct)).DataOrLoggedNull("Get symbol folder path");
+            UiApiRoutes.WithParam(UiApiRoutes.StorageSymbolPath, "symbol", symbol), ct).ConfigureAwait(false)).DataOrLoggedNull("Get symbol folder path");
         return response?.FolderPath;
     }
 
@@ -73,7 +73,7 @@ public class StorageServiceBase
     /// </summary>
     public async Task<StorageHealthReport?> GetStorageHealthAsync(CancellationToken ct = default)
     {
-        return (await _apiClient.GetWithResponseAsync<StorageHealthReport>(UiApiRoutes.StorageHealth, ct)).DataOrLoggedNull("Get storage health");
+        return (await _apiClient.GetWithResponseAsync<StorageHealthReport>(UiApiRoutes.StorageHealth, ct).ConfigureAwait(false)).DataOrLoggedNull("Get storage health");
     }
 
     /// <summary>
@@ -81,7 +81,7 @@ public class StorageServiceBase
     /// </summary>
     public async Task<List<CleanupCandidate>?> GetCleanupCandidatesAsync(CancellationToken ct = default)
     {
-        return (await _apiClient.GetWithResponseAsync<List<CleanupCandidate>>(UiApiRoutes.StorageCleanupCandidates, ct)).DataOrLoggedNull("Get cleanup candidates");
+        return (await _apiClient.GetWithResponseAsync<List<CleanupCandidate>>(UiApiRoutes.StorageCleanupCandidates, ct).ConfigureAwait(false)).DataOrLoggedNull("Get cleanup candidates");
     }
 
     /// <summary>
@@ -92,7 +92,7 @@ public class StorageServiceBase
         return (await _apiClient.PostWithResponseAsync<CleanupResult>(
             UiApiRoutes.StorageCleanup,
             new { dryRun },
-            ct)).DataOrLoggedNull("Run storage cleanup");
+            ct).ConfigureAwait(false)).DataOrLoggedNull("Run storage cleanup");
     }
 
     /// <summary>
@@ -100,7 +100,7 @@ public class StorageServiceBase
     /// </summary>
     public async Task<ArchiveStats?> GetArchiveStatsAsync(CancellationToken ct = default)
     {
-        return (await _apiClient.GetWithResponseAsync<ArchiveStats>(UiApiRoutes.StorageArchiveStats, ct)).DataOrLoggedNull("Get archive statistics");
+        return (await _apiClient.GetWithResponseAsync<ArchiveStats>(UiApiRoutes.StorageArchiveStats, ct).ConfigureAwait(false)).DataOrLoggedNull("Get archive statistics");
     }
 
     /// <summary>

--- a/src/Meridian.Ui.Services/Services/SystemHealthService.cs
+++ b/src/Meridian.Ui.Services/Services/SystemHealthService.cs
@@ -32,7 +32,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<SystemHealthSummary?> GetHealthSummaryAsync(CancellationToken ct = default)
     {
-        return await _apiClient.GetAsync<SystemHealthSummary>(UiApiRoutes.HealthSummary, ct);
+        return (await _apiClient.GetWithResponseAsync<SystemHealthSummary>(UiApiRoutes.HealthSummary, ct)).DataOrLoggedNull("Get system health summary");
     }
 
     /// <summary>
@@ -40,7 +40,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<List<ProviderHealth>?> GetProviderHealthAsync(CancellationToken ct = default)
     {
-        return await _apiClient.GetAsync<List<ProviderHealth>>(UiApiRoutes.HealthProviders, ct);
+        return (await _apiClient.GetWithResponseAsync<List<ProviderHealth>>(UiApiRoutes.HealthProviders, ct)).DataOrLoggedNull("Get provider health");
     }
 
     /// <summary>
@@ -48,7 +48,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<ProviderReadinessSummaryDto?> GetProviderReadinessAsync(CancellationToken ct = default)
     {
-        return await _apiClient.GetAsync<ProviderReadinessSummaryDto>(UiApiRoutes.ProviderReadiness, ct);
+        return (await _apiClient.GetWithResponseAsync<ProviderReadinessSummaryDto>(UiApiRoutes.ProviderReadiness, ct)).DataOrLoggedNull("Get provider readiness");
     }
 
     /// <summary>
@@ -56,7 +56,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<ProviderDiagnosticsSnapshot?> GetProviderDiagnosticsAsync(string provider, CancellationToken ct = default)
     {
-        return await _apiClient.GetAsync<ProviderDiagnosticsSnapshot>(BuildProviderDiagnosticsRoute(provider), ct);
+        return (await _apiClient.GetWithResponseAsync<ProviderDiagnosticsSnapshot>(BuildProviderDiagnosticsRoute(provider), ct)).DataOrLoggedNull("Get provider diagnostics");
     }
 
     /// <summary>
@@ -64,7 +64,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<StorageHealth?> GetStorageHealthAsync(CancellationToken ct = default)
     {
-        return await _apiClient.GetAsync<StorageHealth>(UiApiRoutes.HealthStorage, ct);
+        return (await _apiClient.GetWithResponseAsync<StorageHealth>(UiApiRoutes.HealthStorage, ct)).DataOrLoggedNull("Get storage health");
     }
 
     /// <summary>
@@ -72,7 +72,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<List<SystemEvent>?> GetRecentEventsAsync(int limit = 50, CancellationToken ct = default)
     {
-        return await _apiClient.GetAsync<List<SystemEvent>>(BuildRecentEventsRoute(limit), ct);
+        return (await _apiClient.GetWithResponseAsync<List<SystemEvent>>(BuildRecentEventsRoute(limit), ct)).DataOrLoggedNull("Get recent system events");
     }
 
     /// <summary>
@@ -80,7 +80,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<SystemMetrics?> GetSystemMetricsAsync(CancellationToken ct = default)
     {
-        return await _apiClient.GetAsync<SystemMetrics>(UiApiRoutes.HealthMetrics, ct);
+        return (await _apiClient.GetWithResponseAsync<SystemMetrics>(UiApiRoutes.HealthMetrics, ct)).DataOrLoggedNull("Get system metrics");
     }
 
     /// <summary>
@@ -88,7 +88,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<ConnectionTestResult?> TestConnectionAsync(string provider, CancellationToken ct = default)
     {
-        return await _apiClient.PostAsync<ConnectionTestResult>(BuildProviderTestRoute(provider), null, ct);
+        return (await _apiClient.PostWithResponseAsync<ConnectionTestResult>(BuildProviderTestRoute(provider), null, ct)).DataOrLoggedNull("Test provider connection");
     }
 
     /// <summary>
@@ -96,7 +96,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<DiagnosticBundle?> GenerateDiagnosticBundleAsync(CancellationToken ct = default)
     {
-        return await _apiClient.PostAsync<DiagnosticBundle>(UiApiRoutes.HealthDiagnosticsBundle, null, ct);
+        return (await _apiClient.PostWithResponseAsync<DiagnosticBundle>(UiApiRoutes.HealthDiagnosticsBundle, null, ct)).DataOrLoggedNull("Generate diagnostic bundle");
     }
 
     internal static string BuildProviderDiagnosticsRoute(string provider)
@@ -116,15 +116,43 @@ internal interface ISystemHealthApiClient
     Task<T?> GetAsync<T>(string endpoint, CancellationToken ct = default) where T : class;
 
     Task<T?> PostAsync<T>(string endpoint, object? body = null, CancellationToken ct = default) where T : class;
+
+    /// <summary>
+    /// Default implementations adapt legacy nullable-result implementations (e.g. test doubles)
+    /// onto the <see cref="ApiResponse{T}"/> seam; a null result maps to a 404-style failure so
+    /// <see cref="ApiResponseExtensions.DataOrLoggedNull{T}"/> stays silent, matching the legacy
+    /// null path. Production implementations override these with true response pass-throughs.
+    /// </summary>
+    async Task<ApiResponse<T>> GetWithResponseAsync<T>(string endpoint, CancellationToken ct = default) where T : class
+    {
+        var data = await GetAsync<T>(endpoint, ct);
+        return data is null
+            ? ApiResponse<T>.Fail("No data returned.", statusCode: 404)
+            : ApiResponse<T>.Ok(data);
+    }
+
+    async Task<ApiResponse<T>> PostWithResponseAsync<T>(string endpoint, object? body = null, CancellationToken ct = default) where T : class
+    {
+        var data = await PostAsync<T>(endpoint, body, ct);
+        return data is null
+            ? ApiResponse<T>.Fail("No data returned.", statusCode: 404)
+            : ApiResponse<T>.Ok(data);
+    }
 }
 
 internal sealed class ApiClientSystemHealthApiClient(ApiClientService apiClient) : ISystemHealthApiClient
 {
-    public Task<T?> GetAsync<T>(string endpoint, CancellationToken ct = default) where T : class
-        => apiClient.GetAsync<T>(endpoint, ct);
+    public async Task<T?> GetAsync<T>(string endpoint, CancellationToken ct = default) where T : class
+        => (await apiClient.GetWithResponseAsync<T>(endpoint, ct)).DataOrLoggedNull("System health API GET request");
 
-    public Task<T?> PostAsync<T>(string endpoint, object? body = null, CancellationToken ct = default) where T : class
-        => apiClient.PostAsync<T>(endpoint, body, ct);
+    public async Task<T?> PostAsync<T>(string endpoint, object? body = null, CancellationToken ct = default) where T : class
+        => (await apiClient.PostWithResponseAsync<T>(endpoint, body, ct)).DataOrLoggedNull("System health API POST request");
+
+    public Task<ApiResponse<T>> GetWithResponseAsync<T>(string endpoint, CancellationToken ct = default) where T : class
+        => apiClient.GetWithResponseAsync<T>(endpoint, ct);
+
+    public Task<ApiResponse<T>> PostWithResponseAsync<T>(string endpoint, object? body = null, CancellationToken ct = default) where T : class
+        => apiClient.PostWithResponseAsync<T>(endpoint, body, ct);
 }
 
 // DTO classes for system health

--- a/src/Meridian.Ui.Services/Services/SystemHealthService.cs
+++ b/src/Meridian.Ui.Services/Services/SystemHealthService.cs
@@ -32,7 +32,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<SystemHealthSummary?> GetHealthSummaryAsync(CancellationToken ct = default)
     {
-        return (await _apiClient.GetWithResponseAsync<SystemHealthSummary>(UiApiRoutes.HealthSummary, ct)).DataOrLoggedNull("Get system health summary");
+        return (await _apiClient.GetWithResponseAsync<SystemHealthSummary>(UiApiRoutes.HealthSummary, ct).ConfigureAwait(false)).DataOrLoggedNull("Get system health summary");
     }
 
     /// <summary>
@@ -40,7 +40,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<List<ProviderHealth>?> GetProviderHealthAsync(CancellationToken ct = default)
     {
-        return (await _apiClient.GetWithResponseAsync<List<ProviderHealth>>(UiApiRoutes.HealthProviders, ct)).DataOrLoggedNull("Get provider health");
+        return (await _apiClient.GetWithResponseAsync<List<ProviderHealth>>(UiApiRoutes.HealthProviders, ct).ConfigureAwait(false)).DataOrLoggedNull("Get provider health");
     }
 
     /// <summary>
@@ -48,7 +48,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<ProviderReadinessSummaryDto?> GetProviderReadinessAsync(CancellationToken ct = default)
     {
-        return (await _apiClient.GetWithResponseAsync<ProviderReadinessSummaryDto>(UiApiRoutes.ProviderReadiness, ct)).DataOrLoggedNull("Get provider readiness");
+        return (await _apiClient.GetWithResponseAsync<ProviderReadinessSummaryDto>(UiApiRoutes.ProviderReadiness, ct).ConfigureAwait(false)).DataOrLoggedNull("Get provider readiness");
     }
 
     /// <summary>
@@ -56,7 +56,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<ProviderDiagnosticsSnapshot?> GetProviderDiagnosticsAsync(string provider, CancellationToken ct = default)
     {
-        return (await _apiClient.GetWithResponseAsync<ProviderDiagnosticsSnapshot>(BuildProviderDiagnosticsRoute(provider), ct)).DataOrLoggedNull("Get provider diagnostics");
+        return (await _apiClient.GetWithResponseAsync<ProviderDiagnosticsSnapshot>(BuildProviderDiagnosticsRoute(provider), ct).ConfigureAwait(false)).DataOrLoggedNull("Get provider diagnostics");
     }
 
     /// <summary>
@@ -64,7 +64,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<StorageHealth?> GetStorageHealthAsync(CancellationToken ct = default)
     {
-        return (await _apiClient.GetWithResponseAsync<StorageHealth>(UiApiRoutes.HealthStorage, ct)).DataOrLoggedNull("Get storage health");
+        return (await _apiClient.GetWithResponseAsync<StorageHealth>(UiApiRoutes.HealthStorage, ct).ConfigureAwait(false)).DataOrLoggedNull("Get storage health");
     }
 
     /// <summary>
@@ -72,7 +72,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<List<SystemEvent>?> GetRecentEventsAsync(int limit = 50, CancellationToken ct = default)
     {
-        return (await _apiClient.GetWithResponseAsync<List<SystemEvent>>(BuildRecentEventsRoute(limit), ct)).DataOrLoggedNull("Get recent system events");
+        return (await _apiClient.GetWithResponseAsync<List<SystemEvent>>(BuildRecentEventsRoute(limit), ct).ConfigureAwait(false)).DataOrLoggedNull("Get recent system events");
     }
 
     /// <summary>
@@ -80,7 +80,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<SystemMetrics?> GetSystemMetricsAsync(CancellationToken ct = default)
     {
-        return (await _apiClient.GetWithResponseAsync<SystemMetrics>(UiApiRoutes.HealthMetrics, ct)).DataOrLoggedNull("Get system metrics");
+        return (await _apiClient.GetWithResponseAsync<SystemMetrics>(UiApiRoutes.HealthMetrics, ct).ConfigureAwait(false)).DataOrLoggedNull("Get system metrics");
     }
 
     /// <summary>
@@ -88,7 +88,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<ConnectionTestResult?> TestConnectionAsync(string provider, CancellationToken ct = default)
     {
-        return (await _apiClient.PostWithResponseAsync<ConnectionTestResult>(BuildProviderTestRoute(provider), null, ct)).DataOrLoggedNull("Test provider connection");
+        return (await _apiClient.PostWithResponseAsync<ConnectionTestResult>(BuildProviderTestRoute(provider), null, ct).ConfigureAwait(false)).DataOrLoggedNull("Test provider connection");
     }
 
     /// <summary>
@@ -96,7 +96,7 @@ public sealed class SystemHealthService
     /// </summary>
     public async Task<DiagnosticBundle?> GenerateDiagnosticBundleAsync(CancellationToken ct = default)
     {
-        return (await _apiClient.PostWithResponseAsync<DiagnosticBundle>(UiApiRoutes.HealthDiagnosticsBundle, null, ct)).DataOrLoggedNull("Generate diagnostic bundle");
+        return (await _apiClient.PostWithResponseAsync<DiagnosticBundle>(UiApiRoutes.HealthDiagnosticsBundle, null, ct).ConfigureAwait(false)).DataOrLoggedNull("Generate diagnostic bundle");
     }
 
     internal static string BuildProviderDiagnosticsRoute(string provider)
@@ -143,10 +143,10 @@ internal interface ISystemHealthApiClient
 internal sealed class ApiClientSystemHealthApiClient(ApiClientService apiClient) : ISystemHealthApiClient
 {
     public async Task<T?> GetAsync<T>(string endpoint, CancellationToken ct = default) where T : class
-        => (await apiClient.GetWithResponseAsync<T>(endpoint, ct)).DataOrLoggedNull("System health API GET request");
+        => (await apiClient.GetWithResponseAsync<T>(endpoint, ct).ConfigureAwait(false)).DataOrLoggedNull("System health API GET request");
 
     public async Task<T?> PostAsync<T>(string endpoint, object? body = null, CancellationToken ct = default) where T : class
-        => (await apiClient.PostWithResponseAsync<T>(endpoint, body, ct)).DataOrLoggedNull("System health API POST request");
+        => (await apiClient.PostWithResponseAsync<T>(endpoint, body, ct).ConfigureAwait(false)).DataOrLoggedNull("System health API POST request");
 
     public Task<ApiResponse<T>> GetWithResponseAsync<T>(string endpoint, CancellationToken ct = default) where T : class
         => apiClient.GetWithResponseAsync<T>(endpoint, ct);

--- a/src/Meridian.Wpf/Services/OperationsControlCenterClient.cs
+++ b/src/Meridian.Wpf/Services/OperationsControlCenterClient.cs
@@ -20,13 +20,13 @@ public sealed class OperationsControlCenterClient : IOperationsControlCenterClie
         _apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
     }
 
-    public Task<OperationsApprovalPolicyMatrixDto?> GetApprovalPolicyMatrixAsync(CancellationToken ct = default)
-        => _apiClient.GetAsync<OperationsApprovalPolicyMatrixDto>(
+    public async Task<OperationsApprovalPolicyMatrixDto?> GetApprovalPolicyMatrixAsync(CancellationToken ct = default)
+        => (await _apiClient.GetWithResponseAsync<OperationsApprovalPolicyMatrixDto>(
             UiApiRoutes.OperationsContinuityApprovalPolicyMatrix,
-            ct);
+            ct).ConfigureAwait(false)).DataOrLoggedNull("Get approval policy matrix");
 
-    public Task<OperationsCloseCalendarDto?> GetCloseCalendarAsync(CancellationToken ct = default)
-        => _apiClient.GetAsync<OperationsCloseCalendarDto>(
+    public async Task<OperationsCloseCalendarDto?> GetCloseCalendarAsync(CancellationToken ct = default)
+        => (await _apiClient.GetWithResponseAsync<OperationsCloseCalendarDto>(
             UiApiRoutes.OperationsContinuityCloseCalendar,
-            ct);
+            ct).ConfigureAwait(false)).DataOrLoggedNull("Get close calendar");
 }

--- a/src/Meridian.Wpf/Services/SecurityAssetProfileWorkflowClient.cs
+++ b/src/Meridian.Wpf/Services/SecurityAssetProfileWorkflowClient.cs
@@ -36,18 +36,18 @@ public sealed class SecurityAssetProfileWorkflowClient : ISecurityAssetProfileWo
 
     public async Task<IReadOnlyList<SecurityAssetProfileDefinitionDto>> GetProfilesAsync(CancellationToken ct = default)
     {
-        var profiles = await _apiClient.GetAsync<SecurityAssetProfileDefinitionDto[]>(
+        var profiles = (await _apiClient.GetWithResponseAsync<SecurityAssetProfileDefinitionDto[]>(
             UiApiRoutes.SecurityMasterAssetProfiles,
-            ct).ConfigureAwait(false);
+            ct).ConfigureAwait(false)).DataOrLoggedNull("Get security asset profiles");
 
         return profiles ?? [];
     }
 
-    public Task<SecurityAssetProfileLineageDto?> GetLineageAsync(string profileId, CancellationToken ct = default)
+    public async Task<SecurityAssetProfileLineageDto?> GetLineageAsync(string profileId, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(profileId))
         {
-            return Task.FromResult<SecurityAssetProfileLineageDto?>(null);
+            return null;
         }
 
         var endpoint = UiApiRoutes.SecurityMasterAssetProfileLineage.Replace(
@@ -55,7 +55,7 @@ public sealed class SecurityAssetProfileWorkflowClient : ISecurityAssetProfileWo
             Uri.EscapeDataString(profileId.Trim()),
             StringComparison.Ordinal);
 
-        return _apiClient.GetAsync<SecurityAssetProfileLineageDto>(endpoint, ct);
+        return (await _apiClient.GetWithResponseAsync<SecurityAssetProfileLineageDto>(endpoint, ct).ConfigureAwait(false)).DataOrLoggedNull("Get asset profile lineage");
     }
 
     public Task<ApiResponse<SecurityAssetProfileGovernanceResultDto>> DraftProfileAsync(

--- a/src/Meridian.Wpf/Services/SecurityMasterOperatorWorkflowClient.cs
+++ b/src/Meridian.Wpf/Services/SecurityMasterOperatorWorkflowClient.cs
@@ -21,14 +21,14 @@ public interface ISecurityMasterOperatorWorkflowClient
 public sealed class SecurityMasterOperatorWorkflowClient : ISecurityMasterOperatorWorkflowClient
 {
     public async Task<SecurityMasterIngestStatusResponse?> GetIngestStatusAsync(CancellationToken ct = default)
-        => await ApiClientService.Instance
-            .GetAsync<SecurityMasterIngestStatusResponse>("/api/security-master/ingest/status", ct)
-            .ConfigureAwait(false);
+        => (await ApiClientService.Instance
+            .GetWithResponseAsync<SecurityMasterIngestStatusResponse>("/api/security-master/ingest/status", ct)
+            .ConfigureAwait(false)).DataOrLoggedNull("Get security master ingest status");
 
     public async Task<IReadOnlyList<SecurityMasterConflict>> GetOpenConflictsAsync(CancellationToken ct = default)
-        => await ApiClientService.Instance
-            .GetAsync<SecurityMasterConflict[]>("/api/security-master/conflicts", ct)
-            .ConfigureAwait(false)
+        => (await ApiClientService.Instance
+            .GetWithResponseAsync<SecurityMasterConflict[]>("/api/security-master/conflicts", ct)
+            .ConfigureAwait(false)).DataOrLoggedNull("Get open security master conflicts")
             ?? [];
 
     public async Task<SecurityMasterConflict?> ResolveConflictAsync(
@@ -44,11 +44,11 @@ public sealed class SecurityMasterOperatorWorkflowClient : ISecurityMasterOperat
             ResolvedBy: resolvedBy,
             Reason: reason);
 
-        return await ApiClientService.Instance
-            .PostAsync<SecurityMasterConflict>(
+        return (await ApiClientService.Instance
+            .PostWithResponseAsync<SecurityMasterConflict>(
                 $"/api/security-master/conflicts/{conflictId}/resolve",
                 request,
                 ct)
-            .ConfigureAwait(false);
+            .ConfigureAwait(false)).DataOrLoggedNull("Resolve security master conflict");
     }
 }

--- a/src/Meridian.Wpf/Services/StorageService.cs
+++ b/src/Meridian.Wpf/Services/StorageService.cs
@@ -28,8 +28,8 @@ public sealed class StorageService : StorageServiceBase
     /// </summary>
     public async Task<List<DataFileInfo>> GetSymbolFilesAsync(string symbol, CancellationToken ct = default)
     {
-        var response = await ApiClientService.Instance.GetAsync<List<SymbolFileDto>>(
-            UiApiRoutes.WithParam(UiApiRoutes.StorageSymbolFiles, "symbol", symbol), ct);
+        var response = (await ApiClientService.Instance.GetWithResponseAsync<List<SymbolFileDto>>(
+            UiApiRoutes.WithParam(UiApiRoutes.StorageSymbolFiles, "symbol", symbol), ct)).DataOrLoggedNull("Get symbol data files");
 
         if (response == null)
             return new List<DataFileInfo>();

--- a/src/Meridian.Wpf/Services/WatchlistService.cs
+++ b/src/Meridian.Wpf/Services/WatchlistService.cs
@@ -394,8 +394,8 @@ public sealed class WatchlistService : IWatchlistReader, IWatchlistService
     {
         try
         {
-            var remoteWatchlists = await _remoteClient.GetAsync<List<Watchlist>>("/api/watchlists", ct)
-                .ConfigureAwait(false);
+            var remoteWatchlists = (await _remoteClient.GetWithResponseAsync<List<Watchlist>>("/api/watchlists", ct)
+                .ConfigureAwait(false)).DataOrLoggedNull("Sync watchlists from backend");
 
             if (remoteWatchlists is null)
             {

--- a/src/Meridian.Wpf/Services/WorkstationOperatorInboxApiClient.cs
+++ b/src/Meridian.Wpf/Services/WorkstationOperatorInboxApiClient.cs
@@ -18,12 +18,12 @@ public sealed class WorkstationOperatorInboxApiClient : IWorkstationOperatorInbo
         _apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
     }
 
-    public Task<OperatorInboxDto?> GetInboxAsync(Guid? fundAccountId = null, CancellationToken ct = default)
+    public async Task<OperatorInboxDto?> GetInboxAsync(Guid? fundAccountId = null, CancellationToken ct = default)
     {
         var route = fundAccountId.HasValue
             ? UiApiRoutes.WithQuery(UiApiRoutes.WorkstationOperatorInbox, $"fundAccountId={fundAccountId.Value:D}")
             : UiApiRoutes.WorkstationOperatorInbox;
 
-        return _apiClient.GetAsync<OperatorInboxDto>(route, ct);
+        return (await _apiClient.GetWithResponseAsync<OperatorInboxDto>(route, ct).ConfigureAwait(false)).DataOrLoggedNull("Get operator inbox");
     }
 }

--- a/src/Meridian.Wpf/Services/WorkstationReconciliationApiClient.cs
+++ b/src/Meridian.Wpf/Services/WorkstationReconciliationApiClient.cs
@@ -1,4 +1,5 @@
 using Meridian.Contracts.Workstation;
+using Meridian.Ui.Services;
 using Meridian.Ui.Shared.Contracts.Reconciliation;
 
 namespace Meridian.Wpf.Services;
@@ -58,24 +59,24 @@ public sealed class WorkstationReconciliationApiClient : IWorkstationReconciliat
         ?? [];
 
     public async Task<IReadOnlyList<StatementRunSummaryDto>> GetStatementRunsAsync(CancellationToken ct = default)
-        => await _apiClient.GetAsync<List<StatementRunSummaryDto>>(Meridian.Contracts.Api.UiApiRoutes.ReconciliationStatementRuns, ct).ConfigureAwait(false) ?? [];
+        => (await _apiClient.GetWithResponseAsync<List<StatementRunSummaryDto>>(Meridian.Contracts.Api.UiApiRoutes.ReconciliationStatementRuns, ct).ConfigureAwait(false)).DataOrLoggedNull("Get statement runs") ?? [];
 
-    public Task<StatementRunSummaryDto?> GetStatementRunAsync(string runId, CancellationToken ct = default)
-        => _apiClient.GetAsync<StatementRunSummaryDto>(
+    public async Task<StatementRunSummaryDto?> GetStatementRunAsync(string runId, CancellationToken ct = default)
+        => (await _apiClient.GetWithResponseAsync<StatementRunSummaryDto>(
             Meridian.Contracts.Api.UiApiRoutes.WithParam(Meridian.Contracts.Api.UiApiRoutes.ReconciliationStatementRunById, "runId", runId),
-            ct);
+            ct).ConfigureAwait(false)).DataOrLoggedNull("Get statement run");
 
     public async Task<IReadOnlyList<StatementRunExceptionDto>> GetStatementExceptionsAsync(CancellationToken ct = default)
-        => await _apiClient.GetAsync<List<StatementRunExceptionDto>>(Meridian.Contracts.Api.UiApiRoutes.ReconciliationStatementExceptions, ct).ConfigureAwait(false) ?? [];
+        => (await _apiClient.GetWithResponseAsync<List<StatementRunExceptionDto>>(Meridian.Contracts.Api.UiApiRoutes.ReconciliationStatementExceptions, ct).ConfigureAwait(false)).DataOrLoggedNull("Get statement exceptions") ?? [];
 
     public async Task<IReadOnlyList<StatementBreakDto>> GetOpenStatementBreaksAsync(CancellationToken ct = default)
-        => await _apiClient.GetAsync<List<StatementBreakDto>>(Meridian.Contracts.Api.UiApiRoutes.ReconciliationStatementBreaks, ct).ConfigureAwait(false) ?? [];
+        => (await _apiClient.GetWithResponseAsync<List<StatementBreakDto>>(Meridian.Contracts.Api.UiApiRoutes.ReconciliationStatementBreaks, ct).ConfigureAwait(false)).DataOrLoggedNull("Get open statement breaks") ?? [];
 
     public async Task<IReadOnlyList<ReconciliationCaseSummaryDto>> GetOpenReconciliationCasesAsync(CancellationToken ct = default)
-        => await _apiClient.GetAsync<List<ReconciliationCaseSummaryDto>>(Meridian.Contracts.Api.UiApiRoutes.ReconciliationOpenCases, ct).ConfigureAwait(false) ?? [];
+        => (await _apiClient.GetWithResponseAsync<List<ReconciliationCaseSummaryDto>>(Meridian.Contracts.Api.UiApiRoutes.ReconciliationOpenCases, ct).ConfigureAwait(false)).DataOrLoggedNull("Get open reconciliation cases") ?? [];
 
     public async Task<IReadOnlyList<ReconciliationQueueAccountStatusDto>> GetReconciliationQueueStatusAsync(CancellationToken ct = default)
-        => await _apiClient.GetAsync<List<ReconciliationQueueAccountStatusDto>>(Meridian.Contracts.Api.UiApiRoutes.ReconciliationQueueStatus, ct).ConfigureAwait(false) ?? [];
+        => (await _apiClient.GetWithResponseAsync<List<ReconciliationQueueAccountStatusDto>>(Meridian.Contracts.Api.UiApiRoutes.ReconciliationQueueStatus, ct).ConfigureAwait(false)).DataOrLoggedNull("Get reconciliation queue status") ?? [];
 
     public Task<ReconciliationRunDetail?> GetLatestRunDetailAsync(string runId, CancellationToken ct = default)
         => _apiClient.UiApi.GetLatestRunReconciliationAsync(runId, ct);

--- a/src/Meridian.Wpf/Services/WorkstationSecurityMasterApiClient.cs
+++ b/src/Meridian.Wpf/Services/WorkstationSecurityMasterApiClient.cs
@@ -57,17 +57,17 @@ public sealed class WorkstationSecurityMasterApiClient : IWorkstationSecurityMas
         _apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
     }
 
-    public Task<OperatorOverridesDto?> GetOperatorOverridesAsync(
+    public async Task<OperatorOverridesDto?> GetOperatorOverridesAsync(
         Guid securityId, CancellationToken ct = default)
-        => _apiClient.GetAsync<OperatorOverridesDto>(
-            SecurityIdRoute(UiApiRoutes.SecurityMasterOperatorOverrides, securityId), ct);
+        => (await _apiClient.GetWithResponseAsync<OperatorOverridesDto>(
+            SecurityIdRoute(UiApiRoutes.SecurityMasterOperatorOverrides, securityId), ct).ConfigureAwait(false)).DataOrLoggedNull("Get operator overrides");
 
     public Task<ApiResponse<OperatorOverridesDto>> RecordOperatorOverrideDecisionAsync(
         Guid securityId, OperatorOverrideDecisionRequest request, CancellationToken ct = default)
         => _apiClient.PostWithResponseAsync<OperatorOverridesDto>(
             SecurityIdRoute(UiApiRoutes.SecurityMasterOperatorOverrideDecision, securityId), request, ct);
 
-    public Task<SecurityMasterTrustSnapshotDto?> GetTrustSnapshotAsync(
+    public async Task<SecurityMasterTrustSnapshotDto?> GetTrustSnapshotAsync(
         Guid securityId,
         string? fundProfileId,
         CancellationToken ct = default)
@@ -78,10 +78,10 @@ public sealed class WorkstationSecurityMasterApiClient : IWorkstationSecurityMas
             endpoint += $"?fundProfileId={Uri.EscapeDataString(fundProfileId.Trim())}";
         }
 
-        return _apiClient.GetAsync<SecurityMasterTrustSnapshotDto>(endpoint, ct);
+        return (await _apiClient.GetWithResponseAsync<SecurityMasterTrustSnapshotDto>(endpoint, ct).ConfigureAwait(false)).DataOrLoggedNull("Get security trust snapshot");
     }
 
-    public Task<InstrumentPassportDto?> GetInstrumentPassportAsync(
+    public async Task<InstrumentPassportDto?> GetInstrumentPassportAsync(
         Guid securityId,
         string? fundProfileId,
         CancellationToken ct = default)
@@ -92,7 +92,7 @@ public sealed class WorkstationSecurityMasterApiClient : IWorkstationSecurityMas
             endpoint += $"?fundProfileId={Uri.EscapeDataString(fundProfileId.Trim())}";
         }
 
-        return _apiClient.GetAsync<InstrumentPassportDto>(endpoint, ct);
+        return (await _apiClient.GetWithResponseAsync<InstrumentPassportDto>(endpoint, ct).ConfigureAwait(false)).DataOrLoggedNull("Get instrument passport");
     }
 
     public Task<ApiResponse<BulkResolveSecurityMasterConflictsResult>> BulkResolveConflictsAsync(

--- a/src/Meridian.Wpf/Services/WorkstationStrategyBriefingService.cs
+++ b/src/Meridian.Wpf/Services/WorkstationStrategyBriefingService.cs
@@ -20,8 +20,8 @@ public sealed class WorkstationStrategyBriefingApiClient : IWorkstationStrategyB
         _apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
     }
 
-    public Task<StrategyBriefingDto?> GetBriefingAsync(CancellationToken ct = default)
-        => _apiClient.GetAsync<StrategyBriefingDto>(UiApiRoutes.WorkstationStrategyBriefing, ct);
+    public async Task<StrategyBriefingDto?> GetBriefingAsync(CancellationToken ct = default)
+        => (await _apiClient.GetWithResponseAsync<StrategyBriefingDto>(UiApiRoutes.WorkstationStrategyBriefing, ct).ConfigureAwait(false)).DataOrLoggedNull("Get strategy briefing");
 }
 
 public interface IStrategyBriefingWorkspaceService

--- a/src/Meridian.Wpf/Services/WpfRemoteWorkstationClient.cs
+++ b/src/Meridian.Wpf/Services/WpfRemoteWorkstationClient.cs
@@ -60,14 +60,14 @@ public sealed class WpfRemoteWorkstationClient : IRemoteWorkstationClient
     public Task<ApiResponse<StatusResponse>> GetStatusWithResponseAsync(CancellationToken ct = default)
         => _apiClientService.UiApi.GetWithResponseAsync<StatusResponse>(UiApiRoutes.Status, ct);
 
-    public Task<T?> GetAsync<T>(string endpoint, CancellationToken ct = default) where T : class
-        => _apiClientService.GetAsync<T>(endpoint, ct);
+    public async Task<T?> GetAsync<T>(string endpoint, CancellationToken ct = default) where T : class
+        => (await _apiClientService.GetWithResponseAsync<T>(endpoint, ct).ConfigureAwait(false)).DataOrLoggedNull("Get remote workstation resource");
 
     public Task<ApiResponse<T>> GetWithResponseAsync<T>(string endpoint, CancellationToken ct = default) where T : class
         => _apiClientService.GetWithResponseAsync<T>(endpoint, ct);
 
-    public Task<T?> PostAsync<T>(string endpoint, object? body = null, CancellationToken ct = default) where T : class
-        => _apiClientService.PostAsync<T>(endpoint, body, ct);
+    public async Task<T?> PostAsync<T>(string endpoint, object? body = null, CancellationToken ct = default) where T : class
+        => (await _apiClientService.PostWithResponseAsync<T>(endpoint, body, ct).ConfigureAwait(false)).DataOrLoggedNull("Post remote workstation resource");
 
     public Task<ApiResponse<T>> PostWithResponseAsync<T>(
         string endpoint,

--- a/src/Meridian.Wpf/ViewModels/AccountPortfolioViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/AccountPortfolioViewModel.cs
@@ -331,8 +331,8 @@ public sealed class AccountPortfolioViewModel : BindableBase, IDisposable
 
         try
         {
-            var snapshot = await _apiClient.GetAsync<AccountDetailDto>(
-                $"/api/execution/accounts/{Uri.EscapeDataString(AccountId)}", ct);
+            var snapshot = (await _apiClient.GetWithResponseAsync<AccountDetailDto>(
+                $"/api/execution/accounts/{Uri.EscapeDataString(AccountId)}", ct)).DataOrLoggedNull("Load account portfolio snapshot");
 
             if (snapshot is null)
             {

--- a/src/Meridian.Wpf/ViewModels/AggregatePortfolioViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/AggregatePortfolioViewModel.cs
@@ -242,13 +242,13 @@ public sealed class AggregatePortfolioViewModel : BindableBase, IDisposable
 
         try
         {
-            var positionsTask = _apiClient.GetAsync<List<AggregatedPositionDto>>("/api/portfolio/aggregate", ct);
-            var exposureTask = _apiClient.GetAsync<ExposureDto>("/api/portfolio/exposure", ct);
+            var positionsTask = _apiClient.GetWithResponseAsync<List<AggregatedPositionDto>>("/api/portfolio/aggregate", ct);
+            var exposureTask = _apiClient.GetWithResponseAsync<ExposureDto>("/api/portfolio/exposure", ct);
 
             await Task.WhenAll(positionsTask, exposureTask);
 
-            var positions = await positionsTask.ConfigureAwait(false);
-            var exposure = await exposureTask.ConfigureAwait(false);
+            var positions = (await positionsTask.ConfigureAwait(false)).DataOrLoggedNull("Load aggregate portfolio positions");
+            var exposure = (await exposureTask.ConfigureAwait(false)).DataOrLoggedNull("Load aggregate portfolio exposure");
 
             if (positions is null)
             {

--- a/src/Meridian.Wpf/ViewModels/DirectLendingViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/DirectLendingViewModel.cs
@@ -576,12 +576,14 @@ public sealed class DirectLendingViewModel : BindableBase
                 $"/api/loans/{SelectedLoan.LoanId}/accruals/daily", body, ct)
                 .ConfigureAwait(false);
 
-            if (response.Success && response.Data is not null)
+            if (response.Success)
             {
-                var result = response.Data;
-                AccrualResultText =
-                    $"Accrual posted for {result.AccrualDate}: interest ${result.InterestAmount:N2}, " +
-                    $"commitment fee ${result.CommitmentFeeAmount:N2}";
+                // A success with no payload (empty body) is still a posted accrual; only a
+                // failed response may show the failure text.
+                AccrualResultText = response.Data is { } result
+                    ? $"Accrual posted for {result.AccrualDate}: interest ${result.InterestAmount:N2}, " +
+                      $"commitment fee ${result.CommitmentFeeAmount:N2}"
+                    : "Accrual posted.";
             }
             else
             {

--- a/src/Meridian.Wpf/ViewModels/DirectLendingViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/DirectLendingViewModel.cs
@@ -384,13 +384,13 @@ public sealed class DirectLendingViewModel : BindableBase
 
         try
         {
-            var portfolioTask = _apiClient.GetAsync<LoanPortfolioSummaryDto>("/api/loans/portfolio", ct);
-            var operationsTask = _apiClient.GetAsync<DirectLendingOperationsReadModelDto>("/api/loans/operations", ct);
+            var portfolioTask = _apiClient.GetWithResponseAsync<LoanPortfolioSummaryDto>("/api/loans/portfolio", ct);
+            var operationsTask = _apiClient.GetWithResponseAsync<DirectLendingOperationsReadModelDto>("/api/loans/operations", ct);
 
             await Task.WhenAll(portfolioTask, operationsTask).ConfigureAwait(false);
 
-            var portfolio = await portfolioTask.ConfigureAwait(false);
-            var operations = await operationsTask.ConfigureAwait(false);
+            var portfolio = (await portfolioTask.ConfigureAwait(false)).DataOrLoggedNull("Load loan portfolio summary");
+            var operations = (await operationsTask.ConfigureAwait(false)).DataOrLoggedNull("Load direct-lending operations read model");
 
             _allLoans.Clear();
             if (portfolio?.Loans is not null)
@@ -494,13 +494,13 @@ public sealed class DirectLendingViewModel : BindableBase
 
         try
         {
-            var contractTask = _apiClient.GetAsync<LoanContractDetailDto>(
+            var contractTask = _apiClient.GetWithResponseAsync<LoanContractDetailDto>(
                 $"/api/loans/{summary.LoanId}");
-            var servicingTask = _apiClient.GetAsync<LoanServicingStateDto>(
+            var servicingTask = _apiClient.GetWithResponseAsync<LoanServicingStateDto>(
                 $"/api/loans/{summary.LoanId}/servicing-state");
-            var accrualsTask = _apiClient.GetAsync<List<DailyAccrualEntryDto>>(
+            var accrualsTask = _apiClient.GetWithResponseAsync<List<DailyAccrualEntryDto>>(
                 $"/api/loans/{summary.LoanId}/projections/accruals");
-            var cashTask = _apiClient.GetAsync<List<CashTransactionDto>>(
+            var cashTask = _apiClient.GetWithResponseAsync<List<CashTransactionDto>>(
                 $"/api/loans/{summary.LoanId}/cash-transactions");
 
             await Task.WhenAll(contractTask, servicingTask, accrualsTask, cashTask)
@@ -511,10 +511,10 @@ public sealed class DirectLendingViewModel : BindableBase
                 return;
             }
 
-            var contract = await contractTask.ConfigureAwait(false);
-            var servicing = await servicingTask.ConfigureAwait(false);
-            var accruals = await accrualsTask.ConfigureAwait(false);
-            var cash = await cashTask.ConfigureAwait(false);
+            var contract = (await contractTask.ConfigureAwait(false)).DataOrLoggedNull("Load loan contract detail");
+            var servicing = (await servicingTask.ConfigureAwait(false)).DataOrLoggedNull("Load loan servicing state");
+            var accruals = (await accrualsTask.ConfigureAwait(false)).DataOrLoggedNull("Load loan accrual projections");
+            var cash = (await cashTask.ConfigureAwait(false)).DataOrLoggedNull("Load loan cash transactions");
 
             SelectedContract = contract;
             SelectedServicing = servicing;
@@ -572,14 +572,24 @@ public sealed class DirectLendingViewModel : BindableBase
 
         try
         {
-            var result = await _apiClient.PostAsync<DailyAccrualEntryDto>(
+            var response = await _apiClient.PostWithResponseAsync<DailyAccrualEntryDto>(
                 $"/api/loans/{SelectedLoan.LoanId}/accruals/daily", body, ct)
                 .ConfigureAwait(false);
 
-            AccrualResultText = result is not null
-                ? $"Accrual posted for {result.AccrualDate}: interest ${result.InterestAmount:N2}, " +
-                  $"commitment fee ${result.CommitmentFeeAmount:N2}"
-                : "Accrual posted.";
+            if (response.Success && response.Data is not null)
+            {
+                var result = response.Data;
+                AccrualResultText =
+                    $"Accrual posted for {result.AccrualDate}: interest ${result.InterestAmount:N2}, " +
+                    $"commitment fee ${result.CommitmentFeeAmount:N2}";
+            }
+            else
+            {
+                AccrualResultText = string.IsNullOrWhiteSpace(response.ErrorMessage)
+                    ? "Accrual failed — the workstation service rejected the request."
+                    : $"Accrual failed: {response.ErrorMessage}";
+            }
+
             AccrualResultVisibility = Visibility.Visible;
 
             await LoadLoanDetailAsync(SelectedLoan).ConfigureAwait(false);

--- a/src/Meridian.Wpf/ViewModels/FinancialRecordExplorerViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/FinancialRecordExplorerViewModel.cs
@@ -246,7 +246,7 @@ public sealed class FinancialRecordExplorerViewModel : BindableBase, IDisposable
         try
         {
             var route = BuildExplorerRoute(ExplorerId, ActiveSavedViewId);
-            var dto = await _apiClient.GetAsync<FinancialRecordExplorerDto>(route, ct).ConfigureAwait(true);
+            var dto = (await _apiClient.GetWithResponseAsync<FinancialRecordExplorerDto>(route, ct).ConfigureAwait(true)).DataOrLoggedNull("Load financial record explorer");
             ApplyExplorer(dto ?? CreateUnavailableExplorer(ExplorerId, Title));
             _hasLoaded = true;
         }
@@ -304,7 +304,7 @@ public sealed class FinancialRecordExplorerViewModel : BindableBase, IDisposable
         try
         {
             var route = BuildExplorerRoute(ExplorerId, viewId);
-            var dto = await _apiClient.GetAsync<FinancialRecordExplorerDto>(route, ct).ConfigureAwait(true);
+            var dto = (await _apiClient.GetWithResponseAsync<FinancialRecordExplorerDto>(route, ct).ConfigureAwait(true)).DataOrLoggedNull("Apply financial record explorer saved view");
             ApplyExplorer(dto ?? CreateUnavailableExplorer(ExplorerId, Title));
             _hasLoaded = true;
         }

--- a/src/Meridian.Wpf/ViewModels/SecurityMasterViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/SecurityMasterViewModel.cs
@@ -2253,9 +2253,9 @@ public sealed class SecurityMasterViewModel : BindableBase, IDisposable
             var endpoint = $"/api/workstation/security-master/securities" +
                            $"?query={Uri.EscapeDataString(query)}&take=50&activeOnly={ActiveOnly}";
 
-            var results = await ApiClientService.Instance
-                .GetAsync<SecurityMasterWorkstationDto[]>(endpoint, linked)
-                .ConfigureAwait(false);
+            var results = (await ApiClientService.Instance
+                .GetWithResponseAsync<SecurityMasterWorkstationDto[]>(endpoint, linked)
+                .ConfigureAwait(false)).DataOrLoggedNull("Search security master securities");
 
             await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
             {
@@ -3343,9 +3343,9 @@ public sealed class SecurityMasterViewModel : BindableBase, IDisposable
                 SubscriptionPricePerShare: null,
                 RightsPerShare: null);
 
-            var result = await ApiClientService.Instance
-                .PostAsync<CorporateActionDto>($"/api/workstation/security-master/securities/{securityId}/corporate-actions", dto, ct)
-                .ConfigureAwait(false);
+            var result = (await ApiClientService.Instance
+                .PostWithResponseAsync<CorporateActionDto>($"/api/workstation/security-master/securities/{securityId}/corporate-actions", dto, ct)
+                .ConfigureAwait(false)).DataOrLoggedNull("Record corporate action");
 
             if (result is not null)
             {

--- a/src/Meridian.Wpf/ViewModels/TradingHoursViewModel.cs
+++ b/src/Meridian.Wpf/ViewModels/TradingHoursViewModel.cs
@@ -140,7 +140,7 @@ public sealed class TradingHoursViewModel : BindableBase
     {
         try
         {
-            var response = await _apiClient.GetAsync<CalendarStatusResponse>(UiApiRoutes.CalendarStatus);
+            var response = (await _apiClient.GetWithResponseAsync<CalendarStatusResponse>(UiApiRoutes.CalendarStatus)).DataOrLoggedNull("Load market calendar status");
             if (response?.Market is not null)
             {
                 UpdateStatusBanner(
@@ -252,8 +252,8 @@ public sealed class TradingHoursViewModel : BindableBase
 
         try
         {
-            var response = await _apiClient.GetAsync<CalendarHolidaysResponse>(
-                $"{UiApiRoutes.CalendarHolidays}?year={year}");
+            var response = (await _apiClient.GetWithResponseAsync<CalendarHolidaysResponse>(
+                $"{UiApiRoutes.CalendarHolidays}?year={year}")).DataOrLoggedNull("Load market holiday calendar");
             if (response?.Holidays is not null)
             {
                 Holidays.Clear();

--- a/tests/Meridian.Wpf.Tests/Services/WatchlistServiceTests.cs
+++ b/tests/Meridian.Wpf.Tests/Services/WatchlistServiceTests.cs
@@ -277,8 +277,11 @@ public sealed class WatchlistServiceTests
         }
 
         public Task<ApiResponse<T>> GetWithResponseAsync<T>(string endpoint, CancellationToken ct = default)
-            where T : class =>
-            Task.FromResult(new ApiResponse<T> { Success = true, Data = Watchlists as T });
+            where T : class
+        {
+            LastGetEndpoint = endpoint;
+            return Task.FromResult(new ApiResponse<T> { Success = true, Data = Watchlists as T });
+        }
 
         public Task<T?> PostAsync<T>(string endpoint, object? body = null, CancellationToken ct = default)
             where T : class =>


### PR DESCRIPTION
## Summary

Follow-up to the audit-remediation PR #2340, delivering the deferred P7 caller batches: every one of the **96 legacy `ApiClientService.GetAsync`/`PostAsync` call sites across 26 files** moves onto the `*WithResponseAsync` transport, and the caller-ratchet baseline (`build/scripts/ci/apiclient-caller-baseline.json`) is now **empty** — any future legacy call site fails CI as a new file.

- **Bridging helper** — `ApiResponseExtensions.DataOrLoggedNull` unwraps an `ApiResponse` to the legacy nullable result while keeping the legacy path's diagnostics (non-404 failures logged with operation context), so converted sites are transport-migrated with zero behavior change; public contracts move to `ApiResponse` end-to-end in the consumer follow-ups.
- **Batch 1 (Ui.Services + Infrastructure template, 58 sites)** — ScheduleManagerService (exemplar, 14), BackfillApiService, LiveDataService, SystemHealthService, StorageServiceBase, ActivityFeedService, BackfillProviderConfigService, DataQualityApiClient, ProviderDiagnosticsApiClient, BrokerAdapterTemplate.
- **Batch 2 (WPF workstation clients, 22 sites)** — ten service/client files; pass-through task returns became awaited conversions with signatures unchanged (new awaits use `ConfigureAwait(false)` to preserve the no-context-capture behavior of direct task returns); the `IRemoteWorkstationClient.GetAsync/PostAsync` seam implementations route through the response path with equivalent log-then-null semantics; the WatchlistService test fake records `LastGetEndpoint` on the new path.
- **Batch 3 (WPF ViewModels, 16 sites)** — six ViewModels; `Task.WhenAll` fan-outs unwrap at their existing join points so concurrency and null handling are unchanged. `DirectLendingViewModel.PostAccrualAsync` no longer reports "Accrual posted." when the POST failed (the audit's false-success instance) — it branches on the response and surfaces the server's error message, while a success with an empty body still reads as posted.
- **Review feedback applied** — every awaited `*WithResponseAsync` call in the converted service files carries `ConfigureAwait(false)`; `DataOrLoggedNull` returns an explicit null on failure.

**Not in this PR (remaining P7 scope):** the endpoint-side conversion (request-time `GetService` + 501 fallbacks → `[FromServices]` handler injection, ~85 sites in `WorkstationEndpoints.cs` and siblings) and the service-contract moves to `ApiResponse` end-to-end — staged as the next follow-ups.

## Reason

Audit finding P7: the legacy null-returning seam made backend failures indistinguishable from empty data at 96 call sites. PR #2340 added failure logging and the ratchet (stage 0); this PR completes the caller migration and locks the seam shut.

## Testing performed

- [x] `Meridian.Ui.Services` and `Meridian.Infrastructure` build clean (Release, EnableWindowsTargeting)
- [x] Caller ratchet reports **0 legacy call sites across 0 files** with the regenerated baseline; ratchet unit tests 3/3 (including repository-baseline-is-current)
- [x] UiServices test suites 5/5 locally
- [x] Mandatory per-file greps: zero `\.GetAsync<`/`\.PostAsync<` matches in all 26 converted files
- [x] verify-desktop green on CI — the Windows compile and test pass covers all 38 WPF-side conversions and the test-fake change
- [x] GitHub Actions `Meridian CI / quality-gate` green on head `b4748f0c` (an earlier cycle failed only on the pre-existing flaky `WebSocketConnectionManagerTests` dispose-race in core-infrastructure, untouched by this PR and 940/940 locally; it passed on re-run)

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed — one test fake gained endpoint recording on the new path so existing assertions keep asserting
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

(The ratchet baseline under `build/scripts/ci/` is CI configuration, not a governance-gated file; it shrank to empty, which only tightens the gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147VPDYkCjktDieE7ggiScD