### PR TITLE
fix(screenshots): resolve deterministic web capture failures

### DIFF
--- a/scripts/dev/capture-web-screenshots.mjs
+++ b/scripts/dev/capture-web-screenshots.mjs
@@ -372,21 +372,33 @@ function extractExplicitAppRoutes(source) {
 }
 
 function collectExpectedCapturePaths(routeCatalog, appRoutes) {
+  // Compatibility redirect routes forward to a canonical screen that already has
+  // its own capture, so they do not need a dedicated screenshot entry. This list
+  // must stay in sync with the compatibility routes excluded by the coverage
+  // tests in tests/scripts/test_refresh_screenshots_workflow.py.
   const compatibilityRouteKeys = new Set([
+    "accountingTrialBalanceLegacy",
+    "dataAlertsLegacy",
     "dataSecurityMasterLegacy",
+    "dataWatchlistLegacy",
     "settingsIntegrations",
     "settingsFeatureCoverage",
     "settingsAlpacaProviderSetup",
     "settingsBackendCapabilityCoverage",
-    "settingsDiagnosticEndpoints"
+    "settingsDiagnosticEndpoints",
+    "strategyFormulaWorkbenchLegacy"
   ]);
   const compatibilityAppRoutes = new Set([
+    "/accounting/trial-balance",
+    "/data/alerts",
     "/data/security-master",
     "/data/security-master/*",
+    "/data/watchlist",
     "/overview/*",
     "/research/*",
     "/data-operations/*",
-    "/governance/*"
+    "/governance/*",
+    "/strategy/formula-workbench"
   ]);
   const expected = new Set(["/"]);
 
@@ -658,7 +670,16 @@ async function captureRoute(page, pageErrors, capture, outputDir, baseUrl, defau
   }
 
   const actualUrl = page.url();
-  const expectedPath = new URL(url).pathname;
+  const requestedPath = new URL(url).pathname;
+  // Some captures deliberately target a compatibility route that redirects to
+  // the canonical screen (e.g. the accounting/data evidence entry points land
+  // on the reporting evidence workbench). When a capture declares that redirect
+  // via `expectedRedirectPath`, treat the redirect destination as the expected
+  // final path so the intentional navigation is not mistaken for a route that
+  // bounced to a fallback. The strict check still catches undeclared redirects.
+  const expectedPath = typeof capture.expectedRedirectPath === "string" && capture.expectedRedirectPath.trim().length > 0
+    ? new URL(toRouteUrl(baseUrl, capture.expectedRedirectPath.trim())).pathname
+    : requestedPath;
   const actualPath = new URL(actualUrl).pathname;
   if (actualPath !== expectedPath) {
     throw new Error(`Capture ${capture.name} ended on '${actualPath}', expected '${expectedPath}'.`);
@@ -677,6 +698,7 @@ async function captureRoute(page, pageErrors, capture, outputDir, baseUrl, defau
     route: capture.path,
     url,
     actualUrl,
+    requestedPath,
     expectedPath,
     actualPath,
     file: fileName,

--- a/scripts/dev/web-screenshot-routes.json
+++ b/scripts/dev/web-screenshot-routes.json
@@ -474,6 +474,7 @@
       "id": "W03I5",
       "name": "web-accounting-evidence-detail",
       "path": "/accounting/evidence/detail?evidenceId=bank-statement",
+      "expectedRedirectPath": "/reporting/evidence",
       "docLabel": "Accounting \u2014 Evidence Detail (redirects to Reporting Evidence)",
       "waitForText": "Evidence workbench",
       "requiredApiRoutes": [
@@ -544,6 +545,7 @@
       "id": "W03L",
       "name": "web-accounting-evidence-workbench",
       "path": "/accounting/evidence",
+      "expectedRedirectPath": "/reporting/evidence",
       "docLabel": "Accounting \u2014 Evidence Workbench (redirects to Reporting Evidence)",
       "waitForText": "Evidence workbench",
       "requiredApiRoutes": [
@@ -1031,6 +1033,7 @@
       "id": "W06F",
       "name": "web-data-evidence-workbench",
       "path": "/data/evidence",
+      "expectedRedirectPath": "/reporting/evidence",
       "docLabel": "Data \u2014 Evidence Workbench (redirects to Reporting Evidence)",
       "waitForText": "Evidence workbench",
       "requiredApiRoutes": [

--- a/tests/scripts/test_refresh_screenshots_workflow.py
+++ b/tests/scripts/test_refresh_screenshots_workflow.py
@@ -496,6 +496,51 @@ class RefreshScreenshotsWorkflowTests(unittest.TestCase):
         self.assertIn("assertCaptureRouteStateIdentity(allCaptures)", self.web_screenshot_capture_script)
         self.assertIn("must use a unique route state", self.web_screenshot_capture_script)
 
+    def test_web_screenshot_capture_script_excludes_all_compatibility_redirect_routes(self) -> None:
+        # The JS coverage-exclusion lists must match the compatibility redirect
+        # routes the coverage tests exclude below; otherwise the capture run fails
+        # with "Live route(s) without a screenshot capture entry" for routes that
+        # intentionally forward to an already-captured canonical screen.
+        for compatibility_route_key in (
+            "accountingTrialBalanceLegacy",
+            "dataAlertsLegacy",
+            "dataWatchlistLegacy",
+            "strategyFormulaWorkbenchLegacy",
+        ):
+            self.assertIn(compatibility_route_key, self.web_screenshot_capture_script)
+        for compatibility_app_route in (
+            '"/accounting/trial-balance"',
+            '"/data/alerts"',
+            '"/data/watchlist"',
+            '"/strategy/formula-workbench"',
+        ):
+            self.assertIn(compatibility_app_route, self.web_screenshot_capture_script)
+
+    def test_web_screenshot_capture_script_honors_declared_route_redirects(self) -> None:
+        # Captures that intentionally redirect to a canonical screen assert the
+        # redirect destination instead of failing the strict path-identity check.
+        self.assertIn("capture.expectedRedirectPath", self.web_screenshot_capture_script)
+        self.assertIn(
+            "new URL(toRouteUrl(baseUrl, capture.expectedRedirectPath.trim())).pathname",
+            self.web_screenshot_capture_script,
+        )
+
+    def test_web_screenshot_evidence_captures_declare_expected_redirect(self) -> None:
+        # The accounting/data evidence entry points are compatibility routes that
+        # redirect to the reporting evidence workbench; declaring the redirect lets
+        # each capture assert the intended destination and still produce an
+        # entry-point-specific screenshot.
+        captures = {
+            capture.get("id"): capture
+            for capture in self.web_screenshot_routes.get("captures", [])
+        }
+        for capture_id in ("W03I5", "W03L", "W06F"):
+            self.assertEqual(
+                "/reporting/evidence",
+                captures[capture_id].get("expectedRedirectPath"),
+                f"{capture_id} must declare its redirect to the reporting evidence workbench",
+            )
+
     def test_web_screenshot_capture_script_isolates_per_route_failures(self) -> None:
         # A screen that fails to render is recorded and skipped so the run continues
         # through the remaining screens, then exits non-zero with a consolidated


### PR DESCRIPTION
## Summary

Follow-up to #2363. A dispatch of the **Web Screenshot Capture** workflow still exits non-zero for two *deterministic* reasons that the per-route retry from #2363 cannot help (they fail identically on every attempt). This fixes both so a run reaches the success state that gates the refresh PR. Evidence: a real dispatch captured 74/77 routes then failed with three redirect errors and a coverage-gap error.

**1. Coverage-gap false positive.** The capture script's JS compatibility exclusion list (`collectExpectedCapturePaths`) had drifted out of sync with the coverage-test contract, so `/accounting/trial-balance`, `/data/alerts`, `/data/watchlist`, and `/strategy/formula-workbench` — all `LegacyWorkspaceRedirect` compatibility routes that forward to an already-captured canonical screen — were reported as `Live route(s) without a screenshot capture entry`. Added their catalog keys and app-route paths so the JS list matches the routes already excluded in `tests/scripts/test_refresh_screenshots_workflow.py`.

**2. Intentional-redirect captures failed the strict path-identity check.** The three evidence captures (`web-accounting-evidence-detail`, `web-accounting-evidence-workbench`, `web-data-evidence-workbench`) deliberately target compatibility routes that redirect to `/reporting/evidence` — their `docLabel`s literally say "(redirects to Reporting Evidence)" — but the final-path assertion rejected the redirect as if the route had bounced to a fallback. Added an optional `expectedRedirectPath` capture field: when set, the redirect destination (resolved through the same base URL as the route) is treated as the expected final path, so declared redirects pass while undeclared ones are still caught. Declared the redirect on the three evidence captures.

Behavior is otherwise preserved: the other 74 routes still assert their own path, and the strict check still fails on any *undeclared* redirect.

## Reason

The merged robustness work (#2363) added retry / fast-fail / manifest infrastructure, but the workflow was still red because these two failures are deterministic, not transient. The failing run made the root causes visible: a stale coverage exclusion list and a strict path check that didn't account for the catalog's intentional compatibility redirects.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully
- [x] Relevant unit tests were added or updated — `tests/scripts/test_refresh_screenshots_workflow.py` (35/35 pass): added coverage for the compatibility-list sync, the redirect-aware assertion, and the three evidence captures' declared `expectedRedirectPath`
- [ ] Relevant integration tests were added or updated
- [ ] GitHub Actions `quality-gate` passed

Additional local validation, reproducing the failing run's two error classes against the **real** dashboard route catalog and app shell:
- `findMissingCaptureRoutePaths(...)` now returns **zero** missing routes (the `/accounting/trial-balance`, `/data/alerts`, `/data/watchlist`, `/strategy/formula-workbench` gap is gone).
- The three evidence captures resolve their expected final path to `/workstation/reporting/evidence` — exactly the destination observed in the failing log — while the other 74 routes keep expecting their own path.
- `node --check` on the script; routes JSON validates; the #2363 retry/fast-fail behavior harness still passes. Full `tests/scripts` discovery shows no new failures versus the base branch.

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

Check every governance file modified:

- [x] No governance files changed
- [ ] `.github/workflows/**`
- [ ] `.github/CODEOWNERS`
- [ ] `.github/pull_request_template.md`
- [ ] `AGENTS.md`
- [ ] `scripts/ci.sh`

Changes are limited to `scripts/dev/capture-web-screenshots.mjs`, `scripts/dev/web-screenshot-routes.json`, and the corresponding test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8ckjYLXwyJqfqYVNBqPgx

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8ckjYLXwyJqfqYVNBqPgx)_