### PR TITLE
Feed live trade/quote ingress into the data-quality monitoring suite

### DIFF
--- a/src/Meridian.Application/Composition/Features/PipelineFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/PipelineFeatureRegistration.cs
@@ -236,64 +236,79 @@ internal sealed class PipelineFeatureRegistration : IServiceFeatureRegistration
             return new DualPathEventPipeline(slowPath, symbolTable, logger: logger);
         });
 
-        // IMarketEventPublisher - facade for publishing events.
+        // IMarketEventPublisher - facade for publishing events. The composed publisher is
+        // wrapped with QualityMonitoringPublisher so live trade/quote ingress feeds the
+        // data-quality monitoring suite (dashboards, gap analysis, anomaly detection).
         services.AddSingleton<IMarketEventPublisher>(sp =>
         {
-            // Check if canonicalization should wrap the publisher
-            var canonPublisher = sp.GetService<CanonicalizingPublisher>();
-            if (canonPublisher is not null)
-            {
-                var configStore = sp.GetRequiredService<ConfigStore>();
-                var config = configStore.Load();
-                if (config.Canonicalization is { Enabled: true })
-                    return canonPublisher;
-            }
-
-            var metrics = sp.GetRequiredService<IEventMetrics>();
-            IMarketEventPublisher innerPublisher = sp.GetRequiredService<DualPathEventPipeline>();
-            IMarketEventPublisher publisher = new PipelinePublisher(
-                innerPublisher,
-                metrics);
-
-            var pipelineConfigStore = sp.GetRequiredService<ConfigStore>();
-            var pipelineConfig = pipelineConfigStore.Load();
-
-            if (pipelineConfig.Canonicalization is { Enabled: true })
-            {
-                var canonConfig = pipelineConfig.Canonicalization;
-                var symbolRegistry = sp.GetService<Contracts.Catalog.ICanonicalSymbolRegistry>();
-                if (symbolRegistry is null)
-                {
-                    Log.ForContext<EventPipeline>().Warning(
-                        "Canonicalization enabled but ICanonicalSymbolRegistry not registered; skipping");
-                    return publisher;
-                }
-                var conditionsPath = canonConfig.ConditionCodesPath
-                    ?? Path.Combine(AppContext.BaseDirectory, "config", "condition-codes.json");
-                var conditions = ConditionCodeMapper.LoadFromFile(conditionsPath);
-                var venuesPath = canonConfig.VenueMappingPath
-                    ?? Path.Combine(AppContext.BaseDirectory, "config", "venue-mapping.json");
-                var venues = VenueMicMapper.LoadFromFile(venuesPath);
-                var securityIdLookup = sp.GetService<ICanonicalSecurityIdLookup>();
-                var canonicalizer = new EventCanonicalizer(
-                    symbolRegistry, conditions, venues, (byte)canonConfig.Version, securityIdLookup);
-
-                CanonicalizationMetrics.SetActiveVersion(canonConfig.Version);
-
-                publisher = new CanonicalizingPublisher(
-                    publisher, canonicalizer, canonConfig.PilotSymbols, canonConfig.EnableDualWrite);
-
-                Log.ForContext<EventPipeline>().Information(
-                    "Canonicalization enabled (version={Version}, pilotSymbols={PilotCount}, dualWrite={DualWrite})",
-                    canonConfig.Version,
-                    canonConfig.PilotSymbols?.Length ?? 0,
-                    canonConfig.EnableDualWrite);
-            }
-
-            return publisher;
+            var publisher = BuildCorePublisher(sp);
+            return new QualityMonitoringPublisher(
+                publisher,
+                sp.GetRequiredService<DataQualityMonitoringService>(),
+                sp.GetService<Microsoft.Extensions.Logging.ILogger<QualityMonitoringPublisher>>());
         });
 
         return services;
+    }
+
+    /// <summary>
+    /// Composes the pipeline-backed publisher chain (dual-path pipeline, metrics facade, and
+    /// optional canonicalization) that <see cref="QualityMonitoringPublisher"/> decorates.
+    /// </summary>
+    private static IMarketEventPublisher BuildCorePublisher(IServiceProvider sp)
+    {
+        // Check if canonicalization should wrap the publisher
+        var canonPublisher = sp.GetService<CanonicalizingPublisher>();
+        if (canonPublisher is not null)
+        {
+            var configStore = sp.GetRequiredService<ConfigStore>();
+            var config = configStore.Load();
+            if (config.Canonicalization is { Enabled: true })
+                return canonPublisher;
+        }
+
+        var metrics = sp.GetRequiredService<IEventMetrics>();
+        IMarketEventPublisher innerPublisher = sp.GetRequiredService<DualPathEventPipeline>();
+        IMarketEventPublisher publisher = new PipelinePublisher(
+            innerPublisher,
+            metrics);
+
+        var pipelineConfigStore = sp.GetRequiredService<ConfigStore>();
+        var pipelineConfig = pipelineConfigStore.Load();
+
+        if (pipelineConfig.Canonicalization is { Enabled: true })
+        {
+            var canonConfig = pipelineConfig.Canonicalization;
+            var symbolRegistry = sp.GetService<Contracts.Catalog.ICanonicalSymbolRegistry>();
+            if (symbolRegistry is null)
+            {
+                Log.ForContext<EventPipeline>().Warning(
+                    "Canonicalization enabled but ICanonicalSymbolRegistry not registered; skipping");
+                return publisher;
+            }
+            var conditionsPath = canonConfig.ConditionCodesPath
+                ?? Path.Combine(AppContext.BaseDirectory, "config", "condition-codes.json");
+            var conditions = ConditionCodeMapper.LoadFromFile(conditionsPath);
+            var venuesPath = canonConfig.VenueMappingPath
+                ?? Path.Combine(AppContext.BaseDirectory, "config", "venue-mapping.json");
+            var venues = VenueMicMapper.LoadFromFile(venuesPath);
+            var securityIdLookup = sp.GetService<ICanonicalSecurityIdLookup>();
+            var canonicalizer = new EventCanonicalizer(
+                symbolRegistry, conditions, venues, (byte)canonConfig.Version, securityIdLookup);
+
+            CanonicalizationMetrics.SetActiveVersion(canonConfig.Version);
+
+            publisher = new CanonicalizingPublisher(
+                publisher, canonicalizer, canonConfig.PilotSymbols, canonConfig.EnableDualWrite);
+
+            Log.ForContext<EventPipeline>().Information(
+                "Canonicalization enabled (version={Version}, pilotSymbols={PilotCount}, dualWrite={DualWrite})",
+                canonConfig.Version,
+                canonConfig.PilotSymbols?.Length ?? 0,
+                canonConfig.EnableDualWrite);
+        }
+
+        return publisher;
     }
 
     /// <summary>

--- a/src/Meridian.Application/DataQuality/QualityMonitoringPublisher.cs
+++ b/src/Meridian.Application/DataQuality/QualityMonitoringPublisher.cs
@@ -164,7 +164,17 @@ public sealed class QualityMonitoringPublisher : IMarketEventPublisher, IAsyncDi
         if (await Task.WhenAny(_consumer, drainTimeout).ConfigureAwait(false) == drainTimeout)
         {
             await _cts.CancelAsync().ConfigureAwait(false);
+        }
+
+        try
+        {
             await _consumer.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Observe consumer faults here so they surface in logs instead of dying as
+            // unobserved task exceptions; disposal itself must not throw.
+            _logger.LogError(ex, "Quality-monitoring consumer terminated with an unhandled error during disposal");
         }
 
         _cts.Dispose();

--- a/src/Meridian.Application/DataQuality/QualityMonitoringPublisher.cs
+++ b/src/Meridian.Application/DataQuality/QualityMonitoringPublisher.cs
@@ -1,0 +1,172 @@
+using System.Threading.Channels;
+using Meridian.Contracts.Domain.Enums;
+using Meridian.Contracts.Domain.Models;
+using Meridian.DataIntegration.Monitoring.DataQuality;
+using Meridian.Domain.Events;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Meridian.Application.DataQuality;
+
+/// <summary>
+/// <see cref="IMarketEventPublisher"/> decorator that feeds live <see cref="MarketEventType.Trade"/>
+/// and <see cref="MarketEventType.BboQuote"/> ingress into the
+/// <see cref="DataQualityMonitoringService"/> (completeness, gap analysis, sequence tracking,
+/// anomaly detection, latency histograms, and cross-provider comparison).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The publish result of the inner publisher is always returned unchanged, so pipeline
+/// backpressure semantics are unaffected. Quality observation happens on a dedicated background
+/// consumer fed by a bounded drop-on-full channel: a slow quality monitor can never stall or
+/// block the market data hot path. Samples are recorded even when the pipeline sheds the event
+/// under backpressure, because feed-quality metrics describe what the provider delivered, not
+/// what storage accepted.
+/// </para>
+/// </remarks>
+public sealed class QualityMonitoringPublisher : IMarketEventPublisher, IAsyncDisposable
+{
+    private const int DefaultSampleCapacity = 8_192;
+    private const long DropLogInterval = 10_000;
+
+    private readonly IMarketEventPublisher _inner;
+    private readonly DataQualityMonitoringService _quality;
+    private readonly ILogger<QualityMonitoringPublisher> _logger;
+    private readonly Channel<MarketEvent> _samples;
+    private readonly Task _consumer;
+    private readonly CancellationTokenSource _cts = new();
+
+    private long _tradesObserved;
+    private long _quotesObserved;
+    private long _samplesDropped;
+    private int _disposed;
+
+    public QualityMonitoringPublisher(
+        IMarketEventPublisher inner,
+        DataQualityMonitoringService quality,
+        ILogger<QualityMonitoringPublisher>? logger = null,
+        int sampleCapacity = DefaultSampleCapacity)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _quality = quality ?? throw new ArgumentNullException(nameof(quality));
+        _logger = logger ?? NullLogger<QualityMonitoringPublisher>.Instance;
+
+        if (sampleCapacity < 1)
+            throw new ArgumentOutOfRangeException(nameof(sampleCapacity), sampleCapacity, "Sample capacity must be at least 1.");
+
+        _samples = Channel.CreateBounded<MarketEvent>(new BoundedChannelOptions(sampleCapacity)
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.DropWrite
+        });
+
+        _consumer = Task.Run(() => ConsumeAsync(_cts.Token));
+    }
+
+    /// <summary>Gets the number of trade events recorded into the quality monitors.</summary>
+    public long TradesObserved => Interlocked.Read(ref _tradesObserved);
+
+    /// <summary>Gets the number of quote events recorded into the quality monitors.</summary>
+    public long QuotesObserved => Interlocked.Read(ref _quotesObserved);
+
+    /// <summary>Gets the number of quality samples dropped because the sample buffer was full.</summary>
+    public long SamplesDropped => Interlocked.Read(ref _samplesDropped);
+
+    /// <inheritdoc/>
+    public bool TryPublish(in MarketEvent evt)
+    {
+        var accepted = _inner.TryPublish(in evt);
+
+        if (evt.Type is MarketEventType.Trade or MarketEventType.BboQuote
+            && Volatile.Read(ref _disposed) == 0
+            && !_samples.Writer.TryWrite(evt))
+        {
+            var dropped = Interlocked.Increment(ref _samplesDropped);
+            if (dropped == 1 || dropped % DropLogInterval == 0)
+            {
+                _logger.LogWarning(
+                    "Quality-monitoring sample buffer is full; {DroppedCount} samples dropped so far. " +
+                    "Dashboards remain live but under-count during the overload window.",
+                    dropped);
+            }
+        }
+
+        return accepted;
+    }
+
+    private async Task ConsumeAsync(CancellationToken ct)
+    {
+        try
+        {
+            await foreach (var evt in _samples.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                try
+                {
+                    Observe(evt);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex,
+                        "Failed to record {EventType} quality sample for {Symbol}",
+                        evt.Type, evt.EffectiveSymbol);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Disposal requested a hard stop before the channel drained.
+        }
+    }
+
+    private void Observe(MarketEvent evt)
+    {
+        switch (evt.Payload)
+        {
+            case Trade trade:
+                _quality.ProcessTrade(
+                    evt.EffectiveSymbol,
+                    evt.Timestamp,
+                    trade.Price,
+                    trade.Size,
+                    // Sequence 0 means "provider does not sequence this stream"; passing it
+                    // through would register false sequence errors for every event.
+                    evt.Sequence > 0 ? evt.Sequence : null,
+                    evt.Source,
+                    evt.EstimatedLatencyMs);
+                Interlocked.Increment(ref _tradesObserved);
+                break;
+
+            case BboQuotePayload quote:
+                _quality.ProcessQuote(
+                    evt.EffectiveSymbol,
+                    evt.Timestamp,
+                    quote.BidPrice,
+                    quote.AskPrice,
+                    quote.BidSize,
+                    quote.AskSize,
+                    evt.Source,
+                    evt.EstimatedLatencyMs);
+                Interlocked.Increment(ref _quotesObserved);
+                break;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        _samples.Writer.TryComplete();
+
+        var drainTimeout = Task.Delay(TimeSpan.FromSeconds(5));
+        if (await Task.WhenAny(_consumer, drainTimeout).ConfigureAwait(false) == drainTimeout)
+        {
+            await _cts.CancelAsync().ConfigureAwait(false);
+            await _consumer.ConfigureAwait(false);
+        }
+
+        _cts.Dispose();
+    }
+}

--- a/tests/Meridian.Tests/Application/Composition/PipelineFeatureRegistrationTests.cs
+++ b/tests/Meridian.Tests/Application/Composition/PipelineFeatureRegistrationTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Channels;
 using FluentAssertions;
 using Meridian.Application.Composition;
 using Meridian.Application.Composition.Features;
+using Meridian.Application.DataQuality;
 using Meridian.Core.Config;
 using Meridian.DataIntegration.Monitoring.DataQuality;
 using Meridian.Application.Pipeline;
@@ -143,6 +144,39 @@ public sealed class PipelineFeatureRegistrationTests : IDisposable
 
         publisher.TryPublish(CreateTradeEvent("SPY", 1)).Should().BeTrue();
         dualPath.HotTradePublished.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Register_FeedsLiveTradeIngressIntoQualityMonitoring()
+    {
+        var root = CreateTempDirectory();
+        var dataRoot = Path.Combine(root, "persistent-data");
+        var configPath = WriteConfig(root, new AppConfig(DataRoot: "persistent-data"));
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(new StorageOptions { RootPath = dataRoot });
+
+        var options = CompositionOptions.WebDashboard with { ConfigPath = configPath };
+        new ConfigurationFeatureRegistration().Register(services, options);
+        new PipelineFeatureRegistration().Register(services, options);
+
+        await using var provider = services.BuildServiceProvider();
+        var publisher = provider.GetRequiredService<IMarketEventPublisher>();
+        var monitoring = provider.GetRequiredService<DataQualityMonitoringService>();
+
+        publisher.Should().BeOfType<QualityMonitoringPublisher>();
+        publisher.TryPublish(CreateTradeEvent("QQQ", 1)).Should().BeTrue();
+
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (monitoring.GetSymbolHealth("QQQ") is null && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(10);
+        }
+
+        monitoring.GetSymbolHealth("QQQ").Should().NotBeNull(
+            "live trade ingress must reach the data-quality monitoring suite");
+        monitoring.GetRealTimeMetrics().ActiveSymbols.Should().Be(1);
     }
 
     private static string GetReportOutputDirectory(DataQualityReportGenerator generator)

--- a/tests/Meridian.Tests/Application/DataQuality/QualityMonitoringPublisherTests.cs
+++ b/tests/Meridian.Tests/Application/DataQuality/QualityMonitoringPublisherTests.cs
@@ -1,0 +1,176 @@
+using FluentAssertions;
+using Meridian.Application.DataQuality;
+using Meridian.Contracts.Domain.Enums;
+using Meridian.Contracts.Domain.Models;
+using Meridian.DataIntegration.Monitoring.DataQuality;
+using Meridian.Domain.Events;
+using Xunit;
+
+namespace Meridian.Tests.Application.DataQuality;
+
+public sealed class QualityMonitoringPublisherTests
+{
+    [Fact]
+    public async Task TryPublish_TradeEvent_FeedsQualityMonitoringService()
+    {
+        await using var quality = new DataQualityMonitoringService();
+        var inner = new RecordingPublisher();
+        await using var sut = new QualityMonitoringPublisher(inner, quality);
+
+        sut.TryPublish(CreateTradeEvent("SPY", sequence: 1)).Should().BeTrue();
+
+        await WaitUntilAsync(() => sut.TradesObserved == 1);
+        inner.Events.Should().ContainSingle(evt => evt.Type == MarketEventType.Trade);
+        quality.GetSymbolHealth("SPY").Should().NotBeNull();
+        quality.GetRealTimeMetrics().ActiveSymbols.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task TryPublish_QuoteEvent_FeedsQualityMonitoringService()
+    {
+        await using var quality = new DataQualityMonitoringService();
+        var inner = new RecordingPublisher();
+        await using var sut = new QualityMonitoringPublisher(inner, quality);
+
+        sut.TryPublish(CreateQuoteEvent("MSFT", sequence: 7)).Should().BeTrue();
+
+        await WaitUntilAsync(() => sut.QuotesObserved == 1);
+        inner.Events.Should().ContainSingle(evt => evt.Type == MarketEventType.BboQuote);
+        quality.GetSymbolHealth("MSFT").Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task TryPublish_NonHotPathEvent_IsForwardedButNotObserved()
+    {
+        await using var quality = new DataQualityMonitoringService();
+        var inner = new RecordingPublisher();
+        await using var sut = new QualityMonitoringPublisher(inner, quality);
+
+        sut.TryPublish(MarketEvent.Heartbeat(DateTimeOffset.UtcNow)).Should().BeTrue();
+        sut.TryPublish(CreateTradeEvent("SPY", sequence: 1)).Should().BeTrue();
+
+        // The trade published after the heartbeat has been observed, so the heartbeat
+        // has already passed through the sampling filter without being recorded.
+        await WaitUntilAsync(() => sut.TradesObserved == 1);
+        sut.QuotesObserved.Should().Be(0);
+        inner.Events.Should().HaveCount(2);
+        quality.GetSymbolHealth("SYSTEM").Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TryPublish_WhenPipelineRejectsEvent_PreservesResultAndStillObservesFeed()
+    {
+        await using var quality = new DataQualityMonitoringService();
+        var inner = new RecordingPublisher { Result = false };
+        await using var sut = new QualityMonitoringPublisher(inner, quality);
+
+        sut.TryPublish(CreateTradeEvent("SPY", sequence: 1)).Should().BeFalse();
+
+        // Feed quality describes what the provider delivered, not what storage accepted.
+        await WaitUntilAsync(() => sut.TradesObserved == 1);
+        quality.GetSymbolHealth("SPY").Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task TryPublish_TradeWithExchangeTimestamp_RecordsLatencySample()
+    {
+        await using var quality = new DataQualityMonitoringService();
+        var inner = new RecordingPublisher();
+        await using var sut = new QualityMonitoringPublisher(inner, quality);
+
+        var evt = CreateTradeEvent("SPY", sequence: 1)
+            .StampReceiveTime(exchangeTs: DateTimeOffset.UtcNow.AddMilliseconds(-50));
+        sut.TryPublish(evt).Should().BeTrue();
+
+        await WaitUntilAsync(() => sut.TradesObserved == 1);
+        quality.LatencyHistogram.GetStatistics().TotalSamples.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DrainsPendingSamplesBeforeCompleting()
+    {
+        await using var quality = new DataQualityMonitoringService();
+        var inner = new RecordingPublisher();
+        var sut = new QualityMonitoringPublisher(inner, quality);
+
+        for (var i = 1; i <= 100; i++)
+        {
+            sut.TryPublish(CreateTradeEvent("SPY", sequence: i));
+        }
+
+        await sut.DisposeAsync();
+
+        sut.TradesObserved.Should().Be(100);
+        sut.SamplesDropped.Should().Be(0);
+    }
+
+    private static MarketEvent CreateTradeEvent(string symbol, long sequence)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var trade = new Trade(
+            Timestamp: now,
+            Symbol: symbol,
+            Price: 100.50m,
+            Size: 100L,
+            Aggressor: AggressorSide.Buy,
+            SequenceNumber: sequence);
+
+        return MarketEvent.Trade(now, symbol, trade, sequence);
+    }
+
+    private static MarketEvent CreateQuoteEvent(string symbol, long sequence)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var quote = new BboQuotePayload(
+            Timestamp: now,
+            Symbol: symbol,
+            BidPrice: 100.00m,
+            BidSize: 200L,
+            AskPrice: 100.05m,
+            AskSize: 300L,
+            MidPrice: 100.025m,
+            Spread: 0.05m,
+            SequenceNumber: sequence);
+
+        return MarketEvent.BboQuote(now, symbol, quote, sequence);
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, int timeoutMs = 5_000)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (!condition() && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(10);
+        }
+
+        condition().Should().BeTrue("the background quality consumer should observe the sample within {0}ms", timeoutMs);
+    }
+
+    private sealed class RecordingPublisher : IMarketEventPublisher
+    {
+        private readonly List<MarketEvent> _events = new();
+
+        public bool Result { get; set; } = true;
+
+        public IReadOnlyList<MarketEvent> Events
+        {
+            get
+            {
+                lock (_events)
+                {
+                    return _events.ToList();
+                }
+            }
+        }
+
+        public bool TryPublish(in MarketEvent evt)
+        {
+            lock (_events)
+            {
+                _events.Add(evt);
+            }
+
+            return Result;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`DataQualityMonitoringService.ProcessTrade`/`ProcessQuote` (anomaly detection, gap analysis, latency histograms, cross-provider comparison) were only ever invoked from tests, so the Data Quality dashboards rendered zeros regardless of feed health while looking live.

This wires the entire quality suite into the live feed:

- **New `QualityMonitoringPublisher`** (`src/Meridian.Application/DataQuality/`): an `IMarketEventPublisher` decorator that forwards every event to the composed pipeline publisher unchanged, and observes `Trade`/`BboQuote` ingress through a bounded drop-on-full channel drained by a background consumer. A slow quality monitor can never block or stall the market-data hot path, and the inner publisher's accept/reject result is preserved exactly so backpressure semantics are untouched. Samples are recorded even when the pipeline sheds an event under backpressure, since feed-quality metrics describe what the provider delivered, not what storage accepted. Buffer overflow is counted and logged (first drop, then every 10,000th) instead of silently truncating.
- **`PipelineFeatureRegistration`**: the `IMarketEventPublisher` factory body is extracted into `BuildCorePublisher` and every branch (plain pipeline, locally-composed canonicalization, and the registered `CanonicalizingPublisher`) is now wrapped with the quality tap. Trades feed sequence tracking only when the provider actually sequences the stream (`Sequence > 0`), avoiding false sequence errors; symbol, provider, and latency come from `EffectiveSymbol`, `Source`, and `EstimatedLatencyMs`.

Since all collectors and provider adapters publish via the DI-resolved `IMarketEventPublisher` (no production caller uses the zero-allocation bypass API), this single wrap point covers all live ingress, and the live-trading engine's `CompositePublisher` tap re-wraps the same descriptor so the chain is preserved there too.

## Reason

The Data Quality dashboards and `/api/quality/*` endpoints read from the `DataQualityMonitoringService` DI singleton, but nothing in production ever fed it events — the entire monitoring suite was dead weight and the dashboards showed misleading zeros for gaps, anomalies, latency, and health regardless of actual feed condition.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated
- [x] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

New `QualityMonitoringPublisherTests` (6 tests: trade/quote observation, non-hot-path events ignored, inner publish result preserved on rejection, latency sample recording, drain-on-dispose) and a new composition test `Register_FeedsLiveTradeIngressIntoQualityMonitoring` proving the DI-resolved publisher feeds the same quality singleton the dashboards read. Ran targeted suites locally: `QualityMonitoringPublisherTests`, `PipelineFeatureRegistrationTests`, `DataQualityTests`, `CompositeDataQualityReadServiceTests`, `QualityEndpointContractTests`, `DualPathEventPipelineTests` — 44 passed, 0 failed. Full `quality-gate` will run on this PR.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

Check every governance file modified:

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

Governance-file changes require explicit human approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ouSMxZV3LbPXUj5DygfDL

---
_Generated by [Claude Code](https://claude.ai/code/session_019ouSMxZV3LbPXUj5DygfDL)_