### PR TITLE
Make degraded modes loud and fail-closed: provider resolution, paper fills, backfill recency, unified persistence

### DIFF
--- a/build/python/cli/buildctl.py
+++ b/build/python/cli/buildctl.py
@@ -684,7 +684,9 @@ def _check_docker_daemon() -> tuple[bool, bool, str, str | None]:
 
 def _check_postgres() -> tuple[bool, bool, str, str | None]:
     """Attempt a TCP connection to the PostgreSQL port and report fix hints."""
-    conn_str = os.getenv("MERIDIAN_SECURITY_MASTER_CONNECTION_STRING", "")
+    conn_str = os.getenv("MERIDIAN_SECURITY_MASTER_CONNECTION_STRING", "") or os.getenv(
+        "MERIDIAN_DATABASE_URL", ""
+    )
     host = _POSTGRES_DEFAULT_HOST
     port = _POSTGRES_DEFAULT_PORT
 

--- a/build/python/diagnostics/doctor.py
+++ b/build/python/diagnostics/doctor.py
@@ -258,7 +258,9 @@ class Doctor:
 
     def _check_postgres(self) -> None:
         """Try a TCP connection to PostgreSQL and report fix hints."""
-        conn_str = os.getenv("MERIDIAN_SECURITY_MASTER_CONNECTION_STRING", "")
+        conn_str = os.getenv("MERIDIAN_SECURITY_MASTER_CONNECTION_STRING", "") or os.getenv(
+        "MERIDIAN_DATABASE_URL", ""
+    )
         host = _POSTGRES_DEFAULT_HOST
         port = _POSTGRES_DEFAULT_PORT
 

--- a/config/appsettings.schema.json
+++ b/config/appsettings.schema.json
@@ -1426,6 +1426,9 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "AllowScaffoldMarketFills": {
+              "type": "boolean"
+            },
             "ScaffoldMarketFillPrice": {
               "type": "number"
             }

--- a/docs/HELP.md
+++ b/docs/HELP.md
@@ -115,8 +115,8 @@ pwsh ./scripts/dev/run-desktop.ps1 -LaunchMode Production
 ```
 
 `-LaunchMode Production` builds Release host and desktop artifacts and requires
-`MERIDIAN_FUND_ACCOUNTS_CONNECTION_STRING` plus `MERIDIAN_FUND_STRUCTURE_CONNECTION_STRING` before
-the desktop-local host starts. `-BuildOnly` verifies the Release build without starting the host.
+`MERIDIAN_DATABASE_URL` (or `MERIDIAN_FUND_ACCOUNTS_CONNECTION_STRING` plus
+`MERIDIAN_FUND_STRUCTURE_CONNECTION_STRING`) before the desktop-local host starts. `-BuildOnly` verifies the Release build without starting the host.
 The WPF startup screen uses the same environment-backed operator credentials as the browser
 workstation: prefer `MDC_USERS` with `passwordHash` values, or use `MDC_USERNAME` /
 `MDC_PASSWORD_HASH` for a single local admin bootstrap. Production, packaged, and customer-build auth

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -180,10 +180,30 @@ pwsh ./scripts/dev/run-desktop.ps1 -LaunchMode Development
 Use `pwsh ./scripts/dev/run-desktop.ps1 -LaunchMode Production -BuildOnly` for a Release
 host/desktop build that does not require database connectivity. Use `-LaunchMode Production`
 without `-BuildOnly` only when the production governance persistence variables are configured:
-`MERIDIAN_FUND_ACCOUNTS_CONNECTION_STRING` and `MERIDIAN_FUND_STRUCTURE_CONNECTION_STRING`.
+`MERIDIAN_DATABASE_URL`, or `MERIDIAN_FUND_ACCOUNTS_CONNECTION_STRING` and
+`MERIDIAN_FUND_STRUCTURE_CONNECTION_STRING`.
 Development launch mode sets `DOTNET_ENVIRONMENT=Development`,
 `ASPNETCORE_ENVIRONMENT=Development`, and `MERIDIAN_USE_INMEMORY_GOVERNANCE=true` for the
 launched processes, then restores the caller's environment.
+
+### Persistence
+
+**Without database configuration, every money-path store (ledger, fund accounts, banking,
+money market, reporting, and more) runs in-memory: journal entries, reconciliations, and
+approvals are lost on restart.** Hosts surface this loudly — a `PERSISTENCE: NONE`/`PARTIAL`
+warning at startup, in the `postgresql` readiness check, and as a red banner in the browser
+workstation.
+
+Set the single unified variable to persist every store domain to one PostgreSQL database:
+
+```bash
+export MERIDIAN_DATABASE_URL="postgres://user:password@localhost:5432/meridian"
+# or Npgsql keyword form:
+export MERIDIAN_DATABASE_URL="Host=localhost;Port=5432;Database=meridian;Username=user;Password=password"
+```
+
+Per-domain `MERIDIAN_*_CONNECTION_STRING` variables remain supported and always take
+precedence over `MERIDIAN_DATABASE_URL`, so split-database deployments keep working.
 
 ## Workstation Architecture Rules
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -110,6 +110,28 @@ IB credentials are managed via TWS/Gateway, not environment variables. However, 
 | `NYSE__APIKEY` | `NYSE:ApiKey` | NYSE market data API key | When using NYSE | — |
 | `NASDAQ__APIKEY` | — | Nasdaq Data Link API key | When using Nasdaq | — |
 
+## Database Persistence
+
+**Without any of these variables, every money-path store (ledger, security master, fund
+accounts, fund structure, direct lending, asset operations, banking, money market, reporting,
+scoped access) runs in-memory and loses its data on restart.** Hosts log a loud
+`PERSISTENCE: NONE`/`PARTIAL` warning, report it in the `postgresql` readiness check, and the
+browser workstation shows a persistent red banner until persistence is configured.
+
+| Variable | Description | Required | Default |
+|----------|-------------|----------|---------|
+| `MERIDIAN_DATABASE_URL` | Unified PostgreSQL connection for **all** store domains. Accepts `postgres://user:pass@host:port/db` URLs or Npgsql keyword form. Propagated at startup into every unset `MERIDIAN_*_CONNECTION_STRING`. | No | — (in-memory stores) |
+| `MERIDIAN_LEDGER_CONNECTION_STRING` | Ledger journal store (per-domain override; wins over `MERIDIAN_DATABASE_URL`). | No | inherits `MERIDIAN_DATABASE_URL` |
+| `MERIDIAN_SECURITY_MASTER_CONNECTION_STRING` | Security Master store (also inherited by Direct Lending unless its dedicated variable is set). | No | inherits `MERIDIAN_DATABASE_URL` |
+| `MERIDIAN_FUND_ACCOUNTS_CONNECTION_STRING` | Fund accounts governance store. | No | inherits `MERIDIAN_DATABASE_URL` |
+| `MERIDIAN_FUND_STRUCTURE_CONNECTION_STRING` | Fund structure governance store. | No | inherits `MERIDIAN_DATABASE_URL` |
+| `MERIDIAN_ASSET_OPERATIONS_CONNECTION_STRING` | Asset operations projection store. | No | inherits `MERIDIAN_DATABASE_URL` |
+| `MERIDIAN_BANKING_CONNECTION_STRING` | Banking store. | No | inherits `MERIDIAN_DATABASE_URL` |
+| `MERIDIAN_MONEY_MARKET_CONNECTION_STRING` | Money market fund store. | No | inherits `MERIDIAN_DATABASE_URL` |
+| `MERIDIAN_SCOPED_ACCESS_CONNECTION_STRING` | Scoped access assignment store. | No | inherits `MERIDIAN_DATABASE_URL` |
+| `MERIDIAN_REPORTING_CONNECTION_STRING` | Reporting stores. | No | inherits the ledger connection |
+| `MERIDIAN_DIRECT_LENDING_CONNECTION_STRING` | Direct lending store (dedicated/test databases only). | No | inherits the Security Master connection |
+
 ## Storage Configuration
 
 | Variable | Config Path | Description | Required | Default |

--- a/docs/start/README.md
+++ b/docs/start/README.md
@@ -83,6 +83,22 @@ If `where.exe make` finds nothing, skip Make and use the underlying `dotnet`, `n
 | WPF production shell | `pwsh ./scripts/dev/run-desktop.ps1 -LaunchMode Production` | Requires persistence-backed governance connection strings before host startup. |
 | Headless collector | `dotnet run --project src/Meridian/Meridian.csproj -- --mode headless` | Use for non-UI collection scenarios. |
 
+### Persistence and simulation defaults
+
+Two defaults matter before you trust what a local launch shows you:
+
+- **Persistence.** Without database configuration, every money-path store (ledger, fund
+  accounts, banking, reporting, and more) runs in-memory — journal entries, reconciliations,
+  and approvals are lost on restart. Set one variable to persist all store domains to
+  PostgreSQL: `MERIDIAN_DATABASE_URL=postgres://user:password@localhost:5432/meridian`
+  (per-domain `MERIDIAN_*_CONNECTION_STRING` variables override it individually). Hosts log
+  `PERSISTENCE: NONE`/`PARTIAL` at startup, report it on `/readyz`, and the browser
+  workstation shows a persistent red banner until persistence is configured.
+- **Market data.** The default `ib` streaming source runs as a random-walk **simulator** in
+  standard builds (no IBAPI reference), and the `synthetic` source is always simulated.
+  Simulated data is flagged in `/api/status` (`degradedMode.marketDataMode`) and by the same
+  red workstation banner — never treat quotes, fills, or P&L from a simulated source as real.
+
 The WPF desktop startup screen prompts for the environment-backed Meridian operator profile. Configure
 `MDC_USERS` with `passwordHash` values for multi-user login, or use the legacy `MDC_USERNAME` /
 `MDC_PASSWORD_HASH` bootstrap pair for a single local admin. Development launches can continue

--- a/scripts/dev/run-desktop.ps1
+++ b/scripts/dev/run-desktop.ps1
@@ -111,6 +111,13 @@ function Apply-DesktopLaunchMode {
 }
 
 function Assert-ProductionGovernanceConfiguration {
+    # MERIDIAN_DATABASE_URL is the unified persistence variable; the host propagates it into
+    # every per-domain connection string at startup, so its presence satisfies this gate.
+    if (-not [string]::IsNullOrWhiteSpace([System.Environment]::GetEnvironmentVariable('MERIDIAN_DATABASE_URL'))) {
+        Write-Ok 'Production governance persistence configuration is present (MERIDIAN_DATABASE_URL).'
+        return
+    }
+
     $requiredVariables = @(
         'MERIDIAN_FUND_ACCOUNTS_CONNECTION_STRING',
         'MERIDIAN_FUND_STRUCTURE_CONNECTION_STRING'
@@ -122,7 +129,7 @@ function Assert-ProductionGovernanceConfiguration {
 
     if ($missing.Count -gt 0) {
         $joined = $missing -join ', '
-        throw "Production desktop launch requires persistence-backed governance services. Configure $joined, or rerun with -LaunchMode Development for the explicit local/dev in-memory profile."
+        throw "Production desktop launch requires persistence-backed governance services. Configure $joined (or MERIDIAN_DATABASE_URL), or rerun with -LaunchMode Development for the explicit local/dev in-memory profile."
     }
 
     Write-Ok 'Production governance persistence configuration is present.'

--- a/src/Meridian.Application/Backfill/HistoricalBackfillService.cs
+++ b/src/Meridian.Application/Backfill/HistoricalBackfillService.cs
@@ -258,14 +258,37 @@ public sealed class HistoricalBackfillService
                         ct).ConfigureAwait(false);
                 }
 
-                // Emit validation signal.
+                // Emit validation signal. Recency comes first: a provider whose dataset is
+                // frozen (e.g. Nasdaq WIKI ended March 2018) can return plenty of bars that
+                // still end years before the requested range end, and an open-ended request
+                // (To == null) implicitly expects data through today.
+                var utcToday = DateOnly.FromDateTime(DateTime.UtcNow);
+                var expectedThrough = request.To is { } requestedTo && requestedTo < utcToday ? requestedTo : utcToday;
+                var staleDays = lastBarDate.HasValue ? expectedThrough.DayNumber - lastBarDate.Value.DayNumber : 0;
+                // Only requests that expect data through (roughly) now can be "stale"; an
+                // explicitly historical range that falls short is partial coverage, not staleness.
+                var requestExpectsFreshData = request.To is null ||
+                    request.To.Value.DayNumber >= utcToday.DayNumber - BackfillBarValidation.DefaultStaleToleranceDays;
+                var isStale = requestExpectsFreshData && symbolBars > 0 && lastBarDate.HasValue &&
+                    staleDays > BackfillBarValidation.DefaultStaleToleranceDays;
+
                 var coversRequestedRange =
                     symbolBars > 0 &&
                     firstBarDate.HasValue &&
                     (effectiveFrom is null || firstBarDate.Value <= effectiveFrom.Value) &&
                     (!request.To.HasValue || (lastBarDate.HasValue && lastBarDate.Value >= request.To.Value));
 
-                if (coversRequestedRange)
+                if (isStale)
+                {
+                    var staleReason =
+                        $"Backfilled data is stale: newest bar {lastBarDate:yyyy-MM-dd} is {staleDays} calendar days " +
+                        $"short of the expected range end {expectedThrough:yyyy-MM-dd}. The provider's dataset may be frozen or paywalled.";
+                    _log.Warning(
+                        "Stale backfill for {Symbol} via {Provider}: newest bar {LastBarDate} vs expected {ExpectedThrough} ({StaleDays} days)",
+                        symbol, provider.DisplayName, lastBarDate, expectedThrough, staleDays);
+                    validationSignals.Add(SymbolValidationSignal.Warn(symbol, effectiveFrom, request.To, staleReason));
+                }
+                else if (coversRequestedRange)
                     validationSignals.Add(SymbolValidationSignal.Pass(symbol, symbolBars, effectiveFrom, lastBarDate));
                 else if (symbolBars > 0)
                     validationSignals.Add(SymbolValidationSignal.Warn(symbol, effectiveFrom, request.To, "Provider returned partial bars that do not cover the requested date range"));
@@ -274,8 +297,17 @@ public sealed class HistoricalBackfillService
 
                 async Task PublishAggregateBarsAsync(IReadOnlyList<AggregateBar> bars)
                 {
+                    var futureCutoff = DateTimeOffset.UtcNow.AddDays(1);
+                    var futureDropped = 0;
                     foreach (var bar in bars)
                     {
+                        // A bar ending in the future is provider garbage, not history.
+                        if (bar.EndTime > futureCutoff)
+                        {
+                            futureDropped++;
+                            continue;
+                        }
+
                         var evt = MarketEvent.AggregateBar(bar.EndTime, bar.Symbol, bar, bar.SequenceNumber, provider.Name);
                         await pipeline.PublishAsync(evt, ct).ConfigureAwait(false);
                         _metrics.IncHistoricalBars();
@@ -288,10 +320,25 @@ public sealed class HistoricalBackfillService
                         if (lastBarDate is null || barDate > lastBarDate.Value)
                             lastBarDate = barDate;
                     }
+
+                    if (futureDropped > 0)
+                    {
+                        _log.Warning(
+                            "Dropped {FutureDropped} future-dated aggregate bars for {Symbol} from {Provider}",
+                            futureDropped, symbol, provider.Name);
+                    }
                 }
 
                 async Task PublishHistoricalBarsAsync(IReadOnlyList<HistoricalBar> bars)
                 {
+                    bars = BackfillBarValidation.RemoveFutureDatedBars(bars, out var futureDropped);
+                    if (futureDropped > 0)
+                    {
+                        _log.Warning(
+                            "Dropped {FutureDropped} future-dated daily bars for {Symbol} from {Provider}",
+                            futureDropped, symbol, provider.Name);
+                    }
+
                     foreach (var bar in bars)
                     {
                         var evt = MarketEvent.HistoricalBar(bar.ToTimestampUtc(), bar.Symbol, bar, bar.SequenceNumber, provider.Name);

--- a/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
+++ b/src/Meridian.Application/Composition/Features/StorageFeatureRegistration.cs
@@ -77,6 +77,10 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
 {
     public IServiceCollection Register(IServiceCollection services, CompositionOptions options)
     {
+        // Unified persistence config must resolve before any per-domain in-memory-vs-Postgres
+        // decision below reads the per-domain variables.
+        MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl();
+
         SecurityMasterStartup.EnsureEnvironmentDefaults();
         AssetOperationsStartup.EnsureEnvironmentDefaults();
         DirectLendingStartup.EnsureEnvironmentDefaults();
@@ -604,7 +608,8 @@ internal sealed class StorageFeatureRegistration : IServiceFeatureRegistration
 
         throw new InvalidOperationException(
             "Production-safe startup requires persistence-backed governance domain services. " +
-            $"Configure {string.Join(", ", missing)} or set MERIDIAN_USE_INMEMORY_GOVERNANCE=true only for local/dev fixture scenarios.");
+            $"Configure {string.Join(", ", missing)} (or set {MeridianDatabaseEnvironment.UnifiedVariable} to cover all store domains at once), " +
+            "or set MERIDIAN_USE_INMEMORY_GOVERNANCE=true only for local/dev fixture scenarios.");
     }
 
     private static bool IsInMemoryGovernanceProfileEnabled()

--- a/src/Meridian.Application/Composition/HostStartup.cs
+++ b/src/Meridian.Application/Composition/HostStartup.cs
@@ -56,6 +56,8 @@ public sealed class HostStartup : IAsyncDisposable
 
     private static HostStartup Create(CompositionOptions options)
     {
+        Meridian.Storage.MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl();
+
         var log = LoggingSetup.ForContext<HostStartup>();
         var services = new ServiceCollection();
         services.AddLogging(builder => builder.AddSerilog());

--- a/src/Meridian.Application/Composition/PersistenceConfigurationStatus.cs
+++ b/src/Meridian.Application/Composition/PersistenceConfigurationStatus.cs
@@ -1,0 +1,62 @@
+using Meridian.Storage;
+
+namespace Meridian.Application.Composition;
+
+/// <summary>
+/// Snapshot of which money-path store domains have database persistence configured.
+/// </summary>
+/// <param name="Mode">"none", "partial", or "configured".</param>
+/// <param name="ConfiguredDomains">Domains backed by a database connection.</param>
+/// <param name="MissingDomains">Domains that will run in-memory (or unregistered) and lose data on restart.</param>
+public sealed record PersistenceStatusSnapshot(
+    string Mode,
+    IReadOnlyList<string> ConfiguredDomains,
+    IReadOnlyList<string> MissingDomains)
+{
+    public const string None = "none";
+    public const string Partial = "partial";
+    public const string Configured = "configured";
+}
+
+/// <summary>
+/// Evaluates persistence configuration across every money-path store domain, resolving the same
+/// environment variables (including the unified <c>MERIDIAN_DATABASE_URL</c> propagation and the
+/// Direct Lending / Reporting inheritance chains) as the composition switchboards. Used by
+/// status endpoints, readiness checks, and startup logging so operators see a loud
+/// "PERSISTENCE: NONE" signal instead of silently losing journal entries on restart.
+/// </summary>
+public static class PersistenceConfigurationStatus
+{
+    public static PersistenceStatusSnapshot Evaluate()
+    {
+        MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl();
+
+        var configured = new List<string>();
+        var missing = new List<string>();
+
+        void Classify(string domain, bool isConfigured)
+            => (isConfigured ? configured : missing).Add(domain);
+
+        Classify("ledger", LedgerStartup.IsConfigured());
+        Classify("security-master", SecurityMasterStartup.IsConfigured());
+        Classify("fund-accounts", FundAccountsStartup.IsConfigured());
+        Classify("fund-structure", FundStructureStartup.IsConfigured());
+        Classify("direct-lending", DirectLendingStartup.IsConfigured());
+        Classify("asset-operations", AssetOperationsStartup.IsConfigured());
+        Classify("banking", BankingStartup.IsConfigured());
+        Classify("money-market", MoneyMarketStartup.IsConfigured());
+        Classify("reporting", HasValue("MERIDIAN_REPORTING_CONNECTION_STRING") || LedgerStartup.IsConfigured());
+        Classify("scoped-access", HasValue("MERIDIAN_SCOPED_ACCESS_CONNECTION_STRING"));
+
+        var mode = missing.Count == 0
+            ? PersistenceStatusSnapshot.Configured
+            : configured.Count == 0
+                ? PersistenceStatusSnapshot.None
+                : PersistenceStatusSnapshot.Partial;
+
+        return new PersistenceStatusSnapshot(mode, configured, missing);
+    }
+
+    private static bool HasValue(string variable)
+        => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(variable));
+}

--- a/src/Meridian.Application/Http/Endpoints/StatusEndpointHandlers.cs
+++ b/src/Meridian.Application/Http/Endpoints/StatusEndpointHandlers.cs
@@ -27,6 +27,7 @@ public sealed class StatusEndpointHandlers
     private readonly Func<PipelineStatistics> _pipelineProvider;
     private readonly Func<IReadOnlyList<DepthIntegrityEvent>> _integrityProvider;
     private readonly Func<ErrorRingBuffer?> _errorBufferProvider;
+    private readonly Func<DegradedModeStatus?>? _degradedModeProvider;
 
     // Optional extended providers
     private Func<Task<DetailedHealthReport>>? _detailedHealthProvider;
@@ -44,13 +45,15 @@ public sealed class StatusEndpointHandlers
         Func<PipelineStatistics> pipelineProvider,
         Func<IReadOnlyList<DepthIntegrityEvent>> integrityProvider,
         Func<ErrorRingBuffer?>? errorBufferProvider = null,
-        DateTimeOffset? startTime = null)
+        DateTimeOffset? startTime = null,
+        Func<DegradedModeStatus?>? degradedModeProvider = null)
     {
         _metricsProvider = metricsProvider ?? throw new ArgumentNullException(nameof(metricsProvider));
         _pipelineProvider = pipelineProvider ?? throw new ArgumentNullException(nameof(pipelineProvider));
         _integrityProvider = integrityProvider ?? throw new ArgumentNullException(nameof(integrityProvider));
         _errorBufferProvider = errorBufferProvider ?? (() => null);
         _startTime = startTime ?? DateTimeOffset.UtcNow;
+        _degradedModeProvider = degradedModeProvider;
     }
 
     /// <summary>
@@ -284,7 +287,8 @@ public sealed class StatusEndpointHandlers
                 QueueCapacity = pipeline.QueueCapacity,
                 QueueUtilization = (float)pipeline.QueueUtilization,
                 AverageProcessingTimeUs = (float)pipeline.AverageProcessingTimeUs
-            }
+            },
+            DegradedMode = _degradedModeProvider?.Invoke()
         };
     }
 

--- a/src/Meridian.Application/README.md
+++ b/src/Meridian.Application/README.md
@@ -417,9 +417,13 @@ and UI presentation concerns in their owning layers.
   in `Backfill/` alongside the rest of the backfill pipeline.
 - `Composition/` - application feature registration and service wiring.
   `StorageFeatureRegistration` keeps production-safe governance composition explicit: production
-  startup requires `MERIDIAN_FUND_ACCOUNTS_CONNECTION_STRING` and
-  `MERIDIAN_FUND_STRUCTURE_CONNECTION_STRING` so fund account and fund structure workflows use
-  persistence-backed services. Local/dev launcher flows may set
+  startup requires `MERIDIAN_DATABASE_URL` (or the per-domain
+  `MERIDIAN_FUND_ACCOUNTS_CONNECTION_STRING` and `MERIDIAN_FUND_STRUCTURE_CONNECTION_STRING`)
+  so fund account and fund structure workflows use persistence-backed services.
+  `MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl` (in `Meridian.Storage`) propagates
+  `MERIDIAN_DATABASE_URL` into every unset per-domain connection-string variable at composition
+  time; `PersistenceConfigurationStatus.Evaluate` reports the resulting NONE/PARTIAL/CONFIGURED
+  posture for status endpoints and readiness checks. Local/dev launcher flows may set
   `MERIDIAN_USE_INMEMORY_GOVERNANCE=true` only with a non-production environment. Placeholder
   projection-reconciliation jobs are also omitted from production composition until real domain
   reconcilers replace them; production startup does not report a no-op comparison as assurance.

--- a/src/Meridian.Contracts/Api/StatusModels.cs
+++ b/src/Meridian.Contracts/Api/StatusModels.cs
@@ -21,6 +21,36 @@ public sealed class StatusResponse
 
     [JsonPropertyName("pipeline")]
     public PipelineData? Pipeline { get; set; }
+
+    /// <summary>
+    /// Degraded-mode posture (simulated market data, missing persistence). Null when the host
+    /// does not evaluate degraded modes; consumers must not treat null as "everything is fine".
+    /// </summary>
+    [JsonPropertyName("degradedMode")]
+    public DegradedModeStatus? DegradedMode { get; set; }
+}
+
+/// <summary>
+/// Loud degraded-mode posture surfaced to operators: whether market data is simulated and
+/// whether the money-path stores actually persist anything.
+/// </summary>
+public sealed class DegradedModeStatus
+{
+    /// <summary>Market data fidelity: "live", "simulated", or "unknown".</summary>
+    [JsonPropertyName("marketDataMode")]
+    public string MarketDataMode { get; set; } = "unknown";
+
+    /// <summary>Human-readable detail for the market data mode (provider, reason).</summary>
+    [JsonPropertyName("marketDataDetail")]
+    public string? MarketDataDetail { get; set; }
+
+    /// <summary>Persistence posture: "none", "partial", or "configured".</summary>
+    [JsonPropertyName("persistenceMode")]
+    public string PersistenceMode { get; set; } = "none";
+
+    /// <summary>Store domains currently running without a database (in-memory or unregistered).</summary>
+    [JsonPropertyName("missingPersistenceDomains")]
+    public string[] MissingPersistenceDomains { get; set; } = Array.Empty<string>();
 }
 
 /// <summary>

--- a/src/Meridian.Core/Config/ConfigEnvironmentOverride.cs
+++ b/src/Meridian.Core/Config/ConfigEnvironmentOverride.cs
@@ -93,6 +93,12 @@ public sealed class ConfigEnvironmentOverride
                 result = ApplyOverride(result, configPath, value);
                 appliedOverrides.Add($"{envVar} -> {configPath}");
             }
+            catch (Meridian.Core.Exceptions.ConfigurationException)
+            {
+                // A recognized variable carrying an invalid value (e.g. a typo'd MDC_DATASOURCE)
+                // must fail startup instead of being quietly skipped.
+                throw;
+            }
             catch (Exception ex)
             {
                 _log.Warning(ex, "Failed to apply environment override {EnvVar} to {Path}", envVar, configPath);
@@ -378,9 +384,14 @@ public sealed class ConfigEnvironmentOverride
 
     private static DataSourceKind ParseDataSource(string value)
     {
-        return Enum.TryParse<DataSourceKind>(value, ignoreCase: true, out var result)
-            ? result
-            : DataSourceKind.IB;
+        if (Enum.TryParse<DataSourceKind>(value, ignoreCase: true, out var result))
+            return result;
+
+        throw new Meridian.Core.Exceptions.ConfigurationException(
+            $"Unknown data source '{value}' in MDC_DATASOURCE. " +
+            $"Valid values: {string.Join(", ", Enum.GetNames<DataSourceKind>())}.",
+            configPath: null,
+            fieldName: "DataSource");
     }
 
     private static bool IsSensitiveVariable(string envVar)

--- a/src/Meridian.Core/Config/ConfigJsonSchemaGenerator.cs
+++ b/src/Meridian.Core/Config/ConfigJsonSchemaGenerator.cs
@@ -139,6 +139,7 @@ public sealed class ConfigJsonSchemaGenerator
                     ["additionalProperties"] = false,
                     ["properties"] = new JsonObject
                     {
+                        ["AllowScaffoldMarketFills"] = CreateTypedSchema("boolean"),
                         ["ScaffoldMarketFillPrice"] = CreateTypedSchema("number")
                     }
                 },

--- a/src/Meridian.Core/Config/DataSourceKindConverter.cs
+++ b/src/Meridian.Core/Config/DataSourceKindConverter.cs
@@ -4,8 +4,9 @@ using System.Text.Json.Serialization;
 namespace Meridian.Core.Config;
 
 /// <summary>
-/// Parses <see cref="DataSourceKind"/> from config JSON strings in a forgiving way
-/// (case-insensitive, defaults to IB on unknown values).
+/// Parses <see cref="DataSourceKind"/> from config JSON strings (case-insensitive).
+/// Unknown values are a configuration error: coercing them to a default provider would
+/// silently route the operator to the wrong data source, so parsing fails closed instead.
 /// </summary>
 public sealed class DataSourceKindConverter : JsonConverter<DataSourceKind>
 {
@@ -16,14 +17,25 @@ public sealed class DataSourceKindConverter : JsonConverter<DataSourceKind>
             var value = reader.GetString();
             if (!string.IsNullOrWhiteSpace(value) && Enum.TryParse<DataSourceKind>(value, ignoreCase: true, out var parsed))
                 return parsed;
-        }
-        else if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out var num))
-        {
-            if (Enum.IsDefined(typeof(DataSourceKind), num))
-                return (DataSourceKind)num;
+
+            throw new JsonException(
+                $"Unknown DataSource '{value}'. Valid values: {string.Join(", ", Enum.GetNames<DataSourceKind>())}.");
         }
 
-        return DataSourceKind.IB;
+        if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out var num))
+        {
+            // DataSourceKind is byte-backed; range-check before casting so out-of-range
+            // numbers cannot wrap around onto a defined member.
+            if (num >= 0 && num <= byte.MaxValue && Enum.IsDefined((DataSourceKind)num))
+                return (DataSourceKind)num;
+
+            throw new JsonException(
+                $"Unknown DataSource value '{num}'. Valid values: {string.Join(", ", Enum.GetNames<DataSourceKind>())}.");
+        }
+
+        throw new JsonException(
+            $"DataSource must be a string or number, not {reader.TokenType}. " +
+            $"Valid values: {string.Join(", ", Enum.GetNames<DataSourceKind>())}.");
     }
 
     public override void Write(Utf8JsonWriter writer, DataSourceKind value, JsonSerializerOptions options)

--- a/src/Meridian.Execution/Adapters/PaperTradingGateway.cs
+++ b/src/Meridian.Execution/Adapters/PaperTradingGateway.cs
@@ -13,8 +13,10 @@ namespace Meridian.Execution.Adapters;
 
 /// <summary>
 /// Simulated order gateway that routes no real orders to any exchange.
-/// Fills are generated synthetically at a notional price (or at the limit price for
-/// limit orders), making this the safe default for strategy validation before live promotion.
+/// Fills are priced from the limit/stop price or the live feed's last observed price;
+/// market orders with no available reference price are rejected unless scaffold notional
+/// pricing is explicitly enabled via
+/// <see cref="PaperTradingGatewayOptions.AllowScaffoldMarketFills"/>.
 /// Implements ADR-015.
 /// </summary>
 [ImplementsAdr("ADR-015", "Simulated IOrderGateway over live Meridian feed — no real orders")]
@@ -23,7 +25,9 @@ public sealed class PaperTradingGateway : IOrderGateway
     // Notional fallback fill price used for market orders when no live feed price is
     // available, configurable via PaperTradingGatewayOptions. When a live feed adapter
     // is supplied, market fills are priced from the last trade (or quote midpoint).
+    // Scaffold pricing is opt-in: without it, priceless market orders are rejected.
     private readonly decimal _scaffoldMarketFillPrice;
+    private readonly bool _allowScaffoldMarketFills;
     private readonly Interfaces.ILiveFeedAdapter? _liveFeed;
     private int _scaffoldPriceWarningIssued;
 
@@ -98,6 +102,7 @@ public sealed class PaperTradingGateway : IOrderGateway
             securityMaster,
             LogLevel.Debug);
         _scaffoldMarketFillPrice = PaperTradingGatewayScaffoldPricing.ResolveScaffoldMarketFillPrice(options);
+        _allowScaffoldMarketFills = PaperTradingGatewayScaffoldPricing.ResolveAllowScaffoldMarketFills(options);
         _liveFeed = liveFeed;
         // Use EventPipelinePolicy for consistent backpressure settings across the platform (ADR-013).
         // Disposal waits for in-flight fills before completing this bounded update channel.
@@ -273,6 +278,33 @@ public sealed class PaperTradingGateway : IOrderGateway
 
         if (referencePrice is null)
         {
+            if (!_allowScaffoldMarketFills)
+            {
+                var rejectReason = PaperTradingGatewayScaffoldPricing.BuildNoReferencePriceRejectReason(request.Symbol);
+                _logger.LogWarning(
+                    "Paper order rejected: {ClientOrderId} {Symbol} — {RejectReason}",
+                    orderId, request.Symbol, rejectReason);
+
+                var rejection = new OrderStatusUpdate(
+                    OrderId: orderId,
+                    ClientOrderId: orderId,
+                    Symbol: request.Symbol,
+                    Status: GatewayOrderStatus.Rejected,
+                    FilledQuantity: 0,
+                    AverageFillPrice: null,
+                    RejectReason: rejectReason,
+                    Timestamp: DateTimeOffset.UtcNow);
+
+                if (!_updates.Writer.TryWrite(rejection))
+                {
+                    _logger.LogWarning(
+                        "Paper rejection update for {OrderId} could not be queued because the update channel was unavailable.",
+                        orderId);
+                }
+
+                return;
+            }
+
             WarnScaffoldPriceUsed();
         }
 

--- a/src/Meridian.Execution/Adapters/PaperTradingGatewayOptions.cs
+++ b/src/Meridian.Execution/Adapters/PaperTradingGatewayOptions.cs
@@ -10,10 +10,18 @@ public sealed class PaperTradingGatewayOptions
     public const string SectionKey = "PaperTrading:Gateway";
 
     /// <summary>
-    /// Notional fill price used for market-style orders when no live feed price is available.
-    /// A production implementation would source the last-traded price from ILiveFeedAdapter;
-    /// until then every fill priced from this value produces meaningless paper P&amp;L, and the
-    /// gateway logs a warning the first time it is used.
+    /// Whether market-style orders may fill at <see cref="ScaffoldMarketFillPrice"/> when no
+    /// live feed price is available. Off by default: a fabricated fill price produces
+    /// plausible-looking but meaningless paper P&amp;L, so the gateways fail closed and reject
+    /// priceless market orders unless this is explicitly enabled.
+    /// </summary>
+    public bool AllowScaffoldMarketFills { get; set; }
+
+    /// <summary>
+    /// Notional fill price used for market-style orders when no live feed price is available
+    /// and <see cref="AllowScaffoldMarketFills"/> is enabled. Every fill priced from this
+    /// value produces meaningless paper P&amp;L, and the gateway logs a warning the first
+    /// time it is used.
     /// </summary>
     public decimal ScaffoldMarketFillPrice { get; set; } = 1m;
 }

--- a/src/Meridian.Execution/Adapters/PaperTradingGatewaySupport.cs
+++ b/src/Meridian.Execution/Adapters/PaperTradingGatewaySupport.cs
@@ -132,6 +132,14 @@ internal static class PaperTradingGatewayScaffoldPricing
         return scaffoldPrice;
     }
 
+    public static bool ResolveAllowScaffoldMarketFills(PaperTradingGatewayOptions? options)
+        => (options ?? new PaperTradingGatewayOptions()).AllowScaffoldMarketFills;
+
+    public static string BuildNoReferencePriceRejectReason(string symbol)
+        => $"No live reference price is available for '{symbol}' and scaffold fill pricing is disabled. " +
+           "Wire a live feed price source, submit the order with an explicit price, or opt in via " +
+           $"'{PaperTradingGatewayOptions.SectionKey}:{nameof(PaperTradingGatewayOptions.AllowScaffoldMarketFills)}'.";
+
     public static void WarnIfFirstUse(
         ref int warningIssued,
         ILogger logger,

--- a/src/Meridian.Execution/PaperTradingGateway.cs
+++ b/src/Meridian.Execution/PaperTradingGateway.cs
@@ -8,9 +8,11 @@ namespace Meridian.Execution;
 
 /// <summary>
 /// Simulated execution gateway for paper trading. Market orders fill immediately at the
-/// caller-provided simulated price (<see cref="OrderRequest.LimitPrice"/>), the last observed
-/// live feed price when an <see cref="Interfaces.ILiveFeedAdapter"/> is wired, or, when neither is
-/// available, the configured scaffold notional price. Limit and stop orders are accepted and rest
+/// caller-provided simulated price (<see cref="OrderRequest.LimitPrice"/>) or the last observed
+/// live feed price when an <see cref="Interfaces.ILiveFeedAdapter"/> is wired. When neither is
+/// available the order is rejected, unless scaffold pricing is explicitly enabled via
+/// <see cref="Adapters.PaperTradingGatewayOptions.AllowScaffoldMarketFills"/>, in which case it
+/// fills at the configured scaffold notional price. Limit and stop orders are accepted and rest
 /// in memory but are never simulated to fill — this gateway performs no price-touch matching and
 /// exposes no execution-report stream. Cancel and modify act only on orders currently resting in
 /// this gateway; an unknown order id is rejected rather than acknowledged.
@@ -20,6 +22,7 @@ public sealed class PaperTradingGateway : IExecutionGateway, IExecutionGatewayMo
     private readonly ILogger<PaperTradingGateway> _logger;
     private readonly Adapters.PaperTradingGatewayTradingParameters _tradingParameters;
     private readonly decimal _scaffoldMarketFillPrice;
+    private readonly bool _allowScaffoldMarketFills;
     private readonly Interfaces.ILiveFeedAdapter? _liveFeed;
     // Ids of limit/stop orders accepted and resting in this gateway, so cancel/modify can
     // distinguish a real resting order from an unknown id instead of fabricating success.
@@ -40,6 +43,7 @@ public sealed class PaperTradingGateway : IExecutionGateway, IExecutionGatewayMo
             securityMaster,
             LogLevel.Warning);
         _scaffoldMarketFillPrice = Adapters.PaperTradingGatewayScaffoldPricing.ResolveScaffoldMarketFillPrice(options);
+        _allowScaffoldMarketFills = Adapters.PaperTradingGatewayScaffoldPricing.ResolveAllowScaffoldMarketFills(options);
         _liveFeed = liveFeed;
     }
 
@@ -89,11 +93,34 @@ public sealed class PaperTradingGateway : IExecutionGateway, IExecutionGatewayMo
         if (request.Type is OrderType.Market)
         {
             // Callers may set a simulated price via LimitPrice; otherwise the last observed
-            // live feed price applies, then the configured scaffold notional price
-            // (with a one-time warning).
+            // live feed price applies. Without either, the order is rejected unless scaffold
+            // pricing is explicitly enabled (with a one-time warning when it is).
             var simulatedPrice = request.LimitPrice ?? GetLiveReferencePrice(request.Symbol);
             if (simulatedPrice is null)
             {
+                if (!_allowScaffoldMarketFills)
+                {
+                    var rejectReason = Adapters.PaperTradingGatewayScaffoldPricing
+                        .BuildNoReferencePriceRejectReason(request.Symbol);
+                    _logger.LogWarning(
+                        "Paper order rejected: {Symbol} {Side} {Quantity} — {RejectReason}",
+                        request.Symbol, request.Side, request.Quantity, rejectReason);
+
+                    return new ExecutionReport
+                    {
+                        OrderId = request.ClientOrderId ?? $"PAPER-{fillSeq}",
+                        ReportType = ExecutionReportType.Rejected,
+                        Symbol = request.Symbol,
+                        Side = request.Side,
+                        OrderStatus = OrderStatus.Rejected,
+                        OrderQuantity = request.Quantity,
+                        FilledQuantity = 0,
+                        RejectReason = rejectReason,
+                        Timestamp = DateTimeOffset.UtcNow,
+                        GatewayOrderId = $"PAPER-{fillSeq}"
+                    };
+                }
+
                 WarnScaffoldPriceUsed();
             }
 

--- a/src/Meridian.Infrastructure/Adapters/Core/Backfill/BackfillWorkerService.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/Backfill/BackfillWorkerService.cs
@@ -282,6 +282,21 @@ public sealed class BackfillWorkerService : IDisposable
                     var bars = await FetchBarsAsync(request, ct).ConfigureAwait(false);
                     MarketDataTracing.RecordEventCount(fetchActivity, bars.Count);
 
+                    bars = BackfillBarValidation.RemoveFutureDatedBars(bars, out var futureDropped);
+                    if (futureDropped > 0)
+                    {
+                        scopedLog.Warning(
+                            "Dropped {FutureDropped} future-dated bars for {Symbol} from {Provider}",
+                            futureDropped, request.Symbol, providerName);
+                    }
+
+                    if (BackfillBarValidation.EvaluateDailyRecency(bars, request.ToDate) is { } staleVerdict)
+                    {
+                        scopedLog.Warning(
+                            "Stale backfill persisted for {Symbol} via {Provider}: {StaleReason}. The provider's dataset may be frozen or paywalled.",
+                            request.Symbol, providerName, staleVerdict.Description);
+                    }
+
                     if (bars.Count > 0)
                     {
                         // Write to storage

--- a/src/Meridian.Infrastructure/Adapters/Core/BackfillBarValidation.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/BackfillBarValidation.cs
@@ -1,0 +1,110 @@
+using Meridian.Contracts.Domain.Models;
+
+namespace Meridian.Infrastructure.Adapters.Core;
+
+/// <summary>
+/// Verdict describing a backfill result whose newest bar is materially older than the end of
+/// the requested range — e.g. a provider whose dataset is frozen (Nasdaq WIKI stopped in
+/// March 2018) returning years-old prices for a request that expects data through today.
+/// </summary>
+/// <param name="LatestSessionDate">Session date of the newest bar in the result.</param>
+/// <param name="ExpectedThrough">The date the request expected data to reach (requested end, capped at today).</param>
+/// <param name="StaleDays">Calendar days between <paramref name="LatestSessionDate"/> and <paramref name="ExpectedThrough"/>.</param>
+/// <param name="Description">Human-readable description for logs and validation signals.</param>
+public sealed record StaleBarsVerdict(
+    DateOnly LatestSessionDate,
+    DateOnly ExpectedThrough,
+    int StaleDays,
+    string Description);
+
+/// <summary>
+/// Recency and sanity validation for backfilled bars. OHLC invariants are already enforced by
+/// the <see cref="HistoricalBar"/> constructor; this adds the request-relative checks the
+/// constructor cannot express: results whose newest bar falls far short of the requested range
+/// end (stale/frozen datasets) and bars dated in the future.
+/// </summary>
+public static class BackfillBarValidation
+{
+    /// <summary>
+    /// Calendar-day gap tolerated between the requested range end and the newest returned bar
+    /// before a result is considered stale. Wide enough to absorb weekends, market holidays,
+    /// and provider publish lag; narrow enough to catch datasets frozen months or years ago.
+    /// </summary>
+    public const int DefaultStaleToleranceDays = 10;
+
+    /// <summary>
+    /// Evaluates whether a non-empty daily-bar result is stale relative to the requested range.
+    /// Historical-era requests (an explicit <paramref name="requestedTo"/> in the past) are
+    /// compared against that end date, so backfilling old ranges never trips this check.
+    /// </summary>
+    /// <returns>A verdict when the result is stale; <c>null</c> when it is acceptable.</returns>
+    public static StaleBarsVerdict? EvaluateDailyRecency(
+        IReadOnlyList<HistoricalBar> bars,
+        DateOnly? requestedTo,
+        DateOnly? today = null,
+        int staleToleranceDays = DefaultStaleToleranceDays)
+    {
+        if (bars.Count == 0)
+            return null;
+
+        var utcToday = today ?? DateOnly.FromDateTime(DateTime.UtcNow);
+        var expectedThrough = requestedTo is { } to && to < utcToday ? to : utcToday;
+
+        var latest = bars[0].SessionDate;
+        foreach (var bar in bars)
+        {
+            if (bar.SessionDate > latest)
+                latest = bar.SessionDate;
+        }
+
+        var staleDays = expectedThrough.DayNumber - latest.DayNumber;
+        if (staleDays <= staleToleranceDays)
+            return null;
+
+        return new StaleBarsVerdict(
+            latest,
+            expectedThrough,
+            staleDays,
+            $"newest bar {latest:yyyy-MM-dd} is {staleDays} calendar days short of the requested range end {expectedThrough:yyyy-MM-dd}");
+    }
+
+    /// <summary>
+    /// Removes bars dated after today (one day of tolerance for exchange-local time zones ahead
+    /// of UTC). A future session date is provider garbage that would otherwise be persisted as
+    /// legitimate history.
+    /// </summary>
+    public static IReadOnlyList<HistoricalBar> RemoveFutureDatedBars(
+        IReadOnlyList<HistoricalBar> bars,
+        out int removedCount,
+        DateOnly? today = null)
+    {
+        removedCount = 0;
+        if (bars.Count == 0)
+            return bars;
+
+        var latestAllowed = (today ?? DateOnly.FromDateTime(DateTime.UtcNow)).AddDays(1);
+        var hasFuture = false;
+        foreach (var bar in bars)
+        {
+            if (bar.SessionDate > latestAllowed)
+            {
+                hasFuture = true;
+                break;
+            }
+        }
+
+        if (!hasFuture)
+            return bars;
+
+        var filtered = new List<HistoricalBar>(bars.Count);
+        foreach (var bar in bars)
+        {
+            if (bar.SessionDate > latestAllowed)
+                removedCount++;
+            else
+                filtered.Add(bar);
+        }
+
+        return filtered;
+    }
+}

--- a/src/Meridian.Infrastructure/Adapters/Core/CompositeHistoricalDataProvider.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/CompositeHistoricalDataProvider.cs
@@ -175,7 +175,8 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
             allFailedMessageFactory: summary => $"All providers failed for {symbol}: {summary}",
             rangeStart: from,
             rangeEnd: to,
-            ct).ConfigureAwait(false);
+            recencyEvaluator: bars => BackfillBarValidation.EvaluateDailyRecency(bars, to),
+            ct: ct).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<AggregateBar>> GetAggregateBarsAsync(
@@ -206,16 +207,21 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
                 $"All aggregate-capable providers failed for {symbol} ({granularity.ToDisplayName()}): {summary}",
             rangeStart: from,
             rangeEnd: to,
-            ct).ConfigureAwait(false);
+            recencyEvaluator: null,
+            ct: ct).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Shared failover skeleton for the daily-bar and aggregate-bar paths: iterate the ordered
     /// candidate providers, skipping backed-off and rate-limited ones, and return the first
-    /// non-empty result. If every candidate is rate limited it waits (bounded by
-    /// <see cref="_maxRateLimitRetryBudget"/>, with jitter) for the earliest reset and retries.
-    /// When all providers fail it raises the exhausted progress event and throws an
-    /// <see cref="AggregateException"/>; when they simply return no data it returns an empty list.
+    /// non-empty result that passes the optional recency evaluation. A stale result (e.g. a
+    /// frozen dataset ending years before the requested range end) is held as a last-resort
+    /// fallback while fresher providers are tried; if only stale data exists it is returned
+    /// with an error-level log so consumers cannot mistake it for fresh coverage. If every
+    /// candidate is rate limited it waits (bounded by <see cref="_maxRateLimitRetryBudget"/>,
+    /// with jitter) for the earliest reset and retries. When all providers fail it raises the
+    /// exhausted progress event and throws an <see cref="AggregateException"/>; when they
+    /// simply return no data it returns an empty list.
     /// </summary>
     private async Task<IReadOnlyList<TResult>> ExecuteWithFailoverAsync<TResult>(
         string symbol,
@@ -226,11 +232,15 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
         Func<string, string> allFailedMessageFactory,
         DateOnly? rangeStart,
         DateOnly? rangeEnd,
+        Func<IReadOnlyList<TResult>, StaleBarsVerdict?>? recencyEvaluator,
         CancellationToken ct)
     {
         var requestStartedAt = DateTimeOffset.UtcNow;
         var retryDeadline = requestStartedAt + _maxRateLimitRetryBudget;
         var providerAttempt = 0;
+        IReadOnlyList<TResult>? freshestStaleResult = null;
+        StaleBarsVerdict? freshestStaleVerdict = null;
+        string? freshestStaleProvider = null;
 
         for (var attempt = 0; ; attempt++)
         {
@@ -298,6 +308,25 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
                         _health.ClearFailure(provider.Name);
                         _rotation.ClearRateLimitState(provider.Name);
 
+                        var staleVerdict = recencyEvaluator?.Invoke(results);
+                        if (staleVerdict is not null)
+                        {
+                            _log.Warning(
+                                "Provider {Provider} returned stale {Operation} for {Symbol}: {StaleReason}. Trying fresher providers before accepting.",
+                                provider.Name, operationLabel, symbol, staleVerdict.Description);
+                            Report(provider.Name, "stale-data", results.Count, error: staleVerdict.Description);
+
+                            if (freshestStaleVerdict is null ||
+                                staleVerdict.LatestSessionDate > freshestStaleVerdict.LatestSessionDate)
+                            {
+                                freshestStaleResult = results;
+                                freshestStaleVerdict = staleVerdict;
+                                freshestStaleProvider = provider.Name;
+                            }
+
+                            continue;
+                        }
+
                         _log.Information("Successfully retrieved {Count} {Operation} from {Provider} for {Symbol}",
                             results.Count, operationLabel, provider.Name, symbol);
                         Report(provider.Name, "completed", results.Count);
@@ -356,6 +385,18 @@ public sealed class CompositeHistoricalDataProvider : IHistoricalDataProvider, I
                     await Task.Delay(wait.Value, ct).ConfigureAwait(false);
                     continue;
                 }
+            }
+
+            // No provider produced a fresh result. If a stale result was held back, return it
+            // loudly rather than failing outright — old data with an error-level signal beats
+            // no data — but never let it masquerade as fresh coverage.
+            if (freshestStaleResult is not null)
+            {
+                _log.Error(
+                    "All providers returned stale {Operation} for {Symbol}; accepting freshest stale result from {Provider} ({StaleReason})",
+                    operationLabel, symbol, freshestStaleProvider, freshestStaleVerdict!.Description);
+                Report(freshestStaleProvider!, "stale-data-accepted", freshestStaleResult.Count, error: freshestStaleVerdict.Description);
+                return freshestStaleResult;
             }
 
             // All providers failed

--- a/src/Meridian.Infrastructure/Adapters/Core/ProviderRegistry.cs
+++ b/src/Meridian.Infrastructure/Adapters/Core/ProviderRegistry.cs
@@ -136,11 +136,12 @@ public sealed class ProviderRegistry : IDisposable, IAsyncDisposable
 
     /// <summary>
     /// Creates a streaming client for the specified provider ID using the registered factory.
-    /// Falls back to the <c>"ib"</c> factory if the requested ID has no registered factory.
+    /// Unknown provider IDs fail closed: silently substituting a default provider would route
+    /// the operator to a data source they did not configure, so no fallback exists.
     /// </summary>
     /// <param name="providerId">The provider ID to create a client for (case-insensitive).</param>
     /// <returns>A new streaming client instance.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when no factory is registered for the ID and no IB fallback is available.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when no factory is registered for the ID.</exception>
     public IMarketDataClient CreateStreamingClient(string providerId)
     {
         var key = ProviderIdentity.NormalizeId(providerId);
@@ -151,16 +152,17 @@ public sealed class ProviderRegistry : IDisposable, IAsyncDisposable
             return factory();
         }
 
-        // Fallback to "ib" (default provider)
-        if (key != "ib" && _streamingFactories.TryGetValue("ib", out var ibFactory))
-        {
-            _log.Warning("No factory registered for {DataSource}, falling back to IB", key);
-            return ibFactory();
-        }
-
+        var registered = SupportedStreamingSources;
+        _log.Error(
+            "No streaming factory registered for {DataSource}. Registered providers: {RegisteredProviders}",
+            key,
+            registered);
         throw new InvalidOperationException(
-            $"No streaming factory registered for '{key}' and no IB fallback available. " +
-            "Register factories via RegisterStreamingFactory() during startup.");
+            $"No streaming factory registered for '{key}'. " +
+            (registered.Count > 0
+                ? $"Registered providers: {string.Join(", ", registered)}. "
+                : "No streaming factories are registered. ") +
+            "Check the configured DataSource for typos, or register the provider via RegisterStreamingFactory() during startup.");
     }
 
     /// <summary>

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBMarketDataClient.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBMarketDataClient.cs
@@ -61,6 +61,10 @@ public sealed class IBMarketDataClient :
 #else
         _inner = new IBSimulationClient(publisher);
         _isSimulation = true;
+        Log.ForContext<IBMarketDataClient>().Warning(
+            "Interactive Brokers market data is running in SIMULATION mode: prices are a synthetic random walk, " +
+            "historical requests return no bars, and no order reaches a broker. Build with the IBAPI compile flag " +
+            "and connect TWS/Gateway for real market data.");
 #endif
         _inner.ConnectionDiagnosticsChanged += OnInnerConnectionDiagnosticsChanged;
     }
@@ -69,6 +73,20 @@ public sealed class IBMarketDataClient :
     /// True when running without the IBAPI reference (simulation mode).
     /// </summary>
     public bool IsSimulation => _isSimulation;
+
+    /// <inheritdoc/>
+    public bool IsSimulated => _isSimulation;
+
+    /// <summary>
+    /// True when this build carries no IBAPI reference, so every IB client it creates is a
+    /// random-walk simulator. Lets hosts report simulation mode without constructing a client.
+    /// </summary>
+    public static bool IsSimulationBuild =>
+#if IBAPI
+        false;
+#else
+        true;
+#endif
 
     public bool IsEnabled => _inner.IsEnabled;
 

--- a/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBSimulationClient.cs
+++ b/src/Meridian.Infrastructure/Adapters/InteractiveBrokers/IBSimulationClient.cs
@@ -79,6 +79,9 @@ public sealed class IBSimulationClient : IMarketDataClient
     public bool IsEnabled => true;
     public bool IsSimulation => true;
 
+    /// <inheritdoc/>
+    public bool IsSimulated => true;
+
 
     public string ProviderId => "ib-sim";
     public string ProviderDisplayName => "Interactive Brokers (Simulation)";

--- a/src/Meridian.Infrastructure/Adapters/Synthetic/SyntheticMarketDataClient.cs
+++ b/src/Meridian.Infrastructure/Adapters/Synthetic/SyntheticMarketDataClient.cs
@@ -41,6 +41,10 @@ public sealed class SyntheticMarketDataClient : IMarketDataClient, ISymbolSearch
     }
 
     public bool IsEnabled => _config.Enabled;
+
+    /// <inheritdoc/>
+    public bool IsSimulated => true;
+
     public string ProviderId => "synthetic";
     public string ProviderDisplayName => "Synthetic Market Data";
     public string ProviderDescription => "Synthetic trades, BBO quotes, level-2 order books, and reference data for offline development.";

--- a/src/Meridian.ProviderSdk/IMarketDataClient.cs
+++ b/src/Meridian.ProviderSdk/IMarketDataClient.cs
@@ -28,6 +28,13 @@ public interface IMarketDataClient :
 {
     bool IsEnabled { get; }
 
+    /// <summary>
+    /// True when this client fabricates synthetic data instead of delivering real market data.
+    /// Hosts surface this loudly (status endpoints, workstation banner) so simulated prices are
+    /// never mistaken for live ones.
+    /// </summary>
+    bool IsSimulated => false;
+
     Task ConnectAsync(CancellationToken ct = default);
     Task DisconnectAsync(CancellationToken ct = default);
 

--- a/src/Meridian.Storage/MeridianDatabaseEnvironment.cs
+++ b/src/Meridian.Storage/MeridianDatabaseEnvironment.cs
@@ -1,0 +1,123 @@
+using System.Text;
+using Serilog;
+
+namespace Meridian.Storage;
+
+/// <summary>
+/// Unified database configuration for every money-path store. Setting the single
+/// <c>MERIDIAN_DATABASE_URL</c> environment variable enables PostgreSQL persistence for all
+/// domains at once; each per-domain <c>MERIDIAN_*_CONNECTION_STRING</c> variable remains
+/// supported and always wins over the unified value, so split-database deployments keep working.
+/// </summary>
+/// <remarks>
+/// Propagation works by populating the per-domain variables that are unset, which keeps every
+/// existing read site (composition roots, readiness probes, migration runners, tooling) working
+/// without changes as long as <see cref="ApplyUnifiedDatabaseUrl"/> runs before those sites read
+/// the environment. Direct Lending and Reporting are not propagated directly: they already
+/// inherit from Security Master and Ledger respectively, and populating their dedicated
+/// variables would change how their schema/migration inheritance resolves.
+/// </remarks>
+public static class MeridianDatabaseEnvironment
+{
+    public const string UnifiedVariable = "MERIDIAN_DATABASE_URL";
+
+    /// <summary>
+    /// Per-domain connection-string variables that inherit <see cref="UnifiedVariable"/> when unset.
+    /// </summary>
+    public static readonly IReadOnlyList<string> PropagatedConnectionStringVariables =
+    [
+        "MERIDIAN_LEDGER_CONNECTION_STRING",
+        "MERIDIAN_SECURITY_MASTER_CONNECTION_STRING",
+        "MERIDIAN_FUND_ACCOUNTS_CONNECTION_STRING",
+        "MERIDIAN_FUND_STRUCTURE_CONNECTION_STRING",
+        "MERIDIAN_ASSET_OPERATIONS_CONNECTION_STRING",
+        "MERIDIAN_BANKING_CONNECTION_STRING",
+        "MERIDIAN_MONEY_MARKET_CONNECTION_STRING",
+        "MERIDIAN_SCOPED_ACCESS_CONNECTION_STRING"
+    ];
+
+    private static readonly Lock SyncRoot = new();
+
+    /// <summary>
+    /// Propagates <c>MERIDIAN_DATABASE_URL</c> into every unset per-domain connection-string
+    /// variable. Idempotent and safe to call from every composition root; explicitly set
+    /// per-domain variables are never overwritten. Returns the variables populated by this call.
+    /// </summary>
+    public static IReadOnlyList<string> ApplyUnifiedDatabaseUrl()
+    {
+        var raw = Environment.GetEnvironmentVariable(UnifiedVariable);
+        if (string.IsNullOrWhiteSpace(raw))
+            return Array.Empty<string>();
+
+        lock (SyncRoot)
+        {
+            var connectionString = NormalizeToConnectionString(raw.Trim());
+            var inherited = new List<string>();
+            foreach (var variable in PropagatedConnectionStringVariables)
+            {
+                if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(variable)))
+                {
+                    Environment.SetEnvironmentVariable(variable, connectionString);
+                    inherited.Add(variable);
+                }
+            }
+
+            if (inherited.Count > 0)
+            {
+                Log.Information(
+                    "{UnifiedVariable} is set; {Count} store domains inherit it: {Variables}",
+                    UnifiedVariable, inherited.Count, inherited);
+            }
+
+            return inherited;
+        }
+    }
+
+    /// <summary>
+    /// Converts a <c>postgres://</c> / <c>postgresql://</c> URL into Npgsql keyword form
+    /// (<c>Host=...;Port=...;Database=...</c>). Values already in keyword form pass through
+    /// unchanged. Query parameters are forwarded as keywords; <c>sslmode</c> maps to
+    /// <c>SSL Mode</c>.
+    /// </summary>
+    public static string NormalizeToConnectionString(string value)
+    {
+        if (!value.StartsWith("postgres://", StringComparison.OrdinalIgnoreCase) &&
+            !value.StartsWith("postgresql://", StringComparison.OrdinalIgnoreCase))
+        {
+            return value;
+        }
+
+        var uri = new Uri(value);
+        var builder = new StringBuilder();
+        builder.Append("Host=").Append(uri.Host);
+        builder.Append(";Port=").Append(uri.IsDefaultPort || uri.Port <= 0 ? 5432 : uri.Port);
+
+        var database = uri.AbsolutePath.Trim('/');
+        if (database.Length > 0)
+            builder.Append(";Database=").Append(Uri.UnescapeDataString(database));
+
+        if (uri.UserInfo.Length > 0)
+        {
+            var separatorIndex = uri.UserInfo.IndexOf(':');
+            var username = separatorIndex >= 0 ? uri.UserInfo[..separatorIndex] : uri.UserInfo;
+            builder.Append(";Username=").Append(Uri.UnescapeDataString(username));
+            if (separatorIndex >= 0)
+                builder.Append(";Password=").Append(Uri.UnescapeDataString(uri.UserInfo[(separatorIndex + 1)..]));
+        }
+
+        foreach (var pair in uri.Query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eq = pair.IndexOf('=');
+            if (eq <= 0)
+                continue;
+
+            var key = Uri.UnescapeDataString(pair[..eq]);
+            var parameterValue = Uri.UnescapeDataString(pair[(eq + 1)..]);
+            if (key.Equals("sslmode", StringComparison.OrdinalIgnoreCase))
+                key = "SSL Mode";
+            builder.Append(';').Append(key).Append('=').Append(parameterValue);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/Meridian.Ui.Shared/Endpoints/ProviderEndpoints.cs
+++ b/src/Meridian.Ui.Shared/Endpoints/ProviderEndpoints.cs
@@ -83,6 +83,14 @@ public static class ProviderEndpoints
             if (string.IsNullOrWhiteSpace(req.Name))
                 return Results.BadRequest("Name is required.");
 
+            // Fail closed on unknown provider names: silently coercing a typo to IB would
+            // persist a data source pointed at a provider the operator never chose.
+            if (!Enum.TryParse<DataSourceKind>(req.Provider, ignoreCase: true, out var provider))
+            {
+                return Results.BadRequest(
+                    $"Unknown provider '{req.Provider}'. Valid values: {string.Join(", ", Enum.GetNames<DataSourceKind>())}.");
+            }
+
             var cfg = store.Load();
             var dataSources = cfg.DataSources ?? new DataSourcesConfig();
             var sources = (dataSources.Sources ?? Array.Empty<DataSourceConfig>()).ToList();
@@ -91,7 +99,7 @@ public static class ProviderEndpoints
             var source = new DataSourceConfig(
                 Id: id,
                 Name: req.Name,
-                Provider: Enum.TryParse<DataSourceKind>(req.Provider, ignoreCase: true, out var p) ? p : DataSourceKind.IB,
+                Provider: provider,
                 Enabled: req.Enabled,
                 Type: Enum.TryParse<Meridian.Core.Config.DataSourceType>(req.Type, ignoreCase: true, out var t)
                     ? t
@@ -652,6 +660,14 @@ public static class ProviderEndpoints
             if (string.IsNullOrWhiteSpace(req.Name))
                 return Results.BadRequest("Name is required.");
 
+            // Fail closed on unknown provider names: silently coercing a typo to IB would
+            // persist a data source pointed at a provider the operator never chose.
+            if (!Enum.TryParse<DataSourceKind>(req.Provider, ignoreCase: true, out var provider))
+            {
+                return Results.BadRequest(
+                    $"Unknown provider '{req.Provider}'. Valid values: {string.Join(", ", Enum.GetNames<DataSourceKind>())}.");
+            }
+
             var cfg = store.Load();
             var dataSources = cfg.DataSources ?? new DataSourcesConfig();
             var sources = (dataSources.Sources ?? Array.Empty<DataSourceConfig>()).ToList();
@@ -660,7 +676,7 @@ public static class ProviderEndpoints
             var source = new DataSourceConfig(
                 Id: id,
                 Name: req.Name,
-                Provider: Enum.TryParse<DataSourceKind>(req.Provider, ignoreCase: true, out var p) ? p : DataSourceKind.IB,
+                Provider: provider,
                 Enabled: req.Enabled,
                 Type: Enum.TryParse<Meridian.Core.Config.DataSourceType>(req.Type, ignoreCase: true, out var t)
                     ? t

--- a/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
+++ b/src/Meridian.Ui.Shared/Services/WorkstationServiceCollectionExtensions.cs
@@ -74,6 +74,10 @@ public static class WorkstationServiceCollectionExtensions
 {
     public static IServiceCollection AddWorkstationSharedServices(this IServiceCollection services)
     {
+        // Unified persistence config must resolve before the reporting/scoped-access
+        // registrations below read the per-domain connection-string variables.
+        Meridian.Storage.MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl();
+
         var isProductionComposition = ProductionServiceRegistrationPolicy.IsProductionComposition(services);
 
         services.TryAddSingleton<ConfigStore>(sp =>

--- a/src/Meridian.Ui/dashboard/src/app.tsx
+++ b/src/Meridian.Ui/dashboard/src/app.tsx
@@ -68,6 +68,7 @@ import { CopyLinkButton } from "@/components/meridian/copy-link-button";
 import { SaveViewButton } from "@/components/meridian/save-view-dialog";
 import { NotificationCenter } from "@/components/meridian/notification-center";
 import { ActivityCenter } from "@/components/meridian/activity-center";
+import { DegradedModeBanner } from "@/components/meridian/degraded-mode-banner";
 import { DesignSystemMasthead } from "@/design-system/primitives";
 import {
   WorkstationStatusBar,
@@ -505,6 +506,8 @@ function AppShell({ firstRunStatus }: { firstRunStatus?: FirstRunStatus | null }
           </>
         )}
       />
+
+      <DegradedModeBanner degradedMode={overview?.degradedMode} />
 
       <div className="workstation-shell">
         <WorkspaceNav

--- a/src/Meridian.Ui/dashboard/src/components/meridian/degraded-mode-banner.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/degraded-mode-banner.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DegradedModeBanner } from "@/components/meridian/degraded-mode-banner";
+import type { DegradedModeStatus } from "@/types";
+
+function status(overrides: Partial<DegradedModeStatus> = {}): DegradedModeStatus {
+  return {
+    marketDataMode: "live",
+    marketDataDetail: null,
+    persistenceMode: "configured",
+    missingPersistenceDomains: [],
+    ...overrides
+  };
+}
+
+describe("DegradedModeBanner", () => {
+  it("renders nothing when the payload is absent", () => {
+    const { container } = render(<DegradedModeBanner degradedMode={null} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when market data is live and persistence is configured", () => {
+    const { container } = render(<DegradedModeBanner degradedMode={status()} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows a red alert when market data is simulated", () => {
+    render(
+      <DegradedModeBanner
+        degradedMode={status({
+          marketDataMode: "simulated",
+          marketDataDetail: "Streaming source 'ib' runs as a random-walk simulator in this build."
+        })}
+      />
+    );
+
+    const alert = screen.getByTestId("degraded-mode-simulated-market-data");
+    expect(alert).toHaveAttribute("role", "alert");
+    expect(alert).toHaveTextContent("SIMULATED MARKET DATA");
+    expect(alert).toHaveTextContent("random-walk simulator");
+  });
+
+  it("shows a persistence alert listing the domains without a database", () => {
+    render(
+      <DegradedModeBanner
+        degradedMode={status({
+          persistenceMode: "none",
+          missingPersistenceDomains: ["ledger", "banking", "fund-accounts"]
+        })}
+      />
+    );
+
+    const alert = screen.getByTestId("degraded-mode-persistence");
+    expect(alert).toHaveTextContent("PERSISTENCE: NONE");
+    expect(alert).toHaveTextContent("ledger, banking, fund-accounts");
+    expect(alert).toHaveTextContent("MERIDIAN_DATABASE_URL");
+  });
+
+  it("shows both alerts when simulated data and partial persistence overlap", () => {
+    render(
+      <DegradedModeBanner
+        degradedMode={status({
+          marketDataMode: "simulated",
+          persistenceMode: "partial",
+          missingPersistenceDomains: ["banking"]
+        })}
+      />
+    );
+
+    expect(screen.getByTestId("degraded-mode-simulated-market-data")).toBeInTheDocument();
+    expect(screen.getByTestId("degraded-mode-persistence")).toHaveTextContent("PERSISTENCE: PARTIAL");
+  });
+});

--- a/src/Meridian.Ui/dashboard/src/components/meridian/degraded-mode-banner.tsx
+++ b/src/Meridian.Ui/dashboard/src/components/meridian/degraded-mode-banner.tsx
@@ -1,0 +1,61 @@
+import { StatusBanner } from "@/components/ui/status-banner";
+import type { DegradedModeStatus } from "@/types";
+
+export interface DegradedModeBannerProps {
+  degradedMode: DegradedModeStatus | null | undefined;
+}
+
+/**
+ * Persistent red banner for degraded host postures: simulated market data and/or money-path
+ * stores running without persistence. Driven by the backend /api/status payload, never by
+ * client-side fixture state, so it reflects what the host is actually doing.
+ */
+export function DegradedModeBanner({ degradedMode }: DegradedModeBannerProps) {
+  if (!degradedMode) {
+    return null;
+  }
+
+  const notices: { key: string; title: string; detail: string }[] = [];
+
+  if (degradedMode.marketDataMode === "simulated") {
+    notices.push({
+      key: "simulated-market-data",
+      title: "SIMULATED MARKET DATA",
+      detail: degradedMode.marketDataDetail
+        ?? "The configured streaming source generates synthetic prices. Do not treat quotes, fills, or P&L as real."
+    });
+  }
+
+  if (degradedMode.persistenceMode !== "configured") {
+    const missing = degradedMode.missingPersistenceDomains;
+    notices.push({
+      key: "persistence",
+      title: `PERSISTENCE: ${degradedMode.persistenceMode.toUpperCase()}`,
+      detail: missing.length > 0
+        ? `Store domains without a database (data is lost on restart): ${missing.join(", ")}. `
+          + "Set MERIDIAN_DATABASE_URL to enable persistence."
+        : "No store domain has a database configured. Set MERIDIAN_DATABASE_URL to enable persistence."
+    });
+  }
+
+  if (notices.length === 0) {
+    return null;
+  }
+
+  return (
+    <section aria-label="Degraded mode warnings" className="border-b border-border bg-surface px-4 py-2">
+      <div className="flex flex-col gap-2">
+        {notices.map(notice => (
+          <StatusBanner
+            key={notice.key}
+            tone="danger"
+            role="alert"
+            title={notice.title}
+            detail={notice.detail}
+            data-testid={`degraded-mode-${notice.key}`}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/Meridian.Ui/dashboard/src/lib/api.ts
+++ b/src/Meridian.Ui/dashboard/src/lib/api.ts
@@ -207,6 +207,7 @@ import type {
   SecurityMasterEntry,
   SecurityMasterTrustSnapshot,
   SessionInfo,
+  DegradedModeStatus,
   SystemEventRecord,
   SystemOverviewResponse,
   ReplayFileRecord,
@@ -3559,11 +3560,29 @@ function normalizeSystemOverviewResponse(payload: unknown): SystemOverviewRespon
       storageHealth: readStorageHealth(payload.storageHealth),
       lastHeartbeatUtc: heartbeat,
       metrics: Array.isArray(payload.metrics) ? payload.metrics as MetricSnapshot[] : [],
-      recentEvents: Array.isArray(payload.recentEvents) ? payload.recentEvents as SystemEventRecord[] : []
+      recentEvents: Array.isArray(payload.recentEvents) ? payload.recentEvents as SystemEventRecord[] : [],
+      degradedMode: readDegradedMode(payload.degradedMode)
     };
   }
 
   return normalizeLegacyStatusResponse(payload);
+}
+
+function readDegradedMode(value: unknown): DegradedModeStatus | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const marketDataMode = readString(value.marketDataMode);
+  const persistenceMode = readString(value.persistenceMode);
+  return {
+    marketDataMode: marketDataMode === "live" || marketDataMode === "simulated" ? marketDataMode : "unknown",
+    marketDataDetail: readString(value.marketDataDetail),
+    persistenceMode: persistenceMode === "configured" || persistenceMode === "partial" ? persistenceMode : "none",
+    missingPersistenceDomains: Array.isArray(value.missingPersistenceDomains)
+      ? value.missingPersistenceDomains.filter((domain): domain is string => typeof domain === "string")
+      : []
+  };
 }
 
 function normalizeLegacyStatusResponse(payload: Record<string, unknown>): SystemOverviewResponse {
@@ -3633,7 +3652,8 @@ function normalizeLegacyStatusResponse(payload: Record<string, unknown>): System
         source: "Meridian host",
         timestamp: timestampUtc
       }
-    ]
+    ],
+    degradedMode: readDegradedMode(payload.degradedMode)
   };
 }
 

--- a/src/Meridian.Ui/dashboard/src/types/workstation-7.ts
+++ b/src/Meridian.Ui/dashboard/src/types/workstation-7.ts
@@ -1243,6 +1243,17 @@ export interface SystemEventRecord {
   timestamp: string;
 }
 
+/**
+ * Backend-reported degraded-mode posture: simulated market data and/or missing persistence.
+ * Rendered as a persistent workstation banner so fabricated data is never mistaken for real.
+ */
+export interface DegradedModeStatus {
+  marketDataMode: "live" | "simulated" | "unknown";
+  marketDataDetail?: string | null;
+  persistenceMode: "none" | "partial" | "configured";
+  missingPersistenceDomains: string[];
+}
+
 export interface SystemOverviewResponse {
   systemStatus: "Healthy" | "Degraded" | "Offline";
   providersOnline: number;
@@ -1255,6 +1266,7 @@ export interface SystemOverviewResponse {
   lastHeartbeatUtc: string;
   metrics: MetricSnapshot[];
   recentEvents: SystemEventRecord[];
+  degradedMode?: DegradedModeStatus | null;
 }
 
 // --- Quality monitoring types ---

--- a/src/Meridian.Wpf/App.xaml.cs
+++ b/src/Meridian.Wpf/App.xaml.cs
@@ -323,6 +323,10 @@ public partial class App : System.Windows.Application
     /// </summary>
     private static void ConfigureServices(IServiceCollection services, Microsoft.Extensions.Configuration.IConfiguration configuration)
     {
+        // Unified persistence config must resolve before feature modules read the
+        // per-domain connection-string variables.
+        Meridian.Storage.MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl();
+
         AddHostEnvironmentFallback(services);
 
         // Register shared desktop HttpClient configurations

--- a/src/Meridian/UiServer.cs
+++ b/src/Meridian/UiServer.cs
@@ -87,6 +87,21 @@ public sealed class UiServer : IAsyncDisposable
         _lifecycle = lifecycle ?? ApplicationLifecycleCoordinator.Create(Serilog.Log.Logger);
         _ownsLifecycle = lifecycle is null;
 
+        // Unified persistence config must resolve before service composition and the
+        // ledger/readiness gates below read the per-domain connection-string variables.
+        Meridian.Storage.MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl();
+
+        var persistenceStatus = PersistenceConfigurationStatus.Evaluate();
+        if (persistenceStatus.Mode != PersistenceStatusSnapshot.Configured)
+        {
+            Serilog.Log.Warning(
+                "PERSISTENCE: {PersistenceMode} — store domains without a database: {MissingDomains}. " +
+                "Journal entries, reconciliations, and approvals in these domains are held in memory and will be " +
+                "lost on restart. Set MERIDIAN_DATABASE_URL (or the per-domain MERIDIAN_*_CONNECTION_STRING variables) to persist them.",
+                persistenceStatus.Mode.ToUpperInvariant(),
+                persistenceStatus.MissingDomains);
+        }
+
         var contentRootPath = Directory.GetCurrentDirectory();
         var serviceRegistrationStopwatch = Stopwatch.StartNew();
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
@@ -143,7 +158,8 @@ public sealed class UiServer : IAsyncDisposable
             if (!LedgerStartup.IsConfigured())
             {
                 throw new InvalidOperationException(
-                    $"{TradeFillLedgerPostingHostOptions.SectionKey}:Enabled requires {LedgerStartup.ConnectionStringVariable} so accepted fills have an authoritative ledger target.");
+                    $"{TradeFillLedgerPostingHostOptions.SectionKey}:Enabled requires {LedgerStartup.ConnectionStringVariable} " +
+                    $"(or {Meridian.Storage.MeridianDatabaseEnvironment.UnifiedVariable}) so accepted fills have an authoritative ledger target.");
             }
 
             var postingContext = tradeFillPostingOptions.BuildContext();
@@ -206,7 +222,8 @@ public sealed class UiServer : IAsyncDisposable
                 Metrics.GetSnapshot,
                 pipeline.GetStatistics,
                 () => depthCollector.GetRecentIntegrityEvents(),
-                () => null);
+                () => null,
+                degradedModeProvider: () => EvaluateDegradedMode(sp));
         });
 
         builder.Services.AddSingleton<IReconciliationGovernanceAuditStore>(_ =>
@@ -820,19 +837,28 @@ public sealed class UiServer : IAsyncDisposable
                         "Database initialization is still running."));
                 }
 
-                var configured = HasConfiguredLocalPostgreSql();
-                if (productionPosture && !configured)
+                var persistence = PersistenceConfigurationStatus.Evaluate();
+                if (productionPosture && persistence.Mode != PersistenceStatusSnapshot.Configured)
                 {
                     return ValueTask.FromResult(new RuntimeReadinessCheckResult(
                         LifecycleCheckStatus.Failing,
-                        "A required local PostgreSQL connection is not configured."));
+                        $"PERSISTENCE: {persistence.Mode.ToUpperInvariant()} — store domains without a database: " +
+                        $"{string.Join(", ", persistence.MissingDomains)}. Set MERIDIAN_DATABASE_URL or the per-domain connection strings."));
                 }
 
-                return ValueTask.FromResult(new RuntimeReadinessCheckResult(
-                    LifecycleCheckStatus.Passing,
-                    configured
-                        ? "Configured PostgreSQL dependencies are ready."
-                        : "PostgreSQL is not required by this development posture."));
+                return ValueTask.FromResult(persistence.Mode switch
+                {
+                    PersistenceStatusSnapshot.Configured => new RuntimeReadinessCheckResult(
+                        LifecycleCheckStatus.Passing,
+                        "Configured PostgreSQL dependencies are ready."),
+                    PersistenceStatusSnapshot.Partial => new RuntimeReadinessCheckResult(
+                        LifecycleCheckStatus.Degraded,
+                        $"PERSISTENCE: PARTIAL — store domains without a database: {string.Join(", ", persistence.MissingDomains)}."),
+                    _ => new RuntimeReadinessCheckResult(
+                        LifecycleCheckStatus.Degraded,
+                        "PERSISTENCE: NONE — every money-path store is in-memory and loses data on restart. " +
+                        "Set MERIDIAN_DATABASE_URL to enable persistence.")
+                });
             }));
 
         services.AddSingleton<IRuntimeReadinessCheck>(sp => new DelegateRuntimeReadinessCheck(
@@ -858,18 +884,54 @@ public sealed class UiServer : IAsyncDisposable
             }));
     }
 
-    private static bool HasConfiguredLocalPostgreSql()
+    /// <summary>
+    /// Evaluates the degraded-mode posture surfaced by /api/status: whether the configured
+    /// streaming source delivers real or simulated market data, and which store domains run
+    /// without persistence. Static build/configuration facts only — no provider is constructed.
+    /// </summary>
+    private static Meridian.Contracts.Api.DegradedModeStatus EvaluateDegradedMode(IServiceProvider sp)
     {
-        string[] variables =
-        [
-            "MERIDIAN_SECURITY_MASTER_CONNECTION_STRING",
-            "MERIDIAN_LEDGER_CONNECTION_STRING",
-            "MERIDIAN_FUND_ACCOUNTS_CONNECTION_STRING",
-            "MERIDIAN_FUND_STRUCTURE_CONNECTION_STRING",
-            "MERIDIAN_DIRECT_LENDING_CONNECTION_STRING"
-        ];
-        return variables.Any(variable =>
-            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(variable)));
+        var persistence = PersistenceConfigurationStatus.Evaluate();
+        var marketDataMode = "unknown";
+        string? marketDataDetail = null;
+
+        try
+        {
+            var configStore = sp.GetService<Meridian.Application.UI.ConfigStore>();
+            if (configStore is not null)
+            {
+                var dataSource = configStore.Load().DataSource;
+                switch (dataSource)
+                {
+                    case DataSourceKind.Synthetic:
+                        marketDataMode = "simulated";
+                        marketDataDetail = "Streaming source 'synthetic' generates deterministic synthetic data.";
+                        break;
+                    case DataSourceKind.IB when Meridian.Infrastructure.Adapters.InteractiveBrokers.IBMarketDataClient.IsSimulationBuild:
+                        marketDataMode = "simulated";
+                        marketDataDetail =
+                            "Streaming source 'ib' runs as a random-walk simulator in this build (no IBAPI reference). " +
+                            "Prices are synthetic and historical requests return no bars.";
+                        break;
+                    default:
+                        marketDataMode = "live";
+                        marketDataDetail = $"Streaming source '{dataSource.ToString().ToLowerInvariant()}'.";
+                        break;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            marketDataDetail = $"Market data mode could not be evaluated: {ex.Message}";
+        }
+
+        return new Meridian.Contracts.Api.DegradedModeStatus
+        {
+            MarketDataMode = marketDataMode,
+            MarketDataDetail = marketDataDetail,
+            PersistenceMode = persistence.Mode,
+            MissingPersistenceDomains = persistence.MissingDomains.ToArray()
+        };
     }
 
     public async Task StartAsync(CancellationToken ct = default)

--- a/tests/Meridian.Tests/Application/Backfill/ParallelBackfillServiceTests.cs
+++ b/tests/Meridian.Tests/Application/Backfill/ParallelBackfillServiceTests.cs
@@ -923,7 +923,9 @@ public sealed class ParallelBackfillServiceTests : IAsyncLifetime
             Task.FromResult<IReadOnlyList<HistoricalBar>>(new[] { MakeBar(symbol) }));
 
         var svc = new HistoricalBackfillService([provider]);
-        var request = new AppBackfillRequest("test", new[] { "SPY", "AAPL" });
+        // MakeBar produces bars dated 2024-01-02; an explicit matching range keeps this a
+        // covered historical request rather than an open-ended one implying "through today".
+        var request = new AppBackfillRequest("test", new[] { "SPY", "AAPL" }, To: new DateOnly(2024, 1, 2));
 
         // Act
         var result = await svc.RunAsync(request, _pipeline);
@@ -945,7 +947,7 @@ public sealed class ParallelBackfillServiceTests : IAsyncLifetime
                 symbol == "TSLA" ? [] : new[] { MakeBar(symbol) }));
 
         var svc = new HistoricalBackfillService([provider]);
-        var request = new AppBackfillRequest("test", new[] { "SPY", "TSLA" });
+        var request = new AppBackfillRequest("test", new[] { "SPY", "TSLA" }, To: new DateOnly(2024, 1, 2));
 
         // Act
         var result = await svc.RunAsync(request, _pipeline);
@@ -975,6 +977,24 @@ public sealed class ParallelBackfillServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task RunAsync_OpenEndedRequestWithFrozenDataset_EmitsStaleWarnSignal()
+    {
+        // An open-ended request implies "through today"; a frozen dataset (e.g. Nasdaq WIKI,
+        // ended March 2018) must be flagged stale instead of passing as fresh coverage.
+        var provider = new ControllableProvider("test", (symbol, ct) =>
+            Task.FromResult<IReadOnlyList<HistoricalBar>>(new[] { MakeBar(symbol) }));
+
+        var svc = new HistoricalBackfillService([provider]);
+        var request = new AppBackfillRequest("test", ["SPY"]);
+
+        var result = await svc.RunAsync(request, _pipeline);
+
+        var signal = result.SymbolValidationSignals.Should().ContainSingle(s => s.Symbol == "SPY").Which;
+        signal.Status.Should().Be("Warn");
+        signal.Reason.Should().Contain("stale");
+    }
+
+    [Fact]
     public async Task RunAsync_FailedSymbol_EmitsFailSignal()
     {
         // Arrange — TSLA always throws
@@ -986,7 +1006,7 @@ public sealed class ParallelBackfillServiceTests : IAsyncLifetime
         });
 
         var svc = new HistoricalBackfillService([provider]);
-        var request = new AppBackfillRequest("test", new[] { "SPY", "TSLA" });
+        var request = new AppBackfillRequest("test", new[] { "SPY", "TSLA" }, To: new DateOnly(2024, 1, 2));
 
         // Act
         var result = await svc.RunAsync(request, _pipeline);

--- a/tests/Meridian.Tests/Application/Composition/StorageFeatureRegistrationTests.cs
+++ b/tests/Meridian.Tests/Application/Composition/StorageFeatureRegistrationTests.cs
@@ -50,6 +50,7 @@ public sealed class StorageFeatureRegistrationTests : IDisposable
     private readonly string? _originalBankingSchema;
     private readonly string? _originalMoneyMarketConnectionString;
     private readonly string? _originalMoneyMarketSchema;
+    private readonly string? _originalUnifiedDatabaseUrl;
     private readonly string? _originalScopedAccessConnectionString;
     private readonly string? _originalScopedAccessSchema;
     private readonly string? _originalUseInMemoryGovernance;
@@ -74,6 +75,7 @@ public sealed class StorageFeatureRegistrationTests : IDisposable
         _originalBankingSchema = Environment.GetEnvironmentVariable(BankingStartup.SchemaVariable);
         _originalMoneyMarketConnectionString = Environment.GetEnvironmentVariable(MoneyMarketStartup.ConnectionStringVariable);
         _originalMoneyMarketSchema = Environment.GetEnvironmentVariable(MoneyMarketStartup.SchemaVariable);
+        _originalUnifiedDatabaseUrl = Environment.GetEnvironmentVariable(Meridian.Storage.MeridianDatabaseEnvironment.UnifiedVariable);
         _originalScopedAccessConnectionString = Environment.GetEnvironmentVariable("MERIDIAN_SCOPED_ACCESS_CONNECTION_STRING");
         _originalScopedAccessSchema = Environment.GetEnvironmentVariable("MERIDIAN_SCOPED_ACCESS_SCHEMA");
         _originalUseInMemoryGovernance = Environment.GetEnvironmentVariable("MERIDIAN_USE_INMEMORY_GOVERNANCE");
@@ -364,6 +366,7 @@ public sealed class StorageFeatureRegistrationTests : IDisposable
 
     private static void ClearPostgresBackedStorageEnvironment()
     {
+        Environment.SetEnvironmentVariable(Meridian.Storage.MeridianDatabaseEnvironment.UnifiedVariable, null);
         Environment.SetEnvironmentVariable(SecurityMasterStartup.ConnectionStringVariable, null);
         Environment.SetEnvironmentVariable(SecurityMasterStartup.SchemaVariable, null);
         Environment.SetEnvironmentVariable(DirectLendingStartup.ConnectionStringVariable, null);
@@ -407,6 +410,7 @@ public sealed class StorageFeatureRegistrationTests : IDisposable
         Environment.SetEnvironmentVariable(BankingStartup.SchemaVariable, _originalBankingSchema);
         Environment.SetEnvironmentVariable(MoneyMarketStartup.ConnectionStringVariable, _originalMoneyMarketConnectionString);
         Environment.SetEnvironmentVariable(MoneyMarketStartup.SchemaVariable, _originalMoneyMarketSchema);
+        Environment.SetEnvironmentVariable(Meridian.Storage.MeridianDatabaseEnvironment.UnifiedVariable, _originalUnifiedDatabaseUrl);
         Environment.SetEnvironmentVariable("MERIDIAN_SCOPED_ACCESS_CONNECTION_STRING", _originalScopedAccessConnectionString);
         Environment.SetEnvironmentVariable("MERIDIAN_SCOPED_ACCESS_SCHEMA", _originalScopedAccessSchema);
         Environment.SetEnvironmentVariable("MERIDIAN_USE_INMEMORY_GOVERNANCE", _originalUseInMemoryGovernance);

--- a/tests/Meridian.Tests/Application/Pipeline/MarketDataClientFactoryTests.cs
+++ b/tests/Meridian.Tests/Application/Pipeline/MarketDataClientFactoryTests.cs
@@ -72,16 +72,19 @@ public sealed class MarketDataClientFactoryTests
     }
 
     [Fact]
-    public void CreateStreamingClient_UnknownProviderId_FallsBackToIB()
+    public void CreateStreamingClient_UnknownProviderId_ThrowsWithRegisteredProviders()
     {
         // Arrange
         var registry = CreateRegistryWithFactories();
 
-        // Act - use a provider ID with no registered factory; falls back to IB
-        var client = registry.CreateStreamingClient("custom-feed");
+        // Act - a provider ID with no registered factory must fail closed, not
+        // silently substitute another provider's data feed
+        var act = () => registry.CreateStreamingClient("custom-feed");
 
         // Assert
-        client.Should().BeOfType<IBMarketDataClient>();
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*custom-feed*")
+            .WithMessage("*alpaca*");
     }
 
     [Fact]

--- a/tests/Meridian.Tests/Core/Config/ConfigEnvironmentOverrideTests.cs
+++ b/tests/Meridian.Tests/Core/Config/ConfigEnvironmentOverrideTests.cs
@@ -32,6 +32,31 @@ public sealed class ConfigEnvironmentOverrideTests
         result.IBClientPortal.AllowSelfSignedCertificates.Should().BeTrue();
     }
 
+    [Fact]
+    public void ApplyOverrides_ValidDataSource_IsApplied()
+    {
+        using var dataSourceVar = new EnvironmentVariableScope("MDC_DATASOURCE", "alpaca");
+
+        var sut = new ConfigEnvironmentOverride();
+        var result = sut.ApplyOverrides(new AppConfig());
+
+        result.DataSource.Should().Be(DataSourceKind.Alpaca);
+    }
+
+    [Fact]
+    public void ApplyOverrides_UnknownDataSource_FailsClosed()
+    {
+        // A typo must not silently route the operator to another provider's data feed.
+        using var dataSourceVar = new EnvironmentVariableScope("MDC_DATASOURCE", "alpacca");
+
+        var sut = new ConfigEnvironmentOverride();
+        var act = () => sut.ApplyOverrides(new AppConfig());
+
+        act.Should().Throw<Meridian.Core.Exceptions.ConfigurationException>()
+            .WithMessage("*alpacca*")
+            .WithMessage("*MDC_DATASOURCE*");
+    }
+
     private sealed class EnvironmentVariableScope : IDisposable
     {
         private readonly string _name;

--- a/tests/Meridian.Tests/Core/Config/DataSourceKindConverterTests.cs
+++ b/tests/Meridian.Tests/Core/Config/DataSourceKindConverterTests.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using FluentAssertions;
+using Meridian.Core.Config;
+using Xunit;
+
+namespace Meridian.Tests.Core.Config;
+
+public sealed class DataSourceKindConverterTests
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        Converters = { new DataSourceKindConverter() }
+    };
+
+    [Theory]
+    [InlineData("\"IB\"", DataSourceKind.IB)]
+    [InlineData("\"alpaca\"", DataSourceKind.Alpaca)]
+    [InlineData("\"SYNTHETIC\"", DataSourceKind.Synthetic)]
+    public void Read_ValidStrings_ParseCaseInsensitively(string json, DataSourceKind expected)
+    {
+        JsonSerializer.Deserialize<DataSourceKind>(json, Options).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Read_UnknownString_FailsClosedWithValidValues()
+    {
+        // Coercing a typo to a default provider would silently route the operator to a data
+        // source they never configured — the config load must fail instead.
+        var act = () => JsonSerializer.Deserialize<DataSourceKind>("\"alpacca\"", Options);
+
+        act.Should().Throw<JsonException>()
+            .WithMessage("*alpacca*")
+            .WithMessage($"*{nameof(DataSourceKind.Alpaca)}*");
+    }
+
+    [Fact]
+    public void Read_UnknownNumber_FailsClosed()
+    {
+        var act = () => JsonSerializer.Deserialize<DataSourceKind>("999", Options);
+
+        act.Should().Throw<JsonException>().WithMessage("*999*");
+    }
+
+    [Fact]
+    public void Read_DefinedNumber_Parses()
+    {
+        var expected = Enum.GetValues<DataSourceKind>()[0];
+
+        JsonSerializer.Deserialize<DataSourceKind>(((int)expected).ToString(), Options)
+            .Should().Be(expected);
+    }
+
+    [Fact]
+    public void Write_RoundTripsAsString()
+    {
+        JsonSerializer.Serialize(DataSourceKind.Alpaca, Options).Should().Be("\"Alpaca\"");
+    }
+}

--- a/tests/Meridian.Tests/Execution/OrderManagementSystemGovernanceTests.cs
+++ b/tests/Meridian.Tests/Execution/OrderManagementSystemGovernanceTests.cs
@@ -91,7 +91,9 @@ public sealed class OrderManagementSystemGovernanceTests
             changedBy: "ops");
 
         using var oms = new OrderManagementSystem(
-            new ExecutionGateway(NullLogger<ExecutionGateway>.Instance),
+            new ExecutionGateway(
+                NullLogger<ExecutionGateway>.Instance,
+                options: new Meridian.Execution.Adapters.PaperTradingGatewayOptions { AllowScaffoldMarketFills = true }),
             NullLogger<OrderManagementSystem>.Instance,
             operatorControls: controls,
             auditTrail: auditTrail,
@@ -152,7 +154,9 @@ public sealed class OrderManagementSystemGovernanceTests
             changedBy: "ops");
 
         using var oms = new OrderManagementSystem(
-            new ExecutionGateway(NullLogger<ExecutionGateway>.Instance),
+            new ExecutionGateway(
+                NullLogger<ExecutionGateway>.Instance,
+                options: new Meridian.Execution.Adapters.PaperTradingGatewayOptions { AllowScaffoldMarketFills = true }),
             NullLogger<OrderManagementSystem>.Instance,
             operatorControls: controls,
             auditTrail: auditTrail,
@@ -218,7 +222,9 @@ public sealed class OrderManagementSystemGovernanceTests
             changedBy: "ops");
 
         using var oms = new OrderManagementSystem(
-            new ExecutionGateway(NullLogger<ExecutionGateway>.Instance),
+            new ExecutionGateway(
+                NullLogger<ExecutionGateway>.Instance,
+                options: new Meridian.Execution.Adapters.PaperTradingGatewayOptions { AllowScaffoldMarketFills = true }),
             NullLogger<OrderManagementSystem>.Instance,
             operatorControls: controls,
             auditTrail: auditTrail,
@@ -273,7 +279,9 @@ public sealed class OrderManagementSystemGovernanceTests
             reason: "Event-risk limit");
 
         using var oms = new OrderManagementSystem(
-            new ExecutionGateway(NullLogger<ExecutionGateway>.Instance),
+            new ExecutionGateway(
+                NullLogger<ExecutionGateway>.Instance,
+                options: new Meridian.Execution.Adapters.PaperTradingGatewayOptions { AllowScaffoldMarketFills = true }),
             NullLogger<OrderManagementSystem>.Instance,
             operatorControls: controls,
             auditTrail: auditTrail,
@@ -331,7 +339,9 @@ public sealed class OrderManagementSystemGovernanceTests
             RunId: "run-force-block"));
 
         using var oms = new OrderManagementSystem(
-            new ExecutionGateway(NullLogger<ExecutionGateway>.Instance),
+            new ExecutionGateway(
+                NullLogger<ExecutionGateway>.Instance,
+                options: new Meridian.Execution.Adapters.PaperTradingGatewayOptions { AllowScaffoldMarketFills = true }),
             NullLogger<OrderManagementSystem>.Instance,
             operatorControls: controls,
             auditTrail: auditTrail,

--- a/tests/Meridian.Tests/Execution/OrderManagementSystemTests.cs
+++ b/tests/Meridian.Tests/Execution/OrderManagementSystemTests.cs
@@ -25,7 +25,11 @@ public sealed class OrderManagementSystemTests : IDisposable
 
     public OrderManagementSystemTests()
     {
-        _gateway = new ExecutionGateway(NullLogger<ExecutionGateway>.Instance);
+        // These tests exercise OMS behavior over a gateway that fills feed-less market
+        // orders, so scaffold pricing is explicitly opted in.
+        _gateway = new ExecutionGateway(
+            NullLogger<ExecutionGateway>.Instance,
+            options: new Meridian.Execution.Adapters.PaperTradingGatewayOptions { AllowScaffoldMarketFills = true });
         _oms = new OrderManagementSystem(_gateway, NullLogger<OrderManagementSystem>.Instance);
     }
 
@@ -1099,7 +1103,9 @@ public sealed class OrderManagementSystemGateTests : IDisposable
 
     public OrderManagementSystemGateTests()
     {
-        _gateway = new ExecutionGateway(NullLogger<ExecutionGateway>.Instance);
+        _gateway = new ExecutionGateway(
+            NullLogger<ExecutionGateway>.Instance,
+            options: new Meridian.Execution.Adapters.PaperTradingGatewayOptions { AllowScaffoldMarketFills = true });
     }
 
     public void Dispose() { }

--- a/tests/Meridian.Tests/Execution/PaperExecutionGatewayLotSizeTests.cs
+++ b/tests/Meridian.Tests/Execution/PaperExecutionGatewayLotSizeTests.cs
@@ -26,19 +26,20 @@ public sealed class PaperExecutionGatewayLotSizeTests
         var sm = new StubSecurityMaster(securityId: Guid.NewGuid(), lotSize: 100m);
         var gateway = new Meridian.Execution.PaperTradingGateway(NullLogger<Meridian.Execution.PaperTradingGateway>.Instance, sm);
 
-        var report = await gateway.SubmitOrderAsync(MarketBuy("XYZ", 200));
+        var report = await gateway.SubmitOrderAsync(MarketBuy("XYZ", 200, simulatedPrice: 50m));
 
         report.OrderStatus.Should().Be(OrderStatus.Filled);
         report.FilledQuantity.Should().Be(200m);
     }
 
-    private static OrderRequest MarketBuy(string symbol, decimal qty) => new()
+    private static OrderRequest MarketBuy(string symbol, decimal qty, decimal? simulatedPrice = null) => new()
     {
         Symbol = symbol,
         Side = OrderSide.Buy,
         Type = OrderType.Market,
         Quantity = qty,
-        TimeInForce = TimeInForce.Day
+        TimeInForce = TimeInForce.Day,
+        LimitPrice = simulatedPrice
     };
 
     private sealed class StubSecurityMaster : ISecurityMasterQueryService

--- a/tests/Meridian.Tests/Execution/PaperGatewayLiveFeedPricingTests.cs
+++ b/tests/Meridian.Tests/Execution/PaperGatewayLiveFeedPricingTests.cs
@@ -120,7 +120,7 @@ public sealed class PaperGatewayLiveFeedPricingTests
     }
 
     [Fact]
-    public async Task ExecutionGateway_MarketOrder_WithoutFeed_FallsBackToScaffoldPrice()
+    public async Task ExecutionGateway_MarketOrder_WithoutFeed_RejectsByDefault()
     {
         var gateway = new ExecutionGateway(
             NullLogger<ExecutionGateway>.Instance,
@@ -135,7 +135,61 @@ public sealed class PaperGatewayLiveFeedPricingTests
             Quantity = 3m
         });
 
+        report.OrderStatus.Should().Be(OrderStatus.Rejected,
+            "a market order with no live reference price must fail closed instead of filling at a fabricated price");
+        report.FilledQuantity.Should().Be(0);
+        report.RejectReason.Should().Contain("SPY").And.Contain("AllowScaffoldMarketFills");
+    }
+
+    [Fact]
+    public async Task ExecutionGateway_MarketOrder_WithoutFeed_FillsAtScaffoldPriceWhenOptedIn()
+    {
+        var gateway = new ExecutionGateway(
+            NullLogger<ExecutionGateway>.Instance,
+            securityMaster: null,
+            options: new PaperTradingGatewayOptions
+            {
+                AllowScaffoldMarketFills = true,
+                ScaffoldMarketFillPrice = 42m
+            });
+
+        var report = await gateway.SubmitOrderAsync(new OrderRequest
+        {
+            Symbol = "SPY",
+            Side = OrderSide.Buy,
+            Type = OrderType.Market,
+            Quantity = 3m
+        });
+
+        report.OrderStatus.Should().Be(OrderStatus.Filled);
         report.FillPrice.Should().Be(42m);
+    }
+
+    [Fact]
+    public async Task AdapterGateway_MarketOrder_WithoutFeed_RejectsByDefault()
+    {
+        await using var gateway = new AdapterGateway(NullLogger<AdapterGateway>.Instance);
+
+        await gateway.SubmitAsync(new OrderRequest
+        {
+            Symbol = "AAPL",
+            Side = OrderSide.Buy,
+            Type = OrderType.Market,
+            Quantity = 10m
+        });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await foreach (var update in gateway.StreamOrderUpdatesAsync(cts.Token))
+        {
+            update.Status.Should().Be(Meridian.Execution.Models.OrderStatus.Rejected,
+                "a market order with no live reference price must fail closed instead of filling at a fabricated price");
+            update.FilledQuantity.Should().Be(0);
+            update.AverageFillPrice.Should().BeNull();
+            update.RejectReason.Should().Contain("AAPL").And.Contain("AllowScaffoldMarketFills");
+            return;
+        }
+
+        Assert.Fail("No order update was received from the paper gateway.");
     }
 
     [Fact]

--- a/tests/Meridian.Tests/Execution/PaperTradingGatewayTests.cs
+++ b/tests/Meridian.Tests/Execution/PaperTradingGatewayTests.cs
@@ -73,7 +73,11 @@ public sealed class PaperTradingGatewayTests
     {
         var gateway = new PaperTradingGateway(
             NullLogger<PaperTradingGateway>.Instance,
-            options: new PaperTradingGatewayOptions { ScaffoldMarketFillPrice = 123.45m });
+            options: new PaperTradingGatewayOptions
+            {
+                AllowScaffoldMarketFills = true,
+                ScaffoldMarketFillPrice = 123.45m
+            });
 
         var acknowledgement = await gateway.SubmitAsync(MarketBuy("SPY", 10));
 

--- a/tests/Meridian.Tests/Infrastructure/Providers/BackfillBarValidationTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/BackfillBarValidationTests.cs
@@ -1,0 +1,104 @@
+using FluentAssertions;
+using Meridian.Contracts.Domain.Models;
+using Meridian.Infrastructure.Adapters.Core;
+using Xunit;
+
+namespace Meridian.Tests.Infrastructure.Providers;
+
+public sealed class BackfillBarValidationTests
+{
+    private static readonly DateOnly Today = new(2026, 7, 21);
+
+    private static HistoricalBar Bar(DateOnly sessionDate, string symbol = "AAPL")
+        => new(symbol, sessionDate, 100m, 101m, 99m, 100.5m, 1_000, Source: "test");
+
+    [Fact]
+    public void EvaluateDailyRecency_EmptyResult_IsNotStale()
+    {
+        BackfillBarValidation.EvaluateDailyRecency([], requestedTo: Today, today: Today)
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void EvaluateDailyRecency_RecentBars_AreFresh()
+    {
+        var bars = new[] { Bar(Today.AddDays(-5)), Bar(Today.AddDays(-4)) };
+
+        BackfillBarValidation.EvaluateDailyRecency(bars, requestedTo: null, today: Today)
+            .Should().BeNull("a latest bar within the tolerance window satisfies an open-ended request");
+    }
+
+    [Fact]
+    public void EvaluateDailyRecency_FrozenDataset_IsStaleForOpenEndedRequest()
+    {
+        // Nasdaq WIKI froze in March 2018; an open-ended request implies "through today".
+        var frozen = new[] { Bar(new DateOnly(2018, 3, 27)) };
+
+        var verdict = BackfillBarValidation.EvaluateDailyRecency(frozen, requestedTo: null, today: Today);
+
+        verdict.Should().NotBeNull();
+        verdict!.LatestSessionDate.Should().Be(new DateOnly(2018, 3, 27));
+        verdict.ExpectedThrough.Should().Be(Today);
+        verdict.StaleDays.Should().BeGreaterThan(3000);
+        verdict.Description.Should().Contain("2018-03-27");
+    }
+
+    [Fact]
+    public void EvaluateDailyRecency_HistoricalEraRequest_IsNeverStale()
+    {
+        // Backfilling an old range on purpose must not trip the recency check.
+        var bars = new[] { Bar(new DateOnly(2015, 12, 30)) };
+
+        BackfillBarValidation.EvaluateDailyRecency(bars, requestedTo: new DateOnly(2015, 12, 31), today: Today)
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void EvaluateDailyRecency_FutureRequestedTo_IsCappedAtToday()
+    {
+        var bars = new[] { Bar(Today.AddDays(-3)) };
+
+        BackfillBarValidation.EvaluateDailyRecency(bars, requestedTo: Today.AddDays(365), today: Today)
+            .Should().BeNull("a requested end date in the future must not make fresh data look stale");
+    }
+
+    [Fact]
+    public void EvaluateDailyRecency_RespectsCustomTolerance()
+    {
+        var bars = new[] { Bar(Today.AddDays(-8)) };
+
+        BackfillBarValidation.EvaluateDailyRecency(bars, requestedTo: null, today: Today, staleToleranceDays: 5)
+            .Should().NotBeNull();
+        BackfillBarValidation.EvaluateDailyRecency(bars, requestedTo: null, today: Today, staleToleranceDays: 10)
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void RemoveFutureDatedBars_KeepsCleanResultsUntouched()
+    {
+        var bars = new[] { Bar(Today.AddDays(-2)), Bar(Today.AddDays(-1)), Bar(Today) };
+
+        var filtered = BackfillBarValidation.RemoveFutureDatedBars(bars, out var removed, today: Today);
+
+        removed.Should().Be(0);
+        filtered.Should().BeSameAs(bars, "a clean result avoids reallocating the list");
+    }
+
+    [Fact]
+    public void RemoveFutureDatedBars_DropsBarsBeyondTomorrow()
+    {
+        var bars = new[]
+        {
+            Bar(Today.AddDays(-1)),
+            Bar(Today.AddDays(1)),  // tolerated: exchange time zones ahead of UTC
+            Bar(Today.AddDays(2)),  // provider garbage
+            Bar(Today.AddDays(30))  // provider garbage
+        };
+
+        var filtered = BackfillBarValidation.RemoveFutureDatedBars(bars, out var removed, today: Today);
+
+        removed.Should().Be(2);
+        filtered.Should().HaveCount(2);
+        filtered.Select(b => b.SessionDate).Should().Equal(Today.AddDays(-1), Today.AddDays(1));
+    }
+}

--- a/tests/Meridian.Tests/Infrastructure/Providers/CompositeProviderStaleDataTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Providers/CompositeProviderStaleDataTests.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+using Meridian.Contracts.Domain.Models;
+using Meridian.Infrastructure.Adapters.Core;
+using Xunit;
+
+namespace Meridian.Tests.Infrastructure.Providers;
+
+/// <summary>
+/// The composite failover chain must not let a frozen dataset (e.g. Nasdaq WIKI, ended March
+/// 2018) win a request for recent data just because it is first in priority order and non-empty.
+/// </summary>
+public sealed class CompositeProviderStaleDataTests
+{
+    private static HistoricalBar Bar(DateOnly sessionDate, string source)
+        => new("AAPL", sessionDate, 100m, 101m, 99m, 100.5m, 1_000, Source: source);
+
+    private static IReadOnlyList<HistoricalBar> BarsEndingAt(DateOnly latest, string source)
+        => [Bar(latest.AddDays(-1), source), Bar(latest, source)];
+
+    [Fact]
+    public async Task GetDailyBarsAsync_SkipsStaleProviderWhenFresherProviderExists()
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var frozen = new StubProvider("frozen-wiki", priority: 1, BarsEndingAt(new DateOnly(2018, 3, 27), "frozen-wiki"));
+        var fresh = new StubProvider("fresh", priority: 2, BarsEndingAt(today, "fresh"));
+
+        using var composite = new CompositeHistoricalDataProvider([frozen, fresh]);
+
+        var bars = await composite.GetDailyBarsAsync("AAPL", from: null, to: null);
+
+        bars.Should().NotBeEmpty();
+        bars.Should().OnlyContain(b => b.Source == "fresh",
+            "a stale first-priority result must yield to a fresher provider further down the chain");
+        frozen.CallCount.Should().Be(1);
+        fresh.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetDailyBarsAsync_ReturnsFreshestStaleResultWhenAllProvidersAreStale()
+    {
+        var older = new StubProvider("older", priority: 1, BarsEndingAt(new DateOnly(2018, 3, 27), "older"));
+        var newer = new StubProvider("newer", priority: 2, BarsEndingAt(new DateOnly(2020, 6, 15), "newer"));
+
+        using var composite = new CompositeHistoricalDataProvider([older, newer]);
+
+        var bars = await composite.GetDailyBarsAsync("AAPL", from: null, to: null);
+
+        bars.Should().NotBeEmpty("stale data with a loud signal beats no data");
+        bars.Should().OnlyContain(b => b.Source == "newer",
+            "when every provider is stale the freshest stale result wins");
+    }
+
+    [Fact]
+    public async Task GetDailyBarsAsync_HistoricalEraRequest_AcceptsFirstProviderNormally()
+    {
+        var frozen = new StubProvider("frozen-wiki", priority: 1, BarsEndingAt(new DateOnly(2016, 12, 30), "frozen-wiki"));
+        var fresh = new StubProvider("fresh", priority: 2, BarsEndingAt(DateOnly.FromDateTime(DateTime.UtcNow), "fresh"));
+
+        using var composite = new CompositeHistoricalDataProvider([frozen, fresh]);
+
+        var bars = await composite.GetDailyBarsAsync(
+            "AAPL",
+            from: new DateOnly(2016, 1, 1),
+            to: new DateOnly(2016, 12, 31));
+
+        bars.Should().OnlyContain(b => b.Source == "frozen-wiki",
+            "a request for an old range is satisfied by an old dataset; recency only applies to range ends near today");
+        fresh.CallCount.Should().Be(0);
+    }
+
+    private sealed class StubProvider : IHistoricalDataProvider
+    {
+        private readonly IReadOnlyList<HistoricalBar> _bars;
+
+        public StubProvider(string name, int priority, IReadOnlyList<HistoricalBar> bars)
+        {
+            Name = DisplayName = name;
+            Priority = priority;
+            _bars = bars;
+        }
+
+        public string Name { get; }
+        public string DisplayName { get; }
+        public string Description => string.Empty;
+        public int Priority { get; }
+        public int CallCount { get; private set; }
+
+        public Task<IReadOnlyList<HistoricalBar>> GetDailyBarsAsync(
+            string symbol, DateOnly? from, DateOnly? to, CancellationToken ct = default)
+        {
+            CallCount++;
+            return Task.FromResult(_bars);
+        }
+    }
+}

--- a/tests/Meridian.Tests/Storage/MeridianDatabaseEnvironmentTests.cs
+++ b/tests/Meridian.Tests/Storage/MeridianDatabaseEnvironmentTests.cs
@@ -1,0 +1,124 @@
+using FluentAssertions;
+using Meridian.Storage;
+using Xunit;
+
+namespace Meridian.Tests.Storage;
+
+[Collection("Sequential")]
+public sealed class MeridianDatabaseEnvironmentTests : IDisposable
+{
+    private readonly Dictionary<string, string?> _originalValues = new();
+
+    public MeridianDatabaseEnvironmentTests()
+    {
+        foreach (var variable in TrackedVariables())
+        {
+            _originalValues[variable] = Environment.GetEnvironmentVariable(variable);
+            Environment.SetEnvironmentVariable(variable, null);
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var (variable, value) in _originalValues)
+        {
+            Environment.SetEnvironmentVariable(variable, value);
+        }
+    }
+
+    private static IEnumerable<string> TrackedVariables()
+    {
+        yield return MeridianDatabaseEnvironment.UnifiedVariable;
+        foreach (var variable in MeridianDatabaseEnvironment.PropagatedConnectionStringVariables)
+            yield return variable;
+    }
+
+    [Fact]
+    public void ApplyUnifiedDatabaseUrl_WhenUnset_LeavesDomainVariablesUntouched()
+    {
+        var inherited = MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl();
+
+        inherited.Should().BeEmpty();
+        foreach (var variable in MeridianDatabaseEnvironment.PropagatedConnectionStringVariables)
+        {
+            Environment.GetEnvironmentVariable(variable).Should().BeNull();
+        }
+    }
+
+    [Fact]
+    public void ApplyUnifiedDatabaseUrl_PopulatesUnsetDomainVariables()
+    {
+        Environment.SetEnvironmentVariable(
+            MeridianDatabaseEnvironment.UnifiedVariable,
+            "Host=localhost;Port=5432;Database=meridian;Username=meridian");
+
+        var inherited = MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl();
+
+        inherited.Should().BeEquivalentTo(MeridianDatabaseEnvironment.PropagatedConnectionStringVariables);
+        foreach (var variable in MeridianDatabaseEnvironment.PropagatedConnectionStringVariables)
+        {
+            Environment.GetEnvironmentVariable(variable)
+                .Should().Be("Host=localhost;Port=5432;Database=meridian;Username=meridian");
+        }
+    }
+
+    [Fact]
+    public void ApplyUnifiedDatabaseUrl_NeverOverwritesExplicitDomainVariables()
+    {
+        Environment.SetEnvironmentVariable(
+            MeridianDatabaseEnvironment.UnifiedVariable,
+            "Host=shared;Database=meridian");
+        Environment.SetEnvironmentVariable(
+            "MERIDIAN_LEDGER_CONNECTION_STRING",
+            "Host=dedicated-ledger;Database=ledger");
+
+        var inherited = MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl();
+
+        inherited.Should().NotContain("MERIDIAN_LEDGER_CONNECTION_STRING");
+        Environment.GetEnvironmentVariable("MERIDIAN_LEDGER_CONNECTION_STRING")
+            .Should().Be("Host=dedicated-ledger;Database=ledger");
+        Environment.GetEnvironmentVariable("MERIDIAN_BANKING_CONNECTION_STRING")
+            .Should().Be("Host=shared;Database=meridian");
+    }
+
+    [Fact]
+    public void ApplyUnifiedDatabaseUrl_IsIdempotent()
+    {
+        Environment.SetEnvironmentVariable(
+            MeridianDatabaseEnvironment.UnifiedVariable,
+            "Host=shared;Database=meridian");
+
+        var first = MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl();
+        var second = MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl();
+
+        first.Should().NotBeEmpty();
+        second.Should().BeEmpty("the first call already populated every domain variable");
+    }
+
+    [Fact]
+    public void NormalizeToConnectionString_PassesKeywordFormThrough()
+    {
+        const string keywordForm = "Host=localhost;Port=5432;Database=meridian;Username=app;Password=secret";
+
+        MeridianDatabaseEnvironment.NormalizeToConnectionString(keywordForm).Should().Be(keywordForm);
+    }
+
+    [Fact]
+    public void NormalizeToConnectionString_ConvertsPostgresUrl()
+    {
+        var normalized = MeridianDatabaseEnvironment.NormalizeToConnectionString(
+            "postgres://app:s%40cret@db.example.com:6432/meridian?sslmode=require&pooling=true");
+
+        normalized.Should().Be(
+            "Host=db.example.com;Port=6432;Database=meridian;Username=app;Password=s@cret;SSL Mode=require;pooling=true");
+    }
+
+    [Fact]
+    public void NormalizeToConnectionString_DefaultsPortAndOmitsMissingParts()
+    {
+        var normalized = MeridianDatabaseEnvironment.NormalizeToConnectionString(
+            "postgresql://db.example.com/meridian");
+
+        normalized.Should().Be("Host=db.example.com;Port=5432;Database=meridian");
+    }
+}

--- a/tests/Meridian.Tests/Ui/PromotionDecisionChainScenarioTests.cs
+++ b/tests/Meridian.Tests/Ui/PromotionDecisionChainScenarioTests.cs
@@ -42,7 +42,9 @@ public sealed class PromotionDecisionChainScenarioTests
             auditTrail);
 
         using var oms = new OrderManagementSystem(
-            new ExecutionGateway(NullLogger<ExecutionGateway>.Instance),
+            new ExecutionGateway(
+                NullLogger<ExecutionGateway>.Instance,
+                options: new Meridian.Execution.Adapters.PaperTradingGatewayOptions { AllowScaffoldMarketFills = true }),
             NullLogger<OrderManagementSystem>.Instance,
             operatorControls: controls,
             auditTrail: auditTrail,
@@ -222,7 +224,9 @@ public sealed class PromotionDecisionChainScenarioTests
         await controls.SetCircuitBreakerAsync(true, "Operator halt for risk review", "risk-officer");
 
         using var oms = new OrderManagementSystem(
-            new ExecutionGateway(NullLogger<ExecutionGateway>.Instance),
+            new ExecutionGateway(
+                NullLogger<ExecutionGateway>.Instance,
+                options: new Meridian.Execution.Adapters.PaperTradingGatewayOptions { AllowScaffoldMarketFills = true }),
             NullLogger<OrderManagementSystem>.Instance,
             operatorControls: controls,
             auditTrail: auditTrail,

--- a/tests/Meridian.Tests/Ui/RiskEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/RiskEndpointsTests.cs
@@ -72,7 +72,9 @@ public sealed class RiskEndpointsTests
             services.AddSingleton(new RiskRuleRuntimeOptions(Path.Combine(Path.GetTempPath(), $"risk-rules-{Guid.NewGuid():N}.json")));
             services.AddSingleton<PaperTradingPortfolio>(_ => new PaperTradingPortfolio(100_000m));
             services.AddSingleton<IPortfolioState>(sp => sp.GetRequiredService<PaperTradingPortfolio>());
-            services.AddSingleton<IExecutionGateway>(_ => new Meridian.Execution.PaperTradingGateway(NullLogger<Meridian.Execution.PaperTradingGateway>.Instance));
+            services.AddSingleton<IExecutionGateway>(_ => new Meridian.Execution.PaperTradingGateway(
+                NullLogger<Meridian.Execution.PaperTradingGateway>.Instance,
+                options: new Meridian.Execution.Adapters.PaperTradingGatewayOptions { AllowScaffoldMarketFills = true }));
             services.AddSingleton<RiskRuleRuntimeService>();
             services.AddSingleton<IRiskValidator>(sp =>
             {


### PR DESCRIPTION
## Summary

Silent simulation was the product's default failure mode: several paths produced plausible-looking fake or stale results with no loud signal. This PR makes each of those modes either fail closed or announce itself loudly:

- **Provider resolution fails closed.** `ProviderRegistry.CreateStreamingClient` no longer silently substitutes the IB factory (the random-walk simulator in default builds) for unknown/typo'd provider ids — it throws with the registered-provider list. The two upstream coercion layers are also fixed: `DataSourceKindConverter` and `MDC_DATASOURCE` parsing no longer coerce unknown values to `DataSourceKind.IB` (they fail with valid values named), and the data-source config endpoints return 400 for unknown provider names instead of persisting them as IB.
- **Paper trading fails closed.** Both paper gateways reject market orders when no live reference price exists instead of filling at the fabricated scaffold price ($1 default). Scaffold pricing is now an explicit opt-in: `PaperTrading:Gateway:AllowScaffoldMarketFills` (default `false`). The `IOrderGateway` variant emits a terminal `Rejected` order update; the `IExecutionGateway` variant returns a `Rejected` execution report.
- **Backfilled bars get recency/sanity validation.** `CompositeHistoricalDataProvider` no longer lets a frozen dataset (e.g. Nasdaq WIKI, ended March 2018) win a request for recent data just by being first and non-empty — stale results are held back while fresher providers are tried, and only returned (with an error-level log and a `stale-data-accepted` progress event) when nothing fresher exists. `HistoricalBackfillService` emits stale `Warn` validation signals for requests that expect fresh data and drops future-dated bars in both publish paths; `BackfillWorkerService` does the same before persisting. Explicitly historical ranges are unaffected.
- **Persistence is one variable and loudly reported.** New `MERIDIAN_DATABASE_URL` (accepts `postgres://` URLs or Npgsql keyword form) enables PostgreSQL persistence for all money-path store domains at once via `MeridianDatabaseEnvironment.ApplyUnifiedDatabaseUrl`, called at every composition root (console host, `UiServer`, `Meridian.Ui.Shared`, WPF, storage switchboard). Per-domain `MERIDIAN_*_CONNECTION_STRING` variables always win, so split-database deployments keep working. `PersistenceConfigurationStatus` evaluates a NONE/PARTIAL/CONFIGURED posture used by a loud startup warning, the `postgresql` readiness check (now listing missing domains; PARTIAL is Degraded rather than silently Passing), the production governance gate message, `run-desktop.ps1`, and the `doctor.py`/`buildctl.py` probes.
- **Simulation is visible end to end.** `IMarketDataClient.IsSimulated` (defaulted interface member) identifies synthetic clients; the IB simulation client now warns loudly at construction; `/api/status` exposes a `degradedMode` payload (`marketDataMode`, `persistenceMode`, `missingPersistenceDomains`); and the browser workstation renders a persistent red banner (`role=alert`) for **SIMULATED MARKET DATA** and **PERSISTENCE: NONE/PARTIAL** states, driven by the backend payload rather than client-side fixture state.

Not in scope (deliberately): a SQLite default would require new store implementations for every Postgres-backed domain — `MERIDIAN_DATABASE_URL` plus the loud NONE banner covers the intent; the WPF status-bar parity surface is follow-up work that now has its shared DTO seam (`DegradedModeStatus`); the IB smoke stub itself is unchanged (it exists to satisfy compilation — the loud signaling now happens at the client/host layer).

## Reason

Addresses the "silent simulation is the default" report: the flagship IB feed is a random-walk simulator in every default build, unknown provider ids silently routed to that simulator, the default backfill chain could persist eight-year-old prices as fresh, paper trading filled at a fabricated $1, and every money-path store ran in-memory unless 10 separate env vars were set — with the quick start never mentioning it. Fake-but-plausible data in a trading and fund-operations platform is the worst failure mode; degraded modes must be loud and fail-closed.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully (full local gate not run in this environment; targeted lanes below were)
- [x] Relevant unit tests were added or updated (`dotnet build Meridian.sln` clean; 262 tests across all affected classes pass: provider registry/converter/env-override, both paper gateways, OMS/governance/promotion/risk endpoints, backfill orchestrator/worker/composite, storage feature registration, new `BackfillBarValidationTests`, `CompositeProviderStaleDataTests`, `DataSourceKindConverterTests`, `MeridianDatabaseEnvironmentTests`)
- [x] Relevant integration tests were added or updated (dashboard: full vitest suite 257 files green incl. new `degraded-mode-banner` tests; `tsc --noEmit` clean; `vite build` succeeds; eslint 0 errors; `check-ai-inventory.py` passes)
- [ ] GitHub Actions `quality-gate` passed (pending on this PR)

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed (fallback-reliant tests were rewritten to assert the fail-closed behavior; tests exercising unrelated OMS/governance flows opt into scaffold pricing explicitly)
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

Check every governance file modified:

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

Governance-file changes require explicit human approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvDHbeoxTurZxoNivFkWdD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvDHbeoxTurZxoNivFkWdD)_