### PR TITLE
Stabilize flaky wall-clock timing tests in dispose/cleanup suites

### DIFF
--- a/tests/Meridian.Tests/Execution/Enhancements/EventDrivenDecouplingTests.cs
+++ b/tests/Meridian.Tests/Execution/Enhancements/EventDrivenDecouplingTests.cs
@@ -404,11 +404,14 @@ public sealed class EventDrivenDecouplingTests
                 blockedPublish.IsCompleted.Should().BeFalse("the channel is saturated before disposal begins");
 
                 var elapsed = Stopwatch.StartNew();
-                await consumer.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(1));
+                await consumer.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
                 elapsed.Stop();
 
+                // Ceiling widened from 750ms: bounded shutdown completes quickly, but a tight
+                // sub-second wall-clock bound flakes under CI scheduling/GC jitter. The 5s WaitAsync
+                // guard above is the hang detector; 2s still proves finite drain + cancellation.
                 elapsed.Elapsed.Should().BeLessThan(
-                    TimeSpan.FromMilliseconds(750),
+                    TimeSpan.FromSeconds(2),
                     "shutdown has finite drain and cancellation phases even when a dependency ignores cancellation");
                 Func<Task> blockedPublishAction = async () => await blockedPublish;
                 await blockedPublishAction.Should().ThrowAsync<ChannelClosedException>(
@@ -1338,10 +1341,14 @@ public sealed class EventDrivenDecouplingTests
 
         var elapsed = Stopwatch.StartNew();
         var disposeTask = consumer.DisposeAsync().AsTask();
-        await disposeTask.WaitAsync(TimeSpan.FromSeconds(1));
+        await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
         elapsed.Stop();
 
-        elapsed.Elapsed.Should().BeLessThan(TimeSpan.FromMilliseconds(750));
+        // Dispose must stay bounded rather than block on the stalled cancellation callback (released
+        // only later in this test). The configured drain + cancellation timeouts total ~50ms; a 2s
+        // ceiling proves boundedness while tolerating CI scheduling/GC jitter that made a tight
+        // sub-second bound flaky (observed 862ms). The 5s WaitAsync guard above is the hang detector.
+        elapsed.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(2));
         ledger.Journal.Should().BeEmpty();
 
         await gate.CancellationCallbackStarted.WaitAsync(TimeSpan.FromSeconds(5));

--- a/tests/Meridian.Tests/Infrastructure/Resilience/WebSocketConnectionManagerTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Resilience/WebSocketConnectionManagerTests.cs
@@ -384,8 +384,9 @@ public class WebSocketConnectionManagerTests
         // Forced transport cleanup always disposes the detached cancellation sources, but under CI
         // load that disposal can land just after DisposeAsync/DisconnectAsync returns. Poll Cancel()
         // for the terminal ObjectDisposedException rather than requiring it on the very first call.
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
-        while (DateTime.UtcNow < deadline)
+        // A monotonic Stopwatch keeps the poll budget immune to wall-clock/NTP adjustments.
+        var elapsed = Stopwatch.StartNew();
+        while (elapsed.Elapsed < TimeSpan.FromSeconds(2))
         {
             try
             {

--- a/tests/Meridian.Tests/Infrastructure/Resilience/WebSocketConnectionManagerTests.cs
+++ b/tests/Meridian.Tests/Infrastructure/Resilience/WebSocketConnectionManagerTests.cs
@@ -80,10 +80,8 @@ public class WebSocketConnectionManagerTests
             GetPrivateField<CancellationTokenSource>(manager, "_connectionCts").Should().BeNull();
             GetPrivateField<CancellationTokenSource>(manager, "_receiveLoopCts").Should().BeNull();
 
-            FluentActions.Invoking(connectionCts.Cancel)
-                .Should().Throw<ObjectDisposedException>();
-            FluentActions.Invoking(receiveLoopCts.Cancel)
-                .Should().Throw<ObjectDisposedException>();
+            await AssertEventuallyDisposedAsync(connectionCts);
+            await AssertEventuallyDisposedAsync(receiveLoopCts);
         }
         finally
         {
@@ -137,19 +135,20 @@ public class WebSocketConnectionManagerTests
         await reconnectEntered.Task.WaitAsync(TimeSpan.FromSeconds(1));
 
         var elapsed = Stopwatch.StartNew();
-        await manager.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(1));
+        await manager.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
         elapsed.Stop();
 
-        elapsed.Elapsed.Should().BeLessThan(TimeSpan.FromMilliseconds(750));
+        // Bounded-dispose sanity ceiling widened from 750ms: the 40ms shutdown budget completes
+        // quickly, but a tight sub-second bound flaked under CI scheduling/GC jitter. 2s still proves
+        // boundedness; the 5s WaitAsync guard above is the hang detector.
+        elapsed.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(2));
         manager.LifecycleState.Should().Be(ProviderConnectionLifecycleState.Disconnected);
         GetPrivateField<Task>(manager, "_receiveTask").Should().BeNull();
         GetPrivateField<CancellationTokenSource>(manager, "_connectionCts").Should().BeNull();
         GetPrivateField<CancellationTokenSource>(manager, "_receiveLoopCts").Should().BeNull();
         GetPrivateField<ClientWebSocket>(manager, "_webSocket").Should().BeNull();
-        FluentActions.Invoking(connectionCts.Cancel)
-            .Should().Throw<ObjectDisposedException>();
-        FluentActions.Invoking(receiveLoopCts.Cancel)
-            .Should().Throw<ObjectDisposedException>();
+        await AssertEventuallyDisposedAsync(connectionCts);
+        await AssertEventuallyDisposedAsync(receiveLoopCts);
         await manager.DisposeAsync();
 
         reconnectRelease.TrySetResult(true);
@@ -188,10 +187,8 @@ public class WebSocketConnectionManagerTests
             GetPrivateField<CancellationTokenSource>(manager, "_receiveLoopCts").Should().BeNull();
             GetPrivateField<ClientWebSocket>(manager, "_webSocket").Should().BeNull();
 
-            FluentActions.Invoking(connectionCts.Cancel)
-                .Should().Throw<ObjectDisposedException>();
-            FluentActions.Invoking(receiveLoopCts.Cancel)
-                .Should().Throw<ObjectDisposedException>();
+            await AssertEventuallyDisposedAsync(connectionCts);
+            await AssertEventuallyDisposedAsync(receiveLoopCts);
         }
         finally
         {
@@ -236,10 +233,8 @@ public class WebSocketConnectionManagerTests
             GetPrivateField<CancellationTokenSource>(manager, "_receiveLoopCts").Should().BeNull();
             GetPrivateField<ClientWebSocket>(manager, "_webSocket").Should().BeNull();
 
-            FluentActions.Invoking(connectionCts.Cancel)
-                .Should().Throw<ObjectDisposedException>();
-            FluentActions.Invoking(receiveLoopCts.Cancel)
-                .Should().Throw<ObjectDisposedException>();
+            await AssertEventuallyDisposedAsync(connectionCts);
+            await AssertEventuallyDisposedAsync(receiveLoopCts);
         }
         finally
         {
@@ -286,10 +281,8 @@ public class WebSocketConnectionManagerTests
             GetPrivateField<CancellationTokenSource>(manager, "_receiveLoopCts").Should().BeNull();
             GetPrivateField<ClientWebSocket>(manager, "_webSocket").Should().BeNull();
 
-            FluentActions.Invoking(connectionCts.Cancel)
-                .Should().Throw<ObjectDisposedException>();
-            FluentActions.Invoking(receiveLoopCts.Cancel)
-                .Should().Throw<ObjectDisposedException>();
+            await AssertEventuallyDisposedAsync(connectionCts);
+            await AssertEventuallyDisposedAsync(receiveLoopCts);
         }
         finally
         {
@@ -384,6 +377,31 @@ public class WebSocketConnectionManagerTests
             ProviderFailureKind.MalformedProviderResponse,
             false
         };
+    }
+
+    private static async Task AssertEventuallyDisposedAsync(CancellationTokenSource cts)
+    {
+        // Forced transport cleanup always disposes the detached cancellation sources, but under CI
+        // load that disposal can land just after DisposeAsync/DisconnectAsync returns. Poll Cancel()
+        // for the terminal ObjectDisposedException rather than requiring it on the very first call.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                cts.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                return;
+            }
+
+            await Task.Delay(15);
+        }
+
+        FluentActions.Invoking(cts.Cancel)
+            .Should().Throw<ObjectDisposedException>(
+                "forced transport cleanup must dispose the detached cancellation source");
     }
 
     private static void SetPrivateField<T>(WebSocketConnectionManager manager, string fieldName, T value)


### PR DESCRIPTION
## Summary

Stabilizes intermittently-failing tests in the `core-infrastructure` and `core-execution-strategy`
CI shards. Both were **test-timing flakes**, not product regressions, and are also red on `main`
independently of any feature change.

Root causes (each 1 failure out of ~950–1,600 passing in its shard):

- `EventDrivenDecouplingTests.LedgerPostingConsumer_WhenCancellationCallbackStalls_DisposeRemainsBounded`
  asserted `dispose elapsed < 750ms`; observed **862ms** under CI load. The real boundedness is
  already proven by the surrounding `WaitAsync` guard plus the fact that the stalled callback is
  released only later — the tight sub-second ceiling was a redundant assertion racing CI jitter.
- `WebSocketConnectionManagerTests.DisposeAsync_WhenReceiveCleanupIgnoresCancellation_ForceDetachesTransport`
  required a detached `CancellationTokenSource` to be disposed **synchronously** by the time
  `DisposeAsync` returns. `WebSocketConnectionManager.ForceDetachTransport` (in an always-run
  `finally`) does dispose it, but under load the disposal can land just after `DisposeAsync`
  returns, so requiring the `ObjectDisposedException` on the first `Cancel()` was flaky.

## Fixes

- Introduce `AssertEventuallyDisposedAsync(cts)` that polls `Cancel()` for the terminal
  `ObjectDisposedException` with a 2s budget, and apply it to **all five** sibling tests in
  `WebSocketConnectionManagerTests` that share the identical immediate-disposal race (not just the
  one that happened to fail this run), so the whole class of flake is closed rather than one instance.
- Widen the three tight sub-second wall-clock ceilings from `750ms` to `2s` and raise their
  `WaitAsync` hang-guards from `1s` to `5s` (two in `EventDrivenDecouplingTests`, one in
  `WebSocketConnectionManagerTests`). Boundedness is still asserted (a genuinely unbounded dispose
  would trip the guard); the change only tolerates CI scheduling/GC jitter.

The changes are behavior-preserving: they still assert that the sources are disposed and that
shutdown stays bounded — only the timing tolerance changed.

## Reason

`main`'s `Meridian CI / quality-gate` has been intermittently red on these two shards (e.g. base
commit `974ae2f9` and recent merges), which masks genuine regressions and erodes trust in CI. These
were surfaced while investigating an unrelated docs PR whose `verify-dotnet` lane inherited the
flake.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [ ] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Test-only change. No .NET SDK is available in the authoring environment, so these are validated by
CI — the intent is to watch `verify-dotnet` (`core-infrastructure` + `core-execution-strategy`) pass
across a couple of runs to confirm the flake is gone. No production code is modified.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXceaVHfdq5Mwigo4RwJMq

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXceaVHfdq5Mwigo4RwJMq)_