### PR TITLE
Raise the api.ts file-size ratchet cap to its post-merge line count

### DIFF
--- a/build/config/file-size-baseline.json
+++ b/build/config/file-size-baseline.json
@@ -25,7 +25,7 @@
     "src/Meridian.Ui.Shared/Services/ReportingWorkflowService.cs": 2026,
     "src/Meridian.Ui.Shared/Services/SecurityMasterWorkbenchQueryService.cs": 4740,
     "src/Meridian.Ui.Shared/Services/TradingOperatorReadinessService.cs": 2507,
-    "src/Meridian.Ui/dashboard/src/lib/api.ts": 4155,
+    "src/Meridian.Ui/dashboard/src/lib/api.ts": 4175,
     "src/Meridian.Ui/dashboard/src/lib/dev-fixtures.ts": 6663,
     "src/Meridian.Ui/dashboard/src/screens/accounting-screen.close-cockpit.view-model.ts": 2588,
     "src/Meridian.Ui/dashboard/src/screens/accounting-screen.governance.view-model.ts": 5028,


### PR DESCRIPTION
## Summary

One-line fix for a ratchet race on `main`: PRs #2353 and #2354 each passed the no-new-god-file ratchet independently, but their combined merge grew `src/Meridian.Ui/dashboard/src/lib/api.ts` to 4175 lines while `build/config/file-size-baseline.json` still caps it at 4155. Every PR now fails `verify-dotnet` through its merge ref (first observed on #2355, a docs-only PR).

This records the current line count (4175) as the new cap. The ratchet still blocks any further growth of the file, and this stays a baseline adjustment with justification per the ratchet's own guidance, not an exemption.

## Reason

Unblocks `verify-dotnet` / `quality-gate` for all open PRs, including #2355, without touching `api.ts` itself.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — not run; single-value baseline change validated with the ratchet check itself
- [ ] Relevant unit tests were added or updated — not applicable (config-only change)
- [ ] Relevant integration tests were added or updated — not applicable (config-only change)
- [ ] GitHub Actions `quality-gate` passed — pending on this PR

Targeted validation: `python3 build/scripts/ci/check-file-size.py` → `File-size ratchet OK: 49 tracked file(s), no new or grown god files (threshold 2000 lines).`

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

Check every governance file modified:

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

Governance-file changes require explicit human approval.

<!-- phase:PR6 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6AcM4JrpvARMtLH2p345u

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6AcM4JrpvARMtLH2p345u)_