### PR TITLE
Add daily-return distribution chart to portfolio run drill-in

### DIFF
--- a/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.test.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.test.tsx
@@ -976,4 +976,77 @@ describe("PortfolioScreen", () => {
     expect(api.getRunCashFlows).toHaveBeenCalledWith("run-1");
     expect(api.getRunFills).toHaveBeenCalledWith("run-1");
   });
+
+  it("charts the daily-return distribution from a multi-point drill-in equity curve", async () => {
+    vi.spyOn(api, "getRunAttribution").mockResolvedValue({
+      runId: "run-1",
+      totalRealizedPnl: 120,
+      totalUnrealizedPnl: 80,
+      totalCommissions: 5,
+      bySymbol: []
+    });
+    vi.spyOn(api, "getRunEquityCurve").mockResolvedValue({
+      runId: "run-1",
+      initialEquity: 100000,
+      finalEquity: 101900,
+      maxDrawdown: 800,
+      maxDrawdownPercent: 0.008,
+      maxDrawdownRecoveryDays: 2,
+      sharpeRatio: 1.41,
+      sortinoRatio: 1.8,
+      points: [
+        { date: "2026-05-01", totalEquity: 100000, cash: 50000, dailyReturn: 0, drawdownFromPeak: 0, drawdownFromPeakPercent: 0 },
+        { date: "2026-05-02", totalEquity: 101200, cash: 50000, dailyReturn: 0.012, drawdownFromPeak: 0, drawdownFromPeakPercent: 0 },
+        { date: "2026-05-03", totalEquity: 100390, cash: 50000, dailyReturn: -0.008, drawdownFromPeak: 810, drawdownFromPeakPercent: 0.008 },
+        { date: "2026-05-04", totalEquity: 102398, cash: 50000, dailyReturn: 0.02, drawdownFromPeak: 0, drawdownFromPeakPercent: 0 },
+        { date: "2026-05-05", totalEquity: 101886, cash: 50000, dailyReturn: -0.005, drawdownFromPeak: 512, drawdownFromPeakPercent: 0.005 }
+      ]
+    });
+    vi.spyOn(api, "getRunCashFlows").mockResolvedValue({
+      runId: "run-1",
+      asOf: "2026-05-07T12:00:00Z",
+      currency: "USD",
+      totalEntries: 0,
+      totalInflows: 0,
+      totalOutflows: 0,
+      netCashFlow: 0,
+      entries: [],
+      ladder: {
+        asOf: "2026-05-07T12:00:00Z",
+        currency: "USD",
+        bucketDays: 7,
+        totalProjectedInflows: 0,
+        totalProjectedOutflows: 0,
+        netPosition: 0,
+        buckets: []
+      }
+    });
+    vi.spyOn(api, "getRunFills").mockResolvedValue({
+      runId: "run-1",
+      totalFills: 0,
+      totalCommissions: 0,
+      fills: []
+    });
+    const user = userEvent.setup();
+
+    await renderPortfolioScreen(<PortfolioScreen trading={trading} strategy={strategy} accounting={accounting} />, {
+      initialEntries: ["/portfolio/attribution"]
+    });
+
+    await user.click(screen.getByRole("button", { name: "Load portfolio drill-in evidence for Mean Reversion" }));
+
+    // Equity/drawdown curve renders for a multi-point profile.
+    expect(await screen.findByRole("img", { name: "Equity performance curve" })).toBeDefined();
+
+    // The daily-return distribution reuses the same fetched points — no extra request — and
+    // surfaces the signed histogram with mean, best, worst, and positive-day readouts. Scope the
+    // readout assertions to the distribution card so a matching value elsewhere (e.g. the equity
+    // card's max-drawdown readout) cannot satisfy them.
+    const distribution = await screen.findByRole("img", { name: "Distribution histogram" });
+    const distributionCard = distribution.closest("div")!.parentElement!;
+    expect(within(distributionCard).getByText("Daily return distribution")).toBeDefined();
+    expect(within(distributionCard).getByText("+0.38%")).toBeDefined();
+    expect(within(distributionCard).getByText("+2.00%")).toBeDefined();
+    expect(within(distributionCard).getByText("-0.80%")).toBeDefined();
+  });
 });

--- a/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.tsx
@@ -23,6 +23,7 @@ import { EmptyState } from "@/components/data/concrete";
 import { SeverityBadge, TrustStrip, type TrustStripItem } from "@/components/operations";
 import {
   EquityCurve,
+  Histogram,
   ChartCard,
   ChartSyncProvider,
   useChartSync,
@@ -1538,6 +1539,7 @@ function PortfolioChip({ label, value }: { label: string; value: string }) {
 }
 
 const drillInCurrency = (value: number) => `$${Math.round(value).toLocaleString("en-US")}`;
+const drillInSignedPercent = (value: number) => `${value >= 0 ? "+" : ""}${value.toFixed(2)}%`;
 
 /** Concrete equity + underwater drawdown view for a loaded run drill-in profile. Additive
  * evidence only — rendered when the selected run has a fetched equity/drawdown series. The
@@ -1566,31 +1568,86 @@ function PortfolioDrillInChartInner({
   const sync = useChartCrosshairSync(timestamps);
 
   return (
+    <div className="space-y-3">
+      <ChartCard
+        title="Run equity and drawdown"
+        subtitle={`Source-backed equity curve and underwater drawdown for ${runTitle}.`}
+        readout={[
+          { label: "Final equity", value: drillInCurrency(profile.finalEquity) },
+          {
+            label: "Max drawdown",
+            value: `-${(profile.maxDrawdownPercent * 100).toFixed(2)}%`,
+            color: "var(--chart-drawdown, #BA3F55)"
+          },
+          { label: "Sharpe", value: profile.sharpeRatio.toFixed(2) }
+        ]}
+        height={280}
+        style={{ flexShrink: 0 }}
+      >
+        <EquityCurve
+          series={[{ label: "Equity", color: "var(--chart-equity, #2F6F8F)", points: equity }]}
+          drawdown={drawdown}
+          labels={labels}
+          valueFmt={drillInCurrency}
+          crosshairIndex={sync.crosshairIndex}
+          onCrosshairChange={sync.onCrosshairChange}
+          onPointActivate={sync.onPointActivate}
+        />
+        <PortfolioDrillInPointEvidence profile={profile} timestamps={timestamps} />
+      </ChartCard>
+      <PortfolioDrillInReturnDistribution profile={profile} runTitle={runTitle} />
+    </div>
+  );
+}
+
+/** Daily-return distribution for a loaded run drill-in profile. Reuses the already-fetched
+ * equity-curve points (no extra request) so the same drill-in that draws the equity/drawdown
+ * curve also shows the shape of its returns — a signed histogram with a mean rule. Rendered only
+ * when at least two return observations exist so a single-day profile stays a curve-only view. */
+function PortfolioDrillInReturnDistribution({
+  profile,
+  runTitle
+}: {
+  profile: EquityCurveSummary;
+  runTitle: string;
+}) {
+  const returns = useMemo(
+    () => profile.points.map((point) => point.dailyReturn * 100),
+    [profile.points]
+  );
+
+  if (returns.length < 2) {
+    return null;
+  }
+
+  const mean = returns.reduce((sum, value) => sum + value, 0) / returns.length;
+  const best = Math.max(...returns);
+  const worst = Math.min(...returns);
+  const positiveShare = (returns.filter((value) => value > 0).length / returns.length) * 100;
+
+  return (
     <ChartCard
-      title="Run equity and drawdown"
-      subtitle={`Source-backed equity curve and underwater drawdown for ${runTitle}.`}
+      title="Daily return distribution"
+      subtitle={`Shape of the ${runTitle} daily returns behind the equity curve above.`}
       readout={[
-        { label: "Final equity", value: drillInCurrency(profile.finalEquity) },
         {
-          label: "Max drawdown",
-          value: `-${(profile.maxDrawdownPercent * 100).toFixed(2)}%`,
-          color: "var(--chart-drawdown, #BA3F55)"
+          label: "Mean / day",
+          value: drillInSignedPercent(mean),
+          color: mean >= 0 ? "var(--chart-equity, #16885F)" : "var(--chart-drawdown, #BA3F55)"
         },
-        { label: "Sharpe", value: profile.sharpeRatio.toFixed(2) }
+        { label: "Best day", value: drillInSignedPercent(best), color: "var(--chart-equity, #16885F)" },
+        { label: "Worst day", value: drillInSignedPercent(worst), color: "var(--chart-drawdown, #BA3F55)" },
+        { label: "Positive days", value: `${positiveShare.toFixed(0)}%` }
       ]}
-      height={280}
+      height={220}
       style={{ flexShrink: 0 }}
     >
-      <EquityCurve
-        series={[{ label: "Equity", color: "var(--chart-equity, #2F6F8F)", points: equity }]}
-        drawdown={drawdown}
-        labels={labels}
-        valueFmt={drillInCurrency}
-        crosshairIndex={sync.crosshairIndex}
-        onCrosshairChange={sync.onCrosshairChange}
-        onPointActivate={sync.onPointActivate}
+      <Histogram
+        values={returns}
+        signed
+        showMean
+        valueFmt={(value) => `${value.toFixed(1)}%`}
       />
-      <PortfolioDrillInPointEvidence profile={profile} timestamps={timestamps} />
     </ChartCard>
   );
 }

--- a/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.tsx
+++ b/src/Meridian.Ui/dashboard/src/screens/portfolio-screen.tsx
@@ -1611,19 +1611,26 @@ function PortfolioDrillInReturnDistribution({
   profile: EquityCurveSummary;
   runTitle: string;
 }) {
-  const returns = useMemo(
-    () => profile.points.map((point) => point.dailyReturn * 100),
-    [profile.points]
-  );
+  // Memoize the returns series and its summary stats on the fetched points so they are not
+  // recomputed on every crosshair move — the parent re-renders on each hover, but these O(n)
+  // reductions only depend on profile.points.
+  const stats = useMemo(() => {
+    const returns = profile.points.map((point) => point.dailyReturn * 100);
+    if (returns.length < 2) {
+      return null;
+    }
+    const mean = returns.reduce((sum, value) => sum + value, 0) / returns.length;
+    const best = Math.max(...returns);
+    const worst = Math.min(...returns);
+    const positiveShare = (returns.filter((value) => value > 0).length / returns.length) * 100;
+    return { returns, mean, best, worst, positiveShare };
+  }, [profile.points]);
 
-  if (returns.length < 2) {
+  if (!stats) {
     return null;
   }
 
-  const mean = returns.reduce((sum, value) => sum + value, 0) / returns.length;
-  const best = Math.max(...returns);
-  const worst = Math.min(...returns);
-  const positiveShare = (returns.filter((value) => value > 0).length / returns.length) * 100;
+  const { returns, mean, best, worst, positiveShare } = stats;
 
   return (
     <ChartCard


### PR DESCRIPTION
## Summary

Adds a **daily-return distribution** chart to the Portfolio → Attribution run drill-in. When a run's equity/drawdown drill-in is loaded, the screen now renders a signed return histogram (with a mean rule) directly beneath the existing equity/drawdown curve, plus a readout of mean-per-day, best day, worst day, and positive-day share.

The distribution reuses the equity-curve points that the drill-in **already fetches** (`EquityCurveSummary.points[].dailyReturn`), so there is **no additional request**. It renders only when at least two return observations exist, so a single-day profile stays a curve-only view.

This gives the shared `Histogram` chart primitive — previously built and tested but unused across screens — a real home next to the equity curve, and turns an already-loaded numeric series into a visual.

## Reason

The browser workstation ships a full, tested chart library under `src/Meridian.Ui/dashboard/src/components/charts/`, but most of it is unwired — the Attribution drill-in fetched a daily-return series and only surfaced it as numbers. This is the first "surface existing capability" UI win from the web-UI improvement brainstorm: additive, low-risk, and backed by data the screen already loads.

## Testing performed

- [ ] `bash scripts/ci.sh` completed successfully — not run (full mixed .NET + web gate); relied on targeted web validation below
- [x] Relevant unit tests were added or updated
- [ ] Relevant integration tests were added or updated — n/a for this change
- [ ] GitHub Actions `quality-gate` passed — pending on this PR

Targeted validation run locally in `src/Meridian.Ui/dashboard`:

- `npx tsc --noEmit` — passed (0 errors)
- `npm run test:vitest -- src/screens/portfolio-screen.test.tsx` — 23/23 passed (adds one test covering the distribution for a multi-point drill-in profile)
- `npm run test:vitest -- src/components/charts` — 31/31 passed
- `npx eslint` on the changed files — clean

## Safety review

- [x] This pull request targets `main`
- [x] No direct push to `main` was performed
- [x] No tests were disabled or bypassed
- [x] No secrets or credentials were committed
- [x] No unrelated changes were included

## Governance changes

- [x] No governance files changed

---

Files changed:

- `src/Meridian.Ui/dashboard/src/screens/portfolio-screen.tsx` — split the drill-in chart into the existing equity/drawdown card plus a new `PortfolioDrillInReturnDistribution` card fed by the same profile points.
- `src/Meridian.Ui/dashboard/src/screens/portfolio-screen.test.tsx` — cover the distribution rendering for a multi-point drill-in profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uTdj984BcB4Ex59suQJK4

---
_Generated by [Claude Code](https://claude.ai/code/session_015uTdj984BcB4Ex59suQJK4)_