### PR TITLE
Fix main-red paper close-position endpoint tests after fail-closed gateway change

### DIFF
--- a/tests/Meridian.Tests/Ui/ExecutionWriteEndpointsTests.cs
+++ b/tests/Meridian.Tests/Ui/ExecutionWriteEndpointsTests.cs
@@ -196,6 +196,13 @@ public sealed class ExecutionWriteEndpointsTests
             RegisterMinimalOms(
                 services,
                 new ExecutionPosition("AAPL", 5, 180m, 10m, 0m));
+            // The paper gateway fails closed on priceless market orders when no live feed is
+            // wired; this test asserts the paper close is submitted, not fill-price realism, so
+            // opt into scaffold pricing to exercise the submission path.
+            services.AddSingleton(new Meridian.Execution.Adapters.PaperTradingGatewayOptions
+            {
+                AllowScaffoldMarketFills = true
+            });
             services.AddSingleton(new BrokerageConfiguration
             {
                 ProductionRoutingPhaseEnabled = false,
@@ -233,9 +240,18 @@ public sealed class ExecutionWriteEndpointsTests
     public async Task ClosePositionByKey_WithPaperPosition_SubmitsOrder()
     {
         await using var app = await CreateAppAsync(services =>
+        {
             RegisterMinimalOms(
                 services,
-                new ExecutionPosition("AAPL", 5, 180m, 10m, 0m)));
+                new ExecutionPosition("AAPL", 5, 180m, 10m, 0m));
+            // The paper gateway fails closed on priceless market orders when no live feed is
+            // wired; this test asserts the close order is submitted, not fill-price realism, so
+            // opt into scaffold pricing to exercise the submission path.
+            services.AddSingleton(new Meridian.Execution.Adapters.PaperTradingGatewayOptions
+            {
+                AllowScaffoldMarketFills = true
+            });
+        });
 
         var client = app.GetTestClient();
         var response = await client.PostAsync(


### PR DESCRIPTION
## Summary

`main` is currently red on `verify-dotnet`: the `core-ui-other` test shard fails two cases in `tests/Meridian.Tests/Ui/ExecutionWriteEndpointsTests.cs`:

- `ClosePosition_WhenProductionPhaseDisabled_StillSubmitsPaperClose`
- `ClosePositionByKey_WithPaperPosition_SubmitsOrder`

Both assert `200 OK` / `Accepted` but receive `400 BadRequest` / `Rejected`.

Root cause: commit `97298601` ("Make degraded modes loud and fail-closed across providers, execution, backfill, and persistence") made the paper trading gateways **reject market orders when no live reference price exists** — scaffold ("$1 notional") fills became an explicit opt-in via `PaperTrading:Gateway:AllowScaffoldMarketFills`. That change updated the gateway and pricing tests but did **not** update these two endpoint tests, whose close-position path submits a market order with no live feed wired. So they now fail closed.

Because `verify-dotnet` runs on each PR's merge-ref, this `main`-side failure blocks **every** open PR, not just this one.

## Reason

These two endpoint tests exist to prove the paper close is **submitted and accepted** through the endpoint → OMS → gateway path — not to assert fill-price realism. The fix registers a `PaperTradingGatewayOptions { AllowScaffoldMarketFills = true }` for just these two cases, restoring the exact pre-`97298601` behavior they were written against while leaving the new fail-closed default intact everywhere else. The adjacent `ClosePosition_WhenSymbolHasNoPosition_ReturnsRejectedActionResult` case still expects `400 Rejected` (it is rejected before reaching the gateway) and is unchanged.

`PaperTradingGatewayOptions` is fully-qualified rather than imported via `using`, because `using Meridian.Execution.Adapters;` would make the unqualified `PaperTradingGateway` in the test harness ambiguous with `Meridian.Execution.PaperTradingGateway`.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — not run; no .NET SDK in this environment, validating via hosted CI per the repo's fallback guidance
- [x] Relevant unit tests were updated (the two failing endpoint tests)
- [ ] Relevant integration tests were added or updated — not applicable
- [ ] GitHub Actions `quality-gate` passed — pending on this PR (specifically the `core-ui-other` shard of `verify-dotnet`)

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

Check every governance file modified:

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

Governance-file changes require explicit human approval.

<!-- phase:PR4 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6AcM4JrpvARMtLH2p345u

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6AcM4JrpvARMtLH2p345u)_